### PR TITLE
feat: add `nub node default <version>` command

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4330,7 +4330,8 @@ fn run_node(args: &[String]) -> Result<i32> {
              \x20 install [<version>...]   provision version(s) into nub's cache (bare: the project pin)\n\
              \x20 ls                       list versions in nub's cache\n\
              \x20 uninstall <version>      remove a version from nub's cache\n\
-             \x20 pin <version>            write the project's Node pin"
+             \x20 pin <version>            write the project's Node pin\n\
+             \x20 default <version>        set the user-global default Node (--unset to clear)"
         );
         return Ok(0);
     }
@@ -4417,6 +4418,28 @@ fn run_node(args: &[String]) -> Result<i32> {
             println!("pinned Node {} → {}", result.spec, result.path.display());
             Ok(0)
         }
+        "default" => {
+            use nub_core::version_management::manage;
+            match args.get(1).map(String::as_str) {
+                Some("--unset") | Some("--clear") => {
+                    match manage::unset_default()? {
+                        Some(prev) => println!("Cleared the default Node ({prev})."),
+                        None => println!("No default Node was set."),
+                    }
+                    Ok(0)
+                }
+                // Auto-installs the version if it isn't cached.
+                Some(spec) => {
+                    let result = manage::set_default(spec, &store)?;
+                    report_default_set(&result);
+                    Ok(0)
+                }
+                None => bail!(
+                    "nub node default requires a version (e.g. 22, lts, 22.13.0), \
+                     or --unset to clear the current default"
+                ),
+            }
+        }
         // `nub node <file>` (or any non-verb positional) is an error, NOT a
         // passthrough — the exact wording is locked by the spec
         // (node-versions.md line 25). The literal `<file>` placeholder is part of
@@ -4428,6 +4451,40 @@ fn run_node(args: &[String]) -> Result<i32> {
                  To run a file, use 'nub <file>'."
             );
         }
+    }
+}
+
+/// Print the outcome of `nub node default <version>` — the version set, then how
+/// (and whether) it reached PATH for other programs.
+fn report_default_set(result: &nub_core::version_management::manage::DefaultResult) {
+    use nub_core::pm::shim::ProfileOutcome;
+    use nub_core::version_management::manage::Exposure;
+
+    let installed = if result.installed { " (installed)" } else { "" };
+    println!("Set default Node to {}{installed}.", result.version);
+    match &result.exposure {
+        Exposure::Path(ProfileOutcome::Added(profile)) => println!(
+            "  the default Node (node, npm, npx) is on PATH via ~/.nub/current\n  \
+             restart your shell, or run: source {}",
+            profile.display()
+        ),
+        Exposure::Path(ProfileOutcome::AlreadyPresent(_)) => {
+            println!("  the default Node (node, npm, npx) is on PATH via ~/.nub/current")
+        }
+        Exposure::Path(ProfileOutcome::Manual { line }) => println!(
+            "  PATH: no known shell profile to edit — add this line to your shell config:\n    {line}"
+        ),
+        Exposure::Unsupported(dir) => println!(
+            "  PATH: add {} to your PATH (PATH editing isn't automated on Windows yet)",
+            dir.display()
+        ),
+        // Step 2 failed — the default is still recorded and in use; only the PATH
+        // exposure is missing, and re-running retries just that step.
+        Exposure::Failed(reason) => eprintln!(
+            "  warning: couldn't put it on PATH ({reason})\n  \
+             the default is set and nub will use it — re-run `nub node default {}` to retry the PATH setup",
+            result.version
+        ),
     }
 }
 

--- a/crates/nub-cli/tests/pm_shim.rs
+++ b/crates/nub-cli/tests/pm_shim.rs
@@ -493,8 +493,8 @@ fn pm_shim_and_unshim_round_trip_against_a_temp_home() {
     let profile = std::fs::read_to_string(&zshrc).unwrap();
     assert_eq!(
         profile,
-        format!("{original}\n# nub shims\nexport PATH=\"$HOME/.nub/shims:$PATH\"\n"),
-        "the marked PATH block lands once, install.sh-shaped"
+        format!("{original}\n# nub path\nexport PATH=\"$HOME/.nub/shims:$PATH\"\n"),
+        "the unified managed PATH block lands once, install.sh-shaped"
     );
     assert!(
         stdout.contains("source") && stdout.contains(".zshrc"),

--- a/crates/nub-core/src/node/discovery.rs
+++ b/crates/nub-core/src/node/discovery.rs
@@ -422,6 +422,11 @@ const DEV_ENGINES_RUNTIME_SOURCE: &str = "package.json#devEngines.runtime";
 /// Source label for the `engines.node` pin channel (precedence #4).
 const ENGINES_NODE_SOURCE: &str = "package.json#engines.node";
 
+/// Source label for the user-global default pin (`nub node default`) — the
+/// lowest rung (precedence #5), consulted only when no project source (#1–#4)
+/// pins a version.
+const DEFAULT_SOURCE: &str = "nub node default";
+
 /// The governing `package.json` for `cwd`, parsed: the WORKSPACE ROOT's manifest
 /// when one exists above `cwd`, else the nearest one. This is the one manifest
 /// both `devEngines.runtime` (#1) and `engines.node` (#4) read from.
@@ -457,6 +462,22 @@ fn read_engines_node(cwd: &Path) -> Option<(String, String)> {
         .filter(|s| !s.is_empty())
         .map(str::to_string)?;
     Some((range, ENGINES_NODE_SOURCE.to_string()))
+}
+
+/// Read the user-global default pin (precedence #5) from [`default_file`].
+/// Returns `(raw, parsed)`, or `None` when the file is absent, empty, or
+/// unparseable — a corrupt default falls through to the PATH node rather than
+/// erroring, mirroring `walk_up_for_pin`'s skip-an-unparseable-pin posture.
+fn read_default_pin() -> Option<(String, VersionPin)> {
+    let content = fs::read_to_string(default_file()?).ok()?;
+    // Strip a leading UTF-8 BOM, same as walk_up_for_pin (a Windows-editor default).
+    let content = content.strip_prefix('\u{FEFF}').unwrap_or(&content);
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let pin = trimmed.parse::<VersionPin>().ok()?;
+    Some((trimmed.to_string(), pin))
 }
 
 /// One entry of `devEngines.runtime` (the object form is a single entry).
@@ -592,10 +613,23 @@ pub struct PinChain {
 /// The pin-source chain in spec precedence order
 /// (`wiki/runtime/node-version-management.md` §"Resolution order"):
 /// `package.json#devEngines.runtime` (#1) → `.node-version` (#2) → `.nvmrc`
-/// (#3) → `package.json#engines.node` (#4, a resolution range). Errs with
-/// [`DiscoveryError::RuntimeNotNode`] when `devEngines.runtime` declares a
-/// non-Node runtime that refuses (its default).
+/// (#3) → `package.json#engines.node` (#4, a resolution range) → the user-global
+/// default `~/.nub/default` (#5, only when no project source pins a version).
+/// Errs with [`DiscoveryError::RuntimeNotNode`] when `devEngines.runtime`
+/// declares a non-Node runtime that refuses (its default).
 pub fn resolve_pin_chain(cwd: &Path) -> Result<PinChain, DiscoveryError> {
+    resolve_pin_chain_with(cwd, read_default_pin())
+}
+
+/// Body of [`resolve_pin_chain`] with the #5 default injected, so the rung is
+/// unit-testable against a chosen value instead of the real `~/.nub/default`
+/// (which in-process tests must not touch). Same testable-body split as
+/// `nub_store_node_in`, `ls_with`, and `add_path_block_for`; production code only
+/// ever calls `resolve_pin_chain`.
+fn resolve_pin_chain_with(
+    cwd: &Path,
+    default_pin: Option<(String, VersionPin)>,
+) -> Result<PinChain, DiscoveryError> {
     let mut warnings = Vec::new();
     let manifest = project_manifest(cwd);
     if let Some(field) = manifest
@@ -638,6 +672,17 @@ pub fn resolve_pin_chain(cwd: &Path) -> Result<PinChain, DiscoveryError> {
                  using node on PATH."
             )),
         }
+    }
+    // #5: the user-global default (`nub node default`). The lowest rung — only
+    // reached when no project source pinned a version — so it never overrides a
+    // project's own pin; it's the fallback for a no-pin project (which would
+    // otherwise dead-end at the PATH node, or `NoNodeOnPath` when nub installed
+    // the only Node it has).
+    if let Some((raw, pin)) = default_pin {
+        return Ok(PinChain {
+            pin: Some((raw, pin, DEFAULT_SOURCE.to_string())),
+            warnings,
+        });
     }
     Ok(PinChain {
         pin: None,
@@ -819,6 +864,13 @@ pub fn cache_dir() -> Option<PathBuf> {
 /// group (`ls`/`uninstall`/`install` all key off this dir).
 pub fn node_store_dir() -> Option<PathBuf> {
     Some(cache_dir()?.join("node"))
+}
+
+/// The user-global default-version record: `~/.nub/default`, a single concrete
+/// version line. Under `~/.nub` (not the wipeable cache) so a cache clear can't
+/// drop the opted-into default — same reasoning as the PM shims.
+pub fn default_file() -> Option<PathBuf> {
+    dirs_next::home_dir().map(|h| h.join(".nub").join("default"))
 }
 
 fn read_version_cache(node_path: &Path) -> Option<NodeVersion> {
@@ -1187,6 +1239,38 @@ mod tests {
         let chain = resolve_pin_chain(&dir).unwrap();
         let (_, _, source) = chain.pin.expect("a pin");
         assert_eq!(source, ".node-version", "a pin file must beat engines.node");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn default_pin_applies_when_no_project_source() {
+        // Precedence #5: with no devEngines/.node-version/.nvmrc/engines.node, the
+        // user-global default (`nub node default`) is what resolves — the rung that
+        // keeps a no-pin project from dead-ending at NoNodeOnPath.
+        let dir = resolution_tmpdir("default-applies");
+        let default = Some(("22.15.0".to_string(), "22.15.0".parse::<VersionPin>().unwrap()));
+        let chain = resolve_pin_chain_with(&dir, default).unwrap();
+        let (raw, pin, source) = chain.pin.expect("the default pins when nothing else does");
+        assert_eq!(source, DEFAULT_SOURCE);
+        assert_eq!(raw, "22.15.0");
+        assert_eq!(pin, VersionPin::Exact(NodeVersion::new(22, 15, 0)));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn project_source_outranks_the_default() {
+        // The default is the LOWEST rung: a project pin file (#2) must win over it,
+        // so a global default never hijacks a project that pins its own Node.
+        let dir = resolution_tmpdir("default-loses");
+        std::fs::write(dir.join(".node-version"), "20.11.0\n").unwrap();
+        let default = Some(("22.15.0".to_string(), "22.15.0".parse::<VersionPin>().unwrap()));
+        let chain = resolve_pin_chain_with(&dir, default).unwrap();
+        let (raw, _pin, source) = chain.pin.expect("a pin");
+        assert_eq!(
+            source, ".node-version",
+            "a project pin must beat the global default"
+        );
+        assert_eq!(raw, "20.11.0");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/nub-core/src/pm/shim.rs
+++ b/crates/nub-core/src/pm/shim.rs
@@ -18,7 +18,6 @@
 
 use std::ffi::OsStr;
 use std::fmt;
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -642,18 +641,55 @@ pub fn dir_is_noexec(_dir: &Path) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// Shell-profile PATH block (the install.sh mechanism, ported)
+// Shell-profile PATH block (the install.sh mechanism, ported + unified)
 // ---------------------------------------------------------------------------
+//
+// ONE marked block lists every nub-managed dir in fixed priority order, so the
+// layering is deterministic whichever feature wired PATH first. `add_path_block`
+// (called by `pm shim` + `node default`) and `remove_path_block` both rewrite it
+// from current on-disk state.
 
-/// The PATH lines, exactly install.sh's shape (`$HOME`-relative so the profile
-/// stays portable across machines), pointing at the SHIMS dir.
-pub const SHIMS_POSIX_PATH_LINE: &str = r#"export PATH="$HOME/.nub/shims:$PATH""#;
-pub const SHIMS_FISH_PATH_LINE: &str = "set -gx PATH $HOME/.nub/shims $PATH";
+/// nub-managed PATH dirs, highest priority first; only the active ones (dir
+/// present). `shims` outranks `current` so a shimmed npm still routes through
+/// nub's PM engine. `$HOME`-relative for a portable profile line.
+fn managed_path_dirs(home: &Path) -> Vec<&'static str> {
+    let mut dirs = Vec::new();
+    if home.join(".nub").join("shims").is_dir() {
+        dirs.push("$HOME/.nub/shims");
+    }
+    // symlink_metadata: the link's own presence, not its (possibly dangling) target.
+    if home
+        .join(".nub")
+        .join("current")
+        .symlink_metadata()
+        .is_ok()
+    {
+        dirs.push("$HOME/.nub/current");
+    }
+    dirs
+}
 
-/// The block's marker comment. install.sh writes `# nub` above its `~/.nub/bin`
-/// line; this is deliberately DISTINCT so `nub pm unshim` strips exactly the
-/// shims block and never the installer's.
-const BLOCK_MARKER: &str = "# nub shims";
+/// The POSIX `export PATH=…` line wiring `dirs` in priority order, `$HOME`-relative
+/// like install.sh's own line. `None` when nothing is active (the block is then
+/// removed, never written as an empty `:$PATH` that would put cwd on PATH).
+fn posix_path_line(dirs: &[&str]) -> Option<String> {
+    (!dirs.is_empty()).then(|| format!(r#"export PATH="{}:$PATH""#, dirs.join(":")))
+}
+
+/// The fish equivalent of [`posix_path_line`].
+fn fish_path_line(dirs: &[&str]) -> Option<String> {
+    (!dirs.is_empty()).then(|| format!("set -gx PATH {} $PATH", dirs.join(" ")))
+}
+
+/// The managed block's marker comment. install.sh writes `# nub` above its
+/// `~/.nub/bin` line; this is deliberately DISTINCT so a rewrite touches exactly
+/// our block and never the installer's.
+const MANAGED_MARKER: &str = "# nub path";
+
+/// The pre-unification marker — `nub pm shim` wrote this for the shims-only
+/// block. Recognized and stripped on every rewrite so existing installs converge
+/// onto the unified [`MANAGED_MARKER`] block.
+const LEGACY_MARKER: &str = "# nub shims";
 
 /// Outcome of [`add_path_block`], for the CLI's "what changed" report.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -664,16 +700,20 @@ pub enum ProfileOutcome {
     AlreadyPresent(PathBuf),
     /// No known profile exists / is writable for this shell — the CLI prints
     /// `line` as "add this to your shell config yourself" and exits 0.
-    Manual { line: &'static str },
+    Manual { line: String },
 }
 
-/// Append the marked PATH block to ALL of the current shell's profile files —
+/// Rewrite the managed PATH block in ALL of the current shell's profile files —
 /// both the INTERACTIVE rc and the NON-INTERACTIVE/LOGIN files a GUI-app-spawned
 /// shell, an IDE integrated terminal, an `ssh host command`, or a build tool's
 /// bare `pnpm` actually reads. install.sh only wires the interactive rc; the
-/// shim widens coverage (mise's lesson — [`shell_profiles`] documents which
-/// files and why), since intercepting tool-spawned bare PMs is the shim's whole
-/// reason to exist and those processes never source an interactive rc.
+/// managed block widens coverage (mise's lesson — [`shell_profiles`] documents
+/// which files and why), since intercepting tool-spawned bare PMs is the shims'
+/// whole reason to exist and those processes never source an interactive rc.
+///
+/// The block lists every active managed dir ([`managed_path_dirs`]) in priority
+/// order, so callers (`nub pm shim`, `nub node default`) need not coordinate —
+/// each just creates its dir, then calls this to re-derive the block.
 ///
 /// File selection per shell (`$SHELL` basename):
 ///   - **zsh** → `~/.zshrc` (interactive) **and** `~/.zshenv` (read by ALL zsh
@@ -698,34 +738,42 @@ pub fn add_path_block() -> Result<ProfileOutcome> {
     let xdg = std::env::var_os("XDG_CONFIG_HOME")
         .filter(|v| !v.is_empty())
         .map(PathBuf::from);
-    add_path_block_for(&shell, &home, xdg.as_deref())
+    let dirs = managed_path_dirs(&home);
+    add_path_block_for(&shell, &home, xdg.as_deref(), &dirs)
 }
 
-/// [`add_path_block`] with the environment made explicit (the testable body).
+/// [`add_path_block`] with the environment + active dirs made explicit (the
+/// testable body).
 ///
-/// Writes the block to every target [`shell_profiles`] yields and folds their
+/// Rewrites the block in every target [`shell_profiles`] yields and folds their
 /// per-file outcomes into one (the result cli.rs prints, kept a single
 /// [`ProfileOutcome`] so the CLI surface is unchanged): the FIRST file actually
-/// added is reported as `Added` (the interactive rc, the one the user sources to
-/// pick the shims up in their current shell); if every target already carried
-/// the line it's `AlreadyPresent` (naming the first); if nothing could be
+/// written is reported as `Added` (the interactive rc, the one the user sources
+/// to pick the dirs up in their current shell); if every target already carried
+/// the exact block it's `AlreadyPresent` (naming the first); if nothing could be
 /// written it's `Manual`. Non-interactive files are wired silently as extra
 /// coverage — the per-file detail isn't surfaced to keep one headline outcome.
 pub fn add_path_block_for(
     shell: &str,
     home: &Path,
     xdg_config: Option<&Path>,
+    dirs: &[&str],
 ) -> Result<ProfileOutcome> {
-    let targets = shell_profiles(shell, home, xdg_config);
+    let posix = posix_path_line(dirs);
+    let fish = fish_path_line(dirs);
+    let targets = shell_profiles(shell, home, xdg_config, posix.as_deref(), fish.as_deref());
+    // Manual hint uses the POSIX line; `dirs.is_empty()` (nothing to add) yields
+    // an empty string the caller never reaches via the add path.
+    let manual = || ProfileOutcome::Manual {
+        line: posix.clone().unwrap_or_default(),
+    };
     if targets.is_empty() {
-        return Ok(ProfileOutcome::Manual {
-            line: SHIMS_POSIX_PATH_LINE,
-        });
+        return Ok(manual());
     }
     let mut first_added: Option<PathBuf> = None;
     let mut first_present: Option<PathBuf> = None;
     for target in &targets {
-        match append_block(target)? {
+        match write_block(target)? {
             ProfileOutcome::Added(p) => {
                 first_added.get_or_insert(p);
             }
@@ -741,28 +789,34 @@ pub fn add_path_block_for(
     Ok(match (first_added, first_present) {
         (Some(p), _) => ProfileOutcome::Added(p),
         (None, Some(p)) => ProfileOutcome::AlreadyPresent(p),
-        (None, None) => ProfileOutcome::Manual {
-            line: SHIMS_POSIX_PATH_LINE,
-        },
+        (None, None) => manual(),
     })
 }
 
-/// One profile-file target: which file, which line dialect, and whether a
-/// missing file may be created.
+/// One profile-file target: which file, the desired managed line in that file's
+/// dialect (`None` = no active dirs → remove the block), and whether a missing
+/// file may be created.
 struct ProfileTarget {
     path: PathBuf,
-    line: &'static str,
+    line: Option<String>,
     may_create: bool,
 }
 
 /// The set of profile files to wire for `shell`, interactive first. See
 /// [`add_path_block`] for the per-shell rationale. Empty = unknown shell
 /// (Manual). The order matters: the first element is the one cli.rs reports as
-/// the "source this" file, so it must be the interactive rc.
-fn shell_profiles(shell: &str, home: &Path, xdg_config: Option<&Path>) -> Vec<ProfileTarget> {
-    let posix = |path: PathBuf, may_create: bool| ProfileTarget {
+/// the "source this" file, so it must be the interactive rc. `posix`/`fish` are
+/// the desired line in each dialect (`None` when no dirs are active).
+fn shell_profiles(
+    shell: &str,
+    home: &Path,
+    xdg_config: Option<&Path>,
+    posix: Option<&str>,
+    fish: Option<&str>,
+) -> Vec<ProfileTarget> {
+    let posix_t = |path: PathBuf, may_create: bool| ProfileTarget {
         path,
-        line: SHIMS_POSIX_PATH_LINE,
+        line: posix.map(str::to_string),
         may_create,
     };
     match shell {
@@ -771,8 +825,8 @@ fn shell_profiles(shell: &str, home: &Path, xdg_config: Option<&Path>) -> Vec<Pr
         // single file that guarantees a GUI/IDE-spawned shell sees the shims.
         // Both are canonical zsh files — created if missing.
         "zsh" => vec![
-            posix(home.join(".zshrc"), true),
-            posix(home.join(".zshenv"), true),
+            posix_t(home.join(".zshrc"), true),
+            posix_t(home.join(".zshenv"), true),
         ],
         "bash" => {
             let mut targets = Vec::with_capacity(2);
@@ -781,7 +835,7 @@ fn shell_profiles(shell: &str, home: &Path, xdg_config: Option<&Path>) -> Vec<Pr
             // is what a fresh HOME gets).
             let bashrc = home.join(".bashrc");
             if bashrc.is_file() && appendable(&bashrc) {
-                targets.push(posix(bashrc, false));
+                targets.push(posix_t(bashrc, false));
             }
             // Login / non-interactive: bash reads `.bash_profile` (then
             // `.bash_login`, then `.profile`) for login shells. Prefer an
@@ -791,9 +845,9 @@ fn shell_profiles(shell: &str, home: &Path, xdg_config: Option<&Path>) -> Vec<Pr
             // silent Manual punt.
             let bash_profile = home.join(".bash_profile");
             if bash_profile.is_file() && appendable(&bash_profile) {
-                targets.push(posix(bash_profile, false));
+                targets.push(posix_t(bash_profile, false));
             } else {
-                targets.push(posix(home.join(".profile"), true));
+                targets.push(posix_t(home.join(".profile"), true));
             }
             targets
         }
@@ -803,7 +857,7 @@ fn shell_profiles(shell: &str, home: &Path, xdg_config: Option<&Path>) -> Vec<Pr
                 .unwrap_or_else(|| home.join(".config"));
             vec![ProfileTarget {
                 path: base.join("fish").join("config.fish"),
-                line: SHIMS_FISH_PATH_LINE,
+                line: fish.map(str::to_string),
                 may_create: true,
             }]
         }
@@ -816,25 +870,42 @@ fn appendable(path: &Path) -> bool {
     std::fs::OpenOptions::new().append(true).open(path).is_ok()
 }
 
-/// Append `\n# nub shims\n<line>\n` — byte-for-byte what install.sh's three
-/// `echo`s produce for its own block. Idempotency keys on the PATH line itself
-/// (trimmed line equality), so a hand-added identical line also counts as
-/// present — and is then deliberately NOT ours to remove.
-fn append_block(target: &ProfileTarget) -> Result<ProfileOutcome> {
+/// Rewrite `target` so it carries exactly the managed block for `target.line`
+/// (`\n# nub path\n<line>\n` — byte-for-byte install.sh's three-`echo` shape).
+/// Idempotency keys on the PATH line itself (trimmed equality), so a hand-added
+/// identical line also counts as present and is then deliberately NOT rewritten.
+/// Otherwise any stale managed/legacy block is stripped and the fresh one
+/// appended — handling both a content change (shims-only → shims+current) and
+/// migration off the legacy `# nub shims` marker.
+fn write_block(target: &ProfileTarget) -> Result<ProfileOutcome> {
+    // No active dirs → nothing to add here (full removal is the sweep's job).
+    let Some(line) = target.line.as_deref() else {
+        return Ok(ProfileOutcome::AlreadyPresent(target.path.clone()));
+    };
     let existing = match std::fs::read_to_string(&target.path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             if !target.may_create {
-                return Ok(ProfileOutcome::Manual { line: target.line });
+                return Ok(ProfileOutcome::Manual {
+                    line: line.to_string(),
+                });
             }
             String::new()
         }
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-            return Ok(ProfileOutcome::Manual { line: target.line });
+            return Ok(ProfileOutcome::Manual {
+                line: line.to_string(),
+            });
         }
         Err(e) => return Err(e).with_context(|| format!("reading {}", target.path.display())),
     };
-    if existing.lines().any(|l| l.trim() == target.line) {
+    // Already exactly present — UNLESS a legacy `# nub shims` block is still
+    // there, which must be migrated to the unified marker even when the PATH line
+    // itself is unchanged (the common shims-only re-run). The line check (not a
+    // full-block check) also leaves a hand-added identical line in place rather
+    // than appending a duplicate.
+    let has_legacy = existing.lines().any(|l| l.trim() == LEGACY_MARKER);
+    if !has_legacy && existing.lines().any(|l| l.trim() == line) {
         return Ok(ProfileOutcome::AlreadyPresent(target.path.clone()));
     }
     if target.may_create {
@@ -843,29 +914,50 @@ fn append_block(target: &ProfileTarget) -> Result<ProfileOutcome> {
                 .with_context(|| format!("creating {}", parent.display()))?;
         }
     }
-    let mut file = match std::fs::OpenOptions::new()
-        .append(true)
-        .create(target.may_create)
-        .open(&target.path)
-    {
-        Ok(f) => f,
-        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-            return Ok(ProfileOutcome::Manual { line: target.line });
-        }
-        Err(e) => return Err(e).with_context(|| format!("opening {}", target.path.display())),
-    };
-    write!(file, "\n{BLOCK_MARKER}\n{}\n", target.line)
-        .with_context(|| format!("appending to {}", target.path.display()))?;
-    Ok(ProfileOutcome::Added(target.path.clone()))
+    // Strip any stale managed/legacy block first, then append the fresh one, so
+    // re-running with a changed dir set (or an old `# nub shims` block) converges
+    // to exactly one canonical block.
+    let new = format!("{}\n{MANAGED_MARKER}\n{line}\n", strip_managed(&existing));
+    match write_profile_atomically(&target.path, &new) {
+        Ok(()) => Ok(ProfileOutcome::Added(target.path.clone())),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => Ok(ProfileOutcome::Manual {
+            line: line.to_string(),
+        }),
+        Err(e) => Err(e).with_context(|| format!("writing {}", target.path.display())),
+    }
 }
 
-/// Strip the marked block from EVERY profile [`add_path_block`] may have
-/// written — across all shells, both the interactive rc and the
-/// non-interactive/login files — not just the current `$SHELL`'s, since the user
-/// may have switched shells since `nub pm shim` ran. Returns the files that
-/// changed. Unreadable / missing profiles are skipped (nothing of ours to
-/// strip); write failures propagate. Must keep working when the official nub is
-/// gone — it touches only profile files, never `current_exe`'s install dir.
+/// Replace `path`'s contents with `new` via temp + rename, so a torn write can
+/// never truncate a shell profile. The rename targets the CANONICALIZED path — a
+/// `~/.zshrc` that is a symlink into a dotfiles repo stays a symlink, with the
+/// edit landing in the linked-to file; renaming onto the symlink path would
+/// replace the link with a regular file and orphan the dotfiles copy. The
+/// original file's permissions are copied over so a 600 profile stays 600.
+fn write_profile_atomically(path: &Path, new: &str) -> std::io::Result<()> {
+    let target = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let tmp = target.with_file_name(format!(
+        "{}.nub-path-{}",
+        target.file_name().unwrap_or_default().to_string_lossy(),
+        std::process::id()
+    ));
+    std::fs::write(&tmp, new)?;
+    if let Ok(meta) = std::fs::metadata(&target) {
+        let _ = std::fs::set_permissions(&tmp, meta.permissions());
+    }
+    if let Err(e) = std::fs::rename(&tmp, &target) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Re-derive the managed block across EVERY profile it may live in (all shells,
+/// interactive + login files — the user may have switched shells). Call AFTER a
+/// feature tears down its dir: any STILL-active dir is re-written, so unshimming
+/// with a default set keeps `~/.nub/current` on PATH (and vice versa); when none
+/// remain the block is dropped. Returns the changed files; profiles without our
+/// block are left untouched. Touches only profiles, so it works even when the
+/// official nub is gone.
 pub fn remove_path_block() -> Result<Vec<PathBuf>> {
     let home = dirs_next::home_dir().context("cannot locate the home directory")?;
     let xdg = std::env::var_os("XDG_CONFIG_HOME")
@@ -893,65 +985,80 @@ pub fn remove_path_block_from_profiles(
         home.join(".profile"),
         fish_base.join("fish").join("config.fish"),
     ];
+    // Whatever's still active after the caller's teardown — re-added to any file
+    // that carried our block, or omitted entirely (full strip) when none remain.
+    let dirs = managed_path_dirs(home);
+    let posix = posix_path_line(&dirs);
+    let fish = fish_path_line(&dirs);
     let mut changed = Vec::new();
     for path in candidates {
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        let Some(stripped) = strip_block(&content) else {
-            continue;
+        let stripped = strip_managed(&content);
+        if stripped == content {
+            continue; // no managed block in this file — leave it untouched
+        }
+        // config.fish takes the fish dialect; everything else POSIX.
+        let line = if path.ends_with("config.fish") {
+            fish.as_deref()
+        } else {
+            posix.as_deref()
         };
-        // Temp + rename: a torn write must never truncate a shell profile.
-        // The rename targets the CANONICALIZED path — a `~/.zshrc` that is a
-        // symlink into a dotfiles repo must stay a symlink, with the edit
-        // landing in the linked-to file; renaming onto the symlink path would
-        // replace the link with a regular file and orphan the dotfiles copy.
-        // Permissions are copied over so a 600 profile stays 600.
-        let target = path.canonicalize().unwrap_or_else(|_| path.clone());
-        let tmp = target.with_file_name(format!(
-            "{}.nub-unshim-{}",
-            target.file_name().unwrap_or_default().to_string_lossy(),
-            std::process::id()
-        ));
-        std::fs::write(&tmp, &stripped).with_context(|| format!("writing {}", tmp.display()))?;
-        if let Ok(meta) = std::fs::metadata(&target) {
-            let _ = std::fs::set_permissions(&tmp, meta.permissions());
-        }
-        if let Err(e) = std::fs::rename(&tmp, &target) {
-            let _ = std::fs::remove_file(&tmp);
-            return Err(e).with_context(|| format!("replacing {}", target.display()));
-        }
+        let new = match line {
+            Some(l) => format!("{stripped}\n{MANAGED_MARKER}\n{l}\n"),
+            None => stripped,
+        };
+        write_profile_atomically(&path, &new)
+            .with_context(|| format!("replacing {}", path.display()))?;
         changed.push(path);
     }
     Ok(changed)
 }
 
-/// Remove exactly the bytes [`append_block`] wrote — `"\n{BLOCK_MARKER}\n{line}\n"`
-/// — and nothing else. `None` = no block, file untouched. A hand-added PATH line
-/// without the marker is NOT removed (we only strip what we wrote).
+/// Remove EVERY managed block — both the unified `# nub path` marker and the
+/// legacy `# nub shims` one — leaving everything else byte-for-byte intact. A
+/// hand-added PATH line without our marker is NOT removed (we only strip what we
+/// wrote). Loops [`strip_one_block`] so a file carrying both a legacy and a
+/// unified block (or two of either) is fully cleaned.
+fn strip_managed(content: &str) -> String {
+    let mut s = content.to_string();
+    while let Some(stripped) = strip_one_block(&s) {
+        s = stripped;
+    }
+    s
+}
+
+/// Remove ONE managed block (whichever managed/legacy marker appears first),
+/// byte-exactly; `None` once none remain.
 ///
 /// This is byte-exact string-slicing, NOT a line-split/rejoin, specifically so
 /// the result preserves the ORIGINAL file's trailing-newline state: a profile
-/// that had no trailing newline before `nub pm shim` ran must regain none after
-/// `unshim` (the old line-rejoin gained one — the breaker's byte-cleanliness
-/// nit). The block carries its own leading `\n` separator and a trailing `\n`
-/// after the path line; we excise that whole span, so whatever surrounded it —
-/// including "the file ended right here, no newline" — is restored verbatim.
-fn strip_block(content: &str) -> Option<String> {
-    // The marker as it sits on its own line: find a line whose trimmed text is
-    // exactly BLOCK_MARKER. We scan line starts so an in-prose mention of the
-    // string can't be mistaken for the marker.
-    let marker_line_start = content
-        .match_indices(BLOCK_MARKER)
-        .map(|(idx, _)| idx)
-        .find(|&idx| {
-            let at_line_start = idx == 0 || content.as_bytes()[idx - 1] == b'\n';
-            let rest = &content[idx + BLOCK_MARKER.len()..];
-            let to_eol_blank = rest.starts_with('\n') || rest.is_empty();
-            at_line_start && to_eol_blank
-        })?;
+/// that had no trailing newline before the block was written must regain none
+/// after it's removed (a line-rejoin would gain one). The block carries its own
+/// leading `\n` separator and a trailing `\n` after the path line; we excise
+/// that whole span, so whatever surrounded it — including "the file ended right
+/// here, no newline" — is restored verbatim.
+fn strip_one_block(content: &str) -> Option<String> {
+    // The earliest marker (either dialect) sitting on its own line. We scan line
+    // starts so an in-prose mention of the string can't be mistaken for it.
+    let (marker_line_start, marker_len) = [MANAGED_MARKER, LEGACY_MARKER]
+        .iter()
+        .filter_map(|marker| {
+            content
+                .match_indices(marker)
+                .map(|(idx, _)| idx)
+                .find(|&idx| {
+                    let at_line_start = idx == 0 || content.as_bytes()[idx - 1] == b'\n';
+                    let rest = &content[idx + marker.len()..];
+                    let to_eol_blank = rest.starts_with('\n') || rest.is_empty();
+                    at_line_start && to_eol_blank
+                })
+                .map(|idx| (idx, marker.len()))
+        })
+        .min_by_key(|(idx, _)| *idx)?;
 
-    // The block starts at the single `\n` separator we appended right before the
+    // The block starts at the single `\n` separator written right before the
     // marker (if present — the marker can be the very first byte of the file).
     let block_start = if marker_line_start > 0 && content.as_bytes()[marker_line_start - 1] == b'\n'
     {
@@ -960,11 +1067,12 @@ fn strip_block(content: &str) -> Option<String> {
         marker_line_start
     };
 
-    // The block end: past the marker's newline, then past our PATH line's
-    // newline — but only consume that next line when it really names
-    // `.nub/shims` (defensive: a malformed half-block without the line stops at
-    // the marker rather than eating an unrelated following line).
-    let after_marker = marker_line_start + BLOCK_MARKER.len();
+    // The block end: past the marker's newline, then past the PATH line's
+    // newline — but only consume that next line when it names one of OUR managed
+    // dirs (defensive: a half-block whose line was hand-deleted stops at the
+    // marker, and a user's own `.nub/`-containing PATH line is never eaten — it
+    // must be exactly `.nub/shims` or `.nub/current`).
+    let after_marker = marker_line_start + marker_len;
     let mut block_end = after_marker;
     if content.as_bytes().get(block_end) == Some(&b'\n') {
         block_end += 1; // the marker's trailing newline
@@ -972,8 +1080,9 @@ fn strip_block(content: &str) -> Option<String> {
             .find('\n')
             .map(|n| block_end + n + 1)
             .unwrap_or(content.len());
-        if content[block_end..path_line_end].contains(".nub/shims") {
-            block_end = path_line_end; // our PATH line + its newline
+        let path_line = &content[block_end..path_line_end];
+        if path_line.contains(".nub/shims") || path_line.contains(".nub/current") {
+            block_end = path_line_end; // the PATH line + its newline
         }
     }
 
@@ -1229,6 +1338,15 @@ pub fn sibling_bin(primary_bin: &Path, entry: &str) -> Result<PathBuf> {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// The managed-dir set + its rendered lines for the PATH-block tests. A
+    /// shims-only block (the common case); `managed_path_dirs` is exercised
+    /// separately via the real-state paths. These mirror what
+    /// `posix_path_line(SHIMS_DIRS)` / `fish_path_line(SHIMS_DIRS)` render, kept
+    /// as literals so the expected profile bytes read at a glance.
+    const SHIMS_DIRS: &[&str] = &["$HOME/.nub/shims"];
+    const SHIMS_POSIX: &str = r#"export PATH="$HOME/.nub/shims:$PATH""#;
+    const SHIMS_FISH: &str = "set -gx PATH $HOME/.nub/shims $PATH";
 
     /// Unique temp dir under the system temp root (mirrors `resolve.rs`'s
     /// `tmpdir` — never under $HOME, so nothing here can touch real profiles
@@ -1753,27 +1871,27 @@ mod tests {
         // file every zsh invocation reads — the non-interactive coverage). The
         // reported outcome is the interactive rc, the file the user sources.
         assert_eq!(
-            add_path_block_for("zsh", &home, None).unwrap(),
+            add_path_block_for("zsh", &home, None, SHIMS_DIRS).unwrap(),
             ProfileOutcome::Added(zshrc.clone()),
             "the headline outcome names the interactive rc the user sources"
         );
         let with_block = std::fs::read_to_string(&zshrc).unwrap();
         assert_eq!(
             with_block,
-            format!("{original}\n# nub shims\n{SHIMS_POSIX_PATH_LINE}\n"),
+            format!("{original}\n# nub path\n{SHIMS_POSIX}\n"),
             "the appended block must be byte-for-byte install.sh's shape"
         );
         // .zshenv was created from scratch and carries the same block — this is
         // what a GUI/IDE-spawned non-interactive zsh actually reads.
         assert_eq!(
             std::fs::read_to_string(&zshenv).unwrap(),
-            format!("\n# nub shims\n{SHIMS_POSIX_PATH_LINE}\n"),
+            format!("\n# nub path\n{SHIMS_POSIX}\n"),
             ".zshenv gets the block so non-interactive shells see the shims"
         );
 
         // Adding twice is a no-op on every target.
         assert_eq!(
-            add_path_block_for("zsh", &home, None).unwrap(),
+            add_path_block_for("zsh", &home, None, SHIMS_DIRS).unwrap(),
             ProfileOutcome::AlreadyPresent(zshrc.clone())
         );
         assert_eq!(std::fs::read_to_string(&zshrc).unwrap(), with_block);
@@ -1806,9 +1924,9 @@ mod tests {
 
         // zsh: both .zshrc (interactive) and .zshenv (all invocations) are
         // created; the headline outcome is the interactive rc.
-        let outcome = add_path_block_for("zsh", &home, None).unwrap();
+        let outcome = add_path_block_for("zsh", &home, None, SHIMS_DIRS).unwrap();
         assert_eq!(outcome, ProfileOutcome::Added(home.join(".zshrc")));
-        let zsh_block = format!("\n# nub shims\n{SHIMS_POSIX_PATH_LINE}\n");
+        let zsh_block = format!("\n# nub path\n{SHIMS_POSIX}\n");
         assert_eq!(
             std::fs::read_to_string(home.join(".zshrc")).unwrap(),
             zsh_block
@@ -1823,20 +1941,20 @@ mod tests {
         let xdg = home.join("xdg");
         let fish_config = xdg.join("fish").join("config.fish");
         assert_eq!(
-            add_path_block_for("fish", &home, Some(&xdg)).unwrap(),
+            add_path_block_for("fish", &home, Some(&xdg), SHIMS_DIRS).unwrap(),
             ProfileOutcome::Added(fish_config.clone())
         );
         let fish_content = std::fs::read_to_string(&fish_config).unwrap();
         assert!(
-            fish_content.contains(SHIMS_FISH_PATH_LINE) && !fish_content.contains("export PATH"),
+            fish_content.contains(SHIMS_FISH) && !fish_content.contains("export PATH"),
             "fish gets `set -gx`, never the posix line, got: {fish_content}"
         );
 
         // An unknown shell still can only be handled manually.
         assert_eq!(
-            add_path_block_for("tcsh", &home, None).unwrap(),
+            add_path_block_for("tcsh", &home, None, SHIMS_DIRS).unwrap(),
             ProfileOutcome::Manual {
-                line: SHIMS_POSIX_PATH_LINE
+                line: SHIMS_POSIX.to_string()
             }
         );
     }
@@ -1850,13 +1968,13 @@ mod tests {
         // actually work.
         let home = tmpdir("fresh-bash");
         assert_eq!(
-            add_path_block_for("bash", &home, None).unwrap(),
+            add_path_block_for("bash", &home, None, SHIMS_DIRS).unwrap(),
             ProfileOutcome::Added(home.join(".profile")),
             "a fresh bash HOME must get a created+wired login profile, not Manual"
         );
         assert_eq!(
             std::fs::read_to_string(home.join(".profile")).unwrap(),
-            format!("\n# nub shims\n{SHIMS_POSIX_PATH_LINE}\n")
+            format!("\n# nub path\n{SHIMS_POSIX}\n")
         );
         // .bashrc is NOT conjured (install.sh parity — interactive rc is only
         // touched when it already exists); the login file alone carries it.
@@ -1870,19 +1988,19 @@ mod tests {
         let home = tmpdir("bash-with-rc");
         std::fs::write(home.join(".bashrc"), "# rc\n").unwrap();
         assert_eq!(
-            add_path_block_for("bash", &home, None).unwrap(),
+            add_path_block_for("bash", &home, None, SHIMS_DIRS).unwrap(),
             ProfileOutcome::Added(home.join(".bashrc"))
         );
         assert!(
             std::fs::read_to_string(home.join(".bashrc"))
                 .unwrap()
-                .contains(SHIMS_POSIX_PATH_LINE),
+                .contains(SHIMS_POSIX),
             "the existing interactive rc is wired"
         );
         assert!(
             std::fs::read_to_string(home.join(".profile"))
                 .unwrap()
-                .contains(SHIMS_POSIX_PATH_LINE),
+                .contains(SHIMS_POSIX),
             "and the login file too, for non-interactive coverage"
         );
 
@@ -1890,7 +2008,7 @@ mod tests {
         let home = tmpdir("bash-with-profile");
         std::fs::write(home.join(".bash_profile"), "# hello\n").unwrap();
         assert_eq!(
-            add_path_block_for("bash", &home, None).unwrap(),
+            add_path_block_for("bash", &home, None, SHIMS_DIRS).unwrap(),
             ProfileOutcome::Added(home.join(".bash_profile")),
             "an existing .bash_profile is preferred as the login target"
         );
@@ -1908,10 +2026,10 @@ mod tests {
         let home = tmpdir("sweep");
         let xdg = home.join("xdg");
 
-        add_path_block_for("zsh", &home, None).unwrap(); // .zshrc + .zshenv
-        add_path_block_for("fish", &home, Some(&xdg)).unwrap(); // config.fish
+        add_path_block_for("zsh", &home, None, SHIMS_DIRS).unwrap(); // .zshrc + .zshenv
+        add_path_block_for("fish", &home, Some(&xdg), SHIMS_DIRS).unwrap(); // config.fish
         std::fs::write(home.join(".bashrc"), "# rc\n").unwrap();
-        add_path_block_for("bash", &home, None).unwrap(); // .bashrc + .profile
+        add_path_block_for("bash", &home, None, SHIMS_DIRS).unwrap(); // .bashrc + .profile
 
         let mut changed = remove_path_block_from_profiles(&home, Some(&xdg)).unwrap();
         changed.sort();
@@ -1945,11 +2063,11 @@ mod tests {
         let original = "export EDITOR=vi"; // deliberately no trailing newline
         std::fs::write(&zshrc, original).unwrap();
 
-        add_path_block_for("zsh", &home, None).unwrap();
+        add_path_block_for("zsh", &home, None, SHIMS_DIRS).unwrap();
         // Sanity: the block landed after the original's last byte.
         assert_eq!(
             std::fs::read_to_string(&zshrc).unwrap(),
-            format!("{original}\n# nub shims\n{SHIMS_POSIX_PATH_LINE}\n")
+            format!("{original}\n# nub path\n{SHIMS_POSIX}\n")
         );
 
         remove_path_block_from_profiles(&home, None).unwrap();
@@ -1961,45 +2079,161 @@ mod tests {
     }
 
     #[test]
-    fn strip_block_is_byte_exact_across_block_positions_and_newline_states() {
-        let line = SHIMS_POSIX_PATH_LINE;
-        let block = format!("\n# nub shims\n{line}\n");
-
-        // No block present → None, file untouched.
-        assert_eq!(strip_block("just some config\n"), None);
-        // A `# nub` (installer) block is NOT our `# nub shims` marker → untouched.
+    fn managed_block_lists_dirs_in_fixed_priority_order_and_rewrites_in_place() {
+        // The unified block's whole reason to exist: `~/.nub/shims` (PM shims)
+        // outranks `~/.nub/current` (the default Node's bin) regardless of which
+        // feature wired PATH first, so a shimmed npm keeps routing through nub.
+        let home = tmpdir("order");
+        let zshrc = home.join(".zshrc");
         assert_eq!(
-            strip_block("# nub\nexport PATH=\"$HOME/.nub/bin:$PATH\"\n"),
-            None
+            add_path_block_for("zsh", &home, None, &["$HOME/.nub/shims", "$HOME/.nub/current"])
+                .unwrap(),
+            ProfileOutcome::Added(zshrc.clone())
         );
+        assert_eq!(
+            std::fs::read_to_string(&zshrc).unwrap(),
+            "\n# nub path\nexport PATH=\"$HOME/.nub/shims:$HOME/.nub/current:$PATH\"\n",
+            "shims precede current in the one managed line"
+        );
+
+        // Re-running with a different dir set REWRITES the block in place (a
+        // content change is not a no-op), converging on exactly one block.
+        assert_eq!(
+            add_path_block_for("zsh", &home, None, SHIMS_DIRS).unwrap(),
+            ProfileOutcome::Added(zshrc.clone())
+        );
+        assert_eq!(
+            std::fs::read_to_string(&zshrc).unwrap(),
+            format!("\n# nub path\n{SHIMS_POSIX}\n"),
+            "the block is rewritten, never duplicated"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_path_dirs_reflects_on_disk_state_in_priority_order() {
+        let home = tmpdir("managed-dirs");
+        let nub = home.join(".nub");
+        std::fs::create_dir_all(&nub).unwrap();
+
+        assert!(managed_path_dirs(&home).is_empty(), "nothing active");
+
+        std::fs::create_dir_all(nub.join("shims")).unwrap();
+        assert_eq!(managed_path_dirs(&home), vec!["$HOME/.nub/shims"]);
+
+        // current is a symlink to a NON-existent target (dangling) — it must still
+        // count (symlink_metadata sees the link, not the target), and rank after
+        // shims.
+        std::os::unix::fs::symlink(home.join("store/bin"), nub.join("current")).unwrap();
+        assert_eq!(
+            managed_path_dirs(&home),
+            vec!["$HOME/.nub/shims", "$HOME/.nub/current"],
+            "shims outranks current; a dangling current still counts"
+        );
+
+        std::fs::remove_dir_all(nub.join("shims")).unwrap();
+        assert_eq!(managed_path_dirs(&home), vec!["$HOME/.nub/current"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_re_adds_still_active_dirs_in_each_dialect() {
+        // Unshim with a default still set: the block keeps ~/.nub/current rather
+        // than being fully stripped — in both the posix and fish dialects.
+        let home = tmpdir("remove-readd");
+        let nub = home.join(".nub");
+        std::fs::create_dir_all(&nub).unwrap();
+        // current active, shims NOT (the just-removed one).
+        std::os::unix::fs::symlink(home.join("store/bin"), nub.join("current")).unwrap();
+
+        let zshrc = home.join(".zshrc");
+        std::fs::write(
+            &zshrc,
+            "# nub path\nexport PATH=\"$HOME/.nub/shims:$HOME/.nub/current:$PATH\"\n",
+        )
+        .unwrap();
+        let xdg = home.join("xdg");
+        let fishrc = xdg.join("fish").join("config.fish");
+        std::fs::create_dir_all(fishrc.parent().unwrap()).unwrap();
+        std::fs::write(
+            &fishrc,
+            "# nub path\nset -gx PATH $HOME/.nub/shims $HOME/.nub/current $PATH\n",
+        )
+        .unwrap();
+
+        let changed = remove_path_block_from_profiles(&home, Some(&xdg)).unwrap();
+        assert!(changed.contains(&zshrc) && changed.contains(&fishrc));
+        assert_eq!(
+            std::fs::read_to_string(&zshrc).unwrap(),
+            "\n# nub path\nexport PATH=\"$HOME/.nub/current:$PATH\"\n",
+            "shims dropped (gone), current re-added in the posix dialect"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&fishrc).unwrap(),
+            "\n# nub path\nset -gx PATH $HOME/.nub/current $PATH\n",
+            "the fish profile is re-added in the fish dialect"
+        );
+    }
+
+    #[test]
+    fn add_migrates_a_legacy_shims_block_even_when_the_line_is_unchanged() {
+        // A pre-unification user (legacy `# nub shims` marker, identical PATH line)
+        // re-running `pm shim` must converge to the unified `# nub path` marker —
+        // the line-equality idempotency check must not short-circuit the migration.
+        let home = tmpdir("migrate");
+        let zshrc = home.join(".zshrc");
+        std::fs::write(&zshrc, format!("# keep\n\n# nub shims\n{SHIMS_POSIX}\n")).unwrap();
+
+        let outcome = add_path_block_for("zsh", &home, None, SHIMS_DIRS).unwrap();
+        assert_eq!(outcome, ProfileOutcome::Added(zshrc.clone()));
+        assert_eq!(
+            std::fs::read_to_string(&zshrc).unwrap(),
+            format!("# keep\n\n# nub path\n{SHIMS_POSIX}\n"),
+            "the legacy marker migrates to the unified one, the PATH line unchanged"
+        );
+    }
+
+    #[test]
+    fn strip_managed_is_byte_exact_across_block_positions_and_newline_states() {
+        let block = format!("\n# nub path\n{SHIMS_POSIX}\n");
+
+        // No block present → unchanged.
+        assert_eq!(strip_managed("just some config\n"), "just some config\n");
+        // A `# nub` (installer) block is NOT a managed marker → untouched.
+        let installer = "# nub\nexport PATH=\"$HOME/.nub/bin:$PATH\"\n";
+        assert_eq!(strip_managed(installer), installer);
 
         // Original with trailing newline: restored exactly.
-        let orig = "a\nb\n";
-        assert_eq!(
-            strip_block(&format!("{orig}{block}")).as_deref(),
-            Some(orig)
-        );
+        assert_eq!(strip_managed(&format!("a\nb\n{block}")), "a\nb\n");
         // Original without trailing newline: restored exactly (no NL gained).
-        let orig = "a\nb";
-        assert_eq!(
-            strip_block(&format!("{orig}{block}")).as_deref(),
-            Some(orig)
-        );
-        // Empty original (a file we created solely for the block): back to empty.
-        assert_eq!(strip_block(&block).as_deref(), Some(""));
+        assert_eq!(strip_managed(&format!("a\nb{block}")), "a\nb");
+        // Empty original (a file created solely for the block): back to empty.
+        assert_eq!(strip_managed(&block), "");
         // Block followed by later user content: only our bytes are excised.
         assert_eq!(
-            strip_block(&format!("a\n{block}c\n")).as_deref(),
-            Some("a\nc\n"),
+            strip_managed(&format!("a\n{block}c\n")),
+            "a\nc\n",
             "content appended after our block survives the strip"
         );
-        // A half-block (marker but the line was hand-deleted) stops at the
-        // marker rather than eating the unrelated next line.
+        // A half-block (marker but the line was hand-deleted) stops at the marker
+        // rather than eating the unrelated next line.
         assert_eq!(
-            strip_block("a\n\n# nub shims\nunrelated line\n").as_deref(),
-            Some("a\nunrelated line\n"),
+            strip_managed("a\n\n# nub path\nunrelated line\n"),
+            "a\nunrelated line\n",
             "a marker without our PATH line must not consume the following line"
         );
+        // A user's OWN `.nub/`-containing PATH line under a half-block is NOT eaten
+        // — only an exact `.nub/shims` or `.nub/current` line is ours to consume.
+        assert_eq!(
+            strip_managed("# nub path\nexport PATH=\"/opt/.nub/bin:$PATH\"\nKEEP=1\n"),
+            "export PATH=\"/opt/.nub/bin:$PATH\"\nKEEP=1\n",
+            "a foreign .nub/ PATH line survives — only our managed dirs are consumed"
+        );
+        // Migration: the legacy `# nub shims` block is stripped the same way, and
+        // a file carrying BOTH a legacy and a unified block is fully cleaned.
+        let legacy = format!("\n# nub shims\n{SHIMS_POSIX}\n");
+        assert_eq!(strip_managed(&format!("x\n{legacy}")), "x\n");
+        assert_eq!(strip_managed(&format!("x\n{legacy}{block}")), "x\n");
     }
 
     #[cfg(unix)]
@@ -2082,7 +2316,7 @@ mod tests {
         let real = dotfiles.join("zshrc");
         std::fs::write(
             &real,
-            format!("export EDITOR=vi\n\n{BLOCK_MARKER}\n{SHIMS_POSIX_PATH_LINE}\n"),
+            format!("export EDITOR=vi\n\n# nub path\n{SHIMS_POSIX}\n"),
         )
         .unwrap();
         std::os::unix::fs::symlink(&real, home.join(".zshrc")).unwrap();

--- a/crates/nub-core/src/version_management/manage.rs
+++ b/crates/nub-core/src/version_management/manage.rs
@@ -25,6 +25,7 @@ use super::node_index;
 use super::{HostTarget, provision_node, resolve_mirror_base};
 use crate::node::discovery;
 use crate::node::version::{NodeVersion, VersionPin};
+use crate::pm::shim;
 
 /// True when `<dir>` holds an installed Node (`bin/node` unix, `node.exe`
 /// windows) — the cache-hit / install-complete signal, matching the store
@@ -239,18 +240,21 @@ fn ls_with(store: &Path, active: Option<NodeVersion>) -> Vec<LsEntry> {
 
 /// Remove `version` from nub's cache. `version` is the literal spec the user
 /// typed; it must name a concrete cached version (`X.Y.Z`). Errors when the
-/// version isn't cached, or when the cwd currently resolves to it (removing the
-/// live version would break the current project's runs).
+/// version isn't cached, when the cwd currently resolves to it (removing the
+/// live version would break the current project's runs), or when it's the
+/// user-global default (removing it would dangle the default + `~/.nub/current`).
 pub fn uninstall(version_spec: &str, store: &Path, cwd: &Path) -> Result<NodeVersion> {
-    uninstall_with(version_spec, store, resolved_version(cwd))
+    let default = discovery::default_file().and_then(|f| read_default_record(&f));
+    uninstall_with(version_spec, store, resolved_version(cwd), default)
 }
 
-/// `uninstall` core, parameterized over the resolved version so the active-guard
-/// is testable without touching `discover_node`'s real store.
+/// `uninstall` core, parameterized over the resolved + default versions so the
+/// active- and default-guards are testable without touching the real store.
 fn uninstall_with(
     version_spec: &str,
     store: &Path,
     active: Option<NodeVersion>,
+    default: Option<NodeVersion>,
 ) -> Result<NodeVersion> {
     let version: NodeVersion = version_spec.trim().parse().map_err(|_| {
         anyhow::anyhow!(
@@ -267,6 +271,13 @@ fn uninstall_with(
         bail!(
             "Node {version} is the version this directory currently resolves to — \
              change the pin (or cd elsewhere) before uninstalling it"
+        );
+    }
+
+    if default.as_ref() == Some(&version) {
+        bail!(
+            "Node {version} is your default (nub node default) — \
+             set another default or clear it (nub node default --unset) before uninstalling it"
         );
     }
 
@@ -338,6 +349,196 @@ pub fn pin(spec: &str, cwd: &Path) -> Result<PinResult> {
     })
 }
 
+// ── default ────────────────────────────────────────────────────────────────
+
+/// Outcome of putting the default on PATH (step 2 of `nub node default`). The
+/// record (step 1) is already written regardless of this; a `Failed` here is a
+/// warning, not a command failure — re-running just retries this step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Exposure {
+    /// `~/.nub/current` was wired onto PATH; carries the profile outcome (file to
+    /// source, already present, or a manual line).
+    Path(shim::ProfileOutcome),
+    /// PATH editing isn't automated on Windows yet (its own PR) — `dir` is the
+    /// version's bin dir for the user to add by hand.
+    Unsupported(PathBuf),
+    /// The symlink/profile write failed; `0` is the reason. Non-fatal.
+    Failed(String),
+}
+
+/// What [`set_default`] resolved + did, so the CLI can print a tailored line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DefaultResult {
+    /// The concrete version now recorded as the user-global default.
+    pub version: NodeVersion,
+    /// True when the version had to be downloaded (vs. already in nub's cache).
+    pub installed: bool,
+    /// How (and whether) the default was put on PATH for other programs.
+    pub exposure: Exposure,
+}
+
+/// Set the user-global default Node (`nub node default <spec>`): resolve `spec`
+/// to a concrete version, provision it if absent, record it in `~/.nub/default`
+/// (resolution rung #5), and expose its bin dir on PATH via `~/.nub/current`.
+///
+/// Two design choices: provision into nub's OWN store even if the version is
+/// already on PATH (the default needs a copy nub controls — it's what
+/// `~/.nub/current` links), and store the CONCRETE version not the alias (so the
+/// record and store can't drift; re-run to bump an `lts`/`22`).
+///
+/// Step 2 (`expose_default`) is non-fatal: the record is written first, so a
+/// PATH-wiring failure still leaves a working default and is reported as a
+/// warning, not an error.
+pub fn set_default(spec: &str, store: &Path) -> Result<DefaultResult> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        bail!("nub node default requires a version (e.g. 22, lts, 22.13.0)");
+    }
+    let (version, installed) = resolve_and_provision(spec, store)?;
+    write_default(&version)?;
+    let exposure = expose_default(store, &version);
+    Ok(DefaultResult {
+        version,
+        installed,
+        exposure,
+    })
+}
+
+/// Resolve `spec` to a concrete cached version, downloading it when absent.
+/// Returns `(version, installed)` — `installed` true only when a download
+/// happened. Fast offline path: an exact already-cached version needs no index
+/// fetch.
+fn resolve_and_provision(spec: &str, store: &Path) -> Result<(NodeVersion, bool)> {
+    if let Ok(exact) = spec.parse::<NodeVersion>() {
+        if version_dir_has_node(&store.join(exact.to_string())) {
+            return Ok((exact, false));
+        }
+    }
+    let host = HostTarget::detect()
+        .ok_or_else(|| anyhow::anyhow!("this host is not a platform nodejs.org publishes"))?;
+    let concrete = resolve_to_concrete(spec, store, &host)?;
+    if version_dir_has_node(&store.join(concrete.to_string())) {
+        return Ok((concrete, false));
+    }
+    provision_node(&concrete, &host, store_root_of(store), None)
+        .with_context(|| format!("installing Node {concrete}"))?;
+    Ok((concrete, true))
+}
+
+/// Clear the user-global default (`nub node default --unset`): remove
+/// `~/.nub/default` and tear down the PATH exposure ([`unexpose_default`]).
+/// Returns the version that was set, or `None` when none was. Idempotent —
+/// clearing an unset default is a no-op, not an error.
+pub fn unset_default() -> Result<Option<NodeVersion>> {
+    let Some(file) = discovery::default_file() else {
+        return Ok(None);
+    };
+    let prev = read_default_record(&file);
+    match std::fs::remove_file(&file) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e).with_context(|| format!("removing {}", file.display())),
+    }
+    unexpose_default()?;
+    Ok(prev)
+}
+
+/// `~/.nub/current` — the symlink to the default Node's bin dir that carries it
+/// (and its `npm`/`npx`/`corepack`) onto PATH. A sibling of `~/.nub/shims` and
+/// install.sh's `~/.nub/bin`.
+fn current_link() -> Result<PathBuf> {
+    dirs_next::home_dir()
+        .map(|h| h.join(".nub").join("current"))
+        .ok_or_else(|| anyhow::anyhow!("cannot locate the home directory for ~/.nub/current"))
+}
+
+/// Put the default on PATH (step 2). Infallible by design — any error becomes
+/// `Exposure::Failed` so a wiring failure can't undo the already-written record;
+/// the CLI surfaces it as a warning.
+#[cfg(unix)]
+fn expose_default(store: &Path, version: &NodeVersion) -> Exposure {
+    match try_expose_default(store, version) {
+        Ok(outcome) => Exposure::Path(outcome),
+        Err(e) => Exposure::Failed(format!("{e:#}")),
+    }
+}
+
+/// Atomically re-point `~/.nub/current` at `<store>/<version>/bin` (temp link +
+/// rename, so the swap never leaves `current` missing) and wire it onto PATH via
+/// `shim::add_path_block` (which orders shims ahead of it).
+#[cfg(unix)]
+fn try_expose_default(store: &Path, version: &NodeVersion) -> Result<shim::ProfileOutcome> {
+    let current = current_link()?;
+    if let Some(parent) = current.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let bin = store.join(version.to_string()).join("bin");
+    let tmp = current.with_file_name(format!("current.nub-{}", std::process::id()));
+    let _ = std::fs::remove_file(&tmp);
+    std::os::unix::fs::symlink(&bin, &tmp)
+        .with_context(|| format!("linking {} -> {}", tmp.display(), bin.display()))?;
+    std::fs::rename(&tmp, &current).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })?;
+    shim::add_path_block()
+}
+
+/// Windows: PATH editing isn't automated yet (its own PR) — report the version's
+/// bin dir for the user to add by hand. The record is already written, so nub's
+/// own resolution + the PM shims still pick the default up.
+#[cfg(not(unix))]
+fn expose_default(store: &Path, version: &NodeVersion) -> Exposure {
+    Exposure::Unsupported(store.join(version.to_string()))
+}
+
+/// Remove `~/.nub/current` and recompute the managed PATH block (which drops
+/// `current` while keeping `~/.nub/shims` if it's still installed). Unix only.
+#[cfg(unix)]
+fn unexpose_default() -> Result<()> {
+    let current = current_link()?;
+    match std::fs::remove_file(&current) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e).with_context(|| format!("removing {}", current.display())),
+    }
+    shim::remove_path_block()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn unexpose_default() -> Result<()> {
+    Ok(())
+}
+
+/// Write the concrete default version to `~/.nub/default`, creating `~/.nub` if
+/// missing. Thin real-path wrapper over [`write_default_record`].
+fn write_default(version: &NodeVersion) -> Result<()> {
+    let file = discovery::default_file()
+        .ok_or_else(|| anyhow::anyhow!("could not locate ~/.nub for the default record"))?;
+    write_default_record(&file, version)
+}
+
+/// Write `<version>\n` to `file` (creating its parent), parameterized over the
+/// path so the record format is testable against a temp file. The single
+/// newline-terminated version line mirrors the pin files `pin` writes.
+fn write_default_record(file: &Path, version: &NodeVersion) -> Result<()> {
+    if let Some(parent) = file.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    std::fs::write(file, format!("{version}\n"))
+        .with_context(|| format!("writing {}", file.display()))
+}
+
+/// Read the concrete default version from `file`; `None` when absent, empty, or
+/// unparseable. Strips a leading BOM, matching the pin-file readers.
+fn read_default_record(file: &Path) -> Option<NodeVersion> {
+    let content = std::fs::read_to_string(file).ok()?;
+    let content = content.strip_prefix('\u{FEFF}').unwrap_or(&content);
+    content.trim().parse().ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -363,6 +564,32 @@ mod tests {
         let bin = store.join(version).join("bin");
         std::fs::create_dir_all(&bin).unwrap();
         std::fs::write(bin.join("node"), "").unwrap();
+    }
+
+    #[test]
+    fn default_record_round_trips_and_rejects_garbage() {
+        // The `~/.nub/default` record is a single concrete-version line: what
+        // `write_default` writes is what `unset_default` reads back. Exercised via
+        // the path-injected core (`write_default_record`/`read_default_record`) so
+        // it never touches the real ~/.nub.
+        let dir = tmpdir("default-record");
+        let file = dir.join("default");
+
+        assert_eq!(read_default_record(&file), None, "absent file → no default");
+
+        write_default_record(&file, &NodeVersion::new(22, 15, 0)).unwrap();
+        assert_eq!(
+            read_default_record(&file),
+            Some(NodeVersion::new(22, 15, 0)),
+            "the written concrete version reads back"
+        );
+
+        // A blank or unparseable record falls through to None — a corrupt default
+        // must not error the resolver, the same posture as an unparseable pin file.
+        std::fs::write(&file, "  \n").unwrap();
+        assert_eq!(read_default_record(&file), None, "blank record → no default");
+        std::fs::write(&file, "not-a-version\n").unwrap();
+        assert_eq!(read_default_record(&file), None, "garbage → no default");
     }
 
     #[test]
@@ -466,7 +693,7 @@ mod tests {
         let active = NodeVersion::new(22, 13, 0);
         plant(&store, &active.to_string());
 
-        let err = uninstall_with(&active.to_string(), &store, Some(active.clone()))
+        let err = uninstall_with(&active.to_string(), &store, Some(active.clone()), None)
             .unwrap_err()
             .to_string();
         assert!(
@@ -480,6 +707,28 @@ mod tests {
                 .join("node")
                 .is_file(),
             "the guarded version is NOT removed"
+        );
+    }
+
+    #[test]
+    fn uninstall_guards_the_global_default() {
+        // The global default can't be uninstalled even from a dir that doesn't
+        // resolve to it (active != default) — otherwise `~/.nub/default` and
+        // `~/.nub/current` would dangle. Injected so the guard is hermetic.
+        let store = tmpdir("guard-default-store");
+        let default = NodeVersion::new(22, 15, 0);
+        plant(&store, &default.to_string());
+
+        let err = uninstall_with(&default.to_string(), &store, None, Some(default.clone()))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("is your default"),
+            "the default guard fires with a clear message: {err}"
+        );
+        assert!(
+            store.join(default.to_string()).join("bin").join("node").is_file(),
+            "the default version is NOT removed"
         );
     }
 

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -389,7 +389,7 @@ That installs the Rust binary (via the usual `@<scope>/<platform-arch>` npm dist
 npm install -g --ignore-scripts=false @nubjs/nub@latest
 ```
 
-Same as installing. Nub and Node version independently: Nub resolves the Node your project pins (`.node-version` / `.nvmrc` / `engines.node`) and provisions it if it's missing, falling back to the `node` on your `PATH` only when nothing is pinned. So upgrading Nub does not change your project's Node version, and upgrading Node does not change your Nub version.
+Same as installing. Nub and Node version independently: Nub resolves the Node your project pins (`.node-version` / `.nvmrc` / `engines.node`) and provisions it if it's missing, falling back to your global default — or the `node` on your `PATH` — when nothing is pinned. So upgrading Nub does not change your project's Node version, and upgrading Node does not change your Nub version.
 
 ## Is there a curl install script?
 

--- a/site/content/docs/node.mdx
+++ b/site/content/docs/node.mdx
@@ -1,13 +1,13 @@
 ---
 title: Node manager
-description: Manage the Node versions Nub provisions — pin a version and it's fetched automatically, or drive the cache explicitly with the install, list, uninstall, and pin subcommands.
+description: Manage the Node versions Nub provisions — pin a version and it's fetched automatically, or drive the cache explicitly with the install, list, uninstall, pin, and default subcommands.
 ---
 
-Nub runs your code on stock Node and provisions the right version for you. Pin a version, run a file, and the matching Node is downloaded and cached without a second command — the [implicit path](/docs/runtime#node-version-resolution) covers the common case, so you rarely manage versions by hand. The `nub node` subcommands cover what the automatic path can't reach: warming the cache before you run, listing what's installed, reclaiming disk, and recording a pin.
+Nub runs your code on stock Node and provisions the right version for you. Pin a version, run a file, and the matching Node is downloaded and cached without a second command — the [implicit path](/docs/runtime#node-version-resolution) covers the common case, so you rarely manage versions by hand. The `nub node` subcommands cover what the automatic path can't reach: warming the cache before you run, listing what's installed, reclaiming disk, recording a pin, and setting a global default.
 
 ## Automatic provisioning
 
-Drop a `.node-version` or `.nvmrc` in your project (or an `engines.node` range in `package.json`) and run `nub`. If that Node is already on your machine it's used as-is; if not, Nub downloads the matching stock build from nodejs.org — SHA-256 verified and cached under `~/.cache/nub/node` — then runs your code. Nub provisions the pinned version itself rather than handing off to `nvm`, `fnm`, or `mise`; with nothing pinned anywhere up the tree, it uses whatever `node` is already on your `PATH`.
+Drop a `.node-version` or `.nvmrc` in your project (or an `engines.node` range in `package.json`) and run `nub`. If that Node is already on your machine it's used as-is; if not, Nub downloads the matching stock build from nodejs.org — SHA-256 verified and cached under `~/.cache/nub/node` — then runs your code. Nub provisions the pinned version itself rather than handing off to `nvm`, `fnm`, or `mise`; with nothing pinned anywhere up the tree, it uses your [global default](#nub-node-default) when one is set, otherwise whatever `node` is already on your `PATH`.
 
 ```console
 $ echo 22.15.0 > .node-version
@@ -59,7 +59,7 @@ Only Nub's own download cache is shown — `ls` doesn't enumerate your `nvm` / `
 
 ## `nub node uninstall`
 
-Reclaim disk by deleting a cached version. Nub guards against removing the version your current directory resolves to.
+Reclaim disk by deleting a cached version. Nub guards against removing the version your current directory resolves to, or the one set as your global default.
 
 ```console
 $ nub node uninstall 20.11.0
@@ -85,6 +85,26 @@ A few deliberate behaviors:
 
 Whatever spec you give is written verbatim — including an alias like `lts` — and `pin` works offline. The `.node-version` file is the tool-agnostic convention (`nvm`, `fnm`, `volta`, `asdf` all read it), so the pin is portable to your other tools.
 
+## `nub node default`
+
+Set a user-global default Node — your baseline version, used anywhere a project pins nothing. Setting it also puts that Node on your `PATH`, so a bare `node` at the shell, and any tool that calls one, resolves to it.
+
+```console
+$ nub node default 24.17.0
+Set default Node to 24.17.0.
+  the default Node (node, npm, npx) is on PATH via ~/.nub/current
+  restart your shell, or run: source /Users/you/.zshrc
+```
+
+The spec resolves like any pin — `lts`, a bare major, an exact version — and is downloaded if the cache doesn't already hold it. A project pin always wins; the default only fills in where nothing in the project does. Clear it with `--unset`:
+
+```console
+$ nub node default --unset
+Cleared the default Node (24.17.0).
+```
+
+On Windows the version is recorded the same way, but the `PATH` step isn't automated yet — Nub prints the directory to add by hand.
+
 ## `nub node which`
 
 Resolve which Node runs here and where it lives. The binary path goes to stdout; a `» resolved from <source>` explainer goes to stderr, so it never pollutes a captured value.
@@ -104,7 +124,7 @@ $ echo "$NODE"
 /Users/you/.nvm/versions/node/v22.15.0/bin/node
 ```
 
-With no pin the explainer reads `» resolved from node on PATH`. Bare `nub node` prints a status block instead — the version, path, and resolution source on separate lines.
+With no pin the explainer reads `» resolved from node on PATH`, or `» resolved from nub node default (…)` when a default is set. Bare `nub node` prints a status block instead — the version, path, and resolution source on separate lines.
 
 ## Mirrors and proxies
 

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -26,7 +26,8 @@ Nub resolves the project's pinned Node before running anything, walking up from 
 - `.node-version`
 - `.nvmrc`
 - `package.json` → `engines.node` (a range)
-- the `node` on your `PATH`, when nothing is pinned
+- the global default set with [`nub node default`](/docs/node#nub-node-default)
+- the `node` on your `PATH`, when nothing above is set
 
 When a pinned version isn't installed, Nub fetches it — see [Managing Node versions](/docs/node).
 


### PR DESCRIPTION
### user-global default Node

Resolves #5 

Adds `nub node default <version>`: the Node version used when a project pins nothing, and exposes it on `PATH` so non-nub programs find `node` / `npm` / `npx`.

Disclaimer: I've also used Opus to help me navigate and draft some of the changes, as I've written in rust only a handful of times.

#### What changed

Added a new command, new resolution step and rewrote the internal handling of shims to take into account `npm` and `npx` overridability. Generally speaking:

- `nub node default <version>` sets the default (auto-installs if uncached); `--unset` clears it.
- Resolution gains a lowest rung — `~/.nub/default`, after `engines.node`, before the bare-`PATH` node.
- The default's `bin/` is put on `PATH` via a `~/.nub/current` symlink.
- Shell-profile PATH block unified under `# nub path`: lists `~/.nub/shims` then `~/.nub/current` in fixed priority; the old `# nub shims` block migrates automatically.
- I've preferred to configure `nub node uninstall` to refuse the version that's set as the default, but we could rewrite this into auto-cleanup instead if required.
- docs updated accordingly

#### Why (decisions)

- **Unified PATH block.** Deterministic ordering, so a `pm shim`-routed `npm` always outranks the default distribution's `npm` regardless of which feature was enabled first.
- **PATH wiring is non-fatal.** The record is written before the symlink/profile step, so a wiring failure still leaves a working default plus a warning; re-running retries only that step.
- **Uninstall guard.** Prevents a dangling `~/.nub/default` and a broken `~/.nub/current`.
- **Fallback fixes a dead-end.** With no pin and Node only in nub's cache, resolution errored (`NoNodeOnPath`) — which also broke the PM shims on a clean system. The default is the user-wide fallback.
- **Default beats the system `node` in unpinned projects.** Matches nvm / volta / fnm: "default" (as far as I know) is what runs when nothing else specifies.
- **Stored outside the cache, as a concrete version.** A cache wipe must not drop an opted-in default; recording the resolved version (not `lts` / `22`) keeps the record and store in lockstep.
- **Exposes the whole `bin/`, as plain Node.** `npm` / `npx` are relative symlinks into `../lib` and only work with the bin dir intact; plain Node keeps a bare `node` unsurprising, while `nub <file>` still auto-switches per project.

#### Additional internal breaking change

I've touched the shipped `nub pm shim`: its profile marker changes `# nub shims` → `# nub path`, rewritten to the unified block. Existing blocks migrate on the next `pm shim` / `node default` / `unshim`.

While asking Opus for some review of the changes it also noted that both `SHIMS_POSIX_PATH_LINE` and `SHIMS_FISH_PATH_LINE` were stale, unused, public consts, so personally agreed on cleaning them up. Easy readdition if I've missed the underlying logic for those 🙏

#### Kept out of scope

Windows `PATH` automation — `default` records the version (resolution + shims use it) but prints a manual `PATH` instruction, exactly like shims one.
