### PR TITLE
nub-native: recover from mutex poison in tsconfig cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "nub-cli"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "aube",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "nub-core"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "nub-native"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "blake3",
  "json5",

--- a/crates/nub-native/src/tsconfig.rs
+++ b/crates/nub-native/src/tsconfig.rs
@@ -99,13 +99,13 @@ pub fn load_tsconfig(dir: String) -> TsconfigResult {
 /// Shared internal entry — returns the cached `Loaded` (with its matcher) so the
 /// resolver can reuse the same per-dir state without re-reading the FS.
 fn load_for_dir(dir: &str) -> Arc<Loaded> {
-    if let Some(hit) = cache().lock().unwrap().get(dir) {
+    if let Some(hit) = cache().lock().unwrap_or_else(|e| e.into_inner()).get(dir) {
         return hit.clone();
     }
     let loaded = Arc::new(build_loaded(dir));
     cache()
         .lock()
-        .unwrap()
+        .unwrap_or_else(|e| e.into_inner())
         .insert(dir.to_string(), loaded.clone());
     loaded
 }


### PR DESCRIPTION
Both lock accesses in `load_for_dir` used `.unwrap()`, which would panic if the lock had been poisoned by an earlier panic. This changes them to `.unwrap_or_else(|e| e.into_inner())`, matching the pattern already used elsewhere in the codebase, so a previous transient panic doesn't cause all future `loadTsconfig` and `resolveTs` N-API calls to fail.
