### PR TITLE
node: unflag wasm-modules (compat-backfill) + shadow-realm

### DIFF
--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -149,6 +149,23 @@ pub static FEATURES: &[Feature] = &[
         )],
         evidence: "flag added Node 9.6.0 (#14253); never unflagged through Node 26",
     },
+    // ── ShadowRealm global ──────────────────────────────────────────────────
+    // `--experimental-shadow-realm` gates `globalThis.ShadowRealm` (TC39 Stage 3:
+    // an isolated global with fresh intrinsics). The flag was added in Node
+    // 18.13.0 / 19.0.0 — below nub's 18.19 floor — and has NEVER been made
+    // default-on through Node 26 (still experimental, rides the V8
+    // `--harmony-shadow-realm` staging). So, like vm-modules, inject across the
+    // ENTIRE supported floor: [18.19.0, ∞). It survives as an accepted bool at
+    // every higher version, so the open-ended band never over-injects into an
+    // unsupported range.
+    Feature {
+        name: "shadow-realm",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Unflag("--experimental-shadow-realm"),
+        )],
+        evidence: "flag added Node 18.13.0/19.0.0; never default-on through 26 (TC39 Stage 3)",
+    },
     // ── EventSource global ──────────────────────────────────────────────────
     // #51575 ("add EventSource Client"). Landed on the 22.x line at 22.3.0 and was
     // backported to the 20.x LTS line at 20.18.0. The 21.x line was already EOL
@@ -189,6 +206,33 @@ pub static FEATURES: &[Feature] = &[
             ),
         ],
         evidence: "flag added Node 22.5.0 (#53752); unflagged 22.13.0 (22.x) and 23.4.0 (23.x)",
+    },
+    // ── Wasm ES-module imports (import of `.wasm`) ──────────────────────────
+    // `--experimental-wasm-modules` gates `import` of `.wasm` files (instance-
+    // phase `import * as M from './x.wasm'` and source-phase `import source M
+    // from './x.wasm'`). The flag has existed since Node 12 — far below nub's
+    // 18.19 floor — so it both EXISTS and is REQUIRED across the whole compat
+    // range below the default-on cutover. It became default-on (flag → NoOp) at
+    // 24.5.0 on the 24.x line and was backported to 22.19.0 on the 22.x line
+    // (PR #57038); the 23.x line was EOL before the backport, so it never went
+    // default-on there and stays flagged through the end of the 23.x line.
+    // Inject only where the flag is still required:
+    //   [18.19.0, 22.19.0) ∪ [23.0.0, 24.5.0).
+    // (Injecting in the default-on range would be a harmless no-op — the flag
+    // survives as a NoOp — but the bands are kept tight, matching sqlite.)
+    Feature {
+        name: "wasm-modules",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((22, 19, 0))),
+                Mitigation::Unflag("--experimental-wasm-modules"),
+            ),
+            (
+                band((23, 0, 0), Some((24, 5, 0))),
+                Mitigation::Unflag("--experimental-wasm-modules"),
+            ),
+        ],
+        evidence: "flag since Node 12; default-on 24.5.0 (24.x) and 22.19.0 (22.x) via #57038; never default-on on 23.x (EOL)",
     },
     // ── addon-modules (ESM import of native .node addons) ────────────────────
     // `--experimental-addon-modules` makes the ESM resolver return format
@@ -586,6 +630,10 @@ mod tests {
         // vm-modules: whole floor.
         assert!(unflag_flags_for(&v(18, 19, 0)).contains(&"--experimental-vm-modules"));
         assert!(unflag_flags_for(&v(26, 2, 0)).contains(&"--experimental-vm-modules"));
+        // shadow-realm: whole floor, open-ended (never default-on).
+        assert!(unflag_flags_for(&v(18, 19, 0)).contains(&"--experimental-shadow-realm"));
+        assert!(unflag_flags_for(&v(22, 19, 0)).contains(&"--experimental-shadow-realm"));
+        assert!(unflag_flags_for(&v(26, 0, 0)).contains(&"--experimental-shadow-realm"));
         // eventsource: the 21.x hole.
         assert!(!unflag_flags_for(&v(21, 0, 0)).contains(&"--experimental-eventsource"));
         assert!(unflag_flags_for(&v(20, 18, 0)).contains(&"--experimental-eventsource"));
@@ -595,6 +643,19 @@ mod tests {
         assert!(!unflag_flags_for(&v(22, 13, 0)).contains(&"--experimental-sqlite"));
         assert!(unflag_flags_for(&v(23, 3, 0)).contains(&"--experimental-sqlite"));
         assert!(!unflag_flags_for(&v(24, 0, 0)).contains(&"--experimental-sqlite"));
+        // wasm-modules: two disjoint bands [18.19, 22.19) ∪ [23.0, 24.5).
+        // 22.x line: flagged below 22.19, native at/after (backport).
+        assert!(unflag_flags_for(&v(18, 19, 0)).contains(&"--experimental-wasm-modules"));
+        assert!(unflag_flags_for(&v(20, 18, 0)).contains(&"--experimental-wasm-modules"));
+        assert!(unflag_flags_for(&v(22, 13, 0)).contains(&"--experimental-wasm-modules"));
+        assert!(unflag_flags_for(&v(22, 18, 0)).contains(&"--experimental-wasm-modules"));
+        assert!(!unflag_flags_for(&v(22, 19, 0)).contains(&"--experimental-wasm-modules"));
+        // 23.x line: flagged the whole line (never got the backport).
+        assert!(unflag_flags_for(&v(23, 2, 0)).contains(&"--experimental-wasm-modules"));
+        assert!(unflag_flags_for(&v(24, 4, 0)).contains(&"--experimental-wasm-modules"));
+        // 24.5+: native (flag → NoOp).
+        assert!(!unflag_flags_for(&v(24, 5, 0)).contains(&"--experimental-wasm-modules"));
+        assert!(!unflag_flags_for(&v(26, 0, 0)).contains(&"--experimental-wasm-modules"));
         // addon-modules: [22.20, 23.0) ∪ [23.6, ∞); the [23.0, 23.6) hole and
         // the whole compat tier below 22.20 are excluded (flag doesn't exist).
         let addon = "--experimental-addon-modules";

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -379,6 +379,33 @@ mod tests {
     }
 
     #[test]
+    fn wasm_modules_injected_only_in_the_two_flagged_bands() {
+        // Wasm ES-module imports: flag exists since Node 12 (below the floor),
+        // default-on at 24.5.0 (24.x) and 22.19.0 (22.x) via #57038; never
+        // default-on on the 23.x line (EOL before the backport). Inject on
+        // [18.19, 22.19) ∪ [23.0, 24.5).
+        let w = "--experimental-wasm-modules";
+        assert!(compute_inject_flags(v(18, 19, 0), &[], None, false).contains(&w)); // floor
+        assert!(compute_inject_flags(v(22, 13, 0), &[], None, false).contains(&w));
+        assert!(compute_inject_flags(v(22, 18, 0), &[], None, false).contains(&w));
+        assert!(!compute_inject_flags(v(22, 19, 0), &[], None, false).contains(&w)); // default-on 22.x
+        assert!(compute_inject_flags(v(23, 2, 0), &[], None, false).contains(&w)); // 23.x stays flagged
+        assert!(compute_inject_flags(v(24, 4, 0), &[], None, false).contains(&w));
+        assert!(!compute_inject_flags(v(24, 5, 0), &[], None, false).contains(&w)); // default-on 24.x
+        assert!(!compute_inject_flags(v(26, 0, 0), &[], None, false).contains(&w));
+    }
+
+    #[test]
+    fn shadow_realm_injected_across_the_whole_floor() {
+        // ShadowRealm: flag exists from 18.13/19.0 (below the floor), never made
+        // default-on through Node 26 (TC39 Stage 3). Inject from 18.19 to infinity.
+        let s = "--experimental-shadow-realm";
+        assert!(compute_inject_flags(v(18, 19, 0), &[], None, false).contains(&s));
+        assert!(compute_inject_flags(v(22, 19, 0), &[], None, false).contains(&s));
+        assert!(compute_inject_flags(v(26, 0, 0), &[], None, false).contains(&s));
+    }
+
+    #[test]
     fn user_opt_out_via_argv() {
         let argv = vec!["--no-experimental-vm-modules".to_string()];
         let flags = compute_inject_flags(v(22, 15, 0), &argv, None, false);

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -95,6 +95,8 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`navigator.locks`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) | — | polyfill below Node 24.5, native above |
 | [`reportError`](https://developer.mozilla.org/en-US/docs/Web/API/Window/reportError) | — | polyfill |
 | [`vm.Module`](https://nodejs.org/api/vm.html#class-vmmodule) | — | flag-injected |
+| [`ShadowRealm`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ShadowRealm) | — | flag-injected |
+| [Wasm module imports](https://nodejs.org/api/esm.html#wasm-modules) | — | flag-injected below Node 24.5 (22.19 on the 22.x line), native above |
 | [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) | Node 20.10 | flag-injected below Node 22, native above |
 | [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) | Node 20.18 | flag-injected below the native line, native above |
 | [`node:sqlite`](https://nodejs.org/api/sqlite.html) | Node 22.5 | flag-injected below Node 22.13, native above |


### PR DESCRIPTION
Adds two feature-matrix rows so nub auto-injects the experimental flag on the Node versions that still require it.

## wasm-modules (mechanical compat-backfill)

\`import` of `.wasm` files is **default-on in current Node** — the `--experimental-wasm-modules` flag became a NoOp at **24.5.0** (24.x line) and **22.19.0** (22.x line) via [nodejs/node#57038](https://github.com/nodejs/node/pull/57038). Per the unflag-on-prior-versions rule (default-on in current Node ⇒ backfill it where it was flagged), this is a mechanical banded unflag, same shape as the live sqlite row.

Bands (injected where the flag both exists and is required):

```
[18.19, 22.19)  inject   # 22.x line, pre-backport
[22.19, 23.0)   native   # backport landed
[23.0,  24.5)   inject   # 23.x EOL before the backport — stays flagged
[24.5,  inf)    native   # default-on
```

The 23.x line never received the #57038 backport (EOL before 24.5), so it stays flagged through the end of the line — verified against `.repos/node` `doc/api/esm.md`.

**Resolver passthrough:** nub leaves `.wasm` import specifiers untouched. `TRANSPILE_EXTS` covers only `.ts/.tsx/.mts/.cts/.jsx`, and the additive resolver (`resolveTs`) returns `null` for a `.wasm` specifier, so it falls through to Node native wasm loader — no transform, no re-resolve.

## shadow-realm

`--experimental-shadow-realm` exists from Node 18.13/19.0 (below the floor) and has **never** been made default-on through Node 26 (TC39 Stage 3, rides V8 `--harmony-shadow-realm` staging). Inject across the whole supported floor `[18.19, inf)`, like vm-modules.

> [!IMPORTANT]
> shadow-realm is **NOT** the mechanical case wasm-modules is — it is a Stage-3, not-default-on-anywhere global, and turning it on by default is a product/posture call, not a backport. The thread `.fray/v0x-shadow-realm-unflag.md` recommends DEFER. It is included here per a coordinator-relayed decision, but a coordinator relay is not user authority — **this row needs Colin own sign-off before merge.** If the call is to defer, drop the shadow-realm commit/row and ship wasm-modules alone.

## Tests

- Band tests in `feature_matrix.rs` (matrix layer) and end-to-end `compute_inject_flags` band tests in `flags.rs` (the spawn path) for both features.
- `cargo test -p nub-core --lib` → 274 passed; clippy + fmt clean.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa