### PR TITLE
node: unflag addon-modules (ESM import of native .node addons on prior versions)

### DIFF
--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -190,6 +190,30 @@ pub static FEATURES: &[Feature] = &[
         ],
         evidence: "flag added Node 22.5.0 (#53752); unflagged 22.13.0 (22.x) and 23.4.0 (23.x)",
     },
+    // ── addon-modules (ESM import of native .node addons) ────────────────────
+    // `--experimental-addon-modules` makes the ESM resolver return format
+    // "addon" for a `.node` URL, so `import x from './foo.node'` loads the native
+    // addon directly. Flag added on the 23.x line at 23.6.0 and backported to the
+    // 22.x LTS line at 22.20.0 (the same dual-line split as node:sqlite). It is
+    // Stability 1.0 (Early development) and NEVER default-on through Node 27
+    // nightly, so the Unflag bands are open-ended on the high side — there is no
+    // native cutover. The flag does not exist below 22.20.0 or on [23.0, 23.6)
+    // (the 23.x line before the backport landed), where injecting it is a "bad
+    // option" startup abort. Injection set: [22.20.0, 23.0.0) ∪ [23.6.0, ∞).
+    Feature {
+        name: "addon-modules",
+        mitigations: &[
+            (
+                band((22, 20, 0), Some((23, 0, 0))),
+                Mitigation::Unflag("--experimental-addon-modules"),
+            ),
+            (
+                band((23, 6, 0), None),
+                Mitigation::Unflag("--experimental-addon-modules"),
+            ),
+        ],
+        evidence: "flag added 23.6.0 (23.x) / 22.20.0 (22.x backport); Stability 1.0; never default-on through Node 27",
+    },
     // ── WebSocket global ────────────────────────────────────────────────────
     // Flag-gated on [20.10.0, 22.0.0) — the global exists on 20.10+ and all of the
     // 21.x line behind `--experimental-websocket`, then becomes default-on at
@@ -571,6 +595,15 @@ mod tests {
         assert!(!unflag_flags_for(&v(22, 13, 0)).contains(&"--experimental-sqlite"));
         assert!(unflag_flags_for(&v(23, 3, 0)).contains(&"--experimental-sqlite"));
         assert!(!unflag_flags_for(&v(24, 0, 0)).contains(&"--experimental-sqlite"));
+        // addon-modules: [22.20, 23.0) ∪ [23.6, ∞); the [23.0, 23.6) hole and
+        // the whole compat tier below 22.20 are excluded (flag doesn't exist).
+        let addon = "--experimental-addon-modules";
+        assert!(!unflag_flags_for(&v(22, 19, 0)).contains(&addon));
+        assert!(unflag_flags_for(&v(22, 20, 0)).contains(&addon));
+        assert!(!unflag_flags_for(&v(23, 0, 0)).contains(&addon));
+        assert!(!unflag_flags_for(&v(23, 5, 0)).contains(&addon));
+        assert!(unflag_flags_for(&v(23, 6, 0)).contains(&addon));
+        assert!(unflag_flags_for(&v(26, 2, 0)).contains(&addon));
         // websocket: [20.10, 22.0).
         assert!(!unflag_flags_for(&v(20, 9, 0)).contains(&"--experimental-websocket"));
         assert!(unflag_flags_for(&v(20, 10, 0)).contains(&"--experimental-websocket"));

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -98,12 +98,14 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) | Node 20.10 | flag-injected below Node 22, native above |
 | [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) | Node 20.18 | flag-injected below the native line, native above |
 | [`node:sqlite`](https://nodejs.org/api/sqlite.html) | Node 22.5 | flag-injected below Node 22.13, native above |
+| [addon imports](https://nodejs.org/api/esm.html#node-addons) | Node 22.20 | flag-injected, never native |
 
-A dash means the API works across the full supported range, 18.19 and up. The three floored rows have a real cutoff, because the underlying Node mechanism doesn't exist below it:
+A dash means the API works across the full supported range, 18.19 and up. The floored rows have a real cutoff, because the underlying Node mechanism doesn't exist below it:
 
 - The `WebSocket` global needs Node 20.10 — the flag Nub injects below the native line (Node 22) doesn't exist on older 20.x patches.
 - The `EventSource` global needs Node 20.18, the patch where Node added the flag on the 20 LTS line.
 - The `node:sqlite` module needs Node 22.5, where Node first shipped it.
+- Importing a native `.node` addon from an ES module needs Node 22.20 (or 23.6 on the 23 line), where Node added the flag Nub injects. It is never native — Node keeps the import behind the flag — so Nub injects it on every version that has it.
 
 ## `--node`
 


### PR DESCRIPTION
Adds an `Unflag` matrix row for `--experimental-addon-modules`, so ES modules can `import` native `.node` addons directly (`import addon from './foo.node'`) on the Node versions where the flag exists.

## Bands (verified against `.repos/node`)

The flag was added on the 23.x line at **23.6.0** and backported to the 22.x LTS line at **22.20.0** (`doc/api/cli.md` `added: [v23.6.0, v22.20.0]` — the same dual-line split as `node:sqlite`). It is **Stability 1.0 (Early development)** and **never default-on** (`experimental_addon_modules = EXPERIMENTALS_DEFAULT_VALUE` = `false`, confirmed through Node 27 nightly), so the Unflag bands are open-ended on the high side — there is no native cutover.

Injection set: `[22.20.0, 23.0.0)` ∪ `[23.6.0, ∞)`. The flag does not exist below 22.20.0 (compat tier) or on `[23.0.0, 23.6.0)` (the 23.x line before the backport), where injecting it is a "bad option" startup abort, so those ranges are excluded. The flag is `kAllowedInEnvvar`, so it is safe in NODE_OPTIONS.

## Changes

- `crates/nub-core/src/node/feature_matrix.rs`: new `addon-modules` row + band tests (the two disjoint bands, the `[23.0, 23.6)` hole, and the compat-tier exclusion).
- `site/content/docs/runtime/index.mdx`: addon-imports row in the Modern APIs table, version-banded and factual.

## Verification

- `cargo test -p nub-core --lib` — 274 passed.
- `cargo clippy -p nub-core --lib` — clean.
- `cargo fmt` — clean.

Greenlit (consistent with the shadow-realm posture: routinely unflag Stability-1 experimental features Node is not discouraging; `--node` opts out).

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa