### PR TITLE
pm: lock brand boundary on the not-a-command front door

### DIFF
--- a/crates/nub-cli/src/pm_engine/store_config_family.rs
+++ b/crates/nub-cli/src/pm_engine/store_config_family.rs
@@ -2,9 +2,10 @@
 //! through the embedded aube engine: `store` (add/path/prune/status),
 //! `cache` (list/view/delete/prune/list-registries), `cat-file`,
 //! `cat-index`, `find-hash`, `config` (+`c`) with the hidden top-level
-//! `get`/`set` shorthands, and the npm-fallback verbs `pkg`, `set-script`.
+//! `get`/`set` shorthands, and the native package.json editors `pkg`,
+//! `set-script` (engine-implemented, not an npm shell-out).
 //!
-//! The wiring helpers (`parse_verb`, `run_async`, `run_npm_fallback`) are
+//! The wiring helpers (`parse_verb`, `run_async`) are
 //! shared with [`super::publish_family`] — see its module doc for the
 //! common shape (brand-rewritten help/usage, engine session preflight,
 //! failures through [`present::emit_report`]).

--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -735,3 +735,54 @@ fn warm_exact_re_pin_skips_the_network_while_a_range_still_resolves() {
         range.stdout, range.stderr
     );
 }
+
+/// Brand boundary on the not-a-command front door. pnpm 10.15 delegates its
+/// own "not implemented" set (`access`/`edit`/`issues`/`profile`/`team`/…) to
+/// the npm CLI, so `pnpm access` prints `npm error code EUSAGE`. nub must NOT
+/// inherit that leak: a command nub does not implement is refused with a
+/// nub-branded message, never an `npm error` (or `aube`) line, on every output
+/// stream. This locks the brand contract regardless of how the refusal message
+/// is later worded or which exit code it carries.
+///
+/// `set-script` and `token` are deliberately excluded — nub ships native verbs
+/// for both (a superset of pnpm's not-implemented list, v0.1.9), verified
+/// clean elsewhere; they are not refused.
+#[test]
+fn unimplemented_pm_commands_never_leak_npm() {
+    let dir = pm_tmpdir("noleak");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"x","version":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    // pnpm's npm-delegated "not implemented" set, plus a wholly unsupported
+    // word. None of these is a nub command; each must be refused brand-clean.
+    for cmd in [
+        "access",
+        "edit",
+        "issues",
+        "prefix",
+        "profile",
+        "team",
+        "xmas",
+        "totallyfakecommand",
+    ] {
+        let out = run_nub(&dir, &[cmd]);
+        assert_ne!(out.code, 0, "`nub {cmd}` is not a command — must fail");
+        out.assert_brand_clean();
+        let lower = out.combined().to_lowercase();
+        assert!(
+            !lower.contains("npm error"),
+            "`nub {cmd}` must not leak an npm error (pnpm delegates these to npm; nub does not):\nstdout: {}\nstderr: {}",
+            out.stdout,
+            out.stderr
+        );
+        assert!(
+            out.combined().contains("nub"),
+            "the refusal must be nub-branded:\nstdout: {}\nstderr: {}",
+            out.stdout,
+            out.stderr
+        );
+    }
+}


### PR DESCRIPTION
Investigated three pnpm-compat front-door divergences (B1 not-implemented→npm leak, B2 unsupported-command exit code, B3 self-update nag) against current nub and real pnpm 10.15.1. Most premises did not reproduce on current nub; this PR lands the one unambiguous, brand-correct guard plus a stale-comment fix.

## What landed
- Regression test (`unimplemented_pm_commands_never_leak_npm`): asserts that pnpm's npm-delegated not-implemented set (`access`/`edit`/`issues`/`profile`/`team`/`xmas`/`prefix`) and a wholly unsupported word are refused brand-clean — no `npm error` (or `aube`) line on any stream, nub-branded message. Locks the brand contract regardless of future wording/exit-code changes. Deliberately does not pin an exit code (that is an open behavior question, below).
- Stale module-doc fix in `store_config_family.rs`: removed a reference to a deleted `run_npm_fallback` helper and corrected the `pkg`/`set-script` description (native engine verbs, not npm shell-outs).

## Findings (grounded against pnpm 10.15.1 + current nub on origin/main)
- B1: current nub has no npm-leak path — the unknown-command→npm passthrough the thread feared was already removed; these commands give a nub-branded refusal. pnpm 10.15 itself leaks `npm error` for them, so matching pnpm would *introduce* a leak. `token`/`set-script` are clean native supersets.
- B2: real pnpm exits 254 for an unsupported command (via its implicit exec-shorthand, `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`); nub exits 1. The thread had this inverted (claimed pnpm=1/nub=254). Aligning would mean adopting an exec-shorthand nub deliberately rejects — a behavior call.
- B3: already fixed. nub's embedder profile sets `self_update_enabled: false`; aube's notifier early-returns, only fires from the dead-under-nub `aube --version`/`doctor` path, and writes to stderr. A first-run install probe showed no nag on stdout.

## Verification
- `cargo test -p nub-cli --test pm_verbs unimplemented_pm_commands_never_leak_npm` → 1 passed
- `cargo clippy -p nub-cli --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --check` → clean
- e2e: diffed `nub` vs pnpm 10.15.1 across the full command set

Refs the pnpm-compat-harness-bugs thread.