### PR TITLE
cli: dispatch -r/--filter before info verbs to the PM engine

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1008,41 +1008,38 @@ const PM_VERBS: &[&str] = &[
     "migrate",
 ];
 
-/// The verbs a leading flag-run may precede. pnpm accepts `pnpm -r <verb>` for
-/// every workspace-aware verb, not just `run`/`exec` — so a leading `-r`/`-F`/…
-/// before an install-family verb (`install`/`ci`/`add`/…) must reorder the same
-/// way, or it falls through to the Node-passthrough path and Node fails on
-/// `--require install` (`Cannot find module 'install'`).
-const NORMALIZABLE_LEADING_FLAG_VERBS: &[&str] = &[
-    "run",
-    "exec", // the original run/exec set
-    "install",
-    "i",
-    "ci", // native install-family verbs
-    "add",
-    "remove",
-    "rm",
-    "uninstall",
-    "un", // engine add/remove family
-    "update",
-    "up",
-    "dedupe",
-    "prune",
-    "rebuild",
-    "fetch",
-    "link",
-    "unlink",
-    "import",
-];
+/// Whether a leading flag-run may be reordered to sit *after* `verb`. pnpm
+/// accepts `pnpm -r <verb>` / `pnpm --filter <x> <verb>` for every workspace-
+/// aware verb — not just `run`/`exec`, but the install family (`install`/`ci`/
+/// `add`/…) AND the read-only info family (`list`/`ls`/`why`/`outdated`/
+/// `licenses`/`audit`/…). A leading run-flag before one of these must reorder
+/// into canonical subcommand-first order; otherwise the verb token falls
+/// through to the Node-passthrough/file-runner path and Node fails on, e.g.,
+/// `--require list` (`Cannot find module 'list'`) or `node: bad option:
+/// --filter`, falsely reporting success.
+///
+/// The recognized set is exactly the PM verbs nub can dispatch — the same
+/// authority the bareword arm consults (`SUBCOMMANDS` + the engine verb
+/// registry). Tying the two together is what keeps them from drifting: a verb
+/// nub dispatches in first position must also be reorderable behind a leading
+/// workspace flag, or the two surfaces disagree (the install family worked only
+/// because it was hand-listed here; the info family crashed purely because it
+/// was absent). Verbs that don't actually accept `-r`/`--filter` are still safe
+/// to reorder — clap (or the engine) rejects the unsupported flag downstream
+/// with a proper non-zero error, exactly as pnpm does.
+fn is_normalizable_leading_flag_verb(verb: &str) -> bool {
+    SUBCOMMANDS.contains(&verb) || crate::pm_engine::lookup_verb(verb).is_some()
+}
 
 /// Accept pnpm's flag-before-subcommand order. pnpm takes `pnpm -r run build` AND
 /// `pnpm run -r build`; nub's pre-parse otherwise only recognizes a subcommand in
 /// first position, so a leading run-flag (`-r`, `--filter`, …) falls through to
 /// the Node-passthrough path and Node fails on `--require run` (`Cannot find
 /// module 'run'`). If the args begin with a run of the `run`/`exec` flags
-/// (consuming the value of value-taking ones) immediately followed by one of
-/// [`NORMALIZABLE_LEADING_FLAG_VERBS`], reorder into canonical subcommand-first
-/// order (`run -r build`, `install -r`). Anything else — a Node flag, a file,
+/// (consuming the value of value-taking ones) immediately followed by a verb
+/// [`is_normalizable_leading_flag_verb`] recognizes, reorder into canonical
+/// subcommand-first order (`run -r build`, `install -r`, `list -r`). Anything
+/// else — a Node flag, a file,
 /// `nub <file>`, eval — leaves the args untouched, so file/passthrough/eval
 /// dispatch is unaffected. Returns `None` when no normalization applies. Keep the
 /// flag lists in sync with the `Run` subcommand's `#[arg]` set.
@@ -1096,7 +1093,7 @@ fn normalize_leading_run_flags(args: &[String]) -> Option<Vec<String>> {
     if !leading.is_empty()
         && args
             .get(i)
-            .is_some_and(|v| NORMALIZABLE_LEADING_FLAG_VERBS.contains(&v.as_str()))
+            .is_some_and(|v| is_normalizable_leading_flag_verb(v))
     {
         let mut out = Vec::with_capacity(args.len());
         out.push(args[i].clone()); // subcommand first

--- a/crates/nub-cli/tests/cli_grammar_parity.rs
+++ b/crates/nub-cli/tests/cli_grammar_parity.rs
@@ -211,6 +211,94 @@ fn leading_global_flags_before_install_family() {
     );
 }
 
+// Leading global flags before a READ-ONLY/info verb (`-r list`, `--filter x
+// why`). pnpm runs `pnpm -r <info-verb>` / `pnpm --filter <x> <info-verb>` as
+// the canonical recursive/filtered query; nub must reorder the leading flags so
+// the verb dispatches to the PM engine. The grammar table above can't guard
+// this: appending `--help` short-circuits to the help page BEFORE dispatch, so
+// it never exercises the routing. Here we dispatch for real (no `--help`) and
+// assert the verb reached the engine — i.e. the file-runner crash markers
+// (`Cannot find module 'list'`, `node: bad option: --filter`) are ABSENT. (Bug:
+// the info family was omitted from the leading-flag reorder set, so these fell
+// through to the Node file-runner.)
+#[test]
+fn leading_global_flags_before_info_verb_reach_engine() {
+    // Run `nub <args>` in an isolated, manifest-bearing workspace (no `--help`)
+    // and return whether the verb fell through to the Node file-runner — keyed
+    // on the crash markers that path emits. Engine dispatch (even when it then
+    // bails on a missing lockfile) never emits these.
+    fn fell_through_to_file_runner(args: &[&str]) -> (bool, String) {
+        let tmp = std::env::temp_dir().join(format!(
+            "nub-route-{}-{}",
+            std::process::id(),
+            args.join("_").replace(['/', ' ', '='], "-")
+        ));
+        let _ = std::fs::create_dir_all(&tmp);
+        let _ = std::fs::write(
+            tmp.join("package.json"),
+            r#"{"name":"root","private":true,"workspaces":["packages/*"]}"#,
+        );
+        let _ = std::fs::create_dir_all(tmp.join("packages/a"));
+        let _ = std::fs::write(
+            tmp.join("packages/a/package.json"),
+            r#"{"name":"a","version":"1.0.0"}"#,
+        );
+
+        let out = Command::new(nub_binary())
+            .args(args)
+            .current_dir(&tmp)
+            .env("HOME", &tmp)
+            .env("XDG_CACHE_HOME", tmp.join("cache"))
+            .env("XDG_DATA_HOME", tmp.join("data"))
+            .env("PNPM_HOME", tmp.join("pnpm"))
+            .output()
+            .expect("spawn nub");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+        // The file-runner is Node: a verb misrouted to it as a module/flag dies
+        // in the CJS loader or with a Node bad-option error.
+        let crashed = combined.contains("Cannot find module")
+            || combined.contains("node: bad option")
+            || combined.contains("internal/modules/cjs/loader");
+        (crashed, combined)
+    }
+
+    let rows: &[(&[&str], &str)] = &[
+        (&["-r", "list"], "pnpm -r list"),
+        (&["--recursive", "list"], "pnpm --recursive list"),
+        (&["-r", "ls"], "pnpm -r ls (alias)"),
+        (&["--filter", "a", "list"], "pnpm --filter <x> list"),
+        (&["-F", "a", "why", "a"], "pnpm -F <x> why <pkg>"),
+        (&["-r", "why", "a"], "pnpm -r why <pkg>"),
+        (&["-r", "outdated"], "pnpm -r outdated"),
+        (&["-r", "licenses"], "pnpm -r licenses"),
+        (&["-r", "audit"], "pnpm -r audit"),
+    ];
+
+    let mut failures = Vec::new();
+    for (form, note) in rows {
+        let (crashed, output) = fell_through_to_file_runner(form);
+        if crashed {
+            failures.push(format!(
+                "  nub {} → fell through to the file-runner (pnpm: {note})\n    output: {}",
+                form.join(" "),
+                output.lines().next().unwrap_or("").trim()
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "leading-flag-before-info-verb: {} of {} forms misrouted to the Node file-runner:\n{}",
+        failures.len(),
+        rows.len(),
+        failures.join("\n")
+    );
+}
+
 // `nub ci` — pnpm `ci` (clean-install). pnpm's `ci` documents NO production
 // control (it is exactly `clean` + `install --frozen-lockfile`), so the
 // pnpm-only surface is bare `ci` plus nub's workspace/script knobs.


### PR DESCRIPTION
## Problem

`nub -r <verb>` and `nub --filter <x> <verb>` for the read-only info verb family (`list`/`ls`/`la`/`ll`, `why`, `outdated`, `licenses`, `audit`, `peers`, `query`, `check`, `sbom`, `bin`, `root`, `view`, `search`) fell through to the Node file-runner instead of dispatching to the PM engine:

- `nub -r list` → `Error: Cannot find module 'list'`
- `nub --filter a list` → `node: bad option: --filter`

`pnpm -r <cmd>` / `pnpm --filter <x> <cmd>` are the canonical workspace invocations, so this was a high-traffic compat break.

## Root cause

`normalize_leading_run_flags` reorders a leading run-flag (`-r`/`--recursive`/`--filter`/`-F`/…) to sit after the verb, but only when the verb was in the hand-curated `NORMALIZABLE_LEADING_FLAG_VERBS` list — which covered the install family only. The info family was absent, so the verb token was never reordered and reached Node's file-runner as a `--require` module / bad option.

## Fix

Replace the hand-curated list with `is_normalizable_leading_flag_verb`, which recognizes any PM verb nub can dispatch — the same authority the bareword dispatch arm consults (`SUBCOMMANDS` + the engine verb registry `pm_engine::lookup_verb`). Tying the reorder set to the dispatch set keeps them from drifting: every verb nub dispatches in first position is now also reorderable behind a leading workspace flag. Verbs that don't accept `-r`/`--filter` remain safe to reorder — clap/the engine rejects the unsupported flag downstream with a proper non-zero error, matching pnpm.

## Exit-code note

The conformance catalog flagged a secondary "exit 0 on crash" defect. Reproduced against the pre-fix code: `nub -r list` returned raw exit **1** and `nub --filter a list` returned exit **9** (Node's bad-option code) — both non-zero. The reported "exit 0" was a measurement artifact of a `| head` pipe (PIPESTATUS of the tail). The file-runner faithfully propagates Node's exit code via `exit_code_from_status`; no exit-code change was needed.

## Test

Adds `leading_global_flags_before_info_verb_reach_engine` to `cli_grammar_parity.rs`. The existing grammar table can't guard this case (appending `--help` short-circuits before dispatch), so the new test dispatches for real and asserts the file-runner crash markers (`Cannot find module`, `node: bad option`) are absent.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test -p nub-cli --test cli_grammar_parity` — 8 passed (1 pre-existing ignore)
- `cargo test -p nub-cli --test pm_verbs` and the cli unit tests — green
- e2e against a tmp workspace fixture: `nub -r list` / `nub --filter a why a` now reach the engine; file-run, `--import` passthrough, and `nub -r <file>` (no-verb) paths unchanged.

Refs the pnpm conformance work (D1).

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa