### PR TITLE
pm: align list/outdated --json empty state and `run` no-arg exit with pnpm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "nub-cli"
-version = "0.1.7"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "aube",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "nub-core"
-version = "0.1.7"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "nub-native"
-version = "0.1.7"
+version = "0.1.9"
 dependencies = [
  "blake3",
  "json5",

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -2164,10 +2164,22 @@ fn run_script(
     // No script name (`nub run`): list available scripts instead of a raw clap
     // "required argument" error — same shape as the missing-named-script path.
     let Some(script) = script else {
-        bail!(
-            "no script specified\n\nAvailable scripts:\n{}",
-            list_scripts(&project.manifest)
-        );
+        // `nub run` with no script name mirrors `pnpm run` with no args: it is
+        // not an error (exit 0), it lists the package's runnable scripts. This
+        // is distinct from nub's "no implicit script shortcuts" stance (which
+        // bans bareword `nub test`/`nub start`); the explicit no-arg `run` verb
+        // legitimately mirrors pnpm here so CI that probes `pnpm run` and
+        // branches on the exit code sees the same success.
+        match project.manifest.get("scripts") {
+            Some(serde_json::Value::Object(map)) if !map.is_empty() => {
+                println!("Available scripts:");
+                println!("{}", list_scripts(&project.manifest));
+            }
+            _ => {
+                println!("There are no scripts specified.");
+            }
+        }
+        return Ok(0);
     };
 
     // Workspace-wide execution: -r, --filter, or --parallel.

--- a/crates/nub-cli/src/pm_engine/info_family.rs
+++ b/crates/nub-cli/src/pm_engine/info_family.rs
@@ -302,8 +302,16 @@ fn run_list(typed: &str, args: &[String], force_long: bool) -> Result<i32> {
         cli.args.long = true;
     }
     let session = super::engine_session_quiet(cli.dir.as_deref())?;
+    // `--json` (or `--format json`) must emit a parseable empty array on
+    // stdout in the never-installed state, not empty-stdout + a prose note.
+    let want_json = cli.args.json || cli.args.format == aube::commands::list::ListFormat::Json;
+    let empty = if want_json {
+        EmptyState::ListJson
+    } else {
+        EmptyState::Prose(MSG_POPULATE)
+    };
     if !cli.args.global
-        && let Some(code) = no_lockfile_short_circuit(EngineRoot::WorkspaceOrProject, MSG_POPULATE)?
+        && let Some(code) = no_lockfile_short_circuit(EngineRoot::WorkspaceOrProject, empty)?
     {
         return Ok(code);
     }
@@ -321,7 +329,9 @@ fn run_why(typed: &str, args: &[String]) -> Result<i32> {
         Parsed::Done(code) => return Ok(code),
     };
     let session = super::engine_session_quiet(cli.dir.as_deref())?;
-    if let Some(code) = no_lockfile_short_circuit(EngineRoot::WorkspaceOrProject, MSG_FIRST)? {
+    if let Some(code) =
+        no_lockfile_short_circuit(EngineRoot::WorkspaceOrProject, EmptyState::Prose(MSG_FIRST))?
+    {
         return Ok(code);
     }
     let filter = effective_filter(&cli.filter);
@@ -347,7 +357,14 @@ fn run_outdated(typed: &str, args: &[String]) -> Result<i32> {
     } else {
         EngineRoot::Project
     };
-    if let Some(code) = no_lockfile_short_circuit(root, MSG_FIRST)? {
+    // `--json` must emit a parseable empty object on stdout in the
+    // never-installed state, not empty-stdout + a prose note.
+    let empty = if cli.args.json {
+        EmptyState::OutdatedJson
+    } else {
+        EmptyState::Prose(MSG_FIRST)
+    };
+    if let Some(code) = no_lockfile_short_circuit(root, empty)? {
         return Ok(code);
     }
     finish_code(
@@ -363,7 +380,9 @@ fn run_query(typed: &str, args: &[String]) -> Result<i32> {
         Parsed::Done(code) => return Ok(code),
     };
     let session = super::engine_session_quiet(cli.dir.as_deref())?;
-    if let Some(code) = no_lockfile_short_circuit(EngineRoot::WorkspaceOrProject, MSG_FIRST)? {
+    if let Some(code) =
+        no_lockfile_short_circuit(EngineRoot::WorkspaceOrProject, EmptyState::Prose(MSG_FIRST))?
+    {
         return Ok(code);
     }
     let filter = effective_filter(&cli.filter);
@@ -412,7 +431,9 @@ fn run_licenses(typed: &str, args: &[String]) -> Result<i32> {
         Parsed::Done(code) => return Ok(code),
     };
     let session = super::engine_session_quiet(cli.dir.as_deref())?;
-    if let Some(code) = no_lockfile_short_circuit(EngineRoot::Project, MSG_FIRST)? {
+    if let Some(code) =
+        no_lockfile_short_circuit(EngineRoot::Project, EmptyState::Prose(MSG_FIRST))?
+    {
         return Ok(code);
     }
     finish(
@@ -428,7 +449,9 @@ fn run_deprecations(typed: &str, args: &[String]) -> Result<i32> {
         Parsed::Done(code) => return Ok(code),
     };
     let session = super::engine_session_quiet(cli.dir.as_deref())?;
-    if let Some(code) = no_lockfile_short_circuit(EngineRoot::Project, MSG_FIRST)? {
+    if let Some(code) =
+        no_lockfile_short_circuit(EngineRoot::Project, EmptyState::Prose(MSG_FIRST))?
+    {
         return Ok(code);
     }
     // `deprecations` is the one info verb whose engine `run` returns its
@@ -543,13 +566,31 @@ enum EngineRoot {
     WorkspaceOrProject,
 }
 
-/// When the engine's read directory holds no lockfile, print the engine's
-/// own message (rebranded) and exit 0 — exactly what the engine would do,
-/// minus the brand leak. `None` means "let the engine run": either a
-/// lockfile exists, no root resolves (the engine's own error is
-/// brand-clean), or only a binary `bun.lockb` exists (the engine's
-/// actionable error is brand-clean too).
-fn no_lockfile_short_circuit(root: EngineRoot, msg: &str) -> Result<Option<i32>> {
+/// What the no-lockfile short-circuit emits in place of running the engine.
+/// The default `Prose` path prints the engine's rebranded "No lockfile found…"
+/// note to stderr (exit 0). The JSON variants exist because a `--json` query
+/// must ALWAYS emit parseable JSON on stdout — never empty-stdout + a prose
+/// stderr note — so `nub list --json | jq` / `nub outdated --json | jq`
+/// behave like pnpm's, which emit the empty shape (an array of importer
+/// headers for `list`, `{}` for `outdated`) in the never-installed state.
+enum EmptyState<'a> {
+    /// Rebranded engine note to stderr; exit 0 (`why`, `query`, `licenses`,
+    /// `deprecations`, and the non-JSON `list`/`outdated` paths).
+    Prose(&'a str),
+    /// Empty `list --json` shape: a JSON array with one importer header
+    /// (`{name, version, path}`) on stdout; exit 0.
+    ListJson,
+    /// Empty `outdated --json` shape: `{}` on stdout; exit 0.
+    OutdatedJson,
+}
+
+/// When the engine's read directory holds no lockfile, emit the no-install
+/// empty state (see [`EmptyState`]) and exit 0 — exactly what the engine
+/// would do, minus the brand leak and the missing-JSON divergence. `None`
+/// means "let the engine run": either a lockfile exists, no root resolves
+/// (the engine's own error is brand-clean), or only a binary `bun.lockb`
+/// exists (the engine's actionable error is brand-clean too).
+fn no_lockfile_short_circuit(root: EngineRoot, empty: EmptyState<'_>) -> Result<Option<i32>> {
     let cwd = std::env::current_dir()?;
     let dir = match root {
         EngineRoot::Project => find_project_root(&cwd),
@@ -563,10 +604,45 @@ fn no_lockfile_short_circuit(root: EngineRoot, msg: &str) -> Result<Option<i32>>
     if aube_lockfile::detect_existing_lockfile_kind(&dir).is_none()
         && !dir.join("bun.lockb").exists()
     {
-        present::info(msg);
+        match empty {
+            EmptyState::Prose(msg) => present::info(msg),
+            EmptyState::OutdatedJson => println!("{{}}"),
+            EmptyState::ListJson => println!("{}", empty_list_json(&dir)),
+        }
         return Ok(Some(0));
     }
     Ok(None)
+}
+
+/// Build the empty `list --json` shape: a one-element array whose object
+/// carries the project's `name`/`version`/`path`, matching the importer
+/// header nub's populated `list --json` emits (and pnpm's empty-state array).
+/// Reads the project's `package.json` at `dir`; falls back to `(unnamed)` and
+/// omits `version` when the manifest is missing/unreadable, mirroring the
+/// engine's own `unwrap_or_else` for the name field.
+fn empty_list_json(dir: &Path) -> String {
+    let manifest = aube_manifest::PackageJson::from_path(&dir.join("package.json")).ok();
+    let mut importer = serde_json::Map::new();
+    importer.insert(
+        "name".to_string(),
+        serde_json::Value::String(
+            manifest
+                .as_ref()
+                .and_then(|m| m.name.clone())
+                .unwrap_or_else(|| "(unnamed)".to_string()),
+        ),
+    );
+    if let Some(v) = manifest.as_ref().and_then(|m| m.version.clone()) {
+        importer.insert("version".to_string(), serde_json::Value::String(v));
+    }
+    importer.insert(
+        "path".to_string(),
+        serde_json::Value::String(dir.display().to_string()),
+    );
+    serde_json::to_string_pretty(&serde_json::Value::Array(vec![serde_json::Value::Object(
+        importer,
+    )]))
+    .unwrap_or_else(|_| "[]".to_string())
 }
 
 /// Replica of the engine's `dirs::find_project_root`: nearest ancestor with

--- a/crates/nub-cli/tests/info_engine.rs
+++ b/crates/nub-cli/tests/info_engine.rs
@@ -180,6 +180,50 @@ fn missing_lockfile_reports_the_nub_install_hint_and_exits_zero() {
     assert_no_engine_branding(&[("stdout", &stdout), ("stderr", &stderr)]);
 }
 
+/// `--json` must ALWAYS emit parseable JSON on stdout — never empty-stdout +
+/// a prose stderr note — in the never-installed (no-lockfile) state, so
+/// `nub list --json | jq` / `nub outdated --json | jq` behave like pnpm's,
+/// which emit the empty shape (an importer-header array for `list`, `{}` for
+/// `outdated`). Regression for D2.
+#[test]
+fn json_queries_emit_parseable_empty_shape_without_a_lockfile() {
+    let dir = pm_tmpdir("nolock-json");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"nolock-json","version":"2.3.4","dependencies":{"is-positive":"3.1.0"}}"#,
+    )
+    .unwrap();
+
+    // list --json: a one-element array with the project's name/version/path.
+    let (stdout, stderr, code) = run_nub(&dir, &["list", "--json"]);
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("list --json must be parseable JSON");
+    assert_eq!(v[0]["name"], "nolock-json", "importer name: {stdout}");
+    assert_eq!(v[0]["version"], "2.3.4", "importer version: {stdout}");
+    assert!(v[0]["path"].is_string(), "importer path: {stdout}");
+
+    // `--format json` (the long spelling) goes through the same path.
+    let (stdout, _, code) = run_nub(&dir, &["list", "--format", "json"]);
+    assert_eq!(code, 0);
+    assert!(
+        serde_json::from_str::<serde_json::Value>(stdout.trim()).is_ok(),
+        "list --format json must be parseable JSON: {stdout}"
+    );
+
+    // outdated --json: the empty object.
+    let (stdout, stderr, code) = run_nub(&dir, &["outdated", "--json"]);
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(stdout.trim())
+            .expect("outdated --json must be parseable JSON"),
+        serde_json::json!({}),
+        "outdated --json empty shape must be {{}}: {stdout}"
+    );
+
+    assert_no_engine_branding(&[("stdout", &stdout), ("stderr", &stderr)]);
+}
+
 /// The path verbs print the resolved project locations without any install,
 /// `check` on a never-installed project reports zero packages and exits 0,
 /// and `licenses` accepts pnpm's documented `list` spelling beside the

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -2941,27 +2941,53 @@ fn lifecycle_hooks() {
 
 #[test]
 fn run_without_script_lists_available_scripts() {
-    // `nub run` with no script name lists available scripts (A46) instead of a
-    // raw clap "required argument" error — same shape as the missing-named path.
+    // `nub run` with no script name mirrors `pnpm run` with no args: exit 0,
+    // listing the package's scripts on stdout (D3). This is distinct from
+    // nub's "no implicit script shortcuts" stance, which only bans bareword
+    // `nub test`/`nub start`; the explicit no-arg `run` verb legitimately
+    // mirrors pnpm so CI that branches on `pnpm run`'s exit code matches.
     let fixture = fixtures_dir().join("lifecycle");
     let output = Command::new(nub_binary())
         .arg("run")
         .current_dir(&fixture)
         .output()
         .expect("failed to spawn nub");
-    assert_ne!(
+    assert_eq!(
         output.status.code(),
         Some(0),
-        "`nub run` with no script must not exit 0"
+        "`nub run` with no script must exit 0 like `pnpm run`"
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stderr.contains("Available scripts"),
-        "should list scripts: {stderr}"
+        stdout.contains("Available scripts"),
+        "should list scripts on stdout: {stdout}"
     );
     assert!(
-        stderr.contains("greet"),
-        "should include the greet script: {stderr}"
+        stdout.contains("greet"),
+        "should include the greet script: {stdout}"
+    );
+}
+
+#[test]
+fn run_without_script_in_scriptless_package_exits_zero() {
+    // No scripts at all: `nub run` prints pnpm's exact "There are no scripts
+    // specified." message and exits 0 (D3 / pnpm parity).
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("package.json"),
+        r#"{"name":"scriptless","version":"1.0.0"}"#,
+    )
+    .expect("write package.json");
+    let output = Command::new(nub_binary())
+        .arg("run")
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to spawn nub");
+    assert_eq!(output.status.code(), Some(0), "must exit 0 with no scripts");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("There are no scripts specified."),
+        "should print pnpm's no-scripts message: {stdout}"
     );
 }
 


### PR DESCRIPTION
Fixes two pnpm-compat error-contract divergences from the conformance audit (D2, D3). The third (D5, fetch/prune no-lockfile exit codes) is routed back as an open question rather than landed — see below.

## D2 — `--json` emits no JSON in the empty state

With a valid package.json but no install/lockfile:

- `nub list --json` emitted empty stdout plus a prose stderr note, so `nub list --json | jq` got no input.
- `nub outdated --json` emitted empty stdout.

Real pnpm emits a valid JSON array (`[{name, version, path, ...}]`) for `list` and `{}` for `outdated`, both exit 0.

Fix: under `--json` (or `--format json`), the no-lockfile short-circuit now emits the correct empty shape on stdout — a one-element importer-header array for `list` (name/version/path, matching nub's populated `list --json` header), `{}` for `outdated`. The non-JSON paths keep the rebranded "No lockfile found" note on stderr, so the brand boundary is unchanged.

## D3 — `nub run` (no script) exited 1; pnpm exits 0

`nub run` with no script name now exits 0 and lists the package's scripts on stdout (or prints `There are no scripts specified.` when none), matching `pnpm run` with no args. Previously it exited 1 with the listing on stderr, so CI that probes `pnpm run` and branches on the exit code saw a spurious failure.

This is the explicit no-arg `run` verb mirroring pnpm. It does not relax nub's no-implicit-script-shortcuts stance — bareword `nub test`/`nub start` are still rejected; only the no-arg `run` path changed.

## D5 — routed to a maintainer decision, not landed

`fetch`/`prune` with no lockfile exit non-zero (fetch exit 1, prune exit 10 `ERR_NUB_NO_LOCKFILE`); pnpm exits 0 `Already up to date`. Grounding showed the strict guard is a deliberate, explicit design in the embedded engine (an intentional `requires a lockfile` error message, not a NotFound bubbling through), and pnpm's `prune` actually resolves+installs rather than no-op'ing. Flipping an engine-deliberate error into silent success is an error-contract judgment call, so it is surfaced for maintainer sign-off rather than landed here.

## Tests

- Updated the run-no-script integration test to the new exit-0/stdout contract.
- Added `run_without_script_in_scriptless_package_exits_zero` (D3, no-scripts case).
- Added `json_queries_emit_parseable_empty_shape_without_a_lockfile` (D2, list/outdated/`--format json`).

Verified locally: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, scoped `cargo test -p nub-cli` (info_engine + integration), and e2e against the dev binary diffed vs pnpm 10.15.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa