### PR TITLE
pm: honor yarn supportedArchitectures, mTLS cert/key, npmAlwaysAuth

### DIFF
--- a/crates/nub-cli/src/pm_engine/unsupported_config.rs
+++ b/crates/nub-cli/src/pm_engine/unsupported_config.rs
@@ -243,10 +243,11 @@ pub(crate) enum ScanResult {
 ///
 /// The FATAL set is deliberately SHORT — only fields whose silent omission
 /// produces a correctness-divergent install AND which nub cannot honor:
-/// npm `legacy-peer-deps` (different peer graph), npm `install-strategy=nested`
-/// (different resolution/layout), and yarn `supportedArchitectures` (changes
-/// which platform deps land — the arch-filter resolver isn't built). PnP stays
-/// a WARN+downgrade (handled separately in `warn_if_pnp_requested`), not
+/// npm `legacy-peer-deps` (different peer graph) and npm
+/// `install-strategy=nested` (different resolution/layout). yarn
+/// `supportedArchitectures` is NOT here — the engine honors it via the
+/// arch-filter resolver. PnP stays a WARN+downgrade (handled separately in
+/// `warn_if_pnp_requested`), not
 /// promoted. `checksumBehavior`/`enableHardenedMode` are NOT here: aube verifies
 /// every tarball's SHA-512 by default (`verifyStoreIntegrity=true`), satisfying
 /// the `throw` posture.
@@ -298,20 +299,11 @@ fn scan_fatal(role: Role, root: &Path) -> Option<FatalField> {
             }
             None
         }
-        Role::Yarn => {
-            if yarn_supported_architectures(root) {
-                return Some(FatalField {
-                    code: "ERR_NUB_UNSUPPORTED_CONFIG",
-                    field: "`supportedArchitectures`",
-                    detail: "nub installs only the current platform's optional/platform deps; \
-                             this setting changes which packages land on disk",
-                    remedy: "remove `supportedArchitectures` from .yarnrc.yml, or run the install \
-                             on each target platform",
-                });
-            }
-            None
-        }
-        Role::Pnpm | Role::Bun | Role::Nub => None,
+        // yarn `supportedArchitectures` is HONORED, not fatal: the engine
+        // reads `.yarnrc.yml`'s `supportedArchitectures` and feeds it to
+        // the same arch-filter resolver the pnpm path uses (translated to
+        // the `supportedArchitectures` object setting in the yarnrc reader).
+        Role::Yarn | Role::Pnpm | Role::Bun | Role::Nub => None,
     }
 }
 
@@ -376,12 +368,6 @@ fn manifest_has_pnpm_overrides(root: &Path) -> bool {
         .and_then(|p| p.get("overrides"))
         .and_then(|v| v.as_object())
         .is_some_and(|o| !o.is_empty())
-}
-
-fn yarn_supported_architectures(root: &Path) -> bool {
-    std::fs::read_to_string(root.join(".yarnrc.yml"))
-        .ok()
-        .is_some_and(|c| yarnrc_has_top_level_key(&c, "supportedArchitectures"))
 }
 
 fn yarnrc_top_level_bool_str(root: &Path, key: &str) -> Option<bool> {
@@ -575,13 +561,6 @@ fn yarnrc_top_level_bool(content: &str, key: &str) -> Option<bool> {
         }
     }
     None
-}
-
-/// Whether a top-level `key:` exists at all in `.yarnrc.yml` (scalar or block).
-fn yarnrc_has_top_level_key(content: &str, key: &str) -> bool {
-    content.lines().any(|line| {
-        !line.starts_with(char::is_whitespace) && line.trim().starts_with(&format!("{key}:"))
-    })
 }
 
 /// Whether a top-level `key:` introduces a non-empty indented block (a YAML
@@ -845,17 +824,22 @@ mod tests {
     }
 
     #[test]
-    fn scan_fatal_on_supported_architectures() {
+    fn supported_architectures_is_honored_not_fatal() {
+        // The arch-filter resolver honors yarn `supportedArchitectures`
+        // (the yarnrc reader translates it to the `supportedArchitectures`
+        // object setting), so it must no longer abort the install.
         let d = tmp();
         fs::write(
             d.path().join(".yarnrc.yml"),
             "supportedArchitectures:\n  os:\n    - linux\n",
         )
         .unwrap();
-        assert!(matches!(
-            scan_unsupported_config(Role::Yarn, None, None, d.path()),
-            ScanResult::Fatal(_)
-        ));
+        match scan_unsupported_config(Role::Yarn, None, None, d.path()) {
+            ScanResult::Warn(_) => {}
+            ScanResult::Fatal(e) => {
+                panic!("supportedArchitectures is honored and must not be fatal: {e}")
+            }
+        }
     }
 
     #[test]

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -199,7 +199,7 @@ What Nub reads and writes keys off the project's incumbent package manager — i
           code: '.yarnrc.yml',
           ok: true,
           partial: true,
-          note: 'Not read: supportedArchitectures, npmAlwaysAuth, file-path TLS cert/key, per-host proxies, PnP.',
+          note: 'Not read: per-host proxies, PnP.',
         },
         {
           code: '.yarnrc',

--- a/site/content/docs/install/yarn.mdx
+++ b/site/content/docs/install/yarn.mdx
@@ -42,7 +42,7 @@ Both formats are read:
     { feature: <>workspace selectors</>, status: 'partial', note: 'No git-since ([ref]) selector.' },
     // ── Config files ──────────────────────────────────────────────────
     { feature: <code>.npmrc</code>, status: 'yes' },
-    { feature: <code>.yarnrc.yml</code>, status: 'partial', note: 'Not read: supportedArchitectures, npmAlwaysAuth, file-path TLS cert/key, per-host proxies, PnP.' },
+    { feature: <code>.yarnrc.yml</code>, status: 'partial', note: 'Not read: per-host proxies, PnP.' },
     { feature: <code>.yarnrc</code>, status: 'partial', note: 'Registry and auth keys only.' },
     // ── Environment variables ─────────────────────────────────────────
     { feature: <><code>npm_config_*</code></>, status: 'yes' },
@@ -51,7 +51,9 @@ Both formats are read:
     { feature: <><code>yarn.lock</code></>, status: 'partial', note: 'Read-only; writes refused.' },
     // ── Linking / install behavior ────────────────────────────────────
     { feature: <code>nodeLinker</code>, status: 'partial', note: 'No PnP.' },
-    { feature: <code>supportedArchitectures</code>, status: 'no', note: 'Not read.' },
+    { feature: <code>supportedArchitectures</code>, status: 'yes', note: 'Filters optional/platform deps for the declared os/cpu/libc.' },
+    { feature: <>mTLS client cert/key</>, status: 'yes', note: 'File-path (httpsCertFilePath / httpsKeyFilePath) and per-host networkSettings forms.' },
+    { feature: <code>npmAlwaysAuth</code>, status: 'yes', note: 'Attaches credentials to cross-origin tarball requests too.' },
   ]}
 />
 
@@ -120,7 +122,7 @@ npmRegistries:
 nodeLinker: node-modules
 ```
 
-Nub reads the global `~/.yarnrc.yml` plus any project `.yarnrc.yml` files from the workspace root down to the current project directory; nearer project files win. The support is intentionally narrow. Still ignored: `supportedArchitectures`, `npmAlwaysAuth`, file-path TLS client cert and key (`httpsKeyFilePath` / `httpsCertFilePath` — Nub takes inline PEM only), per-host `networkSettings` proxies (the proxy Nub applies is process-wide), constraints, plugins, patch-folder config, and Yarn cache layout.
+Nub reads the global `~/.yarnrc.yml` plus any project `.yarnrc.yml` files from the workspace root down to the current project directory; nearer project files win. The support is intentionally narrow. Still ignored: per-host `networkSettings` proxies (the proxy Nub applies is process-wide), constraints, plugins, patch-folder config, and Yarn cache layout.
 
 Classic `.yarnrc` (Yarn 1) gets the same basic treatment for its core registry and auth fields. Its keys are already npmrc-shaped, so Nub reads them directly:
 
@@ -159,8 +161,5 @@ nub 0.1.1 · ✓ Already up to date
 
 Several Yarn `package.json` and `.yarnrc.yml` fields still have no effect under Nub:
 
-- `supportedArchitectures` — Yarn's platform/arch download controls are not read.
-- `npmAlwaysAuth` — no Nub equivalent.
-- `httpsKeyFilePath` / `httpsCertFilePath` — file-path TLS client cert and key; Nub takes inline PEM only.
 - Per-host `networkSettings` proxies — the proxy Nub applies is process-wide, not per registry host.
 - `nodeLinker: pnp` — PnP install generation is out of scope; Nub warns and links `node_modules` instead. Install with Yarn, run with Nub.


### PR DESCRIPTION
Reads three previously-ignored `.yarnrc.yml` settings and routes them through the existing engine machinery, **plus** a bundled one-line trust-list fix to unblock CI on a single pin advance. Bumps the `vendor/aube` pin to `e7aaafc` (on `nub-fork`).

## Yarn config (B-3 / B-9 / B-12)

- **supportedArchitectures** — translated to the JSON-object `supportedArchitectures` setting (the same channel `packageExtensions` uses) and unioned into the resolver's platform filter at install time, so optional/platform deps are filtered for the declared `os`/`cpu`/`libc`. The nub-side FATAL gate that aborted on this key is removed — the arch-filter resolver is built and now fed for yarn, same as the pnpm path.
- **httpsCertFilePath / httpsKeyFilePath** (top-level and per-host `networkSettings`) — the referenced PEM files are loaded and emitted as the inline `cert`/`key` the registry client's mTLS identity consumer already takes.
- **npmAlwaysAuth** (top-level, per-registry, per-scope) — translated to `always-auth`; the registry client now attaches the home registry's token to requests on a different origin (e.g. tarballs on a separate CDN) when set, instead of sending them unauthenticated.

All three are additive reads gated on the user's explicit yarn config; the default (no setting) path is unchanged.

## Bundled CI unblock: nanoid trust-downgrade

`nanoid@3.3.14` was published to npm without trust evidence after an earlier version carried a trusted publisher, so `trustPolicy=no-downgrade` (the aube default) rejects it with `ERR_NUB_TRUST_DOWNGRADE` (exit 23) at `nub install` — which breaks the daily-driver on `main` and every open PR. `nanoid` is added to `DEFAULT_TRUST_POLICY_EXCLUDES` alongside the other provenance-churn packages. Bundled here so a single pin advance fixes both concerns at once; the other PRs rebase onto this after merge.

## Verification

- aube: 7 new yarn-config unit tests + the trust-list test (39 trust tests) pass; `cargo build` clean.
- nub: `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo test -p nub-cli unsupported_config` green.
- e2e: a `.yarnrc.yml` with a `supportedArchitectures` block no longer aborts `nub install`. The daily-driver `install` step now passes against the new pin (it exits 23 on `main` due to nanoid); main + `npm_config_trust_policy=off` runs the full daily-driver green, confirming nanoid is the sole install-stage blocker.

Docs: the yarn compat tables (`yarn.mdx`, `install/index.mdx`) now mark the three yarn settings as supported.