### PR TITLE
site: docs page chrome tweaks (edit link, pager size, star footer, runtime table mono)

### DIFF
--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -96,11 +96,11 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`reportError`](https://developer.mozilla.org/en-US/docs/Web/API/Window/reportError) | — | polyfill |
 | [`vm.Module`](https://nodejs.org/api/vm.html#class-vmmodule) | — | flag-injected |
 | [`ShadowRealm`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ShadowRealm) | — | flag-injected |
-| [Wasm module imports](https://nodejs.org/api/esm.html#wasm-modules) | — | flag-injected below Node 24.5 (22.19 on the 22.x line), native above |
+| [`Wasm module imports`](https://nodejs.org/api/esm.html#wasm-modules) | — | flag-injected below Node 24.5 (22.19 on the 22.x line), native above |
 | [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) | Node 20.10 | flag-injected below Node 22, native above |
 | [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) | Node 20.18 | flag-injected below the native line, native above |
 | [`node:sqlite`](https://nodejs.org/api/sqlite.html) | Node 22.5 | flag-injected below Node 22.13, native above |
-| [addon imports](https://nodejs.org/api/esm.html#node-addons) | Node 22.20 | flag-injected, never native |
+| [`addon imports`](https://nodejs.org/api/esm.html#node-addons) | Node 22.20 | flag-injected, never native |
 
 A dash means the API works across the full supported range, 18.19 and up. The floored rows have a real cutoff, because the underlying Node mechanism doesn't exist below it:
 

--- a/site/src/app/docs/[[...slug]]/page.tsx
+++ b/site/src/app/docs/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import {
   DocsBody,
   DocsDescription,
   DocsTitle,
+  EditOnGitHub,
 } from 'fumadocs-ui/page';
 import { notFound } from 'next/navigation';
 import { AIActions } from '@/components/ai-actions';
@@ -42,6 +43,23 @@ function TocGitHubLink() {
   );
 }
 
+/* Small footer rendered below the prev/next pager: GitHub star link. */
+function PageStarFooter() {
+  return (
+    <div className="mt-6 flex items-center justify-center">
+      <a
+        href="https://github.com/nubjs/nub"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1.5 text-xs text-fd-muted-foreground transition-colors hover:text-fd-foreground"
+      >
+        <GitHubIcon className="h-3 w-3 shrink-0" />
+        <span>Star Nub on GitHub</span>
+      </a>
+    </div>
+  );
+}
+
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
 }) {
@@ -51,8 +69,19 @@ export default async function Page(props: {
 
   const MDXContent = page.data.body;
 
+  /* Construct the GitHub edit URL from the virtual file path fumadocs exposes on
+     the page object. The path is relative to the docs content root (e.g.
+     "runtime/index.mdx"), so we prepend the repo-relative prefix to build the
+     full edit URL. */
+  const editHref = `https://github.com/nubjs/nub/edit/main/site/content/docs/${(page as { path?: string }).path ?? ''}`;
+
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full} tableOfContent={{ footer: <TocGitHubLink /> }}>
+    <DocsPage
+      toc={page.data.toc}
+      full={page.data.full}
+      tableOfContent={{ footer: <TocGitHubLink /> }}
+      footer={{ children: <PageStarFooter /> }}
+    >
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <AIActions
@@ -65,6 +94,7 @@ export default async function Page(props: {
       <DocsBody role="main">
         <MDXContent components={getMDXComponents()} />
       </DocsBody>
+      <EditOnGitHub href={editHref} />
     </DocsPage>
   );
 }

--- a/site/src/app/global.css
+++ b/site/src/app/global.css
@@ -361,6 +361,14 @@ pre .line[data-output] span {
   }
 }
 
+/* Prev/next pager — the fumadocs FooterItem link is text-sm (14px) and the page-name
+   title <p> inherits it, which reads too small. Target the title paragraph inside
+   .font-medium (the wrapper div that holds the chevron icon + page name) to bring it
+   up to 0.9375rem (15px) — one step below body prose, comfortable and consistent. */
+#nd-page .\@container > a .font-medium p {
+  font-size: 0.9375rem;
+}
+
 /* Clickable elements always get the pointer cursor. */
 button:not(:disabled),
 [role='button'],


### PR DESCRIPTION
Four small docs-page tweaks:

1. **Edit this page** — each docs page now has an "Edit on GitHub" link (bottom of content area, above the pager) pointing to the source MDX file at `/edit/main/site/content/docs/<path>`. Uses the fumadocs `EditOnGitHub` component with a manually constructed `/edit/` URL (the built-in `editOnGithub` prop uses `/blob/`). File path comes from `page.path` on the fumadocs loader's page object.

2. **Prev/next pager titles** — the fumadocs `FooterItem` link uses `text-sm` (14px) on the entire element; the page-name title `<p>` inherits it and reads too small. A CSS rule in `global.css` bumps the title `<p>` inside `.font-medium` to 0.9375rem (15px).

3. **Star Nub on GitHub footer** — a small centered line below the pager (GitHub mark icon + "Star Nub on GitHub" link) rendered via `footer.children` in `DocsPage`. Subtle/muted, matches site register.

4. **Runtime table mono** — on `/docs/runtime`, "Wasm module imports" and "addon imports" in the Modern APIs table were plain link text (proportional font) while every other row uses backtick-wrapped code (monospace). Fixed both to use `` [`Wasm module imports`](...) `` and `` [`addon imports`](...) ``.

Claude-Session: https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa