### PR TITLE
ci: gate PRs to Linux + one Windows leg; full cross-OS matrix on main + nightly

### DIFF
--- a/.github/workflows/aube-parity.yml
+++ b/.github/workflows/aube-parity.yml
@@ -41,6 +41,13 @@ on:
       - ".github/workflows/aube-parity.yml"
       - "tests/aube-bats/**"
       - "tests/aube-conformance/**"
+  schedule:
+    # Nightly at 06:30 UTC. The Windows conformance leg is gated off
+    # pull_request (it is the only Windows-runner contributor in this workflow);
+    # the nightly schedule keeps that Windows coverage running on a cadence even
+    # between vendor/aube bumps. Scheduled runs ignore the path filters above and
+    # exercise the full workflow, Windows leg included.
+    - cron: "30 6 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -135,6 +142,10 @@ jobs:
 
   aube-conformance-windows:
     name: lockfile conformance, real PMs (windows)
+    # Gated off pull_request to keep Windows runners off the PR hot path; runs on
+    # push (main / aube-integration, on a vendor/aube bump) and the nightly
+    # schedule. The Linux conformance legs above still gate every PR.
+    if: github.event_name != 'pull_request'
     # Windows leg of the conformance matrix (the maintainer 2026-06-10). Budgeted
     # subset: the pnpm + npm judge legs over the simple, peer-heavy, and
     # workspace fixtures — the signal is lockfile semantics crossed with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Nightly full cross-OS matrix at 06:00 UTC (offset from the lockfile-roundtrip
+    # nightly at 07:00 and pnpm-conformance at 08:00). PR pushes run a Linux-gated
+    # matrix (plus one Windows representative) to avoid saturating the macOS-5
+    # concurrent-runner cap during busy PR waves; the full os × node cross-product
+    # runs here and on push:main, so cross-platform regressions are still caught —
+    # just on trunk/nightly rather than per-PR. See the `test`/`pnp` jobs for the
+    # exact PR-vs-trunk split (driven by the `matrix-plan` job below).
+    - cron: "0 6 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +23,47 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Emit the os × node matrices for the `test` and `pnp` jobs, varying by event:
+  #   pull_request → Linux legs (full Node-version tier matrix) + ONE windows-latest
+  #                  representative (the only place cfg(windows) PM-shim / PnP-path
+  #                  code compiles + runs). macOS is dropped from PRs entirely — it
+  #                  is the macOS-5-concurrent bottleneck.
+  #   push:main / schedule (nightly) / any other event → the FULL matrix: ubuntu +
+  #                  windows-latest + macos-14 on the current Node line, plus the
+  #                  Linux-only tier representatives. This is where cross-OS (incl.
+  #                  macOS) coverage is proven.
+  # One job emitting JSON consumed via fromJSON keeps the split in a single place
+  # instead of duplicating workflow files or hand-maintaining parallel matrices.
+  matrix-plan:
+    name: Plan matrices
+    runs-on: ubuntu-latest
+    outputs:
+      test: ${{ steps.plan.outputs.test }}
+      pnp: ${{ steps.plan.outputs.pnp }}
+    steps:
+      - id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The Linux Node-version tier legs are common to PR and trunk (compat
+          # divergences are runtime-version-specific, not OS-specific). The
+          # current-line cross-OS legs differ: PR keeps ubuntu + ONE windows;
+          # trunk/nightly adds macos-14.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            test_os='[{"os":"ubuntu-latest","node":"24"},{"os":"windows-latest","node":"24"}]'
+            pnp_os='[{"os":"ubuntu-latest","node":"24"},{"os":"windows-latest","node":"24"}]'
+          else
+            test_os='[{"os":"ubuntu-latest","node":"24"},{"os":"windows-latest","node":"24"},{"os":"macos-14","node":"24"}]'
+            pnp_os='[{"os":"ubuntu-latest","node":"24"},{"os":"windows-latest","node":"24"},{"os":"macos-14","node":"24"}]'
+          fi
+          # Linux-only Node-version tier representatives (same on PR and trunk).
+          test_tiers='[{"os":"ubuntu-latest","node":"22.15"},{"os":"ubuntu-latest","node":"22.13"},{"os":"ubuntu-latest","node":"20.11"},{"os":"ubuntu-latest","node":"18.19"}]'
+          pnp_tiers='[{"os":"ubuntu-latest","node":"22.15"},{"os":"ubuntu-latest","node":"18.19"}]'
+          test=$(jq -cn --argjson a "$test_os" --argjson b "$test_tiers" '{include: ($a + $b)}')
+          pnp=$(jq -cn --argjson a "$pnp_os" --argjson b "$pnp_tiers" '{include: ($a + $b)}')
+          echo "test=$test" >> "$GITHUB_OUTPUT"
+          echo "pnp=$pnp" >> "$GITHUB_OUTPUT"
+
   check:
     name: Check
     runs-on: ubuntu-latest
@@ -52,59 +102,57 @@ jobs:
 
   test:
     name: Test (${{ matrix.os }}, node ${{ matrix.node }})
+    needs: matrix-plan
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        # macos-14 is Apple Silicon (arm64) — the primary dev platform and the
-        # darwin-arm64 release target (A24). darwin-x64 is built in release.yml
-        # but not yet exercised here; add macos-13 (Intel) if x64 coverage is
-        # wanted later.
-        #
-        # The windows-latest leg is the ONLY place the PM-shim's cfg(windows)
-        # code executes (Docker on the dev box is Linux-only): `cargo test`
-        # picks up nub-cli's tests/pm_shim_windows.rs, which covers
-        # install_shims_into's `.exe` entry naming, argv0 dispatch through a
-        # pnpm.exe/npm.exe link, the `.exe`/`.cmd` PATH probing of the
-        # fall-through scan, the pinned-PM cached run under the project Node,
-        # the strict refusal, and exit-code fidelity through the spawn+wait
-        # exec replacement. (The portable pm::shim unit tests — decision
-        # matrix, profile-block edits, lockfile/redirect logic — already ran
-        # here; the #[cfg(unix)] ones — inode/hardlink, exec-bit, symlink
-        # tests and all of tests/pm_shim.rs — still don't.) Not covered
-        # anywhere yet: replacing a RUNNING shim .exe (image lock), and a
-        # `nub pm shim`/`unshim` round trip (dirs_next ignores env HOME on
-        # Windows, so an end-to-end run would write the runner's real
-        # profile — kept out deliberately).
-        #
-        # This leg also compiles + runs the cfg(windows) arm of the
-        # `nub upgrade` npm channel: the npm_upgrade_invocation_is_os_correct
-        # unit test pins the Windows argv (`cmd /C npm install -g …`), which is
-        # what fixes npm-channel upgrade on a plain Windows box (no `sh` there).
-        # A real end-to-end `npm install -g` is left CI-dark on purpose — it
-        # mutates global state and needs a published release.
-        os: [ubuntu-latest, windows-latest, macos-14]
-        # Node matrix spans the support range so the integration suite (which
-        # nub runs against whatever `node` is first on PATH) exercises every
-        # tier + capability boundary. 24 = current line; 22.15 = fast-path floor
-        # (sync registerHooks); 22.13 = compat-tier top (async module.register,
-        # has require(esm)+detect-module+webstorage); 20.11 = compat mid (NO
-        # require(esm) — exercises the dynamic-import oxc-parser path — and NO
-        # detect-module/webstorage, so it catches the version-gated flag
-        # injection); 18.19 = the hard floor (no require(esm), no native `using`,
-        # async tier). Compat divergences are runtime-version-specific, not
-        # OS-specific, so the floor/compat legs run on Linux only — a full
-        # os×node cross-product would multiply cost for no extra signal.
-        node: ['24']
-        include:
-          - os: ubuntu-latest
-            node: '22.15'
-          - os: ubuntu-latest
-            node: '22.13'
-          - os: ubuntu-latest
-            node: '20.11'
-          - os: ubuntu-latest
-            node: '18.19'
+      matrix: ${{ fromJSON(needs.matrix-plan.outputs.test) }}
+      # The matrix is computed by the matrix-plan job. On pull_request: ubuntu
+      # (full Node-version tier matrix) + ONE windows-latest representative;
+      # macOS is dropped from PRs (the macOS-5 concurrency bottleneck). On
+      # push:main / nightly schedule: the FULL matrix adds macos-14.
+      #
+      # macos-14 is Apple Silicon (arm64) — the primary dev platform and the
+      # darwin-arm64 release target (A24). It runs on trunk/nightly only.
+      # darwin-x64 is built in release.yml but not yet exercised here; add
+      # macos-13 (Intel) if x64 coverage is wanted later.
+      #
+      # The windows-latest leg is the ONLY place the PM-shim's cfg(windows)
+      # code executes (Docker on the dev box is Linux-only): `cargo test`
+      # picks up nub-cli's tests/pm_shim_windows.rs, which covers
+      # install_shims_into's `.exe` entry naming, argv0 dispatch through a
+      # pnpm.exe/npm.exe link, the `.exe`/`.cmd` PATH probing of the
+      # fall-through scan, the pinned-PM cached run under the project Node,
+      # the strict refusal, and exit-code fidelity through the spawn+wait
+      # exec replacement. (The portable pm::shim unit tests — decision
+      # matrix, profile-block edits, lockfile/redirect logic — already ran
+      # here; the #[cfg(unix)] ones — inode/hardlink, exec-bit, symlink
+      # tests and all of tests/pm_shim.rs — still don't.) Not covered
+      # anywhere yet: replacing a RUNNING shim .exe (image lock), and a
+      # `nub pm shim`/`unshim` round trip (dirs_next ignores env HOME on
+      # Windows, so an end-to-end run would write the runner's real
+      # profile — kept out deliberately). That genuinely-Windows-only code is
+      # why one Windows leg is KEPT on PR rather than moved to trunk-only.
+      #
+      # This leg also compiles + runs the cfg(windows) arm of the
+      # `nub upgrade` npm channel: the npm_upgrade_invocation_is_os_correct
+      # unit test pins the Windows argv (`cmd /C npm install -g …`), which is
+      # what fixes npm-channel upgrade on a plain Windows box (no `sh` there).
+      # A real end-to-end `npm install -g` is left CI-dark on purpose — it
+      # mutates global state and needs a published release.
+      #
+      # Node matrix spans the support range so the integration suite (which
+      # nub runs against whatever `node` is first on PATH) exercises every
+      # tier + capability boundary. 24 = current line; 22.15 = fast-path floor
+      # (sync registerHooks); 22.13 = compat-tier top (async module.register,
+      # has require(esm)+detect-module+webstorage); 20.11 = compat mid (NO
+      # require(esm) — exercises the dynamic-import oxc-parser path — and NO
+      # detect-module/webstorage, so it catches the version-gated flag
+      # injection); 18.19 = the hard floor (no require(esm), no native `using`,
+      # async tier). Compat divergences are runtime-version-specific, not
+      # OS-specific, so the floor/compat legs run on Linux only (PR and trunk
+      # alike) — a full os×node cross-product would multiply cost for no extra
+      # signal.
     steps:
       # No node-suite submodule here: the fast unit + integration suite reads
       # only tests/fixtures, never tests/node-suite. The heavyweight Node-suite
@@ -206,23 +254,21 @@ jobs:
 
   pnp:
     name: Yarn PnP (${{ matrix.os }}, node ${{ matrix.node }})
+    needs: matrix-plan
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        # Cross-OS coverage on the current Node line — PnP's zipfs fs patch, path
-        # handling, and `findPnpApi` differ by OS (Windows backslashes especially),
-        # which the host (macOS) + Docker (Linux) legs can't fully cover. Plus two
-        # Linux tier representatives: 22.15 = fast-tier floor (sync registerHooks),
-        # 18.19 = compat-tier floor (async loader worker). Tiers are runtime-version
-        # specific, not OS-specific, so they run on Linux only.
-        os: [ubuntu-latest, windows-latest, macos-14]
-        node: ['24']
-        include:
-          - os: ubuntu-latest
-            node: '22.15'
-          - os: ubuntu-latest
-            node: '18.19'
+      matrix: ${{ fromJSON(needs.matrix-plan.outputs.pnp) }}
+      # Matrix computed by the matrix-plan job. Cross-OS coverage on the current
+      # Node line matters here because PnP's zipfs fs patch, path handling, and
+      # `findPnpApi` differ by OS (Windows backslashes especially), which the host
+      # (macOS) + Docker (Linux) legs can't fully cover. On pull_request: ubuntu +
+      # ONE windows-latest representative (the Windows-path divergence is the real
+      # cross-OS risk); macos-14 runs on push:main / nightly schedule only.
+      # Plus two Linux tier representatives on PR and trunk alike: 22.15 = fast-tier
+      # floor (sync registerHooks), 18.19 = compat-tier floor (async loader worker).
+      # Tiers are runtime-version specific, not OS-specific, so they run on Linux
+      # only.
     steps:
       - uses: actions/checkout@v5
       # vendor/aube path dep — see the `check` job for the rationale.

--- a/.github/workflows/launcher.yml
+++ b/.github/workflows/launcher.yml
@@ -22,6 +22,12 @@ on:
     paths:
       - npm/nub/**
       - tests/launcher/**
+  schedule:
+    # Nightly at 06:45 UTC. The macOS self-heal leg is gated off pull_request
+    # (the macOS-5 concurrency bottleneck); the nightly schedule keeps that
+    # coverage running on a cadence. Scheduled runs ignore the path filters and
+    # run the full OS matrix.
+    - cron: "45 6 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -36,8 +42,12 @@ jobs:
     name: heal · ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # On pull_request: ubuntu only (the dash leg) — macOS is dropped from PRs
+      # to stay off the macOS-5 concurrency bottleneck. On push / nightly
+      # schedule / dispatch: ubuntu + macOS (the bash leg). The non-owner job
+      # below (Linux container) gates every event including PRs.
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest","macos-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## What

Stop running the full cross-OS matrix on every PR push. GitHub's macOS concurrency cap is 5 concurrent runners across the free/Pro/Team plans (only Enterprise lifts it), so a per-PR full-OS matrix saturates the pool and queues runs for hours during busy PR waves.

**On `pull_request`:** Linux legs (full Node-version tier matrix) + **one** `windows-latest` representative. macOS is dropped from PRs entirely.

**On `push: main` + nightly `schedule`:** the full `os × node` matrix, adding `macos-14`.

## Per-workflow changes

- **ci.yml** — new `matrix-plan` job emits the `test`/`pnp` `os × node` matrices as JSON keyed on `github.event_name`; both jobs consume it via `fromJSON`. Single source of the split — no duplicated workflow files. Nightly `schedule` (06:00 UTC) added.
- **aube-parity.yml** — the `aube-conformance-windows` leg (the only Windows leg) is gated `if: github.event_name != 'pull_request'`; a nightly `schedule` (06:30 UTC) keeps it running on a cadence. The Linux conformance legs still gate every PR.
- **launcher.yml** — the `heal` job matrix is event-conditional: PR → `[ubuntu-latest]`; push/schedule/dispatch → `[ubuntu-latest, macos-latest]`. Nightly `schedule` (06:45 UTC) added. The `non-owner` Linux-container job still gates every event including PRs.
- **release.yml** — untouched (tag-triggered 8-platform build).
- `concurrency: cancel-in-progress` preserved everywhere it existed.

## Why keep one Windows leg on PR

The `test` Windows leg is the only place `cfg(windows)` PM-shim code (`.exe`/`.cmd` resolution, argv0 dispatch, shim install) and the `nub upgrade` Windows argv compile and run. The `pnp` Windows leg guards genuinely OS-divergent PnP zipfs/path handling (Windows backslashes). macOS, by contrast, re-runs platform-agnostic logic on PR and is the concurrency bottleneck, so it moves to trunk/nightly.

## Tradeoff

Cross-platform regressions on macOS surface on `main`/nightly rather than per-PR. This is standard practice for matrix-heavy projects; the full matrix still runs on every merge to `main` and every night, so coverage is preserved — just off the PR hot path.

## Verification

- `actionlint` clean on all three changed workflows.
- Simulated the `matrix-plan` jq for `pull_request` / `push` / `schedule`: PR → ubuntu (all Node tiers) + 1 windows, **no macOS**; push and schedule → full set including `macos-14`. The full matrix still runs on main and nightly.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa