### PR TITLE
docs: structural dedup across docs pages

### DIFF
--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -40,7 +40,7 @@ Running `nub <file>` is flag-for-flag compatible with `node <file>` — same arg
 - **Automatic polyfills** — `Temporal`, `URLPattern`, browser-shape `Worker`, WinterTC gap globals, version-detected and feature-gated
 - **Unflagged experimentals** — `EventSource`, `WebSocket`, `localStorage` / `sessionStorage`, `vm.Module`, `node:sqlite` — flags Node already ships but keeps gated, auto-injected in exact per-version bands where each is still behind `--experimental-*`
 
-All of that comes for free when you type `nub` instead of `node`. For plain Node behavior, type `node` — the PATH shim is per-invocation, so shell `node` is always the user's real Node. For orchestration without runtime augmentation, `nub run --node` and `nubx --node` strip the hook/preload/flag-injection while keeping Nub's CLI work.
+All of that comes for free when you type `nub` instead of `node`. For plain Node behavior, type `node` — the PATH shim is per-invocation, so shell `node` is always the user's real Node. For orchestration without runtime augmentation, the [`--node` flag](#whats-the---node-flag) on `nub run` and `nubx` strips the hook/preload/flag-injection while keeping Nub's CLI work.
 
 ## What's the elevator pitch?
 
@@ -78,7 +78,7 @@ Yes. Every `node:` core module — `node:fs`, `node:http`, `node:test`, `node:wo
 ## What Node versions does it support?
 
 - **Augmented modes** require Node 18.19+ (Node 18 LTS) — the floor for the loader-hook API Nub uses for the transpile-on-import path.
-- **Compat mode** (`nub run --node` / `nubx --node`) is best-effort on any Node version. Here Nub is a pure orchestrator (script resolution, workspace bin PATH, env var injection) and spawns plain Node without registering augmentation. For ad-hoc plain-Node behavior on a file, type `node` directly.
+- **Compat mode** (the [`--node` flag](#whats-the---node-flag)) is best-effort on any Node version. Here Nub is a pure orchestrator (script resolution, workspace bin PATH, env var injection) and spawns plain Node without runtime augmentation. For ad-hoc plain-Node behavior on a file, type `node` directly.
 
 <Callout title="Below the floor">
 On Node older than 18.19, augmented commands emit a tagged error telling you to upgrade Node or use compat mode.
@@ -189,7 +189,7 @@ Nub is a Rust CLI. When you type `nub script.ts`, the Rust binary:
 4. The preload bundle calls `module.registerHooks()` to install Nub's load hook (TS / JSX / YAML / TOML / JSON5 / JSONC transpile-and-parse path, backed by an N-API binding to `oxc`), installs polyfills (`Temporal`, `URLPattern`, `WebSocket`, `Worker`, WinterTC gap globals) where Node is behind, and hands control to your script.
 5. Subprocesses inherit the same augmentation recursively — `node hello.js` from inside a script, the Node process Vite or Next.js spawns for a dev server, the worker pool your test runner spins up, `child_process.spawn("node", …)` from your own code, all augmented.
 
-No patched Node, no vendored `libnode`, no separate runtime to discover.
+Every step rides on a public Node extension surface — see [What Node features does it rely on?](#what-node-features-does-it-rely-on) for the full inventory.
 
 ## What Node features does it rely on?
 
@@ -206,15 +206,7 @@ That's the entire kit. There is no patched Node binary, no vendored `libnode`, n
 
 ## Why hasn't anyone else done this?
 
-Because the extension surface that makes it possible is new. Everything Nub does rides on five public Node mechanisms:
-
-- **`module.registerHooks()`** (Node 22.15, April 2025) — synchronous loader hooks. The entire TS / JSX / YAML / TOML path is one registered hook.
-- **`module.register()`** (Node 20.6, 2023) — programmatic loader registration, used on the legacy lines.
-- **`--import` / `--require` preloads** — code that runs before your `main`, used to install the polyfills.
-- **`NODE_OPTIONS` / V8 flag injection** — unflags the `--experimental-*` features Node already implements.
-- **N-API addons** (ABI-stable since 2017) — the oxc transpiler, called from inside the load hook.
-
-No patched Node binary, no vendored `libnode`, no separate runtime to discover. Deno and Bun predate most of this surface — back then, shipping integrated TypeScript meant writing a runtime around it; today the same layer composes on top of Node, with the entire compatibility surface preserved for free.
+Because the extension surface that makes it possible is new — the [public Node mechanisms](#what-node-features-does-it-rely-on) Nub composes only landed over the last three years (`module.registerHooks()` in April 2025, `module.register()` in 2023). Deno and Bun predate most of that surface — back then, shipping integrated TypeScript meant writing a runtime around it; today the same layer composes on top of Node, with the entire compatibility surface preserved for free.
 
 ## Why doesn't Node ship these defaults natively?
 
@@ -318,14 +310,7 @@ The `nub run` command is just as fast in the [script-runner benchmark](https://g
 
 ## What if I want to stop using Nub?
 
-Your codebase keeps working on plain Node, unchanged. Nub adds no APIs to your code:
-
-```text
-no globalThis.nub
-no nub:* module namespace
-no @nub/* npm scope
-no "nub" field in package.json
-```
+Your codebase keeps working on plain Node, unchanged. Nub adds no APIs to your code — no `nub` global, no `nub:*` import namespace, no `@nub/*` scope, no `"nub"` field in your `package.json`.
 
 If Nub disappeared tomorrow, the worst case is going back to whatever toolchain you had before:
 
@@ -345,15 +330,7 @@ nub run --node test           # Nub's CLI orchestration, runtime augmentation of
 nubx --node prisma generate   # Nub's bin resolution, runtime augmentation off
 ```
 
-It disables every runtime augmentation for the spawned process:
-
-```text
-no transpile hook
-no .env loading
-no polyfills
-no experimental-flag injection
-no PATH shim
-```
+It strips every runtime augmentation for the spawned process — the transpile hook, `.env` loading, polyfills, experimental-flag injection, and the PATH shim — leaving byte-exact Node runtime behavior; full contract at [the runtime overview](/docs/runtime#--node).
 
 Useful when a script's `#!/usr/bin/env node` shebang chain expects real Node, when bisecting a Nub bug, or when CI wants byte-exact Node runtime behavior with Nub's `--filter` / workspace selection. For ad-hoc plain-Node runs, type `node`.
 

--- a/site/content/docs/install/npm.mdx
+++ b/site/content/docs/install/npm.mdx
@@ -125,7 +125,7 @@ npm ignores the Yarn-style top-level `resolutions`, so Nub drops it with a warni
 
 The default `node_modules` layout is **hoisted** — the flat npm-style scheme.
 
-Lifecycle scripts run under Nub's deny-by-default trust posture plus a gated default-trust floor (see [Security](/docs/install#security)), not npm's run-everything default. Curated, age-vetted packages build automatically; everything else is skipped with `WARN_NUB_IGNORED_BUILD_SCRIPTS` until `nub approve-builds`. Platform-gated optionals (e.g. `fsevents`) resolve and round-trip into the lock.
+Lifecycle scripts run under Nub's deny-by-default trust posture plus a gated default-trust floor (see [the default-trust floor](/docs/install#default-trust-floor)), not npm's run-everything default. Curated, age-vetted packages build automatically; everything else is skipped with `WARN_NUB_IGNORED_BUILD_SCRIPTS` until `nub approve-builds`. Platform-gated optionals (e.g. `fsevents`) resolve and round-trip into the lock.
 
 ## Gaps
 

--- a/site/content/docs/install/pnpm.mdx
+++ b/site/content/docs/install/pnpm.mdx
@@ -139,7 +139,7 @@ $ nub install
   │ `hoisted`
 ```
 
-Lifecycle scripts for dependencies are skipped by default, exactly as pnpm 10 does. A package runs install scripts only when allowlisted via `pnpm.onlyBuiltDependencies` (or `pnpm.allowBuilds`), or when Nub's gated default-trust floor vouches for it (see [Security](/docs/install#security)); `nub approve-builds` adds an entry interactively. `pnpm.neverBuiltDependencies` is a denylist that wins over any allow and over the floor.
+Lifecycle scripts for dependencies are skipped by default, exactly as pnpm 10 does. A package runs install scripts only when allowlisted via `pnpm.onlyBuiltDependencies` (or `pnpm.allowBuilds`), or when Nub's gated default-trust floor vouches for it (see [the default-trust floor](/docs/install#default-trust-floor)); `nub approve-builds` adds an entry interactively. `pnpm.neverBuiltDependencies` is a denylist that wins over any allow and over the floor.
 
 ## Unsupported
 

--- a/site/content/docs/nubx.mdx
+++ b/site/content/docs/nubx.mdx
@@ -52,14 +52,14 @@ nubx vitest run --coverage
 
 ## --node
 
-By default `nubx` runs the tool under Nub's augmentation — the PATH shim makes any `node` the tool spawns resolve back to Nub, with TypeScript transpilation and polyfills active. Pass `--node` to turn that off for the invocation: the bin's `#!/usr/bin/env node` shebang resolves to your real Node binary, no `--import` preload is added, and no experimental flags are injected. Reach for it when a tool's shebang chain needs byte-exact plain Node, when you're bisecting a Nub-vs-Node issue, or when CI wants exact Node runtime behavior with `nubx`'s resolution.
+Pass `--node` to run the tool with runtime augmentation disabled — see [the runtime overview](/docs/runtime#--node) for the full contract.
 
 ```bash
 nubx --node prisma generate
 nub exec --node tsc --noEmit
 ```
 
-What still happens under `--node`: the workspace-aware `node_modules/.bin` walk-up, the registry DLX fallback below, and `nubx`'s own CLI machinery. Only the runtime augmentation is disabled.
+What still happens under `--node`: the workspace-aware `node_modules/.bin` walk-up, the registry DLX fallback, and `nubx`'s own CLI machinery. Only the runtime augmentation is disabled. Reach for it when a tool's shebang chain needs byte-exact plain Node, when bisecting a Nub-vs-Node issue, or when CI wants exact Node runtime behavior with `nubx`'s resolution.
 
 ## Download and execute
 
@@ -103,7 +103,7 @@ dependencies:
 
 ## Yarn Plug'n'Play
 
-Yarn Berry's Plug'n'Play mode replaces `node_modules/.bin/` with a runtime resolution table managed by Yarn's own loader. Tools that only walk the `.bin/` tree — `npx`, `pnpm exec`, `bunx` — don't see it. `nubx` does: when the `.bin` walk-up misses in a PnP tree, it hands off to a PnP-aware runner that resolves the bin through `pnpapi` and loads it with `require()` — the way `yarn exec` does, reading zip-stored bins on every supported tier. A Yarn Berry project's bins run with no setup. The same machinery that lets Nub *run* a PnP project backs this; see [module resolution](/docs/runtime/resolution#yarn-plugnplay).
+Tools that only walk `node_modules/.bin/` — `npx`, `pnpm exec`, `bunx` — miss Yarn Berry's PnP bins. `nubx` resolves them: when the `.bin` walk-up misses in a PnP tree, it falls through to a PnP-aware runner that finds and executes the bin. See [module resolution](/docs/runtime/resolution#yarn-plugnplay) for how the shared PnP machinery works.
 
 ## Flag differences
 

--- a/site/content/docs/run.mdx
+++ b/site/content/docs/run.mdx
@@ -242,13 +242,13 @@ nub run --silent build
 
 ## `--node`
 
-By default, the `nub` executable is aliased as `node` for the duration of a `nub run` call, so any subprocess that spawns `node` (a script shebang, `child_process.spawn("node", …)`) gets Nub's TypeScript transpilation, `.env` loading, and polyfills too. Pass `--node` to turn that augmentation off for one invocation.
+By default, the `nub` executable is aliased as `node` for the duration of a `nub run` call, so any subprocess that spawns `node` (a script shebang, `child_process.spawn("node", …)`) gets Nub's augmentation too. Pass `--node` to turn that off for one invocation — see [the runtime overview](/docs/runtime#--node) for the full contract.
 
 ```bash
 nub run --node test
 ```
 
-With `--node`, the PATH shim, the transpile/preload hook, and experimental-flag injection are all skipped — child `node` calls resolve to your real Node binary. What still happens: script lookup, workspace walk-up, `--filter` evaluation, `npm_*` env injection, `node_modules/.bin` on `PATH`, and the `pre` / `post` lifecycle hooks. Reach for it when a script's `#!/usr/bin/env node` shebang chain expects plain Node, when bisecting a Nub bug, or when CI wants byte-exact Node runtime behavior with Nub's workspace selection.
+What still happens under `--node`: script lookup, workspace walk-up, `--filter` evaluation, `npm_*` env injection, `node_modules/.bin` on `PATH`, and the `pre` / `post` lifecycle hooks. Reach for it when a script's `#!/usr/bin/env node` shebang chain expects plain Node, when bisecting a Nub bug, or when CI wants byte-exact Node runtime behavior with Nub's workspace selection.
 
 ## Drop-in for `pnpm run`
 

--- a/site/content/docs/runtime/resolution.mdx
+++ b/site/content/docs/runtime/resolution.mdx
@@ -24,7 +24,7 @@ Nub reads your nearest `tsconfig.json` and applies its resolution settings at ru
 
 ### `paths`
 
-Nub reads `compilerOptions.paths` and `compilerOptions.baseUrl` from your nearest `tsconfig.json` and applies them at runtime, so `@/...`-style aliases resolve with no extra tooling.
+The `compilerOptions.paths` and `compilerOptions.baseUrl` mappings resolve `@/...`-style aliases with no extra tooling.
 
 ```json
 {

--- a/site/content/docs/watch.mdx
+++ b/site/content/docs/watch.mdx
@@ -9,13 +9,15 @@ This page is a cookbook. For how `nub` runs files in the first place, see [Runni
 
 ## Watch and restart a file
 
-Point `nub watch` at an entry file. It runs the file, then restarts the process on any change to the file or anything in its resolved import graph.
+The watcher takes a file, not a script name. Point `nub watch` at an entry file — the one your `dev` script runs, for example. It runs the file, then restarts the process on any change to the file or anything in its resolved import graph.
 
 ```bash
 nub watch src/server.ts
 ```
 
 TypeScript, JSX, `.env*` loading, `tsconfig.json` paths — everything `nub <file>` gives you is active here too, because `nub watch` runs the same augmented Node underneath.
+
+A `--watch` placed after a script name is forwarded *to the script* like any other argument — `nub run test --watch` runs your test tool's own watch mode, it does not invoke Nub's watcher. See [`nub run` → Forward arguments](/docs/run#forward-arguments).
 
 ## `--watch`
 
@@ -24,16 +26,6 @@ Flag and subcommand are aliases: `nub --watch <file>` dispatches to the exact sa
 ```bash
 nub --watch src/server.ts
 ```
-
-## Watching a script
-
-The watcher takes a file, not a script: point `nub watch` at the entry your `dev` script runs.
-
-```bash
-nub watch src/server.ts
-```
-
-A `--watch` placed after a script name is forwarded *to the script* like any other argument — `nub run test --watch` runs your test tool's own watch mode, it does not invoke Nub's watcher. See [`nub run` → Forward arguments](/docs/run#forward-arguments).
 
 ## Preserve output
 


### PR DESCRIPTION
Docs-wide structural audit to kill within-page and cross-page information duplication. Each duplicated concept gets one canonical home; everything else cross-links to it. No facts removed — dedup and relocation only.

## Changes

- **faq.mdx** — the 5 Node-extension-surface mechanisms were spelled out near-verbatim in three answers; collapsed to one canonical list under "What Node features does it rely on?", with the other two answers keeping their distinct angle and linking it. The brand-boundary block (no `globalThis.nub` / `nub:*` / `@nub/*` / `"nub"` field) was verbatim twice; kept once. The `--node` flag was explained in three places; reduced to one canonical short answer that links the runtime overview for the full contract.
- **run.mdx / nubx.mdx** — trimmed the per-command `--node` sections to each command's specific behavior plus a link to the canonical contract at `/docs/runtime#--node`. Trimmed nubx's Yarn PnP section to the bin-resolution specifics and linked the canonical `/docs/runtime/resolution#yarn-plugnplay`.
- **watch.mdx** — merged two near-identical "watch a file" sections into one, preserving the post-script-name `--watch`-forwarding caveat.
- **install/npm.mdx, install/pnpm.mdx** — repointed the now-dead `/docs/install#security` anchor to `#default-trust-floor`.
- **runtime/resolution.mdx** — dropped the duplicated tsconfig framing in the `paths` subsection opener.

## Verification

- Code-fence parity even in all seven files; all intra-page and cross-doc anchors resolve to real headings (`#what-node-features-does-it-rely-on`, `#whats-the---node-flag`, `#how-does-it-work-under-the-hood`, `/docs/runtime#--node`, `/docs/runtime/resolution#yarn-plugnplay`).
- The `#default-trust-floor` anchor depends on the in-flight install/index.mdx terseness PR exposing that slug.

Note: install/index.mdx (which carries the original "build jail" vs "Lifecycle scripts" duplication) is owned by a concurrent terseness PR and is intentionally not touched here.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa