### PR TITLE
ci: mechanize code-quality + brand boundary as lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,11 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --all-features -- -D warnings
+      # Static brand-boundary gate: no AUBE_*-branded env-var READS in nub crate
+      # source (the embedded engine's brand is never nub's config surface). Cheap
+      # grep, no build — runs alongside clippy on the same run_rust gate.
+      - name: Brand lint (no AUBE_* env reads)
+        run: tests/brand-lint/check-env-reads.sh
 
   test:
     name: Test (${{ matrix.os }}, node ${{ matrix.node }})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "nub-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "aube",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "nub-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "nub-native"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "blake3",
  "json5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,3 +120,17 @@ zip = { version = "8.6", default-features = false, features = ["deflate"] }
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Workspace restriction lints, promoted to warn and inherited by every nub crate
+# (each opts in with `[lints] workspace = true`). CI runs clippy under
+# `-D warnings`, so each is a hard gate. Scope is deliberately MINIMAL: only the
+# zero-violation, high-signal markers that flag unfinished/debug code shipping
+# to users. Deliberately OMITTED (measured 2026-06-21, would need a large
+# refactor, not a review-miss guard): `print_stdout`/`print_stderr` (a CLI
+# legitimately prints and there is no output wrapper — 239 sites); `unwrap_used`/
+# `expect_used`/`panic`/`exit` (1300+ sites, mostly tests). Revisit those behind
+# an output wrapper / `allow-in-tests` later.
+[workspace.lints.clippy]
+dbg_macro = "warn"
+todo = "warn"
+unimplemented = "warn"

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -90,3 +90,6 @@ libc.workspace = true
 # (pm_engine/mod.rs::with_fd_captured). Without it the substitution silently
 # breaks and the default registry is never surfaced on Windows.
 libc.workspace = true
+
+[lints]
+workspace = true

--- a/crates/nub-core/Cargo.toml
+++ b/crates/nub-core/Cargo.toml
@@ -57,3 +57,6 @@ harness = false
 [[bench]]
 name = "cache_hash"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/nub-native/Cargo.toml
+++ b/crates/nub-native/Cargo.toml
@@ -47,3 +47,6 @@ blake3.workspace = true
 
 [build-dependencies]
 napi-build = "2"
+
+[lints]
+workspace = true

--- a/tests/brand-lint/check-env-reads.sh
+++ b/tests/brand-lint/check-env-reads.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Static brand-boundary gate: the nub crates must never READ an AUBE_*-branded
+# environment variable.
+#
+# WHY a grep-gate and not a clippy lint: forcing every env access through a
+# wrapper (uv's `disallowed-methods` pattern) would mean migrating ~89 direct
+# `std::env::var` sites — a large refactor, tracked as a follow-up. This gate is
+# the bounded, zero-violation guard that actually holds the invariant TODAY: it
+# catches the specific regression (a new AUBE_* read sneaking into nub) without
+# the refactor.
+#
+# The invariant (AGENTS.md "The nub runtime respects ZERO AUBE_* env vars"): the
+# embedded aube engine's brand is never nub's config surface. Standalone aube
+# reads AUBE_*; under the nub embedder profile those are dead, and a nub-facing
+# knob is a neutral npmrc field / NUB_* — never AUBE_*. SETTING an AUBE_* var for
+# a child the engine spawns (e.g. AUBE_NODE_GYP_EXE via Command::env) is fine and
+# not matched; only READING one (env::var / env::var_os) is the violation.
+#
+# Scope: crates/*/src (production source). Tests are excluded — a test may
+# legitimately set an AUBE_* canary to PROVE it has no effect (see
+# tests/brand-sweep/run.sh).
+#
+# Usage: tests/brand-lint/check-env-reads.sh
+# CI: a step in the `clippy` job (run_rust-gated, no build needed).
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# env::var / env::var_os calls whose argument carries an "AUBE_ string literal.
+# Matches `std::env::var("AUBE_X")`, `env::var_os("AUBE_X")`, and a leading `&`.
+pattern='env::var(_os)?\s*\(\s*&?"AUBE_'
+
+hits=$(grep -rnE "$pattern" crates/*/src --include='*.rs' || true)
+
+if [ -n "$hits" ]; then
+  echo "FAIL: nub crate source reads an AUBE_*-branded env var (brand-boundary violation)."
+  echo "      Under the nub embedder profile AUBE_* env vars are dead; use a neutral"
+  echo "      npmrc field or a NUB_* knob instead. See AGENTS.md, brand boundary."
+  echo
+  echo "$hits"
+  exit 1
+fi
+
+echo "ok: no AUBE_* env-var reads in nub crate source"


### PR DESCRIPTION
Mechanizes two things that were previously only review-enforced, so they can't regress by a review miss. Mirrors uv's `clippy.toml`/`[lints]` pattern, but scoped to a **clean, zero-violation subset** — no ocean-boiling, no large refactor.

## What landed

**Workspace restriction lints** (`[workspace.lints.clippy]`, inherited by every nub crate via `[lints] workspace = true`), promoted to warn → hard-gated by the existing `cargo clippy --all-targets --all-features -- -D warnings` CI job:

- `dbg_macro`, `todo`, `unimplemented`

All three measured at **0 violations** across the whole workspace (2026-06-21), so they land clean and act purely as a forward guard against unfinished/debug code shipping.

**Static brand-boundary gate** — `tests/brand-lint/check-env-reads.sh`, wired as a step in the `clippy` CI job (cheap grep, no build, same `run_rust` gate). Fails if nub crate *source* READs an `AUBE_*`-branded env var. Enforces the settled AGENTS.md invariant ("the nub runtime respects ZERO `AUBE_*` env vars") mechanically. Currently 0 violations; verified the gate both passes clean and catches an injected violation. SETTING an `AUBE_*` var for a child the engine spawns (`Command::env`) is not matched — only reads are.

## What was deliberately omitted (and why)

Measured violation counts made these a refactor, not a review-miss guard — noted as follow-ups, not in this PR:

- `print_stdout` / `print_stderr` — a CLI legitimately prints and there is **no output wrapper** (239 sites across 15 production source files). Per the thread's guidance, skipped absent a wrapper.
- `unwrap_used` / `expect_used` / `panic` / `exit` — 1300+ sites, overwhelmingly in tests. Would need `allow-in-tests` config + nontrivial production cleanup.
- Forcing all env access through a wrapper (uv's `disallowed-methods` approach, ~89 direct `std::env::var` sites) — the larger refactor that would let `disallowed-methods` ban direct env access; the grep-gate holds the boundary today without it.

## Verification (local, pre-push)

- `cargo clippy --all-targets --all-features -- -D warnings` → exit 0 (new lints clean)
- `cargo fmt --check` → clean
- `tests/brand-lint/check-env-reads.sh` → passes; injected `env::var("AUBE_CACHE_DIR")` → correctly fails

Refs the contribution-quality investigation (uv/ruff adopt-now pick #1).

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa