### PR TITLE
site: align heading inline-code baseline + strengthen PM security copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,11 @@ npm    4163 ms   (3.7×)
 - 🗄️ Dedupes through a global content-addressed store and materializes by reflink/hardlink.
 - 🐍 Accepts pnpm's flags with the same spelling and semantics, down to the workspace catalog.
 - 🛡️ Treats dependency build scripts as deny-by-default — a script runs only on an explicit allow or a vetted default-trust floor.
+- 🦠 Queries OSV for malicious-package (`MAL-*`) advisories on every fresh resolve and hard-blocks a confirmed hit (`ERR_NUB_MALICIOUS_PACKAGE`).
+- 🔻 Refuses a version whose publish trust evidence weakened against an earlier release (`trustPolicy=no-downgrade`, `ERR_NUB_TRUST_DOWNGRADE`).
+- ⏳ Holds back releases younger than `minimumReleaseAge` (24h by default, matching pnpm), so a freshly-compromised version isn't pulled in.
 
-Dependency build scripts run only on an explicit allow (`pnpm.onlyBuiltDependencies`, `trustedDependencies`, `nub approve-builds`) or when a curated default-trust floor vouches for the package under registry-provenance, advisory-vetting, and cooling-window gates. See [Package manager](https://nubjs.com/docs/install).
+These supply-chain defenses are on by default, no config required. Dependency build scripts run only on an explicit allow (`pnpm.onlyBuiltDependencies`, `trustedDependencies`, `nub approve-builds`) or when a curated default-trust floor vouches for the package under registry-provenance, advisory-vetting, and cooling-window gates; a skipped package is named with `WARN_NUB_IGNORED_BUILD_SCRIPTS`. An OSV malicious-package hit aborts the install, a weakened-provenance downgrade is refused, and too-new versions wait out the cooling window. See [Package manager](https://nubjs.com/docs/install).
 
 ### Package meta-manager — `nub pm`
 

--- a/site/src/app/(home)/page.tsx
+++ b/site/src/app/(home)/page.tsx
@@ -68,7 +68,7 @@ function DocLink({ href, children }: { href: string; children: ReactNode }) {
    serif around it, with a faint tinted pill so a command reads as a command. */
 function HeadingCode({ children }: { children: ReactNode }) {
   return (
-    <code className="rounded-md border border-fd-border/70 bg-fd-muted/40 px-2 py-0.5 align-[-0.09em] font-mono text-[0.66em] font-normal tracking-tight text-fd-foreground">
+    <code className="rounded-md border border-fd-border/70 bg-fd-muted/40 px-2 py-0.5 align-[-0.035em] font-mono text-[0.66em] font-normal tracking-tight text-fd-foreground">
       {children}
     </code>
   );
@@ -1092,8 +1092,8 @@ function HypermanagerBand() {
             <>
               A pnpm-compatible package manager, built in. It reads the lockfile your project
               already has — <Mono>pnpm</Mono>, <Mono>npm</Mono>, or <Mono>bun</Mono> — writes the
-              same format back, and configures itself from your <Mono>.npmrc</Mono>{' '}and{' '}
-              <Mono>workspaces</Mono>. Powered by the{' '}
+              same format back, and is hardened against supply-chain attacks out of the box.
+              Powered by the{' '}
               <a
                 href="https://github.com/jdx/aube"
                 target="_blank"
@@ -1109,6 +1109,89 @@ function HypermanagerBand() {
         />
 
         <div className="mt-10 divide-y divide-fd-border/60">
+          <Feature
+            accent="pink"
+            eyebrow="Supply-chain safe by default"
+            title="Hardened against supply-chain attacks"
+            body={
+              <>
+                The defenses are on out of the box, no config required. Nub treats dependency
+                build scripts as <Mono>deny-by-default</Mono>, queries OSV for malicious-package
+                advisories on every fresh resolve, refuses a version whose publish trust evidence
+                weakened against an earlier release, and holds back releases younger than{' '}
+                <Mono>minimumReleaseAge</Mono> (24h, matching pnpm) so a freshly-compromised
+                version isn&rsquo;t pulled in.
+              </>
+            }
+            visual={
+              <Terminal
+                lines={[
+                  { cmd: 'nub add @ledgerhq/connect-kit' },
+                  {
+                    out: 'Error: refusing to add malicious package(s):',
+                    tone: 'error',
+                  },
+                  {
+                    out: '  - @ledgerhq/connect-kit (MAL-2023-8697:',
+                    tone: 'error',
+                  },
+                  {
+                    out: '      https://osv.dev/vulnerability/MAL-2023-8697)',
+                    tone: 'error',
+                  },
+                  { out: '  ❌ code=ERR_NUB_MALICIOUS_PACKAGE', tone: 'error' },
+                  { out: '' },
+                  { cmd: 'nub install', comment: 'a version that lost its provenance' },
+                  {
+                    out: 'Error: trust downgrade for nanoid@3.3.14 (trustPolicy=',
+                    tone: 'error',
+                  },
+                  {
+                    out: '  no-downgrade): earlier published version 3.3.7 had',
+                    tone: 'error',
+                  },
+                  {
+                    out: '  provenance attestation but this version has no trust evidence',
+                    tone: 'error',
+                  },
+                  { out: '  ❌ code=ERR_NUB_TRUST_DOWNGRADE', tone: 'error' },
+                ]}
+              />
+            }
+          />
+
+          <Feature
+            accent="pink"
+            reverse
+            eyebrow="Deny-by-default build scripts"
+            title={<>Build scripts don&rsquo;t run until you allow them</>}
+            body={
+              <>
+                Install-time <Mono>postinstall</Mono> scripts are where most supply-chain payloads
+                land. Nub skips them by default, names what it skipped, and waits for{' '}
+                <Mono>nub approve-builds</Mono>. A curated default-trust floor can vouch for a
+                package only after it clears provenance, advisory, and cooling gates.
+              </>
+            }
+            visual={
+              <Terminal
+                lines={[
+                  { cmd: 'nub install' },
+                  {
+                    out: 'WARN ignored build scripts for 1 package(s): esbuild@0.21.5.',
+                    tone: 'error',
+                  },
+                  {
+                    out: '     Run `nub approve-builds` to review and enable them.',
+                  },
+                  { out: '     code=WARN_NUB_IGNORED_BUILD_SCRIPTS' },
+                  { out: '' },
+                  { cmd: 'nub approve-builds', comment: 'review + allow, once' },
+                ]}
+              />
+            }
+          />
+
           <Feature
             accent="pink"
             eyebrow="Meta package manager"

--- a/site/src/app/(home)/page.tsx
+++ b/site/src/app/(home)/page.tsx
@@ -172,7 +172,7 @@ function HeroPill() {
       href="/blog/introducing-nub"
       className="group inline-flex items-center gap-2 rounded-full border border-fd-border bg-fd-card/50 py-1 pl-1 pr-3 text-sm leading-none text-fd-muted-foreground hover:border-ember/50"
     >
-      <span className="rounded-full bg-ember px-2.5 py-0.5 font-mono text-[0.7rem] font-medium uppercase tracking-wider text-[#160c08]">
+      <span className="rounded-full bg-ember px-2.5 py-0.5 font-mono text-[0.7rem] font-medium uppercase tracking-wider text-[#fffdf8] dark:text-[#160c08]">
         New
       </span>
       <span className="translate-y-px text-fd-foreground">Introducing Nub</span>

--- a/site/src/components/code.tsx
+++ b/site/src/components/code.tsx
@@ -28,7 +28,14 @@ export function Terminal({
   className = '',
   size = 'sm',
 }: {
-  lines: { cmd?: string; comment?: string; out?: string; bright?: boolean }[];
+  lines: {
+    cmd?: string;
+    comment?: string;
+    out?: string;
+    bright?: boolean;
+    /* tone for an `out` line: an error/refusal line reads ember-red */
+    tone?: 'error';
+  }[];
   className?: string;
   size?: 'sm' | 'lg';
 }) {
@@ -43,7 +50,15 @@ export function Terminal({
         {lines.map((line, i) => (
           <div key={i} className="whitespace-pre">
             {line.out !== undefined ? (
-              <span className={line.bright ? 'nub-code-fg' : 'nub-code-muted'}>
+              <span
+                className={
+                  line.tone === 'error'
+                    ? 'text-ember'
+                    : line.bright
+                      ? 'nub-code-fg'
+                      : 'nub-code-muted'
+                }
+              >
                 {line.out}
               </span>
             ) : (


### PR DESCRIPTION
Two homepage changes in one PR (distinct regions of `site/src/app/(home)/page.tsx`).

## Heading inline-code baseline (measured)

`HeadingCode` (inline monospace inside serif headings, e.g. "A 24× faster `pnpm run`") rendered with its glyph bottoms below the serif baseline. Measured via headless Chrome / CDP `getBoundingClientRect`:

| Heading | before (code − serif) | after |
| --- | --- | --- |
| h2 (40px serif) | +2.13px | −0.09px |
| h3 (25px serif) | +1.27px | −0.13px |

Fix: `vertical-align` `-0.09em` → `-0.035em` on `HeadingCode`. Residual is sub-pixel (±0.13px) across every instance (`using`, `node`, `pnpm run`, `npx`, `pnpm exec`, `pnpm`), verified at both heading sizes. Vercel preview gives the visual confirmation.

## PM band security

The PM band under-sold the supply-chain posture. Now leads with the defenses that are **on by default**, each grounded in code:

- Deny-by-default build scripts (`WARN_NUB_IGNORED_BUILD_SCRIPTS`, `nub approve-builds`)
- OSV malicious-package advisory check, hard-block on a hit (`ERR_NUB_MALICIOUS_PACKAGE`)
- Trust-downgrade refusal (`trustPolicy=no-downgrade`, `ERR_NUB_TRUST_DOWNGRADE`)
- `minimumReleaseAge` cooling window (24h default, matching pnpm)

Terminal demos use real output: the `@ledgerhq/connect-kit` / `MAL-2023-8697` block (real OSV advisory), the `nanoid@3.3.14` trust-downgrade in the engine's exact format, and the captured build-script warning. Error/refusal lines render in ember-red with ❌ via a new `tone` on the `Terminal` component. README PM section aligned to match.

Deliberately NOT claimed (verified against code): install-time cryptographic attestation verification (only metadata-shape presence checks exist), default-on build sandboxing (opt-in via `paranoid`), and install-failing-by-default for the age gate (default is soft fallback).

tsc clean, `next build` green.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa