### PR TITLE
node: bare `nub node` prints status then help

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -5030,28 +5030,35 @@ fn run_node(args: &[String]) -> Result<i32> {
         anyhow::anyhow!("could not locate nub's cache directory (no $HOME / $XDG_CACHE_HOME)")
     })?;
 
+    // The verb listing — shared by `--help`/`-h`/`help` and the bare form, so the
+    // two never drift. Bare `nub node` prepends the resolved-Node status block.
+    const NODE_HELP: &str = "nub node — manage Node versions\n\n\
+         Usage: nub node <command>\n\n\
+         Commands:\n\
+         \x20 which                    print the resolved Node binary path (why → stderr)\n\
+         \x20 install [<version>...]   provision version(s) into nub's cache (bare: the project pin)\n\
+         \x20 ls                       list versions in nub's cache\n\
+         \x20 uninstall <version>      remove a version from nub's cache\n\
+         \x20 pin <version>            write the project's Node pin";
+
     // `nub node --help`/`-h`/`help`: short usage listing the verbs.
     let verb = args.first().map(String::as_str);
     if matches!(verb, Some("--help") | Some("-h") | Some("help")) {
-        println!(
-            "nub node — manage Node versions\n\n\
-             Usage: nub node <command>\n\n\
-             Commands:\n\
-             \x20 which                    print the resolved Node binary path (why → stderr)\n\
-             \x20 install [<version>...]   provision version(s) into nub's cache (bare: the project pin)\n\
-             \x20 ls                       list versions in nub's cache\n\
-             \x20 uninstall <version>      remove a version from nub's cache\n\
-             \x20 pin <version>            write the project's Node pin"
-        );
+        println!("{NODE_HELP}");
         return Ok(0);
     }
 
-    // Bare `nub node`: status — the resolved version, its path, and why.
+    // Bare `nub node`: the idiomatic command-group behavior — print the resolved
+    // Node status block first, then the verb listing. Discovery is best-effort:
+    // if no Node resolves, still print the help rather than erroring out.
     if verb.is_none() {
-        let node = discover_node_for_status(&cwd)?;
-        println!("node {}", node.version);
-        println!("  path      {}", node.path);
-        println!("  resolved  {}", resolution_source(&cwd));
+        if let Ok(node) = discover_node_for_status(&cwd) {
+            println!("node {}", node.version);
+            println!("  path      {}", node.path);
+            println!("  resolved  {}", resolution_source(&cwd));
+            println!();
+        }
+        println!("{NODE_HELP}");
         return Ok(0);
     }
 

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -631,25 +631,34 @@ fn node_which_prints_path_to_stdout() {
 
 #[test]
 fn bare_node_prints_status_then_help() {
-    // Bare `nub node` is a command group: it prints the resolved-Node status
-    // block, then the verb listing. `nub node -h` prints only the listing.
+    // Bare `nub node` is a command group: it ALWAYS prints the verb listing, and
+    // PREPENDS the resolved-Node status block WHEN a Node resolves. The status
+    // block is environment-dependent — on a clean machine whose only Node is
+    // below the project's `engines.node` floor (the CI compat-tier legs), nothing
+    // resolves and bare `nub node` degrades to help-only. So this test asserts
+    // the stable contract (verb listing always present; exit 0) plus the
+    // status-THEN-help ordering invariant only when the status block appears.
     let bare = Command::new(nub_binary())
         .arg("node")
         .output()
         .expect("failed to spawn nub node");
     let bare_stdout = String::from_utf8_lossy(&bare.stdout);
     assert_eq!(bare.status.code(), Some(0), "bare `nub node` exits cleanly");
-    // The status block leads with `node <version>` and a `  path  ` line — the
-    // verb listing's `resolved` substring appears in a command description, so
-    // key the assertion on the block-specific `  path  ` prefix instead.
-    assert!(
-        bare_stdout.contains("\n  path  ") || bare_stdout.starts_with("node "),
-        "bare `nub node` should print the resolved-Node status block: {bare_stdout}"
-    );
+    // The verb listing is the environment-independent part — always present.
     assert!(
         bare_stdout.contains("Commands:") && bare_stdout.contains("which"),
-        "bare `nub node` should also print the verb listing: {bare_stdout}"
+        "bare `nub node` always prints the verb listing: {bare_stdout}"
     );
+    // The status block is keyed on the block-specific `  path  ` prefix (the
+    // verb listing's `resolved` substring appears in a command description). When
+    // present, it must come BEFORE the help — status THEN help.
+    if let Some(path_idx) = bare_stdout.find("\n  path  ") {
+        let help_idx = bare_stdout.find("Commands:").expect("verb listing present");
+        assert!(
+            path_idx < help_idx,
+            "status block must precede the help text: {bare_stdout}"
+        );
+    }
 
     let help = Command::new(nub_binary())
         .args(["node", "-h"])

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -630,6 +630,44 @@ fn node_which_prints_path_to_stdout() {
 }
 
 #[test]
+fn bare_node_prints_status_then_help() {
+    // Bare `nub node` is a command group: it prints the resolved-Node status
+    // block, then the verb listing. `nub node -h` prints only the listing.
+    let bare = Command::new(nub_binary())
+        .arg("node")
+        .output()
+        .expect("failed to spawn nub node");
+    let bare_stdout = String::from_utf8_lossy(&bare.stdout);
+    assert_eq!(bare.status.code(), Some(0), "bare `nub node` exits cleanly");
+    // The status block leads with `node <version>` and a `  path  ` line — the
+    // verb listing's `resolved` substring appears in a command description, so
+    // key the assertion on the block-specific `  path  ` prefix instead.
+    assert!(
+        bare_stdout.contains("\n  path  ") || bare_stdout.starts_with("node "),
+        "bare `nub node` should print the resolved-Node status block: {bare_stdout}"
+    );
+    assert!(
+        bare_stdout.contains("Commands:") && bare_stdout.contains("which"),
+        "bare `nub node` should also print the verb listing: {bare_stdout}"
+    );
+
+    let help = Command::new(nub_binary())
+        .args(["node", "-h"])
+        .output()
+        .expect("failed to spawn nub node -h");
+    let help_stdout = String::from_utf8_lossy(&help.stdout);
+    assert_eq!(help.status.code(), Some(0), "`nub node -h` exits cleanly");
+    assert!(
+        help_stdout.contains("Commands:") && help_stdout.contains("which"),
+        "`nub node -h` prints the verb listing: {help_stdout}"
+    );
+    assert!(
+        !help_stdout.contains("\n  path  ") && !help_stdout.starts_with("node "),
+        "`nub node -h` prints help only, no status block: {help_stdout}"
+    );
+}
+
+#[test]
 fn top_level_short_and_long_help_are_distinct() {
     let short = Command::new(nub_binary())
         .arg("-h")


### PR DESCRIPTION
Bare `nub node` now follows the idiomatic command-group convention: it prints the resolved-Node status block, then the verb listing — made clearer by the `nub node which` subcommand. `nub node --help`/`-h`/`help` still prints help only (unchanged).

The shared help text is factored into a single `NODE_HELP` const so the bare form and the `--help` form never drift. Discovery on the bare path is best-effort: if no Node resolves, the help still prints rather than erroring.

New bare-`nub node` output:

```
node 26.2.0
  path      /Users/.../bin/node
  resolved  package.json#engines.node (>=22.15.0)

nub node — manage Node versions

Usage: nub node <command>

Commands:
  which                    print the resolved Node binary path (why → stderr)
  install [<version>...]   provision version(s) into nub's cache (bare: the project pin)
  ls                       list versions in nub's cache
  uninstall <version>      remove a version from nub's cache
  pin <version>            write the project's Node pin
```

Verified locally: `cargo build -p nub-cli --profile fast`, `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --check` (clean), scoped integration tests green; dev binary confirmed for `nub node`, `nub node -h`, `nub node which`. Adds one integration test (`bare_node_prints_status_then_help`).

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa