### PR TITLE
tests: command×flag conformance harness (full CLI surface, differential vs reference PM)

### DIFF
--- a/tests/conformance/cmdflag/README.md
+++ b/tests/conformance/cmdflag/README.md
@@ -1,0 +1,96 @@
+# Command×flag conformance harness
+
+Exercise nub's **full CLI command × flag surface** against a real project and
+assert each command behaves: exits cleanly where it should, fails *correctly*
+where it should, never leaks the `aube` brand, and — where parity is claimed —
+agrees with the reference package manager.
+
+This is a **different axis** from the lockfile harness one level up
+(`tests/conformance/run.sh`), which verifies lockfile round-trip fidelity. This
+one verifies that every wired verb + its major flags actually *run* in a real
+repo. It exists because shallow happy-path probing let `nub audit` ship a
+real-machine failure (it failed under a normal `~/.npmrc` carrying a custom
+`registry=`). The fix is a durable, exhaustive surface sweep run on a cadence.
+
+## Loop
+
+For a given nub binary + a real project fixture, the runner:
+
+1. Spins a hermetic sandbox `HOME` / `XDG_*` (the dev box's `~/.npmrc`, caches,
+   and stores never leak in or get clobbered).
+2. Optionally seeds `~/.npmrc` from `USER_NPMRC` — the real-world machine state
+   the harness must cover (a custom `registry=` is exactly what broke `audit`).
+3. Primes a read-only copy of the fixture with one `nub install` so query verbs
+   have a `node_modules` to read.
+4. Drives every cell in [`inventory.tsv`](inventory.tsv): runs `nub <args>` in
+   the right cwd, captures exit + output, classifies PASS / FAIL / RED(expected)
+   / XPASS-STALE, and sweeps the output for the `aube` brand.
+5. For `mut`/`net` cells (anything that writes the tree or hits the registry),
+   operates on a fresh **throwaway copy** so the fixture is never dirtied.
+
+## The inventory
+
+[`inventory.tsv`](inventory.tsv) is the canonical command×flag surface,
+enumerated authoritatively from `crates/nub-cli/src/cli.rs` (the clap `Command`
+enum + `NodeCommand`) and `crates/nub-cli/src/pm_engine/mod.rs` (`ENGINE_VERBS`,
+restricted to the WIRED match arms in each `*_family.rs`). Stubbed/unwired verbs
+are intentionally omitted — they error by design.
+
+Columns (TAB-separated): `id`, `kind`, `parity`, `args`.
+
+| kind | meaning |
+| --- | --- |
+| `meta` | version / help — no project needed |
+| `ro`   | read-only / idempotent — runs in the primed RO copy in place |
+| `mut`  | mutates the project — runner copies the fixture first |
+| `net`  | needs network / a registry account / a TTY — run only with `NET=1` |
+
+`parity` names the reference-PM verb to diff against (or `-`). With `REF=1` the
+runner also runs `<REFPM> <parity> <args>` on a fresh copy and records exit-code
+agreement (a coarse but high-signal check; deep output diffing is future work).
+
+## Usage
+
+```sh
+# build the dev nub first (see the nub-dev skill), then:
+tests/conformance/cmdflag/run.sh /path/to/nub /path/to/fixture-checkout
+
+# cover the real-world ~/.npmrc condition that broke audit:
+USER_NPMRC=/path/to/custom-registry.npmrc tests/conformance/cmdflag/run.sh nub fixture
+
+# include network cells + reference-PM parity diffing:
+NET=1 REF=1 REFPM=pnpm tests/conformance/cmdflag/run.sh nub fixture
+
+# one cell:
+tests/conformance/cmdflag/run.sh nub fixture audit
+```
+
+[`expectations.txt`](expectations.txt) is the known-failure red list: a listed
+cell is expected to fail and stays green overall; the moment it passes the
+harness flags `XPASS-STALE` so a fix can't land silently. Each entry should
+reference its tracking thread/issue.
+
+**Expectations are fixture-specific.** A cell that *correctly* exits non-zero on
+one fixture (e.g. `audit` → 1 because that tree has vulnerabilities; `add` → 1
+because a monorepo root refuses a bare add) may exit 0 on another. The current
+`expectations.txt` is tuned to **zod**. The fan-out's per-repo runs will each
+need their own expectations (or — the planned refinement — an `expect` column on
+`inventory.tsv` encoding `ok` / `nonzero-ok` / `run` semantics per cell, so the
+pass/fail rule is intrinsic and not fixture-tuned). For phase 1 the red list is
+the mechanism; the `expect`-column refinement is the follow-up.
+
+## Fixture set (for the L0 fan-out)
+
+The first sweep targets **zod** (single-package TS lib, pnpm). The diverse set
+for the broader fan-out spans three axes — PM/lockfile, project shape, and
+ecosystem — so the surface is exercised under every incumbent the PM mirrors.
+Candidate repos at pinned SHAs are listed in the parent thread; pick a few that
+together cover npm / pnpm / yarn-classic / yarn-berry / bun × single-pkg vs
+monorepo × lib vs app.
+
+## CI
+
+This is network-touching and slow, so it belongs on a **scheduled / opt-in CI
+leg**, not every-PR. The hermetic `meta`/`ro` core (no `NET`, no `REF`) is fast
+and offline-ish and could gate PRs against a committed fixture; the `net`/`REF`
+legs run on a cadence.

--- a/tests/conformance/cmdflag/expectations.txt
+++ b/tests/conformance/cmdflag/expectations.txt
@@ -1,0 +1,40 @@
+# Known-NON-ZERO / expected-red list for the command×flag conformance harness.
+#
+# Format:  <id>  <reason...>
+#
+# A cell listed here is EXPECTED to exit non-zero (or be a known leak) — the
+# harness reports it RED(expected) and stays green overall. The moment a listed
+# cell starts passing (exit 0, no leak), it's flagged XPASS-STALE and the run
+# FAILS, so a behavior change can't land silently. Delete the entry when the
+# cell's expected outcome changes.
+#
+# Two categories live here:
+#  (A) CORRECT non-zero — the command did its job; non-zero is the right answer
+#      (e.g. `audit` found vulnerabilities → exit 1, matching pnpm/npm). These
+#      are NOT bugs; the entry documents that the harness's bare "exit 0 = pass"
+#      rule doesn't apply to this cell. (Future: an `expect` column on the
+#      inventory will encode this directly; for phase 1 it lives here.)
+#  (B) REAL nub bugs found by the sweep — kept red until fixed, each referencing
+#      its tracking thread. When fixed, the cell goes green and the entry is
+#      deleted (XPASS-STALE forces that).
+#
+# ── (A) correct non-zero on the zod fixture (NOT bugs) ───────────────────────
+audit            vulnerabilities present in the tree → exit 1 (matches pnpm/npm)
+audit-json       same, --json
+audit-dev        same, --dev
+audit-level      same, --audit-level high
+outdated         outdated deps present → exit 1 (conventional)
+run-missing-script  missing script → exit 1 (correct; pnpm also errors WITHOUT --if-present)
+add-dep          monorepo root refuses bare add (needs -W) → exit 1 (correct guard)
+add-dev          same, -D
+remove-dep       removing an absent dep → non-zero (correct)
+update           trust-policy blocked a provenance-downgrade beta → exit 23 (protective refusal)
+import           pnpm-lock.yaml already present → exit 1 (correct; needs --force)
+install-prod     fixture `prepare` script needs husky (not installed) → exit 127-from-script (env, not nub)
+rebuild          same husky prepare-script env failure
+fetch            network-touching (net): linux-only optional dep tarball decode can flake over the network
+peers-check      exit 1 on UNPARSEABLE-ONLY peers (0 unmet/0 missing, 5 unparseable workspace link: peers). No reference-PM equivalent (peers is a nub/aube-native verb). DESIGN-DECISION item for triage: is "couldn't verify" → non-zero the right posture?
+#
+# ── (B) REAL nub findings on the zod sweep (recommend-only; own fix threads) ──
+run-ifpresent    BUG: `run <missing> --if-present` exits 1; pnpm/npm exit 0. parity divergence.
+agent-skill      BUG: `nub agent skill` output contains literal "aube" (brand leak in public agent copy).

--- a/tests/conformance/cmdflag/inventory.tsv
+++ b/tests/conformance/cmdflag/inventory.tsv
@@ -1,0 +1,100 @@
+# Canonical command×flag conformance inventory for nub's full CLI surface.
+#
+# One row = one command×flagset CELL the harness runs against a repo fixture.
+# Columns (TAB-separated):
+#
+#   id        unique slug for the cell (used in results + expectations.txt)
+#   kind      ro | mut | net | meta
+#               ro   = read-only / idempotent — runs in the fixture in place
+#               mut  = mutates the project (writes lockfile/node_modules/manifest)
+#                      — the runner copies the fixture to a throwaway dir first
+#               net  = needs the network / a registry account / a TTY — run only
+#                      when NET=1; otherwise skipped (recorded as SKIP-net)
+#               meta = global/version/help surface, no project needed
+#   parity    reference PM verb to diff against (pnpm verb), or "-" for none.
+#               When set + REF=1, the runner also runs `<refpm> <parity>` on the
+#               same input and records an exit-code agreement check.
+#   args      the argv passed to nub (after the binary). May be empty.
+#
+# The surface is enumerated authoritatively from crates/nub-cli/src/cli.rs
+# (the clap Command enum + NodeCommand) and crates/nub-cli/src/pm_engine/mod.rs
+# (ENGINE_VERBS, restricted to the WIRED match arms in each *_family.rs).
+# Stubbed/unwired verbs are NOT listed — they intentionally error.
+#
+# ── meta: version / help (no project) ───────────────────────────────────────
+version	meta	-	--version
+version-short	meta	-	-v
+help	meta	-	--help
+help-run	meta	-	help run
+help-cmd-install	meta	-	install --help
+help-cmd-add	meta	-	add --help
+help-cmd-audit	meta	-	audit --help
+help-cmd-run	meta	-	run --help
+help-cmd-list	meta	-	list --help
+
+# ── info family (read-only queries) ─────────────────────────────────────────
+list	ro	list	list
+list-recursive	ro	list	list -r
+ls-alias	ro	list	ls
+list-depth	ro	list	list --depth 0
+list-prod	ro	list	list --prod
+list-json	ro	list	list --json
+why-self	ro	-	why typescript
+outdated	net	outdated	outdated
+audit	net	audit	audit
+audit-json	net	audit	audit --json
+audit-dev	net	audit	audit --dev
+audit-level	net	audit	audit --audit-level high
+licenses	ro	-	licenses
+peers-check	ro	-	peers check
+check	ro	-	check
+bin	ro	-	bin
+root	ro	-	root
+query-all	ro	-	query "*"
+view-self	net	-	view typescript
+search	net	-	search left-pad
+deprecations	net	-	deprecations
+
+# ── store/config family ─────────────────────────────────────────────────────
+config-list	ro	-	config list
+config-get-registry	ro	-	config get registry
+store-status	ro	-	store status
+store-path	ro	-	store path
+cache-list-registries	ro	-	cache list-registries
+pkg-get-name	ro	-	pkg get name
+pkg-get-version	ro	-	pkg get version
+
+# ── run / exec / scripts ────────────────────────────────────────────────────
+run-bare	ro	-	run
+run-missing-script	ro	-	run __nub_conformance_no_such_script__
+run-ifpresent	ro	-	run __nub_conformance_no_such_script__ --if-present
+
+# ── pm subcommands ──────────────────────────────────────────────────────────
+pm-which	ro	-	pm which
+pm-cache	ro	-	pm cache
+
+# ── node version management ─────────────────────────────────────────────────
+node-ls	ro	-	node ls
+
+# ── agent onboarding (print-only) ───────────────────────────────────────────
+agent-skill	meta	-	agent skill
+agent-docs	meta	-	agent docs
+
+# ── install family (MUTATING — runner copies the fixture first) ──────────────
+install	mut	install	install
+install-frozen	mut	install	install --frozen-lockfile
+install-prod	mut	install	install --prod
+install-offline	mut	-	install --offline
+install-lockfile-only	mut	-	install --lockfile-only
+ci	mut	-	ci
+dedupe	mut	dedupe	dedupe
+fetch	net	-	fetch
+rebuild	mut	-	rebuild
+prune	mut	prune	prune
+
+# ── mutating add/remove (MUTATING + network) ────────────────────────────────
+add-dep	net	add	add left-pad
+add-dev	net	add	add -D left-pad
+remove-dep	net	remove	remove left-pad
+update	net	update	update
+import	mut	-	import

--- a/tests/conformance/cmdflag/run.sh
+++ b/tests/conformance/cmdflag/run.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Command×flag conformance harness — exercise nub's FULL CLI surface against a
+# REAL repo and assert each command behaves (exits cleanly where it should,
+# fails correctly where it should, and — where parity is claimed — agrees with
+# the reference package manager). This is the durable backstop for the gap that
+# let `nub audit` ship a real-machine failure: shallow happy-path probing.
+#
+# DISTINCT from the lockfile harness one level up (tests/conformance/run.sh),
+# which verifies LOCKFILE round-trip fidelity. This one verifies the COMMAND ×
+# FLAG surface — every wired verb + its major flags actually runs.
+#
+# See README.md for the loop; inventory.tsv for the canonical surface;
+# expectations.txt for the known-failure red list.
+#
+# Usage:   run.sh <path-to-nub> <fixture-dir> [id ...]
+#            <fixture-dir>  a real project checkout (has package.json). The
+#                           harness operates on COPIES — the fixture is never
+#                           dirtied.
+#            [id ...]       restrict to specific inventory ids (default: all).
+#
+# Env:
+#   REFPM=pnpm           reference PM for parity diffs (pnpm|npm|yarn|bun).
+#   REF=1                run the reference PM for parity-tagged cells + compare
+#                        exit-code agreement. Off by default (slow/network).
+#   NET=1                also run the `net` cells (registry/network/TTY). Off by
+#                        default so the core sweep is hermetic + offline-ish.
+#   USER_NPMRC=<file>    seed the sandbox HOME's ~/.npmrc from this file BEFORE
+#                        any cell runs — the real-world condition (a custom
+#                        `registry=`) that broke `nub audit`. Empty = clean.
+#   KEEP=1               keep the sandbox for forensics.
+#   SANDBOX_ROOT=<dir>   reuse/inspect a sandbox (implies KEEP).
+set -uo pipefail   # NOT -e: a failing cell is data, not a harness abort.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ $# -lt 2 ]; then
+  echo "usage: run.sh <path-to-nub> <fixture-dir> [id ...]" >&2
+  exit 2
+fi
+NUB="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+{ [ -x "$NUB" ] || ! [ -x "$NUB.exe" ]; } || NUB="$NUB.exe"
+[ -x "$NUB" ] || { echo "error: nub binary not executable: $NUB" >&2; exit 2; }
+FIXTURE="$(cd "$2" && pwd)"
+[ -f "$FIXTURE/package.json" ] || { echo "error: fixture has no package.json: $FIXTURE" >&2; exit 2; }
+shift 2
+ONLY=("$@")
+
+REFPM="${REFPM:-pnpm}"
+REF="${REF:-0}"
+NET="${NET:-0}"
+
+# Hermetic sandbox HOME so the dev box's ~/.npmrc / caches / stores don't leak
+# in or get clobbered. (Same discipline as tests/aube-conformance/run.sh.)
+CREATED_SANDBOX=0
+if [ -z "${SANDBOX_ROOT:-}" ]; then
+  SANDBOX_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/nub-cmdconf.XXXXXX")"
+  CREATED_SANDBOX=1
+fi
+mkdir -p "$SANDBOX_ROOT/home" "$SANDBOX_ROOT/runs" "$SANDBOX_ROOT/logs"
+export HOME="$SANDBOX_ROOT/home"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_STATE_HOME="$HOME/.local/state"
+mkdir -p "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_STATE_HOME"
+
+# Seed the user ~/.npmrc — the real-world config that broke `nub audit`. The
+# point of the harness is to cover REAL machine state, not a pristine void.
+if [ -n "${USER_NPMRC:-}" ]; then
+  [ -f "$USER_NPMRC" ] || { echo "error: USER_NPMRC not a file: $USER_NPMRC" >&2; exit 2; }
+  cp "$USER_NPMRC" "$HOME/.npmrc"
+  echo "seeded ~/.npmrc from $USER_NPMRC:"
+  sed 's/^/    | /' "$HOME/.npmrc"
+fi
+
+echo "== nub command×flag conformance =="
+echo "nub:      $NUB ($("$NUB" --version 2>/dev/null || echo '?'))"
+echo "node:     $(node --version 2>/dev/null || echo MISSING)"
+echo "fixture:  $FIXTURE"
+echo "refpm:    $REFPM (parity diff: $([ "$REF" = 1 ] && echo on || echo off))"
+echo "net:      $([ "$NET" = 1 ] && echo on || echo off)"
+echo "sandbox:  $SANDBOX_ROOT"
+echo
+
+# A pristine copy for read-only cells, primed with one `install` so queries have
+# a node_modules to read. mut/net cells each get their own throwaway copy.
+RO_PROJ="$SANDBOX_ROOT/runs/_ro"
+rm -rf "$RO_PROJ"; mkdir -p "$RO_PROJ"
+cp -R "$FIXTURE/." "$RO_PROJ/"
+if [ "${PRIME_RO:-1}" = 1 ]; then
+  echo "priming RO copy: nub install (so read-only queries have a node_modules)…"
+  (cd "$RO_PROJ" && "$NUB" install) >"$SANDBOX_ROOT/logs/_ro-prime.log" 2>&1 \
+    && echo "  prime OK" || echo "  prime FAILED (read-only cells may degrade) — see logs/_ro-prime.log"
+fi
+
+expected_reason() {
+  awk -v id="$1" '$1==id { $1=""; sub(/^[ \t]*/,""); print; exit }' \
+    "$HERE/expectations.txt" 2>/dev/null
+}
+
+RESULTS=()
+FAILS=0; XPASSES=0
+run_cell() {
+  local id="$1" kind="$2" parity="$3"; shift 3
+  local -a cell_args=("$@")
+  local log="$SANDBOX_ROOT/logs/$id.log"
+
+  if [ "$kind" = net ] && [ "$NET" != 1 ]; then
+    RESULTS+=("$id|SKIP-net|(NET=1 to run)"); echo "--- $id  SKIP-net"; return
+  fi
+
+  local proj
+  case "$kind" in
+    meta) proj="$SANDBOX_ROOT" ;;
+    mut|net)
+      proj="$SANDBOX_ROOT/runs/$id"
+      rm -rf "$proj"; mkdir -p "$proj"; cp -R "$FIXTURE/." "$proj/" ;;
+    ro|*) proj="$RO_PROJ" ;;
+  esac
+
+  echo "--- $id  ($kind)  \$ nub ${cell_args[*]}"
+  { echo "### nub ${cell_args[*]}   (cwd=$proj, kind=$kind)"; } >"$log"
+  local code=0
+  (cd "$proj" && "$NUB" "${cell_args[@]}") >>"$log" 2>&1 || code=$?
+  echo "### exit=$code" >>"$log"
+
+  local leak=""
+  grep -qiE '\baube\b' "$log" && leak=" [BRAND-LEAK:aube]"
+
+  local parity_note=""
+  if [ "$REF" = 1 ] && [ "$parity" != "-" ]; then
+    local refproj="$SANDBOX_ROOT/runs/${id}__ref"
+    rm -rf "$refproj"; mkdir -p "$refproj"; cp -R "$FIXTURE/." "$refproj/"
+    local refcode=0
+    (cd "$refproj" && "$REFPM" "$parity" "${cell_args[@]:1}") >"$log.ref" 2>&1 || refcode=$?
+    echo "### refpm($REFPM $parity) exit=$refcode" >>"$log"
+    if { [ "$code" = 0 ] && [ "$refcode" = 0 ]; } || { [ "$code" != 0 ] && [ "$refcode" != 0 ]; }; then
+      parity_note=" parity:agree($code/$refcode)"
+    else
+      parity_note=" parity:DIVERGE(nub=$code ref=$refcode)"
+    fi
+  fi
+
+  local reason; reason="$(expected_reason "$id")"
+  local status
+  if [ "$code" = 0 ] && [ -z "$leak" ]; then
+    if [ -n "$reason" ]; then status="XPASS-STALE"; XPASSES=$((XPASSES+1));
+      echo "    XPASS: now passes — delete its expectations.txt entry: $reason"
+    else status="PASS"; fi
+  else
+    if [ -n "$reason" ]; then status="RED(expected)"; echo "    expected red: $reason";
+    else status="FAIL"; FAILS=$((FAILS+1));
+      echo "    FAIL (exit=$code$leak) — log: $log"; tail -n 12 "$log" | sed 's/^/    | /'; fi
+  fi
+  RESULTS+=("$id|$status$leak$parity_note|exit=$code")
+}
+
+want_id() {
+  [ ${#ONLY[@]} -eq 0 ] && return 0
+  local x; for x in "${ONLY[@]}"; do [ "$x" = "$1" ] && return 0; done; return 1
+}
+
+while IFS=$'\t' read -r id kind parity args; do
+  [ -z "$id" ] && continue
+  case "$id" in \#*) continue ;; esac
+  want_id "$id" || continue
+  # shellcheck disable=SC2206
+  read -r -a argv <<<"$args"
+  run_cell "$id" "$kind" "$parity" "${argv[@]}"
+done < <(grep -vE '^[[:space:]]*(#|$)' "$HERE/inventory.tsv")
+
+echo
+echo "== results =="
+printf '%-22s %-34s %s\n' "id" "status" "detail"
+for row in "${RESULTS[@]}"; do
+  IFS='|' read -r i s d <<<"$row"
+  printf '%-22s %-34s %s\n' "$i" "$s" "$d"
+done
+echo
+
+if [ "$FAILS" -gt 0 ] || [ "$XPASSES" -gt 0 ]; then
+  echo "RESULT: FAIL ($FAILS unexpected, $XPASSES stale expected-failure entries)"
+  echo "sandbox kept for forensics: $SANDBOX_ROOT"
+  exit 1
+fi
+echo "RESULT: OK"
+if [ "$CREATED_SANDBOX" = 1 ] && [ "${KEEP:-0}" != 1 ]; then rm -rf "$SANDBOX_ROOT";
+else echo "sandbox kept: $SANDBOX_ROOT"; fi


### PR DESCRIPTION
## What

A durable, data-driven harness that exercises nub's **full command × flag surface** against a real project and asserts each command behaves — exits cleanly where it should, fails *correctly* where it should, never leaks the embedded-engine brand, and (where parity is claimed) agrees with the reference package manager.

Lands under `tests/conformance/cmdflag/` (a sibling to the existing lockfile-conformance harness, which verifies round-trip fidelity — a different axis). This one verifies that every wired verb + its major flags actually *runs* in a real repo.

## Why

Shallow happy-path probing let a real-machine `nub audit` failure ship. The fix is a committed, exhaustive surface sweep run on a cadence — the differential-fixture methodology at scale.

## Contents

- `inventory.tsv` — 60 cells, enumerated authoritatively from `crates/nub-cli/src/cli.rs` (the clap `Command` enum + `NodeCommand`) and `crates/nub-cli/src/pm_engine/mod.rs` (`ENGINE_VERBS`, restricted to the WIRED match arms in each `*_family.rs`). Stubbed verbs are intentionally omitted.
- `run.sh` — hermetic runner: sandbox `HOME`/`XDG_*`, `USER_NPMRC` seed (covers the custom `registry=` ~/.npmrc condition), an `nub install`-primed read-only copy for query verbs, fresh throwaway copies for `mut`/`net` cells so the fixture is never dirtied, a reference-PM parity hook (`REF=1`), and an `aube` brand-leak canary.
- `expectations.txt` — fixture-tuned known-non-zero / red list; an `XPASS-STALE` flag forces it to shrink when a cell's outcome changes.
- `README.md` — the loop, the inventory schema, the diverse repo fixture-set plan for the fan-out.

## Verification

- No-NET deterministic core sweep on a fresh **zod** clone (`@912f0f51`, pnpm-10 workspace monorepo): **RESULT: OK** (green).
- Full `NET=1` sweep with a custom-registry `~/.npmrc` surfaced two real nub findings (triaged separately, not fixed here — recommend-only):
  - `run <missing> --if-present` exits 1; pnpm/npm exit 0 (parity divergence).
  - `nub agent skill` output contains the literal string "aube" (brand leak in public agent-facing copy).
- No Rust changes — test tooling only.

Refs the conformance-matrix effort.