### PR TITLE
fix(agent): remove embedded-engine brand leak from `nub agent skill` copy

### DIFF
--- a/crates/nub-cli/src/agent/mod.rs
+++ b/crates/nub-cli/src/agent/mod.rs
@@ -254,6 +254,14 @@ mod tests {
                 "evergreen skill must point the agent at `{pointer}`"
             );
         }
+        // Brand boundary: the agent-facing skill is PUBLIC copy a user's coding
+        // agent reads. The embedded PM engine's brand ("aube") is internal
+        // mechanism and must never surface here (the engine is an invisible
+        // implementation detail under nub).
+        assert!(
+            !body.to_lowercase().contains("aube"),
+            "agent skill copy must not leak the embedded engine brand 'aube'"
+        );
     }
 
     #[test]

--- a/site/public/skill.md
+++ b/site/public/skill.md
@@ -54,7 +54,7 @@ Restart-on-change driven by the actual resolved dependency graph plus `.env*`, `
 
 ## Package manager — `nub install` / `nub add`
 
-A full package manager (embedded aube engine), **pnpm-shaped CLI** regardless of the project's incumbent. It is **lockfile-compatible with whatever the project already uses** — it infers the incumbent PM (from `packageManager`/`devEngines`/lockfile) and reads+writes that PM's native lockfile, never imposing its own:
+A full package manager, **pnpm-shaped CLI** regardless of the project's incumbent. It is **lockfile-compatible with whatever the project already uses** — it infers the incumbent PM (from `packageManager`/`devEngines`/lockfile) and reads+writes that PM's native lockfile, never imposing its own:
 
 - **pnpm / npm / Bun** round-trip in place (`pnpm-lock.yaml`, `package-lock.json` v2/v3, `bun.lock`).
 - **Yarn** is **read-only** — nub installs/runs a Yarn project but refuses any command that would rewrite `yarn.lock` (use `yarn` for those).


### PR DESCRIPTION
`nub agent skill` prints the evergreen agent onboarding skill (from `site/public/skill.md`, also served at https://nubjs.com/skill.md, embedded into the binary via `include_str!`). The copy described the package manager as the "embedded aube engine" — but that output is **public, agent-facing onboarding text** a user's coding agent reads. The embedded PM engine's brand is internal mechanism and must never surface on a public surface (the engine is an invisible implementation detail under nub).

## Change
- Drop the `(embedded aube engine)` parenthetical in `site/public/skill.md` → now reads "A full package manager, **pnpm-shaped CLI** …".
- Add a regression test asserting the skill body never contains "aube".

## Verification
- `nub agent skill | grep -i aube` → no matches (was 1 before).
- `cargo test -p nub-cli --bin nub skill_verb` → pass (new brand-leak assertion).
- `cargo fmt --check` + `cargo clippy --all-targets --all-features -- -D warnings` → clean.

Refs the command-conformance-matrix sweep (zod-sweep finding #2).

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa