### PR TITLE
fix(pm): clear conformance-sweep bugs (brand leak, lockfile-name hint, pm which bun)

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -5324,6 +5324,34 @@ fn run_pm(args: &[String]) -> Result<i32> {
                 eprintln!("» this project uses nub (resolved from packageManager)");
                 return Ok(0);
             }
+            // A project may DECLARE a manager nub doesn't provision (bun — and
+            // any name outside nub's provisioning scope). The install path
+            // honors the declared identity (`declared_pm_raw`); `which` must
+            // agree rather than mislabel a genuinely-pinned project as
+            // "unpinned". `resolve_target_with_source` returns None for such a
+            // pin (it only resolves provisionable targets), so consult the
+            // name-level identity probe before falling through to the
+            // no-pin diagnosis. Berry (committed yarnPath / pinned yarn) and
+            // every provisionable PM still resolve below — this branch fires
+            // only for a declared-but-unprovisionable identity.
+            if let Some(id) = resolve::project_pm_identity(&cwd) {
+                if resolve::resolve_target_with_source(&cwd).is_none() && !id.berry {
+                    let (_, version) =
+                        resolve::declared_pm_raw(&cwd).unwrap_or_else(|| (id.name.clone(), None));
+                    println!("{}", id.name);
+                    std::io::stdout().flush().ok();
+                    let pin = match &version {
+                        Some(v) => format!("{}@{v}", id.name),
+                        None => id.name.clone(),
+                    };
+                    eprintln!(
+                        "» this project is pinned to {pin} (resolved from packageManager) — \
+                         nub doesn't provision {}, run it with its own installer",
+                        id.name
+                    );
+                    return Ok(0);
+                }
+            }
             let res = resolve::resolve_target_with_source(&cwd)
                 .context("no package manager is pinned (no .yarnrc.yml yarnPath, packageManager, or devEngines.packageManager) — declare one with `nub pm use <pm>`")?;
             // Drain the structured advisories first (disagreement / range /
@@ -7995,6 +8023,35 @@ mod tests {
         std::fs::remove_dir_all(&pm).unwrap();
         assert!(!pm.exists(), "the pm cache dir is gone after clear");
         assert!(node.exists(), "the sibling node/ store must be untouched");
+    }
+
+    #[test]
+    fn which_honors_a_declared_unprovisionable_pm() {
+        // A `packageManager: "bun@x"` pin is a genuine identity nub doesn't
+        // provision — `resolve_target_with_source` returns None for it, so the
+        // old `which` path mislabeled the project "no PM pinned". The install
+        // path already honors the declared identity; `which` must agree. It
+        // reports bun (exit 0), not the no-pin error.
+        let dir = pm_tmpdir("which-bun");
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"app","packageManager":"bun@1.2.20"}"#,
+        )
+        .unwrap();
+        // The identity probe sees bun; the provisioning resolver does not — the
+        // exact gap the `which` branch bridges.
+        let id = nub_core::pm::resolve::project_pm_identity(&dir).expect("bun identity");
+        assert_eq!(id.name, "bun");
+        assert!(!id.berry);
+        assert!(
+            nub_core::pm::resolve::resolve_target_with_source(&dir).is_none(),
+            "bun is unprovisionable, so the target resolver yields None"
+        );
+        let code = with_cwd(&dir, || run_pm(&["which".into()])).expect("which must not error");
+        assert_eq!(
+            code, 0,
+            "a declared bun pin reports bun (exit 0), not an error"
+        );
     }
 
     #[test]

--- a/crates/nub-cli/src/pm_engine/present.rs
+++ b/crates/nub-cli/src/pm_engine/present.rs
@@ -173,10 +173,33 @@ pub(crate) fn rewrite_help(text: impl AsRef<str>) -> String {
     rewrite(&text)
 }
 
-/// The brand rewrite. Order matters: codes first (so the `AUBE` inside
-/// `ERR_AUBE_*` never reaches the word pass), then per-line URL stripping,
-/// then the word-boundary `aube` → `nub` pass.
+/// Runtime hint-context corrections nub applies on top of the brand rewrite.
+/// These are NOT brand leaks (the branded workspace/lockfile-name leaks are
+/// fixed at the engine source via the embedder seam — `aube_util::
+/// workspace_markers()` / `lockfile_basename()` — so they never reach this
+/// layer, and would be split mid-token by miette's line-wrapping anyway).
+/// They are messages that are brand-clean but factually misleading for nub:
+///
+/// - The frozen-install / `nub ci` missing-lockfile hint names a single
+///   lockfile to commit (`pnpm-lock.yaml`), but which file a fresh
+///   `nub install` writes is context-dependent (`lock.yaml` for a truly-fresh
+///   project, `pnpm-lock.yaml` otherwise), so naming one is misleading.
+///   Neutralized to "a lockfile" — a nub-only correction (standalone aube's
+///   `pnpm-lock.yaml` hint is correct for it, so this stays out of the fork).
+const RUNTIME_HINT_VOCAB: &[(&str, &str)] = &[(
+    "commit pnpm-lock.yaml to your repository",
+    "commit a lockfile to your repository",
+)];
+
+/// The brand rewrite. Order matters: the runtime-hint corrections first (a
+/// plain phrase substitution before any brand pass touches the text), then
+/// codes (so the `AUBE` inside `ERR_AUBE_*` never reaches the word pass), then
+/// per-line URL stripping, then the word-boundary `aube` → `nub` pass.
 pub(crate) fn rewrite(text: &str) -> String {
+    let mut text = text.to_string();
+    for (from, to) in RUNTIME_HINT_VOCAB {
+        text = text.replace(from, to);
+    }
     let text = text
         .replace("ERR_AUBE_", "ERR_NUB_")
         .replace("WARN_AUBE_", "WARN_NUB_")
@@ -406,6 +429,29 @@ mod tests {
             !out.contains("  "),
             "no double-space gap left behind: {out}"
         );
+    }
+
+    #[test]
+    fn neutralizes_misleading_frozen_lockfile_name() {
+        // The `nub ci` / `--frozen-lockfile` missing-lockfile hint names a
+        // single lockfile to commit, but a fresh `nub install` may write
+        // `lock.yaml` (truly-fresh) rather than `pnpm-lock.yaml` — so the
+        // specific name is misleading. The corrected hint names no specific
+        // file.
+        let msg = "no lockfile found and --frozen-lockfile is set\n\
+                   help: commit pnpm-lock.yaml to your repository, or run \
+                   `aube install --no-frozen-lockfile` to generate one";
+        let out = rewrite(msg);
+        assert!(
+            out.contains("commit a lockfile to your repository"),
+            "the misleading specific lockfile name must be neutralized: {out}"
+        );
+        assert!(
+            !out.contains("commit pnpm-lock.yaml"),
+            "the specific (misleading) lockfile name must not survive: {out}"
+        );
+        // The actionable verb spelling still rebrands and survives.
+        assert!(out.contains("`nub install --no-frozen-lockfile`"), "{out}");
     }
 
     #[test]

--- a/crates/nub-cli/tests/info_engine.rs
+++ b/crates/nub-cli/tests/info_engine.rs
@@ -180,6 +180,43 @@ fn missing_lockfile_reports_the_nub_install_hint_and_exits_zero() {
     assert_no_engine_branding(&[("stdout", &stdout), ("stderr", &stderr)]);
 }
 
+/// The `--filter requires a workspace root (…)` error names the workspace
+/// markers the engine looks for. The engine's own phrasing lists
+/// `aube-workspace.yaml` — a brand leak in nub's public output (the
+/// conformance sweep hit it on `nub list -r` across 5/6 fixtures). nub's
+/// embedder has no branded workspace yaml, so the error must name only
+/// `pnpm-workspace.yaml`, with zero `aube` on either stream. Exercised across
+/// the verbs that share the workspace-root resolver (list/why).
+#[test]
+fn filter_workspace_root_error_is_brand_clean() {
+    let dir = pm_tmpdir("filter-nonws");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"app","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    // A lockfile so the no-lockfile pre-flight doesn't short-circuit before the
+    // --filter workspace-root check fires.
+    std::fs::write(
+        dir.join("pnpm-lock.yaml"),
+        "lockfileVersion: '9.0'\n\nimporters:\n  .:\n    dependencies: {}\n",
+    )
+    .unwrap();
+
+    for verb in [
+        vec!["list", "--filter", "foo"],
+        vec!["list", "-r", "--filter", "foo"],
+        vec!["why", "react", "--filter", "foo"],
+    ] {
+        let (stdout, stderr, _code) = run_nub(&dir, &verb);
+        assert!(
+            stderr.contains("pnpm-workspace.yaml"),
+            "{verb:?} must name pnpm-workspace.yaml as the workspace marker: {stderr}"
+        );
+        assert_no_engine_branding(&[("stdout", &stdout), ("stderr", &stderr)]);
+    }
+}
+
 /// `--json` must ALWAYS emit parseable JSON on stdout — never empty-stdout +
 /// a prose stderr note — in the never-installed (no-lockfile) state, so
 /// `nub list --json | jq` / `nub outdated --json | jq` behave like pnpm's,


### PR DESCRIPTION
Three clear, no-posture-change bugs surfaced by the command×flag conformance sweep. Each is unambiguous (a brand-boundary violation in public output, a misleading message, or a detection gap that contradicts nub's own working install path).

## Fixes

**1. Brand leak in workspace-root errors (highest priority).** `nub list -r` / `nub list --filter` / `nub why --filter` named `aube-workspace.yaml` in their `--filter requires a workspace root (…)` error (hit on 5/6 sweep fixtures), and `doctor`'s fresh-lockfile hint named `aube-lock.yaml` — both AGENTS.md public brand-boundary violations. Fixed at the engine source via two new embedder source-branding helpers in `aube_util` (`workspace_markers()` / `lockfile_basename()`, alongside the existing `prog()`/`cmd()`), bumping the `vendor/aube` pin. nub's embedder has no branded workspace yaml, so the error now names only `pnpm-workspace.yaml` with zero engine branding on either stream. Default-preserving: under the standalone `AUBE` profile the strings are byte-for-byte unchanged. (The present.rs `rewrite()` layer could not catch these — miette line-wrapping splits the names mid-token — so the source/embedder layer is the correct, comprehensive fix.)

**2. Misleading lockfile name.** `nub install --frozen-lockfile` / `nub ci` said "commit pnpm-lock.yaml to your repository", but a fresh `nub install` may write `lock.yaml` (a truly-fresh project) rather than `pnpm-lock.yaml`. Neutralized to "commit a lockfile" in `present.rs` — a nub-only correction (standalone aube's `pnpm-lock.yaml` hint is correct for it, so this stays out of the fork).

**3. `pm which` ignored a declared-but-unprovisionable PM.** On a bun project (`packageManager: "bun@1.2.20"`), `nub install` honors the declared identity but `nub pm which` reported "no package manager is pinned" — because the target resolver only yields *provisionable* targets and bun isn't one. `pm which` now consults the name-level identity probe (the same one the install path uses) and reports bun (exit 0) with provenance, before falling through to the no-pin diagnosis.

## Before / after

```
# FIX 1 — nub list --filter foo  (non-workspace project)
- × nub list: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or …)
+ × nub list: --filter requires a workspace root (`pnpm-workspace.yaml`, or …)

# FIX 2 — nub ci  (no lockfile)
- help: commit pnpm-lock.yaml to your repository, or run `nub install --no-frozen-lockfile` …
+ help: commit a lockfile to your repository, or run `nub install --no-frozen-lockfile` …

# FIX 3 — nub pm which  (packageManager: bun@1.2.20)
- Error: no package manager is pinned …
+ bun
+ » this project is pinned to bun@1.2.20 (resolved from packageManager) — nub doesn't provision bun, run it with its own installer
```

A broad canary across list / list -r / list --filter / why / why --filter / ls / ll / ci / install --frozen-lockfile / outdated / doctor shows zero `aube` leaks.

## Tests

- `info_engine::filter_workspace_root_error_is_brand_clean` — list/why `--filter` workspace-root error names `pnpm-workspace.yaml`, zero engine branding.
- `cli::which_honors_a_declared_unprovisionable_pm` — a declared bun pin reports bun (exit 0), not the no-pin error.
- `present::neutralizes_misleading_frozen_lockfile_name` — the frozen hint drops the specific lockfile name.
- `aube_util::identity::workspace_markers_and_lockfile_basename_under_default_profile` — default-preserving contract for the new helpers.

## Engine fork

aube-fork commit `a018c88` (pushed to `nubjs/aube:nub-fork`); the additive embedder helpers are upstreamable (no-op for standalone aube). Pin bumped `3778dc8 → a018c88`.

Local gates green: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and the affected test suites (info_engine, pm_verbs, pm_identity, aube-util). Five pre-existing `add_supply_chain` aube test failures are unrelated (fail on the clean pin too).

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa