### PR TITLE
test(aube-bats): skip stale workspace-marker assertion after #77 brand fix

### DIFF
--- a/tests/aube-bats/skips.txt
+++ b/tests/aube-bats/skips.txt
@@ -37,6 +37,7 @@ install.bats|aube run auto-reinstalls after --prod install|'run' is nub's native
 install.bats|aube run auto-installs when installed package metadata is missing|'run' is nub's native script runner (collision policy); also walks node_modules/.aube
 install.bats|aube install ignores --network-concurrency=0 and falls back to default|test invokes 'aube -v' — nub's -v is --version (reserved); re-evaluate when the flag wiring lands
 add.bats|aube add: refuses to add to workspace root with aube-workspace.yaml|nub-divergence: aube-workspace.yaml is not consulted (workspace-yaml toggle restricts discovery to pnpm-workspace.yaml), so it cannot define a workspace root — the pnpm-workspace.yaml variant asserts the guard
+add.bats|aube add -w: errors outside a workspace|engine emits pnpm-workspace.yaml (brand-clean via workspace_markers(), PR #77); upstream test asserts aube-workspace.yaml
 
 # ── pnpm-parity divergences (decision C: nub extends aube's behavior to match pnpm) ──
 add.bats|aube add --save-peer writes only peerDependencies and does not install|nub dual-writes --save-peer to devDependencies+peerDependencies for pnpm parity (decision C); aube asserts peerDependencies-only


### PR DESCRIPTION
## Summary

- PR #77 fixed a brand leak in the aube engine: workspace-root error messages now emit `pnpm-workspace.yaml` (via the new `workspace_markers()` embedder API) instead of `aube-workspace.yaml`.
- The upstream bats test `"aube add -w: errors outside a workspace"` (`add.bats:538`) still asserts the old `aube-workspace.yaml` string — it was written against aube's own branding and is now stale.
- Adds one entry to `tests/aube-bats/skips.txt` as a permanent intended divergence: the brand-clean output is the correct nub behavior; the upstream test reflects aube's internal naming.

No other `assert_output` assertions in the run.sh suites (install/ci/add/remove/update/lockfile_settings/lockfile_dir) reference `aube-workspace.yaml` or `aube-lock.yaml` in output assertions (file-existence checks like `assert_file_exists aube-lock.yaml` are unchanged — those check for a file on disk, not engine output).

Closes: red CI from `a71bfd6` (#77 follow-up)

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa