### PR TITLE
fix(pm): bun.lock writer byte-identity — multi-line named catalogs + collapse empty packages

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/bun/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/tests.rs
@@ -565,14 +565,11 @@ fn test_write_byte_identical_to_native_bun() {
 /// top-level metadata blocks, so a wrong block order slipped through.
 ///
 /// Scope note: this asserts byte-identity for the four blocks bun and
-/// nub render identically. Named `catalogs` (object-of-objects) and an
-/// EMPTY `packages` block are deliberately excluded — nub currently
-/// renders a named catalog's inner object inline (bun renders it
-/// multi-line) and emits `"packages": {\n  }` for empty (bun emits
-/// `{}`). Those two rendering drifts are real but out of this lane's
-/// scope (B-7 is block *order*, not these renderings); they're tracked
-/// as follow-ups. `catalogs` ordering/preservation is still covered
-/// below by a parse round-trip.
+/// nub render identically (block *order* — B-7). The named-`catalogs`
+/// multi-line render and the empty-`packages` collapse are their own
+/// rendering concerns, covered by the two byte-identity tests below
+/// (`test_write_byte_identical_named_catalogs_multiline` and
+/// `test_write_byte_identical_empty_packages_collapses`).
 #[test]
 fn test_write_byte_identical_top_level_block_order() {
     let tmp = tempfile::NamedTempFile::new().unwrap();
@@ -650,6 +647,87 @@ fn test_write_byte_identical_top_level_block_order() {
     assert_eq!(
         reparsed.catalogs["evens"]["date-fns"].specifier, "^2.30.0",
         "named catalogs must survive a write→reparse round-trip"
+    );
+}
+
+/// R-1: a named `catalogs` block must render byte-identically to bun's
+/// native writer — the inner per-catalog object is MULTI-LINE (one dep
+/// per indented line, trailing comma on each, including the last), not
+/// nub's earlier inline `{ "k": v }` form. bun's writer
+/// (`bun.lock.zig`) emits the catalog name, then each dep on its own
+/// 6-space-indented line, then a 4-space-dedented `},`, then the outer
+/// 2-space `},`. Any lockfile carrying named catalogs would otherwise
+/// round-trip to a byte sequence bun never produces (a gratuitous diff
+/// against `bun install`'s own output).
+#[test]
+fn test_write_byte_identical_named_catalogs_multiline() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    // Hand-authored in bun 1.3.x's exact JSONC style. Two deps in the
+    // named catalog so the multi-line, one-per-line rendering (and the
+    // trailing comma on the last dep) is exercised.
+    let original = r#"{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "root",
+    },
+  },
+  "catalogs": {
+    "evens": {
+      "date-fns": "^2.30.0",
+      "lodash": "^4.17.21",
+    },
+  },
+  "packages": {}
+}
+"#;
+    std::fs::write(tmp.path(), original).unwrap();
+    let graph = parse(tmp.path()).unwrap();
+    let manifest = aube_manifest::PackageJson {
+        name: Some("root".to_string()),
+        ..Default::default()
+    };
+    let out = tempfile::NamedTempFile::new().unwrap();
+    write(out.path(), &graph, &manifest).unwrap();
+    let written = std::fs::read_to_string(out.path()).unwrap();
+    assert_eq!(
+        written, original,
+        "named-catalogs block must render multi-line, byte-identical to bun"
+    );
+}
+
+/// R-2: an EMPTY `packages` block must collapse to `"packages": {}` on
+/// a single line, matching bun's writer (which emits `"packages": {`
+/// then a bare closing `}` via its `first` guard when no entries are
+/// written) — never nub's earlier multi-line `"packages": {\n  }`. A
+/// dependency-free root is the canonical trigger.
+#[test]
+fn test_write_byte_identical_empty_packages_collapses() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let original = r#"{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "root",
+    },
+  },
+  "packages": {}
+}
+"#;
+    std::fs::write(tmp.path(), original).unwrap();
+    let graph = parse(tmp.path()).unwrap();
+    let manifest = aube_manifest::PackageJson {
+        name: Some("root".to_string()),
+        ..Default::default()
+    };
+    let out = tempfile::NamedTempFile::new().unwrap();
+    write(out.path(), &graph, &manifest).unwrap();
+    let written = std::fs::read_to_string(out.path()).unwrap();
+    assert_eq!(
+        written, original,
+        "empty packages block must collapse to `{{}}`, byte-identical to bun"
     );
 }
 

--- a/vendor/aube/crates/aube-lockfile/src/bun/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/write.rs
@@ -756,6 +756,42 @@ fn format_bun_lockfile(
     for (k, v) in top_level_extras {
         let key_str = serde_json::to_string(k).unwrap();
         match v {
+            // `catalogs` is an object-of-objects: each named catalog's
+            // inner map is rendered MULTI-LINE (one dep per line),
+            // matching bun's writer (`bun.lock.zig` emits the catalog
+            // name, then each dep on its own indented line, then a
+            // dedented `},`). The generic object arm below renders inner
+            // objects via `inline_json` (single line), which is correct
+            // for `overrides`/`catalog` but drifts from bun for the
+            // nested `catalogs` block. Special-case the extra level here.
+            serde_json::Value::Object(map) if k == "catalogs" && !map.is_empty() => {
+                out.push_str(&format!("  {key_str}: {{\n"));
+                for (catalog_name, catalog_val) in map {
+                    let name_str = serde_json::to_string(catalog_name).unwrap();
+                    match catalog_val {
+                        serde_json::Value::Object(inner) if !inner.is_empty() => {
+                            out.push_str(&format!("    {name_str}: {{\n"));
+                            for (dk, dv) in inner {
+                                out.push_str(&format!(
+                                    "      {}: {},\n",
+                                    serde_json::to_string(dk).unwrap(),
+                                    inline_json(dv, 0)
+                                ));
+                            }
+                            out.push_str("    },\n");
+                        }
+                        // An empty named catalog collapses inline, mirroring
+                        // bun's empty-object rendering elsewhere.
+                        _ => {
+                            out.push_str(&format!(
+                                "    {name_str}: {},\n",
+                                inline_json(catalog_val, 0)
+                            ));
+                        }
+                    }
+                }
+                out.push_str("  },\n");
+            }
             serde_json::Value::Object(map) if !map.is_empty() => {
                 out.push_str(&format!("  {key_str}: {{\n"));
                 for (dk, dv) in map {
@@ -777,18 +813,28 @@ fn format_bun_lockfile(
     // entries with a blank line (an empty line between every
     // consecutive pair). `packages:` is bun's last top-level field and
     // gets no trailing comma on its closing brace.
-    out.push_str("  \"packages\": {\n");
-    for (i, (key, entry)) in package_entries.iter().enumerate() {
-        if i > 0 {
-            out.push('\n');
+    //
+    // An EMPTY packages block collapses to `"packages": {}` on a single
+    // line — bun's writer emits `"packages": {` then closes with a bare
+    // `}` when no entries were written (`bun.lock.zig`'s `first` guard),
+    // never the multi-line `{\n  }` form. A dependency-free root would
+    // otherwise round-trip to a byte sequence bun never produces.
+    if package_entries.is_empty() {
+        out.push_str("  \"packages\": {}\n");
+    } else {
+        out.push_str("  \"packages\": {\n");
+        for (i, (key, entry)) in package_entries.iter().enumerate() {
+            if i > 0 {
+                out.push('\n');
+            }
+            out.push_str(&format!(
+                "    {}: {},\n",
+                serde_json::to_string(key).unwrap(),
+                inline_json(entry, 0)
+            ));
         }
-        out.push_str(&format!(
-            "    {}: {},\n",
-            serde_json::to_string(key).unwrap(),
-            inline_json(entry, 0)
-        ));
+        out.push_str("  }\n");
     }
-    out.push_str("  }\n");
     out.push_str("}\n");
     out
 }


### PR DESCRIPTION
Two pure-rendering drifts in the bun.lock writer (`format_bun_lockfile`, `vendor/aube/crates/aube-lockfile/src/bun/write.rs`) diverged from bun's native output. In both cases the data round-trips correctly through parse; only the emitted bytes differed from what `bun install` would produce — a gratuitous diff against bun's own lockfile.

- **R-1 — named `catalogs` rendered inline.** The per-catalog inner object was emitted as `{ "k": v }`. bun renders it multi-line — one dep per indented line with a trailing comma (`.repos/bun/src/install/lockfile/bun.lock.zig:349-380`).
- **R-2 — empty `packages` block.** Was emitted as `"packages": {\n  }`. bun collapses an empty block to `"packages": {}` via its `first` guard (`bun.lock.zig:388,675-682`). A dependency-free root triggered this.

Adds two byte-identity regression tests (`test_write_byte_identical_named_catalogs_multiline`, `test_write_byte_identical_empty_packages_collapses`) that parse a hand-authored bun.lock and assert the re-written bytes are identical to bun's form.

Re-lands aube fork commit `b4d0dc0` (nubjs/aube `nub-fork-bunlock-r1r2`) in the new plain-vendored aube model — an ordinary nub PR touching `vendor/aube/**`, no submodule / pin bump. The old fork branch is now historical.

## Verification
- `cargo test -p aube-lockfile` (from `vendor/aube`): 419 unit tests + proptest round-trips pass, including both new byte-identity tests.
- `cargo clippy -p aube-lockfile --all-targets --all-features -- -D warnings`: clean.
- `rustfmt --edition 2024 --check` on the two changed files: clean.
- `cargo check -p nub-cli` (nub workspace, aube as path dep): builds.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa