### PR TITLE
test(pm): isolate HOME in aube-registry config tests so a host ~/.npmrc can't fail them

### DIFF
--- a/vendor/aube/crates/aube-registry/src/config/tests.rs
+++ b/vendor/aube/crates/aube-registry/src/config/tests.rs
@@ -22,6 +22,33 @@ impl Drop for ScopedEnvVars {
     }
 }
 
+/// Env pairs that pin the user- and global-level `.npmrc` to empty files
+/// inside `dir`, so the host machine's real `~/.npmrc` (and any
+/// `$PREFIX/etc/npmrc`) cannot leak into a `load_with_env` assertion. The
+/// `NPM_CONFIG_USERCONFIG` override beats `$HOME/.npmrc` (see
+/// `load_npmrc_entries_tagged_with_globals`), and `NPM_CONFIG_GLOBALCONFIG`
+/// pins the global scope — together they make a `load_with_env` call
+/// hermetic regardless of what the developer/CI host has configured. Files
+/// are created empty so the result is identical to a fresh user machine.
+/// Returned via the env slice (not process-wide `set_var`) so it stays
+/// thread-safe under the parallel test harness.
+fn isolated_npmrc_env(dir: &Path) -> Vec<(String, String)> {
+    let user_rc = dir.join("user.npmrc");
+    let global_rc = dir.join("global.npmrc");
+    std::fs::write(&user_rc, "").unwrap();
+    std::fs::write(&global_rc, "").unwrap();
+    vec![
+        (
+            "NPM_CONFIG_USERCONFIG".to_string(),
+            user_rc.to_string_lossy().into_owned(),
+        ),
+        (
+            "NPM_CONFIG_GLOBALCONFIG".to_string(),
+            global_rc.to_string_lossy().into_owned(),
+        ),
+    ]
+}
+
 #[test]
 fn parse_npmrc_strips_utf8_bom() {
     let dir = tempfile::tempdir().unwrap();
@@ -573,8 +600,9 @@ npmScopes:
     )
     .unwrap();
 
+    let env = isolated_npmrc_env(project.path());
     aube_util::update_engine_context(|ctx| ctx.read_yarn_config = false);
-    let disabled = NpmConfig::load_with_env(project.path(), &[]);
+    let disabled = NpmConfig::load_with_env(project.path(), &env);
     assert_eq!(disabled.registry, "https://registry.npmjs.org/");
     assert_eq!(
         disabled.registry_for("@myorg/pkg"),
@@ -583,7 +611,7 @@ npmScopes:
     assert_eq!(disabled.auth_token_for("https://npm.myorg.example/"), None);
 
     aube_util::update_engine_context(|ctx| ctx.read_yarn_config = true);
-    let enabled = NpmConfig::load_with_env(project.path(), &[]);
+    let enabled = NpmConfig::load_with_env(project.path(), &env);
     aube_util::update_engine_context(|ctx| ctx.read_yarn_config = false);
 
     assert_eq!(enabled.registry, "https://yarn-only.example/");
@@ -668,12 +696,14 @@ fn classic_yarnrc_load_is_incumbent_and_classic_gated() {
     )
     .unwrap();
 
+    let env = isolated_npmrc_env(project.path());
+
     // No Yarn incumbent → not read.
     aube_util::update_engine_context(|ctx| {
         ctx.read_yarn_config = false;
         ctx.yarn_is_classic = false;
     });
-    let disabled = NpmConfig::load_with_env(project.path(), &[]);
+    let disabled = NpmConfig::load_with_env(project.path(), &env);
     assert_eq!(disabled.registry, "https://registry.npmjs.org/");
 
     // Yarn incumbent but BERRY (classic gate off) → `.yarnrc` is NOT read. A
@@ -683,7 +713,7 @@ fn classic_yarnrc_load_is_incumbent_and_classic_gated() {
         ctx.read_yarn_config = true;
         ctx.yarn_is_classic = false;
     });
-    let berry = NpmConfig::load_with_env(project.path(), &[]);
+    let berry = NpmConfig::load_with_env(project.path(), &env);
     assert_eq!(berry.registry, "https://registry.npmjs.org/");
 
     // Classic (v1) Yarn incumbent → `.yarnrc` IS read.
@@ -691,7 +721,7 @@ fn classic_yarnrc_load_is_incumbent_and_classic_gated() {
         ctx.read_yarn_config = true;
         ctx.yarn_is_classic = true;
     });
-    let enabled = NpmConfig::load_with_env(project.path(), &[]);
+    let enabled = NpmConfig::load_with_env(project.path(), &env);
     aube_util::update_engine_context(|ctx| {
         ctx.read_yarn_config = false;
         ctx.yarn_is_classic = false;


### PR DESCRIPTION
## Problem

Two tests in `vendor/aube/crates/aube-registry/src/config/tests.rs` —
`yarnrc_load_is_incumbent_gated_for_registry_config` and
`classic_yarnrc_load_is_incumbent_and_classic_gated` — were **not HOME-isolated**.
They call `NpmConfig::load_with_env(project, &[])` with an empty env slice, but that
loader still resolves the user-level `.npmrc` from the real process `$HOME`. On any
host whose `~/.npmrc` carries a `registry=...` line, the host registry bled into the
loaded config and the tests' "defaults to `registry.npmjs.org`" assertions failed.

This is a latent CI/dev footgun — it bit two developers whose `~/.npmrc` set
`registry=https://registry.example.com/`. Reproduced: with that polluted HOME both
tests fail; with a clean HOME all config tests pass.

## Fix

Test-only hermeticity. A new `isolated_npmrc_env` helper pins `NPM_CONFIG_USERCONFIG`
and `NPM_CONFIG_GLOBALCONFIG` to empty files inside the test's own tempdir. The
userconfig override beats `$HOME/.npmrc` (per `load_npmrc_entries_tagged_with_globals`)
and the globalconfig pin covers `$PREFIX/etc/npmrc`, so the result matches a fresh
user machine regardless of the host's npm config. Passed through the env slice (not
process-wide `set_var`) so it stays thread-safe under the parallel test harness.

No production config-loading behavior changes — the loader reading `~/.npmrc` in real
use is correct; only the tests are isolated.

## Verification

- Reproduced the failure: both tests fail under a polluted HOME (`~/.npmrc` with
  `registry=https://registry.example.com/`) before the fix.
- After the fix, the full `aube-registry` suite passes **268/268** under both:
  - a **polluted HOME** (`~/.npmrc` set to `registry=https://registry.example.com/`), and
  - a **clean HOME**.
- `cargo clippy -p aube-registry --all-targets --all-features -- -D warnings` clean.
- `cargo fmt -p aube-registry -- --check` clean.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa