### PR TITLE
test(bench): add cold-CAS install benchmark harness

### DIFF
--- a/tests/bench/install/COLD-CAS.md
+++ b/tests/bench/install/COLD-CAS.md
@@ -1,0 +1,91 @@
+# Cold-CAS install benchmark
+
+Measures the un-benched install pipeline — fetch tarball → gzip-decode → tar-unpack → CAS-store write → link into `node_modules` — with the content-addressed store reset to **cold** before each timed run. This is the path the link-side roadmap items target:
+
+- **OPP-2** — eager clonedir tree-build on macOS (the `simple` multi-dep fixture).
+- **OPP-5** — CAS rayon chunk size for fat packages (the `fat` fixture: `next` + `typescript` + `@swc/core`, whose tarballs unpack to thousands of files each).
+
+It is the gate for measuring those changes A/B: the harness can reset the store to cold between runs, and separately measures a warm-store run for contrast.
+
+The script is `cold-cas.sh`; it sits alongside the older `run.sh` / `run-warm-gvs.sh` matrices and shares their fixtures + idioms.
+
+## Quick run
+
+```bash
+cargo build --release
+bash tests/bench/install/cold-cas.sh
+```
+
+Options:
+
+```bash
+--fixture <name>   # simple | fat (default: both)
+--cold-only        # skip the warm contrast leg
+--warm-only        # skip the cold leg
+--runs <n>         # timed runs per leg (default: cold 5, warm 8)
+--no-hermetic      # install against the public npm registry instead of Verdaccio
+--no-rss           # skip the peak-RSS measurement pass
+--save             # write JSON under results/ (default: a temp dir)
+```
+
+## What "cold-CAS" means
+
+The CAS store lives at `$XDG_DATA_HOME/nub/store/v1/files` and the packument/index cache at `$XDG_CACHE_HOME/nub/pm` (the namespaces come from nub's embedder profile; the store path itself is aube's `dirs::store_dir()`). A cold run points both `XDG_DATA_HOME` and `XDG_CACHE_HOME` at fresh empty directories, so the install pays the full fetch+decode+unpack+link cost rather than relinking from a warm store.
+
+hyperfine's `--prepare` wipes and re-creates those directories before **each** timed run, so every iteration starts fully cold. `--prepare` is excluded from the measured wall-clock.
+
+The warm contrast leg populates the store + cache once, then reuses them; only `node_modules` is wiped between runs. It measures the relink-against-warm-store path.
+
+GVS is pinned **off** for both legs (`CI=1`), so the timed path is the materialized fetch+decode+unpack+link path the CAS work lives on. With GVS on, a warm reinstall would relink from the global virtual store and hide the unpack cost the cold measurement is about.
+
+## Hermetic registry
+
+The harness sources `vendor/aube/benchmarks/hermetic.bash`, which brings up a no-uplink Verdaccio on port 4874 (`BENCH_VERDACCIO_PORT`) serving a one-time-warmed local storage so every tarball fetch hits localhost rather than npmjs — the numbers measure nub's code path, not CDN jitter. nub is pointed at it with `nub install --registry "$BENCH_REGISTRY_URL"`.
+
+The first hermetic run warms the Verdaccio storage from npmjs (a one-time network fetch into `~/.cache/aube-bench/registry/`) and installs Verdaccio globally if it is not on `PATH`. Subsequent runs are fully offline. Wipe `~/.cache/aube-bench/registry/` to force a re-warm. The registry warm is scoped to `BENCH_TOOLS=aube,pnpm,npm` (the pnpm-family tarballs nub needs); the harness then pulls each fixture's exact tarballs via uplink before the timed runs, so the warm does not need the slower yarn/deno/bun legs. Override `BENCH_TOOLS` in the environment for the full warm set.
+
+To avoid colliding with another benchmark sharing the default port 4874 + `~/.cache/aube-bench` (e.g. a sibling run of aube's own `bench.sh`), give this harness a private registry:
+
+```bash
+BENCH_VERDACCIO_PORT=4894 \
+BENCH_HERMETIC_CACHE="$TMPDIR/coldcas-registry" \
+  bash tests/bench/install/cold-cas.sh
+```
+
+Pass `--no-hermetic` to skip Verdaccio and install against the public npm registry. Those numbers carry CDN jitter and are labelled as such in the output.
+
+## What's measured
+
+- **Wall-clock** — hyperfine, median ± σ over N runs, exported as JSON.
+- **Peak RSS** — a separate single install under `/usr/bin/time` (`-l` on macOS, `-v` on GNU/Linux). hyperfine does not capture RSS, so this is its own pass. macOS reports both "maximum resident set size" and "peak memory footprint"; this harness parses the former. Peak RSS matters for OPP-5's chunk-size memory tradeoff (a larger chunk size trades RSS for throughput).
+
+Report median and σ. σ-overlap between A/B runs is a tie, not a win.
+
+## Fixtures
+
+| Fixture | Shape | Targets |
+|---------|-------|---------|
+| `simple` | ~435 packages, single project (express/react/typescript/vite/…) | OPP-2 — many small packages, clonedir tree-build |
+| `fat` | `next` + `typescript` + `@swc/core` | OPP-5 — packages whose tarballs unpack to thousands of files |
+
+`simple` is shared with `run.sh`. `fat` is new for this benchmark.
+
+Lockfiles are committed (`pnpm-lock.yaml`) so resolution is deterministic across runs. Regenerate the `fat` lockfile after editing its `package.json`:
+
+```bash
+cd tests/bench/install/fixtures/fat
+rm -rf node_modules pnpm-lock.yaml
+pnpm install --no-frozen-lockfile
+rm -rf node_modules
+```
+
+## Results
+
+By default the script writes JSON to a temp directory. Pass `--save` to update checked-in JSON under `tests/bench/install/results/` (`coldcas-<fixture>-<ts>.json`, `warmcas-<fixture>-<ts>.json`).
+
+## Caveats
+
+- Cold-reset correctness depends on `XDG_DATA_HOME` + `XDG_CACHE_HOME` fully controlling the store + cache. nub's store/cache resolution honors both (`aube-store/src/dirs.rs`, `nub-cli/src/pm_engine`); a stray pre-existing `~/.cache/nub` or `~/.local/share/nub` is NOT consulted because the timed command overrides both env vars.
+- RSS is the peak of a single representative install, not an average — it is the right metric for the chunk-size memory ceiling but is noisier run-to-run than the wall-clock median.
+- Run on a quiet machine. Install timings are sensitive to filesystem load, CPU contention, Spotlight indexing, and concurrent builds.
+- The default registry warm is scoped to `aube,pnpm,npm` because the full aube warm set also runs yarn/deno/bun legs, and a host that routes `yarn`/`pnpm` through an interactive package-manager shim can stall those legs. nub only needs the pnpm-family tarballs, so the scoped warm is both faster and more robust.

--- a/tests/bench/install/cold-cas.sh
+++ b/tests/bench/install/cold-cas.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+# Cold-CAS install benchmark for nub's package manager.
+#
+# Measures the un-benched fetch → gzip-decode → tar-unpack → CAS-store-write →
+# link-into-node_modules path against a HERMETIC registry, with the
+# content-addressed store reset to COLD before each timed run. This is the path
+# OPP-2 (eager clonedir tree-build on macOS) and OPP-5 (CAS rayon chunk size for
+# fat packages) target, and the gate for measuring those changes.
+#
+# Two things are reported per fixture:
+#   • install wall-clock (hyperfine, median ± σ over N runs)
+#   • peak RSS (a separate `/usr/bin/time -l` run; macOS reports "maximum
+#     resident set size" + "peak memory footprint", Linux `-v` reports
+#     "Maximum resident set size")
+#
+# COLD vs WARM:
+#   COLD — XDG_DATA_HOME (CAS store at $XDG_DATA_HOME/nub/store/v1/files) and
+#          XDG_CACHE_HOME (packument/index cache at $XDG_CACHE_HOME/nub/pm) both
+#          point at FRESH empty dirs for the timed run, so the install pays the
+#          full fetch+decode+unpack+link cost. hyperfine's --prepare wipes and
+#          re-creates those dirs before EACH timed run (excluded from timing).
+#   WARM — the store + cache are populated once, then REUSED across runs (only
+#          node_modules is wiped between runs). Contrast number for the
+#          relink-against-warm-store path.
+#
+# HERMETIC REGISTRY:
+#   Sources vendor/aube/benchmarks/hermetic.bash, which brings up a no-uplink
+#   Verdaccio on port 4874 (BENCH_VERDACCIO_PORT) serving a one-time-warmed
+#   local storage so every tarball fetch hits localhost, not npmjs. nub is
+#   pointed at it via `nub install --registry $BENCH_REGISTRY_URL`. Falls back
+#   to the public npm registry (clearly labelled) if --no-hermetic is passed or
+#   Verdaccio can't start.
+#
+# Usage:
+#   bash tests/bench/install/cold-cas.sh [options]
+#     --fixture <name>     simple | fat   (default: both)
+#     --cold-only          skip the warm contrast leg
+#     --warm-only          skip the cold leg
+#     --runs <n>           timed runs per leg (default: cold 5, warm 8)
+#     --no-hermetic        skip Verdaccio; install against the public npm
+#                          registry (numbers carry CDN jitter — labelled)
+#     --no-rss             skip the peak-RSS measurement pass
+#     --save               write JSON results under results/ (default: temp dir)
+#
+# Requires: hyperfine, /usr/bin/time; target/release/nub built. Verdaccio is
+# auto-installed by hermetic.bash on first hermetic run (npm i -g verdaccio@6).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+NUB="${NUB:-$REPO_ROOT/target/release/nub}"
+FIXTURE_DIR="$REPO_ROOT/tests/bench/install/fixtures"
+HERMETIC_BASH="$REPO_ROOT/vendor/aube/benchmarks/hermetic.bash"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+
+RUN_COLD=1
+RUN_WARM=1
+FIXTURE_FILTER=""
+COLD_RUNS=5
+WARM_RUNS=8
+USE_HERMETIC=1
+MEASURE_RSS=1
+SAVE_RESULTS=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cold-only)   RUN_WARM=0 ;;
+    --warm-only)   RUN_COLD=0 ;;
+    --fixture)     shift; FIXTURE_FILTER="${1:-}" ;;
+    --runs)        shift; COLD_RUNS="${1:-5}"; WARM_RUNS="${1:-8}" ;;
+    --no-hermetic) USE_HERMETIC=0 ;;
+    --no-rss)      MEASURE_RSS=0 ;;
+    --save)        SAVE_RESULTS=1 ;;
+    *) echo "WARN: unknown arg '$1'" >&2 ;;
+  esac
+  shift
+done
+
+if [[ "$SAVE_RESULTS" -eq 1 ]]; then
+  RESULTS_DIR="$REPO_ROOT/tests/bench/install/results"
+else
+  RESULTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nub-coldcas-results-XXXXXX")"
+fi
+mkdir -p "$RESULTS_DIR"
+
+# Scratch root for per-run isolated XDG dirs + workdirs. Reaped on exit.
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/nub-coldcas-$$-XXXXXX")"
+cleanup() {
+  [[ -n "${HERMETIC_BASH:-}" && "$USE_HERMETIC" -eq 1 ]] && hermetic_stop 2>/dev/null || true
+  rm -rf "$SCRATCH" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+if [[ ! -x "$NUB" ]]; then
+  echo "ERROR: $NUB not found or not executable. Run 'cargo build --release' first." >&2
+  exit 1
+fi
+if ! command -v hyperfine &>/dev/null; then
+  echo "ERROR: hyperfine not found. Install with: brew install hyperfine" >&2
+  exit 1
+fi
+
+# Peak-RSS measurement tool. macOS /usr/bin/time -l, GNU /usr/bin/time -v.
+# Capture the probe output into a var first — piping into `grep -q` would
+# SIGPIPE /usr/bin/time and, under `set -o pipefail`, misreport the probe.
+RSS_KIND=""
+if [[ "$MEASURE_RSS" -eq 1 ]]; then
+  _probe_l="$(/usr/bin/time -l true 2>&1 || true)"
+  _probe_v="$(/usr/bin/time -v true 2>&1 || true)"
+  if [[ "$_probe_l" == *"maximum resident set size"* ]]; then
+    RSS_KIND="macos"
+  elif [[ "$_probe_v" == *"Maximum resident set size"* ]]; then
+    RSS_KIND="gnu"
+  else
+    echo "WARN: no /usr/bin/time peak-RSS support detected; disabling RSS pass." >&2
+    MEASURE_RSS=0
+  fi
+fi
+
+# `nub --version | head -1` would SIGPIPE nub when head closes the pipe early;
+# under `set -o pipefail` that non-zero status kills the script. Read the first
+# line without a pipe instead.
+NUB_VERSION="$({ "$NUB" --version 2>&1 || true; } | { IFS= read -r l; echo "$l"; })"
+
+# ── Hermetic registry ────────────────────────────────────────────────────────
+REGISTRY_LABEL=""
+REGISTRY_ARGS=()
+if [[ "$USE_HERMETIC" -eq 1 ]]; then
+  if [[ ! -f "$HERMETIC_BASH" ]]; then
+    echo "WARN: $HERMETIC_BASH not found; falling back to public registry." >&2
+    USE_HERMETIC=0
+  else
+    # hermetic.bash resolves its own dir from BASH_SOURCE; SCRIPT_DIR helps it.
+    SCRIPT_DIR="$(dirname "$HERMETIC_BASH")"
+    # Scope the one-time registry warm to the tools nub actually needs cached
+    # (pnpm-family resolution). The default aube warm also runs yarn/deno/bun
+    # legs; those are slow and, in some host setups (e.g. a package-manager
+    # shim that prompts), can stall the warm. nub only needs the npm/pnpm/aube
+    # tarballs, and populate_registry pulls each fixture's exact tarballs via
+    # uplink regardless, so dropping yarn/deno/bun here is safe. Override with
+    # BENCH_TOOLS=... in the environment if you want the full warm set.
+    export BENCH_TOOLS="${BENCH_TOOLS:-aube,pnpm,npm}"
+    # shellcheck disable=SC1090
+    source "$HERMETIC_BASH"
+    export AUBE_BIN="$NUB"   # warm step skips aube if unset; nub serves the same role
+    echo "[hermetic] bringing up Verdaccio (port ${BENCH_VERDACCIO_PORT:-4874})..." >&2
+    if hermetic_start; then
+      REGISTRY_LABEL="hermetic Verdaccio ($BENCH_REGISTRY_URL)"
+      REGISTRY_ARGS=(--registry "$BENCH_REGISTRY_URL")
+    else
+      echo "WARN: hermetic_start failed; falling back to public registry." >&2
+      USE_HERMETIC=0
+    fi
+  fi
+fi
+if [[ "$USE_HERMETIC" -eq 0 ]]; then
+  REGISTRY_LABEL="public npm registry (registry.npmjs.org — CDN jitter present)"
+fi
+
+echo "================================================================"
+echo "  Cold-CAS install benchmark — nub package manager"
+echo "  nub:      $NUB_VERSION  ($NUB)"
+echo "  registry: $REGISTRY_LABEL"
+echo "  RSS:      $([[ $MEASURE_RSS -eq 1 ]] && echo "$RSS_KIND /usr/bin/time" || echo "disabled")"
+echo "  date:     $(date)"
+echo "================================================================"
+echo ""
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# Copy a fixture to a fresh workdir, stripping foreign lockfiles so nub installs
+# from its own pnpm-lock family without a competing-lockfile refusal.
+setup_workdir() {
+  local fixture="$1" workdir="$2"
+  rm -rf "$workdir"
+  cp -r "$FIXTURE_DIR/$fixture" "$workdir"
+  rm -rf "$workdir/node_modules" 2>/dev/null || true
+  rm -f "$workdir/bun.lock" "$workdir/bun.lockb" "$workdir/package-lock.json" 2>/dev/null || true
+}
+
+# Pre-populate the hermetic Verdaccio storage with THIS fixture's own tarballs.
+#
+# hermetic.bash's one-time warm only caches the packages in aube's
+# benchmarks/fixture.package.json — not our `simple`/`fat` fixtures. Against the
+# no-uplink (cold) config those tarballs would 404. So before the timed loop we
+# swap Verdaccio to the warm (uplink-enabled) config, run a throwaway nub install
+# (its own scratch store, discarded) to pull+cache the fixture's tarballs from
+# npmjs into Verdaccio's storage, then swap back to no-uplink. Subsequent timed
+# installs are then fully offline against localhost. Mirrors bench.sh's per-tool
+# populate step (hermetic_use_warm_uplink → install → hermetic_use_no_uplink).
+populate_registry() {
+  local fixture="$1"
+  [[ "$USE_HERMETIC" -eq 1 ]] || return 0
+  echo "[populate] caching $fixture tarballs into Verdaccio (uplink on)..." >&2
+  hermetic_use_warm_uplink
+  local pwd_data="$SCRATCH/populate-data-$fixture"
+  local pwd_cache="$SCRATCH/populate-cache-$fixture"
+  local pwd_wd="$SCRATCH/populate-wd-$fixture"
+  mkdir -p "$pwd_data" "$pwd_cache"
+  setup_workdir "$fixture" "$pwd_wd"
+  if ! CI=1 XDG_DATA_HOME="$pwd_data" XDG_CACHE_HOME="$pwd_cache" \
+      "$NUB" install --frozen-lockfile --dir "$pwd_wd" --registry "$BENCH_REGISTRY_URL" -s \
+      >"$SCRATCH/populate-$fixture.log" 2>&1; then
+    echo "  WARN: populate install for $fixture had errors (see $SCRATCH/populate-$fixture.log)" >&2
+    tail -5 "$SCRATCH/populate-$fixture.log" >&2 || true
+  fi
+  rm -rf "$pwd_data" "$pwd_cache" "$pwd_wd"
+  hermetic_use_no_uplink
+  echo "[populate] $fixture cached; Verdaccio back to no-uplink." >&2
+}
+
+# nub install invocation, GVS pinned OFF via CI=1 so the timed path is the
+# materialized fetch+decode+unpack+link path the CAS work lives on (GVS-on would
+# relink from the warm GVS and hide the unpack cost we want cold). --frozen-lockfile
+# installs strictly from the committed lockfile (deterministic resolution).
+nub_install() {
+  local data="$1" cache="$2" wd="$3"; shift 3
+  CI=1 XDG_DATA_HOME="$data" XDG_CACHE_HOME="$cache" \
+    "$NUB" install --frozen-lockfile --dir "$wd" "${REGISTRY_ARGS[@]+${REGISTRY_ARGS[@]}}" -s "$@"
+}
+
+# Portable millisecond timer (perl is on macOS + Linux).
+ms_now() { perl -MTime::HiRes=time -e 'printf "%d\n", time()*1000'; }
+
+# Parse peak RSS (bytes) out of a /usr/bin/time log file.
+parse_peak_rss_bytes() {
+  local logf="$1"
+  if [[ "$RSS_KIND" == "macos" ]]; then
+    # macOS reports bytes for "maximum resident set size".
+    grep "maximum resident set size" "$logf" | awk '{print $1}'
+  else
+    # GNU reports kilobytes for "Maximum resident set size (kbytes)".
+    local kb
+    kb="$(grep "Maximum resident set size" "$logf" | awk -F': ' '{print $2}')"
+    echo $(( kb * 1024 ))
+  fi
+}
+
+human_mb() { awk "BEGIN{printf \"%.1f\", $1/1048576}"; }
+
+# ── COLD benchmark ───────────────────────────────────────────────────────────
+# Each timed run gets a fresh empty store + cache (cold CAS). hyperfine's
+# --prepare wipes+recreates them before each run and is EXCLUDED from timing.
+run_cold() {
+  local fixture="$1" label="$2"
+  echo "────────────────────────────────────────────────────────────────"
+  echo "  COLD-CAS — $label"
+  echo "  (empty CAS store + cache per run; full fetch+decode+unpack+link)"
+  echo "────────────────────────────────────────────────────────────────"
+
+  local wd="$SCRATCH/cold-$fixture"
+  local data="$SCRATCH/cold-data-$fixture"
+  local cache="$SCRATCH/cold-cache-$fixture"
+  setup_workdir "$fixture" "$wd"
+
+  # --prepare runs before EACH timed run (untimed): wipe node_modules + the cold
+  # store/cache so the timed install starts fully cold every iteration.
+  local prepare="rm -rf '$wd/node_modules' '$data' '$cache'; mkdir -p '$data' '$cache'"
+  local reg_flag=""
+  [[ ${#REGISTRY_ARGS[@]} -gt 0 ]] && reg_flag="${REGISTRY_ARGS[*]}"
+  local cmd="CI=1 XDG_DATA_HOME='$data' XDG_CACHE_HOME='$cache' '$NUB' install --frozen-lockfile --dir '$wd' $reg_flag -s"
+
+  local outfile="$RESULTS_DIR/coldcas-${fixture}-${TIMESTAMP}.json"
+  hyperfine \
+    --warmup 0 \
+    --runs "$COLD_RUNS" \
+    --prepare "$prepare" \
+    --command-name "nub install (cold-CAS, $fixture)" \
+    "$cmd" \
+    --export-json "$outfile"
+
+  echo "  [wall-clock results → $outfile]"
+
+  # Peak-RSS pass: one cold install under /usr/bin/time. Separate from hyperfine
+  # because hyperfine does not capture RSS.
+  if [[ "$MEASURE_RSS" -eq 1 ]]; then
+    rm -rf "$wd/node_modules" "$data" "$cache"; mkdir -p "$data" "$cache"
+    local rss_log="$SCRATCH/rss-cold-$fixture.log"
+    if [[ "$RSS_KIND" == "macos" ]]; then
+      CI=1 XDG_DATA_HOME="$data" XDG_CACHE_HOME="$cache" \
+        /usr/bin/time -l "$NUB" install --frozen-lockfile --dir "$wd" "${REGISTRY_ARGS[@]+${REGISTRY_ARGS[@]}}" -s \
+        >/dev/null 2>"$rss_log" || true
+    else
+      CI=1 XDG_DATA_HOME="$data" XDG_CACHE_HOME="$cache" \
+        /usr/bin/time -v "$NUB" install --frozen-lockfile --dir "$wd" "${REGISTRY_ARGS[@]+${REGISTRY_ARGS[@]}}" -s \
+        >/dev/null 2>"$rss_log" || true
+    fi
+    local rss_bytes; rss_bytes="$(parse_peak_rss_bytes "$rss_log")"
+    if [[ -n "$rss_bytes" ]]; then
+      printf "  peak RSS (cold install): %s MB (%s bytes)\n" "$(human_mb "$rss_bytes")" "$rss_bytes"
+    fi
+  fi
+  echo ""
+}
+
+# ── WARM contrast benchmark ──────────────────────────────────────────────────
+# Store + cache populated ONCE, then reused; only node_modules wiped between
+# runs. The relink-against-warm-store contrast number.
+run_warm() {
+  local fixture="$1" label="$2"
+  echo "────────────────────────────────────────────────────────────────"
+  echo "  WARM (contrast) — $label"
+  echo "  (CAS store + cache warm + reused; only node_modules wiped per run)"
+  echo "────────────────────────────────────────────────────────────────"
+
+  local wd="$SCRATCH/warm-$fixture"
+  local data="$SCRATCH/warm-data-$fixture"
+  local cache="$SCRATCH/warm-cache-$fixture"
+  setup_workdir "$fixture" "$wd"
+  mkdir -p "$data" "$cache"
+
+  echo "[setup] warming CAS store + cache once..."
+  nub_install "$data" "$cache" "$wd" 2>/dev/null \
+    || nub_install "$data" "$cache" "$wd" 2>&1 | tail -3
+
+  local prepare="rm -rf '$wd/node_modules'"
+  local reg_flag=""
+  [[ ${#REGISTRY_ARGS[@]} -gt 0 ]] && reg_flag="${REGISTRY_ARGS[*]}"
+  local cmd="CI=1 XDG_DATA_HOME='$data' XDG_CACHE_HOME='$cache' '$NUB' install --frozen-lockfile --dir '$wd' $reg_flag -s"
+
+  local outfile="$RESULTS_DIR/warmcas-${fixture}-${TIMESTAMP}.json"
+  hyperfine \
+    --warmup 2 \
+    --runs "$WARM_RUNS" \
+    --prepare "$prepare" \
+    --command-name "nub install (warm-store, $fixture)" \
+    "$cmd" \
+    --export-json "$outfile"
+
+  echo "  [wall-clock results → $outfile]"
+
+  if [[ "$MEASURE_RSS" -eq 1 ]]; then
+    rm -rf "$wd/node_modules"
+    local rss_log="$SCRATCH/rss-warm-$fixture.log"
+    if [[ "$RSS_KIND" == "macos" ]]; then
+      CI=1 XDG_DATA_HOME="$data" XDG_CACHE_HOME="$cache" \
+        /usr/bin/time -l "$NUB" install --frozen-lockfile --dir "$wd" "${REGISTRY_ARGS[@]+${REGISTRY_ARGS[@]}}" -s \
+        >/dev/null 2>"$rss_log" || true
+    else
+      CI=1 XDG_DATA_HOME="$data" XDG_CACHE_HOME="$cache" \
+        /usr/bin/time -v "$NUB" install --frozen-lockfile --dir "$wd" "${REGISTRY_ARGS[@]+${REGISTRY_ARGS[@]}}" -s \
+        >/dev/null 2>"$rss_log" || true
+    fi
+    local rss_bytes; rss_bytes="$(parse_peak_rss_bytes "$rss_log")"
+    if [[ -n "$rss_bytes" ]]; then
+      printf "  peak RSS (warm install): %s MB (%s bytes)\n" "$(human_mb "$rss_bytes")" "$rss_bytes"
+    fi
+  fi
+  echo ""
+}
+
+# ── Fixture registry ─────────────────────────────────────────────────────────
+# Each entry: "name|label"
+#   simple — multi-dep clonedir tree-build (OPP-2: eager clonedir on macOS)
+#   fat    — a few thousand-file packages (OPP-5: CAS rayon chunk size)
+ALL_FIXTURES=(
+  "simple|simple multi-dep (~435 pkgs — OPP-2 clonedir tree-build)"
+  "fat|fat packages (next + typescript + @swc/core — OPP-5 CAS chunk size)"
+)
+
+# ── Run ──────────────────────────────────────────────────────────────────────
+for entry in "${ALL_FIXTURES[@]}"; do
+  IFS='|' read -r name label <<< "$entry"
+  [[ -n "$FIXTURE_FILTER" && "$name" != "$FIXTURE_FILTER" ]] && continue
+  if [[ ! -d "$FIXTURE_DIR/$name" ]]; then
+    echo "WARN: fixture '$name' not found at $FIXTURE_DIR/$name — skipping." >&2
+    continue
+  fi
+  if [[ ! -f "$FIXTURE_DIR/$name/pnpm-lock.yaml" ]]; then
+    echo "WARN: fixture '$name' has no pnpm-lock.yaml — generate it first (see COLD-CAS.md). Skipping." >&2
+    continue
+  fi
+  populate_registry "$name"
+  [[ "$RUN_COLD" -eq 1 ]] && run_cold "$name" "$label"
+  [[ "$RUN_WARM" -eq 1 ]] && run_warm "$name" "$label"
+done
+
+echo "================================================================"
+echo "  Cold-CAS benchmark complete. Results: $RESULTS_DIR/"
+echo "================================================================"

--- a/tests/bench/install/fixtures/fat/package.json
+++ b/tests/bench/install/fixtures/fat/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "bench-fat",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Fat-package fixture for the cold-CAS OPP-5 case: a small dep set dominated by packages whose tarballs unpack to thousands of files (next, typescript, @swc/core), exercising the CAS rayon chunk-size path on large per-package file counts.",
+  "dependencies": {
+    "next": "^14.2.0",
+    "typescript": "^5.4.0",
+    "@swc/core": "^1.4.0"
+  }
+}

--- a/tests/bench/install/fixtures/fat/pnpm-lock.yaml
+++ b/tests/bench/install/fixtures/fat/pnpm-lock.yaml
@@ -1,0 +1,443 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@swc/core':
+        specifier: ^1.4.0
+        version: 1.15.41
+      next:
+        specifier: ^14.2.0
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
+packages:
+
+  '@next/env@14.2.35':
+    resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
+
+  '@next/swc-darwin-arm64@14.2.33':
+    resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@14.2.33':
+    resolution: {integrity: sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@14.2.33':
+    resolution: {integrity: sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@14.2.33':
+    resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@14.2.33':
+    resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@14.2.33':
+    resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@14.2.33':
+    resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-ia32-msvc@14.2.33':
+    resolution: {integrity: sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@14.2.33':
+    resolution: {integrity: sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core-darwin-arm64@1.15.41':
+    resolution: {integrity: sha512-kREh6J5paQFvP3i7f/4FbqRNOJREutVFVOkder4GVyCBQ39YmER55cW/y1NNjwrchzFqgYswFn0mMDCqbqKzrw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.41':
+    resolution: {integrity: sha512-N8B56ESFazZAWZyIkecADSPCwlLEinW7QLMEeotCpv4J7VXwfH+OLkmRL8o96UZ+1355fwHxDTS6/wK7yucvkA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.41':
+    resolution: {integrity: sha512-6XrId2fyle0mS5xxON8rU84mPd2Cq1kDJRj+4BnQKTd7u+2kSA6Ww+JkOP0iTNqOqt9OXhPOEAjBHAuonWcdCg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.41':
+    resolution: {integrity: sha512-ynLIarxlkVnqHn1D0fKOVht6mNU5ks6lrH+MY3kkS+XFaGGgDxFZVjWKJlkYTKm3RCvBTfA8Ng5fLufXheMRKQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-arm64-musl@1.15.41':
+    resolution: {integrity: sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-linux-ppc64-gnu@1.15.41':
+    resolution: {integrity: sha512-XGO6zVPXoPE0gf/XnI4jBbafNT13AYgoh6ns0JCSdOetI/kqVf0vhpz7NuNgAzZrMVCsmieqjPoTwViDgh4mOQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-s390x-gnu@1.15.41':
+    resolution: {integrity: sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-gnu@1.15.41':
+    resolution: {integrity: sha512-VxkuQK59c0tHm6uJZCUrS3cyA2JhGGfdU6e41SZz0x/JS+4Sm7C1mIc97In14vkZJopEt7yXA2TouCqZDSygEA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-musl@1.15.41':
+    resolution: {integrity: sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-win32-arm64-msvc@1.15.41':
+    resolution: {integrity: sha512-Y481sMNZM6rECh9VO4+y26N1lWEDAyxnBZskUf37fl90uHE946VHfmiVQWT0uMFOhyJJFovGTRuF4W82dwewUg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.41':
+    resolution: {integrity: sha512-BAchBD5qeUzy3hiPSLJtaaoSm4blCLyYffOF1bGE4ETcV+OisqjUAwDQMJj++4bTpvMCDzwC+Bj3PmQyBCtscw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.41':
+    resolution: {integrity: sha512-WOkA+fJ/ViVBQDsSV9JC52NACTe5PhlurA6viASDZGb7HR3KS01ZG7RZ+Bg6SVQFIoq3gSbTsskQVe6EbHFAYw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.41':
+    resolution: {integrity: sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.5':
+    resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
+  '@swc/types@0.1.27':
+    resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  next@14.2.35:
+    resolution: {integrity: sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==}
+    engines: {node: '>=18.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      sass:
+        optional: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
+  styled-jsx@5.1.1:
+    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  '@next/env@14.2.35': {}
+
+  '@next/swc-darwin-arm64@14.2.33':
+    optional: true
+
+  '@next/swc-darwin-x64@14.2.33':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@14.2.33':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@14.2.33':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@14.2.33':
+    optional: true
+
+  '@next/swc-linux-x64-musl@14.2.33':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@14.2.33':
+    optional: true
+
+  '@next/swc-win32-ia32-msvc@14.2.33':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@14.2.33':
+    optional: true
+
+  '@swc/core-darwin-arm64@1.15.41':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.41':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.41':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.41':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.41':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.41':
+    optional: true
+
+  '@swc/core@1.15.41':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.27
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.41
+      '@swc/core-darwin-x64': 1.15.41
+      '@swc/core-linux-arm-gnueabihf': 1.15.41
+      '@swc/core-linux-arm64-gnu': 1.15.41
+      '@swc/core-linux-arm64-musl': 1.15.41
+      '@swc/core-linux-ppc64-gnu': 1.15.41
+      '@swc/core-linux-s390x-gnu': 1.15.41
+      '@swc/core-linux-x64-gnu': 1.15.41
+      '@swc/core-linux-x64-musl': 1.15.41
+      '@swc/core-win32-arm64-msvc': 1.15.41
+      '@swc/core-win32-ia32-msvc': 1.15.41
+      '@swc/core-win32-x64-msvc': 1.15.41
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.5':
+    dependencies:
+      '@swc/counter': 0.1.3
+      tslib: 2.8.1
+
+  '@swc/types@0.1.27':
+    dependencies:
+      '@swc/counter': 0.1.3
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
+  caniuse-lite@1.0.30001799: {}
+
+  client-only@0.0.1: {}
+
+  graceful-fs@4.2.11: {}
+
+  js-tokens@4.0.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  nanoid@3.3.15: {}
+
+  next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 14.2.35
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001799
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.33
+      '@next/swc-darwin-x64': 14.2.33
+      '@next/swc-linux-arm64-gnu': 14.2.33
+      '@next/swc-linux-arm64-musl': 14.2.33
+      '@next/swc-linux-x64-gnu': 14.2.33
+      '@next/swc-linux-x64-musl': 14.2.33
+      '@next/swc-win32-arm64-msvc': 14.2.33
+      '@next/swc-win32-ia32-msvc': 14.2.33
+      '@next/swc-win32-x64-msvc': 14.2.33
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  picocolors@1.1.1: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  source-map-js@1.2.1: {}
+
+  streamsearch@1.1.0: {}
+
+  styled-jsx@5.1.1(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}


### PR DESCRIPTION
## What

Adds a cold-store install benchmark harness. The install pipeline — fetch tarball → gzip-decode → tar-unpack → CAS-store write → link into `node_modules` — was previously un-benched.

## Change

- `tests/bench/install/cold-cas.sh` — hyperfine harness; resets the content-addressed store **cold** before each timed run (`XDG_DATA_HOME`/`XDG_CACHE_HOME` at fresh dirs + hyperfine `--prepare` wipe, excluded from timing), with a warm-store contrast leg and a separate peak-RSS pass (`/usr/bin/time`).
- Sources the existing hermetic Verdaccio rig (`vendor/aube/benchmarks/hermetic.bash`); `--no-hermetic` falls back to the public registry, labelled as carrying CDN jitter.
- Adds a `fat` fixture (`next` + `typescript` + `@swc/core`, many files per tarball) alongside the shared `simple` fixture; lockfiles committed for deterministic resolution.
- `COLD-CAS.md` documents the cold-vs-warm reset, what's measured, and the registry warm.

Benchmark tooling only — no runtime behavior change.
