### PR TITLE
test(native): extract nub-cache-key crate to lock cache-key invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,8 +3042,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nub-cache-key"
+version = "0.1.12"
+dependencies = [
+ "blake3",
+]
+
+[[package]]
 name = "nub-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "aube",
@@ -3079,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "nub-core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3108,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "nub-native"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "blake3",
  "json5",
@@ -3116,6 +3123,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "nub-cache-key",
  "oxc",
  "oxc_napi",
  "oxc_sourcemap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/nub-cli", "crates/nub-core", "crates/nub-native"]
+members = ["crates/nub-cache-key", "crates/nub-cli", "crates/nub-core", "crates/nub-native"]
 # vendor/aube is its own Cargo workspace (the vendored aube package manager,
 # plain in-tree files vendored from nubjs/aube). The exclude is load-bearing: nub crates
 # take `path` dependencies into vendor/aube/crates/*, and cargo auto-adopts

--- a/crates/nub-cache-key/Cargo.toml
+++ b/crates/nub-cache-key/Cargo.toml
@@ -1,0 +1,20 @@
+# The transpile-cache key derivation, factored out of `nub-native` so it is unit
+# testable. `nub-native` is a `cdylib` N-API addon: its `napi_*` symbols are
+# resolved by the Node host at dlopen, so a `cargo test` harness for that crate
+# cannot link (it has `test = false` for that reason — see its Cargo.toml). The
+# key-derivation is pure (blake3 over a fixed preimage) with no napi dependency,
+# so it lives here where it CAN be tested on every platform, and `nub-native`
+# calls into it. Keep this crate napi-free.
+[package]
+name = "nub-cache-key"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+blake3.workspace = true
+
+[lints]
+workspace = true

--- a/crates/nub-cache-key/src/lib.rs
+++ b/crates/nub-cache-key/src/lib.rs
@@ -1,0 +1,90 @@
+//! Transpile-cache key derivation, factored out of `nub-native` so the
+//! invalidation contract is unit-testable (see this crate's Cargo.toml for why a
+//! test can't live in the cdylib `nub-native`).
+//!
+//! The key preimage is NUL-separated and order-fixed (no trailing separator):
+//!   `nub_version \0 schema \0 build_id \0 source \0 ext \0 tsconfig_hash \0 pkg_type`
+//! → blake3 → 64-hex lowercase → the cache FILENAME. Every component is hashed
+//! IN, so a change to ANY of them (a nub release, a CACHE_SCHEMA bump, a rebuild
+//! at a new build-id) yields a disjoint filename — old on-disk entries are
+//! silently ignored (a miss), never mis-read. `nub-native` calls `cache_key` with
+//! its `NUB_VERSION` / `CACHE_SCHEMA` / `BUILD_ID` consts.
+
+/// blake3 of the NUL-separated key preimage → 64-hex lowercase.
+///
+/// `nub_version` / `schema` / `build_id` are the cross-build invalidation
+/// components (compile-time consts on the production path); `source` / `ext` /
+/// `tsconfig_hash` / `pkg_type` are the per-file inputs.
+#[allow(clippy::too_many_arguments)]
+pub fn cache_key(
+    nub_version: &str,
+    schema: &str,
+    build_id: &str,
+    source: &str,
+    ext: &str,
+    tsconfig_hash: &str,
+    pkg_type: &str,
+) -> String {
+    let mut h = blake3::Hasher::new();
+    h.update(nub_version.as_bytes());
+    h.update(b"\0");
+    h.update(schema.as_bytes());
+    h.update(b"\0");
+    h.update(build_id.as_bytes());
+    h.update(b"\0");
+    h.update(source.as_bytes());
+    h.update(b"\0");
+    h.update(ext.as_bytes());
+    h.update(b"\0");
+    h.update(tsconfig_hash.as_bytes());
+    h.update(b"\0");
+    h.update(pkg_type.as_bytes());
+    h.finalize().to_hex().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cache_key;
+
+    // Fixed per-file inputs so each test varies exactly one cross-build component.
+    const SRC: &str = "export const x: number = 1;";
+    const EXT: &str = "ts";
+    const TSCONFIG: &str = "tsconfig-hash";
+    const PKG: &str = "module";
+
+    fn key(version: &str, schema: &str, build_id: &str) -> String {
+        cache_key(version, schema, build_id, SRC, EXT, TSCONFIG, PKG)
+    }
+
+    /// A rebuilt binary (new build-id) must not serve a prior build's entries:
+    /// folding the build-id into the key is the whole point of the compile-time
+    /// build-id stamp, so a changed build-id over identical source/config has to
+    /// produce a different filename.
+    #[test]
+    fn cache_key_changes_when_build_id_changes() {
+        assert_ne!(
+            key("0.0.1", "5", "abc1234"),
+            key("0.0.1", "5", "def5678"),
+            "a different build-id must yield a different cache key"
+        );
+    }
+
+    /// The schema is hashed into the key, so a schema bump (e.g. the 4→5 move)
+    /// makes the two eras' filenames disjoint — a "5" build can never read a
+    /// "4"-era entry, it simply misses.
+    #[test]
+    fn cache_key_namespaced_by_schema() {
+        assert_ne!(
+            key("0.0.1", "4", "abc1234"),
+            key("0.0.1", "5", "abc1234"),
+            "a different schema must yield a different cache key"
+        );
+    }
+
+    /// At a fixed clean commit the build-id is reproducible, so a release's
+    /// rebuilds reuse the cache — identical inputs must always map to one key.
+    #[test]
+    fn cache_key_is_stable_for_identical_inputs() {
+        assert_eq!(key("0.0.1", "5", "abc1234"), key("0.0.1", "5", "abc1234"));
+    }
+}

--- a/crates/nub-native/Cargo.toml
+++ b/crates/nub-native/Cargo.toml
@@ -11,10 +11,12 @@ crate-type = ["cdylib"]
 # nub-native is a Node N-API addon: its `napi_*` symbols are resolved by the Node
 # host at dlopen, never at link time. A cdylib links fine (undefined symbols are
 # allowed), but a `cargo test` harness is a normal executable and CANNOT link those
-# symbols (`undefined symbol: napi_create_object`). The crate has no unit/doc tests
-# anyway — it's exercised by loading the built addon into Node (the nub-cli
-# integration suite). So opt it out of `cargo test` to keep bare `cargo test`
-# (whole-workspace, as CI runs) green. Regressed when oxc_napi pulled napi 3 in.
+# symbols (`undefined symbol: napi_create_object`). So opt it out of `cargo test`
+# to keep bare `cargo test` (whole-workspace, as CI runs) green. Regressed when
+# oxc_napi pulled napi 3 in. Pure logic that warrants a unit test is factored
+# out into the napi-free `nub-cache-key` crate, which IS testable (the transpile
+# cache-key derivation + its invalidation contract live there); the rest of the
+# addon is exercised by loading the built `.node` into Node (the nub-cli suite).
 test = false
 doctest = false
 
@@ -40,10 +42,13 @@ oxc_sourcemap.workspace = true
 rustc-hash.workspace = true
 # tsconfig discovery/parse/extends + the transpile cache (moved in-process from
 # the get-tsconfig npm package and the JS cache). serde drives the RawTsconfig /
-# CompilerOptions deserialization; blake3 computes the cache key + integrity
-# prefix (SIMD content hash, replaced SHA-256 on the warm path).
+# CompilerOptions deserialization; blake3 computes the integrity prefix (SIMD
+# content hash, replaced SHA-256 on the warm path).
 serde.workspace = true
 blake3.workspace = true
+# Transpile cache-key derivation (the blake3 preimage), factored out so its
+# invalidation contract can be unit-tested off the un-testable cdylib.
+nub-cache-key = { path = "../nub-cache-key" }
 
 [build-dependencies]
 napi-build = "2"

--- a/crates/nub-native/src/cache.rs
+++ b/crates/nub-native/src/cache.rs
@@ -165,23 +165,19 @@ const BUILD_ID: &str = env!("NUB_NATIVE_BUILD_ID");
 /// blake3(NUB_VERSION \0 SCHEMA \0 BUILD_ID \0 source \0 ext \0 tsconfig_hash \0
 /// pkg_type) → 64-hex lowercase. blake3 (SIMD) replaces SHA-256 on the hot path;
 /// the compile-time `BUILD_ID` is folded in so a rebuilt binary auto-invalidates
-/// the cache without any runtime I/O.
+/// the cache without any runtime I/O. The derivation lives in the napi-free
+/// `nub-cache-key` crate so its invalidation contract is unit-testable (this
+/// cdylib has `test = false` — a test harness can't link the napi symbols).
 fn cache_key(source: &str, ext: &str, tsconfig_hash: &str, pkg_type: &str) -> String {
-    let mut h = blake3::Hasher::new();
-    h.update(NUB_VERSION.as_bytes());
-    h.update(b"\0");
-    h.update(CACHE_SCHEMA.as_bytes());
-    h.update(b"\0");
-    h.update(BUILD_ID.as_bytes());
-    h.update(b"\0");
-    h.update(source.as_bytes());
-    h.update(b"\0");
-    h.update(ext.as_bytes());
-    h.update(b"\0");
-    h.update(tsconfig_hash.as_bytes());
-    h.update(b"\0");
-    h.update(pkg_type.as_bytes());
-    h.finalize().to_hex().to_string()
+    nub_cache_key::cache_key(
+        NUB_VERSION,
+        CACHE_SCHEMA,
+        BUILD_ID,
+        source,
+        ext,
+        tsconfig_hash,
+        pkg_type,
+    )
 }
 
 fn integrity(body: &[u8]) -> String {


### PR DESCRIPTION
Locks the transpile cache-key invalidation contract that #85 introduced (the compile-time build-id + `CACHE_SCHEMA` folded into the key), which previously had no test.

`nub-native` is a `cdylib` N-API addon with `test = false` — a `cargo test` harness can't link the `napi_*` symbols (resolved by the Node host at dlopen). So the pure key derivation (the blake3 preimage) is factored into a new napi-free `nub-cache-key` crate that `nub-native` calls into, with the tests living there:

- `cache_key_changes_when_build_id_changes` — a changed build-id yields a different key (the point of #85's build-id stamp).
- `cache_key_namespaced_by_schema` — the schema is hashed into the key, so the 4→5 bump makes the two eras' filenames disjoint.
- `cache_key_is_stable_for_identical_inputs` — determinism.

Behavior is byte-identical: `cache_key` delegates with the same `NUB_VERSION`/`CACHE_SCHEMA`/`BUILD_ID` consts and an identical preimage. `nub-native` keeps `test = false`, so the whole-workspace `cargo test` (including the Windows CI leg) still never builds the cdylib's harness — the new tests run on every platform via the standalone crate.

Refs #85.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa