### PR TITLE
fix(pm): don't name-only-block a bare/dist-tag install whose resolved version is clean (#88)

### DIFF
--- a/vendor/aube/crates/aube/src/commands/add/supply_chain.rs
+++ b/vendor/aube/crates/aube/src/commands/add/supply_chain.rs
@@ -22,7 +22,6 @@ pub(super) async fn run_cli_name_gates(
             )
         });
     crate::commands::add_supply_chain::run_gates(
-        &registry_inputs.name_only_advisory_names,
         &registry_inputs.exact_advisory_pairs,
         &registry_inputs.download_names,
         advisory_check,
@@ -35,7 +34,6 @@ pub(super) async fn run_cli_name_gates(
 
 #[derive(Default)]
 struct RegistryBoundSupplyChainInputs {
-    name_only_advisory_names: Vec<String>,
     exact_advisory_pairs: Vec<(String, String)>,
     download_names: Vec<String>,
 }
@@ -45,7 +43,6 @@ fn registry_bound_inputs_for_supply_chain(
     packages: &[String],
 ) -> RegistryBoundSupplyChainInputs {
     let mut inputs = RegistryBoundSupplyChainInputs {
-        name_only_advisory_names: Vec::with_capacity(packages.len()),
         exact_advisory_pairs: Vec::with_capacity(packages.len()),
         download_names: Vec::with_capacity(packages.len()),
     };
@@ -99,14 +96,23 @@ fn registry_bound_inputs_for_supply_chain(
         // API doesn't index them), so the prompt naturally skips
         // them — no per-name special case needed in the gate.
         inputs.download_names.push(spec.name.clone());
+        // Only a FULL exact pin (`name@x.y.z`) gets a version-aware
+        // pre-resolve OSV block here. Bare / dist-tag / partial-range
+        // specs are intentionally NOT name-blocked: a name-only OSV
+        // query flags a package because SOME version is malicious, which
+        // wrongly rejects a popular package with a *patched* malicious
+        // version (axios's MAL-2026-2307 covers only 0.30.4 + 1.14.1,
+        // yet `aube add axios` would resolve to a clean 1.18.1). The
+        // resolver hasn't run yet, so we can't version-check these here
+        // — the post-resolve transitive OSV gate (`osv_transitive_check`
+        // → `run_transitive_osv_gate`, version-aware over the full
+        // resolved graph) is the authoritative block. An all-versions
+        // typosquat resolves to a malicious version and is still caught
+        // there; only the patched-popular-package case newly succeeds.
         if spec.has_explicit_range && is_full_exact_version(&spec.range) {
             inputs.exact_advisory_pairs.push((spec.name, spec.range));
-        } else {
-            inputs.name_only_advisory_names.push(spec.name);
         }
     }
-    inputs.name_only_advisory_names.sort();
-    inputs.name_only_advisory_names.dedup();
     inputs.exact_advisory_pairs.sort();
     inputs.exact_advisory_pairs.dedup();
     inputs.download_names.sort();
@@ -149,12 +155,16 @@ mod tests {
             inputs.exact_advisory_pairs,
             vec![("nx".to_string(), "23.0.0".to_string())],
         );
-        assert!(inputs.name_only_advisory_names.is_empty());
         assert_eq!(inputs.download_names, vec!["nx".to_string()]);
     }
 
     #[test]
-    fn registry_bound_inputs_keep_ranges_and_tags_name_only() {
+    fn registry_bound_inputs_skip_pre_resolve_osv_for_ranges_and_tags() {
+        // Bare / dist-tag / partial-range specs get NO pre-resolve OSV
+        // pair — a name-only block would reject a popular package whose
+        // malicious version has since been patched (issue #88: axios).
+        // The post-resolve transitive gate is the authoritative check
+        // for these. The downloads gate still sees every name.
         let tmp = tempfile::tempdir().expect("tempdir");
         let inputs = registry_bound_inputs_for_supply_chain(
             tmp.path(),
@@ -167,17 +177,10 @@ mod tests {
             ],
         );
 
-        assert_eq!(
-            inputs.name_only_advisory_names,
-            vec![
-                "nx".to_string(),
-                "pkg-major".to_string(),
-                "pkg-minor".to_string(),
-                "react".to_string(),
-                "vite".to_string(),
-            ],
+        assert!(
+            inputs.exact_advisory_pairs.is_empty(),
+            "ranges/tags must not be pre-resolve OSV-checked"
         );
-        assert!(inputs.exact_advisory_pairs.is_empty());
         assert_eq!(
             inputs.download_names,
             vec![
@@ -187,6 +190,34 @@ mod tests {
                 "react".to_string(),
                 "vite".to_string(),
             ],
+        );
+    }
+
+    #[test]
+    fn bare_spec_with_patched_malicious_version_is_not_pre_resolve_blocked() {
+        // Issue #88 regression: `aube add axios` must NOT be name-only
+        // OSV-blocked. axios has MAL-2026-2307 (affecting only 0.30.4 +
+        // 1.14.1), so the old name-only pre-resolve gate hard-rejected
+        // every bare/dist-tag install even though it resolves to a clean
+        // 1.18.1. A bare spec now produces no pre-resolve advisory pair;
+        // the post-resolve versioned gate is the authoritative block,
+        // and it clears a clean resolved version while still catching a
+        // malicious one. An explicit malicious EXACT pin
+        // (`axios@1.14.1`) still routes to the version-aware pre-check.
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        let bare = registry_bound_inputs_for_supply_chain(tmp.path(), &["axios".into()]);
+        assert!(
+            bare.exact_advisory_pairs.is_empty(),
+            "bare `axios` must not be pre-resolve OSV-blocked (issue #88)"
+        );
+        assert_eq!(bare.download_names, vec!["axios".to_string()]);
+
+        let pinned = registry_bound_inputs_for_supply_chain(tmp.path(), &["axios@1.14.1".into()]);
+        assert_eq!(
+            pinned.exact_advisory_pairs,
+            vec![("axios".to_string(), "1.14.1".to_string())],
+            "an exact malicious pin still gets the version-aware pre-check"
         );
     }
 

--- a/vendor/aube/crates/aube/src/commands/add_supply_chain.rs
+++ b/vendor/aube/crates/aube/src/commands/add_supply_chain.rs
@@ -6,7 +6,11 @@
 //!    `ERR_AUBE_MALICIOUS_PACKAGE`. Confirmed malicious advisories
 //!    aren't a judgement call. Default fails open on a fetch error
 //!    (so offline workflows still install); `advisoryCheck=required`
-//!    flips that to fail closed for hardened CI.
+//!    flips that to fail closed for hardened CI. Only FULL exact pins
+//!    (`name@x.y.z`) are version-checked here pre-resolve; bare /
+//!    dist-tag / range specs are left for the post-resolve transitive
+//!    gate so a name-only hit can't reject a patched popular package
+//!    (see `run_gates`).
 //!
 //! 2. **Weekly-downloads floor** — interactive confirm prompt below
 //!    the threshold, hard refusal in non-interactive contexts unless
@@ -32,8 +36,8 @@ use aube_codes::warnings::{
 use aube_registry::osv_bloom_client::OsvBloomClient;
 use aube_registry::osv_mirror::OsvMirror;
 use aube_registry::supply_chain::{
-    DownloadCount, MaliciousAdvisory, advisory_url, fetch_malicious_advisories,
-    fetch_malicious_advisories_versioned, fetch_weekly_downloads_with,
+    DownloadCount, MaliciousAdvisory, advisory_url, fetch_malicious_advisories_versioned,
+    fetch_weekly_downloads_with,
 };
 use aube_settings::resolved::{AdvisoryBloomCheck, AdvisoryCheck, AdvisoryCheckOnInstall};
 use miette::miette;
@@ -42,9 +46,21 @@ use std::io::{BufRead, IsTerminal, Write};
 /// Run both supply-chain gates against the registry-bound specs the
 /// user passed to `aube add`. Inputs should already be filtered to
 /// packages that resolve via the public npm registry — workspace, git,
-/// and local specs are not in scope. Exact pins can use OSV's
-/// version-aware query; ranges and dist-tags stay on the name-only
-/// query until the resolver picks a concrete version.
+/// and local specs are not in scope.
+///
+/// Only FULL exact pins (`name@x.y.z`) get a pre-resolve OSV block here,
+/// via OSV's version-aware query. Bare / dist-tag / partial-range specs
+/// are deliberately NOT name-blocked at this stage: a name-only OSV query
+/// flags a package whenever *some* version is malicious, which wrongly
+/// rejects a popular package whose malicious version has since been
+/// patched (e.g. axios's MAL-2026-2307 covers only 0.30.4 + 1.14.1 while
+/// `aube add axios` resolves to a clean 1.18.1). The resolver hasn't run
+/// yet, so there's no concrete version to check — the authoritative block
+/// for these specs is the post-resolve transitive OSV gate
+/// (`run_transitive_osv_gate`, version-aware over the full resolved
+/// graph), which still catches an all-versions typosquat (it resolves to
+/// a malicious version) and a bare install whose resolved version is
+/// itself malicious.
 ///
 /// `allow_low_downloads` is the per-invocation `--allow-low-downloads`
 /// override; when `true` the download gate is skipped entirely (the
@@ -56,7 +72,6 @@ use std::io::{BufRead, IsTerminal, Write};
 /// every package regardless — exempting confirmed-malicious advisories
 /// is not what this list is for.
 pub async fn run_gates(
-    name_only_advisory_names: &[String],
     exact_advisory_pairs: &[(String, String)],
     download_names: &[String],
     advisory_check: AdvisoryCheck,
@@ -64,10 +79,7 @@ pub async fn run_gates(
     allow_low_downloads: bool,
     allowed_unpopular_globs: &[String],
 ) -> miette::Result<()> {
-    if name_only_advisory_names.is_empty()
-        && exact_advisory_pairs.is_empty()
-        && download_names.is_empty()
-    {
+    if exact_advisory_pairs.is_empty() && download_names.is_empty() {
         return Ok(());
     }
     // One client shared across both gates and every per-package
@@ -103,7 +115,6 @@ pub async fn run_gates(
             return Ok(());
         }
     };
-    osv_gate(&client, name_only_advisory_names, advisory_check).await?;
     osv_gate_versioned(
         &client,
         exact_advisory_pairs,
@@ -583,22 +594,6 @@ fn compile_allowed_unpopular(raw: &[String]) -> Vec<glob::Pattern> {
         .collect()
 }
 
-async fn osv_gate(
-    client: &reqwest::Client,
-    names: &[String],
-    policy: AdvisoryCheck,
-) -> miette::Result<()> {
-    if matches!(policy, AdvisoryCheck::Off) {
-        return Ok(());
-    }
-    handle_osv_result(
-        fetch_malicious_advisories(client, names).await,
-        policy,
-        "refusing to add malicious package(s):",
-        "advisoryCheck",
-    )
-}
-
 async fn osv_gate_versioned(
     client: &reqwest::Client,
     pairs: &[(String, String)],
@@ -797,7 +792,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn osv_gate_off_skips_network() {
+    async fn osv_gate_versioned_off_skips_network() {
         // `Off` short-circuits before any HTTP — important so users
         // who set `advisoryCheck = off` for an air-gapped registry
         // don't see spurious timeouts on add. The dummy client is
@@ -805,8 +800,12 @@ mod tests {
         // construct one to satisfy the type signature.
         let client = aube_registry::supply_chain::build_probe_client()
             .expect("probe client builder shouldn't fail in tests");
-        let names = vec!["lodash".to_string()];
-        assert!(osv_gate(&client, &names, AdvisoryCheck::Off).await.is_ok());
+        let pairs = vec![("lodash".to_string(), "4.17.21".to_string())];
+        assert!(
+            osv_gate_versioned(&client, &pairs, AdvisoryCheck::Off, "refusing to add:")
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -815,7 +814,7 @@ mod tests {
         // registry-name list. The function must be a no-op in that
         // case (no network, no error) so those code paths stay free.
         assert!(
-            run_gates(&[], &[], &[], AdvisoryCheck::Required, 1000, false, &[])
+            run_gates(&[], &[], AdvisoryCheck::Required, 1000, false, &[])
                 .await
                 .is_ok()
         );


### PR DESCRIPTION
## Problem

`nub install axios` (and any bare / dist-tag / partial-range spec) was rejected with `ERR_NUB_MALICIOUS_PACKAGE`, citing **bare** `axios (MAL-2026-2307)` under the *"refusing to add"* header — while `nub install axios@1.18.1` worked and `nub info axios` shows latest = 1.18.1 (clean). Reported in #88 (external, v0.1.12).

## Root cause

The pre-resolve CLI-name OSV gate (`run_cli_name_gates` -> `osv_gate` -> `fetch_malicious_advisories`, `version: None`) runs a **name-only** OSV query on the typed package name, **before the resolver runs**. A name-only query flags a package whenever *some* published version carries a `MAL-*` advisory. **MAL-2026-2307 affects only `axios@0.30.4` and `axios@1.14.1`** (explicit two-version affected set) — but the name-only query blocked every bare install regardless. Exact pins worked because they routed to the version-aware query (`osv_gate_versioned`).

Confirmed empirically: with `advisory_check=off`, bare `nub install axios` resolves to the clean **1.18.1** — the resolver does not pick a malicious version, and `minimumReleaseAge` does not fall back to 0.30.4/1.14.1. The block was purely the name-only pre-gate, which fires before resolution.

## Fix

Only **full exact pins** (`name@x.y.z`) keep the version-aware pre-resolve OSV block. Bare / dist-tag / partial-range specs are no longer name-only hard-blocked — there's no concrete version to check pre-resolve.

## Security property preserved

The post-resolve **transitive** OSV gate already runs version-aware over the full resolved graph on every `add` (`osv_transitive_check=true` -> `run_transitive_osv_gate`). It:
- clears a clean resolved version (axios 1.18.1),
- still blocks an **all-versions typosquat** (it resolves to a malicious version),
- still blocks a **bare install whose resolved version is itself malicious**.

Exact-pinned malicious versions remain blocked by the version-aware pre-gate.

## Verification (e2e, isolated empty npmrc)

| Command | Before | After |
| --- | --- | --- |
| `nub install axios` | blocked (bare `axios`) | installs **1.18.1** |
| `nub install axios@1.14.1` (malicious) | blocked | blocked (`axios@1.14.1`) |
| `nub install axios@0.30.4` (malicious) | blocked | blocked (`axios@0.30.4`) |
| `nub install axios@1.18.1` (clean) | installs | installs |

- `cargo test -p aube --lib` -> **668 passed, 0 failed**
- `cargo clippy -p aube --all-targets --all-features -- -D warnings` -> clean
- rustfmt --check on both touched files -> clean

Regression tests added: `bare_spec_with_patched_malicious_version_is_not_pre_resolve_blocked`, `registry_bound_inputs_skip_pre_resolve_osv_for_ranges_and_tags`.

> Note: the input-routing unit tests depend on `is_public_npmjs`, which a polluted host `~/.npmrc` (dead proxy / custom registry) can flip false. Run with an isolated/empty npmrc, as CI does.

Upstream `jdx/aube` main has no post-#923 fix for this; candidate to upstream.

Fixes #88

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa