### PR TITLE
feat(run): add --env-file-if-exists (Node v22 parity)

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1184,13 +1184,27 @@ fn run_nub() -> Result<i32> {
             s if s == "--color" || s.starts_with("--color=") || s == "--no-color" => {
                 // --color (no value), --color=always, --no-color: all consumed, not forwarded
             }
-            s if s == "--env-file" || s.starts_with("--env-file=") => {
-                // Presence of the flag (even pointing at an empty/unreadable file)
-                // opts the run out of eager `.env*` auto-discovery — only the
-                // explicit file(s) load (the maintainer, 2026-06-15).
+            s if s == "--env-file"
+                || s.starts_with("--env-file=")
+                || s == "--env-file-if-exists"
+                || s.starts_with("--env-file-if-exists=") =>
+            {
+                // `--env-file-if-exists` mirrors Node v22: load the file if present,
+                // skip SILENTLY when it is absent — vs `--env-file`, which errors on
+                // a missing file. Everything else is identical: same first-writer
+                // merge, same `${VAR}` expansion, and the flag's presence opts the
+                // run out of eager `.env*` auto-discovery either way (even when the
+                // if-exists target turns out to be absent — the user named explicit
+                // file(s), so guessing is off).
+                let if_exists = s.starts_with("--env-file-if-exists");
+                let prefix = if if_exists {
+                    "--env-file-if-exists="
+                } else {
+                    "--env-file="
+                };
                 env_file_present = true;
-                let file_path = if s.starts_with("--env-file=") {
-                    s.strip_prefix("--env-file=").unwrap().to_string()
+                let file_path = if let Some(v) = s.strip_prefix(prefix) {
+                    v.to_string()
                 } else {
                     i += 1;
                     if i < raw_args.len() {
@@ -1200,10 +1214,17 @@ fn run_nub() -> Result<i32> {
                     }
                 };
                 if !file_path.is_empty() {
-                    // read_env_file refuses non-regular files (e.g. /dev/zero) and
-                    // oversized files, so a hostile --env-file can't hang or OOM.
-                    if let Some(content) =
-                        nub_core::workspace::env::read_env_file(std::path::Path::new(&file_path))
+                    let path = std::path::Path::new(&file_path);
+                    // `--env-file-if-exists`: a non-existent file is a silent no-op
+                    // (Node's whole reason for the flag). A file that DOES exist but
+                    // can't be read still surfaces the error, matching Node — only
+                    // the missing-file case is suppressed.
+                    if if_exists && !path.exists() {
+                        // silent no-op
+                    } else if let Some(content) =
+                        // read_env_file refuses non-regular files (e.g. /dev/zero) and
+                        // oversized files, so a hostile --env-file can't hang or OOM.
+                        nub_core::workspace::env::read_env_file(path)
                     {
                         // Route through parse_env (not dotenvy directly) so the
                         // explicit --env-file flag strips backtick-quoted values
@@ -4923,6 +4944,7 @@ nub {v} — the all-in-one Node.js toolkit
   --verbose            increase nub's log verbosity (repeatable)
   --color[=<when>]     color mode: auto (default), always, never
   --env-file <file>    load environment variables from <file>
+  --env-file-if-exists <file>  like --env-file, but skip silently if <file> is absent
   --node               run on plain Node, no augmentation (the compat escape hatch)
   -v, --version        print the nub version
   -h, --help           print help (`-h` curated, `--help` this full reference)
@@ -4941,6 +4963,7 @@ nub {v} — the all-in-one Node.js toolkit
   --watch-path <path>            path to watch (repeatable)
   --watch-preserve-output        preserve output across watch restarts
   --env-file <file>              load environment variables from a file
+  --env-file-if-exists <file>    like --env-file, but skip silently if the file is absent
   --enable-source-maps           enable source-map support for stack traces
   --inspect[=[host:]port]        activate the inspector
   --inspect-brk[=[host:]port]    activate the inspector and break at start

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -3665,6 +3665,58 @@ fn env_file_flag_reaches_child_and_shell_wins() {
 }
 
 #[test]
+fn env_file_if_exists_skips_absent_file_and_loads_present_one() {
+    // Node v22 parity: `--env-file-if-exists` loads the file when present but is a
+    // SILENT no-op when absent (vs `--env-file`, which errors on a missing file).
+    // Otherwise identical to `--env-file` — same merge into the spawned child.
+    let fixture = fixtures_dir().join("env-file-flag");
+
+    // (a) absent file → no error, run succeeds, the var stays unset.
+    let missing =
+        std::env::temp_dir().join(format!("nub-ifexists-missing-{}.env", std::process::id()));
+    let _ = std::fs::remove_file(&missing); // ensure it does not exist
+    let out = Command::new(nub_binary())
+        .arg(format!("--env-file-if-exists={}", missing.display()))
+        .arg(fixture.join("print.ts"))
+        .current_dir(&fixture)
+        .output()
+        .expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "absent --env-file-if-exists must be a no-op, not an error; stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("VAR=unset"),
+        "absent if-exists file injects nothing: {stdout}"
+    );
+    assert!(
+        !stderr.contains("cannot read env file"),
+        "absent if-exists file must not warn: {stderr}"
+    );
+
+    // (b) present file → loads and reaches the child, exactly like --env-file.
+    let present =
+        std::env::temp_dir().join(format!("nub-ifexists-present-{}.env", std::process::id()));
+    std::fs::write(&present, "A19=from_ifexists\n").unwrap();
+    let out2 = Command::new(nub_binary())
+        .arg(format!("--env-file-if-exists={}", present.display()))
+        .arg(fixture.join("print.ts"))
+        .current_dir(&fixture)
+        .output()
+        .expect("failed to spawn nub");
+    let stdout2 = String::from_utf8_lossy(&out2.stdout);
+    let _ = std::fs::remove_file(&present);
+    assert_eq!(out2.status.code(), Some(0));
+    assert!(
+        stdout2.contains("VAR=from_ifexists"),
+        "present --env-file-if-exists var must reach the child: {stdout2}"
+    );
+}
+
+#[test]
 fn transpile_cache_eviction_evicts_oldest_over_cap() {
     // A16: exercises the eviction logic directly (the fixture imports
     // runtime/cache-evict.mjs and sweeps a temp dir with a small cap), so it

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -48,3 +48,9 @@ Passing `--env-file=<path>` disables the automatic `.env*` discovery entirely â€
 ```bash
 nub --env-file=.env.ci server.ts   # only .env.ci loads; auto .env* discovery is skipped; shell env still wins
 ```
+
+A missing file is an error. To load a file only when it is present and skip silently otherwise, use `--env-file-if-exists` â€” the Node v22 variant. It behaves identically to `--env-file` in every other respect.
+
+```bash
+nub --env-file-if-exists=.env.local server.ts   # loads .env.local if present; no error if it isn't
+```


### PR DESCRIPTION
Adds \`--env-file-if-exists\` to nub's env-file surface, matching Node v22.

## Semantics
- \`--env-file-if-exists <file>\`: load the file if present, **skip silently when absent** (Node's whole reason for the flag).
- \`--env-file <file>\`: unchanged — still warns on a missing file.
- A file that *exists* but can't be read still surfaces the error under \`--env-file-if-exists\`; only the missing-file case is suppressed (matching Node).

Otherwise identical to \`--env-file\`: parsed in the same command-wide pre-parse, so it inherits the same first-writer merge, \`\${VAR}\` expansion, eager \`.env*\` auto-discovery suppression, and per-child application across \`nub <file>\`, \`nub run\`, \`nubx\`, and exec. Both \`--env-file-if-exists=path\` and the space-separated form work.

## Tests
New integration test \`env_file_if_exists_skips_absent_file_and_loads_present_one\` (reuses the \`env-file-flag\` fixture): absent file is a no-op (exit 0, var unset, no warning); present file loads and reaches the child.

## Verification
- \`cargo fmt --check\` clean
- \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- \`cargo test -p nub-cli --test integration env_file\` — 3 passed
- e2e against /tmp fixtures: absent = silent no-op, present = loads, both flag forms work; cross-checked intent against \`node --env-file-if-exists\`.

## Docs
\`site/content/docs/runtime/env.mdx\` updated with the if-exists variant.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa