### PR TITLE
feat(add): mirror npm save-prefix for bare-version add under npm incumbent

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1316,6 +1316,11 @@ pub(crate) fn engine_brand_preflight() {
     // incumbent; under any other surface those Bun-named env vars are another
     // tool's state and must not be read (name-based policy, like `read_yarn_config`).
     let read_bun_config = read_bun_config_for_surface(&surface);
+    // npm save-prefix convention: only under an npm incumbent does a bare-exact
+    // `add pkg@1.2.3` get npm's `^` save-prefix (`"^1.2.3"`). pnpm/bun/nub-identity
+    // preserve the literal bare version — matching each PM's real behavior.
+    let npm_save_prefix_on_bare_exact =
+        matches!(surface, ConfigSurface::NonPnpmCompat { role: "npm", .. });
     aube_util::update_engine_context(|c| {
         c.read_branded_pnpm_config = read_branded_pnpm_config;
         // GLOBAL config is read PM-AGNOSTICALLY and UNGATED by cwd incumbency:
@@ -1337,6 +1342,7 @@ pub(crate) fn engine_brand_preflight() {
         c.pnpmfile_default_enabled = pnpmfile_default_enabled;
         c.synthetic_user_npmrc_entries = bunfig.user;
         c.synthetic_project_npmrc_entries = bunfig.project;
+        c.npm_save_prefix_on_bare_exact = npm_save_prefix_on_bare_exact;
     });
     match surface {
         ConfigSurface::NubIdentity(dir) => {

--- a/tests/mutation/expected-failures.txt
+++ b/tests/mutation/expected-failures.txt
@@ -8,24 +8,3 @@
 # SAME mutation (add/remove/update). Each entry names the exact divergence
 # richly enough to open a fix thread.
 
-# -- npm save-prefix: bare-version add does not apply npm's `^` save-prefix --
-# When the user runs `nub add <pkg>@<exact>` or `nub add <pkg>` (a BARE version,
-# no range operator), nub writes the resolved version VERBATIM to package.json
-# dependencies (e.g. `"ms": "2.1.3"`). Real npm's `npm install <pkg>` applies its
-# save-prefix default (`^`) and writes `"ms": "^2.1.3"`. nub instead mirrors
-# PNPM's convention (preserve the user-typed spec literally -- pnpm/bun legs PASS
-# because real pnpm/bun ALSO write bare `2.1.3` for an explicit version), and
-# applies that one convention regardless of the active PM. So on an npm-format
-# project the manifest spec diverges: nub `2.1.3` vs npm `^2.1.3`.
-#   - An EXPLICIT range is preserved correctly by nub on all PMs (verified:
-#     `nub add ms@^2.1.3` -> `^2.1.3`, `nub add ms@~2.1.0` -> `~2.1.0`). The bug
-#     is ONLY the bare-exact-version -> save-prefix-default path, and ONLY npm.
-#   - Per-PM CONVENTION question (mirror each PM's save-prefix when nub mirrors
-#     that PM, vs one universal literal-preserve rule) -> product decision,
-#     recommend-only. Fix candidate: when the target lockfile is npm-format and
-#     the user supplied a bare version, default the saved spec to `^<version>`.
-# Both npm legs below are the SAME root cause (m1 = top-level bare add; m3 = bare
-# add that also pulls a second is-odd version -- dedup is correct, only the
-# manifest spec diverges).
-m1-add-noconflict npm bare-version add writes literal 2.1.3 to package.json; npm applies its ^ save-prefix and writes ^2.1.3 (nub mirrors pnpm literal-preserve regardless of active PM; npm-save-prefix convention question -- recommend-only)
-m3-add-dedup npm bare-version add of is-even writes literal 1.0.0 to package.json; npm writes ^1.0.0 (same npm save-prefix divergence as m1; de-dup itself is correct -- frozen npm ci accepts, only manifest spec differs)

--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -2447,6 +2447,22 @@ sources.npmrc = ["save-prefix", "savePrefix"]
 sources.workspaceYaml = ["savePrefix"]
 examples = []
 
+[saveExact]
+description = "Save dependencies with an exact version instead of a range prefix."
+type = "bool"
+default = "false"
+docs = """
+The npm/pnpm-compatible `save-exact` knob: when set, `add` pins the saved
+specifier to the exact resolved version (empty save-prefix). Equivalent to the
+`--save-exact` flag, and overrides `save-prefix` when both are set. Read from
+`.npmrc` so an existing `save-exact=true` is honored on `add`.
+"""
+sources.cli = []
+sources.env = ["npm_config_save_exact", "NPM_CONFIG_SAVE_EXACT", "AUBE_SAVE_EXACT"]
+sources.npmrc = ["save-exact", "saveExact"]
+sources.workspaceYaml = []
+examples = []
+
 [linkWorkspacePackages]
 description = "Resolve `aube add <name>` against local workspace siblings before falling back to the registry."
 type = '"false" | "true" | "deep"'

--- a/vendor/aube/crates/aube-util/src/engine_context.rs
+++ b/vendor/aube/crates/aube-util/src/engine_context.rs
@@ -200,6 +200,28 @@ pub struct EngineContext {
     ///
     /// [`Embedder::user_agent`]: crate::identity::Embedder::user_agent
     pub lifecycle_user_agent_product: Option<String>,
+
+    /// Whether a bare *exact* version on `add` (`add pkg@1.2.3`, or a bare
+    /// `add pkg` that resolves to a concrete version) is saved to
+    /// `package.json` with the configured `save-prefix` applied (e.g.
+    /// `"^1.2.3"`) rather than the literal version (`"1.2.3"`). `false`
+    /// (default) preserves upstream aube/pnpm behavior: pnpm and bun write the
+    /// user-typed bare version verbatim, so standalone aube (a pnpm drop-in)
+    /// does too. An embedder mirroring an **npm** incumbent sets this `true`,
+    /// because real `npm install pkg@1.2.3` applies its `save-prefix` default
+    /// (`^`) and writes `"^1.2.3"`.
+    ///
+    /// This gates ONLY the bare-exact-version path. An explicit *range*
+    /// (`add pkg@^1`, `add pkg@~1.2`, `add pkg@>=1`) is always preserved
+    /// verbatim on every PM, and `--save-exact` (or `save-exact=true`) always
+    /// pins the bare version regardless of this posture. The prefix applied is
+    /// the resolved `save-prefix` (honoring `.npmrc` `save-prefix` /
+    /// `save-exact`), so a custom `save-prefix=~` yields `"~1.2.3"`.
+    ///
+    /// Embedder-fixed per invocation: the host derives it from the project's
+    /// incumbent PM, exactly like [`read_branded_pnpm_config`](Self::read_branded_pnpm_config)
+    /// and the other incumbent-keyed read postures. aube assigns no policy.
+    pub npm_save_prefix_on_bare_exact: bool,
 }
 
 impl Default for EngineContext {
@@ -221,6 +243,7 @@ impl Default for EngineContext {
             path_prepends: Vec::new(),
             env_overlay: Vec::new(),
             lifecycle_user_agent_product: None,
+            npm_save_prefix_on_bare_exact: false,
         }
     }
 }
@@ -284,5 +307,6 @@ mod tests {
         assert!(ctx.path_prepends.is_empty());
         assert!(ctx.env_overlay.is_empty());
         assert_eq!(ctx.lifecycle_user_agent_product, None);
+        assert!(!ctx.npm_save_prefix_on_bare_exact);
     }
 }

--- a/vendor/aube/crates/aube/src/commands/add/manifest.rs
+++ b/vendor/aube/crates/aube/src/commands/add/manifest.rs
@@ -133,7 +133,11 @@ pub(super) async fn update_manifest_for_add(
     let (default_tag, default_prefix, catalog_mode) =
         crate::commands::with_settings_ctx(cwd, |ctx| {
             let tag = aube_settings::resolved::tag(ctx);
-            let prefix = if opts.save_exact {
+            // `--save-exact` (CLI) OR a resolved `.npmrc`/env `save-exact=true`
+            // both pin to the exact version (empty prefix). npm and pnpm both
+            // honor the `save-exact` config knob, so reading it here is the
+            // npm/pnpm-compatible behavior, not nub-specific.
+            let prefix = if opts.save_exact || aube_settings::resolved::save_exact(ctx) {
                 String::new()
             } else {
                 let raw = aube_settings::resolved::save_prefix(ctx);
@@ -421,9 +425,23 @@ pub(super) async fn update_manifest_for_add(
         let is_jsr = spec.jsr_name.is_some();
         let needs_npm_prefix = !is_jsr && (spec.alias.is_some() || orig.starts_with("npm:"));
         let prefix = &default_prefix;
+        // npm-incumbent save-prefix convention: `npm install pkg@1.2.3` applies
+        // its `save-prefix` default and writes `"^1.2.3"`, whereas pnpm/bun
+        // preserve the bare version. The embedder turns this on
+        // (`npm_save_prefix_on_bare_exact`) only under an npm incumbent; under
+        // pnpm/bun/nub-identity it stays off and the literal is preserved.
+        // Scope is exactly a BARE EXACT version the user supplied — an explicit
+        // range (`^1`, `~1.2`, `>=1`) never parses as a strict `Version`, so it
+        // is preserved verbatim. Dist-tags and `--save-exact` are handled by the
+        // other `pin_to_resolved` clauses; this one only catches the
+        // bare-exact-version add.
+        let bare_exact_npm_save_prefix = aube_util::engine_context().npm_save_prefix_on_bare_exact
+            && spec.has_explicit_range
+            && node_semver::Version::parse(&spec.range).is_ok();
         let pin_to_resolved = spec.range == default_tag
             || packument.dist_tags.contains_key(&spec.range)
-            || opts.save_exact;
+            || opts.save_exact
+            || bare_exact_npm_save_prefix;
         // Dist-tags and `--save-exact` both resolve to a concrete version
         // with the configured prefix (empty when `--save-exact`). Non-dist-tag
         // explicit ranges (e.g. `lodash@^4`) are preserved as-is.


### PR DESCRIPTION
## What

When the project's incumbent package manager is **npm**, `nub add <pkg>@<exact>` (or a bare `nub add <pkg>` that resolves to a concrete version) now writes the saved specifier with npm's default save-prefix applied (`"^1.2.3"`), matching real `npm install`. pnpm/bun/nub-identity projects keep literal-preserve (`"1.2.3"`), matching real pnpm/bun. An explicit range (`^1`, `~1.2`, `>=1`) is preserved verbatim on every PM.

This is the npm-incumbent behavior nub users expect (Option A, decided by the maintainer).

## How

- **`vendor/aube` EngineContext**: new per-invocation posture `npm_save_prefix_on_bare_exact` (default `false` = upstream-neutral; standalone aube byte-for-byte unaffected). Set `true` only under an npm compat surface.
- **`vendor/aube` add manifest writer**: a bare *exact* version (detected via `Version::parse` on the user's explicit range) is written with the resolved save-prefix when the posture is on. Explicit ranges always fall through to verbatim preservation.
- **`vendor/aube` settings**: new `saveExact` knob so an existing `.npmrc save-exact=true` (or env) pins the exact version on add — npm and pnpm both read this knob; previously only the CLI `--save-exact` flag took effect.
- **nub `pm_engine`**: sets the posture `true` only for `ConfigSurface::NonPnpmCompat { role: "npm" }`.

The resolved save-prefix is honored, so `.npmrc save-prefix=~` yields `"~1.2.3"`; `save-exact=true` yields the exact pin `"1.2.3"`.

## Mutation harness

Un-gates `m1-add-noconflict npm` + `m3-add-dedup npm` (removed from `tests/mutation/expected-failures.txt`). The full differential harness is now **9/9 PASS** (npm legs produce package.json specifiers byte-equivalent to real npm; pnpm/bun literal-preserve legs unchanged).

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check`: clean.
- aube unit tests: `aube-settings` 61 passed, `aube` add 71 passed.
- Mutation harness (real npm 11.13.0 / pnpm 10.15.1 / bun 1.3.14): 9/9 PASS.
- e2e parity vs real npm: `ms@2.1.3`→`^2.1.3`, `~2.1.0`→`~2.1.0` (preserved), bare `ms`→`^2.1.3`, `save-exact=true`→`2.1.3`, `save-prefix=~`→`~2.1.3`, `--save-exact`→`2.1.3`; pnpm/bun/nub-identity all keep `2.1.3`.

Refs: npm-add-save-prefix-convention thread.