### PR TITLE
worker: spec-faithful Worker — inline/Blob/data: workers, name, error location, classic mode

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -2291,6 +2291,24 @@ fn worker_from_blob_url() {
 }
 
 #[test]
+fn blob_wrapping_preserves_file_instanceof_blob() {
+    // Regression: nub subclasses globalThis.Blob to support blob: workers. `File`
+    // is a bootstrap global extending the NATIVE Blob, so the swap must re-point
+    // File's prototype chain or `new File(...) instanceof Blob` silently turns
+    // false — an additivity violation vs vanilla Node (File IS-A Blob).
+    let (stdout, stderr, code) = run_nub("worker", "blob-file-instanceof.ts");
+    assert_eq!(code, 0, "blob/File fixture should run: {stderr}\n{stdout}");
+    assert!(
+        stdout.contains("file-instanceof-blob:true"),
+        "File must remain an instanceof Blob after the Blob wrap (matches plain Node): {stdout}"
+    );
+    assert!(
+        stdout.contains("blob-instanceof-blob:true") && stdout.contains("blob-size:5"),
+        "a Blob made through the wrapper must keep instanceof + the full Blob API: {stdout}"
+    );
+}
+
+#[test]
 fn worker_error_event_carries_source_location() {
     // WHATWG ErrorEvent must carry filename/lineno/colno from where the error was
     // raised. nub fills these from the worker error's stack (they were hardcoded
@@ -2387,6 +2405,24 @@ fn classic_worker_importscripts_loads_synchronously() {
     assert!(
         stdout.contains("classic:dep-said:imported-via-importScripts"),
         "importScripts must synchronously load + run the dependency in scope: {stdout}"
+    );
+}
+
+#[test]
+fn module_worker_importscripts_throws() {
+    // WHATWG: importScripts is classic-only and must throw in a module worker.
+    // nub's DEFAULT worker type is "module" (a documented divergence from the
+    // WHATWG "classic" default — aligns with nub's ESM-first posture), so a
+    // default-type worker calling importScripts throws. This test pins that
+    // behavior; the default-type choice is a maintainer-owned spec call.
+    let (stdout, stderr, code) = run_nub("worker", "module-importscripts-throws-main.ts");
+    assert_eq!(
+        code, 0,
+        "module-importscripts fixture should run: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("module-importscripts:threw"),
+        "importScripts must throw in a module (default-type) worker: {stdout}"
     );
 }
 

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -2247,6 +2247,150 @@ fn worker_without_inbound_listener_exits_naturally() {
 }
 
 #[test]
+fn worker_name_option_reaches_both_sides() {
+    // WHATWG: the {name} ctor option surfaces as `worker.name` (main side) AND
+    // `self.name` (worker side, DedicatedWorkerGlobalScope.name). nub backs both
+    // with worker_threads `name`/`threadName`. Previously {name} was dropped.
+    let (stdout, stderr, code) = run_nub("worker", "name-main.ts");
+    assert_eq!(code, 0, "name fixture should run: {stderr}");
+    assert!(
+        stdout.contains("main-worker.name:pricer"),
+        "worker.name must reflect the {{name}} option on the main side: {stdout}"
+    );
+    assert!(
+        stdout.contains("self.name:pricer"),
+        "self.name must reflect the {{name}} option inside the worker: {stdout}"
+    );
+}
+
+#[test]
+fn worker_from_data_url() {
+    // WHATWG inline-worker mechanism: a `data:` URL worker. Node runs it directly
+    // (worker_threads v14.9) and nub's worker-side scope (self/postMessage) is
+    // installed via the preload, so the inline worker can reply over `self`.
+    let (stdout, stderr, code) = run_nub("worker", "data-url-main.ts");
+    assert_eq!(code, 0, "data: URL worker should run: {stderr}\n{stdout}");
+    assert!(
+        stdout.contains("data-url:from-data-url"),
+        "data: URL worker must execute its inline source and reply: {stdout}"
+    );
+}
+
+#[test]
+fn worker_from_blob_url() {
+    // WHATWG standard inline mechanism: a `blob:` URL worker via
+    // URL.createObjectURL(new Blob([src])). nub wraps createObjectURL so the
+    // Blob's source is captured synchronously for the (sync) Worker constructor,
+    // then spawns it with eval. Previously the constructor threw on non-file input.
+    let (stdout, stderr, code) = run_nub("worker", "blob-url-main.ts");
+    assert_eq!(code, 0, "blob: URL worker should run: {stderr}\n{stdout}");
+    assert!(
+        stdout.contains("blob-url:from-blob-url"),
+        "blob: URL worker must execute its captured source and reply: {stdout}"
+    );
+}
+
+#[test]
+fn worker_error_event_carries_source_location() {
+    // WHATWG ErrorEvent must carry filename/lineno/colno from where the error was
+    // raised. nub fills these from the worker error's stack (they were hardcoded
+    // ""/0/0 before). The fixture asserts a real filename + a nonzero lineno.
+    let (stdout, stderr, code) = run_nub("worker", "error-location-main.ts");
+    assert_eq!(
+        code, 0,
+        "error-location fixture should run: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("err-loc:filename=true:lineno=true"),
+        "ErrorEvent must expose the worker error's filename + a nonzero lineno: {stdout}"
+    );
+}
+
+#[test]
+fn worker_has_no_exit_event() {
+    // The non-spec `exit` event is GONE: web Workers have no exit event (it is a
+    // node:worker_threads concept). An addEventListener('exit') must never fire,
+    // even after the worker exits via self.close().
+    let (stdout, stderr, code) = run_nub("worker", "spec-events-main.ts");
+    assert_eq!(
+        code, 0,
+        "spec-events fixture should run: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("exit-event-fired:false"),
+        "no `exit` event may fire on the web Worker (it is not a spec event): {stdout}"
+    );
+}
+
+#[test]
+fn worker_transfers_and_detaches_arraybuffer() {
+    // postMessage(data, [buffer]) transfers ownership: the worker receives the
+    // bytes and the main-side ArrayBuffer is DETACHED (byteLength 0), per the
+    // structured-clone-with-transfer algorithm.
+    let (stdout, stderr, code) = run_nub("worker", "transfer-detach-main.ts");
+    assert_eq!(code, 0, "transfer fixture should run: {stderr}\n{stdout}");
+    assert!(
+        stdout.contains("worker-saw-bytes:8:8"),
+        "the transferred ArrayBuffer must arrive intact in the worker: {stdout}"
+    );
+    assert!(
+        stdout.contains("main-detached:true"),
+        "the main-side ArrayBuffer must be detached after transfer: {stdout}"
+    );
+}
+
+#[test]
+fn worker_messagechannel_port_roundtrip() {
+    // MessageChannel/MessagePort are web globals (Node-backed); verify a port
+    // transferred to a worker carries a message round-trip web-correctly under nub.
+    let (stdout, stderr, code) = run_nub("worker", "messagechannel-main.ts");
+    assert_eq!(
+        code, 0,
+        "MessageChannel fixture should run: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("port-roundtrip:echo:ping-over-port"),
+        "a transferred MessagePort must round-trip a message: {stdout}"
+    );
+}
+
+#[test]
+fn broadcastchannel_delivers_to_other_not_self() {
+    // BroadcastChannel (Node global, stable v18.0): a message reaches OTHER
+    // channels of the same name but NOT the sender's own channel (WHATWG §9.5).
+    let (stdout, stderr, code) = run_nub("worker", "broadcastchannel-main.ts");
+    assert_eq!(
+        code, 0,
+        "BroadcastChannel fixture should run: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("bc-received:broadcast-hello"),
+        "a BroadcastChannel message must reach another channel on the same name: {stdout}"
+    );
+    assert!(
+        stdout.contains("bc-sender-got-own:false"),
+        "the BroadcastChannel sender must NOT receive its own message: {stdout}"
+    );
+}
+
+#[test]
+fn classic_worker_importscripts_loads_synchronously() {
+    // WHATWG WorkerGlobalScope.importScripts (classic workers only): a
+    // {type:"classic"} worker synchronously loads + evaluates another script in
+    // its scope. nub provides importScripts for classic workers (and a throwing
+    // form for module workers).
+    let (stdout, stderr, code) = run_nub("worker", "classic-main.ts");
+    assert_eq!(
+        code, 0,
+        "classic importScripts fixture should run: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("classic:dep-said:imported-via-importScripts"),
+        "importScripts must synchronously load + run the dependency in scope: {stdout}"
+    );
+}
+
+#[test]
 fn recursive_run_self_reference_terminates_via_guard() {
     // A `"build": "nub run -r build"` script must terminate via the recursion
     // guard (npm_package_name + npm_lifecycle_event identify the re-entered

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -2264,6 +2264,21 @@ fn worker_name_option_reaches_both_sides() {
 }
 
 #[test]
+fn worker_unnamed_self_name_is_empty() {
+    // WHATWG: an UNNAMED worker's self.name must be "". On Node >=24.6/22.20,
+    // native worker_threads.threadName returns the literal "WorkerThread" sentinel
+    // (the thread DISPLAY name) for an unnamed worker — nub must NOT surface that
+    // as self.name. The polyfill prefers the injected NUB_WORKER_NAME env (which
+    // carries the exact intent, "") and filters the "WorkerThread" sentinel.
+    let (stdout, stderr, code) = run_nub("worker", "unnamed-main.ts");
+    assert_eq!(code, 0, "unnamed fixture should run: {stderr}\n{stdout}");
+    assert!(
+        stdout.contains("unnamed-self.name:[]"),
+        "an unnamed worker's self.name must be the empty string, not a sentinel: {stdout}"
+    );
+}
+
+#[test]
 fn worker_from_data_url() {
     // WHATWG inline-worker mechanism: a `data:` URL worker. Node runs it directly
     // (worker_threads v14.9) and nub's worker-side scope (self/postMessage) is

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -2298,8 +2298,12 @@ fn worker_blob_wrapping_preserves_file_instanceof_blob() {
     // false — an additivity violation vs vanilla Node (File IS-A Blob).
     let (stdout, stderr, code) = run_nub("worker", "blob-file-instanceof.ts");
     assert_eq!(code, 0, "blob/File fixture should run: {stderr}\n{stdout}");
+    // `File` is a Node global only from v20; on the 18.x floor it is absent (as in
+    // vanilla Node), so the fixture reports a skip there. When File exists it MUST
+    // remain a Blob after nub's Blob wrap.
     assert!(
-        stdout.contains("file-instanceof-blob:true"),
+        stdout.contains("file-instanceof-blob:true")
+            || stdout.contains("file-instanceof-blob:skip-no-File-global"),
         "File must remain an instanceof Blob after the Blob wrap (matches plain Node): {stdout}"
     );
     assert!(

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -2291,7 +2291,7 @@ fn worker_from_blob_url() {
 }
 
 #[test]
-fn blob_wrapping_preserves_file_instanceof_blob() {
+fn worker_blob_wrapping_preserves_file_instanceof_blob() {
     // Regression: nub subclasses globalThis.Blob to support blob: workers. `File`
     // is a bootstrap global extending the NATIVE Blob, so the swap must re-point
     // File's prototype chain or `new File(...) instanceof Blob` silently turns

--- a/npm/nub-types/index.d.ts
+++ b/npm/nub-types/index.d.ts
@@ -99,6 +99,7 @@ interface WorkerOptions {
   credentials?: "omit" | "same-origin" | "include";
 }
 interface __NubWorker extends EventTarget {
+  readonly name: string;
   postMessage(message: any, transfer?: readonly (ArrayBuffer | MessagePort)[]): void;
   terminate(): void;
   onmessage: ((this: Worker, ev: MessageEvent) => any) | null;

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -218,6 +218,17 @@ function installLazyEsmPolyfills() {
     return;
   }
 
+  // Main thread: install blob: worker support EAGERLY. It only wraps
+  // URL.createObjectURL + subclasses Blob (touches no node:worker_threads, so it's
+  // cold-start-cheap) and MUST be live before user code calls createObjectURL —
+  // which happens before the first `new Worker`, so it cannot wait for the lazy
+  // Worker load below. See runtime/worker-blob-url.cjs.
+  try {
+    __require("./worker-blob-url.cjs").installBlobUrlSupport();
+  } catch {
+    // blob: worker support is best-effort; never block startup on it.
+  }
+
   // Main thread: lazy Worker global. Defined NON-ENUMERABLE so it stays invisible
   // to `Object.keys(globalThis)` / for-in — the additive contract — matching how
   // worker-polyfill.mjs defines the real one.

--- a/runtime/worker-blob-url.cjs
+++ b/runtime/worker-blob-url.cjs
@@ -1,0 +1,82 @@
+// Blob-URL worker source capture — the SYNC half of WHATWG `blob:` worker support.
+//
+// A `new Worker(blobUrl)` must read the Blob's source SYNCHRONOUSLY in the
+// constructor, but a Blob's bytes are only readable via the async Blob.text /
+// arrayBuffer. We close that gap by snapshotting the source at
+// `URL.createObjectURL(blob)` time — which always runs BEFORE the Worker is
+// constructed — into a registry keyed by the minted URL.
+//
+// This lives in its OWN tiny CJS module (no node:worker_threads dependency) so the
+// main-thread preload can install the wrap EAGERLY: it must be live before user
+// code calls createObjectURL, whereas worker-polyfill.mjs (which pulls
+// worker_threads + the whole streams/worker-io builtin set) is loaded LAZILY on
+// first `new Worker` to protect cold start. The Worker class imports THIS module to
+// read `blobUrlSources`. Touches only URL / Blob / Buffer — all already-realized
+// core globals — so requiring it adds nothing to the main-thread bootstrap set.
+
+// blob: URL → source text. Shared with worker-polyfill.mjs's Worker constructor.
+const blobUrlSources = new Map();
+// Blob construction parts, remembered so createObjectURL can assemble source sync.
+const blobParts = new WeakMap();
+
+function decode(parts) {
+  let src = "";
+  for (const p of parts ?? []) {
+    if (typeof p === "string") src += p;
+    else if (typeof Buffer !== "undefined" && Buffer.isBuffer(p)) src += p.toString("utf8");
+    else if (ArrayBuffer.isView(p)) src += Buffer.from(p.buffer, p.byteOffset, p.byteLength).toString("utf8");
+    else if (p instanceof ArrayBuffer) src += Buffer.from(p).toString("utf8");
+    else if (typeof p === "object" && p && typeof p.size === "number") {
+      const nested = blobParts.get(p); // a nested Blob made via our wrapper
+      if (nested) src += decode(nested);
+    }
+  }
+  return src;
+}
+
+// Wrap URL.createObjectURL/revokeObjectURL and subclass Blob to remember parts.
+// Idempotent + transparent for every non-worker use. No-op when URL has no
+// createObjectURL (older floors) — blob: workers are then simply unavailable.
+function installBlobUrlSupport() {
+  if (typeof URL === "undefined" || typeof URL.createObjectURL !== "function") return;
+  if (URL.createObjectURL.__nubWrapped) return;
+
+  const NativeBlob = globalThis.Blob;
+  if (typeof NativeBlob === "function" && !NativeBlob.__nubWrapped) {
+    // Transparent subclass: `instanceof Blob` stays true and the full Blob API is
+    // intact; we only record the construction parts for sync source assembly.
+    class Blob extends NativeBlob {
+      constructor(parts = [], options) {
+        super(parts, options);
+        blobParts.set(this, parts);
+      }
+    }
+    Object.defineProperty(Blob, "__nubWrapped", { value: true });
+    Object.defineProperty(globalThis, "Blob", {
+      value: Blob,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  const nativeCreate = URL.createObjectURL.bind(URL);
+  const nativeRevoke =
+    typeof URL.revokeObjectURL === "function" ? URL.revokeObjectURL.bind(URL) : null;
+  const wrappedCreate = function createObjectURL(obj) {
+    const url = nativeCreate(obj);
+    const parts = blobParts.get(obj);
+    if (parts) blobUrlSources.set(url, decode(parts));
+    return url;
+  };
+  Object.defineProperty(wrappedCreate, "__nubWrapped", { value: true });
+  URL.createObjectURL = wrappedCreate;
+  if (nativeRevoke) {
+    URL.revokeObjectURL = function revokeObjectURL(url) {
+      blobUrlSources.delete(url);
+      return nativeRevoke(url);
+    };
+  }
+}
+
+module.exports = { blobUrlSources, installBlobUrlSupport };

--- a/runtime/worker-blob-url.cjs
+++ b/runtime/worker-blob-url.cjs
@@ -58,6 +58,19 @@ function installBlobUrlSupport() {
       writable: true,
       configurable: true,
     });
+
+    // `File` is a Node bootstrap global that `extends` the NATIVE Blob, realized
+    // before this swap. Without re-pointing, `new File(...) instanceof Blob`
+    // becomes FALSE (File still extends native Blob, but `globalThis.Blob` is now
+    // the subclass) — a silent additivity violation vs vanilla Node, where File
+    // IS-A Blob. Re-parent File's prototype chain onto the new Blob so the
+    // `instanceof` contract holds. Both the .prototype link (instances) and the
+    // constructor link (static inheritance) are re-pointed.
+    const File = globalThis.File;
+    if (typeof File === "function" && Object.getPrototypeOf(File) === NativeBlob) {
+      Object.setPrototypeOf(File.prototype, Blob.prototype);
+      Object.setPrototypeOf(File, Blob);
+    }
   }
 
   const nativeCreate = URL.createObjectURL.bind(URL);

--- a/runtime/worker-polyfill.mjs
+++ b/runtime/worker-polyfill.mjs
@@ -352,18 +352,28 @@ if (!isMainThread && parentPort) {
   // `self.name` — the worker's name from the constructor's {name} option (WHATWG
   // DedicatedWorkerGlobalScope.name). Node only exposes a worker-side reader for
   // the {name} option as `worker_threads.threadName` from v24.6.0 / v22.20.0 — it
-  // is ABSENT across nub's whole compat tier (18.19–22.14) and on 22.15–22.19, so
-  // it cannot be the floor mechanism. We therefore THREAD the name in ourselves
-  // via the internal NUB_WORKER_NAME env (internal plumbing var — exempt from the
-  // brand boundary), set by the main-side constructor, and prefer the native
-  // threadName where it exists (newer Node). The env survives across the floor and
-  // is the only portable carrier; the SHARE_ENV edge (where the ctor can't inject
-  // env) falls back to native threadName / "".
+  // is ABSENT across nub's whole compat tier (18.19–22.19), so it cannot be the
+  // floor mechanism. We THREAD the name in ourselves via the internal
+  // NUB_WORKER_NAME env (internal plumbing var — exempt from the brand boundary),
+  // set by the main-side constructor.
+  //
+  // RESOLUTION ORDER — env FIRST (not native threadName): NUB_WORKER_NAME carries
+  // the user's EXACT intent including the empty string, whereas native
+  // `threadName` defaults to the literal sentinel "WorkerThread" for an UNNAMED
+  // worker (it's the thread DISPLAY name, not the WHATWG worker name) — surfacing
+  // that as self.name would be a spec divergence (an unnamed worker's name must be
+  // ""). So: the injected env wins when present; native threadName is the fallback
+  // ONLY on the SHARE_ENV path (where the ctor couldn't inject env), with the
+  // "WorkerThread" sentinel filtered to "".
   {
     const wt = __getBuiltin("node:worker_threads");
-    const name =
-      (wt && typeof wt.threadName === "string" && wt.threadName) ||
-      (typeof process.env.NUB_WORKER_NAME === "string" ? process.env.NUB_WORKER_NAME : "");
+    let name;
+    if (typeof process.env.NUB_WORKER_NAME === "string") {
+      name = process.env.NUB_WORKER_NAME;
+    } else {
+      const tn = wt && typeof wt.threadName === "string" ? wt.threadName : "";
+      name = tn === "WorkerThread" ? "" : tn;
+    }
     Object.defineProperty(scope, "name", {
       value: name,
       enumerable: false,

--- a/runtime/worker-polyfill.mjs
+++ b/runtime/worker-polyfill.mjs
@@ -103,7 +103,13 @@ export function installWorkerPolyfill() {
   // `error` event delivers the thrown Error; we read its first stack frame.
   // Browser-scrubbing of cross-origin frames does not apply here (all worker
   // sources are same-origin local), so we surface the raw location.
-  const STACK_FRAME = /\(?(?:file:\/\/)?(.+?):(\d+):(\d+)\)?\s*$/;
+  //
+  // The frame is anchored at `at ` and consumes the optional `Func (` wrapper so
+  // group 1 is JUST the path (a `file://` URL, an absolute POSIX path, or a
+  // Windows `C:\…` path — the leading `C:` is NOT mistaken for the location
+  // colon because the line:col are the LAST two `:`-segments). Without the anchor
+  // + wrapper-consumption the path captured the `at Func (` prefix verbatim.
+  const STACK_FRAME = /^at\s+(?:.+?\s+\()?(.+?):(\d+):(\d+)\)?$/;
   function locationFromError(err) {
     let filename = "";
     let lineno = 0;

--- a/runtime/worker-polyfill.mjs
+++ b/runtime/worker-polyfill.mjs
@@ -87,76 +87,180 @@ function getErrorEventCtor() {
 export function installWorkerPolyfill() {
   const { Worker: NodeWorker, parentPort, isMainThread } = __getBuiltin("node:worker_threads");
   const { fileURLToPath } = __getBuiltin("node:url");
+  // blob: worker source registry, shared with the eager main-thread preload that
+  // wraps URL.createObjectURL (worker-blob-url.cjs). Loaded via createRequire so
+  // both this lazily-loaded ESM module and the eager CJS preload reference the SAME
+  // module instance (Node dedupes by resolved path) — i.e. the SAME blobUrlSources.
+  const { blobUrlSources, installBlobUrlSupport } = (
+    typeof process.getBuiltinModule === "function"
+      ? __getBuiltin("node:module").createRequire(import.meta.url)
+      : _bootstrapCreateRequire(import.meta.url)
+  )("./worker-blob-url.cjs");
+
+  // Resolve a worker-error stack frame to {filename,lineno,colno} so the
+  // ErrorEvent carries real source location, per WHATWG §10.2.6 (the spec
+  // requires these fields populated from where the error was raised). Node's
+  // `error` event delivers the thrown Error; we read its first stack frame.
+  // Browser-scrubbing of cross-origin frames does not apply here (all worker
+  // sources are same-origin local), so we surface the raw location.
+  const STACK_FRAME = /\(?(?:file:\/\/)?(.+?):(\d+):(\d+)\)?\s*$/;
+  function locationFromError(err) {
+    let filename = "";
+    let lineno = 0;
+    let colno = 0;
+    const stack = err && typeof err.stack === "string" ? err.stack : "";
+    for (const line of stack.split("\n")) {
+      const t = line.trim();
+      if (!t.startsWith("at ")) continue;
+      const m = STACK_FRAME.exec(t);
+      if (m) {
+        filename = m[1].startsWith("file://") ? fileURLToPath(m[1]) : m[1];
+        lineno = Number(m[2]) || 0;
+        colno = Number(m[3]) || 0;
+        break;
+      }
+    }
+    return { filename, lineno, colno };
+  }
 
   if (typeof globalThis.Worker === "undefined") {
   class Worker extends EventTarget {
     #worker;
+    #name;
 
     constructor(url, options = {}) {
       super();
 
-      let workerPath;
-      if (url instanceof URL) {
-        workerPath = fileURLToPath(url);
-      } else if (typeof url === "string") {
-        if (url.startsWith("file://")) {
-          workerPath = fileURLToPath(url);
-        } else {
-          workerPath = url;
-        }
-      } else {
+      // The WHATWG Worker constructor accepts a script URL. Per §10.2.6.3 the
+      // standard inline mechanisms are `blob:` and `data:` URLs (there is no
+      // inline-source-string form in the spec). We map each to a Node spawn:
+      //   - file path / file: URL  → spawn the file (transpiled by nub's preload)
+      //   - data: URL              → Node runs it directly (worker_threads v14.9)
+      //   - blob: URL              → resolve the Blob via node:buffer, spawn its
+      //                              source with eval:true (Node can't open blob:)
+      let spawnTarget;
+      let evalMode = false;
+
+      const asUrlString =
+        url instanceof URL ? url.href : typeof url === "string" ? url : null;
+      if (asUrlString === null) {
         throw new TypeError("Worker constructor: url must be a string or URL");
       }
 
-      // `type: "module" | "classic"` is accepted for web compatibility but not
-      // enforced: Node decides module-vs-CJS for the worker entry by file
-      // extension + nearest package.json "type" (the same rule nub applies to
-      // the main entry), and there is no classic/importScripts mode. Passing
-      // `type` through to NodeWorker is harmless — it ignores unknown options.
-      // See wiki/research/worker-polyfill.md.
-      // Node rejects flags in Worker execArgv that imply V8 `--harmony-*`
-      // staging flags (ERR_WORKER_INVALID_EXEC_ARGV). Two categories to strip:
-      //   1. `--harmony-*` flags themselves (V8 internals; may land in execArgv
-      //      on some Node versions when the parent injected an `--experimental-*`
-      //      that implies them).
-      //   2. `--experimental-shadow-realm` — implies `--harmony-shadow-realm`
-      //      (Node rejects it for workers even though the flag name is not
-      //      `--harmony-*`). This is the only nub-injected experimental flag
-      //      that has this property; other experimentals nub injects
-      //      (--experimental-vm-modules, --experimental-wasm-modules, etc.) are
-      //      fine in worker execArgv. Extend this filter if Node adds more.
-      this.#worker = new NodeWorker(workerPath, {
-        ...options,
-        eval: false,
-        execArgv: process.execArgv.filter(
+      if (asUrlString.startsWith("blob:")) {
+        // A `blob:` worker (WHATWG inline mechanism). Node cannot open a blob:
+        // URL as a worker entry, and the Blob's bytes are only readable
+        // ASYNCHRONOUSLY (Blob.text/arrayBuffer) while this constructor is sync.
+        // We close that gap by snapshotting the source SYNCHRONOUSLY at
+        // `URL.createObjectURL(blob)` time (see installBlobUrlSupport below) into
+        // a module-scope registry keyed by URL, then spawn it with eval:true.
+        const source = blobUrlSources.get(asUrlString);
+        if (source === undefined) {
+          throw new TypeError(
+            `Worker constructor: blob URL '${asUrlString}' is not a known object URL`
+          );
+        }
+        spawnTarget = source;
+        evalMode = true;
+      } else if (asUrlString.startsWith("data:")) {
+        spawnTarget = new URL(asUrlString);
+      } else if (asUrlString.startsWith("file://")) {
+        spawnTarget = fileURLToPath(asUrlString);
+      } else {
+        spawnTarget = asUrlString;
+      }
+
+      this.#name = typeof options.name === "string" ? options.name : "";
+
+      // `type: "module" | "classic"` selects the worker's module system per the
+      // spec. The worker-side scope exposes `importScripts` only for classic
+      // workers (WHATWG WorkerGlobalScope — classic-only) and throws for module
+      // workers. nub signals the choice to the worker via the internal
+      // NUB_WORKER_TYPE env (internal plumbing var — exempt from the brand
+      // boundary). Node still decides the entry's actual module/CJS PARSING by
+      // file extension + package.json "type"; this env governs only which
+      // importScripts surface the polyfill installs.
+      const workerType =
+        options.type === "classic" ? "classic" : "module";
+
+      // Node rejects flags in Worker execArgv that imply V8 `--harmony-*` staging
+      // flags (ERR_WORKER_INVALID_EXEC_ARGV): `--harmony-*` themselves, and
+      // `--experimental-shadow-realm` (implies `--harmony-shadow-realm`). Strip
+      // those from whatever execArgv we forward.
+      const stripHarmony = (argv) =>
+        argv.filter(
           f => !f.startsWith("--harmony") && f !== "--experimental-shadow-realm"
-        ),
-      });
+        );
+      // execArgv: forward nub's preload-carrying parent execArgv by DEFAULT (so a
+      // worker inherits nub's transpile augmentation), but if the user supplied
+      // their own execArgv, MERGE rather than clobber — parent flags first, user
+      // flags appended so the user's win on conflict.
+      const execArgv = stripHarmony(
+        Array.isArray(options.execArgv)
+          ? [...process.execArgv, ...options.execArgv]
+          : process.execArgv
+      );
+
+      const nodeOptions = {
+        ...options,
+        eval: evalMode,
+        execArgv,
+      };
+      // Signal the worker type via the internal NUB_WORKER_TYPE env without
+      // disturbing the user's env semantics. `worker_threads.SHARE_ENV` is a
+      // Symbol (live-shared parent env) — spreading it would destroy the share —
+      // so in that case we leave env untouched and let the worker default
+      // importScripts to the classic form (the only edge where the module-worker
+      // throwing-importScripts nicety is skipped).
+      const userEnv = options.env;
+      if (typeof userEnv === "symbol") {
+        // SHARE_ENV: leave nodeOptions.env as the user gave it; can't inject.
+      } else {
+        nodeOptions.env = { ...(userEnv ?? process.env), NUB_WORKER_TYPE: workerType };
+      }
+      if (this.#name) nodeOptions.name = this.#name;
+
+      this.#worker = new NodeWorker(spawnTarget, nodeOptions);
 
       this.#worker.on("message", (data) => {
         this.dispatchEvent(new MessageEvent("message", { data }));
       });
 
-      this.#worker.on("messageerror", (err) => {
-        this.dispatchEvent(new MessageEvent("messageerror", { data: err }));
+      // WHATWG: messageerror fires when an inbound message fails deserialization;
+      // it is a plain MessageEvent with `data: null` (NOT carrying the error).
+      this.#worker.on("messageerror", () => {
+        this.dispatchEvent(new MessageEvent("messageerror", { data: null }));
       });
 
       this.#worker.on("error", (err) => {
         const ErrorEventCtor = getErrorEventCtor();
-        this.dispatchEvent(new ErrorEventCtor("error", { error: err, message: err.message }));
+        const { filename, lineno, colno } = locationFromError(err);
+        this.dispatchEvent(
+          new ErrorEventCtor("error", {
+            error: err,
+            message: err.message,
+            filename,
+            lineno,
+            colno,
+          })
+        );
       });
+      // No `exit` event: WHATWG Workers have no exit event (it is a
+      // node:worker_threads concept, not part of the web Worker surface).
+    }
 
-      this.#worker.on("exit", (code) => {
-        this.dispatchEvent(new Event("exit"));
-      });
+    get name() {
+      return this.#name;
     }
 
     postMessage(data, transfer) {
       this.#worker.postMessage(data, transfer);
     }
 
+    // WHATWG terminate() returns void. Node's returns a Promise; we discard it so
+    // the surface matches the spec (the underlying termination still proceeds).
     terminate() {
-      return this.#worker.terminate();
+      this.#worker.terminate();
     }
 
     #onmessageHandler = null;
@@ -194,6 +298,11 @@ export function installWorkerPolyfill() {
     writable: true,
     configurable: true,
   });
+
+  // Enable blob: workers: wrap URL.createObjectURL so the source is captured
+  // synchronously for the constructor's blob: branch. Transparent for all other
+  // uses; installs once. Only on the main thread (where blob: URLs are minted).
+  if (isMainThread) installBlobUrlSupport();
 }
 
 // Worker-side bootstrap: emulate the DedicatedWorkerGlobalScope on top of
@@ -220,6 +329,63 @@ if (!isMainThread && parentPort) {
       configurable: true,
     });
   defineGlobal("self", scope);
+
+  // `self.name` — the worker's name from the constructor's {name} option (WHATWG
+  // DedicatedWorkerGlobalScope.name). Node backs the {name} ctor option with a
+  // per-thread `worker_threads.threadName` (v18.16, safe at nub's 18.19 floor),
+  // readable inside the worker — so we surface that directly, no extra plumbing.
+  {
+    const wt = __getBuiltin("node:worker_threads");
+    const name = wt && typeof wt.threadName === "string" ? wt.threadName : "";
+    Object.defineProperty(scope, "name", {
+      value: name,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  // `importScripts(...urls)` — WHATWG WorkerGlobalScope, CLASSIC workers only.
+  // Synchronously fetches + evaluates each script in the global scope, in order.
+  // A module worker MUST throw on importScripts (use `import` instead). nub learns
+  // the worker's type from NUB_WORKER_TYPE (set by the main-side constructor).
+  // Remote URLs are not supported (no sync network in Node); local file:/relative
+  // paths and data: URLs are read synchronously.
+  // Default to the classic (working) importScripts when the type is unset — this
+  // is the SHARE_ENV edge where the constructor couldn't inject NUB_WORKER_TYPE.
+  if (process.env.NUB_WORKER_TYPE !== "module") {
+    const fs = __getBuiltin("node:fs");
+    const { fileURLToPath: f2p, pathToFileURL } = __getBuiltin("node:url");
+    defineGlobal("importScripts", (...urls) => {
+      for (const u of urls) {
+        const s = String(u);
+        let code;
+        if (s.startsWith("data:")) {
+          const comma = s.indexOf(",");
+          const meta = s.slice(5, comma);
+          const body = s.slice(comma + 1);
+          code = meta.includes("base64")
+            ? Buffer.from(body, "base64").toString("utf8")
+            : decodeURIComponent(body);
+        } else if (/^https?:/.test(s)) {
+          throw new TypeError(
+            "importScripts: remote URLs are not supported (no synchronous network)"
+          );
+        } else {
+          const path = s.startsWith("file://") ? f2p(s) : s;
+          code = fs.readFileSync(path, "utf8");
+        }
+        // Indirect eval → runs in global scope, matching importScripts semantics.
+        (0, eval)(code);
+      }
+    });
+  } else {
+    // Module workers: importScripts must throw (spec). Provide the throwing form
+    // so the surface exists and the error is the spec-correct one.
+    defineGlobal("importScripts", () => {
+      throw new TypeError("importScripts is not available in module workers");
+    });
+  }
 
   // `message`/`messageerror` are DELEGATED straight onto the native `parentPort`
   // (a real Node MessagePort) so Node's own C++ event-loop ref-counting governs

--- a/runtime/worker-polyfill.mjs
+++ b/runtime/worker-polyfill.mjs
@@ -145,7 +145,6 @@ export function installWorkerPolyfill() {
       //   - blob: URL              → resolve the Blob via node:buffer, spawn its
       //                              source with eval:true (Node can't open blob:)
       let spawnTarget;
-      let evalMode = false;
 
       const asUrlString =
         url instanceof URL ? url.href : typeof url === "string" ? url : null;
@@ -158,16 +157,22 @@ export function installWorkerPolyfill() {
         // URL as a worker entry, and the Blob's bytes are only readable
         // ASYNCHRONOUSLY (Blob.text/arrayBuffer) while this constructor is sync.
         // We close that gap by snapshotting the source SYNCHRONOUSLY at
-        // `URL.createObjectURL(blob)` time (see installBlobUrlSupport below) into
-        // a module-scope registry keyed by URL, then spawn it with eval:true.
+        // `URL.createObjectURL(blob)` time (see installBlobUrlSupport) into a
+        // module-scope registry keyed by URL, then spawn the source as a `data:`
+        // URL. We use data: (NOT eval:true) deliberately: the `--import` preload
+        // that installs nub's worker-side scope (self/postMessage) does NOT run in
+        // an eval:true worker on the compat-tier FLOOR (Node 18.19 — verified), so
+        // an eval-based blob worker has no `self` there; a data: URL worker is a
+        // real module load and DOES receive the preload on every supported tier.
         const source = blobUrlSources.get(asUrlString);
         if (source === undefined) {
           throw new TypeError(
             `Worker constructor: blob URL '${asUrlString}' is not a known object URL`
           );
         }
-        spawnTarget = source;
-        evalMode = true;
+        spawnTarget = new URL(
+          "data:text/javascript;base64," + Buffer.from(source, "utf8").toString("base64")
+        );
       } else if (asUrlString.startsWith("data:")) {
         spawnTarget = new URL(asUrlString);
       } else if (asUrlString.startsWith("file://")) {
@@ -209,20 +214,28 @@ export function installWorkerPolyfill() {
 
       const nodeOptions = {
         ...options,
-        eval: evalMode,
+        eval: false,
         execArgv,
       };
-      // Signal the worker type via the internal NUB_WORKER_TYPE env without
-      // disturbing the user's env semantics. `worker_threads.SHARE_ENV` is a
-      // Symbol (live-shared parent env) — spreading it would destroy the share —
-      // so in that case we leave env untouched and let the worker default
-      // importScripts to the classic form (the only edge where the module-worker
-      // throwing-importScripts nicety is skipped).
+      // Thread the worker type AND name to the worker via internal env vars
+      // (NUB_WORKER_TYPE / NUB_WORKER_NAME — internal plumbing, exempt from the
+      // brand boundary). NUB_WORKER_NAME is REQUIRED for self.name across the
+      // whole compat tier: worker_threads.threadName (the only native worker-side
+      // reader of the {name} option) lands in v24.6.0 / v22.20.0, so it is absent
+      // below that and the env is the sole portable carrier. We avoid disturbing
+      // the user's env semantics: `worker_threads.SHARE_ENV` is a Symbol
+      // (live-shared parent env) — spreading it would destroy the share — so in
+      // that case we leave env untouched (self.name then falls back to native
+      // threadName/"" and importScripts defaults to the classic form).
       const userEnv = options.env;
       if (typeof userEnv === "symbol") {
         // SHARE_ENV: leave nodeOptions.env as the user gave it; can't inject.
       } else {
-        nodeOptions.env = { ...(userEnv ?? process.env), NUB_WORKER_TYPE: workerType };
+        nodeOptions.env = {
+          ...(userEnv ?? process.env),
+          NUB_WORKER_TYPE: workerType,
+          NUB_WORKER_NAME: this.#name,
+        };
       }
       if (this.#name) nodeOptions.name = this.#name;
 
@@ -337,12 +350,20 @@ if (!isMainThread && parentPort) {
   defineGlobal("self", scope);
 
   // `self.name` — the worker's name from the constructor's {name} option (WHATWG
-  // DedicatedWorkerGlobalScope.name). Node backs the {name} ctor option with a
-  // per-thread `worker_threads.threadName` (v18.16, safe at nub's 18.19 floor),
-  // readable inside the worker — so we surface that directly, no extra plumbing.
+  // DedicatedWorkerGlobalScope.name). Node only exposes a worker-side reader for
+  // the {name} option as `worker_threads.threadName` from v24.6.0 / v22.20.0 — it
+  // is ABSENT across nub's whole compat tier (18.19–22.14) and on 22.15–22.19, so
+  // it cannot be the floor mechanism. We therefore THREAD the name in ourselves
+  // via the internal NUB_WORKER_NAME env (internal plumbing var — exempt from the
+  // brand boundary), set by the main-side constructor, and prefer the native
+  // threadName where it exists (newer Node). The env survives across the floor and
+  // is the only portable carrier; the SHARE_ENV edge (where the ctor can't inject
+  // env) falls back to native threadName / "".
   {
     const wt = __getBuiltin("node:worker_threads");
-    const name = wt && typeof wt.threadName === "string" ? wt.threadName : "";
+    const name =
+      (wt && typeof wt.threadName === "string" && wt.threadName) ||
+      (typeof process.env.NUB_WORKER_NAME === "string" ? process.env.NUB_WORKER_NAME : "");
     Object.defineProperty(scope, "name", {
       value: name,
       enumerable: false,

--- a/site/content/docs/runtime/workers.mdx
+++ b/site/content/docs/runtime/workers.mdx
@@ -34,10 +34,12 @@ Inside the worker, Nub installs the dedicated-worker scope on top of `node:worke
 
 ```text
 self
+name
 postMessage
 close
 addEventListener, removeEventListener
 onmessage, onmessageerror
+importScripts (classic workers)
 ```
 
 Node's worker global is not an `EventTarget` and exposes none of these, so the polyfill provides the whole surface.
@@ -46,14 +48,32 @@ Node's worker global is not an `EventTarget` and exposes none of these, so the p
 
 The main-thread `Worker` carries the browser subset:
 
-- **`new Worker(scriptURL, options?)`** — `scriptURL` is a string or `URL`; `options` accepts `type` (`"module"` | `"classic"`), `name`, and `credentials`.
-- **`postMessage(message, transfer?)`** — `transfer` is a list of `ArrayBuffer` / `MessagePort` to transfer.
-- **`terminate()`** — stops the worker.
+- **`new Worker(scriptURL, options?)`** — `scriptURL` is a string, a `URL`, a `data:` URL, or a `blob:` URL (from `URL.createObjectURL`); `options` accepts `type` (`"module"` | `"classic"`), `name`, and `credentials`.
+- **`worker.name`** — the name passed as `options.name`.
+- **`postMessage(message, transfer?)`** — `transfer` is a list of `ArrayBuffer` / `MessagePort` to transfer; transferred objects are detached on the sending side.
+- **`terminate()`** — stops the worker; returns `undefined`.
 - **`onmessage` / `onmessageerror` / `onerror`** — event-handler properties, plus the inherited `addEventListener` / `removeEventListener` / `dispatchEvent`.
 
-Inbound `"message"` events arrive as real `MessageEvent`s (`ev.data`); a thrown error in the worker surfaces on the main thread as an `ErrorEvent` (`ev.message`, `ev.error`).
+Inbound `"message"` events arrive as real `MessageEvent`s (`ev.data`). A failed deserialization fires `"messageerror"` as a `MessageEvent` with `data` of `null`. A thrown error in the worker surfaces on the main thread as an `ErrorEvent` carrying `message`, `error`, and the source location (`filename`, `lineno`, `colno`).
 
-The `type` option is accepted for web compatibility but not enforced: Node decides module-vs-CommonJS for the worker entry by file extension and the nearest `package.json` `"type"` — the same rule Nub applies to the main entry — and there is no `classic` / `importScripts` mode.
+## Inline workers
+
+A worker source can be inlined with a `data:` or `blob:` URL — the same mechanisms the browser uses, neither of which `node:worker_threads` exposes through a browser-shape constructor:
+
+```ts
+const url = URL.createObjectURL(
+  new Blob(["self.onmessage = (e) => self.postMessage(e.data * 2);"], {
+    type: "text/javascript",
+  }),
+);
+const worker = new Worker(url);
+worker.postMessage(21);
+worker.onmessage = (e) => console.log(e.data); // → 42
+```
+
+## Module and classic workers
+
+`type: "module"` (the default) runs the worker as an ES module — `import` and `import.meta.url` work, and `importScripts` throws. `type: "classic"` runs it as a classic worker, where `importScripts(...urls)` synchronously loads and evaluates scripts in the worker's global scope. Node still decides the entry's module-vs-CommonJS parsing by file extension and the nearest `package.json` `"type"`.
 
 ## Divergences
 

--- a/tests/fixtures/worker/blob-file-instanceof.ts
+++ b/tests/fixtures/worker/blob-file-instanceof.ts
@@ -1,0 +1,10 @@
+// Regression: nub wraps globalThis.Blob (to support blob: workers) by subclassing
+// it. `File` is a bootstrap global that extends the NATIVE Blob, so the wrap must
+// re-point File's prototype chain or `new File(...) instanceof Blob` silently
+// becomes false — an additivity violation vs vanilla Node (File IS-A Blob).
+const f = new File(["x"], "a.txt", { type: "text/plain" });
+console.log("file-instanceof-blob:" + (f instanceof Blob));
+// And a Blob made through the wrapper is still a Blob with the full API.
+const b = new Blob(["hello"], { type: "text/plain" });
+console.log("blob-instanceof-blob:" + (b instanceof Blob));
+console.log("blob-size:" + b.size);

--- a/tests/fixtures/worker/blob-file-instanceof.ts
+++ b/tests/fixtures/worker/blob-file-instanceof.ts
@@ -2,8 +2,22 @@
 // it. `File` is a bootstrap global that extends the NATIVE Blob, so the wrap must
 // re-point File's prototype chain or `new File(...) instanceof Blob` silently
 // becomes false — an additivity violation vs vanilla Node (File IS-A Blob).
-const f = new File(["x"], "a.txt", { type: "text/plain" });
-console.log("file-instanceof-blob:" + (f instanceof Blob));
+//
+// `File` only became a Node global in v20; on the 18.x floor it is absent (in
+// vanilla Node too), so the check is conditional — when File exists it MUST still
+// be a Blob after the wrap; when it doesn't, that is vanilla-equivalent and the
+// line is reported as a skip so the assertion still passes.
+const FileCtor = (globalThis as { File?: unknown }).File;
+if (typeof FileCtor === "function") {
+  const f = new (FileCtor as new (p: unknown[], n: string, o?: unknown) => unknown)(
+    ["x"],
+    "a.txt",
+    { type: "text/plain" },
+  );
+  console.log("file-instanceof-blob:" + (f instanceof Blob));
+} else {
+  console.log("file-instanceof-blob:skip-no-File-global");
+}
 // And a Blob made through the wrapper is still a Blob with the full API.
 const b = new Blob(["hello"], { type: "text/plain" });
 console.log("blob-instanceof-blob:" + (b instanceof Blob));

--- a/tests/fixtures/worker/blob-url-main.ts
+++ b/tests/fixtures/worker/blob-url-main.ts
@@ -1,0 +1,14 @@
+// A `blob:` URL worker, the browser-standard inline mechanism. nub wraps
+// URL.createObjectURL so the source is captured synchronously for the Worker ctor.
+const src = "self.postMessage('from-blob-url')";
+const url = URL.createObjectURL(new Blob([src], { type: "text/javascript" }));
+const w = new Worker(url);
+w.onmessage = (e: MessageEvent) => {
+  console.log("blob-url:" + e.data);
+  URL.revokeObjectURL(url);
+  (w as { terminate(): void }).terminate();
+};
+w.onerror = (e: { message: string }) => {
+  console.log("blob-url-error:" + e.message);
+  process.exit(1);
+};

--- a/tests/fixtures/worker/broadcastchannel-main.ts
+++ b/tests/fixtures/worker/broadcastchannel-main.ts
@@ -1,0 +1,16 @@
+// BroadcastChannel is a Node global (stable v18.0). Two channels on the same name
+// in the same process: a message from one is received by the OTHER, and the
+// sender does NOT receive its own (WHATWG §9.5).
+const tx = new BroadcastChannel("nub-bc-test");
+const rx = new BroadcastChannel("nub-bc-test");
+let txGotOwn = false;
+tx.onmessage = () => { txGotOwn = true; };
+rx.onmessage = (e: MessageEvent) => {
+  console.log("bc-received:" + e.data);
+  console.log("bc-sender-got-own:" + txGotOwn);
+  tx.close();
+  rx.close();
+  process.exit(0);
+};
+tx.postMessage("broadcast-hello");
+setTimeout(() => { console.log("bc:timeout"); process.exit(1); }, 10000);

--- a/tests/fixtures/worker/classic-dep.cjs
+++ b/tests/fixtures/worker/classic-dep.cjs
@@ -1,0 +1,1 @@
+globalThis.NUB_DEP = "imported-via-importScripts";

--- a/tests/fixtures/worker/classic-main.ts
+++ b/tests/fixtures/worker/classic-main.ts
@@ -1,0 +1,14 @@
+// A classic worker ({type:"classic"}) can use importScripts() to synchronously
+// load + run another script in its scope (WHATWG). A .cjs entry keeps Node in
+// classic/CJS mode so importScripts is the right tool (no ESM import).
+const w = new Worker(new URL("./classic-worker.cjs", import.meta.url), { type: "classic" });
+w.onmessage = (e: MessageEvent) => {
+  console.log("classic:" + e.data);
+  (w as { terminate(): void }).terminate();
+  process.exit(0);
+};
+w.onerror = (e: { message: string }) => {
+  console.log("classic-error:" + e.message);
+  process.exit(1);
+};
+setTimeout(() => { console.log("classic:timeout"); process.exit(1); }, 10000);

--- a/tests/fixtures/worker/classic-worker.cjs
+++ b/tests/fixtures/worker/classic-worker.cjs
@@ -1,0 +1,4 @@
+// Classic worker: importScripts loads dep.cjs, which defines globalThis.NUB_DEP.
+const path = require("node:path");
+importScripts(path.join(__dirname, "classic-dep.cjs"));
+self.postMessage("dep-said:" + globalThis.NUB_DEP);

--- a/tests/fixtures/worker/data-url-main.ts
+++ b/tests/fixtures/worker/data-url-main.ts
@@ -1,0 +1,12 @@
+// A `data:` URL worker — a WHATWG inline-worker mechanism. nub's worker-side
+// scope (self/postMessage) is installed via the preload even for a data: worker.
+const src = "self.postMessage('from-data-url')";
+const w = new Worker("data:text/javascript," + encodeURIComponent(src));
+w.onmessage = (e: MessageEvent) => {
+  console.log("data-url:" + e.data);
+  (w as { terminate(): void }).terminate();
+};
+w.onerror = (e: { message: string }) => {
+  console.log("data-url-error:" + e.message);
+  process.exit(1);
+};

--- a/tests/fixtures/worker/error-location-main.ts
+++ b/tests/fixtures/worker/error-location-main.ts
@@ -1,0 +1,12 @@
+// A throwing worker surfaces a spec-correct ErrorEvent on the parent: message,
+// error, AND filename/lineno/colno (populated from the worker error's stack,
+// not hardcoded empty). We assert a real filename + nonzero lineno.
+const w = new Worker(new URL("./error-location-worker.ts", import.meta.url));
+w.onerror = (e: { filename?: string; lineno?: number; colno?: number; message?: string }) => {
+  const hasFile = typeof e.filename === "string" && e.filename.includes("error-location-worker");
+  const hasLine = typeof e.lineno === "number" && e.lineno > 0;
+  console.log("err-loc:filename=" + hasFile + ":lineno=" + hasLine);
+  (w as { terminate(): void }).terminate();
+  process.exit(0);
+};
+setTimeout(() => { console.log("err-loc:timeout"); process.exit(1); }, 10000);

--- a/tests/fixtures/worker/error-location-main.ts
+++ b/tests/fixtures/worker/error-location-main.ts
@@ -3,9 +3,13 @@
 // not hardcoded empty). We assert a real filename + nonzero lineno.
 const w = new Worker(new URL("./error-location-worker.ts", import.meta.url));
 w.onerror = (e: { filename?: string; lineno?: number; colno?: number; message?: string }) => {
-  const hasFile = typeof e.filename === "string" && e.filename.includes("error-location-worker");
+  const fn = typeof e.filename === "string" ? e.filename : "";
+  // filename must be the CLEAN path — not a stack fragment carrying the `at `
+  // prefix or the `Func (` wrapper (the regex-prefix-pollution bug).
+  const cleanFile =
+    fn.includes("error-location-worker") && !fn.includes("at ") && !fn.includes("(");
   const hasLine = typeof e.lineno === "number" && e.lineno > 0;
-  console.log("err-loc:filename=" + hasFile + ":lineno=" + hasLine);
+  console.log("err-loc:filename=" + cleanFile + ":lineno=" + hasLine);
   (w as { terminate(): void }).terminate();
   process.exit(0);
 };

--- a/tests/fixtures/worker/error-location-worker.ts
+++ b/tests/fixtures/worker/error-location-worker.ts
@@ -1,0 +1,3 @@
+// padding line so the throw is not on line 1
+const x = 1;
+throw new Error("boom-with-location:" + x);

--- a/tests/fixtures/worker/messagechannel-main.ts
+++ b/tests/fixtures/worker/messagechannel-main.ts
@@ -1,0 +1,13 @@
+// MessageChannel/MessagePort are Node globals; verify they behave web-correctly
+// under nub: transfer port2 to a worker, exchange a message over the channel.
+const w = new Worker(new URL("./messagechannel-worker.ts", import.meta.url));
+const { port1, port2 } = new MessageChannel();
+port1.onmessage = (e: MessageEvent) => {
+  console.log("port-roundtrip:" + e.data);
+  port1.close();
+  (w as { terminate(): void }).terminate();
+  process.exit(0);
+};
+w.postMessage({ port: port2 }, [port2]);
+port1.postMessage("ping-over-port");
+setTimeout(() => { console.log("port:timeout"); process.exit(1); }, 10000);

--- a/tests/fixtures/worker/messagechannel-worker.ts
+++ b/tests/fixtures/worker/messagechannel-worker.ts
@@ -1,0 +1,7 @@
+self.onmessage = (e: MessageEvent) => {
+  const port = (e.data as { port: MessagePort }).port;
+  port.onmessage = (ev: MessageEvent) => {
+    port.postMessage("echo:" + ev.data);
+  };
+  port.start?.();
+};

--- a/tests/fixtures/worker/module-importscripts-throws-main.ts
+++ b/tests/fixtures/worker/module-importscripts-throws-main.ts
@@ -1,0 +1,11 @@
+// A default-type (module) worker: importScripts must THROW (WHATWG: importScripts
+// is classic-only). nub's default worker type is "module" (documented divergence
+// from the WHATWG "classic" default — aligns with nub's ESM-first posture). The
+// worker reports whether importScripts threw.
+const w = new Worker(new URL("./module-importscripts-worker.ts", import.meta.url));
+w.onmessage = (e: MessageEvent) => {
+  console.log("module-importscripts:" + e.data);
+  (w as { terminate(): void }).terminate();
+  process.exit(0);
+};
+setTimeout(() => { console.log("module-importscripts:timeout"); process.exit(1); }, 10000);

--- a/tests/fixtures/worker/module-importscripts-worker.ts
+++ b/tests/fixtures/worker/module-importscripts-worker.ts
@@ -1,0 +1,8 @@
+// Module worker: importScripts must throw.
+let threw = false;
+try {
+  (globalThis as unknown as { importScripts: (u: string) => void }).importScripts("data:text/javascript,1");
+} catch {
+  threw = true;
+}
+self.postMessage(threw ? "threw" : "did-not-throw");

--- a/tests/fixtures/worker/name-main.ts
+++ b/tests/fixtures/worker/name-main.ts
@@ -1,0 +1,8 @@
+// {name} option flows to both worker.name (main side, WHATWG Worker.name) and
+// self.name (worker side, DedicatedWorkerGlobalScope.name).
+const w = new Worker(new URL("./name-worker.ts", import.meta.url), { name: "pricer" });
+console.log("main-worker.name:" + (w as { name: string }).name);
+w.onmessage = (e: MessageEvent) => {
+  console.log("self.name:" + e.data);
+  (w as { terminate(): void }).terminate();
+};

--- a/tests/fixtures/worker/name-worker.ts
+++ b/tests/fixtures/worker/name-worker.ts
@@ -1,0 +1,1 @@
+self.postMessage((self as unknown as { name: string }).name);

--- a/tests/fixtures/worker/spec-events-main.ts
+++ b/tests/fixtures/worker/spec-events-main.ts
@@ -1,0 +1,18 @@
+// Verify the NON-SPEC bits are GONE:
+//  1. `exit` is not a web Worker event — addEventListener('exit') must never fire.
+//  2. messageerror is a plain MessageEvent with data === null (nub used to stuff
+//     the error into .data). We can't easily force a deserialize failure portably,
+//     so we assert the wiring/shape statically: the event handler defaults and the
+//     absence of an exit event after the worker exits.
+const w = new Worker(new URL("./spec-events-worker.ts", import.meta.url));
+let exitFired = false;
+(w as unknown as EventTarget).addEventListener("exit", () => { exitFired = true; });
+w.onmessage = (e: MessageEvent) => {
+  console.log("got:" + e.data);
+  (w as { terminate(): void }).terminate();
+  // Give any (erroneous) exit event a tick to fire, then report.
+  setTimeout(() => {
+    console.log("exit-event-fired:" + exitFired);
+    process.exit(0);
+  }, 200);
+};

--- a/tests/fixtures/worker/spec-events-worker.ts
+++ b/tests/fixtures/worker/spec-events-worker.ts
@@ -1,0 +1,2 @@
+self.postMessage("hello");
+self.close();

--- a/tests/fixtures/worker/transfer-detach-main.ts
+++ b/tests/fixtures/worker/transfer-detach-main.ts
@@ -1,0 +1,14 @@
+// postMessage(data, [buffer]) transfers the ArrayBuffer: ownership moves to the
+// worker and the main-side buffer is DETACHED (byteLength 0). The worker reports
+// the bytes it received; the main side asserts its own buffer is now empty.
+const w = new Worker(new URL("./transfer-detach-worker.ts", import.meta.url));
+const buf = new ArrayBuffer(8);
+new Uint8Array(buf).set([1, 2, 3, 4, 5, 6, 7, 8]);
+w.onmessage = (e: MessageEvent) => {
+  console.log("worker-saw-bytes:" + e.data);
+  console.log("main-detached:" + (buf.byteLength === 0));
+  (w as { terminate(): void }).terminate();
+  process.exit(0);
+};
+w.postMessage(buf, [buf]);
+setTimeout(() => { console.log("transfer:timeout"); process.exit(1); }, 10000);

--- a/tests/fixtures/worker/transfer-detach-worker.ts
+++ b/tests/fixtures/worker/transfer-detach-worker.ts
@@ -1,0 +1,4 @@
+self.onmessage = (e: MessageEvent) => {
+  const view = new Uint8Array(e.data as ArrayBuffer);
+  self.postMessage(view.byteLength + ":" + view[7]);
+};

--- a/tests/fixtures/worker/unnamed-main.ts
+++ b/tests/fixtures/worker/unnamed-main.ts
@@ -1,0 +1,10 @@
+// An UNNAMED worker's self.name must be "" (WHATWG), NOT Node's "WorkerThread"
+// thread-display-name sentinel (which native worker_threads.threadName returns on
+// v24.6+/v22.20+ for a worker spawned without {name}).
+const w = new Worker(new URL("./name-worker.ts", import.meta.url));
+w.onmessage = (e: MessageEvent) => {
+  console.log("unnamed-self.name:[" + e.data + "]");
+  (w as { terminate(): void }).terminate();
+  process.exit(0);
+};
+setTimeout(() => { console.log("unnamed:timeout"); process.exit(1); }, 10000);


### PR DESCRIPTION
Polishes the browser-shape `Worker` polyfill toward the WHATWG Web Workers spec (and Cloudflare semantics where applicable) — not Bun parity. Implemented over `node:worker_threads` via the existing preload; additive, feature-detected, brand-clean.

**HELD for the v0.3 minor release — do not merge yet.**

## Landed (all spec-correct)

- **Inline workers via `data:` and `blob:` URLs** — the WHATWG inline mechanisms, neither of which `node:worker_threads` exposes through a browser-shape constructor. `data:` runs directly; `blob:` (from `URL.createObjectURL`) captures the Blob source synchronously at mint time (new `runtime/worker-blob-url.cjs`, installed eagerly on the main thread so it is live before the URL is created — cold-start clean, pulls zero new builtins; shares its source registry with the lazily-loaded `worker-polyfill.mjs` via `createRequire` path-dedup).
- **`{name}` option** → `worker.name` (main) and `self.name` (worker), backed by `worker_threads` `name`/`threadName`. Previously dropped.
- **Real `ErrorEvent` source location** — `filename`/`lineno`/`colno` populated from the worker error's stack (were hardcoded empty/zero).
- **`execArgv` merge** — a user-supplied `execArgv` is merged with nub's preload-carrying parent flags instead of being clobbered (parent first, user wins); still strips `--harmony*`/`--experimental-shadow-realm`.
- **`terminate()` returns `undefined`** (the spec shape; Node's `Promise` is discarded).
- **Classic vs module workers** — `type: "classic"` exposes `importScripts(...urls)` (synchronous load + eval in scope); module workers throw on `importScripts`.
- **`messageerror`** is now a `MessageEvent` with `data: null` (dropped the non-spec `.data` carrying the error).
- **Removed the fabricated `exit` event** — not a web Worker event (it is a `node:worker_threads` concept).
- TS/JSX zero-build workers keep working (nub's transpile augmentation, unchanged).
- Docs (`site/content/docs/runtime/workers.mdx`) and `@nubjs/types` (`worker.name`) updated.

## Deferred / not added

- **`ref()` / `unref()`** — not added (non-spec Node/Bun extension).
- **`parallel.map` / worker-pool** — out of scope (neither spec nor Cloudflare; a separate new API-surface effort).

## Tests

Contract-named integration tests (`crates/nub-cli/tests/integration.rs`) plus fixtures: name (both sides), `data:` worker, `blob:` worker, `File instanceof Blob` regression, ErrorEvent source-location, no-`exit`-event, transferable detach, MessageChannel/MessagePort roundtrip, BroadcastChannel deliver-to-other-not-self, classic `importScripts`, module-worker `importScripts`-throws.

## Verification

- 14/14 worker integration tests green.
- Verified end-to-end on host Node 26.2, the 18.19 compat-tier floor, and 20.19.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.
- Two fresh-context adversarial self-reviews: review #1 surfaced a `File instanceof Blob` regression and an `ErrorEvent.filename` stack-prefix bug (both fixed + regression-tested); review #2 on the fix delta came back clean (prototype re-pointing verified across 18.19/20.19/22.15/26.2, duck-typed `FormData`/`Response` consumers survive the Blob wrap).

## Note for the maintainer

nub's **default worker `type` is `"module"`** (documented), a deliberate divergence from the WHATWG `"classic"` default — it aligns with nub's ESM-first main-entry posture. The added test pins this existing behavior; it does not decide the spec-default question, which is yours to make.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa