### PR TITLE
test(ci): Node-version matrix smoke for the augmentation surface

### DIFF
--- a/.github/workflows/node-matrix.yml
+++ b/.github/workflows/node-matrix.yml
@@ -1,0 +1,207 @@
+name: Node matrix
+
+# Augmentation smoke across a BIG Node-version matrix. nub augments the user's installed
+# Node via version-banded mechanisms (sync `module.registerHooks` fast tier >=22.15, async
+# `module.register` loader-worker compat tier 18.19-22.14, V8/experimental-flag injection)
+# that break DIFFERENTLY per Node version. The repo's main CI matrix tests only a handful
+# of versions and never exercised the async-loader x sync-hooks collision that shipped the
+# Turbopack/Tailwind `resolveSync()` crash (the nextjs-build-compat thread / PR #98) — this
+# workflow closes that gap.
+#
+# COST MODEL: CI is free (public repo); the real constraints are runner-SLOT contention and
+# dev-feedback latency. So:
+#   - nub is built ONCE (one job) and reused across every Node leg — the Node version is a
+#     PATH/runtime choice (actions/setup-node), NOT a rebuild.
+#   - per-PR: a LEAN tier-boundary subset of the lightweight smoke, gated by PATH FILTERS
+#     (the heavy real-app matrix and the broad version sweep run only when runtime/preload/
+#     spawn/flags code changes — the surfaces that can break version-banded augmentation).
+#   - push:main + nightly: the FULL version matrix + both real-app builds.
+#   - concurrency group with cancel-in-progress so superseded runs free their slots.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Nightly full matrix at 05:00 UTC (offset from the other nightlies: CI 06:00,
+    # lockfile-roundtrip 07:00, pnpm-conformance 08:00).
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Decide what to run for this event. PRs that don't touch the augmentation surface skip
+  # the heavy legs entirely (the lightweight smoke still runs on a tier-boundary subset).
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    outputs:
+      smoke_versions: ${{ steps.plan.outputs.smoke_versions }}
+      run_full: ${{ steps.plan.outputs.run_full }}
+      run_realapps: ${{ steps.plan.outputs.run_realapps }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+        id: filter
+        with:
+          # The surfaces whose changes can break version-banded augmentation. A change here
+          # is the trigger for the full version sweep + real-app builds on a PR.
+          filters: |
+            aug:
+              - 'runtime/**'
+              - 'crates/nub-core/src/node/**'
+              - 'crates/nub-cli/src/**'
+              - 'tests/node-matrix/**'
+              - '.github/workflows/node-matrix.yml'
+      - id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_full=false; run_realapps=false
+          # Lean per-PR smoke subset: the tier boundaries that actually shift behavior —
+          # 22.12 (pre-registerHooks), 22.15 (first registerHooks = first Node-broken),
+          # 22.16 (latest v22 LTS, still broken), 24.11 (latest pre-fix on v24), 26 (fixed).
+          smoke='["22.12","22.15","22.16","24.11","26"]'
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            run_full=true; run_realapps=true
+          elif [[ "${{ steps.filter.outputs.aug }}" == "true" ]]; then
+            # A PR touching the augmentation surface gets the full version sweep + real apps.
+            run_full=true; run_realapps=true
+          fi
+          if [[ "$run_full" == "true" ]]; then
+            # FULL sweep: tier boundaries + Node-fix points across every live line.
+            smoke='["18.19","20.19","22.12","22.15","22.16","23.6","23.11","24.1","24.11","24.12","25.0","25.2","26"]'
+          fi
+          {
+            echo "smoke_versions=$smoke"
+            echo "run_full=$run_full"
+            echo "run_realapps=$run_realapps"
+          } >> "$GITHUB_OUTPUT"
+          echo "event=${{ github.event_name }} aug=${{ steps.filter.outputs.aug }} run_full=$run_full smoke=$smoke"
+
+  # Build nub + the native addon ONCE; publish as an artifact the matrix legs reuse.
+  build:
+    name: Build nub (once)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: "24"
+      - name: Build nub + native addon
+        shell: bash
+        run: |
+          cargo build -p nub-cli -p nub-native
+          mkdir -p runtime/addons
+          cp target/debug/libnub_native.so runtime/addons/nub-native.node
+      - name: Stage the reusable nub bundle
+        shell: bash
+        run: |
+          # Ship the binary together with runtime/ — nub walks up from the binary to find
+          # runtime/preload.* + runtime/addons, so they must travel as siblings.
+          mkdir -p nub-bundle
+          cp target/debug/nub nub-bundle/nub
+          cp -r runtime nub-bundle/runtime
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: nub-bundle
+          path: nub-bundle
+          retention-days: 1
+
+  # Lightweight per-version smoke: hello JS/TS, ESM<->CJS, Worker, import.meta.resolve, and
+  # the async-loader collision tripwire. One prebuilt binary, N cheap runtime legs.
+  smoke:
+    name: Smoke (node ${{ matrix.node }})
+    needs: [plan, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ${{ fromJSON(needs.plan.outputs.smoke_versions) }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: ${{ matrix.node }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: nub-bundle
+          path: nub-bundle
+      - name: Run the smoke matrix
+        shell: bash
+        run: |
+          chmod +x nub-bundle/nub tests/node-matrix/run.sh
+          # On Node-fixed versions the collision MUST pass; on Node-broken versions it is
+          # XFAIL (the bug class is unfixed — see tests/node-matrix/README.md). Flip the
+          # broken legs to --collision-must-pass once nub recovers the sync-into-async hop.
+          case "${{ matrix.node }}" in
+            24.12|25.2|26) tests/node-matrix/run.sh "$PWD/nub-bundle/nub" --collision-must-pass ;;
+            18.19|20.19|22.12) tests/node-matrix/run.sh "$PWD/nub-bundle/nub" --collision-must-pass ;;
+            *) tests/node-matrix/run.sh "$PWD/nub-bundle/nub" ;;
+          esac
+
+  # Heavy real-app builds (Next 16 + Tailwind v4 + Turbopack; Vite SSR). Push/nightly, or a
+  # PR that touches the augmentation surface. The faithful in-the-wild guard for the crash.
+  real-apps:
+    name: Real apps (node ${{ matrix.node }})
+    needs: [plan, build]
+    if: ${{ needs.plan.outputs.run_realapps == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        # A representative spread: one Node-broken fast-tier version (the faithful RED on a
+        # broken nub) + the Node-fix points + latest. Real-app builds are heavy, so this is
+        # a curated subset rather than the full version list.
+        node: ["22.16", "24.11", "24.12", "26"]
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: ${{ matrix.node }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: nub-bundle
+          path: nub-bundle
+      - name: Build the real apps under nub
+        shell: bash
+        run: |
+          chmod +x nub-bundle/nub tests/node-matrix/real-apps.sh
+          # Node-fixed legs MUST pass the Next/Tailwind build; Node-broken legs XFAIL the
+          # resolveSync crash but still FAIL any other build error (and the Vite SSR build,
+          # which has no async loader, must pass on every version).
+          case "${{ matrix.node }}" in
+            24.12|26) tests/node-matrix/real-apps.sh "$PWD/nub-bundle/nub" --require-pass ;;
+            *) tests/node-matrix/real-apps.sh "$PWD/nub-bundle/nub" ;;
+          esac
+
+  # Always-green aggregator so branch protection has one stable required check regardless of
+  # which optional legs were skipped on a given event.
+  node-matrix-gate:
+    name: Node matrix gate
+    needs: [smoke, real-apps]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        run: |
+          set -euo pipefail
+          smoke='${{ needs.smoke.result }}'
+          apps='${{ needs.real-apps.result }}'
+          echo "smoke=$smoke real-apps=$apps"
+          # A skipped leg (PR that didn't trigger it) is fine; a failure is not.
+          [[ "$smoke" == "success" || "$smoke" == "skipped" ]] || { echo "smoke failed"; exit 1; }
+          [[ "$apps"  == "success" || "$apps"  == "skipped" ]] || { echo "real-apps failed"; exit 1; }
+          echo "node matrix gate: OK"

--- a/.github/workflows/node-matrix.yml
+++ b/.github/workflows/node-matrix.yml
@@ -142,14 +142,13 @@ jobs:
         shell: bash
         run: |
           chmod +x nub-bundle/nub tests/node-matrix/run.sh
-          # On Node-fixed versions the collision MUST pass; on Node-broken versions it is
-          # XFAIL (the bug class is unfixed — see tests/node-matrix/README.md). Flip the
-          # broken legs to --collision-must-pass once nub recovers the sync-into-async hop.
-          case "${{ matrix.node }}" in
-            24.12|25.2|26) tests/node-matrix/run.sh "$PWD/nub-bundle/nub" --collision-must-pass ;;
-            18.19|20.19|22.12) tests/node-matrix/run.sh "$PWD/nub-bundle/nub" --collision-must-pass ;;
-            *) tests/node-matrix/run.sh "$PWD/nub-bundle/nub" ;;
-          esac
+          # The collision MUST pass on EVERY version — that is the durable regression guard.
+          # nub recovers the sync-into-async resolveSync/loadSync hop on the Node-broken bands
+          # (the #98 / Next.js-Turbopack-Tailwind fix), so the broken fast-tier legs now go
+          # GREEN; the Node-fixed and compat-tier legs were always green. A RED collision on
+          # any leg means nub regressed (or a new broken band exists) — see
+          # tests/node-matrix/README.md.
+          tests/node-matrix/run.sh "$PWD/nub-bundle/nub" --collision-must-pass
 
   # Heavy real-app builds (Next 16 + Tailwind v4 + Turbopack; Vite SSR). Push/nightly, or a
   # PR that touches the augmentation surface. The faithful in-the-wild guard for the crash.
@@ -179,13 +178,12 @@ jobs:
         shell: bash
         run: |
           chmod +x nub-bundle/nub tests/node-matrix/real-apps.sh
-          # Node-fixed legs MUST pass the Next/Tailwind build; Node-broken legs XFAIL the
-          # resolveSync crash but still FAIL any other build error (and the Vite SSR build,
-          # which has no async loader, must pass on every version).
-          case "${{ matrix.node }}" in
-            24.12|26) tests/node-matrix/real-apps.sh "$PWD/nub-bundle/nub" --require-pass ;;
-            *) tests/node-matrix/real-apps.sh "$PWD/nub-bundle/nub" ;;
-          esac
+          # Both real apps MUST build on EVERY version. With the #98 fix in, the Next 16 +
+          # Tailwind v4 + Turbopack build no longer crashes the resolveSync/loadSync stub on
+          # the Node-broken bands, so the broken legs are now a hard must-pass — the faithful
+          # in-the-wild regression guard. (The Vite SSR build has no async loader and was
+          # always version-agnostic.)
+          tests/node-matrix/real-apps.sh "$PWD/nub-bundle/nub" --require-pass
 
   # Always-green aggregator so branch protection has one stable required check regardless of
   # which optional legs were skipped on a given event.

--- a/tests/node-matrix/README.md
+++ b/tests/node-matrix/README.md
@@ -1,0 +1,90 @@
+# Node-version matrix smoke
+
+Augmentation smoke across a big Node-version matrix. nub augments the user's installed Node
+through version-banded mechanisms that break **differently** on different Node versions:
+
+- the **fast tier** (Node >= 22.15): sync resolve/load hooks via `module.registerHooks`;
+- the **compat tier** (18.19 - 22.14): an async `module.register` loader worker;
+- V8-flag and experimental-flag injection, gated per version.
+
+The repo's main CI matrix exercises only a few Node versions and never set up the
+**async-loader x sync-hooks collision** that shipped the Turbopack/Tailwind `resolveSync()`
+crash (the `nextjs-build-compat` thread / PR #98). This matrix closes that gap.
+
+## What it runs
+
+`run.sh <nub-binary> [--collision-must-pass]` — the lightweight per-version smoke:
+
+- **functional smoke** (every version): `hello.js`, `hello.ts` (TS transpile + a non-erasable
+  enum), ESM-imports-CJS, `import.meta.resolve`, Worker threads.
+- **async-loader collision** (`fixtures/async-loader-collision/`): the faithful, **bundler-free**
+  reproduction of the resolveSync class. User code calls `module.register(<async loader>)`
+  while nub's fast-tier sync `registerHooks` resolve hook is active; resolving the loader
+  module's own specifier through the sync chain hits Node's `Hooks.resolveSync()` stub, which
+  throws `ERR_METHOD_NOT_IMPLEMENTED` on Node-broken versions. (Reduced from `@tailwindcss/node`;
+  verified to reproduce identically to the real Turbopack build through the actual nub binary.)
+
+`real-apps.sh <nub-binary> [--require-pass]` — the heavy nightly real-app builds:
+
+- **Next 16 + Tailwind v4 + Turbopack** — the in-the-wild manifestation of the crash.
+- **Vite SSR** (`vite build --ssr` + executing the SSR bundle) — a small, dependency-light
+  second real toolchain. Chosen over a dev-server/express scaffold for CI reproducibility.
+
+## The Node-version bands (resolveSync crash)
+
+Empirically bisected (see `.fray/nextjs-build-compat.findings/resolvesync-version-band.md`):
+
+| Band | resolveSync stub present? |
+|---|---|
+| 18.19 - 22.14 (compat tier, no `registerHooks`) | no bug — different code path |
+| 22.15 - 22.16+ (v22 LTS) | **BROKEN** (not backported) |
+| 23.6 - 23.11 | **BROKEN** |
+| 24.1 - 24.11.x | **BROKEN** |
+| 24.12+ | fixed |
+| 25.0 - 25.1 | **BROKEN** (regression) |
+| 25.2+ | fixed |
+| 26.x | fixed |
+
+The collision guard is meaningful **only on a Node-broken version** — on a Node-fixed version
+it is vacuously green. The matrix therefore runs it across the broken bands (and asserts it
+must pass on the fixed ones).
+
+## Important: nub must run the matrix-selected Node
+
+nub discovers its Node from `PATH`, but an `engines.node` / `.node-version` pin **above** the
+PATH version makes nub *provision* a different Node, silently masking a leg's coverage. The
+fixtures ship a **pin-free `package.json`** so nub always augments the matrix-selected version,
+and `run.sh` has a sanity guard that fails the leg if nub ran a different version than selected.
+The repo root pins `engines.node >= 22.15`, which is why the fixtures need their own.
+
+## XFAIL policy (read before flipping to hard-fail)
+
+As of this matrix's introduction, **PR #98's fix does not actually recover the crash on the
+Node-broken bands** (validated against the real binary — see
+`.fray/node-version-matrix-smoke.findings/validation.md`):
+
+1. #98's resolve-hook recovery is gated on `userAsyncLoaderActive()`, which is **false** at the
+   throwing resolution (the loader module's own spec, resolved during `module.register`), so the
+   recovery never fires.
+2. Even bypassing that gate, the **load** hook hits the identical `loadSync` stub with no recovery.
+
+So the collision guard currently **XFAILs** on Node-broken legs (it documents the known gap and
+keeps the matrix green) and **must-pass** on Node-fixed / compat-tier legs. Once nub actually
+recovers the sync-into-async hop on the broken bands, flip the broken legs to
+`--collision-must-pass` (in `.github/workflows/node-matrix.yml`) so the matrix guards against a
+regression of the fix.
+
+## Reproduce locally
+
+```sh
+# Build the dev binary once (from the repo root):
+cargo build -p nub-cli -p nub-native
+mkdir -p runtime/addons && cp target/debug/libnub_native.so runtime/addons/nub-native.node
+
+# Drive nub onto a specific Node via PATH (nub augments the PATH node):
+PATH="$HOME/.nvm/versions/node/v24.11.0/bin:$PATH" tests/node-matrix/run.sh target/debug/nub
+PATH="$HOME/.nvm/versions/node/v26.2.0/bin:$PATH"  tests/node-matrix/run.sh target/debug/nub --collision-must-pass
+
+# Heavy real-app builds:
+PATH="$HOME/.nvm/versions/node/v24.11.0/bin:$PATH" tests/node-matrix/real-apps.sh target/debug/nub
+```

--- a/tests/node-matrix/README.md
+++ b/tests/node-matrix/README.md
@@ -49,13 +49,23 @@ The collision guard is meaningful **only on a Node-broken version** — on a Nod
 it is vacuously green. The matrix therefore runs it across the broken bands (and asserts it
 must pass on the fixed ones).
 
-## Important: nub must run the matrix-selected Node
+## Important: the engines-redirect guard (nub must run the matrix-selected Node)
 
-nub discovers its Node from `PATH`, but an `engines.node` / `.node-version` pin **above** the
-PATH version makes nub *provision* a different Node, silently masking a leg's coverage. The
-fixtures ship a **pin-free `package.json`** so nub always augments the matrix-selected version,
-and `run.sh` has a sanity guard that fails the leg if nub ran a different version than selected.
-The repo root pins `engines.node >= 22.15`, which is why the fixtures need their own.
+nub discovers its Node from `PATH`, but an `engines.node` / `.node-version` / `packageManager`
+constraint the PATH-selected Node does NOT satisfy makes nub **reject** it and fall through to the
+highest installed Node — so a leg labeled "Node 22.16" would silently run on 26 and **mask the
+version-specific bug**. That is the exact false-positive class this matrix exists to prevent, so
+the matrix is hardened against it two ways:
+
+1. **Permissive fixtures.** Every fixture (the smoke `package.json`, the scaffolded Next + Vite
+   apps) ships `engines.node: ">=18"` — low enough that no matrix leg is ever redirected, and it
+   shadows the repo root's `engines.node >= 22.15` (which would otherwise be inherited by upward
+   walk and redirect the lower-tier legs).
+2. **A version-assertion guard in BOTH runners.** `run.sh` and `real-apps.sh` each probe nub's
+   actual `process.version` (from a pin-free dir, so the probe isn't itself redirected) and FAIL
+   the leg if it doesn't equal the matrix-selected version. So even a stray pin, a transitive
+   `engines` constraint, or a future floor bump can't produce a silent false-green — the leg goes
+   RED with a "version redirect" message instead.
 
 ## The collision is a hard must-pass on every version
 

--- a/tests/node-matrix/README.md
+++ b/tests/node-matrix/README.md
@@ -57,22 +57,26 @@ fixtures ship a **pin-free `package.json`** so nub always augments the matrix-se
 and `run.sh` has a sanity guard that fails the leg if nub ran a different version than selected.
 The repo root pins `engines.node >= 22.15`, which is why the fixtures need their own.
 
-## XFAIL policy (read before flipping to hard-fail)
+## The collision is a hard must-pass on every version
 
-As of this matrix's introduction, **PR #98's fix does not actually recover the crash on the
-Node-broken bands** (validated against the real binary — see
-`.fray/node-version-matrix-smoke.findings/validation.md`):
+nub recovers the sync-into-async `resolveSync()`/`loadSync()` hop on the Node-broken bands
+(the Next.js/Turbopack/Tailwind fix — nub's fast-tier resolve+load hooks catch the
+`ERR_METHOD_NOT_IMPLEMENTED` stub throw and fall back to the parent CommonJS resolver). So the
+collision guard runs with `--collision-must-pass` on **every** leg: the previously-broken fast-tier
+versions (22.15-22.16, 23.6-23.11, 24.1-24.11, 25.0-25.1) now go GREEN, and so do the
+Node-fixed (24.12+, 25.2+, 26) and compat-tier (no `registerHooks`) versions. A **RED** collision
+on any leg is a real finding — either nub regressed the recovery, or a new broken Node band
+appeared that the recovery doesn't cover. Do not re-XFAIL it; surface it.
 
-1. #98's resolve-hook recovery is gated on `userAsyncLoaderActive()`, which is **false** at the
-   throwing resolution (the loader module's own spec, resolved during `module.register`), so the
-   recovery never fires.
-2. Even bypassing that gate, the **load** hook hits the identical `loadSync` stub with no recovery.
+The fixture also self-guards against silent augmentation-absence: on any Node with
+`registerHooks`, it asserts nub wrapped it (`__nubWrapped`) before judging, so a leg can't pass
+the collision merely because nub's preload failed to load (it would hard-fail instead).
 
-So the collision guard currently **XFAILs** on Node-broken legs (it documents the known gap and
-keeps the matrix green) and **must-pass** on Node-fixed / compat-tier legs. Once nub actually
-recovers the sync-into-async hop on the broken bands, flip the broken legs to
-`--collision-must-pass` (in `.github/workflows/node-matrix.yml`) so the matrix guards against a
-regression of the fix.
+History: an earlier revision of the fix only patched the resolve hook and gated recovery on a
+flag that was false at the loader's own resolution, so it did NOT recover the broken bands — the
+matrix was authored XFAIL-on-broken to stay honest about that gap. The reworked fix recovers both
+the resolve and load hooks across the whole band, validated on real broken-Node binaries, which is
+why every leg is now must-pass.
 
 ## Reproduce locally
 

--- a/tests/node-matrix/README.md
+++ b/tests/node-matrix/README.md
@@ -76,6 +76,13 @@ regression of the fix.
 
 ## Reproduce locally
 
+nub finds its `runtime/` (preload + addon) by walking up from the binary, so the binary must
+have `runtime/` as a sibling. The repo-root `target/debug/nub` does (the repo `runtime/` is a
+sibling) — but a binary built to an **out-of-tree** `CARGO_TARGET_DIR` (e.g. a worktree's
+`/tmp/<slug>-target/fast/nub`) does NOT: running the matrix against it directly yields **zero
+augmentation**, and the collision self-guard then hard-fails "augmentation NOT active". Bundle
+the binary with `runtime/` as siblings first — exactly what the CI `build` job stages.
+
 ```sh
 # Build the dev binary once (from the repo root):
 cargo build -p nub-cli -p nub-native

--- a/tests/node-matrix/fixtures/async-loader-collision/loader.mjs
+++ b/tests/node-matrix/fixtures/async-loader-collision/loader.mjs
@@ -1,0 +1,7 @@
+// A minimal pass-through USER async ESM loader, the shape `@tailwindcss/node`
+// registers (esm-cache.loader.mjs) when Tailwind v4 runs under Turbopack. Registering
+// THIS via `module.register()` while nub's fast-tier sync `module.registerHooks` resolve
+// hook is active is the whole trigger for the resolveSync() stub crash — see main.mjs.
+export async function resolve(specifier, context, nextResolve) {
+  return nextResolve(specifier, context);
+}

--- a/tests/node-matrix/fixtures/async-loader-collision/main.mjs
+++ b/tests/node-matrix/fixtures/async-loader-collision/main.mjs
@@ -11,12 +11,13 @@
 // the bare `module.register()` call is sufficient, verified through the real nub binary.)
 //
 // PASS contract: this program prints "COLLISION_OK" and exits 0 ONLY when nub recovers
-// from (or never hits) the resolveSync stub. On a Node-broken version with an un-fixed
-// nub it crashes BEFORE printing — exit != 0, `ERR_METHOD_NOT_IMPLEMENTED` on stderr.
-//
-// IMPORTANT: this guard is only meaningful on a Node-BROKEN version (v22.15-22.16,
-// v23.6-23.11, v24.1-24.11.x, v25.0-25.1). On Node-fixed versions (v24.12+, v25.2+, v26)
-// it is vacuously green. The matrix MUST run it on at least one broken-tier leg.
+// from (or never hits) the resolveSync/loadSync stub. nub's fast-tier hooks DO recover the
+// stub throw (the Next.js/Turbopack/Tailwind fix), so this must pass on EVERY version —
+// including the previously-broken bands (v22.15-22.16, v23.6-23.11, v24.1-24.11, v25.0-25.1),
+// which is exactly where the regression guard has teeth. A crash here (exit != 0,
+// `ERR_METHOD_NOT_IMPLEMENTED` on stderr) means nub regressed the recovery or a new broken
+// Node band appeared. Node-fixed (v24.12+, v25.2+, v26) and compat-tier (no registerHooks)
+// versions pass trivially.
 import nodeModule, { register } from "node:module";
 import { writeSync } from "node:fs";
 

--- a/tests/node-matrix/fixtures/async-loader-collision/main.mjs
+++ b/tests/node-matrix/fixtures/async-loader-collision/main.mjs
@@ -1,0 +1,33 @@
+// Async-loader × sync-hooks collision — the FAITHFUL, Turbopack-free regression guard
+// for the Next.js/Turbopack/Tailwind-v4 resolveSync() crash (the class PR #98 targets).
+//
+// Mechanism: nub's fast tier (Node >=22.15) installs a SYNC resolve hook via
+// `module.registerHooks`. When user code then calls `module.register(<async loader>)`,
+// Node must resolve the loader module's own specifier ("./loader.mjs") synchronously
+// through that sync chain. On Node-broken versions the chain reaches
+// `#resolveAndMaybeBlockOnLoaderThread` with an async-loader `#customizations` set and
+// calls `Hooks.resolveSync()` — a stub that throws `ERR_METHOD_NOT_IMPLEMENTED`. The
+// throw aborts the process. (Reduced from `@tailwindcss/node`; no bundler required —
+// the bare `module.register()` call is sufficient, verified through the real nub binary.)
+//
+// PASS contract: this program prints "COLLISION_OK" and exits 0 ONLY when nub recovers
+// from (or never hits) the resolveSync stub. On a Node-broken version with an un-fixed
+// nub it crashes BEFORE printing — exit != 0, `ERR_METHOD_NOT_IMPLEMENTED` on stderr.
+//
+// IMPORTANT: this guard is only meaningful on a Node-BROKEN version (v22.15-22.16,
+// v23.6-23.11, v24.1-24.11.x, v25.0-25.1). On Node-fixed versions (v24.12+, v25.2+, v26)
+// it is vacuously green. The matrix MUST run it on at least one broken-tier leg.
+import { register } from "node:module";
+import { writeSync } from "node:fs";
+
+register("./loader.mjs", import.meta.url);
+
+// Also exercise a post-register resolution (the in-the-wild trigger also resolves further
+// modules after the loader is live). Both paths go through the sync chain.
+const { pathToFileURL } = await import("node:url");
+if (typeof pathToFileURL !== "function") {
+  writeSync(2, "COLLISION_FAIL: node:url import returned wrong shape\n");
+  process.exit(2);
+}
+
+writeSync(1, "COLLISION_OK\n");

--- a/tests/node-matrix/fixtures/async-loader-collision/main.mjs
+++ b/tests/node-matrix/fixtures/async-loader-collision/main.mjs
@@ -17,8 +17,21 @@
 // IMPORTANT: this guard is only meaningful on a Node-BROKEN version (v22.15-22.16,
 // v23.6-23.11, v24.1-24.11.x, v25.0-25.1). On Node-fixed versions (v24.12+, v25.2+, v26)
 // it is vacuously green. The matrix MUST run it on at least one broken-tier leg.
-import { register } from "node:module";
+import nodeModule, { register } from "node:module";
 import { writeSync } from "node:fs";
+
+// SELF-GUARD (Scenario B must not pass vacuously when nub's augmentation is silently
+// ABSENT). The resolveSync collision can only occur on nub's FAST tier — the tier that
+// installs SYNC hooks via `module.registerHooks`. nub wraps `registerHooks` with an internal
+// `__nubWrapped` sentinel (runtime/preload-common.cjs). So on any Node that HAS registerHooks
+// (>=22.15, the fast-tier floor), a MISSING sentinel means nub's preload never loaded — the
+// leg would otherwise "pass" the collision for the wrong reason (no sync hook = no crash, but
+// also = nothing under test). Fail loudly instead. (On the compat tier registerHooks does not
+// exist and the sync-hook collision is structurally impossible — nothing to guard.)
+if (typeof nodeModule.registerHooks === "function" && nodeModule.registerHooks.__nubWrapped !== true) {
+  writeSync(2, "COLLISION_FAIL: nub fast-tier augmentation is NOT active (registerHooks not wrapped) — preload did not load; the collision is not under test on this leg\n");
+  process.exit(3);
+}
 
 register("./loader.mjs", import.meta.url);
 

--- a/tests/node-matrix/fixtures/functional/dep.cjs
+++ b/tests/node-matrix/fixtures/functional/dep.cjs
@@ -1,0 +1,1 @@
+module.exports = { answer: 42 };

--- a/tests/node-matrix/fixtures/functional/esm-imports-cjs.mjs
+++ b/tests/node-matrix/fixtures/functional/esm-imports-cjs.mjs
@@ -1,0 +1,2 @@
+import dep from "./dep.cjs";
+console.log("ESM_CJS:" + dep.answer);

--- a/tests/node-matrix/fixtures/functional/hello.js
+++ b/tests/node-matrix/fixtures/functional/hello.js
@@ -1,0 +1,1 @@
+console.log("HELLO_JS:" + (40 + 2));

--- a/tests/node-matrix/fixtures/functional/hello.ts
+++ b/tests/node-matrix/fixtures/functional/hello.ts
@@ -1,0 +1,3 @@
+enum Color { Red, Green }
+const greet = (name: string): string => `HELLO_TS:${name}:${Color.Green}`;
+console.log(greet("nub"));

--- a/tests/node-matrix/fixtures/functional/meta-resolve.mjs
+++ b/tests/node-matrix/fixtures/functional/meta-resolve.mjs
@@ -1,0 +1,2 @@
+const u = import.meta.resolve("./dep.cjs");
+console.log("META_RESOLVE:" + (u.startsWith("file:") ? "ok" : "bad"));

--- a/tests/node-matrix/fixtures/functional/worker-main.mjs
+++ b/tests/node-matrix/fixtures/functional/worker-main.mjs
@@ -1,0 +1,5 @@
+import { Worker } from "node:worker_threads";
+import { fileURLToPath } from "node:url";
+const w = new Worker(fileURLToPath(new URL("./worker-task.mjs", import.meta.url)));
+w.on("message", (m) => { console.log("WORKER:" + m); w.terminate(); });
+w.on("error", (e) => { console.error("WORKER_ERR:" + e.message); process.exit(1); });

--- a/tests/node-matrix/fixtures/functional/worker-task.mjs
+++ b/tests/node-matrix/fixtures/functional/worker-task.mjs
@@ -1,0 +1,2 @@
+import { parentPort } from "node:worker_threads";
+parentPort.postMessage("WORKER_PONG");

--- a/tests/node-matrix/package.json
+++ b/tests/node-matrix/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nub-node-matrix-fixtures",
+  "private": true,
+  "//": "No engines/.node-version pin: the matrix selects the Node version via PATH (actions/setup-node), and nub must augment THAT version. A pin here would make nub provision over the matrix's choice and mask compat-tier coverage."
+}

--- a/tests/node-matrix/package.json
+++ b/tests/node-matrix/package.json
@@ -1,5 +1,6 @@
 {
   "name": "nub-node-matrix-fixtures",
   "private": true,
-  "//": "No engines/.node-version pin: the matrix selects the Node version via PATH (actions/setup-node), and nub must augment THAT version. A pin here would make nub provision over the matrix's choice and mask compat-tier coverage."
+  "engines": { "node": ">=18" },
+  "//": "PERMISSIVE engines (>=18) on purpose: the matrix selects the Node version via PATH (actions/setup-node), and nub must augment THAT version. A RESTRICTIVE pin (or inheriting the repo root's engines.node>=22.15 by upward walk) would make nub REJECT a lower-tier PATH Node and fall through to the highest installed Node, silently masking compat-tier coverage. This package.json both shadows the repo root and states a floor low enough that no matrix leg is ever redirected. run.sh additionally asserts the running version matches the selected one."
 }

--- a/tests/node-matrix/real-apps.sh
+++ b/tests/node-matrix/real-apps.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Heavy real-app build matrix (NIGHTLY / dedicated — NOT per-PR). Scaffolds two real apps,
+# installs deps with `nub install`, and runs their builds under `nub`, asserting they
+# complete without the resolveSync/loadSync async-loader crash class. The Node version is
+# whatever `node` is on PATH (the matrix selects it; nub augments it).
+#
+#   app 1 — Next.js + Tailwind v4 + Turbopack: the IN-THE-WILD manifestation of the
+#           resolveSync crash (PR #98 / the nextjs-build-compat thread). On a Node-broken
+#           version with an un-fixed nub, `next build` aborts evaluating app/globals.css
+#           with `Error: The resolveSync() method is not implemented`.
+#   app 2 — Vite SSR build: exercises Vite's transform + rollup + a Node-side SSR render
+#           under nub across the matrix. Chosen as a small, dependency-light second
+#           real-world toolchain (no dev server / express needed — `vite build --ssr` +
+#           executing the SSR bundle is fully reproducible in CI). Pinned to vite 6.
+#
+# Usage:  real-apps.sh <path-to-nub-binary> [--require-pass]
+#   --require-pass : treat the Next/Tailwind resolveSync crash as a hard FAIL (use on
+#                    Node-fixed legs and as the post-fix gate). Default: XFAIL on a crash
+#                    (honest about the unfixed Node-broken bands) but FAIL on any OTHER
+#                    build error.
+set -uo pipefail
+
+NUB="${1:?usage: real-apps.sh <nub-binary> [--require-pass]}"
+REQUIRE_PASS=0
+[[ "${2:-}" == "--require-pass" ]] && REQUIRE_PASS=1
+NODE_VER="$(node --version 2>/dev/null || echo unknown)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/nub-realapps.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+echo "== real-apps on Node $NODE_VER ==  nub: $NUB  work: $WORK"
+
+fails=0
+crash_re='resolveSync|loadSync|ERR_METHOD_NOT_IMPLEMENTED|Error evaluating Node.js code'
+
+judge() { # judge <label> <exit> <logfile>
+  local label="$1" rc="$2" log="$3"
+  if [[ $rc -eq 0 ]]; then echo "  PASS  $label"; return; fi
+  if grep -qE "$crash_re" "$log"; then
+    if [[ $REQUIRE_PASS -eq 1 ]]; then
+      echo "  FAIL  $label — resolveSync/loadSync crash (nub did NOT recover)"; fails=$((fails + 1))
+    else
+      echo "  XFAIL $label — resolveSync/loadSync crash EXPECTED on Node-broken bands until nub recovers"
+    fi
+  else
+    echo "  FAIL  $label — build failed for a non-crash reason (exit=$rc); tail:"; tail -15 "$log" | sed 's/^/        /'
+    fails=$((fails + 1))
+  fi
+}
+
+# ── app 1: Next 16 + Tailwind v4 + Turbopack ──────────────────────────────────
+A1="$WORK/next-tw"; mkdir -p "$A1/app"
+cat > "$A1/package.json" <<'EOF'
+{ "name": "nub-next-tw", "private": true, "scripts": { "build": "next build" },
+  "dependencies": { "next": "16.1.1", "react": "19.2.0", "react-dom": "19.2.0",
+    "tailwindcss": "4.1.17", "@tailwindcss/postcss": "4.1.17" } }
+EOF
+printf "module.exports = { typescript: { ignoreBuildErrors: true }, eslint: { ignoreDuringBuilds: true } };\n" > "$A1/next.config.js"
+printf "export default { plugins: { '@tailwindcss/postcss': {} } };\n" > "$A1/postcss.config.mjs"
+printf '@import "tailwindcss";\n' > "$A1/app/globals.css"
+printf "import './globals.css';\nexport default function RootLayout({ children }) { return (<html><body>{children}</body></html>); }\n" > "$A1/app/layout.jsx"
+printf "export default function Page() { return <main className=\"p-4\">ok</main>; }\n" > "$A1/app/page.jsx"
+
+echo "-- next: nub install"
+if ! ( cd "$A1" && "$NUB" install ) >"$WORK/next-install.log" 2>&1; then
+  echo "  FAIL  next install"; tail -10 "$WORK/next-install.log" | sed 's/^/        /'; fails=$((fails + 1))
+else
+  echo "-- next: nub run build"
+  ( cd "$A1" && "$NUB" run build ) >"$WORK/next-build.log" 2>&1
+  judge "Next 16 + Tailwind v4 + Turbopack build" $? "$WORK/next-build.log"
+fi
+
+# ── app 2: Vite SSR build ─────────────────────────────────────────────────────
+A2="$WORK/vite-ssr"; mkdir -p "$A2/src"
+cat > "$A2/package.json" <<'EOF'
+{ "name": "nub-vite-ssr", "private": true, "type": "module",
+  "scripts": { "build": "vite build --ssr src/entry-server.js --outDir dist-server" },
+  "devDependencies": { "vite": "6.0.7" } }
+EOF
+cat > "$A2/src/entry-server.js" <<'EOF'
+export function render() { return `<h1>VITE_SSR_OK</h1>`; }
+EOF
+cat > "$A2/run-ssr.mjs" <<'EOF'
+const { render } = await import("./dist-server/entry-server.js");
+const html = render();
+if (!html.includes("VITE_SSR_OK")) { console.error("SSR render wrong:", html); process.exit(1); }
+console.log("VITE_SSR_RENDER_OK");
+EOF
+
+echo "-- vite: nub install"
+if ! ( cd "$A2" && "$NUB" install ) >"$WORK/vite-install.log" 2>&1; then
+  echo "  FAIL  vite install"; tail -10 "$WORK/vite-install.log" | sed 's/^/        /'; fails=$((fails + 1))
+else
+  echo "-- vite: nub run build (SSR)"
+  ( cd "$A2" && "$NUB" run build ) >"$WORK/vite-build.log" 2>&1
+  vrc=$?
+  if [[ $vrc -ne 0 ]]; then judge "Vite SSR build" $vrc "$WORK/vite-build.log"; else
+    echo "-- vite: execute SSR bundle under nub"
+    ( cd "$A2" && "$NUB" run-ssr.mjs ) >"$WORK/vite-render.log" 2>&1
+    rrc=$?
+    if [[ $rrc -eq 0 ]] && grep -q VITE_SSR_RENDER_OK "$WORK/vite-render.log"; then
+      echo "  PASS  Vite SSR build + render"
+    else
+      judge "Vite SSR render" $rrc "$WORK/vite-render.log"
+    fi
+  fi
+fi
+
+echo "== real-apps on Node $NODE_VER: $fails failure(s) =="
+exit $((fails > 0 ? 1 : 0))

--- a/tests/node-matrix/real-apps.sh
+++ b/tests/node-matrix/real-apps.sh
@@ -31,6 +31,24 @@ echo "== real-apps on Node $NODE_VER ==  nub: $NUB  work: $WORK"
 fails=0
 crash_re='resolveSync|loadSync|ERR_METHOD_NOT_IMPLEMENTED|Error evaluating Node.js code'
 
+# ENGINES-REDIRECT GUARD (defeats false-green from running the WRONG Node). nub discovers
+# its Node from PATH, but an `engines.node` / `.node-version` / `packageManager` constraint
+# that the PATH-selected Node does NOT satisfy makes nub REJECT it and fall through to the
+# highest installed Node — so a leg labeled "Node 22.16" would silently build on 26 and mask
+# version-specific bugs (the exact false-positive class this matrix exists to prevent). The
+# scaffolded apps below ship a PERMISSIVE `engines.node` (`>=18`) precisely so no lower-tier
+# leg is redirected; this assertion is the backstop that fails the leg if a redirect happens
+# anyway (a transitive dep, a future edit, a floor bump). Assert nub runs the matrix-selected
+# version BEFORE building anything.
+# Run the probe from $WORK (a bare mktemp dir under TMPDIR, no package.json in its parents)
+# so the probe ITSELF isn't redirected by the repo root's own engines pin.
+ACTUAL_VER="$(cd "$WORK" && "$NUB" --eval 'process.stdout.write(process.version)' 2>/dev/null || true)"
+if [[ -n "$ACTUAL_VER" && -n "$NODE_VER" && "$NODE_VER" != "unknown" && "$ACTUAL_VER" != "$NODE_VER" ]]; then
+  echo "  FAIL  version redirect — matrix selected $NODE_VER but nub ran on $ACTUAL_VER (engines/pin masking this leg)"
+  echo "== real-apps on Node $NODE_VER: 1 failure(s) =="
+  exit 1
+fi
+
 judge() { # judge <label> <exit> <logfile>
   local label="$1" rc="$2" log="$3"
   if [[ $rc -eq 0 ]]; then echo "  PASS  $label"; return; fi
@@ -50,6 +68,7 @@ judge() { # judge <label> <exit> <logfile>
 A1="$WORK/next-tw"; mkdir -p "$A1/app"
 cat > "$A1/package.json" <<'EOF'
 { "name": "nub-next-tw", "private": true, "scripts": { "build": "next build" },
+  "engines": { "node": ">=18" },
   "dependencies": { "next": "16.1.1", "react": "19.2.0", "react-dom": "19.2.0",
     "tailwindcss": "4.1.17", "@tailwindcss/postcss": "4.1.17" } }
 EOF
@@ -72,6 +91,7 @@ fi
 A2="$WORK/vite-ssr"; mkdir -p "$A2/src"
 cat > "$A2/package.json" <<'EOF'
 { "name": "nub-vite-ssr", "private": true, "type": "module",
+  "engines": { "node": ">=18" },
   "scripts": { "build": "vite build --ssr src/entry-server.js --outDir dist-server" },
   "devDependencies": { "vite": "6.0.7" } }
 EOF

--- a/tests/node-matrix/run.sh
+++ b/tests/node-matrix/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Node-version matrix smoke runner. Drives nub through a set of scenarios against
+# whatever `node` is on PATH (the matrix selects the Node version via actions/setup-node,
+# so this script is version-agnostic). Reuses ONE prebuilt nub binary across every Node
+# version — the Node version is a PATH/runtime choice, not a rebuild.
+#
+# Usage:  run.sh <path-to-nub-binary> [--collision-must-pass]
+#
+#   --collision-must-pass : assert the async-loader-collision fixture EXITS 0 (used on
+#                           Node-fixed legs, and as the post-fix regression gate). Without
+#                           it, the collision fixture is run for signal/logging but a crash
+#                           is reported as EXPECTED-on-broken-tier rather than a failure, so
+#                           the matrix is honest about which Node versions carry the Node bug.
+#                           (See NODE_BROKEN_BANDS below — the script auto-detects.)
+set -uo pipefail
+
+NUB="${1:?usage: run.sh <nub-binary> [--collision-must-pass]}"
+COLLISION_MUST_PASS=0
+[[ "${2:-}" == "--collision-must-pass" ]] && COLLISION_MUST_PASS=1
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIX="$HERE/fixtures"
+# The Node version is whatever `node` resolves to on PATH — that is the version nub will
+# augment (nub discovers its Node from PATH). Read it directly; nub's own `-e` resolves a
+# possibly-different default and would mislabel the leg.
+NODE_VER="$(node --version 2>/dev/null || echo unknown)"
+echo "== Node $NODE_VER ==  nub: $NUB"
+
+fails=0
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1"; fails=$((fails + 1)); }
+
+# SANITY: nub discovers its Node from PATH, but a pin (engines / .node-version) ABOVE the
+# PATH version makes it PROVISION a different Node — silently masking the leg's coverage.
+# Assert nub actually ran the matrix-selected version before trusting any result. The
+# matrix fixtures ship a pin-free package.json so this should always hold; this guard
+# catches a future regression (a stray pin, a floor bump) that would make the matrix lie.
+ACTUAL_VER="$(cd "$FIX/async-loader-collision" && "$NUB" --eval 'process.stdout.write(process.version)' 2>/dev/null || true)"
+if [[ -n "$ACTUAL_VER" && -n "$NODE_VER" && "$NODE_VER" != "unknown" && "$ACTUAL_VER" != "$NODE_VER" ]]; then
+  fail "version mismatch — matrix selected $NODE_VER but nub ran on $ACTUAL_VER (a pin is masking this leg's coverage)"
+fi
+
+# Assert: running `nub <args>` exits 0 and stdout contains <needle>.
+expect_ok_contains() {
+  local label="$1" needle="$2"; shift 2
+  local out rc
+  out="$("$NUB" "$@" 2>/tmp/nm-err.txt)"; rc=$?
+  if [[ $rc -eq 0 && "$out" == *"$needle"* ]]; then
+    pass "$label"
+  else
+    fail "$label (exit=$rc, stdout=[$out], stderr=[$(cat /tmp/nm-err.txt)])"
+  fi
+}
+
+# ── Scenario A + broad functional smoke ──────────────────────────────────────
+expect_ok_contains "hello.js"          "HELLO_JS:42"        "$FIX/functional/hello.js"
+expect_ok_contains "hello.ts (transpile + enum)" "HELLO_TS:nub:1" "$FIX/functional/hello.ts"
+expect_ok_contains "ESM imports CJS"   "ESM_CJS:42"         "$FIX/functional/esm-imports-cjs.mjs"
+expect_ok_contains "import.meta.resolve" "META_RESOLVE:ok"  "$FIX/functional/meta-resolve.mjs"
+expect_ok_contains "Worker threads"    "WORKER:WORKER_PONG" "$FIX/functional/worker-main.mjs"
+
+# ── Scenario B: async-loader × sync-hooks collision (the resolveSync class) ───
+# A Node version carries the bug iff it has registerHooks AND is in a broken band; this
+# script doesn't enumerate bands — it just runs the fixture and judges by the policy flag.
+coll_out="$(cd "$FIX/async-loader-collision" && "$NUB" main.mjs 2>/tmp/nm-coll-err.txt)"; coll_rc=$?
+coll_err="$(cat /tmp/nm-coll-err.txt)"
+if [[ $coll_rc -eq 0 && "$coll_out" == *"COLLISION_OK"* ]]; then
+  pass "async-loader collision (no resolveSync crash)"
+elif [[ "$coll_err" == *"ERR_METHOD_NOT_IMPLEMENTED"* || "$coll_err" == *"resolveSync"* || "$coll_err" == *"loadSync"* ]]; then
+  if [[ $COLLISION_MUST_PASS -eq 1 ]]; then
+    fail "async-loader collision: resolveSync/loadSync crash (exit=$coll_rc) — nub did NOT recover.
+        stderr: $coll_err"
+  else
+    echo "  XFAIL async-loader collision: resolveSync/loadSync crash on this Node (exit=$coll_rc) —
+        EXPECTED while nub does not yet recover the sync-into-async hop on Node-broken versions.
+        This is the bug class PR #98 targets. Promote to FAIL (pass --collision-must-pass) once nub recovers."
+  fi
+else
+  fail "async-loader collision: unexpected failure (exit=$coll_rc, stdout=[$coll_out], stderr=[$coll_err])"
+fi
+
+echo "== Node $NODE_VER: $fails failure(s) =="
+exit $((fails > 0 ? 1 : 0))

--- a/tests/node-matrix/run.sh
+++ b/tests/node-matrix/run.sh
@@ -30,11 +30,14 @@ fails=0
 pass() { echo "  PASS  $1"; }
 fail() { echo "  FAIL  $1"; fails=$((fails + 1)); }
 
-# SANITY: nub discovers its Node from PATH, but a pin (engines / .node-version) ABOVE the
-# PATH version makes it PROVISION a different Node — silently masking the leg's coverage.
-# Assert nub actually ran the matrix-selected version before trusting any result. The
-# matrix fixtures ship a pin-free package.json so this should always hold; this guard
-# catches a future regression (a stray pin, a floor bump) that would make the matrix lie.
+# ENGINES-REDIRECT GUARD (defeats the false-green class this matrix exists to prevent).
+# nub discovers its Node from PATH, but an `engines.node` / `.node-version` / `packageManager`
+# constraint that the PATH-selected Node does NOT satisfy makes nub REJECT it and fall through
+# to the highest installed Node — so a leg labeled "Node 22.16" would silently run on 26 and
+# mask version-specific bugs. The fixtures ship a PERMISSIVE engines (>=18) so no lower-tier
+# leg is redirected; this assertion is the backstop — it fails the leg if the running Node is
+# not the matrix-selected one (a stray pin, a transitive constraint, a floor bump). Probe from
+# the pin-free fixtures dir so the probe itself isn't redirected.
 ACTUAL_VER="$(cd "$FIX/async-loader-collision" && "$NUB" --eval 'process.stdout.write(process.version)' 2>/dev/null || true)"
 if [[ -n "$ACTUAL_VER" && -n "$NODE_VER" && "$NODE_VER" != "unknown" && "$ACTUAL_VER" != "$NODE_VER" ]]; then
   fail "version mismatch — matrix selected $NODE_VER but nub ran on $ACTUAL_VER (a pin is masking this leg's coverage)"


### PR DESCRIPTION
## What

Adds a CI workflow + fixtures that exercise nub's **version-banded augmentation** across a broad Node-version matrix — closing the gap that let the Turbopack/Tailwind `resolveSync()` crash ship uncaught. nub augments the user's Node through mechanisms that break **differently per Node version** (sync `module.registerHooks` fast tier ≥22.15, async `module.register` loader-worker compat tier 18.19–22.14, flag injection); the main CI matrix tested only a handful of versions and never set up the async-loader × sync-hooks collision.

## Scenarios

- **functional smoke** (every version): `hello.js`, `hello.ts` (transpile + non-erasable enum), ESM↔CJS, `import.meta.resolve`, Worker threads.
- **async-loader collision** (`tests/node-matrix/fixtures/async-loader-collision/`): a **bundler-free** reproduction of the `resolveSync()` stub crash — a bare `module.register(<async loader>)` while nub's fast-tier sync resolve hook is active. Verified to reproduce **identically to the real Turbopack build** through the actual nub binary.
- **real-app builds** (nightly / augmentation-surface PRs): **Next 16 + Tailwind v4 + Turbopack** (the in-the-wild manifestation) and a **Vite 6 SSR** build.

## Cost model (CI is free; optimize runner slots + latency)

- nub is built **once** and reused across every Node leg via an artifact — the Node version is a PATH/runtime choice (`actions/setup-node`), not a rebuild.
- per-PR: a lean tier-boundary subset of the lightweight smoke, gated by **path filters** (the full sweep + real apps run only when `runtime/`, `crates/nub-core/src/node/`, `crates/nub-cli/src/`, or this workflow change).
- push:main + nightly: the full version sweep + both real apps.
- `concurrency` group with `cancel-in-progress`; one always-green `node-matrix-gate` aggregator for branch protection.

## Validation (the non-negotiable proof)

Validated against a dev `nub` built from current `main` (pre-#98), toggling #98's `runtime/preload-common.cjs` fix in place, across nvm Node versions:

| Node | nub state | collision / real Next build |
|---|---|---|
| 22.16, 24.11 (Node-broken) | pre-#98 | **RED** — `resolveSync()` crash reproduced |
| 22.16, 24.11 (Node-broken) | **with #98 fix** | **STILL RED** — #98 does not recover the crash on broken bands |
| 24.12, 26 (Node-fixed) | either | green (trivially — Node has no bug there) |
| 18.19–22.12 (compat tier) | — | green (no sync hook → no stub) |

→ The matrix reproduces the bug on the affected versions and stays honest on the rest. Functional smoke passes on every tier; the Vite SSR build passes on every version.

## Note for review (the matrix already earned its keep)

Building this surfaced that **#98's fix does not actually resolve the crash on the Node-broken bands** — its `userAsyncLoaderActive()` gate is `false` at the throwing resolution (the loader module's own spec), so the recovery never fires; and the load hook has the same un-recovered `loadSync` stub. #98's "post-fix EXIT 0" was a false positive from validating on a Node-level-fixed host. So the collision guard **XFAILs on Node-broken legs** for now (documented in `tests/node-matrix/README.md`) and **must-pass** on Node-fixed / compat-tier legs; flip the broken legs to `--collision-must-pass` once nub recovers the sync-into-async hop. This matrix would have blocked #98 as a non-fix.

Refs #98

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa