### PR TITLE
tests/vm: Apple Silicon VM-control runbook + proven Tart Linux loop

### DIFF
--- a/tests/vm/README.md
+++ b/tests/vm/README.md
@@ -1,0 +1,89 @@
+# Local VMs on Apple Silicon — spin up, exec, tear down
+
+A CLI-scriptable way to boot a throwaway VM on a macOS/arm64 host, run a command or probe script inside it, capture the output back on the host, and tear it down. The point is to turn a "does X behave this way on another OS?" question into a local experiment instead of a CI round-trip — cross-distro Linux sandbox probing, floor-Node testing, clean-machine install runs, and (the original driver) the Windows script-sandbox probes.
+
+Two backends, because no single tool covers both guest families on Apple Silicon:
+
+| Guest | Tool | Speed | Status |
+| --- | --- | --- | --- |
+| Linux (and macOS) | **Tart** (`tart`) — Apple Virtualization.framework | Native, fast | **Proven loop** — `tart-vm.sh` |
+| Windows 11 ARM64 | **QEMU + HVF** (`qemu-system-aarch64 -accel hvf`) | Native arm64 kernel | **Install blocked** — see below; runbook in `~/winvm-build/` |
+
+**Why two tools:** Apple's Virtualization.framework (and therefore Tart, and UTM's "Apple" backend) **cannot boot Windows on ARM** — no Windows-compatible UEFI/virtio guest support (cirruslabs/tart#1123). So Linux uses the fast native path (Tart) and Windows requires QEMU under the Hypervisor.framework accelerator. UTM's `utmctl` only does lifecycle of an *already-built* VM; it doesn't help with the hard part (unattended create + OOBE bypass).
+
+## Linux — the proven loop (`tart-vm.sh`)
+
+Requires Tart (`brew install cirruslabs/cli/tart`) — already installed on this host. `sshpass` (optional, `brew install sshpass`) enables `run` to scp a script in; without it, `run` pipes the script body through `tart exec` stdin.
+
+```bash
+# Full demo: clone → boot headless → exec → run a local probe → teardown.
+./tart-vm.sh demo
+
+# Or step by step:
+./tart-vm.sh up                              # clone ghcr.io/cirruslabs/ubuntu:latest + boot, prints IP
+./tart-vm.sh exec -- bash -lc 'uname -srm'   # run a command in the guest
+./tart-vm.sh run ./my-probe.sh               # copy a local script in and run it
+./tart-vm.sh down                            # stop (disk persists, fast restart)
+./tart-vm.sh rm                              # stop + delete (frees disk)
+```
+
+Proven end-to-end **2026-06-23** on M1 Max / macOS 26.5 / tart 2.32.1, Ubuntu 24.04.4 arm64. Captured output of `./tart-vm.sh demo`:
+
+```
+>> cloning ghcr.io/cirruslabs/ubuntu:latest -> nub-vm-demo-...
+>> booting nub-vm-demo-... headless
+>> nub-vm-demo-... up at 192.168.64.4
+-- exec: guest identity --
+ARCH=aarch64
+DISTRO=Ubuntu 24.04.4 LTS
+WHOAMI=admin
+-- run: a local probe script --
+probe on: aarch64 / ubuntu
+fs write /tmp: ok
+egress https: 200
+-- teardown --
+== demo complete ==
+```
+
+Boot-to-IP is ~20s; `tart exec` runs synchronously and returns the guest's stdout/exit code to the host. cirruslabs Linux images log in as `admin`/`admin`. Pass a different image as the last arg to `up` (any `tart`-pullable OCI VM image, e.g. `ghcr.io/cirruslabs/ubuntu:22.04`).
+
+### Worked example — running a sandbox/probe script
+
+`run` is the probe pattern: author a `.sh` on the host, `run` it in the guest, read the result on host stdout. The same shape works for the script-sandbox probes — write the probe (FS write-confine, egress block, read-deny assertions), `run` it, assert on the captured output. For a clean-distro matrix, loop `up <name> <image>` over several images.
+
+## Windows 11 ARM64 — QEMU runbook (install currently BLOCKED)
+
+The full runbook, scripts, and artifacts live in **`~/winvm-build/`** (host home, outside the repo — the ISO is 7.3 GB and the disk image 12 GB). Start with `~/winvm-build/README.md`. It is a complete, well-documented QEMU+HVF setup: EDK2 aarch64 UEFI firmware, an `autounattend.xml` answer file (bypasses TPM/SecureBoot, skips OOBE, creates admin `nub`/`NubWin11!Pass`, installs OpenSSH Server, authorizes `~/.ssh/nub-winvm.pub`, opens firewall :22, PowerShell default shell), NetKVM ARM64 NIC driver injection, NVMe `bootindex=1` boot-order fix, a QMP `kickstart.py` to clear the first-boot UEFI shell, `shot.sh` to screenshot the headless VM, and `install-loop.sh` to relaunch QEMU across Setup's ACPI power-offs. Once SSH is up the VM is driven exactly like Linux — over SSH from the Bash tool:
+
+```bash
+ssh -i ~/.ssh/nub-winvm -p 2222 -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null nub@localhost \
+    'powershell -NoProfile -Command "$PSVersionTable.OS; $env:PROCESSOR_ARCHITECTURE"'
+```
+
+The harness to run once it's up is `../windows/papercut-survey.ps1`.
+
+### Where it's blocked (verified 2026-06-23)
+
+The unattended install reaches **WIM-apply + the first NVMe reboot** (qcow2 grows to ~12-13 GB) then hangs in a **persistent "The computer restarted unexpectedly or encountered an unexpected error. Windows installation cannot proceed." loop at the specialize/OOBE phase** — confirmed by screenshot (TianoCore/EDK2 firmware behind the Windows Setup error dialog). `install-loop.sh` rides out Setup's ACPI power-offs by relaunching from NVMe, but the install never advances past specialize, so SSH on :2222 never comes up. **No verified Windows arm64 SSH output, no clean snapshot.**
+
+Likely cause (per the prior session's analysis in the `windows-papercut` thread): a `RunSynchronousCommand` in the answer file's `specialize`/`oobeSystem` pass returning non-zero (which aborts Setup with exactly this error), and/or the install media staying attached so Setup re-enters WinPE on reboot.
+
+### Human-unblock / next-step options
+
+Diagnosing further needs the Setup logs, which on macOS is the friction point (no NBD to loopback-mount the qcow2 and read `X:\Windows\Panther\setuperr.log`). Concrete unblock paths, cheapest first:
+
+1. **Read the Setup logs.** Convert the qcow2 to raw and mount, or boot the VM with a WinPE/recovery ISO and `type` the `Panther\setupact.log` / `setuperr.log` + `UnattendGC\setupact.log` to find the exact failing specialize step, then fix that one command in `~/winvm-build/unattend/autounattend.xml` and rebuild `unattend.iso`.
+2. **Strip the specialize pass.** Move ALL provisioning (OpenSSH install, key authorization, firewall) out of `specialize`'s `RunSynchronousCommand` and into `oobeSystem` `FirstLogonCommands` only, so nothing non-zero can abort Setup mid-specialize. (Prior session's stated fallback plan.)
+3. **Do the OOBE once interactively.** Attach a display (VNC is wired: `-vnc 127.0.0.1:1`, connect a VNC client to `localhost:5901`), click through the one stuck transition by hand, then snapshot clean — after that everything is headless/SSH/CLI. This is the "one human step" that most reliably gets to a working baseline.
+4. **Recommend-only — a paid VM tool.** VMware Fusion (`VMware Fusion.app` is installed; Fusion is now free for personal use, `vmrun` CLI) and Parallels (`prlctl`, paid) both have first-class Windows-11-ARM support and far smoother unattended Windows installs than hand-rolled QEMU. If a reliable local Windows VM becomes a recurring need, evaluating Fusion's `vmrun`-driven unattended path is the highest-leverage next move — but it's a maintainer call and not required (the `windows-latest` CI leg already covers Windows; this local VM is an iteration-speed convenience, and x64-native is CI-only regardless).
+
+### Platform caveat (state in every Windows claim from this VM)
+
+An ARM VM exercises **win32-arm64 natively** + win32-x64 under Windows-on-ARM's x64 *emulation* layer. **True win32-x64 native is NOT covered** — that stays the `windows-latest` CI leg or an x64 host.
+
+## Hygiene
+
+- Keep VMs ephemeral: `tart-vm.sh rm` (or `demo`, which self-cleans) frees the disk. `tart list` shows what exists; `tart prune` clears caches.
+- **Windows: exactly ONE QEMU against `win11.qcow2` at a time** (qcow2 takes a write lock; overlapping launches corrupt install progress — this caused a multi-launch "war" in a prior session). Before any launch: `pkill -9 -f qemu-system-aarch64; sleep 2` must leave no QEMU running.
+- Nothing here touches the repo tree or anything destructive on the host; VM disks live under `~/.tart/` (Linux) and `~/winvm-build/` (Windows).

--- a/tests/vm/tart-vm.sh
+++ b/tests/vm/tart-vm.sh
@@ -57,7 +57,10 @@ cmd_up() {
 }
 
 cmd_exec() {
-  local name="${1:-$NAME_DEFAULT}"; shift || true
+  # Optional leading [name]; if the first arg is the `--` separator (or absent),
+  # the name was omitted -> use the default.
+  local name="$NAME_DEFAULT"
+  if [ "${1:-}" != "--" ] && [ "$#" -gt 0 ]; then name="$1"; shift; fi
   [ "${1:-}" = "--" ] && shift
   [ "$#" -gt 0 ] || die "exec needs a command after --"
   need tart
@@ -65,7 +68,11 @@ cmd_exec() {
 }
 
 cmd_run() {
-  local name="${1:-$NAME_DEFAULT}" file="${2:?run needs a local script path}"
+  # Optional leading [name]; if the first arg is an existing file, the name was
+  # omitted -> use the default and treat that arg as the script.
+  local name="$NAME_DEFAULT" file
+  if [ -f "${1:-}" ]; then file="$1"; else name="${1:-$NAME_DEFAULT}"; file="${2:-}"; fi
+  [ -n "$file" ] || die "run needs a local script path"
   [ -f "$file" ] || die "no such file: $file"
   need tart
   local ip; ip=$(tart ip "$name" 2>/dev/null) || die "$name has no IP — is it up?"

--- a/tests/vm/tart-vm.sh
+++ b/tests/vm/tart-vm.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# tart-vm.sh — spin up a headless Linux VM on Apple Silicon, run a command/script
+# inside it, capture the output on the host, and tear it down. The fast,
+# free, fully-CLI-scriptable VM loop for cross-platform probing on macOS/arm64.
+#
+# Backend: Tart (Apple Virtualization.framework). Linux + macOS guests only —
+# Windows-on-ARM is NOT supported by Apple's framework (see ../windows + the
+# QEMU runbook referenced in README.md). For a Linux probe this is the loop.
+#
+# Proven end-to-end 2026-06-23 on M1 Max / macOS 26.5 with tart 2.32.1 against
+# ghcr.io/cirruslabs/ubuntu:latest (Ubuntu 24.04 arm64). See README.md.
+#
+# Usage:
+#   tart-vm.sh up    [name] [image]   # clone + boot headless, wait for IP
+#   tart-vm.sh exec  [name] -- CMD... # run CMD in the guest, output to host stdout
+#   tart-vm.sh run   [name] FILE      # copy a local script into the guest and run it
+#   tart-vm.sh ip    [name]           # print the guest IP
+#   tart-vm.sh down  [name]           # stop the VM (disk persists)
+#   tart-vm.sh rm    [name]           # stop + delete the VM (frees disk)
+#   tart-vm.sh demo                   # full up→exec→run→down on a throwaway VM
+#
+# Defaults: name=nub-linux-proof, image=ghcr.io/cirruslabs/ubuntu:latest.
+# cirruslabs Linux images use credentials admin/admin (used here for scp).
+set -uo pipefail
+
+NAME_DEFAULT="nub-linux-proof"
+IMAGE_DEFAULT="ghcr.io/cirruslabs/ubuntu:latest"
+GUEST_USER="admin"
+GUEST_PASS="admin"
+
+die() { echo "error: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing dependency: $1"; }
+
+wait_for_ip() {
+  local name="$1" ip
+  for _ in $(seq 1 60); do
+    ip=$(tart ip "$name" 2>/dev/null)
+    if [ -n "$ip" ]; then echo "$ip"; return 0; fi
+    sleep 5
+  done
+  return 1
+}
+
+cmd_up() {
+  local name="${1:-$NAME_DEFAULT}" image="${2:-$IMAGE_DEFAULT}"
+  need tart
+  if ! tart list 2>/dev/null | awk '{print $2}' | grep -qx "$name"; then
+    echo ">> cloning $image -> $name" >&2
+    tart clone "$image" "$name" || die "clone failed"
+  fi
+  echo ">> booting $name headless" >&2
+  tart run --no-graphics "$name" >/tmp/tart-$name.log 2>&1 &
+  local ip
+  ip=$(wait_for_ip "$name") || die "VM never got an IP (see /tmp/tart-$name.log)"
+  echo ">> $name up at $ip" >&2
+  echo "$ip"
+}
+
+cmd_exec() {
+  local name="${1:-$NAME_DEFAULT}"; shift || true
+  [ "${1:-}" = "--" ] && shift
+  [ "$#" -gt 0 ] || die "exec needs a command after --"
+  need tart
+  tart exec "$name" "$@"
+}
+
+cmd_run() {
+  local name="${1:-$NAME_DEFAULT}" file="${2:?run needs a local script path}"
+  [ -f "$file" ] || die "no such file: $file"
+  need tart
+  local ip; ip=$(tart ip "$name" 2>/dev/null) || die "$name has no IP — is it up?"
+  local remote="/tmp/$(basename "$file")"
+  if command -v sshpass >/dev/null 2>&1; then
+    sshpass -p "$GUEST_PASS" scp -q -o StrictHostKeyChecking=no \
+      -o UserKnownHostsFile=/dev/null "$file" "$GUEST_USER@$ip:$remote" \
+      || die "scp failed"
+    tart exec "$name" bash "$remote"
+  else
+    # No sshpass: pipe the script body through tart exec stdin.
+    tart exec "$name" bash -c "$(cat "$file")"
+  fi
+}
+
+cmd_ip()   { tart ip "${1:-$NAME_DEFAULT}"; }
+cmd_down() { tart stop "${1:-$NAME_DEFAULT}"; }
+cmd_rm()   { local n="${1:-$NAME_DEFAULT}"; tart stop "$n" 2>/dev/null; tart delete "$n"; }
+
+cmd_demo() {
+  local name="nub-vm-demo-$$"
+  echo "== VM-control demo (throwaway VM: $name) =="
+  cmd_up "$name" >/dev/null
+  echo "-- exec: guest identity --"
+  cmd_exec "$name" -- bash -lc \
+    'echo "ARCH=$(uname -m)"; echo "DISTRO=$(. /etc/os-release; echo $PRETTY_NAME)"; echo "WHOAMI=$(whoami)"'
+  echo "-- run: a local probe script --"
+  local probe; probe=$(mktemp /tmp/vm-probe.XXXXXX.sh)
+  cat > "$probe" <<'EOF'
+echo "probe on: $(uname -m) / $(hostname)"
+echo "fs write /tmp: $(touch /tmp/marker && echo ok)"
+echo "egress https: $(curl -s -o /dev/null -w '%{http_code}' --max-time 5 https://example.com || echo blocked)"
+EOF
+  cmd_run "$name" "$probe"
+  rm -f "$probe"
+  echo "-- teardown --"
+  cmd_rm "$name"
+  echo "== demo complete =="
+}
+
+sub="${1:-}"; shift || true
+case "$sub" in
+  up)   cmd_up   "$@" ;;
+  exec) cmd_exec "$@" ;;
+  run)  cmd_run  "$@" ;;
+  ip)   cmd_ip   "$@" ;;
+  down) cmd_down "$@" ;;
+  rm)   cmd_rm   "$@" ;;
+  demo) cmd_demo "$@" ;;
+  *) sed -n '2,30p' "$0"; exit 1 ;;
+esac


### PR DESCRIPTION
Adds `tests/vm/` — a CLI-scriptable way to spin up a VM on the macOS/arm64 host, run a command/probe inside it, capture output, and tear down. Turns cross-platform "does X behave this way on another OS?" questions into local experiments instead of CI round-trips (immediate driver: the Windows script-sandbox probes; broader: cross-distro Linux probing, floor-Node, clean-machine installs).

## What's here
- **`tart-vm.sh`** — `up`/`exec`/`run`/`down`/`rm`/`demo` over Tart (Apple Virtualization). **Proven end-to-end** 2026-06-23 (M1 Max, macOS 26.5, tart 2.32.1) against Ubuntu 24.04 arm64: clone -> boot headless -> `tart exec` -> scp-and-run a probe -> capture host-side output -> teardown. `./tart-vm.sh demo` runs the whole loop and self-cleans.
- **`README.md`** — two-backend runbook: Tart for Linux (fast, native), QEMU+HVF for Windows-11-ARM. Documents why Windows needs QEMU (Apple Virtualization can't boot Windows guests), where the Windows unattended install is currently blocked (specialize-phase restart loop) + the human-unblock options, and the win32-arm64-only platform caveat.

## Why test tooling, not Rust
No code/behavior change — a test/probe harness + runbook. Path-filtered CI skips the Rust matrix.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa