### PR TITLE
docs(run): document the in-package /regex/ multi-script selector

### DIFF
--- a/site/content/docs/run.mdx
+++ b/site/content/docs/run.mdx
@@ -44,6 +44,32 @@ Dispatch is handled in Rust with no Node bootstrap in the wrapper, so the runner
   source="https://github.com/nubjs/nub/tree/main/tests/bench/script-runner"
 />
 
+## Run several scripts at once
+
+A `/regex/` selector in place of a script name runs every script whose name matches, mirroring `pnpm run`. This is the in-package equivalent of `npm-run-all`'s `run-p` — without the extra dependency or the per-task PM re-spawn, since Nub spawns each script body directly.
+
+```bash
+nub run "/^build:/"     # runs build:js, build:css, build:types — concurrently
+```
+
+Matching scripts run concurrently by default, capped at `min(4, CPU count)`, with each line prefixed by its script name. To run them one at a time instead (the `run-s` behavior), cap the concurrency at one:
+
+```bash
+nub run --workspace-concurrency 1 "/^build:/"   # one at a time, in package.json order
+```
+
+The selector must be a slash-delimited regular expression literal (`/^build:/`); a plain `build:*` is treated as a literal script name, not a glob. Regex flags are not supported. An exact script name (no slashes) always runs that single script unchanged.
+
+Coming from `npm-run-all` / `npm-run-all2`:
+
+| npm-run-all | Nub |
+|---|---|
+| `run-p build:js build:css` | `nub run "/^build:(js\|css)$/"` |
+| `run-p "build:*"` | `nub run "/^build:/"` |
+| `run-s "build:*"` | `nub run --workspace-concurrency 1 "/^build:/"` |
+
+Selecting an *arbitrary, unrelated* set of scripts (for example `build`, `lint`, `test` together, which share no name pattern) is not yet supported — track [#102](https://github.com/nubjs/nub/issues/102).
+
 ## Forward arguments
 
 Trailing arguments after the script name are passed straight through to the script. You do not need the `--` separator that `npm run` requires.


### PR DESCRIPTION
Documents the in-package `/regex/` multi-script selector (the run-p/run-s ergonomic) that merged in #49 but was never documented.

## What

Adds a "Run several scripts at once" section to `site/content/docs/run.mdx`:

- `nub run "/^build:/"` runs every matching script concurrently (cap `min(4, cpus)`).
- `nub run --workspace-concurrency 1 "/^build:/"` serializes them (the run-s form).
- An `npm-run-all` / `npm-run-all2` migration table.
- Notes that selecting an arbitrary, unrelated script set (e.g. `build lint test`, no shared pattern) is not yet supported.

Every command in the section was verified against the dev binary on a real fixture.

## Context for the reviewer (issue #102)

This came out of #102 (jdalton's run-s/run-p request). Building the full feature surfaced a grammar decision the maintainer owns, so the **arbitrary-list run-p/run-s feature is NOT in this PR** — only the doc for the already-working `/regex/` form is. The open grammar question:

- The previously-recorded plan was `nub run --parallel/--sequential <list>`, but `--parallel`/`--sequential` are **already live pnpm-compat workspace flags** on `run` (they promote to `--recursive`, mirroring pnpm's `run.ts` shorthands). Overloading them for an in-package script list would be a context-dependent flag meaning and a pnpm-compat regression in workspaces.
- Separately, the in-package run-s via `--sequential` is currently broken (it leaks into script args / errors); only `--workspace-concurrency 1` serializes the set today. The doc uses the working knob.

Full options + recommendation are in the thread for the maintainer's call; this PR ships only the decision-free documentation.

Refs #102