### PR TITLE
Audit pnpm v11.9.0: fix inherited credential leak + multi-version minimumReleaseAgeExclude

### DIFF
--- a/crates/nub-cli/src/pm_engine/present.rs
+++ b/crates/nub-cli/src/pm_engine/present.rs
@@ -196,7 +196,8 @@ const RUNTIME_HINT_VOCAB: &[(&str, &str)] = &[(
 /// codes (so the `AUBE` inside `ERR_AUBE_*` never reaches the word pass), then
 /// per-line URL stripping, then the word-boundary `aube` → `nub` pass.
 pub(crate) fn rewrite(text: &str) -> String {
-    let mut text = text.to_string();
+    let text = redact_credentials(text);
+    let mut text = text;
     for (from, to) in RUNTIME_HINT_VOCAB {
         text = text.replace(from, to);
     }
@@ -221,6 +222,71 @@ pub(crate) fn rewrite(text: &str) -> String {
         emitted = true;
     }
     out
+}
+
+/// Defense-in-depth credential scrub over arbitrary engine prose.
+///
+/// The engine redacts URLs at every known source (the tarball path, the
+/// `Error::Http` Display), so in correct operation no credential reaches
+/// here. This backstop guarantees that a FUTURE un-redacted engine path
+/// cannot leak `user:pass@host` userinfo or a `token`/`auth`/`api_key`
+/// query value through nub's output: it finds every whitespace-delimited
+/// URL-like token (`scheme://…` or scheme-relative `//…`) and runs it
+/// through the same [`aube_util::url::redact_url`] the engine uses, so the
+/// two layers can never diverge. Non-URL text is returned untouched.
+fn redact_credentials(text: &str) -> String {
+    // Cheap pre-check: a credential can only ride on a URL token, which
+    // always contains "//". Skip the allocation/scan for the common case.
+    if !text.contains("//") {
+        return text.to_string();
+    }
+    let mut out = String::with_capacity(text.len());
+    // Walk the text token-by-token, preserving every whitespace separator
+    // verbatim so the rendered message's spacing/newlines survive.
+    let mut rest = text;
+    while !rest.is_empty() {
+        let ws_end = rest
+            .find(|c: char| !c.is_whitespace())
+            .unwrap_or(rest.len());
+        if ws_end > 0 {
+            out.push_str(&rest[..ws_end]);
+            rest = &rest[ws_end..];
+            continue;
+        }
+        let tok_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+        let token = &rest[..tok_end];
+        if is_url_like(token) {
+            out.push_str(&redact_url_token(token));
+        } else {
+            out.push_str(token);
+        }
+        rest = &rest[tok_end..];
+    }
+    out
+}
+
+/// True when a whitespace-delimited token looks like a URL that could
+/// carry credentials — `scheme://` or scheme-relative `//`, anywhere in
+/// the token (error prose often wraps a URL in `(…)` or trailing punct).
+fn is_url_like(token: &str) -> bool {
+    token.contains("//")
+}
+
+/// Redact a single URL-bearing token. The token may carry surrounding
+/// punctuation (`(https://…)`, `https://…,`), so peel a leading `(`/`[`
+/// run and a trailing run of `)`/`]`/`,`/`.`/`;` before redacting, then
+/// re-attach it — `redact_url` expects a bare URL.
+fn redact_url_token(token: &str) -> String {
+    let lead_end = token
+        .find(|c: char| c != '(' && c != '[' && c != '<')
+        .unwrap_or(token.len());
+    let (lead, after_lead) = token.split_at(lead_end);
+    let trail_start = after_lead
+        .rfind(|c: char| !matches!(c, ')' | ']' | '>' | ',' | '.' | ';' | '"' | '\''))
+        .map(|i| i + after_lead[i..].chars().next().map_or(1, char::len_utf8))
+        .unwrap_or(0);
+    let (core, trail) = after_lead.split_at(trail_start);
+    format!("{lead}{}{trail}", aube_util::url::redact_url(core))
 }
 
 /// Host of the engine's documentation site. Any URL token containing it is
@@ -328,6 +394,30 @@ fn is_word_boundary(c: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rewrite_redacts_credentials_in_registry_urls() {
+        // Backstop: even if an engine path forgets to scrub a URL, no
+        // userinfo or query token may reach nub's output. Covers the
+        // common prose shapes — bare URL, parenthesized (reqwest's
+        // ` for url (…)`), and a trailing-punctuation URL.
+        let msg = "HTTP error: error sending request \
+                   for url (https://alice:s3cr3t@registry.example.com/foo?token=abc123)";
+        let out = rewrite(msg);
+        assert!(!out.contains("s3cr3t"), "password leaked: {out}");
+        assert!(!out.contains("alice:"), "userinfo leaked: {out}");
+        assert!(!out.contains("abc123"), "token leaked: {out}");
+        assert!(
+            out.contains("registry.example.com"),
+            "redacted host must survive: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_leaves_credential_free_urls_intact() {
+        let url = "https://registry.npmjs.org/lodash";
+        assert_eq!(rewrite(url), url, "clean URL must pass through unchanged");
+    }
 
     #[test]
     fn rewrites_diagnostic_codes_from_the_real_constants() {

--- a/vendor/aube/crates/aube-registry/src/lib.rs
+++ b/vendor/aube/crates/aube-registry/src/lib.rs
@@ -725,7 +725,14 @@ impl<'de> Deserialize<'de> for FundingArrayEntry {
 
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum Error {
-    #[error("HTTP error: {0}")]
+    // reqwest's own Display appends ` for url (<url>)` rendered via
+    // `url::Url`'s Display, which serializes embedded `user:pass@`
+    // userinfo and `?token=`/`?_auth=` query auth UNREDACTED. Registry
+    // URLs legitimately carry such auth (npmrc/config), so the raw
+    // Display would leak credentials into surfaced errors and logs.
+    // Render through `redact_http_error` to scrub the URL while keeping
+    // the (redacted) host for debuggability.
+    #[error("HTTP error: {}", redact_http_error(.0))]
     Http(#[from] reqwest::Error),
     #[error("package not found: {0}")]
     #[diagnostic(code(ERR_AUBE_PACKAGE_NOT_FOUND))]
@@ -769,6 +776,30 @@ pub enum Error {
     InvalidName(String),
 }
 
+/// Render a [`reqwest::Error`] for display with any embedded registry
+/// URL credential-scrubbed.
+///
+/// reqwest's `Display` appends ` for url (<url>)` with the full URL —
+/// including `user:pass@` userinfo and `token`/`auth`/`api_key` query
+/// params — verbatim. When the error carries a URL we substitute its
+/// [`redact_url`](aube_util::url::redact_url) form for the raw rendering
+/// so credentials never reach an error message or log; the redacted host
+/// is preserved for debuggability. Errors with no attached URL render
+/// unchanged (reqwest's Display emits no URL in that case).
+fn redact_http_error(e: &reqwest::Error) -> String {
+    match e.url() {
+        Some(url) => {
+            let raw = url.as_str();
+            let safe = aube_util::url::redact_url(raw);
+            // reqwest interpolates the URL via `url::Url`'s Display,
+            // which equals `Url::as_str()`, so a plain substring swap on
+            // the rendered message reliably replaces the leaked form.
+            e.to_string().replace(raw, &safe)
+        }
+        None => e.to_string(),
+    }
+}
+
 impl Error {
     /// True when the error represents an upstream backpressure
     /// signal worth feeding into [`aube_util::adaptive::AdaptiveLimit::record_throttle`].
@@ -800,6 +831,47 @@ mod tests {
 
     fn parse(json: &str) -> VersionMetadata {
         serde_json::from_str(json).unwrap()
+    }
+
+    /// A registry URL carrying both `user:pass@` userinfo and a
+    /// `?token=` query param must never appear UNREDACTED in a surfaced
+    /// HTTP error — reqwest's raw Display leaks both, so `Error::Http`'s
+    /// rendering routes through `redact_http_error`. We build a real
+    /// `reqwest::Error` against an unreachable port (a connect failure
+    /// that reqwest tags with the request URL) and assert the rendered
+    /// message hides every credential while keeping the host.
+    #[tokio::test]
+    async fn http_error_display_redacts_url_credentials() {
+        let url = "https://alice:s3cr3t@127.0.0.1:1/foo?token=abc123";
+        let reqwest_err = reqwest::Client::new()
+            .get(url)
+            .send()
+            .await
+            .expect_err("connect to port 1 must fail");
+        assert!(
+            reqwest_err.url().is_some(),
+            "precondition: reqwest must tag the error with the request URL"
+        );
+
+        let err = Error::Http(reqwest_err);
+        let rendered = err.to_string();
+
+        assert!(
+            !rendered.contains("s3cr3t"),
+            "password leaked in error display: {rendered}"
+        );
+        assert!(
+            !rendered.contains("alice:"),
+            "userinfo leaked in error display: {rendered}"
+        );
+        assert!(
+            !rendered.contains("abc123"),
+            "token query param leaked in error display: {rendered}"
+        );
+        assert!(
+            rendered.contains("127.0.0.1"),
+            "redacted host should remain for debuggability: {rendered}"
+        );
     }
 
     #[test]

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -594,17 +594,28 @@ impl<'a> ResolveDriver<'a> {
         let pick_lowest =
             self.resolver.resolution_mode == ResolutionMode::TimeBased && task.is_root;
         // Apply the cutoff unless this package is on the
-        // minimumReleaseAge exclude list. The exclude list only
-        // suppresses the *minimumReleaseAge* leg, not the
-        // time-based-mode leg — but since we collapse both
-        // into the same `published_by` string at this point,
-        // we have to skip the cutoff entirely for excluded
-        // names. Acceptable: time-based mode and exclude
-        // lists aren't expected to coexist in the wild.
-        let cutoff_for_pkg = match self.resolver.minimum_release_age.as_ref() {
-            Some(mra) if mra.exclude.contains(&task.name) => None,
+        // minimumReleaseAge exclude list. A *name-only* exclude entry
+        // (`lodash`) suppresses the cutoff for the whole package — and
+        // because we collapse the minimumReleaseAge and time-based-mode
+        // legs into the same `published_by` string here, that also drops
+        // the time-based leg (acceptable: the two aren't expected to
+        // coexist in the wild). A *version-pinned* entry
+        // (`axios@0.18.1 || 0.21.1`) can't be decided before the version
+        // is picked, so the cutoff stays active and the per-version
+        // exemption is threaded into `pick_version` via `age_exclude`
+        // below, where it bypasses the gate only for the listed versions.
+        let mra = self.resolver.minimum_release_age.as_ref();
+        let cutoff_for_pkg = match mra {
+            Some(m) if m.excludes_all_versions(&task.name) => None,
             _ => self.published_by.as_deref(),
         };
+        // Only pass the rules to the pick when this package actually has
+        // a version-pinned rule, so the common (no-exclude) path skips
+        // the per-candidate parse+match entirely.
+        let age_exclude = mra.and_then(|m| {
+            m.has_versioned_exclude(&task.name)
+                .then_some((&m.exclude, task.name.as_str()))
+        });
         // Strict semantics in two cases:
         //   - `minimumReleaseAgeStrict=true` (the user opted in
         //     to hard failures), or
@@ -630,6 +641,7 @@ impl<'a> ResolveDriver<'a> {
                 pick_lowest,
                 cutoff_for_pkg,
                 strict,
+                age_exclude,
             );
             match pick {
                 // A primer-seeded pick that satisfies the range still

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -1,3 +1,4 @@
+use crate::trust::TrustExcludeRules;
 use aube_registry::Packument;
 
 /// Outcome of [`pick_version`]. Distinguishes "nothing in the range
@@ -41,6 +42,15 @@ impl<'a> PickResult<'a> {
 /// cutoff. The lowest-satisfying fallback is pnpm's deliberate choice
 /// — the oldest version in the range is least likely to be the freshly
 /// pushed compromise that triggered the filter in the first place.
+///
+/// `age_exclude` carries the `minimumReleaseAgeExclude` rules plus the
+/// package name. A candidate version matched by a (version-pinned)
+/// exclude rule bypasses the cutoff individually — this is what makes a
+/// `name@v1 || v2` entry exempt only those exact versions. Name-only
+/// rules are handled by the caller (which passes `cutoff = None` for the
+/// whole package), so by the time they reach here `age_exclude` only
+/// ever contributes per-version exemptions; passing it is harmless when
+/// no rule matches.
 #[inline]
 pub(crate) fn pick_version<'a>(
     packument: &'a Packument,
@@ -49,6 +59,7 @@ pub(crate) fn pick_version<'a>(
     pick_lowest: bool,
     cutoff: Option<&str>,
     strict: bool,
+    age_exclude: Option<(&TrustExcludeRules, &str)>,
 ) -> PickResult<'a> {
     // Handle dist-tag references. If the requested range is a tag
     // name and the packument has that tag, use the tagged version
@@ -94,6 +105,17 @@ pub(crate) fn pick_version<'a>(
 
     let passes_cutoff = |ver: &str| -> bool {
         let Some(c) = cutoff else { return true };
+        // A version-pinned `minimumReleaseAgeExclude` rule exempts this
+        // exact version from the gate (`name@v1 || v2`). Parse failures
+        // fall through: a version that can't be parsed can only be
+        // matched by a name-only rule, which the caller already handled
+        // by disabling the cutoff for the whole package.
+        if let Some((rules, name)) = age_exclude
+            && let Ok(v) = node_semver::Version::parse(ver)
+            && rules.matches(name, &v)
+        {
+            return true;
+        }
         match packument.time.get(ver) {
             Some(t) => t.as_str() <= c,
             // Missing time: keep it — we'd rather risk a slightly newer

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -678,7 +678,7 @@ fn test_pick_version_highest_match() {
     // dist-tag preference doesn't apply and we fall through to the
     // strictly-highest version inside the range — 1.2.0.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0", "2.0.0"], "2.0.0");
-    let result = pick_version(&packument, "^1.0.0", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "^1.0.0", None, false, None, false, None).unwrap();
     assert_eq!(result.version, "1.2.0");
 }
 
@@ -695,7 +695,7 @@ fn test_pick_version_prefers_dist_tag_latest_when_in_range() {
     // -> aube add foo@^100.0.0` flow, which expects the lockfile to
     // pin 100.0.0 even though 100.1.0 is available.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0"], "1.0.0");
-    let result = pick_version(&packument, "^1.0.0", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "^1.0.0", None, false, None, false, None).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -705,7 +705,7 @@ fn test_pick_version_falls_through_when_latest_outside_range() {
     // preference is a no-op; the strictly-highest matching version
     // (1.1.0) wins.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "2.0.0"], "2.0.0");
-    let result = pick_version(&packument, "^1.0.0", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "^1.0.0", None, false, None, false, None).unwrap();
     assert_eq!(result.version, "1.1.0");
 }
 
@@ -715,21 +715,21 @@ fn test_pick_version_lowest_ignores_dist_tag_preference() {
     // range, not whatever the publisher tagged latest. Confirm the
     // dist-tag preference is suppressed when pick_lowest is set.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0"], "1.2.0");
-    let result = pick_version(&packument, "^1.0.0", None, true, None, false).unwrap();
+    let result = pick_version(&packument, "^1.0.0", None, true, None, false, None).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
 #[test]
 fn test_pick_version_exact() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
-    let result = pick_version(&packument, "1.0.0", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "1.0.0", None, false, None, false, None).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
 #[test]
 fn test_pick_version_no_match() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
-    let result = pick_version(&packument, "^2.0.0", None, false, None, false);
+    let result = pick_version(&packument, "^2.0.0", None, false, None, false, None);
     assert!(matches!(result, PickResult::NoMatch));
 }
 
@@ -746,19 +746,28 @@ fn test_pick_version_strict_distinguishes_age_gate_from_no_match() {
         .time
         .insert("1.1.0".into(), "2024-06-01T00:00:00.000Z".into());
     let cutoff = "2020-01-01T00:00:00.000Z";
-    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), true);
+    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), true, None);
     assert!(matches!(result, PickResult::AgeGated));
 
     // No version satisfies the range at all → still NoMatch even
     // in strict mode.
-    let result = pick_version(&packument, "^9.0.0", None, false, Some(cutoff), true);
+    let result = pick_version(&packument, "^9.0.0", None, false, Some(cutoff), true, None);
     assert!(matches!(result, PickResult::NoMatch));
 }
 
 #[test]
 fn test_pick_version_prefers_locked() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0"], "1.2.0");
-    let result = pick_version(&packument, "^1.0.0", Some("1.1.0"), false, None, false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        Some("1.1.0"),
+        false,
+        None,
+        false,
+        None,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.1.0");
 }
 
@@ -816,21 +825,30 @@ fn classify_regime_unparseable_pick_is_current() {
 fn test_pick_version_locked_out_of_range() {
     let packument = make_packument("foo", &["1.0.0", "2.0.0"], "2.0.0");
     // Locked version doesn't satisfy range, should pick highest match
-    let result = pick_version(&packument, "^2.0.0", Some("1.0.0"), false, None, false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^2.0.0",
+        Some("1.0.0"),
+        false,
+        None,
+        false,
+        None,
+    )
+    .unwrap();
     assert_eq!(result.version, "2.0.0");
 }
 
 #[test]
 fn test_pick_version_dist_tag() {
     let packument = make_packument("foo", &["1.0.0", "2.0.0-beta.1"], "1.0.0");
-    let result = pick_version(&packument, "latest", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "latest", None, false, None, false, None).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
 #[test]
 fn test_pick_version_lowest_picks_smallest_satisfying() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0", "2.0.0"], "2.0.0");
-    let result = pick_version(&packument, "^1.0.0", None, true, None, false).unwrap();
+    let result = pick_version(&packument, "^1.0.0", None, true, None, false, None).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -848,7 +866,8 @@ fn test_pick_version_cutoff_filters_future_versions() {
         .insert("1.2.0".into(), "2023-01-01T00:00:00.000Z".into());
     // Highest pick, but cutoff forbids 1.2.0 → fall back to 1.1.0.
     let cutoff = "2022-06-01T00:00:00.000Z";
-    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), false).unwrap();
+    let result =
+        pick_version(&packument, "^1.0.0", None, false, Some(cutoff), false, None).unwrap();
     assert_eq!(result.version, "1.1.0");
 }
 
@@ -868,7 +887,8 @@ fn test_pick_version_lenient_falls_back_to_lowest_when_cutoff_excludes_all() {
         .time
         .insert("1.2.0".into(), "2025-01-01T00:00:00.000Z".into());
     let cutoff = "2020-01-01T00:00:00.000Z";
-    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), false).unwrap();
+    let result =
+        pick_version(&packument, "^1.0.0", None, false, Some(cutoff), false, None).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -882,8 +902,97 @@ fn test_pick_version_strict_returns_age_gated_when_cutoff_excludes_all() {
         .time
         .insert("1.1.0".into(), "2024-06-01T00:00:00.000Z".into());
     let cutoff = "2020-01-01T00:00:00.000Z";
-    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), true);
+    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), true, None);
     assert!(matches!(result, PickResult::AgeGated));
+}
+
+#[test]
+fn test_pick_version_minimum_release_age_exclude_version_union() {
+    // pnpm supports `name@v1 || v2` in minimumReleaseAgeExclude: only
+    // the listed exact versions skip the age gate, not the whole
+    // package. Regression for the bug where a version-pinned entry was
+    // stored as a literal string and compared against the bare package
+    // name, so it never matched and was silently dropped.
+    let mut packument = make_packument("axios", &["0.18.1", "0.21.1", "1.0.0"], "1.0.0");
+    packument
+        .time
+        .insert("0.18.1".into(), "2024-01-01T00:00:00.000Z".into());
+    packument
+        .time
+        .insert("0.21.1".into(), "2024-06-01T00:00:00.000Z".into());
+    packument
+        .time
+        .insert("1.0.0".into(), "2025-01-01T00:00:00.000Z".into());
+    // Cutoff is BEFORE every version, so absent an exclude the strict
+    // gate rejects them all.
+    let cutoff = "2020-01-01T00:00:00.000Z";
+    let (rules, errs) = crate::trust::TrustExcludeRules::parse_lossy(["axios@0.18.1 || 0.21.1"]);
+    assert!(errs.is_empty(), "union pattern parses cleanly");
+    let exclude = Some((&rules, "axios"));
+
+    // 0.21.1 is excluded → it clears the gate and, being the highest
+    // excluded version, is picked even in strict mode.
+    let result = pick_version(
+        &packument,
+        ">=0.18.0",
+        None,
+        false,
+        Some(cutoff),
+        true,
+        exclude,
+    )
+    .unwrap();
+    assert_eq!(
+        result.version, "0.21.1",
+        "an excluded version bypasses the age gate"
+    );
+
+    // 1.0.0 is NOT on the exclude list, so restricting the range to it
+    // alone leaves every candidate age-gated → strict mode rejects.
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        Some(cutoff),
+        true,
+        exclude,
+    );
+    assert!(
+        matches!(result, PickResult::AgeGated),
+        "a version not on the exclude list stays age-gated"
+    );
+}
+
+#[test]
+fn test_pick_version_minimum_release_age_exclude_name_only() {
+    // A name-only exclude entry (`lodash`) exempts every version of the
+    // package — the original behavior. (In the resolver the whole-package
+    // exemption is applied by disabling the cutoff upstream; here we
+    // verify the matcher itself treats every version as excluded.)
+    let mut packument = make_packument("lodash", &["4.17.20", "4.17.21"], "4.17.21");
+    packument
+        .time
+        .insert("4.17.20".into(), "2024-01-01T00:00:00.000Z".into());
+    packument
+        .time
+        .insert("4.17.21".into(), "2024-06-01T00:00:00.000Z".into());
+    let cutoff = "2020-01-01T00:00:00.000Z";
+    let (rules, _) = crate::trust::TrustExcludeRules::parse_lossy(["lodash"]);
+    assert!(rules.matches_name_only("lodash"));
+    let exclude = Some((&rules, "lodash"));
+    // Highest pick clears the gate because the name-only rule matches it.
+    let result = pick_version(
+        &packument,
+        "^4.0.0",
+        None,
+        false,
+        Some(cutoff),
+        true,
+        exclude,
+    )
+    .unwrap();
+    assert_eq!(result.version, "4.17.21");
 }
 
 #[test]
@@ -1801,7 +1910,8 @@ fn test_pick_version_cutoff_allows_missing_time_entries() {
     // remove every candidate, or the resolver can never make
     // progress on abbreviated-packument registries.
     let cutoff = "2000-01-01T00:00:00.000Z";
-    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), false).unwrap();
+    let result =
+        pick_version(&packument, "^1.0.0", None, false, Some(cutoff), false, None).unwrap();
     assert_eq!(result.version, "1.1.0");
 }
 
@@ -1815,7 +1925,7 @@ fn test_pick_version_with_deps() {
         .dependencies
         .insert("bar".to_string(), "^2.0.0".to_string());
 
-    let result = pick_version(&packument, "^1.0.0", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "^1.0.0", None, false, None, false, None).unwrap();
     assert_eq!(result.dependencies.get("bar").unwrap(), "^2.0.0");
 }
 
@@ -4532,7 +4642,7 @@ fn pick_version_exact_pin_not_hijacked_by_dist_tag() {
     packument
         .dist_tags
         .insert("1.0.0".to_string(), "1.5.0".to_string());
-    let result = pick_version(&packument, "1.0.0", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "1.0.0", None, false, None, false, None).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -4541,7 +4651,7 @@ fn assert_protocol_hijack_blocked(spec: &str) {
     packument
         .dist_tags
         .insert(spec.to_string(), "1.0.0".to_string());
-    let result = pick_version(&packument, spec, None, false, None, false);
+    let result = pick_version(&packument, spec, None, false, None, false, None);
     assert!(
         matches!(result, super::semver_util::PickResult::NoMatch),
         "protocol-prefixed range {spec:?} reached dist-tag fallback",
@@ -4586,10 +4696,10 @@ fn colonless_dist_tag_still_resolves_after_scheme_guard() {
     packument
         .dist_tags
         .insert("nightly".to_string(), "1.0.0".to_string());
-    let result = pick_version(&packument, "nightly", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "nightly", None, false, None, false, None).unwrap();
     assert_eq!(result.version, "1.0.0");
 
-    let result = pick_version(&packument, "latest", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "latest", None, false, None, false, None).unwrap();
     assert_eq!(result.version, "2.0.0");
 }
 

--- a/vendor/aube/crates/aube-resolver/src/trust.rs
+++ b/vendor/aube/crates/aube-resolver/src/trust.rs
@@ -312,6 +312,23 @@ pub enum TrustExcludeParseError {
 }
 
 impl TrustExcludeRules {
+    /// An exclude set with no rules. Used by callers (e.g.
+    /// `minimumReleaseAgeExclude`) that must NOT inherit the
+    /// trust-policy default exclusions baked into [`Self::default`].
+    pub fn empty() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    /// Number of parsed rules. For diagnostics/logging only.
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+
+    /// True when there are no rules.
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
     fn from_name_excludes(names: &[&str]) -> Self {
         Self {
             rules: names
@@ -372,7 +389,7 @@ impl TrustExcludeRules {
         (Self { rules }, errors)
     }
 
-    fn matches(&self, name: &str, version: &node_semver::Version) -> bool {
+    pub(crate) fn matches(&self, name: &str, version: &node_semver::Version) -> bool {
         for rule in &self.rules {
             if !rule.name_matcher.matches(name) {
                 continue;
@@ -393,10 +410,21 @@ impl TrustExcludeRules {
     /// no-version rule can match in that case (pnpm behavior:
     /// `evaluateVersionPolicy` returns `true` for name-only rules
     /// before the version array branch is taken).
-    fn matches_name_only(&self, name: &str) -> bool {
+    pub(crate) fn matches_name_only(&self, name: &str) -> bool {
         self.rules
             .iter()
             .any(|r| r.exact_versions.is_none() && r.name_matcher.matches(name))
+    }
+
+    /// True when `name` is matched by at least one *version-pinned* rule
+    /// (a rule carrying an exact-version union). Callers use this to know
+    /// the cutoff must be evaluated per-candidate version rather than
+    /// skipped wholesale — a name-only match is handled by
+    /// [`Self::matches_name_only`] instead.
+    pub(crate) fn has_versioned_match(&self, name: &str) -> bool {
+        self.rules
+            .iter()
+            .any(|r| r.exact_versions.is_some() && r.name_matcher.matches(name))
     }
 }
 

--- a/vendor/aube/crates/aube-resolver/src/types.rs
+++ b/vendor/aube/crates/aube-resolver/src/types.rs
@@ -1,5 +1,5 @@
 use aube_lockfile::LocalSource;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -25,21 +25,43 @@ pub trait ReadPackageHook: Send {
 }
 
 /// Supply-chain mitigation: forbid versions younger than `min_age` for
-/// every package whose name isn't in `exclude`. Mirrors pnpm's
+/// every package not matched by an `exclude` rule. Mirrors pnpm's
 /// `minimumReleaseAge` / `minimumReleaseAgeExclude` /
 /// `minimumReleaseAgeStrict` triplet. Constructed by the install
 /// command, threaded into [`Resolver::with_minimum_release_age`].
-#[derive(Debug, Clone, Default)]
+///
+/// `exclude` reuses the same [`TrustExcludeRules`] grammar as
+/// `trustPolicyExclude`, so a `minimumReleaseAgeExclude` entry may be
+/// name-only (`lodash` — every version of the package skips the age
+/// gate, the original behavior), or version-pinned with a `||` union
+/// (`axios@0.18.1 || 0.21.1` — only those exact versions skip the
+/// gate), matching pnpm's documented `name@v1 || v2` support.
+#[derive(Debug, Clone)]
 pub struct MinimumReleaseAge {
     /// Minutes a version must have aged in the registry. `0` disables.
     pub minutes: u64,
-    /// Package names skipped by the cutoff filter entirely.
-    pub exclude: HashSet<String>,
+    /// Packages/versions skipped by the cutoff filter. Name-only rules
+    /// exempt the whole package; version-pinned rules exempt only the
+    /// listed exact versions.
+    pub exclude: crate::trust::TrustExcludeRules,
     /// When true, fail the install if no version satisfies the range
     /// without violating the cutoff. When false (the pnpm default), the
     /// resolver falls back to the lowest satisfying version, ignoring
     /// the cutoff for that pick only.
     pub strict: bool,
+}
+
+impl Default for MinimumReleaseAge {
+    fn default() -> Self {
+        Self {
+            minutes: 0,
+            // Empty — unlike `trustPolicyExclude`, the release-age gate
+            // ships no default exclusions, so `TrustExcludeRules::default()`
+            // (which seeds the trust-policy defaults) would be wrong here.
+            exclude: crate::trust::TrustExcludeRules::empty(),
+            strict: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -98,6 +120,32 @@ impl MinimumReleaseAge {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
         let cutoff_secs = now.saturating_sub(self.minutes * 60);
         Some(format_iso8601_utc(cutoff_secs))
+    }
+
+    /// True when a *name-only* exclude rule matches `name` — the whole
+    /// package is exempt from the age gate regardless of which version is
+    /// picked (the original `minimumReleaseAgeExclude` behavior, preserved
+    /// exactly). Version-pinned rules are evaluated per-candidate during
+    /// the pick instead, so they do NOT trip this.
+    pub fn excludes_all_versions(&self, name: &str) -> bool {
+        self.exclude.matches_name_only(name)
+    }
+
+    /// True when the picked `version` of `name` is exempt from the age
+    /// gate by either a name-only rule or a version-pinned rule listing
+    /// this exact version. This is the per-candidate predicate used inside
+    /// the pick so a `name@v1 || v2` entry exempts only those versions.
+    pub fn excludes_version(&self, name: &str, version: &node_semver::Version) -> bool {
+        self.exclude.matches(name, version)
+    }
+
+    /// True when `name` has at least one version-pinned exclude rule, so
+    /// the cutoff must be evaluated per-candidate rather than skipped for
+    /// the whole package. `false` means the package's exclude rules (if
+    /// any) are all name-only and were already handled by
+    /// [`Self::excludes_all_versions`].
+    pub fn has_versioned_exclude(&self, name: &str) -> bool {
+        self.exclude.has_versioned_match(name)
     }
 }
 

--- a/vendor/aube/crates/aube-resolver/src/types.rs
+++ b/vendor/aube/crates/aube-resolver/src/types.rs
@@ -131,14 +131,6 @@ impl MinimumReleaseAge {
         self.exclude.matches_name_only(name)
     }
 
-    /// True when the picked `version` of `name` is exempt from the age
-    /// gate by either a name-only rule or a version-pinned rule listing
-    /// this exact version. This is the per-candidate predicate used inside
-    /// the pick so a `name@v1 || v2` entry exempts only those versions.
-    pub fn excludes_version(&self, name: &str, version: &node_semver::Version) -> bool {
-        self.exclude.matches(name, version)
-    }
-
     /// True when `name` has at least one version-pinned exclude rule, so
     /// the cutoff must be evaluated per-candidate rather than skipped for
     /// the whole package. `false` means the package's exclude rules (if

--- a/vendor/aube/crates/aube/src/commands/install/default_trust.rs
+++ b/vendor/aube/crates/aube/src/commands/install/default_trust.rs
@@ -123,8 +123,7 @@ impl DefaultTrustFloor {
             mra_cli_minutes.unwrap_or_else(|| aube_settings::resolved::minimum_release_age(ctx));
         let age_cutoff = aube_resolver::MinimumReleaseAge {
             minutes,
-            exclude: Default::default(),
-            strict: false,
+            ..Default::default()
         }
         .cutoff();
         Self {
@@ -293,8 +292,7 @@ mod tests {
             lockfile_vetted: false,
             age_cutoff: aube_resolver::MinimumReleaseAge {
                 minutes: 1440,
-                exclude: Default::default(),
-                strict: false,
+                ..Default::default()
             }
             .cutoff(),
         }
@@ -334,8 +332,7 @@ mod tests {
     ) -> BTreeMap<String, String> {
         let published = aube_resolver::MinimumReleaseAge {
             minutes,
-            exclude: Default::default(),
-            strict: false,
+            ..Default::default()
         }
         .cutoff()
         .expect("non-zero minutes always produce a cutoff");

--- a/vendor/aube/crates/aube/src/commands/install/fetch.rs
+++ b/vendor/aube/crates/aube/src/commands/install/fetch.rs
@@ -351,10 +351,12 @@ pub(super) async fn import_local_source(
                     local.specifier()
                 )
             })?;
-            let bytes = client
-                .fetch_tarball_bytes(&t.url)
-                .await
-                .map_err(|e| miette!("failed to fetch {}: {e}{chain}", t.url))?;
+            let bytes = client.fetch_tarball_bytes(&t.url).await.map_err(|e| {
+                miette!(
+                    "failed to fetch {}: {e}{chain}",
+                    aube_util::url::redact_url(&t.url)
+                )
+            })?;
             if t.integrity.is_empty() {
                 tracing::warn!(
                     code = aube_codes::warnings::WARN_AUBE_MISSING_INTEGRITY,

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -84,11 +84,23 @@ fn resolve_minimum_release_age(
     if minutes == 0 {
         return None;
     }
-    let exclude: std::collections::HashSet<String> =
-        aube_settings::resolved::minimum_release_age_exclude(ctx)
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
+    // Parse `minimumReleaseAgeExclude` with the same grammar as
+    // `trustPolicyExclude` so a version-pinned or `||`-union entry
+    // (`axios@0.18.1 || 0.21.1`) actually exempts those versions, not
+    // just name-only entries. parse_lossy keeps every well-formed rule
+    // and reports malformed ones individually — a strict batch parse
+    // would turn one typo into a silently-empty exclude list, a security
+    // regression. Name-only entries behave exactly as before.
+    let (exclude, exclude_parse_errors) = aube_resolver::TrustExcludeRules::parse_lossy(
+        aube_settings::resolved::minimum_release_age_exclude(ctx).unwrap_or_default(),
+    );
+    for err in exclude_parse_errors {
+        tracing::warn!(
+            code = aube_codes::warnings::WARN_AUBE_INVALID_TRUST_POLICY,
+            error = %err,
+            "ignoring malformed minimumReleaseAgeExclude entry"
+        );
+    }
     // `paranoid=true` forces the gate to be hard, not advisory.
     let strict = aube_settings::resolved::minimum_release_age_strict(ctx)
         || aube_settings::resolved::paranoid(ctx);


### PR DESCRIPTION
Audit of pnpm v11.9.0's 17 changelog items against nub's package manager (the vendored `aube` engine + `crates/nub-cli/src/pm_engine`). For each item: does nub inherit the bug, and is the enhancement worth adopting? Two inherited defects are fixed here; the rest are N/A or maintainer-gated (surfaced below, not landed).

## Per-item disposition

| # | pnpm v11.9.0 item | Disposition | Notes |
|---|-------------------|-------------|-------|
| 1 | Tarball integrity compute for checksumless registries | Recommend-only (C) | Round-trip already verbatim; hard-fail already matches. Computing integrity for checksumless registries changes emitted lockfile content + `strict-store-integrity` semantics — maintainer call. |
| 2 | `sbom --exclude-peers` | N/A | `sbom` is stubbed in nub. |
| 3 | `audit --fix` combined `minimumReleaseAgeExclude` | N/A | nub `audit --fix` writes overrides only; no writer for that setting yet. |
| 4 | Non-deterministic peer resolution | N/A | aube resolution is structurally deterministic (single-threaded FIFO BFS, all output `BTreeMap`s, sorted fallback). |
| 5 | Windows dlx EBUSY / MAX_PATH | N/A (design-note) | dlx uses an ephemeral tempdir; no persistent cache yet. Routed to the dlx-cache design. |
| 6 | Hang on non-retryable network error | N/A | aube's retry loop is bounded and always terminates; no hang. |
| 7 | Audit perf via Tarjan SCC | N/A (design-note) | No vuln-tree prune in nub's audit yet. Routed to the audit design. |
| 8 | Optional-dep update rewriting unrelated specs | N/A | Manifest write happens after a successful resolve, on a clone; each key rewrites from its own resolution. |
| 9 | GVS enable replaces stale symlinks | N/A (minor gap) | GVS implemented; stale-hoisted-symlink replacement on toggle absent. Low risk; routed to GVS-correctness. |
| 10 | `install --ignore-workspace` clobbers `allowBuilds` | N/A | No `--ignore-workspace` flag in nub; all config writes are read-modify-write (structurally immune). |
| **11** | **`minimumReleaseAgeExclude` multiple exact-version entries** | **Fixed** | Was name-only; version-pinned and `\|\|`-union entries were silently dropped. |
| 12 | Metadata cache registry-in-key | N/A | Cache key already includes the registry (CVE-2018-7167 class already handled). |
| 13 | `patch` dropped name for git single-version | N/A | Patch key is unconditionally `name@version`. |
| 14 | pnpr resolver endpoints | N/A | pnpm-internal service; no nub equivalent. |
| 15 | sbom CycloneDX issue-tracker refs | N/A | sbom stubbed. |
| 16 | `@pnpm/resolving.tarball-url` | N/A | pnpm-internal JS package; no nub equivalent. |
| **17** | **Registry-fetch failure leaks credentials** | **Fixed** | Error display surfaced the full credentialed registry URL. |

## What landed

### #17 — Redact credentials from registry HTTP errors (security)
`aube-registry`'s `Error::Http` rendered reqwest's `Display`, which appends the full request URL via `url::Url`'s `Display` — including `user:pass@` userinfo and `?token=`/`_auth` query auth, unredacted. Command and install mappers format that into user-facing reports. aube already had `aube_util::url::redact_url` (used on the tarball path) but not on the metadata / error path.

- `aube-registry/src/lib.rs`: `Error::Http` now renders through `redact_http_error`, substituting `redact_url(e.url())` for the raw URL (redacted host preserved for debuggability).
- `aube/src/commands/install/fetch.rs`: wrapped a directly-interpolated tarball URL in `redact_url`.
- `crates/nub-cli/src/pm_engine/present.rs`: defense-in-depth `redact_credentials` pass at nub's output choke point, scrubbing any URL-like token through `redact_url` so a future un-redacted engine path cannot leak through nub.
- Tests: engine-level (builds a real connect error to `https://alice:s3cr3t@.../foo?token=abc123`, asserts the rendered text omits `s3cr3t`/`alice:`/`abc123` but keeps the host) + two `present.rs` unit tests.

### #11 — Multi-version `minimumReleaseAgeExclude` entries
`minimumReleaseAgeExclude` was name-only: a version-pinned entry like `axios@0.21.1` was stored as a literal string and compared against the bare package name, so it never matched and the age gate still fired. A rich union parser (`TrustExcludeRules`, supporting `name@v1 || v2`) already existed but was only wired to `trustPolicyExclude`.

- Unified `minimumReleaseAgeExclude` onto `TrustExcludeRules` (`aube-resolver/src/types.rs`, `trust.rs`, `settings.rs` via `parse_lossy` so a malformed entry doesn't drop the whole list).
- Per-version exclusion threaded through `pick_version`/`passes_cutoff` (`semver_util.rs`, `resolve/driver.rs`): name-only rules skip the gate for the whole package (original behavior preserved exactly); version-pinned rules exempt only the listed candidate versions.
- Tests: `name@v1 || v2` excludes both listed versions but not a third; name-only still excludes all versions.

Both fixes are default-preserving for standalone aube and cleanly upstreamable to `jdx/aube`.

## Verification
- `cargo clippy --all-targets --all-features -- -D warnings` (nub workspace) — clean
- `cargo fmt --check` — clean
- `cargo test -p aube-resolver` — 246 passed (2 new)
- `cargo test -p aube-registry` — 270 passed (1 new)
- HEAD compiles (`cargo build -p nub-cli`)
- A fresh-context adversarial review of the full diff returned clean (no blockers).

## Maintainer-gated recommendations (NOT landed — your call)
- **#1 — checksumless-registry integrity compute.** aube has the primitive (`aube_store::sha512_integrity`) and uses it on git/remote/local paths, but not for checksumless registry packages — they get no `integrity` in the lockfile. Adopting pnpm's behavior (compute from the downloaded tarball) would change emitted-lockfile content and interact with `strict-store-integrity`, so it's a behavior/default decision. Low incidence.
- **#6 (optional polish).** aube terminates on cert errors (no hang) but retries them twice first; classifying deterministic TLS errors as non-retryable to fail fast is minor polish.
- **Engine-source hardening for publish/login/unpublish error sites.** Those raw-URL error paths are covered by the new `present.rs` backstop at nub's boundary, but redacting them at the aube source too is a clean upstream win — separate scoped follow-up.

## Upstreamable to jdx/aube
The `aube-registry` redaction hunk (#17) and the entire `aube-resolver`/`aube` portion of #11 are default-preserving for standalone aube — both upstreamable as-is via `format-patch --relative=vendor/aube`. The `present.rs` backstop is nub-only.
