### PR TITLE
docker: official nub images (node:26 slim + alpine) + publish workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,136 @@
+name: Docker image
+
+# Builds the official nub Docker images (Debian slim + Alpine), installing the
+# released @nubjs/nub npm package onto an official node:* base.
+#
+#   - On PR / push to main: build BOTH variants and run the in-image smoke test.
+#     Never pushes.
+#   - On a release tag (v*): build, smoke-test, then push to the configured
+#     registry.
+#
+# REGISTRY WIRING IS A MAINTAINER-OWNED TODO — see the `vars`/`secrets` below.
+# The registry choice (Docker Hub `nubjs/nub` vs GHCR `ghcr.io/nubjs/nub` vs both)
+# and the image name are deliberately NOT hardcoded. Set them at merge:
+#
+#   Repo variables (Settings → Secrets and variables → Actions → Variables):
+#     DOCKER_IMAGE   e.g. "nubjs/nub" (Docker Hub) or "ghcr.io/nubjs/nub" (GHCR)
+#     DOCKER_REGISTRY (optional) e.g. "ghcr.io" — omit for Docker Hub
+#   Secrets (only needed for the push leg):
+#     DOCKERHUB_TOKEN  (Docker Hub) — paired with the DOCKERHUB_USERNAME variable
+#     (GHCR uses the built-in GITHUB_TOKEN; no secret needed — see the login step.)
+#
+# Until DOCKER_IMAGE is set, the push leg is skipped (the `if` guards it), so this
+# workflow is safe to merge as build-and-smoke-only.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docker/**"
+      - ".github/workflows/docker.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docker/**"
+      - ".github/workflows/docker.yml"
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build + smoke (${{ matrix.variant }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: slim
+            dockerfile: docker/Dockerfile.slim
+            node_base: 26-slim
+          - variant: alpine
+            dockerfile: docker/Dockerfile.alpine
+            node_base: 26-alpine
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # The nub version to bake in. On a release tag, install exactly that version;
+      # otherwise install the latest published @nubjs/nub.
+      - name: Resolve nub version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Build to a local image (load: true) so the smoke step can run it. Push is a
+      # separate step gated on release + DOCKER_IMAGE being configured.
+      - name: Build ${{ matrix.variant }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          load: true
+          tags: nub-local:${{ matrix.variant }}
+          build-args: |
+            NODE_BASE=${{ matrix.node_base }}
+            NUB_VERSION=${{ steps.ver.outputs.value }}
+          cache-from: type=gha,scope=docker-${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.variant }}
+
+      - name: Smoke test ${{ matrix.variant }} image
+        run: docker run --rm nub-local:${{ matrix.variant }} /usr/local/bin/smoke.sh
+
+      - name: Report image size
+        run: docker image inspect nub-local:${{ matrix.variant }} --format '${{ matrix.variant }} size: {{.Size}} bytes'
+
+      # ── PUBLISH (release tags only, and only once a registry is configured) ───
+      # MAINTAINER TODO: set the DOCKER_IMAGE repo variable to enable this. With it
+      # unset, this step no-ops on every event — the workflow stays build+smoke only.
+      - name: Log in to registry
+        if: github.event_name == 'release' && vars.DOCKER_IMAGE != ''
+        uses: docker/login-action@v3
+        with:
+          # For GHCR: registry: ghcr.io, username: ${{ github.actor }},
+          #   password: ${{ secrets.GITHUB_TOKEN }} (no extra secret needed).
+          # For Docker Hub: omit registry, set DOCKERHUB_USERNAME var +
+          #   DOCKERHUB_TOKEN secret.
+          registry: ${{ vars.DOCKER_REGISTRY }}
+          username: ${{ vars.DOCKERHUB_USERNAME || github.actor }}
+          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.GITHUB_TOKEN }}
+
+      # The slim variant carries the unsuffixed tags (`latest`, `<version>`);
+      # alpine is suffixed (`alpine`, `<version>-alpine`). Mirrors oven/bun.
+      - name: Compute push tags
+        if: github.event_name == 'release' && vars.DOCKER_IMAGE != ''
+        id: tags
+        run: |
+          IMG="${{ vars.DOCKER_IMAGE }}"
+          VER="${{ steps.ver.outputs.value }}"
+          if [ "${{ matrix.variant }}" = "slim" ]; then
+            echo "list=${IMG}:latest,${IMG}:${VER},${IMG}:slim,${IMG}:${VER}-slim" >> "$GITHUB_OUTPUT"
+          else
+            echo "list=${IMG}:alpine,${IMG}:${VER}-alpine" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build + push ${{ matrix.variant }}
+        if: github.event_name == 'release' && vars.DOCKER_IMAGE != ''
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.tags.outputs.list }}
+          build-args: |
+            NODE_BASE=${{ matrix.node_base }}
+            NUB_VERSION=${{ steps.ver.outputs.value }}
+          cache-from: type=gha,scope=docker-${{ matrix.variant }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,12 +1,12 @@
 name: Docker image
 
 # Builds the official nub Docker images (Debian slim + Alpine), installing the
-# released @nubjs/nub npm package onto an official node:* base.
+# released @nubjs/nub npm package onto an official, digest-pinned node:* base.
 #
-#   - On PR / push to main: build BOTH variants and run the in-image smoke test.
-#     Never pushes.
-#   - On a release tag (v*): build, smoke-test, then push to the configured
-#     registry.
+#   - On PR / push to main: build BOTH variants for the runner arch and run the
+#     in-image smoke test. Never pushes.
+#   - On a release tag (v*): build multi-arch (linux/amd64 + linux/arm64),
+#     smoke-test, then push to the configured registry with provenance + SBOM.
 #
 # REGISTRY WIRING IS A MAINTAINER-OWNED TODO — see the `vars`/`secrets` below.
 # The registry choice (Docker Hub `nubjs/nub` vs GHCR `ghcr.io/nubjs/nub` vs both)
@@ -15,12 +15,14 @@ name: Docker image
 #   Repo variables (Settings → Secrets and variables → Actions → Variables):
 #     DOCKER_IMAGE   e.g. "nubjs/nub" (Docker Hub) or "ghcr.io/nubjs/nub" (GHCR)
 #     DOCKER_REGISTRY (optional) e.g. "ghcr.io" — omit for Docker Hub
+#     DOCKERHUB_USERNAME (Docker Hub only) e.g. "nubjs"
 #   Secrets (only needed for the push leg):
 #     DOCKERHUB_TOKEN  (Docker Hub) — paired with the DOCKERHUB_USERNAME variable
-#     (GHCR uses the built-in GITHUB_TOKEN; no secret needed — see the login step.)
+#     (GHCR uses the built-in GITHUB_TOKEN; no extra secret needed.)
 #
 # Until DOCKER_IMAGE is set, the push leg is skipped (the `if` guards it), so this
-# workflow is safe to merge as build-and-smoke-only.
+# workflow is safe to merge as build-and-smoke-only. Full publish runbook: the PR
+# body and docker/PUBLISHING.md.
 
 on:
   push:
@@ -51,19 +53,21 @@ jobs:
   build:
     name: Build + smoke (${{ matrix.variant }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
           - variant: slim
             dockerfile: docker/Dockerfile.slim
-            node_base: 26-slim
           - variant: alpine
             dockerfile: docker/Dockerfile.alpine
-            node_base: 26-alpine
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      # QEMU enables the linux/arm64 leg of the multi-arch push on an amd64 runner.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf  # v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
@@ -79,9 +83,10 @@ jobs:
             echo "value=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      # Build to a local image (load: true) so the smoke step can run it. Push is a
-      # separate step gated on release + DOCKER_IMAGE being configured.
-      - name: Build ${{ matrix.variant }} image
+      # ── BUILD + SMOKE (every event) ──────────────────────────────────────────
+      # Single-arch (runner arch) load so the smoke step can run the image. The
+      # base is digest-pinned in the Dockerfile, so NODE_BASE is not passed here.
+      - name: Build ${{ matrix.variant }} image (smoke)
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
@@ -89,8 +94,8 @@ jobs:
           load: true
           tags: nub-local:${{ matrix.variant }}
           build-args: |
-            NODE_BASE=${{ matrix.node_base }}
             NUB_VERSION=${{ steps.ver.outputs.value }}
+            NUB_REVISION=${{ github.sha }}
           cache-from: type=gha,scope=docker-${{ matrix.variant }}
           cache-to: type=gha,mode=max,scope=docker-${{ matrix.variant }}
 
@@ -102,14 +107,15 @@ jobs:
 
       # ── PUBLISH (release tags only, and only once a registry is configured) ───
       # MAINTAINER TODO: set the DOCKER_IMAGE repo variable to enable this. With it
-      # unset, this step no-ops on every event — the workflow stays build+smoke only.
+      # unset, every step below no-ops — the workflow stays build+smoke only, and a
+      # PR can NEVER push (the event is `pull_request`, not `release`).
       - name: Log in to registry
         if: github.event_name == 'release' && vars.DOCKER_IMAGE != ''
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3
         with:
-          # For GHCR: registry: ghcr.io, username: ${{ github.actor }},
-          #   password: ${{ secrets.GITHUB_TOKEN }} (no extra secret needed).
-          # For Docker Hub: omit registry, set DOCKERHUB_USERNAME var +
+          # GHCR: set DOCKER_REGISTRY=ghcr.io; username/password fall through to
+          #   github.actor + GITHUB_TOKEN (no extra secret).
+          # Docker Hub: leave DOCKER_REGISTRY unset; set DOCKERHUB_USERNAME var +
           #   DOCKERHUB_TOKEN secret.
           registry: ${{ vars.DOCKER_REGISTRY }}
           username: ${{ vars.DOCKERHUB_USERNAME || github.actor }}
@@ -129,15 +135,22 @@ jobs:
             echo "list=${IMG}:alpine,${IMG}:${VER}-alpine" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build + push ${{ matrix.variant }}
+      # Multi-arch (amd64 + arm64) push with provenance + SBOM attestation. The
+      # arm64 leg builds under QEMU emulation (slow but cheap to add). This rebuilds
+      # rather than reusing the loaded single-arch image — buildx cannot `load` a
+      # multi-arch manifest, so the canonical pattern is build-and-push directly.
+      - name: Build + push ${{ matrix.variant }} (multi-arch)
         if: github.event_name == 'release' && vars.DOCKER_IMAGE != ''
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: true
+          provenance: true
+          sbom: true
           tags: ${{ steps.tags.outputs.list }}
           build-args: |
-            NODE_BASE=${{ matrix.node_base }}
             NUB_VERSION=${{ steps.ver.outputs.value }}
+            NUB_REVISION=${{ github.sha }}
           cache-from: type=gha,scope=docker-${{ matrix.variant }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -139,6 +139,12 @@ jobs:
       # arm64 leg builds under QEMU emulation (slow but cheap to add). This rebuilds
       # rather than reusing the loaded single-arch image — buildx cannot `load` a
       # multi-arch manifest, so the canonical pattern is build-and-push directly.
+      #
+      # Coverage note: the full smoke (TS run + PM install) above only exercises the
+      # runner-arch (amd64) image. Each arch IS build-time-verified — the Dockerfile's
+      # `RUN ... nub --version` executes per-platform under QEMU, proving the -musl/
+      # arm64 binary loads and reports a version — but the arm64 leg gets no full
+      # smoke. A QEMU arm64 smoke leg is a reasonable future addition.
       - name: Build + push ${{ matrix.variant }} (multi-arch)
         if: github.event_name == 'release' && vars.DOCKER_IMAGE != ''
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,6 +40,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# packages: write is required for the GHCR push leg — the default GITHUB_TOKEN is
+# read-only for packages without it, so a GHCR `docker push` would 403. Harmless
+# for the Docker Hub path (which authenticates with its own token).
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     name: Build + smoke (${{ matrix.variant }})
@@ -56,10 +63,10 @@ jobs:
             dockerfile: docker/Dockerfile.alpine
             node_base: 26-alpine
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       # The nub version to bake in. On a release tag, install exactly that version;
       # otherwise install the latest published @nubjs/nub.
@@ -75,7 +82,7 @@ jobs:
       # Build to a local image (load: true) so the smoke step can run it. Push is a
       # separate step gated on release + DOCKER_IMAGE being configured.
       - name: Build ${{ matrix.variant }} image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -98,7 +105,7 @@ jobs:
       # unset, this step no-ops on every event — the workflow stays build+smoke only.
       - name: Log in to registry
         if: github.event_name == 'release' && vars.DOCKER_IMAGE != ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3
         with:
           # For GHCR: registry: ghcr.io, username: ${{ github.actor }},
           #   password: ${{ secrets.GITHUB_TOKEN }} (no extra secret needed).
@@ -124,7 +131,7 @@ jobs:
 
       - name: Build + push ${{ matrix.variant }}
         if: github.event_name == 'release' && vars.DOCKER_IMAGE != ''
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -20,15 +20,6 @@ FROM ${NODE_BASE}
 
 ARG NUB_VERSION=latest
 
-ARG NUB_REVISION=""
-LABEL org.opencontainers.image.title="nub" \
-      org.opencontainers.image.description="TypeScript-first developer supertool — a fast script runner and TS runtime that augments Node" \
-      org.opencontainers.image.source="https://github.com/nubjs/nub" \
-      org.opencontainers.image.url="https://nubjs.com" \
-      org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.version="${NUB_VERSION}" \
-      org.opencontainers.image.revision="${NUB_REVISION}"
-
 # libgcc + libstdc++ are the runtime deps of the prebuilt N-API addon (.node) on
 # musl; node:*-alpine ships neither by default. tini reaps zombies as PID 1 (nub
 # itself forwards signals — see Dockerfile.slim). --no-cache keeps the apk index
@@ -41,6 +32,17 @@ RUN apk add --no-cache libgcc libstdc++ tini \
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY docker/smoke.sh /usr/local/bin/smoke.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/smoke.sh
+
+# OCI labels last: NUB_REVISION changes every commit, so keeping the LABEL after
+# the heavy install RUN preserves that layer's cache across no-op rebuilds.
+ARG NUB_REVISION=""
+LABEL org.opencontainers.image.title="nub" \
+      org.opencontainers.image.description="TypeScript-first developer supertool — a fast script runner and TS runtime that augments Node" \
+      org.opencontainers.image.source="https://github.com/nubjs/nub" \
+      org.opencontainers.image.url="https://nubjs.com" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${NUB_VERSION}" \
+      org.opencontainers.image.revision="${NUB_REVISION}"
 
 # node:*-alpine ships a non-root `node` user (uid/gid 1000); drop to it.
 WORKDIR /app

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -6,8 +6,8 @@
 # musl via Node's diagnostic report (`header.glibcVersionRuntime` absent) — so the
 # correct musl binary is both installed and dispatched. (See npm/nub/platform.js.)
 #
-# Base default = node:26-alpine. The 22-alpine floor/compat variant is this same
-# Dockerfile with NODE_BASE=22-alpine.
+# Base default = node:26-alpine, digest-pinned. The floor/compat variant overrides
+# NODE_BASE to node:22-alpine.
 #
 # Build:
 #   docker build -f docker/Dockerfile.alpine \
@@ -15,15 +15,25 @@
 # Run:
 #   docker run --rm nub:alpine nub --version
 
-ARG NODE_BASE=26-alpine
-FROM node:${NODE_BASE}
+ARG NODE_BASE=node:26-alpine@sha256:a2dc166a387cc6ca1e62d0c8e265e49ca985d6e60abc9fe6e6c3d6ce8e63f606
+FROM ${NODE_BASE}
 
 ARG NUB_VERSION=latest
 
-# libstdc++ is required by the native N-API addon (the prebuilt .node links it).
-# node:*-alpine ships libgcc but not libstdc++; add it explicitly. --no-cache keeps
-# the apk index out of the layer.
-RUN apk add --no-cache libstdc++ \
+ARG NUB_REVISION=""
+LABEL org.opencontainers.image.title="nub" \
+      org.opencontainers.image.description="TypeScript-first developer supertool — a fast script runner and TS runtime that augments Node" \
+      org.opencontainers.image.source="https://github.com/nubjs/nub" \
+      org.opencontainers.image.url="https://nubjs.com" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${NUB_VERSION}" \
+      org.opencontainers.image.revision="${NUB_REVISION}"
+
+# libgcc + libstdc++ are the runtime deps of the prebuilt N-API addon (.node) on
+# musl; node:*-alpine ships neither by default. tini reaps zombies as PID 1 (nub
+# itself forwards signals — see Dockerfile.slim). --no-cache keeps the apk index
+# out of the layer.
+RUN apk add --no-cache libgcc libstdc++ tini \
     && npm install -g @nubjs/nub@${NUB_VERSION} \
     && npm cache clean --force \
     && nub --version
@@ -32,7 +42,10 @@ COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY docker/smoke.sh /usr/local/bin/smoke.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/smoke.sh
 
+# node:*-alpine ships a non-root `node` user (uid/gid 1000); drop to it.
 WORKDIR /app
+RUN chown node:node /app
+USER node
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 CMD ["nub", "--help"]

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,38 @@
+# Official nub image — Alpine (musl) variant.
+#
+# Same model as Dockerfile.slim: start from an official `node:*-alpine` base (Node
+# already present) and layer nub via `npm install -g @nubjs/nub`. On musl, npm's
+# os/cpu filters resolve the `-musl` platform package, and nub's launcher detects
+# musl via Node's diagnostic report (`header.glibcVersionRuntime` absent) — so the
+# correct musl binary is both installed and dispatched. (See npm/nub/platform.js.)
+#
+# Base default = node:26-alpine. The 22-alpine floor/compat variant is this same
+# Dockerfile with NODE_BASE=22-alpine.
+#
+# Build:
+#   docker build -f docker/Dockerfile.alpine \
+#     --build-arg NUB_VERSION=0.1.14 -t nub:alpine .
+# Run:
+#   docker run --rm nub:alpine nub --version
+
+ARG NODE_BASE=26-alpine
+FROM node:${NODE_BASE}
+
+ARG NUB_VERSION=latest
+
+# libstdc++ is required by the native N-API addon (the prebuilt .node links it).
+# node:*-alpine ships libgcc but not libstdc++; add it explicitly. --no-cache keeps
+# the apk index out of the layer.
+RUN apk add --no-cache libstdc++ \
+    && npm install -g @nubjs/nub@${NUB_VERSION} \
+    && npm cache clean --force \
+    && nub --version
+
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY docker/smoke.sh /usr/local/bin/smoke.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/smoke.sh
+
+WORKDIR /app
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["nub", "--help"]

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -21,7 +21,9 @@ ARG NODE_BASE=26-slim
 FROM node:${NODE_BASE}
 
 # The nub version to install. Defaults to the latest published @nubjs/nub; the
-# publish workflow pins this to the release tag so an image is reproducible.
+# publish workflow pins this to the release tag so the nub version is pinned. (The
+# base image still floats on the node:26-slim tag — pin a digest if you need the
+# base fully reproducible too.)
 ARG NUB_VERSION=latest
 
 # Install nub globally as root so postinstall can chmod the binary for every user

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -1,0 +1,41 @@
+# Official nub image — Debian slim (glibc), the default variant.
+#
+# nub AUGMENTS the user's installed Node; it is not a self-contained runtime like
+# bun. So this image starts from an official `node:*` base (Node already present)
+# and layers nub on top via the released npm package `@nubjs/nub`. The per-platform
+# binary is selected by npm's os/cpu filters at install time, and the package's
+# postinstall sets the execute bit on the binary as the INSTALLER (root) — the
+# canonical "install as root, then drop to a non-root user" container pattern.
+#
+# Base default = node:26 (current release line). 22.x is only the fast-tier floor;
+# the floor/compat variant is Dockerfile.slim with NODE_BASE=22-slim, never the
+# default headline.
+#
+# Build:
+#   docker build -f docker/Dockerfile.slim \
+#     --build-arg NUB_VERSION=0.1.14 -t nub:slim .
+# Run:
+#   docker run --rm nub:slim nub --version
+
+ARG NODE_BASE=26-slim
+FROM node:${NODE_BASE}
+
+# The nub version to install. Defaults to the latest published @nubjs/nub; the
+# publish workflow pins this to the release tag so an image is reproducible.
+ARG NUB_VERSION=latest
+
+# Install nub globally as root so postinstall can chmod the binary for every user
+# (see npm/nub/postinstall.js). Clean the npm cache in the same layer to keep the
+# image small. node:*-slim already carries glibc + ca-certificates, so no apt step.
+RUN npm install -g @nubjs/nub@${NUB_VERSION} \
+    && npm cache clean --force \
+    && nub --version
+
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY docker/smoke.sh /usr/local/bin/smoke.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/smoke.sh
+
+WORKDIR /app
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["nub", "--help"]

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -26,16 +26,6 @@ FROM ${NODE_BASE}
 # publish workflow pins this to the release tag so the nub version is pinned.
 ARG NUB_VERSION=latest
 
-# OCI image labels — passed by the publish workflow so version/revision are accurate.
-ARG NUB_REVISION=""
-LABEL org.opencontainers.image.title="nub" \
-      org.opencontainers.image.description="TypeScript-first developer supertool — a fast script runner and TS runtime that augments Node" \
-      org.opencontainers.image.source="https://github.com/nubjs/nub" \
-      org.opencontainers.image.url="https://nubjs.com" \
-      org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.version="${NUB_VERSION}" \
-      org.opencontainers.image.revision="${NUB_REVISION}"
-
 # tini reaps zombies as PID 1. nub already forwards SIGINT/SIGTERM/SIGHUP to its
 # Node child (crates/nub-core/src/node/spawn.rs), so signals are not the gap —
 # zombie reaping of re-parented grandchildren is. tini is the small, idiomatic
@@ -50,6 +40,17 @@ RUN apt-get update \
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY docker/smoke.sh /usr/local/bin/smoke.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/smoke.sh
+
+# OCI labels last: NUB_REVISION changes every commit, so keeping the LABEL after
+# the heavy install RUN preserves that layer's cache across no-op rebuilds.
+ARG NUB_REVISION=""
+LABEL org.opencontainers.image.title="nub" \
+      org.opencontainers.image.description="TypeScript-first developer supertool — a fast script runner and TS runtime that augments Node" \
+      org.opencontainers.image.source="https://github.com/nubjs/nub" \
+      org.opencontainers.image.url="https://nubjs.com" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${NUB_VERSION}" \
+      org.opencontainers.image.revision="${NUB_REVISION}"
 
 # The official node base ships a non-root `node` user (uid/gid 1000). nub was
 # installed as root (so postinstall could chmod the binary for everyone), so the

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -7,9 +7,9 @@
 # postinstall sets the execute bit on the binary as the INSTALLER (root) — the
 # canonical "install as root, then drop to a non-root user" container pattern.
 #
-# Base default = node:26 (current release line). 22.x is only the fast-tier floor;
-# the floor/compat variant is Dockerfile.slim with NODE_BASE=22-slim, never the
-# default headline.
+# Base default = node:26 (current release line), digest-pinned for reproducibility.
+# 22.x is only the fast-tier floor; the floor/compat variant is this Dockerfile with
+# NODE_BASE=node:22-slim (override the whole ref), never the default headline.
 #
 # Build:
 #   docker build -f docker/Dockerfile.slim \
@@ -17,19 +17,33 @@
 # Run:
 #   docker run --rm nub:slim nub --version
 
-ARG NODE_BASE=26-slim
-FROM node:${NODE_BASE}
+# Full ref incl. digest so the base is reproducible. The publish workflow refreshes
+# the digest; override NODE_BASE to retarget (e.g. node:22-slim for the floor).
+ARG NODE_BASE=node:26-slim@sha256:f9b8bd6c62fcd007c08ce2bb2907485b624b968fd76094445822e0ec14002cf0
+FROM ${NODE_BASE}
 
 # The nub version to install. Defaults to the latest published @nubjs/nub; the
-# publish workflow pins this to the release tag so the nub version is pinned. (The
-# base image still floats on the node:26-slim tag — pin a digest if you need the
-# base fully reproducible too.)
+# publish workflow pins this to the release tag so the nub version is pinned.
 ARG NUB_VERSION=latest
 
-# Install nub globally as root so postinstall can chmod the binary for every user
-# (see npm/nub/postinstall.js). Clean the npm cache in the same layer to keep the
-# image small. node:*-slim already carries glibc + ca-certificates, so no apt step.
-RUN npm install -g @nubjs/nub@${NUB_VERSION} \
+# OCI image labels — passed by the publish workflow so version/revision are accurate.
+ARG NUB_REVISION=""
+LABEL org.opencontainers.image.title="nub" \
+      org.opencontainers.image.description="TypeScript-first developer supertool — a fast script runner and TS runtime that augments Node" \
+      org.opencontainers.image.source="https://github.com/nubjs/nub" \
+      org.opencontainers.image.url="https://nubjs.com" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${NUB_VERSION}" \
+      org.opencontainers.image.revision="${NUB_REVISION}"
+
+# tini reaps zombies as PID 1. nub already forwards SIGINT/SIGTERM/SIGHUP to its
+# Node child (crates/nub-core/src/node/spawn.rs), so signals are not the gap —
+# zombie reaping of re-parented grandchildren is. tini is the small, idiomatic
+# insurance; --no-install-recommends + cache cleanup keep the layer lean.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g @nubjs/nub@${NUB_VERSION} \
     && npm cache clean --force \
     && nub --version
 
@@ -37,7 +51,13 @@ COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY docker/smoke.sh /usr/local/bin/smoke.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/smoke.sh
 
+# The official node base ships a non-root `node` user (uid/gid 1000). nub was
+# installed as root (so postinstall could chmod the binary for everyone), so the
+# global binary is world-runnable — drop to `node` for the default runtime.
 WORKDIR /app
+RUN chown node:node /app
+USER node
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+# tini as PID 1; the entrypoint then dispatches args to `nub` (bun-style).
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 CMD ["nub", "--help"]

--- a/docker/PUBLISHING.md
+++ b/docker/PUBLISHING.md
@@ -1,0 +1,83 @@
+# Publishing the official nub Docker images
+
+Maintainer runbook for `.github/workflows/docker.yml`. The workflow builds and
+smoke-tests both variants (slim + alpine) on every PR and push to `main`, and
+publishes a multi-arch image (`linux/amd64` + `linux/arm64`) **only on a release
+tag** and **only once a registry is wired up**. The registry and image name are a
+maintainer choice — nothing is hardcoded to publish until you set the variable
+below. Pick **one** of the two options.
+
+## Tag scheme
+
+| Variant | Tags pushed |
+|---|---|
+| slim (default) | `latest`, `<version>`, `slim`, `<version>-slim` |
+| alpine | `alpine`, `<version>-alpine` |
+
+`<version>` is the release tag with the leading `v` stripped (e.g. `0.1.14`).
+
+---
+
+## Option A — Docker Hub (`nubjs/nub`)
+
+1. **Create the org + repo.** On Docker Hub, create the `nubjs` organization, then a
+   repository named `nub` (so the image is `nubjs/nub`). Set it public.
+2. **Create an access token.** Docker Hub → Account Settings → Personal access
+   tokens (or an org service account) → New token, **Read & Write** scope. Copy it.
+3. **Add the GitHub Actions secret + variables** (repo Settings → Secrets and
+   variables → Actions):
+   - Secret `DOCKERHUB_TOKEN` = the token from step 2.
+   - Variable `DOCKERHUB_USERNAME` = the Docker Hub account/org that owns the token.
+   - Variable `DOCKER_IMAGE` = `nubjs/nub`.
+   - Leave `DOCKER_REGISTRY` **unset** (defaults to Docker Hub).
+4. **Publish.** Cut a release the normal way (`make version V=<ver>` → commit → tag
+   `v<ver>` → push tag). The `release: published` event triggers `docker.yml`, which
+   logs in with `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` and pushes the tags above.
+5. **Verify.**
+   ```sh
+   docker run --rm nubjs/nub nub --version
+   docker run --rm nubjs/nub:alpine nub --version
+   docker buildx imagetools inspect nubjs/nub:latest   # confirm amd64 + arm64 in the manifest
+   ```
+
+---
+
+## Option B — GHCR (`ghcr.io/nubjs/nub`)
+
+No extra secret — the built-in `GITHUB_TOKEN` plus `permissions: packages: write`
+(already set in the workflow) is sufficient.
+
+1. **Add the variables** (repo Settings → Secrets and variables → Actions → Variables):
+   - Variable `DOCKER_IMAGE` = `ghcr.io/nubjs/nub`.
+   - Variable `DOCKER_REGISTRY` = `ghcr.io`.
+   - (No `DOCKERHUB_*`; the workflow falls through to `github.actor` + `GITHUB_TOKEN`.)
+2. **Publish.** Cut a release as above. The tag-triggered run logs in to `ghcr.io`
+   with the built-in token and pushes.
+3. **Make the package public** (first publish only): GHCR → the `nub` package →
+   Package settings → Change visibility → Public. (Optional but expected for an
+   official image; without it, pulls require auth.)
+4. **Verify.**
+   ```sh
+   docker run --rm ghcr.io/nubjs/nub nub --version
+   docker buildx imagetools inspect ghcr.io/nubjs/nub:latest
+   ```
+
+---
+
+## Publishing to BOTH registries
+
+The workflow targets a single `DOCKER_IMAGE`. To publish to both Docker Hub and
+GHCR, the cleanest change is to extend the matrix (or add a second push step) with
+a second image name + login. Not wired by default — decide if you actually want two
+registries before adding the complexity.
+
+## Notes
+
+- **PRs never push.** The push steps are gated on `github.event_name == 'release'`,
+  so a fork PR or a `main` push only builds + smokes. The `DOCKER_IMAGE` guard is a
+  second backstop: with it unset, even a release no-ops the push.
+- **Base image digests** are pinned in `docker/Dockerfile.{slim,alpine}`. Refresh
+  them when you want a newer `node:26-*` base (`docker buildx imagetools inspect
+  node:26-slim` → copy the index `Digest`).
+- **Provenance + SBOM** attestations are attached on push (`provenance: true`,
+  `sbom: true`). They add a manifest entry per image; harmless for consumers.

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Entrypoint mirroring oven/bun's: if the first arg looks like a flag, is not an
+# executable on PATH, or is a non-executable file, treat the whole arg list as
+# arguments to `nub` (so `docker run nub:slim script.ts` runs the file). Otherwise
+# exec the command verbatim (so `docker run nub:slim sh` opens a shell).
+set -e
+
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ] || { [ -f "${1}" ] && ! [ -x "${1}" ]; }; then
+  set -- nub "$@"
+fi
+
+exec "$@"

--- a/docker/smoke.sh
+++ b/docker/smoke.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Official-image smoke test — runs INSIDE a built nub image where `nub` is already
+# on PATH via `npm install -g @nubjs/nub`. Verifies the image is usable end-to-end:
+#
+#   1. nub --version returns a semver string (binary is real, not a stub).
+#   2. nub <file.ts> transpiles + runs TypeScript on the in-image Node.
+#   3. nub install materializes a real dep and the module is require()-loadable.
+#
+# This is the image counterpart of tests/docker-smoke/smoke.sh (which tests a
+# from-source binary). Here we test the SHIPPED npm path on the chosen Node base.
+#
+# Usage: docker run --rm nub:slim /usr/local/bin/smoke.sh
+set -eu
+
+fail() { echo "FAIL: $*"; exit 1; }
+pass() { echo "ok: $*"; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# ── 1. version ────────────────────────────────────────────────────────────────
+ver="$(nub --version 2>/dev/null)"
+echo "$ver" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || fail "--version returned non-semver: '$ver'"
+pass "nub --version: $ver"
+
+# ── 2. TypeScript run ─────────────────────────────────────────────────────────
+cat > "$SANDBOX/hello.ts" <<'TS'
+const greet = (name: string): string => `TS-SMOKE-OK ${name}`;
+console.log(greet("nub"));
+TS
+out="$(nub "$SANDBOX/hello.ts" 2>&1)"
+echo "$out" | grep -q "TS-SMOKE-OK nub" || fail "TS execution failed: $out"
+pass "TypeScript run: $out"
+
+# ── 3. PM install + module load ───────────────────────────────────────────────
+mkdir -p "$SANDBOX/pm"
+cat > "$SANDBOX/pm/package.json" <<'JSON'
+{ "name": "smoke-pm", "private": true, "dependencies": { "kleur": "4.1.5" } }
+JSON
+install_out="$(cd "$SANDBOX/pm" && nub install 2>&1)"
+[ -e "$SANDBOX/pm/node_modules/kleur" ] || fail "nub install did not materialize kleur. Output: $install_out"
+load_out="$(cd "$SANDBOX/pm" && node -e "const k=require('kleur'); console.log('PM-SMOKE-OK', typeof k.red)" 2>&1)"
+echo "$load_out" | grep -q "PM-SMOKE-OK function" || fail "installed module not loadable: $load_out"
+pass "nub install + module load: kleur materialized and require()-loadable"
+
+echo "ALL SMOKE CHECKS PASSED"

--- a/site/content/docs/docker.mdx
+++ b/site/content/docs/docker.mdx
@@ -9,10 +9,12 @@ Nub augments the Node already in your image — it is not a separate runtime. Th
 
 ```dockerfile
 FROM nubjs/nub
-COPY . .
+COPY --chown=node:node . .
 RUN nub install
 CMD ["nub", "run", "start"]
 ```
+
+The image runs as the non-root `node` user, so copy your project in with `--chown=node:node` — a bare `COPY . .` lands root-owned files that `nub install` then can't write alongside.
 
 Two variants, both on the current Node release line, digest-pinned and published for `linux/amd64` and `linux/arm64`:
 
@@ -27,7 +29,7 @@ Run a TypeScript file directly — the entrypoint passes any non-command argumen
 docker run --rm -v "$PWD:/app" nubjs/nub script.ts
 ```
 
-The image runs as the non-root `node` user, and signals reach the runtime: `docker stop` delivers `SIGTERM` to `nub`, which forwards it to the Node process for a clean shutdown.
+Signals reach the runtime: `docker stop` delivers `SIGTERM` to `nub`, which forwards it to the Node process for a clean shutdown. The container runs as the non-root `node` user (uid 1000); when you bind-mount a directory that `nub install` must write into, run with `--user "$(id -u)"` so the writes land with your host ownership.
 
 ## Adding nub to your own image
 

--- a/site/content/docs/docker.mdx
+++ b/site/content/docs/docker.mdx
@@ -1,0 +1,46 @@
+---
+title: Docker
+description: Official nub Docker images, and how to add nub to your own image. The images install nub onto an official node base, so Node is present and the runtime is augmented out of the box.
+---
+
+Nub augments the Node already in your image — it is not a separate runtime. The official images start from an official `node` base and layer nub on top, so `node`, `npm`, and `nub` are all present.
+
+## Official images
+
+```dockerfile
+FROM nubjs/nub
+COPY . .
+RUN nub install
+CMD ["nub", "run", "start"]
+```
+
+Two variants, both on the current Node release line:
+
+| Tag | Base | libc |
+|---|---|---|
+| `latest`, `slim` | `node:26-slim` | glibc |
+| `alpine` | `node:26-alpine` | musl |
+
+Run a TypeScript file directly — the entrypoint passes any non-command argument to `nub`:
+
+```bash
+docker run --rm -v "$PWD:/app" nubjs/nub script.ts
+```
+
+## Adding nub to your own image
+
+If you already build on a `node` base, install nub with one line. npm selects the correct per-platform binary at install time — including the musl build on Alpine — and the package's postinstall sets the execute bit, so installing as root and then dropping to a non-root user works.
+
+```dockerfile
+FROM node:26-slim
+RUN npm install -g @nubjs/nub
+```
+
+On Alpine, add `libstdc++` for the native addon:
+
+```dockerfile
+FROM node:26-alpine
+RUN apk add --no-cache libstdc++ && npm install -g @nubjs/nub
+```
+
+To pin the floor Node version instead of the current line, use a `22` base (`node:22-slim` or `node:22-alpine`) — the lowest version nub's fast tier supports.

--- a/site/content/docs/docker.mdx
+++ b/site/content/docs/docker.mdx
@@ -14,18 +14,20 @@ RUN nub install
 CMD ["nub", "run", "start"]
 ```
 
-Two variants, both on the current Node release line:
+Two variants, both on the current Node release line, digest-pinned and published for `linux/amd64` and `linux/arm64`:
 
 | Tag | Base | libc |
 |---|---|---|
-| `latest`, `slim` | `node:26-slim` | glibc |
-| `alpine` | `node:26-alpine` | musl |
+| `latest`, `<version>`, `slim`, `<version>-slim` | `node:26-slim` | glibc |
+| `alpine`, `<version>-alpine` | `node:26-alpine` | musl |
 
 Run a TypeScript file directly — the entrypoint passes any non-command argument to `nub`:
 
 ```bash
 docker run --rm -v "$PWD:/app" nubjs/nub script.ts
 ```
+
+The image runs as the non-root `node` user, and signals reach the runtime: `docker stop` delivers `SIGTERM` to `nub`, which forwards it to the Node process for a clean shutdown.
 
 ## Adding nub to your own image
 
@@ -36,11 +38,11 @@ FROM node:26-slim
 RUN npm install -g @nubjs/nub
 ```
 
-On Alpine, add `libstdc++` for the native addon:
+On Alpine, add `libgcc` and `libstdc++` for the native addon:
 
 ```dockerfile
 FROM node:26-alpine
-RUN apk add --no-cache libstdc++ && npm install -g @nubjs/nub
+RUN apk add --no-cache libgcc libstdc++ && npm install -g @nubjs/nub
 ```
 
 To pin the floor Node version instead of the current line, use a `22` base (`node:22-slim` or `node:22-alpine`) — the lowest version nub's fast tier supports.

--- a/site/content/docs/meta.json
+++ b/site/content/docs/meta.json
@@ -12,6 +12,7 @@
     "pm-shim",
     "faq",
     "---",
-    "setup-nub"
+    "setup-nub",
+    "docker"
   ]
 }


### PR DESCRIPTION
Adds official, Bun-style Docker images for nub and a publish workflow, opened as one PR. Hardened to OCI/container best practices after a Bun-image audit.

## What's here

- **`docker/Dockerfile.slim`** — default variant, `FROM node:26-slim` (glibc, digest-pinned). Installs nub via `npm install -g @nubjs/nub`.
- **`docker/Dockerfile.alpine`** — `FROM node:26-alpine` (musl, digest-pinned). Adds `libgcc` + `libstdc++` for the native N-API addon.
- **`docker/docker-entrypoint.sh`** — bun-style arg dispatch (`docker run img script.ts` → `nub script.ts`; `docker run img sh` → shell), behind `tini` as PID 1.
- **`docker/smoke.sh`** — in-image smoke: `nub --version`, a TS run, a PM install + `require()`-load.
- **`.github/workflows/docker.yml`** — build + smoke BOTH variants on PR/main; multi-arch (`linux/amd64` + `linux/arm64`) push with provenance + SBOM on a release tag, gated behind a parameterized, maintainer-owned registry var (no publish target hardcoded). SHA-pinned actions; `permissions: packages: write` for GHCR.
- **`docker/PUBLISHING.md`** — copy-pasteable Docker Hub + GHCR publish runbooks.
- **`site/content/docs/docker.mdx`** + meta — docs page.

## Design decision: node-baked, not nub-provisioned

nub augments the user's installed Node — it is not a self-contained runtime like bun. So the images start from an official `node:*` base (Node present, cached, version-pinned at build time) and layer nub on top. A nub-only image relying on `nub node` to provision Node on first use would hit the network on first run, bloat the runtime layer, and diverge from every official Node-tool image. `npm install -g @nubjs/nub` (not the curl script) is the install path: npm is already present, its os/cpu filters resolve the correct per-platform binary including `-musl` on Alpine, and the package postinstall chmods the binary as the installer (root) — the install-as-root-then-drop-user container pattern. Default base is **node:26** (current line); 22.x is only the fast-tier floor, exposed by overriding `NODE_BASE`, never the default.

## Best-practice audit vs oven/bun + OCI (applied / left)

| Best practice | Applied? |
|---|---|
| Non-root user (`USER node`, uid 1000) | yes — base already ships it |
| PID-1 zombie reaping (`tini`) | yes — nub already forwards SIGINT/TERM/HUP to its Node child |
| Base digest-pin (slim + alpine) | yes |
| OCI `org.opencontainers.image.*` labels | yes (version/revision via build-args) |
| `--no-install-recommends` / cache cleanup | yes |
| Alpine native-dep libs (`libgcc` + `libstdc++`) | yes |
| Multi-arch amd64 + arm64 | yes (QEMU + buildx, push leg) |
| Provenance + SBOM attestation | yes (on push) |
| HEALTHCHECK | left — a CLI/runtime image has no long-lived service to probe |
| Distroless variant | left — nub needs Node present; distroless-node is niche, defer to demand |

## Verification (local, both variants green)

| Variant | Base | Image size | `npm i -g @nubjs/nub` | Smoke (non-root) |
|---|---|---|---|---|
| slim | node:26-slim (glibc) | ~367 MB | **yes** | pass |
| alpine | node:26-alpine (musl) | ~266 MB | **yes** | pass |

Each variant: `nub --version` = v0.1.14, a TypeScript file ran, `nub install` materialized a dep and it loaded via `require()` — all as the non-root `node` user. Alpine resolved `@nubjs/nub-linux-arm64-musl`. OCI labels populate. Signal handling verified end-to-end: `docker stop` → SIGTERM → tini → nub → Node child shut down cleanly (exit 0, not a 137 SIGKILL timeout). The headline docs example (`FROM nubjs/nub` + `COPY --chown=node:node . .` + `nub install`) was built downstream and confirmed to install + load a dependency as non-root.

**`npm install -g @nubjs/nub` works cleanly in a fresh node:26-slim AND node:26-alpine container — yes on both.**

Two adversarial L2 reviewer passes (fresh context, Opus) found no P0s and no leaked secrets; confirmed a PR can never push (every push step gated `if: github.event_name == 'release' && vars.DOCKER_IMAGE != ''`). Their P1s (SHA-pin convention, missing `packages: write`, the non-root docs example, bind-mount note) and P2s (cache-layer reorder, arm64 smoke-gap note) are all addressed.

## Maintainer-owned decisions (recommend-only — not decided here)

- **Registry:** Docker Hub `nubjs/nub` vs GHCR `ghcr.io/nubjs/nub` vs both. The workflow is parameterized via `vars.DOCKER_IMAGE` / `vars.DOCKER_REGISTRY`; the push leg no-ops until that var is set. `docker/PUBLISHING.md` has copy-paste steps for each.
- **Image name/namespace.** The docs + runbook show `nubjs/nub` as the proposed name — adjust on main if you pick another.
- **Variants + tag scheme at launch.** Proposed: slim = `latest`/`<ver>`/`slim`/`<ver>-slim`; alpine = `alpine`/`<ver>-alpine` (mirrors oven/bun).
- **Final ratification** of node-baked-vs-provisioned.

Do not merge or publish until those are signed off.