### PR TITLE
test(pnpm-conformance): fix run.sh shift-on-empty bug; correct the safe-fixes analysis

### DIFF
--- a/tests/pnpm-conformance/run.sh
+++ b/tests/pnpm-conformance/run.sh
@@ -40,7 +40,7 @@ shift
 PNPM_TAG="${1:-v${PNPM_PIN:-10.15.1}}"
 # Allow passing a bare jest-arg in $1 (only shift the tag if it looks like a tag).
 case "$PNPM_TAG" in
-  v[0-9]*|[0-9]*) shift; [[ "$PNPM_TAG" == v* ]] || PNPM_TAG="v$PNPM_TAG" ;;
+  v[0-9]*|[0-9]*) [[ $# -gt 0 ]] && shift; [[ "$PNPM_TAG" == v* ]] || PNPM_TAG="v$PNPM_TAG" ;;
   *) PNPM_TAG="v${PNPM_PIN:-10.15.1}" ;;
 esac
 JEST_EXTRA=("$@")


### PR DESCRIPTION
## What this lands

A single test-harness fix: `tests/pnpm-conformance/run.sh` ran an unguarded `shift` on an already-empty positional list when invoked with only the nub-binary arg (no pnpm-tag), aborting under `set -euo pipefail`. Guarded with `[[ $# -gt 0 ]] && shift`. Version-independent, zero nub behavior change.

## Why this is the only fix (corrected analysis)

This spike set out to land the "safe pnpm-conformance convergence fixes" from the analysis thread (projected +7 tests → 300/337). Empirical verification against the **actually-pinned pnpm (v10.15.1)** — not the v11 checkout the original analysis was grounded on — showed the projected fixes do NOT apply as described. Each was verified by reproducing the real failure:

- **`bin -g` `/bin` leaf** — v10.15.1's `test/bin.ts` asserts `bin -g == <PNPM_HOME>` with **no** `/bin` leaf (the opposite of v11). The original "append `/bin`" fix would have *diverged* nub from the pinned pnpm. The actual failure is `status: 1` (the clean test env strips node from PATH). Fix reverted; correctly stays allowlisted.
- **packageManager hash (`pnpm@<v>+sha256…`)** — nub's PM shim **fail-closes** on an unverifiable hash algorithm (`sha256`): "refusing to install unverified" (`crates/nub-core/src/pm/provision.rs::verify_pin_hash`). This is a deliberate fail-closed supply-chain posture, not a parse bug. Maintainer-owned security decision.
- **packageManager url (`pnpm@https://…`)** — nub's shim tries to resolve the URL as a version and errors; pnpm treats a url-form as "no version pin" and proceeds. A defensible match + crash-fix, but it changes shim version-resolution semantics → recommend-only.
- **`--global-dir` / `root -g` / `global*` / `link*` ×3** — all the `global-nub/` vs pnpm's `global/<LAYOUT_VERSION>/` brand-coexistence layout. (The 3 `link` entries are NOT phantom/stale — they are real `link -g` tests in v10.15.1's `test/link.ts`; the "phantom" claim came from a stale v11 checkout.) Maintainer brand ruling.
- **`do not switch` ×3 / strict / self-update** — nub's deliberate non-switching + lenient `package-manager-strict=warn` default (pnpm defaults to error). Maintainer-owned.
- **`create a package.json if there is none`** — nub exits 243 (a crash) on an empty-dir install via the mock registry; real bug, needs investigation, not a safe one-liner.
- **`dlx read registry from .npmrc`** — scratch-dir auth/registry forwarding gap; needs investigation.

## Result

- Pass count unchanged at **293/337**; conformance run stays **100% green (0 SURPRISE, 0 STALE-ALLOW, exit 0)** — confirmed no regression.
- The allowlist is **honest as-is**: every entry matched a real failing test in the v10.15.1 run; nothing is stale.

Refs the pnpm-conformance harness work.