### PR TITLE
test(core): cover topological_chunks cycle-handling branch

### DIFF
--- a/crates/nub-core/src/workspace/filter.rs
+++ b/crates/nub-core/src/workspace/filter.rs
@@ -1330,8 +1330,7 @@ mod tests {
 
     /// A cycle keeps the cyclic nodes out of every wave (they never reach
     /// zero in-degree), so the leftover branch dumps them in ONE final chunk
-    /// after the acyclic prefix waves out normally — the cycle-handling
-    /// contract the Kahn's-algorithm rewrite preserves. No node is dropped or
+    /// after the acyclic prefix waves out normally. No node is dropped or
     /// duplicated even when the graph isn't a DAG.
     #[test]
     fn topological_chunks_cycle_dumps_remainder_in_one_chunk() {

--- a/crates/nub-core/src/workspace/filter.rs
+++ b/crates/nub-core/src/workspace/filter.rs
@@ -1328,6 +1328,47 @@ mod tests {
         assert_eq!(chunks[1], vec![2]);
     }
 
+    /// A cycle keeps the cyclic nodes out of every wave (they never reach
+    /// zero in-degree), so the leftover branch dumps them in ONE final chunk
+    /// after the acyclic prefix waves out normally — the cycle-handling
+    /// contract the Kahn's-algorithm rewrite preserves. No node is dropped or
+    /// duplicated even when the graph isn't a DAG.
+    #[test]
+    fn topological_chunks_cycle_dumps_remainder_in_one_chunk() {
+        // D(3) is an acyclic head; C(2) depends on D; A(0)<->B(1) form a 2-cycle.
+        let deps = vec![
+            HashSet::from([1]), // 0 (A) -> B
+            HashSet::from([0]), // 1 (B) -> A   (the cycle)
+            HashSet::from([3]), // 2 (C) -> D
+            HashSet::new(),     // 3 (D) no deps
+        ];
+        let nodes: HashSet<usize> = [0, 1, 2, 3].into();
+        let chunks = topological_chunks(&nodes, &deps);
+
+        // Acyclic prefix waves out in dependency order: D, then C.
+        assert_eq!(chunks[0], vec![3], "D (no deps) is the first wave");
+        assert_eq!(chunks[1], vec![2], "C waves once its dep D is emitted");
+
+        // The cyclic remainder {A, B} is the single final chunk (order is the
+        // node-set iteration order, so compare as a set).
+        let leftover: HashSet<usize> = chunks.last().unwrap().iter().copied().collect();
+        assert_eq!(
+            leftover,
+            HashSet::from([0, 1]),
+            "the A<->B cycle is dumped together in the final chunk"
+        );
+        assert_eq!(
+            chunks.len(),
+            3,
+            "two acyclic waves + one leftover cycle chunk"
+        );
+
+        // Every node appears exactly once across all chunks (none lost or dupes).
+        let mut all: Vec<usize> = chunks.into_iter().flatten().collect();
+        all.sort_unstable();
+        assert_eq!(all, vec![0, 1, 2, 3]);
+    }
+
     #[test]
     fn resolve_concurrency_defaults() {
         let cores = std::thread::available_parallelism()


### PR DESCRIPTION
## What

Add a regression test for the cycle-handling branch of `topological_chunks` in `crates/nub-core/src/workspace/filter.rs`.

## Why

PR #17 rewrote `topological_chunks` from an O(remaining × deps)-per-wave rescan to an O(V+E) Kahn's algorithm, stating that "wave grouping and cycle handling are unchanged." The wave-grouping contract was covered by the existing `topological_chunks_simple` (linear chain) and `topological_chunks_parallel` (fan-in) tests, but **the cycle-handling branch had no test** — both existing tests terminate with `emitted == nodes.len()`, so neither reaches the leftover-dump path (`if emitted < nodes.len()`).

That branch is the one place the function handles a non-DAG: cyclic nodes never reach zero in-degree, so they're never emitted in a wave, and the remainder is dumped together in one final chunk.

## The test

`topological_chunks_cycle_dumps_remainder_in_one_chunk` runs a graph that mixes an acyclic head (D), a one-hop acyclic dependent (C → D), and a 2-cycle (A ↔ B), asserting:

- the acyclic prefix waves out in dependency order (`[D]`, then `[C]`),
- the cyclic remainder `{A, B}` lands together in the single final chunk (compared as a set, since the leftover's internal order is `HashSet` iteration order and not guaranteed),
- there are exactly three chunks (two acyclic waves + one leftover), and
- every node appears exactly once across all chunks — none dropped or duplicated.

The two single-element acyclic waves are asserted positionally because each is provably a unique singleton (D is the only initial zero-in-degree node; C is the only node freed by emitting D), so those comparisons are order-safe.

## Verification

- **Pass-after:** the test passes against current `main`.
- **Fail-before:** disabling the leftover branch (modeling a rewrite that forgets cycle handling) drops the cyclic nodes — the final chunk becomes `{C}` instead of `{A, B}` and the test fails.
- `cargo test -p nub-core --lib workspace::filter`: 43 passed, 0 failed.
- `cargo fmt --check` and `cargo clippy -p nub-core --all-targets --all-features -- -D warnings`: clean.

Refs #17
