### PR TITLE
Write link: version for versionless workspace members in pnpm-lock.yaml

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
@@ -2721,6 +2721,62 @@ fn workspace_deps_write_importer_relative_link_versions() {
     );
 }
 
+// A workspace member whose package.json omits `version` must still
+// serialize the consuming importer's edge as `link:<dir>`, not the bare
+// default version. The resolver defaults a missing version to "0.0.0"
+// (install::workspace), so the dep_path is `name@0.0.0`; the writer must
+// mirror that default when recovering member dirs or the lookup misses
+// and pnpm rejects the lockfile under `--frozen-lockfile`
+// (ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY: no entry for `foo@0.0.0`).
+#[test]
+fn versionless_workspace_member_writes_link_not_bare_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+    // `foo` has a name but no version — the regression case.
+    for (rel, body) in [
+        ("apps/app", r#"{"name": "app", "version": "0.0.0"}"#),
+        ("packages/foo", r#"{"name": "foo"}"#),
+    ] {
+        let pkg_dir = dir.path().join(rel);
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("package.json"), body).unwrap();
+    }
+
+    let mut importers = BTreeMap::new();
+    importers.insert(".".to_string(), vec![]);
+    importers.insert(
+        "apps/app".to_string(),
+        vec![DirectDep {
+            name: "foo".to_string(),
+            dep_path: "foo@0.0.0".to_string(),
+            dep_type: DepType::Production,
+            specifier: Some("workspace:*".to_string()),
+        }],
+    );
+    importers.insert("packages/foo".to_string(), vec![]);
+    let graph = LockfileGraph {
+        importers,
+        ..Default::default()
+    };
+    let manifest = PackageJson {
+        name: Some("repro-root".to_string()),
+        version: Some("0.0.0".to_string()),
+        ..Default::default()
+    };
+
+    write(&lockfile_path, &graph, &manifest).unwrap();
+    let yaml = std::fs::read_to_string(&lockfile_path).unwrap();
+
+    assert!(
+        yaml.contains("version: link:../../packages/foo"),
+        "versionless workspace member must render as an importer-relative link: {yaml}"
+    );
+    assert!(
+        !yaml.contains("version: 0.0.0"),
+        "versionless member must not record the default 0.0.0 as a registry version: {yaml}"
+    );
+}
+
 // Same property at the whole-file level: a workspace lockfile written
 // by native pnpm 10.15.1 (fixture generated from a real install) must
 // survive parse → write byte-identically — in particular the

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
@@ -68,7 +68,14 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         }
         let pj_path = project_dir.join(importer_path).join("package.json");
         let pj = PackageJson::from_path(&pj_path).unwrap_or_default();
-        if let (Some(name), Some(version)) = (pj.name, pj.version) {
+        // A versionless member resolves to a dep_path of `name@0.0.0`
+        // (the resolver defaults a missing `version` to "0.0.0" in
+        // install::workspace) — mirror that default here so the
+        // `name@version` lookup matches and the importer edge serializes
+        // as `link:<dir>` rather than the bare `0.0.0` version, which
+        // pnpm rejects under `--frozen-lockfile` (no `foo@0.0.0` entry).
+        if let Some(name) = pj.name {
+            let version = pj.version.as_deref().unwrap_or("0.0.0");
             workspace_member_dirs.insert(format!("{name}@{version}"), importer_path.clone());
         }
     }


### PR DESCRIPTION
## Problem

When `nub install` writes `pnpm-lock.yaml` for a pnpm workspace where an internal member's `package.json` omits the `version` field, nub serialized the consuming importer's `workspace:` edge as `version: 0.0.0` instead of pnpm's `version: link:<relative-path>` form. Stock pnpm then rejected nub's own lockfile under a frozen install:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for 'foo@0.0.0' in pnpm-lock.yaml
```

A workspace member with an explicit `version` serialized correctly — only the versionless case was affected. Reported with a minimal repro in #113.

## Root cause

The pnpm writer (`vendor/aube/crates/aube-lockfile/src/pnpm/write.rs`) recovers each workspace member's directory from a map keyed on the member manifest's `name@version`, used to render the importer edge as `link:<dir>`. That map only inserted members whose `package.json` declared **both** `name` and `version`. The resolver (`vendor/aube/crates/aube/src/commands/install/workspace.rs`) defaults a missing version to `0.0.0`, so a versionless member's edge keys as `name@0.0.0` — it missed the lookup and fell through to the bare-version branch.

## Fix

Default the writer's missing version to `0.0.0`, mirroring the resolver, so the `link:` target resolves. The change is a no-op for the versioned path (the `unwrap_or` only fires when `version` is absent), and the lookup is gated on the dep having no `packages:` entry, so it cannot collide with a real registry `name@0.0.0` package.

## Verification

- New regression test `versionless_workspace_member_writes_link_not_bare_version` — confirmed to fail on the pre-fix code and pass with the fix.
- Existing pnpm writer tests green (117/117), including the versioned-member round-trip.
- e2e against the reporter's repro: nub now writes `version: link:../../packages/foo`, and stock pnpm 10.15.1 `install --frozen-lockfile` passes.

Fixes #113