### PR TITLE
pm: fix packageManager URL-form crash and store-open without HOME

### DIFF
--- a/crates/nub-core/src/pm/resolve.rs
+++ b/crates/nub-core/src/pm/resolve.rs
@@ -799,7 +799,28 @@ pub fn parse_spec(spec: &str) -> Result<PmPin> {
     let (name, version) = spec.split_once('@').with_context(|| {
         format!("packageManager \"{spec}\" must be in name@version form (e.g. pnpm@9.1.0)")
     })?;
+    // A URL/git reference in place of a version (`pnpm@https://…`, `pnpm@git+…`)
+    // is a Corepack-supported form meaning "fetch this artifact" — there is no
+    // semver to pin. nub can't provision an arbitrary tarball as a PM version,
+    // so it treats the field as NAME-only (no version pin) and falls through to
+    // the user's PM on PATH / a dynamic default — matching pnpm, which does not
+    // version-switch on a URL spec. Without this the URL reached the semver
+    // resolver and aborted the run (`unexpected character 'h'`).
+    if is_url_version_ref(version) {
+        return classify(name, None);
+    }
     classify(name, Some(version))
+}
+
+/// Whether a `packageManager` *version* slot holds a URL / git / file reference
+/// rather than a semver-ish spec — `https://…`, `git+…`, `git://…`, a `git@…`
+/// shorthand, or a `file:…` path Corepack accepts. Such a value carries no
+/// version to pin (see [`parse_spec`]). A bare `host:path` SSH shorthand is left
+/// out deliberately: it is ambiguous against a real version and not worth the
+/// false-positive risk.
+fn is_url_version_ref(version: &str) -> bool {
+    let v = version.trim();
+    v.contains("://") || v.starts_with("git+") || v.starts_with("git@") || v.starts_with("file:")
 }
 
 /// Map a `(name, version)` pair to a [`PmPin`], applying the yarn classic/berry
@@ -1069,6 +1090,40 @@ mod tests {
         assert!(
             err.contains("name@version"),
             "missing-version error must name the form, got: {err}"
+        );
+    }
+
+    #[test]
+    fn url_version_spec_parses_as_name_only_no_version_pin() {
+        // Corepack/pnpm accept a URL/git reference in the version slot
+        // (`pnpm@https://…`) meaning "fetch this artifact" — there is no semver
+        // to pin. nub treats it as name-only so the spec never reaches the
+        // semver resolver (which aborted the run on the leading 'h').
+        for spec in [
+            "pnpm@https://github.com/pnpm/pnpm",
+            "pnpm@git+https://github.com/pnpm/pnpm.git",
+            "yarn@git@github.com:yarnpkg/berry.git",
+            "pnpm@file:../local-pnpm.tgz",
+        ] {
+            let pin = parse_spec(spec).unwrap_or_else(|e| panic!("{spec} should parse: {e}"));
+            assert_eq!(
+                pin.version, None,
+                "{spec} carries no version pin (URL reference)"
+            );
+        }
+
+        // A normal exact pin and the Corepack hash suffix are NOT URLs and keep
+        // their verbatim version — the URL guard must not swallow them.
+        assert_eq!(
+            parse_spec("pnpm@9.1.0").unwrap().version.as_deref(),
+            Some("9.1.0")
+        );
+        assert_eq!(
+            parse_spec("yarn@4.2.2+sha512.abc")
+                .unwrap()
+                .version
+                .as_deref(),
+            Some("4.2.2+sha512.abc")
         );
     }
 

--- a/tests/pnpm-conformance/allowlist.txt
+++ b/tests/pnpm-conformance/allowlist.txt
@@ -43,7 +43,6 @@ throws error if pnpm tools dir is corrupt
 install should not fail if the used pnpm version does not satisfy
 install should fail if the project requires a different package manager
 install should not fail for packageManager field with hash
-install should not fail for packageManager field with url
 some commands should not fail if the required package manager is not pnpm
 self-update updates the packageManager field
 

--- a/vendor/aube/crates/aube-store/src/lib.rs
+++ b/vendor/aube/crates/aube-store/src/lib.rs
@@ -103,13 +103,28 @@ impl Store {
     /// rest of aube expects them.
     pub fn with_root(root: PathBuf) -> Result<Self, Error> {
         let cache_dir = dirs::cache_dir().ok_or(Error::NoHome)?;
+        Ok(Self::with_root_and_cache_inner(root, cache_dir))
+    }
+
+    /// Open the store with both root and cache dir supplied explicitly.
+    /// Unlike [`with_root`] / [`default_location`] this never resolves a
+    /// HOME/XDG path of its own, so it cannot fail with [`Error::NoHome`]
+    /// — the caller resolves both paths (including any graceful `$TMPDIR`
+    /// fallback when no HOME is set). This is the path the embedded install
+    /// pipeline uses so a configured `storeDir` is honored even when the
+    /// environment has no HOME (a stripped test env or a minimal container).
+    pub fn with_root_and_cache(root: PathBuf, cache_dir: PathBuf) -> Result<Self, Error> {
+        Ok(Self::with_root_and_cache_inner(root, cache_dir))
+    }
+
+    fn with_root_and_cache_inner(root: PathBuf, cache_dir: PathBuf) -> Self {
         let store = Self {
             root,
             cache_dir,
             fast_path: Arc::new(AtomicBool::new(false)),
         };
         store.migrate_legacy_index_dir();
-        Ok(store)
+        store
     }
 
     /// Open the store at a specific path (cache dir derived from store root).
@@ -359,6 +374,22 @@ mod tests {
             cache_dir,
             fast_path: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    #[test]
+    fn with_root_and_cache_never_needs_home() {
+        // The embedded install pipeline resolves both the store root and the
+        // cache dir itself (with a $TMPDIR fallback) and hands them in, so a
+        // configured storeDir is honored even with no HOME in the env — e.g.
+        // pnpm's own test harness strips HOME. `with_root`/`default_location`
+        // would have aborted with `NoHome`; this ctor must not.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("store/v1/files");
+        let cache_dir = tmp.path().join("cache");
+        let store = Store::with_root_and_cache(root.clone(), cache_dir.clone())
+            .expect("with_root_and_cache must not require HOME");
+        assert_eq!(store.root(), root);
+        assert_eq!(store.index_dir(), tmp.path().join("store/v1/index"));
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/settings_context.rs
+++ b/vendor/aube/crates/aube/src/commands/settings_context.rs
@@ -237,15 +237,29 @@ pub(crate) fn ensure_registry_auth_for_package(
 /// across versions of aube and never collides with a pnpm store rooted
 /// at the same path.
 pub(crate) fn open_store(cwd: &std::path::Path) -> miette::Result<aube_store::Store> {
-    if let Some(custom) = resolved_store_dir(cwd) {
-        aube_store::Store::with_root(custom.join("v1").join("files"))
-            .into_diagnostic()
-            .wrap_err("failed to open store")
-    } else {
-        aube_store::Store::default_location()
-            .into_diagnostic()
-            .wrap_err("failed to open store")
-    }
+    // The cache dir is resolved through `resolved_cache_dir`, which (a) honors a
+    // configured `cacheDir` (`.npmrc` / `AUBE_CACHE_DIR`) and (b) carries a
+    // `$TMPDIR/aube` fallback when no HOME/XDG is set. The store ctor
+    // (`with_root`/`default_location`) instead used `dirs::cache_dir()`
+    // directly: it ignored a configured `cacheDir` and hard-failed with
+    // `NoHome` when it couldn't locate one, so an install with HOME stripped
+    // from the env (e.g. pnpm's own test harness, or a minimal CI container)
+    // errored out even when a concrete `storeDir` was configured. Two latent
+    // bugs in one: this aligns the store-open with the packument-cache helper
+    // (`packument_cache_dir`, which already honored `cacheDir`) — they were
+    // split-brained — AND removes the spurious `NoHome` abort.
+    let cache_dir = resolved_cache_dir(cwd);
+    let root = match resolved_store_dir(cwd) {
+        Some(custom) => custom.join("v1").join("files"),
+        // No configured `storeDir`: the aube-owned default under XDG/HOME, or a
+        // `$TMPDIR`-rooted store when neither is available (matches the cache
+        // fallback above rather than aborting the install).
+        None => aube_store::dirs::store_dir()
+            .unwrap_or_else(|| std::env::temp_dir().join("aube").join("store/v1/files")),
+    };
+    aube_store::Store::with_root_and_cache(root, cache_dir)
+        .into_diagnostic()
+        .wrap_err("failed to open store")
 }
 
 /// Resolve the configured `storeDir` for `cwd`, returning `None` if


### PR DESCRIPTION
Two pnpm-conformance fixes surfaced by the v10.15.1 conformance harness spike.

## `packageManager` URL form no longer crashes the PM shim

A project pinning a URL/git reference instead of a version — `packageManager: "pnpm@https://github.com/pnpm/pnpm"` — made nub's pnpm-identity shim feed the URL to the semver resolver and abort the run with `unexpected character 'h'`. Corepack and pnpm both treat a URL value as "no version pin" (corepack downloads the referenced artifact; pnpm does not version-switch). `parse_spec` now recognizes a URL/git reference in the version slot (`https://…`, `git+…`, `git@…`) and treats the field as name-only, falling through to the user's PM on PATH / a dynamic default — matching both tools. Normal exact pins, dist-tags, ranges, and the Corepack `+sha512.…` hash suffix are untouched.

The conformance test `install should not fail for packageManager field with url` now passes; its allowlist entry is removed.

## Store open no longer requires HOME when `storeDir` is configured

`Store::with_root` / `default_location` resolved the store's cache directory from `$XDG_CACHE_HOME`/`$HOME` via `dirs::cache_dir()` and hard-failed with `Error::NoHome` when neither is set — even when a concrete `storeDir` is configured. So `nub install` in an environment with HOME stripped from the env (a minimal container, or pnpm's own test harness, which keeps only `PATH`/`COLORTERM`/`APPDATA`) crashed with `failed to open store: HOME environment variable not set` after already scaffolding the manifest. The store open now resolves the cache dir through `resolved_cache_dir` and the store root through the configured `storeDir` (else the platform default, else a `$TMPDIR` fallback), via a new `Store::with_root_and_cache(root, cache_dir)` constructor.

This fixes two latent bugs in one. Besides removing the spurious `NoHome` abort, `resolved_cache_dir` honors a configured `cacheDir` (`.npmrc` / `AUBE_CACHE_DIR`), which `dirs::cache_dir()` ignored — so the store's packument/index cache now lands under a configured `cacheDir` instead of always under `~/.cache`. That aligns the store-open path with the `packument_cache_dir` helper, which already honored `cacheDir` (the two were split-brained). For a user with HOME set and **no** `cacheDir` configured, behavior is byte-identical.

## Scope

Both changes are isolated and default-preserving. The `vendor/aube` change is a justified latent-bug-fix: standalone aube's behavior is unchanged when HOME is set; only the previously-aborting no-HOME path now degrades gracefully, consistent with the rest of the engine. The sha256 fail-closed pin-hash path and the global-package layout are untouched.

Each fix carries a focused unit test. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean for the touched crates; the conformance run stays green (0 surprise, 0 stale-allow).

Refs the pnpm-conformance work.

https://claude.ai/code/session_01YRvztkcr4fzfg9rD5edUwa
