### PR TITLE
ci: bump Homebrew tap formula on release

### DIFF
--- a/.github/scripts/gen-homebrew-formula.sh
+++ b/.github/scripts/gen-homebrew-formula.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # Usage: gen-homebrew-formula.sh <version> <output-path>
 #   <version>     release version without the leading v (e.g. 0.1.14)
 #   <output-path> where to write nub.rb
-# Requires: gh (authed to read nubjs/nub releases), curl.
+# Requires: gh (authed to read nubjs/nub releases).
 
 VERSION="${1:?usage: gen-homebrew-formula.sh <version> <output-path>}"
 OUT="${2:?usage: gen-homebrew-formula.sh <version> <output-path>}"

--- a/.github/scripts/gen-homebrew-formula.sh
+++ b/.github/scripts/gen-homebrew-formula.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regenerate the Homebrew formula for nubjs/homebrew-tap from a published release.
+#
+# Fills VERSION + the four GNU/macOS sha256s into Formula/nub.rb. The sha256s are
+# READ from the release's own `.sha256` sidecar assets (the same bytes the release
+# job uploaded) rather than recomputed, so this can never disagree with what was
+# shipped. Homebrew targets macOS (arm/intel) + Linux GLIBC (arm/intel) only — the
+# musl tarballs and the win32 .zip are not Homebrew-installable and are omitted.
+#
+# Usage: gen-homebrew-formula.sh <version> <output-path>
+#   <version>     release version without the leading v (e.g. 0.1.14)
+#   <output-path> where to write nub.rb
+# Requires: gh (authed to read nubjs/nub releases), curl.
+
+VERSION="${1:?usage: gen-homebrew-formula.sh <version> <output-path>}"
+OUT="${2:?usage: gen-homebrew-formula.sh <version> <output-path>}"
+TAG="v${VERSION}"
+REPO="nubjs/nub"
+
+# Read a sha256 out of a release `.sha256` sidecar asset. The sidecar is
+# `sha256sum` format (`<hex>  <name>`); take the first field. Fail loud if the
+# asset is absent or the value isn't a 64-char hex digest — a bad formula must
+# not be committed to the tap.
+sidecar_sha256() {
+  local target="$1" tmp sha
+  tmp="$(mktemp)"
+  if ! gh release download "$TAG" --repo "$REPO" \
+        --pattern "nub-${target}.tar.gz.sha256" --output "$tmp" --clobber; then
+    echo "::error::could not download nub-${target}.tar.gz.sha256 from $REPO@$TAG" >&2
+    rm -f "$tmp"
+    exit 1
+  fi
+  sha="$(awk '{print $1}' "$tmp")"
+  rm -f "$tmp"
+  if [[ ! "$sha" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "::error::nub-${target}.tar.gz.sha256 did not contain a valid sha256 (got: '$sha')" >&2
+    exit 1
+  fi
+  printf '%s' "$sha"
+}
+
+SHA_DARWIN_ARM="$(sidecar_sha256 darwin-arm64)"
+SHA_DARWIN_X64="$(sidecar_sha256 darwin-x64)"
+SHA_LINUX_ARM="$(sidecar_sha256 linux-arm64)"
+SHA_LINUX_X64="$(sidecar_sha256 linux-x64)"
+
+BASE="https://github.com/${REPO}/releases/download/${TAG}"
+
+cat > "$OUT" <<EOF
+class Nub < Formula
+  desc "Fast TypeScript runtime and package manager that augments Node"
+  homepage "https://github.com/nubjs/nub"
+  version "${VERSION}"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "${BASE}/nub-darwin-arm64.tar.gz"
+      sha256 "${SHA_DARWIN_ARM}"
+    end
+    on_intel do
+      url "${BASE}/nub-darwin-x64.tar.gz"
+      sha256 "${SHA_DARWIN_X64}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "${BASE}/nub-linux-arm64.tar.gz"
+      sha256 "${SHA_LINUX_ARM}"
+    end
+    on_intel do
+      url "${BASE}/nub-linux-x64.tar.gz"
+      sha256 "${SHA_LINUX_X64}"
+    end
+  end
+
+  def install
+    # The release archive is a tree (bin/nub, bin/nubx, runtime/), not a bare
+    # binary: nub loads runtime/ (preload + vendored polyfills + native addon)
+    # relative to the real binary, so the whole tree must stay together. Install
+    # it into libexec and symlink the executables onto PATH. Plain symlinks (no
+    # wrapper script) so each call execs the native binary with zero overhead;
+    # nub canonicalizes current_exe() to find runtime/ beside the real binary.
+    libexec.install Dir["*"]
+    bin.install_symlink libexec/"bin/nub"
+    bin.install_symlink libexec/"bin/nubx"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/nub --version")
+
+    # Prove runtime/ was installed correctly: a bare-binary install passes
+    # --version but cannot transpile TS (it needs runtime/preload).
+    (testpath/"hello.ts").write("const x: string = \"hi nub\";\nconsole.log(x);\n")
+    assert_equal "hi nub", shell_output("#{bin}/nub #{testpath}/hello.ts").strip
+  end
+end
+EOF
+
+echo "✓ wrote $OUT for nub ${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1030,3 +1030,66 @@ jobs:
             echo "--- attempt $attempt failed; retrying in ${DELAY}s ---"
             sleep "$DELAY"
           done
+
+  bump-homebrew-tap:
+    name: Bump Homebrew tap formula
+    # Update the nubjs/homebrew-tap formula to this release. Runs ONLY on a real
+    # tag-push release (never the debug `workflow_dispatch` build-only path) and
+    # AFTER github-release, because it reads the published `.sha256` sidecar
+    # assets from the release this run created.
+    if: github.event_name == 'push'
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the nub repo for the formula generator script.
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      # Push access to nubjs/homebrew-tap is CROSS-REPO, so the default
+      # GITHUB_TOKEN (scoped to nubjs/nub only) cannot push there. A PAT (or
+      # fine-grained token) with contents:write on nubjs/homebrew-tap must be
+      # added as the HOMEBREW_TAP_TOKEN repo secret. If the secret is absent
+      # (empty string), skip the bump rather than fail the release.
+      - name: Check tap token present
+        id: gate
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "${HOMEBREW_TAP_TOKEN:-}" ]; then
+            echo "::warning::HOMEBREW_TAP_TOKEN secret absent — skipping Homebrew tap bump. Add a PAT with contents:write on nubjs/homebrew-tap to enable it."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out the tap
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          repository: nubjs/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Regenerate formula for this release
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          # The generator reads the release's `.sha256` sidecars via `gh`; the
+          # default GITHUB_TOKEN can read nubjs/nub releases.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          bash .github/scripts/gen-homebrew-formula.sh "$VERSION" homebrew-tap/Formula/nub.rb
+
+      - name: Commit and push the bump
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: homebrew-tap
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- Formula/nub.rb; then
+            echo "Formula already at v$VERSION — nothing to commit."
+            exit 0
+          fi
+          git add Formula/nub.rb
+          git commit -m "nub: update formula to v$VERSION"
+          git push

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ curl -fsSL https://nubjs.com/install.sh | bash
 # Windows (PowerShell)
 irm https://nubjs.com/install.ps1 | iex
 
+# Homebrew (macOS / Linux)
+brew install nubjs/tap/nub
+
 # Or via npm (pnpm / yarn global add work too)
 npm install -g --ignore-scripts=false @nubjs/nub
 ```

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -370,7 +370,7 @@ Same as installing. Nub and Node version independently: Nub resolves the Node yo
 
 ## Is there a curl install script?
 
-Yes. On macOS and Linux, `curl -fsSL https://nubjs.com/install.sh | bash`; on Windows, `powershell -c "irm https://nubjs.com/install.ps1 | iex"`. Both drop a native binary into `~/.nub` and put it on your `PATH`. If you'd rather go through your package manager, `npm install -g --ignore-scripts=false @nubjs/nub` (or `pnpm add -g` / `yarn global add`) does the same thing.
+Yes. On macOS and Linux, `curl -fsSL https://nubjs.com/install.sh | bash`; on Windows, `powershell -c "irm https://nubjs.com/install.ps1 | iex"`. Both drop a native binary into `~/.nub` and put it on your `PATH`. If you'd rather go through your package manager, `npm install -g --ignore-scripts=false @nubjs/nub` (or `pnpm add -g` / `yarn global add`) does the same thing, and on macOS and Linux `brew install nubjs/tap/nub` works too.
 
 ## Does it have a dev server?
 

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -43,7 +43,13 @@ There is no new runtime to adopt and no lock-in: every augmentation rides on Nod
 npm install -g --ignore-scripts=false @nubjs/nub
 ```
 
-Both `pnpm add -g @nubjs/nub` and `yarn global add @nubjs/nub` work equivalently. That installs the Rust binary plus the platform-specific N-API addons, and puts `nub` and `nubx` on your `PATH`. In CI, swap `actions/setup-node` for the [setup-nub action](/docs/setup-nub):
+Both `pnpm add -g @nubjs/nub` and `yarn global add @nubjs/nub` work equivalently. That installs the Rust binary plus the platform-specific N-API addons, and puts `nub` and `nubx` on your `PATH`. On macOS and Linux, Homebrew works too:
+
+```bash
+brew install nubjs/tap/nub
+```
+
+In CI, swap `actions/setup-node` for the [setup-nub action](/docs/setup-nub):
 
 ```diff
 - - uses: actions/setup-node@v4


### PR DESCRIPTION
Adds Homebrew distribution for nub via a custom tap (\`nubjs/homebrew-tap\`, already created + populated) and automates per-release formula bumps from the release workflow.

## What this PR does

- **New CI job \`bump-homebrew-tap\`** in \`.github/workflows/release.yml\`. After \`github-release\` completes on a real tag-push release, it checks out \`nubjs/homebrew-tap\`, regenerates \`Formula/nub.rb\` for the new version, commits, and pushes.
- **New script \`.github/scripts/gen-homebrew-formula.sh\`** — templated formula generator. It reads the four GNU/macOS \`.sha256\` sidecar assets from the release (\`darwin-arm64\`, \`darwin-x64\`, \`linux-arm64\`, \`linux-x64\`) rather than recomputing them, so the formula can never disagree with the shipped tarballs. musl tarballs and the win32 \`.zip\` are omitted (not Homebrew-installable).
- **Docs**: Homebrew install note (\`brew install nubjs/tap/nub\`) added to the README install block, the docs landing page, and the FAQ curl-install answer.

## Trigger gating

The job is gated \`if: github.event_name == 'push'\` so it runs ONLY on real \`v*\` tag releases, never the debug \`workflow_dispatch\` build-only path. It also \`needs: github-release\` so the release + its sidecar assets exist before the formula is generated.

## Manual step required (maintainer)

The default \`GITHUB_TOKEN\` is scoped to \`nubjs/nub\` and cannot push cross-repo to \`nubjs/homebrew-tap\`. **Add a repo secret \`HOMEBREW_TAP_TOKEN\`** — a PAT (or fine-grained token) with \`contents:write\` on \`nubjs/homebrew-tap\`. Until it is added, the job skips cleanly (logs a warning, does not fail the release); the tap can be bumped manually by running the generator.

## Verification

The formula was installed, tested, and audited locally on macOS arm64 against v0.1.14:
- \`brew install nubjs/tap/nub\` → \`brew test nub\` (exit 0) → \`brew audit --strict nub\` (exit 0).
- \`nub --version\` reports \`v0.1.14\`; \`nub hello.ts\` transpiles + runs (proves \`runtime/\` is installed via the libexec tree, not a bare binary).
- The generator script reproduces the hand-verified formula byte-for-byte.

The formula uses plain symlinks (\`bin.install_symlink\`), no wrapper script, so \`nub\`/\`nubx\` exec the native binary with zero per-call overhead; nub canonicalizes \`current_exe()\` to find \`runtime/\` beside the real binary.

Infra change, no associated issue.