### PR TITLE
docs: complete Homebrew install-path sweep across remaining surfaces

### DIFF
--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -366,7 +366,7 @@ That installs the Rust binary (via the usual `@<scope>/<platform-arch>` npm dist
 npm install -g --ignore-scripts=false @nubjs/nub@latest
 ```
 
-Same as installing. Nub and Node version independently: Nub resolves the Node your project pins (`.node-version` / `.nvmrc` / `engines.node`) and provisions it if it's missing, falling back to the `node` on your `PATH` only when nothing is pinned. So upgrading Nub does not change your project's Node version, and upgrading Node does not change your Nub version.
+Same as installing — match how you installed: `brew upgrade nub` for a Homebrew install, otherwise re-run your installer. Nub and Node version independently: Nub resolves the Node your project pins (`.node-version` / `.nvmrc` / `engines.node`) and provisions it if it's missing, falling back to the `node` on your `PATH` only when nothing is pinned. So upgrading Nub does not change your project's Node version, and upgrading Node does not change your Nub version.
 
 ## Is there a curl install script?
 

--- a/site/public/start.md
+++ b/site/public/start.md
@@ -42,6 +42,8 @@ If that prints a version, go to step 2. If it's not found, tell the user you'd l
 curl -fsSL https://nubjs.com/install.sh | bash
 # Windows (PowerShell)
 irm https://nubjs.com/install.ps1 | iex
+# Homebrew (macOS / Linux)
+brew install nubjs/tap/nub
 # or via any package manager
 npm install -g @nubjs/nub
 ```

--- a/site/src/components/install-tabs.tsx
+++ b/site/src/components/install-tabs.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useState } from 'react';
 
-type TabId = 'unix' | 'windows' | 'npm';
+type TabId = 'unix' | 'windows' | 'brew' | 'npm';
 
 const TABS: { id: TabId; label: string; command: string }[] = [
   { id: 'unix', label: 'macOS / Linux', command: 'curl -fsSL https://nubjs.com/install.sh | bash' },
   { id: 'windows', label: 'Windows', command: 'powershell -c "irm https://nubjs.com/install.ps1 | iex"' },
+  { id: 'brew', label: 'Homebrew', command: 'brew install nubjs/tap/nub' },
   { id: 'npm', label: 'npm', command: 'npm install -g --ignore-scripts=false @nubjs/nub' },
 ];
 


### PR DESCRIPTION
Follows up #121 (which added the Homebrew line to README, docs/index.mdx, and docs/faq.mdx's curl-script Q) by filling every other surface that lists install methods.

## Surfaces touched
- `site/src/components/install-tabs.tsx` — homepage tabbed install widget: added a **Homebrew** tab (`brew install nubjs/tap/nub`) alongside macOS/Linux, Windows, npm.
- `site/public/start.md` — agent adoption flow install block: added the Homebrew one-liner.
- `site/content/docs/faq.mdx` — "How do I upgrade?": noted `brew upgrade nub` for Homebrew installs (nub already detects the Homebrew channel and defers to `brew upgrade`).

## Audit of #121 surfaces (verified, no fixes needed)
- `README.md`, `site/content/docs/index.mdx`, `site/content/docs/faq.mdx` (curl-script Q) all read correctly and consistently.

## Consistency
Every surface uses the exact string `brew install nubjs/tap/nub` (the `nubjs/tap/` prefix is required — not yet homebrew-core).

## Deliberately left unchanged
- `site/content/docs/docker.mdx`, `site/content/guides/bun-to-nub.mdx`, `site/content/blog/introducing-nub.mdx` — these show npm install inside a **Dockerfile** example, not an install-methods list.
- `site/content/docs/install/index.mdx` — documents the install *engine* (`nub install`), not how to install nub itself.

No issue reference (no closing keyword).