### PR TITLE
githooks: only block AGENT commits to shared main (not the maintainer's terminal)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,20 +1,22 @@
 #!/bin/sh
-# pre-commit hook: block direct commits to the SHARED main checkout.
+# pre-commit hook: block an AGENT commit to the SHARED main checkout.
 #
 # WHY: the shared `main` working tree must stay ALWAYS fast-forwardable to
-# origin/main. A commit made directly in the shared tree creates a local commit
-# that is NOT on origin; on a stale base this DIVERGES the shared tree from
-# origin/main, so `git pull --ff-only` then fails and the tree silently rots
-# (AGENTS.md "Default to a PR flow" + its no-direct-shared-commit corollary).
-# Worktrees can't cause this — they branch off origin/main fresh and land via
-# push, so the shared tree only ever fast-forwards. This guard makes the rule
-# STRUCTURAL: tracked-file commits must go through a worktree.
+# origin/main, so tracked-file work lands via a WORKTREE (branch off origin/main,
+# push, PR) — never as a direct commit on the shared tree (AGENTS.md "Default to
+# a PR flow" + its no-direct-shared-commit corollary). But the maintainer
+# legitimately makes one-off commits directly to main from his own terminal, and
+# this guard must NEVER block him. The distinguishing signal: any Claude Code /
+# dispatched-agent context has CLAUDECODE / AI_AGENT SET in the environment; a
+# bare human terminal has them UNSET. So we block ONLY automation commits to the
+# shared main tree — "agents can't, the maintainer can." Worktrees are always
+# fine (they can only fast-forward the shared tree).
 #
 # Detection: in the shared clone `git-dir` == `git-common-dir` (both the main
 # .git); in a linked worktree git-dir is .git/worktrees/<name> and DIFFERS from
-# the common-dir. Only the shared-clone + on-`main` combination is the footgun;
-# anything else (a worktree, a deliberate non-main branch, detached HEAD) is
-# allowed. Escape hatch NUB_ALLOW_SHARED_COMMIT=1 for a sanctioned emergency.
+# the common-dir. No fetch / no remote-ref dependency — the automation marker is
+# a pure-env check, so this works offline. Escape hatch NUB_ALLOW_SHARED_COMMIT=1
+# for a sanctioned exception.
 #
 # core.hooksPath is .githooks (shared across all worktrees), so this is active
 # everywhere without per-clone setup.
@@ -24,28 +26,32 @@ if [ "${NUB_ALLOW_SHARED_COMMIT:-}" = "1" ]; then
   exit 0
 fi
 
+# Only automation is gated. A human terminal has neither marker set → allow.
+[ -n "${CLAUDECODE:-}" ] || [ -n "${AI_AGENT:-}" ] || exit 0
+
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
 
 # A linked worktree (git-dir != common-dir) is the sanctioned landing path.
 [ "$GIT_DIR" = "$COMMON_DIR" ] || exit 0
 
-# Shared clone: allow unless on `main`. A detached HEAD or any non-main branch
-# is a deliberate state, not the footgun this guard prevents.
+# Shared clone: only `main` is the footgun surface. A detached HEAD or any
+# non-main branch is a deliberate state, not what this guard prevents.
 BRANCH=$(git symbolic-ref --quiet --short HEAD 2>/dev/null) || exit 0
 [ "$BRANCH" = "main" ] || exit 0
 
 cat >&2 <<'EOF'
-pre-commit: blocked a direct commit to the SHARED main tree.
+pre-commit: blocked an AGENT commit to the SHARED main tree.
 
-Commits to tracked files must land via a WORKTREE (which branches off
-origin/main fresh and pushes), so the shared tree only ever fast-forwards —
-a direct commit here would diverge it from origin/main and break `git pull`.
+Land it via a worktree (branches off origin/main, pushes, opens a PR) so the
+shared tree only ever fast-forwards:
 
-  nub scripts/new-worktree.ts <slug>     # create a worktree, work + push there
-  # then open a PR; the orchestrator merges.
+  nub scripts/new-worktree.ts <slug>     # work + push there, then open a PR
 
-Genuine emergency (sanctioned direct commit):
+Sanctioned exception:
   NUB_ALLOW_SHARED_COMMIT=1 git commit ...
+
+(Your own terminal is never blocked; this only fires inside Claude Code
+automation.)
 EOF
 exit 1


### PR DESCRIPTION
PR #122's pre-commit guard blocked **every** direct commit to the shared main checkout — including the maintainer's legitimate one-off terminal commits.

This narrows the block to automation only. A Claude Code / dispatched-agent context has `CLAUDECODE` / `AI_AGENT` set in the environment; a bare human terminal has neither. The hook now blocks only when running under automation on the shared main tree:

- Agent commit to shared `main` → blocked; land it via a worktree.
- Maintainer's own terminal (no markers) → never blocked.
- Worktree, non-main branch, detached HEAD → always allowed.
- `NUB_ALLOW_SHARED_COMMIT=1` → sanctioned bypass with a stderr note.

Pure-env check, no fetch, works offline. The earlier stale-base approach on this branch was dropped in favor of the simpler, intent-matching automation marker.

Refs #122