### PR TITLE
fix(homebrew): make brew test Node-free

### DIFF
--- a/.github/scripts/gen-homebrew-formula.sh
+++ b/.github/scripts/gen-homebrew-formula.sh
@@ -92,10 +92,12 @@ class Nub < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/nub --version")
 
-    # Prove runtime/ was installed correctly: a bare-binary install passes
-    # --version but cannot transpile TS (it needs runtime/preload).
-    (testpath/"hello.ts").write("const x: string = \"hi nub\";\nconsole.log(x);\n")
-    assert_equal "hi nub", shell_output("#{bin}/nub #{testpath}/hello.ts").strip
+    # Prove the runtime tree (preload + vendored polyfills + native addon) was
+    # installed alongside the binary — a bare-binary install would be missing it.
+    # Do NOT run a transpile here: \`brew test\` runs on a clean machine with no Node
+    # on PATH, and nub augments the user's Node rather than bundling one.
+    assert_path_exists libexec/"runtime/preload.mjs"
+    assert_path_exists libexec/"runtime/addons/nub-native.node"
   end
 end
 EOF


### PR DESCRIPTION
## Bug

The Homebrew formula's `test do` block ran a TypeScript transpile (`nub hello.ts`) to prove the `runtime/` tree was installed. That requires Node on PATH — nub augments the user's Node and deliberately doesn't bundle one. On a clean Linuxbrew machine with no Node (the normal `brew test` / tap-CI / `brew audit` environment), the assertion FAILS.

Confirmed via clean-Docker linuxbrew: install PASS, symlink→Cellar/libexec PASS, `nub --version` PASS, `nub upgrade`→defers to brew PASS; only `brew test`'s transpile assertion failed (no Node in a clean image).

## Fix

Replace the transpile assertion with a Node-free path-existence check that still proves the `runtime/` tree was installed (a bare-binary install would be missing it):

```ruby
assert_path_exists libexec/"runtime/preload.mjs"
assert_path_exists libexec/"runtime/addons/nub-native.node"
```

Paths confirmed present in the v0.1.14 release tarballs. The `--version` assertion is kept.

This script is the source of truth — the live tap formula (`nubjs/homebrew-tap/Formula/nub.rb`) is regenerated from it and updated to match. Verified with a clean-Docker `brew test` (no Node) passing.