### PR TITLE
ci(docker): fix startup_failure in build leg (unquoted YAML scalar)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,7 +103,8 @@ jobs:
         run: docker run --rm nub-local:${{ matrix.variant }} /usr/local/bin/smoke.sh
 
       - name: Report image size
-        run: docker image inspect nub-local:${{ matrix.variant }} --format '${{ matrix.variant }} size: {{.Size}} bytes'
+        run: |
+          docker image inspect nub-local:${{ matrix.variant }} --format '${{ matrix.variant }} size: {{.Size}} bytes'
 
       # ── PUBLISH (release tags only, and only once a registry is configured) ───
       # MAINTAINER TODO: set the DOCKER_IMAGE repo variable to enable this. With it

--- a/site/content/docs/docker.mdx
+++ b/site/content/docs/docker.mdx
@@ -8,7 +8,7 @@ Nub augments the Node already in your image — it is not a separate runtime. Th
 ## Official images
 
 ```dockerfile
-FROM nubjs/nub
+FROM ghcr.io/nubjs/nub
 COPY --chown=node:node . .
 RUN nub install
 CMD ["nub", "run", "start"]
@@ -26,7 +26,7 @@ Two variants, both on the current Node release line, digest-pinned and published
 Run a TypeScript file directly — the entrypoint passes any non-command argument to `nub`:
 
 ```bash
-docker run --rm -v "$PWD:/app" nubjs/nub script.ts
+docker run --rm -v "$PWD:/app" ghcr.io/nubjs/nub script.ts
 ```
 
 Signals reach the runtime: `docker stop` delivers `SIGTERM` to `nub`, which forwards it to the Node process for a clean shutdown. The container runs as the non-root `node` user (uid 1000); when you bind-mount a directory that `nub install` must write into, run with `--user "$(id -u)"` so the writes land with your host ownership.


### PR DESCRIPTION
## Root cause

The \`Docker image\` workflow (\`.github/workflows/docker.yml\`) "Build + smoke" leg has been **RED on every push to main** since it merged (#108) — as a **startup_failure**, not a step failure. The failed runs show **0 jobs and 0s duration** (\`created_at == updated_at == run_started_at\`, empty \`billable\`), the signature of GitHub rejecting a workflow at parse time before scheduling any job.

The defect is on the "Report image size" step:

\`\`\`yaml
run: docker image inspect nub-local:${{ matrix.variant }} --format '${{ matrix.variant }} size: {{.Size}} bytes'
\`\`\`

\`run:\` here is an **unquoted YAML flow scalar**, and the \`: \` inside \`size: {{.Size}}\` parses as a nested mapping value — invalid YAML in that context. \`actionlint\` pinpoints it:

\`\`\`
docker.yml:106:102: could not parse as YAML: mapping values are not allowed in this context
\`\`\`

This is **release-critical**: the same \`build\` job is what the release \`v*\` publish leg runs to build and push the images to GHCR (\`ghcr.io/nubjs/nub\`), so a parse-rejected workflow breaks the v0.2 Docker publish too.

## Fix

Wrap the command in a YAML \`|\` block scalar, so the colon is plain text — no quote-juggling around the existing single-quoted \`--format\`. Minimal, no behavior change.

Also corrects the published-image references in \`site/content/docs/docker.mdx\` from the Docker Hub short form (\`nubjs/nub\`) to the configured GHCR registry (\`ghcr.io/nubjs/nub\`) on the two image-use examples (\`FROM\` and \`docker run\`); the \`@nubjs/nub\` npm-package and \`node:26-*\` base lines are untouched.

## Verification (local)

- \`actionlint .github/workflows/docker.yml\` → clean (exit 0).
- \`docker build -f docker/Dockerfile.slim --build-arg NUB_VERSION=latest .\` → green; in-build \`nub --version\` → v0.1.14.
- \`docker build -f docker/Dockerfile.alpine --build-arg NUB_VERSION=latest .\` → green.
- Full in-image smoke (\`docker run --rm <img> /usr/local/bin/smoke.sh\`) on **both** variants → all checks pass (\`nub --version\`, TS run, \`nub install\` + require()).

No version-sequencing issue: push/PR builds install \`@nubjs/nub@latest\` (0.1.14, published), so the build works pre-release; the release leg pins the tag version.

This is a CI fix and resolves no tracked issue, so no closing keyword.