### PR TITLE
fix(pm): resolve yarn-berry catalogs instead of erroring

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -804,15 +804,17 @@ fn apply_config_scope(
     Ok(())
 }
 
-/// Does the active PM honor `catalog:` specifiers? pnpm@9+ and bun@1.2+
-/// implement catalogs; npm and yarn do not. nub identity honors catalogs
-/// (an un-branded cross-tool field, like `workspaces`). aube resolves both
-/// dialects: pnpm's `pnpm.catalog(s)` / `pnpm-workspace.yaml` AND bun's
-/// `workspaces.catalog(s)` in `package.json` (see aube's `discover_catalogs`),
-/// so honoring bun here resolves the real catalog rather than mis-failing a
-/// project that works under bun.
+/// Does the active PM honor `catalog:` specifiers? pnpm@9+, bun@1.2+, and
+/// yarn-berry (v2+) implement catalogs; npm and yarn-classic (v1) do not. nub
+/// identity honors catalogs (an un-branded cross-tool field, like
+/// `workspaces`). aube resolves every dialect: pnpm's `pnpm.catalog(s)` /
+/// `pnpm-workspace.yaml`, bun's `workspaces.catalog(s)` in `package.json`, and
+/// yarn's `catalog(s)` in `.yarnrc.yml` (see aube's `discover_catalogs`), so
+/// honoring a PM here resolves the real catalog rather than mis-failing a
+/// project that works under that PM.
 fn role_honors_catalog(role: config_scope::Role, major: Option<u64>, minor: Option<u64>) -> bool {
     use config_scope::Role;
+    let _ = minor;
     match role {
         // pnpm gained catalogs in 9.0.
         Role::Pnpm => major.map(|m| m >= 9).unwrap_or(true),
@@ -823,8 +825,18 @@ fn role_honors_catalog(role: config_scope::Role, major: Option<u64>, minor: Opti
             (Some(m), None) => m >= 2,
             _ => true,
         },
+        // yarn shipped catalogs in 4.10.0 (catalog plugin bundled by default).
+        // We honor them on ALL yarn-berry (v2+) rather than gating on a parsed
+        // 4.10: nub's yarn-minor detection isn't granular enough to reliably
+        // distinguish 4.10 from earlier berry, and resolving a `catalog:` on an
+        // older berry costs nothing — a project only carries `catalog:`
+        // specifiers (+ a `.yarnrc.yml` catalog block) if it's actually using
+        // the feature, so there is nothing to mis-resolve. Classic yarn v1 has
+        // no catalogs, so a `1.x` pin correctly refuses. Absent/unparseable
+        // version → assume modern berry and honor (the "assume modern" default).
+        Role::Yarn => major.map(|m| m >= 2).unwrap_or(true),
         Role::Nub => true,
-        Role::Npm | Role::Yarn => false,
+        Role::Npm => false,
     }
 }
 
@@ -901,8 +913,8 @@ fn catalog_unsupported_error(role: config_scope::Role, spec: &str) -> anyhow::Er
     let pm = role.display();
     anyhow::anyhow!(
         "nub: `catalog:` specifier ({spec}) is not supported — this project uses {pm}, \
-         which doesn't implement catalogs (pnpm@9+ and bun@1.2+ do). Inline the version, or switch \
-         the project to a PM that supports catalogs (`nub pm use pnpm`)."
+         which doesn't implement catalogs (pnpm@9+, bun@1.2+, and yarn-berry do). Inline the \
+         version, or switch the project to a PM that supports catalogs (`nub pm use pnpm`)."
     )
 }
 
@@ -3023,8 +3035,53 @@ mod tests {
         // ...but a catalog-honoring bun does not refuse it.
         assert!(role_honors_catalog(Role::Bun, Some(1), Some(2)));
 
-        // npm / yarn never honor catalogs.
+        // npm never honors catalogs; classic yarn v1 doesn't either.
         assert!(!role_honors_catalog(Role::Npm, Some(10), Some(0)));
-        assert!(!role_honors_catalog(Role::Yarn, Some(4), Some(0)));
+        assert!(!role_honors_catalog(Role::Yarn, Some(1), Some(22)));
+    }
+
+    #[test]
+    fn yarn_berry_honors_catalogs_classic_v1_does_not() {
+        // yarn shipped catalogs in 4.10.0, declared in `.yarnrc.yml` with the
+        // same `catalog:`/`catalogs:` shape as pnpm; aube discovers them. We
+        // honor catalogs on ALL yarn-berry (v2+) rather than gating on a parsed
+        // 4.10 — nub's yarn-minor detection isn't reliable enough to split 4.10
+        // from earlier berry, and a `catalog:` only appears if the project uses
+        // the feature, so there's nothing to mis-resolve. Classic yarn v1 has no
+        // catalogs and must still refuse.
+        use config_scope::Role;
+
+        assert!(
+            role_honors_catalog(Role::Yarn, Some(4), Some(10)),
+            "yarn 4.10 (berry) implements catalogs"
+        );
+        assert!(
+            role_honors_catalog(Role::Yarn, Some(4), Some(0)),
+            "yarn 4.x (berry) honors — minor not gated"
+        );
+        assert!(
+            role_honors_catalog(Role::Yarn, Some(2), None),
+            "yarn 2 (berry) honors — all berry honors"
+        );
+        assert!(
+            role_honors_catalog(Role::Yarn, None, None),
+            "an undeclared/unparseable yarn version assumes modern berry and honors"
+        );
+        assert!(
+            !role_honors_catalog(Role::Yarn, Some(1), Some(22)),
+            "classic yarn v1 never had catalogs and must refuse"
+        );
+
+        // A yarn-berry fixture with a real `catalog:` ref: the specifier is
+        // detected, but a berry identity does not refuse it. (The catalog VALUES
+        // live in `.yarnrc.yml`, resolved by aube's `discover_catalogs`; here we
+        // only assert the per-role gate, not the resolution.)
+        let d = workspace(&[(
+            "package.json",
+            r#"{"name":"root","packageManager":"yarn@4.10.0","dependencies":{"is-odd":"catalog:"}}"#,
+        )]);
+        let m = root_manifest(d.path());
+        assert!(first_catalog_specifier(&m, d.path()).is_some());
+        assert!(role_honors_catalog(Role::Yarn, Some(4), Some(10)));
     }
 }

--- a/vendor/aube/crates/aube/src/commands/catalog_discovery.rs
+++ b/vendor/aube/crates/aube/src/commands/catalog_discovery.rs
@@ -39,6 +39,32 @@ fn merge_manifest_catalogs(out: &mut CatalogMap, manifest: &aube_manifest::Packa
     merge_catalog_source(out, &manifest.pnpm_catalog(), &manifest.pnpm_catalogs());
 }
 
+/// Read the yarn-style `catalog:` / `catalogs:` blocks out of the
+/// `.yarnrc.yml` at `dir` (if one exists) and merge them into `out`.
+///
+/// Yarn shipped catalogs in 4.10.0 (the catalog plugin is bundled by
+/// default from that release). The on-disk shape is byte-identical to
+/// pnpm's — top-level `catalog:` for the default catalog and `catalogs:`
+/// for named ones — so the same `WorkspaceConfig` deserializer reads it;
+/// only the file differs (`.yarnrc.yml` rather than `pnpm-workspace.yaml`).
+/// A malformed or catalog-less `.yarnrc.yml` is a no-op: `.yarnrc.yml`
+/// carries unrelated yarn config (registries, plugins, …), and a parse
+/// failure must not abort catalog discovery for the rest of the sources.
+fn merge_yarnrc_catalogs(out: &mut CatalogMap, dir: &std::path::Path) {
+    let path = dir.join(".yarnrc.yml");
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    if content.trim().is_empty() {
+        return;
+    }
+    let Ok(cfg) = aube_manifest::parse_yaml::<aube_manifest::WorkspaceConfig>(&path, content)
+    else {
+        return;
+    };
+    merge_catalog_source(out, &cfg.catalog, &cfg.catalogs);
+}
+
 /// Discover catalog entries from every supported source and merge them
 /// into a single map for the resolver.
 ///
@@ -52,7 +78,10 @@ fn merge_manifest_catalogs(out: &mut CatalogMap, manifest: &aube_manifest::Packa
 ///    root is the nearest ancestor with either a `pnpm-workspace.yaml` /
 ///    `aube-workspace.yaml` or a `package.json` carrying a `workspaces`
 ///    field — bun / npm / yarn projects use the latter and have no yaml.
-/// 4. `catalog:` / `catalogs:` in the nearest `pnpm-workspace.yaml` /
+/// 4. `catalog:` / `catalogs:` in the `.yarnrc.yml` at the project root
+///    and (when distinct) the workspace root — yarn's catalog feature
+///    (yarn 4.10+), same on-disk shape as pnpm's, different file.
+/// 5. `catalog:` / `catalogs:` in the nearest `pnpm-workspace.yaml` /
 ///    `aube-workspace.yaml` walking up from `project_root`.
 ///
 /// Walking up matters for monorepos where `aube install` runs from a
@@ -86,6 +115,19 @@ pub(crate) fn discover_catalogs(project_root: &std::path::Path) -> miette::Resul
         merge_manifest_catalogs(&mut out, &m);
     }
 
+    // (3b): yarn-style `.yarnrc.yml` catalogs (yarn 4.10+). Read at the
+    // project root and, when distinct, the workspace root — yarn's catalog
+    // is a project-level config that a subpackage install must still see.
+    // Lower precedence than the pnpm/aube workspace yaml below (which never
+    // co-exists with a yarn project in practice, but ordering keeps the
+    // pnpm-native source authoritative if both somehow appear).
+    merge_yarnrc_catalogs(&mut out, project_root);
+    if let Some(dir) = &workspace_root_dir
+        && dir != project_root
+    {
+        merge_yarnrc_catalogs(&mut out, dir);
+    }
+
     // (4): workspace yaml catalogs, highest precedence. Loaded from the
     // walk-up directory when present, else from `project_root`.
     let yaml_dir = workspace_yaml_dir.as_deref().unwrap_or(project_root);
@@ -102,4 +144,53 @@ pub(crate) fn discover_catalogs(project_root: &std::path::Path) -> miette::Resul
 /// [`discover_catalogs`] so every command sees the same merged view.
 pub(crate) fn load_workspace_catalogs(cwd: &std::path::Path) -> miette::Result<CatalogMap> {
     discover_catalogs(cwd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `.yarnrc.yml`'s default + named catalogs (yarn 4.10+) are discovered,
+    /// keyed identically to the pnpm dialect (`default` for the unnamed
+    /// catalog), so the resolver resolves `catalog:` / `catalog:<name>` deps
+    /// in a yarn project without a `pnpm-workspace.yaml` in sight.
+    #[test]
+    fn discovers_yarnrc_default_and_named_catalogs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"y","dependencies":{"react":"catalog:","lodash":"catalog:legacy"}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join(".yarnrc.yml"),
+            "catalog:\n  react: ^18.3.1\ncatalogs:\n  legacy:\n    lodash: ^4.17.21\n",
+        )
+        .unwrap();
+
+        let cats = discover_catalogs(dir.path()).unwrap();
+        assert_eq!(
+            cats.get("default").unwrap().get("react").unwrap(),
+            "^18.3.1"
+        );
+        assert_eq!(
+            cats.get("legacy").unwrap().get("lodash").unwrap(),
+            "^4.17.21"
+        );
+    }
+
+    /// A `.yarnrc.yml` with only non-catalog yarn config (the common case —
+    /// registries, plugins) contributes nothing and never aborts discovery.
+    #[test]
+    fn yarnrc_without_catalogs_is_a_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), r#"{"name":"y"}"#).unwrap();
+        std::fs::write(
+            dir.path().join(".yarnrc.yml"),
+            "nodeLinker: node-modules\nnpmRegistryServer: \"https://registry.npmjs.org\"\n",
+        )
+        .unwrap();
+
+        assert!(discover_catalogs(dir.path()).unwrap().is_empty());
+    }
 }


### PR DESCRIPTION
yarn supports catalogs since 4.10.0, declared in `.yarnrc.yml` with the same `catalog:`/`catalog:<name>` protocol as pnpm — only the file differs. nub previously errored on a `catalog:` specifier under a yarn identity; it now discovers `.yarnrc.yml` catalogs and resolves the specifiers itself.

- Gated on the incumbent being yarn-berry (v2+), not a parsed `>=4.10` version: nub's declarative yarn-version detection can't reliably split 4.10 from earlier berry, and a `catalog:` specifier only appears when the project actually uses the feature. Classic yarn v1 still refuses (no catalogs there).
- No PM binary is invoked for version detection — yarn-berry is read purely from declarative on-disk signals (`packageManager`, `devEngines`, lockfile, `.yarnrc.yml`).
- yarn stays read-only: catalog resolution reads `.yarnrc.yml` and resolves for the install graph; it never writes `yarn.lock`.

Tests: `.yarnrc.yml` default + named catalog discovery (aube); the per-role gate (yarn-berry honors, classic v1 refuses). e2e: `nub install` on a yarn-berry catalog fixture resolves `catalog:` (the old unsupported-catalog error is gone); classic v1 still errors.

Closes #118