### PR TITLE
fix(pm): honor yarn npmMinimalAgeGate + drop fabricated bun trustedDependencies gate

### DIFF
--- a/crates/nub-cli/src/pm_engine/config_scope.rs
+++ b/crates/nub-cli/src/pm_engine/config_scope.rs
@@ -238,12 +238,13 @@ fn honors_namespaced_overrides(role: Role) -> bool {
 }
 
 /// Does the active PM honor Bun's top-level `trustedDependencies` (the
-/// build-script allowlist)? Only bun — and bun@10 DROPPED it (pnpm@10's
-/// approve-builds migration also dropped `trustedDependencies` +
-/// `onlyBuiltDependencies`, and bun followed). `major` is bun's declared
-/// major; undeclared bun is assumed current (honors).
-pub(crate) fn honors_trusted_dependencies(role: Role, major: Option<u64>) -> bool {
-    role == Role::Bun && major.is_none_or(|m| m < 10)
+/// build-script allowlist)? Only bun — at every major. Bun's current line
+/// (1.3.x) still uses `trustedDependencies` for lifecycle-script approval
+/// (bun.com/docs/install/lifecycle; bun source `install/lifecycle.zig` +
+/// `lockfile.zig`), and ships no `onlyBuiltDependencies` / `approve-builds`
+/// migration (zero hits in bun source). No version gate applies.
+pub(crate) fn honors_trusted_dependencies(role: Role) -> bool {
+    role == Role::Bun
 }
 
 /// One graph-shaping field nub dropped because the active PM ignores it,
@@ -463,10 +464,13 @@ mod tests {
     }
 
     #[test]
-    fn bun_10_dropped_trusted_dependencies() {
-        assert!(honors_trusted_dependencies(Role::Bun, Some(9)));
-        assert!(honors_trusted_dependencies(Role::Bun, None));
-        assert!(!honors_trusted_dependencies(Role::Bun, Some(10)));
-        assert!(!honors_trusted_dependencies(Role::Pnpm, None));
+    fn only_bun_honors_trusted_dependencies() {
+        // Bun honors `trustedDependencies` at every major (no version drop —
+        // bun 1.3.x still uses it; see `honors_trusted_dependencies`).
+        assert!(honors_trusted_dependencies(Role::Bun));
+        assert!(!honors_trusted_dependencies(Role::Pnpm));
+        assert!(!honors_trusted_dependencies(Role::Npm));
+        assert!(!honors_trusted_dependencies(Role::Yarn));
+        assert!(!honors_trusted_dependencies(Role::Nub));
     }
 }

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -773,9 +773,9 @@ fn apply_config_scope(
     let (effective, ignored) = config_scope::scope_overrides(role, major, minor, &tagged);
 
     // Register the scoped source as the engine's sole override source, and
-    // the trusted-deps toggle (only bun, only below the major that dropped
-    // it, honors `trustedDependencies`). Both are idempotent OnceLocks.
-    let trusted = config_scope::honors_trusted_dependencies(role, major);
+    // the trusted-deps toggle (only bun honors `trustedDependencies`). Both
+    // are idempotent OnceLocks.
+    let trusted = config_scope::honors_trusted_dependencies(role);
     aube_util::update_engine_context(|c| {
         c.embedder_overrides = Some(effective);
         c.trusted_dependencies_honored = trusted;

--- a/vendor/aube/crates/aube-registry/src/config/tests.rs
+++ b/vendor/aube/crates/aube-registry/src/config/tests.rs
@@ -382,6 +382,55 @@ supportedArchitectures:
 }
 
 #[test]
+fn yarnrc_translates_min_age_gate_to_minimum_release_age() {
+    // Yarn's `npmMinimalAgeGate` is a DURATION declared in MINUTES. A unit
+    // suffix is converted to minutes the way Yarn's parseDuration does
+    // (`7d` = 7 * 1440 = 10080 min); a bare number is already minutes; a
+    // sub-minute value rounds UP so it never collapses to 0 (disabling the
+    // gate). `npmPreapprovedPackages` → `minimumReleaseAgeExclude`.
+    let entries = translate_yarnrc_content(
+        "npmMinimalAgeGate: 7d\nnpmPreapprovedPackages:\n  - \"@acme/internal\"\n  - left-pad\n",
+    );
+    let age = entries
+        .iter()
+        .find(|(k, _)| k == "minimumReleaseAge")
+        .map(|(_, v)| v.as_str())
+        .expect("npmMinimalAgeGate must map to minimumReleaseAge");
+    assert_eq!(age, "10080", "7d must convert to 10080 minutes");
+    let exclude = entries
+        .iter()
+        .find(|(k, _)| k == "minimumReleaseAgeExclude")
+        .map(|(_, v)| v.as_str())
+        .expect("npmPreapprovedPackages must map to minimumReleaseAgeExclude");
+    assert_eq!(exclude, "@acme/internal,left-pad");
+
+    // Bare number = minutes (unitless DURATION path).
+    let bare = translate_yarnrc_content("npmMinimalAgeGate: 1440\n");
+    assert_eq!(
+        bare.iter()
+            .find(|(k, _)| k == "minimumReleaseAge")
+            .map(|(_, v)| v.as_str()),
+        Some("1440")
+    );
+
+    // Sub-minute gate rounds up to 1, never 0.
+    let sub = translate_yarnrc_content("npmMinimalAgeGate: 30s\n");
+    assert_eq!(
+        sub.iter()
+            .find(|(k, _)| k == "minimumReleaseAge")
+            .map(|(_, v)| v.as_str()),
+        Some("1")
+    );
+
+    // Unset gate emits no entry (yarn's `1d` default is yarn's, not nub's).
+    let unset = translate_yarnrc_content("nodeLinker: node-modules\n");
+    assert!(
+        unset.iter().all(|(k, _)| k != "minimumReleaseAge"),
+        "an unset npmMinimalAgeGate must not synthesize a minimumReleaseAge entry"
+    );
+}
+
+#[test]
 fn yarnrc_translates_npm_always_auth_top_level_and_per_registry() {
     // Top-level `npmAlwaysAuth` scopes to the default registry; a
     // per-registry `npmRegistries.<url>.npmAlwaysAuth` scopes to that host.

--- a/vendor/aube/crates/aube-registry/src/config/yarnrc.rs
+++ b/vendor/aube/crates/aube-registry/src/config/yarnrc.rs
@@ -382,6 +382,19 @@ struct YarnRc {
     // platform filter. Captured as a generic `serde_json::Value` so the
     // arrays round-trip untouched.
     supported_architectures: Option<serde_json::Value>,
+    // Yarn Berry's supply-chain min-release-age gate (`npmMinimalAgeGate`, a
+    // DURATION whose declared unit is MINUTES — plugin-npm
+    // `scopablePackageGateSettings`) and its allowlist
+    // (`npmPreapprovedPackages`, an array of package descriptors / name globs).
+    // Mapped onto the engine's `minimumReleaseAge` (also minutes) +
+    // `minimumReleaseAgeExclude` — the SAME gate nub reads from npmrc/pnpm/bun
+    // config. Only honored when the user set them explicitly: yarn's `1d`
+    // default is yarn's, not nub's, so an unset gate stays unset (no entry
+    // emitted). Captured as a generic `Value` because a duration may be written
+    // either as a unit string (`"7d"`) or a bare number of minutes (`1440`).
+    npm_minimal_age_gate: Option<serde_json::Value>,
+    #[serde(default)]
+    npm_preapproved_packages: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -606,8 +619,86 @@ impl YarnRc {
             push(&mut out, "supportedArchitectures", json);
         }
 
+        // Supply-chain age gate. Honor ONLY an explicit user value — never
+        // impose yarn's `1d` default (that default belongs to yarn, not nub).
+        if let Some(minutes) = self
+            .npm_minimal_age_gate
+            .as_ref()
+            .and_then(parse_yarn_duration_minutes)
+        {
+            push(&mut out, "minimumReleaseAge", minutes.to_string());
+        }
+        // `npmPreapprovedPackages` → `minimumReleaseAgeExclude`. Yarn's entries
+        // are package descriptors / name-glob patterns; pass them verbatim
+        // (comma-joined) the same way the bun reader forwards
+        // `minimumReleaseAgeExcludes` — the engine's exclude matcher consumes
+        // the list, and an entry it can't interpret simply doesn't match.
+        let excludes: Vec<&str> = self
+            .npm_preapproved_packages
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !excludes.is_empty() {
+            push(&mut out, "minimumReleaseAgeExclude", excludes.join(","));
+        }
+
         out
     }
+}
+
+/// Parse a Yarn Berry `npmMinimalAgeGate` value into the engine's
+/// `minimumReleaseAge` unit (MINUTES). Yarn declares the setting as a DURATION
+/// with `unit: MINUTES`, so a unitless number is already minutes; a unit suffix
+/// (`ms`/`s`/`m`/`h`/`d`/`w`) is converted to minutes the same way Yarn's
+/// `parseDuration` does (`miscUtils.parseDuration`: value→ms via the unit
+/// table, then ÷ the target unit's ms). A value may arrive as a YAML number
+/// (bare minutes) or a string (`"7d"`).
+///
+/// Rounds UP to a whole minute so a small sub-minute gate (`"30s"`) never
+/// collapses to 0 and silently disables a security control — matching the
+/// bunfig reader's ceiling-division rationale. Returns `None` for an
+/// unparseable / negative value (the gate is then simply not applied, rather
+/// than emitting a malformed entry).
+fn parse_yarn_duration_minutes(value: &serde_json::Value) -> Option<u64> {
+    // ms per unit, mirroring Yarn's `DURATION_UNITS`.
+    fn unit_ms(unit: &str) -> Option<f64> {
+        Some(match unit {
+            "ms" => 1.0,
+            "s" => 1_000.0,
+            "m" => 60_000.0,
+            "h" => 3_600_000.0,
+            "d" => 86_400_000.0,
+            "w" => 604_800_000.0,
+            _ => return None,
+        })
+    }
+    const MS_PER_MINUTE: f64 = 60_000.0;
+
+    let minutes = match value {
+        // A bare YAML number is already minutes (Yarn's unitless path returns
+        // `parseFloat(num)` directly, interpreted in the setting's declared
+        // MINUTES unit).
+        serde_json::Value::Number(n) => n.as_f64()?,
+        serde_json::Value::String(s) => {
+            let s = s.trim();
+            // Split the trailing alphabetic unit, if any, off the numeric head.
+            let split = s.find(|c: char| c.is_alphabetic()).unwrap_or(s.len());
+            let (num, unit) = s.split_at(split);
+            let num: f64 = num.trim().parse().ok()?;
+            if unit.is_empty() {
+                num
+            } else {
+                num * unit_ms(unit)? / MS_PER_MINUTE
+            }
+        }
+        _ => return None,
+    };
+    if !minutes.is_finite() || minutes < 0.0 {
+        return None;
+    }
+    // Ceiling to a whole minute (a sub-minute non-zero gate must not become 0).
+    Some(minutes.ceil() as u64)
 }
 
 /// Read a PEM file referenced by a Yarn `httpsCertFilePath` /


### PR DESCRIPTION
Two compat-correctness defects the PM feature-matrix re-audit confirmed.

## FIX 1 — yarn `npmMinimalAgeGate` silently dropped (security-honoring)

Yarn Berry has a supply-chain min-release-age gate `npmMinimalAgeGate` plus an allowlist `npmPreapprovedPackages` (berry `packages/plugin-npm/sources/index.ts`, `scopablePackageGateSettings`). nub already has the engine gate `minimumReleaseAge` and reads it for npm, pnpm, and bun — but the yarnrc reader (`vendor/aube/crates/aube-registry/src/config/yarnrc.rs`) never mapped yarn's spelling, so a yarn project's configured gate was ignored.

Map `npmMinimalAgeGate` → `minimumReleaseAge` and `npmPreapprovedPackages` → `minimumReleaseAgeExclude`, **only when the user set them** (yarn's `1d` default is yarn's, not nub's — an unset gate emits no entry).

Unit conversion: `npmMinimalAgeGate` is a `DURATION` declared in `MINUTES` (berry `Configuration.ts` + `miscUtils.parseDuration`). The engine's `minimumReleaseAge` is also minutes, so:
- a **bare number** (`1440`) is already minutes — pass through;
- a **unit string** (`7d`) is converted via berry's ms table then ÷ minutes (`7d` = 10080 min);
- **sub-minute** values (`30s`) round **up** to 1, so a non-zero gate never collapses to 0 and silently disables the control (same rationale as the bunfig reader).

Scope-level `npmScopes.<s>.npmMinimalAgeGate` is **not** mapped — the engine has no per-scope min-age setting; top-level only.

This honors a **user-configured supply-chain security control**, consistent with how nub already treats npm/pnpm/bun. No posture change — it only stops dropping config the user wrote. Hold on review if you want it gated differently.

## FIX 2 — fabricated bun `trustedDependencies` drop (latent)

`crates/nub-cli/src/pm_engine/config_scope.rs` claimed bun@10 dropped `trustedDependencies` via a pnpm-style approve-builds migration. Fabricated: there is no bun major 10; bun 1.3.x still uses `trustedDependencies` (bun.com/docs/install/lifecycle; bun source `install/lifecycle.zig` + `lockfile.zig`), and `onlyBuiltDependencies`/`approve-builds` have zero hits in bun source. Dropped the `<10` major gate so bun honors `trustedDependencies` unconditionally; rewrote the comment factually; replaced the false `bun_10_dropped_trusted_dependencies` test.

## Verified
- `cargo build -p nub-cli -p aube-registry` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- new test `yarnrc_translates_min_age_gate_to_minimum_release_age` (7d→10080, bare-number→minutes, 30s→1 round-up, unset→no entry) + all 133 aube-registry config tests pass
- new test `only_bun_honors_trusted_dependencies` + `pm_two_mode` suite pass

Refs: pm-feature-matrix-reaudit audit context.