### PR TITLE
fix(release): make nub-native cross-build resolve nub-cache-key standalone (#112 fallout)

### DIFF
--- a/crates/nub-cache-key/Cargo.toml
+++ b/crates/nub-cache-key/Cargo.toml
@@ -5,16 +5,32 @@
 # key-derivation is pure (blake3 over a fixed preimage) with no napi dependency,
 # so it lives here where it CAN be tested on every platform, and `nub-native`
 # calls into it. Keep this crate napi-free.
+#
+# SELF-CONTAINED MANIFEST (no `*.workspace = true`): nub-cache-key is a member of
+# the ROOT workspace, but it is ALSO a cross-workspace path dependency of
+# `crates/nub-native` (its own panic=unwind workspace). The release `cross` build
+# runs `cd crates/nub-native && cross build`, which mounts ONLY the nub-native
+# workspace into the container — the repo-root manifest is absent there, so any
+# `.workspace = true` field in this crate cannot find a workspace root to inherit
+# from and the manifest parse fails ("failed to find a workspace root", #112
+# fallout that broke the v0.2.0 cross matrix). Inlining the values (identical to
+# the root `[workspace.package]` / `[workspace.lints.clippy]` / blake3 pin) lets
+# this manifest parse standalone in the cross container while staying byte-identical
+# to what it inherited as a root-workspace member. Keep these literals in lockstep
+# with the root `Cargo.toml`'s `[workspace.package]`, `[workspace.lints.clippy]`,
+# and the blake3 pin.
 [package]
 name = "nub-cache-key"
-version.workspace = true
-edition.workspace = true
-rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
+version = "0.2.0"
+edition = "2024"
+rust-version = "1.88"
+license = "MIT"
+repository = "https://github.com/nubjs/nub"
 
 [dependencies]
-blake3.workspace = true
+blake3 = "1"
 
-[lints]
-workspace = true
+[lints.clippy]
+dbg_macro = "warn"
+todo = "warn"
+unimplemented = "warn"


### PR DESCRIPTION
## The bug

The v0.2.0 release (run 28132098567, tag-triggered) failed: the 3 Linux **cross** builds (linux-x64-musl, linux-arm64-musl, linux-arm64-glibc, built via `cross`) failed at "Build nub-native addon". Native x64-glibc/darwin/win passed.

```
failed to load manifest for workspace member crates/nub-native/.
  -> failed to load manifest for dependency `nub-cache-key`
  -> error inheriting `edition` from workspace root manifest's workspace.package.edition
  -> failed to find a workspace root
```

publish-npm + github-release were skipped, so nothing was published.

## Root cause

#112 split `crates/nub-native` into its own cargo workspace. It path-depends on `crates/nub-cache-key`, a member of the **root** workspace that used `*.workspace = true` inheritance. The cross step runs `cd crates/nub-native && cross build`, which mounts only the nub-native workspace into the container — the repo-root manifest is absent, so nub-cache-key's inherited fields can't resolve a workspace root and the parse dies. Native builds pass because the root manifest sits in the parent dir. Invisible until now: release.yml runs only on `v*` tags, so the cross matrix never ran post-#112.

## The fix

Inline nub-cache-key's package fields, blake3 pin, and clippy lints (byte-identical to root) so the manifest parses standalone in the cross container while staying consistent as a root-workspace member. Single-file change.

## Verification

- Reproduced the exact error in an isolated copy (no root Cargo.toml) via `cargo metadata`; fix resolves it; standalone `cargo build` of nub-native then succeeds end-to-end.
- Root workspace unaffected: `cargo build -p nub-cache-key`/`-p nub-cli`, native nub-native release build, 3 nub-cache-key unit tests, clippy `--all-targets --all-features -D warnings`, fmt — all pass.

No issue to close.
