### PR TITLE
ci: share rust-cache across jobs, save only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,15 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      # shared-key (stable across runs, NOT per-ref) so PRs restore the warm cache
+      # main saves; save-if gates writes to main only, so PRs/tags are read-only and
+      # don't churn the 10GB/repo budget (the default per-(job,ref) key let every PR
+      # write its own cache). Per job-family because compiled artifacts differ by
+      # build profile (check=--all-targets debug vs test profile vs pnp debug build).
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: ci-check
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo check --all-targets
       # Real Windows compile + test coverage is the windows-latest leg of the
       # `test` job. The previous fast `x86_64-pc-windows-gnu` cross-check needed
@@ -152,6 +160,12 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: ci-clippy
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            .
+            crates/nub-native
       - run: cargo clippy --all-targets --all-features -- -D warnings
       # nub-native is its OWN workspace (split so the CLI uses panic=abort while
       # the cdylib stays panic=unwind), `exclude`d from the root workspace — so the
@@ -229,7 +243,15 @@ jobs:
       # files — checked out by the normal checkout, no submodule init needed.
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      # Keyed by OS only (not the node version) so the 4 ubuntu node-tier legs
+      # share ONE cache instead of writing four. save-if:main → read-only on PRs.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: ci-test-${{ runner.os }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            .
+            crates/nub-native
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5
         with:
           version: 10
@@ -340,7 +362,15 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      # Keyed by OS only so the node-tier legs share one cache; save-if:main →
+      # PRs restore main's warm cache read-only.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: ci-pnp-${{ runner.os }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            .
+            crates/nub-native
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/node-matrix.yml
+++ b/.github/workflows/node-matrix.yml
@@ -94,7 +94,15 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      # Stable shared-key (restore main's warm cache on PR); save-if:main → PRs
+      # read-only. Same debug nub-cli + nub-native footprint as ci.yml's build legs.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: node-matrix
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            .
+            crates/nub-native
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"

--- a/.github/workflows/wpt-worker.yml
+++ b/.github/workflows/wpt-worker.yml
@@ -39,7 +39,15 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      # Stable shared-key (restore main's warm cache on PR); save-if:main → PRs
+      # read-only. Same debug nub-cli + nub-native footprint as ci.yml's build legs.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: wpt-worker
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            .
+            crates/nub-native
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"


### PR DESCRIPTION
CI build jobs used rust-cache's default per-(job,ref) key, so every job and every PR wrote its own cache and none shared. This consolidates them and makes PRs restore main's warm cache read-only.

## What changed

`ci.yml` (check / clippy / test / pnp), `node-matrix.yml`, `wpt-worker.yml` build jobs → stable `shared-key` + `save-if: ${{ github.ref == 'refs/heads/main' }}`:

- **PRs RESTORE main's warm cache, read-only** — only `main` writes, so PRs/branches stop churning the 10GB/repo budget with per-ref duplicates.
- **The matrixed `test`/`pnp` legs share one cache per OS** (keyed by `runner.os`, not node version) instead of one cache per node-tier leg — the 4 ubuntu node-tier legs now share a single cache.
- Added a `workspaces` entry (`.` + `crates/nub-native`) so the separate `nub-native` workspace's deps cache too.

## Footprint (10GB budget)

~10 stable main-saved keys (ci-check, ci-clippy, ci-test-{Linux,Windows,macOS}, ci-pnp-{Linux,Windows,macOS}, node-matrix, wpt-worker), each rust-cache-pruned to **deps-only** (~hundreds MB to ~1-2GB — no pathological single key). `save-if`-on-main stops PR/branch churn; GitHub's LRU eviction owns the total (hot keys stay warm, cold evict). No manual job selection.

## Why release.yml is NOT touched

The original plan was to fix cold `v*`-tag release builds via a shared-key. **GitHub Actions cache scoping makes that inert:** a tag run can only restore caches from its *own ref* or the *default branch* — never from a sibling tag (GitHub's docs: "cannot restore caches created for different tag names"). Since no `main` job builds the release/cross targets, there is no tag-readable warm cache to restore, and the previous `key: ${{ matrix.platform }}` was equally cold — so changing it saves nothing.

Warming release-profile deps for tag runs would require a **main-branch build job** that compiles each target and saves under a tag-readable key — extra main-CI runner cost, a separate maintainer cost/architecture decision (not a free win). Flagged for follow-up; not in this PR.

## Validation

`actionlint` clean on all three workflows (the pre-existing `SC2193` warnings in release.yml are untouched/unrelated). Config-only — no build/compile commands changed. The empirical proof is a subsequent run's rust-cache log showing "Cache restored from key" (appears on the second run after the first main save).

Self-reviewed by a fresh-context adversarial pass that caught the tag-scoping issue above (hence release.yml dropped from scope).