### PR TITLE
fix(ci): guard thread::spawn against EAGAIN + cgroup-aware concurrency cap so install degrades instead of aborting (panic=abort)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,6 +2618,7 @@ dependencies = [
  "miette",
  "mimalloc",
  "nub-core",
+ "rayon",
  "rustc-hash",
  "semver",
  "serde_json",

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -84,6 +84,13 @@ toml.workspace = true
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tracing-subscriber.workspace = true
 url = "2.5"
+# Only to SIZE the rayon GLOBAL pool under a detected PID/thread constraint
+# (pm_engine::build_runtime): the embedded engine fans CAS writes / delta / fetch
+# out over rayon's implicit global pool, whose lazy init spins up
+# available_parallelism() threads (CPU-quota-bound, NOT PID-bound) and PANICS on
+# thread-create EAGAIN — the same exit-101 abort the tokio cap closes. We cap it
+# under the same headroom budget; unconstrained boxes keep rayon's default.
+rayon = "1"
 
 [target.'cfg(unix)'.dependencies]
 # fd-level capture of the engine's raw println/eprintln hint lines so the

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -2693,75 +2693,82 @@ fn run_workspace_target(
             let (tx, rx) = mpsc::channel::<usize>();
             let rx = Arc::new(std::sync::Mutex::new(rx));
 
-            let num_workers = concurrency.min(chunk.len());
-            let workers: Vec<_> = (0..num_workers)
-                .map(|_| {
-                    let rx = Arc::clone(&rx);
-                    let failed = Arc::clone(&failed);
-                    let ran = Arc::clone(&ran);
-                    // Clone the selected members so they cross the thread boundary
-                    // (the borrowed `&members` slice can't be `move`d); paired with
-                    // their original index for the prefix color. `WorkspacePackage`
-                    // derives Clone, so this replaces the prior 4-field tuple
-                    // snapshot with one structured clone.
-                    let members_snapshot: Vec<(
-                        usize,
-                        nub_core::workspace::filter::WorkspacePackage,
-                    )> = chunk
+            // The per-worker loop body, factored out so it backs BOTH a spawned
+            // worker thread and the inline fallback (when thread creation fails
+            // under resource pressure). Each invocation pulls indices from the
+            // shared channel until it drains, so any number of live workers — even
+            // one, even the calling thread — completes ALL the work; thread-create
+            // EAGAIN only costs parallelism, never correctness.
+            let run_worker = |rx: Arc<std::sync::Mutex<mpsc::Receiver<usize>>>,
+                              failed: Arc<AtomicUsize>,
+                              ran: Arc<AtomicUsize>| {
+                let members_snapshot: Vec<(usize, nub_core::workspace::filter::WorkspacePackage)> =
+                    chunk
                         .iter()
                         .map(|&idx| (idx, members[idx].clone()))
                         .collect();
-                    let ws_root_buf = ws_root.to_path_buf();
-                    // Owned target + per-script knobs so they cross the thread
-                    // boundary; reconstituted into the borrowed forms inside the
-                    // worker (the borrowed forms can't be `move`d).
-                    let target = OwnedTarget::from(target);
-                    let ignore_scripts = exec.ignore_scripts;
-                    let script_shell = ws.script_shell.clone();
+                let ws_root_buf = ws_root.to_path_buf();
+                let target = OwnedTarget::from(target);
+                let ignore_scripts = exec.ignore_scripts;
+                let script_shell = ws.script_shell.clone();
 
-                    thread::spawn(move || {
-                        let exec = ScriptExecOpts {
-                            ignore_scripts,
-                            script_shell: script_shell.as_deref(),
-                        };
-                        let target = target.borrow();
-                        loop {
-                            let work_idx = match rx.lock() {
-                                Ok(guard) => match guard.recv() {
-                                    Ok(idx) => idx,
-                                    Err(_) => break,
-                                },
+                move || {
+                    let exec = ScriptExecOpts {
+                        ignore_scripts,
+                        script_shell: script_shell.as_deref(),
+                    };
+                    let target = target.borrow();
+                    loop {
+                        let work_idx = match rx.lock() {
+                            Ok(guard) => match guard.recv() {
+                                Ok(idx) => idx,
                                 Err(_) => break,
-                            };
-                            if bail && failed.load(AtomicOrdering::Relaxed) > 0 {
-                                continue;
-                            }
-                            let Some((_, member)) =
-                                members_snapshot.iter().find(|(i, _)| *i == work_idx)
-                            else {
-                                continue;
-                            };
-                            let leaf = MemberLeaf {
-                                compat_mode,
-                                // The concurrent path always streams (prefixed) —
-                                // its whole reason for existing is interleaved output.
-                                stream: true,
-                                color_idx: work_idx,
-                                exec: &exec,
-                                aggregate,
-                            };
-                            match run_one_member(target, member, &ws_root_buf, &leaf) {
-                                MemberOutcome::Ran(0) => {
-                                    ran.fetch_add(1, AtomicOrdering::Relaxed);
-                                }
-                                MemberOutcome::Ran(_) => {
-                                    ran.fetch_add(1, AtomicOrdering::Relaxed);
-                                    failed.fetch_add(1, AtomicOrdering::Relaxed);
-                                }
-                                MemberOutcome::SkippedMissingScript => {}
-                            }
+                            },
+                            Err(_) => break,
+                        };
+                        if bail && failed.load(AtomicOrdering::Relaxed) > 0 {
+                            continue;
                         }
-                    })
+                        let Some((_, member)) =
+                            members_snapshot.iter().find(|(i, _)| *i == work_idx)
+                        else {
+                            continue;
+                        };
+                        let leaf = MemberLeaf {
+                            compat_mode,
+                            // The concurrent path always streams (prefixed) —
+                            // its whole reason for existing is interleaved output.
+                            stream: true,
+                            color_idx: work_idx,
+                            exec: &exec,
+                            aggregate,
+                        };
+                        match run_one_member(target, member, &ws_root_buf, &leaf) {
+                            MemberOutcome::Ran(0) => {
+                                ran.fetch_add(1, AtomicOrdering::Relaxed);
+                            }
+                            MemberOutcome::Ran(_) => {
+                                ran.fetch_add(1, AtomicOrdering::Relaxed);
+                                failed.fetch_add(1, AtomicOrdering::Relaxed);
+                            }
+                            MemberOutcome::SkippedMissingScript => {}
+                        }
+                    }
+                }
+            };
+
+            let num_workers = concurrency.min(chunk.len());
+            // `Builder::spawn` (returns `io::Result`) over `thread::spawn` (which
+            // PANICS — and under `panic = "abort"` aborts the install — on
+            // thread-create EAGAIN under PID/thread pressure). A worker that fails
+            // to spawn is simply absent; the survivors drain the whole queue.
+            let workers: Vec<_> = (0..num_workers)
+                .filter_map(|i| {
+                    let body = run_worker(Arc::clone(&rx), Arc::clone(&failed), Arc::clone(&ran));
+                    thread::Builder::new()
+                        .name(format!("nub-run-worker-{i}"))
+                        .spawn(body)
+                        .ok()
                 })
                 .collect();
 
@@ -2769,6 +2776,13 @@ fn run_workspace_target(
                 let _ = tx.send(idx);
             }
             drop(tx);
+
+            // If EVERY worker failed to spawn (total thread exhaustion), drain the
+            // queue inline on the calling thread so the work still completes —
+            // serially, but never lost, and never a panic/abort.
+            if workers.is_empty() {
+                run_worker(Arc::clone(&rx), Arc::clone(&failed), Arc::clone(&ran))();
+            }
 
             for w in workers {
                 let _ = w.join();
@@ -3486,6 +3500,109 @@ fn run_single_script_prefixed(
 /// serialize the script *runs* themselves — only their final output emission.
 static AGGREGATE_FLUSH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Inputs a pipe-drain reader needs, owned so they can cross the thread boundary
+/// OR be consumed inline on the current thread. Bundled into one struct so the
+/// SAME drain logic backs both the spawned-thread and the spawn-failure-inline
+/// fallback paths (`Builder::spawn` consumes its closure and never returns it on
+/// `Err`, so the inline fallback must own the inputs separately — hence this
+/// struct, moved into whichever path runs).
+struct PipeDrain<R: std::io::Read> {
+    stream: Option<R>,
+    ndjson: bool,
+    aggregate: bool,
+    is_stderr: bool,
+    prefix: String,
+    name: String,
+    script: String,
+}
+
+/// The outcome of [`PipeDrain::spawn`]: either a join handle (the drain runs on
+/// its own thread) or the already-collected lines (thread creation failed under
+/// resource pressure, so the drain ran inline as a fallback).
+enum DrainHandle {
+    Thread(std::thread::JoinHandle<Vec<String>>),
+    Inline(Vec<String>),
+}
+
+impl DrainHandle {
+    fn collect(self) -> Vec<String> {
+        match self {
+            DrainHandle::Thread(h) => h.join().unwrap_or_default(),
+            DrainHandle::Inline(lines) => lines,
+        }
+    }
+}
+
+impl<R: std::io::Read + Send + 'static> PipeDrain<R> {
+    /// Put this drain on its own thread, degrading to an INLINE drain when the OS
+    /// can't create a thread (`EAGAIN` under thread/PID exhaustion). The bare
+    /// `thread::spawn` would PANIC there — and under `panic = "abort"` abort the
+    /// whole process — which is the latent install crash this guards. The reader
+    /// is LOAD-BEARING (a missing one deadlocks the child on a full pipe buffer),
+    /// so on resource pressure we must still drain it, just without a thread.
+    ///
+    /// `Builder::spawn` consumes its closure even on `Err`, so we can't try the
+    /// real spawn and recover `self`. Instead we PROBE thread availability with a
+    /// trivial throwaway thread first: if that spawns and joins, real thread
+    /// creation will (near-certainly) succeed and we spawn the drain; if the
+    /// probe fails we drain inline without ever moving `self` into a doomed
+    /// spawn. The probe costs one cheap thread create only on the success path.
+    fn spawn(self, thread_name: &str) -> DrainHandle {
+        let probe = std::thread::Builder::new()
+            .name(format!("{thread_name}-probe"))
+            .spawn(|| {});
+        match probe {
+            Ok(p) => {
+                let _ = p.join();
+                match std::thread::Builder::new()
+                    .name(thread_name.into())
+                    .spawn(move || self.run())
+                {
+                    Ok(h) => DrainHandle::Thread(h),
+                    // Probe succeeded but the real spawn still failed — a genuine
+                    // race right at the resource ceiling. `self` is already
+                    // consumed, so we can't inline-drain; return empty. This loses
+                    // this stream's captured lines in that vanishingly-rare double
+                    // race, which is still strictly better than the panic/abort
+                    // the bare `thread::spawn` would have caused.
+                    Err(_) => DrainHandle::Inline(Vec::new()),
+                }
+            }
+            Err(_) => DrainHandle::Inline(self.run()),
+        }
+    }
+
+    /// Drain the pipe to completion, returning the prefixed lines (and emitting
+    /// them live unless `aggregate`). Consumes `self`; runs identically on a
+    /// drain thread or inline.
+    fn run(self) -> Vec<String> {
+        use std::io::BufRead as _;
+        let mut lines = Vec::new();
+        if let Some(stream) = self.stream {
+            for line in std::io::BufReader::new(stream)
+                .lines()
+                .map_while(Result::ok)
+            {
+                if self.ndjson {
+                    let level = if self.is_stderr { "error" } else { "info" };
+                    emit_ndjson("log", level, &self.name, &self.script, Some(&line), None);
+                    continue;
+                }
+                let prefixed = format!("{}{line}", self.prefix);
+                if !self.aggregate {
+                    if self.is_stderr {
+                        eprintln!("{prefixed}");
+                    } else {
+                        println!("{prefixed}");
+                    }
+                }
+                lines.push(prefixed);
+            }
+        }
+        lines
+    }
+}
+
 /// Spawn a script with piped stdout/stderr, prefixing each output line
 /// with `<prefix> <script>: `. Returns (exit_code, collected_output).
 ///
@@ -3506,7 +3623,7 @@ fn spawn_script_prefixed(
     exec: &ScriptExecOpts,
     aggregate: bool,
 ) -> Result<(i32, String)> {
-    use std::io::{BufRead, BufReader, Write};
+    use std::io::Write;
 
     let mut command = build_script_command(
         cmd,
@@ -3519,7 +3636,7 @@ fn spawn_script_prefixed(
     )?;
 
     nub_core::node::spawn::group_on_spawn(&mut command);
-    let mut child = command.spawn()?;
+    let mut child = nub_core::node::spawn::spawn_with_eagain_retry(&mut command)?;
     // Relay docker stop / Ctrl-C to the streamed child's whole process group too
     // (workspace `-r` runs) — the `sh -c` won't pass a forwarded signal to node.
     nub_core::node::spawn::track_child_group(child.id());
@@ -3548,48 +3665,40 @@ fn spawn_script_prefixed(
     let (name_out, script_out) = (pkg_name.clone(), script_name.to_string());
     let (name_err, script_err) = (pkg_name.clone(), script_name.to_string());
 
-    // In aggregate mode the reader threads collect prefixed lines instead of
+    // In aggregate mode the reader drains collect prefixed lines instead of
     // emitting them live; the parent flushes the buffered blocks once, below.
-    let out_handle = std::thread::spawn(move || {
-        let mut lines = Vec::new();
-        if let Some(stdout) = stdout {
-            for line in BufReader::new(stdout).lines().map_while(Result::ok) {
-                if ndjson {
-                    emit_ndjson("log", "info", &name_out, &script_out, Some(&line), None);
-                    continue;
-                }
-                let prefixed = format!("{prefix_out}{line}");
-                if !aggregate {
-                    println!("{prefixed}");
-                }
-                lines.push(prefixed);
-            }
-        }
-        lines
-    });
+    let out_drain = PipeDrain {
+        stream: stdout,
+        ndjson,
+        aggregate,
+        is_stderr: false,
+        prefix: prefix_out,
+        name: name_out,
+        script: script_out,
+    };
+    let err_drain = PipeDrain {
+        stream: stderr,
+        ndjson,
+        aggregate,
+        is_stderr: true,
+        prefix: prefix_err,
+        name: name_err,
+        script: script_err,
+    };
 
-    let err_handle = std::thread::spawn(move || {
-        let mut lines = Vec::new();
-        if let Some(stderr) = stderr {
-            for line in BufReader::new(stderr).lines().map_while(Result::ok) {
-                if ndjson {
-                    emit_ndjson("log", "error", &name_err, &script_err, Some(&line), None);
-                    continue;
-                }
-                let prefixed = format!("{prefix_err}{line}");
-                if !aggregate {
-                    eprintln!("{prefixed}");
-                }
-                lines.push(prefixed);
-            }
-        }
-        lines
-    });
+    // The pipe drains are LOAD-BEARING — a missing reader deadlocks the child on a
+    // full pipe buffer. `PipeDrain::spawn` guards against OS thread-create EAGAIN
+    // (the bare `thread::spawn` would PANIC, and under `panic = "abort"` abort the
+    // process) by degrading to an inline drain. The stdout drain goes on its own
+    // thread; the stderr drain runs on THIS thread, concurrently — so under
+    // resource pressure stderr still drains live while stdout's thread (or its
+    // inline fallback) drains too.
+    let out_handle = out_drain.spawn("nub-script-stdout");
+    let err_lines = err_drain.run();
+    let out_lines = out_handle.collect();
 
     let status = child.wait()?;
     nub_core::node::spawn::untrack_child();
-    let out_lines = out_handle.join().unwrap_or_default();
-    let err_lines = err_handle.join().unwrap_or_default();
     let exit_code = nub_core::node::spawn::exit_code_from_status(&status);
     if ndjson {
         emit_ndjson(

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3500,14 +3500,13 @@ fn run_single_script_prefixed(
 /// serialize the script *runs* themselves — only their final output emission.
 static AGGREGATE_FLUSH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Inputs a pipe-drain reader needs, owned so they can cross the thread boundary
-/// OR be consumed inline on the current thread. Bundled into one struct so the
-/// SAME drain logic backs both the spawned-thread and the spawn-failure-inline
-/// fallback paths (`Builder::spawn` consumes its closure and never returns it on
-/// `Err`, so the inline fallback must own the inputs separately — hence this
-/// struct, moved into whichever path runs).
-struct PipeDrain<R: std::io::Read> {
-    stream: Option<R>,
+/// Per-stream formatting + emission policy for a script's stdout/stderr drain.
+/// Owned so it can cross a thread boundary OR drive an inline drain — the same
+/// logic backs both paths. The stream (`R`) is held SEPARATELY (see
+/// [`PipeReaders`]) so a failed thread-spawn never loses the pipe: the policy
+/// can always still drain the stream inline.
+#[derive(Clone)]
+struct DrainPolicy {
     ndjson: bool,
     aggregate: bool,
     is_stderr: bool,
@@ -3516,90 +3515,322 @@ struct PipeDrain<R: std::io::Read> {
     script: String,
 }
 
-/// The outcome of [`PipeDrain::spawn`]: either a join handle (the drain runs on
-/// its own thread) or the already-collected lines (thread creation failed under
-/// resource pressure, so the drain ran inline as a fallback).
-enum DrainHandle {
-    Thread(std::thread::JoinHandle<Vec<String>>),
-    Inline(Vec<String>),
-}
-
-impl DrainHandle {
-    fn collect(self) -> Vec<String> {
-        match self {
-            DrainHandle::Thread(h) => h.join().unwrap_or_default(),
-            DrainHandle::Inline(lines) => lines,
+impl DrainPolicy {
+    /// Emit one raw line per this policy, returning the prefixed form to collect.
+    fn emit(&self, line: &str) -> Option<String> {
+        if self.ndjson {
+            let level = if self.is_stderr { "error" } else { "info" };
+            emit_ndjson("log", level, &self.name, &self.script, Some(line), None);
+            return None;
         }
-    }
-}
-
-impl<R: std::io::Read + Send + 'static> PipeDrain<R> {
-    /// Put this drain on its own thread, degrading to an INLINE drain when the OS
-    /// can't create a thread (`EAGAIN` under thread/PID exhaustion). The bare
-    /// `thread::spawn` would PANIC there — and under `panic = "abort"` abort the
-    /// whole process — which is the latent install crash this guards. The reader
-    /// is LOAD-BEARING (a missing one deadlocks the child on a full pipe buffer),
-    /// so on resource pressure we must still drain it, just without a thread.
-    ///
-    /// `Builder::spawn` consumes its closure even on `Err`, so we can't try the
-    /// real spawn and recover `self`. Instead we PROBE thread availability with a
-    /// trivial throwaway thread first: if that spawns and joins, real thread
-    /// creation will (near-certainly) succeed and we spawn the drain; if the
-    /// probe fails we drain inline without ever moving `self` into a doomed
-    /// spawn. The probe costs one cheap thread create only on the success path.
-    fn spawn(self, thread_name: &str) -> DrainHandle {
-        let probe = std::thread::Builder::new()
-            .name(format!("{thread_name}-probe"))
-            .spawn(|| {});
-        match probe {
-            Ok(p) => {
-                let _ = p.join();
-                match std::thread::Builder::new()
-                    .name(thread_name.into())
-                    .spawn(move || self.run())
-                {
-                    Ok(h) => DrainHandle::Thread(h),
-                    // Probe succeeded but the real spawn still failed — a genuine
-                    // race right at the resource ceiling. `self` is already
-                    // consumed, so we can't inline-drain; return empty. This loses
-                    // this stream's captured lines in that vanishingly-rare double
-                    // race, which is still strictly better than the panic/abort
-                    // the bare `thread::spawn` would have caused.
-                    Err(_) => DrainHandle::Inline(Vec::new()),
-                }
+        let prefixed = format!("{}{line}", self.prefix);
+        if !self.aggregate {
+            if self.is_stderr {
+                eprintln!("{prefixed}");
+            } else {
+                println!("{prefixed}");
             }
-            Err(_) => DrainHandle::Inline(self.run()),
         }
+        Some(prefixed)
     }
 
-    /// Drain the pipe to completion, returning the prefixed lines (and emitting
-    /// them live unless `aggregate`). Consumes `self`; runs identically on a
-    /// drain thread or inline.
-    fn run(self) -> Vec<String> {
+    /// Drain `stream` to EOF on the CURRENT thread, returning the collected lines.
+    fn run<R: std::io::Read>(&self, stream: R) -> Vec<String> {
         use std::io::BufRead as _;
         let mut lines = Vec::new();
-        if let Some(stream) = self.stream {
-            for line in std::io::BufReader::new(stream)
-                .lines()
-                .map_while(Result::ok)
-            {
-                if self.ndjson {
-                    let level = if self.is_stderr { "error" } else { "info" };
-                    emit_ndjson("log", level, &self.name, &self.script, Some(&line), None);
-                    continue;
-                }
-                let prefixed = format!("{}{line}", self.prefix);
-                if !self.aggregate {
-                    if self.is_stderr {
-                        eprintln!("{prefixed}");
-                    } else {
-                        println!("{prefixed}");
-                    }
-                }
+        for line in std::io::BufReader::new(stream)
+            .lines()
+            .map_while(Result::ok)
+        {
+            if let Some(prefixed) = self.emit(&line) {
                 lines.push(prefixed);
             }
         }
         lines
+    }
+}
+
+/// Both of a script child's output pipes plus their per-stream policies, drained
+/// together so the child can never deadlock on a full pipe buffer.
+///
+/// The two pipes MUST be drained CONCURRENTLY: draining one to EOF before
+/// starting the other lets a child that fills the not-yet-read pipe block on
+/// `write` forever. The happy path drains stdout on its own thread while stderr
+/// drains on the calling thread. Under OS thread-create EAGAIN (the `nub ci`
+/// exit-101 family) — where `thread::spawn` would PANIC, and under
+/// `panic = "abort"` abort the whole process — we fall back to a SINGLE-THREAD
+/// concurrent drain that interleaves both pipes via `poll(2)`, preserving the
+/// no-deadlock guarantee without a second thread.
+struct PipeReaders {
+    stdout: Option<std::process::ChildStdout>,
+    stderr: Option<std::process::ChildStderr>,
+    out_policy: DrainPolicy,
+    err_policy: DrainPolicy,
+}
+
+impl PipeReaders {
+    /// Drain both pipes to EOF, returning `(stdout_lines, stderr_lines)`. Never
+    /// deadlocks: stdout on a thread + stderr inline normally; both interleaved
+    /// on one thread via `poll(2)` when a thread can't be created.
+    fn drain(self) -> (Vec<String>, Vec<String>) {
+        let PipeReaders {
+            stdout,
+            stderr,
+            out_policy,
+            err_policy,
+        } = self;
+
+        let Some(out) = stdout else {
+            // No stdout pipe — only stderr to drain (inline, always concurrent
+            // enough since there's nothing to race it against).
+            let err_lines = stderr.map(|e| err_policy.run(e)).unwrap_or_default();
+            return (Vec::new(), err_lines);
+        };
+
+        // Happy path: stdout on its own thread (concurrent with the inline stderr
+        // drain below). On Unix we hand the thread a `dup`ed fd and KEEP the
+        // original `ChildStdout` — so a `Builder::spawn` failure (thread-create
+        // EAGAIN, which a bare `thread::spawn` would panic/abort on) leaves the
+        // original recoverable for the inline fallback. The dup and the original
+        // share the same OS pipe; only one ever reads it (the thread on success,
+        // the original inline on failure), so there's no double-drain.
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::{AsRawFd, FromRawFd};
+            // SAFETY: dup an fd we own; wrap the new fd in an owning File. -1 on
+            // failure is handled below (drain inline).
+            let dup_fd = unsafe { libc::dup(out.as_raw_fd()) };
+            let spawn_result = if dup_fd < 0 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                // SAFETY: `dup_fd` is a fresh, owned fd; `File` takes ownership.
+                let dup_file = unsafe { std::fs::File::from_raw_fd(dup_fd) };
+                let policy = out_policy.clone();
+                std::thread::Builder::new()
+                    .name("nub-script-stdout".into())
+                    .spawn(move || policy.run(dup_file))
+            };
+            match spawn_result {
+                Ok(handle) => {
+                    let err_lines = stderr.map(|e| err_policy.run(e)).unwrap_or_default();
+                    let out_lines = handle.join().unwrap_or_default();
+                    (out_lines, err_lines)
+                }
+                Err(_) => {
+                    // Thread-create (or dup) EAGAIN: drain BOTH pipes concurrently
+                    // on this one thread so neither can deadlock the child.
+                    drain_both_inline(out, out_policy, stderr, err_policy)
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            // Windows never exhibited the thread-exhaustion abort, and has no
+            // `poll`-based inline multiplex here — move stdout into the thread as
+            // before. `Builder::spawn` still avoids the unconditional panic of
+            // `thread::spawn`; on the (astronomically rare) failure we drain
+            // stdout inline AFTER stderr, accepting the sequential-drain window.
+            let policy = out_policy.clone();
+            let spawn_result = std::thread::Builder::new()
+                .name("nub-script-stdout".into())
+                .spawn(move || policy.run(out));
+            match spawn_result {
+                Ok(handle) => {
+                    let err_lines = stderr.map(|e| err_policy.run(e)).unwrap_or_default();
+                    let out_lines = handle.join().unwrap_or_default();
+                    (out_lines, err_lines)
+                }
+                Err(_) => {
+                    let err_lines = stderr.map(|e| err_policy.run(e)).unwrap_or_default();
+                    // stdout was moved into the failed closure; it's gone. Lose
+                    // its lines (Windows-only, vanishing-probability path).
+                    (Vec::new(), err_lines)
+                }
+            }
+        }
+    }
+}
+
+/// Concurrently drain stdout + stderr on the CURRENT thread (no second thread),
+/// using `poll(2)` to multiplex the two pipes so a full buffer on either can
+/// never block the other — preserving the no-deadlock guarantee without a thread.
+/// Non-Unix has no `poll` here; it falls back to sequential draining, accepting
+/// the rare large-output deadlock window (the abort this replaces was Linux-only,
+/// and Windows never exhibited the thread-exhaustion bug).
+fn drain_both_inline(
+    out: std::process::ChildStdout,
+    out_policy: DrainPolicy,
+    err: Option<std::process::ChildStderr>,
+    err_policy: DrainPolicy,
+) -> (Vec<String>, Vec<String>) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        // `out` / `err` stay owned (and so their fds stay valid) until this block
+        // ends. Set both pipes non-blocking so a `read` after a `poll`-ready
+        // signal can never block (and returns `WouldBlock` when momentarily
+        // drained), which is what makes the single-thread multiplex safe.
+        set_nonblocking(out.as_raw_fd());
+        if let Some(e) = err.as_ref() {
+            set_nonblocking(e.as_raw_fd());
+        }
+        let mut out_pipe = LinePipe::new(out.as_raw_fd(), out_policy);
+        let mut err_pipe = err
+            .as_ref()
+            .map(|e| LinePipe::new(e.as_raw_fd(), err_policy));
+
+        loop {
+            let mut fds: Vec<libc::pollfd> = Vec::with_capacity(2);
+            if !out_pipe.done {
+                fds.push(libc::pollfd {
+                    fd: out_pipe.fd,
+                    events: libc::POLLIN,
+                    revents: 0,
+                });
+            }
+            if let Some(ep) = err_pipe.as_ref() {
+                if !ep.done {
+                    fds.push(libc::pollfd {
+                        fd: ep.fd,
+                        events: libc::POLLIN,
+                        revents: 0,
+                    });
+                }
+            }
+            if fds.is_empty() {
+                break;
+            }
+            // SAFETY: `fds` is a valid, len-sized slice of pollfd; -1 = no timeout.
+            let rc = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, -1) };
+            if rc < 0 {
+                let e = std::io::Error::last_os_error();
+                if e.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                break; // unrecoverable poll error — stop draining
+            }
+            for pfd in &fds {
+                if pfd.revents == 0 {
+                    continue;
+                }
+                if pfd.fd == out_pipe.fd {
+                    out_pipe.pump();
+                } else if let Some(ep) = err_pipe.as_mut() {
+                    if pfd.fd == ep.fd {
+                        ep.pump();
+                    }
+                }
+            }
+        }
+        let out_lines = out_pipe.finish();
+        let err_lines = err_pipe.map(LinePipe::finish).unwrap_or_default();
+        (out_lines, err_lines)
+    }
+    #[cfg(not(unix))]
+    {
+        // No `poll` — drain sequentially. Safe for the small-output common case;
+        // the thread-exhaustion abort this guards was never seen off Linux.
+        let out_lines = out_policy.run(out);
+        let err_lines = err.map(|e| err_policy.run(e)).unwrap_or_default();
+        (out_lines, err_lines)
+    }
+}
+
+/// Put a raw fd into non-blocking mode (best-effort — a failure just leaves the
+/// `poll`-then-`read` slightly more cautious; it does not break correctness).
+#[cfg(unix)]
+fn set_nonblocking(fd: std::os::unix::io::RawFd) {
+    // SAFETY: F_GETFL/F_SETFL on an fd we own; flags OR'd with O_NONBLOCK.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags >= 0 {
+            let _ = libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+        }
+    }
+}
+
+/// A raw-fd pipe drained incrementally under `poll(2)`: reads available bytes,
+/// splits complete lines, emits + collects them per its [`DrainPolicy`], and
+/// buffers any partial trailing line until more arrives or EOF.
+#[cfg(unix)]
+struct LinePipe {
+    fd: std::os::unix::io::RawFd,
+    policy: DrainPolicy,
+    buf: Vec<u8>,
+    lines: Vec<String>,
+    done: bool,
+}
+
+#[cfg(unix)]
+impl LinePipe {
+    fn new(fd: std::os::unix::io::RawFd, policy: DrainPolicy) -> Self {
+        LinePipe {
+            fd,
+            policy,
+            buf: Vec::new(),
+            lines: Vec::new(),
+            done: false,
+        }
+    }
+
+    /// Read whatever is ready and emit any newly-complete lines.
+    fn pump(&mut self) {
+        let mut chunk = [0u8; 8192];
+        loop {
+            // SAFETY: read into a valid local buffer on a raw fd we own.
+            let n = unsafe {
+                libc::read(
+                    self.fd,
+                    chunk.as_mut_ptr() as *mut libc::c_void,
+                    chunk.len(),
+                )
+            };
+            if n > 0 {
+                self.buf.extend_from_slice(&chunk[..n as usize]);
+                self.drain_complete_lines();
+                continue; // keep reading until the pipe is momentarily empty
+            }
+            if n == 0 {
+                self.done = true; // EOF
+                return;
+            }
+            // n < 0
+            let e = std::io::Error::last_os_error();
+            match e.kind() {
+                std::io::ErrorKind::WouldBlock => return, // nothing more right now
+                std::io::ErrorKind::Interrupted => continue,
+                _ => {
+                    self.done = true;
+                    return;
+                }
+            }
+        }
+    }
+
+    fn drain_complete_lines(&mut self) {
+        while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
+            let mut line = self.buf.drain(..=pos).collect::<Vec<u8>>();
+            line.pop(); // drop '\n'
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+            let text = String::from_utf8_lossy(&line);
+            if let Some(prefixed) = self.policy.emit(&text) {
+                self.lines.push(prefixed);
+            }
+        }
+    }
+
+    /// Flush any partial trailing line (no terminating newline) and return all
+    /// collected lines.
+    fn finish(mut self) -> Vec<String> {
+        if !self.buf.is_empty() {
+            let text = String::from_utf8_lossy(&self.buf);
+            if let Some(prefixed) = self.policy.emit(&text) {
+                self.lines.push(prefixed);
+            }
+        }
+        self.lines
     }
 }
 
@@ -3665,37 +3896,33 @@ fn spawn_script_prefixed(
     let (name_out, script_out) = (pkg_name.clone(), script_name.to_string());
     let (name_err, script_err) = (pkg_name.clone(), script_name.to_string());
 
-    // In aggregate mode the reader drains collect prefixed lines instead of
-    // emitting them live; the parent flushes the buffered blocks once, below.
-    let out_drain = PipeDrain {
-        stream: stdout,
-        ndjson,
-        aggregate,
-        is_stderr: false,
-        prefix: prefix_out,
-        name: name_out,
-        script: script_out,
-    };
-    let err_drain = PipeDrain {
-        stream: stderr,
-        ndjson,
-        aggregate,
-        is_stderr: true,
-        prefix: prefix_err,
-        name: name_err,
-        script: script_err,
-    };
-
-    // The pipe drains are LOAD-BEARING — a missing reader deadlocks the child on a
-    // full pipe buffer. `PipeDrain::spawn` guards against OS thread-create EAGAIN
-    // (the bare `thread::spawn` would PANIC, and under `panic = "abort"` abort the
-    // process) by degrading to an inline drain. The stdout drain goes on its own
-    // thread; the stderr drain runs on THIS thread, concurrently — so under
-    // resource pressure stderr still drains live while stdout's thread (or its
-    // inline fallback) drains too.
-    let out_handle = out_drain.spawn("nub-script-stdout");
-    let err_lines = err_drain.run();
-    let out_lines = out_handle.collect();
+    // In aggregate mode the drains collect prefixed lines instead of emitting
+    // them live; the parent flushes the buffered blocks once, below. `PipeReaders`
+    // drains both pipes CONCURRENTLY and never deadlocks — stdout on its own
+    // thread + stderr inline normally, or both interleaved on one thread via
+    // `poll(2)` when OS thread-create EAGAIN forces the inline fallback (the
+    // `nub ci` exit-101 family, where a bare `thread::spawn` would panic/abort).
+    let (out_lines, err_lines) = PipeReaders {
+        stdout,
+        stderr,
+        out_policy: DrainPolicy {
+            ndjson,
+            aggregate,
+            is_stderr: false,
+            prefix: prefix_out,
+            name: name_out,
+            script: script_out,
+        },
+        err_policy: DrainPolicy {
+            ndjson,
+            aggregate,
+            is_stderr: true,
+            prefix: prefix_err,
+            name: name_err,
+            script: script_err,
+        },
+    }
+    .drain();
 
     let status = child.wait()?;
     nub_core::node::spawn::untrack_child();

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -59,6 +59,7 @@ pub mod install_family;
 pub mod log;
 pub mod present;
 pub mod publish_family;
+mod resource_limits;
 pub mod store_config_family;
 pub mod unsupported_config;
 pub mod use_align;
@@ -1886,17 +1887,88 @@ pub(crate) fn env_snapshot() -> Vec<(String, String)> {
 /// (`vendor/aube/crates/aube/src/lib.rs`): workers capped at 8 (the install
 /// semaphore already gates network), blocking pool at 128 (tarball decode +
 /// linker fan-out). The AUBE_TOKIO_* benchmark overrides are not honored here.
+///
+/// CONSTRAINT-AWARE sizing: on a resource-constrained box (a tight cgroup
+/// `pids.max` or low `RLIMIT_NPROC`) the unbounded `128` blocking pool plus the
+/// parallel native postinstalls can drive the total thread+process count past
+/// the kernel ceiling; tokio then PANICS when `clone(2)` returns `EAGAIN` growing
+/// its blocking pool, which under `panic = "abort"` aborts the whole install
+/// (the `nub ci` exit-101). When [`resource_limits::spawn_headroom`] detects a
+/// constraint we shrink BOTH pools to fit the headroom; on an unconstrained box
+/// it returns `None` and we keep the full-speed defaults — so normal-box install
+/// performance is untouched.
 fn build_runtime() -> Result<tokio::runtime::Runtime> {
-    let workers = std::thread::available_parallelism()
+    // Lower the parallel build-script count under a detected constraint BEFORE the
+    // runtime is built (single-threaded here, so the env mutation is race-free).
+    apply_constrained_child_concurrency();
+
+    let cpu = std::thread::available_parallelism()
         .map(|n| n.get())
-        .unwrap_or(4)
-        .min(8);
+        .unwrap_or(4);
+    let mut workers = cpu.min(8);
+    let mut blocking = 128usize;
+
+    if let Some(headroom) = resource_limits::spawn_headroom() {
+        // Split the headroom between worker threads (a small fixed share — the
+        // install is IO-bound, not CPU-bound) and the blocking pool (the larger
+        // share, since tarball decode + CAS writes dominate the OS-thread peak).
+        // Clamp each to a sane floor so the install still makes progress.
+        workers = workers.min(headroom / 4).max(2);
+        blocking = blocking.min(headroom).max(4);
+        tracing::debug!(
+            headroom,
+            workers,
+            blocking,
+            "constrained box detected: capping install runtime pools under the PID/thread ceiling"
+        );
+    }
+
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(workers)
-        .max_blocking_threads(128)
+        .max_blocking_threads(blocking)
         .enable_all()
         .build()
         .context("failed to build the install engine's tokio runtime")
+}
+
+/// When the box is resource-constrained, lower the parallel build-script process
+/// count (aube's `child_concurrency`, default 5) so the peak native-postinstall
+/// fan-out — each spawning Go/Rust grandchildren — stays under the PID ceiling.
+/// nub exports this through the engine's env (aube resolves `child_concurrency`
+/// from `npm_config_child_concurrency` / `AUBE_CHILD_CONCURRENCY`), so standalone
+/// aube is UNCHANGED — only nub, on a detected constraint, asks for fewer
+/// parallel builds. A user/CI-set value already in the env is left untouched.
+///
+/// SAFETY: called before the engine runs, single-threaded at that point (the
+/// install runtime is built after this), so the `set_var` is not racing other
+/// threads reading the environment.
+fn apply_constrained_child_concurrency() {
+    // Respect an explicit user/CI choice — never override a value they set.
+    const KEYS: [&str; 3] = [
+        "npm_config_child_concurrency",
+        "NPM_CONFIG_CHILD_CONCURRENCY",
+        "AUBE_CHILD_CONCURRENCY",
+    ];
+    if KEYS.iter().any(|k| std::env::var_os(k).is_some()) {
+        return;
+    }
+    let Some(headroom) = resource_limits::spawn_headroom() else {
+        return; // unconstrained — keep aube's default of 5
+    };
+    // Each parallel build budgets for a handful of grandchild processes/threads;
+    // divide the headroom accordingly and clamp to [1, 5] (never above the
+    // default, never below serial).
+    const PER_BUILD_BUDGET: usize = 8;
+    let capped = (headroom / PER_BUILD_BUDGET).clamp(1, 5);
+    // SAFETY: see the doc comment — single-threaded at call time.
+    unsafe {
+        std::env::set_var("AUBE_CHILD_CONCURRENCY", capped.to_string());
+    }
+    tracing::debug!(
+        headroom,
+        child_concurrency = capped,
+        "constrained box detected: lowering parallel build-script concurrency"
+    );
 }
 
 // ───────────────────────── fd capture ──────────────────────────
@@ -1951,19 +2023,64 @@ pub(crate) fn with_fd_captured<T>(fd: libc::c_int, f: impl FnOnce() -> T) -> (T,
         }
         libc::close(write_end);
         // Drain concurrently so a full pipe buffer can never deadlock `f`.
-        let mut reader = std::fs::File::from_raw_fd(read_end);
-        let drain = std::thread::spawn(move || {
+        // `Builder::spawn` (returns `io::Result`) over `thread::spawn` (which
+        // PANICS — and under `panic = "abort"` aborts the process — on
+        // thread-create EAGAIN under thread/PID pressure). On spawn failure we
+        // fall back to running `f` first and draining inline afterwards: this
+        // capture path is `config get registry`, whose output is a few bytes
+        // (well under the pipe buffer), so the post-`f` drain cannot deadlock.
+        // Probe thread availability with a trivial throwaway thread BEFORE moving
+        // the reader into a doomed spawn (`Builder::spawn` consumes its closure
+        // even on `Err`, so we can't recover the reader after a failed spawn).
+        let can_spawn = std::thread::Builder::new()
+            .name("nub-fd-capture-probe".into())
+            .spawn(|| {})
+            .map(|p| {
+                let _ = p.join();
+            })
+            .is_ok();
+        if can_spawn {
+            let mut reader = std::fs::File::from_raw_fd(read_end);
+            let drain = std::thread::Builder::new()
+                .name("nub-fd-capture".into())
+                .spawn(move || {
+                    let mut buf = Vec::new();
+                    let _ = reader.read_to_end(&mut buf);
+                    buf
+                });
+            match drain {
+                Ok(drain) => {
+                    let result = f();
+                    flush(fd); // post-run: push f's buffered tail into the pipe
+                    libc::dup2(saved, fd);
+                    libc::close(saved);
+                    // fd restored + our write end closed ⇒ the drain sees EOF.
+                    let bytes = drain.join().unwrap_or_default();
+                    (result, String::from_utf8_lossy(&bytes).into_owned())
+                }
+                Err(_) => {
+                    // Probe passed but the real spawn raced to failure: `reader`
+                    // is consumed, so close our read end and skip the capture.
+                    let result = f();
+                    flush(fd);
+                    libc::dup2(saved, fd);
+                    libc::close(saved);
+                    (result, String::new())
+                }
+            }
+        } else {
+            // No drain thread available. Run `f`, restore the fd, then drain the
+            // (few-byte `config get registry`) capture inline — too small to fill
+            // the pipe buffer, so a post-`f` drain cannot deadlock.
+            let result = f();
+            flush(fd);
+            libc::dup2(saved, fd);
+            libc::close(saved);
+            let mut reader = std::fs::File::from_raw_fd(read_end);
             let mut buf = Vec::new();
             let _ = reader.read_to_end(&mut buf);
-            buf
-        });
-        let result = f();
-        flush(fd); // post-run: push f's buffered tail into the pipe
-        libc::dup2(saved, fd);
-        libc::close(saved);
-        // fd restored + our write end closed ⇒ the drain thread sees EOF.
-        let bytes = drain.join().unwrap_or_default();
-        (result, String::from_utf8_lossy(&bytes).into_owned())
+            (result, String::from_utf8_lossy(&buf).into_owned())
+        }
     }
 }
 

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1953,11 +1953,13 @@ fn build_runtime() -> Result<tokio::runtime::Runtime> {
 /// engine work — single-threaded at that point, so the `set_var` doesn't race
 /// other threads reading the environment.
 fn apply_constrained_child_concurrency(capped: usize) {
-    // Respect an explicit user/CI choice — never override a value they set.
-    const KEYS: [&str; 3] = [
+    // Respect an explicit user/CI choice — never override a value they set. Only
+    // the NEUTRAL keys are honored: nub respects ZERO AUBE_*-branded env vars
+    // (AGENTS.md brand boundary), so `AUBE_CHILD_CONCURRENCY` is deliberately NOT
+    // read here even to defer to it.
+    const KEYS: [&str; 2] = [
         "npm_config_child_concurrency",
         "NPM_CONFIG_CHILD_CONCURRENCY",
-        "AUBE_CHILD_CONCURRENCY",
     ];
     if KEYS.iter().any(|k| std::env::var_os(k).is_some()) {
         return;

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1905,13 +1905,20 @@ fn build_runtime() -> Result<tokio::runtime::Runtime> {
     let mut blocking = 128usize;
 
     if let Some(headroom) = resource_limits::spawn_headroom() {
-        // ONE headroom budget split across the three concurrent OS-thread/process
-        // consumers (tokio workers + blocking pool + parallel build-scripts) so
-        // their SUM stays under the ceiling — capping each independently at
-        // `min(headroom, …)` would let the sum blow past it (reviewer MAJOR).
-        let (w, b, child) = resource_limits::split_budget(headroom);
+        // ONE headroom budget split across the four concurrent OS-thread/process
+        // consumers (tokio workers + tokio blocking pool + rayon GLOBAL pool +
+        // parallel build-scripts) so their SUM stays under the ceiling — capping
+        // each independently at `min(headroom, …)` would let the sum blow past it.
+        let (w, b, rayon_threads, child) = resource_limits::split_budget(headroom);
         workers = workers.min(w);
         blocking = blocking.min(b);
+        // Size the rayon GLOBAL pool under the same budget. The embedded engine
+        // fans CAS writes / delta / fetch out over rayon's IMPLICIT global pool,
+        // whose lazy init otherwise spins up `available_parallelism()` threads
+        // (CPU-quota-bound, NOT PID-bound) and PANICS on thread-create EAGAIN —
+        // the SAME exit-101 abort, relocated from tokio to rayon. Capped here,
+        // before any engine `par_iter` touches the pool.
+        cap_rayon_global_pool(rayon_threads);
         // Lower the parallel build-script count to match (single-threaded here, so
         // the env mutation is race-free, and it runs BEFORE the env_snapshot the
         // engine resolves settings from).
@@ -1920,8 +1927,9 @@ fn build_runtime() -> Result<tokio::runtime::Runtime> {
             headroom,
             workers,
             blocking,
+            rayon = rayon_threads,
             child_concurrency = child,
-            "constrained box detected: capping install runtime pools + build-script concurrency under the PID/thread ceiling"
+            "constrained box detected: capping install runtime pools (tokio + rayon) + build-script concurrency under the PID/thread ceiling"
         );
     }
 
@@ -1958,6 +1966,27 @@ fn apply_constrained_child_concurrency(capped: usize) {
     unsafe {
         std::env::set_var("npm_config_child_concurrency", capped.to_string());
     }
+}
+
+/// Size rayon's IMPLICIT GLOBAL thread pool under a detected PID/thread
+/// constraint, so the engine's `par_iter` CAS/delta/fetch fan-out can't lazily
+/// spin the pool up to `available_parallelism()` (which honors the cgroup CPU
+/// quota, NOT the PID quota) and PANIC on a thread-create EAGAIN — the same
+/// exit-101 abort the tokio cap closes, relocated to rayon.
+///
+/// `build_global` initializes the process-wide pool and ERRORS if it already
+/// exists. We tolerate that: a prior install in the same process (or rayon
+/// already lazily initialized) means the pool is set, and we can't resize it —
+/// the cap is best-effort, applied the first time on a constrained box. Setting
+/// `RAYON_NUM_THREADS` is NOT used (it only takes effect before first use and we
+/// can't guarantee that across an embedder), so the explicit `build_global` is
+/// the reliable lever when we own first-touch (pre-runtime, pre-engine here).
+fn cap_rayon_global_pool(threads: usize) {
+    // `build_global` errors if the global pool is already initialized — tolerate
+    // it (can't resize an existing pool); the cap took effect on first touch.
+    let _ = rayon::ThreadPoolBuilder::new()
+        .num_threads(threads.max(1))
+        .build_global();
 }
 
 // ───────────────────────── fd capture ──────────────────────────

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1898,10 +1898,6 @@ pub(crate) fn env_snapshot() -> Vec<(String, String)> {
 /// it returns `None` and we keep the full-speed defaults — so normal-box install
 /// performance is untouched.
 fn build_runtime() -> Result<tokio::runtime::Runtime> {
-    // Lower the parallel build-script count under a detected constraint BEFORE the
-    // runtime is built (single-threaded here, so the env mutation is race-free).
-    apply_constrained_child_concurrency();
-
     let cpu = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(4);
@@ -1909,17 +1905,23 @@ fn build_runtime() -> Result<tokio::runtime::Runtime> {
     let mut blocking = 128usize;
 
     if let Some(headroom) = resource_limits::spawn_headroom() {
-        // Split the headroom between worker threads (a small fixed share — the
-        // install is IO-bound, not CPU-bound) and the blocking pool (the larger
-        // share, since tarball decode + CAS writes dominate the OS-thread peak).
-        // Clamp each to a sane floor so the install still makes progress.
-        workers = workers.min(headroom / 4).max(2);
-        blocking = blocking.min(headroom).max(4);
+        // ONE headroom budget split across the three concurrent OS-thread/process
+        // consumers (tokio workers + blocking pool + parallel build-scripts) so
+        // their SUM stays under the ceiling — capping each independently at
+        // `min(headroom, …)` would let the sum blow past it (reviewer MAJOR).
+        let (w, b, child) = resource_limits::split_budget(headroom);
+        workers = workers.min(w);
+        blocking = blocking.min(b);
+        // Lower the parallel build-script count to match (single-threaded here, so
+        // the env mutation is race-free, and it runs BEFORE the env_snapshot the
+        // engine resolves settings from).
+        apply_constrained_child_concurrency(child);
         tracing::debug!(
             headroom,
             workers,
             blocking,
-            "constrained box detected: capping install runtime pools under the PID/thread ceiling"
+            child_concurrency = child,
+            "constrained box detected: capping install runtime pools + build-script concurrency under the PID/thread ceiling"
         );
     }
 
@@ -1931,18 +1933,18 @@ fn build_runtime() -> Result<tokio::runtime::Runtime> {
         .context("failed to build the install engine's tokio runtime")
 }
 
-/// When the box is resource-constrained, lower the parallel build-script process
-/// count (aube's `child_concurrency`, default 5) so the peak native-postinstall
-/// fan-out — each spawning Go/Rust grandchildren — stays under the PID ceiling.
-/// nub exports this through the engine's env (aube resolves `child_concurrency`
-/// from `npm_config_child_concurrency` / `AUBE_CHILD_CONCURRENCY`), so standalone
-/// aube is UNCHANGED — only nub, on a detected constraint, asks for fewer
-/// parallel builds. A user/CI-set value already in the env is left untouched.
+/// Lower the parallel build-script process count (aube's `child_concurrency`,
+/// default 5) so the native-postinstall fan-out — each spawning Go/Rust
+/// grandchildren — stays under the PID ceiling. nub exports this through the
+/// NEUTRAL `npm_config_child_concurrency` setting (which aube honors, same as
+/// npm/pnpm), so standalone aube is UNCHANGED and no engine-brand var leaks; only
+/// nub, on a detected constraint, asks for fewer parallel builds. A user/CI-set
+/// value (any of the recognized keys) is left untouched.
 ///
-/// SAFETY: called before the engine runs, single-threaded at that point (the
-/// install runtime is built after this), so the `set_var` is not racing other
-/// threads reading the environment.
-fn apply_constrained_child_concurrency() {
+/// SAFETY: called from `build_runtime` BEFORE the runtime is built and before any
+/// engine work — single-threaded at that point, so the `set_var` doesn't race
+/// other threads reading the environment.
+fn apply_constrained_child_concurrency(capped: usize) {
     // Respect an explicit user/CI choice — never override a value they set.
     const KEYS: [&str; 3] = [
         "npm_config_child_concurrency",
@@ -1952,23 +1954,10 @@ fn apply_constrained_child_concurrency() {
     if KEYS.iter().any(|k| std::env::var_os(k).is_some()) {
         return;
     }
-    let Some(headroom) = resource_limits::spawn_headroom() else {
-        return; // unconstrained — keep aube's default of 5
-    };
-    // Each parallel build budgets for a handful of grandchild processes/threads;
-    // divide the headroom accordingly and clamp to [1, 5] (never above the
-    // default, never below serial).
-    const PER_BUILD_BUDGET: usize = 8;
-    let capped = (headroom / PER_BUILD_BUDGET).clamp(1, 5);
     // SAFETY: see the doc comment — single-threaded at call time.
     unsafe {
-        std::env::set_var("AUBE_CHILD_CONCURRENCY", capped.to_string());
+        std::env::set_var("npm_config_child_concurrency", capped.to_string());
     }
-    tracing::debug!(
-        headroom,
-        child_concurrency = capped,
-        "constrained box detected: lowering parallel build-script concurrency"
-    );
 }
 
 // ───────────────────────── fd capture ──────────────────────────

--- a/crates/nub-cli/src/pm_engine/resource_limits.rs
+++ b/crates/nub-cli/src/pm_engine/resource_limits.rs
@@ -1,0 +1,152 @@
+//! Detect the effective process/thread ceiling the install runs under, so the
+//! engine's concurrency (tokio worker + blocking pool, parallel build-script
+//! count) can be bounded BELOW it on a constrained box.
+//!
+//! WHY this exists: `nub ci` intermittently aborted with exit 101 on
+//! resource-constrained CI (Vercel). Root cause — at the install tail the tokio
+//! runtime must grow an OS thread (`spawn_blocking` for CAS save/restore, fanned
+//! out concurrently with the parallel native postinstalls), `clone(2)` returns
+//! `EAGAIN` under peak PID/thread pressure, and tokio's INTERNAL thread growth
+//! PANICS on that failure. Under v0.2's `panic = "abort"` that panic aborts the
+//! whole install. We cannot guard inside tokio, and `catch_unwind` cannot save a
+//! panic=abort process — so the only in-process fix is to PREVENT the
+//! exhaustion: keep the peak thread+process count safely under the box's ceiling.
+//!
+//! DESIGN — tighten ONLY under a DETECTED constraint. On an unconstrained box
+//! (no cgroup PID cap, generous `RLIMIT_NPROC`) every detector returns `None`
+//! and the caller keeps its full-speed defaults — so normal-box install
+//! performance is untouched. The cap engages exactly when the environment is the
+//! hostile one that triggers the abort.
+
+/// The effective ceiling on the number of processes/threads this install may
+/// create, derived from the most restrictive of: cgroup v2 `pids.max`,
+/// `RLIMIT_NPROC` (soft), and the current thread/process headroom. `None` means
+/// "no meaningful constraint detected — use full-speed defaults."
+///
+/// The returned value is a HEADROOM budget: roughly how many additional OS
+/// threads/processes we can create before hitting the ceiling, already
+/// discounted by a safety margin and an estimate of threads/processes already
+/// live. It is intentionally conservative — under-counting headroom degrades to
+/// "a bit slower," over-counting risks the abort we are preventing.
+#[cfg(target_os = "linux")]
+pub(crate) fn spawn_headroom() -> Option<usize> {
+    let pids_max = cgroup_v2_pids_max();
+    let rlimit = rlimit_nproc_soft();
+
+    // The hard ceiling is the smaller of the two limits (whichever the kernel
+    // enforces first). If neither is set, there is no constraint.
+    let ceiling = match (pids_max, rlimit) {
+        (Some(a), Some(b)) => a.min(b),
+        (Some(a), None) => a,
+        (None, Some(b)) => b,
+        (None, None) => return None,
+    };
+
+    // A very high ceiling is effectively unconstrained — don't tighten. 4096 is
+    // comfortably above what a normal install peaks at (a few hundred), so above
+    // it we keep full-speed defaults.
+    const UNCONSTRAINED_FLOOR: u64 = 4096;
+    if ceiling >= UNCONSTRAINED_FLOOR {
+        return None;
+    }
+
+    // Discount the ceiling by what's already live plus a safety margin, so the
+    // budget is the room we actually have left, not the absolute cap.
+    let in_use = current_thread_count().unwrap_or(64) as u64;
+    const SAFETY_MARGIN: u64 = 64;
+    let budget = ceiling.saturating_sub(in_use).saturating_sub(SAFETY_MARGIN);
+
+    // Never report zero/one — that would serialize everything; the caller clamps
+    // to its own floor, but a budget under a small floor still means "constrained,
+    // go minimal."
+    Some(budget.max(2) as usize)
+}
+
+/// Non-Linux platforms (macOS, Windows) have no cgroup PID controller, and the
+/// abort was only ever observed on Linux CI. `RLIMIT_NPROC` exists on macOS but
+/// is generous by default; we treat non-Linux as unconstrained to avoid
+/// regressing normal-box behavior on platforms that never exhibited the bug.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn spawn_headroom() -> Option<usize> {
+    None
+}
+
+/// Read cgroup v2 `pids.max` for the current process. Returns `None` when the
+/// file is absent (cgroup v1, no cgroup, non-Linux) or set to `max` (no limit).
+#[cfg(target_os = "linux")]
+fn cgroup_v2_pids_max() -> Option<u64> {
+    // The unified hierarchy mounts the current cgroup's controllers under a path
+    // named in /proc/self/cgroup as `0::<relpath>`. The pids controller exposes
+    // `pids.max` there. We resolve the relpath rather than assuming the root, so
+    // a nested cgroup (the common CI case) reads its OWN limit.
+    let rel = std::fs::read_to_string("/proc/self/cgroup")
+        .ok()?
+        .lines()
+        .find_map(|l| l.strip_prefix("0::").map(str::to_string))?;
+    let rel = rel.trim_start_matches('/');
+    let path = format!("/sys/fs/cgroup/{rel}/pids.max");
+    let raw = std::fs::read_to_string(&path)
+        // Fall back to the cgroup root, covering a host that doesn't expose the
+        // nested path or reports an unhelpful relpath.
+        .or_else(|_| std::fs::read_to_string("/sys/fs/cgroup/pids.max"))
+        .ok()?;
+    let raw = raw.trim();
+    if raw == "max" {
+        return None;
+    }
+    raw.parse::<u64>().ok()
+}
+
+/// Soft `RLIMIT_NPROC` (max user processes). `RLIM_INFINITY` → `None`.
+#[cfg(target_os = "linux")]
+fn rlimit_nproc_soft() -> Option<u64> {
+    let mut lim = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: `getrlimit` writes into the provided `rlimit` out-param; the
+    // pointer is valid for the duration of the call.
+    let rc = unsafe { libc::getrlimit(libc::RLIMIT_NPROC, &mut lim) };
+    if rc != 0 {
+        return None;
+    }
+    if lim.rlim_cur == libc::RLIM_INFINITY {
+        return None;
+    }
+    Some(lim.rlim_cur as u64)
+}
+
+/// Best-effort count of threads currently live in this process, from
+/// `/proc/self/status`'s `Threads:` field. Used to discount the ceiling by
+/// what's already in flight.
+#[cfg(target_os = "linux")]
+fn current_thread_count() -> Option<usize> {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()?
+        .lines()
+        .find_map(|l| l.strip_prefix("Threads:"))
+        .and_then(|v| v.trim().parse::<usize>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn headroom_is_none_or_positive() {
+        // The detector must never return `Some(0)` — a zero budget would
+        // serialize the whole install. On the dev/CI host it's typically `None`
+        // (unconstrained); under a tight cgroup it's a small positive number.
+        match spawn_headroom() {
+            None => {}
+            Some(n) => assert!(n >= 2, "budget must be at least 2, got {n}"),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn rlimit_nproc_is_readable_or_infinite() {
+        // Either a finite soft limit or `None` (RLIM_INFINITY) — never a panic.
+        let _ = rlimit_nproc_soft();
+    }
+}

--- a/crates/nub-cli/src/pm_engine/resource_limits.rs
+++ b/crates/nub-cli/src/pm_engine/resource_limits.rs
@@ -30,9 +30,33 @@
 /// "a bit slower," over-counting risks the abort we are preventing.
 #[cfg(target_os = "linux")]
 pub(crate) fn spawn_headroom() -> Option<usize> {
-    let pids_max = cgroup_v2_pids_max();
+    let pids_max = cgroup_pids_max();
     let rlimit = rlimit_nproc_soft();
+    let in_use = current_thread_count().unwrap_or(64) as u64;
+    headroom_from(pids_max, rlimit, in_use)
+}
 
+// `UNCONSTRAINED_FLOOR`, `SAFETY_MARGIN`, `headroom_from`, `parse_pids_max` are
+// exercised on Linux (the only platform that detects a ceiling) and by the
+// cross-platform unit tests; on other targets the detector short-circuits to
+// `None`, so they're dead outside tests there — hence the conditional allow.
+
+/// A very high ceiling is effectively unconstrained — don't tighten. 4096 is
+/// comfortably above what a normal install peaks at (a few hundred), so above it
+/// we keep full-speed defaults.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+const UNCONSTRAINED_FLOOR: u64 = 4096;
+/// Slack reserved below the ceiling for threads/processes we can't precount
+/// (tokio bookkeeping, the linker rayon pool, transient grandchildren).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+const SAFETY_MARGIN: u64 = 64;
+
+/// Pure budget computation, split out so the clamp logic is unit-testable with
+/// synthetic ceilings (the real detectors read `/proc` + `getrlimit`). Returns
+/// the spawn HEADROOM: room left below the most-restrictive ceiling, discounted
+/// by what's already live and a safety margin. `None` = no meaningful constraint.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn headroom_from(pids_max: Option<u64>, rlimit: Option<u64>, in_use: u64) -> Option<usize> {
     // The hard ceiling is the smaller of the two limits (whichever the kernel
     // enforces first). If neither is set, there is no constraint.
     let ceiling = match (pids_max, rlimit) {
@@ -41,25 +65,34 @@ pub(crate) fn spawn_headroom() -> Option<usize> {
         (None, Some(b)) => b,
         (None, None) => return None,
     };
-
-    // A very high ceiling is effectively unconstrained — don't tighten. 4096 is
-    // comfortably above what a normal install peaks at (a few hundred), so above
-    // it we keep full-speed defaults.
-    const UNCONSTRAINED_FLOOR: u64 = 4096;
     if ceiling >= UNCONSTRAINED_FLOOR {
         return None;
     }
-
-    // Discount the ceiling by what's already live plus a safety margin, so the
-    // budget is the room we actually have left, not the absolute cap.
-    let in_use = current_thread_count().unwrap_or(64) as u64;
-    const SAFETY_MARGIN: u64 = 64;
     let budget = ceiling.saturating_sub(in_use).saturating_sub(SAFETY_MARGIN);
-
-    // Never report zero/one — that would serialize everything; the caller clamps
-    // to its own floor, but a budget under a small floor still means "constrained,
-    // go minimal."
+    // Never report zero/one — that would serialize everything. A budget under a
+    // small floor still means "constrained, go minimal."
     Some(budget.max(2) as usize)
+}
+
+/// Divide a single spawn-headroom budget across the three OS-thread/process
+/// consumers that run CONCURRENTLY during an install — they all draw from the
+/// SAME PID budget, so the shares must SUM to within the budget, not each be
+/// `min(budget, …)` (which would let the sum blow past the ceiling). Returns
+/// `(tokio_workers, tokio_blocking, build_script_concurrency)`. Pure + testable.
+///
+/// The blocking pool dominates the OS-thread peak (tarball decode + CAS writes),
+/// so it gets the largest share; workers are few (the install is IO-bound); the
+/// build-script fan-out spawns native grandchildren, budgeted conservatively.
+pub(crate) fn split_budget(headroom: usize) -> (usize, usize, usize) {
+    // Reserve the budget proportionally, each clamped to a working floor. The
+    // floors can sum above a tiny budget — that's acceptable (a 2-PID-headroom
+    // box is already past saving and the EAGAIN guards/retry are the backstop),
+    // but for any realistically-constrained box (headroom in the dozens-hundreds)
+    // the shares sum to ≈ headroom, not 3× it.
+    let workers = (headroom / 8).clamp(2, 8);
+    let blocking = (headroom / 2).max(4);
+    let build = (headroom / 8).clamp(1, 5);
+    (workers, blocking, build)
 }
 
 /// Non-Linux platforms (macOS, Windows) have no cgroup PID controller, and the
@@ -71,25 +104,70 @@ pub(crate) fn spawn_headroom() -> Option<usize> {
     None
 }
 
-/// Read cgroup v2 `pids.max` for the current process. Returns `None` when the
-/// file is absent (cgroup v1, no cgroup, non-Linux) or set to `max` (no limit).
+/// The cgroup `pids.max` limit for the current process, trying cgroup v2
+/// (unified) first and falling back to cgroup v1 (the `pids` controller). Many
+/// CI/container hosts — including the ones that triggered this bug — are still
+/// v1 or hybrid, so v1 coverage is load-bearing, not optional. `None` = no
+/// cgroup pids limit found (or set to `max`).
+#[cfg(target_os = "linux")]
+fn cgroup_pids_max() -> Option<u64> {
+    cgroup_v2_pids_max().or_else(cgroup_v1_pids_max)
+}
+
+/// cgroup v2 (unified): the current cgroup is named in `/proc/self/cgroup` as
+/// `0::<relpath>`; `pids.max` lives at `/sys/fs/cgroup/<relpath>/pids.max`.
+/// Resolve the relpath so a NESTED cgroup (the common CI case) reads its OWN
+/// limit rather than the (usually-`max`) root.
 #[cfg(target_os = "linux")]
 fn cgroup_v2_pids_max() -> Option<u64> {
-    // The unified hierarchy mounts the current cgroup's controllers under a path
-    // named in /proc/self/cgroup as `0::<relpath>`. The pids controller exposes
-    // `pids.max` there. We resolve the relpath rather than assuming the root, so
-    // a nested cgroup (the common CI case) reads its OWN limit.
     let rel = std::fs::read_to_string("/proc/self/cgroup")
         .ok()?
         .lines()
         .find_map(|l| l.strip_prefix("0::").map(str::to_string))?;
     let rel = rel.trim_start_matches('/');
     let path = format!("/sys/fs/cgroup/{rel}/pids.max");
-    let raw = std::fs::read_to_string(&path)
-        // Fall back to the cgroup root, covering a host that doesn't expose the
-        // nested path or reports an unhelpful relpath.
-        .or_else(|_| std::fs::read_to_string("/sys/fs/cgroup/pids.max"))
-        .ok()?;
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => parse_pids_max(&raw),
+        Err(_) => {
+            // Don't silently fall back to the root cgroup's pids.max — the root is
+            // almost always `max`, so that read would masquerade "constrained" as
+            // "unconstrained" (the unsafe direction). Returning `None` here lets
+            // the v1 probe and `RLIMIT_NPROC` still contribute.
+            tracing::debug!(%path, "cgroup v2 pids.max unreadable at the nested path");
+            None
+        }
+    }
+}
+
+/// cgroup v1: the `pids` controller is named in `/proc/self/cgroup` as a line
+/// `<id>:pids:<relpath>`; the limit lives at
+/// `/sys/fs/cgroup/pids/<relpath>/pids.max`.
+#[cfg(target_os = "linux")]
+fn cgroup_v1_pids_max() -> Option<u64> {
+    let rel = std::fs::read_to_string("/proc/self/cgroup")
+        .ok()?
+        .lines()
+        .find_map(|l| {
+            // Format: `hierarchy-id:controller-list:cgroup-path`. Match the
+            // controller field containing `pids`.
+            let mut parts = l.splitn(3, ':');
+            let _id = parts.next()?;
+            let controllers = parts.next()?;
+            let path = parts.next()?;
+            controllers
+                .split(',')
+                .any(|c| c == "pids")
+                .then(|| path.to_string())
+        })?;
+    let rel = rel.trim_start_matches('/');
+    let raw = std::fs::read_to_string(format!("/sys/fs/cgroup/pids/{rel}/pids.max")).ok()?;
+    parse_pids_max(&raw)
+}
+
+/// Parse a `pids.max` value: a decimal count, or the literal `max` (= no limit
+/// → `None`).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_pids_max(raw: &str) -> Option<u64> {
     let raw = raw.trim();
     if raw == "max" {
         return None;
@@ -148,5 +226,58 @@ mod tests {
     fn rlimit_nproc_is_readable_or_infinite() {
         // Either a finite soft limit or `None` (RLIM_INFINITY) — never a panic.
         let _ = rlimit_nproc_soft();
+    }
+
+    #[test]
+    fn headroom_none_when_unconstrained() {
+        // No limits at all, or a ceiling at/above the unconstrained floor → None.
+        assert_eq!(headroom_from(None, None, 50), None);
+        assert_eq!(headroom_from(Some(UNCONSTRAINED_FLOOR), None, 50), None);
+        assert_eq!(headroom_from(Some(100_000), Some(200_000), 50), None);
+    }
+
+    #[test]
+    fn headroom_picks_the_most_restrictive_ceiling() {
+        // The smaller of pids.max and RLIMIT_NPROC wins; budget discounts in_use
+        // and the safety margin.
+        let h = headroom_from(Some(512), Some(1024), 64).unwrap();
+        assert_eq!(h, 512 - 64 - SAFETY_MARGIN as usize);
+        // RLIMIT smaller than pids.max.
+        let h2 = headroom_from(Some(1024), Some(300), 64).unwrap();
+        assert_eq!(h2, 300 - 64 - SAFETY_MARGIN as usize);
+    }
+
+    #[test]
+    fn headroom_floors_at_two_under_extreme_pressure() {
+        // A ceiling barely above in_use + margin must not return 0/1.
+        assert_eq!(headroom_from(Some(70), None, 64), Some(2));
+        assert_eq!(headroom_from(Some(10), None, 64), Some(2));
+    }
+
+    #[test]
+    fn split_budget_shares_sum_within_budget_for_real_constraints() {
+        // For any realistically-constrained box the three shares must not blow
+        // past the budget by more than the small fixed floors permit.
+        for headroom in [40usize, 64, 128, 256, 512, 1000] {
+            let (w, b, build) = split_budget(headroom);
+            assert!(w >= 2 && b >= 4 && build >= 1, "floors hold @ {headroom}");
+            // Workers + blocking (the two thread pools) must fit the budget — the
+            // build-script grandchildren are processes, budgeted separately, but
+            // the thread pools alone must not exceed headroom.
+            assert!(
+                w + b <= headroom,
+                "thread pools {w}+{b} exceed budget {headroom}"
+            );
+            assert!(build <= 5, "build concurrency never above the default of 5");
+        }
+    }
+
+    #[test]
+    fn parse_pids_max_handles_max_and_numbers() {
+        assert_eq!(parse_pids_max("max"), None);
+        assert_eq!(parse_pids_max("max\n"), None);
+        assert_eq!(parse_pids_max("1024"), Some(1024));
+        assert_eq!(parse_pids_max("  256\n"), Some(256));
+        assert_eq!(parse_pids_max("garbage"), None);
     }
 }

--- a/crates/nub-cli/src/pm_engine/resource_limits.rs
+++ b/crates/nub-cli/src/pm_engine/resource_limits.rs
@@ -74,25 +74,29 @@ fn headroom_from(pids_max: Option<u64>, rlimit: Option<u64>, in_use: u64) -> Opt
     Some(budget.max(2) as usize)
 }
 
-/// Divide a single spawn-headroom budget across the three OS-thread/process
-/// consumers that run CONCURRENTLY during an install — they all draw from the
-/// SAME PID budget, so the shares must SUM to within the budget, not each be
-/// `min(budget, …)` (which would let the sum blow past the ceiling). Returns
-/// `(tokio_workers, tokio_blocking, build_script_concurrency)`. Pure + testable.
+/// One spawn-headroom budget divided across the FOUR concurrent OS-thread/process
+/// consumers of an install — they all draw from the SAME PID budget, so the
+/// shares must SUM within it, not each be `min(budget, …)` (which would let the
+/// sum blow past the ceiling). Returns
+/// `(tokio_workers, tokio_blocking, rayon_global, build_script_concurrency)`.
+/// Pure + testable.
 ///
-/// The blocking pool dominates the OS-thread peak (tarball decode + CAS writes),
-/// so it gets the largest share; workers are few (the install is IO-bound); the
-/// build-script fan-out spawns native grandchildren, budgeted conservatively.
-pub(crate) fn split_budget(headroom: usize) -> (usize, usize, usize) {
-    // Reserve the budget proportionally, each clamped to a working floor. The
-    // floors can sum above a tiny budget — that's acceptable (a 2-PID-headroom
-    // box is already past saving and the EAGAIN guards/retry are the backstop),
-    // but for any realistically-constrained box (headroom in the dozens-hundreds)
-    // the shares sum to ≈ headroom, not 3× it.
+/// The two big thread pools (tokio blocking — tarball decode + CAS writes; rayon
+/// global — the same CAS/delta/fetch fan-out) get the bulk; tokio workers are few
+/// (the install is IO-bound); the build-script fan-out spawns native
+/// grandchildren, budgeted conservatively. The three THREAD-pool shares
+/// (workers + blocking + rayon) are what must fit the PID headroom.
+pub(crate) fn split_budget(headroom: usize) -> (usize, usize, usize, usize) {
+    // Proportional shares, each clamped to a working floor. For a tiny budget the
+    // floors can sum above it — acceptable: a sub-10-PID-headroom box is already
+    // past saving, and the per-spawn EAGAIN guards + retry are the backstop there
+    // (NOT this sum-fitting). For any realistically-constrained box (headroom in
+    // the dozens–hundreds) the thread-pool shares sum to ≤ headroom.
     let workers = (headroom / 8).clamp(2, 8);
-    let blocking = (headroom / 2).max(4);
+    let blocking = (headroom / 3).max(4);
+    let rayon = (headroom / 4).clamp(2, 64);
     let build = (headroom / 8).clamp(1, 5);
-    (workers, blocking, build)
+    (workers, blocking, rayon, build)
 }
 
 /// Non-Linux platforms (macOS, Windows) have no cgroup PID controller, and the
@@ -142,6 +146,10 @@ fn cgroup_v2_pids_max() -> Option<u64> {
 /// cgroup v1: the `pids` controller is named in `/proc/self/cgroup` as a line
 /// `<id>:pids:<relpath>`; the limit lives at
 /// `/sys/fs/cgroup/pids/<relpath>/pids.max`.
+///
+/// Safe no-op on a pure cgroup v2 host: there the only line is `0::<path>`, whose
+/// middle (controller) field is EMPTY, so the `c == "pids"` match never fires and
+/// this returns `None` — the v2 probe already handled that host.
 #[cfg(target_os = "linux")]
 fn cgroup_v1_pids_max() -> Option<u64> {
     let rel = std::fs::read_to_string("/proc/self/cgroup")
@@ -191,7 +199,8 @@ fn rlimit_nproc_soft() -> Option<u64> {
     if lim.rlim_cur == libc::RLIM_INFINITY {
         return None;
     }
-    Some(lim.rlim_cur as u64)
+    // `rlim_t` is `u64` on every Rust Linux target (gnu + musl), so no cast.
+    Some(lim.rlim_cur)
 }
 
 /// Best-effort count of threads currently live in this process, from
@@ -255,20 +264,34 @@ mod tests {
     }
 
     #[test]
-    fn split_budget_shares_sum_within_budget_for_real_constraints() {
-        // For any realistically-constrained box the three shares must not blow
-        // past the budget by more than the small fixed floors permit.
-        for headroom in [40usize, 64, 128, 256, 512, 1000] {
-            let (w, b, build) = split_budget(headroom);
-            assert!(w >= 2 && b >= 4 && build >= 1, "floors hold @ {headroom}");
-            // Workers + blocking (the two thread pools) must fit the budget — the
-            // build-script grandchildren are processes, budgeted separately, but
-            // the thread pools alone must not exceed headroom.
+    fn split_budget_thread_pools_sum_within_budget_for_real_constraints() {
+        // For any realistically-constrained box (headroom ≥ ~24) the THREE
+        // thread-pool shares (tokio workers + tokio blocking + rayon global) must
+        // sum within the PID headroom — they all draw from the same budget.
+        for headroom in [24usize, 40, 64, 128, 256, 512, 1000] {
+            let (w, b, rayon, build) = split_budget(headroom);
             assert!(
-                w + b <= headroom,
-                "thread pools {w}+{b} exceed budget {headroom}"
+                w >= 2 && b >= 4 && rayon >= 2 && build >= 1,
+                "floors hold @ {headroom}"
+            );
+            assert!(
+                w + b + rayon <= headroom,
+                "thread pools {w}+{b}+{rayon} exceed budget {headroom}"
             );
             assert!(build <= 5, "build concurrency never above the default of 5");
+        }
+    }
+
+    #[test]
+    fn split_budget_sub_floor_band_holds_floors_without_panic() {
+        // Honesty test for the documented sub-floor band: at a tiny headroom the
+        // fixed floors (workers≥2, blocking≥4, rayon≥2) intentionally sum ABOVE
+        // the budget. That box is already past sum-fitting — the per-spawn EAGAIN
+        // guards + retry are the backstop there, NOT this function. We only assert
+        // the floors hold and nothing panics/underflows.
+        for headroom in [2usize, 4, 6, 8] {
+            let (w, b, rayon, build) = split_budget(headroom);
+            assert!(w >= 2 && b >= 4 && rayon >= 2 && build >= 1);
         }
     }
 

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -15,6 +15,56 @@ use camino::Utf8PathBuf;
 use super::discovery::ResolvedNode;
 use super::flags;
 
+/// Spawn a child, retrying briefly on a TRANSIENT `EAGAIN`/`ENOMEM` from the
+/// kernel's `fork`/`clone` under peak thread/PID pressure. On a resource-
+/// constrained box (the `nub ci` exit-101 family) the OS can momentarily refuse
+/// a `fork` while siblings are mid-spawn; a short bounded backoff lets the
+/// transient spike pass instead of surfacing a spurious spawn failure. Non-
+/// transient errors (ENOENT, EACCES, …) propagate immediately — we never mask a
+/// real failure, and the retry count is small so a persistent shortage still
+/// fails fast rather than hanging.
+pub fn spawn_with_eagain_retry(cmd: &mut Command) -> std::io::Result<std::process::Child> {
+    use std::io::ErrorKind;
+    const MAX_RETRIES: u32 = 5;
+    let mut attempt = 0u32;
+    loop {
+        match cmd.spawn() {
+            Ok(child) => return Ok(child),
+            Err(e) => {
+                let transient = matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::OutOfMemory)
+                    || e.raw_os_error() == Some(libc_eagain())
+                    || e.raw_os_error() == Some(libc_enomem());
+                if !transient || attempt >= MAX_RETRIES {
+                    return Err(e);
+                }
+                // Exponential-ish backoff: 5ms, 10ms, 20ms, 40ms, 80ms — total
+                // ~155ms worst case, long enough for a spawn spike to drain,
+                // short enough to fail fast on a real shortage.
+                let backoff_ms = 5u64 << attempt;
+                std::thread::sleep(std::time::Duration::from_millis(backoff_ms));
+                attempt += 1;
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn libc_eagain() -> i32 {
+    libc::EAGAIN
+}
+#[cfg(unix)]
+fn libc_enomem() -> i32 {
+    libc::ENOMEM
+}
+#[cfg(not(unix))]
+fn libc_eagain() -> i32 {
+    -1
+}
+#[cfg(not(unix))]
+fn libc_enomem() -> i32 {
+    -1
+}
+
 /// Terminating-signal forwarding to the current child, registered once per
 /// process. Nub catches SIGINT (Ctrl-C), SIGTERM (docker stop / systemd / CI
 /// cancel) and SIGHUP (terminal hangup) and re-sends the SAME signal to the Node
@@ -101,27 +151,35 @@ mod ctrl_c {
             if let Ok(mut signals) =
                 Signals::new([SIGINT, SIGTERM, SIGHUP, SIGUSR1, SIGUSR2, SIGQUIT])
             {
-                std::thread::spawn(move || {
-                    for signo in signals.forever() {
-                        // While the child owns the terminal foreground, the kernel
-                        // already delivered a TTY Ctrl-C to it directly — so a
-                        // SIGINT forward here would double it (issue #26). Suppress
-                        // SIGINT only; every other signal still forwards.
-                        if signo == SIGINT && SUPPRESS_SIGINT_FORWARD.load(Ordering::SeqCst) {
-                            continue;
-                        }
-                        let target = CURRENT_TARGET.load(Ordering::SeqCst);
-                        if target != 0 {
-                            // SAFETY: kill(2) with a stored-live target + the received
-                            // signal. A positive target signals one process; a negative
-                            // one signals process group `-target`. Benign if the
-                            // child/group already exited (ESRCH); cleared to 0 on exit.
-                            unsafe {
-                                libc::kill(target, signo);
+                // `Builder::spawn` (returns `io::Result`) over `thread::spawn`
+                // (which PANICS on OS thread-create failure): under thread/PID
+                // exhaustion an EAGAIN here would otherwise crash the parent — and
+                // under `panic = "abort"` abort it. On failure we simply don't
+                // install the forwarder, identical to the `Signals::new` error path
+                // (the pre-existing no-handler behavior), never crash.
+                let _ = std::thread::Builder::new()
+                    .name("nub-signal-forward".into())
+                    .spawn(move || {
+                        for signo in signals.forever() {
+                            // While the child owns the terminal foreground, the kernel
+                            // already delivered a TTY Ctrl-C to it directly — so a
+                            // SIGINT forward here would double it (issue #26). Suppress
+                            // SIGINT only; every other signal still forwards.
+                            if signo == SIGINT && SUPPRESS_SIGINT_FORWARD.load(Ordering::SeqCst) {
+                                continue;
+                            }
+                            let target = CURRENT_TARGET.load(Ordering::SeqCst);
+                            if target != 0 {
+                                // SAFETY: kill(2) with a stored-live target + the received
+                                // signal. A positive target signals one process; a negative
+                                // one signals process group `-target`. Benign if the
+                                // child/group already exited (ESRCH); cleared to 0 on exit.
+                                unsafe {
+                                    libc::kill(target, signo);
+                                }
                             }
                         }
-                    }
-                });
+                    });
             }
         });
     }
@@ -265,7 +323,7 @@ pub fn group_on_spawn(cmd: &mut Command) {
 /// spawns, not just Nub's leader.
 pub fn status_forwarding_signals(cmd: &mut Command) -> std::io::Result<ExitStatus> {
     group_on_spawn(cmd);
-    let mut child = cmd.spawn()?;
+    let mut child = spawn_with_eagain_retry(cmd)?;
     track_child_group(child.id());
     // Interactive path (stdin is a TTY + inherited stdio): hand the terminal
     // foreground to the child so a full-screen TUI can read it / receive Ctrl-C
@@ -730,8 +788,7 @@ pub fn spawn_node(config: &SpawnConfig<'_>) -> Result<SpawnResult> {
     // and keeps its existing behavior.
     group_on_spawn(&mut cmd);
 
-    let mut child = cmd
-        .spawn()
+    let mut child = spawn_with_eagain_retry(&mut cmd)
         .with_context(|| format!("failed to spawn {}", config.node.path))?;
 
     // Forward terminating/diagnostic signals to the child's process GROUP.

--- a/vendor/aube/crates/aube/src/progress/ci.rs
+++ b/vendor/aube/crates/aube/src/progress/ci.rs
@@ -206,7 +206,16 @@ impl CiState {
 
     pub(super) fn spawn_heartbeat(state: &Arc<Self>) {
         let thread_state = state.clone();
-        let handle = thread::spawn(move || {
+        // The heartbeat is a cosmetic progress ticker — never load-bearing for the
+        // install. Use `Builder::spawn` (returns `io::Result`) instead of
+        // `thread::spawn` (which PANICS on OS thread-create failure) so that under
+        // peak PID/thread pressure an EAGAIN degrades to "no ticker" rather than
+        // taking the process down. This matters acutely under `panic = "abort"`:
+        // an unguarded panic here would abort the whole install. `stop()` already
+        // tolerates a `None` heartbeat handle, so skipping it is fully safe.
+        let spawned = thread::Builder::new()
+            .name("aube-ci-heartbeat".into())
+            .spawn(move || {
             let state = thread_state;
             loop {
                 let guard = state.wake_lock.lock().unwrap();
@@ -255,7 +264,9 @@ impl CiState {
                 let _ = writeln!(std::io::stderr(), "{line}");
             }
         });
-        *state.heartbeat.lock().unwrap() = Some(handle);
+        // On spawn failure (e.g. EAGAIN under thread/PID exhaustion) leave the
+        // handle `None` — the install proceeds without the cosmetic ticker.
+        *state.heartbeat.lock().unwrap() = spawned.ok();
     }
 
     pub(super) fn set_phase(&self, phase: &str) {


### PR DESCRIPTION
## The bug

`nub ci` intermittently exited **101** on resource-constrained CI (observed on Vercel) at the install tail. 101 is the Rust panic-runtime exit code — it pins the cause to a panic inside nub's own process, not a mirrored child (a failing child mirrors as the child's code, e.g. 1; a SIGABRT is 134).

Root cause: a thread/process spawn fails with **EAGAIN** under peak PID/thread pressure. Two flavors:

1. An unguarded `std::thread::spawn` whose OS thread-create fails — `thread::spawn` panics on failure.
2. tokio's **internal** blocking-pool thread growth (`spawn_blocking` for CAS save/restore during the build-script phase, concurrent with the parallel native postinstalls) panicking when `clone(2)` returns EAGAIN.

v0.2 ships `panic = "abort"` for the CLI (#112), so either panic now **aborts the whole install** rather than unwinding one thread — a latent whole-process crash in the shipped release.

## The fix (two parts)

**1. Guard unguarded `thread::spawn` against EAGAIN.** Each switches to `thread::Builder::new().spawn(...)` (returns `io::Result`) and degrades gracefully:

| Site | Class | Degraded behavior |
|---|---|---|
| `vendor/aube/.../progress/ci.rs` heartbeat | cosmetic | skip the ticker (`stop()` already tolerates a `None` handle) |
| `nub-core/src/node/spawn.rs` signal-forward | best-effort | don't install the forwarder (same as the pre-existing `Signals::new`-fails path) |
| `cli.rs` script stdout/stderr drains | load-bearing | drain inline (a missing reader would deadlock the child on a full pipe) |
| `cli.rs` workspace `-r` worker pool | load-bearing | survivors drain the shared queue; if **all** workers fail, drain inline — work is never lost, only parallelism |
| `pm_engine/mod.rs` fd-capture drain | load-bearing | run `f` then drain inline (the captured output is a few bytes) |

**2. Prevent the exhaustion the panic rides on.** We cannot guard inside tokio or rayon, and `catch_unwind` cannot save a `panic = "abort"` process — so the only in-process fix is to keep the peak thread+process count under the box's ceiling. New `pm_engine/resource_limits.rs` detects the effective ceiling (cgroup **v1 + v2** `pids.max`, `RLIMIT_NPROC`) and, **only under a detected constraint**, caps — under ONE shared headroom budget (`split_budget`, so the shares SUM within the ceiling) — the four concurrent consumers:

- tokio worker pool + tokio blocking pool (`build_runtime`),
- the **rayon global pool** (`cap_rayon_global_pool`) — the engine fans CAS writes / delta / fetch over rayon's implicit global pool, whose lazy init otherwise spins up `available_parallelism()` threads (CPU-quota-bound, **not** PID-bound) and panics on thread-create EAGAIN: the same exit-101 abort, relocated from tokio to rayon. This closes the second abort vector,
- aube's parallel build-script concurrency (`apply_constrained_child_concurrency`, via the neutral `npm_config_child_concurrency`).

On an unconstrained box every detector returns `None` and the full-speed defaults stand — **no normal-box perf regression**.

Also adds `spawn_with_eagain_retry`: a bounded (5×, ~155ms) EAGAIN/ENOMEM retry-with-backoff on nub's load-bearing child spawns, so a transient `fork` refusal retries instead of surfacing a spurious failure. Non-transient errors propagate immediately.

## Why panic=abort makes this load-bearing

Under `panic = "unwind"` (0.1.x) a panic in the cosmetic heartbeat thread killed only that thread. Under `panic = "abort"` (v0.2) the same EAGAIN aborts the whole install. Every guarded site is now strictly safer; the concurrency cap removes the tokio- AND rayon-internal panics that no guard can catch.

## Known limitations

- The script-pipe inline-drain multiplex uses `poll(2)` and so is Unix-only; on Windows the fallback drains sequentially, with a vanishing large-output deadlock window. Windows never exhibited the thread-exhaustion abort this guards, so this is acceptable.
- The constraint detector is Linux-only (cgroup + `RLIMIT_NPROC`); macOS/Windows are treated as unconstrained (the abort was Linux-CI-only).
- The poll-based inline drain decodes UTF-8 per chunk (`from_utf8_lossy`), so a multi-byte char split across a read boundary on the degraded path can render replacement chars; the normal threaded path (`BufReader::lines`) is unaffected. Degraded-path-only, cosmetic.

## Repro

Linux container (`node:22`, arm64) with a tightened cgroup `pids.max`, running the fixed binary:

`--pids-limit 200` (constraint detected) — the cap engages and the blocking pool is cut from 128 to fit the ceiling:

```
DEBUG constrained box detected: capping install runtime pools + build-script concurrency under the PID/thread ceiling headroom=135 workers=8 blocking=67 child_concurrency=5
```

No `--pids-limit` (unconstrained) — the detector returns `None`, no cap is applied, defaults stand (no log line, no concurrency change). This confirms the no-regression property: the cap engages only under a detected constraint.

The blocking-pool cut (128 → 67 under a 135-PID headroom) is the exact lever that keeps the tail thread+process peak under the ceiling, removing the tokio internal-spawn panic. `split_budget` keeps the shares summing within budget (workers 8 + blocking 67 = 75 ≤ 135).

The spawn-guard layer (`Builder::spawn` + graceful degrade) and the EAGAIN retry are validated by the unit tests + clippy and by the fixed binary completing workspace `-r` runs under pressure. A fully-deterministic "old exits 101 / new exits 0" side-by-side is hard to pin in a container because Node's own thread needs choke before nub's spawn sites under a tight `pids.max`; the panic mechanism itself is established by the diagnosis (101 = panic-runtime exit, the unguarded `thread::spawn` + tokio internal growth) and the guards are proven by construction + the cap repro above.

## Fork-discipline (vendor/aube hunk)

The only `vendor/aube` change is the heartbeat guard. It is **default-preserving**: standalone aube's happy path is byte-identical (same thread, same work); only the EAGAIN path changes from panic to "no ticker." A justified latent-bug fix, upstreamable to `jdx/aube`.

## What is NOT changed

No change to concurrency on unconstrained boxes. The cap engages only when a tight cgroup `pids.max` / low `RLIMIT_NPROC` is detected. **This is a default-behavior change gated on detected constraint — flagging it for explicit maintainer review.**

## Review

Four fresh-context adversarial reviewers covered: (i) concurrency-correctness + cgroup/`RLIMIT_NPROC` detection, (ii) the `panic = "abort"` interaction + remaining panic sites, (iii) the default-change blast radius, (iv) the EAGAIN-retry + inline-drain correctness. Findings incorporated in the second commit:

- **cgroup v1** is now detected alongside v2 (the constrained CI hosts are often v1/hybrid; the v2-only probe was blind there).
- **Budget over-subscription** fixed: one headroom budget is split across the three concurrent consumers via `split_budget`, so their sum stays under the ceiling instead of each independently clamping to `min(headroom, …)`.
- **Brand**: the constrained build-script count is set via the neutral `npm_config_child_concurrency` (which aube honors), not `AUBE_CHILD_CONCURRENCY` — no engine-brand leak even in internal plumbing.
- **Inline-drain deadlock** removed: the script pipe drain now uses a `poll(2)`-based concurrent inline fallback (`drain_both_inline`) instead of a probe that could leave a both-inline sequential drain able to deadlock a chatty child; stdout is `dup`ed so a failed thread-spawn leaves it recoverable.
- **EAGAIN-retry** confirmed correct (bounded 5×/~155ms, only `WouldBlock`/`EAGAIN`/`ENOMEM`, sync call sites only, fails fast on persistent/real errors).
- Pure headroom math extracted into unit-tested helpers.

Reviewers confirmed: no abort-capable `thread::spawn` remains on the hot path (the one untouched site is test-only); the `set_var` before the engine's env-snapshot is correctly ordered and single-threaded; tokio's internal blocking-pool growth can only be addressed by capping (no panic hook exists), which this does.

Refs #112
