### PR TITLE
perf(pm): read each config file once per command via an mtime-validated cache

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -730,6 +730,29 @@ pub(crate) fn session_role_root(
     Some((role, detected.dir.clone()))
 }
 
+/// Per-process, mtime-validated cache of parsed `aube_manifest::PackageJson`
+/// keyed by file path. The PM-engine config phase parses the root manifest
+/// through aube's parser several times per command — `apply_config_scope`, the
+/// scan's `manifest_has_pnpm_overrides`, and `injected_deps_present`'s
+/// `manifest_has_injected` — and `first_catalog_specifier` parses every member
+/// manifest. This collapses repeat parses of one path to a single read. mtime
+/// validation keeps it stale-proof (a mid-command engine rewrite re-reads).
+///
+/// A parse ERROR (or missing file) yields `None` and is NOT cached, matching
+/// every call site's existing `let Ok(..) = .. else { skip }` handling exactly.
+static AUBE_MANIFEST_CACHE: nub_core::config_cache::MtimeCache<aube_manifest::PackageJson> =
+    nub_core::config_cache::MtimeCache::new();
+
+/// Read + parse `path` as an `aube_manifest::PackageJson` through
+/// [`AUBE_MANIFEST_CACHE`]. `None` on a missing/unparseable manifest (never
+/// cached) — behavior-identical to a direct `PackageJson::from_path(path).ok()`,
+/// just deduplicated across the repeat parses one command makes of the same path.
+pub(crate) fn cached_aube_manifest(
+    path: &Path,
+) -> Option<std::sync::Arc<aube_manifest::PackageJson>> {
+    AUBE_MANIFEST_CACHE.get_or_read(path, || aube_manifest::PackageJson::from_path(path).ok())
+}
+
 /// Apply the config-scoping policy for one verb invocation: resolve the
 /// active-PM role, scope the manifest's graph-shaping override fields to
 /// that role's dialect, register the scoped source + trusted-deps toggle on
@@ -751,7 +774,7 @@ fn apply_config_scope(
 
     let root = detected.map(|d| d.dir.as_path()).unwrap_or(cwd);
     let manifest_path = root.join("package.json");
-    let Ok(manifest) = aube_manifest::PackageJson::from_path(&manifest_path) else {
+    let Some(manifest) = cached_aube_manifest(&manifest_path) else {
         return Ok(());
     };
 
@@ -873,8 +896,7 @@ fn first_catalog_specifier(manifest: &aube_manifest::PackageJson, root: &Path) -
     // independently, so a member-only `catalog:` ref must refuse too.
     if let Ok(members) = aube_workspace::find_workspace_packages(root) {
         for dir in members {
-            let Ok(member) = aube_manifest::PackageJson::from_path(&dir.join("package.json"))
-            else {
+            let Some(member) = cached_aube_manifest(&dir.join("package.json")) else {
                 continue;
             };
             if let Some(hit) = first_catalog_in_dep_maps(&member) {

--- a/crates/nub-cli/src/pm_engine/unsupported_config.rs
+++ b/crates/nub-cli/src/pm_engine/unsupported_config.rs
@@ -31,8 +31,27 @@
 //! symmetric brand-boundary discipline the rest of `pm_engine` enforces.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use nub_core::config_cache::MtimeCache;
 
 use super::config_scope::{IgnoredField, Role};
+
+/// Per-process, mtime-validated cache of raw config-file CONTENTS keyed by path.
+/// The unsupported-config readers each opened the same `.yarnrc.yml` / `.npmrc`
+/// file once PER KEY (immutable, scripts, network, hardened; omit, include,
+/// legacy-peer-deps, install-strategy) — several reads of one file per command.
+/// This collapses them to a single read per `(path, mtime)`; the per-key parse
+/// then runs against the cached string. mtime validation keeps it stale-proof:
+/// any rewrite of the file bumps the mtime, the next lookup misses and re-reads.
+static CONFIG_TEXT_CACHE: MtimeCache<String> = MtimeCache::new();
+
+/// Read a config file's full contents through [`CONFIG_TEXT_CACHE`]. `None`
+/// (missing / unreadable) is never cached — identical to `read_to_string().ok()`
+/// on those paths, just deduplicated across repeated readers in one command.
+fn read_config_text(path: &Path) -> Option<Arc<String>> {
+    CONFIG_TEXT_CACHE.get_or_read(path, || std::fs::read_to_string(path).ok())
+}
 
 /// A config-derived override of the dependency selection axis
 /// (`--prod`/`--dev`/`--no-optional`). `None` per field means "not pinned by
@@ -81,7 +100,7 @@ fn npm_omit_include(root: &Path) -> DepSelectionConfig {
     let mut omit: Vec<String> = Vec::new();
     let mut include: Vec<String> = Vec::new();
     for path in npmrc_paths(root) {
-        let Ok(content) = std::fs::read_to_string(&path) else {
+        let Some(content) = read_config_text(&path) else {
             continue;
         };
         if let Some(v) = npmrc_scalar(&content, "omit") {
@@ -132,7 +151,7 @@ pub(crate) fn frozen_from_config(role: Role, root: &Path) -> bool {
 /// yarn `.yarnrc.yml` `enableImmutableInstalls: true` or a non-empty
 /// `immutablePatterns:` block.
 fn yarn_immutable(root: &Path) -> bool {
-    let Ok(content) = std::fs::read_to_string(root.join(".yarnrc.yml")) else {
+    let Some(content) = read_config_text(&root.join(".yarnrc.yml")) else {
         return false;
     };
     if yarnrc_top_level_bool(&content, "enableImmutableInstalls") == Some(true) {
@@ -149,8 +168,7 @@ pub(crate) fn yarn_scripts_disabled(role: Role, root: &Path) -> bool {
     if role != Role::Yarn {
         return false;
     }
-    std::fs::read_to_string(root.join(".yarnrc.yml"))
-        .ok()
+    read_config_text(&root.join(".yarnrc.yml"))
         .and_then(|c| yarnrc_top_level_bool(&c, "enableScripts"))
         == Some(false)
 }
@@ -165,8 +183,7 @@ pub(crate) fn yarn_network_disabled(role: Role, root: &Path) -> bool {
     if role != Role::Yarn {
         return false;
     }
-    std::fs::read_to_string(root.join(".yarnrc.yml"))
-        .ok()
+    read_config_text(&root.join(".yarnrc.yml"))
         .and_then(|c| yarnrc_top_level_bool(&c, "enableNetwork"))
         == Some(false)
 }
@@ -182,8 +199,8 @@ pub(crate) fn yarn_network_disabled(role: Role, root: &Path) -> bool {
 /// The classic `.yarnrc` is a space-separated `key "value"` format (parsed by
 /// Yarn 1's own lockfile parser), distinct from Berry's `.yarnrc.yml`.
 fn yarn_offline_mirror_configured(root: &Path) -> bool {
-    std::fs::read_to_string(root.join(".yarnrc"))
-        .is_ok_and(|c| classic_yarnrc_has_key(&c, "yarn-offline-mirror"))
+    read_config_text(&root.join(".yarnrc"))
+        .is_some_and(|c| classic_yarnrc_has_key(&c, "yarn-offline-mirror"))
 }
 
 /// Whether the root (or any workspace member) manifest declares
@@ -201,7 +218,7 @@ pub(crate) fn injected_deps_present(root: &Path) -> bool {
 }
 
 fn manifest_has_injected(manifest_path: &Path) -> bool {
-    let Ok(manifest) = aube_manifest::PackageJson::from_path(manifest_path) else {
+    let Some(manifest) = super::cached_aube_manifest(manifest_path) else {
         return false;
     };
     let Some(meta) = manifest
@@ -358,7 +375,7 @@ fn scan_warn(role: Role, root: &Path) -> Vec<IgnoredField> {
 }
 
 fn manifest_has_pnpm_overrides(root: &Path) -> bool {
-    let Ok(manifest) = aube_manifest::PackageJson::from_path(&root.join("package.json")) else {
+    let Some(manifest) = super::cached_aube_manifest(&root.join("package.json")) else {
         return false;
     };
     manifest
@@ -371,7 +388,7 @@ fn manifest_has_pnpm_overrides(root: &Path) -> bool {
 }
 
 fn yarnrc_top_level_bool_str(root: &Path, key: &str) -> Option<bool> {
-    let content = std::fs::read_to_string(root.join(".yarnrc.yml")).ok()?;
+    let content = read_config_text(&root.join(".yarnrc.yml"))?;
     yarnrc_top_level_bool(&content, key)
 }
 
@@ -426,7 +443,7 @@ fn npmrc_value_in(paths: &[PathBuf], key: &str) -> Option<String> {
     paths
         .iter()
         .filter_map(|path| {
-            let content = std::fs::read_to_string(path).ok()?;
+            let content = read_config_text(path)?;
             npmrc_scalar(&content, key)
         })
         .next_back()
@@ -505,7 +522,7 @@ fn split_list(v: &str) -> Vec<String> {
 fn bunfig_install_bool(root: &Path, key: &str) -> Option<bool> {
     let mut value = None;
     for path in bunfig_paths(root) {
-        if let Ok(raw) = std::fs::read_to_string(&path)
+        if let Some(raw) = read_config_text(&path)
             && let Ok(parsed) = raw.parse::<toml::Value>()
             && let Some(b) = parsed
                 .get("install")

--- a/crates/nub-core/src/config_cache.rs
+++ b/crates/nub-core/src/config_cache.rs
@@ -1,0 +1,267 @@
+//! Per-process, mtime-validated cache for config-file reads.
+//!
+//! The PM engine re-reads and re-parses the same handful of files (the root
+//! `package.json`, `.yarnrc.yml`, the `.npmrc` ancestor chain) several times
+//! per command — once during `engine_session` construction, again from the
+//! later `install_config_signals` / `session_role_root` reads. Each read is a
+//! `stat` + `read` + parse the previous read already did.
+//!
+//! This is a memoizer for the READ/parse phase only. The single thing that
+//! makes it correct rather than a stale-value hazard: every lookup re-stats the
+//! file and serves the cached value ONLY when the file's modification time is
+//! unchanged. A mutation (the in-process aube engine rewriting `package.json`
+//! mid-command) bumps the mtime, the next lookup misses, and the file is
+//! re-read. So the no-stale-read property is STRUCTURAL — it does not depend on
+//! call-ordering analysis: a cache validated on mtime can never serve a value
+//! older than the file on disk.
+//!
+//! Cache MISS semantics match an uncached read exactly: a missing/unreadable
+//! file, or a file whose mtime is unavailable, is never cached (the closure
+//! re-runs every time), so behavior is byte-for-byte identical to the
+//! pre-cache code on those paths.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::SystemTime;
+
+/// A path-keyed cache whose entries are invalidated when the underlying file's
+/// freshness stamp — its `(mtime, size)` pair — changes. Stores `Arc<V>` so a
+/// hit is a pointer clone.
+///
+/// `V` is the already-parsed value (e.g. the parsed manifest, or the raw file
+/// contents) — the read + parse runs once per `(path, stamp)` pair.
+pub struct MtimeCache<V> {
+    inner: OnceLock<RwLock<std::collections::HashMap<PathBuf, Entry<V>>>>,
+}
+
+/// The cheap two-field freshness signal compared on every lookup. Both fields
+/// come from one `stat`. `size` is belt-and-suspenders alongside `mtime`: a
+/// rewrite that lands within the same mtime tick but changes the file length
+/// (common on coarse-resolution filesystems, and in tests that rewrite-then-
+/// reread the same path) still invalidates. A same-mtime, same-size content
+/// edit is not distinguished — that case does not arise in nub's one-command-
+/// per-process flow (the only mutator runs after all config reads), and the
+/// cache is per-process, so there is no cross-run staleness to chase.
+#[derive(PartialEq, Eq, Clone, Copy)]
+struct Stamp {
+    mtime: SystemTime,
+    size: u64,
+}
+
+struct Entry<V> {
+    /// The freshness stamp observed when this value was cached. A later lookup
+    /// serves the value only if the file still reports this exact stamp.
+    stamp: Stamp,
+    value: Arc<V>,
+}
+
+impl<V> MtimeCache<V> {
+    pub const fn new() -> Self {
+        Self {
+            inner: OnceLock::new(),
+        }
+    }
+
+    fn map(&self) -> &RwLock<std::collections::HashMap<PathBuf, Entry<V>>> {
+        self.inner
+            .get_or_init(|| RwLock::new(std::collections::HashMap::new()))
+    }
+}
+
+impl<V> Default for MtimeCache<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V> MtimeCache<V> {
+    /// Return the cached parse for `path` when the file's current freshness
+    /// stamp matches the cached one; otherwise run `read` to produce a fresh
+    /// value and cache it under the current stamp. A `None` from `read`
+    /// (missing/unparseable file) is NOT cached — the next caller retries — so
+    /// the result is identical to calling `read` directly every time.
+    ///
+    /// The current stamp is read with a single `stat`. If the file has no
+    /// obtainable stamp, the value is computed but not cached (a `stat` failure
+    /// means the file is gone or inaccessible, which the uncached path would
+    /// also surface on its own `read`).
+    pub fn get_or_read<F>(&self, path: &Path, read: F) -> Option<Arc<V>>
+    where
+        F: FnOnce() -> Option<V>,
+    {
+        if let Some(stamp) = current_stamp(path)
+            && let Some(hit) = self.lookup_fresh(path, stamp)
+        {
+            return Some(hit);
+        }
+        let value = Arc::new(read()?);
+        // Only cache when we can observe a stamp to validate against. The common
+        // case (the file exists, so `read` succeeded) has one; re-stat to pin
+        // the value to the version we just read. A read-then-mutate race within
+        // the same command is impossible (the only mutator is the engine call
+        // that runs after all config reads), but the post-read re-stat keeps the
+        // cached stamp honest regardless.
+        if let Some(stamp) = current_stamp(path) {
+            self.map()
+                .write()
+                .expect("MtimeCache lock poisoned")
+                .insert(
+                    path.to_path_buf(),
+                    Entry {
+                        stamp,
+                        value: Arc::clone(&value),
+                    },
+                );
+        }
+        Some(value)
+    }
+
+    fn lookup_fresh(&self, path: &Path, stamp: Stamp) -> Option<Arc<V>> {
+        let guard = self.map().read().expect("MtimeCache lock poisoned");
+        let entry = guard.get(path)?;
+        (entry.stamp == stamp).then(|| Arc::clone(&entry.value))
+    }
+}
+
+/// The file's freshness stamp `(mtime, size)`, or `None` when it can't be
+/// stat'd (missing / inaccessible) or the platform reports no mtime.
+fn current_stamp(path: &Path) -> Option<Stamp> {
+    let meta = std::fs::metadata(path).ok()?;
+    Some(Stamp {
+        mtime: meta.modified().ok()?,
+        size: meta.len(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+    /// A unique temp dir (no tempfile dev-dep — matching this crate's
+    /// convention, see `node::discovery`'s `resolution_tmpdir`).
+    fn tmpdir(tag: &str) -> PathBuf {
+        static N: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "nub-cfgcache-{tag}-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn mtime_of(path: &Path) -> SystemTime {
+        std::fs::metadata(path).unwrap().modified().unwrap()
+    }
+
+    /// Rewrite `path` with `contents`, busy-rewriting until the file's reported
+    /// mtime advances past `prev` — so the test forces a genuine mtime change
+    /// regardless of the filesystem's mtime granularity, without a fixed sleep
+    /// or a `filetime` dev-dep. Bounded to avoid hanging.
+    fn write_until_mtime_advances(path: &Path, contents: &str, prev: SystemTime) {
+        for _ in 0..10_000 {
+            std::fs::write(path, contents).unwrap();
+            if mtime_of(path) > prev {
+                return;
+            }
+        }
+        panic!("filesystem mtime did not advance after repeated writes");
+    }
+
+    #[test]
+    fn second_read_of_unchanged_file_is_a_cache_hit() {
+        let dir = tmpdir("hit");
+        let path = dir.join("f.txt");
+        std::fs::write(&path, "v1").unwrap();
+
+        let cache: MtimeCache<String> = MtimeCache::new();
+        let reads = AtomicUsize::new(0);
+        let read = |c: &AtomicUsize| {
+            c.fetch_add(1, Ordering::SeqCst);
+            std::fs::read_to_string(&path).ok()
+        };
+
+        let a = cache.get_or_read(&path, || read(&reads)).unwrap();
+        let b = cache.get_or_read(&path, || read(&reads)).unwrap();
+        assert_eq!(&*a, "v1");
+        assert_eq!(&*b, "v1");
+        assert_eq!(
+            reads.load(Ordering::SeqCst),
+            1,
+            "second read must hit cache"
+        );
+        // Same Arc => zero-copy hit.
+        assert!(Arc::ptr_eq(&a, &b));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mtime_change_invalidates_and_rereads() {
+        let dir = tmpdir("inval");
+        let path = dir.join("f.txt");
+        std::fs::write(&path, "v1").unwrap();
+
+        let cache: MtimeCache<String> = MtimeCache::new();
+        let read = || std::fs::read_to_string(&path).ok();
+
+        let a = cache.get_or_read(&path, read).unwrap();
+        assert_eq!(&*a, "v1");
+        let cached_mtime = mtime_of(&path);
+
+        // Mutate the file (same byte length, so this exercises the MTIME half of
+        // the stamp specifically) and force a later mtime so the cache must miss
+        // and re-read — the same protection a mid-command engine write gets.
+        write_until_mtime_advances(&path, "v2", cached_mtime);
+
+        let b = cache.get_or_read(&path, read).unwrap();
+        assert_eq!(&*b, "v2", "a changed mtime must yield the fresh contents");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A rewrite that lands within the SAME mtime tick but changes the file
+    /// length must still invalidate — the `size` half of the stamp. This is the
+    /// rapid rewrite-then-reread pattern some config tests use, and without the
+    /// size field it served a stale value on coarse-mtime filesystems. The loop
+    /// hammers the rewrite to make a same-tick collision likely; the assertion
+    /// must hold whether or not the tick actually collided.
+    #[test]
+    fn same_mtime_different_size_invalidates() {
+        let dir = tmpdir("size");
+        let path = dir.join("f.txt");
+
+        let cache: MtimeCache<String> = MtimeCache::new();
+        let read = || std::fs::read_to_string(&path).ok();
+
+        for _ in 0..200 {
+            std::fs::write(&path, "longer-contents").unwrap();
+            let long = cache.get_or_read(&path, read).unwrap();
+            assert_eq!(&*long, "longer-contents");
+            // Different length — a same-mtime-tick collision here must NOT serve
+            // the stale "longer-contents".
+            std::fs::write(&path, "short").unwrap();
+            let short = cache.get_or_read(&path, read).unwrap();
+            assert_eq!(&*short, "short", "size change must invalidate the cache");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_file_is_not_cached() {
+        let dir = tmpdir("absent");
+        let path = dir.join("absent.txt");
+
+        let cache: MtimeCache<String> = MtimeCache::new();
+        let calls = AtomicUsize::new(0);
+        let read = |c: &AtomicUsize| {
+            c.fetch_add(1, Ordering::SeqCst);
+            std::fs::read_to_string(&path).ok()
+        };
+
+        assert!(cache.get_or_read(&path, || read(&calls)).is_none());
+        assert!(cache.get_or_read(&path, || read(&calls)).is_none());
+        // A None result is never cached: a file that appears later must be seen.
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/nub-core/src/config_cache.rs
+++ b/crates/nub-core/src/config_cache.rs
@@ -125,6 +125,11 @@ impl<V> MtimeCache<V> {
 
 /// The file's freshness stamp `(mtime, size)`, or `None` when it can't be
 /// stat'd (missing / inaccessible) or the platform reports no mtime.
+///
+/// Cache keys are the literal, un-canonicalized paths the callers pass in, and
+/// `fs::metadata` follows symlinks to stamp the TARGET. So two distinct keys
+/// that alias one file (e.g. a symlinked config path) cache independently but
+/// each stamps the real target — at worst a redundant read, never a stale one.
 fn current_stamp(path: &Path) -> Option<Stamp> {
     let meta = std::fs::metadata(path).ok()?;
     Some(Stamp {

--- a/crates/nub-core/src/lib.rs
+++ b/crates/nub-core/src/lib.rs
@@ -5,6 +5,7 @@
 // so allow it.
 #![allow(clippy::collapsible_if)]
 
+pub mod config_cache;
 pub mod node;
 pub mod pm;
 pub mod pnp;

--- a/crates/nub-core/src/pm/resolve.rs
+++ b/crates/nub-core/src/pm/resolve.rs
@@ -517,18 +517,44 @@ fn raw_pin_name_version(manifest: &serde_json::Value) -> Option<(String, Option<
     Some((name.to_string(), version))
 }
 
+/// Per-process, mtime-validated cache of the root manifest keyed by the
+/// resolved manifest FILE path. `declared_pm_raw` is called several times per PM
+/// command (config-scoping, the lifecycle UA, the install-signals re-read) and
+/// each call walked + read + parsed the same `package.json`; this collapses
+/// those to one read per `(path, mtime)`. mtime validation makes it stale-proof:
+/// any rewrite of the manifest (the in-process engine mid-command) bumps the
+/// mtime, the next lookup misses, and the file is re-read.
+static ROOT_MANIFEST_CACHE: crate::config_cache::MtimeCache<serde_json::Value> =
+    crate::config_cache::MtimeCache::new();
+
 /// The `package.json` value at [`pin_target_dir`] — the workspace root if one is
-/// above `cwd`, else the nearest project root. The detected project already parsed
-/// the nearest manifest; only a distinct workspace root needs a second read.
-fn root_manifest(cwd: &Path) -> Option<serde_json::Value> {
+/// above `cwd`, else the nearest project root.
+///
+/// The path is resolved via [`detect_project`] (a directory walk), then the
+/// chosen manifest is read through [`ROOT_MANIFEST_CACHE`] keyed on that path so
+/// repeated callers within one command share a single read + parse. Returns an
+/// `Arc` so a cache hit is a pointer clone, not a deep manifest copy.
+fn root_manifest(cwd: &Path) -> Option<std::sync::Arc<serde_json::Value>> {
     let project = detect_project(cwd)?;
-    match &project.workspace_root {
-        Some(ws) if *ws != project.root => {
-            let content = std::fs::read_to_string(ws.join("package.json")).ok()?;
-            serde_json::from_str(&content).ok()
+    // The manifest path the value is read from — keys (and mtime-validates) the
+    // cache. A distinct workspace root reads the workspace manifest; otherwise
+    // the project root's own manifest.
+    let manifest_path = match &project.workspace_root {
+        Some(ws) if *ws != project.root => ws.join("package.json"),
+        _ => project.root.join("package.json"),
+    };
+    ROOT_MANIFEST_CACHE.get_or_read(&manifest_path, || {
+        // `detect_project` already parsed the project-root manifest; reuse it on
+        // the common (no distinct workspace root) path to avoid a second parse on
+        // a cache miss. A distinct workspace root needs its own read.
+        match &project.workspace_root {
+            Some(ws) if *ws != project.root => {
+                let content = std::fs::read_to_string(ws.join("package.json")).ok()?;
+                serde_json::from_str(&content).ok()
+            }
+            _ => Some(project.manifest),
         }
-        _ => Some(project.manifest),
-    }
+    })
 }
 
 /// The result of [`write_declared_pm`]: the manifest written, and the


### PR DESCRIPTION
The `pm_engine` re-read and re-parsed the same config files several times per command — root `package.json` (3x via aube's parser, 3x via serde), `.yarnrc.yml` (once per key), and the `.npmrc` ancestor chain (re-walked per key). This caches each per-invocation so every file is read once.

A per-process cache in `nub-core` (`config_cache::MtimeCache`), path-keyed and validated on a `(mtime, size)` stamp. The serde `package.json`, the aube-parsed manifest, and the yarnrc/npmrc/bunfig readers route through it.

Output-preserving with no stale read: every lookup re-stats the file and serves the cached value only when the stamp is unchanged, so a mid-command rewrite re-reads; a missing/unparseable file is never cached, matching the prior `.ok()` paths exactly.

Verified: reads of each existing config file drop 3x to 1x on an install fixture; cached vs uncached `install`/`list`/`why`/`outdated` give byte-identical stdout, stderr, and exit codes. New `config_cache` unit tests cover hit, mtime invalidation, size invalidation, and not-cached-on-missing. `clippy --all-targets --all-features -D warnings`, `fmt --check`, and `test -p nub-cli -p nub-core` pass.
