### PR TITLE
fix(ci): drop pnpm cache from daily-driver setup-node

### DIFF
--- a/.github/workflows/daily-driver.yml
+++ b/.github/workflows/daily-driver.yml
@@ -54,7 +54,11 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"
-          cache: "pnpm"
+          # No `cache: pnpm` here: the smoke installs into a throwaway temp fixture
+          # via the freshly-built `nub`, so no repo-root pnpm install ever populates
+          # the pnpm store. setup-node's post-cleanup cache-save then validates the
+          # (non-existent) store path and fails the job — even though every smoke
+          # scenario passed. The cache offered zero speedup and only this failure mode.
       - name: Build nub + native addon
         shell: bash
         run: |


### PR DESCRIPTION
## What

Remove `cache: "pnpm"` from the `actions/setup-node` step in the Daily-driver smoke workflow.

## Why

The Daily-driver job fails on its **post-cleanup cache-save step** even when every smoke scenario passes. The job log ends with `daily-driver: all scenarios passed.`, then the `Post Run actions/setup-node` step throws:

```
Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

Root cause: the smoke installs into a throwaway temp fixture (`mktemp -d`) via the freshly-built `nub` binary — it never runs a repo-root `pnpm install`, so the pnpm store path setup-node resolves (`pnpm store path` → `.../store/v10`) is never populated. At post-cleanup, setup-node validates that path and errors.

The failure was non-deterministic: when the cache key already existed in the Actions cache, post-cleanup logged `Cache hit occurred on the primary key, not saving cache` and the job stayed green; on a fresh key it attempted the save against the empty store and went red. That's why some `main` runs are green and PR runs flake red on the same config.

The cache provided **zero speedup** (nothing installs at the repo root to cache) and only this failure mode, so it's removed outright. This is a pre-existing repo-wide workflow misconfig, not specific to any feature branch.

## Validation

This PR touches `daily-driver.yml`, which is in the workflow's own path filter, so the Daily-driver job runs on this PR and validates the fix end-to-end.