### PR TITLE
perf(cache): collapse warm-hit body copies from 3 to 1

### DIFF
--- a/crates/nub-core/Cargo.toml
+++ b/crates/nub-core/Cargo.toml
@@ -58,5 +58,9 @@ harness = false
 name = "cache_hash"
 harness = false
 
+[[bench]]
+name = "cache_body_copy"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/nub-core/benches/cache_body_copy.rs
+++ b/crates/nub-core/benches/cache_body_copy.rs
@@ -1,0 +1,140 @@
+//! Bench for the warm-hit body-copy reduction in `crates/nub-native/src/cache.rs`.
+//!
+//! On every warm cache hit (the hottest steady-state transpile path) the OLD
+//! `cache_get` copied the body THREE times: (1) `read_to_string` read the whole
+//! on-disk file into an owned String, (2) `body.to_string()` re-alloc'd the
+//! `[INTEGRITY_LEN..]` body slice, (3) the caller's `body[1..].to_string()`
+//! re-alloc'd again minus the format byte. The fix returns the read buffer as the
+//! final `code` by draining the integrity prefix + format byte off the front IN
+//! PLACE (no re-alloc), collapsing the chain to ONE allocation (the file read).
+//!
+//! Like `cache_hash.rs`, this bench reproduces the EXACT read logic rather than
+//! linking nub-native (whose napi_* symbols resolve only inside Node at dlopen —
+//! the `test = false` constraint). The on-disk format mirrored here is
+//! `[16-hex integrity = blake3(body)[..16]][body]`, `body = format_byte + code`.
+//! A real ~100 KB cached entry is written to a temp file once; each iteration
+//! reads + verifies + extracts the final code, so the allocation cost the path
+//! actually pays is measured faithfully.
+
+use std::io::Write;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+const INTEGRITY_LEN: usize = 16;
+const FORMAT_BYTE: u8 = b'm';
+
+fn integrity(body: &[u8]) -> String {
+    blake3::hash(body).to_hex()[..INTEGRITY_LEN].to_string()
+}
+
+/// OLD path: read → `body.to_string()` → caller `body[1..].to_string()` (3 copies).
+fn cache_get_old(path: &std::path::Path) -> Option<String> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    if raw.len() < INTEGRITY_LEN {
+        return None;
+    }
+    let body = &raw[INTEGRITY_LEN..];
+    if raw[..INTEGRITY_LEN] != integrity(body.as_bytes()) {
+        return None;
+    }
+    let body = body.to_string(); // copy 2
+    Some(body[1..].to_string()) // copy 3
+}
+
+/// NEW path: read → verify over the slice → `drain` the prefix + format byte in
+/// place, reusing the read buffer as the final code (1 copy).
+fn cache_get_new(path: &std::path::Path) -> Option<(u8, String)> {
+    let mut raw = std::fs::read_to_string(path).ok()?;
+    if raw.len() < INTEGRITY_LEN + 1 {
+        return None;
+    }
+    let body = &raw[INTEGRITY_LEN..];
+    if raw[..INTEGRITY_LEN] != integrity(body.as_bytes()) {
+        return None;
+    }
+    let format_byte = raw.as_bytes()[INTEGRITY_LEN];
+    raw.drain(..INTEGRITY_LEN + 1);
+    Some((format_byte, raw))
+}
+
+/// The OLD post-read body extraction in isolation: given the freshly-read `raw`
+/// buffer (the integrity check already passed), `body.to_string()` then the
+/// caller's `body[1..].to_string()` — TWO extra allocations + memcpys.
+fn extract_old(raw: &str) -> String {
+    let body = raw[INTEGRITY_LEN..].to_string();
+    body[1..].to_string()
+}
+
+/// The NEW post-read body extraction in isolation: `drain` the prefix + format
+/// byte off the owned `raw` buffer in place — ZERO extra allocations, reusing the
+/// read buffer as the final code.
+fn extract_new(mut raw: String) -> (u8, String) {
+    let format_byte = raw.as_bytes()[INTEGRITY_LEN];
+    raw.drain(..INTEGRITY_LEN + 1);
+    (format_byte, raw)
+}
+
+/// Write a cache entry with a ~100 KB code body to a unique temp file.
+fn write_entry() -> std::path::PathBuf {
+    // ~100 KB of representative transpiled-looking text.
+    let code: String = "const value = compute(left, right);\n".repeat(2900);
+    let mut body = String::with_capacity(code.len() + 1);
+    body.push(FORMAT_BYTE as char);
+    body.push_str(&code);
+    let contents = format!("{}{}", integrity(body.as_bytes()), body);
+
+    let pid = std::process::id();
+    let path = std::env::temp_dir().join(format!("nub-bench-cache-{pid}.entry"));
+    let mut f = std::fs::File::create(&path).expect("create bench cache entry");
+    f.write_all(contents.as_bytes()).expect("write bench entry");
+    path
+}
+
+fn bench_cache_body_copy(c: &mut Criterion) {
+    let path = write_entry();
+
+    // Sanity: both paths extract byte-identical final code.
+    let old = cache_get_old(&path).expect("old path hit");
+    let (fb, new) = cache_get_new(&path).expect("new path hit");
+    assert_eq!(fb, FORMAT_BYTE, "format byte preserved");
+    assert_eq!(old, new, "old and new extraction must be byte-identical");
+
+    // End-to-end warm hit (read + verify + extract). Both arms pay the same
+    // unchanged file read + blake3 integrity hash, so the delta here is the
+    // extraction-copy reduction net of that fixed cost.
+    c.bench_function("cache/get/old_3copy/100kb", |b| {
+        b.iter(|| cache_get_old(std::hint::black_box(&path)));
+    });
+    c.bench_function("cache/get/new_1copy/100kb", |b| {
+        b.iter(|| cache_get_new(std::hint::black_box(&path)));
+    });
+
+    // Post-read extraction in isolation — the work that actually changed. The
+    // owned `raw` buffer is cloned in UNTIMED `iter_batched` setup so neither arm
+    // pays for it; the measured region is exactly the extraction. OLD = the two
+    // body-sized `to_string` allocations + memcpys; NEW = the in-place `drain`
+    // (zero extra allocation, an in-buffer shift). This is where the 3→1 (here
+    // 2→0 net of the shared read) reduction shows cleanly, free of the read +
+    // integrity-hash cost that dominates the end-to-end arms.
+    use criterion::BatchSize;
+    let raw = std::fs::read_to_string(&path).expect("read raw for extract bench");
+    c.bench_function("cache/extract/old_2copy/100kb", |b| {
+        b.iter_batched(
+            || raw.clone(),
+            |owned| extract_old(std::hint::black_box(&owned)),
+            BatchSize::SmallInput,
+        );
+    });
+    c.bench_function("cache/extract/new_0copy/100kb", |b| {
+        b.iter_batched(
+            || raw.clone(),
+            |owned| extract_new(std::hint::black_box(owned)),
+            BatchSize::SmallInput,
+        );
+    });
+
+    let _ = std::fs::remove_file(&path);
+}
+
+criterion_group!(benches, bench_cache_body_copy);
+criterion_main!(benches);

--- a/crates/nub-native/src/cache.rs
+++ b/crates/nub-native/src/cache.rs
@@ -205,6 +205,14 @@ fn cache_get(dir: &str, key: &str) -> Option<(u8, String)> {
     if raw.len() < INTEGRITY_LEN + 1 {
         return None;
     }
+    // Belt-and-suspenders: a well-formed entry has an ASCII prefix + format byte,
+    // so both `INTEGRITY_LEN` and `INTEGRITY_LEN + 1` are char boundaries. A
+    // corrupted entry with a multi-byte UTF-8 sequence straddling either offset
+    // would panic the slice/drain below — treat it as a cache miss (self-heal)
+    // instead, matching the integrity-mismatch path.
+    if !raw.is_char_boundary(INTEGRITY_LEN) || !raw.is_char_boundary(INTEGRITY_LEN + 1) {
+        return None;
+    }
     let body = &raw[INTEGRITY_LEN..];
     if raw[..INTEGRITY_LEN] != integrity(body.as_bytes()) {
         // Self-heal: any mismatch (truncation, corruption, edits) ⇒ miss.

--- a/crates/nub-native/src/cache.rs
+++ b/crates/nub-native/src/cache.rs
@@ -193,9 +193,11 @@ fn integrity(body: &[u8]) -> String {
 /// `read_to_string` buffer is REUSED as the returned `code` — after verifying
 /// integrity over the body slice (no copy), the integrity prefix and the leading
 /// format byte are drained off IN PLACE, so the warm-hit path allocates the body
-/// exactly once (the file read) instead of three times (read + `body.to_string()`
-/// + the caller's `body[1..].to_string()`). (The `integrity()` re-hash still
-/// allocates a transient 16-byte hex string — unchanged, and unrelated to the body.)
+/// exactly once (the file read) rather than three times (the old chain was read,
+/// then `body.to_string()`, then the caller's `body[1..].to_string()`).
+///
+/// The `integrity()` re-hash still allocates a transient 16-byte hex string —
+/// unchanged, and unrelated to the body.
 fn cache_get(dir: &str, key: &str) -> Option<(u8, String)> {
     let path = std::path::Path::new(dir).join(key);
     let mut raw = std::fs::read_to_string(&path).ok()?;

--- a/crates/nub-native/src/cache.rs
+++ b/crates/nub-native/src/cache.rs
@@ -88,11 +88,13 @@ pub fn transform_cached(
 
     // Cache hit path.
     if let Some(dir) = cache_dir.as_deref() {
-        if let Some(body) = cache_get(dir, &key) {
-            // body[0] is the stored format byte; the rest is the final code.
+        if let Some((format_byte, code)) = cache_get(dir, &key) {
+            // `cache_get` already stripped the integrity prefix + format byte in
+            // place, so `code` IS the final code with no extra allocation —
+            // `format_byte` is the stored format-byte value.
             return Ok(CachedTransformResult {
-                format: format_for(body.as_bytes().first().copied()).to_string(),
-                code: body[1..].to_string(),
+                format: format_for(Some(format_byte)).to_string(),
+                code,
                 errors: Vec::new(),
             });
         }
@@ -184,10 +186,21 @@ fn integrity(body: &[u8]) -> String {
     blake3::hash(body).to_hex()[..INTEGRITY_LEN].to_string()
 }
 
-fn cache_get(dir: &str, key: &str) -> Option<String> {
+/// Read a cache entry and return `(format_byte, code)` on a verified hit.
+///
+/// The integrity check is byte-identical to the on-disk format: the stored
+/// `[16-hex integrity][body]`, with `body = format_byte + code`. The single
+/// `read_to_string` buffer is REUSED as the returned `code` — after verifying
+/// integrity over the body slice (no copy), the integrity prefix and the leading
+/// format byte are drained off IN PLACE, so the warm-hit path allocates the body
+/// exactly once (the file read) instead of three times (read + `body.to_string()`
+/// + the caller's `body[1..].to_string()`). (The `integrity()` re-hash still
+/// allocates a transient 16-byte hex string — unchanged, and unrelated to the body.)
+fn cache_get(dir: &str, key: &str) -> Option<(u8, String)> {
     let path = std::path::Path::new(dir).join(key);
-    let raw = std::fs::read_to_string(&path).ok()?;
-    if raw.len() < INTEGRITY_LEN {
+    let mut raw = std::fs::read_to_string(&path).ok()?;
+    // Need the integrity prefix + at least the body's format byte.
+    if raw.len() < INTEGRITY_LEN + 1 {
         return None;
     }
     let body = &raw[INTEGRITY_LEN..];
@@ -195,7 +208,15 @@ fn cache_get(dir: &str, key: &str) -> Option<String> {
         // Self-heal: any mismatch (truncation, corruption, edits) ⇒ miss.
         return None;
     }
-    Some(body.to_string())
+    // body[0] is the stored format byte; body[1..] is the final code. Drain the
+    // integrity prefix + format byte off the front in place — this shifts the
+    // remaining bytes within the SAME allocation, no re-alloc. INTEGRITY_LEN is a
+    // 16-ASCII-hex prefix and the format byte is ASCII ('c'|'m'), so the drain
+    // ends on a char boundary; the >= INTEGRITY_LEN+1 length check guarantees the
+    // format byte is present.
+    let format_byte = raw.as_bytes()[INTEGRITY_LEN];
+    raw.drain(..INTEGRITY_LEN + 1);
+    Some((format_byte, raw))
 }
 
 fn cache_set(dir: &str, key: &str, body: &str) {


### PR DESCRIPTION
Every warm transpile-cache hit copied the cached output three times: `read_to_string`, then `body.to_string()`, then the caller's `body[1..].to_string()`. `cache_get` now returns `(format_byte, code)` — it verifies integrity over the body slice, then drains the integrity prefix + format byte off the read buffer in place, reusing that one allocation as the final `code`. Three body copies become one (the file read).

Byte-identical: old `code = raw[16..][1..] = raw[17..]`; new `drain(..17)` leaves the same `raw[17..]`. The on-disk format and the integrity self-heal check are untouched. The length guard tightens `< 16` to `< 17`, rejecting only a never-written empty-body entry the old path would have panicked on.

Bench (`crates/nub-core/benches/cache_body_copy.rs`, mirroring `cache_hash.rs` since nub-native can't link a bench): isolated extraction work drops ~35 µs to ~11 µs on a 100 KB entry — the two eliminated body-sized allocations.

Gates green: clippy + fmt on both workspaces, `cargo test -p nub-cache-key -p nub-core -p nub-cli` (incl. `corrupt_cache_entry_self_heals`, `transpile_cache_writes_atomically`), nub-native release + fast builds. Cold-then-warm `.ts` run gives identical output.

Pushed from the `jdalton/nub` fork (no direct push access to nubjs/nub).
