### PR TITLE
feat(install): size CPU-bound pools to the cgroup CPU quota, not host cores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,6 +2618,7 @@ dependencies = [
  "miette",
  "mimalloc",
  "nub-core",
+ "num_cpus",
  "rayon",
  "rustc-hash",
  "semver",
@@ -2732,6 +2733,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -91,6 +91,12 @@ url = "2.5"
 # thread-create EAGAIN — the same exit-101 abort the tokio cap closes. We cap it
 # under the same headroom budget; unconstrained boxes keep rayon's default.
 rayon = "1"
+# CPU-budget detection (resource_limits::cpu_budget): num_cpus::get() reads the
+# cgroup CFS quota (cgroup v1 `cpu.cfs_quota_us`/`cfs_period_us` AND v2 `cpu.max`,
+# via /proc/self/mountinfo) and returns min(ceil(quota/period), logical_cores) —
+# exactly the automaxprocs algorithm, maintained, 2-dep. Closes the v1-quota +
+# affinity-blocked gaps in std's `available_parallelism()`.
+num_cpus = "1"
 
 [target.'cfg(unix)'.dependencies]
 # fd-level capture of the engine's raw println/eprintln hint lines so the

--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -129,6 +129,11 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     no_churn_lockfile_write: true,
     read_branded_settings_env: false,
     primer_ttl: None,
+    // Cap aube's CPU-bound pools (linker rayon pool, tokio worker seed) to the
+    // real cgroup CFS-CPU-quota budget on a constrained box; `None` on an
+    // unconstrained box leaves them at full cores. Same detector the nub-side
+    // install runtime uses (`build_runtime`), so both stay consistent.
+    cpu_budget: Some(super::resource_limits::cpu_budget),
 };
 
 /// Register [`NUB`] as the active embedder profile. Idempotent (the engine's

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1898,9 +1898,11 @@ pub(crate) fn env_snapshot() -> Vec<(String, String)> {
 /// it returns `None` and we keep the full-speed defaults — so normal-box install
 /// performance is untouched.
 fn build_runtime() -> Result<tokio::runtime::Runtime> {
-    let raw_cpu = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(4);
+    // Use `resource_limits::available_cores()` (NOT a local `unwrap_or(4)`) so this
+    // `raw_cpu` matches the `cores` the `cpu_budget()` gate compares against — the
+    // two must agree on the same `unwrap_or(1)` fallback or the gate could disagree
+    // with the pool sizing in the rare `available_parallelism()`-errors case.
+    let raw_cpu = resource_limits::available_cores();
     // The effective CPU budget under a cgroup CFS quota (or the NUB_CPU_BUDGET
     // override) — `None` on an unconstrained box, where we keep the full core
     // count. This is the PROACTIVE CPU axis, composed below with the REACTIVE PID

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1898,11 +1898,23 @@ pub(crate) fn env_snapshot() -> Vec<(String, String)> {
 /// it returns `None` and we keep the full-speed defaults — so normal-box install
 /// performance is untouched.
 fn build_runtime() -> Result<tokio::runtime::Runtime> {
-    let cpu = std::thread::available_parallelism()
+    let raw_cpu = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(4);
+    // The effective CPU budget under a cgroup CFS quota (or the NUB_CPU_BUDGET
+    // override) — `None` on an unconstrained box, where we keep the full core
+    // count. This is the PROACTIVE CPU axis, composed below with the REACTIVE PID
+    // headroom: a CPU-bound pool is bounded by the smaller of the two.
+    let cpu_budget = resource_limits::cpu_budget();
+    let cpu = cpu_budget.unwrap_or(raw_cpu);
     let mut workers = cpu.min(8);
     let mut blocking = 128usize;
+    // The rayon GLOBAL pool is sized off the most restrictive of the two axes and
+    // capped EXACTLY ONCE below: `build_global` errors if the pool already exists,
+    // so the first cap wins — computing the final value first lets the PID share
+    // tighten rayon BELOW the CPU budget (and vice versa) instead of whichever cap
+    // happened to run first sticking. Start from the CPU budget (None → raw cores).
+    let mut rayon_target = cpu;
 
     if let Some(headroom) = resource_limits::spawn_headroom() {
         // ONE headroom budget split across the four concurrent OS-thread/process
@@ -1912,25 +1924,54 @@ fn build_runtime() -> Result<tokio::runtime::Runtime> {
         let (w, b, rayon_threads, child) = resource_limits::split_budget(headroom);
         workers = workers.min(w);
         blocking = blocking.min(b);
-        // Size the rayon GLOBAL pool under the same budget. The embedded engine
-        // fans CAS writes / delta / fetch out over rayon's IMPLICIT global pool,
-        // whose lazy init otherwise spins up `available_parallelism()` threads
-        // (CPU-quota-bound, NOT PID-bound) and PANICS on thread-create EAGAIN —
-        // the SAME exit-101 abort, relocated from tokio to rayon. Capped here,
-        // before any engine `par_iter` touches the pool.
-        cap_rayon_global_pool(rayon_threads);
+        // Compose with the CPU budget: rayon is bounded by the SMALLER of the
+        // CPU-quota-derived and PID-headroom-derived shares (both feed the same
+        // pool). Capped once after this block.
+        rayon_target = rayon_target.min(rayon_threads);
         // Lower the parallel build-script count to match (single-threaded here, so
         // the env mutation is race-free, and it runs BEFORE the env_snapshot the
         // engine resolves settings from).
         apply_constrained_child_concurrency(child);
         tracing::debug!(
             headroom,
+            cpu_budget = cpu,
             workers,
             blocking,
-            rayon = rayon_threads,
+            rayon = rayon_target,
             child_concurrency = child,
-            "constrained box detected: capping install runtime pools (tokio + rayon) + build-script concurrency under the PID/thread ceiling"
+            "constrained box detected: capping install runtime pools (tokio + rayon) + build-script concurrency under the PID/thread + CPU-quota ceilings"
         );
+    } else if let Some(budget) = cpu_budget {
+        // CPU-quota constraint with NO PID constraint: the box has a CFS quota (or
+        // a NUB_CPU_BUDGET override) but generous PIDs. Size the CPU-bound pools
+        // (workers + rayon, already set above) to the quota; the IO-bound blocking
+        // pool and child concurrency keep their full defaults (PID headroom is fine).
+        tracing::debug!(
+            cpu_budget = budget,
+            workers,
+            rayon = rayon_target,
+            "CPU-quota constraint detected: capping CPU-bound install pools (tokio workers + rayon) to the effective CPU budget"
+        );
+    }
+
+    // Internal diagnostic seam (NOT a public knob — `__NUB_*` per the brand
+    // boundary's internal exemption): when set, print the resolved pool sizing to
+    // real stderr, BEFORE the install's fd-capture can swallow a `tracing` line.
+    // Lets a constrained-box test assert the detected budget deterministically.
+    if std::env::var_os("__NUB_PRINT_CPU_BUDGET").is_some() {
+        eprintln!(
+            "__nub_cpu_budget raw_cpu={raw_cpu} cpu_budget={cpu_budget:?} workers={workers} blocking={blocking} rayon={rayon_target}"
+        );
+    }
+
+    // Size the rayon GLOBAL pool whenever EITHER axis constrains below the raw core
+    // count. The embedded engine fans CAS writes / delta / fetch out over rayon's
+    // IMPLICIT global pool, whose lazy init otherwise spins up
+    // `available_parallelism()` threads (v1-quota-blind, PID-unbounded) and PANICS
+    // on thread-create EAGAIN — the SAME exit-101 abort, relocated to rayon. Done
+    // once here, before any engine `par_iter` touches the pool.
+    if rayon_target < raw_cpu {
+        cap_rayon_global_pool(rayon_target);
     }
 
     tokio::runtime::Builder::new_multi_thread()

--- a/crates/nub-cli/src/pm_engine/resource_limits.rs
+++ b/crates/nub-cli/src/pm_engine/resource_limits.rs
@@ -177,9 +177,15 @@ pub(crate) fn cpu_budget() -> Option<usize> {
 
 /// Quota-aware logical-core count — `available_parallelism()` reads affinity AND
 /// the cgroup-v2 quota (since Rust 1.61), so on a pure-v2 host it already returns
-/// the effective budget. The detected-budget gate clamps to this.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-fn available_cores() -> usize {
+/// the effective budget. The detected-budget gate clamps to this, and
+/// `build_runtime` uses it as `raw_cpu`, so both agree on the same `unwrap_or(1)`
+/// fallback. NOTE: if `available_parallelism()` ERRORS (a rare seccomp sandbox
+/// blocking the syscall), this collapses to 1, which makes the gate
+/// `cpu_budget_from(1, _)` return `None` — i.e. CPU-budget DETECTION quietly
+/// no-ops there. Harmless: the caller then uses `raw_cpu == 1` and sizes pools
+/// minimally anyway; an explicit `NUB_CPU_BUDGET` still works (it's read before
+/// this gate).
+pub(crate) fn available_cores() -> usize {
     std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1)
@@ -209,11 +215,13 @@ fn host_logical_cpus() -> usize {
 ///
 /// Note the asymmetry between lowering and raising: the override's primary use is
 /// to LOWER concurrency (pin to 1 on a box where auto-detection missed a v1 quota),
-/// which is fully honored. Raising ABOVE the auto-detected v2 quota is honored for
-/// the pools nub sizes explicitly (tokio workers), but rayon/tokio's own internal
-/// defaults are already quota-clamped by Rust std, so a request above the v2 quota
-/// can't lift those past the quota — a deliberately minor edge (you can't conjure
-/// CPU the cgroup won't grant).
+/// which is fully honored everywhere. Raising ABOVE the auto-detected v2 quota is
+/// honored for the tokio worker count nub sets directly from `cpu_budget()`, but
+/// any pool whose ceiling is `available_parallelism()` — rayon/tokio's own internal
+/// defaults AND aube's linker pool via `effective_cpu_cap()` — is already
+/// quota-clamped by Rust std, so a request above the v2 quota can't lift those past
+/// the quota. A deliberately minor edge: you can't conjure CPU the cgroup won't
+/// grant, and the common case (lowering) is unaffected.
 fn cpu_budget_override(ceiling: usize) -> Option<usize> {
     let raw = std::env::var(CPU_BUDGET_ENV).ok()?;
     parse_override(&raw, ceiling)

--- a/crates/nub-cli/src/pm_engine/resource_limits.rs
+++ b/crates/nub-cli/src/pm_engine/resource_limits.rs
@@ -108,6 +108,144 @@ pub(crate) fn spawn_headroom() -> Option<usize> {
     None
 }
 
+// ───────────────────────── CPU budget (cgroup CFS quota) ─────────────────────────
+//
+// The CPU analog of `spawn_headroom`. The PID axis (above) is REACTIVE — it sizes
+// pools below the kernel thread ceiling to dodge the `clone(2)` EAGAIN abort. This
+// axis is PROACTIVE: on a box with a cgroup CPU bandwidth limit (a 0.5-CPU
+// Vercel/Lambda/K8s pod) the host still reports many cores, so the pools over-
+// subscribe the quota → CFS throttles the process (latency cliffs) and the attendant
+// thread growth feeds the SAME PID exhaustion. Sizing CPU-bound pools to the real
+// quota prevents both. Rust's `available_parallelism()` already reads cgroup-v2
+// `cpu.max` + affinity (since 1.61), but NOT cgroup-v1 quota, and silently drops the
+// v2 quota when `sched_getaffinity` is unreadable (sandbox) — `cpu_budget` closes
+// both gaps by reading the cgroup files directly, exactly as the PID detector does.
+// Default-preserving: an unconstrained box returns `None` and pools keep full cores.
+
+/// The dedicated user override for the effective CPU budget — a hard cap on the
+/// auto-detected CPU-count the pools size against. DISTINCT from the existing
+/// `NUB_CONCURRENCY` knob, which is aube's tarball-FETCH concurrency (an IO knob,
+/// clamped `[8, 256]`); this caps the CPU/thread pools (workers, rayon), so it
+/// needs its own name and its own range `[1, cores]`.
+const CPU_BUDGET_ENV: &str = "NUB_CPU_BUDGET";
+
+/// The effective CPU count the engine's CPU-bound pools (tokio workers, rayon
+/// global) should size against: `min(available_parallelism, cgroup-CFS-quota-cores)`
+/// with `max(1, ceil)` rounding. `None` means "no CPU constraint detected — use
+/// full-speed defaults," matching today's `available_parallelism()`.
+///
+/// Auto-detection is `num_cpus::get()`, which reads the cgroup CFS quota for BOTH
+/// cgroup v1 (`cpu.cfs_quota_us`/`cfs_period_us`) and v2 (`cpu.max`) — locating the
+/// controller via `/proc/self/mountinfo` — and returns `min(ceil(quota/period),
+/// logical_cores)`. That is exactly the automaxprocs algorithm and the maintainer-
+/// chosen `max(1, ceil)` rounding (any positive quota ceils to ≥1; the `quota == 0`
+/// degenerate is guarded). It closes the two gaps in std's `available_parallelism()`
+/// that nub would otherwise inherit (no cgroup-v1 quota; the v2 quota is dropped when
+/// `sched_getaffinity` is unreadable under a sandbox).
+///
+/// An explicit `NUB_CPU_BUDGET` always wins over auto-detection (the automaxprocs/Go
+/// `GOMAXPROCS`-env precedence model), clamped to `[1, cores]`.
+///
+/// Returns a budget ONLY when it constrains BELOW the logical core count — at/above
+/// the cores it tightens nothing, so we return `None` and the caller keeps its
+/// full-speed default (no needless pool rebuild). Linux-gated: `num_cpus`'s quota
+/// read is a Linux-cgroup concept, and like `spawn_headroom` the over-report trap
+/// was only ever a Linux-container problem; on macOS/Windows only the explicit
+/// override can produce a budget.
+pub(crate) fn cpu_budget() -> Option<usize> {
+    // The override's ceiling is the quota-IGNORING host logical-CPU count, so an
+    // EXPLICIT value can raise concurrency ABOVE a detected quota (explicit wins) —
+    // not the quota-aware `available_parallelism()`, which would silently clamp the
+    // user's request back down to the quota.
+    if let Some(n) = cpu_budget_override(host_logical_cpus()) {
+        return Some(n);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // `num_cpus::get()` returns min(ceil(quota), logical) reading the cgroup
+        // files directly (v1 AND v2, even when affinity is unreadable). Gate on
+        // "actually below available_parallelism()" so a box std already sized
+        // correctly (v2 + readable affinity) stays `None` — we only ADD the v1 /
+        // sandbox coverage std misses.
+        cpu_budget_from(available_cores(), num_cpus::get())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// Quota-aware logical-core count — `available_parallelism()` reads affinity AND
+/// the cgroup-v2 quota (since Rust 1.61), so on a pure-v2 host it already returns
+/// the effective budget. The detected-budget gate clamps to this.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn available_cores() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+/// The host's online logical-CPU count, IGNORING any cgroup quota — the ceiling an
+/// explicit `NUB_CPU_BUDGET` may request up to. On Linux this is
+/// `sysconf(_SC_NPROCESSORS_ONLN)` (quota-blind by design); elsewhere there's no
+/// quota, so `available_parallelism()` is already the host count.
+fn host_logical_cpus() -> usize {
+    #[cfg(target_os = "linux")]
+    {
+        // SAFETY: `sysconf` with a valid name has no preconditions and no
+        // out-params; it returns the count or -1 on error.
+        let n = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
+        if n > 0 {
+            return n as usize;
+        }
+    }
+    available_cores()
+}
+
+/// Read + clamp the `NUB_CPU_BUDGET` override. `Some(n)` (clamped to `[1, ceiling]`)
+/// when set to a positive integer; `None` when unset/invalid (auto-detect). A value
+/// above the ceiling clamps down rather than erroring — asking for more than the
+/// host has just gets the host.
+///
+/// Note the asymmetry between lowering and raising: the override's primary use is
+/// to LOWER concurrency (pin to 1 on a box where auto-detection missed a v1 quota),
+/// which is fully honored. Raising ABOVE the auto-detected v2 quota is honored for
+/// the pools nub sizes explicitly (tokio workers), but rayon/tokio's own internal
+/// defaults are already quota-clamped by Rust std, so a request above the v2 quota
+/// can't lift those past the quota — a deliberately minor edge (you can't conjure
+/// CPU the cgroup won't grant).
+fn cpu_budget_override(ceiling: usize) -> Option<usize> {
+    let raw = std::env::var(CPU_BUDGET_ENV).ok()?;
+    parse_override(&raw, ceiling)
+}
+
+/// Pure parse+clamp of a `NUB_CPU_BUDGET` value (split out so the clamp/precedence
+/// is unit-testable without mutating the process env). `Some(n)` clamped to
+/// `[1, ceiling]` for a positive integer; `None` (with a warning) otherwise.
+fn parse_override(raw: &str, ceiling: usize) -> Option<usize> {
+    match raw.trim().parse::<usize>() {
+        Ok(n) if n >= 1 => Some(n.min(ceiling.max(1))),
+        _ => {
+            tracing::warn!(
+                value = %raw,
+                "{CPU_BUDGET_ENV} ignored: must be a positive integer; using the auto-detected CPU budget"
+            );
+            None
+        }
+    }
+}
+
+/// Pure budget gate (testable with synthetic inputs): given the logical core count
+/// and `num_cpus::get()`'s already-quota-clamped count, return `Some(detected)` ONLY
+/// when it constrains below the cores; otherwise `None` (default-preserving). The
+/// `max(1)` floor mirrors `num_cpus`'s own (it never returns 0 for a live process).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn cpu_budget_from(cores: usize, detected: usize) -> Option<usize> {
+    let cores = cores.max(1);
+    let effective = detected.max(1).min(cores);
+    (effective < cores).then_some(effective)
+}
+
 /// The cgroup `pids.max` limit for the current process, trying cgroup v2
 /// (unified) first and falling back to cgroup v1 (the `pids` controller). Many
 /// CI/container hosts — including the ones that triggered this bug — are still
@@ -302,5 +440,66 @@ mod tests {
         assert_eq!(parse_pids_max("1024"), Some(1024));
         assert_eq!(parse_pids_max("  256\n"), Some(256));
         assert_eq!(parse_pids_max("garbage"), None);
+    }
+
+    // ─────────────────────── CPU budget ───────────────────────
+
+    #[test]
+    fn cpu_budget_is_none_or_in_range() {
+        // Detector contract: either `None` (unconstrained / undetectable) or a
+        // value in `[1, cores]`. Never 0, never above the host cores.
+        if let Some(n) = cpu_budget() {
+            let cores = available_cores();
+            assert!(n >= 1 && n <= cores, "budget {n} out of [1, {cores}]");
+        }
+    }
+
+    #[test]
+    fn cpu_budget_from_reports_only_when_constraining() {
+        // `num_cpus::get()` already returns min(ceil(quota), logical); this gate
+        // only reports a budget when it's strictly below the logical cores.
+        // Quota of 2 on an 8-core box → 2 (constrains).
+        assert_eq!(cpu_budget_from(8, 2), Some(2));
+        // 0.5-CPU quota ceils to 1 inside num_cpus → 1 here (constrains, never 0).
+        assert_eq!(cpu_budget_from(8, 1), Some(1));
+    }
+
+    #[test]
+    fn cpu_budget_from_unconstrained_is_none() {
+        // Detected == cores → no real constraint → None (default-preserving).
+        assert_eq!(cpu_budget_from(8, 8), None);
+        // Detected above cores (shouldn't happen, but be safe) → clamps to cores,
+        // which equals cores → None.
+        assert_eq!(cpu_budget_from(4, 16), None);
+        // A 1-core box can never tighten below itself.
+        assert_eq!(cpu_budget_from(1, 1), None);
+    }
+
+    #[test]
+    fn cpu_budget_from_floors_at_one_and_clamps_to_cores() {
+        // A degenerate 0 from the detector floors to 1 (never serialize to 0).
+        assert_eq!(cpu_budget_from(8, 0), Some(1));
+        // cores=0 (impossible in practice) is treated as 1 → nothing to constrain.
+        assert_eq!(cpu_budget_from(0, 4), None);
+    }
+
+    #[test]
+    fn parse_override_clamps_and_validates() {
+        // Positive integer, within the host ceiling → honored verbatim.
+        assert_eq!(parse_override("4", 10), Some(4));
+        // Above the ceiling clamps DOWN to the host (can't conjure CPU).
+        assert_eq!(parse_override("16", 10), Some(10));
+        // Explicit-wins ABOVE a detected v2 quota: ceiling is the quota-ignoring
+        // host count, so 3 is honored on a 2-quota box (ceiling 10 here).
+        assert_eq!(parse_override("3", 10), Some(3));
+        // Whitespace tolerated.
+        assert_eq!(parse_override("  2\n", 10), Some(2));
+        // 0 / negative / non-numeric / empty → None (auto-detect).
+        assert_eq!(parse_override("0", 10), None);
+        assert_eq!(parse_override("-1", 10), None);
+        assert_eq!(parse_override("garbage", 10), None);
+        assert_eq!(parse_override("", 10), None);
+        // A degenerate ceiling of 0 still floors the honored value at 1.
+        assert_eq!(parse_override("5", 0), Some(1));
     }
 }

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -177,7 +177,7 @@ A project is Nub's own in three cases: it declares Nub through `nub pm use nub`,
 
 - **Lockfile:** `lock.yaml` — the pnpm v9 schema byte-for-byte, under Nub's own basename
 - **Package fields:** `workspaces`, `overrides`, `resolutions`, `patchedDependencies`, `allowBuilds`, `engines.node`, `scripts`
-- **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`
+- **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_CPU_BUDGET`, `NUB_PRIMER_TTL`
 - **Install state:** `node_modules/.nub/`, `.nub-state`, and the global store under Nub's own directories
 
 This is the brand boundary in both directions: Nub never emits its own brand into your config, and under its own identity reads *only* neutral, cross-tool config — never `pnpm-workspace.yaml`, `.pnpmfile.cjs`, the `pnpm.*` namespace, `pnpm_config_*`, `.yarnrc.yml`, `bunfig.toml`, Bun `trustedDependencies`, or aube's `AUBE_*` knobs. Injected dependencies are unsupported under Nub identity — `nub pm use nub` refuses a project that relies on `dependenciesMeta.injected`. To keep pnpm hooks or workspace config active, stay pnpm-owned or run `nub pm use pnpm`.

--- a/vendor/aube/crates/aube-linker/src/pool.rs
+++ b/vendor/aube/crates/aube-linker/src/pool.rs
@@ -10,13 +10,14 @@ pub fn default_linker_parallelism() -> usize {
     // 4-thread cap pinning a 10-core machine at ~3.9 effective
     // concurrency with ~6 idle cores; lifting the cap lets the
     // clonefile pass use them. 16 matches the non-macOS default and is
-    // itself bounded by `available_parallelism` below.
+    // itself bounded by the effective CPU cap below.
     let default_limit = 16;
 
-    std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1)
-        .min(default_limit)
+    // `effective_cpu_cap()` is `available_parallelism()` for standalone aube
+    // (byte-for-byte unchanged) and the cgroup-CPU-quota budget under an embedder
+    // that installs the hook — so the symlink fan-out doesn't over-subscribe a
+    // constrained box's quota. Always ≥1.
+    aube_util::concurrency::effective_cpu_cap().min(default_limit)
 }
 
 type LinkPoolCache = std::sync::Mutex<Vec<(usize, std::sync::Arc<rayon::ThreadPool>)>>;

--- a/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -34,6 +34,7 @@ static MYTOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 #[test]

--- a/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
@@ -40,6 +40,7 @@ static MYTOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 fn project(files: &[(&str, &str)]) -> tempfile::TempDir {

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -44,6 +44,7 @@ static NO_CHURN_TOOL: Embedder = Embedder {
     no_churn_lockfile_write: true,
     read_branded_settings_env: true,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 fn pkg(name: &str, version: &str, integrity: &str) -> LockedPackage {

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -40,6 +40,7 @@ static ROOT_TOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 fn read_manifest(dir: &std::path::Path) -> serde_json::Value {

--- a/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
@@ -36,6 +36,7 @@ static MYTOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 #[tokio::test]

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -31,6 +31,7 @@ static ROOT_TOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 fn build_decision(manifest: &PackageJson, name: &str, version: &str) -> AllowDecision {

--- a/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
@@ -30,6 +30,7 @@ static MYTOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 #[test]

--- a/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
+++ b/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
@@ -45,6 +45,7 @@ static MYTOOL_NO_BRANDED_ENV: Embedder = Embedder {
     read_branded_settings_env: false,
     no_churn_lockfile_write: false,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 fn ctx<'a>(

--- a/vendor/aube/crates/aube-util/src/concurrency.rs
+++ b/vendor/aube/crates/aube-util/src/concurrency.rs
@@ -15,6 +15,26 @@
 //! hostile or typo'd value can't exhaust file descriptors on Windows
 //! (default ulimit 8192).
 
+/// The effective CPU-count cap for the tool's CPU-bound thread pools — the host's
+/// logical core count (`available_parallelism()`), further lowered to the active
+/// embedder's [`cpu_budget`](crate::Embedder::cpu_budget) hook when one is installed
+/// AND it reports a constraint. Returns at least 1.
+///
+/// Standalone aube installs no hook, so this is exactly `available_parallelism()`
+/// (byte-for-byte unchanged). An embedder under a cgroup CPU quota installs a hook
+/// returning the real budget, and the pools (linker rayon pool, tokio worker seed)
+/// size against it instead of over-subscribing the quota. The hook returns `None`
+/// when even it detects no constraint, so an unconstrained box keeps full cores.
+pub fn effective_cpu_cap() -> usize {
+    let cores = std::thread::available_parallelism()
+        .map(std::num::NonZero::get)
+        .unwrap_or(1);
+    match crate::embedder().cpu_budget.and_then(|f| f()) {
+        Some(budget) => budget.clamp(1, cores),
+        None => cores,
+    }
+}
+
 /// Lower bound on the concurrency override. A degenerate slow link still
 /// makes progress with 8 in-flight fetches.
 pub const CONCURRENCY_FLOOR: u32 = 8;
@@ -119,5 +139,18 @@ mod tests {
         with_env(Some("256"), || {
             assert_eq!(parse_concurrency_env(), Some(CONCURRENCY_CEILING));
         });
+    }
+
+    #[test]
+    fn effective_cpu_cap_without_hook_is_available_parallelism() {
+        // Standalone aube installs no `cpu_budget` hook, so the cap is exactly the
+        // host core count — the unchanged pre-existing behavior. (No embedder is
+        // registered in this unit-test process, so `embedder()` yields AUBE, whose
+        // `cpu_budget` is `None`.)
+        let cores = std::thread::available_parallelism()
+            .map(std::num::NonZero::get)
+            .unwrap_or(1);
+        assert_eq!(effective_cpu_cap(), cores);
+        assert!(effective_cpu_cap() >= 1);
     }
 }

--- a/vendor/aube/crates/aube-util/src/identity.rs
+++ b/vendor/aube/crates/aube-util/src/identity.rs
@@ -212,6 +212,18 @@ pub struct Embedder {
     /// fixed: it's the host's call, not the user's, and it doesn't vary per
     /// project.
     pub primer_ttl: Option<std::time::Duration>,
+    /// Optional hook returning an effective CPU-count budget that caps the tool's
+    /// CPU-bound thread pools (the linker rayon pool, the tokio worker seed) below
+    /// the host's logical core count. `None` (aube's default) → no embedder cap,
+    /// so every pool sizes off `available_parallelism()` exactly as before
+    /// (byte-for-byte standalone behavior). An embedder running under a cgroup CPU
+    /// quota (a 0.5-CPU container) sets `Some(fn)` returning the real budget so the
+    /// pools don't over-subscribe the quota (CFS throttling) or feed thread/PID
+    /// exhaustion. The hook itself returns `None` when IT detects no constraint, so
+    /// even with a hook installed an unconstrained box keeps full-core pools.
+    /// Embedder-fixed pluggability (same shape as the other profile hooks); read
+    /// through [`effective_cpu_cap`](crate::effective_cpu_cap).
+    pub cpu_budget: Option<fn() -> Option<usize>>,
 }
 
 /// Standalone aube's embedder profile. Reproduces every hardcoded branding
@@ -240,6 +252,7 @@ pub const AUBE: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 static ACTIVE: OnceLock<&'static Embedder> = OnceLock::new();

--- a/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -40,6 +40,7 @@ static NUBLIKE: Embedder = Embedder {
     read_branded_settings_env: false,
     no_churn_lockfile_write: true,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 /// Restore the previous value of an env var around a closure. Integration-test

--- a/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -39,6 +39,7 @@ static NUBLIKE: Embedder = Embedder {
     read_branded_settings_env: false,
     no_churn_lockfile_write: true,
     primer_ttl: None,
+    cpu_budget: None,
 };
 
 #[test]


### PR DESCRIPTION
Generalizes the PID-only `resource_limits.rs` from #136 with a CPU-budget axis: the install's CPU-bound pools (tokio workers, the rayon global pool, aube's linker pool) now size to the box's cgroup CFS CPU quota instead of the over-reported host core count. On a quota-constrained container the pools no longer over-subscribe the quota — preventing the CFS-throttle latency cliff and the thread/PID growth that #136 caps reactively.

## Crate vs. port

Uses `num_cpus = "1"` (`num_cpus::get()`), not a hand-rolled cgroup parser. It reads the CFS quota for both cgroup v1 (`cpu.cfs_quota_us`/`cfs_period_us`) and v2 (`cpu.max`) via `/proc/self/mountinfo` and returns `min(ceil(quota/period), logical_cores)` — the automaxprocs algorithm with the chosen `max(1, ceil)` rounding. Maintained (v1.17.0), 2 deps. Replaced a first-draft ~80-line port.

## Finding

On a cgroup-v2 host, Rust std's `available_parallelism()` already reads `cpu.max` (since 1.61), so under `docker --cpus=0.5` it returns 1 on its own. `cpu_budget()` returns `None` there — its net value is the two gaps std misses: cgroup-v1 quota, and the affinity-blocked sandbox path (std drops the v2 quota when `sched_getaffinity` fails). `num_cpus` reads the files directly, covering both.

## Composition + override

- The rayon global pool is sized to `min(cpu-budget-derived, pid-headroom-derived)` and capped exactly once (a double `build_global` no-ops the second cap).
- A dedicated `NUB_CPU_BUDGET` env var overrides auto-detection (distinct from the fetch-concurrency `NUB_CONCURRENCY`). Explicit-wins, clamped `[1, host_logical_cpus]` (quota-ignoring) so it can raise above a detected quota, not only lower.

## Fork-discipline (vendor/aube)

aube's CPU-bound pools route through a new `Embedder.cpu_budget` hook + `aube_util::concurrency::effective_cpu_cap()`. Standalone aube installs no hook, so `effective_cpu_cap() == available_parallelism()` — byte-for-byte unchanged. Default-preserving, upstreamable (extends the #862 embedder profile).

## Stress matrix (Docker, cgroup v2, 10-core host) — all INSTALL_OK

| case | cpu_budget | workers / blocking / rayon |
|---|---|---|
| `--cpus=0.5` | None (std to 1) | 1 / 128 / 1 |
| `--cpus=2` | None (std to 2) | 2 / 128 / 2 |
| `--cpuset-cpus=0-1` | None (affinity to 2) | 2 / 128 / 2 |
| `--cpus=0.5 --pids-limit=80` | None min PID | 1 / 5 / 1 |
| unconstrained | None | 8 / 128 / 10 |
| `NUB_CPU_BUDGET=1` (free box) | Some(1) | 1 / 128 / 1 |
| `NUB_CPU_BUDGET=3` + `--cpus=2` | Some(3) override wins | 3 / 128 / 3 |

No EAGAIN/panic in any case; unconstrained sizing unchanged.

## Tests + gates

5 new unit tests in `resource_limits.rs` + 1 in `aube-util`. `clippy --all-targets --all-features -- -D warnings` and `fmt --check` clean; nub-cli bin suite 193 passing.

Refs #136

https://claude.ai/code/session_012YwF7yWjrXcj3bVJ1TziHK
