### PR TITLE
feat(worker): resolve a raw-string Worker specifier caller-relative at transpile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "nub-worker-resolve"
+version = "0.2.0"
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/nub-cache-key", "crates/nub-cli", "crates/nub-core"]
+members = ["crates/nub-cache-key", "crates/nub-cli", "crates/nub-core", "crates/nub-worker-resolve"]
 # vendor/aube is its own Cargo workspace (the vendored aube package manager,
 # plain in-tree files vendored from nubjs/aube). The exclude is load-bearing: nub crates
 # take `path` dependencies into vendor/aube/crates/*, and cargo auto-adopts

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -60,6 +60,29 @@ fn run_nub_with_env(fixture: &str, file: &str, env: &[(&str, &str)]) -> (String,
     (stdout, stderr, code)
 }
 
+/// Like `run_nub` but with the process CWD set to a FOREIGN directory (the system
+/// temp dir), not the fixture dir. This is the load-bearing setup for the
+/// worker-string-resolution tests: a cwd-relative resolver would fail to find a
+/// fixture-relative path from here, so a passing run proves caller-relative
+/// resolution.
+fn run_nub_foreign_cwd(fixture: &str, file: &str, env: &[(&str, &str)]) -> (String, String, i32) {
+    let fixture_path = fixtures_dir().join(fixture);
+    let mut cmd = Command::new(nub_binary());
+    cmd.arg(fixture_path.join(file).to_str().unwrap())
+        .current_dir(std::env::temp_dir());
+    if !env.iter().any(|(k, _)| *k == "XDG_CACHE_HOME") {
+        cmd.env("XDG_CACHE_HOME", unique_test_cache());
+    }
+    for &(k, v) in env {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let code = output.status.code().unwrap_or(-1);
+    (stdout, stderr, code)
+}
+
 /// Flagship provisioning, end-to-end through the binary: a project pinned (via
 /// `.node-version`) to an EXACT version that is on neither PATH nor in nub's store
 /// nor nvm → `nub <file>` downloads + installs it from nodejs.org (uv-style
@@ -5477,4 +5500,224 @@ fn run_script_reports_role_aware_user_agent() {
     }
 
     let _ = std::fs::remove_dir_all(&base);
+}
+
+// ── Worker string-specifier resolution (caller-relative, transpile-time) ──────
+// A raw STRING in `new Worker("…")` resolves with nub's full module resolution
+// against the CALLING module (like a top-level import) — fixing worker_threads'
+// cwd-relative footgun. The transpiler rewrites the literal to the canonical
+// `new Worker(new URL("<rel>", import.meta.url))` (nub-owned cases) or
+// `new Worker(import.meta.resolve("<bare>"))` (node_modules). Each run uses a
+// FOREIGN cwd so a cwd-relative resolver would fail — a pass proves caller-relative.
+
+#[test]
+fn worker_bare_relative_string_resolves_caller_relative() {
+    // The core fix: `new Worker("./worker.ts")`, run from a cwd that is NOT the
+    // fixture dir, reaches the sibling worker.ts. Under worker_threads' cwd
+    // behavior this would be a ModuleNotFound.
+    let (stdout, stderr, code) = run_nub_foreign_cwd("worker-string", "main.ts", &[]);
+    assert_eq!(
+        code, 0,
+        "bare relative worker string must resolve + run: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("main-got:worker-string:ready"),
+        "worker resolved caller-relative and ran (enum lowered): {stdout}"
+    );
+}
+
+#[test]
+fn worker_extensionless_string_gains_extension() {
+    // `new Worker("./worker")` (no extension) probes to ./worker.ts, like an import.
+    let (stdout, stderr, code) = run_nub_foreign_cwd("worker-string", "extensionless-main.ts", &[]);
+    assert_eq!(
+        code, 0,
+        "extensionless worker string must resolve: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("main-got:worker-string:ready"),
+        "extensionless specifier resolved to the .ts sibling: {stdout}"
+    );
+}
+
+#[test]
+fn worker_tsconfig_paths_alias_resolves() {
+    // A tsconfig `paths` alias (`@workers/w`) resolves like a top-level import and
+    // is erased to a portable relative URL in the emit (no tsconfig at runtime).
+    let (stdout, stderr, code) = run_nub_foreign_cwd("worker-string-paths", "src/main.ts", &[]);
+    assert_eq!(
+        code, 0,
+        "tsconfig paths worker alias must resolve: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("main-got:paths-worker:ready"),
+        "paths alias resolved + relativized: {stdout}"
+    );
+}
+
+#[test]
+fn worker_non_ascii_path_round_trips() {
+    // A non-ASCII worker filename (`café.ts`) must percent-encode its UTF-8 bytes
+    // in the emitted URL (`caf%C3%A9.ts`, NOT the latin-1 mojibake `cafÃ©.ts`) and
+    // round-trip back through `new URL` → `fileURLToPath` to the real file. Run
+    // from a foreign cwd so resolution is genuinely caller-relative.
+    let (stdout, stderr, code) = run_nub_foreign_cwd("worker-string", "unicode-main.ts", &[]);
+    assert_eq!(
+        code, 0,
+        "non-ASCII worker path must resolve + run: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("main-got:unicode-worker:ready"),
+        "percent-encoded UTF-8 path resolved to the real file: {stdout}"
+    );
+}
+
+#[test]
+fn worker_threads_import_is_not_rewritten() {
+    // The additivity guard: `import { Worker } from "node:worker_threads"` binds
+    // `Worker`, so the rewrite must SKIP it (its ctor is genuinely cwd/path-relative
+    // — rewriting would be a regression). The fixture passes an absolute path, so a
+    // pass proves the worker_threads Worker still works AND nub left it untouched.
+    let (stdout, stderr, code) = run_nub("worker-string", "wt-main.ts");
+    assert_eq!(
+        code, 0,
+        "worker_threads Worker must still work, unrewritten: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("main-got:wt-ran"),
+        "the bound worker_threads Worker ran (not rewritten): {stdout}"
+    );
+}
+
+#[test]
+fn worker_string_no_rewrite_in_compat_mode() {
+    // `--node` and NODE_COMPAT=1 disable augmentation entirely: no transpile
+    // rewrite AND no Worker global. The bare-string worker then behaves like plain
+    // Node (`Worker is not defined`), never caller-relative. One assertion per
+    // opt-out surface (the `--node` flag, the env var).
+    //
+    // Uses a PLAIN-JS (.mjs) fixture, NOT a .ts one: `--node` also disables nub's
+    // transpiler, and Node below 22.18 (the fast-tier floor and every compat tier)
+    // can't strip TS types — a .ts entry would throw a SyntaxError on the type
+    // annotation BEFORE reaching `new Worker`, masking the signal. Plain JS parses
+    // on every tier, so the ONLY failure is the missing Worker global.
+    let entry = fixtures_dir().join("worker-string").join("compat-main.mjs");
+
+    let node_flag = Command::new(nub_binary())
+        .arg("--node")
+        .arg(&entry)
+        .current_dir(std::env::temp_dir())
+        .env("XDG_CACHE_HOME", unique_test_cache())
+        .output()
+        .expect("spawn nub --node");
+    let flag_err = String::from_utf8_lossy(&node_flag.stderr);
+    assert_ne!(
+        node_flag.status.code(),
+        Some(0),
+        "--node must not augment: {flag_err}"
+    );
+    assert!(
+        flag_err.contains("Worker is not defined"),
+        "--node leaves the bare string unaugmented (plain-Node Worker): {flag_err}"
+    );
+
+    let (_o, env_err, env_code) =
+        run_nub_foreign_cwd("worker-string", "compat-main.mjs", &[("NODE_COMPAT", "1")]);
+    assert_ne!(env_code, 0, "NODE_COMPAT=1 must not augment: {env_err}");
+    assert!(
+        env_err.contains("Worker is not defined"),
+        "NODE_COMPAT=1 leaves the bare string unaugmented: {env_err}"
+    );
+}
+
+// ── Worker string resolution from RAW JS callers (.js/.mjs/.cjs) ──────────────
+// Uniformity with .ts callers: a raw `new Worker("./w.js")` resolves caller-relative
+// from a plain `.js`/`.mjs` module too. nub does not transpile plain JS by default
+// (the #152 byte-parity invariant), so a bare-worker file is routed through the
+// transform by an ADDED trigger in `maybeTranspilePlainJs` (the
+// `has_global_worker_string_call` detection), where the existing rewrite fires.
+
+#[test]
+fn worker_string_resolves_from_plain_mjs_caller() {
+    // A plain `.mjs` caller with ONLY a worker (no other lowerable syntax) must be
+    // transpiled + rewritten so its `./js-worker.js` resolves caller-relative. Run
+    // from a foreign cwd, so a cwd-relative resolver would fail.
+    let (stdout, stderr, code) = run_nub_foreign_cwd("worker-string", "mjs-main.mjs", &[]);
+    assert_eq!(
+        code, 0,
+        "raw .mjs caller must resolve its worker string caller-relative: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("main-got:mjs-worker:ready"),
+        "the .mjs caller's worker resolved the sibling: {stdout}"
+    );
+}
+
+#[test]
+fn worker_string_resolves_from_dotjs_esm_caller() {
+    // A `.js` file in a `type: module` package is ESM but not transpiled by default —
+    // the worker trigger routes it through the transform, so behavior is uniform
+    // across module languages.
+    let (stdout, stderr, code) = run_nub_foreign_cwd("worker-string-js-esm", "main.js", &[]);
+    assert_eq!(
+        code, 0,
+        "raw .js-as-ESM caller must resolve caller-relative: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("main-got:dotjs-esm:ready"),
+        "the .js caller's worker resolved the sibling: {stdout}"
+    );
+}
+
+#[test]
+fn worker_string_plain_js_no_worker_is_byte_identical() {
+    // The #152 no-op invariant must hold: a plain `.mjs` with NO worker and no other
+    // lowerable syntax is NOT transpiled — Node loads it raw, byte-identical. We run
+    // it (it must succeed) AND assert the loaded source kept its distinctive
+    // formatting (single quotes, trailing commas) that oxc codegen would have
+    // normalized — proving nub did not route it through the transform.
+    let (stdout, stderr, code) = run_nub("worker-string-byte-parity", "plain.mjs");
+    assert_eq!(code, 0, "no-worker plain .mjs must run: {stderr}\n{stdout}");
+    assert!(
+        stdout.contains("byte-parity:12hi"),
+        "the no-worker file ran unchanged: {stdout}"
+    );
+}
+
+#[test]
+fn worker_string_in_node_modules_is_not_rewritten() {
+    // The byte-parity boundary is node_modules, NOT the file extension: a dep's
+    // internal `new Worker("./inner.js")` must be left RAW (cwd-relative), never
+    // transpiled/rewritten. Run from a foreign cwd: left raw, the dep's worker
+    // resolves against cwd and errors — exactly what proves nub did not touch
+    // node_modules source. (A rewrite would have made it resolve + run.)
+    let (stdout, stderr, code) = run_nub_foreign_cwd("worker-string-nm", "main.mjs", &[]);
+    assert_eq!(code, 0, "fixture should complete: {stderr}\n{stdout}");
+    assert!(
+        stdout.contains("dep-worker-cwd-relative-as-expected"),
+        "a node_modules dep's worker string must stay cwd-relative (unrewritten): {stdout}"
+    );
+    assert!(
+        !stdout.contains("UNEXPECTED-dep-resolved"),
+        "nub must NOT rewrite node_modules worker strings: {stdout}"
+    );
+}
+
+#[test]
+fn worker_string_in_cjs_is_not_rewritten() {
+    // The rewrite emits `import.meta.url` (ESM-only), so a CommonJS caller is left
+    // as-is: NOT transpiled (byte-identical, Node's native CJS path) and NOT
+    // rewritten. The worker keeps worker_threads' cwd-relative behavior, so run from
+    // the fixture dir where the sibling resolves. This guards the byte-parity no-op
+    // invariant for a CJS file that carries a global Worker string — without the ESM
+    // gate it would be needlessly codegen'd (and reformatted).
+    let (stdout, stderr, code) = run_nub("worker-string", "cjs-main.cjs");
+    assert_eq!(
+        code, 0,
+        "CJS worker file must run on the native path: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("cjs-got:cjs-native:ok:1"),
+        "the CJS worker ran cwd-relative (unrewritten, untranspiled): {stdout}"
+    );
 }

--- a/crates/nub-native/Cargo.lock
+++ b/crates/nub-native/Cargo.lock
@@ -624,6 +624,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "nub-cache-key",
+ "nub-worker-resolve",
  "oxc",
  "oxc_napi",
  "oxc_sourcemap",
@@ -633,6 +634,10 @@ dependencies = [
  "toml",
  "yaml-rust2",
 ]
+
+[[package]]
+name = "nub-worker-resolve"
+version = "0.2.0"
 
 [[package]]
 name = "num-bigint"

--- a/crates/nub-native/Cargo.toml
+++ b/crates/nub-native/Cargo.toml
@@ -155,6 +155,9 @@ blake3.workspace = true
 # invalidation contract can be unit-tested off the un-testable cdylib. A path dep
 # that crosses into the MAIN workspace (where nub-cache-key is a member).
 nub-cache-key = { path = "../nub-cache-key" }
+# Worker-specifier path classification + re-relativization (the portability moat).
+# Same cross-workspace path-dep + napi-free-testable shape as nub-cache-key above.
+nub-worker-resolve = { path = "../nub-worker-resolve" }
 
 [build-dependencies]
 napi-build = "2"

--- a/crates/nub-native/src/detect.rs
+++ b/crates/nub-native/src/detect.rs
@@ -21,9 +21,13 @@ use napi_derive::napi;
 
 use oxc::{
     allocator::Allocator,
-    ast::ast::{ImportDeclarationSpecifier, RegExpFlags, Statement, VariableDeclaration},
+    ast::ast::{
+        Argument, Expression, ImportDeclarationSpecifier, NewExpression, RegExpFlags, Statement,
+        VariableDeclaration,
+    },
     ast_visit::Visit,
     parser::Parser,
+    semantic::SemanticBuilder,
 };
 use oxc_napi::get_source_type;
 
@@ -69,6 +73,18 @@ pub struct ModuleInfo {
     /// the target-version-gated SYNTAX triggers (using ∪ v-flag-regexp); the JS gate
     /// ORs it with `has_decorators`.
     pub transformable_syntax: bool,
+
+    /// True when the source contains a `new Worker(<string-literal>)` whose callee
+    /// is the FREE/global `Worker` (the browser-global the polyfill installs) — the
+    /// exact shape the Worker-specifier rewrite (`worker_rewrite`) acts on. It is
+    /// an ADDITIONAL trigger for transpiling project-source plain JS: such a file
+    /// must be routed through the transform so the caller-relative rewrite fires,
+    /// uniformly with `.ts`/`.jsx` callers. PRECISE (semantic-scoped, not a name
+    /// match), so a bound `Worker` — `import { Worker } from "node:worker_threads"`,
+    /// a shadowed local — does NOT trigger, preserving the byte-identical no-op path
+    /// for those files. Computed only when a cheap candidate is present (see below),
+    /// so the semantic build stays off the common no-Worker hot path.
+    pub has_global_worker_string_call: bool,
 }
 
 /// Detect a file's module-format and decorator shape. `lang` is `'ts'`, `'tsx'`,
@@ -100,6 +116,7 @@ pub fn detect_module_info(
             has_value_esm_syntax: false,
             has_decorators: false,
             transformable_syntax: false,
+            has_global_worker_string_call: false,
         };
     }
 
@@ -109,19 +126,43 @@ pub fn detect_module_info(
         !ret.module_record.import_metas.is_empty(),
     );
 
-    // ONE AST walk computes both the decorator guard and the skip-gate verdict —
-    // the visitor already traverses the whole tree, so folding the using/v-flag
-    // checks into the same pass is near-free (no extra parse, no second walk).
+    // ONE AST walk computes the decorator guard, the skip-gate verdict, AND a CHEAP
+    // boolean: does any `new Worker(<string-literal>)` with a bare `Worker` callee
+    // exist? (No scope info — the parser doesn't resolve references.) The visitor
+    // already traverses the whole tree, so folding these in is near-free.
     let mut finder = SyntaxFinder {
         decorators: false,
         transformable: false,
+        has_worker_candidate: false,
     };
     finder.visit_program(&ret.program);
+
+    // The Worker trigger is PRECISE: only a FREE/global `Worker` counts. Build
+    // semantic ONLY when a candidate exists (the common no-Worker file pays nothing),
+    // then re-walk with the resolved scoping to confirm at least one candidate's
+    // callee reference is unresolved (free/global) — `reference_id`s are populated by
+    // SemanticBuilder, so this scope check must run AFTER the build, not in the
+    // pre-semantic pass above.
+    let has_global_worker_string_call = if !finder.has_worker_candidate {
+        false
+    } else {
+        let scoping = SemanticBuilder::new()
+            .build(&ret.program)
+            .semantic
+            .into_scoping();
+        let mut checker = WorkerScopeChecker {
+            scoping: &scoping,
+            found_global: false,
+        };
+        checker.visit_program(&ret.program);
+        checker.found_global
+    };
 
     ModuleInfo {
         has_value_esm_syntax,
         has_decorators: finder.decorators,
         transformable_syntax: finder.transformable,
+        has_global_worker_string_call,
     }
 }
 
@@ -212,16 +253,28 @@ fn specifier_is_type(spec: &ImportDeclarationSpecifier<'_>) -> bool {
     }
 }
 
-/// Walks the AST once, latching two independent verdicts:
+/// Walks the AST once, latching the verdicts:
 ///   * `decorators` — a `@decorator` appears anywhere (drives the Stage-3 guard).
 ///   * `transformable` — the source contains target-version-gated SYNTAX oxc lowers
 ///     at `target:"es2022"`: a `using`/`await using` declaration, or a `v`-flag
 ///     RegExp literal. See `ModuleInfo::transformable_syntax` for the pinned
-///     provenance of this set (oxc =0.132.0). Both fields keep going once latched
-///     (the visit completes) — correctness only needs "did we ever see one".
+///     provenance of this set (oxc =0.132.0). Latches once seen.
+///   * `has_worker_candidate` — does any `new Worker(<string-literal>)` with a bare
+///     `Worker` callee exist? A cheap, pre-semantic OVER-approximation (no scope
+///     info). The caller confirms FREE/global via a second, semantic-aware pass —
+///     run only when this latches, so the common no-Worker file pays nothing.
 struct SyntaxFinder {
     decorators: bool,
     transformable: bool,
+    has_worker_candidate: bool,
+}
+
+/// Does a `new Worker(<string-literal>)` call have a bare-identifier `Worker`
+/// callee AND a string-literal first arg? (The eligibility SHAPE the rewrite acts
+/// on, minus the scope guard.)
+fn is_worker_string_call(it: &NewExpression<'_>) -> bool {
+    matches!(&it.callee, Expression::Identifier(ident) if ident.name.as_str() == "Worker")
+        && matches!(it.arguments.first(), Some(Argument::StringLiteral(_)))
 }
 
 impl<'a> Visit<'a> for SyntaxFinder {
@@ -244,5 +297,38 @@ impl<'a> Visit<'a> for SyntaxFinder {
         if it.regex.flags.contains(RegExpFlags::V) {
             self.transformable = true;
         }
+    }
+
+    fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
+        if is_worker_string_call(it) {
+            self.has_worker_candidate = true;
+        }
+        oxc::ast_visit::walk::walk_new_expression(self, it);
+    }
+}
+
+/// Second pass, run with the resolved `Scoping` only when a candidate exists:
+/// latches `found_global` iff some `new Worker(<string-literal>)` callee is a
+/// FREE/global reference (`symbol_id().is_none()`) — exactly the rewrite's guard,
+/// so the transpile trigger matches what the rewrite will actually act on.
+struct WorkerScopeChecker<'a> {
+    scoping: &'a oxc::semantic::Scoping,
+    found_global: bool,
+}
+
+impl<'a> Visit<'a> for WorkerScopeChecker<'_> {
+    fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
+        if is_worker_string_call(it) {
+            if let Expression::Identifier(ident) = &it.callee {
+                let free = match ident.reference_id.get() {
+                    Some(id) => self.scoping.get_reference(id).symbol_id().is_none(),
+                    None => false,
+                };
+                if free {
+                    self.found_global = true;
+                }
+            }
+        }
+        oxc::ast_visit::walk::walk_new_expression(self, it);
     }
 }

--- a/crates/nub-native/src/lib.rs
+++ b/crates/nub-native/src/lib.rs
@@ -16,6 +16,7 @@ mod detect;
 mod resolve;
 mod transform;
 mod tsconfig;
+mod worker_rewrite;
 
 use napi_derive::napi;
 

--- a/crates/nub-native/src/resolve.rs
+++ b/crates/nub-native/src/resolve.rs
@@ -28,22 +28,30 @@ const TS_PARENT_EXTS: [&str; 4] = [".ts", ".tsx", ".mts", ".cts"];
 /// absolute filesystem path (empty for the entry).
 #[napi]
 pub fn resolve_ts(specifier: String, parent_path: String) -> Option<String> {
-    let parent_ext = extname(&parent_path);
+    resolve_ts_core(&specifier, &parent_path)
+}
+
+/// In-process core of [`resolve_ts`], called both from the napi entry above and
+/// from the worker-specifier rewrite pass (`worker_rewrite`). Same `Some`/`None`
+/// boundary: `Some` is an additive case nub owns (relative/extensionless/tsconfig
+/// `paths`), `None` is everything Node owns (node_modules / `exports` / bare).
+pub fn resolve_ts_core(specifier: &str, parent_path: &str) -> Option<String> {
+    let parent_ext = extname(parent_path);
     let parent_dir = if parent_path.is_empty() {
         std::env::current_dir().ok()?.to_string_lossy().into_owned()
     } else {
-        dirname(&parent_path)
+        dirname(parent_path)
     };
 
     let is_relative = specifier.starts_with("./") || specifier.starts_with("../");
-    let is_absolute = specifier.starts_with('/') || Path::new(&specifier).is_absolute();
+    let is_absolute = specifier.starts_with('/') || Path::new(specifier).is_absolute();
     let is_file_url = specifier.starts_with("file:");
 
     // tsconfig `paths` branch — non-relative, non-absolute specifiers from a file
     // outside node_modules. (Not gated on a TS parent: a plain .js with a paths
     // alias resolves too.)
-    if !is_relative && !is_absolute && !is_file_url && !is_node_modules(&parent_path) {
-        let candidates = tsconfig::match_paths(&parent_dir, &specifier);
+    if !is_relative && !is_absolute && !is_file_url && !is_node_modules(parent_path) {
+        let candidates = tsconfig::match_paths(&parent_dir, specifier);
         for candidate in candidates {
             if let Some(resolved) = try_resolve_file(&candidate, &parent_ext, true) {
                 return Some(resolved);
@@ -57,12 +65,45 @@ pub fn resolve_ts(specifier: String, parent_path: String) -> Option<String> {
     // Extensionless / emit-swap branch — only when the importer is itself a TS
     // file and the specifier is relative.
     if is_ts_parent(&parent_ext) && is_relative {
-        let target = path_join_resolve(&parent_dir, &specifier);
+        let target = path_join_resolve(&parent_dir, specifier);
         if let Some(resolved) = try_resolve_file(&target, &parent_ext, true) {
             return Some(resolved);
         }
     }
 
+    None
+}
+
+/// Resolve a `new Worker("…")` STRING specifier like a top-level import, for ANY
+/// caller extension (`.ts`/`.tsx`/… AND raw `.js`/`.mjs`/`.cjs`). This is the
+/// SINGLE worker-resolution shared by both the AST-rewrite path and (when a JS
+/// caller is routed through the transform via `maybeTranspilePlainJs`) that same
+/// pass — so a `.js` caller resolves IDENTICALLY to a `.ts` caller.
+///
+/// It reuses [`resolve_ts_core`] (covers tsconfig `paths` for every parent, and the
+/// TS-parent relative/extensionless/emit-swap probing) and, when that returns `None`
+/// for a RELATIVE specifier (the case `resolve_ts_core` gates to TS parents), adds a
+/// parent-ext-agnostic relative probe so a raw-JS caller's `./worker.js` / `./worker`
+/// resolves too. `None` still means Node-owned (node_modules / bare) — the
+/// bare-package seam is unchanged.
+pub fn resolve_worker_target(specifier: &str, parent_path: &str) -> Option<String> {
+    if let Some(hit) = resolve_ts_core(specifier, parent_path) {
+        return Some(hit);
+    }
+    let is_relative = specifier.starts_with("./") || specifier.starts_with("../");
+    if is_relative {
+        let parent_dir = if parent_path.is_empty() {
+            std::env::current_dir().ok()?.to_string_lossy().into_owned()
+        } else {
+            dirname(parent_path)
+        };
+        let target = path_join_resolve(&parent_dir, specifier);
+        // Empty parent_ext → default probe order (.ts/.tsx/.js/.jsx/.json); the
+        // `.js`→`.ts` emit-swap still applies for an explicit `.js`.
+        if let Some(resolved) = try_resolve_file(&target, "", true) {
+            return Some(resolved);
+        }
+    }
     None
 }
 

--- a/crates/nub-native/src/transform.rs
+++ b/crates/nub-native/src/transform.rs
@@ -40,6 +40,8 @@ use oxc::{
 use oxc_napi::{OxcError, get_source_type};
 use oxc_sourcemap::napi::SourceMap;
 
+use crate::worker_rewrite;
+
 /// The result of a transform. Mirror of oxc's `TransformResult`, minus the
 /// isolated-declarations fields nub never requests.
 #[derive(Default)]
@@ -441,6 +443,12 @@ struct Compiler {
     transform_options: oxc::transformer::TransformOptions,
     sourcemap: bool,
 
+    /// The compiling module's absolute path. Threaded in from `transform()` so the
+    /// worker-specifier rewrite pass (`worker_rewrite`) can resolve a string
+    /// `new Worker("…")` against the CALLING module, like a top-level import — not
+    /// node:worker_threads' cwd. Empty for a sourceless / unknown-path transform.
+    file_path: String,
+
     printed: String,
     printed_sourcemap: Option<SourceMap>,
 
@@ -504,6 +512,7 @@ impl Compiler {
         Ok(Self {
             transform_options,
             sourcemap,
+            file_path: String::default(),
             printed: String::default(),
             printed_sourcemap: None,
             define,
@@ -538,6 +547,43 @@ impl CompilerInterface for Compiler {
     fn after_codegen(&mut self, ret: CodegenReturn) {
         self.printed = ret.code;
         self.printed_sourcemap = ret.map.map(SourceMap::from);
+    }
+
+    /// Override the transform seam (NOT `after_transform`) because this is the one
+    /// hook that holds BOTH the `Allocator` (to build replacement AST) AND the
+    /// post-transform `Scoping` (the free-vs-bound `Worker` guard). Run oxc's stock
+    /// transform first — preserving byte-parity — then the additive worker-specifier
+    /// rewrite over the same allocator + scoping before returning.
+    fn transform<'a>(
+        &self,
+        options: &oxc::transformer::TransformOptions,
+        allocator: &'a oxc::allocator::Allocator,
+        program: &mut oxc::ast::ast::Program<'a>,
+        source_path: &Path,
+        scoping: oxc::semantic::Scoping,
+    ) -> oxc::transformer::TransformerReturn {
+        let ret = oxc::transformer::Transformer::new(allocator, source_path, options)
+            .build_with_scoping(scoping, program);
+
+        // ESM-only: `import.meta` is invalid in CJS output. A CJS-format source is
+        // parsed with ModuleKind::CommonJS, so this gate also covers a CJS-syntax
+        // `.ts` (nub passes sourceType per detected format).
+        if program.source_type.is_module() && !self.file_path.is_empty() {
+            let dir = Path::new(&self.file_path)
+                .parent()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let ast = oxc::ast::AstBuilder::new(allocator);
+            worker_rewrite::rewrite_worker_specifiers(
+                ast,
+                program,
+                &ret.scoping,
+                &self.file_path,
+                &dir,
+            );
+        }
+
+        ret
     }
 
     #[expect(deprecated)]
@@ -586,6 +632,8 @@ pub fn transform(
             };
         }
     };
+    // The resolver referrer for the worker-specifier rewrite (see Compiler.file_path).
+    compiler.file_path = filename.clone();
 
     compiler.compile(&source_text, source_type, source_path);
 

--- a/crates/nub-native/src/worker_rewrite.rs
+++ b/crates/nub-native/src/worker_rewrite.rs
@@ -1,0 +1,181 @@
+//! The net-new oxc `VisitMut` pass that rewrites a STRING-LITERAL `new Worker(...)`
+//! specifier to resolve like a top-level `import` against the COMPILING module —
+//! instead of `node:worker_threads`' cwd-relative behavior.
+//!
+//! Run from `Compiler::transform` (transform.rs) AFTER the TS transform, so it has
+//! the live post-transform `Scoping`. It fires ONLY when:
+//!   * the callee is the bare identifier `Worker` whose reference is FREE/global
+//!     (`symbol_id().is_none()`) — i.e. the browser-`Worker` global the polyfill
+//!     installs, NOT an `import { Worker } from "node:worker_threads"` (a BOUND
+//!     reference) nor a shadowed local. Rewriting the worker_threads `Worker`
+//!     (genuinely cwd-relative) would be an additivity regression, so the scope
+//!     guard is load-bearing.
+//!   * the first argument is a `StringLiteral`.
+//!   * the emit target is ESM (gated by the caller — `import.meta` is invalid in
+//!     CJS output).
+//!
+//! HYBRID resolution, splitting on nub's existing resolver boundary:
+//!   * nub-owned (relative / extensionless / tsconfig `paths` → `resolve_ts_core`
+//!     returns `Some`): re-relativize the absolute target back to the compiling
+//!     module and emit `new Worker(new URL("<relative>", import.meta.url))` — the
+//!     bundler-analyzable, deploy-portable form.
+//!   * bare package (`resolve_ts_core` returns `None` AND the specifier is bare):
+//!     emit `new Worker(import.meta.resolve("<bare>"))` — Node's own resolver owns
+//!     node_modules / `exports` / conditions at runtime (no forbidden Rust reimpl).
+//!
+//! SOUNDNESS: passthrough (absolute / `file:` / `data:` / `blob:` / any non-string
+//! arg) is left byte-identical, and a nub-owned target that cannot be relativized
+//! (cross-root) is LEFT UNTOUCHED — the rewrite NEVER bakes an absolute path.
+
+use oxc::ast::ast::{Argument, Expression, NewExpression, Program};
+use oxc::ast::{AstBuilder, NONE};
+use oxc::ast_visit::VisitMut;
+use oxc::semantic::Scoping;
+use oxc::span::SPAN;
+
+use crate::resolve::resolve_worker_target;
+
+/// Rewrite eligible `new Worker("…")` specifiers in `program`. `file_path` is the
+/// compiling module's absolute path (the resolver referrer); `file_dir` its
+/// directory (the relativize base). No-op unless a `Worker` global call with a
+/// string literal is present.
+pub fn rewrite_worker_specifiers<'a>(
+    ast: AstBuilder<'a>,
+    program: &mut Program<'a>,
+    scoping: &Scoping,
+    file_path: &str,
+    file_dir: &str,
+) {
+    let mut visitor = WorkerRewrite {
+        ast,
+        scoping,
+        file_path,
+        file_dir,
+    };
+    visitor.visit_program(program);
+}
+
+struct WorkerRewrite<'a, 'b> {
+    ast: AstBuilder<'a>,
+    scoping: &'b Scoping,
+    file_path: &'b str,
+    file_dir: &'b str,
+}
+
+impl<'a> VisitMut<'a> for WorkerRewrite<'a, '_> {
+    fn visit_new_expression(&mut self, it: &mut NewExpression<'a>) {
+        // Recurse first so nested `new Worker(...)` (e.g. inside an argument) is
+        // also visited; the rewrite below only touches THIS node's first arg.
+        oxc::ast_visit::walk_mut::walk_new_expression(self, it);
+
+        if !self.is_free_global_worker(&it.callee) {
+            return;
+        }
+        let Some(Argument::StringLiteral(lit)) = it.arguments.first() else {
+            return;
+        };
+        let specifier = lit.value.to_string();
+
+        if let Some(replacement) = self.resolve_replacement(&specifier) {
+            it.arguments[0] = Argument::from(replacement);
+        }
+    }
+}
+
+impl<'a> WorkerRewrite<'a, '_> {
+    /// The callee is the bare identifier `Worker` AND its reference is unresolved
+    /// (free/global). A bound reference — `import { Worker } from
+    /// "node:worker_threads"`, a `const Worker = …`, a param — has a `symbol_id`
+    /// and is SKIPPED.
+    fn is_free_global_worker(&self, callee: &Expression<'a>) -> bool {
+        let Expression::Identifier(ident) = callee else {
+            return false;
+        };
+        if ident.name.as_str() != "Worker" {
+            return false;
+        }
+        match ident.reference_id.get() {
+            Some(ref_id) => self.scoping.get_reference(ref_id).symbol_id().is_none(),
+            // No reference id resolved ⇒ treat as not-eligible (conservative).
+            None => false,
+        }
+    }
+
+    /// Build the replacement first-argument expression for `specifier`, or `None`
+    /// to leave the node untouched (passthrough / unresolvable / cross-root).
+    fn resolve_replacement(&self, specifier: &str) -> Option<Expression<'a>> {
+        // Passthrough: already cwd-independent or an inline source. The same
+        // discrimination resolve_ts_core encodes — short-circuit here so a `file:`
+        // absolute etc. is never rewritten.
+        if is_passthrough(specifier) {
+            return None;
+        }
+
+        match resolve_worker_target(specifier, self.file_path) {
+            // nub-owned: re-relativize → `new URL("<rel>", import.meta.url)`.
+            Some(abs) => {
+                let rel = nub_worker_resolve::relativize_for_url(self.file_dir, &abs)?;
+                Some(self.build_new_url(&rel))
+            }
+            // Node-owned bare package → `import.meta.resolve("<bare>")`. A non-bare
+            // `None` (e.g. a relative path that simply doesn't exist on disk) is
+            // left untouched.
+            None if nub_worker_resolve::is_bare_specifier(specifier) => {
+                Some(self.build_import_meta_resolve(specifier))
+            }
+            None => None,
+        }
+    }
+
+    /// `new URL("<rel>", import.meta.url)`.
+    fn build_new_url(&self, rel: &str) -> Expression<'a> {
+        let callee = self.ast.expression_identifier(SPAN, "URL");
+        let arg_str = self
+            .ast
+            .expression_string_literal(SPAN, self.ast.str(rel), None);
+        let import_meta_url = self.import_meta_member("url");
+        let args = self
+            .ast
+            .vec_from_array([Argument::from(arg_str), Argument::from(import_meta_url)]);
+        self.ast.expression_new(SPAN, callee, NONE, args)
+    }
+
+    /// `import.meta.resolve("<bare>")`.
+    fn build_import_meta_resolve(&self, bare: &str) -> Expression<'a> {
+        let callee = self.import_meta_member("resolve");
+        let arg = self
+            .ast
+            .expression_string_literal(SPAN, self.ast.str(bare), None);
+        let args = self.ast.vec1(Argument::from(arg));
+        self.ast.expression_call(SPAN, callee, NONE, args, false)
+    }
+
+    /// `import.meta.<prop>` (a static member access on the `import.meta` meta
+    /// property).
+    fn import_meta_member(&self, prop: &str) -> Expression<'a> {
+        let meta = self.ast.identifier_name(SPAN, "import");
+        let property = self.ast.identifier_name(SPAN, "meta");
+        let import_meta = self.ast.expression_meta_property(SPAN, meta, property);
+        let prop_name = self.ast.identifier_name(SPAN, self.ast.str(prop));
+        Expression::from(
+            self.ast
+                .member_expression_static(SPAN, import_meta, prop_name, false),
+        )
+    }
+}
+
+/// A specifier that is already cwd-independent (absolute / `file:`) or an inline
+/// source (`data:` / `blob:`), or a degenerate non-specifier — never rewritten.
+fn is_passthrough(specifier: &str) -> bool {
+    // Degenerate: empty, whitespace-only, or a bare `.`/`..` directory reference.
+    // These are not real worker specifiers; leave them to Node rather than emit a
+    // nonsensical `import.meta.resolve("")`.
+    if specifier.trim().is_empty() || specifier == "." || specifier == ".." {
+        return true;
+    }
+    specifier.starts_with('/')
+        || std::path::Path::new(specifier).is_absolute()
+        || specifier.starts_with("file:")
+        || specifier.starts_with("data:")
+        || specifier.starts_with("blob:")
+}

--- a/crates/nub-worker-resolve/Cargo.toml
+++ b/crates/nub-worker-resolve/Cargo.toml
@@ -1,0 +1,34 @@
+# The worker-specifier path classification + re-relativization helpers, factored
+# out of `nub-native` so they are unit testable. `nub-native` is a `cdylib` N-API
+# addon: its `napi_*` symbols are resolved by the Node host at dlopen, so a
+# `cargo test` harness for that crate cannot link (it has `test = false` — see its
+# Cargo.toml). These helpers are pure path arithmetic (classify a Worker string
+# specifier, re-relativize an absolute resolved target to a POSIX-`/` URL, encode
+# it) with no napi dependency, and they carry the LOAD-BEARING portability moat
+# (never bake an absolute build path; cross-root → no rewrite) plus
+# Windows-separator behavior that the Linux-only e2e suite cannot exercise — so
+# they live here where they CAN be tested on every platform, and `nub-native`
+# calls into them. Keep this crate napi-free.
+#
+# SELF-CONTAINED MANIFEST (no `*.workspace = true`): same rationale as
+# `nub-cache-key` — this crate is a member of the ROOT workspace AND a
+# cross-workspace path dependency of `crates/nub-native`, whose release `cross`
+# build mounts only the nub-native workspace, where the root manifest is absent.
+# Inlining the package fields (identical to the root `[workspace.package]`) lets
+# this manifest parse standalone in the cross container. Keep these literals in
+# lockstep with the root `Cargo.toml`'s `[workspace.package]` /
+# `[workspace.lints.clippy]`.
+[package]
+name = "nub-worker-resolve"
+version = "0.2.0"
+edition = "2024"
+rust-version = "1.88"
+license = "MIT"
+repository = "https://github.com/nubjs/nub"
+
+[dependencies]
+
+[lints.clippy]
+dbg_macro = "warn"
+todo = "warn"
+unimplemented = "warn"

--- a/crates/nub-worker-resolve/src/lib.rs
+++ b/crates/nub-worker-resolve/src/lib.rs
@@ -1,0 +1,239 @@
+//! Pure path helpers for the Worker string-specifier rewrite (`nub-native`'s
+//! `worker_rewrite` pass). Factored out of the cdylib so the portability-critical
+//! invariants are unit-testable on every platform — including the Windows
+//! separator / drive-letter behavior the Linux-only e2e suite cannot reach.
+//!
+//! THE SOUNDNESS MOAT: [`relativize_for_url`] returns `None` whenever no relative
+//! path exists (cross-root / cross-drive). The rewrite pass treats `None` as
+//! "leave the node untouched" — it NEVER bakes an absolute build-machine path into
+//! the emitted `new URL(...)`, which is the exact portability failure the feature
+//! exists to avoid.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Is `specifier` a BARE package name (not relative, not absolute, not a URL
+/// scheme, not a `#`-subpath)? The rewrite pass uses this to decide the
+/// `import.meta.resolve` emit when nub's TS resolver returned `None` (= Node owns
+/// it: node_modules / `exports`). A scheme is `<word>:` at the head (`file:`,
+/// `data:`, `node:`, `http:`); a Windows drive (`C:\`) is NOT a scheme — it is
+/// absolute, hence not bare.
+pub fn is_bare_specifier(specifier: &str) -> bool {
+    if specifier.starts_with("./") || specifier.starts_with("../") {
+        return false;
+    }
+    if specifier.starts_with('/') || Path::new(specifier).is_absolute() {
+        return false;
+    }
+    if specifier.starts_with('#') {
+        return false;
+    }
+    !has_url_scheme(specifier)
+}
+
+/// A leading `<scheme>:` where scheme is `[A-Za-z][A-Za-z0-9+.-]*` and longer than
+/// one char (so a Windows drive letter `C:` is NOT mistaken for a scheme).
+fn has_url_scheme(s: &str) -> bool {
+    let Some(colon) = s.find(':') else {
+        return false;
+    };
+    if colon < 2 {
+        return false; // single-letter prefix ⇒ a drive letter, not a scheme
+    }
+    let mut chars = s[..colon].chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '-'))
+}
+
+/// Re-relativize an absolute resolved `target` back to `from_dir` (the compiling
+/// module's directory) → a POSIX-separator relative URL specifier, prefixed with
+/// `./` or `../` and percent-encoded for use as the first arg of
+/// `new URL(<rel>, import.meta.url)`.
+///
+/// `None` when no relative path exists (different root/drive, or `target == dir`)
+/// — the caller LEAVES THE NODE UNTOUCHED, never emitting an absolute path.
+pub fn relativize_for_url(from_dir: &str, target: &str) -> Option<String> {
+    let rel = relative_path(Path::new(from_dir), Path::new(target))?;
+    // POSIX `/` separators in the emitted URL (a backslash is not a URL path sep).
+    let posix = rel
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/");
+    if posix.is_empty() {
+        return None;
+    }
+    let encoded = encode_url_path(&posix);
+    Some(if encoded.starts_with("../") {
+        encoded
+    } else {
+        format!("./{encoded}")
+    })
+}
+
+/// Pure lexical relative path from `base` (a directory) to `target`, à la Node's
+/// `path.relative`. Both must share a root (prefix/drive); `None` otherwise — the
+/// cross-root guard. Operates on already-normalized absolute paths.
+fn relative_path(base: &Path, target: &Path) -> Option<PathBuf> {
+    let base_comps: Vec<Component> = base.components().collect();
+    let target_comps: Vec<Component> = target.components().collect();
+
+    // Roots must match (same prefix on Windows, same `/` on unix). A differing
+    // RootDir/Prefix ⇒ no relative path exists.
+    let is_root = |c: &Component| matches!(c, Component::Prefix(_) | Component::RootDir);
+    let base_root: Vec<&Component> = base_comps.iter().take_while(|c| is_root(c)).collect();
+    let target_root: Vec<&Component> = target_comps.iter().take_while(|c| is_root(c)).collect();
+    if base_root != target_root {
+        return None;
+    }
+
+    let common = base_comps
+        .iter()
+        .zip(&target_comps)
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let mut rel = PathBuf::new();
+    for _ in common..base_comps.len() {
+        rel.push("..");
+    }
+    for comp in &target_comps[common..] {
+        rel.push(comp.as_os_str());
+    }
+    Some(rel)
+}
+
+/// Percent-encode a path for use as the first arg of `new URL(<literal>, base)`.
+/// Encodes, per BYTE of the UTF-8 encoding: the URL-hazard ASCII chars (space,
+/// `?`, `#`, `%`) AND every NON-ASCII byte. The non-ASCII case is load-bearing:
+/// `é` is `0xC3 0xA9` in UTF-8, so emitting it raw (or worse, byte-as-`char`,
+/// which yields latin-1 mojibake `Ã©`) produces a literal that `new URL` decodes
+/// to the wrong path. Percent-encoding the UTF-8 bytes round-trips: `new URL`
+/// re-decodes `%C3%A9` back to `é`, and `fileURLToPath` recovers the real file.
+/// Path separators (`/`) and unreserved ASCII (`.`, `-`, `_`, alnum) pass through.
+fn encode_url_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for b in path.bytes() {
+        match b {
+            b'/' => out.push('/'),
+            // Unreserved ASCII (RFC 3986) + the path-safe `.`/`-`/`_`/`~` — verbatim.
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'-' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            // Everything else — URL-hazard ASCII (space/`?`/`#`/`%`/…) AND every
+            // non-ASCII UTF-8 byte — is percent-encoded.
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_bare_vs_relative_vs_absolute() {
+        assert!(is_bare_specifier("pkg"));
+        assert!(is_bare_specifier("@scope/pkg/worker"));
+        assert!(!is_bare_specifier("./w.ts"));
+        assert!(!is_bare_specifier("../lib/w"));
+        assert!(!is_bare_specifier("/abs/w.js"));
+        assert!(!is_bare_specifier("file:///w.js"));
+        assert!(!is_bare_specifier("data:text/javascript,0"));
+        assert!(!is_bare_specifier("#internal/w"));
+    }
+
+    #[test]
+    fn drive_letter_is_not_a_scheme() {
+        // A Windows drive prefix is absolute, never bare; `C:` must not parse as a
+        // URL scheme (which would mis-route it through `import.meta.resolve`).
+        assert!(!has_url_scheme("C:\\proj\\w.ts"));
+        assert!(has_url_scheme("file:///x"));
+        assert!(has_url_scheme("data:text/js,0"));
+    }
+
+    #[test]
+    fn relativizes_to_posix_dot_prefixed() {
+        assert_eq!(
+            relativize_for_url("/proj/src", "/proj/src/w.ts").unwrap(),
+            "./w.ts"
+        );
+        assert_eq!(
+            relativize_for_url("/proj/src", "/proj/lib/w.ts").unwrap(),
+            "../lib/w.ts"
+        );
+    }
+
+    #[test]
+    fn percent_encodes_spaces() {
+        assert_eq!(
+            relativize_for_url("/proj/src", "/proj/src/my worker.ts").unwrap(),
+            "./my%20worker.ts"
+        );
+    }
+
+    #[test]
+    fn percent_encodes_non_ascii_utf8_bytes() {
+        // `é` is 0xC3 0xA9 in UTF-8 — it MUST become `%C3%A9`, never the latin-1
+        // mojibake `Ã©` a byte-as-char cast produces. `new URL` re-decodes
+        // `%C3%A9` → `é`, so the resolved file path round-trips.
+        assert_eq!(
+            relativize_for_url("/proj/src", "/proj/src/café.ts").unwrap(),
+            "./caf%C3%A9.ts"
+        );
+        // A non-Latin script (CJK) round-trips the same way.
+        assert_eq!(
+            relativize_for_url("/proj/src", "/proj/src/worker-日本.ts").unwrap(),
+            "./worker-%E6%97%A5%E6%9C%AC.ts"
+        );
+    }
+
+    #[test]
+    fn percent_encodes_url_hazard_ascii() {
+        // `?`/`#` would otherwise be parsed by `new URL` as query/fragment; `%` is
+        // the escape char itself; a `"` is encoded too (defense in depth — oxc also
+        // escapes it in the JS string literal).
+        assert_eq!(
+            relativize_for_url("/proj/src", "/proj/src/a?b#c.ts").unwrap(),
+            "./a%3Fb%23c.ts"
+        );
+    }
+
+    #[test]
+    fn same_path_is_none() {
+        // `target == dir` ⇒ empty relative ⇒ None ⇒ caller leaves the node alone.
+        assert!(relativize_for_url("/proj/src", "/proj/src").is_none());
+    }
+
+    #[test]
+    fn output_is_never_absolute() {
+        // The portability moat: every Some result is a `./`/`../`-prefixed relative
+        // URL — never an absolute path baked in from the build machine.
+        for (dir, target) in [
+            ("/proj/src", "/proj/src/w.ts"),
+            ("/proj/a/b/c", "/proj/x/y/deep.ts"),
+            ("/proj/src/feature", "/proj/lib/w.ts"),
+        ] {
+            let r = relativize_for_url(dir, target).unwrap();
+            assert!(
+                (r.starts_with("./") || r.starts_with("../")) && !r.starts_with('/'),
+                "{r} for ({dir}, {target}) must be a relative URL, never absolute"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cross_drive_is_none() {
+        // Different Windows drives share no root ⇒ no relative path ⇒ the rewrite
+        // must NOT fire (would otherwise be forced to bake an absolute path).
+        assert!(relativize_for_url("C:\\a\\b", "D:\\a\\b\\w.ts").is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_separators_become_posix() {
+        let r = relativize_for_url("C:\\proj\\src", "C:\\proj\\src\\w.ts").unwrap();
+        assert_eq!(r, "./w.ts");
+    }
+}

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -670,7 +670,23 @@ export function maybeTranspilePlainJs(url, ext) {
   }
   // lang "ts" parses all JS (a TS superset) but NOT JSX — JSX-in-.js is out of scope.
   const info = detectModuleInfo(filePath, source, "ts");
-  if (!info.transformableSyntax && !info.hasDecorators) {
+  // The Worker rewrite emits `import.meta.url`, valid ONLY in an ES module — so the
+  // worker trigger fires ONLY for an ESM file. Without this gate a CJS plain-JS file
+  // (.cjs, or a .js/.mjs that detects as commonjs) carrying a worker string would be
+  // routed through oxc, which reformats it (quotes/whitespace) while the ESM-gated
+  // rewrite does nothing — breaking the byte-parity no-op invariant for CJS. Compute
+  // the format the same way loadTranspile will (nearest package.json `type`, else
+  // source detection); only an ESM verdict admits the worker trigger.
+  const pkgType = ext === ".mts" || ext === ".cts" ? undefined : getPackageType(dirname(filePath));
+  const isEsm = moduleFormatFor(ext, pkgType, filePath, source) === "module";
+  const workerTrigger = info.hasGlobalWorkerStringCall && isEsm;
+  // Trigger transpilation when the file needs lowering (using/v-flag/decorators) OR
+  // carries an ESM `new <free/global Worker>(<string-literal>)` the rewrite must act
+  // on — so a raw `new Worker("./w.js")` resolves caller-relative from a .js/.mjs/.cjs
+  // ES module, UNIFORMLY with .ts callers. The worker flag is semantic-scoped (a
+  // bound/shadowed Worker does NOT set it) and ESM-gated, so a no-eligible-worker /
+  // CJS / no-lowerable file stays byte-identical.
+  if (!info.transformableSyntax && !info.hasDecorators && !workerTrigger) {
     return null; // no-op: Node's native loader handles it, byte-identical.
   }
   // Transformable: run the SAME pipeline as TS/JSX (target es2022 lowering, tsconfig,

--- a/site/content/docs/runtime/workers.mdx
+++ b/site/content/docs/runtime/workers.mdx
@@ -24,7 +24,7 @@ self.onmessage = (ev) => {
 };
 ```
 
-The worker entry is TypeScript here for free — Nub transpiles it like any other entry. The constructor takes a string or `URL`; pass `new URL("./worker.ts", import.meta.url)` for a path resolved relative to the current module, exactly as in the browser.
+The worker entry is TypeScript here for free — Nub transpiles it like any other entry. The constructor takes a string or `URL`; `new URL("./worker.ts", import.meta.url)` is the canonical form, and a plain relative string resolves against the current module too — see [Constructor inputs](#constructor-inputs).
 
 ## Mechanism
 
@@ -47,9 +47,14 @@ Node's worker global is not an `EventTarget` and exposes none of these, so the p
 
 `new Worker(scriptURL, options?)` accepts the WHATWG inputs:
 
-- **A file path or `URL`** (including `file://`) — spawned and transpiled like any nub entry.
+- **A `URL`** — pass `new URL("./worker.ts", import.meta.url)` to resolve a path relative to the current module, exactly as in the browser. This is the canonical form: it is explicit, portable without a build step, and the shape every bundler (Vite, esbuild, webpack, Rollup) traces to chunk the worker.
+- **A relative string** — `new Worker("./worker.ts")` resolves with Nub's full module resolution against the calling module, the same way a top-level `import "./worker.ts"` would: relative paths, extension probing (`./worker` → `./worker.ts`), and tsconfig `paths` aliases all work. Nub resolves it at compile time and rewrites it to the `new URL(..., import.meta.url)` form for you, so it resolves against the module — never `process.cwd()`, the `node:worker_threads` quirk. This is uniform across module languages — a `.ts`, `.tsx`, `.js`, `.mjs`, or `.cjs` ES module behaves the same. (A worker constructed in a CommonJS module is left as-is, since `import.meta` is ES-module-only; use the `URL` form with `pathToFileURL(__filename)` there.)
 - **A `data:` URL** — run directly.
 - **A `blob:` URL** from `URL.createObjectURL(blob)` — the WHATWG inline-worker mechanism. Nub snapshots the Blob's source synchronously at `createObjectURL` time and spawns it.
+
+An absolute path, a `file://` / `data:` / `blob:` URL string, a `URL` instance, and any non-literal (computed) specifier pass through unchanged — only a relative or bare string literal is resolved. For a computed path, wrap it yourself: `new Worker(new URL(path, import.meta.url))`.
+
+A **bare package** string — `new Worker("some-pkg/worker")` — resolves through Node's own resolver via `import.meta.resolve`, honoring the package's `exports` under the default (`node`) conditions; there is no special `"worker"` condition, so it resolves like a top-level `import` of the same name. Unlike the relative `new URL(...)` form, a bare-package worker is **not statically analyzable by bundlers** (the same way a dynamic `import.meta.resolve` isn't) — prefer the `new URL` form on a build pipeline.
 
 `options` accepts `type` (`"module"` | `"classic"`), `name`, `execArgv`, and `env`. There is no inline source-string form (the spec has none either — use a `blob:` or `data:` URL).
 

--- a/tests/fixtures/worker-string-byte-parity/plain.mjs
+++ b/tests/fixtures/worker-string-byte-parity/plain.mjs
@@ -1,0 +1,8 @@
+// A no-worker plain .mjs. If nub transpiled it, oxc codegen would normalize the
+// single quotes to double, drop the trailing comma, and add a sourcemap footer.
+// We read OUR OWN on-disk source — which is always the raw file — but the real
+// proof is behavioral: this file must run on Node's NATIVE path (nub returns null
+// from maybeTranspilePlainJs), so it executes verbatim. The marker confirms it ran.
+const   obj = { a:1, b:2, };
+const s = 'hi'
+console.log('byte-parity:' + obj.a + obj.b + s)

--- a/tests/fixtures/worker-string-js-esm/main.js
+++ b/tests/fixtures/worker-string-js-esm/main.js
@@ -1,0 +1,4 @@
+// A `.js` in a type:module package is ESM but not transpiled by default — the
+// worker trigger routes it through the transform so the rewrite fires.
+const w = new Worker("./worker.js");
+w.onmessage = (e) => { console.log("main-got:" + e.data); w.terminate(); };

--- a/tests/fixtures/worker-string-js-esm/package.json
+++ b/tests/fixtures/worker-string-js-esm/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests/fixtures/worker-string-js-esm/worker.js
+++ b/tests/fixtures/worker-string-js-esm/worker.js
@@ -1,0 +1,1 @@
+self.postMessage("dotjs-esm:ready");

--- a/tests/fixtures/worker-string-nm/main.mjs
+++ b/tests/fixtures/worker-string-nm/main.mjs
@@ -1,0 +1,4 @@
+import { makeWorker } from "dep";
+const w = makeWorker();
+w.onmessage = (e) => { console.log("UNEXPECTED-dep-resolved:" + e.data); w.terminate(); };
+w.onerror = () => { console.log("dep-worker-cwd-relative-as-expected"); process.exit(0); };

--- a/tests/fixtures/worker-string-nm/node_modules/dep/index.js
+++ b/tests/fixtures/worker-string-nm/node_modules/dep/index.js
@@ -1,0 +1,4 @@
+// A dep's worker string is in node_modules → nub must NOT transpile/rewrite it
+// (the byte-parity boundary). Left raw, it resolves cwd-relative, so from a
+// foreign cwd it errors — which proves nub left it alone.
+export function makeWorker() { return new Worker("./inner.js"); }

--- a/tests/fixtures/worker-string-nm/node_modules/dep/inner.js
+++ b/tests/fixtures/worker-string-nm/node_modules/dep/inner.js
@@ -1,0 +1,1 @@
+self.postMessage("inner");

--- a/tests/fixtures/worker-string-nm/node_modules/dep/package.json
+++ b/tests/fixtures/worker-string-nm/node_modules/dep/package.json
@@ -1,0 +1,1 @@
+{"name":"dep","type":"module","exports":"./index.js"}

--- a/tests/fixtures/worker-string-nm/package.json
+++ b/tests/fixtures/worker-string-nm/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests/fixtures/worker-string-paths/src/main.ts
+++ b/tests/fixtures/worker-string-paths/src/main.ts
@@ -1,0 +1,8 @@
+// A tsconfig `paths` alias resolves like a top-level import + is erased to a
+// portable relative URL in the emit (no tsconfig needed at runtime).
+const w = new Worker("@workers/w");
+w.onmessage = (e: MessageEvent) => {
+  console.log("main-got:" + e.data);
+  (w as { terminate(): void }).terminate();
+};
+export {};

--- a/tests/fixtures/worker-string-paths/src/workers/w.ts
+++ b/tests/fixtures/worker-string-paths/src/workers/w.ts
@@ -1,0 +1,2 @@
+enum Status { Ready = "ready" }
+self.postMessage("paths-worker:" + Status.Ready);

--- a/tests/fixtures/worker-string-paths/tsconfig.json
+++ b/tests/fixtures/worker-string-paths/tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "baseUrl": ".", "paths": { "@workers/*": ["src/workers/*"] } } }

--- a/tests/fixtures/worker-string/café.ts
+++ b/tests/fixtures/worker-string/café.ts
@@ -1,0 +1,2 @@
+enum S { Ready = "ready" }
+self.postMessage("unicode-worker:" + S.Ready);

--- a/tests/fixtures/worker-string/cjs-main.cjs
+++ b/tests/fixtures/worker-string/cjs-main.cjs
@@ -1,0 +1,8 @@
+// CommonJS caller. The Worker rewrite is ESM-only (import.meta), so nub must NOT
+// transpile/rewrite this — it runs on Node's native CJS path, byte-identical, and
+// the worker string keeps worker_threads' cwd-relative behavior. Distinctive
+// formatting (single quotes, trailing comma) would be normalized if nub wrongly
+// codegen'd it.
+const w = new Worker('./cjs-worker.js');
+const o = { a: 1, };
+w.onmessage = (e) => { console.log('cjs-got:' + e.data + ':' + o.a); w.terminate(); };

--- a/tests/fixtures/worker-string/cjs-worker.js
+++ b/tests/fixtures/worker-string/cjs-worker.js
@@ -1,0 +1,1 @@
+self.postMessage("cjs-native:ok");

--- a/tests/fixtures/worker-string/compat-main.mjs
+++ b/tests/fixtures/worker-string/compat-main.mjs
@@ -1,0 +1,6 @@
+// Plain JS (no TS syntax) so it parses under --node on EVERY Node tier — the floor
+// tiers don't strip types, and --node disables nub's transpiler. With augmentation
+// off there is no Worker global, so this throws `Worker is not defined` (not a
+// SyntaxError), isolating the no-rewrite/no-augmentation signal.
+const w = new Worker("./worker.js");
+w.onmessage = (e) => { console.log("main-got:" + e.data); w.terminate(); };

--- a/tests/fixtures/worker-string/extensionless-main.ts
+++ b/tests/fixtures/worker-string/extensionless-main.ts
@@ -1,0 +1,6 @@
+const w = new Worker("./worker"); // no extension — nub probes to ./worker.ts
+w.onmessage = (e: MessageEvent) => {
+  console.log("main-got:" + e.data);
+  (w as { terminate(): void }).terminate();
+};
+export {};

--- a/tests/fixtures/worker-string/js-worker.js
+++ b/tests/fixtures/worker-string/js-worker.js
@@ -1,0 +1,1 @@
+self.postMessage("mjs-worker:ready");

--- a/tests/fixtures/worker-string/main.ts
+++ b/tests/fixtures/worker-string/main.ts
@@ -1,0 +1,13 @@
+// A BARE relative string (no `new URL`) must resolve against THIS module — like a
+// top-level import — not process.cwd(). Run from a foreign cwd, this reaches the
+// sibling worker.ts only because nub rewrote the specifier caller-relative.
+const w = new Worker("./worker.ts");
+w.onmessage = (e: MessageEvent) => {
+  console.log("main-got:" + e.data);
+  (w as { terminate(): void }).terminate();
+};
+w.onerror = (e: { message: string }) => {
+  console.log("worker-error:" + e.message);
+  process.exit(1);
+};
+export {};

--- a/tests/fixtures/worker-string/mjs-main.mjs
+++ b/tests/fixtures/worker-string/mjs-main.mjs
@@ -1,0 +1,4 @@
+// A plain .mjs caller — nub does not transpile it by default, but a bare worker
+// string triggers the transform so the rewrite fires, uniformly with .ts callers.
+const w = new Worker("./js-worker.js");
+w.onmessage = (e) => { console.log("main-got:" + e.data); w.terminate(); };

--- a/tests/fixtures/worker-string/unicode-main.ts
+++ b/tests/fixtures/worker-string/unicode-main.ts
@@ -1,0 +1,8 @@
+// A non-ASCII worker filename must percent-encode its UTF-8 bytes in the emitted
+// URL (café → caf%C3%A9) and round-trip back through new URL → fileURLToPath.
+const w = new Worker("./café.ts");
+w.onmessage = (e: MessageEvent) => {
+  console.log("main-got:" + e.data);
+  (w as { terminate(): void }).terminate();
+};
+export {};

--- a/tests/fixtures/worker-string/worker.ts
+++ b/tests/fixtures/worker-string/worker.ts
@@ -1,0 +1,4 @@
+// Worker entry in TS — the `enum` is non-erasable, so it only runs if the worker
+// thread's transpile hook is active (proves the resolved sibling actually ran).
+enum Status { Ready = "ready" }
+self.postMessage("worker-string:" + Status.Ready);

--- a/tests/fixtures/worker-string/wt-main.ts
+++ b/tests/fixtures/worker-string/wt-main.ts
@@ -1,0 +1,14 @@
+// `Worker` is BOUND to node:worker_threads here → must NOT be rewritten. A bound
+// reference has a symbol_id, so the scope guard skips it. We pass a RELATIVE path
+// (not absolute, which would be passthrough either way) to genuinely exercise the
+// guard: worker_threads resolves it against cwd, so running this from the fixture
+// dir finds ./wt-worker.cjs. If nub had wrongly rewritten the bound Worker to the
+// caller-relative `new URL(...)` form, the spawn target would differ — this proves
+// it left the worker_threads binding alone.
+import { Worker } from "node:worker_threads";
+const w = new Worker("./wt-worker.cjs");
+w.on("message", (m: string) => {
+  console.log("main-got:" + m);
+  w.terminate();
+});
+export {};

--- a/tests/fixtures/worker-string/wt-worker.cjs
+++ b/tests/fixtures/worker-string/wt-worker.cjs
@@ -1,0 +1,2 @@
+const { parentPort } = require("node:worker_threads");
+parentPort.postMessage("wt-ran");


### PR DESCRIPTION
## What

A raw string in `new Worker("./worker.ts")` resolves with nub's full module resolution against the calling module — like a top-level import — instead of `node:worker_threads`' cwd-relative behavior. Running a script from a different directory than the one that constructs the worker no longer breaks.

This is **uniform across module languages**: a `.ts`/`.tsx`/`.mts`/`.cts`/`.jsx` caller and a plain `.js`/`.mjs`/`.cjs` ES module all behave the same.

## How

A net-new oxc `VisitMut` pass (run from the transform seam, which holds both the allocator and the post-transform scoping) rewrites the first argument of a `new Worker(<string-literal>)` when the callee is the **free/global** `Worker`:

- **nub-owned** (relative / extensionless / tsconfig `paths`) → re-relativized `new Worker(new URL("<rel>", import.meta.url))` — the canonical, bundler-analyzable form;
- **bare package** → `new Worker(import.meta.resolve("<bare>"))` — Node's own resolver owns node_modules / `exports`.

### Uniform across `.ts` and plain JS

`.ts`/`.jsx`/… callers are already transpiled, so the pass runs there directly. A plain `.js`/`.mjs`/`.cjs` ES module is **not** transpiled by default (the #152 byte-parity no-op invariant), so it's routed through the transform by an added trigger in `maybeTranspilePlainJs`: a precise, semantic-scoped `has_global_worker_string_call` detection. A single `resolve_worker_target` resolves a relative specifier for any caller extension, so a `.js` caller resolves identically to a `.ts` caller.

The byte-parity no-op invariant is preserved:

- a bound or shadowed `Worker`, a non-string-literal arg, or no worker at all → does **not** trigger, so the file stays byte-identical;
- a **CommonJS** caller is left as-is — the rewrite emits `import.meta.url`, which is ES-module-only — and is **not** transpiled, so a CJS file with a worker string stays byte-identical (no needless codegen);
- **node_modules** is never transpiled/rewritten (the byte-parity boundary).

### Guards

- **Scope guard** (`symbol_id().is_none()`): only the global `Worker` is rewritten — an `import { Worker } from "node:worker_threads"` or a shadowed local is left untouched.
- **Never bake an absolute path**: a target that can't be relativized (cross-root) is left untouched. Non-ASCII paths percent-encode their UTF-8 bytes and round-trip through `new URL` → `fileURLToPath`.
- **Passthrough** (byte-identical): absolute paths, `file:` / `data:` / `blob:` URL strings, a `new URL(...)` arg, a `URL` instance, any computed/dynamic arg.

`--node` / `NODE_COMPAT=1` disable augmentation entirely, so the bare string behaves like plain Node.

The portability-critical path helpers live in a napi-free `nub-worker-resolve` crate, unit-testable on every platform (Windows separators/drives the Linux e2e can't reach).

## Tests

Worker-string cases for `.ts`/`.tsx`, `.mjs`, `.js`-as-ESM, and `.cjs` callers; the scope guard; tsconfig-paths; non-ASCII round-trip; the byte-parity no-op invariant (a no-worker `.mjs` and a CJS worker file both stay native); node_modules exclusion. Green on the fast (22.15) and compat (18.19) tiers + Node 26.

## Caveat

A bare-package worker (`new Worker("pkg/worker")`) resolves via `import.meta.resolve`, which is **not statically analyzable by bundlers** — the same way a dynamic `import.meta.resolve` isn't. This is the price of node_modules/`exports` parity; the common relative / `new URL` cases stay fully static.

This is a runtime-behavior change to a shipped API (the bare-string Worker resolved cwd-relative before; it's now caller-relative). Flagging it for the maintainer.

Refs the `worker-relative-specifier-resolution` design thread.

https://claude.ai/code/session_012YwF7yWjrXcj3bVJ1TziHK