### PR TITLE
chore(worktree): default worktrees to ~/.cache/nub/worktrees (off /tmp)

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -33,18 +33,18 @@ node scripts/new-worktree.ts <slug>
 It performs the proven recipe, in order:
 
 1. `git fetch origin` (skip with `--no-fetch`).
-2. `git worktree add /tmp/nub-wt-<slug> -b <slug> origin/main` — tracked files only; the shared tree is untouched. vendor/aube is plain in-tree files (Pattern B) — checked out by this step, no submodule init needed.
+2. `git worktree add ~/.cache/nub/worktrees/<slug> -b <slug> origin/main` — tracked files only; the shared tree is untouched. vendor/aube is plain in-tree files (Pattern B) — checked out by this step, no submodule init needed. The script creates `~/.cache/nub/worktrees/` if it doesn't exist. (Non-temp location: not auto-swept like `/tmp`; out of the repo dir; same volume as the repo so APFS clonefile stays fast.)
 3. Apply `.worktreeinclude` — copy/symlink the listed gitignored entries in (see below).
 4. Print the stable per-worktree `CARGO_TARGET_DIR` convention to export.
 
-Options: `--base <ref>` (default `origin/main`), `--path <dir>` (default `/tmp/nub-wt-<slug>`), `--no-fetch`, `--help`.
+Options: `--base <ref>` (default `origin/main`), `--path <dir>` (default `~/.cache/nub/worktrees/<slug>`), `--no-fetch`, `--help`.
 
 After it prints the ready line:
 
 ```bash
-cd /tmp/nub-wt-<slug>
-export CARGO_TARGET_DIR=/tmp/nub-wt-<slug>-target   # keep this stable for the whole session
-cargo build -p nub-cli --profile fast               # ~3 min cold, ~5s incremental
+cd ~/.cache/nub/worktrees/<slug>
+export CARGO_TARGET_DIR=~/.cache/nub/worktrees/<slug>-target   # keep this stable for the whole session
+cargo build -p nub-cli --profile fast                          # ~3 min cold, ~5s incremental
 ```
 
 The build loop, profiles, and crate map live in the `dev-loop` skill (`.claude/skills/dev-loop/SKILL.md`). The one rule that makes iteration fast: keep ONE stable target dir per worktree for the whole session — cargo's incremental fingerprints are keyed to the absolute target path, so cleaning, moving, or re-seeding it forces a full cold rebuild. The script never seeds a target dir for exactly this reason; it just prints the dir to export.
@@ -76,7 +76,7 @@ Corollary: do NOT commit directly in the shared tree's checkout — even control
 ## Clean up after a merge
 
 ```bash
-git worktree remove /tmp/nub-wt-<slug> --force && rm -rf /tmp/nub-wt-<slug>-target
+git worktree remove ~/.cache/nub/worktrees/<slug> --force && rm -rf ~/.cache/nub/worktrees/<slug>-target
 ```
 
 `--force` is used to discard the worktree even with build artifacts present. Before discarding, make sure your work is pushed — a `git worktree remove --force` throws away anything uncommitted (vendor/aube edits are now plain in-tree files committed to the worktree's branch, so push before removing).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,10 +49,10 @@ These are the load-bearing, always-true architectural premises of nub. They are 
 #    source (NOT target/ .repos/ node_modules) and shares the .git object store — no re-clone, no
 #    re-fetch. The shared main tree is UNTOUCHED and stays on main. vendor/aube is now plain
 #    in-tree files (NOT a submodule) — they come along with the checkout, no init step needed.
-git worktree add /tmp/nub-wt-<slug> -b <branch-slug> origin/main
+git worktree add ~/.cache/nub/worktrees/<slug> -b <branch-slug> origin/main
 
 # 2. Give the worktree its OWN target dir so a sibling's build can't contaminate it.
-cd /tmp/nub-wt-<slug> && export CARGO_TARGET_DIR=/tmp/nub-wt-<slug>-target
+cd ~/.cache/nub/worktrees/<slug> && export CARGO_TARGET_DIR=~/.cache/nub/worktrees/<slug>-target
 cargo check -p nub-cli                       # or the scoped test for what changed
 
 # 4. Commit your work, push the branch, open the PR — then REPORT the URL. Do NOT merge your own PR.
@@ -61,7 +61,7 @@ git push -u origin <branch-slug>
 gh pr create --title "<title>" --body "<body>"   # report the returned URL to the orchestrator
 
 # 5. After the orchestrator merges, clean up (orchestrator or agent):
-git worktree remove /tmp/nub-wt-<slug> --force && rm -rf /tmp/nub-wt-<slug>-target
+git worktree remove ~/.cache/nub/worktrees/<slug> --force && rm -rf ~/.cache/nub/worktrees/<slug>-target
 
 # 6. Eagerly pull the SHARED tree so it tracks origin (see the eagerly-pull rule below).
 git -C <shared-tree> pull --ff-only
@@ -85,7 +85,7 @@ A busy `main` with several open PRs and in-progress worktrees is expected and fi
 
 Full runbook + crate map: the `dev-loop` skill (`.claude/skills/dev-loop/SKILL.md`). The essentials, so a worktree iterates fast (measured 2026-06-20):
 
-- **Set up the worktree, give it its OWN target dir** (per the proven workflow above): `git worktree add … -b <slug> origin/main`, then `export CARGO_TARGET_DIR=/tmp/<slug>-target`. vendor/aube is plain in-tree files now — no submodule init step. The per-worktree target dir is what keeps a sibling's build from contaminating yours — keep it.
+- **Set up the worktree, give it its OWN target dir** (per the proven workflow above): `git worktree add … -b <slug> origin/main`, then `export CARGO_TARGET_DIR=~/.cache/nub/worktrees/<slug>-target`. vendor/aube is plain in-tree files now — no submodule init step. The per-worktree target dir is what keeps a sibling's build from contaminating yours — keep it.
 - **Iterate with the `fast` profile, NEVER `release`.** `cargo build -p nub-cli --profile fast` builds the dev CLI to `target/fast/nub`. Cold ≈ 3 min; every subsequent rebuild in the same target dir ≈ 5s via cargo's native incremental. The `release` profile's `lto=thin` + `codegen-units=1` makes a cold build ≈ 15 min and re-LTOs the whole binary on every change — do not use it to iterate. For the full dev binary + N-API addon on PATH, `make install-dev` (symlinks `nub-dev`/`nubx-dev` → `target/fast/nub`); for the addon alone, `make addon-fast`. There is no `nub build` command.
 - **Pay the cold build ONCE per worktree, then keep the target dir stable.** Do NOT clean, move, re-clone, or seed the target dir between iterations — cargo's incremental fingerprints are keyed to the absolute target path, so any of those forces a full ~3-min rebuild. The fast path is one stable target dir per worktree for the whole session.
 - **A shared cross-worktree compile cache does NOT help here.** sccache was measured against this Rust workspace and delivered a 0% Rust cache-hit rate across worktrees (rustc embeds per-target-dir paths in its cache keys; `--remap-path-prefix` does not fix it) — no speedup over a cold build. Do not reach for it; the `fast` profile + a stable per-worktree target dir is the whole answer.

--- a/scripts/new-worktree.ts
+++ b/scripts/new-worktree.ts
@@ -26,6 +26,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, mkdirSync, cpSync, symlinkSync, lstatSync } from "node:fs";
 import { dirname, join, resolve, isAbsolute } from "node:path";
+import { homedir } from "node:os";
 
 const HELP = `new-worktree — create an isolated git worktree off origin/main
 
@@ -35,11 +36,11 @@ Usage:
 
 Arguments:
   <slug>              Branch name and default path suffix (worktree lands at
-                     /tmp/nub-wt-<slug>, branch <slug>).
+                     ~/.cache/nub/worktrees/<slug>, branch <slug>).
 
 Options:
   --base <ref>       Base ref for the new branch (default: origin/main).
-  --path <dir>       Explicit worktree path (default: /tmp/nub-wt-<slug>).
+  --path <dir>       Explicit worktree path (default: ~/.cache/nub/worktrees/<slug>).
   --no-fetch         Skip the initial \`git fetch origin\`.
   -h, --help         Show this help.
 
@@ -105,7 +106,7 @@ function parseArgs(argv: string[]): Opts {
   return {
     slug,
     base,
-    path: path ?? `/tmp/nub-wt-${slug}`,
+    path: path ?? `${homedir()}/.cache/nub/worktrees/${slug}`,
     fetch,
   };
 }
@@ -189,6 +190,9 @@ function main(): void {
   const mainRoot = mainWorktree(repoRoot);
 
   if (existsSync(opts.path)) die(`worktree path already exists: ${opts.path}`);
+
+  // Ensure the parent directory exists (e.g. ~/.cache/nub/worktrees/ on first run).
+  mkdirSync(dirname(opts.path), { recursive: true });
 
   if (opts.fetch) {
     const remoteRef = opts.base.includes("/") ? opts.base.split("/")[0] : "origin";


### PR DESCRIPTION
`/tmp` on macOS sweeps idle files after 3 days; a paused worktree can silently vanish. `~/.cache/nub/worktrees/` is never auto-swept, out of the repo dir, and on the same volume (APFS clonefile stays fast).

- `scripts/new-worktree.ts`: `os.homedir()` default, `mkdir -p` parent, updated help text.
- `.claude/skills/worktree/SKILL.md`: all path examples and cleanup commands.
- `AGENTS.md`: worktree-flow recipe + dev-loop line.

Verified: creates at `~/.cache/nub/worktrees/<slug>`, correct CARGO_TARGET_DIR, `.worktreeinclude` applied. `node --check` clean.

https://claude.ai/code/session_012YwF7yWjrXcj3bVJ1TziHK