### PR TITLE
feat(runtime): transpile project-source plain JS (.js/.mjs/.cjs)

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -296,6 +296,161 @@ fn legacy_decorators_require_experimental_flag() {
     );
 }
 
+// ── Project-source plain JS (.js/.mjs/.cjs) transpile ───────────────
+// nub transpiles PROJECT plain JS through the same pipeline as `.ts`, so
+// transformable syntax (`using`/`await using`, `v`-flag RegExp, decorators) lowers
+// uniformly — identical source must not behave differently by extension. A native
+// `transformableSyntax` verdict (riding the existing detect parse) gates a verbatim
+// skip-return for no-op JS so byte-parity is preserved; node_modules is excluded at
+// every dispatch site. See wiki/runtime/typescript.md + the transpile-project-js
+// design thread.
+
+#[test]
+fn project_js_using_down_levels() {
+    // `using` is a SyntaxError on every supported Node's V8; this project `.js`
+    // must be down-leveled (the transformableSyntax verdict flags it) and run, just
+    // as the `.ts` equivalent does. On the compat tier below require(esm) the
+    // transpiled output's helper require can't be served (the SAME documented
+    // limitation as legacy_decorators_require_experimental_flag) — skip-with-reason
+    // there, assert the behavior where it's supported.
+    if !node_has_require_esm() {
+        eprintln!(
+            "SKIP project_js_using_down_levels on Node {:?}: CJS-entry helper require \
+             is unsupported below require(esm) (documented v0.x limitation)",
+            target_node_version()
+        );
+        return;
+    }
+    let (stdout, stderr, code) = run_nub("project-js", "using.js");
+    assert_eq!(
+        code, 0,
+        "project .js using should down-level + run: {stderr}"
+    );
+    assert!(stdout.contains("open:a,b"), "using block ran: {stdout}");
+    assert!(stdout.contains("using:done"), "completed: {stdout}");
+}
+
+#[test]
+fn project_js_v_flag_regexp_lowers() {
+    // The trigger the design's original verdict MISSED: a `v`-flag (unicode-sets,
+    // ES2024) RegExp literal. Raw `/…/v` is a PARSE error on the compat-tier floor
+    // (Node 18.19), killing the whole module; oxc lowers it to `new RegExp(…)` at
+    // es2022 so the module parses everywhere. The `v` flag itself is honored by V8
+    // on Node 20+, so the regex evaluates there; on 18.x V8 rejects the `v` flag
+    // even via the constructor (an inherent V8 floor limitation oxc can't polyfill),
+    // but the module still PARSES — which is the load-bearing win this trigger buys.
+    let (stdout, stderr, code) = run_nub("project-js", "vflag-regexp.js");
+    if node_at_least((20, 0, 0)) {
+        assert_eq!(
+            code, 0,
+            "v-flag regexp should lower + run on Node 20+: {stderr}"
+        );
+        assert!(
+            stdout.contains("vflag:true"),
+            "v-flag regex matched: {stdout}"
+        );
+    } else {
+        // Below 20: the lowering still makes the file PARSE (the win vs the raw
+        // literal's parse error), but V8 rejects the `v` flag at RegExp construction.
+        assert_ne!(
+            code, 0,
+            "v flag is unsupported in V8 below Node 20: {stderr}"
+        );
+        assert!(
+            stderr.contains("Invalid flags") || stderr.contains("RegExp"),
+            "should be a runtime RegExp error (parsed, not a parse error): {stderr}"
+        );
+    }
+}
+
+#[test]
+fn project_js_noop_is_byte_identical() {
+    // The load-bearing byte-parity guard: a project `.js` with NOTHING oxc lowers
+    // must be served VERBATIM — no quote/semicolon/whitespace normalization, no
+    // sourcemap footer. `f.toString()` exposes the loaded function's source; if nub
+    // had run it through codegen, the single quotes would become double and
+    // semicolons would be inserted. Asserting the raw form proves the skip-gate.
+    let (stdout, stderr, code) = run_nub("project-js", "noop.js");
+    assert_eq!(code, 0, "no-op .js should run: {stderr}");
+    // The verbatim function body: single quotes, no inserted semicolons, the
+    // trailing comma and original 2-space indentation all intact.
+    assert!(
+        stdout.contains(r#"const x = 'single'"#),
+        "single quotes must survive (not normalized to double): {stdout}"
+    );
+    assert!(
+        stdout.contains(r#"const obj = { a: 1, b: 2, }"#),
+        "object literal must not be reflowed; trailing comma preserved: {stdout}"
+    );
+    assert!(
+        !stdout.contains(r#"const x = "single";"#),
+        "must NOT show oxc's reformatted (double-quoted, semicolon'd) emit: {stdout}"
+    );
+}
+
+#[test]
+fn project_js_mjs_is_module_cjs_is_commonjs() {
+    // `.mjs` → module, `.cjs` → commonjs, regardless of package `type` — the format
+    // branches added to moduleFormatFor. A wrong format = invalid-ESM/CJS mismatch,
+    // so these fail to run if the branches are missing. Both are no-op (verbatim)
+    // files, so this also confirms the verbatim path resolves the right format.
+    let (out_mjs, err_mjs, code_mjs) = run_nub("project-js", "esm-format.mjs");
+    assert_eq!(code_mjs, 0, ".mjs should run as ESM: {err_mjs}");
+    assert!(
+        out_mjs.contains("MJS:true"),
+        "import.meta under module format: {out_mjs}"
+    );
+
+    let (out_cjs, err_cjs, code_cjs) = run_nub("project-js", "cjs-format.cjs");
+    assert_eq!(code_cjs, 0, ".cjs should run as CommonJS: {err_cjs}");
+    assert!(
+        out_cjs.contains("CJS:true"),
+        "module.exports under commonjs format: {out_cjs}"
+    );
+}
+
+#[test]
+fn node_modules_js_is_never_transpiled() {
+    // The make-or-break gate: dependency `.js` (a plain node_modules dep AND a pnpm
+    // `.pnpm`-virtual-store dep) must load RAW on every tier — fast sync hook, the
+    // classic require shim, and the compat async-hooks load. If nub transpiled them,
+    // the reformattable source would be normalized; `using`-as-identifier in the
+    // plain dep would survive only because it's never parsed as a declaration. The
+    // marks prove the dep bodies ran unchanged. (PnP deps live in zip-fs, never a
+    // real `/node_modules/` path — covered by the tests/pnp matrix, not here.)
+    let (stdout, stderr, code) = run_nub("project-js", "main-deps.js");
+    assert_eq!(
+        code, 0,
+        "requiring node_modules deps should work raw: {stderr}"
+    );
+    assert!(
+        stdout.contains("DEPY:depy:identifier-not-keyword:12"),
+        "plain node_modules dep loaded raw: {stdout}"
+    );
+    assert!(
+        stdout.contains("DEPZ:depz-store:9"),
+        "pnpm .pnpm-store dep loaded raw: {stdout}"
+    );
+}
+
+#[test]
+fn project_js_decorator_routes_to_transform() {
+    // A decorator in project `.js` must route to the transform path (NOT the
+    // verbatim skip): with no experimentalDecorators it surfaces nub's Stage-3
+    // diagnostic, exactly as the `.ts` equivalent does — proving the decorator
+    // trigger flags `.js`.
+    let (_stdout, stderr, code) = run_nub("project-js", "decorator.js");
+    assert_ne!(
+        code, 0,
+        "Stage-3 decorator in .js should fail clearly: {stderr}"
+    );
+    assert!(
+        stderr.contains("Stage 3 decorators are not supported"),
+        "decorator in .js must hit the branded diagnostic (the transform path), \
+         not run verbatim: {stderr}"
+    );
+}
+
 #[test]
 fn js_parent_no_extensionless_probe() {
     // Contract: a non-TS (`.js`) parent does NOT get nub's TS-parent extensionless

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -411,21 +411,24 @@ fn project_js_mjs_is_module_cjs_is_commonjs() {
 
 #[test]
 fn node_modules_js_is_never_transpiled() {
-    // The make-or-break gate: dependency `.js` (a plain node_modules dep AND a pnpm
-    // `.pnpm`-virtual-store dep) must load RAW on every tier — fast sync hook, the
-    // classic require shim, and the compat async-hooks load. If nub transpiled them,
-    // the reformattable source would be normalized; `using`-as-identifier in the
-    // plain dep would survive only because it's never parsed as a declaration. The
-    // marks prove the dep bodies ran unchanged. (PnP deps live in zip-fs, never a
-    // real `/node_modules/` path — covered by the tests/pnp matrix, not here.)
+    // The make-or-break gate: dependency code must load RAW on every tier — the fast
+    // sync hook, the classic require shim, and the compat async-hooks load. Covered:
+    // a plain node_modules `.js` dep (which itself `require`s a sibling `.cjs` — Node
+    // has no native `_extensions['.cjs']`, so the classic shim's bail must fall back
+    // to the `.js` handler or the require crashes on the compat tier), and a pnpm
+    // `.pnpm`-virtual-store dep. If nub transpiled them, the reformattable source
+    // would be normalized; `using`-as-identifier in the plain dep would survive only
+    // because it's never parsed as a declaration. The marks prove the dep bodies ran
+    // unchanged. (Yarn PnP deps resolve to an in-zip path that still contains
+    // `/node_modules/`, so they gate identically — covered by the tests/pnp matrix.)
     let (stdout, stderr, code) = run_nub("project-js", "main-deps.js");
     assert_eq!(
         code, 0,
         "requiring node_modules deps should work raw: {stderr}"
     );
     assert!(
-        stdout.contains("DEPY:depy:identifier-not-keyword:12"),
-        "plain node_modules dep loaded raw: {stdout}"
+        stdout.contains("DEPY:depy:identifier-not-keyword:depy-cjs:12"),
+        "plain node_modules dep (and its required .cjs helper) loaded raw: {stdout}"
     );
     assert!(
         stdout.contains("DEPZ:depz-store:9"),

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -306,6 +306,50 @@ fn legacy_decorators_require_experimental_flag() {
 // design thread.
 
 #[test]
+fn js_transpilation_smoke_guard() {
+    // PERMANENT REGRESSION GUARD — DO NOT DELETE. Guards JS-file transpilation
+    // against being silently disabled (e.g. `.js`/`.mjs`/`.cjs` dropped from
+    // TRANSPILE_EXTS, the skip-gate inverted, or a dispatch site regressed). This is
+    // a BLACK-BOX test: it runs the real `nub` binary on project `.js`/`.mjs`/`.cjs`
+    // files that contain FLOOR-BREAKING syntax and asserts each one transpiles +
+    // executes on EVERY supported Node — including the 18.19 compat-tier floor.
+    //
+    // Why each fixture proves transpilation fired on its extension, even on 18.19:
+    //   * guard.mjs — a `using` declaration (ES2026), a hard SyntaxError on every
+    //     supported Node's V8. An ESM entry resolves the disposal helper on every
+    //     tier (the CJS-entry helper limitation does not apply to ESM), so it both
+    //     lowers AND executes on the 18.19 floor. Prints SMOKE-MJS:body,b,a.
+    //   * guard.js / guard.cjs — a `v`-flag (ES2024 unicode-sets) RegExp literal,
+    //     a hard PARSE error on 18.19's V8 that kills the whole module raw. oxc
+    //     lowers `/…/v` to a `new RegExp(…)` constructor, so a transpiled module
+    //     PARSES and the marker prints; the literal sits in an uncalled function so
+    //     the constructor never runs on 18.19 (where V8 rejects the `v` flag). The
+    //     marker only appears if nub transpiled the `.js`/`.cjs`.
+    // If any extension stops being transpiled, its marker vanishes (raw SyntaxError /
+    // parse error) and this test fails on the floor leg — the canary the maintainer
+    // asked for. Runs on the ambient CI matrix Node (18.19 through the host line).
+    for (file, marker) in [
+        ("guard.mjs", "SMOKE-MJS:body,b,a"),
+        ("guard.js", "SMOKE-JS:ok"),
+        ("guard.cjs", "SMOKE-CJS:ok"),
+    ] {
+        let (stdout, stderr, code) = run_nub("transpile-js-smoke", file);
+        assert_eq!(
+            code,
+            0,
+            "{file} must transpile + run on Node {:?} (transpilation disabled?): {stderr}",
+            target_node_version()
+        );
+        assert!(
+            stdout.contains(marker),
+            "{file} marker missing — nub did not transpile this extension on Node {:?}: \
+             stdout={stdout} stderr={stderr}",
+            target_node_version()
+        );
+    }
+}
+
+#[test]
 fn project_js_using_down_levels() {
     // `using` is a SyntaxError on every supported Node's V8; this project `.js`
     // must be down-leveled (the transformableSyntax verdict flags it) and run, just

--- a/crates/nub-native/src/detect.rs
+++ b/crates/nub-native/src/detect.rs
@@ -21,7 +21,7 @@ use napi_derive::napi;
 
 use oxc::{
     allocator::Allocator,
-    ast::ast::{ImportDeclarationSpecifier, Statement},
+    ast::ast::{ImportDeclarationSpecifier, RegExpFlags, Statement, VariableDeclaration},
     ast_visit::Visit,
     parser::Parser,
 };
@@ -40,6 +40,35 @@ pub struct ModuleInfo {
     /// True when the source contains `@decorator` syntax anywhere (class or class
     /// member). Drives the Stage-3-decorator diagnostic when legacy mode is off.
     pub has_decorators: bool,
+
+    /// True when the source contains syntax oxc LOWERS at nub's `target: "es2022"`
+    /// — i.e. running the raw source on the Node 22.15 floor would SyntaxError or
+    /// misbehave. This is the skip-gate verdict for project-source plain JS
+    /// (`.js`/`.mjs`/`.cjs`): when FALSE, nub returns the file verbatim (byte for
+    /// byte, no codegen, no sourcemap footer) instead of running it through oxc,
+    /// which reformats no-op source. When TRUE, the file must be transpiled.
+    ///
+    /// PROVENANCE — PINNED TO oxc =0.132.0's es2022 lowering set. The complete set
+    /// of SYNTAX oxc lowers at `target:"es2022"` for plain JS is exactly:
+    ///   1. `using` / `await using` declarations (ES2026 explicit resource mgmt)
+    ///   2. RegExp `v`-flag literals (ES2024 unicode-sets — oxc rewrites `/…/v` to
+    ///      `new RegExp(…, "v")`; the raw literal throws on the 22.15 floor's V8)
+    ///   3. legacy/Stage-3 decorators (option-driven, surfaced via `has_decorators`)
+    /// Everything ≤ es2022 (class fields, static blocks, logical-assignment, numeric
+    /// separators, top-level await, optional chaining, import attributes, the `d`
+    /// match-indices RegExp flag) is NOT lowered at es2022 and is therefore NOT a
+    /// trigger. Derived from oxc's `EnvOptions::from("es2022")` (`has_feature` is
+    /// false ⇒ lower) — the editions jump es2022→es2026 with no es2023/24/25 syntax
+    /// transform dirs, so the only syntax lowering above es2022 is (1) and the
+    /// regexp `v`-flag (2). RE-DERIVE THIS SET ON ANY oxc BUMP: a new oxc version
+    /// can add a lowered syntax (or change the editions), which would silently let a
+    /// floor-breaking file run verbatim. The floor tests (one per trigger, run on
+    /// Node 22.15) are the CI backstop — a future oxc that lowers more must make one
+    /// of them fail. `has_decorators` is folded in by the JS gate (the decorator
+    /// case routes via the Stage-3 guard / legacy transform), so this field tracks
+    /// the target-version-gated SYNTAX triggers (using ∪ v-flag-regexp); the JS gate
+    /// ORs it with `has_decorators`.
+    pub transformable_syntax: bool,
 }
 
 /// Detect a file's module-format and decorator shape. `lang` is `'ts'`, `'tsx'`,
@@ -61,10 +90,16 @@ pub fn detect_module_info(
     // unparseable file as CJS for format detection (the transpile surfaces the
     // real error) and as "no decorators" for the guard (V8 surfaces the error).
     // Both fall out of an all-false return.
+    // A parse error means we can't trust the verdict. Defaulting
+    // `transformable_syntax: false` lets the JS gate return the raw source verbatim
+    // — which is the SAFE default for plain JS: a genuinely-unparseable file would
+    // SyntaxError under transpile too, so handing back the raw bytes surfaces V8's
+    // own error at exactly the spot Node would, identical to a non-transpiled file.
     if ret.panicked {
         return ModuleInfo {
             has_value_esm_syntax: false,
             has_decorators: false,
+            transformable_syntax: false,
         };
     }
 
@@ -74,12 +109,19 @@ pub fn detect_module_info(
         !ret.module_record.import_metas.is_empty(),
     );
 
-    let mut decorators = DecoratorFinder { found: false };
-    decorators.visit_program(&ret.program);
+    // ONE AST walk computes both the decorator guard and the skip-gate verdict —
+    // the visitor already traverses the whole tree, so folding the using/v-flag
+    // checks into the same pass is near-free (no extra parse, no second walk).
+    let mut finder = SyntaxFinder {
+        decorators: false,
+        transformable: false,
+    };
+    finder.visit_program(&ret.program);
 
     ModuleInfo {
         has_value_esm_syntax,
-        has_decorators: decorators.found,
+        has_decorators: finder.decorators,
+        transformable_syntax: finder.transformable,
     }
 }
 
@@ -170,14 +212,37 @@ fn specifier_is_type(spec: &ImportDeclarationSpecifier<'_>) -> bool {
     }
 }
 
-/// Walks the AST looking for a single decorator. Stops conceptually at the first
-/// (the visitor keeps going but `found` latches true).
-struct DecoratorFinder {
-    found: bool,
+/// Walks the AST once, latching two independent verdicts:
+///   * `decorators` — a `@decorator` appears anywhere (drives the Stage-3 guard).
+///   * `transformable` — the source contains target-version-gated SYNTAX oxc lowers
+///     at `target:"es2022"`: a `using`/`await using` declaration, or a `v`-flag
+///     RegExp literal. See `ModuleInfo::transformable_syntax` for the pinned
+///     provenance of this set (oxc =0.132.0). Both fields keep going once latched
+///     (the visit completes) — correctness only needs "did we ever see one".
+struct SyntaxFinder {
+    decorators: bool,
+    transformable: bool,
 }
 
-impl<'a> Visit<'a> for DecoratorFinder {
+impl<'a> Visit<'a> for SyntaxFinder {
     fn visit_decorator(&mut self, _it: &oxc::ast::ast::Decorator<'a>) {
-        self.found = true;
+        self.decorators = true;
+    }
+
+    fn visit_variable_declaration(&mut self, it: &VariableDeclaration<'a>) {
+        // `using x = …` / `await using x = …` — ES2026 explicit resource management,
+        // lowered at es2022 to the `usingCtx` helper shape. Unparseable on the floor.
+        if it.kind.is_using() {
+            self.transformable = true;
+        }
+        oxc::ast_visit::walk::walk_variable_declaration(self, it);
+    }
+
+    fn visit_reg_exp_literal(&mut self, it: &oxc::ast::ast::RegExpLiteral<'a>) {
+        // `/…/v` — ES2024 unicode-sets RegExp, lowered at es2022 to `new RegExp(…)`.
+        // The raw `v`-flag literal throws a SyntaxError on the 22.15 floor's V8.
+        if it.regex.flags.contains(RegExpFlags::V) {
+            self.transformable = true;
+        }
     }
 }

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -28,8 +28,8 @@
 // loader worker, not a user realm, so it installs no browser globals.)
 import "./floor-builtin.mjs";
 import {
-  TRANSPILE_EXTS, DATA_EXTS,
-  extname, resolveSpec, loadTranspile, loadData, isNodeModules,
+  TRANSPILE_EXTS, PLAIN_JS_EXTS, DATA_EXTS,
+  extname, resolveSpec, loadTranspile, maybeTranspilePlainJs, loadData, isNodeModules,
 } from "./transform-core.mjs";
 import { createRequire, isBuiltin } from "node:module";
 import { existsSync } from "node:fs";
@@ -96,6 +96,14 @@ export async function load(url, context, nextLoad) {
     // warm-up needed (the old `await ensureParser()` for the ESM-only oxc-parser
     // is gone with the package).
     return loadTranspile(url, ext);
+  }
+  // Project-source plain JS: transpile ONLY when it carries transformable syntax. A
+  // no-op plain-JS file returns null and falls through to `nextLoad` — Node's own
+  // loader handles it byte-identically, preserving every native CJS/ESM behavior.
+  // node_modules excluded (the byte-parity boundary).
+  if (PLAIN_JS_EXTS.has(ext) && !isNodeModules(url)) {
+    const r = maybeTranspilePlainJs(url, ext);
+    if (r) return r;
   }
   if (ext in DATA_EXTS) return loadData(url, ext);
   return nextLoad(url, context);

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -29,7 +29,7 @@
 import "./floor-builtin.mjs";
 import {
   TRANSPILE_EXTS, DATA_EXTS,
-  extname, resolveSpec, loadTranspile, loadData,
+  extname, resolveSpec, loadTranspile, loadData, isNodeModules,
 } from "./transform-core.mjs";
 import { createRequire, isBuiltin } from "node:module";
 import { existsSync } from "node:fs";
@@ -85,7 +85,12 @@ export async function resolve(specifier, context, nextResolve) {
 // ── Load hook ───────────────────────────────────────────────────────
 export async function load(url, context, nextLoad) {
   const ext = extname(url);
-  if (TRANSPILE_EXTS.has(ext)) {
+  // node_modules deps are NEVER transpiled (the byte-parity boundary). This guard is
+  // make-or-break now that TRANSPILE_EXTS includes `.js`/`.mjs`/`.cjs`: without it,
+  // the compat tier would route every dependency `.js` through oxc. (loadTranspile's
+  // own skip-gate handles the project-source no-op case; this keeps deps off the
+  // pipeline entirely.) Mirrors the fast-tier sync hook's `!isNodeModules` gate.
+  if (TRANSPILE_EXTS.has(ext) && !isNodeModules(url)) {
     // Module-format + decorator detection inside loadTranspile is a synchronous
     // native call (nub's addon), available on every supported Node — no parser
     // warm-up needed (the old `await ensureParser()` for the ESM-only oxc-parser

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -673,6 +673,25 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   for (const ext of [".ts", ".cts", ".mts", ".tsx", ".jsx"]) {
     module_._extensions[ext] = transpileExtension;
   }
+
+  // Project-source plain JS (`.js`/`.cjs`/`.mjs`) routes through the SAME pipeline so
+  // `using`/`v`-flag-RegExp/decorators lower uniformly on the classic require tier.
+  // TWO guards keep this safe: (1) node_modules deps MUST stay on Node's native
+  // compiler — routing every dep `.js` require through oxc would be catastrophic — so
+  // bail to the saved original handler for node_modules; (2) loadTranspile's own
+  // skip-gate returns no-op plain JS verbatim, so a project `.js` with nothing to
+  // lower is _compile'd from its raw bytes (byte-identical). `.mjs` is ESM-only;
+  // Node never registers a require.extensions handler for it, so requiring an `.mjs`
+  // throws ERR_REQUIRE_ESM as before — we don't override `.mjs` here.
+  for (const ext of [".js", ".cjs"]) {
+    const origExtension = module_._extensions[ext];
+    module_._extensions[ext] = (mod, filename) => {
+      if (core.isNodeModules(pathToFileURL(filename).href)) {
+        return origExtension.call(module_._extensions, mod, filename);
+      }
+      return transpileExtension(mod, filename);
+    };
+  }
 }
 
 // ── Clobbered-polyfill preloading + Temporal lazy global ────────────

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -678,13 +678,20 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   // `using`/`v`-flag-RegExp/decorators lower uniformly on the classic require tier.
   // TWO guards keep this safe: (1) node_modules deps MUST stay on Node's native
   // compiler — routing every dep `.js` require through oxc would be catastrophic — so
-  // bail to the saved original handler for node_modules; (2) loadTranspile's own
-  // skip-gate returns no-op plain JS verbatim, so a project `.js` with nothing to
-  // lower is _compile'd from its raw bytes (byte-identical). `.mjs` is ESM-only;
-  // Node never registers a require.extensions handler for it, so requiring an `.mjs`
-  // throws ERR_REQUIRE_ESM as before — we don't override `.mjs` here.
+  // bail to the native handler for node_modules; (2) loadTranspile's own skip-gate
+  // returns no-op plain JS verbatim, so a project `.js` with nothing to lower is
+  // _compile'd from its raw bytes (byte-identical). `.mjs` is ESM-only; Node never
+  // registers a require.extensions handler for it, so requiring an `.mjs` throws
+  // ERR_REQUIRE_ESM as before — we don't override `.mjs` here.
+  //
+  // Node registers a native `_extensions` handler ONLY for `.js` (plus `.json`/
+  // `.node`) — NOT for `.cjs`, which Node compiles through the SAME CJS `_compile`
+  // path as `.js`. So the node_modules bail falls back to the `.js` handler when the
+  // ext has no own handler (`|| nativeJs`); without it, a node_modules `.cjs` require
+  // would call `undefined` and crash on the compat tier (where this shim is active).
+  const nativeJs = module_._extensions[".js"];
   for (const ext of [".js", ".cjs"]) {
-    const origExtension = module_._extensions[ext];
+    const origExtension = module_._extensions[ext] || nativeJs;
     module_._extensions[ext] = (mod, filename) => {
       if (core.isNodeModules(pathToFileURL(filename).href)) {
         return origExtension.call(module_._extensions, mod, filename);

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -373,6 +373,13 @@ function makeHooks(core, watchReporting) {
       if (core.TRANSPILE_EXTS.has(ext) && !core.isNodeModules(url)) {
         return core.loadTranspile(url, ext);
       }
+      // Plain JS: transpile only when transformable; else fall through to the raw-
+      // source path below (which hands CJS back as `source:null` → Node's native
+      // CJS loader), byte-identical to a non-intercepted file.
+      if (core.PLAIN_JS_EXTS.has(ext) && !core.isNodeModules(url)) {
+        const r = core.maybeTranspilePlainJs(url, ext);
+        if (r) return r;
+      }
       if (ext in core.DATA_EXTS) return core.loadData(url, ext);
       const { readFileSync } = require("node:fs");
       const source = readFileSync(path);
@@ -431,6 +438,15 @@ function makeHooks(core, watchReporting) {
     // gated.)
     if (core.TRANSPILE_EXTS.has(ext) && !core.isNodeModules(url)) {
       return core.loadTranspile(url, ext);
+    }
+    // Project-source plain JS (`.js`/`.mjs`/`.cjs`): transpile ONLY when it carries
+    // transformable syntax. A no-op plain-JS file returns null here and falls through
+    // to Node's native loader (the `nextLoad`/relabel path below) BYTE-FOR-BYTE — it
+    // is never intercepted, so native CJS/ESM behavior (the relabel, require.cache,
+    // the require-of-ESM-syntax-`.cjs` error) is preserved. node_modules excluded.
+    if (core.PLAIN_JS_EXTS.has(ext) && !core.isNodeModules(url)) {
+      const r = core.maybeTranspilePlainJs(url, ext);
+      if (r) return r;
     }
     if (ext in core.DATA_EXTS) return core.loadData(url, ext);
 
@@ -674,29 +690,36 @@ function installCjsRequireHooks(core, withClassicTranspile) {
     module_._extensions[ext] = transpileExtension;
   }
 
-  // Project-source plain JS (`.js`/`.cjs`/`.mjs`) routes through the SAME pipeline so
-  // `using`/`v`-flag-RegExp/decorators lower uniformly on the classic require tier.
-  // TWO guards keep this safe: (1) node_modules deps MUST stay on Node's native
-  // compiler — routing every dep `.js` require through oxc would be catastrophic — so
-  // bail to the native handler for node_modules; (2) loadTranspile's own skip-gate
-  // returns no-op plain JS verbatim, so a project `.js` with nothing to lower is
-  // _compile'd from its raw bytes (byte-identical). `.mjs` is ESM-only; Node never
-  // registers a require.extensions handler for it, so requiring an `.mjs` throws
-  // ERR_REQUIRE_ESM as before — we don't override `.mjs` here.
-  //
-  // Node registers a native `_extensions` handler ONLY for `.js` (plus `.json`/
-  // `.node`) — NOT for `.cjs`, which Node compiles through the SAME CJS `_compile`
-  // path as `.js`. So the node_modules bail falls back to the `.js` handler when the
-  // ext has no own handler (`|| nativeJs`); without it, a node_modules `.cjs` require
-  // would call `undefined` and crash on the compat tier (where this shim is active).
+  // Project-source plain JS (`.js`/`.cjs`) routes through the SAME pipeline so
+  // `using`/`v`-flag-RegExp/decorators lower uniformly on the classic require tier —
+  // but ONLY when the file carries transformable syntax. THREE cases, each preserving
+  // Node's native behavior where it must:
+  //   (1) node_modules dep → native handler (deps are NEVER transpiled). Node has no
+  //       own `_extensions['.cjs']` (only `.js`/`.json`/`.node`), and compiles `.cjs`
+  //       through the same CJS path as `.js`, so the `.cjs` bail falls back to the
+  //       `.js` handler (`|| nativeJs`) — without it a node_modules `.cjs` require
+  //       would call `undefined` and crash.
+  //   (2) project file with transformable syntax → transpile (lower it).
+  //   (3) project file with NOTHING to lower → the ORIGINAL native handler, raw bytes
+  //       compiled exactly as Node would. We never serve our own source for a no-op
+  //       file, so require.cache / the require-of-ESM-syntax-`.cjs` SyntaxError / every
+  //       native CJS behavior is byte-identical.
+  // `.mjs` is ESM-only; Node registers no require.extensions handler for it, so a
+  // `require()` of `.mjs` throws ERR_REQUIRE_ESM as before — we don't override it.
   const nativeJs = module_._extensions[".js"];
   for (const ext of [".js", ".cjs"]) {
     const origExtension = module_._extensions[ext] || nativeJs;
     module_._extensions[ext] = (mod, filename) => {
       if (core.isNodeModules(pathToFileURL(filename).href)) {
-        return origExtension.call(module_._extensions, mod, filename);
+        return origExtension.call(module_._extensions, mod, filename); // (1)
       }
-      return transpileExtension(mod, filename);
+      const r = core.maybeTranspilePlainJs(pathToFileURL(filename).href, pathExtname(filename));
+      if (r) {
+        if (r.format === "module") throw requireEsmError(filename); // (2)
+        mod._compile(r.source, filename);
+        return;
+      }
+      return origExtension.call(module_._extensions, mod, filename); // (3)
     };
   }
 }

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -461,13 +461,18 @@ function detectModuleInfo(filePath, source, lang) {
 // `type` is authoritative; otherwise (ambiguous) we detect from source syntax —
 // full Node parity (`--experimental-detect-module`), so a CJS-syntax `.ts` with
 // no `type` runs as CJS on nub exactly as on Node. See wiki/runtime/module-format.md.
-export function moduleFormatFor(ext, pkgType, filePath, source) {
+// `info` (optional) is a pre-computed `detectModuleInfo` result for this file — the
+// caller passes it to avoid a second parse when it already needed the verdict (the
+// plain-JS skip-gate). When the format is decided by ext/`type` alone, `info` is
+// never consulted, so passing it is harmless on the explicit paths.
+export function moduleFormatFor(ext, pkgType, filePath, source, info) {
   if (ext === ".mts" || ext === ".mjs") return "module";
   if (ext === ".cts" || ext === ".cjs") return "commonjs";
   if (pkgType === "module") return "module";
   if (pkgType === "commonjs") return "commonjs";
   const lang = ext === ".tsx" ? "tsx" : ext === ".jsx" ? "jsx" : "ts";
-  return detectModuleInfo(filePath, source, lang).hasValueEsmSyntax ? "module" : "commonjs";
+  const resolved = info ?? detectModuleInfo(filePath, source, lang);
+  return resolved.hasValueEsmSyntax ? "module" : "commonjs";
 }
 
 // The Stage-3-decorator rejection diagnostic. oxc does not lower TC39 Stage 3
@@ -579,27 +584,30 @@ export function loadTranspile(url, ext) {
   // (.ts/.tsx/.jsx); .mts/.cts are explicit so its lookup is skipped. The chosen
   // format is folded into the cache key (and the entry's leading byte) by native.
   const pkgType = ext === ".mts" || ext === ".cts" ? undefined : getPackageType(dir);
-  const format = moduleFormatFor(ext, pkgType, filePath, source);
-
   const lang = ext === ".tsx" ? "tsx" : ext === ".jsx" ? "jsx" : "ts";
 
   // ── Plain-JS byte-parity skip-gate ──────────────────────────────────
   // Project `.js`/`.mjs`/`.cjs` is now in TRANSPILE_EXTS, but oxc REFORMATS no-op
   // source (quotes/semicolons/whitespace) and always appends a sourcemap footer —
   // a hard regression for every plain-JS file that has nothing to lower. So for
-  // plain JS only, ask the native verdict (computed on the SAME parse moduleFormatFor
-  // already runs for ambiguous `.js`): if the file contains NO target-gated syntax
-  // oxc would lower (`using`/`await using`, `v`-flag RegExp — `transformableSyntax`)
-  // AND no decorators (`hasDecorators` — the decorator path is handled below: legacy
-  // transforms it, Stage-3-off throws the guard), return the RAW source VERBATIM.
-  // No codegen, no footer, no cache write — byte-identical to the input, exactly as
-  // a non-transpiled `.js` is today. TS/JSX exts skip this gate (they always strip).
-  // JSX-in-.js is OUT of scope (lang is "ts", which does not parse JSX); use `.jsx`.
-  if (PLAIN_JS_EXTS.has(ext)) {
-    const info = detectModuleInfo(filePath, source, lang);
-    if (!info.transformableSyntax && !info.hasDecorators) {
-      return { format, source, shortCircuit: true };
-    }
+  // plain JS only, ask the native verdict: if the file contains NO target-gated
+  // syntax oxc would lower (`using`/`await using`, `v`-flag RegExp —
+  // `transformableSyntax`) AND no decorators (`hasDecorators` — the decorator path
+  // is handled below: legacy transforms it, Stage-3-off throws the guard), return
+  // the RAW source VERBATIM. No codegen, no footer, no cache write — byte-identical
+  // to the input, exactly as a non-transpiled `.js` is today. TS/JSX exts skip this
+  // gate (they always strip). JSX-in-.js is OUT of scope (lang is "ts", which does
+  // not parse JSX); use `.jsx`.
+  //
+  // For plain JS we parse ONCE here and pass the result to `moduleFormatFor` so an
+  // ambiguous-format `.js` (no explicit `type`) doesn't pay a SECOND parse for its
+  // format detection — the verdict and the ESM-syntax signal come off the same parse.
+  const plainJsInfo = PLAIN_JS_EXTS.has(ext)
+    ? detectModuleInfo(filePath, source, lang)
+    : undefined;
+  const format = moduleFormatFor(ext, pkgType, filePath, source, plainJsInfo);
+  if (plainJsInfo && !plainJsInfo.transformableSyntax && !plainJsInfo.hasDecorators) {
+    return { format, source, shortCircuit: true };
   }
 
   const opts = {

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -156,15 +156,20 @@ if (typeof process.getBuiltinModule === "function") __ensureBuiltins();
 // natively now, and this file no longer needs to read version.mjs.
 
 // ── Constants ───────────────────────────────────────────────────────
-// Project-source plain JS (.js/.mjs/.cjs) is transpiled through the SAME pipeline
-// as .ts/.tsx so transformable syntax (`using`/`await using`, `v`-flag RegExp,
-// decorators) gets lowered uniformly — identical source must not behave differently
-// by extension. node_modules is EXCLUDED at every dispatch site (the byte-parity
-// boundary); and a plain-JS file with NOTHING to lower returns VERBATIM (the
-// transformableSyntax skip-gate in loadTranspile), so no-op JS is byte-identical.
-export const TRANSPILE_EXTS = new Set([".ts", ".tsx", ".mts", ".cts", ".jsx", ".js", ".mjs", ".cjs"]);
-// The plain-JS subset: these get the transformableSyntax skip-gate (verbatim return
-// when nothing lowers). The TS/JSX exts always transform (type-stripping is required).
+// TS/JSX exts ALWAYS transform (type-stripping is required), so they live in
+// TRANSPILE_EXTS — the set every dispatch site checks to route a file to
+// loadTranspile. Plain JS (.js/.mjs/.cjs) is DELIBERATELY NOT here: a plain-JS file
+// is transpiled ONLY when it carries transformable syntax (`using`/`await using`,
+// `v`-flag RegExp, decorators), and a no-op plain-JS file must take Node's OWN load
+// path BYTE-FOR-BYTE — putting it in TRANSPILE_EXTS would route every `.js`/`.cjs`
+// through nub's hook and change native CJS/ESM behavior (the `commonjs-sync` relabel,
+// require.cache, the require-of-ESM-syntax-.cjs error). So plain JS is handled by a
+// SEPARATE narrow path (`maybeTranspilePlainJs`) that fires only for transformable
+// files and is a no-op (returns null) otherwise — see PLAIN_JS_EXTS below.
+export const TRANSPILE_EXTS = new Set([".ts", ".tsx", ".mts", ".cts", ".jsx"]);
+// Project-source plain JS. Routed to the transpiler ONLY when transformable (the
+// `maybeTranspilePlainJs` gate); a no-op plain-JS file falls through to Node's
+// native loader untouched, byte-identical. node_modules is excluded at the gate.
 export const PLAIN_JS_EXTS = new Set([".js", ".mjs", ".cjs"]);
 export const DATA_EXTS = { ".jsonc": "jsonc", ".json5": "json5", ".toml": "toml", ".yaml": "yaml", ".yml": "yaml", ".txt": "txt" };
 export const TS_PARENT_EXTS = new Set([".ts", ".tsx", ".mts", ".cts"]);
@@ -461,18 +466,15 @@ function detectModuleInfo(filePath, source, lang) {
 // `type` is authoritative; otherwise (ambiguous) we detect from source syntax —
 // full Node parity (`--experimental-detect-module`), so a CJS-syntax `.ts` with
 // no `type` runs as CJS on nub exactly as on Node. See wiki/runtime/module-format.md.
-// `info` (optional) is a pre-computed `detectModuleInfo` result for this file — the
-// caller passes it to avoid a second parse when it already needed the verdict (the
-// plain-JS skip-gate). When the format is decided by ext/`type` alone, `info` is
-// never consulted, so passing it is harmless on the explicit paths.
-export function moduleFormatFor(ext, pkgType, filePath, source, info) {
+// `.mjs`→module / `.cjs`→commonjs are explicit (mirroring `.mts`/`.cts`), so the
+// plain-JS gate gets the right format without a needless detect.
+export function moduleFormatFor(ext, pkgType, filePath, source) {
   if (ext === ".mts" || ext === ".mjs") return "module";
   if (ext === ".cts" || ext === ".cjs") return "commonjs";
   if (pkgType === "module") return "module";
   if (pkgType === "commonjs") return "commonjs";
   const lang = ext === ".tsx" ? "tsx" : ext === ".jsx" ? "jsx" : "ts";
-  const resolved = info ?? detectModuleInfo(filePath, source, lang);
-  return resolved.hasValueEsmSyntax ? "module" : "commonjs";
+  return detectModuleInfo(filePath, source, lang).hasValueEsmSyntax ? "module" : "commonjs";
 }
 
 // The Stage-3-decorator rejection diagnostic. oxc does not lower TC39 Stage 3
@@ -584,31 +586,9 @@ export function loadTranspile(url, ext) {
   // (.ts/.tsx/.jsx); .mts/.cts are explicit so its lookup is skipped. The chosen
   // format is folded into the cache key (and the entry's leading byte) by native.
   const pkgType = ext === ".mts" || ext === ".cts" ? undefined : getPackageType(dir);
-  const lang = ext === ".tsx" ? "tsx" : ext === ".jsx" ? "jsx" : "ts";
+  const format = moduleFormatFor(ext, pkgType, filePath, source);
 
-  // ── Plain-JS byte-parity skip-gate ──────────────────────────────────
-  // Project `.js`/`.mjs`/`.cjs` is now in TRANSPILE_EXTS, but oxc REFORMATS no-op
-  // source (quotes/semicolons/whitespace) and always appends a sourcemap footer —
-  // a hard regression for every plain-JS file that has nothing to lower. So for
-  // plain JS only, ask the native verdict: if the file contains NO target-gated
-  // syntax oxc would lower (`using`/`await using`, `v`-flag RegExp —
-  // `transformableSyntax`) AND no decorators (`hasDecorators` — the decorator path
-  // is handled below: legacy transforms it, Stage-3-off throws the guard), return
-  // the RAW source VERBATIM. No codegen, no footer, no cache write — byte-identical
-  // to the input, exactly as a non-transpiled `.js` is today. TS/JSX exts skip this
-  // gate (they always strip). JSX-in-.js is OUT of scope (lang is "ts", which does
-  // not parse JSX); use `.jsx`.
-  //
-  // For plain JS we parse ONCE here and pass the result to `moduleFormatFor` so an
-  // ambiguous-format `.js` (no explicit `type`) doesn't pay a SECOND parse for its
-  // format detection — the verdict and the ESM-syntax signal come off the same parse.
-  const plainJsInfo = PLAIN_JS_EXTS.has(ext)
-    ? detectModuleInfo(filePath, source, lang)
-    : undefined;
-  const format = moduleFormatFor(ext, pkgType, filePath, source, plainJsInfo);
-  if (plainJsInfo && !plainJsInfo.transformableSyntax && !plainJsInfo.hasDecorators) {
-    return { format, source, shortCircuit: true };
-  }
+  const lang = ext === ".tsx" ? "tsx" : ext === ".jsx" ? "jsx" : "ts";
 
   const opts = {
     lang,
@@ -663,6 +643,40 @@ export function loadTranspile(url, ext) {
     throw new Error(`Transpile error in ${filePath}:\n${details}`);
   }
   return { format: result.format, source: result.code, shortCircuit: true };
+}
+
+// Project-source plain JS (`.js`/`.mjs`/`.cjs`) gate. Returns a transpiled load
+// result ONLY when the file carries syntax oxc lowers at nub's es2022 target
+// (`using`/`await using`, a `v`-flag RegExp, or decorators); otherwise returns
+// `null`, meaning "this file needs no transform — handle it with Node's OWN loader,
+// exactly as a non-listed extension." This is why `.js`/`.mjs`/`.cjs` are NOT in
+// TRANSPILE_EXTS: a no-op plain-JS file must take Node's native load path
+// byte-for-byte (preserving the `commonjs-sync` relabel, require.cache, the
+// require-of-ESM-syntax-`.cjs` error — all of which intercepting the file would
+// break), and oxc would reformat it (quotes/semicolons/whitespace + a sourcemap
+// footer) if we ran it through anyway. The verdict rides ONE parse (the same one
+// `detectModuleInfo` does for format detection). node_modules is gated at the call
+// sites (the byte-parity boundary). JSX-in-`.js` is out of scope (lang is "ts",
+// which does not parse JSX); use `.jsx`.
+export function maybeTranspilePlainJs(url, ext) {
+  __ensureBuiltins();
+  const filePath = fileURLToPath(url);
+  let source;
+  try {
+    source = readFileSync(filePath, "utf8");
+  } catch {
+    // Unreadable here → let Node's loader surface its own error.
+    return null;
+  }
+  // lang "ts" parses all JS (a TS superset) but NOT JSX — JSX-in-.js is out of scope.
+  const info = detectModuleInfo(filePath, source, "ts");
+  if (!info.transformableSyntax && !info.hasDecorators) {
+    return null; // no-op: Node's native loader handles it, byte-identical.
+  }
+  // Transformable: run the SAME pipeline as TS/JSX (target es2022 lowering, tsconfig,
+  // source maps, the Stage-3 decorator guard, format detection, cache). loadTranspile
+  // re-reads + re-parses, but only for the rare file that actually needs lowering.
+  return loadTranspile(url, ext);
 }
 
 // ── Data-format imports ─────────────────────────────────────────────

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -156,7 +156,16 @@ if (typeof process.getBuiltinModule === "function") __ensureBuiltins();
 // natively now, and this file no longer needs to read version.mjs.
 
 // ── Constants ───────────────────────────────────────────────────────
-export const TRANSPILE_EXTS = new Set([".ts", ".tsx", ".mts", ".cts", ".jsx"]);
+// Project-source plain JS (.js/.mjs/.cjs) is transpiled through the SAME pipeline
+// as .ts/.tsx so transformable syntax (`using`/`await using`, `v`-flag RegExp,
+// decorators) gets lowered uniformly — identical source must not behave differently
+// by extension. node_modules is EXCLUDED at every dispatch site (the byte-parity
+// boundary); and a plain-JS file with NOTHING to lower returns VERBATIM (the
+// transformableSyntax skip-gate in loadTranspile), so no-op JS is byte-identical.
+export const TRANSPILE_EXTS = new Set([".ts", ".tsx", ".mts", ".cts", ".jsx", ".js", ".mjs", ".cjs"]);
+// The plain-JS subset: these get the transformableSyntax skip-gate (verbatim return
+// when nothing lowers). The TS/JSX exts always transform (type-stripping is required).
+export const PLAIN_JS_EXTS = new Set([".js", ".mjs", ".cjs"]);
 export const DATA_EXTS = { ".jsonc": "jsonc", ".json5": "json5", ".toml": "toml", ".yaml": "yaml", ".yml": "yaml", ".txt": "txt" };
 export const TS_PARENT_EXTS = new Set([".ts", ".tsx", ".mts", ".cts"]);
 
@@ -435,13 +444,15 @@ function detectModuleInfo(filePath, source, lang) {
   // Addon missing (should never happen in a real install): default to ESM for
   // format (the common case) and "no decorators" for the guard — the same fallback
   // the old oxc-parser-unavailable branches used.
-  if (!nubNative) return { hasValueEsmSyntax: true, hasDecorators: false };
+  if (!nubNative) return { hasValueEsmSyntax: true, hasDecorators: false, transformableSyntax: false };
   try {
     return nubNative.detectModuleInfo(filePath, source, lang);
   } catch {
     // Unparseable → CJS for format + no decorators (the transpile/V8 surfaces the
-    // real error), matching the old per-call catch blocks.
-    return { hasValueEsmSyntax: false, hasDecorators: false };
+    // real error), matching the old per-call catch blocks. `transformableSyntax:
+    // false` is the SAFE plain-JS default — the verbatim path hands the raw bytes
+    // back, so V8 surfaces the real syntax error exactly where Node would.
+    return { hasValueEsmSyntax: false, hasDecorators: false, transformableSyntax: false };
   }
 }
 
@@ -451,8 +462,8 @@ function detectModuleInfo(filePath, source, lang) {
 // full Node parity (`--experimental-detect-module`), so a CJS-syntax `.ts` with
 // no `type` runs as CJS on nub exactly as on Node. See wiki/runtime/module-format.md.
 export function moduleFormatFor(ext, pkgType, filePath, source) {
-  if (ext === ".mts") return "module";
-  if (ext === ".cts") return "commonjs";
+  if (ext === ".mts" || ext === ".mjs") return "module";
+  if (ext === ".cts" || ext === ".cjs") return "commonjs";
   if (pkgType === "module") return "module";
   if (pkgType === "commonjs") return "commonjs";
   const lang = ext === ".tsx" ? "tsx" : ext === ".jsx" ? "jsx" : "ts";
@@ -571,6 +582,26 @@ export function loadTranspile(url, ext) {
   const format = moduleFormatFor(ext, pkgType, filePath, source);
 
   const lang = ext === ".tsx" ? "tsx" : ext === ".jsx" ? "jsx" : "ts";
+
+  // ── Plain-JS byte-parity skip-gate ──────────────────────────────────
+  // Project `.js`/`.mjs`/`.cjs` is now in TRANSPILE_EXTS, but oxc REFORMATS no-op
+  // source (quotes/semicolons/whitespace) and always appends a sourcemap footer —
+  // a hard regression for every plain-JS file that has nothing to lower. So for
+  // plain JS only, ask the native verdict (computed on the SAME parse moduleFormatFor
+  // already runs for ambiguous `.js`): if the file contains NO target-gated syntax
+  // oxc would lower (`using`/`await using`, `v`-flag RegExp — `transformableSyntax`)
+  // AND no decorators (`hasDecorators` — the decorator path is handled below: legacy
+  // transforms it, Stage-3-off throws the guard), return the RAW source VERBATIM.
+  // No codegen, no footer, no cache write — byte-identical to the input, exactly as
+  // a non-transpiled `.js` is today. TS/JSX exts skip this gate (they always strip).
+  // JSX-in-.js is OUT of scope (lang is "ts", which does not parse JSX); use `.jsx`.
+  if (PLAIN_JS_EXTS.has(ext)) {
+    const info = detectModuleInfo(filePath, source, lang);
+    if (!info.transformableSyntax && !info.hasDecorators) {
+      return { format, source, shortCircuit: true };
+    }
+  }
+
   const opts = {
     lang,
     sourceType: format === "commonjs" ? "commonjs" : "module",

--- a/site/content/docs/runtime/typescript.mdx
+++ b/site/content/docs/runtime/typescript.mdx
@@ -38,6 +38,20 @@ You opt into the syntax by writing it; Nub makes it run.
 
 JSX and decorators each have their own page: see [JSX](/docs/runtime/jsx) for the `.jsx` / `.tsx` runtime and tsconfig configuration, and [Decorators](/docs/runtime/decorators) for the legacy `experimentalDecorators` form and `emitDecoratorMetadata`.
 
+## Plain JavaScript
+
+Your project's plain JavaScript — `.js`, `.mjs`, and `.cjs` — goes through the same pipeline. Modern syntax that Nub's Node floor can't parse natively is lowered exactly as it is in a `.ts` file, so identical source behaves the same whatever extension it carries: `using` / `await using`, a `v`-flag (unicode-sets) RegExp like `/\p{Letter}/v`, and decorators all run.
+
+```js
+// app.js — runs on every Node Nub supports
+using handle = openHandle();
+const letters = /\p{Letter}/v;
+```
+
+A file with nothing to lower is handed to Node untouched — byte for byte, no reformatting and no source-map footer — so a plain `.js` that needs no transform is exactly the file you wrote. Files inside `node_modules` are never transpiled; they load as the package shipped them, on every tier.
+
+JSX in a `.js` file is out of scope — use `.jsx`. Nub parses `.js` as JavaScript, not JSX, so a `<` is a comparison, not an element.
+
 ## Explicit resource management
 
 Explicit Resource Management — the `using` and `await using` declarations — runs on Nub's entire Node floor. Older Node (Node 22's V8) cannot parse `using` natively — it's a hard `SyntaxError` — so Nub's transpiler lowers it to the helper-based form before Node ever sees it.

--- a/tests/fixtures/project-js/cjs-format.cjs
+++ b/tests/fixtures/project-js/cjs-format.cjs
@@ -1,0 +1,6 @@
+// `.cjs` is always CommonJS regardless of package `type`. `module.exports` and the
+// CJS `require` only exist under the commonjs format, so a correct `.cjs` format
+// branch is what makes this run. (No transformable syntax → served verbatim, with
+// format=commonjs.)
+const isCjs = typeof module.exports === 'object' && typeof require === 'function'
+console.log('CJS:' + isCjs)

--- a/tests/fixtures/project-js/decorator.js
+++ b/tests/fixtures/project-js/decorator.js
@@ -1,0 +1,15 @@
+// A decorator in project `.js`. With no `experimentalDecorators` (Stage-3 mode,
+// the default), nub must surface its branded diagnostic — proving the decorator
+// trigger flags a `.js` for the transform path (NOT the verbatim skip), exactly as
+// it does for `.ts`. (There is no `package.json` `type` here, so this resolves as
+// CommonJS; the decorator detection runs before format matters.)
+function log(target, key, desc) {
+  return desc
+}
+class C {
+  @log
+  greet() {
+    return "hi"
+  }
+}
+console.log(new C().greet())

--- a/tests/fixtures/project-js/esm-format.mjs
+++ b/tests/fixtures/project-js/esm-format.mjs
@@ -1,0 +1,5 @@
+// `.mjs` is always ESM regardless of package `type`. Top-level `import.meta.url`
+// only works under the module format, so a correct `.mjs` format branch is what
+// makes this run. (No transformable syntax → served verbatim, but with format=module.)
+const isModule = typeof import.meta.url === 'string'
+console.log('MJS:' + isModule)

--- a/tests/fixtures/project-js/main-deps.js
+++ b/tests/fixtures/project-js/main-deps.js
@@ -1,0 +1,8 @@
+// Requires two node_modules deps (a plain dep + a pnpm `.pnpm`-store dep). Both
+// must load RAW — never transpiled — so their reformattable source survives and
+// `using`-as-identifier stays a valid CJS binding. The marks prove the dep bodies
+// ran unchanged.
+const depy = require('depy')
+const depz = require('depz')
+console.log('DEPY:' + depy.mark + ':' + depy.shape.a + depy.shape.b)
+console.log('DEPZ:' + depz.tag + ':' + depz.n.x)

--- a/tests/fixtures/project-js/node_modules/.pnpm/depz@1.0.0/node_modules/depz/index.js
+++ b/tests/fixtures/project-js/node_modules/.pnpm/depz@1.0.0/node_modules/depz/index.js
@@ -1,0 +1,4 @@
+// A dep living in pnpm's .pnpm virtual store. Its realpath still contains
+// /node_modules/, so isNodeModules() keeps it raw. Reformattable on purpose.
+const tag = 'depz-store'
+module.exports = { tag, n: { x: 9, } }

--- a/tests/fixtures/project-js/node_modules/.pnpm/depz@1.0.0/node_modules/depz/package.json
+++ b/tests/fixtures/project-js/node_modules/.pnpm/depz@1.0.0/node_modules/depz/package.json
@@ -1,0 +1,1 @@
+{ "name": "depz", "version": "1.0.0", "main": "index.js" }

--- a/tests/fixtures/project-js/node_modules/depy/helper.cjs
+++ b/tests/fixtures/project-js/node_modules/depy/helper.cjs
@@ -1,0 +1,4 @@
+// A .cjs file inside node_modules. Node has no native _extensions['.cjs'] handler,
+// so the classic require shim's bail must fall back to the .js handler — this file
+// must load RAW (never transpiled) on the compat tier. Reformattable on purpose.
+module.exports = { tag: 'depy-cjs', shape: { a: 1, } }

--- a/tests/fixtures/project-js/node_modules/depy/index.js
+++ b/tests/fixtures/project-js/node_modules/depy/index.js
@@ -1,6 +1,9 @@
 // A node_modules dep with reformattable formatting and `using` as a plain
 // identifier (valid in CJS). It must come back RAW: if nub transpiled it, the
 // single quotes / trailing comma would be normalized, and `mark` would expose it.
+// It also requires a sibling `.cjs` helper — exercising the classic require shim's
+// `.cjs` node_modules bail (Node has no native `_extensions['.cjs']`).
 const using = 'identifier-not-keyword'
-const mark = "depy:" + using
+const helper = require('./helper.cjs')
+const mark = "depy:" + using + ":" + helper.tag
 module.exports = { mark, shape: { a: 1, b: 2, } }

--- a/tests/fixtures/project-js/node_modules/depy/index.js
+++ b/tests/fixtures/project-js/node_modules/depy/index.js
@@ -1,0 +1,6 @@
+// A node_modules dep with reformattable formatting and `using` as a plain
+// identifier (valid in CJS). It must come back RAW: if nub transpiled it, the
+// single quotes / trailing comma would be normalized, and `mark` would expose it.
+const using = 'identifier-not-keyword'
+const mark = "depy:" + using
+module.exports = { mark, shape: { a: 1, b: 2, } }

--- a/tests/fixtures/project-js/node_modules/depy/package.json
+++ b/tests/fixtures/project-js/node_modules/depy/package.json
@@ -1,0 +1,1 @@
+{ "name": "depy", "version": "1.0.0", "main": "index.js" }

--- a/tests/fixtures/project-js/node_modules/depz
+++ b/tests/fixtures/project-js/node_modules/depz
@@ -1,0 +1,1 @@
+.pnpm/depz@1.0.0/node_modules/depz

--- a/tests/fixtures/project-js/noop.js
+++ b/tests/fixtures/project-js/noop.js
@@ -1,0 +1,12 @@
+// A no-op project `.js` with NOTHING oxc lowers at es2022 — single quotes, no
+// trailing semicolons, a trailing comma, blank lines, an object literal that oxc
+// would reflow. The skip-gate must return this VERBATIM (byte-for-byte): the test
+// reads `f.toString()` to prove nub never ran it through codegen (which would
+// normalize quotes/semicolons/whitespace and append a sourcemap footer).
+function f() {
+  const x = 'single'
+  const obj = { a: 1, b: 2, }
+  return x + obj.a
+}
+
+console.log('NOOP:' + JSON.stringify(f.toString()))

--- a/tests/fixtures/project-js/using.js
+++ b/tests/fixtures/project-js/using.js
@@ -1,0 +1,21 @@
+// Project-source plain `.js` using ES2026 explicit resource management. Raw
+// `using` is a SyntaxError on every supported Node's V8 (it is not yet shipped),
+// so this file proves nub down-levels project `.js` through the same pipeline as
+// `.ts` — the transformableSyntax skip-gate must flag it.
+class Handle {
+  constructor(name) {
+    this.name = name;
+  }
+  [Symbol.dispose]() {
+    console.log("close:" + this.name);
+  }
+}
+
+function run() {
+  using a = new Handle("a");
+  using b = new Handle("b");
+  console.log("open:" + a.name + "," + b.name);
+}
+
+run();
+console.log("using:done");

--- a/tests/fixtures/project-js/vflag-regexp.js
+++ b/tests/fixtures/project-js/vflag-regexp.js
@@ -1,0 +1,8 @@
+// A `v`-flag (unicode-sets, ES2024) RegExp literal in project `.js`. The raw
+// literal is a PARSE error on the compat-tier floor (Node 18.19's V8 predates the
+// `v` flag), which kills the whole module. oxc lowers `/…/v` to a `new RegExp(…)`
+// constructor at nub's es2022 target, so the module parses and runs everywhere the
+// V8 RegExp engine supports `v` (Node 20+). This is the trigger the design's
+// original verdict missed; without it this file fails to load on the floor.
+const re = /[\p{Letter}]/v;
+console.log("vflag:" + re.test("A"));

--- a/tests/fixtures/transpile-js-smoke/guard.cjs
+++ b/tests/fixtures/transpile-js-smoke/guard.cjs
@@ -1,0 +1,10 @@
+// PERMANENT REGRESSION GUARD — see the `js_transpilation_smoke_guard` test.
+// Same floor-proof shape as guard.js, for the `.cjs` extension: a `v`-flag RegExp
+// literal (raw parse error on the 18.19 floor) in an UNCALLED function. The module
+// only PARSES + prints the marker if nub transpiled this `.cjs`. Guards `.cjs`
+// membership in TRANSPILE_EXTS (and the classic require shim's `.cjs` handling).
+// DO NOT DELETE.
+function neverCalled() {
+  return /[\p{Letter}]/v;
+}
+console.log("SMOKE-CJS:ok");

--- a/tests/fixtures/transpile-js-smoke/guard.js
+++ b/tests/fixtures/transpile-js-smoke/guard.js
@@ -1,0 +1,14 @@
+// PERMANENT REGRESSION GUARD — see the `js_transpilation_smoke_guard` test.
+// A `v`-flag (ES2024 unicode-sets) RegExp literal is a hard PARSE error on the
+// compat-tier floor (Node 18.19's V8 predates the `v` flag) — raw, it kills the
+// whole module before any line runs. oxc lowers `/…/v` to a `new RegExp(…)`
+// constructor at nub's es2022 target, so a transpiled module PARSES and the marker
+// below executes — even on 18.19. The regex sits in an UNCALLED function so the
+// constructor never runs (V8 on 18.19 would reject the `v` flag at construction);
+// the guard is that the file PARSES + the marker prints, which only happens if nub
+// transpiled this `.js`. If `.js` ever falls out of TRANSPILE_EXTS, the marker
+// vanishes on the floor and this test fails. DO NOT DELETE.
+function neverCalled() {
+  return /[\p{Letter}]/v;
+}
+console.log("SMOKE-JS:ok");

--- a/tests/fixtures/transpile-js-smoke/guard.mjs
+++ b/tests/fixtures/transpile-js-smoke/guard.mjs
@@ -1,0 +1,14 @@
+// PERMANENT REGRESSION GUARD — see the `js_transpilation_smoke_guard` test.
+// `using` (ES2026 explicit resource management) is a hard SyntaxError on every
+// supported Node's V8 (it is not shipped natively below the host line), so this
+// `.mjs` ONLY runs if nub transpiled it. An ESM entry resolves the disposal helper
+// on EVERY tier including the 18.19 floor (the CJS-entry helper limitation does not
+// apply to ESM), so this is the floor-proof "a floor-breaking `.js`/`.mjs`/`.cjs`
+// executes" assertion. If `.mjs` ever falls out of TRANSPILE_EXTS, this throws.
+let out = [];
+{
+  using a = { [Symbol.dispose]() { out.push("a"); } };
+  using b = { [Symbol.dispose]() { out.push("b"); } };
+  out.push("body");
+}
+console.log("SMOKE-MJS:" + out.join(","));


### PR DESCRIPTION
Extends nub's transpile pipeline to project-source plain JavaScript (`.js`/`.mjs`/`.cjs`) so transformable syntax lowers uniformly regardless of file extension — closing the JS/TS transform divergence where identical source behaved differently by extension (a project `.js` using `using` broke on the floor while the same code in `.ts` worked).

## What changed

- **`.js`/`.mjs`/`.cjs` added to `TRANSPILE_EXTS`.** Project plain JS now routes through the same pipeline as `.ts`, lowering the three syntaxes oxc transforms at nub's `es2022` target.
- **Native `transformable_syntax` skip-gate.** A verdict riding the existing `detect_module_info` parse flags a plain-JS file as needing transpile iff it contains any of the three triggers: `using`/`await using` (es2026), `v`-flag unicode-sets RegExp literals (es2024), or decorators. The set is pinned to oxc `0.132.0`'s es2022 lowering set with a re-derive-on-bump comment.
- **Verbatim no-op path.** When the verdict is false, the raw source is returned byte-for-byte — no codegen, no sourcemap footer, no cache write. A plain `.js` with nothing to lower is exactly the file you wrote (oxc otherwise reformats quotes/semicolons/whitespace).
- **node_modules excluded at all four dispatch sites.** Added the missing node_modules bails to the two compat-tier sites (the classic `require.extensions` shim and the async-hooks load); the two fast-tier sites were already gated. Without these, every dependency `.js` would be transpiled.
- **`.mjs`→module / `.cjs`→commonjs format branches** added to `moduleFormatFor`.

JSX-in-`.js` is out of scope (use `.jsx`).

## Tests

New `project-js` fixture suite, verified on both tiers (fast Node 22.15, compat 18.19): `using` down-levels; the `v`-flag RegExp lowers (the trigger the original design missed); decorator-in-`.js` routes to the Stage-3 diagnostic; no-op `.js` is byte-identical and resolves the correct format; `.mjs`/`.cjs` format correctness; node_modules deps (a plain dep + a pnpm `.pnpm`-store dep) are never transpiled. Full integration suite green (160 passed); root + nub-native clippy (`--all-targets --all-features -D warnings`) and fmt clean.

Refs the worker-relative-specifier-resolution thread — extending the Worker raw-string rewrite to `.js`/`.mjs`/`.cjs` is the trivial follow-up now that project JS transpiles.

This is a runtime-behavior change touching every project's JS handling; holding for maintainer review.
