### PR TITLE
pm: honor bare pnpm_config_* registry env vars under a pnpm v11+ incumbent

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -965,6 +965,23 @@ pub(crate) fn parse_major_minor(version: &str) -> (Option<u64>, Option<u64>) {
     (major, minor)
 }
 
+/// Whether the project's incumbent pnpm is provably v11+, the major at which
+/// pnpm switched its env-var convention from `npm_config_*` to `pnpm_config_*`.
+/// Reads the declared `packageManager`/`devEngines` pin (`declared_pm_raw`,
+/// packageManager first) and requires the name to be LITERALLY "pnpm" — a
+/// non-pnpm or unknown declared name (or a fresh project with no declaration)
+/// yields `false`. An undeclared/unparseable version also yields `false`: the
+/// dominant v9/v10 base ignores `pnpm_config_*`, so off is the safe default.
+/// Mirrors `store_config_family::project_scalar_home`'s detection exactly.
+fn pnpm_incumbent_major_is_v11_plus() -> bool {
+    std::env::current_dir()
+        .ok()
+        .and_then(|cwd| nub_core::pm::resolve::declared_pm_raw(&cwd))
+        .and_then(|(name, version)| (name == "pnpm").then_some(version).flatten())
+        .and_then(|v| parse_major_minor(&v).0)
+        .is_some_and(|major| major >= 11)
+}
+
 /// Emit one dim warning line per graph-shaping field nub ignored under the
 /// active PM's dialect. Color-gated: dim only when stderr is a terminal (or
 /// `FORCE_COLOR` set) and `NO_COLOR` is unset; otherwise plain. Suppressed
@@ -1335,6 +1352,19 @@ pub(crate) fn engine_brand_preflight() {
         .map(|cwd| resolve_config_surface(&cwd))
         .unwrap_or(ConfigSurface::PnpmOrFresh);
     let read_branded_pnpm_config = matches!(surface, ConfigSurface::PnpmOrFresh);
+    // pnpm REVERSED its env-var convention at v11: pnpm ≤10 reads `npm_config_*`
+    // registry-client env vars and IGNORES `pnpm_config_*`; pnpm 11 reads
+    // `pnpm_config_*` / `PNPM_CONFIG_*` and IGNORES `npm_config_*`. Honor bare
+    // `pnpm_config_<registry-client-key>` (registry, proxies, TLS knobs) only
+    // under a provable pnpm-v11+ incumbent, so nub mirrors the project's actual
+    // pnpm. Detection matches `store_config_family::project_scalar_home`: the
+    // declared `packageManager`/`devEngines` pin, name LITERALLY "pnpm", major
+    // ≥ 11. Unknown/undeclared version → off (the dominant v9/v10 base ignores
+    // `pnpm_config_*`); the installed-PM `--version` probe and lockfile signal
+    // are intentionally not consulted (they'd only move an unknown off its
+    // already-correct default). `npm_config_*` keeps working universally.
+    let read_pnpm_config_env_registry =
+        read_branded_pnpm_config && pnpm_incumbent_major_is_v11_plus();
     let read_yarn_config = read_yarn_config_for_surface(&surface);
     // Classic Yarn (v1) reads `.yarnrc`; Yarn Berry (v2+) abandoned it for
     // `.yarnrc.yml` and ignores a stray legacy `.yarnrc`. Gate the engine's
@@ -1376,6 +1406,7 @@ pub(crate) fn engine_brand_preflight() {
         // enforced in store_config_family: `config set -g` never writes a
         // pnpm-branded global file.)
         c.read_pnpm_global_config = true;
+        c.read_pnpm_config_env_registry = read_pnpm_config_env_registry;
         c.read_yarn_config = read_yarn_config;
         c.yarn_is_classic = yarn_is_classic;
         c.read_bun_config = read_bun_config;

--- a/vendor/aube/crates/aube-registry/src/config.rs
+++ b/vendor/aube/crates/aube-registry/src/config.rs
@@ -24,7 +24,7 @@ pub(crate) use token::run_token_helper;
 pub(crate) use url::lookup_by_uri_prefix;
 
 #[cfg(test)]
-use env::{npm_config_env_entries_from, translate_npm_config_env};
+use env::npm_config_env_entries_from;
 #[cfg(test)]
 use load::{
     GlobalNpmrcPaths, expand_userconfig_path, load_npmrc_entries_tagged_with_globals,

--- a/vendor/aube/crates/aube-registry/src/config/env.rs
+++ b/vendor/aube/crates/aube-registry/src/config/env.rs
@@ -6,44 +6,94 @@
 /// via `aube_settings::resolved::*`, which consults its own env-var
 /// aliases. Env entries must be applied *after* `.npmrc` entries so
 /// last-write-wins gives env the higher precedence npm/pnpm document.
+///
+/// Reads [`EngineContext::read_pnpm_config_env_registry`] to decide whether
+/// bare `pnpm_config_<key>` / `PNPM_CONFIG_<KEY>` registry-client keys are
+/// honored too (pnpm v11+ incumbent only); off by default, so standalone
+/// aube and non-pnpm-v11 paths emit exactly the `npm_config_*` set as before.
+///
+/// [`EngineContext::read_pnpm_config_env_registry`]: aube_util::EngineContext::read_pnpm_config_env_registry
 pub(super) fn npm_config_env_entries_from(env: &[(String, String)]) -> Vec<(String, String)> {
+    let read_pnpm = aube_util::engine_context().read_pnpm_config_env_registry;
     let mut npm_scoped = Vec::new();
     let mut pnpm_scoped = Vec::new();
     let mut out = Vec::new();
+    let mut pnpm_out = Vec::new();
     for (name, value) in env {
         if value.is_empty() {
             continue;
         }
-        match translate_npm_config_env(name, value) {
+        // A `pnpm_config_`-prefixed source. Under the gate, real pnpm 11
+        // reads ONLY `pnpm_config_*` and ignores `npm_config_*`, so when both
+        // spell the same key the pnpm one must win deterministically — env
+        // iteration order is arbitrary, so a single `out` bucket would pick a
+        // nondeterministic winner. Route pnpm-prefixed entries to their own
+        // bucket appended LAST (last-write-wins → pnpm beats its npm twin),
+        // mirroring the `//`-auth two-bucket ordering below.
+        let is_pnpm_prefixed = name
+            .get(.."pnpm_config_".len())
+            .is_some_and(|p| p.eq_ignore_ascii_case("pnpm_config_"));
+        match translate_config_env(name, value, read_pnpm) {
             Some((key, value)) if key.starts_with("//") => {
-                if name
-                    .get(.."pnpm_config_".len())
-                    .is_some_and(|p| p.eq_ignore_ascii_case("pnpm_config_"))
-                {
+                if is_pnpm_prefixed {
                     pnpm_scoped.push((key, value));
                 } else {
                     npm_scoped.push((key, value));
                 }
             }
+            Some(entry) if is_pnpm_prefixed => pnpm_out.push(entry),
             Some(entry) => out.push(entry),
             None => {}
         }
     }
+    // Order (low → high precedence, last-write-wins): npm non-auth, pnpm
+    // non-auth, npm auth, pnpm auth. The auth buckets stay after the non-auth
+    // ones to preserve the existing auth-wins layering.
+    out.extend(pnpm_out);
     out.extend(npm_scoped);
     out.extend(pnpm_scoped);
     out
 }
 
-/// Map a single `npm_config_*` / `NPM_CONFIG_*` env var to the
-/// `.npmrc`-style `(key, value)` that [`NpmConfig::apply`] understands.
-/// Returns `None` for env vars unrelated to registry-client config —
-/// those are owned by the generic settings resolver. Pure function so
-/// tests can exercise the mapping without mutating `std::env`.
-pub(super) fn translate_npm_config_env(name: &str, value: &str) -> Option<(String, String)> {
+/// Map a single registry-client env var to the `.npmrc`-style `(key, value)`
+/// that [`NpmConfig::apply`] understands. Accepts the `npm_config_*` /
+/// `NPM_CONFIG_*` family unconditionally and the `//`-scoped-auth
+/// `pnpm_config_*` carve-out (upstream behavior). When `read_pnpm` is `true`
+/// (pnpm v11+ incumbent), it ALSO accepts bare `pnpm_config_<key>` /
+/// `PNPM_CONFIG_<KEY>` registry-client keys, mirroring pnpm 11's env reader
+/// (`config/reader/src/env.ts`): the suffix must be strictly snake_case in a
+/// single case — all-lowercase under `pnpm_config_`, all-uppercase under
+/// `PNPM_CONFIG_` — which is why neither the `//`-auth nor the
+/// `@scope:registry` form is reachable through this prefix on pnpm 11.
+///
+/// Returns `None` for env vars unrelated to registry-client config — those are
+/// owned by the generic settings resolver. Pure function (the embedder gate is
+/// passed in) so tests can exercise the mapping without mutating `std::env` or
+/// the engine context.
+pub(super) fn translate_config_env(
+    name: &str,
+    value: &str,
+    read_pnpm: bool,
+) -> Option<(String, String)> {
     let suffix = name
         .strip_prefix("npm_config_")
         .or_else(|| name.strip_prefix("NPM_CONFIG_"))
-        .or_else(|| strip_url_scoped_config_prefix(name))?;
+        .map(std::borrow::Cow::Borrowed)
+        .or_else(|| strip_url_scoped_config_prefix(name).map(std::borrow::Cow::Borrowed))
+        // pnpm v11+ only: bare `pnpm_config_<snake>` / `PNPM_CONFIG_<SNAKE>`.
+        // Returns the suffix already lowercased (pnpm camel-cases internally;
+        // the `.npmrc`-key match below lowercases too, so a lowercased suffix
+        // feeds it cleanly). The strict-snake gate keeps `//`-auth and
+        // `@scope:registry` forms out of this branch — exactly as pnpm 11
+        // rejects them — so they fall through to the existing
+        // `strip_url_scoped_config_prefix` carve-out (or to `None`).
+        .or_else(|| {
+            read_pnpm
+                .then(|| strip_bare_pnpm_config_prefix(name))
+                .flatten()
+                .map(std::borrow::Cow::Owned)
+        })?;
+    let suffix = suffix.as_ref();
     // Per-URI auth keys (e.g. `//registry.example.com/:_authToken`)
     // already carry `.npmrc` syntax in the env-var name. Pass them
     // through unchanged so `apply`'s `starts_with("//")` arm picks
@@ -74,7 +124,10 @@ pub(super) fn translate_npm_config_env(name: &str, value: &str) -> Option<(Strin
         "https_proxy" => "https-proxy",
         "http_proxy" => "http-proxy",
         "proxy" => "proxy",
-        "noproxy" => "noproxy",
+        // Both the collapsed `noproxy` and underscored `no_proxy` spellings:
+        // pnpm 11 kebab-cases the suffix, so `no_proxy` → `no-proxy` (a key
+        // in npm's config schema) is honored alongside the bare `noproxy`.
+        "noproxy" | "no_proxy" => "noproxy",
         "strict_ssl" => "strict-ssl",
         "local_address" => "local-address",
         "maxsockets" => "maxsockets",
@@ -153,6 +206,41 @@ fn is_url_scoped_env_auth_key(key: &str) -> bool {
     key.rsplit_once(':').is_some_and(|(_, suffix)| {
         matches!(suffix, "_authToken" | "_auth" | "username" | "_password")
     })
+}
+
+/// Strip a bare `pnpm_config_<suffix>` / `PNPM_CONFIG_<SUFFIX>` prefix,
+/// returning the suffix LOWERCASED, but only when the suffix is strictly
+/// snake_case in a SINGLE case — all-lowercase under the lowercase prefix,
+/// all-uppercase under the uppercase prefix. Mirrors pnpm 11's
+/// `getEnvKeySuffix` (`config/reader/src/env.ts`): pnpm accepts only those two
+/// forms (shell convention favors the uppercase spelling, and the v11
+/// migration guide renames `NPM_CONFIG_*` → `PNPM_CONFIG_*`), and rejects a
+/// mixed-case or non-snake suffix outright. The strict-snake gate is also what
+/// keeps the `//`-auth and `@scope:registry` shapes — which carry `/`, `:`,
+/// `@` — out of this branch, matching pnpm 11 (those forms are unreadable via
+/// `pnpm_config_*` there).
+fn strip_bare_pnpm_config_prefix(name: &str) -> Option<String> {
+    if let Some(suffix) = name.strip_prefix("pnpm_config_")
+        && is_snake_case(suffix, char::is_ascii_lowercase)
+    {
+        return Some(suffix.to_string());
+    }
+    if let Some(suffix) = name.strip_prefix("PNPM_CONFIG_")
+        && is_snake_case(suffix, char::is_ascii_uppercase)
+    {
+        return Some(suffix.to_ascii_lowercase());
+    }
+    None
+}
+
+/// A non-empty string whose `_`-separated segments are each non-empty and
+/// composed solely of ASCII digits plus letters accepted by `letter_ok`.
+/// Mirrors pnpm's `isLowerSnakeCase` / `isUpperSnakeCase`
+/// (`/^[a-z0-9]+$/` / `/^[A-Z0-9]+$/` per segment).
+fn is_snake_case(s: &str, letter_ok: impl Fn(&char) -> bool) -> bool {
+    !s.is_empty()
+        && s.split('_')
+            .all(|seg| !seg.is_empty() && seg.chars().all(|c| c.is_ascii_digit() || letter_ok(&c)))
 }
 /// Return the first set (and non-empty) env var in `names`. Used to
 /// read proxy config from both the upper- and lowercase spellings that

--- a/vendor/aube/crates/aube-registry/src/config/load.rs
+++ b/vendor/aube/crates/aube-registry/src/config/load.rs
@@ -348,6 +348,7 @@ pub fn load_npmrc_entries(project_dir: &Path) -> Vec<(String, String)> {
 struct NpmrcCacheKey {
     project_dir: PathBuf,
     read_branded_pnpm_config: bool,
+    read_pnpm_config_env_registry: bool,
     read_yarn_config: bool,
     synthetic_user_npmrc_entries: Vec<(String, String)>,
     synthetic_project_npmrc_entries: Vec<(String, String)>,
@@ -370,6 +371,7 @@ fn npmrc_cache_key(project_dir: &Path) -> NpmrcCacheKey {
     NpmrcCacheKey {
         project_dir: project_dir.to_path_buf(),
         read_branded_pnpm_config: ctx.read_branded_pnpm_config,
+        read_pnpm_config_env_registry: ctx.read_pnpm_config_env_registry,
         read_yarn_config: ctx.read_yarn_config,
         synthetic_user_npmrc_entries: ctx.synthetic_user_npmrc_entries,
         synthetic_project_npmrc_entries: ctx.synthetic_project_npmrc_entries,

--- a/vendor/aube/crates/aube-registry/src/config/tests.rs
+++ b/vendor/aube/crates/aube-registry/src/config/tests.rs
@@ -4,6 +4,14 @@ use base64::Engine as _;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+/// The registry-client env mapping with the pnpm-v11 bare-key track OFF — the
+/// upstream-neutral path (`npm_config_*` + the `//`-auth `pnpm_config_*`
+/// carve-out). Keeps the long-standing `npm_config_*` mapping tests reading
+/// cleanly; the gated bare-`pnpm_config_*` behavior is exercised separately.
+fn translate_config_env_compat(name: &str, value: &str) -> Option<(String, String)> {
+    super::env::translate_config_env(name, value, false)
+}
+
 /// Serializes the auth.ini tests that touch the process-global
 /// `engine_context().read_branded_pnpm_config` gate, so the toggle test's
 /// disabled-window can't race a concurrent auth.ini read that assumes the
@@ -3019,16 +3027,16 @@ fn translate_npm_config_env_maps_default_registry() {
     // `NPM_CONFIG_REGISTRY aube install` works; this is the hook
     // that makes it true.
     assert_eq!(
-        translate_npm_config_env("NPM_CONFIG_REGISTRY", "https://r.example/"),
+        translate_config_env_compat("NPM_CONFIG_REGISTRY", "https://r.example/"),
         Some(("registry".to_string(), "https://r.example/".to_string()))
     );
     assert_eq!(
-        translate_npm_config_env("npm_config_registry", "https://r.example/"),
+        translate_config_env_compat("npm_config_registry", "https://r.example/"),
         Some(("registry".to_string(), "https://r.example/".to_string()))
     );
     // Non-npm env vars are ignored so the entry list stays tight
     // and `apply` isn't fed noise.
-    assert_eq!(translate_npm_config_env("HOME", "/tmp"), None);
+    assert_eq!(translate_config_env_compat("HOME", "/tmp"), None);
 }
 
 #[test]
@@ -3048,7 +3056,7 @@ fn translate_npm_config_env_maps_proxy_and_tls_knobs() {
     ];
     for (name, value, expected_key) in cases {
         assert_eq!(
-            translate_npm_config_env(name, value),
+            translate_config_env_compat(name, value),
             Some((expected_key.to_string(), value.to_string())),
             "mapping failed for {name}"
         );
@@ -3061,14 +3069,14 @@ fn translate_npm_config_env_maps_scoped_registry() {
     // lowercase canonical `@myorg:registry` key that `apply`
     // matches via `strip_suffix(":registry")`.
     assert_eq!(
-        translate_npm_config_env("NPM_CONFIG_@MYORG:REGISTRY", "https://r.mycorp/"),
+        translate_config_env_compat("NPM_CONFIG_@MYORG:REGISTRY", "https://r.mycorp/"),
         Some((
             "@myorg:registry".to_string(),
             "https://r.mycorp/".to_string()
         ))
     );
     assert_eq!(
-        translate_npm_config_env("npm_config_@myorg:registry", "https://r.mycorp/"),
+        translate_config_env_compat("npm_config_@myorg:registry", "https://r.mycorp/"),
         Some((
             "@myorg:registry".to_string(),
             "https://r.mycorp/".to_string()
@@ -3082,7 +3090,7 @@ fn translate_npm_config_env_passes_uri_auth_through_verbatim() {
     // Passthrough preserves the `_authToken` casing that `apply`
     // matches inside its `starts_with("//")` branch.
     assert_eq!(
-        translate_npm_config_env(
+        translate_config_env_compat(
             "NPM_CONFIG_//registry.example.com/:_authToken",
             "secret-token"
         ),
@@ -3096,7 +3104,7 @@ fn translate_npm_config_env_passes_uri_auth_through_verbatim() {
 #[test]
 fn translate_npm_config_env_passes_pnpm_uri_auth_through_verbatim() {
     assert_eq!(
-        translate_npm_config_env(
+        translate_config_env_compat(
             "PNPM_CONFIG_//registry.example.com/:_authToken",
             "secret-token"
         ),
@@ -3130,12 +3138,149 @@ fn npm_config_env_entries_pnpm_uri_auth_wins_over_npm_uri_auth() {
 #[test]
 fn translate_npm_config_env_ignores_uri_token_helper() {
     assert_eq!(
-        translate_npm_config_env(
+        translate_config_env_compat(
             "pnpm_config_//registry.example.com/:tokenHelper",
             "/tmp/helper"
         ),
         None
     );
+}
+
+/// Serializes the tests that flip the process-global
+/// `engine_context().read_pnpm_config_env_registry` gate so a window can't race
+/// a concurrent load assuming the upstream default (off).
+static PNPM_CONFIG_ENV_GATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[test]
+fn translate_config_env_ignores_bare_pnpm_keys_when_gate_off() {
+    // Upstream / non-pnpm-v11 path: bare `pnpm_config_<key>` registry-client
+    // keys are another tool's convention and are NOT mapped. Only `npm_config_*`
+    // and the `//`-auth `pnpm_config_*` carve-out apply (covered above).
+    for name in [
+        "pnpm_config_registry",
+        "PNPM_CONFIG_REGISTRY",
+        "pnpm_config_strict_ssl",
+        "pnpm_config_https_proxy",
+    ] {
+        assert_eq!(
+            super::env::translate_config_env(name, "x", false),
+            None,
+            "{name} must be ignored when the pnpm-v11 gate is off"
+        );
+    }
+}
+
+#[test]
+fn translate_config_env_maps_bare_pnpm_keys_when_gate_on() {
+    // pnpm v11+ incumbent: bare `pnpm_config_<key>` / `PNPM_CONFIG_<KEY>` land
+    // on the same canonical `.npmrc` keys as their `npm_config_*` twins. The key
+    // set mirrors real pnpm 11.9 (`config/reader/src/env.ts` is generic over the
+    // settings schema; these are the registry-client members probed against it).
+    let cases = [
+        ("pnpm_config_registry", "https://r.ex/", "registry"),
+        ("PNPM_CONFIG_REGISTRY", "https://r.ex/", "registry"),
+        ("pnpm_config_proxy", "http://p:0", "proxy"),
+        ("pnpm_config_https_proxy", "http://p:8", "https-proxy"),
+        ("pnpm_config_http_proxy", "http://p:9", "http-proxy"),
+        ("pnpm_config_noproxy", "a.com,b.com", "noproxy"),
+        // pnpm 11 kebab-cases the suffix, so the underscored `no_proxy` spelling
+        // maps to the same `noproxy` key as the collapsed form.
+        ("pnpm_config_no_proxy", "c.com", "noproxy"),
+        ("pnpm_config_strict_ssl", "false", "strict-ssl"),
+        ("PNPM_CONFIG_STRICT_SSL", "false", "strict-ssl"),
+        ("pnpm_config_local_address", "1.2.3.4", "local-address"),
+        ("pnpm_config_maxsockets", "7", "maxsockets"),
+    ];
+    for (name, value, expected_key) in cases {
+        assert_eq!(
+            super::env::translate_config_env(name, value, true),
+            Some((expected_key.to_string(), value.to_string())),
+            "bare pnpm mapping failed for {name}"
+        );
+    }
+}
+
+#[test]
+fn translate_config_env_rejects_non_snake_pnpm_suffix() {
+    // pnpm 11's env reader requires a strictly snake_case suffix in a SINGLE
+    // case (`getEnvKeySuffix` → `isLowerSnakeCase`/`isUpperSnakeCase`). So a
+    // mixed-case suffix, and the `@scope:registry` / `//`-auth shapes (which
+    // carry `@`/`:`/`/`), are NOT readable via the bare `pnpm_config_` prefix —
+    // matching pnpm 11, which rejects them too. (`//`-auth still flows through
+    // the dedicated url-scoped carve-out, asserted separately above.)
+    for name in [
+        "PNPM_CONFIG_Strict_Ssl",      // mixed case
+        "pnpm_config_STRICT_SSL",      // upper suffix under lower prefix
+        "pnpm_config_@myorg:registry", // scoped registry: not snake
+        "pnpm_config_strict-ssl",      // hyphen, not underscore
+    ] {
+        assert_eq!(
+            super::env::translate_config_env(name, "false", true),
+            None,
+            "{name} must be rejected as non-snake under the pnpm prefix"
+        );
+    }
+}
+
+#[test]
+fn load_with_env_honors_bare_pnpm_config_registry_only_when_gate_on() {
+    let _guard = PNPM_CONFIG_ENV_GATE_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        "registry=https://file.registry.example/\n",
+    )
+    .unwrap();
+    let env = vec![(
+        "pnpm_config_registry".to_string(),
+        "https://pnpm.registry.example/".to_string(),
+    )];
+
+    // Off (pnpm ≤10 / non-pnpm / unknown): `pnpm_config_registry` is ignored,
+    // the project `.npmrc` registry stands — matching real pnpm 10.
+    aube_util::update_engine_context(|c| c.read_pnpm_config_env_registry = false);
+    let disabled = NpmConfig::load_with_env(dir.path(), &env);
+    assert_eq!(disabled.registry, "https://file.registry.example/");
+
+    // On (pnpm v11+ incumbent): `pnpm_config_registry` wins over the project
+    // file (env beats file in pnpm) — matching real pnpm 11.9.
+    aube_util::update_engine_context(|c| c.read_pnpm_config_env_registry = true);
+    let enabled = NpmConfig::load_with_env(dir.path(), &env);
+    aube_util::update_engine_context(|c| c.read_pnpm_config_env_registry = false);
+    assert_eq!(enabled.registry, "https://pnpm.registry.example/");
+}
+
+#[test]
+fn npm_config_env_entries_pnpm_registry_deterministically_beats_npm_when_gate_on() {
+    let _guard = PNPM_CONFIG_ENV_GATE_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    // Both prefixes set the same non-auth key. Real pnpm 11 reads ONLY
+    // `pnpm_config_*` and ignores `npm_config_*`, so the pnpm value must win
+    // deterministically regardless of env iteration order. The entries are
+    // applied last-write-wins, so the pnpm-prefixed entry must come LAST.
+    let env = [
+        (
+            "npm_config_registry".to_string(),
+            "https://npm.example/".to_string(),
+        ),
+        (
+            "pnpm_config_registry".to_string(),
+            "https://pnpm.example/".to_string(),
+        ),
+    ];
+    aube_util::update_engine_context(|c| c.read_pnpm_config_env_registry = true);
+    let entries = super::env::npm_config_env_entries_from(&env);
+    aube_util::update_engine_context(|c| c.read_pnpm_config_env_registry = false);
+    // pnpm-prefixed registry is the last `registry` entry → wins on apply.
+    let last_registry = entries
+        .iter()
+        .rev()
+        .find(|(k, _)| k == "registry")
+        .map(|(_, v)| v.as_str());
+    assert_eq!(last_registry, Some("https://pnpm.example/"));
 }
 
 /// Serializes the tests that flip the process-global
@@ -3291,7 +3436,7 @@ fn env_registry_overrides_project_npmrc() {
     assert_eq!(config.registry, "https://file.registry/");
     // Emulate the `load_npm_config_env_entries` output for
     // `NPM_CONFIG_REGISTRY=https://env.registry/`.
-    let env = translate_npm_config_env("NPM_CONFIG_REGISTRY", "https://env.registry/")
+    let env = translate_config_env_compat("NPM_CONFIG_REGISTRY", "https://env.registry/")
         .map(|e| vec![e])
         .unwrap_or_default();
     config.apply(env);

--- a/vendor/aube/crates/aube-util/src/engine_context.rs
+++ b/vendor/aube/crates/aube-util/src/engine_context.rs
@@ -108,6 +108,31 @@ pub struct EngineContext {
     /// concern, not this read gate.)
     pub read_pnpm_global_config: bool,
 
+    /// Whether aube honors bare `pnpm_config_<registry-client-key>` /
+    /// `PNPM_CONFIG_<REGISTRY_CLIENT_KEY>` environment variables on the
+    /// registry-client config track — the default `registry`, the proxies,
+    /// the TLS knobs, `maxsockets`, `local-address`. `false` (default)
+    /// preserves upstream aube behavior: only `npm_config_*` / `NPM_CONFIG_*`
+    /// set these registry-client keys, and the `pnpm_config_` prefix is
+    /// stripped solely for `//`-scoped per-URI auth keys.
+    ///
+    /// pnpm REVERSED its env-var convention at v11: pnpm ≤10 reads
+    /// `npm_config_*` and ignores `pnpm_config_*`; pnpm 11 reads
+    /// `pnpm_config_*` / `PNPM_CONFIG_*` (its general settings env, see
+    /// pnpm's `config/reader/src/env.ts`) and ignores `npm_config_*`. An
+    /// embedder whose active PM is provably **pnpm v11+** sets this `true`
+    /// so the registry-client track mirrors pnpm 11; under any earlier pnpm,
+    /// any other PM, nub identity, or standalone aube it stays `false`.
+    ///
+    /// Scope note: this gates ONLY the registry-client track in
+    /// `aube-registry`. The GENERIC settings family (`aube-settings`, e.g.
+    /// `pnpm_config_auto_install_peers`) has its own `pnpm_config_*` aliases
+    /// gated separately by [`read_branded_pnpm_config`](Self::read_branded_pnpm_config).
+    /// pnpm 11's env reader requires a strictly snake_case suffix, so the
+    /// `//`-auth and `@scope:registry` forms are NOT readable via
+    /// `pnpm_config_*` on pnpm 11 — only the bare single/`_`-joined keys are.
+    pub read_pnpm_config_env_registry: bool,
+
     /// Whether aube reads Yarn Berry's `.yarnrc.yml` config surface and
     /// translates the subset that maps cleanly onto the existing npmrc-shaped
     /// registry/settings model. `false` (default) preserves upstream aube
@@ -233,6 +258,7 @@ impl Default for EngineContext {
             trusted_dependencies_honored: true,
             read_branded_pnpm_config: true,
             read_pnpm_global_config: true,
+            read_pnpm_config_env_registry: false,
             read_yarn_config: false,
             yarn_is_classic: false,
             read_bun_config: false,
@@ -297,6 +323,7 @@ mod tests {
         assert!(ctx.trusted_dependencies_honored);
         assert!(ctx.read_branded_pnpm_config);
         assert!(ctx.read_pnpm_global_config);
+        assert!(!ctx.read_pnpm_config_env_registry);
         assert!(!ctx.read_yarn_config);
         assert!(!ctx.yarn_is_classic);
         assert!(!ctx.read_bun_config);


### PR DESCRIPTION
## What

pnpm reversed its env-var convention at v11. pnpm ≤10 reads `npm_config_*` registry-client env vars and ignores `pnpm_config_*`; pnpm 11 reads `pnpm_config_*` / `PNPM_CONFIG_*` (its general settings env, `config/reader/src/env.ts`) and ignores `npm_config_*`. nub already honored `npm_config_*` fully and the `//`-scoped-auth `pnpm_config_*` carve-out, but bare registry-client keys in `pnpm_config_` form — `registry`, the proxies, `strict-ssl`, `maxsockets`, `local-address` — were silently dropped. Under a pnpm 11 project that set `pnpm_config_registry`, nub installed from the wrong registry.

## How

A default-preserving aube embedder seam: a new `EngineContext` field `read_pnpm_config_env_registry` (default `false` = upstream-neutral) gates bare `pnpm_config_<key>` / `PNPM_CONFIG_<KEY>` translation on the registry-client track. It mirrors pnpm 11's env reader exactly — a strictly snake_case suffix in a single case (`pnpm_config_<lower_snake>` or `PNPM_CONFIG_<UPPER_SNAKE>`), so the `//`-auth and `@scope:registry` forms stay unreachable through this prefix, as on pnpm 11.

nub sets the flag only under a provable **pnpm v11+ incumbent** (declared `packageManager` / `devEngines`, name literally `pnpm`, major ≥ 11; unknown/undeclared → off). When both prefixes set the same non-auth key, the pnpm-prefixed entry wins deterministically.

Standalone aube, pnpm ≤10, npm, yarn, bun, and nub identity are byte-identical (flag off). `npm_config_*` keeps working universally.

**Fork-discipline:** default-preserving — the new field defaults to the upstream-neutral path; standalone aube reads no new env vars. Additive and upstreamable to jdx/aube.

## Verification

- 276 `aube-registry` lib tests pass (new: gate-off ignores, gate-on mapping incl. both casings + `no_proxy`, non-snake rejection, env-beats-file load, deterministic pnpm-over-npm precedence). `clippy --all-targets`/`fmt` clean on both workspaces.
- E2E differential vs real binaries (install/resolution path):
  - pnpm@11 incumbent + `pnpm_config_registry=<bogus>` → nub resolves from the bogus registry (honored). Matches real pnpm 11.
  - pnpm@10 incumbent + `pnpm_config_registry=<bogus>` → ignored, installs from npmjs. Matches real pnpm 10.
  - pnpm@10 incumbent + `npm_config_registry=<bogus>` → honored (npm_config universal).
  - fresh project → ignored.
  - pnpm@11 + both `npm_config_registry` and `pnpm_config_registry` → pnpm wins.

Empirically grounded against pnpm 11.5/11.9 and pnpm 10.15.

Refs: pnpm-config-env-support, verify-pm-field-support

https://claude.ai/code/session_012YwF7yWjrXcj3bVJ1TziHK
