### PR TITLE
fix(pm): link yarn workspace members into the consumer's node_modules

### DIFF
--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -468,3 +468,81 @@ fn prefer_offline_does_not_trip_the_yarn_offline_mirror_fatal() {
     // by the yarn gate / install path, never the mirror preflight.
     let _ = code_prefer;
 }
+
+/// Workspace-member linking under a YARN incumbent. A classic yarn.lock never
+/// records workspace members (they aren't registry packages), so a member that
+/// depends on a SIBLING member has no resolution entry. nub must still symlink
+/// the sibling into the consumer's node_modules so it resolves — matching what
+/// reference yarn does (and what nub already does under pnpm/npm incumbents).
+///
+/// No network: every dep is a local member, the yarn.lock is empty, and the
+/// install is a frozen read (yarn.lock left byte-identical). Before the fix
+/// nub printed "✓ Already up to date" and linked nothing, so `@x/app` could not
+/// resolve `@x/utils`. The differential reference (real yarn 1.x links both)
+/// lives in `.fray/yarn-workspace-member-linking.md`; this guards the nub side.
+#[test]
+fn install_links_yarn_workspace_member_into_consumer() {
+    let dir = pm_tmpdir("yarn-ws-link");
+    // Root: a yarn incumbent (packageManager + an on-disk yarn.lock), workspaces.
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{ "name": "root", "private": true, "packageManager": "yarn@1.13.0", "workspaces": ["packages/*"] }"#,
+    )
+    .unwrap();
+    // An empty-but-valid classic yarn.lock — the members are the only deps, so
+    // it genuinely satisfies the manifest (no drift, no write).
+    std::fs::write(dir.join("yarn.lock"), "# yarn lockfile v1\n").unwrap();
+    for (member, body, index) in [
+        (
+            "utils",
+            r#"{ "name": "@x/utils", "version": "1.0.0", "main": "index.js" }"#,
+            "module.exports = 'utils-ok';",
+        ),
+        (
+            "app",
+            r#"{ "name": "@x/app", "version": "1.0.0", "dependencies": { "@x/utils": "1.0.0" } }"#,
+            "console.log(require('@x/utils'));",
+        ),
+    ] {
+        let mdir = dir.join("packages").join(member);
+        std::fs::create_dir_all(&mdir).unwrap();
+        std::fs::write(mdir.join("package.json"), body).unwrap();
+        std::fs::write(mdir.join("index.js"), index).unwrap();
+    }
+
+    let (stdout, stderr, code) = run_install(&dir, &["install"]);
+    assert_eq!(code, 0, "install must succeed: {stdout}{stderr}");
+
+    // The sibling must be linked where node resolves it from the consumer.
+    // nub's isolated linker hoists into the consumer's own node_modules
+    // (`packages/app/node_modules/@x/utils`), the same shape it produces under a
+    // pnpm incumbent; reference yarn hoists to the top level. Either resolves —
+    // assert the resolution outcome, the contract, not the exact hoist site.
+    let app = dir.join("packages").join("app");
+    let resolved = Command::new("node")
+        .args(["-e", "process.stdout.write(require.resolve('@x/utils'))"])
+        .current_dir(&app)
+        .output()
+        .expect("failed to spawn node");
+    assert!(
+        resolved.status.success(),
+        "`@x/utils` must resolve from `@x/app` after install — it did not.\n\
+         stdout: {}\nstderr: {}\ninstall said: {stdout}{stderr}",
+        String::from_utf8_lossy(&resolved.stdout),
+        String::from_utf8_lossy(&resolved.stderr),
+    );
+    // And it must resolve to the local member, not a stray copy.
+    let resolved_path = String::from_utf8_lossy(&resolved.stdout);
+    assert!(
+        std::fs::canonicalize(resolved_path.trim()).unwrap()
+            == std::fs::canonicalize(dir.join("packages/utils/index.js")).unwrap(),
+        "`@x/utils` must resolve to the local member, got: {resolved_path}"
+    );
+
+    // yarn.lock is read-only — the install must not have rewritten it.
+    assert_eq!(
+        std::fs::read_to_string(dir.join("yarn.lock")).unwrap(),
+        "# yarn lockfile v1\n",
+        "yarn.lock must be byte-identical after a read-only workspace install"
+    );
+}

--- a/vendor/aube/crates/aube-lockfile/src/yarn/classic.rs
+++ b/vendor/aube/crates/aube-lockfile/src/yarn/classic.rs
@@ -128,27 +128,92 @@ pub(super) fn parse_classic_str(
         }
     }
 
-    // Build direct deps from the manifest, cross-referencing against spec_to_dep_path.
+    // Discover the workspace members once, up front, so both the root
+    // and member importers can recognize a dep on a SIBLING member.
+    // Classic yarn.lock never records workspace members (they aren't
+    // registry packages), so a member-to-member dependency is absent
+    // from `spec_to_dep_path` and would otherwise be dropped — the
+    // consumer then never gets the sibling symlinked into node_modules.
+    // `member_versions` maps each member's package name → its on-disk
+    // version; `member_manifests` carries the parsed manifests forward
+    // so we don't re-read them when building each member's importer.
+    let project_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut member_versions: BTreeMap<String, String> = BTreeMap::new();
+    let mut member_manifests: Vec<(String, aube_manifest::PackageJson)> = Vec::new();
+    if let Some(workspaces) = &manifest.workspaces {
+        for member_dir in discover_workspace_members(project_dir, workspaces.patterns()) {
+            let member_pj_path = project_dir.join(&member_dir).join("package.json");
+            let Ok(member_pj) = aube_manifest::PackageJson::from_path(&member_pj_path) else {
+                continue;
+            };
+            if let Some(name) = &member_pj.name {
+                member_versions.insert(
+                    name.clone(),
+                    member_pj.version.clone().unwrap_or_else(|| "0.0.0".into()),
+                );
+            }
+            member_manifests.push((member_dir, member_pj));
+        }
+    }
+
+    // A dep on a workspace SIBLING links to the local member rather than
+    // a registry tarball. Mirror the resolver's `try_workspace_link`
+    // (aube-resolver `driver.rs`): a `workspace:`/`link:`/`portal:` spec
+    // binds unconditionally for the `*`/`^`/`~`/empty sigils, and a bare
+    // semver range binds when the member's version satisfies it. We emit
+    // a DirectDep whose `dep_path` (`name@version`) has NO entry in
+    // `packages` — the convention the linker keys on to symlink the
+    // sibling dir (`aube-linker` link.rs: `workspace_dirs.contains_key`
+    // && `!graph.packages.contains_key(dep_path)`). The real yarn.lock
+    // entry, when one exists (a member that is ALSO published), still
+    // wins via the `spec_to_dep_path` path checked first by the callers.
+    let workspace_link = |name: &str, range: &str| -> Option<String> {
+        let version = member_versions.get(name)?;
+        let matches = match range
+            .strip_prefix("workspace:")
+            .or_else(|| range.strip_prefix("link:"))
+            .or_else(|| range.strip_prefix("portal:"))
+        {
+            Some("" | "*" | "^" | "~") => true,
+            // `link:`/`portal:` to a member binds by name; the path tail
+            // is the on-disk location, not a version constraint.
+            Some(_) if range.starts_with("link:") || range.starts_with("portal:") => true,
+            Some(rest) => version_satisfies(version, rest),
+            None if range.is_empty() || range == "*" => true,
+            None => version_satisfies(version, range),
+        };
+        matches.then(|| format!("{name}@{version}"))
+    };
+
+    // Build direct deps from the manifest, cross-referencing against
+    // spec_to_dep_path; falling back to a workspace-sibling link.
     let mut direct: Vec<DirectDep> = Vec::new();
-    let push_direct = |name: &str, range: &str, dep_type: DepType, direct: &mut Vec<DirectDep>| {
+    let push_dep = |name: &str, range: &str, dep_type: DepType, into: &mut Vec<DirectDep>| {
         let spec = format!("{name}@{range}");
         if let Some(dep_path) = spec_to_dep_path.get(&spec) {
-            direct.push(DirectDep {
+            into.push(DirectDep {
                 name: name.to_string(),
                 dep_path: dep_path.clone(),
                 dep_type,
-                specifier: None,
+                specifier: Some(range.to_string()),
+            });
+        } else if let Some(dep_path) = workspace_link(name, range) {
+            into.push(DirectDep {
+                name: name.to_string(),
+                dep_path,
+                dep_type,
+                specifier: Some(range.to_string()),
             });
         }
     };
     for (name, range) in &manifest.dependencies {
-        push_direct(name, range, DepType::Production, &mut direct);
+        push_dep(name, range, DepType::Production, &mut direct);
     }
     for (name, range) in &manifest.dev_dependencies {
-        push_direct(name, range, DepType::Dev, &mut direct);
+        push_dep(name, range, DepType::Dev, &mut direct);
     }
     for (name, range) in &manifest.optional_dependencies {
-        push_direct(name, range, DepType::Optional, &mut direct);
+        push_dep(name, range, DepType::Optional, &mut direct);
     }
 
     let mut importers = BTreeMap::new();
@@ -161,39 +226,22 @@ pub(super) fn parse_classic_str(
     // yarn-source workspace converts to a single lone `.` importer and
     // the target PM frozen-rejects (pnpm ERR_PNPM_OUTDATED_LOCKFILE on a
     // child package.json, npm "Missing" members, bun "lockfile had
-    // changes"). Discover each member from the globs + disk and build
-    // its importer, cross-referencing its declared ranges against the
-    // flat resolution list the same way the root importer is built.
-    if let Some(workspaces) = &manifest.workspaces {
-        let project_dir = path.parent().unwrap_or_else(|| Path::new("."));
-        for member_dir in discover_workspace_members(project_dir, workspaces.patterns()) {
-            let member_pj_path = project_dir.join(&member_dir).join("package.json");
-            let Ok(member_pj) = aube_manifest::PackageJson::from_path(&member_pj_path) else {
-                continue;
-            };
-            let mut member_direct: Vec<DirectDep> = Vec::new();
-            let mut push_member = |name: &str, range: &str, dep_type: DepType| {
-                let spec = format!("{name}@{range}");
-                if let Some(dep_path) = spec_to_dep_path.get(&spec) {
-                    member_direct.push(DirectDep {
-                        name: name.to_string(),
-                        dep_path: dep_path.clone(),
-                        dep_type,
-                        specifier: Some(range.to_string()),
-                    });
-                }
-            };
-            for (name, range) in &member_pj.dependencies {
-                push_member(name, range, DepType::Production);
-            }
-            for (name, range) in &member_pj.dev_dependencies {
-                push_member(name, range, DepType::Dev);
-            }
-            for (name, range) in &member_pj.optional_dependencies {
-                push_member(name, range, DepType::Optional);
-            }
-            importers.insert(member_dir, member_direct);
+    // changes"). Build each member's importer from the manifests
+    // gathered above, cross-referencing its declared ranges against the
+    // flat resolution list — and against the workspace siblings — the
+    // same way the root importer is built.
+    for (member_dir, member_pj) in &member_manifests {
+        let mut member_direct: Vec<DirectDep> = Vec::new();
+        for (name, range) in &member_pj.dependencies {
+            push_dep(name, range, DepType::Production, &mut member_direct);
         }
+        for (name, range) in &member_pj.dev_dependencies {
+            push_dep(name, range, DepType::Dev, &mut member_direct);
+        }
+        for (name, range) in &member_pj.optional_dependencies {
+            push_dep(name, range, DepType::Optional, &mut member_direct);
+        }
+        importers.insert(member_dir.clone(), member_direct);
     }
 
     Ok(LockfileGraph {
@@ -201,6 +249,22 @@ pub(super) fn parse_classic_str(
         packages,
         ..Default::default()
     })
+}
+
+/// Does `version` satisfy the semver `range`? An empty/whitespace range
+/// means "any" (npm/yarn/pnpm treat it as `*`; `node_semver` rejects it).
+/// Mirrors the resolver's `version_satisfies` for the workspace-link
+/// match — a bare uncached parse, since the workspace-sibling path runs
+/// only over the handful of member-to-member deps, not a resolver hot loop.
+fn version_satisfies(version: &str, range: &str) -> bool {
+    let range = if range.trim().is_empty() { "*" } else { range };
+    let (Ok(v), Ok(r)) = (
+        node_semver::Version::parse(version),
+        node_semver::Range::parse(range),
+    ) else {
+        return false;
+    };
+    v.satisfies(&r)
 }
 
 /// Expand the root manifest's `workspaces` globs against the on-disk

--- a/vendor/aube/crates/aube-lockfile/src/yarn/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/yarn/tests.rs
@@ -674,6 +674,127 @@ fn test_parse_berry_skips_workspace_root() {
     assert!(!graph.packages.contains_key("my-project@0.0.0-use.local"));
 }
 
+/// A classic yarn.lock never records workspace members (they aren't
+/// registry packages), so a member that depends on a SIBLING member has
+/// no resolution entry to cross-reference. The reconstructed member
+/// importer must still carry that sibling as a workspace-link DirectDep
+/// — a `dep_path` (`name@version`) with NO `packages` entry — so the
+/// linker symlinks the sibling into the consumer's node_modules. Before
+/// the fix the dep was silently dropped and the consumer couldn't
+/// resolve it (the yarn-incumbent bug).
+#[test]
+fn test_classic_member_links_workspace_sibling() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{ "name": "root", "private": true, "workspaces": ["packages/*"] }"#,
+    )
+    .unwrap();
+    for (member, body) in [
+        (
+            "app",
+            r#"{ "name": "@x/app", "version": "1.0.0", "dependencies": { "@x/utils": "1.0.0" } }"#,
+        ),
+        ("utils", r#"{ "name": "@x/utils", "version": "1.0.0" }"#),
+    ] {
+        let mdir = root.join("packages").join(member);
+        std::fs::create_dir_all(&mdir).unwrap();
+        std::fs::write(mdir.join("package.json"), body).unwrap();
+    }
+    // A genuinely empty classic lockfile — the members are the only deps.
+    let lock = root.join("yarn.lock");
+    std::fs::write(&lock, "# yarn lockfile v1\n").unwrap();
+
+    let manifest = aube_manifest::PackageJson::from_path(&root.join("package.json")).unwrap();
+    let graph = parse(&lock, &manifest).unwrap();
+
+    let app = graph
+        .importers
+        .get("packages/app")
+        .expect("app member importer must be reconstructed");
+    let utils = app
+        .iter()
+        .find(|d| d.name == "@x/utils")
+        .expect("the sibling workspace dep must survive as a DirectDep");
+    assert_eq!(utils.dep_path, "@x/utils@1.0.0");
+    // The workspace-link convention the linker keys on: a DirectDep whose
+    // dep_path has no `packages` entry => link the sibling dir, don't fetch.
+    assert!(
+        !graph.packages.contains_key(&utils.dep_path),
+        "a workspace-sibling dep must NOT have a packages entry"
+    );
+
+    // `utils` has no deps, so its importer is present but empty.
+    assert!(graph.importers.contains_key("packages/utils"));
+}
+
+/// Each arm of the workspace-link match: the `workspace:` protocol
+/// (always links), a `link:`-to-a-member spec (binds by name, path tail
+/// ignored), a SATISFIABLE caret range (the dominant real-world
+/// yarn-classic member-to-member form — exercises `version_satisfies`),
+/// and a bare-semver range the sibling does NOT satisfy (must NOT link —
+/// it resolves from the registry instead). The negative case is the one
+/// that guards against silently substituting the wrong local copy.
+#[test]
+fn test_classic_workspace_protocol_and_range_gating() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{ "name": "root", "private": true, "workspaces": ["packages/*"] }"#,
+    )
+    .unwrap();
+    for (member, body) in [
+        (
+            "app",
+            r#"{ "name": "@x/app", "version": "1.0.0",
+                "dependencies": {
+                    "@x/proto": "workspace:*",
+                    "@x/portal": "link:../portal",
+                    "@x/caret": "^1.0.0",
+                    "@x/mismatch": "2.0.0"
+                } }"#,
+        ),
+        ("proto", r#"{ "name": "@x/proto", "version": "9.9.9" }"#),
+        ("portal", r#"{ "name": "@x/portal", "version": "0.0.0" }"#),
+        ("caret", r#"{ "name": "@x/caret", "version": "1.4.2" }"#),
+        (
+            "mismatch",
+            r#"{ "name": "@x/mismatch", "version": "1.0.0" }"#,
+        ),
+    ] {
+        let mdir = root.join("packages").join(member);
+        std::fs::create_dir_all(&mdir).unwrap();
+        std::fs::write(mdir.join("package.json"), body).unwrap();
+    }
+    let lock = root.join("yarn.lock");
+    std::fs::write(&lock, "# yarn lockfile v1\n").unwrap();
+
+    let manifest = aube_manifest::PackageJson::from_path(&root.join("package.json")).unwrap();
+    let graph = parse(&lock, &manifest).unwrap();
+    let app = graph.importers.get("packages/app").unwrap();
+    let links = |name: &str| app.iter().any(|d| d.name == name);
+
+    // `workspace:*` links regardless of the version.
+    assert!(links("@x/proto"), "workspace:* must link the sibling");
+    // `link:`-to-a-member binds by name; the `../portal` path tail is the
+    // on-disk location, not a version constraint.
+    assert!(links("@x/portal"), "link: to a member must link it by name");
+    // `^1.0.0` against a member at `1.4.2` satisfies — the common case.
+    assert!(
+        links("@x/caret"),
+        "a satisfiable caret range must link the sibling"
+    );
+    // `2.0.0` against a sibling at `1.0.0` does NOT satisfy, so it is left
+    // for registry resolution — not silently linked to the wrong local
+    // copy. (No yarn.lock entry exists either, so it's simply absent.)
+    assert!(
+        !links("@x/mismatch"),
+        "an unsatisfied bare-semver range must not link the sibling"
+    );
+}
+
 /// Berry emits `version:` unquoted, so scalar-looking values can
 /// parse as numbers instead of strings. Our parser must unfold
 /// those back to strings instead of failing with "has no version" —
@@ -1746,7 +1867,11 @@ ms@^2.1.3:
 
     // The empty root importer carries no deps; the two members are
     // reconstructed as their own importers with their child deps.
-    assert_eq!(graph.importers["."].len(), 0, "root importer must stay empty");
+    assert_eq!(
+        graph.importers["."].len(),
+        0,
+        "root importer must stay empty"
+    );
     let pkg_a = graph
         .importers
         .get("packages/pkg-a")


### PR DESCRIPTION
## What

Fix workspace-member linking under a yarn incumbent. With a classic `yarn.lock` present, `nub install` printed `✓ Already up to date` and never symlinked a local workspace member into `node_modules`, so a consumer member couldn't resolve it. pnpm and npm incumbents already linked the member correctly — the gap was yarn-incumbent-specific.

## Why

A classic `yarn.lock` is a flat resolution list with no importer structure and never records workspace members (they aren't registry packages). The classic reader (`vendor/aube/crates/aube-lockfile/src/yarn/classic.rs`) reconstructs member importers from the root `workspaces` globs, but built each importer's direct deps only by matching declared ranges against the flat resolution list. A member-to-member dependency has no `yarn.lock` entry, so it was silently dropped — leaving the linker with nothing to symlink.

The reader now also recognizes a dep whose name is a workspace sibling and emits a workspace-link `DirectDep` (a `dep_path` with no `packages` entry — the convention the linker keys on, mirroring the resolver's `try_workspace_link`). A real `yarn.lock` entry, when one exists, still wins. `yarn.lock` stays read-only (byte-identical).

## Tests (differential — fail on `main`, pass with the fix)

- `aube-lockfile` `yarn/tests.rs`: `test_classic_member_links_workspace_sibling`, `test_classic_workspace_protocol_and_range_gating` (parse layer — verifies the `DirectDep`/`dep_path` convention; covers `workspace:`/`link:`/satisfiable caret/unsatisfiable range).
- `nub-cli` `install_engine.rs`: `install_links_yarn_workspace_member_into_consumer` (end-to-end, no network — runs the real `nub install`, then `node require.resolve` from the consumer, and asserts `yarn.lock` is unchanged).

## aube fork-discipline

The change is default-preserving (it only adds importer edges the classic yarn reader was dropping; standalone aube on a non-workspace or pnpm/npm/bun path is untouched) — a latent-bug fix, upstreamable to `jdx/aube`.

Refs the #120 PM-field-support audit (`verify-pm-field-support`).
