### PR TITLE
fix(pm): re-read dist-tag specs live when the primer served the pick

### DIFF
--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -26,7 +26,10 @@ use crate::local_source::{
 use crate::package_ext::{
     apply_package_extensions, apply_package_extensions_to_deps, pick_override_spec,
 };
-use crate::semver_util::{PickResult, Regime, classify_regime, pick_version, version_satisfies};
+use crate::semver_util::{
+    PickResult, Regime, classify_regime, pick_version, range_resolves_via_dist_tag,
+    version_satisfies,
+};
 use crate::{
     Error, ExoticSubdepDetails, FxHashMap, FxHashSet, ResolutionMode, ResolveTask, ResolvedPackage,
     Resolver, error, is_deprecation_allowed, is_supported,
@@ -396,19 +399,38 @@ impl<'a> ResolveDriver<'a> {
     /// Only consulted when the pick came from the bundled primer (checked
     /// by the caller).
     ///
-    /// Returns `true` (refetch) when the pick is at the live frontier
-    /// (`Current`) and the offline seed is stale for the active cutoff,
-    /// or when a `SoftFrozen` pick coincides with `trustPolicy=NoDowngrade`
-    /// (the sparse-seed fail-open hazard). Returns `false` (accept the
-    /// offline pick) for frozen picks whose history is settled. See the
-    /// big comment on the matching arm in the pick loop for the full
-    /// rationale.
+    /// Returns `true` (refetch) when the resolved spec was a dist-tag
+    /// (the offline seed's tag pointer may be stale — see below), when
+    /// the pick is at the live frontier (`Current`) and the offline seed
+    /// is stale for the active cutoff, or when a `SoftFrozen` pick
+    /// coincides with `trustPolicy=NoDowngrade` (the sparse-seed
+    /// fail-open hazard). Returns `false` (accept the offline pick) for
+    /// frozen picks whose history is settled. See the big comment on the
+    /// matching arm in the pick loop for the full rationale.
     fn primer_pick_needs_refetch(
         &self,
         packument: &aube_registry::Packument,
         picked_version: &str,
         cutoff_for_pkg: Option<&str>,
+        range_is_dist_tag: bool,
     ) -> bool {
+        // A dist-tag (`latest`, `next`, a custom tag) is a MUTABLE pointer
+        // the publisher can repoint between builds. The primer bakes the
+        // tag's value at build time, and `classify_regime` — which keys
+        // freshness on the picked version's position in the version
+        // history — cannot see that the *pointer* moved: the baked
+        // `dist_tags.latest` is itself the frontier of the seed, so a
+        // stale `latest` always classifies as `Current` with nothing
+        // newer beside it, and (absent a cutoff) the `Current` arm below
+        // would accept it. That is issue #135: a binary built when
+        // `vite@latest` = 8.0.16 keeps resolving `"vite": "latest"` to
+        // 8.0.16 long after the registry repointed `latest` to 8.1.0
+        // (`aube update` served the stale primer pick; `aube install`'s
+        // fresh-resolve refetched, so the two diverged and `update`
+        // downgraded). Refetch unconditionally so the tag is re-read live.
+        if range_is_dist_tag {
+            return true;
+        }
         match classify_regime(packument, picked_version) {
             // Live edge: refetch only if the offline seed predates the
             // active cutoff (the staleness the legacy gate keyed on,
@@ -728,6 +750,7 @@ impl<'a> ResolveDriver<'a> {
                             packument,
                             &meta.version,
                             cutoff_for_pkg,
+                            range_resolves_via_dist_tag(packument, &task.range),
                         ) =>
                 {
                     // Consume the seed flag (one refetch per package,

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -208,6 +208,31 @@ pub(crate) fn pick_version<'a>(
     PickResult::NoMatch
 }
 
+/// True when `range_str` is a dist-tag reference (`latest`, `next`, a
+/// custom tag) rather than a semver range — i.e. `pick_version` would
+/// resolve it through `packument.dist_tags` (or the bare-`latest`
+/// highest-stable fallback) instead of parsing it as a range.
+///
+/// A dist-tag is a *mutable pointer* the publisher can repoint at any
+/// time, so the primer's build-time snapshot of it cannot be trusted the
+/// way an immutable semver-range pick can: `classify_regime` (which keys
+/// freshness on the picked version's position in settled history) is the
+/// right gate for a range, but it has no way to see that a dist-tag's
+/// *target* moved on the registry since the binary was built. The
+/// pick-site freshness gate uses this to force a live refetch for any
+/// primer-seeded dist-tag pick. Mirrors the dist-tag branch in
+/// `pick_version`: a protocol-shaped spec is never a tag.
+#[inline]
+pub(crate) fn range_resolves_via_dist_tag(packument: &Packument, range_str: &str) -> bool {
+    if node_semver::Range::parse(normalize_range(range_str)).is_ok() {
+        return false;
+    }
+    if looks_like_protocol_range(range_str) {
+        return false;
+    }
+    packument.dist_tags.contains_key(range_str) || range_str == "latest"
+}
+
 /// Walk the packument's versions and return the highest non
 /// prerelease version string. Used as the `latest` tag fallback
 /// when the registry response lacks `dist-tags.latest`. Some

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -822,6 +822,30 @@ fn classify_regime_unparseable_pick_is_current() {
 }
 
 #[test]
+fn range_resolves_via_dist_tag_detection() {
+    use crate::semver_util::range_resolves_via_dist_tag;
+    let mut packument = make_packument("foo", &["1.0.0", "2.0.0"], "2.0.0");
+    packument
+        .dist_tags
+        .insert("next".to_string(), "2.0.0".to_string());
+
+    // Dist-tags: `latest` (always, even absent the tag) + any tag the
+    // packument carries.
+    assert!(range_resolves_via_dist_tag(&packument, "latest"));
+    assert!(range_resolves_via_dist_tag(&packument, "next"));
+    // Semver ranges are never dist-tags.
+    assert!(!range_resolves_via_dist_tag(&packument, "^1.0.0"));
+    assert!(!range_resolves_via_dist_tag(&packument, "1.2.3"));
+    assert!(!range_resolves_via_dist_tag(&packument, "*"));
+    // An unknown bareword that isn't a published tag is not a dist-tag
+    // (pick_version returns NoMatch for it; it must not force a refetch).
+    assert!(!range_resolves_via_dist_tag(&packument, "beta"));
+    // Protocol-shaped specs are never tags (dependency-confusion guard).
+    assert!(!range_resolves_via_dist_tag(&packument, "workspace:*"));
+    assert!(!range_resolves_via_dist_tag(&packument, "evil:steal"));
+}
+
+#[test]
 fn test_pick_version_locked_out_of_range() {
     let packument = make_packument("foo", &["1.0.0", "2.0.0"], "2.0.0");
     // Locked version doesn't satisfy range, should pick highest match
@@ -1492,6 +1516,128 @@ async fn primer_serves_frozen_pick_offline_even_on_an_aged_binary() {
         aged_hits, 0,
         "evergreen default: aged binary must STILL serve the frozen pick \
          offline (unlimited TTL + always-on pick-gate), but the registry was hit"
+    );
+}
+
+/// Regression for issue #135: a `latest` (dist-tag) spec must be
+/// re-read LIVE when the pick was served from the bundled primer — the
+/// primer bakes the tag's value at build time, and a dist-tag is a
+/// mutable pointer the publisher can repoint afterwards. The reported
+/// symptom: a binary built when `vite@latest` = 8.0.16 kept resolving
+/// `"vite": "latest"` to 8.0.16 long after the registry repointed
+/// `latest` to 8.1.0 (`aube update` served the stale primer pick while
+/// `aube install`'s fresh-resolve refetched — so the two diverged and
+/// `update` silently DOWNGRADED a correctly-installed 8.1.0).
+///
+/// Setup: pick a real primer entry, stand up a registry whose `latest`
+/// points to a version STRICTLY NEWER than the primer's baked latest,
+/// request `"latest"`, and assert the resolver picks the live newer
+/// version. Before the dist-tag arm in `primer_pick_needs_refetch` this
+/// resolved to the primer's stale latest with zero registry hits.
+#[tokio::test]
+async fn primer_dist_tag_pick_refetches_when_registry_repointed_latest() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // A real primer entry whose baked `latest` parses as semver AND
+    // resolves standalone (no runtime/peer/optional deps on the latest
+    // version), so the single-package mock registry is sufficient and the
+    // only failure mode is the version assertion below. Skip honestly on
+    // an empty primer.
+    let Some((name, primer_latest)) = crate::primer::names().find_map(|name| {
+        let pkt = crate::primer::get(name)?.packument();
+        let latest = pkt.dist_tags.get("latest")?.clone();
+        node_semver::Version::parse(&latest).ok()?;
+        let meta = pkt.versions.get(&latest)?;
+        (meta.dependencies.is_empty()
+            && meta.optional_dependencies.is_empty()
+            && meta.peer_dependencies.is_empty())
+        .then(|| (name.to_string(), latest))
+    }) else {
+        return;
+    };
+    let live_latest = {
+        let p = node_semver::Version::parse(&primer_latest).unwrap();
+        // A strictly-higher version the primer's slice does NOT carry, so
+        // the only way to resolve it is reading the live registry.
+        format!("{}.{}.{}", p.major, p.minor, p.patch + 1)
+    };
+
+    // Live registry: serves a full packument whose `latest` = the newer
+    // version. Any request reaching it means the dist-tag was re-read
+    // live (the fix); zero requests means the stale primer pick was
+    // served (the bug).
+    let mut full = make_packument(&name, &[&primer_latest, &live_latest], &live_latest);
+    full.modified = Some("2024-01-01T00:00:00.000Z".to_string());
+    full.time
+        .insert(primer_latest.clone(), "2024-01-01T00:00:00.000Z".to_string());
+    full.time
+        .insert(live_latest.clone(), "2024-01-02T00:00:00.000Z".to_string());
+    let full_body = serde_json::to_vec(&full).unwrap();
+
+    let hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let seen = hits.clone();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            seen.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let full_body = full_body.clone();
+            tokio::spawn(async move {
+                let mut buf = vec![0_u8; 8192];
+                let _ = socket.read(&mut buf).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    full_body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.write_all(&full_body).await;
+            });
+        }
+    });
+
+    let base = std::env::temp_dir().join(format!(
+        "aube-resolver-disttag-refetch-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(base.join("packuments")).unwrap();
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    // `force_metadata_primer` routes the mock registry through the primer
+    // seed so the offline `latest` is the baked value; no cutoff, so only
+    // the dist-tag arm can force the refetch.
+    let mut resolver = Resolver::new(client)
+        .with_packument_cache(base.join("packuments"))
+        .with_force_metadata_primer(true);
+    let mut manifest = PackageJson::default();
+    manifest.dependencies.insert(name.clone(), "latest".to_string());
+
+    let graph = resolver
+        .resolve(&manifest, None)
+        .await
+        .unwrap_or_else(|e| panic!("resolve of {name}@latest failed: {e}"));
+    server.abort();
+    let _ = std::fs::remove_dir_all(base);
+
+    assert!(
+        graph_has_package(&graph, &name, &live_latest),
+        "`{name}@latest` resolved to the primer's stale baked latest \
+         ({primer_latest}) instead of the registry's repointed latest \
+         ({live_latest}); the dist-tag pick was not re-read live \
+         ({} registry requests seen)",
+        hits.load(std::sync::atomic::Ordering::Relaxed)
+    );
+    assert!(
+        hits.load(std::sync::atomic::Ordering::Relaxed) > 0,
+        "a primer-seeded `latest` pick must touch the registry to \
+         re-validate the dist-tag pointer; zero requests means the stale \
+         primer value was served"
     );
 }
 


### PR DESCRIPTION
A dist-tag (`latest`/`next`) is a mutable pointer, but the metadata primer bakes its value at build time. The freshness gate keyed refetch on `classify_regime` (version position in history), which can't see the pointer moved: a stale baked `latest` is the primer frontier, classifies `Current`, and absent a cutoff was served offline. So a 0.2.0 binary kept resolving `"vite": "latest"` to 8.0.16 after the registry moved it to 8.1.0; `update` served the stale pick while `install` refetched, so they diverged and `update` downgraded.

Fix: refetch any primer-seeded pick whose range is a dist-tag (matching npm/pnpm). Frozen range picks still serve offline.

Closes #135