### PR TITLE
test(wpt): expand WPT slice to urlpattern + web-locks + reporterror

### DIFF
--- a/.github/workflows/wpt-worker.yml
+++ b/.github/workflows/wpt-worker.yml
@@ -61,6 +61,8 @@ jobs:
           (cd crates/nub-native && cargo build)
           mkdir -p runtime/addons
           cp target/debug/libnub_native.so runtime/addons/nub-native.node
+      - name: Install runtime npm deps
+        run: npm ci --ignore-scripts
       - name: Stage the reusable nub bundle
         shell: bash
         run: |
@@ -69,6 +71,19 @@ jobs:
           mkdir -p nub-bundle
           cp target/debug/nub nub-bundle/nub
           cp -r runtime nub-bundle/runtime
+          # Vendor the pure-JS runtime polyfills into the bundle (same set as npm/build-local.sh).
+          # `reqFromRuntime()` in preload.cjs resolves packages relative to runtime/, so they
+          # must be in runtime/node_modules/. The source runtime/ tree has none; the published
+          # npm package copies them here during packaging. Mirror that in the CI bundle.
+          mkdir -p nub-bundle/runtime/node_modules
+          cp -r node_modules/urlpattern-polyfill nub-bundle/runtime/node_modules/
+          mkdir -p nub-bundle/runtime/node_modules/@petamoriken
+          cp -r "node_modules/@petamoriken/float16" nub-bundle/runtime/node_modules/@petamoriken/
+          mkdir -p nub-bundle/runtime/node_modules/@js-temporal
+          cp -r "node_modules/@js-temporal/polyfill" nub-bundle/runtime/node_modules/@js-temporal/
+          cp -r node_modules/jsbi nub-bundle/runtime/node_modules/
+          mkdir -p nub-bundle/runtime/node_modules/@oxc-project
+          cp -r "node_modules/@oxc-project/runtime" nub-bundle/runtime/node_modules/@oxc-project/
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: nub-bundle

--- a/tests/worker-wpt/harness/run-file.mjs
+++ b/tests/worker-wpt/harness/run-file.mjs
@@ -208,6 +208,64 @@ async function main() {
   const isWindow = SCOPE === "window";
 
   if (isWindow) {
+    // ── Harness shims for window-scope tests ──────────────────────────────────
+    // These globals aren't in nub's base runtime but many WPT tests expect them.
+    //
+    // location — used by web-locks helpers.js for unique resource names via
+    //   `self.location.pathname`. The fake pathname uniquely identifies the file.
+    //
+    // isSecureContext — spec tests check this; nub's CLI has no browser HTTPS
+    //   context, so it's false. Tests asserting `true` are expected-fail.
+    //
+    // fetch shim — relay relative-URL fetches to local files next to the test.
+    //   URLPattern tests load their JSON test data via `fetch('resources/…json')`.
+    //   Absolute URLs fall through to nub's native fetch (undici).
+    if (typeof globalThis.location === "undefined") {
+      const _pathname = "/" + TEST_REL.replace(/\\/g, "/").replace(/^\/+/, "");
+      globalThis.location = {
+        pathname: _pathname,
+        href: "https://wpt.example" + _pathname,
+        origin: "https://wpt.example",
+        protocol: "https:",
+        host: "wpt.example",
+        hostname: "wpt.example",
+        port: "",
+        search: "",
+        hash: "",
+        toString() { return this.href; },
+      };
+    }
+    if (typeof globalThis.isSecureContext === "undefined") {
+      globalThis.isSecureContext = false;
+    }
+    if (!globalThis.__wptFetchShimInstalled) {
+      globalThis.__wptFetchShimInstalled = true;
+      const _nativeFetch = typeof globalThis.fetch === "function" ? globalThis.fetch : null;
+      globalThis.fetch = async (_input) => {
+        const _urlStr = typeof _input === "string" ? _input : (_input && (_input.url || String(_input)));
+        if (!/^[a-z][a-z0-9+\-.]*:\/\//i.test(_urlStr)) {
+          // Relative URL — resolve from the test file's directory.
+          const _p = resolve(testDir, _urlStr);
+          const _buf = readFileSync(_p);
+          const _text = _buf.toString("utf8");
+          return {
+            ok: true,
+            status: 200,
+            headers: { get: (_k) => null },
+            json: async () => JSON.parse(_text),
+            text: async () => _text,
+            arrayBuffer: async () => {
+              const ab = new ArrayBuffer(_buf.length);
+              new Uint8Array(ab).set(_buf);
+              return ab;
+            },
+          };
+        }
+        if (_nativeFetch) return _nativeFetch(_input);
+        throw new TypeError("fetch: no handler for absolute URL: " + _urlStr);
+      };
+    }
+
     // Main-realm path: drive directly here, under nub.
     const drive = makeRealmDriver({
       harnessCode,

--- a/tests/worker-wpt/harness/run-file.mjs
+++ b/tests/worker-wpt/harness/run-file.mjs
@@ -224,9 +224,9 @@ async function main() {
       const _pathname = "/" + TEST_REL.replace(/\\/g, "/").replace(/^\/+/, "");
       globalThis.location = {
         pathname: _pathname,
-        href: "https://wpt.example" + _pathname,
-        origin: "https://wpt.example",
-        protocol: "https:",
+        href: "http://wpt.example" + _pathname,
+        origin: "http://wpt.example",
+        protocol: "http:",
         host: "wpt.example",
         hostname: "wpt.example",
         port: "",

--- a/tests/worker-wpt/harness/run-wpt.mjs
+++ b/tests/worker-wpt/harness/run-wpt.mjs
@@ -175,9 +175,22 @@ const PASS = 0;
 
   for (const rel of files) {
     const entry = status.tests[rel];
-    if (entry.skip) {
+    // skip can be a string (unconditional) or {versioned:[{minMajor?,maxMajor?,reason}]}
+    // (version-gated: only skip when NODE_MAJOR falls inside a listed band).
+    const skipReason = (() => {
+      if (typeof entry.skip === "string") return entry.skip;
+      if (entry.skip && entry.skip.versioned) {
+        for (const v of entry.skip.versioned) {
+          const okMin = v.minMajor == null || NODE_MAJOR >= v.minMajor;
+          const okMax = v.maxMajor == null || NODE_MAJOR <= v.maxMajor;
+          if (okMin && okMax) return v.reason;
+        }
+      }
+      return null;
+    })();
+    if (skipReason) {
       skipped++;
-      report.push(`  skip  ${rel}  (${entry.skip})`);
+      report.push(`  skip  ${rel}  (${skipReason})`);
       continue;
     }
     const expectedFails = expectedFailsFor(entry);

--- a/tests/worker-wpt/status.json
+++ b/tests/worker-wpt/status.json
@@ -9,7 +9,7 @@
 
     "webmessaging/MessagePort_initial_disabled.any.js": {
       "fail": {
-        "expected": ["Untitled"],
+        "expected": ["MessagePort_initial_disabled"],
         "note": "PORT AUTO-START (Node-inherited). The spec requires that addEventListener('message') WITHOUT start() must not deliver; nub follows node:worker_threads, which starts a port on any listener (workerd shares this). Documented in the worker FAQ. The file itself notes it duplicates message-channels/no-start.any.js."
       }
     },
@@ -37,7 +37,7 @@
 
     "webmessaging/message-channels/no-start.any.js": {
       "fail": {
-        "expected": ["Untitled"],
+        "expected": ["no-start"],
         "note": "PORT AUTO-START (Node-inherited). addEventListener('message') without start() should not deliver per spec; node:worker_threads (and workerd) start the port on any listener. Documented in the worker FAQ. Same divergence as MessagePort_initial_disabled.any.js."
       }
     },
@@ -115,6 +115,164 @@
     },
 
     "workers/Worker-custom-event.any.js": {},
-    "workers/Worker-replace-event-handler.any.js": {}
+    "workers/Worker-replace-event-handler.any.js": {},
+
+    "urlpattern/urlpattern.any.js": {
+      "fail": {
+        "expected": [],
+        "versioned": [
+          {
+            "minMajor": 22,
+            "maxMajor": 22,
+            "expected": [
+              "Pattern: [{\"pathname\":\":a󠄀b\"}] Inputs: []",
+              "Pattern: [{\"pathname\":\"test/:a𐑐b\"}] Inputs: [{\"pathname\":\"test/foo\"}]",
+              "Pattern: [{\"protocol\":\"http\",\"port\":\"80 \"}] Inputs: [{\"protocol\":\"http\",\"port\":\"80\"}]",
+              "Pattern: [{\"port\":\"80\"}] Inputs: [{\"port\":\"8\\t0\"}]",
+              "Pattern: [{\"port\":\"80\"}] Inputs: [{\"port\":\"80x\"}]",
+              "Pattern: [{\"port\":\"80\"}] Inputs: [{\"port\":\"80?x\"}]",
+              "Pattern: [{\"port\":\"80\"}] Inputs: [{\"port\":\"80\\\\x\"}]",
+              "Pattern: [\"https://{sub.}?example{.com/}foo\"] Inputs: [\"https://example.com/foo\"]",
+              "Pattern: [{\"hostname\":\"bad#hostname\"}] Inputs: [{\"hostname\":\"bad\"}]",
+              "Pattern: [{\"hostname\":\"bad/hostname\"}] Inputs: [{\"hostname\":\"bad\"}]",
+              "Pattern: [{\"hostname\":\"bad\\\\\\\\hostname\"}] Inputs: [{\"hostname\":\"badhostname\"}]",
+              "Pattern: [{\"hostname\":\"bad\\nhostname\"}] Inputs: [{\"hostname\":\"badhostname\"}]",
+              "Pattern: [{\"hostname\":\"bad\\rhostname\"}] Inputs: [{\"hostname\":\"badhostname\"}]",
+              "Pattern: [{\"hostname\":\"bad\\thostname\"}] Inputs: [{\"hostname\":\"badhostname\"}]",
+              "Pattern: [{\"pathname\":\"/([[a-z]--a])\"}] Inputs: [{\"pathname\":\"/a\"}]",
+              "Pattern: [{\"pathname\":\"/([[a-z]--a])\"}] Inputs: [{\"pathname\":\"/z\"}]",
+              "Pattern: [{\"pathname\":\"/([\\\\d&&[0-1]])\"}] Inputs: [{\"pathname\":\"/0\"}]",
+              "Pattern: [{\"pathname\":\"/([\\\\d&&[0-1]])\"}] Inputs: [{\"pathname\":\"/3\"}]",
+              "Pattern: [{\"protocol\":\"http\",\"hostname\":\"example.com/ignoredpath\"}] Inputs: [\"http://example.com/\"]",
+              "Pattern: [{\"protocol\":\"http\",\"hostname\":\"example.com\\\\?ignoredsearch\"}] Inputs: [\"http://example.com/\"]",
+              "Pattern: [{\"protocol\":\"http\",\"hostname\":\"example.com#ignoredhash\"}] Inputs: [\"http://example.com/\"]",
+              "Pattern: [{\"pathname\":\"/:𠀀\"}] Inputs: [{\"pathname\":\"/foo\"}]"
+            ],
+            "note": "URLPATTERN-POLYFILL DIVERGENCES on Node 22 (nub uses urlpattern-polyfill@10.1.0 where native URLPattern is absent; Node 18/20 use the polyfill and pass all tests, Node 24+ uses native and passes all). On the Node 22 tier the V8 regex engine's Unicode set notation and URL-parsing behavior diverge from the polyfill's assumptions: (1) port normalization — polyfill strips trailing spaces/non-numeric suffixes that native rejects at construction time; (2) hostname validation — polyfill accepts hostnames with control chars/special chars that native rejects; (3) Unicode set notation `[[a-z]--a]` / `[\\d&&[0-1]]` — Node 22 V8 parses these as Unicode-set classes while the polyfill generates them for non-set engines; (4) Unicode-escapes in named groups (astral-plane chars in group names). These are polyfill/engine gaps on the single narrow Node 22 band."
+          },
+          {
+            "minMajor": 24,
+            "maxMajor": 24,
+            "expected": [
+              "Pattern: [{\"pathname\":\"/:foo((?<x>a))\"}] Inputs: [{\"pathname\":\"/a\"}]",
+              "Pattern: [{\"pathname\":\"/foo/(bar(?<x>baz))\"}] Inputs: [{\"pathname\":\"/foo/barbaz\"}]"
+            ],
+            "note": "NODE 24 native URLPattern bug: named capture groups inside non-capturing groups produce incorrect match results in Node 24's V8 implementation. Verified absent on both Node 22 (polyfill) and Node 26 (fixed native). Tracked upstream."
+          }
+        ],
+        "note": "URLPattern battery (370 subtests). Tests nub's urlpattern-polyfill (on Node 22, where native is absent) and native URLPattern (Node 24+). The two versioned bands document known divergences on specific Node tiers; all other subtests pass across the full CI matrix (18.19, 20, 22.15, 24)."
+      }
+    },
+
+    "urlpattern/urlpattern-constructor.any.js": {
+      "fail": {
+        "expected": [],
+        "versioned": [
+          {
+            "minMajor": 24,
+            "maxMajor": 24,
+            "expected": ["Test constructor with undefined"],
+            "note": "NODE 24 native URLPattern constructor bug: `new URLPattern(undefined)` throws instead of accepting undefined as 'no pattern' (matches on Node 22 polyfill and Node 26 native). Fixed in Node 26."
+          }
+        ],
+        "note": "URLPattern constructor tests (2 subtests). One test fails on Node 24's native implementation only; passes on the polyfill (Node 18/20/22) and Node 26+."
+      }
+    },
+
+    "urlpattern/urlpattern-hasregexpgroups.any.js": {},
+
+    "urlpattern/urlpattern-compare.tentative.any.js": {
+      "skip": "TENTATIVE API: URLPattern.prototype.compareComponent is in nub's urlpattern-polyfill but is absent in native Node 24+'s URLPattern, making the test pass only on some tiers. Tentative APIs are excluded from the conformance gate until the spec stabilizes."
+    },
+
+    "urlpattern/urlpattern-generate.tentative.any.js": {
+      "skip": "TENTATIVE API: URLPattern.prototype.generate is absent in both native and the polyfill; 11/20 subtests pass by expecting generate to be absent or undefined. Tentative APIs are excluded from the conformance gate until the spec stabilizes."
+    },
+
+    "web-locks/acquire.https.any.js": {
+      "fail": {
+        "expected": [],
+        "versioned": [
+          {
+            "minMajor": 22,
+            "maxMajor": 22,
+            "expected": [
+              "mode must be \"shared\" or \"exclusive\"",
+              "The 'steal' and 'ifAvailable' options are mutually exclusive",
+              "The 'steal' option must be used with exclusive locks",
+              "The 'signal' and 'steal' options are mutually exclusive",
+              "The 'signal' and 'ifAvailable' options are mutually exclusive"
+            ],
+            "note": "POLYFILL VALIDATION GAPS on Node 22: nub's hand-rolled navigator.locks polyfill (navigator-locks.mjs, used on Node 22 where native is absent) does not validate mode values, the steal/ifAvailable/signal mutual-exclusivity constraints, or restrict steal to exclusive mode. Native Node (18/20 via their own locks, 24+ natively) rejects these invalid inputs. Passes across all other CI matrix legs."
+          }
+        ],
+        "note": "Web Locks acquire/option validation (11 subtests). 5 subtests test parameter validation that nub's Node-22 polyfill doesn't enforce; all pass on Node 18/20 and 24+."
+      }
+    },
+
+    "web-locks/held.https.any.js": {},
+    "web-locks/ifAvailable.https.any.js": {},
+    "web-locks/lock-attributes.https.any.js": {},
+    "web-locks/mode-exclusive.https.any.js": {},
+
+    "web-locks/mode-mixed.https.any.js": {
+      "fail": {
+        "expected": [],
+        "versioned": [
+          {
+            "minMajor": 22,
+            "maxMajor": 22,
+            "expected": ["An exclusive lock between shared locks"],
+            "note": "POLYFILL BATCH-GRANT BUG on Node 22: when an exclusive lock is released, nub's polyfill should batch-grant all consecutive queued shared locks. The test checks held.length === 5 after the exclusive releases, but the polyfill grants them serially, leaving a different count at the query() instant. Native Node (18/20 and 24+) handles batch-grant correctly."
+          }
+        ],
+        "note": "Mixed-mode lock ordering (3 subtests). One subtest tests batch-granting of shared locks after an exclusive releases — a behavior gap in nub's Node-22 polyfill."
+      }
+    },
+
+    "web-locks/mode-shared.https.any.js": {},
+
+    "web-locks/non-secure-context.any.js": {
+      "skip": "nub installs navigator.locks unconditionally regardless of isSecureContext; this test asserts navigator.locks is undefined in non-secure contexts, which nub never satisfies. Skipped rather than expected-fail because nub's run-file.mjs sets isSecureContext=false (no HTTPS context) for all tests."
+    },
+
+    "web-locks/query-empty.https.any.js": {},
+
+    "web-locks/query.https.any.js": {
+      "fail": {
+        "expected": [
+          "query() reports different ids for held locks from different contexts",
+          "query() can observe a deadlock"
+        ],
+        "note": "CROSS-WORKER TESTS: these two subtests spawn `new Worker('resources/worker.js')` to coordinate locks across contexts. nub's WPT runner operates in the main realm (window scope), where Worker is unavailable as a bare path specifier, and nub's locks are single-process only (no cross-worker coordination). The other 7 subtests pass across all CI matrix legs."
+      }
+    },
+
+    "web-locks/resource-names.https.any.js": {
+      "fail": {
+        "expected": [],
+        "versioned": [
+          {
+            "minMajor": 22,
+            "maxMajor": 22,
+            "expected": ["Names cannot start with \"-\""],
+            "note": "POLYFILL VALIDATION GAP on Node 22: nub's polyfill does not reject resource names starting with '-'. Native Node (18/20 and 24+) rejects these per spec."
+          }
+        ],
+        "note": "Web Locks resource name validation (8 subtests). One subtest tests that names starting with '-' are rejected — enforced by native but not by nub's Node-22 polyfill."
+      }
+    },
+
+    "web-locks/signal.https.any.js": {
+      "skip": "POLYFILL GAPS on Node 22 cause harness WATCHDOG: nub's hand-rolled polyfill (Node 22) does not validate that options.signal is an AbortSignal instance, and does not handle synchronous pre-abort correctly — tests expecting immediate rejection instead hang indefinitely, triggering the 5s WATCHDOG and failing the whole file. On Node 18/20 and 24+ (native locks), all 13 subtests pass. Tracked for a follow-up polyfill improvement PR."
+    },
+
+    "web-locks/steal.https.any.js": {
+      "skip": "POLYFILL GAP on Node 22 causes harness WATCHDOG: nub's hand-rolled polyfill (Node 22) does not implement the steal option — a steal request blocks forever rather than preempting the held lock, so the harness WATCHDOG fires and fails the whole file. On Node 18/20 and 24+ (native locks), all 5 subtests pass. Tracked for a follow-up polyfill improvement PR."
+    },
+
+    "html/webappapis/scripting/reporterror.any.js": {
+      "skip": "nub's reportError dispatches asynchronously (queueMicrotask(() => { throw err })) while the spec requires synchronous ErrorEvent dispatch at the global; the async throw also crashes the process before the __WPT_RESULT__ marker can be emitted. A spec-compliant implementation requires ErrorEvent and dispatchEvent on the global (not in any Node version). Tracked for a future runtime improvement."
+    }
   }
 }

--- a/tests/worker-wpt/status.json
+++ b/tests/worker-wpt/status.json
@@ -122,8 +122,7 @@
         "expected": [],
         "versioned": [
           {
-            "minMajor": 22,
-            "maxMajor": 22,
+            "maxMajor": 23,
             "expected": [
               "Pattern: [{\"pathname\":\":a󠄀b\"}] Inputs: []",
               "Pattern: [{\"pathname\":\"test/:a𐑐b\"}] Inputs: [{\"pathname\":\"test/foo\"}]",
@@ -148,36 +147,14 @@
               "Pattern: [{\"protocol\":\"http\",\"hostname\":\"example.com#ignoredhash\"}] Inputs: [\"http://example.com/\"]",
               "Pattern: [{\"pathname\":\"/:𠀀\"}] Inputs: [{\"pathname\":\"/foo\"}]"
             ],
-            "note": "URLPATTERN-POLYFILL DIVERGENCES on Node 22 (the sole polyfill tier). On all other CI legs (18, 20, 24+), URLPattern is native and all 370 subtests pass. On Node 22.15 the polyfill (urlpattern-polyfill@10.1.0) is used because native URLPattern is absent, and its regex-generation diverges from what Node 22's V8 engine expects: (1) port normalization — polyfill strips trailing spaces/non-numeric suffixes that native rejects at construction time; (2) hostname validation — polyfill accepts hostnames with control chars/special chars that native rejects; (3) Unicode set notation `[[a-z]--a]` / `[\\d&&[0-1]]` — Node 22 V8 parses these as Unicode-set classes while the polyfill generates them for non-set engines; (4) Unicode-escapes in named groups (astral-plane chars in group names)."
-          },
-          {
-            "minMajor": 24,
-            "maxMajor": 24,
-            "expected": [
-              "Pattern: [{\"pathname\":\"/:foo((?<x>a))\"}] Inputs: [{\"pathname\":\"/a\"}]",
-              "Pattern: [{\"pathname\":\"/foo/(bar(?<x>baz))\"}] Inputs: [{\"pathname\":\"/foo/barbaz\"}]"
-            ],
-            "note": "NODE 24 native URLPattern bug: named capture groups inside non-capturing groups produce incorrect match results in Node 24's V8 implementation. Verified absent on both Node 22 (polyfill) and Node 26 (fixed native). Tracked upstream."
+            "note": "URLPATTERN-POLYFILL DIVERGENCES on the polyfill tiers (Node 18/20/22). Native URLPattern landed in Node 24; below it nub loads urlpattern-polyfill@10.1.0, whose regex generation diverges from native URLPattern on these inputs: (1) port normalization — the polyfill strips trailing spaces / non-numeric suffixes that native rejects at construction; (2) hostname validation — the polyfill accepts hostnames with control/special chars that native rejects; (3) Unicode set notation `[[a-z]--a]` / `[\\d&&[0-1]]`; (4) Unicode escapes in named-group names (astral-plane chars). Verified failing on real Node 18.19, 20, and 22.15 (identical set on all three) and passing on native Node 24+."
           }
         ],
-        "note": "URLPattern battery (370 subtests). Node 22 is the sole polyfill tier (urlpattern-polyfill@10.1.0); all other CI legs use native URLPattern. Two versioned bands document known divergences: 22 on Node 22 (polyfill/engine gaps) and 2 on Node 24 (native bug, fixed in Node 26)."
+        "note": "URLPattern battery. URLPattern is native on Node 24+ and every subtest passes there; on the polyfill tiers (Node 18/20/22) nub uses urlpattern-polyfill@10.1.0 and the 22 subtests in the versioned band diverge. The earlier Node-24 named-capture band was removed: that native bug was fixed in Node 24.17, which is the version the floating `24` CI leg installs."
       }
     },
 
-    "urlpattern/urlpattern-constructor.any.js": {
-      "fail": {
-        "expected": [],
-        "versioned": [
-          {
-            "minMajor": 24,
-            "maxMajor": 24,
-            "expected": ["Test constructor with undefined"],
-            "note": "NODE 24 native URLPattern constructor bug: `new URLPattern(undefined)` throws instead of accepting undefined as 'no pattern' (matches on Node 22 polyfill and Node 26 native). Fixed in Node 26."
-          }
-        ],
-        "note": "URLPattern constructor tests (2 subtests). One test fails on Node 24's native implementation only; passes on Node 22 (polyfill) and all other legs."
-      }
-    },
+    "urlpattern/urlpattern-constructor.any.js": {},
 
     "urlpattern/urlpattern-hasregexpgroups.any.js": {},
 
@@ -189,46 +166,14 @@
       "skip": "TENTATIVE API: URLPattern.prototype.generate is absent in both native and the polyfill; 11/20 subtests pass by expecting generate to be absent or undefined. Tentative APIs are excluded from the conformance gate until the spec stabilizes."
     },
 
-    "web-locks/acquire.https.any.js": {
-      "fail": {
-        "expected": [],
-        "versioned": [
-          {
-            "minMajor": 22,
-            "maxMajor": 22,
-            "expected": [
-              "mode must be \"shared\" or \"exclusive\"",
-              "The 'steal' and 'ifAvailable' options are mutually exclusive",
-              "The 'steal' option must be used with exclusive locks",
-              "The 'signal' and 'steal' options are mutually exclusive",
-              "The 'signal' and 'ifAvailable' options are mutually exclusive"
-            ],
-            "note": "POLYFILL VALIDATION GAPS on Node 22: nub's hand-rolled navigator.locks polyfill (navigator-locks.mjs, used on Node 22 where native is absent) does not validate mode values, the steal/ifAvailable/signal mutual-exclusivity constraints, or restrict steal to exclusive mode. Native Node (18/20 via their own locks, 24+ natively) rejects these invalid inputs. Passes across all other CI matrix legs."
-          }
-        ],
-        "note": "Web Locks acquire/option validation (11 subtests). 5 subtests test parameter validation that nub's Node-22 polyfill doesn't enforce; all pass on Node 18/20 and 24+."
-      }
-    },
+    "web-locks/acquire.https.any.js": {},
 
     "web-locks/held.https.any.js": {},
     "web-locks/ifAvailable.https.any.js": {},
     "web-locks/lock-attributes.https.any.js": {},
     "web-locks/mode-exclusive.https.any.js": {},
 
-    "web-locks/mode-mixed.https.any.js": {
-      "fail": {
-        "expected": [],
-        "versioned": [
-          {
-            "minMajor": 22,
-            "maxMajor": 22,
-            "expected": ["An exclusive lock between shared locks"],
-            "note": "POLYFILL BATCH-GRANT BUG on Node 22: when an exclusive lock is released, nub's polyfill should batch-grant all consecutive queued shared locks. The test checks held.length === 5 after the exclusive releases, but the polyfill grants them serially, leaving a different count at the query() instant. Native Node (18/20 and 24+) handles batch-grant correctly."
-          }
-        ],
-        "note": "Mixed-mode lock ordering (3 subtests). One subtest tests batch-granting of shared locks after an exclusive releases — a behavior gap in nub's Node-22 polyfill."
-      }
-    },
+    "web-locks/mode-mixed.https.any.js": {},
 
     "web-locks/mode-shared.https.any.js": {},
 
@@ -248,44 +193,11 @@
       }
     },
 
-    "web-locks/resource-names.https.any.js": {
-      "fail": {
-        "expected": [],
-        "versioned": [
-          {
-            "minMajor": 22,
-            "maxMajor": 22,
-            "expected": ["Names cannot start with \"-\""],
-            "note": "POLYFILL VALIDATION GAP on Node 22: nub's polyfill does not reject resource names starting with '-'. Native Node (18/20 and 24+) rejects these per spec."
-          }
-        ],
-        "note": "Web Locks resource name validation (8 subtests). One subtest tests that names starting with '-' are rejected — enforced by native but not by nub's Node-22 polyfill."
-      }
-    },
+    "web-locks/resource-names.https.any.js": {},
 
-    "web-locks/signal.https.any.js": {
-      "skip": {
-        "versioned": [
-          {
-            "minMajor": 22,
-            "maxMajor": 22,
-            "reason": "POLYFILL GAPS on Node 22 cause harness WATCHDOG: nub's hand-rolled polyfill (Node 22) does not validate that options.signal is an AbortSignal instance, and does not handle synchronous pre-abort correctly — tests expecting immediate rejection instead hang indefinitely, triggering the 5s WATCHDOG and failing the whole file. All 13 subtests pass on other CI legs. Tracked for a follow-up polyfill improvement PR."
-          }
-        ]
-      }
-    },
+    "web-locks/signal.https.any.js": {},
 
-    "web-locks/steal.https.any.js": {
-      "skip": {
-        "versioned": [
-          {
-            "minMajor": 22,
-            "maxMajor": 22,
-            "reason": "POLYFILL GAP on Node 22 causes harness WATCHDOG: nub's hand-rolled polyfill (Node 22) does not implement the steal option — a steal request blocks forever rather than preempting the held lock, so the harness WATCHDOG fires and fails the whole file. All 5 subtests pass on other CI legs. Tracked for a follow-up polyfill improvement PR."
-          }
-        ]
-      }
-    },
+    "web-locks/steal.https.any.js": {},
 
     "html/webappapis/scripting/reporterror.any.js": {
       "skip": "nub's reportError dispatches asynchronously (queueMicrotask(() => { throw err })) while the spec requires synchronous ErrorEvent dispatch at the global; the async throw also crashes the process before the __WPT_RESULT__ marker can be emitted. A spec-compliant implementation requires ErrorEvent and dispatchEvent on the global (not in any Node version). Tracked for a future runtime improvement."

--- a/tests/worker-wpt/status.json
+++ b/tests/worker-wpt/status.json
@@ -148,7 +148,7 @@
               "Pattern: [{\"protocol\":\"http\",\"hostname\":\"example.com#ignoredhash\"}] Inputs: [\"http://example.com/\"]",
               "Pattern: [{\"pathname\":\"/:𠀀\"}] Inputs: [{\"pathname\":\"/foo\"}]"
             ],
-            "note": "URLPATTERN-POLYFILL DIVERGENCES on Node 22 (nub uses urlpattern-polyfill@10.1.0 where native URLPattern is absent; Node 18/20 use the polyfill and pass all tests, Node 24+ uses native and passes all). On the Node 22 tier the V8 regex engine's Unicode set notation and URL-parsing behavior diverge from the polyfill's assumptions: (1) port normalization — polyfill strips trailing spaces/non-numeric suffixes that native rejects at construction time; (2) hostname validation — polyfill accepts hostnames with control chars/special chars that native rejects; (3) Unicode set notation `[[a-z]--a]` / `[\\d&&[0-1]]` — Node 22 V8 parses these as Unicode-set classes while the polyfill generates them for non-set engines; (4) Unicode-escapes in named groups (astral-plane chars in group names). These are polyfill/engine gaps on the single narrow Node 22 band."
+            "note": "URLPATTERN-POLYFILL DIVERGENCES on Node 22 (the sole polyfill tier). On all other CI legs (18, 20, 24+), URLPattern is native and all 370 subtests pass. On Node 22.15 the polyfill (urlpattern-polyfill@10.1.0) is used because native URLPattern is absent, and its regex-generation diverges from what Node 22's V8 engine expects: (1) port normalization — polyfill strips trailing spaces/non-numeric suffixes that native rejects at construction time; (2) hostname validation — polyfill accepts hostnames with control chars/special chars that native rejects; (3) Unicode set notation `[[a-z]--a]` / `[\\d&&[0-1]]` — Node 22 V8 parses these as Unicode-set classes while the polyfill generates them for non-set engines; (4) Unicode-escapes in named groups (astral-plane chars in group names)."
           },
           {
             "minMajor": 24,
@@ -160,7 +160,7 @@
             "note": "NODE 24 native URLPattern bug: named capture groups inside non-capturing groups produce incorrect match results in Node 24's V8 implementation. Verified absent on both Node 22 (polyfill) and Node 26 (fixed native). Tracked upstream."
           }
         ],
-        "note": "URLPattern battery (370 subtests). Tests nub's urlpattern-polyfill (on Node 22, where native is absent) and native URLPattern (Node 24+). The two versioned bands document known divergences on specific Node tiers; all other subtests pass across the full CI matrix (18.19, 20, 22.15, 24)."
+        "note": "URLPattern battery (370 subtests). Node 22 is the sole polyfill tier (urlpattern-polyfill@10.1.0); all other CI legs use native URLPattern. Two versioned bands document known divergences: 22 on Node 22 (polyfill/engine gaps) and 2 on Node 24 (native bug, fixed in Node 26)."
       }
     },
 
@@ -175,7 +175,7 @@
             "note": "NODE 24 native URLPattern constructor bug: `new URLPattern(undefined)` throws instead of accepting undefined as 'no pattern' (matches on Node 22 polyfill and Node 26 native). Fixed in Node 26."
           }
         ],
-        "note": "URLPattern constructor tests (2 subtests). One test fails on Node 24's native implementation only; passes on the polyfill (Node 18/20/22) and Node 26+."
+        "note": "URLPattern constructor tests (2 subtests). One test fails on Node 24's native implementation only; passes on Node 22 (polyfill) and all other legs."
       }
     },
 
@@ -264,11 +264,27 @@
     },
 
     "web-locks/signal.https.any.js": {
-      "skip": "POLYFILL GAPS on Node 22 cause harness WATCHDOG: nub's hand-rolled polyfill (Node 22) does not validate that options.signal is an AbortSignal instance, and does not handle synchronous pre-abort correctly — tests expecting immediate rejection instead hang indefinitely, triggering the 5s WATCHDOG and failing the whole file. On Node 18/20 and 24+ (native locks), all 13 subtests pass. Tracked for a follow-up polyfill improvement PR."
+      "skip": {
+        "versioned": [
+          {
+            "minMajor": 22,
+            "maxMajor": 22,
+            "reason": "POLYFILL GAPS on Node 22 cause harness WATCHDOG: nub's hand-rolled polyfill (Node 22) does not validate that options.signal is an AbortSignal instance, and does not handle synchronous pre-abort correctly — tests expecting immediate rejection instead hang indefinitely, triggering the 5s WATCHDOG and failing the whole file. All 13 subtests pass on other CI legs. Tracked for a follow-up polyfill improvement PR."
+          }
+        ]
+      }
     },
 
     "web-locks/steal.https.any.js": {
-      "skip": "POLYFILL GAP on Node 22 causes harness WATCHDOG: nub's hand-rolled polyfill (Node 22) does not implement the steal option — a steal request blocks forever rather than preempting the held lock, so the harness WATCHDOG fires and fails the whole file. On Node 18/20 and 24+ (native locks), all 5 subtests pass. Tracked for a follow-up polyfill improvement PR."
+      "skip": {
+        "versioned": [
+          {
+            "minMajor": 22,
+            "maxMajor": 22,
+            "reason": "POLYFILL GAP on Node 22 causes harness WATCHDOG: nub's hand-rolled polyfill (Node 22) does not implement the steal option — a steal request blocks forever rather than preempting the held lock, so the harness WATCHDOG fires and fails the whole file. All 5 subtests pass on other CI legs. Tracked for a follow-up polyfill improvement PR."
+          }
+        ]
+      }
     },
 
     "html/webappapis/scripting/reporterror.any.js": {

--- a/tests/worker-wpt/wpt/html/webappapis/scripting/reporterror.any.js
+++ b/tests/worker-wpt/wpt/html/webappapis/scripting/reporterror.any.js
@@ -1,0 +1,49 @@
+setup({ allow_uncaught_exception:true });
+
+[
+  1,
+  new TypeError(),
+  undefined
+].forEach(throwable => {
+  test(t => {
+    let happened = false;
+    self.addEventListener("error", t.step_func(e => {
+      assert_true(e.message !== "");
+      assert_equals(e.filename, new URL("reporterror.any.js", location.href).href);
+      assert_greater_than(e.lineno, 0);
+      assert_greater_than(e.colno, 0);
+      assert_equals(e.error, throwable);
+      happened = true;
+    }), { once:true });
+    self.reportError(throwable);
+    assert_true(happened);
+  }, `self.reportError(${throwable})`);
+});
+
+test(() => {
+  assert_throws_js(TypeError, () => self.reportError());
+}, `self.reportError() (without arguments) throws`);
+
+test(() => {
+  // Workaround for https://github.com/web-platform-tests/wpt/issues/32105
+  let invoked = false;
+  self.reportError({
+    get name() {
+      invoked = true;
+      assert_unreached('get name')
+    },
+    get message() {
+      invoked = true;
+      assert_unreached('get message');
+    },
+    get fileName() {
+      invoked = true;
+      assert_unreached('get fileName');
+    },
+    get lineNumber() {
+      invoked = true;
+      assert_unreached('get lineNumber');
+    }
+  });
+  assert_false(invoked);
+}, `self.reportError() doesn't invoke getters`);

--- a/tests/worker-wpt/wpt/urlpattern/resources/urlpattern-compare-test-data.json
+++ b/tests/worker-wpt/wpt/urlpattern/resources/urlpattern-compare-test-data.json
@@ -1,0 +1,152 @@
+[
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/a" },
+    "right": { "pathname": "/foo/b" },
+    "expected": -1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/b" },
+    "right": { "pathname": "/foo/bar" },
+    "expected": -1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/bar" },
+    "right": { "pathname": "/foo/:bar" },
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/" },
+    "right": { "pathname": "/foo/:bar" },
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/:bar" },
+    "right": { "pathname": "/foo/*" },
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/{bar}" },
+    "right": { "pathname": "/foo/(bar)" },
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/{bar}" },
+    "right": { "pathname": "/foo/{bar}+" },
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/{bar}+" },
+    "right": { "pathname": "/foo/{bar}?" },
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/{bar}?" },
+    "right": { "pathname": "/foo/{bar}*" },
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/(123)" },
+    "right": { "pathname": "/foo/(12)" },
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/:b" },
+    "right": { "pathname": "/foo/:a" },
+    "expected": 0
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "*/foo" },
+    "right": { "pathname": "*" },
+    "expected": 1
+  },
+  {
+    "component": "port",
+    "left": { "port": "9" },
+    "right": { "port": "100" },
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "foo/:bar?/baz" },
+    "right": { "pathname": "foo/{:bar}?/baz" },
+    "expected": -1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "foo/:bar?/baz" },
+    "right": { "pathname": "foo{/:bar}?/baz" },
+    "expected": 0
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "foo/:bar?/baz" },
+    "right": { "pathname": "fo{o/:bar}?/baz" },
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "foo/:bar?/baz" },
+    "right": { "pathname": "foo{/:bar/}?baz" },
+    "expected": -1
+  },
+  {
+    "component": "pathname",
+    "left": "https://a.example.com/b?a",
+    "right": "https://b.example.com/a?b",
+    "expected": 1
+  },
+  {
+    "component": "pathname",
+    "left": { "pathname": "/foo/{bar}/baz" },
+    "right": { "pathname": "/foo/bar/baz" },
+    "expected": 0
+  },
+  {
+    "component": "protocol",
+    "left": { "protocol": "a" },
+    "right": { "protocol": "b" },
+    "expected": -1
+  },
+  {
+    "component": "username",
+    "left": { "username": "a" },
+    "right": { "username": "b" },
+    "expected": -1
+  },
+  {
+    "component": "password",
+    "left": { "password": "a" },
+    "right": { "password": "b" },
+    "expected": -1
+  },
+  {
+    "component": "hostname",
+    "left": { "hostname": "a" },
+    "right": { "hostname": "b" },
+    "expected": -1
+  },
+  {
+    "component": "search",
+    "left": { "search": "a" },
+    "right": { "search": "b" },
+    "expected": -1
+  },
+  {
+    "component": "hash",
+    "left": { "hash": "a" },
+    "right": { "hash": "b" },
+    "expected": -1
+  }
+]

--- a/tests/worker-wpt/wpt/urlpattern/resources/urlpattern-compare-tests.tentative.js
+++ b/tests/worker-wpt/wpt/urlpattern/resources/urlpattern-compare-tests.tentative.js
@@ -1,0 +1,26 @@
+function runTests(data) {
+  for (let entry of data) {
+    test(function() {
+      const left = new URLPattern(entry.left);
+      const right = new URLPattern(entry.right);
+
+      assert_equals(URLPattern.compareComponent(entry.component, left, right), entry.expected);
+
+      // We have to coerce to an integer here in order to avoid asserting
+      // that `+0` is `-0`.
+      const reverse_expected = ~~(entry.expected * -1);
+      assert_equals(URLPattern.compareComponent(entry.component, right, left), reverse_expected, "reverse order");
+
+      assert_equals(URLPattern.compareComponent(entry.component, left, left), 0, "left equality");
+      assert_equals(URLPattern.compareComponent(entry.component, right, right), 0, "right equality");
+    }, `Component: ${entry.component} ` +
+       `Left: ${JSON.stringify(entry.left)} ` +
+       `Right: ${JSON.stringify(entry.right)}`);
+  }
+}
+
+promise_test(async function() {
+  const response = await fetch('resources/urlpattern-compare-test-data.json');
+  const data = await response.json();
+  runTests(data);
+}, 'Loading data...');

--- a/tests/worker-wpt/wpt/urlpattern/resources/urlpattern-generate-test-data.json
+++ b/tests/worker-wpt/wpt/urlpattern/resources/urlpattern-generate-test-data.json
@@ -1,0 +1,116 @@
+[
+  {
+    "pattern": { "pathname": "/foo" },
+    "component": "invalid",
+    "groups": {},
+    "expected": null
+  },
+  {
+    "pattern": { "pathname": "/foo" },
+    "component": "pathname",
+    "groups": {},
+    "expected": "/foo"
+  },
+  {
+    "pattern": { "pathname": "/:foo" },
+    "component": "pathname",
+    "groups": { "foo": "bar" },
+    "expected": "/bar"
+  },
+  {
+    "pattern": { "pathname": "/:foo" },
+    "component": "pathname",
+    "groups": { "foo": "🍅" },
+    "expected": "/%F0%9F%8D%85"
+  },
+  {
+    "pattern": { "hostname": "{:foo}.example.com" },
+    "component": "hostname",
+    "groups": { "foo": "🍅" },
+    "expected": "xn--fi8h.example.com"
+  },
+  {
+    "pattern": { "pathname": "/:foo" },
+    "component": "pathname",
+    "groups": {},
+    "expected": null
+  },
+  {
+    "pattern": { "pathname": "/foo/:bar" },
+    "component": "pathname",
+    "groups": { "bar": "baz" },
+    "expected": "/foo/baz"
+  },
+  {
+    "pattern": { "pathname": "/foo:bar" },
+    "component": "pathname",
+    "groups": { "bar": "baz" },
+    "expected": "/foobaz"
+  },
+  {
+    "pattern": { "pathname": "/:foo/:bar" },
+    "component": "pathname",
+    "groups": { "foo": "baz", "bar": "qux" },
+    "expected": "/baz/qux"
+  },
+  {
+    "pattern": "https://example.com/:foo",
+    "component": "pathname",
+    "groups": { "foo": " " },
+    "expected": "/%20"
+  },
+  {
+    "pattern": "original-scheme://example.com/:foo",
+    "component": "pathname",
+    "groups": { "foo": " " },
+    "expected": "/ "
+  },
+  {
+    "pattern": { "pathname": "/:foo" },
+    "component": "pathname",
+    "groups": { "foo": "bar/baz" },
+    "expected": null
+  },
+  {
+    "pattern": { "pathname": "*" },
+    "component": "pathname",
+    "groups": {},
+    "expected": null
+  },
+  {
+    "pattern": { "pathname": "/{foo}+" },
+    "component": "pathname",
+    "groups": {},
+    "expected": null
+  },
+  {
+    "pattern": { "pathname": "/{foo}?" },
+    "component": "pathname",
+    "groups": {},
+    "expected": null
+  },
+  {
+    "pattern": { "pathname": "/{foo}*" },
+    "component": "pathname",
+    "groups": {},
+    "expected": null
+  },
+  {
+    "pattern": { "pathname": "/(regexp)" },
+    "component": "pathname",
+    "groups": {},
+    "expected": null
+  },
+  {
+    "pattern": { "pathname": "/([^\\/]+?)" },
+    "component": "pathname",
+    "groups": {},
+    "expected": null
+  },
+  {
+    "pattern": { "port": "([^\\:]+?)" },
+    "component": "port",
+    "groups": {},
+    "expected": null
+  }
+]

--- a/tests/worker-wpt/wpt/urlpattern/resources/urlpattern-hasregexpgroups-tests.js
+++ b/tests/worker-wpt/wpt/urlpattern/resources/urlpattern-hasregexpgroups-tests.js
@@ -1,0 +1,18 @@
+test(() => {
+  assert_implements('hasRegExpGroups' in URLPattern.prototype, "hasRegExpGroups is not implemented");
+  assert_false(new URLPattern({}).hasRegExpGroups, "match-everything pattern");
+  for (let component of ['protocol', 'username', 'password', 'hostname', 'port', 'pathname', 'search', 'hash']) {
+    assert_false(new URLPattern({[component]: '*'}).hasRegExpGroups, `wildcard in ${component}`);
+    assert_false(new URLPattern({[component]: ':foo'}).hasRegExpGroups, `segment wildcard  in ${component}`);
+    assert_false(new URLPattern({[component]: ':foo?'}).hasRegExpGroups, `optional segment wildcard  in ${component}`);
+    assert_true(new URLPattern({[component]: ':foo(hi)'}).hasRegExpGroups, `named regexp group in ${component}`);
+    assert_true(new URLPattern({[component]: '(hi)'}).hasRegExpGroups, `anonymous regexp group in ${component}`);
+    if (component !== 'protocol' && component !== 'port') {
+      // These components are more narrow in what they accept in any case.
+      assert_false(new URLPattern({[component]: 'a-{:hello}-z-*-a'}).hasRegExpGroups, `wildcards mixed in with fixed text and wildcards in ${component}`);
+      assert_true(new URLPattern({[component]: 'a-(hi)-z-(lo)-a'}).hasRegExpGroups, `regexp groups mixed in with fixed text and wildcards in ${component}`);
+    }
+  }
+  assert_false(new URLPattern({pathname: '/a/:foo/:baz?/b/*'}).hasRegExpGroups, "complex pathname with no regexp");
+  assert_true(new URLPattern({pathname: '/a/:foo/:baz([a-z]+)?/b/*'}).hasRegExpGroups, "complex pathname with regexp");
+}, '');

--- a/tests/worker-wpt/wpt/urlpattern/resources/urlpatterntestdata.json
+++ b/tests/worker-wpt/wpt/urlpattern/resources/urlpatterntestdata.json
@@ -1,0 +1,3181 @@
+[
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/ba" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar/baz" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar" }],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://example.com" }],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/baz",
+                 "baseURL": "https://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?otherquery#otherhash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar?otherquery#otherhash" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar?query#hash" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "hash", "groups": { "0": "hash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "query", "groups": { "0": "query" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar/baz" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://other.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "http://other.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar/baz",
+                 "baseURL": "https://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://other.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "http://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/([^\\/]+?)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/index.html" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/index.html", "groups": { "bar": "index.html" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/bar/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "bar": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "bar": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "bar": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "username": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "password": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "search": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hash": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "protocol": ":café" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":café" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":café" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":café" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:café" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":café" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":café" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":\u2118" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":\u2118" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":\u2118" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":\u2118" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:\u2118" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":\u2118" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":\u2118" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":\u3400" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":\u3400" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":\u3400" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":\u3400" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:\u3400" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":\u3400" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":\u3400" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(.*)" }],
+    "inputs": [{ "protocol" : "café" }],
+    "expected_obj": {
+      "protocol": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "(.*)" }],
+    "inputs": [{ "protocol": "cafe" }],
+    "expected_obj": {
+      "protocol": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "cafe", "groups": { "0": "cafe" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "foo-bar" }],
+    "inputs": [{ "protocol": "foo-bar" }],
+    "expected_match": {
+      "protocol": { "input": "foo-bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "username": "caf%C3%A9" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_match": {
+      "username": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "username": "café" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_obj": {
+      "username": "caf%C3%A9"
+    },
+    "expected_match": {
+      "username": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "username": "caf%c3%a9" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "password": "caf%C3%A9" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_match": {
+      "password": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "password": "café" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_obj": {
+      "password": "caf%C3%A9"
+    },
+    "expected_match": {
+      "password": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "password": "caf%c3%a9" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hostname": "xn--caf-dma.com" }],
+    "inputs": [{ "hostname" : "café.com" }],
+    "expected_match": {
+      "hostname": { "input": "xn--caf-dma.com", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "café.com" }],
+    "inputs": [{ "hostname" : "café.com" }],
+    "expected_obj": {
+      "hostname": "xn--caf-dma.com"
+    },
+    "expected_match": {
+      "hostname": { "input": "xn--caf-dma.com", "groups": {}}
+    }
+  },
+  {
+    "pattern": ["http://\uD83D\uDEB2.com/"],
+    "inputs": ["http://\uD83D\uDEB2.com/"],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "xn--h78h.com",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {}},
+      "hostname": { "input": "xn--h78h.com", "groups": {}},
+      "pathname": { "input": "/", "groups": {}}
+    }
+  },
+  {
+    "pattern": ["http://\uD83D \uDEB2"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"hostname":"\uD83D \uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"pathname":"\uD83D \uDEB2"}],
+    "inputs": [],
+    "expected_obj": {
+      "pathname": "%EF%BF%BD%20%EF%BF%BD"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{"pathname":":\uD83D \uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"pathname":":a\uDB40\uDD00b"}],
+    "inputs": [],
+    "expected_obj": {
+      "pathname": ":a\uDB40\uDD00b"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{"pathname":"test/:a\uD801\uDC50b"}],
+    "inputs": [{"pathname":"test/foo"}],
+    "expected_obj": {
+      "pathname": "test/:a\uD801\uDC50b"
+    },
+    "expected_match": {
+      "pathname": { "input": "test/foo", "groups": { "a\uD801\uDC50b": "foo" }}
+    }
+  },
+  {
+    "pattern": [{"pathname":":\uD83D\uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "port": "" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "protocol": { "input": "http", "groups": { "0": "http" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80{20}?" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80 " }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_obj": {
+      "protocol": "http",
+      "port": "80"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "100000" }],
+    "inputs": [{ "protocol": "http", "port": "100000" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http{s}?", "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "8\t0" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80?x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80\\x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "(.*)" }],
+    "inputs": [{ "port": "invalid80" }],
+    "expected_obj": {
+      "port": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "https", "port": "443*" }],
+    "inputs": [{ "protocol": "https", "port": "4430" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "port": { "input": "4430", "groups": { "0": "0" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "https", "port": "*443" }],
+    "inputs": [{ "protocol": "https", "port": "1443" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "port": { "input": "1443", "groups": { "0": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/./bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/baz" }],
+    "inputs": [{ "pathname": "/foo/bar/../baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/baz", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/caf%C3%A9" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_match": {
+      "pathname": { "input": "/caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/café" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_obj": {
+      "pathname": "/caf%C3%A9"
+    },
+    "expected_match": {
+      "pathname": { "input": "/caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/caf%c3%a9" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/../bar" }],
+    "inputs": [{ "pathname": "/bar" }],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "./foo/bar", "baseURL": "https://example.com" }],
+    "inputs": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "", "baseURL": "https://example.com" }],
+    "inputs": [{ "pathname": "/", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{/bar}", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./bar", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "\\/bar", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./bar", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "b", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./b", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/b"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/b", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name.html", "baseURL": "https://example.com" }],
+    "inputs": [ "https://example.com/foo.html"] ,
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/:name.html"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo.html", "groups": { "name": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=caf%C3%A9" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_match": {
+      "search": { "input": "q=caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=café" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_obj": {
+      "search": "q=caf%C3%A9"
+    },
+    "expected_match": {
+      "search": { "input": "q=caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=caf%c3%a9" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hash": "caf%C3%A9" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_match": {
+      "hash": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hash": "café" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_obj": {
+      "hash": "caf%C3%A9"
+    },
+    "expected_match": {
+      "hash": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hash": "caf%c3%a9" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "about", "pathname": "(blank|sourcedoc)" }],
+    "inputs": [ "about:blank" ],
+    "expected_match": {
+      "protocol": { "input": "about", "groups": {}},
+      "pathname": { "input": "blank", "groups": { "0": "blank" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "data", "pathname": ":number([0-9]+)" }],
+    "inputs": [ "data:8675309" ],
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {}},
+      "pathname": { "input": "8675309", "groups": { "number": "8675309" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/(\\m)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo!" }],
+    "inputs": [{ "pathname": "/foo!" }],
+    "expected_match": {
+      "pathname": { "input": "/foo!", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\:" }],
+    "inputs": [{ "pathname": "/foo:" }],
+    "expected_match": {
+      "pathname": { "input": "/foo:", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\{" }],
+    "inputs": [{ "pathname": "/foo{" }],
+    "expected_obj": {
+      "pathname": "/foo%7B"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo%7B", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\(" }],
+    "inputs": [{ "pathname": "/foo(" }],
+    "expected_match": {
+      "pathname": { "input": "/foo(", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "inputs": [{ "baseURL": "javascript:var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(data|javascript)", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {"0": "javascript"}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(https|javascript)", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "var x = 1;" }],
+    "inputs": [{ "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": {
+      "pathname": { "input": "var%20x%20=%201;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "./foo/bar", "https://example.com" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ { "pathname": "/foo/bar" }, "https://example.com" ],
+    "expected_match": "error"
+  },
+  {
+    "pattern": [ "https://example.com:8080/foo?bar#baz" ],
+    "inputs": [{ "pathname": "/foo", "search": "bar", "hash": "baz",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "*",
+      "password": "*",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", "https://example.com:8080" ],
+    "inputs": [{ "pathname": "/foo", "search": "bar", "hash": "baz",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "http{s}?://{*.}?example.com/:product/:endpoint" ],
+    "inputs": [ "https://sub.example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http{s}?",
+      "hostname": "{*.}?example.com",
+      "pathname": "/:product/:endpoint"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "sub.example.com", "groups": { "0": "sub" } },
+      "pathname": { "input": "/foo/bar", "groups": { "product": "foo",
+                                                     "endpoint": "bar" } }
+    }
+  },
+  {
+    "pattern": [ "https://example.com?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com#foo" ],
+    "inputs": [ "https://example.com/#foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080?foo" ],
+    "inputs": [ "https://example.com:8080/?foo" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080#foo" ],
+    "inputs": [ "https://example.com:8080/#foo" ],
+    "exactly_empty_components": [ "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/#foo" ],
+    "inputs": [ "https://example.com/#foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/*?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/*?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/*\\?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/*",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/:name?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/:name?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/:name\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/:name",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": { "name": "bar" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/(bar)?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/(bar)?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/(bar)\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/(bar)",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": { "0": "bar" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/{bar}?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/{bar}?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/{bar}\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/bar",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/" ],
+    "inputs": [ "https://example.com:8080/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "",
+      "pathname": "/"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "data:foobar" ],
+    "inputs": [ "data:foobar" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "data\\:foobar" ],
+    "inputs": [ "data:foobar" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "foobar"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "foobar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://{sub.}?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "{sub.}?example.com",
+      "pathname": "/foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://{sub.}?example{.com/}foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "{sub.}?example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": { "0": "/foo" } }
+    }
+  },
+  {
+    "pattern": [ "{https://}example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://(sub.)?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub.)?example.com",
+      "pathname": "/foo"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": null } },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://(sub.)?example(.com/)foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub.)?example(.com/)foo",
+      "pathname": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "(https://)example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://{sub{.}}example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://(sub(?:.))?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub(?:.))?example.com",
+      "pathname": "/foo"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": null } },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "file:///foo/bar" ],
+    "inputs": [ "file:///foo/bar" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "file",
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "file", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "data:" ],
+    "inputs": [ "data:" ],
+    "exactly_empty_components": [ "hostname", "port", "pathname" ],
+    "expected_obj": {
+      "protocol": "data"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "foo://bar" ],
+    "inputs": [ "foo://bad_url_browser_interop" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "foo",
+      "hostname": "bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "(café)://foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://example.com/foo?bar#baz" ],
+    "inputs": [{ "protocol": "https:",
+                 "search": "?bar",
+                 "hash": "#baz",
+                 "baseURL": "http://example.com/foo" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http{s}?:",
+                  "search": "?bar",
+                  "hash": "#baz" }],
+    "inputs": [ "http://example.com/foo?bar#baz" ],
+    "expected_obj": {
+      "protocol": "http{s}?",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/foo", "groups": { "0": "/foo" }},
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "?bar#baz", "https://example.com/foo" ],
+    "inputs": [ "?bar#baz", "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "?bar", "https://example.com/foo#baz" ],
+    "inputs": [ "?bar", "https://example.com/foo#snafu" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#baz", "https://example.com/foo?bar" ],
+    "inputs": [ "#baz", "https://example.com/foo?bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#baz", "https://example.com/foo" ],
+    "inputs": [ "#baz", "https://example.com/foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*" }],
+    "inputs": [ "foo", "data:data-urls-cannot-be-base-urls" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "*" }],
+    "inputs": [ "foo", "not|a|valid|url" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://foo\\:bar@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://foo@example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://\\:bar@example.com" ],
+    "inputs": [ "https://:bar@example.com" ],
+    "exactly_empty_components": [ "username", "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://:user::pass@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": ":user",
+      "password": ":pass",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": { "user": "foo" } },
+      "password": { "input": "bar", "groups": { "pass": "bar" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https\\:foo\\:bar@example.com" ],
+    "inputs": [ "https:foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "data\\:foo\\:bar@example.com" ],
+    "inputs": [ "data:foo:bar@example.com" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "foo\\:bar@example.com"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "foo:bar@example.com", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://foo{\\:}bar@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo%3Abar",
+      "hostname": "example.com"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "data{\\:}channel.html", "https://example.com" ],
+    "inputs": [ "https://example.com/data:channel.html" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/data\\:channel.html",
+      "search": "*",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/data:channel.html", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:1]/" ],
+    "inputs": [ "http://[::1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:1]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:1]:8080/" ],
+    "inputs": [ "http://[::1]:8080/" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:1]",
+      "port": "8080",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:a]/" ],
+    "inputs": [ "http://[::a]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:a]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::a]", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[:address]/" ],
+    "inputs": [ "http://[::1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[:address]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": { "address": "::1" }},
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:AB\\::num]/" ],
+    "inputs": [ "http://[::ab:1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:ab\\::num]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }},
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "[\\:\\:AB\\::num]" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_obj": {
+      "hostname": "[\\:\\:ab\\::num]"
+    },
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "[\\:\\:xY\\::num]" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\:ab\\::num]}" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\:fé\\::num]}" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\::num\\:1]}" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "ab" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\::num\\:fé]}" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "[*\\:1]" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "0": "::ab" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "*\\:1]" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://foo{{@}}example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://foo{@example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "data\\:text/javascript,let x = 100/:tens?5;" ],
+    "inputs": [ "data:text/javascript,let x = 100/5;" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "text/javascript,let x = 100/:tens?5;"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "text/javascript,let x = 100/5;", "groups": { "tens": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:id/:id" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo", "baseURL": "" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "/foo", "" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo" }, "https://example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": ":name*" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name+" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name*" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name+" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad#hostname" }],
+    "inputs": [{ "hostname":  "bad" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad%hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad/hostname" }],
+    "inputs": [{ "hostname": "bad" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad\\:hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad<hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad>hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad?hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad@hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad[hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad]hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\\\\hostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hostname": "bad^hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad|hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\nhostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad\rhostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad\thostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{}],
+    "inputs": ["https://example.com/"],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/", "groups": { "0": "/" }}
+    }
+  },
+  {
+    "pattern": [],
+    "inputs": ["https://example.com/"],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/", "groups": { "0": "/" }}
+    }
+  },
+  {
+    "pattern": [],
+    "inputs": [{}],
+    "expected_match": {}
+  },
+  {
+    "pattern": [],
+    "inputs": [],
+    "expected_match": { "inputs": [{}] }
+  },
+  {
+    "pattern": [{ "pathname": "(foo)(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{(foo)bar}(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "(foo)?(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": "(foo)?*"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}(barbaz)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "foo", "0": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{(.*)}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": "{:foo}(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{(.*)bar}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo{*bar}"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{bar(.*)}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo{bar*}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "foo", "0": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}:bar(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo:bar(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "bar": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}?(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo?*"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo\\bar}" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo\\.bar}" }],
+    "inputs": [{ "pathname": "foo.bar" }],
+    "expected_obj": {
+      "pathname": "{:foo.bar}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foo.bar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo(foo)bar}" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo\\bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}(.*)" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "f", "0": "oobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}?bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*{}**?" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "*(.*)?"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "0": "foobar", "1": null }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo(baz)(.*)" }],
+    "inputs": [{ "pathname": "bazbar" }],
+    "expected_match": {
+      "pathname": { "input": "bazbar", "groups": { "foo": "baz", "0": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo(baz)bar" }],
+    "inputs": [{ "pathname": "bazbar" }],
+    "expected_match": {
+      "pathname": { "input": "bazbar", "groups": { "foo": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*/*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*\\/*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_obj": {
+      "pathname": "*/{*}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*/{*}" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*//*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/:foo." }],
+    "inputs": [{ "pathname": "/bar." }],
+    "expected_match": {
+      "pathname": { "input": "/bar.", "groups": { "foo": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:foo.." }],
+    "inputs": [{ "pathname": "/bar.." }],
+    "expected_match": {
+      "pathname": { "input": "/bar..", "groups": { "foo": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "./foo" }],
+    "inputs": [{ "pathname": "./foo" }],
+    "expected_match": {
+      "pathname": { "input": "./foo", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "../foo" }],
+    "inputs": [{ "pathname": "../foo" }],
+    "expected_match": {
+      "pathname": { "input": "../foo", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo./" }],
+    "inputs": [{ "pathname": "bar./" }],
+    "expected_match": {
+      "pathname": { "input": "bar./", "groups": { "foo": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo../" }],
+    "inputs": [{ "pathname": "bar../" }],
+    "expected_match": {
+      "pathname": { "input": "bar../", "groups": { "foo": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:foo\\bar" }],
+    "inputs": [{ "pathname": "/bazbar" }],
+    "expected_obj": {
+      "pathname": "{/:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/bazbar", "groups": { "foo": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }, { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO/BAR" }],
+    "expected_match": {
+      "pathname": { "input": "/FOO/BAR", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO/BAR" }],
+    "expected_match": {
+      "pathname": { "input": "/FOO/BAR", "groups": { "0": "/FOO/BAR" } }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080/foo?bar#baz",
+                 { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/FOO", "groups": {} },
+      "search": { "input": "BAR", "groups": {} },
+      "hash": { "input": "BAZ", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", "https://example.com:8080",
+                 { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/FOO", "groups": {} },
+      "search": { "input": "BAR", "groups": {} },
+      "hash": { "input": "BAZ", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", { "ignoreCase": true },
+                 "https://example.com:8080" ],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "search": "foo", "baseURL": "https://example.com/a/+/b" }],
+    "inputs": [{ "search": "foo", "baseURL": "https://example.com/a/+/b" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/a/\\+/b"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/a/+/b", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hash": "foo", "baseURL": "https://example.com/?q=*&v=?&hmm={}&umm=()" }],
+    "inputs": [{ "hash": "foo", "baseURL": "https://example.com/?q=*&v=?&hmm={}&umm=()" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "search": "q=\\*&v=\\?&hmm=\\{\\}&umm=\\(\\)"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "q=*&v=?&hmm={}&umm=()", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#foo", "https://example.com/?q=*&v=?&hmm={}&umm=()" ],
+    "inputs": [ "https://example.com/?q=*&v=?&hmm={}&umm=()#foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "search": "q=\\*&v=\\?&hmm=\\{\\}&umm=\\(\\)",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "q=*&v=?&hmm={}&umm=()", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/([[a-z]--a])" }],
+    "inputs": [{ "pathname": "/a" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/([[a-z]--a])" }],
+    "inputs": [{ "pathname": "/z" }],
+    "expected_match": {
+      "pathname": { "input": "/z", "groups": { "0": "z" } }
+    }
+  },
+    {
+    "pattern": [{ "pathname": "/([\\d&&[0-1]])" }],
+    "inputs": [{ "pathname": "/0" }],
+    "expected_match": {
+      "pathname": { "input": "/0", "groups": { "0": "0" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/([\\d&&[0-1]])" }],
+    "inputs": [{ "pathname": "/3" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com/ignoredpath" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com\\?ignoredsearch" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "search": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com#ignoredhash" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/x"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/x", "groups": { "0": "x" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/xyz"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/xyz", "groups": { "0": "xyz" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/example"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/example", "groups": { "0": "example" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/text"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/text", "groups": { "0": "text" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/path/with/x"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/path/with/x", "groups": { "0": "path/with/x" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":domain(.*)" }],
+    "inputs": [{ "hostname": "localhost" }],
+    "expected_obj": {
+      "hostname": ":domain(.*)"
+    },
+    "expected_match": {
+      "hostname": { "input": "localhost", "groups": { "domain" : "localhost"} }
+    }
+  },
+  {
+    "pattern": ["((?R)):"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": ["(\\H):"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [
+      {"pathname": "/:foo((?<x>a))"}
+    ],
+    "inputs": [
+      {"pathname": "/a"}
+    ],
+    "expected_match": {
+      "pathname": {
+        "input": "/a",
+        "groups": {"foo": "a"}
+      }
+    }
+  },
+  {
+    "pattern": [
+      {"pathname": "/foo/(bar(?<x>baz))"}
+    ],
+    "inputs": [
+      {"pathname": "/foo/barbaz"}
+    ],
+    "expected_match": {
+      "pathname": {
+        "input": "/foo/barbaz",
+        "groups": {"0": "barbaz"}
+      }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:𠀀" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "𠀀": "foo" } }
+    }
+  }
+]

--- a/tests/worker-wpt/wpt/urlpattern/resources/urlpatterntests.js
+++ b/tests/worker-wpt/wpt/urlpattern/resources/urlpatterntests.js
@@ -1,0 +1,188 @@
+const kComponents = [
+  'protocol',
+  'username',
+  'password',
+  'hostname',
+  'port',
+  'password',
+  'pathname',
+  'search',
+  'hash',
+];
+
+function runTests(data) {
+  for (let entry of data) {
+    test(function() {
+      if (entry.expected_obj === 'error') {
+        assert_throws_js(TypeError, _ => new URLPattern(...entry.pattern),
+                         'URLPattern() constructor');
+        return;
+      }
+
+      const pattern = new URLPattern(...entry.pattern);
+
+      // If the expected_obj property is not present we will automatically
+      // fill it with the most likely expected values.
+      entry.expected_obj = entry.expected_obj || {};
+
+      // The compiled URLPattern object should have a property for each
+      // component exposing the compiled pattern string.
+      for (let component of kComponents) {
+        // If the test case explicitly provides an expected pattern string,
+        // then use that.  This is necessary in cases where the original
+        // construction pattern gets canonicalized, etc.
+        let expected = entry.expected_obj[component];
+
+        // If there is no explicit expected pattern string, then compute
+        // the expected value based on the URLPattern constructor args.
+        if (expected == undefined) {
+          // First determine if there is a baseURL present in the pattern
+          // input.  A baseURL can be the source for many component patterns.
+          let baseURL = null;
+          if (entry.pattern.length > 0 && entry.pattern[0].baseURL) {
+            baseURL = new URL(entry.pattern[0].baseURL);
+          } else if (entry.pattern.length > 1 &&
+                     typeof entry.pattern[1] === 'string') {
+            baseURL = new URL(entry.pattern[1]);
+          }
+
+          const EARLIER_COMPONENTS = {
+            protocol: [],
+            hostname: ["protocol"],
+            port: ["protocol", "hostname"],
+            username: [],
+            password: [],
+            pathname: ["protocol", "hostname", "port"],
+            search: ["protocol", "hostname", "port", "pathname"],
+            hash: ["protocol", "hostname", "port", "pathname", "search"],
+          };
+
+          // We automatically populate the expected pattern string using
+          // the following options in priority order:
+          //
+          //  1. If the original input explicitly provided a pattern, then
+          //     echo that back as the expected value.
+          //  2. If an "earlier" component is specified, then a wildcard
+          //     will be used rather than inheriting from the base URL.
+          //  3. If the baseURL exists and provides a component value then
+          //     use that for the expected pattern.
+          //  4. Otherwise fall back on the default pattern of `*` for an
+          //     empty component pattern.
+          //
+          // Note that username and password are never inherited, and will only
+          // need to match if explicitly specified.
+          if (entry.exactly_empty_components &&
+              entry.exactly_empty_components.includes(component)) {
+            expected = '';
+          } else if (typeof entry.pattern[0] === 'object' &&
+              entry.pattern[0][component]) {
+            expected = entry.pattern[0][component];
+          } else if (typeof entry.pattern[0] === 'object' &&
+              EARLIER_COMPONENTS[component].some(c => c in entry.pattern[0])) {
+            expected = '*';
+          } else if (baseURL && component !== 'username' && component !== 'password') {
+            let base_value = baseURL[component];
+            // Unfortunately some URL() getters include separator chars; e.g.
+            // the trailing `:` for the protocol.  Strip those off if necessary.
+            if (component === 'protocol')
+              base_value = base_value.substring(0, base_value.length - 1);
+            else if (component === 'search' || component === 'hash')
+              base_value = base_value.substring(1, base_value.length);
+            expected = base_value;
+          } else {
+            expected = '*';
+          }
+        }
+
+        // Finally, assert that the compiled object property matches the
+        // expected property.
+        assert_equals(pattern[component], expected,
+                      `compiled pattern property '${component}'`);
+      }
+
+      if (entry.expected_match === 'error') {
+        assert_throws_js(TypeError, _ => pattern.test(...entry.inputs),
+                         'test() result');
+        assert_throws_js(TypeError, _ => pattern.exec(...entry.inputs),
+                         'exec() result');
+        return;
+      }
+
+      // First, validate the test() method by converting the expected result to
+      // a truthy value.
+      assert_equals(pattern.test(...entry.inputs), !!entry.expected_match,
+                    'test() result');
+
+      // Next, start validating the exec() method.
+      const exec_result = pattern.exec(...entry.inputs);
+
+      // On a failed match exec() returns null.
+      if (!entry.expected_match || typeof entry.expected_match !== "object") {
+        assert_equals(exec_result, entry.expected_match, 'exec() failed match result');
+        return;
+      }
+
+      if (!entry.expected_match.inputs)
+        entry.expected_match.inputs = entry.inputs;
+
+      // Next verify the result.input is correct.  This may be a structured
+      // URLPatternInit dictionary object or a URL string.
+      assert_equals(exec_result.inputs.length,
+                    entry.expected_match.inputs.length,
+                    'exec() result.inputs.length');
+      for (let i = 0; i < exec_result.inputs.length; ++i) {
+        const input = exec_result.inputs[i];
+        const expected_input = entry.expected_match.inputs[i];
+        if (typeof input === 'string') {
+          assert_equals(input, expected_input, `exec() result.inputs[${i}]`);
+          continue;
+        }
+        for (let component of kComponents) {
+          assert_equals(input[component], expected_input[component],
+                        `exec() result.inputs[${i}][${component}]`);
+        }
+      }
+
+      // Next we will compare the URLPatternComponentResult for each of these
+      // expected components.
+      for (let component of kComponents) {
+        let expected_obj = entry.expected_match[component];
+
+        // If the test expectations don't include a component object, then
+        // we auto-generate one.  This is convenient for the many cases
+        // where the pattern has a default wildcard or empty string pattern
+        // for a component and the input is essentially empty.
+        if (!expected_obj) {
+          expected_obj = { input: '', groups: {} };
+
+          // Next, we must treat default wildcards differently than empty string
+          // patterns.  The wildcard results in a capture group, but the empty
+          // string pattern does not.  The expectation object must list which
+          // components should be empty instead of wildcards in
+          // |exactly_empty_components|.
+          if (!entry.exactly_empty_components ||
+              !entry.exactly_empty_components.includes(component)) {
+            expected_obj.groups['0'] = '';
+          }
+        }
+        // JSON does not allow us to use undefined directly, so the data file
+        // contains null instead.  Translate to the expected undefined value
+        // here.
+        for (const key in expected_obj.groups) {
+          if (expected_obj.groups[key] === null) {
+            expected_obj.groups[key] = undefined;
+          }
+        }
+        assert_object_equals(exec_result[component], expected_obj,
+                             `exec() result for ${component}`);
+      }
+    }, `Pattern: ${JSON.stringify(entry.pattern)} ` +
+       `Inputs: ${JSON.stringify(entry.inputs)}`);
+  }
+}
+
+promise_test(async function() {
+  const response = await fetch('resources/urlpatterntestdata.json');
+  const data = await response.json();
+  runTests(data);
+}, 'Loading data...');

--- a/tests/worker-wpt/wpt/urlpattern/urlpattern-compare.tentative.any.js
+++ b/tests/worker-wpt/wpt/urlpattern/urlpattern-compare.tentative.any.js
@@ -1,0 +1,2 @@
+// META: global=window,worker
+// META: script=resources/urlpattern-compare-tests.tentative.js

--- a/tests/worker-wpt/wpt/urlpattern/urlpattern-constructor.any.js
+++ b/tests/worker-wpt/wpt/urlpattern/urlpattern-constructor.any.js
@@ -1,0 +1,10 @@
+// META: global=window,worker
+test(() => {
+  assert_throws_js(TypeError, () => { new URLPattern(new URL('https://example.org/%(')); } );
+  assert_throws_js(TypeError, () => { new URLPattern(new URL('https://example.org/%((')); } );
+  assert_throws_js(TypeError, () => { new URLPattern('(\\'); } );
+}, `Test unclosed token`);
+
+test(() => {
+  new URLPattern(undefined, undefined);
+}, `Test constructor with undefined`);

--- a/tests/worker-wpt/wpt/urlpattern/urlpattern-generate.tentative.any.js
+++ b/tests/worker-wpt/wpt/urlpattern/urlpattern-generate.tentative.any.js
@@ -1,0 +1,26 @@
+// META: global=window,worker
+
+function runTests(data) {
+  for (let entry of data) {
+    test(function () {
+      const pattern = new URLPattern(entry.pattern);
+
+      if (entry.expected === null) {
+        assert_throws_js(TypeError, _ => pattern.generate(entry.component, entry.groups),
+                         'generate() should fail with TypeError');
+        return;
+      }
+
+      const result = pattern.generate(entry.component, entry.groups);
+      assert_equals(result, entry.expected);
+    }, `Pattern: ${JSON.stringify(entry.pattern)} ` +
+    `Component: ${entry.component} ` +
+    `Groups: ${JSON.stringify(entry.groups)}`);
+  }
+}
+
+promise_test(async function () {
+  const response = await fetch('resources/urlpattern-generate-test-data.json');
+  const data = await response.json();
+  runTests(data);
+}, 'Loading data...');

--- a/tests/worker-wpt/wpt/urlpattern/urlpattern-hasregexpgroups.any.js
+++ b/tests/worker-wpt/wpt/urlpattern/urlpattern-hasregexpgroups.any.js
@@ -1,0 +1,2 @@
+// META: global=window,worker
+// META: script=resources/urlpattern-hasregexpgroups-tests.js

--- a/tests/worker-wpt/wpt/urlpattern/urlpattern.any.js
+++ b/tests/worker-wpt/wpt/urlpattern/urlpattern.any.js
@@ -1,0 +1,2 @@
+// META: global=window,worker
+// META: script=resources/urlpatterntests.js

--- a/tests/worker-wpt/wpt/web-locks/acquire.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/acquire.https.any.js
@@ -1,0 +1,136 @@
+// META: title=Web Locks API: navigator.locks.request method
+// META: script=resources/helpers.js
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  await promise_rejects_js(t, TypeError, navigator.locks.request());
+  await promise_rejects_js(t, TypeError, navigator.locks.request(res));
+}, 'navigator.locks.request requires a name and a callback');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  await promise_rejects_js(
+    t, TypeError,
+    navigator.locks.request(res, {mode: 'foo'}, lock => {}));
+  await promise_rejects_js(
+    t, TypeError,
+    navigator.locks.request(res, {mode: null }, lock => {}));
+  assert_equals(await navigator.locks.request(
+    res, {mode: 'exclusive'}, lock => lock.mode), 'exclusive',
+                'mode is exclusive');
+  assert_equals(await navigator.locks.request(
+    res, {mode: 'shared'}, lock => lock.mode), 'shared',
+                'mode is shared');
+}, 'mode must be "shared" or "exclusive"');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  await promise_rejects_dom(
+    t, 'NotSupportedError',
+    navigator.locks.request(
+      res, {steal: true, ifAvailable: true}, lock => {}),
+    "A NotSupportedError should be thrown if both " +
+    "'steal' and 'ifAvailable' are specified.");
+}, "The 'steal' and 'ifAvailable' options are mutually exclusive");
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  await promise_rejects_dom(
+    t, 'NotSupportedError',
+    navigator.locks.request(res, {mode: 'shared', steal: true}, lock => {}),
+    'Request with mode=shared and steal=true should fail');
+}, "The 'steal' option must be used with exclusive locks");
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  const controller = new AbortController();
+  await promise_rejects_dom(
+    t, 'NotSupportedError',
+    navigator.locks.request(
+      res, {signal: controller.signal, steal: true}, lock => {}),
+    'Request with signal and steal=true should fail');
+}, "The 'signal' and 'steal' options are mutually exclusive");
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  const controller = new AbortController();
+  await promise_rejects_dom(
+    t, 'NotSupportedError',
+    navigator.locks.request(
+      res, {signal: controller.signal, ifAvailable: true}, lock => {}),
+    'Request with signal and ifAvailable=true should fail');
+}, "The 'signal' and 'ifAvailable' options are mutually exclusive");
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, undefined));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, null));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, 123));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, 'abc'));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, []));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, {}));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, new Promise(r => {})));
+}, 'callback must be a function');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  let release;
+  const promise = new Promise(r => { release = r; });
+
+  let returned = navigator.locks.request(res, lock => { return promise; });
+
+  const order = [];
+
+  returned.then(() => { order.push('returned'); });
+  promise.then(() => { order.push('holding'); });
+
+  release();
+
+  await Promise.all([returned, promise]);
+
+  assert_array_equals(order, ['holding', 'returned']);
+
+}, 'navigator.locks.request\'s returned promise resolves after' +
+   ' lock is released');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  const test_error = {name: 'test'};
+  const p = navigator.locks.request(res, lock => {
+    throw test_error;
+  });
+  assert_equals(Promise.resolve(p), p, 'request() result is a Promise');
+  await promise_rejects_exactly(t, test_error, p, 'result should reject');
+}, 'Returned Promise rejects if callback throws synchronously');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  const test_error = {name: 'test'};
+  const p = navigator.locks.request(res, async lock => {
+    throw test_error;
+  });
+  assert_equals(Promise.resolve(p), p, 'request() result is a Promise');
+  await promise_rejects_exactly(t, test_error, p, 'result should reject');
+}, 'Returned Promise rejects if callback throws asynchronously');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  let then_invoked = false;
+  const test_error = { then: _ => { then_invoked = true; } };
+  const p = navigator.locks.request(res, async lock => {
+    throw test_error;
+  });
+  assert_equals(Promise.resolve(p), p, 'request() result is a Promise');
+  await promise_rejects_exactly(t, test_error, p, 'result should reject');
+  assert_false(then_invoked, 'then() should not be invoked');
+}, 'If callback throws a thenable, its then() should not be invoked');

--- a/tests/worker-wpt/wpt/web-locks/held.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/held.https.any.js
@@ -1,0 +1,91 @@
+// META: title=Web Locks API: Lock held until callback result resolves
+// META: script=resources/helpers.js
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+// For uncaught rejections.
+setup({allow_uncaught_exception: true});
+
+function snooze(t, ms) { return new Promise(r => t.step_timeout(r, ms)); }
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  const p = navigator.locks.request(res, lock => 123);
+  assert_equals(Promise.resolve(p), p, 'request() result is a Promise');
+  assert_equals(await p, 123, 'promise resolves to the returned value');
+}, 'callback\'s result is promisified if not async');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  // Resolved when the lock is granted.
+  let granted;
+  const lock_granted_promise = new Promise(r => { granted = r; });
+
+  // Lock is held until this is resolved.
+  let resolve;
+  const lock_release_promise = new Promise(r => { resolve = r; });
+
+  const order = [];
+
+  navigator.locks.request(res, lock => {
+    granted(lock);
+    return lock_release_promise;
+  });
+  await lock_granted_promise;
+
+  await Promise.all([
+    snooze(t, 50).then(() => {
+      order.push('1st lock released');
+      resolve();
+    }),
+    navigator.locks.request(res, () => {
+      order.push('2nd lock granted');
+    })
+  ]);
+
+  assert_array_equals(order, ['1st lock released', '2nd lock granted']);
+}, 'lock is held until callback\'s returned promise resolves');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  // Resolved when the lock is granted.
+  let granted;
+  const lock_granted_promise = new Promise(r => { granted = r; });
+
+  // Lock is held until this is rejected.
+  let reject;
+  const lock_release_promise = new Promise((_, r) => { reject = r; });
+
+  const order = [];
+
+  navigator.locks.request(res, lock => {
+    granted(lock);
+    return lock_release_promise;
+  });
+  await lock_granted_promise;
+
+  await Promise.all([
+    snooze(t, 50).then(() => {
+      order.push('reject');
+      reject(new Error('this uncaught rejection is expected'));
+    }),
+    navigator.locks.request(res, () => {
+      order.push('2nd lock granted');
+    })
+  ]);
+
+  assert_array_equals(order, ['reject', '2nd lock granted']);
+}, 'lock is held until callback\'s returned promise rejects');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, async lock => {
+    await navigator.locks.request(res, {ifAvailable: true}, lock => {
+      callback_called = true;
+      assert_equals(lock, null, 'lock request should fail if held');
+    });
+  });
+  assert_true(callback_called, 'callback should have executed');
+}, 'held lock prevents the same client from acquiring it');

--- a/tests/worker-wpt/wpt/web-locks/ifAvailable.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/ifAvailable.https.any.js
@@ -1,0 +1,163 @@
+// META: title=Web Locks API: ifAvailable option
+// META: script=resources/helpers.js
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+promise_test(async t => {
+  const res = self.uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, {ifAvailable: true}, async lock => {
+    callback_called = true;
+    assert_not_equals(lock, null, 'lock should be granted');
+  });
+  assert_true(callback_called, 'callback should be called');
+}, 'Lock request with ifAvailable - lock available');
+
+promise_test(async t => {
+  const res = self.uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, async lock => {
+    // Request would time out if |ifAvailable| was not specified.
+    const result = await navigator.locks.request(
+      res, {ifAvailable: true}, async lock => {
+        callback_called = true;
+        assert_equals(lock, null, 'lock should not be granted');
+        return 123;
+      });
+    assert_equals(result, 123, 'result should be value returned by callback');
+  });
+  assert_true(callback_called, 'callback should be called');
+}, 'Lock request with ifAvailable - lock not available');
+
+promise_test(async t => {
+  const res = self.uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, async lock => {
+    try {
+      // Request would time out if |ifAvailable| was not specified.
+      await navigator.locks.request(res, {ifAvailable: true}, async lock => {
+        callback_called = true;
+        assert_equals(lock, null, 'lock should not be granted');
+        throw 123;
+      });
+      assert_unreached('call should throw');
+    } catch (ex) {
+      assert_equals(ex, 123, 'ex should be value thrown by callback');
+    }
+  });
+  assert_true(callback_called, 'callback should be called');
+}, 'Lock request with ifAvailable - lock not available, callback throws');
+
+promise_test(async t => {
+  const res = self.uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, async lock => {
+    // Request with a different name - should be grantable.
+    await navigator.locks.request('different', {ifAvailable: true}, async lock => {
+      callback_called = true;
+      assert_not_equals(lock, null, 'lock should be granted');
+    });
+  });
+  assert_true(callback_called, 'callback should be called');
+}, 'Lock request with ifAvailable - unrelated lock held');
+
+promise_test(async t => {
+  const res = self.uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, {mode: 'shared'}, async lock => {
+    await navigator.locks.request(
+      res, {mode: 'shared', ifAvailable: true}, async lock => {
+        callback_called = true;
+        assert_not_equals(lock, null, 'lock should be granted');
+      });
+  });
+  assert_true(callback_called, 'callback should be called');
+}, 'Shared lock request with ifAvailable - shared lock held');
+
+promise_test(async t => {
+  const res = self.uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, {mode: 'shared'}, async lock => {
+    // Request would time out if |ifAvailable| was not specified.
+    await navigator.locks.request(res, {ifAvailable: true}, async lock => {
+      callback_called = true;
+      assert_equals(lock, null, 'lock should not be granted');
+    });
+  });
+  assert_true(callback_called, 'callback should be called');
+}, 'Exclusive lock request with ifAvailable - shared lock held');
+
+promise_test(async t => {
+  const res = self.uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, async lock => {
+    // Request would time out if |ifAvailable| was not specified.
+    await navigator.locks.request(
+      res, {mode: 'shared', ifAvailable: true}, async lock => {
+        callback_called = true;
+        assert_equals(lock, null, 'lock should not be granted');
+      });
+  });
+  assert_true(callback_called, 'callback should be called');
+}, 'Shared lock request with ifAvailable - exclusive lock held');
+
+promise_test(async t => {
+  const res = self.uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, async lock => {
+    callback_called = true;
+    const test_error = {name: 'test'};
+    const p = navigator.locks.request(
+      res, {ifAvailable: true}, lock => {
+        assert_equals(lock, null, 'lock should not be available');
+        throw test_error;
+      });
+    assert_equals(Promise.resolve(p), p, 'request() result is a Promise');
+    await promise_rejects_exactly(t, test_error, p, 'result should reject');
+  });
+  assert_true(callback_called, 'callback should be called');
+}, 'Returned Promise rejects if callback throws synchronously');
+
+promise_test(async t => {
+  const res = self.uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, async lock => {
+    callback_called = true;
+    const test_error = {name: 'test'};
+    const p = navigator.locks.request(
+      res, {ifAvailable: true}, async lock => {
+        assert_equals(lock, null, 'lock should not be available');
+        throw test_error;
+      });
+    assert_equals(Promise.resolve(p), p, 'request() result is a Promise');
+    await promise_rejects_exactly(t, test_error, p, 'result should reject');
+  });
+  assert_true(callback_called, 'callback should be called');
+}, 'Returned Promise rejects if async callback yields rejected promise');
+
+// Regression test for: https://crbug.com/840994
+promise_test(async t => {
+  const res1 = self.uniqueName(t);
+  const res2 = self.uniqueName(t);
+  let callback1_called = false;
+  await navigator.locks.request(res1, async lock => {
+    callback1_called = true;
+    let callback2_called = false;
+    await navigator.locks.request(res2, async lock => {
+      callback2_called = true;
+    });
+    assert_true(callback2_called, 'callback2 should be called');
+
+    let callback3_called = false;
+    await navigator.locks.request(res2, {ifAvailable: true}, async lock => {
+      callback3_called = true;
+      // This request would fail if the "is this grantable?" test
+      // failed, e.g. due to the release without a pending request
+      // skipping steps.
+      assert_not_equals(lock, null, 'Lock should be available');
+    });
+    assert_true(callback3_called, 'callback2 should be called');
+  });
+  assert_true(callback1_called, 'callback1 should be called');
+}, 'Locks are available once previous release is processed');

--- a/tests/worker-wpt/wpt/web-locks/lock-attributes.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/lock-attributes.https.any.js
@@ -1,0 +1,18 @@
+// META: title=Web Locks API: Lock Attributes
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+promise_test(async t => {
+  await navigator.locks.request('resource', lock => {
+    assert_equals(lock.name, 'resource');
+    assert_equals(lock.mode, 'exclusive');
+  });
+}, 'Lock attributes reflect requested properties (exclusive)');
+
+promise_test(async t => {
+  await navigator.locks.request('resource', {mode: 'shared'}, lock => {
+    assert_equals(lock.name, 'resource');
+    assert_equals(lock.mode, 'shared');
+  });
+}, 'Lock attributes reflect requested properties (shared)');

--- a/tests/worker-wpt/wpt/web-locks/mode-exclusive.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/mode-exclusive.https.any.js
@@ -1,0 +1,34 @@
+// META: title=Web Locks API: Exclusive Mode
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+promise_test(async t => {
+  const granted = [];
+  function log_grant(n) { return () => { granted.push(n); }; }
+
+  await Promise.all([
+    navigator.locks.request('a', log_grant(1)),
+    navigator.locks.request('a', log_grant(2)),
+    navigator.locks.request('a', log_grant(3))
+  ]);
+  assert_array_equals(granted, [1, 2, 3]);
+}, 'Lock requests are granted in order');
+
+promise_test(async t => {
+  const granted = [];
+  function log_grant(n) { return () => { granted.push(n); }; }
+
+  let inner_promise;
+  await navigator.locks.request('a', async lock => {
+    inner_promise = Promise.all([
+      // This will be blocked.
+      navigator.locks.request('a', log_grant(1)),
+      // But this should be grantable immediately.
+      navigator.locks.request('b', log_grant(2))
+    ]);
+  });
+
+  await inner_promise;
+  assert_array_equals(granted, [2, 1]);
+}, 'Requests for distinct resources can be granted');

--- a/tests/worker-wpt/wpt/web-locks/mode-mixed.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/mode-mixed.https.any.js
@@ -1,0 +1,98 @@
+// META: title=Web Locks API: Mixed Modes
+// META: script=resources/helpers.js
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+promise_test(async t => {
+  let unblock;
+  const blocked = new Promise(r => { unblock = r; });
+
+  const granted = [];
+
+  // These should be granted immediately, and held until unblocked.
+  navigator.locks.request('a', {mode: 'shared'}, async lock => {
+    granted.push('a-shared-1'); await blocked; });
+  navigator.locks.request('a', {mode: 'shared'}, async lock => {
+    granted.push('a-shared-2'); await blocked; });
+  navigator.locks.request('a', {mode: 'shared'}, async lock => {
+    granted.push('a-shared-3'); await blocked; });
+
+  // This should be blocked.
+  let exclusive_lock;
+  const exclusive_request = navigator.locks.request('a', async lock => {
+    granted.push('a-exclusive');
+    exclusive_lock = lock;
+  });
+
+  // This should be granted immediately (different name).
+  await navigator.locks.request('b', {mode: 'exclusive'}, lock => {
+    granted.push('b-exclusive'); });
+
+  assert_array_equals(
+    granted, ['a-shared-1', 'a-shared-2', 'a-shared-3', 'b-exclusive']);
+
+  // Release the shared locks granted above.
+  unblock();
+
+  // Now the blocked request can be granted.
+  await exclusive_request;
+  assert_equals(exclusive_lock.mode, 'exclusive');
+
+  assert_array_equals(
+    granted,
+    ['a-shared-1', 'a-shared-2', 'a-shared-3', 'b-exclusive', 'a-exclusive']);
+
+}, 'Lock requests are granted in order');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  let [promise, resolve] = makePromiseAndResolveFunc();
+
+  const exclusive = navigator.locks.request(res, () => promise);
+  for (let i = 0; i < 5; i++) {
+    requestLockAndHold(t, res, { mode: "shared" });
+  }
+
+  let answer = await navigator.locks.query();
+  assert_equals(answer.held.length, 1, "An exclusive lock is held");
+  assert_equals(answer.pending.length, 5, "Requests for shared locks are pending");
+  resolve();
+  await exclusive;
+
+  answer = await navigator.locks.query();
+  assert_equals(answer.held.length, 5, "Shared locks are held");
+  assert_true(answer.held.every(l => l.mode === "shared"), "All held locks are shared ones");
+}, 'Releasing exclusive lock grants multiple shared locks');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  let [sharedPromise, sharedResolve] = makePromiseAndResolveFunc();
+  let [exclusivePromise, exclusiveResolve] = makePromiseAndResolveFunc();
+
+  const sharedReleasedPromise = Promise.all(new Array(5).fill(0).map(
+    () => navigator.locks.request(res, { mode: "shared" }, () => sharedPromise))
+  );
+  const exclusiveReleasedPromise = navigator.locks.request(res, () => exclusivePromise);
+  for (let i = 0; i < 5; i++) {
+    requestLockAndHold(t, res, { mode: "shared" });
+  }
+
+  let answer = await navigator.locks.query();
+  assert_equals(answer.held.length, 5, "Shared locks are held");
+  assert_true(answer.held.every(l => l.mode === "shared"), "All held locks are shared ones");
+  sharedResolve();
+  await sharedReleasedPromise;
+
+  answer = await navigator.locks.query();
+  assert_equals(answer.held.length, 1, "An exclusive lock is held");
+  assert_equals(answer.held[0].mode, "exclusive");
+  exclusiveResolve();
+  await exclusiveReleasedPromise;
+
+  answer = await navigator.locks.query();
+  assert_equals(answer.held.length, 5, "The next shared locks are held");
+  assert_true(answer.held.every(l => l.mode === "shared"), "All held locks are shared ones");
+}, 'An exclusive lock between shared locks');

--- a/tests/worker-wpt/wpt/web-locks/mode-shared.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/mode-shared.https.any.js
@@ -1,0 +1,38 @@
+// META: title=Web Locks API: Shared Mode
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+promise_test(async t => {
+  const granted = [];
+  function log_grant(n) { return () => { granted.push(n); }; }
+
+  await Promise.all([
+    navigator.locks.request('a', {mode: 'shared'}, log_grant(1)),
+    navigator.locks.request('b', {mode: 'shared'}, log_grant(2)),
+    navigator.locks.request('c', {mode: 'shared'}, log_grant(3)),
+    navigator.locks.request('a', {mode: 'shared'}, log_grant(4)),
+    navigator.locks.request('b', {mode: 'shared'}, log_grant(5)),
+    navigator.locks.request('c', {mode: 'shared'}, log_grant(6)),
+  ]);
+
+  assert_array_equals(granted, [1, 2, 3, 4, 5, 6]);
+}, 'Lock requests are granted in order');
+
+promise_test(async t => {
+  let a_acquired = false, a_acquired_again = false;
+
+  await navigator.locks.request('a', {mode: 'shared'}, async lock => {
+    a_acquired = true;
+
+    // Since lock is held, this request would be blocked if the
+    // lock was not 'shared', causing this test to time out.
+
+    await navigator.locks.request('a', {mode: 'shared'}, lock => {
+      a_acquired_again = true;
+    });
+  });
+
+  assert_true(a_acquired, 'first lock acquired');
+  assert_true(a_acquired_again, 'second lock acquired');
+}, 'Shared locks are not exclusive');

--- a/tests/worker-wpt/wpt/web-locks/non-secure-context.any.js
+++ b/tests/worker-wpt/wpt/web-locks/non-secure-context.any.js
@@ -1,0 +1,14 @@
+// META: title=Web Locks API: API not available in non-secure context
+// META: global=window,dedicatedworker,sharedworker
+
+'use strict';
+
+test(t => {
+  assert_false(self.isSecureContext);
+  assert_false('locks' in navigator,
+               'navigator.locks is only present in secure contexts');
+  assert_false('LockManager' in self,
+               'LockManager is only present in secure contexts');
+  assert_false('Lock' in self,
+               'Lock interface is only present in secure contexts');
+}, 'API presence in non-secure contexts');

--- a/tests/worker-wpt/wpt/web-locks/query-empty.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/query-empty.https.any.js
@@ -1,0 +1,18 @@
+// META: title=Web Locks API: navigator.locks.query method - no locks held
+// META: script=resources/helpers.js
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+promise_test(async t => {
+  const state = await navigator.locks.query();
+
+  assert_own_property(state, 'pending', 'State has `pending` property');
+  assert_true(Array.isArray(state.pending),
+              'State `pending` property is an array');
+  assert_array_equals(state.pending, [], 'Pending array is empty');
+
+  assert_own_property(state, 'held', 'State has `held` property');
+  assert_true(Array.isArray(state.held), 'State `held` property is an array');
+  assert_array_equals(state.held, [], 'Held array is empty');
+}, 'query() returns dictionary with empty arrays when no locks are held');

--- a/tests/worker-wpt/wpt/web-locks/query.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/query.https.any.js
@@ -1,0 +1,227 @@
+// META: title=Web Locks API: navigator.locks.query method
+// META: script=resources/helpers.js
+
+'use strict';
+
+// Returns an array of the modes for the locks with matching name.
+function modes(list, name) {
+  return list.filter(item => item.name === name).map(item => item.mode);
+}
+// Returns an array of the clientIds for the locks with matching name.
+function clients(list, name) {
+  return list.filter(item => item.name === name).map(item => item.clientId);
+}
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  await navigator.locks.request(res, async lock1 => {
+    // Attempt to request this again - should be blocked.
+    let lock2_acquired = false;
+    navigator.locks.request(res, lock2 => { lock2_acquired = true; });
+
+    // Verify that it was blocked.
+    await navigator.locks.request(res, {ifAvailable: true}, async lock3 => {
+      assert_false(lock2_acquired, 'second request should be blocked');
+      assert_equals(lock3, null, 'third request should have failed');
+
+      const state = await navigator.locks.query();
+
+      assert_own_property(state, 'pending', 'State has `pending` property');
+      assert_true(Array.isArray(state.pending),
+                  'State `pending` property is an array');
+      const pending_info = state.pending[0];
+      assert_own_property(pending_info, 'name',
+                          'Pending info dictionary has `name` property');
+      assert_own_property(pending_info, 'mode',
+                          'Pending info dictionary has `mode` property');
+      assert_own_property(pending_info, 'clientId',
+                          'Pending info dictionary has `clientId` property');
+
+      assert_own_property(state, 'held', 'State has `held` property');
+      assert_true(Array.isArray(state.held),
+                  'State `held` property is an array');
+      const held_info = state.held[0];
+      assert_own_property(held_info, 'name',
+                          'Held info dictionary has `name` property');
+      assert_own_property(held_info, 'mode',
+                          'Held info dictionary has `mode` property');
+      assert_own_property(held_info, 'clientId',
+                          'Held info dictionary has `clientId` property');
+    });
+  });
+}, 'query() returns dictionaries with expected properties');
+
+
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  await navigator.locks.request(res, async lock1 => {
+    const state = await navigator.locks.query();
+    assert_array_equals(modes(state.held, res), ['exclusive'],
+                        'Held lock should appear once');
+  });
+
+  await navigator.locks.request(res, {mode: 'shared'}, async lock1 => {
+    const state = await navigator.locks.query();
+    assert_array_equals(modes(state.held, res), ['shared'],
+                        'Held lock should appear once');
+  });
+}, 'query() reports individual held locks');
+
+promise_test(async t => {
+  const res1 = uniqueName(t);
+  const res2 = uniqueName(t);
+
+  await navigator.locks.request(res1, async lock1 => {
+    await navigator.locks.request(res2, {mode: 'shared'}, async lock2 => {
+      const state = await navigator.locks.query();
+      assert_array_equals(modes(state.held, res1), ['exclusive'],
+                          'Held lock should appear once');
+      assert_array_equals(modes(state.held, res2), ['shared'],
+                          'Held lock should appear once');
+    });
+  });
+}, 'query() reports multiple held locks');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  await navigator.locks.request(res, async lock1 => {
+    // Attempt to request this again - should be blocked.
+    let lock2_acquired = false;
+    navigator.locks.request(res, lock2 => { lock2_acquired = true; });
+
+    // Verify that it was blocked.
+    await navigator.locks.request(res, {ifAvailable: true}, async lock3 => {
+      assert_false(lock2_acquired, 'second request should be blocked');
+      assert_equals(lock3, null, 'third request should have failed');
+
+      const state = await navigator.locks.query();
+      assert_array_equals(modes(state.pending, res), ['exclusive'],
+                          'Pending lock should appear once');
+      assert_array_equals(modes(state.held, res), ['exclusive'],
+                          'Held lock should appear once');
+    });
+  });
+}, 'query() reports pending and held locks');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  await navigator.locks.request(res, {mode: 'shared'}, async lock1 => {
+    await navigator.locks.request(res, {mode: 'shared'}, async lock2 => {
+      const state = await navigator.locks.query();
+      assert_array_equals(modes(state.held, res), ['shared', 'shared'],
+                          'Held lock should appear twice');
+    });
+  });
+}, 'query() reports held shared locks with appropriate count');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  await navigator.locks.request(res, async lock1 => {
+    let lock2_acquired = false, lock3_acquired = false;
+    navigator.locks.request(res, {mode: 'shared'},
+                            lock2 => { lock2_acquired = true; });
+    navigator.locks.request(res, {mode: 'shared'},
+                            lock3 => { lock3_acquired = true; });
+
+    await navigator.locks.request(res, {ifAvailable: true}, async lock4 => {
+      assert_equals(lock4, null, 'lock should not be available');
+      assert_false(lock2_acquired, 'second attempt should be blocked');
+      assert_false(lock3_acquired, 'third attempt should be blocked');
+
+      const state = await navigator.locks.query();
+      assert_array_equals(modes(state.held, res), ['exclusive'],
+                          'Held lock should appear once');
+
+      assert_array_equals(modes(state.pending, res), ['shared', 'shared'],
+                          'Pending lock should appear twice');
+    });
+  });
+}, 'query() reports pending shared locks with appropriate count');
+
+promise_test(async t => {
+  const res1 = uniqueName(t);
+  const res2 = uniqueName(t);
+
+  await navigator.locks.request(res1, async lock1 => {
+    await navigator.locks.request(res2, async lock2 => {
+      const state = await navigator.locks.query();
+
+      const res1_clients = clients(state.held, res1);
+      const res2_clients = clients(state.held, res2);
+
+      assert_equals(res1_clients.length, 1, 'Each lock should have one holder');
+      assert_equals(res2_clients.length, 1, 'Each lock should have one holder');
+
+      assert_array_equals(res1_clients, res2_clients,
+                          'Both locks should have same clientId');
+    });
+  });
+}, 'query() reports the same clientId for held locks from the same context');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  const worker = new Worker('resources/worker.js');
+  t.add_cleanup(() => { worker.terminate(); });
+
+  await postToWorkerAndWait(
+    worker, {op: 'request', name: res, mode: 'shared'});
+
+  await navigator.locks.request(res, {mode: 'shared'}, async lock => {
+    const state = await navigator.locks.query();
+    const res_clients = clients(state.held, res);
+    assert_equals(res_clients.length, 2, 'Clients should have same resource');
+    assert_not_equals(res_clients[0], res_clients[1],
+                      'Clients should have different ids');
+  });
+}, 'query() reports different ids for held locks from different contexts');
+
+promise_test(async t => {
+  const res1 = uniqueName(t);
+  const res2 = uniqueName(t);
+
+  const worker = new Worker('resources/worker.js');
+  t.add_cleanup(() => { worker.terminate(); });
+
+  // Acquire 1 in the worker.
+  await postToWorkerAndWait(worker, {op: 'request', name: res1})
+
+  // Acquire 2 here.
+  await new Promise(resolve => {
+    navigator.locks.request(res2, lock => {
+      resolve();
+      return new Promise(() => {}); // Never released.
+    });
+  });
+
+  // Request 2 in the worker.
+  postToWorkerAndWait(worker, {op: 'request', name: res2});
+  assert_true((await postToWorkerAndWait(worker, {
+    op: 'request', name: res2, ifAvailable: true
+  })).failed, 'Lock request should have failed');
+
+  // Request 1 here.
+  navigator.locks.request(
+    res1, t.unreached_func('Lock should not be acquired'));
+
+  // Verify that we're seeing a deadlock.
+  const state = await navigator.locks.query();
+  const res1_held_clients = clients(state.held, res1);
+  const res2_held_clients = clients(state.held, res2);
+  const res1_pending_clients = clients(state.pending, res1);
+  const res2_pending_clients = clients(state.pending, res2);
+
+  assert_equals(res1_held_clients.length, 1);
+  assert_equals(res2_held_clients.length, 1);
+  assert_equals(res1_pending_clients.length, 1);
+  assert_equals(res2_pending_clients.length, 1);
+
+  assert_equals(res1_held_clients[0], res2_pending_clients[0]);
+  assert_equals(res2_held_clients[0], res1_pending_clients[0]);
+}, 'query() can observe a deadlock');

--- a/tests/worker-wpt/wpt/web-locks/resource-names.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/resource-names.https.any.js
@@ -1,0 +1,56 @@
+// META: title=Web Locks API: Resources DOMString edge cases
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+function code_points(s) {
+  return [...s]
+    .map(c => '0x' + c.charCodeAt(0).toString(16).toUpperCase())
+    .join(' ');
+}
+
+[
+  '', // Empty strings
+  'abc\x00def', // Embedded NUL
+  '\uD800', // Unpaired low surrogage
+  '\uDC00', // Unpaired high surrogage
+  '\uDC00\uD800', // Swapped surrogate pair
+  '\uFFFF' // Non-character
+].forEach(string => {
+  promise_test(async t => {
+    await navigator.locks.request(string, lock => {
+      assert_equals(lock.name, string,
+                          'Requested name matches granted name');
+    });
+  }, 'DOMString: ' + code_points(string));
+});
+
+promise_test(async t => {
+  // '\uD800' treated as a USVString would become '\uFFFD'.
+  await navigator.locks.request('\uD800', async lock => {
+    assert_equals(lock.name, '\uD800');
+
+    // |lock| is held for the duration of this name. It
+    // Should not block acquiring |lock2| with a distinct
+    // DOMString.
+    await navigator.locks.request('\uFFFD', lock2 => {
+      assert_equals(lock2.name, '\uFFFD');
+    });
+
+    // If we did not time out, this passed.
+  });
+}, 'Resource names that are not valid UTF-16 are not mangled');
+
+promise_test(async t => {
+  for (const name of ['-', '-foo']) {
+    await promise_rejects_dom(
+      t, 'NotSupportedError',
+      navigator.locks.request(name, lock => {}),
+      'Names starting with "-" should be rejected');
+  }
+  let got_lock = false;
+  await navigator.locks.request('x-anything', lock => {
+    got_lock = true;
+  });
+  assert_true(got_lock, 'Names with embedded "-" should be accepted');
+}, 'Names cannot start with "-"');

--- a/tests/worker-wpt/wpt/web-locks/resources/helpers.js
+++ b/tests/worker-wpt/wpt/web-locks/resources/helpers.js
@@ -1,0 +1,93 @@
+// Test helpers used by multiple Web Locks API tests.
+(() => {
+
+  // Generate a unique resource identifier, using the script path and
+  // test case name. This is useful to avoid lock interference between
+  // test cases.
+  let res_num = 0;
+  self.uniqueName = (testCase, prefix) => {
+    return `${self.location.pathname}-${prefix}-${testCase.name}-${++res_num}`;
+  };
+  self.uniqueNameByQuery = () => {
+    const prefix = new URL(location.href).searchParams.get('prefix');
+    // Add randomness to prevent tests from timing out on leaked locks from
+    // previous sub-tests in the same file.
+    return `${prefix}-${++res_num}-${Math.random()}`;
+  }
+
+  // Inject an iframe showing the given url into the page, and resolve
+  // the returned promise when the frame is loaded.
+  self.iframe = url => new Promise(resolve => {
+    const element = document.createElement('iframe');
+    element.addEventListener(
+      'load', () => { resolve(element); }, { once: true });
+    element.src = url;
+    document.documentElement.appendChild(element);
+  });
+
+  // Post a message to the target frame, and resolve the returned
+  // promise when a response comes back. The posted data is annotated
+  // with unique id to track the response. This assumes the use of
+  // 'iframe.html' as the frame, which implements this protocol.
+  let next_request_id = 0;
+  self.postToFrameAndWait = (frame, data) => {
+    const iframe_window = frame.contentWindow;
+    data.rqid = next_request_id++;
+    iframe_window.postMessage(data, '*');
+    return new Promise(resolve => {
+      const listener = event => {
+        if (event.source !== iframe_window || event.data.rqid !== data.rqid)
+          return;
+        self.removeEventListener('message', listener);
+        resolve(event.data);
+      };
+      self.addEventListener('message', listener);
+    });
+  };
+
+  // Post a message to the target worker, and resolve the returned
+  // promise when a response comes back. The posted data is annotated
+  // with unique id to track the response. This assumes the use of
+  // 'worker.js' as the worker, which implements this protocol.
+  self.postToWorkerAndWait = (worker, data) => {
+    return new Promise(resolve => {
+      data.rqid = next_request_id++;
+      worker.postMessage(data);
+      const listener = event => {
+        if (event.data.rqid !== data.rqid)
+          return;
+        worker.removeEventListener('message', listener);
+        resolve(event.data);
+      };
+      worker.addEventListener('message', listener);
+    });
+  };
+
+  /**
+   * Request a lock and hold it until the subtest ends.
+   * @param {*} t test runner object
+   * @param {string} name lock name
+   * @param {LockOptions=} options lock options
+   * @returns
+   */
+  self.requestLockAndHold = (t, name, options = {}) => {
+    let [promise, resolve] = self.makePromiseAndResolveFunc();
+    const released = navigator.locks.request(name, options, () => promise);
+    // Add a cleanup function that releases the lock by resolving the promise,
+    // and then waits until the lock is really released, to avoid contaminating
+    // following tests with temporarily held locks.
+    t.add_cleanup(() => {
+      resolve();
+      // Cleanup shouldn't fail if the request is aborted.
+      return released.catch(() => undefined);
+    });
+    return released;
+  };
+
+  self.makePromiseAndResolveFunc = () => {
+    let resolve;
+    const promise = new Promise(r => { resolve = r; });
+    return [promise, resolve];
+  };
+
+})();

--- a/tests/worker-wpt/wpt/web-locks/signal.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/signal.https.any.js
@@ -1,0 +1,261 @@
+// META: title=Web Locks API: AbortSignal integration
+// META: script=resources/helpers.js
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  // These cases should not work:
+  for (const signal of ['string', 12.34, false, {}, Symbol(), () => {}, self]) {
+    await promise_rejects_js(
+      t, TypeError,
+      navigator.locks.request(
+        res, {signal}, t.unreached_func('callback should not run')),
+      'Bindings should throw if the signal option is a not an AbortSignal');
+  }
+}, 'The signal option must be an AbortSignal');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  const controller = new AbortController();
+  controller.abort();
+
+  await promise_rejects_dom(
+    t, 'AbortError',
+    navigator.locks.request(res, {signal: controller.signal},
+                            t.unreached_func('callback should not run')),
+    'Request should reject with AbortError');
+}, 'Passing an already aborted signal aborts');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  const controller = new AbortController();
+  const reason = 'My dog ate it.';
+  controller.abort(reason);
+
+  const promise =
+        navigator.locks.request(res, {signal: controller.signal},
+                                t.unreached_func('callback should not run'));
+
+  await promise_rejects_exactly(
+    t, reason, promise, "Rejection should give the abort reason");
+}, 'Passing an already aborted signal rejects with the custom abort reason.');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  const controller = new AbortController();
+  controller.abort();
+
+  const promise =
+        navigator.locks.request(res, {signal: controller.signal},
+                                t.unreached_func('callback should not run'));
+
+  await promise_rejects_exactly(
+    t, controller.signal.reason, promise,
+    "Rejection should give the abort reason");
+}, 'Passing an already aborted signal rejects with the default abort reason.');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  // Grab a lock and hold it until this subtest completes.
+  requestLockAndHold(t, res);
+
+  const controller = new AbortController();
+
+  const promise =
+    navigator.locks.request(res, {signal: controller.signal},
+                            t.unreached_func('callback should not run'));
+
+  // Verify the request is enqueued:
+  const state = await navigator.locks.query();
+  assert_equals(state.held.filter(lock => lock.name === res).length, 1,
+                'Number of held locks');
+  assert_equals(state.pending.filter(lock => lock.name === res).length, 1,
+                'Number of pending locks');
+
+  const rejected = promise_rejects_dom(
+    t, 'AbortError', promise, 'Request should reject with AbortError');
+
+  controller.abort();
+
+  await rejected;
+
+}, 'An aborted request results in AbortError');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  // Grab a lock and hold it until this subtest completes.
+  requestLockAndHold(t, res);
+
+  const controller = new AbortController();
+
+  const promise =
+    navigator.locks.request(res, {signal: controller.signal}, lock => {});
+
+  // Verify the request is enqueued:
+  const state = await navigator.locks.query();
+  assert_equals(state.held.filter(lock => lock.name === res).length, 1,
+                'Number of held locks');
+  assert_equals(state.pending.filter(lock => lock.name === res).length, 1,
+                'Number of pending locks');
+
+  const rejected = promise_rejects_dom(
+    t, 'AbortError', promise, 'Request should reject with AbortError');
+
+  let callback_called = false;
+  t.step_timeout(() => {
+    callback_called = true;
+    controller.abort();
+  }, 10);
+
+  await rejected;
+  assert_true(callback_called, 'timeout should have caused the abort');
+
+}, 'Abort after a timeout');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  const controller = new AbortController();
+
+  let got_lock = false;
+  await navigator.locks.request(
+    res, {signal: controller.signal}, async lock => { got_lock = true; });
+
+  assert_true(got_lock, 'Lock should be acquired if abort is not signaled.');
+
+}, 'Signal that is not aborted');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  const controller = new AbortController();
+
+  let got_lock = false;
+  const p = navigator.locks.request(
+    res, {signal: controller.signal}, lock => { got_lock = true; });
+
+  // Even though lock is grantable, this abort should be processed synchronously.
+  controller.abort();
+
+  await promise_rejects_dom(t, 'AbortError', p, 'Request should abort');
+
+  assert_false(got_lock, 'Request should be aborted if signal is synchronous');
+
+  await navigator.locks.request(res, lock => { got_lock = true; });
+  assert_true(got_lock, 'Subsequent request should not be blocked');
+
+}, 'Synchronously signaled abort');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  const controller = new AbortController();
+
+  // Make a promise that resolves when the lock is acquired.
+  const [acquired_promise, acquired_func] = makePromiseAndResolveFunc();
+
+  // Request the lock.
+  let release_func;
+  const released_promise = navigator.locks.request(
+    res, {signal: controller.signal}, lock => {
+      acquired_func();
+
+      // Hold lock until release_func is called.
+      const [waiting_promise, waiting_func] = makePromiseAndResolveFunc();
+      release_func = waiting_func;
+      return waiting_promise;
+    });
+
+  // Wait for the lock to be acquired.
+  await acquired_promise;
+
+  // Signal an abort.
+  controller.abort();
+
+  // Release the lock.
+  release_func('resolved ok');
+
+  assert_equals(await released_promise, 'resolved ok',
+                'Lock released promise should not reject');
+
+}, 'Abort signaled after lock granted');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  const controller = new AbortController();
+
+  // Make a promise that resolves when the lock is acquired.
+  const [acquired_promise, acquired_func] = makePromiseAndResolveFunc();
+
+  // Request the lock.
+  let release_func;
+  const released_promise = navigator.locks.request(
+    res, {signal: controller.signal}, lock => {
+      acquired_func();
+
+      // Hold lock until release_func is called.
+      const [waiting_promise, waiting_func] = makePromiseAndResolveFunc();
+      release_func = waiting_func;
+      return waiting_promise;
+    });
+
+  // Wait for the lock to be acquired.
+  await acquired_promise;
+
+  // Release the lock.
+  release_func('resolved ok');
+
+  // Signal an abort.
+  controller.abort();
+
+  assert_equals(await released_promise, 'resolved ok',
+                'Lock released promise should not reject');
+
+}, 'Abort signaled after lock released');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  const controller = new AbortController();
+  const first = requestLockAndHold(t, res, { signal: controller.signal });
+  const next = navigator.locks.request(res, () => "resolved");
+  controller.abort();
+
+  await promise_rejects_dom(t, "AbortError", first, "Request should abort");
+  assert_equals(
+    await next,
+    "resolved",
+    "The next request is processed after abort"
+  );
+}, "Abort should process the next pending lock request");
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  const controller = new AbortController();
+  const promise = requestLockAndHold(t, res, { signal: controller.signal });
+
+  const reason = "My cat handled it";
+  controller.abort(reason);
+
+  await promise_rejects_exactly(t, reason, promise, "Rejection should give the abort reason");
+}, "Aborted promise should reject with the custom abort reason");
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  const controller = new AbortController();
+  const promise = requestLockAndHold(t, res, { signal: controller.signal });
+
+  controller.abort();
+
+  await promise_rejects_exactly(t, controller.signal.reason, promise, "Should be the same reason");
+}, "Aborted promise should reject with the default abort reason");

--- a/tests/worker-wpt/wpt/web-locks/steal.https.any.js
+++ b/tests/worker-wpt/wpt/web-locks/steal.https.any.js
@@ -1,0 +1,91 @@
+// META: title=Web Locks API: steal option
+// META: script=resources/helpers.js
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+
+'use strict';
+
+const never_settled = new Promise(resolve => { /* never */ });
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  let callback_called = false;
+  await navigator.locks.request(res, {steal: true}, lock => {
+    callback_called = true;
+    assert_not_equals(lock, null, 'Lock should be granted');
+  });
+  assert_true(callback_called, 'Callback should be called');
+}, 'Lock available');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+  let callback_called = false;
+
+  // Grab and hold the lock.
+  navigator.locks.request(res, lock => never_settled).catch(_ => {});
+
+  // Steal it.
+  await navigator.locks.request(res, {steal: true}, lock => {
+    callback_called = true;
+    assert_not_equals(lock, null, 'Lock should be granted');
+  });
+
+  assert_true(callback_called, 'Callback should be called');
+}, 'Lock not available');
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  // Grab and hold the lock.
+  const promise = navigator.locks.request(res, lock => never_settled);
+  const assertion = promise_rejects_dom(
+    t, 'AbortError', promise, `Initial request's promise should reject`);
+
+  // Steal it.
+  await navigator.locks.request(res, {steal: true}, lock => {});
+
+  await assertion;
+
+}, `Broken lock's release promise rejects`);
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  // Grab and hold the lock.
+  navigator.locks.request(res, lock => never_settled).catch(_ => {});
+
+  // Make a request for it.
+  let request_granted = false;
+  const promise = navigator.locks.request(res, lock => {
+    request_granted = true;
+  });
+
+  // Steal it.
+  await navigator.locks.request(res, {steal: true}, lock => {
+    assert_false(request_granted, 'Steal should override request');
+  });
+
+  await promise;
+  assert_true(request_granted, 'Request should eventually be granted');
+
+}, `Requested lock's release promise is deferred`);
+
+promise_test(async t => {
+  const res = uniqueName(t);
+
+  // Grab and hold the lock.
+  navigator.locks.request(res, lock => never_settled).catch(_ => {});
+
+  // Steal it.
+  let saw_abort = false;
+  const first_steal = navigator.locks.request(
+    res, {steal: true}, lock => never_settled).catch(error => {
+      saw_abort = true;
+    });
+
+  // Steal it again.
+  await navigator.locks.request(res, {steal: true}, lock => {});
+
+  await first_steal;
+  assert_true(saw_abort, 'First steal should have aborted');
+
+}, 'Last caller wins');


### PR DESCRIPTION
Adds 18 WPT files covering nub's polyfilled surface: URLPattern (3 active + 2 tentative-skip), Web Locks (12 active + 1 non-secure-context skip), reportError (skip).

`run-file.mjs`: `location`, `isSecureContext=false`, and `fetch`→local-file shims. The `location` shim also fixes two stale "Untitled" expected-fail names in existing webmessaging entries.

`status.json` tier attributions are honest against the real floor legs — #163 now pins each matrix leg to its own Node, and #164 backfills `navigator` + spec-faithful Web Locks to the 18.19 floor:

- URLPattern is native only on Node 24+; on 18/20/22 nub loads urlpattern-polyfill, whose 22 regex-divergences fail identically across those polyfill tiers (one versioned band, Node ≤ 23). The earlier Node-24 native bugs were fixed in 24.17, the version the floating `24` leg installs, so those bands are removed.
- Web Locks passes fully on every tier — including `signal`/`steal` on Node 22 — via #164's navigator-locks. Cross-worker `query()` subtests stay expected-fail (single-process locks); reportError stays skipped (async dispatch, no global ErrorEvent).

Verified on real Node 18.19 / 20.19 / 22.15 / 24.17: 0 unexpected-fail and 0 unexpected-pass on every leg.