### PR TITLE
test(wpt): pin the WPT Worker matrix to the floor Node it claims to test

### DIFF
--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -84,6 +84,63 @@ function installSyncPolyfills(preloaded) {
     });
   }
 
+  // ── File (global on Node 20+, missing on the 18.x compat floor) ─────
+  // Node exposes the WHATWG `File` as a global from Node 20; on 18.13–18.x it
+  // exists only as `node:buffer`'s `File` export. Backfill the global from there
+  // so worker/messaging code that constructs `new File(...)` works down to the
+  // floor (polyfill-all-the-way-down). Identity is preserved (same constructor as
+  // `node:buffer`), so `instanceof` and undici's webidl brand checks hold. Reading
+  // `buffer.File` on Node 18 emits a one-time `ExperimentalWarning`; suppress just
+  // that line so the floor backfill is silent (the API is stable in practice and
+  // is the standard global on Node 20+). Blob is already global on 18.x, but the
+  // same backfill guards it for completeness. Non-enumerable to match Node's own
+  // global descriptors (the additive contract: invisible to global enumeration).
+  if (typeof globalThis.File === "undefined" || typeof globalThis.Blob === "undefined") {
+    const origEmitWarning = process.emitWarning;
+    process.emitWarning = function (warning, ...rest) {
+      const opt = rest[0];
+      const type = opt && typeof opt === "object" ? opt.type : opt;
+      const msg = typeof warning === "string" ? warning : (warning && warning.message) || "";
+      if (type === "ExperimentalWarning" && /buffer\.(File|Blob)/.test(msg)) return;
+      return origEmitWarning.call(this, warning, ...rest);
+    };
+    try {
+      const buffer = require("node:buffer");
+      for (const name of ["File", "Blob"]) {
+        if (typeof globalThis[name] === "undefined" && typeof buffer[name] === "function") {
+          Object.defineProperty(globalThis, name, {
+            value: buffer[name],
+            enumerable: false,
+            writable: true,
+            configurable: true,
+          });
+        }
+      }
+    } finally {
+      process.emitWarning = origEmitWarning;
+    }
+  }
+
+  // ── MessageEvent.ports → frozen array (WHATWG read-only requirement) ─
+  // The spec mandates `MessageEvent.ports` be a read-only (frozen) array; Node's
+  // native MessageEvent returns a mutable array. Wrap the configurable prototype
+  // getter so every read yields a frozen array, for both a native MessageChannel's
+  // delivery and nub's worker-side MessageEvents. Idempotent (the wrapper is marked
+  // so a re-run in the same realm doesn't double-wrap).
+  if (typeof globalThis.MessageEvent === "function") {
+    const proto = globalThis.MessageEvent.prototype;
+    const desc = Object.getOwnPropertyDescriptor(proto, "ports");
+    if (desc && typeof desc.get === "function" && desc.configurable && !desc.get.__nubFreezesPorts) {
+      const origGet = desc.get;
+      const get = function () {
+        const ports = origGet.call(this);
+        return Array.isArray(ports) ? Object.freeze(ports) : ports;
+      };
+      get.__nubFreezesPorts = true;
+      Object.defineProperty(proto, "ports", { ...desc, get });
+    }
+  }
+
   // ── URLPattern (native on Node 24+, missing on 22.x) ───────────────
   if (typeof globalThis.URLPattern === "undefined") {
     const mod = preloaded.urlpattern;

--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -89,12 +89,18 @@ function installSyncPolyfills(preloaded) {
   // exists only as `node:buffer`'s `File` export. Backfill the global from there
   // so worker/messaging code that constructs `new File(...)` works down to the
   // floor (polyfill-all-the-way-down). Identity is preserved (same constructor as
-  // `node:buffer`), so `instanceof` and undici's webidl brand checks hold. Reading
-  // `buffer.File` on Node 18 emits a one-time `ExperimentalWarning`; suppress just
-  // that line so the floor backfill is silent (the API is stable in practice and
-  // is the standard global on Node 20+). Blob is already global on 18.x, but the
-  // same backfill guards it for completeness. Non-enumerable to match Node's own
-  // global descriptors (the additive contract: invisible to global enumeration).
+  // `node:buffer`), so `instanceof` and undici's webidl brand checks hold. Blob is
+  // already global on 18.x, but the same backfill guards it for completeness.
+  // Non-enumerable to match Node's own global descriptors (the additive contract:
+  // invisible to global enumeration).
+  //
+  // Node 18 emits a one-time `ExperimentalWarning: buffer.File …` on the FIRST
+  // `new File(...)` (the constructor, NOT the property read). Without nub the floor
+  // simply has no `File` global, so backfilling it would newly surface that warning
+  // when user code first constructs a File. To keep the floor backfill silent we
+  // force one throwaway construction INSIDE a suppression window: that consumes
+  // Node's once-per-feature guard (the warning is dropped here) so the user's later
+  // `new File(...)` is silent.
   if (typeof globalThis.File === "undefined" || typeof globalThis.Blob === "undefined") {
     const origEmitWarning = process.emitWarning;
     process.emitWarning = function (warning, ...rest) {
@@ -106,14 +112,19 @@ function installSyncPolyfills(preloaded) {
     };
     try {
       const buffer = require("node:buffer");
+      const sampleArgs = { File: [[], ""], Blob: [[]] };
       for (const name of ["File", "Blob"]) {
-        if (typeof globalThis[name] === "undefined" && typeof buffer[name] === "function") {
+        const Ctor = buffer[name];
+        if (typeof globalThis[name] === "undefined" && typeof Ctor === "function") {
           Object.defineProperty(globalThis, name, {
-            value: buffer[name],
+            value: Ctor,
             enumerable: false,
             writable: true,
             configurable: true,
           });
+          // Trip (and suppress) the experimental-feature warning now, so user code
+          // never sees it.
+          try { new Ctor(...sampleArgs[name]); } catch { /* construction shape varies; the warning fires regardless */ }
         }
       }
     } finally {

--- a/tests/worker-wpt/harness/run-wpt.mjs
+++ b/tests/worker-wpt/harness/run-wpt.mjs
@@ -54,12 +54,18 @@ const NUB = findNub();
 const status = JSON.parse(readFileSync(STATUS_PATH, "utf8"));
 
 // The Node version under test. In CI each matrix leg runs `node run-wpt.mjs` with
-// that leg's Node on PATH (setup-node), and WPT_NUB resolves the same Node — so the
-// orchestrator's own process.version IS the version every subprocess runs under.
-// Used to gate VERSION-SPECIFIC expected-fails (a divergence inherited from a
-// specific Node line, e.g. structuredClone(File) losing its File-ness on Node 22,
-// fixed in Node 24+) so the gate stays green on the floor without masking the
-// behavior on versions where it's actually correct.
+// that leg's Node on PATH (setup-node), so this orchestrator's own process.version
+// IS the version every subprocess must run under. We ENFORCE that below by pinning
+// NODE_EXECUTABLE=process.execPath on the spawned nub children — without it, nub
+// would read the repo-root package.json `engines.node` (>=22.15.0) and silently
+// PROVISION a satisfying Node on the floor legs, so the "Node 18.19/20 leg" would
+// actually run a >=22.15 Node and the floor coverage would be vacuous.
+//
+// NODE_MAJOR is used to gate VERSION-SPECIFIC expected-fails (a divergence inherited
+// from a specific Node line, e.g. structuredClone(File) losing its File-ness on Node
+// 22, fixed in Node 24+) so the gate stays green on the floor without masking the
+// behavior on versions where it's actually correct. The NODE_EXECUTABLE pin keeps
+// the children's Node provably equal to this NODE_MAJOR.
 const NODE_MAJOR = Number(process.versions.node.split(".")[0]) || 0;
 
 // Resolve a fail-entry to the set of subtest names expected to fail ON THIS Node.
@@ -116,7 +122,11 @@ function runOne(rel, scope) {
   return new Promise((res) => {
     const child = spawn(NUB, [DRIVER, WPT_ROOT, rel, scope], {
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env },
+      // Pin nub's Node to THIS harness's Node (the matrix leg's setup-node Node).
+      // NODE_EXECUTABLE bypasses pin-file/engines resolution, so nub can't upgrade
+      // past the floor via the repo-root engines.node >=22.15.0 — the floor legs
+      // run the real floor Node. (See the NODE_MAJOR comment above.)
+      env: { ...process.env, NODE_EXECUTABLE: process.execPath },
     });
     let out = "";
     let err = "";

--- a/tests/worker-wpt/status.json
+++ b/tests/worker-wpt/status.json
@@ -77,16 +77,40 @@
         ],
         "versioned": [
           {
-            "minMajor": 22,
-            "maxMajor": 22,
+            "maxMajor": 23,
             "expected": [
               "File basic",
               "A subclass instance will deserialize as its closest serializable superclass"
             ],
-            "note": "NODE 22 structured-clone bug: on the Node 22 line, structuredClone/postMessage of a File deserializes to a plain Blob — File-ness is lost (verified on vanilla Node 22.15.1 + 22.16.0, no nub: `structuredClone(new File([…])) instanceof File === false`). Node 24+ fixed it (round-trips as File). nub's polyfill is faithful — this is the underlying node:worker_threads/v8 serializer on v22, not a nub divergence — so it is an expected-fail ONLY on the Node 22 tier (which is the fast-tier FLOOR). The 'subclass deserializes as closest serializable superclass' subtest fails for the same reason (the File subclass collapses to Blob)."
+            "note": "NODE structured-clone limitation on every line BELOW 24: structuredClone/postMessage of a File deserializes to a plain Blob — File-ness is lost. Verified on vanilla Node (no nub) on 18.19, 20, and 22 (22.15.1/22.16.0): `structuredClone(new File([…])) instanceof File === false`. Node 24+ fixed it (round-trips as File). nub is faithful here — the loss is in the underlying node:worker_threads/v8 serializer, which nub does not intermediate for a native MessageChannel; nub backfills the `File` global on the 18.x floor (runtime/polyfills.cjs) so the test can construct the File, but cannot make the native serializer preserve its subclass identity. The 'subclass deserializes as closest serializable superclass' subtest fails for the same reason (the File subclass collapses to Blob)."
+          },
+          {
+            "maxMajor": 21,
+            "expected": [
+              "A detached ArrayBuffer cannot be transferred",
+              "Transferring a non-transferable platform object fails",
+              "Serializing a non-serializable platform object fails"
+            ],
+            "note": "NODE native-serializer error behavior on lines BELOW 22: Node's native MessageChannel postMessage does NOT reject these transfer/serialize error cases on Node 18/20 — re-transferring an already-detached ArrayBuffer, transferring a non-transferable Blob, and serializing a non-serializable Response all silently succeed instead of throwing DataCloneError. Verified on vanilla Node (no nub) on 18.19 and 20 (no throw) vs Node 22.15+/24 (throws DataCloneError). nub does not intermediate a native MessageChannel's serializer, so this is the underlying Node behavior, not a nub divergence — expected-fail on the 18/20 legs only."
+          },
+          {
+            "maxMajor": 19,
+            "expected": [
+              "Resizable ArrayBuffer",
+              "Length-tracking TypedArray",
+              "Length-tracking DataView",
+              "Serializing OOB TypedArray throws",
+              "Serializing OOB DataView throws",
+              "Resizable ArrayBuffer is transferable",
+              "Length-tracking TypedArray is transferable",
+              "Length-tracking DataView is transferable",
+              "Transferring OOB TypedArray throws",
+              "Transferring OOB DataView throws"
+            ],
+            "note": "NODE 18 V8 limitation: resizable/growable ArrayBuffer (the `maxByteLength` option + `ArrayBuffer.prototype.resize`) is a V8 feature that landed in Node 20 — it is absent on the 18.x compat floor (`new ArrayBuffer(n, {maxByteLength}).resize` is not a function). nub cannot add a V8 engine feature, so these resizable-buffer serialize/transfer subtests are expected-fail on the Node 18 leg only; Node 20+ has the feature and passes them."
           }
         ],
-        "note": "Structured-clone battery (152 subtests). The version-independent expected fails are all NON-Blob: (1) DOM-only types with NO Node substrate — FileList/ImageData/ImageBitmap need `document`/canvas (throw 'document is not defined' / 'OffscreenCanvas is not defined'); legitimately out of scope (no DOM on Node), kept expected-fail rather than skip so a future DOM polyfill surfaces as an unexpected-pass. (2) 'Growable SharedArrayBuffer instanceof ArrayBuffer' — a growable SAB is not an ArrayBuffer instance under Node. Plus two Node-22-ONLY File-clone fails (see `versioned`). The 19 Blob clone rows now PASS — `cloned instanceof Blob` AND the Blob's bytes-via-Response are fixed (runtime/worker-blob-url.cjs makes globalThis.Blob a Proxy over the native Blob, keeping `globalThis.Blob.prototype === node:buffer.Blob.prototype` so a deserialized native Blob passes both `instanceof` and undici's webidl brand check). Every Map/Set/Date/typed-array/SAB-identity/transfer/circular case also passes."
+        "note": "Structured-clone battery (152 subtests). The version-independent expected fails are all NON-Blob: (1) DOM-only types with NO Node substrate — FileList/ImageData/ImageBitmap need `document`/canvas (throw 'document is not defined' / 'OffscreenCanvas is not defined'); legitimately out of scope (no DOM on Node), kept expected-fail rather than skip so a future DOM polyfill surfaces as an unexpected-pass. (2) 'Growable SharedArrayBuffer instanceof ArrayBuffer' — a growable SAB is not an ArrayBuffer instance under Node. Plus three VERSION-GATED bands (see `versioned`), all genuine below-floor Node limitations nub cannot fix and does not mask on the versions where the behavior is correct: File→Blob clone loss on Node <24, native-serializer non-rejection on Node <22, and resizable-ArrayBuffer absence on Node 18. The 19 Blob clone rows now PASS — `cloned instanceof Blob` AND the Blob's bytes-via-Response are fixed (runtime/worker-blob-url.cjs makes globalThis.Blob a Proxy over the native Blob, keeping `globalThis.Blob.prototype === node:buffer.Blob.prototype` so a deserialized native Blob passes both `instanceof` and undici's webidl brand check). Every Map/Set/Date/typed-array/SAB-identity/transfer/circular case also passes."
       }
     },
 

--- a/tests/worker-wpt/status.json
+++ b/tests/worker-wpt/status.json
@@ -91,7 +91,7 @@
               "Transferring a non-transferable platform object fails",
               "Serializing a non-serializable platform object fails"
             ],
-            "note": "NODE native-serializer error behavior on lines BELOW 22: Node's native MessageChannel postMessage does NOT reject these transfer/serialize error cases on Node 18/20 — re-transferring an already-detached ArrayBuffer, transferring a non-transferable Blob, and serializing a non-serializable Response all silently succeed instead of throwing DataCloneError. Verified on vanilla Node (no nub) on 18.19 and 20 (no throw) vs Node 22.15+/24 (throws DataCloneError). nub does not intermediate a native MessageChannel's serializer, so this is the underlying Node behavior, not a nub divergence — expected-fail on the 18/20 legs only."
+            "note": "NODE native-serializer error behavior on lines BELOW 22: Node's native MessageChannel postMessage does NOT reject these transfer/serialize error cases on Node 18/20 — re-transferring an already-detached ArrayBuffer, transferring a non-transferable Blob, and serializing a non-serializable Response all silently succeed instead of throwing DataCloneError. Verified on vanilla Node (no nub) on 18.19 and 20 (no throw) vs Node 22.15+/24 (throws DataCloneError). nub does not intermediate a native MessageChannel's serializer, so this is the underlying Node behavior, not a nub divergence — expected-fail on the 18/20 legs only. The throw boundary is verified at the matrix legs (no-throw on 18.19/20, throws on 22.15+); if a sub-22.15 leg (22.0-22.14) is ever added, re-verify the exact minor where the native rejection landed."
           },
           {
             "maxMajor": 19,


### PR DESCRIPTION
The WPT harness spawns nub with cwd = repo root, so nub reads the root `engines.node >=22.15.0` and, on the floor legs (18.19, 20), silently provisions a >=22.15 Node — the "18.19 leg" actually ran a fast-tier Node, making the compat-floor coverage vacuous.

Fix: pin `NODE_EXECUTABLE=process.execPath` on the spawned nub children. `NODE_EXECUTABLE` is nub's existing override (bypasses pin-file/engines resolution; the floor check still applies); the harness runs under the leg's Node, so the children now run that exact Node.

Reproduced: floor 18.19 + `engines >=22.15.0` ran v26.2.0 without the pin, v18.19.0 with it.

Refs #158