### PR TITLE
feat(runtime): backfill navigator on Node <21 and make Web Locks spec-faithful

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -686,6 +686,47 @@ fn urlpattern_available() {
 }
 
 #[test]
+fn web_locks_spec_behavior() {
+    // Web Locks works to the spec under nub on every supported Node: the hand-rolled
+    // polyfill below 24.5, native at/above. The fixture asserts steal, option/name
+    // validation, reader/writer fairness, AbortSignal, and core mutual exclusion —
+    // every assertion holds on BOTH paths, so this is a true differential test (a
+    // regression on either turns it red). On the 18.19–20.x compat legs it also proves
+    // the navigator backfill hosts navigator.locks. Verified against the WPT web-locks
+    // suite (68/68 of the runnable subtests, matching native Node) across 18.19/20.19/
+    // 22.15/24.4 at implementation time.
+    let (stdout, stderr, code) = run_nub("web-locks", "main.mjs");
+    assert_eq!(
+        code, 0,
+        "web-locks spec checks must pass: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("weblocks:ALL-OK"),
+        "all web-locks scenarios pass: {stdout}"
+    );
+}
+
+#[test]
+fn navigator_surface_present() {
+    // `navigator` is present and well-shaped under nub on every supported Node —
+    // native on 21+, backfilled by navigator-shim.mjs on 18.19–20.x — with a
+    // `Node.js/<major>` userAgent (never `Nub/…`: brand boundary).
+    let (stdout, stderr, code) = run_nub("navigator-shim", "main.mjs");
+    assert_eq!(
+        code, 0,
+        "navigator surface must be well-shaped: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("navshim:ALL-OK"),
+        "navigator surface checks pass: {stdout}"
+    );
+    assert!(
+        !stdout.to_lowercase().contains("navshim:ua:nub"),
+        "navigator.userAgent must not be nub-branded: {stdout}"
+    );
+}
+
+#[test]
 fn jsonc_import_works() {
     let (stdout, stderr, code) = run_nub("jsonc-import", "main.ts");
     assert_eq!(code, 0, "stderr: {stderr}");

--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -434,11 +434,33 @@ pub static FEATURES: &[Feature] = &[
         )],
         evidence: "browser-shape Worker not in any Node; wraps node:worker_threads",
     },
+    // ── navigator global ────────────────────────────────────────────────────
+    // The `navigator` object (hardwareConcurrency / userAgent / language / languages
+    // / platform, and from 24.5 `locks`) was added in Node 21.0.0 (#47769). Below 21
+    // it is wholly absent, so any API hosted ON navigator — chiefly navigator.locks —
+    // has no object to attach to. nub backfills the navigator object from
+    // navigator-shim.mjs so the surface (and locks, below) reaches the 18.19 floor.
+    // The userAgent stays `Node.js/<major>` — never `Nub/…` (brand boundary).
+    Feature {
+        name: "navigator",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((21, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "navigator-shim.mjs",
+                    global: "globalThis.navigator",
+                },
+            ),
+            (band((21, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "navigator global added Node 21.0.0 (#47769); backfilled below the 21.0 floor",
+    },
     // ── navigator.locks (Web Locks API) ─────────────────────────────────────
     // Native on Node 24.5+ (worker: add web locks api, #58666 — NOT 24.0: the
     // global is undefined on 24.0–24.4); below that nub installs a Web Locks
     // polyfill onto `navigator.locks` (typeof-gated, so the 24.0–24.4 gap is
-    // covered either way).
+    // covered either way). On Node < 21 the polyfill rides on the navigator object
+    // the `navigator` row backfills (navigator-shim.mjs runs first).
     Feature {
         name: "navigator.locks",
         mitigations: &[

--- a/runtime/navigator-locks.mjs
+++ b/runtime/navigator-locks.mjs
@@ -1,10 +1,21 @@
-// Web Locks API polyfill for Node 22.x (native on Node 24.5+).
-// Single-process only — locks don't coordinate across workers.
+// Web Locks API polyfill for Node < 24.5 (native on Node 24.5+, #58666).
+// Single-process only — locks don't coordinate across worker threads (a deliberate
+// scope: the common in-process serialization use is covered; cross-thread coordination
+// would need a SharedArrayBuffer waitlist and is out of scope until there's demand).
+//
+// Spec: https://w3c.github.io/web-locks/. Modeled to match Node's own
+// internal/locks.js (the native impl on 24.5+) so behavior is identical across the
+// version boundary — including `steal`, AbortSignal integration, and the option/name
+// validation that the WPT web-locks suite exercises. Requires a `navigator` object to
+// host `navigator.locks`; navigator-shim.mjs backfills that on Node < 21 and MUST run
+// first.
 
 if (typeof globalThis.navigator === "object" && typeof globalThis.navigator.locks === "undefined") {
-  // Track held locks: name → { mode, count } where count > 1 means shared holders
-  const held = new Map();
-  const queue = new Map();
+  const AbortSig = globalThis.AbortSignal;
+
+  const abortError = (msg) => new DOMException(msg || "The operation was aborted", "AbortError");
+  const stolenError = () => abortError("The lock was stolen by another request");
+  const notSupported = (msg) => new DOMException(msg, "NotSupportedError");
 
   class Lock {
     #name;
@@ -17,113 +28,204 @@ if (typeof globalThis.navigator === "object" && typeof globalThis.navigator.lock
     get mode() { return this.#mode; }
   }
 
+  // held: name → { mode, holders:Set<Holder> }. A shared grant has N holders sharing
+  // one record; an exclusive grant has exactly one. queue: name → Array<Waiter> (FIFO).
+  const held = new Map();
+  const queue = new Map();
+
   function canAcquire(name, mode) {
-    const current = held.get(name);
-    if (!current) return true;
-    if (mode === "shared" && current.mode === "shared") return true;
-    return false;
+    const rec = held.get(name);
+    if (!rec) return true;
+    return mode === "shared" && rec.mode === "shared";
   }
 
-  function acquire(name, mode) {
-    const current = held.get(name);
-    if (current && mode === "shared" && current.mode === "shared") {
-      current.count++;
-    } else {
-      held.set(name, { mode, count: 1 });
-    }
+  // A FRESH request may be granted immediately only when no waiters are already
+  // queued for the name — otherwise it must queue behind them. This is the
+  // reader/writer FAIRNESS rule: a new shared request must NOT barge ahead of a
+  // pending exclusive request and join the current shared holders, which would
+  // starve the writer (WPT mode-mixed "An exclusive lock between shared locks").
+  // drainQueue, which only ever grants from the FRONT of the queue, keeps using
+  // canAcquire directly.
+  function canGrantNow(name, mode) {
+    const q = queue.get(name);
+    if (q && q.length > 0) return false;
+    return canAcquire(name, mode);
   }
 
-  function release(name) {
-    const current = held.get(name);
-    if (!current) return;
-    current.count--;
-    if (current.count <= 0) {
-      held.delete(name);
-      drainQueue(name);
-    }
+  function addHolder(name, mode, holder) {
+    const rec = held.get(name);
+    if (rec) rec.holders.add(holder);
+    else held.set(name, { mode, holders: new Set([holder]) });
   }
 
+  function removeHolder(name, holder) {
+    const rec = held.get(name);
+    if (!rec) return;
+    rec.holders.delete(holder);
+    if (rec.holders.size === 0) held.delete(name);
+  }
+
+  function enqueue(name, waiter) {
+    let q = queue.get(name);
+    if (!q) queue.set(name, (q = []));
+    q.push(waiter);
+  }
+
+  // Grant as many head-of-queue waiters as the current held state allows: a head
+  // exclusive takes the lock alone; a run of head shared waiters is all granted.
   function drainQueue(name) {
     const q = queue.get(name);
     if (!q || q.length === 0) return;
-
-    // Try to grant as many queued requests as possible.
-    // If the first queued is shared, grant all consecutive shared requests.
-    // If the first queued is exclusive, grant only that one.
-    const first = q[0];
-    if (canAcquire(name, first.mode)) {
-      if (first.mode === "exclusive") {
-        q.shift();
-        first.resolve();
-      } else {
-        // Grant all consecutive shared requests.
-        while (q.length > 0 && q[0].mode === "shared") {
-          const req = q.shift();
-          req.resolve();
-        }
-      }
+    while (q.length > 0) {
+      const first = q[0];
+      if (!canAcquire(name, first.mode)) break;
+      q.shift();
+      first.grant(); // synchronously addHolders, so canAcquire reflects it next iter
+      if (first.mode === "exclusive") break;
     }
+    if (q.length === 0) queue.delete(name);
+  }
+
+  // Run `cb(lock)` as a holder of (name, mode); return the promise that settles when
+  // the holder releases (cb's result/throw) — or rejects early if a steal BREAKS it.
+  // The callback is invoked one microtask later (matching Node), so a synchronously
+  // signaled abort is observed before the callback runs.
+  function runHolder(name, mode, cb) {
+    const lock = new Lock(name, mode);
+    let broken = false;
+    let rejectReleased;
+    const holder = {
+      mode,
+      break(reason) {
+        if (broken) return;
+        broken = true;
+        // Remove WITHOUT draining — the stealer takes the lock next; queued waiters
+        // stay pending until the steal's own holder releases.
+        removeHolder(name, holder);
+        rejectReleased(reason);
+      },
+    };
+    addHolder(name, mode, holder);
+    return new Promise((resolve, reject) => {
+      rejectReleased = reject;
+      Promise.resolve()
+        .then(() => cb(lock))
+        .then(
+          (value) => { if (!broken) { removeHolder(name, holder); resolve(value); drainQueue(name); } },
+          (err) => { if (!broken) { removeHolder(name, holder); reject(err); drainQueue(name); } },
+        );
+    });
+  }
+
+  // The lock engine: returns the `released` promise. `cb` receives the granted Lock
+  // (or null on an ifAvailable miss). Mirrors the grant/steal/ifAvailable/queue shape
+  // of Node's internalBinding('locks').request.
+  function engineRequest(name, mode, steal, ifAvailable, cb) {
+    if (steal) {
+      const rec = held.get(name);
+      if (rec) for (const h of [...rec.holders]) h.break(stolenError());
+      return runHolder(name, "exclusive", cb);
+    }
+    if (canGrantNow(name, mode)) {
+      return runHolder(name, mode, cb);
+    }
+    if (ifAvailable) {
+      return Promise.resolve().then(() => cb(null));
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        mode,
+        settled: false,
+        grant() {
+          if (waiter.settled) return;
+          waiter.settled = true;
+          runHolder(name, mode, cb).then(resolve, reject);
+        },
+      };
+      enqueue(name, waiter);
+    });
   }
 
   class LockManager {
-    async request(name, optionsOrCallback, callback) {
-      let options = {};
-      if (typeof optionsOrCallback === "function") {
-        callback = optionsOrCallback;
-      } else {
-        options = optionsOrCallback || {};
+    async request(name, optionsOrCallback, maybeCallback) {
+      let options = optionsOrCallback;
+      let callback = maybeCallback;
+      if (callback === undefined) {
+        callback = options;
+        options = undefined;
       }
 
-      const mode = options.mode || "exclusive";
-      const ifAvailable = options.ifAvailable || false;
+      // WebIDL DOMString coercion (throws TypeError on a Symbol, like the binding).
+      name = `${name}`;
+      if (typeof callback !== "function") {
+        throw new TypeError("Failed to execute 'request' on 'LockManager': parameter 2 is not a function.");
+      }
+      if (options === undefined || typeof options === "function") options = {};
+
+      const mode = options.mode === undefined ? "exclusive" : options.mode;
+      if (mode !== "exclusive" && mode !== "shared") {
+        throw new TypeError(`Failed to execute 'request' on 'LockManager': '${mode}' is not a valid value for enumeration LockMode.`);
+      }
+      const ifAvailable = !!options.ifAvailable;
+      const steal = !!options.steal;
       const signal = options.signal;
-
-      if (signal?.aborted) {
-        throw signal.reason || new DOMException("Lock request aborted", "AbortError");
+      if (signal !== undefined && signal !== null && !(AbortSig && signal instanceof AbortSig)) {
+        throw new TypeError("Failed to execute 'request' on 'LockManager': member signal is not of type AbortSignal.");
       }
 
-      if (!canAcquire(name, mode)) {
-        if (ifAvailable) {
-          return callback(null);
-        }
-        await new Promise((resolve, reject) => {
-          if (!queue.has(name)) queue.set(name, []);
-          queue.get(name).push({ resolve, reject, mode });
-          if (signal) {
-            signal.addEventListener("abort", () => {
-              const q = queue.get(name) || [];
-              const idx = q.findIndex((e) => e.resolve === resolve);
-              if (idx !== -1) q.splice(idx, 1);
-              reject(signal.reason || new DOMException("Lock request aborted", "AbortError"));
-            }, { once: true });
-          }
+      // Already-aborted signal rejects with its reason BEFORE the option-combo checks
+      // (matching Node's signal.throwIfAborted() ordering).
+      if (signal && signal.aborted) {
+        throw signal.reason || abortError();
+      }
+      if (name[0] === "-") {
+        throw notSupported("Lock name may not start with hyphen '-'");
+      }
+      if (ifAvailable && steal) {
+        throw notSupported("ifAvailable and steal options cannot be used together");
+      }
+      if (mode !== "exclusive" && steal) {
+        throw notSupported("mode must be 'exclusive' when using the steal option");
+      }
+      if (signal && (steal || ifAvailable)) {
+        throw notSupported("signal cannot be used with the steal or ifAvailable options");
+      }
+
+      // Signal path: the callback is deferred and skipped if the signal aborts before
+      // it runs; the abort rejects the OUTER promise iff the callback hasn't entered
+      // (lockGranted false). Verbatim shape of Node's internal/locks.js so a queued
+      // abort releases the slot (callback skipped) and the next waiter is granted.
+      if (signal) {
+        return new Promise((resolve, reject) => {
+          let lockGranted = false;
+          const onAbort = () => {
+            if (!lockGranted) reject(signal.reason || abortError());
+          };
+          signal.addEventListener("abort", onAbort, { once: true });
+          const wrapped = (lock) =>
+            Promise.resolve().then(() => {
+              if (signal.aborted) return undefined;
+              lockGranted = true;
+              return callback(lock);
+            });
+          const released = engineRequest(name, mode, false, false, wrapped);
+          released.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
         });
       }
 
-      acquire(name, mode);
-      const lock = new Lock(name, mode);
-
-      try {
-        return await callback(lock);
-      } finally {
-        release(name);
-      }
+      return engineRequest(name, mode, steal, ifAvailable, (lock) => callback(lock));
     }
 
     async query() {
-      const heldLocks = [];
-      for (const [name, info] of held) {
-        for (let i = 0; i < info.count; i++) {
-          heldLocks.push({ name, mode: info.mode, clientId: "" });
-        }
+      const heldOut = [];
+      for (const [name, rec] of held) {
+        for (let i = 0; i < rec.holders.size; i++) heldOut.push({ name, mode: rec.mode, clientId: "" });
       }
       const pending = [];
       for (const [name, q] of queue) {
-        for (const req of q) {
-          pending.push({ name, mode: req.mode, clientId: "" });
-        }
+        for (const w of q) if (!w.settled) pending.push({ name, mode: w.mode, clientId: "" });
       }
-      return { held: heldLocks, pending };
+      return { held: heldOut, pending };
     }
   }
 

--- a/runtime/navigator-locks.mjs
+++ b/runtime/navigator-locks.mjs
@@ -217,13 +217,18 @@ if (typeof globalThis.navigator === "object" && typeof globalThis.navigator.lock
     }
 
     async query() {
+      // clientId is per-realm and opaque: `node-<pid>-0` (single-process; this polyfill
+      // does not coordinate across worker threads, so the threadId slot is always 0 —
+      // and we avoid importing node:worker_threads to keep this module builtin-free for a
+      // cheap bootstrap). The cross-context distinct-id WPT cases are browser-specific.
+      const clientId = `node-${process.pid}-0`;
       const heldOut = [];
       for (const [name, rec] of held) {
-        for (let i = 0; i < rec.holders.size; i++) heldOut.push({ name, mode: rec.mode, clientId: "" });
+        for (let i = 0; i < rec.holders.size; i++) heldOut.push({ name, mode: rec.mode, clientId });
       }
       const pending = [];
       for (const [name, q] of queue) {
-        for (const w of q) if (!w.settled) pending.push({ name, mode: w.mode, clientId: "" });
+        for (const w of q) if (!w.settled) pending.push({ name, mode: w.mode, clientId });
       }
       return { held: heldOut, pending };
     }

--- a/runtime/navigator-shim.mjs
+++ b/runtime/navigator-shim.mjs
@@ -1,0 +1,140 @@
+// `navigator` global backfill for Node < 21 (where the global is wholly absent).
+//
+// Node ships `globalThis.navigator` from 21.0.0. Below that it is `undefined`, so
+// any web-platform API hosted ON navigator — chiefly `navigator.locks` (Web Locks,
+// see navigator-locks.mjs) — has no object to attach to and silently does nothing.
+// nub's floor is 18.19, so to make those APIs reach the floor we synthesize the
+// `navigator` object Node 21+ would provide. Companion to navigator-locks.mjs:
+// this MUST run BEFORE it so locks has a host on 18.19–20.x.
+//
+// Shape mirrors Node's internal/navigator.js: a `Navigator` instance with the
+// enumerable prototype getters `hardwareConcurrency`, `language`, `languages`,
+// `userAgent`, `platform` (locks is added separately by navigator-locks.mjs). The
+// userAgent is `Node.js/<major>` — NEVER `Nub/…`: the user is running Node, nub is
+// the augmenter, and a `Nub/` UA would be a brand-boundary leak.
+//
+// VERSION-GATE, not a global read: installNavigatorShim() returns early on Node >= 21
+// from `process.versions.node` WITHOUT ever touching `globalThis.navigator`. That
+// matters because on Node 24.5+ the native `navigator` is a lazy getter whose first
+// access realizes ~30 internal/stream/worker-io builtins — a cold-start regression
+// (test-bootstrap-modules). The shim must never trigger that; the version check makes
+// the fast tier (>= 22.15, navigator always present) a free no-op.
+//
+// node: builtins (node:os) are fetched via `process.getBuiltinModule` when present,
+// else via a createRequire THREADED IN through `setBootstrapCreateRequire` — the same
+// brand-safe, off-the-user-loader-chain pattern worker-polyfill.mjs uses. The narrow
+// floor (18.19.x, 20.11–20.15) lacks `process.getBuiltinModule`, and the shim only
+// touches os lazily (the `hardwareConcurrency` getter), so the threaded require is
+// needed exactly there. `os` is never loaded on Node >= 21 (the early return).
+
+let _bootstrapCreateRequire = null;
+export function setBootstrapCreateRequire(fn) {
+  _bootstrapCreateRequire = fn;
+}
+
+function __getBuiltin(id) {
+  if (typeof process.getBuiltinModule === "function") return process.getBuiltinModule(id);
+  if (_bootstrapCreateRequire) return _bootstrapCreateRequire(import.meta.url)(id);
+  // Last-resort: a bare specifier require off this module's own createRequire is
+  // unavailable in ESM without node:module, which is exactly what the threading
+  // avoids importing statically. If neither path is wired, surface a clear error.
+  throw new Error("navigator-shim: no builtin accessor for " + id);
+}
+
+function deriveLanguage() {
+  // Approximate Node's ICU default locale from the POSIX locale env, falling back
+  // to "en-US" (Node's own fallback). `en_US.UTF-8` → `en-US`.
+  const raw =
+    process.env.LC_ALL || process.env.LC_MESSAGES || process.env.LANG || "";
+  const base = raw.split(".")[0].split("@")[0].replace("_", "-");
+  return base && base !== "C" && base !== "POSIX" ? base : "en-US";
+}
+
+function navigatorPlatform(platform, arch) {
+  // Mirror node/lib/internal/navigator.js getNavigatorPlatform.
+  if (platform === "darwin") return "MacIntel";
+  if (platform === "win32") return "Win32";
+  if (platform === "linux") {
+    if (arch === "ia32") return "Linux i686";
+    if (arch === "x64") return "Linux x86_64";
+    return `Linux ${arch}`;
+  }
+  if (platform === "freebsd") return arch === "ia32" ? "FreeBSD i386" : arch === "x64" ? "FreeBSD amd64" : `FreeBSD ${arch}`;
+  if (platform === "openbsd") return arch === "ia32" ? "OpenBSD i386" : arch === "x64" ? "OpenBSD amd64" : `OpenBSD ${arch}`;
+  if (platform === "sunos") return arch === "ia32" ? "SunOS i86pc" : `SunOS ${arch}`;
+  if (platform === "aix") return "AIX";
+  return `${platform[0].toUpperCase()}${platform.slice(1)} ${arch}`;
+}
+
+// Build the Navigator class lazily (only when actually backfilling) so loading this
+// module on the fast tier costs nothing beyond the early-return check.
+function makeNavigator() {
+  let _hw, _lang, _langs, _ua, _plat;
+  class Navigator {
+    get hardwareConcurrency() {
+      // os.availableParallelism honors cgroup CPU limits (Node 18.14+/19.4+; present
+      // on the 18.19 floor); fall back to cpus().length on the off chance it's absent.
+      if (_hw === undefined) {
+        const os = __getBuiltin("node:os");
+        _hw = typeof os.availableParallelism === "function" ? os.availableParallelism() : os.cpus().length;
+      }
+      return _hw;
+    }
+    get language() {
+      return (_lang ??= deriveLanguage());
+    }
+    get languages() {
+      return (_langs ??= Object.freeze([this.language]));
+    }
+    get userAgent() {
+      // `Node.js/<major>` — match Node exactly; never a nub-branded UA.
+      return (_ua ??= `Node.js/${process.versions.node.split(".")[0]}`);
+    }
+    get platform() {
+      return (_plat ??= navigatorPlatform(process.platform, process.arch));
+    }
+  }
+  // Match Node: the property getters live on the prototype and are enumerable, so a
+  // `for (const k in navigator)` walks them, while `Object.keys(navigator)` (own
+  // enumerable) is empty — exactly Node's instance shape.
+  return { Navigator, instance: new Navigator() };
+}
+
+// Install the navigator backfill if and only if the running Node lacks the global
+// (i.e. Node < 21). Idempotent and side-effect-free on Node >= 21.
+export function installNavigatorShim() {
+  const major = parseInt(process.versions.node.split(".")[0], 10);
+  // Node 21+ ships navigator natively — never read the (possibly lazy) global here.
+  if (major >= 21) return;
+  // Defensive idempotency for the < 21 path (navigator is genuinely undefined there,
+  // so this read can't trigger a lazy realization).
+  if (typeof globalThis.navigator !== "undefined") return;
+
+  const { Navigator, instance } = makeNavigator();
+
+  // The binding on globalThis is NON-ENUMERABLE (invisible to Object.keys(globalThis)
+  // / for-in) — nub's additive-global contract, matching how reportError and Worker
+  // are installed. Configurable + writable so user code may still override it.
+  Object.defineProperty(globalThis, "navigator", {
+    value: instance,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  });
+  // Node also exposes the `Navigator` constructor globally; mirror it (non-enumerable).
+  if (typeof globalThis.Navigator === "undefined") {
+    Object.defineProperty(globalThis, "Navigator", {
+      value: Navigator,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+  }
+}
+
+// Fast tier / modern compat (getBuiltinModule present, Node >= 20.16): install eagerly
+// at module eval — a guaranteed no-op above Node 21 thanks to the version gate, and
+// correct on a 20.16–20.x compat run where navigator is still absent. On the narrow
+// floor below getBuiltinModule the compat entry calls setBootstrapCreateRequire(...)
+// + installNavigatorShim() explicitly (mirroring worker-polyfill's wiring).
+if (typeof process.getBuiltinModule === "function") installNavigatorShim();

--- a/runtime/navigator-shim.mjs
+++ b/runtime/navigator-shim.mjs
@@ -94,9 +94,13 @@ function makeNavigator() {
       return (_plat ??= navigatorPlatform(process.platform, process.arch));
     }
   }
-  // Match Node: the property getters live on the prototype and are enumerable, so a
-  // `for (const k in navigator)` walks them, while `Object.keys(navigator)` (own
-  // enumerable) is empty — exactly Node's instance shape.
+  // Match Node's instance shape: the property getters live on the prototype and are
+  // ENUMERABLE (Node sets them with kEnumerableProperty), so `for (const k in
+  // navigator)` walks them while `Object.keys(navigator)` (own enumerable) is empty.
+  // Class-body getters default to enumerable:false, so flip them in place.
+  for (const k of ["hardwareConcurrency", "language", "languages", "userAgent", "platform"]) {
+    Object.defineProperty(Navigator.prototype, k, { enumerable: true });
+  }
   return { Navigator, instance: new Navigator() };
 }
 

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -209,6 +209,19 @@ function installLazyEsmPolyfills() {
     }
   };
 
+  // navigator backfill, ordered BEFORE the navigator.locks installs below so locks
+  // always has a host. The fast tier floor is 22.15 (navigator is always native, >= 21),
+  // so installNavigatorShim() version-checks and returns WITHOUT reading globalThis
+  // .navigator — never triggering the 24.5+ lazy-navigator realization. It does real
+  // work only if this preload is ever reached on Node < 21; on the fast floor it is a
+  // cheap no-op, wired for symmetry with the compat tier. See navigator-shim.mjs.
+  try {
+    __require("./navigator-shim.mjs").installNavigatorShim();
+  } catch {
+    // require(esm) disabled (--no-experimental-require-module): navigator is native at
+    // the fast floor, so skipping the no-op shim is harmless.
+  }
+
   if (inWorkerThread) {
     // Worker-side scope bootstrap must be present synchronously where possible.
     loadEsmSideEffect("./worker-polyfill.mjs");

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -217,9 +217,11 @@ function installLazyEsmPolyfills() {
   // cheap no-op, wired for symmetry with the compat tier. See navigator-shim.mjs.
   try {
     __require("./navigator-shim.mjs").installNavigatorShim();
-  } catch {
+  } catch (err) {
     // require(esm) disabled (--no-experimental-require-module): navigator is native at
-    // the fast floor, so skipping the no-op shim is harmless.
+    // the fast floor, so skipping the no-op shim is harmless. Any OTHER error is a real
+    // fault in the module — surface it rather than swallow it.
+    if (!err || err.code !== "ERR_REQUIRE_ESM") throw err;
   }
 
   if (inWorkerThread) {

--- a/runtime/preload.mjs
+++ b/runtime/preload.mjs
@@ -112,6 +112,14 @@ if (__isFastTier) {
 // modules is unreliable, so they load via dynamic `import()` here.
 const __preloadedPolyfills = common.preloadPolyfillPackages(__require);
 installSyncPolyfills(__preloadedPolyfills);
+// navigator backfill (Node < 21: the `navigator` global is wholly absent). MUST run
+// BEFORE navigator-locks so Web Locks has a host on the 18.19–20.x floor. On Node >= 21
+// it is a no-op (navigator is native). Thread the floor's createRequire so the shim can
+// fetch node:os where process.getBuiltinModule is absent (the narrow floor). See
+// navigator-shim.mjs.
+const __navShim = await import("./navigator-shim.mjs");
+__navShim.setBootstrapCreateRequire(floorCreateRequire);
+__navShim.installNavigatorShim();
 if (typeof globalThis.navigator?.locks === "undefined") {
   await import("./navigator-locks.mjs");
 }

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -92,6 +92,7 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`Error.isError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError) | — | polyfilled below Node 24, native above |
 | [`Promise.try`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try) | — | polyfilled below Node 24, native above |
 | [`Float16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array) | — | polyfilled below Node 24, native above |
+| [`navigator`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator) | — | backfilled below Node 21, native above |
 | [`navigator.locks`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) | — | polyfilled below Node 24.5, native above |
 | [`reportError`](https://developer.mozilla.org/en-US/docs/Web/API/Window/reportError) | — | polyfilled |
 | [`vm.Module`](https://nodejs.org/api/vm.html#class-vmmodule) | — | unflagged |

--- a/tests/fixtures/navigator-shim/main.mjs
+++ b/tests/fixtures/navigator-shim/main.mjs
@@ -1,0 +1,22 @@
+// The `navigator` surface is present and well-shaped under nub on every supported
+// Node version: native on 21+, backfilled by navigator-shim.mjs on 18.19–20.x. The
+// userAgent is `Node.js/<major>` — never `Nub/…` (brand boundary). Web Locks rides on
+// this object, so on the < 21 floor this also proves the shim hosts navigator.locks.
+const nav = globalThis.navigator;
+const checks = [];
+const push = (name, cond) => checks.push([name, !!cond]);
+
+push("navigator is an object", typeof nav === "object" && nav !== null);
+push("hardwareConcurrency is a positive number", typeof nav.hardwareConcurrency === "number" && nav.hardwareConcurrency > 0);
+push("userAgent matches Node.js/<major>", /^Node\.js\/\d+$/.test(nav.userAgent));
+push("userAgent is not nub-branded", !/nub/i.test(nav.userAgent));
+push("language is a string", typeof nav.language === "string" && nav.language.length > 0);
+push("languages is an array of strings", Array.isArray(nav.languages) && nav.languages.every((l) => typeof l === "string"));
+push("platform is a string", typeof nav.platform === "string" && nav.platform.length > 0);
+push("navigator.locks is present", typeof nav.locks === "object" && nav.locks !== null);
+
+const ok = checks.every((c) => c[1]);
+for (const c of checks) if (!c[1]) console.log("navshim:FAIL:" + c[0]);
+console.log("navshim:ua:" + nav.userAgent);
+console.log(ok ? "navshim:ALL-OK" : "navshim:FAILED");
+process.exit(ok ? 0 : 1);

--- a/tests/fixtures/navigator-shim/main.mjs
+++ b/tests/fixtures/navigator-shim/main.mjs
@@ -14,6 +14,11 @@ push("language is a string", typeof nav.language === "string" && nav.language.le
 push("languages is an array of strings", Array.isArray(nav.languages) && nav.languages.every((l) => typeof l === "string"));
 push("platform is a string", typeof nav.platform === "string" && nav.platform.length > 0);
 push("navigator.locks is present", typeof nav.locks === "object" && nav.locks !== null);
+// Match Node: the prototype getters are enumerable, so for-in walks them (this catches
+// a regression to class-default non-enumerable getters on the shim path).
+const forIn = [];
+for (const k in nav) forIn.push(k);
+push("for-in walks the enumerable getters", forIn.includes("hardwareConcurrency") && forIn.includes("userAgent"));
 
 const ok = checks.every((c) => c[1]);
 for (const c of checks) if (!c[1]) console.log("navshim:FAIL:" + c[0]);

--- a/tests/fixtures/navigator-shim/package.json
+++ b/tests/fixtures/navigator-shim/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "navigator-shim-fixture",
+  "private": true,
+  "description": "Pin-free project boundary (no engines.node / devEngines): keeps Node-version discovery from provisioning latest, so this fixture runs on the matrix leg's Node — exercising the navigator backfill on 18.19–20.x and native navigator at 21+."
+}

--- a/tests/fixtures/web-locks/main.mjs
+++ b/tests/fixtures/web-locks/main.mjs
@@ -1,0 +1,109 @@
+// Differential web-locks check: every assertion holds on BOTH nub's polyfill
+// (Node < 24.5) and native Web Locks (24.5+), so it passes on every CI Node leg —
+// a regression on either path turns it red. Covers the spec behaviors that the WPT
+// suite exercises and that the hand-rolled polyfill previously got wrong: steal,
+// option/name validation, reader/writer fairness, AbortSignal, and core mutual
+// exclusion. Hang-proof: each scenario is time-bounded and the process exits.
+const checks = [];
+const withTimeout = (p, ms, label) =>
+  Promise.race([p, new Promise((_, rej) => setTimeout(() => rej(new Error("timeout/deadlock " + label)), ms))]);
+const check = async (name, fn) => {
+  try { await withTimeout(fn(), 1500, name); checks.push([name, true]); }
+  catch (e) { checks.push([name, false, String((e && e.message) || e)]); }
+};
+let n = 0;
+const uniq = () => `r-${++n}`;
+const locks = globalThis.navigator.locks;
+
+await check("core mutual exclusion serializes exclusive holders", async () => {
+  const r = uniq();
+  const order = [];
+  let release;
+  const first = locks.request(r, () => new Promise((res) => { release = res; order.push("a"); }));
+  const second = locks.request(r, () => { order.push("b"); });
+  await new Promise((res) => setTimeout(res, 20));
+  if (order.join(",") !== "a") throw new Error("second ran while first held: " + order);
+  release();
+  await second;
+  if (order.join(",") !== "a,b") throw new Error("order: " + order);
+});
+
+await check("shared holders coexist; exclusive waits", async () => {
+  const r = uniq();
+  let unblock; const blocked = new Promise((res) => { unblock = res; });
+  const g = [];
+  locks.request(r, { mode: "shared" }, async () => { g.push("s1"); await blocked; });
+  locks.request(r, { mode: "shared" }, async () => { g.push("s2"); await blocked; });
+  const ex = locks.request(r, async () => { g.push("ex"); });
+  await new Promise((res) => setTimeout(res, 20));
+  if (g.join(",") !== "s1,s2") throw new Error("shared not co-granted: " + g);
+  unblock(); await ex;
+  if (g[2] !== "ex") throw new Error("exclusive not after shared: " + g);
+});
+
+await check("reader/writer fairness: new shared queues behind pending exclusive", async () => {
+  const r = uniq();
+  let relShared; const sharedHold = new Promise((res) => { relShared = res; });
+  let relEx; const exHold = new Promise((res) => { relEx = res; });
+  const firstShared = Promise.all([0, 0, 0].map(() => locks.request(r, { mode: "shared" }, () => sharedHold)));
+  locks.request(r, () => exHold);                       // exclusive queues behind the held shared
+  for (let i = 0; i < 3; i++) locks.request(r, { mode: "shared" }, () => new Promise(() => {})); // must NOT barge ahead
+  let q = await locks.query();
+  if (q.held.filter((l) => l.name === r).length !== 3) throw new Error("held != 3: " + q.held.length);
+  relShared(); await firstShared;
+  q = await locks.query();
+  const heldHere = q.held.filter((l) => l.name === r);
+  if (heldHere.length !== 1 || heldHere[0].mode !== "exclusive") throw new Error("exclusive should hold next, got " + JSON.stringify(heldHere));
+  relEx();
+});
+
+await check("ifAvailable yields null when not grantable", async () => {
+  const r = uniq();
+  await locks.request(r, async () => {
+    const got = await locks.request(r, { ifAvailable: true }, (l) => { if (l !== null) throw new Error("expected null"); return 7; });
+    if (got !== 7) throw new Error("result " + got);
+  });
+});
+
+await check("steal grants and breaks the current holder with AbortError", async () => {
+  const r = uniq();
+  let brokenName = null;
+  locks.request(r, () => new Promise(() => {})).catch((e) => { brokenName = e && e.name; });
+  let stolen = false;
+  await locks.request(r, { steal: true }, () => { stolen = true; });
+  await new Promise((res) => setTimeout(res, 30));
+  if (!stolen) throw new Error("steal callback never ran");
+  if (brokenName !== "AbortError") throw new Error("broken holder name = " + brokenName);
+});
+
+await check("signal: non-AbortSignal throws TypeError", async () => {
+  let err = null;
+  try { await locks.request(uniq(), { signal: {} }, () => {}); } catch (e) { err = e; }
+  if (!(err instanceof TypeError)) throw new Error("got " + (err && err.constructor.name));
+});
+
+await check("signal: already-aborted rejects with the reason", async () => {
+  const ctrl = new AbortController();
+  const reason = new Error("nope");
+  ctrl.abort(reason);
+  let err = null;
+  try { await locks.request(uniq(), { signal: ctrl.signal }, () => { throw new Error("callback ran"); }); } catch (e) { err = e; }
+  if (err !== reason) throw new Error("reason mismatch: " + err);
+});
+
+await check("name starting with '-' rejects NotSupportedError", async () => {
+  let name = null;
+  try { await locks.request("-bad", () => {}); } catch (e) { name = e && e.name; }
+  if (name !== "NotSupportedError") throw new Error("got " + name);
+});
+
+await check("invalid option combo steal+ifAvailable rejects NotSupportedError", async () => {
+  let name = null;
+  try { await locks.request(uniq(), { steal: true, ifAvailable: true }, () => {}); } catch (e) { name = e && e.name; }
+  if (name !== "NotSupportedError") throw new Error("got " + name);
+});
+
+const ok = checks.every((c) => c[1]);
+for (const c of checks) if (!c[1]) console.log("weblocks:FAIL:" + c[0] + " :: " + c[2]);
+console.log(ok ? "weblocks:ALL-OK" : "weblocks:FAILED");
+process.exit(ok ? 0 : 1);

--- a/tests/fixtures/web-locks/package.json
+++ b/tests/fixtures/web-locks/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "web-locks-fixture",
+  "private": true,
+  "description": "Pin-free project boundary (no engines.node / devEngines): keeps Node-version discovery from walking up to the repo-root engines (>=22.15) and provisioning latest, so this fixture runs on the matrix leg's Node — exercising the polyfill path below 24.5 and native at/above."
+}


### PR DESCRIPTION
`navigator` is absent before Node 21.0, so `navigator.locks` (Web Locks) was unavailable on Node 18.19–20.x despite nub shipping the polyfill.

- `runtime/navigator-shim.mjs` (new): backfills `globalThis.navigator` on Node <21 (matching Node internal/navigator.js; userAgent `Node.js/<major>`; non-enumerable, no-op on 21+).
- `runtime/navigator-locks.mjs` (rewrite per Node internal/locks.js): adds `steal` (was unimplemented — an ignored `steal:true` deadlocked), AbortSignal, option/name validation, reader/writer fairness.
- Wires shim before locks in both preloads; adds a feature-matrix row, differential tests, docs row.

Verified: WPT web-locks 68/68 runnable subtests on Node 18.19/20.19/22.15, matching native Node 25; integration 163 passed; clippy+fmt clean.