### PR TITLE
feat(nix): add prebuilt-binary flake (nix run github:nubjs/nub)

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,60 @@
+name: Nix flake
+
+# Validates the prebuilt-binary flake (flake.nix) that lets Nix users install via
+# `nix run github:nubjs/nub`. There is no Nix on the dev host, so THIS job is the
+# flake's only validation: it evaluates every system's outputs, builds the package
+# for the runner's own system (fetchurl + autoPatchelf), and smoke-runs the binary.
+#
+# Path-filtered to the flake files so it fires only when they change — not on every
+# Rust or docs commit.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "**/*.nix"
+      - ".github/workflows/nix.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "**/*.nix"
+      - ".github/workflows/nix.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v16
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      # Evaluate every system's outputs (the locked flake must evaluate for all
+      # four targets, including the Darwin ones that cannot build on this runner).
+      - name: nix flake check
+        run: nix flake check --all-systems --print-build-logs
+
+      # Build the package for x86_64-linux: fetchurl the release tarball, run
+      # autoPatchelfHook against the glibc binary + nub-native.node, lay out the
+      # bin/ + runtime/ tree. Proves the install layout actually realizes.
+      - name: nix build .#default
+        run: nix build .#default --print-build-logs
+
+      # Smoke the patched binary end to end: `nix run` execs $out/bin/nub, which
+      # canonicalizes current_exe() and resolves the runtime/ sibling. A clean
+      # version print proves the layout + autoPatchelf produced a runnable nub.
+      - name: nix run .#default -- --version
+        run: nix run .#default -- --version

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: Cache Nix store
-        uses: DeterminateSystems/magic-nix-cache-action@v8
-
       # Evaluate every system's outputs (the locked flake must evaluate for all
       # four targets, including the Darwin ones that cannot build on this runner).
       - name: nix flake check

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ irm https://nubjs.com/install.ps1 | iex
 # Homebrew (macOS / Linux)
 brew install nubjs/tap/nub
 
+# Nix (flakes)
+nix run github:nubjs/nub
+
 # Or via npm (pnpm / yarn global add work too)
 npm install -g --ignore-scripts=false @nubjs/nub
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,123 @@
+{
+  description = "nub — fast TypeScript-first runtime and pnpm-compatible package manager for Node";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      version = "0.2.2";
+
+      # Per-system prebuilt release tarball + its sha256, verified against the
+      # GitHub release assets for v${version}. nub ships prebuilt per-platform
+      # tarballs on every channel (curl installer, Homebrew, npm); this flake lays
+      # one out rather than building from source. WHY prebuilt, not buildRustPackage:
+      # a from-source cargo build omits the vendored runtime/ tree (preload +
+      # node_modules + the nub-native.node N-API addon) that nub resolves beside its
+      # binary at run time — a bare cargo binary passes `--version` but fails real
+      # TypeScript workloads. The prebuilt tarball already carries that layout.
+      assets = {
+        "x86_64-linux" = {
+          file = "nub-linux-x64.tar.gz";
+          sha256 = "6cc63a89f25f12719bce9afc97e513cc8ee22ef203e4a72a3c7398e62b413a23";
+        };
+        "aarch64-linux" = {
+          file = "nub-linux-arm64.tar.gz";
+          sha256 = "b9a292a725a959809fd629e7b3d8d6d886480300b8451bb41f8fb4a5098107ec";
+        };
+        "x86_64-darwin" = {
+          file = "nub-darwin-x64.tar.gz";
+          sha256 = "39c0f5200be3688e776c51ee2978e3cfe50fdb50946261a52ca42f6481145d75";
+        };
+        "aarch64-darwin" = {
+          file = "nub-darwin-arm64.tar.gz";
+          sha256 = "1c561d820145e9eb7640f6f97c0fe2f2d8b8d4a4d64b19f78fccf8f9dd79ac46";
+        };
+      };
+
+      systems = builtins.attrNames assets;
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+
+      nubFor =
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          asset = assets.${system};
+        in
+        pkgs.stdenv.mkDerivation {
+          pname = "nub";
+          inherit version;
+
+          src = pkgs.fetchurl {
+            url = "https://github.com/nubjs/nub/releases/download/v${version}/${asset.file}";
+            sha256 = asset.sha256;
+          };
+
+          # The tarball expands to bin/ + runtime/ at the top level (no wrapping dir).
+          sourceRoot = ".";
+
+          # The prebuilt Linux binary and nub-native.node link glibc (libc, libm,
+          # libgcc_s) and hard-code a /lib64 interpreter — autoPatchelfHook rewrites
+          # both for the Nix store. Darwin mach-o binaries need no patching.
+          nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
+
+          dontConfigure = true;
+          dontBuild = true;
+
+          # Lay bin/nub (+ bin/nubx) and the runtime/ sibling out exactly as the
+          # tarball ships them. nub canonicalizes current_exe() and walks UP from the
+          # binary's directory to find runtime/preload.mjs, so the binary MUST be a
+          # real file with runtime/ as a real sibling — no makeWrapper, no symlinked
+          # entrypoint, which would canonicalize to a different directory and lose the
+          # runtime/ tree.
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out"
+            cp -r bin "$out/bin"
+            cp -r runtime "$out/runtime"
+            chmod +x "$out/bin/nub" "$out/bin/nubx"
+            runHook postInstall
+          '';
+
+          # nub provisions and locates Node itself at run time (from PATH or its own
+          # cache), so the package declares no Node runtime dependency here.
+
+          meta = with pkgs.lib; {
+            description = "Fast TypeScript-first runtime and pnpm-compatible package manager for Node";
+            homepage = "https://nubjs.com";
+            downloadPage = "https://github.com/nubjs/nub/releases";
+            license = licenses.mit;
+            mainProgram = "nub";
+            platforms = systems;
+            sourceProvenance = [ sourceTypes.binaryNativeCode ];
+          };
+        };
+    in
+    {
+      packages = forAllSystems (
+        system: rec {
+          nub = nubFor system;
+          default = nub;
+        }
+      );
+
+      apps = forAllSystems (
+        system:
+        let
+          nub = nubFor system;
+        in
+        rec {
+          nub = {
+            type = "app";
+            program = "${nub}/bin/nub";
+          };
+          nubx = {
+            type = "app";
+            program = "${nub}/bin/nubx";
+          };
+          default = nub;
+        }
+      );
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -105,18 +105,21 @@
       apps = forAllSystems (
         system:
         let
-          nub = nubFor system;
+          nubPkg = nubFor system;
         in
-        rec {
+        {
           nub = {
             type = "app";
-            program = "${nub}/bin/nub";
+            program = "${nubPkg}/bin/nub";
           };
           nubx = {
             type = "app";
-            program = "${nub}/bin/nubx";
+            program = "${nubPkg}/bin/nubx";
           };
-          default = nub;
+          default = {
+            type = "app";
+            program = "${nubPkg}/bin/nub";
+          };
         }
       );
     };


### PR DESCRIPTION
Adds a Nix flake so Nix/NixOS users can install nub via `nix run github:nubjs/nub` (or `nix profile install github:nubjs/nub`).

## Build model: prebuilt binary, not from-source

The flake `fetchurl`s nub's existing per-platform GitHub release tarballs and lays them out — it does not compile from source. Every other nub channel (curl installer, Homebrew, npm) ships these prebuilt tarballs, and a from-source `rustPlatform.buildRustPackage` would omit the vendored `runtime/` tree (preload + `node_modules` + the `nub-native.node` N-API addon) that nub resolves beside its binary at run time — a bare cargo binary passes `--version` but fails real TypeScript workloads. The prebuilt tarball already carries the correct `bin/` + `runtime/` layout.

## What's here

- **`flake.nix`** — `packages.<system>.default` + `apps.<system>.default` across the four Nix-supported targets (`x86_64`/`aarch64` × `linux`/`darwin`). Each `fetchurl`s the matching v0.2.2 tarball (sha256 pinned from the release asset digests) and lays out a real `bin/nub` (+ `bin/nubx`) with the `runtime/` sibling exactly as shipped — no wrapper or symlinked entrypoint, since nub canonicalizes `current_exe()` and walks up to find `runtime/preload.mjs`. Linux uses `autoPatchelfHook` (+ `stdenv.cc.cc.lib` for `libgcc_s`) to rewrite the glibc interpreter/rpath; Darwin needs no patching.
- **`flake.lock`** — pins nixpkgs (`nixpkgs-unstable`).
- **`.github/workflows/nix.yml`** — path-filtered CI (fires only on flake/`*.nix` changes) that runs `nix flake check --all-systems`, `nix build .#default`, and `nix run .#default -- --version` on an Ubuntu runner via `DeterminateSystems/nix-installer-action`. There is no Nix on the dev host, so this job is the flake's validation gate (it exercises `fetchurl` + `autoPatchelf` + exec end to end).
- **README** — a `nix run github:nubjs/nub` line in the Install block.

The win32/musl targets are excluded — Windows isn't a Nix target, and the glibc tarballs cover the Linux Nix systems.

## Fast-follow (not in this PR)

A prebuilt flake pins version + sha per release, so a future change should auto-bump `flake.nix`'s `version` + the four sha256s from the published `.sha256` sidecars on each release (the shape of the existing `bump-homebrew-tap` job, but committing in-repo). Deferred here because it mutates `main` post-publish and can't be exercised by this PR's CI; the flake is correct pinned to v0.2.2 in the meantime.

Closes #167
