### PR TITLE
fix(runtime): neutralized localStorage is absent, not present-undefined

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1608,6 +1608,78 @@ fn sessionstorage_works_by_default_localstorage_needs_user_file() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// On the flag-needed band (22.4–24.x), the neutralized `localStorage` must be
+/// ABSENT (`'localStorage' in globalThis === false`), matching vanilla Node 24 —
+/// NOT present-but-undefined. A present-but-undefined global broke isomorphic
+/// libraries that gate on `'localStorage' in window/globalThis` (vitest's happy-dom
+/// `getWindowKeys`): the present property made them SKIP installing their own
+/// store, so user code read nub's `undefined` and crashed (#166). nub now `delete`s
+/// the throwing getter inside the neutralize gate, restoring the absent shape so
+/// such libraries install their own. `sessionStorage` stays working (the flag is
+/// still injected). Gated to the band nub actually neutralizes on: on 25+ Node has
+/// webstorage native and nub injects nothing, so the global is natively present and
+/// this assertion would not apply.
+#[test]
+fn neutralized_localstorage_is_absent_not_present_undefined() {
+    let (maj, min, _) = target_node_version();
+    let on_band = (maj == 22 && min >= 4) || maj == 23 || maj == 24;
+    if !on_band {
+        eprintln!("skipping: neutralize path only runs on the 22.4–24 band (target is off-band)");
+        return;
+    }
+    let dir = std::env::temp_dir().join(format!("nub-ws-absent-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"ws-absent"}"#).unwrap();
+    let cache = dir.join("cache");
+
+    // `'localStorage' in globalThis` is read FIRST, then `typeof`. On the raw band a
+    // working/throwing getter would make `in` true; the neutralize `delete` makes it
+    // false. sessionStorage proves the webstorage flag stays injected (it needs only
+    // the flag, no file). Each token is tagged so a failure is self-debugging.
+    std::fs::write(
+        dir.join("probe.js"),
+        "console.log('IN:' + ('localStorage' in globalThis));\n\
+         console.log('TYPEOF:' + typeof localStorage);\n\
+         sessionStorage.setItem('k', 'v');\n\
+         console.log('SS:' + sessionStorage.getItem('k'));",
+    )
+    .unwrap();
+
+    let out = Command::new(nub_binary())
+        .args(["probe.js"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", &cache)
+        .output()
+        .expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "probe must not throw: stdout={stdout:?} stderr={stderr:?}"
+    );
+    // The contract that fixes #166: the neutralized global is ABSENT, so a library
+    // gating on `'localStorage' in globalThis` installs its own store.
+    assert!(
+        stdout.contains("IN:false"),
+        "neutralized localStorage must be ABSENT (`'localStorage' in globalThis === false`), \
+         matching vanilla Node 24, not present-undefined; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains("TYPEOF:undefined"),
+        "`typeof localStorage` must be \"undefined\" (no throw); stdout={stdout:?} stderr={stderr:?}"
+    );
+    // sessionStorage must STILL work — the webstorage flag stays injected; only the
+    // throwing localStorage getter is deleted.
+    assert!(
+        stdout.contains("SS:v"),
+        "sessionStorage must still work after the localStorage delete; stdout={stdout:?} stderr={stderr:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// A user-set `NODE_OPTIONS=--localstorage-file=<their path>` must reach Node
 /// untouched: nub never injects its own store and never strips the user's, so the
 /// user's file gets the data and nub's cache dir stays empty of any webstorage

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1501,8 +1501,8 @@ fn node_compat_flag_disables_augmentation() {
 /// native), so `sessionStorage` is a working global with no opt-in. localStorage
 /// stays the user's explicit opt-in: nub NEVER synthesizes a `--localstorage-file`,
 /// so without one the store never materializes. With no file, nub NEUTRALIZES the
-/// `localStorage` global so it reads `undefined` (matching Node 25+'s clean shape)
-/// instead of Node's throwing getter on the band — so `typeof localStorage ===
+/// `localStorage` global by DELETING it (absent, matching vanilla Node 24) instead
+/// of leaving Node's throwing getter on the band — so `typeof localStorage ===
 /// "undefined"` feature-detection is safe and nothing throws (the maintainer, 2026-06-15).
 /// A user who passes their own `--localstorage-file=<path>` gets a working,
 /// persistent store, and nub never stands one up on its own.
@@ -1520,10 +1520,11 @@ fn sessionstorage_works_by_default_localstorage_needs_user_file() {
     let user_store = dir.join("mine.sqlite");
 
     // sessionStorage needs only the flag (no file) — works on the whole 22.4+ range.
-    // Also assert localStorage is the NEUTRALIZED `undefined` shape (no throw): on the
-    // band nub replaces Node's throwing getter so `typeof localStorage` is "undefined"
-    // and feature-detection works. `typeof` is read FIRST — on the raw band even
-    // `typeof localStorage` throws, so this line proves the neutralize ran.
+    // Also assert localStorage neutralizes to `typeof === "undefined"` (no throw): on
+    // the band nub deletes Node's throwing getter, so `typeof localStorage` is
+    // "undefined". `typeof` is read FIRST — on the raw band even `typeof localStorage`
+    // throws, so this line proves the neutralize ran. (The absent-vs-present shape is
+    // pinned separately by `neutralized_localstorage_is_absent_not_present_undefined`.)
     std::fs::write(
         dir.join("probe.js"),
         "console.log('LS:' + typeof localStorage); sessionStorage.setItem('k', 'v'); console.log('SS:' + sessionStorage.getItem('k'));",

--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -39,29 +39,31 @@ function installSyncPolyfills(preloaded) {
   // `typeof localStorage` throws, so feature-detection is impossible and the throw
   // can surface before user code expects it. The spawn layer signals this case via
   // the internal `__NUB_NEUTRALIZE_LOCALSTORAGE` env var (set iff unflagged ∧
-  // no user file). Replace the throwing getter with a plain `undefined` value —
-  // matching Node 25+'s clean shape — so `typeof localStorage === "undefined"` is
-  // true and no throw occurs; `sessionStorage`, which needs only the flag, keeps
-  // working. This runs in the preload BEFORE any user code, so the throwing getter
-  // is never observed. When the user passes `--localstorage-file`, the env var is
-  // absent and `localStorage` works normally (we do not touch it). We deliberately
-  // KEEP the env var set so it inherits to the whole process subtree: a `node`- or
+  // no user file). DELETE the throwing getter so the global becomes ABSENT —
+  // matching vanilla Node 24's shape on this band (`'localStorage' in globalThis
+  // === false`), not present-but-undefined. Absent is the additive choice: a bare
+  // `localStorage` read throws ReferenceError exactly as on vanilla Node 24, and
+  // `typeof localStorage === "undefined"` stays true with no throw. The earlier
+  // present-undefined define matched Node 26's shape, but that broke isomorphic
+  // libraries that gate on `'localStorage' in window/globalThis` (e.g. vitest's
+  // happy-dom `getWindowKeys`): a present property made them SKIP installing their
+  // own store, so user code then read nub's `undefined` and crashed (#166). This
+  // runs in the preload BEFORE any user code, so the throwing getter is never
+  // observed. When the user passes `--localstorage-file`, the env var is absent and
+  // `localStorage` works normally (we do not touch it). We deliberately KEEP the
+  // env var set so it inherits to the whole process subtree: a `node`- or
   // `nub`-spawned grandchild re-inherits the webstorage flag via NODE_OPTIONS and
   // would otherwise re-install the throwing getter with no neutralize signal. It's
   // an internal `__NUB_*` plumbing var that's explicitly fine to leak to children.
-  // Neutralization is idempotent — a descendant re-running this preload with the
-  // var still set just re-defines `localStorage` to undefined again, which is
-  // harmless. The descriptor is configurable+writable so user code can still assign
-  // its own `localStorage`.
+  // Neutralization is idempotent — a descendant re-running this preload deletes an
+  // already-absent or re-installed `localStorage` again, which is harmless. The
+  // property is configurable (the define that replaced it before already proved
+  // that), so `delete` cannot throw; the try/catch guards only a hypothetical
+  // non-configurable runtime, where we leave Node's behavior.
   if (process.env.__NUB_NEUTRALIZE_LOCALSTORAGE) {
     try {
-      Object.defineProperty(globalThis, "localStorage", {
-        value: undefined,
-        configurable: true,
-        writable: true,
-        enumerable: false,
-      });
-    } catch { /* descriptor non-configurable on this runtime: leave Node's behavior */ }
+      delete globalThis.localStorage;
+    } catch { /* non-configurable on this runtime: leave Node's behavior */ }
   }
 
   // ── reportError (WinterTC min-common-API, not in any Node) ──────────

--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -44,7 +44,7 @@ function installSyncPolyfills(preloaded) {
   // === false`), not present-but-undefined. Absent is the additive choice: a bare
   // `localStorage` read throws ReferenceError exactly as on vanilla Node 24, and
   // `typeof localStorage === "undefined"` stays true with no throw. The earlier
-  // present-undefined define matched Node 26's shape, but that broke isomorphic
+  // present-undefined define matched Node 25+'s native shape, but that broke isomorphic
   // libraries that gate on `'localStorage' in window/globalThis` (e.g. vitest's
   // happy-dom `getWindowKeys`): a present property made them SKIP installing their
   // own store, so user code then read nub's `undefined` and crashed (#166). This
@@ -57,9 +57,11 @@ function installSyncPolyfills(preloaded) {
   // an internal `__NUB_*` plumbing var that's explicitly fine to leak to children.
   // Neutralization is idempotent — a descendant re-running this preload deletes an
   // already-absent or re-installed `localStorage` again, which is harmless. The
-  // property is configurable (the define that replaced it before already proved
-  // that), so `delete` cannot throw; the try/catch guards only a hypothetical
-  // non-configurable runtime, where we leave Node's behavior.
+  // property is a configurable own accessor (the define that replaced it before
+  // already proved that), so `delete` removes it cleanly. This file is sloppy-mode
+  // CJS, where `delete` never throws (a non-configurable property would just make
+  // it return false and leave Node's getter in place); the try/catch is belt-and-
+  // suspenders for any future strict/ESM move.
   if (process.env.__NUB_NEUTRALIZE_LOCALSTORAGE) {
     try {
       delete globalThis.localStorage;


### PR DESCRIPTION
On the Node 22.4–24 band, nub neutralized the throwing `localStorage` getter by redefining it present-but-undefined, leaving `'localStorage' in globalThis === true`. Libraries gating on that check (vitest happy-dom) skipped installing their own store, so user code read nub's `undefined` and crashed. Vanilla Node 24 has it absent.

Fix: delete the getter inside the existing `__NUB_NEUTRALIZE_LOCALSTORAGE` gate so the global is absent, matching vanilla Node 24. `sessionStorage` still works; the `--localstorage-file` path and Node 25/26 are unaffected. The env var is retained to scope neutralization to what nub causes.

Adds a band-gated regression test.

Closes #166