### PR TITLE
Single self-contained binary (embed runtime, JIT-extract on first run)

### DIFF
--- a/.github/scripts/gen-homebrew-formula.sh
+++ b/.github/scripts/gen-homebrew-formula.sh
@@ -78,26 +78,18 @@ class Nub < Formula
   end
 
   def install
-    # The release archive is a tree (bin/nub, bin/nubx, runtime/), not a bare
-    # binary: nub loads runtime/ (preload + vendored polyfills + native addon)
-    # relative to the real binary, so the whole tree must stay together. Install
-    # it into libexec and symlink the executables onto PATH. Plain symlinks (no
-    # wrapper script) so each call execs the native binary with zero overhead;
-    # nub canonicalizes current_exe() to find runtime/ beside the real binary.
-    libexec.install Dir["*"]
-    bin.install_symlink libexec/"bin/nub"
-    bin.install_symlink libexec/"bin/nubx"
+    # nub is a single self-contained binary: it embeds its runtime (preload +
+    # vendored polyfills + native addon) and JIT-extracts it to ~/.cache/nub on
+    # first run, so there is no sidecar to keep beside the binary. The archive ships
+    # bin/nub + bin/nubx (both real copies; nub picks its verb from the argv[0]
+    # basename), so install them straight onto PATH — no libexec, no symlink dance.
+    bin.install "bin/nub", "bin/nubx"
   end
 
   test do
     assert_match version.to_s, shell_output("#{bin}/nub --version")
-
-    # Prove the runtime tree (preload + vendored polyfills + native addon) was
-    # installed alongside the binary — a bare-binary install would be missing it.
     # Do NOT run a transpile here: \`brew test\` runs on a clean machine with no Node
     # on PATH, and nub augments the user's Node rather than bundling one.
-    assert_path_exists libexec/"runtime/preload.mjs"
-    assert_path_exists libexec/"runtime/addons/nub-native.node"
   end
 end
 EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,152 @@ jobs:
       - run: cargo test -p nub-core --features embed-runtime
       - run: cargo build -p nub-cli --features embed-runtime
 
+  # TEMPORARY (PR #175 data point) — remove after Windows embed behavior is confirmed.
+  #
+  # The single-binary first-run mechanism is novel ON WINDOWS specifically: the binary
+  # extracts the embedded nub-native.node (a DLL) to a cache dir and dlopen's it on the
+  # first run — the "process writes a DLL then loads it" shape Windows Defender real-time
+  # scanning can flag. No other CI leg exercises extract-then-load: the `embed-runtime`
+  # job above only BUILDS the feature-on binary, and the release.yml test-install runs
+  # post-publish. This job builds the REAL release single binary (--features embed-runtime,
+  # with the actual release nub-native addon staged into the embedded blob), runs a TS
+  # fixture end-to-end on a runner with Defender enabled, and asserts the full first-run
+  # round-trip — extract -> dlopen -> transpile -> execute — plus warm-cache reuse, and
+  # surfaces any Defender detection so a silent quarantine can't pass as green. A clean
+  # exit 0 with correct output is the proof Defender did not block the write/load.
+  #
+  # Scope: this proves the Defender real-time-scan + extract/dlopen mechanism. It does
+  # NOT reproduce SmartScreen Mark-of-the-Web reputation (that needs a browser-downloaded,
+  # internet-zoned nub.exe — a separate download-UX concern). Standalone (NOT wired into
+  # ci-gate): it is a non-blocking data point, not a new required check.
+  windows-embed-roundtrip:
+    name: Windows embed round-trip (TEMPORARY, PR #175)
+    if: github.event_name == 'pull_request'
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      # Throwaway job: read-only cache (save-if: false) so it never churns the budget.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: ci-win-embed-roundtrip
+          save-if: false
+          workspaces: |
+            .
+            crates/nub-native
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: "24"
+      # Stage the REAL release addon into runtime/ so the embedded blob carries a
+      # loadable DLL — without it the extracted runtime can't transpile. nub-native is
+      # its own workspace (cdylib, panic=unwind); its .cargo/config routes output into
+      # the shared root target/. Windows cdylib output is nub_native.dll.
+      - name: Build + stage release nub-native addon
+        shell: bash
+        run: |
+          set -euo pipefail
+          (cd crates/nub-native && cargo build --release)
+          mkdir -p runtime/addons
+          cp target/release/nub_native.dll runtime/addons/nub-native.node
+      # Build the real single binary: --features embed-runtime makes build.rs tar+zstd-19
+      # the staged runtime/ into the binary; the binary extracts it on first run. The
+      # feature (not the profile) is what triggers the include_bytes! blob arm + the
+      # find_preload extraction path, so this exercises the same code a release build does.
+      - name: Build release nub.exe (--features embed-runtime)
+        run: cargo build -p nub-cli --release --features embed-runtime
+      - name: Round-trip — extract, dlopen, execute, warm cache, Defender
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          # Cold, isolated cache so the FIRST run is forced to extract (proves the
+          # DLL write + dlopen). cache_dir() honors XDG_CACHE_HOME on every platform,
+          # so the extracted dir is <XDG_CACHE_HOME>\nub\runtime-<key>.
+          $cache = Join-Path $env:RUNNER_TEMP "nub-embed-cache"
+          if (Test-Path $cache) { Remove-Item -Recurse -Force $cache }
+          $env:XDG_CACHE_HOME = $cache
+          $nubRoot = Join-Path $cache "nub"
+
+          $nub = Join-Path (Get-Location) "target\release\nub.exe"
+          if (-not (Test-Path $nub)) { throw "nub.exe not found at $nub" }
+
+          # Isolated work dir (no package.json/.nvmrc) so nub uses the PATH Node and
+          # no project pin interferes. A typed fixture forces real transpilation
+          # (annotations stripped) -> addon dlopen -> execute.
+          $work = Join-Path $env:RUNNER_TEMP "fixture"
+          if (Test-Path $work) { Remove-Item -Recurse -Force $work }
+          New-Item -ItemType Directory -Force -Path $work | Out-Null
+          $fixture = Join-Path $work "embed.ts"
+          @'
+          const greeting: string = "embed-roundtrip-ok";
+          const n: number = 21 * 2;
+          console.log(`${greeting}-${n}`);
+          '@ | Set-Content -Encoding utf8 $fixture
+
+          # --- First run: must extract runtime + dlopen addon + transpile + execute ---
+          Push-Location $work
+          $out1 = & $nub $fixture 2>&1 | Out-String
+          $code1 = $LASTEXITCODE
+          Pop-Location
+          Write-Host "first-run exit=$code1"
+          Write-Host "first-run output: $out1"
+          if ($code1 -ne 0) { throw "first run exited $code1 — extract/dlopen/execute failed" }
+          if ($out1 -notmatch "embed-roundtrip-ok-42") { throw "first run wrong output: $out1" }
+
+          # --- Cache assertions: exactly one runtime-* dir, addon + preload present ---
+          $rt = @(Get-ChildItem -Path $nubRoot -Directory -Filter "runtime-*")
+          if ($rt.Count -ne 1) { throw "expected exactly one runtime-* dir, got $($rt.Count)" }
+          $dir = $rt[0].FullName
+          Write-Host "extracted cache dir: $dir"
+          if (-not (Test-Path (Join-Path $dir "preload.mjs"))) { throw "preload.mjs missing in $dir" }
+          if (-not (Test-Path (Join-Path $dir "addons\nub-native.node"))) { throw "addon missing in $dir" }
+          $tmpLeft = @(Get-ChildItem -Path $nubRoot -Directory -Filter ".runtime-*")
+          if ($tmpLeft.Count -ne 0) { throw "leftover .tmp extract dir(s): $($tmpLeft.FullName -join ', ')" }
+          $mtime1 = (Get-Item $dir).LastWriteTimeUtc
+
+          # --- Second run: warm cache must be reused, no re-extract ---
+          Push-Location $work
+          $out2 = & $nub $fixture 2>&1 | Out-String
+          $code2 = $LASTEXITCODE
+          Pop-Location
+          Write-Host "second-run exit=$code2"
+          Write-Host "second-run output: $out2"
+          if ($code2 -ne 0) { throw "second run exited $code2" }
+          if ($out2 -notmatch "embed-roundtrip-ok-42") { throw "second run wrong output: $out2" }
+          $rt2 = @(Get-ChildItem -Path $nubRoot -Directory -Filter "runtime-*")
+          if ($rt2.Count -ne 1) { throw "warm run changed runtime-* dir count to $($rt2.Count)" }
+          $mtime2 = (Get-Item $dir).LastWriteTimeUtc
+          if ($mtime1 -ne $mtime2) { throw "warm run re-extracted (dir mtime $mtime1 -> $mtime2)" }
+          Write-Host "warm-cache reuse confirmed (dir mtime unchanged: $mtime1)"
+
+          # --- Defender: surface any detection so a silent quarantine can't pass green ---
+          Write-Host "=== Get-MpComputerStatus ==="
+          try {
+            Get-MpComputerStatus |
+              Select-Object AMRunningMode, RealTimeProtectionEnabled, AntivirusEnabled |
+              Format-List | Out-String | Write-Host
+          } catch { Write-Host "Get-MpComputerStatus unavailable: $_" }
+
+          Write-Host "=== Get-MpThreatDetection ==="
+          $threats = @(Get-MpThreatDetection -ErrorAction SilentlyContinue)
+          Write-Host "Defender threat-detection record count: $($threats.Count)"
+          if ($threats.Count -gt 0) {
+            $threats | Format-List | Out-String | Write-Host
+            # Fail only on a detection referencing a nub artifact / our cache path — the
+            # runner may carry pre-existing unrelated records.
+            $related = $threats | Where-Object {
+              $res = ($_.Resources -join ';')
+              ($res -match 'nub') -or ($res -match [regex]::Escape($cache))
+            }
+            if ($related) { throw "Defender flagged a nub artifact:`n$($related | Format-List | Out-String)" }
+            Write-Host "detections present but none reference a nub artifact — not a block"
+          } else {
+            Write-Host "no Defender threat detections"
+          }
+
+          Write-Host "ROUND-TRIP OK: extract -> dlopen -> transpile -> execute -> warm-cache reuse; Defender did not block"
+
   test:
     name: Test (${{ matrix.os }}, node ${{ matrix.node }})
     needs: matrix-plan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,35 @@ jobs:
       # find_preload extraction path, so this exercises the same code a release build does.
       - name: Build release nub.exe (--features embed-runtime)
         run: cargo build -p nub-cli --release --features embed-runtime
+      # The WHOLE point of a Windows runner is the on-access AV heuristic (process
+      # writes a DLL then dlopen's it). GitHub-hosted runners ship with real-time
+      # protection OFF, so try to turn it ON before the round-trip so the scan is
+      # actually firing. This needs admin (runners are admin-capable) but tamper-
+      # protection or the image policy may refuse — that's an informative outcome,
+      # not a failure, so this step never fails the job; it just records whether RTP
+      # actually came on. The round-trip step below re-reads + prints the live status.
+      - name: Try to enable Defender real-time protection
+        shell: pwsh
+        run: |
+          Write-Host "=== Defender status BEFORE enable attempt ==="
+          Get-MpComputerStatus |
+            Select-Object RealTimeProtectionEnabled, IsTamperProtected, AMRunningMode |
+            Format-List | Out-String | Write-Host
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $false -ErrorAction Stop
+            Write-Host "Set-MpPreference -DisableRealtimeMonitoring \$false succeeded"
+          } catch {
+            Write-Host "Set-MpPreference failed (expected if tamper-protected / policy-locked): $_"
+          }
+          Write-Host "=== Defender status AFTER enable attempt ==="
+          $st = Get-MpComputerStatus
+          $st | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AMRunningMode |
+            Format-List | Out-String | Write-Host
+          if ($st.RealTimeProtectionEnabled) {
+            Write-Host "RTP_OUTCOME: real-time protection is ON — round-trip will run under active scanning"
+          } else {
+            Write-Host "RTP_OUTCOME: real-time protection is OFF (tamper-protected:$($st.IsTamperProtected)) — CI cannot exercise active-RTP; residual risk needs a post-publish stock-Defender machine"
+          }
       - name: Round-trip — extract, dlopen, execute, warm cache, Defender
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,28 @@ jobs:
       - name: Brand lint (no AUBE_* env reads)
         run: tests/brand-lint/check-env-reads.sh
 
+  # The single-binary `embed-runtime` feature is OFF in every default build, so the
+  # feature-off `test` job never RUNS the runtime_cache extraction/race/GC unit
+  # tests, and build.rs's tar+zstd blob arm + the tar/zstd/sha2 build-dep wiring go
+  # unexercised on PRs (they would first break at a release tag). Build + test the
+  # feature-on path here so an embed/extract regression fails a PR. One platform
+  # suffices for the logic; the tracked runtime/*.mjs satisfy build.rs's staging
+  # probe with no extra assembly.
+  embed-runtime:
+    name: embed-runtime (single-binary)
+    needs: matrix-plan
+    if: needs.matrix-plan.outputs.run_rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: ci-embed-runtime
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: cargo test -p nub-core --features embed-runtime
+      - run: cargo build -p nub-cli --features embed-runtime
+
   test:
     name: Test (${{ matrix.os }}, node ${{ matrix.node }})
     needs: matrix-plan
@@ -498,7 +520,7 @@ jobs:
   ci-gate:
     name: CI gate
     if: always()
-    needs: [matrix-plan, check, clippy, test, pnp, fmt, types-fixtures, docs-links]
+    needs: [matrix-plan, check, clippy, embed-runtime, test, pnp, fmt, types-fixtures, docs-links]
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required job failed or was cancelled

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,12 +391,84 @@ jobs:
         # `--git` (a from-source rebuild of cross on every cross-target job).
         run: cargo install cross --version 0.2.5 --locked
 
-      - name: Build binary
+      # SINGLE-BINARY EMBED — the runtime now ships INSIDE the binary. Stage the
+      # runtime (per-platform addon + the os/cpu-agnostic vendored node_modules)
+      # into the repo's runtime/ BEFORE building nub-cli, so nub-core's build.rs
+      # tars + zstd-19-compresses it and `include_bytes!`-embeds it into THIS
+      # platform's binary. build.rs reads <repo>/runtime by default, so the staging
+      # location needs no env override (and so it works inside the cross containers,
+      # which mount the project — no AUBE_*-style passthrough needed).
+      - name: Build + stage nub-native addon (embedded into the binary)
+        run: |
+          CMD="cargo"; [ "${{ matrix.cross }}" = "true" ] && CMD="cross"
+          case "${{ matrix.target }}" in
+            *-musl)
+              # musl's default crt-static can't produce a cdylib (a .node is a
+              # dynamic lib); disable it for the ADDON only so it builds dynamic.
+              # The static nub BINARY (built below) is untouched. napi-rs's canonical
+              # musl recipe (what oxc/swc ship); the crate-local Cross.toml carries
+              # the RUSTFLAGS passthrough into the cross container.
+              (cd crates/nub-native && RUSTFLAGS="-C target-feature=-crt-static" $CMD build --release --target ${{ matrix.target }})
+              ;;
+            *)
+              (cd crates/nub-native && $CMD build --release --target ${{ matrix.target }})
+              ;;
+          esac
+          mkdir -p runtime/addons
+          if [[ "${{ matrix.platform }}" == win32-* ]]; then
+            cp "target/${{ matrix.target }}/release/nub_native.dll" runtime/addons/nub-native.node
+          elif [[ "${{ matrix.platform }}" == darwin-* ]]; then
+            cp "target/${{ matrix.target }}/release/libnub_native.dylib" runtime/addons/nub-native.node
+          else
+            cp "target/${{ matrix.target }}/release/libnub_native.so" runtime/addons/nub-native.node
+          fi
+          # The addon is MANDATORY — if it didn't build, it would be silently absent
+          # from the embedded runtime and the data-format loaders would be dead. Gate
+          # it here, BEFORE the binary build embeds the staged tree.
+          test -f runtime/addons/nub-native.node \
+            || { echo "::error::missing nub-native.node for ${{ matrix.platform }} — the addon didn't build; it would be absent from the embedded runtime. Fix the addon build before releasing."; exit 1; }
+        shell: bash
+
+      - name: Stage vendored runtime node_modules (embedded into the binary)
+        shell: bash
+        run: |
+          # Vendor the pure-JS runtime deps into runtime/node_modules at the EXACT
+          # versions installed in the workspace (so a shipped nub's transpile output
+          # is byte-identical to dev's). Read versions by relative-FILE require from
+          # the workspace root (cwd), which is Windows-safe and bypasses package
+          # `exports` (modern packages don't export ./package.json). Only the deps the
+          # EMITTED code / JS runtime need are vendored: @oxc-project/runtime (helper
+          # imports) + the web-API polyfills; oxc itself is compiled into the addon.
+          ver() { node -p "require('./node_modules/$1/package.json').version"; }
+          OXCRT_VERSION=$(ver @oxc-project/runtime)
+          URLP_VERSION=$(ver urlpattern-polyfill)
+          TEMPORAL_VERSION=$(ver @js-temporal/polyfill)
+          FLOAT16_VERSION=$(ver @petamoriken/float16)
+          rm -rf runtime/node_modules
+          mkdir -p runtime/node_modules
+          cd runtime
+          npm init -y > /dev/null 2>&1
+          # SINGLE install — a second --no-save install would prune the first as
+          # "extraneous" (the 0.0.7 breakage). Keep it one call.
+          npm install --no-save \
+            "@oxc-project/runtime@$OXCRT_VERSION" \
+            "urlpattern-polyfill@$URLP_VERSION" \
+            "@js-temporal/polyfill@$TEMPORAL_VERSION" \
+            "@petamoriken/float16@$FLOAT16_VERSION" \
+            2>&1 | tail -8
+          for d in "@oxc-project/runtime"; do
+            test -d "node_modules/$d" \
+              || { echo "::error::vendored dep missing from runtime/node_modules: $d"; exit 1; }
+          done
+          rm -f package.json package-lock.json
+          cd "$GITHUB_WORKSPACE"
+
+      - name: Build binary (embeds the staged runtime)
         run: |
           if [ "${{ matrix.cross }}" = "true" ]; then
-            cross build --release -p nub-cli --target ${{ matrix.target }}
+            cross build --release -p nub-cli --features embed-runtime --target ${{ matrix.target }}
           else
-            cargo build --release -p nub-cli --target ${{ matrix.target }}
+            cargo build --release -p nub-cli --features embed-runtime --target ${{ matrix.target }}
           fi
         shell: bash
 
@@ -431,41 +503,14 @@ jobs:
             exit 1
           fi
 
-      - name: Build nub-native addon
-        run: |
-          CMD="cargo"; [ "${{ matrix.cross }}" = "true" ] && CMD="cross"
-          case "${{ matrix.target }}" in
-            *-musl)
-              # musl's default fully-static crt can't produce a cdylib (a .node is a
-              # dynamic lib). Disable crt-static for the ADDON only on musl so it
-              # builds as a dynamic lib; the static nub BINARY (built above) is
-              # untouched and stays portable. The resulting .node dyn-links
-              # libgcc_s.so.1 (Rust's musl unwinder) — present on node:*-alpine
-              # (pulled via libstdc++), so it loads. This is napi-rs's canonical
-              # musl recipe (what oxc/swc ship). The addon builds from inside its
-              # own workspace (`cd crates/nub-native`; it is excluded from the root
-              # workspace), so `cross` reads crates/nub-native/Cross.toml — NOT the
-              # repo-root one — for its RUSTFLAGS passthrough; that crate-local
-              # Cross.toml carries the passthrough so -C target-feature=-crt-static
-              # reaches the cross container. Verified in Docker: builds + loads
-              # under node:alpine, exporting parseYaml/etc.
-              (cd crates/nub-native && RUSTFLAGS="-C target-feature=-crt-static" $CMD build --release --target ${{ matrix.target }})
-              ;;
-            *)
-              (cd crates/nub-native && $CMD build --release --target ${{ matrix.target }})
-              ;;
-          esac
-        shell: bash
-
-      - name: Assemble platform package
+      - name: Assemble platform package (single binary — bin/ only)
         shell: bash
         run: |
+          # The runtime is EMBEDDED in the binary (staged + built above), so the
+          # platform package ships ONLY bin/ — no runtime/ sidecar. Both verbs are
+          # real binary copies (nub picks its verb from the argv[0] basename).
           PKG="npm/nub-${{ matrix.platform }}"
-          mkdir -p "$PKG/bin" "$PKG/runtime/addons"
-
-          # Binary — staged under BOTH names (nub, nubx). The POSIX launcher heals
-          # the on-PATH entry into a minimal sh trampoline that exec's bin/<verb>,
-          # whose argv[0] basename is the verb, so nubx must be a real second copy.
+          mkdir -p "$PKG/bin"
           if [[ "${{ matrix.platform }}" == win32-* ]]; then
             cp "target/${{ matrix.target }}/release/nub.exe" "$PKG/bin/nub.exe"
             cp "target/${{ matrix.target }}/release/nub.exe" "$PKG/bin/nubx.exe"
@@ -474,80 +519,6 @@ jobs:
             cp "target/${{ matrix.target }}/release/nub" "$PKG/bin/nubx"
             chmod +x "$PKG/bin/nub" "$PKG/bin/nubx"
           fi
-
-          # Runtime files — copy EVERY top-level runtime module: the .mjs ESM
-          # modules AND the .cjs preload chain (preload.cjs / preload-common.cjs /
-          # polyfills.cjs, used by the fast-tier `--require`). The old `*.mjs`-only
-          # glob silently dropped the .cjs files and shipped a package that can't
-          # load (0.0.13). `find -type f` ships new modules of any extension without
-          # editing a whitelist. node_modules/ + addons/ are handled below.
-          find runtime -maxdepth 1 -type f -exec cp {} "$PKG/runtime/" \;
-
-          # Native addon
-          if [[ "${{ matrix.platform }}" == win32-* ]]; then
-            cp "target/${{ matrix.target }}/release/nub_native.dll" "$PKG/runtime/addons/nub-native.node" 2>/dev/null || true
-          elif [[ "${{ matrix.platform }}" == darwin-* ]]; then
-            cp "target/${{ matrix.target }}/release/libnub_native.dylib" "$PKG/runtime/addons/nub-native.node" 2>/dev/null || true
-          else
-            cp "target/${{ matrix.target }}/release/libnub_native.so" "$PKG/runtime/addons/nub-native.node" 2>/dev/null || true
-          fi
-
-          # The addon is MANDATORY — the data-format loaders (YAML/TOML/JSON5/JSONC)
-          # are dead without it. Gate its presence (mirrors the oxc-binding gates
-          # below) so a failed/missing addon build can't silently ship a broken
-          # package (A36-adjacent). The post-publish smoke also imports a data file
-          # to validate this end-to-end on the installed package.
-          test -f "$PKG/runtime/addons/nub-native.node" \
-            || { echo "::error::missing nub-native.node for ${{ matrix.platform }} — the addon didn't build; data-format loaders would be dead. Fix the addon build before releasing."; exit 1; }
-
-          # Vendor node_modules into a self-contained runtime directory, pinned to
-          # the EXACT versions installed in the workspace so a shipped nub's transpile
-          # output is byte-identical to dev's. Read versions by package-NAME
-          # resolution (cwd is the workspace root here, which has node_modules) —
-          # never via an absolute path inside a `node -e` string, because on Windows
-          # $GITHUB_WORKSPACE is a backslash path (D:\a\nub\nub) that breaks require().
-          # Relative FILE path on purpose: a package-name require ('pkg/package.json')
-          # hits the package `exports` map, and modern packages (e.g. @oxc-project/runtime)
-          # don't export ./package.json -> ERR_PACKAGE_PATH_NOT_EXPORTED. A relative
-          # path bypasses exports AND is Windows-safe (forward slashes in a relative
-          # specifier work on win32, unlike the backslash $GITHUB_WORKSPACE).
-          ver() { node -p "require('./node_modules/$1/package.json').version"; }
-          OXCRT_VERSION=$(ver @oxc-project/runtime)
-          URLP_VERSION=$(ver urlpattern-polyfill)
-          TEMPORAL_VERSION=$(ver @js-temporal/polyfill)
-          FLOAT16_VERSION=$(ver @petamoriken/float16)
-          mkdir -p "$PKG/runtime/node_modules"
-          cd "$PKG/runtime"
-          npm init -y > /dev/null 2>&1
-          # The TS/JSX transpiler + module detection, tsconfig discovery/parse + the
-          # additive TS-resolver, AND the transpile cache are now IN-PROCESS in nub-native
-          # (the Rust addon, with oxc compiled in) — so oxc-transform / oxc-parser and
-          # their per-platform @oxc-transform/@oxc-parser bindings, AND get-tsconfig (+ its
-          # resolve-pkg-maps dep), are NO LONGER vendored (that whole npm-resolution
-          # surface, the source of the 0.0.7/0.0.13 breakage, is gone — nub loads zero npm
-          # packages internally now). Only the pure-JS deps the EMITTED code or the JS
-          # runtime still need are vendored: @oxc-project/runtime (helper imports the
-          # transpile output references, e.g. usingCtx/decorate) and the web-API polyfills.
-          # All are os/cpu-agnostic, so no --force is needed.
-          #
-          # SINGLE install — do NOT re-split into a second `npm install` in this dir:
-          # with --no-save a second install reconciles node_modules to the ideal tree and
-          # PRUNES the first install's packages as "extraneous" (this is what shipped the
-          # broken 0.0.7). Keep it one call.
-          npm install --no-save \
-            "@oxc-project/runtime@$OXCRT_VERSION" \
-            "urlpattern-polyfill@$URLP_VERSION" \
-            "@js-temporal/polyfill@$TEMPORAL_VERSION" \
-            "@petamoriken/float16@$FLOAT16_VERSION" \
-            2>&1 | tail -8
-          # Confirm the critical JS dep actually landed (a 404'd version or a future
-          # re-split that reintroduces the prune bug dies here, not in a shipped package).
-          for d in "@oxc-project/runtime"; do
-            test -d "node_modules/$d" \
-              || { echo "::error::vendored dep missing from runtime/node_modules: $d"; exit 1; }
-          done
-          rm -f package.json package-lock.json
-          cd "$GITHUB_WORKSPACE"
 
       - name: Upload platform package
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
@@ -821,15 +792,15 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      - name: Package release archives (binary + runtime)
+      - name: Package release archives (single binary)
         run: |
-          # Per-platform archives containing bin/ + runtime/ (preload + vendored
-          # node_modules), so a curl|sh / irm install is self-contained and can
-          # transpile (A30). Distinct names per platform avoid the GitHub-Release
-          # asset collision of uploading bare `nub` for every target (A31).
-          # A `.sha256` sidecar is published next to each archive so the
-          # self-owned `~/.nub` upgrade channel (`nub upgrade`) can verify the
-          # download before swapping it into place. Format is `sha256sum`'s
+          # Per-platform archives containing ONLY bin/ — nub is a single self-
+          # contained binary that embeds its runtime and JIT-extracts it on first
+          # run, so the archive needs no runtime/ sidecar. Distinct names per
+          # platform avoid the GitHub-Release asset collision of uploading bare `nub`
+          # for every target (A31). A `.sha256` sidecar is published next to each
+          # archive so the self-owned `~/.nub` upgrade channel (`nub upgrade`) can
+          # verify the download before swapping it into place. Format is `sha256sum`'s
           # `<hex>  <name>`; `nub upgrade` reads the first field.
           mkdir -p release-archives
           for platform in darwin-arm64 darwin-x64 linux-x64 linux-x64-musl linux-arm64 linux-arm64-musl win32-x64 win32-arm64; do
@@ -837,7 +808,7 @@ jobs:
             [ -d "$PKG" ] || { echo "skip $platform (not built)"; continue; }
             if [[ "$platform" == win32-* ]]; then
               archive="nub-$platform.zip"
-              (cd "$PKG" && zip -qr "$GITHUB_WORKSPACE/release-archives/$archive" bin runtime)
+              (cd "$PKG" && zip -qr "$GITHUB_WORKSPACE/release-archives/$archive" bin)
             else
               # Re-apply +x BEFORE tarring: the build job's chmod (assemble step)
               # does NOT survive the upload-artifact → download-artifact round-trip
@@ -849,7 +820,7 @@ jobs:
               # the curl|sh installer and `nub upgrade` get an executable binary.
               chmod +x "$PKG/bin/nub" "$PKG/bin/nubx"
               archive="nub-$platform.tar.gz"
-              tar -czf "release-archives/$archive" -C "$PKG" bin runtime
+              tar -czf "release-archives/$archive" -C "$PKG" bin
             fi
             (cd release-archives && sha256sum "$archive" > "$archive.sha256")
           done

--- a/.gitignore
+++ b/.gitignore
@@ -77,9 +77,11 @@ compile_commands.json
 runtime/addons/*.node
 # tests/node-suite is a registered git submodule (see .gitmodules), not ignored content. Git manages its working tree across the submodule boundary and the gitlink is committed (mode 160000), so an ignore rule here only contradicts .gitmodules and risks confusing `git submodule update` / `actions/checkout` in CI. Test-run artifacts that land inside it surface as the submodule's own "untracked content" and never leak into this repo's index.
 
-# npm platform packages (built artifacts)
+# npm platform packages (built artifacts). The single-binary build embeds the
+# runtime in the binary, so platform packages ship only bin/ — no per-package
+# runtime/ is produced anymore. The repo's own runtime/ (staged into the binary
+# at build time) is covered by the node_modules/ + runtime/addons/*.node rules above.
 npm/nub-*/bin/
-npm/nub-*/runtime/
 npm/nub/*.tgz
 npm/nub-*/*.tgz
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,6 +2650,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rustc-hash",
+ "ruzstd",
  "semver",
  "serde",
  "serde_json",
@@ -2660,6 +2661,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -3616,6 +3618,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "ryu"
@@ -4850,6 +4861,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-path"

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -10,6 +10,14 @@ repository.workspace = true
 name = "nub"
 path = "src/main.rs"
 
+[features]
+# Single self-contained binary: embed the `runtime/` tree as a compressed blob and
+# JIT-extract it on first run (forwards to nub-core, where the extract module +
+# build.rs blob generation live). OFF by default — the `--profile fast` dev loop
+# and `make install-dev` keep walking to the in-repo `runtime/`. CI release builds
+# pass `--features embed-runtime`.
+embed-runtime = ["nub-core/embed-runtime"]
+
 [dependencies]
 nub-core = { path = "../nub-core" }
 # Vendored aube (vendor/aube — plain in-tree files, vendored from nubjs/aube). aube-lockfile

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4798,11 +4798,11 @@ fn windows_selfowned_unsupported(is_windows: bool) -> Option<String> {
 /// `sha256_hex`, and sidecar parsing — are individually exercised; the glue here
 /// is kept deliberately linear and small so its correctness is reviewable by eye.
 fn perform_selfowned_upgrade(install_dir: &Path, version_spec: &str) -> Result<()> {
-    // Windows fail-fast: the self-owned swap renames `bin/`+`runtime/` out from
-    // under the running `nub.exe`. A running executable cannot be renamed or
-    // deleted while in use on Windows (ERROR_SHARING_VIOLATION), so the swap can
-    // fail mid-flight and leave a half-replaced — potentially unbootable —
-    // install. We do not yet implement the rename-self-to-`.old` dance that would
+    // Windows fail-fast: the self-owned swap renames `bin/` out from under the
+    // running `nub.exe`. A running executable cannot be renamed or deleted while
+    // in use on Windows (ERROR_SHARING_VIOLATION), so the swap can fail mid-flight
+    // and leave a half-replaced — potentially unbootable — install. We do not yet
+    // implement the rename-self-to-`.old` dance that would
     // make this safe, so refuse BEFORE touching the filesystem. See
     // upgrade.md#windows. This guards the real swap only; the npm/homebrew
     // channels (which shell out to a package manager) are unaffected.
@@ -4844,8 +4844,8 @@ fn perform_selfowned_upgrade(install_dir: &Path, version_spec: &str) -> Result<(
         );
     }
 
-    // Extract into a fresh `staged/` subdir (contains bin/ + runtime/), matching
-    // install.sh's `tar -xzf … -C $install_dir`.
+    // Extract into a fresh `staged/` subdir (the single-binary archive contains
+    // bin/ only), matching install.sh's `tar -xzf … -C $install_dir`.
     let staged_root = staging.path().join("staged");
     std::fs::create_dir_all(&staged_root)?;
     let tar_status = std::process::Command::new("tar")
@@ -4859,22 +4859,18 @@ fn perform_selfowned_upgrade(install_dir: &Path, version_spec: &str) -> Result<(
         bail!("nub upgrade: failed to extract archive {url}");
     }
     let new_bin = staged_root.join("bin");
-    let new_runtime = staged_root.join("runtime");
     if !new_bin.join("nub").is_file() {
         bail!("nub upgrade: downloaded archive did not contain bin/nub");
     }
 
-    // Swap: move old bin/runtime aside, rename new into place, then GC the old.
-    // If the second rename fails we restore the first so the install is intact.
+    // Swap bin/ into place (move the old aside, rename the new in, GC the old).
+    // The single-binary release ships ONLY bin/ — the runtime is embedded in the
+    // binary and JIT-extracted to ~/.cache/nub on first run — so there is no
+    // runtime/ to swap. A stale runtime/ left by a pre-single-binary install is
+    // dead weight the new binary ignores; remove it best-effort for hygiene
+    // (mirrors install.sh / install.ps1's fresh-extract cleanup).
     swap_dir(install_dir, "bin", &new_bin)?;
-    if let Err(e) = swap_dir(install_dir, "runtime", &new_runtime) {
-        // bin already swapped; runtime failed. The new bin pairs with the new
-        // runtime layout, so leave bin swapped (versions match) and surface the
-        // error — a partial-but-consistent bin/ with a stale runtime/ would be
-        // worse. In practice both renames are same-filesystem and don't fail
-        // independently; this branch is the documented tail risk.
-        bail!("nub upgrade: swapped bin/ but failed to swap runtime/: {e}");
-    }
+    let _ = std::fs::remove_dir_all(install_dir.join("runtime"));
 
     // The release tarball ships `bin/nub` (and `bin/nubx`) at mode 0644 — the
     // upload-artifact → download-artifact round-trip in CI strips the executable
@@ -7690,15 +7686,14 @@ mod tests {
         const FAKE_VERSION: &str = "9.9.9"; // not a real release — proves the channel, not the net
         let fixture = tempfile::tempdir().expect("fixture root");
 
-        // 1. Build the artifact the fake channel serves: a tar.gz containing the
-        //    install.sh layout (bin/nub + runtime/), with sentinel bytes so we can
-        //    prove the SWAPPED-IN binary is the downloaded one, not the old one.
+        // 1. Build the artifact the fake channel serves: a tar.gz of the
+        //    single-binary layout (bin/ ONLY — the runtime is embedded in the
+        //    binary, not a sidecar), with sentinel bytes so we can prove the
+        //    SWAPPED-IN binary is the downloaded one, not the old one.
         const NEW_NUB_BYTES: &[u8] = b"#!/bin/sh\necho fake-upgraded-nub 9.9.9\n";
         let build = fixture.path().join("build");
         std::fs::create_dir_all(build.join("bin")).unwrap();
-        std::fs::create_dir_all(build.join("runtime")).unwrap();
         std::fs::write(build.join("bin").join("nub"), NEW_NUB_BYTES).unwrap();
-        std::fs::write(build.join("runtime").join("VERSION"), FAKE_VERSION).unwrap();
 
         // Lay the asset down at GitHub's release-asset path shape so the seam's
         // `<base>/v<version>/nub-<target>.tar.gz` resolves: download_base/v9.9.9/.
@@ -7714,7 +7709,7 @@ mod tests {
             .arg(&archive)
             .arg("-C")
             .arg(&build)
-            .args(["bin", "runtime"])
+            .args(["bin"])
             .status()
             .expect("tar the fixture archive");
         assert!(tar_ok.success(), "fixture archive must tar cleanly");
@@ -7734,7 +7729,9 @@ mod tests {
         std::fs::write(&latest_json, format!(r#"{{"tag_name":"v{FAKE_VERSION}"}}"#)).unwrap();
 
         // 3. A self-owned install with a DIFFERENT old binary in place, so the swap
-        //    has something to replace and we can prove the bytes changed.
+        //    has something to replace and we can prove the bytes changed. The stale
+        //    runtime/ sidecar (a pre-single-binary install) must be cleaned up by
+        //    the upgrade — asserted below.
         let install = fixture.path().join(".nub");
         let old_bin = install.join("bin");
         std::fs::create_dir_all(&old_bin).unwrap();
@@ -7769,7 +7766,6 @@ mod tests {
         let bad_install = fixture.path().join(".nub-bad");
         std::fs::create_dir_all(bad_install.join("bin")).unwrap();
         std::fs::write(bad_install.join("bin").join("nub"), b"OLD\n").unwrap();
-        std::fs::create_dir_all(bad_install.join("runtime")).unwrap();
         std::fs::write(
             asset_dir.join(format!("nub-{target}.tar.gz.sha256")),
             format!("{}  nub-{target}.tar.gz\n", "0".repeat(64)),
@@ -7802,10 +7798,9 @@ mod tests {
             Path::new("nub"),
             "self-owned upgrade must recreate the nubx → nub alias"
         );
-        assert_eq!(
-            std::fs::read(install.join("runtime").join("VERSION")).unwrap(),
-            FAKE_VERSION.as_bytes(),
-            "runtime/ must be swapped to the new release's payload"
+        assert!(
+            !install.join("runtime").exists(),
+            "single-binary upgrade must remove a stale pre-single-binary runtime/ sidecar"
         );
 
         // (c) The npm-channel install invocation is OS-correct for the resolved

--- a/crates/nub-core/Cargo.toml
+++ b/crates/nub-core/Cargo.toml
@@ -6,6 +6,17 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+# Release-only single-binary mode: `build.rs` tars+zstd-compresses the staged
+# `runtime/` tree into the binary (`include_bytes!`) and `runtime_cache` extracts
+# it once, on first run, to a versioned cache dir. OFF by default so the dev loop
+# (`--profile fast`, `make install-dev`) pays no blob re-tar and `find_preload`
+# keeps walking to the in-repo `runtime/` (live-editable). CI release builds turn
+# it on via `nub-cli/embed-runtime`. The optional deps are pulled in ONLY here:
+# `ruzstd` (pure-Rust decode at runtime) ships in the binary; `zstd`/`tar`/`sha2`
+# (encode + key-hash at build time) are build-deps that never reach the binary.
+embed-runtime = ["dep:ruzstd", "dep:zstd", "dep:tar", "dep:sha2"]
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true
@@ -40,6 +51,19 @@ tar.workspace = true
 zip.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+# Pure-Rust zstd DECODER for inflating the embedded runtime blob on first run
+# (embed-runtime only). Pure-Rust on purpose: no libzstd/C toolchain in the
+# shipped binary; the one-time ~tens-of-ms decode is irrelevant. Encode happens
+# at build time with the `zstd` build-dep (libzstd) — decode never needs it.
+ruzstd = { version = "0.8", optional = true }
+
+# Build-time only (embed-runtime): tar + zstd-compress the staged runtime tree
+# into `$OUT_DIR/runtime.tar.zst` and hash it for the cache key. Build-deps never
+# reach the shipped binary, so libzstd's C build lives here, not in the product.
+[build-dependencies]
+tar = { version = "0.4", optional = true }
+zstd = { version = "0.13", optional = true }
+sha2 = { version = "0.10", optional = true }
 
 # Unix-only: terminating-signal forwarding to the child (SIGINT/SIGTERM/SIGHUP).
 # Gated so the Windows build (which uses a different ctrl_c path) doesn't pull it.
@@ -49,6 +73,10 @@ signal-hook = "0.3"
 [dev-dependencies]
 criterion.workspace = true
 blake3 = { workspace = true }
+# Encoder for the runtime_cache unit tests (they build a tiny tar.zst to exercise
+# the decode/unpack/rename/GC path). The PRODUCT decodes with pure-Rust `ruzstd`;
+# only the test fixtures need the libzstd encoder, so it stays a dev-dep.
+zstd = "0.13"
 
 [[bench]]
 name = "workspace_filter"

--- a/crates/nub-core/build.rs
+++ b/crates/nub-core/build.rs
@@ -1,0 +1,101 @@
+//! Single-binary blob generation (the `embed-runtime` feature only).
+//!
+//! When `embed-runtime` is on (release/CI), tar + zstd-19 the staged `runtime/`
+//! tree into `$OUT_DIR/runtime.tar.zst`, which `node::runtime_cache` pulls in via
+//! `include_bytes!`. We also bake the cache key (`runtime-<version>-<blobhash8>`)
+//! as a `rustc-env` so the runtime const is a compile-time literal — zero startup
+//! cost to compute, and content-safe (a different blob ⇒ a different key ⇒ a clean
+//! cache miss ⇒ re-extract).
+//!
+//! When the feature is OFF (the default `--profile fast` dev loop) this is a
+//! near-no-op: no tar, no zstd, no re-run-on-runtime-change — `find_preload` walks
+//! to the in-repo `runtime/` exactly as before, so the measured ~5 s incremental
+//! loop is untouched. The blob-producing deps (`tar`/`zstd`/`sha2`) are optional
+//! build-deps gated by the feature, so a feature-off build never even compiles
+//! libzstd's C.
+//!
+//! The blob carries the CONTENTS of the staging dir at the tar root (`preload.mjs`,
+//! `addons/nub-native.node`, `node_modules/…`) — NOT a `runtime/` prefix — so
+//! extraction lands them directly in `<cache>/runtime-<key>/`, reproducing the
+//! sidecar's internal layout. That layout is load-bearing: the addon resolves
+//! `./addons/nub-native.node` relative to the preload, and the fast-tier
+//! `--require <stem>.cjs` is the byte-identical sibling of the extracted `.mjs`.
+
+#[cfg(feature = "embed-runtime")]
+fn main() {
+    use sha2::{Digest, Sha256};
+    use std::path::PathBuf;
+
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+
+    // Staging dir: default `<repo>/runtime` (= manifest_dir/../../runtime). CI
+    // stages the per-platform addon + the vendored node_modules into the repo's
+    // `runtime/` BEFORE this build, so the default already points at the assembled
+    // tree. `NUB_RUNTIME_STAGING_DIR` overrides it (absolute, or relative to the
+    // repo root) for local release-style packaging.
+    println!("cargo:rerun-if-env-changed=NUB_RUNTIME_STAGING_DIR");
+    let repo_root = manifest_dir.join("../..");
+    let staging = match std::env::var_os("NUB_RUNTIME_STAGING_DIR") {
+        Some(v) => {
+            let p = PathBuf::from(v);
+            if p.is_absolute() {
+                p
+            } else {
+                repo_root.join(p)
+            }
+        }
+        None => repo_root.join("runtime"),
+    };
+    let staging = staging.canonicalize().unwrap_or_else(|e| {
+        panic!(
+            "embed-runtime: staging runtime dir {} not found: {e} \
+             (set NUB_RUNTIME_STAGING_DIR or stage runtime/ before the build)",
+            staging.display()
+        )
+    });
+
+    // Fail loud on an incomplete stage — a feature-on build that embedded a
+    // runtime missing its preload would ship a binary that can't transpile.
+    let preload = staging.join("preload.mjs");
+    if !preload.is_file() {
+        panic!(
+            "embed-runtime: {} has no preload.mjs — the runtime stage is incomplete \
+             (expected the JS + addons/ + node_modules/ assembled tree)",
+            staging.display()
+        );
+    }
+
+    // Re-tar only when the staged tree changes (CI re-stages each build; a local
+    // feature-on rebuild with an unchanged runtime/ skips the work).
+    println!("cargo:rerun-if-changed={}", staging.display());
+
+    // tar(CONTENTS at root) → in-memory bytes.
+    let mut builder = tar::Builder::new(Vec::new());
+    builder
+        .append_dir_all("", &staging)
+        .expect("embed-runtime: tar the staged runtime tree");
+    let tar_bytes = builder
+        .into_inner()
+        .expect("embed-runtime: finalize the runtime tar");
+
+    // zstd level 19 (measured sweet spot: ~2.7 MB; 22 saves nothing, xz adds a dep
+    // + slower decode for ~0.3 MB).
+    let blob = zstd::encode_all(&tar_bytes[..], 19).expect("embed-runtime: zstd-compress the tar");
+
+    let dest = out_dir.join("runtime.tar.zst");
+    std::fs::write(&dest, &blob).expect("embed-runtime: write runtime.tar.zst");
+
+    // Cache key = runtime-<pkg version>-<first 8 hex of sha256(blob)>. Version for
+    // readability + the `~/.cache/nub/node/<version>/` sibling convention; the hash
+    // suffix makes it content-safe.
+    let mut hasher = Sha256::new();
+    hasher.update(&blob);
+    let digest = hasher.finalize();
+    let hash8: String = digest.iter().take(4).map(|b| format!("{b:02x}")).collect();
+    let version = std::env::var("CARGO_PKG_VERSION").unwrap();
+    println!("cargo:rustc-env=NUB_RUNTIME_CACHE_KEY=runtime-{version}-{hash8}");
+}
+
+#[cfg(not(feature = "embed-runtime"))]
+fn main() {}

--- a/crates/nub-core/src/node/mod.rs
+++ b/crates/nub-core/src/node/mod.rs
@@ -4,5 +4,10 @@
 pub mod discovery;
 pub mod feature_matrix;
 pub mod flags;
+// Single-binary runtime extraction — only compiled in release builds that embed
+// the runtime blob (`embed-runtime`). The default dev build resolves `runtime/`
+// via the in-repo walk in `spawn::find_preload`, so this module is absent.
+#[cfg(feature = "embed-runtime")]
+pub mod runtime_cache;
 pub mod spawn;
 pub mod version;

--- a/crates/nub-core/src/node/runtime_cache.rs
+++ b/crates/nub-core/src/node/runtime_cache.rs
@@ -1,0 +1,372 @@
+//! Single-binary runtime extraction (the `embed-runtime` feature only).
+//!
+//! In single-binary mode the whole `runtime/` tree (preload scripts + vendored
+//! `node_modules` + the platform `nub-native.node`) is embedded in the binary as
+//! a zstd-19 tar blob (see `build.rs`). On first run we inflate it ONCE to a
+//! versioned cache dir and hand `find_preload` that path; every later run finds
+//! the dir already present and pays a single `stat`.
+//!
+//! Design points that make this safe:
+//!
+//! - **Atomic publish, no lock.** We extract into a unique `.<key>.<pid>.<rand>.tmp`
+//!   dir then `rename` it onto `<cache>/runtime-<key>/`. `rename` of a populated
+//!   dir is atomic, so a concurrent reader sees the complete dir or nothing. If a
+//!   sibling won the race (target already exists) the loser removes its tmp and
+//!   uses the winner's dir. No flock, no partial-population window.
+//!
+//! - **Existence ⟺ integrity.** The dir name embeds the blob's content hash and
+//!   only ever appears via the atomic rename, so the dir being present means a
+//!   COMPLETE extraction of THIS EXACT blob. That is the integrity sentinel — the
+//!   hot path hashes nothing.
+//!
+//! - **RO-FS fallback.** `~/.cache/nub` first; if it can't be written (immutable
+//!   container, read-only `$HOME`) fall back to `$TMPDIR/nub`. The runtime is
+//!   needed on every invocation, so a silent `$TMPDIR` fallback keeps nub working
+//!   rather than erroring; only when NEITHER is writable do we give up (and log).
+//!
+//! - **Age-based GC.** After a fresh extract, sibling `runtime-*` dirs older than
+//!   30 days are removed (best-effort). Age-based, not "delete all non-current",
+//!   so two versions in active use (a global install + an `npx nub@<old>`) don't
+//!   evict each other. In-progress `.tmp` dirs and the current dir are never
+//!   touched.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime};
+
+use super::discovery;
+
+/// The embedded blob: `runtime/` tarred and zstd-19 compressed at build time.
+static RUNTIME_BLOB: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/runtime.tar.zst"));
+
+/// `runtime-<pkg version>-<blobhash8>` — a compile-time literal baked by build.rs.
+const CACHE_KEY: &str = env!("NUB_RUNTIME_CACHE_KEY");
+
+/// Stale-version eviction threshold.
+const MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// Memoized result of the (at most once) extraction for this process.
+static EXTRACTED: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Ensure the embedded runtime is extracted and return the dir holding
+/// `preload.mjs` / `addons/` / `node_modules/`. Runs the work at most once per
+/// process (OnceLock), returning a cheap clone afterward. `None` only on a
+/// genuinely unusable environment (no writable cache dir) — the caller then runs
+/// without augmentation, exactly as it would for a not-found sidecar.
+pub fn ensure_runtime() -> Option<PathBuf> {
+    EXTRACTED.get_or_init(extract_once).clone()
+}
+
+fn extract_once() -> Option<PathBuf> {
+    let candidates = base_candidates();
+
+    // Fast path: a candidate already holds the extracted dir — one stat, no write.
+    // (Both `~/.cache/nub` and the `$TMPDIR` fallback are checked so a machine that
+    // extracted to the fallback on a read-only `$HOME` still hits the cache.)
+    for base in &candidates {
+        let target = base.join(CACHE_KEY);
+        if target.is_dir() {
+            return Some(target);
+        }
+    }
+
+    // First run for this blob: extract into the first writable base. `try_extract`
+    // probes writability by actually creating its tmp dir, so a read-only primary
+    // falls through to `$TMPDIR`.
+    for base in &candidates {
+        if let Some(dir) = try_extract(base) {
+            return Some(dir);
+        }
+    }
+
+    tracing::warn!(
+        "could not extract the nub runtime (no writable cache dir); \
+         set XDG_CACHE_HOME to a writable path"
+    );
+    None
+}
+
+/// Candidate cache bases in priority order: `~/.cache/nub` (or `$XDG_CACHE_HOME/nub`)
+/// then `$TMPDIR/nub`. Deduplicated so an exotic `TMPDIR == cache_dir` setup
+/// doesn't try the same path twice.
+fn base_candidates() -> Vec<PathBuf> {
+    let mut out = Vec::with_capacity(2);
+    if let Some(c) = discovery::cache_dir() {
+        out.push(c);
+    }
+    let tmp = std::env::temp_dir().join("nub");
+    if !out.contains(&tmp) {
+        out.push(tmp);
+    }
+    out
+}
+
+/// Extract the blob into `<base>/runtime-<key>/` via a unique tmp dir + atomic
+/// rename. Returns the final dir on success (ours or a concurrent winner's), or
+/// `None` if this base is unusable (read-only) or the extraction failed.
+fn try_extract(base: &Path) -> Option<PathBuf> {
+    // create_dir_all is the writability probe: a read-only base fails here and the
+    // caller moves on to the next candidate.
+    if fs::create_dir_all(base).is_err() {
+        return None;
+    }
+    let target = base.join(CACHE_KEY);
+
+    let tmp = base.join(format!(
+        ".{CACHE_KEY}.{}.{}.tmp",
+        std::process::id(),
+        rand_suffix()
+    ));
+    // A leftover tmp from a crashed run with the same name is vanishingly unlikely
+    // (pid + monotonic-ish rand), but clear it so create + unpack start clean.
+    let _ = fs::remove_dir_all(&tmp);
+    if fs::create_dir_all(&tmp).is_err() {
+        return None;
+    }
+
+    if let Err(e) = unpack_blob(&tmp) {
+        let _ = fs::remove_dir_all(&tmp);
+        tracing::warn!("failed to inflate the embedded nub runtime: {e}");
+        return None;
+    }
+
+    match fs::rename(&tmp, &target) {
+        Ok(()) => {
+            gc_stale(base, &target);
+            Some(target)
+        }
+        Err(_) => {
+            // Either a concurrent extractor already published `target` (the common,
+            // benign case — `rename` onto a populated dir fails on both Unix and
+            // Windows), or a genuine FS error. Clean up our tmp and adopt the
+            // winner's dir if it materialized.
+            let _ = fs::remove_dir_all(&tmp);
+            if target.is_dir() { Some(target) } else { None }
+        }
+    }
+}
+
+/// Stream-decompress the embedded zstd blob and unpack the tar into `dest`. The
+/// tar entries are at the root (`preload.mjs`, `addons/…`, `node_modules/…`), so
+/// they land directly in `dest`, reproducing the sidecar layout.
+fn unpack_blob(dest: &Path) -> std::io::Result<()> {
+    let decoder = ruzstd::decoding::StreamingDecoder::new(RUNTIME_BLOB)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    let mut archive = tar::Archive::new(decoder);
+    // The extracted runtime has no executables (the `.node` is dlopen'd, not
+    // exec'd), so preserving the tar-recorded modes (read perms) is sufficient.
+    archive.unpack(dest)
+}
+
+/// Remove sibling `runtime-*` dirs older than [`MAX_AGE`]. Best-effort, never
+/// throws, and never touches the current dir or any in-progress `.tmp` dir (those
+/// start with `.`, so the `runtime-` prefix check skips them). Runs only on the
+/// rare fresh-extract path.
+fn gc_stale(base: &Path, current: &Path) {
+    let Ok(entries) = fs::read_dir(base) else {
+        return;
+    };
+    let now = SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == *current {
+            continue;
+        }
+        if !entry.file_name().to_string_lossy().starts_with("runtime-") {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_dir() {
+            continue;
+        }
+        let stale = meta
+            .modified()
+            .ok()
+            .and_then(|m| now.duration_since(m).ok())
+            .map(|age| age > MAX_AGE)
+            .unwrap_or(false);
+        if stale {
+            let _ = fs::remove_dir_all(&path);
+        }
+    }
+}
+
+/// A short, collision-resistant suffix for the tmp dir name — dep-free
+/// (SystemTime nanos XOR'd with a per-process atomic counter). It only needs to be
+/// unique among this machine's concurrent extractors; the atomic guards two
+/// same-process extractors and the nanos guard cross-process ones.
+fn rand_suffix() -> u64 {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    nanos
+        ^ (COUNTER
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_mul(0x9E37_79B9_7F4A_7C15))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    /// Build a tiny zstd-19 tar blob matching the real embedded layout, so the
+    /// unpack/rename/idempotence/race/GC logic can be exercised without the
+    /// feature's build.rs output. Mirrors `unpack_blob`'s decode side.
+    fn make_test_blob() -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        let preload = b"// preload\n";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(preload.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "preload.mjs", &preload[..])
+            .unwrap();
+
+        let addon = b"\x7fELF-fake-addon";
+        let mut h2 = tar::Header::new_gnu();
+        h2.set_size(addon.len() as u64);
+        h2.set_mode(0o644);
+        h2.set_cksum();
+        builder
+            .append_data(&mut h2, "addons/nub-native.node", &addon[..])
+            .unwrap();
+        let tar_bytes = builder.into_inner().unwrap();
+        zstd::encode_all(&tar_bytes[..], 19).unwrap()
+    }
+
+    fn unpack_test_blob(blob: &[u8], dest: &Path) {
+        let decoder = ruzstd::decoding::StreamingDecoder::new(blob).unwrap();
+        let mut archive = tar::Archive::new(decoder);
+        archive.unpack(dest).unwrap();
+    }
+
+    #[test]
+    fn blob_roundtrips_to_the_sidecar_layout() {
+        let tmp = std::env::temp_dir().join(format!("nub-rtc-rt-{}", rand_suffix()));
+        let _ = fs::remove_dir_all(&tmp);
+        let blob = make_test_blob();
+        unpack_test_blob(&blob, &tmp);
+
+        let mut preload = String::new();
+        fs::File::open(tmp.join("preload.mjs"))
+            .unwrap()
+            .read_to_string(&mut preload)
+            .unwrap();
+        assert_eq!(preload, "// preload\n");
+        assert!(tmp.join("addons/nub-native.node").is_file());
+        fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn extract_then_atomic_rename_is_idempotent() {
+        // First extract publishes the dir; a second pass over the same base + key
+        // sees it present and reuses it byte-for-byte (no re-write).
+        let base = std::env::temp_dir().join(format!("nub-rtc-idem-{}", rand_suffix()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        let key = "runtime-test-deadbeef";
+        let blob = make_test_blob();
+
+        let publish = |base: &Path| -> PathBuf {
+            let target = base.join(key);
+            if target.is_dir() {
+                return target;
+            }
+            let tmp = base.join(format!(".{key}.{}.tmp", rand_suffix()));
+            fs::create_dir_all(&tmp).unwrap();
+            unpack_test_blob(&blob, &tmp);
+            match fs::rename(&tmp, &target) {
+                Ok(()) => target,
+                Err(_) => {
+                    let _ = fs::remove_dir_all(&tmp);
+                    target
+                }
+            }
+        };
+
+        let a = publish(&base);
+        let mtime_a = fs::metadata(a.join("preload.mjs"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        let b = publish(&base);
+        let mtime_b = fs::metadata(b.join("preload.mjs"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        assert_eq!(a, b);
+        assert_eq!(mtime_a, mtime_b, "second pass must not re-extract");
+        fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[test]
+    fn read_only_base_create_probe_fails_cleanly() {
+        // `try_extract`'s writability probe is `create_dir_all(base)`. Point it at a
+        // path whose parent is a FILE (so create_dir_all can't succeed) and confirm
+        // the probe fails rather than panicking — the production fallback to $TMPDIR
+        // rides on exactly this `is_err()`.
+        let file = std::env::temp_dir().join(format!("nub-rtc-file-{}", rand_suffix()));
+        fs::write(&file, b"x").unwrap();
+        let unusable = file.join("subdir"); // parent is a file → create_dir_all errors
+        assert!(fs::create_dir_all(&unusable).is_err());
+        fs::remove_file(&file).unwrap();
+    }
+
+    #[test]
+    fn gc_evicts_stale_keeps_current_and_tmp() {
+        let base = std::env::temp_dir().join(format!("nub-rtc-gc-{}", rand_suffix()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+
+        let current = base.join("runtime-cur");
+        let stale = base.join("runtime-old");
+        let tmp = base.join(".runtime-old.123.tmp");
+        for d in [&current, &stale, &tmp] {
+            fs::create_dir_all(d).unwrap();
+        }
+        // Backdate the stale dir well past MAX_AGE.
+        let old = SystemTime::now() - Duration::from_secs(40 * 24 * 60 * 60);
+        filetime_set(&stale, old);
+
+        gc_stale(&base, &current);
+
+        assert!(current.is_dir(), "current version must survive GC");
+        assert!(!stale.is_dir(), "a >30d sibling must be evicted");
+        assert!(
+            tmp.is_dir(),
+            "an in-progress .tmp dir must never be touched"
+        );
+        fs::remove_dir_all(&base).unwrap();
+    }
+
+    /// Set a dir's mtime via libc `utimes` (unix) — dep-free. On platforms where
+    /// this isn't wired the GC age-test is skipped by leaving mtime as-is, which
+    /// would make the eviction assertion fail loudly rather than silently pass, so
+    /// keep it unix-gated.
+    #[cfg(unix)]
+    fn filetime_set(path: &Path, time: SystemTime) {
+        use std::os::unix::ffi::OsStrExt;
+        let secs = time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as libc::time_t;
+        let tv = libc::timeval {
+            tv_sec: secs,
+            tv_usec: 0,
+        };
+        let times = [tv, tv];
+        let c = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        unsafe {
+            libc::utimes(c.as_ptr(), times.as_ptr());
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn filetime_set(_path: &Path, _time: SystemTime) {}
+}

--- a/crates/nub-core/src/node/runtime_cache.rs
+++ b/crates/nub-core/src/node/runtime_cache.rs
@@ -65,9 +65,13 @@ fn extract_once() -> Option<PathBuf> {
     // Fast path: a candidate already holds the extracted dir — one stat, no write.
     // (Both `~/.cache/nub` and the `$TMPDIR` fallback are checked so a machine that
     // extracted to the fallback on a read-only `$HOME` still hits the cache.)
+    // `preload.mjs` is the completeness sentinel: the dir only ever appears via the
+    // atomic rename of a fully-unpacked tree, so probing the file (still one stat)
+    // rather than just the dir also rejects an externally-induced empty leftover dir
+    // for free — it falls through to a re-extract instead of being trusted.
     for base in &candidates {
         let target = base.join(CACHE_KEY);
-        if target.is_dir() {
+        if target.join("preload.mjs").is_file() {
             return Some(target);
         }
     }
@@ -318,6 +322,10 @@ mod tests {
         fs::remove_file(&file).unwrap();
     }
 
+    // Unix-only: the eviction assertion needs `filetime_set` to backdate the stale
+    // dir, and that helper is a no-op off unix (see its `#[cfg(not(unix))]` arm), so
+    // on other platforms the stale dir would keep its fresh mtime and survive.
+    #[cfg(unix)]
     #[test]
     fn gc_evicts_stale_keeps_current_and_tmp() {
         let base = std::env::temp_dir().join(format!("nub-rtc-gc-{}", rand_suffix()));

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -1500,21 +1500,46 @@ pub fn find_public_preload(nub_binary: &Path) -> Option<String> {
 }
 
 fn find_preload(nub_binary: &Path) -> Option<String> {
-    // Walk up from the binary's directory to find runtime/preload.mjs.
-    let mut dir = nub_binary.parent()?.to_path_buf();
-    for _ in 0..5 {
-        let candidate = dir.join("runtime").join("preload.mjs");
-        if candidate.is_file() {
-            // Strip the `\\?\` verbatim prefix `fs::canonicalize` adds on Windows so
-            // the path is usable in NODE_PATH and convertible to a valid file:// URL.
-            return candidate.to_str().map(|s| strip_verbatim(s, cfg!(windows)));
-        }
-        if !dir.pop() {
-            break;
-        }
+    // Single-binary mode: the runtime is embedded in the binary. Extract it once
+    // (memoized) to a versioned cache dir and point the preload there. This runs
+    // synchronously, BEFORE preload injection / NODE_OPTIONS assembly / the child
+    // spawn (find_preload is the first thing spawn touches), so extraction is
+    // complete before any path is read. The returned `.mjs` path is the
+    // byte-identical sibling of today's sidecar `preload.mjs`; only its directory
+    // moved (sidecar → cache), so `preload_injection_for`'s `--require <stem>.cjs`,
+    // `vendored_node_path`'s `<dir>/node_modules`, and the addon's
+    // `./addons/nub-native.node` all resolve unchanged. A `None` here (no writable
+    // cache dir anywhere) leaves nub un-augmented, exactly as a not-found sidecar
+    // would — never falls through to the (sidecar-less) walk below.
+    #[cfg(feature = "embed-runtime")]
+    {
+        let _ = nub_binary; // resolution is from the embedded blob, not the binary's dir
+        super::runtime_cache::ensure_runtime().and_then(|dir| {
+            dir.join("preload.mjs")
+                .to_str()
+                .map(|s| strip_verbatim(s, cfg!(windows)))
+        })
     }
-    tracing::warn!("preload not found relative to nub binary");
-    None
+
+    // Dev / feature-off: walk up from the binary's directory to find
+    // runtime/preload.mjs (the in-repo, live-editable sidecar).
+    #[cfg(not(feature = "embed-runtime"))]
+    {
+        let mut dir = nub_binary.parent()?.to_path_buf();
+        for _ in 0..5 {
+            let candidate = dir.join("runtime").join("preload.mjs");
+            if candidate.is_file() {
+                // Strip the `\\?\` verbatim prefix `fs::canonicalize` adds on Windows so
+                // the path is usable in NODE_PATH and convertible to a valid file:// URL.
+                return candidate.to_str().map(|s| strip_verbatim(s, cfg!(windows)));
+            }
+            if !dir.pop() {
+                break;
+            }
+        }
+        tracing::warn!("preload not found relative to nub binary");
+        None
+    }
 }
 
 /// Resolve the path to the currently running Nub binary (follows symlinks).

--- a/install.ps1
+++ b/install.ps1
@@ -33,16 +33,18 @@ $Exe = "$BinDir\nub.exe"
 
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-# Download the per-platform archive (binary + runtime) and extract it into the
-# install dir. The archive ships bin\nub.exe alongside runtime\ (preload.mjs +
-# vendored node_modules); without runtime\, nub cannot transpile at all (A30).
+# Download the per-platform archive and extract it into the install dir. The
+# archive ships ONLY bin\ — nub is a single self-contained binary that embeds its
+# runtime (preload + vendored node_modules + native addon) and JIT-extracts it to
+# the user cache on first run, so there is no sidecar runtime\ to ship.
 $Url = "https://github.com/nubjs/nub/releases/download/v$Version/nub-$Target.zip"
 Write-Host "Downloading from $Url..."
 
 $TmpZip = Join-Path $env:TEMP "nub-$Target-$PID.zip"
 try {
     Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
-    # Replace any prior bin\ + runtime\ for a clean upgrade, then extract.
+    # Replace any prior bin\ for a clean upgrade. A stale runtime\ from a
+    # pre-single-binary install is also removed for hygiene, then extract bin\.
     if (Test-Path $BinDir) { Remove-Item -Recurse -Force $BinDir }
     if (Test-Path "$InstallDir\runtime") { Remove-Item -Recurse -Force "$InstallDir\runtime" }
     Expand-Archive -Path $TmpZip -DestinationPath $InstallDir -Force

--- a/install.sh
+++ b/install.sh
@@ -80,9 +80,10 @@ info "Installing nub v${version} for ${target}..."
 
 mkdir -p "$bin_dir" || error "Failed to create install directory: $bin_dir"
 
-# Download the per-platform archive (binary + runtime) and extract it into the
-# install dir. The archive ships bin/nub alongside runtime/ (preload.mjs +
-# vendored node_modules); without runtime/, nub cannot transpile at all (A30).
+# Download the per-platform archive and extract it into the install dir. The
+# archive ships ONLY bin/ — nub is a single self-contained binary that embeds its
+# runtime (preload + vendored node_modules + native addon) and JIT-extracts it to
+# ~/.cache/nub on first run, so there is no sidecar runtime/ to ship.
 # (Windows is handled by install.ps1 above, so $target is always darwin/linux.)
 url="https://github.com/nubjs/nub/releases/download/v${version}/nub-${target}.tar.gz"
 
@@ -92,8 +93,9 @@ trap 'rm -f "$tmp_archive"' EXIT
 curl --fail --location --progress-bar --output "$tmp_archive" "$url" ||
     error "Failed to download nub from: $url"
 
-# Replace any prior bin/ + runtime/ for a clean upgrade (other files under
-# $install_dir, e.g. caches, are preserved), then extract bin/ + runtime/.
+# Replace any prior bin/ for a clean upgrade (other files under $install_dir,
+# e.g. caches, are preserved). A stale runtime/ from a pre-single-binary install
+# is also removed so it can't shadow the embedded runtime. Then extract bin/.
 rm -rf "${install_dir:?}/bin" "${install_dir:?}/runtime"
 tar -xzf "$tmp_archive" -C "$install_dir" ||
     error "Failed to extract nub archive from: $url"

--- a/npm/build-local.sh
+++ b/npm/build-local.sh
@@ -11,46 +11,36 @@ case "$PLATFORM" in darwin) ;; linux) ;; *) echo "Unsupported: $PLATFORM"; exit 
 case "$ARCH" in arm64|aarch64) ARCH="arm64" ;; x86_64|amd64) ARCH="x64" ;; *) echo "Unsupported: $ARCH"; exit 1 ;; esac
 
 PKG_DIR="$REPO_ROOT/npm/nub-${PLATFORM}-${ARCH}"
-echo "Building for ${PLATFORM}-${ARCH} → $PKG_DIR"
+echo "Building for ${PLATFORM}-${ARCH} → $PKG_DIR (single binary, embedded runtime)"
 
-# 1. Build release binary
-cargo build --release -p nub-cli
+# Single-binary build: the runtime is EMBEDDED in the binary, so we stage it into
+# the repo's runtime/ FIRST, then build nub-cli with --features embed-runtime so
+# nub-core's build.rs tars + zstd-embeds it. `make npm-build` runs `make build`
+# (= addon) first, so runtime/addons/nub-native.node is already staged here.
 
-# 2. Copy binary — under BOTH names (nub, nubx). The launcher heals the on-PATH
-# entry into a minimal sh trampoline that exec's bin/<verb> directly; the verb is
-# the binary's own argv[0] basename, so nubx must be a real second copy here.
+# 1. Vendor node_modules into the REPO runtime/ (embedded, not a $PKG sidecar).
+#    Pure-JS deps only — oxc is compiled into the addon. @oxc-project/runtime
+#    supplies the emit-helper imports; the rest are web-API polyfills.
+rm -rf "$REPO_ROOT/runtime/node_modules"
+mkdir -p "$REPO_ROOT/runtime/node_modules/@oxc-project" \
+         "$REPO_ROOT/runtime/node_modules/@js-temporal" \
+         "$REPO_ROOT/runtime/node_modules/@petamoriken"
+cp -RL "$REPO_ROOT/node_modules/@oxc-project/runtime" "$REPO_ROOT/runtime/node_modules/@oxc-project/"
+cp -RL "$REPO_ROOT/node_modules/urlpattern-polyfill" "$REPO_ROOT/runtime/node_modules/"
+cp -RL "$REPO_ROOT/node_modules/@js-temporal/polyfill" "$REPO_ROOT/runtime/node_modules/@js-temporal/"
+cp -RL "$REPO_ROOT/node_modules/jsbi" "$REPO_ROOT/runtime/node_modules/"
+cp -RL "$REPO_ROOT/node_modules/@petamoriken/float16" "$REPO_ROOT/runtime/node_modules/@petamoriken/"
+
+# 2. Build the release binary with the runtime embedded.
+cargo build --release -p nub-cli --features embed-runtime
+
+# 3. Copy ONLY the binary — under BOTH names (nub, nubx). The verb is the binary's
+#    own argv[0] basename, so nubx must be a real second copy. No runtime/ sidecar.
+rm -rf "$PKG_DIR/runtime"
 mkdir -p "$PKG_DIR/bin"
 cp "$REPO_ROOT/target/release/nub" "$PKG_DIR/bin/nub"
 cp "$REPO_ROOT/target/release/nub" "$PKG_DIR/bin/nubx"
 chmod +x "$PKG_DIR/bin/nub" "$PKG_DIR/bin/nubx"
-
-# 3. Copy runtime
-rm -rf "$PKG_DIR/runtime"
-cp -r "$REPO_ROOT/runtime" "$PKG_DIR/runtime"
-
-# 4. Vendor node_modules — pure-JS deps only. The TS/JSX transpiler + module
-# detection, tsconfig discovery/parse + the additive TS-resolver, AND the transpile
-# cache are now IN-PROCESS in nub-native (Rust addon, oxc compiled in), so
-# oxc-transform / oxc-parser and get-tsconfig (+ its resolve-pkg-maps dep) are NO
-# LONGER vendored. nub loads zero npm packages internally now.
-rm -rf "$PKG_DIR/runtime/node_modules"
-mkdir -p "$PKG_DIR/runtime/node_modules"
-# @oxc-project/runtime — oxc-transform emits helper imports from it (e.g.
-# `@oxc-project/runtime/helpers/decorate`) for decorators; oxc has zero deps, so
-# it never arrives transitively (A30). cp the package symlink (cp -r follows the
-# source symlink) into a freshly-made scope dir.
-mkdir -p "$PKG_DIR/runtime/node_modules/@oxc-project"
-cp -r "$REPO_ROOT/node_modules/@oxc-project/runtime" "$PKG_DIR/runtime/node_modules/@oxc-project/"
-# Clobbered/lazy polyfills nub provides as internal deps: URLPattern (A39, Node
-# 22.x), Temporal (A37), and Float16Array (D5/A25, Node 22.x). @js-temporal/
-# polyfill pulls jsbi (its only dep), kept flat alongside so the package resolves
-# it; @petamoriken/float16 has zero deps.
-cp -r "$REPO_ROOT/node_modules/urlpattern-polyfill" "$PKG_DIR/runtime/node_modules/"
-mkdir -p "$PKG_DIR/runtime/node_modules/@js-temporal"
-cp -r "$REPO_ROOT/node_modules/@js-temporal/polyfill" "$PKG_DIR/runtime/node_modules/@js-temporal/"
-cp -r "$REPO_ROOT/node_modules/jsbi" "$PKG_DIR/runtime/node_modules/"
-mkdir -p "$PKG_DIR/runtime/node_modules/@petamoriken"
-cp -r "$REPO_ROOT/node_modules/@petamoriken/float16" "$PKG_DIR/runtime/node_modules/@petamoriken/"
 
 echo ""
 echo "✓ Platform package ready: $PKG_DIR ($(du -sh "$PKG_DIR" | cut -f1))"

--- a/npm/nub-darwin-arm64/package.json
+++ b/npm/nub-darwin-arm64/package.json
@@ -11,7 +11,6 @@
     "arm64"
   ],
   "files": [
-    "bin",
-    "runtime"
+    "bin"
   ]
 }

--- a/npm/nub-darwin-x64/package.json
+++ b/npm/nub-darwin-x64/package.json
@@ -11,7 +11,6 @@
     "x64"
   ],
   "files": [
-    "bin",
-    "runtime"
+    "bin"
   ]
 }

--- a/npm/nub-linux-arm64-musl/package.json
+++ b/npm/nub-linux-arm64-musl/package.json
@@ -11,8 +11,7 @@
     "arm64"
   ],
   "files": [
-    "bin",
-    "runtime"
+    "bin"
   ],
   "libc": [
     "musl"

--- a/npm/nub-linux-arm64/package.json
+++ b/npm/nub-linux-arm64/package.json
@@ -11,8 +11,7 @@
     "arm64"
   ],
   "files": [
-    "bin",
-    "runtime"
+    "bin"
   ],
   "libc": [
     "glibc"

--- a/npm/nub-linux-x64-musl/package.json
+++ b/npm/nub-linux-x64-musl/package.json
@@ -11,8 +11,7 @@
     "x64"
   ],
   "files": [
-    "bin",
-    "runtime"
+    "bin"
   ],
   "libc": [
     "musl"

--- a/npm/nub-linux-x64/package.json
+++ b/npm/nub-linux-x64/package.json
@@ -11,8 +11,7 @@
     "x64"
   ],
   "files": [
-    "bin",
-    "runtime"
+    "bin"
   ],
   "libc": [
     "glibc"

--- a/npm/nub-win32-arm64/package.json
+++ b/npm/nub-win32-arm64/package.json
@@ -11,7 +11,6 @@
     "arm64"
   ],
   "files": [
-    "bin",
-    "runtime"
+    "bin"
   ]
 }

--- a/npm/nub-win32-x64/package.json
+++ b/npm/nub-win32-x64/package.json
@@ -11,7 +11,6 @@
     "x64"
   ],
   "files": [
-    "bin",
-    "runtime"
+    "bin"
   ]
 }

--- a/site/public/install.ps1
+++ b/site/public/install.ps1
@@ -33,16 +33,18 @@ $Exe = "$BinDir\nub.exe"
 
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-# Download the per-platform archive (binary + runtime) and extract it into the
-# install dir. The archive ships bin\nub.exe alongside runtime\ (preload.mjs +
-# vendored node_modules); without runtime\, nub cannot transpile at all (A30).
+# Download the per-platform archive and extract it into the install dir. The
+# archive ships ONLY bin\ — nub is a single self-contained binary that embeds its
+# runtime (preload + vendored node_modules + native addon) and JIT-extracts it to
+# the user cache on first run, so there is no sidecar runtime\ to ship.
 $Url = "https://github.com/nubjs/nub/releases/download/v$Version/nub-$Target.zip"
 Write-Host "Downloading from $Url..."
 
 $TmpZip = Join-Path $env:TEMP "nub-$Target-$PID.zip"
 try {
     Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
-    # Replace any prior bin\ + runtime\ for a clean upgrade, then extract.
+    # Replace any prior bin\ for a clean upgrade. A stale runtime\ from a
+    # pre-single-binary install is also removed for hygiene, then extract bin\.
     if (Test-Path $BinDir) { Remove-Item -Recurse -Force $BinDir }
     if (Test-Path "$InstallDir\runtime") { Remove-Item -Recurse -Force "$InstallDir\runtime" }
     Expand-Archive -Path $TmpZip -DestinationPath $InstallDir -Force

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -80,9 +80,10 @@ info "Installing nub v${version} for ${target}..."
 
 mkdir -p "$bin_dir" || error "Failed to create install directory: $bin_dir"
 
-# Download the per-platform archive (binary + runtime) and extract it into the
-# install dir. The archive ships bin/nub alongside runtime/ (preload.mjs +
-# vendored node_modules); without runtime/, nub cannot transpile at all (A30).
+# Download the per-platform archive and extract it into the install dir. The
+# archive ships ONLY bin/ — nub is a single self-contained binary that embeds its
+# runtime (preload + vendored node_modules + native addon) and JIT-extracts it to
+# ~/.cache/nub on first run, so there is no sidecar runtime/ to ship.
 # (Windows is handled by install.ps1 above, so $target is always darwin/linux.)
 url="https://github.com/nubjs/nub/releases/download/v${version}/nub-${target}.tar.gz"
 
@@ -92,8 +93,9 @@ trap 'rm -f "$tmp_archive"' EXIT
 curl --fail --location --progress-bar --output "$tmp_archive" "$url" ||
     error "Failed to download nub from: $url"
 
-# Replace any prior bin/ + runtime/ for a clean upgrade (other files under
-# $install_dir, e.g. caches, are preserved), then extract bin/ + runtime/.
+# Replace any prior bin/ for a clean upgrade (other files under $install_dir,
+# e.g. caches, are preserved). A stale runtime/ from a pre-single-binary install
+# is also removed so it can't shadow the embedded runtime. Then extract bin/.
 rm -rf "${install_dir:?}/bin" "${install_dir:?}/runtime"
 tar -xzf "$tmp_archive" -C "$install_dir" ||
     error "Failed to extract nub archive from: $url"


### PR DESCRIPTION
Ships nub as one file: the runtime/ tree (preload + vendored node_modules + native addon) is embedded as a zstd-19 blob and JIT-extracted once, on first run, to ~/.cache/nub/runtime-<ver>-<hash>/. Steady state unchanged (one stat).

Release-only `embed-runtime` cargo feature, off by default — the dev loop walks to the in-repo runtime/ as before. build.rs makes the blob (include_bytes!); runtime_cache.rs extracts it (atomic tmp+rename, RO-FS to $TMPDIR fallback, age-based GC). find_preload routes through it; downstream resolution unchanged.

Tradeoff: binary +~2.1-2.7 MB/platform; npm package -~8 MB net; first run +~35-90 ms once.

Open item: Windows first-run DLL write (SmartScreen/AV), verifiable only on the Windows CI leg.

Held for maintainer review — architectural, not part of the patch release. Full detail in the commit message.