### PR TITLE
fix(cache): fold filename into transpile cache key (#171)

### DIFF
--- a/crates/nub-cache-key/src/lib.rs
+++ b/crates/nub-cache-key/src/lib.rs
@@ -3,18 +3,26 @@
 //! test can't live in the cdylib `nub-native`).
 //!
 //! The key preimage is NUL-separated and order-fixed (no trailing separator):
-//!   `nub_version \0 schema \0 build_id \0 source \0 ext \0 tsconfig_hash \0 pkg_type`
+//!   `nub_version \0 schema \0 build_id \0 source \0 ext \0 tsconfig_hash \0 pkg_type \0 filename`
 //! → blake3 → 64-hex lowercase → the cache FILENAME. Every component is hashed
 //! IN, so a change to ANY of them (a nub release, a CACHE_SCHEMA bump, a rebuild
 //! at a new build-id) yields a disjoint filename — old on-disk entries are
 //! silently ignored (a miss), never mis-read. `nub-native` calls `cache_key` with
 //! its `NUB_VERSION` / `CACHE_SCHEMA` / `BUILD_ID` consts.
+//!
+//! `filename` is in the preimage because the cached body carries a per-file
+//! `//# sourceURL=<absolute path>` magic comment: two byte-identical sources in
+//! the same directory would otherwise collide on one entry and the second file
+//! would be served the first's `sourceURL`, misattributing V8 stack frames and
+//! debugger source mapping (issue #171).
 
 /// blake3 of the NUL-separated key preimage → 64-hex lowercase.
 ///
 /// `nub_version` / `schema` / `build_id` are the cross-build invalidation
 /// components (compile-time consts on the production path); `source` / `ext` /
-/// `tsconfig_hash` / `pkg_type` are the per-file inputs.
+/// `tsconfig_hash` / `pkg_type` / `filename` are the per-file inputs. `filename`
+/// is keyed in because it is baked into the cached body as the `//# sourceURL`
+/// comment, so distinct files must not share an entry (issue #171).
 #[allow(clippy::too_many_arguments)]
 pub fn cache_key(
     nub_version: &str,
@@ -24,6 +32,7 @@ pub fn cache_key(
     ext: &str,
     tsconfig_hash: &str,
     pkg_type: &str,
+    filename: &str,
 ) -> String {
     let mut h = blake3::Hasher::new();
     h.update(nub_version.as_bytes());
@@ -39,6 +48,8 @@ pub fn cache_key(
     h.update(tsconfig_hash.as_bytes());
     h.update(b"\0");
     h.update(pkg_type.as_bytes());
+    h.update(b"\0");
+    h.update(filename.as_bytes());
     h.finalize().to_hex().to_string()
 }
 
@@ -51,9 +62,10 @@ mod tests {
     const EXT: &str = "ts";
     const TSCONFIG: &str = "tsconfig-hash";
     const PKG: &str = "module";
+    const FILENAME: &str = "/proj/src/x.ts";
 
     fn key(version: &str, schema: &str, build_id: &str) -> String {
-        cache_key(version, schema, build_id, SRC, EXT, TSCONFIG, PKG)
+        cache_key(version, schema, build_id, SRC, EXT, TSCONFIG, PKG, FILENAME)
     }
 
     /// A rebuilt binary (new build-id) must not serve a prior build's entries:
@@ -63,20 +75,20 @@ mod tests {
     #[test]
     fn cache_key_changes_when_build_id_changes() {
         assert_ne!(
-            key("0.0.1", "5", "abc1234"),
-            key("0.0.1", "5", "def5678"),
+            key("0.0.1", "6", "abc1234"),
+            key("0.0.1", "6", "def5678"),
             "a different build-id must yield a different cache key"
         );
     }
 
-    /// The schema is hashed into the key, so a schema bump (e.g. the 4→5 move)
-    /// makes the two eras' filenames disjoint — a "5" build can never read a
-    /// "4"-era entry, it simply misses.
+    /// The schema is hashed into the key, so a schema bump (e.g. the 5→6 move)
+    /// makes the two eras' filenames disjoint — a "6" build can never read a
+    /// "5"-era entry, it simply misses.
     #[test]
     fn cache_key_namespaced_by_schema() {
         assert_ne!(
-            key("0.0.1", "4", "abc1234"),
             key("0.0.1", "5", "abc1234"),
+            key("0.0.1", "6", "abc1234"),
             "a different schema must yield a different cache key"
         );
     }
@@ -85,6 +97,38 @@ mod tests {
     /// rebuilds reuse the cache — identical inputs must always map to one key.
     #[test]
     fn cache_key_is_stable_for_identical_inputs() {
-        assert_eq!(key("0.0.1", "5", "abc1234"), key("0.0.1", "5", "abc1234"));
+        assert_eq!(key("0.0.1", "6", "abc1234"), key("0.0.1", "6", "abc1234"));
+    }
+
+    /// Regression for #171: two byte-identical sources (same ext / tsconfig /
+    /// pkg_type) at DIFFERENT paths must map to DISTINCT cache keys. The cached
+    /// body bakes in a per-file `//# sourceURL`, so a shared entry would serve the
+    /// second file the first's `sourceURL` and misattribute stack frames.
+    #[test]
+    fn cache_key_distinguishes_identical_sources_by_filename() {
+        let alpha = cache_key(
+            "0.0.1",
+            "6",
+            "abc1234",
+            SRC,
+            EXT,
+            TSCONFIG,
+            PKG,
+            "/proj/alpha.ts",
+        );
+        let beta = cache_key(
+            "0.0.1",
+            "6",
+            "abc1234",
+            SRC,
+            EXT,
+            TSCONFIG,
+            PKG,
+            "/proj/beta.ts",
+        );
+        assert_ne!(
+            alpha, beta,
+            "identical content at different paths must yield distinct cache keys"
+        );
     }
 }

--- a/crates/nub-native/src/cache.rs
+++ b/crates/nub-native/src/cache.rs
@@ -3,10 +3,12 @@
 //! the old JS cache, so warm caches survive the JS→Rust move (no global miss).
 //!
 //! Cache key preimage (no trailing separator):
-//!   `NUB_VERSION \0 CACHE_SCHEMA \0 build_id \0 source \0 ext \0 tsconfig_hash \0 (pkg_type||"")`
-//!   → blake3 → 64-hex lowercase → cache FILENAME. (SCHEMA "5" = compile-time
-//!   build-id era; SCHEMA "4" folded a runtime exe-hash here, SCHEMA "3" / the old
-//!   JS path used SHA-256 and a key without that component.)
+//!   `NUB_VERSION \0 CACHE_SCHEMA \0 build_id \0 source \0 ext \0 tsconfig_hash \0 (pkg_type||"") \0 filename`
+//!   → blake3 → 64-hex lowercase → cache FILENAME. `filename` is in the key
+//!   because the cached body carries a per-file `//# sourceURL` comment (issue
+//!   #171). (SCHEMA "6" added `filename`; SCHEMA "5" = compile-time build-id era;
+//!   SCHEMA "4" folded a runtime exe-hash here, SCHEMA "3" / the old JS path used
+//!   SHA-256 and a key without that component.)
 //! On-disk entry: `[16-hex integrity = blake3(body)[..16]][body]`, where
 //!   `body = format_byte('c'|'m') + post_processed_code`.
 //! Atomic write via a `*.tmp` sibling + rename (the `*.tmp` suffix is what
@@ -25,14 +27,15 @@ use oxc_napi::OxcError;
 
 use crate::transform::{TransformOptions, transform};
 
-/// On-disk entry format version. Bumped to "5" when the key's per-build
-/// component switched from a runtime exe-hash to the compile-time build-id const
-/// (see `BUILD_ID`): a "4"-era entry was named with a 64-hex exe-hash in the
-/// preimage and must never be read by a "5" build, and vice versa. This constant
-/// is hashed INTO the key, so the filenames are disjoint across schemas — old
-/// entries are silently ignored (a miss), never mis-read. (SCHEMA "4" was the
-/// blake3 + exe-hash era; "3" / the old JS path used SHA-256.)
-const CACHE_SCHEMA: &str = "5";
+/// On-disk entry format version. Bumped to "6" when `filename` was folded into
+/// the key (issue #171): a "5"-era entry was named without `filename` in the
+/// preimage, so two byte-identical sources in a directory collided on one entry
+/// and the second was served the first's `//# sourceURL`. "5" was the move from a
+/// runtime exe-hash to the compile-time build-id const (see `BUILD_ID`). This
+/// constant is hashed INTO the key, so the filenames are disjoint across schemas
+/// — old entries are silently ignored (a miss), never mis-read. (SCHEMA "4" was
+/// the blake3 + exe-hash era; "3" / the old JS path used SHA-256.)
+const CACHE_SCHEMA: &str = "6";
 const INTEGRITY_LEN: usize = 16;
 /// Lockstep with `runtime/version.mjs` via `make version`; the sole version
 /// component of the key (a new nub release ships any emit change + a rebuilt addon).
@@ -84,7 +87,7 @@ pub fn transform_cached(
         "module"
     };
 
-    let key = cache_key(&source, &ext, &tsconfig_hash, &pkg_type);
+    let key = cache_key(&source, &ext, &tsconfig_hash, &pkg_type, &filename);
 
     // Cache hit path.
     if let Some(dir) = cache_dir.as_deref() {
@@ -165,12 +168,21 @@ pub fn transform_cached(
 const BUILD_ID: &str = env!("NUB_NATIVE_BUILD_ID");
 
 /// blake3(NUB_VERSION \0 SCHEMA \0 BUILD_ID \0 source \0 ext \0 tsconfig_hash \0
-/// pkg_type) → 64-hex lowercase. blake3 (SIMD) replaces SHA-256 on the hot path;
-/// the compile-time `BUILD_ID` is folded in so a rebuilt binary auto-invalidates
-/// the cache without any runtime I/O. The derivation lives in the napi-free
-/// `nub-cache-key` crate so its invalidation contract is unit-testable (this
-/// cdylib has `test = false` — a test harness can't link the napi symbols).
-fn cache_key(source: &str, ext: &str, tsconfig_hash: &str, pkg_type: &str) -> String {
+/// pkg_type \0 filename) → 64-hex lowercase. blake3 (SIMD) replaces SHA-256 on the
+/// hot path; the compile-time `BUILD_ID` is folded in so a rebuilt binary
+/// auto-invalidates the cache without any runtime I/O. `filename` is keyed in
+/// because the cached body bakes in a per-file `//# sourceURL` (issue #171), so
+/// two byte-identical sources at different paths must not share an entry. The
+/// derivation lives in the napi-free `nub-cache-key` crate so its invalidation
+/// contract is unit-testable (this cdylib has `test = false` — a test harness
+/// can't link the napi symbols).
+fn cache_key(
+    source: &str,
+    ext: &str,
+    tsconfig_hash: &str,
+    pkg_type: &str,
+    filename: &str,
+) -> String {
     nub_cache_key::cache_key(
         NUB_VERSION,
         CACHE_SCHEMA,
@@ -179,6 +191,7 @@ fn cache_key(source: &str, ext: &str, tsconfig_hash: &str, pkg_type: &str) -> St
         ext,
         tsconfig_hash,
         pkg_type,
+        filename,
     )
 }
 


### PR DESCRIPTION
The transpile cache key omitted `filename`, but the cached body bakes in a per-file `//# sourceURL`. Two byte-identical sources in one directory collided on one entry, so the second was served the first's `sourceURL` — misattributing V8 stack frames, even cold within one process.

Fold `filename` into the cache-key preimage and bump `CACHE_SCHEMA` 5 → 6 (one-time cold-cache miss on upgrade). Adds a regression test; verified e2e that identical files now get distinct entries + sourceURLs cold and warm.

Closes #171