### PR TITLE
feat(install): forward pnpm reporter/silent/loglevel flags to quiet the install

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -731,6 +731,9 @@ pub enum Command {
         /// Include the workspace root in recursive operations.
         #[arg(long)]
         include_workspace_root: bool,
+
+        #[command(flatten)]
+        output: crate::pm_engine::OutputFlags,
     },
 
     /// Clean install for CI: delete node_modules, install strictly from the
@@ -772,6 +775,9 @@ pub enum Command {
         /// Include the workspace root in recursive operations.
         #[arg(long)]
         include_workspace_root: bool,
+
+        #[command(flatten)]
+        output: crate::pm_engine::OutputFlags,
     },
 }
 
@@ -1957,6 +1963,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             recursive,
             fail_if_no_match,
             include_workspace_root,
+            output,
         }) => crate::pm_engine::run_install(crate::pm_engine::InstallFlags {
             frozen_lockfile,
             no_frozen_lockfile,
@@ -1979,6 +1986,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
                 fail_if_no_match,
                 include_workspace_root,
             },
+            output,
         }),
         Some(Command::Ci {
             ignore_scripts,
@@ -1990,6 +1998,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             recursive,
             fail_if_no_match,
             include_workspace_root,
+            output,
         }) => crate::pm_engine::run_ci(crate::pm_engine::CiFlags {
             ignore_scripts,
             no_optional,
@@ -2002,6 +2011,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
                 fail_if_no_match,
                 include_workspace_root,
             },
+            output,
         }),
         // `node` is intercepted at the top of `dispatch_subcommand` (manual
         // sub-verb match in `run_node`) and never reaches clap here.

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -218,6 +218,11 @@ struct EngineGlobals {
     /// Include the workspace root in recursive operations
     #[arg(long, hide = true)]
     include_workspace_root: bool,
+
+    /// Output-verbosity flags (`--reporter`, `--silent`/`-s`, `--loglevel`),
+    /// forwarded to the engine's text-mode renderers.
+    #[command(flatten)]
+    output: super::output::OutputFlags,
 }
 
 impl EngineGlobals {
@@ -291,6 +296,38 @@ macro_rules! parse_or_return {
     };
 }
 
+/// Apply the forwarded output flags (`--reporter`/`--silent`/`--loglevel`) for
+/// the duration of `f`, then restore. The returned [`output::OutputGuard`] is
+/// held only across `f` (the engine run) and dropped before the caller's
+/// `finish`/`finish_code` — so under `--silent` the progress/summary written
+/// during the run is suppressed while a final error report still reaches the
+/// real stderr. The progress-mode and log-level side effects persist (harmless
+/// once the command is done).
+fn with_output<T>(output: &super::output::OutputFlags, f: impl FnOnce() -> T) -> T {
+    let _guard = output.apply();
+    f()
+}
+
+/// Run an engine future to completion under the forwarded output flags, then
+/// map its result to nub's exit contract via [`finish`]. The output guard is
+/// dropped before `finish`, so errors print even under `--silent`.
+fn finish_quieted(
+    output: &super::output::OutputFlags,
+    session: &EngineSession,
+    fut: impl std::future::Future<Output = miette::Result<()>>,
+) -> Result<i32> {
+    finish(with_output(output, || session.runtime.block_on(fut)))
+}
+
+/// [`finish_quieted`] for engine verbs that return an explicit exit code.
+fn finish_code_quieted(
+    output: &super::output::OutputFlags,
+    session: &EngineSession,
+    fut: impl std::future::Future<Output = miette::Result<Option<i32>>>,
+) -> Result<i32> {
+    finish_code(with_output(output, || session.runtime.block_on(fut)))
+}
+
 /// Map an engine result to nub's exit contract: success → 0, failure →
 /// rendered through the presentation layer + the engine's exit table.
 fn finish(result: miette::Result<()>) -> Result<i32> {
@@ -323,12 +360,11 @@ fn run_add(typed: &str, args: &[String]) -> Result<i32> {
             &yarn_remedy("add", &verb.packages),
         ));
     }
-    let code = finish(
-        session
-            .runtime
-            .block_on(aube::commands::add::run(verb, globals.effective_filter())),
-    )?;
-    Ok(code)
+    finish_quieted(
+        &globals.output,
+        &session,
+        aube::commands::add::run(verb, globals.effective_filter()),
+    )
 }
 
 fn run_remove(typed: &str, args: &[String]) -> Result<i32> {
@@ -341,10 +377,11 @@ fn run_remove(typed: &str, args: &[String]) -> Result<i32> {
             &yarn_remedy("remove", &verb.packages),
         ));
     }
-    finish(session.runtime.block_on(aube::commands::remove::run(
-        verb,
-        globals.effective_filter(),
-    )))
+    finish_quieted(
+        &globals.output,
+        &session,
+        aube::commands::remove::run(verb, globals.effective_filter()),
+    )
 }
 
 fn run_update(typed: &str, args: &[String]) -> Result<i32> {
@@ -367,11 +404,11 @@ fn run_update(typed: &str, args: &[String]) -> Result<i32> {
             &yarn_remedy("upgrade", &verb.packages),
         ));
     }
-    let code = finish_code(session.runtime.block_on(aube::commands::update::run(
-        verb,
-        globals.effective_filter(),
-    )))?;
-    Ok(code)
+    finish_code_quieted(
+        &globals.output,
+        &session,
+        aube::commands::update::run(verb, globals.effective_filter()),
+    )
 }
 
 fn run_dedupe(typed: &str, args: &[String]) -> Result<i32> {
@@ -386,7 +423,7 @@ fn run_dedupe(typed: &str, args: &[String]) -> Result<i32> {
             "yarn dedupe",
         ));
     }
-    finish(session.runtime.block_on(aube::commands::dedupe::run(verb)))
+    finish_quieted(&globals.output, &session, aube::commands::dedupe::run(verb))
 }
 
 fn run_prune(typed: &str, args: &[String]) -> Result<i32> {
@@ -395,46 +432,56 @@ fn run_prune(typed: &str, args: &[String]) -> Result<i32> {
     // prune prints its summary via raw eprintln with a hardcoded `.aube`
     // store label (the walked directory is the *resolved* virtualStoreDir —
     // node_modules/.nub here — only the label lies). Capture + neutralize.
-    let (result, captured) = super::with_fd_captured(2, || {
-        session.runtime.block_on(aube::commands::prune::run(verb))
+    // Under `--silent` the output guard redirects stderr, so the rebranded
+    // reprint is suppressed too; the guard drops before `finish`.
+    let result = with_output(&globals.output, || {
+        let (result, captured) = super::with_fd_captured(2, || {
+            session.runtime.block_on(aube::commands::prune::run(verb))
+        });
+        eprint!(
+            "{}",
+            present::rewrite(&captured).replace(" from .aube,", " from the virtual store,")
+        );
+        result
     });
-    eprint!(
-        "{}",
-        present::rewrite(&captured).replace(" from .aube,", " from the virtual store,")
-    );
     finish(result)
 }
 
 fn run_rebuild(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::rebuild::RebuildArgs) = parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
-    finish(session.runtime.block_on(aube::commands::rebuild::run(
-        verb,
-        globals.effective_filter(),
-    )))
+    finish_quieted(
+        &globals.output,
+        &session,
+        aube::commands::rebuild::run(verb, globals.effective_filter()),
+    )
 }
 
 fn run_fetch(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::fetch::FetchArgs) = parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
-    finish(session.runtime.block_on(aube::commands::fetch::run(verb)))
+    finish_quieted(&globals.output, &session, aube::commands::fetch::run(verb))
 }
 
 fn run_link(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::link::LinkArgs) = parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
-    finish(session.runtime.block_on(aube::commands::link::run(verb)))
+    finish_quieted(&globals.output, &session, aube::commands::link::run(verb))
 }
 
 fn run_unlink(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::unlink::UnlinkArgs) = parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
     // The unlink-all path ends with a raw `` Run `aube install` … `` hint
-    // on stderr; capture + rewrite (no children, no progress UI here).
-    let (result, captured) = super::with_fd_captured(2, || {
-        session.runtime.block_on(aube::commands::unlink::run(verb))
+    // on stderr; capture + rewrite (no children, no progress UI here). Under
+    // `--silent` the output guard redirects stderr, suppressing the reprint.
+    let result = with_output(&globals.output, || {
+        let (result, captured) = super::with_fd_captured(2, || {
+            session.runtime.block_on(aube::commands::unlink::run(verb))
+        });
+        eprint!("{}", present::rewrite(&captured));
+        result
     });
-    eprint!("{}", present::rewrite(&captured));
     finish(result)
 }
 
@@ -458,10 +505,10 @@ fn run_ignored_builds(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::ignored_builds::IgnoredBuildsArgs) =
         parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
-    finish(
-        session
-            .runtime
-            .block_on(aube::commands::ignored_builds::run(verb)),
+    finish_quieted(
+        &globals.output,
+        &session,
+        aube::commands::ignored_builds::run(verb),
     )
 }
 
@@ -482,8 +529,10 @@ fn run_dlx(typed: &str, args: &[String]) -> Result<i32> {
     }
     let session = super::engine_session(globals.dir.as_deref())?;
     // NOTE: on child failure the engine propagates the child's exit code via
-    // std::process::exit — control does not return here on that path.
-    finish_code(session.runtime.block_on(aube::commands::dlx::run(verb)))
+    // std::process::exit — control does not return here on that path. Output
+    // flags quiet the fetch; the run tool's own output is preserved (the
+    // silencer registers the saved fd for child stderr).
+    finish_code_quieted(&globals.output, &session, aube::commands::dlx::run(verb))
 }
 
 /// DLX fallback for the `nubx <tool> [args]` entry point: the bin was absent
@@ -562,7 +611,7 @@ fn run_create(typed: &str, args: &[String]) -> Result<i32> {
     // The engine maps the template to its create-* package (foo → create-foo,
     // @scope/foo → @scope/create-foo) and chains into dlx; like dlx, on child
     // failure the engine propagates the exit code via std::process::exit.
-    finish_code(session.runtime.block_on(aube::commands::create::run(verb)))
+    finish_code_quieted(&globals.output, &session, aube::commands::create::run(verb))
 }
 
 // ───────────────────────── patch workflow ──────────────────────────
@@ -674,7 +723,11 @@ fn run_import(typed: &str, args: &[String]) -> Result<i32> {
     super::engine_brand_preflight();
     match import_to_pnpm_lock(verb.force) {
         Ok(summary) => {
-            present::info(&summary);
+            // import writes no progress UI; the only output is this summary,
+            // suppressed under `--silent` to match `pnpm import --silent`.
+            if !globals.output.is_silent() {
+                present::info(&summary);
+            }
             Ok(0)
         }
         Err(report) => Ok(present::emit_report(&report)),
@@ -821,6 +874,8 @@ pub struct InstallFlags {
     /// Workspace selectors (`--filter`/`-r`/…), routed through the same
     /// `EffectiveFilter` path the registry verbs (`add`/`remove`/`update`) use.
     pub filter: WorkspaceFilterFlags,
+    /// Output-verbosity flags (`--reporter`/`--silent`/`--loglevel`).
+    pub output: super::output::OutputFlags,
 }
 
 /// `nub ci` flags. `ci` is frozen + clean by definition, so only the script /
@@ -834,6 +889,8 @@ pub struct CiFlags {
     pub dir: Option<std::path::PathBuf>,
     /// Workspace selectors (`--filter`/`-r`/…) — same path as `install`.
     pub filter: WorkspaceFilterFlags,
+    /// Output-verbosity flags (`--reporter`/`--silent`/`--loglevel`).
+    pub output: super::output::OutputFlags,
 }
 
 /// The workspace-selection flags nub honors on `install`/`ci`, mirroring the
@@ -971,7 +1028,7 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
         opts.mode = FrozenMode::Frozen;
     }
 
-    let code = run_engine(&session, opts, yarn)?;
+    let code = run_engine(&session, opts, yarn, &flags.output)?;
     // Truly-fresh install: the neutral `lock.yaml` was already written (the
     // `defaultLockfileFormat=aube` embedder default on this path), and that
     // lockfile is the quiet identity marker — the classifier treats a present
@@ -1097,7 +1154,7 @@ pub fn run_ci(flags: CiFlags) -> Result<i32> {
             ));
         }
     }
-    run_engine(&session, opts, yarn)
+    run_engine(&session, opts, yarn, &flags.output)
 }
 
 /// Yarn-kind drift pre-flight, at the nub layer.
@@ -1220,12 +1277,23 @@ fn pnpm_era_for_lockfile_version(version: &str) -> &'static str {
 /// Run the install on the session runtime, route failures through the
 /// presentation layer. `yarn_gated` switches the frozen-drift failure to the
 /// yarn write-gate message.
-fn run_engine(session: &EngineSession, opts: InstallOptions, yarn_gated: bool) -> Result<i32> {
-    let result = session.runtime.block_on(aube::commands::install::run(opts));
-    // Flush the diagnostics recorder (summary table, critical-path, etc.) so
-    // that AUBE_DIAG_* env vars work end-to-end via `nub install`. aube's own
-    // CLI entry flushes from lib.rs; the library path needs an explicit call.
-    aube_util::diag::flush();
+fn run_engine(
+    session: &EngineSession,
+    opts: InstallOptions,
+    yarn_gated: bool,
+    output: &super::output::OutputFlags,
+) -> Result<i32> {
+    // Hold the output guard only across the engine run (so `--silent` suppresses
+    // the progress/summary written during install) and drop it before the match
+    // below, so a final error report still reaches the real stderr.
+    let result = with_output(output, || {
+        let result = session.runtime.block_on(aube::commands::install::run(opts));
+        // Flush the diagnostics recorder (summary table, critical-path, etc.) so
+        // that AUBE_DIAG_* env vars work end-to-end via `nub install`. aube's own
+        // CLI entry flushes from lib.rs; the library path needs an explicit call.
+        aube_util::diag::flush();
+        result
+    });
     match result {
         Ok(()) => Ok(0),
         // Frozen-drift on a gated yarn project: the install *would* rewrite

--- a/crates/nub-cli/src/pm_engine/log.rs
+++ b/crates/nub-cli/src/pm_engine/log.rs
@@ -25,29 +25,87 @@
 //! revisit if the fork ever exports the pausing writer.
 
 use super::present;
+use std::sync::OnceLock;
 use tracing::field::{Field, Visit};
 use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::reload;
 use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::{EnvFilter, Registry};
 
-/// Default filter: the engine's crate targets at `warn`, nothing else.
-/// Mirrors the directive list in the engine's own `init_logging`
-/// (`vendor/aube/crates/aube/src/startup.rs`) so warnings surface from
-/// every engine crate, not just the command layer.
-const ENGINE_WARN_DIRECTIVES: &str = "aube=warn,aube_registry=warn,aube_resolver=warn,\
-     aube_lockfile=warn,aube_store=warn,aube_linker=warn,aube_manifest=warn,\
-     aube_scripts=warn,aube_workspace=warn,aube_settings=warn,aube_util=warn";
+/// Default engine log level: `warn`, so routine install output doesn't
+/// collide with the progress display while warnings still surface.
+const DEFAULT_ENGINE_LEVEL: &str = "warn";
+
+/// Per-engine-crate filter directives at `level`. Mirrors the directive
+/// list in the engine's own `init_logging`
+/// (`vendor/aube/crates/aube/src/startup.rs`) so warnings (and, when the
+/// user raises the level, info/debug) surface from every engine crate, not
+/// just the command layer. `level` is a tracing level token (`warn`,
+/// `error`, `info`, `debug`) or `off`.
+fn engine_directives(level: &str) -> String {
+    const CRATES: [&str; 11] = [
+        "aube",
+        "aube_registry",
+        "aube_resolver",
+        "aube_lockfile",
+        "aube_store",
+        "aube_linker",
+        "aube_manifest",
+        "aube_scripts",
+        "aube_workspace",
+        "aube_settings",
+        "aube_util",
+    ];
+    CRATES
+        .iter()
+        .map(|c| format!("{c}={level}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Reload handle for the engine filter, so a per-invocation `--loglevel` /
+/// `--reporter` / `--silent` flag can retune verbosity after the global
+/// subscriber is installed. `None` until [`init`] runs; absent when
+/// `RUST_LOG` owns the filter (see [`set_engine_loglevel`]).
+static FILTER_RELOAD: OnceLock<reload::Handle<EnvFilter, Registry>> = OnceLock::new();
+
+/// Whether `RUST_LOG` was set at [`init`] time. When it was, it owns the
+/// filter and a per-invocation flag must not override it (mirrors aube's
+/// `AUBE_LOG`-wins precedence).
+static RUST_LOG_OWNS_FILTER: OnceLock<bool> = OnceLock::new();
 
 /// Install the process-global subscriber. Call once, before any engine
 /// (or nub) code can emit tracing events.
 pub fn init() {
-    let filter = match std::env::var("RUST_LOG") {
-        Ok(spec) if !spec.is_empty() => tracing_subscriber::EnvFilter::new(spec),
-        _ => tracing_subscriber::EnvFilter::new(ENGINE_WARN_DIRECTIVES),
+    let rust_log = std::env::var("RUST_LOG").ok().filter(|s| !s.is_empty());
+    let _ = RUST_LOG_OWNS_FILTER.set(rust_log.is_some());
+    let filter = match rust_log {
+        Some(spec) => EnvFilter::new(spec),
+        None => EnvFilter::new(engine_directives(DEFAULT_ENGINE_LEVEL)),
     };
+    let (filter, handle) = reload::Layer::new(filter);
+    let _ = FILTER_RELOAD.set(handle);
     tracing_subscriber::registry()
         .with(filter)
         .with(RewriteLayer)
         .init();
+}
+
+/// Retune the engine log level for the rest of the process (a per-invocation
+/// `--loglevel` / `--reporter=silent` / `--silent`). `level` is a tracing
+/// level token (`error`, `warn`, `info`, `debug`) or `off`. A no-op when
+/// `RUST_LOG` was set at startup — an explicit `RUST_LOG` owns the filter,
+/// mirroring aube's `AUBE_LOG`-wins precedence.
+pub fn set_engine_loglevel(level: &str) {
+    if *RUST_LOG_OWNS_FILTER.get().unwrap_or(&false) {
+        return;
+    }
+    let Some(handle) = FILTER_RELOAD.get() else {
+        return;
+    };
+    if let Ok(filter) = EnvFilter::try_new(engine_directives(level)) {
+        let _ = handle.reload(filter);
+    }
 }
 
 /// Minimal event renderer: `LEVEL message [field=value …]`, no

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -57,6 +57,7 @@ pub mod identity;
 pub mod info_family;
 pub mod install_family;
 pub mod log;
+pub mod output;
 pub mod present;
 pub mod publish_family;
 mod resource_limits;
@@ -68,6 +69,7 @@ pub mod use_nub;
 pub use install_family::{
     CiFlags, InstallFlags, WorkspaceFilterFlags, run_ci, run_dlx_for_nubx, run_install,
 };
+pub use output::OutputFlags;
 
 use std::path::{Path, PathBuf};
 

--- a/crates/nub-cli/src/pm_engine/output.rs
+++ b/crates/nub-cli/src/pm_engine/output.rs
@@ -1,0 +1,191 @@
+//! Output-verbosity flags for the install family, forwarded to the embedded
+//! engine's existing text-mode renderers.
+//!
+//! nub dispatches the engine's command impls directly and never runs aube's
+//! `async_main`, so the reporter/verbosity setup `async_main` performs (force
+//! the progress UI to text, retune the log level, install the silent-stderr
+//! redirect) does not happen for nub — leaving no way to quiet `nub install`.
+//! This module mirrors that setup for the spellings real pnpm accepts:
+//! `--reporter <default|append-only|silent>`, `--silent`/`-s`, and
+//! `--loglevel <level>`. Each maps onto the engine's own switch — there are no
+//! nub-specific output knobs.
+//!
+//! Mapping (mirrors `vendor/aube/crates/aube/src/startup.rs`):
+//! - silent (`--silent`/`-s`, `--reporter=silent`, `--loglevel silent`) →
+//!   progress to text + engine logs off + [`aube::silence_own_output`] (skips
+//!   the install summary; redirects fd 2 on Unix). Matches `pnpm --silent`:
+//!   nothing on stderr but fatal errors.
+//! - `--reporter=append-only` → progress to text (the engine drops its
+//!   progress object; the dependency summary still prints).
+//! - `--loglevel <error|warn|info|debug>` → retune the engine log level
+//!   (`error` hides warnings; `info`/`debug` surface more). `debug` also
+//!   forces text so logs don't collide with the progress display.
+
+use super::log;
+
+/// `--reporter` values nub accepts, mirroring pnpm's. `ndjson` is deliberately
+/// absent: a machine-readable event stream is a separate feature from quieting
+/// and is not yet wired through the embedder — see the issue thread.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum Reporter {
+    /// The default progress display.
+    Default,
+    /// Plain, append-only output (no progress object).
+    AppendOnly,
+    /// Suppress all non-error output.
+    Silent,
+}
+
+/// `--loglevel` values nub accepts, mirroring pnpm's documented set (`debug`,
+/// `info`, `warn`, `error`) plus `silent` (what `--silent` resolves to).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub enum LogLevel {
+    Silent,
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+// The forwarded output flags, flattened into the install/ci clap surfaces and
+// the engine-verb globals (and embedded in the install/ci flag structs).
+// Default = no override (the engine's normal output). Spellings mirror pnpm's;
+// each field's `///` doc is its `--help` text. (Plain `//` on the struct: a
+// rustdoc comment here would clobber the flattened command's about-text.)
+#[derive(Debug, Default, Clone, Copy, clap::Args)]
+pub struct OutputFlags {
+    /// Output format: `default`, `append-only`, or `silent`.
+    #[arg(long, value_name = "NAME", value_enum)]
+    pub reporter: Option<Reporter>,
+
+    /// Suppress all output except errors (alias for `--reporter=silent`).
+    #[arg(short = 's', long)]
+    pub silent: bool,
+
+    /// Log level: logs at or above this level are shown. One of `debug`,
+    /// `info`, `warn`, `error`, `silent`.
+    #[arg(long, value_name = "LEVEL", value_enum)]
+    pub loglevel: Option<LogLevel>,
+}
+
+impl OutputFlags {
+    /// True when any spelling resolves to full silence (`pnpm --silent`).
+    /// Public so command impls that print their own (non-engine) summary —
+    /// e.g. `import` — can suppress it under `--silent`.
+    pub fn is_silent(&self) -> bool {
+        self.silent
+            || self.reporter == Some(Reporter::Silent)
+            || self.loglevel == Some(LogLevel::Silent)
+    }
+
+    /// True when the progress UI must drop to plain text — silent, the
+    /// append-only reporter, or a debug log level (whose lines would
+    /// otherwise collide with the progress display). Mirrors the engine's
+    /// `force_text`.
+    fn force_text(&self) -> bool {
+        self.is_silent()
+            || self.reporter == Some(Reporter::AppendOnly)
+            || self.loglevel == Some(LogLevel::Debug)
+    }
+
+    /// The engine log level to apply, as a tracing token, or `None` to leave
+    /// the default. Silent turns logging off entirely.
+    fn engine_level(&self) -> Option<&'static str> {
+        if self.is_silent() {
+            return Some("off");
+        }
+        match self.loglevel {
+            Some(LogLevel::Error) => Some("error"),
+            Some(LogLevel::Info) => Some("info"),
+            Some(LogLevel::Debug) => Some("debug"),
+            // `warn` is already the default filter, so no reload is needed.
+            // Silent is handled above; `None` leaves the default intact.
+            Some(LogLevel::Warn | LogLevel::Silent) | None => None,
+        }
+    }
+
+    /// Apply the resolved output mode for the rest of this command. Returns a
+    /// guard ([`OutputGuard`] is itself `#[must_use]`) that MUST be held across
+    /// the engine run — when silent, its `Drop` restores stderr (so a final
+    /// error report still prints). Idempotent and cheap when no flag is set (the
+    /// common path): it does nothing.
+    pub fn apply(&self) -> OutputGuard {
+        if self.force_text() {
+            clx::progress::set_output(clx::progress::ProgressOutput::Text);
+        }
+        if let Some(level) = self.engine_level() {
+            log::set_engine_loglevel(level);
+        }
+        let silencer = self.is_silent().then(aube::silence_own_output);
+        OutputGuard {
+            _silencer: silencer,
+        }
+    }
+}
+
+/// Holds the engine's silent-output guard for the duration of a command. Drop
+/// restores stderr. Inert (no guard) when the command isn't silent.
+#[must_use]
+pub struct OutputGuard {
+    _silencer: Option<aube::OwnOutputSilencer>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flags(reporter: Option<Reporter>, silent: bool, loglevel: Option<LogLevel>) -> OutputFlags {
+        OutputFlags {
+            reporter,
+            silent,
+            loglevel,
+        }
+    }
+
+    #[test]
+    fn silent_spellings_all_resolve_to_silence() {
+        assert!(flags(None, true, None).is_silent());
+        assert!(flags(Some(Reporter::Silent), false, None).is_silent());
+        assert!(flags(None, false, Some(LogLevel::Silent)).is_silent());
+        // append-only is text, not silence.
+        assert!(!flags(Some(Reporter::AppendOnly), false, None).is_silent());
+        assert!(!flags(None, false, Some(LogLevel::Error)).is_silent());
+    }
+
+    #[test]
+    fn force_text_covers_silent_append_only_and_debug() {
+        assert!(flags(None, true, None).force_text());
+        assert!(flags(Some(Reporter::AppendOnly), false, None).force_text());
+        assert!(flags(None, false, Some(LogLevel::Debug)).force_text());
+        // default reporter / info level keep the rich display.
+        assert!(!flags(Some(Reporter::Default), false, None).force_text());
+        assert!(!flags(None, false, Some(LogLevel::Info)).force_text());
+        assert!(!flags(None, false, None).force_text());
+    }
+
+    #[test]
+    fn engine_level_maps_each_level_and_silence_to_off() {
+        assert_eq!(flags(None, true, None).engine_level(), Some("off"));
+        assert_eq!(
+            flags(None, false, Some(LogLevel::Error)).engine_level(),
+            Some("error")
+        );
+        assert_eq!(
+            flags(None, false, Some(LogLevel::Debug)).engine_level(),
+            Some("debug")
+        );
+        // No level flag — and an explicit `warn`, which equals the default —
+        // both leave the filter untouched (no redundant reload).
+        assert_eq!(flags(None, false, None).engine_level(), None);
+        assert_eq!(
+            flags(None, false, Some(LogLevel::Warn)).engine_level(),
+            None
+        );
+        assert_eq!(
+            flags(Some(Reporter::AppendOnly), false, None).engine_level(),
+            None
+        );
+    }
+}

--- a/crates/nub-cli/tests/cli_grammar_parity.rs
+++ b/crates/nub-cli/tests/cli_grammar_parity.rs
@@ -142,6 +142,26 @@ fn install_family_grammar_accepts_documented_forms() {
             (&["install", "-F", "foo"], "pnpm -F <pattern>"),
             (&["install", "--filter", "foo"], "pnpm --filter <pattern>"),
             (&["install", "-C", "/tmp"], "pnpm -C / --dir <dir>"),
+            // Output-verbosity flags (#179) — pnpm's reporter/silent/loglevel.
+            (&["install", "--silent"], "pnpm --silent"),
+            (&["install", "-s"], "pnpm -s (silent short)"),
+            (
+                &["install", "--reporter", "silent"],
+                "pnpm --reporter silent",
+            ),
+            (
+                &["install", "--reporter=append-only"],
+                "pnpm --reporter append-only",
+            ),
+            (
+                &["install", "--reporter=default"],
+                "pnpm --reporter default",
+            ),
+            (
+                &["install", "--loglevel", "error"],
+                "pnpm --loglevel <level>",
+            ),
+            (&["install", "--loglevel=debug"], "pnpm --loglevel=debug"),
             // A/B/C — pnpm install <pkg> routes through `add` (the P0 + save flags).
             (
                 &["install", "express"],
@@ -312,6 +332,10 @@ fn ci_grammar_accepts_documented_forms() {
             (&["ci", "--no-optional"], "pnpm --no-optional"),
             (&["ci", "-r"], "pnpm -r ci"),
             (&["ci", "-F", "foo"], "pnpm -F <pattern>"),
+            // Output-verbosity flags (#179).
+            (&["ci", "--silent"], "pnpm --silent"),
+            (&["ci", "--reporter=silent"], "pnpm --reporter silent"),
+            (&["ci", "--loglevel=error"], "pnpm --loglevel <level>"),
         ],
     );
 }
@@ -343,6 +367,17 @@ fn engine_add_grammar_accepts_documented_forms() {
             (&["add", "foo", "-r"], "pnpm -r"),
             (&["add", "foo", "-F", "bar"], "pnpm -F <pattern>"),
             (&["add", "foo", "--ignore-scripts"], "pnpm --ignore-scripts"),
+            // Output-verbosity flags (#179), forwarded via EngineGlobals.
+            (&["add", "foo", "--silent"], "pnpm --silent"),
+            (&["add", "foo", "-s"], "pnpm -s (silent short)"),
+            (
+                &["add", "foo", "--reporter=silent"],
+                "pnpm --reporter silent",
+            ),
+            (
+                &["add", "foo", "--loglevel=warn"],
+                "pnpm --loglevel <level>",
+            ),
         ],
     );
 }

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -143,6 +143,54 @@ fn install_truly_fresh_project_claims_nub_identity() {
     );
 }
 
+/// `--silent` (and its spellings) quiet the install: nothing on stderr but a
+/// fatal error, matching `pnpm install --silent` (#179). The default install,
+/// by contrast, prints the dependency summary + the `✓ installed` line. We
+/// assert the silent contract (empty stderr, success, deps actually linked) and
+/// that the default is NOT empty — so a regression that silences the default,
+/// or one that fails to silence `--silent`, both fail.
+#[test]
+#[ignore = "network: resolves + fetches is-positive@3.1.0 from the npm registry"]
+fn install_silent_flag_suppresses_all_nonerror_output() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let manifest = r#"{"name":"q","version":"1.0.0","dependencies":{"is-positive":"3.1.0"}}"#;
+
+    // Baseline: the default install writes a human summary to stderr.
+    let base = pm_tmpdir("silent-base");
+    std::fs::write(base.join("package.json"), manifest).unwrap();
+    let (_, default_stderr, default_code) = run_install(&base, &["install"]);
+    assert_eq!(default_code, 0, "default install failed: {default_stderr}");
+    assert!(
+        !default_stderr.trim().is_empty(),
+        "the default install should print a summary on stderr (guards against \
+         over-silencing): got empty output"
+    );
+
+    // Every silent spelling produces empty stderr while still linking the dep.
+    for form in [
+        &["install", "--silent"][..],
+        &["install", "-s"][..],
+        &["install", "--reporter=silent"][..],
+        &["install", "--loglevel=silent"][..],
+    ] {
+        let dir = pm_tmpdir(&format!("silent-{}", form.join("-").replace('=', "")));
+        std::fs::write(dir.join("package.json"), manifest).unwrap();
+        let (stdout, stderr, code) = run_install(&dir, form);
+        assert_eq!(code, 0, "nub {form:?} failed: {stdout}\n{stderr}");
+        assert!(
+            stderr.is_empty(),
+            "nub {form:?} must write nothing to stderr, got: {stderr:?}"
+        );
+        assert!(
+            dir.join("node_modules/is-positive/package.json").is_file(),
+            "nub {form:?} still installs the dependency"
+        );
+    }
+}
+
 /// A `pnpm-workspace.yaml` with no lockfile is a genuine pnpm signal, NOT a
 /// truly-fresh project: nub stays pnpm-shaped — writes `pnpm-lock.yaml` and
 /// does NOT stamp the manifest.

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -253,7 +253,12 @@ The accepted flags are pnpm's spellings:
 --node-linker
 --registry
 --dir, -C             # pnpm's spelling, not npm's --prefix
+--reporter <name>     # default, append-only, silent
+--silent, -s          # alias for --reporter=silent
+--loglevel <level>    # debug, info, warn, error, silent
 ```
+
+To quiet the progress output, pass `--silent` (or `-s`, or `--reporter=silent`): nothing reaches stderr but a fatal error, matching `pnpm install --silent`. The `--reporter=append-only` form drops the live progress display while keeping the dependency summary, and `--loglevel error` hides warnings without touching the rest. These spellings apply to every install-family command — `install`, `ci`, `add`, `remove`, `update`, `dedupe`, `import`.
 
 In a workspace, `install` and `ci` accept the same selector flags as script running — install only the packages a filter matches:
 

--- a/vendor/aube/crates/aube/src/lib.rs
+++ b/vendor/aube/crates/aube/src/lib.rs
@@ -267,7 +267,14 @@ impl SilentStderrGuard {
             if saved < 0 {
                 return None;
             }
-            let devnull = libc::open(c"/dev/null".as_ptr(), libc::O_WRONLY);
+            // The null device is `/dev/null` on Unix, `NUL` on Windows — open
+            // the right one so `--silent` actually redirects fd 2 on both (a
+            // hardcoded `/dev/null` silently no-ops the redirect on Windows).
+            #[cfg(windows)]
+            let devnull_path = c"NUL";
+            #[cfg(not(windows))]
+            let devnull_path = c"/dev/null";
+            let devnull = libc::open(devnull_path.as_ptr(), libc::O_WRONLY);
             if devnull < 0 {
                 libc::close(saved);
                 return None;
@@ -290,6 +297,36 @@ impl Drop for SilentStderrGuard {
             libc::close(self.saved);
         }
     }
+}
+
+/// Guard returned by [`silence_own_output`]; restores stderr on drop.
+pub struct OwnOutputSilencer {
+    // Held for its `Drop` (restores fd 2). `None` when the redirect could
+    // not be installed (non-Unix, or `/dev/null` unavailable) — the global
+    // output flag still suppresses the install summary in that case.
+    _stderr: Option<SilentStderrGuard>,
+}
+
+/// Embedder entry point that mirrors `--silent` / `--reporter=silent` for a
+/// host (e.g. nub) that dispatches the command impls directly and never runs
+/// aube's own `async_main`. It sets the process-global silent output flag
+/// (so the install summary and other [`global_output_flags`]-gated output is
+/// skipped) and, on Unix, redirects fd 2 to `/dev/null` until the returned
+/// guard drops — the saved fd is registered with `aube-scripts` so child
+/// lifecycle scripts keep writing to the real terminal, matching the standalone
+/// `--silent` path. Hold the guard across the command run and drop it before
+/// emitting a final error report so the error still reaches stderr.
+#[must_use]
+pub fn silence_own_output() -> OwnOutputSilencer {
+    commands::set_global_output_flags(commands::GlobalOutputFlags {
+        ndjson: false,
+        silent: true,
+    });
+    let stderr = SilentStderrGuard::install();
+    if let Some(ref guard) = stderr {
+        aube_scripts::set_saved_stderr_fd(guard.saved);
+    }
+    OwnOutputSilencer { _stderr: stderr }
 }
 
 // Commands are listed in alphabetical order; validated by


### PR DESCRIPTION
Closes #179

Adds pnpm's output flags to the install family (install/ci/add/remove/update/import/dedupe), mapped to the engine's text-mode renderers:

- `--silent` / `-s` / `--reporter=silent` / `--loglevel=silent` → nothing on stderr but a fatal error (matches `pnpm install --silent`).
- `--reporter=append-only` → plain output, no progress object.
- `--loglevel <error|warn|info|debug>` → retune verbosity. Default unchanged.

The silencer drops before the error path, so `--silent` still prints errors. `--reporter=ndjson` not accepted (separate feature). Additive, default-preserving aube change. Grammar + network tests; docs updated.