### PR TITLE
build(nix): from-source flake with embed-runtime (drop prebuilt tarball)

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,9 +1,14 @@
 name: Nix flake
 
-# Validates the prebuilt-binary flake (flake.nix) that lets Nix users install via
-# `nix run github:nubjs/nub`. There is no Nix on the dev host, so THIS job is the
-# flake's only validation: it evaluates every system's outputs, builds the package
-# for the runner's own system (fetchurl + autoPatchelf), and smoke-runs the binary.
+# Validates the from-source flake (flake.nix) that lets Nix users install via
+# `nix run github:nubjs/nub`. nub now ships as a single self-contained binary
+# (the runtime/ tree is embedded via the `embed-runtime` cargo feature and
+# JIT-extracted on first run), so the flake builds nub FROM SOURCE — it builds the
+# N-API addon, stages the vendored runtime node_modules, and cargo-builds the
+# binary with the runtime embedded; there is no prebuilt tarball and no sidecar to
+# patch. There is no Nix on the dev host, so THIS job is the flake's only
+# validation: it evaluates every system's outputs, builds the package for the
+# runner's own system, and cold-runs a TypeScript fixture end to end.
 #
 # Path-filtered to the flake files so it fires only when they change — not on every
 # Rust or docs commit.
@@ -32,26 +37,43 @@ jobs:
   check:
     name: nix flake check
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # A cold from-source build of the whole nub + vendored-aube workspace under Nix
+    # (no Swatinem cache) is far heavier than the old fetchurl repackage.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
+      # Real Node on PATH so the cold TS run below exercises the embedded-runtime
+      # extraction deterministically instead of provisioning a Node first.
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "24"
+
       # Evaluate every system's outputs (the locked flake must evaluate for all
       # four targets, including the Darwin ones that cannot build on this runner).
       - name: nix flake check
         run: nix flake check --all-systems --print-build-logs
 
-      # Build the package for x86_64-linux: fetchurl the release tarball, run
-      # autoPatchelfHook against the glibc binary + nub-native.node, lay out the
-      # bin/ + runtime/ tree. Proves the install layout actually realizes.
+      # Build the package for x86_64-linux from source: build the N-API addon,
+      # stage the vendored runtime node_modules, cargo-build nub with the runtime
+      # embedded. Proves the from-source single binary actually realizes.
       - name: nix build .#default
         run: nix build .#default --print-build-logs
 
-      # Smoke the patched binary end to end: `nix run` execs $out/bin/nub, which
-      # canonicalizes current_exe() and resolves the runtime/ sibling. A clean
-      # version print proves the layout + autoPatchelf produced a runnable nub.
       - name: nix run .#default -- --version
         run: nix run .#default -- --version
+
+      # End-to-end: a cold `nix run` must extract the embedded runtime to a fresh
+      # cache and transpile+run a TypeScript fixture. Run under an empty HOME so the
+      # extraction path is exercised from scratch, and a wrong/incomplete embedded
+      # runtime fails here rather than silently shipping.
+      - name: nix run — cold TS extract + transpile + run
+        run: |
+          printf 'const greet = (who: string): string => `hello, ${who}`;\nconsole.log(greet("nix"));\n' > /tmp/smoke.ts
+          export HOME="$(mktemp -d)"
+          out="$(nix run .#default -- /tmp/smoke.ts)"
+          echo "got: $out"
+          test "$out" = "hello, nix"

--- a/flake.nix
+++ b/flake.nix
@@ -6,93 +6,202 @@
   outputs =
     { self, nixpkgs }:
     let
-      version = "0.2.2";
+      # Track the workspace version automatically — the binary's own version comes
+      # from Cargo.toml (CARGO_PKG_VERSION) at build time, so this attr is only
+      # package metadata; read it from the same source to avoid a manual sync point.
+      version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
 
-      # Per-system prebuilt release tarball + its sha256, verified against the
-      # GitHub release assets for v${version}. nub ships prebuilt per-platform
-      # tarballs on every channel (curl installer, Homebrew, npm); this flake lays
-      # one out rather than building from source. WHY prebuilt, not buildRustPackage:
-      # a from-source cargo build omits the vendored runtime/ tree (preload +
-      # node_modules + the nub-native.node N-API addon) that nub resolves beside its
-      # binary at run time — a bare cargo binary passes `--version` but fails real
-      # TypeScript workloads. The prebuilt tarball already carries that layout.
-      assets = {
-        "x86_64-linux" = {
-          file = "nub-linux-x64.tar.gz";
-          sha256 = "6cc63a89f25f12719bce9afc97e513cc8ee22ef203e4a72a3c7398e62b413a23";
-        };
-        "aarch64-linux" = {
-          file = "nub-linux-arm64.tar.gz";
-          sha256 = "b9a292a725a959809fd629e7b3d8d6d886480300b8451bb41f8fb4a5098107ec";
-        };
-        "x86_64-darwin" = {
-          file = "nub-darwin-x64.tar.gz";
-          sha256 = "39c0f5200be3688e776c51ee2978e3cfe50fdb50946261a52ca42f6481145d75";
-        };
-        "aarch64-darwin" = {
-          file = "nub-darwin-arm64.tar.gz";
-          sha256 = "1c561d820145e9eb7640f6f97c0fe2f2d8b8d4a4d64b19f78fccf8f9dd79ac46";
-        };
-      };
-
-      systems = builtins.attrNames assets;
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
 
       nubFor =
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          asset = assets.${system};
+          inherit (pkgs) lib rustPlatform;
+
+          # ── Embedded-runtime node_modules ──────────────────────────────────
+          # The single-binary build embeds the `runtime/` tree (preload + native
+          # addon + a small vendored node_modules) INTO the binary; build.rs
+          # tars+zstd-compresses it and `include_bytes!`s the blob, JIT-extracting
+          # it on first run. So the Nix sandbox must assemble the same `runtime/`
+          # tree BEFORE the cargo build — including these pure-JS runtime deps that
+          # the EMITTED transpile output / web-API polyfills require (oxc itself is
+          # compiled into the addon, not vendored here). Versions + integrity are
+          # pinned to the workspace pnpm-lock.yaml (the sha512 SRI is the lockfile's
+          # own `integrity` field, accepted verbatim by fetchurl), so a shipped
+          # nub's transpile output is byte-identical to dev's. `jsbi` is the one
+          # transitive dep (of @js-temporal/polyfill).
+          npmTarball =
+            {
+              name,
+              file,
+              hash,
+            }:
+            pkgs.fetchurl {
+              url = "https://registry.npmjs.org/${name}/-/${file}";
+              inherit hash;
+            };
+
+          runtimeDeps = [
+            {
+              dest = "@js-temporal/polyfill";
+              src = npmTarball {
+                name = "@js-temporal/polyfill";
+                file = "polyfill-0.5.1.tgz";
+                hash = "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==";
+              };
+            }
+            {
+              dest = "@oxc-project/runtime";
+              src = npmTarball {
+                name = "@oxc-project/runtime";
+                file = "runtime-0.132.0.tgz";
+                hash = "sha512-Y8if5Ci7/WP163yuVBxG98zxB0dK3QKiO9vKHXVP05MNHYFdoqMx5bhl8x69SNOaFM+hV0uadGHJmZ+zU3oILQ==";
+              };
+            }
+            {
+              dest = "@petamoriken/float16";
+              src = npmTarball {
+                name = "@petamoriken/float16";
+                file = "float16-3.9.3.tgz";
+                hash = "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==";
+              };
+            }
+            {
+              dest = "urlpattern-polyfill";
+              src = npmTarball {
+                name = "urlpattern-polyfill";
+                file = "urlpattern-polyfill-10.1.0.tgz";
+                hash = "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==";
+              };
+            }
+            {
+              dest = "jsbi";
+              src = npmTarball {
+                name = "jsbi";
+                file = "jsbi-4.3.2.tgz";
+                hash = "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==";
+              };
+            }
+          ];
+
+          # Lay the fetched tarballs out as a real `node_modules/` tree (each npm
+          # tarball expands to `package/`; --strip-components=1 drops that wrapper).
+          # Real file copies, not symlinks, so the tar embedded into the binary is
+          # fully self-contained — no /nix/store symlinks survive into ~/.cache/nub.
+          runtimeNodeModules = pkgs.runCommand "nub-runtime-node-modules-${version}" { } (
+            ''
+              mkdir -p "$out"
+            ''
+            + lib.concatMapStringsSep "\n" (dep: ''
+              mkdir -p "$out/${dep.dest}"
+              tar -xzf "${dep.src}" --strip-components=1 -C "$out/${dep.dest}"
+            '') runtimeDeps
+          );
+
+          # ── Native N-API addon (separate cargo workspace) ──────────────────
+          # crates/nub-native is its OWN cargo workspace (it keeps panic=unwind for
+          # the cdylib while the `nub` workspace uses panic=abort) with its OWN
+          # Cargo.lock, so it is NOT built by the main `nub` build and needs its own
+          # derivation. It cross-depends on crates/nub-cache-key by path, so it must
+          # build from the full source tree (src = self), not an isolated copy. The
+          # output is the `.node` the embedded runtime resolves as
+          # `addons/nub-native.node`.
+          nubNativeAddon = rustPlatform.buildRustPackage {
+            pname = "nub-native";
+            inherit version;
+            src = self;
+            buildAndTestSubdir = "crates/nub-native";
+            cargoLock.lockFile = ./crates/nub-native/Cargo.lock;
+            doCheck = false;
+
+            # Install the cdylib as the addon. The crate routes output into the
+            # repo-root target/ via its .cargo/config.toml, and nixpkgs may build
+            # under a target triple, so locate it by name rather than a fixed path.
+            installPhase = ''
+              runHook preInstall
+              mkdir -p "$out/lib"
+              addon=$(find . -type f \
+                \( -name 'libnub_native.so' -o -name 'libnub_native.dylib' \) \
+                -path '*/release/*' | head -1)
+              if [ -z "$addon" ]; then
+                echo "nub-native: built addon dylib not found under target/*/release" >&2
+                exit 1
+              fi
+              cp "$addon" "$out/lib/nub-native.node"
+              runHook postInstall
+            '';
+
+            meta.description = "nub N-API transpiler addon (embedded into the nub binary)";
+          };
+
+          # ── The nub binary (root workspace, single self-contained build) ───
+          nub = rustPlatform.buildRustPackage {
+            pname = "nub";
+            inherit version;
+            src = self;
+
+            cargoLock.lockFile = ./Cargo.lock;
+            buildAndTestSubdir = "crates/nub-cli";
+
+            # Single self-contained binary: embed the staged runtime/ tree. nub-core's
+            # build.rs (gated on this feature) tars+zstd-19s `<repo>/runtime` and
+            # `include_bytes!`s it; ruzstd decodes at runtime, extracting once to
+            # ~/.cache/nub. This is the whole reason the flake can now build FROM
+            # SOURCE: a feature-off cargo build produces a binary that walks to a
+            # runtime/ SIDECAR (absent here), which is why the flake formerly shipped
+            # a prebuilt tarball. The embedded runtime dissolves that — no sidecar.
+            buildFeatures = [ "embed-runtime" ];
+
+            # Tests aren't part of the package build (they need Node + a network
+            # registry); the upstream CI matrix owns them.
+            doCheck = false;
+
+            # Stage runtime/ BEFORE the build so build.rs embeds a COMPLETE tree.
+            # The tracked runtime/*.{mjs,cjs} ship in the source; add the per-platform
+            # addon + the vendored node_modules. build.rs panics on a missing
+            # preload.mjs and embeds whatever is staged, so this must run before
+            # configure/build.
+            postPatch = ''
+              chmod -R u+w runtime
+              mkdir -p runtime/addons
+              cp "${nubNativeAddon}/lib/nub-native.node" runtime/addons/nub-native.node
+              cp -rL "${runtimeNodeModules}" runtime/node_modules
+              chmod -R u+w runtime
+            '';
+
+            # nub dispatches its nub/nubx personality from the argv[0] basename
+            # (cli.rs Argv0::detect → file_stem), NOT from a canonicalized
+            # current_exe(), so a symlink invoked as `nubx` enters nubx mode — no
+            # need for a second real binary copy.
+            postInstall = ''
+              ln -s nub "$out/bin/nubx"
+            '';
+
+            # The Node N-API addon is embedded as opaque bytes, so Nix can't see its
+            # store references — but it links the SAME nixpkgs glibc/libgcc as this
+            # binary, which IS in this package's closure (referenced by the binary's
+            # own interpreter/rpath), so the libs the runtime-extracted addon needs
+            # at dlopen stay live. nub provisions/locates Node itself at run time, so
+            # no Node runtime dependency is declared.
+
+            meta = with lib; {
+              description = "Fast TypeScript-first runtime and pnpm-compatible package manager for Node";
+              homepage = "https://nubjs.com";
+              downloadPage = "https://github.com/nubjs/nub/releases";
+              license = licenses.mit;
+              mainProgram = "nub";
+              platforms = systems;
+            };
+          };
         in
-        pkgs.stdenv.mkDerivation {
-          pname = "nub";
-          inherit version;
-
-          src = pkgs.fetchurl {
-            url = "https://github.com/nubjs/nub/releases/download/v${version}/${asset.file}";
-            sha256 = asset.sha256;
-          };
-
-          # The tarball expands to bin/ + runtime/ at the top level (no wrapping dir).
-          sourceRoot = ".";
-
-          # The prebuilt Linux binary and nub-native.node link glibc (libc, libm,
-          # libgcc_s) and hard-code a /lib64 interpreter — autoPatchelfHook rewrites
-          # both for the Nix store. Darwin mach-o binaries need no patching.
-          nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
-          buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
-
-          dontConfigure = true;
-          dontBuild = true;
-
-          # Lay bin/nub (+ bin/nubx) and the runtime/ sibling out exactly as the
-          # tarball ships them. nub canonicalizes current_exe() and walks UP from the
-          # binary's directory to find runtime/preload.mjs, so the binary MUST be a
-          # real file with runtime/ as a real sibling — no makeWrapper, no symlinked
-          # entrypoint, which would canonicalize to a different directory and lose the
-          # runtime/ tree.
-          installPhase = ''
-            runHook preInstall
-            mkdir -p "$out"
-            cp -r bin "$out/bin"
-            cp -r runtime "$out/runtime"
-            chmod +x "$out/bin/nub" "$out/bin/nubx"
-            runHook postInstall
-          '';
-
-          # nub provisions and locates Node itself at run time (from PATH or its own
-          # cache), so the package declares no Node runtime dependency here.
-
-          meta = with pkgs.lib; {
-            description = "Fast TypeScript-first runtime and pnpm-compatible package manager for Node";
-            homepage = "https://nubjs.com";
-            downloadPage = "https://github.com/nubjs/nub/releases";
-            license = licenses.mit;
-            mainProgram = "nub";
-            platforms = systems;
-            sourceProvenance = [ sourceTypes.binaryNativeCode ];
-          };
-        };
+        nub;
     in
     {
       packages = forAllSystems (

--- a/flake.nix
+++ b/flake.nix
@@ -117,17 +117,28 @@
             pname = "nub-native";
             inherit version;
             src = self;
-            buildAndTestSubdir = "crates/nub-native";
+            # crates/nub-native is a SELF-CONTAINED cargo workspace in a subdir (its
+            # own Cargo.toml + Cargo.lock), so it needs `cargoRoot` — NOT
+            # `buildAndTestSubdir`. buildAndTestSubdir keeps the cargo root at the
+            # source top, which makes the lock-consistency hook validate the ROOT
+            # workspace's Cargo.lock against the addon's vendor dir (built from the
+            # addon's lock) and fail. cargoRoot points the vendoring, the
+            # consistency check, and the build cwd at crates/nub-native, where the
+            # matching Cargo.lock lives. The cross-workspace `../nub-cache-key` path
+            # dep still resolves — src = self carries the whole tree.
+            cargoRoot = "crates/nub-native";
             cargoLock.lockFile = ./crates/nub-native/Cargo.lock;
             doCheck = false;
 
-            # Install the cdylib as the addon. The crate routes output into the
-            # repo-root target/ via its .cargo/config.toml, and nixpkgs may build
-            # under a target triple, so locate it by name rather than a fixed path.
+            # Install the cdylib as the addon. The crate's .cargo/config.toml routes
+            # output into the repo-root target/, and nixpkgs builds under a target
+            # triple, so search the whole build tree (cwd is crates/nub-native, but
+            # the artifact lands at <source>/target/<triple>/release/) by exact name
+            # — which skips the hash-suffixed deps/ copy.
             installPhase = ''
               runHook preInstall
               mkdir -p "$out/lib"
-              addon=$(find . -type f \
+              addon=$(find "$NIX_BUILD_TOP" -type f \
                 \( -name 'libnub_native.so' -o -name 'libnub_native.dylib' \) \
                 -path '*/release/*' | head -1)
               if [ -z "$addon" ]; then

--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,16 @@
             cargoLock.lockFile = ./Cargo.lock;
             buildAndTestSubdir = "crates/nub-cli";
 
+            # The hermetic Nix sandbox ships no system tools, so the C-building
+            # crates in nub's graph need their build tools declared explicitly:
+            # aws-lc-sys (via aube → sigstore) and libz-ng-sys (via flate2's
+            # zlib-ng feature) both compile through cmake. Every existing CI runner
+            # ships cmake preinstalled, which is why this surfaces only under Nix.
+            nativeBuildInputs = [
+              pkgs.cmake
+              pkgs.perl
+            ];
+
             # Single self-contained binary: embed the staged runtime/ tree. nub-core's
             # build.rs (gated on this feature) tars+zstd-19s `<repo>/runtime` and
             # `include_bytes!`s it; ruzstd decodes at runtime, extracting once to

--- a/flake.nix
+++ b/flake.nix
@@ -118,15 +118,19 @@
             inherit version;
             src = self;
             # crates/nub-native is a SELF-CONTAINED cargo workspace in a subdir (its
-            # own Cargo.toml + Cargo.lock), so it needs `cargoRoot` — NOT
-            # `buildAndTestSubdir`. buildAndTestSubdir keeps the cargo root at the
-            # source top, which makes the lock-consistency hook validate the ROOT
-            # workspace's Cargo.lock against the addon's vendor dir (built from the
-            # addon's lock) and fail. cargoRoot points the vendoring, the
-            # consistency check, and the build cwd at crates/nub-native, where the
-            # matching Cargo.lock lives. The cross-workspace `../nub-cache-key` path
-            # dep still resolves — src = self carries the whole tree.
+            # own Cargo.toml + Cargo.lock) living inside the larger repo, so it needs
+            # BOTH knobs, honored by different hooks:
+            #   - `cargoRoot` points the vendoring + the lock-consistency check at
+            #     crates/nub-native/Cargo.lock (without it, the check validates the
+            #     ROOT workspace lock against the addon's vendor dir and fails).
+            #   - `buildAndTestSubdir` cds the BUILD into crates/nub-native so cargo
+            #     resolves the nub-native workspace. Without it the build runs at the
+            #     source root and resolves the ROOT workspace (nub-cli) against the
+            #     addon vendor dir — which lacks nub-cli-only crates like anyhow.
+            # The cross-workspace `../nub-cache-key` path dep resolves either way —
+            # src = self carries the whole tree.
             cargoRoot = "crates/nub-native";
+            buildAndTestSubdir = "crates/nub-native";
             cargoLock.lockFile = ./crates/nub-native/Cargo.lock;
             doCheck = false;
 


### PR DESCRIPTION
#175 embeds the `runtime/` tree into the binary (JIT-extracted on first run), so a from-source build is self-contained — the flake no longer needs the prebuilt tarball.

`flake.nix` builds from source: a derivation builds the N-API addon (`crates/nub-native`), a `runCommand` lays out the runtime `node_modules` (4 deps + transitive `jsbi`, versions/SRI pinned to `pnpm-lock.yaml`), and `buildRustPackage` stages both into `runtime/` before building `nub-cli --features embed-runtime`. `nubx` is a symlink; `version` reads from `Cargo.toml`. `nix.yml` gains a cold-run `.ts` smoke.

No Nix on the dev host: verified by this PR's Nix CI.

Refs #175