### PR TITLE
fix(install): silence the unactionable GVS-incompatible auto-fallback notice

### DIFF
--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -135,6 +135,13 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     warm_store_verify: false,
     no_churn_lockfile_write: true,
     read_branded_settings_env: false,
+    // The GVS-incompatible auto-fallback notice (e.g. Next.js drops the install
+    // to per-project) is unactionable by the user — the only fix is upstream in
+    // the package — so nub demotes it from a default-shown warning to a
+    // `debug`-level detail: silent under `nub i`, reachable with
+    // `--loglevel debug` / `RUST_LOG`. The per-project fallback behavior itself
+    // is unchanged; only the notice is silenced.
+    gvs_incompatible_warning: false,
     primer_ttl: None,
     // Cap aube's CPU-bound pools (linker rayon pool, tokio worker seed) to the
     // real cgroup CFS-CPU-quota budget on a constrained box; `None` on an
@@ -175,5 +182,6 @@ const _: () = {
     assert!(!NUB.self_update_enabled);
     assert!(NUB.no_churn_lockfile_write);
     assert!(!NUB.read_branded_settings_env);
+    assert!(!NUB.gvs_incompatible_warning);
     assert!(NUB.primer_ttl.is_none());
 };

--- a/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -34,6 +34,7 @@ static MYTOOL: Embedder = Embedder {
     warm_store_verify: true,
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
+    gvs_incompatible_warning: true,
     primer_ttl: None,
     cpu_budget: None,
 };

--- a/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
@@ -40,6 +40,7 @@ static MYTOOL: Embedder = Embedder {
     warm_store_verify: true,
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
+    gvs_incompatible_warning: true,
     primer_ttl: None,
     cpu_budget: None,
 };

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -44,6 +44,7 @@ static NO_CHURN_TOOL: Embedder = Embedder {
     warm_store_verify: true,
     no_churn_lockfile_write: true,
     read_branded_settings_env: true,
+    gvs_incompatible_warning: true,
     primer_ttl: None,
     cpu_budget: None,
 };

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -40,6 +40,7 @@ static ROOT_TOOL: Embedder = Embedder {
     warm_store_verify: true,
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
+    gvs_incompatible_warning: true,
     primer_ttl: None,
     cpu_budget: None,
 };

--- a/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
@@ -36,6 +36,7 @@ static MYTOOL: Embedder = Embedder {
     warm_store_verify: true,
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
+    gvs_incompatible_warning: true,
     primer_ttl: None,
     cpu_budget: None,
 };

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -31,6 +31,7 @@ static ROOT_TOOL: Embedder = Embedder {
     warm_store_verify: true,
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
+    gvs_incompatible_warning: true,
     primer_ttl: None,
     cpu_budget: None,
 };

--- a/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
@@ -30,6 +30,7 @@ static MYTOOL: Embedder = Embedder {
     warm_store_verify: true,
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
+    gvs_incompatible_warning: true,
     primer_ttl: None,
     cpu_budget: None,
 };

--- a/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
+++ b/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
@@ -44,6 +44,7 @@ static MYTOOL_NO_BRANDED_ENV: Embedder = Embedder {
     self_update_enabled: true,
     warm_store_verify: true,
     read_branded_settings_env: false,
+    gvs_incompatible_warning: true,
     no_churn_lockfile_write: false,
     primer_ttl: None,
     cpu_budget: None,

--- a/vendor/aube/crates/aube-util/src/identity.rs
+++ b/vendor/aube/crates/aube-util/src/identity.rs
@@ -198,6 +198,17 @@ pub struct Embedder {
     ///
     /// [`read_branded_pnpm_config`]: crate::engine_context::EngineContext::read_branded_pnpm_config
     pub read_branded_settings_env: bool,
+    /// When `true` (aube's default), the global-virtual-store *incompatible
+    /// package* auto-fallback emits a user-facing `WARN_AUBE_GVS_INCOMPATIBLE`
+    /// warning: an incompatible dep (e.g. Next.js) was detected, so the install
+    /// silently dropped to per-project materialization instead of the shared
+    /// store. An embedder sets this `false` to demote that notice to
+    /// `debug`-level — it is unactionable by the end user (the only fix is an
+    /// upstream change in the offending package), so a host that owns its own
+    /// UX hides it at default verbosity while keeping it reachable when the
+    /// engine log level is raised to `debug`. Gates ONLY the notice's level;
+    /// the per-project fallback BEHAVIOR is identical either way. Embedder-fixed.
+    pub gvs_incompatible_warning: bool,
     /// How long after the bundled primer's build date (`generated_at`) the
     /// offline metadata primer is consulted at all. `None` = unlimited (the
     /// primer never expires); `Some(d)` = consult the primer only while
@@ -263,6 +274,7 @@ pub const AUBE: Embedder = Embedder {
     warm_store_verify: true,
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
+    gvs_incompatible_warning: true,
     primer_ttl: None,
     cpu_budget: None,
 };

--- a/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -39,6 +39,7 @@ static NUBLIKE: Embedder = Embedder {
     self_update_enabled: false,
     warm_store_verify: false,
     read_branded_settings_env: false,
+    gvs_incompatible_warning: true,
     no_churn_lockfile_write: true,
     primer_ttl: None,
     cpu_budget: None,

--- a/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -38,6 +38,7 @@ static NUBLIKE: Embedder = Embedder {
     self_update_enabled: false,
     warm_store_verify: false,
     read_branded_settings_env: false,
+    gvs_incompatible_warning: true,
     no_churn_lockfile_write: true,
     primer_ttl: None,
     cpu_budget: None,

--- a/vendor/aube/crates/aube/src/commands/install/gvs.rs
+++ b/vendor/aube/crates/aube/src/commands/install/gvs.rs
@@ -18,8 +18,15 @@ pub(super) fn resolve_global_virtual_store_override(
             && !ci_mode
             && !virtual_store_only_setting
         {
-            tracing::warn!(
-                code = aube_codes::warnings::WARN_AUBE_GVS_INCOMPATIBLE,
+            // The notice is unactionable by the end user (the only fix is an
+            // upstream change in `{name}`), so an embedder that owns its own UX
+            // (`gvs_incompatible_warning = false`) demotes it to `debug` —
+            // silent at default verbosity, reachable when the engine log level
+            // is raised. The per-project fallback (`Some(false)`) is identical
+            // regardless; only the notice's level differs. The level can't be a
+            // runtime value in `tracing::event!`, so the message is built once
+            // and the macro selected by branch.
+            let msg = format!(
                 "`{name}` isn't compatible with aube's global virtual store — \
                  installing per-project instead. Install still succeeds; repeat \
                  installs of this project just won't share materialized packages \
@@ -31,6 +38,12 @@ pub(super) fn resolve_global_virtual_store_override(
                  auto-detection entirely. \
                  Details: https://aube.jdx.dev/package-manager/global-virtual-store"
             );
+            let code = aube_codes::warnings::WARN_AUBE_GVS_INCOMPATIBLE;
+            if aube_util::embedder().gvs_incompatible_warning {
+                tracing::warn!(code, "{msg}");
+            } else {
+                tracing::debug!(code, "{msg}");
+            }
             Some(false)
         } else {
             None


### PR DESCRIPTION
On `nub i`, an incompatible dep (Next.js, Nuxt, Parcel, SvelteKit) forces per-project materialization and emitted a loud `WARN_NUB_GVS_INCOMPATIBLE` every run. The fix is upstream in the package, so it is unactionable; this silences it by default.

A new embedder-fixed `gvs_incompatible_warning` toggle defaults `true` (standalone aube unchanged); the nub profile sets it `false`, demoting the notice to `debug` — hidden under nub's `aube=warn` filter, reachable via `RUST_LOG=aube=debug`. Per-project fallback behavior is unchanged; only the log level differs.

https://claude.ai/code/session_01DnwgDLy5Tay9vsL544STPe