### PR TITLE
chore(nix): bump flake to v0.2.3

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   outputs =
     { self, nixpkgs }:
     let
-      version = "0.2.2";
+      version = "0.2.3";
 
       # Per-system prebuilt release tarball + its sha256, verified against the
       # GitHub release assets for v${version}. nub ships prebuilt per-platform
@@ -19,19 +19,19 @@
       assets = {
         "x86_64-linux" = {
           file = "nub-linux-x64.tar.gz";
-          sha256 = "6cc63a89f25f12719bce9afc97e513cc8ee22ef203e4a72a3c7398e62b413a23";
+          sha256 = "40f5148ec41988a23bf6d22ed6673a9c0ab69c084eaedaa241ac36a597f883db";
         };
         "aarch64-linux" = {
           file = "nub-linux-arm64.tar.gz";
-          sha256 = "b9a292a725a959809fd629e7b3d8d6d886480300b8451bb41f8fb4a5098107ec";
+          sha256 = "9441cc730cb0fdf5acc0762b296f997f2590e0ed1a71ca3ca96a92a34a7a8552";
         };
         "x86_64-darwin" = {
           file = "nub-darwin-x64.tar.gz";
-          sha256 = "39c0f5200be3688e776c51ee2978e3cfe50fdb50946261a52ca42f6481145d75";
+          sha256 = "6f8fa5b1acc5aa047d1447d1e93d05d46acd4146ca332a2489252db5293b300d";
         };
         "aarch64-darwin" = {
           file = "nub-darwin-arm64.tar.gz";
-          sha256 = "1c561d820145e9eb7640f6f97c0fe2f2d8b8d4a4d64b19f78fccf8f9dd79ac46";
+          sha256 = "b550e25cd119db95c9d56fb14cec972956e1d835cea15228c8625cd13cd77f94";
         };
       };
 


### PR DESCRIPTION
## Summary
- Bumps the Nix flake package from nub v0.2.2 to v0.2.3.
- Updates the four Linux/Darwin release tarball hashes from the published v0.2.3 sidecars.

## Test plan
- [x] `nix flake check --all-systems --print-build-logs`
- [x] `nix build .#default --print-build-logs`
- [x] `nix run .#default -- --version`