### PR TITLE
Harden self-provisioning to aube-parity security (5 #172-class findings)

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -6042,8 +6042,12 @@ fn resolve_provision_declare(
     // same file to the provisioner instead of letting it re-download. (`dist` was
     // resolved against the project's authed/mirror registry config above — the
     // contract `provision_pm_from_tarball` requires.)
-    let fetched = fetch_verify_and_hash_tarball(name, &dist, cfg.auth.as_ref())
-        .map_err(|e| humanize_transport_error(e, &cfg.base))?;
+    // Host-match the registry auth to the resolved tarball before downloading it:
+    // a (malicious/MITM) packument's `dist.tarball` can name a foreign host, and
+    // the registry `_authToken` must never leave the registry's own origin (N1b).
+    let fetched =
+        fetch_verify_and_hash_tarball(name, &dist, registry::auth_for_tarball(&cfg, &dist.tarball))
+            .map_err(|e| humanize_transport_error(e, &cfg.base))?;
     let hex = &fetched.hex;
 
     if let Some(pm) = pm {

--- a/crates/nub-core/src/pm/extract.rs
+++ b/crates/nub-core/src/pm/extract.rs
@@ -1,27 +1,79 @@
 //! PM tarball extraction. npm publishes `.tgz` (gzip + tar) with everything under
 //! a single `package/` dir — the same single-top-dir shape as a Node dist archive,
-//! so this reuses the shared [`single_top_dir`] guard (which also keeps the `tar`
-//! crate's path-traversal protection in one place).
+//! so this reuses the shared [`single_top_dir`] guard.
+//!
+//! This extractor handles ONLY package-manager tarballs (pnpm / npm / yarn), whose
+//! genuine publishes ship regular files and directories — never symlinks or
+//! hardlinks. So, unlike the Node-dist extractor (which must allow Node's
+//! intra-tree symlinks), this path REJECTS symlink/hardlink entries outright
+//! (F0b, CVE-2021-37701 class): the extracted tree is executed as the PM, and a
+//! symlink whose target escapes the package dir would otherwise become an
+//! exec-able file pointing anywhere on disk. It also caps the decompressed stream
+//! against a gzip bomb (N2) — mirroring the engine's own tarball importer.
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use flate2::read::GzDecoder;
 
-use crate::version_management::extract::single_top_dir;
+use crate::version_management::extract::{
+    CappedReader, MAX_ARCHIVE_DECOMPRESSED_BYTES, single_top_dir,
+};
 
 /// Decode a `.tgz` (gzip + tar) and unpack it under `dest_parent`, returning the
-/// single top-level directory it created (`package/` for an npm tarball). The
-/// `tar` crate guards against path-traversal (`..` / absolute entries) during
-/// `unpack`, and `single_top_dir` enforces the one-dir invariant.
+/// single top-level directory it created (`package/` for an npm tarball).
+///
+/// A manual entry walk (rather than `Archive::unpack`) so each entry's TYPE is
+/// vetted: symlink and hardlink entries are rejected (F0b — a PM tarball never
+/// ships them, and one would let extraction plant an exec-able link escaping the
+/// package dir). The gzip stream is wrapped in a [`CappedReader`] so a
+/// decompression bomb errors instead of exhausting disk (N2). `Entry::unpack_in`
+/// keeps the `tar` crate's `..`/absolute path-traversal guard (an escaping entry
+/// is skipped, not written) and preserves the bin's executable mode;
+/// `single_top_dir` enforces the one-dir invariant.
 pub fn extract_tgz(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
+    extract_tgz_capped(archive, dest_parent, MAX_ARCHIVE_DECOMPRESSED_BYTES)
+}
+
+/// [`extract_tgz`] with the decompression cap as an explicit parameter — the seam
+/// a bomb test uses to inject a tiny cap (the public entry uses the 1 GiB prod
+/// [`MAX_ARCHIVE_DECOMPRESSED_BYTES`], which the real-tarball provisioning e2e
+/// relies on).
+fn extract_tgz_capped(
+    archive: &Path,
+    dest_parent: &Path,
+    decompressed_cap: u64,
+) -> Result<PathBuf> {
     let file =
         std::fs::File::open(archive).with_context(|| format!("open {}", archive.display()))?;
-    let mut tar = tar::Archive::new(GzDecoder::new(file));
+    let capped = CappedReader::new(GzDecoder::new(file), decompressed_cap);
+    let mut tar = tar::Archive::new(capped);
     std::fs::create_dir_all(dest_parent)
         .with_context(|| format!("create {}", dest_parent.display()))?;
-    tar.unpack(dest_parent)
-        .with_context(|| format!("extracting {}", archive.display()))?;
+
+    for entry in tar
+        .entries()
+        .with_context(|| format!("reading {}", archive.display()))?
+    {
+        let mut entry = entry.with_context(|| format!("reading entry in {}", archive.display()))?;
+        let entry_type = entry.header().entry_type();
+        if matches!(entry_type, tar::EntryType::Symlink | tar::EntryType::Link) {
+            let name = entry
+                .path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "<unreadable>".to_string());
+            bail!(
+                "refusing {entry_type:?} entry {name:?} in package-manager tarball {} \
+                 (symlink/hardlink entries are not allowed — CVE-2021-37701 class)",
+                archive.display()
+            );
+        }
+        // `unpack_in` applies the path-traversal guard (an entry that resolves
+        // outside `dest_parent` returns Ok(false) and is skipped, never written).
+        entry
+            .unpack_in(dest_parent)
+            .with_context(|| format!("extracting {}", archive.display()))?;
+    }
     single_top_dir(dest_parent, archive)
 }
 
@@ -124,6 +176,90 @@ mod tests {
         assert!(
             !out.join("escaped.txt").exists(),
             "the escaping entry must not appear inside the extraction dir either"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// F0b: a PM tarball ships regular files only; a symlink entry (the
+    /// CVE-2021-37701 primitive) whose target escapes the package dir would land
+    /// an exec-able link pointing anywhere on disk, then be run as the PM bin.
+    /// Extraction must REFUSE the archive, not silently materialize the link.
+    #[test]
+    fn extract_tgz_rejects_a_symlink_entry() {
+        let dir = tmpdir();
+        let archive = dir.join("symlink.tgz");
+        {
+            let file = std::fs::File::create(&archive).unwrap();
+            let gz = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+            let mut builder = tar::Builder::new(gz);
+            // A legit package.json gives the archive its single top dir...
+            let manifest = br#"{"name":"x"}"#;
+            let mut h = tar::Header::new_gnu();
+            h.set_size(manifest.len() as u64);
+            h.set_mode(0o644);
+            h.set_cksum();
+            builder
+                .append_data(&mut h, "package/package.json", &manifest[..])
+                .unwrap();
+            // ...then a hostile symlink pointing outside the package dir.
+            let mut link = tar::Header::new_gnu();
+            link.set_entry_type(tar::EntryType::Symlink);
+            link.set_size(0);
+            link.set_mode(0o777);
+            link.set_cksum();
+            builder
+                .append_link(&mut link, "package/evil", "/etc/passwd")
+                .unwrap();
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        let out = dir.join("extracted");
+        let err = extract_tgz(&archive, &out).unwrap_err().to_string();
+        assert!(
+            err.contains("Symlink") && err.contains("CVE-2021-37701"),
+            "a symlink entry must be refused with a clear reason: {err}"
+        );
+        assert!(
+            !out.join("evil").exists(),
+            "the symlink must not be materialized"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// N2: a small-compressed / huge-decompressed `.tgz` whose sha512 (computed
+    /// over the COMPRESSED bytes) passes integrity, then extracts unbounded. The
+    /// `CappedReader` must error before the whole payload lands on disk. Drives
+    /// the `_capped` seam with a 1 MiB cap (the public entry uses the 1 GiB prod
+    /// cap, which the real-tarball provisioning e2e relies on).
+    #[test]
+    fn extract_tgz_rejects_a_decompression_bomb() {
+        let dir = tmpdir();
+        let archive = dir.join("bomb.tgz");
+        {
+            let file = std::fs::File::create(&archive).unwrap();
+            let gz = flate2::write::GzEncoder::new(file, flate2::Compression::best());
+            let mut builder = tar::Builder::new(gz);
+            let big = vec![0u8; 4 * 1024 * 1024]; // 4 MiB of zeros → compresses tiny
+            let mut h = tar::Header::new_gnu();
+            h.set_size(big.len() as u64);
+            h.set_mode(0o644);
+            h.set_cksum();
+            builder
+                .append_data(&mut h, "package/big.bin", &big[..])
+                .unwrap();
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        assert!(
+            std::fs::metadata(&archive).unwrap().len() < 64 * 1024,
+            "the compressed bomb must be tiny for this to be a real amplification"
+        );
+        let out = dir.join("extracted");
+        let err = format!(
+            "{:#}",
+            extract_tgz_capped(&archive, &out, 1 << 20).unwrap_err()
+        );
+        assert!(
+            err.to_lowercase().contains("cap") || err.to_lowercase().contains("decompress"),
+            "a decompression bomb must be refused by the cap: {err}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/nub-core/src/pm/extract.rs
+++ b/crates/nub-core/src/pm/extract.rs
@@ -17,7 +17,7 @@ use anyhow::{Context, Result, bail};
 use flate2::read::GzDecoder;
 
 use crate::version_management::extract::{
-    CappedReader, MAX_ARCHIVE_DECOMPRESSED_BYTES, single_top_dir,
+    CappedReader, MAX_ARCHIVE_DECOMPRESSED_BYTES, MAX_ARCHIVE_ENTRIES, single_top_dir,
 };
 
 /// Decode a `.tgz` (gzip + tar) and unpack it under `dest_parent`, returning the
@@ -30,19 +30,25 @@ use crate::version_management::extract::{
 /// decompression bomb errors instead of exhausting disk (N2). `Entry::unpack_in`
 /// keeps the `tar` crate's `..`/absolute path-traversal guard (an escaping entry
 /// is skipped, not written) and preserves the bin's executable mode;
-/// `single_top_dir` enforces the one-dir invariant.
+/// `single_top_dir` enforces the one-dir invariant. The entry COUNT is bounded
+/// too (N2 — the `tar` crate has no count guard), mirroring aube-store's caps.
 pub fn extract_tgz(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
-    extract_tgz_capped(archive, dest_parent, MAX_ARCHIVE_DECOMPRESSED_BYTES)
+    extract_tgz_capped(
+        archive,
+        dest_parent,
+        MAX_ARCHIVE_DECOMPRESSED_BYTES,
+        MAX_ARCHIVE_ENTRIES,
+    )
 }
 
-/// [`extract_tgz`] with the decompression cap as an explicit parameter — the seam
-/// a bomb test uses to inject a tiny cap (the public entry uses the 1 GiB prod
-/// [`MAX_ARCHIVE_DECOMPRESSED_BYTES`], which the real-tarball provisioning e2e
-/// relies on).
+/// [`extract_tgz`] with the decompression + entry-count caps as explicit
+/// parameters — the seam a bomb test uses to inject tiny caps (the public entry
+/// uses the prod constants, which the real-tarball provisioning e2e relies on).
 fn extract_tgz_capped(
     archive: &Path,
     dest_parent: &Path,
     decompressed_cap: u64,
+    max_entries: usize,
 ) -> Result<PathBuf> {
     let file =
         std::fs::File::open(archive).with_context(|| format!("open {}", archive.display()))?;
@@ -51,10 +57,18 @@ fn extract_tgz_capped(
     std::fs::create_dir_all(dest_parent)
         .with_context(|| format!("create {}", dest_parent.display()))?;
 
+    let mut count = 0usize;
     for entry in tar
         .entries()
         .with_context(|| format!("reading {}", archive.display()))?
     {
+        count += 1;
+        if count > max_entries {
+            bail!(
+                "{} exceeds the {max_entries}-entry archive cap",
+                archive.display()
+            );
+        }
         let mut entry = entry.with_context(|| format!("reading entry in {}", archive.display()))?;
         let entry_type = entry.header().entry_type();
         if matches!(entry_type, tar::EntryType::Symlink | tar::EntryType::Link) {
@@ -255,11 +269,38 @@ mod tests {
         let out = dir.join("extracted");
         let err = format!(
             "{:#}",
-            extract_tgz_capped(&archive, &out, 1 << 20).unwrap_err()
+            extract_tgz_capped(&archive, &out, 1 << 20, MAX_ARCHIVE_ENTRIES).unwrap_err()
         );
         assert!(
             err.to_lowercase().contains("cap") || err.to_lowercase().contains("decompress"),
             "a decompression bomb must be refused by the cap: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// N2 (entry-count): an archive of many tiny entries stays under the byte cap
+    /// but drives a `File::create` per entry. The entry-count cap must refuse it.
+    /// Drives the `_capped` seam with a 2-entry cap.
+    #[test]
+    fn extract_tgz_rejects_too_many_entries() {
+        let dir = tmpdir();
+        let archive = dir.join("manyentries.tgz");
+        write_tgz(
+            &archive,
+            &[
+                ("package/a", b"x"),
+                ("package/b", b"y"),
+                ("package/c", b"z"),
+            ],
+        );
+        let out = dir.join("extracted");
+        let err = format!(
+            "{:#}",
+            extract_tgz_capped(&archive, &out, 1 << 20, 2).unwrap_err()
+        );
+        assert!(
+            err.contains("entry archive cap"),
+            "an over-count archive must be refused: {err}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/nub-core/src/pm/provision.rs
+++ b/crates/nub-core/src/pm/provision.rs
@@ -158,7 +158,11 @@ pub fn provision_pm_announced(
         &pm_store,
         &final_dir,
         pin_hash,
-        cfg.auth.as_ref(),
+        // Host-match the registry auth to the tarball before attaching it: a
+        // packument's `dist.tarball` can name a foreign host, and the bearer
+        // token must never leave the registry's own origin (N1b). The packument
+        // fetch above already used the full `cfg.auth`.
+        registry::auth_for_tarball(&cfg, &dist.tarball),
         resolved_from,
         on_resolved.is_some(),
     )?;

--- a/crates/nub-core/src/pm/registry.rs
+++ b/crates/nub-core/src/pm/registry.rs
@@ -325,6 +325,30 @@ pub fn rewrite_tarball_origin(tarball: &str, registry_base: &str) -> String {
     format!("{reg_origin}{rest}")
 }
 
+/// The registry credential to present when DOWNLOADING `tarball_url` — `cfg.auth`,
+/// but ONLY when the tarball is served from the SAME `scheme://host[:port]` origin
+/// the credential belongs to. `dist.tarball` is an absolute URL the packument
+/// declares, so under a malicious / MITM'd registry it can name an ARBITRARY
+/// foreign host; attaching the registry bearer token (`_authToken`) to that
+/// request would disclose the credential in flight (N1b). The packument fetch is
+/// unaffected — it always targets `cfg.base` and keeps full auth; this gate is
+/// only for the tarball download. For a private mirror [`rewrite_tarball_origin`]
+/// has already pinned the tarball onto the registry's own origin, so this matches
+/// and auth is attached exactly as before; the public-registry tarball is on the
+/// registry host, so it matches too. The only request that loses auth is one to a
+/// host the credential was never issued for — the leak. Mirrors aube matching
+/// tarball auth to the tarball's own host.
+pub fn auth_for_tarball<'a>(cfg: &'a RegistryConfig, tarball_url: &str) -> Option<&'a Auth> {
+    let reg_origin = origin_of(&cfg.base)?;
+    let tar_origin = origin_of(tarball_url)?;
+    // scheme + host are ASCII-case-insensitive; the origin carries no path/query.
+    if reg_origin.eq_ignore_ascii_case(tar_origin) {
+        cfg.auth.as_ref()
+    } else {
+        None
+    }
+}
+
 /// The `scheme://host[:port]` origin of a URL — everything up to (not including)
 /// the first `/` after the `://`. Returns `None` for a URL with no `://`.
 fn origin_of(url: &str) -> Option<&str> {
@@ -398,9 +422,41 @@ pub(crate) fn normalize_range(spec: &str) -> String {
     spec.split_whitespace().collect::<Vec<_>>().join(", ")
 }
 
+/// Reject a registry-declared version string before it becomes a STORE PATH
+/// component (and a `.tmp-<version>-…` work-dir name) that nub then EXECUTES. The
+/// dist-tag branch of [`resolve_dist`] passes a raw, registry-controlled
+/// `dist-tags.<tag>` value straight into [`dist_from_meta`], and the runnable
+/// target is built `<store>/pm/<pm>/<version>/package/<bin>` via `Path::join`,
+/// which an absolute or `..`-laden version escapes (the F0c registry-exec
+/// boundary). Mirrors the engine's own guard `aube_store::validate_version`
+/// (nub-core has no aube dep, so the char-blocklist is restated here, the same
+/// way [`safe_bin_subpath`] mirrors aube's bin-path guard): reject path
+/// separators on any platform, NUL, control chars, and the `.`/`..` dir aliases.
+/// A normal semver — `9.5.0`, `11.0.0-rc.1` — passes untouched.
+fn validate_version(version: &str) -> bool {
+    if version.is_empty() || version.len() > 256 {
+        return false;
+    }
+    if version
+        .bytes()
+        .any(|b| b.is_ascii_control() || matches!(b, b'/' | b'\\' | b'\0'))
+    {
+        return false;
+    }
+    !matches!(version, "." | "..")
+}
+
 /// Build a [`VersionDist`] from one `versions[X.Y.Z]` entry. `version` is the
 /// resolved key (so callers print the concrete version, never the spec).
 fn dist_from_meta(version: &str, meta: &Value) -> Result<VersionDist> {
+    // The sole construction point of `VersionDist`, so the single chokepoint for
+    // the version string before it flows into a store path. The dist-tag branch
+    // feeds a raw registry value here; reject anything that could escape the join.
+    if !validate_version(version) {
+        bail!(
+            "registry returned an unsafe version string {version:?} — refusing to use it as a store path"
+        );
+    }
     let dist = meta
         .get("dist")
         .with_context(|| format!("version {version} has no \"dist\" object"))?;
@@ -827,6 +883,103 @@ mod tests {
         assert!(
             resolve_dist(&meta, "9.0.0").is_err(),
             "an escaping bin must fail resolution, never yield a runnable out-of-package target"
+        );
+    }
+
+    #[test]
+    fn validate_version_accepts_semver_and_rejects_path_escapes() {
+        // Legitimate version strings the resolver must keep accepting.
+        for ok in [
+            "9.5.0",
+            "11.0.0-rc.1",
+            "1.2.3+build.5",
+            "0.0.0-canary.20240101",
+        ] {
+            assert!(validate_version(ok), "{ok:?} is a legitimate version");
+        }
+        // Anything that could escape `<store>/pm/<pm>/<version>` when joined, or
+        // alias a directory, must be refused (F0c).
+        for bad in [
+            "../evil",
+            "..",
+            ".",
+            "a/b",
+            "a\\b",
+            "x\u{0}y",
+            "ctrl\u{7}x",
+            "",
+        ] {
+            assert!(
+                !validate_version(bad),
+                "{bad:?} must be rejected as a store-path component"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_dist_rejects_a_dist_tag_pointing_at_a_path_escaping_version() {
+        // F0c: a malicious / MITM registry points a dist-tag at a version KEY that
+        // carries `..`. The runnable PM target is `<store>/pm/<pm>/<version>/…`
+        // built with `Path::join`, so an escaping version would relocate the
+        // executed bin outside the store. The dist-tag branch is the one that
+        // passes a raw registry string straight to `dist_from_meta`; resolution
+        // must refuse it rather than hand back a traversal-bearing `VersionDist`.
+        let p: Value = serde_json::from_str(
+            r#"{
+                "name": "pnpm",
+                "dist-tags": { "latest": "../../../../tmp/evil" },
+                "versions": {
+                    "../../../../tmp/evil": {
+                        "name": "pnpm",
+                        "bin": { "pnpm": "bin/pnpm.cjs" },
+                        "dist": {
+                            "tarball": "https://registry.npmjs.org/pnpm/-/pnpm-evil.tgz",
+                            "integrity": "sha512-EVIL"
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        let err = resolve_dist(&p, "latest").unwrap_err().to_string();
+        assert!(
+            err.contains("unsafe version"),
+            "an escaping dist-tag version must be refused: {err}"
+        );
+    }
+
+    #[test]
+    fn auth_for_tarball_attaches_only_to_the_registry_origin() {
+        let auth = Auth::Bearer("secret-token".into());
+        let cfg = RegistryConfig {
+            base: "https://npm.corp.test/api/npm".into(),
+            auth: Some(auth.clone()),
+        };
+        // Same origin (the private-mirror case, post origin-rewrite) → auth rides.
+        assert_eq!(
+            auth_for_tarball(&cfg, "https://npm.corp.test/pnpm/-/pnpm-10.0.0.tgz"),
+            Some(&auth)
+        );
+        // A foreign-host tarball a malicious/MITM packument named must NOT receive
+        // the registry credential (N1b — the leak this guard closes).
+        assert_eq!(
+            auth_for_tarball(&cfg, "https://evil.test/pnpm/-/pnpm-10.0.0.tgz"),
+            None
+        );
+        // An https→http downgrade to the same host is a different origin → no auth
+        // (belt-and-suspenders with the redirect-policy downgrade stop).
+        assert_eq!(
+            auth_for_tarball(&cfg, "http://npm.corp.test/pnpm/-/pnpm-10.0.0.tgz"),
+            None
+        );
+        // No auth configured (the public-registry default) → nothing to leak.
+        let no_auth = RegistryConfig {
+            base: PUBLIC_REGISTRY.into(),
+            auth: None,
+        };
+        assert_eq!(
+            auth_for_tarball(&no_auth, "https://registry.npmjs.org/x/-/x-1.0.0.tgz"),
+            None
         );
     }
 

--- a/crates/nub-core/src/version_management/download.rs
+++ b/crates/nub-core/src/version_management/download.rs
@@ -52,11 +52,31 @@ const RETRY_BACKOFF: Duration = Duration::from_millis(400);
 
 /// Blocking HTTP client: rustls (no OpenSSL), native roots so corporate MITM CAs
 /// keep working, and `HTTP(S)_PROXY` / `NO_PROXY` honored for free by reqwest.
+///
+/// The redirect policy blocks an https→http DOWNGRADE on redirect (N1; mirrors
+/// the engine's `aube-registry` client). reqwest already strips `Authorization`
+/// on a cross-HOST redirect as of 0.12, but an https→http hop to the SAME
+/// host+port is not "cross-host" by that check — so a `302` from a good registry
+/// to `http://<same-host>/` would otherwise carry the `_authToken` (which
+/// `fetch_text_auth` / `download_to_file_auth` attach) into cleartext. The hop
+/// cap matches reqwest's own default (≤10) so the only behavior change is the
+/// scheme guard.
 fn client() -> Result<reqwest::blocking::Client> {
     reqwest::blocking::Client::builder()
         .user_agent(concat!("nub/", env!("CARGO_PKG_VERSION")))
         .connect_timeout(Duration::from_secs(30))
         .timeout(Duration::from_secs(600))
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.previous().len() >= 10 {
+                return attempt.error("too many redirects");
+            }
+            if let Some(prev) = attempt.previous().last() {
+                if prev.scheme() == "https" && attempt.url().scheme() != "https" {
+                    return attempt.stop();
+                }
+            }
+            attempt.follow()
+        }))
         .build()
         .context("building HTTP client")
 }

--- a/crates/nub-core/src/version_management/extract.rs
+++ b/crates/nub-core/src/version_management/extract.rs
@@ -123,6 +123,16 @@ fn extract_tar_xz_capped(
     // recreates a symlink entry the same way `Archive::unpack` did, while the
     // manual walk lets us bound the entry COUNT (the `tar` crate has no
     // entry-count guard) on top of the decompression cap.
+    //
+    // `Archive::unpack` is itself a per-entry `unpack_in` loop; this hand-rolled
+    // version intentionally drops only two of its behaviors, both immaterial for a
+    // Node `.tar.xz`: (1) the deferred final directory pass (a no-op here — it
+    // exists to reapply restrictive dir *permissions*, gated on
+    // `preserve_permissions`, which a default `Archive` leaves off, so only dir
+    // mtimes differ, which nothing reads); (2) Windows `\\?\` long-path
+    // canonicalization (unreachable — Windows Node ships as `.zip`, handled by
+    // `extract_zip`). File data, exec bits, symlink targets, and the `..`/absolute
+    // traversal guard are all preserved by `unpack_in`.
     let decoder = CappedReader::new(liblzma::read::XzDecoder::new(file), decompressed_cap);
     let mut tar = tar::Archive::new(decoder);
     std::fs::create_dir_all(dest_parent)

--- a/crates/nub-core/src/version_management/extract.rs
+++ b/crates/nub-core/src/version_management/extract.rs
@@ -24,6 +24,14 @@ pub(crate) const MAX_ARCHIVE_DECOMPRESSED_BYTES: u64 = 1 << 30;
 /// same shape as `aube_store::MAX_TARBALL_ENTRY_BYTES`.
 pub(crate) const MAX_ARCHIVE_ENTRY_BYTES: u64 = 512 << 20;
 
+/// Maximum number of entries in a single archive — the third aube-store cap
+/// (`aube_store::MAX_TARBALL_ENTRIES`), bounding the per-entry `File::create`
+/// syscall/inode cost so a crafted archive of millions of tiny (empty-header)
+/// entries can't pin the CPU or exhaust inodes even while staying under the byte
+/// cap. `next` (the largest top-1000 npm package) ships ~8k files and a Node dist
+/// a few thousand; 200_000 is ~25× above either, so no real artifact trips it.
+pub(crate) const MAX_ARCHIVE_ENTRIES: usize = 200_000;
+
 /// A `Read` wrapper that refuses to deliver more than `remaining` bytes,
 /// surfacing exhaustion as an `io::Error` rather than a clean EOF. Mirror of
 /// `aube_store`'s `CappedReader`: when it wraps a gzip/xz decoder feeding a tar
@@ -90,29 +98,54 @@ pub(crate) fn single_top_dir(dest_parent: &Path, archive: &Path) -> Result<PathB
 /// top-level directory it created (the `node-v<ver>-<plat>` dir). The `tar` crate
 /// guards against path-traversal (`..` / absolute entries) during `unpack`.
 pub fn extract_tar_xz(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
-    extract_tar_xz_capped(archive, dest_parent, MAX_ARCHIVE_DECOMPRESSED_BYTES)
+    extract_tar_xz_capped(
+        archive,
+        dest_parent,
+        MAX_ARCHIVE_DECOMPRESSED_BYTES,
+        MAX_ARCHIVE_ENTRIES,
+    )
 }
 
-/// [`extract_tar_xz`] with the decompression cap as an explicit parameter — the
-/// seam a bomb test uses to inject a tiny cap (the public entry uses the prod
-/// [`MAX_ARCHIVE_DECOMPRESSED_BYTES`]).
+/// [`extract_tar_xz`] with the decompression + entry-count caps as explicit
+/// parameters — the seam a bomb test uses to inject tiny caps (the public entry
+/// uses the prod constants).
 fn extract_tar_xz_capped(
     archive: &Path,
     dest_parent: &Path,
     decompressed_cap: u64,
+    max_entries: usize,
 ) -> Result<PathBuf> {
     let file =
         std::fs::File::open(archive).with_context(|| format!("open {}", archive.display()))?;
     // Cap the DECOMPRESSED stream against a decompression bomb (N2). Node
     // tarballs legitimately ship intra-tree symlinks (`bin/npm → ../lib/…`), so
-    // unlike the PM-tgz extractor this path keeps `tar::unpack` (which preserves
-    // them); the cap is the only hardening here.
+    // unlike the PM-tgz extractor this path allows them — `Entry::unpack_in`
+    // recreates a symlink entry the same way `Archive::unpack` did, while the
+    // manual walk lets us bound the entry COUNT (the `tar` crate has no
+    // entry-count guard) on top of the decompression cap.
     let decoder = CappedReader::new(liblzma::read::XzDecoder::new(file), decompressed_cap);
     let mut tar = tar::Archive::new(decoder);
     std::fs::create_dir_all(dest_parent)
         .with_context(|| format!("create {}", dest_parent.display()))?;
-    tar.unpack(dest_parent)
-        .with_context(|| format!("extracting {}", archive.display()))?;
+    let mut count = 0usize;
+    for entry in tar
+        .entries()
+        .with_context(|| format!("reading {}", archive.display()))?
+    {
+        count += 1;
+        if count > max_entries {
+            bail!(
+                "{} exceeds the {max_entries}-entry archive cap",
+                archive.display()
+            );
+        }
+        let mut entry = entry.with_context(|| format!("reading entry in {}", archive.display()))?;
+        // `unpack_in` keeps the `tar` crate's `..`/absolute traversal guard (an
+        // escaping entry returns Ok(false) and is skipped) and recreates symlinks.
+        entry
+            .unpack_in(dest_parent)
+            .with_context(|| format!("extracting {}", archive.display()))?;
+    }
     single_top_dir(dest_parent, archive)
 }
 
@@ -136,22 +169,33 @@ pub fn extract_zip(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
         dest_parent,
         MAX_ARCHIVE_ENTRY_BYTES,
         MAX_ARCHIVE_DECOMPRESSED_BYTES,
+        MAX_ARCHIVE_ENTRIES,
     )
 }
 
-/// [`extract_zip`] with the per-entry + archive-total caps as explicit
-/// parameters — the seam a zip-bomb test uses to inject tiny caps (the public
-/// entry uses the prod constants).
+/// [`extract_zip`] with the per-entry + archive-total + entry-count caps as
+/// explicit parameters — the seam a zip-bomb test uses to inject tiny caps (the
+/// public entry uses the prod constants).
 fn extract_zip_capped(
     archive: &Path,
     dest_parent: &Path,
     entry_cap: u64,
     total_cap: u64,
+    max_entries: usize,
 ) -> Result<PathBuf> {
     let file =
         std::fs::File::open(archive).with_context(|| format!("open {}", archive.display()))?;
     let mut zip =
         zip::ZipArchive::new(file).with_context(|| format!("reading zip {}", archive.display()))?;
+    // The central directory declares the entry count up front — bound it before
+    // the walk so a many-tiny-entries archive can't drive `File::create` spam
+    // (0-byte entries never trip the byte caps). Mirrors `MAX_TARBALL_ENTRIES`.
+    if zip.len() > max_entries {
+        bail!(
+            "zip {} exceeds the {max_entries}-entry archive cap",
+            archive.display()
+        );
+    }
     std::fs::create_dir_all(dest_parent)
         .with_context(|| format!("create {}", dest_parent.display()))?;
 
@@ -330,11 +374,43 @@ mod tests {
         let out = dir.join("extracted");
         let err = format!(
             "{:#}",
-            extract_tar_xz_capped(&archive, &out, 1 << 20).unwrap_err()
+            extract_tar_xz_capped(&archive, &out, 1 << 20, MAX_ARCHIVE_ENTRIES).unwrap_err()
         );
         assert!(
             err.to_lowercase().contains("cap") || err.to_lowercase().contains("decompress"),
             "a decompression bomb must be refused by the cap: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// N2 (entry-count): a `.tar.xz` of many tiny entries stays under the byte
+    /// cap but drives an unpack per entry. The entry-count cap must refuse it.
+    #[test]
+    fn extract_tar_xz_rejects_too_many_entries() {
+        let dir = std::env::temp_dir().join(format!("nub-xz-count-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let archive = dir.join("manyentries.tar.xz");
+        {
+            let file = std::fs::File::create(&archive).unwrap();
+            let enc = liblzma::write::XzEncoder::new(file, 6);
+            let mut builder = tar::Builder::new(enc);
+            for name in ["top/a", "top/b", "top/c"] {
+                let mut h = tar::Header::new_gnu();
+                h.set_size(1);
+                h.set_mode(0o644);
+                h.set_cksum();
+                builder.append_data(&mut h, name, &b"x"[..]).unwrap();
+            }
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        let out = dir.join("extracted");
+        let err = format!(
+            "{:#}",
+            extract_tar_xz_capped(&archive, &out, 1 << 20, 2).unwrap_err()
+        );
+        assert!(
+            err.contains("entry archive cap"),
+            "an over-count archive must be refused: {err}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -361,11 +437,41 @@ mod tests {
         let out = dir.join("extracted");
         let err = format!(
             "{:#}",
-            extract_zip_capped(&archive, &out, 1 << 20, 1 << 30).unwrap_err()
+            extract_zip_capped(&archive, &out, 1 << 20, 1 << 30, MAX_ARCHIVE_ENTRIES).unwrap_err()
         );
         assert!(
             err.to_lowercase().contains("cap"),
             "an oversized zip entry must be refused by the cap: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// N2 (entry-count): a `.zip` of many tiny entries must be refused up front by
+    /// the entry-count cap (0-byte entries never trip the byte caps).
+    #[test]
+    fn extract_zip_rejects_too_many_entries() {
+        use std::io::Write;
+        let dir = std::env::temp_dir().join(format!("nub-zip-count-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let archive = dir.join("manyentries.zip");
+        {
+            let file = std::fs::File::create(&archive).unwrap();
+            let mut writer = zip::ZipWriter::new(file);
+            let opts: zip::write::FileOptions<()> = zip::write::FileOptions::default();
+            for name in ["top/a", "top/b", "top/c"] {
+                writer.start_file(name, opts).unwrap();
+                writer.write_all(b"x").unwrap();
+            }
+            writer.finish().unwrap();
+        }
+        let out = dir.join("extracted");
+        let err = format!(
+            "{:#}",
+            extract_zip_capped(&archive, &out, 1 << 20, 1 << 30, 2).unwrap_err()
+        );
+        assert!(
+            err.contains("entry archive cap"),
+            "an over-count zip must be refused: {err}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/nub-core/src/version_management/extract.rs
+++ b/crates/nub-core/src/version_management/extract.rs
@@ -1,8 +1,70 @@
 //! Extract a verified Node dist archive into nub's store.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+
+/// Maximum total decompressed bytes accepted from a single archive — the
+/// decompression-bomb ceiling (N2). 1 GiB, mirroring the engine's
+/// `aube_store::MAX_TARBALL_DECOMPRESSED_BYTES`. A stock Node dist tarball
+/// unpacks to well under 100 MiB, so this sits an order of magnitude above any
+/// real artifact while stopping a malicious/mirror-served small-compressed /
+/// huge-decompressed payload from exhausting disk or memory. The download is
+/// already checksum-verified against `SHASUMS256.txt` before extraction, so this
+/// is defense-in-depth against a MITM/mirror that also forged the checksum.
+///
+/// The cap is wired through the `_capped` extractor variants as a parameter
+/// rather than read from this const directly, so a bomb test can inject a tiny
+/// cap without a `cfg(test)` value that would also throttle the real-archive
+/// (~25 MB Node / ~15 MB pnpm) provisioning e2e tests.
+pub(crate) const MAX_ARCHIVE_DECOMPRESSED_BYTES: u64 = 1 << 30;
+
+/// Maximum bytes for a single archive entry (zip per-file cap). 512 MiB, the
+/// same shape as `aube_store::MAX_TARBALL_ENTRY_BYTES`.
+pub(crate) const MAX_ARCHIVE_ENTRY_BYTES: u64 = 512 << 20;
+
+/// A `Read` wrapper that refuses to deliver more than `remaining` bytes,
+/// surfacing exhaustion as an `io::Error` rather than a clean EOF. Mirror of
+/// `aube_store`'s `CappedReader`: when it wraps a gzip/xz decoder feeding a tar
+/// archive, a clean EOF on a block boundary would let a crafted archive silently
+/// truncate into a partial tree; an explicit error keeps the tar iterator from
+/// accepting a half-read stream as complete. Shared with [`crate::pm::extract`].
+pub(crate) struct CappedReader<R: Read> {
+    inner: R,
+    remaining: u64,
+    cap: u64,
+}
+
+impl<R: Read> CappedReader<R> {
+    pub(crate) fn new(inner: R, cap: u64) -> Self {
+        Self {
+            inner,
+            remaining: cap,
+            cap,
+        }
+    }
+}
+
+impl<R: Read> Read for CappedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // A zero-length read is a no-op by the `Read` contract and must not error
+        // even once the cap is exhausted.
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.remaining == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("archive decompression exceeds the {}-byte cap", self.cap),
+            ));
+        }
+        let want = buf.len().min(self.remaining as usize);
+        let n = self.inner.read(&mut buf[..want])?;
+        self.remaining -= n as u64;
+        Ok(n)
+    }
+}
 
 /// The single top-level directory `dest_parent` now holds after an archive was
 /// unpacked into it — the `node-v<ver>-<plat>` dir for Node tarballs/zips, the
@@ -28,9 +90,24 @@ pub(crate) fn single_top_dir(dest_parent: &Path, archive: &Path) -> Result<PathB
 /// top-level directory it created (the `node-v<ver>-<plat>` dir). The `tar` crate
 /// guards against path-traversal (`..` / absolute entries) during `unpack`.
 pub fn extract_tar_xz(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
+    extract_tar_xz_capped(archive, dest_parent, MAX_ARCHIVE_DECOMPRESSED_BYTES)
+}
+
+/// [`extract_tar_xz`] with the decompression cap as an explicit parameter — the
+/// seam a bomb test uses to inject a tiny cap (the public entry uses the prod
+/// [`MAX_ARCHIVE_DECOMPRESSED_BYTES`]).
+fn extract_tar_xz_capped(
+    archive: &Path,
+    dest_parent: &Path,
+    decompressed_cap: u64,
+) -> Result<PathBuf> {
     let file =
         std::fs::File::open(archive).with_context(|| format!("open {}", archive.display()))?;
-    let decoder = liblzma::read::XzDecoder::new(file);
+    // Cap the DECOMPRESSED stream against a decompression bomb (N2). Node
+    // tarballs legitimately ship intra-tree symlinks (`bin/npm → ../lib/…`), so
+    // unlike the PM-tgz extractor this path keeps `tar::unpack` (which preserves
+    // them); the cap is the only hardening here.
+    let decoder = CappedReader::new(liblzma::read::XzDecoder::new(file), decompressed_cap);
     let mut tar = tar::Archive::new(decoder);
     std::fs::create_dir_all(dest_parent)
         .with_context(|| format!("create {}", dest_parent.display()))?;
@@ -43,23 +120,95 @@ pub fn extract_tar_xz(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
 /// top-level directory it created (the `node-v<ver>-win-<arch>` dir holding
 /// `node.exe`). Pure-Rust via the `zip` crate — no shell-out to PowerShell's
 /// `Expand-Archive` or `tar.exe`, so extraction is identical across Windows
-/// versions and the checksum-verify-then-extract flow stays in one process.
-/// `ZipArchive::extract` guards against path-traversal (`..` / absolute entries).
+/// versions and the checksum-verify-then-extract flow stays in one process. The
+/// entry walk uses `ZipFile::enclosed_name` as the path-traversal guard (`..` /
+/// absolute entries are refused) and caps each entry + the archive total against
+/// a zip bomb (N2).
 ///
-/// Mode handling: `extract` applies stored unix mode bits on unix targets and is
-/// a no-op for them on Windows (where executability is by extension, so
-/// `node.exe` is runnable automatically). Stock Node `.zip`s carry POSIX modes
-/// in their extra fields, so a unix build extracting one keeps `node.exe`
-/// readable; the normal Windows-only path doesn't depend on it.
+/// Mode handling: stored unix mode bits are reapplied on unix targets and are a
+/// no-op on Windows (where executability is by extension, so `node.exe` is
+/// runnable automatically). Stock Node `.zip`s carry POSIX modes in their extra
+/// fields, so a unix build extracting one keeps `node.exe` readable; the normal
+/// Windows-only path doesn't depend on it.
 pub fn extract_zip(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
+    extract_zip_capped(
+        archive,
+        dest_parent,
+        MAX_ARCHIVE_ENTRY_BYTES,
+        MAX_ARCHIVE_DECOMPRESSED_BYTES,
+    )
+}
+
+/// [`extract_zip`] with the per-entry + archive-total caps as explicit
+/// parameters — the seam a zip-bomb test uses to inject tiny caps (the public
+/// entry uses the prod constants).
+fn extract_zip_capped(
+    archive: &Path,
+    dest_parent: &Path,
+    entry_cap: u64,
+    total_cap: u64,
+) -> Result<PathBuf> {
     let file =
         std::fs::File::open(archive).with_context(|| format!("open {}", archive.display()))?;
     let mut zip =
         zip::ZipArchive::new(file).with_context(|| format!("reading zip {}", archive.display()))?;
     std::fs::create_dir_all(dest_parent)
         .with_context(|| format!("create {}", dest_parent.display()))?;
-    zip.extract(dest_parent)
-        .with_context(|| format!("extracting {}", archive.display()))?;
+
+    // A manual entry walk (instead of `ZipArchive::extract`) so each entry's
+    // decompressed output can be capped against a zip bomb (N2). `enclosed_name`
+    // is the path-traversal guard — it returns `None` for any `..`/absolute entry.
+    let mut total: u64 = 0;
+    for i in 0..zip.len() {
+        let mut entry = zip
+            .by_index(i)
+            .with_context(|| format!("reading zip entry {i} of {}", archive.display()))?;
+        let Some(rel) = entry.enclosed_name() else {
+            bail!(
+                "zip entry path {:?} escapes the extraction dir in {}",
+                entry.name(),
+                archive.display()
+            );
+        };
+        let dest_path = dest_parent.join(&rel);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&dest_path)
+                .with_context(|| format!("create {}", dest_path.display()))?;
+            continue;
+        }
+        if let Some(parent) = dest_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        let mut out = std::fs::File::create(&dest_path)
+            .with_context(|| format!("create {}", dest_path.display()))?;
+        // Per-entry cap (+1 so a write of exactly the cap is detectable) plus a
+        // running archive-total cap — a lying header can't amplify past either.
+        let written = std::io::copy(&mut (&mut entry).take(entry_cap + 1), &mut out)
+            .with_context(|| format!("extracting {} from {}", rel.display(), archive.display()))?;
+        if written > entry_cap {
+            bail!(
+                "zip entry {} exceeds the {entry_cap}-byte per-entry cap",
+                rel.display()
+            );
+        }
+        total = total.saturating_add(written);
+        if total > total_cap {
+            bail!(
+                "zip {} exceeds the {total_cap}-byte archive cap",
+                archive.display()
+            );
+        }
+        // Preserve stored unix mode bits (Node `.zip`s carry POSIX modes in their
+        // extra fields) so a unix host extracting one keeps `node.exe` readable —
+        // the behavior `ZipArchive::extract` gave for free. A no-op on Windows,
+        // where executability is by extension.
+        #[cfg(unix)]
+        if let Some(mode) = entry.unix_mode() {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&dest_path, std::fs::Permissions::from_mode(mode));
+        }
+    }
     single_top_dir(dest_parent, archive)
 }
 
@@ -150,6 +299,74 @@ mod tests {
         assert_eq!(top.file_name().unwrap(), "top");
         assert!(top.join("node.exe").is_file());
         assert!(top.join("README").is_file());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// N2: a `.tar.xz` whose decompressed output dwarfs its compressed size — a
+    /// MITM/malicious-mirror Node tarball that also forged the checksum. The
+    /// `CappedReader` must error before the payload exhausts disk. Drives the
+    /// `_capped` seam with a 1 MiB cap (the public entry uses the 1 GiB prod cap,
+    /// which the real ~25 MB Node provisioning e2e relies on).
+    #[test]
+    fn extract_tar_xz_rejects_a_decompression_bomb() {
+        let dir = std::env::temp_dir().join(format!("nub-xz-bomb-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let archive = dir.join("bomb.tar.xz");
+        {
+            let file = std::fs::File::create(&archive).unwrap();
+            let enc = liblzma::write::XzEncoder::new(file, 6);
+            let mut builder = tar::Builder::new(enc);
+            let big = vec![0u8; 4 * 1024 * 1024];
+            let mut h = tar::Header::new_gnu();
+            h.set_size(big.len() as u64);
+            h.set_mode(0o644);
+            h.set_cksum();
+            builder
+                .append_data(&mut h, "top/big.bin", &big[..])
+                .unwrap();
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        assert!(std::fs::metadata(&archive).unwrap().len() < 64 * 1024);
+        let out = dir.join("extracted");
+        let err = format!(
+            "{:#}",
+            extract_tar_xz_capped(&archive, &out, 1 << 20).unwrap_err()
+        );
+        assert!(
+            err.to_lowercase().contains("cap") || err.to_lowercase().contains("decompress"),
+            "a decompression bomb must be refused by the cap: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// N2: a `.zip` entry that decompresses past the per-entry cap (a zip bomb).
+    /// The capped entry copy must error rather than write the whole payload.
+    /// Drives the `_capped` seam with a 1 MiB per-entry cap.
+    #[test]
+    fn extract_zip_rejects_an_oversized_entry() {
+        use std::io::Write;
+        let dir = std::env::temp_dir().join(format!("nub-zip-bomb-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let archive = dir.join("bomb.zip");
+        {
+            let file = std::fs::File::create(&archive).unwrap();
+            let mut writer = zip::ZipWriter::new(file);
+            let opts: zip::write::FileOptions<()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
+            writer.start_file("top/big.bin", opts).unwrap();
+            writer.write_all(&vec![0u8; 4 * 1024 * 1024]).unwrap(); // > the 1 MiB injected cap
+            writer.finish().unwrap();
+        }
+        assert!(std::fs::metadata(&archive).unwrap().len() < 64 * 1024);
+        let out = dir.join("extracted");
+        let err = format!(
+            "{:#}",
+            extract_zip_capped(&archive, &out, 1 << 20, 1 << 30).unwrap_err()
+        );
+        assert!(
+            err.to_lowercase().contains("cap"),
+            "an oversized zip entry must be refused by the cap: {err}"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/vendor/aube/crates/aube-runtime/src/extract.rs
+++ b/vendor/aube/crates/aube-runtime/src/extract.rs
@@ -4,7 +4,67 @@
 //! discovery.
 
 use crate::error::Error;
+use std::io::Read;
 use std::path::{Component, Path, PathBuf};
+
+/// Maximum total decompressed bytes accepted from a single runtime archive — the
+/// decompression-bomb ceiling. 1 GiB, mirroring
+/// `aube_store::MAX_TARBALL_DECOMPRESSED_BYTES`. A stock Node release unpacks to
+/// well under 100 MiB, so this sits an order of magnitude above any real artifact
+/// while stopping a malicious/mirror-served small-compressed / huge-decompressed
+/// payload from exhausting disk or memory. The download is checksum-verified
+/// before extraction, so this is defense-in-depth against a forged-checksum MITM.
+/// Lowered under `cfg(test)` (as `aube_store` does) so a bomb test stays cheap.
+#[cfg(not(test))]
+const MAX_ARCHIVE_DECOMPRESSED_BYTES: u64 = 1 << 30;
+#[cfg(test)]
+const MAX_ARCHIVE_DECOMPRESSED_BYTES: u64 = 1 << 20;
+
+/// Maximum bytes for a single zip entry — the per-file cap on the zip path,
+/// matching `aube_store::MAX_TARBALL_ENTRY_BYTES`.
+#[cfg(not(test))]
+const MAX_ARCHIVE_ENTRY_BYTES: u64 = 512 << 20;
+#[cfg(test)]
+const MAX_ARCHIVE_ENTRY_BYTES: u64 = 1 << 20;
+
+/// A `Read` wrapper that refuses to deliver more than `remaining` bytes,
+/// surfacing exhaustion as an `io::Error` rather than a clean EOF — so a crafted
+/// archive can't silently truncate a tar stream into a partial tree at a block
+/// boundary. Local mirror of `aube_store`'s `CappedReader` (it is `pub(crate)`
+/// there, so it can't be shared across the crate boundary).
+struct CappedReader<R: Read> {
+    inner: R,
+    remaining: u64,
+}
+
+impl<R: Read> CappedReader<R> {
+    fn new(inner: R, cap: u64) -> Self {
+        Self {
+            inner,
+            remaining: cap,
+        }
+    }
+}
+
+impl<R: Read> Read for CappedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.remaining == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "archive decompression exceeds the {MAX_ARCHIVE_DECOMPRESSED_BYTES}-byte cap"
+                ),
+            ));
+        }
+        let want = buf.len().min(self.remaining as usize);
+        let n = self.inner.read(&mut buf[..want])?;
+        self.remaining -= n as u64;
+        Ok(n)
+    }
+}
 
 /// Extract `archive_path` into `dest`. `strip_first` drops the
 /// top-level directory (`node-v{V}-{slug}/`; aube release archives
@@ -28,7 +88,12 @@ pub(crate) fn extract_archive(
 fn extract_tar_gz(archive_path: &Path, dest: &Path, strip_first: bool) -> Result<(), Error> {
     let file = std::fs::File::open(archive_path)
         .map_err(|e| Error::io(format!("open {}", archive_path.display()), e))?;
-    let decoder = flate2::read::GzDecoder::new(std::io::BufReader::new(file));
+    // Cap the DECOMPRESSED stream against a gzip bomb (defense-in-depth on top of
+    // the upstream checksum gate).
+    let decoder = CappedReader::new(
+        flate2::read::GzDecoder::new(std::io::BufReader::new(file)),
+        MAX_ARCHIVE_DECOMPRESSED_BYTES,
+    );
     let mut archive = tar::Archive::new(decoder);
     for entry in archive.entries().map_err(|e| Error::ExtractFailed {
         reason: e.to_string(),
@@ -104,6 +169,9 @@ fn extract_zip(archive_path: &Path, dest: &Path, strip_first: bool) -> Result<()
     let mut zip = zip::ZipArchive::new(file).map_err(|e| Error::ExtractFailed {
         reason: e.to_string(),
     })?;
+    // Running decompressed total, capped per-entry and per-archive against a zip
+    // bomb (defense-in-depth on top of the upstream checksum gate).
+    let mut total: u64 = 0;
     for i in 0..zip.len() {
         let mut entry = zip.by_index(i).map_err(|e| Error::ExtractFailed {
             reason: e.to_string(),
@@ -128,9 +196,31 @@ fn extract_zip(archive_path: &Path, dest: &Path, strip_first: bool) -> Result<()
         }
         let mut out = std::fs::File::create(&dest_path)
             .map_err(|e| Error::io(format!("create {}", dest_path.display()), e))?;
-        std::io::copy(&mut entry, &mut out).map_err(|e| Error::ExtractFailed {
+        // Per-entry cap (+1 so a write of exactly the cap is detectable) plus the
+        // running archive total — a lying header can't amplify past either.
+        let written = std::io::copy(
+            &mut (&mut entry).take(MAX_ARCHIVE_ENTRY_BYTES + 1),
+            &mut out,
+        )
+        .map_err(|e| Error::ExtractFailed {
             reason: format!("{}: {e}", stripped.display()),
         })?;
+        if written > MAX_ARCHIVE_ENTRY_BYTES {
+            return Err(Error::ExtractFailed {
+                reason: format!(
+                    "{} exceeds the {MAX_ARCHIVE_ENTRY_BYTES}-byte per-entry cap",
+                    stripped.display()
+                ),
+            });
+        }
+        total = total.saturating_add(written);
+        if total > MAX_ARCHIVE_DECOMPRESSED_BYTES {
+            return Err(Error::ExtractFailed {
+                reason: format!(
+                    "archive exceeds the {MAX_ARCHIVE_DECOMPRESSED_BYTES}-byte decompression cap"
+                ),
+            });
+        }
     }
     Ok(())
 }
@@ -274,6 +364,75 @@ mod tests {
             Path::new("bin/npm"),
             Path::new("/etc/passwd")
         ));
+    }
+
+    #[test]
+    fn tar_gz_decompression_bomb_is_capped() {
+        // A small-compressed / huge-decompressed `.tar.gz` (the gzip-bomb shape)
+        // must be refused by the CappedReader before the payload exhausts disk.
+        // Test cap is 1 MiB; author well past it from a tiny compressed input.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut builder = tar::Builder::new(flate2::write::GzEncoder::new(
+            Vec::new(),
+            flate2::Compression::best(),
+        ));
+        let big = vec![0u8; 4 * 1024 * 1024];
+        let mut header = tar::Header::new_gnu();
+        header.set_size(big.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "top/big.bin", &big[..])
+            .unwrap();
+        let bytes = builder.into_inner().unwrap().finish().unwrap();
+        assert!(
+            bytes.len() < 64 * 1024,
+            "compressed bomb must be tiny: {}",
+            bytes.len()
+        );
+        let archive = tmp.path().join("bomb.tar.gz");
+        std::fs::write(&archive, bytes).unwrap();
+        let dest = tmp.path().join("out");
+        std::fs::create_dir_all(&dest).unwrap();
+        // Extraction must be refused, and the cap must have interrupted the write
+        // BEFORE the full 4 MiB landed (the tar-crate unpack error wraps the
+        // CappedReader's io error without surfacing its message, so assert the
+        // truncation behavior, not the wording).
+        assert!(
+            extract_archive(&archive, &dest, false, true).is_err(),
+            "a decompression bomb must be refused"
+        );
+        if let Ok(meta) = std::fs::metadata(dest.join("big.bin")) {
+            assert!(
+                meta.len() <= MAX_ARCHIVE_DECOMPRESSED_BYTES,
+                "the cap must interrupt the write; any partial file is at most the cap, got {} bytes",
+                meta.len()
+            );
+        }
+    }
+
+    #[test]
+    fn zip_oversized_entry_is_capped() {
+        use std::io::Write;
+        // A zip entry decompressing past the per-entry cap (1 MiB under test) must
+        // be refused rather than written in full.
+        let tmp = tempfile::tempdir().unwrap();
+        let archive = tmp.path().join("bomb.zip");
+        let file = std::fs::File::create(&archive).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        let opts: zip::write::SimpleFileOptions = Default::default();
+        writer.start_file("top/big.bin", opts).unwrap();
+        writer.write_all(&vec![0u8; 4 * 1024 * 1024]).unwrap();
+        writer.finish().unwrap();
+        assert!(std::fs::metadata(&archive).unwrap().len() < 64 * 1024);
+        let dest = tmp.path().join("out");
+        std::fs::create_dir_all(&dest).unwrap();
+        let err = extract_archive(&archive, &dest, true, true).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.to_lowercase().contains("cap"),
+            "an oversized zip entry must be refused by the cap: {msg}"
+        );
     }
 
     #[test]

--- a/vendor/aube/crates/aube-runtime/src/extract.rs
+++ b/vendor/aube/crates/aube-runtime/src/extract.rs
@@ -27,6 +27,15 @@ const MAX_ARCHIVE_ENTRY_BYTES: u64 = 512 << 20;
 #[cfg(test)]
 const MAX_ARCHIVE_ENTRY_BYTES: u64 = 1 << 20;
 
+/// Maximum number of entries in a single archive — the third aube-store cap
+/// (`aube_store::MAX_TARBALL_ENTRIES`), bounding the per-entry syscall/inode cost
+/// so a crafted archive of millions of tiny entries can't pin the CPU even under
+/// the byte cap. A Node release ships a few thousand files; 200_000 is far above.
+#[cfg(not(test))]
+const MAX_ARCHIVE_ENTRIES: usize = 200_000;
+#[cfg(test)]
+const MAX_ARCHIVE_ENTRIES: usize = 4;
+
 /// A `Read` wrapper that refuses to deliver more than `remaining` bytes,
 /// surfacing exhaustion as an `io::Error` rather than a clean EOF — so a crafted
 /// archive can't silently truncate a tar stream into a partial tree at a block
@@ -95,9 +104,16 @@ fn extract_tar_gz(archive_path: &Path, dest: &Path, strip_first: bool) -> Result
         MAX_ARCHIVE_DECOMPRESSED_BYTES,
     );
     let mut archive = tar::Archive::new(decoder);
+    let mut count = 0usize;
     for entry in archive.entries().map_err(|e| Error::ExtractFailed {
         reason: e.to_string(),
     })? {
+        count += 1;
+        if count > MAX_ARCHIVE_ENTRIES {
+            return Err(Error::ExtractFailed {
+                reason: format!("archive exceeds the {MAX_ARCHIVE_ENTRIES}-entry cap"),
+            });
+        }
         let mut entry = entry.map_err(|e| Error::ExtractFailed {
             reason: e.to_string(),
         })?;
@@ -169,6 +185,14 @@ fn extract_zip(archive_path: &Path, dest: &Path, strip_first: bool) -> Result<()
     let mut zip = zip::ZipArchive::new(file).map_err(|e| Error::ExtractFailed {
         reason: e.to_string(),
     })?;
+    // Bound the declared entry count up front (mirrors aube-store's
+    // MAX_TARBALL_ENTRIES) so a many-tiny-entries archive can't drive
+    // `File::create` spam — 0-byte entries never trip the byte caps below.
+    if zip.len() > MAX_ARCHIVE_ENTRIES {
+        return Err(Error::ExtractFailed {
+            reason: format!("archive exceeds the {MAX_ARCHIVE_ENTRIES}-entry cap"),
+        });
+    }
     // Running decompressed total, capped per-entry and per-archive against a zip
     // bomb (defense-in-depth on top of the upstream checksum gate).
     let mut total: u64 = 0;
@@ -285,6 +309,32 @@ mod tests {
         extract_archive(&archive, &dest, false, true).unwrap();
         assert!(dest.join("bin/node").is_file());
         assert!(dest.join("LICENSE").is_file());
+    }
+
+    #[test]
+    fn tar_gz_entry_count_is_capped() {
+        // Many tiny entries stay under the byte cap but drive an unpack per
+        // entry; the entry-count cap (4 under cfg(test)) must refuse the archive.
+        let tmp = tempfile::tempdir().unwrap();
+        let bytes = make_tar_gz(&[
+            ("top/a", "1"),
+            ("top/b", "2"),
+            ("top/c", "3"),
+            ("top/d", "4"),
+            ("top/e", "5"),
+        ]);
+        let archive = tmp.path().join("many.tar.gz");
+        std::fs::write(&archive, bytes).unwrap();
+        let dest = tmp.path().join("out");
+        std::fs::create_dir_all(&dest).unwrap();
+        let err = format!(
+            "{:?}",
+            extract_archive(&archive, &dest, false, true).unwrap_err()
+        );
+        assert!(
+            err.contains("entry cap"),
+            "over-count archive must be refused: {err}"
+        );
     }
 
     #[cfg(unix)]

--- a/vendor/aube/crates/aube/src/commands/install/delta.rs
+++ b/vendor/aube/crates/aube/src/commands/install/delta.rs
@@ -495,12 +495,21 @@ fn fingerprint(pkg: &LockedPackage, patch_hash: Option<&str>, project_root: &Pat
             LocalSource::Exec(p) => {
                 h.update(b"exec");
                 update_field(&mut h, b"path", p.to_string_lossy().as_bytes());
-                let script = if p.is_absolute() {
-                    p.as_path().to_path_buf()
-                } else {
-                    project_root.join(p)
-                };
-                if let Ok(content) = std::fs::read(script) {
+                // Fold the generator script's content so a changed script lands
+                // in the `changed` bucket on the next install. Resolve it through
+                // the SAME containment guard the exec *execution* sink uses
+                // (`resolve_exec_script_path`: canonicalize, assert the path stays
+                // under `project_root`, reject absolute) before reading. Without
+                // it a malicious committed lockfile's `exec:/etc/shadow` or
+                // `exec:../escape` turned this change-hash read into an
+                // out-of-project arbitrary-file read, and `exec:/dev/zero` into an
+                // unbounded one (DoS). A legit in-project script canonicalizes to
+                // the same bytes, so the fingerprint is unchanged; an
+                // out-of-project script is skipped here and rejected at execution
+                // time anyway, so omitting its content costs nothing.
+                if let Ok(script) = aube_resolver::resolve_exec_script_path(src, project_root)
+                    && let Ok(content) = std::fs::read(&script)
+                {
                     update_field(&mut h, b"content", &content);
                 }
             }
@@ -652,6 +661,39 @@ mod tests {
         let after = fingerprint(&pkg, None, temp.path());
 
         assert_ne!(before, after);
+    }
+
+    #[test]
+    fn fingerprint_skips_out_of_project_exec_script_content() {
+        // N3: a committed lockfile's `exec:` source whose path escapes the project
+        // root must NOT have its content folded into the change-hash — the read is
+        // contained to the project the same way the execution sink is. Proof:
+        // mutating the out-of-project file leaves the fingerprint unchanged (the
+        // pre-fix code read `project_root.join(p)` / the absolute path directly, so
+        // a `../escape` or `/etc/shadow` became an arbitrary out-of-project read,
+        // and `/dev/zero` an unbounded one). The legit in-project case is covered
+        // by `fingerprint_changes_on_exec_script_edit` above.
+        let temp = tempfile::tempdir().unwrap();
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+        let outside = temp.path().join("outside.js");
+        std::fs::write(&outside, "module.exports = { name: 'before' }").unwrap();
+
+        for escaping in [
+            std::path::PathBuf::from("../outside.js"), // relative escape
+            outside.clone(),                           // absolute escape
+        ] {
+            let mut pkg = pkg("generated", "1.0.0");
+            pkg.local_source = Some(LocalSource::Exec(escaping.clone()));
+            let before = fingerprint(&pkg, None, &project_root);
+            std::fs::write(&outside, "module.exports = { name: 'after-DIFFERENT' }").unwrap();
+            let after = fingerprint(&pkg, None, &project_root);
+            std::fs::write(&outside, "module.exports = { name: 'before' }").unwrap(); // reset
+            assert_eq!(
+                before, after,
+                "out-of-project exec source {escaping:?} must not have its content read into the hash"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Brings nub's PM/Node self-provisioning (`crates/nub-core/src/pm/*`, `version_management/*`) up to the guards the embedded aube engine already enforces. Five findings from `wiki/research/security-audit-172class.md` (#172 / F0a was fixed in #180); each fix mirrors an existing aube guard.

- **F0c** (`pm/registry.rs`): validate a registry `dist.version` (reject `/ \ NUL` ctrl `.` `..`) in `dist_from_meta` before it joins the executed `<store>/pm/<pm>/<version>/…` path. Mirrors `aube_store::validate_version`. Covers dist-tag + range; exact-pin was already semver-gated.
- **N1a** (`version_management/download.rs`): https→http downgrade-stop redirect policy (mirror of aube-registry), so the registry `_authToken` can't follow a redirect into cleartext.
- **N1b** (`pm/registry.rs`, `pm/provision.rs`, `cli.rs`): attach the registry credential to the tarball download only when `dist.tarball`'s origin matches the registry's. Packument fetch keeps full auth.
- **N2** (`pm/extract.rs`, `version_management/extract.rs`, `aube-runtime/extract.rs`): `CappedReader` on the gz/xz decoders + `take`-cap on zip entries (mirror of aube-store). Prod cap 1 GiB; bomb tests inject a tiny cap via `_capped` seams so real-tarball e2e is unaffected.
- **F0b** (`pm/extract.rs`): reject symlink/hardlink entries in the PM-provision extractor (CVE-2021-37701 class). pnpm/npm/yarn publishes ship none (verified live). The Node extractor still allows Node's intra-tree symlinks.
- **N3** (`vendor/aube/.../install/delta.rs`): contain the `exec:` change-hash `fs::read` through aube's own `resolve_exec_script_path`, so a committed lockfile's `exec:/abs` / `exec:../escape` / `exec:/dev/zero` can't drive an out-of-project or unbounded read. Default-preserving for standalone aube. `link:`/`file:`/`portal:` left unrestricted (legitimate monorepo semantics).

Verification: clippy `--all-targets --all-features -D warnings` + `fmt --check` clean; nub-core (306) + aube delta (33) + aube-runtime extract (7) + nub-cli PM integration green; each finding has a malicious-fixture test; real pnpm@10.0.0 provisioned through the rewritten extractor and run under Node.

Fork-discipline: aube-side hunks (N3 + aube-runtime caps) are default-preserving and upstreamable to `jdx/aube`.

Refs: `wiki/research/security-audit-172class.md`; the #172 registry-path class.
