### PR TITLE
fix(install): honor --silent/--reporter/--loglevel before the verb too

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1140,6 +1140,14 @@ fn run_nub() -> Result<i32> {
     let mut help_verbose = false;
     let mut show_warnings = false;
     let mut silent = false;
+    // Pre-verb PM output flags (`nub --reporter=silent install`,
+    // `nub --loglevel=error add foo`): captured here and recorded as process
+    // defaults below so the per-verb `OutputFlags` resolution can fall back to
+    // them (per-verb always wins). Without these arms a leading `--reporter`/
+    // `--loglevel` falls through to the file-run path and is shipped to Node
+    // (`node: bad option`). `--silent`/`-s` is already captured above.
+    let mut reporter_val: Option<String> = None;
+    let mut loglevel_val: Option<String> = None;
     // Top-level `--node`: provision the project's Node (version management stays
     // on) but run with zero augmentation — the compat escape hatch. Routed to
     // `run_file_with_compat(_, true)`. See wiki/commands/node.md.
@@ -1189,6 +1197,30 @@ fn run_nub() -> Result<i32> {
             }
             s if s == "--color" || s.starts_with("--color=") || s == "--no-color" => {
                 // --color (no value), --color=always, --no-color: all consumed, not forwarded
+            }
+            // Pre-verb PM output flags. `--reporter`/`--loglevel` only appear
+            // here BEFORE a subcommand (after the verb they belong to the
+            // verb's own clap surface and never reach this scan). Captured, not
+            // forwarded to Node; recorded as process defaults below. The value
+            // is validated where it's recorded (clean usage error on a bad
+            // spelling) — a separate concern from grabbing the token here.
+            "--reporter" => {
+                i += 1;
+                if i < raw_args.len() {
+                    reporter_val = Some(raw_args[i].clone());
+                }
+            }
+            s if s.starts_with("--reporter=") => {
+                reporter_val = Some(s["--reporter=".len()..].to_string());
+            }
+            "--loglevel" => {
+                i += 1;
+                if i < raw_args.len() {
+                    loglevel_val = Some(raw_args[i].clone());
+                }
+            }
+            s if s.starts_with("--loglevel=") => {
+                loglevel_val = Some(s["--loglevel=".len()..].to_string());
             }
             s if s == "--env-file"
                 || s.starts_with("--env-file=")
@@ -1322,6 +1354,32 @@ fn run_nub() -> Result<i32> {
 
     SHOW_WARNINGS.store(show_warnings, Ordering::Relaxed);
     SILENT.store(silent, Ordering::Relaxed);
+
+    // Record the pre-verb PM output flags as process defaults so a PM verb
+    // dispatched below (`nub --silent install`, `nub --reporter=silent add foo`)
+    // honors them — the per-verb clap flag still wins. A `run`/file-run path
+    // simply doesn't read these defaults (run carries its own `--reporter`), so
+    // they're inert there. Invalid `--reporter`/`--loglevel` values get the same
+    // clean usage error clap gives for the per-verb form.
+    if silent {
+        crate::pm_engine::output::set_global_silent();
+    }
+    if let Some(ref value) = reporter_val
+        && let Err(bad) = crate::pm_engine::output::set_global_reporter_str(value)
+    {
+        bail!(
+            "invalid value '{bad}' for '--reporter <NAME>'\n  \
+             [possible values: default, append-only, silent]"
+        );
+    }
+    if let Some(ref value) = loglevel_val
+        && let Err(bad) = crate::pm_engine::output::set_global_loglevel_str(value)
+    {
+        bail!(
+            "invalid value '{bad}' for '--loglevel <LEVEL>'\n  \
+             [possible values: silent, error, warn, info, debug]"
+        );
+    }
 
     if let Some(ref dir) = cwd {
         env::set_current_dir(dir)?;

--- a/crates/nub-cli/src/pm_engine/output.rs
+++ b/crates/nub-cli/src/pm_engine/output.rs
@@ -21,7 +21,99 @@
 //!   (`error` hides warnings; `info`/`debug` surface more). `debug` also
 //!   forces text so logs don't collide with the progress display.
 
+use std::sync::atomic::{AtomicU8, Ordering};
+
 use super::log;
+
+// ───────────────────────── process-global defaults ──────────────────────────
+//
+// nub accepts the output flags in TWO positions: after the verb (`nub install
+// --silent`, parsed by the per-verb `OutputFlags` below) and BEFORE it (`nub
+// --silent install`, `nub --reporter=silent add foo`). The pre-verb position is
+// parsed by the hand-rolled scan in `cli::dispatch`, never by clap — the PM
+// verbs are dispatched through their own clap `Command` (install/ci) or a
+// separately-built one (the registry verbs), neither of which sees the
+// top-level globals. So the pre-verb values are recorded here as process
+// defaults and merged UNDER the per-verb flags (per-verb always wins). This
+// mirrors the existing `cli::SILENT` atomic that already carries `--silent` to
+// `nub run`'s preamble — same seam, extended to the PM reporter/loglevel.
+//
+// `0` is "unset" for each enum; the encodings are private to this module.
+static PROC_REPORTER: AtomicU8 = AtomicU8::new(0);
+static PROC_LOGLEVEL: AtomicU8 = AtomicU8::new(0);
+static PROC_SILENT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+fn reporter_to_u8(r: Reporter) -> u8 {
+    match r {
+        Reporter::Default => 1,
+        Reporter::AppendOnly => 2,
+        Reporter::Silent => 3,
+    }
+}
+fn u8_to_reporter(v: u8) -> Option<Reporter> {
+    match v {
+        1 => Some(Reporter::Default),
+        2 => Some(Reporter::AppendOnly),
+        3 => Some(Reporter::Silent),
+        _ => None,
+    }
+}
+fn loglevel_to_u8(l: LogLevel) -> u8 {
+    match l {
+        LogLevel::Silent => 1,
+        LogLevel::Error => 2,
+        LogLevel::Warn => 3,
+        LogLevel::Info => 4,
+        LogLevel::Debug => 5,
+    }
+}
+fn u8_to_loglevel(v: u8) -> Option<LogLevel> {
+    match v {
+        1 => Some(LogLevel::Silent),
+        2 => Some(LogLevel::Error),
+        3 => Some(LogLevel::Warn),
+        4 => Some(LogLevel::Info),
+        5 => Some(LogLevel::Debug),
+        _ => None,
+    }
+}
+
+/// Record `nub --silent <verb>` as a process default. Called by `cli::dispatch`
+/// when the global `--silent`/`-s` precedes a subcommand.
+pub fn set_global_silent() {
+    PROC_SILENT.store(true, Ordering::Relaxed);
+}
+
+/// Parse + record a pre-verb `--reporter <value>` as a process default. Returns
+/// the invalid value (for a clean usage error) when the spelling isn't one of
+/// `default`/`append-only`/`silent`. Reuses clap's `ValueEnum` parse so the
+/// accepted set can't drift from the per-verb flag.
+pub fn set_global_reporter_str(value: &str) -> Result<(), String> {
+    use clap::ValueEnum as _;
+    let r = Reporter::from_str(value, true).map_err(|_| value.to_string())?;
+    PROC_REPORTER.store(reporter_to_u8(r), Ordering::Relaxed);
+    Ok(())
+}
+
+/// Parse + record a pre-verb `--loglevel <value>` as a process default. Returns
+/// the invalid value when the spelling isn't one of
+/// `silent`/`error`/`warn`/`info`/`debug`.
+pub fn set_global_loglevel_str(value: &str) -> Result<(), String> {
+    use clap::ValueEnum as _;
+    let l = LogLevel::from_str(value, true).map_err(|_| value.to_string())?;
+    PROC_LOGLEVEL.store(loglevel_to_u8(l), Ordering::Relaxed);
+    Ok(())
+}
+
+fn proc_reporter() -> Option<Reporter> {
+    u8_to_reporter(PROC_REPORTER.load(Ordering::Relaxed))
+}
+fn proc_loglevel() -> Option<LogLevel> {
+    u8_to_loglevel(PROC_LOGLEVEL.load(Ordering::Relaxed))
+}
+fn proc_silent() -> bool {
+    PROC_SILENT.load(Ordering::Relaxed)
+}
 
 /// `--reporter` values nub accepts, mirroring pnpm's. `ndjson` is deliberately
 /// absent: a machine-readable event stream is a separate feature from quieting
@@ -71,13 +163,26 @@ pub struct OutputFlags {
 }
 
 impl OutputFlags {
-    /// True when any spelling resolves to full silence (`pnpm --silent`).
-    /// Public so command impls that print their own (non-engine) summary —
-    /// e.g. `import` — can suppress it under `--silent`.
+    /// The reporter in effect: the per-verb flag, else the pre-verb process
+    /// default (`nub --reporter=… <verb>`). Per-verb always wins.
+    fn eff_reporter(&self) -> Option<Reporter> {
+        self.reporter.or_else(proc_reporter)
+    }
+
+    /// The loglevel in effect: per-verb flag, else the process default.
+    fn eff_loglevel(&self) -> Option<LogLevel> {
+        self.loglevel.or_else(proc_loglevel)
+    }
+
+    /// True when any spelling resolves to full silence (`pnpm --silent`),
+    /// including the pre-verb global forms (`nub --silent <verb>`,
+    /// `nub --reporter=silent <verb>`). Public so command impls that print
+    /// their own (non-engine) summary — e.g. `import` — can suppress it.
     pub fn is_silent(&self) -> bool {
         self.silent
-            || self.reporter == Some(Reporter::Silent)
-            || self.loglevel == Some(LogLevel::Silent)
+            || proc_silent()
+            || self.eff_reporter() == Some(Reporter::Silent)
+            || self.eff_loglevel() == Some(LogLevel::Silent)
     }
 
     /// True when the progress UI must drop to plain text — silent, the
@@ -86,8 +191,8 @@ impl OutputFlags {
     /// `force_text`.
     fn force_text(&self) -> bool {
         self.is_silent()
-            || self.reporter == Some(Reporter::AppendOnly)
-            || self.loglevel == Some(LogLevel::Debug)
+            || self.eff_reporter() == Some(Reporter::AppendOnly)
+            || self.eff_loglevel() == Some(LogLevel::Debug)
     }
 
     /// The engine log level to apply, as a tracing token, or `None` to leave
@@ -96,7 +201,7 @@ impl OutputFlags {
         if self.is_silent() {
             return Some("off");
         }
-        match self.loglevel {
+        match self.eff_loglevel() {
             Some(LogLevel::Error) => Some("error"),
             Some(LogLevel::Info) => Some("info"),
             Some(LogLevel::Debug) => Some("debug"),

--- a/crates/nub-cli/src/pm_engine/output.rs
+++ b/crates/nub-cli/src/pm_engine/output.rs
@@ -39,9 +39,12 @@ use super::log;
 // `nub run`'s preamble — same seam, extended to the PM reporter/loglevel.
 //
 // `0` is "unset" for each enum; the encodings are private to this module.
+// Pre-verb `--silent`/`-s` folds into `PROC_REPORTER = Silent` (it's the
+// documented `--reporter=silent` alias) so all three pre-verb spellings merge
+// through the SAME `.or` path and a per-verb `--reporter` can override any of
+// them uniformly — there is no separate silent cell.
 static PROC_REPORTER: AtomicU8 = AtomicU8::new(0);
 static PROC_LOGLEVEL: AtomicU8 = AtomicU8::new(0);
-static PROC_SILENT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 fn reporter_to_u8(r: Reporter) -> u8 {
     match r {
@@ -78,29 +81,31 @@ fn u8_to_loglevel(v: u8) -> Option<LogLevel> {
     }
 }
 
-/// Record `nub --silent <verb>` as a process default. Called by `cli::dispatch`
-/// when the global `--silent`/`-s` precedes a subcommand.
+/// Record `nub --silent <verb>` as a process default — the `--reporter=silent`
+/// alias, so it merges through the same `.or` path as a pre-verb `--reporter`.
+/// Called by `cli::dispatch` when the global `--silent`/`-s` precedes a verb.
 pub fn set_global_silent() {
-    PROC_SILENT.store(true, Ordering::Relaxed);
+    PROC_REPORTER.store(reporter_to_u8(Reporter::Silent), Ordering::Relaxed);
 }
 
 /// Parse + record a pre-verb `--reporter <value>` as a process default. Returns
 /// the invalid value (for a clean usage error) when the spelling isn't one of
 /// `default`/`append-only`/`silent`. Reuses clap's `ValueEnum` parse so the
-/// accepted set can't drift from the per-verb flag.
+/// accepted set can't drift from the per-verb flag — `false` = case-sensitive,
+/// matching the per-verb clap surface (which has no `ignore_case`).
 pub fn set_global_reporter_str(value: &str) -> Result<(), String> {
     use clap::ValueEnum as _;
-    let r = Reporter::from_str(value, true).map_err(|_| value.to_string())?;
+    let r = Reporter::from_str(value, false).map_err(|_| value.to_string())?;
     PROC_REPORTER.store(reporter_to_u8(r), Ordering::Relaxed);
     Ok(())
 }
 
 /// Parse + record a pre-verb `--loglevel <value>` as a process default. Returns
 /// the invalid value when the spelling isn't one of
-/// `silent`/`error`/`warn`/`info`/`debug`.
+/// `silent`/`error`/`warn`/`info`/`debug`. Case-sensitive, matching per-verb.
 pub fn set_global_loglevel_str(value: &str) -> Result<(), String> {
     use clap::ValueEnum as _;
-    let l = LogLevel::from_str(value, true).map_err(|_| value.to_string())?;
+    let l = LogLevel::from_str(value, false).map_err(|_| value.to_string())?;
     PROC_LOGLEVEL.store(loglevel_to_u8(l), Ordering::Relaxed);
     Ok(())
 }
@@ -110,9 +115,6 @@ fn proc_reporter() -> Option<Reporter> {
 }
 fn proc_loglevel() -> Option<LogLevel> {
     u8_to_loglevel(PROC_LOGLEVEL.load(Ordering::Relaxed))
-}
-fn proc_silent() -> bool {
-    PROC_SILENT.load(Ordering::Relaxed)
 }
 
 /// `--reporter` values nub accepts, mirroring pnpm's. `ndjson` is deliberately
@@ -180,7 +182,6 @@ impl OutputFlags {
     /// their own (non-engine) summary — e.g. `import` — can suppress it.
     pub fn is_silent(&self) -> bool {
         self.silent
-            || proc_silent()
             || self.eff_reporter() == Some(Reporter::Silent)
             || self.eff_loglevel() == Some(LogLevel::Silent)
     }

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -169,12 +169,18 @@ fn install_silent_flag_suppresses_all_nonerror_output() {
          over-silencing): got empty output"
     );
 
-    // Every silent spelling produces empty stderr while still linking the dep.
+    // Every silent spelling produces empty stderr while still linking the dep —
+    // both AFTER the verb (per-verb clap surface) and BEFORE it (the pre-verb
+    // global position, recorded as a process default in cli::dispatch).
     for form in [
         &["install", "--silent"][..],
         &["install", "-s"][..],
         &["install", "--reporter=silent"][..],
         &["install", "--loglevel=silent"][..],
+        &["--silent", "install"][..],
+        &["-s", "install"][..],
+        &["--reporter=silent", "install"][..],
+        &["--loglevel=silent", "install"][..],
     ] {
         let dir = pm_tmpdir(&format!("silent-{}", form.join("-").replace('=', "")));
         std::fs::write(dir.join("package.json"), manifest).unwrap();
@@ -187,6 +193,37 @@ fn install_silent_flag_suppresses_all_nonerror_output() {
         assert!(
             dir.join("node_modules/is-positive/package.json").is_file(),
             "nub {form:?} still installs the dependency"
+        );
+    }
+}
+
+/// Regression (non-network): a PRE-verb `--reporter`/`--loglevel`/`--silent`
+/// reaches the PM verb instead of falling through the dispatch scan to the file
+/// runner — which shipped it to Node as `node: bad option: --reporter=silent`
+/// before the fix. A no-dependency manifest installs fully offline, so the only
+/// thing under test is that the global form parses and dispatches to `install`.
+#[test]
+fn pre_verb_output_flags_reach_install_not_node() {
+    for form in [
+        &["--reporter=silent", "install"][..],
+        &["--loglevel=error", "install"][..],
+        &["--silent", "install"][..],
+    ] {
+        let dir = pm_tmpdir(&format!("preverb-{}", form.join("-").replace('=', "")));
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"q","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        let (stdout, stderr, code) = run_install(&dir, form);
+        let combined = format!("{stdout}\n{stderr}");
+        assert!(
+            !combined.contains("bad option") && !combined.contains("is not a nub command"),
+            "nub {form:?} misrouted instead of dispatching to install: {combined}"
+        );
+        assert_eq!(
+            code, 0,
+            "nub {form:?} (no deps) should install cleanly offline: {combined}"
         );
     }
 }

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -228,6 +228,36 @@ fn pre_verb_output_flags_reach_install_not_node() {
     }
 }
 
+/// Precedence (non-network): a per-verb `--reporter` overrides a PRE-verb
+/// `--silent`. `--silent` folds into the same `--reporter=silent` process
+/// default as a pre-verb `--reporter`, so the "per-verb always wins" invariant
+/// holds for every pre-verb spelling — a pre-verb global is only a fallback.
+#[test]
+fn per_verb_reporter_overrides_pre_verb_silent() {
+    let manifest = r#"{"name":"q","version":"1.0.0"}"#;
+
+    // Pre-verb --silent alone silences (empty stderr).
+    let quiet = pm_tmpdir("prec-quiet");
+    std::fs::write(quiet.join("package.json"), manifest).unwrap();
+    let (_, s1, c1) = run_install(&quiet, &["--silent", "install"]);
+    assert_eq!(c1, 0, "pre-verb --silent install failed: {s1}");
+    assert!(
+        s1.is_empty(),
+        "pre-verb --silent should silence, got: {s1:?}"
+    );
+
+    // A per-verb --reporter=default un-silences it: per-verb wins over the
+    // pre-verb default.
+    let loud = pm_tmpdir("prec-loud");
+    std::fs::write(loud.join("package.json"), manifest).unwrap();
+    let (_, s2, c2) = run_install(&loud, &["--silent", "install", "--reporter=default"]);
+    assert_eq!(c2, 0, "install failed: {s2}");
+    assert!(
+        !s2.trim().is_empty(),
+        "per-verb --reporter=default must override pre-verb --silent: got empty stderr"
+    );
+}
+
 /// A `pnpm-workspace.yaml` with no lockfile is a genuine pnpm signal, NOT a
 /// truly-fresh project: nub stays pnpm-shaped — writes `pnpm-lock.yaml` and
 /// does NOT stamp the manifest.

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -258,7 +258,7 @@ The accepted flags are pnpm's spellings:
 --loglevel <level>    # debug, info, warn, error, silent
 ```
 
-To quiet the progress output, pass `--silent` (or `-s`, or `--reporter=silent`): nothing reaches stderr but a fatal error, matching `pnpm install --silent`. The `--reporter=append-only` form drops the live progress display while keeping the dependency summary, and `--loglevel error` hides warnings without touching the rest. These spellings apply to every install-family command — `install`, `ci`, `add`, `remove`, `update`, `dedupe`, `import`.
+To quiet the progress output, pass `--silent` (or `-s`, or `--reporter=silent`): nothing reaches stderr but a fatal error, matching `pnpm install --silent`. The `--reporter=append-only` form drops the live progress display while keeping the dependency summary, and `--loglevel error` hides warnings without touching the rest. These spellings apply to every install-family command — `install`, `ci`, `add`, `remove`, `update`, `dedupe`, `import` — and work either after the command (`nub install --silent`) or before it (`nub --silent install`).
 
 In a workspace, `install` and `ci` accept the same selector flags as script running — install only the packages a filter matches:
 


### PR DESCRIPTION
## What

#183 wired the PM output flags (`--reporter=<default|append-only|silent>`, `--silent`/`-s`, `--loglevel`) onto every install-family verb in the per-verb position (`nub install --silent`). The same flags **before** the verb were broken:

- `nub --silent install` ran noisily (the global `--silent` only drove `nub run`'s preamble).
- `nub --reporter=silent install` fell through the dispatch scan to the file runner → `node: bad option: --reporter=silent`, exit 9, install never ran.

The originally-reported per-verb P0 was already fixed by #183 (that repro was on v0.2.3, which predates it). This closes the global-position gap.

## How

`cli::dispatch`'s pre-verb scan now recognizes `--reporter`/`--loglevel` (captured, not leaked to Node) and records them — plus `--silent`/`-s` — as process defaults (atomics in `pm_engine::output`), mirroring the existing `SILENT` atomic. `OutputFlags` merges the per-verb flag over the default (per-verb wins). Invalid values give a clean usage error. `run` keeps its own per-run `--reporter`; the PM defaults are inert there.

## Maintainer-owned bit

run and PM have different `--reporter` vocabularies (`default/silent/ndjson` vs `default/append-only/silent`), so this deliberately does **not** add a single unified global `--reporter` ValueEnum. Unifying them (pnpm's full set is `default/append-only/ndjson/silent`) is a larger follow-up you own.

## Verified

Dev binary, byte-measured stderr: per-verb unchanged; `nub --silent install` / `-s install` / `--reporter=silent install` / `--loglevel=silent install` / `--silent add …` → empty stderr, dep linked, exit 0; `pnpm install --silent` parity = 0 bytes; global silent + install error still prints the error; append-only drops the footer keeps the dep list; `nub run` unaffected. Gates: clippy `--all-targets --all-features -D warnings` + fmt clean; output/cli/install_engine/grammar-parity tests pass. Non-network regression test `pre_verb_output_flags_reach_install_not_node` guards the misroute.

Refs #179
