### PR TITLE
fix(spawn): use `as _` for the TIOCSCTTY ioctl request cast (musl compile)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,10 +201,11 @@ jobs:
   # verify logic is pure-Rust (fs::read + blake3 + libc::geteuid / symlink_metadata),
   # identical on musl — and the musl RUNTIME is exercised by the `Docker smoke (musl,
   # node:22-alpine)` leg + release.yml's musl binary build. (A standalone `cargo test
-  # --target x86_64-unknown-linux-musl` leg was attempted but blocked by a PRE-EXISTING,
-  # unrelated musl-compile error in spawn.rs's PTY ioctl — `libc::TIOCSCTTY as c_ulong`,
-  # where libc's Ioctl request type is c_int on musl vs c_ulong on glibc — which is a
-  # separate fix outside this integrity change.) The addon is gitignored (built locally
+  # --target x86_64-unknown-linux-musl` leg was once blocked by a musl-compile error in
+  # spawn.rs's PTY ioctl — `libc::TIOCSCTTY as c_ulong`, where libc types the ioctl
+  # request as c_int on musl vs c_ulong on glibc; fixed to `as _` so inference picks the
+  # per-target type. It was test-only, so the released musl binary was never affected.)
+  # The addon is gitignored (built locally
   # / staged in release.yml), so a placeholder is staged so build.rs's three-entrypoint
   # hash set is complete; it is never dlopen'd here (the tests verify hash CONSISTENCY —
   # baked == extracted — not native loading).

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -2198,7 +2198,7 @@ mod tests {
             if libc::setsid() < 0 {
                 return 2;
             }
-            libc::ioctl(slave, libc::TIOCSCTTY as libc::c_ulong, 0);
+            libc::ioctl(slave, libc::TIOCSCTTY as _, 0);
             libc::dup2(slave, libc::STDIN_FILENO);
             if slave > 2 {
                 libc::close(slave);
@@ -2327,7 +2327,7 @@ mod tests {
             if libc::setsid() < 0 {
                 return 2;
             }
-            libc::ioctl(slave, libc::TIOCSCTTY as libc::c_ulong, 0);
+            libc::ioctl(slave, libc::TIOCSCTTY as _, 0);
             libc::dup2(slave, libc::STDIN_FILENO);
             if slave > 2 {
                 libc::close(slave);


### PR DESCRIPTION
Two PTY test workers in `spawn.rs` cast `libc::TIOCSCTTY as libc::c_ulong`. libc types the `ioctl` request as `c_int` on musl vs `c_ulong` on glibc, so it fails to compile for `x86_64-unknown-linux-musl` (`E0308: expected i32, found u64`). Surfaced by #182s dropped `embed-runtime-musl` leg.

Not release-blocking: both sites are inside `#[cfg(test)] mod tests`, excluded from release builds — only `cargo test`/`check --tests` for musl hit it.

Fix: `as _`, so inference picks the per-target type. Default-preserving on glibc.

Verified: musl Docker repro shows old cast errors, `as _` compiles on musl + glibc; local glibc clippy/fmt/test green.