### PR TITLE
fix(pm): close the Windows drive-letter store-path escape in PM provisioning (F0c residual)

### DIFF
--- a/crates/nub-core/src/pm/provision.rs
+++ b/crates/nub-core/src/pm/provision.rs
@@ -31,6 +31,30 @@ pub struct ProvisionedPm {
     pub version: String,
 }
 
+/// Join a registry-resolved version onto the PM store dir, asserting the result
+/// stays UNDER the store. The STRUCTURAL half of the F0c containment, paired with
+/// [`registry::validate_version`]'s char-blocklist: an ABSOLUTE or DRIVE-prefixed
+/// version (`C:foo` on Windows) makes `Path::join` DISCARD the base and escape the
+/// store, so the bin nub then writes + EXECUTES would land outside `<store>/pm/<pm>/`.
+/// This is the exact escape class a char-blocklist is most apt to miss a
+/// metacharacter for (the Windows `:` slipped through once). `validate_version`
+/// already rejects those at resolution, so in practice this never fires — it is
+/// belt-and-suspenders. The two layers are complementary: this catches the
+/// base-discarding join (absolute/drive), while the separator/`..` class stays with
+/// `validate_version` (`PathBuf::starts_with` is a lexical component-prefix and does
+/// NOT normalize `..`, so it is not a traversal guard on its own — but it is
+/// component-wise, so a sibling-prefix dir like `…/pm-evil` does not spuriously pass).
+fn store_version_dir(pm_store: &Path, version: &str) -> Result<PathBuf> {
+    let dir = pm_store.join(version);
+    if !dir.starts_with(pm_store) {
+        bail!(
+            "refusing to use {version:?} as a store path component — it escapes {}",
+            pm_store.display()
+        );
+    }
+    Ok(dir)
+}
+
 /// Download + verify + extract the pinned package manager into nub's store,
 /// returning its runnable bin. Flow mirrors [`provision_node`]:
 ///   1. split any Corepack `+<algo>.<hex>` pin hash off the pinned version (the
@@ -143,7 +167,7 @@ pub fn provision_pm_announced(
         cb(&dist.version);
     }
 
-    let final_dir = pm_store.join(&dist.version);
+    let final_dir = store_version_dir(&pm_store, &dist.version)?;
     let bin = final_dir.join("package").join(&dist.bin_subpath);
     if bin.is_file() {
         return Ok(ProvisionedPm {
@@ -206,7 +230,7 @@ pub fn provision_pm_from_tarball(
     store_root: &Path,
 ) -> Result<ProvisionedPm> {
     let pm_store = store_root.join("pm").join(pm.to_string());
-    let final_dir = pm_store.join(&dist.version);
+    let final_dir = store_version_dir(&pm_store, &dist.version)?;
     let bin = final_dir.join("package").join(&dist.bin_subpath);
 
     // Cache hit on the exact resolved version → done, zero work (the warm re-pin
@@ -509,6 +533,23 @@ impl Drop for WorkGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// F0c structural backstop: a legit version stays under the store; an absolute
+    /// component (the cross-platform stand-in for the Windows `C:foo` drive-relative
+    /// escape, where `Path::join` discards the base) is refused. `validate_version`
+    /// blocks both before they reach here — this proves the second line of defense.
+    #[test]
+    fn store_version_dir_contains_legit_and_rejects_a_base_discarding_join() {
+        let store = Path::new("/var/cache/nub/pm/pnpm");
+        assert_eq!(
+            store_version_dir(store, "11.9.0").unwrap(),
+            store.join("11.9.0")
+        );
+        assert!(
+            store_version_dir(store, "/etc/evil").is_err(),
+            "an absolute version makes join discard the base — must be refused"
+        );
+    }
     use crate::pm::Pm;
 
     #[test]

--- a/crates/nub-core/src/pm/registry.rs
+++ b/crates/nub-core/src/pm/registry.rs
@@ -432,6 +432,19 @@ pub(crate) fn normalize_range(spec: &str) -> String {
 /// (nub-core has no aube dep, so the char-blocklist is restated here, the same
 /// way [`safe_bin_subpath`] mirrors aube's bin-path guard): reject path
 /// separators on any platform, NUL, control chars, and the `.`/`..` dir aliases.
+///
+/// nub-core is deliberately STRICTER than aube-store on one byte — it also rejects
+/// `:`. The two guards have different input domains. aube-store's `version` slot
+/// can carry non-semver specs (git URLs, npm aliases, file specs) that legitimately
+/// contain `:`, so blocking it there would break real installs. nub-core's
+/// `version` is always a CONCRETE PUBLISHED npm version: every branch of
+/// [`resolve_dist`] passes a `versions[..]` KEY (npm publishes are semver), which
+/// never contains `:`. Blocking it here costs nothing and closes a real escape — on
+/// Windows `Path::join` treats a drive-prefixed component (`C:foo`) as drive-relative
+/// and DISCARDS the base, so `<store>/pm/<pm>` joined with `C:foo` resolves to
+/// `C:foo` (CWD on drive C:), relocating the written + executed PM bin outside the
+/// store. `/` and `\` were already blocked, so `:` was the last Windows
+/// separator-equivalent the blocklist missed.
 /// A normal semver — `9.5.0`, `11.0.0-rc.1` — passes untouched.
 fn validate_version(version: &str) -> bool {
     if version.is_empty() || version.len() > 256 {
@@ -439,7 +452,7 @@ fn validate_version(version: &str) -> bool {
     }
     if version
         .bytes()
-        .any(|b| b.is_ascii_control() || matches!(b, b'/' | b'\\' | b'\0'))
+        .any(|b| b.is_ascii_control() || matches!(b, b'/' | b'\\' | b':' | b'\0'))
     {
         return false;
     }
@@ -908,6 +921,13 @@ mod tests {
             "x\u{0}y",
             "ctrl\u{7}x",
             "",
+            // F0c (Windows): a drive-prefixed version is drive-RELATIVE under
+            // `Path::join` (it discards the store base), so `:` must be rejected
+            // just like `/` and `\`.
+            "C:foo",
+            "C:",
+            "C:\\windows\\system32",
+            "npm:alias@1.0.0",
         ] {
             assert!(
                 !validate_version(bad),


### PR DESCRIPTION
Post-merge review of #190 found one residual in the F0c guard: `validate_version` didn't block `:`, so on Windows a drive-prefixed version (`C:foo`) makes `Path::join` discard the base and escape the store — a malicious-registry dist-tag could relocate the executed PM bin. Windows-only, drive-relative, registry-gated.

Fix: block `:` in nub-core's `validate_version` (always a concrete published semver; aube-store stays permissive for its git/alias version slots — no parity break) plus a `store_version_dir` containment backstop.

The other four lenses and the bot reviews were clean. Gates green: clippy --all-targets --all-features, fmt, nub-core lib 313, real pnpm/Node e2e.

Refs #172; follow-up to #190.
