### PR TITLE
fix(pm): scope lockfile-ambiguity guard to the mutating install family

### DIFF
--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -527,7 +527,10 @@ fn run_dlx(typed: &str, args: &[String]) -> Result<i32> {
         println!("{}", present::rewrite_help(help.to_string().trim_end()));
         return Ok(0);
     }
-    let session = super::engine_session(globals.dir.as_deref())?;
+    // Transient fetch-and-run (see `engine_session_transient`): a dlx never
+    // touches the CWD project's lockfile, so a multi-lockfile project must not
+    // hard-error on identity ambiguity — it degrades to no-identity here.
+    let session = super::engine_session_transient(globals.dir.as_deref())?;
     // NOTE: on child failure the engine propagates the child's exit code via
     // std::process::exit — control does not return here on that path. Output
     // flags quiet the fetch; the run tool's own output is preserved (the
@@ -563,7 +566,11 @@ pub fn run_dlx_for_nubx(
         clx::progress::set_output(clx::progress::ProgressOutput::Text);
     }
     let verb = nubx_dlx_args(bin, args, flags);
-    let session = super::engine_session(None)?;
+    // Transient fetch-and-run (see `engine_session_transient`): `nubx <tool>`
+    // fetches a throwaway package and runs it; the CWD project's lockfile is
+    // irrelevant, so a multi-lockfile project must not raise
+    // ERR_NUB_LOCKFILE_AMBIGUOUS the way npm/pnpm/bun's npx/dlx/bunx don't.
+    let session = super::engine_session_transient(None)?;
     // NOTE: on child failure the engine propagates the child's exit code via
     // std::process::exit — control does not return here on that path.
     finish_code(session.runtime.block_on(aube::commands::dlx::run(verb)))
@@ -607,7 +614,10 @@ fn run_create(typed: &str, args: &[String]) -> Result<i32> {
         println!("{}", present::rewrite_help(help.to_string().trim_end()));
         return Ok(0);
     }
-    let session = super::engine_session(globals.dir.as_deref())?;
+    // Transient: `nub create` chains into dlx (fetch the create-* package and
+    // run it), so like dlx it must not hard-error on the CWD project's
+    // lockfile ambiguity (see `engine_session_transient`).
+    let session = super::engine_session_transient(globals.dir.as_deref())?;
     // The engine maps the template to its create-* package (foo → create-foo,
     // @scope/foo → @scope/create-foo) and chains into dlx; like dlx, on child
     // failure the engine propagates the exit code via std::process::exit.

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -603,7 +603,22 @@ pub(crate) struct EngineSession {
 /// land after it (they feed settings resolution, which no detection-path
 /// code consults).
 pub(crate) fn engine_session(dir: Option<&Path>) -> Result<EngineSession> {
-    engine_session_inner(dir, ConfigScopeNoise::Warn)
+    engine_session_inner(dir, ConfigScopeNoise::Warn, IdentityStrictness::Strict)
+}
+
+/// [`engine_session`] for the TRANSIENT-package families (`nubx`/`dlx`,
+/// plain `exec` dlx-fallback, `create`). These fetch-and-run a package into a
+/// throwaway store and never read or write the CWD project's lockfile, so the
+/// project's PM identity is irrelevant to them. Identity resolution therefore
+/// runs in LENIENT mode: a multi-lockfile / declaration-contradiction project
+/// degrades to no-identity (engine defaults) instead of hard-erroring with
+/// `ERR_NUB_LOCKFILE_AMBIGUOUS`. npm/pnpm/bun likewise run `npx`/`dlx`/`bunx`
+/// regardless of lockfile ambiguity — the ambiguity guard belongs only to the
+/// mutating install family that actually writes a lockfile. Config-scoping
+/// warnings are suppressed (Silent) for the same reason: the CWD project's
+/// config does not shape a transient run.
+pub(crate) fn engine_session_transient(dir: Option<&Path>) -> Result<EngineSession> {
+    engine_session_inner(dir, ConfigScopeNoise::Silent, IdentityStrictness::Lenient)
 }
 
 /// [`engine_session`] for the read-only / non-graph-mutating families
@@ -614,7 +629,20 @@ pub(crate) fn engine_session(dir: Option<&Path>) -> Result<EngineSession> {
 /// install-time UX, and surfacing them on a `nub why` would be noise. See
 /// the config-scoping policy ([`config_scope`]).
 pub(crate) fn engine_session_quiet(dir: Option<&Path>) -> Result<EngineSession> {
-    engine_session_inner(dir, ConfigScopeNoise::Silent)
+    engine_session_inner(dir, ConfigScopeNoise::Silent, IdentityStrictness::Strict)
+}
+
+/// Whether an identity-resolution failure (multi-lockfile ambiguity, declared
+/// PM contradicted by the on-disk lockfile) is a HARD ERROR or degrades to
+/// no-identity. `Strict` — the default for every project-reading/-writing
+/// family — surfaces the loud diagnostic with the `nub pm use` remedy.
+/// `Lenient` — the transient-package families (dlx/create) — swallows it and
+/// proceeds with no resolved identity, because those commands never touch the
+/// CWD project's lockfile (see [`engine_session_transient`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IdentityStrictness {
+    Strict,
+    Lenient,
 }
 
 /// Whether [`engine_session_inner`] emits the config-scoping warnings and
@@ -626,7 +654,11 @@ enum ConfigScopeNoise {
     Silent,
 }
 
-fn engine_session_inner(dir: Option<&Path>, noise: ConfigScopeNoise) -> Result<EngineSession> {
+fn engine_session_inner(
+    dir: Option<&Path>,
+    noise: ConfigScopeNoise,
+    strictness: IdentityStrictness,
+) -> Result<EngineSession> {
     // Initialize the diagnostics recorder from AUBE_DIAG_* env vars so that
     // `AUBE_DIAG_SUMMARY=1 nub install` works the same as `AUBE_DIAG_SUMMARY=1
     // aube install`. The OnceLock inside diag::init() makes this idempotent.
@@ -640,7 +672,7 @@ fn engine_session_inner(dir: Option<&Path>, noise: ConfigScopeNoise) -> Result<E
     apply_dir(dir)?;
     engine_brand_preflight();
     let cwd = std::env::current_dir()?;
-    let detected = resolve_identity_walk_up(&cwd)?;
+    let detected = resolve_identity_walk_up(&cwd, strictness)?;
     // Role-first lifecycle UA (two-mode model, the maintainer 2026-06-10): in compat
     // mode nub plays the incumbent PM's role completely, so the UA dep
     // postinstalls sniff leads with that PM's token (`pnpm/<ver> nub/<ver>
@@ -1060,7 +1092,9 @@ fn lifecycle_ua_product(detected: Option<&DetectedLockfile>, cwd: &Path) -> Stri
 /// (a malformed/ambiguous lockfile is surfaced loudly elsewhere; the UA must
 /// never panic a script spawn).
 pub(crate) fn run_lifecycle_ua_product(cwd: &Path, node_version: &str) -> String {
-    let detected = resolve_identity_walk_up(cwd).ok().flatten();
+    let detected = resolve_identity_walk_up(cwd, IdentityStrictness::Lenient)
+        .ok()
+        .flatten();
     compose_lifecycle_ua(
         nub_core::pm::resolve::declared_pm_raw(cwd),
         detected.map(|d| d.kind),
@@ -1233,7 +1267,10 @@ pub(crate) struct DetectedLockfile {
 /// engine's declaration-aware policy applies — declaration first, lockfile
 /// inference second; contradiction/ambiguity are loud errors carrying the
 /// `nub pm use` remedy.
-fn resolve_identity_walk_up(cwd: &Path) -> Result<Option<DetectedLockfile>> {
+fn resolve_identity_walk_up(
+    cwd: &Path,
+    strictness: IdentityStrictness,
+) -> Result<Option<DetectedLockfile>> {
     use aube_lockfile::ResolvedLockfileKind;
     let mut dir = cwd.to_path_buf();
     for _ in 0..16 {
@@ -1254,6 +1291,12 @@ fn resolve_identity_walk_up(cwd: &Path) -> Result<Option<DetectedLockfile>> {
             }
             // Nothing at this level decides the identity — keep walking.
             Ok(ResolvedLockfileKind::Fresh) => {}
+            // An ambiguity / declaration-contradiction is a HARD error only
+            // for the project-touching families (Strict). The transient
+            // fetch-and-run families (Lenient) never read or write the CWD
+            // lockfile, so the ambiguity is irrelevant — degrade to
+            // no-identity and let the engine's fresh-project defaults stand.
+            Err(_) if strictness == IdentityStrictness::Lenient => return Ok(None),
             Err(err) => return Err(identity_error(err)),
         }
         if !dir.pop() {

--- a/crates/nub-cli/tests/pm_identity.rs
+++ b/crates/nub-cli/tests/pm_identity.rs
@@ -195,6 +195,74 @@ fn undeclared_multi_lockfile_projects_error_as_ambiguous() {
     );
 }
 
+/// The over-scope regression (maintainer report 2026-06-26): the ambiguity
+/// guard belongs ONLY to the mutating install family that writes a lockfile.
+/// A TRANSIENT fetch-and-run — `nubx <tool>` / `nub dlx <tool>` — never touches
+/// the project's lockfile, so a multi-lockfile project must run it without the
+/// `ERR_NUB_LOCKFILE_AMBIGUOUS` hard error (matching `npx`/`pnpm dlx`/`bunx`).
+/// The mutating-side guard stays proven by
+/// [`undeclared_multi_lockfile_projects_error_as_ambiguous`].
+#[test]
+fn transient_runs_do_not_error_on_multi_lockfile_projects() {
+    let dir = project("ambiguous-transient", r#"{"name":"app","version":"1.0.0"}"#);
+    std::fs::write(
+        dir.join("package-lock.json"),
+        r#"{"name":"app","version":"1.0.0","lockfileVersion":3,"requires":true,"packages":{}}"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("yarn.lock"), "# yarn lockfile v1\n").unwrap();
+    // These arms get PAST identity and reach the (dead-port) registry; drop the
+    // retry backoff so the fetch fails fast instead of sleeping ~70s.
+    std::fs::write(
+        dir.join(".npmrc"),
+        "registry=http://127.0.0.1:1/\nfetch-retries=0\n",
+    )
+    .unwrap();
+
+    // `nub dlx <tool>`: the dead-port registry (see `project`) makes the fetch
+    // itself fail, but the point is the command gets PAST identity resolution —
+    // no ambiguity hard-error in preflight, where it used to die.
+    let (_, stderr, _) = run(&dir, &["dlx", "cowsay"]);
+    assert!(
+        !stderr.contains("ERR_NUB_LOCKFILE_AMBIGUOUS"),
+        "dlx must not raise the ambiguity guard in a multi-lockfile project: {stderr}"
+    );
+    // Positive proof it cleared the identity preflight and reached the (dead-port)
+    // registry, rather than no-op-passing on some unrelated early exit.
+    assert!(
+        stderr.contains("ERR_NUB_REGISTRY_ERROR"),
+        "dlx should get past identity to the registry fetch: {stderr}"
+    );
+
+    // The reported repro, exactly: invoked as `nubx`. argv0 dispatch selects the
+    // nubx entry point from a symlink named `nubx`. (Unix-only — Windows symlink
+    // creation needs privilege; the `dlx` arm above already covers the same
+    // transient session on every platform.)
+    #[cfg(unix)]
+    {
+        let nubx = dir.join("nubx");
+        std::os::unix::fs::symlink(nub_binary(), &nubx).unwrap();
+        let out = Command::new(&nubx)
+            .args(["cowsay", "hi"])
+            .current_dir(&dir)
+            .env("XDG_DATA_HOME", dir.join("xdg-data"))
+            .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
+            .output()
+            .expect("failed to spawn nubx");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !stderr.contains("ERR_NUB_LOCKFILE_AMBIGUOUS"),
+            "nubx must not raise the ambiguity guard in a multi-lockfile project: {stderr}"
+        );
+        // Confirms argv0 actually routed to the nubx DLX fallback (not an
+        // unrelated help/early exit that would no-op-pass the assert above).
+        assert!(
+            stderr.contains("ERR_NUB_REGISTRY_ERROR"),
+            "nubx should get past identity to the registry fetch: {stderr}"
+        );
+    }
+}
+
 /// The declared-yarn corner of the fresh row: identity resolves to yarn with
 /// no yarn.lock on disk, and the first install would CREATE yarn.lock — the
 /// gated write. Refused with the gate message, nothing written.


### PR DESCRIPTION
`nubx cowsay hi` (and `nub dlx`/`nub create`) errored with `ERR_NUB_LOCKFILE_AMBIGUOUS` ("multiple lockfiles found: …") in a project that has multiple lockfiles. npm/pnpm/bun do not error on `npx`/`dlx`/`bunx` in this situation.

Root cause: the transient fetch-and-run verbs shared the same identity-resolution preflight (`engine_session` → `resolve_identity_walk_up` → `identity_error`) as the mutating install family that actually writes a lockfile. A dlx/nubx/create run never reads or writes the project lockfile, so lockfile ambiguity is irrelevant to it.

The fix adds an identity-strictness axis to the engine session:

- `engine_session_transient` (Lenient) — `dlx`, `nubx`, `create`: an ambiguity / declaration-contradiction degrades to no-identity (the same well-trodden fresh-project path) instead of hard-erroring. The transient run then proceeds (and fails downstream only for real reasons, e.g. a registry error).
- `engine_session` / `engine_session_quiet` (Strict) — `install`/`ci`/`add`/`remove`/`update`/`dedupe` and the project-reading families keep the hard error, since they operate on the project's lockfile and cannot proceed without a resolved identity.

`run`/`watch`/`nub <file>` never hit this path.

Regression test `transient_runs_do_not_error_on_multi_lockfile_projects` (`tests/pm_identity.rs`): a multi-lockfile fixture runs `nub dlx` and a `nubx` argv0 symlink without the ambiguity error (reaching the registry instead); the existing `undeclared_multi_lockfile_projects_error_as_ambiguous` continues to prove the mutating guard.

Verified locally: `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `cargo test -p nub-cli --test pm_identity` (7/7). End-to-end on a 3-lockfile fixture: `nubx`/`dlx`/`run`/`nub <file>` succeed; `install`/`add`/`remove`/`update`/`dedupe`/`ci` still raise the ambiguity error.

https://claude.ai/code/session_01DnwgDLy5Tay9vsL544STPe