### PR TITLE
fix(pm): scope lockfile-ambiguity guard off global-scope read commands

### DIFF
--- a/crates/nub-cli/src/pm_engine/info_family.rs
+++ b/crates/nub-cli/src/pm_engine/info_family.rs
@@ -484,8 +484,10 @@ fn run_view(typed: &str, args: &[String]) -> Result<i32> {
         Parsed::Args(c) => c,
         Parsed::Done(code) => return Ok(code),
     };
-    let session = super::engine_session_quiet(cli.dir.as_deref())?;
-    // Pure registry query: no lockfile involvement at all.
+    // Pure registry query: no lockfile involvement at all, so identity
+    // resolution is lenient (see `engine_session_global`) — a multi-lockfile
+    // project must not block `nub view <pkg>`.
+    let session = super::engine_session_global(cli.dir.as_deref())?;
     finish(
         session
             .runtime
@@ -524,9 +526,10 @@ fn run_bin(typed: &str, args: &[String]) -> Result<i32> {
         Parsed::Args(c) => c,
         Parsed::Done(code) => return Ok(code),
     };
-    let session = super::engine_session_quiet(cli.dir.as_deref())?;
     // Pure path print (`<modulesDir>/.bin`, or the global bin dir under
-    // `-g`); the directory need not exist.
+    // `-g`); the directory need not exist and no lockfile is read, so identity
+    // resolution is lenient (see `engine_session_global`).
+    let session = super::engine_session_global(cli.dir.as_deref())?;
     finish(session.runtime.block_on(aube::commands::bin::run(cli.args)))
 }
 
@@ -535,8 +538,10 @@ fn run_root(typed: &str, args: &[String]) -> Result<i32> {
         Parsed::Args(c) => c,
         Parsed::Done(code) => return Ok(code),
     };
-    let session = super::engine_session_quiet(cli.dir.as_deref())?;
-    // Pure path print (`<modulesDir>`, or the global package dir under `-g`).
+    // Pure path print (`<modulesDir>`, or the global package dir under `-g`);
+    // no lockfile is read, so identity resolution is lenient (see
+    // `engine_session_global`).
+    let session = super::engine_session_global(cli.dir.as_deref())?;
     finish(
         session
             .runtime

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -624,24 +624,49 @@ pub(crate) fn engine_session_transient(dir: Option<&Path>) -> Result<EngineSessi
     engine_session_inner(dir, ConfigScopeNoise::Silent, IdentityStrictness::Lenient)
 }
 
-/// [`engine_session`] for the read-only / non-graph-mutating families
-/// (info, publish, store-config). The config-scoping FILTER still applies —
-/// `why` / `outdated` should reflect the same effective override set a real
-/// install would — but the user-facing scoping *warnings* and the
-/// `catalog:`-under-the-wrong-PM hard error are suppressed: those are
-/// install-time UX, and surfacing them on a `nub why` would be noise. See
-/// the config-scoping policy ([`config_scope`]).
+/// [`engine_session`] for the read-only PROJECT-GRAPH families that resolve
+/// the project's dependency tree from its lockfile (`list`, `why`, `outdated`,
+/// `query`, `audit`, `licenses`, `deprecations`, `peers`, `check`). The
+/// config-scoping FILTER still applies — `why` / `outdated` should reflect the
+/// same effective override set a real install would — but the user-facing
+/// scoping *warnings* and the `catalog:`-under-the-wrong-PM hard error are
+/// suppressed: those are install-time UX, and surfacing them on a `nub why`
+/// would be noise. Identity resolution stays STRICT: these commands READ the
+/// project lockfile, so a multi-lockfile ambiguity must be a loud error — a
+/// silent degrade to no-identity would yield an empty/wrong graph. See the
+/// config-scoping policy ([`config_scope`]).
 pub(crate) fn engine_session_quiet(dir: Option<&Path>) -> Result<EngineSession> {
     engine_session_inner(dir, ConfigScopeNoise::Silent, IdentityStrictness::Strict)
+}
+
+/// [`engine_session_quiet`] for GLOBAL-SCOPE commands that never read or write
+/// the project's lockfile: the global store/cache forensics (`store`, `cache`,
+/// `cat-file`, `cat-index`, `find-hash`), config get/set, the registry/auth
+/// surface (`publish`, `pack`, `version`, `deprecate`/`undeprecate`,
+/// `dist-tag`, `unpublish`, `login`/`logout`, `whoami`, `owner`, `token`),
+/// package.json edits (`pkg`, `set-script`), and the pure registry-query /
+/// path-print verbs (`view`, `search`, `bin`, `root`). Because none of these
+/// consume the project's resolved PM identity, a multi-lockfile /
+/// declaration-contradiction project must NOT block them — identity resolution
+/// runs LENIENT (degrades to no-identity instead of hard-erroring
+/// `ERR_NUB_LOCKFILE_AMBIGUOUS`), exactly like the transient dlx path (#197).
+/// This is the same `IdentityStrictness` machinery, applied to the global-scope
+/// read class rather than the transient fetch-and-run class. The STRICT
+/// ambiguity guard remains for the mutating install family (writes the
+/// lockfile) and the project-graph readers above (see [`engine_session_quiet`]).
+pub(crate) fn engine_session_global(dir: Option<&Path>) -> Result<EngineSession> {
+    engine_session_inner(dir, ConfigScopeNoise::Silent, IdentityStrictness::Lenient)
 }
 
 /// Whether an identity-resolution failure (multi-lockfile ambiguity, declared
 /// PM contradicted by the on-disk lockfile) is a HARD ERROR or degrades to
 /// no-identity. `Strict` — the default for every project-reading/-writing
 /// family — surfaces the loud diagnostic with the `nub pm use` remedy.
-/// `Lenient` — the transient-package families (dlx/create) — swallows it and
-/// proceeds with no resolved identity, because those commands never touch the
-/// CWD project's lockfile (see [`engine_session_transient`]).
+/// `Lenient` — the transient-package families (dlx/create, see
+/// [`engine_session_transient`]) and the global-scope read class (store/cache/
+/// config/registry/path, see [`engine_session_global`]) — swallows it and
+/// proceeds with no resolved identity, because those commands never read or
+/// write the CWD project's lockfile.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum IdentityStrictness {
     Strict,

--- a/crates/nub-cli/src/pm_engine/publish_family.rs
+++ b/crates/nub-cli/src/pm_engine/publish_family.rs
@@ -139,7 +139,12 @@ where
         Parsed::Ok(wrap) => wrap.args,
         Parsed::Exit(code) => return Ok(code),
     };
-    let session = super::engine_session_quiet(None)?;
+    // The shared wired-verb shape backs only GLOBAL-SCOPE verbs — store/cache
+    // forensics, package.json edits (`pkg`/`set-script`), and the registry/auth
+    // surface (`pack`/`version`/`deprecate`/`token`/…). None read or write the
+    // project lockfile, so identity resolution is lenient (see
+    // `engine_session_global`): a multi-lockfile project must not block them.
+    let session = super::engine_session_global(None)?;
     match session.runtime.block_on(run(parsed)) {
         Ok(()) => Ok(0),
         Err(report) => Ok(present::emit_report(&report)),
@@ -213,7 +218,10 @@ fn run_publish(typed: &str, args: &[String]) -> Result<i32> {
         Parsed::Exit(code) => return Ok(code),
     };
     let filter = wrap.filter.effective();
-    let session = super::engine_session_quiet(None)?;
+    // `publish` reads package.json + workspace catalogs and uploads to the
+    // registry; it never reads or writes the project lockfile, so identity
+    // resolution is lenient (see `engine_session_global`).
+    let session = super::engine_session_global(None)?;
     match session
         .runtime
         .block_on(aube::commands::publish::run(wrap.args, filter))

--- a/crates/nub-cli/src/pm_engine/store_config_family.rs
+++ b/crates/nub-cli/src/pm_engine/store_config_family.rs
@@ -324,7 +324,10 @@ fn dispatch_config(parsed: ConfigArgs, explicit_global: bool) -> Result<i32> {
         // `get` / `list` / `delete` / bare `config` delegate unchanged.
         _ => {}
     }
-    let session = super::engine_session_quiet(None)?;
+    // `config` reads/writes `.npmrc`-class settings; it never reads the project
+    // lockfile, so identity resolution is lenient (see `engine_session_global`):
+    // a multi-lockfile project must not block a `config get`/`set`/`list`.
+    let session = super::engine_session_global(None)?;
     match session
         .runtime
         .block_on(aube::commands::config::run(parsed))
@@ -342,7 +345,8 @@ fn dispatch_config(parsed: ConfigArgs, explicit_global: bool) -> Result<i32> {
 /// `NpmConfig` default (vendor/aube/crates/aube-registry/src/config/load.rs).
 fn run_config_get_registry(parsed: ConfigArgs, json: bool) -> Result<i32> {
     const DEFAULT_REGISTRY: &str = "https://registry.npmjs.org/";
-    let session = super::engine_session_quiet(None)?;
+    // Global-scope config read (see the sibling `config` dispatch): lenient.
+    let session = super::engine_session_global(None)?;
     let (result, captured) = super::with_fd_captured(1, || {
         session
             .runtime

--- a/crates/nub-cli/tests/pm_identity.rs
+++ b/crates/nub-cli/tests/pm_identity.rs
@@ -263,6 +263,65 @@ fn transient_runs_do_not_error_on_multi_lockfile_projects() {
     }
 }
 
+/// The follow-up over-scope class (maintainer report 2026-06-26, follow-up to
+/// #197): GLOBAL-SCOPE commands that operate on the global store/config or the
+/// registry — never the project lockfile — must not raise the ambiguity guard
+/// either. `store path`, `config get`, `bin`, `root` run leniently and succeed;
+/// the PROJECT-GRAPH readers (`why`) and the mutating install family (`add`)
+/// stay strict and keep the loud `ERR_NUB_LOCKFILE_AMBIGUOUS`.
+#[test]
+fn global_scope_commands_ignore_multi_lockfile_ambiguity() {
+    let dir = project("ambiguous-global", r#"{"name":"app","version":"1.0.0"}"#);
+    std::fs::write(
+        dir.join("package-lock.json"),
+        r#"{"name":"app","version":"1.0.0","lockfileVersion":3,"requires":true,"packages":{}}"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("yarn.lock"), "# yarn lockfile v1\n").unwrap();
+
+    // Global-scope reads succeed and print their datum — no ambiguity preflight.
+    for args in [
+        &["store", "path"][..],
+        &["config", "get", "registry"],
+        &["bin"],
+        &["root"],
+    ] {
+        let (stdout, stderr, code) = run(&dir, args);
+        assert_eq!(
+            code,
+            0,
+            "`nub {}` must succeed in a multi-lockfile project: {stderr}",
+            args.join(" ")
+        );
+        assert!(
+            !stderr.contains("ERR_NUB_LOCKFILE_AMBIGUOUS"),
+            "`nub {}` must not raise the ambiguity guard: {stderr}",
+            args.join(" ")
+        );
+        assert!(
+            !stdout.trim().is_empty(),
+            "`nub {}` should print its datum: stdout empty",
+            args.join(" ")
+        );
+    }
+
+    // Project-graph reader stays strict: `why` reads the lockfile, so ambiguity
+    // is a loud error (a silent degrade would yield a wrong/empty graph).
+    let (_, stderr, _) = run(&dir, &["why", "is-odd"]);
+    assert!(
+        stderr.contains("ERR_NUB_LOCKFILE_AMBIGUOUS"),
+        "`nub why` must keep the ambiguity guard (it reads the project lockfile): {stderr}"
+    );
+
+    // The mutating install family keeps the guard — it would WRITE a lockfile,
+    // and must never silently pick one under ambiguity.
+    let (_, stderr, _) = run(&dir, &["add", "left-pad"]);
+    assert!(
+        stderr.contains("ERR_NUB_LOCKFILE_AMBIGUOUS"),
+        "`nub add` must keep the ambiguity guard (it writes the project lockfile): {stderr}"
+    );
+}
+
 /// The declared-yarn corner of the fresh row: identity resolves to yarn with
 /// no yarn.lock on disk, and the first install would CREATE yarn.lock — the
 /// gated write. Refused with the gate message, nothing written.


### PR DESCRIPTION
Follow-up to #197. Global-scope commands (store/cache/config, registry, `pkg`/`set-script`, `view`/`bin`/`root`) still hard-errored `ERR_NUB_LOCKFILE_AMBIGUOUS` in a multi-lockfile project despite never touching the project lockfile.

Adds `engine_session_global` (Silent + `IdentityStrictness::Lenient`, reusing #197's machinery) and routes those callers through it. Project-graph readers (`list`/`why`/`outdated`/`audit`/...) and the mutating install family stay strict.

Verified on a multi-lockfile fixture; new test `global_scope_commands_ignore_multi_lockfile_ambiguity`. Gates green.

Refs #197