### PR TITLE
feat: git-style external subcommand dispatch (nub-<verb>)

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1534,6 +1534,34 @@ fn run_nub() -> Result<i32> {
                     rest.join(" ")
                 );
             }
+            // External-subcommand fallthrough (git `git-foo` / cargo `cargo-foo`):
+            // an unknown bareword that isn't a built-in, a redirected PM/init verb,
+            // or a likely script resolves to an executable named `nub-<verb>` and
+            // runs it with the remaining argv forwarded verbatim (no clap, so every
+            // flag passes through). Built-ins always win — they match in the
+            // pre-verb scan above, so a plugin can never shadow one. We probe ONLY
+            // the prefixed name (never the bare `first`), so a verb typo can't exec
+            // a random PATH binary. Resolution order: project-local
+            // node_modules/.bin (the nub-idiomatic place a plugin installs) then a
+            // PATH search (a globally-installed plugin). launch_bin runs a JS/TS
+            // plugin under nub's augmentation (the runtime value prop) and execs a
+            // native one. If nothing resolves, fall through to the bail below.
+            //
+            // PnP gap (deliberate, additive): unlike the nubx/exec path, this
+            // does NOT fall back to the PnP bin-runner when find_bin misses in a
+            // Yarn-PnP tree (no node_modules/.bin) — a plugin in a PnP project
+            // resolves only via PATH, not via PnP. Symmetry with the sibling
+            // resolver is a follow-up; PnP plugin support isn't documented.
+            //
+            // Resolution base reflects any `--cwd` already applied via
+            // set_current_dir above; cwd is unchanged since then.
+            let cwd = env::current_dir()?;
+            let plugin_name = format!("nub-{first}");
+            let plugin = nub_core::workspace::scripts::find_bin(&plugin_name, &cwd)
+                .or_else(|| find_on_path(&plugin_name));
+            if let Some(plugin_path) = plugin {
+                return launch_bin(&plugin_path, &rest[1..], compat, &cwd);
+            }
             bail!(
                 "nub: \"{first}\" is not a nub command — see `nub --help`\n\
                  \x20\x20(to run a script: nub run {first} · to run a file: nub ./{first})"
@@ -4332,6 +4360,29 @@ fn pnp_bin_runner_path() -> Option<String> {
             .to_string_lossy()
             .into_owned(),
     )
+}
+
+/// Resolve `name` against the `PATH` env, returning the first existing
+/// executable file. Used by the external-subcommand fallthrough for a globally-
+/// installed `nub-<verb>` plugin (the project-local node_modules/.bin lookup is
+/// tried first). On Windows a bare `name` is probed against the executable
+/// extensions (`.exe`/`.cmd`/`.bat`); on Unix the literal name is the entry.
+fn find_on_path(name: &str) -> Option<PathBuf> {
+    #[cfg(windows)]
+    let exts: &[&str] = &["", ".exe", ".cmd", ".bat"];
+    #[cfg(not(windows))]
+    let exts: &[&str] = &[""];
+
+    let path_var = env::var_os("PATH")?;
+    for dir in env::split_paths(&path_var) {
+        for ext in exts {
+            let candidate = dir.join(format!("{name}{ext}"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
 }
 
 /// Launch a resolved `node_modules/.bin` entry, shebang/extension-aware (A40).

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -5654,3 +5654,137 @@ fn run_script_reports_role_aware_user_agent() {
 
     let _ = std::fs::remove_dir_all(&base);
 }
+
+// ── Section 9: external-subcommand fallthrough (git/cargo-style nub-<verb>) ──
+//
+// `nub <unknown-bareword>` resolves an executable named `nub-<verb>` (project-
+// local node_modules/.bin, then PATH) and runs it with the rest of argv
+// forwarded verbatim. Built-ins always win; only the prefixed name is probed.
+
+/// A `nub-<verb>` plugin in node_modules/.bin runs on `nub <verb>` with every
+/// remaining argument forwarded verbatim (flags included, since this path never
+/// touches clap), and its exit code propagates.
+#[cfg(not(windows))]
+#[test]
+fn external_subcommand_runs_local_plugin_and_forwards_argv() {
+    let dir = unique_test_cache();
+    let bin = dir.join("node_modules").join(".bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    // A shell-script plugin that echoes its args and exits non-zero so we also
+    // confirm the child's exit code is what propagates (not nub's own).
+    let plugin = bin.join("nub-foo");
+    std::fs::write(&plugin, "#!/bin/sh\necho \"plugin-args: $*\"\nexit 7\n").unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&plugin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let out = Command::new(nub_binary())
+        .args(["foo", "a", "b", "--c"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", unique_test_cache())
+        .output()
+        .expect("spawn nub foo");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("plugin-args: a b --c"),
+        "argv must forward verbatim, flags included: {stdout}"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(7),
+        "the plugin's exit code must propagate, not nub's"
+    );
+}
+
+/// An unknown bareword with no matching `nub-<verb>` still errors with the
+/// existing not-a-command guidance — the fallthrough adds a resolution attempt,
+/// it does not swallow the error when nothing resolves.
+#[test]
+fn external_subcommand_absent_still_errors() {
+    let dir = unique_test_cache();
+    std::fs::create_dir_all(&dir).unwrap();
+    let out = Command::new(nub_binary())
+        .args(["frobnicate", "--wat"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", unique_test_cache())
+        // An empty PATH so a stray host `nub-frobnicate` can't exist; the prefixed
+        // name still must not resolve.
+        .env("PATH", "")
+        .output()
+        .expect("spawn nub frobnicate");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("\"frobnicate\" is not a nub command"),
+        "with no plugin the original error must surface: {stderr}"
+    );
+    assert_ne!(out.status.code(), Some(0));
+}
+
+/// A built-in verb is never shadowed by a same-named plugin: a `nub-run` in
+/// node_modules/.bin does NOT intercept `nub run` — the built-in `run` dispatch
+/// wins (here surfacing run's own no-script-named error, not the plugin's
+/// output).
+#[cfg(not(windows))]
+#[test]
+fn external_subcommand_never_shadows_a_builtin() {
+    let dir = unique_test_cache();
+    let bin = dir.join("node_modules").join(".bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"app"}"#).unwrap();
+    let plugin = bin.join("nub-run");
+    std::fs::write(&plugin, "#!/bin/sh\necho INTERCEPTED-BY-PLUGIN\nexit 0\n").unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&plugin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let out = Command::new(nub_binary())
+        .args(["run", "nonexistent-script"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", unique_test_cache())
+        .output()
+        .expect("spawn nub run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("INTERCEPTED-BY-PLUGIN"),
+        "the built-in `run` verb must win over a nub-run plugin: stdout={stdout}"
+    );
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "run with a missing script must error via the built-in, not exit 0 via the plugin"
+    );
+}
+
+/// A PM-engine verb is never shadowed by a same-named plugin: a `nub-add` in
+/// node_modules/.bin does NOT intercept `nub add` — the engine `add` dispatch
+/// wins (here surfacing the engine's no-packages-specified error, not the
+/// plugin's output). Same no-shadow contract as the built-in case above, but
+/// through the engine-verb branch of the pre-verb scan (lookup_verb), pinning
+/// that both verb sets resist plugin capture.
+#[cfg(not(windows))]
+#[test]
+fn external_subcommand_never_shadows_an_engine_verb() {
+    let dir = unique_test_cache();
+    let bin = dir.join("node_modules").join(".bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"app"}"#).unwrap();
+    let plugin = bin.join("nub-add");
+    std::fs::write(&plugin, "#!/bin/sh\necho INTERCEPTED-BY-PLUGIN\nexit 0\n").unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&plugin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let out = Command::new(nub_binary())
+        .arg("add")
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", unique_test_cache())
+        .output()
+        .expect("spawn nub add");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("INTERCEPTED-BY-PLUGIN"),
+        "the engine `add` verb must win over a nub-add plugin: stdout={stdout}"
+    );
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "add with no packages must error via the engine, not exit 0 via the plugin"
+    );
+}

--- a/site/content/docs/meta.json
+++ b/site/content/docs/meta.json
@@ -10,6 +10,7 @@
     "node",
     "pm",
     "pm-shim",
+    "plugins",
     "faq",
     "---",
     "setup-nub",

--- a/site/content/docs/plugins.mdx
+++ b/site/content/docs/plugins.mdx
@@ -1,0 +1,52 @@
+---
+title: Plugins
+description: Extend the nub CLI with your own subcommands — an unknown verb resolves to an executable named after it and runs, the same convention git and cargo use for their plugins.
+---
+
+Run `nub <verb>` with a verb nub doesn't recognize and it resolves an executable named `nub-<verb>`, then runs it with the rest of the arguments forwarded untouched. This is the same convention behind `git-foo` and `cargo-foo`.
+
+```bash
+nub deploy --prod          # runs nub-deploy --prod
+nub changeset publish      # runs nub-changeset publish
+```
+
+A plugin is just a package that installs a `nub-<verb>` bin — there is no plugin manifest, no registration step, and no config field to declare it. Install it like any other dependency and the verb works.
+
+```bash
+nub add -D nub-deploy      # ships a nub-deploy bin
+nub deploy                 # now resolves and runs it
+```
+
+## Resolution
+
+The prefixed name is resolved in two places, in order:
+
+- `node_modules/.bin` — the project-local bin, walking up from the current directory (the same chain `nub run` and `nubx` use).
+- `PATH` — a globally-installed plugin.
+
+Only the prefixed `nub-<verb>` name is ever probed — never the bare verb. A mistyped command like `nub bnuild` resolves nothing and prints the usual not-a-command error; it can't fall through to a random `bnuild` binary on your PATH.
+
+## Built-ins always win
+
+A plugin can never shadow a built-in verb. Native commands and package-manager verbs are matched before any plugin lookup, so `nub run`, `nub install`, `nub add`, and the rest always dispatch to nub itself, even if a `nub-run` bin exists in `node_modules/.bin`. The fallthrough fires only for a verb nub has no built-in for.
+
+Script names take the same priority. A verb that names a script in the local `package.json`, or one of the conventional names `dev`, `build`, `test`, `start`, and `lint`, resolves to the `nub run <verb>` hint before the plugin lookup — so a `nub-build` or `nub-test` plugin is never reached through its bare verb. Name a plugin for something that isn't a script (`nub-deploy`, `nub-changeset`), or invoke a script-named one through `nub run` or by its bin directly.
+
+## JavaScript and TypeScript plugins
+
+A plugin written in JavaScript or TypeScript runs under nub's runtime augmentation, exactly as `nub run` runs a script — TypeScript executes directly, and the version-gated globals are present. A native executable plugin just runs. The plugin's exit code is what nub returns.
+
+```ts
+#!/usr/bin/env node
+// nub-deploy: TypeScript runs as-is, no build step
+const target: string = process.argv[2] ?? "staging";
+console.log(`deploying to ${target}`);
+```
+
+To run a plugin with augmentation disabled, pass `--node` before the verb — `nub --node deploy`, the same position a file run uses. Anything after the verb is forwarded to the plugin untouched, so a trailing `nub deploy --node` reaches the plugin as an argument and does not disable augmentation. See [the runtime overview](/docs/runtime#--node) for the contract.
+
+## Related
+
+- [Package runner](/docs/nubx) — `nubx`, for running a tool by name without installing it as a subcommand.
+- [Running scripts](/docs/run) — `nub run`, which shares the bin-resolution chain.
+- [Runtime](/docs/runtime) — TypeScript-first execution and the augmentation a JS/TS plugin inherits.


### PR DESCRIPTION
An unknown `nub <verb>` resolves `nub-<verb>` (project-local node_modules/.bin, then PATH) and runs it via the existing launch_bin with the remaining args forwarded verbatim; built-ins and PM-engine verbs always win, and the fallthrough fires only on an otherwise-unknown bareword.

JS/TS plugins run under nub's augmentation; native plugins exec directly.

Refs #162