### PR TITLE
tests: macOS Seatbelt write-confine probe harness for the build-jail

### DIFF
--- a/.github/workflows/sandbox-macos-writeconfine.yml
+++ b/.github/workflows/sandbox-macos-writeconfine.yml
@@ -1,0 +1,35 @@
+# Validation harness for the macOS Seatbelt write-confine mechanism the build-jail
+# relies on (thread: sandbox). Runs the self-contained core on a real macos-latest
+# runner: the SBPL profile-generator unit tests + the enforcement/bypass smoke tests
+# (write-confine, symlink-escape, .. traversal, in-jail hardlink creation, fail-closed
+# parse, device minimum, canonicalization). No mega-fixture, no network — the heavy
+# per-cache-family runs live in results.md and are reproduced on demand, not in CI.
+# Mirror of .github/workflows/sandbox-win-probes.yml.
+name: sandbox-macos-writeconfine
+on:
+  workflow_dispatch:
+  push:
+    branches: [fs-write-confine]
+    paths:
+      - 'tests/sandbox-macos-writeconfine/**'
+      - '.github/workflows/sandbox-macos-writeconfine.yml'
+jobs:
+  writeconfine:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Environment baseline
+        run: |
+          echo "uname: $(uname -a)"
+          echo "node:  $(node --version)"
+          echo "sandbox-exec: $(command -v sandbox-exec)"
+          echo "DARWIN_USER_TEMP_DIR=$(getconf DARWIN_USER_TEMP_DIR)"
+      - name: Profile-generator unit tests
+        working-directory: tests/sandbox-macos-writeconfine
+        run: node gen-profile.test.mjs
+      - name: Enforcement + bypass smoke tests
+        working-directory: tests/sandbox-macos-writeconfine
+        run: ./smoke-test.sh

--- a/tests/sandbox-macos-writeconfine/README.md
+++ b/tests/sandbox-macos-writeconfine/README.md
@@ -1,0 +1,62 @@
+# macOS filesystem write-confine probes (build-jail)
+
+Ground-truth validation of the macOS Seatbelt (SBPL) **write-confine** mechanism nub's
+build-jail relies on: confine a dependency lifecycle script's filesystem **writes** to its
+own package dir (+ a private scratch tmp), leaving reads/exec broad so the toolchain works.
+The companion axis to the Windows probes in [`../sandbox-win-probes/`](../sandbox-win-probes/).
+The question: does strict "write only your own package dir" break the out-of-package writes
+native builds make, what exact path does each need, and does a single base-anchor repoint
+collapse the cache-allowlist toward one dir.
+
+Mirrors the Windows-probe shape: a self-contained harness + a `results.md` record. No cargo
+build needed — the harness is a Node profile generator + a bash runner, runnable on any macOS.
+
+## Harness
+
+| File | Role |
+|---|---|
+| `gen-profile.mjs` | SBPL write-confine profile generator. Canonicalizes every write-allow path (the load-bearing correctness rule — see `results.md` §Bypass). `--mode strict` = pkg + tmp only; `--mode relaxed` = + the `--write` cache allowlist. |
+| `jail-run.sh` | Wraps a command in `sandbox-exec -p <profile>` with cwd = the package dir and the npm-lifecycle env (PATH incl. the tree `.bin`, `INIT_CWD`, `npm_config_*`, tmp anchors repointed at the granted scratch). Captures exit code + parsed denied write paths. `--mode control` runs un-sandboxed (the baseline). |
+| `results.md` | The findings: bypass/correctness analysis, the holes catalog per cache-family, the minimal cache-allowlist, the base-anchor collapse verdict, and the optimization analysis. |
+
+## The experiment (per package / cache-family)
+
+Three passes over the same build, so a sandbox FAIL is attributable to write-confine, not a
+broken package:
+
+1. **control** — un-sandboxed; confirms the build works on this machine at all.
+2. **strict** — pkg dir + private tmp only. The write-confine floor. A denial here is a *hole*.
+3. **relaxed** — + the candidate cache path(s) via `--write`. Confirms the hole closes with
+   exactly that grant (and records which path it was).
+
+## Reproducing (the proven loop)
+
+Built against a mega-fixture: the Bun-trusted list (~365, pruned dead `@softvisio/core` /
+`webdev-toolkit`) + the major frameworks, installed with `pnpm install --ignore-scripts` (pnpm
+links transitive bins so node-gyp / prebuild-install / node-pre-gyp resolve). A modern
+`node-gyp` (v13) is pinned in a tools dir because the host's global node-gyp may be ancient.
+
+```sh
+# locate a package's real dir in the pnpm virtual store
+PKGDIR=$(echo "$NM"/.pnpm/better-sqlite3@*/node_modules/better-sqlite3 | head -1)
+PROJ="$(dirname "$(dirname "$PKGDIR")")"   # the .pnpm/<pkg@ver> dir — its node_modules/.bin
+export PATH="$TOOLS/node_modules/.bin:$PATH"   # modern node-gyp
+
+# strict — expect the out-of-pkg cache write to be DENIED (the hole)
+DEVDIR=$(mktemp -d)
+./jail-run.sh --pkg "$PKGDIR" --project "$PROJ" --mode strict \
+  -- node-gyp rebuild --release --devdir="$DEVDIR"
+
+# relaxed — grant the cache path, expect the build to COMPLETE
+./jail-run.sh --pkg "$PKGDIR" --project "$PROJ" --mode relaxed --write "$DEVDIR" \
+  -- node-gyp rebuild --release --devdir="$DEVDIR"
+```
+
+## The base-anchor collapse (the optimization the cache-allowlist hinges on)
+
+Per [`wiki/research/native-build-cache-paths.md`](../../wiki/research/native-build-cache-paths.md),
+every cache path derives from a tiny set of base anchors — chiefly `os.homedir()`. Repointing
+`HOME` (and `npm_config_cache`, `TMPDIR`) at ONE nub-owned writable cache root lands every
+convention-following tool's cache inside that root, so the cache-allowlist collapses from N
+per-tool dirs to a single granted root. `jail-run.sh` already repoints the tmp anchors; the
+HOME-repoint experiment is recorded in `results.md` §Collapse.

--- a/tests/sandbox-macos-writeconfine/README.md
+++ b/tests/sandbox-macos-writeconfine/README.md
@@ -15,9 +15,15 @@ build needed — the harness is a Node profile generator + a bash runner, runnab
 
 | File | Role |
 |---|---|
-| `gen-profile.mjs` | SBPL write-confine profile generator. Canonicalizes every write-allow path (the load-bearing correctness rule — see `results.md` §Bypass). `--mode strict` = pkg + tmp only; `--mode relaxed` = + the `--write` cache allowlist. |
+| `gen-profile.mjs` | SBPL write-confine profile generator. Canonicalizes every write-allow path (the load-bearing correctness rule — see `results.md` §Canon). `--mode strict` = pkg + tmp only; `--mode relaxed` = + the `--write` cache allowlist; `--darwin-temp` grants the Apple-toolchain confstr scratch. |
+| `gen-profile.test.mjs` | Generator unit tests (`node gen-profile.test.mjs`) — canonicalization, write-deny floor, device set, strict/relaxed gating, SBPL escaping, darwin-temp. |
 | `jail-run.sh` | Wraps a command in `sandbox-exec -p <profile>` with cwd = the package dir and the npm-lifecycle env (PATH incl. the tree `.bin`, `INIT_CWD`, `npm_config_*`, tmp anchors repointed at the granted scratch). Captures exit code + parsed denied write paths. `--mode control` runs un-sandboxed (the baseline). |
+| `smoke-test.sh` | Self-contained enforcement + bypass smoke suite (no fixture, no network) — the fast CI core. `./smoke-test.sh`. |
 | `results.md` | The findings: bypass/correctness analysis, the holes catalog per cache-family, the minimal cache-allowlist, the base-anchor collapse verdict, and the optimization analysis. |
+
+CI: `.github/workflows/sandbox-macos-writeconfine.yml` runs the unit tests + smoke suite on
+`macos-latest` (mirror of `sandbox-win-probes.yml`); the heavy per-family runs are reproduced on
+demand, not in CI.
 
 ## The experiment (per package / cache-family)
 

--- a/tests/sandbox-macos-writeconfine/gen-profile.mjs
+++ b/tests/sandbox-macos-writeconfine/gen-profile.mjs
@@ -32,11 +32,18 @@
 //   --mode relaxed    pkg + tmp + every --write root (the cache allowlist).
 //   --dev-subpath     grant write to all of /dev (subpath) instead of the tight
 //                     literal device set. Default is the tight literal set.
+//   --darwin-temp     also grant the per-user DARWIN_USER_TEMP_DIR +
+//                     DARWIN_USER_CACHE_DIR (`/private/var/folders/<uid>/{T,C}`).
+//                     The Apple toolchain (xcrun/cc/libtool) writes its `xcrun_db`
+//                     scratch there via confstr — NOT redirectable by TMPDIR — so a
+//                     from-source compile spews EPERM noise without it. Per-user OS
+//                     scratch, low risk. Granted in BOTH modes when set.
 //
 // Output: the SBPL profile text on stdout.
 
 import { realpathSync, existsSync } from "node:fs";
-import { resolve, dirname, relative, sep } from "node:path";
+import { resolve, dirname, sep } from "node:path";
+import { execFileSync } from "node:child_process";
 
 // The minimal char-device write set a Node/native build actually touches.
 // Proven sufficient empirically (results.md §Device): /dev/null is required
@@ -55,7 +62,7 @@ const DEVICE_LITERALS = [
 ];
 
 function parseArgs(argv) {
-  const out = { pkg: null, project: null, write: [], tmp: [], mode: "strict", devSubpath: false };
+  const out = { pkg: null, project: null, write: [], tmp: [], mode: "strict", devSubpath: false, darwinTemp: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--pkg") out.pkg = argv[++i];
@@ -64,6 +71,7 @@ function parseArgs(argv) {
     else if (a === "--tmp") out.tmp.push(argv[++i]);
     else if (a === "--mode") out.mode = argv[++i];
     else if (a === "--dev-subpath") out.devSubpath = true;
+    else if (a === "--darwin-temp") out.darwinTemp = true;
     else throw new Error(`unknown arg: ${a}`);
   }
   if (!out.pkg) throw new Error("--pkg is required");
@@ -99,6 +107,22 @@ function subpathRule(p) {
   return `(allow file-write* (subpath "${sbplEscape(p)}"))`;
 }
 
+// The per-user Apple-toolchain scratch dirs (`/var/folders/<uid>/{T,C}`), read by
+// `xcrun`/cc/libtool via confstr — NOT redirectable via TMPDIR. Queried from
+// `getconf` so the <uid> hash is correct on any machine. Returns canonical paths.
+function darwinTempDirs() {
+  const dirs = [];
+  for (const key of ["DARWIN_USER_TEMP_DIR", "DARWIN_USER_CACHE_DIR"]) {
+    try {
+      const d = execFileSync("getconf", [key], { encoding: "utf8" }).trim();
+      if (d) dirs.push(canonicalizeForAllow(d));
+    } catch {
+      /* non-macOS or getconf missing — skip */
+    }
+  }
+  return dirs;
+}
+
 function build(opts) {
   const rules = ["(version 1)", "(allow default)", "(deny file-write*)"];
 
@@ -120,6 +144,7 @@ function build(opts) {
 
   add(opts.pkg); // pkg dir: always writable
   for (const t of opts.tmp) add(t); // private scratch
+  if (opts.darwinTemp) for (const d of darwinTempDirs()) add(d); // Apple-toolchain confstr scratch
   if (opts.mode === "relaxed") {
     for (const w of opts.write) add(w); // the cache allowlist
   }

--- a/tests/sandbox-macos-writeconfine/gen-profile.mjs
+++ b/tests/sandbox-macos-writeconfine/gen-profile.mjs
@@ -42,7 +42,7 @@
 // Output: the SBPL profile text on stdout.
 
 import { realpathSync, existsSync } from "node:fs";
-import { resolve, dirname, sep } from "node:path";
+import { resolve, dirname, basename, join } from "node:path";
 import { execFileSync } from "node:child_process";
 
 // The minimal char-device write set a Node/native build actually touches.
@@ -86,17 +86,22 @@ function parseArgs(argv) {
 // ancestor and re-append the non-existing tail — so the emitted subpath is still
 // anchored at the real on-disk prefix.
 function canonicalizeForAllow(p) {
-  let abs = resolve(p);
+  const abs = resolve(p);
   if (existsSync(abs)) return realpathSync(abs);
-  // walk up to nearest existing ancestor
-  let tail = [];
+  // Walk up to the nearest existing ancestor, collecting the non-existent tail
+  // by basename. Use basename + join (NOT a manual slice/concat): for a component
+  // directly under root, `dirname` is "/" and a manual `slice(len+1)` would drop
+  // the first char and a manual `prefix + sep + tail` would yield a leading `//`
+  // (which Seatbelt reads as `/` = a filesystem-wide grant — a FAIL-OPEN). basename
+  // + join are root-correct.
+  const tail = [];
   let cur = abs;
   while (cur !== dirname(cur) && !existsSync(cur)) {
-    tail.unshift(cur.slice(dirname(cur).length + 1));
+    tail.unshift(basename(cur));
     cur = dirname(cur);
   }
   const realPrefix = existsSync(cur) ? realpathSync(cur) : cur;
-  return tail.length ? realPrefix + sep + tail.join(sep) : realPrefix;
+  return tail.length ? join(realPrefix, ...tail) : realPrefix;
 }
 
 function sbplEscape(s) {
@@ -139,6 +144,10 @@ function build(opts) {
   const add = (p) => {
     if (!p) return;
     const c = canonicalizeForAllow(p);
+    // Hard guard: a write-allow root that resolves to `/` (or empty) would grant
+    // write across the WHOLE filesystem — a fail-open. Refuse rather than emit it.
+    // (Reachable only via a nonsensical `--pkg /`; fail-closed by construction.)
+    if (c === "/" || c === "") throw new Error(`refusing filesystem-root write grant from "${p}"`);
     if (!roots.includes(c)) roots.push(c);
   };
 

--- a/tests/sandbox-macos-writeconfine/gen-profile.mjs
+++ b/tests/sandbox-macos-writeconfine/gen-profile.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// SBPL write-confine profile generator for the macOS build-jail.
+//
+// Emits a Seatbelt (SBPL) profile that confines a lifecycle script's filesystem
+// WRITES to an explicit allow-set while leaving reads/exec broad (so the
+// toolchain — cc/node/python/make — works). This is the macOS write-confine
+// mechanism nub's production backend (`crates/nub-sandbox/src/backend/macos.rs`)
+// should generate; this generator is the validated reference + the harness's
+// profile source.
+//
+// THE LOAD-BEARING CORRECTNESS RULE (proven empirically — see results.md §Bypass):
+// Seatbelt evaluates every rule against the CANONICAL path (it resolves symlinks,
+// `..`, and the macOS firmlinks `/tmp`->`/private/tmp`, `/var`->`/private/var`).
+// So a write-allow given in SYMLINK form (`/tmp/x`, `/var/folders/.../pkg`) is
+// INERT — it never matches the canonical path the kernel checks, and the write is
+// silently DENIED (fail-closed breakage: every build under a `/tmp`- or
+// `/var`-rooted project dir would lose all writes). Therefore every write-allow
+// path MUST be canonicalized to its real form before it is emitted. This
+// generator canonicalizes each allow root (resolving the nearest existing
+// ancestor for not-yet-created cache dirs).
+//
+// Usage:
+//   gen-profile.mjs --pkg <dir> [--project <dir>] [--write <dir>]... \
+//                   [--tmp <dir>] [--mode strict|relaxed] [--dev-subpath]
+//
+//   --pkg <dir>       the package dir whose lifecycle script runs (read+write). Required.
+//   --project <dir>   project root (read-only; documented, not write-granted).
+//   --write <dir>     an extra writable root (repeatable) — the cache allowlist.
+//                     In strict mode these are IGNORED (pkg + tmp only).
+//   --tmp <dir>       a private scratch dir to grant write (repeatable).
+//   --mode strict     pkg + sandbox-home/tmp only, NO cache allowlist (default).
+//   --mode relaxed    pkg + tmp + every --write root (the cache allowlist).
+//   --dev-subpath     grant write to all of /dev (subpath) instead of the tight
+//                     literal device set. Default is the tight literal set.
+//
+// Output: the SBPL profile text on stdout.
+
+import { realpathSync, existsSync } from "node:fs";
+import { resolve, dirname, relative, sep } from "node:path";
+
+// The minimal char-device write set a Node/native build actually touches.
+// Proven sufficient empirically (results.md §Device): /dev/null is required
+// (build tooling redirects to it); the rest are the standard char devices
+// node/cc/make open for writing. Tighter than a blanket `(subpath "/dev")`.
+const DEVICE_LITERALS = [
+  "/dev/null",
+  "/dev/zero",
+  "/dev/tty",
+  "/dev/dtracehelper",
+  "/dev/random",
+  "/dev/urandom",
+  "/dev/stdout",
+  "/dev/stderr",
+  "/dev/fd",
+];
+
+function parseArgs(argv) {
+  const out = { pkg: null, project: null, write: [], tmp: [], mode: "strict", devSubpath: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--pkg") out.pkg = argv[++i];
+    else if (a === "--project") out.project = argv[++i];
+    else if (a === "--write") out.write.push(argv[++i]);
+    else if (a === "--tmp") out.tmp.push(argv[++i]);
+    else if (a === "--mode") out.mode = argv[++i];
+    else if (a === "--dev-subpath") out.devSubpath = true;
+    else throw new Error(`unknown arg: ${a}`);
+  }
+  if (!out.pkg) throw new Error("--pkg is required");
+  if (out.mode !== "strict" && out.mode !== "relaxed")
+    throw new Error(`--mode must be strict|relaxed, got ${out.mode}`);
+  return out;
+}
+
+// Canonicalize a path for a write-allow rule. Resolves symlinks/firmlinks/`..`
+// to the form the Seatbelt kernel check sees. For a path that does not exist yet
+// (a cache dir created later by the build), realpath the nearest EXISTING
+// ancestor and re-append the non-existing tail — so the emitted subpath is still
+// anchored at the real on-disk prefix.
+function canonicalizeForAllow(p) {
+  let abs = resolve(p);
+  if (existsSync(abs)) return realpathSync(abs);
+  // walk up to nearest existing ancestor
+  let tail = [];
+  let cur = abs;
+  while (cur !== dirname(cur) && !existsSync(cur)) {
+    tail.unshift(cur.slice(dirname(cur).length + 1));
+    cur = dirname(cur);
+  }
+  const realPrefix = existsSync(cur) ? realpathSync(cur) : cur;
+  return tail.length ? realPrefix + sep + tail.join(sep) : realPrefix;
+}
+
+function sbplEscape(s) {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function subpathRule(p) {
+  return `(allow file-write* (subpath "${sbplEscape(p)}"))`;
+}
+
+function build(opts) {
+  const rules = ["(version 1)", "(allow default)", "(deny file-write*)"];
+
+  // Device writes (tight literal set by default).
+  if (opts.devSubpath) {
+    rules.push(subpathRule("/dev"));
+  } else {
+    const lits = DEVICE_LITERALS.map((d) => `(literal "${d}")`).join(" ");
+    rules.push(`(allow file-write* ${lits})`);
+  }
+
+  // Collect the write roots for the chosen mode, canonicalize, dedup.
+  const roots = [];
+  const add = (p) => {
+    if (!p) return;
+    const c = canonicalizeForAllow(p);
+    if (!roots.includes(c)) roots.push(c);
+  };
+
+  add(opts.pkg); // pkg dir: always writable
+  for (const t of opts.tmp) add(t); // private scratch
+  if (opts.mode === "relaxed") {
+    for (const w of opts.write) add(w); // the cache allowlist
+  }
+
+  for (const r of roots) rules.push(subpathRule(r));
+
+  return rules.join("\n") + "\n";
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  process.stdout.write(build(opts));
+}
+
+// Exported for unit tests; run as CLI when invoked directly.
+export { canonicalizeForAllow, build, sbplEscape, parseArgs, DEVICE_LITERALS };
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/tests/sandbox-macos-writeconfine/gen-profile.test.mjs
+++ b/tests/sandbox-macos-writeconfine/gen-profile.test.mjs
@@ -88,6 +88,18 @@ console.log("# devSubpath opt-out");
   ok(prof.includes('(allow file-write* (subpath "/dev"))'), "--dev-subpath emits /dev subpath");
 }
 
+console.log("# darwin-temp grant (Apple-toolchain confstr scratch)");
+{
+  const off = build({ pkg: realPkg, write: [], tmp: [], mode: "strict", devSubpath: false });
+  // the per-user darwin dirs end in /T" or /C"; the pkg path (also under
+  // /private/var/folders) does not — so anchor on the trailing-segment quote.
+  ok(!/\/T"\)\)$/m.test(off) && !/\/C"\)\)$/m.test(off), "no darwin-temp grant by default");
+  const on = build({ pkg: realPkg, write: [], tmp: [], mode: "strict", devSubpath: false, darwinTemp: true });
+  // getconf returns /var/folders/<uid>/{T,C}; canonical is /private/var/folders/...
+  ok(/private\/var\/folders\/[^"]+\/T/.test(on), "darwin-temp grants the per-user T dir (canonical)");
+  ok(/private\/var\/folders\/[^"]+\/C/.test(on), "darwin-temp grants the per-user C dir (canonical)");
+}
+
 rmSync(root, { recursive: true, force: true });
 console.log(failures === 0 ? "\nALL PASS" : `\n${failures} FAILURE(S)`);
 process.exit(failures === 0 ? 0 : 1);

--- a/tests/sandbox-macos-writeconfine/gen-profile.test.mjs
+++ b/tests/sandbox-macos-writeconfine/gen-profile.test.mjs
@@ -42,6 +42,25 @@ console.log("# canonicalization");
   );
 }
 
+console.log("# canonicalization — root-adjacent non-existent paths (BUG-1 regression)");
+{
+  // a non-existent component DIRECTLY under / must NOT drop a char or yield `//`
+  // (a `//`-subpath is read by Seatbelt as `/` = a filesystem-wide FAIL-OPEN).
+  const c1 = canonicalizeForAllow("/nonexistent-cache-xyz/sub");
+  ok(c1 === "/nonexistent-cache-xyz/sub", `root-adjacent path intact (${c1})`);
+  ok(!c1.includes("//"), "no leading/double slash");
+  const c2 = canonicalizeForAllow("/Q"); // single-char top-level — the fail-open trigger
+  ok(c2 === "/Q", `single-char top-level path intact (${c2})`);
+  // the build() guard must REFUSE a grant that resolves to the filesystem root
+  let threw = false;
+  try {
+    build({ pkg: "/", write: [], tmp: [], mode: "strict", devSubpath: false });
+  } catch {
+    threw = true;
+  }
+  ok(threw, "build() refuses a `/`-root write grant (no fail-open)");
+}
+
 console.log("# write-deny floor + device set");
 {
   const prof = build({ pkg: realPkg, write: [], tmp: [], mode: "strict", devSubpath: false });

--- a/tests/sandbox-macos-writeconfine/gen-profile.test.mjs
+++ b/tests/sandbox-macos-writeconfine/gen-profile.test.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Unit tests for gen-profile.mjs. Run: node gen-profile.test.mjs
+// Asserts the load-bearing properties: write-deny floor, canonicalization of
+// write-allow paths (symlink-form input -> canonical-form rule), strict vs
+// relaxed cache-allowlist gating, the tight device literal set, and SBPL escaping.
+
+import { mkdtempSync, mkdirSync, symlinkSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { build, canonicalizeForAllow, sbplEscape, DEVICE_LITERALS } from "./gen-profile.mjs";
+
+let failures = 0;
+function ok(cond, msg) {
+  if (cond) console.log(`  ok  ${msg}`);
+  else {
+    failures++;
+    console.error(`FAIL  ${msg}`);
+  }
+}
+
+// A real on-disk symlinked dir so canonicalization has something to resolve.
+// `tmpdir()` is itself a /var/folders firmlink -> /private/var/folders, so
+// realpath the root: the generator canonicalizes to the /private form, and the
+// expectations must match that (this is the firmlink-resolution the generator
+// exists to do).
+const root = realpathSync(mkdtempSync(join(tmpdir(), "genprof-")));
+const realPkg = join(root, "real", "pkg");
+mkdirSync(realPkg, { recursive: true });
+const linkDir = join(root, "link");
+symlinkSync(join(root, "real"), linkDir); // link/ -> real/
+const symlinkedPkg = join(linkDir, "pkg"); // resolves to real/pkg
+
+console.log("# canonicalization");
+{
+  const canon = canonicalizeForAllow(symlinkedPkg);
+  ok(canon === realPkg, `symlinked input resolves to real path (${canon})`);
+  // non-existent tail anchored at nearest existing real ancestor
+  const future = join(symlinkedPkg, "build", "Release");
+  ok(
+    canonicalizeForAllow(future) === join(realPkg, "build", "Release"),
+    "non-existent cache tail anchored at canonical existing prefix",
+  );
+}
+
+console.log("# write-deny floor + device set");
+{
+  const prof = build({ pkg: realPkg, write: [], tmp: [], mode: "strict", devSubpath: false });
+  ok(prof.includes("(deny file-write*)"), "emits deny-write floor");
+  ok(prof.indexOf("(deny file-write*)") < prof.indexOf("(allow file-write*"), "deny precedes allows");
+  for (const d of ["/dev/null", "/dev/tty", "/dev/urandom"])
+    ok(prof.includes(`(literal "${d}")`), `device literal present: ${d}`);
+  ok(!prof.includes('(subpath "/dev")'), "tight literal device set, not /dev subpath");
+}
+
+console.log("# strict emits the CANONICAL pkg path, not the symlink form");
+{
+  const prof = build({ pkg: symlinkedPkg, write: [], tmp: [], mode: "strict", devSubpath: false });
+  ok(prof.includes(`(allow file-write* (subpath "${realPkg}"))`), "pkg allow uses canonical path");
+  ok(!prof.includes(`(subpath "${symlinkedPkg}")`), "symlink-form pkg path NOT emitted (would be inert)");
+}
+
+console.log("# strict gates out the cache allowlist; relaxed admits it");
+{
+  const cache = join(root, "real", "cache");
+  mkdirSync(cache, { recursive: true });
+  const strict = build({ pkg: realPkg, write: [cache], tmp: [], mode: "strict", devSubpath: false });
+  ok(!strict.includes(`(subpath "${cache}")`), "strict mode IGNORES --write cache roots");
+  const relaxed = build({ pkg: realPkg, write: [cache], tmp: [], mode: "relaxed", devSubpath: false });
+  ok(relaxed.includes(`(allow file-write* (subpath "${cache}"))`), "relaxed mode grants the cache root");
+}
+
+console.log("# tmp roots always granted (both modes)");
+{
+  const t = join(root, "real", "scratch");
+  mkdirSync(t, { recursive: true });
+  const strict = build({ pkg: realPkg, write: [], tmp: [t], mode: "strict", devSubpath: false });
+  ok(strict.includes(`(allow file-write* (subpath "${t}"))`), "tmp granted in strict");
+}
+
+console.log("# SBPL escaping");
+{
+  ok(sbplEscape('a"b\\c') === 'a\\"b\\\\c', "escapes quote and backslash");
+}
+
+console.log("# devSubpath opt-out");
+{
+  const prof = build({ pkg: realPkg, write: [], tmp: [], mode: "strict", devSubpath: true });
+  ok(prof.includes('(allow file-write* (subpath "/dev"))'), "--dev-subpath emits /dev subpath");
+}
+
+rmSync(root, { recursive: true, force: true });
+console.log(failures === 0 ? "\nALL PASS" : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/tests/sandbox-macos-writeconfine/jail-run.sh
+++ b/tests/sandbox-macos-writeconfine/jail-run.sh
@@ -71,7 +71,7 @@ if [[ "$MODE" == "control" ]]; then
   ( cd "$PKG" && "${CMD[@]}" ) >"$LOG" 2>&1
   CODE=$?
 else
-  GENARGS=(--pkg "$PKG" --project "$PROJECT" --mode "$MODE")
+  GENARGS=(--pkg "$PKG" --project "$PROJECT" --mode "$MODE" --darwin-temp)
   for w in "${WRITES[@]}"; do GENARGS+=(--write "$w"); done
   for t in "${TMPS[@]}"; do GENARGS+=(--tmp "$t"); done
   PROFILE="$(node "$GEN" "${GENARGS[@]}")" || { echo "profile-gen failed" >&2; exit 3; }

--- a/tests/sandbox-macos-writeconfine/jail-run.sh
+++ b/tests/sandbox-macos-writeconfine/jail-run.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Run a lifecycle command under the macOS write-confine SBPL profile, with the
+# npm lifecycle environment, capturing the exit code + any write-denial paths.
+#
+# Two passes are the experiment (see README.md):
+#   strict  — pkg dir + tmp only (NO cache allowlist)
+#   relaxed — + the cache allowlist (--write roots)
+# plus a --control pass that runs UN-sandboxed to confirm the build works on this
+# machine at all (so a sandbox FAIL is attributable to write-confine, not a
+# broken package).
+#
+# Usage:
+#   jail-run.sh --pkg <dir> [--project <dir>] [--write <dir>]... [--tmp <dir>] \
+#               --mode strict|relaxed|control [--label NAME] -- <cmd> [args...]
+#
+# The command runs with cwd = the package dir and an npm-lifecycle-shaped env
+# (npm_config_* build hints, INIT_CWD, PATH including the tree's node_modules/.bin).
+#
+# Output: prints the captured exit code and a de-duplicated list of denied write
+# paths parsed from the child's combined output (build tools print the offending
+# path on EPERM/EACCES). Also streams the macOS unified-log Sandbox violations for
+# this run (no sudo needed for our own user's processes) when `log` is available.
+
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GEN="$HERE/gen-profile.mjs"
+
+PKG=""; PROJECT=""; MODE="strict"; LABEL=""
+WRITES=(); TMPS=()
+CMD=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pkg) PKG="$2"; shift 2;;
+    --project) PROJECT="$2"; shift 2;;
+    --write) WRITES+=("$2"); shift 2;;
+    --tmp) TMPS+=("$2"); shift 2;;
+    --mode) MODE="$2"; shift 2;;
+    --label) LABEL="$2"; shift 2;;
+    --) shift; CMD=("$@"); break;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+[[ -z "$PKG" ]] && { echo "jail-run: --pkg required" >&2; exit 2; }
+[[ ${#CMD[@]} -eq 0 ]] && { echo "jail-run: missing -- <cmd>" >&2; exit 2; }
+[[ -z "$PROJECT" ]] && PROJECT="$PKG"
+
+# A private scratch tmp for the build, granted write + made the child's tmp root.
+# REPOINTING TMPDIR/TMP/TEMP at this granted dir is load-bearing: many build tools
+# (node-gyp's atomic header extract, cc/ld scratch) `mkdtemp` in `os.tmpdir()` =
+# the OS temp ROOT (`/var/folders/.../T`), which is NOT in the allowlist. Pointing
+# the tmp anchors at the granted private dir lands those writes in-allowlist — the
+# `tmp: private` shorthand from the design (see results.md §Tmp anchor).
+SANDBOX_TMP="${NUB_SANDBOX_TMP:-$(mktemp -d "${TMPDIR:-/tmp}/nub-jail.XXXXXX")}"
+TMPS+=("$SANDBOX_TMP")
+export TMPDIR="$SANDBOX_TMP" TMP="$SANDBOX_TMP" TEMP="$SANDBOX_TMP"
+
+# Build the npm-lifecycle env. PATH carries the tree's hoisted .bin so transitive
+# build tools (node-gyp, prebuild-install, node-pre-gyp) resolve.
+BIN="$PROJECT/node_modules/.bin"
+export PATH="$BIN:$PATH"
+export INIT_CWD="$PROJECT"
+export npm_config_cache="${npm_config_cache:-$SANDBOX_TMP/npm-cache}"
+export npm_lifecycle_event="${npm_lifecycle_event:-install}"
+
+LOG="$(mktemp "${TMPDIR:-/tmp}/jail-run.out.XXXXXX")"
+
+run_label="${LABEL:-$(basename "$PKG")}"
+echo "=== [$run_label] mode=$MODE pkg=$PKG ===" >&2
+
+if [[ "$MODE" == "control" ]]; then
+  ( cd "$PKG" && "${CMD[@]}" ) >"$LOG" 2>&1
+  CODE=$?
+else
+  GENARGS=(--pkg "$PKG" --project "$PROJECT" --mode "$MODE")
+  for w in "${WRITES[@]}"; do GENARGS+=(--write "$w"); done
+  for t in "${TMPS[@]}"; do GENARGS+=(--tmp "$t"); done
+  PROFILE="$(node "$GEN" "${GENARGS[@]}")" || { echo "profile-gen failed" >&2; exit 3; }
+  ( cd "$PKG" && exec sandbox-exec -p "$PROFILE" -- "${CMD[@]}" ) >"$LOG" 2>&1
+  CODE=$?
+fi
+
+echo "--- exit: $CODE ---"
+echo "--- output (tail) ---"
+tail -40 "$LOG"
+echo "--- denied write paths (parsed) ---"
+# Build tools print the offending path next to EPERM/EACCES/not permitted.
+grep -oE '(/[^ :"'"'"']+)' "$LOG" \
+  | grep -E '^/' \
+  | sort -u \
+  | grep -iE 'permission|denied' >/dev/null 2>&1 || true
+# More reliable: pull lines mentioning the denial, then extract absolute paths.
+grep -iE 'operation not permitted|EPERM|EACCES|permission denied|not permitted' "$LOG" \
+  | grep -oE '/[^ :"'"'"',()]+' | sort -u || echo "(none parsed from child output)"
+echo "RESULT $run_label mode=$MODE exit=$CODE"
+echo "(full log: $LOG)"

--- a/tests/sandbox-macos-writeconfine/jail-run.sh
+++ b/tests/sandbox-macos-writeconfine/jail-run.sh
@@ -72,8 +72,12 @@ if [[ "$MODE" == "control" ]]; then
   CODE=$?
 else
   GENARGS=(--pkg "$PKG" --project "$PROJECT" --mode "$MODE" --darwin-temp)
-  for w in "${WRITES[@]}"; do GENARGS+=(--write "$w"); done
-  for t in "${TMPS[@]}"; do GENARGS+=(--tmp "$t"); done
+  # Guard the empty-array expansion: macOS ships bash 3.2, where `"${EMPTY[@]}"`
+  # under `set -u` aborts with "unbound variable" — which would crash the documented
+  # strict-mode path (no --write). TMPS is always non-empty (SANDBOX_TMP), but guard
+  # both for robustness.
+  if [[ ${#WRITES[@]} -gt 0 ]]; then for w in "${WRITES[@]}"; do GENARGS+=(--write "$w"); done; fi
+  if [[ ${#TMPS[@]} -gt 0 ]]; then for t in "${TMPS[@]}"; do GENARGS+=(--tmp "$t"); done; fi
   PROFILE="$(node "$GEN" "${GENARGS[@]}")" || { echo "profile-gen failed" >&2; exit 3; }
   ( cd "$PKG" && exec sandbox-exec -p "$PROFILE" -- "${CMD[@]}" ) >"$LOG" 2>&1
   CODE=$?

--- a/tests/sandbox-macos-writeconfine/results.md
+++ b/tests/sandbox-macos-writeconfine/results.md
@@ -96,16 +96,44 @@ gyp info ok
 So the write set a from-source native build needs: **pkg dir + private scratch (tmp anchors
 repointed) + the node-gyp devdir cache** (`~/Library/Caches/node-gyp/<ver>` on macOS by default).
 
-## §Catalog — cache-family holes (pending the empirical sweep)
+## §Darwin — the Apple-toolchain confstr scratch (a macOS-specific residual)
+
+Even with `TMPDIR`/`TMP`/`TEMP` repointed, a from-source compile emits:
+```
+make: error: couldn't create cache file '/var/folders/qg/.../T/xcrun_db-XXX' (errno=Operation not permitted)
+cc:  error: couldn't create cache file '/var/folders/qg/.../T/xcrun_db-XXX' (errno=Operation not permitted)
+```
+`xcrun`/cc/libtool write their `xcrun_db` to the per-user **DARWIN_USER_TEMP_DIR**
+(`/var/folders/<uid>/T`, canonical `/private/var/folders/<uid>/T`), resolved via confstr
+(`_CS_DARWIN_USER_TEMP_DIR`) — **NOT redirectable by the `TMPDIR` env var**. Here it is
+non-fatal (xcrun degrades), but it spams EPERM and could break a stricter toolchain. Granting
+the confstr pair (`DARWIN_USER_TEMP_DIR` + `DARWIN_USER_CACHE_DIR`) silences it completely
+(`gyp info ok`, zero xcrun noise). These are per-user OS scratch dirs (low risk). The generator
+grants them with `--darwin-temp` (jail-run passes it by default); paths queried from `getconf`
+so the `<uid>` hash is correct on any machine.
+
+## §Collapse — base-anchor HOME-repoint (the optimization verdict)
+
+**Repointing `HOME` at ONE granted cache root collapses the N per-tool caches to a single grant.**
+Proven: relaxed jail granting ONLY `$CACHEROOT` (one root), with `HOME=$CACHEROOT` and the
+DEFAULT node-gyp devdir (HOME-derived `$HOME/Library/Caches/node-gyp`):
+```
+gyp info ok
+=> better_sqlite3.node produced; cache landed at $CACHEROOT/Library/Caches/node-gyp/26.2.0
+```
+node-gyp's devdir followed `HOME` into the single granted root — one grant covered it. (A
+control with `--mode strict`, where `--write` is correctly ignored, denied `mkdir
+$CACHEROOT/Library` — confirming strict gates the cache allowlist out, AND that the cache *did*
+derive from HOME.) Per [`native-build-cache-paths`](../../wiki/research/native-build-cache-paths.md)
+the same `os.homedir()` anchor moves 9/9 cache-bearing tools on macOS (where `~/Library/Caches`
+has no env override), so the explicit N-dir cache enumeration collapses to: **pkg dir + private
+scratch + ONE base-anchor cache root (HOME-repointed) + the DARWIN confstr pair.**
+
+## §Catalog — cache-family holes (empirical sweep)
 
 <!-- Filled from the cache-family empirical sweep: per family — representative package, install
 command, exact denied out-of-package write path under strict, genuine-write-vs-prefetchable,
 HOME-repoint capture. -->
-
-## §Collapse — base-anchor HOME-repoint (pending the empirical sweep)
-
-<!-- Does repointing HOME at one granted cache root collapse the N per-tool caches to a single
-grant? Which tools comply, which are residual. -->
 
 ## Conclusion (so far)
 

--- a/tests/sandbox-macos-writeconfine/results.md
+++ b/tests/sandbox-macos-writeconfine/results.md
@@ -1,0 +1,118 @@
+# macOS write-confine probes — results
+
+Ground-truth validation of the macOS Seatbelt (SBPL) **write-confine** mechanism nub's
+build-jail relies on, run via `sandbox-exec` on macOS 15 (Darwin 25.5.0, arm64). Each finding
+carries the exact command + captured output so a verdict cannot be vacuous. The harness lives
+alongside this file (`gen-profile.mjs`, `jail-run.sh`); see `README.md` for the loop. The
+canonical research synthesis is `wiki/research/macos-seatbelt-write-confine.md`.
+
+## Verdicts
+
+| Axis | Verdict | Evidence |
+|---|---|---|
+| Write-confine (pkg dir only) | ENFORCED | write inside pkg OK; write outside → EPERM |
+| Symlink-escape bypass | BLOCKED | write through pkg-internal symlink to outside → EPERM |
+| `..`-traversal bypass | BLOCKED | `pkg/../secret/x` → EPERM, file not created |
+| Hardlink-creation-in-jail bypass | BLOCKED | `ln <outside> pkg/h` → EPERM at creation |
+| Firmlink canonicalization (`/tmp`,`/var`) | HANDLED | symlink-form write-allow is INERT; canonical-form allow works |
+| Device-write minimum | tight literal set sufficient | `/dev/null` write needs a grant; literal set < `(subpath "/dev")` |
+| node-gyp from-source (the headline) | strict BREAKS, relaxed BUILDS | devdir `mkdir` EPERM under strict; clean `.node` under relaxed+tmp-repoint |
+
+## §Bypass — the bypass surface (exact probes)
+
+Profile under test (write-allow = `<B>/pkg` + `/dev`, deny everything else):
+
+**1. Symlink escape — BLOCKED.** `ln -sf <B>/secret <B>/pkg/link`, then inside the jail
+`echo PWNED > <B>/pkg/link/data.txt`:
+```
+/bin/sh: <B>/pkg/link/data.txt: Operation not permitted
+secret now: ORIGINAL                       # unchanged
+```
+Seatbelt resolves the symlink and checks the canonical target (`<B>/secret/...`), outside the
+allow-set.
+
+**2. `..` traversal — BLOCKED.** `echo PWNED > <B>/pkg/../secret/dd.txt`:
+```
+/bin/sh: <B>/pkg/../secret/dd.txt: Operation not permitted
+ls: <B>/secret/dd.txt: No such file or directory     # not created
+```
+
+**3. Hardlink creation in-jail — BLOCKED.** A confined script cannot create the escaping link:
+```
+ln <B>/secret/data.txt <B>/pkg/h.txt
+ln: <B>/pkg/h.txt: Operation not permitted           # creation denied
+```
+Creating a hardlink requires `file-write*` on the TARGET inode (outside the writable root) →
+denied. (`(deny file-link*)` is NOT a valid Seatbelt op — parse error — and is unnecessary.)
+Residual: a PRE-EXISTING hardlink inside pkg pointing out-of-root *is* writable, but the
+confined script can't create one and a tarball can't deliver one (extractor rejects escaping
+links; absolute victim paths aren't expressible in a tarball) — outside the threat model.
+
+## §Canon — firmlink canonicalization (the load-bearing rule)
+
+A write-allow given in **symlink form is inert** — the write is silently DENIED, because the
+kernel checks the canonical path. Proven with a `mktemp -d` dir (`/var/folders/...` →
+`/private/var/folders/...`):
+```
+# allow ONLY the /var/folders (symlink) form:
+(allow file-write* (subpath "/var/folders/qg/.../T/tmp.X"))
+echo hi > /var/folders/qg/.../T/tmp.X/viasym.txt   →  Operation not permitted   (DENIED)
+
+# allow the canonical /private/var form:
+(allow file-write* (subpath "/private/var/folders/qg/.../T/tmp.X"))
+echo hi > /var/folders/qg/.../T/tmp.X/viacanon.txt →  WROTE_ALLOWING_CANON_FORM  (OK)
+```
+The same bit me with `/tmp` → `/private/tmp`. **Conclusion: the generator MUST canonicalize
+every write-allow path.** `gen-profile.mjs` does (`canonicalizeForAllow`, unit-tested in
+`gen-profile.test.mjs` — `node gen-profile.test.mjs` → ALL PASS).
+
+## §Device — device-write minimum
+
+Under a no-`/dev` write profile, `echo x > /dev/null` → `Operation not permitted` (build dies).
+A tight literal set — `/dev/null /dev/zero /dev/tty /dev/dtracehelper /dev/random /dev/urandom
+/dev/stdout /dev/stderr /dev/fd` — restores it, smaller than the reference's `(subpath "/dev")`.
+Writing a real disk-device node needs root the jailed user lacks, so the subpath grant buys
+nothing. Generator default = the literal set; `--dev-subpath` is the escape hatch.
+
+## §node-gyp — the headline breakage + fix (better-sqlite3, from-source)
+
+**STRICT (pkg + tmp only):** node-gyp's devdir write is DENIED:
+```
+gyp ERR! stack Error: EPERM: operation not permitted, mkdir '<fresh-devdir>'
+```
+Granting `--write <devdir>` alone is NOT enough — node-gyp also `mkdtemp`s in `os.tmpdir()` =
+the OS temp ROOT:
+```
+gyp ERR! stack Error: EPERM: operation not permitted, mkdtemp '/var/folders/.../T/node-gyp-tmp-XXX'
+```
+**Fix = the `tmp: private` shorthand:** repoint `TMPDIR`/`TMP`/`TEMP` at the granted private
+scratch (jail-run does this). With devdir granted + tmp repointed:
+```
+  CXX(target) Release/obj.target/better_sqlite3/src/better_sqlite3.o
+  SOLINK_MODULE(target) Release/better_sqlite3.node
+gyp info ok
+=> better_sqlite3.node (1.9 MB) produced; devdir populated with headers
+```
+So the write set a from-source native build needs: **pkg dir + private scratch (tmp anchors
+repointed) + the node-gyp devdir cache** (`~/Library/Caches/node-gyp/<ver>` on macOS by default).
+
+## §Catalog — cache-family holes (pending the empirical sweep)
+
+<!-- Filled from the cache-family empirical sweep: per family — representative package, install
+command, exact denied out-of-package write path under strict, genuine-write-vs-prefetchable,
+HOME-repoint capture. -->
+
+## §Collapse — base-anchor HOME-repoint (pending the empirical sweep)
+
+<!-- Does repointing HOME at one granted cache root collapse the N per-tool caches to a single
+grant? Which tools comply, which are residual. -->
+
+## Conclusion (so far)
+
+The write-confine mechanism is sound and bypass-resistant on macOS: symlink-escape, `..`, and
+in-jail hardlink-creation all fail closed because Seatbelt matches the canonical path and gates
+link-creation on the target. The one mandatory correctness rule is **canonicalizing every
+write-allow path** (a symlink-form allow is inert → would deny all writes and break every build
+under a `/tmp`- or `/var`-rooted tree). Package-dir-only is not a viable write set; pkg + private
+tmp + one base-anchor-captured cache root is. The cache-family catalog + the HOME-collapse
+verdict follow below once the sweep completes.

--- a/tests/sandbox-macos-writeconfine/results.md
+++ b/tests/sandbox-macos-writeconfine/results.md
@@ -179,6 +179,37 @@ wasn't forced); git-hook installers other than pre-commit failed on a hand-built
 (broken pnpm symlinks from a `cp -R`), not a sandbox finding — zero-dep pre-commit cleanly proved
 the `.git/hooks` collision.
 
+## §Production-gaps — what this harness reveals about the reference backend
+
+The harness is the validated reference for `crates/nub-sandbox/src/backend/macos.rs` +
+`script_sandbox.rs` (branch `build-jail-engine`). Three divergences an implementer must close
+(surfaced by the impact-analysis review):
+
+1. **Canonicalization of NOT-YET-CREATED write-allow paths (fail-closed bug).** Production
+   `macos.rs::push_write_rule` uses `if let Ok(canon) = p.canonicalize()` — but
+   `std::fs::canonicalize` returns `Err` for any path that does not yet exist. So a write-allow
+   path that (a) doesn't exist at profile-build time AND (b) crosses a firmlink emits ONLY the
+   inert symlink-form rule → the write is silently DENIED (§Canon). At risk: `sandbox_home`
+   (`/tmp/nub-sandbox/...`, under the `/tmp` firmlink) and the `extra_write` caches
+   (`~/.cache/node-gyp`, `~/.npm/_prebuilds`, …) which don't exist on a clean machine. **Fix:**
+   replicate this harness's `canonicalizeForAllow` — realpath the nearest EXISTING ancestor and
+   re-append the non-existent tail — instead of `Path::canonicalize`.
+2. **The DARWIN confstr write grant is absent.** Production's write set is
+   `package_dir + sandbox_home + extra_write` + `/dev`; none covers the per-user
+   `/private/var/folders/<uid>/{T,C}` the Apple toolchain writes `xcrun_db` to via confstr
+   (§Darwin). A from-source compile under the production jail emits the EPERM xcrun noise. **Fix:**
+   grant the confstr pair (query `getconf`/`confstr`, canonicalize) — the `--darwin-temp` grant
+   here.
+3. **The tmp-anchor repoint must happen at the embedder seam.** The node-gyp fix (§node-gyp) is
+   `TMPDIR`/`TMP`/`TEMP` = the granted private scratch. Production `script_sandbox_env()`
+   allowlists those KEYS but injects no VALUES, and `macos.rs` deliberately DROPS the `/tmp`
+   re-allow — so unless the nub embedder sets `TMPDIR/TMP/TEMP/HOME = sandbox_home` before
+   `apply()`, node-gyp's `os.tmpdir()` `mkdtemp` is denied and every from-source build breaks.
+   **Verify** the embedder does this; it is the load-bearing pairing for the dropped `/tmp` grant.
+
+(Lower-severity: production grants `/dev` as a subpath where the tight literal device set
+suffices — looser-not-defect, since writing a real device node needs root.)
+
 ## Conclusion
 
 The write-confine mechanism is sound and bypass-resistant on macOS: symlink-escape, `..`, and

--- a/tests/sandbox-macos-writeconfine/results.md
+++ b/tests/sandbox-macos-writeconfine/results.md
@@ -112,6 +112,16 @@ the confstr pair (`DARWIN_USER_TEMP_DIR` + `DARWIN_USER_CACHE_DIR`) silences it 
 grants them with `--darwin-temp` (jail-run passes it by default); paths queried from `getconf`
 so the `<uid>` hash is correct on any machine.
 
+**Breadth note (surfaced by the smoke suite):** `--darwin-temp` grants the WHOLE
+`/private/var/folders/<uid>/{T,C}` subtree, so anything any of the user's processes drops there
+is writable by the jailed script. That is the per-user OS temp/cache tree (already
+same-user-readable, OS-managed, not a code-execution persistence sink), so the risk is low — but
+it means a test fixture must NOT be placed under the darwin temp dir or its writes look
+"allowed" (the smoke suite bases its fixture under `/tmp` for exactly this reason). A tighter
+alternative if the breadth is ever a concern: grant only a nub-created subdir of the darwin temp
+dir and repoint the toolchain at it — but xcrun's confstr lookup ignores env, so that needs a
+per-build bind/copy and isn't worth it for OS scratch.
+
 ## §Collapse — base-anchor HOME-repoint (the optimization verdict)
 
 **Repointing `HOME` at ONE granted cache root collapses the N per-tool caches to a single grant.**

--- a/tests/sandbox-macos-writeconfine/results.md
+++ b/tests/sandbox-macos-writeconfine/results.md
@@ -131,16 +131,53 @@ scratch + ONE base-anchor cache root (HOME-repointed) + the DARWIN confstr pair.
 
 ## §Catalog — cache-family holes (empirical sweep)
 
-<!-- Filled from the cache-family empirical sweep: per family — representative package, install
-command, exact denied out-of-package write path under strict, genuine-write-vs-prefetchable,
-HOME-repoint capture. -->
+Every row reproduced against the real tool under the write-confine profile (EPERM captured), on
+the mega-fixture (Bun-trusted list + frameworks, `pnpm install --ignore-scripts`).
 
-## Conclusion (so far)
+| Family | Repr. pkg | Install cmd | Denied out-of-pkg write under strict | Genuine write vs pre-populatable | HOME-repoint captures? |
+|---|---|---|---|---|---|
+| node-gyp-build + bundled prebuilds | bufferutil, bcrypt | `node-gyp-build` | **NONE** — strict exit 0, loads in-pkg `prebuilds/*.node` | no write | n/a |
+| prebuild-install | sqlite3 | `prebuild-install \|\| node-gyp rebuild` | `npm_config_cache/_prebuilds` (default `~/.npm/_prebuilds`); `.node` extracts in-pkg | genuine (tarball cache) | yes (via `npm_config_cache`, default `$HOME/.npm`) |
+| node-gyp from source | cpu-features, better-sqlite3 | `node-gyp rebuild` | devdir `~/Library/Caches/node-gyp/<ver>` (HOME-derived); objects/`.node` in-pkg | genuine on FIRST header fetch; **pre-populatable read-only after** (headers present → strict exit 0) | yes |
+| browser/engine blobs | cypress, electron, playwright-core | `node …/install` | `~/Library/Caches/{Cypress,electron,ms-playwright}` (HOME-derived); binary RUNS from cache | genuine cache write | yes (all 3) |
+| prisma | @prisma/engines | `node scripts/postinstall.js` | `~/.cache/prisma` (`getRootCacheDir`, HOME/XDG-derived); engine copied in-pkg | genuine download cache (live denial NOT reproduced — postinstall self-skipped; path source-confirmed) | yes |
+| sharp | sharp | `node install/check.js` | **NONE** — prebuilt optionalDep `@img/sharp-darwin-arm64` | no write | n/a |
+| node-sass | node-sass | `node scripts/install.js` | **NONE by default** — binary in-pkg `vendor/<abi>/binding.node`; cache copy → `npm_config_cache/node-sass`. Hole only if user sets `SASS_BINARY_DIR` outside pkg | in-pkg + captured cache | yes |
+| **git-hook installers** | pre-commit | `node install.js` | **`<project>/.git/hooks/pre-commit`** — `EPERM open` | **genuine project-tree write, NOT a cache** | **NO — the one true residual** |
+
+Representative captured EPERM: `prebuild-install warn install EPERM … mkdir '…/extcache-sqlite'`;
+`gyp ERR! … EPERM … mkdir '…/fresh-devdir-cpu'`; `EPERM … mkdir '…/fresh-{cypress,electron,pw}-cache'`;
+`node-sass: Unable to save binary … EPERM mkdir '…/darwin-arm64-147'` (external dir only);
+`pre-commit: Found .git in <proj>/.git → EPERM … open '<proj>/.git/hooks/pre-commit'`.
+
+**HOME-collapse, independently confirmed by the sweep:** with `HOME=$CACHEROOT` and relaxed jail
+granting ONLY `$CACHEROOT`, four independent tool caches (node-gyp headers, Cypress, electron,
+ms-playwright) all relocated inside that one root and the builds/downloads COMPLETED.
+
+**Residuals beyond the one cache root:**
+- **git-hook `<project>/.git/hooks`** — not HOME-derived, not a cache; the single legitimate
+  project-tree write-confine collision (pre-commit, husky, simple-git-hooks, yorkie, …). A narrow,
+  opt-in `.git/hooks` carve-out for trusted hook installers, or those installers no-op under strict.
+- **`npm_config_cache`** — defaults to `$HOME/.npm` (captured if unset), but commonly set
+  explicitly, so point it into the same cache root rather than relying on the HOME default.
+- **OS tmp root + Apple confstr scratch** — `TMPDIR`/`TMP`/`TEMP` → private scratch; the per-user
+  `/private/var/folders/<uid>/{T,C}` confstr pair (§Darwin).
+
+**Not-reproduced flags (honest):** prisma's live denial (postinstall self-skipped even after wiping
+the engine + lock — cache path source-confirmed + HOME/XDG-derived, so it collapses, but the denial
+wasn't forced); git-hook installers other than pre-commit failed on a hand-built-fixture artifact
+(broken pnpm symlinks from a `cp -R`), not a sandbox finding — zero-dep pre-commit cleanly proved
+the `.git/hooks` collision.
+
+## Conclusion
 
 The write-confine mechanism is sound and bypass-resistant on macOS: symlink-escape, `..`, and
 in-jail hardlink-creation all fail closed because Seatbelt matches the canonical path and gates
 link-creation on the target. The one mandatory correctness rule is **canonicalizing every
 write-allow path** (a symlink-form allow is inert → would deny all writes and break every build
-under a `/tmp`- or `/var`-rooted tree). Package-dir-only is not a viable write set; pkg + private
-tmp + one base-anchor-captured cache root is. The cache-family catalog + the HOME-collapse
-verdict follow below once the sweep completes.
+under a `/tmp`- or `/var`-rooted tree). Package-dir-only is not a viable write set; **pkg + private
+tmp + one base-anchor-captured cache root (HOME + `npm_config_cache` → it) + the DARWIN confstr
+pair** is — the N-tool cache enumeration collapses to one granted root (§Catalog/§Collapse). The
+sole non-cache residual is the git-hook `<project>/.git/hooks` write (an opt-in carve-out for
+trusted hook installers). And node-gyp headers are pre-populatable read-only (strict exit 0 once
+present), so prefetch drives the cache write-need of the dominant native family toward zero.

--- a/tests/sandbox-macos-writeconfine/smoke-test.sh
+++ b/tests/sandbox-macos-writeconfine/smoke-test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Self-contained macOS write-confine smoke tests — the fast core of the harness:
+# enforcement + the bypass surface, no mega-fixture, no network. Each assertion
+# carries a negative control so a PASS cannot be vacuous. Exits non-zero on any
+# failure (CI gate). Run: ./smoke-test.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GEN="$HERE/gen-profile.mjs"
+FAIL=0
+pass() { echo "  ok  $1"; }
+fail() { echo "FAIL  $1"; FAIL=$((FAIL + 1)); }
+
+[[ "$(uname)" == "Darwin" ]] || { echo "smoke-test: macOS only (uname=$(uname))"; exit 2; }
+
+# Base the fixture under /tmp (-> /private/tmp), NOT mktemp's default
+# /var/folders/<uid>/T — the latter is the DARWIN_USER_TEMP_DIR that --darwin-temp
+# legitimately grants, which would make a fixture placed there writable and mask the
+# confinement. /private/tmp is outside every grant, so an out-of-pkg write there is a
+# true negative.
+B="$(mktemp -d /tmp/scwc-base.XXXXXX)"
+trap 'rm -rf "$B"' EXIT
+mkdir -p "$B/pkg" "$B/secret"
+echo ORIGINAL >"$B/secret/data.txt"
+PROF="$(node "$GEN" --pkg "$B/pkg" --mode strict --darwin-temp)"
+
+# A profile that fails to PARSE must fail-CLOSED (sandbox-exec errors, no run).
+if sandbox-exec -p "(version 1) (this-is-not-valid" /bin/echo hi >/dev/null 2>&1; then
+  fail "malformed profile should fail-closed (sandbox-exec must error)"
+else
+  pass "malformed profile fails closed (sandbox-exec errors, does not run unconfined)"
+fi
+
+# 1. write INSIDE pkg → allowed
+if sandbox-exec -p "$PROF" /bin/sh -c "echo hi >'$B/pkg/in.txt'" 2>/dev/null; then
+  pass "write inside pkg allowed"
+else
+  fail "write inside pkg should be allowed"
+fi
+
+# 2. write OUTSIDE pkg → EPERM (the confinement)
+if sandbox-exec -p "$PROF" /bin/sh -c "echo hi >'$B/secret/out.txt'" 2>/dev/null; then
+  fail "write outside pkg should be DENIED"
+else
+  pass "write outside pkg denied"
+fi
+
+# 3. symlink escape → blocked
+ln -sf "$B/secret" "$B/pkg/link"
+if sandbox-exec -p "$PROF" /bin/sh -c "echo PWNED >'$B/pkg/link/data.txt'" 2>/dev/null; then
+  fail "symlink-escape should be blocked"
+else
+  [[ "$(cat "$B/secret/data.txt")" == ORIGINAL ]] && pass "symlink-escape blocked (secret intact)" || fail "symlink-escape mutated secret"
+fi
+
+# 4. .. traversal → blocked
+if sandbox-exec -p "$PROF" /bin/sh -c "echo PWNED >'$B/pkg/../secret/dd.txt'" 2>/dev/null; then
+  fail ".. traversal should be blocked"
+else
+  [[ -e "$B/secret/dd.txt" ]] && fail ".. traversal created file" || pass ".. traversal blocked"
+fi
+
+# 5. in-jail hardlink creation to an out-of-root inode → blocked at creation
+if sandbox-exec -p "$PROF" /bin/sh -c "ln '$B/secret/data.txt' '$B/pkg/h.txt'" 2>/dev/null; then
+  fail "in-jail hardlink creation to out-of-root target should be denied"
+else
+  pass "in-jail hardlink creation to out-of-root target denied"
+fi
+
+# 6. device /dev/null write → allowed (the device minimum)
+if sandbox-exec -p "$PROF" /bin/sh -c "echo x >/dev/null" 2>/dev/null; then
+  pass "/dev/null write allowed (device minimum)"
+else
+  fail "/dev/null write should be allowed"
+fi
+
+# 7. canonicalization: a write-allow given in SYMLINK form must still confine —
+#    i.e. the generator emits the canonical path so the allow actually works AND
+#    nothing outside it is writable. Use a /tmp-rooted pkg (firmlink to /private/tmp).
+TMPPKG="$(mktemp -d /tmp/scwc.XXXXXX)"
+PROF2="$(node "$GEN" --pkg "$TMPPKG" --mode strict)"
+if sandbox-exec -p "$PROF2" /bin/sh -c "echo hi >'$TMPPKG/a.txt'" 2>/dev/null; then
+  pass "canonicalized /tmp-form pkg grant actually allows the write (not inert)"
+else
+  fail "canonicalized /tmp-form pkg grant should allow the write (symlink-form would be inert)"
+fi
+rm -rf "$TMPPKG"
+
+echo
+if [[ $FAIL -eq 0 ]]; then echo "ALL SMOKE TESTS PASS"; else echo "$FAIL SMOKE FAILURE(S)"; fi
+exit $((FAIL == 0 ? 0 : 1))

--- a/tests/sandbox-macos-writeconfine/smoke-test.sh
+++ b/tests/sandbox-macos-writeconfine/smoke-test.sh
@@ -48,15 +48,19 @@ fi
 ln -sf "$B/secret" "$B/pkg/link"
 if sandbox-exec -p "$PROF" /bin/sh -c "echo PWNED >'$B/pkg/link/data.txt'" 2>/dev/null; then
   fail "symlink-escape should be blocked"
+elif [[ "$(cat "$B/secret/data.txt")" == ORIGINAL ]]; then
+  pass "symlink-escape blocked (secret intact)"
 else
-  [[ "$(cat "$B/secret/data.txt")" == ORIGINAL ]] && pass "symlink-escape blocked (secret intact)" || fail "symlink-escape mutated secret"
+  fail "symlink-escape mutated secret"
 fi
 
 # 4. .. traversal → blocked
 if sandbox-exec -p "$PROF" /bin/sh -c "echo PWNED >'$B/pkg/../secret/dd.txt'" 2>/dev/null; then
   fail ".. traversal should be blocked"
+elif [[ -e "$B/secret/dd.txt" ]]; then
+  fail ".. traversal created file"
 else
-  [[ -e "$B/secret/dd.txt" ]] && fail ".. traversal created file" || pass ".. traversal blocked"
+  pass ".. traversal blocked"
 fi
 
 # 5. in-jail hardlink creation to an out-of-root inode → blocked at creation


### PR DESCRIPTION
Self-contained harness validating the macOS write-confine mechanism for the build-jail (counterpart to `tests/sandbox-win-probes/`): SBPL profile generator + `sandbox-exec` runner + unit/smoke tests + a `macos-latest` CI workflow + `results.md`, validated against a Bun-trusted-list + frameworks mega-fixture.

Findings: symlink/`..`/in-jail-hardlink escapes fail closed; write-allow paths must be canonicalized; `HOME`-repoint collapses the N caches to one root. Opus self-review fixed a generator fail-open + a bash-3.2 crash (regression-tested). Touches nothing under `crates/`; defaults recommend-only.