### PR TITLE
fix(install): suppress IWR progress bar on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -41,7 +41,11 @@ $Url = "https://github.com/nubjs/nub/releases/download/v$Version/nub-$Target.zip
 Write-Host "Downloading from $Url..."
 
 $TmpZip = Join-Path $env:TEMP "nub-$Target-$PID.zip"
+# Suppress the per-chunk progress bar — it re-renders on every received byte
+# and dominates the total download time in PowerShell.
+$prevProgressPreference = $ProgressPreference
 try {
+    $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
     # Replace any prior bin\ for a clean upgrade. A stale runtime\ from a
     # pre-single-binary install is also removed for hygiene, then extract bin\.
@@ -52,6 +56,7 @@ try {
     Write-Error "Failed to download/extract nub: $_"
     exit 1
 } finally {
+    $ProgressPreference = $prevProgressPreference
     if (Test-Path $TmpZip) { Remove-Item -Force $TmpZip }
 }
 

--- a/site/public/install.ps1
+++ b/site/public/install.ps1
@@ -41,7 +41,11 @@ $Url = "https://github.com/nubjs/nub/releases/download/v$Version/nub-$Target.zip
 Write-Host "Downloading from $Url..."
 
 $TmpZip = Join-Path $env:TEMP "nub-$Target-$PID.zip"
+# Suppress the per-chunk progress bar — it re-renders on every received byte
+# and dominates the total download time in PowerShell.
+$prevProgressPreference = $ProgressPreference
 try {
+    $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
     # Replace any prior bin\ for a clean upgrade. A stale runtime\ from a
     # pre-single-binary install is also removed for hygiene, then extract bin\.
@@ -52,6 +56,7 @@ try {
     Write-Error "Failed to download/extract nub: $_"
     exit 1
 } finally {
+    $ProgressPreference = $prevProgressPreference
     if (Test-Path $TmpZip) { Remove-Item -Force $TmpZip }
 }
 


### PR DESCRIPTION
`Invoke-WebRequest` re-renders a progress bar on every received chunk. In PowerShell this dominates the total download time.

Fix: set `$ProgressPreference = 'SilentlyContinue'` around the `Invoke-WebRequest` call, restore it after.

Applied to both `install.ps1` and `site/public/install.ps1`.

**Before / after on the same machine:**

<img width="1746" height="420" alt="pwsh-install-before-fix" src="https://github.com/user-attachments/assets/1ff89128-a22b-4fdf-98fc-9db638a60f4c" />

<img width="1834" height="420" alt="pwsh-install-after-fix" src="https://github.com/user-attachments/assets/02cd29b7-eddb-4019-8b7d-d07860751faf" />


| | |
|---|---|
| Before | 1m 39s |
| After | 6s |
