### PR TITLE
aube bun lockfile reader: accept lockfileVersion 2 (forward-compat for unreleased bun 1.4)

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/bun/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/read.rs
@@ -23,11 +23,18 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         Err(e) => return Err(Error::parse_json_err(path, raw_content, &e)),
     };
 
-    if raw.lockfile_version != 1 {
+    // bun.lock's on-disk JSON shape is identical across v1 and v2: bun's
+    // own writer documents v1→v2 as added parse-time STRICTNESS on the
+    // same content (it rejects an off-registry npm tuple with missing
+    // integrity and an unsafe git `.bun-tag` that v1 tolerated), not a
+    // format change. v2 became the default for fresh installs in bun 1.4.
+    // So accept both versions through the identical parse path; we don't
+    // replicate bun's v2 strictness (this is a lenient reader).
+    if !matches!(raw.lockfile_version, 1 | 2) {
         return Err(Error::parse(
             path,
             format!(
-                "bun.lock lockfileVersion {} is not supported (expected 1)",
+                "bun.lock lockfileVersion {} is not supported (expected 1 or 2)",
                 raw.lockfile_version
             ),
         ));

--- a/vendor/aube/crates/aube-lockfile/src/bun/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/tests.rs
@@ -2128,3 +2128,77 @@ fn git_hosted_remote_tarball_is_emitted_as_bun_git_tuple() {
          entry (the bug that fails bun's cold-cache frozen install):\n{body}"
     );
 }
+
+/// bun stamps `lockfileVersion: 2` on fresh installs as of bun 1.4
+/// (`bun.lock.rs`: `Version::CURRENT = V2`). v1→v2 added only parse-time
+/// strictness on identical on-disk content, so a v2 lockfile parses
+/// through the same path as v1 — its package versions and integrity
+/// hashes must land on the graph unchanged. The same `{ ident, "",
+/// { meta }, integrity }` tuple shape is used; only the header number
+/// differs from `test_parse_simple`.
+#[test]
+fn test_parse_accepts_lockfile_version_2() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let sri_foo = fake_sri('a');
+    let sri_bar = fake_sri('b');
+    let content = r#"{
+  "lockfileVersion": 2,
+  "workspaces": {
+    "": {
+      "name": "test",
+      "dependencies": {
+        "foo": "^1.0.0",
+        "bar": "^2.0.0",
+      },
+    },
+  },
+  "packages": {
+    "foo": ["foo@1.2.3", "", { "dependencies": { "bar": "^2.0.0" } }, "SRI_FOO"],
+    "bar": ["bar@2.5.0", "", {}, "SRI_BAR"],
+  }
+}"#
+    .replace("SRI_FOO", &sri_foo)
+    .replace("SRI_BAR", &sri_bar);
+    std::fs::write(tmp.path(), &content).unwrap();
+    let graph = parse(tmp.path()).unwrap();
+
+    assert_eq!(graph.packages.len(), 2);
+    assert_eq!(
+        graph.packages["foo@1.2.3"].integrity.as_deref(),
+        Some(sri_foo.as_str())
+    );
+    assert_eq!(
+        graph.packages["bar@2.5.0"].integrity.as_deref(),
+        Some(sri_bar.as_str())
+    );
+    assert_eq!(
+        graph.packages["foo@1.2.3"]
+            .dependencies
+            .get("bar")
+            .map(String::as_str),
+        Some("2.5.0")
+    );
+    let root = graph.importers.get(".").unwrap();
+    assert!(root.iter().any(|d| d.name == "foo"));
+    assert!(root.iter().any(|d| d.name == "bar"));
+}
+
+/// Only v1 and v2 are known bun.lock shapes; an unknown version
+/// (a future format, or a corrupt/hand-edited header) must still be
+/// rejected rather than silently mis-parsed against the v1/v2 layout.
+#[test]
+fn test_parse_rejects_unsupported_lockfile_version() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+  "lockfileVersion": 3,
+  "workspaces": { "": { "name": "test" } },
+  "packages": {}
+}"#;
+    std::fs::write(tmp.path(), content).unwrap();
+    let err = parse(tmp.path()).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("lockfileVersion 3") && msg.contains("expected 1 or 2"),
+        "unsupported version error should name the version and the supported set, got: {msg}"
+    );
+}


### PR DESCRIPTION
The aube bun reader hard-errored on `lockfileVersion != 1`, rejecting a `bun.lock` from bun 1.4 (`Version::CURRENT = V2`, stamped on fresh installs). bun 1.4 is finalized in source but unreleased; lands forward-compat.

The on-disk JSON shape is unchanged v1->v2 (bun documents it as parse-time strictness on identical content, not a format change), so accepting v2 is additive: the v1 path is byte-for-byte unchanged. v0/v3/unknown stay rejected. Default-preserving; upstreamable to jdx/aube.

Tests: a v2 fixture (versions, integrity, transitive resolution) and a boundary test rejecting an unknown version.

https://claude.ai/code/session_01TuvdYzBgmnyJQJDXheWmF9