### PR TITLE
feat(lockfile): read legacy npm lockfiles (lockfileVersion 1 + pre-2017 shrinkwrap)

### DIFF
--- a/crates/nub-cli/src/pm_engine/use_align.rs
+++ b/crates/nub-cli/src/pm_engine/use_align.rs
@@ -287,7 +287,9 @@ fn parse_source_graph(
 ) -> Result<aube_lockfile::LockfileGraph> {
     match from_kind {
         LockfileKind::Pnpm | LockfileKind::Aube => aube_lockfile::pnpm::parse(from),
-        LockfileKind::Npm | LockfileKind::NpmShrinkwrap => aube_lockfile::npm::parse(from),
+        LockfileKind::Npm | LockfileKind::NpmShrinkwrap => {
+            aube_lockfile::npm::parse(from, manifest)
+        }
         LockfileKind::Yarn | LockfileKind::YarnBerry => aube_lockfile::yarn::parse(from, manifest),
         LockfileKind::Bun => aube_lockfile::bun::parse(from),
     }

--- a/vendor/aube/crates/aube-codes/src/warnings.rs
+++ b/vendor/aube/crates/aube-codes/src/warnings.rs
@@ -95,6 +95,8 @@ pub const WARN_AUBE_YARN_BERRY_UNSUPPORTED: &str = "WARN_AUBE_YARN_BERRY_UNSUPPO
 pub const WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX: &str =
     "WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX";
 pub const WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE: &str = "WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE";
+pub const WARN_AUBE_LOCKFILE_LEGACY_INCOMPLETE_GRAPH: &str =
+    "WARN_AUBE_LOCKFILE_LEGACY_INCOMPLETE_GRAPH";
 
 // ── progress UI ─────────────────────────────────────────────────────
 pub const WARN_AUBE_PROGRESS_OVERFLOW: &str = "WARN_AUBE_PROGRESS_OVERFLOW";
@@ -525,6 +527,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE,
         category: category::LOCKFILE,
         description: "`aube outdated -g` found a global install without a lockfile and skipped that install.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_LOCKFILE_LEGACY_INCOMPLETE_GRAPH,
+        category: category::LOCKFILE,
+        description: "A legacy npm lockfile (lockfileVersion 1 / pre-2017 npm-shrinkwrap.json) hoists a package to the top level with no recorded dependency edge — pre-npm-5 shrinkwraps omit the `requires` links that record which package depends on it. The package is unreachable from the project's dependencies and will not be installed. Re-lock with npm 7+ (or `nub install` then commit the regenerated lockfile) for a complete graph.",
         exit_code: None,
     },
     // Progress UI

--- a/vendor/aube/crates/aube-lockfile/src/io.rs
+++ b/vendor/aube/crates/aube-lockfile/src/io.rs
@@ -509,7 +509,7 @@ fn parse_one(
         // caller keeps the kind label it resolved from
         // `refine_yarn_kind` for downstream write-back.
         LockfileKind::Yarn | LockfileKind::YarnBerry => yarn::parse(path, manifest),
-        LockfileKind::Npm | LockfileKind::NpmShrinkwrap => npm::parse(path),
+        LockfileKind::Npm | LockfileKind::NpmShrinkwrap => npm::parse(path, manifest),
         LockfileKind::Bun => bun::parse(path),
     }?;
     validate_resolution_shapes(path, &graph)?;

--- a/vendor/aube/crates/aube-lockfile/src/npm/raw.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/raw.rs
@@ -9,10 +9,69 @@ pub(super) struct InstallPathInfo {
 
 #[derive(Debug, Deserialize)]
 pub(super) struct RawNpmLockfile {
-    #[serde(rename = "lockfileVersion")]
-    pub(super) lockfile_version: u32,
+    /// `Option` (not `u32`) because pre-2017 `npm-shrinkwrap.json` omits
+    /// the field entirely — npm 3/4 wrote no `lockfileVersion`. The
+    /// reader treats `None` as the legacy (nested-`dependencies`) format,
+    /// the same as an explicit `lockfileVersion: 1`. A required `u32`
+    /// here is what made an old shrinkwrap hard-fail at serde with
+    /// `missing field lockfileVersion` before it could reach the
+    /// version branch.
+    #[serde(rename = "lockfileVersion", default)]
+    pub(super) lockfile_version: Option<u32>,
     #[serde(default)]
     pub(super) packages: BTreeMap<String, RawNpmPackage>,
+}
+
+/// Pre-npm-7 lockfile shape: `package-lock.json` `lockfileVersion 1`
+/// (npm 5/6) and pre-2017 `npm-shrinkwrap.json` (no `lockfileVersion`).
+/// Both encode the resolution as a recursively-nested `dependencies`
+/// tree instead of the flat install-path-keyed `packages` map the
+/// v2/v3 reader consumes — `read::lift_legacy_to_packages` walks this
+/// into that flat form so the rest of the reader is unchanged.
+#[derive(Debug, Deserialize)]
+pub(super) struct RawNpmLegacyLockfile {
+    #[serde(default)]
+    pub(super) dependencies: BTreeMap<String, RawNpmLegacyDep>,
+}
+
+/// One entry in the legacy nested `dependencies` tree. npm hoists the
+/// shared version to the top level and nests only the conflicting one,
+/// so nesting depth here is the package's install path
+/// (`node_modules/<a>/node_modules/<b>/…`).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RawNpmLegacyDep {
+    #[serde(default)]
+    pub(super) version: Option<String>,
+    #[serde(default)]
+    pub(super) resolved: Option<String>,
+    /// sha512 (npm 5.1+/6), sha1 (npm 5.0), or ABSENT (npm ≤4 / npm 3).
+    /// aube's store verifies sha512, so a missing/sha1 hash is recovered
+    /// at install time: a `None` integrity is filled from the streaming
+    /// fetch's computed sha512 (`apply_computed_integrities`), and a
+    /// sha1 is verified directly by the store (sha1 is in the SRI set
+    /// `aube-store::integrity` accepts). Either way the install succeeds.
+    #[serde(default)]
+    pub(super) integrity: Option<String>,
+    /// v1's single edge list (declared name → range). v1 predates the
+    /// per-entry `optionalDependencies` split, so this lumps regular and
+    /// optional deps; it maps onto `RawNpmPackage.dependencies`, which
+    /// the reader uses to seed forward-refs and preserve declared ranges.
+    #[serde(default)]
+    pub(super) requires: BTreeMap<String, String>,
+    /// npm marks an entry shipped inside a parent tarball's
+    /// `bundleDependencies`. Maps to `in_bundle`; fidelity-only.
+    #[serde(default)]
+    pub(super) bundled: bool,
+    /// Nested (non-hoisted) deps. Their install path is this entry's
+    /// path plus `/node_modules/<name>`.
+    #[serde(default)]
+    pub(super) dependencies: BTreeMap<String, RawNpmLegacyDep>,
+    // `from` (npm-internal spec string), `dev`, and `optional` are
+    // intentionally not captured: `from` is recoverable from name+version,
+    // and the v2/v3 pipeline classifies dev/optional from the root
+    // manifest sections — not from per-entry flags — so capturing them
+    // here would have no place to flow. See `lift_legacy_to_packages`.
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/vendor/aube/crates/aube-lockfile/src/npm/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/read.rs
@@ -2,7 +2,9 @@ use crate::{DepType, DirectDep, Error, LocalSource, LockedPackage, LockfileGraph
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use super::raw::{InstallPathInfo, RawNpmLegacyLockfile, RawNpmLegacyDep, RawNpmLockfile, RawNpmPackage};
+use super::raw::{
+    InstallPathInfo, RawNpmLegacyDep, RawNpmLegacyLockfile, RawNpmLockfile, RawNpmPackage,
+};
 /// Parse a package-lock.json or npm-shrinkwrap.json file into a LockfileGraph.
 ///
 /// `manifest` is consulted only on the legacy (`lockfileVersion < 2` or
@@ -482,7 +484,7 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
 /// the *correct* source, not a shortcut: mislabeling a hoisted
 /// transitive as a root direct dep would over-hoist it into aube's
 /// isolated root `node_modules/` and break the phantom-dep guarantee.
-fn lift_legacy_to_packages(
+pub(super) fn lift_legacy_to_packages(
     legacy: &RawNpmLegacyLockfile,
     manifest: &aube_manifest::PackageJson,
 ) -> RawNpmLockfile {
@@ -505,10 +507,66 @@ fn lift_legacy_to_packages(
 
     lift_legacy_tree(&legacy.dependencies, "node_modules", &mut packages);
 
+    // Honesty diagnostic for the pre-npm-5 flat-shrinkwrap limitation
+    // (see `legacy_unreferenced_top_level`): a fully-hoisted npm 3/4
+    // shrinkwrap omits `requires`, so a top-level transitive whose incoming
+    // edge is recorded nowhere is unreachable and the writer's reachability
+    // walk drops it — it will not install. Surface it rather than silently
+    // shipping a broken tree. Legacy-path-only: never runs for v2/v3.
+    let orphans = legacy_unreferenced_top_level(legacy, &packages, manifest);
+    if !orphans.is_empty() {
+        let list = orphans.join(", ");
+        tracing::warn!(
+            code = aube_codes::warnings::WARN_AUBE_LOCKFILE_LEGACY_INCOMPLETE_GRAPH,
+            "legacy lockfile omits dependency edges for {} hoisted package(s) ({list}); they are unreachable from the project's dependencies and will not be installed. Re-lock with a modern npm for a complete graph.",
+            orphans.len(),
+        );
+    }
+
     RawNpmLockfile {
         lockfile_version: Some(1),
         packages,
     }
+}
+
+/// Top-level legacy packages with NO incoming edge — referenced by neither
+/// the project manifest nor any lifted package's recorded dependencies
+/// (`requires` plus nesting-derived edges). Such a package is unreachable
+/// from the project's dependencies, so the reachability-pruning writer drops
+/// it and it never installs. The cause is structural: a fully-hoisted npm
+/// 3/4 `npm-shrinkwrap.json` records transitives at the top level but omits
+/// the `requires` links that say which package needs them, so the edge
+/// exists nowhere in the file and is unrecoverable from the lockfile alone
+/// (npm 3 rebuilt it by reading each fetched package.json — a thing a
+/// lockfile reader cannot do). Returning the list lets the caller warn.
+pub(super) fn legacy_unreferenced_top_level(
+    legacy: &RawNpmLegacyLockfile,
+    packages: &BTreeMap<String, RawNpmPackage>,
+    manifest: &aube_manifest::PackageJson,
+) -> Vec<String> {
+    let mut referenced: BTreeSet<&str> = BTreeSet::new();
+    for k in manifest
+        .dependencies
+        .keys()
+        .chain(manifest.dev_dependencies.keys())
+        .chain(manifest.optional_dependencies.keys())
+    {
+        referenced.insert(k.as_str());
+    }
+    for (install_path, pkg) in packages {
+        if install_path.is_empty() {
+            continue;
+        }
+        for dep_name in pkg.dependencies.keys() {
+            referenced.insert(dep_name.as_str());
+        }
+    }
+    legacy
+        .dependencies
+        .keys()
+        .filter(|name| !referenced.contains(name.as_str()))
+        .cloned()
+        .collect()
 }
 
 /// Recursively flatten one level of the legacy `dependencies` tree at

--- a/vendor/aube/crates/aube-lockfile/src/npm/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/read.rs
@@ -2,20 +2,32 @@ use crate::{DepType, DirectDep, Error, LocalSource, LockedPackage, LockfileGraph
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use super::raw::{InstallPathInfo, RawNpmLockfile};
+use super::raw::{InstallPathInfo, RawNpmLegacyLockfile, RawNpmLegacyDep, RawNpmLockfile, RawNpmPackage};
 /// Parse a package-lock.json or npm-shrinkwrap.json file into a LockfileGraph.
-pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
+///
+/// `manifest` is consulted only on the legacy (`lockfileVersion < 2` or
+/// absent) path, where the lockfile carries no `""` root entry marking
+/// which packages are direct deps — those come from package.json, the
+/// same way the yarn-classic reader recovers importers. The v2/v3 path
+/// ignores it.
+pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<LockfileGraph, Error> {
     let content = crate::read_lockfile(path)?;
     let mut raw: RawNpmLockfile = crate::parse_json(path, content)?;
 
-    if raw.lockfile_version < 2 {
-        return Err(Error::parse(
-            path,
-            format!(
-                "package-lock.json lockfileVersion {} is not supported (need v2 or v3)",
-                raw.lockfile_version
-            ),
-        ));
+    // Pre-npm-7 lockfiles — `package-lock.json` `lockfileVersion 1`
+    // (npm 5/6) and pre-2017 `npm-shrinkwrap.json` (no `lockfileVersion`,
+    // hence the `unwrap_or(1)` default) — use a nested `dependencies`
+    // tree and have no flat `packages` map. Lift either into the same
+    // flat install-path-keyed representation the v2/v3 reader below
+    // consumes, then fall through unchanged. This is the whole legacy
+    // story: one pre-pass, the battle-tested nested-resolution / hoist /
+    // importer pipeline reused verbatim. Re-reading the file on this
+    // rare path keeps the common v2/v3 path a single allocation-free
+    // parse.
+    if raw.lockfile_version.unwrap_or(1) < 2 {
+        let content = crate::read_lockfile(path)?;
+        let legacy: RawNpmLegacyLockfile = crate::parse_json(path, content)?;
+        raw = lift_legacy_to_packages(&legacy, manifest);
     }
 
     // `npm install --prefix <proj>` (run from a different cwd than the
@@ -451,6 +463,98 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         graph.importers.insert(target.clone(), direct);
     }
     Ok(graph)
+}
+
+/// Lift a pre-npm-7 nested-`dependencies` tree into the flat,
+/// install-path-keyed `RawNpmLockfile.packages` representation the
+/// v2/v3 reader consumes. npm's nesting encodes the install path
+/// exactly as the v2/v3 `packages` keys do — a top-level
+/// `dependencies.foo` lives at `node_modules/foo`; a nested
+/// `dependencies.foo.dependencies.bar` (npm nests only the conflicting
+/// version, hoisting the shared one to the top) lives at
+/// `node_modules/foo/node_modules/bar` — so the synthesized paths feed
+/// `resolve_nested` and the hoist walk with no special-casing.
+///
+/// v1 lockfiles list every resolved package (direct + hoisted
+/// transitive) flat at the top level and carry no `""` root entry
+/// marking which are direct, so the root importer's deps are taken from
+/// the manifest (the yarn-classic precedent). Reading the manifest is
+/// the *correct* source, not a shortcut: mislabeling a hoisted
+/// transitive as a root direct dep would over-hoist it into aube's
+/// isolated root `node_modules/` and break the phantom-dep guarantee.
+fn lift_legacy_to_packages(
+    legacy: &RawNpmLegacyLockfile,
+    manifest: &aube_manifest::PackageJson,
+) -> RawNpmLockfile {
+    let mut packages: BTreeMap<String, RawNpmPackage> = BTreeMap::new();
+
+    // The `""` root entry: the v2/v3 reader reads the project's direct
+    // deps (and their declared ranges, used as importer specifiers) from
+    // its `dependencies`/`devDependencies`/`optionalDependencies`
+    // sections. Synthesize them from the manifest. name/version are
+    // unused by the reader for the root entry, so they stay defaulted.
+    packages.insert(
+        String::new(),
+        RawNpmPackage {
+            dependencies: manifest.dependencies.clone(),
+            dev_dependencies: manifest.dev_dependencies.clone(),
+            optional_dependencies: manifest.optional_dependencies.clone(),
+            ..Default::default()
+        },
+    );
+
+    lift_legacy_tree(&legacy.dependencies, "node_modules", &mut packages);
+
+    RawNpmLockfile {
+        lockfile_version: Some(1),
+        packages,
+    }
+}
+
+/// Recursively flatten one level of the legacy `dependencies` tree at
+/// install-path `prefix` (`node_modules` for the top level), pushing one
+/// `RawNpmPackage` per entry and recursing into nested `dependencies`
+/// one `node_modules` level deeper.
+fn lift_legacy_tree(
+    deps: &BTreeMap<String, RawNpmLegacyDep>,
+    prefix: &str,
+    out: &mut BTreeMap<String, RawNpmPackage>,
+) {
+    for (name, dep) in deps {
+        let install_path = format!("{prefix}/{name}");
+        // Edges come from `requires` (declared name → range), which the
+        // reader uses to seed forward-refs and preserve declared ranges;
+        // the second pass resolves the actual target via the nested-tree
+        // walk. Pre-npm-5 shrinkwraps omit `requires` entirely and
+        // express edges ONLY through nesting, so a nested child IS a
+        // declared dependency of its parent — fold those names in (a `*`
+        // range stands in for the unrecorded specifier; the resolved
+        // target still comes from the nested-tree walk). A hoisted-to-root
+        // transitive of a no-`requires` shrinkwrap has no edge anywhere in
+        // the file and stays unrecoverable — a flat-layout limitation
+        // documented in the PR.
+        let mut dependencies = dep.requires.clone();
+        for child_name in dep.dependencies.keys() {
+            dependencies
+                .entry(child_name.clone())
+                .or_insert_with(|| "*".to_string());
+        }
+        out.insert(
+            install_path.clone(),
+            RawNpmPackage {
+                version: dep.version.clone(),
+                resolved: dep.resolved.clone(),
+                integrity: dep.integrity.clone(),
+                dependencies,
+                in_bundle: dep.bundled,
+                ..Default::default()
+            },
+        );
+        if !dep.dependencies.is_empty() {
+            let child_prefix = format!("{install_path}/node_modules");
+            lift_legacy_tree(&dep.dependencies, &child_prefix, out);
+        }
+    }
 }
 
 /// Canonical project-relative form of an npm `packages` install path

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -5,6 +5,16 @@ use crate::{DepType, DirectDep, Error, GitSource, LocalSource, LockedPackage, Lo
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+/// Test shim shadowing the manifest-taking `read::parse`. Every v2/v3
+/// reader test predates the manifest param (consulted only on the
+/// legacy `<v2` path), so default it. Legacy-path tests below call
+/// `super::read::parse` with an explicit manifest. A local item beats
+/// the `use super::*` glob import, so this requires no churn at the 30+
+/// existing call sites.
+fn parse(path: &Path) -> Result<LockfileGraph, Error> {
+    super::read::parse(path, &aube_manifest::PackageJson::default())
+}
+
 #[test]
 fn test_package_name_from_install_path() {
     assert_eq!(
@@ -1408,8 +1418,12 @@ fn test_write_dev_optional_flags() {
     assert!(packages["node_modules/foo"].get("dev").is_none());
 }
 
+/// `lockfileVersion 1` is now SUPPORTED (was rejected before the legacy
+/// reader landed). An empty v1 lockfile lifts to an empty graph rather
+/// than erroring — the legacy branch fires and the manifest (empty here)
+/// drives the importer.
 #[test]
-fn test_reject_v1() {
+fn legacy_v1_empty_lockfile_parses() {
     let tmp = tempfile::NamedTempFile::new().unwrap();
     let content = r#"{
             "name": "test",
@@ -1418,8 +1432,9 @@ fn test_reject_v1() {
         }"#;
     std::fs::write(tmp.path(), content).unwrap();
 
-    let err = parse(tmp.path()).unwrap_err();
-    assert!(matches!(err, Error::Parse(_, msg) if msg.contains("lockfileVersion 1")));
+    let graph = read::parse(tmp.path(), &aube_manifest::PackageJson::default()).unwrap();
+    assert!(graph.packages.is_empty());
+    assert!(graph.importers["."].is_empty());
 }
 
 /// Pre-npm-2.x packages (e.g. `ansi-html-community@0.0.8`) ship
@@ -2610,4 +2625,384 @@ fn test_roundtrip_preserves_npm_verbatim_meta_fields() {
     assert_eq!(addon2.deprecated.as_deref(), Some("use native-addon@2 instead"));
     assert_eq!(addon2.bundled_dependencies, vec!["inner".to_string()]);
     assert!(reparsed.packages["inner@2.0.0"].in_bundle);
+}
+
+// ---------------------------------------------------------------------
+// Legacy (pre-npm-7) lockfile reader: `package-lock.json`
+// `lockfileVersion 1` (npm 5/6) and pre-2017 `npm-shrinkwrap.json` (no
+// `lockfileVersion`). Both use a nested `dependencies` tree the reader
+// lifts into the v2/v3 flat representation before the shared pipeline
+// runs. Differential oracle: the v1 and v2 fixtures below are the SAME
+// dependency set (authentic npm 6 vs npm 8 output for `is-odd@^3.0.0`),
+// so the lifted v1 graph must equal the v2 graph modulo fields v1
+// doesn't carry.
+// ---------------------------------------------------------------------
+
+/// Build a root manifest with the given production deps (legacy
+/// lockfiles carry no `""` root entry, so direct deps come from here).
+fn manifest_with_deps(deps: &[(&str, &str)]) -> aube_manifest::PackageJson {
+    aube_manifest::PackageJson {
+        dependencies: deps
+            .iter()
+            .map(|(n, r)| ((*n).to_string(), (*r).to_string()))
+            .collect(),
+        ..Default::default()
+    }
+}
+
+fn write_lockfile(content: &str) -> tempfile::NamedTempFile {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), content).unwrap();
+    tmp
+}
+
+/// Authentic npm 6 (`node:14`) v1 `package-lock.json` for `is-odd@^3.0.0`
+/// (pulls transitive `is-number`). Carries sha512 integrity.
+const V1_PACKAGE_LOCK: &str = r#"{
+  "name": "legacy-test",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "is-number": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-6.0.0.tgz",
+      "integrity": "sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg=="
+    },
+    "is-odd": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz",
+      "integrity": "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==",
+      "requires": {
+        "is-number": "^6.0.0"
+      }
+    }
+  }
+}"#;
+
+/// Authentic npm 3 (`node:6`) pre-2017 `npm-shrinkwrap.json` for the
+/// same dep set: NO `lockfileVersion`, NO `integrity`, uses `from`.
+const OLD_SHRINKWRAP: &str = r#"{
+  "name": "legacy-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-number": {
+      "version": "6.0.0",
+      "from": "is-number@>=6.0.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-6.0.0.tgz"
+    },
+    "is-odd": {
+      "version": "3.0.1",
+      "from": "is-odd@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz"
+    }
+  }
+}"#;
+
+/// v1 `package-lock.json` lifts into the same graph the v2/v3 reader
+/// builds: package set, versions, integrity, tarball URL, the
+/// `is-odd → is-number` edge, and the manifest-driven root importer.
+#[test]
+fn legacy_v1_package_lock_lifts_to_graph() {
+    let tmp = write_lockfile(V1_PACKAGE_LOCK);
+    let manifest = manifest_with_deps(&[("is-odd", "^3.0.0")]);
+    let graph = read::parse(tmp.path(), &manifest).unwrap();
+
+    assert_eq!(graph.packages.len(), 2);
+    let is_odd = &graph.packages["is-odd@3.0.1"];
+    assert_eq!(is_odd.version, "3.0.1");
+    assert_eq!(
+        is_odd.integrity.as_deref(),
+        Some("sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==")
+    );
+    assert_eq!(
+        is_odd.tarball_url.as_deref(),
+        Some("https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz")
+    );
+    // `requires` resolves through the nested-tree walk to the hoisted
+    // is-number; the edge value is the dep_path tail (just the version).
+    assert_eq!(
+        is_odd.dependencies.get("is-number").map(String::as_str),
+        Some("6.0.0")
+    );
+
+    let is_number = &graph.packages["is-number@6.0.0"];
+    assert_eq!(
+        is_number.integrity.as_deref(),
+        Some("sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==")
+    );
+
+    // Direct deps come from the manifest, NOT the lockfile (v1 has no
+    // root entry): is-odd is direct, is-number is hoisted-transitive.
+    let root = graph.importers.get(".").unwrap();
+    assert_eq!(root.len(), 1);
+    assert_eq!(root[0].name, "is-odd");
+    assert_eq!(root[0].dep_type, DepType::Production);
+    assert_eq!(root[0].specifier.as_deref(), Some("^3.0.0"));
+}
+
+/// The differential oracle: the lifted v1 graph equals the v2 graph for
+/// the same dependency set, comparing every field v1 carries.
+#[test]
+fn legacy_v1_matches_v2_reader_differentially() {
+    // The v2 fixture for the same `is-odd@^3.0.0` dep set (authentic
+    // npm 8 output). Root entry present, flat `packages` map.
+    const V2_PACKAGE_LOCK: &str = r#"{
+      "name": "legacy-test",
+      "version": "1.0.0",
+      "lockfileVersion": 2,
+      "requires": true,
+      "packages": {
+        "": {
+          "name": "legacy-test",
+          "version": "1.0.0",
+          "dependencies": { "is-odd": "^3.0.0" }
+        },
+        "node_modules/is-number": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-6.0.0.tgz",
+          "integrity": "sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==",
+          "engines": { "node": ">=0.10.0" }
+        },
+        "node_modules/is-odd": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz",
+          "integrity": "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==",
+          "dependencies": { "is-number": "^6.0.0" },
+          "engines": { "node": ">=4" }
+        }
+      }
+    }"#;
+
+    let v1 = read::parse(
+        write_lockfile(V1_PACKAGE_LOCK).path(),
+        &manifest_with_deps(&[("is-odd", "^3.0.0")]),
+    )
+    .unwrap();
+    // v2 has a root entry, so the manifest is ignored — default is fine.
+    let v2 = parse(write_lockfile(V2_PACKAGE_LOCK).path()).unwrap();
+
+    // Same package set, versions, integrity, tarball URL, dep edges.
+    assert_eq!(
+        v1.packages.keys().collect::<Vec<_>>(),
+        v2.packages.keys().collect::<Vec<_>>()
+    );
+    for (dep_path, v1_pkg) in &v1.packages {
+        let v2_pkg = &v2.packages[dep_path];
+        assert_eq!(v1_pkg.version, v2_pkg.version, "version {dep_path}");
+        assert_eq!(v1_pkg.integrity, v2_pkg.integrity, "integrity {dep_path}");
+        assert_eq!(
+            v1_pkg.tarball_url, v2_pkg.tarball_url,
+            "tarball_url {dep_path}"
+        );
+        assert_eq!(
+            v1_pkg.dependencies, v2_pkg.dependencies,
+            "dep edges {dep_path}"
+        );
+    }
+    // Same root importer (name, dep_path, type, specifier). DirectDep
+    // has no PartialEq, so compare the load-bearing fields explicitly.
+    let project = |d: &DirectDep| {
+        (
+            d.name.clone(),
+            d.dep_path.clone(),
+            d.dep_type,
+            d.specifier.clone(),
+        )
+    };
+    let v1_root: Vec<_> = v1.importers["."].iter().map(project).collect();
+    let v2_root: Vec<_> = v2.importers["."].iter().map(project).collect();
+    assert_eq!(v1_root, v2_root);
+}
+
+/// pre-2017 `npm-shrinkwrap.json`: no `lockfileVersion` (→ legacy path
+/// via the `unwrap_or(1)` default), no `integrity`. The reader must
+/// produce a graph with `integrity: None` and the `resolved` URL
+/// preserved — the install path recovers sha512 from the fetch (proven
+/// by the e2e test in the PR). Before this change it hard-failed at
+/// serde with `missing field lockfileVersion`.
+#[test]
+fn legacy_old_shrinkwrap_no_version_no_integrity() {
+    let tmp = write_lockfile(OLD_SHRINKWRAP);
+    let manifest = manifest_with_deps(&[("is-odd", "^3.0.0")]);
+    let graph = read::parse(tmp.path(), &manifest).unwrap();
+
+    assert_eq!(graph.packages.len(), 2);
+    let is_odd = &graph.packages["is-odd@3.0.1"];
+    assert_eq!(is_odd.integrity, None);
+    assert_eq!(
+        is_odd.tarball_url.as_deref(),
+        Some("https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz")
+    );
+    assert_eq!(graph.packages["is-number@6.0.0"].integrity, None);
+
+    let root = graph.importers.get(".").unwrap();
+    assert_eq!(root.len(), 1);
+    assert_eq!(root[0].name, "is-odd");
+    assert_eq!(root[0].specifier.as_deref(), Some("^3.0.0"));
+}
+
+/// Nested/deduped hoisting: npm hoists the shared version to the top and
+/// nests only the conflicting one. The tree walk must synthesize the
+/// nested install path so `resolve_nested` routes each parent to the
+/// right version — `a → shared@1` (hoisted), `b → shared@2` (nested
+/// under b).
+#[test]
+fn legacy_v1_nested_dedupe_hoisting() {
+    const NESTED: &str = r#"{
+      "name": "nest-test",
+      "version": "1.0.0",
+      "lockfileVersion": 1,
+      "requires": true,
+      "dependencies": {
+        "a": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/a/-/a-1.0.0.tgz",
+          "integrity": "sha512-aaa",
+          "requires": { "shared": "^1.0.0" }
+        },
+        "shared": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shared/-/shared-1.0.0.tgz",
+          "integrity": "sha512-s1"
+        },
+        "b": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/b/-/b-1.0.0.tgz",
+          "integrity": "sha512-bbb",
+          "requires": { "shared": "^2.0.0" },
+          "dependencies": {
+            "shared": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/shared/-/shared-2.0.0.tgz",
+              "integrity": "sha512-s2"
+            }
+          }
+        }
+      }
+    }"#;
+    let tmp = write_lockfile(NESTED);
+    let manifest = manifest_with_deps(&[("a", "^1.0.0"), ("b", "^1.0.0")]);
+    let graph = read::parse(tmp.path(), &manifest).unwrap();
+
+    // Both versions of the conflicting dep are present.
+    assert!(graph.packages.contains_key("shared@1.0.0"));
+    assert!(graph.packages.contains_key("shared@2.0.0"));
+    // a resolves to the hoisted shared@1; b to its nested shared@2.
+    assert_eq!(
+        graph.packages["a@1.0.0"]
+            .dependencies
+            .get("shared")
+            .map(String::as_str),
+        Some("1.0.0")
+    );
+    assert_eq!(
+        graph.packages["b@1.0.0"]
+            .dependencies
+            .get("shared")
+            .map(String::as_str),
+        Some("2.0.0")
+    );
+
+    let mut root: Vec<&str> = graph.importers["."].iter().map(|d| d.name.as_str()).collect();
+    root.sort_unstable();
+    assert_eq!(root, vec!["a", "b"]);
+}
+
+/// Scoped package install path (`node_modules/@scope/pkg`) plus
+/// manifest-driven dev/optional classification — v1 carries no per-entry
+/// section split, so dep_type comes entirely from the manifest sections.
+#[test]
+fn legacy_v1_scoped_and_dev_optional() {
+    const SCOPED: &str = r#"{
+      "name": "s",
+      "version": "1.0.0",
+      "lockfileVersion": 1,
+      "requires": true,
+      "dependencies": {
+        "@scope/pkg": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@scope/pkg/-/pkg-1.0.0.tgz",
+          "integrity": "sha512-sc"
+        },
+        "devdep": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/devdep/-/devdep-2.0.0.tgz",
+          "integrity": "sha512-dd",
+          "dev": true
+        },
+        "optdep": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/optdep/-/optdep-3.0.0.tgz",
+          "integrity": "sha512-od",
+          "optional": true
+        }
+      }
+    }"#;
+    let tmp = write_lockfile(SCOPED);
+    let manifest = aube_manifest::PackageJson {
+        dependencies: [("@scope/pkg".to_string(), "^1.0.0".to_string())]
+            .into_iter()
+            .collect(),
+        dev_dependencies: [("devdep".to_string(), "^2.0.0".to_string())]
+            .into_iter()
+            .collect(),
+        optional_dependencies: [("optdep".to_string(), "^3.0.0".to_string())]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    let graph = read::parse(tmp.path(), &manifest).unwrap();
+
+    // Scoped name is recovered from the `node_modules/@scope/pkg` path.
+    assert_eq!(graph.packages["@scope/pkg@1.0.0"].name, "@scope/pkg");
+
+    let root = graph.importers.get(".").unwrap();
+    let by_name = |n: &str| root.iter().find(|d| d.name == n).unwrap();
+    assert_eq!(by_name("@scope/pkg").dep_type, DepType::Production);
+    assert_eq!(by_name("devdep").dep_type, DepType::Dev);
+    assert_eq!(by_name("optdep").dep_type, DepType::Optional);
+}
+
+/// Pre-npm-5 shrinkwraps (npm 3/4) omit `requires` and express the
+/// dependency edge ONLY through nesting: a child under a parent's
+/// `dependencies` IS a dep of that parent. The lift must recover that
+/// edge from the nesting so the transitive resolves and installs —
+/// otherwise a no-`requires` nested shrinkwrap would parse but drop the
+/// child. (The hoisted-to-root variant, where the transitive is a flat
+/// top-level sibling with no edge anywhere in the file, is the one
+/// documented limitation — that edge is unrecoverable from the lockfile.)
+#[test]
+fn legacy_nested_no_requires_recovers_edge_from_nesting() {
+    const NESTED_NO_REQUIRES: &str = r#"{
+      "name": "nest-noreq",
+      "version": "1.0.0",
+      "dependencies": {
+        "parent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/parent/-/parent-1.0.0.tgz",
+          "dependencies": {
+            "child": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/child/-/child-2.0.0.tgz"
+            }
+          }
+        }
+      }
+    }"#;
+    let tmp = write_lockfile(NESTED_NO_REQUIRES);
+    let manifest = manifest_with_deps(&[("parent", "^1.0.0")]);
+    let graph = read::parse(tmp.path(), &manifest).unwrap();
+
+    assert!(graph.packages.contains_key("parent@1.0.0"));
+    assert!(graph.packages.contains_key("child@2.0.0"));
+    // The edge is recovered from nesting (no `requires` present) and
+    // resolves to the nested child@2.0.0.
+    assert_eq!(
+        graph.packages["parent@1.0.0"]
+            .dependencies
+            .get("child")
+            .map(String::as_str),
+        Some("2.0.0")
+    );
 }

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -3006,3 +3006,41 @@ fn legacy_nested_no_requires_recovers_edge_from_nesting() {
         Some("2.0.0")
     );
 }
+
+/// The pre-npm-5 flat-shrinkwrap limitation, surfaced: when a transitive is
+/// hoisted to the top level with its incoming edge recorded NOWHERE (no
+/// `requires`, no nesting — the shape npm 3/4 produced), it is unreachable
+/// and would silently drop. The lift must flag it
+/// (drives WARN_AUBE_LOCKFILE_LEGACY_INCOMPLETE_GRAPH). The counter-case —
+/// the same graph carrying `requires` — must flag nothing.
+#[test]
+fn legacy_flat_hoisted_transitive_flagged_as_unreferenced() {
+    let manifest = manifest_with_deps(&[("is-odd", "^3.0.0")]);
+
+    let flat: super::raw::RawNpmLegacyLockfile = serde_json::from_str(
+        r#"{ "dependencies": {
+            "is-odd": { "version": "3.0.1", "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz" },
+            "is-number": { "version": "6.0.0", "resolved": "https://registry.npmjs.org/is-number/-/is-number-6.0.0.tgz" }
+        } }"#,
+    )
+    .unwrap();
+    let lifted = read::lift_legacy_to_packages(&flat, &manifest);
+    assert_eq!(
+        read::legacy_unreferenced_top_level(&flat, &lifted.packages, &manifest),
+        vec!["is-number".to_string()],
+        "the edgeless hoisted transitive must be flagged"
+    );
+
+    let with_requires: super::raw::RawNpmLegacyLockfile = serde_json::from_str(
+        r#"{ "dependencies": {
+            "is-odd": { "version": "3.0.1", "requires": { "is-number": "^6.0.0" } },
+            "is-number": { "version": "6.0.0" }
+        } }"#,
+    )
+    .unwrap();
+    let lifted = read::lift_legacy_to_packages(&with_requires, &manifest);
+    assert!(
+        read::legacy_unreferenced_top_level(&with_requires, &lifted.packages, &manifest).is_empty(),
+        "a recorded `requires` edge means nothing is orphaned"
+    );
+}

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
@@ -4820,7 +4820,7 @@ fn npm_to_pnpm_conversion_omits_phantom_member_links_on_empty_root() {
     let npm_path = root.join("package-lock.json");
     std::fs::write(&npm_path, npm_lock).unwrap();
 
-    let graph = crate::npm::parse(&npm_path).unwrap();
+    let graph = crate::npm::parse(&npm_path, &aube_manifest::PackageJson::default()).unwrap();
 
     // Root manifest declares NO deps (empty root importer).
     let manifest = PackageJson {

--- a/vendor/aube/crates/aube-resolver/src/platform.rs
+++ b/vendor/aube/crates/aube-resolver/src/platform.rs
@@ -812,7 +812,8 @@ mod tests {
         }"#;
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(tmp.path(), content).unwrap();
-        let mut graph = aube_lockfile::npm::parse(tmp.path()).unwrap();
+        let mut graph =
+            aube_lockfile::npm::parse(tmp.path(), &aube_manifest::PackageJson::default()).unwrap();
 
         let host_dep_path = graph.importers["."][0].dep_path.clone();
         assert!(


### PR DESCRIPTION
Reads `package-lock.json` lockfileVersion 1 (npm 5/6) and pre-2017 `npm-shrinkwrap.json` (nested `dependencies`, no `lockfileVersion`) — both previously hard-failed the install. The legacy nested tree is lifted into the existing flat v2/v3 `packages` representation, then reuses the unchanged reader pipeline (nested resolution, hoist, importers).

Default-preserving: the legacy branch fires only for lockfileVersion < 2 / absent, which standalone aube rejected, so the v2/v3 path is byte-for-byte unchanged — a clean additive upstream candidate for jdx/aube.

- The `lockfile_version` field becomes `Option` (old shrinkwraps omit it); direct deps come from package.json (yarn-classic model), so `npm::parse` now takes the manifest, threaded at the reader and the pm-use conversion path.
- Edges come from `requires` plus nesting (pre-npm-5 shrinkwraps omit `requires`).
- No-integrity / sha1 entries (npm 3 / npm 5.0) reuse the unchanged verify path: a missing pin warns and recovers a fresh sha512, or refuses under `strict-store-integrity`. The v2/v3 trust posture is untouched (reader-only diff).
- A fully-hoisted shrinkwrap that omits a dependency edge entirely (the transitive is unreachable and would silently drop) now warns (`WARN_NUB_LOCKFILE_LEGACY_INCOMPLETE_GRAPH`) instead of shipping a broken tree.

Verified with real `nub install`: npm-6 v1 (2-pkg, a 13-pkg scoped/nested/dev fixture, and lodash/lodash's 673-entry v1 lockfile), npm-3 oldshrink (warns + installs), `--frozen-lockfile`, and the strict-store-integrity refusal. Gates green (clippy/fmt/464 aube-lockfile tests). Five fresh-context self-review passes (correctness, impact, format-fidelity, security, follow-up) all clean.

Known follow-up: v1 git/`file:` deps encode the source marker in `version` (not `resolved`), so they aren't routed yet and fail loudly; registry deps — the dominant v1 population — work fully.
