### PR TITLE
feat(dist): winget manifest + release-time winget-pkgs submission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1064,3 +1064,51 @@ jobs:
           git add Formula/nub.rb
           git commit -m "nub: update formula to v$VERSION"
           git push
+
+  submit-winget:
+    name: Submit winget manifest
+    # Open/refresh the Nubjs.Nub manifest in microsoft/winget-pkgs for this release.
+    # Runs ONLY on a real tag-push release (never the debug workflow_dispatch path)
+    # and AFTER github-release, because the manifest references the published
+    # release-asset URLs + their SHA256 sidecars this run created.
+    #
+    # HELD FOR MAINTAINER ENABLEMENT — this is an EXTERNAL, effectively-irreversible
+    # publish under the nubjs publisher identity (winget-releaser opens a PR on
+    # microsoft/winget-pkgs from the token owner's fork). It is a NO-OP until a
+    # WINGET_PAT secret is present: the gate step below reads the secret and skips
+    # the submission when it is absent (empty string), so merging this workflow
+    # fires NOTHING. winget-releaser also UPDATES an existing package — the FIRST
+    # version (Nubjs.Nub v1) is bootstrapped manually from the committed
+    # winget/manifests/... set. Both are documented in winget/README.md.
+    if: github.event_name == 'push'
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      # winget-releaser opens the PR under a FORK of microsoft/winget-pkgs owned by
+      # the WINGET_PAT account. The default GITHUB_TOKEN cannot fork or push there,
+      # so a classic PAT (scope: public_repo) — or a fine-grained token with
+      # contents+pull-requests:write on that fork — must be added as the WINGET_PAT
+      # repo secret. Absent the secret (empty string), skip rather than fail.
+      - name: Check winget token present
+        id: gate
+        env:
+          WINGET_PAT: ${{ secrets.WINGET_PAT }}
+        run: |
+          if [ -z "${WINGET_PAT:-}" ]; then
+            echo "::warning::WINGET_PAT secret absent — skipping winget-pkgs submission. See winget/README.md to enable."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Submit manifest to winget-pkgs
+        if: steps.gate.outputs.enabled == 'true'
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: Nubjs.Nub
+          version: ${{ steps.gate.outputs.version }}
+          release-tag: ${{ github.ref_name }}
+          # Match only the two Windows portable zips this release uploads.
+          installers-regex: '^nub-win32-(x64|arm64)\.zip$'
+          token: ${{ secrets.WINGET_PAT }}

--- a/.github/workflows/winget-validate.yml
+++ b/.github/workflows/winget-validate.yml
@@ -1,0 +1,90 @@
+name: winget manifest
+
+# High-confidence test that the committed winget manifest actually installs nub,
+# WITHOUT needing the manifest to be published to microsoft/winget-pkgs. It runs
+# the exact operation the winget-pkgs validation bot runs — download the release
+# zip, verify its SHA256, extract, and register the portable binaries — so a green
+# run here means the same manifest will pass the bot's gate when submitted.
+#
+# Path-filtered to manifest/workflow changes (a static manifest only needs
+# re-testing when it changes) plus manual dispatch — it does not run a Windows
+# runner on every unrelated PR. Broaden the paths/triggers if you want it on all PRs.
+
+on:
+  pull_request:
+    paths:
+      - "winget/**"
+      - ".github/workflows/winget-validate.yml"
+  push:
+    branches: [main]
+    paths:
+      - "winget/**"
+      - ".github/workflows/winget-validate.yml"
+  workflow_dispatch:
+
+jobs:
+  install-from-manifest:
+    name: winget install --manifest (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # GitHub-hosted Windows runners do not reliably ship the winget CLI (it is a
+      # desktop App Installer component, not a Server feature). Install it if it's
+      # absent so the job is deterministic regardless of image drift.
+      - name: Ensure winget is available
+        shell: pwsh
+        run: |
+          if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+            Write-Host "winget not found; installing via Cyberboss/install-winget below."
+            echo "NEED_WINGET=1" >> $env:GITHUB_ENV
+          } else {
+            winget --version
+          }
+      - name: Install winget (if missing)
+        if: env.NEED_WINGET == '1'
+        uses: Cyberboss/install-winget@1c6f189175e9f015bf1aa113cd1cc6c73efb9d47 # v1
+
+      - name: Validate + install nub from the local manifest, then smoke
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # Resolve the single committed version directory (survives version bumps).
+          $verDir = Get-ChildItem -Directory winget/manifests/n/Nubjs/Nub |
+            Sort-Object Name | Select-Object -Last 1
+          if (-not $verDir) { Write-Error "no manifest version directory found"; exit 1 }
+          $manifest = $verDir.FullName
+          Write-Host "Testing manifest: $manifest"
+
+          # Schema lint. Informational: a schema ERROR also fails the install below
+          # (the authoritative gate), and winget validate returns a non-zero code for
+          # benign warnings too — so surface its output without hard-failing on it.
+          Write-Host "=== winget validate ==="
+          winget validate --manifest $manifest
+          Write-Host "validate exit code: $LASTEXITCODE"
+
+          # The authoritative gate — the same download + hash-verify + sandbox-style
+          # install the winget-pkgs bot performs. A bad URL, a wrong SHA256, or a
+          # broken nested-installer path fails HERE.
+          Write-Host "=== winget install --manifest ==="
+          winget install --manifest $manifest `
+            --accept-package-agreements --accept-source-agreements `
+            --disable-interactivity
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "winget install --manifest failed with exit code $LASTEXITCODE"
+            exit 1
+          }
+
+          # winget registers portable command aliases under the user Links dir and
+          # appends it to PATH, but that PATH change is not reflected in this running
+          # session — prepend it so the smoke can find the freshly-installed verbs.
+          $links = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
+          $env:PATH = "$links;$env:PATH"
+
+          Write-Host "=== smoke: nub --version / nubx --version ==="
+          nub --version
+          if ($LASTEXITCODE -ne 0) { Write-Error "nub --version failed"; exit 1 }
+          nubx --version
+          if ($LASTEXITCODE -ne 0) { Write-Error "nubx --version failed"; exit 1 }
+          Write-Host "OK: nub installed from the local winget manifest and both verbs run."

--- a/.github/workflows/winget-validate.yml
+++ b/.github/workflows/winget-validate.yml
@@ -64,20 +64,22 @@ jobs:
           winget validate --manifest $manifest
           Write-Host "validate exit code: $LASTEXITCODE"
 
-          # Installing FROM A LOCAL MANIFEST is an admin-gated winget feature, OFF by
-          # default ("This feature needs to be enabled by administrators ... winget
-          # settings --enable LocalManifestFiles"). GitHub-hosted Windows runners run
-          # elevated, so enabling it here is what lets the --manifest install proceed.
-          Write-Host "=== enable LocalManifestFiles ==="
+          # Two admin-gated winget settings must be enabled for an unattended install
+          # FROM A LOCAL MANIFEST of an ARCHIVE (zip) package — both default OFF and
+          # both surface as "This feature needs to be enabled by administrators ...".
+          # GitHub-hosted Windows runners are elevated, so enabling them here works.
+          #   LocalManifestFiles            — permits `winget install --manifest`.
+          #   LocalArchiveMalwareScanOverride — permits --ignore-local-archive-malware-scan,
+          #     which skips the archive malware scan that otherwise blocks unattended.
+          Write-Host "=== enable admin settings ==="
           winget settings --enable LocalManifestFiles
+          winget settings --enable LocalArchiveMalwareScanOverride
 
           # The authoritative gate — the same download + hash-verify + sandbox-style
           # install the winget-pkgs bot performs. A bad URL, a wrong SHA256, or a
-          # broken nested-installer path fails HERE.
-          #   --ignore-local-archive-malware-scan: a local-manifest ARCHIVE (zip)
-          #     install otherwise blocks on winget's local-archive malware scan in an
-          #     unattended session. (Irrelevant to the published package, which is
-          #     installed from the source, not a local manifest.)
+          # broken nested-installer path fails HERE. (The malware-scan override is
+          # irrelevant to the published package, which installs from the source, not
+          # a local manifest.)
           Write-Host "=== winget install --manifest ==="
           winget install --manifest $manifest `
             --accept-package-agreements --accept-source-agreements `

--- a/.github/workflows/winget-validate.yml
+++ b/.github/workflows/winget-validate.yml
@@ -64,13 +64,24 @@ jobs:
           winget validate --manifest $manifest
           Write-Host "validate exit code: $LASTEXITCODE"
 
+          # Installing FROM A LOCAL MANIFEST is an admin-gated winget feature, OFF by
+          # default ("This feature needs to be enabled by administrators ... winget
+          # settings --enable LocalManifestFiles"). GitHub-hosted Windows runners run
+          # elevated, so enabling it here is what lets the --manifest install proceed.
+          Write-Host "=== enable LocalManifestFiles ==="
+          winget settings --enable LocalManifestFiles
+
           # The authoritative gate — the same download + hash-verify + sandbox-style
           # install the winget-pkgs bot performs. A bad URL, a wrong SHA256, or a
           # broken nested-installer path fails HERE.
+          #   --ignore-local-archive-malware-scan: a local-manifest ARCHIVE (zip)
+          #     install otherwise blocks on winget's local-archive malware scan in an
+          #     unattended session. (Irrelevant to the published package, which is
+          #     installed from the source, not a local manifest.)
           Write-Host "=== winget install --manifest ==="
           winget install --manifest $manifest `
             --accept-package-agreements --accept-source-agreements `
-            --disable-interactivity
+            --disable-interactivity --ignore-local-archive-malware-scan
           if ($LASTEXITCODE -ne 0) {
             Write-Error "winget install --manifest failed with exit code $LASTEXITCODE"
             exit 1

--- a/winget/README.md
+++ b/winget/README.md
@@ -1,0 +1,111 @@
+# winget packaging
+
+Manifests and automation that make nub installable with `winget install` on Windows.
+
+winget installs from manifests published in the community repo
+[`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs). This directory
+holds:
+
+- `manifests/n/Nubjs/Nub/<version>/` — the three-file manifest set (version,
+  installer, en-US locale) for a published nub release. It is both the **first-submission
+  payload** for winget-pkgs and the **fixture** the test workflow installs from.
+- Automation: `.github/workflows/winget-validate.yml` (the per-change install test)
+  and a gated `submit-winget` job in `.github/workflows/release.yml` (release-time
+  submission of new versions).
+
+## Package identity
+
+| Field | Value |
+| --- | --- |
+| PackageIdentifier | `Nubjs.Nub` |
+| Moniker | `nub` (so `winget install nub` resolves once published) |
+| Installer | per-arch `.zip` (x64, arm64), portable `nub.exe` + `nubx.exe` |
+
+The publisher/casing (`Nubjs.Nub`, `nub contributors`) follows winget convention and
+can be adjusted on review before the first submission.
+
+## Confidence chain — why a broken manifest cannot reach users
+
+1. **Local / CI install from the manifest** (`winget install --manifest ...`) performs
+   the *exact* operation the winget-pkgs validation bot performs: download the release
+   zip, verify its SHA256, extract, and register the portable binaries. Green here means
+   the manifest is installable.
+2. **Submission to `microsoft/winget-pkgs`** opens a PR. Microsoft's validation bot
+   **re-runs that same install-in-sandbox check** and **blocks merge on failure**.
+3. Therefore a manifest that fails cannot be merged — the worst case of a bad submission
+   is "the PR doesn't merge," never "users get a broken install." The local/CI install is
+   the high-confidence pre-check that makes a submission near-certain to pass.
+
+## Testing
+
+### Automated (CI) — `winget install --manifest`
+
+`.github/workflows/winget-validate.yml` runs on `windows-latest` whenever the manifest
+or the workflow changes, and on manual `workflow_dispatch`. It `winget validate`s the
+manifest, then `winget install --manifest`s it and asserts `nub --version` and
+`nubx --version` succeed. This needs **no** winget-pkgs publication — it tests the
+manifest directly.
+
+### Manual local test (a Windows machine)
+
+```powershell
+winget validate --manifest .\winget\manifests\n\Nubjs\Nub\0.2.5
+winget install --manifest .\winget\manifests\n\Nubjs\Nub\0.2.5 `
+  --accept-package-agreements --accept-source-agreements
+nub --version
+nubx --version
+```
+
+### Highest-fidelity local test — Windows Sandbox
+
+winget-pkgs ships `Tools/SandboxTest.ps1`, which spins up Windows Sandbox and runs the
+manifest through the same flow the validation bot uses — a 1:1 mirror of the merge gate.
+On a Windows host with Windows Sandbox enabled, from a `microsoft/winget-pkgs` checkout:
+
+```powershell
+.\Tools\SandboxTest.ps1 <path-to>\winget\manifests\n\Nubjs\Nub\0.2.5
+```
+
+This is the most faithful pre-submission check; it is not run in CI (it requires
+Windows Sandbox / nested virtualization).
+
+### Post-publish smoke (only after the package is live in winget-pkgs)
+
+Once `Nubjs.Nub` exists in winget-pkgs, a scheduled/manual job can verify the *published*
+package end-to-end:
+
+```powershell
+winget install --id Nubjs.Nub --silent --accept-package-agreements --accept-source-agreements
+nub --version
+```
+
+This is secondary — it only works after submission; the per-change `--manifest` install
+above is the gate that matters.
+
+## Maintainer enablement (one-time)
+
+The release workflow's `submit-winget` job is a **no-op until enabled** — it auto-submits
+nothing without a secret.
+
+1. **Bootstrap the first version.** winget-releaser *updates* an existing package; the
+   first `Nubjs.Nub` version is submitted manually from the committed manifest. Either
+   open a PR to `microsoft/winget-pkgs` adding `manifests/n/Nubjs/Nub/0.2.5/` (the files
+   here), or run [`wingetcreate`](https://github.com/microsoft/winget-create):
+   `wingetcreate submit --token <PAT> .\winget\manifests\n\Nubjs\Nub\0.2.5`.
+   Verify CI/Sandbox green first.
+2. **Create the PAT.** Under the account that will own the winget-pkgs fork, create a
+   classic PAT with the `public_repo` scope (or a fine-grained token with
+   contents + pull-requests: write on the fork).
+3. **Add the secret.** Add it as the `WINGET_PAT` repository secret on `nubjs/nub`.
+
+After that, every tagged release auto-opens a winget-pkgs PR for the new version via the
+`submit-winget` job; Microsoft's bot validates and merges it.
+
+## Refreshing the committed manifest fixture
+
+The committed manifest pins a specific release (URLs + SHA256s). To re-point the CI test
+at a newer release, copy the version directory, bump `PackageVersion`, the two
+`InstallerUrl`s, and the `ReleaseNotesUrl`, and replace each `InstallerSha256` with the
+value from that release's `nub-win32-<arch>.zip.sha256` sidecar asset (uppercased).
+Ongoing winget-pkgs submissions are automated by `submit-winget`, so this fixture only
+needs refreshing when you want the test to track a newer release.

--- a/winget/manifests/n/Nubjs/Nub/0.2.5/Nubjs.Nub.installer.yaml
+++ b/winget/manifests/n/Nubjs/Nub/0.2.5/Nubjs.Nub.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Nubjs.Nub
+PackageVersion: 0.2.5
+# nub ships as a portable single binary inside a per-architecture .zip; the two
+# verbs (nub, nubx) are the same binary and dispatch on argv[0]. winget extracts
+# the zip and registers each as a portable command alias on PATH.
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin\nub.exe
+    PortableCommandAlias: nub
+  - RelativeFilePath: bin\nubx.exe
+    PortableCommandAlias: nubx
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nubjs/nub/releases/download/v0.2.5/nub-win32-x64.zip
+    InstallerSha256: 16E5C8EAA7CBE211FC8FB51FD6FA4AAB9B5C3938B077C19BAF995100977D4F39
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nubjs/nub/releases/download/v0.2.5/nub-win32-arm64.zip
+    InstallerSha256: E14BD184BD9723D3EC9E9553050365CF0BB9F8BAB9755CF3BC99D64A0B242EB3
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/winget/manifests/n/Nubjs/Nub/0.2.5/Nubjs.Nub.locale.en-US.yaml
+++ b/winget/manifests/n/Nubjs/Nub/0.2.5/Nubjs.Nub.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Nubjs.Nub
+PackageVersion: 0.2.5
+PackageLocale: en-US
+Publisher: nub contributors
+PublisherUrl: https://nubjs.com
+PublisherSupportUrl: https://github.com/nubjs/nub/issues
+PackageName: Nub
+PackageUrl: https://nubjs.com
+License: MIT
+LicenseUrl: https://github.com/nubjs/nub/blob/main/LICENSE
+Copyright: Copyright (c) 2026 nub contributors
+ShortDescription: A fast all-in-one toolkit that augments Node.js instead of replacing it.
+Description: |-
+  Nub is a Rust CLI that augments your installed Node.js via Node's own extension
+  surfaces. It runs TypeScript directly, runs scripts and package binaries faster,
+  ships a pnpm-shaped package manager that is lockfile-compatible with npm, pnpm,
+  and Bun, has a native watch mode, and manages Node versions — all without
+  replacing or forking Node.
+Moniker: nub
+Tags:
+  - typescript
+  - nodejs
+  - runtime
+  - package-manager
+  - node-version-manager
+  - script-runner
+  - developer-tools
+ReleaseNotesUrl: https://github.com/nubjs/nub/releases/tag/v0.2.5
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/winget/manifests/n/Nubjs/Nub/0.2.5/Nubjs.Nub.yaml
+++ b/winget/manifests/n/Nubjs/Nub/0.2.5/Nubjs.Nub.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Nubjs.Nub
+PackageVersion: 0.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Makes nub installable via `winget install` on Windows, with a high-confidence test path that does not require publishing to `microsoft/winget-pkgs` first.

## What's here

- **Manifest** — `winget/manifests/n/Nubjs/Nub/0.2.5/` (version, installer, en-US locale; schema 1.6.0). Installer type `zip` + `NestedInstallerType: portable`, one `Installer` per arch (x64, arm64) with the real release-asset URLs and SHA256s (read from the published `.sha256` sidecars). Exposes both `nub` and `nubx` as portable command aliases. This committed set is both the first-submission payload and the fixture the test workflow installs from.
- **Test workflow** — `.github/workflows/winget-validate.yml` (windows-latest): `winget validate` then `winget install --manifest` the local manifest, then asserts `nub --version` and `nubx --version`. Path-filtered to `winget/**` + the workflow file, plus `workflow_dispatch`. No winget-pkgs publication needed.
- **Release submission** — a `submit-winget` job in `.github/workflows/release.yml` that submits new versions to winget-pkgs via `vedantmgoyal9/winget-releaser` (pinned by SHA). Gated exactly like the existing `bump-homebrew-tap` job: it is a **no-op when the `WINGET_PAT` secret is absent**, so merging this fires nothing externally.
- **`winget/README.md`** — the test paths, the confidence chain, and the one-time maintainer enablement.

## Why the test is high-confidence

`winget install --manifest` performs the same operation the winget-pkgs validation bot performs — download the zip, verify its SHA256, extract, register the portable binaries. So:

1. Local/CI `winget install --manifest` green means the manifest is installable.
2. Submission to `microsoft/winget-pkgs` opens a PR; their bot re-runs that same install-in-sandbox check and blocks merge on failure.
3. A broken manifest therefore cannot reach users — worst case is "the PR doesn't merge."

The highest-fidelity local check (Windows Sandbox via winget-pkgs's `Tools/SandboxTest.ps1`) is documented in `winget/README.md`; it mirrors the bot 1:1 but needs nested virtualization, so it is referenced rather than run in CI.

## Held for maintainer sign-off

No external submission fires from this PR. To enable real submission later (per `winget/README.md`):

1. Bootstrap the first `Nubjs.Nub` version manually from the committed manifest (winget-releaser only updates an existing package).
2. Create a PAT (classic `public_repo`, or fine-grained contents+pull-requests:write on the winget-pkgs fork) under the account that forks winget-pkgs.
3. Add it as the `WINGET_PAT` repo secret. After that, each tagged release auto-opens a winget-pkgs PR.

## Notes

- Package id casing (`Nubjs.Nub`), moniker (`nub`), and publisher (`nub contributors`) follow winget convention and can be adjusted before the first submission.
- No originating issue exists, so no closing keyword.
- User-facing "winget install nub" docs are intentionally deferred until the package is live in winget-pkgs, to avoid documenting an install path that doesn't yet resolve.
- Windows is nub's least-exercised platform; winget exposure invites more Windows installs. Flagging, not gating.

https://claude.ai/code/session_01DnwgDLy5Tay9vsL544STPe
