### PR TITLE
pm: abort install on unresolvable yarn.lock sources and Yarn PnP

### DIFF
--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -158,6 +158,11 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     // The animated single-line install bar is nub's first-class TTY UX; the
     // engine still falls back to append-only for CI / piped / non-TTY output.
     tty_progress: true,
+    // nub's guarantee is "the installed tree equals the incumbent PM's, or an
+    // eager precise refusal" — so a lockfile source nub can't resolve (a
+    // git/jsr/unknown protocol in a yarn.lock or bun.lock) aborts at plan time
+    // for a non-optional dep, instead of reclassify→404 / silent drop.
+    strict_unsupported_source: true,
 };
 
 /// Register [`NUB`] as the active embedder profile. Idempotent (the engine's

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1188,8 +1188,22 @@ pub fn run_ci(flags: CiFlags) -> Result<i32> {
 fn yarn_drift_reason(dir: &Path) -> Option<String> {
     let manifest = aube_manifest::PackageJson::from_path(&dir.join("package.json")).ok()?;
     let graph = aube_lockfile::parse_lockfile(dir, &manifest).ok()?;
-    let satisfied: std::collections::HashSet<&str> =
+    let mut satisfied: std::collections::HashSet<&str> =
         graph.root_deps().iter().map(|d| d.name.as_str()).collect();
+    // An optional dependency the reader consciously skipped (e.g. an
+    // unresolvable `git`/`jsr` source under the strict-unsupported-source
+    // policy) is not drift — it's deliberately absent and needs no yarn.lock
+    // rewrite, exactly like a platform-filtered optional. Without this, an
+    // optional unsupported dep would trip the read-only yarn write-gate even
+    // though the policy is to warn + proceed.
+    // Root importer only, matching `root_deps()` above: this function checks
+    // only the root manifest, so folding a workspace member's skipped optional
+    // into `satisfied` could mask real root drift on a same-named dep. Both
+    // yarn readers key the root's skipped optionals under "." (classic keys
+    // members under their dir), so this lookup is exact.
+    if let Some(root_skipped) = graph.skipped_optional_dependencies.get(".") {
+        satisfied.extend(root_skipped.keys().map(String::as_str));
+    }
     let manifest_deps = manifest
         .dependencies
         .iter()

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -717,13 +717,13 @@ fn engine_session_inner(
     // when the resolver reads them. Filter applies in every family; warnings
     // + the catalog hard-error are install-family only (see `noise`).
     apply_config_scope(detected.as_ref(), &cwd, noise)?;
-    // Warn once at install time when the project requests Plug'n'Play
-    // (nodeLinker: pnp in .yarnrc.yml) but nub will install a node_modules
-    // tree instead — the embedder default below forces `hoisted` and the
-    // .yarnrc.yml is not re-read anywhere in the install path, so without this
-    // the divergence is entirely silent.
+    // Abort the install when the project requests Plug'n'Play (nodeLinker: pnp
+    // in .yarnrc.yml, or Yarn Berry's default): nub installs a node_modules
+    // tree, so honoring the lockfile under PnP would silently produce a
+    // materially different on-disk layout than yarn's. Install-family only
+    // (`noise == Warn`); read-only PM commands don't reach here.
     if noise == ConfigScopeNoise::Warn {
-        warn_if_pnp_requested(detected.as_ref(), &cwd);
+        pnp_fatal_if_requested(detected.as_ref(), &cwd)?;
     }
     // Truly-fresh = no PM-preference signal anywhere (no lockfile, no
     // declaration, no pnpm-named file). On this path nub claims identity via the
@@ -1813,24 +1813,34 @@ fn read_file_head(path: &Path, max_bytes: usize) -> std::io::Result<String> {
 /// linker is PnP but nub will install a `node_modules` tree instead. Yarn
 /// Berry defaults to PnP when no `nodeLinker` is configured, so absence is
 /// warning-worthy for Berry but not for Yarn Classic.
-fn warn_if_pnp_requested(detected: Option<&DetectedLockfile>, cwd: &Path) {
+/// Abort a mutating install when the Yarn project requests Plug'n'Play
+/// (`nodeLinker: pnp` in `.yarnrc.yml`, or Yarn Berry's default). nub installs
+/// a `node_modules` tree, so honoring the lockfile under PnP would silently
+/// produce a materially different on-disk layout than the incumbent's —
+/// exactly the silent partial the abort-eagerly policy refuses. Fatal at plan
+/// time (before any `node_modules` write); gated to the install family via the
+/// `noise == Warn` call site, so read-only PM commands are unaffected.
+fn pnp_fatal_if_requested(detected: Option<&DetectedLockfile>, cwd: &Path) -> Result<()> {
     let Some(kind @ (LockfileKind::Yarn | LockfileKind::YarnBerry)) = detected.map(|d| d.kind)
     else {
-        return;
+        return Ok(());
     };
     let root = detected.map(|d| d.dir.as_path()).unwrap_or(cwd);
     if effective_yarn_node_linker(root, cwd, kind == LockfileKind::YarnBerry).as_deref()
         == Some("pnp")
     {
-        let line = "nub: this Yarn project uses Plug'n'Play (nodeLinker: pnp or Yarn Berry's default), \
-                    which nub does not implement — installing a node_modules tree instead. \
-                    [WARN_NUB_PNP_LINKER_DOWNGRADE]";
-        if scope_warning_uses_dim() {
-            eprintln!("\x1b[2m{line}\x1b[0m");
-        } else {
-            eprintln!("{line}");
-        }
+        return Err(pnp_unsupported_error());
     }
+    Ok(())
+}
+
+fn pnp_unsupported_error() -> anyhow::Error {
+    anyhow::anyhow!(
+        "nub: this project is configured for Yarn Plug'n'Play (nodeLinker: pnp, or Yarn Berry's \
+         default) — nub installs a node_modules tree and doesn't support PnP yet, so the result \
+         would diverge from yarn's. Install with yarn, or set `nodeLinker: node-modules` in \
+         .yarnrc.yml. [ERR_NUB_PNP_UNSUPPORTED]"
+    )
 }
 
 fn effective_yarn_node_linker(root: &Path, cwd: &Path, berry_default_pnp: bool) -> Option<String> {
@@ -2640,14 +2650,14 @@ mod tests {
     }
 
     #[test]
-    fn warn_if_pnp_requested_fires_only_for_yarn_with_pnp_linker() {
+    fn pnp_fatal_fires_only_for_yarn_with_pnp_linker() {
         let dir = tempfile::tempdir().unwrap();
         let yarnrc = dir.path().join(".yarnrc.yml");
         static YARN_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-        // Helper that mirrors the gating logic without actually calling
-        // eprintln! — we check the predicate, not the output channel.
-        let would_warn = |kind: Option<LockfileKind>, content: Option<&str>| {
+        // Helper that mirrors the gating predicate without constructing the
+        // error — we check when the fatal fires, not its rendering.
+        let would_abort = |kind: Option<LockfileKind>, content: Option<&str>| {
             let _ = std::fs::remove_file(&yarnrc);
             if let Some(c) = content {
                 std::fs::write(&yarnrc, c).unwrap();
@@ -2677,25 +2687,25 @@ mod tests {
                     == Some("pnp")
         };
 
-        // Yarn + pnp → warn.
-        assert!(would_warn(
+        // Yarn + pnp → abort.
+        assert!(would_abort(
             Some(LockfileKind::Yarn),
             Some("nodeLinker: pnp\n")
         ));
-        assert!(would_warn(
+        assert!(would_abort(
             Some(LockfileKind::YarnBerry),
             Some("nodeLinker: pnp\n")
         ));
 
-        // Yarn + hoisted → no warn.
-        assert!(!would_warn(
+        // Yarn + hoisted → no abort.
+        assert!(!would_abort(
             Some(LockfileKind::Yarn),
             Some("nodeLinker: hoisted\n")
         ));
 
-        // Yarn Classic + no .yarnrc.yml → no warn; Yarn Berry defaults to PnP.
-        assert!(!would_warn(Some(LockfileKind::Yarn), None));
-        assert!(would_warn(Some(LockfileKind::YarnBerry), None));
+        // Yarn Classic + no .yarnrc.yml → no abort; Yarn Berry defaults to PnP.
+        assert!(!would_abort(Some(LockfileKind::Yarn), None));
+        assert!(would_abort(Some(LockfileKind::YarnBerry), None));
 
         // A nearer rc file overrides an ancestor rc file.
         std::fs::write(&yarnrc, "nodeLinker: pnp\n").unwrap();
@@ -2729,21 +2739,21 @@ mod tests {
         unsafe { std::env::remove_var("YARN_NODE_LINKER") };
 
         // Non-yarn kinds + pnp → no warn (npm/bun projects can't have .yarnrc.yml pnp).
-        assert!(!would_warn(
+        assert!(!would_abort(
             Some(LockfileKind::Npm),
             Some("nodeLinker: pnp\n")
         ));
-        assert!(!would_warn(
+        assert!(!would_abort(
             Some(LockfileKind::Bun),
             Some("nodeLinker: pnp\n")
         ));
-        assert!(!would_warn(
+        assert!(!would_abort(
             Some(LockfileKind::Pnpm),
             Some("nodeLinker: pnp\n")
         ));
 
         // No lockfile → no warn.
-        assert!(!would_warn(None, Some("nodeLinker: pnp\n")));
+        assert!(!would_abort(None, Some("nodeLinker: pnp\n")));
     }
 
     // The brand-surface toggles (workspace-yaml list, manifest config

--- a/crates/nub-cli/src/pm_engine/unsupported_config.rs
+++ b/crates/nub-cli/src/pm_engine/unsupported_config.rs
@@ -263,9 +263,9 @@ pub(crate) enum ScanResult {
 /// npm `legacy-peer-deps` (different peer graph) and npm
 /// `install-strategy=nested` (different resolution/layout). yarn
 /// `supportedArchitectures` is NOT here — the engine honors it via the
-/// arch-filter resolver. PnP stays a WARN+downgrade (handled separately in
-/// `warn_if_pnp_requested`), not
-/// promoted. `checksumBehavior`/`enableHardenedMode` are NOT here: aube verifies
+/// arch-filter resolver. yarn `nodeLinker: pnp` is a plan-time FATAL handled
+/// separately in `pnp_fatal_if_requested` (it needs `.yarnrc.yml` reading, not
+/// the role-keyed scan here). `checksumBehavior`/`enableHardenedMode` are NOT here: aube verifies
 /// every tarball's SHA-512 by default (`verifyStoreIntegrity=true`), satisfying
 /// the `throw` posture.
 pub(crate) fn scan_unsupported_config(

--- a/crates/nub-cli/tests/abort_eagerly.rs
+++ b/crates/nub-cli/tests/abort_eagerly.rs
@@ -75,8 +75,16 @@ fn install_aborts_on_unresolvable_yarn_lock_source() {
             out.contains("ERR_NUB_LOCKFILE_UNSUPPORTED_SOURCE"),
             "`nub {verb}` output should carry the rebranded code; got:\n{out}"
         );
-        // The refusal names the offending entry and protocol.
-        assert!(out.contains("foo@user/repo#abc123") && out.contains("git"));
+        // The refusal names the offending entry and protocol. miette wraps the
+        // rendered diagnostic at terminal width (CI's width differs from a dev
+        // box's), so match against a whitespace-flattened copy — the entry key
+        // and protocol token carry no internal whitespace, so a wrap can only
+        // have split them across a newline + indent.
+        let flat: String = out.split_whitespace().collect();
+        assert!(
+            flat.contains("foo@user/repo#abc123") && flat.contains("git"),
+            "`nub {verb}` should name the offending entry and protocol; got:\n{out}"
+        );
         // No brand leak — the engine's `aube` code must be rewritten.
         assert!(!out.contains("ERR_AUBE_LOCKFILE_UNSUPPORTED_SOURCE"));
         // Genuinely pre-mutation: no node_modules was created.

--- a/crates/nub-cli/tests/abort_eagerly.rs
+++ b/crates/nub-cli/tests/abort_eagerly.rs
@@ -1,0 +1,140 @@
+//! End-to-end (through the binary) tests for the install abort-eagerly policy:
+//! a lockfile source nub can't resolve, or a Yarn PnP project, aborts at PLAN
+//! time — before any `node_modules` write — with a precise, branded refusal,
+//! instead of a silent reclassify→404 / downgrade. The reader-level behavior
+//! lives in `vendor/aube/crates/aube-lockfile`; these assert the nub surface:
+//! the rebranded code, a non-zero exit, an untouched tree, and the optional
+//! carve-out (warn + proceed, not abort).
+//!
+//! All three are hermetic — the fatals abort before any fetch, and the
+//! optional case has nothing left to install — so none need `#[ignore]`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/ (or fast/)
+    path.push("nub");
+    path
+}
+
+fn tmpdir(tag: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nub-abort-{tag}-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Spawn `nub <args>` in `dir`, isolating the store/cache to fresh temp roots.
+fn run(dir: &Path, args: &[&str]) -> (String, i32) {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .env("XDG_DATA_HOME", tmpdir("xdg-data"))
+        .env("XDG_CACHE_HOME", tmpdir("xdg-cache"))
+        .output()
+        .expect("failed to spawn nub");
+    let mut combined = String::from_utf8_lossy(&out.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&out.stderr));
+    (combined, out.status.code().unwrap_or(-1))
+}
+
+fn write(dir: &Path, files: &[(&str, &str)]) {
+    for (name, body) in files {
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, body).unwrap();
+    }
+}
+
+const GIT_DEP_PKG: &str =
+    r#"{"name":"t","version":"1.0.0","dependencies":{"foo":"user/repo#abc123"}}"#;
+const GIT_DEP_LOCK: &str = "# yarn lockfile v1\n\n\"foo@user/repo#abc123\":\n  version \"1.0.0\"\n  resolved \"https://codeload.github.com/user/repo/tar.gz/abc123\"\n";
+
+#[test]
+fn install_aborts_on_unresolvable_yarn_lock_source() {
+    for verb in ["install", "ci"] {
+        let dir = tmpdir("git");
+        write(
+            &dir,
+            &[("package.json", GIT_DEP_PKG), ("yarn.lock", GIT_DEP_LOCK)],
+        );
+        let (out, code) = run(&dir, &[verb]);
+        assert_ne!(code, 0, "`nub {verb}` must abort on an unresolvable source");
+        assert!(
+            out.contains("ERR_NUB_LOCKFILE_UNSUPPORTED_SOURCE"),
+            "`nub {verb}` output should carry the rebranded code; got:\n{out}"
+        );
+        // The refusal names the offending entry and protocol.
+        assert!(out.contains("foo@user/repo#abc123") && out.contains("git"));
+        // No brand leak — the engine's `aube` code must be rewritten.
+        assert!(!out.contains("ERR_AUBE_LOCKFILE_UNSUPPORTED_SOURCE"));
+        // Genuinely pre-mutation: no node_modules was created.
+        assert!(
+            !dir.join("node_modules").exists(),
+            "`nub {verb}` must abort before writing node_modules"
+        );
+    }
+}
+
+#[test]
+fn install_aborts_on_yarn_pnp() {
+    for verb in ["install", "ci"] {
+        let dir = tmpdir("pnp");
+        write(
+            &dir,
+            &[
+                ("package.json", r#"{"name":"t","version":"1.0.0"}"#),
+                ("yarn.lock", "# yarn lockfile v1\n"),
+                (".yarnrc.yml", "nodeLinker: pnp\n"),
+            ],
+        );
+        let (out, code) = run(&dir, &[verb]);
+        assert_ne!(code, 0, "`nub {verb}` must abort on a Yarn PnP project");
+        assert!(
+            out.contains("ERR_NUB_PNP_UNSUPPORTED"),
+            "`nub {verb}` should refuse PnP with the branded code; got:\n{out}"
+        );
+        assert!(!dir.join("node_modules").exists());
+    }
+}
+
+#[test]
+fn install_proceeds_on_optional_unresolvable_source() {
+    // decision #3: an OPTIONAL unresolvable dep warns and the install proceeds
+    // (matching the incumbent's tolerance of a missing optional), instead of
+    // aborting. With nothing else to install, the run completes offline.
+    let dir = tmpdir("opt");
+    write(
+        &dir,
+        &[
+            (
+                "package.json",
+                r#"{"name":"t","version":"1.0.0","optionalDependencies":{"foo":"user/repo#abc123"}}"#,
+            ),
+            (
+                "yarn.lock",
+                "# yarn lockfile v1\n\n\"foo@user/repo#abc123\":\n  version \"1.0.0\"\n  resolved \"x\"\n",
+            ),
+        ],
+    );
+    let (out, code) = run(&dir, &["install"]);
+    assert_eq!(
+        code, 0,
+        "an optional unresolvable dep must not abort; got:\n{out}"
+    );
+    assert!(
+        out.contains("WARN_NUB_LOCKFILE_UNSUPPORTED_SOURCE"),
+        "the optional skip should warn; got:\n{out}"
+    );
+}

--- a/site/content/docs/install/yarn.mdx
+++ b/site/content/docs/install/yarn.mdx
@@ -37,6 +37,7 @@ Both formats are read:
     { feature: <><code>workspace:</code> protocol</>, status: 'yes' },
     { feature: <><code>npm:</code> alias</>, status: 'yes' },
     { feature: <><code>portal:</code> / <code>patch:</code></>, status: 'yes' },
+    { feature: <><code>git:</code> / <code>github:</code> sources</>, status: 'no', note: 'A git or unknown lockfile source aborts the install — it cannot be resolved from yarn.lock. An optional one is skipped with a warning.' },
     // ── Workspaces ────────────────────────────────────────────────────
     { feature: <><code>workspaces</code></>, status: 'yes' },
     { feature: <>workspace selectors</>, status: 'partial', note: 'No git-since ([ref]) selector.' },
@@ -50,7 +51,7 @@ Both formats are read:
     // ── Lockfiles ─────────────────────────────────────────────────────
     { feature: <><code>yarn.lock</code></>, status: 'partial', note: 'Read-only; writes refused.' },
     // ── Linking / install behavior ────────────────────────────────────
-    { feature: <code>nodeLinker</code>, status: 'partial', note: 'No PnP.' },
+    { feature: <code>nodeLinker</code>, status: 'partial', note: 'node-modules and pnpm linkers supported; a PnP project aborts the install.' },
     { feature: <code>supportedArchitectures</code>, status: 'yes', note: 'Filters optional/platform deps for the declared os/cpu/libc.' },
     { feature: <>mTLS client cert/key</>, status: 'yes', note: 'File-path (httpsCertFilePath / httpsKeyFilePath) and per-host networkSettings forms.' },
     { feature: <code>npmAlwaysAuth</code>, status: 'yes', note: 'Attaches credentials to cross-origin tarball requests too.' },
@@ -143,16 +144,14 @@ Nub maps the Yarn linker settings it can represent:
 # .yarnrc.yml
 nodeLinker: node-modules  # hoisted node_modules
 nodeLinker: pnpm          # isolated symlink layout
-nodeLinker: pnp           # ❌ warns; installs node_modules instead
+nodeLinker: pnp           # ❌ install aborts
 ```
 
-Yarn Berry defaults to PnP when `nodeLinker` is absent. On install, Nub prints one warning and links a `node_modules` tree:
+Yarn Berry defaults to PnP when `nodeLinker` is absent. Nub installs a `node_modules` tree, so honoring a PnP project would lay out something different from what Yarn produces. Rather than silently diverge, the install aborts before touching `node_modules`:
 
 ```console
-# captured: nub 0.1.1, Yarn Berry lockfile with no nodeLinker
 $ nub install
-nub: this Yarn project uses Plug'n'Play (nodeLinker: pnp or Yarn Berry's default), which nub does not implement — installing a node_modules tree instead. [WARN_NUB_PNP_LINKER_DOWNGRADE]
-nub 0.1.1 · ✓ Already up to date
+Error: nub: this project is configured for Yarn Plug'n'Play (nodeLinker: pnp, or Yarn Berry's default) — nub installs a node_modules tree and doesn't support PnP yet, so the result would diverge from yarn's. Install with yarn, or set `nodeLinker: node-modules` in .yarnrc.yml. [ERR_NUB_PNP_UNSUPPORTED]
 ```
 
 **Nub-the-runtime fully supports Plug'n'Play.** If a project was *already* installed by Yarn in PnP mode, Nub can run it — `nub <file>`, `nub run`, and `nubx` honor `.pnp.cjs` across all supported Node versions. What Nub cannot do is *produce* a PnP install. So the supported workflow for a PnP project is: install with `yarn`, run with `nub`. See [Plug'n'Play resolution](/docs/runtime/resolution#yarn-plugnplay) for how Nub resolves a PnP project at runtime.
@@ -162,4 +161,4 @@ nub 0.1.1 · ✓ Already up to date
 Several Yarn `package.json` and `.yarnrc.yml` fields still have no effect under Nub:
 
 - Per-host `networkSettings` proxies — the proxy Nub applies is process-wide, not per registry host.
-- `nodeLinker: pnp` — PnP install generation is out of scope; Nub warns and links `node_modules` instead. Install with Yarn, run with Nub.
+- PnP install generation (`nodeLinker: pnp`) is out of scope — Nub aborts the install rather than produce a `node_modules` tree that diverges from Yarn's. Install with Yarn, run with Nub.

--- a/vendor/aube/crates/aube-codes/src/errors.rs
+++ b/vendor/aube/crates/aube-codes/src/errors.rs
@@ -15,6 +15,7 @@ use crate::CodeMeta;
 pub const ERR_AUBE_NO_LOCKFILE: &str = "ERR_AUBE_NO_LOCKFILE";
 pub const ERR_AUBE_LOCKFILE_PARSE: &str = "ERR_AUBE_LOCKFILE_PARSE";
 pub const ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT: &str = "ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT";
+#[rustfmt::skip] pub const ERR_AUBE_LOCKFILE_UNSUPPORTED_SOURCE: &str = "ERR_AUBE_LOCKFILE_UNSUPPORTED_SOURCE";
 pub const ERR_AUBE_RESOLUTION_SHAPE_MISMATCH: &str = "ERR_AUBE_RESOLUTION_SHAPE_MISMATCH";
 pub const ERR_AUBE_OUTDATED_LOCKFILE: &str = "ERR_AUBE_OUTDATED_LOCKFILE";
 #[rustfmt::skip] pub const ERR_AUBE_LOCKFILE_DECLARATION_MISMATCH: &str = "ERR_AUBE_LOCKFILE_DECLARATION_MISMATCH";
@@ -150,6 +151,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::LOCKFILE,
         description: "Lockfile filename was recognized but its format isn't supported on this aube version.",
         exit_code: Some(12),
+    },
+    CodeMeta {
+        name: ERR_AUBE_LOCKFILE_UNSUPPORTED_SOURCE,
+        category: category::LOCKFILE,
+        description: "A lockfile entry's dependency source (protocol) can't be resolved from that lockfile — e.g. a git or jsr source in a yarn.lock — so the installed tree would silently diverge from the incumbent's. Install with the original package manager, or remove the dependency.",
+        exit_code: Some(14),
     },
     CodeMeta {
         name: ERR_AUBE_RESOLUTION_SHAPE_MISMATCH,

--- a/vendor/aube/crates/aube-codes/src/warnings.rs
+++ b/vendor/aube/crates/aube-codes/src/warnings.rs
@@ -92,6 +92,7 @@ pub const WARN_AUBE_LOCKFILE_MERGE_CONFLICT: &str = "WARN_AUBE_LOCKFILE_MERGE_CO
 pub const WARN_AUBE_LOCKFILE_MERGE_CLEANUP_FAILED: &str = "WARN_AUBE_LOCKFILE_MERGE_CLEANUP_FAILED";
 pub const WARN_AUBE_LOCKFILE_CONFLICT_MARKERS: &str = "WARN_AUBE_LOCKFILE_CONFLICT_MARKERS";
 pub const WARN_AUBE_YARN_BERRY_UNSUPPORTED: &str = "WARN_AUBE_YARN_BERRY_UNSUPPORTED";
+#[rustfmt::skip] pub const WARN_AUBE_LOCKFILE_UNSUPPORTED_SOURCE: &str = "WARN_AUBE_LOCKFILE_UNSUPPORTED_SOURCE";
 pub const WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX: &str =
     "WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX";
 pub const WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE: &str = "WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE";
@@ -515,6 +516,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_YARN_BERRY_UNSUPPORTED,
         category: category::LOCKFILE,
         description: "A Yarn Berry `patch:` / `portal:` / `exec:` protocol — or any unrecognized protocol — was found in `yarn.lock`. Entry was skipped.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_LOCKFILE_UNSUPPORTED_SOURCE,
+        category: category::LOCKFILE,
+        description: "An OPTIONAL dependency's source (protocol) can't be resolved from the lockfile (e.g. a git or jsr source). It was skipped; the install continues. A non-optional such dependency is a hard error (ERR_AUBE_LOCKFILE_UNSUPPORTED_SOURCE) instead.",
         exit_code: None,
     },
     CodeMeta {

--- a/vendor/aube/crates/aube-lockfile/src/io.rs
+++ b/vendor/aube/crates/aube-lockfile/src/io.rs
@@ -892,6 +892,33 @@ pub enum Error {
         )
     )]
     ResolutionShapeMismatch(std::path::PathBuf, String, &'static str),
+    /// A lockfile entry names a dependency source (protocol) the reader
+    /// can't resolve from that lockfile — a `git`/`jsr`/unknown source in
+    /// a yarn.lock or bun.lock that a registry fetch can't satisfy.
+    /// Reclassifying it to a registry `name@version` would 404 at fetch
+    /// time (a confusing mid-install error past the abort window) or, for
+    /// berry, silently drop the dependency — either way the installed tree
+    /// diverges from the incumbent's. Raised at PLAN time (before any
+    /// `node_modules` write) so the refusal is eager and precise. Fields
+    /// stay machine-readable so embedders can render their own surface,
+    /// matching [`Error::DeclarationMismatch`]. Only emitted under an
+    /// embedder whose profile sets `strict_unsupported_source` (nub);
+    /// standalone aube keeps its prior reclassify/drop default.
+    #[error("lockfile {path} entry `{key}` uses the unsupported `{protocol}` source")]
+    #[diagnostic(
+        code(ERR_AUBE_LOCKFILE_UNSUPPORTED_SOURCE),
+        help(
+            "aube can't resolve this source from the lockfile — install with the package manager that wrote it, or remove the dependency"
+        )
+    )]
+    UnsupportedSource {
+        /// The lockfile path (also identifies the reader kind for remedy wording).
+        path: std::path::PathBuf,
+        /// The offending lockfile block key / spec (e.g. `foo@user/repo#abc`).
+        key: String,
+        /// The unsupported protocol token (`git`, `jsr`, `exec`, …).
+        protocol: String,
+    },
     /// Deserialization failure with a byte offset into the source
     /// content, so miette's `fancy` handler can draw a pointer at the
     /// offending byte of the lockfile. Reuses `aube_manifest`'s
@@ -927,6 +954,20 @@ pub fn parse_json<T: serde::de::DeserializeOwned>(
 impl Error {
     pub fn parse(path: &std::path::Path, msg: impl Into<String>) -> Self {
         Error::Parse(path.to_path_buf(), msg.into())
+    }
+
+    /// Build an [`Error::UnsupportedSource`] for a lockfile entry whose
+    /// dependency source the reader can't resolve from that lockfile.
+    pub fn unsupported_source(
+        path: &std::path::Path,
+        key: impl Into<String>,
+        protocol: impl Into<String>,
+    ) -> Self {
+        Error::UnsupportedSource {
+            path: path.to_path_buf(),
+            key: key.into(),
+            protocol: protocol.into(),
+        }
     }
 
     pub fn parse_json_err(

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -319,6 +319,60 @@ pub fn dep_type_label(dt: DepType) -> &'static str {
     }
 }
 
+/// A lockfile entry whose dependency source the reader can't resolve,
+/// recorded by a format reader's classifier under the `strict_unsupported_source`
+/// embedder profile instead of silently dropping it (yarn-berry) or
+/// reclassifying it to a registry `name@version` that 404s at fetch
+/// (yarn-classic / bun). Resolved to a fatal or a warn at the edge sites
+/// (where dep-type is known) by [`resolve_dep_spec`].
+#[derive(Debug, Clone)]
+pub(crate) struct UnsupportedSpec {
+    /// The dependency name (for the optional-skip warning).
+    pub name: String,
+    /// A human-readable entry identifier (for the fatal message), e.g. the
+    /// resolution/spec string `foo@user/repo#abc`.
+    pub key: String,
+    /// The unsupported protocol token (`git`, `jsr`, `exec`, …).
+    pub protocol: String,
+}
+
+/// Resolve a dependency `spec` against the lockfile's `spec → dep_path`
+/// index, applying the abort-eagerly policy for specs a classifier
+/// recorded as an [`UnsupportedSpec`]. Returns the resolved dep_path,
+/// `None` when the spec is genuinely absent OR an OPTIONAL unsupported
+/// source (warned + skipped, matching the incumbent's tolerance of a
+/// missing optional), or `Err(UnsupportedSource)` for a NON-optional
+/// unsupported source — the eager, pre-mutation plan-time refusal. The
+/// `unsupported` map is empty unless the active embedder set
+/// `strict_unsupported_source`, so for standalone aube this is a plain
+/// index lookup with the historical drop/reclassify behavior preserved
+/// upstream of it.
+pub(crate) fn resolve_dep_spec(
+    spec: &str,
+    optional: bool,
+    spec_to_dep_path: &BTreeMap<String, String>,
+    unsupported: &BTreeMap<String, UnsupportedSpec>,
+    path: &std::path::Path,
+) -> Result<Option<String>, Error> {
+    if let Some(dep_path) = spec_to_dep_path.get(spec) {
+        return Ok(Some(dep_path.clone()));
+    }
+    let Some(u) = unsupported.get(spec) else {
+        return Ok(None);
+    };
+    if optional {
+        tracing::warn!(
+            code = aube_codes::warnings::WARN_AUBE_LOCKFILE_UNSUPPORTED_SOURCE,
+            "optional dependency `{}` uses the unsupported `{}` source — skipping it (the install continues)",
+            u.name,
+            u.protocol,
+        );
+        Ok(None)
+    } else {
+        Err(Error::unsupported_source(path, &u.key, &u.protocol))
+    }
+}
+
 /// A single resolved package in the lockfile.
 ///
 /// The `dependencies` map keys are dep names and values are the dependency's

--- a/vendor/aube/crates/aube-lockfile/src/yarn/berry.rs
+++ b/vendor/aube/crates/aube-lockfile/src/yarn/berry.rs
@@ -46,6 +46,15 @@ pub(super) fn parse_berry_str(
     let mut spec_to_dep_path: BTreeMap<String, String> = BTreeMap::new();
     let mut packages: BTreeMap<String, LockedPackage> = BTreeMap::new();
     let mut patched_dependencies: BTreeMap<String, String> = BTreeMap::new();
+    // Under `strict_unsupported_source` (nub), a block whose protocol the
+    // reader can't resolve is RECORDED here (keyed by every header spec that
+    // resolves to it) instead of being silently dropped, so the edge sites
+    // below can raise an eager fatal for a non-optional consumer / warn+skip
+    // an optional one. Empty (and inert) for standalone aube, which keeps the
+    // warn+drop default.
+    let strict = aube_util::embedder().strict_unsupported_source;
+    let mut unsupported: BTreeMap<String, crate::UnsupportedSpec> = BTreeMap::new();
+    let mut skipped_optional: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     // Transitive dep values written into each `LockedPackage` in this
     // pass are the raw header specs (e.g. `"foo@npm:^2.0.0"`); the
     // second pass collapses them down to dep_paths.
@@ -162,6 +171,23 @@ pub(super) fn parse_berry_str(
                 }))
             }
             _ => {
+                if strict {
+                    // Record the unresolvable block under each of its header
+                    // specs so a non-optional consumer raises a fatal (and an
+                    // optional one a warn) at the edge sites below, rather than
+                    // silently vanishing from the graph.
+                    for spec in &specs {
+                        unsupported.insert(
+                            spec.clone(),
+                            crate::UnsupportedSpec {
+                                name: res_name.to_string(),
+                                key: resolution.to_string(),
+                                protocol: res_protocol.to_string(),
+                            },
+                        );
+                    }
+                    continue;
+                }
                 tracing::warn!(
                     code = aube_codes::warnings::WARN_AUBE_YARN_BERRY_UNSUPPORTED,
                     "yarn berry unrecognized protocol '{}' in block '{}' — entry skipped",
@@ -242,17 +268,25 @@ pub(super) fn parse_berry_str(
     let mut resolved_deps: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     let mut resolved_opts: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     for (dep_path, pkg) in &packages {
-        let resolve = |raw: &BTreeMap<String, String>| {
+        let resolve = |raw: &BTreeMap<String, String>,
+                       optional: bool|
+         -> Result<BTreeMap<String, String>, Error> {
             let mut out = BTreeMap::new();
             for (name, raw_spec) in raw {
-                if let Some(target) = spec_to_dep_path.get(raw_spec) {
-                    out.insert(name.clone(), target.clone());
+                if let Some(target) = crate::resolve_dep_spec(
+                    raw_spec,
+                    optional,
+                    &spec_to_dep_path,
+                    &unsupported,
+                    path,
+                )? {
+                    out.insert(name.clone(), target);
                 }
             }
-            out
+            Ok(out)
         };
-        resolved_deps.insert(dep_path.clone(), resolve(&pkg.dependencies));
-        resolved_opts.insert(dep_path.clone(), resolve(&pkg.optional_dependencies));
+        resolved_deps.insert(dep_path.clone(), resolve(&pkg.dependencies, false)?);
+        resolved_opts.insert(dep_path.clone(), resolve(&pkg.optional_dependencies, true)?);
     }
     for (dep_path, deps) in resolved_deps {
         if let Some(pkg) = packages.get_mut(&dep_path) {
@@ -284,29 +318,71 @@ pub(super) fn parse_berry_str(
     // protocol prefix (`workspace:*`, `file:./pkgs/foo`, ...), it's
     // already a valid spec suffix and we try it verbatim first.
     let mut direct: Vec<DirectDep> = Vec::new();
-    let push_direct = |name: &str, range: &str, dep_type: DepType, direct: &mut Vec<DirectDep>| {
+    let push_direct = |name: &str,
+                       range: &str,
+                       dep_type: DepType,
+                       direct: &mut Vec<DirectDep>,
+                       skipped: &mut BTreeMap<String, BTreeMap<String, String>>|
+     -> Result<(), Error> {
         let resolved = crate::override_match::apply(&resolution_rules, name, range);
         let candidates = berry_spec_candidates(name, range, resolved);
-        for candidate in candidates {
-            if let Some(dep_path) = spec_to_dep_path.get(&candidate) {
+        let optional = matches!(dep_type, DepType::Optional);
+        for candidate in &candidates {
+            // `resolve_dep_spec`: `Some(dep_path)` when the candidate resolves;
+            // `Err` for a NON-optional unsupported source (the eager fatal);
+            // `None` for a genuine miss OR an optional unsupported source
+            // (already warned inside the helper).
+            if let Some(dep_path) =
+                crate::resolve_dep_spec(candidate, optional, &spec_to_dep_path, &unsupported, path)?
+            {
                 direct.push(DirectDep {
                     name: name.to_string(),
-                    dep_path: dep_path.clone(),
+                    dep_path,
                     dep_type,
                     specifier: None,
                 });
-                return;
+                return Ok(());
+            }
+            // An optional unsupported candidate was warned + skipped by the
+            // helper; record it as a consciously-skipped optional so a frozen
+            // install's drift check tolerates the absent dep, exactly like a
+            // platform-filtered optional (drift.rs `skipped_optional_dependencies`).
+            if optional && unsupported.contains_key(candidate) {
+                skipped
+                    .entry(".".to_string())
+                    .or_default()
+                    .insert(name.to_string(), range.to_string());
+                return Ok(());
             }
         }
+        Ok(())
     };
     for (name, range) in &manifest.dependencies {
-        push_direct(name, range, DepType::Production, &mut direct);
+        push_direct(
+            name,
+            range,
+            DepType::Production,
+            &mut direct,
+            &mut skipped_optional,
+        )?;
     }
     for (name, range) in &manifest.dev_dependencies {
-        push_direct(name, range, DepType::Dev, &mut direct);
+        push_direct(
+            name,
+            range,
+            DepType::Dev,
+            &mut direct,
+            &mut skipped_optional,
+        )?;
     }
     for (name, range) in &manifest.optional_dependencies {
-        push_direct(name, range, DepType::Optional, &mut direct);
+        push_direct(
+            name,
+            range,
+            DepType::Optional,
+            &mut direct,
+            &mut skipped_optional,
+        )?;
     }
 
     let mut importers = BTreeMap::new();
@@ -316,6 +392,7 @@ pub(super) fn parse_berry_str(
         importers,
         packages,
         patched_dependencies,
+        skipped_optional_dependencies: skipped_optional,
         ..Default::default()
     })
 }

--- a/vendor/aube/crates/aube-lockfile/src/yarn/classic.rs
+++ b/vendor/aube/crates/aube-lockfile/src/yarn/classic.rs
@@ -16,6 +16,15 @@ pub(super) fn parse_classic_str(
     // from package.json ranges and transitive dep references.
     let mut spec_to_dep_path: BTreeMap<String, String> = BTreeMap::new();
     let mut packages: BTreeMap<String, LockedPackage> = BTreeMap::new();
+    // Under `strict_unsupported_source` (nub), a block whose source the
+    // classic reader can't resolve (git, github shorthand, jsr, http
+    // tarball, …) is RECORDED here (keyed by each of its specs) instead of
+    // being reclassified to a registry `name@version` that 404s at fetch, so
+    // the edge sites below can raise an eager fatal / warn+skip. Empty (and
+    // inert) for standalone aube, which keeps the reclassify default.
+    let strict = aube_util::embedder().strict_unsupported_source;
+    let mut unsupported: BTreeMap<String, crate::UnsupportedSpec> = BTreeMap::new();
+    let mut skipped_optional: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
 
     for block in &blocks {
         let version = block
@@ -61,10 +70,43 @@ pub(super) fn parse_classic_str(
         // install. The dep_path is keyed by `LocalSource::dep_path` (the
         // FS-safe hashed form) exactly like the berry parser keys its
         // local packages.
-        let local_source = block
-            .specs
-            .iter()
-            .find_map(|s| classic_local_source(s, &name));
+        // Classify the block's source. All specs in a yarn.lock v1 block share
+        // one resolution, so they classify identically; scan for the first
+        // non-Registry signal (a `Local` source, or an `Unsupported` protocol).
+        let mut classic_src = ClassicSource::Registry;
+        for s in &block.specs {
+            match classic_local_source(s, &name) {
+                ClassicSource::Registry => {}
+                other => {
+                    classic_src = other;
+                    break;
+                }
+            }
+        }
+        let local_source = match classic_src {
+            ClassicSource::Registry => None,
+            ClassicSource::Local(src) => Some(src),
+            ClassicSource::Unsupported(protocol) => {
+                if strict {
+                    // Record under each spec and skip the block entirely (no
+                    // registry package, no `spec_to_dep_path` entry), so a
+                    // consumer raises a fatal / warn at the edge sites instead
+                    // of resolving to a `name@version` that 404s at fetch.
+                    for s in &block.specs {
+                        unsupported.insert(
+                            s.clone(),
+                            crate::UnsupportedSpec {
+                                name: name.clone(),
+                                key: s.clone(),
+                                protocol: protocol.clone(),
+                            },
+                        );
+                    }
+                    continue;
+                }
+                None
+            }
+        };
         let dep_path = match &local_source {
             Some(src) => src.dep_path(&name),
             None => format!("{name}@{version}"),
@@ -108,15 +150,20 @@ pub(super) fn parse_classic_str(
         }
     }
 
-    // Second pass: resolve transitive dep references to dep_paths.
+    // Second pass: resolve transitive dep references to dep_paths. Classic
+    // tracks only `dependencies:` sections (the tokenizer drops
+    // `optionalDependencies:`), so every transitive edge here is non-optional
+    // — an unsupported one is therefore an eager fatal, never a warn.
     let mut resolved: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     for (dep_path, pkg) in &packages {
         let mut deps: BTreeMap<String, String> = BTreeMap::new();
         for (name, raw_spec) in &pkg.dependencies {
-            if let Some(resolved_path) = spec_to_dep_path.get(raw_spec) {
+            if let Some(resolved_path) =
+                crate::resolve_dep_spec(raw_spec, false, &spec_to_dep_path, &unsupported, path)?
+            {
                 deps.insert(
                     name.clone(),
-                    crate::npm::dep_path_tail(name, resolved_path).to_string(),
+                    crate::npm::dep_path_tail(name, &resolved_path).to_string(),
                 );
             }
         }
@@ -188,16 +235,40 @@ pub(super) fn parse_classic_str(
     // Build direct deps from the manifest, cross-referencing against
     // spec_to_dep_path; falling back to a workspace-sibling link.
     let mut direct: Vec<DirectDep> = Vec::new();
-    let push_dep = |name: &str, range: &str, dep_type: DepType, into: &mut Vec<DirectDep>| {
+    let push_dep = |name: &str,
+                    range: &str,
+                    dep_type: DepType,
+                    importer: &str,
+                    into: &mut Vec<DirectDep>,
+                    skipped: &mut BTreeMap<String, BTreeMap<String, String>>|
+     -> Result<(), Error> {
         let spec = format!("{name}@{range}");
-        if let Some(dep_path) = spec_to_dep_path.get(&spec) {
+        let optional = matches!(dep_type, DepType::Optional);
+        // `resolve_dep_spec`: `Some` when the spec resolves; `Err` for a
+        // non-optional unsupported source (the eager fatal); `None` for a
+        // genuine miss OR an optional unsupported source (warned inside).
+        if let Some(dep_path) =
+            crate::resolve_dep_spec(&spec, optional, &spec_to_dep_path, &unsupported, path)?
+        {
             into.push(DirectDep {
                 name: name.to_string(),
-                dep_path: dep_path.clone(),
+                dep_path,
                 dep_type,
                 specifier: Some(range.to_string()),
             });
-        } else if let Some(dep_path) = workspace_link(name, range) {
+            return Ok(());
+        }
+        // An optional unsupported dep was warned + skipped; record it as a
+        // consciously-skipped optional so a frozen install's drift check
+        // tolerates the absent dep (same as a platform-filtered optional).
+        if optional && unsupported.contains_key(&spec) {
+            skipped
+                .entry(importer.to_string())
+                .or_default()
+                .insert(name.to_string(), range.to_string());
+            return Ok(());
+        }
+        if let Some(dep_path) = workspace_link(name, range) {
             into.push(DirectDep {
                 name: name.to_string(),
                 dep_path,
@@ -205,15 +276,37 @@ pub(super) fn parse_classic_str(
                 specifier: Some(range.to_string()),
             });
         }
+        Ok(())
     };
     for (name, range) in &manifest.dependencies {
-        push_dep(name, range, DepType::Production, &mut direct);
+        push_dep(
+            name,
+            range,
+            DepType::Production,
+            ".",
+            &mut direct,
+            &mut skipped_optional,
+        )?;
     }
     for (name, range) in &manifest.dev_dependencies {
-        push_dep(name, range, DepType::Dev, &mut direct);
+        push_dep(
+            name,
+            range,
+            DepType::Dev,
+            ".",
+            &mut direct,
+            &mut skipped_optional,
+        )?;
     }
     for (name, range) in &manifest.optional_dependencies {
-        push_dep(name, range, DepType::Optional, &mut direct);
+        push_dep(
+            name,
+            range,
+            DepType::Optional,
+            ".",
+            &mut direct,
+            &mut skipped_optional,
+        )?;
     }
 
     let mut importers = BTreeMap::new();
@@ -233,13 +326,34 @@ pub(super) fn parse_classic_str(
     for (member_dir, member_pj) in &member_manifests {
         let mut member_direct: Vec<DirectDep> = Vec::new();
         for (name, range) in &member_pj.dependencies {
-            push_dep(name, range, DepType::Production, &mut member_direct);
+            push_dep(
+                name,
+                range,
+                DepType::Production,
+                member_dir,
+                &mut member_direct,
+                &mut skipped_optional,
+            )?;
         }
         for (name, range) in &member_pj.dev_dependencies {
-            push_dep(name, range, DepType::Dev, &mut member_direct);
+            push_dep(
+                name,
+                range,
+                DepType::Dev,
+                member_dir,
+                &mut member_direct,
+                &mut skipped_optional,
+            )?;
         }
         for (name, range) in &member_pj.optional_dependencies {
-            push_dep(name, range, DepType::Optional, &mut member_direct);
+            push_dep(
+                name,
+                range,
+                DepType::Optional,
+                member_dir,
+                &mut member_direct,
+                &mut skipped_optional,
+            )?;
         }
         importers.insert(member_dir.clone(), member_direct);
     }
@@ -247,6 +361,7 @@ pub(super) fn parse_classic_str(
     Ok(LockfileGraph {
         importers,
         packages,
+        skipped_optional_dependencies: skipped_optional,
         ..Default::default()
     })
 }
@@ -459,22 +574,59 @@ pub(super) fn parse_spec_name(spec: &str) -> Option<String> {
     }
 }
 
-/// Detect a yarn-classic local-package protocol on a spec key and map
-/// it to a [`LocalSource`]. Classic encodes the protocol in the spec
-/// *range* (`name@link:./path`, `name@file:./path`, `name@portal:./path`)
-/// rather than in a separate `resolution:` field the way berry does.
-/// Registry and remote (`http(s):`, git) specs return `None` — they
-/// resolve through the normal `name@version` path.
-fn classic_local_source(spec: &str, name: &str) -> Option<LocalSource> {
-    let range = spec.strip_prefix(name)?.strip_prefix('@')?;
-    let (protocol, body) = range.split_once(':')?;
-    match protocol {
-        "link" => Some(LocalSource::Link(PathBuf::from(strip_hash_fragment(body)))),
-        "file" => Some(file_protocol_source(body)),
-        "portal" => Some(LocalSource::Portal(PathBuf::from(strip_hash_fragment(
-            body,
-        )))),
-        _ => None,
+/// How the classic reader classifies a spec's source.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum ClassicSource {
+    /// A registry-resolvable spec: a semver range, a dist-tag, or an `npm:`
+    /// alias (the real name rides on `alias_of`). Resolves via `name@version`.
+    Registry,
+    /// A local on-disk source (`link:`/`file:`/`portal:`) the linker
+    /// materializes directly.
+    Local(LocalSource),
+    /// A source the classic reader cannot resolve from a yarn.lock — a git
+    /// dep (`git+https`/`git+ssh`/`git`/`ssh`, or a `user/repo#ref` github
+    /// shorthand), an `http(s)` tarball, `jsr:`, or any unknown protocol.
+    /// Reclassifying it to `name@version` would 404 at fetch. Carries the
+    /// protocol token for the diagnostic.
+    Unsupported(String),
+}
+
+/// Classify a yarn-classic spec's source. Classic encodes the protocol in
+/// the spec *range* (`name@link:./path`, `name@user/repo#ref`,
+/// `name@git+https://…`) rather than a separate `resolution:` field the way
+/// berry does.
+pub(super) fn classic_local_source(spec: &str, name: &str) -> ClassicSource {
+    let Some(range) = spec.strip_prefix(name).and_then(|r| r.strip_prefix('@')) else {
+        // Not a `name@…` spec (malformed block); keep the historical
+        // registry default rather than inventing an unsupported source.
+        return ClassicSource::Registry;
+    };
+    match range.split_once(':') {
+        Some(("link", body)) => {
+            ClassicSource::Local(LocalSource::Link(PathBuf::from(strip_hash_fragment(body))))
+        }
+        Some(("file", body)) => ClassicSource::Local(file_protocol_source(body)),
+        Some(("portal", body)) => ClassicSource::Local(LocalSource::Portal(PathBuf::from(
+            strip_hash_fragment(body),
+        ))),
+        // `npm:` is a registry alias (resolves via `alias_of`) — NOT a local
+        // or unsupported source. Must be matched before the github-shorthand
+        // rule below, since an alias body can contain `/` (`npm:@scope/x@1`).
+        Some(("npm", _)) => ClassicSource::Registry,
+        // A `user/repo#semver:<range>` github shorthand splits on the
+        // `#semver:` colon, so its "protocol" carries the `/` — it's the same
+        // unsupportable git source as the no-colon `user/repo#ref` form below.
+        Some((protocol, _)) if protocol.contains('/') => {
+            ClassicSource::Unsupported("git".to_string())
+        }
+        // Any other explicit protocol is a source the classic reader can't
+        // resolve from yarn.lock (git+https/git+ssh/git/ssh/http/https/jsr/…).
+        Some((protocol, _)) => ClassicSource::Unsupported(protocol.to_string()),
+        // No protocol colon: a bare semver/dist-tag is registry-resolvable, but
+        // a `/`-bearing range is a github shorthand (`user/repo#ref`) — a git
+        // source classic can't resolve. A registry range never contains `/`.
+        None if range.contains('/') => ClassicSource::Unsupported("git".to_string()),
+        None => ClassicSource::Registry,
     }
 }
 

--- a/vendor/aube/crates/aube-lockfile/src/yarn/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/yarn/tests.rs
@@ -1889,3 +1889,83 @@ ms@^2.1.3:
     assert_eq!(pkg_b[0].name, "kleur");
     assert_eq!(pkg_b[0].dep_path, "kleur@4.1.5");
 }
+
+// ── strict_unsupported_source: gating + classifier ──────────────────────────
+//
+// These run under the DEFAULT (standalone-aube) embedder — `strict_unsupported_source`
+// is false — so they assert the historical lenient behavior is byte-identical
+// (the strict/fatal path is exercised in `tests/unsupported_source.rs`, which
+// registers a strict profile in its own process).
+
+#[test]
+fn lenient_berry_jsr_dep_is_warn_dropped_not_fatal() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = "__metadata:\n  version: 8\n  cacheKey: 10c0\n\n\"foo@jsr:^1.0.0\":\n  version: 1.0.0\n  resolution: \"foo@jsr:1.0.0\"\n  languageName: node\n  linkType: hard\n";
+    std::fs::write(tmp.path(), content).unwrap();
+    let manifest = make_manifest(&[("foo", "jsr:^1.0.0")], &[]);
+    let graph = parse(tmp.path(), &manifest).expect("default embedder must not fatal");
+    // Historical behavior: the jsr block is dropped, so `foo` never lands.
+    assert!(!graph.importers["."].iter().any(|d| d.name == "foo"));
+}
+
+#[test]
+fn lenient_classic_git_dep_reclassifies_not_fatal() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = "# yarn lockfile v1\n\n\"foo@git+https://github.com/u/r.git#abc123\":\n  version \"1.0.0\"\n  resolved \"git+https://github.com/u/r.git#abc123\"\n";
+    std::fs::write(tmp.path(), content).unwrap();
+    let manifest = make_manifest(&[("foo", "git+https://github.com/u/r.git#abc123")], &[]);
+    let graph = parse(tmp.path(), &manifest).expect("default embedder must not fatal");
+    // Historical behavior: the git block reclassifies to a registry name@version
+    // and stays in the graph (it would 404 at fetch, but parse is lenient).
+    assert!(graph.importers["."].iter().any(|d| d.name == "foo"));
+}
+
+#[test]
+fn classic_local_source_classification() {
+    use super::classic::{ClassicSource, classic_local_source};
+    let is = |spec: &str| classic_local_source(spec, "foo");
+    // Registry-resolvable: semver ranges, dist-tags, and npm-aliases.
+    assert!(matches!(is("foo@^1.0.0"), ClassicSource::Registry));
+    assert!(matches!(is("foo@latest"), ClassicSource::Registry));
+    assert!(matches!(is("foo@>=1.0.0 <2.0.0"), ClassicSource::Registry));
+    assert!(matches!(
+        is("foo@npm:@scope/real@1.2.3"),
+        ClassicSource::Registry
+    ));
+    // Local on-disk sources.
+    assert!(matches!(is("foo@link:./x"), ClassicSource::Local(_)));
+    assert!(matches!(is("foo@file:./x.tgz"), ClassicSource::Local(_)));
+    assert!(matches!(is("foo@portal:./x"), ClassicSource::Local(_)));
+    // Unsupported: explicit git protocols + the github `user/repo#ref` shorthand.
+    assert!(matches!(
+        is("foo@git+https://h/r.git#c"),
+        ClassicSource::Unsupported(_)
+    ));
+    assert!(matches!(
+        is("foo@user/repo#ref"),
+        ClassicSource::Unsupported(_)
+    ));
+    // A `user/repo#semver:<range>` shorthand splits on the `#semver:` colon;
+    // the protocol token must be the clean `git`, not `user/repo#semver`.
+    assert_eq!(
+        is("foo@user/repo#semver:^1.2.3"),
+        ClassicSource::Unsupported("git".to_string())
+    );
+}
+
+proptest::proptest! {
+    /// A registry-shaped range (semver, no protocol `:` and no `/`) must
+    /// ALWAYS classify as `Registry` — never a false-positive `Unsupported`
+    /// that would turn a valid yarn.lock into an eager fatal under nub.
+    #[test]
+    fn registry_ranges_never_classify_unsupported(
+        range in r"[\^~]?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}",
+    ) {
+        use super::classic::{ClassicSource, classic_local_source};
+        let spec = format!("foo@{range}");
+        proptest::prop_assert!(matches!(
+            classic_local_source(&spec, "foo"),
+            ClassicSource::Registry
+        ));
+    }
+}

--- a/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -38,6 +38,7 @@ static MYTOOL: Embedder = Embedder {
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,
+    strict_unsupported_source: false,
 };
 
 #[test]

--- a/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
@@ -44,6 +44,7 @@ static MYTOOL: Embedder = Embedder {
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,
+    strict_unsupported_source: false,
 };
 
 fn project(files: &[(&str, &str)]) -> tempfile::TempDir {

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -48,6 +48,7 @@ static NO_CHURN_TOOL: Embedder = Embedder {
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,
+    strict_unsupported_source: false,
 };
 
 fn pkg(name: &str, version: &str, integrity: &str) -> LockedPackage {

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -1,0 +1,183 @@
+//! Integration test for the abort-eagerly policy on unresolvable lockfile
+//! sources (the `strict_unsupported_source` embedder toggle).
+//!
+//! Lives in its own integration-test binary — its own process — because the
+//! active embedder is once-per-process. The in-crate unit tests assert the
+//! default (lenient: warn+drop for berry, reclassify for classic) behavior, so
+//! the STRICT profile is registered only here, where every parse exercises the
+//! nub-style "fatal on a non-optional unresolvable source, warn+skip an
+//! optional one" path.
+
+use aube_lockfile::{Error, LockfileGraph, parse_lockfile};
+use aube_util::Embedder;
+
+/// A strict profile: identical to standalone `aube` except it opts INTO the
+/// eager unsupported-source refusal (`strict_unsupported_source: true`), the
+/// way nub's profile does.
+static STRICT: Embedder = Embedder {
+    name: "aube",
+    display_name: "aube",
+    vendor: None,
+    version: "1.0.0",
+    user_agent: "aube/1.0.0",
+    self_names: &["aube"],
+    compatible_names: &["pnpm"],
+    lockfile_basename: "aube-lock.yaml",
+    workspace_yaml: Some("aube-workspace.yaml"),
+    manifest_namespace: "aube",
+    env_prefix: Some("AUBE"),
+    config_env_prefix: Some("AUBE"),
+    cache_namespace: "aube",
+    data_namespace: "aube",
+    managed_config_system_dir: Some("aube"),
+    canonical_lockfile_always_wins: true,
+    runtime_switching: true,
+    self_engines_check: true,
+    self_update_enabled: true,
+    warm_store_verify: true,
+    no_churn_lockfile_write: false,
+    read_branded_settings_env: true,
+    gvs_incompatible_warning: true,
+    primer_ttl: None,
+    cpu_budget: None,
+    tty_progress: false,
+    strict_unsupported_source: true,
+};
+
+fn parse(files: &[(&str, &str)]) -> Result<LockfileGraph, Error> {
+    let dir = tempfile::tempdir().unwrap();
+    for (name, body) in files {
+        std::fs::write(dir.path().join(name), body).unwrap();
+    }
+    let manifest = aube_manifest::PackageJson::from_path(&dir.path().join("package.json")).unwrap();
+    parse_lockfile(dir.path(), &manifest)
+}
+
+fn assert_unsupported(result: Result<LockfileGraph, Error>, want_protocol: &str) {
+    match result {
+        Err(Error::UnsupportedSource { protocol, .. }) => assert_eq!(
+            protocol, want_protocol,
+            "wrong protocol in UnsupportedSource error"
+        ),
+        other => panic!("expected UnsupportedSource({want_protocol}), got {other:?}"),
+    }
+}
+
+const BERRY_HEADER: &str = "__metadata:\n  version: 8\n  cacheKey: 10c0\n\n";
+
+#[test]
+fn strict_must_register_before_other_tests() {
+    // The whole binary shares one embedder; register it once up front.
+    aube_util::set_embedder(&STRICT);
+    assert!(aube_util::embedder().strict_unsupported_source);
+}
+
+#[test]
+fn berry_jsr_dep_is_a_fatal() {
+    aube_util::set_embedder(&STRICT);
+    let lock = format!(
+        "{BERRY_HEADER}\"foo@jsr:^1.0.0\":\n  version: 1.0.0\n  resolution: \"foo@jsr:1.0.0\"\n  languageName: node\n  linkType: hard\n"
+    );
+    let r = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","dependencies":{"foo":"jsr:^1.0.0"}}"#,
+        ),
+        ("yarn.lock", &lock),
+    ]);
+    assert_unsupported(r, "jsr");
+}
+
+#[test]
+fn berry_git_dep_still_resolves() {
+    // Berry HANDLES git sources (LocalSource::Git), so a git dep is NOT
+    // unsupported — only protocols berry can't represent (jsr, unknown) are.
+    aube_util::set_embedder(&STRICT);
+    let lock = format!(
+        "{BERRY_HEADER}\"foo@https://github.com/u/r.git#commit=abc123\":\n  version: 1.0.0\n  resolution: \"foo@https://github.com/u/r.git#commit=abc123\"\n  languageName: node\n  linkType: hard\n"
+    );
+    let graph = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","dependencies":{"foo":"https://github.com/u/r.git#commit=abc123"}}"#,
+        ),
+        ("yarn.lock", &lock),
+    ])
+    .expect("a berry git dep must resolve, not fatal");
+    assert!(graph.importers["."].iter().any(|d| d.name == "foo"));
+}
+
+#[test]
+fn classic_git_protocol_dep_is_a_fatal() {
+    aube_util::set_embedder(&STRICT);
+    let lock = "# yarn lockfile v1\n\n\"foo@git+https://github.com/u/r.git#abc123\":\n  version \"1.0.0\"\n  resolved \"git+https://github.com/u/r.git#abc123\"\n";
+    let r = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","dependencies":{"foo":"git+https://github.com/u/r.git#abc123"}}"#,
+        ),
+        ("yarn.lock", lock),
+    ]);
+    assert_unsupported(r, "git+https");
+}
+
+#[test]
+fn classic_github_shorthand_dep_is_a_fatal() {
+    aube_util::set_embedder(&STRICT);
+    let lock = "# yarn lockfile v1\n\n\"foo@user/repo#abc123\":\n  version \"1.0.0\"\n  resolved \"https://codeload.github.com/user/repo/tar.gz/abc123\"\n";
+    let r = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","dependencies":{"foo":"user/repo#abc123"}}"#,
+        ),
+        ("yarn.lock", lock),
+    ]);
+    assert_unsupported(r, "git");
+}
+
+#[test]
+fn classic_optional_unsupported_dep_warns_and_is_skipped() {
+    // decision #3 + B3: an OPTIONAL unresolvable dep is NOT fatal — it's
+    // dropped (the install continues) and recorded as a skipped optional so a
+    // frozen install's drift check tolerates the absent dep.
+    aube_util::set_embedder(&STRICT);
+    let lock =
+        "# yarn lockfile v1\n\n\"foo@user/repo#abc123\":\n  version \"1.0.0\"\n  resolved \"x\"\n";
+    let graph = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","optionalDependencies":{"foo":"user/repo#abc123"}}"#,
+        ),
+        ("yarn.lock", lock),
+    ])
+    .expect("an optional unsupported dep must NOT be fatal");
+    assert!(
+        !graph.importers["."].iter().any(|d| d.name == "foo"),
+        "the optional unsupported dep should be dropped from the importer"
+    );
+    assert_eq!(
+        graph.skipped_optional_dependencies["."]
+            .get("foo")
+            .map(String::as_str),
+        Some("user/repo#abc123"),
+        "the dropped optional must be recorded as skipped for drift tolerance"
+    );
+}
+
+#[test]
+fn clean_classic_lockfile_does_not_fatal() {
+    // The critical anti-regression: a lockfile with only resolvable sources
+    // must parse cleanly under the strict profile (no false-positive fatal).
+    aube_util::set_embedder(&STRICT);
+    let lock = "# yarn lockfile v1\n\nlodash@^4.17.0:\n  version \"4.17.21\"\n  resolved \"https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz\"\n  integrity sha512-aaa\n\nlink-dep@link:./local:\n  version \"0.0.0\"\n";
+    let graph = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","dependencies":{"lodash":"^4.17.0","link-dep":"link:./local"}}"#,
+        ),
+        ("yarn.lock", lock),
+    ])
+    .expect("a clean lockfile must not fatal under strict");
+    assert!(graph.importers["."].iter().any(|d| d.name == "lodash"));
+    assert!(graph.importers["."].iter().any(|d| d.name == "link-dep"));
+}

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -44,6 +44,7 @@ static ROOT_TOOL: Embedder = Embedder {
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,
+    strict_unsupported_source: false,
 };
 
 fn read_manifest(dir: &std::path::Path) -> serde_json::Value {

--- a/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
@@ -40,6 +40,7 @@ static MYTOOL: Embedder = Embedder {
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,
+    strict_unsupported_source: false,
 };
 
 #[tokio::test]

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -35,6 +35,7 @@ static ROOT_TOOL: Embedder = Embedder {
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,
+    strict_unsupported_source: false,
 };
 
 fn build_decision(manifest: &PackageJson, name: &str, version: &str) -> AllowDecision {

--- a/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
@@ -34,6 +34,7 @@ static MYTOOL: Embedder = Embedder {
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,
+    strict_unsupported_source: false,
 };
 
 #[test]

--- a/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
+++ b/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
@@ -49,6 +49,7 @@ static MYTOOL_NO_BRANDED_ENV: Embedder = Embedder {
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,
+    strict_unsupported_source: false,
 };
 
 fn ctx<'a>(

--- a/vendor/aube/crates/aube-util/src/identity.rs
+++ b/vendor/aube/crates/aube-util/src/identity.rs
@@ -258,6 +258,20 @@ pub struct Embedder {
     /// repaint, no leftover frame, no flash) is unconditional — only *whether
     /// the animated renderer is the default* is gated here.
     pub tty_progress: bool,
+    /// When `false` (aube's default), a lockfile entry whose dependency
+    /// source the reader can't resolve (a `git`/`jsr`/unknown protocol in a
+    /// yarn.lock or bun.lock) keeps aube's prior best-effort behavior:
+    /// yarn-berry `warn!`s and drops the block; yarn-classic / bun reclassify
+    /// it to a registry `name@version` (which 404s at fetch). When `true`,
+    /// the reader instead raises [`crate`-external `Error::UnsupportedSource`]
+    /// at parse time for a NON-optional such entry (so the install aborts
+    /// eagerly, before any `node_modules` write, instead of producing a tree
+    /// that silently diverges from the incumbent's), and `warn!`s + drops an
+    /// OPTIONAL one (recording it as a skipped optional so a frozen install
+    /// still verifies). An embedder that guarantees "the installed tree
+    /// equals the incumbent PM's, or an eager precise refusal" (nub) sets
+    /// this `true`. Embedder-fixed: it's the host's call, not the user's.
+    pub strict_unsupported_source: bool,
 }
 
 /// Standalone aube's embedder profile. Reproduces every hardcoded branding
@@ -293,6 +307,10 @@ pub const AUBE: Embedder = Embedder {
     // `AUBE_TTY_PROGRESS` opt-in for standalone aube, so default output is
     // unchanged.
     tty_progress: false,
+    // Standalone aube keeps its prior best-effort source handling
+    // (warn+drop for berry, reclassify-to-registry for classic/bun) so its
+    // default install behavior is byte-identical.
+    strict_unsupported_source: false,
 };
 
 static ACTIVE: OnceLock<&'static Embedder> = OnceLock::new();

--- a/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -44,6 +44,7 @@ static NUBLIKE: Embedder = Embedder {
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,
+    strict_unsupported_source: false,
 };
 
 /// Restore the previous value of an env var around a closure. Integration-test

--- a/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -43,6 +43,7 @@ static NUBLIKE: Embedder = Embedder {
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,
+    strict_unsupported_source: false,
 };
 
 #[test]


### PR DESCRIPTION
## What

`nub install` / `nub ci` now refuse, before any `node_modules` write, a Yarn lockfile they can't honor faithfully — rather than produce a tree that diverges from what Yarn installs.

**Unresolvable lockfile source.** A `yarn.lock` (Classic or Berry) entry whose dependency source the reader can't resolve — a `git`/`jsr`/unknown protocol — was reclassified to a registry `name@version` (a 404 at fetch, past the abort window) or, for Berry, dropped. A non-optional such entry now aborts at parse time, naming the entry and protocol; an optional one warns and is skipped, matching Yarn's tolerance of a missing optional.

```console
$ nub install
ERR_NUB_LOCKFILE_UNSUPPORTED_SOURCE
  × failed to parse lockfile
  ╰─▶ lockfile yarn.lock entry `leftpad@git+https://github.com/user/leftpad.git` uses the unsupported `git+https` source
  help: nub can't resolve this source from the lockfile — install with the package manager that wrote it, or remove the dependency
```

**Yarn Plug'n'Play.** A PnP project (`nodeLinker: pnp`, or Yarn Berry's default) was silently downgraded to a `node_modules` install — a different on-disk layout than Yarn's. It now aborts with `ERR_NUB_PNP_UNSUPPORTED`.

## Fork discipline

The strict behavior is gated behind a new compile-time embedder toggle `strict_unsupported_source` — `false` in the standalone `aube` profile, `true` in nub's — so standalone aube keeps its prior reclassify/drop default byte-for-byte. The optional-skip reuses the existing `skipped_optional_dependencies` graph field, so a frozen (`ci`) drift check tolerates the deliberately-absent optional.

## Tests + docs

- `vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs` — strict-profile reader behavior (Berry jsr fatal, Berry git still resolves, Classic git/github-shorthand fatal, optional warn+skip, clean lockfile no false-positive).
- `vendor/aube/crates/aube-lockfile/src/yarn/tests.rs` — toggle-off anti-regression, the `ClassicSource` classifier, a property test that a registry-shaped range never classifies unsupported.
- `crates/nub-cli/tests/abort_eagerly.rs` — end-to-end: git-dep and PnP fatal (non-zero exit, branded code, no `node_modules`), and the optional carve-out.
- `site/content/docs/install/yarn.mdx` — PnP-abort and git-source rows.

Full aube workspace suite (2429 tests) and the nub PM suite are green; `clippy --all-targets --all-features` and `fmt --check` clean.

https://claude.ai/code/session_01TuvdYzBgmnyJQJDXheWmF9
