### PR TITLE
docs: rewrite the workers page + fix prose-skill violations across docs

### DIFF
--- a/site/content/docs/docker.mdx
+++ b/site/content/docs/docker.mdx
@@ -1,9 +1,9 @@
 ---
 title: Docker
-description: Official nub Docker images, and how to add nub to your own image. The images install nub onto an official node base, so Node is present and the runtime is augmented out of the box.
+description: Official Nub Docker images, and how to add Nub to your own image. The images install Nub onto an official Node base, so Node is present and the runtime is augmented out of the box.
 ---
 
-Nub augments the Node already in your image — it is not a separate runtime. The official images start from an official `node` base and layer nub on top, so `node`, `npm`, and `nub` are all present.
+Nub augments the Node already in your image — it is not a separate runtime. The official images start from an official `node` base and layer Nub on top, so `node`, `npm`, and `nub` are all present.
 
 ## Official images
 
@@ -31,9 +31,9 @@ docker run --rm -v "$PWD:/app" ghcr.io/nubjs/nub script.ts
 
 Signals reach the runtime: `docker stop` delivers `SIGTERM` to `nub`, which forwards it to the Node process for a clean shutdown. The container runs as the non-root `node` user (uid 1000); when you bind-mount a directory that `nub install` must write into, run with `--user "$(id -u)"` so the writes land with your host ownership.
 
-## Adding nub to your own image
+## Adding Nub to your own image
 
-If you already build on a `node` base, install nub with one line. npm selects the correct per-platform binary at install time — including the musl build on Alpine — and the package's postinstall sets the execute bit, so installing as root and then dropping to a non-root user works.
+If you already build on a `node` base, install Nub with one line. At install time, npm selects the correct per-platform binary — including the musl build on Alpine — and the package's postinstall sets the execute bit, so installing as root and then dropping to a non-root user works.
 
 ```dockerfile
 FROM node:26-slim
@@ -47,4 +47,4 @@ FROM node:26-alpine
 RUN apk add --no-cache libgcc libstdc++ && npm install -g @nubjs/nub
 ```
 
-To pin the floor Node version instead of the current line, use a `22` base (`node:22-slim` or `node:22-alpine`) — the lowest version nub's fast tier supports.
+To pin the floor Node version instead of the current line, use a `22` base (`node:22-slim` or `node:22-alpine`) — the lowest version Nub's fast tier supports.

--- a/site/content/docs/install/bun.mdx
+++ b/site/content/docs/install/bun.mdx
@@ -104,7 +104,7 @@ dependencies:
 nub 0.0.44 · ✓ installed 2 packages in 35ms
 ```
 
-Nub's curated default-trust floor is on, but inert over a `bun.lock`: its cooling-window gate needs per-package publish-time data, and `bun.lock` carries none, so it fails closed. `trustedDependencies` is the only allowlist that builds anything — exactly Bun's model.
+Nub's curated default-trust floor is on, but inert over a `bun.lock`: its cooling-window gate needs per-package publish-time data, and `bun.lock` carries none, so it fails closed. Only `trustedDependencies` builds anything — exactly Bun's model.
 
 ## `bunfig.toml`
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -258,7 +258,7 @@ The accepted flags are pnpm's spellings:
 --loglevel <level>    # debug, info, warn, error, silent
 ```
 
-To quiet the progress output, pass `--silent` (or `-s`, or `--reporter=silent`): nothing reaches stderr but a fatal error, matching `pnpm install --silent`. The `--reporter=append-only` form drops the live progress display while keeping the dependency summary, and `--loglevel error` hides warnings without touching the rest. These spellings apply to every install-family command — `install`, `ci`, `add`, `remove`, `update`, `dedupe`, `import` — and work either after the command (`nub install --silent`) or before it (`nub --silent install`).
+To quiet the progress output, pass `--silent` (or `-s`, or `--reporter=silent`): nothing reaches stderr but a fatal error, matching `pnpm install --silent`. The `--reporter=append-only` form drops the live progress display while keeping the dependency summary, and `--loglevel error` hides warnings without touching the rest. These spellings apply to every install-family command, and work either after the command (`nub install --silent`) or before it (`nub --silent install`).
 
 In a workspace, `install` and `ci` accept the same selector flags as script running — install only the packages a filter matches:
 

--- a/site/content/docs/nubx.mdx
+++ b/site/content/docs/nubx.mdx
@@ -54,7 +54,7 @@ nubx prisma migrate dev --name init
 nubx vitest run --coverage
 ```
 
-## --node
+## `--node`
 
 Pass `--node` to run the tool with runtime augmentation disabled — see [the runtime overview](/docs/runtime#--node) for the full contract.
 
@@ -122,7 +122,7 @@ The window is resolved from the same `.npmrc` scopes that `npx` reads: the built
 
 ## Yarn Plug'n'Play
 
-Tools that only walk `node_modules/.bin/` — `npx`, `pnpm exec`, `bunx` — miss Yarn Berry's PnP bins. `nubx` resolves them: when the `.bin` walk-up misses in a PnP tree, it falls through to a PnP-aware runner that finds and executes the bin. See [module resolution](/docs/runtime/resolution#yarn-plugnplay) for how the shared PnP machinery works.
+Tools that only walk `node_modules/.bin/` — `npx`, `pnpm exec`, `bunx` — miss Yarn Berry's PnP bins. Nub handles them anyway: when the `.bin` walk-up misses in a PnP tree, `nubx` falls through to a PnP-aware runner that finds and executes the bin. See [module resolution](/docs/runtime/resolution#yarn-plugnplay) for how the shared PnP machinery works.
 
 ## Flag differences
 

--- a/site/content/docs/run.mdx
+++ b/site/content/docs/run.mdx
@@ -3,7 +3,7 @@ title: Script runner
 description: A drop-in for pnpm run and npm run — every flag carries over with the same spelling and semantics, 24× faster on the cold path, with the full workspace and lifecycle-hook surface preserved.
 ---
 
-`nub run` is a drop-in for `pnpm run` and `npm run` — every flag carries over with the same spelling and semantics, down to the recursive and workspace-filter ones a real monorepo leans on. Existing invocations work unchanged:
+A drop-in for `pnpm run` and `npm run`, `nub run` carries every flag over with the same spelling and semantics, down to the recursive and workspace-filter ones a real monorepo leans on. Existing invocations work unchanged:
 
 ```bash
 nub run -r --resume-from @scope/pkg build      # resume an interrupted recursive run mid-graph
@@ -106,7 +106,7 @@ Nub runs `pre<script>` and `post<script>` hooks automatically, matching `npm run
 }
 ```
 
-a single `nub run build` runs all three in order:
+A single `nub run build` runs all three in order:
 
 ```bash
 nub run build                 # runs prebuild, then build, then postbuild

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -18,7 +18,7 @@ Four filenames are loaded, highest priority first. The shell environment always 
 3. `.env.[NODE_ENV]`
 4. `.env`
 
-The `[NODE_ENV]` slots only exist when `NODE_ENV` is set, so with `NODE_ENV=production` the full set is `.env.production.local`, `.env.local`, `.env.production`, `.env`. Among the `.env*` files, the first one to define a key wins (first-writer-wins); the shell env sits above all of them.
+The `[NODE_ENV]` slots only exist when `NODE_ENV` is set; the example below resolves them under `NODE_ENV=production`. Among the `.env*` files, the first one to define a key wins (first-writer-wins); the shell env sits above all of them.
 
 ```bash
 NODE_ENV=production nub server.ts   # reads .env.production.local, .env.local, .env.production, .env

--- a/site/content/docs/runtime/workers.mdx
+++ b/site/content/docs/runtime/workers.mdx
@@ -63,7 +63,7 @@ The second argument is a `WorkerOptions` object:
 
 | Option | Values | Effect |
 | --- | --- | --- |
-| `type` | `"module"` (default), `"classic"` | Selects the worker's module system and which `importScripts` form its scope exposes |
+| `type` | `"module"` (default), `"classic"` | Selects which `importScripts` form the worker scope exposes — classic gets the synchronous loader, module gets the throwing form |
 | `name` | string | Readable as `self.name` inside the worker |
 | `execArgv` | string array | Node flags for the worker; merged onto the flags carrying Nub's preload |
 | `env` | object | Environment for the worker thread |

--- a/site/content/docs/runtime/workers.mdx
+++ b/site/content/docs/runtime/workers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Web Workers
-description: A browser-style Worker global on stock Node — the full constructor, messaging, transferables, and event surface, with the divergences documented.
+description: A browser-style Worker global on stock Node — its constructor, messaging, transferables, and event surface.
 ---
 
 <TypesSetup>
@@ -27,7 +27,7 @@ self.onmessage = (ev) => {
 };
 ```
 
-The worker entry is TypeScript here for free — Nub transpiles it like any other entry. A worker that listens for messages keeps the process alive, so the main thread calls `worker.terminate()` once it has its reply (or the worker can `self.close()` itself). The `import.meta.resolve("./worker.ts")` call resolves the path against the current module — the clean, standard spelling. If you bundle for production, switch to `new URL("./worker.ts", import.meta.url)`, which third-party bundlers trace (see [Constructor inputs](#constructor-inputs)).
+The worker entry is TypeScript here for free — Nub transpiles it like any other entry. A worker that listens for messages keeps the process alive, so the main thread calls `worker.terminate()` once it has its reply (or the worker can `self.close()` itself). The `import.meta.resolve("./worker.ts")` call resolves the path against the current module — the clean, standard spelling. For a production build, switch to `new URL("./worker.ts", import.meta.url)`, which third-party bundlers trace (see [Constructor inputs](#constructor-inputs)).
 
 ## Mechanism
 
@@ -45,31 +45,34 @@ onmessage, onmessageerror
 importScripts   (classic workers only)
 ```
 
-Node's worker global is not an `EventTarget` and exposes none of these, so the polyfill provides the whole surface. The standard messaging types — `MessageEvent`, `MessageChannel`, `MessagePort` — are Node's own globals and are available inside a worker unchanged.
+Node's worker global is not an `EventTarget` and exposes none of these, so the polyfill provides the whole surface. The standard messaging types are Node's own globals — `MessageEvent`, `MessageChannel`, and `MessagePort` are available inside a worker unchanged.
 
 ## Constructor inputs
 
-`new Worker(scriptURL, options?)` accepts the WHATWG inputs: a file path or `URL` (including `file://`), a `data:` URL, or a `blob:` URL.
-
-For a path-based worker, reach for **`new Worker(import.meta.resolve("./worker.ts"))`**. The `import.meta.resolve` call is a standard API that resolves a specifier against the current module — caller-relative, never `process.cwd()` — and returns its URL, which the worker then loads (TypeScript and all). It is explicit, build-free, and the clean spelling to default to.
+The constructor accepts the WHATWG script-URL inputs: a file path or `URL` (including `file://`), a `data:` URL, or a `blob:` URL. For a path-based worker, reach for `new Worker(import.meta.resolve("./worker.ts"))`. The `import.meta.resolve` call is a standard API that resolves a specifier against the current module — caller-relative, never `process.cwd()` — and returns its URL, which the worker then loads (TypeScript and all). It is explicit, build-free, and the clean spelling to default to.
 
 <Callout title="Bundling for production? Use the new URL form.">
-Vite, webpack, and esbuild trace the `new URL("./worker.ts", import.meta.url)` pattern — they pull the worker into its own chunk and rewrite its path — but they do **not** yet trace `import.meta.resolve`, so a worker spawned that way is left unbundled and breaks in the build. When a third-party bundler is in your pipeline, write `new Worker(new URL("./worker.ts", import.meta.url))` instead. That form is caller-relative and runtime-correct too — the safe choice whenever you build.
+Vite, webpack, and esbuild trace the `new URL("./worker.ts", import.meta.url)` pattern — they pull the worker into its own chunk and rewrite its path — but they do **not** yet trace `import.meta.resolve`, so a worker spawned that way is left unbundled and breaks in the build. Whenever a third-party bundler is in your pipeline, write `new Worker(new URL("./worker.ts", import.meta.url))` instead. That form is caller-relative and runtime-correct too — the safe choice for a build.
 </Callout>
 
-A bare relative string — `new Worker("./worker.ts")` — resolves against `process.cwd()`, matching `node:worker_threads` and Bun, not the calling module. It works when the process is launched from the directory the path is relative to, but it is not module-relative and breaks for a nested file run from elsewhere.
+A bare relative string resolves against `process.cwd()`, not the calling module: `new Worker("./worker.ts")` matches `node:worker_threads` and Bun. It works when the process is launched from the directory the path is relative to, but it is not module-relative and breaks for a nested file run from elsewhere.
 
-A `data:` URL runs directly. A `blob:` URL from `URL.createObjectURL(blob)` is the WHATWG inline-worker mechanism — Nub snapshots the Blob's source synchronously at `createObjectURL` time and spawns it.
+A `data:` URL runs directly. A `blob:` URL from `URL.createObjectURL(blob)` is the WHATWG inline-worker mechanism — Nub snapshots the Blob's source synchronously at `createObjectURL` time and spawns it. There is no inline source-string form (the spec has none either — use a `blob:` or `data:` URL).
 
-`options` accepts `type` (`"module"` | `"classic"`), `name`, `execArgv`, and `env`. There is no inline source-string form (the spec has none either — use a `blob:` or `data:` URL).
+The second argument is a `WorkerOptions` object:
+
+| Option | Values | Effect |
+| --- | --- | --- |
+| `type` | `"module"` (default), `"classic"` | Selects the worker's module system and which `importScripts` form its scope exposes |
+| `name` | string | Readable as `self.name` inside the worker |
+| `execArgv` | string array | Node flags for the worker; merged onto the flags carrying Nub's preload |
+| `env` | object | Environment for the worker thread |
 
 ## Module and classic workers
 
-Both modes work. `{ type: "module" }` is the default shape; `{ type: "classic" }` enables `importScripts()`.
+Both modes work. A module worker is the default; a classic worker (`{ type: "classic" }`) gets the synchronous `importScripts()` loader, while a module worker gets the throwing form (use `import`). The `type` option chooses only which `importScripts` surface the worker exposes — Node still decides the entry's actual module-vs-CommonJS **parsing** by file extension and the nearest `package.json` `"type"`, the same rule Nub applies to the main entry.
 
-The `type` option is honored only to choose which `importScripts` surface the worker exposes — a classic worker gets the synchronous loader, a module worker gets the throwing form (use `import`). Node still decides the entry's actual module-vs-CommonJS **parsing** by file extension and the nearest `package.json` `"type"`, the same rule Nub applies to the main entry.
-
-`importScripts()` in a classic worker fetches and evaluates local files and `data:` URLs synchronously, in order. Remote (`http:`/`https:`) URLs are not supported — there is no synchronous network on Node.
+In a classic worker, `importScripts()` fetches and evaluates local files and `data:` URLs synchronously, in order. Remote (`http:`/`https:`) URLs are not supported — there is no synchronous network on Node.
 
 ```ts
 const worker = new Worker(new URL("./worker.js", import.meta.url), { type: "classic" });
@@ -104,7 +107,16 @@ Inbound `"message"` events arrive as real `MessageEvent`s (`ev.data`); a thrown 
 
 ### Transferables and cloning
 
-Message payloads are cloned with Node's structured serializer. Plain data, `ArrayBuffer`, `Map`/`Set`/`Date`/typed arrays, `MessagePort`, and `SharedArrayBuffer` all clone or transfer correctly; transferring an `ArrayBuffer` detaches it on the sending side. The transferable set is Node's: `ArrayBuffer`, `MessagePort`, `FileHandle`. Browser-only transferables (`ImageBitmap`, `OffscreenCanvas`, stream transfer) are unavailable — there is no DOM substrate on Node.
+Message payloads are cloned with Node's structured serializer:
+
+| Category | Members |
+| --- | --- |
+| Cloned | plain objects and arrays, `Map` / `Set` / `Date`, typed arrays |
+| Transferred | `ArrayBuffer`, `MessagePort`, `FileHandle` — Node's transferable set |
+| Shared | `SharedArrayBuffer` (shared by reference, not copied) |
+| Unavailable | `ImageBitmap`, `OffscreenCanvas`, stream transfer — no DOM substrate on Node |
+
+Transferring an `ArrayBuffer` detaches it on the sending side.
 
 ## Conformance
 
@@ -116,13 +128,13 @@ These are the behaviors where nub's wrapper differs from a browser `Worker`. The
 
 **Port start.** Adding a `"message"` listener with `addEventListener` starts a `MessagePort` immediately. The spec starts a port only on `start()` or on setting `onmessage`; `node:worker_threads` (and Cloudflare's `workerd`) start it on any listener, so with nub a message can be delivered before an explicit `start()`.
 
-**`self.close()` is immediate.** Calling `close()` inside a worker exits the thread at once. The browser's `close()` is graceful — already-queued tasks still run — so code that does work *after* `close()` (for example a `postMessage` right after closing) behaves differently here.
+**Immediate `self.close()`.** Calling `close()` inside a worker exits the thread at once. The browser's `close()` is graceful — already-queued tasks still run — so code that does work *after* `close()` (for example a `postMessage` right after closing) behaves differently here.
 
-**`MessageEvent.isTrusted`.** Events from a `MessagePort` report `isTrusted === false`. Node's `MessageEvent` is not a trusted event; native Node behaves the same.
+**Untrusted `MessageEvent`.** Events from a `MessagePort` report `isTrusted === false`. Node's `MessageEvent` is not a trusted event; native Node behaves the same.
 
-**`event.target` for non-message events.** Events other than `"message"` / `"messageerror"` dispatched on `self` inside a worker land on a private `EventTarget`, so `event.target` is that target rather than the global scope. Dispatch itself works — `self.addEventListener("custom", …)` plus `self.dispatchEvent(new Event("custom"))` fires the listener — only the `target` identity differs. The private target is a deliberate seam so worker lifetime (auto-exit when no message listeners remain) matches Node.
+**Non-message `event.target`.** Events other than `"message"` / `"messageerror"` dispatched on `self` inside a worker land on a private `EventTarget`, so `event.target` is that target rather than the global scope. Dispatch itself works — `self.addEventListener("custom", …)` plus `self.dispatchEvent(new Event("custom"))` fires the listener — only the `target` identity differs. The private target is a deliberate seam so worker lifetime (auto-exit when no message listeners remain) matches Node.
 
-**`File` round-trip on Node 22.** On the Node 22 line, posting or `structuredClone`-ing a `File` deserializes it to a plain `Blob` — the bytes survive but the `File` wrapper (and `instanceof File`) is lost. This is a Node 22 structured-clone limitation, fixed in Node 24; it reproduces on plain Node 22 with no nub involved. `Blob` itself round-trips correctly on every version.
+**File round-trip on Node 22.** On the Node 22 line, posting or `structuredClone`-ing a `File` deserializes it to a plain `Blob` — the bytes survive but the `File` wrapper (and `instanceof File`) is lost. This is a Node 22 structured-clone limitation, fixed in Node 24; it reproduces on plain Node 22 with no nub involved. `Blob` itself round-trips correctly on every version.
 
 **No `SharedWorker`.** It depends on a browser document/origin model with no server-side equivalent — Bun and Cloudflare omit it too. Use one worker plus message passing.
 

--- a/site/content/docs/setup-nub.mdx
+++ b/site/content/docs/setup-nub.mdx
@@ -207,7 +207,7 @@ Token for GitHub-API rate-limit relief when resolving Nub's version range (and N
 The drop-in is mechanical, so the differences are small and rarely surface:
 
 - The `cache` input is a boolean rather than a package-manager name. A package-manager name still works (it is treated as on), since Nub keeps a single store regardless of package manager.
-- The registry `.npmrc` is written fresh to `$RUNNER_TEMP` and pointed at via `NPM_CONFIG_USERCONFIG`, rather than merged into the user `.npmrc`. npm and Nub's package manager parse both identically.
+- The registry `.npmrc` is written fresh to `$RUNNER_TEMP` and pointed at via `NPM_CONFIG_USERCONFIG`, rather than merged into the user `.npmrc`. Both are parsed identically by npm and Nub's package manager.
 
 ## Related
 

--- a/site/content/guides/turborepo.mdx
+++ b/site/content/guides/turborepo.mdx
@@ -11,7 +11,7 @@ Everything below is grounded in how the two tools actually behave together today
 
 - Keep your `package.json` `packageManager` field and your existing lockfile exactly as they are.
 - Install with `nub install` instead of your old package manager.
-- Run Turborepo under nub — `nub run <script>` where the script is `turbo run …`, or `nubx turbo run …`.
+- Run Turborepo under Nub — `nub run <script>` where the script is `turbo run …`, or `nubx turbo run …`.
 
 That is the whole integration. The rest of this page explains why it works and what to watch for.
 
@@ -59,7 +59,7 @@ nub run build         # root script: "turbo run build"
  Tasks:    1 successful, 1 total
 ```
 
-The one thing that matters is that **Turborepo runs under nub**. Launch it with `nub run <script>` (where the script's command is `turbo run …`) or with `nubx turbo run …`. If you invoke the `turbo` binary directly from a plain shell, the tasks run on whatever Node is on your path with no augmentation, and a `.ts` entry will fail to parse.
+The one thing that matters is that **Turborepo runs under Nub**. Launch it with `nub run <script>` (where the script's command is `turbo run …`) or with `nubx turbo run …`. If you invoke the `turbo` binary directly from a plain shell, the tasks run on whatever Node is on your path with no augmentation, and a `.ts` entry will fail to parse.
 
 You do not need to rewrite your package scripts to say `nub` anywhere. A script of `node ./build.ts` is enough — Nub's augmentation is what turns that into a TypeScript-aware run.
 


### PR DESCRIPTION
Surgical PROSE.md cleanup of the docs pages that clearly disrespected the prose skill; the Web Workers page is the flagship rewrite. Most pages are already good and were left untouched (FAQ, runtime overview, the rest).

`runtime/workers.mdx`: no sentence opens with inline code; the options and transferables pileups became tables; claims re-grounded in `worker-polyfill.mjs` and verified against the dev binary.

One-violation fixes elsewhere: docker/turborepo (Nub capitalization in prose), nubx (heading + sentence), run (opening sentence + lowercase start), env and install-index (inline-code pileups), bun and setup-nub (sentence starts).

Docs-only; path-filtered CI.