### PR TITLE
fix(aube): content-address the no-integrity warm lookup per project

### DIFF
--- a/vendor/aube/crates/aube-linker/src/builder.rs
+++ b/vendor/aube/crates/aube-linker/src/builder.rs
@@ -41,7 +41,37 @@ impl Linker {
             virtual_store_only: false,
             modules_dir_name: "node_modules".to_string(),
             aube_dir_override: None,
+            no_integrity_read_keys: std::collections::BTreeMap::new(),
         }
+    }
+
+    /// Supply per-project `<registry-name>@<version>` → computed-sha512
+    /// bindings so the `load_index` fallback can content-address the
+    /// index read for a no-integrity package instead of keying by `None`
+    /// (see the field docs on [`Linker`]). The install driver populates
+    /// this from `state::read_no_integrity_index`; standalone callers
+    /// and tests omit it and get unchanged behavior.
+    pub fn with_no_integrity_read_keys(
+        mut self,
+        keys: std::collections::BTreeMap<String, String>,
+    ) -> Self {
+        self.no_integrity_read_keys = keys;
+        self
+    }
+
+    /// The index-cache read key for `pkg`: its lockfile SRI when present,
+    /// else this project's computed-sha512 binding for the coordinate
+    /// (no-integrity packages). `None` only when a no-integrity package
+    /// has no binding yet — the caller then misses cleanly and re-fetches.
+    pub(crate) fn index_read_key<'a>(
+        &'a self,
+        pkg: &'a aube_lockfile::LockedPackage,
+    ) -> Option<&'a str> {
+        pkg.integrity.as_deref().or_else(|| {
+            self.no_integrity_read_keys
+                .get(&format!("{}@{}", pkg.registry_name(), pkg.version))
+                .map(String::as_str)
+        })
     }
 
     /// Select the layout mode. Defaults to `NodeLinker::Isolated`

--- a/vendor/aube/crates/aube-linker/src/hoisted.rs
+++ b/vendor/aube/crates/aube-linker/src/hoisted.rs
@@ -416,7 +416,7 @@ fn materialize_hoisted_node(
         None => {
             owned_index = linker
                 .store
-                .load_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref())
+                .load_index(pkg.registry_name(), &pkg.version, linker.index_read_key(pkg))
                 .ok_or_else(|| Error::MissingPackageIndex(dep_path.to_string()))?;
             &owned_index
         }
@@ -475,7 +475,11 @@ fn materialize_hoisted_node(
             let target = pkg_dir.join(rel_path);
             if let Err(e) = linker.link_file_fresh(stored, rel_path, &target) {
                 if let Error::MissingStoreFile { .. } = &e {
-                    crate::invalidate_stale_index_for_package(&linker.store, pkg);
+                    crate::invalidate_stale_index_for_package(
+                        &linker.store,
+                        pkg,
+                        linker.index_read_key(pkg),
+                    );
                 }
                 return Err(e);
             }

--- a/vendor/aube/crates/aube-linker/src/lib.rs
+++ b/vendor/aube/crates/aube-linker/src/lib.rs
@@ -227,6 +227,18 @@ pub struct Linker {
     /// `NodeLinker::Hoisted` — that layout *is* a flat top-level
     /// materialization, so "only the virtual store" doesn't apply.
     virtual_store_only: bool,
+    /// Per-project `<registry-name>@<version>` → computed-sha512
+    /// bindings for packages whose lockfile carries no integrity
+    /// (v1/legacy or an integrity-stripping proxy). Consulted ONLY by
+    /// the on-demand `load_index` fallback (a package the fetch driver
+    /// classified `AlreadyLinked` whose `.aube/<dep_path>` entry then
+    /// vanished or was invalidated). Without it, such a package's index
+    /// read would key by `None` and either miss or, in a shared store,
+    /// hit a content-free selector pointing at another project's bytes;
+    /// this binds the read to the sha512 THIS project computed, matching
+    /// the warm classifier. Empty for callers that don't supply it
+    /// (standalone-default and every existing test) → unchanged behavior.
+    no_integrity_read_keys: std::collections::BTreeMap<String, String>,
 }
 
 /// Strategy for linking files from the store to node_modules.

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -40,6 +40,7 @@ impl Linker {
             aube_dir_override: self.aube_dir_override.clone(),
             link_concurrency: self.link_concurrency,
             virtual_store_only: self.virtual_store_only,
+            no_integrity_read_keys: self.no_integrity_read_keys.clone(),
         }
     }
 
@@ -326,7 +327,7 @@ impl Linker {
                                         .load_index(
                                             pkg.registry_name(),
                                             &pkg.version,
-                                            pkg.integrity.as_deref(),
+                                            self.index_read_key(pkg),
                                         )
                                         .ok_or_else(|| {
                                             Error::MissingPackageIndex(dep_path.to_string())
@@ -420,7 +421,7 @@ impl Linker {
                                         .load_index(
                                             pkg.registry_name(),
                                             &pkg.version,
-                                            pkg.integrity.as_deref(),
+                                            self.index_read_key(pkg),
                                         )
                                         .ok_or_else(|| {
                                             Error::MissingPackageIndex(dep_path.to_string())
@@ -869,7 +870,7 @@ impl Linker {
                                         .load_index(
                                             pkg.registry_name(),
                                             &pkg.version,
-                                            pkg.integrity.as_deref(),
+                                            self.index_read_key(pkg),
                                         )
                                         .ok_or_else(|| {
                                             Error::MissingPackageIndex(dep_path.to_string())
@@ -940,7 +941,7 @@ impl Linker {
                                         .load_index(
                                             pkg.registry_name(),
                                             &pkg.version,
-                                            pkg.integrity.as_deref(),
+                                            self.index_read_key(pkg),
                                         )
                                         .ok_or_else(|| {
                                             Error::MissingPackageIndex(dep_path.to_string())

--- a/vendor/aube/crates/aube-linker/src/materialize.rs
+++ b/vendor/aube/crates/aube-linker/src/materialize.rs
@@ -609,7 +609,7 @@ impl Linker {
 
             if let Err(e) = self.link_file_fresh(stored, rel_path, &target) {
                 if let Error::MissingStoreFile { .. } = &e {
-                    invalidate_stale_index_for_package(&self.store, pkg);
+                    invalidate_stale_index_for_package(&self.store, pkg, self.index_read_key(pkg));
                 }
                 return Err(e);
             }
@@ -1131,7 +1131,7 @@ impl Linker {
             if let Err(e) = self.link_file_fresh(stored, rel_path, &target) {
                 let _ = std::fs::remove_dir_all(&tmp);
                 if let Error::MissingStoreFile { .. } = &e {
-                    invalidate_stale_index_for_package(&self.store, pkg);
+                    invalidate_stale_index_for_package(&self.store, pkg, self.index_read_key(pkg));
                 }
                 return Err(e);
             }
@@ -1185,9 +1185,17 @@ fn classify_link_error(
 /// reference. If the cache write fails (e.g. permission error), warn
 /// loudly so the user knows the auto-recovery didn't take and they need
 /// to wipe the index dir by hand (run `aube store path` to find it).
-pub(crate) fn invalidate_stale_index_for_package(store: &aube_store::Store, pkg: &LockedPackage) {
-    match store.invalidate_cached_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref())
-    {
+pub(crate) fn invalidate_stale_index_for_package(
+    store: &aube_store::Store,
+    pkg: &LockedPackage,
+    // The same key the warm read uses (`Linker::index_read_key`): the
+    // lockfile SRI, or the per-project computed-sha512 binding for a
+    // no-integrity package. Invalidating by `pkg.integrity` (`None`)
+    // would clear a key the read never uses and leave the stale hex
+    // index in place — the exact dead-reference loop this guards against.
+    read_key: Option<&str>,
+) {
+    match store.invalidate_cached_index(pkg.registry_name(), &pkg.version, read_key) {
         Ok(true) => debug!("invalidated stale index for {}", pkg.spec_key()),
         Ok(false) => {}
         Err(e) => warn!(

--- a/vendor/aube/crates/aube/src/commands/ignored_builds.rs
+++ b/vendor/aube/crates/aube/src/commands/ignored_builds.rs
@@ -146,6 +146,12 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
         super::install::build_policy_from_sources(&manifest, &workspace, false);
 
     let store = super::open_store(project_dir)?;
+    // Resolve a no-integrity package's index by the per-project
+    // computed-sha512 binding (matching the install warm read), so a
+    // v1/legacy-lock package with a suspicious lifecycle script still
+    // surfaces here — keying by `None` would miss now that the
+    // content-free root index is no longer written.
+    let no_integrity_index = crate::state::read_no_integrity_index(project_dir);
 
     let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
     let mut out: Vec<IgnoredEntry> = Vec::new();
@@ -164,12 +170,14 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
         ) {
             continue;
         }
-        let Some(suspicions) = lifecycle_scripts_with_suspicions(
-            &store,
-            &pkg.name,
-            &pkg.version,
-            pkg.integrity.as_deref(),
-        ) else {
+        let read_key = pkg.integrity.as_deref().or_else(|| {
+            no_integrity_index
+                .get(&format!("{}@{}", pkg.registry_name(), pkg.version))
+                .map(String::as_str)
+        });
+        let Some(suspicions) =
+            lifecycle_scripts_with_suspicions(&store, &pkg.name, &pkg.version, read_key)
+        else {
             continue;
         };
         out.push(IgnoredEntry {
@@ -201,11 +209,11 @@ fn lifecycle_scripts_with_suspicions(
     version: &str,
     integrity: Option<&str>,
 ) -> Option<Vec<aube_scripts::Suspicion>> {
-    // Cache lookup is integrity-keyed when available (prevents
-    // same-(name, version) entries from different sources colliding)
-    // and falls back to the plain (name, version) key when integrity
-    // is absent so proxy-served packages without `dist.integrity` are
-    // still classifiable.
+    // `integrity` is the read key the caller resolved: the lockfile SRI,
+    // or — for a no-integrity package — the per-project computed-sha512
+    // binding, so a v1/legacy-lock package stays classifiable now that
+    // the content-free root index is no longer written. A package with
+    // no binding yet simply isn't classified (conservative miss).
     let index = store.load_index(name, version, integrity)?;
     let stored = index.get("package.json")?;
     let content = std::fs::read_to_string(&stored.store_path).ok()?;

--- a/vendor/aube/crates/aube/src/commands/install/fetch.rs
+++ b/vendor/aube/crates/aube/src/commands/install/fetch.rs
@@ -376,6 +376,22 @@ pub(super) async fn import_local_source(
     }
 }
 
+/// The warm-classifier index read key for `pkg`: its lockfile SRI when
+/// present, else this project's computed-sha512 binding for the
+/// coordinate (a no-integrity package). `None` means a no-integrity
+/// package with no binding yet — the caller must re-fetch rather than
+/// fall back to the content-free `None` selector.
+fn warm_read_key<'a>(
+    pkg: &'a aube_lockfile::LockedPackage,
+    no_integrity_index: &'a BTreeMap<String, String>,
+) -> Option<&'a str> {
+    pkg.integrity.as_deref().or_else(|| {
+        no_integrity_index
+            .get(&format!("{}@{}", pkg.registry_name(), pkg.version))
+            .map(String::as_str)
+    })
+}
+
 /// Fetch tarballs for resolved packages, checking the index cache first.
 /// Used by the lockfile path where all packages are known upfront.
 /// Exposed to sibling commands so `aube fetch` can reuse the same
@@ -569,6 +585,13 @@ where
         NeedsFetch,
     }
 
+    // Per-project content-address bindings for no-integrity packages
+    // (see `state::read_no_integrity_index`). Loaded once; the warm
+    // classifier resolves each no-integrity lookup through it so the
+    // read content-addresses the store by the sha512 THIS project
+    // computed, never a content-free shared-store selector.
+    let no_integrity_index = crate::state::read_no_integrity_index(project_root);
+
     // Parallel index check (rayon)
     let check_results: Vec<_> = packages
         .par_iter()
@@ -604,14 +627,24 @@ where
             // `ERR_AUBE_MISSING_STORE_FILE`, forcing a whole-install
             // retry. Independent of import-time SRI / `verifyStoreIntegrity`,
             // which is enforced on fetch regardless of this flag.
-            match super::warm_load_index(
-                store,
-                pkg.registry_name(),
-                &pkg.version,
-                pkg.integrity.as_deref(),
-            ) {
-                Some(index) => (dep_path.clone(), pkg, CheckResult::Cached(index)),
+            // Content-address the lookup: a no-integrity package keys by
+            // the sha512 this project bound for the coordinate, not the
+            // bare `None` selector. No binding yet (first install, or a
+            // store predating this index) → re-fetch rather than read the
+            // content-free selector that, in a shared store, could return
+            // a different project's bytes for the same name@version.
+            let read_key = warm_read_key(pkg, &no_integrity_index);
+            match read_key {
                 None => (dep_path.clone(), pkg, CheckResult::NeedsFetch),
+                Some(key) => match super::warm_load_index(
+                    store,
+                    pkg.registry_name(),
+                    &pkg.version,
+                    Some(key),
+                ) {
+                    Some(index) => (dep_path.clone(), pkg, CheckResult::Cached(index)),
+                    None => (dep_path.clone(), pkg, CheckResult::NeedsFetch),
+                },
             }
         })
         .collect();
@@ -1015,6 +1048,28 @@ where
         sem.persist(&state, "tarball:default");
     }
 
+    // Bind every no-integrity package we imported this run to the sha512
+    // we computed, keyed by the coordinate the warm classifier looks up
+    // (`<registry-name>@<version>`), so the next frozen warm install
+    // content-addresses the store lookup instead of re-fetching — and
+    // never relies on a content-free shared-store selector. Only
+    // no-integrity entries need it; `computed_integrities` already holds
+    // exactly those (it is populated only when the lockfile carried no
+    // SRI). Merge-persisted so a partial/filtered run keeps prior
+    // coordinates' bindings.
+    let resolved_no_integrity: BTreeMap<String, String> = packages
+        .iter()
+        .filter(|(_, pkg)| pkg.integrity.is_none())
+        .filter_map(|(dep_path, pkg)| {
+            computed_integrities
+                .get(strip_peer_context_suffix(dep_path))
+                .map(|sri| (format!("{}@{}", pkg.registry_name(), pkg.version), sri.clone()))
+        })
+        .collect();
+    if let Err(e) = crate::state::merge_no_integrity_index(project_root, &resolved_no_integrity) {
+        tracing::debug!("failed to persist no-integrity content-address index: {e}");
+    }
+
     Ok((indices, cached_count, fetch_count, computed_integrities))
 }
 
@@ -1329,5 +1384,121 @@ mod tests {
 
         let out = super::remap_indices_to_contextualized(&canonical_indices, &graph);
         assert!(out.contains_key(canonical));
+    }
+
+    // Option B closure: mirrors the a46858e cross-project root-key repro,
+    // asserting it CANNOT happen anymore. Two projects share one per-user
+    // store and resolve the same `foo@1.0.0` to DIFFERENT bytes from
+    // DIFFERENT registries, neither carrying lockfile integrity. The warm
+    // lookup must content-address to each project's OWN computed sha512,
+    // and the shared store must carry NO content-free selector that could
+    // serve one project's bytes to the other.
+    #[test]
+    fn no_integrity_warm_lookup_is_per_project_content_addressed() {
+        use std::collections::BTreeMap;
+        use std::io::Write;
+
+        // A distinct gzipped tarball per project (distinct manifest body
+        // → distinct stored content), imported into the SHARED store so
+        // load_index's file stat finds real CAS shards.
+        let build_tgz = |marker: &str| {
+            let mut builder = tar::Builder::new(Vec::new());
+            let manifest =
+                format!(r#"{{"name":"foo","version":"1.0.0","_from":"{marker}"}}"#).into_bytes();
+            let mut header = tar::Header::new_gnu();
+            header.set_size(manifest.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "package/package.json", &manifest[..])
+                .unwrap();
+            let tar_bytes = builder.into_inner().unwrap();
+            let mut encoder =
+                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+            encoder.write_all(&tar_bytes).unwrap();
+            encoder.finish().unwrap()
+        };
+
+        let store_dir = tempfile::tempdir().unwrap();
+        let store = aube_store::Store::at(store_dir.path().join("files"));
+        let name = "foo";
+        let version = "1.0.0";
+        let coord = format!("{name}@{version}");
+
+        // Project A and B import different bytes; each is cached ONLY under
+        // its own computed-sha512 hex key (Option B writes no root key).
+        let index_a = store.import_tarball(&build_tgz("registry-a")).unwrap();
+        let index_b = store.import_tarball(&build_tgz("registry-b")).unwrap();
+        let sri_a = aube_store::sha512_integrity_from_digest(&[0xAA; 64]);
+        let sri_b = aube_store::sha512_integrity_from_digest(&[0xBB; 64]);
+        store.save_index(name, version, Some(&sri_a), &index_a).unwrap();
+        store.save_index(name, version, Some(&sri_b), &index_b).unwrap();
+
+        // Each project binds the coordinate to ITS OWN sha512.
+        let proj_a = tempfile::tempdir().unwrap();
+        let proj_b = tempfile::tempdir().unwrap();
+        crate::state::merge_no_integrity_index(
+            proj_a.path(),
+            &BTreeMap::from([(coord.clone(), sri_a.clone())]),
+        )
+        .unwrap();
+        crate::state::merge_no_integrity_index(
+            proj_b.path(),
+            &BTreeMap::from([(coord.clone(), sri_b.clone())]),
+        )
+        .unwrap();
+
+        // The substitution surface is structurally absent: no content-free
+        // selector exists in the shared store.
+        assert!(
+            store.load_index(name, version, None).is_none(),
+            "shared store must carry no content-free <name>@<version> selector"
+        );
+
+        // A v1/no-integrity package; its lockfile carries no SRI.
+        let pkg = aube_lockfile::LockedPackage {
+            name: name.to_string(),
+            version: version.to_string(),
+            dep_path: coord.clone(),
+            ..Default::default()
+        };
+        assert!(pkg.integrity.is_none());
+
+        // Each project's warm classifier resolves its OWN bytes — never
+        // the other project's.
+        let idx_a = crate::state::read_no_integrity_index(proj_a.path());
+        let key_a = super::warm_read_key(&pkg, &idx_a).expect("project A has a binding");
+        assert_eq!(key_a, sri_a);
+        let a_hash = store
+            .load_index(name, version, Some(key_a))
+            .expect("project A hits its own hex index")
+            .get("package.json")
+            .unwrap()
+            .hex_hash
+            .clone();
+
+        let idx_b = crate::state::read_no_integrity_index(proj_b.path());
+        let key_b = super::warm_read_key(&pkg, &idx_b).expect("project B has a binding");
+        assert_eq!(key_b, sri_b);
+        let b_hash = store
+            .load_index(name, version, Some(key_b))
+            .expect("project B hits its own hex index")
+            .get("package.json")
+            .unwrap()
+            .hex_hash
+            .clone();
+
+        assert_ne!(
+            a_hash, b_hash,
+            "each project must resolve its own distinct bytes — no cross-substitution"
+        );
+
+        // No binding yet (a fresh project, or a store predating the index)
+        // → re-fetch, never the content-free selector.
+        let empty = BTreeMap::new();
+        assert!(
+            super::warm_read_key(&pkg, &empty).is_none(),
+            "a no-integrity package with no binding must miss (re-fetch), not read the root key"
+        );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -754,20 +754,19 @@ pub(crate) async fn run_dep_lifecycle_scripts(
 /// lockfile (`None` for a v1/legacy entry or an integrity-stripping
 /// proxy); `computed_integrity` is the sha512 the streaming path
 /// derived from the tarball bytes when the lockfile carried none. The
-/// index is always saved under the effective key
+/// index is saved under the effective key
 /// (`lockfile_integrity.or(computed_integrity)`).
 ///
-/// The legacy-cache fix: when there is no lockfile integrity but the
-/// effective key is a *computed* sha512, the index lands in a hex
-/// subdirectory. A frozen warm install's classifier, however, reads
-/// with `integrity = None` (the root key) for those same entries, so it
-/// would never look in the hex subdir — a permanent cache miss that
-/// re-fetches the tarball every install. Persisting *also* under the
-/// root key makes the warm read hit, while keeping the hex write for
-/// the self-heal case (the lockfile is later upgraded to v3 carrying
-/// the computed integrity). When `lockfile_integrity` is `Some`, the
-/// effective key already equals it and no root-key write happens — an
-/// integrity-bearing entry must stay discriminated by source.
+/// No content-FREE root-key (`None`) write happens here. A no-integrity
+/// package's index lands ONLY under its computed-sha512 hex key, and the
+/// warm classifier reaches it by content-addressing through the
+/// per-project no-integrity index (`state::read_no_integrity_index`) —
+/// not by reading a bare `<name>@<version>` selector that, in a
+/// per-user shared store, would let one project's bytes be served to
+/// another for the same coordinate. (A predecessor wrote both keys; that
+/// root-key write opened exactly that cross-project substitution surface
+/// and is removed here.) The hex write is kept — both the content-
+/// addressed warm read and the v3-self-heal upgrade resolve through it.
 fn persist_pkg_index(
     store: &aube_store::Store,
     registry_name: &str,
@@ -782,15 +781,6 @@ fn persist_pkg_index(
         tracing::warn!(
             code = aube_codes::warnings::WARN_AUBE_CACHE_WRITE_FAILED,
             "Failed to cache index for {display_name}@{version}: {e}"
-        );
-    }
-    if lockfile_integrity.is_none()
-        && effective.is_some()
-        && let Err(e) = store.save_index(registry_name, version, None, index)
-    {
-        tracing::warn!(
-            code = aube_codes::warnings::WARN_AUBE_CACHE_WRITE_FAILED,
-            "Failed to cache root-key index for {display_name}@{version}: {e}"
         );
     }
 }
@@ -1358,7 +1348,7 @@ mod tests {
     }
 
     #[test]
-    fn no_integrity_import_is_retrievable_by_warm_none_key() {
+    fn no_integrity_import_keys_only_by_computed_hex_never_root() {
         use flate2::write::GzEncoder;
         use std::io::Write;
 
@@ -1393,24 +1383,24 @@ mod tests {
         let index = store.import_tarball(&build_tgz()).unwrap();
         persist_pkg_index(&store, name, version, None, Some(&computed), &index, name);
 
-        // THE REGRESSION: a frozen warm install's classifier reads with
-        // integrity=None, so the no-integrity import must be retrievable
-        // by that root key or it re-fetches every install.
-        assert!(
-            store.load_index(name, version, None).is_some(),
-            "no-integrity import must be retrievable by the warm None key"
-        );
-        // The computed-sha512 key still resolves — the self-heal path
-        // when the lockfile is later upgraded to carry that integrity.
+        // Option B: the no-integrity import is content-addressed by its
+        // computed-sha512 hex key. The warm classifier reaches it through
+        // the per-project no-integrity index, NOT a content-free root
+        // selector — so NO `None`-key entry may exist in the shared store
+        // (that selector is the cross-project substitution surface).
         assert!(
             store.load_index(name, version, Some(&computed)).is_some(),
-            "computed-sha512 key must still resolve (self-heal path)"
+            "no-integrity import must be retrievable by its computed-sha512 hex key"
+        );
+        assert!(
+            store.load_index(name, version, None).is_none(),
+            "no content-free root-key selector may be written to the shared store"
         );
 
         // CONTROL: an integrity-bearing entry is keyed solely by its SRI
-        // and must NOT be dual-saved under the root key — otherwise two
+        // and must NOT be saved under the root key — otherwise two
         // sources for the same (name, version) would alias on disk. A
-        // fresh store isolates it from the legacy entry's root-key write.
+        // fresh store isolates it from the legacy entry above.
         let dir2 = tempfile::tempdir().unwrap();
         let store2 = aube_store::Store::at(dir2.path().join("files"));
         let index2 = store2.import_tarball(&build_tgz()).unwrap();

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -757,16 +757,24 @@ pub(crate) async fn run_dep_lifecycle_scripts(
 /// index is saved under the effective key
 /// (`lockfile_integrity.or(computed_integrity)`).
 ///
-/// No content-FREE root-key (`None`) write happens here. A no-integrity
-/// package's index lands ONLY under its computed-sha512 hex key, and the
+/// No content-FREE root-key (`None`) write happens here — ever. The
+/// index is cached ONLY when there's an integrity to key it by; a
+/// no-integrity package lands under its computed-sha512 hex key, and the
 /// warm classifier reaches it by content-addressing through the
 /// per-project no-integrity index (`state::read_no_integrity_index`) —
-/// not by reading a bare `<name>@<version>` selector that, in a
-/// per-user shared store, would let one project's bytes be served to
-/// another for the same coordinate. (A predecessor wrote both keys; that
-/// root-key write opened exactly that cross-project substitution surface
-/// and is removed here.) The hex write is kept — both the content-
-/// addressed warm read and the v3-self-heal upgrade resolve through it.
+/// not a bare `<name>@<version>` selector that, in a per-user shared
+/// store, would let one project's bytes be served to another for the
+/// same coordinate. (A predecessor wrote both keys; that root-key write
+/// opened exactly that cross-project substitution surface.) The hex
+/// write is kept — both the content-addressed warm read and the
+/// v3-self-heal upgrade resolve through it.
+///
+/// When BOTH integrities are `None` (the non-default buffered import of
+/// a no-integrity package — `DISABLE_TARBALL_STREAM=1`; the streaming
+/// default always computes a sha512), nothing is cached: writing the
+/// bare key would reopen the surface, and the binding the warm read
+/// needs comes from the streaming path. The buffered warm install
+/// re-fetches instead, which is the pre-existing trade-off for that mode.
 fn persist_pkg_index(
     store: &aube_store::Store,
     registry_name: &str,
@@ -776,8 +784,10 @@ fn persist_pkg_index(
     index: &aube_store::PackageIndex,
     display_name: &str,
 ) {
-    let effective = lockfile_integrity.or(computed_integrity);
-    if let Err(e) = store.save_index(registry_name, version, effective, index) {
+    let Some(effective) = lockfile_integrity.or(computed_integrity) else {
+        return;
+    };
+    if let Err(e) = store.save_index(registry_name, version, Some(effective), index) {
         tracing::warn!(
             code = aube_codes::warnings::WARN_AUBE_CACHE_WRITE_FAILED,
             "Failed to cache index for {display_name}@{version}: {e}"
@@ -849,12 +859,11 @@ pub(super) fn import_verified_tarball(
     }
     // Cache under `registry_name` so two aliases of the same real
     // package hit the same on-disk index file and avoid redundant
-    // fetches. When `integrity` is `Some` the filename carries a
-    // `+<hex>` suffix that discriminates same-(name, version)
-    // tarballs from different sources; when `None` falls back to the
-    // plain name@version key so warm installs still find the cache
-    // on integrity-stripping proxies. The buffered path derives no
-    // computed integrity, so it keys solely by the lockfile SRI.
+    // fetches, keyed by the effective integrity (`+<hex>` subdir) so
+    // same-(name, version) tarballs from different sources stay
+    // discriminated. The buffered path derives no computed integrity, so
+    // a no-integrity entry isn't cached here (see `persist_pkg_index`);
+    // the streaming default computes the sha512 the warm read needs.
     persist_pkg_index(
         store,
         registry_name,
@@ -1422,6 +1431,18 @@ mod tests {
                 .load_index(name, version, Some(&lockfile_sri))
                 .is_some(),
             "integrity-bearing entry must resolve by its lockfile SRI"
+        );
+
+        // CONTROL: a buffered no-integrity import (both integrities None —
+        // the `DISABLE_TARBALL_STREAM=1` path) caches NOTHING. Writing the
+        // bare key would reopen the content-free shared selector.
+        let dir3 = tempfile::tempdir().unwrap();
+        let store3 = aube_store::Store::at(dir3.path().join("files"));
+        let index3 = store3.import_tarball(&build_tgz()).unwrap();
+        persist_pkg_index(&store3, name, version, None, None, &index3, name);
+        assert!(
+            store3.load_index(name, version, None).is_none(),
+            "buffered no-integrity import must not write a content-free root selector"
         );
     }
 

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -151,7 +151,12 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         .with_link_concurrency(link_concurrency_setting)
         .with_virtual_store_only(virtual_store_only)
         .with_modules_dir_name(modules_dir_name.to_string())
-        .with_aube_dir_override(aube_dir.to_path_buf());
+        .with_aube_dir_override(aube_dir.to_path_buf())
+        // Lets the linker's on-demand `load_index` fallback content-address
+        // a no-integrity package's index (matching the warm classifier)
+        // instead of keying by the bare `None` selector — see the field
+        // docs on `aube_linker::Linker`.
+        .with_no_integrity_read_keys(crate::state::read_no_integrity_index(cwd));
     if let Some(enabled) = use_global_virtual_store_override {
         linker = linker.with_use_global_virtual_store(enabled);
     }

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -262,7 +262,7 @@ fn persist_no_integrity_index(
     let resolved: BTreeMap<String, String> = graph
         .packages
         .values()
-        .filter(|pkg| pkg.local_source.is_none())
+        .filter(|pkg| pkg.local_source.is_none() && pkg.integrity.is_none())
         .filter_map(|pkg| {
             let canonical = strip_peer_context_suffix(&pkg.dep_path);
             computed
@@ -1498,6 +1498,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 // single shared atomic.
                 let mut resolved_received: usize = 0;
 
+                // Per-project content-address bindings for no-integrity
+                // packages, so the streaming-resolve warm read hits the
+                // hex index instead of missing on the (removed) root key.
+                let fetch_no_integrity_index =
+                    crate::state::read_no_integrity_index(&fetch_project_root);
+
                 while let Some(pkg) = resolved_rx.recv().await {
                     if let Some(ref msg) = pkg.deprecated {
                         fetch_deprecations_tx.lock().unwrap().push(
@@ -1626,12 +1632,23 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     // `ERR_AUBE_MISSING_STORE_FILE`. Independent of
                     // import-time SRI / `verifyStoreIntegrity`.
                     let pkg_registry_name = pkg.registry_name().to_string();
-                    if let Some(index) = warm_load_index(
-                        &fetch_store,
-                        &pkg_registry_name,
-                        &pkg.version,
-                        pkg.integrity.as_deref(),
-                    ) {
+                    // Content-address the lookup; a no-integrity package
+                    // with no per-project binding yet has no read key and
+                    // falls through to fetch rather than reading the
+                    // content-free root selector.
+                    let read_key = pkg.integrity.as_deref().or_else(|| {
+                        fetch_no_integrity_index
+                            .get(&format!("{pkg_registry_name}@{}", pkg.version))
+                            .map(String::as_str)
+                    });
+                    if let Some(read_key) = read_key
+                        && let Some(index) = warm_load_index(
+                            &fetch_store,
+                            &pkg_registry_name,
+                            &pkg.version,
+                            Some(read_key),
+                        )
+                    {
                         materialize_tx
                             .send((pkg.dep_path.clone(), index.clone()))
                             .await

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -239,6 +239,42 @@ impl InstallPhaseTimings {
     }
 }
 
+/// Persist the per-project no-integrity content-address index from a
+/// run's freshly `computed` sha512s. Keys by the coordinate the warm
+/// classifier looks up (`<registry-name>@<version>`) so the next frozen
+/// warm install content-addresses the store lookup instead of relying on
+/// a content-free shared selector. `computed` holds only no-integrity
+/// packages (the fetch derives a sha512 solely when the lockfile carried
+/// none); registry name + version are read off the graph, where the
+/// canonical (peer-suffix-stripped) dep_path matches `computed`'s keys.
+///
+/// The lockfile/frozen fetch path persists this inside
+/// `fetch::fetch_packages_with_root`; this covers the streaming-resolve
+/// path, whose `computed_integrities` are surfaced here, not there.
+fn persist_no_integrity_index(
+    cwd: &std::path::Path,
+    graph: &aube_lockfile::LockfileGraph,
+    computed: &BTreeMap<String, String>,
+) {
+    if computed.is_empty() {
+        return;
+    }
+    let resolved: BTreeMap<String, String> = graph
+        .packages
+        .values()
+        .filter(|pkg| pkg.local_source.is_none())
+        .filter_map(|pkg| {
+            let canonical = strip_peer_context_suffix(&pkg.dep_path);
+            computed
+                .get(canonical)
+                .map(|sri| (format!("{}@{}", pkg.registry_name(), pkg.version), sri.clone()))
+        })
+        .collect();
+    if let Err(e) = crate::state::merge_no_integrity_index(cwd, &resolved) {
+        tracing::debug!("failed to persist no-integrity content-address index: {e}");
+    }
+}
+
 fn apply_computed_integrities(
     graph: &mut aube_lockfile::LockfileGraph,
     computed: &BTreeMap<String, String>,
@@ -2066,6 +2102,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // same canonical package share a single set of files, so
             // cloning the PackageIndex is cheap relative to re-extraction.
             let mut indices = remap_indices_to_contextualized(&canonical_indices, &graph);
+            persist_no_integrity_index(&cwd, &graph, &computed_integrities);
             apply_computed_integrities(&mut graph, &computed_integrities);
 
             // Write the lockfile in whatever format the project was

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 const DEFAULT_STATE_DIR: &str = "node_modules";
 const INSTALL_STATE_FILE_NAME: &str = "state.json";
 const FRESH_STATE_FILE_NAME: &str = "fresh.json";
+const NO_INTEGRITY_INDEX_FILE_NAME: &str = "no-integrity-index.json";
 
 /// The install-state directory name, `.<name>-state`. Standalone aube:
 /// `.aube-state`.
@@ -830,6 +831,65 @@ fn read_state(state_path: &Path) -> Option<InstallState> {
 
 fn install_state_file(state_path: &Path) -> PathBuf {
     state_path.join(INSTALL_STATE_FILE_NAME)
+}
+
+fn no_integrity_index_file(state_path: &Path) -> PathBuf {
+    state_path.join(NO_INTEGRITY_INDEX_FILE_NAME)
+}
+
+/// Read the project's no-integrity content-address index — the binding
+/// `<registry-name>@<version>` → computed sha512 that lets a frozen warm
+/// install content-address the store-index lookup for a package whose
+/// lockfile carries no integrity (a v1/legacy lock, or an
+/// integrity-stripping proxy).
+///
+/// WHY this exists: the store index can also be keyed by a content-FREE
+/// `<name>@<version>` selector. In the per-user store shared across all
+/// of a user's projects, that selector lets the first project to import
+/// `foo@1.0.0` (from any registry) decide what every other project's
+/// warm install of the same coordinate links — even one scoped to a
+/// different, locked-down registry — with no registry contact and no
+/// verification. Binding the lookup to the sha512 THIS project computed
+/// from its OWN download closes that substitution surface: the key is
+/// per-project and self-established, so a different registry's bytes
+/// (different hash) can never be substituted. It lives outside the
+/// lockfile so a frozen install reads it without a download and without
+/// rewriting the lock. Missing/corrupt file → empty map (re-fetch
+/// re-establishes it).
+pub fn read_no_integrity_index(project_dir: &Path) -> BTreeMap<String, String> {
+    let state_path = state_dir(project_dir);
+    std::fs::read_to_string(no_integrity_index_file(&state_path))
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or_default()
+}
+
+/// Merge freshly-resolved `<registry-name>@<version>` → sha512 bindings
+/// into the project's no-integrity index, preserving entries from prior
+/// installs (a `--prod` / `--filter` / partial install must not drop
+/// coordinates it didn't fetch this run). No-op when nothing new.
+pub fn merge_no_integrity_index(
+    project_dir: &Path,
+    resolved: &BTreeMap<String, String>,
+) -> Result<(), std::io::Error> {
+    if resolved.is_empty() {
+        return Ok(());
+    }
+    let mut current = read_no_integrity_index(project_dir);
+    let mut changed = false;
+    for (coord, sri) in resolved {
+        if current.get(coord).map(String::as_str) != Some(sri.as_str()) {
+            current.insert(coord.clone(), sri.clone());
+            changed = true;
+        }
+    }
+    if !changed {
+        return Ok(());
+    }
+    let state_path = state_dir(project_dir);
+    std::fs::create_dir_all(&state_path)?;
+    let json = serde_json::to_string_pretty(&current)?;
+    aube_util::fs_atomic::atomic_write(&no_integrity_index_file(&state_path), json.as_bytes())
 }
 
 fn fresh_state_file(state_path: &Path) -> PathBuf {


### PR DESCRIPTION
A no-integrity package's store index was also written under a content-free `index/<name>@<version>.json` root key. In the per-user shared store, that key lets one project's bytes serve another's warm install of the same coordinate, across registries, unverified.

Now content-addressed: `persist_pkg_index` drops the root-key write (hex write kept); a per-project `<state-dir>/no-integrity-index.json` binds `<registry-name>@<version>` to the sha512 this project computed. Classifier and linker fallback resolve through it; no binding → re-fetch.

Integrity-bearing locks and warm perf unchanged. Changes standalone aube on-disk behavior.

Refs #212. Hardens #220.