### PR TITLE
fix(aube): honor bundleDependencies on the lockfile-restore install path

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/npm/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/read.rs
@@ -597,6 +597,20 @@ fn lift_legacy_tree(
                 .entry(child_name.clone())
                 .or_insert_with(|| "*".to_string());
         }
+        // v1 records bundled deps only as a per-entry `bundled: true`
+        // flag on each nested child; it has no parent-level
+        // `bundleDependencies` array the way v3 does. The install path
+        // keys off the parent's `bundled_dependencies` to avoid fetching
+        // the bundled closure (it ships inside the parent's tarball), so
+        // reconstruct that array here from the direct `bundled` children
+        // — otherwise a v1 restore promotes the whole bundled subtree to
+        // registry-fetch nodes and breaks `--offline`.
+        let bundle_dependencies: Vec<String> = dep
+            .dependencies
+            .iter()
+            .filter(|(_, child)| child.bundled)
+            .map(|(child_name, _)| child_name.clone())
+            .collect();
         out.insert(
             install_path.clone(),
             RawNpmPackage {
@@ -605,6 +619,7 @@ fn lift_legacy_tree(
                 integrity: dep.integrity.clone(),
                 dependencies,
                 in_bundle: dep.bundled,
+                bundle_dependencies,
                 ..Default::default()
             },
         );

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -2741,6 +2741,55 @@ fn legacy_v1_package_lock_lifts_to_graph() {
     assert_eq!(root[0].specifier.as_deref(), Some("^3.0.0"));
 }
 
+/// v1 records bundled deps only as a per-entry `bundled: true` flag —
+/// there is no parent-level `bundleDependencies` array the way v3 has.
+/// The install/fetch path keys off the parent's `bundled_dependencies`
+/// to avoid re-fetching the bundled closure (it ships inside the
+/// parent's tarball), so the lifter must reconstruct that array from the
+/// `bundled` children. Without it a v1 restore promotes the bundled
+/// subtree to standalone fetch nodes and breaks `--offline`.
+#[test]
+fn legacy_v1_reconstructs_parent_bundle_dependencies_from_bundled_children() {
+    // npm 6 hoists a package's whole bundled closure flat under the
+    // parent's nested `dependencies`, every member flagged `bundled`.
+    const V1_BUNDLED: &str = r#"{
+      "name": "legacy-bundled",
+      "version": "1.0.0",
+      "lockfileVersion": 1,
+      "requires": true,
+      "dependencies": {
+        "host": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/host/-/host-1.0.0.tgz",
+          "integrity": "sha512-host",
+          "requires": { "gyp": "^1.0.0", "plain": "^1.0.0" },
+          "dependencies": {
+            "gyp": { "version": "1.0.0", "bundled": true, "requires": { "gyp-dep": "^1.0.0" } },
+            "gyp-dep": { "version": "1.0.0", "bundled": true }
+          }
+        },
+        "plain": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/plain/-/plain-1.0.0.tgz",
+          "integrity": "sha512-plain"
+        }
+      }
+    }"#;
+    let tmp = write_lockfile(V1_BUNDLED);
+    let manifest = manifest_with_deps(&[("host", "^1.0.0")]);
+    let graph = read::parse(tmp.path(), &manifest).unwrap();
+
+    let host = &graph.packages["host@1.0.0"];
+    // The bundled children are reconstructed onto the parent…
+    assert!(host.bundled_dependencies.contains(&"gyp".to_string()));
+    assert!(host.bundled_dependencies.contains(&"gyp-dep".to_string()));
+    // …while the non-bundled `plain` dep is NOT folded in.
+    assert!(!host.bundled_dependencies.contains(&"plain".to_string()));
+    // The nested bundled children still carry their own `in_bundle` flag.
+    assert!(graph.packages["gyp@1.0.0"].in_bundle);
+    assert!(graph.packages["gyp-dep@1.0.0"].in_bundle);
+}
+
 /// The differential oracle: the lifted v1 graph equals the v2 graph for
 /// the same dependency set, comparing every field v1 carries.
 #[test]

--- a/vendor/aube/crates/aube-resolver/src/locked_index.rs
+++ b/vendor/aube/crates/aube-resolver/src/locked_index.rs
@@ -21,7 +21,10 @@
 //! by iterating `.values()` in that same order and pushing into each
 //! name's bucket, so the first element of a bucket is the first
 //! `.values()` match — applying the same predicate to the bucket
-//! selects the byte-identical package.
+//! selects the byte-identical package. (`find_satisfying` additionally
+//! excludes `inBundle` entries — see its doc — so its predicate is a
+//! strict superset of a plain `.values().find()`; the bucket-order
+//! identity above still holds among the non-bundled candidates.)
 
 use aube_lockfile::{LocalSource, LockedPackage, LockfileGraph};
 use smallvec::SmallVec;
@@ -72,8 +75,16 @@ impl<'a> LockedIndex<'a> {
     /// First locked package whose name matches and whose version both
     /// satisfies `range` and is not vulnerable. The vulnerability check
     /// is part of the predicate, so a vulnerable match is *skipped* and
-    /// the search continues — mirroring `try_lockfile_reuse`'s
-    /// `.find(|p| name && satisfies && !is_vulnerable)`.
+    /// the search continues. This is `try_lockfile_reuse`'s reuse-target
+    /// selector (it calls straight through here).
+    ///
+    /// `inBundle` entries are excluded: a package that ships inside an
+    /// ancestor's tarball is materialized from there, never fetched or
+    /// linked as a standalone node, so it is not a valid reuse target.
+    /// Without the exclusion a legitimate consumer of the same name
+    /// could bind to the integrity-less bundled entry (it sorts ahead of
+    /// the real standalone entry in nested dep_path order) and fail
+    /// offline. The real standalone entry, if any, is selected instead.
     pub fn find_satisfying(
         &self,
         name: &str,
@@ -82,7 +93,8 @@ impl<'a> LockedIndex<'a> {
         vulnerable_ranges: &BTreeMap<String, Vec<String>>,
     ) -> Option<&'a LockedPackage> {
         self.bucket(name).iter().copied().find(|p| {
-            version_satisfies(&p.version, range)
+            !p.in_bundle
+                && version_satisfies(&p.version, range)
                 && !is_vulnerable(registry_name, &p.version, vulnerable_ranges)
         })
     }

--- a/vendor/aube/crates/aube-resolver/src/platform.rs
+++ b/vendor/aube/crates/aube-resolver/src/platform.rs
@@ -289,6 +289,37 @@ pub fn filter_graph(
         }
     }
 
+    // 2b. Sever `bundleDependencies` edges. A bundled dep ships *inside*
+    //     its parent's tarball along with that dep's entire closure, so
+    //     it is materialized from the parent's extracted tree — never
+    //     fetched or linked as a standalone node (this is exactly what
+    //     npm records `inBundle` for). But npm's lockfile still
+    //     enumerates the bundled subtree with live `dependencies` edges,
+    //     so without cutting the parent→bundle edge the GC walk below
+    //     keeps the whole closure and the fetch/link path promotes it to
+    //     first-class nodes: redundant standalone copies online, and a
+    //     fatal `--offline` miss on any bundled child not in cache.
+    //     Cutting the edge per the parent's own `bundled_dependencies`
+    //     is context-correct (a legitimate non-bundled consumer of the
+    //     same name keeps its edge) and lets the GC prune the now-
+    //     unreachable closure — the same shape as the optional-edge
+    //     pruning above. The fresh-resolve path already skips these via
+    //     the packument's `bundledDependencies`; this is its frozen-
+    //     restore counterpart. (v1 lockfiles carry no parent-level
+    //     `bundleDependencies`; the npm reader reconstructs it from the
+    //     nested `bundled:true` children so this edge cut fires there
+    //     too.)
+    for pkg in graph.packages.values_mut() {
+        if pkg.bundled_dependencies.is_empty() {
+            continue;
+        }
+        let bundled = pkg.bundled_dependencies.clone();
+        for name in &bundled {
+            pkg.dependencies.remove(name);
+            pkg.optional_dependencies.remove(name);
+        }
+    }
+
     // 3. Garbage-collect unreachable packages by walking from the
     //    surviving roots.
     let mut reachable: FxHashSet<String> = FxHashSet::default();
@@ -841,6 +872,98 @@ mod tests {
         let host = &graph.packages[&host_dep_path];
         assert!(!host.dependencies.contains_key("native-win"));
         assert!(!host.optional_dependencies.contains_key("native-win"));
+    }
+
+    /// `bundleDependencies` are transitive: the parent's tarball ships
+    /// the bundled dep AND its whole closure, so on the frozen-restore
+    /// path the parent→bundle edge must be cut and the now-unreachable
+    /// closure GC'd — otherwise it is promoted to standalone fetch/link
+    /// nodes (redundant online, fatal offline).
+    #[test]
+    fn filter_graph_severs_bundled_edges_and_gcs_closure() {
+        use aube_lockfile::DepType;
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph
+            .importers
+            .insert(".".to_string(), vec![dep("host", DepType::Production)]);
+        // `host` bundles `gyp` (which drags in `gyp-dep`) and also has a
+        // normal, non-bundled `plain` dep that must survive.
+        let (host_key, mut host) = pkg("host", &["gyp", "gyp-dep", "plain"], &[]);
+        host.bundled_dependencies = vec!["gyp".to_string(), "gyp-dep".to_string()];
+        graph.packages.extend([
+            (host_key.clone(), host),
+            pkg("gyp", &["gyp-dep"], &[]),
+            pkg("gyp-dep", &[], &[]),
+            pkg("plain", &[], &[]),
+        ]);
+
+        filter_graph(
+            &mut graph,
+            &SupportedArchitectures::default(),
+            &Default::default(),
+        );
+
+        let host = &graph.packages[&host_key];
+        assert!(
+            !host.dependencies.contains_key("gyp"),
+            "bundled edge severed"
+        );
+        assert!(
+            !host.dependencies.contains_key("gyp-dep"),
+            "bundled edge severed"
+        );
+        assert!(
+            host.dependencies.contains_key("plain"),
+            "non-bundled edge kept"
+        );
+        // The bundled closure is unreachable after the cut → GC'd.
+        assert!(!graph.packages.contains_key("gyp@1.0.0"));
+        assert!(!graph.packages.contains_key("gyp-dep@1.0.0"));
+        assert!(graph.packages.contains_key("plain@1.0.0"));
+        assert!(graph.packages.contains_key(&host_key));
+    }
+
+    /// Cutting a bundled edge is scoped to the declaring parent: a
+    /// package the parent bundles can ALSO be a legitimate standalone
+    /// dep of another package, and that consumer's edge (and the shared
+    /// node) must survive.
+    #[test]
+    fn filter_graph_keeps_bundled_name_for_non_bundled_consumer() {
+        use aube_lockfile::DepType;
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.importers.insert(
+            ".".to_string(),
+            vec![
+                dep("host", DepType::Production),
+                dep("app", DepType::Production),
+            ],
+        );
+        let (host_key, mut host) = pkg("host", &["gyp"], &[]);
+        host.bundled_dependencies = vec!["gyp".to_string()];
+        graph.packages.extend([
+            (host_key.clone(), host),
+            pkg("app", &["gyp"], &[]), // legit, non-bundled consumer
+            pkg("gyp", &[], &[]),
+        ]);
+
+        filter_graph(
+            &mut graph,
+            &SupportedArchitectures::default(),
+            &Default::default(),
+        );
+
+        assert!(
+            !graph.packages[&host_key].dependencies.contains_key("gyp"),
+            "host's bundled edge cut"
+        );
+        assert!(
+            graph.packages["app@1.0.0"].dependencies.contains_key("gyp"),
+            "app's legit edge kept"
+        );
+        assert!(
+            graph.packages.contains_key("gyp@1.0.0"),
+            "shared node survives via app"
+        );
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -2254,13 +2254,28 @@ impl<'a> ResolveDriver<'a> {
             // dep_path) form, while pnpm stores bare versions. Without
             // the strip, a yarn/bun-locked `is-odd` would emit a
             // transitive task for is-number with range
-            // `"is-number@6.0.0"`, which doesn't parse as semver. The
-            // lockfile already omitted bundled dep edges on write, so
-            // iterating `locked_pkg.dependencies` naturally skips them.
+            // `"is-number@6.0.0"`, which doesn't parse as semver.
+            //
+            // `bundleDependencies` are transitive: a child this package
+            // bundles ships *inside* its tarball along with that child's
+            // entire closure, and npm's lockfile still enumerates the
+            // bundled subtree with live edges (v3 keeps the `inBundle`
+            // entries; v1 nests them, and `lift_legacy_tree`
+            // reconstructs the parent's `bundleDependencies`). Walking
+            // those edges would promote the bundled closure to
+            // first-class registry-fetch nodes — redundant standalone
+            // fetches online, and a fatal offline miss when one isn't
+            // cached. Skip the declared bundle names here exactly as the
+            // fresh-from-packument path does (`bundled_names` above);
+            // skipping the direct bundle root prunes its whole subtree,
+            // since the closure is reachable only through this edge.
             let mut child_ancestors = task.ancestors.to_vec();
             child_ancestors.push((task.name.clone(), version.clone()));
             let child_ancestors: Arc<[(String, String)]> = child_ancestors.into();
             for (dep_name, dep_version) in &locked_pkg.dependencies {
+                if locked_pkg.bundled_dependencies.contains(dep_name) {
+                    continue;
+                }
                 let prefix = format!("{dep_name}@");
                 let stripped = dep_version.strip_prefix(&prefix).unwrap_or(dep_version);
                 let canonical_version = stripped.split('(').next().unwrap_or(stripped).to_string();


### PR DESCRIPTION
## The bug

`bundleDependencies` are transitive. A package ships its bundled dep **and that dep's entire dependency closure** physically inside its own tarball; npm marks every closure member `inBundle` (v3) / `bundled` (v1) — "do not fetch this from the registry." The fresh-from-packument resolve path prunes this correctly, but the **lockfile-restore path** walked the locked edges straight into the closure and promoted all of it to standalone registry-fetch/link nodes.

Online masked it (the copies already inside the parent's tarball satisfy linking). `nub install --offline` failed with `ERR_AUBE_OFFLINE` on whichever bundled child was not in cache. The canonical trigger is `fsevents@1.1.2`, which bundles node-pre-gyp's ~108-package closure.

## The fix

Sever the parent to bundled-dependency edge on the restore path so the closure is materialized from the parent's extracted tree, never fetched or linked standalone — matching the fresh path and npm/pnpm:

- `aube-resolver/platform.rs` `filter_graph` (the frozen full-graph `nub install` restore): cut each parent's `bundled_dependencies` edges before the GC walk, so the unreachable closure is pruned (same shape as the existing optional-edge pruning).
- `aube-resolver/driver.rs` `try_lockfile_reuse` (warm per-task reuse, `nub add` / drift): skip bundled children in the transitive enqueue.
- `aube-resolver/locked_index.rs` `find_satisfying`: never return an `inBundle` entry as a reuse target.
- `aube-lockfile/npm/read.rs` `lift_legacy_tree`: reconstruct the v1 parent's `bundleDependencies` from its nested `bundled:true` children (v1 has no parent-level array; v3 carries it natively).

## Evidence

Minimal `optionalDependencies: { "fsevents": "1.1.2" }` fixture, v1 and v3 lockfiles, fresh isolated `HOME`:

| | install | install --offline | top-level node_modules | standalone node-pre-gyp |
|---|---|---|---|---|
| before | rc=0 | rc=1 | 110 | yes (promoted) |
| after | rc=0 | rc=0 | 2 (fsevents, nan) | no |

The bundled node-pre-gyp is still present inside `fsevents/node_modules/` (materialized from the tarball). pnpm on the same fixture is offline rc=0 — this brings nub to parity. The on-disk `package-lock.json` is byte-identical after the install (the cut affects only the in-memory fetch/link graph; no round-trip churn).

Regression tests: `filter_graph` severs bundled edges and GCs the closure; a bundled name that is also a non-bundled consumer's dep is kept; the v1 reader reconstructs the parent `bundleDependencies`.

## Notes

A default-preserving aube latent-bug-fix — makes aube correct vs npm/pnpm on a real spec feature (no nub-only behavior).

Refs: warm-offline-store-completeness

