### PR TITLE
fix(runtime): fall back to original source when oxc rejects V8-tolerated plain JS (#225)

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -408,6 +408,44 @@ fn project_js_v_flag_regexp_lowers() {
 }
 
 #[test]
+fn project_js_transpile_failure_falls_back_to_original() {
+    // #225: pnpm 11.x's bundled `pnpm.mjs` pairs a transformable construct (a `v`-flag
+    // RegExp here) with `set choices(choices = [])` — spec-invalid but V8-accepted. nub
+    // routed the file to oxc (transformable verdict) and HARD-CRASHED on the setter
+    // ("A 'set' accessor cannot have an initializer"). The graceful fallback runs the
+    // ORIGINAL source instead. The oxc rejection must never surface; on Node 20+ (where
+    // the `v` flag is native) the whole file executes.
+    let (stdout, stderr, code) = run_nub("project-js", "setter-default-fallback.mjs");
+    assert!(
+        !stderr.contains("set accessor") && !stderr.contains("Transpile error"),
+        "the oxc setter-rejection must not surface — fallback should run original source: {stderr}"
+    );
+    if node_at_least((20, 0, 0)) {
+        assert_eq!(
+            code, 0,
+            "fallback should run the V8-tolerated file: {stderr}"
+        );
+        assert!(
+            stdout.contains("FALLBACK-RAN:true:[]"),
+            "file ran via fallback to the original source: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn project_js_genuine_syntax_error_still_errors() {
+    // The other side of the #225 fallback: a GENUINELY broken plain-JS file must still
+    // fail loudly — the fallback to original source surfaces V8's own SyntaxError rather
+    // than masking it.
+    let (_stdout, stderr, code) = run_nub("project-js", "genuine-syntax-error.mjs");
+    assert_ne!(code, 0, "a genuine syntax error must still fail: {stderr}");
+    assert!(
+        stderr.contains("SyntaxError"),
+        "V8's syntax error must surface, not be swallowed: {stderr}"
+    );
+}
+
+#[test]
 fn project_js_noop_is_byte_identical() {
     // The load-bearing byte-parity guard: a project `.js` with NOTHING oxc lowers
     // must be served VERBATIM — no quote/semicolon/whitespace normalization, no

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -695,7 +695,23 @@ export function maybeTranspilePlainJs(url, ext) {
   // Transformable: run the SAME pipeline as TS/JSX (target es2022 lowering, tsconfig,
   // source maps, the Stage-3 decorator guard, format detection, cache). loadTranspile
   // re-reads + re-parses, but only for the rare file that actually needs lowering.
-  return loadTranspile(url, ext);
+  try {
+    return loadTranspile(url, ext);
+  } catch (err) {
+    // #225: a plain-JS file the transformable verdict flagged (a `using` decl or
+    // `v`-flag RegExp somewhere) but whose transform oxc then REJECTS — V8 tolerates
+    // constructs oxc's stricter ES grammar forbids, e.g. `set x(v = []) {}` in pnpm
+    // 11.x's bundled `pnpm.mjs`. Falling back to `null` hands the file to Node's
+    // native loader running the ORIGINAL source: a V8-tolerated file runs, and a
+    // GENUINELY broken one still surfaces V8's own SyntaxError at the same spot Node
+    // would — so no real error is masked. Plain-JS only (the `.ts`/`.tsx`/`.jsx` path
+    // keeps hard-erroring, since those MUST transpile to run); the cost is that
+    // down-leveling is forfeited for THIS one file. The Stage-3 decorator diagnostic
+    // is a deliberate nub error and must not be swallowed — a decorator file can't
+    // run on V8 raw regardless, so re-throw nub's guidance.
+    if (info.hasDecorators) throw err;
+    return null;
+  }
 }
 
 // ── Data-format imports ─────────────────────────────────────────────

--- a/tests/fixtures/project-js/genuine-syntax-error.mjs
+++ b/tests/fixtures/project-js/genuine-syntax-error.mjs
@@ -1,0 +1,7 @@
+// The other side of the #225 fallback: a GENUINELY broken plain-JS file must still
+// fail loudly. The real syntax error (`const x = ;`) means neither oxc nor V8 can run
+// it — whichever internal path it takes (early no-op or transpile-then-fallback), the
+// original source reaches V8, which surfaces its own SyntaxError rather than masking it.
+const re = /a/v;
+const x = ;
+console.log("UNREACHABLE", re, x);

--- a/tests/fixtures/project-js/setter-default-fallback.mjs
+++ b/tests/fixtures/project-js/setter-default-fallback.mjs
@@ -1,0 +1,14 @@
+// #225: the `v`-flag RegExp flags this file "transformable", routing it through
+// nub's transpiler; oxc's stricter ES grammar then rejects `set choices(choices =
+// [])` (a setter with a default param — V8 tolerates it, the spec forbids it). The
+// graceful fallback must run the ORIGINAL source instead of hard-crashing, exactly
+// as pnpm 11.x's bundled `pnpm.mjs` requires.
+const re = /a/v;
+class C {
+  set choices(choices = []) {
+    this._c = choices;
+  }
+}
+const c = new C();
+c.choices = undefined;
+console.log("FALLBACK-RAN:" + re.test("a") + ":" + JSON.stringify(c._c));


### PR DESCRIPTION
Fixes #225

## The crash

With `nub pm shim` active and `packageManager: pnpm@11.x`, `pnpm run <script>` hard-crashed:

```
Error: Transpile error in .../pnpm.mjs:
  x A 'set' accessor cannot have an initializer.
```

pnpm 11.3.0 and 11.9.0 bundle `set choices(choices = [])` in `dist/pnpm.mjs` — a setter with a default parameter. V8 accepts it; the ES grammar forbids it, so oxc correctly rejects it. pnpm 9.x has no such construct, which is why only pnpm 10/11 shim users hit it (and it blocks every turbo workspace, since turbo runs `pnpm run` per package).

## Root cause

The runtime's plain-JS gate (`maybeTranspilePlainJs` in `runtime/transform-core.mjs`) latches a `transformableSyntax` verdict when a file contains a `using` declaration or a `/…/v` RegExp. pnpm's bundle has one, so nub routed `pnpm.mjs` through `loadTranspile`, where oxc's transform then threw on the unrelated setter and the load aborted. The bundle is not nub's code to transpile — it just needs to run.

## The fix

When transpiling a plain-JS file (`.js`/`.mjs`/`.cjs`) fails, fall back to Node's native loader running the original source. V8 accepts the constructs oxc's stricter grammar forbids, so the file runs; a genuinely broken file still surfaces V8's own `SyntaxError` at the same spot Node would, so no real error is masked.

Scope is deliberately narrow:

- Plain JS only. The `.ts`/`.tsx`/`.jsx` path calls `loadTranspile` directly and keeps hard-erroring — those must transpile to run.
- The Stage-3 decorator diagnostic is re-thrown (a decorator file can't run on V8 raw, so nub's guidance is preserved).
- Down-leveling still applies to every plain-JS file that transpiles cleanly; only a file that both needs lowering and can't transpile forfeits it — strictly better than a hard crash.

All four call sites of `maybeTranspilePlainJs` already treat a `null` return as "let Node's native loader handle it," so the fallback integrates without touching them.

## Verification

Built the dev binary and ran the real pnpm 11.9.0 bundle:

```
# before: Error: Transpile error ... A 'set' accessor cannot have an initializer.
# after:
$ nub dist/pnpm.mjs --version
11.9.0
```

A minimal fixture pairing a `/…/v` regex with the setter runs; a genuinely broken plain-JS file still exits non-zero with `SyntaxError`. Both are committed as integration tests (`project_js_transpile_failure_falls_back_to_original`, `project_js_genuine_syntax_error_still_errors`). Full integration suite green (171 passed).
