### PR TITLE
perf(aube): overlap no-downgrade trust validation with the tarball fetch

### DIFF
--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -1060,8 +1060,37 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 &ws_config_shared,
                 &settings_ctx,
             )?;
-            validate_lockfile_trust_policy(&cwd, &graph, opts.network_mode, &dependency_policy)
-                .await?;
+            // Trust-policy (no-downgrade) validation. Previously this ran
+            // serial-before-fetch and, on a cold lockfile install, was the
+            // dominant cost — a full-packument fan-out over every unique
+            // package, all ahead of the first downloaded byte. It has no
+            // data dependency on the tarball bytes (it checks each picked
+            // version's publish-trust against registry metadata, not file
+            // contents), so it now runs as a concurrent task overlapping
+            // the download phase and is `await`ed at the gate below,
+            // strictly before the link/finalize phase. A genuine
+            // no-downgrade violation still aborts the install (via `?` on
+            // the awaited result) before any package is linked into
+            // `node_modules` or any lifecycle script runs: identical
+            // validation, identical gate, only the `await` point moved
+            // later to hide the metadata round-trip behind the download
+            // tail. Single-task `JoinSet` (abort-on-drop) so an early `?`
+            // between here and the gate cancels the in-flight probe.
+            let trust_cwd = cwd.clone();
+            let trust_graph = graph.clone();
+            let trust_network_mode = opts.network_mode;
+            let trust_policy = dependency_policy.clone();
+            let mut lock_trust_set: tokio::task::JoinSet<miette::Result<()>> =
+                tokio::task::JoinSet::new();
+            lock_trust_set.spawn(async move {
+                validate_lockfile_trust_policy(
+                    &trust_cwd,
+                    &trust_graph,
+                    trust_network_mode,
+                    &trust_policy,
+                )
+                .await
+            });
             let source_label = resolve::lockfile_source_label(kind);
             tracing::debug!(
                 "{source_label}: {} packages for {project_name}",
@@ -1226,16 +1255,28 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 Ok(t) => t,
                 Err(e) => {
                     // Fetch failed: the install is aborting, so no build
-                    // script will run. Dropping `lock_osv_set` aborts the
-                    // in-flight OSV probe so it doesn't keep doing network
-                    // I/O after the CLI has errored.
+                    // script will run. Dropping the OSV and trust-policy
+                    // sets aborts the in-flight probes so they don't keep
+                    // doing network I/O after the CLI has errored.
                     drop(lock_osv_set);
+                    drop(lock_trust_set);
                     return Err(combine_install_pipeline_errors(lock_materialize_handle, e).await);
                 }
             };
             // Materializer stats roll into link via GVS-already-linked
             // fast path. Errors abort install.
             let _ = lock_materialize_handle.await.into_diagnostic()??;
+            // Gate: consume the trust-policy verdict that ran concurrently
+            // with the download phase above. This `await` is strictly
+            // before the link + finalize phases, so a no-downgrade
+            // violation aborts the install (via `?`) before any package is
+            // linked or any lifecycle script runs — the security posture is
+            // unchanged, the validation simply overlapped the download tail
+            // instead of serializing ahead of the fetch.
+            match lock_trust_set.join_next().await {
+                Some(joined) => joined.into_diagnostic()??,
+                None => unreachable!("trust-policy JoinSet had exactly one spawned task"),
+            }
             // Gate: consume the OSV verdict that ran concurrently with
             // the download phase above. This `await` is strictly before
             // the link + finalize phases, so a `MAL-*` finding aborts


### PR DESCRIPTION
On the lockfile-install path, the `trustPolicy=no-downgrade` validation ran serially before the tarball fetch — a per-unique-package full-packument network fan-out that dominated the cold resolve phase. Warm installs skip it via the validation cache, so this is a cold-install cost.

The validation has no data dependency on the tarball bytes (it checks each picked version's publish-trust against registry metadata, not file contents). This spawns it into an abort-on-drop task that runs concurrently with the fetch, and awaits its result before the link/finalize gate — mirroring the existing post-resolve OSV gate already in the same function.

## Security posture unchanged

Same validation, same abort-before-link gate. A genuine no-downgrade violation still aborts the install before any package is linked into `node_modules` or any lifecycle script runs; only the `await` point moves later, hiding the metadata round-trip behind the download tail. Verified end-to-end against a real downgrade case (`node-gyp@10.3.0`, whose earlier `10.3.1` carried provenance and the later `10.3.0` does not):

```
× trust downgrade for node-gyp@10.3.0 (trustPolicy=no-downgrade): earlier
  published version 10.3.1 had provenance attestation but this version has
  no trust evidence
```

Post-change the install still exits non-zero and links nothing.

## Measured

Same fixture, back-to-back cold validated installs, phase split (load-independent):

| phase | before (serial) | after (concurrent) |
| --- | --- | --- |
| resolve (from lockfile) | 700–995 ms | 2–11 ms |
| fetch | 50–93 ms | 670–740 ms |

The validation moves out of the resolve phase and overlaps the fetch.

## Verification

- Abort case: a real no-downgrade violation still aborts (rc 23, nothing linked).
- Clean case: a non-downgrade install succeeds (rc 0), validation overlapping the fetch of 89 packages.
- `cargo test -p aube-resolver` (255), `cargo test -p aube --lib` (710), trust-policy tests (4) all pass.
- `cargo clippy` clean; fresh-context impact-analysis review confirmed no path links or executes before the validation completes and every validation error still aborts.
