### PR TITLE
fix(aube): key the no-integrity warm binding by registry URL in the global store

### DIFF
--- a/vendor/aube/crates/aube-linker/src/builder.rs
+++ b/vendor/aube/crates/aube-linker/src/builder.rs
@@ -45,12 +45,13 @@ impl Linker {
         }
     }
 
-    /// Supply per-project `<registry-name>@<version>` → computed-sha512
-    /// bindings so the `load_index` fallback can content-address the
-    /// index read for a no-integrity package instead of keying by `None`
-    /// (see the field docs on [`Linker`]). The install driver populates
-    /// this from `state::read_no_integrity_index`; standalone callers
-    /// and tests omit it and get unchanged behavior.
+    /// Supply `<registry-name>@<version>` → computed-sha512 bindings so the
+    /// `load_index` fallback can content-address the index read for a
+    /// no-integrity package instead of keying by `None` (see the field docs
+    /// on [`Linker`]). The install driver populates this by projecting the
+    /// global URL-keyed bindings down to `<name>@<version>` keys
+    /// (`state::read_no_integrity_index_for`); standalone callers and tests
+    /// omit it and get unchanged behavior.
     pub fn with_no_integrity_read_keys(
         mut self,
         keys: std::collections::BTreeMap<String, String>,

--- a/vendor/aube/crates/aube/src/commands/ignored_builds.rs
+++ b/vendor/aube/crates/aube/src/commands/ignored_builds.rs
@@ -146,12 +146,13 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
         super::install::build_policy_from_sources(&manifest, &workspace, false);
 
     let store = super::open_store(project_dir)?;
-    // Resolve a no-integrity package's index by the per-project
+    // Resolve a no-integrity package's index by its URL-keyed
     // computed-sha512 binding (matching the install warm read), so a
     // v1/legacy-lock package with a suspicious lifecycle script still
     // surfaces here — keying by `None` would miss now that the
     // content-free root index is no longer written.
-    let no_integrity_index = crate::state::read_no_integrity_index(project_dir);
+    let no_integrity_index =
+        crate::state::read_no_integrity_index_for(project_dir, graph.packages.values());
 
     let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
     let mut out: Vec<IgnoredEntry> = Vec::new();

--- a/vendor/aube/crates/aube/src/commands/install/fetch.rs
+++ b/vendor/aube/crates/aube/src/commands/install/fetch.rs
@@ -585,12 +585,13 @@ where
         NeedsFetch,
     }
 
-    // Per-project content-address bindings for no-integrity packages
-    // (see `state::read_no_integrity_index`). Loaded once; the warm
-    // classifier resolves each no-integrity lookup through it so the
-    // read content-addresses the store by the sha512 THIS project
-    // computed, never a content-free shared-store selector.
-    let no_integrity_index = crate::state::read_no_integrity_index(project_root);
+    // URL-keyed content-address bindings for no-integrity packages,
+    // projected to the `name@version` lookup the warm classifier uses
+    // (see `state::read_no_integrity_index_for`). The read keys each
+    // no-integrity coordinate by the sha512 bound for the registry URL it
+    // resolves to, never a content-free shared-store selector.
+    let no_integrity_index =
+        crate::state::read_no_integrity_index_for(project_root, packages.values());
 
     // Parallel index check (rayon)
     let check_results: Vec<_> = packages
@@ -1049,25 +1050,40 @@ where
     }
 
     // Bind every no-integrity package we imported this run to the sha512
-    // we computed, keyed by the coordinate the warm classifier looks up
-    // (`<registry-name>@<version>`), so the next frozen warm install
-    // content-addresses the store lookup instead of re-fetching — and
-    // never relies on a content-free shared-store selector. Only
-    // no-integrity entries need it; `computed_integrities` already holds
-    // exactly those (it is populated only when the lockfile carried no
-    // SRI). Merge-persisted so a partial/filtered run keeps prior
-    // coordinates' bindings.
-    let resolved_no_integrity: BTreeMap<String, String> = packages
-        .iter()
-        .filter(|(_, pkg)| pkg.integrity.is_none())
-        .filter_map(|(dep_path, pkg)| {
-            computed_integrities
-                .get(strip_peer_context_suffix(dep_path))
-                .map(|sri| (format!("{}@{}", pkg.registry_name(), pkg.version), sri.clone()))
-        })
-        .collect();
-    if let Err(e) = crate::state::merge_no_integrity_index(project_root, &resolved_no_integrity) {
-        tracing::debug!("failed to persist no-integrity content-address index: {e}");
+    // we computed, keyed in the GLOBAL store by the registry tarball URL it
+    // resolves to (derived from this project's `.npmrc` registry config),
+    // so the next frozen warm install — including one whose `node_modules`
+    // was wiped, and any other project on the same registry — content-
+    // addresses the store lookup instead of re-fetching, without ever
+    // relying on a content-free shared-store selector. Keying by the
+    // configured-registry URL is the #212/#220 closure: a different
+    // registry yields a different key. Only no-integrity entries need it;
+    // `computed_integrities` already holds exactly those (populated only
+    // when the lockfile carried no SRI). The client closure may already be
+    // consumed by the fetches above, so derive URLs from a fresh sync
+    // client; this only runs when there are no-integrity packages to bind.
+    if !computed_integrities.is_empty() {
+        let url_client = crate::commands::make_client(project_root);
+        let bindings: BTreeMap<String, String> = packages
+            .iter()
+            .filter(|(_, pkg)| pkg.integrity.is_none() && pkg.local_source.is_none())
+            .filter_map(|(dep_path, pkg)| {
+                computed_integrities
+                    .get(strip_peer_context_suffix(dep_path))
+                    .map(|sri| {
+                        (
+                            url_client.tarball_url(pkg.registry_name(), &pkg.version),
+                            sri.clone(),
+                        )
+                    })
+            })
+            .collect();
+        if let Err(e) = crate::state::write_no_integrity_bindings(
+            &crate::state::no_integrity_dir(project_root),
+            &bindings,
+        ) {
+            tracing::debug!("failed to persist no-integrity content-address index: {e}");
+        }
     }
 
     Ok((indices, cached_count, fetch_count, computed_integrities))
@@ -1384,121 +1400,5 @@ mod tests {
 
         let out = super::remap_indices_to_contextualized(&canonical_indices, &graph);
         assert!(out.contains_key(canonical));
-    }
-
-    // Option B closure: mirrors the a46858e cross-project root-key repro,
-    // asserting it CANNOT happen anymore. Two projects share one per-user
-    // store and resolve the same `foo@1.0.0` to DIFFERENT bytes from
-    // DIFFERENT registries, neither carrying lockfile integrity. The warm
-    // lookup must content-address to each project's OWN computed sha512,
-    // and the shared store must carry NO content-free selector that could
-    // serve one project's bytes to the other.
-    #[test]
-    fn no_integrity_warm_lookup_is_per_project_content_addressed() {
-        use std::collections::BTreeMap;
-        use std::io::Write;
-
-        // A distinct gzipped tarball per project (distinct manifest body
-        // → distinct stored content), imported into the SHARED store so
-        // load_index's file stat finds real CAS shards.
-        let build_tgz = |marker: &str| {
-            let mut builder = tar::Builder::new(Vec::new());
-            let manifest =
-                format!(r#"{{"name":"foo","version":"1.0.0","_from":"{marker}"}}"#).into_bytes();
-            let mut header = tar::Header::new_gnu();
-            header.set_size(manifest.len() as u64);
-            header.set_mode(0o644);
-            header.set_cksum();
-            builder
-                .append_data(&mut header, "package/package.json", &manifest[..])
-                .unwrap();
-            let tar_bytes = builder.into_inner().unwrap();
-            let mut encoder =
-                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
-            encoder.write_all(&tar_bytes).unwrap();
-            encoder.finish().unwrap()
-        };
-
-        let store_dir = tempfile::tempdir().unwrap();
-        let store = aube_store::Store::at(store_dir.path().join("files"));
-        let name = "foo";
-        let version = "1.0.0";
-        let coord = format!("{name}@{version}");
-
-        // Project A and B import different bytes; each is cached ONLY under
-        // its own computed-sha512 hex key (Option B writes no root key).
-        let index_a = store.import_tarball(&build_tgz("registry-a")).unwrap();
-        let index_b = store.import_tarball(&build_tgz("registry-b")).unwrap();
-        let sri_a = aube_store::sha512_integrity_from_digest(&[0xAA; 64]);
-        let sri_b = aube_store::sha512_integrity_from_digest(&[0xBB; 64]);
-        store.save_index(name, version, Some(&sri_a), &index_a).unwrap();
-        store.save_index(name, version, Some(&sri_b), &index_b).unwrap();
-
-        // Each project binds the coordinate to ITS OWN sha512.
-        let proj_a = tempfile::tempdir().unwrap();
-        let proj_b = tempfile::tempdir().unwrap();
-        crate::state::merge_no_integrity_index(
-            proj_a.path(),
-            &BTreeMap::from([(coord.clone(), sri_a.clone())]),
-        )
-        .unwrap();
-        crate::state::merge_no_integrity_index(
-            proj_b.path(),
-            &BTreeMap::from([(coord.clone(), sri_b.clone())]),
-        )
-        .unwrap();
-
-        // The substitution surface is structurally absent: no content-free
-        // selector exists in the shared store.
-        assert!(
-            store.load_index(name, version, None).is_none(),
-            "shared store must carry no content-free <name>@<version> selector"
-        );
-
-        // A v1/no-integrity package; its lockfile carries no SRI.
-        let pkg = aube_lockfile::LockedPackage {
-            name: name.to_string(),
-            version: version.to_string(),
-            dep_path: coord.clone(),
-            ..Default::default()
-        };
-        assert!(pkg.integrity.is_none());
-
-        // Each project's warm classifier resolves its OWN bytes — never
-        // the other project's.
-        let idx_a = crate::state::read_no_integrity_index(proj_a.path());
-        let key_a = super::warm_read_key(&pkg, &idx_a).expect("project A has a binding");
-        assert_eq!(key_a, sri_a);
-        let a_hash = store
-            .load_index(name, version, Some(key_a))
-            .expect("project A hits its own hex index")
-            .get("package.json")
-            .unwrap()
-            .hex_hash
-            .clone();
-
-        let idx_b = crate::state::read_no_integrity_index(proj_b.path());
-        let key_b = super::warm_read_key(&pkg, &idx_b).expect("project B has a binding");
-        assert_eq!(key_b, sri_b);
-        let b_hash = store
-            .load_index(name, version, Some(key_b))
-            .expect("project B hits its own hex index")
-            .get("package.json")
-            .unwrap()
-            .hex_hash
-            .clone();
-
-        assert_ne!(
-            a_hash, b_hash,
-            "each project must resolve its own distinct bytes — no cross-substitution"
-        );
-
-        // No binding yet (a fresh project, or a store predating the index)
-        // → re-fetch, never the content-free selector.
-        let empty = BTreeMap::new();
-        assert!(
-            super::warm_read_key(&pkg, &empty).is_none(),
-            "a no-integrity package with no binding must miss (re-fetch), not read the root key"
-        );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -760,8 +760,8 @@ pub(crate) async fn run_dep_lifecycle_scripts(
 /// No content-FREE root-key (`None`) write happens here — ever. The
 /// index is cached ONLY when there's an integrity to key it by; a
 /// no-integrity package lands under its computed-sha512 hex key, and the
-/// warm classifier reaches it by content-addressing through the
-/// per-project no-integrity index (`state::read_no_integrity_index`) —
+/// warm classifier reaches it by content-addressing through the global
+/// URL-keyed no-integrity binding (`state::read_no_integrity_index_for`) —
 /// not a bare `<name>@<version>` selector that, in a per-user shared
 /// store, would let one project's bytes be served to another for the
 /// same coordinate. (A predecessor wrote both keys; that root-key write

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -155,8 +155,13 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         // Lets the linker's on-demand `load_index` fallback content-address
         // a no-integrity package's index (matching the warm classifier)
         // instead of keying by the bare `None` selector — see the field
-        // docs on `aube_linker::Linker`.
-        .with_no_integrity_read_keys(crate::state::read_no_integrity_index(cwd));
+        // docs on `aube_linker::Linker`. Projected from the global URL-keyed
+        // bindings here (the linker has no registry client), so the linker
+        // crate keeps its existing `name@version` lookup untouched.
+        .with_no_integrity_read_keys(crate::state::read_no_integrity_index_for(
+            cwd,
+            graph_for_link.packages.values(),
+        ));
     if let Some(enabled) = use_global_virtual_store_override {
         linker = linker.with_use_global_virtual_store(enabled);
     }

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -239,14 +239,20 @@ impl InstallPhaseTimings {
     }
 }
 
-/// Persist the per-project no-integrity content-address index from a
-/// run's freshly `computed` sha512s. Keys by the coordinate the warm
-/// classifier looks up (`<registry-name>@<version>`) so the next frozen
-/// warm install content-addresses the store lookup instead of relying on
-/// a content-free shared selector. `computed` holds only no-integrity
-/// packages (the fetch derives a sha512 solely when the lockfile carried
-/// none); registry name + version are read off the graph, where the
-/// canonical (peer-suffix-stripped) dep_path matches `computed`'s keys.
+/// Persist the global no-integrity content-address bindings from a run's
+/// freshly `computed` sha512s. Each no-integrity package is bound by the
+/// registry tarball URL it resolves to (derived from THIS project's
+/// `.npmrc` registry config via `client.tarball_url`), so the next frozen
+/// warm install — including one whose `node_modules` was wiped, and any
+/// other project resolving the same coordinate from the same registry —
+/// content-addresses the store lookup instead of relying on a content-free
+/// shared selector. Keying by the configured-registry URL (not the
+/// lockfile's baked `resolved`) is the #212/#220 closure: a different
+/// registry yields a different key, so cross-registry substitution can't
+/// happen. `computed` holds only no-integrity packages (the fetch derives a
+/// sha512 solely when the lockfile carried none); the canonical
+/// (peer-suffix-stripped) dep_path matches `computed`'s keys, and peer
+/// variants of one package collapse to a single URL binding.
 ///
 /// The lockfile/frozen fetch path persists this inside
 /// `fetch::fetch_packages_with_root`; this covers the streaming-resolve
@@ -259,18 +265,24 @@ fn persist_no_integrity_index(
     if computed.is_empty() {
         return;
     }
-    let resolved: BTreeMap<String, String> = graph
+    let client = crate::commands::make_client(cwd);
+    let bindings: BTreeMap<String, String> = graph
         .packages
         .values()
         .filter(|pkg| pkg.local_source.is_none() && pkg.integrity.is_none())
         .filter_map(|pkg| {
             let canonical = strip_peer_context_suffix(&pkg.dep_path);
-            computed
-                .get(canonical)
-                .map(|sri| (format!("{}@{}", pkg.registry_name(), pkg.version), sri.clone()))
+            computed.get(canonical).map(|sri| {
+                (
+                    client.tarball_url(pkg.registry_name(), &pkg.version),
+                    sri.clone(),
+                )
+            })
         })
         .collect();
-    if let Err(e) = crate::state::merge_no_integrity_index(cwd, &resolved) {
+    if let Err(e) =
+        crate::state::write_no_integrity_bindings(&crate::state::no_integrity_dir(cwd), &bindings)
+    {
         tracing::debug!("failed to persist no-integrity content-address index: {e}");
     }
 }
@@ -1498,11 +1510,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 // single shared atomic.
                 let mut resolved_received: usize = 0;
 
-                // Per-project content-address bindings for no-integrity
-                // packages, so the streaming-resolve warm read hits the
-                // hex index instead of missing on the (removed) root key.
-                let fetch_no_integrity_index =
-                    crate::state::read_no_integrity_index(&fetch_project_root);
+                // Global URL-keyed no-integrity binding dir, so the
+                // streaming-resolve warm read hits the hex index instead of
+                // missing on the (removed) root key. The streaming path
+                // resolves packages one at a time, so it reads each binding
+                // by its tarball URL on the fly rather than projecting a
+                // batch map (the frozen/warm batch path does the latter).
+                let fetch_no_integrity_dir = crate::state::no_integrity_dir(&fetch_project_root);
+                let fetch_no_integrity_present = fetch_no_integrity_dir.exists();
 
                 while let Some(pkg) = resolved_rx.recv().await {
                     if let Some(ref msg) = pkg.deprecated {
@@ -1633,14 +1648,20 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     // import-time SRI / `verifyStoreIntegrity`.
                     let pkg_registry_name = pkg.registry_name().to_string();
                     // Content-address the lookup; a no-integrity package
-                    // with no per-project binding yet has no read key and
-                    // falls through to fetch rather than reading the
-                    // content-free root selector.
-                    let read_key = pkg.integrity.as_deref().or_else(|| {
-                        fetch_no_integrity_index
-                            .get(&format!("{pkg_registry_name}@{}", pkg.version))
-                            .map(String::as_str)
-                    });
+                    // with no binding yet has no read key and falls through
+                    // to fetch rather than reading the content-free root
+                    // selector. The binding is keyed by the configured
+                    // registry's tarball URL (the #212/#220 closure), read
+                    // on demand for this one coordinate.
+                    let no_integrity_key = (pkg.integrity.is_none() && fetch_no_integrity_present)
+                        .then(|| {
+                            crate::state::read_no_integrity_binding(
+                                &fetch_no_integrity_dir,
+                                &fetch_local_client.tarball_url(&pkg_registry_name, &pkg.version),
+                            )
+                        })
+                        .flatten();
+                    let read_key = pkg.integrity.as_deref().or(no_integrity_key.as_deref());
                     if let Some(read_key) = read_key
                         && let Some(index) = warm_load_index(
                             &fetch_store,

--- a/vendor/aube/crates/aube/src/commands/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/mod.rs
@@ -123,9 +123,9 @@ pub(crate) use settings_context::{
     packument_full_cache_dir, project_modules_dir, resolve_fetch_policy,
     resolve_lockfile_kind_for_write, resolve_modules_dir_name_for_cwd, resolve_virtual_store_dir,
     resolve_virtual_store_dir_for_cwd, resolve_virtual_store_dir_max_length,
-    resolve_virtual_store_dir_max_length_for_cwd, resolved_cache_dir, run_pnpmfile_pre_resolution,
-    set_fetch_cli_overrides, set_global_frozen_override, set_global_output_flags,
-    set_global_virtual_store_flags, set_registry_override,
+    resolve_virtual_store_dir_max_length_for_cwd, resolved_cache_dir, resolved_store_dir,
+    run_pnpmfile_pre_resolution, set_fetch_cli_overrides, set_global_frozen_override,
+    set_global_output_flags, set_global_virtual_store_flags, set_registry_override,
     set_skip_auto_install_on_package_manager_mismatch,
     skip_auto_install_on_package_manager_mismatch, with_settings_ctx,
 };

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 const DEFAULT_STATE_DIR: &str = "node_modules";
 const INSTALL_STATE_FILE_NAME: &str = "state.json";
 const FRESH_STATE_FILE_NAME: &str = "fresh.json";
-const NO_INTEGRITY_INDEX_FILE_NAME: &str = "no-integrity-index.json";
 
 /// The install-state directory name, `.<name>-state`. Standalone aube:
 /// `.aube-state`.
@@ -833,63 +832,119 @@ fn install_state_file(state_path: &Path) -> PathBuf {
     state_path.join(INSTALL_STATE_FILE_NAME)
 }
 
-fn no_integrity_index_file(state_path: &Path) -> PathBuf {
-    state_path.join(NO_INTEGRITY_INDEX_FILE_NAME)
+/// The no-integrity content-address binding: the sha512 some install
+/// computed for a registry tarball URL, recorded alongside the URL it
+/// addresses so the content-addressed file is self-describing and a
+/// (vanishingly unlikely) blake3 key collision is caught on read.
+#[derive(Serialize, Deserialize)]
+struct NoIntegrityBinding {
+    url: String,
+    sha512: String,
 }
 
-/// Read the project's no-integrity content-address index — the binding
-/// `<registry-name>@<version>` → computed sha512 that lets a frozen warm
-/// install content-address the store-index lookup for a package whose
-/// lockfile carries no integrity (a v1/legacy lock, or an
-/// integrity-stripping proxy).
+/// The GLOBAL directory holding no-integrity bindings, one
+/// content-addressed file per resolved tarball URL, under the store's `v1/`
+/// dir next to the CAS `files/` and `index/`.
 ///
-/// WHY this exists: the store index can also be keyed by a content-FREE
-/// `<name>@<version>` selector. In the per-user store shared across all
-/// of a user's projects, that selector lets the first project to import
-/// `foo@1.0.0` (from any registry) decide what every other project's
-/// warm install of the same coordinate links — even one scoped to a
-/// different, locked-down registry — with no registry contact and no
-/// verification. Binding the lookup to the sha512 THIS project computed
-/// from its OWN download closes that substitution surface: the key is
-/// per-project and self-established, so a different registry's bytes
-/// (different hash) can never be substituted. It lives outside the
-/// lockfile so a frozen install reads it without a download and without
-/// rewriting the lock. Missing/corrupt file → empty map (re-fetch
-/// re-establishes it).
-pub fn read_no_integrity_index(project_dir: &Path) -> BTreeMap<String, String> {
-    let state_path = state_dir(project_dir);
-    std::fs::read_to_string(no_integrity_index_file(&state_path))
-        .ok()
-        .and_then(|c| serde_json::from_str(&c).ok())
-        .unwrap_or_default()
+/// WHY it lives in the store and not in `node_modules`: the binding indexes
+/// store bytes, so it shares the store's lifetime. The dominant CI warm
+/// pattern restores the store cache but `rm -rf node_modules`; a binding
+/// inside `node_modules` was wiped with it, forcing a network re-fetch of
+/// the ~hundreds of no-integrity packages the store already held. In the
+/// store it survives the wipe, so the warm/offline relink content-addresses
+/// them straight from the store. Tracks a `storeDir` override so the binding
+/// moves with the store it indexes.
+pub fn no_integrity_dir(project_dir: &Path) -> PathBuf {
+    let store_v1 = match crate::commands::resolved_store_dir(project_dir) {
+        Some(custom) => custom.join("v1"),
+        None => aube_store::dirs::store_dir()
+            .and_then(|files| files.parent().map(Path::to_path_buf))
+            .unwrap_or_else(|| std::env::temp_dir().join("aube").join("store").join("v1")),
+    };
+    store_v1.join("no-integrity")
 }
 
-/// Merge freshly-resolved `<registry-name>@<version>` → sha512 bindings
-/// into the project's no-integrity index, preserving entries from prior
-/// installs (a `--prod` / `--filter` / partial install must not drop
-/// coordinates it didn't fetch this run). No-op when nothing new.
-pub fn merge_no_integrity_index(
-    project_dir: &Path,
-    resolved: &BTreeMap<String, String>,
+fn no_integrity_binding_file(dir: &Path, url: &str) -> PathBuf {
+    dir.join(format!(
+        "{}.json",
+        hex::encode(blake3::hash(url.as_bytes()).as_bytes())
+    ))
+}
+
+/// Read the global no-integrity binding for one resolved tarball `url`: the
+/// sha512 some install computed for it, or `None` if nothing is bound. Used
+/// directly by the streaming-resolve path (which resolves packages one at a
+/// time and so can't pre-build a projection map); the batch warm path goes
+/// through [`read_no_integrity_index_for`].
+pub fn read_no_integrity_binding(dir: &Path, url: &str) -> Option<String> {
+    let content = std::fs::read_to_string(no_integrity_binding_file(dir, url)).ok()?;
+    let binding: NoIntegrityBinding = serde_json::from_str(&content).ok()?;
+    // The URL is hashed into the filename; re-check it to reject a key
+    // collision rather than serve a different URL's bytes.
+    (binding.url == url).then_some(binding.sha512)
+}
+
+/// Project the GLOBAL URL-keyed no-integrity bindings down to the
+/// `<registry-name>@<version>` → sha512 map the warm classifier, the linker
+/// `load_index` fallback, and `ignored-builds` consume — so those readers
+/// keep their existing coordinate lookup and never need a registry client.
+///
+/// A no-integrity package's binding is keyed by the registry tarball URL it
+/// resolves to, derived from THIS project's configured registry (`.npmrc`)
+/// via `client.tarball_url` — NOT the lockfile's baked `resolved` field. The
+/// user's registry config, never a copied or hostile lockfile, defines the
+/// trust domain. The same coordinate resolved from a different registry
+/// hashes to a different key, so a project scoped to a locked-down registry
+/// can never link bytes another project bound from a different registry
+/// (the #212/#220 closure). A globally-shared binding for the SAME URL is
+/// intentional: it matches npm's and pnpm's per-URL global caches and is
+/// what lets a second project — and a `node_modules`-wiped relink — reuse
+/// the bytes without a re-fetch.
+pub fn read_no_integrity_index_for<'a, I>(project_dir: &Path, pkgs: I) -> BTreeMap<String, String>
+where
+    I: IntoIterator<Item = &'a aube_lockfile::LockedPackage>,
+{
+    let dir = no_integrity_dir(project_dir);
+    // Nothing bound yet (fresh store) → skip building a registry client.
+    if !dir.exists() {
+        return BTreeMap::new();
+    }
+    let client = crate::commands::make_client(project_dir);
+    pkgs.into_iter()
+        .filter(|pkg| pkg.integrity.is_none() && pkg.local_source.is_none())
+        .filter_map(|pkg| {
+            let url = client.tarball_url(pkg.registry_name(), &pkg.version);
+            read_no_integrity_binding(&dir, &url)
+                .map(|sri| (format!("{}@{}", pkg.registry_name(), pkg.version), sri))
+        })
+        .collect()
+}
+
+/// Persist `url` → `sha512` bindings into the global store, one
+/// content-addressed file per URL. Idempotent: a URL already bound to the
+/// same sha512 is skipped; a changed value (a re-publish under the same URL)
+/// overwrites atomically. One file per URL means concurrent installs binding
+/// different URLs never contend on a shared file.
+pub fn write_no_integrity_bindings(
+    dir: &Path,
+    bindings: &BTreeMap<String, String>,
 ) -> Result<(), std::io::Error> {
-    if resolved.is_empty() {
+    if bindings.is_empty() {
         return Ok(());
     }
-    let mut current = read_no_integrity_index(project_dir);
-    let mut changed = false;
-    for (coord, sri) in resolved {
-        if current.get(coord).map(String::as_str) != Some(sri.as_str()) {
-            current.insert(coord.clone(), sri.clone());
-            changed = true;
+    std::fs::create_dir_all(dir)?;
+    for (url, sri) in bindings {
+        let path = no_integrity_binding_file(dir, url);
+        if read_no_integrity_binding(dir, url).as_deref() == Some(sri.as_str()) {
+            continue;
         }
+        let json = serde_json::to_string(&NoIntegrityBinding {
+            url: url.clone(),
+            sha512: sri.clone(),
+        })?;
+        aube_util::fs_atomic::atomic_write(&path, json.as_bytes())?;
     }
-    if !changed {
-        return Ok(());
-    }
-    let state_path = state_dir(project_dir);
-    std::fs::create_dir_all(&state_path)?;
-    let json = serde_json::to_string_pretty(&current)?;
-    aube_util::fs_atomic::atomic_write(&no_integrity_index_file(&state_path), json.as_bytes())
+    Ok(())
 }
 
 fn fresh_state_file(state_path: &Path) -> PathBuf {
@@ -1685,6 +1740,138 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("temp dir should be creatable");
         dir
+    }
+
+    // --- no-integrity URL-keyed global binding ---
+    //
+    // The binding lives in the GLOBAL store keyed by the registry tarball
+    // URL a no-integrity coordinate resolves to. These exercise the two
+    // properties the relocation must hold simultaneously: (1) it survives a
+    // `node_modules` wipe and is shared across projects on the same registry
+    // (the perf win — no re-fetch), and (2) a different registry produces a
+    // different key so one project can never read another's binding (the
+    // #212/#220 cross-registry closure). All hermetic: `store-dir` pins the
+    // store and `registry` pins the URL via `.npmrc`; no network.
+
+    fn no_integrity_project(name: &str, registry: &str, store: &Path) -> PathBuf {
+        let dir = temp_project_dir(name);
+        std::fs::write(
+            dir.join(".npmrc"),
+            format!("store-dir={}\nregistry={registry}\n", store.display()),
+        )
+        .expect(".npmrc should write");
+        dir
+    }
+
+    fn no_integrity_pkg() -> aube_lockfile::LockedPackage {
+        aube_lockfile::LockedPackage {
+            name: "foo".into(),
+            version: "1.0.0".into(),
+            dep_path: "foo@1.0.0".into(),
+            ..Default::default()
+        }
+    }
+
+    fn bind(project: &Path, sha512: &str) {
+        let pkg = no_integrity_pkg();
+        let url =
+            crate::commands::make_client(project).tarball_url(pkg.registry_name(), &pkg.version);
+        super::write_no_integrity_bindings(
+            &super::no_integrity_dir(project),
+            &BTreeMap::from([(url, sha512.to_string())]),
+        )
+        .expect("binding should persist");
+    }
+
+    fn resolved_sha512(project: &Path) -> Option<String> {
+        super::read_no_integrity_index_for(project, std::slice::from_ref(&no_integrity_pkg()))
+            .get("foo@1.0.0")
+            .cloned()
+    }
+
+    #[test]
+    fn no_integrity_binding_is_global_and_survives_node_modules_wipe() {
+        let store = temp_project_dir("ni-wipe-store");
+        let proj = no_integrity_project("ni-wipe-proj", "https://reg.test/", &store);
+        bind(&proj, "sha512-AAA");
+
+        // The binding sits under the store, not node_modules, so the
+        // dominant CI warm pattern (`rm -rf node_modules`) can't touch it.
+        let dir = super::no_integrity_dir(&proj);
+        let nm = proj.join("node_modules");
+        std::fs::create_dir_all(nm.join(".aube/foo@1.0.0")).unwrap();
+        std::fs::remove_dir_all(&nm).unwrap();
+
+        assert!(dir.starts_with(&store), "binding must live under the store");
+        assert!(
+            !dir.starts_with(&nm),
+            "binding must be outside node_modules"
+        );
+        assert_eq!(resolved_sha512(&proj).as_deref(), Some("sha512-AAA"));
+    }
+
+    #[test]
+    fn same_registry_projects_share_one_binding() {
+        let store = temp_project_dir("ni-share-store");
+        let a = no_integrity_project("ni-share-a", "https://reg.test/", &store);
+        let b = no_integrity_project("ni-share-b", "https://reg.test/", &store);
+
+        bind(&a, "sha512-shared");
+        // B never wrote a binding but resolves the same coordinate from the
+        // same registry, so it reuses A's from the shared store — no refetch.
+        assert_eq!(resolved_sha512(&b).as_deref(), Some("sha512-shared"));
+    }
+
+    #[test]
+    fn different_registries_do_not_share_binding() {
+        let store = temp_project_dir("ni-xreg-store");
+        let a = no_integrity_project("ni-xreg-a", "https://reg-a.test/", &store);
+        let b = no_integrity_project("ni-xreg-b", "https://reg-b.test/", &store);
+
+        bind(&a, "sha512-from-a");
+        // The #212/#220 closure: B resolves the SAME coordinate from a
+        // DIFFERENT registry, so its URL key differs and it must NOT read
+        // A's binding out of the shared store.
+        assert!(
+            resolved_sha512(&b).is_none(),
+            "a different registry must not read another project's binding"
+        );
+
+        // Each project keeps its own independent binding.
+        bind(&b, "sha512-from-b");
+        assert_eq!(resolved_sha512(&a).as_deref(), Some("sha512-from-a"));
+        assert_eq!(resolved_sha512(&b).as_deref(), Some("sha512-from-b"));
+    }
+
+    #[test]
+    fn stale_in_node_modules_binding_is_ignored() {
+        let store = temp_project_dir("ni-migrate-store");
+        let proj = no_integrity_project("ni-migrate-proj", "https://reg.test/", &store);
+
+        // A pre-relocation binding left inside node_modules must never be
+        // read. Bind an UNRELATED coordinate globally so the read builds a
+        // client and actually consults the store — proving the stale file is
+        // ignored, not merely short-circuited by an absent store dir.
+        super::write_no_integrity_bindings(
+            &super::no_integrity_dir(&proj),
+            &BTreeMap::from([(
+                "https://reg.test/other/-/other-9.9.9.tgz".to_string(),
+                "sha512-other".to_string(),
+            )]),
+        )
+        .unwrap();
+        let legacy = proj.join("node_modules/.aube-state");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(
+            legacy.join("no-integrity-index.json"),
+            r#"{"foo@1.0.0":"sha512-stale"}"#,
+        )
+        .unwrap();
+
+        assert!(
+            resolved_sha512(&proj).is_none(),
+            "stale in-node_modules binding must not be read"
+        );
     }
 
     #[test]


### PR DESCRIPTION
A no-integrity package (npm v1/legacy lock, or an integrity-stripping proxy) records a content-address binding so a frozen warm install resolves its store index without re-fetching. That binding lived inside `node_modules`, so `rm -rf node_modules && install` — the dominant CI warm pattern, which restores the store cache but not `node_modules` — wiped it and forced a network re-fetch of every no-integrity package the store already held. An offline relink failed outright on the first such package.

This moves the binding to the global store at `<store>/v1/no-integrity/<blake3(url)>.json`, keyed by the registry tarball URL the coordinate resolves to (derived from the project's configured registry, not the lockfile's baked `resolved`).

- Survives a `node_modules` wipe — it lives next to the CAS bytes it indexes, so the warm/offline relink content-addresses straight from the store.
- Shared across projects resolving the same coordinate from the same registry, so a second project links it with no re-fetch.
- Cross-registry substitution stays closed: a different registry yields a different URL key, so one project can never read another's binding for the same `name@version` from a different registry.

Readers (warm classifier, the linker's `load_index` fallback, ignored-builds, the streaming-resolve path) project the global URL-keyed store down to the existing `name@version` lookup, so the linker keeps its current key and needs no registry client.

## Verification

On a real npm-v1 fixture (113 no-integrity entries), store isolated, `--offline` as the request counter:

- COLD (online) → rc=0, writes 104 bindings.
- WARM (nm-wiped, offline) → rc=0, 739 packages in 1.8s (previously rc=1, failing on `abbrev@1.1.0`).
- Second same-registry project, never installed, offline → rc=0, reuses the global bindings with no network.
- Control (wipe only the binding dir, store bytes intact) → offline fails on `aproba@1.1.1`, confirming the binding is the load-bearing artifact.

Regression tests cover cross-registry isolation, same-registry sharing, nm-wipe survival, and stale-in-node_modules migration; the install suite and clippy/fmt are green.

Refs #212 #220.
