### PR TITLE
pm: expose the aube diagnostics layer under nub via NUB_DIAG_*

### DIFF
--- a/.claude/skills/pm-perf-tracing/SKILL.md
+++ b/.claude/skills/pm-perf-tracing/SKILL.md
@@ -6,17 +6,24 @@ How to performance-trace the nub package manager (install/resolve/fetch/**link**
 
 1. **Phase timings — works under nub TODAY.** `RUST_LOG=debug nub install` emits `phase:<name> <elapsed>` lines on stderr: `phase:resolve`, `phase:fetch (N packages)`, `phase:link (N files)`, `phase:link_bins`. This alone tells you the coarse split (is it network/resolve, or linking?). The aube engine wires these through the `tracing` crate.
 
-2. **Per-file / per-strategy diagnostic — exists in aube, GATED OFF under nub.** `aube_util::diag::event(Category::…, …)` emits structured JSONL to `AUBE_DIAG_FILE=<path>` — including, for the linker, one event per file naming the strategy used (`link_clonedir`, `link_reflink`, `link_macos_small_copy`, `link_copy`, `link_hardlink`). This is the load-independent crux for a link-perf question. **It is inert under the nub embedder** (`crates/nub-cli/src/pm_engine/identity.rs` sets `env_prefix: None`, so `embedder_env()` returns None and `AUBE_DIAG_*` is never read). To use it, build a throwaway dev binary with the prefix flipped on:
+2. **Rich diagnostics layer — native under nub via `NUB_DIAG_*`.** `aube_util::diag` emits structured JSONL to `NUB_DIAG_FILE=<path>` — including, for the linker, one event per file naming the strategy used (`link_clonedir`, `link_reflink`, `link_macos_small_copy`, `link_copy`, `link_hardlink`). This is the load-independent crux for a link-perf question. The full knob set (all off by default, zero cost when unset):
+
+   - `NUB_DIAG_FILE=<path>` — JSONL events to a file.
+   - `NUB_DIAG_PRINT=1` — live per-span lines to stderr.
+   - `NUB_DIAG_SUMMARY=1` — end-of-run aggregate table.
+   - `NUB_DIAG_CRITPATH=1` — retain records for the critical-path / lifecycle / starvation analyzers.
+   - `NUB_DIAG_THRESHOLD_MS=<n>` — filter live prints below `<n>` ms.
+   - `NUB_DIAG_KERNEL=1` — `getrusage` kernel deltas around phases.
+   - `NUB_BENCH_PHASES_FILE=<path>` — per-run phase-timing JSON for the bench harness.
 
 ```sh
-# in an isolated worktree (own CARGO_TARGET_DIR), edit identity.rs: env_prefix: Some("NUB")
-cargo build -p nub-cli --profile fast
+cargo build -p nub-cli --profile fast        # dev binary at <worktree>-target/fast/nub
 NUB=<worktree>-target/fast/nub
-AUBE_DIAG_FILE=/tmp/d.jsonl RUST_LOG=debug "$NUB" install --offline
+NUB_DIAG_FILE=/tmp/d.jsonl NUB_DIAG_SUMMARY=1 "$NUB" install --offline
 grep -o '"name":"link_[a-z_]*"' /tmp/d.jsonl | sort | uniq -c     # per-strategy tally
 ```
 
-(The `dev-tracing-telemetry` thread / `wiki/research/dev-tracing-telemetry.md` is making this accessible without the source flip + adding chrome-trace/flamegraph export — once that lands, prefer its toggle over the manual `env_prefix` flip.)
+(The diag layer reads `NUB_DIAG_*` under the nub embedder profile via the `diag_env_prefix` hook — no source edit needed. `AUBE_DIAG_*` is NOT read under nub. The `dev-tracing-telemetry` thread / `wiki/research/dev-tracing-telemetry.md` tracks the optional chrome-trace/flamegraph export layer on top.)
 
 ## The measurement discipline (load-independent — this host is permanently contended)
 
@@ -42,4 +49,4 @@ Span/JSONL instrumentation can distort a syscall-bound, parallel pass (observer 
 
 ## The one-liner to remember
 
-`RUST_LOG=debug nub install` for the phase split; if it's `phase:link`, build with `env_prefix: Some("NUB")` and `AUBE_DIAG_FILE=…` for the per-file strategy tally; A/B against `--node-linker isolated`; judge by strategy-tally + ratio, never the contended absolute.
+`RUST_LOG=debug nub install` for the phase split; if it's `phase:link`, set `NUB_DIAG_FILE=…` for the per-file strategy tally; A/B against `--node-linker isolated`; judge by strategy-tally + ratio, never the contended absolute.

--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -43,12 +43,14 @@
 ///   ROOT (top-level `workspaces`/`overrides`/`allowBuilds`), not a branded
 ///   `"nub"` object.
 /// - `env_prefix` = `None` — nub exposes NONE of aube's internal debug /
-///   diagnostic / perf-bisect toggle family (`AUBE_DISABLE_*`, `AUBE_DIAG_*`,
-///   `AUBE_CAS_*`, …). Those route through `aube_util::env::embedder_env`, which
-///   reads `{env_prefix}_<SUFFIX>` — so `None` makes every such toggle simply
+///   perf-bisect toggle family (`AUBE_DISABLE_*`, `AUBE_CAS_*`, `AUBE_INTERNAL_*`,
+///   …). Those route through `aube_util::env::embedder_env`, which reads
+///   `{env_prefix}_<SUFFIX>` — so `None` makes every such toggle simply
 ///   unreadable under nub, and the branded `AUBE_*` forms never leak into nub's
 ///   surface. (The user-facing settings-class `AUBE_*` aliases are gated
-///   separately by `read_branded_settings_env = false`.)
+///   separately by `read_branded_settings_env = false`. The diagnostics `DIAG_*`
+///   knobs are split out onto `diag_env_prefix` so nub can expose THEM under its
+///   own brand without re-admitting this whole family — see below.)
 /// - `config_env_prefix` = `Some("NUB")` — nub's three FIRST-CLASS config knobs
 ///   are read under nub's own brand via `aube_util::env::config_env`:
 ///   `NUB_CACHE_DIR` (the PM cache dir), `NUB_CONCURRENCY` (the tarball-fetch
@@ -57,6 +59,19 @@
 ///   deliberate, minimal exception to the brand boundary: a handful of knobs nub
 ///   legitimately owns under its own name. The corresponding `AUBE_*` forms are
 ///   never read under nub.
+/// - `diag_env_prefix` = `Some("NUB")` — exposes aube's rich diagnostics layer
+///   (per-phase/per-op spans, JSONL output, end-of-run summary table,
+///   critical-path analyzer, `getrusage` kernel deltas) under nub's OWN brand
+///   via `aube_util::env::diag_env`: `NUB_DIAG_FILE` (JSONL events to a file),
+///   `NUB_DIAG_PRINT`, `NUB_DIAG_SUMMARY`, `NUB_DIAG_CRITPATH`,
+///   `NUB_DIAG_THRESHOLD_MS`, `NUB_DIAG_KERNEL`, plus `NUB_BENCH_PHASES_FILE`.
+///   These are dev/perf-tracing knobs (a sanctioned internal `NUB_*` surface),
+///   off by default — unset, the diag layer's `ENABLED` atomic stays false and
+///   the instrumentation no-ops exactly as today, so there is zero hot-path
+///   cost. Carved out from `env_prefix` deliberately: routing JUST the `DIAG_*`
+///   knobs here lets nub reach the diagnostics layer without also exposing
+///   aube's ~30 unrelated internal `AUBE_*` toggles under `NUB_*`. The `AUBE_*`
+///   forms are never read under nub.
 /// - `cache_namespace` = `"nub/pm"` — engine cache lands at
 ///   `$XDG_CACHE_HOME/nub/pm` (a `/pm` sibling of nub's own runtime caches
 ///   under `$XDG_CACHE_HOME/nub/`), reproducing the old
@@ -132,6 +147,11 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     manifest_namespace: "",
     env_prefix: None,
     config_env_prefix: Some("NUB"),
+    // Exposes the diagnostics layer under nub's own brand (`NUB_DIAG_*` +
+    // `NUB_BENCH_PHASES_FILE`) without re-admitting the broad `AUBE_*` toggle
+    // family that `env_prefix: None` shuts off. Off by default — zero hot-path
+    // cost when unset.
+    diag_env_prefix: Some("NUB"),
     cache_namespace: "nub/pm",
     data_namespace: "nub",
     managed_config_system_dir: Some("nub"),
@@ -189,6 +209,7 @@ const _: () = {
     assert!(NUB.workspace_yaml.is_none());
     assert!(NUB.env_prefix.is_none());
     assert!(matches!(NUB.config_env_prefix, Some(p) if matches!(p.as_bytes(), b"NUB")));
+    assert!(matches!(NUB.diag_env_prefix, Some(p) if matches!(p.as_bytes(), b"NUB")));
     assert!(NUB.vendor.is_some());
     assert!(!NUB.self_engines_check);
     assert!(!NUB.canonical_lockfile_always_wins);

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -687,9 +687,18 @@ fn engine_session_inner(
     noise: ConfigScopeNoise,
     strictness: IdentityStrictness,
 ) -> Result<EngineSession> {
-    // Initialize the diagnostics recorder from AUBE_DIAG_* env vars so that
-    // `AUBE_DIAG_SUMMARY=1 nub install` works the same as `AUBE_DIAG_SUMMARY=1
-    // aube install`. The OnceLock inside diag::init() makes this idempotent.
+    // Register the embedder profile BEFORE initializing diagnostics: the diag
+    // recorder reads its toggles through the active profile's `diag_env_prefix`
+    // (`NUB` under nub), so it must see NUB — not the AUBE fallback — at init,
+    // or `NUB_DIAG_*` is missed and `AUBE_DIAG_*` wrongly read. `register()` is
+    // an idempotent set-once OnceLock, so the later `engine_brand_preflight()`
+    // (which calls it again as its first step, alongside the project-state-
+    // dependent config surface) is a no-op for the registration.
+    identity::register();
+    // Initialize the diagnostics recorder from NUB_DIAG_* env vars so that
+    // `NUB_DIAG_SUMMARY=1 nub install` surfaces the same per-phase/per-op
+    // spans + summary table that `AUBE_DIAG_SUMMARY=1 aube install` does. The
+    // OnceLock inside diag::init() makes this idempotent.
     aube_util::diag::init();
     // Raise the open-file-descriptor soft limit toward the hard ceiling. The aube
     // engine does this in its own startup, but nub dispatches the command impls

--- a/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -24,6 +24,7 @@ static MYTOOL: Embedder = Embedder {
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),
     config_env_prefix: Some("MYTOOL"),
+    diag_env_prefix: Some("MYTOOL"),
     cache_namespace: "mytool",
     data_namespace: "mytool",
     managed_config_system_dir: Some("mytool"),

--- a/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
@@ -30,6 +30,7 @@ static MYTOOL: Embedder = Embedder {
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),
     config_env_prefix: Some("MYTOOL"),
+    diag_env_prefix: Some("MYTOOL"),
     cache_namespace: "mytool",
     data_namespace: "mytool",
     managed_config_system_dir: Some("mytool"),

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -34,6 +34,7 @@ static NO_CHURN_TOOL: Embedder = Embedder {
     manifest_namespace: "nochurn",
     env_prefix: Some("NOCHURN"),
     config_env_prefix: Some("NOCHURN"),
+    diag_env_prefix: Some("NOCHURN"),
     cache_namespace: "nochurn",
     data_namespace: "nochurn",
     managed_config_system_dir: Some("nochurn"),

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -27,6 +27,7 @@ static STRICT: Embedder = Embedder {
     manifest_namespace: "aube",
     env_prefix: Some("AUBE"),
     config_env_prefix: Some("AUBE"),
+    diag_env_prefix: Some("AUBE"),
     cache_namespace: "aube",
     data_namespace: "aube",
     managed_config_system_dir: Some("aube"),

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -30,6 +30,7 @@ static ROOT_TOOL: Embedder = Embedder {
     manifest_namespace: "",
     env_prefix: None,
     config_env_prefix: None,
+    diag_env_prefix: None,
     cache_namespace: "roottool",
     data_namespace: "roottool",
     managed_config_system_dir: Some("roottool"),

--- a/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
@@ -26,6 +26,7 @@ static MYTOOL: Embedder = Embedder {
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),
     config_env_prefix: Some("MYTOOL"),
+    diag_env_prefix: Some("MYTOOL"),
     cache_namespace: "mytool",
     data_namespace: "mytool",
     managed_config_system_dir: Some("mytool"),

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -21,6 +21,7 @@ static ROOT_TOOL: Embedder = Embedder {
     manifest_namespace: "",
     env_prefix: None,
     config_env_prefix: None,
+    diag_env_prefix: None,
     cache_namespace: "roottool",
     data_namespace: "roottool",
     managed_config_system_dir: Some("roottool"),

--- a/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
@@ -20,6 +20,7 @@ static MYTOOL: Embedder = Embedder {
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),
     config_env_prefix: Some("MYTOOL"),
+    diag_env_prefix: Some("MYTOOL"),
     cache_namespace: "mytool",
     data_namespace: "mytool",
     managed_config_system_dir: Some("mytool"),

--- a/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
+++ b/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
@@ -35,6 +35,7 @@ static MYTOOL_NO_BRANDED_ENV: Embedder = Embedder {
     // MYTOOL_* var: with the family disabled, no branded settings var is read.
     env_prefix: Some("MYTOOL"),
     config_env_prefix: Some("MYTOOL"),
+    diag_env_prefix: Some("MYTOOL"),
     cache_namespace: "mytool",
     data_namespace: "mytool",
     managed_config_system_dir: Some("mytool"),

--- a/vendor/aube/crates/aube-util/src/diag.rs
+++ b/vendor/aube/crates/aube-util/src/diag.rs
@@ -267,14 +267,14 @@ impl DiagConfig {
      * per-event log is the costly bit.
      */
     pub fn from_env() -> Option<Self> {
-        let file = crate::env::embedder_env("DIAG_FILE").map(PathBuf::from);
-        let print = crate::env::embedder_env("DIAG_PRINT").is_some();
-        let summary_env = crate::env::embedder_env("DIAG_SUMMARY").is_some();
-        let critpath_env = crate::env::embedder_env("DIAG_CRITPATH").is_some();
+        let file = crate::env::diag_env("DIAG_FILE").map(PathBuf::from);
+        let print = crate::env::diag_env("DIAG_PRINT").is_some();
+        let summary_env = crate::env::diag_env("DIAG_SUMMARY").is_some();
+        let critpath_env = crate::env::diag_env("DIAG_CRITPATH").is_some();
         if file.is_none() && !print && !summary_env && !critpath_env {
             return None;
         }
-        let threshold_ms = crate::env::embedder_env("DIAG_THRESHOLD_MS")
+        let threshold_ms = crate::env::diag_env("DIAG_THRESHOLD_MS")
             .as_deref()
             .and_then(|s| s.to_str())
             .and_then(|s| s.parse::<u64>().ok())

--- a/vendor/aube/crates/aube-util/src/diag_kernel.rs
+++ b/vendor/aube/crates/aube-util/src/diag_kernel.rs
@@ -84,7 +84,7 @@ pub fn snapshot() -> Option<KernelSnapshot> {
  * other platforms.
  */
 pub fn enabled() -> bool {
-    crate::env::embedder_env("DIAG_KERNEL").is_some() && snapshot().is_some()
+    crate::env::diag_env("DIAG_KERNEL").is_some() && snapshot().is_some()
 }
 
 /**

--- a/vendor/aube/crates/aube-util/src/env.rs
+++ b/vendor/aube/crates/aube-util/src/env.rs
@@ -128,6 +128,25 @@ pub fn config_env(suffix: &str) -> Option<std::ffi::OsString> {
     std::env::var_os(format!("{prefix}_{suffix}"))
 }
 
+/// Read one of the diagnostics layer's toggles through the active embedder's
+/// [`diag_env_prefix`](crate::identity::Embedder::diag_env_prefix). For
+/// standalone aube (`Some("AUBE")`) `diag_env("DIAG_FILE")` reads
+/// `AUBE_DIAG_FILE`; for an embedder with `diag_env_prefix = Some("NUB")` it
+/// reads `NUB_DIAG_FILE`. `None` reads nothing.
+///
+/// Distinct from [`embedder_env`]: that family follows the broad `env_prefix`
+/// and carries aube's whole internal `{env_prefix}_*` toggle surface (~30
+/// `DISABLE_*`/`CAS_*`/`INTERNAL_*` knobs), whereas this routes ONLY the
+/// `DIAG_*` knobs and `BENCH_PHASES_FILE` through their own prefix — so a host
+/// can expose the diagnostics layer under its own brand without inheriting the
+/// rest. Default-preserving: standalone aube sets `diag_env_prefix` to its
+/// `env_prefix`, so these reads resolve to exactly the `AUBE_*` forms they did
+/// when this family lived on `embedder_env`.
+pub fn diag_env(suffix: &str) -> Option<std::ffi::OsString> {
+    let prefix = embedder().diag_env_prefix?;
+    std::env::var_os(format!("{prefix}_{suffix}"))
+}
+
 /// Parse a primer-TTL env value into an *override* of the embedder's default.
 ///
 /// Returns:
@@ -390,6 +409,21 @@ mod tests {
             assert_eq!(
                 config_env("CACHE_DIR").as_deref(),
                 Some(std::ffi::OsStr::new("/tmp/x")),
+            );
+        });
+        // The diag family defaults to `env_prefix` under AUBE, so `diag_env`
+        // reads exactly the `AUBE_DIAG_*` forms it read when these knobs lived
+        // on `embedder_env` — the default-preserving contract for the carve-out.
+        with_var("AUBE_DIAG_FILE", "/tmp/d.jsonl", || {
+            assert_eq!(
+                diag_env("DIAG_FILE").as_deref(),
+                Some(std::ffi::OsStr::new("/tmp/d.jsonl")),
+            );
+        });
+        with_var("AUBE_BENCH_PHASES_FILE", "/tmp/p.json", || {
+            assert_eq!(
+                diag_env("BENCH_PHASES_FILE").as_deref(),
+                Some(std::ffi::OsStr::new("/tmp/p.json")),
             );
         });
     }

--- a/vendor/aube/crates/aube-util/src/identity.rs
+++ b/vendor/aube/crates/aube-util/src/identity.rs
@@ -111,6 +111,21 @@ pub struct Embedder {
     /// the host wants under its own brand, whereas the debug toggles vanish
     /// under an embedder that hides them. `None` reads no first-class config env.
     pub config_env_prefix: Option<&'static str>,
+    /// Env-var prefix for the diagnostics layer's small toggle set — the
+    /// `DIAG_*` knobs (`DIAG_FILE`/`DIAG_PRINT`/`DIAG_SUMMARY`/`DIAG_CRITPATH`/
+    /// `DIAG_THRESHOLD_MS`/`DIAG_KERNEL`) plus `BENCH_PHASES_FILE` — read through
+    /// [`diag_env`](crate::env::diag_env), e.g. `Some("AUBE")` → `AUBE_DIAG_FILE`,
+    /// `Some("NUB")` → `NUB_DIAG_FILE`. `None` reads none of them.
+    ///
+    /// Carved out from [`env_prefix`](Self::env_prefix) so a host can expose the
+    /// rich diagnostics layer under its OWN brand WITHOUT also inheriting aube's
+    /// ~30 other internal `{env_prefix}_*` debug toggles (`DISABLE_*`, `CAS_*`,
+    /// `INTERNAL_*`, …): those stay on `env_prefix`, the diag knobs follow this.
+    /// Standalone aube sets it to its `env_prefix` value (`Some("AUBE")`), so the
+    /// `AUBE_DIAG_*` surface is byte-for-byte unchanged; an embedder that hides
+    /// the general toggle family (`env_prefix = None`) can still opt the
+    /// diagnostics layer in by setting this to its own brand.
+    pub diag_env_prefix: Option<&'static str>,
     /// Leaf directory name under the OS cache root, e.g. `"aube"` →
     /// `<XDG_CACHE_HOME>/aube`.
     pub cache_namespace: &'static str,
@@ -290,6 +305,9 @@ pub const AUBE: Embedder = Embedder {
     manifest_namespace: "aube",
     env_prefix: Some("AUBE"),
     config_env_prefix: Some("AUBE"),
+    // Defaults to `env_prefix` so the `AUBE_DIAG_*` / `AUBE_BENCH_PHASES_FILE`
+    // surface is byte-for-byte unchanged for standalone aube.
+    diag_env_prefix: Some("AUBE"),
     cache_namespace: "aube",
     data_namespace: "aube",
     managed_config_system_dir: Some("aube"),
@@ -470,6 +488,7 @@ mod tests {
         assert_eq!(id.manifest_namespace, "aube");
         assert_eq!(id.env_prefix, Some("AUBE"));
         assert_eq!(id.config_env_prefix, Some("AUBE"));
+        assert_eq!(id.diag_env_prefix, Some("AUBE"));
         assert_eq!(id.cache_namespace, "aube");
         assert_eq!(id.data_namespace, "aube");
         assert_eq!(id.managed_config_system_dir, Some("aube"));

--- a/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -12,11 +12,14 @@
 //! which runs under the default profile in a different binary.
 
 use aube_util::Embedder;
-use aube_util::env::{config_env, embedder_env};
+use aube_util::env::{config_env, diag_env, embedder_env};
 
-/// A nub-shaped embedder: hides the branded debug-toggle family
-/// (`env_prefix = None`) but owns the first-class config knobs under its own
-/// brand (`config_env_prefix = Some("NUB")`).
+/// A nub-shaped embedder: hides the broad branded debug-toggle family
+/// (`env_prefix = None`) but owns the first-class config knobs
+/// (`config_env_prefix = Some("NUB")`) AND the diagnostics layer
+/// (`diag_env_prefix = Some("NUB")`) under its own brand — matching nub's real
+/// profile, where the `DIAG_*` knobs are reachable as `NUB_DIAG_*` while the
+/// rest of the `AUBE_*` toggle family stays unreadable.
 static NUBLIKE: Embedder = Embedder {
     name: "nublike",
     display_name: "nublike",
@@ -30,6 +33,7 @@ static NUBLIKE: Embedder = Embedder {
     manifest_namespace: "",
     env_prefix: None,
     config_env_prefix: Some("NUB"),
+    diag_env_prefix: Some("NUB"),
     cache_namespace: "nublike",
     data_namespace: "nublike",
     managed_config_system_dir: Some("nublike"),
@@ -96,6 +100,44 @@ fn nub_profile_hides_debug_toggles_and_reads_nub_config() {
         assert!(
             config_env("CONCURRENCY").is_none(),
             "AUBE_CONCURRENCY must be ignored under config_env_prefix = Some(\"NUB\")"
+        );
+    });
+
+    // Diagnostics layer (`diag_env_prefix = Some("NUB")`): the `NUB_DIAG_*`
+    // surface is reachable while the branded `AUBE_DIAG_*` form is NOT — only
+    // nub's own brand wins, even with both set.
+    with_var("NUB_DIAG_FILE", "/nub/diag.jsonl", || {
+        with_var("AUBE_DIAG_FILE", "/aube/diag.jsonl", || {
+            assert_eq!(
+                diag_env("DIAG_FILE").as_deref(),
+                Some(std::ffi::OsStr::new("/nub/diag.jsonl")),
+                "diag_env must read NUB_DIAG_FILE and ignore AUBE_DIAG_FILE under nub"
+            );
+        });
+    });
+
+    // The diag knobs ride `diag_env_prefix`, NOT the broad `env_prefix` family:
+    // with only the branded `AUBE_DIAG_*` form set, the diag read is empty (the
+    // AUBE brand is off nub's diag surface) and the broad `embedder_env` family
+    // stays unreadable (env_prefix = None) so no diag toggle leaks through it.
+    with_var("AUBE_DIAG_KERNEL", "1", || {
+        assert!(
+            diag_env("DIAG_KERNEL").is_none(),
+            "AUBE_DIAG_KERNEL must be ignored under diag_env_prefix = Some(\"NUB\")"
+        );
+        assert!(
+            embedder_env("DIAG_KERNEL").is_none(),
+            "the DIAG_* knobs never ride the broad env_prefix family (None under nub)"
+        );
+    });
+
+    // BENCH_PHASES_FILE rides the diag prefix too — `NUB_BENCH_PHASES_FILE` is
+    // read, the branded `AUBE_*` form is not.
+    with_var("NUB_BENCH_PHASES_FILE", "/nub/phases.json", || {
+        assert_eq!(
+            diag_env("BENCH_PHASES_FILE").as_deref(),
+            Some(std::ffi::OsStr::new("/nub/phases.json")),
+            "diag_env must read NUB_BENCH_PHASES_FILE under nub"
         );
     });
 }

--- a/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -29,6 +29,7 @@ static NUBLIKE: Embedder = Embedder {
     manifest_namespace: "",
     env_prefix: None,
     config_env_prefix: Some("NUB"),
+    diag_env_prefix: None,
     cache_namespace: "nublike",
     data_namespace: "nublike",
     managed_config_system_dir: Some("nublike"),

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -173,7 +173,7 @@ struct InstallPhaseTimings {
 impl InstallPhaseTimings {
     fn from_env() -> Self {
         Self {
-            path: aube_util::env::embedder_env("BENCH_PHASES_FILE").map(std::path::PathBuf::from),
+            path: aube_util::env::diag_env("BENCH_PHASES_FILE").map(std::path::PathBuf::from),
             phases_ms: BTreeMap::new(),
             last_kernel_snap: aube_util::diag_kernel::snapshot(),
         }


### PR DESCRIPTION
Exposes the engine's diagnostics layer (per-phase/op spans, JSONL, summary table, critical-path analyzer, kernel rusage) under nub via `NUB_DIAG_*`. It was reachable only via `AUBE_DIAG_*`, inert under nub (`env_prefix: None`).

A narrow new `diag_env_prefix` embedder field routes the diag knobs (`NUB_DIAG_FILE`/`PRINT`/`SUMMARY`/`CRITPATH`/`THRESHOLD_MS`/`KERNEL`, `NUB_BENCH_PHASES_FILE`) without re-admitting aube's other `AUBE_*` toggles. Standalone aube keeps `AUBE_DIAG_*` byte-for-byte. Zero hot-path cost when unset.

Held for review — do not merge. Refs: dev-tracing-telemetry thread.