### PR TITLE
perf(install): short-circuit a warm-satisfied install under no-downgrade

### DIFF
--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -163,6 +163,14 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     // git/jsr/unknown protocol in a yarn.lock or bun.lock) aborts at plan time
     // for a non-optional dep, instead of reclassify→404 / silent drop.
     strict_unsupported_source: true,
+    // A fully-satisfied warm install (node_modules present, lockfile/manifest/
+    // settings/layout all match) short-circuits to an instant "Already up to
+    // date" regardless of `trustPolicy`, matching npm/pnpm/bun and aube's own
+    // offline + `aube run` auto-install paths. The trust gate is a resolve-time
+    // downgrade defense with nothing to validate on a no-op (zero resolve/fetch/
+    // link); any install that does REAL work misses the short-circuit and still
+    // trips the gate during resolution. Standalone aube keeps the re-validation.
+    warm_trust_revalidate: false,
 };
 
 /// Register [`NUB`] as the active embedder profile. Idempotent (the engine's
@@ -200,4 +208,5 @@ const _: () = {
     assert!(!NUB.gvs_incompatible_warning);
     assert!(NUB.primer_ttl.is_none());
     assert!(NUB.tty_progress);
+    assert!(!NUB.warm_trust_revalidate);
 };

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -661,3 +661,110 @@ fn install_links_yarn_workspace_member_into_consumer() {
         "yarn.lock must be byte-identical after a read-only workspace install"
     );
 }
+
+/// Run `nub <args>` in `dir` against a CALLER-OWNED store/cache so a second
+/// install warm-hits the first's node_modules + CAS — the realistic
+/// warm-satisfied loop, unlike [`run_install`] which isolates a fresh store
+/// per call.
+fn run_install_in_store(dir: &Path, store: &Path, cache: &Path, args: &[&str]) -> (String, i32) {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .env("XDG_DATA_HOME", store)
+        .env("XDG_CACHE_HOME", cache)
+        .output()
+        .expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// A second `nub install` on an unchanged, fully-satisfied tree short-circuits
+/// to the instant "Already up to date" exit — even online under the default
+/// `trustPolicy=no-downgrade`. Before the fix the trust posture disabled the
+/// warm short-circuit on any online install (gated in `install_fast_path_eligible`
+/// before `check_needs_install` ran), so the second install re-ran the full
+/// resolve/fetch/link pipeline every time; nub's `warm_trust_revalidate=false`
+/// profile now lets a no-op skip the redundant re-validation. The short-circuit
+/// is the load-independent signal: `emit_up_to_date` fires ONLY on the fast path,
+/// and it does so here with a fresh (empty) packument cache, proving nothing was
+/// re-resolved or re-fetched. The security half (real work still trips the gate)
+/// is covered by `frozen_install_with_trust_downgrade_still_aborts`.
+#[test]
+#[ignore = "network: resolves + fetches is-positive@3.1.0 from the npm registry"]
+fn warm_satisfied_install_short_circuits_under_no_downgrade() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("warm-satisfied");
+    let store = pm_tmpdir("warm-store");
+    let cache = pm_tmpdir("warm-cache");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"warm","version":"1.0.0","dependencies":{"is-positive":"3.1.0"}}"#,
+    )
+    .unwrap();
+
+    // Cold install populates node_modules + the freshness state sidecar.
+    let (cold_stderr, cold_code) = run_install_in_store(&dir, &store, &cache, &["install"]);
+    assert_eq!(cold_code, 0, "cold install must succeed: {cold_stderr}");
+    assert!(
+        dir.join("node_modules/is-positive/package.json").is_file(),
+        "is-positive must be installed by the cold pass: {cold_stderr}"
+    );
+    assert!(
+        !cold_stderr.contains("Already up to date"),
+        "the COLD install must NOT report up-to-date (it did real work): {cold_stderr}"
+    );
+
+    // Second install, online, default trust posture — must short-circuit.
+    let (warm_stderr, warm_code) = run_install_in_store(&dir, &store, &cache, &["install"]);
+    assert_eq!(warm_code, 0, "warm install must succeed: {warm_stderr}");
+    assert!(
+        warm_stderr.contains("Already up to date"),
+        "a warm-satisfied online install must short-circuit to 'Already up to date' \
+         under the default trustPolicy=no-downgrade, got: {warm_stderr}"
+    );
+}
+
+/// SECURITY INVARIANT: the warm short-circuit must NOT weaken the trust gate on
+/// an install that does real work. A fresh install of a package whose picked
+/// version dropped the trust evidence an earlier version carried
+/// (`node-gyp@10.3.0` lost the provenance attestation `10.3.1` had) is real work
+/// — `check_needs_install` returns `Some`, so the fast path is bypassed and the
+/// full pipeline runs, where `trustPolicy=no-downgrade` aborts during
+/// resolution. The short-circuit is reachable only on a no-op, never on this.
+/// (Depends on `node-gyp@10.3.0`'s live registry provenance metadata staying a
+/// downgrade vs `10.3.1`; the canonical case is recorded in
+/// `.fray/install-warm-fastpath-trust-gate.md`.)
+#[test]
+#[ignore = "network: resolves node-gyp@10.3.0 from the npm registry to assert the trust-downgrade abort"]
+fn frozen_install_with_trust_downgrade_still_aborts() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("trust-downgrade");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"dg","version":"1.0.0","dependencies":{"node-gyp":"10.3.0"}}"#,
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run_install(&dir, &["install"]);
+    assert_eq!(
+        code, 23,
+        "a trust-downgrade install must abort with the trust exit code (23), got {code}: \
+         {stdout}{stderr}"
+    );
+    assert!(
+        stderr.contains("ERR_NUB_TRUST_DOWNGRADE"),
+        "the abort must carry the trust-downgrade code: {stderr}"
+    );
+    assert!(
+        !dir.join("node_modules/node-gyp").exists(),
+        "no package may be linked when the trust gate aborts resolution"
+    );
+}

--- a/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -39,6 +39,7 @@ static MYTOOL: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: false,
+    warm_trust_revalidate: true,
 };
 
 #[test]

--- a/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
@@ -45,6 +45,7 @@ static MYTOOL: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: false,
+    warm_trust_revalidate: true,
 };
 
 fn project(files: &[(&str, &str)]) -> tempfile::TempDir {

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -49,6 +49,7 @@ static NO_CHURN_TOOL: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: false,
+    warm_trust_revalidate: true,
 };
 
 fn pkg(name: &str, version: &str, integrity: &str) -> LockedPackage {

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -42,6 +42,7 @@ static STRICT: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: true,
+    warm_trust_revalidate: true,
 };
 
 fn parse(files: &[(&str, &str)]) -> Result<LockfileGraph, Error> {

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -45,6 +45,7 @@ static ROOT_TOOL: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: false,
+    warm_trust_revalidate: true,
 };
 
 fn read_manifest(dir: &std::path::Path) -> serde_json::Value {

--- a/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
@@ -41,6 +41,7 @@ static MYTOOL: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: false,
+    warm_trust_revalidate: true,
 };
 
 #[tokio::test]

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -36,6 +36,7 @@ static ROOT_TOOL: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: false,
+    warm_trust_revalidate: true,
 };
 
 fn build_decision(manifest: &PackageJson, name: &str, version: &str) -> AllowDecision {

--- a/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
@@ -35,6 +35,7 @@ static MYTOOL: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: false,
+    warm_trust_revalidate: true,
 };
 
 #[test]

--- a/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
+++ b/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
@@ -50,6 +50,7 @@ static MYTOOL_NO_BRANDED_ENV: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: false,
+    warm_trust_revalidate: true,
 };
 
 fn ctx<'a>(

--- a/vendor/aube/crates/aube-util/src/identity.rs
+++ b/vendor/aube/crates/aube-util/src/identity.rs
@@ -272,6 +272,28 @@ pub struct Embedder {
     /// equals the incumbent PM's, or an eager precise refusal" (nub) sets
     /// this `true`. Embedder-fixed: it's the host's call, not the user's.
     pub strict_unsupported_source: bool,
+    /// When `true` (aube's default), an online install under a re-validating
+    /// trust posture (`trustPolicy=no-downgrade` or `paranoid`) disables the
+    /// warm "already up to date" short-circuit, so even a fully-satisfied tree
+    /// re-runs the resolve/fetch/link pipeline to re-assert the trust check.
+    /// When `false`, a fully-satisfied no-op (`check_needs_install` => `None`:
+    /// lockfile, manifest, settings, layout all match the on-disk tree) takes
+    /// the short-circuit regardless of trust policy.
+    ///
+    /// Safe because the short-circuit is reachable ONLY on a no-op — zero
+    /// resolve, zero fetch, zero link — whose bytes were already trust-validated
+    /// when they were installed; `trustPolicy` is a resolve-time downgrade
+    /// defense with nothing to validate when no version is (re)resolved. Any
+    /// install that does REAL work returns `Some(reason)` and falls through to
+    /// the full pipeline, where the trust check still fires during resolution —
+    /// so this never weakens the guard on an install that installs anything. It
+    /// only drops the redundant re-validation of an unchanged tree, matching
+    /// aube's own offline path and `aube run` auto-install (both already
+    /// short-circuit a satisfied tree with no trust gate), and matching npm /
+    /// pnpm / bun (none re-validate a satisfied tree). An embedder that wants the
+    /// instant warm exit (nub) sets this `false`; standalone aube keeps `true`
+    /// so its online-install behavior is byte-for-byte unchanged. Embedder-fixed.
+    pub warm_trust_revalidate: bool,
 }
 
 /// Standalone aube's embedder profile. Reproduces every hardcoded branding
@@ -311,6 +333,9 @@ pub const AUBE: Embedder = Embedder {
     // (warn+drop for berry, reclassify-to-registry for classic/bun) so its
     // default install behavior is byte-identical.
     strict_unsupported_source: false,
+    // Standalone aube re-validates the trust posture on every online install,
+    // even a fully-satisfied no-op, so its online-install behavior is unchanged.
+    warm_trust_revalidate: true,
 };
 
 static ACTIVE: OnceLock<&'static Embedder> = OnceLock::new();

--- a/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -45,6 +45,7 @@ static NUBLIKE: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: false,
+    warm_trust_revalidate: true,
 };
 
 /// Restore the previous value of an env var around a closure. Integration-test

--- a/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -44,6 +44,7 @@ static NUBLIKE: Embedder = Embedder {
     cpu_budget: None,
     tty_progress: false,
     strict_unsupported_source: false,
+    warm_trust_revalidate: true,
 };
 
 #[test]

--- a/vendor/aube/crates/aube/src/commands/install/startup.rs
+++ b/vendor/aube/crates/aube/src/commands/install/startup.rs
@@ -74,7 +74,16 @@ fn install_fast_path_eligible(
     if !preconditions_met {
         return false;
     }
-    if trust_policy_requires_validation(cwd, opts) {
+    // Trust re-validation only blocks the short-circuit under embedders that opt
+    // into re-validating an already-satisfied tree (`warm_trust_revalidate`,
+    // aube's default). When it does NOT (nub), the gate is skipped here and the
+    // warm path is decided purely by `check_needs_install` below: only a
+    // fully-satisfied no-op (`None`) short-circuits, and any real work
+    // (`Some(reason)`) falls through to the full pipeline where the trust check
+    // fires during resolution. So skipping this gate never lets an install that
+    // installs anything bypass the trust posture — it only drops the redundant
+    // re-validation of an unchanged, on-disk, previously-validated tree.
+    if aube_util::embedder().warm_trust_revalidate && trust_policy_requires_validation(cwd, opts) {
         return false;
     }
     // Surface *why* the warm path was missed at debug level — the state


### PR DESCRIPTION
A repeat `nub install` on an unchanged, fully-satisfied tree re-ran the whole resolve/fetch/link pipeline instead of exiting "Already up to date". The warm short-circuit was gated off before it could run: under the default `trustPolicy=no-downgrade`, an online install forced trust re-validation in `install_fast_path_eligible` and bailed before `check_needs_install` was ever consulted. npm, pnpm, and bun all exit instantly on a satisfied tree, as do nub's own `--offline` path and `nub run` auto-install — only the explicit online `install` re-validated.

## Change

A fully-satisfied no-op now short-circuits regardless of trust policy; the trust gate fires only when there is real work.

- New embedder toggle `warm_trust_revalidate` on `aube_util::Embedder`. Standalone aube sets it `true` (re-validates online exactly as before — byte-for-byte unchanged); nub's profile sets it `false`.
- In `install_fast_path_eligible`, the pre-`check_needs_install` trust bail is now gated on the toggle. The short-circuit is reachable only when `check_needs_install` returns `None` (lockfile, manifest, settings, and layout all match the on-disk tree — zero resolve, fetch, or link). Any install that does real work returns `Some(reason)`, falls through to the full pipeline, and trips the trust check during resolution.

## Security

The trust gate still fires on every install that installs anything. The short-circuit only skips redundant re-validation of an already-on-disk, already-validated tree, and a no-downgrade-violating package can never be in a satisfied tree because installing it aborts first.

Verified end-to-end:

- Warm-satisfied online install under the default `no-downgrade` exits "Already up to date" with zero network and no re-link (wall ~0.02s, down from a full re-pipeline).
- A fresh install of `node-gyp@10.3.0` (whose picked version dropped the provenance attestation `10.3.1` carried) still aborts with exit 23 / `ERR_NUB_TRUST_DOWNGRADE`, linking nothing.

Both directions are covered by committed regression tests in `crates/nub-cli/tests/install_engine.rs`.

Refs: install-warm-fastpath-trust-gate (perf fix #2 of the warm-install workstream).
