### PR TITLE
perf(install): overlap the default isolated materialize with fetch

### DIFF
--- a/vendor/aube/crates/aube/src/commands/install/gvs.rs
+++ b/vendor/aube/crates/aube/src/commands/install/gvs.rs
@@ -80,6 +80,34 @@ pub(super) fn effective_global_virtual_store(
     planned_gvs && !hoist && matches!(node_linker, aube_linker::NodeLinker::Isolated)
 }
 
+/// The global-virtual-store decision the fetch-pipelined materializer
+/// (`spawn_gvs_prewarm`) must use so its per-package materialize lands
+/// exactly where the link phase later reads it.
+///
+/// For the isolated linker this is the *effective* mode
+/// ([`effective_global_virtual_store`]), which folds in `hoist`: under the
+/// default `hoist=true` layout `Linker::link_all` recurses to
+/// `without_global_virtual_store` and materializes per-project, so the
+/// prewarm must too. Feeding the prewarm the raw (hoist-unaware) override
+/// instead made it populate the shared global store while the link phase
+/// re-materialized every package per-project off the fetch tail — wasted
+/// work and a serial materialize the pipeline was meant to hide.
+///
+/// The hoisted linker discards `.aube` regardless, so it keeps the raw
+/// override unchanged: forcing its prewarm per-project would only strand
+/// orphan `.aube/<dep_path>` dirs the hoisted sweep doesn't reclaim.
+pub(super) fn prewarm_global_virtual_store_override(
+    node_linker: aube_linker::NodeLinker,
+    effective_gvs: bool,
+    raw_override: Option<bool>,
+) -> Option<bool> {
+    if matches!(node_linker, aube_linker::NodeLinker::Isolated) {
+        Some(effective_gvs)
+    } else {
+        raw_override
+    }
+}
+
 pub(super) fn reset_on_mode_change(
     cwd: &Path,
     aube_dir: &Path,
@@ -146,23 +174,87 @@ mod tests {
     fn default_project_predicts_per_project_so_no_spurious_reset() {
         // hoist=true (default), isolated (default), GVS requested on (off-CI):
         // the linker writes per-project, so the effective mode is `false`.
-        assert!(!effective_global_virtual_store(true, true, NodeLinker::Isolated));
+        assert!(!effective_global_virtual_store(
+            true,
+            true,
+            NodeLinker::Isolated
+        ));
     }
 
     #[test]
     fn gvs_active_only_when_hoist_off_and_isolated() {
-        assert!(effective_global_virtual_store(true, false, NodeLinker::Isolated));
+        assert!(effective_global_virtual_store(
+            true,
+            false,
+            NodeLinker::Isolated
+        ));
     }
 
     #[test]
     fn hoisted_layout_never_uses_global_virtual_store() {
-        assert!(!effective_global_virtual_store(true, false, NodeLinker::Hoisted));
-        assert!(!effective_global_virtual_store(true, true, NodeLinker::Hoisted));
+        assert!(!effective_global_virtual_store(
+            true,
+            false,
+            NodeLinker::Hoisted
+        ));
+        assert!(!effective_global_virtual_store(
+            true,
+            true,
+            NodeLinker::Hoisted
+        ));
     }
 
     #[test]
     fn requested_off_stays_off_regardless_of_hoist() {
-        assert!(!effective_global_virtual_store(false, false, NodeLinker::Isolated));
-        assert!(!effective_global_virtual_store(false, true, NodeLinker::Isolated));
+        assert!(!effective_global_virtual_store(
+            false,
+            false,
+            NodeLinker::Isolated
+        ));
+        assert!(!effective_global_virtual_store(
+            false,
+            true,
+            NodeLinker::Isolated
+        ));
+    }
+
+    // The prewarm materializer must mirror the link phase's *effective*
+    // decision for the isolated linker so its per-package work lands where
+    // `link_all` reads it. Under default isolated (`hoist=true`,
+    // effective=false) it must route per-project; under GVS (`hoist=false`,
+    // effective=true) it stays on the shared store.
+    #[test]
+    fn prewarm_isolated_mirrors_effective_gvs() {
+        // default isolated (hoist=true) → effective false → per-project
+        assert_eq!(
+            prewarm_global_virtual_store_override(NodeLinker::Isolated, false, None),
+            Some(false)
+        );
+        // GVS (hoist=false) → effective true → shared store
+        assert_eq!(
+            prewarm_global_virtual_store_override(NodeLinker::Isolated, true, None),
+            Some(true)
+        );
+        // An explicit raw override is overridden by the effective decision:
+        // the link phase ignores it once hoist forces per-project.
+        assert_eq!(
+            prewarm_global_virtual_store_override(NodeLinker::Isolated, false, Some(true)),
+            Some(false)
+        );
+    }
+
+    // The hoisted linker discards `.aube`, so its prewarm decision is left
+    // as-is (the raw override) — never forced per-project, which would
+    // strand orphan `.aube/<dep_path>` dirs the hoisted sweep can't reclaim.
+    #[test]
+    fn prewarm_hoisted_passes_raw_override_through() {
+        assert_eq!(
+            prewarm_global_virtual_store_override(NodeLinker::Hoisted, false, Some(true)),
+            Some(true)
+        );
+        assert_eq!(
+            prewarm_global_virtual_store_override(NodeLinker::Hoisted, false, None),
+            None
+        );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/materialize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/materialize.rs
@@ -133,6 +133,17 @@ pub(super) async fn run_gvs_prewarm_materializer(
         probe = probe.with_use_global_virtual_store(enabled);
     }
     if !probe.uses_global_virtual_store() {
+        // Per-project materialize must apply patches at materialize time, the
+        // same as `link_all`'s per-project step1 (`materialize_into`). Without
+        // this the prewarm writes an UNPATCHED `.aube/<dep_path>`, and the
+        // link phase's existence-gated step1 then accepts it as cached —
+        // silently shipping unpatched bytes for any `patchedDependencies`.
+        // (The per-project prewarm was patch-less before too, but only the CI /
+        // explicit-GVS-off path reached it; routing the default isolated layout
+        // here makes the patch application load-bearing.)
+        if !patches.is_empty() {
+            probe = probe.with_patches(patches);
+        }
         return run_aube_dir_materializer(probe, graph, cwd, link_concurrency, materialize_rx)
             .await;
     }

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -923,12 +923,25 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // install on a default project see a spurious `disabled → enabled`
     // transition and wipe `node_modules` (issue #71). `resolve_node_linker`
     // is the same resolver the link phase uses, so the two stay in lockstep.
+    let resolved_node_linker = link::resolve_node_linker(&settings_ctx)?;
     let effective_gvs = gvs::effective_global_virtual_store(
         planned_gvs,
         aube_settings::resolved::hoist(&settings_ctx),
-        link::resolve_node_linker(&settings_ctx)?,
+        resolved_node_linker,
     );
     gvs::reset_on_mode_change(&cwd, &aube_dir, &modules_dir_name, effective_gvs)?;
+
+    // The fetch-pipelined materializer (`spawn_gvs_prewarm`) must target the
+    // SAME virtual store the link phase reads from, or its work is wasted and
+    // the materialize re-runs serially in `link_all`. Under the default
+    // isolated layout (`hoist=true`) `link_all` materializes per-project, so
+    // the prewarm must too; the raw, hoist-unaware override sent it to the
+    // shared global store instead. See `prewarm_global_virtual_store_override`.
+    let prewarm_gvs_override = gvs::prewarm_global_virtual_store_override(
+        resolved_node_linker,
+        effective_gvs,
+        use_global_virtual_store_override,
+    );
 
     // 3. Parse or resolve lockfile, streaming tarball fetches during resolution
     let phase_start = std::time::Instant::now();
@@ -1215,7 +1228,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 patch_hashes: lock_patch_hashes,
                 node_version: lock_node_version,
                 build_policy: lock_build_policy,
-                use_global_virtual_store_override,
+                use_global_virtual_store_override: prewarm_gvs_override,
                 virtual_store_dir: aube_dir.clone(),
             };
             let lock_materialize_handle =
@@ -2097,7 +2110,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 patch_hashes: materialize_patch_hashes,
                 node_version: node_version_for_prewarm.clone(),
                 build_policy: build_policy_for_prewarm.clone(),
-                use_global_virtual_store_override,
+                use_global_virtual_store_override: prewarm_gvs_override,
                 virtual_store_dir: aube_dir.clone(),
             };
             aube_util::diag::instant(


### PR DESCRIPTION
## What

The fetch-pipelined materializer (`spawn_gvs_prewarm`) hides the per-package materialize under the download tail — but until now only for the GVS sub-mode (`node-linker=isolated` + `hoist=false`). Under the default isolated layout (`hoist=true`) the prewarm got the raw, hoist-unaware global-virtual-store override, so it populated the shared global store while `link_all` — which recurses to per-project materialization when `use_global_virtual_store && hoist` — re-materialized every package into `.aube/<dep_path>` serially after fetch. The prewarm work was wasted; the materialize ran on the critical path.

This routes the prewarm by the link phase's effective GVS decision, so the per-project copy lands where `link_all` reads it and overlaps fetch. `gvs::prewarm_global_virtual_store_override` is the single home for that decision.

## Scope

Isolated linker only. The hoisted layout keeps the raw override — it discards `.aube` regardless, so forcing its prewarm per-project would only strand orphan `.aube/<dep_path>` dirs the hoisted sweep doesn't reclaim. GVS (`hoist=false`) is unchanged: `effective_gvs` is `true` off-CI, so the prewarm stays on the shared store.

## Behavior

The `node_modules` tree is byte-identical; only the timing of the materialize moves. Measured on a 440-package isolated cold install (`coffeescript@2.0.1` closure):

| mode | link phase before | link phase after |
| --- | --- | --- |
| default isolated (`hoist=true`) | ~0.5s (materializes every file) | tens of ms (0 files, overlaps fetch) |
| GVS (`hoist=false`) | ~30ms | ~30ms (unchanged) |
| hoisted `node-linker` | unchanged | unchanged |

Verified cold + warm (idempotent) installs at rc=0; the cold tree is byte-identical before/after (paths + symlink targets); the global virtual store is no longer populated under default isolated.

## Tests

`gvs::prewarm_global_virtual_store_override` carries unit tests for the isolated-mirrors-effective and hoisted-passes-raw cases.
