### PR TITLE
feat(install): default npm/yarn/bun incumbents to isolated + GVS

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1926,10 +1926,17 @@ fn strip_yarnrc_value(rest: &str) -> &str {
     rest.split('#').next().map(str::trim).unwrap_or(rest)
 }
 
-/// - Layout policy: flat-layout lockfile kinds (npm/yarn/bun) default
-///   `nodeLinker` to `hoisted`; pnpm/aube kinds and fresh projects keep the
-///   engine's `isolated` default (no entry pushed, so user/env settings
-///   resolve exactly as in stock aube).
+/// - Layout policy: flat-layout incumbent kinds (npm/yarn/bun) default to the
+///   isolated layout with the hidden hoist tree OFF (`nodeLinker=isolated` +
+///   `hoist=false`) — the config that engages the global virtual store, since
+///   aube's `effective_gvs = planned_gvs && !hoist && Isolated`. This is the
+///   greenlit compat→correctness shift (2026-06-28): isolated is strict (no
+///   phantom deps) and GVS-fast; a project that relies on phantom deps opts
+///   back into the flat tree with one `.npmrc` line (`node-linker=hoisted`).
+///   pnpm/aube kinds and fresh projects push no layout entry, keeping the
+///   engine's isolated default WITH the hidden hoist tree on (stock-aube
+///   phantom-dep tolerance, matching pnpm's own default). A user-set
+///   `nodeLinker`/`hoist` (env/.npmrc/yaml) still wins — embedder-tier default.
 /// - Fresh-write lockfile format: a TRULY-fresh project (no PM-preference
 ///   signal of any kind — `truly_fresh`) writes nub's neutral `lock.yaml`
 ///   (`defaultLockfileFormat=aube`, which under the nub embedder resolves to
@@ -1964,7 +1971,7 @@ fn nub_setting_defaults(
             data.join("store").to_string_lossy().into_owned(),
         ));
     }
-    let hoisted_kind = matches!(
+    let flat_incumbent = matches!(
         detected.map(|d| d.kind),
         Some(
             LockfileKind::Npm
@@ -1974,18 +1981,23 @@ fn nub_setting_defaults(
                 | LockfileKind::Bun
         )
     );
-    // `dependenciesMeta.*.injected` is materialized only under the isolated
-    // linker (aube needs the `.nub/` virtual store to sibling-link packed
-    // copies). When a flat-layout incumbent declares injected deps, keep the
-    // engine's `isolated` default instead of forcing `hoisted` — otherwise the
-    // injection directive is silently dropped and peer deps resolve against the
-    // wrong tree. A user-set `nodeLinker` (env/.npmrc/yaml) still wins; this
-    // only declines to push the embedder-tier hoisted default.
     let injected = detected
         .map(|d| unsupported_config::injected_deps_present(&d.dir))
         .unwrap_or(false);
-    if hoisted_kind && !injected {
-        defaults.push(("nodeLinker".to_string(), "hoisted".to_string()));
+    // GREENLIT 2026-06-28 compat→correctness flip: flat-layout incumbents
+    // (npm/yarn/bun) default to isolated with the hidden hoist tree OFF.
+    // Pushing `hoist=false` under the engine's isolated default is precisely
+    // what engages the global virtual store (aube gvs.rs: `effective_gvs =
+    // planned_gvs && !hoist && Isolated`); `nodeLinker=isolated` is pushed
+    // explicitly so the layout intent reads at this call site even though it
+    // equals the engine default. Injected deps (`dependenciesMeta.*.injected`)
+    // are the carve-out: they need the hidden tree to sibling-link packed
+    // copies, so they stay on stock-aube isolated+hoist=true (GVS off) — that
+    // path is proven, injected-under-GVS is not. A user-set `nodeLinker`/
+    // `hoist` (env/.npmrc/yaml) still wins; this is only the embedder default.
+    if flat_incumbent && !injected {
+        defaults.push(("nodeLinker".to_string(), "isolated".to_string()));
+        defaults.push(("hoist".to_string(), "false".to_string()));
     }
     defaults
 }
@@ -2464,38 +2476,51 @@ mod tests {
             fresh: false,
         };
 
-        // Flat-layout kinds ⇒ nodeLinker defaults to hoisted.
+        // Flat-layout incumbents ⇒ isolated + hoist=false (the GVS-engaging
+        // config: aube's effective_gvs needs `!hoist && Isolated`).
         for kind in [
             LockfileKind::Npm,
             LockfileKind::YarnBerry,
             LockfileKind::Bun,
         ] {
+            let defaults = nub_setting_defaults(Some(&detected(kind)), false);
             assert_eq!(
-                get(
-                    &nub_setting_defaults(Some(&detected(kind)), false),
-                    "nodeLinker"
-                ),
-                Some("hoisted"),
-                "{kind:?} must default to the hoisted layout"
+                get(&defaults, "nodeLinker"),
+                Some("isolated"),
+                "{kind:?} must default to the isolated layout"
+            );
+            assert_eq!(
+                get(&defaults, "hoist"),
+                Some("false"),
+                "{kind:?} must turn the hidden hoist tree off so GVS engages"
             );
         }
 
-        // pnpm-shaped kinds and no lockfile ⇒ no entry (engine's isolated
-        // default applies, user/env settings resolve as in stock aube).
+        // pnpm-shaped kinds and no lockfile ⇒ no layout entry (engine's
+        // isolated + hoist=true default applies, GVS off, stock-aube
+        // phantom-dep tolerance, matching pnpm's own default).
         for kind in [LockfileKind::Pnpm, LockfileKind::Aube] {
+            let defaults = nub_setting_defaults(Some(&detected(kind)), false);
             assert_eq!(
-                get(
-                    &nub_setting_defaults(Some(&detected(kind)), false),
-                    "nodeLinker"
-                ),
+                get(&defaults, "nodeLinker"),
                 None,
                 "{kind:?} must not inject a nodeLinker default"
+            );
+            assert_eq!(
+                get(&defaults, "hoist"),
+                None,
+                "{kind:?} must not inject a hoist default"
             );
         }
         assert_eq!(
             get(&nub_setting_defaults(None, true), "nodeLinker"),
             None,
             "no lockfile must not inject a nodeLinker default"
+        );
+        assert_eq!(
+            get(&nub_setting_defaults(None, true), "hoist"),
+            None,
+            "no lockfile must not inject a hoist default"
         );
     }
 

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -744,7 +744,11 @@ fn engine_session_inner(
     let truly_fresh = is_truly_fresh_project(&cwd, detected.as_ref());
     // Set-unless-user-set: ranks below CLI flags, env vars, and every
     // config file in the engine's settings precedence.
-    aube_settings::set_embedder_defaults(nub_setting_defaults(detected.as_ref(), truly_fresh));
+    aube_settings::set_embedder_defaults(nub_setting_defaults(
+        detected.as_ref(),
+        truly_fresh,
+        &cwd,
+    ));
     // Route the engine's lifecycle scripts through nub's runtime augmentation
     // (project-pinned + augmented Node, shim on PATH, preload) — the SAME
     // augmentation `nub run` / `nub exec` apply, so run / exec / lifecycle
@@ -1926,16 +1930,17 @@ fn strip_yarnrc_value(rest: &str) -> &str {
     rest.split('#').next().map(str::trim).unwrap_or(rest)
 }
 
-/// - Layout policy: flat-layout incumbent kinds (npm/yarn/bun) default to the
+/// - Layout policy: EVERY non-injected project — every incumbent
+///   (npm/yarn/bun/pnpm) and a fresh nub-identity project — defaults to the
 ///   isolated layout with the hidden hoist tree OFF (`nodeLinker=isolated` +
-///   `hoist=false`) — the config that engages the global virtual store, since
+///   `hoist=false`), the config that engages the global virtual store since
 ///   aube's `effective_gvs = planned_gvs && !hoist && Isolated`. This is the
 ///   greenlit compat→correctness shift (2026-06-28): isolated is strict (no
-///   phantom deps) and GVS-fast; a project that relies on phantom deps opts
-///   back into the flat tree with one `.npmrc` line (`node-linker=hoisted`).
-///   pnpm/aube kinds and fresh projects push no layout entry, keeping the
-///   engine's isolated default WITH the hidden hoist tree on (stock-aube
-///   phantom-dep tolerance, matching pnpm's own default). A user-set
+///   phantom deps) and GVS-fast across every project; a project that relies on
+///   phantom deps opts back into the flat tree with one `.npmrc` line
+///   (`node-linker=hoisted`). The ONLY carve-out is injected deps
+///   (`dependenciesMeta.*.injected`), which need the hidden hoist tree and so
+///   keep the engine's isolated + hoist=true default (GVS off). A user-set
 ///   `nodeLinker`/`hoist` (env/.npmrc/yaml) still wins — embedder-tier default.
 /// - Fresh-write lockfile format: a TRULY-fresh project (no PM-preference
 ///   signal of any kind — `truly_fresh`) writes nub's neutral `lock.yaml`
@@ -1947,6 +1952,7 @@ fn strip_yarnrc_value(rest: &str) -> &str {
 fn nub_setting_defaults(
     detected: Option<&DetectedLockfile>,
     truly_fresh: bool,
+    cwd: &Path,
 ) -> Vec<(String, String)> {
     let fresh_format = if truly_fresh { "aube" } else { "pnpm" };
     let mut defaults = vec![
@@ -1971,31 +1977,23 @@ fn nub_setting_defaults(
             data.join("store").to_string_lossy().into_owned(),
         ));
     }
-    let flat_incumbent = matches!(
-        detected.map(|d| d.kind),
-        Some(
-            LockfileKind::Npm
-                | LockfileKind::NpmShrinkwrap
-                | LockfileKind::Yarn
-                | LockfileKind::YarnBerry
-                | LockfileKind::Bun
-        )
-    );
-    let injected = detected
-        .map(|d| unsupported_config::injected_deps_present(&d.dir))
-        .unwrap_or(false);
-    // GREENLIT 2026-06-28 compat→correctness flip: flat-layout incumbents
-    // (npm/yarn/bun) default to isolated with the hidden hoist tree OFF.
-    // Pushing `hoist=false` under the engine's isolated default is precisely
-    // what engages the global virtual store (aube gvs.rs: `effective_gvs =
-    // planned_gvs && !hoist && Isolated`); `nodeLinker=isolated` is pushed
-    // explicitly so the layout intent reads at this call site even though it
-    // equals the engine default. Injected deps (`dependenciesMeta.*.injected`)
-    // are the carve-out: they need the hidden tree to sibling-link packed
-    // copies, so they stay on stock-aube isolated+hoist=true (GVS off) — that
-    // path is proven, injected-under-GVS is not. A user-set `nodeLinker`/
-    // `hoist` (env/.npmrc/yaml) still wins; this is only the embedder default.
-    if flat_incumbent && !injected {
+    // Scan for injected deps at the incumbent's root when detected, else the
+    // cwd — a fresh project (`detected.is_none()`) is rooted at the cwd, so it
+    // is still excluded from the GVS default below if it declares injected deps.
+    let injected_root = detected.map(|d| d.dir.as_path()).unwrap_or(cwd);
+    let injected = unsupported_config::injected_deps_present(injected_root);
+    // GREENLIT 2026-06-28 compat→correctness flip: EVERY non-injected project —
+    // any incumbent (npm/yarn/bun/pnpm) and a fresh nub-identity project —
+    // defaults to isolated with the hidden hoist tree OFF. Pushing `hoist=false`
+    // under the engine's isolated default is what engages the global virtual
+    // store (aube gvs.rs: `effective_gvs = planned_gvs && !hoist && Isolated`);
+    // `nodeLinker=isolated` is pushed explicitly so the layout intent reads at
+    // this call site even though it equals the engine default. Injected deps
+    // (`dependenciesMeta.*.injected`) are the ONE carve-out: they need the
+    // hidden tree to sibling-link packed copies, so they keep stock-aube
+    // isolated+hoist=true (GVS off) — proven, where injected-under-GVS is not.
+    // A user-set `nodeLinker`/`hoist` (env/.npmrc/yaml) still wins.
+    if !injected {
         defaults.push(("nodeLinker".to_string(), "isolated".to_string()));
         defaults.push(("hoist".to_string(), "false".to_string()));
     }
@@ -2476,14 +2474,19 @@ mod tests {
             fresh: false,
         };
 
-        // Flat-layout incumbents ⇒ isolated + hoist=false (the GVS-engaging
-        // config: aube's effective_gvs needs `!hoist && Isolated`).
+        // Every non-injected incumbent kind AND a fresh project default to
+        // isolated + hoist=false (the GVS-engaging config: aube's effective_gvs
+        // needs `!hoist && Isolated`). The tempdir has no injected manifest.
         for kind in [
             LockfileKind::Npm,
+            LockfileKind::NpmShrinkwrap,
+            LockfileKind::Yarn,
             LockfileKind::YarnBerry,
             LockfileKind::Bun,
+            LockfileKind::Pnpm,
+            LockfileKind::Aube,
         ] {
-            let defaults = nub_setting_defaults(Some(&detected(kind)), false);
+            let defaults = nub_setting_defaults(Some(&detected(kind)), false, dir.path());
             assert_eq!(
                 get(&defaults, "nodeLinker"),
                 Some("isolated"),
@@ -2496,50 +2499,76 @@ mod tests {
             );
         }
 
-        // pnpm-shaped kinds and no lockfile ⇒ no layout entry (engine's
-        // isolated + hoist=true default applies, GVS off, stock-aube
-        // phantom-dep tolerance, matching pnpm's own default).
-        for kind in [LockfileKind::Pnpm, LockfileKind::Aube] {
-            let defaults = nub_setting_defaults(Some(&detected(kind)), false);
-            assert_eq!(
-                get(&defaults, "nodeLinker"),
-                None,
-                "{kind:?} must not inject a nodeLinker default"
-            );
-            assert_eq!(
-                get(&defaults, "hoist"),
-                None,
-                "{kind:?} must not inject a hoist default"
-            );
-        }
+        // A fresh project (no lockfile) gets the same GVS default.
+        let fresh = nub_setting_defaults(None, true, dir.path());
         assert_eq!(
-            get(&nub_setting_defaults(None, true), "nodeLinker"),
-            None,
-            "no lockfile must not inject a nodeLinker default"
+            get(&fresh, "nodeLinker"),
+            Some("isolated"),
+            "fresh ⇒ isolated"
         );
         assert_eq!(
-            get(&nub_setting_defaults(None, true), "hoist"),
-            None,
-            "no lockfile must not inject a hoist default"
+            get(&fresh, "hoist"),
+            Some("false"),
+            "fresh ⇒ hoist off (GVS)"
         );
     }
 
     #[test]
+    fn injected_deps_keep_the_hidden_hoist_tree_and_opt_out_of_gvs() {
+        // The ONE carve-out: a project declaring `dependenciesMeta.*.injected`
+        // needs the hidden hoist tree, so it keeps the engine's isolated +
+        // hoist=true default (no nodeLinker/hoist pushed) — GVS off. Covered for
+        // both a detected incumbent and a fresh project rooted at cwd.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"x","dependenciesMeta":{"foo":{"injected":true}}}"#,
+        )
+        .unwrap();
+        let detected = DetectedLockfile {
+            kind: LockfileKind::Npm,
+            dir: dir.path().to_path_buf(),
+            fresh: false,
+        };
+        for defaults in [
+            nub_setting_defaults(Some(&detected), false, dir.path()),
+            nub_setting_defaults(None, true, dir.path()), // fresh, injected at cwd
+        ] {
+            assert_eq!(
+                get(&defaults, "nodeLinker"),
+                None,
+                "injected ⇒ no nodeLinker push"
+            );
+            assert_eq!(
+                get(&defaults, "hoist"),
+                None,
+                "injected ⇒ no hoist push (GVS off)"
+            );
+        }
+    }
+
+    #[test]
     fn fresh_write_format_flips_with_truly_fresh() {
+        let dir = tempfile::tempdir().unwrap();
         // A truly-fresh project writes nub's neutral `lock.yaml`
         // (`defaultLockfileFormat=aube`); every other surface keeps the
         // pnpm-lock fresh-write default for drop-in interop.
         assert_eq!(
-            get(&nub_setting_defaults(None, true), "defaultLockfileFormat"),
+            get(
+                &nub_setting_defaults(None, true, dir.path()),
+                "defaultLockfileFormat"
+            ),
             Some("aube"),
             "truly-fresh must write nub's lock.yaml"
         );
         assert_eq!(
-            get(&nub_setting_defaults(None, false), "defaultLockfileFormat"),
+            get(
+                &nub_setting_defaults(None, false, dir.path()),
+                "defaultLockfileFormat"
+            ),
             Some("pnpm"),
             "a project with a pnpm signal keeps the pnpm-lock fresh-write default"
         );
-        let dir = tempfile::tempdir().unwrap();
         let pnpm = DetectedLockfile {
             kind: LockfileKind::Pnpm,
             dir: dir.path().to_path_buf(),
@@ -2547,7 +2576,7 @@ mod tests {
         };
         assert_eq!(
             get(
-                &nub_setting_defaults(Some(&pnpm), false),
+                &nub_setting_defaults(Some(&pnpm), false, dir.path()),
                 "defaultLockfileFormat"
             ),
             Some("pnpm"),
@@ -2576,7 +2605,7 @@ mod tests {
             // identity-settings invariants for the non-truly-fresh surfaces
             // (the truly-fresh lockfile-format flip is covered separately in
             // `fresh_write_format_flips_with_truly_fresh`).
-            let defaults = nub_setting_defaults(detected.as_ref(), false);
+            let defaults = nub_setting_defaults(detected.as_ref(), false, dir.path());
             assert_eq!(get(&defaults, "defaultLockfileFormat"), Some("pnpm"));
             assert_eq!(get(&defaults, "virtualStoreDir"), Some("node_modules/.nub"));
             assert_eq!(get(&defaults, "stateDir"), Some("node_modules/.nub"));
@@ -2626,7 +2655,7 @@ mod tests {
 
         for kind in all_kinds {
             let d = kind.map(detected);
-            let defaults = nub_setting_defaults(d.as_ref(), false);
+            let defaults = nub_setting_defaults(d.as_ref(), false, dir.path());
             let label = format!("{kind:?}");
 
             // Must always carry the safe explicit-allowlist posture.

--- a/crates/nub-cli/src/pm_engine/unsupported_config.rs
+++ b/crates/nub-cli/src/pm_engine/unsupported_config.rs
@@ -12,9 +12,11 @@
 //!      mode (same path `--frozen-lockfile` takes).
 //!   3. `enableScripts: false` (yarn) → force a block-all-builds policy that
 //!      overrides even nub's curated default-trust floor.
-//!   4. `dependenciesMeta.*.injected` → auto-switch to the isolated linker (the
-//!      only layout where aube materializes injected copies) instead of
-//!      silently dropping the directive under nub's hoisted default.
+//!   4. `dependenciesMeta.*.injected` → the carve-out from the isolated+GVS
+//!      default: nub's default flips every other non-injected project to
+//!      `hoist=false` (no hidden hoist tree, GVS on), but injected copies
+//!      materialize only with the hidden hoist tree, so an injected project
+//!      keeps the engine's isolated + `hoist=true` default (GVS off).
 //!
 //! (`minimumReleaseAge` from bunfig is wired in [`super::bun_config`] — it maps
 //! to a synthetic `.npmrc` entry the settings registry already reads.)
@@ -205,10 +207,10 @@ fn yarn_offline_mirror_configured(root: &Path) -> bool {
 
 /// Whether the root (or any workspace member) manifest declares
 /// `dependenciesMeta.<pkg>.injected: true`. aube materializes injected copies
-/// only under the isolated linker, so when injection is present nub auto-
-/// switches the embedder's `nodeLinker` default to `isolated` (instead of the
-/// hoisted default for flat-layout incumbents) rather than silently dropping
-/// the directive.
+/// only with the hidden hoist tree on, so an injected project is the carve-out
+/// from the isolated+GVS default: instead of `hoist=false` (GVS on) it keeps
+/// the engine's isolated + `hoist=true` default (GVS off), rather than silently
+/// dropping the directive.
 pub(crate) fn injected_deps_present(root: &Path) -> bool {
     manifest_has_injected(&root.join("package.json"))
         || aube_workspace::find_workspace_packages(root)

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -826,29 +826,16 @@ pub(crate) fn run_use_nub(root: &Path) -> Result<i32> {
     let mut migration = plan_migration(&source)?;
     migration.notes.append(&mut merge_notes);
 
-    // Layout preservation (the maintainer ruling, 2026-06-10): a hoisted-origin repo
-    // (npm/yarn/bun lockfile converted) keeps its flat layout — going
-    // isolated is the team's deliberate follow-up, not a side effect of
-    // switching tools. Skipped when the migration itself carries a
-    // node-linker (the explicit setting wins).
-    let hoisted_origin = matches!(
-        &plan,
-        AlignPlan::Convert {
-            from_kind: aube_lockfile::LockfileKind::Npm
-                | aube_lockfile::LockfileKind::NpmShrinkwrap
-                | aube_lockfile::LockfileKind::Yarn
-                | aube_lockfile::LockfileKind::YarnBerry
-                | aube_lockfile::LockfileKind::Bun,
-            ..
-        }
-    );
     // Phantom-dependency warning gate (writeup §6): switching FROM a *hoisting*
-    // PM (npm or yarn — flat node_modules) changes the layout, so undeclared
-    // imports that only resolved via hoisting may break. pnpm/bun are already
-    // isolated (non-hoisting), so they get no warning; nor does a fresh project
-    // or a pnpm→nub rename. Bun is part of `hoisted_origin` above only for the
-    // layout-preservation note (it carries a flat-ish lockfile shape there), but
-    // it is NOT a hoisting PM for phantom-deps purposes — exclude it here.
+    // PM (npm or yarn — flat node_modules) to nub's isolated default changes
+    // the layout, so undeclared imports that only resolved via hoisting may
+    // break. The switch no longer writes `node-linker=hoisted` to preserve the
+    // flat layout (it once did; dropped 2026-06-28 to match the isolated+GVS
+    // install default — the layout-preservation note is gone, the warning
+    // stays). pnpm/bun are already isolated (non-hoisting), so they get no
+    // warning; nor does a fresh project or a pnpm→nub rename. (Bun's lockfile
+    // shape is flat-ish, but it is NOT a hoisting PM for phantom-deps purposes —
+    // exclude it here.)
     let from_hoisting_pm = matches!(
         &plan,
         AlignPlan::Convert {
@@ -859,17 +846,6 @@ pub(crate) fn run_use_nub(root: &Path) -> Result<i32> {
             ..
         }
     );
-    if hoisted_origin && !migration.npmrc.iter().any(|(k, _)| k == "node-linker") {
-        migration
-            .npmrc
-            .push(("node-linker".into(), "hoisted".into()));
-        migration.notes.push(
-            "layout preserved: the project was on a hoisted (flat) node_modules layout, so \
-             node-linker=hoisted is written to .npmrc — remove it to adopt nub's isolated layout"
-                .into(),
-        );
-    }
-
     // ── writes ──────────────────────────────────────────────────────────
     let nub_version = env!("CARGO_PKG_VERSION");
     let mut manifest_notes = Vec::new();

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -988,7 +988,8 @@ fn warn_phantom_dependencies() {
         "  npm and yarn use a flat, hoisted layout. Packages you imported but never",
         "  declared in package.json (\"phantom dependencies\") were only reachable via",
         "  that hoisting and may no longer resolve. If an install or run fails on a",
-        "  missing module, add it to package.json explicitly.",
+        "  missing module, add it to package.json explicitly — or add",
+        "  node-linker=hoisted to .npmrc to keep the flat layout.",
     ];
     eprintln!();
     for line in lines {

--- a/crates/nub-cli/tests/bun_basic_config.rs
+++ b/crates/nub-cli/tests/bun_basic_config.rs
@@ -85,7 +85,7 @@ fn bun_incumbent_reads_project_and_global_bunfig_install_subset() {
         r#"
         [install]
         registry = "https://global.registry.example/"
-        linker = "isolated"
+        linker = "hoisted"
         "#,
     )
     .unwrap();
@@ -98,7 +98,11 @@ fn bun_incumbent_reads_project_and_global_bunfig_install_subset() {
         config_get(&dir, &xdg_config, "@acme:registry"),
         "https://scope.registry.example/"
     );
-    assert_eq!(config_get(&dir, &xdg_config, "nodeLinker"), "isolated");
+    // The global bunfig's `linker` IS read for a bun incumbent. `hoisted` is the
+    // NON-default value (nub's own default is now isolated+GVS), so resolving to
+    // `hoisted` proves the bunfig was read and overrode the embedder default —
+    // an `isolated` bunfig would be indistinguishable from that default.
+    assert_eq!(config_get(&dir, &xdg_config, "nodeLinker"), "hoisted");
 }
 
 #[test]
@@ -149,7 +153,7 @@ fn nub_identity_does_not_read_project_or_global_bunfig() {
                 r#"
                 [install]
                 registry = "https://must-not-read.project.example/"
-                linker = "isolated"
+                linker = "hoisted"
                 "#,
             ),
         ],
@@ -169,7 +173,12 @@ fn nub_identity_does_not_read_project_or_global_bunfig() {
         config_get(&dir, &xdg_config, "registry"),
         "https://registry.npmjs.org/"
     );
-    assert_eq!(config_get(&dir, &xdg_config, "nodeLinker"), "undefined");
+    // The bunfig's `linker = "hoisted"` must NOT be read under nub identity:
+    // nodeLinker resolves to nub's own default (isolated, with hoist=false for
+    // GVS), not the bunfig's `hoisted`. Asserting the NON-bunfig value is what
+    // proves the bunfig was ignored — the project still gets nub's isolated+GVS
+    // default like any other non-injected project.
+    assert_eq!(config_get(&dir, &xdg_config, "nodeLinker"), "isolated");
 }
 
 #[test]

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -295,11 +295,12 @@ fn install_with_pnpm_workspace_stays_pnpm_shaped_no_stamp() {
 }
 
 /// A project with a (frozen-satisfiable) package-lock.json: the layout policy
-/// defaults to the hoisted (npm-style) layout, and the lockfile format is
-/// preserved — no aube-lock.yaml appears next to package-lock.json.
+/// defaults to the isolated layout (the GVS flip — npm/yarn/bun incumbents no
+/// longer force hoisted), and the lockfile format is preserved — no
+/// aube-lock.yaml appears next to package-lock.json.
 #[test]
 #[ignore = "network: fetches is-positive@3.1.0 (resolution comes from the lockfile)"]
-fn install_with_package_lock_hoists_and_preserves_the_npm_lockfile() {
+fn install_with_package_lock_isolates_and_preserves_the_npm_lockfile() {
     if !registry_reachable() {
         eprintln!("skipping: registry.npmjs.org unreachable");
         return;
@@ -342,9 +343,13 @@ fn install_with_package_lock_hoists_and_preserves_the_npm_lockfile() {
         dep.join("package.json").is_file(),
         "is-positive must be installed: stderr: {stderr}"
     );
+    // npm/yarn/bun incumbents now default to the isolated layout (the GVS flip):
+    // a declared dep is a top-level SYMLINK into the `.nub` virtual store, not a
+    // real directory. (GVS engagement itself is off-CI-gated, but the isolated
+    // symlink layout holds regardless.)
     assert!(
-        !dep.symlink_metadata().unwrap().file_type().is_symlink(),
-        "package-lock projects default to the hoisted layout (real dir, not a symlink)"
+        dep.symlink_metadata().unwrap().file_type().is_symlink(),
+        "package-lock projects default to the isolated layout (a symlink into .nub)"
     );
     assert!(
         dir.join("package-lock.json").is_file(),

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -5842,3 +5842,82 @@ fn external_subcommand_never_shadows_an_engine_verb() {
         "add with no packages must error via the engine, not exit 0 via the plugin"
     );
 }
+
+/// The isolated-layout phantom-dependency hint. nub's default isolated layout
+/// exposes only declared packages, so an undeclared transitive that resolved
+/// under a flat node_modules fails — and the runtime resolve hooks annotate
+/// that specific failure with the one-line `node-linker=hoisted` opt-out.
+/// Hand-built minimal layout (no real install / network): the bare-package
+/// presence in `node_modules/.nub` plus top-level reachability is the entire
+/// discriminator, so a directory tree is enough. Guards the three branches that
+/// the gate must get right (the middle one is the regression the reachability
+/// check fixes): a true phantom hints, a subpath miss of a DECLARED dep does
+/// not, and a genuine typo does not.
+#[test]
+fn phantom_dependency_miss_points_at_the_hoisted_opt_out() {
+    let dir = unique_test_cache();
+    let nm = dir.join("node_modules");
+    let mk = |rel: &str, body: &str| {
+        let p = dir.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, body).unwrap();
+    };
+    // A DECLARED, top-level-reachable dep (a real dir — no symlink, so the
+    // fixture is cross-platform). `foo` resolves; `foo/nope` is a subpath miss.
+    mk(
+        "package.json",
+        r#"{"name":"app","version":"1.0.0","dependencies":{"foo":"1.0.0"}}"#,
+    );
+    mk(
+        "node_modules/foo/package.json",
+        r#"{"name":"foo","version":"1.0.0","main":"index.js"}"#,
+    );
+    mk("node_modules/foo/index.js", "module.exports = 'foo';");
+    // A graph package present ONLY in the virtual store (a phantom: installed,
+    // not reachable from the project root).
+    mk(
+        "node_modules/.nub/phantom-pkg@1.0.0/node_modules/phantom-pkg/package.json",
+        r#"{"name":"phantom-pkg","version":"1.0.0","main":"index.js"}"#,
+    );
+    mk(
+        "node_modules/.nub/phantom-pkg@1.0.0/node_modules/phantom-pkg/index.js",
+        "module.exports = 'phantom';",
+    );
+    let _ = &nm; // node_modules is created lazily by the writes above.
+
+    mk("phantom.cjs", "require('phantom-pkg');");
+    mk("subpath.cjs", "require('foo/nope');");
+    mk("typo.cjs", "require('totally-absent-xyz');");
+
+    let run = |file: &str| -> String {
+        let out = Command::new(nub_binary())
+            .arg(dir.join(file))
+            .current_dir(&dir)
+            .env("XDG_CACHE_HOME", unique_test_cache())
+            .output()
+            .expect("spawn nub");
+        String::from_utf8_lossy(&out.stderr).to_string()
+    };
+
+    let phantom = run("phantom.cjs");
+    assert!(
+        phantom.contains("phantom dependency") && phantom.contains("node-linker=hoisted"),
+        "an undeclared transitive present in .nub must surface the opt-out hint: {phantom}"
+    );
+    assert!(
+        phantom.matches("phantom dependency").count() == 1,
+        "the hint must appear exactly once (no double-annotation): {phantom}"
+    );
+
+    let subpath = run("subpath.cjs");
+    assert!(
+        !subpath.contains("phantom dependency"),
+        "a missing subpath of a DECLARED, reachable dep is not a phantom dep — no hint: {subpath}"
+    );
+
+    let typo = run("typo.cjs");
+    assert!(
+        !typo.contains("phantom dependency"),
+        "a package absent from .nub is a genuine miss, not a phantom dep — no hint: {typo}"
+    );
+}

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -16,7 +16,7 @@
 // (it imported them as ESM), so this module never require()s the core there.
 
 const module_ = require("node:module");
-const { readdirSync } = require("node:fs");
+const { readdirSync, existsSync } = require("node:fs");
 const { fileURLToPath, pathToFileURL } = require("node:url");
 const { join, dirname, extname: pathExtname } = require("node:path");
 
@@ -335,14 +335,17 @@ function resolveViaParentRequire(specifier, parentURL) {
 // `phantomDepHint` returns the one-line opt-out to append — but ONLY when the
 // package is genuinely a phantom dep.
 //
-// The discriminator is the virtual store: nub names every package in the
-// project's graph `<name>@<version>` (scoped `/` → `+`) under
-// `node_modules/.nub`, so a matching entry means the package IS installed but
-// unreachable from here — a phantom dep. A genuine typo / absent dep has no
-// entry and gets Node's error verbatim. This is correct under GVS (entries are
-// symlinks into the global store) and non-GVS (real dirs) alike, and the
-// hoisted opt-out leaves NO `<name>@*` entries (only `.nub-state`) so it never
-// matches — nor do node-suite / plain-Node trees (no `.nub` at all).
+// Two conditions, both required, so the hint fires ONLY for a true phantom dep:
+//   (1) the bare package is in the project's graph — nub names every graph
+//       package `<name>@<version>` (scoped `/` → `+`) under `node_modules/.nub`,
+//       so a matching entry means it's installed (GVS: symlinks into the global
+//       store; non-GVS: real dirs);
+//   (2) the bare package is NOT reachable at any `node_modules/<pkg>` up the
+//       tree — otherwise the package resolves and the MODULE_NOT_FOUND is a
+//       missing SUBPATH/file inside it (`react-dom/client-typo`), not a phantom.
+// A genuine typo / absent dep fails (1); a subpath miss of a declared dep fails
+// (2); the hoisted opt-out leaves no `<name>@*` entries (only internal state),
+// and node-suite / plain-Node trees have no `.nub` at all — none get the hint.
 // NOT COVERED: the compat-tier ESM loader (Node 18.19–22.14 `import`) resolves
 // in preload-async-hooks.mjs and can't reach this CJS helper, so that band
 // surfaces Node's standard error without the hint; the fast tier (22.15+) and
@@ -363,29 +366,31 @@ function phantomDepHint(specifier, fromPath) {
     return null;
   }
   const prefix = pkg.replace(/\//g, "+") + "@";
+  let inStore = false;
   for (let i = 0; i < 40 && dir; i++) {
-    let entries;
-    try {
-      entries = readdirSync(join(dir, "node_modules", ".nub"));
-    } catch {
-      entries = null;
-    }
-    if (entries) {
-      // Nearest `.nub` is the project's virtual store; decide here rather than
-      // walking past it into a parent monorepo store.
-      if (!entries.some((e) => e.startsWith(prefix))) return null;
-      return (
-        `\n\n"${pkg}" is installed but not reachable here — it's a phantom dependency (an ` +
-        `undeclared transitive). nub's isolated node_modules exposes only the packages ` +
-        `declared in package.json. Add "${pkg}" to your dependencies, or add ` +
-        "`node-linker=hoisted` to .npmrc to use a flat node_modules."
-      );
+    const nm = join(dir, "node_modules");
+    // Reachable here ⇒ the bare package resolves, so this miss is a subpath/file
+    // inside it, not a phantom dep — suppress. existsSync follows the isolated
+    // layout's top-level symlink to the real package.
+    if (existsSync(join(nm, pkg))) return null;
+    if (!inStore) {
+      try {
+        inStore = readdirSync(join(nm, ".nub")).some((e) => e.startsWith(prefix));
+      } catch {
+        /* no `.nub` at this level */
+      }
     }
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;
   }
-  return null;
+  // In the graph's virtual store yet never reachable up the tree → phantom dep.
+  return inStore
+    ? `\n\n"${pkg}" is installed but not reachable here — it's a phantom dependency (an ` +
+        `undeclared transitive). nub's isolated node_modules exposes only the packages ` +
+        `declared in package.json. Add "${pkg}" to your dependencies, or add ` +
+        "`node-linker=hoisted` to .npmrc to use a flat node_modules."
+    : null;
 }
 
 // Append `hint` to a thrown error's message AND its printed `.stack`. V8

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -327,6 +327,88 @@ function resolveViaParentRequire(specifier, parentURL) {
   }
 }
 
+// Phantom-dependency remediation for nub's isolated layout. The isolated layout
+// (the post-flip default for npm/yarn/bun incumbents, and the standing default
+// for pnpm/fresh projects) exposes only DECLARED packages at the importer's
+// node_modules, so an UNDECLARED transitive that resolved under a flat
+// node_modules fails. When a BARE specifier hits (ERR_)MODULE_NOT_FOUND,
+// `phantomDepHint` returns the one-line opt-out to append — but ONLY when the
+// package is genuinely a phantom dep.
+//
+// The discriminator is the virtual store: nub names every package in the
+// project's graph `<name>@<version>` (scoped `/` → `+`) under
+// `node_modules/.nub`, so a matching entry means the package IS installed but
+// unreachable from here — a phantom dep. A genuine typo / absent dep has no
+// entry and gets Node's error verbatim. This is correct under GVS (entries are
+// symlinks into the global store) and non-GVS (real dirs) alike, and the
+// hoisted opt-out leaves NO `<name>@*` entries (only `.nub-state`) so it never
+// matches — nor do node-suite / plain-Node trees (no `.nub` at all).
+// NOT COVERED: the compat-tier ESM loader (Node 18.19–22.14 `import`) resolves
+// in preload-async-hooks.mjs and can't reach this CJS helper, so that band
+// surfaces Node's standard error without the hint; the fast tier (22.15+) and
+// CommonJS `require()` on every tier are covered.
+function phantomDepHint(specifier, fromPath) {
+  if (!specifier || !fromPath) return null;
+  const c = specifier[0];
+  if (c === "." || c === "/" || c === "#" || c === "\\") return null;
+  if (specifier.startsWith("node:") || module_.isBuiltin(specifier)) return null;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(specifier)) return null; // file:/data:/http:/C:\ …
+  const parts = specifier.split("/");
+  const pkg = c === "@" ? parts.slice(0, 2).join("/") : parts[0];
+  if (!pkg) return null;
+  let dir;
+  try {
+    dir = dirname(String(fromPath).startsWith("file:") ? fileURLToPath(fromPath) : fromPath);
+  } catch {
+    return null;
+  }
+  const prefix = pkg.replace(/\//g, "+") + "@";
+  for (let i = 0; i < 40 && dir; i++) {
+    let entries;
+    try {
+      entries = readdirSync(join(dir, "node_modules", ".nub"));
+    } catch {
+      entries = null;
+    }
+    if (entries) {
+      // Nearest `.nub` is the project's virtual store; decide here rather than
+      // walking past it into a parent monorepo store.
+      if (!entries.some((e) => e.startsWith(prefix))) return null;
+      return (
+        `\n\n"${pkg}" is installed but not reachable here — it's a phantom dependency (an ` +
+        `undeclared transitive). nub's isolated node_modules exposes only the packages ` +
+        `declared in package.json. Add "${pkg}" to your dependencies, or add ` +
+        "`node-linker=hoisted` to .npmrc to use a flat node_modules."
+      );
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+// Append `hint` to a thrown error's message AND its printed `.stack`. V8
+// materializes `.stack` LAZILY from the current `.message`, so the original
+// hint-free stack MUST be read before `.message` is mutated — reading it after
+// would already contain the new message and the `.replace` would double the
+// hint. The marker makes it idempotent if the same error passes two catch
+// sites. Best-effort: a frozen/exotic error is left verbatim.
+function annotateError(err, hint) {
+  try {
+    if (!err || typeof err !== "object" || err.__nubPhantomHinted) return;
+    Object.defineProperty(err, "__nubPhantomHinted", { value: true, configurable: true });
+    const oldStack = typeof err.stack === "string" ? err.stack : null;
+    const oldMsg = err.message;
+    err.message = oldMsg + hint;
+    if (oldStack !== null) {
+      err.stack = oldStack.includes(oldMsg) ? oldStack.replace(oldMsg, err.message) : oldStack + hint;
+    }
+  } catch {
+    /* read-only error: leave verbatim */
+  }
+}
+
 function makeHooks(core, watchReporting) {
   installUserHookDetector();
   installUserAsyncLoaderDetector();
@@ -354,6 +436,10 @@ function makeHooks(core, watchReporting) {
       if (isAsyncLoaderSyncStub(err)) {
         const fallback = resolveViaParentRequire(specifier, context.parentURL);
         if (fallback) return fallback;
+      }
+      if (err && err.code === "ERR_MODULE_NOT_FOUND") {
+        const hint = phantomDepHint(specifier, context.parentURL);
+        if (hint) annotateError(err, hint);
       }
       throw err;
     }
@@ -669,6 +755,11 @@ function installCjsRequireHooks(core, withClassicTranspile) {
         const lookupPaths = module_._resolveLookupPaths(request, parent) || [];
         const found = module_._findPath(request, lookupPaths, isMain);
         if (found) return found;
+      }
+      if (e && e.code === "MODULE_NOT_FOUND") {
+        const fromPath = parent && typeof parent.filename === "string" ? parent.filename : null;
+        const hint = phantomDepHint(request, fromPath);
+        if (hint) annotateError(e, hint);
       }
       throw e;
     }

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -432,7 +432,13 @@ Files materialize into `node_modules` by reflink (APFS/btrfs), hardlink (ext4), 
 
 The default `node_modules` layout is **isolated**: direct dependencies sit at the top level, transitive packages link into a per-project virtual store, and phantom dependencies fail instead of resolving by accident. Nub's virtual store is `node_modules/.nub/` (pnpm uses `node_modules/.pnpm/`) — same shape, not byte-shared, so alternating tools relinks the tree.
 
-Passing `--node-linker hoisted` produces a flat, npm-style layout instead. The npm, Yarn, and Bun incumbents default to `hoisted`; pnpm and Nub-identity projects keep `isolated`.
+Every incumbent defaults to **isolated** — npm, Yarn, and Bun included, alongside pnpm and Nub-identity projects. A project that relies on phantom (undeclared) dependencies opts into the flat, npm-style layout with one line in `.npmrc`:
+
+```ini
+node-linker=hoisted
+```
+
+The `--node-linker hoisted` flag does the same for a single command. When an undeclared package fails to resolve at runtime, Nub's error names it and points at this opt-out.
 
 ### Offline installs
 

--- a/site/content/docs/install/npm.mdx
+++ b/site/content/docs/install/npm.mdx
@@ -119,7 +119,13 @@ npm ignores the Yarn-style top-level `resolutions`, so Nub drops it with a warni
 
 ## Install behavior
 
-The default `node_modules` layout is **hoisted** — the flat npm-style scheme.
+The default `node_modules` layout is **isolated** — direct dependencies at the top level, transitive packages in a per-project virtual store, and phantom (undeclared) dependencies that fail instead of resolving by accident. This is stricter than npm's flat tree, so a project that relies on undeclared transitives opts back in with one line in `.npmrc`:
+
+```ini
+node-linker=hoisted
+```
+
+When an undeclared package fails to resolve at runtime, Nub's error names it and points at this opt-out.
 
 Lifecycle scripts run under Nub's deny-by-default trust posture plus a gated default-trust floor (see [the default-trust floor](/docs/install#default-trust-floor)), not npm's run-everything default. Curated, age-vetted packages build automatically; everything else is skipped with `WARN_NUB_IGNORED_BUILD_SCRIPTS` until `nub approve-builds`. Platform-gated optionals (e.g. `fsevents`) resolve and round-trip into the lock.
 


### PR DESCRIPTION
Flips the default linker for npm/yarn/bun-lock incumbents from hoisted to isolated + GVS (greenlit).

- `nub_setting_defaults`: these incumbents push `nodeLinker=isolated` + `hoist=false`, engaging GVS. pnpm/aube/fresh unchanged; injected carve-out kept; user `nodeLinker`/`hoist` wins.
- Runtime hint: MODULE_NOT_FOUND for a bare specifier in `.nub` but unreachable → ESM + CJS resolve append a `node-linker=hoisted` opt-out. Typos / opt-out never annotated; compat-tier ESM not covered.
- Docs: isolated default + `.npmrc` opt-out.

e2e: npm-lock → isolated symlinks into global store; opt-out → flat tree; phantom import → hint once. clippy/fmt/tests green.