### PR TITLE
cli: keep `--` on `nub watch` + durable target-passthrough test

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1699,12 +1699,19 @@ fn split_subcommand_argv(rest: Vec<String>) -> (Vec<String>, Vec<String>) {
         // First bare token after the subcommand = the positional. The prefix is
         // everything up to and including it; the rest is forwarded verbatim — but
         // a single `--` immediately after the positional is the conventional
-        // end-of-options separator (npm/pnpm/yarn/cargo all drop it), so consume
-        // it. (`nub run build -- a b c` → args `["a","b","c"]`.) Only that first
-        // `--` is stripped; any later `--` is a literal argument.
+        // end-of-options separator the pnpm-style runners (run/exec/nubx) consume
+        // (npm/pnpm/yarn/cargo all drop it). (`nub run build -- a b c` →
+        // `["a","b","c"]`.) Only that first `--` is consumed; a later `--` is a
+        // literal argument.
+        //
+        // `watch` is EXEMPT: it is a file-run (`node --watch <file>`), so it keeps
+        // `--` byte-for-byte like the `nub <file>` runner and the `nub --watch`
+        // flag-form (which never reaches this split). The subcommand and flag
+        // spellings of watch MUST agree, and node never strips — so watch forwards
+        // the `--` verbatim.
         let prefix = rest[..=i].to_vec();
         let mut start = i + 1;
-        if rest.get(start).is_some_and(|t| t == "--") {
+        if subcommand != "watch" && rest.get(start).is_some_and(|t| t == "--") {
             start += 1;
         }
         let suffix = rest[start..].to_vec();
@@ -7743,6 +7750,25 @@ mod tests {
         // No separator: args forward verbatim, including a literal `--` mid-stream.
         let (_, suffix) =
             split_subcommand_argv(["run", "build", "a", "b"].map(String::from).to_vec());
+        assert_eq!(suffix, ["a", "b"]);
+    }
+
+    #[test]
+    fn watch_keeps_the_post_target_dashdash() {
+        // `nub watch` is a file-run (`node --watch <file>`), so unlike the
+        // pnpm-style runners it does NOT consume the first post-target `--` — it
+        // forwards it verbatim, matching `node` and the `nub --watch` flag-form
+        // (which never reaches this split). The two spellings of watch must agree.
+        let (_, suffix) = split_subcommand_argv(
+            ["watch", "app.js", "--", "a", "b"]
+                .map(String::from)
+                .to_vec(),
+        );
+        assert_eq!(suffix, ["--", "a", "b"]);
+
+        // Contrast: `run` still consumes that first `--` (option B, current).
+        let (_, suffix) =
+            split_subcommand_argv(["run", "build", "--", "a", "b"].map(String::from).to_vec());
         assert_eq!(suffix, ["a", "b"]);
     }
 

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1696,25 +1696,16 @@ fn split_subcommand_argv(rest: Vec<String>) -> (Vec<String>, Vec<String>) {
             }
             continue;
         }
-        // First bare token after the subcommand = the positional. The prefix is
-        // everything up to and including it; the rest is forwarded verbatim — but
-        // a single `--` immediately after the positional is the conventional
-        // end-of-options separator the pnpm-style runners (run/exec/nubx) consume
-        // (npm/pnpm/yarn/cargo all drop it). (`nub run build -- a b c` →
-        // `["a","b","c"]`.) Only that first `--` is consumed; a later `--` is a
-        // literal argument.
-        //
-        // `watch` is EXEMPT: it is a file-run (`node --watch <file>`), so it keeps
-        // `--` byte-for-byte like the `nub <file>` runner and the `nub --watch`
-        // flag-form (which never reaches this split). The subcommand and flag
-        // spellings of watch MUST agree, and node never strips — so watch forwards
-        // the `--` verbatim.
+        // First bare token after the subcommand = the positional. It TERMINATES
+        // runner parsing: everything after it is the target's, forwarded VERBATIM
+        // — including any `--`, which is NOT stripped and NOT special-cased
+        // (Option A, decided 2026-06-28). Matches the gold standard — real `node
+        // <file> -- a`, `pnpm 10 run build -- a`, and `pnpm 10 exec bin -- a` all
+        // keep the `--` in the child's argv — and the already-correct `nub <file>`
+        // runner. Uniform across run/exec/watch/nubx; no per-subcommand carve-out.
+        // (`nub run build -- a b` → args `["--","a","b"]`.)
         let prefix = rest[..=i].to_vec();
-        let mut start = i + 1;
-        if subcommand != "watch" && rest.get(start).is_some_and(|t| t == "--") {
-            start += 1;
-        }
-        let suffix = rest[start..].to_vec();
+        let suffix = rest[i + 1..].to_vec();
         return (prefix, suffix);
     }
     // No positional found (e.g. `nub run`, `nub exec --help`): hand the whole
@@ -7728,48 +7719,41 @@ mod tests {
     }
 
     #[test]
-    fn run_strips_the_post_script_dashdash_separator() {
-        // `nub run build -- a b c` must forward `["a","b","c"]`, not
-        // `["--","a","b","c"]`: the first `--` after the script positional is the
-        // conventional end-of-options separator (npm/pnpm/yarn/cargo all drop it).
-        // Only that first `--` is consumed; a later `--` is a literal argument.
-        let (_, suffix) = split_subcommand_argv(
-            ["run", "build", "--", "a", "b", "c"]
-                .map(String::from)
-                .to_vec(),
-        );
-        assert_eq!(suffix, ["a", "b", "c"]);
+    fn runners_keep_the_post_target_dashdash_verbatim() {
+        // Option A (decided 2026-06-28): the target token terminates runner
+        // parsing and everything after it forwards VERBATIM — the `--` is kept,
+        // uniform across run/exec/watch and byte-identical to `node` / `pnpm 10`.
+        // No `--` is ever consumed as a separator; only a LEADING `--` (before the
+        // target — handled by the explicit-separator branch) ends runner options.
+        for verb in ["run", "exec", "watch"] {
+            let (_, suffix) = split_subcommand_argv(
+                [verb, "target", "--", "a", "b", "c"]
+                    .map(String::from)
+                    .to_vec(),
+            );
+            assert_eq!(
+                suffix,
+                ["--", "a", "b", "c"],
+                "{verb}: post-target `--` kept"
+            );
 
-        let (_, suffix) = split_subcommand_argv(
-            ["run", "build", "--", "a", "--", "b"]
-                .map(String::from)
-                .to_vec(),
-        );
-        assert_eq!(suffix, ["a", "--", "b"]);
+            // A repeated `--` is equally literal — nothing is consumed.
+            let (_, suffix) = split_subcommand_argv(
+                [verb, "target", "--", "a", "--", "b"]
+                    .map(String::from)
+                    .to_vec(),
+            );
+            assert_eq!(
+                suffix,
+                ["--", "a", "--", "b"],
+                "{verb}: repeated `--` literal"
+            );
 
-        // No separator: args forward verbatim, including a literal `--` mid-stream.
-        let (_, suffix) =
-            split_subcommand_argv(["run", "build", "a", "b"].map(String::from).to_vec());
-        assert_eq!(suffix, ["a", "b"]);
-    }
-
-    #[test]
-    fn watch_keeps_the_post_target_dashdash() {
-        // `nub watch` is a file-run (`node --watch <file>`), so unlike the
-        // pnpm-style runners it does NOT consume the first post-target `--` — it
-        // forwards it verbatim, matching `node` and the `nub --watch` flag-form
-        // (which never reaches this split). The two spellings of watch must agree.
-        let (_, suffix) = split_subcommand_argv(
-            ["watch", "app.js", "--", "a", "b"]
-                .map(String::from)
-                .to_vec(),
-        );
-        assert_eq!(suffix, ["--", "a", "b"]);
-
-        // Contrast: `run` still consumes that first `--` (option B, current).
-        let (_, suffix) =
-            split_subcommand_argv(["run", "build", "--", "a", "b"].map(String::from).to_vec());
-        assert_eq!(suffix, ["a", "b"]);
+            // No separator: args forward verbatim, including a literal `--` mid-stream.
+            let (_, suffix) =
+                split_subcommand_argv([verb, "target", "a", "b"].map(String::from).to_vec());
+            assert_eq!(suffix, ["a", "b"], "{verb}: no-separator passthrough");
+        }
     }
 
     #[test]

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -3517,6 +3517,8 @@ fn single_package_run_echoes_command_to_stderr_unless_silent() {
     // literal token), proving the echo reflects the real escaped command. The
     // escaping is shell-specific: POSIX `sh` single-quotes, Windows `cmd.exe`
     // caret-escapes, so the expected preamble and echoed output differ per OS.
+    // The post-target `--` is forwarded verbatim (Option A) — byte-identical to
+    // `pnpm 10 run greet -- "brave new world"`.
     let out_args = Command::new(nub_binary())
         .args(["run", "greet", "--", "brave new world"])
         .current_dir(&fixture)
@@ -3527,11 +3529,14 @@ fn single_package_run_echoes_command_to_stderr_unless_silent() {
     assert_eq!(out_args.status.code(), Some(0), "stderr: {stderr_args}");
     let (want_preamble, want_output) = if cfg!(windows) {
         (
-            "$ echo hello ^\"brave^ new^ world^\"",
-            "hello \"brave new world\"",
+            "$ echo hello -- ^\"brave^ new^ world^\"",
+            "hello -- \"brave new world\"",
         )
     } else {
-        ("$ echo hello 'brave new world'", "hello brave new world")
+        (
+            "$ echo hello -- 'brave new world'",
+            "hello -- brave new world",
+        )
     };
     assert!(
         stderr_args.contains(want_preamble),

--- a/crates/nub-cli/tests/target_passthrough.rs
+++ b/crates/nub-cli/tests/target_passthrough.rs
@@ -6,35 +6,18 @@
 //! regression in any command's split — dropping a flag, stealing a trailing
 //! flag, mis-binding a value flag's value as the target — fails here.
 //!
+//! The post-target `--` is KEPT VERBATIM by every command (decided 2026-06-28,
+//! Option A): the target token ends runner parsing, and `--` is neither required
+//! nor special-cased — uniform across file/run/exec/watch and byte-identical to
+//! `node` and `pnpm 10`. (npm/yarn/bun strip it; nub deliberately does not.)
+//!
 //! Golden values are captured from the real reference tools (offline, so the
 //! tests stay deterministic and CI-cheap):
-//!   - node 26.2.0  — oracle for the file runner and `nub watch` (both file-runs)
-//!   - pnpm 10.15.1 — oracle for `nub run` / `nub exec`
-//!   - npm 11.13.0  — the contrasting `--`-stripping reference (option B below)
-//!
-//! THE ONE MAINTAINER-PENDING CELL: whether `nub run` / `nub exec` CONSUME the
-//! single end-of-options `--` immediately after the target, or forward it
-//! verbatim. node + pnpm 10 KEEP it (option A); npm + yarn + bun STRIP it
-//! (option B), which is nub's CURRENT behavior. The file runner CANNOT strip
-//! (node-compat), so "strip" and "consistent everywhere" are mutually exclusive
-//! — hence the open A/B call. That cell is isolated in exactly one constant
-//! ([`RUNNER_KEEPS_POST_TARGET_DASHDASH`]); flip it when the maintainer decides
-//! and every run/exec `--` assertion follows. Every OTHER property here is
-//! stable under both choices.
+//!   - node 26.2.0  — oracle for the file runner and `nub watch` (file-runs)
+//!   - pnpm 10.15.1 — oracle for `nub run` / `nub exec` (also keeps `--`)
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-/// A/B PENDING (maintainer, 2026-06-28): does the post-target `--` survive into
-/// the run/exec child's argv?
-///   - `false` = option B (CURRENT): `nub run`/`nub exec` strip the first
-///     post-target `--` (npm/yarn/bun behavior).
-///   - `true`  = option A: keep it (node/pnpm 10 behavior; would make run/exec
-///     match the file runner, which always keeps).
-///
-/// This governs ONLY the run/exec post-target `--`. The file runner and `watch`
-/// are file-runs and ALWAYS keep `--` (asserted unconditionally below).
-const RUNNER_KEEPS_POST_TARGET_DASHDASH: bool = false;
 
 fn nub_binary() -> PathBuf {
     let mut path = std::env::current_exe().unwrap();
@@ -51,15 +34,6 @@ fn fixture_dir() -> PathBuf {
 
 fn svec(v: &[&str]) -> Vec<String> {
     v.iter().map(|s| s.to_string()).collect()
-}
-
-/// The post-target `--` cell: pick the expected argv per the A/B constant.
-fn dd(kept: &[&str], stripped: &[&str]) -> Vec<String> {
-    svec(if RUNNER_KEEPS_POST_TARGET_DASHDASH {
-        kept
-    } else {
-        stripped
-    })
 }
 
 /// Pull the fixture's `ARGV:[...]` line out of captured output and parse the
@@ -163,38 +137,38 @@ fn file_runner_forwards_verbatim_like_node() {
     }
 }
 
-/// `nub run` and `nub exec` forward post-target flags verbatim and never require
-/// `--`. The single post-target `--` is the A/B cell.
+/// `nub run` and `nub exec` forward everything after the target VERBATIM, keeping
+/// the post-target `--` — byte-identical to `pnpm 10 run`/`pnpm 10 exec` and to
+/// the file runner (Option A). `--` is never required.
 #[test]
-fn run_and_exec_passthrough_and_dashdash_cell() {
+fn run_and_exec_keep_post_target_dashdash_like_pnpm() {
     for &(verb, target) in &[("run", "echo"), ("exec", "echo-argv")] {
-        // Flags after the target reach the target — STABLE under both A/B.
+        // Flags after the target reach the target — no `--` required.
         assert_eq!(
             forwarded_argv(&[verb, target, "--foo", "bar"]),
             svec(&["--foo", "bar"]),
             "{verb}: flags after the target must pass through"
         );
 
-        // The single post-target `--` — the maintainer-pending A/B cell.
+        // The post-target `--` is kept verbatim (= node / pnpm 10).
         assert_eq!(
             forwarded_argv(&[verb, target, "--", "--foo", "bar"]),
-            dd(&["--", "--foo", "bar"], &["--foo", "bar"]),
-            "{verb}: post-target `--` (A/B cell, keeps={RUNNER_KEEPS_POST_TARGET_DASHDASH})"
+            svec(&["--", "--foo", "bar"]),
+            "{verb}: post-target `--` must be kept"
         );
 
-        // Only the FIRST `--` is ever the separator; a second `--` is a literal
-        // arg. Under B the first is consumed and the second survives.
+        // Every `--` is literal — a repeated separator survives in full.
         assert_eq!(
             forwarded_argv(&[verb, target, "--", "a", "--", "b"]),
-            dd(&["--", "a", "--", "b"], &["a", "--", "b"]),
-            "{verb}: a repeated `--` is literal (A/B cell, keeps={RUNNER_KEEPS_POST_TARGET_DASHDASH})"
+            svec(&["--", "a", "--", "b"]),
+            "{verb}: a repeated `--` is literal and kept"
         );
     }
 }
 
 /// The target boundary is resolved correctly before the passthrough suffix
 /// begins — consumed/`=`-joined runner flags and value flags whose value looks
-/// like the target don't shift where forwarding starts. STABLE under both A/B.
+/// like the target don't shift where forwarding starts.
 #[test]
 fn target_boundary_is_resolved_before_passthrough() {
     // file: a consumed `=`-joined nub flag before the file is not forwarded.
@@ -237,7 +211,7 @@ fn target_boundary_is_resolved_before_passthrough() {
 
     // run: a script forced via the LEADING `--` separator (before the target) —
     // that `--` ends runner options and is consumed (pnpm 10 + node), distinct
-    // from a post-target `--`. STABLE under both A/B.
+    // from a post-target `--`, which is kept.
     assert_eq!(
         forwarded_argv(&["run", "--", "echo", "zz"]),
         svec(&["zz"]),

--- a/crates/nub-cli/tests/target_passthrough.rs
+++ b/crates/nub-cli/tests/target_passthrough.rs
@@ -1,0 +1,295 @@
+//! Target-token termination + verbatim arg/flag passthrough — the durable,
+//! oracle-grounded contract across every nub command that takes a target token
+//! (`nub <file>`, `nub run`, `nub exec`, `nub watch`). The model is node's own
+//! grammar: the first resolved target token ENDS runner/flag parsing, and
+//! everything after it is the target's, forwarded byte-for-byte. A future
+//! regression in any command's split — dropping a flag, stealing a trailing
+//! flag, mis-binding a value flag's value as the target — fails here.
+//!
+//! Golden values are captured from the real reference tools (offline, so the
+//! tests stay deterministic and CI-cheap):
+//!   - node 26.2.0  — oracle for the file runner and `nub watch` (both file-runs)
+//!   - pnpm 10.15.1 — oracle for `nub run` / `nub exec`
+//!   - npm 11.13.0  — the contrasting `--`-stripping reference (option B below)
+//!
+//! THE ONE MAINTAINER-PENDING CELL: whether `nub run` / `nub exec` CONSUME the
+//! single end-of-options `--` immediately after the target, or forward it
+//! verbatim. node + pnpm 10 KEEP it (option A); npm + yarn + bun STRIP it
+//! (option B), which is nub's CURRENT behavior. The file runner CANNOT strip
+//! (node-compat), so "strip" and "consistent everywhere" are mutually exclusive
+//! — hence the open A/B call. That cell is isolated in exactly one constant
+//! ([`RUNNER_KEEPS_POST_TARGET_DASHDASH`]); flip it when the maintainer decides
+//! and every run/exec `--` assertion follows. Every OTHER property here is
+//! stable under both choices.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// A/B PENDING (maintainer, 2026-06-28): does the post-target `--` survive into
+/// the run/exec child's argv?
+///   - `false` = option B (CURRENT): `nub run`/`nub exec` strip the first
+///     post-target `--` (npm/yarn/bun behavior).
+///   - `true`  = option A: keep it (node/pnpm 10 behavior; would make run/exec
+///     match the file runner, which always keeps).
+///
+/// This governs ONLY the run/exec post-target `--`. The file runner and `watch`
+/// are file-runs and ALWAYS keep `--` (asserted unconditionally below).
+const RUNNER_KEEPS_POST_TARGET_DASHDASH: bool = false;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/ or release/
+    path.push("nub");
+    path
+}
+
+fn fixture_dir() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    Path::new(&manifest).join("../../tests/fixtures/target-passthrough")
+}
+
+fn svec(v: &[&str]) -> Vec<String> {
+    v.iter().map(|s| s.to_string()).collect()
+}
+
+/// The post-target `--` cell: pick the expected argv per the A/B constant.
+fn dd(kept: &[&str], stripped: &[&str]) -> Vec<String> {
+    svec(if RUNNER_KEEPS_POST_TARGET_DASHDASH {
+        kept
+    } else {
+        stripped
+    })
+}
+
+/// Pull the fixture's `ARGV:[...]` line out of captured output and parse the
+/// JSON array — the exact argv the executed target received.
+fn parse_argv(stdout: &str, stderr: &str) -> Vec<String> {
+    let line = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("ARGV:"))
+        .unwrap_or_else(|| {
+            panic!("fixture never emitted an ARGV line\nstdout: {stdout:?}\nstderr: {stderr:?}")
+        });
+    serde_json::from_str(line).expect("fixture must emit a JSON argv array")
+}
+
+/// Run `nub <args>` in the fixture dir and return the argv the target received.
+/// Used for the file runner, `nub run`, and `nub exec` — all of which exit
+/// cleanly after echoing.
+fn forwarded_argv(args: &[&str]) -> Vec<String> {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(fixture_dir())
+        .output()
+        .expect("spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    parse_argv(&stdout, &stderr)
+}
+
+/// `nub watch` never exits (it re-runs on change), and its own control output
+/// races stdout — so the watched run writes its argv to a sentinel file (via
+/// ARGV_OUT) which we poll for, then kill the watcher. Same approach as the
+/// other `nub watch` integration test.
+fn watch_argv(args: &[&str]) -> Vec<String> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let sentinel = std::env::temp_dir().join(format!(
+        "nub-ttph-watch-{}-{}.json",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_file(&sentinel);
+
+    let mut child = Command::new(nub_binary())
+        .args(args)
+        .current_dir(fixture_dir())
+        .env("ARGV_OUT", &sentinel)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn nub watch");
+
+    let mut contents = None;
+    for _ in 0..100 {
+        if let Ok(s) = std::fs::read_to_string(&sentinel)
+            && s.starts_with("ARGV:")
+        {
+            contents = Some(s);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&sentinel);
+
+    let s = contents.expect("`nub watch` probe never ran (no sentinel written)");
+    parse_argv(&s, "")
+}
+
+/// The file runner is the gold standard: node-identical, ALWAYS keeps `--`,
+/// NEVER requires it. (node 26.2.0 oracle, captured.)
+#[test]
+fn file_runner_forwards_verbatim_like_node() {
+    let cases: &[(&[&str], &[&str])] = &[
+        // post-target `--` is kept (the property the runners diverge on)
+        (
+            &["echo-argv.js", "--", "--foo", "bar"],
+            &["--", "--foo", "bar"],
+        ),
+        // flags after the file pass straight through — `--` not required
+        (
+            &["echo-argv.js", "--foo", "bar", "-x"],
+            &["--foo", "bar", "-x"],
+        ),
+        // every `--` is literal: repeated separators all survive
+        (
+            &["echo-argv.js", "--", "a", "--", "b"],
+            &["--", "a", "--", "b"],
+        ),
+        // a lone trailing `--` survives (node keeps it)
+        (&["echo-argv.js", "--"], &["--"]),
+    ];
+    for (input, want) in cases {
+        assert_eq!(
+            forwarded_argv(input),
+            svec(want),
+            "file runner argv for `nub {}`",
+            input.join(" ")
+        );
+    }
+}
+
+/// `nub run` and `nub exec` forward post-target flags verbatim and never require
+/// `--`. The single post-target `--` is the A/B cell.
+#[test]
+fn run_and_exec_passthrough_and_dashdash_cell() {
+    for &(verb, target) in &[("run", "echo"), ("exec", "echo-argv")] {
+        // Flags after the target reach the target — STABLE under both A/B.
+        assert_eq!(
+            forwarded_argv(&[verb, target, "--foo", "bar"]),
+            svec(&["--foo", "bar"]),
+            "{verb}: flags after the target must pass through"
+        );
+
+        // The single post-target `--` — the maintainer-pending A/B cell.
+        assert_eq!(
+            forwarded_argv(&[verb, target, "--", "--foo", "bar"]),
+            dd(&["--", "--foo", "bar"], &["--foo", "bar"]),
+            "{verb}: post-target `--` (A/B cell, keeps={RUNNER_KEEPS_POST_TARGET_DASHDASH})"
+        );
+
+        // Only the FIRST `--` is ever the separator; a second `--` is a literal
+        // arg. Under B the first is consumed and the second survives.
+        assert_eq!(
+            forwarded_argv(&[verb, target, "--", "a", "--", "b"]),
+            dd(&["--", "a", "--", "b"], &["a", "--", "b"]),
+            "{verb}: a repeated `--` is literal (A/B cell, keeps={RUNNER_KEEPS_POST_TARGET_DASHDASH})"
+        );
+    }
+}
+
+/// The target boundary is resolved correctly before the passthrough suffix
+/// begins — consumed/`=`-joined runner flags and value flags whose value looks
+/// like the target don't shift where forwarding starts. STABLE under both A/B.
+#[test]
+fn target_boundary_is_resolved_before_passthrough() {
+    // file: a consumed `=`-joined nub flag before the file is not forwarded.
+    assert_eq!(
+        forwarded_argv(&["--color=always", "echo-argv.js", "q"]),
+        svec(&["q"]),
+        "a consumed `=`-joined nub flag must not leak into argv"
+    );
+
+    // file: a value flag (`--env-file`) whose VALUE looks like the target binds
+    // the value; the real file positional follows, so only `x` is forwarded.
+    assert_eq!(
+        forwarded_argv(&["--env-file", "echo-argv.js", "echo-argv.js", "x"]),
+        svec(&["x"]),
+        "a value-flag value that looks like the target must bind to the flag"
+    );
+
+    // run: a `=`-joined consumed runner flag before the script doesn't leak.
+    assert_eq!(
+        forwarded_argv(&["run", "--reporter=silent", "echo", "aa", "bb"]),
+        svec(&["aa", "bb"]),
+        "a consumed `=`-joined run flag must not leak into the script's argv"
+    );
+
+    // run: a script forced via the LEADING `--` separator (before the target) —
+    // that `--` ends runner options and is consumed (pnpm 10 + node), distinct
+    // from a post-target `--`. STABLE under both A/B.
+    assert_eq!(
+        forwarded_argv(&["run", "--", "echo", "zz"]),
+        svec(&["zz"]),
+        "a leading `--` ends runner options and is consumed; the script gets the rest"
+    );
+}
+
+/// A target whose name LOOKS like a flag is still the target, not parsed as one.
+#[test]
+fn target_named_like_a_flag() {
+    // file: a path whose basename looks like a flag (`./-x.js`). The `./` marks
+    // it a path; node-identical, `--` kept. Built in a temp dir to avoid
+    // committing a `-`-prefixed filename.
+    let dir = std::env::temp_dir().join(format!("nub-ttph-dashfile-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("-x.js"),
+        "console.log(\"ARGV:\" + JSON.stringify(process.argv.slice(2)));\n",
+    )
+    .unwrap();
+    let out = Command::new(nub_binary())
+        .args(["./-x.js", "--", "p"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        parse_argv(&stdout, &String::from_utf8_lossy(&out.stderr)),
+        svec(&["--", "p"]),
+        "a file path whose name looks like a flag is the target, `--` kept"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// No target at all: `nub run` lists scripts and exits 0 (pnpm parity) — it must
+/// not treat a later token as a phantom target or error.
+#[test]
+fn no_target_lists_and_succeeds() {
+    let out = Command::new(nub_binary())
+        .arg("run")
+        .current_dir(fixture_dir())
+        .output()
+        .expect("spawn nub");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "bare `nub run` must list scripts and exit 0\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The watch fix: `nub watch <file>` (subcommand) and `nub --watch <file>`
+/// (flag) are two spellings of the same file-run and MUST agree — both keep
+/// `--` verbatim, byte-identical to `node --watch <file> -- …`. The subcommand
+/// form previously stripped the first `--` via the shared runner split; watch is
+/// now exempt because it is a file-run, not a pnpm-style runner.
+#[test]
+fn watch_subcommand_and_flag_keep_dashdash_like_node() {
+    let want = svec(&["--", "--foo", "bar"]);
+    assert_eq!(
+        watch_argv(&["watch", "echo-argv.js", "--", "--foo", "bar"]),
+        want,
+        "`nub watch <file>` (subcommand) must keep `--`"
+    );
+    assert_eq!(
+        watch_argv(&["--watch", "echo-argv.js", "--", "--foo", "bar"]),
+        want,
+        "`nub --watch <file>` (flag) must keep `--` — and equal the subcommand form"
+    );
+}

--- a/crates/nub-cli/tests/target_passthrough.rs
+++ b/crates/nub-cli/tests/target_passthrough.rs
@@ -212,6 +212,22 @@ fn target_boundary_is_resolved_before_passthrough() {
         "a value-flag value that looks like the target must bind to the flag"
     );
 
+    // file: a REPEATED value flag before the target — each occurrence consumes its
+    // own value (both fixture files exist), and the target is the token after the
+    // last one. Only `z` is forwarded.
+    assert_eq!(
+        forwarded_argv(&[
+            "--env-file",
+            "echo-argv.js",
+            "--env-file",
+            "package.json",
+            "echo-argv.js",
+            "z",
+        ]),
+        svec(&["z"]),
+        "a repeated value flag must consume each value; the target follows the last"
+    );
+
     // run: a `=`-joined consumed runner flag before the script doesn't leak.
     assert_eq!(
         forwarded_argv(&["run", "--reporter=silent", "echo", "aa", "bb"]),

--- a/tests/fixtures/target-passthrough/echo-argv.js
+++ b/tests/fixtures/target-passthrough/echo-argv.js
@@ -1,0 +1,8 @@
+// Echoes the args this process received (process.argv past argv[0]/argv[1]) so a
+// passthrough test can assert exactly what a runner forwarded. Dual sink: when
+// ARGV_OUT is set (the long-running `nub watch` case, whose own control output
+// races stdout) it writes a sentinel file; otherwise it prints to stdout. One
+// fixture serves the file runner, `nub run`, `nub exec`, and `nub watch`.
+const line = "ARGV:" + JSON.stringify(process.argv.slice(2));
+if (process.env.ARGV_OUT) require("fs").writeFileSync(process.env.ARGV_OUT, line);
+else console.log(line);

--- a/tests/fixtures/target-passthrough/node_modules/.bin/echo-argv
+++ b/tests/fixtures/target-passthrough/node_modules/.bin/echo-argv
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// A node_modules/.bin entry so `nub exec echo-argv …` has a real bin to run.
+// Node-shebang bin → nub runs it via `node <path>`, so no executable bit is
+// needed for the committed fixture. Echoes its argv like echo-argv.js.
+const line = "ARGV:" + JSON.stringify(process.argv.slice(2));
+if (process.env.ARGV_OUT) require("fs").writeFileSync(process.env.ARGV_OUT, line);
+else console.log(line);

--- a/tests/fixtures/target-passthrough/node_modules/.bin/echo-argv.cmd
+++ b/tests/fixtures/target-passthrough/node_modules/.bin/echo-argv.cmd
@@ -1,0 +1,2 @@
+@ECHO off
+node "%~dp0\echo-argv" %*

--- a/tests/fixtures/target-passthrough/package.json
+++ b/tests/fixtures/target-passthrough/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "target-passthrough",
+  "scripts": {
+    "echo": "node echo-argv.js"
+  }
+}


### PR DESCRIPTION
nub keeps the post-target `--` verbatim across `nub <file>`, `run`, `exec`, and `watch` (maintainer decision, Option A): the target token ends runner parsing and everything after it forwards byte-for-byte — `--` neither required nor special-cased. Matches `node` and `pnpm 10`.

Removes the first-`--`-strip from `split_subcommand_argv` (uniform; no per-subcommand carve-out). The leading `--` (end of runner options, before the target) is still consumed, as in node/pnpm. Also fixes the prior `nub watch` subcommand-vs-flag inconsistency, now subsumed by the uniform keep.

Adds an oracle-grounded table-driven test (`target_passthrough.rs` + fixture) pinning target termination + verbatim passthrough across file/run/exec/watch, plus a split-level unit test. Goldens from node 26.2.0 / pnpm 10.15.1.

Refs: target-token-passthrough-hardening thread.