### PR TITLE
fix(pm): close brand-boundary leak on aube's user/project config-file path

### DIFF
--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -87,6 +87,15 @@
 ///   aube cannot make nub silently inherit its `/etc/aube` policy: the brand
 ///   boundary holds on the system path the same way it already held on the env
 ///   override (`NUB_MANAGED_CONFIG_PATH`, via `config_env_prefix`).
+/// - `config_namespace` = `None` — nub has NO branded user/project config file.
+///   The engine never reads `~/.config/aube/config.toml` or
+///   `<cwd>/.config/aube/config.toml` (the leak this profile closes), and nub
+///   does NOT substitute a `~/.config/nub/` home of its own: a nub project's
+///   config surface is the neutral `.npmrc` + the sanctioned `NUB_*` env knobs,
+///   so there is no bespoke nub config file to author or read. Mirrors how
+///   `managed_config_system_dir = None` would skip the system read — here the
+///   user/project branded-file read/write is skipped entirely. Standalone aube
+///   keeps `Some("aube")`, so its `~/.config/aube/config.toml` path is unchanged.
 /// - `canonical_lockfile_always_wins` = `false` — `lock.yaml` never silently
 ///   outranks a foreign lockfile beside it; that state is the loud
 ///   ambiguity/contradiction error (was
@@ -155,6 +164,10 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     cache_namespace: "nub/pm",
     data_namespace: "nub",
     managed_config_system_dir: Some("nub"),
+    // No branded user/project config file: nub never reads `~/.config/aube/`
+    // (or `<cwd>/.config/aube/`) and authors no `~/.config/nub/` of its own —
+    // a nub project's config surface is `.npmrc` + the `NUB_*` env knobs.
+    config_namespace: None,
     canonical_lockfile_always_wins: false,
     runtime_switching: false,
     self_engines_check: false,
@@ -213,6 +226,7 @@ const _: () = {
     assert!(matches!(NUB.cache_namespace.as_bytes(), b"nub/pm"));
     assert!(matches!(NUB.data_namespace.as_bytes(), b"nub"));
     assert!(matches!(NUB.managed_config_system_dir, Some(d) if matches!(d.as_bytes(), b"nub")));
+    assert!(NUB.config_namespace.is_none());
     assert!(matches!(NUB.manifest_namespace.as_bytes(), b""));
     assert!(NUB.workspace_yaml.is_none());
     assert!(NUB.env_prefix.is_none());

--- a/crates/nub-cli/tests/pm_identity.rs
+++ b/crates/nub-cli/tests/pm_identity.rs
@@ -406,3 +406,114 @@ fn lock_yaml_is_nub_identity_and_conflicts_are_loud() {
         "declared nub keeps lock.yaml: {stderr}"
     );
 }
+
+/// Brand boundary on the config-FILE surface: under the NUB profile the engine
+/// reads NO branded user/project config file. The vendored engine's
+/// `~/.config/aube/config.toml` + `<cwd>/.config/aube/config.toml` (the leak)
+/// are ignored, and nub authors no `~/.config/nub/` home of its own — a planted
+/// `.config/nub/config.{toml}` is ignored too. The reader is `nub config get`,
+/// whose value would echo any honored file source. All four plants set
+/// `minimumReleaseAge`; with every branded file ignored the setting falls back
+/// to its built-in default, so the readout is NOT any planted value.
+///
+/// HOME + XDG_CONFIG_HOME are pinned to throwaway dirs so the user-scope plant
+/// is hermetic (never the developer's real `~/.config`).
+#[test]
+fn nub_profile_reads_no_branded_user_or_project_config_file() {
+    let dir = project("config-file-brand", r#"{"name":"app","version":"1.0.0"}"#);
+    let xdg_config = dir.join("xdg-config");
+
+    // User scope (XDG_CONFIG_HOME): both the aube leak and a would-be nub home.
+    std::fs::create_dir_all(xdg_config.join("aube")).unwrap();
+    std::fs::write(
+        xdg_config.join("aube").join("config.toml"),
+        "minimumReleaseAge = 4321\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(xdg_config.join("nub")).unwrap();
+    std::fs::write(
+        xdg_config.join("nub").join("config.toml"),
+        "minimumReleaseAge = 5555\n",
+    )
+    .unwrap();
+
+    // Project scope (<cwd>/.config/<brand>/config.toml).
+    std::fs::create_dir_all(dir.join(".config").join("aube")).unwrap();
+    std::fs::write(
+        dir.join(".config").join("aube").join("config.toml"),
+        "minimumReleaseAge = 7777\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join(".config").join("nub")).unwrap();
+    std::fs::write(
+        dir.join(".config").join("nub").join("config.toml"),
+        "minimumReleaseAge = 8888\n",
+    )
+    .unwrap();
+
+    let out = Command::new(nub_binary())
+        .args(["config", "get", "minimumReleaseAge"])
+        .current_dir(&dir)
+        .env("HOME", dir.join("home"))
+        .env("USERPROFILE", dir.join("home"))
+        .env("XDG_CONFIG_HOME", &xdg_config)
+        .env("XDG_DATA_HOME", dir.join("xdg-data"))
+        .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
+        .output()
+        .expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    for planted in ["4321", "5555", "7777", "8888"] {
+        assert!(
+            !stdout.contains(planted),
+            "nub must ignore every branded config file (read `{planted}`): {stdout}"
+        );
+    }
+
+    // Write side: a `config set` must never AUTHOR a branded config file under
+    // nub — the value lands on the neutral `.npmrc`, and the pre-existing
+    // branded plants are left byte-for-byte untouched.
+    std::fs::create_dir_all(dir.join("home")).unwrap();
+    let set = Command::new(nub_binary())
+        .args([
+            "config",
+            "set",
+            "--location",
+            "user",
+            "minimumReleaseAge",
+            "1000",
+        ])
+        .current_dir(&dir)
+        .env("HOME", dir.join("home"))
+        .env("USERPROFILE", dir.join("home"))
+        .env("XDG_CONFIG_HOME", &xdg_config)
+        .env("XDG_DATA_HOME", dir.join("xdg-data"))
+        .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
+        .output()
+        .expect("failed to spawn nub");
+    assert_eq!(
+        set.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&set.stderr)
+    );
+    assert!(
+        dir.join("home").join(".npmrc").exists(),
+        "the write must land on the neutral .npmrc"
+    );
+    assert_eq!(
+        std::fs::read_to_string(xdg_config.join("aube").join("config.toml")).unwrap(),
+        "minimumReleaseAge = 4321\n",
+        "config set must not write the aube-branded user config file"
+    );
+    assert_eq!(
+        std::fs::read_to_string(xdg_config.join("nub").join("config.toml")).unwrap(),
+        "minimumReleaseAge = 5555\n",
+        "config set must not write a nub-branded user config file"
+    );
+}

--- a/vendor/aube/crates/aube-codes/src/errors.rs
+++ b/vendor/aube/crates/aube-codes/src/errors.rs
@@ -92,6 +92,7 @@ pub const ERR_AUBE_NPM_ONLY_COMMAND: &str = "ERR_AUBE_NPM_ONLY_COMMAND";
 pub const ERR_AUBE_COMPLETION_FAILED: &str = "ERR_AUBE_COMPLETION_FAILED";
 pub const ERR_AUBE_REMOVE_PRIOR_INSTALL_DIR: &str = "ERR_AUBE_REMOVE_PRIOR_INSTALL_DIR";
 pub const ERR_AUBE_CONFIG_NESTED_AUBE_KEY: &str = "ERR_AUBE_CONFIG_NESTED_AUBE_KEY";
+pub const ERR_AUBE_NO_BRANDED_CONFIG_FILE: &str = "ERR_AUBE_NO_BRANDED_CONFIG_FILE";
 pub const ERR_AUBE_CONFLICTING_BUILD_FLAGS: &str = "ERR_AUBE_CONFLICTING_BUILD_FLAGS";
 pub const ERR_AUBE_SHIM_CREATE_FAILED: &str = "ERR_AUBE_SHIM_CREATE_FAILED";
 pub const ERR_AUBE_SHIM_EXEC_FAILED: &str = "ERR_AUBE_SHIM_EXEC_FAILED";
@@ -497,6 +498,12 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_CONFIG_NESTED_AUBE_KEY,
         category: category::ENGINE_CLI,
         description: "`aube config set <prefix>.<sub> …` was used for a key whose prefix is an aube map setting (e.g. `allowBuilds.<pkg>`). Such nested writes would otherwise land in `.npmrc` where aube doesn't read them and npm warns/errors about the unknown key — set the map in workspace yaml or `package.json#aube.<prefix>` instead.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_NO_BRANDED_CONFIG_FILE,
+        category: category::ENGINE_CLI,
+        description: "A `config set` write targeted the tool's own user/project config file, but the active embedder profile has no branded config file (`config_namespace = None`) — it keeps settings on the neutral `.npmrc` + environment surface. Set the value in `.npmrc`, `pnpm-workspace.yaml`/`package.json`, or via an environment variable instead. Unreachable for standalone aube, which always has a `~/.config/aube/config.toml`.",
         exit_code: None,
     },
     CodeMeta {

--- a/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -28,6 +28,7 @@ static MYTOOL: Embedder = Embedder {
     cache_namespace: "mytool",
     data_namespace: "mytool",
     managed_config_system_dir: Some("mytool"),
+    config_namespace: Some("mytool"),
     canonical_lockfile_always_wins: true,
     runtime_switching: true,
     self_engines_check: true,

--- a/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
@@ -34,6 +34,7 @@ static MYTOOL: Embedder = Embedder {
     cache_namespace: "mytool",
     data_namespace: "mytool",
     managed_config_system_dir: Some("mytool"),
+    config_namespace: Some("mytool"),
     canonical_lockfile_always_wins: false,
     runtime_switching: true,
     self_engines_check: true,

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -38,6 +38,7 @@ static NO_CHURN_TOOL: Embedder = Embedder {
     cache_namespace: "nochurn",
     data_namespace: "nochurn",
     managed_config_system_dir: Some("nochurn"),
+    config_namespace: Some("nochurn"),
     canonical_lockfile_always_wins: true,
     runtime_switching: true,
     self_engines_check: true,

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -31,6 +31,7 @@ static STRICT: Embedder = Embedder {
     cache_namespace: "aube",
     data_namespace: "aube",
     managed_config_system_dir: Some("aube"),
+    config_namespace: Some("aube"),
     canonical_lockfile_always_wins: true,
     runtime_switching: true,
     self_engines_check: true,

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -34,6 +34,7 @@ static ROOT_TOOL: Embedder = Embedder {
     cache_namespace: "roottool",
     data_namespace: "roottool",
     managed_config_system_dir: Some("roottool"),
+    config_namespace: Some("roottool"),
     canonical_lockfile_always_wins: true,
     runtime_switching: true,
     self_engines_check: true,

--- a/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
@@ -30,6 +30,7 @@ static MYTOOL: Embedder = Embedder {
     cache_namespace: "mytool",
     data_namespace: "mytool",
     managed_config_system_dir: Some("mytool"),
+    config_namespace: Some("mytool"),
     canonical_lockfile_always_wins: true,
     runtime_switching: true,
     self_engines_check: true,

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -25,6 +25,7 @@ static ROOT_TOOL: Embedder = Embedder {
     cache_namespace: "roottool",
     data_namespace: "roottool",
     managed_config_system_dir: Some("roottool"),
+    config_namespace: Some("roottool"),
     canonical_lockfile_always_wins: true,
     runtime_switching: true,
     self_engines_check: true,

--- a/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
@@ -24,6 +24,7 @@ static MYTOOL: Embedder = Embedder {
     cache_namespace: "mytool",
     data_namespace: "mytool",
     managed_config_system_dir: Some("mytool"),
+    config_namespace: Some("mytool"),
     canonical_lockfile_always_wins: true,
     runtime_switching: true,
     self_engines_check: true,

--- a/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
+++ b/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
@@ -39,6 +39,7 @@ static MYTOOL_NO_BRANDED_ENV: Embedder = Embedder {
     cache_namespace: "mytool",
     data_namespace: "mytool",
     managed_config_system_dir: Some("mytool"),
+    config_namespace: Some("mytool"),
     canonical_lockfile_always_wins: true,
     runtime_switching: true,
     self_engines_check: true,

--- a/vendor/aube/crates/aube-util/src/identity.rs
+++ b/vendor/aube/crates/aube-util/src/identity.rs
@@ -142,6 +142,22 @@ pub struct Embedder {
     /// tool's `/etc/<other>/managed.toml`. Distinct from the env-overridden
     /// managed path, which already follows [`config_env_prefix`](Self::config_env_prefix).
     pub managed_config_system_dir: Option<&'static str>,
+    /// Leaf directory under the XDG config root for the tool's OWN *user/project*
+    /// config file — `~/.config/<dir>/config.toml` at user scope and
+    /// `<cwd>/.config/<dir>/config.toml` at project scope, e.g. `Some("aube")` →
+    /// `~/.config/aube/config.toml`. `None` disables the branded user/project
+    /// config file ENTIRELY: the tool reads no such file (settings come only from
+    /// `.npmrc` + env + the per-setting defaults) and writes none, so a host
+    /// never reads another tool's `~/.config/<other>/config.toml` and never
+    /// authors a branded config file under its own name.
+    ///
+    /// This is a *user-authored* public config surface, so it follows the brand
+    /// boundary the same way [`managed_config_system_dir`](Self::managed_config_system_dir)
+    /// does for the system path: an embedder that keeps its settings on the
+    /// neutral `.npmrc`/env surface (nub) sets `None` rather than substituting a
+    /// `~/.config/<host>/` home. Standalone aube: `Some("aube")`, byte-for-byte
+    /// its prior `~/.config/aube/config.toml` path.
+    pub config_namespace: Option<&'static str>,
 
     // --- embedder-fixed behavior toggles (not user-tunable) ---
     /// When `true` (aube's default), this tool's canonical lockfile
@@ -333,6 +349,7 @@ pub const AUBE: Embedder = Embedder {
     cache_namespace: "aube",
     data_namespace: "aube",
     managed_config_system_dir: Some("aube"),
+    config_namespace: Some("aube"),
     canonical_lockfile_always_wins: true,
     runtime_switching: true,
     self_engines_check: true,
@@ -517,6 +534,7 @@ mod tests {
         assert_eq!(id.cache_namespace, "aube");
         assert_eq!(id.data_namespace, "aube");
         assert_eq!(id.managed_config_system_dir, Some("aube"));
+        assert_eq!(id.config_namespace, Some("aube"));
         assert!(id.canonical_lockfile_always_wins);
         assert!(id.runtime_switching);
         assert!(id.self_engines_check);

--- a/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -37,6 +37,7 @@ static NUBLIKE: Embedder = Embedder {
     cache_namespace: "nublike",
     data_namespace: "nublike",
     managed_config_system_dir: Some("nublike"),
+    config_namespace: Some("nublike"),
     canonical_lockfile_always_wins: false,
     runtime_switching: false,
     self_engines_check: false,

--- a/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -33,6 +33,7 @@ static NUBLIKE: Embedder = Embedder {
     cache_namespace: "nublike",
     data_namespace: "nublike",
     managed_config_system_dir: Some("nublike"),
+    config_namespace: Some("nublike"),
     canonical_lockfile_always_wins: false,
     runtime_switching: false,
     self_engines_check: false,

--- a/vendor/aube/crates/aube/src/commands/config/aube_config.rs
+++ b/vendor/aube/crates/aube/src/commands/config/aube_config.rs
@@ -81,9 +81,20 @@ impl AubeConfigEdit {
     }
 }
 
-pub(crate) fn user_aube_config_path() -> miette::Result<PathBuf> {
+/// User-scope branded config path: `~/.config/<dir>/config.toml`, where `<dir>`
+/// is the active embedder's [`config_namespace`]. `Ok(None)` when the embedder
+/// opts out of a branded user/project config file ([`config_namespace`] = `None`,
+/// e.g. nub) — the tool then reads and writes no such file, keeping its config
+/// surface on `.npmrc` + env. Standalone aube derives `~/.config/aube/config.toml`
+/// byte-for-byte (its profile sets `Some("aube")`).
+///
+/// [`config_namespace`]: aube_util::Embedder::config_namespace
+pub(crate) fn user_aube_config_path() -> miette::Result<Option<PathBuf>> {
+    let Some(ns) = aube_util::embedder().config_namespace else {
+        return Ok(None);
+    };
     if let Some(dir) = aube_util::env::xdg_config_home() {
-        return Ok(dir.join("aube").join("config.toml"));
+        return Ok(Some(dir.join(ns).join("config.toml")));
     }
     let home = aube_util::env::home_dir().ok_or_else(|| {
         miette!(
@@ -91,16 +102,49 @@ pub(crate) fn user_aube_config_path() -> miette::Result<PathBuf> {
             aube_util::prog()
         )
     })?;
-    Ok(home.join(".config").join("aube").join("config.toml"))
+    Ok(Some(home.join(".config").join(ns).join("config.toml")))
 }
 
-/// Project-scope aube config path: `<project>/.config/aube/config.toml`.
-/// Mirrors the XDG layout used at user-scope so the same file name and
-/// folder shape applies everywhere. Project-scope is an alternative to
-/// committing aube-specific settings into a project `.npmrc` shared
-/// with npm/pnpm/yarn.
-pub(crate) fn project_aube_config_path(project_dir: &Path) -> PathBuf {
-    project_dir.join(".config").join("aube").join("config.toml")
+/// Project-scope branded config path: `<project>/.config/<dir>/config.toml`,
+/// where `<dir>` is the active embedder's [`config_namespace`]. Mirrors the XDG
+/// layout used at user-scope. `None` when the embedder opts out
+/// ([`config_namespace`] = `None`); standalone aube derives
+/// `<project>/.config/aube/config.toml`. Project-scope is an alternative to
+/// committing aube-specific settings into a project `.npmrc` shared with
+/// npm/pnpm/yarn.
+///
+/// [`config_namespace`]: aube_util::Embedder::config_namespace
+pub(crate) fn project_aube_config_path(project_dir: &Path) -> Option<PathBuf> {
+    let ns = aube_util::embedder().config_namespace?;
+    Some(project_dir.join(".config").join(ns).join("config.toml"))
+}
+
+/// Error for a config-file WRITE under a profile with no branded config file
+/// ([`config_namespace`] = `None`). Unreachable for standalone aube (always
+/// `Some`); an embedder like nub keeps settings on `.npmrc`/env, so a write that
+/// targets the branded file has no destination.
+///
+/// [`config_namespace`]: aube_util::Embedder::config_namespace
+fn no_branded_config_file_err() -> miette::Report {
+    miette!(
+        code = aube_codes::errors::ERR_AUBE_NO_BRANDED_CONFIG_FILE,
+        help = "this setting isn't part of the shared `.npmrc` surface; set it in `pnpm-workspace.yaml` / `package.json`, or via an environment variable.",
+        "{prog} has no user/project config file — it stores settings in `.npmrc` and the environment, so this key can't be written to a config file.",
+        prog = aube_util::prog(),
+    )
+}
+
+/// The user-scope config-file path for a WRITE, erroring when the active profile
+/// has no branded config file. Write paths use this; reads use
+/// [`user_aube_config_path`] directly and skip on `None`.
+pub(super) fn user_config_write_path() -> miette::Result<PathBuf> {
+    user_aube_config_path()?.ok_or_else(no_branded_config_file_err)
+}
+
+/// The project-scope config-file path for a WRITE, erroring when the active
+/// profile has no branded config file.
+pub(super) fn project_config_write_path(project_dir: &Path) -> miette::Result<PathBuf> {
+    project_aube_config_path(project_dir).ok_or_else(no_branded_config_file_err)
 }
 
 /// System-managed config path (`/etc/<dir>/managed.toml`), where `<dir>` is the
@@ -156,14 +200,19 @@ pub(crate) fn load_managed_entries() -> Vec<(String, String)> {
 }
 
 pub(crate) fn load_user_entries() -> Vec<(String, String)> {
-    let Ok(path) = user_aube_config_path() else {
+    // `Ok(None)` (profile has no branded config file, e.g. nub) and `Err`
+    // (no home dir) both yield no entries — the branded file is simply absent.
+    let Ok(Some(path)) = user_aube_config_path() else {
         return Vec::new();
     };
     load_entries_at(&path)
 }
 
 pub(crate) fn load_project_entries(project_dir: &Path) -> Vec<(String, String)> {
-    load_entries_at(&project_aube_config_path(project_dir))
+    match project_aube_config_path(project_dir) {
+        Some(path) => load_entries_at(&path),
+        None => Vec::new(),
+    }
 }
 
 fn load_entries_at(path: &Path) -> Vec<(String, String)> {
@@ -379,6 +428,32 @@ mod tests {
             Some(PathBuf::from("/etc/aube/managed.toml"))
         );
         assert_eq!(managed_config_env_var(), "AUBE_MANAGED_CONFIG_PATH");
+    }
+
+    /// Default-preserving contract for the profile-derived USER/PROJECT config
+    /// paths: under the default (AUBE) profile the user path ends in
+    /// `aube/config.toml` and the project path is exactly
+    /// `<project>/.config/aube/config.toml`, byte-for-byte as before the path was
+    /// routed through `config_namespace`. The `None` branch (nub: no branded
+    /// config file → both paths absent, no `.config/aube/` read or write) can't be
+    /// asserted here — registering a non-AUBE profile would flip the
+    /// process-global `OnceLock` fallback every default-profile test depends on —
+    /// so it's pinned by nub's `pm_engine::identity` compile-time assertion
+    /// (`config_namespace.is_none()`) and the nub-side `pm_identity` brand sweep.
+    #[test]
+    fn user_project_config_paths_are_aube_branded_under_default_profile() {
+        let user = user_aube_config_path()
+            .expect("aube profile resolves a path")
+            .expect("aube profile has a branded config file");
+        assert!(
+            user.ends_with("aube/config.toml"),
+            "user path must live under the aube namespace: {}",
+            user.display()
+        );
+        assert_eq!(
+            project_aube_config_path(Path::new("/proj")),
+            Some(PathBuf::from("/proj/.config/aube/config.toml"))
+        );
     }
 
     #[cfg(unix)]

--- a/vendor/aube/crates/aube/src/commands/config/delete.rs
+++ b/vendor/aube/crates/aube/src/commands/config/delete.rs
@@ -46,19 +46,23 @@ pub fn run(args: DeleteArgs) -> miette::Result<()> {
             aube_config::project_aube_config_path(&crate::dirs::project_root_or_cwd()?)
         }
     };
-    let mut config_edit = aube_config::AubeConfigEdit::load(&config_path)?;
-    let mut sweep: Vec<String> = aliases.clone();
-    if let Some(meta) = meta
-        && !sweep.iter().any(|s| s == meta.name)
-    {
-        sweep.push(meta.name.to_string());
-    }
-    if !sweep.iter().any(|s| s == &args.key) {
-        sweep.push(args.key.clone());
-    }
-    if config_edit.remove_aliases(&sweep) {
-        config_edit.save(&config_path)?;
-        removed_paths.push(config_path.clone());
+    // No branded config file under this profile (e.g. nub) → nothing to sweep
+    // there; the `.npmrc` sweep below still runs.
+    if let Some(config_path) = &config_path {
+        let mut config_edit = aube_config::AubeConfigEdit::load(config_path)?;
+        let mut sweep: Vec<String> = aliases.clone();
+        if let Some(meta) = meta
+            && !sweep.iter().any(|s| s == meta.name)
+        {
+            sweep.push(meta.name.to_string());
+        }
+        if !sweep.iter().any(|s| s == &args.key) {
+            sweep.push(args.key.clone());
+        }
+        if config_edit.remove_aliases(&sweep) {
+            config_edit.save(config_path)?;
+            removed_paths.push(config_path.clone());
+        }
     }
 
     // `.npmrc`: sweep when the key is npm-shared (the canonical home
@@ -99,7 +103,7 @@ pub fn run(args: DeleteArgs) -> miette::Result<()> {
             return Err(missing_aube_key_error(
                 &args.key,
                 &aliases,
-                &config_path,
+                config_path.as_deref(),
                 location,
             ));
         }
@@ -176,24 +180,28 @@ fn try_delete_aube_map_entry(key: &str, location: Location) -> miette::Result<Op
 fn missing_aube_key_error(
     key: &str,
     aliases: &[String],
-    config_path: &Path,
+    config_path: Option<&Path>,
     location: Location,
 ) -> miette::Report {
+    // `None` (profile with no branded config file, e.g. nub): name the tool's
+    // config surface generically rather than a nonexistent file path.
+    let config_label = config_path.map_or_else(
+        || format!("{} config", aube_util::prog()),
+        |p| p.display().to_string(),
+    );
     if let Ok(npmrc_path) = location.path()
         && npmrc_path.exists()
         && let Ok(edit) = NpmrcEdit::load(&npmrc_path)
         && edit.entries().iter().any(|(k, _)| aliases.contains(k))
     {
         return miette!(
-            "{key} is not set in {} but an entry exists in {}.\n\
+            "{key} is not set in {config_label} but an entry exists in {}.\n\
              aube doesn't modify `.npmrc` for aube-only settings (it's shared with \
              npm/pnpm/yarn) — edit that file directly to remove it, or run \
-             `{} {key} <value>` to override it from {}.",
-            config_path.display(),
+             `{} {key} <value>` to override it from {config_label}.",
             npmrc_path.display(),
             aube_util::cmd("config set"),
-            config_path.display(),
         );
     }
-    miette!("{key} not set in {}", config_path.display())
+    miette!("{key} not set in {config_label}")
 }

--- a/vendor/aube/crates/aube/src/commands/config/set.rs
+++ b/vendor/aube/crates/aube/src/commands/config/set.rs
@@ -285,6 +285,10 @@ fn sweep_stale_aube_config(
             aube_config::project_aube_config_path(&crate::dirs::project_root_or_cwd()?)
         }
     };
+    // No branded config file under this profile (e.g. nub) → nothing to sweep.
+    let Some(config_path) = config_path else {
+        return Ok(());
+    };
     let mut edit = aube_config::AubeConfigEdit::load(&config_path)?;
     let mut sweep: Vec<String> = aliases.to_vec();
     if !sweep.iter().any(|s| s == meta.name) {
@@ -314,10 +318,10 @@ fn reject_aube_map_key(key: &str, meta: &aube_settings::meta::SettingMeta) -> mi
 /// random scalars into a file other tools read.
 fn unknown_aube_config_target(location: Location) -> miette::Result<std::path::PathBuf> {
     match location {
-        Location::User | Location::Global => aube_config::user_aube_config_path(),
-        Location::Project => Ok(aube_config::project_aube_config_path(
-            &crate::dirs::project_root_or_cwd()?,
-        )),
+        Location::User | Location::Global => aube_config::user_config_write_path(),
+        Location::Project => {
+            aube_config::project_config_write_path(&crate::dirs::project_root_or_cwd()?)
+        }
     }
 }
 
@@ -332,10 +336,14 @@ fn aube_config_target(
     meta: &aube_settings::meta::SettingMeta,
 ) -> miette::Result<std::path::PathBuf> {
     match location {
-        Location::User | Location::Global => aube_config::user_aube_config_path(),
+        Location::User | Location::Global => aube_config::user_config_write_path(),
         Location::Project => {
             let cwd = crate::dirs::project_root_or_cwd()?;
-            let config_path = aube_config::project_aube_config_path(&cwd);
+            // Errors when the profile has no branded config file (e.g. nub);
+            // standalone aube always resolves a path. The workspace-yaml
+            // fallback below is reached only for the Some case, so its behavior
+            // is byte-identical to before for standalone aube.
+            let config_path = aube_config::project_config_write_path(&cwd)?;
             if !config_path.exists()
                 && aube_config::preferred_workspace_yaml_key(meta).is_some()
                 && let Some(yaml_path) = aube_manifest::workspace::workspace_yaml_existing(&cwd)


### PR DESCRIPTION
## Problem

Under the NUB embedder profile, the vendored aube engine read an `aube`-branded user-authored config file during settings resolution — `~/.config/aube/config.toml` and `<cwd>/.config/aube/config.toml` — and could author one via `nub config set`. That violates the symmetric, public-surface brand boundary: nub must not read another tool's branded config paths, just as it never reads a pnpm-named file off-incumbent.

The asymmetry was the bug: the *managed/system* config path already routes through the embedder profile (`/etc/<dir>/managed.toml`, `{config_env_prefix}_MANAGED_CONFIG_PATH`), but `user_aube_config_path()` / `project_aube_config_path()` hardcoded `aube` with no `embedder()` lookup.

### Empirical verdicts

- **Config-file leak — REAL.** `nub config get minimumReleaseAge` returned a planted `~/.config/aube/config.toml` (4321) and `<cwd>/.config/aube/config.toml` (7777, project outranks user).
- **No nub-branded config file is read today.** Planted `.config/nub/config.{toml,yaml}` → ignored. Nothing to remove.
- **The env-var side is already shut.** `nub store path`: the neutral `NPM_CONFIG_STORE_DIR` redirects the store; the branded `AUBE_STORE_DIR` is ignored. The gate (`branded_env_alias_enabled`) is applied at resolve time for every `sources.env` alias, and `branded_settings_env_gate.rs` exercises that resolve path. No change needed there.

## Fix

A new embedder field `config_namespace: Option<&'static str>` — the XDG leaf dir for the tool's own user/project config file, mirroring the existing `managed_config_system_dir: Option<&'static str>` precedent.

- Standalone aube: `Some("aube")` — `~/.config/aube/config.toml` byte-for-byte as before.
- nub: `None` — the branded user/project config file is disabled entirely. nub reads it nowhere and writes it nowhere; a nub project's config surface stays `.npmrc` (neutral) plus the sanctioned `NUB_*` env knobs. nub does **not** substitute a `~/.config/nub/` home of its own.

`user_aube_config_path()` now returns `Result<Option<PathBuf>>` and `project_aube_config_path()` returns `Option<PathBuf>`. Read loaders return empty on `None`; write paths refuse on `None` with a new coded error `ERR_AUBE_NO_BRANDED_CONFIG_FILE`. Unknown and npm-shared keys still route to the neutral `.npmrc` unchanged.

## Default-preserving

Standalone aube (no profile registered → `AUBE`, `Some("aube")`) is byte-identical: same paths, same write routing, same `config set` workspace-yaml fallback, same `missing key` messages. Verified by the in-crate default-profile unit tests.

## Verification

- Re-ran the empirical repro on the fixed binary: the leak is closed (`config get` → `undefined`), a neutral `.npmrc` value is still honored, and `config set` writes no `.config/aube/` file.
- New nub-cli e2e gate test `nub_profile_reads_no_branded_user_or_project_config_file` (plants both scopes for both brands; asserts none are read).
- New default-profile unit test pins the AUBE path; the NUB `None` is pinned by a compile-time assertion in `pm_engine::identity`.
- Green: aube-codes/util/settings/lib-config/lockfile/manifest/scripts/registry suites, nub-cli `pm_identity`, `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt --check`.

## Impact analysis

Every caller of the two path functions (the read loaders in `aube_config.rs`, and the `config set`/`config delete` write paths) and the `FileSources`/`ResolveCtx` precedence chain were traced: under `None` only the branded-file source is removed from resolution; no other setting source changes. The new error code is registered in the `ALL` array (self-tests gate duplicates/typos).

Refs the brand-boundary work.

## Write-side routing (note)

Under nub, real `config set` keys (npm-shared, pnpm-only, and unknown alike) route to the neutral `.npmrc` — verified empirically; none author a branded config file. The `None` refusal is a defensive guard on the branded-file write destination; the e2e test asserts a `config set` leaves the planted branded files untouched and lands on `.npmrc`.

One deliberate, maintainer-aligned choice worth flagging: for the narrow case of a non-npm-shared known setting written at project scope with an existing `pnpm-workspace.yaml`, the `Some`-path workspace-yaml fallback is preserved for standalone aube but is refused under nub (no branded config file). This does not manifest for any common key (they route to `.npmrc`), and refusing is consistent with nub's stated config surface (`.npmrc` + `NUB_*`). Flagging it for an explicit call rather than burying it.
