### PR TITLE
runtime: make an unhandled worker 'error' fatal, matching node:worker_threads

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -2654,6 +2654,30 @@ fn worker_throw_surfaces_to_parent_onerror() {
 }
 
 #[test]
+fn worker_unhandled_error_is_fatal() {
+    // ORACLE conformance (node:worker_threads): a worker 'error' with NO listener
+    // must be FATAL — surface visibly + nonzero exit — not silently swallowed.
+    // The bug: nub's browser-shape Worker is an EventTarget, whose dispatchEvent
+    // drops an unlistened event, so a failed worker load exited 0 in total silence
+    // (maintainer-found). The fixture spawns a worker whose module fails to
+    // resolve with no onerror; nub must now exit nonzero and print the error.
+    let (stdout, stderr, code) = run_nub("worker", "unhandled-error-fatal-main.ts");
+    assert_ne!(
+        code, 0,
+        "an unhandled worker error must be fatal (nonzero exit), not swallowed: \
+         code={code} stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("swallowed-and-survived"),
+        "process must not survive past the unhandled worker error: {stdout}"
+    );
+    assert!(
+        stderr.contains("does-not-exist") || stderr.contains("Cannot find"),
+        "the worker module-resolution error must be printed to stderr: {stderr}"
+    );
+}
+
+#[test]
 fn worker_without_inbound_listener_exits_naturally() {
     // Regression (worker-polyfill delegation — worker-polyfill.md §4): the worker
     // scope once held a persistent `parentPort.on("message")` forwarder, keeping

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -2678,6 +2678,24 @@ fn worker_unhandled_error_is_fatal() {
 }
 
 #[test]
+fn worker_error_listener_capture_identity_not_a_false_fatality() {
+    // The unhandled-'error' fatality keys on EventTarget's (type, callback,
+    // capture) listener identity. With a live BUBBLE 'error' listener present, a
+    // capture-only removeEventListener of the same fn must NOT empty the registry
+    // and spuriously throw — the handler must fire and the parent survive (exit 0).
+    let (stdout, stderr, code) = run_nub("worker", "error-listener-capture-main.ts");
+    assert_eq!(
+        code, 0,
+        "a live bubble error listener must not be treated as listener-less: \
+         code={code} stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("capture-bubble-handled:boom from worker"),
+        "the surviving bubble-phase error listener must fire: {stdout}"
+    );
+}
+
+#[test]
 fn worker_without_inbound_listener_exits_naturally() {
     // Regression (worker-polyfill delegation — worker-polyfill.md §4): the worker
     // scope once held a persistent `parentPort.on("message")` forwarder, keeping

--- a/runtime/worker-polyfill.mjs
+++ b/runtime/worker-polyfill.mjs
@@ -133,11 +133,15 @@ export function installWorkerPolyfill() {
   class Worker extends EventTarget {
     #worker;
     #name;
-    // Live set of registered 'error' listeners, so an UNHANDLED worker 'error'
-    // can be made fatal to match the oracle (node:worker_threads is an
-    // EventEmitter; EventTarget exposes no listener count). The onerror setter
-    // routes through addEventListener below, so it is tracked here automatically.
-    #errorListeners = new Set();
+    // Live registry of 'error' listeners, so an UNHANDLED worker 'error' can be
+    // made fatal to match the oracle (node:worker_threads is an EventEmitter;
+    // EventTarget exposes no listener count). Keyed listener → set of capture
+    // flags, mirroring EventTarget's `(type, callback, capture)` listener identity
+    // — `(fn, capture)` and `(fn, bubble)` are TWO distinct registrations, so the
+    // registry must distinguish them or a capture-only remove could empty it while
+    // a live bubble listener remains (a false fatality). The onerror setter routes
+    // through addEventListener below, so it is tracked here automatically.
+    #errorListeners = new Map();
 
     constructor(url, options = {}) {
       super();
@@ -294,10 +298,12 @@ export function installWorkerPolyfill() {
 
     // Track 'error' listeners (for the unhandled-'error' fatality above) without
     // changing EventTarget semantics — super does the real registration; we only
-    // record/forget the listener reference. Set membership matches EventTarget's
-    // identity-based dedup; {once}/{signal} auto-removal is not mirrored here, but
-    // a present listener is what matters at error-dispatch time (the only effect
-    // of a stale entry is erring toward delivery, never toward a false fatality).
+    // record/forget the (listener, capture) identity. The registry mirrors
+    // EventTarget's identity-based dedup INCLUDING the capture flag, so a
+    // capture-only remove can never empty it while a live bubble listener remains.
+    // The only un-mirrored case is {once}/{signal} auto-removal (EventTarget drops
+    // those without routing through this override) — a stale entry there errs
+    // toward DELIVERY (swallow), never toward a false fatality.
     addEventListener(type, listener, options) {
       super.addEventListener(type, listener, options);
       if (
@@ -305,13 +311,27 @@ export function installWorkerPolyfill() {
         (typeof listener === "function" ||
           (listener != null && typeof listener.handleEvent === "function"))
       ) {
-        this.#errorListeners.add(listener);
+        const capture =
+          options === true ||
+          (typeof options === "object" && options !== null && !!options.capture);
+        let caps = this.#errorListeners.get(listener);
+        if (!caps) this.#errorListeners.set(listener, (caps = new Set()));
+        caps.add(capture);
       }
     }
 
     removeEventListener(type, listener, options) {
       super.removeEventListener(type, listener, options);
-      if (type === "error") this.#errorListeners.delete(listener);
+      if (type === "error") {
+        const capture =
+          options === true ||
+          (typeof options === "object" && options !== null && !!options.capture);
+        const caps = this.#errorListeners.get(listener);
+        if (caps) {
+          caps.delete(capture);
+          if (caps.size === 0) this.#errorListeners.delete(listener);
+        }
+      }
     }
 
     postMessage(data, transfer) {

--- a/runtime/worker-polyfill.mjs
+++ b/runtime/worker-polyfill.mjs
@@ -133,6 +133,11 @@ export function installWorkerPolyfill() {
   class Worker extends EventTarget {
     #worker;
     #name;
+    // Live set of registered 'error' listeners, so an UNHANDLED worker 'error'
+    // can be made fatal to match the oracle (node:worker_threads is an
+    // EventEmitter; EventTarget exposes no listener count). The onerror setter
+    // routes through addEventListener below, so it is tracked here automatically.
+    #errorListeners = new Set();
 
     constructor(url, options = {}) {
       super();
@@ -263,6 +268,21 @@ export function installWorkerPolyfill() {
             colno,
           })
         );
+        // ORACLE CONFORMANCE: node:worker_threads re-throws an 'error' that has
+        // NO listener (the EventEmitter unhandled-'error' convention) → it surfaces
+        // as an uncaughtException on the main thread, exit code 1, stack printed.
+        // nub's wrapper owns the node-side 'error' listener, so that throw never
+        // fires natively; we reproduce its fatality when the browser-shape Worker
+        // has no 'error'/onerror listener. Without this an EventTarget silently
+        // drops the unlistened event and a failed worker load exits 0 (the bug).
+        // process.nextTick (not a sync throw inside this emit callback) mirrors
+        // Node's surfacing path exactly: a fresh tick → uncaughtException, so a
+        // user process.on('uncaughtException') still intercepts it as on Node.
+        if (this.#errorListeners.size === 0) {
+          process.nextTick(() => {
+            throw err;
+          });
+        }
       });
       // No `exit` event: WHATWG Workers have no exit event (it is a
       // node:worker_threads concept, not part of the web Worker surface).
@@ -270,6 +290,28 @@ export function installWorkerPolyfill() {
 
     get name() {
       return this.#name;
+    }
+
+    // Track 'error' listeners (for the unhandled-'error' fatality above) without
+    // changing EventTarget semantics — super does the real registration; we only
+    // record/forget the listener reference. Set membership matches EventTarget's
+    // identity-based dedup; {once}/{signal} auto-removal is not mirrored here, but
+    // a present listener is what matters at error-dispatch time (the only effect
+    // of a stale entry is erring toward delivery, never toward a false fatality).
+    addEventListener(type, listener, options) {
+      super.addEventListener(type, listener, options);
+      if (
+        type === "error" &&
+        (typeof listener === "function" ||
+          (listener != null && typeof listener.handleEvent === "function"))
+      ) {
+        this.#errorListeners.add(listener);
+      }
+    }
+
+    removeEventListener(type, listener, options) {
+      super.removeEventListener(type, listener, options);
+      if (type === "error") this.#errorListeners.delete(listener);
     }
 
     postMessage(data, transfer) {

--- a/tests/fixtures/worker/error-listener-capture-main.ts
+++ b/tests/fixtures/worker/error-listener-capture-main.ts
@@ -1,0 +1,19 @@
+// A live BUBBLE-phase 'error' listener is present while a CAPTURE-phase
+// registration of the SAME function is removed. EventTarget listener identity is
+// (type, callback, capture), so these are distinct registrations; the unhandled-
+// 'error' fatality must key on that identity and NOT treat the Worker as
+// listener-less here. The handler must fire and the process must survive (exit 0).
+const fn = (e: { message?: string; error?: { message?: string } }) => {
+  console.log("capture-bubble-handled:" + (e.message ?? e.error?.message ?? ""));
+  (w as { terminate(): void }).terminate();
+  process.exit(0);
+};
+const w = new Worker(new URL("./throwing-worker.ts", import.meta.url));
+(w as unknown as EventTarget).addEventListener("error", fn, true); // capture
+(w as unknown as EventTarget).addEventListener("error", fn, false); // bubble (live)
+(w as unknown as EventTarget).removeEventListener("error", fn, true); // remove capture only
+
+setTimeout(() => {
+  console.log("no-handler-fired");
+  process.exit(2);
+}, 10000);

--- a/tests/fixtures/worker/unhandled-error-fatal-main.ts
+++ b/tests/fixtures/worker/unhandled-error-fatal-main.ts
@@ -1,0 +1,15 @@
+// A worker whose module FAILS TO RESOLVE, with NO 'error'/onerror listener. The
+// oracle (node:worker_threads.Worker, an EventEmitter) re-throws an unhandled
+// 'error' on the main thread → uncaughtException → nonzero exit + printed stack.
+// nub's browser-shape Worker is an EventTarget, whose dispatchEvent silently
+// drops an unlistened event — so a failed worker load USED to exit 0 in total
+// silence (the maintainer-found bug). The fix reproduces the oracle's fatality.
+new Worker(new URL("./does-not-exist.mjs", import.meta.url), { type: "module" });
+
+// Keep the loop alive so the async worker-load failure has time to arrive. If the
+// swallow bug were present, the process would exit 0 and print this line; with the
+// fix the unhandled error is fatal before the timer ever fires.
+setTimeout(() => {
+  console.log("swallowed-and-survived");
+  process.exit(0);
+}, 5000);


### PR DESCRIPTION
A worker created with no `'error'`/`onerror` listener that failed to load — or threw at top level — exited 0 in silence. nub's browser-shape global `Worker` is an `EventTarget`, and `dispatchEvent` drops an event with no listener, so the worker failure vanished. The oracle, `node:worker_threads.Worker`, is an `EventEmitter` that re-throws an unhandled `'error'` on the main thread (`process.nextTick(() => { throw err })`) → uncaughtException → exit 1 with the stack printed.

## Fix

The main-thread `Worker` now tracks its `'error'` listeners (a registry keyed on EventTarget's `(listener, capture)` identity, maintained by `addEventListener`/`removeEventListener`; the `onerror` setter routes through `addEventListener`, so it is counted too). When the underlying worker emits `'error'` with none registered, the wrapper re-throws on a fresh tick — mirroring the oracle exactly: visible, fatal (exit 1), and still interceptable by a user `process.on('uncaughtException')`. The listener-present path is unchanged.

The registry keys on capture (not just the function reference) so a capture-phase `removeEventListener` cannot empty it while a live bubble-phase listener remains (which would be a false fatality). `{once}`/`{signal}` auto-removal stays un-mirrored, but a stale entry there errs toward delivery, never toward a false fatality.

## Verification

- New regression tests: `worker_unhandled_error_is_fatal` and `worker_error_listener_capture_identity_not_a_false_fatality`, plus fixtures.
- Verified e2e on Node 26 (fast tier), 20.19 and 18.19 (compat tier + floor): the no-listener resolve-failure exits 1 with the error on stderr; the throwing worker with `onerror` exits 0 (parent survives).
- Worker integration suite (17 tests) and the WPT worker gate (606 pass, 0 unexpected-fail) green; `clippy --all-targets --all-features -D warnings` and `fmt --check` clean.

## Conformance sweep

Ran Node's own worker suite (141 files: `test/parallel/test-worker-*`, `test-messageport-hasref`, `test-structuredClone-*`) under augmented nub vs plain `node`. 140 match. The only divergence is `test-worker-memory.js`, a heuristic asserting a worker-memory ratio below 5×. nub forwards its transpile/polyfill preload into each worker — load-bearing, it is how `Worker(new URL("./x.ts"))` transpiles its own TS entry — so each augmented worker has a larger footprint. The ratio crosses 5× only at high worker concurrency (passes at ≤4 concurrent workers, fails at ≥8); it is concurrency-driven sticky RSS, not a leak, and not a node:worker_threads-conformance bug. Left as-is and surfaced for a maintainer call on whether the per-worker preload footprint is worth trimming.

Refs: worker oracle-conformance (maintainer-directed; no issue number).
