### PR TITLE
test(pnpm-conformance): stop the seam-swap fork bomb on local runs

### DIFF
--- a/tests/pnpm-conformance/README.md
+++ b/tests/pnpm-conformance/README.md
@@ -25,7 +25,7 @@ The reference checkout `.repos/pnpm` tracks pnpm's `main` (currently 11.x), whic
 | file | role |
 | --- | --- |
 | `run.sh` | the harness: clone → bootstrap → seam-swap → jest → classify |
-| `nub-pnpm-shim.cjs` | the seam replacement (re-execs nub as pnpm; `__NUB_BIN__` is baked at swap time) |
+| `nub-pnpm-shim.cjs` | the seam replacement: first entry execs nub-as-pnpm, a NESTED entry execs real pnpm (the re-entry guard — see below); `__NUB_BIN__`/`__ORIG_PNPM__`/`__CLONE_DIR__` are baked at swap time |
 | `classify.mjs` | parses jest `--json` output; classifies each failure against the allowlist |
 | `allowlist.txt` | known-OK failures: intended divergences + tracked bugs |
 
@@ -46,11 +46,23 @@ tests/pnpm-conformance/run.sh target/debug/nub
 # A single test file (fast iteration; stale-allowlist check is skipped on subsets):
 tests/pnpm-conformance/run.sh target/debug/nub v10.15.1 test/root.ts
 
-# Reuse a clone across runs (skips the slow bootstrap):
+# Reuse a clone across runs (skips the slow bootstrap). A reused clone whose
+# checked-out tag differs from the requested pin is re-checked-out automatically.
 PNPM_CLONE_DIR=/tmp/pnpm-conf KEEP_CLONE=1 tests/pnpm-conformance/run.sh target/debug/nub
 ```
 
 Exit 0 iff every failing test is allowlisted AND no allowlist entry is stale.
+
+## Safe local runs — the re-entry guard + process cap
+
+The seam swap makes `pnpm` resolve to the nub shim **everywhere** on a `node_modules/.bin` PATH in the monorepo (jest-config declares `pnpm: workspace:*`, so its `.bin/pnpm` points at the swapped front-door seam too), not only at the test seam. nub-as-pnpm runs lifecycle scripts with `.bin` on PATH, so without a guard a nested `pnpm` (a lifecycle script, dlx, or runtime provision) re-enters nub install and self-spawns unbounded — a fork bomb (once observed locally at ~10k processes).
+
+Two defenses make local runs safe:
+
+- **Re-entry guard (the real fix).** Only the FIRST shim entry is the command under test (nub). It stamps a sentinel env var; a NESTED entry detects the sentinel and execs the REAL pnpm instead — so nested infra `pnpm` terminates exactly as it would in a real-pnpm run. Real pnpm is taken from the `*.orig-pnpm` backup the swap saves (content-verified, so a corrupt backup falls through to a global pnpm on PATH that lives outside the clone).
+- **Process cap (belt-and-suspenders).** `run.sh` sets `ulimit -u` to `current-process-count + headroom` before running, so any future recursion regression still cannot melt the host. Set `NUB_CONF_PROC_HEADROOM` to tune the headroom (default 800), or `NUB_CONF_NO_ULIMIT=1` to skip it (e.g. when relying on a container `--pids-limit` instead).
+
+A reused clone is also tag-verified: if its checked-out tag does not match the requested pin, `run.sh` re-checks-out the correct tag (restoring the seam to pristine) and wipes `node_modules`/`dist` so the bootstrap re-runs cleanly. This closes the stale-clone-reuse hole that originally triggered the fork bomb.
 
 ## Bootstrap, step by step
 

--- a/tests/pnpm-conformance/nub-pnpm-shim.cjs
+++ b/tests/pnpm-conformance/nub-pnpm-shim.cjs
@@ -10,34 +10,107 @@
 // crates/nub-cli/src/cli.rs). nub-as-pnpm is exactly the drop-in surface the
 // suite asserts on (stdout/stderr/exit/lockfile/node_modules).
 //
-// Written as .cjs so it loads regardless of the package's "type" field. The path
-// to the nub binary is read from NUB_BIN (the runner exports it).
+// RE-ENTRY GUARD (why this is not a one-liner): the swap makes `pnpm` resolve
+// to this shim EVERYWHERE on a `node_modules/.bin` PATH in the monorepo, not
+// just at the test seam — jest-config declares `pnpm: workspace:*`, so its
+// `.bin/pnpm` also points here. nub-as-pnpm runs lifecycle scripts with `.bin`
+// on PATH, so a nested `pnpm` (a lifecycle script, dlx, or runtime provision)
+// would re-enter nub install → unbounded self-spawn (the fork bomb). The fix:
+// only the FIRST entry is the command-under-test (nub); a NESTED entry execs
+// the REAL pnpm instead, so nested infra `pnpm` terminates exactly as it would
+// in a real-pnpm run. First-vs-nested is carried by a sentinel env var that the
+// first entry stamps and a nested entry detects.
+//
+// Written as .cjs so it loads regardless of the package's "type" field. The
+// nub path, the pristine-pnpm backup path, and the clone dir are baked in at
+// swap time (pnpm's createEnv() keeps only PATH/COLORTERM/APPDATA, so exported
+// env would not survive to the spawned shim).
 'use strict'
 const { spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
 
-// The runner replaces __NUB_BIN__ with the absolute nub path at swap time. This
-// MUST be baked in (not read from process.env) because pnpm's test harness
-// rebuilds a clean env in createEnv() that copies only PATH/COLORTERM/APPDATA —
-// any NUB_BIN we export would be stripped before the shim is spawned. The env
-// fallback is kept for direct/manual invocation.
+const SENTINEL = '__NUB_PNPM_SEAM'
+
+// The runner replaces these placeholders at swap time. They MUST be baked (not
+// read from env) because pnpm's harness rebuilds a clean env in createEnv().
 const BAKED_NUB_BIN = '__NUB_BIN__'
+const BAKED_ORIG_PNPM = '__ORIG_PNPM__'
+const BAKED_CLONE_DIR = '__CLONE_DIR__'
+
+const args = process.argv.slice(2)
+
+function finish(res, label) {
+  if (res.error) {
+    console.error(`nub-pnpm-shim: failed to exec ${label}: ${res.error.message}`)
+    process.exit(2)
+  }
+  process.exit(res.status != null ? res.status : res.signal ? 1 : 0)
+}
+
+// Does this file look like the swapped seam (so we never recurse into it when
+// hunting for real pnpm)? The .cjs seam IS this shim; the .mjs seam is an ESM
+// wrapper that requires nub-pnpm-shim.cjs — both contain this marker string.
+function isSwappedSeam(file) {
+  try {
+    return fs.readFileSync(file, 'utf8').includes('nub-pnpm-shim')
+  } catch {
+    return false
+  }
+}
+
+// Locate a REAL pnpm to exec for a nested invocation. Order: the pristine
+// backup the runner saved alongside the seam (the exact built front-door pnpm,
+// same version — the correct answer), then a global pnpm on PATH that lives
+// OUTSIDE the clone (so a monorepo `.bin/pnpm` that points back at the swapped
+// seam is never chosen). The backup cannot be trusted blindly — a stale clone
+// reuse once left it itself a shim — so it is content-verified before use.
+function findRealPnpm() {
+  if (!BAKED_ORIG_PNPM.startsWith('__ORIG') && fs.existsSync(BAKED_ORIG_PNPM) && !isSwappedSeam(BAKED_ORIG_PNPM)) {
+    return { kind: 'node', file: BAKED_ORIG_PNPM }
+  }
+  const seamBinDir = path.resolve(__dirname)
+  const cloneDir = BAKED_CLONE_DIR.startsWith('__CLONE') ? null : path.resolve(BAKED_CLONE_DIR)
+  const names = process.platform === 'win32' ? ['pnpm.exe', 'pnpm.cmd', 'pnpm'] : ['pnpm']
+  for (const dir of (process.env.PATH || '').split(path.delimiter)) {
+    if (!dir) continue
+    const resolved = path.resolve(dir)
+    if (resolved === seamBinDir) continue
+    if (cloneDir && resolved.startsWith(cloneDir + path.sep)) continue
+    for (const name of names) {
+      const cand = path.join(dir, name)
+      if (fs.existsSync(cand) && !isSwappedSeam(cand)) return { kind: 'bin', file: cand }
+    }
+  }
+  return null
+}
+
+// NESTED invocation: a `pnpm` spawned from within a nub-as-pnpm run. Defer to
+// real pnpm (keeping the sentinel set so any FURTHER nesting also stays real,
+// exactly as a real-pnpm run would).
+if (process.env[SENTINEL]) {
+  const real = findRealPnpm()
+  if (!real) {
+    console.error('nub-pnpm-shim: nested pnpm invocation but no real pnpm found (backup missing/corrupt and none on PATH)')
+    process.exit(2)
+  }
+  const argv = real.kind === 'node' ? [real.file, ...args] : args
+  const cmd = real.kind === 'node' ? process.execPath : real.file
+  finish(spawnSync(cmd, argv, { stdio: 'inherit', argv0: 'pnpm', env: process.env }), `real pnpm (${real.file})`)
+}
+
+// FIRST entry: this IS the command under test. Run nub-as-pnpm, stamping the
+// sentinel so any nested pnpm it spawns takes the real-pnpm branch above.
 const nubBin = BAKED_NUB_BIN.startsWith('__NUB') ? process.env.NUB_BIN : BAKED_NUB_BIN
 if (!nubBin) {
   console.error('nub-pnpm-shim: nub binary path is not set (neither baked nor NUB_BIN)')
   process.exit(2)
 }
-
-// Re-exec the nub binary with argv[0] basename "pnpm" so nub adopts the pnpm
-// identity, forwarding the suite's args verbatim and inheriting stdio so the
-// suite captures stdout/stderr exactly as pnpm would emit them.
-const res = spawnSync(nubBin, process.argv.slice(2), {
-  stdio: 'inherit',
-  argv0: 'pnpm',
-  env: process.env,
-})
-
-if (res.error) {
-  console.error(`nub-pnpm-shim: failed to exec nub (${nubBin}): ${res.error.message}`)
-  process.exit(2)
-}
-process.exit(res.status != null ? res.status : res.signal ? 1 : 0)
+finish(
+  spawnSync(nubBin, args, {
+    stdio: 'inherit',
+    argv0: 'pnpm',
+    env: { ...process.env, [SENTINEL]: '1' },
+  }),
+  `nub (${nubBin})`,
+)

--- a/tests/pnpm-conformance/run.sh
+++ b/tests/pnpm-conformance/run.sh
@@ -79,7 +79,49 @@ if [ ! -d "$CLONE_DIR/.git" ]; then
   echo "==> cloning pnpm/pnpm @ $PNPM_TAG (shallow)"
   git clone --depth 1 --branch "$PNPM_TAG" https://github.com/pnpm/pnpm.git "$CLONE_DIR"
 else
-  echo "==> reusing existing clone at $CLONE_DIR"
+  # Reusing a clone is the proximate cause of the historical fork bomb: a stale
+  # v11 clone reused for a v10 pin exercised a version-specific re-entrant path,
+  # AND it left the seam already swapped so the `.orig-pnpm` backup was a shim,
+  # not real pnpm. Verify the checked-out tag matches the request; on mismatch,
+  # fetch + hard-checkout the requested tag (which also restores the tracked
+  # seam to pristine), then wipe node_modules/dist so the bootstrap, compile,
+  # and seam-swap all re-run cleanly against the correct version.
+  CURRENT_TAG="$(git -C "$CLONE_DIR" describe --tags --exact-match HEAD 2>/dev/null || echo '')"
+  if [ "$CURRENT_TAG" = "$PNPM_TAG" ]; then
+    echo "==> reusing existing clone at $CLONE_DIR (at $PNPM_TAG)"
+  else
+    echo "==> existing clone is at '${CURRENT_TAG:-unknown}', need '$PNPM_TAG' — re-checking out"
+    if ! git -C "$CLONE_DIR" fetch --depth 1 origin "refs/tags/$PNPM_TAG:refs/tags/$PNPM_TAG" 2>/dev/null; then
+      echo "error: cannot fetch $PNPM_TAG into existing clone at $CLONE_DIR" >&2
+      echo "       remove that dir (or unset PNPM_CLONE_DIR) and re-run for a fresh clone." >&2
+      exit 2
+    fi
+    git -C "$CLONE_DIR" checkout -f "$PNPM_TAG"
+    rm -rf "$CLONE_DIR/node_modules" "$CLONE_DIR/pnpm/dist"
+  fi
+fi
+
+# ── Process-cap safety net ───────────────────────────────────────────────────
+# Belt-and-suspenders for the seam-recursion fork bomb (which hit ~10k pnpm
+# processes and drove load to ~600). The shim re-entry guard is the real fix;
+# this cap ensures any FUTURE recursion regression (e.g. via a jailed dep script
+# whose env_clear strips the sentinel) still cannot melt the host. Sized as
+# current-usage + headroom so it never trips this box's existing build-fleet
+# load, yet kills an unbounded self-spawn. NUB_CONF_NO_ULIMIT=1 skips it (e.g.
+# when relying on a container `--pids-limit` instead); NUB_CONF_PROC_HEADROOM
+# tunes the headroom.
+if [ "${NUB_CONF_NO_ULIMIT:-0}" != 1 ]; then
+  HEADROOM="${NUB_CONF_PROC_HEADROOM:-800}"
+  CUR_PROCS="$(ps -U "$(id -u)" 2>/dev/null | wc -l | tr -d ' ')"
+  [ -z "$CUR_PROCS" ] && CUR_PROCS=200
+  CAP=$((CUR_PROCS + HEADROOM))
+  HARD="$(ulimit -Hu 2>/dev/null || echo unlimited)"
+  if [ "$HARD" != unlimited ] && [ "$CAP" -gt "$HARD" ]; then CAP="$HARD"; fi
+  if ulimit -u "$CAP" 2>/dev/null; then
+    echo "==> process cap:  ulimit -u $CAP (current ~$CUR_PROCS + headroom $HEADROOM)"
+  else
+    echo "==> warning: could not set process cap (ulimit -u $CAP)" >&2
+  fi
 fi
 
 cd "$CLONE_DIR"
@@ -128,14 +170,33 @@ if [ ! -f "$SEAM" ]; then
   exit 2
 fi
 echo "==> swapping seam: $SEAM -> nub"
-cp "$SEAM" "$SEAM.orig-pnpm"
+# Back up the pristine pnpm seam to `*.orig-pnpm` ONLY when the seam is pristine
+# (not already our shim). The shim's nested-pnpm fallthrough execs this backup,
+# so overwriting it with an already-swapped seam (the stale-reuse failure mode)
+# would poison the fork-bomb guard. The clone-tag re-checkout above restores a
+# reused seam to pristine, so this only trips if a clone is hand-swapped.
+if grep -q 'nub-pnpm-shim' "$SEAM" 2>/dev/null; then
+  echo "==> seam already swapped; preserving existing .orig-pnpm backup"
+  if [ ! -f "$SEAM.orig-pnpm" ] || grep -q 'nub-pnpm-shim' "$SEAM.orig-pnpm" 2>/dev/null; then
+    echo "error: seam is swapped but no pristine .orig-pnpm backup exists." >&2
+    echo "       remove $CLONE_DIR (or unset PNPM_CLONE_DIR) and re-run for a clean clone." >&2
+    exit 2
+  fi
+else
+  cp "$SEAM" "$SEAM.orig-pnpm"
+fi
 # The shim body is CommonJS. A .cjs seam takes it verbatim; a .mjs seam would
 # force ESM and reject `require`, so for .mjs we emit an ESM wrapper that defers
 # to the CJS shim via createRequire. Either way nub is what actually runs.
-# Bake the absolute nub path into the shim — pnpm's createEnv() rebuilds a clean
-# env (keeps only PATH/COLORTERM/APPDATA), so an exported NUB_BIN would not reach
-# the spawned shim. Substituting it into the file is the robust seam.
-SHIM_BODY="$(sed "s#__NUB_BIN__#${NUB_BIN}#" "$HERE/nub-pnpm-shim.cjs")"
+# Bake the absolute nub path, the pristine-pnpm backup path, and the clone dir
+# into the shim — pnpm's createEnv() rebuilds a clean env (keeps only
+# PATH/COLORTERM/APPDATA), so exported env would not reach the spawned shim.
+# Substituting them into the file is the robust seam. `#` is the sed delimiter,
+# so any literal `#` in a path would break it — paths here never contain one.
+SHIM_BODY="$(sed -e "s#__NUB_BIN__#${NUB_BIN}#" \
+                 -e "s#__ORIG_PNPM__#${SEAM}.orig-pnpm#" \
+                 -e "s#__CLONE_DIR__#${CLONE_DIR}#" \
+                 "$HERE/nub-pnpm-shim.cjs")"
 case "$SEAM" in
   *.mjs)
     printf '%s\n' "$SHIM_BODY" > "$CLONE_DIR/pnpm/bin/nub-pnpm-shim.cjs"

--- a/tests/pnpm-conformance/run.sh
+++ b/tests/pnpm-conformance/run.sh
@@ -112,8 +112,16 @@ fi
 # tunes the headroom.
 if [ "${NUB_CONF_NO_ULIMIT:-0}" != 1 ]; then
   HEADROOM="${NUB_CONF_PROC_HEADROOM:-800}"
-  CUR_PROCS="$(ps -U "$(id -u)" 2>/dev/null | wc -l | tr -d ' ')"
+  # `|| CUR_PROCS=200` is required: under `pipefail` a failing `ps` makes the
+  # whole substitution non-zero, which would abort the script via `set -e`
+  # before the empty-check fallback could run.
+  CUR_PROCS="$(ps -U "$(id -u)" 2>/dev/null | wc -l | tr -d ' ')" || CUR_PROCS=200
   [ -z "$CUR_PROCS" ] && CUR_PROCS=200
+  # The cap is a per-USER limit (RLIMIT_NPROC), enforced against the user's
+  # TOTAL live processes at fork time — not just this run's tree. HEADROOM must
+  # therefore exceed both jest's worker pool AND any concurrent fleet growth on
+  # a busy box, or a legitimate fork gets EAGAIN. Bump NUB_CONF_PROC_HEADROOM if
+  # so; the default 800 is generous for a normal run yet far below a 10k bomb.
   CAP=$((CUR_PROCS + HEADROOM))
   HARD="$(ulimit -Hu 2>/dev/null || echo unlimited)"
   if [ "$HARD" != unlimited ] && [ "$CAP" -gt "$HARD" ]; then CAP="$HARD"; fi
@@ -170,20 +178,27 @@ if [ ! -f "$SEAM" ]; then
   exit 2
 fi
 echo "==> swapping seam: $SEAM -> nub"
-# Back up the pristine pnpm seam to `*.orig-pnpm` ONLY when the seam is pristine
-# (not already our shim). The shim's nested-pnpm fallthrough execs this backup,
-# so overwriting it with an already-swapped seam (the stale-reuse failure mode)
-# would poison the fork-bomb guard. The clone-tag re-checkout above restores a
-# reused seam to pristine, so this only trips if a clone is hand-swapped.
+# The pristine-pnpm backup MUST keep the seam's original extension: the shim's
+# nested-pnpm fallthrough execs it as `node <backup>`, and node picks its loader
+# (ESM vs CJS) from the extension — a `.mjs` backup renamed to `.orig-pnpm` is
+# rejected (ERR_UNKNOWN_FILE_EXTENSION). So `pnpm.mjs` → `pnpm.orig-pnpm.mjs`,
+# `pnpm.cjs` → `pnpm.orig-pnpm.cjs`.
+SEAM_EXT="${SEAM##*.}"
+ORIG_BACKUP="${SEAM%.*}.orig-pnpm.${SEAM_EXT}"
+# Back up the pristine seam ONLY when the seam is pristine (not already our
+# shim). The fallthrough execs this backup, so overwriting it with an
+# already-swapped seam (the stale-reuse failure mode) would poison the
+# fork-bomb guard. The clone-tag re-checkout above restores a reused seam to
+# pristine, so this only trips if a clone is hand-swapped.
 if grep -q 'nub-pnpm-shim' "$SEAM" 2>/dev/null; then
-  echo "==> seam already swapped; preserving existing .orig-pnpm backup"
-  if [ ! -f "$SEAM.orig-pnpm" ] || grep -q 'nub-pnpm-shim' "$SEAM.orig-pnpm" 2>/dev/null; then
-    echo "error: seam is swapped but no pristine .orig-pnpm backup exists." >&2
+  echo "==> seam already swapped; preserving existing backup"
+  if [ ! -f "$ORIG_BACKUP" ] || grep -q 'nub-pnpm-shim' "$ORIG_BACKUP" 2>/dev/null; then
+    echo "error: seam is swapped but no pristine backup ($ORIG_BACKUP) exists." >&2
     echo "       remove $CLONE_DIR (or unset PNPM_CLONE_DIR) and re-run for a clean clone." >&2
     exit 2
   fi
 else
-  cp "$SEAM" "$SEAM.orig-pnpm"
+  cp "$SEAM" "$ORIG_BACKUP"
 fi
 # The shim body is CommonJS. A .cjs seam takes it verbatim; a .mjs seam would
 # force ESM and reject `require`, so for .mjs we emit an ESM wrapper that defers
@@ -191,10 +206,12 @@ fi
 # Bake the absolute nub path, the pristine-pnpm backup path, and the clone dir
 # into the shim — pnpm's createEnv() rebuilds a clean env (keeps only
 # PATH/COLORTERM/APPDATA), so exported env would not reach the spawned shim.
-# Substituting them into the file is the robust seam. `#` is the sed delimiter,
-# so any literal `#` in a path would break it — paths here never contain one.
+# Substituting them into the file is the robust seam. `#` is the sed delimiter
+# and `&`/`\` are special in sed's replacement — a path containing any of them
+# would corrupt the shim, but these paths (NUB_BIN, the clone/backup dirs) are
+# controlled local input that never contains them.
 SHIM_BODY="$(sed -e "s#__NUB_BIN__#${NUB_BIN}#" \
-                 -e "s#__ORIG_PNPM__#${SEAM}.orig-pnpm#" \
+                 -e "s#__ORIG_PNPM__#${ORIG_BACKUP}#" \
                  -e "s#__CLONE_DIR__#${CLONE_DIR}#" \
                  "$HERE/nub-pnpm-shim.cjs")"
 case "$SEAM" in


### PR DESCRIPTION
The pnpm-conformance harness fork-bombs when run locally — a runaway of recursively self-spawning `pnpm install` processes (observed at ~10k processes, load ~600). This makes the suite safe to run locally.

## The bug

The harness swaps pnpm's front-door bin (`pnpm/bin/pnpm.{cjs,mjs}`) for a nub shim, so every test that "runs pnpm" runs nub-as-pnpm. But `__utils__/jest-config` declares `pnpm: workspace:*`, so its `node_modules/.bin/pnpm` resolves to that same swapped seam — the shim backs `pnpm` everywhere on a `node_modules/.bin` PATH in the monorepo, not just at the test seam. nub-as-pnpm runs lifecycle scripts with `.bin` on PATH, so a nested `pnpm` (a lifecycle script, dlx, or runtime provision) re-enters nub install and self-spawns unbounded.

It surfaced locally but not in CI because `run.sh` reused a stale v11.3.0 clone for a v10.15.1-pinned run (it reused any existing clone without re-checking-out the requested tag), and the v11 path exercises the re-entrant case. The reuse also corrupted the real-pnpm backup.

## The fix

Three defenses:

1. **Shim re-entry guard.** Only the first shim entry is the command under test (nub); it stamps a sentinel env var. A nested entry detects the sentinel and execs the real pnpm instead, so nested infra `pnpm` terminates exactly as it would in a real-pnpm run. Real pnpm comes from the content-verified `*.orig-pnpm` backup, falling through to a global pnpm on PATH outside the clone if the backup is missing or corrupt.
2. **Clone-tag verification.** A reused clone whose checked-out tag differs from the pin is re-checked-out (restoring a pristine seam) and its `node_modules`/`dist` wiped, so the bootstrap re-runs cleanly. This closes the stale-reuse trigger and keeps the backup pristine.
3. **Process cap.** `run.sh` sets `ulimit -u` to current-process-count + headroom before the run, so any future recursion regression cannot melt the host. `NUB_CONF_PROC_HEADROOM` / `NUB_CONF_NO_ULIMIT` tune or disable it.

## Verification

The full suite was never run (it is the thing that fork-bombs). The re-entry guard was verified in isolation with a bounded harness (no install loop): first-vs-nested dispatch, real-pnpm fallthrough for both `.cjs` and `.mjs` backups, PATH fallback on a corrupt backup, and skipping clone-internal `pnpm` candidates — 10/10. A fresh-context review found and this PR fixes two bugs in the first pass: a `.mjs` backup was rejected by node's loader (extension not preserved), and the process-cap `ps` fallback was dead under `pipefail`. `node --check`, `bash -n`, and `shellcheck` are clean.
