### PR TITLE
fix(pm): keep hoisted prod transitives on prune --prod

### DIFF
--- a/tests/aube-bats/run.sh
+++ b/tests/aube-bats/run.sh
@@ -31,7 +31,7 @@ shift
 
 SUITES=("$@")
 if [ ${#SUITES[@]} -eq 0 ]; then
-  SUITES=(install.bats ci.bats add.bats remove.bats update.bats lockfile_settings.bats lockfile_dir.bats)
+  SUITES=(install.bats ci.bats add.bats remove.bats update.bats prune.bats lockfile_settings.bats lockfile_dir.bats)
 fi
 
 SCRATCH=$(mktemp -d)

--- a/tests/aube-bats/skips.txt
+++ b/tests/aube-bats/skips.txt
@@ -15,6 +15,10 @@ install.bats|aube install self-heals when a CAS shard goes missing under a cache
 install.bats|aube install preserves npm-alias as folder on fresh resolve|walks the node_modules/.aube tree
 add.bats|aube add jsr: resolves against the @jsr scope and writes jsr:<range>|asserts the node_modules/.aube path
 lockfile_settings.bats|modulesDir=custom installs into the configured directory|asserts <modulesDir>/.aube; nub's virtual store stem is .nub
+prune.bats|aube prune --help|nub's clap help omits aube's "Remove extraneous packages" about line
+prune.bats|aube prune removes orphaned .aube entries|fixture seeds an orphan under node_modules/.aube; nub's virtual store is node_modules/.nub
+prune.bats|aube prune honors virtualStoreDir|asserts the prune summary's ".aube" label; nub rebrands it to "the virtual store"
+prune.bats|aube prune removes orphan scoped .aube entries and cleans empty scope dir|fixture seeds an orphan under node_modules/.aube; nub's virtual store is node_modules/.nub
 
 # ── fresh projects default to pnpm-lock.yaml (defaultLockfileFormat=pnpm) ───
 install.bats|aube install in CI generates a lockfile when none is present|fresh projects write pnpm-lock.yaml, not aube-lock.yaml

--- a/vendor/aube/crates/aube/src/commands/prune.rs
+++ b/vendor/aube/crates/aube/src/commands/prune.rs
@@ -71,13 +71,55 @@ pub async fn run(args: PruneArgs) -> miette::Result<()> {
         .map(|dp| dep_path_to_filename(dp, DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH))
         .collect();
 
-    // Per-importer set of top-level package names that should stay
-    // in `<importer>/node_modules/`.
+    // Whether the layout on disk flattens transitive deps into the
+    // importer's top-level `node_modules/`. The hoisted linker
+    // materializes the whole reachable closure at top level;
+    // `shamefully-hoist` promotes every package there under the isolated
+    // linker. In both, a direct-deps-only keep-set deletes reachable prod
+    // transitives that legitimately live at top level (issue #241). Plain
+    // isolated keeps only direct-dep symlinks at top level, so its keep-set
+    // stays direct-deps-only — matching pnpm exactly (a package that is
+    // both a direct devDep and a prod transitive loses its top-level
+    // symlink on `prune --prod` there, rather than being over-retained).
+    //
+    // The install records the node-linker it actually used in the layout
+    // state; prefer it, because it reflects a `--node-linker=hoisted` CLI
+    // override that was never written to `.npmrc` (re-resolving settings
+    // here would miss it). The state does not record `shamefully-hoist`,
+    // so resolve that from settings. Fall back to full settings resolution
+    // when there is no state (a tree installed by another tool).
+    let flattens_transitives = match crate::state::read_state_layout_linker(&cwd) {
+        Some(crate::state::InstallLayoutMode::Hoisted) => true,
+        Some(crate::state::InstallLayoutMode::Isolated) => {
+            super::with_settings_ctx(&cwd, aube_settings::resolved::shamefully_hoist)
+        }
+        None => super::with_settings_ctx(&cwd, |ctx| {
+            matches!(
+                aube_settings::resolved::node_linker(ctx),
+                aube_settings::resolved::NodeLinker::Hoisted
+            ) || aube_settings::resolved::shamefully_hoist(ctx)
+        }),
+    };
+
+    // Per-importer set of top-level package names that should stay in
+    // `<importer>/node_modules/`. Under a flattening layout, union the full
+    // reachable-closure NAME set (the same set the store sweep keeps) so
+    // hoisted transitives survive. A name-keyed keep-set can still retain a
+    // top-level symlink that points at a virtual-store *version* the store
+    // sweep removed (a direct devDep and a prod transitive sharing a name
+    // at different versions); the dangling-symlink sweep in
+    // `prune_top_level` cleans that, so the keep-set never leaves a dangler.
+    let closure_names: HashSet<String> = if flattens_transitives {
+        filtered.packages.values().map(|p| p.name.clone()).collect()
+    } else {
+        HashSet::new()
+    };
     let allowed_top_level: BTreeMap<String, HashSet<String>> = filtered
         .importers
         .iter()
         .map(|(path, deps)| {
-            let names: HashSet<String> = deps.iter().map(|d| d.name.clone()).collect();
+            let mut names: HashSet<String> = deps.iter().map(|d| d.name.clone()).collect();
+            names.extend(closure_names.iter().cloned());
             (path.clone(), names)
         })
         .collect();
@@ -119,7 +161,15 @@ pub async fn run(args: PruneArgs) -> miette::Result<()> {
         } else {
             None
         };
-        prune_top_level(&nm, allowed, preserve_leaf.as_deref(), &mut stats)?;
+        // The virtual-store leaf (e.g. `.nub`) scopes the dangling-symlink
+        // sweep to store-pointing symlinks, sparing `link:`/`portal:` deps.
+        prune_top_level(
+            &nm,
+            allowed,
+            preserve_leaf.as_deref(),
+            aube_dir.file_name(),
+            &mut stats,
+        )?;
 
         // Clean any .bin/ entries that now point at nothing.
         let bin = nm.join(".bin");
@@ -203,6 +253,7 @@ fn prune_top_level(
     nm: &Path,
     allowed: &HashSet<String>,
     preserve_leaf: Option<&std::ffi::OsStr>,
+    store_leaf: Option<&std::ffi::OsStr>,
     stats: &mut PruneStats,
 ) -> miette::Result<()> {
     for entry in std::fs::read_dir(nm).into_diagnostic()? {
@@ -226,7 +277,8 @@ fn prune_top_level(
                 let inner = inner.into_diagnostic()?;
                 let inner_name = inner.file_name();
                 let full = format!("{name}/{}", inner_name.to_string_lossy());
-                if !allowed.contains(&full) {
+                if !allowed.contains(&full) || is_dangling_store_symlink(&inner.path(), store_leaf)
+                {
                     super::remove_existing(&inner.path())?;
                     stats.top_level += 1;
                 }
@@ -234,12 +286,35 @@ fn prune_top_level(
             if std::fs::read_dir(&path).into_diagnostic()?.next().is_none() {
                 let _ = std::fs::remove_dir(&path);
             }
-        } else if !allowed.contains(name.as_ref()) {
+        } else if !allowed.contains(name.as_ref()) || is_dangling_store_symlink(&path, store_leaf) {
             super::remove_existing(&path)?;
             stats.top_level += 1;
         }
     }
     Ok(())
+}
+
+/// A top-level entry that is a broken symlink INTO the virtual store.
+/// The keep-set is name-keyed, so a name-matched top-level symlink can
+/// still point at a virtual-store version the store sweep just removed
+/// (a direct devDep and a prod transitive sharing a name at different
+/// versions). Such an entry is swept regardless of the keep-set so prune
+/// never leaves a dangler. The store-leaf check is load-bearing: a
+/// `link:`/`portal:` dep is a bare symlink to an arbitrary external path
+/// (often a sibling build output that may be absent) — it is a
+/// legitimately installed direct dep and must survive even while
+/// dangling, so only danglers pointing into the virtual store are swept.
+/// Real directories (the hoisted layout) are not symlinks, so they are
+/// unaffected.
+fn is_dangling_store_symlink(path: &Path, store_leaf: Option<&std::ffi::OsStr>) -> bool {
+    let Some(leaf) = store_leaf else { return false };
+    let Ok(meta) = path.symlink_metadata() else {
+        return false;
+    };
+    if !meta.file_type().is_symlink() || path.exists() {
+        return false;
+    }
+    matches!(std::fs::read_link(path), Ok(t) if t.components().any(|c| c.as_os_str() == leaf))
 }
 
 /// Remove any `.bin/` entry whose symlink target no longer resolves.

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -732,6 +732,15 @@ pub fn read_state_dep_build_policy_hash(project_dir: &Path) -> Option<String> {
     Some(state.dep_build_policy_hash)
 }
 
+/// Read the node-linker layout the last install materialized, if
+/// recorded. Authoritative over re-resolving settings because it
+/// reflects a `--node-linker=hoisted` CLI override that was never
+/// persisted to `.npmrc`. `None` when state is missing or predates
+/// layout tracking.
+pub fn read_state_layout_linker(project_dir: &Path) -> Option<InstallLayoutMode> {
+    Some(read_state(&state_dir(project_dir))?.layout?.linker)
+}
+
 /// Read the unreviewed-builds spec keys recorded by the last
 /// install. Powers warm-path warning re-emission so repeat
 /// installs keep nudging users about pending build approvals.

--- a/vendor/aube/test/prune.bats
+++ b/vendor/aube/test/prune.bats
@@ -210,6 +210,107 @@ EOF
 	assert_success
 }
 
+@test "aube prune --prod keeps hoisted prod transitives (#241)" {
+	# Under the hoisted linker the whole closure is flattened into
+	# top-level node_modules/, so a prod transitive (is-number, pulled
+	# by the prod dep is-odd) lives at top level even though it is no
+	# importer's direct dep. prune --prod must keep it — deleting it
+	# (the #241 regression) breaks `require` at runtime.
+	echo 'node-linker=hoisted' >.npmrc
+	cat >package.json <<'EOF'
+{
+  "name": "aube-test-prune-prod-hoisted",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "^3.0.1" },
+  "devDependencies": { "kind-of": "6.0.3" }
+}
+EOF
+
+	run aube install
+	assert_success
+
+	# Hoisted: real dirs at top level (not symlinks).
+	run test -d node_modules/is-odd
+	assert_success
+	run test -d node_modules/is-number
+	assert_success
+	run test -d node_modules/kind-of
+	assert_success
+
+	run aube prune --prod
+	assert_success
+
+	# Prod dep and its prod transitive must both survive.
+	run test -d node_modules/is-odd
+	assert_success
+	run test -d node_modules/is-number
+	assert_success
+	# Dev dep is gone.
+	run test -e node_modules/kind-of
+	assert_failure
+}
+
+@test "aube prune --prod keeps hoisted prod transitives via --node-linker flag (#241)" {
+	# Same as the .npmrc hoisted case, but the linker is chosen by the
+	# install CLI flag, which is never written to .npmrc. prune reads the
+	# recorded install layout to detect it (re-resolving settings would
+	# miss the flag and delete the transitives again).
+	cat >package.json <<'EOF'
+{
+  "name": "aube-test-prune-prod-hoisted-cli",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "^3.0.1" },
+  "devDependencies": { "kind-of": "6.0.3" }
+}
+EOF
+
+	run aube install --node-linker hoisted
+	assert_success
+	run test -d node_modules/is-number
+	assert_success
+
+	run aube prune --prod
+	assert_success
+	run test -d node_modules/is-odd
+	assert_success
+	run test -d node_modules/is-number
+	assert_success
+	run test -e node_modules/kind-of
+	assert_failure
+}
+
+@test "aube prune keeps a link: dep whose target is absent" {
+	# A link: dep is a bare symlink to an external path that can be absent
+	# at prune time (e.g. a sibling build output). The dangling-symlink
+	# sweep is scoped to virtual-store-pointing symlinks, so prune must
+	# keep a dangling link: symlink — deleting it drops a declared dep.
+	mkdir -p sib
+	cat >sib/package.json <<'EOF'
+{ "name": "sib", "version": "1.0.0" }
+EOF
+	cat >package.json <<'EOF'
+{
+  "name": "aube-test-prune-link",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "^3.0.1", "sib": "link:./sib" }
+}
+EOF
+
+	run aube install
+	assert_success
+	run test -L node_modules/sib
+	assert_success
+
+	# Remove the link target so the top-level symlink dangles.
+	rm -rf sib
+
+	run aube prune
+	assert_success
+	# The link symlink must survive even while dangling.
+	run test -L node_modules/sib
+	assert_success
+}
+
 @test "aube install --no-optional excludes optional deps" {
 	cat >package.json <<'EOF'
 {


### PR DESCRIPTION
`nub prune --prod` deleted production transitive dependencies under the hoisted node-linker, breaking the install with `ERR_MODULE_NOT_FOUND`.

## Cause

prune built each importer's top-level keep-set from its direct deps only. The hoisted linker (and isolated `shamefully-hoist`) flattens the whole reachable closure into top-level `node_modules/`, so production transitives live there but appear in no importer's direct-dep list — and prune deleted them.

## Fix

- When the on-disk layout flattens transitives to the importer root, union the reachable production-closure package names into the top-level keep-set. Plain isolated stays direct-deps-only, matching pnpm — a package that is both a direct devDependency and a production transitive loses its top-level symlink on `prune --prod` rather than being retained.
- Read the layout from the recorded install state, which captures a `--node-linker=hoisted` CLI flag that was never written to `.npmrc` (re-resolving settings alone would miss it); fall back to settings for `shamefully-hoist` and for trees installed by another tool.
- Sweep dangling top-level symlinks, scoped to symlinks that point into the virtual store. A name-matched symlink can point at a virtual-store version the store sweep removed (a direct devDependency and a production transitive sharing a name at different versions); it is now cleaned instead of left dangling. The scope spares `link:`/`portal:` deps, whose target may legitimately be absent at prune time.

## Tests

Added regression tests for the npmrc-hoisted, CLI-flag-hoisted, and `link:`-preservation cases, and wired `prune.bats` into the nub-adapted bats suite with skips for the pre-existing `.aube` store-path/label and help-text divergences. Verified against pnpm 10.15.1 across hoisted, isolated, isolated + `shamefully-hoist`, and the name/version-collision case.

This is a latent correctness bug in standalone aube as well; the fix lives in `vendor/aube` and is default-preserving (no embedder-specific behavior).

Refs #241 — fixes Bug #1 (hoisted `prune --prod` drops production transitives). Bug #2 (the GVS multi-stage-Docker `node_modules` relocatability regression) is tracked separately and stays open, so this does not close the issue.
