### PR TITLE
test(pnpm-conformance): rebaseline allowlist at pnpm 11.3.0

### DIFF
--- a/tests/pnpm-conformance/allowlist.txt
+++ b/tests/pnpm-conformance/allowlist.txt
@@ -16,186 +16,21 @@
 # Regenerate after a deliberate suite/pin change:
 #   node tests/pnpm-conformance/gen-allowlist.mjs <results.json> > tests/pnpm-conformance/allowlist.txt
 
-# ── version-switching (3) ─────────────────────────────────────────
+# ── version-switching (7) ─────────────────────────────────────────
 # INTENDED / out-of-scope — packageManager version-switching + self-update (nub does not manage pnpm versions). Threads: pnpm-conformance-99, pnpm-conformance-divergences (D8).
+pnpm with <version> ignores the packageManager pin and uses the requested version
+pnpm with current bypasses devEngines.packageManager with onFail=download
+pnpm with current bypasses the packageManager check when an unrelated package manager is pinned
+test/install/global.ts
 test/install/selfUpdate.ts
 test/packageManagerCheck.test.ts
 test/switchingVersions.test.ts
 
-# ── node-provisioning (6) ─────────────────────────────────────────
-# INTENDED / out-of-scope — per-package / --use-node-version Node provisioning (nub uses the host Node).
-exec with executionEnv
-ignores pnpm.executionEnv specified by dependencies
-recursive exec when some packages define different executionEnv
-recursive run when some packages define different node versions
-use node versions specified by pnpm.executionEnv.nodeVersion in workspace packages
-use the specified Node.js version for running scripts
-
-# ── server (1) ────────────────────────────────────────────────────
-# INTENDED / out-of-scope — `pnpm server` store-server mode (unimplemented; tests also time out).
-test/server.ts
-
-# ── supported-arch (1) ────────────────────────────────────────────
-# INTENDED / out-of-scope — supportedArchitectures install matrix.
-test/install/supportedArchitectures.ts
-
-# ── global-layout (12) ─────────────────────────────────────────────
+# ── global-layout (2) ─────────────────────────────────────────────
 # INTENDED / out-of-scope — global install/link/bin layout (nub uses its own global layout).
-link a package from a workspace to the global package
-link a package globally without specifying the global option
-link globally the command of a package that has no name in package.json
 pnpm bin -g
 pnpm root -g
-pnpmfile: pass log function to readPackage hook of global and local pnpmfile
-readPackage async hook from global pnpmfile and local pnpmfile
-readPackage hook from global pnpmfile
-readPackage hook from global pnpmfile and local pnpmfile
-test/install/global.ts
-uninstall global package with its bin files
-using a global virtual store
 
-# ── patch-config-deps (2) ─────────────────────────────────────────
-# INTENDED / out-of-scope — patch + configurational-dependencies hooks.
-test/configurationalDependencies.test.ts
-test/patch/ignorePatchFailures.ts
-
-# ── infra-registry-404 (4) ────────────────────────────────────────
-# HARNESS INFRA — registry-mock not honored on this flow -> real-registry 404. Harness bug, not a nub regression.
-deploy should keep files created by lifecycle scripts
-rebuild in a directory created with "pnpm deploy" and with "pnpm.neverBuiltDependencies" configured should run lifecycle scripts
-selectively allow scripts in some dependencies by --allow-build flag overlap ignoredBuiltDependencies
-throw an error when strict-dep-builds is true and there are ignored scripts
-
-# ── infra-trim-crash (6) ──────────────────────────────────────────
-# HARNESS INFRA — execPnpm.ts helper crashes on empty nub output (undefined.trim).
-dlx should work with npm_config_save_dev env variable
-dlx uses the node version specified by --use-node-version
-dlx with supportedArchitectures CLI options ["--cpu=arm64", "--cpu=x64", "--os=darwin", "--os=linux", "--os=win32"]
-dlx with supportedArchitectures CLI options ["--cpu=arm64", "--os=darwin"]
-dlx with supportedArchitectures CLI options ["--cpu=arm64", "--os=win32"]
-dlx with supportedArchitectures CLI options ["--cpu=x64", "--os=linux", "--libc=musl"]
-
-# ── infra-timeout (1) ─────────────────────────────────────────────
-# HARNESS INFRA — jest timeout (unimplemented feature hangs).
-recursive installation using server
-
-# ── genuine-divergence (118) ────────────────────────────────────────
+# ── genuine-divergence (1) ────────────────────────────────────────
 # GENUINE nub<->pnpm divergence worth fixing — NOT buried; tracked in pnpm-conformance-divergences (D1-D7) + pnpm-conformance-99. Remove the entry (or regenerate) when the divergence is fixed.
---save-catalog adds catalogs to the manifest of a multi-lockfile workspace
---save-catalog adds catalogs to the manifest of a shared lockfile workspace
---save-catalog adds catalogs to the manifest of a single package workspace
---save-catalog creates new workspace manifest with the new catalog (recursive add)
---save-catalog does not affect new dependencies from package.json
---save-catalog does not overwrite existing catalogs
---save-catalog-name
-`pnpm recursive rebuild` specific dependencies
-adding new dep does not fail if node_modules was created with --public-hoist-pattern=eslint-*
-adding or changing pnpmfile should change pnpmfileChecksum and module structure
-automatically loading pnpmfile from a config dependency that has a name that starts with "@pnpm/plugin-"
-bin files are found by lifecycle scripts
-changed-files-ignore-pattern is respected
-command does not fail when a deprecated option is used
-command does not fail when deprecated options are used
-create a package.json if there is none
-custom fetcher can call default fetcher
-deduplicate packages that have peers, when adding new dependency in a workspace
-deep update
-deleting node_modules after install
-dependencies of workspace projects are built during headless installation
-dependency should not be added to package.json and lockfile if it was not built successfully
-directories and symlinks
-dlx creates cache and store prune cleans cache
-dlx should ignore non-auth info from .npmrc in the current directory
-don't fail on case insensitive filesystems when package has 2 files with same name
-failed to install dependencies
-filter scripts
-filtered install
-hoisted node linker and node_modules not exist (#9424)
-ignore .pnpmfile.cjs during update when --ignore-pnpmfile is used
-ignore .pnpmfile.cjs when --ignore-pnpmfile is used
-importPackage hooks
-install with external lockfile directory
-install with package-lock=false in .npmrc
-installation fails when the stored package name and version do not match the meta of the installed package
-installing optional dependencies when --no-optional is not used
-lifecycle script runs with the correct user agent
-loading a pnpmfile from a config dependency
-multi-project workspace
-multiple lockfiles
-nested `pnpm run` should not check for mutated manifest
-not installing optional dependencies when --no-optional is used
-not top-level packages should find the plugins they use
-overrides in workspace project should be taken into account when shared-workspace-lockfiles is false
-parallel dlx calls of the same package
-partial update --latest in a workspace should not affect other packages when dedupe-peer-dependents is true
-partial update in a workspace should work with dedupe-peer-dependents is true
-peer dependency is not unlinked when adding a new dependency
-peer dependents deduplication should not remove peer dependencies
-pnpm fails when an unsupported command is used
-pnpm recursive run finds bins from the root of the workspace
-pnpm run with preferSymlinkedExecutables and custom virtualStoreDir
-pnpm run with preferSymlinkedExecutables true
-pnpm sees the bins from the root of the workspace
-pnpmfile: pass log function to readPackage hook
-pnpmfile: run afterAllResolved hook
-pnpmfile: run async afterAllResolved hook
-pnpx works
-preResolution hook
-read settings from pnpm-workspace.yaml
-readPackage async hook
-readPackage hook
-readPackage hook during update
-readPackage hook from custom location
-readPackage hook from pnpmfile at root of workspace
-readPackage hook in monorepo doesn't modify manifest
-readPackage hook in single project doesn't modify manifest
-readPackage hook is used during removal inside a workspace
-readPackage hook normalizes the package manifest
-recursive command with filter from config
-recursive install with link-workspace-packages and shared-workspace-lockfile
-recursive installation of packages with hooks
-recursive installation with package-specific .npmrc
-recursive installation with shared-workspace-lockfile and a readPackage hook
-recursive test: pass the args to the command that is specified in the build script of a package.json manifest
-recursive update
-recursive update --latest --prod on projects that do not share a lockfile
-recursive update --latest --prod on projects with a shared a lockfile
-recursive update --latest on projects that do not share a lockfile
-recursive update --latest on projects with a shared a lockfile
-recursive update --latest specific dependency on projects that do not share a lockfile
-recursive update --latest specific dependency on projects with a shared a lockfile
-recursive update --no-save
-recursive update --no-shared-workspace-lockfile
-run --reporter-hide-prefix should hide prefix
-run --stream should prefix with dir name
-run -r: pass the args to the command that is specified in the build script
-run js bin file
-selectively allow scripts in some dependencies by --allow-build flag
-selectively allow scripts in some dependencies by onlyBuiltDependenciesFile
-shamefully hoist the dependency graph
-shamefully-hoist: applied to all the workspace projects when set to true in the root pnpm-workspace.yaml file
-shamefully-hoist: applied to all the workspace projects when set to true in the root pnpm-workspace.yaml file (with dedupe-direct-deps=true)
-should check for outdated catalogs
-should print error summary when some packages fail with --no-bail
-should print json format error when add dependency on workspace root
-should use default fetchers if no custom fetchers are defined
-single dependency
-single package workspace
-the list of ignored builds is preserved after a repeat install
-top-level packages should find the plugins they use
-update
-update --latest
-update --latest --prod
-update --latest --save-exact
-update --latest specific dependency
-update --no-save
-update <dep>
-update to latest recursive workspace (outdated, updated, prerelease, outdated)
-update to latest recursive workspace (prerelease, outdated)
-update to latest without downgrading already defined prerelease (#7436)
-update with tag @latest will downgrade prerelease
-verify-deps-before-run=install reuses the same flags as specified by the workspace state (#9109)
-when prefer offline is used, meta from store is used, where latest might be out-of-date
-with sync-injected-deps-after-scripts
-without sync-injected-deps-after-scripts
-workspace .npmrc is always read
+pnpm with current runs the currently active pnpm even when the project pins a different version


### PR DESCRIPTION
Post-#247 follow-up. Regenerates allowlist from CI run [28470440163](https://github.com/nubjs/nub/actions/runs/28470440163) at pnpm 11.3.0.

201 lines → 36 lines: genuine-divergence 118 → 1; node-provisioning, server, supported-arch, patch-config-deps, and infra-* buckets all → 0; global-layout 12 → 2; version-switching 3 → 7 (pnpm 11 added devEngines.packageManager tests).

Test-harness only — no code changes.