### PR TITLE
feat(runtime): publish process.versions.nub self-identification marker

### DIFF
--- a/crates/nub-cli/tests/process_versions_nub.rs
+++ b/crates/nub-cli/tests/process_versions_nub.rs
@@ -1,0 +1,99 @@
+//! `process.versions.nub` — the self-identification marker.
+//!
+//! Augmented `nub` publishes `process.versions.nub` = the running binary's
+//! version, following the universal `process.versions.<runtime>` convention
+//! (cf. `.bun`, `.electron`) so tooling can detect "running under nub". The
+//! value is sourced from the binary itself (`env!("CARGO_PKG_VERSION")`, carried
+//! to the preload via the internal `__NUB_VERSION` env var), so this test asserts
+//! it against the same constant the binary was built with.
+//!
+//! The marker is present ONLY when augmentation is active (the preload runs).
+//! Under `--node` / `NODE_COMPAT` no preload runs, so it is correctly absent —
+//! the plain-Node fingerprint. The mechanism is tier-independent (both preload
+//! entries call the same installer), so this host-node test covers whichever
+//! tier the runner's Node falls on.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/ or release/
+    path.push("nub");
+    path
+}
+
+fn fixture() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    Path::new(&manifest).join("../../tests/fixtures/process-versions/versions.js")
+}
+
+/// Run the fixture under `nub [extra_args] [env]` and parse its JSON.
+fn run(extra_args: &[&str], env: &[(&str, &str)]) -> serde_json::Value {
+    let f = fixture();
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(extra_args)
+        .arg(&f)
+        .current_dir(f.parent().unwrap());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("failed to spawn nub");
+    assert!(
+        output.status.success(),
+        "nub exited {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+        .expect("fixture must emit valid JSON")
+}
+
+/// Augmented run: the marker equals the binary's version and mirrors the shape
+/// of Node's native `process.versions` entries (enumerable, configurable,
+/// non-writable).
+#[test]
+fn augmented_publishes_binary_version() {
+    let v = run(&[], &[]);
+    assert_eq!(
+        v["nub"].as_str(),
+        Some(env!("CARGO_PKG_VERSION")),
+        "process.versions.nub must equal the running binary's version"
+    );
+
+    let desc = &v["desc"];
+    assert_eq!(
+        desc["writable"], false,
+        "match native entries: non-writable"
+    );
+    assert_eq!(desc["enumerable"], true, "match native entries: enumerable");
+    assert_eq!(
+        desc["configurable"], true,
+        "match native entries: configurable"
+    );
+}
+
+/// `--node` disables augmentation (no preload), so the marker is absent — the
+/// plain-Node fingerprint a tool checking `process.versions.nub` should see.
+#[test]
+fn node_compat_flag_omits_marker() {
+    let v = run(&["--node"], &[]);
+    assert!(
+        v["nub"].is_null(),
+        "--node must not publish process.versions.nub, got {:?}",
+        v["nub"]
+    );
+}
+
+/// `NODE_COMPAT=1` is the persistent, tree-wide augmentation opt-out; same
+/// contract as `--node` — the marker is absent.
+#[test]
+fn node_compat_env_omits_marker() {
+    let v = run(&[], &[("NODE_COMPAT", "1")]);
+    assert!(
+        v["nub"].is_null(),
+        "NODE_COMPAT=1 must not publish process.versions.nub, got {:?}",
+        v["nub"]
+    );
+}

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -547,6 +547,12 @@ pub fn spawn_node(config: &SpawnConfig<'_>) -> Result<SpawnResult> {
             cmd.arg("--require").arg(pnp);
         }
 
+        // `process.versions.nub` source: hand the running binary's version to the
+        // preload so it can publish the self-identification marker. Coupled to the
+        // preload injection below — both live in this augment block, so `--node`
+        // and re-entrant child shells skip it for free.
+        cmd.env(VERSION_ENV, env!("CARGO_PKG_VERSION"));
+
         // Preload injection: `--require <cjs-path>` (fast tier) or `--import <url>`
         // (compat tier). See PreloadInjection for why the channel is tier-specific.
         if let Some(ref inj) = injection {
@@ -1251,6 +1257,18 @@ fn should_neutralize_localstorage(
 /// brand boundary. The preload deletes it after reading so it does not leak to
 /// grandchild processes.
 pub(crate) const NEUTRALIZE_LOCALSTORAGE_ENV: &str = "__NUB_NEUTRALIZE_LOCALSTORAGE";
+
+/// Carries the running binary's version (`env!("CARGO_PKG_VERSION")`) to the
+/// preload, which publishes it as `process.versions.nub` — the universal
+/// `process.versions.<runtime>` self-identification marker (cf. `.bun`,
+/// `.electron`) that lets tooling detect "running under nub". Set only inside the
+/// augment block, coupled to preload injection: under `--node`/`NODE_COMPAT` no
+/// preload runs and the var is unset, so the marker is correctly absent (plain
+/// Node). An internal `__NUB_*` plumbing var, NOT a user knob — explicitly
+/// permitted by the brand boundary. Unlike the localStorage signal it is NOT
+/// deleted by the preload, so it inherits into augmented descendants (which run
+/// the same preload via NODE_OPTIONS) and they advertise the marker too.
+pub(crate) const VERSION_ENV: &str = "__NUB_VERSION";
 
 /// Whether Node's test-runner coverage is active for this invocation — i.e. the
 /// user passed `--experimental-test-coverage` directly in argv or via NODE_OPTIONS.

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -20,6 +20,10 @@ const { readdirSync, existsSync } = require("node:fs");
 const { fileURLToPath, pathToFileURL } = require("node:url");
 const { join, dirname, extname: pathExtname } = require("node:path");
 
+// Internal `__NUB_*` plumbing var carrying the running binary's version (set by
+// the Rust spawn layer, coupled to preload injection). Read by installVersionMarker.
+const VERSION_ENV = "__NUB_VERSION";
+
 // ── data: URL unknown-format fidelity helpers ───────────────────────
 // Mirror Node's internal/modules/esm/get_format.js so nub's sync registerHooks load
 // hook surfaces ERR_UNKNOWN_MODULE_FORMAT for an unsupported `data:` MIME exactly as
@@ -1180,7 +1184,30 @@ function reenableUserCompileCache() {
   try { module_.enableCompileCache(dir); } catch {}
 }
 
+// Publish `process.versions.nub` = the running binary's version — the universal
+// `process.versions.<runtime>` self-identification convention (cf. `.bun`,
+// `.electron`). A read-only DETECTION marker, never an importable/callable API.
+// The value comes from the Rust spawn layer's `__NUB_VERSION` (env!("CARGO_PKG_VERSION"),
+// coupled to preload injection), so it always matches the running binary; under
+// `--node`/`NODE_COMPAT` no preload runs and the var is unset, so the marker is
+// absent (plain-Node fingerprint). Shape mirrors Node's own `process.versions`
+// entries: enumerable + configurable + non-writable. Called once per main-thread
+// preload entry (fast + compat), so a single mechanism covers both tiers.
+function installVersionMarker() {
+  const v = process.env[VERSION_ENV];
+  if (!v) return;
+  try {
+    Object.defineProperty(process.versions, "nub", {
+      value: v,
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+  } catch {}
+}
+
 module.exports = {
+  installVersionMarker,
   installWatchReporting,
   registerLoaderWorker,
   makeHooks,

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -49,6 +49,9 @@ const __require = createRequire(__filename);
 // configured from the stripped env), so the chain below stays uncached.
 const common = __require("./preload-common.cjs");
 common.restoreCompileCacheEnv();
+// Publish process.versions.nub (self-identification marker) before user code runs.
+// Tier-independent — same call in the compat entry (preload.mjs).
+common.installVersionMarker();
 
 // `--no-experimental-require-module` disables require(esm) globally, so the
 // transform-core require below (and the worker/locks ESM side-effect modules)

--- a/runtime/preload.mjs
+++ b/runtime/preload.mjs
@@ -46,6 +46,10 @@ const __require = createRequire(import.meta.url);
 const common = __require("./preload-common.cjs");
 const { installSyncPolyfills } = __require("./polyfills.cjs");
 
+// Publish process.versions.nub (self-identification marker) before user code runs.
+// Tier-independent — same call in the fast entry (preload.cjs).
+common.installVersionMarker();
+
 // ── Tier detection ──────────────────────────────────────────────────
 // This `.mjs` preload should only ever be `--import`ed for the compat tier (the
 // Rust spawn path chooses `--require preload.cjs` for 22.15+). But guard anyway: if

--- a/tests/fixtures/process-versions/versions.js
+++ b/tests/fixtures/process-versions/versions.js
@@ -1,0 +1,11 @@
+// Emits the nub self-identification marker on stdout as JSON so the test can
+// assert without text-matching fragility. `nub` is null when the marker is
+// absent (e.g. under `--node`/`NODE_COMPAT`, where the preload doesn't run).
+// `desc` captures the property shape so the test can verify it mirrors Node's
+// own `process.versions` entries (enumerable, configurable, non-writable).
+const d = Object.getOwnPropertyDescriptor(process.versions, "nub");
+const out = {
+  nub: process.versions.nub ?? null,
+  desc: d ? { writable: d.writable, enumerable: d.enumerable, configurable: d.configurable } : null,
+};
+process.stdout.write(JSON.stringify(out) + "\n");


### PR DESCRIPTION
Augmented `nub` sets `process.versions.nub` to the binary's version, so tooling can detect "running under nub" like `process.versions.bun` / `.electron`. Read-only marker, not an importable API.

The Rust spawn layer passes `env!("CARGO_PKG_VERSION")` to the shared preload via the internal `__NUB_VERSION` var (coupled to preload injection); published with `Object.defineProperty` matching Node's native entries (enumerable, configurable, non-writable), both tiers. Absent under `--node`/`NODE_COMPAT`.

Verified on Node 26/20.19/18.19; absent under `--node` and `NODE_COMPAT=1`. Test: `process_versions_nub.rs`.