### PR TITLE
fix(node): stop auto-injecting --experimental-shadow-realm (Electron crash #246)

### DIFF
--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -149,23 +149,28 @@ pub static FEATURES: &[Feature] = &[
         )],
         evidence: "flag added Node 9.6.0 (#14253); never unflagged through Node 26",
     },
-    // ── ShadowRealm global ──────────────────────────────────────────────────
-    // `--experimental-shadow-realm` gates `globalThis.ShadowRealm` (TC39 Stage 3:
-    // an isolated global with fresh intrinsics). The flag was added in Node
-    // 18.13.0 / 19.0.0 — below nub's 18.19 floor — and has NEVER been made
-    // default-on through Node 26 (still experimental, rides the V8
-    // `--harmony-shadow-realm` staging). So, like vm-modules, inject across the
-    // ENTIRE supported floor: [18.19.0, ∞). It survives as an accepted bool at
-    // every higher version, so the open-ended band never over-injects into an
-    // unsupported range.
-    Feature {
-        name: "shadow-realm",
-        mitigations: &[(
-            band((18, 19, 0), None),
-            Mitigation::Unflag("--experimental-shadow-realm"),
-        )],
-        evidence: "flag added Node 18.13.0/19.0.0; never default-on through 26 (TC39 Stage 3)",
-    },
+    // ── ShadowRealm — DELIBERATELY NOT AUTO-UNFLAGGED (the harmony-flag policy) ──
+    // POLICY (load-bearing — enforced by `no_v8_harmony_flag_in_unflag_set` and
+    // listed in V8_HARMONY_UNFLAG_DENYLIST below): nub NEVER auto-injects a V8
+    // *harmony* / startup-snapshot-affecting flag into the tree-wide NODE_OPTIONS.
+    // `--experimental-shadow-realm` implies V8's `--harmony-shadow-realm`, which is
+    // part of the isolate's V8-flag hash. NODE_OPTIONS is inherited by the WHOLE
+    // process subtree, including EMBEDDED Node runtimes that boot from a V8 context
+    // SNAPSHOT (Electron). When the runtime V8-flag hash ≠ the snapshot's, V8's
+    // `Context::FromSnapshot` returns empty and `node::CreateEnvironment` aborts on a
+    // failed CHECK — an EXC_BREAKPOINT/SIGTRAP crash BEFORE any preload JS runs, so
+    // no in-process self-disable can catch it (issue #246: Electron 42.5.1 / Node
+    // 24.17 / V8 14.8 crashed deterministically on this flag alone; Electron 37 /
+    // V8 13.8 tolerated it — the breakage is V8-snapshot-version-dependent, which is
+    // exactly why this is a categorical ban, not a per-version carve-out). Node
+    // itself rejects the same flag in Worker execArgv (ERR_WORKER_INVALID_EXEC_ARGV);
+    // runtime/worker-polyfill.mjs already strips it for the same harmony reason.
+    // Only snapshot-NEUTRAL Node feature flags (vm-modules, eventsource, sqlite, …)
+    // are safe to auto-unflag. The cost of NOT injecting: `globalThis.ShadowRealm`
+    // (TC39 Stage 3) is no longer auto-provided — deferred until Node ships it
+    // default-on, at which point no flag is needed and the snapshot hazard is gone.
+    // Full rationale + evidence: wiki/runtime/harmony-flag-policy.md.
+    //
     // ── EventSource global ──────────────────────────────────────────────────
     // #51575 ("add EventSource Client"). Landed on the 22.x line at 22.3.0 and was
     // backported to the 20.x LTS line at 20.18.0. The 21.x line was already EOL
@@ -546,6 +551,16 @@ pub static FEATURES: &[Feature] = &[
     },
 ];
 
+/// V8 *harmony* / startup-snapshot-affecting flags that must NEVER appear in the
+/// auto-unflag set (the harmony-flag policy — see the ShadowRealm note in
+/// [`FEATURES`] and wiki/runtime/harmony-flag-policy.md). These imply a V8
+/// `--harmony-*` staging flag that changes the isolate's V8-flag hash; injected
+/// into the tree-wide NODE_OPTIONS they crash any embedded Node that boots from a
+/// V8 context snapshot (Electron) in `Context::FromSnapshot` → `CreateEnvironment`,
+/// before any preload JS can intervene (#246). The
+/// `no_v8_harmony_flag_in_unflag_set` test enforces this against the whole matrix.
+pub const V8_HARMONY_UNFLAG_DENYLIST: &[&str] = &["--experimental-shadow-realm"];
+
 /// Look up a feature row by name (used by the webstorage-predicate derivation in
 /// [`super::flags`]). Panics if the name is absent — it is only ever called with
 /// a literal that must exist in [`FEATURES`], so an absent name is a programming
@@ -721,10 +736,11 @@ mod tests {
         // vm-modules: whole floor.
         assert!(unflag_flags_for(&v(18, 19, 0)).contains(&"--experimental-vm-modules"));
         assert!(unflag_flags_for(&v(26, 2, 0)).contains(&"--experimental-vm-modules"));
-        // shadow-realm: whole floor, open-ended (never default-on).
-        assert!(unflag_flags_for(&v(18, 19, 0)).contains(&"--experimental-shadow-realm"));
-        assert!(unflag_flags_for(&v(22, 19, 0)).contains(&"--experimental-shadow-realm"));
-        assert!(unflag_flags_for(&v(26, 0, 0)).contains(&"--experimental-shadow-realm"));
+        // shadow-realm: DELIBERATELY never injected (the harmony-flag policy —
+        // it crashes embedded-Node/Electron via a snapshot-flag-hash mismatch, #246).
+        assert!(!unflag_flags_for(&v(18, 19, 0)).contains(&"--experimental-shadow-realm"));
+        assert!(!unflag_flags_for(&v(22, 19, 0)).contains(&"--experimental-shadow-realm"));
+        assert!(!unflag_flags_for(&v(26, 0, 0)).contains(&"--experimental-shadow-realm"));
         // eventsource: the 21.x hole.
         assert!(!unflag_flags_for(&v(21, 0, 0)).contains(&"--experimental-eventsource"));
         assert!(unflag_flags_for(&v(20, 18, 0)).contains(&"--experimental-eventsource"));
@@ -764,6 +780,37 @@ mod tests {
         assert!(unflag_flags_for(&v(22, 4, 0)).contains(&"--experimental-webstorage"));
         assert!(unflag_flags_for(&v(24, 99, 0)).contains(&"--experimental-webstorage"));
         assert!(!unflag_flags_for(&v(25, 0, 0)).contains(&"--experimental-webstorage"));
+    }
+
+    #[test]
+    fn no_v8_harmony_flag_in_unflag_set() {
+        // The harmony-flag policy, enforced (not just documented): no flag in
+        // V8_HARMONY_UNFLAG_DENYLIST may ever appear in the auto-unflag set, at ANY
+        // version. Such flags imply a V8 `--harmony-*` staging flag that changes the
+        // isolate's V8-flag hash and crashes embedded Node booting from a context
+        // snapshot (Electron) in CreateEnvironment, before any preload JS — #246.
+        // Sweep the whole supported range plus the boundary majors so a future matrix
+        // edit that re-adds shadow-realm (or any other harmony flag) trips here.
+        let versions = [
+            v(18, 19, 0),
+            v(20, 18, 0),
+            v(22, 15, 0),
+            v(23, 6, 0),
+            v(24, 17, 0),
+            v(25, 0, 0),
+            v(26, 2, 0),
+        ];
+        for ver in versions {
+            let set = unflag_flags_for(&ver);
+            for &banned in V8_HARMONY_UNFLAG_DENYLIST {
+                assert!(
+                    !set.contains(&banned),
+                    "harmony-flag policy violated: {banned:?} is auto-unflagged at Node {ver:?} \
+                     — it crashes embedded Node (Electron) via a snapshot-flag-hash mismatch (#246). \
+                     See the ShadowRealm note in FEATURES + wiki/runtime/harmony-flag-policy.md."
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -396,13 +396,17 @@ mod tests {
     }
 
     #[test]
-    fn shadow_realm_injected_across_the_whole_floor() {
-        // ShadowRealm: flag exists from 18.13/19.0 (below the floor), never made
-        // default-on through Node 26 (TC39 Stage 3). Inject from 18.19 to infinity.
+    fn shadow_realm_never_injected() {
+        // ShadowRealm is DELIBERATELY not auto-unflagged (the harmony-flag policy):
+        // `--experimental-shadow-realm` implies V8's `--harmony-shadow-realm`, which
+        // changes the isolate's V8-flag hash and crashes embedded Node booting from a
+        // context snapshot (Electron) in CreateEnvironment — before any preload JS,
+        // so a self-disable can't catch it (#246). Never inject it, at any version.
+        // The categorical guard lives in feature_matrix (no_v8_harmony_flag_in_unflag_set).
         let s = "--experimental-shadow-realm";
-        assert!(compute_inject_flags(v(18, 19, 0), &[], None, false).contains(&s));
-        assert!(compute_inject_flags(v(22, 19, 0), &[], None, false).contains(&s));
-        assert!(compute_inject_flags(v(26, 0, 0), &[], None, false).contains(&s));
+        assert!(!compute_inject_flags(v(18, 19, 0), &[], None, false).contains(&s));
+        assert!(!compute_inject_flags(v(22, 19, 0), &[], None, false).contains(&s));
+        assert!(!compute_inject_flags(v(26, 0, 0), &[], None, false).contains(&s));
     }
 
     #[test]

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -35,6 +35,22 @@
 // test-cjs-esm-warn, test-disable-require-module-with-detection,
 // test-esm-type-field-errors-2, parallel/test-require-mjs.)
 
+// Electron self-disable (issue #246). Bail before any augmentation when this
+// preload runs inside an Electron process: the fast-tier `module.registerHooks`
+// load hook below DEADLOCKS Electron's main-process module bootstrap (the call
+// returns, then Electron's own synchronous internal module loads hang through the
+// installed hook), and Electron's app JS is pre-bundled (the bundler owns TS) so
+// nub's transpile/polyfills add nothing. `process.versions.electron` is set in
+// EVERY Electron process (main / renderer / utility / an ELECTRON_RUN_AS_NODE
+// child) and absent in plain Node, so this never fires for a normal script. This
+// is the JS half of the #246 fix; the dominant half is NOT injecting the
+// snapshot-crashing `--experimental-shadow-realm` flag (the harmony-flag policy in
+// feature_matrix), which crashes Electron BEFORE this point. Top-level `return` is
+// legal in a CommonJS module wrapper.
+if (process.versions.electron) {
+  return;
+}
+
 const { createRequire } = require("node:module");
 const module_ = require("node:module");
 

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -96,7 +96,6 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`navigator.locks`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) | — | polyfilled below Node 24.5, native above |
 | [`reportError`](https://developer.mozilla.org/en-US/docs/Web/API/Window/reportError) | — | polyfilled |
 | [`vm.Module`](https://nodejs.org/api/vm.html#class-vmmodule) | — | unflagged |
-| [`ShadowRealm`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ShadowRealm) | — | unflagged |
 | [`Wasm module imports`](https://nodejs.org/api/esm.html#wasm-modules) | — | unflagged below Node 24.5 (22.19 on the 22.x line), native above |
 | [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) | Node 20.10 | unflagged below Node 22, native above |
 | [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) | Node 20.18 | unflagged below the native line, native above |


### PR DESCRIPTION
## Problem

`nub run dev` crashes Electron immediately with `EXC_BREAKPOINT (SIGTRAP)` in `node::CreateEnvironment` (#246).

`--experimental-shadow-realm` implies V8's `--harmony-shadow-realm`, which is part of the isolate's V8-flag hash. nub injected it into the tree-wide `NODE_OPTIONS`, which is inherited by the whole process subtree — including embedded Node runtimes that boot from a V8 context snapshot, notably Electron. When the runtime flag hash differs from the snapshot's, `v8::Context::FromSnapshot` returns empty and `CreateEnvironment` aborts on a failed `CHECK`. This happens at startup, **before any `--import`/`--require` preload JS runs**, so a preload self-disable cannot prevent it.

Reproduced against the reporter's exact environment — Electron 42.5.1 (Node 24.17 / V8 14.8): `--experimental-shadow-realm` alone crashes the main process deterministically; every other flag nub injects passes. The crash is V8-snapshot-version-dependent (Electron 37 / V8 13.8 tolerated the same flag), so the fix is a categorical policy, not a per-version carve-out.

## Fix

- **Drop the ShadowRealm unflag** from `feature_matrix::FEATURES` so the flag is never injected.
- **Establish the policy:** never auto-unflag a V8 harmony / startup-snapshot-affecting flag into `NODE_OPTIONS`; only snapshot-neutral Node feature flags are eligible. Enforced by `V8_HARMONY_UNFLAG_DENYLIST` + the `no_v8_harmony_flag_in_unflag_set` guard test (a re-add trips CI), and documented at the matrix definition site.
- **Electron self-disable in the fast-tier preload** (`if (process.versions.electron) return;`): once the flag crash is removed, the preload's `module.registerHooks` load hook independently deadlocks Electron's main process. Both pieces are required for Electron to launch clean.

## Verification

- `nub run dev` → real Electron 42.5.1 now launches clean (was a deterministic SIGTRAP).
- Compat tier (host Node 20 → Electron 30) unaffected: the async `module.register` preload does not hang Electron, and no harmony flag is injected.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and the scoped `nub-core` lib tests pass.

## Tradeoff

`globalThis.ShadowRealm` (TC39 Stage 3) is no longer auto-provided; deferred until Node ships it default-on (no flag needed, no snapshot hazard). Users who want it today can pass `--experimental-shadow-realm` themselves — nub forwards user-supplied flags verbatim.

Closes #246
