### PR TITLE
cli: suggest `nub exec` for an unknown bareword binary

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1584,9 +1584,15 @@ fn run_nub() -> Result<i32> {
             if let Some(plugin_path) = plugin {
                 return launch_bin(&plugin_path, &rest[1..], compat, &cwd);
             }
+            // A bareword reaching here is not a known/conventional script (those
+            // took the `nub run` branch above) — so it's most likely a dependency
+            // binary the user meant to exec (`nub turbo login`, `nub eslint`).
+            // Lead with the `nub exec`/`nubx` hint accordingly, then the script
+            // and file fallbacks.
             bail!(
                 "nub: \"{first}\" is not a nub command — see `nub --help`\n\
-                 \x20\x20(to run a script: nub run {first} · to run a file: nub ./{first})"
+                 \x20\x20(to run a dependency's binary: nub exec {first} or nubx {first} · \
+                 to run a script: nub run {first} · to run a file: nub ./{first})"
             );
         }
     }

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -5240,6 +5240,13 @@ fn bareword_unknown_verb_errors() {
         stderr.contains("\"frobnicate\" is not a nub command"),
         "an unknown verb must error, not dispatch: {stderr}"
     );
+    // An unknown bareword is most likely a dependency binary the user meant to
+    // exec (`nub turbo login`), so the hint must point at `nub exec`/`nubx`
+    // alongside the script/file fallbacks.
+    assert!(
+        stderr.contains("nub exec frobnicate") && stderr.contains("nubx frobnicate"),
+        "the hint must suggest nub exec / nubx: {stderr}"
+    );
     assert_ne!(out.status.code(), Some(0));
 }
 


### PR DESCRIPTION
`nub turbo login` / `nub eslint` errored as not-a-nub-command and pointed only at `nub run` and `nub ./` — but a dependency binary runs via `nub exec <name>` (alias `nubx <name>`). This final bail fires only after the known-script and plugin branches, so the token is most likely a binary; the hint now leads with `nub exec`.

Before:

```
  (to run a script: nub run turbo · to run a file: nub ./turbo)
```

After:

```
  (to run a dependency's binary: nub exec turbo or nubx turbo · to run a script: nub run turbo · to run a file: nub ./turbo)
```

`bareword_unknown_verb_errors` now asserts the hint includes `nub exec`/`nubx`.