### PR TITLE
fix(exec): set npm_config_user_agent on the bin-launch path

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4409,7 +4409,11 @@ fn run_exec_with_dlx(
             if let Some(runner) = pnp_bin_runner_path() {
                 let mut cmd_args = vec![runner, bin.to_string()];
                 cmd_args.extend(args.iter().cloned());
-                return run_file_with_compat(&cmd_args, compat_mode);
+                // This is still a bin LAUNCH (a PnP-resolved local bin), so it
+                // carries `npm_config_user_agent` like the node_modules/.bin path
+                // above — `run_file_in_dir` directly (not run_file_with_compat)
+                // to pass `exec_ua=true`. `cwd` is the PnP tree already resolved.
+                return run_file_in_dir(&cmd_args, compat_mode, &cwd, true);
             }
         }
     }

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -2283,7 +2283,9 @@ fn run_file(args: &[String]) -> Result<i32> {
 
 fn run_file_with_compat(args: &[String], compat_mode: bool) -> Result<i32> {
     let cwd = env::current_dir()?;
-    run_file_in_dir(args, compat_mode, &cwd)
+    // A plain file run (`nub <file>`, the `node`-hijack descendant) — not a bin
+    // launch, so no `npm_config_user_agent` (parity with `node <file>`).
+    run_file_in_dir(args, compat_mode, &cwd, false)
 }
 
 /// Run a file with the project context (Node pin, `.env`, PnP, webstorage) and
@@ -2294,7 +2296,7 @@ fn run_file_with_compat(args: &[String], compat_mode: bool) -> Result<i32> {
 /// the member's `.env`, Node pin, and `.bin` chain — not the workspace root's. The
 /// child's cwd is set on `SpawnConfig` so the override reaches Node itself, not
 /// just nub's discovery (spawn_node otherwise inherits the parent's cwd).
-fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path) -> Result<i32> {
+fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path, exec_ua: bool) -> Result<i32> {
     // A truthy `NODE_COMPAT` forces compat tree-wide (the persistent `--node`);
     // OR it into the per-invocation bit so `NODE_COMPAT=1 nub foo.ts` /
     // `NODE_COMPAT=1 node foo.ts` (via the hijack → run_file → here) run vanilla.
@@ -2330,11 +2332,25 @@ fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path) -> Result<i32
     } else {
         Default::default()
     };
-    let env_vars = merge_child_env(
+    let mut env_vars = merge_child_env(
         auto_env,
         env_file_flag_present(),
         ENV_FILE_VARS.get().unwrap_or(&HashMap::new()),
     );
+
+    // Bin-exec parity with `nub run`: when this spawn is nub LAUNCHING a resolved
+    // node bin (a `nubx`/`nub exec` scaffolder — `exec_ua`), set the same role-
+    // aware `npm_config_user_agent` the run path emits so the tool detects nub as
+    // the invoking PM. Not set for a plain `nub <file>` run (`exec_ua == false`),
+    // matching `node <file>`, which leaves it undefined; skipped in compat mode
+    // (`--node` = vanilla). nub's value overrides an inherited one — nub is the
+    // running PM here, exactly as the run path overrides it.
+    if exec_ua && !compat_mode {
+        env_vars.insert(
+            "npm_config_user_agent".to_string(),
+            exec_user_agent(cwd, &node.version.to_string()),
+        );
+    }
 
     let nub_binary = nub_core::node::spawn::current_nub_binary()?;
     // Yarn PnP: inject the user's own `.pnp.cjs` (spawn.rs gates this on
@@ -4491,8 +4507,10 @@ fn launch_bin(bin_path: &Path, args: &[String], compat_mode: bool, cwd: &Path) -
         // passes each member's dir so the node bin sees the member's `.env` / Node
         // pin / `.bin` chain. The single-package path passes the process cwd (a
         // no-op override). run_file_in_dir threads cwd onto SpawnConfig so the
-        // child's working directory is set, not just nub's discovery.
-        return run_file_in_dir(&cmd_args, compat_mode, cwd);
+        // child's working directory is set, not just nub's discovery. `true` =
+        // this is a bin LAUNCH, so it carries `npm_config_user_agent` (the non-
+        // node branch below sets it via apply_exec_augmentation).
+        return run_file_in_dir(&cmd_args, compat_mode, cwd, true);
     }
 
     let mut cmd = bin_launcher(bin_path, args);
@@ -4567,6 +4585,17 @@ fn bin_launcher(path: &Path, args: &[String]) -> std::process::Command {
     c
 }
 
+/// The `npm_config_user_agent` value nub emits when it LAUNCHES a bin/tool
+/// (`nubx`, `nub exec`, a workspace-bin run), reusing the same role-aware
+/// composer + platform tail as the `nub run` / lifecycle paths — no second
+/// hardcoded format. `nub/<v> npm/? …` under nub identity / fresh, incumbent-
+/// first (`pnpm/<pin> nub/<v> …`) in a compat project. `node_version` is the
+/// caller's already-resolved Node so this does not re-discover it.
+fn exec_user_agent(cwd: &Path, node_version: &str) -> String {
+    let product = crate::pm_engine::run_lifecycle_ua_product(cwd, node_version);
+    nub_core::workspace::scripts::user_agent_string(&product)
+}
+
 /// Apply nub's augmentation env (NODE_OPTIONS preload + PATH shim + `.bin`
 /// chain) to a non-node launcher, so any `node` the tool spawns is transpile-
 /// enabled — the same env `nub run` gives a script. No-op if augmentation can't
@@ -4577,6 +4606,16 @@ fn apply_exec_augmentation(cmd: &mut std::process::Command, cwd: &Path) {
     };
     let node = nub_core::node::discovery::discover_node(cwd)
         .unwrap_or_else(|_| nub_core::node::discovery::ResolvedNode::fallback());
+    // Exec-path parity with `nub run`/lifecycle: a launched non-node bin (a
+    // create-* scaffolder, a tool that shells out) must see the same role-aware
+    // `npm_config_user_agent` so it detects nub as the invoking PM instead of a
+    // blank value (which the whitelist detectors fall back to npm on). Set before
+    // the preload early-return below — the UA is independent of whether the
+    // transpile preload was found.
+    cmd.env(
+        "npm_config_user_agent",
+        exec_user_agent(cwd, &node.version.to_string()),
+    );
     let pnp_ctx = nub_core::pnp::detect(cwd);
     let Some(aug) = nub_core::node::spawn::compute_augmentation_env(
         &nub_binary,

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -3468,6 +3468,107 @@ fn exec_runs_node_and_non_node_bins() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
+/// `nub exec`/`nubx` must set the same role-aware `npm_config_user_agent` as
+/// `nub run` (regression guard for the exec-path gap where a launched bin saw a
+/// blank UA and `create-*` scaffolders fell back to detecting nub as npm).
+/// Covers BOTH `launch_bin` branches — a node `.bin` (spawned via `node <bin>`)
+/// and a non-node `.bin` (execed directly with `apply_exec_augmentation`) — plus
+/// role-awareness (fresh nub-identity leads `nub/`, a pnpm incumbent leads
+/// `pnpm/`) and the compat gate (`--node` leaves it unset, matching vanilla
+/// `node <file>`). Unix-only for the same reason as the sibling A40 test: the
+/// fixtures are POSIX shebang scripts; the Windows `.cmd` path rides CI.
+#[cfg(unix)]
+#[test]
+fn exec_bin_reports_role_aware_user_agent() {
+    use std::os::unix::fs::PermissionsExt;
+    let nub_version = env!("CARGO_PKG_VERSION");
+    let base = std::env::temp_dir().join(format!("nub-exec-ua-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+
+    // A project dir with a local node .bin and non-node .bin, each printing the
+    // UA the launched tool sees. `manifest_extra`/`lockfile` set the PM identity.
+    let make_project = |name: &str, manifest_extra: &str, lockfile: Option<(&str, &str)>| {
+        let dir = base.join(name);
+        let bin = dir.join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let write_exec = |path: std::path::PathBuf, body: &str| {
+            std::fs::write(&path, body).unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        };
+        write_exec(
+            bin.join("printua"),
+            "#!/usr/bin/env node\nprocess.stdout.write(process.env.npm_config_user_agent || '<unset>');\n",
+        );
+        write_exec(
+            bin.join("shprintua"),
+            "#!/bin/sh\nprintf '%s' \"${npm_config_user_agent:-<unset>}\"\n",
+        );
+        std::fs::write(
+            dir.join("package.json"),
+            format!(r#"{{ "name": "{name}", "version": "1.0.0"{manifest_extra} }}"#),
+        )
+        .unwrap();
+        if let Some((lock_name, lock_body)) = lockfile {
+            std::fs::write(dir.join(lock_name), lock_body).unwrap();
+        }
+        dir
+    };
+    let exec_ua = |dir: &std::path::Path, extra_args: &[&str], bin: &str| -> String {
+        let mut args = vec!["exec"];
+        args.extend_from_slice(extra_args);
+        args.push(bin);
+        let out = Command::new(nub_binary())
+            .args(&args)
+            .current_dir(dir)
+            .env("XDG_CACHE_HOME", unique_test_cache())
+            .output()
+            .expect("failed to spawn nub exec");
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "nub exec {bin} exited non-zero: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    // Fresh / nub-identity → nub-first, on BOTH branches.
+    let fresh = make_project("fresh", "", None);
+    let fresh_prefix = format!("nub/{nub_version} npm/?");
+    let node_ua = exec_ua(&fresh, &[], "printua");
+    assert!(
+        node_ua.starts_with(&fresh_prefix) && node_ua.contains(" node/v"),
+        "node .bin exec must lead `{fresh_prefix}` with the node/v tail: {node_ua:?}"
+    );
+    let sh_ua = exec_ua(&fresh, &[], "shprintua");
+    assert!(
+        sh_ua.starts_with(&fresh_prefix),
+        "non-node .bin exec (apply_exec_augmentation) must lead `{fresh_prefix}`: {sh_ua:?}"
+    );
+
+    // pnpm incumbent → incumbent-first, nub second (role-aware, same as run).
+    let pnpm = make_project(
+        "pnpm",
+        r#", "packageManager": "pnpm@9.1.0""#,
+        Some(("pnpm-lock.yaml", "lockfileVersion: \"9.0\"\n")),
+    );
+    let pnpm_ua = exec_ua(&pnpm, &[], "printua");
+    let pnpm_prefix = format!("pnpm/9.1.0 nub/{nub_version}");
+    assert!(
+        pnpm_ua.starts_with(&pnpm_prefix),
+        "a pnpm-incumbent exec must lead `{pnpm_prefix}`: {pnpm_ua:?}"
+    );
+
+    // Compat (`--node`) is vanilla: no augmentation, so no UA — matching `node <file>`.
+    let compat_ua = exec_ua(&fresh, &["--node"], "printua");
+    assert_eq!(
+        compat_ua, "<unset>",
+        "`nub exec --node` must not set npm_config_user_agent (vanilla): {compat_ua:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
 #[test]
 fn env_disabled_under_node_flag() {
     let fixture_path = fixtures_dir().join("env-test");

--- a/crates/nub-core/src/workspace/scripts.rs
+++ b/crates/nub-core/src/workspace/scripts.rs
@@ -195,16 +195,9 @@ pub fn npm_env(
 
     env_vars.insert("npm_command".to_string(), "run-script".to_string());
 
-    // pnpm's UA shape (`<product tokens> <platform> <arch>`) so postinstall
-    // sniffers (which-pm-runs, only-allow, create-* scaffolders) parse it. The
-    // product tokens are ROLE-AWARE — composed by the PM engine and threaded in
-    // (incumbent-first in compat mode, e.g. `pnpm/9.1.0 nub/<v> node/v<ver>`;
-    // nub-first under nub identity / fresh). Platform tokens use Node's
-    // process.platform/process.arch vocabulary (darwin/win32, x64/arm64), not
-    // Rust's, so parsers see the same words npm/pnpm send.
     env_vars.insert(
         "npm_config_user_agent".to_string(),
-        format!("{user_agent_product} {} {}", node_platform(), node_arch()),
+        user_agent_string(user_agent_product),
     );
 
     if let Ok(exe) = env::current_exe() {
@@ -223,6 +216,16 @@ pub fn npm_env(
     );
 
     env_vars
+}
+
+/// The full `npm_config_user_agent` value: role-aware product tokens plus the
+/// `<platform> <arch>` tail in Node's `process.platform`/`process.arch`
+/// vocabulary (darwin/win32, x64/arm64) so postinstall sniffers (which-pm-runs,
+/// only-allow, create-* scaffolders) parse one shape regardless of which nub
+/// surface — `run`, lifecycle, or bin-exec — emitted it. The single source of
+/// truth for the UA format; callers supply only the composed product tokens.
+pub fn user_agent_string(product: &str) -> String {
+    format!("{product} {} {}", node_platform(), node_arch())
 }
 
 /// Node's `process.platform` vocabulary for the UA string (`darwin`, `win32`,


### PR DESCRIPTION
`nubx` / `nub exec` launched a bin without `npm_config_user_agent`, so `create-*` scaffolders detected nub as npm. The run and lifecycle paths already set a role-aware UA; the bin-launch path did not.

Both `launch_bin` branches now set it, reusing `run_lifecycle_ua_product` + a shared `scripts::user_agent_string` helper: `nub/<v> npm/? …` under nub identity, incumbent-first (`pnpm/<pin> nub/<v> …`) in a compat project. A plain `nub <file>` run and compat mode (`--node`/`NODE_COMPAT`) stay unset. New test `exec_bin_reports_role_aware_user_agent`.

Out of scope: the engine dlx path (`nub x`/`dlx`/`create`, in aube's `exec_bin`) still lacks it — an aube-side follow-up.