### PR TITLE
fix(worker): inbound message event.target is self, not null

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -2632,6 +2632,29 @@ fn worker_message_roundtrip() {
 }
 
 #[test]
+fn worker_inbound_message_target_is_self() {
+    // WHATWG DedicatedWorkerGlobalScope: an inbound `message` event's `target` and
+    // `currentTarget` are `self` (browsers + Deno agree). The polyfill's worker-side
+    // scope used to hand-invoke the listener with a constructed MessageEvent that
+    // never went through EventTarget dispatch, so both were `null`. Both observation
+    // channels — `addEventListener('message')` and `self.onmessage` — must now see
+    // `=== self`, over the ONE shared event, in registration order.
+    let (stdout, stderr, code) = run_nub("worker", "event-target-self-main.ts");
+    assert_eq!(code, 0, "target-self worker should complete: {stderr}");
+    assert!(
+        stdout.contains("add:target=true:currentTarget=true:type=message:data=ping"),
+        "addEventListener('message') must see target/currentTarget === self: {stdout}"
+    );
+    assert!(
+        stdout.contains(
+            "onmessage:target=true:currentTarget=true:type=message:data=ping:sawAdd=true"
+        ),
+        "self.onmessage must see target/currentTarget === self, after the earlier-\
+         registered addEventListener listener: {stdout}"
+    );
+}
+
+#[test]
 fn worker_throw_surfaces_to_parent_onerror() {
     // A worker that throws at top level must surface as an ErrorEvent on the
     // parent's `Worker.onerror`, and the parent must NOT crash. Below Node 26

--- a/runtime/worker-polyfill.mjs
+++ b/runtime/worker-polyfill.mjs
@@ -547,19 +547,33 @@ if (!isMainThread && parentPort) {
     });
   }
 
-  // `message`/`messageerror` are DELEGATED straight onto the native `parentPort`
-  // (a real Node MessagePort) so Node's own C++ event-loop ref-counting governs
-  // worker lifetime: a worker that never listens leaves parentPort with no
-  // listeners → Node unrefs it → the worker exits naturally (matching
-  // `node:worker_threads` and Bun); a worker listening via `self.onmessage` /
-  // `addEventListener("message", …)` refs it → stays alive. Node reflects
-  // `{once}`/`{signal}`/last-listener removal in the loop ref-count in C++,
-  // which no userland counter can observe. (Earlier this block eagerly held a
-  // `parentPort.on("message")` forwarder, which kept EVERY worker's event loop
-  // alive → pure `parentPort` workers that should exit hung forever. See
-  // wiki/research/worker-polyfill.md §4.) All OTHER event types go to a private
-  // EventTarget (additive; no globalThis prototype re-parenting — `event.target`
-  // is that private target, the documented minor divergence).
+  // `message`/`messageerror` are DELEGATED onto the native `parentPort` (a real
+  // Node MessagePort) so Node's own C++ event-loop ref-counting governs worker
+  // lifetime: a worker that never listens leaves parentPort with no listeners →
+  // Node unrefs it → the worker exits naturally (matching `node:worker_threads`
+  // and Bun); a worker listening via `self.onmessage` / `addEventListener` refs
+  // it → stays alive. (Earlier this block eagerly held a `parentPort.on("message")`
+  // forwarder that kept EVERY worker's loop alive → pure `parentPort` workers that
+  // should exit hung forever. See wiki/research/worker-polyfill.md §4.)
+  //
+  // DISPATCH THROUGH A REAL EventTarget (`inbound`), not a hand-invoked callback:
+  // an inbound event MUST have `event.target === self` and `event.currentTarget
+  // === self` per WHATWG DedicatedWorkerGlobalScope (browsers + Deno agree) — the
+  // old path `cb.call(scope, new MessageEvent(...))` never went through dispatch,
+  // so both stayed null. We can't make globalThis a genuine EventTarget without
+  // prototype re-parenting (a plain object has no [[EventTargetData]] slot, so a
+  // native dispatch keyed on it is impossible), so we dispatch on a private
+  // EventTarget and SHADOW `target`/`currentTarget` = self as own data properties
+  // on the event (they override Event.prototype's accessors; native dispatch still
+  // drives ordering / stopImmediatePropagation over the ONE shared event object).
+  //
+  // REF-COUNTING is preserved by mediating every add/remove and implementing
+  // `{once}`/`{signal}` OURSELVES (not via native EventTarget options), so every
+  // removal — including once-fire and signal-abort — routes through our count and
+  // attaches/detaches the SINGLE parentPort forwarder per type exactly on the
+  // 0↔1 boundary. All OTHER (custom) event types still go to a separate private
+  // EventTarget (`other`); a user-dispatched event's `target` is that private
+  // target — the documented minor divergence, unchanged here.
   const other = new EventTarget();
   const otherAdd =
     typeof scope.addEventListener === "function"
@@ -575,35 +589,66 @@ if (!isMainThread && parentPort) {
       : other.dispatchEvent.bind(other);
 
   const DELEGATED = new Set(["message", "messageerror"]);
-  // user listener → its parentPort wrapper (per delegated event), so
-  // removeEventListener detaches the exact wrapper Node registered.
-  const wrappers = { message: new Map(), messageerror: new Map() };
+  const inbound = new EventTarget();
+  // Per delegated type: the single parentPort forwarder + a live listener count,
+  // so parentPort holds a listener iff ≥1 user listener exists (worker lifetime).
+  const portState = {
+    message: { count: 0, forwarder: null },
+    messageerror: { count: 0, forwarder: null },
+  };
+  // user listener → the wrapper actually registered on `inbound`, so remove
+  // detaches the exact one and dedup of identical (type, listener) holds.
+  const registered = { message: new Map(), messageerror: new Map() };
+
+  function forward(evt, data) {
+    const ev = new MessageEvent(evt, { data });
+    // Shadow the inherited accessors so worker code observes the spec-required
+    // DedicatedWorkerGlobalScope as target/currentTarget instead of `inbound`.
+    Object.defineProperty(ev, "target", { value: scope, configurable: true });
+    Object.defineProperty(ev, "currentTarget", { value: scope, configurable: true });
+    inbound.dispatchEvent(ev);
+  }
+  function attachPort(evt) {
+    const st = portState[evt];
+    if (st.count++ === 0) {
+      st.forwarder = (data) => forward(evt, data);
+      parentPort.on(evt, st.forwarder);
+    }
+  }
+  function detachPort(evt) {
+    const st = portState[evt];
+    if (--st.count === 0 && st.forwarder) {
+      parentPort.off(evt, st.forwarder);
+      st.forwarder = null;
+    }
+  }
 
   function addDelegated(evt, listener, opts) {
+    // Normalize to the function to invoke, binding a handleEvent object so its
+    // `this` is the object (spec) while a bare function gets `this` = self below.
     const cb =
       typeof listener === "function"
         ? listener
         : listener && typeof listener.handleEvent === "function"
-          ? (e) => listener.handleEvent(e)
+          ? listener.handleEvent.bind(listener)
           : null;
     if (!cb) return;
-    const map = wrappers[evt];
+    const map = registered[evt];
     if (map.has(listener)) return; // EventTarget dedups identical (type, listener)
     const o = opts && typeof opts === "object" ? opts : {};
     if (o.signal && o.signal.aborted) return;
-    const fire = (data) => cb.call(scope, new MessageEvent(evt, { data }));
-    let wrapper;
-    if (o.once) {
-      wrapper = (data) => {
-        map.delete(listener);
-        fire(data);
-      };
-      parentPort.once(evt, wrapper);
-    } else {
-      wrapper = fire;
-      parentPort.on(evt, wrapper);
-    }
+    // `once`/`signal` are OURS (not native options) so removal stays observable to
+    // the ref-count. The once wrapper removes itself BEFORE invoking — safe mid
+    // dispatch (removing an EventTarget listener while dispatching is spec-legal).
+    const wrapper = o.once
+      ? (ev) => {
+          removeDelegated(evt, listener);
+          cb.call(scope, ev);
+        }
+      : (ev) => cb.call(scope, ev);
     map.set(listener, wrapper);
+    inbound.addEventListener(evt, wrapper);
+    attachPort(evt);
     if (o.signal) {
       o.signal.addEventListener("abort", () => removeDelegated(evt, listener), {
         once: true,
@@ -611,11 +656,11 @@ if (!isMainThread && parentPort) {
     }
   }
   function removeDelegated(evt, listener) {
-    const wrapper = wrappers[evt].get(listener);
-    if (wrapper) {
-      parentPort.off(evt, wrapper);
-      wrappers[evt].delete(listener);
-    }
+    const wrapper = registered[evt].get(listener);
+    if (!wrapper) return;
+    registered[evt].delete(listener);
+    inbound.removeEventListener(evt, wrapper);
+    detachPort(evt);
   }
 
   defineGlobal("addEventListener", (type, listener, opts) =>

--- a/tests/fixtures/worker/event-target-self-main.ts
+++ b/tests/fixtures/worker/event-target-self-main.ts
@@ -1,0 +1,25 @@
+// Drives event-target-self-worker.ts: post one message, collect the worker's two
+// replies (one per inbound-listener channel), print each channel's target/
+// currentTarget identity so the harness can assert `=== self` on both.
+const w = new Worker(new URL("./event-target-self-worker.ts", import.meta.url));
+let seen = 0;
+w.onmessage = (e: MessageEvent) => {
+  const r = e.data as {
+    ch: string;
+    target: boolean;
+    currentTarget: boolean;
+    type: string;
+    data: unknown;
+    sawAdd?: boolean;
+  };
+  console.log(
+    `${r.ch}:target=${r.target}:currentTarget=${r.currentTarget}:type=${r.type}:data=${r.data}` +
+      (r.ch === "onmessage" ? `:sawAdd=${r.sawAdd}` : ""),
+  );
+  if (++seen === 2) (w as { terminate(): void }).terminate();
+};
+w.onerror = (e: { message: string }) => {
+  console.log("worker-error:" + e.message);
+  process.exit(1);
+};
+w.postMessage("ping");

--- a/tests/fixtures/worker/event-target-self-worker.ts
+++ b/tests/fixtures/worker/event-target-self-worker.ts
@@ -1,0 +1,27 @@
+// Inbound-event `target`/`currentTarget` identity (WHATWG §DedicatedWorkerGlobalScope).
+// An inbound `message` event dispatched to the worker global must have
+// `event.target === self` and `event.currentTarget === self` DURING the handler,
+// observed identically via `addEventListener('message', …)` and `self.onmessage`.
+// Pre-fix, nub hand-invoked the listener with a constructed MessageEvent that never
+// went through EventTarget dispatch, so both were `null`.
+let viaAdd = false;
+self.addEventListener("message", (e: MessageEvent) => {
+  viaAdd = true;
+  self.postMessage({
+    ch: "add",
+    target: e.target === self,
+    currentTarget: e.currentTarget === self,
+    type: e.type,
+    data: e.data,
+  });
+});
+self.onmessage = (e: MessageEvent) => {
+  self.postMessage({
+    ch: "onmessage",
+    target: e.target === self,
+    currentTarget: e.currentTarget === self,
+    type: e.type,
+    data: e.data,
+    sawAdd: viaAdd, // ordering: addEventListener registered first must fire first
+  });
+};


### PR DESCRIPTION
Inside a nub Worker, an inbound `message` event exposed the wrong target identity:

```
before:  event.target === null    event.currentTarget === null
after:   event.target === self    event.currentTarget === self
```

WHATWG DedicatedWorkerGlobalScope dispatches inbound events on the worker global, so both are `self` during the handler (browsers and Deno agree). The polyfill hand-invoked each listener with a constructed `MessageEvent` that never went through `EventTarget` dispatch, so the target slots stayed null.

## Fix

The worker-side `message`/`messageerror` path dispatches the one shared event through a private `EventTarget`, with `target`/`currentTarget` shadowed to `self` as own properties (globalThis can't be a real `EventTarget` without prototype re-parenting, which the polyfill avoids). parentPort ref-counting — a worker with no message listener must still exit naturally — is preserved by mediating add/remove and implementing `{once}`/`{signal}` in-band, attaching one parentPort forwarder per type on the 0-to-1 listener boundary.

## Verification

Both `addEventListener('message')` and `self.onmessage` now see `target === currentTarget === self` on the fast tier (Node 24, 26) and compat tier (Node 20). New test `worker_inbound_message_target_is_self`; the 22 existing worker tests stay green; clippy and fmt clean. The main-thread `Worker.onerror`/`onmessage` target (the Worker instance) is spec-correct and untouched.

Refs the `worker-event-target-null` thread. Held for maintainer review -- behavior change on a shipped worker surface.
