### PR TITLE
feat(pm): honor packageManager: nub@x.y.z by provision + delegate (self-shim)

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4839,7 +4839,7 @@ fn detect_channel(bin_path: &Path) -> UpgradeChannel {
 /// error rather than fetching a 404). musl vs glibc on Linux is a runtime
 /// distinction install.sh makes via `ldd`/`/etc/alpine-release`; we encode the
 /// glibc default here and document musl as the known gap (see note below).
-fn platform_target() -> Option<&'static str> {
+pub(crate) fn platform_target() -> Option<&'static str> {
     // NOTE: a glibc build and a musl build of the same arch are the same Rust
     // `target_env` only under `target_env = "musl"`, so this distinguishes them
     // correctly when Nub itself is built for musl. The detection matches the
@@ -5332,6 +5332,16 @@ fn provision_self(version: &str) -> Result<PathBuf> {
 
     std::fs::create_dir_all(&store)
         .with_context(|| format!("creating the nub self store at {}", store.display()))?;
+    // Defense-in-depth: the self store holds binaries this process EXECs, and a
+    // store hit skips re-verification, so restrict it to the owner (0700) — a
+    // shared/world-writable cache dir can't be used to pre-plant a binary a later
+    // run would exec unverified. Best-effort; a failure here doesn't block the
+    // provision (the verify-before-exec chain below is the real gate).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&store, std::fs::Permissions::from_mode(0o700));
+    }
     let staging = tempfile::Builder::new()
         .prefix(&format!(".self-{version}-"))
         .tempdir_in(&store)
@@ -5360,7 +5370,8 @@ fn provision_self(version: &str) -> Result<PathBuf> {
         bail!(
             "{ERR_NUB_SELF_SHIM}: checksum mismatch for the pinned nub@{version}\n  \
              expected: {expected}\n  actual:   {actual}\n\
-             Refusing to run a corrupted or tampered nub binary."
+             Refusing to run a corrupted or tampered nub binary. \
+             Set NUB_SELF_SHIM=0 to run with your installed nub."
         );
     }
 
@@ -5374,11 +5385,17 @@ fn provision_self(version: &str) -> Result<PathBuf> {
         .status()
         .context("invoking tar to extract the pinned nub")?;
     if !tar_status.success() {
-        bail!("{ERR_NUB_SELF_SHIM}: failed to extract the pinned nub@{version} archive");
+        bail!(
+            "{ERR_NUB_SELF_SHIM}: failed to extract the pinned nub@{version} archive. \
+             Set NUB_SELF_SHIM=0 to run with your installed nub."
+        );
     }
     let staged_bin = staged.join("bin").join(nub_release_bin_name());
     if !staged_bin.is_file() {
-        bail!("{ERR_NUB_SELF_SHIM}: the pinned nub@{version} archive did not contain bin/nub");
+        bail!(
+            "{ERR_NUB_SELF_SHIM}: the pinned nub@{version} archive did not contain bin/nub. \
+             Set NUB_SELF_SHIM=0 to run with your installed nub."
+        );
     }
     // CI's upload/download-artifact round-trip strips +x from the archived binary
     // (see perform_selfowned_upgrade) — re-apply it before the version probe.
@@ -5419,7 +5436,10 @@ fn verify_provisioned_version(bin: &Path, expected: &str) -> Result<()> {
         .output()
         .with_context(|| format!("probing {} --version", bin.display()))?;
     if !out.status.success() {
-        bail!("{ERR_NUB_SELF_SHIM}: the provisioned nub@{expected} failed its --version probe");
+        bail!(
+            "{ERR_NUB_SELF_SHIM}: the provisioned nub@{expected} failed its --version probe. \
+             Set NUB_SELF_SHIM=0 to run with your installed nub."
+        );
     }
     let stdout = String::from_utf8_lossy(&out.stdout);
     let reported = stdout
@@ -5431,7 +5451,8 @@ fn verify_provisioned_version(bin: &Path, expected: &str) -> Result<()> {
     if reported != expected {
         bail!(
             "{ERR_NUB_SELF_SHIM}: the provisioned binary reports nub@{reported}, expected \
-             nub@{expected} — refusing to run a version-mismatched artifact."
+             nub@{expected} — refusing to run a version-mismatched artifact. \
+             Set NUB_SELF_SHIM=0 to run with your installed nub."
         );
     }
     Ok(())

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -21,6 +21,11 @@ const ERR_NUB_MANIFEST_PARSE: &str = "ERR_NUB_MANIFEST_PARSE";
 /// cause as a coded miette diagnostic from the engine; `nub run` reuses this code
 /// so both spellings read consistently (was a bare `Error: no package.json found`).
 const ERR_NUB_NO_MANIFEST: &str = "ERR_NUB_NO_MANIFEST";
+/// The self-shim's failure surface — provisioning or verifying the pinned nub
+/// named by `packageManager: "nub@x.y.z"` failed. Every message carrying it names
+/// the `NUB_SELF_SHIM=0` escape hatch so a bad pin someone else committed can't
+/// brick a clone.
+const ERR_NUB_SELF_SHIM: &str = "ERR_NUB_SELF_SHIM";
 
 static SHOW_WARNINGS: AtomicBool = AtomicBool::new(false);
 /// `--silent` suppresses Nub's own preamble (the `$ <command>` script echo),
@@ -1365,6 +1370,19 @@ fn run_nub() -> Result<i32> {
             }
         }
         i += 1;
+    }
+
+    // ── nub self-shim ── honor `packageManager: "nub@x.y.z"` by provisioning that
+    // exact nub and delegating to it (crates/nub-cli/src/self_shim.rs). Gated on
+    // the resolved verb FIRST — a pure allowlist string compare, so the flagship
+    // `nub <file>` / `run` / `nubx` / `node` / `upgrade` paths pay only that and
+    // never read the manifest. Placed BEFORE the `--cwd` set_current_dir below so
+    // a delegated child re-applies `--cwd` from the original directory exactly
+    // once (delegation execs the ORIGINAL argv from the unchanged cwd).
+    if subcommand_found
+        && let Some(version) = crate::self_shim::delegate_target(&rest, cwd.as_deref())
+    {
+        return delegate_to_self(&version);
     }
 
     // Expand ${VAR} references in --env-file values now that all files have been
@@ -5270,6 +5288,170 @@ fn sha256_hex(bytes: &[u8]) -> String {
         let _ = write!(s, "{b:02x}");
     }
     s
+}
+
+/// The nub binary's filename inside a release archive's `bin/` dir.
+fn nub_release_bin_name() -> &'static str {
+    if cfg!(windows) { "nub.exe" } else { "nub" }
+}
+
+/// Provision an exact nub version into the version-addressed self store and return
+/// the path to its `bin/nub` — the delegated-artifact half of the self-shim
+/// (`self_shim.rs` owns the decision). Reuses the `nub upgrade` release channel:
+/// download `<base>/v<ver>/nub-<target>.tar.gz`, SHA-256-verify it against the
+/// published `.sha256` sidecar BEFORE extracting, then confirm the extracted
+/// binary reports the expected version before it is trusted for a default-on exec.
+///
+/// INTEGRITY: nub's own `packageManager` self-pin carries no `+sha512` (a
+/// pnpm/yarn pin's hash covers a platform-independent npm tarball; nub's release
+/// artifact is per-platform, so a single pin hash could not cover all 8), so this
+/// release-channel checksum is the integrity anchor. A verified store entry
+/// (`<cache>/self/<ver>/bin/nub`) IS the trust cache — a hit is network- and
+/// verification-free. Atomic: stage in a sibling temp dir, then rename into place.
+fn provision_self(version: &str) -> Result<PathBuf> {
+    let store = pm_store_root()?.join("self");
+    let final_dir = store.join(version);
+    let bin = final_dir.join("bin").join(nub_release_bin_name());
+    if bin.is_file() {
+        return Ok(bin); // verified store hit — silent, no network
+    }
+
+    // "No build for this platform" is a distinct, actionable failure — surfaced
+    // BEFORE any download so it never reads as a network error. The 8-platform
+    // release model means a pin can exist for linux-x64 and not win32-arm64.
+    let target = platform_target().ok_or_else(|| {
+        anyhow::anyhow!(
+            "{ERR_NUB_SELF_SHIM}: this project pins nub@{version}, but nub publishes no build \
+             for this platform ({}/{}). Set NUB_SELF_SHIM=0 to run with your installed nub.",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        )
+    })?;
+    let url = tarball_url(version, target);
+    let sha_url = checksum_url(version, target);
+
+    std::fs::create_dir_all(&store)
+        .with_context(|| format!("creating the nub self store at {}", store.display()))?;
+    let staging = tempfile::Builder::new()
+        .prefix(&format!(".self-{version}-"))
+        .tempdir_in(&store)
+        .context("creating a staging dir for the pinned-nub provision")?;
+    let archive = staging.path().join("nub.tar.gz");
+
+    eprintln!("nub: provisioning pinned nub@{version} ({target})...");
+    curl_download(&url, &archive).map_err(|_| {
+        anyhow::anyhow!(
+            "{ERR_NUB_SELF_SHIM}: could not download the pinned nub@{version} from {url} — the \
+             version may not exist or may have been yanked. Set NUB_SELF_SHIM=0 to run with \
+             your installed nub."
+        )
+    })?;
+
+    // Verify BEFORE extracting — a checked digest gates the executable landing on
+    // disk, the same order `perform_selfowned_upgrade` uses.
+    let expected = fetch_expected_sha256(&sha_url).map_err(|_| {
+        anyhow::anyhow!(
+            "{ERR_NUB_SELF_SHIM}: could not fetch the checksum for nub@{version} from {sha_url}. \
+             Set NUB_SELF_SHIM=0 to run with your installed nub."
+        )
+    })?;
+    let actual = sha256_hex(&std::fs::read(&archive)?);
+    if !actual.eq_ignore_ascii_case(&expected) {
+        bail!(
+            "{ERR_NUB_SELF_SHIM}: checksum mismatch for the pinned nub@{version}\n  \
+             expected: {expected}\n  actual:   {actual}\n\
+             Refusing to run a corrupted or tampered nub binary."
+        );
+    }
+
+    let staged = staging.path().join("staged");
+    std::fs::create_dir_all(&staged)?;
+    let tar_status = std::process::Command::new("tar")
+        .arg("-xzf")
+        .arg(&archive)
+        .arg("-C")
+        .arg(&staged)
+        .status()
+        .context("invoking tar to extract the pinned nub")?;
+    if !tar_status.success() {
+        bail!("{ERR_NUB_SELF_SHIM}: failed to extract the pinned nub@{version} archive");
+    }
+    let staged_bin = staged.join("bin").join(nub_release_bin_name());
+    if !staged_bin.is_file() {
+        bail!("{ERR_NUB_SELF_SHIM}: the pinned nub@{version} archive did not contain bin/nub");
+    }
+    // CI's upload/download-artifact round-trip strips +x from the archived binary
+    // (see perform_selfowned_upgrade) — re-apply it before the version probe.
+    ensure_bin_executable(&staged_bin)?;
+
+    // Provision-then-verify: a version-mismatched or corrupt artifact hard-errors
+    // HERE instead of exec-looping. The tarball was already checksum-verified and
+    // the store path is version-addressed, so this is belt-and-suspenders — but it
+    // is the last gate before a default-on exec, so it stays.
+    verify_provisioned_version(&staged_bin, version)?;
+
+    // Atomic place. A concurrent provisioner may have won the race — keep theirs.
+    if !bin.is_file() {
+        if let Err(e) = std::fs::rename(&staged, &final_dir) {
+            if !bin.is_file() {
+                return Err(e).with_context(|| {
+                    format!(
+                        "installing pinned nub@{version} into {}",
+                        final_dir.display()
+                    )
+                });
+            }
+        }
+    }
+    eprintln!("nub: provisioned nub@{version}");
+    Ok(final_dir.join("bin").join(nub_release_bin_name()))
+}
+
+/// Run the freshly-provisioned binary's `--version` and confirm it reports the
+/// expected version — the loop-safety gate before a default-on exec. `nub
+/// --version` prints a bare `v<X.Y.Z>` on its first stdout line. The probe carries
+/// the re-entry guard so it can never itself delegate (`--version` short-circuits
+/// before the dispatcher anyway, but the guard is cheap insurance).
+fn verify_provisioned_version(bin: &Path, expected: &str) -> Result<()> {
+    let out = std::process::Command::new(bin)
+        .arg("--version")
+        .env(crate::self_shim::SELF_DISPATCHED_ENV, expected)
+        .output()
+        .with_context(|| format!("probing {} --version", bin.display()))?;
+    if !out.status.success() {
+        bail!("{ERR_NUB_SELF_SHIM}: the provisioned nub@{expected} failed its --version probe");
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let reported = stdout
+        .lines()
+        .next()
+        .unwrap_or("")
+        .trim()
+        .trim_start_matches('v');
+    if reported != expected {
+        bail!(
+            "{ERR_NUB_SELF_SHIM}: the provisioned binary reports nub@{reported}, expected \
+             nub@{expected} — refusing to run a version-mismatched artifact."
+        );
+    }
+    Ok(())
+}
+
+/// Provision the pinned nub and hand off to it: replace the process image (Unix
+/// `exec`) / spawn+wait (Windows) with the pinned binary, running the ORIGINAL
+/// argv so the pinned nub applies its own CLI grammar (it may accept flags this
+/// nub would reject). The child carries `__NUB_SELF_DISPATCHED=<version>`, whose
+/// presence suppresses ALL further delegation — the exec-loop guard. Never returns
+/// on success (Unix).
+fn delegate_to_self(version: &str) -> Result<i32> {
+    let bin = provision_self(version)?;
+    // The unmodified original argv (env::args is stable within the process).
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let envs = vec![(
+        crate::self_shim::SELF_DISPATCHED_ENV.to_string(),
+        version.to_string(),
+    )];
+    exec_program(&bin, &args, &envs)
 }
 
 /// Print nub's version exactly like `nub --version` (and now `nubx --version`).

--- a/crates/nub-cli/src/main.rs
+++ b/crates/nub-cli/src/main.rs
@@ -6,6 +6,7 @@
 mod agent;
 mod cli;
 mod pm_engine;
+mod self_shim;
 
 use anyhow::Result;
 

--- a/crates/nub-cli/src/self_shim.rs
+++ b/crates/nub-cli/src/self_shim.rs
@@ -86,18 +86,18 @@ enum Plan {
     Notice(String),
 }
 
-/// The loop-safe core decision. `declared` is [`declared_pm_raw`]'s output (the
-/// workspace-root pin with any `+sha512` build-metadata already stripped);
+/// The loop-safe core decision. `declared` is the workspace-root `packageManager`
+/// field's `(name, version)` (with `+sha512` build-metadata already stripped);
 /// `running` is the running nub's version; `guard_set` is whether
-/// `__NUB_SELF_DISPATCHED` is present; `opted_out` is the `NUB_SELF_SHIM`
-/// opt-out. The caller has already confirmed the verb is a delegating one.
-///
-/// [`declared_pm_raw`]: nub_core::pm::resolve::declared_pm_raw
+/// `__NUB_SELF_DISPATCHED` is present; `opted_out` is the `NUB_SELF_SHIM` opt-out;
+/// `platform_supported` is whether nub publishes a release build for this OS/arch.
+/// The caller has already confirmed the verb is a delegating one.
 fn decide(
     declared: Option<(String, Option<String>)>,
     running: &semver::Version,
     guard_set: bool,
     opted_out: bool,
+    platform_supported: bool,
 ) -> Plan {
     // No pin, or a name-only pin with no version → nothing to honor.
     let Some((name, Some(pinned_raw))) = declared else {
@@ -124,7 +124,7 @@ fn decide(
     };
     // Matching pin → the pinning user's hot path: a field read + a compare, then
     // continue IN-PROCESS. Never respawn when we already are the pinned version
-    // (this is the trap the `+sha512` strip in `declared_pm_raw` exists to avoid).
+    // (this is the trap the `+sha512` strip in the field reader exists to avoid).
     if pinned == *running {
         return Plan::Continue;
     }
@@ -134,6 +134,18 @@ fn decide(
             "nub: this project pins nub@{pinned}; you're running nub@{running}. \
              Auto-provisioning is disabled (NUB_SELF_SHIM=0) — running with your \
              installed nub."
+        ));
+    }
+    // No published build for this OS/arch → graceful in-process fallback, NOT a
+    // hard error. A default-on provision that can't succeed on a whole platform
+    // (e.g. one with no release artifact yet) must not brick every install there.
+    if !platform_supported {
+        return Plan::Notice(format!(
+            "nub: this project pins nub@{pinned}, but nub publishes no build for this \
+             platform ({}/{}) — running with your installed nub@{running}. Set \
+             NUB_SELF_SHIM=0 to silence.",
+            std::env::consts::OS,
+            std::env::consts::ARCH
         ));
     }
     Plan::Delegate(pinned)
@@ -157,9 +169,18 @@ pub(crate) fn delegate_target(rest: &[String], cwd_override: Option<&Path>) -> O
     let guard_set = std::env::var_os(SELF_DISPATCHED_ENV).is_some();
     let effective = effective_cwd(cwd_override);
     // The one manifest read — reached only for a delegating verb, which reads the
-    // root manifest downstream anyway (declared_pm_raw hits ROOT_MANIFEST_CACHE).
-    let declared = nub_core::pm::resolve::declared_pm_raw(&effective);
-    match decide(declared, &running, guard_set, opted_out()) {
+    // root manifest downstream anyway (the field reader hits ROOT_MANIFEST_CACHE).
+    // The `packageManager` field ONLY (never the devEngines range-of-intent) drives
+    // the shim — matching the exact-pin channel corepack enforces.
+    let declared = nub_core::pm::resolve::declared_package_manager_field(&effective);
+    let platform_supported = crate::cli::platform_target().is_some();
+    match decide(
+        declared,
+        &running,
+        guard_set,
+        opted_out(),
+        platform_supported,
+    ) {
         Plan::Continue => None,
         Plan::Notice(msg) => {
             eprintln!("{msg}");
@@ -240,11 +261,17 @@ mod tests {
         }
     }
 
+    // decide()'s trailing args: (guard_set, opted_out, platform_supported). The
+    // common case is (false, false, true) — not a guard, not opted out, a real
+    // platform build exists.
     #[test]
     fn no_pin_or_foreign_pin_continues() {
-        assert_eq!(decide(None, &v("0.2.9"), false, false), Plan::Continue);
         assert_eq!(
-            decide(Some(("nub".into(), None)), &v("0.2.9"), false, false),
+            decide(None, &v("0.2.9"), false, false, true),
+            Plan::Continue
+        );
+        assert_eq!(
+            decide(Some(("nub".into(), None)), &v("0.2.9"), false, false, true),
             Plan::Continue,
             "a name-only nub pin has no version to honor"
         );
@@ -253,7 +280,8 @@ mod tests {
                 Some(("pnpm".into(), Some("9.1.0".into()))),
                 &v("0.2.9"),
                 false,
-                false
+                false,
+                true
             ),
             Plan::Continue,
             "a foreign PM pin is the engine's concern, not the self-shim's"
@@ -262,7 +290,7 @@ mod tests {
 
     #[test]
     fn matching_pin_is_a_silent_no_op() {
-        // The `+sha512` strip happens in declared_pm_raw upstream — decide sees the
+        // The `+sha512` strip happens in the field reader upstream — decide sees the
         // bare version. A stripped self-pin equal to the running version must NOT
         // respawn (the regression the whole feature would otherwise ship).
         assert_eq!(
@@ -270,7 +298,8 @@ mod tests {
                 Some(("nub".into(), Some("0.2.9".into()))),
                 &v("0.2.9"),
                 false,
-                false
+                false,
+                true
             ),
             Plan::Continue
         );
@@ -283,7 +312,8 @@ mod tests {
                 Some(("nub".into(), Some("0.1.0".into()))),
                 &v("0.2.9"),
                 false,
-                false
+                false,
+                true
             ),
             Plan::Delegate(v("0.1.0"))
         );
@@ -298,7 +328,8 @@ mod tests {
                 Some(("nub".into(), Some("0.1.0".into()))),
                 &v("0.2.9"),
                 true,
-                false
+                false,
+                true
             ),
             Plan::Continue
         );
@@ -311,12 +342,32 @@ mod tests {
             &v("0.2.9"),
             false,
             true,
+            true,
         );
         match plan {
             Plan::Notice(msg) => {
                 assert!(msg.contains("0.1.0") && msg.contains("0.2.9"));
                 assert!(msg.contains("NUB_SELF_SHIM=0"));
             }
+            other => panic!("expected a Notice, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unsupported_platform_falls_through_in_process() {
+        // A default-on provision that can't succeed on a whole platform must NOT
+        // brick every install there — it runs in-process with a notice.
+        match decide(
+            Some(("nub".into(), Some("0.1.0".into()))),
+            &v("0.2.9"),
+            false,
+            false,
+            false,
+        ) {
+            Plan::Notice(msg) => assert!(
+                msg.contains("no build for this platform") && msg.contains("NUB_SELF_SHIM=0"),
+                "notice: {msg}"
+            ),
             other => panic!("expected a Notice, got {other:?}"),
         }
     }
@@ -329,6 +380,7 @@ mod tests {
                 &v("0.2.9"),
                 false,
                 false,
+                true,
             ) {
                 Plan::Notice(msg) => assert!(
                     msg.contains(spec) && msg.contains("exact"),
@@ -339,7 +391,7 @@ mod tests {
         }
     }
 
-    /// The `+sha512` regression, end-to-end through the real manifest reader: nub's
+    /// The `+sha512` regression, end-to-end through the real field reader: nub's
     /// own #255 stamp is `nub@<v>` (bare today) but a hand-written or future
     /// `+sha512`-suffixed self-pin must strip to the bare version so a matching pin
     /// is a silent no-op — never a spurious delegation on nub's own stamp.
@@ -351,16 +403,34 @@ mod tests {
             r#"{"name":"x","version":"1.0.0","packageManager":"nub@0.2.9+sha512.deadbeefcafe"}"#,
         )
         .unwrap();
-        let declared = nub_core::pm::resolve::declared_pm_raw(dir.path());
+        let declared = nub_core::pm::resolve::declared_package_manager_field(dir.path());
         assert_eq!(
             declared,
             Some(("nub".to_string(), Some("0.2.9".to_string()))),
-            "declared_pm_raw must strip the +sha512 build metadata"
+            "the field reader must strip the +sha512 build metadata"
         );
         assert_eq!(
-            decide(declared, &v("0.2.9"), false, false),
+            decide(declared, &v("0.2.9"), false, false, true),
             Plan::Continue,
             "a suffixed self-pin equal to the running version must NOT delegate"
+        );
+    }
+
+    /// The self-shim reads the exact `packageManager` field ONLY — a nub named in
+    /// the `devEngines` range-of-intent must NOT drive a provision or a not-exact
+    /// notice (that would nag on every command for a legitimate range).
+    #[test]
+    fn devengines_nub_is_not_read_as_a_pin() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"x","version":"1.0.0","devEngines":{"packageManager":{"name":"nub","version":">=0.1.0"}}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            nub_core::pm::resolve::declared_package_manager_field(dir.path()),
+            None,
+            "a devEngines-only nub entry is not the exact packageManager pin"
         );
     }
 }

--- a/crates/nub-cli/src/self_shim.rs
+++ b/crates/nub-cli/src/self_shim.rs
@@ -1,0 +1,366 @@
+//! nub self-shim — honor `packageManager: "nub@x.y.z"` by provisioning that exact
+//! nub and delegating (`exec`) to it, corepack's model applied to nub itself.
+//!
+//! When a project's workspace-root manifest pins a *different* exact nub than the
+//! running one, a PM mutating verb (`install`/`add`/…) provisions the pinned nub
+//! from nub's own release channel and replaces the process with it, so every
+//! contributor and CI runs byte-identical package-manager behavior. This module
+//! owns the pure *decision*; `cli::provision_self` / `cli::delegate_to_self` own
+//! the fetch-verify-exec.
+//!
+//! HOT PATH: the flagship `nub <file>` runner, `run`/`watch`, `nubx`, `upgrade`,
+//! and `node` never reach a manifest read — [`delegate_target`] gates on the verb
+//! allowlist FIRST (a pure string compare). Only a delegating PM verb reads the
+//! workspace-root pin, a read those verbs already make downstream.
+//!
+//! LOOP-SAFETY: delegation fires only on an EXACT `nub@X.Y.Z` that differs from
+//! the running version, with the re-entry guard unset and the opt-out off. The
+//! child runs with `__NUB_SELF_DISPATCHED=<version>`, whose mere presence
+//! suppresses ALL further delegation ([`decide`] returns `Continue`
+//! unconditionally when it is set) — no exec loop is reachable. Exact-version-only
+//! pins mean a spec can never resolve to a different concrete string across the
+//! boundary (corepack enforces the same for the field).
+//!
+//! INTEGRITY: the delegated artifact is nub's own per-platform release binary,
+//! SHA-256-verified against the published `.sha256` sidecar before it runs (see
+//! `cli::provision_self`). nub's `packageManager` self-pin carries NO `+sha512`
+//! (unlike a pnpm/yarn pin, whose hash covers a platform-independent npm tarball),
+//! and one hash could not cover 8 per-platform binaries — so the release-channel
+//! checksum is the integrity anchor, not the pin.
+
+use std::path::{Path, PathBuf};
+
+/// Set on a delegated child so it never re-delegates — the exec-loop guard,
+/// keyed to the resolved concrete version. Internal `__NUB_` plumbing (brand-
+/// exempt), never a user knob.
+pub(crate) const SELF_DISPATCHED_ENV: &str = "__NUB_SELF_DISPATCHED";
+
+/// The user-facing opt-out: a falsey value disables auto-delegation tree-wide and
+/// is inherited by every descendant. Positive-default spelling (modelled on
+/// `NODE_COMPAT`) — only an explicit falsey value turns the feature off. `NUB_*`
+/// is a sanctioned PM knob (`NUB_CACHE_DIR`/`NUB_CONCURRENCY`/`NUB_PRIMER_TTL`).
+pub(crate) const SELF_SHIM_ENV: &str = "NUB_SELF_SHIM";
+
+/// The PM mutating verbs that delegate to a pinned nub — the set whose deliverable
+/// is a *committed* artifact (lockfile + store/linker layout), where "everyone
+/// runs the same nub" is a checkable property that lockfile-compat alone doesn't
+/// pin. Everything else is exempt: the file runner and `run`/`watch` (non-
+/// committed output, latency-critical), `nubx`/`dlx` (ephemeral), `upgrade`
+/// (nub's self-update — a category error to delegate), `node` (orthogonal to the
+/// nub version), and read-only queries.
+fn is_delegating_verb(verb: &str) -> bool {
+    // `install`/`i`/`ci` are top-level SUBCOMMANDS (not ENGINE_VERBS); the rest
+    // resolve through the alias-aware engine registry so `a`→add, `rm`→remove,
+    // `up`→update all count. `upgrade` is deliberately NOT an `update` alias in
+    // nub (it is the self-update), so `lookup_verb` never maps it here.
+    if matches!(verb, "install" | "i" | "ci") {
+        return true;
+    }
+    matches!(
+        crate::pm_engine::lookup_verb(verb).map(|v| v.canonical),
+        Some("add" | "remove" | "update" | "import" | "dedupe")
+    )
+}
+
+/// Whether auto-delegation is opted out via `NUB_SELF_SHIM` — a falsey value
+/// (`0`/`false`/`no`/`off`, case-insensitive). Unset or any other value = enabled.
+fn opted_out() -> bool {
+    match std::env::var(SELF_SHIM_ENV) {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        Err(_) => false,
+    }
+}
+
+/// The delegation decision — computed purely from its inputs (no I/O) so it is
+/// exhaustively unit-testable and the loop-safety argument is inspectable.
+#[derive(Debug, PartialEq, Eq)]
+enum Plan {
+    /// Run in-process: the hot path, no pin, a matching pin, or a re-entry.
+    Continue,
+    /// Provision + exec this exact nub version.
+    Delegate(semver::Version),
+    /// Print this one-line stderr notice, then run in-process.
+    Notice(String),
+}
+
+/// The loop-safe core decision. `declared` is [`declared_pm_raw`]'s output (the
+/// workspace-root pin with any `+sha512` build-metadata already stripped);
+/// `running` is the running nub's version; `guard_set` is whether
+/// `__NUB_SELF_DISPATCHED` is present; `opted_out` is the `NUB_SELF_SHIM`
+/// opt-out. The caller has already confirmed the verb is a delegating one.
+///
+/// [`declared_pm_raw`]: nub_core::pm::resolve::declared_pm_raw
+fn decide(
+    declared: Option<(String, Option<String>)>,
+    running: &semver::Version,
+    guard_set: bool,
+    opted_out: bool,
+) -> Plan {
+    // No pin, or a name-only pin with no version → nothing to honor.
+    let Some((name, Some(pinned_raw))) = declared else {
+        return Plan::Continue;
+    };
+    // Only a nub self-pin is our concern; a foreign PM pin is the engine's.
+    if name != "nub" {
+        return Plan::Continue;
+    }
+    // Re-entry guard: presence-first and UNCONDITIONAL. A delegated child — and
+    // any nested delegating verb beneath it — never re-delegates. Checked before
+    // parsing so no input shape can bypass the primary loop-safety stop.
+    if guard_set {
+        return Plan::Continue;
+    }
+    // Exact-version-only (corepack mandates it for the field; also loop-safety —
+    // a range/tag could resolve to a different concrete string across the exec).
+    let Ok(pinned) = semver::Version::parse(&pinned_raw) else {
+        return Plan::Notice(format!(
+            "nub: packageManager pins nub@{pinned_raw}, which isn't an exact version — \
+             running with your installed nub@{running}. Pin an exact version \
+             (e.g. nub@{running}) to auto-provision the pinned nub."
+        ));
+    };
+    // Matching pin → the pinning user's hot path: a field read + a compare, then
+    // continue IN-PROCESS. Never respawn when we already are the pinned version
+    // (this is the trap the `+sha512` strip in `declared_pm_raw` exists to avoid).
+    if pinned == *running {
+        return Plan::Continue;
+    }
+    // A genuine mismatch, but auto-delegation is opted out → coherent notice.
+    if opted_out {
+        return Plan::Notice(format!(
+            "nub: this project pins nub@{pinned}; you're running nub@{running}. \
+             Auto-provisioning is disabled (NUB_SELF_SHIM=0) — running with your \
+             installed nub."
+        ));
+    }
+    Plan::Delegate(pinned)
+}
+
+/// Resolve the workspace-root pin and decide whether a delegating PM verb should
+/// hand off to a pinned nub. Returns the exact version to provision + exec, or
+/// `None` to continue in-process (printing any coherent notice as a side effect).
+/// `rest` is the resolved subcommand argv (`rest[0]` is the verb); `cwd_override`
+/// is the `--cwd` value (a relative path resolved against the current dir).
+///
+/// The verb-allowlist gate runs FIRST — a non-delegating verb returns with zero
+/// I/O, so the flagship `nub <file>` / `run` / `nubx` paths never read the
+/// manifest.
+pub(crate) fn delegate_target(rest: &[String], cwd_override: Option<&Path>) -> Option<String> {
+    let verb = rest.first()?;
+    if !is_delegating_verb(verb) {
+        return None; // hot path: a pure string compare, no syscalls
+    }
+    let running = semver::Version::parse(env!("CARGO_PKG_VERSION")).ok()?;
+    let guard_set = std::env::var_os(SELF_DISPATCHED_ENV).is_some();
+    let effective = effective_cwd(cwd_override);
+    // The one manifest read — reached only for a delegating verb, which reads the
+    // root manifest downstream anyway (declared_pm_raw hits ROOT_MANIFEST_CACHE).
+    let declared = nub_core::pm::resolve::declared_pm_raw(&effective);
+    match decide(declared, &running, guard_set, opted_out()) {
+        Plan::Continue => None,
+        Plan::Notice(msg) => {
+            eprintln!("{msg}");
+            None
+        }
+        Plan::Delegate(version) => Some(version.to_string()),
+    }
+}
+
+/// The dir to read the workspace-root pin from: the `--cwd` override resolved
+/// against the process cwd (an absolute override wins; a relative one joins), or
+/// the process cwd. Computed WITHOUT mutating the process cwd, so a delegated
+/// child re-applies `--cwd` from the original directory exactly once.
+fn effective_cwd(cwd_override: Option<&Path>) -> PathBuf {
+    let base = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    match cwd_override {
+        Some(dir) => base.join(dir),
+        None => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> semver::Version {
+        semver::Version::parse(s).unwrap()
+    }
+
+    #[test]
+    fn delegating_allowlist_covers_the_mutating_verbs_and_their_aliases() {
+        // The eight families the shim delegates, plus the aliases users type.
+        for verb in [
+            "install",
+            "i",
+            "ci",
+            "add",
+            "a",
+            "remove",
+            "rm",
+            "uninstall",
+            "un",
+            "update",
+            "up",
+            "import",
+            "dedupe",
+        ] {
+            assert!(is_delegating_verb(verb), "{verb} should delegate");
+        }
+    }
+
+    #[test]
+    fn exempt_verbs_never_delegate() {
+        // The hot path + every non-committed / self-update / orthogonal surface.
+        // `upgrade` is the sharpest: it must NOT be treated as an `update` alias.
+        for verb in [
+            "run",
+            "watch",
+            "exec",
+            "nubx",
+            "dlx",
+            "x",
+            "upgrade",
+            "node",
+            "pm",
+            "agent",
+            "list",
+            "ls",
+            "why",
+            "outdated",
+            "help",
+            "app.ts",
+            "./build.js",
+            "prune",
+            "rebuild",
+        ] {
+            assert!(!is_delegating_verb(verb), "{verb} must not delegate");
+        }
+    }
+
+    #[test]
+    fn no_pin_or_foreign_pin_continues() {
+        assert_eq!(decide(None, &v("0.2.9"), false, false), Plan::Continue);
+        assert_eq!(
+            decide(Some(("nub".into(), None)), &v("0.2.9"), false, false),
+            Plan::Continue,
+            "a name-only nub pin has no version to honor"
+        );
+        assert_eq!(
+            decide(
+                Some(("pnpm".into(), Some("9.1.0".into()))),
+                &v("0.2.9"),
+                false,
+                false
+            ),
+            Plan::Continue,
+            "a foreign PM pin is the engine's concern, not the self-shim's"
+        );
+    }
+
+    #[test]
+    fn matching_pin_is_a_silent_no_op() {
+        // The `+sha512` strip happens in declared_pm_raw upstream — decide sees the
+        // bare version. A stripped self-pin equal to the running version must NOT
+        // respawn (the regression the whole feature would otherwise ship).
+        assert_eq!(
+            decide(
+                Some(("nub".into(), Some("0.2.9".into()))),
+                &v("0.2.9"),
+                false,
+                false
+            ),
+            Plan::Continue
+        );
+    }
+
+    #[test]
+    fn exact_mismatch_delegates() {
+        assert_eq!(
+            decide(
+                Some(("nub".into(), Some("0.1.0".into()))),
+                &v("0.2.9"),
+                false,
+                false
+            ),
+            Plan::Delegate(v("0.1.0"))
+        );
+    }
+
+    #[test]
+    fn reentry_guard_suppresses_delegation_unconditionally() {
+        // We ARE a delegated child: even a differing exact pin must continue, or
+        // the child would re-delegate forever.
+        assert_eq!(
+            decide(
+                Some(("nub".into(), Some("0.1.0".into()))),
+                &v("0.2.9"),
+                true,
+                false
+            ),
+            Plan::Continue
+        );
+    }
+
+    #[test]
+    fn opt_out_notices_a_mismatch_without_delegating() {
+        let plan = decide(
+            Some(("nub".into(), Some("0.1.0".into()))),
+            &v("0.2.9"),
+            false,
+            true,
+        );
+        match plan {
+            Plan::Notice(msg) => {
+                assert!(msg.contains("0.1.0") && msg.contains("0.2.9"));
+                assert!(msg.contains("NUB_SELF_SHIM=0"));
+            }
+            other => panic!("expected a Notice, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_exact_pin_notices_and_does_not_delegate() {
+        for spec in ["0.2", "latest", "^0.2.0"] {
+            match decide(
+                Some(("nub".into(), Some(spec.into()))),
+                &v("0.2.9"),
+                false,
+                false,
+            ) {
+                Plan::Notice(msg) => assert!(
+                    msg.contains(spec) && msg.contains("exact"),
+                    "notice for {spec}: {msg}"
+                ),
+                other => panic!("expected a Notice for {spec}, got {other:?}"),
+            }
+        }
+    }
+
+    /// The `+sha512` regression, end-to-end through the real manifest reader: nub's
+    /// own #255 stamp is `nub@<v>` (bare today) but a hand-written or future
+    /// `+sha512`-suffixed self-pin must strip to the bare version so a matching pin
+    /// is a silent no-op — never a spurious delegation on nub's own stamp.
+    #[test]
+    fn sha512_suffixed_self_pin_reads_stripped_and_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"x","version":"1.0.0","packageManager":"nub@0.2.9+sha512.deadbeefcafe"}"#,
+        )
+        .unwrap();
+        let declared = nub_core::pm::resolve::declared_pm_raw(dir.path());
+        assert_eq!(
+            declared,
+            Some(("nub".to_string(), Some("0.2.9".to_string()))),
+            "declared_pm_raw must strip the +sha512 build metadata"
+        );
+        assert_eq!(
+            decide(declared, &v("0.2.9"), false, false),
+            Plan::Continue,
+            "a suffixed self-pin equal to the running version must NOT delegate"
+        );
+    }
+}

--- a/crates/nub-cli/tests/bun_basic_config.rs
+++ b/crates/nub-cli/tests/bun_basic_config.rs
@@ -38,6 +38,10 @@ fn run_with_xdg_config(dir: &Path, xdg_config: &Path, args: &[&str]) -> (String,
         .current_dir(dir)
         .env_clear()
         .env("PATH", path)
+        // The fixture pins a differing `nub@<v>` to exercise nub identity, not the
+        // self-shim — opt out so a PM verb doesn't try to provision that nub.
+        // (env_clear above drops the ambient value, so set it explicitly.)
+        .env("NUB_SELF_SHIM", "0")
         .env("HOME", &home)
         .env("XDG_CONFIG_HOME", xdg_config)
         .env("XDG_DATA_HOME", dir.join("xdg-data"))

--- a/crates/nub-cli/tests/pm_identity.rs
+++ b/crates/nub-cli/tests/pm_identity.rs
@@ -44,6 +44,9 @@ fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
     let out = Command::new(nub_binary())
         .args(args)
         .current_dir(dir)
+        // These fixtures pin a differing `nub@<v>` to exercise nub identity, not
+        // the self-shim — opt out so a PM verb doesn't try to provision that nub.
+        .env("NUB_SELF_SHIM", "0")
         .env("XDG_DATA_HOME", dir.join("xdg-data"))
         .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
         .output()

--- a/crates/nub-cli/tests/pm_publish_store_config.rs
+++ b/crates/nub-cli/tests/pm_publish_store_config.rs
@@ -53,6 +53,9 @@ impl Ctx {
         let out = Command::new(nub_binary())
             .args(args)
             .current_dir(&self.project)
+            // The fixture pins a differing `nub@<v>` to exercise nub identity, not
+            // the self-shim — opt out so a PM verb doesn't provision that nub.
+            .env("NUB_SELF_SHIM", "0")
             .env("HOME", &self.home)
             .env("XDG_DATA_HOME", self.home.join("xdg-data"))
             .env("XDG_CACHE_HOME", self.home.join("xdg-cache"))
@@ -358,6 +361,7 @@ fn global_pnpm_config_is_read_regardless_of_cwd_incumbency() {
         let out = Command::new(nub_binary())
             .args(args)
             .current_dir(project)
+            .env("NUB_SELF_SHIM", "0")
             .env("HOME", &home)
             .env("XDG_DATA_HOME", home.join("xdg-data"))
             .env("XDG_CACHE_HOME", home.join("xdg-cache"))

--- a/crates/nub-cli/tests/pm_two_mode.rs
+++ b/crates/nub-cli/tests/pm_two_mode.rs
@@ -39,6 +39,9 @@ fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
     let out = Command::new(nub_binary())
         .args(args)
         .current_dir(dir)
+        // Fixtures pin a differing `nub@<v>` to exercise nub identity, not the
+        // self-shim — opt out so a PM verb doesn't try to provision that nub.
+        .env("NUB_SELF_SHIM", "0")
         .env("XDG_DATA_HOME", dir.join("xdg-data"))
         .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
         .output()

--- a/crates/nub-cli/tests/self_shim.rs
+++ b/crates/nub-cli/tests/self_shim.rs
@@ -1,0 +1,205 @@
+//! The nub self-shim, behaviorally, through the binary: a workspace-root
+//! `packageManager: "nub@X.Y.Z"` pinning a DIFFERENT nub provisions that nub from
+//! the release channel (redirected to a `file://` fixture via the internal
+//! `NUB_RELEASE_BASE_URL` seam) and execs it. Unix-only: the fixture's `bin/nub`
+//! is a shell script, and the delegate handoff is a POSIX `exec`; the Windows
+//! spawn path is exercised by the windows-latest leg separately.
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // profile dir
+    path.push("nub");
+    path
+}
+
+/// The release-artifact target for this host — the subset of `platform_target()`
+/// the Unix `Test` legs run on. `None` on a platform with no mapping (the test
+/// then skips, mirroring the shim's own graceful platform fallback).
+fn host_target() -> Option<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Some("darwin-arm64"),
+        ("macos", "x86_64") => Some("darwin-x64"),
+        ("linux", "x86_64") => Some("linux-x64"),
+        ("linux", "aarch64") => Some("linux-arm64"),
+        _ => None,
+    }
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nub-selfshim-{tag}-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Stage a fake nub release at `<releases>/v<ver>/nub-<target>.tar.gz` (+ `.sha256`)
+/// whose `bin/nub` prints a marker naming the verb and the re-entry guard, and
+/// reports `v<ver>` to `--version` (so provision-then-verify passes).
+fn stage_fake_release(releases: &Path, target: &str, ver: &str) {
+    let stage = releases.join(format!(".stage-{ver}"));
+    std::fs::create_dir_all(stage.join("bin")).unwrap();
+    let script = format!(
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo \"v{ver}\"; exit 0; fi\n\
+         echo \"FAKE-NUB verb=$1 guard=${{__NUB_SELF_DISPATCHED:-UNSET}}\"\nexit 0\n"
+    );
+    let bin = stage.join("bin").join("nub");
+    std::fs::write(&bin, script).unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let vdir = releases.join(format!("v{ver}"));
+    std::fs::create_dir_all(&vdir).unwrap();
+    let tarball = format!("nub-{target}.tar.gz");
+    assert!(
+        Command::new("tar")
+            .arg("-czf")
+            .arg(vdir.join(&tarball))
+            .arg("-C")
+            .arg(&stage)
+            .arg("bin")
+            .status()
+            .unwrap()
+            .success(),
+        "tar the fake release"
+    );
+    let sum = Command::new("shasum")
+        .args(["-a", "256"])
+        .arg(&tarball)
+        .current_dir(&vdir)
+        .output()
+        .unwrap();
+    assert!(sum.status.success(), "shasum the fake release");
+    std::fs::write(vdir.join(format!("{tarball}.sha256")), &sum.stdout).unwrap();
+}
+
+/// Run `nub <args>` in `project`, self-shim ENABLED, provisioning redirected to
+/// the `file://` release fixture and the store isolated to a fresh cache root.
+fn run(project: &Path, releases: &Path, cache: &Path, args: &[&str]) -> String {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(project)
+        .env(
+            "NUB_RELEASE_BASE_URL",
+            format!("file://{}", releases.display()),
+        )
+        .env("XDG_CACHE_HOME", cache)
+        .env("XDG_DATA_HOME", cache.join("data"))
+        // A dead-port registry so an in-process (non-delegated) install can't
+        // reach the network — any accidental non-delegation fails loud, not slow.
+        .env("XDG_CONFIG_HOME", cache.join("config"))
+        .output()
+        .expect("spawn nub");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+fn write_manifest(project: &Path, pin: &str) {
+    std::fs::write(
+        project.join("package.json"),
+        format!(r#"{{"name":"app","version":"1.0.0","packageManager":"{pin}"}}"#),
+    )
+    .unwrap();
+    std::fs::write(project.join(".npmrc"), "registry=http://127.0.0.1:1/\n").unwrap();
+}
+
+#[test]
+fn differing_exact_pin_provisions_verifies_and_delegates() {
+    let Some(target) = host_target() else {
+        return; // no release mapping for this host — the shim falls through
+    };
+    let root = scratch("delegate");
+    let releases = root.join("releases");
+    std::fs::create_dir_all(&releases).unwrap();
+    stage_fake_release(&releases, target, "99.99.99");
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    write_manifest(&project, "nub@99.99.99");
+    let cache = root.join("cache");
+
+    let out = run(&project, &releases, &cache, &["install"]);
+    assert!(
+        out.contains("provisioning pinned nub@99.99.99"),
+        "provisions the pinned nub: {out}"
+    );
+    assert!(
+        out.contains("FAKE-NUB verb=install"),
+        "execs the delegated binary: {out}"
+    );
+    assert!(
+        out.contains("guard=99.99.99"),
+        "the re-entry guard is set on the child: {out}"
+    );
+
+    // Second run is a verified store hit — no re-provision.
+    let out2 = run(&project, &releases, &cache, &["install"]);
+    assert!(
+        out2.contains("FAKE-NUB verb=install"),
+        "still delegates: {out2}"
+    );
+    assert!(
+        !out2.contains("provisioning pinned nub@99.99.99"),
+        "cache hit does not re-provision: {out2}"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn matching_pin_does_not_delegate() {
+    let Some(target) = host_target() else {
+        return;
+    };
+    let root = scratch("match");
+    let releases = root.join("releases");
+    std::fs::create_dir_all(&releases).unwrap();
+    // Stage a release AT the running version — if the shim wrongly treated a
+    // matching pin as a mismatch it would provision + exec this and print FAKE-NUB.
+    let running = env!("CARGO_PKG_VERSION");
+    stage_fake_release(&releases, target, running);
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    write_manifest(&project, &format!("nub@{running}"));
+    let cache = root.join("cache");
+
+    let out = run(&project, &releases, &cache, &["install"]);
+    assert!(
+        !out.contains("FAKE-NUB") && !out.contains("provisioning pinned nub"),
+        "a matching pin runs in-process, never delegates: {out}"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn non_exact_pin_notices_and_runs_in_process() {
+    let root = scratch("nonexact");
+    let releases = root.join("releases");
+    std::fs::create_dir_all(&releases).unwrap();
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    write_manifest(&project, "nub@0.2");
+    let cache = root.join("cache");
+
+    let out = run(&project, &releases, &cache, &["install"]);
+    assert!(
+        out.contains("isn't an exact version"),
+        "a range pin prints the not-exact notice: {out}"
+    );
+    assert!(
+        !out.contains("FAKE-NUB"),
+        "a range pin never delegates: {out}"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/nub-core/src/pm/resolve.rs
+++ b/crates/nub-core/src/pm/resolve.rs
@@ -434,6 +434,35 @@ pub fn declared_pm_raw(cwd: &Path) -> Option<(String, Option<String>)> {
     Some((name, version))
 }
 
+/// The workspace-root `packageManager` field's `(name, version)` — the exact
+/// Corepack ENFORCEMENT field ONLY, with the `+sha512` build metadata stripped.
+/// Deliberately does NOT fall back to `devEngines.packageManager` the way
+/// [`declared_pm_raw`] does: `packageManager` is the exact pin a tool executes,
+/// while `devEngines` is a range-of-intent. The nub self-shim reads through this
+/// so a `devEngines.packageManager` naming nub (a range) never drives a provision
+/// or a spurious not-exact notice — only the exact `packageManager` field does.
+/// `None` when there is no `packageManager` field at the workspace root.
+pub fn declared_package_manager_field(cwd: &Path) -> Option<(String, Option<String>)> {
+    let manifest = root_manifest(cwd)?;
+    let spec = manifest
+        .get("packageManager")
+        .and_then(|v| v.as_str())?
+        .trim();
+    let (name, version) = match spec.split_once('@') {
+        Some((n, v)) => (n, Some(v.to_string())),
+        None => (spec, None),
+    };
+    if name.is_empty() {
+        return None;
+    }
+    let version = version.map(|v| {
+        v.split_once('+')
+            .map_or(v.as_str(), |(bare, _)| bare)
+            .to_string()
+    });
+    Some((name.to_string(), version))
+}
+
 /// The workspace-root `packageManager` field decomposed as
 /// `(name, exact_version, sha512_hex)` — but ONLY when it pins an EXACT semver
 /// WITH a `+sha512.<hex>` suffix (`pnpm@9.1.0+sha512.abc…`). Returns `None` for

--- a/site/content/docs/pm.mdx
+++ b/site/content/docs/pm.mdx
@@ -109,6 +109,34 @@ Versions live at `~/.cache/nub/pm/<pm>/<version>`. A cached exact pin runs fully
 
 The shims are an opt-in: run `nub pm shim` and a bare `pnpm`, `npm`, or `yarn` command routes through Nub to the pinned manager, with `nub pm unshim` to remove them. Default usage needs none of this — `nub install` and `nub run` already run the pin. See [Package-manager shims](/docs/pm-shim) for the install, the strict-by-default refusal, and the per-invocation overhead.
 
+## Pinning Nub itself
+
+The `packageManager` field can also pin Nub — `nub@X.Y.Z`. When the running Nub is a different version, it fetches that exact release, verifies it, and hands off, so a project's installs don't depend on which Nub each contributor happens to have.
+
+```json
+{
+  "packageManager": "nub@0.2.9"
+}
+```
+
+The handoff runs on the install verbs — where the result is a committed lockfile and `node_modules`:
+
+```console
+$ nub install
+nub: provisioning pinned nub@0.2.9 (darwin-arm64)...
+nub: provisioned nub@0.2.9
+```
+
+The release comes from Nub's own channel and is checksum-verified before it runs; a corrupt, missing, or wrong-version build is a hard error, never a silent fallback. The store lives at `~/.cache/nub/self/<version>`, so a pinned version runs offline once provisioned.
+
+Only the install verbs hand off. Everything else — the file runner, script running, [`nubx`](/docs/nubx), version management, self-update — never reads the pin, so `nub script.ts` stays fast. A matching pin runs in place. A non-exact pin does too, with a notice: like corepack, the `packageManager` field is exact-only.
+
+To run with your installed Nub regardless of the pin, set `NUB_SELF_SHIM=0`. It disables the handoff for the whole tree:
+
+```bash
+NUB_SELF_SHIM=0 nub install
+```
+
 ## `.npmrc`
 
 The PM download — packument and tarball — goes through your `.npmrc`: `registry=` picks the mirror, `//host/:_authToken=` authenticates. An auth-required Artifactory/Nexus mirror works with the config you already have:


### PR DESCRIPTION
A workspace-root `packageManager` pin of a *different* exact nub than the running one now provisions that nub from nub's own release channel and execs it — corepack's model, for nub itself. Auto-delegate is on by default. Scope: the PM mutating verbs (`install`/`i`/`ci`/`add`/`remove`/`update`/`import`/`dedupe`); the file runner, `run`/`watch`, `nubx`, `upgrade`, and `node` are exempt and pay only an argv[1] string compare.

## Integrity — read this first

This is a default-on download-and-exec of a binary named by (potentially untrusted) repo content, so the integrity story is load-bearing.

**What nub's `+sha512` actually hashes:** nothing usable here. nub's own self-pin is written as a *bare* `nub@<version>` — no `+sha512` — by both write paths (`install_family.rs` #255 virgin stamp, `use_nub.rs` for `nub pm use nub`). The `+sha512.<hex>` suffix only exists for *foreign* PM pins (pnpm/yarn/npm), where it hashes the npm-registry tarball of that PM. It never applies to nub, and one hash could not cover nub's 8 per-platform release binaries anyway (corepack's `+sha512` works only because a pnpm/yarn npm tarball is one platform-independent artifact).

**So integrity rides the release channel, not the pin.** `provision_self` downloads `<base>/v<ver>/nub-<target>.tar.gz`, fetches the published `.sha256` sidecar, and SHA-256-verifies the bytes *before* extraction — the same mechanism `nub upgrade` already uses. It then probes `<bin> --version` and refuses to exec a version-mismatched artifact. A store hit is the trust cache (the version-addressed `~/.cache/nub/self/<ver>/`, created `0700`). No unverified or mismatched binary reaches `exec`.

**Named residuals** (accepted, inherent to the class — the same trust model as `nub upgrade` / corepack / nvm):
- The tarball and its `.sha256` come from the same origin, so the checksum defends corruption/truncation but is not a signature — a compromised release host or a valid-cert MITM would control both. A per-release signature layer is a follow-up.
- The shim is a downgrade primitive: repo content selects *which published nub* runs your install. It can only run a genuine, checksum-matching, officially-published nub release — never an arbitrary attacker binary — but a repo can pin an older one. Unavoidable given the reproducibility goal.

The `NUB_SELF_SHIM=0` env var disables the handoff tree-wide, and every failure mode names it so a bad committed pin can't brick a clone.

## Behavior

- Delegation fires only on an exact `nub@X.Y.Z` != the running version, with the re-entry guard unset and the opt-out off. A matching pin, a foreign pin, or a `devEngines`-only nub entry runs in place. A non-exact pin (the `packageManager` field is exact-only, as corepack enforces) prints a notice and runs in place. A platform with no published build runs in place with a notice — never a hard error.
- Loop-safe: the child carries `__NUB_SELF_DISPATCHED=<version>`, whose presence unconditionally suppresses any further delegation. Exact-version-only pins mean a spec can't resolve to a different concrete string across the exec.
- Reads the exact `packageManager` field only (`declared_package_manager_field`), never the `devEngines` range-of-intent.

## Tests

- `crates/nub-cli/src/self_shim.rs` — 11 unit tests over the pure decision (allowlist, the `+sha512`-strip regression through the real field reader, matching/mismatch/opt-out/non-exact/unsupported-platform/re-entry/devEngines-not-a-pin).
- Verified end-to-end against a `file://` release fixture (the `NUB_RELEASE_*` seams): a differing exact pin provisions + verifies + execs with the guard set; the cache hit skips re-download; a `+sha512`-suffixed matching pin is a silent no-op; the hot-path verbs never provision; the opt-out and non-exact pins notice without delegating; a version-mismatched artifact hard-errors before running.

## Self-review

Three fresh-context reviewers (correctness / impact-analysis / security). The verify-before-exec invariant holds. Fixes folded in: the platform fallback (a pin mismatch on an unprovisionable platform ran in-process instead of hard-erroring), the `packageManager`-field-only read (was reading `devEngines`), the escape hatch named in every bail, and `0700` on the self store.

## Follow-ups

- A per-release binary signature layer (closes the same-origin residual).
- GC / `nub pm cache clear` coverage for the new `~/.cache/nub/self` store.
- Real win32 provisioning (win32 ships `.zip`, not `.tar.gz`; today Windows falls through to the local nub with a notice).
- `nub pm which`/`update` still print "unsupported package manager nub" on a nub pin (non-mutating, out of this scope; a `Pm::Nub` variant would be a large blast radius).

https://claude.ai/code/session_01FRRTvRH4BLKmxtbx8GMsTH
