### PR TITLE
feat(pm): virgin install writes a devEngines caret range, not an exact packageManager pin

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -5945,7 +5945,12 @@ fn run_pm(args: &[String]) -> Result<i32> {
                     .unwrap_or_else(|_| PathBuf::from("nub"));
                 println!("{}", exe.display());
                 std::io::stdout().flush().ok();
-                eprintln!("» this project uses nub (resolved from packageManager)");
+                // Name the field the nub identity actually resolved from — the
+                // virgin/bare-`use` path pins via `devEngines.packageManager`
+                // (no exact `packageManager`), only `use nub@<exact>` writes the
+                // latter.
+                let field = field_pin_provenance(&cwd);
+                eprintln!("» this project uses nub (resolved from {field})");
                 return Ok(0);
             }
             // A project may DECLARE a manager nub doesn't provision (bun — and
@@ -6168,13 +6173,14 @@ fn split_pm_arg(arg: &str) -> Result<(&str, Option<&str>)> {
     };
     // `nub pm use nub@<exact>` is the opt-in HARD pin (writes `packageManager:
     // nub@<v>`); bare `nub pm use nub` is the non-locking devEngines range. nub
-    // is the running binary, not a registry package, so its spec must be a
-    // concrete version to pin exactly — a dist-tag/range has nothing to resolve
-    // against (unlike npm/pnpm/yarn, whose specs resolve via the registry).
+    // is the running binary, not a registry package, so its spec must be an
+    // EXACT semver to pin — a dist-tag or range (`next`, `^1`, `1.x`, `1`) has
+    // nothing to resolve against (unlike npm/pnpm/yarn, whose specs resolve via
+    // the registry), so it never reaches the `packageManager` field.
     if name == "nub"
         && let Some(s) = spec
         && s != "latest"
-        && !s.chars().next().is_some_and(|c| c.is_ascii_digit())
+        && semver::Version::parse(s).is_err()
     {
         bail!(
             "`nub pm use nub@{s}` needs an exact version (e.g. nub@{0}) — nub is the \
@@ -8798,12 +8804,16 @@ mod tests {
         );
         // `use nub` is a live target (the full switch). Bare + `nub@<exact>` are
         // both valid; only a range/dist-tag spec is refused — nub is the running
-        // binary, so there is nothing to resolve a range against.
-        let err = run(&["use", "nub@next"]);
-        assert!(
-            err.contains("needs an exact version") && err.contains("running binary"),
-            "`use nub@<range/tag>` must refuse with the exact-version rule: {err}"
-        );
+        // binary, so there is nothing to resolve a range against. Both a dist-tag
+        // (`next`) and a digit-LEADING range (`1.x`) must be caught: the guard
+        // requires an exact semver parse, not merely a leading digit.
+        for bad in ["nub@next", "nub@1.x", "nub@1", "nub@^1.2.3"] {
+            let err = run(&["use", bad]);
+            assert!(
+                err.contains("needs an exact version") && err.contains("running binary"),
+                "`use {bad}` must refuse with the exact-version rule: {err}"
+            );
+        }
         assert!(
             run(&["use", "pnpm@"]).contains("empty version spec"),
             "a trailing @ is named, not treated as latest"

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -6157,17 +6157,29 @@ fn berry_pin_refusal(cwd: &Path) -> String {
 /// resolved against the registry before anything is written (never a range
 /// into `packageManager`). Berry (`yarn@<2+>`) is refused later, by the shared
 /// flow, once a concrete major is known. `use nub` (the full switch into nub
-/// identity, 2026-06-10 reversal) takes no version spec: it pins the running
-/// nub's own version — there is nothing to resolve.
+/// identity) takes an optional EXACT version: bare `nub` writes the non-locking
+/// devEngines caret range, `nub@<exact>` opts into the hard `packageManager`
+/// pin. A range/dist-tag spec for nub is refused — nub is the running binary,
+/// not a registry package, so there is nothing to resolve a range against.
 fn split_pm_arg(arg: &str) -> Result<(&str, Option<&str>)> {
     let (name, spec) = match arg.split_once('@') {
         Some((n, s)) => (n, Some(s.trim())),
         None => (arg, None),
     };
-    if name == "nub" && spec.is_some() {
+    // `nub pm use nub@<exact>` is the opt-in HARD pin (writes `packageManager:
+    // nub@<v>`); bare `nub pm use nub` is the non-locking devEngines range. nub
+    // is the running binary, not a registry package, so its spec must be a
+    // concrete version to pin exactly — a dist-tag/range has nothing to resolve
+    // against (unlike npm/pnpm/yarn, whose specs resolve via the registry).
+    if name == "nub"
+        && let Some(s) = spec
+        && s != "latest"
+        && !s.chars().next().is_some_and(|c| c.is_ascii_digit())
+    {
         bail!(
-            "`nub pm use nub` takes no version — it pins the running nub ({}); \
-             update nub itself with `nub upgrade`.",
+            "`nub pm use nub@{s}` needs an exact version (e.g. nub@{0}) — nub is the \
+             running binary, not a registry package, so a range/tag can't be resolved. \
+             Bare `nub pm use nub` writes a non-locking devEngines range instead.",
             env!("CARGO_PKG_VERSION")
         );
     }
@@ -6362,7 +6374,12 @@ fn run_pm_use(name: &str, spec: &str, cwd: &Path) -> Result<i32> {
     // pm_engine::use_nub (manifest fields, lockfile rename/convert,
     // workspace-yaml migration, printed summary).
     if name == "nub" {
-        return crate::pm_engine::use_nub::run_use_nub(&root);
+        // A bare `nub pm use nub` arrives here with the "latest" default spec —
+        // it means the non-locking range, not an exact pin, so map it to `None`.
+        // Only an explicit `nub@<version>` (a concrete pin) opts into the hard
+        // `packageManager` field.
+        let exact_pin = (spec != "latest").then_some(spec);
+        return crate::pm_engine::use_nub::run_use_nub(&root, exact_pin);
     }
 
     let plan = use_align::plan_alignment(&root, name)?;
@@ -8779,12 +8796,13 @@ mod tests {
             run(&["use", "vlt"]).contains("npm, pnpm, yarn, bun, or nub"),
             "an unsupported PM names the use target set"
         );
-        // `use nub` is a live target (the full switch) but takes no version:
-        // it pins the running nub.
-        let err = run(&["use", "nub@1.2.3"]);
+        // `use nub` is a live target (the full switch). Bare + `nub@<exact>` are
+        // both valid; only a range/dist-tag spec is refused — nub is the running
+        // binary, so there is nothing to resolve a range against.
+        let err = run(&["use", "nub@next"]);
         assert!(
-            err.contains("takes no version") && err.contains("nub upgrade"),
-            "`use nub@<v>` must refuse with the self-version rule: {err}"
+            err.contains("needs an exact version") && err.contains("running binary"),
+            "`use nub@<range/tag>` must refuse with the exact-version rule: {err}"
         );
         assert!(
             run(&["use", "pnpm@"]).contains("empty version spec"),

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1056,44 +1056,50 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     }
 
     let code = run_engine(&session, opts, yarn, &flags.output)?;
-    // Virgin install only: stamp `packageManager: nub@<v>` so the project
-    // advertises nub the standard, cross-tool way. nub's canonical lockfile is
-    // deliberately NEUTRAL (`package.lock`), so — unlike every other PM, whose
-    // branded lockfile is itself the repo's PM signal — nub leaves no signal
-    // downstream tools (turbo, …) can read. The `packageManager` field IS that
-    // signal. The write is gated on `session.truly_fresh`, captured BEFORE the
-    // engine wrote `package.lock`: it is `true` ONLY when nub is the FIRST package
-    // manager to touch the project (no foreign lockfile, no pre-existing nub
-    // lockfile, no `packageManager`/`devEngines` declaration). Any incumbent
-    // signal ⇒ `false` ⇒ no write — nub never imposes its brand on another PM's
-    // project (the symmetric brand boundary). `devEngines` is NOT written here:
-    // that heavier exclusivity stamp stays on the explicit `nub pm use nub`.
+    // Virgin install only: stamp a caret RANGE into `devEngines.packageManager`
+    // so the project advertises nub the standard, cross-tool way WITHOUT locking
+    // itself to one exact nub version. nub's canonical lockfile is deliberately
+    // NEUTRAL (`package.lock`), so — unlike every other PM, whose branded lockfile
+    // is itself the repo's PM signal — nub leaves no signal downstream tools
+    // (turbo, pmd, nypm) can read; the `devEngines.packageManager` object IS that
+    // signal, and detectors key on its `name`, so a `^` range is signal-equivalent
+    // to an exact pin while staying a non-locking floor (upgrades just work). It is
+    // NOT the exact `packageManager: nub@<v>` field: that hard, corepack-visible
+    // pin freezes the repo at one nub version and stays the OPT-IN gesture of an
+    // explicit `nub pm use nub@<exact>`. The write is gated on
+    // `session.truly_fresh`, captured BEFORE the engine wrote `package.lock`: `true`
+    // ONLY when nub is the FIRST package manager to touch the project (no foreign
+    // lockfile, no pre-existing nub lockfile, no `packageManager`/`devEngines`
+    // declaration). Any incumbent signal ⇒ `false` ⇒ no write — nub never imposes
+    // its brand on another PM's project (the symmetric brand boundary).
     stamp_if_virgin(&session, code);
     Ok(code)
 }
 
-/// Stamp the virgin `packageManager` marker after a successful package.json-
-/// modifying engine verb (`install`/`add`/`remove`/`update`). Gated on
-/// `session.truly_fresh` — captured at session build, BEFORE the verb wrote
-/// the lockfile — so it fires exactly once, on the FIRST package-manager
+/// Stamp the virgin `devEngines.packageManager` range after a successful
+/// package.json-modifying engine verb (`install`/`add`/`remove`/`update`).
+/// Gated on `session.truly_fresh` — captured at session build, BEFORE the verb
+/// wrote the lockfile — so it fires exactly once, on the FIRST package-manager
 /// operation in a project nub is first to touch, and the gate self-corrects:
 /// a non-virgin project (any lockfile/declaration present) never stamps,
 /// whichever verb ran. `import` is intentionally not a caller — it converts an
 /// existing FOREIGN lockfile, so its project is non-virgin by construction.
 fn stamp_if_virgin(session: &EngineSession, code: i32) {
     if code == 0 && session.truly_fresh {
-        stamp_virgin_package_manager(&session.cwd);
+        stamp_virgin_dev_engines(&session.cwd);
     }
 }
 
-/// Write `packageManager: "nub@<exact-version>"` into the project manifest of a
-/// VIRGIN install. Best-effort: a successful install must not fail on a manifest
-/// the stamp can't reach (no `package.json` — nub never scaffolds one — or an
-/// unwritable file). Format-preserving + atomic via the shared manifest editor;
-/// it ranks the new key by insertion order at the manifest's tail, leaving the
-/// user's existing keys untouched. The caller has already proven virginity, so
-/// there is no foreign `packageManager` to clobber.
-fn stamp_virgin_package_manager(cwd: &Path) {
+/// Write `devEngines.packageManager = {name:"nub", version:"^<x.y.z>",
+/// onFail:"warn"}` into the project manifest of a VIRGIN install — the
+/// non-locking cross-tool PM signal (see the call-site comment). Best-effort: a
+/// successful install must not fail on a manifest the stamp can't reach (no
+/// `package.json` — nub never scaffolds one — or an unwritable file).
+/// Format-preserving + atomic via the shared manifest editor; it ranks the new
+/// key by insertion order at the manifest's tail, leaving the user's existing
+/// keys untouched. The caller has already proven virginity (no prior
+/// `devEngines`), so the object is created wholesale.
+fn stamp_virgin_dev_engines(cwd: &Path) {
     // Skip silently when the install ran without a `package.json` (the editor
     // refuses to scaffold one); the install already succeeded, so this is a
     // no-op, not an error.
@@ -1104,27 +1110,35 @@ fn stamp_virgin_package_manager(cwd: &Path) {
     // virginity from aube's lockfile detection, which does NOT recognize two
     // foreign PM signals: bun's pre-1.2 BINARY lockfile `bun.lockb` (only the
     // text `bun.lock` is a detection candidate) and a lone yarn-berry
-    // `.yarnrc.yml` config with no `yarn.lock` yet. Without this re-check a
-    // `packageManager: nub@…` stamp could land in a bun/yarn-owned project —
+    // `.yarnrc.yml` config with no `yarn.lock` yet. Without this re-check a nub
+    // `devEngines.packageManager` stamp could land in a bun/yarn-owned project —
     // exactly the brand imposition the virgin predicate forbids. Walk up like
     // `is_truly_fresh_project` does for pnpm-named files, and bail on a hit.
     if dir_walk_up_has_any(cwd, &["bun.lockb", ".yarnrc.yml"]) {
         return;
     }
     // Stamp ONLY when this op wrote nub's OWN canonical (neutral) lockfile. The
-    // field's whole purpose is to supply the PM signal that nub's UNBRANDED
+    // stamp's whole purpose is to supply the PM signal that nub's UNBRANDED
     // lockfile otherwise withholds; when a virgin project resolves to a FOREIGN
     // lockfile format instead (e.g. `default_lockfile_format=pnpm`), that
-    // lockfile IS the signal — so the stamp is unneeded, AND a `nub@…` claim
-    // beside a pnpm/npm-format lock makes corepack-enforcing PMs refuse the
-    // project. Keyed off the canonical-lockfile NAME accessor (rename-safe;
-    // resolves the embedder profile + git-branch variant).
+    // lockfile IS the signal — so the stamp is unneeded, AND a nub claim beside a
+    // pnpm/npm-format lock misrepresents the project. Keyed off the
+    // canonical-lockfile NAME accessor (rename-safe; resolves the embedder
+    // profile + git-branch variant).
     if !root.join(aube_lockfile::aube_lock_filename(&root)).exists() {
         return;
     }
-    let value = format!("nub@{}", env!("CARGO_PKG_VERSION"));
+    let range = format!("^{}", env!("CARGO_PKG_VERSION"));
     let _ = nub_core::pm::resolve::edit_root_manifest(&root, |obj| {
-        obj.insert("packageManager".into(), serde_json::Value::String(value));
+        let dev = obj
+            .entry("devEngines")
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        if let Some(dev) = dev.as_object_mut() {
+            dev.insert(
+                "packageManager".into(),
+                serde_json::json!({ "name": "nub", "version": range, "onFail": "warn" }),
+            );
+        }
     });
 }
 
@@ -1781,11 +1795,11 @@ mod tests {
         );
     }
 
-    /// The virgin stamp writes `packageManager: "nub@<running-version>"` in the
-    /// corepack `<name>@<semver>` shape, appended at the manifest tail (the
-    /// `preserve_order` editor never reflows the user's existing keys). Gating
-    /// on virginity is the caller's job; this asserts the write itself.
-    /// Seed nub's OWN canonical lockfile in `dir` so the stamp's
+    /// The virgin stamp writes the `devEngines.packageManager` caret range
+    /// object, appended at the manifest tail (the `preserve_order` editor never
+    /// reflows the user's existing keys), and NEVER the hard `packageManager`
+    /// pin. Gating on virginity is the caller's job; this asserts the write
+    /// itself. Seed nub's OWN canonical lockfile in `dir` so the stamp's
     /// "nub wrote its neutral format" gate passes deterministically, whichever
     /// embedder profile the test binary happens to have registered.
     fn seed_nub_lockfile(dir: &Path) {
@@ -1797,7 +1811,7 @@ mod tests {
     }
 
     #[test]
-    fn virgin_stamp_writes_corepack_shape_at_tail() {
+    fn virgin_stamp_writes_dev_engines_range_at_tail() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("package.json"),
@@ -1806,20 +1820,27 @@ mod tests {
         .unwrap();
         seed_nub_lockfile(dir.path());
 
-        stamp_virgin_package_manager(dir.path());
+        stamp_virgin_dev_engines(dir.path());
 
         let written = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
-        let expected = format!("nub@{}", env!("CARGO_PKG_VERSION"));
         let manifest: serde_json::Value = serde_json::from_str(&written).unwrap();
         assert_eq!(
-            manifest["packageManager"].as_str(),
-            Some(expected.as_str()),
-            "value must be the running nub version in corepack shape"
+            manifest.pointer("/devEngines/packageManager"),
+            Some(&serde_json::json!({
+                "name": "nub",
+                "version": format!("^{}", env!("CARGO_PKG_VERSION")),
+                "onFail": "warn"
+            })),
+            "value must be the non-locking caret range on the running nub version"
+        );
+        assert!(
+            manifest.get("packageManager").is_none(),
+            "the virgin stamp must NOT write the hard packageManager pin: {written:?}"
         );
         // Tail-append + format preservation: the pre-existing keys keep their
-        // order and the new key lands last, so the diff is one added line.
+        // order and the new key lands last, so the diff is one added block.
         assert!(
-            written.contains("\"version\": \"1.0.0\",\n  \"packageManager\""),
+            written.contains("\"version\": \"1.0.0\",\n  \"devEngines\""),
             "stamp must append after the user's keys, not reflow them: {written:?}"
         );
     }
@@ -1837,7 +1858,7 @@ mod tests {
         if find_manifest_root(dir.path()).is_some() {
             return;
         }
-        stamp_virgin_package_manager(dir.path());
+        stamp_virgin_dev_engines(dir.path());
         assert!(
             !dir.path().join("package.json").exists(),
             "stamp must never scaffold a missing package.json"
@@ -1862,11 +1883,7 @@ mod tests {
             truly_fresh,
             cwd: dir.path().to_path_buf(),
         };
-        let stamped = |p: &Path| {
-            std::fs::read_to_string(p)
-                .unwrap()
-                .contains("packageManager")
-        };
+        let stamped = |p: &Path| std::fs::read_to_string(p).unwrap().contains("devEngines");
 
         seed_nub_lockfile(dir.path());
 
@@ -1886,8 +1903,8 @@ mod tests {
     /// Stamp ONLY when nub wrote its own neutral lockfile. A virgin project that
     /// resolved to a FOREIGN lockfile format (e.g. `default_lockfile_format=pnpm`
     /// writes `pnpm-lock.yaml`, not nub's lockfile) is NOT stamped — that
-    /// lockfile is already the PM signal, and a `nub@…` claim beside it would
-    /// make corepack-enforcing PMs refuse the project.
+    /// lockfile is already the PM signal, and a nub claim beside it would
+    /// misrepresent the project.
     #[test]
     fn virgin_stamp_skips_when_nub_wrote_no_neutral_lockfile() {
         let dir = tempfile::tempdir().unwrap();
@@ -1902,18 +1919,18 @@ mod tests {
         )
         .unwrap();
 
-        stamp_virgin_package_manager(dir.path());
+        stamp_virgin_dev_engines(dir.path());
 
         let written = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
         assert!(
-            !written.contains("packageManager"),
+            !written.contains("devEngines"),
             "a foreign-format lockfile must not get a nub stamp: {written:?}"
         );
     }
 
     /// Symmetric brand boundary: a foreign PM signal aube's detection misses
     /// (`bun.lockb`, pre-1.2 bun) still blocks the stamp, so nub never imposes
-    /// `packageManager: nub@…` on a bun-owned project.
+    /// its `devEngines` marker on a bun-owned project.
     #[test]
     fn virgin_stamp_skips_an_undetected_foreign_lockfile() {
         let dir = tempfile::tempdir().unwrap();
@@ -1925,11 +1942,11 @@ mod tests {
         seed_nub_lockfile(dir.path()); // isolate the bun.lockb guard, not the no-lockfile path
         std::fs::write(dir.path().join("bun.lockb"), b"\0bun").unwrap();
 
-        stamp_virgin_package_manager(dir.path());
+        stamp_virgin_dev_engines(dir.path());
 
         let written = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
         assert!(
-            !written.contains("packageManager"),
+            !written.contains("devEngines"),
             "a bun.lockb project must not be stamped: {written:?}"
         );
     }

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1134,9 +1134,14 @@ fn stamp_virgin_dev_engines(cwd: &Path) {
             .entry("devEngines")
             .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
         if let Some(dev) = dev.as_object_mut() {
-            dev.insert(
-                "packageManager".into(),
-                serde_json::json!({ "name": "nub", "version": range, "onFail": "warn" }),
+            // Never overwrite an existing `devEngines.packageManager`. The
+            // `truly_fresh` gate keys on lockfiles + pnpm-named files, NOT on the
+            // manifest's declaration fields, so a hand-written foreign
+            // `devEngines.packageManager` (e.g. `{name:"pnpm"}`) can coexist with
+            // a virgin lockfile state — and clobbering it would impose nub's
+            // brand over another PM's declaration (the symmetric brand boundary).
+            dev.entry("packageManager").or_insert_with(
+                || serde_json::json!({ "name": "nub", "version": range, "onFail": "warn" }),
             );
         }
     });
@@ -1842,6 +1847,39 @@ mod tests {
         assert!(
             written.contains("\"version\": \"1.0.0\",\n  \"devEngines\""),
             "stamp must append after the user's keys, not reflow them: {written:?}"
+        );
+    }
+
+    /// The stamp NEVER overwrites an existing `devEngines.packageManager`. The
+    /// `truly_fresh` gate keys on lockfiles + pnpm-named files, not on manifest
+    /// declarations, so a hand-written foreign `devEngines.packageManager` can
+    /// reach this path — and imposing nub's brand over it would break the
+    /// symmetric brand boundary. A sibling `devEngines` entry is left intact.
+    #[test]
+    fn virgin_stamp_never_overwrites_an_existing_dev_engines_pin() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"app","devEngines":{"packageManager":{"name":"pnpm","version":"^10"},"runtime":{"name":"node"}}}"#,
+        )
+        .unwrap();
+        seed_nub_lockfile(dir.path());
+
+        stamp_virgin_dev_engines(dir.path());
+
+        let manifest: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("package.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            manifest.pointer("/devEngines/packageManager/name"),
+            Some(&serde_json::json!("pnpm")),
+            "a foreign devEngines.packageManager must not be clobbered by the nub stamp"
+        );
+        assert_eq!(
+            manifest.pointer("/devEngines/runtime/name"),
+            Some(&serde_json::json!("node")),
+            "a sibling devEngines entry survives"
         );
     }
 

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -587,11 +587,11 @@ pub(crate) struct EngineSession {
     /// file. Captured BEFORE the engine writes anything, so it reflects the
     /// pre-install state: the FIRST install in a virgin project sees `true`;
     /// every subsequent install (nub's lockfile now present ⇒ `detected` is
-    /// `Some`) sees `false`. The install family reads this to stamp
-    /// `packageManager: nub@<v>` exactly once, on the virgin install.
+    /// `Some`) sees `false`. The install family reads this to stamp the
+    /// `devEngines.packageManager` caret range exactly once, on the virgin install.
     pub(crate) truly_fresh: bool,
     /// The resolved working directory the session ran in (after `--dir`). The
-    /// install family writes the virgin `packageManager` stamp relative to it.
+    /// install family writes the virgin `devEngines` stamp relative to it.
     pub(crate) cwd: PathBuf,
 }
 
@@ -806,11 +806,12 @@ fn engine_session_inner(
     // neutral lockfile: the embedder default flips to `package.lock`, the quiet
     // identity marker the classifier reads back as nub. Any incumbent signal
     // makes the project pnpm-shaped/compat and is respected untouched. On a
-    // virgin install the install family ALSO stamps `packageManager: nub@<v>`
-    // (see `install_family::stamp_virgin_package_manager`) — safe ONLY because
+    // virgin install the install family ALSO stamps the non-locking
+    // `devEngines.packageManager` caret range (see
+    // `install_family::stamp_virgin_dev_engines`) — safe ONLY because
     // `truly_fresh` proves no other PM owns the project (the symmetric brand
-    // boundary); `nub pm use nub` remains the explicit, heavier identity stamper
-    // (it also writes `devEngines`).
+    // boundary). `nub pm use nub@<exact>` remains the explicit opt-in for the
+    // hard `packageManager: nub@<v>` pin.
     let truly_fresh = is_truly_fresh_project(&cwd, detected.as_ref());
     // Set-unless-user-set: ranks below CLI flags, env vars, and every
     // config file in the engine's settings precedence.

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -581,14 +581,15 @@ pub(crate) fn stub_error(typed: &str, args: &[String], pm_hint: &str) -> anyhow:
 pub(crate) struct EngineSession {
     pub(crate) detected: Option<DetectedLockfile>,
     pub(crate) runtime: tokio::runtime::Runtime,
-    /// No PM-preference signal anywhere at session-build time — no lockfile of
-    /// ANY package manager (npm/pnpm/yarn/bun, NOR nub's own canonical
-    /// lockfile), no `packageManager`/`devEngines` declaration, no pnpm-named
-    /// file. Captured BEFORE the engine writes anything, so it reflects the
-    /// pre-install state: the FIRST install in a virgin project sees `true`;
-    /// every subsequent install (nub's lockfile now present ⇒ `detected` is
-    /// `Some`) sees `false`. The install family reads this to stamp the
-    /// `devEngines.packageManager` caret range exactly once, on the virgin install.
+    /// No PM-preference lockfile signal at session-build time — no lockfile of
+    /// ANY package manager (npm/pnpm/yarn/bun, NOR nub's own canonical lockfile)
+    /// and no pnpm-named file (`is_truly_fresh_project` keys on those, not on the
+    /// manifest's declaration fields). Captured BEFORE the engine writes
+    /// anything, so it reflects the pre-install state: the FIRST install in a
+    /// virgin project sees `true`; every subsequent install (nub's lockfile now
+    /// present ⇒ `detected` is `Some`) sees `false`. The install family reads
+    /// this to stamp the `devEngines.packageManager` caret range exactly once,
+    /// on the virgin install (and never over an existing `devEngines` pin).
     pub(crate) truly_fresh: bool,
     /// The resolved working directory the session ran in (after `--dir`). The
     /// install family writes the virgin `devEngines` stamp relative to it.

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -6,10 +6,11 @@
 //! its Bun-names addendum). The two-mode model in one paragraph: compat mode
 //! (default) plays the incumbent PM's role completely — its lockfile, its
 //! config surface, its grammar. `pm use nub` is the explicit graduation:
-//! `packageManager: "nub@<exact>"` + `devEngines.packageManager
-//! {name:"nub", version:"^<ver>", onFail:"warn"}`, the lockfile renamed (or
-//! converted) to `package.lock` (pnpm-v9 bytes, generic name), and
-//! `pnpm-workspace.yaml` ALWAYS migrated and deleted:
+//! `devEngines.packageManager {name:"nub", version:"^<ver>", onFail:"warn"}`
+//! (the non-locking cross-tool signal, always written) plus — ONLY on the
+//! explicit `pm use nub@<exact>` opt-in — the hard `packageManager: "nub@<exact>"`
+//! pin; the lockfile renamed (or converted) to `package.lock` (pnpm-v9 bytes,
+//! generic name), and `pnpm-workspace.yaml` ALWAYS migrated and deleted:
 //!
 //! - resolution-bearing keys → `package.json` under ecosystem-standard
 //!   top-level names (`workspaces` incl. the object form,
@@ -541,24 +542,36 @@ pub(crate) fn plan_migration(source: &Map<String, Value>) -> Result<YamlMigratio
 pub(crate) fn apply_manifest_edits(
     obj: &mut Map<String, Value>,
     m: &YamlMigration,
-    nub_version: &str,
+    exact_pin: Option<&str>,
+    range_version: &str,
 ) -> Vec<String> {
     let mut notes = Vec::new();
 
-    obj.insert(
-        "packageManager".into(),
-        Value::String(format!("nub@{nub_version}")),
-    );
-    // devEngines.packageManager: created (this verb is the one sanctioned
-    // creator), replacing any prior entry wholesale; sibling devEngines
-    // entries (runtime/os/…) survive.
+    // The exact `packageManager: nub@<v>` field is a HARD, corepack-visible pin
+    // that freezes the repo at one nub version — so it is written ONLY on the
+    // explicit opt-in `nub pm use nub@<exact>`. Bare `nub pm use nub` is the
+    // non-locking gesture: it writes only the devEngines range below, and REMOVES
+    // any prior `packageManager` (a stale exact nub pin being unlocked, or the
+    // incumbent PM's pin being cleared as identity moves to nub) so the field
+    // never contradicts the devEngines entry.
+    match exact_pin {
+        Some(v) => {
+            obj.insert("packageManager".into(), Value::String(format!("nub@{v}")));
+        }
+        None => {
+            obj.remove("packageManager");
+        }
+    }
+    // devEngines.packageManager: the always-written signal (this verb is a
+    // sanctioned creator), replacing any prior entry wholesale; sibling
+    // devEngines entries (runtime/os/…) survive.
     let dev = obj
         .entry("devEngines")
         .or_insert_with(|| Value::Object(Map::new()));
     if let Some(dev) = dev.as_object_mut() {
         dev.insert(
             "packageManager".into(),
-            json!({ "name": "nub", "version": format!("^{nub_version}"), "onFail": "warn" }),
+            json!({ "name": "nub", "version": format!("^{range_version}"), "onFail": "warn" }),
         );
     }
 
@@ -798,9 +811,12 @@ fn pnpm_vocab_precedence(root: &Path) -> VocabPrecedence {
 }
 
 /// `nub pm use nub` — the full switch. `root` is the workspace root (where
-/// the declaration, lockfiles, yaml, and `.npmrc` live). Prints the
-/// file-by-file summary; never silent.
-pub(crate) fn run_use_nub(root: &Path) -> Result<i32> {
+/// the declaration, lockfiles, yaml, and `.npmrc` live). `exact_pin` carries an
+/// explicit `nub pm use nub@<version>` opt-in: `Some(v)` writes the hard
+/// `packageManager: nub@<v>` pin (and bases the devEngines range on `v`); `None`
+/// (bare `nub pm use nub`) writes only the non-locking devEngines caret range on
+/// the running version. Prints the file-by-file summary; never silent.
+pub(crate) fn run_use_nub(root: &Path, exact_pin: Option<&str>) -> Result<i32> {
     // The brand preflight registers the yaml names + package.lock filename the
     // discovery below and the engine writers read.
     super::engine_brand_preflight();
@@ -847,18 +863,24 @@ pub(crate) fn run_use_nub(root: &Path) -> Result<i32> {
         }
     );
     // ── writes ──────────────────────────────────────────────────────────
-    let nub_version = env!("CARGO_PKG_VERSION");
+    // The devEngines range is based on the pinned version when one is named
+    // (`nub@<v>`), else the running binary. The exact `packageManager` field is
+    // written only for the named-version opt-in (see `apply_manifest_edits`).
+    let running_version = env!("CARGO_PKG_VERSION");
+    let range_version = exact_pin.unwrap_or(running_version);
     let mut manifest_notes = Vec::new();
     nub_core::pm::resolve::edit_root_manifest(root, |obj| {
-        manifest_notes = apply_manifest_edits(obj, &migration, nub_version);
+        manifest_notes = apply_manifest_edits(obj, &migration, exact_pin, range_version);
     })?;
 
     let (appended, skipped) = append_npmrc(root, &migration.npmrc)?;
 
-    println!("using nub@{nub_version}");
-    println!("  package.json: packageManager = nub@{nub_version}");
+    println!("using nub@{running_version}");
+    if let Some(v) = exact_pin {
+        println!("  package.json: packageManager = nub@{v}");
+    }
     println!(
-        "  package.json: devEngines.packageManager = {{ name: \"nub\", version: \"^{nub_version}\", onFail: \"warn\" }}"
+        "  package.json: devEngines.packageManager = {{ name: \"nub\", version: \"^{range_version}\", onFail: \"warn\" }}"
     );
     if migration.packages.is_some() || migration.catalog.is_some() || migration.catalogs.is_some() {
         println!(
@@ -966,8 +988,13 @@ pub(crate) fn run_use_nub(root: &Path) -> Result<i32> {
     // support thread later.
     println!();
     println!("heads-up for teammates and tooling not on nub:");
-    println!("  - corepack-enabled shells hard-error on packageManager \"nub@…\" —");
-    println!("    fix: install nub (npm i -g @nubjs/nub) or `corepack disable`");
+    // The corepack hard-error is triggered by the exact `packageManager` field
+    // only — corepack ignores `devEngines`, so the bare (range-only) switch does
+    // not hit it.
+    if exact_pin.is_some() {
+        println!("  - corepack-enabled shells hard-error on packageManager \"nub@…\" —");
+        println!("    fix: install nub (npm i -g @nubjs/nub) or `corepack disable`");
+    }
     println!("  - real pnpm refuses to run here (ERR_PNPM_OTHER_PM_EXPECTED) — by design;");
     println!("    `nub pm use pnpm` reverses this switch completely");
     println!("  - turbo requires a recognized packageManager + lockfile name and will error");
@@ -1255,8 +1282,9 @@ mod tests {
             "catalog": { "react": "^18.0.0" }
         })))
         .unwrap();
+        // Explicit `nub@<exact>` opt-in: the hard packageManager pin IS written.
         let mut obj = src(json!({ "name": "app", "pnpm": { "overrides": {} } }));
-        apply_manifest_edits(&mut obj, &m, "0.1.0");
+        apply_manifest_edits(&mut obj, &m, Some("0.1.0"), "0.1.0");
 
         assert_eq!(obj.get("packageManager"), Some(&json!("nub@0.1.0")));
         assert_eq!(
@@ -1270,6 +1298,21 @@ mod tests {
         );
         assert!(obj.get("pnpm").is_none(), "pnpm namespace must be removed");
 
+        // Bare `nub pm use nub` (None): devEngines range only, and any prior
+        // packageManager (here the incumbent pnpm pin) is CLEARED so the field
+        // never contradicts the nub devEngines entry.
+        let mut obj = src(json!({ "name": "app", "packageManager": "pnpm@9.1.0" }));
+        apply_manifest_edits(&mut obj, &m, None, "0.2.9");
+        assert!(
+            obj.get("packageManager").is_none(),
+            "bare use nub writes no exact packageManager and clears the incumbent pin: {obj:?}"
+        );
+        assert_eq!(
+            obj.get("devEngines").unwrap().get("packageManager"),
+            Some(&json!({ "name": "nub", "version": "^0.2.9", "onFail": "warn" })),
+            "bare use nub still writes the non-locking devEngines range"
+        );
+
         // Conflicting top-level override: package.json wins, named in notes.
         let m = plan_migration(&src(json!({
             "packages": ["packages/*"],
@@ -1277,7 +1320,7 @@ mod tests {
         })))
         .unwrap();
         let mut obj = src(json!({ "name": "app", "overrides": { "lodash": "4.17.20" } }));
-        let notes = apply_manifest_edits(&mut obj, &m, "0.1.0");
+        let notes = apply_manifest_edits(&mut obj, &m, Some("0.1.0"), "0.1.0");
         assert_eq!(
             obj.get("overrides").unwrap().get("lodash"),
             Some(&json!("4.17.20")),

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -127,21 +127,26 @@ fn install_truly_fresh_project_claims_nub_identity() {
         "neither pnpm-lock.yaml nor aube-lock.yaml may appear on the truly-fresh path"
     );
 
-    // A virgin install stamps `packageManager: nub@<v>` (the PM signal nub's
-    // neutral package.lock withholds) — only that field, never `devEngines` (the
-    // heavier exclusivity claim stays on `nub pm use nub`). Identity is also
+    // A virgin install stamps a caret RANGE into `devEngines.packageManager`
+    // (the non-locking PM signal nub's neutral package.lock withholds) — never
+    // the hard, corepack-visible `packageManager: nub@<v>` pin, which stays the
+    // opt-in of an explicit `nub pm use nub@<exact>`. Identity is also
     // self-reinforcing via the lockfile: the next install sees package.lock and is
     // no longer virgin, so it never re-stamps.
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
     assert_eq!(
-        manifest.get("packageManager").and_then(|v| v.as_str()),
-        Some(concat!("nub@", env!("CARGO_PKG_VERSION"))),
-        "a virgin install stamps packageManager: nub@<version>: {manifest}"
+        manifest.pointer("/devEngines/packageManager"),
+        Some(&serde_json::json!({
+            "name": "nub",
+            "version": concat!("^", env!("CARGO_PKG_VERSION")),
+            "onFail": "warn"
+        })),
+        "a virgin install stamps a devEngines.packageManager caret range: {manifest}"
     );
     assert!(
-        manifest.get("devEngines").is_none(),
-        "the virgin stamp writes only packageManager, never devEngines: {manifest}"
+        manifest.get("packageManager").is_none(),
+        "the virgin stamp writes only the devEngines range, never the exact packageManager pin: {manifest}"
     );
 }
 
@@ -493,10 +498,11 @@ fn install_refuses_to_mutate_a_drifted_yarn_lock() {
 
 /// A truly-fresh `nub add` claims nub identity exactly like a fresh `install`:
 /// the add resolves + writes nub's neutral `package.lock` and adds the dep, and —
-/// because the project is virgin (nub is the first PM to touch it) — stamps
-/// `packageManager: nub@<v>`. Only that field; `devEngines` stays unstamped
-/// (the heavier claim is `nub pm use nub`'s). This is the common case the stamp
-/// targets: `nub add <pkg>` as the first command on a fresh project.
+/// because the project is virgin (nub is the first PM to touch it) — stamps the
+/// non-locking `devEngines.packageManager` caret range. Never the exact
+/// `packageManager: nub@<v>` pin (that is `nub pm use nub@<exact>`'s opt-in).
+/// This is the common case the stamp targets: `nub add <pkg>` as the first
+/// command on a fresh project.
 #[test]
 #[ignore = "network: resolves + fetches is-positive@3.1.0 from the npm registry"]
 fn add_on_a_truly_fresh_project_claims_nub_identity() {
@@ -526,13 +532,17 @@ fn add_on_a_truly_fresh_project_claims_nub_identity() {
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
     assert_eq!(
-        manifest.get("packageManager").and_then(|v| v.as_str()),
-        Some(concat!("nub@", env!("CARGO_PKG_VERSION"))),
-        "a virgin add stamps packageManager: nub@<version>: {manifest}"
+        manifest.pointer("/devEngines/packageManager"),
+        Some(&serde_json::json!({
+            "name": "nub",
+            "version": concat!("^", env!("CARGO_PKG_VERSION")),
+            "onFail": "warn"
+        })),
+        "a virgin add stamps a devEngines.packageManager caret range: {manifest}"
     );
     assert!(
-        manifest.get("devEngines").is_none(),
-        "the virgin stamp writes only packageManager, never devEngines: {manifest}"
+        manifest.get("packageManager").is_none(),
+        "the virgin stamp writes only the devEngines range, never the exact packageManager pin: {manifest}"
     );
     assert_eq!(
         manifest["dependencies"]["is-positive"].as_str(),

--- a/crates/nub-cli/tests/pm_identity.rs
+++ b/crates/nub-cli/tests/pm_identity.rs
@@ -63,10 +63,10 @@ const EMPTY_PNPM: &str = r#"{"name":"app","version":"1.0.0","packageManager":"pn
 #[test]
 fn fresh_projects_write_the_identity_format_declared_first_else_nub() {
     // none + none → truly fresh: nub claims identity via the neutral lockfile
-    // (writes package.lock) AND stamps `packageManager: nub@<v>` — the field is the
-    // PM signal nub's unbranded package.lock withholds, the coherent counterpart to
-    // keeping the lockfile neutral. Only `packageManager`; `devEngines` stays
-    // unstamped (that heavier exclusivity claim is `nub pm use nub`'s job).
+    // (writes package.lock) AND stamps a caret RANGE into `devEngines.packageManager`
+    // — the non-locking PM signal nub's unbranded package.lock withholds, the
+    // coherent counterpart to keeping the lockfile neutral. Never the exact
+    // `packageManager: nub@<v>` pin (that hard claim is `nub pm use nub@<exact>`'s).
     let dir = project("fresh-default", r#"{"name":"app","version":"1.0.0"}"#);
     let (stdout, stderr, code) = run(&dir, &["install"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
@@ -81,13 +81,17 @@ fn fresh_projects_write_the_identity_format_declared_first_else_nub() {
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
     assert_eq!(
-        manifest.get("packageManager").and_then(|v| v.as_str()),
-        Some(concat!("nub@", env!("CARGO_PKG_VERSION"))),
-        "a virgin install stamps packageManager: nub@<version>: {manifest}"
+        manifest.pointer("/devEngines/packageManager"),
+        Some(&serde_json::json!({
+            "name": "nub",
+            "version": concat!("^", env!("CARGO_PKG_VERSION")),
+            "onFail": "warn"
+        })),
+        "a virgin install stamps a devEngines.packageManager caret range: {manifest}"
     );
     assert!(
-        manifest.get("devEngines").is_none(),
-        "the virgin stamp writes only packageManager, never devEngines: {manifest}"
+        manifest.get("packageManager").is_none(),
+        "the virgin stamp writes only the devEngines range, never the exact packageManager pin: {manifest}"
     );
 
     // declared npm + none → package-lock.json, NOT the nub default.

--- a/crates/nub-cli/tests/pm_two_mode.rs
+++ b/crates/nub-cli/tests/pm_two_mode.rs
@@ -87,12 +87,19 @@ fn use_nub_migrates_a_single_package_catalog_project_offline_and_idempotently() 
 
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
-    assert_eq!(
-        manifest["packageManager"],
-        format!("nub@{}", env!("CARGO_PKG_VERSION"))
+    // Bare `pm use nub` is the non-locking switch: the incumbent pnpm@ pin is
+    // cleared and only the devEngines caret range is written — never a hard
+    // `packageManager: nub@<v>` pin (that is `pm use nub@<exact>`'s opt-in).
+    assert!(
+        manifest.get("packageManager").is_none(),
+        "bare pm use nub writes no exact packageManager pin: {manifest}"
     );
     assert_eq!(manifest["devEngines"]["packageManager"]["name"], "nub");
     assert_eq!(manifest["devEngines"]["packageManager"]["onFail"], "warn");
+    assert_eq!(
+        manifest["devEngines"]["packageManager"]["version"],
+        format!("^{}", env!("CARGO_PKG_VERSION"))
+    );
     assert_eq!(
         manifest["workspaces"]["catalog"]["left-pad"], "1.3.0",
         "single-package catalogs land as a packages-less workspaces object"
@@ -111,9 +118,11 @@ fn use_nub_migrates_a_single_package_catalog_project_offline_and_idempotently() 
         stdout.contains("production"),
         "the warn tail must name the transient key loudly: {stdout}"
     );
+    // The corepack line is gated to the exact-pin path; the pnpm-refuses line is
+    // the always-present consequence for the bare switch.
     assert!(
-        stdout.contains("corepack") && stdout.contains("nub pm use pnpm"),
-        "the summary must carry the teammates consequences block: {stdout}"
+        stdout.contains("nub pm use pnpm") && !stdout.contains("corepack"),
+        "bare switch carries the consequences block without the corepack (exact-pin) line: {stdout}"
     );
 
     // Idempotent rerun: same identity, lockfile kept, nothing new to migrate.
@@ -126,7 +135,7 @@ fn use_nub_migrates_a_single_package_catalog_project_offline_and_idempotently() 
 }
 
 /// Crash-recovery for the one half-migrated window `use nub` can be killed in:
-/// the manifest edit (atomic — packageManager flipped, the yaml's catalog
+/// the manifest edit (atomic — devEngines range written, the yaml's catalog
 /// already copied into `workspaces`, the `pnpm` namespace dropped) and the
 /// lockfile rename both completed, but the process died BEFORE the final
 /// `pnpm-workspace.yaml` deletion. The project then declares nub identity yet
@@ -138,16 +147,16 @@ fn use_nub_migrates_a_single_package_catalog_project_offline_and_idempotently() 
 /// too fast to interrupt mid-write reliably).
 #[test]
 fn use_nub_recovers_from_a_crash_before_the_yaml_deletion() {
-    let nub_ver = env!("CARGO_PKG_VERSION");
     let dir = project(
         "use-nub-halfstate",
         &[
-            // Manifest as the atomic edit would have left it: nub identity,
-            // catalog migrated into the workspaces object, no pnpm namespace.
+            // Manifest as the atomic (bare) edit would have left it: nub identity
+            // via the devEngines range (no exact packageManager), catalog migrated
+            // into the workspaces object, no pnpm namespace.
             (
                 "package.json",
                 &format!(
-                    r#"{{"name":"app","version":"1.0.0","packageManager":"nub@{nub_ver}",{}}}"#,
+                    r#"{{"name":"app","version":"1.0.0",{}}}"#,
                     r#""devEngines":{"packageManager":{"name":"nub","version":"^0.0.0","onFail":"warn"}},"workspaces":{"catalog":{"left-pad":"1.3.0"}}"#
                 ),
             ),
@@ -176,7 +185,14 @@ fn use_nub_recovers_from_a_crash_before_the_yaml_deletion() {
     // The migrated data survived the half-state — never silently dropped.
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
-    assert_eq!(manifest["packageManager"], format!("nub@{nub_ver}"));
+    assert!(
+        manifest.get("packageManager").is_none(),
+        "bare use nub leaves no exact packageManager pin after recovery: {manifest}"
+    );
+    assert_eq!(
+        manifest["devEngines"]["packageManager"]["version"],
+        format!("^{}", env!("CARGO_PKG_VERSION"))
+    );
     assert_eq!(
         manifest["workspaces"]["catalog"]["left-pad"], "1.3.0",
         "the catalog must remain in the manifest after recovery"
@@ -194,7 +210,6 @@ fn use_nub_recovers_from_a_crash_before_the_yaml_deletion() {
 /// byte-for-byte in the manifest.
 #[test]
 fn use_nub_migrates_with_injected_deps_and_preserves_meta() {
-    let nub_ver = env!("CARGO_PKG_VERSION");
     let dir = project(
         "injected",
         &[
@@ -218,7 +233,14 @@ fn use_nub_migrates_with_injected_deps_and_preserves_meta() {
     );
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
-    assert_eq!(manifest["packageManager"], format!("nub@{nub_ver}"));
+    assert!(
+        manifest.get("packageManager").is_none(),
+        "bare pm use nub writes no exact packageManager pin: {manifest}"
+    );
+    assert_eq!(
+        manifest["devEngines"]["packageManager"]["version"],
+        format!("^{}", env!("CARGO_PKG_VERSION"))
+    );
     // The injected dependenciesMeta survives untouched — the install path honors it.
     assert_eq!(
         manifest["dependenciesMeta"]["sibling"]["injected"], true,

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -180,7 +180,7 @@ A project is Nub's own in three cases: it declares Nub through `nub pm use nub`,
 - **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`
 - **Install state:** `node_modules/.nub/`, `.nub-state`, and the global store under Nub's own directories
 
-A fresh `nub install` records Nub as the manager with a non-locking range — `devEngines.packageManager` set to `{ name: "nub", version: "^<version>", onFail: "warn" }`, never an exact `packageManager` pin. The range is the cross-tool signal (turbo and friends read `devEngines` by name) and a floor, so upgrading Nub just works. To freeze the project at an exact Nub version — the corepack-visible hard pin — opt in with `nub pm use nub@<version>`; the bare `nub pm use nub` writes only the range.
+A fresh `nub install` records Nub as the manager with a non-locking range — `devEngines.packageManager` set to `{ name: "nub", version: "^<version>", onFail: "warn" }`, never an exact `packageManager` pin. Tools that read `devEngines` by name see the signal, and the caret is a floor, so upgrading Nub just works. To freeze the project at an exact Nub version — the corepack-visible hard pin — opt in with `nub pm use nub@<version>`; the bare `nub pm use nub` writes only the range.
 
 This is the brand boundary in both directions: Nub never emits its own brand into your config, and under its own identity reads *only* neutral, cross-tool config — never `pnpm-workspace.yaml`, `.pnpmfile.cjs`, the `pnpm.*` namespace, `pnpm_config_*`, `.yarnrc.yml`, `bunfig.toml`, Bun `trustedDependencies`, or aube's `AUBE_*` knobs. To keep pnpm hooks or pnpm-named workspace config active, stay pnpm-owned or run `nub pm use pnpm`.
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -180,6 +180,8 @@ A project is Nub's own in three cases: it declares Nub through `nub pm use nub`,
 - **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`
 - **Install state:** `node_modules/.nub/`, `.nub-state`, and the global store under Nub's own directories
 
+A fresh `nub install` records Nub as the manager with a non-locking range — `devEngines.packageManager` set to `{ name: "nub", version: "^<version>", onFail: "warn" }`, never an exact `packageManager` pin. The range is the cross-tool signal (turbo and friends read `devEngines` by name) and a floor, so upgrading Nub just works. To freeze the project at an exact Nub version — the corepack-visible hard pin — opt in with `nub pm use nub@<version>`; the bare `nub pm use nub` writes only the range.
+
 This is the brand boundary in both directions: Nub never emits its own brand into your config, and under its own identity reads *only* neutral, cross-tool config — never `pnpm-workspace.yaml`, `.pnpmfile.cjs`, the `pnpm.*` namespace, `pnpm_config_*`, `.yarnrc.yml`, `bunfig.toml`, Bun `trustedDependencies`, or aube's `AUBE_*` knobs. To keep pnpm hooks or pnpm-named workspace config active, stay pnpm-owned or run `nub pm use pnpm`.
 
 ```console


### PR DESCRIPTION
Rolls back the exact `packageManager: nub@<v>` auto-pin #255 landed on virgin `nub install` (main-only, never released — exact pin + self-shim is lock-in).

- Virgin `nub install` writes `devEngines.packageManager = { name: "nub", version: "^<v>", onFail: "warn" }`, never `packageManager`.
- `nub pm use nub@<exact>` opts into the hard `packageManager` pin; a range/dist-tag is refused.
- Bare `nub pm use nub` writes range-only, clearing any incumbent `packageManager`.
- No `devEngines.runtime` write.

The self-shim reads `devEngines.packageManager` when `packageManager` is absent, so a devEngines-only nub project stays nub-owned.

Refs #255, #265.