### PR TITLE
fix(env): ignore NODE_ENV set in a .env file

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -4594,6 +4594,84 @@ fn env_file_flag_reaches_child_and_shell_wins() {
     );
 }
 
+/// #263, end-to-end through the binary — the differential that broke `next build`.
+/// A `.env` FILE must NOT leak its `NODE_ENV` into the spawned child (dotenv/
+/// @next/env/Vite parity), yet an AMBIENT `NODE_ENV` must both pass through
+/// untouched AND still select the `.env.<NODE_ENV>` file. Child ambient is set via
+/// `Command::env`, so the test never mutates its own process env (hermetic).
+#[test]
+fn dotenv_node_env_stripped_but_ambient_selects_env_file() {
+    let work = unique_test_cache();
+    let proj = work.join("proj");
+    std::fs::create_dir_all(&proj).unwrap();
+    std::fs::write(proj.join("package.json"), "{}\n").unwrap();
+    std::fs::write(proj.join(".env"), "NODE_ENV=development\nFROM_BASE=base\n").unwrap();
+    std::fs::write(proj.join(".env.production"), "FROM_PROD=prod\n").unwrap();
+    std::fs::write(
+        proj.join("print.mjs"),
+        "console.log(`NE=[${process.env.NODE_ENV || ''}] BASE=[${process.env.FROM_BASE || ''}] PROD=[${process.env.FROM_PROD || ''}]`);\n",
+    )
+    .unwrap();
+
+    let run = |ambient: Option<&str>| {
+        let mut cmd = Command::new(nub_binary());
+        cmd.arg(proj.join("print.mjs").to_str().unwrap())
+            .current_dir(&proj)
+            .env("XDG_CACHE_HOME", unique_test_cache());
+        match ambient {
+            Some(v) => cmd.env("NODE_ENV", v),
+            None => cmd.env_remove("NODE_ENV"),
+        };
+        let out = cmd.output().expect("failed to spawn nub");
+        (
+            String::from_utf8_lossy(&out.stdout).to_string(),
+            String::from_utf8_lossy(&out.stderr).to_string(),
+            out.status.code().unwrap_or(-1),
+        )
+    };
+
+    // (a) ambient NODE_ENV unset: the `.env` NODE_ENV is dropped (not "development"),
+    //     so `.env` — not `.env.production` — is selected, and nub warns once.
+    let (out_a, err_a, code_a) = run(None);
+    assert_eq!(code_a, 0, "run must succeed; stderr: {err_a}");
+    assert!(
+        out_a.contains("NE=[]"),
+        "`.env` NODE_ENV must not leak into the child: {out_a}"
+    );
+    assert!(
+        out_a.contains("BASE=[base]"),
+        "`.env` siblings must still load: {out_a}"
+    );
+    assert!(
+        out_a.contains("PROD=[]"),
+        "ambient NODE_ENV unset must select `.env`, never `.env.production`: {out_a}"
+    );
+    assert!(
+        err_a.contains("ignoring NODE_ENV set in .env"),
+        "nub must warn that a `.env` NODE_ENV was ignored: {err_a}"
+    );
+
+    // (b) ambient NODE_ENV=production: passes through untouched AND selects
+    //     `.env.production` (selection keys off ambient, never the `.env` value),
+    //     with no spurious warning (ambient wins before the strip).
+    let (out_b, err_b, code_b) = run(Some("production"));
+    assert_eq!(code_b, 0, "run must succeed; stderr: {err_b}");
+    assert!(
+        out_b.contains("NE=[production]"),
+        "ambient NODE_ENV must pass through: {out_b}"
+    );
+    assert!(
+        out_b.contains("PROD=[prod]"),
+        "ambient NODE_ENV must select `.env.production`: {out_b}"
+    );
+    assert!(
+        !err_b.contains("ignoring NODE_ENV set in .env"),
+        "no warning when an ambient NODE_ENV wins over the `.env` value: {err_b}"
+    );
+
+    let _ = std::fs::remove_dir_all(&work);
+}
+
 #[test]
 fn env_file_if_exists_skips_absent_file_and_loads_present_one() {
     // Node v22 parity: `--env-file-if-exists` loads the file when present but is a

--- a/crates/nub-core/src/workspace/env.rs
+++ b/crates/nub-core/src/workspace/env.rs
@@ -104,13 +104,28 @@ pub fn load_env_files_raw(project_root: &Path) -> HashMap<String, String> {
     let files = env_file_names();
 
     let mut result = HashMap::new();
+    let mut node_env_ignored = false;
 
     for filename in &files {
         let path = project_root.join(filename);
         if let Some(content) = read_env_file(&path) {
             for (key, value) in parse_env(&content) {
-                // Shell env wins: don't override existing env vars.
+                // Shell env wins: don't override existing env vars. An AMBIENT
+                // `NODE_ENV` (set in the real process env) therefore passes through
+                // untouched and still selects `.env.<NODE_ENV>` files above — only a
+                // `.env`-FILE `NODE_ENV` is dropped below.
                 if std::env::var_os(&key).is_some() {
+                    continue;
+                }
+                // dotenv / @next/env / Vite parity: a `.env` FILE never sets
+                // `NODE_ENV`. Injecting it broke `next build` — the prerender forks
+                // inherited `NODE_ENV=development`, loading the dev React against
+                // production-compiled chunks (two `ReactSharedInternals` → null hooks
+                // dispatcher → `useContext` of null), #263. Reaching here means ambient
+                // `NODE_ENV` is unset (shell-wins above), so this value WOULD have been
+                // injected — drop it and warn once.
+                if key == "NODE_ENV" {
+                    node_env_ignored = true;
                     continue;
                 }
                 // First writer wins among .env files.
@@ -119,7 +134,26 @@ pub fn load_env_files_raw(project_root: &Path) -> HashMap<String, String> {
         }
     }
 
+    if node_env_ignored {
+        warn_node_env_from_dotenv_ignored();
+    }
+
     result
+}
+
+/// Emit the "ignoring `.env` `NODE_ENV`" notice at most once per process. A
+/// `.env`-file `NODE_ENV` is dropped by [`load_env_files_raw`] (dotenv/Next/Vite
+/// parity, #263); this tells the user their value was ignored and where to set it
+/// instead. `Once` keeps the run path (`load_env_files`) and the watch path (which
+/// both funnel through the raw loader) from double-warning.
+fn warn_node_env_from_dotenv_ignored() {
+    use std::sync::Once;
+    static WARNED: Once = Once::new();
+    WARNED.call_once(|| {
+        eprintln!(
+            "nub: ignoring NODE_ENV set in .env (dotenv, Next, and Vite do the same); set it in the environment instead"
+        );
+    });
 }
 
 /// Load .env* files from the project root, returning the key-value
@@ -619,6 +653,35 @@ mod tests {
             Some("postgres://localhost:5432/db")
         );
         assert_ne!(raw.get("DATABASE_URL"), expanded.get("DATABASE_URL"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #263: a `.env` FILE must never inject `NODE_ENV` into the child env
+    /// (dotenv/@next/env/Vite parity). Leaking `NODE_ENV=development` into
+    /// `next build` loaded the dev React against production-compiled chunks → a
+    /// null hooks dispatcher. Sibling keys still load; `.env.<NODE_ENV>` file
+    /// SELECTION is untouched — it reads AMBIENT `NODE_ENV`, never this map — so
+    /// the assertion holds whether or not the test process itself has `NODE_ENV`
+    /// set (an ambient value is dropped by shell-wins; a file value by the strip).
+    #[test]
+    fn dotenv_node_env_is_never_injected() {
+        let dir = std::env::temp_dir().join(format!("nub-nodeenv-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(".env"), "NODE_ENV=development\nAPP_KEY=secret\n").unwrap();
+
+        let vars = load_env_files(&dir);
+
+        assert!(
+            !vars.contains_key("NODE_ENV"),
+            "a `.env` file must not inject NODE_ENV (#263); got {vars:?}"
+        );
+        assert_eq!(
+            vars.get("APP_KEY").map(String::as_str),
+            Some("secret"),
+            "sibling keys must still load after NODE_ENV is stripped; got {vars:?}"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/nub-core/src/workspace/env.rs
+++ b/crates/nub-core/src/workspace/env.rs
@@ -101,6 +101,16 @@ pub fn expand_env_map(map: &mut HashMap<String, String>) -> &mut HashMap<String,
 /// expansion-changed keys — which Node's `--env-file` can't reproduce — get
 /// injected.
 pub fn load_env_files_raw(project_root: &Path) -> HashMap<String, String> {
+    load_env_files_raw_reporting(project_root).0
+}
+
+/// The raw loader, additionally reporting whether a `.env` FILE declared
+/// `NODE_ENV` (always dropped from the returned map — dotenv/@next/env/Vite
+/// parity, #263). The bool is consumed by [`load_env_files`] (the direct run/file
+/// injection path) to warn the user; the plain [`load_env_files_raw`] wrapper
+/// discards it because the watch path defers `NODE_ENV` to Node's own `--env-file`
+/// and so is NOT the one ignoring it — warning there would be false.
+fn load_env_files_raw_reporting(project_root: &Path) -> (HashMap<String, String>, bool) {
     let files = env_file_names();
 
     let mut result = HashMap::new();
@@ -123,7 +133,7 @@ pub fn load_env_files_raw(project_root: &Path) -> HashMap<String, String> {
                 // production-compiled chunks (two `ReactSharedInternals` → null hooks
                 // dispatcher → `useContext` of null), #263. Reaching here means ambient
                 // `NODE_ENV` is unset (shell-wins above), so this value WOULD have been
-                // injected — drop it and warn once.
+                // injected — drop it and flag it for the caller's warning.
                 if key == "NODE_ENV" {
                     node_env_ignored = true;
                     continue;
@@ -134,18 +144,13 @@ pub fn load_env_files_raw(project_root: &Path) -> HashMap<String, String> {
         }
     }
 
-    if node_env_ignored {
-        warn_node_env_from_dotenv_ignored();
-    }
-
-    result
+    (result, node_env_ignored)
 }
 
-/// Emit the "ignoring `.env` `NODE_ENV`" notice at most once per process. A
-/// `.env`-file `NODE_ENV` is dropped by [`load_env_files_raw`] (dotenv/Next/Vite
-/// parity, #263); this tells the user their value was ignored and where to set it
-/// instead. `Once` keeps the run path (`load_env_files`) and the watch path (which
-/// both funnel through the raw loader) from double-warning.
+/// Emit the "ignoring `.env` `NODE_ENV`" notice at most once per process. Called
+/// only on the direct run/file injection path ([`load_env_files`]), where the
+/// dropped `NODE_ENV` genuinely never reaches the child; the watch path defers to
+/// Node's `--env-file` and does not warn. `Once` guards against any repeat.
 fn warn_node_env_from_dotenv_ignored() {
     use std::sync::Once;
     static WARNED: Once = Once::new();
@@ -161,11 +166,19 @@ fn warn_node_env_from_dotenv_ignored() {
 /// (from the parent process) always wins — values already set in
 /// the process environment are not overridden.
 pub fn load_env_files(project_root: &Path) -> HashMap<String, String> {
-    let mut result = load_env_files_raw(project_root);
+    let (mut result, node_env_ignored) = load_env_files_raw_reporting(project_root);
 
     // Expand ${VAR} references within values. Multi-pass to handle
     // nested references like A=hello, B=${A}_world, C=${B}_!.
     expand_env_map(&mut result);
+
+    // Warn only here — this map is injected straight into the child via
+    // `Command::env`, so a dropped `.env` `NODE_ENV` truly never reaches it. The
+    // watch path (plain `load_env_files_raw`) hands the files to Node's `--env-file`
+    // instead, so nub isn't ignoring `NODE_ENV` there and must not claim to.
+    if node_env_ignored {
+        warn_node_env_from_dotenv_ignored();
+    }
 
     result
 }

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -25,6 +25,16 @@ The `[NODE_ENV]` slots only exist when `NODE_ENV` is set; the example below reso
 NODE_ENV=production nub server.ts
 ```
 
+## Setting NODE_ENV
+
+A `.env` file can't set `NODE_ENV`. That key is ignored on load — matching dotenv, Next.js, and Vite — and Nub prints a warning when a loaded file defines it. Because `NODE_ENV` chooses which files load, set it in the environment instead:
+
+```bash
+NODE_ENV=production nub server.ts
+```
+
+Otherwise a `.env` pinning `NODE_ENV=development` leaks into production tooling: `next build`, for one, then runs its prerender workers in development mode against production-compiled output.
+
 ## Test environment
 
 Under `NODE_ENV=test`, the `.env.local` slot is skipped — only `.env.test.local`, `.env.test`, and `.env` load. This keeps developer-machine secrets in `.env.local` out of the test environment.


### PR DESCRIPTION
Auto-loaded `.env*` files injected their `NODE_ENV` key into the child env. For `next build` this leaked `NODE_ENV=development` into the prerender forks — dev React against production chunks → null hooks dispatcher → `useContext` crash.

`load_env_files_raw` now drops the `NODE_ENV` key from any `.env*` file and warns once, matching dotenv/`@next/env`/Vite. An ambient `NODE_ENV` still passes through (shell-wins) and still selects `.env.<NODE_ENV>` files; the explicit `--env-file` flag is untouched.

Tests: a loader unit test plus an e2e differential through the real binary. Docs updated.

Closes #263