### PR TITLE
fix(pm): strip UTF-8 BOM before parsing package.json

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -2667,7 +2667,9 @@ fn run_workspace_target(
     // targets only the root). Its index is the appended slot.
     let root_idx = if ws.include_workspace_root {
         if let Ok(content) = std::fs::read_to_string(ws_root.join("package.json")) {
-            if let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Ok(manifest) =
+                serde_json::from_str::<serde_json::Value>(nub_core::strip_utf8_bom(&content))
+            {
                 let name = manifest
                     .get("name")
                     .and_then(|v| v.as_str())
@@ -5826,7 +5828,9 @@ fn check_manifest_json(cwd: &Path) -> Result<()> {
                     return Err(e).with_context(|| format!("reading {}", pkg.display()));
                 }
             };
-            if let Err(e) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Err(e) =
+                serde_json::from_str::<serde_json::Value>(nub_core::strip_utf8_bom(&content))
+            {
                 bail!(
                     "{ERR_NUB_MANIFEST_PARSE}: package.json is not valid JSON ({}): {e}",
                     pkg.display()
@@ -6586,7 +6590,8 @@ fn dev_engines_range(cwd: &Path, pm_name: &str) -> Option<String> {
     let project = nub_core::workspace::detect::detect_project(cwd)?;
     let manifest: serde_json::Value = match &project.workspace_root {
         Some(ws) if *ws != project.root => {
-            serde_json::from_str(&std::fs::read_to_string(ws.join("package.json")).ok()?).ok()?
+            let raw = std::fs::read_to_string(ws.join("package.json")).ok()?;
+            serde_json::from_str(nub_core::strip_utf8_bom(&raw)).ok()?
         }
         _ => project.manifest,
     };
@@ -7023,8 +7028,8 @@ fn field_pin_provenance(cwd: &Path) -> nub_core::pm::shim::PinProvenance {
         .and_then(|project| {
             let manifest: serde_json::Value = match &project.workspace_root {
                 Some(ws) if *ws != project.root => {
-                    serde_json::from_str(&std::fs::read_to_string(ws.join("package.json")).ok()?)
-                        .ok()?
+                    let raw = std::fs::read_to_string(ws.join("package.json")).ok()?;
+                    serde_json::from_str(nub_core::strip_utf8_bom(&raw)).ok()?
                 }
                 _ => project.manifest,
             };
@@ -8971,6 +8976,21 @@ mod tests {
         std::fs::write(good.join("package.json"), r#"{"name":"app"}"#).unwrap();
         assert!(check_manifest_json(&good).is_ok());
         assert!(check_manifest_json(&pm_tmpdir("manifest-none")).is_ok());
+
+        // A UTF-8-BOM-prefixed manifest (PowerShell 5.1 / Windows editors write
+        // one by default) is valid JSON to npm/pnpm — the pre-flight check must
+        // strip the BOM before serde_json rather than reject it as "not valid
+        // JSON at line 1 column 1".
+        let bom = pm_tmpdir("manifest-bom");
+        std::fs::write(
+            bom.join("package.json"),
+            format!("\u{feff}{}", r#"{"name":"app"}"#),
+        )
+        .unwrap();
+        assert!(
+            check_manifest_json(&bom).is_ok(),
+            "a UTF-8 BOM-prefixed package.json must pass the pre-flight check"
+        );
 
         // A package.json that EXISTS but can't be read (EACCES) must surface a
         // coded permission error — NOT get swallowed into "no package.json found"

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -826,7 +826,7 @@ pub(crate) fn run_use_nub(root: &Path, exact_pin: Option<&str>) -> Result<i32> {
 
     let manifest_content = std::fs::read_to_string(root.join("package.json"))
         .with_context(|| format!("reading {}", root.join("package.json").display()))?;
-    let manifest: Value = serde_json::from_str(&manifest_content)
+    let manifest: Value = serde_json::from_str(nub_core::strip_utf8_bom(&manifest_content))
         .with_context(|| format!("parsing {}", root.join("package.json").display()))?;
     let pnpm_ns = manifest.get("pnpm").and_then(Value::as_object).cloned();
 
@@ -1059,11 +1059,10 @@ fn remove_strays(paths: &[std::path::PathBuf], why: &str) -> Result<()> {
 /// to move (the idempotent rerun).
 pub(crate) fn regenerate_workspace_yaml(root: &Path) -> Result<Vec<String>> {
     let manifest_path = root.join("package.json");
-    let manifest: Value = serde_json::from_str(
-        &std::fs::read_to_string(&manifest_path)
-            .with_context(|| format!("reading {}", manifest_path.display()))?,
-    )
-    .with_context(|| format!("parsing {}", manifest_path.display()))?;
+    let manifest_raw = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("reading {}", manifest_path.display()))?;
+    let manifest: Value = serde_json::from_str(nub_core::strip_utf8_bom(&manifest_raw))
+        .with_context(|| format!("parsing {}", manifest_path.display()))?;
 
     let workspaces = manifest.get("workspaces");
     let (packages, catalog, catalogs) = match workspaces {

--- a/crates/nub-core/src/lib.rs
+++ b/crates/nub-core/src/lib.rs
@@ -18,9 +18,32 @@ pub mod workspace;
 /// handful of sites that build a PATH by concatenation.
 pub const PATH_LIST_SEPARATOR: &str = if cfg!(windows) { ";" } else { ":" };
 
+/// Strip a leading UTF-8 BOM (U+FEFF, bytes `EF BB BF`) so `serde_json` accepts
+/// the document. Windows PowerShell 5.1 / .NET `Encoding.UTF8` and many Windows
+/// editors write `package.json` with a BOM; npm/pnpm tolerate it, `serde_json`
+/// does not (it rejects the BOM as an unexpected value "at line 1 column 1").
+/// `str::trim`/`trim_start` do NOT remove it (U+FEFF is not ASCII whitespace).
+/// Every nub-side manifest read funnels through this before parsing. (The
+/// vendored aube engine strips the BOM at its own reader independently.)
+pub fn strip_utf8_bom(s: &str) -> &str {
+    s.strip_prefix('\u{feff}').unwrap_or(s)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::PATH_LIST_SEPARATOR;
+    use super::{PATH_LIST_SEPARATOR, strip_utf8_bom};
+
+    #[test]
+    fn strip_utf8_bom_removes_only_a_leading_bom() {
+        // Present → removed; the rest is untouched.
+        assert_eq!(strip_utf8_bom("\u{feff}{\"a\":1}"), "{\"a\":1}");
+        // Absent → borrowed through unchanged.
+        assert_eq!(strip_utf8_bom("{\"a\":1}"), "{\"a\":1}");
+        // A BOM that isn't leading is left alone (not our concern; valid JSON
+        // never has one mid-document, and stripping it would corrupt content).
+        assert_eq!(strip_utf8_bom("{}\u{feff}"), "{}\u{feff}");
+        assert_eq!(strip_utf8_bom(""), "");
+    }
 
     #[test]
     fn path_list_separator_matches_platform() {

--- a/crates/nub-core/src/node/discovery.rs
+++ b/crates/nub-core/src/node/discovery.rs
@@ -450,7 +450,7 @@ fn project_manifest(cwd: &Path) -> Option<serde_json::Value> {
     match &project.workspace_root {
         Some(ws) if *ws != project.root => {
             let content = fs::read_to_string(ws.join("package.json")).ok()?;
-            serde_json::from_str(&content).ok()
+            serde_json::from_str(crate::strip_utf8_bom(&content)).ok()
         }
         _ => Some(project.manifest),
     }

--- a/crates/nub-core/src/pm/provision.rs
+++ b/crates/nub-core/src/pm/provision.rs
@@ -255,8 +255,8 @@ pub fn provision_pm_from_tarball(
 /// `package/` dir as someone else's completed install).
 fn cached_bin(pm_store: &Path, version: &str) -> Option<PathBuf> {
     let pkg_dir = pm_store.join(version).join("package");
-    let manifest: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(pkg_dir.join("package.json")).ok()?).ok()?;
+    let raw = std::fs::read_to_string(pkg_dir.join("package.json")).ok()?;
+    let manifest: serde_json::Value = serde_json::from_str(crate::strip_utf8_bom(&raw)).ok()?;
     let bin = pkg_dir.join(registry::bin_subpath(&manifest)?);
     bin.is_file().then_some(bin)
 }

--- a/crates/nub-core/src/pm/resolve.rs
+++ b/crates/nub-core/src/pm/resolve.rs
@@ -744,11 +744,15 @@ fn edit_manifest(
         );
     }
 
-    let content =
+    let raw =
         std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-    let format = detect_format(&content);
+    // Strip a leading BOM before both format-sniffing and parsing; the rewrite
+    // is emitted BOM-free (npm/pnpm write without one), which is the desired
+    // normalization rather than round-tripping the BOM.
+    let content = crate::strip_utf8_bom(&raw);
+    let format = detect_format(content);
     let mut manifest: serde_json::Value =
-        serde_json::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
+        serde_json::from_str(content).with_context(|| format!("parsing {}", path.display()))?;
 
     let obj = manifest
         .as_object_mut()
@@ -1196,6 +1200,29 @@ mod tests {
             !empty.join("package.json").exists(),
             "write_declared_pm must not scaffold a package.json"
         );
+    }
+
+    #[test]
+    fn write_declared_pm_reads_through_a_utf8_bom_and_rewrites_bom_free() {
+        // A BOM-prefixed manifest (Windows editors / PowerShell 5.1) must parse
+        // for the pin write, not error at the read-modify-write seam — and the
+        // rewrite is emitted BOM-free (npm/pnpm write without one).
+        let dir = tmpdir("write-pin-bom");
+        write_pkg(&dir, "\u{feff}{\n  \"name\": \"app\"\n}\n");
+        let written = write_declared_pm("pnpm", "9.1.0", "abc", &dir, false)
+            .unwrap()
+            .path;
+        let bytes = std::fs::read(&written).unwrap();
+        assert!(
+            !bytes.starts_with(b"\xEF\xBB\xBF"),
+            "the rewrite must not carry a BOM"
+        );
+        let manifest: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            manifest["packageManager"].as_str(),
+            Some("pnpm@9.1.0+sha512.abc"),
+        );
+        assert_eq!(manifest["name"].as_str(), Some("app"));
     }
 
     #[test]

--- a/crates/nub-core/src/pm/resolve.rs
+++ b/crates/nub-core/src/pm/resolve.rs
@@ -550,7 +550,7 @@ fn root_manifest(cwd: &Path) -> Option<std::sync::Arc<serde_json::Value>> {
         match &project.workspace_root {
             Some(ws) if *ws != project.root => {
                 let content = std::fs::read_to_string(ws.join("package.json")).ok()?;
-                serde_json::from_str(&content).ok()
+                serde_json::from_str(crate::strip_utf8_bom(&content)).ok()
             }
             _ => Some(project.manifest),
         }

--- a/crates/nub-core/src/pm/shim.rs
+++ b/crates/nub-core/src/pm/shim.rs
@@ -1242,11 +1242,10 @@ pub fn sibling_bin(primary_bin: &Path, entry: &str) -> Result<PathBuf> {
             )
         })?;
     let manifest_path = pkg_root.join("package.json");
-    let manifest: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(&manifest_path)
-            .with_context(|| format!("reading {}", manifest_path.display()))?,
-    )
-    .with_context(|| format!("parsing {}", manifest_path.display()))?;
+    let manifest_raw = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("reading {}", manifest_path.display()))?;
+    let manifest: serde_json::Value = serde_json::from_str(crate::strip_utf8_bom(&manifest_raw))
+        .with_context(|| format!("parsing {}", manifest_path.display()))?;
     let subpath = super::registry::named_bin_subpath(&manifest, entry).with_context(|| {
         format!(
             "{} declares no bin entry named \"{entry}\"",

--- a/crates/nub-core/src/workspace/detect.rs
+++ b/crates/nub-core/src/workspace/detect.rs
@@ -114,7 +114,8 @@ fn detect_project_walk(cwd: &Path) -> Option<(Project, Vec<PathBuf>)> {
         let pkg_path = dir.join("package.json");
         if pkg_path.is_file()
             && let Ok(content) = fs::read_to_string(&pkg_path)
-            && let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Ok(manifest) =
+                serde_json::from_str::<serde_json::Value>(crate::strip_utf8_bom(&content))
         {
             if project_root.is_none() {
                 project_root = Some((dir.clone(), manifest.clone()));
@@ -137,7 +138,8 @@ fn detect_project_walk(cwd: &Path) -> Option<(Project, Vec<PathBuf>)> {
             if project_root.is_none() {
                 let pkg_path = dir.join("package.json");
                 if let Ok(content) = fs::read_to_string(&pkg_path)
-                    && let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&content)
+                    && let Ok(manifest) =
+                        serde_json::from_str::<serde_json::Value>(crate::strip_utf8_bom(&content))
                 {
                     project_root = Some((dir.clone(), manifest));
                 }
@@ -282,7 +284,8 @@ pub fn find_workspace_members(workspace_root: &Path, _filter: Option<&str>) -> V
     let Ok(content) = fs::read_to_string(&pkg_path) else {
         return vec![];
     };
-    let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&content) else {
+    let Ok(manifest) = serde_json::from_str::<serde_json::Value>(crate::strip_utf8_bom(&content))
+    else {
         return vec![];
     };
 

--- a/crates/nub-core/src/workspace/filter.rs
+++ b/crates/nub-core/src/workspace/filter.rs
@@ -205,7 +205,7 @@ pub fn discover_members(workspace_root: &Path) -> Vec<WorkspacePackage> {
         Ok(c) => c,
         Err(_) => return vec![],
     };
-    let manifest: serde_json::Value = match serde_json::from_str(&content) {
+    let manifest: serde_json::Value = match serde_json::from_str(crate::strip_utf8_bom(&content)) {
         Ok(v) => v,
         Err(_) => return vec![],
     };
@@ -342,7 +342,8 @@ fn expand_member_patterns(workspace_root: &Path, patterns: &[String]) -> Vec<Wor
         let dir = workspace_root.join(&rel);
         let member_pkg = dir.join("package.json");
         if let Ok(content) = fs::read_to_string(&member_pkg)
-            && let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Ok(manifest) =
+                serde_json::from_str::<serde_json::Value>(crate::strip_utf8_bom(&content))
         {
             let name = manifest
                 .get("name")


### PR DESCRIPTION
A `package.json` with a leading UTF-8 BOM (`EF BB BF`) is valid to npm/pnpm but broke nub. PowerShell 5.1 / .NET `Encoding.UTF8` and many Windows editors write one by default.

The pre-flight check rejected it (`ERR_NUB_MANIFEST_PARSE`), failing `nub run`/`add`/`install`/`ci`; other nub-side reads silently skipped it. The vendored aube engine already strips the BOM, so only nub-side reads were affected.

Adds a shared `strip_utf8_bom` in nub-core, routing every nub-side parse through it; non-BOM input is unchanged. A cross-platform fix, found by the Windows papercut survey.

Tests: strip-seam unit, pre-flight accepting a BOM'd manifest, e2e `nub run` on a BOM fixture.