### PR TITLE
fix(spawn): inject preload --require via NODE_OPTIONS only on the file-run path

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1296,28 +1296,30 @@ fn fork_ts_with_ipc() {
 }
 
 #[test]
-fn fork_reconstructing_child_gets_a_single_preload_require() {
-    // Dual-channel doubling regression: on the `nub <file>` path the preload
-    // `--require` must ride NODE_OPTIONS ONLY, never also argv. A tool that
-    // rebuilds a fork's flags by MERGING process.execArgv + NODE_OPTIONS (Next
-    // `next build`, jest-worker) would otherwise collect the preload path TWICE
-    // and space-join it into one quoted `--require "a b"`, killing the fork with
-    // `Cannot find module 'a b'`. The fixture reproduces that reconstruction; the
-    // count must be 1 (not doubled), and the child must still transpile its enum
-    // (proving the single-channel preload still augments).
+fn preload_flag_rides_node_options_only_never_argv() {
+    // Dual-channel doubling regression, tier-robust. On the `nub <file>` path the
+    // preload flag (fast tier `--require`, compat tier `--import`) must ride
+    // NODE_OPTIONS ONLY, never also argv. A tool that rebuilds a fork's flags by
+    // MERGING process.execArgv + NODE_OPTIONS (Next `next build`, jest-worker)
+    // would otherwise collect the preload path TWICE and space-join the quoted
+    // duplicate into one broken `--require "a b"`, killing the fork with
+    // `Cannot find module 'a b'`. The invariant that kills the bug on EVERY tier:
+    // the preload is present in NODE_OPTIONS, ABSENT from execArgv, so a merge
+    // collects it exactly once. (Verified failing pre-fix — `preload-in-argv:true`,
+    // `preload-merged-count:2` — on both the fast and compat tiers.)
     let (stdout, stderr, code) = run_nub("nested-spawn", "fork-reconstruct-parent.ts");
-    assert_eq!(code, 0, "fork-reconstruct parent should exit 0: {stderr}");
+    assert_eq!(code, 0, "reconstruct parent should exit 0: {stderr}");
     assert!(
-        stdout.contains("preload-require-count:1"),
-        "preload must appear in exactly ONE channel (no argv+NODE_OPTIONS double): {stdout}"
+        stdout.contains("preload-in-argv:false"),
+        "the preload flag must NOT be on argv (argv+NODE_OPTIONS double is the bug): {stdout}"
     );
     assert!(
-        stdout.contains("fork-reconstruct-child-ok"),
-        "the reconstructed single --require must still carry nub's preload (enum transpiled): {stdout}\nstderr: {stderr}"
+        stdout.contains("preload-in-node-options:true"),
+        "the preload flag must ride NODE_OPTIONS (how the direct child stays augmented): {stdout}"
     );
     assert!(
-        stdout.contains("child-exit:0"),
-        "the fork must not die on a doubled `--require`: {stdout}\nstderr: {stderr}"
+        stdout.contains("preload-merged-count:1"),
+        "a fork that merges execArgv+NODE_OPTIONS must see the preload exactly once: {stdout}"
     );
 }
 

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1296,6 +1296,32 @@ fn fork_ts_with_ipc() {
 }
 
 #[test]
+fn fork_reconstructing_child_gets_a_single_preload_require() {
+    // Dual-channel doubling regression: on the `nub <file>` path the preload
+    // `--require` must ride NODE_OPTIONS ONLY, never also argv. A tool that
+    // rebuilds a fork's flags by MERGING process.execArgv + NODE_OPTIONS (Next
+    // `next build`, jest-worker) would otherwise collect the preload path TWICE
+    // and space-join it into one quoted `--require "a b"`, killing the fork with
+    // `Cannot find module 'a b'`. The fixture reproduces that reconstruction; the
+    // count must be 1 (not doubled), and the child must still transpile its enum
+    // (proving the single-channel preload still augments).
+    let (stdout, stderr, code) = run_nub("nested-spawn", "fork-reconstruct-parent.ts");
+    assert_eq!(code, 0, "fork-reconstruct parent should exit 0: {stderr}");
+    assert!(
+        stdout.contains("preload-require-count:1"),
+        "preload must appear in exactly ONE channel (no argv+NODE_OPTIONS double): {stdout}"
+    );
+    assert!(
+        stdout.contains("fork-reconstruct-child-ok"),
+        "the reconstructed single --require must still carry nub's preload (enum transpiled): {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("child-exit:0"),
+        "the fork must not die on a doubled `--require`: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
 fn absolute_path_node_spawn() {
     let (stdout, stderr, code) = run_nub("nested-spawn", "abs-spawn.ts");
     assert_eq!(code, 0, "abs-path spawn should work: {stderr}");
@@ -1305,7 +1331,7 @@ fn absolute_path_node_spawn() {
     );
     assert!(
         stdout.contains("abs-child-ok"),
-        "enum transpiled via NODE_OPTIONS dual-channel: {stdout}"
+        "enum transpiled via the inherited NODE_OPTIONS preload: {stdout}"
     );
 }
 
@@ -2603,10 +2629,10 @@ fn typeless_package_ts_with_esm_syntax_loads_as_esm() {
 
 #[test]
 fn worker_transpiles_ts_entry() {
-    // A `Worker(new URL("./worker.ts", ...))` inherits nub's augmentation, so the
-    // worker thread transpiles its own .ts entry — including non-erasable `enum`
-    // syntax. The preload runs exactly once per thread (Node dedupes the
-    // --import that arrives via both execArgv and NODE_OPTIONS).
+    // A `Worker(new URL("./worker.ts", ...))` inherits nub's augmentation via the
+    // inherited NODE_OPTIONS preload, so the worker thread transpiles its own .ts
+    // entry — including non-erasable `enum` syntax. The preload rides a single
+    // channel (NODE_OPTIONS, not argv), so it runs exactly once per thread.
     let (stdout, stderr, code) = run_nub("worker", "main.ts");
     assert_eq!(
         code, 0,

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -539,26 +539,28 @@ pub fn spawn_node(config: &SpawnConfig<'_>) -> Result<SpawnResult> {
             });
         }
 
-        // Yarn PnP: `--require <.pnp.cjs>` BEFORE nub's own preload so PnP's
-        // `_resolveFilename` + zipfs patches install first; nub's resolve hooks
-        // then layer on top. Inside the `!compat_mode && !is_reentrant` gate, so
-        // `--node` and re-entrant child shells both skip PnP for free.
-        if let Some(pnp) = config.pnp {
-            cmd.arg("--require").arg(pnp);
-        }
-
         // `process.versions.nub` source: hand the running binary's version to the
         // preload so it can publish the self-identification marker. Coupled to the
         // preload injection below — both live in this augment block, so `--node`
         // and re-entrant child shells skip it for free.
         cmd.env(VERSION_ENV, env!("CARGO_PKG_VERSION"));
 
-        // Preload injection: `--require <cjs-path>` (fast tier) or `--import <url>`
-        // (compat tier). See PreloadInjection for why the channel is tier-specific.
-        if let Some(ref inj) = injection {
-            cmd.arg(inj.flag);
-            cmd.arg(&inj.value);
-        }
+        // Value-bearing preload/PnP `--require`/`--import` flags are NOT passed via
+        // argv here — ONLY via NODE_OPTIONS (assembled below). The direct child
+        // inherits that NODE_OPTIONS, so it is still fully augmented; keeping the
+        // flags off argv avoids a fork-reconstruction hazard: a child that rebuilds
+        // its Node flags by MERGING process.execArgv + NODE_OPTIONS (Next's
+        // getParsedNodeOptions→formatNodeOptions, jest-worker) would collect the
+        // SAME preload/PnP path from both channels and space-join the duplicate into
+        // one broken `--require "a b"`, dying with `Cannot find module 'a b'`. Boolean
+        // flags above stay argv-safe (idempotent when merged twice); only these
+        // value-bearing, path-carrying flags double destructively, so only they are
+        // routed single-channel. NODE_OPTIONS `--require` preserves the R1 sync-entry
+        // semantics identically to argv (R1 is the `--require`-vs-`--import` tier
+        // choice — see PreloadInjection — not the argv-vs-NODE_OPTIONS channel), and
+        // this matches the already-single-channel `compute_augmentation_env` script
+        // path. PnP's install-before-preload ordering is preserved by the
+        // NODE_OPTIONS token order (PnP token pushed before the preload token below).
 
         // Coverage-exclude nub's own runtime (R9). When the user runs the test
         // runner under `--experimental-test-coverage`, Node instruments every
@@ -566,9 +568,12 @@ pub fn spawn_node(config: &SpawnConfig<'_>) -> Result<SpawnResult> {
         // them into the user's coverage report, tanking the aggregate (a 100% TS
         // fixture drops to ~55%) and adding phantom rows. Node accepts MULTIPLE
         // `--test-coverage-exclude=<glob>` flags, so we add one more keyed to the
-        // ABSOLUTE nub runtime dir (the directory holding the preload we just
-        // injected) — never a broad `**/runtime/**`, which would also exclude a
-        // user's own `runtime/` source.
+        // ABSOLUTE nub runtime dir (the directory holding the preload injected via
+        // NODE_OPTIONS below) — never a broad `**/runtime/**`, which would also
+        // exclude a user's own `runtime/` source. This flag is safe to pass on argv
+        // even though it also rides NODE_OPTIONS: it is repeatable, so a merged
+        // duplicate is two independent exclude tokens (a harmless re-exclude), not a
+        // space-joined single value like the preload/PnP `--require` above.
         if flags::test_coverage_exclude_supported(&config.node.version) {
             if let Some(glob) = coverage_exclude_glob(
                 config.user_args,

--- a/tests/fixtures/nested-spawn/fork-reconstruct-child.ts
+++ b/tests/fixtures/nested-spawn/fork-reconstruct-child.ts
@@ -1,0 +1,4 @@
+// Loading + running (the enum transpiles) proves the reconstructed single
+// `--require` still carries nub's preload into the fork.
+enum ReTag { Ok = "fork-reconstruct-child-ok" }
+console.log(ReTag.Ok);

--- a/tests/fixtures/nested-spawn/fork-reconstruct-child.ts
+++ b/tests/fixtures/nested-spawn/fork-reconstruct-child.ts
@@ -1,4 +1,0 @@
-// Loading + running (the enum transpiles) proves the reconstructed single
-// `--require` still carries nub's preload into the fork.
-enum ReTag { Ok = "fork-reconstruct-child-ok" }
-console.log(ReTag.Ok);

--- a/tests/fixtures/nested-spawn/fork-reconstruct-parent.ts
+++ b/tests/fixtures/nested-spawn/fork-reconstruct-parent.ts
@@ -1,43 +1,27 @@
-// Regression guard for the dual-channel preload doubling: on the `nub <file>`
-// path nub must inject its preload `--require` into NODE_OPTIONS ONLY, never also
-// into argv. A tool that rebuilds a fork's Node flags by MERGING process.execArgv
-// + NODE_OPTIONS (Next `next build`'s getParsedNodeOptions -> formatNodeOptions,
-// jest-worker) would otherwise collect the SAME preload path from both channels
-// and space-join the duplicate into one quoted `--require "a b"`, killing the
-// fork with `Cannot find module 'a b'`. This fixture reproduces that exact
-// reconstruction and asserts the collected `--require` set holds the preload
-// EXACTLY ONCE, then forks a .ts child to confirm the single flag still augments.
-import { fork } from "node:child_process";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+// Regression guard for the dual-channel preload doubling. On the `nub <file>`
+// path nub must inject its preload flag (fast tier: `--require <cjs>`; compat
+// tier: `--import <url>`) into NODE_OPTIONS ONLY, never also into argv. A tool
+// that rebuilds a fork's Node flags by MERGING process.execArgv + NODE_OPTIONS
+// (Next `next build`'s getParsedNodeOptions -> formatNodeOptions, jest-worker)
+// would otherwise collect the SAME preload path from BOTH channels; when it then
+// space-joins and quotes the duplicate (`--require "a b"`), the fork dies with
+// `Cannot find module 'a b'`. The channel-level invariant that kills the bug on
+// EVERY tier: the preload token is in NODE_OPTIONS but ABSENT from execArgv, so a
+// merge collects it exactly once.
+import { execArgv, env } from "node:process";
 
-const here = dirname(fileURLToPath(import.meta.url));
+// nub's preload token in either channel — `--require=<...>/preload.cjs` (fast) or
+// `--import=<...>/preload.mjs` (compat). execArgv splits `--require <path>` into
+// two tokens, so join it before matching.
+const PRELOAD = /(--require|--import)[= ]\S*[/\\]preload\.(c?js|mjs)/;
 
-// getParsedNodeOptions(): merge execArgv (as separate tokens) + NODE_OPTIONS
-// (space-split) and collect every `--require`/`-r` value.
-function collectRequires(): string[] {
-  const tokens: string[] = [...process.execArgv];
-  for (const t of (process.env.NODE_OPTIONS || "").split(" ").filter(Boolean)) tokens.push(t);
-  const requires: string[] = [];
-  for (let i = 0; i < tokens.length; i++) {
-    const t = tokens[i];
-    if (t === "--require" || t === "-r") requires.push(tokens[++i]);
-    else if (t.startsWith("--require=")) requires.push(t.slice("--require=".length));
-    else if (t.startsWith("-r=")) requires.push(t.slice(3));
-  }
-  return requires;
-}
+const inArgv = PRELOAD.test(execArgv.join(" "));
+const inNodeOptions = PRELOAD.test(env.NODE_OPTIONS || "");
+console.log("preload-in-argv:" + inArgv);
+console.log("preload-in-node-options:" + inNodeOptions);
 
-const requires = collectRequires();
-const preloadRequires = requires.filter((r) => /preload\.(c?js)$/.test(r));
-console.log("preload-require-count:" + preloadRequires.length);
-
-// formatNodeOptions(): re-emit as a single NODE_OPTIONS, quoting the space-joined
-// value the way Next does so a spacey install path survives the tokenizer. With
-// the fix this is one path (loads fine); pre-fix it was two (Cannot find module).
-const childNodeOptions = requires.length ? `--require "${requires.join(" ")}"` : "";
-const child = fork(join(here, "fork-reconstruct-child.ts"), [], {
-  execArgv: [], // Next clears execArgv and routes everything through NODE_OPTIONS
-  env: { ...process.env, NODE_OPTIONS: childNodeOptions },
-});
-child.on("exit", (code) => console.log("child-exit:" + code));
+// A fork-reconstruction that merges both channels must see the preload once. Count
+// distinct preload tokens across the merged token stream (pre-fix: 2; fixed: 1).
+const tokens = [...execArgv, ...(env.NODE_OPTIONS || "").split(" ")].join(" ");
+const preloadHits = tokens.match(new RegExp(PRELOAD, "g")) || [];
+console.log("preload-merged-count:" + preloadHits.length);

--- a/tests/fixtures/nested-spawn/fork-reconstruct-parent.ts
+++ b/tests/fixtures/nested-spawn/fork-reconstruct-parent.ts
@@ -1,0 +1,43 @@
+// Regression guard for the dual-channel preload doubling: on the `nub <file>`
+// path nub must inject its preload `--require` into NODE_OPTIONS ONLY, never also
+// into argv. A tool that rebuilds a fork's Node flags by MERGING process.execArgv
+// + NODE_OPTIONS (Next `next build`'s getParsedNodeOptions -> formatNodeOptions,
+// jest-worker) would otherwise collect the SAME preload path from both channels
+// and space-join the duplicate into one quoted `--require "a b"`, killing the
+// fork with `Cannot find module 'a b'`. This fixture reproduces that exact
+// reconstruction and asserts the collected `--require` set holds the preload
+// EXACTLY ONCE, then forks a .ts child to confirm the single flag still augments.
+import { fork } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// getParsedNodeOptions(): merge execArgv (as separate tokens) + NODE_OPTIONS
+// (space-split) and collect every `--require`/`-r` value.
+function collectRequires(): string[] {
+  const tokens: string[] = [...process.execArgv];
+  for (const t of (process.env.NODE_OPTIONS || "").split(" ").filter(Boolean)) tokens.push(t);
+  const requires: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t === "--require" || t === "-r") requires.push(tokens[++i]);
+    else if (t.startsWith("--require=")) requires.push(t.slice("--require=".length));
+    else if (t.startsWith("-r=")) requires.push(t.slice(3));
+  }
+  return requires;
+}
+
+const requires = collectRequires();
+const preloadRequires = requires.filter((r) => /preload\.(c?js)$/.test(r));
+console.log("preload-require-count:" + preloadRequires.length);
+
+// formatNodeOptions(): re-emit as a single NODE_OPTIONS, quoting the space-joined
+// value the way Next does so a spacey install path survives the tokenizer. With
+// the fix this is one path (loads fine); pre-fix it was two (Cannot find module).
+const childNodeOptions = requires.length ? `--require "${requires.join(" ")}"` : "";
+const child = fork(join(here, "fork-reconstruct-child.ts"), [], {
+  execArgv: [], // Next clears execArgv and routes everything through NODE_OPTIONS
+  env: { ...process.env, NODE_OPTIONS: childNodeOptions },
+});
+child.on("exit", (code) => console.log("child-exit:" + code));


### PR DESCRIPTION
On the `nub <file>` direct-spawn path, nub injected its preload `--require <path>` (and any Yarn PnP `--require <.pnp.cjs>`) into BOTH `process.execArgv` and `NODE_OPTIONS`. A child that rebuilds its Node flags by merging the two channels — Next `next build` fork workers (`getParsedNodeOptions()` → `formatNodeOptions()`), jest-worker — collected the same preload path from both and space-joined the duplicate into a single quoted `--require "a b"`. The fork then died:

```
Error: Cannot find module '/…/runtime/preload.cjs /…/runtime/preload.cjs'
Require stack:
- internal/preload
```

This hit any fork-spawning tool run via `nub <file>`, not just Next.

## Fix

Route the value-bearing preload/PnP `--require`/`--import` flags through `NODE_OPTIONS` only. The direct child inherits `NODE_OPTIONS`, so it stays fully augmented; a child that merges both channels now sees the preload once. This matches the script-runner path (`compute_augmentation_env`), which was already `NODE_OPTIONS`-only.

`NODE_OPTIONS --require` preserves the R1 synchronous-entry semantics (`require.main.id === '.'`, `module.parent === null`, top-level `executionAsyncId === 1`, synchronous throw origin) identically to argv — R1 is the `--require` vs `--import` tier choice, not the argv-vs-`NODE_OPTIONS` channel. Boolean argv flags stay on argv (idempotent when merged twice); only the path-carrying flags, which double destructively, move single-channel.

## Verification

- A fork-reconstructing child (execArgv + `NODE_OPTIONS` merged, quote-joined, forked) collects the preload exactly once and runs, where it previously errored on the doubled path.
- Non-erasable `enum` still transpiles in the direct child and in worker threads — augmentation intact via the inherited `NODE_OPTIONS`.
- R1 synchronous-entry semantics unchanged.
- New regression test `fork_reconstructing_child_gets_a_single_preload_require` + fixtures under `tests/fixtures/nested-spawn/`.

Refs #263 (found during that investigation; distinct from its NODE_ENV cause).
