### PR TITLE
pm: rename nub's own lockfile to nub.lock

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -6469,7 +6469,7 @@ fn run_pm_use(name: &str, spec: &str, cwd: &Path) -> Result<i32> {
                 );
             }
         }
-        // nub → pnpm: package.lock renamed back, byte-identical (the two-mode
+        // nub → pnpm: nub.lock renamed back, byte-identical (the two-mode
         // eject — the format was never forked, so the rename IS the eject).
         AlignPlan::Rename { from, remove } => {
             let to = root.join(use_align::lockfile_name(name));

--- a/crates/nub-cli/src/pm_engine/config_scope.rs
+++ b/crates/nub-cli/src/pm_engine/config_scope.rs
@@ -187,7 +187,7 @@ pub(crate) fn role_of(declared: Option<&str>, kind: Option<LockfileKind>) -> Opt
         LockfileKind::Npm | LockfileKind::NpmShrinkwrap => Role::Npm,
         LockfileKind::Yarn | LockfileKind::YarnBerry => Role::Yarn,
         LockfileKind::Bun => Role::Bun,
-        // The generic package.lock (aube's `Aube` slot under nub's filename
+        // The generic nub.lock (aube's `Aube` slot under nub's filename
         // toggle) is nub identity.
         LockfileKind::Aube => Role::Nub,
     })

--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -33,12 +33,12 @@
 /// - `self_names` = `["nub"]`, `compatible_names` = `["pnpm"]` — nub is the
 ///   tool, pnpm the compatible drop-in (was `set_detection_self_names` +
 ///   `set_package_manager_names`).
-/// - `lockfile_basename` = `"package.lock"` — nub's generic, unbranded
+/// - `lockfile_basename` = `"nub.lock"` — nub's generic, unbranded
 ///   canonical lockfile (pnpm-lock v9 bytes), pairing with `package.json`; was
 ///   `set_aube_lock_base_filename(NUB_LOCKFILE)`.
 /// - `lockfile_legacy_basenames` = `["lock.yaml"]` — nub's pre-rename name,
 ///   still recognized on read during the transition and migrated to
-///   `package.lock` on the next mutating PM op.
+///   `nub.lock` on the next mutating PM op.
 /// - `workspace_yaml` = `None` — nub has no branded workspace YAML of its own.
 ///   The shared `pnpm-workspace.yaml` compat surface is gated separately on the
 ///   `EngineContext` (`read_branded_pnpm_config`), per the role.
@@ -99,7 +99,7 @@
 ///   `managed_config_system_dir = None` would skip the system read — here the
 ///   user/project branded-file read/write is skipped entirely. Standalone aube
 ///   keeps `Some("aube")`, so its `~/.config/aube/config.toml` path is unchanged.
-/// - `canonical_lockfile_always_wins` = `false` — `package.lock` never silently
+/// - `canonical_lockfile_always_wins` = `false` — `nub.lock` never silently
 ///   outranks a foreign lockfile beside it; that state is the loud
 ///   ambiguity/contradiction error (was
 ///   `set_canonical_lockfile_always_wins(false)`).
@@ -156,7 +156,7 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     compatible_names: &["pnpm"],
     lockfile_basename: super::use_align::NUB_LOCKFILE,
     // `lock.yaml` (nub's pre-rename name) stays readable through the transition
-    // and is migrated to `package.lock` on the next mutating PM op; sunset at
+    // and is migrated to `nub.lock` on the next mutating PM op; sunset at
     // the next major.
     lockfile_legacy_basenames: &[super::use_align::NUB_LEGACY_LOCKFILE],
     workspace_yaml: None,
@@ -229,7 +229,7 @@ pub(crate) fn register() {
 // drift is a build break, not a test-run failure (and runtime `assert!` on a
 // const trips clippy's `assertions_on_constants`).
 const _: () = {
-    assert!(matches!(NUB.lockfile_basename.as_bytes(), b"package.lock"));
+    assert!(matches!(NUB.lockfile_basename.as_bytes(), b"nub.lock"));
     assert!(matches!(NUB.lockfile_legacy_basenames, [b] if matches!(b.as_bytes(), b"lock.yaml")));
     assert!(matches!(NUB.cache_namespace.as_bytes(), b"nub/pm"));
     assert!(matches!(NUB.data_namespace.as_bytes(), b"nub"));

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -950,7 +950,7 @@ impl WorkspaceFilterFlags {
 /// `nub install` — route through the embedded aube install engine.
 pub fn run_install(flags: InstallFlags) -> Result<i32> {
     let session = super::engine_session(flags.dir.as_deref())?;
-    // Transitional: rename a legacy `lock.yaml` to `package.lock` before the
+    // Transitional: rename a legacy `lock.yaml` to `nub.lock` before the
     // engine resolves (no-op unless this is a nub-identity project carrying the
     // old name).
     super::migrate_session_lockfile(&session);
@@ -1059,7 +1059,7 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     // Virgin install only: stamp a caret RANGE into `devEngines.packageManager`
     // so the project advertises nub the standard, cross-tool way WITHOUT locking
     // itself to one exact nub version. nub's canonical lockfile is deliberately
-    // NEUTRAL (`package.lock`), so — unlike every other PM, whose branded lockfile
+    // NEUTRAL (`nub.lock`), so — unlike every other PM, whose branded lockfile
     // is itself the repo's PM signal — nub leaves no signal downstream tools
     // (turbo, pmd, nypm) can read; the `devEngines.packageManager` object IS that
     // signal, and detectors key on its `name`, so a `^` range is signal-equivalent
@@ -1067,7 +1067,7 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     // NOT the exact `packageManager: nub@<v>` field: that hard, corepack-visible
     // pin freezes the repo at one nub version and stays the OPT-IN gesture of an
     // explicit `nub pm use nub@<exact>`. The write is gated on
-    // `session.truly_fresh`, captured BEFORE the engine wrote `package.lock`: `true`
+    // `session.truly_fresh`, captured BEFORE the engine wrote `nub.lock`: `true`
     // ONLY when nub is the FIRST package manager to touch the project (no foreign
     // lockfile, no pre-existing nub lockfile, no `packageManager`/`devEngines`
     // declaration). Any incumbent signal ⇒ `false` ⇒ no write — nub never imposes

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -804,7 +804,7 @@ fn engine_session_inner(
     }
     // Truly-fresh = no PM-preference signal anywhere (no lockfile, no
     // declaration, no pnpm-named file). On this path nub claims identity via the
-    // neutral lockfile: the embedder default flips to `package.lock`, the quiet
+    // neutral lockfile: the embedder default flips to `nub.lock`, the quiet
     // identity marker the classifier reads back as nub. Any incumbent signal
     // makes the project pnpm-shaped/compat and is respected untouched. On a
     // virgin install the install family ALSO stamps the non-locking
@@ -1465,7 +1465,7 @@ fn identity_error(err: aube_lockfile::Error) -> anyhow::Error {
 /// [`engine_session`]). Every seam is idempotent.
 pub(crate) fn engine_brand_preflight() {
     // Static identity FIRST, before anything reads project state or branding.
-    // The whole compile-time profile — name, `nub/<ver>` UA, `package.lock`
+    // The whole compile-time profile — name, `nub/<ver>` UA, `nub.lock`
     // canonical lockfile, `["nub"]`/`["pnpm"]` detection names, and the five
     // embedder-fixed toggles (engines-self check OFF, runtime-switching OFF,
     // warm-store-verify OFF, canonical-lockfile-always-wins OFF, self-update
@@ -1764,7 +1764,7 @@ fn resolve_config_surface(cwd: &Path) -> ConfigSurface {
     }
     // Nothing decided anywhere within the walk. A truly-fresh project (no
     // PM-preference signal of any kind, no pnpm-named file) becomes NUB
-    // identity: the next install writes `package.lock` and stamps the manifest,
+    // identity: the next install writes `nub.lock` and stamps the manifest,
     // and the project self-reinforces as nub-identity thereafter. A
     // pnpm-named file seen in the walk keeps the pnpm-shaped surface.
     if saw_pnpm_named {
@@ -1866,7 +1866,7 @@ fn read_file_head(path: &Path, max_bytes: usize) -> std::io::Result<String> {
 /// `npm_config_node_linker`, `.npmrc`, or workspace yaml all win):
 ///
 /// - `defaultLockfileFormat` — a TRULY-fresh project (no PM-preference signal
-///   of any kind) writes nub's neutral `package.lock` (`=aube`); every other
+///   of any kind) writes nub's neutral `nub.lock` (`=aube`); every other
 ///   surface writes `pnpm-lock.yaml` (`=pnpm`) for drop-in interop. See
 ///   [`nub_setting_defaults`]'s `truly_fresh` arm.
 /// - `virtualStoreDir` / `stateDir` = `node_modules/.nub` — the isolated
@@ -2018,7 +2018,7 @@ fn strip_yarnrc_value(rest: &str) -> &str {
 ///   keep the engine's isolated + hoist=true default (GVS off). A user-set
 ///   `nodeLinker`/`hoist` (env/.npmrc/yaml) still wins — embedder-tier default.
 /// - Fresh-write lockfile format: a TRULY-fresh project (no PM-preference
-///   signal of any kind — `truly_fresh`) writes nub's neutral `package.lock`
+///   signal of any kind — `truly_fresh`) writes nub's neutral `nub.lock`
 ///   (`defaultLockfileFormat=aube`, which under the nub embedder resolves to
 ///   the `lock.yaml` basename); every other surface writes `pnpm-lock.yaml`,
 ///   keeping a pnpm-incumbent / mixed project drop-in interoperable. A
@@ -2095,7 +2095,7 @@ fn nub_setting_defaults(
 /// `None` only then); this additionally requires that no pnpm-NAMED file
 /// (`pnpm-workspace.yaml`, `.pnpmfile.*`, `.pnpmrc`) sits in the walk — a
 /// pnpm-named file is a genuine pnpm signal that makes the project pnpm-shaped,
-/// not nub's to claim. On the truly-fresh path nub writes `package.lock` and
+/// not nub's to claim. On the truly-fresh path nub writes `nub.lock` and
 /// stamps the manifest with its own identity; any incumbent signal is
 /// respected and left untouched.
 fn is_truly_fresh_project(cwd: &Path, detected: Option<&DetectedLockfile>) -> bool {
@@ -2115,7 +2115,7 @@ fn is_truly_fresh_project(cwd: &Path, detected: Option<&DetectedLockfile>) -> bo
 }
 
 /// Whether `dir` holds nub's own canonical lockfile under EITHER the current
-/// name (`package.lock`) or the legacy name (`lock.yaml`) still honored through
+/// name (`nub.lock`) or the legacy name (`lock.yaml`) still honored through
 /// the rename transition. The bespoke nub-side identity probes
 /// (`resolve_config_surface`) check the file directly rather than through the
 /// engine's candidate set, so they consult both names here.
@@ -2125,8 +2125,8 @@ fn nub_lockfile_present(dir: &Path) -> bool {
 }
 
 /// Transitional auto-migration of nub's own lockfile name: `lock.yaml` →
-/// `package.lock`. The bytes are identical (pnpm-lock v9), so this is a pure
-/// rename; when `package.lock` already exists the redundant `lock.yaml` is
+/// `nub.lock`. The bytes are identical (pnpm-lock v9), so this is a pure
+/// rename; when `nub.lock` already exists the redundant `lock.yaml` is
 /// simply removed. Runs at the project root and every workspace member dir at
 /// the start of a mutating PM op, so a project upgraded onto the new name
 /// converges silently. Best-effort: any IO error is ignored — the engine's
@@ -2140,10 +2140,10 @@ pub(crate) fn migrate_legacy_nub_lockfile(root: &Path) {
 }
 
 /// Run [`migrate_legacy_nub_lockfile`] when `session` resolved a nub-identity
-/// project — the only identity that owns the `package.lock`/`lock.yaml` pair
+/// project — the only identity that owns the `nub.lock`/`lock.yaml` pair
 /// (so a pnpm/npm/yarn/bun incumbent's tree is never touched). Call at the
 /// start of every MUTATING PM op (install/ci/add/remove/update/dedupe), before
-/// the engine resolves, so the engine reads and writes `package.lock` with no
+/// the engine resolves, so the engine reads and writes `nub.lock` with no
 /// stale `lock.yaml` left behind.
 pub(crate) fn migrate_session_lockfile(session: &EngineSession) {
     if let Some(d) = session.detected.as_ref()
@@ -2744,7 +2744,7 @@ mod tests {
     #[test]
     fn fresh_write_format_flips_with_truly_fresh() {
         let dir = tempfile::tempdir().unwrap();
-        // A truly-fresh project writes nub's neutral `package.lock`
+        // A truly-fresh project writes nub's neutral `nub.lock`
         // (`defaultLockfileFormat=aube`); every other surface keeps the
         // pnpm-lock fresh-write default for drop-in interop.
         assert_eq!(
@@ -2753,7 +2753,7 @@ mod tests {
                 "defaultLockfileFormat"
             ),
             Some("aube"),
-            "truly-fresh must write nub's package.lock"
+            "truly-fresh must write nub's nub.lock"
         );
         assert_eq!(
             get(
@@ -3080,10 +3080,10 @@ mod tests {
         }
 
         // ── undeclared: lockfile presence decides ────────────────────────
-        // A lone package.lock (nub's canonical name) → nub identity.
+        // A lone nub.lock (nub's canonical name) → nub identity.
         let d = root(&[
             ("package.json", "{}"),
-            ("package.lock", "lockfileVersion: '9.0'\n"),
+            ("nub.lock", "lockfileVersion: '9.0'\n"),
         ]);
         assert_eq!(
             resolve_config_surface(d.path()),

--- a/crates/nub-cli/src/pm_engine/present.rs
+++ b/crates/nub-cli/src/pm_engine/present.rs
@@ -182,7 +182,7 @@ pub(crate) fn rewrite_help(text: impl AsRef<str>) -> String {
 ///
 /// - The frozen-install / `nub ci` missing-lockfile hint names a single
 ///   lockfile to commit (`pnpm-lock.yaml`), but which file a fresh
-///   `nub install` writes is context-dependent (`package.lock` for a truly-fresh
+///   `nub install` writes is context-dependent (`nub.lock` for a truly-fresh
 ///   project, `pnpm-lock.yaml` otherwise), so naming one is misleading.
 ///   Neutralized to "a lockfile" — a nub-only correction (standalone aube's
 ///   `pnpm-lock.yaml` hint is correct for it, so this stays out of the fork).

--- a/crates/nub-cli/src/pm_engine/use_align.rs
+++ b/crates/nub-cli/src/pm_engine/use_align.rs
@@ -18,12 +18,11 @@ use anyhow::{Context, Result, bail};
 use aube_lockfile::LockfileKind;
 
 /// Nub's own lockfile name under nub identity (the two-mode model): the
-/// engine's canonical-lockfile slot under a generic, deliberately unbranded
-/// filename — `package.lock` pairs with `package.json`, and its
-/// format-agnostic `.lock` extension survives a future serialization change.
-/// Bytes stay pnpm-lock v9 compatible. Carried on the NUB embedder profile's
-/// `lockfile_basename`.
-pub(crate) const NUB_LOCKFILE: &str = "package.lock";
+/// engine's canonical-lockfile slot under nub's own basename — `nub.lock`,
+/// whose format-agnostic `.lock` extension survives a future serialization
+/// change. Bytes stay pnpm-lock v9 compatible. Carried on the NUB embedder
+/// profile's `lockfile_basename`.
+pub(crate) const NUB_LOCKFILE: &str = "nub.lock";
 
 /// Nub's PRIOR canonical lockfile name, still recognized on read during the
 /// rename transition (carried on the NUB profile's `lockfile_legacy_basenames`)
@@ -81,7 +80,7 @@ pub(crate) enum AlignPlan {
         from_kind: LockfileKind,
         remove: Vec<PathBuf>,
     },
-    /// The pnpm ↔ nub pair: same bytes (`package.lock` IS pnpm-v9 format under
+    /// The pnpm ↔ nub pair: same bytes (`nub.lock` IS pnpm-v9 format under
     /// a generic name), different filename — a rename, never a parse/rewrite,
     /// so the file stays byte-identical and the real PM's `--frozen-lockfile`
     /// acceptance is preserved exactly.
@@ -507,14 +506,14 @@ mod tests {
             }
         );
 
-        // package.lock under `use nub` is already nub's artifact: kept.
+        // nub.lock under `use nub` is already nub's artifact: kept.
         let dir = root("keep-nub", &[(NUB_LOCKFILE, "lockfileVersion: '9.0'\n")]);
         assert!(matches!(
             plan_alignment(&dir, "nub").unwrap(),
             AlignPlan::Keep { .. }
         ));
 
-        // package.lock → npm is a real format change: converted, not renamed.
+        // nub.lock → npm is a real format change: converted, not renamed.
         let dir = root("nub-to-npm", &[(NUB_LOCKFILE, "lockfileVersion: '9.0'\n")]);
         assert!(matches!(
             plan_alignment(&dir, "npm").unwrap(),
@@ -524,7 +523,7 @@ mod tests {
             }
         ));
 
-        // package.lock + a foreign family with neither being the target:
+        // nub.lock + a foreign family with neither being the target:
         // ambiguity, loud, naming both files.
         let dir = root(
             "nub-ambig",
@@ -536,7 +535,7 @@ mod tests {
         let err = plan_alignment(&dir, "bun").unwrap_err().to_string();
         assert!(
             err.contains(NUB_LOCKFILE) && err.contains("package-lock.json"),
-            "ambiguity must name package.lock and package-lock.json, got: {err}"
+            "ambiguity must name nub.lock and package-lock.json, got: {err}"
         );
     }
 

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -9,7 +9,7 @@
 //! `devEngines.packageManager {name:"nub", version:"^<ver>", onFail:"warn"}`
 //! (the non-locking cross-tool signal, always written) plus — ONLY on the
 //! explicit `pm use nub@<exact>` opt-in — the hard `packageManager: "nub@<exact>"`
-//! pin; the lockfile renamed (or converted) to `package.lock` (pnpm-v9 bytes,
+//! pin; the lockfile renamed (or converted) to `nub.lock` (pnpm-v9 bytes,
 //! generic name), and `pnpm-workspace.yaml` ALWAYS migrated and deleted:
 //!
 //! - resolution-bearing keys → `package.json` under ecosystem-standard
@@ -817,7 +817,7 @@ fn pnpm_vocab_precedence(root: &Path) -> VocabPrecedence {
 /// (bare `nub pm use nub`) writes only the non-locking devEngines caret range on
 /// the running version. Prints the file-by-file summary; never silent.
 pub(crate) fn run_use_nub(root: &Path, exact_pin: Option<&str>) -> Result<i32> {
-    // The brand preflight registers the yaml names + package.lock filename the
+    // The brand preflight registers the yaml names + nub.lock filename the
     // discovery below and the engine writers read.
     super::engine_brand_preflight();
 
@@ -912,7 +912,7 @@ pub(crate) fn run_use_nub(root: &Path, exact_pin: Option<&str>) -> Result<i32> {
         AlignPlan::Keep { kept, remove } => {
             let kept_name = kept.file_name().unwrap_or_default().to_string_lossy();
             // The explicit graduation must leave the project on the current
-            // name: converge a kept LEGACY-named nub lockfile to `package.lock`
+            // name: converge a kept LEGACY-named nub lockfile to `nub.lock`
             // (byte-identical rename), rather than reporting "kept" and leaving
             // the old filename for a later install to migrate.
             if kept_name == NUB_LEGACY_LOCKFILE {

--- a/crates/nub-cli/tests/bun_basic_config.rs
+++ b/crates/nub-cli/tests/bun_basic_config.rs
@@ -145,7 +145,7 @@ fn nub_identity_does_not_read_project_or_global_bunfig() {
                 r#"{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1"}"#,
             ),
             (
-                "package.lock",
+                "nub.lock",
                 "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n",
             ),
             (

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -69,7 +69,7 @@ fn registry_reachable() -> bool {
 /// Truly-fresh project (no lockfile, no PM declaration, no pnpm-named file):
 /// nub claims identity via the neutral lockfile only. The engine resolves, links
 /// the isolated (pnpm-style) layout under `node_modules/.nub`, and writes nub's
-/// neutral `package.lock` — the quiet identity marker. It must NOT auto-stamp
+/// neutral `nub.lock` — the quiet identity marker. It must NOT auto-stamp
 /// `packageManager` / `devEngines` into `package.json`: that exclusivity claim
 /// is reserved for the explicit `nub pm use nub` command.
 #[test]
@@ -119,8 +119,8 @@ fn install_truly_fresh_project_claims_nub_identity() {
     );
 
     assert!(
-        dir.join("package.lock").is_file(),
-        "truly-fresh install writes nub's neutral package.lock"
+        dir.join("nub.lock").is_file(),
+        "truly-fresh install writes nub's neutral nub.lock"
     );
     assert!(
         !dir.join("pnpm-lock.yaml").exists() && !dir.join("aube-lock.yaml").exists(),
@@ -128,10 +128,10 @@ fn install_truly_fresh_project_claims_nub_identity() {
     );
 
     // A virgin install stamps a caret RANGE into `devEngines.packageManager`
-    // (the non-locking PM signal nub's neutral package.lock withholds) — never
+    // (the non-locking PM signal nub's neutral nub.lock withholds) — never
     // the hard, corepack-visible `packageManager: nub@<v>` pin, which stays the
     // opt-in of an explicit `nub pm use nub@<exact>`. Identity is also
-    // self-reinforcing via the lockfile: the next install sees package.lock and is
+    // self-reinforcing via the lockfile: the next install sees nub.lock and is
     // no longer virgin, so it never re-stamps.
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
@@ -290,8 +290,8 @@ fn install_with_pnpm_workspace_stays_pnpm_shaped_no_stamp() {
         "a pnpm-workspace.yaml project writes pnpm-lock.yaml"
     );
     assert!(
-        !dir.join("package.lock").exists(),
-        "a pnpm-incumbent project must not get nub's package.lock"
+        !dir.join("nub.lock").exists(),
+        "a pnpm-incumbent project must not get nub's nub.lock"
     );
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
@@ -497,7 +497,7 @@ fn install_refuses_to_mutate_a_drifted_yarn_lock() {
 }
 
 /// A truly-fresh `nub add` claims nub identity exactly like a fresh `install`:
-/// the add resolves + writes nub's neutral `package.lock` and adds the dep, and —
+/// the add resolves + writes nub's neutral `nub.lock` and adds the dep, and —
 /// because the project is virgin (nub is the first PM to touch it) — stamps the
 /// non-locking `devEngines.packageManager` caret range. Never the exact
 /// `packageManager: nub@<v>` pin (that is `nub pm use nub@<exact>`'s opt-in).
@@ -521,8 +521,8 @@ fn add_on_a_truly_fresh_project_claims_nub_identity() {
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
 
     assert!(
-        dir.join("package.lock").is_file(),
-        "a truly-fresh add writes nub's neutral package.lock: {stderr}"
+        dir.join("nub.lock").is_file(),
+        "a truly-fresh add writes nub's neutral nub.lock: {stderr}"
     );
     assert!(
         !dir.join("pnpm-lock.yaml").exists() && !dir.join("aube-lock.yaml").exists(),

--- a/crates/nub-cli/tests/lockfile_rename.rs
+++ b/crates/nub-cli/tests/lockfile_rename.rs
@@ -1,4 +1,4 @@
-//! Transitional rename of nub's own lockfile: `lock.yaml` → `package.lock`.
+//! Transitional rename of nub's own lockfile: `lock.yaml` → `nub.lock`.
 //! A virgin install writes the new name; an unmigrated `lock.yaml` is renamed
 //! byte-identically on the next mutating op (and a redundant one is removed);
 //! workspace members migrate too. All rows run OFFLINE with empty-dependency
@@ -55,7 +55,7 @@ fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
 const EMPTY_LOCK: &str = "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n";
 const EMPTY_PKG: &str = r#"{"name":"app","version":"1.0.0"}"#;
 
-/// A truly-fresh project (no lockfile, no PM signal) writes `package.lock`,
+/// A truly-fresh project (no lockfile, no PM signal) writes `nub.lock`,
 /// not the legacy `lock.yaml`.
 #[test]
 fn virgin_install_writes_package_lock() {
@@ -63,8 +63,8 @@ fn virgin_install_writes_package_lock() {
     let (stdout, stderr, code) = run(&dir, &["install", "--offline"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert!(
-        dir.join("package.lock").is_file(),
-        "virgin install must write package.lock: {stderr}"
+        dir.join("nub.lock").is_file(),
+        "virgin install must write nub.lock: {stderr}"
     );
     assert!(
         !dir.join("lock.yaml").exists(),
@@ -72,7 +72,7 @@ fn virgin_install_writes_package_lock() {
     );
 }
 
-/// An existing `lock.yaml` is migrated to `package.lock` byte-identically on
+/// An existing `lock.yaml` is migrated to `nub.lock` byte-identically on
 /// the next install, and the stale file is gone.
 #[test]
 fn existing_lock_yaml_is_migrated_byte_identically() {
@@ -87,14 +87,14 @@ fn existing_lock_yaml_is_migrated_byte_identically() {
         "the legacy lock.yaml must be removed after migration"
     );
     assert_eq!(
-        std::fs::read_to_string(dir.join("package.lock")).unwrap(),
+        std::fs::read_to_string(dir.join("nub.lock")).unwrap(),
         EMPTY_LOCK,
         "the migration is a byte-identical rename"
     );
 }
 
 /// When BOTH names exist, the redundant `lock.yaml` is removed and
-/// `package.lock` is kept untouched (no double-lockfile left behind).
+/// `nub.lock` is kept untouched (no double-lockfile left behind).
 #[test]
 fn both_present_keeps_package_lock_and_removes_legacy() {
     let kept = "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n# kept\n";
@@ -102,7 +102,7 @@ fn both_present_keeps_package_lock_and_removes_legacy() {
         "both",
         &[
             ("package.json", EMPTY_PKG),
-            ("package.lock", kept),
+            ("nub.lock", kept),
             ("lock.yaml", EMPTY_LOCK),
         ],
     );
@@ -113,9 +113,9 @@ fn both_present_keeps_package_lock_and_removes_legacy() {
         "the redundant legacy lock.yaml must be removed"
     );
     assert_eq!(
-        std::fs::read_to_string(dir.join("package.lock")).unwrap(),
+        std::fs::read_to_string(dir.join("nub.lock")).unwrap(),
         kept,
-        "the existing package.lock must be kept verbatim, not overwritten by the legacy file"
+        "the existing nub.lock must be kept verbatim, not overwritten by the legacy file"
     );
 }
 
@@ -131,7 +131,7 @@ fn workspace_member_lock_yaml_migrates() {
                 r#"{"name":"root","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#,
             ),
             // Root carries nub's lockfile so the project resolves as nub identity.
-            ("package.lock", EMPTY_LOCK),
+            ("nub.lock", EMPTY_LOCK),
             (
                 "packages/a/package.json",
                 r#"{"name":"a","version":"1.0.0"}"#,
@@ -146,14 +146,14 @@ fn workspace_member_lock_yaml_migrates() {
         "a workspace member's legacy lock.yaml must migrate too: {stderr}"
     );
     assert!(
-        dir.join("packages/a/package.lock").is_file(),
-        "the member's lockfile must land at package.lock"
+        dir.join("packages/a/nub.lock").is_file(),
+        "the member's lockfile must land at nub.lock"
     );
 }
 
 /// `nub ci` is a frozen, ephemeral install: it installs fine from an existing
 /// `lock.yaml` (read-both) but must NEVER migrate or otherwise mutate a
-/// checked-in file — no rename, no `package.lock` written, `lock.yaml` left
+/// checked-in file — no rename, no `nub.lock` written, `lock.yaml` left
 /// byte-for-byte untouched.
 #[test]
 fn ci_never_migrates_or_mutates_the_lockfile() {
@@ -172,8 +172,8 @@ fn ci_never_migrates_or_mutates_the_lockfile() {
         "ci must leave lock.yaml byte-for-byte untouched"
     );
     assert!(
-        !dir.join("package.lock").exists(),
-        "ci must not rename or write package.lock — a frozen install never mutates checked-in files"
+        !dir.join("nub.lock").exists(),
+        "ci must not rename or write nub.lock — a frozen install never mutates checked-in files"
     );
 }
 

--- a/crates/nub-cli/tests/pm_identity.rs
+++ b/crates/nub-cli/tests/pm_identity.rs
@@ -63,16 +63,16 @@ const EMPTY_PNPM: &str = r#"{"name":"app","version":"1.0.0","packageManager":"pn
 #[test]
 fn fresh_projects_write_the_identity_format_declared_first_else_nub() {
     // none + none → truly fresh: nub claims identity via the neutral lockfile
-    // (writes package.lock) AND stamps a caret RANGE into `devEngines.packageManager`
-    // — the non-locking PM signal nub's unbranded package.lock withholds, the
+    // (writes nub.lock) AND stamps a caret RANGE into `devEngines.packageManager`
+    // — the non-locking PM signal nub's unbranded nub.lock withholds, the
     // coherent counterpart to keeping the lockfile neutral. Never the exact
     // `packageManager: nub@<v>` pin (that hard claim is `nub pm use nub@<exact>`'s).
     let dir = project("fresh-default", r#"{"name":"app","version":"1.0.0"}"#);
     let (stdout, stderr, code) = run(&dir, &["install"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert!(
-        dir.join("package.lock").is_file(),
-        "truly-fresh install must write nub's neutral package.lock: {stderr}"
+        dir.join("nub.lock").is_file(),
+        "truly-fresh install must write nub's neutral nub.lock: {stderr}"
     );
     assert!(
         !dir.join("pnpm-lock.yaml").exists(),
@@ -350,8 +350,8 @@ fn a_fresh_declared_yarn_project_hits_the_write_gate_not_a_pnpm_lockfile() {
     );
 }
 
-/// The package.lock rows (two-mode model, the maintainer 2026-06-10): the generically
-/// named `package.lock` (the engine's canonical slot under nub's filename
+/// The nub.lock rows (two-mode model, the maintainer 2026-06-10): the generically
+/// named `nub.lock` (the engine's canonical slot under nub's filename
 /// toggle) IS nub identity — alone it resolves and installs in place; beside
 /// a foreign lockfile or against a contradicting declaration it is the same
 /// loud error as any other identity conflict, never a silent winner (nub
@@ -360,60 +360,57 @@ fn a_fresh_declared_yarn_project_hits_the_write_gate_not_a_pnpm_lockfile() {
 fn lock_yaml_is_nub_identity_and_conflicts_are_loud() {
     let empty_lock = "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n";
 
-    // package.lock + no declaration → nub identity: install works in place,
-    // package.lock stays the lockfile, no pnpm-lock.yaml appears.
+    // nub.lock + no declaration → nub identity: install works in place,
+    // nub.lock stays the lockfile, no pnpm-lock.yaml appears.
     let dir = project("lockyaml-nub", r#"{"name":"app","version":"1.0.0"}"#);
-    std::fs::write(dir.join("package.lock"), empty_lock).unwrap();
+    std::fs::write(dir.join("nub.lock"), empty_lock).unwrap();
     let (stdout, stderr, code) = run(&dir, &["install"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert!(
-        dir.join("package.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
-        "package.lock is the lockfile under nub identity: {stderr}"
+        dir.join("nub.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
+        "nub.lock is the lockfile under nub identity: {stderr}"
     );
 
-    // package.lock + package-lock.json, no declaration → ambiguity naming both.
+    // nub.lock + package-lock.json, no declaration → ambiguity naming both.
     let dir = project("lockyaml-ambig", r#"{"name":"app","version":"1.0.0"}"#);
-    std::fs::write(dir.join("package.lock"), empty_lock).unwrap();
+    std::fs::write(dir.join("nub.lock"), empty_lock).unwrap();
     std::fs::write(
         dir.join("package-lock.json"),
         r#"{"name":"app","version":"1.0.0","lockfileVersion":3,"requires":true,"packages":{}}"#,
     )
     .unwrap();
     let (_, stderr, code) = run(&dir, &["install"]);
-    assert_ne!(
-        code, 0,
-        "package.lock beside a foreign lockfile must refuse"
-    );
+    assert_ne!(code, 0, "nub.lock beside a foreign lockfile must refuse");
     assert!(
         stderr.contains("ERR_NUB_LOCKFILE_AMBIGUOUS")
-            && stderr.contains("package.lock")
+            && stderr.contains("nub.lock")
             && stderr.contains("package-lock.json"),
         "the ambiguity must carry the code and name both files: {stderr}"
     );
 
-    // Declared pnpm + only package.lock → contradiction (a half-reversed switch;
+    // Declared pnpm + only nub.lock → contradiction (a half-reversed switch;
     // `nub pm use` is the remedy in the message).
     let dir = project("lockyaml-contra", EMPTY_PNPM);
-    std::fs::write(dir.join("package.lock"), empty_lock).unwrap();
+    std::fs::write(dir.join("nub.lock"), empty_lock).unwrap();
     let (_, stderr, code) = run(&dir, &["install"]);
-    assert_ne!(code, 0, "declared pnpm over package.lock must refuse");
+    assert_ne!(code, 0, "declared pnpm over nub.lock must refuse");
     assert!(
-        stderr.contains("ERR_NUB_LOCKFILE_DECLARATION_MISMATCH") && stderr.contains("package.lock"),
-        "the contradiction must carry the code and name package.lock: {stderr}"
+        stderr.contains("ERR_NUB_LOCKFILE_DECLARATION_MISMATCH") && stderr.contains("nub.lock"),
+        "the contradiction must carry the code and name nub.lock: {stderr}"
     );
 
-    // Declared nub + package.lock → clean nub identity (the post-`use nub`
+    // Declared nub + nub.lock → clean nub identity (the post-`use nub`
     // state): resolves and installs.
     let dir = project(
         "lockyaml-declared",
         r#"{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1"}"#,
     );
-    std::fs::write(dir.join("package.lock"), empty_lock).unwrap();
+    std::fs::write(dir.join("nub.lock"), empty_lock).unwrap();
     let (stdout, stderr, code) = run(&dir, &["install"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert!(
-        dir.join("package.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
-        "declared nub keeps package.lock: {stderr}"
+        dir.join("nub.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
+        "declared nub keeps nub.lock: {stderr}"
     );
 }
 

--- a/crates/nub-cli/tests/pm_two_mode.rs
+++ b/crates/nub-cli/tests/pm_two_mode.rs
@@ -76,11 +76,11 @@ fn use_nub_migrates_a_single_package_catalog_project_offline_and_idempotently() 
     let (stdout, stderr, code) = run(&dir, &["pm", "use", "nub"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
 
-    // Zero pnpm-named files; package.lock carries the exact prior bytes.
+    // Zero pnpm-named files; nub.lock carries the exact prior bytes.
     assert!(!dir.join("pnpm-workspace.yaml").exists(), "{stdout}");
     assert!(!dir.join("pnpm-lock.yaml").exists(), "{stdout}");
     assert_eq!(
-        std::fs::read_to_string(dir.join("package.lock")).unwrap(),
+        std::fs::read_to_string(dir.join("nub.lock")).unwrap(),
         EMPTY_LOCK,
         "the rename must be byte-identical"
     );
@@ -129,7 +129,7 @@ fn use_nub_migrates_a_single_package_catalog_project_offline_and_idempotently() 
     let (stdout2, stderr2, code2) = run(&dir, &["pm", "use", "nub"]);
     assert_eq!(code2, 0, "stdout: {stdout2}\nstderr: {stderr2}");
     assert!(
-        stdout2.contains("package.lock: kept"),
+        stdout2.contains("nub.lock: kept"),
         "rerun must keep, not re-convert: {stdout2}"
     );
 }
@@ -160,8 +160,8 @@ fn use_nub_recovers_from_a_crash_before_the_yaml_deletion() {
                     r#""devEngines":{"packageManager":{"name":"nub","version":"^0.0.0","onFail":"warn"}},"workspaces":{"catalog":{"left-pad":"1.3.0"}}"#
                 ),
             ),
-            // The rename already happened: package.lock present, no pnpm-lock.yaml.
-            ("package.lock", EMPTY_LOCK),
+            // The rename already happened: nub.lock present, no pnpm-lock.yaml.
+            ("nub.lock", EMPTY_LOCK),
             // The leftover the crash never got to delete — still carrying the
             // catalog that the atomic manifest edit already preserved.
             ("pnpm-workspace.yaml", "catalog:\n  left-pad: 1.3.0\n"),
@@ -171,15 +171,15 @@ fn use_nub_recovers_from_a_crash_before_the_yaml_deletion() {
     let (stdout, stderr, code) = run(&dir, &["pm", "use", "nub"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
 
-    // The leftover yaml is gone; package.lock is kept (not re-renamed); the
+    // The leftover yaml is gone; nub.lock is kept (not re-renamed); the
     // project is now in clean, fully-migrated nub identity.
     assert!(
         !dir.join("pnpm-workspace.yaml").exists(),
         "the recovery run must delete the stray yaml: {stdout}"
     );
     assert!(
-        dir.join("package.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
-        "package.lock stays the lockfile, untouched: {stdout}"
+        dir.join("nub.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
+        "nub.lock stays the lockfile, untouched: {stdout}"
     );
 
     // The migrated data survived the half-state — never silently dropped.
@@ -226,7 +226,7 @@ fn use_nub_migrates_with_injected_deps_and_preserves_meta() {
 
     // The switch completed: yaml renamed, identity flipped, pnpm namespace gone.
     assert!(
-        dir.join("package.lock").is_file()
+        dir.join("nub.lock").is_file()
             && !dir.join("pnpm-lock.yaml").exists()
             && !dir.join("pnpm-workspace.yaml").exists(),
         "the migration must complete the lockfile rename + yaml deletion: {stdout}"
@@ -250,7 +250,7 @@ fn use_nub_migrates_with_injected_deps_and_preserves_meta() {
 
 /// Under nub identity a stray pnpm-workspace.yaml is ignore-with-warning:
 /// exactly one warning naming it unread plus the remedies, and the install
-/// proceeds against package.lock.
+/// proceeds against nub.lock.
 #[test]
 fn stray_workspace_yaml_under_nub_identity_warns_once_and_install_proceeds() {
     let dir = project(
@@ -260,7 +260,7 @@ fn stray_workspace_yaml_under_nub_identity_warns_once_and_install_proceeds() {
                 "package.json",
                 r#"{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1"}"#,
             ),
-            ("package.lock", EMPTY_LOCK),
+            ("nub.lock", EMPTY_LOCK),
             ("pnpm-workspace.yaml", "nodeLinker: hoisted\n"),
         ],
     );
@@ -278,8 +278,8 @@ fn stray_workspace_yaml_under_nub_identity_warns_once_and_install_proceeds() {
         "the warning must carry both remedies: {stderr}"
     );
     assert!(
-        dir.join("package.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
-        "package.lock stays the lockfile"
+        dir.join("nub.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
+        "nub.lock stays the lockfile"
     );
 }
 
@@ -321,7 +321,7 @@ fn lifecycle_ua_is_pnpm_first_in_compat_and_nub_first_under_nub_identity() {
                     r#"{{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1",{postinstall}}}"#
                 ),
             ),
-            ("package.lock", EMPTY_LOCK),
+            ("nub.lock", EMPTY_LOCK),
         ],
     );
     let (stdout, stderr, code) = run(&dir, &["install"]);
@@ -333,7 +333,7 @@ fn lifecycle_ua_is_pnpm_first_in_compat_and_nub_first_under_nub_identity() {
     );
 }
 
-/// An empty-dependency, in-sync npm v3 package-lock — converts to package.lock
+/// An empty-dependency, in-sync npm v3 package-lock — converts to nub.lock
 /// offline (no graph to fetch), exercising the npm→nub `Convert` path.
 const EMPTY_NPM_LOCK: &str = r#"{
   "name": "app",
@@ -417,7 +417,7 @@ fn pnpmfile_ignored_silently_under_nub_identity() {
                 "package.json",
                 r#"{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1"}"#,
             ),
-            ("package.lock", EMPTY_LOCK),
+            ("nub.lock", EMPTY_LOCK),
             (".pnpmfile.cjs", hook),
         ],
     );

--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -125,7 +125,7 @@ const IS_POSITIVE_PACKAGE_LOCK: &str = r#"{
 "#;
 
 /// `nub add` then `nub rm` (alias) round-trip on a truly-fresh project: add
-/// persists the dep + writes nub's neutral `package.lock` + links node_modules;
+/// persists the dep + writes nub's neutral `nub.lock` + links node_modules;
 /// remove strips the dep from the manifest again. Both outputs brand-clean.
 #[test]
 #[ignore = "network: resolves + fetches is-positive@3.1.0 from the npm registry"]
@@ -155,10 +155,10 @@ fn add_then_remove_round_trips_manifest_lockfile_and_node_modules() {
         "add must persist the dependency: {manifest}"
     );
     assert!(
-        dir.join("package.lock").is_file()
+        dir.join("nub.lock").is_file()
             && !dir.join("pnpm-lock.yaml").exists()
             && !dir.join("aube-lock.yaml").exists(),
-        "add on a truly-fresh project writes nub's neutral package.lock"
+        "add on a truly-fresh project writes nub's neutral nub.lock"
     );
     assert!(
         dir.join("node_modules/is-positive/package.json").is_file(),

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -23,7 +23,7 @@ In a workspace, the chain runs from any member: Nub walks up to the root, which 
 | **pnpm** — [docs →](/docs/install/pnpm) | `pnpm-lock.yaml` (v9) | read + write |
 | **Yarn** — [docs →](/docs/install/yarn) | `yarn.lock` | **read-only** |
 | **Bun** — [docs →](/docs/install/bun) | `bun.lock` | read + write |
-| **Nub** — [docs →](/docs/pm) | `package.lock` (pnpm v9 bytes) | read + write |
+| **Nub** — [docs →](/docs/pm) | `nub.lock` (pnpm v9 bytes) | read + write |
 
 A no-churn guard leaves a graph-equal lockfile untouched, and Nub never drops its own lockfile into a project it doesn't own. The `bun.lockb` binary format is rejected — convert to text `bun.lock` first.
 
@@ -152,7 +152,7 @@ Under its own identity, Nub reads only neutral, cross-tool config — never anot
       href: '/docs/pm',
       highlight: true,
       items: [
-        { code: 'package.lock', ok: true },
+        { code: 'nub.lock', ok: true },
         { code: '.npmrc', ok: true },
         { code: 'overrides', ok: true },
         { code: 'resolutions', ok: true },
@@ -173,9 +173,9 @@ The installer is optional. Keep running `npm`, `pnpm`, `yarn`, or `bun` exactly 
 
 ### Nub identity
 
-A project is Nub's own in three cases: it declares Nub through `nub pm use nub`, `package.lock` is the only lockfile signal, or a fresh project has no declaration and no lockfile. The switch aligns the manifest and lockfile, migrates pnpm workspace config into neutral `package.json` fields, and moves the project onto a neutral surface:
+A project is Nub's own in three cases: it declares Nub through `nub pm use nub`, `nub.lock` is the only lockfile signal, or a fresh project has no declaration and no lockfile. The switch aligns the manifest and lockfile, migrates pnpm workspace config into neutral `package.json` fields, and moves the project onto a neutral surface:
 
-- **Lockfile:** `package.lock` — the pnpm v9 schema byte-for-byte, under Nub's own basename
+- **Lockfile:** `nub.lock` — the pnpm v9 schema byte-for-byte, under Nub's own basename
 - **Package fields:** `workspaces`, `overrides`, `resolutions`, `patchedDependencies`, `allowBuilds`, `engines.node`, `scripts`
 - **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`
 - **Install state:** `node_modules/.nub/`, `.nub-state`, and the global store under Nub's own directories
@@ -185,7 +185,7 @@ A fresh `nub install` records Nub as the manager with a non-locking range — `d
 This is the brand boundary in both directions: Nub never emits its own brand into your config, and under its own identity reads *only* neutral, cross-tool config — never `pnpm-workspace.yaml`, `.pnpmfile.cjs`, the `pnpm.*` namespace, `pnpm_config_*`, `.yarnrc.yml`, `bunfig.toml`, Bun `trustedDependencies`, or aube's `AUBE_*` knobs. To keep pnpm hooks or pnpm-named workspace config active, stay pnpm-owned or run `nub pm use pnpm`.
 
 ```console
-# captured: Nub-identity project (package.lock) with a stray pnpm-workspace.yaml
+# captured: Nub-identity project (nub.lock) with a stray pnpm-workspace.yaml
 $ nub install
 nub: pnpm-workspace.yaml is not read under nub identity — migrate it
      (`nub pm use nub`), delete it, or return to pnpm (`nub pm use pnpm`).
@@ -214,7 +214,7 @@ Error: ERR_NUB_LOCKFILE_DECLARATION_MISMATCH
   help: nub pm use <pm> to declare it, or remove the stale lockfile
 ```
 
-Under Nub identity, `package.lock` beside a foreign lockfile is the ambiguity error.
+Under Nub identity, `nub.lock` beside a foreign lockfile is the ambiguity error.
 </Callout>
 
 <Callout title="Inference vs the pinned PM">


### PR DESCRIPTION
Renames the lockfile nub writes for a nub-identity project from `package.lock` to `nub.lock`. The `package.lock` name landed on `main` via #257 but was never released — the released name through v0.2.10 is still `lock.yaml` — so this supersedes #257 before either name ships.

The change is one authoritative line (`NUB_LOCKFILE` in `crates/nub-cli/src/pm_engine/use_align.rs`); the rest is a mechanical sweep of doc-comments, test string-literals, and the install docs page. Bytes are unchanged (pnpm-lock v9).

The legacy reader is preserved: `NUB_LEGACY_LOCKFILE = "lock.yaml"` stays, so an existing `lock.yaml` still migrates byte-identically to the new name on the next mutating install. `vendor/aube` is untouched — the basename is embedder-driven.

Verified: fmt, `clippy --all-targets --all-features -D warnings`, and the pm/lockfile scoped test files pass. Two e2e fixtures confirm a fresh nub-identity project writes `nub.lock` and a legacy `lock.yaml` migrates byte-identically to `nub.lock`.