### PR TITLE
pm: rename nub's own lockfile to nub.lock

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -6839,7 +6839,7 @@ fn run_pm_use(name: &str, spec: &str, cwd: &Path) -> Result<i32> {
                 );
             }
         }
-        // nub → pnpm: lock.yaml renamed back, byte-identical (the two-mode
+        // nub → pnpm: nub.lock renamed back, byte-identical (the two-mode
         // eject — the format was never forked, so the rename IS the eject).
         AlignPlan::Rename { from, remove } => {
             let to = root.join(use_align::lockfile_name(name));

--- a/crates/nub-cli/src/pm_engine/config_scope.rs
+++ b/crates/nub-cli/src/pm_engine/config_scope.rs
@@ -187,7 +187,7 @@ pub(crate) fn role_of(declared: Option<&str>, kind: Option<LockfileKind>) -> Opt
         LockfileKind::Npm | LockfileKind::NpmShrinkwrap => Role::Npm,
         LockfileKind::Yarn | LockfileKind::YarnBerry => Role::Yarn,
         LockfileKind::Bun => Role::Bun,
-        // The generic lock.yaml (aube's `Aube` slot under nub's filename
+        // The generic nub.lock (aube's `Aube` slot under nub's filename
         // toggle) is nub identity.
         LockfileKind::Aube => Role::Nub,
     })

--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -33,9 +33,12 @@
 /// - `self_names` = `["nub"]`, `compatible_names` = `["pnpm"]` — nub is the
 ///   tool, pnpm the compatible drop-in (was `set_detection_self_names` +
 ///   `set_package_manager_names`).
-/// - `lockfile_basename` = `"lock.yaml"` — nub's generic, unbranded canonical
-///   lockfile (pnpm-lock v9 bytes); was
+/// - `lockfile_basename` = `"nub.lock"` — nub's generic, unbranded
+///   canonical lockfile (pnpm-lock v9 bytes), pairing with `package.json`; was
 ///   `set_aube_lock_base_filename(NUB_LOCKFILE)`.
+/// - `lockfile_legacy_basenames` = `["lock.yaml"]` — nub's pre-rename name,
+///   still recognized on read during the transition and migrated to
+///   `nub.lock` on the next mutating PM op.
 /// - `workspace_yaml` = `None` — nub has no branded workspace YAML of its own.
 ///   The shared `pnpm-workspace.yaml` compat surface is gated separately on the
 ///   `EngineContext` (`read_branded_pnpm_config`), per the role.
@@ -96,7 +99,7 @@
 ///   `managed_config_system_dir = None` would skip the system read — here the
 ///   user/project branded-file read/write is skipped entirely. Standalone aube
 ///   keeps `Some("aube")`, so its `~/.config/aube/config.toml` path is unchanged.
-/// - `canonical_lockfile_always_wins` = `false` — `lock.yaml` never silently
+/// - `canonical_lockfile_always_wins` = `false` — `nub.lock` never silently
 ///   outranks a foreign lockfile beside it; that state is the loud
 ///   ambiguity/contradiction error (was
 ///   `set_canonical_lockfile_always_wins(false)`).
@@ -152,6 +155,10 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     self_names: &["nub"],
     compatible_names: &["pnpm"],
     lockfile_basename: super::use_align::NUB_LOCKFILE,
+    // `lock.yaml` (nub's pre-rename name) stays readable through the transition
+    // and is migrated to `nub.lock` on the next mutating PM op; sunset at
+    // the next major.
+    lockfile_legacy_basenames: &[super::use_align::NUB_LEGACY_LOCKFILE],
     workspace_yaml: None,
     manifest_namespace: "",
     env_prefix: None,
@@ -250,7 +257,8 @@ pub(crate) fn register() {
 // drift is a build break, not a test-run failure (and runtime `assert!` on a
 // const trips clippy's `assertions_on_constants`).
 const _: () = {
-    assert!(matches!(NUB.lockfile_basename.as_bytes(), b"lock.yaml"));
+    assert!(matches!(NUB.lockfile_basename.as_bytes(), b"nub.lock"));
+    assert!(matches!(NUB.lockfile_legacy_basenames, [b] if matches!(b.as_bytes(), b"lock.yaml")));
     assert!(matches!(NUB.cache_namespace.as_bytes(), b"nub/pm"));
     assert!(matches!(NUB.data_namespace.as_bytes(), b"nub"));
     assert!(matches!(NUB.managed_config_system_dir, Some(d) if matches!(d.as_bytes(), b"nub")));

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -353,6 +353,7 @@ fn finish_code(result: miette::Result<Option<i32>>) -> Result<i32> {
 fn run_add(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::add::AddArgs) = parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
+    super::migrate_session_lockfile(&session);
     if !verb.global && yarn_detected(&session) {
         return Err(yarn_gate_error(
             typed,
@@ -380,6 +381,7 @@ fn run_add(typed: &str, args: &[String]) -> Result<i32> {
 fn run_remove(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::remove::RemoveArgs) = parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
+    super::migrate_session_lockfile(&session);
     if !verb.global && yarn_detected(&session) {
         return Err(yarn_gate_error(
             typed,
@@ -409,6 +411,7 @@ fn run_update(typed: &str, args: &[String]) -> Result<i32> {
         ));
     }
     let session = super::engine_session(globals.dir.as_deref())?;
+    super::migrate_session_lockfile(&session);
     if !verb.global && yarn_detected(&session) {
         return Err(yarn_gate_error(
             typed,
@@ -434,7 +437,11 @@ fn run_dedupe(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::dedupe::DedupeArgs) = parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
     // `--check` writes nothing (diff + exit code only) and stays usable on
-    // yarn projects; a real dedupe re-resolves and rewrites the lockfile.
+    // yarn projects; a real dedupe re-resolves and rewrites the lockfile. Only
+    // a writing dedupe migrates the legacy lockfile name.
+    if !verb.check {
+        super::migrate_session_lockfile(&session);
+    }
     if !verb.check && yarn_detected(&session) {
         return Err(yarn_gate_error(
             typed,
@@ -994,6 +1001,10 @@ impl WorkspaceFilterFlags {
 /// `nub install` — route through the embedded aube install engine.
 pub fn run_install(flags: InstallFlags) -> Result<i32> {
     let session = super::engine_session(flags.dir.as_deref())?;
+    // Transitional: rename a legacy `lock.yaml` to `nub.lock` before the
+    // engine resolves (no-op unless this is a nub-identity project carrying the
+    // old name).
+    super::migrate_session_lockfile(&session);
     if let Some(err) = pnpm_lockfile_version_preflight(&session) {
         return Err(err);
     }
@@ -1107,7 +1118,7 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     // Virgin install only: stamp a caret RANGE into `devEngines.packageManager`
     // so the project advertises nub the standard, cross-tool way WITHOUT locking
     // itself to one exact nub version. nub's canonical lockfile is deliberately
-    // NEUTRAL (`lock.yaml`), so — unlike every other PM, whose branded lockfile
+    // NEUTRAL (`nub.lock`), so — unlike every other PM, whose branded lockfile
     // is itself the repo's PM signal — nub leaves no signal downstream tools
     // (turbo, pmd, nypm) can read; the `devEngines.packageManager` object IS that
     // signal, and detectors key on its `name`, so a `^` range is signal-equivalent
@@ -1115,7 +1126,7 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     // NOT the exact `packageManager: nub@<v>` field: that hard, corepack-visible
     // pin freezes the repo at one nub version and stays the OPT-IN gesture of an
     // explicit `nub pm use nub@<exact>`. The write is gated on
-    // `session.truly_fresh`, captured BEFORE the engine wrote `lock.yaml`: `true`
+    // `session.truly_fresh`, captured BEFORE the engine wrote `nub.lock`: `true`
     // ONLY when nub is the FIRST package manager to touch the project (no foreign
     // lockfile, no pre-existing nub lockfile, no `packageManager`/`devEngines`
     // declaration). Any incumbent signal ⇒ `false` ⇒ no write — nub never imposes
@@ -1241,6 +1252,9 @@ pub fn run_ci(flags: CiFlags) -> Result<i32> {
     // ci's frozen node_modules is COPY-relocatable across multi-stage Docker
     // (#241); isolation/phantom-dep protection is preserved.
     let session = super::engine_session_ci(flags.dir.as_deref())?;
+    // `ci` is a frozen, ephemeral install — it NEVER mutates checked-in files,
+    // so it does NOT migrate a legacy `lock.yaml`. Read-both still lets it
+    // install from an existing `lock.yaml`; it just leaves the file untouched.
     if let Some(err) = pnpm_lockfile_version_preflight(&session) {
         return Err(err);
     }

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -353,7 +353,6 @@ fn finish_code(result: miette::Result<Option<i32>>) -> Result<i32> {
 fn run_add(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::add::AddArgs) = parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
-    super::migrate_session_lockfile(&session);
     if !verb.global && yarn_detected(&session) {
         return Err(yarn_gate_error(
             typed,
@@ -381,7 +380,6 @@ fn run_add(typed: &str, args: &[String]) -> Result<i32> {
 fn run_remove(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::remove::RemoveArgs) = parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
-    super::migrate_session_lockfile(&session);
     if !verb.global && yarn_detected(&session) {
         return Err(yarn_gate_error(
             typed,
@@ -411,7 +409,6 @@ fn run_update(typed: &str, args: &[String]) -> Result<i32> {
         ));
     }
     let session = super::engine_session(globals.dir.as_deref())?;
-    super::migrate_session_lockfile(&session);
     if !verb.global && yarn_detected(&session) {
         return Err(yarn_gate_error(
             typed,
@@ -437,11 +434,7 @@ fn run_dedupe(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::dedupe::DedupeArgs) = parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
     // `--check` writes nothing (diff + exit code only) and stays usable on
-    // yarn projects; a real dedupe re-resolves and rewrites the lockfile. Only
-    // a writing dedupe migrates the legacy lockfile name.
-    if !verb.check {
-        super::migrate_session_lockfile(&session);
-    }
+    // yarn projects; a real dedupe re-resolves and rewrites the lockfile.
     if !verb.check && yarn_detected(&session) {
         return Err(yarn_gate_error(
             typed,
@@ -1001,10 +994,6 @@ impl WorkspaceFilterFlags {
 /// `nub install` — route through the embedded aube install engine.
 pub fn run_install(flags: InstallFlags) -> Result<i32> {
     let session = super::engine_session(flags.dir.as_deref())?;
-    // Transitional: rename a legacy `lock.yaml` to `nub.lock` before the
-    // engine resolves (no-op unless this is a nub-identity project carrying the
-    // old name).
-    super::migrate_session_lockfile(&session);
     if let Some(err) = pnpm_lockfile_version_preflight(&session) {
         return Err(err);
     }
@@ -1252,9 +1241,10 @@ pub fn run_ci(flags: CiFlags) -> Result<i32> {
     // ci's frozen node_modules is COPY-relocatable across multi-stage Docker
     // (#241); isolation/phantom-dep protection is preserved.
     let session = super::engine_session_ci(flags.dir.as_deref())?;
-    // `ci` is a frozen, ephemeral install — it NEVER mutates checked-in files,
-    // so it does NOT migrate a legacy `lock.yaml`. Read-both still lets it
-    // install from an existing `lock.yaml`; it just leaves the file untouched.
+    // `ci` is a frozen, ephemeral install — it NEVER writes the lockfile, so
+    // the writer's `lock.yaml` → `nub.lock` migration (which rides a real
+    // write) never fires. Read-both still lets it install from an existing
+    // `lock.yaml`; it just leaves the file untouched.
     if let Some(err) = pnpm_lockfile_version_preflight(&session) {
         return Err(err);
     }

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -820,7 +820,7 @@ fn engine_session_inner(
     }
     // Truly-fresh = no PM-preference signal anywhere (no lockfile, no
     // declaration, no pnpm-named file). On this path nub claims identity via the
-    // neutral lockfile: the embedder default flips to `lock.yaml`, the quiet
+    // neutral lockfile: the embedder default flips to `nub.lock`, the quiet
     // identity marker the classifier reads back as nub. Any incumbent signal
     // makes the project pnpm-shaped/compat and is respected untouched. On a
     // virgin install the install family ALSO stamps the non-locking
@@ -1530,7 +1530,7 @@ fn identity_error(err: aube_lockfile::Error) -> anyhow::Error {
 /// [`engine_session`]). Every seam is idempotent.
 pub(crate) fn engine_brand_preflight() {
     // Static identity FIRST, before anything reads project state or branding.
-    // The whole compile-time profile — name, `nub/<ver>` UA, `lock.yaml`
+    // The whole compile-time profile — name, `nub/<ver>` UA, `nub.lock`
     // canonical lockfile, `["nub"]`/`["pnpm"]` detection names, and the five
     // embedder-fixed toggles (engines-self check OFF, runtime-switching OFF,
     // warm-store-verify OFF, canonical-lockfile-always-wins OFF, self-update
@@ -1815,7 +1815,7 @@ fn resolve_config_surface(cwd: &Path) -> ConfigSurface {
                 _ => ConfigSurface::PnpmOrFresh,
             };
         }
-        let nub_lock = dir.join(use_align::NUB_LOCKFILE).is_file();
+        let nub_lock = nub_lockfile_present(&dir);
         let pnpm_lock = dir.join("pnpm-lock.yaml").is_file();
         let foreign = FOREIGN_NON_PNPM
             .iter()
@@ -1842,7 +1842,7 @@ fn resolve_config_surface(cwd: &Path) -> ConfigSurface {
     }
     // Nothing decided anywhere within the walk. A truly-fresh project (no
     // PM-preference signal of any kind, no pnpm-named file) becomes NUB
-    // identity: the next install writes `lock.yaml` and stamps the manifest,
+    // identity: the next install writes `nub.lock` and stamps the manifest,
     // and the project self-reinforces as nub-identity thereafter. A
     // pnpm-named file seen in the walk keeps the pnpm-shaped surface.
     if saw_pnpm_named {
@@ -1944,7 +1944,7 @@ fn read_file_head(path: &Path, max_bytes: usize) -> std::io::Result<String> {
 /// `npm_config_node_linker`, `.npmrc`, or workspace yaml all win):
 ///
 /// - `defaultLockfileFormat` — a TRULY-fresh project (no PM-preference signal
-///   of any kind) writes nub's neutral `lock.yaml` (`=aube`); every other
+///   of any kind) writes nub's neutral `nub.lock` (`=aube`); every other
 ///   surface writes `pnpm-lock.yaml` (`=pnpm`) for drop-in interop. See
 ///   [`nub_setting_defaults`]'s `truly_fresh` arm.
 /// - `virtualStoreDir` / `stateDir` = `node_modules/.nub` — the isolated
@@ -2100,7 +2100,7 @@ fn strip_yarnrc_value(rest: &str) -> &str {
 ///   DOES veto GVS under the profile (per-project + hidden tree, always). A
 ///   user-set `nodeLinker`/`hoist` (env/.npmrc/yaml) still wins — embedder-tier.
 /// - Fresh-write lockfile format: a TRULY-fresh project (no PM-preference
-///   signal of any kind — `truly_fresh`) writes nub's neutral `lock.yaml`
+///   signal of any kind — `truly_fresh`) writes nub's neutral `nub.lock`
 ///   (`defaultLockfileFormat=aube`, which under the nub embedder resolves to
 ///   the `lock.yaml` basename); every other surface writes `pnpm-lock.yaml`,
 ///   keeping a pnpm-incumbent / mixed project drop-in interoperable. A
@@ -2227,7 +2227,7 @@ fn nub_setting_defaults(
 /// `None` only then); this additionally requires that no pnpm-NAMED file
 /// (`pnpm-workspace.yaml`, `.pnpmfile.*`, `.pnpmrc`) sits in the walk — a
 /// pnpm-named file is a genuine pnpm signal that makes the project pnpm-shaped,
-/// not nub's to claim. On the truly-fresh path nub writes `lock.yaml` and
+/// not nub's to claim. On the truly-fresh path nub writes `nub.lock` and
 /// stamps the manifest with its own identity; any incumbent signal is
 /// respected and left untouched.
 fn is_truly_fresh_project(cwd: &Path, detected: Option<&DetectedLockfile>) -> bool {
@@ -2244,6 +2244,58 @@ fn is_truly_fresh_project(cwd: &Path, detected: Option<&DetectedLockfile>) -> bo
         }
     }
     true
+}
+
+/// Whether `dir` holds nub's own canonical lockfile under EITHER the current
+/// name (`nub.lock`) or the legacy name (`lock.yaml`) still honored through
+/// the rename transition. The bespoke nub-side identity probes
+/// (`resolve_config_surface`) check the file directly rather than through the
+/// engine's candidate set, so they consult both names here.
+fn nub_lockfile_present(dir: &Path) -> bool {
+    dir.join(use_align::NUB_LOCKFILE).is_file()
+        || dir.join(use_align::NUB_LEGACY_LOCKFILE).is_file()
+}
+
+/// Transitional auto-migration of nub's own lockfile name: `lock.yaml` →
+/// `nub.lock`. The bytes are identical (pnpm-lock v9), so this is a pure
+/// rename; when `nub.lock` already exists the redundant `lock.yaml` is
+/// simply removed. Runs at the project root and every workspace member dir at
+/// the start of a mutating PM op, so a project upgraded onto the new name
+/// converges silently. Best-effort: any IO error is ignored — the engine's
+/// read-both candidate set keeps an unmigrated `lock.yaml` resolvable
+/// regardless. Sunset at the next major (drop the legacy read + this sweep).
+pub(crate) fn migrate_legacy_nub_lockfile(root: &Path) {
+    migrate_legacy_nub_lockfile_dir(root);
+    for member_dir in nub_core::workspace::detect::find_workspace_members(root, None) {
+        migrate_legacy_nub_lockfile_dir(&member_dir);
+    }
+}
+
+/// Run [`migrate_legacy_nub_lockfile`] when `session` resolved a nub-identity
+/// project — the only identity that owns the `nub.lock`/`lock.yaml` pair
+/// (so a pnpm/npm/yarn/bun incumbent's tree is never touched). Call at the
+/// start of every MUTATING PM op (install/ci/add/remove/update/dedupe), before
+/// the engine resolves, so the engine reads and writes `nub.lock` with no
+/// stale `lock.yaml` left behind.
+pub(crate) fn migrate_session_lockfile(session: &EngineSession) {
+    if let Some(d) = session.detected.as_ref()
+        && d.kind == aube_lockfile::LockfileKind::Aube
+    {
+        migrate_legacy_nub_lockfile(&d.dir);
+    }
+}
+
+fn migrate_legacy_nub_lockfile_dir(dir: &Path) {
+    let legacy = dir.join(use_align::NUB_LEGACY_LOCKFILE);
+    if !legacy.is_file() {
+        return;
+    }
+    let target = dir.join(use_align::NUB_LOCKFILE);
+    if target.exists() {
+        let _ = std::fs::remove_file(&legacy);
+    } else {
+        let _ = std::fs::rename(&legacy, &target);
+    }
 }
 
 /// Nub's XDG data root (`$XDG_DATA_HOME/nub` or `~/.local/share/nub`), the
@@ -2898,7 +2950,7 @@ mod tests {
     #[test]
     fn fresh_write_format_flips_with_truly_fresh() {
         let dir = tempfile::tempdir().unwrap();
-        // A truly-fresh project writes nub's neutral `lock.yaml`
+        // A truly-fresh project writes nub's neutral `nub.lock`
         // (`defaultLockfileFormat=aube`); every other surface keeps the
         // pnpm-lock fresh-write default for drop-in interop.
         assert_eq!(
@@ -2907,7 +2959,7 @@ mod tests {
                 "defaultLockfileFormat"
             ),
             Some("aube"),
-            "truly-fresh must write nub's lock.yaml"
+            "truly-fresh must write nub's nub.lock"
         );
         assert_eq!(
             get(
@@ -3234,7 +3286,17 @@ mod tests {
         }
 
         // ── undeclared: lockfile presence decides ────────────────────────
-        // A lone lock.yaml → nub identity, carrying the deciding dir.
+        // A lone nub.lock (nub's canonical name) → nub identity.
+        let d = root(&[
+            ("package.json", "{}"),
+            ("nub.lock", "lockfileVersion: '9.0'\n"),
+        ]);
+        assert_eq!(
+            resolve_config_surface(d.path()),
+            ConfigSurface::NubIdentity(d.path().to_path_buf())
+        );
+        // A lone legacy lock.yaml (read-both through the transition) → nub
+        // identity too, carrying the deciding dir.
         let d = root(&[
             ("package.json", "{}"),
             ("lock.yaml", "lockfileVersion: '9.0'\n"),

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2256,48 +2256,6 @@ fn nub_lockfile_present(dir: &Path) -> bool {
         || dir.join(use_align::NUB_LEGACY_LOCKFILE).is_file()
 }
 
-/// Transitional auto-migration of nub's own lockfile name: `lock.yaml` →
-/// `nub.lock`. The bytes are identical (pnpm-lock v9), so this is a pure
-/// rename; when `nub.lock` already exists the redundant `lock.yaml` is
-/// simply removed. Runs at the project root and every workspace member dir at
-/// the start of a mutating PM op, so a project upgraded onto the new name
-/// converges silently. Best-effort: any IO error is ignored — the engine's
-/// read-both candidate set keeps an unmigrated `lock.yaml` resolvable
-/// regardless. Sunset at the next major (drop the legacy read + this sweep).
-pub(crate) fn migrate_legacy_nub_lockfile(root: &Path) {
-    migrate_legacy_nub_lockfile_dir(root);
-    for member_dir in nub_core::workspace::detect::find_workspace_members(root, None) {
-        migrate_legacy_nub_lockfile_dir(&member_dir);
-    }
-}
-
-/// Run [`migrate_legacy_nub_lockfile`] when `session` resolved a nub-identity
-/// project — the only identity that owns the `nub.lock`/`lock.yaml` pair
-/// (so a pnpm/npm/yarn/bun incumbent's tree is never touched). Call at the
-/// start of every MUTATING PM op (install/ci/add/remove/update/dedupe), before
-/// the engine resolves, so the engine reads and writes `nub.lock` with no
-/// stale `lock.yaml` left behind.
-pub(crate) fn migrate_session_lockfile(session: &EngineSession) {
-    if let Some(d) = session.detected.as_ref()
-        && d.kind == aube_lockfile::LockfileKind::Aube
-    {
-        migrate_legacy_nub_lockfile(&d.dir);
-    }
-}
-
-fn migrate_legacy_nub_lockfile_dir(dir: &Path) {
-    let legacy = dir.join(use_align::NUB_LEGACY_LOCKFILE);
-    if !legacy.is_file() {
-        return;
-    }
-    let target = dir.join(use_align::NUB_LOCKFILE);
-    if target.exists() {
-        let _ = std::fs::remove_file(&legacy);
-    } else {
-        let _ = std::fs::rename(&legacy, &target);
-    }
-}
-
 /// Nub's XDG data root (`$XDG_DATA_HOME/nub` or `~/.local/share/nub`), the
 /// data-dir sibling of `nub_core::node::discovery::cache_dir`.
 pub(crate) fn nub_data_dir() -> Option<PathBuf> {

--- a/crates/nub-cli/src/pm_engine/present.rs
+++ b/crates/nub-cli/src/pm_engine/present.rs
@@ -182,7 +182,7 @@ pub(crate) fn rewrite_help(text: impl AsRef<str>) -> String {
 ///
 /// - The frozen-install / `nub ci` missing-lockfile hint names a single
 ///   lockfile to commit (`pnpm-lock.yaml`), but which file a fresh
-///   `nub install` writes is context-dependent (`lock.yaml` for a truly-fresh
+///   `nub install` writes is context-dependent (`nub.lock` for a truly-fresh
 ///   project, `pnpm-lock.yaml` otherwise), so naming one is misleading.
 ///   Neutralized to "a lockfile" — a nub-only correction (standalone aube's
 ///   `pnpm-lock.yaml` hint is correct for it, so this stays out of the fork).

--- a/crates/nub-cli/src/pm_engine/use_align.rs
+++ b/crates/nub-cli/src/pm_engine/use_align.rs
@@ -18,10 +18,17 @@ use anyhow::{Context, Result, bail};
 use aube_lockfile::LockfileKind;
 
 /// Nub's own lockfile name under nub identity (the two-mode model): the
-/// engine's canonical-lockfile slot under a generic, deliberately unbranded
-/// filename — bytes stay pnpm-lock v9 compatible. Registered with the engine
-/// via `aube_lockfile::set_aube_lock_base_filename` in the brand preflight.
-pub(crate) const NUB_LOCKFILE: &str = "lock.yaml";
+/// engine's canonical-lockfile slot under nub's own basename — `nub.lock`,
+/// whose format-agnostic `.lock` extension survives a future serialization
+/// change. Bytes stay pnpm-lock v9 compatible. Carried on the NUB embedder
+/// profile's `lockfile_basename`.
+pub(crate) const NUB_LOCKFILE: &str = "nub.lock";
+
+/// Nub's PRIOR canonical lockfile name, still recognized on read during the
+/// rename transition (carried on the NUB profile's `lockfile_legacy_basenames`)
+/// and migrated to [`NUB_LOCKFILE`] on the next mutating PM op. Same pnpm-lock
+/// v9 bytes — the rename is byte-identical. Sunset at the next major.
+pub(crate) const NUB_LEGACY_LOCKFILE: &str = "lock.yaml";
 
 /// The known lockfile artifacts, in the engine's candidate precedence order
 /// *within* each family (npm-shrinkwrap.json outranks package-lock.json as a
@@ -32,6 +39,8 @@ pub(crate) const NUB_LOCKFILE: &str = "lock.yaml";
 /// nor removes it).
 const LOCKFILES: &[(&str, &str)] = &[
     (NUB_LOCKFILE, "nub"),
+    // Legacy nub name (pre-rename), still nub's artifact for alignment.
+    (NUB_LEGACY_LOCKFILE, "nub"),
     ("pnpm-lock.yaml", "pnpm"),
     ("bun.lock", "bun"),
     ("bun.lockb", "bun"),
@@ -71,8 +80,8 @@ pub(crate) enum AlignPlan {
         from_kind: LockfileKind,
         remove: Vec<PathBuf>,
     },
-    /// The pnpm ↔ nub pair: same bytes (lock.yaml IS pnpm-v9 format under a
-    /// generic name), different filename — a rename, never a parse/rewrite,
+    /// The pnpm ↔ nub pair: same bytes (`nub.lock` IS pnpm-v9 format under
+    /// a generic name), different filename — a rename, never a parse/rewrite,
     /// so the file stays byte-identical and the real PM's `--frozen-lockfile`
     /// acceptance is preserved exactly.
     Rename { from: PathBuf, remove: Vec<PathBuf> },
@@ -247,7 +256,7 @@ pub(crate) fn refuse_unconvertible(root: &Path, target: &str, plan: &AlignPlan) 
 /// yarn.lock, mirroring the engine's `refine_yarn_kind`).
 fn source_kind(path: &Path) -> LockfileKind {
     match path.file_name().and_then(|n| n.to_str()) {
-        Some(NUB_LOCKFILE) => LockfileKind::Aube,
+        Some(NUB_LOCKFILE) | Some(NUB_LEGACY_LOCKFILE) => LockfileKind::Aube,
         Some("pnpm-lock.yaml") => LockfileKind::Pnpm,
         Some("bun.lock") => LockfileKind::Bun,
         Some("npm-shrinkwrap.json") => LockfileKind::NpmShrinkwrap,
@@ -497,14 +506,14 @@ mod tests {
             }
         );
 
-        // lock.yaml under `use nub` is already nub's artifact: kept.
+        // nub.lock under `use nub` is already nub's artifact: kept.
         let dir = root("keep-nub", &[(NUB_LOCKFILE, "lockfileVersion: '9.0'\n")]);
         assert!(matches!(
             plan_alignment(&dir, "nub").unwrap(),
             AlignPlan::Keep { .. }
         ));
 
-        // lock.yaml → npm is a real format change: converted, not renamed.
+        // nub.lock → npm is a real format change: converted, not renamed.
         let dir = root("nub-to-npm", &[(NUB_LOCKFILE, "lockfileVersion: '9.0'\n")]);
         assert!(matches!(
             plan_alignment(&dir, "npm").unwrap(),
@@ -514,7 +523,7 @@ mod tests {
             }
         ));
 
-        // lock.yaml + a foreign family with neither being the target:
+        // nub.lock + a foreign family with neither being the target:
         // ambiguity, loud, naming both files.
         let dir = root(
             "nub-ambig",
@@ -526,7 +535,7 @@ mod tests {
         let err = plan_alignment(&dir, "bun").unwrap_err().to_string();
         assert!(
             err.contains(NUB_LOCKFILE) && err.contains("package-lock.json"),
-            "ambiguity must name lock.yaml and package-lock.json, got: {err}"
+            "ambiguity must name nub.lock and package-lock.json, got: {err}"
         );
     }
 

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -9,7 +9,7 @@
 //! `devEngines.packageManager {name:"nub", version:"^<ver>", onFail:"warn"}`
 //! (the non-locking cross-tool signal, always written) plus — ONLY on the
 //! explicit `pm use nub@<exact>` opt-in — the hard `packageManager: "nub@<exact>"`
-//! pin; the lockfile renamed (or converted) to `lock.yaml` (pnpm-v9 bytes,
+//! pin; the lockfile renamed (or converted) to `nub.lock` (pnpm-v9 bytes,
 //! generic name), and `pnpm-workspace.yaml` ALWAYS migrated and deleted:
 //!
 //! - resolution-bearing keys → `package.json` under ecosystem-standard
@@ -37,7 +37,7 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use serde_json::{Map, Value, json};
 
-use super::use_align::{self, AlignPlan, NUB_LOCKFILE};
+use super::use_align::{self, AlignPlan, NUB_LEGACY_LOCKFILE, NUB_LOCKFILE};
 
 /// Yaml/settings keys whose post-migration home is `.npmrc`, per the audit
 /// table. Spellings are the camelCase yaml forms; emission converts to the
@@ -826,7 +826,7 @@ fn pnpm_vocab_precedence(root: &Path) -> VocabPrecedence {
 /// (bare `nub pm use nub`) writes only the non-locking devEngines caret range on
 /// the running version. Prints the file-by-file summary; never silent.
 pub(crate) fn run_use_nub(root: &Path, exact_pin: Option<&str>) -> Result<i32> {
-    // The brand preflight registers the yaml names + lock.yaml filename the
+    // The brand preflight registers the yaml names + nub.lock filename the
     // discovery below and the engine writers read.
     super::engine_brand_preflight();
 
@@ -919,11 +919,20 @@ pub(crate) fn run_use_nub(root: &Path, exact_pin: Option<&str>) -> Result<i32> {
             println!("  no lockfile — the next install writes {NUB_LOCKFILE}");
         }
         AlignPlan::Keep { kept, remove } => {
-            println!(
-                "  {}: kept (already nub's lockfile)",
-                kept.file_name().unwrap_or_default().to_string_lossy()
-            );
-            remove_strays(&remove, "lock.yaml is authoritative")?;
+            let kept_name = kept.file_name().unwrap_or_default().to_string_lossy();
+            // The explicit graduation must leave the project on the current
+            // name: converge a kept LEGACY-named nub lockfile to `nub.lock`
+            // (byte-identical rename), rather than reporting "kept" and leaving
+            // the old filename for a later install to migrate.
+            if kept_name == NUB_LEGACY_LOCKFILE {
+                let to = root.join(NUB_LOCKFILE);
+                std::fs::rename(&kept, &to)
+                    .with_context(|| format!("renaming {kept_name} to {NUB_LOCKFILE}"))?;
+                println!("  {NUB_LOCKFILE}: renamed from {kept_name} (bytes unchanged)");
+            } else {
+                println!("  {kept_name}: kept (already nub's lockfile)");
+            }
+            remove_strays(&remove, &format!("{NUB_LOCKFILE} is authoritative"))?;
         }
         AlignPlan::Rename { from, remove } => {
             let to = root.join(NUB_LOCKFILE);

--- a/crates/nub-cli/tests/bun_basic_config.rs
+++ b/crates/nub-cli/tests/bun_basic_config.rs
@@ -149,7 +149,7 @@ fn nub_identity_does_not_read_project_or_global_bunfig() {
                 r#"{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1"}"#,
             ),
             (
-                "lock.yaml",
+                "nub.lock",
                 "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n",
             ),
             (

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -69,7 +69,7 @@ fn registry_reachable() -> bool {
 /// Truly-fresh project (no lockfile, no PM declaration, no pnpm-named file):
 /// nub claims identity via the neutral lockfile only. The engine resolves, links
 /// the isolated (pnpm-style) layout under `node_modules/.nub`, and writes nub's
-/// neutral `lock.yaml` — the quiet identity marker. It must NOT auto-stamp
+/// neutral `nub.lock` — the quiet identity marker. It must NOT auto-stamp
 /// `packageManager` / `devEngines` into `package.json`: that exclusivity claim
 /// is reserved for the explicit `nub pm use nub` command.
 #[test]
@@ -119,8 +119,8 @@ fn install_truly_fresh_project_claims_nub_identity() {
     );
 
     assert!(
-        dir.join("lock.yaml").is_file(),
-        "truly-fresh install writes nub's neutral lock.yaml"
+        dir.join("nub.lock").is_file(),
+        "truly-fresh install writes nub's neutral nub.lock"
     );
     assert!(
         !dir.join("pnpm-lock.yaml").exists() && !dir.join("aube-lock.yaml").exists(),
@@ -128,10 +128,10 @@ fn install_truly_fresh_project_claims_nub_identity() {
     );
 
     // A virgin install stamps a caret RANGE into `devEngines.packageManager`
-    // (the non-locking PM signal nub's neutral lock.yaml withholds) — never
+    // (the non-locking PM signal nub's neutral nub.lock withholds) — never
     // the hard, corepack-visible `packageManager: nub@<v>` pin, which stays the
     // opt-in of an explicit `nub pm use nub@<exact>`. Identity is also
-    // self-reinforcing via the lockfile: the next install sees lock.yaml and is
+    // self-reinforcing via the lockfile: the next install sees nub.lock and is
     // no longer virgin, so it never re-stamps.
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
@@ -290,8 +290,8 @@ fn install_with_pnpm_workspace_stays_pnpm_shaped_no_stamp() {
         "a pnpm-workspace.yaml project writes pnpm-lock.yaml"
     );
     assert!(
-        !dir.join("lock.yaml").exists(),
-        "a pnpm-incumbent project must not get nub's lock.yaml"
+        !dir.join("nub.lock").exists(),
+        "a pnpm-incumbent project must not get nub's nub.lock"
     );
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
@@ -497,7 +497,7 @@ fn install_refuses_to_mutate_a_drifted_yarn_lock() {
 }
 
 /// A truly-fresh `nub add` claims nub identity exactly like a fresh `install`:
-/// the add resolves + writes nub's neutral `lock.yaml` and adds the dep, and —
+/// the add resolves + writes nub's neutral `nub.lock` and adds the dep, and —
 /// because the project is virgin (nub is the first PM to touch it) — stamps the
 /// non-locking `devEngines.packageManager` caret range. Never the exact
 /// `packageManager: nub@<v>` pin (that is `nub pm use nub@<exact>`'s opt-in).
@@ -521,8 +521,8 @@ fn add_on_a_truly_fresh_project_claims_nub_identity() {
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
 
     assert!(
-        dir.join("lock.yaml").is_file(),
-        "a truly-fresh add writes nub's neutral lock.yaml: {stderr}"
+        dir.join("nub.lock").is_file(),
+        "a truly-fresh add writes nub's neutral nub.lock: {stderr}"
     );
     assert!(
         !dir.join("pnpm-lock.yaml").exists() && !dir.join("aube-lock.yaml").exists(),

--- a/crates/nub-cli/tests/lockfile_rename.rs
+++ b/crates/nub-cli/tests/lockfile_rename.rs
@@ -309,7 +309,10 @@ fn filtered_no_save_add_restores_legacy_lock_yaml() {
                 r#"{"name":"root","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#,
             ),
             ("lock.yaml", EMPTY_LOCK),
-            ("packages/a/package.json", r#"{"name":"a","version":"1.0.0"}"#),
+            (
+                "packages/a/package.json",
+                r#"{"name":"a","version":"1.0.0"}"#,
+            ),
             ("localdep/package.json", LOCALDEP_PKG),
         ],
     );

--- a/crates/nub-cli/tests/lockfile_rename.rs
+++ b/crates/nub-cli/tests/lockfile_rename.rs
@@ -1,0 +1,207 @@
+//! Transitional rename of nub's own lockfile: `lock.yaml` → `nub.lock`.
+//! A virgin install writes the new name; an unmigrated `lock.yaml` is renamed
+//! byte-identically on the next mutating op (and a redundant one is removed);
+//! workspace members migrate too. All rows run OFFLINE with empty-dependency
+//! manifests, pointing the registry at a dead port so any accidental network
+//! fails loudly.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/
+    path.push("nub");
+    path
+}
+
+fn project(tag: &str, files: &[(&str, &str)]) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nub-lockfile-rename-{tag}-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(".npmrc"), "registry=http://127.0.0.1:1/\n").unwrap();
+    for (name, body) in files {
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, body).unwrap();
+    }
+    dir
+}
+
+fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .env("XDG_DATA_HOME", dir.join("xdg-data"))
+        .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
+        .output()
+        .expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+const EMPTY_LOCK: &str = "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n";
+const EMPTY_PKG: &str = r#"{"name":"app","version":"1.0.0"}"#;
+
+/// A truly-fresh project (no lockfile, no PM signal) writes `nub.lock`,
+/// not the legacy `lock.yaml`.
+#[test]
+fn virgin_install_writes_nub_lock() {
+    let dir = project("virgin", &[("package.json", EMPTY_PKG)]);
+    let (stdout, stderr, code) = run(&dir, &["install", "--offline"]);
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        dir.join("nub.lock").is_file(),
+        "virgin install must write nub.lock: {stderr}"
+    );
+    assert!(
+        !dir.join("lock.yaml").exists(),
+        "the legacy name must never be written fresh"
+    );
+}
+
+/// An existing `lock.yaml` is migrated to `nub.lock` byte-identically on
+/// the next install, and the stale file is gone.
+#[test]
+fn existing_lock_yaml_is_migrated_byte_identically() {
+    let dir = project(
+        "migrate",
+        &[("package.json", EMPTY_PKG), ("lock.yaml", EMPTY_LOCK)],
+    );
+    let (stdout, stderr, code) = run(&dir, &["install", "--offline"]);
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        !dir.join("lock.yaml").exists(),
+        "the legacy lock.yaml must be removed after migration"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("nub.lock")).unwrap(),
+        EMPTY_LOCK,
+        "the migration is a byte-identical rename"
+    );
+}
+
+/// When BOTH names exist, the redundant `lock.yaml` is removed and
+/// `nub.lock` is kept untouched (no double-lockfile left behind).
+#[test]
+fn both_present_keeps_nub_lock_and_removes_legacy() {
+    let kept = "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n# kept\n";
+    let dir = project(
+        "both",
+        &[
+            ("package.json", EMPTY_PKG),
+            ("nub.lock", kept),
+            ("lock.yaml", EMPTY_LOCK),
+        ],
+    );
+    let (stdout, stderr, code) = run(&dir, &["install", "--offline"]);
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        !dir.join("lock.yaml").exists(),
+        "the redundant legacy lock.yaml must be removed"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("nub.lock")).unwrap(),
+        kept,
+        "the existing nub.lock must be kept verbatim, not overwritten by the legacy file"
+    );
+}
+
+/// A read-only op (here, the same install path is mutating, so use a workspace
+/// member) — a `lock.yaml` in a workspace member dir migrates too.
+#[test]
+fn workspace_member_lock_yaml_migrates() {
+    let dir = project(
+        "ws",
+        &[
+            (
+                "package.json",
+                r#"{"name":"root","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#,
+            ),
+            // Root carries nub's lockfile so the project resolves as nub identity.
+            ("nub.lock", EMPTY_LOCK),
+            (
+                "packages/a/package.json",
+                r#"{"name":"a","version":"1.0.0"}"#,
+            ),
+            ("packages/a/lock.yaml", EMPTY_LOCK),
+        ],
+    );
+    let (stdout, stderr, code) = run(&dir, &["install", "--offline"]);
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        !dir.join("packages/a/lock.yaml").exists(),
+        "a workspace member's legacy lock.yaml must migrate too: {stderr}"
+    );
+    assert!(
+        dir.join("packages/a/nub.lock").is_file(),
+        "the member's lockfile must land at nub.lock"
+    );
+}
+
+/// `nub ci` is a frozen, ephemeral install: it installs fine from an existing
+/// `lock.yaml` (read-both) but must NEVER migrate or otherwise mutate a
+/// checked-in file — no rename, no `nub.lock` written, `lock.yaml` left
+/// byte-for-byte untouched.
+#[test]
+fn ci_never_migrates_or_mutates_the_lockfile() {
+    let dir = project(
+        "ci",
+        &[("package.json", EMPTY_PKG), ("lock.yaml", EMPTY_LOCK)],
+    );
+    let (stdout, stderr, code) = run(&dir, &["ci"]);
+    assert_eq!(
+        code, 0,
+        "ci must install from lock.yaml: {stdout}\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("lock.yaml")).unwrap(),
+        EMPTY_LOCK,
+        "ci must leave lock.yaml byte-for-byte untouched"
+    );
+    assert!(
+        !dir.join("nub.lock").exists(),
+        "ci must not rename or write nub.lock — a frozen install never mutates checked-in files"
+    );
+}
+
+/// Read-both: a read-only op resolves a project still carrying the legacy
+/// `lock.yaml` without migrating it (read-only must not rewrite the tree).
+#[test]
+fn read_only_op_resolves_legacy_lock_yaml_without_migrating() {
+    let dir = project(
+        "readonly",
+        &[
+            (
+                "package.json",
+                r#"{"name":"app","version":"1.0.0","dependencies":{}}"#,
+            ),
+            ("lock.yaml", EMPTY_LOCK),
+        ],
+    );
+    // `why` is read-only: it must find the lockfile (read-both) but leave the
+    // legacy name in place.
+    let (stdout, stderr, code) = run(&dir, &["why", "anything"]);
+    // `why` for an absent dep exits non-zero or zero depending on output, but
+    // it must NOT error with "no lockfile" and must NOT migrate the file.
+    assert!(
+        !stderr.contains("no lockfile") && !stderr.to_lowercase().contains("err_nub_no_lockfile"),
+        "read-both must let a read-only op find the legacy lock.yaml: {stderr}\n{stdout} (code {code})"
+    );
+    assert!(
+        dir.join("lock.yaml").is_file(),
+        "a read-only op must not migrate the legacy lockfile"
+    );
+}

--- a/crates/nub-cli/tests/lockfile_rename.rs
+++ b/crates/nub-cli/tests/lockfile_rename.rs
@@ -1,9 +1,12 @@
 //! Transitional rename of nub's own lockfile: `lock.yaml` → `nub.lock`.
-//! A virgin install writes the new name; an unmigrated `lock.yaml` is renamed
-//! byte-identically on the next mutating op (and a redundant one is removed);
-//! workspace members migrate too. All rows run OFFLINE with empty-dependency
-//! manifests, pointing the registry at a dead port so any accidental network
-//! fails loudly.
+//!
+//! The migration rides a REAL lockfile write — nub writes the lockfile only
+//! when the resolved graph actually changes (no-churn), and that write lands
+//! under the new name (`nub.lock`) with the pre-rename `lock.yaml` removed, so
+//! the rename shows up in the same diff as the dep change. A no-op op writes
+//! nothing and leaves the legacy file exactly as-is; a frozen/`ci` op never
+//! writes, so it never migrates. All rows run OFFLINE, pointing the registry at
+//! a dead port so any accidental network fails loudly.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -38,13 +41,27 @@ fn project(tag: &str, files: &[(&str, &str)]) -> PathBuf {
 }
 
 fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
-    let out = Command::new(nub_binary())
-        .args(args)
+    run_env(dir, args, &[])
+}
+
+/// Like [`run`] but with extra env vars. The `CI` var is stripped from the
+/// inherited environment unless a caller overrides it: aube defaults a flagless
+/// install to FROZEN when `CI` is set (pnpm parity), and a frozen op never
+/// writes the lockfile, so a real-change row that relied on the flagless
+/// writable default would flip to frozen (no write, no migration) when the
+/// suite runs on a CI runner. Rows exercising the frozen-read-only path opt
+/// back in explicitly (`CI=1`) or pass `--frozen-lockfile`.
+fn run_env(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, i32) {
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(args)
         .current_dir(dir)
+        .env_remove("CI")
         .env("XDG_DATA_HOME", dir.join("xdg-data"))
-        .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
-        .output()
-        .expect("failed to spawn nub");
+        .env("XDG_CACHE_HOME", dir.join("xdg-cache"));
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("failed to spawn nub");
     (
         String::from_utf8_lossy(&out.stdout).to_string(),
         String::from_utf8_lossy(&out.stderr).to_string(),
@@ -54,6 +71,12 @@ fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
 
 const EMPTY_LOCK: &str = "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n";
 const EMPTY_PKG: &str = r#"{"name":"app","version":"1.0.0"}"#;
+
+/// A manifest with one `file:` local dependency, absent from `EMPTY_LOCK`. An
+/// install must re-resolve to record it — a genuine, network-free graph change
+/// that exercises the migrating write.
+const PKG_WITH_LOCAL_DEP: &str =
+    r#"{"name":"app","version":"1.0.0","dependencies":{"localdep":"file:./localdep"}}"#;
 
 /// A truly-fresh project (no lockfile, no PM signal) writes `nub.lock`,
 /// not the legacy `lock.yaml`.
@@ -72,89 +95,67 @@ fn virgin_install_writes_nub_lock() {
     );
 }
 
-/// An existing `lock.yaml` is migrated to `nub.lock` byte-identically on
-/// the next install, and the stale file is gone.
+/// CASE 1 (the load-bearing one): a NO-OP install on a project still carrying
+/// `lock.yaml` writes nothing — no re-resolve, no rewrite. The legacy file is
+/// left byte-for-byte and no `nub.lock` appears. Migration must not be a
+/// proactive rename; it rides a real change only.
 #[test]
-fn existing_lock_yaml_is_migrated_byte_identically() {
+fn no_op_install_leaves_legacy_untouched() {
     let dir = project(
-        "migrate",
+        "noop",
         &[("package.json", EMPTY_PKG), ("lock.yaml", EMPTY_LOCK)],
     );
     let (stdout, stderr, code) = run(&dir, &["install", "--offline"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
-    assert!(
-        !dir.join("lock.yaml").exists(),
-        "the legacy lock.yaml must be removed after migration"
-    );
     assert_eq!(
-        std::fs::read_to_string(dir.join("nub.lock")).unwrap(),
+        std::fs::read_to_string(dir.join("lock.yaml")).unwrap(),
         EMPTY_LOCK,
-        "the migration is a byte-identical rename"
+        "a no-op install must leave lock.yaml byte-for-byte untouched"
+    );
+    assert!(
+        !dir.join("nub.lock").exists(),
+        "a no-op install must not create nub.lock — no write means no migration"
     );
 }
 
-/// When BOTH names exist, the redundant `lock.yaml` is removed and
-/// `nub.lock` is kept untouched (no double-lockfile left behind).
+/// CASE 2: a REAL lockfile change (here a `file:` dep the lockfile lacks) on a
+/// project carrying `lock.yaml` writes the new graph to `nub.lock` and removes
+/// the legacy file — the rename rides the change. `--no-frozen-lockfile` forces
+/// the writable path deterministically (independent of a CI runner's frozen
+/// default).
 #[test]
-fn both_present_keeps_nub_lock_and_removes_legacy() {
-    let kept = "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n# kept\n";
+fn real_change_migrates_to_nub_lock() {
     let dir = project(
-        "both",
+        "realchange",
         &[
-            ("package.json", EMPTY_PKG),
-            ("nub.lock", kept),
+            ("package.json", PKG_WITH_LOCAL_DEP),
+            (
+                "localdep/package.json",
+                r#"{"name":"localdep","version":"1.0.0"}"#,
+            ),
             ("lock.yaml", EMPTY_LOCK),
         ],
     );
-    let (stdout, stderr, code) = run(&dir, &["install", "--offline"]);
-    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    let (stdout, stderr, code) = run(&dir, &["install", "--no-frozen-lockfile", "--offline"]);
+    assert_eq!(
+        code, 0,
+        "real-change install must succeed: {stdout}\n{stderr}"
+    );
     assert!(
         !dir.join("lock.yaml").exists(),
-        "the redundant legacy lock.yaml must be removed"
+        "the legacy lock.yaml must be removed once the migrating write lands: {stderr}"
     );
-    assert_eq!(
-        std::fs::read_to_string(dir.join("nub.lock")).unwrap(),
-        kept,
-        "the existing nub.lock must be kept verbatim, not overwritten by the legacy file"
-    );
-}
-
-/// A read-only op (here, the same install path is mutating, so use a workspace
-/// member) — a `lock.yaml` in a workspace member dir migrates too.
-#[test]
-fn workspace_member_lock_yaml_migrates() {
-    let dir = project(
-        "ws",
-        &[
-            (
-                "package.json",
-                r#"{"name":"root","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#,
-            ),
-            // Root carries nub's lockfile so the project resolves as nub identity.
-            ("nub.lock", EMPTY_LOCK),
-            (
-                "packages/a/package.json",
-                r#"{"name":"a","version":"1.0.0"}"#,
-            ),
-            ("packages/a/lock.yaml", EMPTY_LOCK),
-        ],
-    );
-    let (stdout, stderr, code) = run(&dir, &["install", "--offline"]);
-    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    let nub_lock =
+        std::fs::read_to_string(dir.join("nub.lock")).expect("a real change must write nub.lock");
     assert!(
-        !dir.join("packages/a/lock.yaml").exists(),
-        "a workspace member's legacy lock.yaml must migrate too: {stderr}"
-    );
-    assert!(
-        dir.join("packages/a/nub.lock").is_file(),
-        "the member's lockfile must land at nub.lock"
+        nub_lock.contains("localdep"),
+        "the migrated nub.lock must reflect the resolved change:\n{nub_lock}"
     );
 }
 
 /// `nub ci` is a frozen, ephemeral install: it installs fine from an existing
-/// `lock.yaml` (read-both) but must NEVER migrate or otherwise mutate a
-/// checked-in file — no rename, no `nub.lock` written, `lock.yaml` left
-/// byte-for-byte untouched.
+/// `lock.yaml` (read-both) but never writes the lockfile, so it never migrates
+/// — no rename, no `nub.lock`, `lock.yaml` left byte-for-byte untouched.
 #[test]
 fn ci_never_migrates_or_mutates_the_lockfile() {
     let dir = project(
@@ -173,7 +174,57 @@ fn ci_never_migrates_or_mutates_the_lockfile() {
     );
     assert!(
         !dir.join("nub.lock").exists(),
-        "ci must not rename or write nub.lock — a frozen install never mutates checked-in files"
+        "ci must not rename or write nub.lock — a frozen install never writes the lockfile"
+    );
+}
+
+/// `nub install --frozen-lockfile` is read-only over the lockfile, so it
+/// installs from the legacy `lock.yaml` (read-both) but must not migrate it —
+/// no rename, no `nub.lock`. The rename is a write; a frozen install makes none.
+#[test]
+fn frozen_flag_install_does_not_migrate() {
+    let dir = project(
+        "frozen-flag",
+        &[("package.json", EMPTY_PKG), ("lock.yaml", EMPTY_LOCK)],
+    );
+    let (stdout, stderr, code) = run(&dir, &["install", "--frozen-lockfile", "--offline"]);
+    assert_eq!(
+        code, 0,
+        "frozen install must succeed from lock.yaml: {stdout}\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("lock.yaml")).unwrap(),
+        EMPTY_LOCK,
+        "a frozen install must leave lock.yaml byte-for-byte untouched"
+    );
+    assert!(
+        !dir.join("nub.lock").exists(),
+        "a frozen install must not rename or write nub.lock"
+    );
+}
+
+/// A flagless `nub install` under `CI=1` defaults to FROZEN (pnpm parity), so
+/// it too must not migrate — the rename would surprise a CI run with an
+/// unexpected git diff. Migration is a developer-machine (writable) event.
+#[test]
+fn ci_env_default_frozen_does_not_migrate() {
+    let dir = project(
+        "ci-env",
+        &[("package.json", EMPTY_PKG), ("lock.yaml", EMPTY_LOCK)],
+    );
+    let (stdout, stderr, code) = run_env(&dir, &["install", "--offline"], &[("CI", "1")]);
+    assert_eq!(
+        code, 0,
+        "CI-frozen install must succeed from lock.yaml: {stdout}\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("lock.yaml")).unwrap(),
+        EMPTY_LOCK,
+        "a CI-default frozen install must leave lock.yaml untouched"
+    );
+    assert!(
+        !dir.join("nub.lock").exists(),
+        "a CI-default frozen install must not rename or write nub.lock"
     );
 }
 

--- a/crates/nub-cli/tests/lockfile_rename.rs
+++ b/crates/nub-cli/tests/lockfile_rename.rs
@@ -256,3 +256,89 @@ fn read_only_op_resolves_legacy_lock_yaml_without_migrating() {
         "a read-only op must not migrate the legacy lockfile"
     );
 }
+
+/// A `file:` local dep, resolvable offline (no registry hit). Used by the
+/// `--no-save` rows: adding it is a genuine graph change whose transient write
+/// migrates the legacy lockfile, so the restore must put `lock.yaml` back.
+const LOCALDEP_PKG: &str = r#"{"name":"localdep","version":"1.0.0"}"#;
+
+/// `nub add <file:dep> --no-save` on a project carrying `lock.yaml` must leave
+/// the tree EXACTLY as it was: the transient add re-resolves and its migrating
+/// write deletes `lock.yaml` (writing `nub.lock`), but `--no-save` restores the
+/// original lockfile — including the legacy name. Without the legacy snapshot
+/// the checked-in `lock.yaml` would be silently dropped.
+#[test]
+fn no_save_add_restores_legacy_lock_yaml() {
+    let dir = project(
+        "nosave",
+        &[
+            ("package.json", EMPTY_PKG),
+            ("lock.yaml", EMPTY_LOCK),
+            ("localdep/package.json", LOCALDEP_PKG),
+        ],
+    );
+    let (stdout, stderr, code) = run(&dir, &["add", "localdep@file:./localdep", "--no-save"]);
+    assert_eq!(code, 0, "no-save add must succeed: {stdout}\n{stderr}");
+    assert_eq!(
+        std::fs::read_to_string(dir.join("lock.yaml")).unwrap(),
+        EMPTY_LOCK,
+        "--no-save must restore the legacy lock.yaml byte-for-byte"
+    );
+    assert!(
+        !dir.join("nub.lock").exists(),
+        "--no-save must not leave a migrated nub.lock behind"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("package.json")).unwrap(),
+        EMPTY_PKG,
+        "--no-save must restore package.json unchanged"
+    );
+}
+
+/// The workspace-filtered `--no-save` path (`add --filter <member> --no-save`)
+/// mutates the ROOT lockfile and must restore it identically — legacy name
+/// included. This is the sibling of [`no_save_add_restores_legacy_lock_yaml`]
+/// for the filtered code path, which snapshots the root lockfile separately.
+#[test]
+fn filtered_no_save_add_restores_legacy_lock_yaml() {
+    let dir = project(
+        "filtered-nosave",
+        &[
+            (
+                "package.json",
+                r#"{"name":"root","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#,
+            ),
+            ("lock.yaml", EMPTY_LOCK),
+            ("packages/a/package.json", r#"{"name":"a","version":"1.0.0"}"#),
+            ("localdep/package.json", LOCALDEP_PKG),
+        ],
+    );
+    let (stdout, stderr, code) = run(
+        &dir,
+        &[
+            "add",
+            "localdep@file:../../localdep",
+            "--filter",
+            "a",
+            "--no-save",
+        ],
+    );
+    assert_eq!(
+        code, 0,
+        "filtered no-save add must succeed: {stdout}\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("lock.yaml")).unwrap(),
+        EMPTY_LOCK,
+        "filtered --no-save must restore the root legacy lock.yaml byte-for-byte"
+    );
+    assert!(
+        !dir.join("nub.lock").exists(),
+        "filtered --no-save must not leave a migrated nub.lock behind"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("packages/a/package.json")).unwrap(),
+        r#"{"name":"a","version":"1.0.0"}"#,
+        "filtered --no-save must restore the member package.json unchanged"
+    );
+}

--- a/crates/nub-cli/tests/pm_identity.rs
+++ b/crates/nub-cli/tests/pm_identity.rs
@@ -66,16 +66,16 @@ const EMPTY_PNPM: &str = r#"{"name":"app","version":"1.0.0","packageManager":"pn
 #[test]
 fn fresh_projects_write_the_identity_format_declared_first_else_nub() {
     // none + none → truly fresh: nub claims identity via the neutral lockfile
-    // (writes lock.yaml) AND stamps a caret RANGE into `devEngines.packageManager`
-    // — the non-locking PM signal nub's unbranded lock.yaml withholds, the
+    // (writes nub.lock) AND stamps a caret RANGE into `devEngines.packageManager`
+    // — the non-locking PM signal nub's unbranded nub.lock withholds, the
     // coherent counterpart to keeping the lockfile neutral. Never the exact
     // `packageManager: nub@<v>` pin (that hard claim is `nub pm use nub@<exact>`'s).
     let dir = project("fresh-default", r#"{"name":"app","version":"1.0.0"}"#);
     let (stdout, stderr, code) = run(&dir, &["install"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert!(
-        dir.join("lock.yaml").is_file(),
-        "truly-fresh install must write nub's neutral lock.yaml: {stderr}"
+        dir.join("nub.lock").is_file(),
+        "truly-fresh install must write nub's neutral nub.lock: {stderr}"
     );
     assert!(
         !dir.join("pnpm-lock.yaml").exists(),
@@ -357,8 +357,8 @@ fn a_fresh_declared_yarn_project_hits_the_write_gate_not_a_pnpm_lockfile() {
     );
 }
 
-/// The lock.yaml rows (two-mode model, the maintainer 2026-06-10): the generically
-/// named `lock.yaml` (the engine's canonical slot under nub's filename
+/// The nub.lock rows (two-mode model, the maintainer 2026-06-10): the generically
+/// named `nub.lock` (the engine's canonical slot under nub's filename
 /// toggle) IS nub identity — alone it resolves and installs in place; beside
 /// a foreign lockfile or against a contradicting declaration it is the same
 /// loud error as any other identity conflict, never a silent winner (nub
@@ -367,57 +367,57 @@ fn a_fresh_declared_yarn_project_hits_the_write_gate_not_a_pnpm_lockfile() {
 fn lock_yaml_is_nub_identity_and_conflicts_are_loud() {
     let empty_lock = "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n";
 
-    // lock.yaml + no declaration → nub identity: install works in place,
-    // lock.yaml stays the lockfile, no pnpm-lock.yaml appears.
+    // nub.lock + no declaration → nub identity: install works in place,
+    // nub.lock stays the lockfile, no pnpm-lock.yaml appears.
     let dir = project("lockyaml-nub", r#"{"name":"app","version":"1.0.0"}"#);
-    std::fs::write(dir.join("lock.yaml"), empty_lock).unwrap();
+    std::fs::write(dir.join("nub.lock"), empty_lock).unwrap();
     let (stdout, stderr, code) = run(&dir, &["install"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert!(
-        dir.join("lock.yaml").is_file() && !dir.join("pnpm-lock.yaml").exists(),
-        "lock.yaml is the lockfile under nub identity: {stderr}"
+        dir.join("nub.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
+        "nub.lock is the lockfile under nub identity: {stderr}"
     );
 
-    // lock.yaml + package-lock.json, no declaration → ambiguity naming both.
+    // nub.lock + package-lock.json, no declaration → ambiguity naming both.
     let dir = project("lockyaml-ambig", r#"{"name":"app","version":"1.0.0"}"#);
-    std::fs::write(dir.join("lock.yaml"), empty_lock).unwrap();
+    std::fs::write(dir.join("nub.lock"), empty_lock).unwrap();
     std::fs::write(
         dir.join("package-lock.json"),
         r#"{"name":"app","version":"1.0.0","lockfileVersion":3,"requires":true,"packages":{}}"#,
     )
     .unwrap();
     let (_, stderr, code) = run(&dir, &["install"]);
-    assert_ne!(code, 0, "lock.yaml beside a foreign lockfile must refuse");
+    assert_ne!(code, 0, "nub.lock beside a foreign lockfile must refuse");
     assert!(
         stderr.contains("ERR_NUB_LOCKFILE_AMBIGUOUS")
-            && stderr.contains("lock.yaml")
+            && stderr.contains("nub.lock")
             && stderr.contains("package-lock.json"),
         "the ambiguity must carry the code and name both files: {stderr}"
     );
 
-    // Declared pnpm + only lock.yaml → contradiction (a half-reversed switch;
+    // Declared pnpm + only nub.lock → contradiction (a half-reversed switch;
     // `nub pm use` is the remedy in the message).
     let dir = project("lockyaml-contra", EMPTY_PNPM);
-    std::fs::write(dir.join("lock.yaml"), empty_lock).unwrap();
+    std::fs::write(dir.join("nub.lock"), empty_lock).unwrap();
     let (_, stderr, code) = run(&dir, &["install"]);
-    assert_ne!(code, 0, "declared pnpm over lock.yaml must refuse");
+    assert_ne!(code, 0, "declared pnpm over nub.lock must refuse");
     assert!(
-        stderr.contains("ERR_NUB_LOCKFILE_DECLARATION_MISMATCH") && stderr.contains("lock.yaml"),
-        "the contradiction must carry the code and name lock.yaml: {stderr}"
+        stderr.contains("ERR_NUB_LOCKFILE_DECLARATION_MISMATCH") && stderr.contains("nub.lock"),
+        "the contradiction must carry the code and name nub.lock: {stderr}"
     );
 
-    // Declared nub + lock.yaml → clean nub identity (the post-`use nub`
+    // Declared nub + nub.lock → clean nub identity (the post-`use nub`
     // state): resolves and installs.
     let dir = project(
         "lockyaml-declared",
         r#"{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1"}"#,
     );
-    std::fs::write(dir.join("lock.yaml"), empty_lock).unwrap();
+    std::fs::write(dir.join("nub.lock"), empty_lock).unwrap();
     let (stdout, stderr, code) = run(&dir, &["install"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert!(
-        dir.join("lock.yaml").is_file() && !dir.join("pnpm-lock.yaml").exists(),
-        "declared nub keeps lock.yaml: {stderr}"
+        dir.join("nub.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
+        "declared nub keeps nub.lock: {stderr}"
     );
 }
 

--- a/crates/nub-cli/tests/pm_two_mode.rs
+++ b/crates/nub-cli/tests/pm_two_mode.rs
@@ -79,11 +79,11 @@ fn use_nub_migrates_a_single_package_catalog_project_offline_and_idempotently() 
     let (stdout, stderr, code) = run(&dir, &["pm", "use", "nub"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
 
-    // Zero pnpm-named files; lock.yaml carries the exact prior bytes.
+    // Zero pnpm-named files; nub.lock carries the exact prior bytes.
     assert!(!dir.join("pnpm-workspace.yaml").exists(), "{stdout}");
     assert!(!dir.join("pnpm-lock.yaml").exists(), "{stdout}");
     assert_eq!(
-        std::fs::read_to_string(dir.join("lock.yaml")).unwrap(),
+        std::fs::read_to_string(dir.join("nub.lock")).unwrap(),
         EMPTY_LOCK,
         "the rename must be byte-identical"
     );
@@ -132,7 +132,7 @@ fn use_nub_migrates_a_single_package_catalog_project_offline_and_idempotently() 
     let (stdout2, stderr2, code2) = run(&dir, &["pm", "use", "nub"]);
     assert_eq!(code2, 0, "stdout: {stdout2}\nstderr: {stderr2}");
     assert!(
-        stdout2.contains("lock.yaml: kept"),
+        stdout2.contains("nub.lock: kept"),
         "rerun must keep, not re-convert: {stdout2}"
     );
 }
@@ -163,8 +163,8 @@ fn use_nub_recovers_from_a_crash_before_the_yaml_deletion() {
                     r#""devEngines":{"packageManager":{"name":"nub","version":"^0.0.0","onFail":"warn"}},"workspaces":{"catalog":{"left-pad":"1.3.0"}}"#
                 ),
             ),
-            // The rename already happened: lock.yaml present, no pnpm-lock.yaml.
-            ("lock.yaml", EMPTY_LOCK),
+            // The rename already happened: nub.lock present, no pnpm-lock.yaml.
+            ("nub.lock", EMPTY_LOCK),
             // The leftover the crash never got to delete — still carrying the
             // catalog that the atomic manifest edit already preserved.
             ("pnpm-workspace.yaml", "catalog:\n  left-pad: 1.3.0\n"),
@@ -174,15 +174,15 @@ fn use_nub_recovers_from_a_crash_before_the_yaml_deletion() {
     let (stdout, stderr, code) = run(&dir, &["pm", "use", "nub"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
 
-    // The leftover yaml is gone; lock.yaml is kept (not re-renamed); the
+    // The leftover yaml is gone; nub.lock is kept (not re-renamed); the
     // project is now in clean, fully-migrated nub identity.
     assert!(
         !dir.join("pnpm-workspace.yaml").exists(),
         "the recovery run must delete the stray yaml: {stdout}"
     );
     assert!(
-        dir.join("lock.yaml").is_file() && !dir.join("pnpm-lock.yaml").exists(),
-        "lock.yaml stays the lockfile, untouched: {stdout}"
+        dir.join("nub.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
+        "nub.lock stays the lockfile, untouched: {stdout}"
     );
 
     // The migrated data survived the half-state — never silently dropped.
@@ -229,7 +229,7 @@ fn use_nub_migrates_with_injected_deps_and_preserves_meta() {
 
     // The switch completed: yaml renamed, identity flipped, pnpm namespace gone.
     assert!(
-        dir.join("lock.yaml").is_file()
+        dir.join("nub.lock").is_file()
             && !dir.join("pnpm-lock.yaml").exists()
             && !dir.join("pnpm-workspace.yaml").exists(),
         "the migration must complete the lockfile rename + yaml deletion: {stdout}"
@@ -253,7 +253,7 @@ fn use_nub_migrates_with_injected_deps_and_preserves_meta() {
 
 /// Under nub identity a stray pnpm-workspace.yaml is ignore-with-warning:
 /// exactly one warning naming it unread plus the remedies, and the install
-/// proceeds against lock.yaml.
+/// proceeds against nub.lock.
 #[test]
 fn stray_workspace_yaml_under_nub_identity_warns_once_and_install_proceeds() {
     let dir = project(
@@ -263,7 +263,7 @@ fn stray_workspace_yaml_under_nub_identity_warns_once_and_install_proceeds() {
                 "package.json",
                 r#"{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1"}"#,
             ),
-            ("lock.yaml", EMPTY_LOCK),
+            ("nub.lock", EMPTY_LOCK),
             ("pnpm-workspace.yaml", "nodeLinker: hoisted\n"),
         ],
     );
@@ -281,8 +281,8 @@ fn stray_workspace_yaml_under_nub_identity_warns_once_and_install_proceeds() {
         "the warning must carry both remedies: {stderr}"
     );
     assert!(
-        dir.join("lock.yaml").is_file() && !dir.join("pnpm-lock.yaml").exists(),
-        "lock.yaml stays the lockfile"
+        dir.join("nub.lock").is_file() && !dir.join("pnpm-lock.yaml").exists(),
+        "nub.lock stays the lockfile"
     );
 }
 
@@ -324,7 +324,7 @@ fn lifecycle_ua_is_pnpm_first_in_compat_and_nub_first_under_nub_identity() {
                     r#"{{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1",{postinstall}}}"#
                 ),
             ),
-            ("lock.yaml", EMPTY_LOCK),
+            ("nub.lock", EMPTY_LOCK),
         ],
     );
     let (stdout, stderr, code) = run(&dir, &["install"]);
@@ -336,7 +336,7 @@ fn lifecycle_ua_is_pnpm_first_in_compat_and_nub_first_under_nub_identity() {
     );
 }
 
-/// An empty-dependency, in-sync npm v3 package-lock — converts to lock.yaml
+/// An empty-dependency, in-sync npm v3 package-lock — converts to nub.lock
 /// offline (no graph to fetch), exercising the npm→nub `Convert` path.
 const EMPTY_NPM_LOCK: &str = r#"{
   "name": "app",
@@ -420,7 +420,7 @@ fn pnpmfile_ignored_silently_under_nub_identity() {
                 "package.json",
                 r#"{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1"}"#,
             ),
-            ("lock.yaml", EMPTY_LOCK),
+            ("nub.lock", EMPTY_LOCK),
             (".pnpmfile.cjs", hook),
         ],
     );

--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -125,7 +125,7 @@ const IS_POSITIVE_PACKAGE_LOCK: &str = r#"{
 "#;
 
 /// `nub add` then `nub rm` (alias) round-trip on a truly-fresh project: add
-/// persists the dep + writes nub's neutral `lock.yaml` + links node_modules;
+/// persists the dep + writes nub's neutral `nub.lock` + links node_modules;
 /// remove strips the dep from the manifest again. Both outputs brand-clean.
 #[test]
 #[ignore = "network: resolves + fetches is-positive@3.1.0 from the npm registry"]
@@ -155,10 +155,10 @@ fn add_then_remove_round_trips_manifest_lockfile_and_node_modules() {
         "add must persist the dependency: {manifest}"
     );
     assert!(
-        dir.join("lock.yaml").is_file()
+        dir.join("nub.lock").is_file()
             && !dir.join("pnpm-lock.yaml").exists()
             && !dir.join("aube-lock.yaml").exists(),
-        "add on a truly-fresh project writes nub's neutral lock.yaml"
+        "add on a truly-fresh project writes nub's neutral nub.lock"
     );
     assert!(
         dir.join("node_modules/is-positive/package.json").is_file(),

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -23,7 +23,7 @@ In a workspace, the chain runs from any member: Nub walks up to the root, which 
 | **pnpm** — [docs →](/docs/install/pnpm) | `pnpm-lock.yaml` (v9) | read + write |
 | **Yarn** — [docs →](/docs/install/yarn) | `yarn.lock` | **read-only** |
 | **Bun** — [docs →](/docs/install/bun) | `bun.lock` | read + write |
-| **Nub** — [docs →](/docs/pm) | `lock.yaml` (pnpm v9 bytes) | read + write |
+| **Nub** — [docs →](/docs/pm) | `nub.lock` (pnpm v9 bytes) | read + write |
 
 A no-churn guard leaves a graph-equal lockfile untouched, and Nub never drops its own lockfile into a project it doesn't own. The `bun.lockb` binary format is rejected — convert to text `bun.lock` first.
 
@@ -152,7 +152,7 @@ Under its own identity, Nub reads only neutral, cross-tool config — never anot
       href: '/docs/pm',
       highlight: true,
       items: [
-        { code: 'lock.yaml', ok: true },
+        { code: 'nub.lock', ok: true },
         { code: '.npmrc', ok: true },
         { code: 'overrides', ok: true },
         { code: 'resolutions', ok: true },
@@ -173,9 +173,9 @@ The installer is optional. Keep running `npm`, `pnpm`, `yarn`, or `bun` exactly 
 
 ### Nub identity
 
-A project is Nub's own in three cases: it declares Nub through `nub pm use nub`, `lock.yaml` is the only lockfile signal, or a fresh project has no declaration and no lockfile. The switch aligns the manifest and lockfile, migrates pnpm workspace config into neutral `package.json` fields, and moves the project onto a neutral surface:
+A project is Nub's own in three cases: it declares Nub through `nub pm use nub`, `nub.lock` is the only lockfile signal, or a fresh project has no declaration and no lockfile. The switch aligns the manifest and lockfile, migrates pnpm workspace config into neutral `package.json` fields, and moves the project onto a neutral surface:
 
-- **Lockfile:** `lock.yaml` — the pnpm v9 schema byte-for-byte, under Nub's own basename
+- **Lockfile:** `nub.lock` — the pnpm v9 schema byte-for-byte, under Nub's own basename
 - **Package fields:** `workspaces`, `overrides`, `resolutions`, `patchedDependencies`, `allowBuilds`, `engines.node`, `scripts`
 - **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`, `NUB_VITE_COMPAT`
 - **Install state:** `node_modules/.nub/`, `.nub-state`, and the global store under Nub's own directories
@@ -185,7 +185,7 @@ A fresh `nub install` records Nub as the manager with a non-locking range — `d
 This is the brand boundary in both directions: Nub never emits its own brand into your config, and under its own identity reads *only* neutral, cross-tool config — never `pnpm-workspace.yaml`, `.pnpmfile.cjs`, the `pnpm.*` namespace, `pnpm_config_*`, `.yarnrc.yml`, `bunfig.toml`, Bun `trustedDependencies`, or aube's `AUBE_*` knobs. To keep pnpm hooks or pnpm-named workspace config active, stay pnpm-owned or run `nub pm use pnpm`.
 
 ```console
-# captured: Nub-identity project (lock.yaml) with a stray pnpm-workspace.yaml
+# captured: Nub-identity project (nub.lock) with a stray pnpm-workspace.yaml
 $ nub install
 nub: pnpm-workspace.yaml is not read under nub identity — migrate it
      (`nub pm use nub`), delete it, or return to pnpm (`nub pm use pnpm`).
@@ -214,7 +214,7 @@ Error: ERR_NUB_LOCKFILE_DECLARATION_MISMATCH
   help: nub pm use <pm> to declare it, or remove the stale lockfile
 ```
 
-Under Nub identity, `lock.yaml` beside a foreign lockfile is the ambiguity error.
+Under Nub identity, `nub.lock` beside a foreign lockfile is the ambiguity error.
 </Callout>
 
 <Callout title="Inference vs the pinned PM">

--- a/tests/aube-bats/skips.txt
+++ b/tests/aube-bats/skips.txt
@@ -45,31 +45,39 @@ add.bats|aube add -w: errors outside a workspace|engine emits pnpm-workspace.yam
 # ── pnpm-parity divergences (decision C: nub extends aube's behavior to match pnpm) ──
 add.bats|aube add --save-peer writes only peerDependencies and does not install|nub dual-writes --save-peer to devDependencies+peerDependencies for pnpm parity (decision C); aube asserts peerDependencies-only
 
-# ── aube-lock.yaml is another tool's file (canonical-lockfile name = lock.yaml) ──
+# ── virgin projects get a `packageManager: nub@<v>` identity stamp (PR #255) ──
+# On a truly-fresh project (no lockfile / packageManager / devEngines), nub's
+# first mutating PM op stamps `packageManager: nub@<v>` so the repo advertises
+# nub the standard cross-tool way. That appends a top-level key aube's upstream
+# order/key-preservation tests don't expect; the mutation itself is correct.
+add.bats|aube add: preserves existing package.json top-level order|a virgin add stamps a packageManager:nub@version identity marker, appending a top-level key the upstream order assertion does not expect (PR #255)
+remove.bats|aube remove: preserves package.json top-level key order|a virgin remove stamps a packageManager:nub@version identity marker, appending a top-level key the upstream key-order assertion does not expect (PR #255)
+
+# ── aube-lock.yaml is another tool's file (canonical-lockfile name = nub.lock) ──
 # The basic fixture commits an aube-lock.yaml; under nub the engine's
-# canonical-lockfile slot carries the generic lock.yaml name (two-mode model),
+# canonical-lockfile slot carries the generic nub.lock name (two-mode model),
 # so a committed aube-lock.yaml is invisible to detection by design — exactly
 # like aube-workspace.yaml above. Frozen installs see "no lockfile", ci can't
 # install from it, update can't refresh it.
-install.bats|aube install --frozen-lockfile works|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-install.bats|aube install --no-frozen-lockfile re-resolves when lockfile is missing|asserts aube-lock.yaml is rewritten; nub's canonical lockfile name is lock.yaml (1.25.1 renamed this test, dropping its old .aube-state assertion)
+install.bats|aube install --frozen-lockfile works|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+install.bats|aube install --no-frozen-lockfile re-resolves when lockfile is missing|asserts aube-lock.yaml is rewritten; nub's canonical lockfile name is nub.lock (1.25.1 renamed this test, dropping its old .aube-state assertion)
 install.bats|aube install surfaces lockfile parse errors instead of silently re-resolving|garbage written into aube-lock.yaml is never read (file invisible under nub's lock name)
-install.bats|aube install --frozen-lockfile errors when lockfile is stale|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-install.bats|aube install --frozen-lockfile succeeds when lockfile is fresh|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-install.bats|aube install --lockfile-only is a no-op when lockfile is fresh|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-ci.bats|aube ci installs from a committed lockfile|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-ci.bats|aube ci deletes existing node_modules first|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-ci.bats|aube ci errors when lockfile drifts from package.json|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-ci.bats|aube ci --ignore-scripts accepts the flag|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-ci.bats|aube ci removes a symlink node_modules without wiping its target|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-update.bats|aube update: updates a named package to latest matching version|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-update.bats|aube update: all deps updates everything|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-update.bats|aube update: reports version change in output|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-update.bats|aube update --latest --no-save: bumps the lockfile but not package.json|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-update.bats|aube update --lockfile-only: refreshes lockfile without populating node_modules|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-update.bats|aube update --lockfile-only --latest: bumps direct deps without linking|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-update.bats|aube update preserves time: entries for direct deps (time-based mode)|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
-update.bats|aube update drops a stray time: block under default resolution (pnpm parity)|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is lock.yaml
+install.bats|aube install --frozen-lockfile errors when lockfile is stale|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+install.bats|aube install --frozen-lockfile succeeds when lockfile is fresh|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+install.bats|aube install --lockfile-only is a no-op when lockfile is fresh|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+ci.bats|aube ci installs from a committed lockfile|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+ci.bats|aube ci deletes existing node_modules first|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+ci.bats|aube ci errors when lockfile drifts from package.json|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+ci.bats|aube ci --ignore-scripts accepts the flag|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+ci.bats|aube ci removes a symlink node_modules without wiping its target|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+update.bats|aube update: updates a named package to latest matching version|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+update.bats|aube update: all deps updates everything|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+update.bats|aube update: reports version change in output|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+update.bats|aube update --latest --no-save: bumps the lockfile but not package.json|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+update.bats|aube update --lockfile-only: refreshes lockfile without populating node_modules|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+update.bats|aube update --lockfile-only --latest: bumps direct deps without linking|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+update.bats|aube update preserves time: entries for direct deps (time-based mode)|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
+update.bats|aube update drops a stray time: block under default resolution (pnpm parity)|fixture's committed aube-lock.yaml is invisible: nub's canonical lockfile name is nub.lock
 
 # ── virgin projects self-pin nub via devEngines.packageManager ──────────────
 # On the FIRST package.json-modifying verb in a project nub is first to touch,

--- a/tests/aube-conformance/run.sh
+++ b/tests/aube-conformance/run.sh
@@ -19,7 +19,7 @@
 #          unproven, so the refusal IS the pass): non-zero exit, the error
 #          names yarn.lock, the file is untouched, no other lockfile appears.
 #   nub  — the two-mode round trip: drive the mutation in compat (pnpm) mode,
-#          `nub pm use nub` (zero pnpm-named files, lock.yaml present, a
+#          `nub pm use nub` (zero pnpm-named files, nub.lock present, a
 #          frozen nub-mode install works from it), `nub pm use pnpm@<pin>`
 #          back, and the REAL pnpm judge accepts the regenerated state frozen.
 #
@@ -255,7 +255,7 @@ leg_bun() {
 # The nub leg: the bidirectional identity switch over real resolution state.
 # Compat-mode mutation first (pnpm artifacts), then `pm use nub` — the full
 # switch — proving the nub-mode invariants; an actual frozen install from
-# lock.yaml (the engine must resolve+link from the renamed lockfile and the
+# nub.lock (the engine must resolve+link from the renamed lockfile and the
 # migrated config homes); then `pm use pnpm@<pin>` reverses everything and
 # the REAL pnpm is the judge of the regenerated state. The pin matters:
 # pnpm errors on a packageManager naming a different major.
@@ -263,17 +263,17 @@ leg_nub() {
   local proj="$1" log="$2" fixture="$3"
   nub_mutation "$log" "$proj" pnpm "$fixture" || { echo "FAILED: nub step (exit $?)" >>"$log"; return 1; }
   nub_step "$log" "$proj" pnpm pm use nub || { echo "FAILED: pm use nub (exit $?)" >>"$log"; return 1; }
-  [ -f "$proj/lock.yaml" ] || { echo "FAILED: use nub left no lock.yaml" >>"$log"; return 1; }
+  [ -f "$proj/nub.lock" ] || { echo "FAILED: use nub left no nub.lock" >>"$log"; return 1; }
   local pnpm_named
   pnpm_named=$(find "$proj" -name '*pnpm*' -not -path '*/node_modules/*' 2>/dev/null || true)
   [ -z "$pnpm_named" ] || { echo "FAILED: pnpm-named files survived use nub: $pnpm_named" >>"$log"; return 1; }
   wipe_node_modules "$proj"
   nub_step "$log" "$proj" pnpm install --frozen-lockfile \
-    || { echo "FAILED: nub-mode frozen install from lock.yaml (exit $?)" >>"$log"; return 1; }
+    || { echo "FAILED: nub-mode frozen install from nub.lock (exit $?)" >>"$log"; return 1; }
   fixture_post_check "$fixture" "$proj" "$log" || return 1
   nub_step "$log" "$proj" pnpm pm use "pnpm@$PNPM_PIN" || { echo "FAILED: pm use pnpm (exit $?)" >>"$log"; return 1; }
-  [ -f "$proj/pnpm-lock.yaml" ] && [ ! -f "$proj/lock.yaml" ] \
-    || { echo "FAILED: use pnpm did not rename lock.yaml back" >>"$log"; return 1; }
+  [ -f "$proj/pnpm-lock.yaml" ] && [ ! -f "$proj/nub.lock" ] \
+    || { echo "FAILED: use pnpm did not rename nub.lock back" >>"$log"; return 1; }
   wipe_node_modules "$proj"
   ( cd "$proj" && step "$log" "real pnpm frozen accept (post round-trip)" run_pnpm install --frozen-lockfile ) \
     || { echo "FAILED: real pnpm rejected the post-round-trip state (--frozen-lockfile)" >>"$log"; return 1; }

--- a/tests/config-scope/run-matrix.sh
+++ b/tests/config-scope/run-matrix.sh
@@ -55,7 +55,7 @@ ms_version() {
     return
   fi
   local lock
-  for lock in "$dir"/lock.yaml "$dir"/pnpm-lock.yaml "$dir"/bun.lock; do
+  for lock in "$dir"/nub.lock "$dir"/lock.yaml "$dir"/pnpm-lock.yaml "$dir"/bun.lock; do
     [ -f "$lock" ] || continue
     grep -oE 'ms@2\.[0-9.]+' "$lock" | sed 's/ms@//' | sort -u | paste -sd, -
     return

--- a/tests/conformance/frontdoor/README.md
+++ b/tests/conformance/frontdoor/README.md
@@ -21,7 +21,7 @@ Two dimensions. **Incumbent** (the project identity nub detects) × **surface** 
 | **env: `npm_config_*` bridge** | honored | honored | honored | honored | honored | honored | honored |
 | **env: branded gating** | no AUBE_*/pnpm_* | no pnpm_* | pnpm_* honored | pnpm_* honored | no pnpm_* | no pnpm_* | BUN_CONFIG_* honored |
 | **run/exec flags** | reporter / regex / env-file / filter (incumbent-invariant) |
-| **lockfile round-trip** | lock.yaml | package-lock | pnpm-lock v9 | pnpm-lock v9 | yarn.lock v1 | yarn.lock v2+ | bun.lock |
+| **lockfile round-trip** | nub.lock | package-lock | pnpm-lock v9 | pnpm-lock v9 | yarn.lock v1 | yarn.lock v2+ | bun.lock |
 
 The run/exec-flag surface is **incumbent-invariant** (the run echo, `--env-file`, reporter, regex selection are nub's own CLI, not gated on identity), so it is asserted once rather than per-incumbent — the matrix tracks it as a single column to avoid bloat.
 

--- a/tests/native-deps/run.sh
+++ b/tests/native-deps/run.sh
@@ -130,11 +130,11 @@ pass "native modules loadable: $LOAD_OUT"
 echo ""
 echo "── frozen install runs trusted builds (Decision 2 regression) ────────────"
 LOCKFILE=""
-for cand in lock.yaml aube-lock.yaml pnpm-lock.yaml; do
+for cand in nub.lock lock.yaml aube-lock.yaml pnpm-lock.yaml; do
   [ -f "$PROJ_ALLOW/$cand" ] && { LOCKFILE="$cand"; break; }
 done
 [ -n "$LOCKFILE" ] \
-  || fail "fresh install produced no lockfile in $PROJ_ALLOW (expected lock.yaml, aube-lock.yaml, or pnpm-lock.yaml)"
+  || fail "fresh install produced no lockfile in $PROJ_ALLOW (expected nub.lock, lock.yaml, aube-lock.yaml, or pnpm-lock.yaml)"
 
 PROJ_FROZEN="$SANDBOX_ROOT/floor-frozen-clone"
 mkdir -p "$PROJ_FROZEN"

--- a/vendor/aube/crates/aube-lockfile/src/io.rs
+++ b/vendor/aube/crates/aube-lockfile/src/io.rs
@@ -273,25 +273,43 @@ fn has_conflict_markers(content: &str) -> bool {
 /// YAML parse + a `git branch --show-current` subprocess just to
 /// recompute a value that can't change mid-process.
 pub fn aube_lock_filename(project_dir: &Path) -> String {
+    let basename = aube_util::embedder().lockfile_basename;
+    match resolved_branch(project_dir) {
+        // basename is "<stem>.<ext>" (e.g. "aube-lock.yaml"); branch lockfiles
+        // splice the branch in as "<stem>.<branch>.<ext>".
+        Some(branch) => {
+            let (stem, ext) = basename.rsplit_once('.').unwrap_or((basename, "yaml"));
+            format!("{stem}.{branch}.{ext}")
+        }
+        None => basename.to_string(),
+    }
+}
+
+/// The slash-encoded current branch when `gitBranchLockfile` is on and the
+/// project is on a branch; `None` otherwise. Memoized per `project_dir` for
+/// the process (an install resolves a lockfile name 3–5 times, and each
+/// resolution would otherwise pay a YAML parse + a `git branch --show-current`
+/// subprocess to recompute a value that can't change mid-process).
+///
+/// This is the single source of the branch suffix shared by
+/// [`aube_lock_filename`] and [`pnpm_lock_filename`] so the two filenames stay
+/// in lockstep WITHOUT one being string-derived from the other — the derivation
+/// must not assume the canonical and pnpm names share an extension (they don't
+/// once an embedder picks a basename like `package.lock`).
+fn resolved_branch(project_dir: &Path) -> Option<String> {
     use std::sync::{Mutex, OnceLock};
-    static CACHE: OnceLock<Mutex<std::collections::HashMap<PathBuf, String>>> = OnceLock::new();
+    static CACHE: OnceLock<Mutex<std::collections::HashMap<PathBuf, Option<String>>>> =
+        OnceLock::new();
     let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
     if let Ok(map) = cache.lock()
         && let Some(hit) = map.get(project_dir)
     {
         return hit.clone();
     }
-    let basename = aube_util::embedder().lockfile_basename;
-    // basename is "<stem>.<ext>" (e.g. "aube-lock.yaml"); branch lockfiles
-    // splice the branch in as "<stem>.<branch>.<ext>".
-    let (stem, ext) = basename.rsplit_once('.').unwrap_or((basename, "yaml"));
-    let resolved = if !git_branch_lockfile_enabled(project_dir) {
-        basename.to_string()
+    let resolved = if git_branch_lockfile_enabled(project_dir) {
+        current_git_branch(project_dir).map(|branch| branch.replace('/', "!"))
     } else {
-        match current_git_branch(project_dir) {
-            Some(branch) => format!("{stem}.{}.{ext}", branch.replace('/', "!")),
-            None => basename.to_string(),
-        }
+        None
     };
     if let Ok(mut map) = cache.lock() {
         map.insert(project_dir.to_path_buf(), resolved.clone());
@@ -301,19 +319,16 @@ pub fn aube_lock_filename(project_dir: &Path) -> String {
 
 /// Resolve the pnpm lockfile filename for `project_dir`.
 ///
-/// Mirrors [`aube_lock_filename`] for branch lockfiles, but keeps the
-/// pnpm filename prefix so projects with an existing `pnpm-lock.yaml`
-/// keep writing to pnpm's file.
+/// Mirrors [`aube_lock_filename`] for branch lockfiles, but keeps pnpm's own
+/// `pnpm-lock` stem and `.yaml` extension so a project with an existing
+/// `pnpm-lock.yaml` keeps writing pnpm's file. Computed from the shared
+/// [`resolved_branch`] rather than string-rewriting the canonical name — the
+/// canonical basename's extension may not be `.yaml` (e.g. `package.lock`).
 pub fn pnpm_lock_filename(project_dir: &Path) -> String {
-    let aube_name = aube_lock_filename(project_dir);
-    // `aube_lock_filename` always returns "<stem>.<rest>", so strip_prefix
-    // always succeeds. The fallback is purely defensive.
-    let basename = aube_util::embedder().lockfile_basename;
-    let stem = basename.rsplit_once('.').map_or(basename, |(s, _)| s);
-    aube_name
-        .strip_prefix(&format!("{stem}."))
-        .map(|rest| format!("pnpm-lock.{rest}"))
-        .unwrap_or_else(|| "pnpm-lock.yaml".to_string())
+    match resolved_branch(project_dir) {
+        Some(branch) => format!("pnpm-lock.{branch}.yaml"),
+        None => "pnpm-lock.yaml".to_string(),
+    }
 }
 
 fn git_branch_lockfile_enabled(project_dir: &Path) -> bool {
@@ -424,11 +439,13 @@ pub(crate) fn lockfile_candidates(
     include_aube: bool,
 ) -> Vec<(PathBuf, LockfileKind)> {
     let basename = aube_util::embedder().lockfile_basename;
-    let stem = basename.rsplit_once('.').map_or(basename, |(s, _)| s);
 
     // The canonical (Aube) candidates: the branch-specific lockfile (if
     // `gitBranchLockfile` is on and we resolve a branch) then the plain
     // canonical lockfile, so a freshly-enabled branch still picks up the base.
+    // Then any LEGACY basenames the embedder still honors on read (a rename
+    // transition) — appended after the primary so the current name always wins
+    // when both are present.
     let mut aube_entries: Vec<(PathBuf, LockfileKind)> = Vec::new();
     if include_aube {
         let branch_name = aube_lock_filename(project_dir);
@@ -436,6 +453,9 @@ pub(crate) fn lockfile_candidates(
             aube_entries.push((project_dir.join(&branch_name), LockfileKind::Aube));
         }
         aube_entries.push((project_dir.join(basename), LockfileKind::Aube));
+        for legacy in aube_util::embedder().lockfile_legacy_basenames {
+            aube_entries.push((project_dir.join(legacy), LockfileKind::Aube));
+        }
     }
 
     // The foreign candidates, in their fixed precedence order. Preserve pnpm
@@ -443,13 +463,7 @@ pub(crate) fn lockfile_candidates(
     // mirrors the aube branch naming so a project already on pnpm branch
     // lockfiles keeps writing through that file.
     let mut foreign: Vec<(PathBuf, LockfileKind)> = Vec::new();
-    let pnpm_branch = {
-        let mut s = aube_lock_filename(project_dir);
-        if let Some(rest) = s.strip_prefix(&format!("{stem}.")) {
-            s = format!("pnpm-lock.{rest}");
-        }
-        s
-    };
+    let pnpm_branch = pnpm_lock_filename(project_dir);
     if pnpm_branch != "pnpm-lock.yaml" {
         foreign.push((project_dir.join(&pnpm_branch), LockfileKind::Pnpm));
     }

--- a/vendor/aube/crates/aube-lockfile/src/io.rs
+++ b/vendor/aube/crates/aube-lockfile/src/io.rs
@@ -128,6 +128,23 @@ pub fn write_lockfile_as(
     };
     let path = project_dir.join(&filename);
 
+    // Pre-rename LEGACY files for nub's OWN canonical lockfile (a filename
+    // transition, e.g. `lock.yaml` → `nub.lock`). Only the canonical (Aube)
+    // kind carries them and the list is EMPTY for standalone aube, so every
+    // branch below is inert there — fork-discipline: the default path is
+    // byte-for-byte unchanged. A present legacy file is nub's not-yet-migrated
+    // lockfile; the migration to `path` rides the first REAL write below.
+    let legacy_present: Vec<PathBuf> = if kind == LockfileKind::Aube {
+        aube_util::embedder()
+            .lockfile_legacy_basenames
+            .iter()
+            .map(|name| project_dir.join(name))
+            .filter(|p| *p != path && p.is_file())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     // No-churn write guard (embedder opt-in; default upstream = always
     // write). When the embedder enables it, skip the write if the graph
     // we'd serialize is identical (by engine-agnostic graph-identity
@@ -139,14 +156,41 @@ pub fn write_lockfile_as(
     // the comparison runs ONLY behind the embedder toggle, and any
     // failure to read/parse the existing file falls through to a normal
     // write (the feature is additive, never load-bearing).
-    if aube_util::embedder().no_churn_lockfile_write
-        && lockfile_write_is_noop(&path, kind, graph, manifest)
-    {
-        tracing::debug!(
-            "no-churn: resolved graph matches existing {}; skipping rewrite",
-            filename
-        );
-        return Ok(path);
+    //
+    // The comparison targets the CURRENT-name file when present, else nub's
+    // pre-rename LEGACY file. That legacy fallback is what keeps a no-op op on
+    // a not-yet-migrated project from writing anything: a graph-equal install /
+    // `--force` re-resolve leaves the old lockfile exactly as-is (no rename, no
+    // new file). The rename rides ONLY a real change (the write below).
+    if aube_util::embedder().no_churn_lockfile_write {
+        let compare_against = if path.exists() {
+            Some(path.clone())
+        } else {
+            legacy_present.first().cloned()
+        };
+        if let Some(existing) = compare_against
+            && lockfile_write_is_noop(&existing, kind, graph, manifest)
+        {
+            tracing::debug!(
+                "no-churn: resolved graph matches existing {}; skipping rewrite",
+                existing
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(&filename)
+            );
+            // Never leave two canonical lockfiles: when the CURRENT-name file is
+            // the one we matched (it exists), a pre-rename dup beside it is
+            // redundant cruft (reads resolve to the current name) — prune it.
+            // When only the legacy exists, it stays untouched (the no-op
+            // contract: a no-op op on a not-yet-migrated project changes
+            // nothing).
+            if path.exists() {
+                for lp in &legacy_present {
+                    let _ = std::fs::remove_file(lp);
+                }
+            }
+            return Ok(path);
+        }
     }
 
     match kind {
@@ -155,6 +199,14 @@ pub fn write_lockfile_as(
         LockfileKind::Yarn => yarn::write_classic(&path, graph, manifest)?,
         LockfileKind::YarnBerry => yarn::write_berry(&path, graph, manifest)?,
         LockfileKind::Bun => bun::write(&path, graph, manifest)?,
+    }
+
+    // A real canonical write just landed under the CURRENT name; complete the
+    // one-time rename by removing any pre-rename LEGACY file so the project ends
+    // on exactly ONE lockfile. Reached only on a genuine change (the no-churn
+    // guard returned above otherwise), so this never fires on a no-op op.
+    for lp in &legacy_present {
+        let _ = std::fs::remove_file(lp);
     }
     Ok(path)
 }

--- a/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -20,6 +20,7 @@ static MYTOOL: Embedder = Embedder {
     self_names: &["mytool"],
     compatible_names: &["pnpm"],
     lockfile_basename: "lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: Some("mytool-workspace.yaml"),
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),

--- a/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
@@ -26,6 +26,7 @@ static MYTOOL: Embedder = Embedder {
     self_names: &["mytool"],
     compatible_names: &["pnpm"],
     lockfile_basename: "lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: Some("mytool-workspace.yaml"),
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -30,6 +30,7 @@ static NO_CHURN_TOOL: Embedder = Embedder {
     self_names: &["nochurn"],
     compatible_names: &["pnpm"],
     lockfile_basename: "nochurn-lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: Some("nochurn-workspace.yaml"),
     manifest_namespace: "nochurn",
     env_prefix: Some("NOCHURN"),

--- a/vendor/aube/crates/aube-lockfile/tests/package_lock_rename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/package_lock_rename.rs
@@ -109,3 +109,92 @@ fn non_yaml_basename_keeps_pnpm_name_and_reads_both_names() {
         Some(LockfileKind::Aube)
     );
 }
+
+const EMPTY_V9: &str = "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n";
+
+/// A real change (a graph differing from what the legacy file holds) writes
+/// under the CURRENT name and removes the pre-rename legacy file — the rename
+/// rides the change, never leaving both.
+#[test]
+fn real_write_migrates_legacy_to_current_name() {
+    aube_util::set_embedder(&MYTOOL);
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("package.json"), r#"{"name":"t"}"#).unwrap();
+    // Legacy holds the empty graph; we write a graph that carries a package.
+    std::fs::write(dir.path().join("lock.yaml"), EMPTY_V9).unwrap();
+
+    let mut changed = aube_lockfile::LockfileGraph::default();
+    changed.packages.insert(
+        "left-pad@1.3.0".to_string(),
+        aube_lockfile::LockedPackage {
+            name: "left-pad".to_string(),
+            version: "1.3.0".to_string(),
+            dep_path: "left-pad@1.3.0".to_string(),
+            integrity: Some("sha512-uNjWgY0DVJtsWJRfXt0G1L2i".to_string()),
+            ..Default::default()
+        },
+    );
+    let manifest = aube_manifest::PackageJson::default();
+    let written = write_lockfile_as(dir.path(), &changed, &manifest, LockfileKind::Aube).unwrap();
+
+    assert_eq!(written, dir.path().join("package.lock"));
+    assert!(dir.path().join("package.lock").is_file());
+    assert!(
+        !dir.path().join("lock.yaml").exists(),
+        "the migrating write must remove the pre-rename legacy file"
+    );
+}
+
+/// A no-op write (the same graph the legacy already holds) writes NOTHING: no
+/// current-name file appears and the legacy stays byte-for-byte. The migration
+/// must not be a proactive rename. The written graph is parsed back FROM the
+/// legacy file so it is graph-identical by construction — mirroring the real
+/// flow, where the resolver reproduces the lockfile it read.
+#[test]
+fn no_op_write_leaves_legacy_untouched() {
+    aube_util::set_embedder(&MYTOOL);
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("package.json"), r#"{"name":"t"}"#).unwrap();
+    std::fs::write(dir.path().join("lock.yaml"), EMPTY_V9).unwrap();
+
+    let manifest = aube_manifest::PackageJson::default();
+    let graph = aube_lockfile::parse_lockfile(dir.path(), &manifest).unwrap();
+    let _ = write_lockfile_as(dir.path(), &graph, &manifest, LockfileKind::Aube).unwrap();
+
+    assert!(
+        !dir.path().join("package.lock").exists(),
+        "a no-op write must not create the current-name file"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("lock.yaml")).unwrap(),
+        EMPTY_V9,
+        "a no-op write must leave the legacy file byte-for-byte"
+    );
+}
+
+/// When BOTH names already exist and the write is a no-op against the
+/// current-name file, the redundant legacy dup is pruned so the project never
+/// carries two canonical lockfiles.
+#[test]
+fn both_present_no_op_prunes_redundant_legacy() {
+    aube_util::set_embedder(&MYTOOL);
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("package.json"), r#"{"name":"t"}"#).unwrap();
+    std::fs::write(dir.path().join("package.lock"), EMPTY_V9).unwrap();
+    std::fs::write(dir.path().join("lock.yaml"), EMPTY_V9).unwrap();
+
+    let manifest = aube_manifest::PackageJson::default();
+    // Parsed from the current-name file (it wins precedence), so the write is a
+    // no-op against it.
+    let graph = aube_lockfile::parse_lockfile(dir.path(), &manifest).unwrap();
+    let _ = write_lockfile_as(dir.path(), &graph, &manifest, LockfileKind::Aube).unwrap();
+
+    assert!(
+        dir.path().join("package.lock").is_file(),
+        "the current-name file is kept verbatim on a no-op"
+    );
+    assert!(
+        !dir.path().join("lock.yaml").exists(),
+        "the redundant legacy dup is pruned so both names never coexist"
+    );
+}

--- a/vendor/aube/crates/aube-lockfile/tests/package_lock_rename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/package_lock_rename.rs
@@ -1,0 +1,111 @@
+//! Regression cover for an embedder whose canonical lockfile basename does
+//! NOT share pnpm's `.yaml` extension (e.g. `package.lock`), plus a legacy
+//! basename honored on read during a rename transition.
+//!
+//! Own integration-test binary (= own process) because the active embedder is
+//! once-per-process.
+
+use aube_lockfile::{
+    LockfileKind, aube_lock_filename, detect_existing_lockfile_kind, pnpm_lock_filename,
+    write_lockfile_as,
+};
+use aube_util::Embedder;
+
+static MYTOOL: Embedder = Embedder {
+    name: "mytool",
+    display_name: "mytool",
+    vendor: None,
+    version: "1.0.0",
+    user_agent: "mytool/1.0.0",
+    self_names: &["mytool"],
+    compatible_names: &["pnpm"],
+    // The renamed canonical: a `.lock` extension, NOT `.yaml`.
+    lockfile_basename: "package.lock",
+    // The pre-rename name, recognized on read but never written.
+    lockfile_legacy_basenames: &["lock.yaml"],
+    workspace_yaml: None,
+    manifest_namespace: "",
+    env_prefix: None,
+    config_env_prefix: Some("MYTOOL"),
+    diag_env_prefix: Some("MYTOOL"),
+    cache_namespace: "mytool",
+    data_namespace: "mytool",
+    managed_config_system_dir: Some("mytool"),
+    config_namespace: None,
+    // Mirror nub: the canonical does not silently outrank a foreign lockfile.
+    canonical_lockfile_always_wins: false,
+    runtime_switching: false,
+    self_engines_check: false,
+    self_update_enabled: false,
+    warm_store_verify: false,
+    no_churn_lockfile_write: true,
+    read_branded_settings_env: false,
+    gvs_incompatible_warning: false,
+    gvs_over_default_hoist: false,
+    primer_ttl: None,
+    cpu_budget: None,
+    tty_progress: false,
+    strict_unsupported_source: true,
+    warm_trust_revalidate: false,
+    trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
+};
+
+#[test]
+fn non_yaml_basename_keeps_pnpm_name_and_reads_both_names() {
+    aube_util::set_embedder(&MYTOOL);
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("package.json"), r#"{"name":"t"}"#).unwrap();
+
+    // The canonical write name follows the basename...
+    assert_eq!(LockfileKind::Aube.filename(), "package.lock");
+    assert_eq!(aube_lock_filename(dir.path()), "package.lock");
+    // ...but the pnpm name must stay `pnpm-lock.yaml`, NOT be derived from the
+    // canonical basename's `.lock` extension (the regression this guards): a
+    // pnpm-incumbent project must keep writing pnpm's real file.
+    assert_eq!(pnpm_lock_filename(dir.path()), "pnpm-lock.yaml");
+
+    // A fresh Aube write lands at the renamed canonical.
+    let graph = aube_lockfile::LockfileGraph::default();
+    let manifest = aube_manifest::PackageJson::default();
+    let written = write_lockfile_as(dir.path(), &graph, &manifest, LockfileKind::Aube).unwrap();
+    assert_eq!(written, dir.path().join("package.lock"));
+
+    // The corruption this pins: a pnpm-incumbent project written under the
+    // renamed profile must land at `pnpm-lock.yaml`, NEVER `pnpm-lock.lock`
+    // (which the old "reuse the canonical basename's extension" derivation
+    // would have produced once the canonical extension became `.lock`).
+    let pnpm_dir = tempfile::tempdir().unwrap();
+    std::fs::write(pnpm_dir.path().join("package.json"), r#"{"name":"t"}"#).unwrap();
+    let pnpm_written =
+        write_lockfile_as(pnpm_dir.path(), &graph, &manifest, LockfileKind::Pnpm).unwrap();
+    assert_eq!(pnpm_written, pnpm_dir.path().join("pnpm-lock.yaml"));
+    assert!(
+        !pnpm_dir.path().join("pnpm-lock.lock").exists(),
+        "no `.lock`-extension pnpm lockfile may ever be produced"
+    );
+
+    // Read-both: a project still carrying only the LEGACY name resolves as the
+    // canonical (Aube) kind so every read path keeps working pre-migration.
+    let legacy = tempfile::tempdir().unwrap();
+    std::fs::write(legacy.path().join("package.json"), r#"{"name":"t"}"#).unwrap();
+    std::fs::write(legacy.path().join("lock.yaml"), "lockfileVersion: '9.0'\n").unwrap();
+    assert_eq!(
+        detect_existing_lockfile_kind(legacy.path()),
+        Some(LockfileKind::Aube),
+        "a legacy lock.yaml must still resolve as the canonical kind"
+    );
+
+    // When both names exist, the current name wins (legacy trails it in the
+    // candidate order).
+    std::fs::write(
+        legacy.path().join("package.lock"),
+        "lockfileVersion: '9.0'\n",
+    )
+    .unwrap();
+    assert_eq!(
+        detect_existing_lockfile_kind(legacy.path()),
+        Some(LockfileKind::Aube)
+    );
+}

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -23,6 +23,7 @@ static STRICT: Embedder = Embedder {
     self_names: &["aube"],
     compatible_names: &["pnpm"],
     lockfile_basename: "aube-lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: Some("aube-workspace.yaml"),
     manifest_namespace: "aube",
     env_prefix: Some("AUBE"),

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -26,6 +26,7 @@ static ROOT_TOOL: Embedder = Embedder {
     self_names: &["roottool"],
     compatible_names: &["pnpm"],
     lockfile_basename: "roottool-lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: None,
     manifest_namespace: "",
     env_prefix: None,

--- a/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
@@ -22,6 +22,7 @@ static MYTOOL: Embedder = Embedder {
     self_names: &["mytool"],
     compatible_names: &["pnpm"],
     lockfile_basename: "mytool-lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: Some("mytool-workspace.yaml"),
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -17,6 +17,7 @@ static ROOT_TOOL: Embedder = Embedder {
     self_names: &["roottool"],
     compatible_names: &["pnpm"],
     lockfile_basename: "roottool-lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: None,
     manifest_namespace: "",
     env_prefix: None,

--- a/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
@@ -16,6 +16,7 @@ static MYTOOL: Embedder = Embedder {
     self_names: &["mytool"],
     compatible_names: &["pnpm"],
     lockfile_basename: "mytool-lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: Some("mytool-workspace.yaml"),
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),

--- a/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
+++ b/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
@@ -28,6 +28,7 @@ static MYTOOL_NO_BRANDED_ENV: Embedder = Embedder {
     self_names: &["mytool"],
     compatible_names: &["pnpm"],
     lockfile_basename: "lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: Some("mytool-workspace.yaml"),
     manifest_namespace: "mytool",
     // Branded prefix is *still set* — proving the toggle is independent of

--- a/vendor/aube/crates/aube-util/src/identity.rs
+++ b/vendor/aube/crates/aube-util/src/identity.rs
@@ -78,6 +78,17 @@ pub struct Embedder {
     /// lockfile indistinguishable from the incumbent's in the
     /// lockfile-candidate set (`io.rs` / `clean.rs` / `pack.rs`).
     pub lockfile_basename: &'static str,
+    /// Former canonical lockfile basenames still RECOGNIZED ON READ during a
+    /// rename transition, but never written. The lockfile-candidate machinery
+    /// appends these as [`LockfileKind::Aube`](crate) read-candidates *after*
+    /// the primary [`lockfile_basename`](Self::lockfile_basename), so an
+    /// existing legacy file keeps resolving while every fresh write targets the
+    /// new name. Same per-name invariant as `lockfile_basename` (must contain a
+    /// `.`, must not alias a foreign lockfile). Standalone aube: `&[]` (no
+    /// legacy names — its name has never changed); an embedder mid-rename lists
+    /// the prior name(s) here (nub: `&["lock.yaml"]`, superseded by
+    /// `package.lock`). Additive and no-op for the empty default.
+    pub lockfile_legacy_basenames: &'static [&'static str],
     /// The *branded* workspace-config YAML this tool reads and writes, e.g.
     /// `"aube-workspace.yaml"`. `None` disables the tool's own branded YAML
     /// entirely (the shared `pnpm-workspace.yaml` compatibility surface is
@@ -390,6 +401,8 @@ pub const AUBE: Embedder = Embedder {
     self_names: &["aube"],
     compatible_names: &["pnpm"],
     lockfile_basename: "aube-lock.yaml",
+    // aube's name has never changed — no legacy lockfile names to honor.
+    lockfile_legacy_basenames: &[],
     workspace_yaml: Some("aube-workspace.yaml"),
     manifest_namespace: "aube",
     env_prefix: Some("AUBE"),
@@ -466,6 +479,19 @@ pub fn set_embedder(embedder: &'static Embedder) {
          pick a distinct name so aube's lockfile stays distinguishable in the candidate set",
         embedder.lockfile_basename,
     );
+    // Legacy read-only basenames follow the same invariants as the primary:
+    // they ride the same candidate machinery, so a missing extension or a
+    // foreign-name alias would corrupt the candidate set just as badly.
+    for legacy in embedder.lockfile_legacy_basenames {
+        debug_assert!(
+            legacy.contains('.'),
+            "embedder lockfile_legacy_basenames entry {legacy:?} must contain a `.`",
+        );
+        debug_assert!(
+            !FOREIGN_LOCKFILE_NAMES.contains(legacy),
+            "embedder lockfile_legacy_basenames entry {legacy:?} aliases a foreign package manager's lockfile",
+        );
+    }
     let _ = ACTIVE.set(embedder);
 }
 
@@ -586,6 +612,7 @@ mod tests {
         assert_eq!(id.self_names, &["aube"]);
         assert_eq!(id.compatible_names, &["pnpm"]);
         assert_eq!(id.lockfile_basename, "aube-lock.yaml");
+        assert!(id.lockfile_legacy_basenames.is_empty());
         assert_eq!(id.workspace_yaml, Some("aube-workspace.yaml"));
         assert_eq!(id.manifest_namespace, "aube");
         assert_eq!(id.env_prefix, Some("AUBE"));

--- a/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -29,6 +29,7 @@ static NUBLIKE: Embedder = Embedder {
     self_names: &["nublike"],
     compatible_names: &["pnpm"],
     lockfile_basename: "lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: None,
     manifest_namespace: "",
     env_prefix: None,

--- a/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -25,6 +25,7 @@ static NUBLIKE: Embedder = Embedder {
     self_names: &["nublike"],
     compatible_names: &["pnpm"],
     lockfile_basename: "lock.yaml",
+    lockfile_legacy_basenames: &[],
     workspace_yaml: None,
     manifest_namespace: "",
     env_prefix: None,

--- a/vendor/aube/crates/aube/src/commands/add/filtered.rs
+++ b/vendor/aube/crates/aube/src/commands/add/filtered.rs
@@ -48,6 +48,14 @@ pub(super) async fn run(
     } else {
         None
     };
+    // A `--no-save` add whose transient write MIGRATES nub's legacy lockfile
+    // (writes `nub.lock`, deletes `lock.yaml`) must restore the legacy file too,
+    // or the checked-in `lock.yaml` is silently lost. Empty for standalone aube.
+    let root_legacy_snapshot = if args.no_save {
+        no_save::snapshot_legacy_lockfiles(&lockfile_path)?
+    } else {
+        Vec::new()
+    };
 
     let result: miette::Result<()> = async {
         for pkg in &matched {
@@ -99,6 +107,11 @@ pub(super) async fn run(
         }
         if let Err(e) = no_save::restore_lockfile(&lockfile_path, &root_lockfile_snapshot) {
             errors.push(e);
+        }
+        for (path, bytes) in &root_legacy_snapshot {
+            if let Err(e) = no_save::restore_lockfile(path, bytes) {
+                errors.push(e);
+            }
         }
         if errors.is_empty() {
             eprintln!(

--- a/vendor/aube/crates/aube/src/commands/add/no_save.rs
+++ b/vendor/aube/crates/aube/src/commands/add/no_save.rs
@@ -60,7 +60,7 @@ pub(super) fn snapshot_manifest_and_lockfile(
 /// parent dir), so a `--no-save` add that migrates the legacy name can restore
 /// the tree byte-for-byte. Inert for standalone aube (empty legacy list) and
 /// for any dir carrying none of the legacy names.
-fn snapshot_legacy_lockfiles(
+pub(super) fn snapshot_legacy_lockfiles(
     lockfile_path: &Path,
 ) -> miette::Result<Vec<(PathBuf, Option<Vec<u8>>)>> {
     let Some(dir) = lockfile_path.parent() else {

--- a/vendor/aube/crates/aube/src/commands/add/no_save.rs
+++ b/vendor/aube/crates/aube/src/commands/add/no_save.rs
@@ -10,6 +10,13 @@ pub(super) struct Snapshot {
     /// `None` means the lockfile didn't exist before the add — in that
     /// case the restore step deletes whatever the resolver wrote.
     lockfile_bytes: Option<Vec<u8>>,
+    /// Pre-rename LEGACY lockfiles for nub's own name (e.g. `lock.yaml`),
+    /// captured alongside the current-name lockfile so a `--no-save` add that
+    /// would MIGRATE the legacy name (the writer writes `nub.lock` and deletes
+    /// `lock.yaml`) can restore the tree EXACTLY — otherwise the migration's
+    /// deletion would survive the restore and silently drop the user's
+    /// lockfile. Empty for standalone aube (no legacy basenames).
+    legacy: Vec<(PathBuf, Option<Vec<u8>>)>,
 }
 
 /// Resolve the on-disk lockfile path that a normal `add` would write
@@ -41,10 +48,33 @@ pub(super) fn snapshot_manifest_and_lockfile(
         .into_diagnostic()
         .wrap_err("failed to snapshot package.json for --no-save")?;
     let lockfile_bytes = snapshot_lockfile(lockfile_path)?;
+    let legacy = snapshot_legacy_lockfiles(lockfile_path)?;
     Ok(Snapshot {
         manifest_bytes,
         lockfile_bytes,
+        legacy,
     })
+}
+
+/// Snapshot every pre-rename LEGACY lockfile beside `lockfile_path` (its
+/// parent dir), so a `--no-save` add that migrates the legacy name can restore
+/// the tree byte-for-byte. Inert for standalone aube (empty legacy list) and
+/// for any dir carrying none of the legacy names.
+fn snapshot_legacy_lockfiles(
+    lockfile_path: &Path,
+) -> miette::Result<Vec<(PathBuf, Option<Vec<u8>>)>> {
+    let Some(dir) = lockfile_path.parent() else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for name in aube_util::embedder().lockfile_legacy_basenames {
+        let p = dir.join(name);
+        if p == lockfile_path {
+            continue;
+        }
+        out.push((p.clone(), snapshot_lockfile(&p)?));
+    }
+    Ok(out)
 }
 
 pub(super) fn snapshot_lockfile(lockfile_path: &Path) -> miette::Result<Option<Vec<u8>>> {
@@ -73,6 +103,13 @@ pub(super) fn restore_manifest_and_lockfile(
     }
     if let Err(e) = restore_lockfile(lockfile_path, &snapshot.lockfile_bytes) {
         errors.push(e);
+    }
+    // Restore any pre-rename legacy lockfile the migration may have deleted, so
+    // the `--no-save` tree ends exactly as the user had it.
+    for (path, bytes) in &snapshot.legacy {
+        if let Err(e) = restore_lockfile(path, bytes) {
+            errors.push(e);
+        }
     }
     errors
 }

--- a/vendor/aube/crates/aube/src/commands/clean.rs
+++ b/vendor/aube/crates/aube/src/commands/clean.rs
@@ -31,17 +31,20 @@ pub struct CleanArgs {
 /// Lockfile basenames removed by `--lockfile`. Kept in one place so
 /// `clean` and any future `purge`-adjacent command see the same set.
 /// Lockfile names `aube clean --lockfile` removes: this tool's canonical
-/// lockfile plus every foreign format it round-trips. Standalone aube leads
-/// with `aube-lock.yaml`.
-fn lockfile_names() -> [&'static str; 6] {
-    [
+/// lockfile (plus any legacy basename still honored through a rename
+/// transition) and every foreign format it round-trips. Standalone aube leads
+/// with `aube-lock.yaml` and has no legacy names.
+fn lockfile_names() -> Vec<&'static str> {
+    let mut names = vec![
         aube_util::embedder().lockfile_basename,
         "pnpm-lock.yaml",
         "package-lock.json",
         "npm-shrinkwrap.json",
         "yarn.lock",
         "bun.lock",
-    ]
+    ];
+    names.extend_from_slice(aube_util::embedder().lockfile_legacy_basenames);
+    names
 }
 
 pub async fn run(args: CleanArgs) -> miette::Result<Option<i32>> {

--- a/vendor/aube/crates/aube/src/commands/pack.rs
+++ b/vendor/aube/crates/aube/src/commands/pack.rs
@@ -490,7 +490,11 @@ fn is_npm_ignored(name: &str) -> bool {
     // registry. Real footgun, real incidents, npm/pnpm both ship a
     // similar list. Users can still override via `files` field if
     // they really want to publish one of these (nobody should).
-    if name == aube_util::embedder().lockfile_basename {
+    if name == aube_util::embedder().lockfile_basename
+        || aube_util::embedder()
+            .lockfile_legacy_basenames
+            .contains(&name)
+    {
         return true;
     }
     if matches!(

--- a/vendor/aube/crates/aube/src/runtime.rs
+++ b/vendor/aube/crates/aube/src/runtime.rs
@@ -232,8 +232,14 @@ pub(crate) fn lockfile_node_pin(
     project_dir: &Path,
     manifest: &PackageJson,
 ) -> Option<aube_lockfile::RuntimePin> {
-    let pinned = [aube_util::embedder().lockfile_basename, "pnpm-lock.yaml"]
-        .iter()
+    let pinned = std::iter::once(aube_util::embedder().lockfile_basename)
+        .chain(
+            aube_util::embedder()
+                .lockfile_legacy_basenames
+                .iter()
+                .copied(),
+        )
+        .chain(std::iter::once("pnpm-lock.yaml"))
         .any(|name| {
             std::fs::read_to_string(project_dir.join(name))
                 .map(|s| s.contains("specifier: runtime:"))

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -784,7 +784,6 @@ pub fn remove_state(project_dir: &Path) -> Result<(), std::io::Error> {
 /// any exists.
 fn active_lockfile(project_dir: &Path) -> (String, Option<PathBuf>) {
     let basename = aube_util::embedder().lockfile_basename;
-    let stem = basename.rsplit_once('.').map_or(basename, |(s, _)| s);
     let preferred = aube_lockfile::aube_lock_filename(project_dir);
     let preferred_path = project_dir.join(&preferred);
     if preferred_path.exists() {
@@ -798,10 +797,22 @@ fn active_lockfile(project_dir: &Path) -> (String, Option<PathBuf>) {
             return (basename.to_string(), Some(base));
         }
     }
+    // A legacy canonical name still honored on read during a rename
+    // transition (e.g. nub's `lock.yaml` superseded by `package.lock`): an
+    // unmigrated project must still recognize its lockfile so the freshness
+    // check doesn't loop on "no lockfile found".
+    for legacy in aube_util::embedder().lockfile_legacy_basenames {
+        let legacy_path = project_dir.join(legacy);
+        if legacy_path.exists() {
+            return ((*legacy).to_string(), Some(legacy_path));
+        }
+    }
     // Preserve pnpm-lock.yaml (and its branch variant) as an active
-    // lockfile when the project already uses it.
-    let pnpm_preferred = preferred.replacen(&format!("{stem}."), "pnpm-lock.", 1);
-    if pnpm_preferred != preferred {
+    // lockfile when the project already uses it. Derived from the shared
+    // branch resolver (`pnpm_lock_filename`), NOT by string-rewriting the
+    // canonical name — the canonical extension may not be `.yaml`.
+    let pnpm_preferred = aube_lockfile::pnpm_lock_filename(project_dir);
+    if pnpm_preferred != "pnpm-lock.yaml" {
         let pnpm_branch = project_dir.join(&pnpm_preferred);
         if pnpm_branch.exists() {
             return (pnpm_preferred, Some(pnpm_branch));


### PR DESCRIPTION
Renames nub's own lockfile (nub-identity projects) from `lock.yaml` to `nub.lock`. Bytes unchanged (pnpm-lock v9). An existing `lock.yaml` keeps working and migrates automatically the next time the lockfile actually changes.

Re-introduces the `aube-lockfile` filename decoupling so a non-`.yaml` basename can't corrupt a pnpm project's `pnpm-lock.yaml` to `pnpm-lock.lock`. Default-preserving for standalone aube. Supersedes #257's `package.lock` (reverted in #273).

## Migration model (rename-on-real-write — no-churn stays sacred)

The migration rides a REAL lockfile write, it is not a proactive rename:

- A routine install with nothing to change writes nothing and leaves `lock.yaml` exactly as-is (no `nub.lock` created).
- The first real change (dep add/remove/update, or any re-resolve that alters the graph) writes `nub.lock` and removes `lock.yaml` in the same diff — never two files.
- `nub ci` and `--frozen` never write the lockfile, so they never migrate; they read `lock.yaml` fine via the legacy candidate.

Implemented in the aube writer (`write_lockfile_as`) with a legacy-aware no-churn guard; `add --no-save` snapshots/restores the legacy file so a `--no-save` add still restores the tree exactly. Gated on the canonical (Aube) kind + the embedder's legacy-basename list, which is empty for standalone aube — so standalone aube is byte-for-byte unaffected.

**Held — do not merge; the maintainer triggers it.**

Tests: `nub-cli` `lockfile_rename` covers fresh→`nub.lock`, no-op-leaves-legacy, real-change-migrates, and the frozen/`ci`/CI-env read-only paths; `aube-lockfile` `package_lock_rename` covers the writer-level migrate/skip/prune and a pnpm project keeping `pnpm-lock.yaml`.

## Release note

> nub's own lockfile is now `nub.lock` (was `lock.yaml`). An existing `lock.yaml` keeps working — nub reads it — and it migrates automatically the next time the lockfile actually changes: on a dependency add, remove, or update, nub writes `nub.lock` and removes the old `lock.yaml` in the same diff. A routine install with nothing to change never rewrites or renames the lockfile, and `nub ci` never touches a checked-in one.