### PR TITLE
fix(pm): default trustPolicyIgnoreAfter to a 14-day window under nub

### DIFF
--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -204,6 +204,18 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     // link); any install that does REAL work misses the short-circuit and still
     // trips the gate during resolution. Standalone aube keeps the re-validation.
     warm_trust_revalidate: false,
+    // Default `trustPolicyIgnoreAfter` to a 14-day window (in minutes) when the
+    // user hasn't set it. A legitimate maintenance backport on an old major —
+    // published later in wall-clock than a newer major that adopted OIDC
+    // provenance — trips the date-ordered downgrade scan on first resolve (the
+    // #270 false positive: `@modelcontextprotocol/inspector` → `tailwind-merge`).
+    // Once such a version has aged past the window un-yanked it is
+    // overwhelmingly a real backport and is exempted; a freshly published
+    // weak-evidence version is still scanned against the full history, so the
+    // downgrade attack (a stolen-token publish into an old line) is still caught
+    // in the window that matters. An explicit user `trustPolicyIgnoreAfter=0`
+    // opts back into the full strict check. Standalone aube keeps `None`.
+    trust_policy_ignore_after_default: Some(14 * 24 * 60),
 };
 
 /// Register [`NUB`] as the active embedder profile. Idempotent (the engine's
@@ -244,4 +256,5 @@ const _: () = {
     assert!(NUB.primer_ttl.is_none());
     assert!(NUB.tty_progress);
     assert!(!NUB.warm_trust_revalidate);
+    assert!(matches!(NUB.trust_policy_ignore_after_default, Some(20160)));
 };

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -415,6 +415,18 @@ Frozen reinstalls — `nub ci`, `--frozen-lockfile`, a teammate's clone — inhe
 
 The OS-level build jail — a network-blocked, filesystem-scoped sandbox around every build script — is compiled in but **off by default**. Opt in with the neutral `paranoid` / `npm_config_paranoid` setting, which also flips the advisory gate to fail-closed. The jail covers macOS and Linux; Windows is a passthrough.
 
+### Trust downgrades
+
+Nub also weighs trust *evidence* across a package's release history — OIDC provenance, a trusted publisher, a staged-publish approval. A resolved version that carries weaker evidence than an earlier-published version of the same package stops the install with `ERR_NUB_TRUST_DOWNGRADE`, because a maintainer's pipeline that suddenly publishes without the attestation it used to carry is the shape of a token-theft supply-chain attack.
+
+The comparison is by publish date, so a legitimate maintenance release on an older major — shipped after a newer major adopted provenance — can trip it. Nub exempts any version older than 14 days, so an aged, un-yanked backport resolves while a freshly published downgrade is still checked against the full history. Widen the window, clear a single package, or turn the check off in `.npmrc`:
+
+```ini
+trustPolicyIgnoreAfter=20160          # age exemption in minutes (default 14 days)
+trustPolicyExclude[]=tailwind-merge   # exempt one package regardless of age
+trustPolicy=off                       # disable the check entirely
+```
+
 ## Store and disk layout
 
 Regardless of the incumbent, Nub installs through a global content-addressed store and links into an isolated virtual store — aube's scheme, under Nub's own directory names.

--- a/site/content/docs/pm.mdx
+++ b/site/content/docs/pm.mdx
@@ -129,7 +129,7 @@ nub: provisioned nub@0.2.9
 
 The release comes from Nub's own channel and is checksum-verified before it runs; a corrupt, missing, or wrong-version build is a hard error, never a silent fallback. The store lives at `~/.cache/nub/self/<version>`, so a pinned version runs offline once provisioned.
 
-Only the install verbs hand off. Everything else — the file runner, script running, [`nubx`](/docs/nubx), version management, self-update — never reads the pin, so `nub script.ts` stays fast. A matching pin runs in place. A non-exact pin does too, with a notice: like corepack, the `packageManager` field is exact-only.
+Only the install verbs hand off. Everything else — the file runner, script running, [`nubx`](/docs/runner), version management, self-update — never reads the pin, so `nub script.ts` stays fast. A matching pin runs in place. A non-exact pin does too, with a notice: like corepack, the `packageManager` field is exact-only.
 
 To run with your installed Nub regardless of the pin, set `NUB_SELF_SHIM=0`. It disables the handoff for the whole tree:
 

--- a/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -42,6 +42,7 @@ static MYTOOL: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 #[test]

--- a/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
@@ -48,6 +48,7 @@ static MYTOOL: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 fn project(files: &[(&str, &str)]) -> tempfile::TempDir {

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -52,6 +52,7 @@ static NO_CHURN_TOOL: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 fn pkg(name: &str, version: &str, integrity: &str) -> LockedPackage {

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -45,6 +45,7 @@ static STRICT: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: true,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 fn parse(files: &[(&str, &str)]) -> Result<LockfileGraph, Error> {

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -48,6 +48,7 @@ static ROOT_TOOL: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 fn read_manifest(dir: &std::path::Path) -> serde_json::Value {

--- a/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
@@ -44,6 +44,7 @@ static MYTOOL: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 #[tokio::test]

--- a/vendor/aube/crates/aube-resolver/src/trust.rs
+++ b/vendor/aube/crates/aube-resolver/src/trust.rs
@@ -1114,6 +1114,97 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    /// A registry-shaped ISO-8601 timestamp `days` before now. Window tests
+    /// must be relative to the wall-clock they run under, not fixed dates, so
+    /// they stay correct at any point in time.
+    fn iso_days_ago(days: u64) -> String {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_secs();
+        crate::types::format_iso8601_utc(now.saturating_sub(days * 86_400))
+    }
+
+    // nub's default `trustPolicyIgnoreAfter` (14 days, in minutes). The two
+    // tests below pin the security contract of that default: aged → exempt,
+    // fresh → still caught.
+    const NUB_IGNORE_AFTER_MIN: u64 = 14 * 24 * 60;
+
+    /// The 14-day window exempts an *aged* legitimate backport — the #270
+    /// shape. An old-major maintenance release (`tailwind-merge@2.6.1`, no
+    /// evidence) is published later in wall-clock than a newer major that
+    /// adopted trusted publishing (`3.4.0`), so the date-ordered scan finds the
+    /// stronger prior evidence and would fail. Aged well past the window, the
+    /// pick clears the check instead.
+    #[test]
+    fn ignore_after_14d_exempts_aged_backport() {
+        let prior_time = iso_days_ago(210);
+        let picked_time = iso_days_ago(150);
+        let p = packument(
+            "tailwind-merge",
+            vec![
+                (
+                    "3.4.0",
+                    &prior_time,
+                    with_trusted_publisher(version("tailwind-merge", "3.4.0")),
+                ),
+                ("2.6.1", &picked_time, version("tailwind-merge", "2.6.1")),
+            ],
+        );
+        let picked = p.versions.get("2.6.1").unwrap();
+        let result = check_no_downgrade(
+            &p,
+            "2.6.1",
+            picked,
+            &TrustExcludeRules::default(),
+            Some(NUB_IGNORE_AFTER_MIN),
+        );
+        assert!(
+            result.is_ok(),
+            "a backport aged past the 14-day window must not trip the downgrade check"
+        );
+    }
+
+    /// The window must NOT hide a *fresh* downgrade — the load-bearing security
+    /// property. A version published inside the window with weaker evidence
+    /// than a stronger earlier-published sibling is still a downgrade (the
+    /// stolen-token-into-an-old-line attack shape), and must still fail. A
+    /// regression here means the 14-day default opened the exact hole the
+    /// analysis behind #270 warned about.
+    #[test]
+    fn ignore_after_14d_still_catches_fresh_downgrade() {
+        let prior_time = iso_days_ago(2);
+        let picked_time = iso_days_ago(1);
+        let p = packument(
+            "foo",
+            vec![
+                (
+                    "2.0.0",
+                    &prior_time,
+                    with_trusted_publisher(version("foo", "2.0.0")),
+                ),
+                ("2.0.1", &picked_time, version("foo", "2.0.1")),
+            ],
+        );
+        let picked = p.versions.get("2.0.1").unwrap();
+        let err = check_no_downgrade(
+            &p,
+            "2.0.1",
+            picked,
+            &TrustExcludeRules::default(),
+            Some(NUB_IGNORE_AFTER_MIN),
+        )
+        .expect_err("a fresh weak-evidence publish inside the window must still fail");
+        match err {
+            TrustCheckError::Downgrade(d) => {
+                assert_eq!(d.prior_evidence, TrustEvidence::TrustedPublisher);
+                assert_eq!(d.prior_version, "2.0.0");
+                assert_eq!(d.current_evidence, None);
+            }
+            _ => panic!("expected Downgrade"),
+        }
+    }
+
     // ---------- TrustExcludeRules parsing ----------
 
     #[test]

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -39,6 +39,7 @@ static ROOT_TOOL: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 fn build_decision(manifest: &PackageJson, name: &str, version: &str) -> AllowDecision {

--- a/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
@@ -38,6 +38,7 @@ static MYTOOL: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 #[test]

--- a/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
+++ b/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
@@ -53,6 +53,7 @@ static MYTOOL_NO_BRANDED_ENV: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 fn ctx<'a>(

--- a/vendor/aube/crates/aube-util/src/identity.rs
+++ b/vendor/aube/crates/aube-util/src/identity.rs
@@ -325,6 +325,26 @@ pub struct Embedder {
     /// instant warm exit (nub) sets this `false`; standalone aube keeps `true`
     /// so its online-install behavior is byte-for-byte unchanged. Embedder-fixed.
     pub warm_trust_revalidate: bool,
+    /// Embedder-fixed default (in **minutes**) for `trustPolicyIgnoreAfter`
+    /// when the user leaves that setting unset: a picked version whose registry
+    /// publish time is older than this window is exempted from the `trustPolicy`
+    /// downgrade check. `None` (aube's default) leaves the knob unset so every
+    /// version is checked — byte-for-byte standalone behavior. An explicit user
+    /// `trustPolicyIgnoreAfter` (including `0`, which re-enables the full check)
+    /// always wins over this default via `.or()` at the resolve site.
+    ///
+    /// A finite window is the principled fix for the aged-backport false
+    /// positive (a legitimate maintenance release on an old major, published
+    /// later in wall-clock than a newer major that adopted OIDC provenance,
+    /// trips the date-ordered downgrade scan): once such a version has sat
+    /// un-yanked past the window it is overwhelmingly legitimate, so it clears
+    /// the check, while a freshly published weak-evidence version is still
+    /// scanned against the full history. The attack this guards is
+    /// time-sensitive — compromised publishes are detected and yanked within
+    /// hours-to-days — so the window trades no meaningful protection for the FP
+    /// relief, the same quarantine logic as `minimumReleaseAge`, mirrored.
+    /// Embedder-fixed: the host's supply-chain posture, not a per-project knob.
+    pub trust_policy_ignore_after_default: Option<u64>,
 }
 
 /// Standalone aube's embedder profile. Reproduces every hardcoded branding
@@ -371,6 +391,9 @@ pub const AUBE: Embedder = Embedder {
     // Standalone aube re-validates the trust posture on every online install,
     // even a fully-satisfied no-op, so its online-install behavior is unchanged.
     warm_trust_revalidate: true,
+    // Standalone aube leaves `trustPolicyIgnoreAfter` unset, so the downgrade
+    // check applies to every version — behavior byte-for-byte unchanged.
+    trust_policy_ignore_after_default: None,
 };
 
 static ACTIVE: OnceLock<&'static Embedder> = OnceLock::new();
@@ -545,6 +568,7 @@ mod tests {
         assert_eq!(id.config_env_prefix, Some("AUBE"));
         assert_eq!(id.primer_ttl, None);
         assert!(!id.tty_progress);
+        assert_eq!(id.trust_policy_ignore_after_default, None);
     }
 
     /// Under the default (AUBE) profile the source-branding helpers reproduce

--- a/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -51,6 +51,7 @@ static NUBLIKE: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 /// Restore the previous value of an env var around a closure. Integration-test

--- a/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -47,6 +47,7 @@ static NUBLIKE: Embedder = Embedder {
     tty_progress: false,
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
+    trust_policy_ignore_after_default: None,
 };
 
 #[test]

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -454,7 +454,12 @@ pub(crate) fn resolve_dependency_policy(
     }
     policy.trust_policy_exclude =
         aube_resolver::TrustExcludeRules::with_defaults_and_user_rules(user_rules);
-    policy.trust_policy_ignore_after = aube_settings::resolved::trust_policy_ignore_after(ctx);
+    // An explicit user `trustPolicyIgnoreAfter` wins (including `0`, which
+    // re-enables the full check); when unset, fall back to the embedder-fixed
+    // default — `None` for standalone aube (unchanged: check every version), a
+    // finite window for nub (see `Embedder::trust_policy_ignore_after_default`).
+    policy.trust_policy_ignore_after = aube_settings::resolved::trust_policy_ignore_after(ctx)
+        .or(aube_util::embedder().trust_policy_ignore_after_default);
     policy.block_exotic_subdeps = aube_settings::resolved::block_exotic_subdeps(ctx);
 
     policy


### PR DESCRIPTION
Fixes #270.

`nubx @modelcontextprotocol/inspector` fails `ERR_NUB_TRUST_DOWNGRADE`: the trust-downgrade check fires on transitive `tailwind-merge@2.6.1`, a 2.x backport published after 3.x adopted a trusted publisher, so the date-ordered scan fails the pick.

This tunes the default of the existing `trustPolicyIgnoreAfter` knob, not the algorithm: a new embedder-fixed `Embedder::trust_policy_ignore_after_default` sets nub to a 14-day window (standalone aube stays `None`). A version aged past the window is exempt; a fresh downgrade is still scanned in full, so a stolen-token publish into an old line is still caught. `trustPolicyIgnoreAfter=0` restores the full check.