### PR TITLE
feat(run): verify dependency freshness before run/exec/file/nubx (#252)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,6 +2622,7 @@ dependencies = [
  "libc",
  "miette",
  "mimalloc",
+ "node-semver",
  "nub-core",
  "num_cpus",
  "rayon",

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -78,6 +78,11 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 rustc-hash.workspace = true
 semver = "1"
+# npm-semantics range satisfaction for the pre-run dependency-freshness gate
+# (verify_deps.rs). The Cargo `semver` crate above uses Cargo semantics, which
+# don't match npm ranges (`x`-ranges, `||` unions, hyphen ranges); node-semver
+# is the same resolver aube already uses.
+node-semver = "2"
 # pnpm-workspace.yaml read + regeneration for `nub pm use nub` / `use pnpm`
 # (pm_engine/use_nub.rs). serde_yaml is archived/unmaintained; serde_yaml_ng
 # is the maintained, API-compatible fork, aliased as `serde_yaml` so the

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -498,6 +498,11 @@ pub enum Command {
         #[arg(long)]
         if_present: bool,
 
+        /// Skip the pre-run dependency-freshness check for this invocation
+        /// (`--no-install` is the alias).
+        #[arg(long = "no-check", visible_alias = "no-install")]
+        no_check: bool,
+
         /// Remaining arguments forwarded to the script.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -557,6 +562,12 @@ pub enum Command {
         /// Run the bin in all packages concurrently with no topological ordering.
         #[arg(long)]
         parallel: bool,
+
+        /// Skip the pre-run dependency-freshness check for this invocation.
+        /// (Spelled `--no-check` — `--no-install` is reserved for the npx
+        /// fetch semantics on `nubx`, so `nub exec` does not accept it.)
+        #[arg(long = "no-check")]
+        no_check: bool,
 
         /// Remaining arguments forwarded to the binary.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -640,6 +651,12 @@ pub enum Command {
         /// Accepted for `npx` parity. Removed from npm v9+; nubx warns and ignores it.
         #[arg(long = "ignore-existing")]
         ignore_existing: bool,
+
+        /// Skip the pre-run dependency-freshness check for this invocation.
+        /// (Spelled `--no-check` here — `--no-install` already means "don't
+        /// fetch a missing tool" on this surface.)
+        #[arg(long = "no-check")]
+        no_check: bool,
 
         /// Remaining arguments forwarded to the binary.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -1223,6 +1240,11 @@ fn run_nub() -> Result<i32> {
             }
             "--watch" => watch = true,
             "--node" => compat = true,
+            // The pre-run dependency-freshness opt-out on the top-level file
+            // runner (`nub --no-check foo.ts`). Consumed here so it never reaches
+            // Node as an unknown flag; after the entry point it forwards to the
+            // script (the three-position rule). `--no-install` is the alias.
+            "--no-check" | "--no-install" => crate::verify_deps::disable(),
             "--silent" | "-s" => silent = true,
             // `--verbose` is the user-facing spelling; `--show-warnings` is its
             // legacy twin. Both raise nub's diagnostic verbosity (e.g. the full
@@ -1863,6 +1885,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             reporter_hide_prefix,
             shell_emulator,
             if_present,
+            no_check,
             ignore_scripts,
             script_shell,
             aggregate_output,
@@ -1870,6 +1893,9 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             mut args,
         }) => {
             args.extend(suffix);
+            if no_check {
+                crate::verify_deps::disable();
+            }
             // `--reporter`: `silent` is `-s`; `ndjson` switches every output site to
             // machine JSON (set the global once, read at each emission site).
             match reporter {
@@ -1945,9 +1971,13 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             fail_if_no_match,
             workspace_concurrency,
             parallel,
+            no_check,
             mut args,
         }) => {
             args.extend(suffix);
+            if no_check {
+                crate::verify_deps::disable();
+            }
             // `--workspace <name>` desugars to a name filter, exactly as on `run`.
             filter.extend(workspace);
             // `--include-workspace-root`/`--parallel` imply a workspace run even
@@ -2011,9 +2041,13 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             quiet,
             yes,
             ignore_existing,
+            no_check,
             mut args,
         }) => {
             args.extend(suffix);
+            if no_check {
+                crate::verify_deps::disable();
+            }
             filter.extend(workspace);
             let recursive = recursive || parallel || include_workspace_root;
             let workspace_run = recursive || !filter.is_empty() || parallel;
@@ -2416,6 +2450,13 @@ fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path, exec_ua: bool
     // this path (pin resolution, .env, PnP), so the run silently drops the
     // project context with no diagnostic. Surface the coded cause up front.
     check_manifest_json(cwd)?;
+    // Pre-run dependency-freshness gate (#252). Fires for `nub <file>`, the
+    // hijack-descendant `node`, and node-bin launches (which reach here via
+    // `launch_bin`); the once-per-process latch keeps a bin launch that already
+    // checked at the exec entry from re-checking. Skipped in compat mode.
+    if let Some(code) = crate::verify_deps::gate(cwd, compat_mode) {
+        return Ok(code);
+    }
     // Fire point: `nub <file>` (and the hijack-descendant `node`, which routes
     // through run_as_node → run_file). A pinned-but-uncached version is downloaded
     // + installed from nodejs.org here, uv-style. (`nub run`/`nub exec` keep plain
@@ -2459,6 +2500,16 @@ fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path, exec_ua: bool
         env_vars.insert(
             "npm_config_user_agent".to_string(),
             exec_user_agent(cwd, &node.version.to_string()),
+        );
+    }
+
+    // Dep-check dedup across processes (#252): once this process owns the
+    // decision, mark the spawned child so a hijack-descendant `node` (a worker a
+    // test runner forks) skips re-checking and the warning appears at most once.
+    if crate::verify_deps::should_propagate_marker() {
+        env_vars.insert(
+            crate::verify_deps::CHECKED_MARKER.to_string(),
+            "1".to_string(),
         );
     }
 
@@ -2518,6 +2569,14 @@ fn run_script(
         }
         return Ok(0);
     };
+
+    // Pre-run dependency-freshness gate (#252): warn (or, per policy, abort)
+    // when node_modules looks stale, so a missing dep surfaces as a nub message
+    // rather than a raw `foo: command not found`. Cheap and once-per-process;
+    // skipped in compat mode and inside a running script (see `verify_deps`).
+    if let Some(code) = crate::verify_deps::gate(&project.root, compat_mode) {
+        return Ok(code);
+    }
 
     // Workspace-wide execution: -r, --filter, or --parallel.
     if ws.recursive || !ws.filter.is_empty() || ws.parallel {
@@ -3351,6 +3410,14 @@ fn run_single_script(
     args: &[String],
     exec: &ScriptExecOpts,
 ) -> Result<i32> {
+    // Pre-run dependency-freshness gate (#252) for direct callers that bypass
+    // `run_script` — the `nubx`/`nub x` script tier (`nubx_resolve_local`). A
+    // `nub run` already gated at `run_script`, and a workspace fan-out gated at
+    // its root, so the once-per-process latch makes this a no-op there.
+    if let Some(code) = crate::verify_deps::gate(&project.root, compat_mode) {
+        return Ok(code);
+    }
+
     // Run pre-script if it exists (unless --ignore-scripts).
     if !exec.ignore_scripts {
         let pre_name = format!("pre{script}");
@@ -4506,6 +4573,14 @@ fn run_exec_with_dlx(
 
     if !force_fetch {
         if let Some(bin_path) = nub_core::workspace::scripts::find_bin(bin, &cwd) {
+            // A local bin is about to run: gate on dependency freshness (#252).
+            // Only here — never on the registry-fetch fallback below, where the
+            // whole point is an ad-hoc tool the project need not have installed.
+            // A node bin re-enters `run_file_in_dir`, but the once-per-process
+            // latch keeps that from re-checking.
+            if let Some(code) = crate::verify_deps::gate(&cwd, compat_mode) {
+                return Ok(code);
+            }
             return launch_bin(&bin_path, args, compat_mode, &cwd);
         }
 
@@ -4657,6 +4732,11 @@ fn launch_bin(bin_path: &Path, args: &[String], compat_mode: bool, cwd: &Path) -
     apply_env_file_vars(&mut cmd);
     if !compat_mode {
         apply_exec_augmentation(&mut cmd, cwd);
+    }
+    // Dep-check dedup (#252): a non-node bin still gets nub's augmentation env, so
+    // a `node` it spawns re-enters nub — mark it so the warning isn't repeated.
+    if crate::verify_deps::should_propagate_marker() {
+        cmd.env(crate::verify_deps::CHECKED_MARKER, "1");
     }
     let status = cmd.status()?;
     Ok(nub_core::node::spawn::exit_code_from_status(&status))

--- a/crates/nub-cli/src/main.rs
+++ b/crates/nub-cli/src/main.rs
@@ -10,6 +10,7 @@ mod nubx_consent;
 mod nubx_resolve;
 mod pm_engine;
 mod self_shim;
+mod verify_deps;
 
 use anyhow::Result;
 

--- a/crates/nub-cli/src/pm_engine/unsupported_config.rs
+++ b/crates/nub-cli/src/pm_engine/unsupported_config.rs
@@ -451,6 +451,13 @@ fn npmrc_value_in(paths: &[PathBuf], key: &str) -> Option<String> {
         .next_back()
 }
 
+/// Read a scalar `.npmrc` key across the project walk-up and, when
+/// `include_global`, the global `~/.npmrc`. The reusable entry for nub-behavior
+/// knobs read from the neutral `.npmrc` surface (the verify-deps policy).
+pub(crate) fn npmrc_scalar_value(root: &Path, key: &str, include_global: bool) -> Option<String> {
+    npmrc_value_in(&npmrc_paths_inner(root, include_global), key)
+}
+
 fn npmrc_bool_set_in(paths: &[PathBuf], key: &str) -> bool {
     npmrc_value_in(paths, key).is_some_and(|v| {
         let v = v.trim();

--- a/crates/nub-cli/src/verify_deps.rs
+++ b/crates/nub-cli/src/verify_deps.rs
@@ -1,0 +1,355 @@
+//! Pre-run dependency-freshness gate (issue #252).
+//!
+//! Before nub runs a script, a file, or a bin, it checks whether the project's
+//! installed `node_modules` looks stale relative to package.json, so a
+//! missing/stale tree surfaces as a clear nub warning instead of a raw
+//! `husky: command not found`. A single marker-free walk of the manifest's
+//! direct dependencies against the installed tree handles every incumbent (npm,
+//! pnpm, yarn-classic, bun, and nub's own installs) — no lockfile parse, so it's
+//! immune to cross-PM lockfile churn.
+//!
+//! Two invariants govern the design:
+//!
+//! - **Never false-warn.** Every uncertain case — yarn-PnP, an unrecognized
+//!   layout, a spec that isn't a semver range, a prerelease install, no manifest
+//!   — degrades to a SILENT skip. A missed warning is cheap; a wrong one erodes
+//!   trust (the maintainer's explicit concern).
+//! - **Fire at most once per user command.** A process latch stops nested
+//!   in-process entrypoints (`exec` → bin launch → file runner) from re-checking,
+//!   and the `npm_lifecycle_event` re-entry guard stops the inner `node`s a
+//!   running script spawns from re-checking (matching npm/pnpm).
+//!
+//! Policy lives in the neutral `.npmrc` key `verify-deps-before-run` (with the
+//! `NUB_VERIFY_DEPS_BEFORE_RUN` env override); nub's default is `warn`. That is a
+//! deliberate divergence from the vendored engine's `install` default, wired
+//! through nub's OWN resolution so standalone aube's default is untouched
+//! (fork-discipline).
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use nub_core::workspace::detect::Project;
+
+/// Explicit `--no-check` / `--no-install` opt-out, set once during arg dispatch.
+static DISABLED: AtomicBool = AtomicBool::new(false);
+/// Run the check at most once per process — nested in-process entrypoints
+/// (`exec` → bin launch → file runner) must not re-check the same tree.
+static CHECKED: AtomicBool = AtomicBool::new(false);
+
+/// Internal, inherited sentinel: once a nub run/file/exec entrypoint in this
+/// process TREE has decided the dep-check, descendants must not re-decide it.
+/// Set on the env of the child nub spawns (see [`should_propagate_marker`]);
+/// [`gate`] skips when it's present. This is what keeps a `nub <file>` / `nub
+/// exec` target that itself spawns `node` (test runners, workers) from
+/// re-entering nub through the PATH shim and repeating the warning. (`nub run`
+/// is already covered by `npm_lifecycle_event`, which its script child carries.)
+pub(crate) const CHECKED_MARKER: &str = "__NUB_DEPS_CHECKED";
+
+/// Disable the gate for this process (the `--no-check`/`--no-install` flag).
+pub(crate) fn disable() {
+    DISABLED.store(true, Ordering::Relaxed);
+}
+
+/// Whether the child nub spawns should inherit [`CHECKED_MARKER`] so it skips
+/// the check. True once this process has OWNED the decision — it ran the check
+/// (`CHECKED`), was told to skip it (`--no-check`), or is itself a marked
+/// descendant propagating the decision further down. Callers set the marker on
+/// the spawned child's env at the file/exec launch sites.
+pub(crate) fn should_propagate_marker() -> bool {
+    CHECKED.load(Ordering::Relaxed)
+        || DISABLED.load(Ordering::Relaxed)
+        || std::env::var_os(CHECKED_MARKER).is_some()
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Policy {
+    Off,
+    Warn,
+    Error,
+}
+
+/// The gate. Call at each execution entrypoint with the invocation's cwd and its
+/// compat bit. Returns `Some(exit_code)` when the run must ABORT (policy `error`
+/// on a stale tree), or `None` to proceed — a fresh/uncertain tree, an opt-out,
+/// or a non-fatal warning that has already been printed.
+pub(crate) fn gate(cwd: &Path, compat_mode: bool) -> Option<i32> {
+    // `--node` / `NODE_COMPAT` is the zero-augmentation contract; a staleness
+    // warning is nub being helpful, so compat mode skips it — and this keeps the
+    // file-runner hot path free when `--node` is passed.
+    if compat_mode {
+        return None;
+    }
+    if DISABLED.load(Ordering::Relaxed) {
+        return None;
+    }
+    // Cross-process re-entry guards — an ancestor already owns the decision:
+    //  - a nub run/file/exec ancestor set our own inherited marker, OR
+    //  - we're inside a running package script (`npm_lifecycle_event`, which the
+    //    script child of a `nub run` carries, matching npm/pnpm).
+    if std::env::var_os(CHECKED_MARKER).is_some()
+        || std::env::var_os("npm_lifecycle_event").is_some()
+    {
+        return None;
+    }
+    // Once per process: latch BEFORE the (I/O-touching) resolution so a second
+    // nested entrypoint is a cheap no-op.
+    if CHECKED.swap(true, Ordering::Relaxed) {
+        return None;
+    }
+
+    // No manifest here or above → nothing to verify (a bare `nub foo.ts` in a
+    // non-project dir stays on the fast path).
+    let project = nub_core::workspace::detect::detect_project(cwd)?;
+    let policy = resolve_policy(&project.root);
+    if policy == Policy::Off {
+        return None;
+    }
+
+    let reason = needs_install_reason(&project)?; // fresh / uncertain → proceed silently
+    // Defense-in-depth brand pass: the reason strings are nub-native today, but
+    // route them through the same rewrite all engine-adjacent output uses so no
+    // future engine-sourced token could ever leak here.
+    let reason = crate::pm_engine::present::rewrite(&reason);
+    match policy {
+        Policy::Warn => {
+            eprintln!("nub: dependencies may be out of date ({reason}). Run `nub install`.");
+            None
+        }
+        Policy::Error => {
+            eprintln!("nub: dependencies are out of date ({reason}). Run `nub install`.");
+            Some(1)
+        }
+        // Handled above; kept exhaustive.
+        Policy::Off => None,
+    }
+}
+
+/// Resolve the policy from nub's OWN surfaces: the `NUB_*` env override, then the
+/// neutral `.npmrc` key, else nub's `warn` default. Deliberately does NOT call
+/// the engine's `resolve_verify_deps_before_run` — that carries the engine's
+/// `install` default, and reusing it would either leak that default under nub or
+/// force a fork-side edit.
+fn resolve_policy(project_root: &Path) -> Policy {
+    if let Some(p) = std::env::var("NUB_VERIFY_DEPS_BEFORE_RUN")
+        .ok()
+        .and_then(|v| parse_policy(&v))
+    {
+        return p;
+    }
+    if let Some(p) = crate::pm_engine::unsupported_config::npmrc_scalar_value(
+        project_root,
+        "verify-deps-before-run",
+        true,
+    )
+    .and_then(|v| parse_policy(&v))
+    {
+        return p;
+    }
+    Policy::Warn
+}
+
+/// Map a config/env value to a policy. Unknown/empty → `None` (fall through to
+/// the next source, ultimately the `warn` default).
+///
+/// `install`/`true` map to `warn`: nub deliberately does NOT auto-install before
+/// a run — it will not reshape a tree another PM installed — so it warns instead.
+fn parse_policy(raw: &str) -> Option<Policy> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "off" | "false" | "0" | "no" | "none" | "skip" => Some(Policy::Off),
+        "warn" | "true" | "install" => Some(Policy::Warn),
+        "error" => Some(Policy::Error),
+        _ => None,
+    }
+}
+
+/// The staleness verdict for `project`: `Some(reason)` if the tree looks stale,
+/// `None` if it's fresh (or freshness can't be determined with confidence).
+///
+/// A single marker-free walk covers every incumbent — npm, pnpm, yarn-classic,
+/// bun, and nub's own installs alike. (An earlier design added a "Tier A" that
+/// reused the engine's exact `check_needs_install` when nub was the installing
+/// PM, but the engine resolves its state-marker path from install-time context
+/// the run path doesn't set up, so it resolved the wrong path and silently
+/// missed. The marker-free walk handles a nub-installed tree correctly on its
+/// own — verified end-to-end — so it's the uniform path, which also keeps the
+/// vendored engine untouched.)
+fn needs_install_reason(project: &Project) -> Option<String> {
+    // Yarn PnP has no `node_modules` — freshness would mean reconciling
+    // `.pnp.cjs`/`.pnp.data.json` against the lockfile, which this walk does not
+    // do. Degrade to a SILENT skip rather than false-warn "nothing installed".
+    if nub_core::pnp::detect(&project.root).is_some() {
+        return None;
+    }
+    installed_tree_reason(project)
+}
+
+/// One installed package's freshness-relevant fields.
+struct InstalledPkg {
+    /// `version` from the on-disk `package.json`, if it parsed.
+    version: Option<String>,
+}
+
+/// The marker-free walk. Compares the manifest's DIRECT dependencies against
+/// what's resolvable in the `node_modules` chain. Catches the fresh-clone case
+/// (nothing installed), a missing production dependency, and a version that no
+/// longer satisfies its declared range — without parsing any lockfile (so it's
+/// immune to cross-PM lockfile churn) and without ever false-warning on a
+/// `--prod` install.
+fn installed_tree_reason(project: &Project) -> Option<String> {
+    let deps = deps_map(&project.manifest, "dependencies");
+    let dev_deps = deps_map(&project.manifest, "devDependencies");
+    if deps.is_empty() && dev_deps.is_empty() {
+        return None; // nothing declared → nothing to verify
+    }
+
+    let resolved = |name: &str| resolve_installed_manifest(&project.root, name);
+
+    // "Nothing installed at all" — the fresh-clone case the issue reports. If
+    // NONE of the declared direct deps resolve in the node_modules chain, an
+    // install has not happened. This fires even for devDependency-only projects
+    // (husky, tsc, …), which a per-set walk would otherwise miss.
+    let any_present = deps
+        .iter()
+        .chain(dev_deps.iter())
+        .any(|(name, _)| resolved(name).is_some());
+    if !any_present {
+        return Some("dependencies are not installed".to_string());
+    }
+
+    // An install HAS happened (something resolved). Require every production
+    // dependency present + version-satisfying. For devDependencies, only flag a
+    // present-but-mismatched version — a devDep that is ABSENT here is tolerated,
+    // because a `--prod` / `--omit=dev` install legitimately omits them and
+    // warning would be a false positive.
+    for (name, spec) in &deps {
+        match resolved(name) {
+            None => return Some(format!("`{name}` is not installed")),
+            Some(installed) => {
+                if let Some(reason) = version_mismatch(name, spec, &installed) {
+                    return Some(reason);
+                }
+            }
+        }
+    }
+    for (name, spec) in &dev_deps {
+        if let Some(installed) = resolved(name)
+            && let Some(reason) = version_mismatch(name, spec, &installed)
+        {
+            return Some(reason);
+        }
+    }
+    None
+}
+
+/// Direct-dependency `(name, spec)` pairs from one manifest map. Non-string
+/// values are skipped — a malformed manifest is not something to guess about.
+fn deps_map(manifest: &serde_json::Value, key: &str) -> Vec<(String, String)> {
+    manifest
+        .get(key)
+        .and_then(|v| v.as_object())
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Resolve `<name>`'s INSTALLED package.json by walking the `node_modules` chain
+/// up from `start` — Node's own resolution — so a workspace member whose deps are
+/// hoisted to the root still resolves, and a pnpm symlink into `.pnpm/<name>@<v>`
+/// is followed transparently. `None` only when the package is absent from the
+/// whole chain; a present-but-unparseable manifest resolves to a version of
+/// `None` (its version check is skipped, never treated as missing).
+fn resolve_installed_manifest(start: &Path, name: &str) -> Option<InstalledPkg> {
+    let mut dir = Some(start);
+    while let Some(d) = dir {
+        let candidate = d.join("node_modules").join(name).join("package.json");
+        if candidate.is_file() {
+            let version = std::fs::read_to_string(&candidate)
+                .ok()
+                .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
+                .and_then(|j| j.get("version").and_then(|v| v.as_str()).map(String::from));
+            return Some(InstalledPkg { version });
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+/// Flag a present dependency whose installed version doesn't satisfy its declared
+/// range. Everything uncertain resolves to `None` (no warn):
+///
+/// - a spec that isn't a semver range (`workspace:`, `file:`, `link:`, `git:`, a
+///   URL, an `npm:` alias, a dist-tag) fails to parse as a range;
+/// - a prerelease install is intentional, and npm range semantics would
+///   spuriously reject it;
+/// - an unreadable installed version.
+fn version_mismatch(name: &str, spec: &str, installed: &InstalledPkg) -> Option<String> {
+    let range = node_semver::Range::parse(spec).ok()?;
+    let installed_ver = installed.version.as_deref()?;
+    let version = node_semver::Version::parse(installed_ver).ok()?;
+    if version.is_prerelease() {
+        return None;
+    }
+    if !version.satisfies(&range) {
+        return Some(format!(
+            "`{name}@{installed_ver}` does not satisfy `{spec}`"
+        ));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_the_canonical_policy_values() {
+        assert_eq!(parse_policy("warn"), Some(Policy::Warn));
+        assert_eq!(parse_policy("error"), Some(Policy::Error));
+        assert_eq!(parse_policy("off"), Some(Policy::Off));
+        assert_eq!(parse_policy("false"), Some(Policy::Off));
+        // `install` is recognized but mapped to `warn`: nub does not auto-install.
+        assert_eq!(parse_policy("install"), Some(Policy::Warn));
+        // Case/whitespace-insensitive; unknown falls through to the default.
+        assert_eq!(parse_policy("  ERROR "), Some(Policy::Error));
+        assert_eq!(parse_policy("nonsense"), None);
+        assert_eq!(parse_policy(""), None);
+    }
+
+    #[test]
+    fn version_mismatch_only_flags_a_clear_range_violation() {
+        let at = |v: &str| InstalledPkg {
+            version: Some(v.to_string()),
+        };
+        // Installed satisfies the declared range → no warning.
+        assert!(version_mismatch("foo", "^1.0.0", &at("1.4.2")).is_none());
+        // Installed violates a bumped range → warning (the manifest-ahead case).
+        assert!(version_mismatch("foo", "^2.0.0", &at("1.4.2")).is_some());
+        // A non-range protocol spec is never a version finding (presence-only).
+        assert!(version_mismatch("foo", "workspace:*", &at("1.0.0")).is_none());
+        assert!(version_mismatch("foo", "npm:bar@^1", &at("1.0.0")).is_none());
+        // A prerelease install is intentional — never flagged.
+        assert!(version_mismatch("foo", "^2.0.0", &at("1.0.0-beta.1")).is_none());
+        // No readable installed version → skip.
+        assert!(version_mismatch("foo", "^2.0.0", &InstalledPkg { version: None }).is_none());
+    }
+
+    #[test]
+    fn deps_map_skips_non_string_values() {
+        let manifest = serde_json::json!({
+            "dependencies": { "a": "^1.0.0", "b": { "nope": true }, "c": "2.0.0" }
+        });
+        let mut got = deps_map(&manifest, "dependencies");
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                ("a".to_string(), "^1.0.0".to_string()),
+                ("c".to_string(), "2.0.0".to_string()),
+            ]
+        );
+        assert!(deps_map(&manifest, "devDependencies").is_empty());
+    }
+}

--- a/crates/nub-cli/tests/verify_deps.rs
+++ b/crates/nub-cli/tests/verify_deps.rs
@@ -1,0 +1,300 @@
+//! Pre-run dependency-freshness gate (issue #252), end-to-end through the
+//! binary. The gate warns (or, per policy, aborts) before `nub run`/file/bin
+//! execution when `node_modules` looks stale, so a missing dep surfaces as a
+//! clear nub message instead of a raw `foo: command not found`.
+//!
+//! These fixtures are node-free: scripts are bare `echo`s and the installed
+//! trees are hand-built (a `node_modules/<dep>/package.json`), so the run path
+//! never needs a real Node or a network install — the gate reads the manifest
+//! and the tree directly.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/
+    path.push("nub");
+    path
+}
+
+fn tmp(tag: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nub-vdbr-{tag}-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+/// Hand-place an installed package: `node_modules/<name>/package.json` at
+/// `version`. Mirrors what any PM's flat/symlinked layout exposes for a read.
+fn install_pkg(root: &Path, name: &str, version: &str) {
+    write(
+        &root.join("node_modules").join(name).join("package.json"),
+        &format!(r#"{{"name":"{name}","version":"{version}"}}"#),
+    );
+}
+
+struct Output {
+    stdout: String,
+    stderr: String,
+    code: i32,
+}
+
+fn run(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(args)
+        .current_dir(dir)
+        .env("XDG_DATA_HOME", tmp("xdg-data"))
+        .env("XDG_CACHE_HOME", tmp("xdg-cache"));
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("failed to spawn nub");
+    Output {
+        stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
+const STALE: &str = "out of date";
+
+#[test]
+fn fresh_clone_warns_but_still_runs_the_script() {
+    // The reported bug: a fresh checkout with no `node_modules` and a devDep
+    // (husky/tsc) — warn, and still run (the warning is non-fatal by default).
+    let d = tmp("fresh");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"f","version":"1.0.0","scripts":{"build":"echo BUILD_RAN"},"devDependencies":{"typescript":"^5.0.0"}}"#,
+    );
+    let out = run(&d, &["run", "build"], &[]);
+    assert!(
+        out.stderr.contains(STALE),
+        "expected a warning: {}",
+        out.stderr
+    );
+    assert!(
+        out.stdout.contains("BUILD_RAN"),
+        "script must still run: {}",
+        out.stdout
+    );
+    assert_eq!(out.code, 0);
+}
+
+#[test]
+fn warm_tree_is_silent() {
+    let d = tmp("warm");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"w","version":"1.0.0","scripts":{"build":"echo OK"},"dependencies":{"lodash":"^4.0.0"}}"#,
+    );
+    install_pkg(&d, "lodash", "4.17.21"); // satisfies ^4.0.0
+    let out = run(&d, &["run", "build"], &[]);
+    assert!(
+        !out.stderr.contains(STALE),
+        "warm tree must not warn: {}",
+        out.stderr
+    );
+    assert!(out.stdout.contains("OK"));
+}
+
+#[test]
+fn version_drift_warns_and_names_the_dependency() {
+    // Installed version no longer satisfies a bumped manifest range.
+    let d = tmp("drift");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"d","version":"1.0.0","scripts":{"build":"echo OK"},"dependencies":{"lodash":"^5.0.0"}}"#,
+    );
+    install_pkg(&d, "lodash", "4.17.21"); // does NOT satisfy ^5.0.0
+    let out = run(&d, &["run", "build"], &[]);
+    assert!(out.stderr.contains(STALE), "{}", out.stderr);
+    assert!(
+        out.stderr.contains("lodash"),
+        "reason should name the dep: {}",
+        out.stderr
+    );
+}
+
+#[test]
+fn a_prod_install_with_devdeps_absent_is_not_flagged() {
+    // Production deps present, devDependencies absent — the shape a
+    // `--prod`/`--omit=dev` install leaves. Warning here would be a false
+    // positive, so an absent devDep is tolerated once anything is installed.
+    let d = tmp("prod");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"p","version":"1.0.0","scripts":{"build":"echo OK"},"dependencies":{"lodash":"^4.0.0"},"devDependencies":{"typescript":"^5.0.0"}}"#,
+    );
+    install_pkg(&d, "lodash", "4.17.21"); // prod present; typescript (dev) absent
+    let out = run(&d, &["run", "build"], &[]);
+    assert!(
+        !out.stderr.contains(STALE),
+        "prod install must not warn: {}",
+        out.stderr
+    );
+}
+
+#[test]
+fn no_check_flag_opts_out() {
+    let d = tmp("nocheck");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"n","version":"1.0.0","scripts":{"build":"echo OK"},"devDependencies":{"typescript":"^5.0.0"}}"#,
+    );
+    let out = run(&d, &["run", "--no-check", "build"], &[]);
+    assert!(
+        !out.stderr.contains(STALE),
+        "--no-check must silence: {}",
+        out.stderr
+    );
+    assert!(out.stdout.contains("OK"));
+}
+
+#[test]
+fn node_compat_env_skips_the_check() {
+    // `NODE_COMPAT=1` is the tree-wide zero-augmentation opt-out; the freshness
+    // check is augmentation, so it's skipped.
+    let d = tmp("compat");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"c","version":"1.0.0","scripts":{"build":"echo OK"},"devDependencies":{"typescript":"^5.0.0"}}"#,
+    );
+    let out = run(&d, &["run", "build"], &[("NODE_COMPAT", "1")]);
+    assert!(
+        !out.stderr.contains(STALE),
+        "compat mode must skip: {}",
+        out.stderr
+    );
+}
+
+#[test]
+fn npmrc_off_disables_the_check() {
+    let d = tmp("npmrcoff");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"o","version":"1.0.0","scripts":{"build":"echo OK"},"devDependencies":{"typescript":"^5.0.0"}}"#,
+    );
+    write(&d.join(".npmrc"), "verify-deps-before-run=off\n");
+    let out = run(&d, &["run", "build"], &[]);
+    assert!(
+        !out.stderr.contains(STALE),
+        "npmrc off must silence: {}",
+        out.stderr
+    );
+}
+
+#[test]
+fn npmrc_error_aborts_before_running() {
+    let d = tmp("npmrcerr");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"e","version":"1.0.0","scripts":{"build":"echo BUILD_RAN"},"devDependencies":{"typescript":"^5.0.0"}}"#,
+    );
+    write(&d.join(".npmrc"), "verify-deps-before-run=error\n");
+    let out = run(&d, &["run", "build"], &[]);
+    assert_eq!(
+        out.code, 1,
+        "error policy must abort non-zero: {:?}",
+        out.code
+    );
+    assert!(out.stderr.contains(STALE), "{}", out.stderr);
+    assert!(
+        !out.stdout.contains("BUILD_RAN"),
+        "script must NOT run: {}",
+        out.stdout
+    );
+}
+
+#[test]
+fn env_override_beats_npmrc() {
+    // `NUB_VERIFY_DEPS_BEFORE_RUN` wins over the `.npmrc` key.
+    let d = tmp("envwin");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"ev","version":"1.0.0","scripts":{"build":"echo OK"},"devDependencies":{"typescript":"^5.0.0"}}"#,
+    );
+    write(&d.join(".npmrc"), "verify-deps-before-run=error\n");
+    let out = run(
+        &d,
+        &["run", "build"],
+        &[("NUB_VERIFY_DEPS_BEFORE_RUN", "off")],
+    );
+    assert_eq!(
+        out.code, 0,
+        "env `off` must override npmrc `error`: {}",
+        out.stderr
+    );
+    assert!(!out.stderr.contains(STALE));
+}
+
+#[test]
+fn yarn_pnp_tree_is_silently_skipped() {
+    // A PnP project has no `node_modules`; the walk would read "nothing
+    // installed", so PnP degrades to a silent skip rather than false-warning.
+    let d = tmp("pnp");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"pnp","version":"1.0.0","scripts":{"build":"echo OK"},"dependencies":{"lodash":"^4.0.0"}}"#,
+    );
+    write(&d.join(".pnp.cjs"), "// pnp\n");
+    let out = run(&d, &["run", "build"], &[]);
+    assert!(
+        !out.stderr.contains(STALE),
+        "PnP must be silent: {}",
+        out.stderr
+    );
+    assert!(out.stdout.contains("OK"));
+}
+
+#[test]
+fn inside_a_running_script_the_gate_does_not_re_fire() {
+    // A script that itself invokes `nub`/`node` sets `npm_lifecycle_event`; the
+    // re-entry guard skips the check there so the run warns at most once.
+    let d = tmp("reentry");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"r","version":"1.0.0","scripts":{"build":"echo OK"},"devDependencies":{"typescript":"^5.0.0"}}"#,
+    );
+    let out = run(&d, &["run", "build"], &[("npm_lifecycle_event", "outer")]);
+    assert!(
+        !out.stderr.contains(STALE),
+        "re-entry must skip the check: {}",
+        out.stderr
+    );
+}
+
+#[test]
+fn an_inherited_checked_marker_skips_the_gate() {
+    // A `nub <file>`/`nub exec` target that spawns `node` re-enters nub through
+    // the PATH shim; nub sets the internal `__NUB_DEPS_CHECKED` marker on that
+    // child's env so it doesn't repeat the warning. This asserts the guard side:
+    // an inherited marker suppresses the check (the propagation side — that nub
+    // sets it — is covered by the ad-hoc node-spawning e2e).
+    let d = tmp("marker");
+    write(
+        &d.join("package.json"),
+        r#"{"name":"m","version":"1.0.0","scripts":{"build":"echo OK"},"devDependencies":{"typescript":"^5.0.0"}}"#,
+    );
+    let out = run(&d, &["run", "build"], &[("__NUB_DEPS_CHECKED", "1")]);
+    assert!(
+        !out.stderr.contains(STALE),
+        "an inherited __NUB_DEPS_CHECKED must skip the check: {}",
+        out.stderr
+    );
+}

--- a/site/content/docs/runner/run.mdx
+++ b/site/content/docs/runner/run.mdx
@@ -122,6 +122,32 @@ To skip the `pre` / `post` hooks (CI, or a security-conscious run), pass `--igno
 nub run --ignore-scripts build
 ```
 
+## Dependency freshness
+
+Before a script runs, Nub checks the installed `node_modules` against your `package.json`. When a dependency is missing or its installed version has drifted out of the declared range — the usual "fresh clone, forgot to install" case — Nub warns and still runs, so a stale tree surfaces as a clear message instead of a raw `husky: command not found`:
+
+```
+nub: dependencies may be out of date (`chalk` is not installed). Run `nub install`.
+```
+
+The check is fast and marker-free, and it works whatever installed the tree — npm, pnpm, Yarn, Bun, or Nub itself. It errs toward silence: an ambiguous tree (Yarn PnP, an unparseable version, or a production-only install with devDependencies deliberately omitted) never warns.
+
+Set the behavior with the `verify-deps-before-run` key in `.npmrc`. The values are `warn` (the default — warn, then run), `error` (print the message and refuse to run), and `off` (skip the check):
+
+```ini
+# .npmrc
+verify-deps-before-run = warn
+```
+
+The `NUB_VERIFY_DEPS_BEFORE_RUN` variable overrides the file for one shell, and `--no-check` (or `--no-install` on `nub run`) skips the check for a single invocation:
+
+```bash
+nub run --no-check build
+NUB_VERIFY_DEPS_BEFORE_RUN=off nub run build
+```
+
+Nub does not install on your behalf here — `install` is accepted as a value but behaves like `warn`, since Nub won't reshape a tree another package manager set up. Run `nub install` when you see the warning. The check also applies to `nub <file>`, `nub exec`, and `nubx`, and is skipped in [`--node` / compat mode](#--node) and inside an already-running script (so a script that spawns `node` doesn't re-check).
+
 ## The `npm_*` environment
 
 Nub populates the child process with the full npm-compatible environment, so scripts and tooling that read `npm_*` variables behave exactly as they do under `npm run`. Locally installed CLIs are on `PATH` via the `node_modules/.bin` chain, so you can call them by bare name.


### PR DESCRIPTION
Closes #252.

`nub run <script>` (and `nub <file>`, `nub exec`, `nubx`) now checks the installed `node_modules` against `package.json` before running, so a missing or drifted dependency surfaces as a clear message instead of a raw `husky: command not found`:

```
nub: dependencies may be out of date (`chalk` is not installed). Run `nub install`.
```

## Behavior

A single marker-free walk of the manifest's direct dependencies against the `node_modules` chain — no lockfile is parsed, so it's immune to cross-PM lockfile churn, and it works whatever installed the tree (npm, pnpm, yarn-classic, bun, or nub). It errs toward silence: Yarn PnP, a spec that isn't a semver range, a prerelease install, or a production-only install with devDependencies omitted never warns.

- Default is `warn` (warn, then run). Set `verify-deps-before-run` in `.npmrc` to `error` (refuse to run) or `off`. `NUB_VERIFY_DEPS_BEFORE_RUN` overrides per shell; `--no-check` (or `--no-install` on `nub run`) skips per invocation.
- Policy is resolved by nub's own path, so `vendor/aube` is unchanged and standalone aube's default is untouched.
- The check fires once per command: a process latch, the `npm_lifecycle_event` re-entry guard, and an inherited internal marker keep a program that spawns `node` from repeating the warning.
- nub does not auto-install — `install` is accepted as a value but treated as `warn`, since nub won't reshape a tree another package manager set up.

## Tests

Unit tests (policy parsing, range satisfaction, dep-map) plus 12 integration tests: fresh-clone warn, warm silent, version drift, production-install safety, PnP skip, `--no-check`, compat-mode skip, `.npmrc` off/error, env override, lifecycle re-entry, inherited marker.

Docs: `site/content/docs/runner/run.mdx`.

https://claude.ai/code/session_01Xuh9u8b93eMNu53fTQTWX7
