### PR TITLE
fix(pm): auto-persist minimumReleaseAgeExclude on loose-mode fallback (#262)

### DIFF
--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -360,11 +360,13 @@ fn run_add(typed: &str, args: &[String]) -> Result<i32> {
             &yarn_remedy("add", &verb.packages),
         ));
     }
+    super::min_release_age::arm();
     let code = finish_quieted(
         &globals.output,
         &session,
         aube::commands::add::run(verb, globals.effective_filter()),
     )?;
+    super::min_release_age::persist(&session.cwd, code == 0, &globals.output);
     stamp_if_virgin(&session, code);
     Ok(code)
 }
@@ -408,11 +410,13 @@ fn run_update(typed: &str, args: &[String]) -> Result<i32> {
             &yarn_remedy("upgrade", &verb.packages),
         ));
     }
+    super::min_release_age::arm();
     let code = finish_code_quieted(
         &globals.output,
         &session,
         aube::commands::update::run(verb, globals.effective_filter()),
     )?;
+    super::min_release_age::persist(&session.cwd, code == 0, &globals.output);
     stamp_if_virgin(&session, code);
     Ok(code)
 }
@@ -1056,7 +1060,9 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
         opts.mode = FrozenMode::Frozen;
     }
 
+    super::min_release_age::arm();
     let code = run_engine(&session, opts, yarn, &flags.output)?;
+    super::min_release_age::persist(&session.cwd, code == 0, &flags.output);
     // Virgin install only: stamp a caret RANGE into `devEngines.packageManager`
     // so the project advertises nub the standard, cross-tool way WITHOUT locking
     // itself to one exact nub version. nub's canonical lockfile is deliberately

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -433,7 +433,10 @@ fn run_dedupe(typed: &str, args: &[String]) -> Result<i32> {
             "yarn dedupe",
         ));
     }
-    finish_quieted(&globals.output, &session, aube::commands::dedupe::run(verb))
+    super::min_release_age::arm();
+    let code = finish_quieted(&globals.output, &session, aube::commands::dedupe::run(verb))?;
+    super::min_release_age::persist(&session.cwd, code == 0, &globals.output);
+    Ok(code)
 }
 
 fn run_prune(typed: &str, args: &[String]) -> Result<i32> {

--- a/crates/nub-cli/src/pm_engine/min_release_age.rs
+++ b/crates/nub-cli/src/pm_engine/min_release_age.rs
@@ -8,37 +8,48 @@
 //! never recorded the exclude, so a `nub install`/`add`/`update` produced a
 //! lockfile pnpm later rejected with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`
 //! ([#262](https://github.com/nubjs/nub/issues/262)). This module closes that
-//! gap: the resolver surfaces each immature fallback pick (armed via
-//! [`arm`]), and after a successful mutating install nub appends the packages
-//! to `minimumReleaseAgeExclude` in the surface the project's config identity
+//! gap: the resolver surfaces each immature fallback pick (armed via [`arm`]),
+//! and after a successful mutating install nub records the packages in
+//! `minimumReleaseAgeExclude` in the surface the project's config identity
 //! dictates.
 //!
-//! Write target — the same yaml-if-present-else-fallback rule aube's own
-//! `config_write_target` uses, adapted to where `minimumReleaseAgeExclude` is
-//! read from (`.npmrc` / the workspace yaml, never the manifest namespace):
+//! ## Write target
 //!
-//! - a pnpm-compat project with a `pnpm-workspace.yaml` → the YAML sequence
-//!   there. pnpm 10 and 11 both read it (and it's pnpm 11's own auto-persist
-//!   home). [`workspace_yaml_existing`] is already gated on the
-//!   `read_branded_pnpm_config` posture, so a nub-identity project's stray
-//!   `pnpm-workspace.yaml` is never chosen.
-//! - everything else (nub identity, a pnpm project with no workspace yaml,
-//!   npm/yarn/bun compat) → the project `.npmrc`, comma-separated. This is the
-//!   neutral surface nub already reads `minimumReleaseAge*` from, so nub reads
-//!   back exactly what it wrote; it is brand-clean (`.npmrc` is the npm-shared
-//!   config, and the key is an unbranded setting name, not another PM's
-//!   namespaced field).
+//! `minimumReleaseAgeExclude` is a pnpm *workspace-config-file* setting — pnpm
+//! reads it ONLY from `pnpm-workspace.yaml`, never from `.npmrc` (it is in
+//! pnpm's `configFileKey` set; verified against pnpm 11's config reader, where
+//! an `.npmrc` `[]` value for a sibling policy key resolves to `undefined`). So
+//! the target is chosen by who will re-read the lockfile:
+//!
+//! - **A pnpm-compat project** (pnpm is the incumbent — an existing
+//!   `pnpm-workspace.yaml`, or a `pnpm-lock.yaml` nub round-trips) → the
+//!   `pnpm-workspace.yaml` sequence, created if absent. This is the only place
+//!   pnpm reads the setting and where pnpm's own auto-persist writes it. The
+//!   choice is gated on the `read_branded_pnpm_config` posture, so a nub-identity
+//!   or npm/yarn/bun project's stray `pnpm-workspace.yaml` is never chosen and no
+//!   file is created for a truly-fresh project (nothing re-reads its lockfile as
+//!   pnpm).
+//! - **Otherwise** (nub identity, npm/yarn/bun compat, fresh) → the project
+//!   `.npmrc`, comma-separated — the neutral surface nub itself reads
+//!   `minimumReleaseAge*` from, so nub reads back exactly what it wrote. No pnpm
+//!   re-reads these projects' lockfiles, so pnpm's `.npmrc` blind spot is moot.
+//!   Brand-clean: `.npmrc` is the npm-shared config and the key is an unbranded
+//!   setting name.
+//!
+//! Entries are written in pnpm's canonical per-package form (`name@v1 || v2`,
+//! merged with what's already recorded), matching pnpm's own auto-persist output
+//! and avoiding the pnpm edge where separate exact-version entries for one
+//! package were not all honored.
 //!
 //! Strict mode (`minimumReleaseAgeStrict=true`) never reaches here: the resolver
-//! hard-aborts on `AgeGated` before returning a fallback pick, so nothing is
-//! recorded.
+//! hard-aborts on `AgeGated` before returning a fallback pick.
 
 use super::output::OutputFlags;
-use aube_manifest::workspace::{add_to_workspace_yaml_string_list, workspace_yaml_existing};
-use std::path::Path;
+use aube_manifest::workspace::{
+    read_workspace_yaml_string_list, set_workspace_yaml_string_list, workspace_yaml_existing,
+};
+use std::path::{Path, PathBuf};
 
-/// The setting key, in both its `.npmrc`/manifest spelling and its resolver
-/// exclude-list semantics.
 const EXCLUDE_KEY: &str = "minimumReleaseAgeExclude";
 
 /// Arm the resolver's age-gate fallback sink for the upcoming resolve. Called
@@ -48,49 +59,47 @@ pub(crate) fn arm() {
 }
 
 /// Drain the resolver's immature fallback picks and, on a successful mutating
-/// install, append them to `minimumReleaseAgeExclude`. Always drains the sink
+/// install, record them in `minimumReleaseAgeExclude`. Always drains the sink
 /// (even on failure or when disarmed) so nothing leaks into a later in-process
 /// command. `success` gates the write to a completed install; `output` gates
-/// the notice on `--silent`.
+/// the notice on `--silent` (the write itself is not gated).
 pub(crate) fn persist(cwd: &Path, success: bool, output: &OutputFlags) {
     let picks = aube_util::take_age_gated_fallback_picks();
     if !success || picks.is_empty() {
         return;
     }
 
-    // `name@version` exact-version entries, in first-seen order, deduped. The
-    // resolver only records a pick that wasn't already age-exempt, so a pick is
-    // never a duplicate of an existing exclude entry — dedup here only collapses
-    // the same version recorded twice within one resolve.
-    let mut entries: Vec<String> = Vec::with_capacity(picks.len());
+    // `name@version` specs in first-seen order, deduped. The resolver only
+    // records a pick that wasn't already age-exempt, so these are genuinely new.
+    let mut new_specs: Vec<String> = Vec::with_capacity(picks.len());
     for (name, version) in &picks {
-        let entry = format!("{name}@{version}");
-        if !entries.contains(&entry) {
-            entries.push(entry);
+        let spec = format!("{name}@{version}");
+        if !new_specs.contains(&spec) {
+            new_specs.push(spec);
         }
     }
 
-    let (target, added) = match write_excludes(cwd, &entries) {
-        Ok(result) => result,
+    match record(cwd, &new_specs) {
+        Ok((target, changed)) => {
+            if changed && !output.is_silent() {
+                emit_notice(&target, &new_specs);
+            }
+        }
         Err(err) => {
+            // The install itself succeeded; a config-write failure is surfaced
+            // (not silently) with the manual remedy, but must not fail the run.
             super::present::warn(&format!(
-                "warn: installed {n} package(s) newer than minimumReleaseAge but could not \
-                 record them in {EXCLUDE_KEY} ({err}); add {list} manually, or pnpm may reject \
-                 this lockfile.",
-                n = entries.len(),
-                list = entries.join(", "),
+                "warn: installed {n} package(s) newer than minimumReleaseAge but could not record \
+                 them in {EXCLUDE_KEY} ({err}); add {list} manually, or pnpm may reject this \
+                 lockfile.",
+                n = new_specs.len(),
+                list = new_specs.join(", "),
             ));
-            return;
         }
-    };
-
-    if added == 0 || output.is_silent() {
-        return;
     }
-    emit_notice(&target, &entries);
 }
 
-/// Where the exclude entries were persisted, for the user-facing notice.
+/// Where the exclude entries were persisted, for the notice.
 enum Target {
     WorkspaceYaml(String),
     Npmrc,
@@ -105,61 +114,156 @@ impl Target {
     }
 }
 
-/// Route to the config surface and append `entries`, returning the target and
-/// how many were newly written (0 = all already present).
-fn write_excludes(cwd: &Path, entries: &[String]) -> anyhow::Result<(Target, usize)> {
-    match workspace_yaml_existing(cwd) {
-        Some(path) => {
-            let added = add_to_workspace_yaml_string_list(&path, EXCLUDE_KEY, entries)
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
+/// Route to the config surface, merge `new_specs` with what's already recorded
+/// into pnpm's canonical per-package form, and write the result. Returns the
+/// target and whether the file changed.
+fn record(cwd: &Path, new_specs: &[String]) -> anyhow::Result<(Target, bool)> {
+    match resolve_target(cwd) {
+        WriteTarget::WorkspaceYaml(path) => {
+            let existing = read_workspace_yaml_string_list(&path, EXCLUDE_KEY);
+            let merged = merge_package_version_specs(&existing, new_specs);
+            let changed = merged != merge_package_version_specs(&existing, &[]);
+            if changed {
+                set_workspace_yaml_string_list(&path, EXCLUDE_KEY, &merged)
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+            }
             let name = path
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("pnpm-workspace.yaml")
                 .to_string();
-            Ok((Target::WorkspaceYaml(name), added))
+            Ok((Target::WorkspaceYaml(name), changed))
         }
-        None => {
-            let added = append_npmrc(cwd, entries)?;
-            Ok((Target::Npmrc, added))
+        WriteTarget::Npmrc => {
+            let changed = write_npmrc(cwd, new_specs)?;
+            Ok((Target::Npmrc, changed))
         }
     }
 }
 
-/// Merge `entries` into the project `.npmrc`'s comma-separated
-/// `minimumReleaseAgeExclude` key, preserving the rest of the file. Returns how
-/// many were newly added.
-fn append_npmrc(cwd: &Path, entries: &[String]) -> anyhow::Result<usize> {
+enum WriteTarget {
+    WorkspaceYaml(PathBuf),
+    Npmrc,
+}
+
+/// Pick the config file to write. See the module docs for the rule.
+fn resolve_target(cwd: &Path) -> WriteTarget {
+    if let Some(path) = workspace_yaml_existing(cwd) {
+        return WriteTarget::WorkspaceYaml(path);
+    }
+    // pnpm is the incumbent (nub round-trips its lockfile) but keeps no
+    // workspace yaml yet: create one, the only surface pnpm reads the setting
+    // from. Gated on the pnpm-compat posture so a nub-identity / npm / yarn /
+    // bun project (or a fresh one) is never handed a pnpm-workspace.yaml.
+    if aube_util::engine_context().read_branded_pnpm_config && cwd.join("pnpm-lock.yaml").is_file()
+    {
+        return WriteTarget::WorkspaceYaml(cwd.join("pnpm-workspace.yaml"));
+    }
+    WriteTarget::Npmrc
+}
+
+/// Merge the project `.npmrc`'s comma-separated `minimumReleaseAgeExclude` with
+/// `new_specs` into the canonical per-package form, preserving the rest of the
+/// file. Returns whether the file changed.
+fn write_npmrc(cwd: &Path, new_specs: &[String]) -> anyhow::Result<bool> {
     use aube::commands::npmrc::NpmrcEdit;
     let path = cwd.join(".npmrc");
     let mut edit = NpmrcEdit::load(&path).map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    // Existing value is last-write-wins at read time, so merge into the last
-    // occurrence's list and rewrite a single canonical key.
-    let mut list: Vec<String> = edit
+    // Existing value is last-write-wins at read time; merge into the last
+    // occurrence and rewrite a single canonical key.
+    let existing: Vec<String> = edit
         .entries()
         .into_iter()
         .rfind(|(k, _)| k == EXCLUDE_KEY)
         .map(|(_, v)| parse_comma_list(&v))
         .unwrap_or_default();
-
-    let mut added = 0usize;
-    for entry in entries {
-        if !list.iter().any(|e| e == entry) {
-            list.push(entry.clone());
-            added += 1;
-        }
+    let merged = merge_package_version_specs(&existing, new_specs);
+    if merged == merge_package_version_specs(&existing, &[]) {
+        return Ok(false);
     }
-    if added == 0 {
-        return Ok(0);
-    }
-    edit.set(EXCLUDE_KEY, &list.join(","));
+    edit.set(EXCLUDE_KEY, &merged.join(","));
     edit.save(&path).map_err(|e| anyhow::anyhow!("{e}"))?;
-    Ok(added)
+    Ok(true)
 }
 
-/// Split a `.npmrc` list value on commas, trimming and dropping empties. Mirrors
-/// how the engine reads a `list<string>` setting from `.npmrc`.
+/// Merge `existing` exclude specs with `additions` into pnpm's canonical
+/// per-package form: one entry per package; a bare name (no version) excludes
+/// every version and absorbs any version-specific specs; otherwise the exact
+/// versions are deduped and joined with ` || `. Packages keep first-seen order.
+/// A faithful port of pnpm's `mergePackageVersionSpecs`
+/// (`config/version-policy`), minus the semver sort (a union is order-agnostic
+/// for matching).
+fn merge_package_version_specs(existing: &[String], additions: &[String]) -> Vec<String> {
+    // `None` for a package means "bare name" (all versions excluded).
+    let mut order: Vec<String> = Vec::new();
+    let mut by_pkg: std::collections::HashMap<String, Option<Vec<String>>> =
+        std::collections::HashMap::new();
+
+    for spec in existing.iter().chain(additions.iter()) {
+        let (name, versions) = parse_spec(spec);
+        match by_pkg.get_mut(&name) {
+            None => {
+                order.push(name.clone());
+                by_pkg.insert(
+                    name,
+                    if versions.is_empty() {
+                        None
+                    } else {
+                        Some(versions)
+                    },
+                );
+            }
+            Some(slot) => {
+                if versions.is_empty() {
+                    // Bare name excludes every version — absorbs the rest.
+                    *slot = None;
+                } else if let Some(vers) = slot.as_mut() {
+                    for v in versions {
+                        if !vers.contains(&v) {
+                            vers.push(v);
+                        }
+                    }
+                }
+                // else the slot is already `None` (all versions): nothing to do.
+            }
+        }
+    }
+
+    order
+        .into_iter()
+        .map(|name| match by_pkg.remove(&name).flatten() {
+            None => name,
+            Some(vers) => format!("{name}@{}", vers.join(" || ")),
+        })
+        .collect()
+}
+
+/// Split a `name@version-union` spec into `(package_name, versions)`. A spec
+/// with no version tail (a bare name or `*` glob) yields an empty version list.
+/// Scoped names (`@scope/name`) keep their leading `@`.
+fn parse_spec(spec: &str) -> (String, Vec<String>) {
+    let at = if let Some(stripped) = spec.strip_prefix('@') {
+        stripped.find('@').map(|i| i + 1)
+    } else {
+        spec.find('@')
+    };
+    match at {
+        None => (spec.to_string(), Vec::new()),
+        Some(i) => {
+            let versions = spec[i + 1..]
+                .split("||")
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect();
+            (spec[..i].to_string(), versions)
+        }
+    }
+}
+
+/// Split a `.npmrc` list value on commas, trimming and dropping empties.
+/// Mirrors how the engine reads a `list<string>` setting from `.npmrc`.
 fn parse_comma_list(raw: &str) -> Vec<String> {
     raw.split(',')
         .map(str::trim)
@@ -171,26 +275,63 @@ fn parse_comma_list(raw: &str) -> Vec<String> {
 /// Factual notice naming what was recorded and where, plus the strict opt-out.
 /// Stderr (engine convention: stdout is data), suppressed under `--silent` by
 /// the caller.
-fn emit_notice(target: &Target, entries: &[String]) {
-    let lead = if entries.len() == 1 {
+fn emit_notice(target: &Target, recorded: &[String]) {
+    let lead = if recorded.len() == 1 {
         "1 version newer than minimumReleaseAge was installed".to_string()
     } else {
         format!(
             "{} versions newer than minimumReleaseAge were installed",
-            entries.len()
+            recorded.len()
         )
     };
     super::present::info(&format!(
         "{lead} and recorded in {EXCLUDE_KEY} ({}):\n  {}\n\
          Set minimumReleaseAgeStrict=true to fail on these instead.",
         target.display(),
-        entries.join("\n  "),
+        recorded.join("\n  "),
     ));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_spec_handles_bare_scoped_and_union() {
+        assert_eq!(parse_spec("react"), ("react".into(), vec![]));
+        assert_eq!(parse_spec("@myorg/*"), ("@myorg/*".into(), vec![]));
+        assert_eq!(
+            parse_spec("vite@6.0.0"),
+            ("vite".into(), vec!["6.0.0".to_string()])
+        );
+        assert_eq!(
+            parse_spec("@scope/pkg@1.0.0 || 2.0.0"),
+            (
+                "@scope/pkg".into(),
+                vec!["1.0.0".to_string(), "2.0.0".to_string()]
+            )
+        );
+    }
+
+    #[test]
+    fn merge_produces_canonical_per_package_union() {
+        // Same package across existing + additions collapses to one `||` entry;
+        // a bare name absorbs versions; order is first-seen.
+        let merged = merge_package_version_specs(
+            &["caniuse-lite@1.0.0".to_string(), "left-pad".to_string()],
+            &[
+                "caniuse-lite@2.0.0".to_string(),
+                "vite@6.0.0".to_string(),
+                "left-pad@9.9.9".to_string(),
+            ],
+        );
+        assert_eq!(
+            merged,
+            vec!["caniuse-lite@1.0.0 || 2.0.0", "left-pad", "vite@6.0.0"]
+        );
+        // Idempotent: re-merging the same additions changes nothing.
+        assert_eq!(merge_package_version_specs(&merged, &[]), merged);
+    }
 
     #[test]
     fn parse_comma_list_trims_and_drops_empties() {
@@ -202,73 +343,87 @@ mod tests {
     }
 
     #[test]
-    fn append_npmrc_creates_merges_and_dedupes() {
+    fn write_npmrc_creates_merges_and_canonicalizes() {
         let dir = tempfile::tempdir().unwrap();
         let npmrc = dir.path().join(".npmrc");
         std::fs::write(&npmrc, "registry=https://example.test/\n").unwrap();
 
-        // First write creates the key alongside the existing line.
-        let added = append_npmrc(
-            dir.path(),
-            &["caniuse-lite@1.0.0".to_string(), "vite@6.0.0".to_string()],
-        )
-        .unwrap();
-        assert_eq!(added, 2);
+        let changed = write_npmrc(dir.path(), &["caniuse-lite@1.0.0".to_string()]).unwrap();
+        assert!(changed);
         let content = std::fs::read_to_string(&npmrc).unwrap();
         assert!(content.contains("registry=https://example.test/"));
         assert!(
-            content.contains("minimumReleaseAgeExclude=caniuse-lite@1.0.0,vite@6.0.0"),
+            content.contains("minimumReleaseAgeExclude=caniuse-lite@1.0.0"),
             "unexpected .npmrc:\n{content}"
         );
 
-        // Merge: one existing (deduped) + one new, into a single canonical key.
-        let added = append_npmrc(
-            dir.path(),
-            &["vite@6.0.0".to_string(), "esbuild@0.20.0".to_string()],
-        )
-        .unwrap();
-        assert_eq!(added, 1);
+        // A second immature version of the same package collapses to `||`, in
+        // one canonical key (not a duplicate line).
+        let changed = write_npmrc(dir.path(), &["caniuse-lite@2.0.0".to_string()]).unwrap();
+        assert!(changed);
         let content = std::fs::read_to_string(&npmrc).unwrap();
-        assert_eq!(
-            content.matches("minimumReleaseAgeExclude").count(),
-            1,
-            "must rewrite one canonical key, not duplicate:\n{content}"
+        assert_eq!(content.matches("minimumReleaseAgeExclude").count(), 1);
+        assert!(
+            content.contains("minimumReleaseAgeExclude=caniuse-lite@1.0.0 || 2.0.0"),
+            "not canonicalized:\n{content}"
         );
-        assert!(content.contains("esbuild@0.20.0"));
     }
 
     #[test]
-    fn write_excludes_routes_to_npmrc_without_workspace_yaml() {
-        // No pnpm-workspace.yaml → the neutral .npmrc surface.
+    fn resolve_target_npmrc_without_pnpm_signal() {
+        // No workspace yaml, no pnpm-lock.yaml → the neutral .npmrc.
         let dir = tempfile::tempdir().unwrap();
-        let (target, added) =
-            write_excludes(dir.path(), &["caniuse-lite@1.0.0".to_string()]).unwrap();
-        assert!(matches!(target, Target::Npmrc));
-        assert_eq!(added, 1);
-        assert!(dir.path().join(".npmrc").exists());
-        assert!(!dir.path().join("pnpm-workspace.yaml").exists());
+        assert!(matches!(resolve_target(dir.path()), WriteTarget::Npmrc));
     }
 
     #[test]
-    fn write_excludes_routes_to_existing_workspace_yaml() {
-        // `workspace_yaml_existing` reads the process-global `EngineContext`
-        // posture; serialize against other tests that mutate it.
+    fn resolve_target_creates_workspace_yaml_for_pnpm_incumbent() {
+        // `workspace_yaml_existing` and the pnpm-lock signal both read the
+        // process-global EngineContext posture; serialize + set it.
         let _guard = super::super::ENGINE_GLOBAL_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        // The pnpm-compat surface must be readable for the yaml to be chosen.
         aube_util::update_engine_context(|c| c.read_branded_pnpm_config = true);
+
+        // Existing pnpm-workspace.yaml wins.
         let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("pnpm-workspace.yaml"), "packages: []\n").unwrap();
+        assert!(matches!(
+            resolve_target(dir.path()),
+            WriteTarget::WorkspaceYaml(_)
+        ));
+
+        // No yaml but a pnpm-lock.yaml (pnpm incumbent) → target the yaml (created).
+        let dir2 = tempfile::tempdir().unwrap();
         std::fs::write(
-            dir.path().join("pnpm-workspace.yaml"),
-            "packages:\n  - 'src/*'\n",
+            dir2.path().join("pnpm-lock.yaml"),
+            "lockfileVersion: '9.0'\n",
         )
         .unwrap();
-        let (target, added) = write_excludes(dir.path(), &["vite@6.0.0".to_string()]).unwrap();
+        match resolve_target(dir2.path()) {
+            WriteTarget::WorkspaceYaml(p) => {
+                assert_eq!(p.file_name().unwrap(), "pnpm-workspace.yaml")
+            }
+            WriteTarget::Npmrc => panic!("pnpm incumbent should target the workspace yaml"),
+        }
+    }
+
+    #[test]
+    fn record_writes_yaml_sequence_for_pnpm_project() {
+        let _guard = super::super::ENGINE_GLOBAL_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        aube_util::update_engine_context(|c| c.read_branded_pnpm_config = true);
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("pnpm-workspace.yaml"), "packages: []\n").unwrap();
+
+        let (target, changed) = record(dir.path(), &["vite@6.0.0".to_string()]).unwrap();
+        assert!(changed);
         assert!(matches!(target, Target::WorkspaceYaml(_)));
-        assert_eq!(added, 1);
         assert!(!dir.path().join(".npmrc").exists());
-        let content = std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml")).unwrap();
-        assert!(content.contains("vite@6.0.0"), "yaml not written:\n{content}");
+        assert_eq!(
+            read_workspace_yaml_string_list(&dir.path().join("pnpm-workspace.yaml"), EXCLUDE_KEY),
+            vec!["vite@6.0.0"]
+        );
     }
 }

--- a/crates/nub-cli/src/pm_engine/min_release_age.rs
+++ b/crates/nub-cli/src/pm_engine/min_release_age.rs
@@ -1,0 +1,274 @@
+//! Loose-mode `minimumReleaseAge` auto-persist (fixes #262).
+//!
+//! With `minimumReleaseAge` set, pnpm's default (loose) mode installs a version
+//! younger than the cutoff when nothing older satisfies the range, and
+//! co-writes that package to `minimumReleaseAgeExclude` so pnpm's own
+//! install-time lockfile verifier — which a project's `pnpm <script>` triggers —
+//! accepts the pin. nub's engine does the same lowest-satisfying fallback but
+//! never recorded the exclude, so a `nub install`/`add`/`update` produced a
+//! lockfile pnpm later rejected with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`
+//! ([#262](https://github.com/nubjs/nub/issues/262)). This module closes that
+//! gap: the resolver surfaces each immature fallback pick (armed via
+//! [`arm`]), and after a successful mutating install nub appends the packages
+//! to `minimumReleaseAgeExclude` in the surface the project's config identity
+//! dictates.
+//!
+//! Write target — the same yaml-if-present-else-fallback rule aube's own
+//! `config_write_target` uses, adapted to where `minimumReleaseAgeExclude` is
+//! read from (`.npmrc` / the workspace yaml, never the manifest namespace):
+//!
+//! - a pnpm-compat project with a `pnpm-workspace.yaml` → the YAML sequence
+//!   there. pnpm 10 and 11 both read it (and it's pnpm 11's own auto-persist
+//!   home). [`workspace_yaml_existing`] is already gated on the
+//!   `read_branded_pnpm_config` posture, so a nub-identity project's stray
+//!   `pnpm-workspace.yaml` is never chosen.
+//! - everything else (nub identity, a pnpm project with no workspace yaml,
+//!   npm/yarn/bun compat) → the project `.npmrc`, comma-separated. This is the
+//!   neutral surface nub already reads `minimumReleaseAge*` from, so nub reads
+//!   back exactly what it wrote; it is brand-clean (`.npmrc` is the npm-shared
+//!   config, and the key is an unbranded setting name, not another PM's
+//!   namespaced field).
+//!
+//! Strict mode (`minimumReleaseAgeStrict=true`) never reaches here: the resolver
+//! hard-aborts on `AgeGated` before returning a fallback pick, so nothing is
+//! recorded.
+
+use super::output::OutputFlags;
+use aube_manifest::workspace::{add_to_workspace_yaml_string_list, workspace_yaml_existing};
+use std::path::Path;
+
+/// The setting key, in both its `.npmrc`/manifest spelling and its resolver
+/// exclude-list semantics.
+const EXCLUDE_KEY: &str = "minimumReleaseAgeExclude";
+
+/// Arm the resolver's age-gate fallback sink for the upcoming resolve. Called
+/// before an install/add/update engine run; [`persist`] drains it afterward.
+pub(crate) fn arm() {
+    aube_util::arm_age_gated_fallback_pick_collection();
+}
+
+/// Drain the resolver's immature fallback picks and, on a successful mutating
+/// install, append them to `minimumReleaseAgeExclude`. Always drains the sink
+/// (even on failure or when disarmed) so nothing leaks into a later in-process
+/// command. `success` gates the write to a completed install; `output` gates
+/// the notice on `--silent`.
+pub(crate) fn persist(cwd: &Path, success: bool, output: &OutputFlags) {
+    let picks = aube_util::take_age_gated_fallback_picks();
+    if !success || picks.is_empty() {
+        return;
+    }
+
+    // `name@version` exact-version entries, in first-seen order, deduped. The
+    // resolver only records a pick that wasn't already age-exempt, so a pick is
+    // never a duplicate of an existing exclude entry — dedup here only collapses
+    // the same version recorded twice within one resolve.
+    let mut entries: Vec<String> = Vec::with_capacity(picks.len());
+    for (name, version) in &picks {
+        let entry = format!("{name}@{version}");
+        if !entries.contains(&entry) {
+            entries.push(entry);
+        }
+    }
+
+    let (target, added) = match write_excludes(cwd, &entries) {
+        Ok(result) => result,
+        Err(err) => {
+            super::present::warn(&format!(
+                "warn: installed {n} package(s) newer than minimumReleaseAge but could not \
+                 record them in {EXCLUDE_KEY} ({err}); add {list} manually, or pnpm may reject \
+                 this lockfile.",
+                n = entries.len(),
+                list = entries.join(", "),
+            ));
+            return;
+        }
+    };
+
+    if added == 0 || output.is_silent() {
+        return;
+    }
+    emit_notice(&target, &entries);
+}
+
+/// Where the exclude entries were persisted, for the user-facing notice.
+enum Target {
+    WorkspaceYaml(String),
+    Npmrc,
+}
+
+impl Target {
+    fn display(&self) -> &str {
+        match self {
+            Target::WorkspaceYaml(name) => name,
+            Target::Npmrc => ".npmrc",
+        }
+    }
+}
+
+/// Route to the config surface and append `entries`, returning the target and
+/// how many were newly written (0 = all already present).
+fn write_excludes(cwd: &Path, entries: &[String]) -> anyhow::Result<(Target, usize)> {
+    match workspace_yaml_existing(cwd) {
+        Some(path) => {
+            let added = add_to_workspace_yaml_string_list(&path, EXCLUDE_KEY, entries)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("pnpm-workspace.yaml")
+                .to_string();
+            Ok((Target::WorkspaceYaml(name), added))
+        }
+        None => {
+            let added = append_npmrc(cwd, entries)?;
+            Ok((Target::Npmrc, added))
+        }
+    }
+}
+
+/// Merge `entries` into the project `.npmrc`'s comma-separated
+/// `minimumReleaseAgeExclude` key, preserving the rest of the file. Returns how
+/// many were newly added.
+fn append_npmrc(cwd: &Path, entries: &[String]) -> anyhow::Result<usize> {
+    use aube::commands::npmrc::NpmrcEdit;
+    let path = cwd.join(".npmrc");
+    let mut edit = NpmrcEdit::load(&path).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    // Existing value is last-write-wins at read time, so merge into the last
+    // occurrence's list and rewrite a single canonical key.
+    let mut list: Vec<String> = edit
+        .entries()
+        .into_iter()
+        .rfind(|(k, _)| k == EXCLUDE_KEY)
+        .map(|(_, v)| parse_comma_list(&v))
+        .unwrap_or_default();
+
+    let mut added = 0usize;
+    for entry in entries {
+        if !list.iter().any(|e| e == entry) {
+            list.push(entry.clone());
+            added += 1;
+        }
+    }
+    if added == 0 {
+        return Ok(0);
+    }
+    edit.set(EXCLUDE_KEY, &list.join(","));
+    edit.save(&path).map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(added)
+}
+
+/// Split a `.npmrc` list value on commas, trimming and dropping empties. Mirrors
+/// how the engine reads a `list<string>` setting from `.npmrc`.
+fn parse_comma_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Factual notice naming what was recorded and where, plus the strict opt-out.
+/// Stderr (engine convention: stdout is data), suppressed under `--silent` by
+/// the caller.
+fn emit_notice(target: &Target, entries: &[String]) {
+    let lead = if entries.len() == 1 {
+        "1 version newer than minimumReleaseAge was installed".to_string()
+    } else {
+        format!(
+            "{} versions newer than minimumReleaseAge were installed",
+            entries.len()
+        )
+    };
+    super::present::info(&format!(
+        "{lead} and recorded in {EXCLUDE_KEY} ({}):\n  {}\n\
+         Set minimumReleaseAgeStrict=true to fail on these instead.",
+        target.display(),
+        entries.join("\n  "),
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_comma_list_trims_and_drops_empties() {
+        assert_eq!(
+            parse_comma_list("a@1.0.0, b@2.0.0 ,, c@3.0.0"),
+            vec!["a@1.0.0", "b@2.0.0", "c@3.0.0"]
+        );
+        assert!(parse_comma_list("").is_empty());
+    }
+
+    #[test]
+    fn append_npmrc_creates_merges_and_dedupes() {
+        let dir = tempfile::tempdir().unwrap();
+        let npmrc = dir.path().join(".npmrc");
+        std::fs::write(&npmrc, "registry=https://example.test/\n").unwrap();
+
+        // First write creates the key alongside the existing line.
+        let added = append_npmrc(
+            dir.path(),
+            &["caniuse-lite@1.0.0".to_string(), "vite@6.0.0".to_string()],
+        )
+        .unwrap();
+        assert_eq!(added, 2);
+        let content = std::fs::read_to_string(&npmrc).unwrap();
+        assert!(content.contains("registry=https://example.test/"));
+        assert!(
+            content.contains("minimumReleaseAgeExclude=caniuse-lite@1.0.0,vite@6.0.0"),
+            "unexpected .npmrc:\n{content}"
+        );
+
+        // Merge: one existing (deduped) + one new, into a single canonical key.
+        let added = append_npmrc(
+            dir.path(),
+            &["vite@6.0.0".to_string(), "esbuild@0.20.0".to_string()],
+        )
+        .unwrap();
+        assert_eq!(added, 1);
+        let content = std::fs::read_to_string(&npmrc).unwrap();
+        assert_eq!(
+            content.matches("minimumReleaseAgeExclude").count(),
+            1,
+            "must rewrite one canonical key, not duplicate:\n{content}"
+        );
+        assert!(content.contains("esbuild@0.20.0"));
+    }
+
+    #[test]
+    fn write_excludes_routes_to_npmrc_without_workspace_yaml() {
+        // No pnpm-workspace.yaml → the neutral .npmrc surface.
+        let dir = tempfile::tempdir().unwrap();
+        let (target, added) =
+            write_excludes(dir.path(), &["caniuse-lite@1.0.0".to_string()]).unwrap();
+        assert!(matches!(target, Target::Npmrc));
+        assert_eq!(added, 1);
+        assert!(dir.path().join(".npmrc").exists());
+        assert!(!dir.path().join("pnpm-workspace.yaml").exists());
+    }
+
+    #[test]
+    fn write_excludes_routes_to_existing_workspace_yaml() {
+        // `workspace_yaml_existing` reads the process-global `EngineContext`
+        // posture; serialize against other tests that mutate it.
+        let _guard = super::super::ENGINE_GLOBAL_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // The pnpm-compat surface must be readable for the yaml to be chosen.
+        aube_util::update_engine_context(|c| c.read_branded_pnpm_config = true);
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'src/*'\n",
+        )
+        .unwrap();
+        let (target, added) = write_excludes(dir.path(), &["vite@6.0.0".to_string()]).unwrap();
+        assert!(matches!(target, Target::WorkspaceYaml(_)));
+        assert_eq!(added, 1);
+        assert!(!dir.path().join(".npmrc").exists());
+        let content = std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml")).unwrap();
+        assert!(content.contains("vite@6.0.0"), "yaml not written:\n{content}");
+    }
+}

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -57,6 +57,7 @@ pub mod identity;
 pub mod info_family;
 pub mod install_family;
 pub mod log;
+pub mod min_release_age;
 pub mod output;
 pub mod present;
 pub mod publish_family;

--- a/vendor/aube/crates/aube-manifest/src/workspace.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace.rs
@@ -26,8 +26,8 @@ pub use config::{
     workspace_yaml_target,
 };
 pub use edits::{
-    add_to_workspace_yaml_string_list, edit_setting_map, edit_workspace_yaml, remove_map_entry,
-    remove_setting_entry, upsert_map_entry,
+    edit_setting_map, edit_workspace_yaml, read_workspace_yaml_string_list, remove_map_entry,
+    remove_setting_entry, set_workspace_yaml_string_list, upsert_map_entry,
 };
 pub use mutations::{
     ALLOW_BUILDS_REVIEW_PLACEHOLDER, add_to_allow_builds, remove_workspace_patched_dependency,
@@ -856,43 +856,45 @@ patchedDependencies:
     }
 
     #[test]
-    fn add_to_workspace_yaml_string_list_creates_appends_dedupes_and_preserves() {
+    fn workspace_yaml_string_list_read_set_roundtrip_and_preserve() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("pnpm-workspace.yaml");
         std::fs::write(&path, "packages:\n  - 'src/*'\n").unwrap();
 
-        // First append creates the sequence key.
-        let added = add_to_workspace_yaml_string_list(
+        // Absent key reads empty.
+        assert!(read_workspace_yaml_string_list(&path, "minimumReleaseAgeExclude").is_empty());
+
+        // Set creates the sequence key; read returns it; unrelated keys survive.
+        set_workspace_yaml_string_list(
             &path,
             "minimumReleaseAgeExclude",
             &["caniuse-lite@1.0.0".to_string(), "vite@6.0.0".to_string()],
         )
         .unwrap();
-        assert_eq!(added, 2);
+        assert_eq!(
+            read_workspace_yaml_string_list(&path, "minimumReleaseAgeExclude"),
+            vec!["caniuse-lite@1.0.0", "vite@6.0.0"]
+        );
         let cfg = WorkspaceConfig::load(dir.path()).unwrap();
         assert_eq!(
             cfg.minimum_release_age_exclude.as_deref(),
             Some(["caniuse-lite@1.0.0".to_string(), "vite@6.0.0".to_string()].as_slice())
         );
+        assert!(
+            std::fs::read_to_string(&path).unwrap().contains("src/*"),
+            "packages lost"
+        );
 
-        // Re-append one existing + one new: only the new lands.
-        let added = add_to_workspace_yaml_string_list(
+        // Replace semantics: set overwrites the whole sequence (canonical form).
+        set_workspace_yaml_string_list(
             &path,
             "minimumReleaseAgeExclude",
-            &["vite@6.0.0".to_string(), "esbuild@0.20.0".to_string()],
+            &["caniuse-lite@1.0.0 || 2.0.0".to_string()],
         )
         .unwrap();
-        assert_eq!(added, 1);
-
-        // Unrelated keys survive; re-adding only duplicates is a no-op write.
-        let written = std::fs::read_to_string(&path).unwrap();
-        assert!(written.contains("src/*"), "packages lost:\n{written}");
-        let added = add_to_workspace_yaml_string_list(
-            &path,
-            "minimumReleaseAgeExclude",
-            &["vite@6.0.0".to_string()],
-        )
-        .unwrap();
-        assert_eq!(added, 0);
+        assert_eq!(
+            read_workspace_yaml_string_list(&path, "minimumReleaseAgeExclude"),
+            vec!["caniuse-lite@1.0.0 || 2.0.0"]
+        );
     }
 }

--- a/vendor/aube/crates/aube-manifest/src/workspace.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace.rs
@@ -26,7 +26,8 @@ pub use config::{
     workspace_yaml_target,
 };
 pub use edits::{
-    edit_setting_map, edit_workspace_yaml, remove_map_entry, remove_setting_entry, upsert_map_entry,
+    add_to_workspace_yaml_string_list, edit_setting_map, edit_workspace_yaml, remove_map_entry,
+    remove_setting_entry, upsert_map_entry,
 };
 pub use mutations::{
     ALLOW_BUILDS_REVIEW_PLACEHOLDER, add_to_allow_builds, remove_workspace_patched_dependency,
@@ -852,5 +853,46 @@ patchedDependencies:
             !written.contains("a@1.0.0"),
             "removed entry still present:\n{written}"
         );
+    }
+
+    #[test]
+    fn add_to_workspace_yaml_string_list_creates_appends_dedupes_and_preserves() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        std::fs::write(&path, "packages:\n  - 'src/*'\n").unwrap();
+
+        // First append creates the sequence key.
+        let added = add_to_workspace_yaml_string_list(
+            &path,
+            "minimumReleaseAgeExclude",
+            &["caniuse-lite@1.0.0".to_string(), "vite@6.0.0".to_string()],
+        )
+        .unwrap();
+        assert_eq!(added, 2);
+        let cfg = WorkspaceConfig::load(dir.path()).unwrap();
+        assert_eq!(
+            cfg.minimum_release_age_exclude.as_deref(),
+            Some(["caniuse-lite@1.0.0".to_string(), "vite@6.0.0".to_string()].as_slice())
+        );
+
+        // Re-append one existing + one new: only the new lands.
+        let added = add_to_workspace_yaml_string_list(
+            &path,
+            "minimumReleaseAgeExclude",
+            &["vite@6.0.0".to_string(), "esbuild@0.20.0".to_string()],
+        )
+        .unwrap();
+        assert_eq!(added, 1);
+
+        // Unrelated keys survive; re-adding only duplicates is a no-op write.
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("src/*"), "packages lost:\n{written}");
+        let added = add_to_workspace_yaml_string_list(
+            &path,
+            "minimumReleaseAgeExclude",
+            &["vite@6.0.0".to_string()],
+        )
+        .unwrap();
+        assert_eq!(added, 0);
     }
 }

--- a/vendor/aube/crates/aube-manifest/src/workspace/edits.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace/edits.rs
@@ -475,39 +475,46 @@ pub(super) fn workspace_yaml_submap<'a>(
 ///
 /// For brand-new or empty files there is no source to preserve, so the
 /// helper falls back to `yaml_serde::to_string` for the initial write.
-/// Append `values` to the top-level string-sequence `key` in the workspace
-/// yaml at `path`, creating the file and the sequence as needed, skipping
-/// values already present. Returns how many were newly added (0 = no write).
-/// Comment- and format-preserving via [`edit_workspace_yaml`].
-///
-/// Used for auto-persisted list settings whose home is the workspace yaml
-/// (e.g. `minimumReleaseAgeExclude`). The values are stored as plain scalars;
-/// a non-sequence existing value under `key` is left untouched and nothing is
-/// added, so a hand-authored inline form is never clobbered.
-pub fn add_to_workspace_yaml_string_list(
+/// Read the top-level string-sequence `key` from the workspace yaml at `path`.
+/// Returns an empty vec when the file, the key, or a sequence value is absent
+/// (a scalar/other value under `key` yields empty — the caller decides how to
+/// reconcile). Used to merge an auto-persisted list setting with what's already
+/// recorded before writing the canonical form back.
+pub fn read_workspace_yaml_string_list(path: &Path, key: &str) -> Vec<String> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let Ok(doc) = crate::parse_yaml::<yaml_serde::Value>(path, content) else {
+        return Vec::new();
+    };
+    doc.as_mapping()
+        .and_then(|m| m.get(yaml_serde::Value::String(key.to_string())))
+        .and_then(|v| v.as_sequence())
+        .map(|seq| {
+            seq.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Set the top-level string-sequence `key` in the workspace yaml at `path` to
+/// exactly `values`, creating the file and key as needed. Comment- and
+/// format-preserving via [`edit_workspace_yaml`] (a no-op when the sequence is
+/// already `values`). Replace semantics — the caller passes the fully-merged
+/// canonical list, so callers that grow a list must read-merge first (see
+/// [`read_workspace_yaml_string_list`]).
+pub fn set_workspace_yaml_string_list(
     path: &Path,
     key: &str,
     values: &[String],
-) -> Result<usize, crate::Error> {
+) -> Result<PathBuf, crate::Error> {
     use yaml_serde::Value;
-    let mut added = 0usize;
     edit_workspace_yaml(path, |map| {
-        let entry = map
-            .entry(Value::String(key.to_string()))
-            .or_insert_with(|| Value::Sequence(Vec::new()));
-        let Some(seq) = entry.as_sequence_mut() else {
-            return Ok(());
-        };
-        for v in values {
-            let present = seq.iter().any(|e| e.as_str() == Some(v.as_str()));
-            if !present {
-                seq.push(Value::String(v.clone()));
-                added += 1;
-            }
-        }
+        let seq: Vec<Value> = values.iter().map(|v| Value::String(v.clone())).collect();
+        map.insert(Value::String(key.to_string()), Value::Sequence(seq));
         Ok(())
-    })?;
-    Ok(added)
+    })
 }
 
 pub fn edit_workspace_yaml<F>(path: &Path, f: F) -> Result<PathBuf, crate::Error>

--- a/vendor/aube/crates/aube-manifest/src/workspace/edits.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace/edits.rs
@@ -475,6 +475,41 @@ pub(super) fn workspace_yaml_submap<'a>(
 ///
 /// For brand-new or empty files there is no source to preserve, so the
 /// helper falls back to `yaml_serde::to_string` for the initial write.
+/// Append `values` to the top-level string-sequence `key` in the workspace
+/// yaml at `path`, creating the file and the sequence as needed, skipping
+/// values already present. Returns how many were newly added (0 = no write).
+/// Comment- and format-preserving via [`edit_workspace_yaml`].
+///
+/// Used for auto-persisted list settings whose home is the workspace yaml
+/// (e.g. `minimumReleaseAgeExclude`). The values are stored as plain scalars;
+/// a non-sequence existing value under `key` is left untouched and nothing is
+/// added, so a hand-authored inline form is never clobbered.
+pub fn add_to_workspace_yaml_string_list(
+    path: &Path,
+    key: &str,
+    values: &[String],
+) -> Result<usize, crate::Error> {
+    use yaml_serde::Value;
+    let mut added = 0usize;
+    edit_workspace_yaml(path, |map| {
+        let entry = map
+            .entry(Value::String(key.to_string()))
+            .or_insert_with(|| Value::Sequence(Vec::new()));
+        let Some(seq) = entry.as_sequence_mut() else {
+            return Ok(());
+        };
+        for v in values {
+            let present = seq.iter().any(|e| e.as_str() == Some(v.as_str()));
+            if !present {
+                seq.push(Value::String(v.clone()));
+                added += 1;
+            }
+        }
+        Ok(())
+    })?;
+    Ok(added)
+}
+
 pub fn edit_workspace_yaml<F>(path: &Path, f: F) -> Result<PathBuf, crate::Error>
 where
     F: FnOnce(&mut yaml_serde::Mapping) -> Result<(), crate::Error>,

--- a/vendor/aube/crates/aube-manifest/src/workspace/yaml_patch.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace/yaml_patch.rs
@@ -137,15 +137,15 @@ fn diff_into(
                     let mut sub = route.to_vec();
                     sub.push(key.to_string());
                     diff_into(bm, am, &sub, path, out)?;
-                } else if matches!(after_v.as_mapping(), Some(m) if !m.is_empty()) {
-                    // Type-change to a non-empty sub-mapping (e.g.
-                    // scalar -> nested mapping). yamlpatch's
-                    // Op::Replace serializes the mapping value via
-                    // the same path as Op::Add, which strips nested
-                    // indentation and lands the children at the
-                    // parent's column. Split into Remove + manual
-                    // injection so step 2 can re-emit the children
-                    // with their canonical indent.
+                } else if needs_manual_injection(after_v) {
+                    // Change into a non-empty block mapping or sequence (e.g.
+                    // scalar -> nested mapping, or an appended list item).
+                    // yamlpatch's Op::Replace serializes such values via the
+                    // same path as Op::Add, which strips the block structure
+                    // (mapping children land at the parent's column; a sequence
+                    // renders inline and breaks the document). Split into
+                    // Remove + manual injection so step 2 re-emits the value
+                    // with its canonical block indentation.
                     out.push(Edit::Yp(Patch {
                         route: route_obj.with_key(key.to_string()),
                         operation: Op::Remove,
@@ -166,6 +166,16 @@ fn diff_into(
         }
     }
     Ok(())
+}
+
+/// Whether `value` must be re-emitted through the manual block injector
+/// rather than a yamlpatch `Op::Add`/`Op::Replace`. True for a non-empty
+/// mapping or a non-empty sequence — both of which yamlpatch renders without
+/// the block indentation the source needs, producing invalid YAML. Empty
+/// containers and scalars round-trip fine through yamlpatch.
+fn needs_manual_injection(value: &Value) -> bool {
+    matches!(value.as_mapping(), Some(m) if !m.is_empty())
+        || matches!(value.as_sequence(), Some(s) if !s.is_empty())
 }
 
 /// Inject a fresh `<key>: <value>` block-style entry into

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -118,6 +118,14 @@ pub(crate) struct ResolveDriver<'a> {
     /// versions must clear — the exclude relaxes only the
     /// minimumReleaseAge age-gate, never the time-based wall.
     time_cutoff: Option<String>,
+    /// The `minimumReleaseAge` cutoff alone (never merged with the
+    /// TimeBased wall), retained so `process_task` can detect a loose-mode
+    /// fallback pick: a `Found` version whose publish time is past this
+    /// cutoff and which isn't age-exempt is the lowest-satisfying fallback,
+    /// which the embedder auto-persists to `minimumReleaseAgeExclude`.
+    /// `None` when the age gate is off or strict (strict aborts before a
+    /// fallback pick is ever returned).
+    age_gate_cutoff: Option<String>,
     /// Direct deps still awaiting a terminal outcome (resolved,
     /// dropped, or filtered). Drops to zero once wave 0 completes and
     /// triggers the TimeBased cutoff computation.
@@ -182,6 +190,14 @@ impl<'a> ResolveDriver<'a> {
         if let Some(c) = published_by.as_deref() {
             tracing::debug!("minimumReleaseAge cutoff: {}", c);
         }
+        // The age-gate cutoff for loose-mode fallback detection: the same
+        // computed cutoff, but only in non-strict mode (strict aborts on
+        // `AgeGated` and never returns a fallback pick to detect). Kept
+        // separate from `published_by`, which the TimeBased wall later merges.
+        let age_gate_cutoff: Option<String> = match resolver.minimum_release_age.as_ref() {
+            Some(m) if !m.strict => published_by.clone(),
+            _ => None,
+        };
 
         seed_direct_deps(
             manifests,
@@ -251,6 +267,7 @@ impl<'a> ResolveDriver<'a> {
             deferred_transitives: Vec::new(),
             published_by,
             time_cutoff: None,
+            age_gate_cutoff,
             direct_deps_pending,
             cutoff_pending,
             needs_time,
@@ -1062,6 +1079,23 @@ impl<'a> ResolveDriver<'a> {
             {
                 self.resolved_times.insert(dep_path.clone(), t.clone());
             }
+        }
+
+        // Loose-mode age-gate fallback surfacing. When `minimumReleaseAge` is
+        // set without strict mode, `pick_version` returns the lowest satisfying
+        // version even when it's younger than the cutoff. A `Found` pick whose
+        // publish time is past `age_gate_cutoff` — and which isn't age-exempt —
+        // is exactly that fallback (a within-cutoff pick would be `<=`; strict
+        // mode aborts before returning `Found`). Surface it so the embedder can
+        // auto-persist the package to `minimumReleaseAgeExclude`, matching
+        // pnpm's loose-mode behavior. The sink is inert unless the embedder
+        // armed it, so standalone aube is unaffected.
+        if let Some(cutoff) = self.age_gate_cutoff.as_deref()
+            && let Some(pub_time) = picked_publish_time.as_deref()
+            && pub_time > cutoff
+            && !is_age_exempt(&version, None)
+        {
+            aube_util::record_age_gated_fallback_pick(task.registry_name(), &version);
         }
 
         // Record root dep

--- a/vendor/aube/crates/aube-util/src/age_gate.rs
+++ b/vendor/aube/crates/aube-util/src/age_gate.rs
@@ -1,0 +1,80 @@
+//! Process-global sink for age-gated (immature) fallback version picks.
+//!
+//! With `minimumReleaseAge` set in loose mode (the default), the resolver falls
+//! back to the lowest satisfying version when every candidate is younger than
+//! the cutoff. pnpm does the same, then auto-persists that package to
+//! `minimumReleaseAgeExclude` so a later verify-lockfile pass accepts the pin.
+//! The resolver here does the fallback but assigns it no policy; an embedder
+//! that wants pnpm's auto-persist ARMS this sink before a resolve, DRAINS it
+//! after, and writes the exclude entry in whatever config surface its identity
+//! model dictates.
+//!
+//! Disarmed by default: standalone aube never arms it, records nothing, and its
+//! behavior is unchanged. The record check is a single relaxed atomic load,
+//! reached only on an actual immature pick.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static ARMED: AtomicBool = AtomicBool::new(false);
+static PICKS: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
+
+/// Arm collection for the next resolve, clearing any prior picks. The embedder
+/// calls this before an install/add/update resolve it wants to auto-persist.
+pub fn arm_age_gated_fallback_pick_collection() {
+    if let Ok(mut picks) = PICKS.lock() {
+        picks.clear();
+    }
+    ARMED.store(true, Ordering::Release);
+}
+
+/// Record an immature fallback pick as `(registry_name, version)`. No-op unless
+/// armed — the standalone-aube path returns after one relaxed atomic load.
+pub fn record_age_gated_fallback_pick(name: &str, version: &str) {
+    if !ARMED.load(Ordering::Acquire) {
+        return;
+    }
+    if let Ok(mut picks) = PICKS.lock() {
+        picks.push((name.to_string(), version.to_string()));
+    }
+}
+
+/// Disarm and drain every recorded pick, in record order (the caller dedups).
+/// The embedder calls this once, after the resolve completes.
+pub fn take_age_gated_fallback_picks() -> Vec<(String, String)> {
+    ARMED.store(false, Ordering::Release);
+    match PICKS.lock() {
+        Ok(mut picks) => std::mem::take(&mut *picks),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Single test: the sink is process-global, so exercising the whole
+    // disarmed → armed → drained lifecycle in one test avoids cross-test races.
+    #[test]
+    fn lifecycle_disarmed_is_noop_armed_collects_take_drains_and_disarms() {
+        // Disarmed by default: records are dropped.
+        record_age_gated_fallback_pick("a", "1.0.0");
+        assert!(take_age_gated_fallback_picks().is_empty());
+
+        // Armed: records land, in order; take drains them.
+        arm_age_gated_fallback_pick_collection();
+        record_age_gated_fallback_pick("caniuse-lite", "1.0.30001700");
+        record_age_gated_fallback_pick("vite", "6.0.0");
+        assert_eq!(
+            take_age_gated_fallback_picks(),
+            vec![
+                ("caniuse-lite".to_string(), "1.0.30001700".to_string()),
+                ("vite".to_string(), "6.0.0".to_string()),
+            ]
+        );
+
+        // take disarmed the sink: subsequent records are dropped again.
+        record_age_gated_fallback_pick("b", "2.0.0");
+        assert!(take_age_gated_fallback_picks().is_empty());
+    }
+}

--- a/vendor/aube/crates/aube-util/src/lib.rs
+++ b/vendor/aube/crates/aube-util/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod adaptive;
+pub mod age_gate;
 pub mod buf;
 pub mod cache;
 pub mod collections;
@@ -11,6 +12,13 @@ pub mod env;
 // Convenience re-exports of the diagnostics public API so binaries can
 // reference `aube_util::DiagConfig` instead of `aube_util::diag::DiagConfig`.
 pub use diag::{DiagConfig, Slot, Span, jstr};
+
+// Convenience re-exports for the age-gate fallback sink (the embedder seam the
+// resolver records immature loose-mode picks into).
+pub use age_gate::{
+    arm_age_gated_fallback_pick_collection, record_age_gated_fallback_pick,
+    take_age_gated_fallback_picks,
+};
 pub mod fs;
 pub mod fs_atomic;
 pub mod hash;


### PR DESCRIPTION
## What

When `minimumReleaseAge` is set in loose mode (the default), the resolver installs the lowest satisfying version even when it is younger than the cutoff — pnpm's documented fallback. pnpm co-writes that package to `minimumReleaseAgeExclude` so its own install-time lockfile verifier accepts the pin. nub did the same fallback pick but never recorded the exclude, so a `nub install`/`add`/`update` produced a lockfile pnpm later rejected with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` — surfaced when a project's scripts shell out to pnpm, which is exactly the report in #262.

This mirrors pnpm's loose-mode behavior: after a successful install/add/update/dedupe, nub records each immature package in `minimumReleaseAgeExclude` and prints a factual notice. `minimumReleaseAgeStrict=true` is unchanged — it still hard-aborts.

## How

- The resolver surfaces each immature fallback pick through a small process-global sink in `aube-util` (`age_gate.rs`). It is inert unless armed (one relaxed atomic on the record path), so standalone aube is unchanged.
- nub arms the sink before an install/add/update/dedupe engine run and, on success, drains it and records the entries.

Write target — `minimumReleaseAgeExclude` is a pnpm *workspace-config-file* setting, so pnpm reads it only from `pnpm-workspace.yaml`, never from `.npmrc` (verified against pnpm 11's config reader; pnpm 10.15.1 has no `minimumReleaseAge` feature at all):

- A pnpm-compat project (an existing `pnpm-workspace.yaml`, or a `pnpm-lock.yaml` nub round-trips) → the `pnpm-workspace.yaml` sequence, created when absent. This is where pnpm reads the setting and where pnpm's own auto-persist writes it. Gated on the incumbent posture, so a nub-identity / npm / yarn / bun / fresh project never gets one created.
- Otherwise (nub identity, npm/yarn/bun compat, fresh) → the project `.npmrc` — the neutral surface nub itself reads `minimumReleaseAge*` from, so nub reads back exactly what it wrote. Nothing re-reads these projects' lockfiles as pnpm, so pnpm's `.npmrc` blind spot is moot.

Entries use pnpm's canonical per-package `name@v1 || v2` form (a port of pnpm's `mergePackageVersionSpecs`), merged with what's already recorded. A companion `yaml_patch` change re-emits a changed block sequence through the manual injector, since yamlpatch's `Op::Replace` mishandles a block sequence the same way it already mishandles a block mapping.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.
- Unit tests for the sink, the yaml read/replace helpers, the npmrc merge, the routing, and the canonical merge; existing suites green (aube-resolver 257, aube-manifest 122).
- End-to-end (`nub install`/`add` with a `minimumReleaseAge` that ages out every version): a nub-identity/fresh project records to `.npmrc`; a declared-pnpm project with no lockfile has both `pnpm-lock.yaml` and a new `pnpm-workspace.yaml` written, carrying `minimumReleaseAgeExclude: [is-number@7.0.0]`, with nothing in `.npmrc`; a second immature version of the same package collapses to the canonical `name@v1 || v2` form across runs; re-running does not duplicate; strict mode still aborts with nothing written.

pnpm 11's acceptance of the created `pnpm-workspace.yaml` was validated from its config-reader source (the local pnpm is 10.15.1, which predates the feature).

Two known non-blocking edges: the write targets the invocation cwd rather than the resolved workspace root (consistent with the existing `devEngines` virgin-stamp), and the pnpm-incumbent signal keys on `pnpm-lock.yaml` presence.

Closes #262