### PR TITLE
fix(run): prepend node_modules/.bin to script PATH unconditionally

### DIFF
--- a/crates/nub-cli/tests/workspace_run.rs
+++ b/crates/nub-cli/tests/workspace_run.rs
@@ -266,3 +266,31 @@ fn filtered_remove_keeps_a_workspace_dep_resolvable() {
         "the lockfile must be updated in lockstep, not left stale"
     );
 }
+
+/// Regression for #281: a script that creates `node_modules/.bin/<tool>` and
+/// then invokes it by bare name in the same run must succeed — the install-
+/// then-invoke pattern. nub used to drop `node_modules/.bin` from the child's
+/// PATH when the directory did not exist at spawn time; npm/pnpm prepend it
+/// unconditionally. Unix-only: the fixture writes a `#!/bin/sh` shim, which is
+/// runnable on Unix but not the `.cmd`-shim shape Windows resolves.
+#[cfg(unix)]
+#[test]
+fn run_script_finds_bin_created_mid_run() {
+    let root = tmp_workspace("bin-created-mid-run");
+    write(
+        &root.join("package.json"),
+        r#"{"name":"mid-run","version":"1.0.0","scripts":{"go":"mkdir -p node_modules/.bin && printf '#!/bin/sh\nprintf IT-WORKS\n' > node_modules/.bin/mytool && chmod +x node_modules/.bin/mytool && mytool"}}"#,
+    );
+    // No node_modules/.bin exists at spawn — the script creates it, then calls
+    // `mytool` by bare name, which resolves only if `.bin` is on PATH.
+    let (stdout, stderr, code) = run_nub(&root, &["run", "go"]);
+    let combined = format!("{stdout}{stderr}");
+    assert_eq!(
+        code, 0,
+        "bare-name invocation of a mid-run-created .bin tool must succeed\n{combined}"
+    );
+    assert!(
+        stdout.contains("IT-WORKS"),
+        "the mid-run-created tool must run and print its output\n{combined}"
+    );
+}

--- a/crates/nub-core/src/workspace/scripts.rs
+++ b/crates/nub-core/src/workspace/scripts.rs
@@ -301,13 +301,15 @@ fn flatten_npm_package_env(
 pub fn bin_path(project_root: &Path, workspace_root: Option<&Path>) -> String {
     let mut dirs = Vec::new();
 
-    // Walk from project root up, adding each node_modules/.bin.
+    // Walk from project root up, adding each node_modules/.bin UNCONDITIONALLY —
+    // no existence check. npm (@npmcli/run-script/lib/set-path.js) and pnpm both
+    // prepend without stat'ing, so a `.bin` that a script creates mid-run (the
+    // install-then-invoke pattern, #281) is reachable. A missing PATH entry is
+    // harmless — the OS/shell silently skips it.
     let mut dir = project_root.to_path_buf();
     for _ in 0..16 {
         let bin_dir = dir.join("node_modules").join(".bin");
-        if bin_dir.is_dir() {
-            dirs.push(bin_dir.to_string_lossy().to_string());
-        }
+        dirs.push(bin_dir.to_string_lossy().to_string());
         if workspace_root.is_some() && Some(dir.as_path()) == workspace_root {
             break;
         }
@@ -394,7 +396,9 @@ pub fn script_shell(project_root: &Path) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ScriptSelection, find_bin, npm_env, npmrc_value, script_shell, select_scripts};
+    use super::{
+        ScriptSelection, bin_path, find_bin, npm_env, npmrc_value, script_shell, select_scripts,
+    };
     use std::fs;
 
     #[test]
@@ -554,5 +558,26 @@ mod tests {
         }
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn bin_path_includes_missing_dir() {
+        // Regression for #281: bin_path must prepend `<root>/node_modules/.bin`
+        // even when that directory does not exist at call time, so a script that
+        // creates its `.bin` mid-run (install-then-invoke) can still find it. npm
+        // and pnpm both prepend unconditionally.
+        let root = std::env::temp_dir().join(format!("nub-281-{}", std::process::id()));
+        // Deliberately do NOT create node_modules/.bin.
+        let expected = root
+            .join("node_modules")
+            .join(".bin")
+            .to_string_lossy()
+            .to_string();
+        let path = bin_path(&root, Some(&root));
+        assert!(
+            path.split(crate::PATH_LIST_SEPARATOR)
+                .any(|p| p == expected),
+            "expected PATH to contain the (non-existent) {expected:?}, got {path:?}"
+        );
     }
 }


### PR DESCRIPTION
`bin_path()` gated each ancestor's `node_modules/.bin` PATH segment on an `is_dir()` check computed before spawn, so a `.bin` absent at spawn was dropped — including one a script creates mid-run (install-then-invoke). npm and pnpm prepend unconditionally without stat'ing; a missing PATH entry is inert. Drop the check; keep the 16-level cap and `workspace_root` break. `find_bin()` untouched.

Tests: `bin_path_includes_missing_dir` (unit) and `run_script_finds_bin_created_mid_run` (Unix e2e).

Closes #281

https://claude.ai/code/session_01Xuh9u8b93eMNu53fTQTWX7