### PR TITLE
feat(runtime): Import Text — `import x from "./f" with { type: "text" }` on any extension

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -3287,6 +3287,50 @@ fn data_named_import_is_a_load_error() {
 }
 
 #[test]
+fn import_text_attribute_any_extension() {
+    // nub's Import Text: `import s from "./f" with { type: "text" }` yields the raw
+    // file contents as a default-export string, on ANY extension. The attribute is
+    // checked ahead of extension dispatch, so it wins over both nub's data loaders
+    // (a `.yaml` read as text is NOT parsed) and Node-native JSON (a `.json` read
+    // as text is the raw string). Matches Node's upstream `textStrategy` semantics.
+    let (stdout, stderr, code) = run_nub("import-text", "main.ts");
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains(r##"md:"# Release notes\n\n- first\n- second\n""##),
+        "text of a non-data extension (.md) returned verbatim as a string: {stdout}"
+    );
+    assert!(
+        stdout.contains("yaml-is-string:true") && stdout.contains("yaml-unparsed:true"),
+        "a .yaml imported with type:text is the RAW text, not the parsed object: {stdout}"
+    );
+    assert!(
+        stdout.contains("json-is-string:true")
+            && stdout.contains(r#"json-unparsed:"{\"name\":\"demo\",\"version\":2}\n""#),
+        "a .json imported with type:text is the RAW string, not Node-native JSON: {stdout}"
+    );
+}
+
+#[test]
+fn import_text_named_import_is_a_load_error() {
+    // A text import exposes ONLY a default export; a named import has no matching
+    // export and fails at module instantiation (Node SyntaxError), exactly as for
+    // the data loaders. Nothing in the importing module runs.
+    let (stdout, stderr, code) = run_nub("import-text-named", "main.ts");
+    assert_ne!(
+        code, 0,
+        "named import of a text module must fail; stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("does not provide an export named 'heading'"),
+        "expected the missing-named-export load error; stderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("should-not-print"),
+        "the importing module must not execute when the named import fails: {stdout}"
+    );
+}
+
+#[test]
 fn env_loading_direct_file() {
     let (stdout, stderr, code) = run_nub("env-test", "main.ts");
     assert_eq!(code, 0, "stderr: {stderr}");

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -166,6 +166,36 @@ fn compat_tier_runs_ts_silently() {
     );
 }
 
+/// Import Text on the COMPAT tier (async `module.register` loader worker). The
+/// feature is served by a load-hook branch that exists in BOTH tier entrypoints
+/// (`preload.cjs`'s sync `registerHooks` and `preload-async-hooks.mjs`'s async
+/// worker); the `integration.rs` cases run on the host's fast-tier Node, so this
+/// pins the async path a modern host would otherwise mask. Node 22.13.0 is the
+/// compat-tier representative (>18.20 so `with {}` parses, <22.15 so the async
+/// worker is used).
+#[test]
+fn import_text_works_on_compat_tier() {
+    let Some((stdout, stderr, code)) = run_nub_against_node((22, 13, 0), "import-text", "main.ts")
+    else {
+        eprintln!(
+            "skipping: Node 22.13.0 not installed (set TEST_NODE_BIN_22_13_0 or nvm install)"
+        );
+        return;
+    };
+    assert_eq!(
+        code, 0,
+        "compat-tier import-text must succeed: stderr={stderr}"
+    );
+    assert!(
+        stdout.contains(r##"md:"# Release notes\n\n- first\n- second\n""##),
+        "compat tier: .md read as text via the async loader worker: stdout={stdout:?}"
+    );
+    assert!(
+        stdout.contains("yaml-is-string:true") && stdout.contains("json-is-string:true"),
+        "compat tier: the attribute wins over data-loader parsing on the async path: stdout={stdout:?}"
+    );
+}
+
 /// Node 18.18.0 is one patch below the 18.19 floor — the boundary case
 /// for the hard-error tier. Contract: stderr carries the canonical
 /// refusal text, exit is non-zero, and (implicitly) Node was never

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -29,7 +29,7 @@
 import "./floor-builtin.mjs";
 import {
   TRANSPILE_EXTS, PLAIN_JS_EXTS, DATA_EXTS,
-  extname, resolveSpec, loadTranspile, maybeTranspilePlainJs, loadData, isNodeModules,
+  extname, resolveSpec, loadTranspile, maybeTranspilePlainJs, loadData, loadTextImport, isNodeModules,
 } from "./transform-core.mjs";
 import { createRequire, isBuiltin } from "node:module";
 import { existsSync } from "node:fs";
@@ -84,6 +84,12 @@ export async function resolve(specifier, context, nextResolve) {
 
 // ── Load hook ───────────────────────────────────────────────────────
 export async function load(url, context, nextLoad) {
+  // Import Text (attribute-keyed): honor `with { type: "text" }` on ANY extension,
+  // checked BEFORE extension dispatch so `import s from "./c.yaml" with {type:"text"}`
+  // returns the raw text, not parsed YAML. shortCircuits, so Node never runs its own
+  // unknown-'text'-attribute validation. (Node 18.20+ parses the `with` syntax; the
+  // 18.19.x floor cannot parse it at all — see the import-text thread.)
+  if (context?.importAttributes?.type === "text") return loadTextImport(url);
   const ext = extname(url);
   // node_modules deps are NEVER transpiled (the byte-parity boundary). This guard is
   // make-or-break now that TRANSPILE_EXTS includes `.js`/`.mjs`/`.cjs`: without it,

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -502,6 +502,16 @@ function makeHooks(core, watchReporting) {
       } catch {}
     }
 
+    // Import Text (attribute-keyed): honor `with { type: "text" }` on ANY extension,
+    // ahead of extension dispatch so `import s from "./c.yaml" with {type:"text"}`
+    // returns raw text, not parsed YAML. Placed after watch reporting (so a text file
+    // gets the same watch treatment as any other), and before the extension/data
+    // dispatch (so the attribute wins over the `.txt`/`.yaml`/… data loaders and
+    // Node-native JSON). shortCircuits, so Node's own unknown-'text'-attribute
+    // validation never runs. Mirror of the compat-tier hook in preload-async-hooks.mjs.
+    // (Node 18.20+ parses the `with` syntax; the 18.19.x floor cannot.)
+    if (context?.importAttributes?.type === "text") return core.loadTextImport(url);
+
     // A USER resolve hook (a ts-node/tsx-style transpiler registered AFTER nub's
     // own preload hook) claimed this file with the bare 'typescript' format: defer
     // to the user's own load chain. The discriminator is `__userHooksRegistered`,

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -770,3 +770,19 @@ export function loadData(url, ext) {
   const code = `export default ${JSON.stringify(parsed)};\n`;
   return { format: "module", source: code, shortCircuit: true };
 }
+
+// Import Text: `import s from "./any.file" with { type: "text" }` → the raw file
+// contents as a default-export string, on ANY extension. This is nub's own
+// implementation of the import-attribute text feature Node standardized upstream
+// (translators.js textStrategy); it is attribute-KEYED (the load hooks call this
+// when `context.importAttributes?.type === "text"`), orthogonal to the
+// EXTENSION-keyed `.txt` data loader above. Semantics match Node's textStrategy:
+// decode via TextDecoder (UTF-8, strips a leading BOM — unlike readFileSync utf8,
+// which keeps it) and expose ONLY a `default` export (a named import errors, as on
+// Node). shortCircuit so this fully owns the module and Node's own
+// unknown-'text'-attribute validation never runs.
+const __textDecoder = new TextDecoder();
+export function loadTextImport(url) {
+  const text = __textDecoder.decode(readFileSync(fileURLToPath(url)));
+  return { format: "module", source: `export default ${JSON.stringify(text)};\n`, shortCircuit: true };
+}

--- a/site/content/docs/runtime/loaders.mdx
+++ b/site/content/docs/runtime/loaders.mdx
@@ -1,6 +1,6 @@
 ---
 title: Loaders
-description: Import JSON, JSONC, JSON5, TOML, YAML, and plain-text files directly as default exports, via an extension-keyed load hook.
+description: Import JSON, JSONC, JSON5, TOML, YAML, and plain-text files as default exports, plus any file as raw text via an import attribute.
 ---
 
 <TypesSetup>
@@ -45,3 +45,15 @@ const { host, port } = config;      // "localhost", 5432
 ```
 
 The object formats are typed `Record<string, unknown>`, so destructured keys are `unknown` — narrow or cast them at the use site. A data file whose top-level value is an array or scalar imports as that value via the default; cast it, since the wildcard type assumes an object.
+
+## Import any file as text
+
+Add the `with { type: "text" }` import attribute to read a file's raw contents as a string, whatever its extension.
+
+```ts
+import readme from "./README.md" with { type: "text" };  // string
+import query from "./query.sql" with { type: "text" };   // string
+import raw from "./config.yaml" with { type: "text" };    // the YAML source, unparsed
+```
+
+The attribute wins over parsing: a `.yaml` or `.json` file read this way is the raw text, not the parsed value. A text import is a single default export, like the data loaders — there are no named exports.

--- a/tests/fixtures/import-text-named/main.ts
+++ b/tests/fixtures/import-text-named/main.ts
@@ -1,0 +1,4 @@
+// A text import exposes ONLY a default export; a named import has no matching
+// export and is a load-time SyntaxError (nothing in this module runs).
+import { heading } from "./note.md" with { type: "text" };
+console.log("should-not-print:" + heading);

--- a/tests/fixtures/import-text-named/note.md
+++ b/tests/fixtures/import-text-named/note.md
@@ -1,0 +1,1 @@
+the raw text

--- a/tests/fixtures/import-text/config.yaml
+++ b/tests/fixtures/import-text/config.yaml
@@ -1,0 +1,2 @@
+host: db.example.com
+port: 5432

--- a/tests/fixtures/import-text/data.json
+++ b/tests/fixtures/import-text/data.json
@@ -1,0 +1,1 @@
+{"name":"demo","version":2}

--- a/tests/fixtures/import-text/main.ts
+++ b/tests/fixtures/import-text/main.ts
@@ -1,0 +1,15 @@
+// nub's own Import Text: `import s from "./f" with { type: "text" }` yields the
+// raw file contents as a default-export string, on ANY extension. The attribute
+// takes precedence over both nub's extension-based data loaders (a `.yaml` read
+// as text is NOT parsed) and Node-native JSON (a `.json` read as text is the raw
+// string, not the parsed object). Default export only — a named import is a
+// separate load-error case (import-text-named fixture).
+import md from "./notes.md" with { type: "text" };
+import yamlText from "./config.yaml" with { type: "text" };
+import jsonText from "./data.json" with { type: "text" };
+
+console.log("md:" + JSON.stringify(md));
+console.log("yaml-is-string:" + (typeof yamlText === "string"));
+console.log("yaml-unparsed:" + yamlText.startsWith("host: db.example.com"));
+console.log("json-is-string:" + (typeof jsonText === "string"));
+console.log("json-unparsed:" + JSON.stringify(jsonText));

--- a/tests/fixtures/import-text/notes.md
+++ b/tests/fixtures/import-text/notes.md
@@ -1,0 +1,4 @@
+# Release notes
+
+- first
+- second


### PR DESCRIPTION
nub's own Import Text: `import s from "./file" with { type: "text" }` yields the raw file contents as a default-export string, on **any** extension. This is a new nub augmentation via the existing load-hook surface — it converges on the semantics Node standardized upstream (the `--experimental-import-text` `textStrategy` translator) and that Bun and Deno ship, not a port of patched Node internals. A plain-Node user registering the same `module.registerHooks` / `module.register` hook gets the identical result, so the augmenter-not-fork contract holds (verified with plain-Node prototypes across the Node matrix).

## What it fixes

`type: "text"` on a non-`.txt` extension previously errored:

```
import notes from "./README.md" with { type: "text" };
// before: TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".md"
// after:  the file contents, as a string
```

The attribute is checked ahead of extension dispatch, so it wins over nub's extension-based data loaders (a `.yaml` read as text is the raw source, not the parsed object) and over Node-native JSON (a `.json` read as text is the raw string).

## Mechanism

Both tier load hooks — fast (`runtime/preload-common.cjs`, sync `module.registerHooks`) and compat (`runtime/preload-async-hooks.mjs`, async `module.register` loader worker) — check `context.importAttributes?.type === "text"` and return a synthesized `export default <string>` via the shared `loadTextImport` helper in `runtime/transform-core.mjs`. It `shortCircuit`s, so Node never runs its own attribute validation. Semantics match Node's `textStrategy`: default export only (a named import is a load-time `SyntaxError`), decoded via `TextDecoder` (UTF-8, strips a leading BOM). ESM-only — Node has no CJS `require`-with-attributes API. The extension-based `.txt`/`.yaml`/… loaders are unchanged; this is additive.

## Node version support — and one deferred decision

Works on every supported Node that can parse the `with { … }` import-attribute syntax: **Node 18.20 → latest, both the fast and compat tiers** (verified on 18.20.4 / 20.19 / 22.13 / 22.14 / 22.15 / 24.14 / 26.2).

The `with { … }` syntax landed in V8 12.3 (Node 22), backported to Node 18.20 and 20.10. **Node 18.19.0 / 18.19.1 — the two patch releases at nub's support floor — cannot parse it in V8 at all** (the import fails before any hook runs). Closing that gap is feasible via a source-level `with` → `assert` keyword rewrite (18.19 parses `assert { type: "text" }` and surfaces the attribute to the load hook identically — proven), but emitting `assert` needs a native transpile-path change (oxc emits `with` verbatim and does not lower import attributes) plus routing plain-JS-with-attributes through the transform on the floor. That is a hot-path change for exactly two patch releases where a bump to Node 18.20 (same LTS major) works natively. **Left as a maintainer decision** — native floor rewrite, a bump-to-18.20 diagnostic on 18.19.x, or accept the gap — rather than shipped here.

## Tests

- `import_text_attribute_any_extension`, `import_text_named_import_is_a_load_error` (`crates/nub-cli/tests/integration.rs`).
- `import_text_works_on_compat_tier` (`crates/nub-cli/tests/version_tiers.rs`, Node 22.13.0) so the async loader-worker path is not masked by a modern host Node.
- Fixtures under `tests/fixtures/import-text/` and `tests/fixtures/import-text-named/`.

`cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

https://claude.ai/code/session_01Xuh9u8b93eMNu53fTQTWX7
