### PR TITLE
Import Text on the Node 18.19.x floor (with→assert keyword rewrite)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,11 +641,18 @@ jobs:
           }
           dir_22_13=$(install_node 22.13.0)
           dir_18_18=$(install_node 18.18.0)
+          # 18.19.0: exact floor patch whose V8 cannot parse the `with {…}`
+          # import-attribute keyword — pins the with->assert rewrite (import-text on the
+          # 18.19 floor). `actions/setup-node`'s "18.19" leg resolves to the latest
+          # patch, so the exact .0 is side-installed like the other tier reps.
+          dir_18_19=$(install_node 18.19.0)
           "$dir_22_13/node" --version
           "$dir_18_18/node" --version
+          "$dir_18_19/node" --version
           {
             echo "TEST_NODE_BIN_22_13_0=$dir_22_13"
             echo "TEST_NODE_BIN_18_18_0=$dir_18_18"
+            echo "TEST_NODE_BIN_18_19_0=$dir_18_19"
           } >> "$GITHUB_ENV"
       - run: pnpm install --frozen-lockfile
       # The data-format loader tests need the nub-native addon (the npm yaml/toml/

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -196,6 +196,54 @@ fn import_text_works_on_compat_tier() {
     );
 }
 
+/// Import Text on the Node 18.19.x FLOOR — the two patch releases (18.19.0 / 18.19.1)
+/// whose V8 cannot parse the `with {…}` import-attribute keyword at all (it landed in
+/// V8 12.3 / Node 22 and was backported to 18.20 / 20.10, never 18.19.x). nub rewrites
+/// the keyword to the older `assert` spelling before Node's parser sees the source, so
+/// the feature works down to nub's documented 18.19 floor. Covers BOTH the
+/// transpiler-output path (`main.ts` → oxc emits `with`, rewritten post-transpile) and
+/// the plain-JS path (`main-plain.mjs` → a minimal keyword splice, since a no-transform
+/// `.mjs` is not routed through oxc), plus string-literal safety.
+#[test]
+fn import_text_works_on_18_19_floor() {
+    let Some((stdout, stderr, code)) = run_nub_against_node((18, 19, 0), "import-text", "main.ts")
+    else {
+        eprintln!(
+            "skipping: Node 18.19.0 not installed (set TEST_NODE_BIN_18_19_0 or nvm install)"
+        );
+        return;
+    };
+    assert_eq!(
+        code, 0,
+        "18.19 floor import-text (TS) must succeed: stderr={stderr}"
+    );
+    assert!(
+        stdout.contains(r##"md:"# Release notes\n\n- first\n- second\n""##),
+        "18.19 floor: .md read as text after the with->assert rewrite: stdout={stdout:?}"
+    );
+    assert!(
+        stdout.contains("yaml-is-string:true") && stdout.contains("json-is-string:true"),
+        "18.19 floor: the attribute wins over data-loader parsing: stdout={stdout:?}"
+    );
+
+    // Plain-JS path: a `.mjs` carrying only a `with {…}` clause is keyword-spliced (no
+    // full transpile), and a `with {` inside a string literal survives untouched.
+    let (stdout, stderr, code) = run_nub_against_node((18, 19, 0), "import-text", "main-plain.mjs")
+        .expect("18.19.0 was present for main.ts, so it is present here too");
+    assert_eq!(
+        code, 0,
+        "18.19 floor import-text (plain JS) must succeed: stderr={stderr}"
+    );
+    assert!(
+        stdout.contains(r##"plain-md:"# Release notes\n\n- first\n- second\n""##),
+        "18.19 floor plain-JS: .md read as text: stdout={stdout:?}"
+    );
+    assert!(
+        stdout.contains("plain-strlit-ok:true"),
+        "18.19 floor: a `with {{` inside a string literal must survive the rewrite: stdout={stdout:?}"
+    );
+}
+
 /// Node 18.18.0 is one patch below the 18.19 floor — the boundary case
 /// for the hard-error tier. Contract: stderr carries the canonical
 /// refusal text, exit is non-zero, and (implicitly) Node was never

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -242,6 +242,42 @@ fn import_text_works_on_18_19_floor() {
         stdout.contains("plain-strlit-ok:true"),
         "18.19 floor: a `with {{` inside a string literal must survive the rewrite: stdout={stdout:?}"
     );
+
+    // Stderr parity with the ≥18.20 `with` path: the load hook shortCircuits before
+    // Node processes the (rewritten) `assert` attribute, so Node never emits its
+    // experimental import-assertions warning — the floor path is as silent as the
+    // native `with` path. `--disable-warning` is band-gated out below Node 20.11, so
+    // this clean-stderr property depends on the shortCircuit, not on suppression;
+    // regression-guard it (a leak here would be a floor-only UX divergence).
+    assert!(
+        !stderr.contains("Import assertions") && !stderr.contains("ExperimentalWarning"),
+        "18.19 floor: the rewritten `assert` import must not leak an experimental warning: stderr={stderr:?}"
+    );
+}
+
+/// Floor (18.19.x) format consistency: a plain `.js` under `type: commonjs` carrying an
+/// `import … with { … }` clause is genuine CommonJS, where an ESM `import` is a
+/// SyntaxError on stock Node and off-floor nub alike. The floor keyword-rewrite must NOT
+/// intercept it as `module` (which would make it RUN on the floor only — a cross-version
+/// divergence); it falls through to Node's native loader, which errors consistently.
+#[test]
+fn floor_plain_js_under_type_commonjs_stays_commonjs() {
+    let Some((stdout, _stderr, code)) =
+        run_nub_against_node((18, 19, 0), "import-text-cjs", "main.js")
+    else {
+        eprintln!(
+            "skipping: Node 18.19.0 not installed (set TEST_NODE_BIN_18_19_0 or nvm install)"
+        );
+        return;
+    };
+    assert_ne!(
+        code, 0,
+        "18.19 floor: an `import` in a `type: commonjs` .js must error, not be forced to module: stdout={stdout:?}"
+    );
+    assert!(
+        !stdout.contains("CJS-CTX-RAN:"),
+        "18.19 floor: the CJS-context file must NOT have run as module: stdout={stdout:?}"
+    );
 }
 
 /// Node 18.18.0 is one patch below the 18.19 floor — the boundary case

--- a/crates/nub-native/src/lib.rs
+++ b/crates/nub-native/src/lib.rs
@@ -14,6 +14,7 @@
 mod cache;
 mod detect;
 mod resolve;
+mod rewrite;
 mod transform;
 mod tsconfig;
 
@@ -22,6 +23,7 @@ use napi_derive::napi;
 pub use cache::transform_cached;
 pub use detect::detect_module_info;
 pub use resolve::resolve_ts;
+pub use rewrite::rewrite_import_attributes_keyword;
 pub use transform::transform;
 pub use tsconfig::load_tsconfig;
 

--- a/crates/nub-native/src/rewrite.rs
+++ b/crates/nub-native/src/rewrite.rs
@@ -1,0 +1,234 @@
+//! Floor-only import-attribute keyword rewrite: `with { … }` → `assert { … }`.
+//!
+//! Node 18.19.0 / 18.19.1's V8 cannot parse the `with` import-attribute keyword —
+//! the grammar landed in V8 12.3 (Node 22) and was backported to 18.20 / 20.10, but
+//! NOT to 18.19.x. Those two patch releases sit inside nub's documented 18.19 support
+//! floor, so the JS preload rewrites the keyword to the older `assert` spelling —
+//! which that V8 parses, and which surfaces the IDENTICAL `importAttributes` to the
+//! load hook — before Node's parser ever sees the source. `assert` is REMOVED on
+//! Node 22+, so the JS side gates this to 18.19.x only.
+//!
+//! Every `with`-keyword clause is rewritten regardless of the attribute (`text`,
+//! `json`, …): the SYNTAX itself is what 18.19.x cannot parse. The rewrite is an
+//! oxc-parse-driven MINIMAL byte splice of just the 4-byte keyword token — a `with`
+//! inside a string, comment, or regexp is never touched, and everything but the
+//! keyword stays byte-for-byte. `import`, `export … from`, and `export * from` all
+//! carry a `WithClause`, so one AST visitor covers them uniformly.
+
+use napi_derive::napi;
+
+use oxc::{
+    allocator::Allocator,
+    ast::ast::{WithClause, WithClauseKeyword},
+    ast_visit::Visit,
+    parser::Parser,
+};
+use oxc_napi::get_source_type;
+
+/// Result of a keyword rewrite. `changed` is false when the source carried no
+/// `with`-keyword clause (or could not be parsed), so the caller keeps the original.
+#[napi(object)]
+pub struct RewriteResult {
+    pub code: String,
+    pub changed: bool,
+}
+
+/// Collects the byte offset of the `{` that opens each `with`-keyword clause.
+/// `WithClause.span` covers only the `{ … }` entries block — NOT the keyword — so the
+/// keyword is located by scanning back from this offset (see `keyword_start_before_brace`).
+/// `assert` clauses already parse on the floor and are left untouched.
+struct WithKeywordFinder {
+    brace_starts: Vec<u32>,
+}
+
+impl<'a> Visit<'a> for WithKeywordFinder {
+    fn visit_with_clause(&mut self, it: &WithClause<'a>) {
+        if matches!(it.keyword, WithClauseKeyword::With) {
+            self.brace_starts.push(it.span.start);
+        }
+    }
+}
+
+const WITH: &[u8] = b"with";
+const ASSERT: &str = "assert";
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
+}
+
+/// The `with` keyword sits immediately before the clause's `{`, separated only by
+/// whitespace in oxc's emit and in all normal source (`with {`, `with{`, `with  {`).
+/// Scan back over ASCII whitespace and return the keyword's start byte iff the four
+/// bytes are a standalone `with`. (A comment between the keyword and the `{` is not
+/// handled — it does not occur in oxc output and is not seen in real code; such a
+/// clause is left as-is and V8 surfaces its own error.)
+fn keyword_start_before_brace(src: &[u8], brace: usize) -> Option<usize> {
+    let mut i = brace;
+    while i > 0 && src[i - 1].is_ascii_whitespace() {
+        i -= 1;
+    }
+    if i >= WITH.len() && &src[i - WITH.len()..i] == WITH {
+        let start = i - WITH.len();
+        // Reject an identifier that merely ends in `with` (e.g. `foowith {`).
+        if start == 0 || !is_ident_byte(src[start - 1]) {
+            return Some(start);
+        }
+    }
+    None
+}
+
+/// Rewrite `with { … }` import-attribute clauses to `assert { … }`. `lang` selects
+/// the parser dialect (`"ts"` parses the JS/TS superset); the source is always parsed
+/// as a module (import attributes are ESM-only). A parse panic returns the source
+/// unchanged so V8 surfaces the real error at the real spot.
+#[allow(clippy::needless_pass_by_value, clippy::allow_attributes)]
+#[napi]
+pub fn rewrite_import_attributes_keyword(
+    filename: String,
+    source_text: String,
+    lang: Option<String>,
+) -> RewriteResult {
+    let source_type = get_source_type(&filename, lang.as_deref(), Some("module"));
+
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, &source_text, source_type).parse();
+    if ret.panicked {
+        return RewriteResult {
+            code: source_text,
+            changed: false,
+        };
+    }
+
+    let mut finder = WithKeywordFinder {
+        brace_starts: Vec::new(),
+    };
+    finder.visit_program(&ret.program);
+    if finder.brace_starts.is_empty() {
+        return RewriteResult {
+            code: source_text,
+            changed: false,
+        };
+    }
+
+    // Resolve each `{` back to its `with` keyword, then splice from the highest offset
+    // down so earlier offsets stay valid. `with` is ASCII, so byte offsets are char
+    // boundaries.
+    let mut keyword_starts: Vec<usize> = finder
+        .brace_starts
+        .iter()
+        .filter_map(|&b| keyword_start_before_brace(source_text.as_bytes(), b as usize))
+        .collect();
+    keyword_starts.sort_unstable();
+    keyword_starts.dedup();
+    if keyword_starts.is_empty() {
+        return RewriteResult {
+            code: source_text,
+            changed: false,
+        };
+    }
+    let mut out = source_text;
+    for &start in keyword_starts.iter().rev() {
+        out.replace_range(start..start + WITH.len(), ASSERT);
+    }
+    RewriteResult {
+        code: out,
+        changed: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rewrite(src: &str) -> (String, bool) {
+        let r = rewrite_import_attributes_keyword("f.mjs".into(), src.into(), Some("ts".into()));
+        (r.code, r.changed)
+    }
+
+    #[test]
+    fn rewrites_default_text_import() {
+        let (code, changed) = rewrite("import x from \"./f.txt\" with { type: \"text\" };\n");
+        assert!(changed);
+        assert_eq!(
+            code,
+            "import x from \"./f.txt\" assert { type: \"text\" };\n"
+        );
+    }
+
+    #[test]
+    fn rewrites_any_attribute_not_just_text() {
+        let (code, changed) = rewrite("import j from \"./d.json\" with { type: \"json\" };");
+        assert!(changed);
+        assert_eq!(
+            code,
+            "import j from \"./d.json\" assert { type: \"json\" };"
+        );
+    }
+
+    #[test]
+    fn rewrites_export_from_and_export_all() {
+        let (code, changed) = rewrite(
+            "export { a } from \"./a.json\" with { type: \"json\" };\n\
+             export * from \"./b.json\" with { type: \"json\" };\n",
+        );
+        assert!(changed);
+        assert_eq!(
+            code,
+            "export { a } from \"./a.json\" assert { type: \"json\" };\n\
+             export * from \"./b.json\" assert { type: \"json\" };\n",
+        );
+    }
+
+    #[test]
+    fn rewrites_multiple_clauses_keeping_offsets() {
+        let (code, changed) = rewrite(
+            "import a from \"./a.txt\" with { type: \"text\" };\n\
+             import b from \"./b.txt\" with { type: \"text\" };\n",
+        );
+        assert!(changed);
+        assert_eq!(
+            code,
+            "import a from \"./a.txt\" assert { type: \"text\" };\n\
+             import b from \"./b.txt\" assert { type: \"text\" };\n",
+        );
+    }
+
+    #[test]
+    fn leaves_string_and_comment_with_untouched() {
+        // `with` inside a string literal / comment / identifier must survive verbatim;
+        // only the real clause keyword is rewritten.
+        let src = "const s = \"import x from 'y' with { type }\"; // trailing with {\n\
+                   const width = 1;\n\
+                   import t from \"./t.txt\" with { type: \"text\" };\n";
+        let (code, changed) = rewrite(src);
+        assert!(changed);
+        assert!(code.contains("const s = \"import x from 'y' with { type }\""));
+        assert!(code.contains("// trailing with {"));
+        assert!(code.contains("const width = 1;"));
+        assert!(code.contains("import t from \"./t.txt\" assert { type: \"text\" };"));
+    }
+
+    #[test]
+    fn handles_no_space_and_extra_space_before_brace() {
+        let (a, ca) = rewrite("import x from \"./f.txt\"with{type:\"text\"};");
+        assert!(ca);
+        assert_eq!(a, "import x from \"./f.txt\"assert{type:\"text\"};");
+        let (b, cb) = rewrite("import y from \"./f.txt\"  with  { type: \"text\" };");
+        assert!(cb);
+        assert_eq!(b, "import y from \"./f.txt\"  assert  { type: \"text\" };");
+    }
+
+    #[test]
+    fn no_clause_is_noop() {
+        let (code, changed) = rewrite("import x from \"./x.js\";\nconst w = { with: 1 };\n");
+        assert!(!changed);
+        assert_eq!(code, "import x from \"./x.js\";\nconst w = { with: 1 };\n");
+    }
+
+    #[test]
+    fn already_assert_is_noop() {
+        let (code, changed) = rewrite("import x from \"./f.txt\" assert { type: \"text\" };");
+        assert!(!changed);
+        assert_eq!(code, "import x from \"./f.txt\" assert { type: \"text\" };");
+    }
+}

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -174,6 +174,20 @@ export const PLAIN_JS_EXTS = new Set([".js", ".mjs", ".cjs"]);
 export const DATA_EXTS = { ".jsonc": "jsonc", ".json5": "json5", ".toml": "toml", ".yaml": "yaml", ".yml": "yaml", ".txt": "txt" };
 export const TS_PARENT_EXTS = new Set([".ts", ".tsx", ".mts", ".cts"]);
 
+// Node 18.19.0 / 18.19.1 are the ONLY supported patch releases whose V8 cannot parse
+// the `with { … }` import-attribute keyword (the grammar was backported to 18.20 /
+// 20.10, never to 18.19.x). On exactly those, nub rewrites the keyword to the older
+// `assert` spelling — which that V8 parses and which surfaces the IDENTICAL
+// importAttributes to the load hook (so Import Text and native JSON attribute imports
+// work down to nub's documented 18.19 floor). `assert` is REMOVED on Node 22+, so this
+// is gated to 18.19.x alone; everything ≥18.20 (and the whole 22.15+ fast tier) is a
+// no-op. The rewrite itself is an oxc-parse-driven keyword splice — see
+// rewriteWithForFloor + nub-native's rewrite_import_attributes_keyword.
+const NODE_NEEDS_ASSERT_KEYWORD = (() => {
+  const [maj, min] = process.versions.node.split(".");
+  return maj === "18" && min === "19";
+})();
+
 // Packages resolved from Nub's distribution, not the user's.
 export const VENDORED_PACKAGES = new Set(["@oxc-project/runtime"]);
 
@@ -580,6 +594,26 @@ export function maybeSweepCache() {
     .catch(() => {});
 }
 
+// ── Floor: with{}→assert{} import-attribute rewrite (Node 18.19.x only) ──────
+// On 18.19.0/18.19.1 (NODE_NEEDS_ASSERT_KEYWORD), rewrite `with {…}` import-attribute
+// clauses to `assert {…}` so that V8 can parse them. Runs on the FINAL source Node
+// will compile — the oxc output for TS/JSX, the raw bytes for plain JS. The `/\bwith\b/`
+// pre-filter keeps the native call off the common no-clause file (a real clause always
+// contains the `with` word); the native pass is AST-driven, so a `with` in a string/
+// comment/regexp is never touched, and `rw.changed` guards a false-positive pre-filter
+// hit. A no-op on every Node ≥18.20 (flag false). See NODE_NEEDS_ASSERT_KEYWORD.
+function rewriteWithForFloor(filePath, source) {
+  if (!NODE_NEEDS_ASSERT_KEYWORD || !nubNative || !/\bwith\b/.test(source)) return source;
+  try {
+    const rw = nubNative.rewriteImportAttributesKeyword(filePath, source, "ts");
+    return rw.changed ? rw.code : source;
+  } catch {
+    // A parse hiccup → hand back the raw source; V8 surfaces the real error at the
+    // real spot, exactly as Node would for an un-intercepted file.
+    return source;
+  }
+}
+
 // ── Transpile ───────────────────────────────────────────────────────
 // Transpile a TS/JSX file to JS, returning `{ format, source, shortCircuit }` in
 // the shape both hook tiers hand back to Node. Format is detected (not derived
@@ -661,7 +695,9 @@ export function loadTranspile(url, ext) {
     const details = result.errors.map((e) => e.codeframe || e.message).join("\n\n");
     throw new Error(`Transpile error in ${filePath}:\n${details}`);
   }
-  return { format: result.format, source: result.code, shortCircuit: true };
+  // oxc emits the `with` import-attribute keyword verbatim; on the 18.19.x floor swap
+  // it to `assert` so Node's own parser can read the transpiled output (no-op elsewhere).
+  return { format: result.format, source: rewriteWithForFloor(filePath, result.code), shortCircuit: true };
 }
 
 // Project-source plain JS (`.js`/`.mjs`/`.cjs`) gate. Returns a transpiled load
@@ -690,6 +726,17 @@ export function maybeTranspilePlainJs(url, ext) {
   // lang "ts" parses all JS (a TS superset) but NOT JSX — JSX-in-.js is out of scope.
   const info = detectModuleInfo(filePath, source, "ts");
   if (!info.transformableSyntax && !info.hasDecorators) {
+    // Floor (18.19.x): a plain-JS file whose ONLY floor-incompatible construct is a
+    // `with {…}` import-attribute clause still won't parse on 18.19's V8. It carries no
+    // transformable syntax, so a full transpile would needlessly reformat it — instead
+    // minimal-splice just the keyword and return it. Import attributes are ESM-only, so
+    // the format is `module` (`.cjs` is skipped — it cannot legitimately carry them).
+    // (A plain-JS file that ALSO has transformable syntax takes the transpile path
+    // below, where loadTranspile's own rewriteWithForFloor handles the keyword.)
+    if (NODE_NEEDS_ASSERT_KEYWORD && ext !== ".cjs") {
+      const rewritten = rewriteWithForFloor(filePath, source);
+      if (rewritten !== source) return { format: "module", source: rewritten, shortCircuit: true };
+    }
     return null; // no-op: Node's native loader handles it, byte-identical.
   }
   // Transformable: run the SAME pipeline as TS/JSX (target es2022 lowering, tsconfig,

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -729,13 +729,20 @@ export function maybeTranspilePlainJs(url, ext) {
     // Floor (18.19.x): a plain-JS file whose ONLY floor-incompatible construct is a
     // `with {…}` import-attribute clause still won't parse on 18.19's V8. It carries no
     // transformable syntax, so a full transpile would needlessly reformat it — instead
-    // minimal-splice just the keyword and return it. Import attributes are ESM-only, so
-    // the format is `module` (`.cjs` is skipped — it cannot legitimately carry them).
+    // minimal-splice just the keyword and return it. `.cjs` is skipped (it cannot
+    // legitimately carry import attributes). We must intercept as `module` ONLY when the
+    // file's real format actually IS module — a `.js` under `type: commonjs` resolves to
+    // commonjs, where an `import` is a SyntaxError on stock Node and off-floor nub alike;
+    // forcing it to `module` would make it RUN on the floor only, a version divergence.
+    // Fall through (null) in that case so Node's native loader errors consistently.
     // (A plain-JS file that ALSO has transformable syntax takes the transpile path
     // below, where loadTranspile's own rewriteWithForFloor handles the keyword.)
     if (NODE_NEEDS_ASSERT_KEYWORD && ext !== ".cjs") {
-      const rewritten = rewriteWithForFloor(filePath, source);
-      if (rewritten !== source) return { format: "module", source: rewritten, shortCircuit: true };
+      const pkgType = getPackageType(dirname(filePath));
+      if (moduleFormatFor(ext, pkgType, filePath, source) === "module") {
+        const rewritten = rewriteWithForFloor(filePath, source);
+        if (rewritten !== source) return { format: "module", source: rewritten, shortCircuit: true };
+      }
     }
     return null; // no-op: Node's native loader handles it, byte-identical.
   }

--- a/tests/fixtures/import-text-cjs/main.js
+++ b/tests/fixtures/import-text-cjs/main.js
@@ -1,0 +1,7 @@
+// A `.js` under `type: commonjs` — Node treats it as CommonJS, where an ESM
+// `import` statement is a SyntaxError on stock Node and off-floor nub alike. On
+// the 18.19 floor the `with`→`assert` rewrite must NOT force this file to run as
+// module (that would make it succeed on the floor only). If it ever ran, it would
+// print this sentinel; the test asserts it does NOT and that nub exits non-zero.
+import s from "./notes.txt" with { type: "text" };
+console.log("CJS-CTX-RAN:" + s);

--- a/tests/fixtures/import-text-cjs/notes.txt
+++ b/tests/fixtures/import-text-cjs/notes.txt
@@ -1,0 +1,1 @@
+plain text body

--- a/tests/fixtures/import-text-cjs/package.json
+++ b/tests/fixtures/import-text-cjs/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/tests/fixtures/import-text/main-plain.mjs
+++ b/tests/fixtures/import-text/main-plain.mjs
@@ -1,0 +1,10 @@
+// Floor (Node 18.19.x) plain-JS path. A `.mjs` whose only floor-incompatible
+// construct is a `with {…}` import-attribute clause is NOT routed through the
+// transpiler; nub minimal-splices the keyword to `assert` so 18.19's V8 can parse it.
+// A `with {` inside a string literal must survive the rewrite untouched.
+import md from "./notes.md" with { type: "text" };
+
+const decoy = "import q from 'z' with { type }";
+
+console.log("plain-md:" + JSON.stringify(md));
+console.log("plain-strlit-ok:" + (decoy === "import q from 'z' with { type }"));


### PR DESCRIPTION
Refs #284.

#284 shipped Import Text (`import x from "./f" with { type: "text" }`) for Node 18.20 through latest. It fails on Node 18.19.0 / 18.19.1 — two patch releases inside nub's documented 18.19 support floor — because their V8 cannot parse the `with` import-attribute keyword at all (it landed in V8 12.3 / Node 22, backported to 18.20 / 20.10, never 18.19.x). The parse fails before any load hook runs.

## Fix

On those two floor patches only, rewrite the `with { … }` keyword to the older `assert { … }` spelling before Node's parser sees the source. On 18.19.x, `assert` parses and surfaces the identical `importAttributes`, so the existing `loadTextImport` is unchanged; native JSON attribute imports (`with { type: "json" }`) work down to the floor too, since the syntax — not the attribute — is the wall. `assert` is removed on Node 22+, so the rewrite is gated to 18.19.x and is a no-op everywhere else.

## Mechanism

- nub-native `rewrite_import_attributes_keyword`: an oxc-parse-driven byte splice of just the keyword token (a `with` in a string / comment / regexp is untouched). One AST visitor covers `import`, `export … from`, `export * from`.
- transform-core gates on `process.versions.node` and rewrites the final source Node compiles — the oxc output for TS/JSX, and the raw bytes for a plain `.js`/`.mjs` whose only floor-incompatible construct is the attribute clause (a minimal splice, no full transpile).

The dynamic form `import(x, { with: {…} })` stays out of scope (18.19's runtime reads the older `assert:` object key; rewriting arbitrary options expressions is unsafe).

## Verification

Real 18.19.0 and 18.19.1: entry `.mjs`, `.ts`, imported module, non-`.txt` extension, string-literal safety, generic JSON all pass; no regression on 18.20.4 / 22.14 / 22.15; cross-version transpile-cache reads correct. nub-native unit tests (8) plus a `version_tiers` floor test (18.19.0, side-installed in CI). `clippy --all-targets --all-features -D warnings` and `fmt --check` clean.
