### PR TITLE
config: move nub's global settings file from nub.toml to nub.jsonc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,6 +2230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonc-parser"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ebcfcb2f2b016f7372835b99cd3be24cc13ce9823107beb0f98b09c6092ba9f"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "junction"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2628,7 @@ dependencies = [
  "console",
  "dirs-next",
  "dotenvy",
+ "jsonc-parser",
  "libc",
  "miette",
  "mimalloc",
@@ -2635,7 +2645,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.8.23",
- "toml_edit",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,10 @@ libc = "0.2"
 clap = { version = "4", features = ["derive"] }
 dirs-next = "2"
 json5 = "0.4"
-jsonc-parser = { version = "0.24", features = ["serde"] }
+# Reads (`serde`) + comment/order-preserving read-modify-write (`cst`) of JSONC —
+# the transpiler's tsconfig parsing and nub's own global config file
+# (~/.config/nub/nub.jsonc).
+jsonc-parser = { version = "0.24", features = ["serde", "cst"] }
 # napi 3 (not 2): oxc_napi 0.132.0 and oxc_sourcemap[napi] are built against
 # napi 3, and a single cdylib cannot mix napi-2 and napi-3 `#[napi]` derives
 # (the OxcError / SourceMap return types would fail to bridge). napi 3 is the
@@ -110,10 +113,6 @@ oxc_napi = "=0.132.0"
 oxc_sourcemap = { version = "=6.0.1", features = ["napi"] }
 rustc-hash = "2"
 toml = "0.8"
-# Comment/order-preserving TOML read-modify-write for nub's own global config
-# file (~/.config/nub/nub.toml). Already in the tree transitively via `toml 0.8`
-# → adding it as a direct dep reuses the same compiled crate (no new build).
-toml_edit = "0.22"
 # Interactive terminal primitive (raw-mode key reads, cursor control) for the
 # dlx consent radio in nubx_consent.rs. Already compiled in via `demand` (aube's
 # build-approval picker) → direct dep reuses the same crate (no new build).

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -92,7 +92,9 @@ sha2.workspace = true
 tracing.workspace = true
 tempfile = "3"
 toml.workspace = true
-toml_edit.workspace = true
+# Comment-preserving JSONC read (serde) + read-modify-write (cst) for nub's own
+# global config file (~/.config/nub/nub.jsonc, see src/config.rs).
+jsonc-parser.workspace = true
 console.workspace = true
 # Multi-thread runtime for the embedded aube install engine (pm_engine.rs).
 # Mirrors aube's own cli_main runtime shape; tokio is dormant on every other

--- a/crates/nub-cli/src/config.rs
+++ b/crates/nub-cli/src/config.rs
@@ -1,34 +1,39 @@
-//! nub's global settings file — `~/.config/nub/nub.toml` (`$XDG_CONFIG_HOME/nub`,
+//! nub's global settings file — `~/.config/nub/nub.jsonc` (`$XDG_CONFIG_HOME/nub`,
 //! `%APPDATA%\nub` on Windows).
 //!
 //! This is nub's OWN durable settings home, distinct from the registry/PM tuning
 //! that rides `.npmrc` and the ephemeral `NUB_*` env knobs: a setting lands here
 //! only when no neutral standard field expresses it AND it must survive a `nub
 //! cache clear` (the config-home ladder). Today the sole key is the dlx consent
-//! kill-switch `exec.implicit-dlx`. It lives under `[exec]` because dlx literally
+//! kill-switch `exec.implicitDlx`. It lives under `exec` because dlx literally
 //! means *download and exec* — a fetch-then-exec variant of local-binary exec,
-//! the same behavior class, not a separate domain — so `[exec]` holds config for
+//! the same behavior class, not a separate domain — so `exec` holds config for
 //! both exec and dlx. (Config sections split by behavior class, not the nubx tier
-//! chain: `[run]` = scripts, `[exec]` = tool/binary execution; this matches pnpm,
+//! chain: `run` = scripts, `exec` = tool/binary execution; this matches pnpm,
 //! where exec/dlx are tools and run is scripts.)
 //!
-//! Read/modify/write goes through `toml_edit::DocumentMut` — NOT serde/`toml::Table`
-//! — so an existing file's comments, whitespace, and key order survive a `set`
-//! that touches one key. Writes are atomic (temp + rename via `aube_util`).
+//! The file is JSONC (JSON + comments + trailing commas). Reads go through
+//! `jsonc_parser::parse_to_serde_value` (best-effort — a malformed or absent file
+//! yields the default, never a hard failure, because the read sits on nubx's hot
+//! consent path). Writes go through the `jsonc_parser::cst` module — a
+//! comment/whitespace/key-order-preserving CST edit — so a `set` that touches one
+//! key leaves the rest of a hand-authored file intact. Writes are atomic (temp +
+//! rename via `aube_util`). Only `nub.jsonc` is accepted; `nub.json` is never read.
 //!
-//! The `nub config get/set exec.implicit-dlx …` surface is NOT a separate clap
+//! The `nub config get/set exec.implicitDlx …` surface is NOT a separate clap
 //! verb (the `config` verb already exists as the engine's `.npmrc` config): the
 //! nub-namespaced dotted key is intercepted in `pm_engine::store_config_family`
 //! and routed here, while every other key stays on the `.npmrc` path.
 
 use std::path::PathBuf;
 
-use toml_edit::{DocumentMut, Item, Table, Value};
+use jsonc_parser::ParseOptions;
+use jsonc_parser::cst::{CstInputValue, CstObject, CstRootNode};
 
-/// The `[exec]` table name and the key within it. One `const` pair so the reader,
+/// The `exec` object name and the key within it. One `const` pair so the reader,
 /// the writer, and the config-verb interception can't drift.
 const TABLE: &str = "exec";
-const KEY: &str = "implicit-dlx";
+const KEY: &str = "implicitDlx";
 
 /// The dlx consent tier. Values are `prompt` (default) and `never`; `never`
 /// mirrors the interactive select's `Never` label. Reserves `allow`
@@ -59,15 +64,16 @@ impl ImplicitDlx {
     }
 }
 
-/// Path to `~/.config/nub/nub.toml`. `None` only when no home/config root
+/// Path to `~/.config/nub/nub.jsonc`. `None` only when no home/config root
 /// resolves at all (a broken environment) — every caller treats that as "use the
 /// default and don't persist."
 pub fn config_path() -> Option<PathBuf> {
-    Some(nub_core::node::discovery::config_dir()?.join("nub.toml"))
+    Some(nub_core::node::discovery::config_dir()?.join("nub.jsonc"))
 }
 
-/// Read `exec.implicit-dlx`. Absent file / absent key / unparseable value all mean
-/// the default (`Prompt`) — config is best-effort and never fails the gate.
+/// Read `exec.implicitDlx`. Absent file / absent key / unparseable value / any
+/// unknown sibling key all mean the default (`Prompt`) — config is best-effort and
+/// never fails the gate.
 pub fn implicit_dlx() -> ImplicitDlx {
     let Some(path) = config_path() else {
         return ImplicitDlx::Prompt;
@@ -75,21 +81,37 @@ pub fn implicit_dlx() -> ImplicitDlx {
     let Ok(text) = std::fs::read_to_string(&path) else {
         return ImplicitDlx::Prompt;
     };
-    let Ok(doc) = text.parse::<DocumentMut>() else {
+    let Ok(Some(value)) = jsonc_parser::parse_to_serde_value(&text, &ParseOptions::default())
+    else {
         return ImplicitDlx::Prompt;
     };
-    doc.get(TABLE)
-        .and_then(Item::as_table)
-        .and_then(|t| t.get(KEY))
-        .and_then(Item::as_str)
+    value
+        .get(TABLE)
+        .and_then(|exec| exec.get(KEY))
+        .and_then(|v| v.as_str())
         .and_then(ImplicitDlx::parse)
         .unwrap_or(ImplicitDlx::Prompt)
 }
 
-/// Write `exec.implicit-dlx = <value>`, preserving every other key/comment in the
-/// file (read-modify-write on the live `DocumentMut`). Creates the file + `nub/`
-/// dir if absent. Returns an error only on an I/O failure the caller should
-/// surface — an in-memory edit never fails.
+/// Get the root object of `text`, creating a fresh `{}` when the file is
+/// absent/empty/unparseable or its root value is not an object. The returned
+/// `CstObject` borrows into `root`, so the caller MUST keep `root` alive for the
+/// whole edit (the CST panics if the root is dropped while a descendant is used).
+fn root_object(text: &str) -> (CstRootNode, CstObject) {
+    let parse = |t: &str| {
+        CstRootNode::parse(t, &ParseOptions::default())
+            .ok()
+            .and_then(|root| root.ensure_object_value().map(|obj| (root, obj)))
+    };
+    // Best-effort: a malformed or non-object existing file is replaced by a fresh
+    // object rather than surfacing a parse error on a `set`.
+    parse(text).unwrap_or_else(|| parse("{}").expect("`{}` parses to an object"))
+}
+
+/// Write `exec.implicitDlx = <value>`, preserving every other key/comment in the
+/// file (comment-aware CST read-modify-write). Creates the file + `nub/` dir if
+/// absent. Returns an error only on an I/O failure the caller should surface — an
+/// in-memory edit never fails.
 pub fn set_implicit_dlx(value: ImplicitDlx) -> std::io::Result<()> {
     let path = config_path().ok_or_else(|| {
         std::io::Error::new(
@@ -98,32 +120,35 @@ pub fn set_implicit_dlx(value: ImplicitDlx) -> std::io::Result<()> {
         )
     })?;
 
-    let mut doc = std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|s| s.parse::<DocumentMut>().ok())
-        .unwrap_or_default();
+    let text = std::fs::read_to_string(&path).unwrap_or_default();
+    let (root, obj) = root_object(&text);
 
-    // Ensure `[exec]` exists as a table, then set the key. `entry(..).or_insert`
-    // keeps a pre-existing `[exec]` table (and its comments) untouched.
-    let table = doc
-        .entry(TABLE)
-        .or_insert(Item::Table(Table::new()))
-        .as_table_mut()
-        .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("`{TABLE}` in nub.toml is not a table"),
-            )
-        })?;
-    table[KEY] = Item::Value(Value::from(value.as_str()));
+    // Get-or-create the `exec` object, then set-or-append the key inside it.
+    // A pre-existing `exec` that is NOT an object (a hand-authored scalar/array)
+    // is best-effort REPLACED with a fresh object — dropping the malformed value
+    // rather than panicking or leaving a duplicate `exec` key. `get_object`
+    // matches the FIRST `exec` prop by name, so a stray non-object one must be
+    // removed before the append or the re-fetch would still find it and be None.
+    let exec = obj.get_object(TABLE).unwrap_or_else(|| {
+        if let Some(stray) = obj.get(TABLE) {
+            stray.remove();
+        }
+        obj.append(TABLE, CstInputValue::Object(Vec::new()));
+        obj.get_object(TABLE)
+            .expect("just-appended `exec` object is present")
+    });
+    match exec.get(KEY) {
+        Some(prop) => prop.set_value(CstInputValue::String(value.as_str().to_string())),
+        None => exec.append(KEY, CstInputValue::String(value.as_str().to_string())),
+    }
 
-    aube_util::fs_atomic::atomic_write(&path, doc.to_string().as_bytes())
+    aube_util::fs_atomic::atomic_write(&path, root.to_string().as_bytes())
 }
 
-/// Remove `exec.implicit-dlx` (restoring the `prompt` default), preserving the
-/// rest of the file. A `config unset`/`delete` on this key routes here rather
-/// than the engine's `.npmrc` delete. Absent file/key → a no-op success (nothing
-/// to clear is not an error).
+/// Remove `exec.implicitDlx` (restoring the `prompt` default), preserving the
+/// rest of the file. A `config unset`/`delete` on this key routes here rather than
+/// the engine's `.npmrc` delete. Absent file/key → a no-op success (nothing to
+/// clear is not an error).
 pub fn unset_implicit_dlx() -> std::io::Result<()> {
     let Some(path) = config_path() else {
         return Ok(());
@@ -131,13 +156,16 @@ pub fn unset_implicit_dlx() -> std::io::Result<()> {
     let Ok(text) = std::fs::read_to_string(&path) else {
         return Ok(());
     };
-    let Ok(mut doc) = text.parse::<DocumentMut>() else {
+    let Ok(root) = CstRootNode::parse(&text, &ParseOptions::default()) else {
         return Ok(());
     };
-    if let Some(table) = doc.get_mut(TABLE).and_then(Item::as_table_mut) {
-        table.remove(KEY);
+    let Some(obj) = root.root_value().and_then(|v| v.as_object()) else {
+        return Ok(());
+    };
+    if let Some(prop) = obj.get_object(TABLE).and_then(|exec| exec.get(KEY)) {
+        prop.remove();
     }
-    aube_util::fs_atomic::atomic_write(&path, doc.to_string().as_bytes())
+    aube_util::fs_atomic::atomic_write(&path, root.to_string().as_bytes())
 }
 
 /// ONE process-wide lock every test that mutates a shared env var (`XDG_*`, `CI`)
@@ -190,11 +218,11 @@ mod tests {
             set_implicit_dlx(ImplicitDlx::Never).unwrap();
             assert_eq!(implicit_dlx(), ImplicitDlx::Never);
 
-            // The written file is the sectioned `[exec]` form we document.
-            let body = std::fs::read_to_string(home.join("nub").join("nub.toml")).unwrap();
-            assert!(body.contains("[exec]"), "wrote an [exec] table: {body}");
+            // The written file is the nested `exec` object form we document.
+            let body = std::fs::read_to_string(home.join("nub").join("nub.jsonc")).unwrap();
+            assert!(body.contains("\"exec\""), "wrote an exec object: {body}");
             assert!(
-                body.contains("implicit-dlx = \"never\""),
+                body.contains("\"implicitDlx\": \"never\""),
                 "wrote the key: {body}"
             );
 
@@ -217,17 +245,18 @@ mod tests {
     }
 
     #[test]
-    fn set_preserves_existing_comments_and_unrelated_keys() {
+    fn set_preserves_comments_trailing_commas_and_unrelated_keys() {
         with_config_home(|home| {
-            // A pre-existing file with a comment, an unrelated top-level key, and
-            // an unrelated key inside [exec]. A comment-dropping serde round-trip
-            // would lose the comment + reorder; toml_edit must keep all of it.
-            let path = home.join("nub").join("nub.toml");
+            // A pre-existing JSONC file with a line comment, a block comment, a
+            // trailing comma, an unrelated top-level key, and an unrelated key
+            // inside `exec`. The comment-aware CST write must keep all of it — the
+            // real regression guard for the jsonc-parser migration.
+            let path = home.join("nub").join("nub.jsonc");
             std::fs::create_dir_all(path.parent().unwrap()).unwrap();
             let mut f = std::fs::File::create(&path).unwrap();
             write!(
                 f,
-                "# nub settings — hand-authored\ntelemetry = false\n\n[exec]\n# an unrelated exec knob\nshell = \"bash\"\n"
+                "{{\n  // nub settings — hand-authored\n  \"telemetry\": false,\n  /* an unrelated block */\n  \"exec\": {{\n    \"shell\": \"bash\",\n  }},\n}}\n"
             )
             .unwrap();
             drop(f);
@@ -236,25 +265,69 @@ mod tests {
 
             let body = std::fs::read_to_string(&path).unwrap();
             assert!(
-                body.contains("# nub settings — hand-authored"),
-                "top comment preserved: {body}"
+                body.contains("// nub settings — hand-authored"),
+                "line comment preserved: {body}"
             );
             assert!(
-                body.contains("telemetry = false"),
+                body.contains("\"telemetry\": false"),
                 "unrelated top key preserved: {body}"
             );
             assert!(
-                body.contains("# an unrelated exec knob"),
-                "in-table comment preserved: {body}"
+                body.contains("/* an unrelated block */"),
+                "block comment preserved: {body}"
             );
             assert!(
-                body.contains("shell = \"bash\""),
-                "unrelated [exec] key preserved: {body}"
+                body.contains("\"shell\": \"bash\""),
+                "unrelated exec key preserved: {body}"
             );
             assert!(
-                body.contains("implicit-dlx = \"never\""),
+                body.contains("\"implicitDlx\": \"never\""),
                 "new key written: {body}"
             );
+            // The value round-trips back through the reader.
+            assert_eq!(implicit_dlx(), ImplicitDlx::Never);
+        });
+    }
+
+    #[test]
+    fn unknown_keys_and_malformed_files_degrade_to_default() {
+        with_config_home(|home| {
+            // A `$schema` pointer and a typo'd sibling key must NOT fail the read —
+            // best-effort parsing returns the real value.
+            let path = home.join("nub").join("nub.jsonc");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(
+                &path,
+                "{\n  \"$schema\": \"https://nubjs.com/schema.json\",\n  \"unknownKey\": 42,\n  \"exec\": { \"implicitDlx\": \"never\" }\n}\n",
+            )
+            .unwrap();
+            assert_eq!(implicit_dlx(), ImplicitDlx::Never);
+
+            // A malformed file degrades to the default rather than erroring.
+            std::fs::write(&path, "{ this is not valid json").unwrap();
+            assert_eq!(implicit_dlx(), ImplicitDlx::Prompt);
+        });
+    }
+
+    #[test]
+    fn set_replaces_a_non_object_exec_without_panicking() {
+        with_config_home(|home| {
+            // A hand-authored `exec` that is NOT an object (a scalar or array)
+            // must not panic the write (`get_object` returns None, so the stray
+            // prop is removed before the fresh object is appended) — best-effort
+            // config never crashes on malformed input.
+            let path = home.join("nub").join("nub.jsonc");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            for junk in ["{ \"exec\": 5 }", "{ \"exec\": [1, 2] }"] {
+                std::fs::write(&path, junk).unwrap();
+                set_implicit_dlx(ImplicitDlx::Never).unwrap();
+                assert_eq!(implicit_dlx(), ImplicitDlx::Never, "recovered from {junk}");
+                let body = std::fs::read_to_string(&path).unwrap();
+                assert!(
+                    body.contains("\"implicitDlx\": \"never\""),
+                    "wrote into a fresh exec object: {body}"
+                );
+            }
         });
     }
 }

--- a/crates/nub-cli/src/nubx_consent.rs
+++ b/crates/nub-cli/src/nubx_consent.rs
@@ -12,7 +12,7 @@
 //! - **Interactive TTY** → an arrow-key consent select (Yes / No / Never) on the
 //!   *first* fetch of a spec, then run without re-asking once that spec is
 //!   recorded as consented. Picking **Never** persists the global kill-switch
-//!   `exec.implicit-dlx = never` (see [`crate::config`]) and disables this whole
+//!   `exec.implicitDlx = never` (see [`crate::config`]) and disables this whole
 //!   implicit tier until re-enabled.
 //!
 //! `-y`/`--yes` is the explicit non-interactive escape hatch: it lets CI / non-TTY
@@ -43,7 +43,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// A pinned spec ignores this (immutable identity → consent never expires).
 const FLOATING_TTL_SECS: u64 = 24 * 60 * 60;
 
-/// The abort message printed when `exec.implicit-dlx = never` and the subject
+/// The abort message printed when `exec.implicitDlx = never` and the subject
 /// missed every local tier. LOCKED, maintainer-authored copy — reproduce verbatim,
 /// no rewording/capitalization/backtick changes. A test pins the exact bytes.
 const NEVER_ABORT_MESSAGE: &str = "No matching script or executable found.\nTo run a package from the remote registry, try `nub dlx`";
@@ -88,7 +88,7 @@ pub fn gate(specs: &[String], yes: bool) -> Decision {
         };
     }
 
-    // The global kill-switch (`exec.implicit-dlx = never`) is read FIRST — before
+    // The global kill-switch (`exec.implicitDlx = never`) is read FIRST — before
     // CI/TTY probing, any prompt, prefetch, or network. Writing it via the `Never`
     // option (or `nub config set`) permanently disables the implicit registry tier;
     // explicit `nub dlx <spec>` / `nubx -y <spec>` (above) stay open. The subject
@@ -143,7 +143,7 @@ pub fn gate(specs: &[String], yes: bool) -> Decision {
             } else {
                 eprintln!(
                     "nubx: disabled the implicit dlx tier. Re-enable with \
-                     `nub config set exec.implicit-dlx prompt`."
+                     `nub config set exec.implicitDlx prompt`."
                 );
             }
             Decision::Refused(1)

--- a/crates/nub-cli/src/pm_engine/store_config_family.rs
+++ b/crates/nub-cli/src/pm_engine/store_config_family.rs
@@ -257,20 +257,24 @@ fn project_scalar_home(pnpm_incumbent: bool) -> config_model::ScalarHome {
     config_model::pnpm_scalar_home(major)
 }
 
-/// nub's OWN durable settings live in `~/.config/nub/nub.toml`, NOT `.npmrc`
+/// nub's OWN durable settings live in `~/.config/nub/nub.jsonc`, NOT `.npmrc`
 /// (which npm will soon ERROR on for unrecognized keys) — so a nub-namespaced
 /// dotted key is intercepted BEFORE the engine's `.npmrc`/pnpm-yaml routing and
-/// handled by [`crate::config`]. Only `exec.implicit-dlx` (the dlx consent
+/// handled by [`crate::config`]. Only `exec.implicitDlx` (the dlx consent
 /// kill-switch) is wired today; the match is shaped so a sibling nub key slots in.
 /// `set`/`get`/`delete` (and the `unset`/`rm` aliases, which parse to `Delete`)
 /// are all routed here so the key can be cleared back to its default too.
-/// Returns `Some(exit)` when the key was ours, `None` to fall through to the
-/// engine's `.npmrc`-class handling.
+/// The kebab spelling `exec.implicit-dlx` is accepted as a read/route ALIAS
+/// (stale muscle memory from the pre-migration TOML key) but always writes the
+/// canonical `exec.implicitDlx`. Returns `Some(exit)` when the key was ours,
+/// `None` to fall through to the engine's `.npmrc`-class handling.
 fn try_nub_config(parsed: &ConfigArgs) -> Option<i32> {
     use crate::config::ImplicitDlx;
-    const KEY: &str = "exec.implicit-dlx";
+    const KEY: &str = "exec.implicitDlx";
+    const KEY_ALIAS: &str = "exec.implicit-dlx";
+    let is_key = |k: &str| k == KEY || k == KEY_ALIAS;
     match &parsed.command {
-        Some(ConfigCommand::Set(set)) if set.key == KEY => {
+        Some(ConfigCommand::Set(set)) if is_key(&set.key) => {
             let Some(value) = ImplicitDlx::parse(&set.value) else {
                 eprintln!(
                     "nub: `{}` is not a valid value for {KEY} (use `prompt` or `never`).",
@@ -284,22 +288,22 @@ fn try_nub_config(parsed: &ConfigArgs) -> Option<i32> {
                     Some(0)
                 }
                 Err(e) => {
-                    eprintln!("nub: could not write nub.toml: {e}");
+                    eprintln!("nub: could not write nub.jsonc: {e}");
                     Some(1)
                 }
             }
         }
-        Some(ConfigCommand::Get(get)) if get.key == KEY => {
+        Some(ConfigCommand::Get(get)) if is_key(&get.key) => {
             println!("{}", crate::config::implicit_dlx().as_str());
             Some(0)
         }
-        // `delete`/`unset`/`rm` all parse to `Delete` — clear it in nub.toml
+        // `delete`/`unset`/`rm` all parse to `Delete` — clear it in nub.jsonc
         // rather than no-op'ing on `.npmrc` (which never held it).
-        Some(ConfigCommand::Delete(del)) if del.key == KEY => {
+        Some(ConfigCommand::Delete(del)) if is_key(&del.key) => {
             match crate::config::unset_implicit_dlx() {
                 Ok(()) => Some(0),
                 Err(e) => {
-                    eprintln!("nub: could not write nub.toml: {e}");
+                    eprintln!("nub: could not write nub.jsonc: {e}");
                     Some(1)
                 }
             }

--- a/crates/nub-core/src/node/discovery.rs
+++ b/crates/nub-core/src/node/discovery.rs
@@ -849,7 +849,7 @@ pub fn cache_dir() -> Option<PathBuf> {
 }
 
 /// nub's config root (`$XDG_CONFIG_HOME/nub` or `~/.config/nub`) — the home of
-/// the global settings file `nub.toml`. Deliberately NOT `dirs_next::config_dir`,
+/// the global settings file `nub.jsonc`. Deliberately NOT `dirs_next::config_dir`,
 /// which resolves to macOS `~/Library/Preferences`: nub follows the XDG `~/.config`
 /// convention on every unix (the norm for developer-facing config, e.g. gh/git/
 /// starship) so the file lands where users expect it. Config and cache live in


### PR DESCRIPTION
Switches nub's sole global-config field from `~/.config/nub/nub.toml` `[exec] implicit-dlx` (TOML) to `~/.config/nub/nub.jsonc` `exec.implicitDlx` (JSONC). The prior `nub.toml` was never released, so this is a clean switch — no migration, no compat read.

- Reads via `jsonc-parser` `parse_to_serde_value` (best-effort: absent/malformed/unknown-key yield the `prompt` default, never failing the nubx consent path); writes via the comment- and trailing-comma-preserving `cst` module. A pre-existing non-object `exec` is replaced rather than panicking. Only `nub.jsonc` is read — `nub.json` is never accepted.
- The `config` verb accepts `exec.implicitDlx` (canonical) and the kebab `exec.implicit-dlx` (read/route alias); it always writes camelCase.
- `toml_edit` is dropped (`config.rs` was its only user); nub-cli gains the `jsonc-parser` `cst` feature. The `toml` crate is unchanged.

Scope is GLOBAL config only; project-level `nub.jsonc` precedence and fail-loud-on-unknown-key remain deferred to the full config-file effort.

Verified: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, config unit tests (55), and an end-to-end run of `config set`/`get`/`delete` against a real `~/.config/nub/nub.jsonc` (comment/`$schema`/trailing-comma preservation, kebab alias, malformed→default, non-object-`exec` recovery).

Refs #275