### PR TITLE
fix(pm): make hoist default GVS-aware — hidden hoist tree wherever GVS does not engage

### DIFF
--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -182,6 +182,16 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     // `--loglevel debug` / `RUST_LOG`. The per-project fallback behavior itself
     // is unchanged; only the notice is silenced.
     gvs_incompatible_warning: false,
+    // GVS-precedence hoisting (#286): a DEFAULT hoist no longer vetoes the
+    // shared virtual store, so GVS engages wherever it's active (off-CI, no
+    // trigger, no explicit opt-out) with no hidden tree, and the pnpm-parity
+    // hidden hoist tree is built wherever GVS is OFF (CI, `nub ci`, a
+    // next/nuxt/parcel trigger, an explicit `enableGlobalVirtualStore=false`,
+    // dlx) — restoring ambient `@types/*` resolution for store-resident
+    // packages. Only an EXPLICIT `hoist=true` (nub's injected-deps push, or a
+    // user setting) vetoes GVS. Nub therefore no longer pushes `hoist=false`;
+    // see `nub_setting_defaults`.
+    gvs_over_default_hoist: true,
     primer_ttl: None,
     // Cap aube's CPU-bound pools (linker rayon pool, tokio worker seed) to the
     // real cgroup CFS-CPU-quota budget on a constrained box; `None` on an
@@ -253,6 +263,7 @@ const _: () = {
     assert!(NUB.no_churn_lockfile_write);
     assert!(!NUB.read_branded_settings_env);
     assert!(!NUB.gvs_incompatible_warning);
+    assert!(NUB.gvs_over_default_hoist);
     assert!(NUB.primer_ttl.is_none());
     assert!(NUB.tty_progress);
     assert!(!NUB.warm_trust_revalidate);

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2006,18 +2006,22 @@ fn strip_yarnrc_value(rest: &str) -> &str {
     rest.split('#').next().map(str::trim).unwrap_or(rest)
 }
 
-/// - Layout policy: EVERY non-injected project — every incumbent
-///   (npm/yarn/bun/pnpm) and a fresh nub-identity project — defaults to the
-///   isolated layout with the hidden hoist tree OFF (`nodeLinker=isolated` +
-///   `hoist=false`), the config that engages the global virtual store since
-///   aube's `effective_gvs = planned_gvs && !hoist && Isolated`. This is the
-///   greenlit compat→correctness shift (2026-06-28): isolated is strict (no
-///   phantom deps) and GVS-fast across every project; a project that relies on
-///   phantom deps opts back into the flat tree with one `.npmrc` line
-///   (`node-linker=hoisted`). The ONLY carve-out is injected deps
-///   (`dependenciesMeta.*.injected`), which need the hidden hoist tree and so
-///   keep the engine's isolated + hoist=true default (GVS off). A user-set
-///   `nodeLinker`/`hoist` (env/.npmrc/yaml) still wins — embedder-tier default.
+/// - Layout policy: EVERY project defaults to the isolated layout
+///   (`nodeLinker=isolated`) — strict (no phantom deps) and GVS-fast; a project
+///   that relies on phantom deps opts back into the flat tree with one `.npmrc`
+///   line (`node-linker=hoisted`). Hoisting is left GVS-AWARE via the engine's
+///   `gvs_over_default_hoist` profile: a NON-injected project leaves `hoist` at
+///   the built-in default (`true`), and under that profile a DEFAULT hoist no
+///   longer vetoes the shared store — so the global virtual store engages
+///   wherever it's active (off-CI, no next/nuxt/parcel trigger, no explicit
+///   `enableGlobalVirtualStore=false`) with NO hidden tree, and the pnpm-parity
+///   hidden hoist tree (`node_modules/.nub/node_modules/`) is built wherever GVS
+///   is OFF (CI, `nub ci`, a trigger, an explicit GVS opt-out, dlx), restoring
+///   ambient `@types/*` resolution for store-resident packages (#286). The ONE
+///   carve-out is injected deps (`dependenciesMeta.*.injected`): they need the
+///   hidden tree unconditionally, so nub pushes an EXPLICIT `hoist=true`, which
+///   DOES veto GVS under the profile (per-project + hidden tree, always). A
+///   user-set `nodeLinker`/`hoist` (env/.npmrc/yaml) still wins — embedder-tier.
 /// - Fresh-write lockfile format: a TRULY-fresh project (no PM-preference
 ///   signal of any kind — `truly_fresh`) writes nub's neutral `lock.yaml`
 ///   (`defaultLockfileFormat=aube`, which under the nub embedder resolves to
@@ -2059,30 +2063,32 @@ fn nub_setting_defaults(
     // is still excluded from the GVS default below if it declares injected deps.
     let injected_root = detected.map(|d| d.dir.as_path()).unwrap_or(cwd);
     let injected = unsupported_config::injected_deps_present(injected_root);
-    // GREENLIT 2026-06-28 compat→correctness flip: EVERY non-injected project —
-    // any incumbent (npm/yarn/bun/pnpm) and a fresh nub-identity project —
-    // defaults to isolated with the hidden hoist tree OFF. Pushing `hoist=false`
-    // under the engine's isolated default is what engages the global virtual
-    // store (aube gvs.rs: `effective_gvs = planned_gvs && !hoist && Isolated`);
-    // `nodeLinker=isolated` is pushed explicitly so the layout intent reads at
-    // this call site even though it equals the engine default. Injected deps
+    // EVERY project defaults to isolated. Hoisting is left GVS-AWARE via the
+    // engine's `gvs_over_default_hoist` profile (nub's identity sets it): a
+    // NON-injected project pushes NO `hoist`, so it resolves to the built-in
+    // default (true) which — under the profile — does NOT veto the shared store,
+    // so GVS engages wherever active (no hidden tree) and the pnpm-parity hidden
+    // hoist tree is built by the linker wherever GVS is off (CI/`nub ci`/a
+    // next/nuxt/parcel trigger/explicit GVS opt-out/dlx) — restoring ambient
+    // `@types/*` for store-resident packages (#286). Injected deps
     // (`dependenciesMeta.*.injected`) are the ONE carve-out: they need the
-    // hidden tree to sibling-link packed copies, so they keep stock-aube
-    // isolated+hoist=true (GVS off) — proven, where injected-under-GVS is not.
-    // A user-set `nodeLinker`/`hoist` (env/.npmrc/yaml) still wins.
-    if !injected {
-        defaults.push(("nodeLinker".to_string(), "isolated".to_string()));
-        defaults.push(("hoist".to_string(), "false".to_string()));
+    // hidden tree unconditionally, so nub pushes an EXPLICIT `hoist=true`, which
+    // DOES veto GVS under the profile (per-project + hidden tree, always) —
+    // proven, where injected-under-GVS is not. A user-set `nodeLinker`/`hoist`
+    // (env/.npmrc/yaml) still wins.
+    defaults.push(("nodeLinker".to_string(), "isolated".to_string()));
+    if injected {
+        defaults.push(("hoist".to_string(), "true".to_string()));
     }
-    // `nub ci` forces the virtual store PROJECT-LOCAL (GVS off). Combined with
-    // the isolated+hoist=false layout above, this yields real `node_modules/
-    // .nub/<dep>` dirs + relative symlinks (aube: `effective_gvs = planned_gvs
-    // && !hoist && Isolated`, and `planned_gvs = override ?? !$CI`) — a self-
-    // contained tree that survives a multi-stage-Docker `COPY --from`, unlike
-    // the machine-global store the default install engages (#241). Isolation
-    // (phantom-dep protection) is unchanged; only the store LOCATION moves.
-    // Embedder-tier, so an explicit user `enableGlobalVirtualStore`/`nodeLinker`
-    // still wins.
+    // `nub ci` forces the virtual store PROJECT-LOCAL by pushing an explicit
+    // `enableGlobalVirtualStore=false` (GVS off). With GVS off and the default
+    // `hoist=true`, the isolated linker yields real `node_modules/.nub/<dep>`
+    // dirs + relative symlinks AND the pnpm-parity hidden hoist tree
+    // (`node_modules/.nub/node_modules/`) — a self-contained tree that survives a
+    // multi-stage-Docker `COPY --from`, unlike the machine-global store the
+    // default install engages (#241). Isolation (phantom-dep protection) is
+    // unchanged; only the store LOCATION moves. Embedder-tier, so an explicit
+    // user `enableGlobalVirtualStore`/`nodeLinker` still wins.
     if store_locality == VirtualStoreLocality::ProjectLocal {
         defaults.push(("enableGlobalVirtualStore".to_string(), "false".to_string()));
     }
@@ -2564,8 +2570,10 @@ mod tests {
         };
 
         // Every non-injected incumbent kind AND a fresh project default to
-        // isolated + hoist=false (the GVS-engaging config: aube's effective_gvs
-        // needs `!hoist && Isolated`). The tempdir has no injected manifest.
+        // isolated with NO `hoist` push: hoist resolves to the built-in default
+        // (true), which under nub's `gvs_over_default_hoist` profile lets GVS
+        // engage while the linker builds the hidden tree only where GVS is off.
+        // The tempdir has no injected manifest.
         for kind in [
             LockfileKind::Npm,
             LockfileKind::NpmShrinkwrap,
@@ -2588,8 +2596,8 @@ mod tests {
             );
             assert_eq!(
                 get(&defaults, "hoist"),
-                Some("false"),
-                "{kind:?} must turn the hidden hoist tree off so GVS engages"
+                None,
+                "{kind:?} must NOT push hoist — a default hoist keeps GVS engaged"
             );
         }
 
@@ -2602,17 +2610,18 @@ mod tests {
         );
         assert_eq!(
             get(&fresh, "hoist"),
-            Some("false"),
-            "fresh ⇒ hoist off (GVS)"
+            None,
+            "fresh ⇒ no hoist push (GVS engages by default)"
         );
     }
 
     #[test]
     fn injected_deps_keep_the_hidden_hoist_tree_and_opt_out_of_gvs() {
         // The ONE carve-out: a project declaring `dependenciesMeta.*.injected`
-        // needs the hidden hoist tree, so it keeps the engine's isolated +
-        // hoist=true default (no nodeLinker/hoist pushed) — GVS off. Covered for
-        // both a detected incumbent and a fresh project rooted at cwd.
+        // needs the hidden hoist tree unconditionally, so nub pushes an EXPLICIT
+        // `hoist=true` — which vetoes GVS under the `gvs_over_default_hoist`
+        // profile (per-project + hidden tree, always). Covered for both a
+        // detected incumbent and a fresh project rooted at cwd.
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("package.json"),
@@ -2635,13 +2644,13 @@ mod tests {
         ] {
             assert_eq!(
                 get(&defaults, "nodeLinker"),
-                None,
-                "injected ⇒ no nodeLinker push"
+                Some("isolated"),
+                "injected ⇒ isolated (like every project)"
             );
             assert_eq!(
                 get(&defaults, "hoist"),
-                None,
-                "injected ⇒ no hoist push (GVS off)"
+                Some("true"),
+                "injected ⇒ explicit hoist=true (vetoes GVS, forces the hidden tree)"
             );
         }
     }
@@ -2650,8 +2659,10 @@ mod tests {
     fn ci_forces_project_local_store_but_keeps_isolation() {
         // `nub ci` (VirtualStoreLocality::ProjectLocal) pushes
         // `enableGlobalVirtualStore=false` so the frozen node_modules is
-        // COPY-relocatable (#241), while keeping the isolated+hoist=false layout
-        // (phantom-dep protection). A plain install (Default) leaves GVS on.
+        // COPY-relocatable (#241), while keeping the isolated layout (phantom-dep
+        // protection). It pushes NO `hoist`: with GVS off the default hoist=true
+        // makes the linker build the pnpm-parity hidden tree. A plain install
+        // (Default) leaves GVS on.
         let dir = tempfile::tempdir().unwrap();
         let detected = DetectedLockfile {
             kind: LockfileKind::Npm,
@@ -2675,7 +2686,11 @@ mod tests {
             Some("isolated"),
             "ci keeps the isolated layout"
         );
-        assert_eq!(get(&ci, "hoist"), Some("false"), "ci keeps hoist off");
+        assert_eq!(
+            get(&ci, "hoist"),
+            None,
+            "ci pushes no hoist — the default builds the hidden tree with GVS off"
+        );
 
         let plain = nub_setting_defaults(
             Some(&detected),

--- a/crates/nub-cli/src/pm_engine/unsupported_config.rs
+++ b/crates/nub-cli/src/pm_engine/unsupported_config.rs
@@ -12,11 +12,13 @@
 //!      mode (same path `--frozen-lockfile` takes).
 //!   3. `enableScripts: false` (yarn) → force a block-all-builds policy that
 //!      overrides even nub's curated default-trust floor.
-//!   4. `dependenciesMeta.*.injected` → the carve-out from the isolated+GVS
-//!      default: nub's default flips every other non-injected project to
-//!      `hoist=false` (no hidden hoist tree, GVS on), but injected copies
-//!      materialize only with the hidden hoist tree, so an injected project
-//!      keeps the engine's isolated + `hoist=true` default (GVS off).
+//!   4. `dependenciesMeta.*.injected` → the carve-out from the GVS-aware
+//!      hoisting default: a non-injected project pushes no `hoist` (it resolves
+//!      to the default `true`, which under nub's `gvs_over_default_hoist` profile
+//!      lets GVS engage without a hidden hoist tree), but injected copies
+//!      materialize only with the hidden hoist tree on, so an injected project
+//!      pushes an EXPLICIT `hoist=true` — vetoing GVS (per-project + hidden
+//!      tree, always).
 //!
 //! (`minimumReleaseAge` from bunfig is wired in [`super::bun_config`] — it maps
 //! to a synthetic `.npmrc` entry the settings registry already reads.)
@@ -208,9 +210,10 @@ fn yarn_offline_mirror_configured(root: &Path) -> bool {
 /// Whether the root (or any workspace member) manifest declares
 /// `dependenciesMeta.<pkg>.injected: true`. aube materializes injected copies
 /// only with the hidden hoist tree on, so an injected project is the carve-out
-/// from the isolated+GVS default: instead of `hoist=false` (GVS on) it keeps
-/// the engine's isolated + `hoist=true` default (GVS off), rather than silently
-/// dropping the directive.
+/// from the GVS-aware hoisting default: instead of leaving `hoist` at its
+/// default (which lets GVS engage), it pushes an EXPLICIT `hoist=true` that
+/// vetoes GVS (per-project + hidden tree), rather than silently dropping the
+/// directive.
 pub(crate) fn injected_deps_present(root: &Path) -> bool {
     manifest_has_injected(&root.join("package.json"))
         || aube_workspace::find_workspace_packages(root)

--- a/crates/nub-cli/tests/bun_basic_config.rs
+++ b/crates/nub-cli/tests/bun_basic_config.rs
@@ -178,10 +178,10 @@ fn nub_identity_does_not_read_project_or_global_bunfig() {
         "https://registry.npmjs.org/"
     );
     // The bunfig's `linker = "hoisted"` must NOT be read under nub identity:
-    // nodeLinker resolves to nub's own default (isolated, with hoist=false for
-    // GVS), not the bunfig's `hoisted`. Asserting the NON-bunfig value is what
-    // proves the bunfig was ignored — the project still gets nub's isolated+GVS
-    // default like any other non-injected project.
+    // nodeLinker resolves to nub's own default (isolated), not the bunfig's
+    // `hoisted`. Asserting the NON-bunfig value is what proves the bunfig was
+    // ignored — the project still gets nub's isolated + GVS-aware default like
+    // any other non-injected project.
     assert_eq!(config_get(&dir, &xdg_config, "nodeLinker"), "isolated");
 }
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -454,6 +454,18 @@ node-linker=hoisted
 
 The `--node-linker hoisted` flag does the same for a single command. When an undeclared package fails to resolve at runtime, Nub's error names it and points at this opt-out.
 
+### Shared vs per-project store
+
+Outside CI, the isolated virtual store is shared across projects: a package version materializes once per machine and every project links to that copy. It is fast and disk-cheap, but machine-local — the links reach outside the project, so a `node_modules` copied to another machine won't resolve.
+
+In CI, and under `nub ci`, each project gets its own self-contained virtual store instead — real directories and relative links, nothing shared. That tree survives a Docker `COPY --from` into a fresh image, where the shared store wouldn't exist. Force it for any install with one line in `.npmrc`:
+
+```ini
+enableGlobalVirtualStore=false
+```
+
+Either layout resolves the same packages — including type packages (`@types/*`) pulled in transitively but not declared, which stay reachable in both.
+
 ### Offline installs
 
 Like pnpm, Nub relinks files from the global store into `node_modules` via reflink (APFS/btrfs) or hardlink (ext4) when the store already holds every package — no re-download, no byte-for-byte copy. The benchmark below measures the warm reinstall case: `node_modules` is removed, packages are already on disk, and the installer rebuilds the project layout.

--- a/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -37,6 +37,7 @@ static MYTOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,

--- a/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
@@ -43,6 +43,7 @@ static MYTOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -47,6 +47,7 @@ static NO_CHURN_TOOL: Embedder = Embedder {
     no_churn_lockfile_write: true,
     read_branded_settings_env: true,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -40,6 +40,7 @@ static STRICT: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -43,6 +43,7 @@ static ROOT_TOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,

--- a/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
@@ -39,6 +39,7 @@ static MYTOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -34,6 +34,7 @@ static ROOT_TOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,

--- a/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
@@ -33,6 +33,7 @@ static MYTOOL: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     primer_ttl: None,
     cpu_budget: None,
     tty_progress: false,

--- a/vendor/aube/crates/aube-settings/build.rs
+++ b/vendor/aube/crates/aube-settings/build.rs
@@ -69,6 +69,18 @@ struct SettingDef {
     /// strings such as `ranked:off<on<required`.
     #[serde(default, rename = "managedPolicy")]
     managed_policy: String,
+    /// When `true`, emit a companion `<fn_name>_explicit(ctx) -> Option<T>`
+    /// accessor alongside the normal one. It resolves the setting through the
+    /// same source chain and managed-config finalizer but WITHOUT folding in the
+    /// built-in default, so the caller can distinguish "explicitly set at some
+    /// tier (cli/env/npmrc/yaml/embedderDefaults)" from "left at the built-in
+    /// default." Only meaningful for settings whose default is a concrete value
+    /// (the normal accessor returns `T`, not `Option<T>`); a setting with an
+    /// undefined default already exposes that distinction. Currently used by
+    /// `hoist`, whose default `true` otherwise hides whether the user (or an
+    /// embedder tier) asked for hoisting.
+    #[serde(default, rename = "explicitAccessor")]
+    explicit_accessor: bool,
     #[serde(default)]
     examples: Vec<String>,
 }
@@ -249,6 +261,17 @@ fn generate_resolved_accessors(settings: &BTreeMap<String, SettingDef>) -> Strin
             Some(_) => value_ty.clone(),
             None => format!("Option<{value_ty}>"),
         };
+        if def.explicit_accessor {
+            assert!(
+                default_expr.is_some(),
+                "{name}: explicitAccessor is redundant when the default is undefined — the \
+                 normal accessor already returns Option<T>"
+            );
+            assert!(
+                kind != Kind::Enum,
+                "{name}: explicitAccessor is not supported for enum settings"
+            );
+        }
         let (npmrc_call, ws_call, env_call, cli_call) = match kind {
             Kind::Bool => (
                 "bool_from_npmrc",
@@ -388,6 +411,30 @@ fn generate_resolved_accessors(settings: &BTreeMap<String, SettingDef>) -> Strin
             .unwrap(),
         }
         writeln!(out, "}}\n").unwrap();
+
+        // Companion `<fn_name>_explicit` accessor: the same source walk +
+        // managed finalizer, but WITHOUT `.or(Some(default))`, so it returns
+        // `None` when only the built-in default would apply. Lets a caller tell
+        // "explicitly configured (cli/env/npmrc/yaml/embedderDefaults)" from
+        // "defaulted." Guarded above to non-enum settings with a concrete
+        // default.
+        if def.explicit_accessor {
+            writeln!(
+                out,
+                "/// Resolved `{name}` WITHOUT the built-in default folded in —\n\
+                 /// `Some` iff set at some source tier, else `None`. Companion to\n\
+                 /// [`{fn_name}`] (see `explicitAccessor` in settings.toml).\n\
+                 pub fn {fn_name}_explicit(ctx: &ResolveCtx<'_>) -> Option<{value_ty}> {{"
+            )
+            .unwrap();
+            emit_resolution(&mut out, &source_exprs);
+            writeln!(
+                out,
+                "    super::{finalizer}({name:?}, value, ctx.managed_aube_config)"
+            )
+            .unwrap();
+            writeln!(out, "}}\n").unwrap();
+        }
     }
 
     out

--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -672,6 +672,10 @@ npmShared = true
 description = "Hoist all dependencies to the hidden modules directory."
 type = "bool"
 default = "true"
+# Emit `hoist_explicit(ctx) -> Option<bool>`: the GVS-precedence layout
+# (embedder `gvs_over_default_hoist`) must distinguish an EXPLICIT hoist=true
+# (vetoes the shared store) from the built-in default (lets GVS engage).
+explicitAccessor = true
 docs = """
 Controls whether aube populates `node_modules/.aube/node_modules/` —
 the *hidden* hoist tree that lives inside the private virtual store.

--- a/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
+++ b/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
@@ -47,6 +47,7 @@ static MYTOOL_NO_BRANDED_ENV: Embedder = Embedder {
     warm_store_verify: true,
     read_branded_settings_env: false,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     no_churn_lockfile_write: false,
     primer_ttl: None,
     cpu_budget: None,

--- a/vendor/aube/crates/aube-settings/tests/hoist_explicit.rs
+++ b/vendor/aube/crates/aube-settings/tests/hoist_explicit.rs
@@ -1,0 +1,72 @@
+//! The `hoist_explicit` companion accessor (`explicitAccessor = true` in
+//! settings.toml) distinguishes an EXPLICITLY-configured `hoist` from the
+//! built-in default. The `gvs_over_default_hoist` layout needs that: an
+//! explicit `hoist=true` vetoes the shared virtual store, a defaulted one does
+//! not.
+
+use aube_settings::{ResolveCtx, resolved};
+use std::collections::BTreeMap;
+
+fn ctx<'a>(
+    npmrc: &'a [(String, String)],
+    env: &'a [(String, String)],
+    cli: &'a [(String, String)],
+    embedder_defaults: &'a [(String, String)],
+    ws: &'a BTreeMap<String, yaml_serde::Value>,
+) -> ResolveCtx<'a> {
+    ResolveCtx {
+        managed_aube_config: &[],
+        project_aube_config: &[],
+        project_npmrc: npmrc,
+        user_aube_config: &[],
+        user_npmrc: &[],
+        workspace_yaml: ws,
+        global_config_yaml: aube_settings::values::empty_yaml_map(),
+        env,
+        cli,
+        embedder_defaults,
+    }
+}
+
+#[test]
+fn unset_is_none_while_normal_accessor_returns_the_default() {
+    let ws = BTreeMap::new();
+    let c = ctx(&[], &[], &[], &[], &ws);
+    assert_eq!(
+        resolved::hoist_explicit(&c),
+        None,
+        "no source set hoist ⇒ explicit is None"
+    );
+    assert!(
+        resolved::hoist(&c),
+        "the normal accessor still folds in the built-in default (true)"
+    );
+}
+
+#[test]
+fn explicit_false_and_true_are_reported_from_every_tier() {
+    let ws = BTreeMap::new();
+
+    let npmrc = vec![("hoist".to_string(), "false".to_string())];
+    assert_eq!(
+        resolved::hoist_explicit(&ctx(&npmrc, &[], &[], &[], &ws)),
+        Some(false),
+        ".npmrc hoist=false ⇒ explicit Some(false)"
+    );
+
+    let env = vec![("npm_config_hoist".to_string(), "true".to_string())];
+    assert_eq!(
+        resolved::hoist_explicit(&ctx(&[], &env, &[], &[], &ws)),
+        Some(true),
+        "env ⇒ explicit Some(true)"
+    );
+
+    // The embedder-defaults tier COUNTS as explicit — this is what lets nub's
+    // injected-deps `hoist=true` push veto GVS.
+    let embedder = vec![("hoist".to_string(), "true".to_string())];
+    assert_eq!(
+        resolved::hoist_explicit(&ctx(&[], &[], &[], &embedder, &ws)),
+        Some(true),
+        "embedderDefaults hoist=true ⇒ explicit Some(true)"
+    );
+}

--- a/vendor/aube/crates/aube-util/src/identity.rs
+++ b/vendor/aube/crates/aube-util/src/identity.rs
@@ -240,6 +240,25 @@ pub struct Embedder {
     /// engine log level is raised to `debug`. Gates ONLY the notice's level;
     /// the per-project fallback BEHAVIOR is identical either way. Embedder-fixed.
     pub gvs_incompatible_warning: bool,
+    /// When `false` (aube's default), a *default* `hoist` (the built-in
+    /// `hoist=true`, nobody set it) vetoes the global virtual store exactly as
+    /// upstream: `effective_gvs = planned && !hoist && Isolated`, so the shared
+    /// store engages only when `hoist` is off. When `true`, only an
+    /// *explicitly-set* `hoist=true` vetoes GVS; a DEFAULT hoist lets GVS engage
+    /// (`effective_gvs = planned && Isolated && !explicit_hoist`), and the hidden
+    /// hoist tree (`node_modules/.<store>/node_modules/`) is built only where GVS
+    /// does NOT engage (CI, per-project, an incompatible-package trigger, an
+    /// explicit `enableGlobalVirtualStore=false`, dlx).
+    ///
+    /// The embedder that pushes an isolated layout as its default (nub) needs
+    /// this so the hidden hoist tree — pnpm-parity for `hoistPattern:['*']`, which
+    /// restores ambient `@types/*` resolution for store-resident packages —
+    /// still gets built wherever the shared store isn't active, instead of being
+    /// lost for zero GVS benefit. Standalone aube keeps `false`, so its coupling
+    /// (`gvs.rs::effective_global_virtual_store` and the linker's
+    /// `use_global_virtual_store && hoist` fallback) is byte-for-byte unchanged.
+    /// Embedder-fixed: the host's layout posture, not a per-project knob.
+    pub gvs_over_default_hoist: bool,
     /// How long after the bundled primer's build date (`generated_at`) the
     /// offline metadata primer is consulted at all. `None` = unlimited (the
     /// primer never expires); `Some(d)` = consult the primer only while
@@ -378,6 +397,9 @@ pub const AUBE: Embedder = Embedder {
     no_churn_lockfile_write: false,
     read_branded_settings_env: true,
     gvs_incompatible_warning: true,
+    // Standalone aube keeps the stock GVS↔hoist coupling: a default hoist=true
+    // vetoes the shared store, so its install layout is byte-for-byte unchanged.
+    gvs_over_default_hoist: false,
     primer_ttl: None,
     cpu_budget: None,
     // Append-only by default on a TTY; the animated renderer stays an
@@ -565,6 +587,7 @@ mod tests {
         assert!(id.warm_store_verify);
         assert!(!id.no_churn_lockfile_write);
         assert!(id.read_branded_settings_env);
+        assert!(!id.gvs_over_default_hoist);
         assert_eq!(id.config_env_prefix, Some("AUBE"));
         assert_eq!(id.primer_ttl, None);
         assert!(!id.tty_progress);

--- a/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -45,6 +45,7 @@ static NUBLIKE: Embedder = Embedder {
     warm_store_verify: false,
     read_branded_settings_env: false,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     no_churn_lockfile_write: true,
     primer_ttl: None,
     cpu_budget: None,

--- a/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -41,6 +41,7 @@ static NUBLIKE: Embedder = Embedder {
     warm_store_verify: false,
     read_branded_settings_env: false,
     gvs_incompatible_warning: true,
+    gvs_over_default_hoist: false,
     no_churn_lockfile_write: true,
     primer_ttl: None,
     cpu_budget: None,

--- a/vendor/aube/crates/aube/src/commands/install/gvs.rs
+++ b/vendor/aube/crates/aube/src/commands/install/gvs.rs
@@ -72,12 +72,59 @@ pub(super) fn planned_global_virtual_store(
 /// (`hoist=true`) project see a spurious `disabled → enabled` transition
 /// and wipe `node_modules` (issue #71 — `aube add` in a workspace member,
 /// which always bypasses the fast path).
+///
+/// Under the [`gvs_over_default_hoist`] embedder profile the coupling changes:
+/// only an EXPLICITLY-set `hoist=true` (`hoist_explicit == Some(true)`) vetoes
+/// the shared store, so a DEFAULT hoist lets GVS engage and the hidden hoist
+/// tree is built only where GVS is off ([`build_hidden_tree`]). Standalone aube
+/// (`gvs_over_default_hoist == false`) keeps the stock formula byte-for-byte, so
+/// its lockstep with the linker's own `use_global_virtual_store && hoist`
+/// fallback is preserved. Under the embedder profile the linker is instead
+/// handed the pre-folded (effective GVS, hidden-tree) pair so that fallback is
+/// never reached — see `run_link_phase`.
+///
+/// [`gvs_over_default_hoist`]: aube_util::Embedder::gvs_over_default_hoist
 pub(super) fn effective_global_virtual_store(
     planned_gvs: bool,
     hoist: bool,
+    hoist_explicit: Option<bool>,
     node_linker: aube_linker::NodeLinker,
 ) -> bool {
-    planned_gvs && !hoist && matches!(node_linker, aube_linker::NodeLinker::Isolated)
+    effective_gvs_impl(
+        aube_util::embedder().gvs_over_default_hoist,
+        planned_gvs,
+        hoist,
+        hoist_explicit,
+        node_linker,
+    )
+}
+
+/// Pure core of [`effective_global_virtual_store`], the embedder flag passed
+/// explicitly so both coupling regimes are unit-testable without registering a
+/// process-global profile.
+fn effective_gvs_impl(
+    gvs_over_default_hoist: bool,
+    planned_gvs: bool,
+    hoist: bool,
+    hoist_explicit: Option<bool>,
+    node_linker: aube_linker::NodeLinker,
+) -> bool {
+    let isolated = matches!(node_linker, aube_linker::NodeLinker::Isolated);
+    if gvs_over_default_hoist {
+        planned_gvs && isolated && !hoist_explicit.unwrap_or(false)
+    } else {
+        planned_gvs && !hoist && isolated
+    }
+}
+
+/// Whether the isolated linker should build the hidden hoist tree
+/// (`node_modules/.<store>/node_modules/`). It exists ONLY where the shared
+/// global virtual store is NOT active: a bare-name alias inside the SHARED
+/// store is cross-project-mutable state (aube issue #6), so a live GVS must
+/// never carry one. `resolved_hoist` is the resolved `hoist` setting (default
+/// `true`); `effective_gvs` is [`effective_global_virtual_store`].
+pub(super) fn build_hidden_tree(resolved_hoist: bool, effective_gvs: bool) -> bool {
+    resolved_hoist && !effective_gvs
 }
 
 /// The global-virtual-store decision the fetch-pipelined materializer
@@ -170,6 +217,10 @@ mod tests {
     // every non-fast-path install (e.g. `add` in a workspace member),
     // wiping node_modules each time.
 
+    // The stock (flag-off) coupling. Tests run with no embedder registered, so
+    // `effective_global_virtual_store` reads `AUBE` (`gvs_over_default_hoist ==
+    // false`) and a default hoist=true still vetoes the shared store.
+
     #[test]
     fn default_project_predicts_per_project_so_no_spurious_reset() {
         // hoist=true (default), isolated (default), GVS requested on (off-CI):
@@ -177,6 +228,7 @@ mod tests {
         assert!(!effective_global_virtual_store(
             true,
             true,
+            None,
             NodeLinker::Isolated
         ));
     }
@@ -186,6 +238,7 @@ mod tests {
         assert!(effective_global_virtual_store(
             true,
             false,
+            Some(false),
             NodeLinker::Isolated
         ));
     }
@@ -195,11 +248,13 @@ mod tests {
         assert!(!effective_global_virtual_store(
             true,
             false,
+            Some(false),
             NodeLinker::Hoisted
         ));
         assert!(!effective_global_virtual_store(
             true,
             true,
+            None,
             NodeLinker::Hoisted
         ));
     }
@@ -209,13 +264,86 @@ mod tests {
         assert!(!effective_global_virtual_store(
             false,
             false,
+            Some(false),
             NodeLinker::Isolated
         ));
         assert!(!effective_global_virtual_store(
             false,
             true,
+            None,
             NodeLinker::Isolated
         ));
+    }
+
+    // The `gvs_over_default_hoist` (nub) coupling, exercised through the pure
+    // `effective_gvs_impl` so the flag is set explicitly (no process-global
+    // embedder registration). Only an EXPLICIT hoist=true vetoes GVS.
+
+    #[test]
+    fn flag_default_hoist_lets_gvs_engage() {
+        // hoist resolves to the default `true` but was never explicitly set:
+        // GVS engages off-CI on the isolated layout.
+        assert!(effective_gvs_impl(
+            true,
+            true,
+            true,
+            None,
+            NodeLinker::Isolated
+        ));
+    }
+
+    #[test]
+    fn flag_explicit_hoist_true_vetoes_gvs() {
+        // An explicit hoist=true (e.g. nub's injected-deps embedder push) keeps
+        // per-project + hidden tree, even off-CI.
+        assert!(!effective_gvs_impl(
+            true,
+            true,
+            true,
+            Some(true),
+            NodeLinker::Isolated
+        ));
+    }
+
+    #[test]
+    fn flag_explicit_hoist_false_keeps_gvs_on() {
+        assert!(effective_gvs_impl(
+            true,
+            true,
+            false,
+            Some(false),
+            NodeLinker::Isolated
+        ));
+    }
+
+    #[test]
+    fn flag_ci_and_hoisted_stay_off() {
+        // planned off (CI) ⇒ off regardless of hoist explicitness.
+        assert!(!effective_gvs_impl(
+            true,
+            false,
+            true,
+            None,
+            NodeLinker::Isolated
+        ));
+        // hoisted layout never engages the shared store.
+        assert!(!effective_gvs_impl(
+            true,
+            true,
+            true,
+            None,
+            NodeLinker::Hoisted
+        ));
+    }
+
+    #[test]
+    fn hidden_tree_is_built_only_when_gvs_is_off() {
+        // Default hoist, GVS on ⇒ no hidden tree (can't live in a shared store).
+        assert!(!build_hidden_tree(true, true));
+        // Default hoist, GVS off (CI / per-project) ⇒ hidden tree built.
+        assert!(build_hidden_tree(true, false));
+        // Explicit hoist=false ⇒ never a hidden tree.
+        assert!(!build_hidden_tree(false, false));
     }
 
     // The prewarm materializer must mirror the link phase's *effective*

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -41,6 +41,19 @@ pub(super) fn resolve_node_linker(
     }
 }
 
+/// Pre-folded (effective GVS, hidden-tree) decision computed once in the
+/// command layer under the `gvs_over_default_hoist` embedder profile. When
+/// present, `run_link_phase` hands the linker `use_global_virtual_store =
+/// effective_gvs` and `hoist = build_hidden_tree` directly, so the linker's own
+/// `use_global_virtual_store && hoist` fallback (which bakes in the stock
+/// coupling) is never reached. `None` on standalone aube's default path, where
+/// the linker re-derives from the raw override + resolved hoist unchanged.
+#[derive(Clone, Copy)]
+pub(super) struct GvsHoistDecision {
+    pub(super) effective_gvs: bool,
+    pub(super) build_hidden_tree: bool,
+}
+
 pub(super) struct LinkPhaseInput<'a> {
     pub(super) cwd: &'a std::path::Path,
     pub(super) settings_ctx: &'a aube_settings::ResolveCtx<'a>,
@@ -60,6 +73,7 @@ pub(super) struct LinkPhaseInput<'a> {
     pub(super) link_concurrency_setting: Option<usize>,
     pub(super) use_global_virtual_store_override: Option<bool>,
     pub(super) planned_gvs: bool,
+    pub(super) gvs_hoist_decision: Option<GvsHoistDecision>,
     pub(super) has_workspace: bool,
     pub(super) dep_selection_filtered: bool,
     pub(super) workspace_filter_empty: bool,
@@ -102,6 +116,7 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         link_concurrency_setting,
         use_global_virtual_store_override,
         planned_gvs,
+        gvs_hoist_decision,
         has_workspace,
         dep_selection_filtered,
         workspace_filter_empty,
@@ -127,7 +142,22 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
 
     let shamefully_hoist = aube_settings::resolved::shamefully_hoist(settings_ctx);
     let public_hoist_pattern = aube_settings::resolved::public_hoist_pattern(settings_ctx);
-    let hoist = aube_settings::resolved::hoist(settings_ctx);
+    // Under the `gvs_over_default_hoist` profile the command layer pre-folded the
+    // (effective GVS, hidden-tree) decision: `hoist` becomes "build the hidden
+    // tree" and the GVS override becomes the effective mode, so the linker's own
+    // `use_global_virtual_store && hoist` fallback is never reached. Standalone
+    // aube (`None`) resolves hoist and keeps the raw override — the linker
+    // re-derives, byte-for-byte unchanged.
+    let (hoist, use_global_virtual_store_override) = match gvs_hoist_decision {
+        Some(GvsHoistDecision {
+            effective_gvs,
+            build_hidden_tree,
+        }) => (build_hidden_tree, Some(effective_gvs)),
+        None => (
+            aube_settings::resolved::hoist(settings_ctx),
+            use_global_virtual_store_override,
+        ),
+    };
     let hoist_pattern = aube_settings::resolved::hoist_pattern(settings_ctx);
     let hoist_workspace_packages = aube_settings::resolved::hoist_workspace_packages(settings_ctx);
     let hoisting_limits = crate::commands::settings_hoisting_limits_to_linker(

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -939,11 +939,32 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // transition and wipe `node_modules` (issue #71). `resolve_node_linker`
     // is the same resolver the link phase uses, so the two stay in lockstep.
     let resolved_node_linker = link::resolve_node_linker(&settings_ctx)?;
+    let resolved_hoist = aube_settings::resolved::hoist(&settings_ctx);
+    // `hoist_explicit` is `Some` only when hoist was set at some tier above the
+    // built-in default (embedder defaults COUNT); under the
+    // `gvs_over_default_hoist` profile only an explicit `hoist=true` vetoes GVS.
+    let hoist_explicit = aube_settings::resolved::hoist_explicit(&settings_ctx);
     let effective_gvs = gvs::effective_global_virtual_store(
         planned_gvs,
-        aube_settings::resolved::hoist(&settings_ctx),
+        resolved_hoist,
+        hoist_explicit,
         resolved_node_linker,
     );
+    // Under the `gvs_over_default_hoist` embedder profile, pre-fold the
+    // (effective GVS, hidden-tree) decision ONCE here and hand it to the link
+    // phase, so the mode-change reset, the prewarm, and the linker all act on
+    // the same values (issue #71 lockstep) and the linker's own
+    // `use_global_virtual_store && hoist` fallback is never reached. `None` on
+    // standalone aube's default path — the link phase then resolves hoist itself
+    // and passes the raw override, and the linker re-derives, byte-for-byte
+    // unchanged.
+    let gvs_hoist_decision =
+        aube_util::embedder()
+            .gvs_over_default_hoist
+            .then(|| link::GvsHoistDecision {
+                effective_gvs,
+                build_hidden_tree: gvs::build_hidden_tree(resolved_hoist, effective_gvs),
+            });
     gvs::reset_on_mode_change(&cwd, &aube_dir, &modules_dir_name, effective_gvs)?;
 
     // The fetch-pipelined materializer (`spawn_gvs_prewarm`) must target the
@@ -2656,6 +2677,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         link_concurrency_setting,
         use_global_virtual_store_override,
         planned_gvs,
+        gvs_hoist_decision,
         has_workspace,
         dep_selection_filtered: opts.dep_selection.is_filtered(),
         workspace_filter_empty: opts.workspace_filter.is_empty(),


### PR DESCRIPTION
## Problem

nub pushed an embedder-tier `hoist=false` unconditionally to engage the shared global virtual store (GVS), since aube couples the axes (`effective_gvs = planned && !hoist && Isolated`). Wherever GVS does not actually engage — CI, `nub ci`, a next/nuxt/parcel trigger, an explicit `enableGlobalVirtualStore=false`, dlx — the project still got `hoist=false`, so the pnpm-parity hidden hoist tree (`node_modules/.nub/node_modules/`) was missing for zero GVS benefit. That broke ambient `@types/*` resolution for store-resident packages and made `enableGlobalVirtualStore=false` an incomplete escape hatch.

## Change

New embedder profile flag `gvs_over_default_hoist` (default `false`). Under it, only an EXPLICITLY-set `hoist=true` vetoes GVS; a default hoist lets GVS engage, and the hidden hoist tree is built only where GVS is off. nub sets the flag and stops pushing `hoist=false`; injected deps push an explicit `hoist=true`. The command layer pre-folds the (effective GVS, hidden-tree) decision once and threads it to the link phase, so the linker's own coupling fallback is never reached under the flag (issue #71 lockstep preserved). A codegen'd `hoist_explicit(ctx) -> Option<bool>` accessor distinguishes an explicit hoist from the built-in default.

Isolated linker, no user-set hoist:

| case | GVS | hidden tree |
|---|---|---|
| off-CI, no trigger | on | no (byte-identical to today) |
| CI · `nub ci` · trigger · `enableGlobalVirtualStore=false` · dlx | off | yes |
| explicit `hoist=false` | — | never |
| explicit `hoist=true` | off | yes |

## Fork-discipline

Flag `false` ⇒ standalone aube is byte-for-byte unchanged on its default path: the effective-GVS formula's flag-off branch is the old formula, the codegen companion accessor is strictly additive, the linker is untouched, and the link phase's non-flag path passes the raw override + resolved hoist exactly as before.

## Verification

21/21 e2e truth-table cells pass (real installs, scratch store); aube + nub-cli tests green; clippy/fmt clean. Three fresh-context review passes (correctness, impact-analysis, fork-discipline) found no bugs. Previously-affected projects take one relink on first post-upgrade install (shape-hash flip, self-healing). The plain non-CI→CI install with a stale `node_modules` short-circuiting one hidden-tree build is a pre-existing, uncommon edge that self-heals; `nub ci` is unaffected.

Refs #286
