### PR TITLE
feat(node): `nub node shim`/`unshim` — persistent global node shim

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -2335,7 +2335,14 @@ fn run_as_node() -> Result<i32> {
     // like `nub --node`/`nub run --node`. Version resolution/pinning stays on in
     // BOTH cases — that's the legitimate job of the hijack.
     let args: Vec<String> = env::args().skip(1).collect();
-    let (compat, forwarded) = scan_node_compat_flag(&args);
+    let (compat_flag, forwarded) = scan_node_compat_flag(&args);
+    // The PERSISTENT global `node` shim (`nub node shim`, ~/.nub/node-shim) runs
+    // VANILLA by default (maintainer, 2026-07-03): a bare-shell `node` must
+    // respect node semantics — version resolution/provisioning is the shim's
+    // job, augmentation belongs to `nub`/`nubx`. The per-invocation hijack
+    // (temp-dir shim, inside a `nub …` subtree the user opted into) keeps
+    // augment-by-default. `--node`/`NODE_COMPAT` force vanilla in either case.
+    let compat = compat_flag || nub_core::node::shim::invoked_as_persistent_node_shim();
     if compat {
         run_file_with_compat(&forwarded, true)
     } else {
@@ -6056,7 +6063,9 @@ fn run_node(args: &[String]) -> Result<i32> {
          \x20 install [<version>...]   provision version(s) into nub's cache (bare: the project pin)\n\
          \x20 ls                       list versions in nub's cache\n\
          \x20 uninstall <version>      remove a version from nub's cache\n\
-         \x20 pin <version>            write the project's Node pin";
+         \x20 pin <version>            write the project's Node pin\n\
+         \x20 shim                     make `node` on PATH resolve through nub (re-run after `nub upgrade`)\n\
+         \x20 unshim                   remove the `node` shim and its PATH block";
 
     // `nub node --help`/`-h`/`help`: short usage listing the verbs.
     let verb = args.first().map(String::as_str);
@@ -6152,6 +6161,8 @@ fn run_node(args: &[String]) -> Result<i32> {
             println!("pinned Node {} → {}", result.spec, result.path.display());
             Ok(0)
         }
+        "shim" => run_node_shim_install(),
+        "unshim" => run_node_unshim(),
         // `nub node <file>` (or any non-verb positional) is an error, NOT a
         // passthrough — the exact wording is locked by the spec
         // (node-versions.md line 25). The literal `<file>` placeholder is part of
@@ -6159,7 +6170,7 @@ fn run_node(args: &[String]) -> Result<i32> {
         // drop trailing args and diverge from the spec).
         _ => {
             bail!(
-                "nub node takes a subcommand (which, install, ls, uninstall, pin). \
+                "nub node takes a subcommand (which, install, ls, uninstall, pin, shim, unshim). \
                  To run a file, use 'nub <file>'."
             );
         }
@@ -7256,6 +7267,119 @@ fn run_pm_unshim() -> Result<i32> {
     Ok(0)
 }
 
+/// `nub node shim`: hardlink the running nub as `node` in `~/.nub/node-shim`,
+/// wire that dir onto PATH, and verify reachability — so a bare-shell `node`
+/// resolves through nub. Idempotent; re-run to refresh after `nub upgrade`.
+/// Mirrors [`run_pm_shim_install`] for the single `node` entry; the shim runs
+/// the resolved Node VANILLA (version management only — augmentation is `nub`).
+fn run_node_shim_install() -> Result<i32> {
+    use nub_core::node::shim;
+    use nub_core::pm::shim::{ProfileOutcome, ShimAction};
+
+    let nub_binary = nub_core::node::spawn::current_nub_binary()?;
+    let dir = shim::node_shim_dir()?;
+    let entry = shim::install_node_shim(&nub_binary)?;
+
+    let state = match entry.action {
+        ShimAction::Created => "created",
+        ShimAction::Relinked => "re-linked",
+        ShimAction::Current => "already current",
+    };
+    println!("node shim in {} ({state})", dir.display());
+    if entry.copied {
+        println!(
+            "  note: {} is on a different filesystem than the nub binary — \
+             a copy was made instead of a hardlink",
+            dir.display()
+        );
+    }
+    // The shim runs the resolved Node VANILLA — state it so nobody expects
+    // TypeScript / `.env` loading from a bare `node`; that's what `nub` is for.
+    println!(
+        "  `node` now resolves through nub (version management only — no augmentation; run `nub` for that)"
+    );
+
+    if shim::check_node_shim_noexec(&dir) {
+        eprintln!(
+            "warning: {} is on a filesystem mounted noexec — the shim is installed but every \
+             invocation will fail with \"Permission denied\". Remount without noexec, or use a \
+             HOME on an exec-allowed filesystem.",
+            dir.display()
+        );
+    }
+
+    // Windows profile editing is out of scope for v0 — print the dir to add.
+    if cfg!(windows) {
+        println!(
+            "  PATH: add {} to your PATH (PATH editing isn't automated on Windows yet)",
+            dir.display()
+        );
+        return Ok(0);
+    }
+    match shim::add_node_path_block()? {
+        ProfileOutcome::Added(profile) => println!(
+            "  added {} to PATH in {}\n  restart your shell, or run: source {}",
+            dir.display(),
+            profile.display(),
+            profile.display()
+        ),
+        ProfileOutcome::AlreadyPresent(profile) => {
+            println!("  PATH: already present in {}", profile.display())
+        }
+        ProfileOutcome::Manual { line } => println!(
+            "  PATH: no known shell profile to edit — add this line to your shell config:\n    {line}"
+        ),
+    }
+
+    // Reachability check is meaningful only once the dir is on THIS process's
+    // PATH (right after a fresh install the block isn't sourced yet — the source
+    // hint above already covers that).
+    if path_contains_dir(&dir) {
+        let r = shim::check_node_shim_reachable(&dir);
+        if !r.ok {
+            match &r.first_hit {
+                Some(hit) => eprintln!(
+                    "warning: node resolves to {} which shadows the shim — move {} earlier \
+                     in PATH, or remove that binary",
+                    hit.display(),
+                    dir.display()
+                ),
+                None => eprintln!(
+                    "warning: node resolves to nothing on PATH even though {} is on it — \
+                     is the shim dir readable?",
+                    dir.display()
+                ),
+            }
+        }
+    }
+    Ok(0)
+}
+
+/// `nub node unshim`: delete `~/.nub/node-shim` and strip its PATH block from
+/// every profile. Touches only the dedicated dir + profiles, so it works from
+/// any nub still on PATH. Mirrors [`run_pm_unshim`]. Idempotent.
+fn run_node_unshim() -> Result<i32> {
+    use nub_core::node::shim;
+
+    let dir = shim::node_shim_dir()?;
+    let (existed, changed) = shim::remove_node_shim()?;
+    if existed {
+        println!("removed {}", dir.display());
+    } else {
+        println!("{} was already gone", dir.display());
+    }
+    for profile in &changed {
+        println!(
+            "  PATH: removed the node-shim block from {}",
+            profile.display()
+        );
+    }
+    if changed.is_empty() {
+        println!("  PATH: no profile carried the node-shim block");
+    }
+    Ok(0)
+}
+
 /// Whether `dir` is one of the current process's `PATH` entries (compared
 /// canonicalized, so a symlinked entry still counts).
 fn path_contains_dir(dir: &Path) -> bool {
@@ -7707,29 +7831,40 @@ fn exec_program(program: &Path, args: &[String], envs: &[(String, String)]) -> R
 /// homebrew), existing shims still hardlink the PRE-upgrade inode — remind the
 /// user to re-link. `None` when no shim dir exists (nothing to remind about).
 fn shim_relink_reminder() -> Option<String> {
-    let dir = nub_core::pm::shim::shim_dir().ok()?;
-    dir.is_dir().then(|| {
+    let mut notes = Vec::new();
+    if nub_core::pm::shim::shim_dir().is_ok_and(|d| d.is_dir()) {
+        notes.push("`nub pm shim`");
+    }
+    if nub_core::node::shim::node_shim_dir().is_ok_and(|d| d.is_dir()) {
+        notes.push("`nub node shim`");
+    }
+    (!notes.is_empty()).then(|| {
         format!(
-            "note: the PM shims in {} still run the previous nub until re-linked — run `nub pm shim`.",
-            dir.display()
+            "note: existing shims still run the previous nub until re-linked — run {}.",
+            notes.join(" and ")
         )
     })
 }
 
-/// The self-owned channel owns the new binary's path, so re-link in place
-/// right after the swap (best-effort: a failure downgrades to the reminder).
+/// The self-owned channel owns the new binary's path, so re-link every installed
+/// shim family in place right after the swap (best-effort: a failure downgrades
+/// to the reminder). Covers both the PM shims and the persistent `node` shim.
 fn relink_shims_after_selfowned(install_dir: &Path) {
-    let Ok(dir) = nub_core::pm::shim::shim_dir() else {
-        return;
-    };
-    if !dir.is_dir() {
-        return;
-    }
     let new_bin = install_dir.join("bin").join("nub");
-    match nub_core::pm::shim::install_shims(&new_bin) {
-        Ok(_) => println!("re-linked the PM shims in {}", dir.display()),
-        Err(e) => {
-            eprintln!("could not re-link the PM shims: {e:#} — run `nub pm shim`.")
+    if let Ok(dir) = nub_core::pm::shim::shim_dir()
+        && dir.is_dir()
+    {
+        match nub_core::pm::shim::install_shims(&new_bin) {
+            Ok(_) => println!("re-linked the PM shims in {}", dir.display()),
+            Err(e) => eprintln!("could not re-link the PM shims: {e:#} — run `nub pm shim`."),
+        }
+    }
+    if let Ok(dir) = nub_core::node::shim::node_shim_dir()
+        && dir.is_dir()
+    {
+        match nub_core::node::shim::install_node_shim(&new_bin) {
+            Ok(_) => println!("re-linked the node shim in {}", dir.display()),
+            Err(e) => eprintln!("could not re-link the node shim: {e:#} — run `nub node shim`."),
         }
     }
 }

--- a/crates/nub-cli/tests/node_shim.rs
+++ b/crates/nub-cli/tests/node_shim.rs
@@ -1,0 +1,189 @@
+//! `nub node shim` / `nub node unshim` integration tests: install the persistent
+//! global `node` shim through the real binary and assert the end-to-end contract
+//! — the shim file lands under `~/.nub/node-shim`, the PATH block is written and
+//! stripped, and the installed shim runs the resolved Node VANILLA (version
+//! management only; augmentation stays on `nub`). Spec: wiki/commands/node-versions.md.
+//!
+//! Hermetic: every child gets an explicit HOME + SHELL, so the install writes
+//! into a throwaway tree, never the developer's real `~/.nub` / profiles.
+
+#![cfg(unix)] // hardlink + shell-script probes; Windows PATH editing is out of scope for v0.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/ (or fast/)
+    path.push("nub");
+    path
+}
+
+fn tmp(tag: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nub-nodeshim-{tag}-{}-{nanos:x}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Run the real nub binary with an explicit HOME (+ SHELL for the profile block).
+fn nub(args: &[&str], home: &Path) -> (String, String, i32) {
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(args)
+        .current_dir(home)
+        .env("HOME", home)
+        // bash so the PATH block lands in a real profile (`sh` is an unknown
+        // shell → Manual). bash with no `.bashrc`/`.bash_profile` creates
+        // `~/.profile`, which the install test asserts on.
+        .env("SHELL", "/bin/bash");
+    let out = cmd.output().expect("spawn nub failed");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn shim_installs_the_node_hardlink_and_path_block_then_unshim_reverses_it() {
+    let home = tmp("install");
+    let (stdout, stderr, code) = nub(&["node", "shim"], &home);
+    assert_eq!(code, 0, "nub node shim must succeed; stderr:\n{stderr}");
+
+    let dir = home.join(".nub/node-shim");
+    let node = dir.join("node");
+    assert!(node.is_file(), "the shim dir must carry the `node` entry");
+    // The entry is the SAME file as nub (hardlink) — argv0 dispatch re-enters nub.
+    assert!(
+        same_file(&node, &nub_binary()),
+        "the `node` shim must be a hardlink/copy of the nub binary"
+    );
+    assert!(
+        stdout.contains("version management only"),
+        "the install must state the shim is vanilla (no augmentation):\n{stdout}"
+    );
+
+    // The PATH block landed in a `/bin/sh` (bash-family) login profile with the
+    // node-shim marker — distinct from the PM shims' `# nub shims` block.
+    let profile = home.join(".profile");
+    let contents = std::fs::read_to_string(&profile).unwrap_or_default();
+    assert!(
+        contents.contains("# nub node shim") && contents.contains(".nub/node-shim"),
+        "the node-shim PATH block must be written:\n{contents}"
+    );
+
+    // unshim: the dir is gone and the block is stripped, leaving the profile clean.
+    let (_out, err, code) = nub(&["node", "unshim"], &home);
+    assert_eq!(code, 0, "nub node unshim must succeed; stderr:\n{err}");
+    assert!(!dir.exists(), "unshim removes ~/.nub/node-shim");
+    let after = std::fs::read_to_string(&profile).unwrap_or_default();
+    assert!(
+        !after.contains("# nub node shim"),
+        "unshim strips the node-shim block:\n{after}"
+    );
+}
+
+#[test]
+fn installed_shim_delegates_to_real_node_and_runs_it_vanilla() {
+    // The headline default: a bare `node` through the persistent shim respects
+    // node semantics — it delegates to the real Node (version resolution is the
+    // shim's job) and runs it VANILLA (no augmentation). Two proofs, both
+    // addon-free (the augment side is the transpiler suite's job, not here):
+    //   (a) `node --version` prints the real Node's version — the shim resolved
+    //       and delegated, skipping its own dir (the recursion guard);
+    //   (b) a non-erasable TS `enum` is REJECTED by Node's strip-only mode — the
+    //       shim did NOT engage nub's transpiler, i.e. it ran vanilla.
+    let real_node = match system_node() {
+        Some(n) => n,
+        None => {
+            eprintln!("skipping: no system node on PATH");
+            return;
+        }
+    };
+
+    let home = tmp("vanilla");
+    let (_o, err, code) = nub(&["node", "shim"], &home);
+    assert_eq!(code, 0, "install failed:\n{err}");
+    let shim_node = home.join(".nub/node-shim/node");
+
+    // PATH = [shim dir, real node's dir]: the shim's own which_node skips its dir
+    // (recursion guard) and resolves the real node behind it.
+    let path = std::env::join_paths([
+        home.join(".nub/node-shim"),
+        real_node.parent().unwrap().to_path_buf(),
+    ])
+    .unwrap();
+    let run = |args: &[&std::ffi::OsStr], cwd: &Path| {
+        Command::new(&shim_node)
+            .args(args)
+            .current_dir(cwd)
+            .env("HOME", &home)
+            .env("PATH", &path)
+            .output()
+            .expect("spawn shim node failed")
+    };
+
+    // (a) delegates to the real Node.
+    let ver = run(&["--version".as_ref()], &home);
+    let real_ver = Command::new(&real_node).arg("--version").output().unwrap();
+    assert_eq!(ver.status.code(), Some(0), "`node --version` via the shim");
+    assert_eq!(
+        String::from_utf8_lossy(&ver.stdout).trim(),
+        String::from_utf8_lossy(&real_ver.stdout).trim(),
+        "the shim reports the REAL node's version — it delegated"
+    );
+
+    // (b) runs vanilla: a non-erasable enum is rejected by strip-only mode.
+    let proj = tmp("vanilla-proj");
+    let app = proj.join("app.ts");
+    std::fs::write(&app, "enum E { A }\nconsole.log(E.A);\n").unwrap();
+    let out = run(&[app.as_os_str()], &proj);
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "the shim runs node VANILLA — a non-erasable enum is not transpiled"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("TypeScript"),
+        "the failure is real Node's strip-only rejection, not nub's transpiler:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The first real `node` on the inherited PATH (skipping any nub shim dir), used
+/// as the resolvable Node behind the persistent shim in the behavioral test.
+fn system_node() -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        if dir
+            .file_name()
+            .is_some_and(|n| n.to_string_lossy().contains("node-shim"))
+        {
+            continue;
+        }
+        let cand = dir.join("node");
+        if cand.is_file() {
+            return Some(cand);
+        }
+    }
+    None
+}
+
+/// Same underlying file (device + inode) — the hardlink identity check.
+fn same_file(a: &Path, b: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    match (a.metadata(), b.metadata()) {
+        (Ok(ma), Ok(mb)) => ma.dev() == mb.dev() && ma.ino() == mb.ino(),
+        _ => false,
+    }
+}

--- a/crates/nub-cli/tests/node_shim.rs
+++ b/crates/nub-cli/tests/node_shim.rs
@@ -143,7 +143,12 @@ fn installed_shim_delegates_to_real_node_and_runs_it_vanilla() {
         "the shim reports the REAL node's version — it delegated"
     );
 
-    // (b) runs vanilla: a non-erasable enum is rejected by strip-only mode.
+    // (b) runs vanilla: a non-erasable enum is NOT transpiled. If nub augmented,
+    // it would transpile the enum and print "0" (exit 0); vanilla node instead
+    // rejects the file. The rejection wording is Node-version-dependent — a
+    // strip-only `TypeScript enum is not supported` on Node ≥23.6, an
+    // `ERR_UNKNOWN_FILE_EXTENSION` on the 22.x floor (which won't run `.ts` at
+    // all) — so the version-independent proof is "failed AND printed no `0`".
     let proj = tmp("vanilla-proj");
     let app = proj.join("app.ts");
     std::fs::write(&app, "enum E { A }\nconsole.log(E.A);\n").unwrap();
@@ -153,10 +158,10 @@ fn installed_shim_delegates_to_real_node_and_runs_it_vanilla() {
         Some(0),
         "the shim runs node VANILLA — a non-erasable enum is not transpiled"
     );
-    assert!(
-        String::from_utf8_lossy(&out.stderr).contains("TypeScript"),
-        "the failure is real Node's strip-only rejection, not nub's transpiler:\n{}",
-        String::from_utf8_lossy(&out.stderr)
+    assert_ne!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        "0",
+        "vanilla node never produced the enum's transpiled output — no augmentation ran"
     );
 }
 

--- a/crates/nub-core/src/node/discovery.rs
+++ b/crates/nub-core/src/node/discovery.rs
@@ -732,12 +732,36 @@ fn shell_path_node(pin_source: Option<String>) -> Result<ResolvedNode, Discovery
 
 /// Find `node` on PATH, skipping nub's own PATH shim directories.
 fn which_node() -> Result<PathBuf, DiscoveryError> {
-    let path_var = env::var_os("PATH").unwrap_or_default();
+    // The persistent global `node` shim (`~/.nub/node-shim`, `nub node shim`) is
+    // a `node` hardlink to nub sitting on PATH. When nub-as-node resolves the
+    // REAL node it must skip that dir, or it would find its own shim first →
+    // infinite recursion. Canonicalized so a symlinked `~/.nub` still matches.
+    let persistent_shim = crate::node::shim::node_shim_dir()
+        .ok()
+        .and_then(|d| d.canonicalize().ok());
+    which_node_in(
+        &env::var_os("PATH").unwrap_or_default(),
+        persistent_shim.as_deref(),
+    )
+}
 
-    for dir in env::split_paths(&path_var) {
-        // Skip our own PATH shim directories.
+/// [`which_node`] against an explicit PATH + persistent-shim dir — the testable
+/// body. Two recursion guards: the per-invocation temp dirs (skipped by their
+/// `nub-node-shim-<pid>` name prefix) and the persistent global shim dir
+/// (skipped by CANONICAL-PATH equality, since it's a fixed possibly-symlinked
+/// path a name prefix can't catch).
+fn which_node_in(
+    path_var: &std::ffi::OsStr,
+    persistent_shim: Option<&Path>,
+) -> Result<PathBuf, DiscoveryError> {
+    for dir in env::split_paths(path_var) {
         if let Some(name) = dir.file_name()
             && name.to_string_lossy().starts_with("nub-node-shim-")
+        {
+            continue;
+        }
+        if let Some(skip) = persistent_shim
+            && dir.canonicalize().ok().as_deref() == Some(skip)
         {
             continue;
         }
@@ -1197,6 +1221,66 @@ mod tests {
             }
             Err(e) => panic!("unexpected error: {e}"),
         }
+    }
+
+    #[test]
+    fn which_node_skips_the_persistent_shim_dir() {
+        // A real `node` in the persistent shim dir must be SKIPPED (it's nub's
+        // own hardlink — following it would recurse), and resolution falls
+        // through to a later PATH dir holding the genuine node.
+        let tmp = unique_tmp("which-skip");
+        let shim = tmp.join("node-shim");
+        let real = tmp.join("real-bin");
+        std::fs::create_dir_all(&shim).unwrap();
+        std::fs::create_dir_all(&real).unwrap();
+        write_fake_node(&shim.join("node"));
+        write_fake_node(&real.join("node"));
+
+        let path_var = env::join_paths([&shim, &real]).unwrap();
+        let canon_shim = shim.canonicalize().unwrap();
+        let got = which_node_in(&path_var, Some(&canon_shim)).unwrap();
+        assert_eq!(
+            got.canonicalize().unwrap(),
+            real.join("node").canonicalize().unwrap(),
+            "the shim dir's node is skipped; the later real node wins"
+        );
+
+        // With the shim dir the ONLY PATH entry, skipping it means no node — the
+        // recursion guard never resolves back to the shim.
+        let only_shim = env::join_paths([&shim]).unwrap();
+        assert!(matches!(
+            which_node_in(&only_shim, Some(&canon_shim)),
+            Err(DiscoveryError::NoNodeOnPath)
+        ));
+    }
+
+    #[cfg(unix)]
+    fn write_fake_node(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::write(path, b"#!/bin/sh\necho v0.0.0\n").unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    #[cfg(windows)]
+    fn write_fake_node(path: &Path) {
+        std::fs::write(path, b"").unwrap();
+    }
+
+    /// A unique throwaway dir under the system temp root (nub-core has no
+    /// `tempfile` dev-dep; this mirrors the `pm::shim` tests' `tmpdir`).
+    fn unique_tmp(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "nub-whichnode-{tag}-{}-{nanos:x}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
     }
 
     #[test]

--- a/crates/nub-core/src/node/mod.rs
+++ b/crates/nub-core/src/node/mod.rs
@@ -4,6 +4,7 @@
 pub mod discovery;
 pub mod feature_matrix;
 pub mod flags;
+pub mod shim;
 // Single-binary runtime extraction — only compiled in release builds that embed
 // the runtime blob (`embed-runtime`). The default dev build resolves `runtime/`
 // via the in-repo walk in `spawn::find_preload`, so this module is absent.

--- a/crates/nub-core/src/node/shim.rs
+++ b/crates/nub-core/src/node/shim.rs
@@ -1,0 +1,202 @@
+//! The persistent global `node`→nub shim: `nub node shim` / `nub node unshim`.
+//!
+//! A fresh machine with no Node can use nub as its default node runner. This
+//! module installs a `node` (Unix) / `node.exe` (Windows) hardlink to nub in a
+//! DEDICATED dir (`~/.nub/node-shim`) and wires that dir onto PATH — so a
+//! bare-shell `node foo.js` resolves through nub (version resolution + the
+//! no-pin/no-node auto-provision of #294), NOT to a missing binary.
+//!
+//! **Vanilla by default (maintainer, 2026-07-03).** Unlike the per-invocation
+//! hijack (`node::spawn::setup_path_shim`, a temp dir scoped to a `nub …`
+//! subtree the user opted into, which runs AUGMENTED), the persistent global
+//! shim runs the resolved Node VANILLA — version management is its job;
+//! augmentation belongs to `nub`/`nubx`. This respects the node-hijack contract
+//! (a bare-shell `node` must behave like node) and bounds the blast radius: a
+//! global augmenting `node` would auto-load `.env` and inject globals for EVERY
+//! node process on the machine. The augment opt-in is one keystroke away —
+//! `nub foo.ts`. `run_as_node` reads [`invoked_as_persistent_node_shim`] to pick
+//! the compat default; `discovery::which_node` skips [`node_shim_dir`] as the
+//! recursion guard (nub-as-node must not re-resolve its own shim).
+//!
+//! The heavy lifting — the shim dir hardlink/copy install, the all-shells PATH
+//! block, the noexec probe, the reachability check — is the SAME engine the PM
+//! shims use, reused from [`crate::pm::shim`] parameterized on a distinct
+//! [`ShimBlock`] (so `nub node unshim` strips exactly its own block and never
+//! the PM shims' or install.sh's).
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::pm::shim::{
+    self, InstalledShim, ProfileOutcome, ShimBlock, ShimReachability, add_path_block_for,
+    remove_path_block_from_profiles,
+};
+
+/// The persistent node shim's PATH block — a DEDICATED dir + marker, distinct
+/// from the PM shims' (`~/.nub/shims`, `# nub shims`) so the two install and
+/// uninstall independently.
+pub const NODE_SHIM_BLOCK: ShimBlock = ShimBlock {
+    marker: "# nub node shim",
+    posix_line: r#"export PATH="$HOME/.nub/node-shim:$PATH""#,
+    fish_line: "set -gx PATH $HOME/.nub/node-shim $PATH",
+    dir_marker: ".nub/node-shim",
+};
+
+/// The name the shim intercepts.
+const NODE: &str = "node";
+
+/// `~/.nub/node-shim` — sibling of the PM shims' `~/.nub/shims` and install.sh's
+/// `~/.nub/bin`, under the `~/.nub` install surface (NOT the wipeable cache): a
+/// shim the user opted into must not vanish when a cache is cleared.
+pub fn node_shim_dir() -> Result<PathBuf> {
+    dirs_next::home_dir()
+        .map(|h| h.join(".nub").join("node-shim"))
+        .context("cannot locate the home directory for ~/.nub/node-shim")
+}
+
+/// Whether THIS nub process was invoked as the persistent `node` shim — i.e.
+/// `current_exe`'s dir canonicalizes to [`node_shim_dir`]. `run_as_node` reads
+/// this to default to VANILLA (compat) mode: only the persistent global shim
+/// runs vanilla; the per-invocation hijack (temp dir) and a direct `nub` still
+/// augment. Canonical-path comparison so a symlinked `~/.nub` still matches.
+pub fn invoked_as_persistent_node_shim() -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        return false;
+    };
+    let Some(parent) = exe.parent() else {
+        return false;
+    };
+    match (
+        parent.canonicalize(),
+        node_shim_dir().and_then(|d| d.canonicalize().map_err(Into::into)),
+    ) {
+        (Ok(p), Ok(d)) => p == d,
+        _ => false,
+    }
+}
+
+/// `nub node shim`: hardlink the running nub as `node` in [`node_shim_dir`],
+/// write the marked PATH block into the shell profiles, and return the entry +
+/// profile outcome for the CLI to report. Idempotent — re-running re-links,
+/// which is how the shim is refreshed after `nub upgrade` (same story as the PM
+/// shims). PATH wiring is skipped on Windows (profile editing isn't automated
+/// there yet — the CLI prints the dir to add).
+pub fn install_node_shim(nub_binary: &Path) -> Result<InstalledShim> {
+    let dir = node_shim_dir()?;
+    let mut report = shim::install_named_shims(&dir, &[NODE], nub_binary)?;
+    Ok(report
+        .pop()
+        .expect("install_named_shims returns one entry per requested name"))
+}
+
+/// Add the node-shim PATH block to the current shell's profiles.
+pub fn add_node_path_block() -> Result<ProfileOutcome> {
+    let home = dirs_next::home_dir().context("cannot locate the home directory")?;
+    let shell = std::env::var("SHELL").unwrap_or_default();
+    let shell = Path::new(&shell)
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "bash".to_string());
+    let xdg = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from);
+    add_path_block_for(&shell, &home, xdg.as_deref(), &NODE_SHIM_BLOCK)
+}
+
+/// `nub node unshim`: delete [`node_shim_dir`] and strip the node-shim PATH
+/// block from every profile. Touches only the dedicated dir + profile files, so
+/// it keeps working from any nub still on PATH. Returns `(dir_existed, changed
+/// profile files)`. Idempotent.
+pub fn remove_node_shim() -> Result<(bool, Vec<PathBuf>)> {
+    let dir = node_shim_dir()?;
+    // The dir is dedicated to the single `node` entry, so removing it wholesale
+    // is correct (unlike a shared dir, which would need per-entry removal).
+    let existed = shim::remove_shims_from(&dir)?;
+    let home = dirs_next::home_dir().context("cannot locate the home directory")?;
+    let xdg = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from);
+    let changed = remove_path_block_from_profiles(&home, xdg.as_deref(), &NODE_SHIM_BLOCK)?;
+    Ok((existed, changed))
+}
+
+/// The post-install reachability check for the `node` name (parity with the PM
+/// shim's sweep): does the first `node` on PATH resolve to the shim?
+pub fn check_node_shim_reachable(dir: &Path) -> ShimReachability {
+    shim::check_shim_reachable(dir, NODE)
+}
+
+/// Whether the shim dir is on a `noexec` mount — where the shim installs but
+/// every invocation dies with "Permission denied". Thin pass-through to the PM
+/// shim's probe so the CLI reads one cohesive `node::shim` surface.
+pub fn check_node_shim_noexec(dir: &Path) -> bool {
+    shim::dir_is_noexec(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_shim_dir_is_under_the_install_surface_not_the_cache() {
+        let dir = node_shim_dir().unwrap();
+        assert!(
+            dir.ends_with(".nub/node-shim"),
+            "the shim lives under ~/.nub (opt-in install), not the wipeable cache: {}",
+            dir.display()
+        );
+    }
+
+    #[test]
+    fn node_block_is_distinct_from_the_pm_block() {
+        // Independent install/uninstall lifecycles hinge on distinct markers +
+        // dirs — sharing either would let one unshim strip the other's block.
+        assert_ne!(NODE_SHIM_BLOCK.marker, shim::PM_SHIM_BLOCK.marker);
+        assert_ne!(NODE_SHIM_BLOCK.dir_marker, shim::PM_SHIM_BLOCK.dir_marker);
+    }
+
+    #[test]
+    fn install_and_remove_roundtrip_via_testable_seams() {
+        // `install_node_shim`/`remove_node_shim` key on $HOME; exercise the same
+        // single-`node`-entry install + wholesale-dir removal through the
+        // dir-explicit seams so the test stays hermetic.
+        let tmp = unique_tmp();
+        let dir = tmp.join("node-shim");
+        let fake_nub = tmp.join("nub");
+        std::fs::write(&fake_nub, b"#!/bin/sh\n").unwrap();
+
+        let report = shim::install_named_shims(&dir, &[NODE], &fake_nub).unwrap();
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].name, NODE);
+        assert!(
+            dir.join(if cfg!(windows) { "node.exe" } else { "node" })
+                .exists()
+        );
+
+        assert!(shim::remove_shims_from(&dir).unwrap(), "the dir existed");
+        assert!(!dir.exists(), "unshim removes the dedicated dir wholesale");
+        assert!(
+            !shim::remove_shims_from(&dir).unwrap(),
+            "removing again is a no-op"
+        );
+    }
+
+    /// A unique throwaway dir (nub-core has no `tempfile` dev-dep).
+    fn unique_tmp() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "nub-nodeshim-ut-{}-{nanos:x}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+}

--- a/crates/nub-core/src/pm/shim.rs
+++ b/crates/nub-core/src/pm/shim.rs
@@ -518,12 +518,24 @@ pub fn install_shims(nub_binary: &Path) -> Result<Vec<InstalledShim>> {
 /// NOT cover: replacing a RUNNING shim `.exe` fails (the OS locks executing
 /// images) — still unverified, no test swaps a live image.
 pub fn install_shims_into(dir: &Path, nub_binary: &Path) -> Result<Vec<InstalledShim>> {
+    install_named_shims(dir, &SHIM_NAMES, nub_binary)
+}
+
+/// Link an explicit set of names in `dir` to `nub_binary` — the generalized body
+/// of [`install_shims_into`]. The PM shim installs all six [`SHIM_NAMES`]; the
+/// persistent `node` shim (`crate::node::shim`) installs the single `["node"]`
+/// through the SAME lock + hardlink-then-copy + same-inode-idempotency path.
+pub fn install_named_shims(
+    dir: &Path,
+    names: &[&'static str],
+    nub_binary: &Path,
+) -> Result<Vec<InstalledShim>> {
     // Serialize concurrent writers (a re-link racing a `pnpm -r` shim storm) on
     // a best-effort advisory lock — see [`ShimLock`]. Held until this returns.
     let _lock = ShimLock::acquire(dir);
     std::fs::create_dir_all(dir).with_context(|| format!("creating shim dir {}", dir.display()))?;
-    let mut report = Vec::with_capacity(SHIM_NAMES.len());
-    for name in SHIM_NAMES {
+    let mut report = Vec::with_capacity(names.len());
+    for name in names.iter().copied() {
         let target = dir.join(shim_file_name(name));
         // Already a hardlink of these exact bytes (same device + inode) — leave
         // it in place and skip the remove-then-link window entirely. This is the
@@ -693,6 +705,32 @@ pub const SHIMS_FISH_PATH_LINE: &str = "set -gx PATH $HOME/.nub/shims $PATH";
 /// shims block and never the installer's.
 const BLOCK_MARKER: &str = "# nub shims";
 
+/// Descriptor for one shim family's shell-profile PATH block, so the intricate
+/// all-shells add/strip engine ([`add_path_block_for`] /
+/// [`remove_path_block_from_profiles`]) serves BOTH the PM shims and the
+/// persistent `node` shim (`crate::node::shim`) without duplicating it. Each
+/// family carries a DISTINCT marker so an unshim strips exactly its own block —
+/// never a sibling's, never install.sh's `# nub` block.
+pub struct ShimBlock {
+    /// The marker comment written on its own line above the PATH line.
+    pub marker: &'static str,
+    /// The POSIX (bash/zsh) `export PATH="…:$PATH"` line.
+    pub posix_line: &'static str,
+    /// The fish `set -gx PATH … $PATH` line.
+    pub fish_line: &'static str,
+    /// A substring the PATH line must contain for [`strip_block`]'s defensive
+    /// "is this really our line" guard — the `$HOME`-relative dir (`.nub/shims`).
+    pub dir_marker: &'static str,
+}
+
+/// The PM shims' block (`~/.nub/shims`, `# nub shims`).
+pub const PM_SHIM_BLOCK: ShimBlock = ShimBlock {
+    marker: BLOCK_MARKER,
+    posix_line: SHIMS_POSIX_PATH_LINE,
+    fish_line: SHIMS_FISH_PATH_LINE,
+    dir_marker: ".nub/shims",
+};
+
 /// Outcome of [`add_path_block`], for the CLI's "what changed" report.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProfileOutcome {
@@ -736,7 +774,7 @@ pub fn add_path_block() -> Result<ProfileOutcome> {
     let xdg = std::env::var_os("XDG_CONFIG_HOME")
         .filter(|v| !v.is_empty())
         .map(PathBuf::from);
-    add_path_block_for(&shell, &home, xdg.as_deref())
+    add_path_block_for(&shell, &home, xdg.as_deref(), &PM_SHIM_BLOCK)
 }
 
 /// [`add_path_block`] with the environment made explicit (the testable body).
@@ -753,17 +791,18 @@ pub fn add_path_block_for(
     shell: &str,
     home: &Path,
     xdg_config: Option<&Path>,
+    block: &ShimBlock,
 ) -> Result<ProfileOutcome> {
-    let targets = shell_profiles(shell, home, xdg_config);
+    let targets = shell_profiles(shell, home, xdg_config, block);
     if targets.is_empty() {
         return Ok(ProfileOutcome::Manual {
-            line: SHIMS_POSIX_PATH_LINE,
+            line: block.posix_line,
         });
     }
     let mut first_added: Option<PathBuf> = None;
     let mut first_present: Option<PathBuf> = None;
     for target in &targets {
-        match append_block(target)? {
+        match append_block(target, block.marker)? {
             ProfileOutcome::Added(p) => {
                 first_added.get_or_insert(p);
             }
@@ -780,7 +819,7 @@ pub fn add_path_block_for(
         (Some(p), _) => ProfileOutcome::Added(p),
         (None, Some(p)) => ProfileOutcome::AlreadyPresent(p),
         (None, None) => ProfileOutcome::Manual {
-            line: SHIMS_POSIX_PATH_LINE,
+            line: block.posix_line,
         },
     })
 }
@@ -797,10 +836,15 @@ struct ProfileTarget {
 /// [`add_path_block`] for the per-shell rationale. Empty = unknown shell
 /// (Manual). The order matters: the first element is the one cli.rs reports as
 /// the "source this" file, so it must be the interactive rc.
-fn shell_profiles(shell: &str, home: &Path, xdg_config: Option<&Path>) -> Vec<ProfileTarget> {
+fn shell_profiles(
+    shell: &str,
+    home: &Path,
+    xdg_config: Option<&Path>,
+    block: &ShimBlock,
+) -> Vec<ProfileTarget> {
     let posix = |path: PathBuf, may_create: bool| ProfileTarget {
         path,
-        line: SHIMS_POSIX_PATH_LINE,
+        line: block.posix_line,
         may_create,
     };
     match shell {
@@ -841,7 +885,7 @@ fn shell_profiles(shell: &str, home: &Path, xdg_config: Option<&Path>) -> Vec<Pr
                 .unwrap_or_else(|| home.join(".config"));
             vec![ProfileTarget {
                 path: base.join("fish").join("config.fish"),
-                line: SHIMS_FISH_PATH_LINE,
+                line: block.fish_line,
                 may_create: true,
             }]
         }
@@ -858,7 +902,7 @@ fn appendable(path: &Path) -> bool {
 /// `echo`s produce for its own block. Idempotency keys on the PATH line itself
 /// (trimmed line equality), so a hand-added identical line also counts as
 /// present — and is then deliberately NOT ours to remove.
-fn append_block(target: &ProfileTarget) -> Result<ProfileOutcome> {
+fn append_block(target: &ProfileTarget, marker: &str) -> Result<ProfileOutcome> {
     let existing = match std::fs::read_to_string(&target.path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -892,7 +936,7 @@ fn append_block(target: &ProfileTarget) -> Result<ProfileOutcome> {
         }
         Err(e) => return Err(e).with_context(|| format!("opening {}", target.path.display())),
     };
-    write!(file, "\n{BLOCK_MARKER}\n{}\n", target.line)
+    write!(file, "\n{marker}\n{}\n", target.line)
         .with_context(|| format!("appending to {}", target.path.display()))?;
     Ok(ProfileOutcome::Added(target.path.clone()))
 }
@@ -909,13 +953,14 @@ pub fn remove_path_block() -> Result<Vec<PathBuf>> {
     let xdg = std::env::var_os("XDG_CONFIG_HOME")
         .filter(|v| !v.is_empty())
         .map(PathBuf::from);
-    remove_path_block_from_profiles(&home, xdg.as_deref())
+    remove_path_block_from_profiles(&home, xdg.as_deref(), &PM_SHIM_BLOCK)
 }
 
 /// [`remove_path_block`] with the environment made explicit (the testable body).
 pub fn remove_path_block_from_profiles(
     home: &Path,
     xdg_config: Option<&Path>,
+    block: &ShimBlock,
 ) -> Result<Vec<PathBuf>> {
     let fish_base = xdg_config
         .map(Path::to_path_buf)
@@ -936,7 +981,7 @@ pub fn remove_path_block_from_profiles(
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        let Some(stripped) = strip_block(&content) else {
+        let Some(stripped) = strip_block(&content, block) else {
             continue;
         };
         // Temp + rename: a torn write must never truncate a shell profile.
@@ -975,16 +1020,17 @@ pub fn remove_path_block_from_profiles(
 /// nit). The block carries its own leading `\n` separator and a trailing `\n`
 /// after the path line; we excise that whole span, so whatever surrounded it —
 /// including "the file ended right here, no newline" — is restored verbatim.
-fn strip_block(content: &str) -> Option<String> {
+fn strip_block(content: &str, block: &ShimBlock) -> Option<String> {
+    let marker = block.marker;
     // The marker as it sits on its own line: find a line whose trimmed text is
-    // exactly BLOCK_MARKER. We scan line starts so an in-prose mention of the
-    // string can't be mistaken for the marker.
+    // exactly the block's marker. We scan line starts so an in-prose mention of
+    // the string can't be mistaken for the marker.
     let marker_line_start = content
-        .match_indices(BLOCK_MARKER)
+        .match_indices(marker)
         .map(|(idx, _)| idx)
         .find(|&idx| {
             let at_line_start = idx == 0 || content.as_bytes()[idx - 1] == b'\n';
-            let rest = &content[idx + BLOCK_MARKER.len()..];
+            let rest = &content[idx + marker.len()..];
             let to_eol_blank = rest.starts_with('\n') || rest.is_empty();
             at_line_start && to_eol_blank
         })?;
@@ -1002,7 +1048,7 @@ fn strip_block(content: &str) -> Option<String> {
     // newline — but only consume that next line when it really names
     // `.nub/shims` (defensive: a malformed half-block without the line stops at
     // the marker rather than eating an unrelated following line).
-    let after_marker = marker_line_start + BLOCK_MARKER.len();
+    let after_marker = marker_line_start + marker.len();
     let mut block_end = after_marker;
     if content.as_bytes().get(block_end) == Some(&b'\n') {
         block_end += 1; // the marker's trailing newline
@@ -1010,7 +1056,7 @@ fn strip_block(content: &str) -> Option<String> {
             .find('\n')
             .map(|n| block_end + n + 1)
             .unwrap_or(content.len());
-        if content[block_end..path_line_end].contains(".nub/shims") {
+        if content[block_end..path_line_end].contains(block.dir_marker) {
             block_end = path_line_end; // our PATH line + its newline
         }
     }
@@ -1046,24 +1092,39 @@ pub fn check_shims_reachable(shim_dir: &Path) -> Vec<ShimReachability> {
 
 /// [`check_shims_reachable`] against an explicit PATH (the testable body).
 fn check_shims_reachable_in(shim_dir: &Path, path_var: &OsStr) -> Vec<ShimReachability> {
-    let canon_shim = shim_dir.canonicalize().ok();
     PM_SHIM_NAMES
         .into_iter()
-        .map(|name| {
-            let first_hit = scan_path(name, path_var, None, None);
-            let ok = first_hit
-                .as_ref()
-                .zip(canon_shim.as_deref())
-                .is_some_and(|(hit, shim)| {
-                    hit.parent().and_then(|p| p.canonicalize().ok()).as_deref() == Some(shim)
-                });
-            ShimReachability {
-                name,
-                first_hit,
-                ok,
-            }
-        })
+        .map(|name| shim_reachability_in(shim_dir, name, path_var))
         .collect()
+}
+
+/// One shim name's which-style reachability against the current `PATH` — is the
+/// first PATH hit for `name` the entry in `shim_dir`? The single-name check the
+/// persistent `node` shim's post-install warning uses (parity with the PM
+/// sweep's per-name diagnosis).
+pub fn check_shim_reachable(shim_dir: &Path, name: &'static str) -> ShimReachability {
+    shim_reachability_in(
+        shim_dir,
+        name,
+        &std::env::var_os("PATH").unwrap_or_default(),
+    )
+}
+
+/// [`check_shim_reachable`] against an explicit PATH (the shared per-name body).
+fn shim_reachability_in(shim_dir: &Path, name: &'static str, path_var: &OsStr) -> ShimReachability {
+    let canon_shim = shim_dir.canonicalize().ok();
+    let first_hit = scan_path(name, path_var, None, None);
+    let ok = first_hit
+        .as_ref()
+        .zip(canon_shim.as_deref())
+        .is_some_and(|(hit, shim)| {
+            hit.parent().and_then(|p| p.canonicalize().ok()).as_deref() == Some(shim)
+        });
+    ShimReachability {
+        name,
+        first_hit,
+        ok,
+    }
 }
 
 /// The unpinned/transparent fall-through: the first executable `invoked` on
@@ -1894,7 +1955,7 @@ mod tests {
         // file every zsh invocation reads — the non-interactive coverage). The
         // reported outcome is the interactive rc, the file the user sources.
         assert_eq!(
-            add_path_block_for("zsh", &home, None).unwrap(),
+            add_path_block_for("zsh", &home, None, &PM_SHIM_BLOCK).unwrap(),
             ProfileOutcome::Added(zshrc.clone()),
             "the headline outcome names the interactive rc the user sources"
         );
@@ -1914,14 +1975,14 @@ mod tests {
 
         // Adding twice is a no-op on every target.
         assert_eq!(
-            add_path_block_for("zsh", &home, None).unwrap(),
+            add_path_block_for("zsh", &home, None, &PM_SHIM_BLOCK).unwrap(),
             ProfileOutcome::AlreadyPresent(zshrc.clone())
         );
         assert_eq!(std::fs::read_to_string(&zshrc).unwrap(), with_block);
 
         // Removal strips BOTH files and restores the rc byte-for-byte — the
         // installer's `# nub` bin block left intact.
-        let mut changed = remove_path_block_from_profiles(&home, None).unwrap();
+        let mut changed = remove_path_block_from_profiles(&home, None, &PM_SHIM_BLOCK).unwrap();
         changed.sort();
         let mut want = vec![zshrc.clone(), zshenv.clone()];
         want.sort();
@@ -1935,9 +1996,51 @@ mod tests {
 
         // Removing again: no block left, no files changed.
         assert!(
-            remove_path_block_from_profiles(&home, None)
+            remove_path_block_from_profiles(&home, None, &PM_SHIM_BLOCK)
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    // A second, distinct ShimBlock standing in for the node shim's — kept local
+    // so the test asserts the ENGINE's block-independence without depending on
+    // `node::shim`'s constant (this is the pm layer's own test).
+    const TEST_NODE_BLOCK: ShimBlock = ShimBlock {
+        marker: "# nub node shim",
+        posix_line: r#"export PATH="$HOME/.nub/node-shim:$PATH""#,
+        fish_line: "set -gx PATH $HOME/.nub/node-shim $PATH",
+        dir_marker: ".nub/node-shim",
+    };
+
+    #[test]
+    fn two_shim_blocks_coexist_and_unshim_strips_only_its_own() {
+        // The dedicated-marker design's load-bearing property: `nub pm shim` and
+        // `nub node shim` write DISTINCT blocks to the same profiles, and
+        // unshimming one must leave the other (and install.sh's `# nub`) intact.
+        let home = tmpdir("two-blocks");
+        let zshrc = home.join(".zshrc");
+        std::fs::write(&zshrc, "# nub\nexport PATH=\"$HOME/.nub/bin:$PATH\"\n").unwrap();
+
+        add_path_block_for("zsh", &home, None, &PM_SHIM_BLOCK).unwrap();
+        add_path_block_for("zsh", &home, None, &TEST_NODE_BLOCK).unwrap();
+        let both = std::fs::read_to_string(&zshrc).unwrap();
+        assert!(both.contains("# nub shims") && both.contains("# nub node shim"));
+
+        // Strip the node block: the PM block and the installer block survive.
+        remove_path_block_from_profiles(&home, None, &TEST_NODE_BLOCK).unwrap();
+        let after = std::fs::read_to_string(&zshrc).unwrap();
+        assert!(after.contains("# nub shims"), "PM block survives");
+        assert!(
+            after.contains(".nub/bin"),
+            "install.sh's bin block survives"
+        );
+        assert!(!after.contains("# nub node shim"), "the node block is gone");
+
+        // Strip the PM block too: back to exactly the original installer block.
+        remove_path_block_from_profiles(&home, None, &PM_SHIM_BLOCK).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&zshrc).unwrap(),
+            "# nub\nexport PATH=\"$HOME/.nub/bin:$PATH\"\n"
         );
     }
 
@@ -1947,7 +2050,7 @@ mod tests {
 
         // zsh: both .zshrc (interactive) and .zshenv (all invocations) are
         // created; the headline outcome is the interactive rc.
-        let outcome = add_path_block_for("zsh", &home, None).unwrap();
+        let outcome = add_path_block_for("zsh", &home, None, &PM_SHIM_BLOCK).unwrap();
         assert_eq!(outcome, ProfileOutcome::Added(home.join(".zshrc")));
         let zsh_block = format!("\n# nub shims\n{SHIMS_POSIX_PATH_LINE}\n");
         assert_eq!(
@@ -1964,7 +2067,7 @@ mod tests {
         let xdg = home.join("xdg");
         let fish_config = xdg.join("fish").join("config.fish");
         assert_eq!(
-            add_path_block_for("fish", &home, Some(&xdg)).unwrap(),
+            add_path_block_for("fish", &home, Some(&xdg), &PM_SHIM_BLOCK).unwrap(),
             ProfileOutcome::Added(fish_config.clone())
         );
         let fish_content = std::fs::read_to_string(&fish_config).unwrap();
@@ -1975,7 +2078,7 @@ mod tests {
 
         // An unknown shell still can only be handled manually.
         assert_eq!(
-            add_path_block_for("tcsh", &home, None).unwrap(),
+            add_path_block_for("tcsh", &home, None, &PM_SHIM_BLOCK).unwrap(),
             ProfileOutcome::Manual {
                 line: SHIMS_POSIX_PATH_LINE
             }
@@ -1991,7 +2094,7 @@ mod tests {
         // actually work.
         let home = tmpdir("fresh-bash");
         assert_eq!(
-            add_path_block_for("bash", &home, None).unwrap(),
+            add_path_block_for("bash", &home, None, &PM_SHIM_BLOCK).unwrap(),
             ProfileOutcome::Added(home.join(".profile")),
             "a fresh bash HOME must get a created+wired login profile, not Manual"
         );
@@ -2011,7 +2114,7 @@ mod tests {
         let home = tmpdir("bash-with-rc");
         std::fs::write(home.join(".bashrc"), "# rc\n").unwrap();
         assert_eq!(
-            add_path_block_for("bash", &home, None).unwrap(),
+            add_path_block_for("bash", &home, None, &PM_SHIM_BLOCK).unwrap(),
             ProfileOutcome::Added(home.join(".bashrc"))
         );
         assert!(
@@ -2031,7 +2134,7 @@ mod tests {
         let home = tmpdir("bash-with-profile");
         std::fs::write(home.join(".bash_profile"), "# hello\n").unwrap();
         assert_eq!(
-            add_path_block_for("bash", &home, None).unwrap(),
+            add_path_block_for("bash", &home, None, &PM_SHIM_BLOCK).unwrap(),
             ProfileOutcome::Added(home.join(".bash_profile")),
             "an existing .bash_profile is preferred as the login target"
         );
@@ -2049,12 +2152,13 @@ mod tests {
         let home = tmpdir("sweep");
         let xdg = home.join("xdg");
 
-        add_path_block_for("zsh", &home, None).unwrap(); // .zshrc + .zshenv
-        add_path_block_for("fish", &home, Some(&xdg)).unwrap(); // config.fish
+        add_path_block_for("zsh", &home, None, &PM_SHIM_BLOCK).unwrap(); // .zshrc + .zshenv
+        add_path_block_for("fish", &home, Some(&xdg), &PM_SHIM_BLOCK).unwrap(); // config.fish
         std::fs::write(home.join(".bashrc"), "# rc\n").unwrap();
-        add_path_block_for("bash", &home, None).unwrap(); // .bashrc + .profile
+        add_path_block_for("bash", &home, None, &PM_SHIM_BLOCK).unwrap(); // .bashrc + .profile
 
-        let mut changed = remove_path_block_from_profiles(&home, Some(&xdg)).unwrap();
+        let mut changed =
+            remove_path_block_from_profiles(&home, Some(&xdg), &PM_SHIM_BLOCK).unwrap();
         changed.sort();
         let mut want = vec![
             home.join(".zshrc"),
@@ -2070,7 +2174,7 @@ mod tests {
         );
         // A second sweep is a clean no-op.
         assert!(
-            remove_path_block_from_profiles(&home, Some(&xdg))
+            remove_path_block_from_profiles(&home, Some(&xdg), &PM_SHIM_BLOCK)
                 .unwrap()
                 .is_empty()
         );
@@ -2086,14 +2190,14 @@ mod tests {
         let original = "export EDITOR=vi"; // deliberately no trailing newline
         std::fs::write(&zshrc, original).unwrap();
 
-        add_path_block_for("zsh", &home, None).unwrap();
+        add_path_block_for("zsh", &home, None, &PM_SHIM_BLOCK).unwrap();
         // Sanity: the block landed after the original's last byte.
         assert_eq!(
             std::fs::read_to_string(&zshrc).unwrap(),
             format!("{original}\n# nub shims\n{SHIMS_POSIX_PATH_LINE}\n")
         );
 
-        remove_path_block_from_profiles(&home, None).unwrap();
+        remove_path_block_from_profiles(&home, None, &PM_SHIM_BLOCK).unwrap();
         assert_eq!(
             std::fs::read_to_string(&zshrc).unwrap(),
             original,
@@ -2107,37 +2211,40 @@ mod tests {
         let block = format!("\n# nub shims\n{line}\n");
 
         // No block present → None, file untouched.
-        assert_eq!(strip_block("just some config\n"), None);
+        assert_eq!(strip_block("just some config\n", &PM_SHIM_BLOCK), None);
         // A `# nub` (installer) block is NOT our `# nub shims` marker → untouched.
         assert_eq!(
-            strip_block("# nub\nexport PATH=\"$HOME/.nub/bin:$PATH\"\n"),
+            strip_block(
+                "# nub\nexport PATH=\"$HOME/.nub/bin:$PATH\"\n",
+                &PM_SHIM_BLOCK
+            ),
             None
         );
 
         // Original with trailing newline: restored exactly.
         let orig = "a\nb\n";
         assert_eq!(
-            strip_block(&format!("{orig}{block}")).as_deref(),
+            strip_block(&format!("{orig}{block}"), &PM_SHIM_BLOCK).as_deref(),
             Some(orig)
         );
         // Original without trailing newline: restored exactly (no NL gained).
         let orig = "a\nb";
         assert_eq!(
-            strip_block(&format!("{orig}{block}")).as_deref(),
+            strip_block(&format!("{orig}{block}"), &PM_SHIM_BLOCK).as_deref(),
             Some(orig)
         );
         // Empty original (a file we created solely for the block): back to empty.
-        assert_eq!(strip_block(&block).as_deref(), Some(""));
+        assert_eq!(strip_block(&block, &PM_SHIM_BLOCK).as_deref(), Some(""));
         // Block followed by later user content: only our bytes are excised.
         assert_eq!(
-            strip_block(&format!("a\n{block}c\n")).as_deref(),
+            strip_block(&format!("a\n{block}c\n"), &PM_SHIM_BLOCK).as_deref(),
             Some("a\nc\n"),
             "content appended after our block survives the strip"
         );
         // A half-block (marker but the line was hand-deleted) stops at the
         // marker rather than eating the unrelated next line.
         assert_eq!(
-            strip_block("a\n\n# nub shims\nunrelated line\n").as_deref(),
+            strip_block("a\n\n# nub shims\nunrelated line\n", &PM_SHIM_BLOCK).as_deref(),
             Some("a\nunrelated line\n"),
             "a marker without our PATH line must not consume the following line"
         );
@@ -2228,7 +2335,7 @@ mod tests {
         .unwrap();
         std::os::unix::fs::symlink(&real, home.join(".zshrc")).unwrap();
 
-        let changed = remove_path_block_from_profiles(&home, None).unwrap();
+        let changed = remove_path_block_from_profiles(&home, None, &PM_SHIM_BLOCK).unwrap();
         assert_eq!(changed, vec![home.join(".zshrc")]);
         assert!(
             home.join(".zshrc").symlink_metadata().unwrap().is_symlink(),

--- a/site/content/docs/node.mdx
+++ b/site/content/docs/node.mdx
@@ -143,6 +143,28 @@ $ echo "$NODE"
 
 With no pin the explainer reads `» resolved from node on PATH`. Bare `nub node` prints a status block instead — the version, path, and resolution source on separate lines.
 
+## nub node shim
+
+Make `node` itself resolve through Nub, so a machine with no Node installed can run `node` at all. This is the fresh-install story: `brew install nub` (or the curl script), `nub node shim`, and now a bare `node file.js` works — Nub resolves the right version, provisions it if it's missing, and runs it.
+
+```console
+$ nub node shim
+node shim in /Users/you/.nub/node-shim (created)
+  `node` now resolves through nub (version management only — no augmentation; run `nub` for that)
+  added /Users/you/.nub/node-shim to PATH in /Users/you/.zshrc
+  restart your shell, or run: source /Users/you/.zshrc
+```
+
+The shimmed `node` runs stock Node, unchanged. It resolves and provisions the version — the [precedence above](#version-precedence) — but adds nothing else: no TypeScript, no injected globals, no automatic `.env`. A bare `node` behaves like `node`; `nub` is what adds the runtime features. So `node app.ts` type-strips exactly as stock Node does, while `nub app.ts` transpiles and runs it.
+
+This is opt-in and reversible, the same shape as [`nub pm shim`](/docs/pm-shim). It installs a `node` link in `~/.nub/node-shim` and adds that directory to your PATH; because that comes first, a Node you install later (`brew install node`) is shadowed until you unshim. Re-run `nub node shim` after `nub upgrade` to re-link.
+
+```console
+$ nub node unshim
+removed /Users/you/.nub/node-shim
+  PATH: removed the node-shim block from /Users/you/.zshrc
+```
+
 ## Mirrors and proxies
 
 Node downloads honor `HTTP(S)_PROXY` and `NO_PROXY`, and TLS-intercepting corporate CAs work out of the box through the system trust store. To fetch Node from an internal mirror instead of nodejs.org, set the standard env var or the `.npmrc` key pnpm uses — Nub reads both, with no Nub-specific config:


### PR DESCRIPTION
Opt-in persistent global `node`→nub shim so a fresh machine with no Node can use nub as its default node runner.

Vanilla by default (signed off 2026-07-03): the shimmed `node` does version resolution + provisioning only, no augmentation — per the node-hijack contract and to bound the blast radius of a machine-wide `node`. The per-invocation hijack still augments; `--node`/`NODE_COMPAT` unchanged.

Reuses the PM-shim engine (parameterized on a `ShimBlock`; PM block unchanged), a dedicated `~/.nub/node-shim` dir + marker, a `which_node` recursion guard, and upgrade re-link parity. Tests + docs included.

Refs #294

https://claude.ai/code/session_01Xuh9u8b93eMNu53fTQTWX7