### PR TITLE
cli: rename --shell-emulator to --posix-shell

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -100,18 +100,18 @@ fn npm_config_reporter_is_silent() -> bool {
         .unwrap_or(false)
 }
 
-/// `--shell-emulator`: run script bodies through a detected POSIX `sh` instead of
+/// `--posix-shell`: run script bodies through a detected POSIX `sh` instead of
 /// the platform default. The default is already `sh` on Unix (so the flag is a
 /// no-op there); on Windows the default is `cmd`, which can't run POSIX-isms
 /// (`FOO=1 cmd`, `$VAR`, `&&`), so the flag routes the body through a `sh` found
 /// on PATH / in a Git-for-Windows install. Set once when `run` parses the flag.
-static SHELL_EMULATOR: AtomicBool = AtomicBool::new(false);
+static POSIX_SHELL: AtomicBool = AtomicBool::new(false);
 
-fn shell_emulator_enabled() -> bool {
-    SHELL_EMULATOR.load(Ordering::Relaxed)
+fn posix_shell_enabled() -> bool {
+    POSIX_SHELL.load(Ordering::Relaxed)
 }
 
-/// Locate a POSIX `sh` for `--shell-emulator`. Searches PATH (`sh`/`sh.exe`), then
+/// Locate a POSIX `sh` for `--posix-shell`. Searches PATH (`sh`/`sh.exe`), then
 /// the standard Git-for-Windows install dirs. Platform-independent — on Unix it
 /// finds `/bin/sh`, on Windows the Git/WSL `sh.exe`. `None` if none is found
 /// (the caller turns that into an actionable error).
@@ -438,7 +438,14 @@ pub enum Command {
         /// Run script bodies through a POSIX `sh` (found on PATH / a Git-for-Windows
         /// install) instead of the platform default. No-op on Unix (already `sh`);
         /// on Windows it replaces `cmd` so POSIX-isms (`FOO=1 …`, `$VAR`, `&&`) work.
-        #[arg(long = "shell-emulator")]
+        #[arg(long = "posix-shell")]
+        posix_shell: bool,
+
+        /// Removed spelling of `--posix-shell`. Kept as a hidden arg so the old name
+        /// hard-errors with guidance rather than clap's generic "unexpected argument"
+        /// — the rename corrected a misnomer (the flag forces a system POSIX `sh`, it
+        /// is not pnpm's built-in JavaScript shell emulator), so it is not aliased.
+        #[arg(long = "shell-emulator", hide = true)]
         shell_emulator: bool,
 
         /// Buffer each package's output and flush it on completion (no
@@ -1883,6 +1890,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             stream,
             reporter,
             reporter_hide_prefix,
+            posix_shell,
             shell_emulator,
             if_present,
             no_check,
@@ -1913,7 +1921,12 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
                 HIDE_STREAM_PREFIX.store(true, Ordering::Relaxed);
             }
             if shell_emulator {
-                SHELL_EMULATOR.store(true, Ordering::Relaxed);
+                bail!(
+                    "--shell-emulator was renamed to --posix-shell. It forces script execution through a system POSIX `sh` (unlike pnpm's shell-emulator, which is a built-in JavaScript shell)."
+                );
+            }
+            if posix_shell {
+                POSIX_SHELL.store(true, Ordering::Relaxed);
             }
             // `--workspace <name>` is npm's member selection; it desugars to a
             // name filter and composes with any `--filter`/`-F` selectors.
@@ -3535,14 +3548,14 @@ fn build_script_command(
     let custom_shell = script_shell_override
         .map(str::to_string)
         .or_else(|| nub_core::workspace::scripts::script_shell(&project.root));
-    // `--shell-emulator`: with no explicit shell set, route the body through a
+    // `--posix-shell`: with no explicit shell set, route the body through a
     // detected POSIX `sh` so Windows' `cmd` default is replaced (a no-op on Unix,
     // where the default is already `sh`). Error actionably if none is found.
     let custom_shell = match custom_shell {
         Some(s) => Some(s),
-        None if shell_emulator_enabled() => Some(find_posix_sh().ok_or_else(|| {
+        None if posix_shell_enabled() => Some(find_posix_sh().ok_or_else(|| {
             anyhow::anyhow!(
-                "--shell-emulator: no POSIX `sh` found on PATH. On Windows, install Git for Windows (provides sh.exe) or use WSL; or pass --script-shell <path-to-sh>."
+                "--posix-shell: no POSIX `sh` found on PATH. On Windows, install Git for Windows (provides sh.exe) or use WSL; or pass --script-shell <path-to-sh>."
             )
         })?),
         None => None,
@@ -3559,7 +3572,7 @@ fn build_script_command(
     // script body is passed to cmd.exe exactly as written (npm's
     // `windowsVerbatimArguments: true`), so Rust's MSVCRT re-quoting never mangles
     // a `node -e "…"` body or undoes the per-arg cmd escaping below. A custom POSIX
-    // shell (e.g. Git-Bash `sh.exe` via `--shell-emulator`) does its own parsing,
+    // shell (e.g. Git-Bash `sh.exe` via `--posix-shell`) does its own parsing,
     // so it takes the normal escaped-`arg` path.
     let cmd_verbatim = custom_shell.is_none() && cfg!(windows);
 
@@ -8085,7 +8098,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn find_posix_sh_locates_sh() {
-        // `--shell-emulator` needs a POSIX `sh`. On any Unix box `sh` is on PATH,
+        // `--posix-shell` needs a POSIX `sh`. On any Unix box `sh` is on PATH,
         // so the detector must find it. (The Windows Git-for-Windows search path is
         // exercised on the windows-latest CI leg — Docker on the dev box is Linux
         // only and can't stand in for it.)

--- a/crates/nub-cli/tests/posix_shell.rs
+++ b/crates/nub-cli/tests/posix_shell.rs
@@ -1,0 +1,82 @@
+//! The `--posix-shell` run flag (renamed from `--shell-emulator`) and the hard
+//! error the removed spelling produces. Two contracts:
+//!
+//!   - `--posix-shell` routes the script body through a POSIX `sh`, so an inline
+//!     env-assignment (`FOO=… cmd`) that Windows' `cmd` default can't parse runs.
+//!     On Unix `sh` is always present, so this exercises flag acceptance + the
+//!     found-`sh` path; the Windows Git-for-Windows detection rides the
+//!     `tests/windows` harness (Docker on the dev box is Linux-only).
+//!   - the removed `--shell-emulator` spelling is NOT a silent alias — the name
+//!     was a misnomer (nub's flag forces a system `sh`; it is not pnpm's built-in
+//!     JavaScript shell), so it hard-errors with guidance toward `--posix-shell`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/
+    path.push("nub");
+    path
+}
+
+fn tmp_pkg(script: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nub-posix-shell-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("package.json"),
+        format!(r#"{{"name":"fix","scripts":{{"greet":"{script}"}}}}"#),
+    )
+    .unwrap();
+    dir
+}
+
+fn run_nub(dir: &Path, args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+#[cfg(unix)]
+#[test]
+fn posix_shell_runs_inline_env_assignment_script() {
+    // `FOO=hello printenv FOO` is a POSIX-ism cmd.exe rejects; through a found
+    // `sh` it prints `hello`. On Unix the flag is a no-op over the default, so
+    // this pins that `--posix-shell` is accepted and routes through `sh`.
+    let dir = tmp_pkg("FOO=hello printenv FOO");
+    let (stdout, stderr, code) = run_nub(&dir, &["run", "--posix-shell", "greet"]);
+    assert_eq!(code, 0, "exit {code}; stderr: {stderr}");
+    assert!(
+        stdout.contains("hello"),
+        "expected script output `hello`, got stdout: {stdout:?}"
+    );
+}
+
+#[test]
+fn shell_emulator_old_spelling_hard_errors_with_guidance() {
+    // The removed spelling must guide toward the new one, not silently alias:
+    // the mechanisms differ (system `sh` vs. pnpm's JS shell), so aliasing would
+    // carry the false-friend semantics forward.
+    let dir = tmp_pkg("echo hi");
+    let (_stdout, stderr, code) = run_nub(&dir, &["run", "--shell-emulator", "greet"]);
+    assert_ne!(code, 0, "old spelling must fail, got exit 0");
+    assert!(
+        stderr.contains("--shell-emulator was renamed to --posix-shell"),
+        "expected rename guidance, got stderr: {stderr:?}"
+    );
+}

--- a/tests/windows/README.md
+++ b/tests/windows/README.md
@@ -22,7 +22,7 @@ Docker is available on the host (macOS/Linux) for Linux-specific tests; it is NO
    npm install -g @nubjs/nub
    nub --version
    ```
-5. **Git for Windows** *(optional)* — needed for the `--shell-emulator` check (`sh.exe`). Install from <https://gitforwindows.org/>; the `sh-detection` check auto-skips if absent.
+5. **Git for Windows** *(optional)* — needed for the `--posix-shell` check (`sh.exe`). Install from <https://gitforwindows.org/>; the `sh-detection` check auto-skips if absent.
 
 ## Snapshot discipline
 
@@ -71,7 +71,7 @@ The script prints a colour-coded console report and writes a `results.json` in t
 | `file-stdin` | stdin execution (`nub -`) | major | stdin plumbing |
 | `run-greet` | `nub run` plain script | blocker | script dispatch |
 | `run-posix-ism` | `FOO=val node` via cmd.exe | major | cmd.exe cannot inline-assign env; expected degradation |
-| `run-shell-emulator` | `--shell-emulator` with `sh.exe` | minor | Git-for-Windows sh.exe path |
+| `run-posix-shell` | `--posix-shell` with `sh.exe` | minor | Git-for-Windows sh.exe path |
 | `run-install-fixture` | `nub install` for subsequent checks | blocker | PM install on Windows |
 | `run-cmd-bin` | `.cmd` shim via `nub exec` | major | `cmd /C` dispatch for `.cmd`/`.bat` bins |
 | `nubx-cowsay` | DLX fetch-and-run | major | network + temp extraction on Windows |
@@ -95,7 +95,7 @@ The script prints a colour-coded console report and writes a `results.json` in t
 
 - **`.cmd`/`.bat` bin shims** — `launch_bin` in `cli.rs` dispatches via `cmd /C <path>` for `.cmd`/`.bat` extensions; any regression here silently breaks every npm bin on Windows (most bins land as `.cmd` shims). Check `run-cmd-bin`.
 - **`.ps1` bin shims** — dispatched via `powershell -NoProfile -ExecutionPolicy Bypass -File <path>`. Execution policy on the VM may block this even with `-Bypass`; if so that is a papercut worth reporting.
-- **`nub run` POSIX-ism scripts** — default shell on Windows is `cmd.exe`, which does not support `FOO=1 node …` inline env syntax. `--shell-emulator` routes through `sh.exe` (Git-for-Windows / WSL path). Without Git for Windows the flag errors with a clear message (`--shell-emulator: no POSIX sh found`); the degraded-but-not-crashed posture is what `run-posix-ism` checks.
+- **`nub run` POSIX-ism scripts** — default shell on Windows is `cmd.exe`, which does not support `FOO=1 node …` inline env syntax. `--posix-shell` routes through `sh.exe` (Git-for-Windows / WSL path). Without Git for Windows the flag errors with a clear message (`--posix-shell: no POSIX sh found`); the degraded-but-not-crashed posture is what `run-posix-ism` checks.
 - **`nub upgrade` self-owned channel** — explicitly documented as unsupported on Windows (the `~/.nub` tarball self-replace cannot overwrite a running `.exe`). `upgrade --dry-run` notes this in its output; actual `upgrade` falls back to printing the `npm install -g` command. Not a blocker but worth confirming the message is clear.
 - **`nub upgrade` via npm** — `npm_upgrade_command_invocation` uses `cmd /C npm install -g …` on Windows (not `sh -c …`), because `npm.cmd` only resolves through `cmd.exe`. A regression here would surface as "program not found" on plain Windows boxes without Git-Bash.
 - **NTFS file watcher** — Node's `--watch` uses `ReadDirectoryChangesW`; on ARM64 VMs under Hyper-V this can be slow to coalesce events. `watch-restart` allows 4 seconds for the restart to appear; adjust `-Timeout` if the VM is slow.

--- a/tests/windows/papercut-survey.ps1
+++ b/tests/windows/papercut-survey.ps1
@@ -343,7 +343,7 @@ Invoke-Check -id "run-greet" -label "nub run greet (plain node script)" -severit
 
 Invoke-Check -id "run-posix-ism" -label "nub run posix-ism (FOO=val node -e) via default cmd.exe" `
     -severity "major" `
-    -note "CMD.EXE cannot interpret 'FOO=val cmd' inline env assignment  -  expect fail without --shell-emulator; pass is if nub degrades gracefully" -Body {
+    -note "CMD.EXE cannot interpret 'FOO=val cmd' inline env assignment  -  expect fail without --posix-shell; pass is if nub degrades gracefully" -Body {
     $r = Invoke-Process $NubBin @("run", "posix-ism") -cwd $fixPkg
     # On Windows with cmd.exe, 'FOO=1 node …' is not valid CMD syntax.
     # PASS if nub either: (a) routes it through sh and it works, or
@@ -359,7 +359,7 @@ Invoke-Check -id "run-posix-ism" -label "nub run posix-ism (FOO=val node -e) via
     }
 }
 
-Invoke-Check -id "run-shell-emulator" -label "nub run posix-ism --shell-emulator (Git-for-Windows sh)" `
+Invoke-Check -id "run-posix-shell" -label "nub run posix-ism --posix-shell (Git-for-Windows sh)" `
     -severity "minor" `
     -note "Only passes if Git for Windows is installed and sh.exe is on PATH; skip otherwise" -Body {
     # Check if sh.exe is findable first
@@ -367,7 +367,7 @@ Invoke-Check -id "run-shell-emulator" -label "nub run posix-ism --shell-emulator
     if (-not $sh) {
         return @{ pass=$true; detail="SKIP  -  sh.exe not on PATH (no Git for Windows)" }
     }
-    $r = Invoke-Process $NubBin @("run", "--shell-emulator", "posix-ism") -cwd $fixPkg
+    $r = Invoke-Process $NubBin @("run", "--posix-shell", "posix-ism") -cwd $fixPkg
     @{
         stdout    = $r.stdout
         stderr    = $r.stderr


### PR DESCRIPTION
Renames the `nub run` flag `--shell-emulator` to `--posix-shell`.

The flag locates a system POSIX `sh` (`PATH` / Git-for-Windows) and errors if none exists — the inverse of the ecosystem's "shell emulator" (pnpm, yarn berry, bun), a bundled JS/native interpreter needing no system `sh`. The shared name was a misnomer; `--posix-shell` names what the flag does. A true bundled emulator is a separate, future question.

The old spelling is not aliased: `--shell-emulator` hard-errors with guidance toward `--posix-shell`, since the semantics were a false friend. Routing is otherwise unchanged. Tests in `crates/nub-cli/tests/posix_shell.rs` cover both paths.