### PR TITLE
pm: read project/user .npmrc through pnpm 11's key allowlist under a pnpm-11 incumbent

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1125,12 +1125,46 @@ pub(crate) fn parse_major_minor(version: &str) -> (Option<u64>, Option<u64>) {
 /// dominant v9/v10 base ignores `pnpm_config_*`, so off is the safe default.
 /// Mirrors `store_config_family::project_scalar_home`'s detection exactly.
 fn pnpm_incumbent_major_is_v11_plus() -> bool {
+    declared_pnpm_major().is_some_and(|major| major >= 11)
+}
+
+/// The declared incumbent pnpm major, or `None` when the project does not
+/// declare pnpm as its package manager (a non-pnpm/unknown/absent
+/// `packageManager`/`devEngines` name, or an undeclared/unparseable version).
+/// Reads the pin packageManager-first, requiring the name to be LITERALLY
+/// "pnpm" — the shared major detection behind [`pnpm_incumbent_major_is_v11_plus`]
+/// and [`pnpm_npmrc_key_policy`], matching
+/// `store_config_family::project_scalar_home`.
+fn declared_pnpm_major() -> Option<u64> {
     std::env::current_dir()
         .ok()
         .and_then(|cwd| nub_core::pm::resolve::declared_pm_raw(&cwd))
         .and_then(|(name, version)| (name == "pnpm").then_some(version).flatten())
         .and_then(|v| parse_major_minor(&v).0)
-        .is_some_and(|major| major >= 11)
+}
+
+/// How a detected pnpm major reads project/user `.npmrc` for *settings*. pnpm
+/// reversed this at v11: v9/v10 (and the unknown-major default) read the open
+/// key space — every setting is readable from `.npmrc`; v11 reads ONLY the
+/// auth/registry/network allowlist from `.npmrc` and takes every layout/behavior
+/// setting from `pnpm-workspace.yaml`/`config.yaml`. Keyed on the major so a
+/// future major slots in as one more arm rather than a new special case.
+enum NpmrcKeyPolicy {
+    /// pnpm ≤10 / npm / unknown-major default: the open `.npmrc` key space.
+    Open,
+    /// pnpm 11+: the auth/registry/network allowlist only (pnpm 11's
+    /// `isNpmrcReadableKey`); layout/behavior keys are dropped.
+    Pnpm11Allowlist,
+}
+
+/// Map a detected incumbent pnpm major to its [`NpmrcKeyPolicy`]. An unknown
+/// major (`None`) defaults to `Open` — the dominant/most-compatible model per
+/// AGENTS ("unknown major → the v10 open-`.npmrc` model").
+fn pnpm_npmrc_key_policy(major: Option<u64>) -> NpmrcKeyPolicy {
+    match major {
+        Some(m) if m >= 11 => NpmrcKeyPolicy::Pnpm11Allowlist,
+        _ => NpmrcKeyPolicy::Open,
+    }
 }
 
 /// Emit one dim warning line per graph-shaping field nub ignored under the
@@ -1527,6 +1561,18 @@ pub(crate) fn engine_brand_preflight() {
     // already-correct default). `npm_config_*` keeps working universally.
     let read_pnpm_config_env_registry =
         read_branded_pnpm_config && pnpm_incumbent_major_is_v11_plus();
+    // pnpm 11 reads a project/user `.npmrc` for *settings* through its
+    // auth/registry/network allowlist only, taking every layout/behavior key
+    // from `pnpm-workspace.yaml`/`config.yaml`; pnpm ≤10 reads the open key
+    // space. Mirror the DETECTED pnpm major (the per-major compat rule),
+    // architected as the `major → policy` map in [`pnpm_npmrc_key_policy`].
+    // Gated on `read_branded_pnpm_config` so it engages only under a pnpm
+    // incumbent — a fresh/unknown-major project keeps the open v10 model.
+    let npmrc_settings_allowlist = read_branded_pnpm_config
+        && matches!(
+            pnpm_npmrc_key_policy(declared_pnpm_major()),
+            NpmrcKeyPolicy::Pnpm11Allowlist
+        );
     let read_yarn_config = read_yarn_config_for_surface(&surface);
     // Classic Yarn (v1) reads `.yarnrc`; Yarn Berry (v2+) abandoned it for
     // `.yarnrc.yml` and ignores a stray legacy `.yarnrc`. Gate the engine's
@@ -1556,6 +1602,7 @@ pub(crate) fn engine_brand_preflight() {
         matches!(surface, ConfigSurface::NonPnpmCompat { role: "npm", .. });
     aube_util::update_engine_context(|c| {
         c.read_branded_pnpm_config = read_branded_pnpm_config;
+        c.npmrc_settings_allowlist = npmrc_settings_allowlist;
         // GLOBAL config is read PM-AGNOSTICALLY and UNGATED by cwd incumbency:
         // nub honors whatever global config the user already has from any tool —
         // npm's `~/.npmrc`, pnpm's global `config.yaml`, pnpm's global `auth.ini`.
@@ -2558,6 +2605,30 @@ mod tests {
             .iter()
             .find(|(k, _)| k == key)
             .map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn pnpm_npmrc_key_policy_narrows_only_at_v11() {
+        // pnpm reversed its `.npmrc` settings-reading at v11: ≤10 reads the
+        // open key space, 11+ restricts to the auth/registry allowlist. An
+        // unknown major defaults to Open (the dominant/most-compatible model).
+        assert!(matches!(
+            pnpm_npmrc_key_policy(Some(9)),
+            NpmrcKeyPolicy::Open
+        ));
+        assert!(matches!(
+            pnpm_npmrc_key_policy(Some(10)),
+            NpmrcKeyPolicy::Open
+        ));
+        assert!(matches!(
+            pnpm_npmrc_key_policy(Some(11)),
+            NpmrcKeyPolicy::Pnpm11Allowlist
+        ));
+        assert!(matches!(
+            pnpm_npmrc_key_policy(Some(12)),
+            NpmrcKeyPolicy::Pnpm11Allowlist
+        ));
+        assert!(matches!(pnpm_npmrc_key_policy(None), NpmrcKeyPolicy::Open));
     }
 
     #[test]

--- a/vendor/aube/crates/aube-registry/src/config/load.rs
+++ b/vendor/aube/crates/aube-registry/src/config/load.rs
@@ -22,6 +22,43 @@ fn pnpm_auth_ini_enabled() -> bool {
     aube_util::engine_context().read_pnpm_global_config
 }
 
+/// pnpm 11's `.npmrc` key allowlist (`isNpmrcReadableKey`, pnpm
+/// `config/reader/src/localConfig.ts:189-198`): under a pnpm-11 incumbent a
+/// project/user `.npmrc` contributes ONLY auth/registry/network keys to the
+/// settings view; every layout/behavior key is dropped (its home is
+/// `pnpm-workspace.yaml`/`config.yaml`). Matched on the key exactly as pnpm
+/// spells it — note `no-proxy` (hyphen) is allowlisted while npm's `noproxy`
+/// is not.
+fn is_pnpm11_npmrc_readable_key(key: &str) -> bool {
+    key.starts_with('@')
+        || key.starts_with("//")
+        || matches!(
+            key,
+            // NPM_AUTH_SETTINGS
+            "ca" | "cafile" | "cert" | "key" | "registry" | "_auth" | "_authToken" | "_password"
+            | "email" | "username"
+            // NETWORK_INI_KEYS
+            | "https-proxy" | "proxy" | "no-proxy" | "http-proxy" | "local-address" | "strict-ssl"
+        )
+}
+
+/// Apply pnpm 11's `.npmrc` settings allowlist when the embedder profile
+/// requests it ([`aube_util::EngineContext::npmrc_settings_allowlist`]);
+/// otherwise return the entries untouched — the open key space that is
+/// standalone aube's default (pnpm ≤10 / npm semantics). Gates the
+/// settings-facing `.npmrc` readers only; the registry-client auth track walks
+/// `.npmrc` on its own path and keeps every auth key regardless, so this never
+/// affects auth resolution.
+fn apply_npmrc_settings_allowlist(entries: Vec<(String, String)>) -> Vec<(String, String)> {
+    if !aube_util::engine_context().npmrc_settings_allowlist {
+        return entries;
+    }
+    entries
+        .into_iter()
+        .filter(|(k, _)| is_pnpm11_npmrc_readable_key(k))
+        .collect()
+}
+
 impl NpmConfig {
     /// Load config by reading npmrc-style sources in priority order:
     /// builtin, global, user, project, auth sidecars, supported incumbent
@@ -199,6 +236,11 @@ pub fn load_npmrc_entries_split(project_dir: &Path) -> SplitNpmrcEntries {
     }
     split.project.extend(yarn_env);
     split.project.extend(bun_env);
+    // pnpm-11 incumbent: the settings view of `.npmrc` is the auth/registry
+    // allowlist only (applied to BOTH user and project scope, matching pnpm 11,
+    // which drops layout keys from `~/.npmrc` as well as the project file).
+    split.user = apply_npmrc_settings_allowlist(split.user);
+    split.project = apply_npmrc_settings_allowlist(split.project);
     if let Ok(mut map) = cache.lock() {
         map.insert(key, split.clone());
     }
@@ -334,10 +376,12 @@ pub fn load_npmrc_entries(project_dir: &Path) -> Vec<(String, String)> {
                 .map(|(k, v)| (NpmrcSource::Env, k, v)),
         );
     }
-    let entries = tagged
-        .into_iter()
-        .map(|(_, k, v)| (k, v))
-        .collect::<Vec<_>>();
+    let entries = apply_npmrc_settings_allowlist(
+        tagged
+            .into_iter()
+            .map(|(_, k, v)| (k, v))
+            .collect::<Vec<_>>(),
+    );
     if let Ok(mut map) = cache.lock() {
         map.insert(key, entries.clone());
     }
@@ -349,6 +393,7 @@ struct NpmrcCacheKey {
     project_dir: PathBuf,
     read_branded_pnpm_config: bool,
     read_pnpm_config_env_registry: bool,
+    npmrc_settings_allowlist: bool,
     read_yarn_config: bool,
     synthetic_user_npmrc_entries: Vec<(String, String)>,
     synthetic_project_npmrc_entries: Vec<(String, String)>,
@@ -372,6 +417,7 @@ fn npmrc_cache_key(project_dir: &Path) -> NpmrcCacheKey {
         project_dir: project_dir.to_path_buf(),
         read_branded_pnpm_config: ctx.read_branded_pnpm_config,
         read_pnpm_config_env_registry: ctx.read_pnpm_config_env_registry,
+        npmrc_settings_allowlist: ctx.npmrc_settings_allowlist,
         read_yarn_config: ctx.read_yarn_config,
         synthetic_user_npmrc_entries: ctx.synthetic_user_npmrc_entries,
         synthetic_project_npmrc_entries: ctx.synthetic_project_npmrc_entries,

--- a/vendor/aube/crates/aube-registry/src/config/tests.rs
+++ b/vendor/aube/crates/aube-registry/src/config/tests.rs
@@ -712,6 +712,55 @@ fn yarnrc_node_linker_reaches_split_settings_sources_only_when_gated_on() {
 }
 
 #[test]
+fn pnpm11_npmrc_allowlist_drops_layout_keys_but_keeps_auth_registry_network() {
+    let _gate = AUTH_INI_GATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let project = tempfile::tempdir().unwrap();
+    // A project `.npmrc` mixing layout/behavior keys (dropped under pnpm 11)
+    // with auth/registry/network keys (kept). `no-proxy` (hyphen) is
+    // allowlisted; npm's `noproxy` spelling is NOT — the pnpm-11 quirk.
+    std::fs::write(
+        project.path().join(".npmrc"),
+        "node-linker=hoisted\n\
+         ignore-scripts=true\n\
+         registry=https://example.test/\n\
+         @myorg:registry=https://npm.myorg.test/\n\
+         //example.test/:_authToken=TKN\n\
+         strict-ssl=false\n\
+         no-proxy=example.test\n\
+         noproxy=other.test\n",
+    )
+    .unwrap();
+
+    // Posture OFF (standalone-aube default / pnpm ≤10): open key space —
+    // the layout key survives.
+    aube_util::update_engine_context(|c| c.npmrc_settings_allowlist = false);
+    let open = load_npmrc_entries_split(project.path());
+    assert!(
+        open.project.iter().any(|(k, _)| k == "node-linker"),
+        "open key space must keep the layout key"
+    );
+
+    // Posture ON (pnpm-11 incumbent): layout/behavior keys dropped;
+    // auth/registry/network keys kept.
+    aube_util::update_engine_context(|c| c.npmrc_settings_allowlist = true);
+    let gated = load_npmrc_entries_split(project.path());
+    aube_util::update_engine_context(|c| c.npmrc_settings_allowlist = false);
+
+    let has = |k: &str| gated.project.iter().any(|(key, _)| key == k);
+    assert!(!has("node-linker"), "layout key must be dropped");
+    assert!(!has("ignore-scripts"), "behavior key must be dropped");
+    assert!(!has("noproxy"), "npm's `noproxy` spelling is not allowlisted");
+    assert!(has("registry"), "registry must survive");
+    assert!(has("@myorg:registry"), "scoped registry must survive");
+    assert!(
+        has("//example.test/:_authToken"),
+        "URL-scoped auth token must survive"
+    );
+    assert!(has("strict-ssl"), "TLS key must survive");
+    assert!(has("no-proxy"), "`no-proxy` (hyphen) must survive");
+}
+
+#[test]
 fn classic_yarnrc_translates_core_registry_scope_and_auth_fields() {
     let entries = translate_classic_yarnrc_content(
         r#"

--- a/vendor/aube/crates/aube-util/src/engine_context.rs
+++ b/vendor/aube/crates/aube-util/src/engine_context.rs
@@ -133,6 +133,31 @@ pub struct EngineContext {
     /// `pnpm_config_*` on pnpm 11 — only the bare single/`_`-joined keys are.
     pub read_pnpm_config_env_registry: bool,
 
+    /// Whether project/user `.npmrc` files are read for *settings* only through
+    /// pnpm 11's auth/registry/network allowlist, dropping every
+    /// layout/behavior key. `false` (default) preserves upstream behavior — the
+    /// open key space, where any setting is readable from `.npmrc` (pnpm ≤10 /
+    /// npm semantics, which standalone aube mirrors).
+    ///
+    /// pnpm reversed how it reads a project `.npmrc` at v11: v9/v10 read every
+    /// setting from `.npmrc`; v11 reads ONLY the auth/registry/network allowlist
+    /// (`isNpmrcReadableKey`, pnpm `config/reader/src/localConfig.ts:189-198`:
+    /// `@…`/`//…`-scoped keys, the npm-auth family, and the proxy/TLS keys) from
+    /// `.npmrc` and takes every layout/behavior setting from
+    /// `pnpm-workspace.yaml`/`config.yaml` instead. An embedder whose active PM
+    /// is provably **pnpm v11+** sets this `true` so the *settings* view of
+    /// `.npmrc` matches pnpm 11; under any earlier pnpm, any other PM, nub
+    /// identity, or standalone aube it stays `false`.
+    ///
+    /// Scope note: this gates ONLY the settings-facing `.npmrc` readers
+    /// (`load_npmrc_entries` / `load_npmrc_entries_split`, feeding
+    /// `aube_settings`). The registry-client auth track
+    /// (`NpmConfig::load`) walks `.npmrc` on its own path and is unaffected —
+    /// it already extracts only auth/registry/network keys, which are exactly
+    /// the keys the allowlist keeps, so auth resolution is identical with the
+    /// posture on or off.
+    pub npmrc_settings_allowlist: bool,
+
     /// Whether aube reads Yarn Berry's `.yarnrc.yml` config surface and
     /// translates the subset that maps cleanly onto the existing npmrc-shaped
     /// registry/settings model. `false` (default) preserves upstream aube
@@ -259,6 +284,7 @@ impl Default for EngineContext {
             read_branded_pnpm_config: true,
             read_pnpm_global_config: true,
             read_pnpm_config_env_registry: false,
+            npmrc_settings_allowlist: false,
             read_yarn_config: false,
             yarn_is_classic: false,
             read_bun_config: false,


### PR DESCRIPTION
## Problem

pnpm 11 reads a project/user `.npmrc` for settings through an auth/registry/network allowlist only (`isNpmrcReadableKey`, pnpm `config/reader/src/localConfig.ts:189-198`), taking layout/behavior keys from `pnpm-workspace.yaml`; pnpm ≤10 read the open key space. nub read the open space regardless of major, so under pnpm 11 it honored `.npmrc` layout keys pnpm 11 ignores: `node-linker=hoisted` gave a hoisted tree vs pnpm 11.9.0's isolated.

## Fix

A default-off aube posture filters the settings `.npmrc` readers (both scopes) to pnpm 11's allowlist; the registry auth path is unaffected. nub enables it under a pnpm-11+ incumbent via a major→policy map; pnpm ≤10 keeps the open space.