### PR TITLE
feat(pm): per-package force-materialization for subpath-adapter phantoms under GVS

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2053,6 +2053,22 @@ fn strip_yarnrc_value(rest: &str) -> &str {
     rest.split('#').next().map(str::trim).unwrap_or(rest)
 }
 
+/// Curated `forceMaterializePackages` list: subpath adapters that statically
+/// import a consumer-installed backend they don't declare. Under nub's default
+/// GVS each of these must be a real project-local directory so its realpath
+/// stays inside the project and Node's upward walk reaches the backend at the
+/// project root (`@hookform/resolvers/zod` → the app's `zod`). Derived from the
+/// phantom-dep detector's top-5000 subpath-adapter offenders, minus the entries
+/// whose imported target is a ubiquitous BUILD tool (`@babel/*`,
+/// `babel-plugin-macros`, `tslib`, `typescript`) rather than a runtime
+/// consumer-backend — those resolve anyway and aren't the pick-your-backend
+/// class. Users grow or shrink it via the `forceMaterializePackages` setting
+/// (embedder-tier, so any user config still wins).
+const NUB_FORCE_MATERIALIZE_PACKAGES: &str = "@hookform/resolvers,cypress,langsmith,\
+@storybook/addon-interactions,@storybook/core,@testing-library/jest-dom,drizzle-orm,\
+storybook,swiper,@angular/common,@angular/router,@apollo/client,\
+@storybook/builder-webpack5,@vercel/analytics,lib0,preact";
+
 /// - Layout policy: EVERY project defaults to the isolated layout
 ///   (`nodeLinker=isolated`) — strict (no phantom deps) and GVS-fast; a project
 ///   that relies on phantom deps opts back into the flat tree with one `.npmrc`
@@ -2097,6 +2113,10 @@ fn nub_setting_defaults(
         (
             "disableGlobalVirtualStoreForPackages".to_string(),
             "next,nuxt,parcel".to_string(),
+        ),
+        (
+            "forceMaterializePackages".to_string(),
+            NUB_FORCE_MATERIALIZE_PACKAGES.to_string(),
         ),
     ];
     if let Some(data) = nub_data_dir() {
@@ -2683,6 +2703,35 @@ mod tests {
             get(&fresh, "hoist"),
             None,
             "fresh ⇒ no hoist push (GVS engages by default)"
+        );
+    }
+
+    #[test]
+    fn force_materialize_default_seeds_the_curated_adapter_list() {
+        // nub seeds the per-package force-materialize list (subpath adapters
+        // that import a consumer-installed backend they don't declare) as an
+        // embedder default so they resolve under the default GVS. The exemplar
+        // `@hookform/resolvers` is present; build-time/helper subpath imports
+        // are excluded (not the runtime consumer-backend class).
+        let dir = tempfile::tempdir().unwrap();
+        let fresh = nub_setting_defaults(None, true, dir.path(), VirtualStoreLocality::Default);
+        let list = get(&fresh, "forceMaterializePackages")
+            .expect("nub must seed forceMaterializePackages");
+        let names: Vec<&str> = list.split(',').collect();
+        assert!(
+            names.contains(&"@hookform/resolvers"),
+            "the exemplar adapter must be on the list: {list}"
+        );
+        for excluded in ["ox", "event-target-shim", "@nestjs/swagger"] {
+            assert!(
+                !names.contains(&excluded),
+                "{excluded} is a build-time/helper import and must be excluded"
+            );
+        }
+        // List-1 (whole-install GVS-off) stays the validated-clean trio.
+        assert_eq!(
+            get(&fresh, "disableGlobalVirtualStoreForPackages"),
+            Some("next,nuxt,parcel"),
         );
     }
 

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -180,6 +180,7 @@ const NPMRC_KEYS: &[&str] = &[
     "linkConcurrency",
     "hoistingLimits",
     "disableGlobalVirtualStoreForPackages",
+    "forceMaterializePackages",
 ];
 
 /// Keys the engine has zero implementation for: warn-drop, naming each and

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -466,6 +466,12 @@ enableGlobalVirtualStore=false
 
 Either layout resolves the same packages — including type packages (`@types/*`) pulled in transitively but not declared, which stay reachable in both.
 
+A few packages statically import a backend you pick at runtime — `@hookform/resolvers/zod` imports the `zod` your app installs, without declaring it. Under the shared store the adapter's real path sits outside the project, so Node's directory walk can't reach that backend and the import throws. Nub materializes those adapters into the project automatically so they resolve, while the rest of the tree keeps sharing. Add your own with one line in `.npmrc`:
+
+```ini
+forceMaterializePackages[]=my-adapter
+```
+
 ### Offline installs
 
 Like pnpm, Nub relinks files from the global store into `node_modules` via reflink (APFS/btrfs) or hardlink (ext4) when the store already holds every package — no re-download, no byte-for-byte copy. The benchmark below measures the warm reinstall case: `node_modules` is removed, packages are already on disk, and the installer rebuilds the project layout.

--- a/vendor/aube/crates/aube-linker/src/builder.rs
+++ b/vendor/aube/crates/aube-linker/src/builder.rs
@@ -43,7 +43,23 @@ impl Linker {
             aube_dir_override: None,
             no_integrity_read_keys: std::collections::BTreeMap::new(),
             link_progress: None,
+            force_materialize: std::collections::HashSet::new(),
         }
+    }
+
+    /// Force a set of packages to materialize as real project-local directories
+    /// even under the global virtual store (see the field docs on [`Linker`]).
+    /// Names are matched exactly against each graph package. Standalone aube and
+    /// every test omit this → the set is empty and the GVS pass is unchanged.
+    pub fn with_force_materialize(mut self, names: &[String]) -> Self {
+        self.force_materialize = names.iter().cloned().collect();
+        self
+    }
+
+    /// Whether `pkg_name` is on the force-materialize list. Consulted only in
+    /// the global-virtual-store link pass; always false when the list is empty.
+    pub(crate) fn force_materialize_matches(&self, pkg_name: &str) -> bool {
+        !self.force_materialize.is_empty() && self.force_materialize.contains(pkg_name)
     }
 
     /// Supply a shared counter the materialize pass bumps once per linked

--- a/vendor/aube/crates/aube-linker/src/lib.rs
+++ b/vendor/aube/crates/aube-linker/src/lib.rs
@@ -250,6 +250,18 @@ pub struct Linker {
     /// [`with_link_progress`]: Linker::with_link_progress
     /// [`note_files_linked`]: Linker::note_files_linked
     link_progress: Option<std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+    /// Package names materialized as real project-local directories even when
+    /// the global virtual store is active — the per-package escape hatch for
+    /// subpath adapters that statically import a consumer-installed backend
+    /// they don't declare (`@hookform/resolvers/zod` → `zod`). Under GVS every
+    /// other package is a symlink into the shared store, whose realpath escapes
+    /// the project, so Node's upward `node_modules` walk from inside the adapter
+    /// can't reach the backend at the project root; materializing just the
+    /// adapter puts its realpath back inside the project and the walk succeeds.
+    /// Matched by exact name against each graph package. Empty for standalone
+    /// callers and every existing test → the GVS pass is byte-for-byte
+    /// unchanged.
+    force_materialize: std::collections::HashSet<String>,
 }
 
 /// Strategy for linking files from the store to node_modules.

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -42,6 +42,7 @@ impl Linker {
             virtual_store_only: self.virtual_store_only,
             no_integrity_read_keys: self.no_integrity_read_keys.clone(),
             link_progress: self.link_progress.clone(),
+            force_materialize: self.force_materialize.clone(),
         }
     }
 
@@ -295,6 +296,61 @@ impl Linker {
                             let mut local_stats = LinkStats::default();
                             let local_aube_entry = aube_dir.join(entry_name);
                             let global_entry = self.virtual_store.join(subdir);
+
+                            // Force-materialize: this package must be a real
+                            // project-local directory (not a shared-store
+                            // symlink) so its realpath stays inside the project
+                            // and Node's upward node_modules walk from inside it
+                            // reaches a consumer-installed, undeclared backend at
+                            // the project root (the subpath-adapter phantom
+                            // class). Materializes exactly as the per-project
+                            // (GVS-off) branch does — the local `.aube/<entry>`
+                            // name is dep_path-keyed regardless of GVS, so the
+                            // top-level and sibling symlinks resolve unchanged. A
+                            // prior GVS install or the fetch prewarm may have left
+                            // a symlink here; replace it. An existing real
+                            // directory is reused as cached.
+                            if self.force_materialize_matches(&pkg.name) {
+                                match std::fs::symlink_metadata(&local_aube_entry) {
+                                    Ok(meta) if meta.file_type().is_symlink() => {
+                                        let _ = std::fs::remove_dir(&local_aube_entry)
+                                            .or_else(|_| std::fs::remove_file(&local_aube_entry));
+                                    }
+                                    Ok(_) => {
+                                        local_stats.packages_cached += 1;
+                                        return Ok(local_stats);
+                                    }
+                                    Err(_) => {}
+                                }
+                                let owned_index;
+                                let index = match package_indices.get(dep_path) {
+                                    Some(idx) => idx,
+                                    None => {
+                                        owned_index = self
+                                            .store
+                                            .load_index(
+                                                pkg.registry_name(),
+                                                &pkg.version,
+                                                self.index_read_key(pkg),
+                                            )
+                                            .ok_or_else(|| {
+                                                Error::MissingPackageIndex(dep_path.to_string())
+                                            })?;
+                                        &owned_index
+                                    }
+                                };
+                                self.materialize_into(
+                                    &aube_dir,
+                                    &aube_dir,
+                                    dep_path,
+                                    pkg,
+                                    index,
+                                    &mut local_stats,
+                                    false,
+                                    nested_link_targets.as_ref(),
+                                )?;
+                                return Ok(local_stats);
+                            }
 
                             // Single readlink classifies the entry into one of
                             // three states and drives the whole per-package

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -306,20 +306,37 @@ impl Linker {
                             // class). Materializes exactly as the per-project
                             // (GVS-off) branch does — the local `.aube/<entry>`
                             // name is dep_path-keyed regardless of GVS, so the
-                            // top-level and sibling symlinks resolve unchanged. A
+                            // top-level and sibling symlinks resolve unchanged.
+                            // Only registry packages reach here — source deps
+                            // (git/tarball/file/link) were filtered from
+                            // `step1_prep` above and keep the shared-store path;
+                            // the curated force-materialize list is registry-only,
+                            // so that gap is unreachable in practice. A
                             // prior GVS install or the fetch prewarm may have left
                             // a symlink here; replace it. An existing real
-                            // directory is reused as cached.
+                            // directory is reused as cached. Classification uses
+                            // `read_link`, not `file_type().is_symlink()`: on
+                            // Windows the GVS entry is an NTFS junction (created by
+                            // `sys::create_dir_link`) whose `is_symlink()` is false
+                            // and `is_dir()` is true, so the file-type bit would
+                            // misread a stale junction as a real dir and skip the
+                            // conversion. `read_link` succeeds on both Unix symlinks
+                            // and junction reparse points and returns `InvalidInput`
+                            // on a real directory — the same signal `classify_entry_state`
+                            // and `detect_aube_dir_gvs_mode` rely on.
                             if self.force_materialize_matches(&pkg.name) {
-                                match std::fs::symlink_metadata(&local_aube_entry) {
-                                    Ok(meta) if meta.file_type().is_symlink() => {
+                                match std::fs::read_link(&local_aube_entry) {
+                                    Ok(_) => {
+                                        // Stale shared-store symlink / junction — drop it.
                                         let _ = std::fs::remove_dir(&local_aube_entry)
                                             .or_else(|_| std::fs::remove_file(&local_aube_entry));
                                     }
-                                    Ok(_) => {
+                                    Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {
+                                        // Already a real project-local directory.
                                         local_stats.packages_cached += 1;
                                         return Ok(local_stats);
                                     }
+                                    // Missing (`NotFound`) or any other error → materialize below.
                                     Err(_) => {}
                                 }
                                 let owned_index;

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -459,6 +459,71 @@ fn test_link_all_creates_pnpm_virtual_store() {
 }
 
 #[test]
+fn force_materialize_makes_only_listed_package_a_real_dir_under_gvs() {
+    // Under the global virtual store every `.aube/<dep>` is normally a symlink
+    // into the shared store, so the package realpath escapes the project. A
+    // package on the force-materialize list must instead be a real
+    // project-local directory (its realpath back inside the project) so Node's
+    // upward walk from inside it reaches a consumer-installed, undeclared
+    // backend at the project root — while every OTHER package stays a symlink.
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let (store, indices) = setup_store_with_files(dir.path());
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
+        .with_hoist(false)
+        .with_force_materialize(&["foo".to_string()]);
+    let graph = make_graph();
+
+    linker.link_all(&project_dir, &graph, &indices).unwrap();
+
+    // foo is force-materialized: a real directory, not a shared-store symlink,
+    // with its files materialized project-local.
+    let aube_foo = project_dir.join("node_modules/.aube/foo@1.0.0");
+    let foo_is_symlink = aube_foo
+        .symlink_metadata()
+        .unwrap()
+        .file_type()
+        .is_symlink();
+    assert!(
+        !foo_is_symlink,
+        "force-materialized foo must be a real dir, not a global-store symlink"
+    );
+    assert_eq!(
+        std::fs::read_to_string(aube_foo.join("node_modules/foo/index.js")).unwrap(),
+        "module.exports = 'foo';"
+    );
+    // foo's declared dep still resolves through the sibling symlink inside it.
+    assert!(
+        aube_foo
+            .join("node_modules/bar")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "foo's transitive dep must remain a sibling symlink"
+    );
+
+    // bar is unlisted: it stays a global-virtual-store symlink.
+    assert!(
+        project_dir
+            .join("node_modules/.aube/bar@2.0.0")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "an unlisted package must stay a global-virtual-store symlink"
+    );
+
+    // The top-level entry resolves foo's content regardless.
+    assert_eq!(
+        std::fs::read_to_string(project_dir.join("node_modules/foo/index.js")).unwrap(),
+        "module.exports = 'foo';"
+    );
+}
+
+#[test]
 fn test_link_file_fresh_reports_missing_cas_shard_and_invalidates_cache() {
     // Reproduces jdx/aube#393: a partially corrupt CAS leaves the
     // cached package index pointing at a missing shard. Materialize

--- a/vendor/aube/crates/aube-manifest/src/workspace/config.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace/config.rs
@@ -99,6 +99,20 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub disable_global_virtual_store_for_packages: Option<Vec<String>>,
 
+    /// Package names force-materialized project-local even under the
+    /// global virtual store. Unlike
+    /// `disable_global_virtual_store_for_packages` (which disables the
+    /// GVS for the whole install), this materializes only the named
+    /// package's own `node_modules/.aube/<pkg>` entry — for a subpath
+    /// adapter that statically imports a specifier it doesn't declare
+    /// (e.g. `@hookform/resolvers/zod` importing the consumer's
+    /// installed `zod`) and so can't resolve across the store's
+    /// symlink boundary. Defaults to `[]`. Declared here so
+    /// `settings.toml`'s workspaceYaml source stays in sync with the
+    /// actual deserialize surface.
+    #[serde(default)]
+    pub force_materialize_packages: Option<Vec<String>>,
+
     /// Package import method: "auto", "hardlink", "copy", "clone", "clone-or-copy".
     #[serde(default)]
     pub package_import_method: Option<String>,

--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -1117,6 +1117,38 @@ sources.npmrc = ["disableGlobalVirtualStoreForPackages", "disable-global-virtual
 sources.workspaceYaml = ["disableGlobalVirtualStoreForPackages"]
 examples = []
 
+[forceMaterializePackages]
+description = "Package names force-materialized project-local even under the global virtual store."
+type = "list<string>"
+default = "[]"
+docs = """
+Under the global virtual store a package's `node_modules/.aube/<pkg>` is a
+symlink into `~/.cache/aube/virtual-store/`, so the package's realpath lives
+outside the project. Node resolves an undeclared import by walking realpath
+parents, so a package that statically imports a specifier it doesn't declare —
+a subpath adapter importing a consumer-installed backend it picks at runtime
+(`@hookform/resolvers/zod` importing the `zod` the app installed) — can't
+reach the project's `node_modules/` from inside the shared store and fails to
+resolve.
+
+Listing the adapter here force-materializes THAT package as a real
+project-local directory (reflink/hardlink/copy from the store, near-zero on
+copy-on-write filesystems) while every other package stays a shared-store
+symlink. Its realpath is then project-local, so Node's upward directory walk
+reaches the consumer-installed backend at the project root. Unlike
+`disableGlobalVirtualStoreForPackages` — which drops the WHOLE install to
+per-project materialization — this is per-package: only the named adapters pay
+the local-copy cost, and the rest of the tree keeps cross-project sharing.
+
+The default is empty. `CI=1` and `disableGlobalVirtualStoreForPackages`
+already force per-project materialization, where this setting is a no-op.
+"""
+sources.cli = []
+sources.env = ["npm_config_force_materialize_packages", "NPM_CONFIG_FORCE_MATERIALIZE_PACKAGES", "AUBE_FORCE_MATERIALIZE_PACKAGES"]
+sources.npmrc = ["forceMaterializePackages", "force-materialize-packages"]
+sources.workspaceYaml = ["forceMaterializePackages"]
+examples = []
+
 # ========================================= Store =========================================
 
 [storeDir]

--- a/vendor/aube/crates/aube-settings/tests/gvs_disable_list_embedder_default.rs
+++ b/vendor/aube/crates/aube-settings/tests/gvs_disable_list_embedder_default.rs
@@ -11,8 +11,8 @@
 //!
 //! This pins the three-part contract:
 //!   1. default profile → aube's built-in list, unchanged;
-//!   2. an embedder default → replaces the built-in list (nub's desired list:
-//!      adds `@sveltejs/kit`, drops `vite`/`vitepress`, keeps the rest);
+//!   2. an embedder default → replaces the built-in list (nub's shipped list:
+//!      drops `vite`/`vitepress`, keeps `next`/`nuxt`/`parcel`);
 //!   3. any real user/project source still outranks the embedder default.
 //!
 //! Lives in its own integration-test binary because `set_embedder_defaults` is
@@ -27,10 +27,10 @@ const SETTING: &str = "disableGlobalVirtualStoreForPackages";
 /// this string list is the "default is unchanged" half of the contract.
 const AUBE_DEFAULT: &[&str] = &["next", "nuxt", "vite", "vitepress", "parcel"];
 
-/// nub's desired list, encoded as the value the NUB embedder will feed through
-/// `set_embedder_defaults`. (The nub-side wiring lives in the nub repo; here we
-/// only prove the override path and that the default is untouched.)
-const NUB_LIST: &[&str] = &["@sveltejs/kit", "next", "nuxt", "parcel"];
+/// nub's shipped list, encoded as the value the NUB embedder feeds through
+/// `set_embedder_defaults` (`nub_setting_defaults` in the nub repo). Here we
+/// only prove the override path and that the default is untouched.
+const NUB_LIST: &[&str] = &["next", "nuxt", "parcel"];
 
 fn ctx<'a>(
     ws: &'a BTreeMap<String, yaml_serde::Value>,

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -167,6 +167,13 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     let virtual_store_only = aube_settings::resolved::virtual_store_only(settings_ctx);
     let node_linker = resolve_node_linker(settings_ctx)?;
     tracing::debug!("node-linker: {:?}", node_linker);
+    // Per-package force-materialize: subpath adapters that must be real
+    // project-local dirs even under GVS so their realpath stays inside the
+    // project (see `Linker::with_force_materialize`). Empty on standalone aube
+    // (settings default `[]`); nub seeds the curated list as an embedder
+    // default. Consulted by the linker only in the GVS pass.
+    let force_materialize_packages =
+        aube_settings::resolved::force_materialize_packages(settings_ctx);
 
     let mut linker = aube_linker::Linker::new(store, strategy)
         .with_shamefully_hoist(shamefully_hoist)
@@ -191,7 +198,8 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         .with_no_integrity_read_keys(crate::state::read_no_integrity_index_for(
             cwd,
             graph_for_link.packages.values(),
-        ));
+        ))
+        .with_force_materialize(&force_materialize_packages);
     if let Some(enabled) = use_global_virtual_store_override {
         linker = linker.with_use_global_virtual_store(enabled);
     }

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -170,14 +170,20 @@ pub(super) fn find_gvs_incompatible_trigger<'a>(
 /// symlinks. Callers use this to detect the transition and wipe
 /// `node_modules/` before the linker runs.
 ///
-/// Assumes a consistent `.aube/` tree (every entry the same type),
-/// which is what a successful install produces. A crash mid-link
-/// during a transition could leave a mixed tree; we classify from the
-/// first entry `read_dir` yields and let the next install self-heal
-/// — worst case is one extra wipe, which is identical to the cost of
-/// the transition we're already handling.
+/// Symlink-PRIORITY classification: any single symlink entry means the tree
+/// is in global-virtual-store mode. GVS-on trees are NOT necessarily uniform
+/// — `forceMaterializePackages` makes a handful of adapter entries real dirs
+/// while the rest stay shared-store symlinks, a legitimately MIXED tree — so
+/// classifying from the first `read_dir` entry would be order-dependent (a
+/// forced real dir landing first would misread the whole tree as per-project
+/// and trigger a spurious wipe on every install). Per-project mode is the
+/// only mode with NO symlink entries, so `false` is returned only after the
+/// full scan finds real dirs and zero symlinks. For a consistent tree (every
+/// entry the same type — standalone aube's default) the result is identical
+/// to the first-entry classification; only the mixed tree differs.
 pub(super) fn detect_aube_dir_gvs_mode(aube_dir: &std::path::Path) -> Option<bool> {
     let entries = std::fs::read_dir(aube_dir).ok()?;
+    let mut saw_real_dir = false;
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
@@ -199,11 +205,11 @@ pub(super) fn detect_aube_dir_gvs_mode(aube_dir: &std::path::Path) -> Option<boo
         // and move on to the next candidate.
         match std::fs::read_link(entry.path()) {
             Ok(_) => return Some(true),
-            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => return Some(false),
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => saw_real_dir = true,
             Err(_) => continue,
         }
     }
-    None
+    saw_real_dir.then_some(false)
 }
 
 /// Honor `cleanupUnusedCatalogs` by pruning declared-but-unreferenced
@@ -1250,6 +1256,44 @@ mod network_concurrency_tests {
         assert_eq!(network_concurrency_for_workers(24), 72);
         assert_eq!(network_concurrency_for_workers(64), 128);
         assert_eq!(network_concurrency_for_workers(usize::MAX), 128);
+    }
+}
+
+#[cfg(all(test, unix))]
+mod gvs_mode_detect_tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    // `forceMaterializePackages` produces a MIXED `.aube` tree — some entries
+    // are shared-store symlinks, some are force-materialized real dirs. The
+    // detector must classify such a tree as GVS-on regardless of `read_dir`
+    // order; a forced real dir landing first must NOT misread it as per-project
+    // (which would wipe node_modules on every install).
+    #[test]
+    fn mixed_tree_with_any_symlink_reads_as_gvs() {
+        let dir = tempfile::tempdir().unwrap();
+        let aube = dir.path();
+        std::fs::create_dir_all(aube.join("real@1.0.0/node_modules/real")).unwrap();
+        symlink("/nonexistent-store/dep@2.0.0", aube.join("dep@2.0.0")).unwrap();
+        assert_eq!(detect_aube_dir_gvs_mode(aube), Some(true));
+    }
+
+    #[test]
+    fn all_real_dirs_reads_as_per_project() {
+        let dir = tempfile::tempdir().unwrap();
+        let aube = dir.path();
+        std::fs::create_dir_all(aube.join("a@1.0.0/node_modules/a")).unwrap();
+        std::fs::create_dir_all(aube.join("b@1.0.0/node_modules/b")).unwrap();
+        assert_eq!(detect_aube_dir_gvs_mode(aube), Some(false));
+    }
+
+    #[test]
+    fn all_symlinks_reads_as_gvs() {
+        let dir = tempfile::tempdir().unwrap();
+        let aube = dir.path();
+        symlink("/store/a@1.0.0", aube.join("a@1.0.0")).unwrap();
+        symlink("/store/b@1.0.0", aube.join("b@1.0.0")).unwrap();
+        assert_eq!(detect_aube_dir_gvs_mode(aube), Some(true));
     }
 }
 

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -1265,6 +1265,18 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
         hasher.update(b"\x1f");
     }
     hasher.update(b"\0");
+    // force_materialize_packages changes which `.aube/<dep>` entries are real
+    // dirs vs shared-store symlinks under GVS. Introducing or editing the list
+    // must invalidate the install state so the link phase re-runs and converts
+    // a stale symlink to a materialized dir (or back) — else the existence-gated
+    // step1 accepts the wrong on-disk shape as cached.
+    let force_materialize_packages = aube_settings::resolved::force_materialize_packages(&ctx);
+    hasher.update(b"force_materialize_packages=");
+    for p in &force_materialize_packages {
+        hasher.update(p.as_bytes());
+        hasher.update(b"\x1f");
+    }
+    hasher.update(b"\0");
     // map shaped workspace settings live in yaml. raw byte hash catches
     // catalog edits, overrides bumps, packageExtensions, allowBuilds list.
     // any of those mean re-resolve is needed, yaml bytes are the source.


### PR DESCRIPTION
## What

Under nub's default global virtual store (GVS, off-CI), a package's realpath lives in the machine-global store, outside the project. Node resolves an undeclared import by walking realpath parents, so a subpath adapter that statically imports a consumer-installed backend it doesn't declare — `@hookform/resolvers/zod` importing the `zod` the app installed — never reaches the project root from inside the shared store, and the import fails. pnpm's default (per-project isolated) resolves this class; nub's default did not.

This adds a per-package escape hatch: a new `forceMaterializePackages` setting makes each listed package materialize as a real project-local directory even under GVS, while every other package stays a shared-store symlink. The listed adapter's realpath is then project-local, so Node's upward walk reaches the backend at the project root. nub seeds the list as an embedder default with the detector-validated subpath adapters, minus the build-time/helper subpath imports (`@babel/*`, `babel-plugin-macros`, `tslib`, `typescript`) that resolve anyway.

## How

- **aube-linker** — `Linker.force_materialize` set (empty by default); a branch in the GVS link pass materializes listed packages locally via the existing per-project `materialize_into` instead of symlinking to the shared store. Empty set ⇒ the GVS pass is byte-for-byte unchanged (standalone aube default path preserved).
- **install** — the install-state hash folds the list, so introducing or changing it forces a relink; `.aube` mode-detection is now symlink-priority, so the now-legitimately mixed tree (forced real dirs + shared-store symlinks) is classified as GVS rather than misread as per-project and wiped.
- **nub** — seeds the curated 16-adapter list as an embedder default; the whole-install `disableGlobalVirtualStoreForPackages` trigger stays at the validated-clean `next,nuxt,parcel`.

## Verification

Empirically confirmed under genuine default GVS (isolated HOME/XDG, off-CI):

- `@hookform/resolvers` is a real project-local directory; `react-hook-form` and `zod` stay machine-global symlinks.
- ESM and CJS `import '@hookform/resolvers/zod'` resolve (previously threw `Cannot find package 'zod'`).
- pnpm resolves the same fixture identically.
- A second install is idempotent — the forced entry stays a real dir, no wipe.

Tests: force-materialize layout (aube-linker), mixed-tree mode detection (aube), embedder-list override + accessor audit (aube-settings), seeded-list + List-1 trigger (nub-cli). `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.

Refs #286
Refs #280
