### PR TITLE
pm: drop lib0 from the force-materialize seed (proven false-inclusion)

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2080,7 +2080,7 @@ fn strip_yarnrc_value(rest: &str) -> &str {
 const NUB_FORCE_MATERIALIZE_PACKAGES: &str = "@hookform/resolvers,cypress,langsmith,\
 @storybook/addon-interactions,@storybook/core,@testing-library/jest-dom,drizzle-orm,\
 storybook,swiper,@angular/common,@angular/router,@apollo/client,\
-@storybook/builder-webpack5,@vercel/analytics,lib0,preact,next-themes,\
+@storybook/builder-webpack5,@vercel/analytics,preact,next-themes,\
 @react-pdf/renderer";
 
 /// - Layout policy: EVERY project defaults to the isolated layout


### PR DESCRIPTION
Removes `lib0` from `NUB_FORCE_MATERIALIZE_PACKAGES`, the curated force-materialize seed in `crates/nub-cli/src/pm_engine/mod.rs`. The other 17 entries are unchanged.

Per the audit (`wiki/research/force-materialize-list-audit.md`), lib0 is a proven false-inclusion. Its only phantom import, `isomorphic-webcrypto`, appears solely in `webcrypto.react-native.js`, and lib0's `./webcrypto` export maps the `node` condition to `webcrypto.node.js` — so Node and nub never load the phantom. Force-materializing lib0 only copies files to disk for no resolution benefit.

Gates run locally (green): `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test -p nub-cli --bins pm_engine` (142 passed). The seed-list test `force_materialize_default_seeds_the_curated_adapter_list` asserts specific entries and exclusions, not lib0 or a count, so it is unaffected.

Refs #286

https://claude.ai/code/session_01Xuh9u8b93eMNu53fTQTWX7
