### PR TITLE
fix(dlx): resolve nub-provisioned node for transient bin-exec on a node-less machine

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1377,6 +1377,19 @@ fn apply_lifecycle_augmentation(cwd: &Path) {
         return;
     };
     let (env_overlay, path_prepends) = augmentation_to_lifecycle_overlay(&aug, node.path.as_str());
+    // The shim dir + provisioned node for the engine's runtime spawn helpers —
+    // the boundary the transient bin-exec paths (dlx / create / `nubx <tool>`)
+    // read but the lifecycle overlay above never reaches. `runtime_switching`
+    // is off (nub owns provisioning), so aube's resolver stays inert and
+    // `runtime::path_entries()` / `apply_child_env` would otherwise surface no
+    // node — a fetched bin's `exec node` shebang then dies with `node: not
+    // found` on a machine with no system node (#303). Supplying the shim dir
+    // fronts PATH so `exec node` re-enters nub-as-node; pinning the real
+    // provisioned node keeps NODE / npm_node_execpath valid for node-gyp-style
+    // re-spawners. Both default to None for standalone aube, so its bin-exec
+    // paths are byte-identical.
+    let runtime_node_dir = aug.shim_dir.as_deref().map(PathBuf::from);
+    let runtime_node_bin = Some(PathBuf::from(node.path.as_str()));
     // Hand the overlay to the engine via the runtime context. aube copies
     // `env_overlay` / `path_prepends` from `engine_context()` into its
     // `ScriptSettings` at settings-resolution time (the spawn path composes them
@@ -1386,6 +1399,8 @@ fn apply_lifecycle_augmentation(cwd: &Path) {
     aube_util::update_engine_context(|c| {
         c.env_overlay = env_overlay;
         c.path_prepends = path_prepends;
+        c.runtime_node_dir = runtime_node_dir;
+        c.runtime_node_bin = runtime_node_bin;
     });
 }
 

--- a/vendor/aube/crates/aube-util/src/engine_context.rs
+++ b/vendor/aube/crates/aube-util/src/engine_context.rs
@@ -240,6 +240,27 @@ pub struct EngineContext {
     /// empty = behavior-preserving.
     pub env_overlay: Vec<(OsString, OsString)>,
 
+    /// A directory holding a resolvable `node`, supplied by an embedder that
+    /// owns Node provisioning itself (`Embedder::runtime_switching = false`) and
+    /// therefore leaves aube's runtime resolver inert. When the resolver
+    /// produced no switch, [`crate::runtime`]'s spawn helpers fall back to this
+    /// so a fetched-bin `exec node` shebang, a dlx/create child, and node-program
+    /// spawns still resolve `node` on a machine with no system `node` on PATH.
+    ///
+    /// Distinct from [`path_prepends`](Self::path_prepends): that reaches only
+    /// the LIFECYCLE-script overlay, which the transient bin-exec paths (dlx /
+    /// create / `nubx <tool>`) never touch. This reaches those paths through the
+    /// runtime helpers instead. `None` (default) = upstream behavior — the
+    /// resolver owns node discovery — byte-identical for standalone aube.
+    pub runtime_node_dir: Option<PathBuf>,
+
+    /// The node executable the embedder provisioned. Pins `NODE` /
+    /// `npm_node_execpath` on runtime-spawned children when the resolver didn't
+    /// switch, so those stay the embedder's provisioned node instead of falling
+    /// back to an ambient PATH `node` (absent on a node-less machine). `None`
+    /// (default) keeps the ambient-`node` fallback — upstream behavior.
+    pub runtime_node_bin: Option<PathBuf>,
+
     /// Replacement lifecycle `npm_config_user_agent` product token. `None`
     /// (default) falls back to the compile-time [`Embedder::user_agent`] —
     /// standalone aube reports `aube/<version>`. An embedder sets `Some` when
@@ -294,6 +315,8 @@ impl Default for EngineContext {
             synthetic_project_npmrc_entries: Vec::new(),
             path_prepends: Vec::new(),
             env_overlay: Vec::new(),
+            runtime_node_dir: None,
+            runtime_node_bin: None,
             lifecycle_user_agent_product: None,
             npm_save_prefix_on_bare_exact: false,
         }
@@ -359,6 +382,8 @@ mod tests {
         assert!(ctx.synthetic_project_npmrc_entries.is_empty());
         assert!(ctx.path_prepends.is_empty());
         assert!(ctx.env_overlay.is_empty());
+        assert_eq!(ctx.runtime_node_dir, None);
+        assert_eq!(ctx.runtime_node_bin, None);
         assert_eq!(ctx.lifecycle_user_agent_product, None);
         assert!(!ctx.npm_save_prefix_on_bare_exact);
     }

--- a/vendor/aube/crates/aube/src/runtime.rs
+++ b/vendor/aube/crates/aube/src/runtime.rs
@@ -97,39 +97,79 @@ pub fn current() -> Option<&'static RuntimeContext> {
 }
 
 /// The node executable spawn sites should use: the switched runtime's
-/// binary when one resolved, otherwise bare `"node"` (PATH lookup at
-/// spawn time, today's behavior).
+/// binary when one resolved, otherwise the embedder-provisioned node
+/// ([`EngineContext::runtime_node_bin`]) when an embedder owns provisioning,
+/// otherwise bare `"node"` (PATH lookup at spawn time, today's behavior).
+///
+/// [`EngineContext::runtime_node_bin`]: aube_util::EngineContext::runtime_node_bin
 pub fn node_program() -> PathBuf {
-    current()
-        .and_then(|c| c.node_bin.clone())
-        .unwrap_or_else(|| PathBuf::from("node"))
+    resolve_node_bin(
+        current().and_then(|c| c.node_bin.clone()),
+        aube_util::engine_context().runtime_node_bin,
+        None,
+    )
+    .unwrap_or_else(|| PathBuf::from("node"))
 }
 
 /// PATH entries to prepend (after `node_modules/.bin`) when spawning
-/// scripts/binaries. Empty when no switching is active.
+/// scripts/binaries. The switched runtime's bin dir when one resolved;
+/// otherwise the embedder-provisioned node dir
+/// ([`EngineContext::runtime_node_dir`]) when an embedder owns provisioning
+/// (`runtime_switching = false`) — the boundary that lets a fetched-bin
+/// `exec node` shebang resolve on a machine with no system `node`. Empty when
+/// neither applies (standalone aube with no active switch — unchanged).
+///
+/// [`EngineContext::runtime_node_dir`]: aube_util::EngineContext::runtime_node_dir
 pub fn path_entries() -> Vec<PathBuf> {
-    current()
-        .and_then(|c| c.bin_dir.clone())
-        .into_iter()
-        .collect()
+    resolve_path_entry(
+        current().and_then(|c| c.bin_dir.clone()),
+        aube_util::engine_context().runtime_node_dir,
+    )
+    .into_iter()
+    .collect()
 }
 
 /// Set the npm-compat env vars naming the node binary on a child
 /// command (`npm_node_execpath`, and `NODE` which npm also exports).
 ///
-/// Prefers the switched runtime's node; when no switch is active,
-/// falls back to the ambient `node` resolved on `PATH` so these vars
-/// are populated on every spawn — pnpm/npm always set them, and tools
-/// (`node-gyp`, `node-pre-gyp`, re-spawners) read `npm_node_execpath`
-/// to locate the exact node that drove the package manager.
+/// Prefers the switched runtime's node; then the embedder-provisioned node
+/// ([`EngineContext::runtime_node_bin`]) when an embedder owns provisioning —
+/// so on a node-less machine these stay the provisioned node instead of
+/// resolving to nothing; then the ambient `node` on `PATH`. pnpm/npm always
+/// set them, and tools (`node-gyp`, `node-pre-gyp`, re-spawners) read
+/// `npm_node_execpath` to locate the exact node that drove the package manager.
+///
+/// [`EngineContext::runtime_node_bin`]: aube_util::EngineContext::runtime_node_bin
 pub fn apply_child_env(cmd: &mut tokio::process::Command) {
-    let node_bin = current()
-        .and_then(|ctx| ctx.node_bin.clone())
-        .or_else(aube_runtime::node_on_path);
+    let node_bin = resolve_node_bin(
+        current().and_then(|ctx| ctx.node_bin.clone()),
+        aube_util::engine_context().runtime_node_bin,
+        aube_runtime::node_on_path(),
+    );
     if let Some(node_bin) = node_bin {
         cmd.env("npm_node_execpath", &node_bin);
         cmd.env("NODE", &node_bin);
     }
+}
+
+/// The node-binary fallback ladder shared by [`node_program`] and
+/// [`apply_child_env`]: the switched runtime's node wins; then the
+/// embedder-provisioned node (set when an embedder owns provisioning and the
+/// resolver stayed inert); then the ambient fallback the caller supplies (the
+/// PATH `node` for env vars, `None` for `node_program`'s bare-`"node"` case).
+/// Pure so the precedence is unit-tested without touching the process globals.
+fn resolve_node_bin(
+    switched: Option<PathBuf>,
+    embedder: Option<PathBuf>,
+    ambient: Option<PathBuf>,
+) -> Option<PathBuf> {
+    switched.or(embedder).or(ambient)
+}
+
+/// The PATH-entry fallback for [`path_entries`]: the switched runtime's bin dir
+/// wins; else the embedder-provisioned node dir. Pure for the same reason.
+fn resolve_path_entry(switched: Option<PathBuf>, embedder: Option<PathBuf>) -> Option<PathBuf> {
+    switched.or(embedder)
 }
 
 /// The runtime-relevant settings, extracted from a `ResolveCtx` so
@@ -692,6 +732,43 @@ impl aube_runtime::DownloadProgress for CliProgress {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn node_bin_prefers_switched_then_embedder_then_ambient() {
+        let sw = PathBuf::from("/switched/node");
+        let emb = PathBuf::from("/embedder/node");
+        let amb = PathBuf::from("/usr/bin/node");
+        // Switched runtime wins over everything.
+        assert_eq!(
+            resolve_node_bin(Some(sw.clone()), Some(emb.clone()), Some(amb.clone())),
+            Some(sw)
+        );
+        // No switch (embedder owns provisioning) → the embedder's node, NOT the
+        // ambient PATH node. This is the #303 fix: on a node-less machine the
+        // embedder-provisioned node pins NODE/npm_node_execpath.
+        assert_eq!(
+            resolve_node_bin(None, Some(emb.clone()), Some(amb.clone())),
+            Some(emb)
+        );
+        // Standalone aube (no embedder node) → ambient fallback, unchanged.
+        assert_eq!(resolve_node_bin(None, None, Some(amb.clone())), Some(amb));
+        // Nothing anywhere → None (node_program's bare-"node" case).
+        assert_eq!(resolve_node_bin(None, None, None), None);
+    }
+
+    #[test]
+    fn path_entry_switch_wins_else_embedder_dir() {
+        let sw = PathBuf::from("/switched/bin");
+        let emb = PathBuf::from("/embedder/shim");
+        assert_eq!(
+            resolve_path_entry(Some(sw.clone()), Some(emb.clone())),
+            Some(sw)
+        );
+        // No switch → the embedder shim dir, so a fetched-bin `exec node`
+        // resolves on a node-less machine (#303). Empty for standalone aube.
+        assert_eq!(resolve_path_entry(None, Some(emb.clone())), Some(emb));
+        assert_eq!(resolve_path_entry(None, None), None);
+    }
 
     #[test]
     fn lockfile_pin_round_trip_shapes() {


### PR DESCRIPTION
`nub dlx`, `nub create`, and `nubx <tool>` died with `exec: node: not found` when no system `node` was on PATH: the fetched bin`'`s `exec node` shim had nothing to resolve. nub sets `runtime_switching = false`, so aube`'`s resolver stays inert and the transient bin-exec path surfaced no node.

Fix: add `runtime_node_dir` + `runtime_node_bin` to aube`'`s `EngineContext` (default `None`, so standalone aube is byte-identical). With no resolver switch, `path_entries()` / `apply_child_env()` fall back to them; nub fills them with its `node`→nub shim dir + resolved node, so `exec node` re-enters nub-as-node. Also covers `nub run` / `nub exec` and install-time node spawns under nub.

Closes #303