### PR TITLE
pm: force-materialize @prisma/client to stop shared-store codegen corruption

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2104,10 +2104,25 @@ fn strip_yarnrc_value(rest: &str) -> &str {
 /// its declared dependent `@storybook/react-webpack5` (not on this list) stays
 /// store-resident and can no longer find its own dependency once pulled out, turning a
 /// passing `storybook build` into `Cannot find module '@storybook/builder-webpack5'`.
+///
+/// A THIRD offender class: postinstall codegen that writes generated output back into
+/// its own installed directory via realpath. `@prisma/client`'s postinstall runs
+/// `prisma generate`, which resolves the default output dir relative to the package's
+/// realpath and writes the generated client (`.prisma/client`) into the enclosing
+/// `node_modules`. Under GVS that realpath is the machine-global shared store, whose
+/// entry key is package-identity-scoped, NOT project- or schema-scoped — so two
+/// projects with different Prisma schemas share ONE mutable generated client and
+/// silently corrupt each other (last-writer-wins; #286-shape data corruption).
+/// Force-materialize makes the entry project-local, so `generate` writes into the
+/// project's own tree, matching pnpm's isolated virtual store. Orphan-safety verified:
+/// `@prisma/client` is a leaf runtime consumed by the app root (adapters like
+/// `@auth/prisma-adapter` take it as a peer, satisfied at the top level), so pulling it
+/// project-local orphans no store-resident dependent (the builder-webpack5 failure mode
+/// above does not apply).
 const NUB_FORCE_MATERIALIZE_PACKAGES: &str = "@hookform/resolvers,cypress,langsmith,\
 @testing-library/jest-dom,drizzle-orm,swiper,@angular/common,@angular/router,\
 @apollo/client,@vercel/analytics,preact,next-themes,\
-@react-pdf/renderer";
+@react-pdf/renderer,@prisma/client";
 
 /// - Layout policy: EVERY project defaults to the isolated layout
 ///   (`nodeLinker=isolated`) — strict (no phantom deps) and GVS-fast; a project
@@ -2771,6 +2786,14 @@ mod tests {
                 "{types_consumer} (#286 ambient-@types class) must be on the list: {list}"
             );
         }
+        // The postinstall-codegen class: `@prisma/client`'s `prisma generate`
+        // writes the generated client into its own realpath, which under GVS is
+        // the machine-global store — two projects with different schemas then
+        // corrupt each other. Force-materialize keeps `generate` project-local.
+        assert!(
+            names.contains(&"@prisma/client"),
+            "@prisma/client (postinstall-codegen class) must be on the list: {list}"
+        );
         for excluded in ["ox", "event-target-shim", "@nestjs/swagger"] {
             assert!(
                 !names.contains(&excluded),

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -466,7 +466,11 @@ enableGlobalVirtualStore=false
 
 Either layout resolves the same packages — including type packages (`@types/*`) pulled in transitively but not declared, which stay reachable in both.
 
-A few packages statically import a backend you pick at runtime — `@hookform/resolvers/zod` imports the `zod` your app installs, without declaring it. Under the shared store the adapter's real path sits outside the project, so Node's directory walk can't reach that backend and the import throws. Nub materializes those adapters into the project automatically so they resolve, while the rest of the tree keeps sharing. Add your own with one line in `.npmrc`:
+A few packages statically import a backend you pick at runtime — `@hookform/resolvers/zod` imports the `zod` your app installs, without declaring it. Under the shared store the adapter's real path sits outside the project, so Node's directory walk can't reach that backend and the import throws. Nub materializes those adapters into the project automatically so they resolve, while the rest of the tree keeps sharing.
+
+The same treatment covers packages that write generated code back into their own install directory. Prisma's postinstall runs `prisma generate`, which writes the generated client next to `@prisma/client` on disk — and under the shared store that spot is machine-global, keyed by version rather than by project or schema. Two projects with different Prisma schemas would otherwise share one generated client and silently overwrite each other's models. Nub materializes `@prisma/client` into each project so `generate` stays project-local, matching pnpm.
+
+Add your own with one line in `.npmrc`:
 
 ```ini
 forceMaterializePackages[]=my-adapter


### PR DESCRIPTION
Under default GVS, `@prisma/client`'s postinstall `prisma generate` writes the generated client into the package realpath — the machine-global store, keyed by version, not project/schema. Two projects with different schemas share one mutable client and silently overwrite each other's models.

Adding `@prisma/client` to the `forceMaterializePackages` default makes the entry project-local, so `generate` stays in-project (matches pnpm).

Validated before/after (shared realpath + bidirectional corruption → distinct project-local, isolated). Orphan-safe: `@auth/prisma-adapter` (store-resident peer) still resolves the intact store copy.

Refs #286