### PR TITLE
fix(linker): keep force-materialized package's store copy so store-resident dependents don't orphan

### DIFF
--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -325,19 +325,46 @@ impl Linker {
                             // on a real directory — the same signal `classify_entry_state`
                             // and `detect_aube_dir_gvs_mode` rely on.
                             if self.force_materialize_matches(&pkg.name) {
-                                match std::fs::read_link(&local_aube_entry) {
-                                    Ok(_) => {
-                                        // Stale shared-store symlink / junction — drop it.
-                                        let _ = std::fs::remove_dir(&local_aube_entry)
-                                            .or_else(|_| std::fs::remove_file(&local_aube_entry));
-                                    }
-                                    Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {
-                                        // Already a real project-local directory.
-                                        local_stats.packages_cached += 1;
-                                        return Ok(local_stats);
-                                    }
-                                    // Missing (`NotFound`) or any other error → materialize below.
-                                    Err(_) => {}
+                                // Orphan-safety invariant: force-materialize gives X
+                                // a real project-local dir so X's OWN undeclared
+                                // consumer-provided import resolves via the project
+                                // root — but every STORE-RESIDENT dependent of X
+                                // still reaches X through a sibling symlink into the
+                                // shared store at `virtual_store_subdir(X)` (==
+                                // `subdir`). The project-local dir alone does NOT
+                                // satisfy those siblings, and X's store copy is NOT
+                                // guaranteed to exist at THIS `subdir`: the fetch
+                                // prewarm materializes X under its own subtree hash,
+                                // which can differ from the link-phase `subdir` a
+                                // dependent's sibling points at (they diverge
+                                // whenever the link phase folds a fingerprint the
+                                // prewarm didn't). A non-force-materialized install
+                                // would still WRITE X's store copy at `subdir` here
+                                // (the normal branch below), keeping every dependent
+                                // resolvable; the pre-fix force-materialize branch
+                                // skipped that write, dangling the sibling — the
+                                // `@storybook/builder-webpack5` ← `react-webpack5`
+                                // regression. So ALWAYS keep X's store copy at
+                                // `subdir` IN ADDITION to the project-local dir. The
+                                // store copy is reflinked/CoW and is exactly what a
+                                // non-force-materialized install writes, so this only
+                                // RESTORES it — it is not a second full byte copy.
+                                let store_pkg_dir = self
+                                    .virtual_store
+                                    .join(subdir)
+                                    .join("node_modules")
+                                    .join(&pkg.name);
+                                // `InvalidInput` from `read_link` == a real dir (not
+                                // a symlink/junction). See the classification note
+                                // above for why this beats `is_symlink()`.
+                                let local_is_real_dir = matches!(
+                                    std::fs::read_link(&local_aube_entry),
+                                    Err(e) if e.kind() == std::io::ErrorKind::InvalidInput
+                                );
+                                if store_pkg_dir.exists() && local_is_real_dir {
+                                    // Both placements already correct.
+                                    local_stats.packages_cached += 1;
+                                    return Ok(local_stats);
                                 }
                                 let owned_index;
                                 let index = match package_indices.get(dep_path) {
@@ -356,6 +383,36 @@ impl Linker {
                                         &owned_index
                                     }
                                 };
+                                // Keep the shared-store copy at the exact `subdir`
+                                // every dependent's sibling targets. Idempotent (a
+                                // cache hit when already placed there). Stats land in
+                                // a throwaway sink so this belt-and-suspenders write
+                                // does not double-count the package — the
+                                // project-local `materialize_into` below is the one
+                                // that counts, matching a normal single-placement
+                                // install's package tally.
+                                let mut store_stats = LinkStats::default();
+                                self.ensure_in_virtual_store_with_subdir(
+                                    dep_path,
+                                    subdir,
+                                    pkg,
+                                    index,
+                                    &mut store_stats,
+                                    nested_link_targets.as_ref(),
+                                )?;
+                                if local_is_real_dir {
+                                    // Project-local dir was already correct; only the
+                                    // store copy needed (re)placing, done above.
+                                    local_stats.packages_cached += 1;
+                                    return Ok(local_stats);
+                                }
+                                // Drop a stale shared-store symlink/junction left by
+                                // a prior GVS install or the fetch prewarm before
+                                // materializing the real project-local dir.
+                                if std::fs::read_link(&local_aube_entry).is_ok() {
+                                    let _ = std::fs::remove_dir(&local_aube_entry)
+                                        .or_else(|_| std::fs::remove_file(&local_aube_entry));
+                                }
                                 self.materialize_into(
                                     &aube_dir,
                                     &aube_dir,

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -524,6 +524,65 @@ fn force_materialize_makes_only_listed_package_a_real_dir_under_gvs() {
 }
 
 #[test]
+fn force_materialize_keeps_store_copy_so_store_resident_dependents_dont_orphan() {
+    // Orphan-safety regression (the shipped @storybook/builder-webpack5 ←
+    // @storybook/react-webpack5 class). The graph is root → foo → bar; here bar
+    // is force-materialized while foo stays a store symlink. foo reaches bar
+    // through its store entry's sibling symlink, which targets
+    // `<store>/<subdir(bar)>/node_modules/bar`. If the force-materialize branch
+    // only wrote bar's project-local real dir and skipped bar's store copy, that
+    // sibling would dangle — the exact orphan the builder-webpack5 case hit. The
+    // fix keeps bar's store copy at its subdir IN ADDITION to the project-local
+    // dir; assert BOTH the store copy and the dependent's resolved sibling.
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let (store, indices) = setup_store_with_files(dir.path());
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
+        .with_hoist(false)
+        .with_force_materialize(&["bar".to_string()]);
+    let graph = make_graph(); // root -> foo -> bar
+
+    linker.link_all(&project_dir, &graph, &indices).unwrap();
+
+    // bar is force-materialized: a real project-local dir.
+    let aube_bar = project_dir.join("node_modules/.aube/bar@2.0.0");
+    assert!(
+        !aube_bar
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "force-materialized bar must be a real project-local dir"
+    );
+
+    // The orphan-safety invariant: bar's store copy still exists at exactly the
+    // subdir a store-resident dependent's sibling symlink points at.
+    let bar_store_copy = store
+        .virtual_store_dir()
+        .join(linker.virtual_store_subdir("bar@2.0.0"))
+        .join("node_modules/bar/index.js");
+    assert_eq!(
+        std::fs::read_to_string(&bar_store_copy).unwrap(),
+        "module.exports = 'bar';",
+        "force-materialized bar's store copy must remain at its subdir so a \
+         store-resident dependent's sibling symlink still resolves"
+    );
+
+    // End-to-end: foo (store-resident) resolves bar through its sibling symlink.
+    // `.aube/foo@1.0.0` is a store symlink; its `node_modules/bar` sibling must
+    // resolve all the way to bar's content — not dangle.
+    let foo_sibling_bar =
+        project_dir.join("node_modules/.aube/foo@1.0.0/node_modules/bar/index.js");
+    assert_eq!(
+        std::fs::read_to_string(&foo_sibling_bar).unwrap(),
+        "module.exports = 'bar';",
+        "store-resident foo's sibling to force-materialized bar must resolve (no orphan)"
+    );
+}
+
+#[test]
 fn test_link_file_fresh_reports_missing_cas_shard_and_invalidates_cache() {
     // Reproduces jdx/aube#393: a partially corrupt CAS leaves the
     // cached package index pointing at a missing shard. Materialize


### PR DESCRIPTION
The GVS force-materialize branch (#304) skipped the link-phase shared-store write, leaving the offender's store copy to the fetch prewarm — whose subtree hash can differ from the link-phase `subdir` a store-resident dependent's sibling symlink targets, dangling it. Force-materializing `@storybook/builder-webpack5` regressed `@storybook/react-webpack5` to `Cannot find module` (why #309 dropped it).

Fix: also ensure the store copy at `virtual_store_subdir(dep_path)` alongside the project-local dir — the write a normal install performs. Default-preserving (empty force-materialize set → branch never runs). Adds a regression test that fails without the fix.

Refs #304, #309