### PR TITLE
Vite symlink-GVS serving compat (#315)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,6 +2668,7 @@ dependencies = [
  "aube-registry",
  "aube-scripts",
  "aube-settings",
+ "aube-store",
  "aube-util",
  "aube-workspace",
  "base64",

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -61,6 +61,10 @@ aube-scripts = { path = "../../vendor/aube/crates/aube-scripts" }
 # Diagnostics / critical-path recorder: nub's engine_session calls diag::init()
 # so AUBE_DIAG_* env vars work when nub install runs the embedded aube engine.
 aube-util = { path = "../../vendor/aube/crates/aube-util" }
+# Store dir resolution: the Vite compat post-install step (pm_engine/vite_compat.rs)
+# reads the global virtual-store path via `aube_store::dirs::cache_dir()` (embedder
+# cache_namespace-aware) to write it into `.modules.yaml`. Already a transitive dep.
+aube-store = { path = "../../vendor/aube/crates/aube-store" }
 # Same major + `fancy` as vendor/aube — present.rs renders the engine's
 # miette::Report exactly as aube's own cli_main would, then rewrites it.
 miette = { version = "7", features = ["fancy"] }

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -368,6 +368,12 @@ fn run_add(typed: &str, args: &[String]) -> Result<i32> {
     )?;
     super::min_release_age::persist(&session.cwd, code == 0, &globals.output);
     stamp_if_virgin(&session, code);
+    // `nub add vite` (or adding any dep to a vite project) changes the graph;
+    // refresh `.modules.yaml` + the < 8.1 patch. Note: a FIRST `nub add vite`
+    // can't have force-materialized vite yet (the manifest didn't declare it at
+    // settings time), so Unit A applies immediately (≥ 8.1) and the < 8.1 dist
+    // patch lands on the next `nub install` once vite is a declared direct dep.
+    apply_vite_compat(&session, code);
     Ok(code)
 }
 
@@ -418,6 +424,9 @@ fn run_update(typed: &str, args: &[String]) -> Result<i32> {
     )?;
     super::min_release_age::persist(&session.cwd, code == 0, &globals.output);
     stamp_if_virgin(&session, code);
+    // `nub update` re-resolves; a vite bump can cross the 8.1 boundary, so
+    // refresh `.modules.yaml` + the < 8.1 patch to match the new graph.
+    apply_vite_compat(&session, code);
     Ok(code)
 }
 
@@ -844,6 +853,29 @@ fn import_to_pnpm_lock(force: bool) -> miette::Result<String> {
 /// `super::detect_lockfile_walk_up`. Approximation of aube's
 /// `dirs::project_root` (which is crate-private); the home-dir boundary is
 /// not enforced here.
+/// Run the Vite symlink-GVS compat post-step ([`super::vite_compat::apply`]) for
+/// a successful engine verb (`install`/`add`/`update`). Resolves the root where
+/// the install's `node_modules` actually lives: the identity walk-up dir
+/// (`detected.dir` — the workspace root for a monorepo member) when IT holds the
+/// tree, else the cwd, so a stray ancestor lockfile can't point the writer at a
+/// `node_modules`-less parent. `nub ci` (project-local store) does not call this
+/// — its store is already under the workspace root, so Vite serves it unchanged.
+fn apply_vite_compat(session: &EngineSession, code: i32) {
+    if code != 0 {
+        return;
+    }
+    let has_node_modules = |d: &Path| d.join("node_modules").is_dir();
+    let root = session
+        .detected
+        .as_ref()
+        .map(|d| d.dir.clone())
+        .filter(|d| has_node_modules(d))
+        .or_else(|| has_node_modules(&session.cwd).then(|| session.cwd.clone()))
+        .or_else(|| find_manifest_root(&session.cwd))
+        .unwrap_or_else(|| session.cwd.clone());
+    super::vite_compat::apply(&root);
+}
+
 fn find_manifest_root(cwd: &Path) -> Option<PathBuf> {
     let mut dir = cwd.to_path_buf();
     for _ in 0..16 {
@@ -1070,16 +1102,8 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     // `node_modules/.modules.yaml` and (for Vite < 8.1) patch the ejected vite
     // dist so its dev server serves the machine-global store. Gated internally on
     // vite-in-graph + the `NUB_VITE_COMPAT` opt-out; best-effort, never fails the
-    // install. The root is where the (hoisted/GVS) node_modules lives.
-    if code == 0 {
-        let root = session
-            .detected
-            .as_ref()
-            .map(|d| d.dir.clone())
-            .or_else(|| find_manifest_root(&session.cwd))
-            .unwrap_or_else(|| session.cwd.clone());
-        super::vite_compat::apply(&root);
-    }
+    // install.
+    apply_vite_compat(&session, code);
     // Virgin install only: stamp a caret RANGE into `devEngines.packageManager`
     // so the project advertises nub the standard, cross-tool way WITHOUT locking
     // itself to one exact nub version. nub's canonical lockfile is deliberately

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1066,6 +1066,20 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     super::min_release_age::arm();
     let code = run_engine(&session, opts, yarn, &flags.output)?;
     super::min_release_age::persist(&session.cwd, code == 0, &flags.output);
+    // Vite symlink-GVS serving compat (#315): after a successful install, write
+    // `node_modules/.modules.yaml` and (for Vite < 8.1) patch the ejected vite
+    // dist so its dev server serves the machine-global store. Gated internally on
+    // vite-in-graph + the `NUB_VITE_COMPAT` opt-out; best-effort, never fails the
+    // install. The root is where the (hoisted/GVS) node_modules lives.
+    if code == 0 {
+        let root = session
+            .detected
+            .as_ref()
+            .map(|d| d.dir.clone())
+            .or_else(|| find_manifest_root(&session.cwd))
+            .unwrap_or_else(|| session.cwd.clone());
+        super::vite_compat::apply(&root);
+    }
     // Virgin install only: stamp a caret RANGE into `devEngines.packageManager`
     // so the project advertises nub the standard, cross-tool way WITHOUT locking
     // itself to one exact nub version. nub's canonical lockfile is deliberately

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2157,17 +2157,24 @@ fn nub_setting_defaults(
     let fresh_format = if truly_fresh { "aube" } else { "pnpm" };
     // Vite symlink-GVS compat (#315): eject the `vite` package project-local so
     // its dist can be patched with the backported fs.allow sniff (< 8.1) without
-    // touching the shared CAS store. Only under the machine-global store
-    // (`Default`) — `nub ci`'s project-local store is already under the
+    // touching the shared CAS store. Scoped to a DIRECT-dep vite (a raw `vite`
+    // app / `vite dev` CLI project) — that is the only shape whose loaded Vite is
+    // the ejected project-local copy the backport reaches; a library-embedded
+    // framework (Astro/SvelteKit) loads its Vite from the shared store via a
+    // sibling symlink, so ejecting for it would be wasted dedup (Unit A's
+    // `.modules.yaml` covers those for Vite ≥ 8.1). Only under the machine-global
+    // store (`Default`) — `nub ci`'s project-local store is already under the
     // workspace root, so Vite serves it with no override. The post-install
     // writer/patcher lives in [`vite_compat`]; this is its materialization half.
     // A user-set `forceMaterializePackages` still wins (embedder-tier).
-    let force_materialize =
-        if store_locality == VirtualStoreLocality::Default && vite_compat::enabled() {
-            format!("{NUB_FORCE_MATERIALIZE_PACKAGES},vite")
-        } else {
-            NUB_FORCE_MATERIALIZE_PACKAGES.to_string()
-        };
+    let force_materialize = if store_locality == VirtualStoreLocality::Default
+        && vite_compat::enabled()
+        && vite_compat::manifest_declares_vite(detected.map(|d| d.dir.as_path()).unwrap_or(cwd))
+    {
+        format!("{NUB_FORCE_MATERIALIZE_PACKAGES},vite")
+    } else {
+        NUB_FORCE_MATERIALIZE_PACKAGES.to_string()
+    };
     let mut defaults = vec![
         (
             "defaultLockfileFormat".to_string(),

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -66,6 +66,7 @@ pub mod store_config_family;
 pub mod unsupported_config;
 pub mod use_align;
 pub mod use_nub;
+pub mod vite_compat;
 
 pub use install_family::{
     CiFlags, InstallFlags, WorkspaceFilterFlags, run_ci, run_dlx_for_nubx, run_install,
@@ -2154,6 +2155,19 @@ fn nub_setting_defaults(
     store_locality: VirtualStoreLocality,
 ) -> Vec<(String, String)> {
     let fresh_format = if truly_fresh { "aube" } else { "pnpm" };
+    // Vite symlink-GVS compat (#315): eject the `vite` package project-local so
+    // its dist can be patched with the backported fs.allow sniff (< 8.1) without
+    // touching the shared CAS store. Only under the machine-global store
+    // (`Default`) — `nub ci`'s project-local store is already under the
+    // workspace root, so Vite serves it with no override. The post-install
+    // writer/patcher lives in [`vite_compat`]; this is its materialization half.
+    // A user-set `forceMaterializePackages` still wins (embedder-tier).
+    let force_materialize =
+        if store_locality == VirtualStoreLocality::Default && vite_compat::enabled() {
+            format!("{NUB_FORCE_MATERIALIZE_PACKAGES},vite")
+        } else {
+            NUB_FORCE_MATERIALIZE_PACKAGES.to_string()
+        };
     let mut defaults = vec![
         (
             "defaultLockfileFormat".to_string(),
@@ -2178,10 +2192,7 @@ fn nub_setting_defaults(
             // phantom-dep class, so force-materialize is the wrong lever.
             "next,nuxt,parcel,react-native".to_string(),
         ),
-        (
-            "forceMaterializePackages".to_string(),
-            NUB_FORCE_MATERIALIZE_PACKAGES.to_string(),
-        ),
+        ("forceMaterializePackages".to_string(), force_materialize),
     ];
     if let Some(data) = nub_data_dir() {
         defaults.push((

--- a/crates/nub-cli/src/pm_engine/vite_compat.rs
+++ b/crates/nub-cli/src/pm_engine/vite_compat.rs
@@ -57,40 +57,117 @@ pub(crate) fn enabled() -> bool {
     }
 }
 
-/// Post-install entry: write `.modules.yaml` and, for Vite < 8.1, patch the
-/// ejected copy. `root` is the install/workspace root (where the hoisted/GVS
+/// Post-install entry: write `.modules.yaml` for every install that has Vite
+/// anywhere in the graph, and patch each project-local (ejected) Vite < 8.1
+/// copy. `root` is the install/workspace root (where the hoisted/GVS
 /// `node_modules` lives). Best-effort — a successful install must never fail on
 /// a compat step, so every fallible step degrades to a no-op.
+///
+/// Vite reaches the graph two ways, and both are handled: as a DIRECT dep (a raw
+/// `vite` app / a `vite dev` CLI project — the top-level `node_modules/vite`),
+/// and TRANSITIVELY as a framework's embedded engine (Astro/SvelteKit/VitePress
+/// — the `.nub/vite@*` isolated-store entries, no top-level symlink). A
+/// library-embedded framework is itself store-resident and loads ITS Vite via a
+/// store-to-store sibling symlink (the shared virtual-store copy, NOT the
+/// project-local ejected copy), so the dist backport cannot reach it CAS-safely
+/// — but Unit A (`.modules.yaml`) fixes it for Vite ≥ 8.1 (the framework's
+/// store Vite reads the file natively). Direct-dep Vite IS loaded from the
+/// force-materialized project-local copy, so the < 8.1 backport reaches it.
 pub(crate) fn apply(root: &Path) {
     if !enabled() {
         return;
     }
     let node_modules = root.join("node_modules");
-    let Some(version) = installed_vite_version(&node_modules) else {
-        return; // vite not in the graph — nothing to do
-    };
+    let copies = discover_vite(&node_modules);
+    if copies.is_empty() {
+        return; // no Vite in the graph — nothing to do
+    }
     let Some(store) = global_virtual_store_dir() else {
         return;
     };
-    // Unit A — always when vite is present. `.modules.yaml` at the workspace
-    // root's node_modules; Vite ≥ 8.1 reads it natively, the < 8.1 backport
-    // reads it too. Canonicalize the store so the path Vite prefix-matches its
-    // realpath'd module ids against has symlinks in `~/.cache` already resolved.
+    // Unit A — Vite present anywhere ⇒ write `.modules.yaml` at the workspace
+    // root's node_modules (the path Vite resolves via `searchForWorkspaceRoot`).
+    // Covers the native sniff (≥ 8.1) for both direct and library-embedded Vite,
+    // and feeds the < 8.1 backport. Canonicalize the store so the allow-list
+    // path already has any `~/.cache` symlinks resolved, matching Vite's
+    // realpath'd module ids.
     let store = std::fs::canonicalize(&store).unwrap_or(store);
     write_modules_yaml(&node_modules, &store);
 
-    // Unit B — only Vite < 8.1 needs the backport (≥ 8.1 has the native sniff).
-    if vite_lt_8_1(&version) {
-        patch_ejected_vite(&node_modules);
+    // Unit B — patch only project-local (ejected) copies below 8.1. The store
+    // copies a framework loads via sibling symlink are shared across projects, so
+    // patching them would corrupt the CAS and leak across projects — left to
+    // Unit A (≥ 8.1) / docs (< 8.1 library-embedded, the documented gap).
+    for c in &copies {
+        if c.project_local && vite_lt_8_1(&c.version) {
+            patch_vite_dist(&c.dir);
+        }
     }
 }
 
-/// Read the installed Vite's version from `node_modules/vite/package.json`.
-/// `None` when vite is not installed or the manifest is unreadable/malformed.
-fn installed_vite_version(node_modules: &Path) -> Option<String> {
-    let raw = std::fs::read_to_string(node_modules.join("vite/package.json")).ok()?;
-    // Minimal extraction — avoid a serde_json dep here; the field is a plain
-    // quoted string in every published vite manifest.
+/// One resolved Vite package present in the install.
+struct ViteCopy {
+    /// Canonical (realpath) package dir — the `dist/node` patch target.
+    dir: PathBuf,
+    version: String,
+    /// Whether the realpath lives inside the project (an ejected, patch-safe
+    /// copy) vs. the shared machine-global store (never patched).
+    project_local: bool,
+}
+
+/// Enumerate every distinct Vite package in the install: the top-level
+/// `node_modules/vite` (direct dep) plus each `node_modules/.nub/vite@*`
+/// isolated-store entry (transitive/library-embedded). Deduplicated by realpath;
+/// each entry carries its version and whether it is project-local.
+fn discover_vite(node_modules: &Path) -> Vec<ViteCopy> {
+    let project_root = node_modules.parent().map(Path::to_path_buf);
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    consider_vite(
+        &node_modules.join("vite"),
+        &project_root,
+        &mut seen,
+        &mut out,
+    );
+    if let Ok(entries) = std::fs::read_dir(node_modules.join(".nub")) {
+        for e in entries.flatten() {
+            if e.file_name().to_string_lossy().starts_with("vite@") {
+                let pkg = e.path().join("node_modules").join("vite");
+                consider_vite(&pkg, &project_root, &mut seen, &mut out);
+            }
+        }
+    }
+    out
+}
+
+fn consider_vite(
+    pkg_dir: &Path,
+    project_root: &Option<PathBuf>,
+    seen: &mut std::collections::HashSet<PathBuf>,
+    out: &mut Vec<ViteCopy>,
+) {
+    let Ok(real) = std::fs::canonicalize(pkg_dir) else {
+        return;
+    };
+    if !seen.insert(real.clone()) {
+        return;
+    }
+    let Some(version) = read_vite_version(&real) else {
+        return;
+    };
+    let project_local = project_root.as_ref().is_some_and(|r| real.starts_with(r));
+    out.push(ViteCopy {
+        dir: real,
+        version,
+        project_local,
+    });
+}
+
+/// Read a Vite package dir's `version`. Minimal string extraction — avoids a
+/// serde_json round-trip; the field is a plain quoted string in every published
+/// vite manifest.
+fn read_vite_version(pkg_dir: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(pkg_dir.join("package.json")).ok()?;
     let key = raw.find("\"version\"")?;
     let after = &raw[key + "\"version\"".len()..];
     let colon = after.find(':')?;
@@ -98,6 +175,24 @@ fn installed_vite_version(node_modules: &Path) -> Option<String> {
     let start = rest.find('"')? + 1;
     let end = rest[start..].find('"')? + start;
     Some(rest[start..end].to_string())
+}
+
+/// Whether the project manifest at `root` declares `vite` as a DIRECT dependency
+/// (any of dependencies / devDependencies / optionalDependencies). Drives the
+/// force-materialize decision: only a direct-dep Vite is loaded from the ejected
+/// project-local copy the backport patches, so ejecting for a library-embedded
+/// Vite (which loads its store copy) would be wasted dedup. Best-effort — an
+/// unreadable/absent manifest ⇒ `false`.
+pub(crate) fn manifest_declares_vite(root: &Path) -> bool {
+    let Ok(raw) = std::fs::read_to_string(root.join("package.json")) else {
+        return false;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return false;
+    };
+    ["dependencies", "devDependencies", "optionalDependencies"]
+        .iter()
+        .any(|field| json.get(field).and_then(|v| v.get("vite")).is_some())
 }
 
 /// Whether a semver version string is below 8.1.0 (the floor at which Vite's
@@ -180,25 +275,16 @@ const ANCHORS: &[&str] = &[
 /// making the whole pass idempotent across re-installs.
 const MARKER: &str = "__nubRfs(__nubJoin";
 
-/// Force-materialize + patch. Resolves the ejected local vite dir via the
-/// realpath of `node_modules/vite` (project-local after the linker's
-/// force-materialize), REFUSES to touch anything under the shared global store
-/// (CAS-safety invariant — if the eject did not happen, patching in place would
-/// corrupt the store shared across every project), then scans `dist/node/**.js`
-/// for the anchor and inserts the sniff. Fail-open at every step.
-fn patch_ejected_vite(node_modules: &Path) {
-    let vite_link = node_modules.join("vite");
-    let Ok(vite_dir) = std::fs::canonicalize(&vite_link) else {
-        return;
-    };
-    // CAS-safety: only patch a project-local ejected copy. If the realpath still
-    // points into the machine-global store (force-materialize did not run, e.g.
-    // a store this exact peer-hash is shared with another project), skip — never
-    // mutate the shared CAS-backed store.
+/// Patch an ejected, project-local Vite package's `dist/node/**.js` with the
+/// backported sniff. `vite_dir` is the CANONICAL package dir (from
+/// [`discover_vite`], already classified project-local). A defensive CAS-safety
+/// re-check refuses anything under the shared global store — patching there
+/// would corrupt the store shared across every project. Fail-open at every step.
+fn patch_vite_dist(vite_dir: &Path) {
     if let Some(store) = global_virtual_store_dir() {
         let store = std::fs::canonicalize(&store).unwrap_or(store);
         if vite_dir.starts_with(&store) {
-            return;
+            return; // never mutate the shared CAS-backed store
         }
     }
     let dist_node = vite_dir.join("dist").join("node");
@@ -296,19 +382,38 @@ mod tests {
     }
 
     #[test]
-    fn version_extraction_from_manifest() {
+    fn version_extraction_from_pkg_dir() {
         let dir = std::env::temp_dir().join(format!("nub-vite-ver-{}", std::process::id()));
-        let nm = dir.join("node_modules").join("vite");
-        std::fs::create_dir_all(&nm).unwrap();
+        std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
-            nm.join("package.json"),
+            dir.join("package.json"),
             r#"{"name":"vite","version":"7.3.6","type":"module"}"#,
         )
         .unwrap();
-        assert_eq!(
-            installed_vite_version(&dir.join("node_modules")).as_deref(),
-            Some("7.3.6")
+        assert_eq!(read_vite_version(&dir).as_deref(), Some("7.3.6"));
+        assert_eq!(read_vite_version(&dir.join("nope")), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn manifest_declares_vite_scans_all_dep_fields() {
+        let dir = std::env::temp_dir().join(format!("nub-vite-decl-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let write = |body: &str| std::fs::write(dir.join("package.json"), body).unwrap();
+
+        write(r#"{"devDependencies":{"vite":"^7"}}"#);
+        assert!(manifest_declares_vite(&dir), "devDependencies");
+        write(r#"{"dependencies":{"vite":"7"}}"#);
+        assert!(manifest_declares_vite(&dir), "dependencies");
+        // Library-embedded: framework declared, Vite only transitive ⇒ not direct.
+        write(r#"{"dependencies":{"astro":"^7","@astrojs/react":"^4"}}"#);
+        assert!(
+            !manifest_declares_vite(&dir),
+            "transitive vite is not a direct dep"
         );
+        // No manifest ⇒ false, no panic.
+        std::fs::remove_file(dir.join("package.json")).unwrap();
+        assert!(!manifest_declares_vite(&dir));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/nub-cli/src/pm_engine/vite_compat.rs
+++ b/crates/nub-cli/src/pm_engine/vite_compat.rs
@@ -227,17 +227,44 @@ fn global_virtual_store_dir() -> Option<PathBuf> {
 /// MUST be JSON-flow (Vite ≤ 8.1.x's native sniff parses with `JSON.parse`;
 /// block YAML would throw and skip the store). JSON-flow is also valid YAML, so
 /// it survives a future YAML-parser upstream fix and the backported regex
-/// fallback. Idempotent (unconditional rewrite). Best-effort.
+/// fallback. Best-effort.
+///
+/// `.modules.yaml` is also pnpm's OWN install-state file (block YAML, many keys:
+/// `hoistPattern`, `packageManager`, …). nub must not clobber a real pnpm state
+/// file — so write ONLY when the file is absent or is already nub's own
+/// single-key JSON stub. A foreign (pnpm) state file is left untouched (that
+/// project's Vite compat is forgone rather than corrupt pnpm's round-trip); the
+/// common nub-identity case has no such file and writes freely.
 fn write_modules_yaml(node_modules: &Path, store: &Path) {
     if !node_modules.is_dir() {
         return;
+    }
+    let path = node_modules.join(".modules.yaml");
+    if let Ok(existing) = std::fs::read_to_string(&path) {
+        if !is_nub_modules_yaml(&existing) {
+            return; // foreign (pnpm) state file — never clobber
+        }
     }
     // JSON string-escape the path (Windows backslashes, spaces). serde_json is a
     // nub-cli dep already.
     let value = serde_json::to_string(&store.to_string_lossy().into_owned())
         .unwrap_or_else(|_| "\"\"".to_string());
     let body = format!("{{\"virtualStoreDir\":{value}}}\n");
-    let _ = std::fs::write(node_modules.join(".modules.yaml"), body);
+    let _ = std::fs::write(&path, body);
+}
+
+/// Whether a `.modules.yaml` body is nub's own stub (a JSON object whose only
+/// key is `virtualStoreDir`) rather than a foreign PM's richer state file. A
+/// pnpm state file is block YAML / carries other keys, so it fails to parse as a
+/// single-key JSON object and is left alone.
+fn is_nub_modules_yaml(body: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| {
+            v.as_object()
+                .map(|o| o.len() == 1 && o.contains_key("virtualStoreDir"))
+        })
+        .unwrap_or(false)
 }
 
 // ───────────────────────── Unit B: the < 8.1 dist backport ─────────────────
@@ -327,6 +354,15 @@ fn collect_js_depth(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
 /// Patch one dist file if it carries an anchor and is not already patched.
 /// Prepends the import and inserts the sniff after the first matching anchor.
 /// The write is best-effort; a read/anchor miss is a no-op.
+///
+/// CAS-safety, CRITICAL: the ejected copy's files are created by the linker via
+/// `hard_link` on non-macOS same-FS targets (macOS clones), so each dist file
+/// SHARES its inode with the content-addressed store blob every project
+/// hardlinks to. A truncate-in-place write (`fs::write` = `O_TRUNC`) would edit
+/// that shared inode and corrupt the global CAS. So write a fresh sibling file
+/// and atomically `rename` over the target — the rename repoints the directory
+/// entry to a NEW inode, leaving the CAS-shared blob untouched. This also makes
+/// the patch atomic (no truncated/half-written chunk on an interrupted write).
 fn patch_one(file: &Path) {
     let Ok(src) = std::fs::read_to_string(file) else {
         return;
@@ -340,7 +376,27 @@ fn patch_one(file: &Path) {
     // Insert AFTER the first anchor occurrence, then prepend the import.
     let patched = src.replacen(anchor, &format!("{anchor}{INSERT}"), 1);
     let patched = format!("{PREPEND}{patched}");
-    let _ = std::fs::write(file, patched);
+    write_breaking_hardlink(file, patched.as_bytes());
+}
+
+/// Replace `file`'s contents WITHOUT truncating its (possibly CAS-hardlinked)
+/// inode: write a temp sibling in the same directory, then atomically rename it
+/// over `file`. Same-dir keeps the rename on one filesystem (atomic); the temp
+/// name is process- + path-unique. Best-effort — a failure cleans up the temp
+/// and leaves the original untouched.
+fn write_breaking_hardlink(file: &Path, bytes: &[u8]) {
+    let Some(dir) = file.parent() else {
+        return;
+    };
+    let stem = file.file_name().and_then(|n| n.to_str()).unwrap_or("chunk");
+    let tmp = dir.join(format!(".{stem}.nub-{}.tmp", std::process::id()));
+    if std::fs::write(&tmp, bytes).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        return;
+    }
+    if std::fs::rename(&tmp, file).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
 }
 
 #[cfg(test)]
@@ -392,6 +448,74 @@ mod tests {
         .unwrap();
         assert_eq!(read_vite_version(&dir).as_deref(), Some("7.3.6"));
         assert_eq!(read_vite_version(&dir.join("nope")), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn only_nub_shaped_modules_yaml_is_overwritable() {
+        // nub's own stub — overwritable.
+        assert!(is_nub_modules_yaml(r#"{"virtualStoreDir":"/abs"}"#));
+        assert!(is_nub_modules_yaml("{\"virtualStoreDir\":\"/abs\"}\n"));
+        // pnpm's real state file (block YAML, many keys) — never clobber.
+        assert!(!is_nub_modules_yaml(
+            "hoistPattern:\n  - '*'\nvirtualStoreDir: node_modules/.pnpm\npackageManager: pnpm@9\n"
+        ));
+        // A JSON object with extra keys is foreign too (not the single-key stub).
+        assert!(!is_nub_modules_yaml(
+            r#"{"virtualStoreDir":"/abs","hoistPattern":["*"]}"#
+        ));
+        assert!(!is_nub_modules_yaml("not json at all"));
+    }
+
+    /// write_modules_yaml refuses to clobber a foreign (pnpm) state file but
+    /// freely writes when absent or over its own stub.
+    #[test]
+    fn write_modules_yaml_preserves_foreign_state() {
+        let nm = std::env::temp_dir().join(format!("nub-vite-my-{}", std::process::id()));
+        std::fs::create_dir_all(&nm).unwrap();
+        let f = nm.join(".modules.yaml");
+        let store = Path::new("/store/virtual-store");
+
+        // absent → writes nub stub
+        write_modules_yaml(&nm, store);
+        assert!(is_nub_modules_yaml(&std::fs::read_to_string(&f).unwrap()));
+
+        // over its own stub → rewrites
+        write_modules_yaml(&nm, Path::new("/store2"));
+        assert!(std::fs::read_to_string(&f).unwrap().contains("/store2"));
+
+        // foreign pnpm file → left untouched
+        let pnpm = "hoistPattern:\n  - '*'\nvirtualStoreDir: node_modules/.pnpm\n";
+        std::fs::write(&f, pnpm).unwrap();
+        write_modules_yaml(&nm, store);
+        assert_eq!(std::fs::read_to_string(&f).unwrap(), pnpm);
+
+        let _ = std::fs::remove_dir_all(&nm);
+    }
+
+    /// CAS-safety regression guard: the ejected dist files are HARDLINKS to the
+    /// content-addressed store on Linux, so the patch write MUST NOT truncate the
+    /// shared inode in place. This proves the write severs the link — the sibling
+    /// hardlink keeps its original bytes. Fails loudly if `patch_one` ever reverts
+    /// to `fs::write` (which is invisible on macOS's copy-on-write link strategy).
+    #[test]
+    fn patch_write_does_not_mutate_a_hardlinked_sibling() {
+        let dir = std::env::temp_dir().join(format!("nub-vite-hl-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cas = dir.join("cas-blob.js"); // stands in for the shared store blob
+        let ejected = dir.join("ejected.js"); // the project-local hardlink to it
+        let original = "let allowDirs = server.fs.allow;\n";
+        std::fs::write(&cas, original).unwrap();
+        std::fs::hard_link(&cas, &ejected).unwrap();
+
+        write_breaking_hardlink(&ejected, b"PATCHED");
+
+        assert_eq!(std::fs::read_to_string(&ejected).unwrap(), "PATCHED");
+        assert_eq!(
+            std::fs::read_to_string(&cas).unwrap(),
+            original,
+            "the CAS-shared inode must be untouched — the write broke the hardlink"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/nub-cli/src/pm_engine/vite_compat.rs
+++ b/crates/nub-cli/src/pm_engine/vite_compat.rs
@@ -1,0 +1,354 @@
+//! Vite symlink-GVS serving compat (issue #315).
+//!
+//! Under nub's default global virtual store a package's realpath is the
+//! machine-global store (`~/.cache/nub/pm/virtual-store/…`), OUTSIDE the project
+//! root. Vite's dev server realpath-checks every `/@fs`-served module against
+//! `server.fs.allow` (default `[workspaceRoot]`), so a store-resident dep served
+//! raw (framework client entries, dev-toolbar modules, SSR/optimizeDeps-excluded
+//! deps) is rejected `403 … outside of Vite serving allow list`. pnpm never hits
+//! this — its virtual store is project-local (`node_modules/.pnpm`, under the
+//! workspace root). nub's external store needs Vite told about it.
+//!
+//! ONE mechanism, PM-agnostic, works-without-nub, zero lock-in — two units:
+//!
+//! - **Unit A (all Vite versions): write `node_modules/.modules.yaml`.** JSON
+//!   `{"virtualStoreDir":"<abs store>"}`. Vite ≥ 8.1 reads it natively
+//!   (`server/index.ts`, PR vitejs/vite#22415) and pushes the path onto
+//!   `fs.allow`. Additive (nub's own state lives in `.aube-state`), idempotent,
+//!   plain data — read regardless of whether nub is in the process.
+//!
+//! - **Unit B (Vite < 8.1): backport Vite's own 8.1 sniff.** The sniff predates
+//!   the majority of installed Vite, so for < 8.1 nub force-materializes just the
+//!   `vite` package project-local (the linker's `forceMaterializePackages` path —
+//!   the shared CAS store stays pristine, only the local ejected copy is touched)
+//!   and codegen-inserts the sniff at Vite's own `fs.allow`-default computation
+//!   site in the bundled (non-minified) dist. That site is upstream of
+//!   `createServer`, so it covers a bare `vite dev` CLI as well as
+//!   library-embedded Vite (Astro/SvelteKit/Nuxt). The inserted sniff is
+//!   YAML-tolerant (JSON first, block-YAML regex fallback) and reads whatever
+//!   `virtualStoreDir` any PM wrote — nub's store path lives ONLY in the
+//!   `.modules.yaml` data file, never hardcoded into the patch.
+//!
+//! Both units are gated on `vite` being in the installed graph and on the
+//! `NUB_VITE_COMPAT` opt-out (a falsey value disables both). The materialization
+//! decision lives in [`super::mod`]'s setting defaults; this module writes the
+//! file and patches the ejected copy post-install. Fail-open throughout: a
+//! missing anchor / unwritable copy is a no-op, never a corrupt Vite.
+
+use std::path::{Path, PathBuf};
+
+/// User-facing opt-out. Default-on (nub's goal is Vite just-working under the
+/// global store); a falsey value disables BOTH units. `NUB_*` is a sanctioned PM
+/// knob. Read at the setting-defaults site (materialize decision) and here (the
+/// post-install writer/patcher) so the two stay in lockstep.
+pub(crate) const VITE_COMPAT_ENV: &str = "NUB_VITE_COMPAT";
+
+/// Whether the Vite compat behavior is enabled. Disabled only by an explicit
+/// falsey `NUB_VITE_COMPAT` (`0`/`false`/`no`/`off`, case-insensitive); unset or
+/// any other value keeps it on. Same spelling as nub's other positive-default
+/// knobs (`NUB_SELF_SHIM`).
+pub(crate) fn enabled() -> bool {
+    match std::env::var(VITE_COMPAT_ENV) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        Err(_) => true,
+    }
+}
+
+/// Post-install entry: write `.modules.yaml` and, for Vite < 8.1, patch the
+/// ejected copy. `root` is the install/workspace root (where the hoisted/GVS
+/// `node_modules` lives). Best-effort — a successful install must never fail on
+/// a compat step, so every fallible step degrades to a no-op.
+pub(crate) fn apply(root: &Path) {
+    if !enabled() {
+        return;
+    }
+    let node_modules = root.join("node_modules");
+    let Some(version) = installed_vite_version(&node_modules) else {
+        return; // vite not in the graph — nothing to do
+    };
+    let Some(store) = global_virtual_store_dir() else {
+        return;
+    };
+    // Unit A — always when vite is present. `.modules.yaml` at the workspace
+    // root's node_modules; Vite ≥ 8.1 reads it natively, the < 8.1 backport
+    // reads it too. Canonicalize the store so the path Vite prefix-matches its
+    // realpath'd module ids against has symlinks in `~/.cache` already resolved.
+    let store = std::fs::canonicalize(&store).unwrap_or(store);
+    write_modules_yaml(&node_modules, &store);
+
+    // Unit B — only Vite < 8.1 needs the backport (≥ 8.1 has the native sniff).
+    if vite_lt_8_1(&version) {
+        patch_ejected_vite(&node_modules);
+    }
+}
+
+/// Read the installed Vite's version from `node_modules/vite/package.json`.
+/// `None` when vite is not installed or the manifest is unreadable/malformed.
+fn installed_vite_version(node_modules: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(node_modules.join("vite/package.json")).ok()?;
+    // Minimal extraction — avoid a serde_json dep here; the field is a plain
+    // quoted string in every published vite manifest.
+    let key = raw.find("\"version\"")?;
+    let after = &raw[key + "\"version\"".len()..];
+    let colon = after.find(':')?;
+    let rest = &after[colon + 1..];
+    let start = rest.find('"')? + 1;
+    let end = rest[start..].find('"')? + start;
+    Some(rest[start..end].to_string())
+}
+
+/// Whether a semver version string is below 8.1.0 (the floor at which Vite's
+/// native `.modules.yaml` sniff exists). Parses only major.minor; a malformed
+/// version conservatively returns `false` (assume modern → skip the patch, Unit
+/// A still covers it).
+fn vite_lt_8_1(version: &str) -> bool {
+    let core = version.split(['-', '+']).next().unwrap_or(version);
+    let mut it = core.split('.');
+    let (Some(major), minor) = (it.next(), it.next()) else {
+        return false;
+    };
+    let Ok(major) = major.parse::<u32>() else {
+        return false;
+    };
+    if major != 8 {
+        return major < 8;
+    }
+    minor.and_then(|m| m.parse::<u32>().ok()).unwrap_or(0) < 1
+}
+
+/// nub's global virtual-store directory (`<cache>/virtual-store`, where `<cache>`
+/// is embedder-namespaced to `~/.cache/nub/pm`). This is the realpath prefix of
+/// every store-resident served module, so it is the value Vite must allow. The
+/// embedder profile is registered by the time install runs, so
+/// `aube_store::dirs::cache_dir()` resolves the nub namespace.
+fn global_virtual_store_dir() -> Option<PathBuf> {
+    aube_store::dirs::cache_dir().map(|c| c.join(aube_store::VIRTUAL_STORE_SUBDIR))
+}
+
+/// Unit A. Write `<node_modules>/.modules.yaml` as JSON `{"virtualStoreDir":…}`.
+/// MUST be JSON-flow (Vite ≤ 8.1.x's native sniff parses with `JSON.parse`;
+/// block YAML would throw and skip the store). JSON-flow is also valid YAML, so
+/// it survives a future YAML-parser upstream fix and the backported regex
+/// fallback. Idempotent (unconditional rewrite). Best-effort.
+fn write_modules_yaml(node_modules: &Path, store: &Path) {
+    if !node_modules.is_dir() {
+        return;
+    }
+    // JSON string-escape the path (Windows backslashes, spaces). serde_json is a
+    // nub-cli dep already.
+    let value = serde_json::to_string(&store.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "\"\"".to_string());
+    let body = format!("{{\"virtualStoreDir\":{value}}}\n");
+    let _ = std::fs::write(node_modules.join(".modules.yaml"), body);
+}
+
+// ───────────────────────── Unit B: the < 8.1 dist backport ─────────────────
+
+/// The bindings Vite's own fs/path are hash-suffixed per build (`path$b`,
+/// `fs__default`), so the insert cannot reference them — it brings its own,
+/// prepended under mangled names that cannot collide.
+const PREPEND: &str = "import{readFileSync as __nubRfs}from\"node:fs\";\
+import{join as __nubJoin,isAbsolute as __nubIsAbs,resolve as __nubResolve}from\"node:path\";\n";
+
+/// The sniff, inserted immediately after the anchor (where `allowDirs` is a live
+/// array and `searchForWorkspaceRoot`/`root` are in scope). YAML-tolerant
+/// (JSON.parse → block-YAML regex fallback) and PM-agnostic: appends whatever
+/// `virtualStoreDir` any PM wrote. Strictly better than upstream 8.1's
+/// JSON-only sniff (which silently no-ops on real pnpm's block YAML).
+const INSERT: &str = ";try{const __wr=searchForWorkspaceRoot(root);\
+const __c=__nubRfs(__nubJoin(__wr,\"node_modules\",\".modules.yaml\"),\"utf-8\");\
+let __v;try{__v=JSON.parse(__c).virtualStoreDir;}\
+catch{const __m=__c.match(/^\\s*virtualStoreDir:\\s*(.+?)\\s*$/m);__v=__m&&__m[1].replace(/^['\"]|['\"]$/g,\"\");}\
+if(__v){if(__nubIsAbs(__v))allowDirs.push(__v);\
+else if(__v.startsWith(\"..\"))allowDirs.push(__nubResolve(__nubJoin(__wr,\"node_modules\"),__v));}}catch{}";
+
+/// The fs.allow-default computation anchors, in Vite's own bundled-but-not-
+/// minified source. `let allowDirs = server.fs.allow;` is identical across
+/// Vite 6 and 7; the `[searchForWorkspaceRoot(root)]` form is Vite 5's. The
+/// insert goes immediately AFTER the anchor. Vite ≥ 8.1 needs no patch (native
+/// sniff), so a new major only needs a one-line anchor check — if it ever stops
+/// matching, nothing is patched (fail-open; Unit A still covers ≥ 8.1).
+const ANCHORS: &[&str] = &[
+    "let allowDirs = server.fs.allow;",            // Vite 6 & 7
+    "allowDirs = [searchForWorkspaceRoot(root)];", // Vite 5
+];
+
+/// A marker unique to the insert; its presence means a file is already patched,
+/// making the whole pass idempotent across re-installs.
+const MARKER: &str = "__nubRfs(__nubJoin";
+
+/// Force-materialize + patch. Resolves the ejected local vite dir via the
+/// realpath of `node_modules/vite` (project-local after the linker's
+/// force-materialize), REFUSES to touch anything under the shared global store
+/// (CAS-safety invariant — if the eject did not happen, patching in place would
+/// corrupt the store shared across every project), then scans `dist/node/**.js`
+/// for the anchor and inserts the sniff. Fail-open at every step.
+fn patch_ejected_vite(node_modules: &Path) {
+    let vite_link = node_modules.join("vite");
+    let Ok(vite_dir) = std::fs::canonicalize(&vite_link) else {
+        return;
+    };
+    // CAS-safety: only patch a project-local ejected copy. If the realpath still
+    // points into the machine-global store (force-materialize did not run, e.g.
+    // a store this exact peer-hash is shared with another project), skip — never
+    // mutate the shared CAS-backed store.
+    if let Some(store) = global_virtual_store_dir() {
+        let store = std::fs::canonicalize(&store).unwrap_or(store);
+        if vite_dir.starts_with(&store) {
+            return;
+        }
+    }
+    let dist_node = vite_dir.join("dist").join("node");
+    if !dist_node.is_dir() {
+        return;
+    }
+    let mut files = Vec::new();
+    collect_js(&dist_node, &mut files);
+    for f in files {
+        patch_one(&f);
+    }
+}
+
+/// Recursively collect `.js` files under `dir` (Vite's dist chunk filenames are
+/// hash-suffixed, so the anchor is scanned for, not a filename hardcoded).
+/// Depth-capped defensively.
+fn collect_js(dir: &Path, out: &mut Vec<PathBuf>) {
+    collect_js_depth(dir, out, 0);
+}
+
+fn collect_js_depth(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+    if depth > 8 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        match entry.file_type() {
+            Ok(t) if t.is_dir() => collect_js_depth(&path, out, depth + 1),
+            Ok(t) if t.is_file() && path.extension().is_some_and(|e| e == "js") => {
+                out.push(path);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Patch one dist file if it carries an anchor and is not already patched.
+/// Prepends the import and inserts the sniff after the first matching anchor.
+/// The write is best-effort; a read/anchor miss is a no-op.
+fn patch_one(file: &Path) {
+    let Ok(src) = std::fs::read_to_string(file) else {
+        return;
+    };
+    if src.contains(MARKER) {
+        return; // already patched
+    }
+    let Some(anchor) = ANCHORS.iter().find(|a| src.contains(**a)) else {
+        return;
+    };
+    // Insert AFTER the first anchor occurrence, then prepend the import.
+    let patched = src.replacen(anchor, &format!("{anchor}{INSERT}"), 1);
+    let patched = format!("{PREPEND}{patched}");
+    let _ = std::fs::write(file, patched);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opt_out_only_on_explicit_falsey() {
+        // Default-on when unset; the test mutates process env, so it is the sole
+        // reader in-process (serialized by cargo per-test-binary is not enough —
+        // keep the assertions in one test to avoid cross-test env races).
+        let key = VITE_COMPAT_ENV;
+        // SAFETY: single-threaded test body; restored at the end.
+        unsafe { std::env::remove_var(key) };
+        assert!(enabled(), "unset ⇒ on");
+        for falsey in ["0", "false", "FALSE", "no", "Off", " off "] {
+            unsafe { std::env::set_var(key, falsey) };
+            assert!(!enabled(), "{falsey:?} ⇒ off");
+        }
+        for truthy in ["1", "true", "yes", "anything"] {
+            unsafe { std::env::set_var(key, truthy) };
+            assert!(enabled(), "{truthy:?} ⇒ on");
+        }
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn version_floor_is_8_1_0() {
+        for v in ["5.4.21", "6.4.3", "7.3.6", "8.0.9", "8.0.0", "0.4.0"] {
+            assert!(vite_lt_8_1(v), "{v} is < 8.1");
+        }
+        // 8.1.0-beta.0 is where the native sniff landed — its core is 8.1.0, so
+        // it (and any 8.1 prerelease) reads as >= 8.1 and needs no patch.
+        for v in ["8.1.0", "8.1.3", "8.2.0", "9.0.0", "10.1.1", "8.1.0-beta.0"] {
+            assert!(!vite_lt_8_1(v), "{v} is >= 8.1");
+        }
+        // Malformed ⇒ treat as modern (skip patch; Unit A still applies).
+        assert!(!vite_lt_8_1("not-a-version"));
+    }
+
+    #[test]
+    fn version_extraction_from_manifest() {
+        let dir = std::env::temp_dir().join(format!("nub-vite-ver-{}", std::process::id()));
+        let nm = dir.join("node_modules").join("vite");
+        std::fs::create_dir_all(&nm).unwrap();
+        std::fs::write(
+            nm.join("package.json"),
+            r#"{"name":"vite","version":"7.3.6","type":"module"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            installed_vite_version(&dir.join("node_modules")).as_deref(),
+            Some("7.3.6")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The codegen patch is anchor-driven, idempotent, and inserts after the
+    /// anchor with the import prepended. Exercised on a synthetic chunk carrying
+    /// the Vite-6/7 anchor.
+    #[test]
+    fn patch_is_anchored_and_idempotent() {
+        let dir = std::env::temp_dir().join(format!("nub-vite-patch-{}", std::process::id()));
+        let dn = dir.join("dist").join("node").join("chunks");
+        std::fs::create_dir_all(&dn).unwrap();
+        let chunk = dn.join("config.js");
+        std::fs::write(
+            &chunk,
+            "import x from 'y';\nlet allowDirs = server.fs.allow;\nif (x) {}\n",
+        )
+        .unwrap();
+
+        patch_one(&chunk);
+        let after = std::fs::read_to_string(&chunk).unwrap();
+        assert!(after.starts_with(PREPEND), "import prepended");
+        assert!(after.contains(MARKER), "sniff inserted");
+        assert!(
+            after.contains("let allowDirs = server.fs.allow;;try{"),
+            "insert lands immediately after the anchor"
+        );
+
+        patch_one(&chunk);
+        let twice = std::fs::read_to_string(&chunk).unwrap();
+        assert_eq!(after, twice, "second pass is a no-op (marker guard)");
+        assert_eq!(twice.matches(MARKER).count(), 1, "no double insert");
+
+        // A file with no anchor is untouched.
+        let plain = dn.join("plain.js");
+        std::fs::write(&plain, "export const a = 1;\n").unwrap();
+        patch_one(&plain);
+        assert_eq!(
+            std::fs::read_to_string(&plain).unwrap(),
+            "export const a = 1;\n"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -177,7 +177,7 @@ A project is Nub's own in three cases: it declares Nub through `nub pm use nub`,
 
 - **Lockfile:** `lock.yaml` — the pnpm v9 schema byte-for-byte, under Nub's own basename
 - **Package fields:** `workspaces`, `overrides`, `resolutions`, `patchedDependencies`, `allowBuilds`, `engines.node`, `scripts`
-- **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`
+- **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`, `NUB_VITE_COMPAT`
 - **Install state:** `node_modules/.nub/`, `.nub-state`, and the global store under Nub's own directories
 
 A fresh `nub install` records Nub as the manager with a non-locking range — `devEngines.packageManager` set to `{ name: "nub", version: "^<version>", onFail: "warn" }`, never an exact `packageManager` pin. Tools that read `devEngines` by name see the signal, and the caret is a floor, so upgrading Nub just works. To freeze the project at an exact Nub version — the corepack-visible hard pin — opt in with `nub pm use nub@<version>`; the bare `nub pm use nub` writes only the range.
@@ -481,6 +481,8 @@ A bundler that resolves modules by their real path — Metro (bare React Native)
 ```ini
 disableGlobalVirtualStoreForPackages[]=my-bundler
 ```
+
+Vite is the exception that keeps the shared store. Its dev server gates real-path file access through a configurable allow-list, not a resolver crawl, so a store-resident module served over `/@fs` would otherwise be rejected with `403 … outside of Vite serving allow list`. Nub tells Vite about the store automatically: it writes `node_modules/.modules.yaml`, which Vite 8.1+ reads natively, and for older Vite it backports the same check into the project's own copy. `vite dev` then serves the store with no `vite.config` change, and the fix lives on disk in `node_modules` — so it works whether or not Nub is in the process (a teammate on plain Vite, or CI). Turn it off with `NUB_VITE_COMPAT=0`.
 
 ### Offline installs
 

--- a/tests/vite-compat/README.md
+++ b/tests/vite-compat/README.md
@@ -1,0 +1,90 @@
+# Vite symlink-GVS compat matrix (#315)
+
+Validates that a Vite-powered project installed by nub — whose deps live in the
+machine-global virtual store (`~/.cache/nub/pm/virtual-store`, OUTSIDE the
+project root) — runs its dev server without the `403 … is outside of Vite
+serving allow list` error, and that the fix is **works-without-nub** (the project
+runs correctly when its dev server is invoked with no nub in the process).
+
+## The fix under test
+
+Two units, both in `crates/nub-cli/src/pm_engine/vite_compat.rs`, default-on
+(opt out with `NUB_VITE_COMPAT=0`), gated on `vite` being in the graph:
+
+- **Unit A — `node_modules/.modules.yaml`** (all Vite versions). nub writes JSON
+  `{"virtualStoreDir":"<abs store>"}`. Vite ≥ 8.1 reads it natively and allows
+  the store.
+- **Unit B — dist backport** (Vite < 8.1). nub force-materializes just the
+  `vite` package project-local (CAS store untouched) and codegen-inserts Vite's
+  own 8.1 `.modules.yaml` sniff at the `fs.allow`-default computation site
+  (`let allowDirs = server.fs.allow;` for v6/v7; `[searchForWorkspaceRoot(root)]`
+  for v5). The sniff is YAML-tolerant + PM-agnostic (reads whatever
+  `virtualStoreDir` any tool wrote — never hardcodes nub's path).
+
+Because the fix lives in `node_modules` on disk (`.modules.yaml` + the patched
+vite dist) and nothing is injected at runtime, it works regardless of whether
+nub is in the process.
+
+## The version tiers this matrix must cover
+
+Each framework pins its OWN Vite, so the matrix spans both code paths:
+
+- **native ≥ 8.1** — `.modules.yaml` only, no patch. (create-vite@latest today.)
+- **backport < 8.1** — the ejected-vite dist patch. (Frameworks that pin Vite
+  5/6/7: many VitePress/Storybook/older-framework releases.)
+
+`driver.sh` records the exact Vite version + which tier each case exercised, so
+the run PROVES both paths fire on real frameworks — not just on raw `vite`.
+
+## How to run
+
+```sh
+export NUB=~/.cache/nub/worktrees/vite-build-target/fast/nub   # or target/fast/nub
+# one framework, already scaffolded into <dir>, dev binds :5180
+tests/vite-compat/driver.sh <dir> "npx vite dev --port 5180 --host 127.0.0.1" "npx vite build" 5180
+```
+
+`scaffold.sh <case> <dir>` non-interactively scaffolds the common cases and
+prints the `DEV=`/`BUILD=` commands to feed `driver.sh` (substitute the port).
+Framework CLIs change their flags often; treat `scaffold.sh` as a starting point
+and adjust per release.
+
+`driver.sh` emits one `ROW|…` line per case:
+
+```
+ROW|<name>|vite=<ver>|<tier>|<eject>|modules.yaml=<present/absent>|patched=<n>|/@fs=<code>|log=<no-403/403-in-log>|build=<ok/FAIL>
+```
+
+Acceptance for a case: `/@fs=200`, `log=no-403`, `build=ok`, and — for `< 8.1` —
+`patched>=1`; for `>= 8.1`, `modules.yaml=present` with `patched=0`.
+
+## Frameworks in scope
+
+The `dev` server is run via each project's OWN bin/CLI (no nub) = works-without-nub.
+
+| Framework | Notes |
+|---|---|
+| Astro + `@astrojs/react` | The literal #315 case (also vue/svelte integrations). |
+| SvelteKit | `sv create` skeleton. |
+| create-vite | `react-ts`, `vue-ts`, `svelte-ts`, `solid`, `preact-ts`, `lit-ts`, `vanilla-ts`. Note which 403 vs which pre-bundle into `.vite/deps` and never 403 (a bare create-vite app pre-bundles its deps project-local, so it does not 403 unless a dep is served raw via `/@fs` — SSR externals, `optimizeDeps.exclude`, framework client entries). |
+| VitePress | Docs SSG; often pins Vite 5/6 ⇒ backport path. |
+| Storybook (Vite builder) | `@storybook/react-vite`; `storybook build`. |
+| SolidStart / Qwik / Remix · React-Router v7 / Analog (Angular+Vite) / Marko / Ionic | Extend `scaffold.sh`; each pins its own Vite. |
+
+## Fidelity
+
+`driver.sh` asserts at the HTTP layer: it fetches the REAL store-resident module
+the browser requests via `/@fs` and greps the dev-server log for the literal 403
+string. A **chrome-devtools MCP** browser pass (navigate the dev URL, confirm the
+island/route hydrates and is interactive, read the console for 403s) is a
+stronger check and SHOULD be run for the flagship Astro+React case when that MCP
+is available; the HTTP + log-scan floor here is the CI-portable substitute.
+
+## The Nuxt note
+
+`nuxt` is currently on nub's `disableGlobalVirtualStoreForPackages` trigger
+(installs all-disk, project-local), so it does NOT run symlink-GVS and this fix
+does not apply to it as shipped. Nuxt IS Vite-based, so it is a candidate to
+REMOVE from the trigger once this fix lets it work under symlink-GVS — see the
+thread's `impl.md` sidecar for the finding. Changing the trigger default is a
+maintainer decision, not part of this PR.

--- a/tests/vite-compat/driver.sh
+++ b/tests/vite-compat/driver.sh
@@ -43,11 +43,27 @@ cd "$proj" || { fail "no dir"; exit 2; }
 inst=$?
 [ $inst -eq 0 ] || { fail "nub install exit $inst"; tail -5 /tmp/vc-$name-install.log >&2; exit 2; }
 
-vite_pkg="node_modules/vite/package.json"
-[ -f "$vite_pkg" ] || { echo "SKIP[$name]: no vite in graph"; exit 0; }
-vite_ver=$(node -p "require('./$vite_pkg').version" 2>/dev/null)
-
-realpath_vite=$(node -e "console.log(require('fs').realpathSync('node_modules/vite'))")
+# Vite reaches the graph as a direct dep (top-level node_modules/vite) OR
+# transitively as a framework's embedded engine (only .nub/vite@* entries, no
+# top-level symlink). Detect + resolve the LOADED vite either way: prefer what
+# the framework/CLI actually imports (node resolution), else the first .nub entry.
+read -r vite_ver realpath_vite < <(node -e '
+const fs=require("fs"),p=require("path");
+function ver(d){try{return require(p.join(d,"package.json")).version}catch{return null}}
+let dir=null;
+try{ // what would `vite dev` / the framework load?
+  dir=p.dirname(fs.realpathSync(require.resolve("vite/package.json",{paths:[process.cwd()]})));
+}catch{}
+if(!dir){ // transitive-only: scan .nub/vite@*
+  const nb=p.join("node_modules",".nub");
+  for(const e of (fs.existsSync(nb)?fs.readdirSync(nb):[])){
+    if(e.startsWith("vite@")){const c=p.join(nb,e,"node_modules","vite");if(fs.existsSync(c)){dir=fs.realpathSync(c);break}}
+  }
+}
+if(!dir){console.log("- -");process.exit(0)}
+console.log((ver(dir)||"?")+" "+dir);
+')
+[ "$vite_ver" = "-" ] && { echo "SKIP[$name]: no vite in graph"; exit 0; }
 case "$realpath_vite" in
   "$proj"/*) eject="ejected-local" ;;
   *)         eject="in-store" ;;
@@ -57,9 +73,13 @@ esac
 modules_yaml="absent"; store=""
 if [ -f node_modules/.modules.yaml ]; then
   modules_yaml="present"
-  store=$(node -p "require('./node_modules/.modules.yaml').virtualStoreDir" 2>/dev/null)
+  # NOT require() — Node has no loader for a .yaml extension (falls to the .js
+  # handler and throws on the JSON body). Parse the bytes directly.
+  store=$(node -e "console.log(JSON.parse(require('fs').readFileSync('node_modules/.modules.yaml','utf8')).virtualStoreDir)" 2>/dev/null)
 fi
-patched=$(grep -rl '__nubRfs' node_modules/vite/dist/node/ 2>/dev/null | wc -l | tr -d ' ')
+# Patch count on the ACTUALLY-LOADED vite (realpath) — the ejected project-local
+# copy for a direct dep; the store copy (never patched) for library-embedded.
+patched=$(grep -rl '__nubRfs' "$realpath_vite/dist/node/" 2>/dev/null | wc -l | tr -d ' ')
 
 # Version tier: < 8.1 exercises the BACKPORT; >= 8.1 the NATIVE sniff.
 tier=$(node -e "const[a,b]=process.argv[1].split('.').map(Number);console.log(a>8||(a===8&&b>=1)?'native>=8.1':'backport<8.1')" "$vite_ver")

--- a/tests/vite-compat/driver.sh
+++ b/tests/vite-compat/driver.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# driver.sh — validate nub's Vite symlink-GVS compat (#315) against one already-
+# scaffolded, Vite-powered project. Given a project dir (containing package.json
+# with a `vite` dep, directly or via a framework), it:
+#
+#   1. `nub install`   — confirms the symlink-GVS layout (vite realpath ⇒ store,
+#                        or ejected project-local under compat) + records the
+#                        exact Vite version the framework pinned.
+#   2. checks Unit A   — node_modules/.modules.yaml written with the store path.
+#   3. checks Unit B   — for Vite < 8.1, the dist backport patch is present.
+#   4. dev serve       — starts the project's OWN dev server (bare, via the vite
+#                        bin / framework CLI = WORKS-WITHOUT-NUB, no nub in the
+#                        process) and fetches a store-resident module via `/@fs`;
+#                        expects 200 (was 403) AND scans the dev log for the
+#                        "outside of Vite serving allow list" 403 line.
+#   5. build           — runs the project's build; expects success.
+#
+# Usage: driver.sh <project-dir> <dev-cmd> <build-cmd> <base-port>
+#   <dev-cmd>/<build-cmd> run from inside <project-dir>; use "-" to skip build.
+#   The dev server is expected to bind 127.0.0.1:<base-port> (pass --port/--host
+#   through in <dev-cmd>).
+#
+# Env: NUB=<path to nub binary> (defaults to the fast dev build in the worktree).
+#
+# Fidelity note: this harness asserts at the HTTP layer — it fetches the REAL
+# store-resident module the browser would request via `/@fs` and greps the dev
+# server log for the actual 403 string. A chrome-devtools MCP browser pass
+# (navigate + confirm hydration/interactivity + read console) is a stronger
+# check when that MCP is available; the HTTP + log-scan pass is the CI-portable
+# floor and is what this script encodes.
+set -u
+
+NUB="${NUB:-$HOME/.cache/nub/worktrees/vite-build-target/fast/nub}"
+proj="$1"; dev_cmd="$2"; build_cmd="$3"; port="$4"
+name="$(basename "$proj")"
+
+fail() { echo "FAIL[$name]: $*" >&2; }
+
+cd "$proj" || { fail "no dir"; exit 2; }
+
+# ── 1. install ──────────────────────────────────────────────────────────────
+"$NUB" install >/tmp/vc-$name-install.log 2>&1
+inst=$?
+[ $inst -eq 0 ] || { fail "nub install exit $inst"; tail -5 /tmp/vc-$name-install.log >&2; exit 2; }
+
+vite_pkg="node_modules/vite/package.json"
+[ -f "$vite_pkg" ] || { echo "SKIP[$name]: no vite in graph"; exit 0; }
+vite_ver=$(node -p "require('./$vite_pkg').version" 2>/dev/null)
+
+realpath_vite=$(node -e "console.log(require('fs').realpathSync('node_modules/vite'))")
+case "$realpath_vite" in
+  "$proj"/*) eject="ejected-local" ;;
+  *)         eject="in-store" ;;
+esac
+
+# ── 2/3. Unit A + Unit B artifacts ──────────────────────────────────────────
+modules_yaml="absent"; store=""
+if [ -f node_modules/.modules.yaml ]; then
+  modules_yaml="present"
+  store=$(node -p "require('./node_modules/.modules.yaml').virtualStoreDir" 2>/dev/null)
+fi
+patched=$(grep -rl '__nubRfs' node_modules/vite/dist/node/ 2>/dev/null | wc -l | tr -d ' ')
+
+# Version tier: < 8.1 exercises the BACKPORT; >= 8.1 the NATIVE sniff.
+tier=$(node -e "const[a,b]=process.argv[1].split('.').map(Number);console.log(a>8||(a===8&&b>=1)?'native>=8.1':'backport<8.1')" "$vite_ver")
+
+# ── 4. dev serve + /@fs of a real store-resident module (WORKS-WITHOUT-NUB) ──
+served_code="n/a"; log_403="n/a"
+target=""
+if [ -n "$store" ]; then
+  target=$(node -e "const fs=require('fs'),p=require('path');const s=process.argv[1];let hit='';for(const d of (fs.existsSync(s)?fs.readdirSync(s):[])){const nm=p.join(s,d,'node_modules');if(fs.existsSync(nm)){for(const m of fs.readdirSync(nm)){const f=p.join(nm,m,'package.json');if(fs.existsSync(f)){hit=fs.realpathSync(f);break}}}if(hit)break}console.log(hit)" "$store")
+fi
+if [ -n "$dev_cmd" ] && [ "$dev_cmd" != "-" ]; then
+  ( cd "$proj" && eval "$dev_cmd" ) >/tmp/vc-$name-dev.log 2>&1 &
+  devpid=$!
+  up=""
+  for i in $(seq 1 40); do
+    sleep 0.5
+    curl -s -o /dev/null "http://127.0.0.1:$port/" 2>/dev/null && { up=1; break; }
+  done
+  if [ -n "$up" ] && [ -n "$target" ]; then
+    served_code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$port/@fs$target")
+  fi
+  # scan for the literal Vite 403 line
+  if grep -q "outside of Vite serving allow list\|is not allowed" /tmp/vc-$name-dev.log 2>/dev/null; then
+    log_403="403-in-log"
+  else
+    log_403="no-403"
+  fi
+  kill $devpid 2>/dev/null; wait $devpid 2>/dev/null
+  pkill -f "vite.*--port $port" 2>/dev/null
+fi
+
+# ── 5. build ────────────────────────────────────────────────────────────────
+build_res="skip"
+if [ -n "$build_cmd" ] && [ "$build_cmd" != "-" ]; then
+  ( cd "$proj" && eval "$build_cmd" ) >/tmp/vc-$name-build.log 2>&1
+  [ $? -eq 0 ] && build_res="ok" || build_res="FAIL"
+fi
+
+echo "ROW|$name|vite=$vite_ver|$tier|$eject|modules.yaml=$modules_yaml|patched=$patched|/@fs=$served_code|log=$log_403|build=$build_res"

--- a/tests/vite-compat/scaffold.sh
+++ b/tests/vite-compat/scaffold.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# scaffold.sh — non-interactively scaffold a real Vite-powered project for the
+# compat matrix. Each case pins its OWN Vite (recorded by driver.sh), so the set
+# naturally spans Vite 5/6/7/8.1 — exercising BOTH the native-sniff (>= 8.1) and
+# the dist-backport (< 8.1) paths on real framework code, not toy fixtures.
+#
+# Usage: scaffold.sh <case> <dest-dir>
+# Cases print, after scaffolding, two lines the runner consumes:
+#   DEV=<dev command incl. --port $PORT --host 127.0.0.1>
+#   BUILD=<build command, or - to skip>
+# The runner substitutes $PORT. Scaffolds DO NOT install deps (nub install does).
+set -u
+case_name="$1"; dest="$2"
+rm -rf "$dest"; mkdir -p "$(dirname "$dest")"
+
+# create-vite official templates — all ship create-vite@latest's Vite (8.1+ today
+# ⇒ native-sniff path). react-ts is the closest analogue to the #315 hydration
+# case among the pure templates.
+vite_template() {
+  npm create vite@latest "$dest" -- --template "$1" >/dev/null 2>&1
+  echo "DEV=npx vite dev --port \$PORT --host 127.0.0.1"
+  echo "BUILD=npx vite build"
+}
+
+case "$case_name" in
+  react-ts|vue-ts|svelte-ts|solid|preact-ts|lit-ts|vanilla-ts)
+    vite_template "$case_name" ;;
+
+  # Astro + @astrojs/react — the literal #315 repro (Adam's Astro app 403'd on
+  # @astrojs/react/dist/client.js served via /@fs). Scaffold minimal, add React.
+  astro-react)
+    npm create astro@latest "$dest" -- --template minimal --install false --git false --skip-houston --yes >/dev/null 2>&1
+    ( cd "$dest" && npm pkg set dependencies.@astrojs/react="^4" dependencies.react="^19" dependencies.react-dom="^19" >/dev/null 2>&1 )
+    cat > "$dest/astro.config.mjs" <<'CFG'
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+export default defineConfig({ integrations: [react()] });
+CFG
+    echo "DEV=npx astro dev --port \$PORT --host 127.0.0.1"
+    echo "BUILD=npx astro build" ;;
+
+  sveltekit)
+    npx --yes sv create "$dest" --template minimal --types ts --no-add-ons >/dev/null 2>&1 \
+      || npm create svelte@latest "$dest" -- --template skeleton --types typescript --no-eslint --no-prettier --no-playwright --no-vitest >/dev/null 2>&1
+    echo "DEV=npx vite dev --port \$PORT --host 127.0.0.1"
+    echo "BUILD=npx vite build" ;;
+
+  vitepress)
+    mkdir -p "$dest/docs"
+    ( cd "$dest" && npm pkg set devDependencies.vitepress="^1" >/dev/null 2>&1 || true )
+    printf '{"name":"vp","private":true,"devDependencies":{"vitepress":"^1"}}' > "$dest/package.json"
+    echo '# Hello' > "$dest/docs/index.md"
+    echo "DEV=npx vitepress dev docs --port \$PORT --host 127.0.0.1"
+    echo "BUILD=npx vitepress build docs" ;;
+
+  storybook-vite)
+    # React + Vite Storybook (uses @storybook/react-vite → Vite builder).
+    npm create vite@latest "$dest" -- --template react-ts >/dev/null 2>&1
+    ( cd "$dest" && npm pkg set devDependencies.storybook="^8" devDependencies.@storybook/react-vite="^8" >/dev/null 2>&1 )
+    echo "DEV=-"   # storybook dev is heavy; build is the meaningful check
+    echo "BUILD=npx storybook build 2>/dev/null || echo skip" ;;
+
+  *)
+    echo "UNKNOWN_CASE" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
Vite dev servers 403 store-resident modules under nub's machine-global virtual store (`~/.cache/nub/pm/virtual-store`, outside the project root): `403 … is outside of Vite serving allow list`. Vite realpath-checks every `/@fs`-served module against `server.fs.allow` (default `[workspaceRoot]`), and a store-resident dep served raw (framework client entries, dev-toolbar modules, SSR/`optimizeDeps`-excluded deps) falls outside it. pnpm never hits this — its virtual store is project-local, under the workspace root.

## The fix

One mechanism, PM-agnostic, works-without-nub, CAS-pristine — default-on, `NUB_VITE_COMPAT=0` opts out. Gated on Vite being in the graph.

- **Unit A — `node_modules/.modules.yaml`.** On install, whenever Vite is anywhere in the graph, write JSON `{"virtualStoreDir":"<abs store>"}` at the workspace root. Vite 8.1+ reads it natively (vitejs/vite#22415) and allows the store. Covers direct and library-embedded Vite.
- **Unit B — dist backport for Vite < 8.1.** For a directly-declared Vite, the linker force-materializes it project-local (the shared CAS store is untouched — only the ejected copy is modified), and nub codegen-inserts Vite's own 8.1 `.modules.yaml` sniff at its `fs.allow`-default site (`let allowDirs = server.fs.allow;` for v6/v7, `[searchForWorkspaceRoot(root)]` for v5). The inserted sniff is YAML-tolerant and PM-agnostic — it reads whatever `virtualStoreDir` any tool wrote; nub's store path lives only in the data file, never in the patch. Idempotent, fail-open (a missing anchor is a no-op, never a broken Vite).

The fix lives on disk in `node_modules` and injects nothing at runtime, so it **works whether or not nub is in the process** — a teammate on plain Vite, or CI, gets the same result.

## Library-embedded frameworks

A framework like Astro is store-resident and loads its Vite through a store-to-store sibling symlink — the shared store copy, not the project-local ejected copy — so the dist backport can't reach it CAS-safely. Unit A covers those for Vite ≥ 8.1 (the store Vite reads `.modules.yaml` natively), which is the reported #315 shape: Astro 7 + `@astrojs/react` pins Vite 8.1.3. A framework pinning Vite < 8.1 that does not set its own `fs.allow` (VitePress already does) is the remaining gap — it shrinks as the ecosystem moves to Vite 8.1+; closing it would mean patching the shared store copy, a separate call.

## Validation

Matrix harness under `tests/vite-compat/` (README + driver). Verified against real installs:

| case | Vite | result |
|---|---|---|
| Astro 7 + @astrojs/react (the #315 repro) | 8.1.3 | `@astrojs/react/dist/client.js` via `/@fs` 403→200, works-without-nub (`npx astro dev`) |
| create-vite ×7 (react/vue/svelte/solid/preact/lit/vanilla) | 8.1.3 | pass (native sniff) |
| SvelteKit, Storybook (Vite builder) | 8.1.3 | pass (native) |
| VitePress | 5.4.21 | pass (self-mitigates) |
| direct-dep `vite dev`, bare CLI, no nub | 5.4.21 / 6.4.3 / 7.3.6 | 403→200, backport applied |
| `NUB_VITE_COMPAT=0` | 7.3.6 | no `.modules.yaml`, no eject, byte-identical default |
| install ×2 | 7.3.6 | second is "Already up to date" — no re-link, patch not doubled |

Closes #315
