### PR TITLE
feat(pm): selective-subtree ancestor-closure force-materialization (behind NUB_DYNAMIC_PHANTOM_EJECT)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ dependencies = [
  "anyhow",
  "aube",
  "aube-codes",
+ "aube-linker",
  "aube-lockfile",
  "aube-manifest",
  "aube-registry",

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -31,6 +31,10 @@ nub-phantom-core = { path = "../nub-phantom-core" }
 # `nub ci` route through `aube::commands::install::run` in-process instead of
 # shelling out. See vendor/aube/AGENTS.md and src/pm_engine/.
 aube-lockfile = { path = "../../vendor/aube/crates/aube-lockfile" }
+# aube-linker: nub installs a force-materialize expansion hook (selective-subtree
+# materialization) via `aube_linker::set_force_materialize_expand_hook`; a pure
+# library crate (no CLI/tokio surface), same lean-graph rationale as aube-lockfile.
+aube-linker = { path = "../../vendor/aube/crates/aube-linker" }
 aube-manifest = { path = "../../vendor/aube/crates/aube-manifest" }
 # default-features = false drops aube's default set (`mimalloc`, `config-tui`),
 # neither of which nub uses: aube's `config-tui` (ratatui/crossterm) only feeds

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -59,6 +59,7 @@ pub mod install_family;
 pub mod log;
 pub mod min_release_age;
 pub mod output;
+pub mod phantom_closure;
 pub mod present;
 pub mod publish_family;
 mod resource_limits;
@@ -765,6 +766,12 @@ fn engine_session_inner(
     // (which calls it again as its first step, alongside the project-state-
     // dependent config surface) is a no-op for the registration.
     identity::register();
+    // Install nub's selective-subtree force-materialize expansion hook (behind
+    // the default-off `NUB_DYNAMIC_PHANTOM_EJECT` flag). No-op when the flag is
+    // off, so the default install path is byte-identical; when armed it expands
+    // the force-materialize seed to its ancestor-closure + phantom-target hoists
+    // at link time. Idempotent set-once, like `identity::register()`.
+    phantom_closure::register();
     // Initialize the diagnostics recorder from NUB_DIAG_* env vars so that
     // `NUB_DIAG_SUMMARY=1 nub install` surfaces the same per-phase/per-op
     // spans + summary table that `AUBE_DIAG_SUMMARY=1 aube install` does. The

--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -1,0 +1,288 @@
+//! Selective-subtree force-materialization policy — nub's force-materialize
+//! expansion hook (behind the default-off `NUB_DYNAMIC_PHANTOM_EJECT` flag).
+//!
+//! Force-materializing a package project-local is only SOUND for a
+//! transitively-consumed package if its whole ancestor-closure materializes with
+//! it — otherwise a store-resident importer keeps resolving the un-materialized
+//! shared-store copy, a silent singleton split (two realpaths, two module
+//! instances). This hook expands aube's flat force-materialize seed into a
+//! graph-aware plan against the resolved lockfile:
+//!
+//! - **Rung 1 — ancestor-closure.** Each seed grows to
+//!   [`LockfileGraph::importer_closure`] — the seed UNION every package that
+//!   transitively imports it. Bounded to the affected subtree by construction
+//!   (unrelated top-level subtrees are not importers), measured 0.3–2.1% of real
+//!   large trees. Also SUBSUMES the #315 library-embedded-vite<8.1 residual: an
+//!   embedded vite<8.1 (a framework's transitive engine, no direct-dep symlink)
+//!   is auto-detected and its `[framework…vite]` closure ejected, so #318's dist
+//!   sniff patch reaches a now-project-local vite.
+//! - **Rung 2 — hoist-within.** For a transitively-phantom importer whose
+//!   undeclared target the closure alone can't place (`@nuxt/devtools`→
+//!   `unstorage`, `vue-router`→`@vue/compiler-sfc`, `@firebase/database`→
+//!   `@firebase/app`), the already-resolved target is hoisted as an extra
+//!   sibling within the importer's own materialized `node_modules`.
+//!
+//! Flag OFF ⇒ no hook installed ⇒ aube's `expand_force_materialize` returns the
+//! seed verbatim ⇒ the force-materialize pass is byte-for-byte the shipped
+//! behavior. All policy lives here; aube owns only the neutral seam + the graph
+//! primitive.
+
+use std::collections::{BTreeMap, HashSet};
+
+use aube_linker::ForceMaterializePlan;
+use aube_lockfile::LockfileGraph;
+
+/// Whether selective-subtree force-materialization is armed. Truthy
+/// `NUB_DYNAMIC_PHANTOM_EJECT` (`1`/`true`/`yes`, or any non-falsey value) arms
+/// it; unset or a falsey value (`0`/`false`/`no`/`off`/empty) is off — the
+/// default. Same flag the (unmerged) dynamic per-version scanner will gate on, so
+/// the closure (transitive soundness) and the scanner (detection) share one arm.
+///
+/// LIMITATION (experimental-flag scope): the flag is NOT folded into the
+/// install-state fingerprint, which hashes only the raw `forceMaterializePackages`
+/// setting + the lockfile. So flipping this flag on an ALREADY-installed tree
+/// (unchanged lockfile) is a no-op — the link phase is skipped as "up to date". A
+/// clean install (or one whose lockfile changed) picks it up. Acceptable for a
+/// default-off experimental flag; folding the flag into the fingerprint is the
+/// productionization fix (an aube `state.rs` change, kept default-preserving).
+fn enabled() -> bool {
+    match std::env::var("NUB_DYNAMIC_PHANTOM_EJECT") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+        Err(_) => false,
+    }
+}
+
+/// Known transitive-phantom classes: an importer that statically imports an
+/// undeclared (or optional-peer-but-unlinked) target ALREADY present in the tree.
+/// Each entry both SEEDS its importer for force-materialization and drives the
+/// rung-2 hoist of the target within it.
+///
+/// PROVISIONAL: the dynamic per-version phantom scanner (the extract-time scan
+/// this same flag gates, unmerged on `scanner-build`) is the intended auto-source
+/// that supersedes this curated map — it scans each version's real code for
+/// undeclared imports, so it needs no hand-maintenance. This small map exists so
+/// the known acceptance classes (Nuxt, Firebase) work end-to-end today; it is the
+/// rung-2 analogue of the shipped static `NUB_FORCE_MATERIALIZE_PACKAGES` list.
+const KNOWN_PHANTOM_TARGETS: &[(&str, &[&str])] = &[
+    // Nuxt 4: vue-router statically imports @vue/compiler-sfc, declared only as
+    // an optional peer, so it is not auto-linked under the isolated GVS layout.
+    ("vue-router", &["@vue/compiler-sfc"]),
+    // Nuxt 4: @nuxt/devtools (stable 3.x) imports unstorage without declaring it
+    // (nitropack, a sibling, is the package that declares it).
+    ("@nuxt/devtools", &["unstorage"]),
+    // Firebase: @firebase/database imports the @firebase/app singleton it does
+    // not declare (its siblings @firebase/firestore / @firebase/auth DO declare
+    // it as a peer — a per-package omission, not a design choice).
+    ("@firebase/database", &["@firebase/app"]),
+];
+
+/// Register nub's force-materialize expansion hook with the embedded engine.
+/// No-op unless `NUB_DYNAMIC_PHANTOM_EJECT` is armed, so the default path installs
+/// nothing and `aube_linker::expand_force_materialize` stays the identity —
+/// byte-for-byte the shipped force-materialize behavior. Set-once (idempotent);
+/// safe to call once per engine-session build.
+pub(crate) fn register() {
+    if !enabled() {
+        return;
+    }
+    aube_linker::set_force_materialize_expand_hook(Box::new(expand));
+}
+
+/// The hook body: resolved graph + flat seed → graph-aware materialization plan.
+/// See the module docs for the two rungs.
+fn expand(graph: &LockfileGraph, seed_names: &[String]) -> ForceMaterializePlan {
+    // Seed set by NAME: the caller's force-materialize list ∪ the known
+    // phantom-importer names. Embedded vite<8.1 is seeded by dep_path below.
+    let mut seed_names_set: HashSet<&str> = seed_names.iter().map(String::as_str).collect();
+    for (importer, _) in KNOWN_PHANTOM_TARGETS {
+        seed_names_set.insert(importer);
+    }
+
+    // Seed DEP_PATHS: every graph package whose name is a seed, plus every
+    // embedded vite<8.1 copy (auto-detected — the #315 residual). Seeding by
+    // dep_path keeps the reverse walk anchored to the real copies present.
+    let mut seed_dep_paths: HashSet<&str> = HashSet::new();
+    for (dep_path, pkg) in &graph.packages {
+        if seed_names_set.contains(pkg.name.as_str())
+            || (pkg.name == "vite" && super::vite_compat::vite_lt_8_1(&pkg.version))
+        {
+            seed_dep_paths.insert(dep_path.as_str());
+        }
+    }
+
+    // Rung 1 — reverse-BFS ancestor-closure = the affected subtree.
+    let closure = graph.importer_closure(seed_dep_paths.iter().copied());
+
+    // Bounded-subtree guard: the closure must stay a small slice of the tree. A
+    // closure approaching the whole tree means a foundational seed — a bug, since
+    // phantom breakers are empirically never foundational. Surface it loudly;
+    // never silently degrade to whole-tree materialization (that is `disableGVS`,
+    // a separate last-resort lever). The `total >= 20` floor avoids a spurious
+    // warning on a tiny fixture where a legitimate 2-3 package closure is
+    // naturally a large fraction (e.g. a 3-package firebase repro).
+    let total = graph.packages.len().max(1);
+    if total >= 20 && closure.len() * 2 > total {
+        tracing::warn!(
+            "selective-subtree closure spans {}/{} packages ({:.0}%) — unexpectedly \
+             large; a seed may be foundational (should not happen for a phantom breaker)",
+            closure.len(),
+            total,
+            closure.len() as f64 / total as f64 * 100.0,
+        );
+    }
+
+    // Rung-1 names: every closure member's name ∪ the original seed names (the
+    // executor is name-keyed). Original seed names are kept even if absent from
+    // the graph — the executor simply never matches an absent name.
+    let mut names: HashSet<String> = seed_names.iter().cloned().collect();
+    for dep_path in &closure {
+        if let Some(pkg) = graph.packages.get(dep_path) {
+            names.insert(pkg.name.clone());
+        }
+    }
+
+    // Rung-2 hoist map: for each known phantom-importer whose dep_path landed in
+    // the closure, resolve its target(s) to a dep_path present in the graph and
+    // record importer_dep_path → [target_dep_paths].
+    let mut hoist_within: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for dep_path in &closure {
+        let Some(pkg) = graph.packages.get(dep_path) else {
+            continue;
+        };
+        let Some((_, targets)) = KNOWN_PHANTOM_TARGETS
+            .iter()
+            .find(|(name, _)| *name == pkg.name)
+        else {
+            continue;
+        };
+        let resolved: Vec<String> = targets
+            .iter()
+            .filter_map(|t| resolve_target_dep_path(graph, t))
+            .collect();
+        if !resolved.is_empty() {
+            hoist_within.insert(dep_path.clone(), resolved);
+        }
+    }
+
+    ForceMaterializePlan {
+        names: names.into_iter().collect(),
+        hoist_within,
+    }
+}
+
+/// Resolve a target package NAME to a dep_path present in the graph. `packages`
+/// is a `BTreeMap`, so `.find` yields the lexically-first matching dep_path —
+/// deterministic, and unambiguous for the single-version acceptance classes. The
+/// dynamic scanner supplies precise per-version targeting when it lands.
+fn resolve_target_dep_path(graph: &LockfileGraph, target_name: &str) -> Option<String> {
+    graph
+        .packages
+        .iter()
+        .find(|(_, pkg)| pkg.name == target_name)
+        .map(|(dep_path, _)| dep_path.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aube_lockfile::LockedPackage;
+
+    /// One test-graph edge: `(dep_path, name, [(child_name, child_tail)])`.
+    type Edge<'a> = (&'a str, &'a str, &'a [(&'a str, &'a str)]);
+
+    fn graph(edges: &[Edge]) -> LockfileGraph {
+        let mut g = LockfileGraph::default();
+        for (dep_path, name, deps) in edges {
+            let mut pkg = LockedPackage {
+                name: name.to_string(),
+                dep_path: dep_path.to_string(),
+                ..Default::default()
+            };
+            // A real graph carries `version`; several packages need it for the
+            // vite<8.1 seed test, so parse it off the dep_path tail.
+            if let Some((_, tail)) = split(dep_path) {
+                pkg.version = tail.split('(').next().unwrap_or(tail).to_string();
+            }
+            for (cn, ct) in *deps {
+                pkg.dependencies.insert(cn.to_string(), ct.to_string());
+            }
+            g.packages.insert(dep_path.to_string(), pkg);
+        }
+        g
+    }
+
+    fn split(dep_path: &str) -> Option<(&str, &str)> {
+        let core_end = dep_path.find('(').unwrap_or(dep_path.len());
+        let at = dep_path[..core_end].rfind('@')?;
+        if at == 0 {
+            return None;
+        }
+        Some((&dep_path[..at], &dep_path[at + 1..]))
+    }
+
+    #[test]
+    fn embedded_vite_lt_8_1_seeds_its_framework_closure() {
+        // astro → vite@6.4.3 (embedded, <8.1). The closure force-materializes
+        // BOTH so the ejected vite is project-local for the #318 patch.
+        let g = graph(&[
+            ("astro@5.0.0", "astro", &[("vite", "6.4.3")]),
+            ("vite@6.4.3", "vite", &[]),
+            // an unrelated modern vite direct dep must NOT drag anything in
+            ("lodash@4.17.21", "lodash", &[]),
+        ]);
+        let plan = expand(&g, &[]);
+        let names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
+        assert!(names.contains("vite"), "embedded vite<8.1 seeded");
+        assert!(names.contains("astro"), "framework in the closure");
+        assert!(!names.contains("lodash"), "unrelated dep stays symlinked");
+    }
+
+    #[test]
+    fn modern_vite_alone_is_not_seeded() {
+        let g = graph(&[
+            ("app@1.0.0", "app", &[("vite", "8.1.3")]),
+            ("vite@8.1.3", "vite", &[]),
+        ]);
+        let plan = expand(&g, &[]);
+        assert!(
+            plan.names.is_empty(),
+            "vite>=8.1 needs no eject (Unit A covers it)"
+        );
+    }
+
+    #[test]
+    fn firebase_class_seeds_closure_and_hoists_the_undeclared_target() {
+        // firebase → @firebase/database (imports the undeclared @firebase/app);
+        // firebase also declares @firebase/app directly (transitive, not root).
+        let g = graph(&[
+            (
+                "firebase@10.0.0",
+                "firebase",
+                &[("@firebase/database", "1.0.0"), ("@firebase/app", "0.15.0")],
+            ),
+            ("@firebase/database@1.0.0", "@firebase/database", &[]),
+            ("@firebase/app@0.15.0", "@firebase/app", &[]),
+        ]);
+        let plan = expand(&g, &[]);
+        let names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
+        assert!(names.contains("@firebase/database"), "seed materialized");
+        assert!(names.contains("firebase"), "importer in the closure");
+        // Rung 2: the undeclared @firebase/app hoisted within @firebase/database.
+        assert_eq!(
+            plan.hoist_within
+                .get("@firebase/database@1.0.0")
+                .map(Vec::as_slice),
+            Some(["@firebase/app@0.15.0".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn no_seeds_yields_empty_plan() {
+        let g = graph(&[("lodash@4.17.21", "lodash", &[])]);
+        let plan = expand(&g, &[]);
+        assert!(plan.names.is_empty() && plan.hoist_within.is_empty());
+    }
+}

--- a/crates/nub-cli/src/pm_engine/vite_compat.rs
+++ b/crates/nub-cli/src/pm_engine/vite_compat.rs
@@ -198,8 +198,10 @@ pub(crate) fn manifest_declares_vite(root: &Path) -> bool {
 /// Whether a semver version string is below 8.1.0 (the floor at which Vite's
 /// native `.modules.yaml` sniff exists). Parses only major.minor; a malformed
 /// version conservatively returns `false` (assume modern → skip the patch, Unit
-/// A still covers it).
-fn vite_lt_8_1(version: &str) -> bool {
+/// A still covers it). `pub(crate)` so the selective-subtree closure policy
+/// ([`super::phantom_closure`]) can auto-detect an embedded vite<8.1 seed with
+/// the identical version rule.
+pub(crate) fn vite_lt_8_1(version: &str) -> bool {
     let core = version.split(['-', '+']).next().unwrap_or(version);
     let mut it = core.split('.');
     let (Some(major), minor) = (it.next(), it.next()) else {

--- a/tests/vite-compat/README.md
+++ b/tests/vite-compat/README.md
@@ -21,6 +21,17 @@ Two units, both in `crates/nub-cli/src/pm_engine/vite_compat.rs`, default-on
   for v5). The sniff is YAML-tolerant + PM-agnostic (reads whatever
   `virtualStoreDir` any tool wrote — never hardcodes nub's path).
 
+Unit B as shipped force-materializes vite ONLY when it is a **direct** dep — a
+raw `vite dev` app. A framework that embeds vite **transitively** (Astro 5 pins
+`vite@^6`, `< 8.1`) loads its vite from a store-to-store sibling symlink, so the
+direct-dep eject never reaches it and the store `/@fs` stays 403 (the #315
+residual). Behind the default-off `NUB_DYNAMIC_PHANTOM_EJECT` flag, nub now
+auto-detects an embedded vite `< 8.1` and force-materializes its
+`[framework … vite]` **ancestor closure** (measured 5 packages for Astro 5,
+`~1.5%` of the tree — everything else stays symlinked), so the framework loads a
+project-local vite that Unit B patches. With the flag OFF the behavior is
+byte-for-byte the shipped Unit B.
+
 Because the fix lives in `node_modules` on disk (`.modules.yaml` + the patched
 vite dist) and nothing is injected at runtime, it works regardless of whether
 nub is in the process.
@@ -80,11 +91,36 @@ island/route hydrates and is interactive, read the console for 403s) is a
 stronger check and SHOULD be run for the flagship Astro+React case when that MCP
 is available; the HTTP + log-scan floor here is the CI-portable substitute.
 
-## The Nuxt note
+## The closure acceptance cases (behind `NUB_DYNAMIC_PHANTOM_EJECT=1`)
 
-`nuxt` is currently on nub's `disableGlobalVirtualStoreForPackages` trigger
-(installs all-disk, project-local), so it does NOT run symlink-GVS and this fix
-does not apply to it as shipped. Nuxt IS Vite-based, so it is a candidate to
-REMOVE from the trigger once this fix lets it work under symlink-GVS — see the
-thread's `impl.md` sidecar for the finding. Changing the trigger default is a
-maintainer decision, not part of this PR.
+The two cases the selective-subtree closure must satisfy. Run the driver with the
+flag armed:
+
+```sh
+NUB_DYNAMIC_PHANTOM_EJECT=1 tests/vite-compat/driver.sh <dir> "<dev-cmd>" "<build-cmd>" <port>
+```
+
+- **Astro 5 (rung 1 — the vite closure).** `astro@^5` pins `vite@6.4.3` (`< 8.1`),
+  loaded library-embedded. The flag force-materializes the `[astro, vite, …]`
+  closure → the ejected vite gets Unit B's sniff → a bare `astro dev` (no nub in
+  the process) serves a store-resident `/@fs` module `200` (was `403`).
+  Acceptance: `/@fs=200`, `log=no-403`, `patched>=1`, and only the framework
+  closure ejected (the rest of the tree stays symlinked).
+- **Nuxt 4 (both rungs).** `nuxt@^4` embeds `vite@7.3.6` (`< 8.1`) AND breaks on
+  transitive undeclared imports the closure alone can't place. The flag
+  force-materializes the `[nuxt, @nuxt/vite-builder, vite, vue-router,
+  @nuxt/devtools]` closure (rung 1) and hoists the two already-resolved phantom
+  targets within their importers — `@vue/compiler-sfc` into `vue-router`,
+  `unstorage` into `@nuxt/devtools` (rung 2). Acceptance: `nuxt prepare` →
+  "Types generated", `nuxt dev` page `200` with SSR-rendered markup, store
+  `/@fs=200`, `0` errors, bare `nuxt dev` (no nub in the process). The closure is
+  bounded to the Nuxt subtree (`~2.1%` of a realistic 1200-package project), so a
+  large app's unrelated deps keep symlink speed.
+
+## The Nuxt trigger note
+
+`nuxt` is on nub's `disableGlobalVirtualStoreForPackages` trigger (installs
+all-disk, project-local), so as shipped it does NOT run symlink-GVS. The closure
+above lets Nuxt work UNDER symlink-GVS (both its vite gap and its phantom class),
+which makes removing it from the trigger a candidate — but the flag is default-off
+and changing the trigger default is a maintainer decision, not part of this PR.

--- a/tests/vite-compat/driver.sh
+++ b/tests/vite-compat/driver.sh
@@ -36,6 +36,17 @@ name="$(basename "$proj")"
 
 fail() { echo "FAIL[$name]: $*" >&2; }
 
+# Kill a process AND all its descendants. A bare `kill $pid` / the old
+# `pkill -f "vite.*--port"` misses the child processes an `astro dev` / `nuxt dev`
+# / `vite` parent spawns, so a server LEAKS onto the port; the next run then binds
+# a DIFFERENT port while the harness curls the stale (unpatched) server → false
+# 403s. Recursing children-first (pgrep -P) tears the whole tree down.
+kill_tree() {
+  local p="$1" c
+  for c in $(pgrep -P "$p" 2>/dev/null); do kill_tree "$c"; done
+  kill -TERM "$p" 2>/dev/null
+}
+
 cd "$proj" || { fail "no dir"; exit 2; }
 
 # ── 1. install ──────────────────────────────────────────────────────────────
@@ -91,24 +102,33 @@ if [ -n "$store" ]; then
   target=$(node -e "const fs=require('fs'),p=require('path');const s=process.argv[1];let hit='';for(const d of (fs.existsSync(s)?fs.readdirSync(s):[])){const nm=p.join(s,d,'node_modules');if(fs.existsSync(nm)){for(const m of fs.readdirSync(nm)){const f=p.join(nm,m,'package.json');if(fs.existsSync(f)){hit=fs.realpathSync(f);break}}}if(hit)break}console.log(hit)" "$store")
 fi
 if [ -n "$dev_cmd" ] && [ "$dev_cmd" != "-" ]; then
-  ( cd "$proj" && eval "$dev_cmd" ) >/tmp/vc-$name-dev.log 2>&1 &
+  devlog=/tmp/vc-$name-dev.log
+  : >"$devlog"
+  # `exec` so devpid IS the dev process (astro/nuxt/vite), not a wrapper subshell,
+  # making kill_tree reach the real tree.
+  ( cd "$proj" && exec $dev_cmd ) >"$devlog" 2>&1 &
   devpid=$!
-  up=""
-  for i in $(seq 1 40); do
+  # Parse the ACTUAL bound port from the dev log — a framework re-picks a free
+  # port if the requested one is taken (e.g. after a prior leak), so curling the
+  # requested port would hit the wrong/stale server. Fall back to the requested.
+  bound="$port"; up=""
+  for i in $(seq 1 60); do
     sleep 0.5
-    curl -s -o /dev/null "http://127.0.0.1:$port/" 2>/dev/null && { up=1; break; }
+    pp=$(grep -oE 'https?://(localhost|127\.0\.0\.1|\[::1\]):[0-9]+' "$devlog" 2>/dev/null \
+           | grep -oE '[0-9]+$' | head -1)
+    [ -n "$pp" ] && bound="$pp"
+    curl -s -o /dev/null "http://127.0.0.1:$bound/" 2>/dev/null && { up=1; break; }
   done
   if [ -n "$up" ] && [ -n "$target" ]; then
-    served_code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$port/@fs$target")
+    served_code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$bound/@fs$target")
   fi
   # scan for the literal Vite 403 line
-  if grep -q "outside of Vite serving allow list\|is not allowed" /tmp/vc-$name-dev.log 2>/dev/null; then
+  if grep -q "outside of Vite serving allow list\|is not allowed" "$devlog" 2>/dev/null; then
     log_403="403-in-log"
   else
     log_403="no-403"
   fi
-  kill $devpid 2>/dev/null; wait $devpid 2>/dev/null
-  pkill -f "vite.*--port $port" 2>/dev/null
+  kill_tree "$devpid"; sleep 0.3; kill -KILL "$devpid" 2>/dev/null; wait "$devpid" 2>/dev/null
 fi
 
 # ── 5. build ────────────────────────────────────────────────────────────────

--- a/vendor/aube/crates/aube-linker/src/builder.rs
+++ b/vendor/aube/crates/aube-linker/src/builder.rs
@@ -44,6 +44,7 @@ impl Linker {
             no_integrity_read_keys: std::collections::BTreeMap::new(),
             link_progress: None,
             force_materialize: std::collections::HashSet::new(),
+            phantom_hoist: std::collections::BTreeMap::new(),
         }
     }
 
@@ -60,6 +61,29 @@ impl Linker {
     /// the global-virtual-store link pass; always false when the list is empty.
     pub(crate) fn force_materialize_matches(&self, pkg_name: &str) -> bool {
         !self.force_materialize.is_empty() && self.force_materialize.contains(pkg_name)
+    }
+
+    /// Rung 2 of selective-subtree materialization: the undeclared phantom
+    /// targets to hoist-within each force-materialized package's `node_modules`,
+    /// keyed by importer dep_path → already-resolved target dep_paths (see the
+    /// `phantom_hoist` field docs on [`Linker`]). Standalone aube and every test
+    /// omit this → the map is empty and the materialize pass is unchanged.
+    pub fn with_phantom_hoist(
+        mut self,
+        map: std::collections::BTreeMap<String, Vec<String>>,
+    ) -> Self {
+        self.phantom_hoist = map;
+        self
+    }
+
+    /// The phantom-hoist targets for the package at `dep_path`, if any. Consulted
+    /// only in the force-materialize branch of the GVS link pass; `None` when the
+    /// map is empty (the standalone/default path) or the dep_path has no entry.
+    pub(crate) fn phantom_hoist_for(&self, dep_path: &str) -> Option<&[String]> {
+        if self.phantom_hoist.is_empty() {
+            return None;
+        }
+        self.phantom_hoist.get(dep_path).map(Vec::as_slice)
     }
 
     /// Supply a shared counter the materialize pass bumps once per linked

--- a/vendor/aube/crates/aube-linker/src/force_materialize.rs
+++ b/vendor/aube/crates/aube-linker/src/force_materialize.rs
@@ -1,0 +1,67 @@
+//! Force-materialize plan expansion — the embedder-pluggable seam that turns a
+//! flat seed list into a graph-aware selective-subtree materialization plan.
+//!
+//! Standalone aube installs NO hook, so [`expand_force_materialize`] returns the
+//! seed verbatim (rung-1 names = the seed, no rung-2 hoist) and the linker's
+//! force-materialize pass is byte-for-byte unchanged. An embedder (nub) installs
+//! a hook via [`set_force_materialize_expand_hook`] that consults the resolved
+//! graph to (1) expand each seed to its ancestor-closure — every package that
+//! transitively imports it — so a transitively-consumed package materializes
+//! together with its importers (else a store-resident importer resolves the
+//! un-materialized copy, a silent singleton split), and (2) compute per-package
+//! phantom-target hoists for undeclared imports the closure alone can't place.
+//!
+//! The hook receives only `&LockfileGraph` + the seed names and returns a pure
+//! [`ForceMaterializePlan`], so all embedder-specific policy (which packages
+//! seed, the flag gate, vite<8.1 detection) lives in the embedder; aube owns
+//! only the neutral seam and the graph primitive ([`LockfileGraph::importer_closure`]).
+
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+use aube_lockfile::LockfileGraph;
+
+/// The materialization plan an [`FmExpandHook`] produces from the resolved graph.
+#[derive(Debug, Default, Clone)]
+pub struct ForceMaterializePlan {
+    /// Rung 1 — the expanded set of package NAMES to force-materialize
+    /// project-local (the seed UNION its ancestor-closure). Fed to
+    /// [`Linker::with_force_materialize`](crate::Linker::with_force_materialize),
+    /// matched by exact name, exactly as the raw seed was.
+    pub names: Vec<String>,
+    /// Rung 2 — undeclared phantom targets to hoist-within a force-materialized
+    /// package's own `node_modules`, keyed by the importer's dep_path → the
+    /// already-resolved target dep_paths. Empty unless a hook populates it.
+    pub hoist_within: BTreeMap<String, Vec<String>>,
+}
+
+/// A hook that expands a force-materialize seed into a graph-aware plan. `Send +
+/// Sync` because it is stored in a process-global consulted from the install
+/// pipeline; `'static` because it outlives any single install.
+pub type FmExpandHook =
+    Box<dyn Fn(&LockfileGraph, &[String]) -> ForceMaterializePlan + Send + Sync + 'static>;
+
+static FM_EXPAND_HOOK: OnceLock<FmExpandHook> = OnceLock::new();
+
+/// Install the embedder's force-materialize expansion hook. Set-once: a second
+/// call is ignored (the first registration wins), matching aube's other
+/// process-global embedder seams. Called once at engine-session build; standalone
+/// aube never calls it, so the default path stays hook-free.
+pub fn set_force_materialize_expand_hook(hook: FmExpandHook) {
+    let _ = FM_EXPAND_HOOK.set(hook);
+}
+
+/// Expand a force-materialize `seed` (the resolved `forceMaterializePackages`
+/// names) into a plan against `graph`. With no hook installed — standalone aube,
+/// every test — returns the seed verbatim as rung-1 names with an empty rung-2
+/// map, so the caller's `with_force_materialize(&plan.names)` is identical to the
+/// pre-existing `with_force_materialize(&seed)` and nothing else changes.
+pub fn expand_force_materialize(graph: &LockfileGraph, seed: &[String]) -> ForceMaterializePlan {
+    match FM_EXPAND_HOOK.get() {
+        Some(hook) => hook(graph, seed),
+        None => ForceMaterializePlan {
+            names: seed.to_vec(),
+            hoist_within: BTreeMap::new(),
+        },
+    }
+}

--- a/vendor/aube/crates/aube-linker/src/lib.rs
+++ b/vendor/aube/crates/aube-linker/src/lib.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 mod builder;
 mod clonedir;
 mod error;
+mod force_materialize;
 mod hoisted;
 mod link;
 mod materialize;
@@ -26,6 +27,9 @@ mod public_hoist_tests;
 mod tests;
 
 pub use error::Error;
+pub use force_materialize::{
+    ForceMaterializePlan, expand_force_materialize, set_force_materialize_expand_hook,
+};
 pub use hoisted::HoistedPlacements;
 pub use link::build_nested_link_targets;
 pub(crate) use materialize::{
@@ -262,6 +266,19 @@ pub struct Linker {
     /// callers and every existing test → the GVS pass is byte-for-byte
     /// unchanged.
     force_materialize: std::collections::HashSet<String>,
+    /// Rung 2 of selective-subtree materialization: undeclared phantom targets
+    /// to HOIST-WITHIN a force-materialized package's own `node_modules`, keyed
+    /// by the importer's dep_path → the target dep_paths. A transitively-phantom
+    /// package (`@nuxt/devtools` → the undeclared `unstorage`, `vue-router` →
+    /// the optional-peer-but-unlinked `@vue/compiler-sfc`) doesn't declare the
+    /// import, so once it's force-materialized its own `node_modules` has no
+    /// sibling for it and Node's walk still 404s. Injecting the target as an
+    /// extra sibling (reusing the materialize sibling-wiring, so the target
+    /// resolves through its existing `.aube/<entry>`) makes the walk succeed.
+    /// The target must already be resolved in the graph (this is reachability,
+    /// not install). Empty for standalone callers and every existing test → the
+    /// materialize pass is byte-for-byte unchanged.
+    phantom_hoist: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 /// Strategy for linking files from the store to node_modules.

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -16,6 +16,21 @@ use aube_store::PackageIndex;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+/// Split a resolved dep_path into `(name, dep_path_tail)` — the inverse of the
+/// `format!("{name}@{tail}")` reconstruction used across the graph walk. The
+/// version `@` is the last `@` BEFORE any peer suffix `(...)`, since a peer
+/// suffix can itself contain `@` (`@vue/compiler-sfc@1.2.3(vue@3.4.0)` →
+/// `("@vue/compiler-sfc", "1.2.3(vue@3.4.0)")`). Returns `None` when there is no
+/// version boundary (a bare scope or malformed key), which the caller skips.
+fn split_dep_path_name_tail(dep_path: &str) -> Option<(&str, &str)> {
+    let core_end = dep_path.find('(').unwrap_or(dep_path.len());
+    let at = dep_path[..core_end].rfind('@')?;
+    if at == 0 {
+        return None;
+    }
+    Some((&dep_path[..at], dep_path.get(at + 1..)?))
+}
+
 impl Linker {
     fn without_global_virtual_store(&self) -> Self {
         Self {
@@ -43,6 +58,7 @@ impl Linker {
             no_integrity_read_keys: self.no_integrity_read_keys.clone(),
             link_progress: self.link_progress.clone(),
             force_materialize: self.force_materialize.clone(),
+            phantom_hoist: self.phantom_hoist.clone(),
         }
     }
 
@@ -413,11 +429,40 @@ impl Linker {
                                     let _ = std::fs::remove_dir(&local_aube_entry)
                                         .or_else(|_| std::fs::remove_file(&local_aube_entry));
                                 }
+                                // Rung 2 (selective-subtree): if this package has
+                                // undeclared phantom targets to hoist-within,
+                                // materialize the PROJECT-LOCAL copy with those
+                                // targets added as extra dependency edges.
+                                // `materialize_into`'s sibling-wiring then creates
+                                // `<P>/node_modules/<T>` → the target's existing
+                                // `.aube/<entry>`, so P's undeclared import
+                                // resolves. Applied ONLY here (the project-local
+                                // copy) — the shared-store copy written above keeps
+                                // the original edges, since the hoist is
+                                // project-specific and the store is cross-project.
+                                let hoisted_pkg;
+                                let pkg_for_local = match self.phantom_hoist_for(dep_path) {
+                                    Some(targets) if !targets.is_empty() => {
+                                        let mut p = pkg.clone();
+                                        for target in targets {
+                                            if let Some((name, tail)) =
+                                                split_dep_path_name_tail(target)
+                                            {
+                                                p.dependencies
+                                                    .entry(name.to_string())
+                                                    .or_insert_with(|| tail.to_string());
+                                            }
+                                        }
+                                        hoisted_pkg = p;
+                                        &hoisted_pkg
+                                    }
+                                    _ => pkg,
+                                };
                                 self.materialize_into(
                                     &aube_dir,
                                     &aube_dir,
                                     dep_path,
-                                    pkg,
+                                    pkg_for_local,
                                     index,
                                     &mut local_stats,
                                     false,

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -731,6 +731,79 @@ impl LockfileGraph {
         reachable
     }
 
+    /// Reverse ("ancestor") closure: the seed dep_paths UNION every package
+    /// that transitively IMPORTS a seed. The mirror image of
+    /// [`transitive_closure`], which walks child edges (what a package depends
+    /// on); this walks importer edges (what depends on a package).
+    ///
+    /// Bounded to the affected subtree BY CONSTRUCTION: a package that does not
+    /// transitively import a seed is never reached, so unrelated top-level
+    /// subtrees are excluded no matter how large the tree — a project with one
+    /// phantom-breaker plus 10k unrelated deps yields a closure of just the
+    /// breaker's importer subtree. The only way this approaches the whole tree
+    /// is a *foundational* seed (everything imports it); phantom breakers are
+    /// empirically never foundational, so a large closure is a signal, not a norm.
+    ///
+    /// Why the closure and not the package alone: force-materializing only a
+    /// transitively-consumed package leaves every store-resident importer
+    /// resolving the un-materialized shared-store copy — a silent singleton
+    /// split (two realpaths, two module instances). Materializing the whole
+    /// importer closure makes every consumer load the one project-local copy.
+    ///
+    /// The project root is the natural top boundary: root importers are the
+    /// project itself, not a materializable package, so the walk stops at the
+    /// `packages` it can reach. Missing seeds are treated as leaves (skipped),
+    /// matching `transitive_closure`.
+    ///
+    /// Registry-only edge caveat (same as `transitive_closure`): the child key is
+    /// rebuilt as the plain `{name}@{tail}`, NOT the `name@git+<hash>` /
+    /// `name@url+<hash>` form a git/tarball dep carries, so an importer reached
+    /// ONLY through a git/tarball intermediary is not walked. This does not weaken
+    /// the force-materialize soundness in practice: force-materialize is
+    /// registry-only, so such an intermediary could not materialize anyway — the
+    /// split it would cause is a boundary of registry-only materialization, not a
+    /// missed closure member.
+    pub fn importer_closure<'a>(
+        &self,
+        seeds: impl IntoIterator<Item = &'a str>,
+    ) -> std::collections::HashSet<String> {
+        use std::collections::{HashMap, HashSet, VecDeque};
+
+        // Invert every forward edge once into child_dep_path → [importer
+        // dep_paths]. Keyed by the reconstructed child key (`{name}@{tail}`,
+        // identical to `transitive_closure`'s reconstruction) so it lines up
+        // with `packages` keys and the seed dep_paths. Importer values borrow
+        // the `packages` keys (live for `&self`), so only the child keys allocate.
+        let mut importers_of: HashMap<String, Vec<&str>> = HashMap::new();
+        for (parent_dep_path, pkg) in &self.packages {
+            for (child_name, child_tail) in &pkg.dependencies {
+                importers_of
+                    .entry(format!("{child_name}@{child_tail}"))
+                    .or_default()
+                    .push(parent_dep_path.as_str());
+            }
+        }
+
+        let mut closure: HashSet<String> = HashSet::new();
+        let mut queue: VecDeque<String> = VecDeque::new();
+        for seed in seeds {
+            if closure.insert(seed.to_string()) {
+                queue.push_back(seed.to_string());
+            }
+        }
+        while let Some(dep_path) = queue.pop_front() {
+            let Some(importers) = importers_of.get(&dep_path) else {
+                continue;
+            };
+            for importer in importers {
+                if closure.insert((*importer).to_string()) {
+                    queue.push_back((*importer).to_string());
+                }
+            }
+        }
+        closure
+    }
+
     /// Clone only the `packages` entries whose keys are in `reachable`.
     /// Paired with `transitive_closure` to produce the pruned
     /// `LockfileGraph.packages` for `filter_deps` / `subset_to_importer`.
@@ -965,5 +1038,145 @@ impl LockfileGraph {
         if self.workspace_extra_fields.is_empty() {
             self.workspace_extra_fields = prior.workspace_extra_fields.clone();
         }
+    }
+}
+
+#[cfg(test)]
+mod importer_closure_tests {
+    use super::*;
+
+    /// Build a graph from `(dep_path, [(child_name, child_tail)])` edges. The
+    /// package name is parsed off the dep_path (the part before the last `@`,
+    /// handling `@scope/name`), matching how real dep_paths encode identity.
+    fn graph(edges: &[(&str, &[(&str, &str)])]) -> LockfileGraph {
+        let mut g = LockfileGraph::default();
+        for (dep_path, deps) in edges {
+            let name = dep_path_name(dep_path);
+            let mut pkg = LockedPackage {
+                name: name.to_string(),
+                dep_path: dep_path.to_string(),
+                ..Default::default()
+            };
+            for (child_name, child_tail) in *deps {
+                pkg.dependencies
+                    .insert(child_name.to_string(), child_tail.to_string());
+            }
+            g.packages.insert(dep_path.to_string(), pkg);
+        }
+        g
+    }
+
+    /// Package name from a dep_path: everything before the version's `@`
+    /// (the LAST `@` for a scoped `@scope/name@1.0.0`).
+    fn dep_path_name(dep_path: &str) -> &str {
+        let core = dep_path.split(['(']).next().unwrap_or(dep_path);
+        match core.rfind('@') {
+            Some(0) | None => core,
+            Some(i) => &core[..i],
+        }
+    }
+
+    fn closure_of(g: &LockfileGraph, seeds: &[&str]) -> std::collections::BTreeSet<String> {
+        g.importer_closure(seeds.iter().copied())
+            .into_iter()
+            .collect()
+    }
+
+    #[test]
+    fn linear_chain_walks_up_to_every_ancestor() {
+        // a → b → c ; seed c ⇒ {a, b, c}. The root importer (project) is not a
+        // package, so the walk stops at `a`.
+        let g = graph(&[
+            ("a@1.0.0", &[("b", "1.0.0")]),
+            ("b@1.0.0", &[("c", "1.0.0")]),
+            ("c@1.0.0", &[]),
+        ]);
+        assert_eq!(
+            closure_of(&g, &["c@1.0.0"]),
+            ["a@1.0.0", "b@1.0.0", "c@1.0.0"].map(String::from).into()
+        );
+    }
+
+    #[test]
+    fn diamond_collects_all_importer_paths() {
+        // a → b, a → c, b → d, c → d ; seed d ⇒ {a, b, c, d} (both paths).
+        let g = graph(&[
+            ("a@1.0.0", &[("b", "1.0.0"), ("c", "1.0.0")]),
+            ("b@1.0.0", &[("d", "1.0.0")]),
+            ("c@1.0.0", &[("d", "1.0.0")]),
+            ("d@1.0.0", &[]),
+        ]);
+        assert_eq!(
+            closure_of(&g, &["d@1.0.0"]),
+            ["a@1.0.0", "b@1.0.0", "c@1.0.0", "d@1.0.0"]
+                .map(String::from)
+                .into()
+        );
+    }
+
+    #[test]
+    fn unrelated_subtree_is_excluded_the_bounded_invariant() {
+        // The load-bearing property: a seed's closure is its importer subtree
+        // ONLY. An unrelated tree (q → r) sharing no path to the seed stays out,
+        // no matter how large — so a big project's unrelated deps keep symlink
+        // speed.
+        let g = graph(&[
+            ("root-a@1.0.0", &[("x", "1.0.0")]),
+            ("x@1.0.0", &[]),               // the phantom breaker (seed)
+            ("q@1.0.0", &[("r", "1.0.0")]), // unrelated top-level subtree
+            ("r@1.0.0", &[]),
+        ]);
+        let closure = closure_of(&g, &["x@1.0.0"]);
+        assert_eq!(
+            closure,
+            ["root-a@1.0.0", "x@1.0.0"].map(String::from).into()
+        );
+        assert!(!closure.contains("q@1.0.0"));
+        assert!(!closure.contains("r@1.0.0"));
+    }
+
+    #[test]
+    fn cycles_terminate() {
+        // a ↔ b mutual dep; seed b ⇒ {a, b}, no infinite loop.
+        let g = graph(&[
+            ("a@1.0.0", &[("b", "1.0.0")]),
+            ("b@1.0.0", &[("a", "1.0.0")]),
+        ]);
+        assert_eq!(
+            closure_of(&g, &["b@1.0.0"]),
+            ["a@1.0.0", "b@1.0.0"].map(String::from).into()
+        );
+    }
+
+    #[test]
+    fn leaf_and_missing_seeds_yield_just_the_seed() {
+        let g = graph(&[("a@1.0.0", &[("b", "1.0.0")]), ("b@1.0.0", &[])]);
+        // `a` has no importer ⇒ closure is just itself.
+        assert_eq!(
+            closure_of(&g, &["a@1.0.0"]),
+            ["a@1.0.0"].map(String::from).into()
+        );
+        // A seed absent from `packages` is treated as a leaf (matches
+        // `transitive_closure`): present in the closure, no importers.
+        assert_eq!(
+            closure_of(&g, &["ghost@9.9.9"]),
+            ["ghost@9.9.9"].map(String::from).into()
+        );
+    }
+
+    #[test]
+    fn scoped_peer_suffixed_dep_paths_reconstruct_correctly() {
+        // The child edge value is the dep_path TAIL, so `@scope/pkg`'s importer
+        // edge reconstructs as `@scope/pkg@<tail>` — including a peer suffix.
+        let g = graph(&[
+            ("firebase@10.0.0", &[("@firebase/database", "1.0.0")]),
+            ("@firebase/database@1.0.0", &[]),
+        ]);
+        assert_eq!(
+            closure_of(&g, &["@firebase/database@1.0.0"]),
+            ["@firebase/database@1.0.0", "firebase@10.0.0"]
+                .map(String::from)
+                .into()
+        );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -174,6 +174,15 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     // default. Consulted by the linker only in the GVS pass.
     let force_materialize_packages =
         aube_settings::resolved::force_materialize_packages(settings_ctx);
+    // Embedder-pluggable expansion (selective-subtree materialization): a host
+    // (nub) installs a hook that expands the flat seed into a graph-aware plan —
+    // rung 1 grows each seed to its ancestor-closure so a transitively-consumed
+    // package materializes with its importers (no store-resident-consumer split);
+    // rung 2 adds per-package undeclared-phantom-target hoists. Standalone aube
+    // installs no hook, so the plan is the seed verbatim with no hoist —
+    // byte-for-byte the prior behavior.
+    let fm_plan =
+        aube_linker::expand_force_materialize(graph_for_link, &force_materialize_packages);
 
     let mut linker = aube_linker::Linker::new(store, strategy)
         .with_shamefully_hoist(shamefully_hoist)
@@ -199,7 +208,8 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
             cwd,
             graph_for_link.packages.values(),
         ))
-        .with_force_materialize(&force_materialize_packages);
+        .with_force_materialize(&fm_plan.names)
+        .with_phantom_hoist(fm_plan.hoist_within);
     if let Some(enabled) = use_global_virtual_store_override {
         linker = linker.with_use_global_virtual_store(enabled);
     }


### PR DESCRIPTION
Selective-subtree ancestor-closure force-materialization, behind the default-off `NUB_DYNAMIC_PHANTOM_EJECT` flag. Flag-off is byte-for-byte the shipped behavior.

## Why

Force-materializing a package project-local is only sound for a *transitively-consumed* package if its whole ancestor-closure materializes with it. Materializing the package alone leaves every store-resident importer resolving the un-materialized shared-store copy — a silent singleton split (two realpaths, two module instances). And a package's *undeclared* import (a transitive phantom target) still 404s even after the closure materializes, because the target isn't a sibling on its walk.

## What

Two rungs, both gated on the flag:

- **Rung 1 — ancestor-closure.** Each force-materialize seed grows to `LockfileGraph::importer_closure` — the seed plus every package that transitively imports it (reverse-BFS over importer edges). Bounded to the affected subtree by construction: unrelated top-level subtrees are never importers, so a framework's closure is a small slice of a large tree (measured 0.3–2.1%). Auto-detects an embedded `vite<8.1` and ejects its `[framework…vite]` closure, so `#318`'s dist patch reaches a now-project-local vite — the library-embedded-vite residual that direct-dep-only ejection left.
- **Rung 2 — hoist-within.** A known transitively-phantom importer (`@firebase/database`→`@firebase/app`, `vue-router`→`@vue/compiler-sfc`, `@nuxt/devtools`→`unstorage`) gets its already-resolved target injected as an extra sibling inside its own materialized `node_modules`.

## Fork-discipline

aube gains only a neutral graph primitive (`importer_closure`) and an embedder-pluggable expansion hook (`set_force_materialize_expand_hook` / `expand_force_materialize`) plus a `phantom_hoist` field. With no hook installed — standalone aube, every test — the hook is the identity and the materialize pass is byte-for-byte unchanged. All policy (the flag, vite detection, the phantom map) lives in nub-cli.

## Evidence

- **Firebase, flag-on:** `@firebase/database` doesn't declare `@firebase/app` (a real phantom), yet `require.resolve('@firebase/app')` from its realpath resolves. Flag-off: `MODULE_NOT_FOUND` (the shipped break).
- **Astro 5, flag-on:** embedded `vite@6.4.3` closure = 5 packages (1.5% of 327); a bare `astro dev` (no nub in the process) serves a store `/@fs` module `200` (was `403`).
- **Bounded-subtree**, measured on realistic large trees (framework + ~100 unrelated deps): Astro 0.28%, Nuxt 2.10% of 1284, Expo 1.67%, nx 0.98% — symlink-eligible 97.9–99.7%.

`cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt` clean; aube-linker's 111 tests plus the new `importer_closure` / `phantom_closure` unit tests pass.

## Scope

The default flip stays a separate decision. Rung-2's target map is provisional — the dynamic per-version scanner is its intended auto-source. Two `tests/vite-compat/` acceptance cases (Astro 5, Nuxt) are documented behind the flag; the driver's dev-server leak is fixed (kill the whole process tree, parse the bound port from the log).

Known limitations (documented in-code, for the experimental flag): the flag isn't folded into the install-state fingerprint, so enabling it on an already-installed tree needs a clean install to take effect; the provisional rung-2 map resolves a multi-version target to the first copy by name. Both are fixed at productionization.

Refs #315

https://claude.ai/code/session_01Xuh9u8b93eMNu53fTQTWX7
