### PR TITLE
feat(phantom): wire dynamic per-version scanner into #319's force-materialize closure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,6 +2685,7 @@ dependencies = [
  "node-semver",
  "nub-core",
  "nub-phantom-core",
+ "nub-phantom-scan",
  "num_cpus",
  "rayon",
  "rustc-hash",
@@ -2741,6 +2742,15 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
+]
+
+[[package]]
+name = "nub-phantom-scan"
+version = "0.2.10"
+dependencies = [
+ "nub-phantom-core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/nub-cache-key", "crates/nub-cli", "crates/nub-core", "crates/nub-phantom-core"]
+members = ["crates/nub-cache-key", "crates/nub-cli", "crates/nub-core", "crates/nub-phantom-core", "crates/nub-phantom-scan"]
 # vendor/aube is its own Cargo workspace (the vendored aube package manager,
 # plain in-tree files vendored from nubjs/aube). The exclude is load-bearing: nub crates
 # take `path` dependencies into vendor/aube/crates/*, and cargo auto-adopts

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -25,6 +25,11 @@ nub-core = { path = "../nub-core" }
 # Depends on the LEAN oxc parser subset, not the full `oxc` umbrella — see the
 # crate's Cargo.toml for why that keeps the shipped CLI's build graph lean.
 nub-phantom-core = { path = "../nub-phantom-core" }
+# The reachable-graph phantom SCANNER (graph walk + classify) for the dynamic
+# per-version scan → sidecar path (behind NUB_DYNAMIC_PHANTOM_EJECT). Lean by
+# construction — same oxc-parser weight as nub-phantom-core, no fetch stack. The
+# `ScanResult` it defines is the sidecar payload phantom_closure deserializes.
+nub-phantom-scan = { path = "../nub-phantom-scan" }
 # Vendored aube (vendor/aube — plain in-tree files, vendored from nubjs/aube). aube-lockfile
 # is a pure library crate (no CLI/tokio surface); `aube` is the command layer
 # as a library (lib target landed in nubjs/aube@b15cdcb) — `nub install` /

--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -1,0 +1,213 @@
+//! Dynamic per-version phantom scan → disk-eject (behind the default-off
+//! `NUB_DYNAMIC_PHANTOM_EJECT` flag).
+//!
+//! The static curated `NUB_FORCE_MATERIALIZE_PACKAGES` list (hand-maintained,
+//! capped at a corpus, stale on new versions) is augmented by SCANNING each
+//! installed dependency version's real published code: does it, along its
+//! reachable `exports`/`main`/`bin` graph, statically and unguardedly import a
+//! package it does not declare? A version's code is immutable, so the verdict is
+//! computed once per content-fingerprint and cached machine-wide.
+//!
+//! Placement — EXTRACT TIME, not post-link. The scan is registered as an aube
+//! store extract hook ([`aube_store::set_extract_hook`]) that fires at the end of
+//! each tarball import, on the fetch/blocking fan-out thread, so per-version
+//! analysis OVERLAPS the network-bound fetch phase (the scan CPU hides under
+//! fetch's idle cores) instead of adding a serial post-link pass. Each verdict is
+//! written to a per-content sidecar.
+//!
+//! The sidecars are CONSUMED by the force-materialize expansion hook
+//! ([`crate::pm_engine::phantom_closure`]): it reads them to seed the
+//! selective-subtree closure with each flagged importer, so a poisoned version is
+//! ejected project-local through #319's graph-aware materialization plan. This
+//! module is the PRODUCER (scan + sidecar) half; `phantom_closure` is the
+//! consumer half. The two share [`store_v1_dir`]/[`phantom_cache_dir`] so their
+//! store handle and sidecar path derive from ONE base and cannot drift apart.
+//!
+//! With the flag OFF this module registers nothing — no extract hook — so the
+//! default install path is byte-identical to a build without the scanner.
+
+use std::path::{Path, PathBuf};
+
+use aube_store::{PackageIndex, index_content_fingerprint};
+use nub_phantom_scan::scan_index;
+use rayon::prelude::*;
+
+/// Whether the dynamic phantom scanner is armed. Truthy `NUB_DYNAMIC_PHANTOM_EJECT`
+/// (`1`/`true`/`yes`, or any non-falsey value) arms it; unset or a falsey value
+/// (`0`/`false`/`no`/`off`/empty) is off — the default.
+fn enabled() -> bool {
+    match std::env::var("NUB_DYNAMIC_PHANTOM_EJECT") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+        Err(_) => false,
+    }
+}
+
+/// Register the extract-time scan hook with the embedded engine. Called once at
+/// engine-session build. No-op unless the flag is on, so the default path pulls
+/// in nothing and stays byte-identical. The registration is process-global
+/// set-once; a second call is ignored. The link-time consumption of the sidecars
+/// this writes lives in [`crate::pm_engine::phantom_closure`], not here.
+pub fn register() {
+    if !enabled() {
+        return;
+    }
+    let Some(dir) = phantom_cache_dir() else {
+        return;
+    };
+    // Extract-time scan: overlap per-version analysis with the fetch phase.
+    aube_store::set_extract_hook(Box::new(move |index: &PackageIndex| {
+        scan_and_cache(&dir, index);
+    }));
+}
+
+/// Scan one freshly-imported package index and persist its verdict to the
+/// per-content sidecar. Best-effort throughout — any failure simply leaves no
+/// sidecar, which the linker reads as "no eject" (a scan miss must never itself
+/// force materialization).
+///
+/// Panic-safety rests on the scan being panic-free BY CONSTRUCTION, not on the
+/// `catch_unwind`: oxc reports an unparseable/hostile file via a return flag (not
+/// an unwind), `serde`/`fs` return `Result`, and the graph walk is depth- and
+/// size-bounded — so a crafted tarball degrades to a scan miss, never a crash.
+/// The `catch_unwind` is a redundant guard that only engages under an unwinding
+/// profile (dev/test); the shipped release profile is `panic = "abort"`, where it
+/// is inert. Do not treat it as a production safety net.
+///
+/// The written JSON is the serialized [`nub_phantom_scan::ScanResult`], read back
+/// by the CONSUMER ([`crate::pm_engine::phantom_closure`]) — which, being in
+/// nub-cli, deserializes it into the typed `ScanResult` (no cross-fork string
+/// coupling) to seed the force-materialize closure.
+fn scan_and_cache(dir: &Path, index: &PackageIndex) {
+    let fingerprint = index_content_fingerprint(index);
+    let sidecar = dir.join(format!("{fingerprint}.json"));
+    // Cross-process / warm cache hit: this exact content was already scanned.
+    // The verdict is a pure function of the immutable bytes, so a concurrent
+    // first-writer race is benign (identical result) — skip the redundant scan.
+    if sidecar.exists() {
+        return;
+    }
+
+    // `StoredFile.store_path` is the absolute CAS blob; the scanner resolves the
+    // reachable graph over the relpath key set and reads content from the blobs.
+    let files: Vec<(String, PathBuf)> = index
+        .iter()
+        .map(|(rel, file)| (rel.clone(), file.store_path.clone()))
+        .collect();
+    let Some(result) =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| scan_index(&files)))
+            .ok()
+            .flatten()
+    else {
+        return;
+    };
+    if let Ok(bytes) = serde_json::to_vec(&result) {
+        let _ = std::fs::create_dir_all(dir);
+        // Atomic publish: write a per-call-unique temp then rename, so a
+        // concurrent installer's linker never observes a half-written sidecar.
+        // (The reader already degrades a torn read to "no eject" and self-heals,
+        // but rename closes the window.) The temp name carries the pid AND a
+        // process-wide sequence: two rayon tasks scanning the SAME content
+        // fingerprint — an npm-alias and its real package share one CAS index, so
+        // the backfill can enqueue both — must not write the same temp path.
+        // Concurrent renames of the same content to the same target are
+        // last-writer-wins and byte-identical.
+        static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = dir.join(format!("{fingerprint}.{}.{seq}.tmp", std::process::id()));
+        if std::fs::write(&tmp, &bytes).is_ok() && std::fs::rename(&tmp, &sidecar).is_err() {
+            let _ = std::fs::remove_file(&tmp);
+        }
+    }
+}
+
+/// Nub's CAS store schema dir: `<nub-data>/store/v1/`, the parent of the CAS
+/// `files/` and `index/` tiers and the `phantom/` sidecar tier. Derives from the
+/// SAME [`crate::pm_engine::nub_data_dir`] nub configures its `storeDir` setting
+/// from (`nub_data_dir()/store`), plus aube's `v1/` schema suffix — so the store
+/// handle and the sidecar dir share ONE base with the real store and cannot drift
+/// (the XDG resolution is not re-implemented here). `None` when no data home
+/// resolves. `pub(crate)` so the sidecar CONSUMER
+/// ([`crate::pm_engine::phantom_closure`]) derives its store handle from the same
+/// base this producer uses.
+pub(crate) fn store_v1_dir() -> Option<PathBuf> {
+    Some(crate::pm_engine::nub_data_dir()?.join("store/v1"))
+}
+
+/// The per-content sidecar directory: `<nub-data>/store/v1/phantom/`, next to the
+/// CAS + index tiers. `None` when no data home resolves (the scanner then simply
+/// doesn't arm). `pub(crate)` so the consumer reads the same directory this
+/// producer writes.
+pub(crate) fn phantom_cache_dir() -> Option<PathBuf> {
+    Some(store_v1_dir()?.join("phantom"))
+}
+
+/// Pre-install BACKFILL pass — the warm-store companion to the extract hook,
+/// called from `run_engine` (so it runs on `nub install` / `nub ci`, NOT on the
+/// `add`/`remove`/`update`/`dedupe` verbs, which dispatch the engine directly).
+/// On those verbs a warm-cache package with no sidecar is simply not scanned this
+/// run (its eject waits for the next `install`); a fresh FETCH is still covered by
+/// the extract hook. A miss only ever means "no eject", never a false break.
+///
+/// The extract hook fires only on a genuine tarball FETCH; a package already in
+/// the CAS with no sidecar (the feature shipping over a warm cache, or a GC'd
+/// sidecar) is never re-scanned, so link finds no sidecar and doesn't eject.
+/// This pass runs BEFORE `install::run`, so the sidecars exist before link's
+/// per-package eject decision on THIS install: for each resolved package already
+/// materialized in the CAS but missing a sidecar, it computes and persists the
+/// verdict — reusing the same [`scan_and_cache`] the extract hook uses, so the
+/// fingerprint keying, sidecar-hit skip, panic-guard, and atomic write are one
+/// implementation.
+///
+/// Flag-OFF is a STRICT no-op: it returns before any lockfile parse, store
+/// access, or fs touch, so the default install path is byte-identical. No
+/// lockfile / an unparseable one is also a no-op — a fresh install has nothing
+/// cached to backfill, and the extract hook covers whatever it fetches. The scan
+/// is CPU-bound and per-package independent, so it fans out across rayon; a
+/// warm re-install where every sidecar already exists does zero scanning (each
+/// package is a `scan_and_cache` sidecar-hit early return).
+///
+/// Best-effort completeness, never correctness (a miss reads as "no eject"):
+/// - Assumes nub's DEFAULT `storeDir` (`store_v1_dir`). A user `store-dir`
+///   override (`.npmrc`/yaml) moves the CAS elsewhere, so `load_index` misses
+///   and the warm-cache backfill no-ops — fresh fetches still eject via the
+///   extract hook; only warm-cache eject is lost under an override.
+/// - Keys `load_index` on `pkg.integrity`; no-integrity packages (git deps /
+///   integrity-stripped proxies) that the linker reads via a computed-sha
+///   binding may not be backfilled. No false eject — the linker recomputes the
+///   fingerprint from its own index, so an absent/mismatched sidecar is "no eject".
+pub fn backfill_from_lockfile(project_dir: &Path) {
+    if !enabled() {
+        return;
+    }
+    let (Some(sidecar_dir), Some(store_v1)) = (phantom_cache_dir(), store_v1_dir()) else {
+        return;
+    };
+    let Ok(manifest) = aube_manifest::PackageJson::from_path(&project_dir.join("package.json"))
+    else {
+        return;
+    };
+    let Ok(graph) = aube_lockfile::parse_lockfile(project_dir, &manifest) else {
+        return;
+    };
+    // `Store::at` takes the CAS `files/` root; `store_v1_dir` is its parent, and
+    // the store derives `index/` from it — matching how nub's configured
+    // `storeDir` resolves to `<storeDir>/v1/files` (aube `open_store`).
+    let store = aube_store::Store::at(store_v1.join("files"));
+    // BTreeMap has no rayon bridge; collect the resolved set first.
+    let packages: Vec<&aube_lockfile::LockedPackage> = graph.packages.values().collect();
+    packages.into_par_iter().for_each(|pkg| {
+        // Not in the CAS ⇒ skip: the resolve/fetch phase fetches it and the
+        // extract hook covers it. `registry_name()` + `integrity` key the index
+        // the SAME way the linker's own eject-gate read does (`builder.rs`
+        // `force_materialize` path), so npm-alias deps resolve to the right blob.
+        let Some(index) =
+            store.load_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref())
+        else {
+            return;
+        };
+        scan_and_cache(&sidecar_dir, &index);
+    });
+}

--- a/crates/nub-cli/src/main.rs
+++ b/crates/nub-cli/src/main.rs
@@ -6,6 +6,7 @@
 mod agent;
 mod cli;
 mod config;
+mod dynamic_phantom;
 mod nubx_consent;
 mod nubx_resolve;
 mod phantom_scan;

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1470,6 +1470,21 @@ fn run_engine(
     yarn_gated: bool,
     output: &super::output::OutputFlags,
 ) -> Result<i32> {
+    // Pre-install phantom backfill (flag-gated STRICT no-op by default): scan any
+    // already-cached resolved package that has no verdict sidecar yet, BEFORE the
+    // engine links. The extract hook only fires on a genuine tarball fetch, so a
+    // package served from a WARM store (or whose sidecar was GC'd) would otherwise
+    // reach the closure with no sidecar and never seed an eject; this closes that
+    // gap on THIS install. Rooted at the lockfile's dir (else the cwd). See
+    // `crate::dynamic_phantom::backfill_from_lockfile`.
+    crate::dynamic_phantom::backfill_from_lockfile(
+        session
+            .detected
+            .as_ref()
+            .map(|d| d.dir.as_path())
+            .unwrap_or(session.cwd.as_path()),
+    );
+
     // Hold the output guard only across the engine run (so `--silent` suppresses
     // the progress/summary written during install) and drop it before the match
     // below, so a final error report still reaches the real stderr.

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -772,6 +772,12 @@ fn engine_session_inner(
     // the force-materialize seed to its ancestor-closure + phantom-target hoists
     // at link time. Idempotent set-once, like `identity::register()`.
     phantom_closure::register();
+    // Arm the dynamic per-version phantom PRODUCER: an extract-time store hook
+    // that scans each fetched package and writes a per-content verdict sidecar
+    // (`phantom_closure`, above, is the CONSUMER that reads those sidecars to seed
+    // the closure). No-op unless the same default-off `NUB_DYNAMIC_PHANTOM_EJECT`
+    // flag is set, so the default path is unchanged. Idempotent set-once.
+    crate::dynamic_phantom::register();
     // Initialize the diagnostics recorder from NUB_DIAG_* env vars so that
     // `NUB_DIAG_SUMMARY=1 nub install` surfaces the same per-phase/per-op
     // spans + summary table that `AUBE_DIAG_SUMMARY=1 aube install` does. The
@@ -2279,7 +2285,7 @@ fn is_truly_fresh_project(cwd: &Path, detected: Option<&DetectedLockfile>) -> bo
 
 /// Nub's XDG data root (`$XDG_DATA_HOME/nub` or `~/.local/share/nub`), the
 /// data-dir sibling of `nub_core::node::discovery::cache_dir`.
-fn nub_data_dir() -> Option<PathBuf> {
+pub(crate) fn nub_data_dir() -> Option<PathBuf> {
     let base = std::env::var("XDG_DATA_HOME")
         .ok()
         .filter(|v| !v.is_empty())

--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -17,26 +17,38 @@
 //!   is auto-detected and its `[framework…vite]` closure ejected, so #318's dist
 //!   sniff patch reaches a now-project-local vite.
 //! - **Rung 2 — hoist-within.** For a transitively-phantom importer whose
-//!   undeclared target the closure alone can't place (`@nuxt/devtools`→
-//!   `unstorage`, `vue-router`→`@vue/compiler-sfc`, `@firebase/database`→
-//!   `@firebase/app`), the already-resolved target is hoisted as an extra
-//!   sibling within the importer's own materialized `node_modules`.
+//!   undeclared target the closure alone can't place, the already-resolved target
+//!   is hoisted as an extra sibling within the importer's own materialized
+//!   `node_modules`.
+//!
+//! The phantom importers + their undeclared targets are the DYNAMIC output of the
+//! extract-time per-version scanner (`crate::dynamic_phantom`, the PRODUCER): it
+//! scans each fetched version's real published code for unguarded undeclared
+//! imports and writes a per-content verdict sidecar. This hook (the CONSUMER)
+//! reads those sidecars — so there is no hand-maintained list of phantom classes;
+//! the detection is per-version and auto-current. A precision SEED-SELECTION
+//! filter (see [`should_seed`]) drops a flagged importer whose undeclared targets
+//! are all already reachable inside its own subtree and absent from the project
+//! top level, so a transitively-satisfied over-flag never ejects.
 //!
 //! Flag OFF ⇒ no hook installed ⇒ aube's `expand_force_materialize` returns the
 //! seed verbatim ⇒ the force-materialize pass is byte-for-byte the shipped
 //! behavior. All policy lives here; aube owns only the neutral seam + the graph
 //! primitive.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 
 use aube_linker::ForceMaterializePlan;
-use aube_lockfile::LockfileGraph;
+use aube_lockfile::{LockedPackage, LockfileGraph};
+use nub_phantom_scan::ScanResult;
+use rayon::prelude::*;
 
 /// Whether selective-subtree force-materialization is armed. Truthy
 /// `NUB_DYNAMIC_PHANTOM_EJECT` (`1`/`true`/`yes`, or any non-falsey value) arms
 /// it; unset or a falsey value (`0`/`false`/`no`/`off`/empty) is off — the
-/// default. Same flag the (unmerged) dynamic per-version scanner will gate on, so
-/// the closure (transitive soundness) and the scanner (detection) share one arm.
+/// default. The SAME flag the extract-time producer (`crate::dynamic_phantom`)
+/// gates on, so the scanner (detection) and this closure (transitive soundness)
+/// share one arm.
 ///
 /// LIMITATION (experimental-flag scope): the flag is NOT folded into the
 /// install-state fingerprint, which hashes only the raw `forceMaterializePackages`
@@ -55,30 +67,6 @@ fn enabled() -> bool {
     }
 }
 
-/// Known transitive-phantom classes: an importer that statically imports an
-/// undeclared (or optional-peer-but-unlinked) target ALREADY present in the tree.
-/// Each entry both SEEDS its importer for force-materialization and drives the
-/// rung-2 hoist of the target within it.
-///
-/// PROVISIONAL: the dynamic per-version phantom scanner (the extract-time scan
-/// this same flag gates, unmerged on `scanner-build`) is the intended auto-source
-/// that supersedes this curated map — it scans each version's real code for
-/// undeclared imports, so it needs no hand-maintenance. This small map exists so
-/// the known acceptance classes (Nuxt, Firebase) work end-to-end today; it is the
-/// rung-2 analogue of the shipped static `NUB_FORCE_MATERIALIZE_PACKAGES` list.
-const KNOWN_PHANTOM_TARGETS: &[(&str, &[&str])] = &[
-    // Nuxt 4: vue-router statically imports @vue/compiler-sfc, declared only as
-    // an optional peer, so it is not auto-linked under the isolated GVS layout.
-    ("vue-router", &["@vue/compiler-sfc"]),
-    // Nuxt 4: @nuxt/devtools (stable 3.x) imports unstorage without declaring it
-    // (nitropack, a sibling, is the package that declares it).
-    ("@nuxt/devtools", &["unstorage"]),
-    // Firebase: @firebase/database imports the @firebase/app singleton it does
-    // not declare (its siblings @firebase/firestore / @firebase/auth DO declare
-    // it as a peer — a per-package omission, not a design choice).
-    ("@firebase/database", &["@firebase/app"]),
-];
-
 /// Register nub's force-materialize expansion hook with the embedded engine.
 /// No-op unless `NUB_DYNAMIC_PHANTOM_EJECT` is armed, so the default path installs
 /// nothing and `aube_linker::expand_force_materialize` stays the identity —
@@ -94,11 +82,33 @@ pub(crate) fn register() {
 /// The hook body: resolved graph + flat seed → graph-aware materialization plan.
 /// See the module docs for the two rungs.
 fn expand(graph: &LockfileGraph, seed_names: &[String]) -> ForceMaterializePlan {
-    // Seed set by NAME: the caller's force-materialize list ∪ the known
-    // phantom-importer names. Embedded vite<8.1 is seeded by dep_path below.
+    // Top-level presence: default-hoist top level = the importer DIRECT deps. See
+    // `should_seed` for why this gate is load-bearing and its non-default-hoist
+    // scope caveat.
+    let root_provided: HashSet<&str> = graph
+        .importers
+        .values()
+        .flat_map(|deps| deps.iter().map(|d| d.name.as_str()))
+        .collect();
+    let is_top_level = |name: &str| root_provided.contains(name);
+
+    // Seed set by NAME: the caller's force-materialize list ∪ every dynamically-
+    // flagged importer that SURVIVES the precision seed-selection filter. Embedded
+    // vite<8.1 is seeded by dep_path below.
     let mut seed_names_set: HashSet<&str> = seed_names.iter().map(String::as_str).collect();
-    for (importer, _) in KNOWN_PHANTOM_TARGETS {
-        seed_names_set.insert(importer);
+
+    // Dynamic phantom source (the per-version scanner's sidecars) — the replacement
+    // for the retired hand-curated map. `dynamic_targets` keeps each SURVIVING
+    // importer's undeclared targets keyed by dep_path, for the rung-2 hoist; only
+    // survivors are kept, so a hoist only ever lands in a package the seed actually
+    // materializes.
+    let flags = dynamic_phantom_flags(graph);
+    let mut dynamic_targets: BTreeMap<&str, &[String]> = BTreeMap::new();
+    for (dep_path, name, targets) in &flags {
+        if should_seed(targets, &reachable_dep_names(dep_path, graph), is_top_level) {
+            seed_names_set.insert(name.as_str());
+            dynamic_targets.insert(dep_path.as_str(), targets.as_slice());
+        }
     }
 
     // Seed DEP_PATHS: every graph package whose name is a seed, plus every
@@ -144,18 +154,14 @@ fn expand(graph: &LockfileGraph, seed_names: &[String]) -> ForceMaterializePlan 
         }
     }
 
-    // Rung-2 hoist map: for each known phantom-importer whose dep_path landed in
-    // the closure, resolve its target(s) to a dep_path present in the graph and
-    // record importer_dep_path → [target_dep_paths].
+    // Rung-2 hoist map: for each closure member that is a surviving dynamically-
+    // flagged importer, resolve its undeclared target(s) to a dep_path present in
+    // the graph and record importer_dep_path → [target_dep_paths]. A survivor is
+    // seeded by name, so its dep_path is in the closure by construction; iterating
+    // the closure keeps this aligned to what actually materializes.
     let mut hoist_within: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for dep_path in &closure {
-        let Some(pkg) = graph.packages.get(dep_path) else {
-            continue;
-        };
-        let Some((_, targets)) = KNOWN_PHANTOM_TARGETS
-            .iter()
-            .find(|(name, _)| *name == pkg.name)
-        else {
+        let Some(targets) = dynamic_targets.get(dep_path.as_str()) else {
             continue;
         };
         let resolved: Vec<String> = targets
@@ -173,10 +179,159 @@ fn expand(graph: &LockfileGraph, seed_names: &[String]) -> ForceMaterializePlan 
     }
 }
 
+/// The dynamic analogue of the retired hand-curated phantom-class map: for each
+/// resolved package whose per-content sidecar (written by the extract-time
+/// PRODUCER, [`crate::dynamic_phantom`]) reports an unguarded phantom, its
+/// `(dep_path, name, undeclared-target-names)`.
+///
+/// Reads the SAME store handle + sidecar dir the producer wrote, via the shared
+/// [`crate::dynamic_phantom`] path helpers, so the two cannot drift. Best-effort:
+/// a package absent from the default store (a `store-dir` override moves the CAS),
+/// a missing/torn sidecar, or a not-yet-scanned version all degrade to "not
+/// flagged" — a scan miss never itself forces materialization. Fans out across
+/// rayon; the backfill already warmed the sidecars, so each item is a small
+/// cached-JSON index load + a blake3 fingerprint + a small sidecar read.
+///
+/// Flag-gated to empty unless armed. In production `expand` is only installed when
+/// armed, so this is belt-and-suspenders; the gate also keeps the pure vite/empty
+/// unit tests hermetic — they call `expand` directly with the flag off and must
+/// not touch the host's real store.
+fn dynamic_phantom_flags(graph: &LockfileGraph) -> Vec<(String, String, Vec<String>)> {
+    if !enabled() {
+        return Vec::new();
+    }
+    let (Some(store_v1), Some(sidecar_dir)) = (
+        crate::dynamic_phantom::store_v1_dir(),
+        crate::dynamic_phantom::phantom_cache_dir(),
+    ) else {
+        return Vec::new();
+    };
+    // `Store::at` takes the CAS `files/` root; `store_v1` is its parent — the same
+    // derivation the producer's backfill uses, so both key the index identically.
+    let store = aube_store::Store::at(store_v1.join("files"));
+    // BTreeMap has no rayon bridge; collect the resolved set first (as the
+    // backfill does).
+    let packages: Vec<(&String, &LockedPackage)> = graph.packages.iter().collect();
+    packages
+        .into_par_iter()
+        .filter_map(|(dep_path, pkg)| {
+            // `registry_name()` + `integrity` key the index the SAME way the
+            // producer's backfill does, so npm-alias deps resolve to the right blob.
+            let index =
+                store.load_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref())?;
+            let fingerprint = aube_store::index_content_fingerprint(&index);
+            let bytes = std::fs::read(sidecar_dir.join(format!("{fingerprint}.json"))).ok()?;
+            // nub-cli CAN depend on the scanner crate, so the sidecar deserializes
+            // straight into the typed `ScanResult` (no cross-fork string coupling).
+            let result: ScanResult = serde_json::from_slice(&bytes).ok()?;
+            if !result.has_unguarded_phantom {
+                return None;
+            }
+            let targets: Vec<String> = result.targets.into_iter().map(|t| t.name).collect();
+            Some((dep_path.clone(), pkg.name.clone(), targets))
+        })
+        .collect()
+}
+
+/// Whether a dynamically-flagged package must SEED the closure — the precision
+/// filter, applied as seed-selection. DEFAULT is SEED (eject); a flag is
+/// downgraded to a SKIP (not seeded) only when it can PROVE every undeclared
+/// target is BOTH reachable inside the package's own resolved subtree AND absent
+/// from the project top level.
+///
+/// SAFETY INVARIANT (non-negotiable): a wrong SKIP is a real phantom BREAK,
+/// strictly worse than a redundant over-eject. So every uncertainty — a
+/// target-less flag, a target outside the closure, a top-level target — falls
+/// through to SEED. The filter only ever REMOVES an over-seed it can prove safe.
+///
+/// Why the top-level gate is load-bearing: under GVS there is no hidden hoist
+/// tree, so an ejected (project-local) realpath additionally reaches the PROJECT
+/// top level in its `node_modules` walk, while a skipped (shared-store) realpath
+/// reaches only its own siblings. The eject therefore changes resolution for
+/// exactly one class of target — those present at the project top level: a
+/// top-level target resolves only when ejected (skipping it 404s), while a
+/// non-top-level target is unresolvable in either state (skipping it is a true
+/// no-op). (Corpus: es-abstract / typed-array-byte-length are transitively
+/// satisfied → SKIP; @hookform/resolvers / swiper / @firebase/database are real
+/// breakers → SEED.)
+///
+/// SCOPE CAVEAT (default-off flag): `is_top_level` here sees only the importer
+/// DIRECT deps (`graph.importers`) — exactly the DEFAULT hoist config's top level.
+/// The expand seam has no access to the linker's `public-hoist` / `shamefully-
+/// hoist` config, so under a NON-default hoist config a target hoisted there (but
+/// not a direct importer dep) is invisible to this check and could permit a skip
+/// the linker-side gate would have ejected. Acceptable under the experimental flag
+/// (the validated corpus is default-hoist); threading the hoist config into the
+/// seam is the productionization fix.
+fn should_seed(
+    targets: &[String],
+    reachable: &HashSet<String>,
+    is_top_level: impl Fn(&str) -> bool,
+) -> bool {
+    if targets.is_empty() {
+        return true;
+    }
+    !targets
+        .iter()
+        .all(|t| reachable.contains(t) && !is_top_level(t))
+}
+
+/// The set of package NAMES transitively reachable from the package at
+/// `root_dep_path` through its resolved `dependencies` edges — the siblings a
+/// phantom import from that package can satisfy WITHIN its own subtree, with no
+/// project-local disk copy.
+///
+/// Walks `dependencies` ONLY, deliberately. Per [`LockedPackage`]'s contract that
+/// map is the resolved edge set, with ACTIVE optional edges and RESOLVED peer
+/// versions already MIRRORED into it — exactly the siblings symlinked into each
+/// node's `node_modules`. Also walking the raw `optional_dependencies` /
+/// `peer_dependencies` maps could only ADD edges ABSENT from `dependencies`
+/// (platform-pruned optionals, or unresolved peer RANGES that never key
+/// `graph.packages`); counting either as reachable would OVER-complete the
+/// closure — the one direction that yields a wrong SKIP. So `dependencies` is both
+/// the complete AND the safe edge source; this mirrors
+/// [`LockfileGraph::importer_closure`]'s reconstruction of child keys.
+///
+/// A child NAME enters only when its full dep_path (`{name}@{tail}`, the tail
+/// carrying any peer suffix) resolves in `graph.packages`; an unresolvable edge
+/// halts that branch, leaving the closure a SUBSET of true reachability — which
+/// errs toward SEED, never toward a wrong skip. A visited set + a hard node cap
+/// bound a cyclic/adversarial graph; hitting the cap truncates, again toward SEED.
+fn reachable_dep_names(root_dep_path: &str, graph: &LockfileGraph) -> HashSet<String> {
+    // Ceiling far above any real subtree (hundreds of nodes); it only bounds a
+    // pathological graph, and truncation errs toward seed.
+    const MAX_NODES: usize = 100_000;
+    let mut names = HashSet::new();
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::new();
+    visited.insert(root_dep_path.to_string());
+    queue.push_back(root_dep_path.to_string());
+    while let Some(dep_path) = queue.pop_front() {
+        if visited.len() >= MAX_NODES {
+            break;
+        }
+        let Some(pkg) = graph.packages.get(&dep_path) else {
+            continue;
+        };
+        for (child_name, child_tail) in &pkg.dependencies {
+            let child_key = format!("{child_name}@{child_tail}");
+            if !graph.packages.contains_key(&child_key) {
+                continue;
+            }
+            names.insert(child_name.clone());
+            if visited.insert(child_key.clone()) {
+                queue.push_back(child_key);
+            }
+        }
+    }
+    names
+}
+
 /// Resolve a target package NAME to a dep_path present in the graph. `packages`
 /// is a `BTreeMap`, so `.find` yields the lexically-first matching dep_path —
-/// deterministic, and unambiguous for the single-version acceptance classes. The
-/// dynamic scanner supplies precise per-version targeting when it lands.
+/// deterministic, and unambiguous for the single-version phantom classes. The
+/// scanner reports targets by name; per-version target dep_paths would need the
+/// scanner to also record the resolved coordinate.
 fn resolve_target_dep_path(graph: &LockfileGraph, target_name: &str) -> Option<String> {
     graph
         .packages
@@ -188,7 +343,6 @@ fn resolve_target_dep_path(graph: &LockfileGraph, target_name: &str) -> Option<S
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aube_lockfile::LockedPackage;
 
     /// One test-graph edge: `(dep_path, name, [(child_name, child_tail)])`.
     type Edge<'a> = (&'a str, &'a str, &'a [(&'a str, &'a str)]);
@@ -201,8 +355,8 @@ mod tests {
                 dep_path: dep_path.to_string(),
                 ..Default::default()
             };
-            // A real graph carries `version`; several packages need it for the
-            // vite<8.1 seed test, so parse it off the dep_path tail.
+            // A real graph carries `version`; the vite<8.1 seed test needs it, so
+            // parse it off the dep_path tail.
             if let Some((_, tail)) = split(dep_path) {
                 pkg.version = tail.split('(').next().unwrap_or(tail).to_string();
             }
@@ -223,6 +377,13 @@ mod tests {
         Some((&dep_path[..at], &dep_path[at + 1..]))
     }
 
+    fn names(xs: &[&str]) -> HashSet<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    // Rung-1 vite seeding is independent of the dynamic source (a flag-off unit
+    // test sees no dynamic flags), so these exercise the closure end to end.
+
     #[test]
     fn embedded_vite_lt_8_1_seeds_its_framework_closure() {
         // astro → vite@6.4.3 (embedded, <8.1). The closure force-materializes
@@ -234,10 +395,13 @@ mod tests {
             ("lodash@4.17.21", "lodash", &[]),
         ]);
         let plan = expand(&g, &[]);
-        let names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
-        assert!(names.contains("vite"), "embedded vite<8.1 seeded");
-        assert!(names.contains("astro"), "framework in the closure");
-        assert!(!names.contains("lodash"), "unrelated dep stays symlinked");
+        let plan_names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
+        assert!(plan_names.contains("vite"), "embedded vite<8.1 seeded");
+        assert!(plan_names.contains("astro"), "framework in the closure");
+        assert!(
+            !plan_names.contains("lodash"),
+            "unrelated dep stays symlinked"
+        );
     }
 
     #[test]
@@ -254,35 +418,105 @@ mod tests {
     }
 
     #[test]
-    fn firebase_class_seeds_closure_and_hoists_the_undeclared_target() {
-        // firebase → @firebase/database (imports the undeclared @firebase/app);
-        // firebase also declares @firebase/app directly (transitive, not root).
-        let g = graph(&[
-            (
-                "firebase@10.0.0",
-                "firebase",
-                &[("@firebase/database", "1.0.0"), ("@firebase/app", "0.15.0")],
-            ),
-            ("@firebase/database@1.0.0", "@firebase/database", &[]),
-            ("@firebase/app@0.15.0", "@firebase/app", &[]),
-        ]);
-        let plan = expand(&g, &[]);
-        let names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
-        assert!(names.contains("@firebase/database"), "seed materialized");
-        assert!(names.contains("firebase"), "importer in the closure");
-        // Rung 2: the undeclared @firebase/app hoisted within @firebase/database.
-        assert_eq!(
-            plan.hoist_within
-                .get("@firebase/database@1.0.0")
-                .map(Vec::as_slice),
-            Some(["@firebase/app@0.15.0".to_string()].as_slice())
-        );
-    }
-
-    #[test]
     fn no_seeds_yields_empty_plan() {
         let g = graph(&[("lodash@4.17.21", "lodash", &[])]);
         let plan = expand(&g, &[]);
         assert!(plan.names.is_empty() && plan.hoist_within.is_empty());
+    }
+
+    // Precision seed-selection (`should_seed`) — the port of the retired link-time
+    // filter, tested as a pure function.
+
+    #[test]
+    fn seed_unless_every_target_in_closure_and_non_top_level() {
+        let closure = names(&["a", "b", "for-each"]);
+        let none_top_level = |_: &str| false;
+        // All targets in-closure, none at the project top level → safe SKIP.
+        assert!(!should_seed(
+            &["a".to_string(), "b".to_string()],
+            &closure,
+            none_top_level
+        ));
+        // A target outside the closure → SEED (can't prove safe).
+        assert!(should_seed(
+            &["a".to_string(), "missing".to_string()],
+            &closure,
+            none_top_level
+        ));
+        // A target-less flag → SEED (can't prove safe on incomplete info).
+        assert!(should_seed(&[], &closure, none_top_level));
+    }
+
+    #[test]
+    fn top_level_target_forces_seed_even_when_in_closure() {
+        // The wrong-skip hole: `for-each` is in-closure BUT also at the project
+        // top level, so an ejected (project-local) copy resolves it while a
+        // skipped (shared-store) one 404s — the eject is load-bearing, so the
+        // top-level gate must veto the skip.
+        let closure = names(&["for-each", "a"]);
+        let for_each_top_level = |n: &str| n == "for-each";
+        assert!(should_seed(
+            &["for-each".to_string()],
+            &closure,
+            for_each_top_level
+        ));
+        // A different, non-top-level in-closure target stays safe to skip.
+        assert!(!should_seed(
+            &["a".to_string()],
+            &closure,
+            for_each_top_level
+        ));
+    }
+
+    // Reachability (`reachable_dep_names`) — the in-subtree name set the precision
+    // filter consults.
+
+    #[test]
+    fn reachable_names_reconstruct_from_tails_including_peer_suffix() {
+        // P → a → shared; P → styled(peer suffix in the tail). The full graph key
+        // for the peer-context child carries the `(react@18.2.0)` suffix — the
+        // reconstruction must reproduce it exactly.
+        let g = graph(&[
+            (
+                "p@1.0.0",
+                "p",
+                &[("a", "1.0.0"), ("styled", "6.0.0(react@18.2.0)")],
+            ),
+            ("a@1.0.0", "a", &[("shared", "2.0.0")]),
+            ("shared@2.0.0", "shared", &[]),
+            ("styled@6.0.0(react@18.2.0)", "styled", &[]),
+        ]);
+        let r = reachable_dep_names("p@1.0.0", &g);
+        assert!(r.contains("a"), "direct dep");
+        assert!(r.contains("shared"), "transitive dep");
+        assert!(r.contains("styled"), "peer-suffixed tail reconstructs");
+        assert!(!r.contains("p"), "root itself is not in its own closure");
+    }
+
+    #[test]
+    fn reachable_names_halt_on_unresolvable_edge_toward_seed() {
+        // P declares `a@9.9.9`, absent from the graph → the edge does not resolve,
+        // so `a` and its subtree (`deep`) stay out of the closure → a phantom
+        // target of either SEEDS (the safe direction).
+        let g = graph(&[
+            ("p@1.0.0", "p", &[("a", "9.9.9")]),
+            ("a@1.0.0", "a", &[("deep", "1.0.0")]),
+            ("deep@1.0.0", "deep", &[]),
+        ]);
+        let r = reachable_dep_names("p@1.0.0", &g);
+        assert!(!r.contains("a"), "unresolved edge is not counted reachable");
+        assert!(!r.contains("deep"), "subtree behind it is unreached");
+    }
+
+    #[test]
+    fn reachable_names_terminate_on_cycles() {
+        // A ↔ B mutual dependency must not stall the bounded walk.
+        let g = graph(&[
+            ("p@1.0.0", "p", &[("a", "1.0.0")]),
+            ("a@1.0.0", "a", &[("b", "1.0.0")]),
+            ("b@1.0.0", "b", &[("a", "1.0.0")]),
+        ]);
+        let r = reachable_dep_names("p@1.0.0", &g);
+        assert!(r.contains("a") && r.contains("b"));
     }
 }

--- a/crates/nub-phantom-core/src/extract.rs
+++ b/crates/nub-phantom-core/src/extract.rs
@@ -51,6 +51,10 @@ pub struct Occurrence {
 /// Parse `source` (its `SourceType` inferred from `path`) and return every
 /// specifier occurrence. A parse that panics yields an empty list (the file is
 /// simply not analyzed rather than aborting the package).
+///
+/// This is the BASELINE (full guard-aware AST visit) path. [`extract_optimized`]
+/// is the production entry — it applies a cost ladder that reaches this same
+/// full walk only for files that can actually carry a guarded (CJS) load.
 pub fn extract(path: &str, source: &str) -> Vec<Occurrence> {
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::mjs());
@@ -64,6 +68,143 @@ pub fn extract(path: &str, source: &str) -> Vec<Occurrence> {
     };
     v.visit_program(&ret.program);
     v.out
+}
+
+/// The static-imports-only cost ladder — same outputs as [`extract`] on the
+/// phantom-relevant dimension (every recorded specifier + its correct `soft`
+/// flag) for all ordinary code, reached by the cheapest rung complete for the
+/// file's shape. INVESTIGATED + MEASURED but NOT the production path — it
+/// regresses the scan (parse+IO-dominated, CJS-heavy reachable graphs), so
+/// production uses [`extract`] (see `nub-phantom-scan::graph::extract_file`).
+///
+/// Residual known gap (why not "identical for EVERY input"): rung routing keys on
+/// a BYTE scan for a dynamic `import(` call ([`has_dynamic_import_call`]), which
+/// recognizes ASCII whitespace between `import` and `(` but NOT a comment or an
+/// exotic Unicode separator (`\u{A0}`, `\u{FEFF}`) there — `import/*c*/("x")`
+/// would route to the static-ESM rung and be dropped. Such forms are
+/// near-nonexistent in published code and the ladder is unused in production, so
+/// this is documented rather than fully closed.
+///
+/// The insight (why this is sound, not a heuristic): a `soft` (guarded) load can
+/// only occur inside a `try`/`catch` or a conditional branch, and the ONLY module
+/// forms that can be nested inside those are runtime CALLS — `require(...)`,
+/// `require.resolve(...)`, and dynamic `import(...)`. Static ESM `import ... from`
+/// / `export ... from` declarations are hoisted and, by the language grammar,
+/// exist ONLY at the top level of a module — they can never be guarded, so they
+/// are always hard. So:
+///
+/// - **(a) byte pre-filter** — a source with none of the substrings `import`,
+///   `require`, `from` has no module edge at all → return empty, no parse.
+/// - **(b) static-ESM fast path** — a source with no `require` substring and no
+///   dynamic-`import(` call has ONLY top-level static declarations. Parse once
+///   (oxc, cheap) but skip the deep AST visit: scan `program.body` at the top
+///   level. Complete by the grammar rule above, and every hit is hard.
+/// - **(c) guard-aware full walk** — a source containing `require` or a dynamic
+///   `import(` may carry a guarded load, so it needs the full guard-modeling
+///   visit ([`extract`]). This is the ONLY rung whose precision (`soft` vs hard)
+///   depends on control-flow nesting, and it is reserved for exactly the files
+///   that can express it.
+pub fn extract_optimized(path: &str, source: &str) -> Vec<Occurrence> {
+    // (a) No module-edge substring anywhere → nothing to record. `from` catches
+    // `export … from` / `import … from`; `import`/`require` catch the rest
+    // (bare imports, dynamic imports, requires, require.resolve).
+    if !contains_module_edge_bytes(source) {
+        return Vec::new();
+    }
+
+    // (c) Anything that could carry a GUARDED (soft) load — a `require`/
+    // `require.resolve` (CJS, the only form guardable in try/catch) or a dynamic
+    // `import(` call — takes the full guard-aware visit. `has_dynamic_import_call`
+    // distinguishes the dynamic `import(` call from a static `import … from`.
+    if source.contains("require") || has_dynamic_import_call(source) {
+        return extract(path, source);
+    }
+
+    // (b) Static-ESM only. Parse, then read top-level declarations without the
+    // deep recursive walk — sound because static import/export-from are
+    // grammatically top-level-only, and all are unguarded (hard).
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::mjs());
+    let ret = Parser::new(&allocator, source, source_type).parse();
+    if ret.panicked {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for stmt in &ret.program.body {
+        record_toplevel_static(stmt, &mut out);
+    }
+    out
+}
+
+/// Byte pre-filter for rung (a): true if `source` contains any substring that a
+/// static or runtime module edge must contain. Conservative — only a source with
+/// NONE of these can be skipped without a parse.
+fn contains_module_edge_bytes(source: &str) -> bool {
+    source.contains("import") || source.contains("require") || source.contains("from")
+}
+
+/// True if `source` contains a dynamic `import(` CALL (as opposed to only static
+/// `import … from` declarations). A dynamic import call is the token `import`
+/// immediately followed (modulo insignificant whitespace) by `(`. This is a byte
+/// scan, not a parse: it only decides whether the guard-aware rung (c) is needed;
+/// a false positive merely routes the file to the (still-correct) full walk.
+fn has_dynamic_import_call(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    let mut i = 0;
+    while let Some(pos) = source[i..].find("import") {
+        let start = i + pos;
+        let mut j = start + "import".len();
+        // ASCII whitespace incl. CRLF (`\r`), vertical tab (`\x0b`), form feed
+        // (`\x0c`) — the realistic separators. (Comment / Unicode-space
+        // separators are the documented residual gap.)
+        while j < bytes.len() && matches!(bytes[j], b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c) {
+            j += 1;
+        }
+        if j < bytes.len() && bytes[j] == b'(' {
+            return true;
+        }
+        i = start + "import".len();
+    }
+    false
+}
+
+/// Record a top-level static `import`/`export … from` declaration (rung (b)).
+/// Mirrors the import/re-export arms of [`SpecVisitor::visit_statement`] but does
+/// NOT recurse — the caller iterates `program.body` directly. Every occurrence is
+/// unguarded (`soft: false`) because a static declaration cannot be nested in a
+/// guard.
+fn record_toplevel_static(stmt: &Statement<'_>, out: &mut Vec<Occurrence>) {
+    match stmt {
+        Statement::ImportDeclaration(decl)
+            if !decl.import_kind.is_type() && import_has_value(decl) =>
+        {
+            out.push(Occurrence {
+                spec: decl.source.value.to_string(),
+                soft: false,
+                kind: RefKind::StaticImport,
+            });
+        }
+        Statement::ExportNamedDeclaration(decl) => {
+            if let Some(src) = &decl.source
+                && !decl.export_kind.is_type()
+                && export_named_has_value(decl)
+            {
+                out.push(Occurrence {
+                    spec: src.value.to_string(),
+                    soft: false,
+                    kind: RefKind::ReExport,
+                });
+            }
+        }
+        Statement::ExportAllDeclaration(decl) if !decl.export_kind.is_type() => {
+            out.push(Occurrence {
+                spec: decl.source.value.to_string(),
+                soft: false,
+                kind: RefKind::ReExport,
+            });
+        }
+        _ => {}
+    }
 }
 
 struct SpecVisitor {
@@ -314,5 +455,73 @@ mod tests {
             "#,
         );
         assert!(got.is_empty(), "no attributable string literal → skip");
+    }
+
+    /// The optimization invariant: `extract_optimized` must record the SAME
+    /// (spec, soft, kind) multiset as the baseline `extract` for every input,
+    /// regardless of which rung it takes. This is what lets the fast rungs stand
+    /// in for the full walk without changing a single phantom verdict.
+    #[test]
+    fn optimized_matches_baseline_across_all_shapes() {
+        use super::extract_optimized;
+        // One representative per rung + the tricky guard/type/dynamic cases.
+        let cases: &[(&str, &str)] = &[
+            // rung (a): no module edge at all.
+            ("a.mjs", "const x = 1 + 2; export const y = fromNowhere(x);"),
+            // rung (b): static ESM only (import/export-from, bare, type-mixed).
+            (
+                "b.mts",
+                r#"import a from "aa";
+                   import "side-effect";
+                   export { z } from "zz";
+                   export * from "ss";
+                   import type { T } from "type-pkg";
+                   import { type Only } from "inline-type-pkg";
+                   import { value, type Also } from "mixed-pkg";"#,
+            ),
+            // rung (c): require + require.resolve + guards + dynamic import.
+            (
+                "c.js",
+                r#"const hard = require("hard-dep");
+                   let opt; try { opt = require("soft-dep"); } catch {}
+                   if (typeof p !== "undefined") { require("system"); }
+                   const t = flag ? require("tern") : null;
+                   const a = cond && require("andg");
+                   require.resolve("rr");
+                   const d = await import("dyn-lit");
+                   require("pre" + "fix");
+                   import(`tpl${x}`);"#,
+            ),
+            // rung (c) via a lone dynamic import call, no require present.
+            (
+                "d.mjs",
+                r#"import base from "base-pkg";
+                   const m = await import("dyn-only");
+                   if (cond) { const g = await import("guarded-dyn"); }"#,
+            ),
+            // CRLF + form-feed between `import` and `(` must still route to
+            // rung (c) (regression guard for the has_dynamic_import_call ws set).
+            ("e.mjs", "const x = import\r\n(\"dyn-crlf\");"),
+            ("f.mjs", "const y = import\u{0c}(\"dyn-ff\");"),
+        ];
+        let sorted = |mut v: Vec<(String, bool, RefKind)>| {
+            v.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+            v
+        };
+        for (path, src) in cases {
+            let base = sorted(
+                extract(path, src)
+                    .into_iter()
+                    .map(|o| (o.spec, o.soft, o.kind))
+                    .collect(),
+            );
+            let opt = sorted(
+                extract_optimized(path, src)
+                    .into_iter()
+                    .map(|o| (o.spec, o.soft, o.kind))
+                    .collect(),
+            );
+            assert_eq!(base, opt, "rung parity mismatch for {path}");
+        }
     }
 }

--- a/crates/nub-phantom-scan/Cargo.toml
+++ b/crates/nub-phantom-scan/Cargo.toml
@@ -1,0 +1,29 @@
+# nub-phantom-scan — the reachable-graph phantom SCANNER, lifted out of the
+# excluded `nub-phantom` eval tool into a shared workspace crate so the shipped
+# `nub` CLI's dynamic per-version scan-on-link can drive package ejection from
+# the SAME graph-walk + classify pipeline the eval tool uses.
+#
+# LEAN by construction: graph.rs / classify.rs / manifest.rs import ZERO oxc
+# directly — they are pure Rust + serde_json over `nub-phantom-core`'s parser
+# subset. So linking this into the CLI costs only what `nub-phantom-core` already
+# costs (the oxc parser subset `verify_deps` already links), NOT the registry
+# fetch stack (reqwest/tar/flate2) that keeps `nub-phantom` excluded.
+[package]
+name = "nub-phantom-scan"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "nub_phantom_scan"
+path = "src/lib.rs"
+
+[dependencies]
+nub-phantom-core = { path = "../nub-phantom-core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/crates/nub-phantom-scan/src/bin/scan-bench.rs
+++ b/crates/nub-phantom-scan/src/bin/scan-bench.rs
@@ -1,0 +1,130 @@
+//! scan-bench — load-robust A/B of the phantom extraction ladder over a real
+//! installed tree. Enumerates every unique package version root under a given
+//! `node_modules`, then times the full reachable-graph scan of the whole set
+//! REPEATS times per mode (min-of-N reflects the least-preempted, true-CPU run on
+//! this always-contended host), for the baseline full-AST extractor vs the
+//! optimized ladder. Reports total scan ms + throughput per mode and the win.
+//!
+//! Usage: `scan-bench <node_modules-dir> [repeats]`
+//!   The `NUB_PHANTOM_BASELINE_EXTRACT` env toggle is set/cleared internally to
+//!   flip `nub_phantom_scan::graph`'s extractor between runs.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let dir = args
+        .next()
+        .expect("usage: scan-bench <node_modules-dir> [repeats]");
+    let repeats: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(9);
+    let roots = enumerate(Path::new(&dir));
+    eprintln!("unique package roots: {}", roots.len());
+
+    // Warm the page cache / filesystem once so neither mode eats first-read I/O.
+    for r in &roots {
+        let _ = nub_phantom_scan::scan_extracted(r);
+    }
+
+    let (base_ms, base_files) = time_mode(&roots, repeats, true);
+    let (opt_ms, opt_files) = time_mode(&roots, repeats, false);
+    assert_eq!(
+        base_files, opt_files,
+        "both modes must parse the same reachable file count"
+    );
+
+    let speedup = base_ms / opt_ms;
+    println!("files_parsed={base_files}");
+    println!(
+        "baseline_full_ast : min {base_ms:8.2} ms  ({:.0} files/s)",
+        base_files as f64 / (base_ms / 1000.0)
+    );
+    println!(
+        "optimized_ladder  : min {opt_ms:8.2} ms  ({:.0} files/s)",
+        opt_files as f64 / (opt_ms / 1000.0)
+    );
+    println!(
+        "speedup           : {speedup:.2}x   (saved {:.1} ms / scan)",
+        base_ms - opt_ms
+    );
+}
+
+/// Min-of-`repeats` total wall-ms to scan all `roots` once, in the given mode.
+fn time_mode(roots: &[PathBuf], repeats: usize, baseline: bool) -> (f64, usize) {
+    // Flip `graph::extract_file`'s extractor. Default (unset) = baseline
+    // `extract`; `=optimized` = the ladder. MUST match the env name graph.rs
+    // reads (`NUB_PHANTOM_EXTRACT_MODE`) or both legs silently run baseline.
+    if baseline {
+        // SAFETY: single-threaded bench, no concurrent env readers.
+        unsafe { std::env::remove_var("NUB_PHANTOM_EXTRACT_MODE") };
+    } else {
+        unsafe { std::env::set_var("NUB_PHANTOM_EXTRACT_MODE", "optimized") };
+    }
+    let mut best = f64::MAX;
+    let mut files = 0;
+    for _ in 0..repeats {
+        let t = Instant::now();
+        let mut f = 0;
+        for r in roots {
+            if let Some(res) = nub_phantom_scan::scan_extracted(r) {
+                f += res.files_analyzed;
+            }
+        }
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        if ms < best {
+            best = ms;
+        }
+        files = f;
+    }
+    (best, files)
+}
+
+fn enumerate(node_modules: &Path) -> Vec<PathBuf> {
+    let mut seen: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut out = Vec::new();
+    let mut stack = vec![node_modules.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(ft) = entry.file_type() else { continue };
+            let is_dir = ft.is_dir()
+                || (ft.is_symlink() && std::fs::metadata(&path).is_ok_and(|m| m.is_dir()));
+            if !is_dir {
+                continue;
+            }
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name == ".bin" || name == ".cache" {
+                continue;
+            }
+            // Only IMMEDIATE node_modules children are package roots: intra-package
+            // subpath dirs like @apollo/client/core each ship a package.json but
+            // are not separate installed packages.
+            let parent_name = path
+                .parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str());
+            let is_root = parent_name == Some("node_modules")
+                || (parent_name.is_some_and(|n| n.starts_with('@'))
+                    && path
+                        .parent()
+                        .and_then(|p| p.parent())
+                        .and_then(|gp| gp.file_name())
+                        .and_then(|n| n.to_str())
+                        == Some("node_modules"));
+            if is_root
+                && path.join("package.json").is_file()
+                && let Ok(canon) = std::fs::canonicalize(&path)
+                && seen.insert(canon.clone())
+            {
+                out.push(canon);
+            }
+            stack.push(path);
+        }
+    }
+    out
+}

--- a/crates/nub-phantom-scan/src/bin/scan-verdicts.rs
+++ b/crates/nub-phantom-scan/src/bin/scan-verdicts.rs
@@ -1,0 +1,83 @@
+//! scan-verdicts — dump the dynamic scanner's per-package verdict over an
+//! installed tree, for corpus-alignment spot-checking. Enumerates true
+//! node_modules-child package roots (canonicalize-dedup) and prints
+//! `name<TAB>has_unguarded_phantom<TAB>target,target,…` one per line.
+//!
+//! Usage: `scan-verdicts <node_modules-dir>`
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let dir = std::env::args()
+        .nth(1)
+        .expect("usage: scan-verdicts <node_modules-dir>");
+    let mut out: Vec<(String, bool, String)> = Vec::new();
+    for root in enumerate(Path::new(&dir)) {
+        let name = read_name(&root).unwrap_or_else(|| root.display().to_string());
+        match nub_phantom_scan::scan_extracted(&root) {
+            Some(r) => {
+                let targets: Vec<&str> = r.targets.iter().map(|t| t.name.as_str()).collect();
+                out.push((name, r.has_unguarded_phantom, targets.join(",")));
+            }
+            None => out.push((name, false, "<scan-miss>".into())),
+        }
+    }
+    out.sort();
+    out.dedup();
+    for (name, flagged, targets) in out {
+        println!("{name}\t{flagged}\t{targets}");
+    }
+}
+
+fn read_name(root: &Path) -> Option<String> {
+    let raw = std::fs::read(root.join("package.json")).ok()?;
+    let v: serde_json::Value = serde_json::from_slice(&raw).ok()?;
+    v.get("name").and_then(|n| n.as_str()).map(str::to_string)
+}
+
+fn enumerate(node_modules: &Path) -> Vec<PathBuf> {
+    let mut seen: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut out = Vec::new();
+    let mut stack = vec![node_modules.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(ft) = entry.file_type() else { continue };
+            let is_dir = ft.is_dir()
+                || (ft.is_symlink() && std::fs::metadata(&path).is_ok_and(|m| m.is_dir()));
+            if !is_dir {
+                continue;
+            }
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name == ".bin" || name == ".cache" {
+                continue;
+            }
+            let parent_name = path
+                .parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str());
+            let is_root = parent_name == Some("node_modules")
+                || (parent_name.is_some_and(|n| n.starts_with('@'))
+                    && path
+                        .parent()
+                        .and_then(|p| p.parent())
+                        .and_then(|gp| gp.file_name())
+                        .and_then(|n| n.to_str())
+                        == Some("node_modules"));
+            if is_root
+                && path.join("package.json").is_file()
+                && let Ok(canon) = std::fs::canonicalize(&path)
+                && seen.insert(canon.clone())
+            {
+                out.push(canon);
+            }
+            stack.push(path);
+        }
+    }
+    out
+}

--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -1,0 +1,237 @@
+//! Classify each referenced package against the manifest's declared surface.
+//!
+//! Aggregation rule: a package is HARD-needed if it is referenced by at least one
+//! UNGUARDED occurrence; it is soft only if EVERY occurrence is guarded (in a
+//! try/catch). The classification then answers the one question that matters —
+//! is this reference covered by something a consumer install makes resolvable?
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use crate::graph::Reference;
+use crate::manifest::Manifest;
+use nub_phantom_core::builtins::is_builtin;
+
+/// The verdict for one referenced package.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Verdict {
+    /// Undeclared and hard-required — a genuine phantom dependency.
+    HardPhantom,
+    /// Undeclared but only ever loaded under a try/catch — a soft/optional load,
+    /// not a hard break.
+    SoftPhantom,
+    /// Declared as an OPTIONAL peer (`peerDependenciesMeta.<x>.optional`). NOT a
+    /// phantom — the pick-your-plugin pattern. Tracked so the report can show how
+    /// much a naive scan over-counts.
+    DeclaredOptionalPeer,
+    /// Declared as a required peer.
+    DeclaredPeer,
+    /// Declared in `dependencies`/`optionalDependencies`, or bundled.
+    Declared,
+    /// A Node builtin.
+    Builtin,
+    /// A self reference (the package's own name / subpath).
+    SelfRef,
+}
+
+impl Verdict {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Verdict::HardPhantom => "hard-phantom",
+            Verdict::SoftPhantom => "soft-phantom",
+            Verdict::DeclaredOptionalPeer => "declared-optional-peer",
+            Verdict::DeclaredPeer => "declared-peer",
+            Verdict::Declared => "declared",
+            Verdict::Builtin => "builtin",
+            Verdict::SelfRef => "self",
+        }
+    }
+}
+
+/// One classified package reference.
+#[derive(Debug, Clone, Serialize)]
+pub struct Finding {
+    pub package: String,
+    pub verdict: Verdict,
+    /// True if every occurrence was guarded (try/catch or a conditional branch).
+    pub soft: bool,
+    /// Reachable from the package's main entry surface.
+    pub from_main: bool,
+    /// Reachable from a non-`.` `exports` subpath (the adapter surface).
+    pub from_subpath: bool,
+    /// Example raw specifiers (deduped) showing how it was referenced.
+    pub specifiers: Vec<String>,
+}
+
+impl Finding {
+    /// The subpath-adapter class the GVS-default bug hinges on: a HARD phantom
+    /// reachable ONLY from a non-`.` `exports` subpath (not the main graph). This
+    /// is the `<pkg>/<adapter>` that statically imports a consumer-installed
+    /// backend it never declares (`@hookform/resolvers/zod` → `zod`).
+    pub fn is_subpath_adapter(&self) -> bool {
+        self.verdict == Verdict::HardPhantom && self.from_subpath && !self.from_main
+    }
+}
+
+/// Classify all references against `manifest`. Returns one `Finding` per distinct
+/// referenced package, sorted by package name.
+pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
+    // Aggregate per package: soft-ness ANDs (hard wins), provenance ORs, collect
+    // example specs.
+    struct Agg {
+        all_soft: bool,
+        from_main: bool,
+        from_subpath: bool,
+        specs: Vec<String>,
+    }
+    let mut by_pkg: BTreeMap<String, Agg> = BTreeMap::new();
+    for r in references {
+        let e = by_pkg.entry(r.package.clone()).or_insert(Agg {
+            all_soft: true,
+            from_main: false,
+            from_subpath: false,
+            specs: Vec::new(),
+        });
+        e.all_soft &= r.soft;
+        e.from_main |= r.from_main;
+        e.from_subpath |= r.from_subpath;
+        if !e.specs.contains(&r.raw) {
+            e.specs.push(r.raw.clone());
+        }
+    }
+
+    by_pkg
+        .into_iter()
+        .map(|(package, agg)| {
+            let verdict = verdict_for(manifest, &package, agg.all_soft);
+            Finding {
+                package,
+                verdict,
+                soft: agg.all_soft,
+                from_main: agg.from_main,
+                from_subpath: agg.from_subpath,
+                specifiers: agg.specs,
+            }
+        })
+        .collect()
+}
+
+fn verdict_for(manifest: &Manifest, package: &str, all_soft: bool) -> Verdict {
+    if is_self(manifest, package) {
+        return Verdict::SelfRef;
+    }
+    if is_builtin(package) {
+        return Verdict::Builtin;
+    }
+    if manifest.deps.contains(package) || manifest.bundled.contains(package) {
+        return Verdict::Declared;
+    }
+    if manifest.optional_peers.contains(package) {
+        return Verdict::DeclaredOptionalPeer;
+    }
+    if manifest.required_peers.contains(package) {
+        return Verdict::DeclaredPeer;
+    }
+    // Undeclared.
+    if all_soft {
+        Verdict::SoftPhantom
+    } else {
+        Verdict::HardPhantom
+    }
+}
+
+/// A reference to the package's own name is a self import (resolvable via the
+/// package's own `exports`), never a phantom.
+fn is_self(manifest: &Manifest, package: &str) -> bool {
+    package == manifest.name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Verdict, classify};
+    use crate::graph::Reference;
+    use crate::manifest::Manifest;
+
+    fn refs(items: &[(&str, &str, bool)]) -> Vec<Reference> {
+        items
+            .iter()
+            .map(|(p, raw, soft)| Reference {
+                package: (*p).to_string(),
+                raw: (*raw).to_string(),
+                soft: *soft,
+                from_main: true,
+                from_subpath: false,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn declared_optional_peer_is_not_a_phantom() {
+        // @hookform/resolvers-style: zod is a DECLARED optional peer, referenced
+        // by the /zod subpath. Must NOT be flagged phantom.
+        let m = Manifest::parse(
+            br#"{"name":"@hookform/resolvers","peerDependencies":{"zod":"*"},
+                 "peerDependenciesMeta":{"zod":{"optional":true}}}"#,
+        )
+        .unwrap();
+        let f = classify(&m, &refs(&[("zod", "zod", false)]));
+        assert_eq!(f[0].verdict, Verdict::DeclaredOptionalPeer);
+    }
+
+    #[test]
+    fn undeclared_hard_require_is_a_phantom_soft_is_not() {
+        let m = Manifest::parse(br#"{"name":"pkg","dependencies":{"a":"1"}}"#).unwrap();
+        let f = classify(
+            &m,
+            &refs(&[
+                ("a", "a", false),         // declared
+                ("ghost", "ghost", false), // hard phantom
+                ("maybe", "maybe", true),  // soft phantom
+                ("fs", "fs", false),       // builtin
+            ]),
+        );
+        let v = |name: &str| f.iter().find(|x| x.package == name).unwrap().verdict;
+        assert_eq!(v("a"), Verdict::Declared);
+        assert_eq!(v("ghost"), Verdict::HardPhantom);
+        assert_eq!(v("maybe"), Verdict::SoftPhantom);
+        assert_eq!(v("fs"), Verdict::Builtin);
+    }
+
+    #[test]
+    fn one_hard_occurrence_beats_a_soft_one() {
+        // Same undeclared package referenced both guarded and unguarded → hard.
+        let m = Manifest::parse(br#"{"name":"pkg"}"#).unwrap();
+        let f = classify(&m, &refs(&[("x", "x", true), ("x", "x/sub", false)]));
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].verdict, Verdict::HardPhantom);
+        assert!(!f[0].soft);
+    }
+
+    #[test]
+    fn subpath_only_hard_phantom_is_the_adapter_class() {
+        let m = Manifest::parse(br#"{"name":"@hookform/resolvers"}"#).unwrap();
+        // A hard phantom reached only from a subpath export is the adapter class;
+        // one reached from the main graph is not.
+        let subpath_only = Reference {
+            package: "zod".into(),
+            raw: "zod/v4/core".into(),
+            soft: false,
+            from_main: false,
+            from_subpath: true,
+        };
+        let main_reached = Reference {
+            package: "junk".into(),
+            raw: "junk".into(),
+            soft: false,
+            from_main: true,
+            from_subpath: false,
+        };
+        let f = classify(&m, &[subpath_only, main_reached]);
+        let zod = f.iter().find(|x| x.package == "zod").unwrap();
+        let junk = f.iter().find(|x| x.package == "junk").unwrap();
+        assert!(zod.is_subpath_adapter());
+        assert!(!junk.is_subpath_adapter());
+    }
+}

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -1,0 +1,651 @@
+//! Walk the module graph reachable from a package's PUBLISHED entry points,
+//! collecting the bare-specifier occurrences seen along the way.
+//!
+//! Restricting to reachable files is what keeps a `devDependencies`-only import
+//! in a test/example file (never referenced by `exports`/`main`/`bin`) from being
+//! mistaken for a phantom: those files are simply never reached. Relative edges
+//! are followed (with Node-style extension/index resolution); bare edges become
+//! candidate dependencies.
+//!
+//! The walk is source-agnostic ([`FileSource`]): [`walk`] drives it over an
+//! extracted directory tree (post-link), [`walk_index`] over a CAS-backed
+//! `PackageIndex` (extract-time, before any navigable tree exists). Both share
+//! the single [`walk_generic`] traversal, so an extract-time scan is guaranteed
+//! to reach the same file set — and produce the same references — as a post-link
+//! scan of the materialized tree.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::manifest::{Entry, EntryKind};
+use nub_phantom_core::extract::{Occurrence, extract, extract_optimized};
+use nub_phantom_core::specifier::{self, SpecKind};
+
+/// Extract one file's specifiers.
+///
+/// PRODUCTION DEFAULT is the BASELINE full-AST-visit `extract`, NOT the
+/// static-imports-only `extract_optimized` ladder. This is the measured outcome
+/// of the extraction-optimization investigation (the maintainer's ask): the
+/// ladder was built, proven output-identical (see `extract_optimized`'s parity
+/// test), and benchmarked inline over real trees — and it REGRESSES the scan
+/// ~3-13% rather than helping. The scan cost is dominated by the oxc PARSE (which
+/// builds the full AST to recover specifiers regardless — the deep-visit depth
+/// the ladder skips is cheap next to it) and by fs I/O + the graph walk, not by
+/// AST traversal; and reachable published npm code is CJS/`require`-heavy, so the
+/// ladder's guard-aware full path is the COMMON case, not the exception it
+/// assumed. So production stays on the simpler, marginally-faster baseline. The
+/// `NUB_PHANTOM_EXTRACT_MODE=optimized` toggle re-enables the ladder for A/B
+/// reproduction (scan-bench). Reading one env var per file is negligible next to
+/// a parse; it is a pure measurement seam.
+fn extract_file(rel: &str, source: &str) -> Vec<Occurrence> {
+    if std::env::var_os("NUB_PHANTOM_EXTRACT_MODE").is_some_and(|v| v == "optimized") {
+        extract_optimized(rel, source)
+    } else {
+        extract(rel, source)
+    }
+}
+
+/// Provenance bit: reached from the main surface (`main`/`bin`/`exports."."`).
+const FROM_MAIN: u8 = 0b01;
+/// Provenance bit: reached from a non-`.` `exports` subpath (the adapter surface).
+const FROM_SUBPATH: u8 = 0b10;
+
+/// A bare-specifier reference collected from a reachable file.
+#[derive(Debug, Clone)]
+pub struct Reference {
+    /// Package name the specifier resolves to (`@scope/name` or `name`).
+    pub package: String,
+    /// The raw specifier (kept for the report — shows the exact subpath).
+    pub raw: String,
+    /// Guarded (try/catch or a conditional branch) at every occurrence collapses
+    /// to soft; a single unguarded occurrence makes the package hard.
+    pub soft: bool,
+    /// Reachable from the main entry surface.
+    pub from_main: bool,
+    /// Reachable from a non-`.` `exports` subpath — the "consumer opts into
+    /// `<pkg>/<subpath>`" adapter surface. A hard phantom reachable ONLY from a
+    /// subpath (not main) is the subpath-adapter class.
+    pub from_subpath: bool,
+}
+
+/// Result of the reachable-module walk.
+#[derive(Debug, Default)]
+pub struct Walk {
+    pub references: Vec<Reference>,
+    pub files_analyzed: usize,
+    /// Relative imports that could not be resolved to a file on disk (a tell of
+    /// an incomplete tarball or an exotic resolver condition; reported, not fatal).
+    pub unresolved_relative: usize,
+}
+
+/// Cap the walk so a pathological package (thousands of files) can't stall a
+/// scan. Real published entry graphs are far smaller.
+const MAX_FILES: usize = 6000;
+
+/// The two package-relative resolution + read operations the walk needs,
+/// abstracted over its backing store. Implemented by [`FsSource`] (an extracted
+/// tree) and [`IndexSource`] (a CAS-backed `PackageIndex`); the single generic
+/// [`walk_generic`] keeps the two backings behaviorally identical.
+trait FileSource {
+    /// A resolved, canonical file identifier within the package.
+    type Key: Ord + Clone;
+    /// Resolve a published entry path (package-root-relative) to a file.
+    fn resolve_entry(&self, entry_path: &str) -> Option<Self::Key>;
+    /// Resolve a relative specifier as written inside `from`.
+    fn resolve_rel(&self, from: &Self::Key, spec: &str) -> Option<Self::Key>;
+    /// Read a file's UTF-8 content (None on read/decode failure).
+    fn read(&self, key: &Self::Key) -> Option<String>;
+    /// The package-relative path for `key` — the parser's `SourceType` hint.
+    fn rel_path(&self, key: &Self::Key) -> String;
+}
+
+/// Walk from `entry_points`, following relative edges and collecting bare
+/// references. Each reachable file accumulates a provenance mask (which entry
+/// surface(s) reach it); a bare reference inherits its file's final mask, so the
+/// report can separate subpath-adapter phantoms from main-graph ones.
+///
+/// Two phases keep provenance correct across diamonds: (1) BFS parses each file
+/// once (cached) and propagates provenance bits to fixpoint — a file re-reached
+/// with new bits is re-queued for propagation only, never re-parsed; (2) build
+/// references from the cache using each file's FINAL mask.
+fn walk_generic<S: FileSource>(source: &S, entry_points: &[Entry]) -> Walk {
+    let mut result = Walk::default();
+    let mut parsed: BTreeMap<S::Key, Vec<Occurrence>> = BTreeMap::new();
+    let mut flags: BTreeMap<S::Key, u8> = BTreeMap::new();
+    let mut queue: VecDeque<S::Key> = VecDeque::new();
+
+    for ep in entry_points {
+        if let Some(resolved) = source.resolve_entry(&ep.path) {
+            let bit = match ep.kind {
+                EntryKind::Main => FROM_MAIN,
+                EntryKind::Subpath => FROM_SUBPATH,
+            };
+            if add_flags(&mut flags, &resolved, bit) {
+                queue.push_back(resolved);
+            }
+        }
+    }
+
+    while let Some(file) = queue.pop_front() {
+        let fflags = *flags.get(&file).unwrap_or(&0);
+        // Parse once; a re-queue for provenance propagation reuses the cache.
+        if !parsed.contains_key(&file) {
+            if parsed.len() >= MAX_FILES {
+                continue;
+            }
+            let Some(text) = source.read(&file) else {
+                continue;
+            };
+            let rel = source.rel_path(&file);
+            // Extract via the BASELINE full-AST path by default (the optimized
+            // ladder was measured to regress; `NUB_PHANTOM_EXTRACT_MODE=optimized`
+            // re-enables it for A/B). See `extract_file`.
+            parsed.insert(file.clone(), extract_file(&rel, &text));
+        }
+        // Collect relative edges first (immutable borrow of the cache) then
+        // propagate — avoids holding a borrow across the flags mutation.
+        let mut targets = Vec::new();
+        for occ in &parsed[&file] {
+            if let SpecKind::Relative = specifier::classify(&occ.spec) {
+                match source.resolve_rel(&file, &occ.spec) {
+                    Some(t) => targets.push(t),
+                    None => result.unresolved_relative += 1,
+                }
+            }
+        }
+        // `ImportsHash` (self) and `NonPackage` (URL/virtual/internal) are not
+        // dependency edges; only `Bare` references are collected in phase 2.
+        for t in targets {
+            if add_flags(&mut flags, &t, fflags) {
+                queue.push_back(t);
+            }
+        }
+    }
+
+    result.files_analyzed = parsed.len();
+    for (file, occs) in &parsed {
+        let fflags = *flags.get(file).unwrap_or(&0);
+        for occ in occs {
+            if let SpecKind::Bare(package) = specifier::classify(&occ.spec) {
+                result.references.push(Reference {
+                    package,
+                    raw: occ.spec.clone(),
+                    soft: occ.soft,
+                    from_main: fflags & FROM_MAIN != 0,
+                    from_subpath: fflags & FROM_SUBPATH != 0,
+                });
+            }
+        }
+    }
+    result
+}
+
+/// Walk an already-extracted package tree rooted at `root`.
+pub fn walk(root: &Path, entry_points: &[Entry]) -> Walk {
+    walk_generic(&FsSource { root }, entry_points)
+}
+
+/// Walk a CAS-backed package: `files` are `(package-relative-path, absolute
+/// CAS-blob-path)` pairs, as produced from a `PackageIndex` at extract time.
+/// Resolution runs over the relative-path key set; content is read from the
+/// paired blob. Output-identical to [`walk`] over the same package's extracted
+/// tree (both drive [`walk_generic`]) for all real package layouts; see
+/// [`normalize_rel_join`] for the one accepted divergence on malformed
+/// (escape-and-re-enter-by-root-name) specifiers that never appear in practice.
+pub fn walk_index(files: &[(String, PathBuf)], entry_points: &[Entry]) -> Walk {
+    let map: BTreeMap<String, PathBuf> = files.iter().cloned().collect();
+    walk_generic(&IndexSource { files: map }, entry_points)
+}
+
+/// OR `bit` into `key`'s provenance mask. Returns true if the mask GREW (new
+/// file, or new bits) — the caller then (re)queues it so the new provenance
+/// propagates to its edges. The 2-bit lattice bounds re-queues to ≤2 per file.
+fn add_flags<K: Ord + Clone>(flags: &mut BTreeMap<K, u8>, key: &K, bit: u8) -> bool {
+    let entry = flags.entry(key.clone()).or_insert(0);
+    let before = *entry;
+    *entry |= bit;
+    *entry != before
+}
+
+/// Bound on `main`-chasing recursion. A dir whose `package.json` `main` points
+/// back at itself (`"."`/`""`/`"./"`) or a mutual `main` cycle across dirs would
+/// otherwise recurse forever → a stack-overflow ABORT that kills the whole scan
+/// (a process abort, not a catchable panic). Such manifests occur in the wild, so
+/// the cap is a hard robustness requirement, not a nicety.
+const MAX_RESOLVE_DEPTH: u32 = 16;
+
+/// Node-style resolution extensions, in priority order.
+const RESOLVE_EXTS: [&str; 8] = ["js", "cjs", "mjs", "jsx", "ts", "tsx", "mts", "cts"];
+
+// --- Filesystem-backed source (extracted tree) ---------------------------------
+
+struct FsSource<'a> {
+    root: &'a Path,
+}
+
+impl FileSource for FsSource<'_> {
+    type Key = PathBuf;
+
+    fn resolve_entry(&self, entry_path: &str) -> Option<PathBuf> {
+        fs_resolve(self.root, self.root, entry_path, 0)
+    }
+
+    fn resolve_rel(&self, from: &PathBuf, spec: &str) -> Option<PathBuf> {
+        let from_dir = from.parent().unwrap_or(self.root);
+        fs_resolve(self.root, from_dir, spec, 0)
+    }
+
+    fn read(&self, key: &PathBuf) -> Option<String> {
+        fs::read_to_string(key).ok()
+    }
+
+    fn rel_path(&self, key: &PathBuf) -> String {
+        key.strip_prefix(self.root)
+            .unwrap_or(key)
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+fn fs_resolve(root: &Path, from_dir: &Path, spec: &str, depth: u32) -> Option<PathBuf> {
+    if depth > MAX_RESOLVE_DEPTH {
+        return None;
+    }
+    let joined = from_dir.join(spec);
+    // Keep the walk inside the package tree (a `../../` that climbs out is not
+    // part of the published surface).
+    let base = normalize(&joined);
+    if !base.starts_with(root) {
+        return None;
+    }
+
+    // 1. Exact file.
+    if is_js_file(&base) {
+        return Some(base);
+    }
+    // 2. `base.<ext>`.
+    for ext in RESOLVE_EXTS {
+        let cand = with_appended_ext(&base, ext);
+        if is_js_file(&cand) {
+            return Some(cand);
+        }
+    }
+    // 3. `base/index.<ext>`.
+    for ext in RESOLVE_EXTS {
+        let cand = base.join(format!("index.{ext}"));
+        if is_js_file(&cand) {
+            return Some(cand);
+        }
+    }
+    // 4. `base/package.json` → its `main` (depth-bounded; see MAX_RESOLVE_DEPTH).
+    let pkg = base.join("package.json");
+    if let Ok(raw) = fs::read(&pkg) {
+        if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&raw)
+            && let Some(main) = v.get("main").and_then(|m| m.as_str())
+        {
+            return fs_resolve(root, &base, main, depth + 1);
+        }
+        // package.json with no main → default index.js in that dir.
+        for ext in RESOLVE_EXTS {
+            let cand = base.join(format!("index.{ext}"));
+            if is_js_file(&cand) {
+                return Some(cand);
+            }
+        }
+    }
+    None
+}
+
+/// Append an extension to a path's file name (`a/b` + `js` → `a/b.js`), rather
+/// than replacing an existing one (`a/b.min` must become `a/b.min.js`).
+fn with_appended_ext(base: &Path, ext: &str) -> PathBuf {
+    let mut s = base.as_os_str().to_os_string();
+    s.push(".");
+    s.push(ext);
+    PathBuf::from(s)
+}
+
+fn is_js_file(p: &Path) -> bool {
+    if !p.is_file() {
+        return false;
+    }
+    let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    crate::manifest::is_js_like(name)
+}
+
+/// Lexically normalize `.`/`..` segments WITHOUT touching the filesystem (we do
+/// not want symlink resolution; a tarball has none anyway). Used only to enforce
+/// the stay-under-root invariant.
+fn normalize(p: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in p.components() {
+        use std::path::Component::*;
+        match comp {
+            ParentDir => {
+                out.pop();
+            }
+            CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+// --- Index-backed source (CAS blobs, no navigable tree) ------------------------
+
+struct IndexSource {
+    /// Package-relative path (POSIX `/`) → absolute CAS blob path.
+    files: BTreeMap<String, PathBuf>,
+}
+
+impl FileSource for IndexSource {
+    type Key = String;
+
+    fn resolve_entry(&self, entry_path: &str) -> Option<String> {
+        self.resolve("", entry_path, 0)
+    }
+
+    fn resolve_rel(&self, from: &String, spec: &str) -> Option<String> {
+        self.resolve(parent_rel(from), spec, 0)
+    }
+
+    fn read(&self, key: &String) -> Option<String> {
+        fs::read_to_string(self.files.get(key)?).ok()
+    }
+
+    fn rel_path(&self, key: &String) -> String {
+        key.clone()
+    }
+}
+
+impl IndexSource {
+    /// True if `rel` is a JS-like file present in the index — the index analogue
+    /// of `is_js_file` (name check + existence), which the fs ladder relies on.
+    fn contains_js(&self, rel: &str) -> bool {
+        crate::manifest::is_js_like(rel) && self.files.contains_key(rel)
+    }
+
+    /// Index analogue of [`fs_resolve`], step-for-step: exact → `base.<ext>` →
+    /// `base/index.<ext>` → `base/package.json` `main`. Resolution is over the
+    /// relpath key set; the `main` chase reads the package.json blob.
+    fn resolve(&self, from_dir: &str, spec: &str, depth: u32) -> Option<String> {
+        if depth > MAX_RESOLVE_DEPTH {
+            return None;
+        }
+        // `None` == escaped the package root, mirroring fs `!starts_with(root)`.
+        let base = normalize_rel_join(from_dir, spec)?;
+
+        if self.contains_js(&base) {
+            return Some(base);
+        }
+        for ext in RESOLVE_EXTS {
+            let cand = format!("{base}.{ext}");
+            if self.contains_js(&cand) {
+                return Some(cand);
+            }
+        }
+        for ext in RESOLVE_EXTS {
+            let cand = join_rel(&base, &format!("index.{ext}"));
+            if self.contains_js(&cand) {
+                return Some(cand);
+            }
+        }
+        let pkg = join_rel(&base, "package.json");
+        if let Some(blob) = self.files.get(&pkg)
+            && let Ok(raw) = fs::read(blob)
+        {
+            if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&raw)
+                && let Some(main) = v.get("main").and_then(|m| m.as_str())
+            {
+                return self.resolve(&base, main, depth + 1);
+            }
+            for ext in RESOLVE_EXTS {
+                let cand = join_rel(&base, &format!("index.{ext}"));
+                if self.contains_js(&cand) {
+                    return Some(cand);
+                }
+            }
+        }
+        None
+    }
+}
+
+/// The directory portion of a POSIX relpath (`a/b/c.js` → `a/b`, `c.js` → ``).
+fn parent_rel(rel: &str) -> &str {
+    rel.rsplit_once('/').map_or("", |(dir, _)| dir)
+}
+
+/// Join a relpath dir and a leaf (`` + `x` → `x`; `a/b` + `x` → `a/b/x`).
+fn join_rel(base: &str, leaf: &str) -> String {
+    if base.is_empty() {
+        leaf.to_string()
+    } else {
+        format!("{base}/{leaf}")
+    }
+}
+
+/// Join `from_dir` + `spec` as POSIX relpaths and collapse `.`/`..`. Returns
+/// `None` when a `..` climbs above the package root — the index analogue of the
+/// fs `normalize` + `!starts_with(root)` reject. `from_dir` is the importing
+/// file's directory (`""` at the root); `spec` may itself contain `/`.
+fn normalize_rel_join(from_dir: &str, spec: &str) -> Option<String> {
+    // An absolute specifier (`/foo`) replaces the base under fs `Path::join` and
+    // then escapes the package root → fs resolves nothing. Reject it here rather
+    // than dropping the leading `/` as an empty segment (which would follow an
+    // edge fs never does). One fs corner is deliberately NOT matched: a spec that
+    // climbs out and re-enters via the root's OWN basename (`../<rootname>/x`)
+    // resolves under fs by absolute-path name coincidence but yields None here —
+    // that input is malformed/never-published, and the stricter reject is the
+    // safer reading, so this is an accepted divergence rather than a bug.
+    if spec.starts_with('/') {
+        return None;
+    }
+    let mut stack: Vec<&str> = from_dir.split('/').filter(|c| !c.is_empty()).collect();
+    for comp in spec.split('/') {
+        match comp {
+            "" | "." => {}
+            ".." => {
+                // A pop with nothing to remove would climb above the root.
+                stack.pop()?;
+            }
+            other => stack.push(other),
+        }
+    }
+    Some(stack.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{walk, walk_index};
+    use crate::manifest::{Entry, EntryKind};
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("nub-phantom-graph-{}-{}", name, std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn main_entry(path: &str) -> Entry {
+        Entry {
+            path: path.to_string(),
+            kind: EntryKind::Main,
+        }
+    }
+
+    /// Build the `(relpath, blob-path)` pairs `walk_index` expects from an
+    /// on-disk tree — here the blob IS the real file, so content is identical.
+    fn index_of(root: &std::path::Path) -> Vec<(String, PathBuf)> {
+        fn rec(base: &std::path::Path, cur: &std::path::Path, out: &mut Vec<(String, PathBuf)>) {
+            for e in fs::read_dir(cur).unwrap().flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    rec(base, &p, out);
+                } else {
+                    let rel = p
+                        .strip_prefix(base)
+                        .unwrap()
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    out.push((rel, p));
+                }
+            }
+        }
+        let mut out = Vec::new();
+        rec(root, root, &mut out);
+        out
+    }
+
+    #[test]
+    fn follows_relative_edges_collects_bare_ignores_unreached() {
+        let root = scratch("reach");
+        // entry → ./util (reached) imports "declared-dep"; orphan test file
+        // imports "dev-only" but is never referenced.
+        fs::write(
+            root.join("index.js"),
+            "require('./util'); require('real-dep');",
+        )
+        .unwrap();
+        fs::write(root.join("util.js"), "import x from 'util-dep';").unwrap();
+        fs::write(root.join("test.js"), "require('dev-only');").unwrap();
+
+        let w = walk(&root, &[main_entry("index.js")]);
+        let pkgs: Vec<_> = w.references.iter().map(|r| r.package.as_str()).collect();
+        assert!(pkgs.contains(&"real-dep"));
+        assert!(pkgs.contains(&"util-dep"));
+        assert!(
+            !pkgs.contains(&"dev-only"),
+            "unreached test file must not contribute"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn self_cyclic_main_does_not_stack_overflow() {
+        // A dir whose package.json `main` points back at itself would recurse
+        // forever without the depth cap → process abort, killing the whole scan.
+        let root = scratch("cycle");
+        fs::write(root.join("index.js"), "require('./lib');").unwrap();
+        fs::create_dir_all(root.join("lib")).unwrap();
+        fs::write(root.join("lib/package.json"), r#"{"main":"."}"#).unwrap();
+        // Must return (not abort); the cyclic dir simply resolves to nothing.
+        let w = walk(&root, &[main_entry("index.js")]);
+        assert_eq!(w.files_analyzed, 1); // only index.js; lib/ resolves to no file
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn subpath_provenance_separates_adapter_from_main_graph() {
+        let root = scratch("subpath");
+        // main graph imports `main-dep`; the `./zod` adapter subpath imports
+        // `backend-zod`. The zod import must carry from_subpath && !from_main.
+        fs::write(root.join("index.js"), "require('main-dep');").unwrap();
+        fs::write(root.join("zod.js"), "import 'backend-zod';").unwrap();
+
+        let w = walk(
+            &root,
+            &[
+                main_entry("index.js"),
+                Entry {
+                    path: "zod.js".to_string(),
+                    kind: EntryKind::Subpath,
+                },
+            ],
+        );
+        let zod = w
+            .references
+            .iter()
+            .find(|r| r.package == "backend-zod")
+            .unwrap();
+        assert!(zod.from_subpath && !zod.from_main, "adapter-only backend");
+        let main = w
+            .references
+            .iter()
+            .find(|r| r.package == "main-dep")
+            .unwrap();
+        assert!(main.from_main && !main.from_subpath, "main-graph dep");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn index_walk_matches_fs_walk_on_nested_resolution() {
+        // A tree exercising every resolution rung: bare edge, `./x` → `x.js`,
+        // a directory `./sub` → `sub/index.js`, and a `./pkg` dir resolved via
+        // its `package.json` main. The index walk must reach the same files and
+        // collect the same bare references as the fs walk.
+        let root = scratch("index-parity");
+        fs::write(
+            root.join("index.js"),
+            "require('./util'); require('./sub'); require('./pkg'); require('root-dep');",
+        )
+        .unwrap();
+        fs::write(root.join("util.js"), "import 'util-dep';").unwrap();
+        fs::create_dir_all(root.join("sub")).unwrap();
+        fs::write(root.join("sub/index.js"), "require('sub-dep');").unwrap();
+        fs::create_dir_all(root.join("pkg")).unwrap();
+        fs::write(root.join("pkg/package.json"), r#"{"main":"./entry.js"}"#).unwrap();
+        fs::write(root.join("pkg/entry.js"), "import 'pkg-dep';").unwrap();
+
+        let eps = [main_entry("index.js")];
+        let fs_walk = walk(&root, &eps);
+        let idx_walk = walk_index(&index_of(&root), &eps);
+
+        assert_eq!(fs_walk.files_analyzed, idx_walk.files_analyzed);
+        let mut a: Vec<_> = fs_walk
+            .references
+            .iter()
+            .map(|r| r.package.clone())
+            .collect();
+        let mut b: Vec<_> = idx_walk
+            .references
+            .iter()
+            .map(|r| r.package.clone())
+            .collect();
+        a.sort();
+        b.sort();
+        assert_eq!(a, b);
+        assert!(a.iter().any(|p| p == "util-dep"));
+        assert!(a.iter().any(|p| p == "sub-dep"));
+        assert!(a.iter().any(|p| p == "pkg-dep"));
+        assert!(a.iter().any(|p| p == "root-dep"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn index_walk_matches_fs_walk_on_absolute_specifier() {
+        // An absolute specifier classifies as Relative and reaches the resolver;
+        // fs `Path::join` makes it escape the root (→ None), and the index resolver
+        // must reject it identically instead of treating the leading `/` as a
+        // no-op. Parity: both walks reach only index.js and collect only `real`.
+        let root = scratch("abs-spec");
+        fs::write(
+            root.join("index.js"),
+            "require('/abs/thing'); require('real');",
+        )
+        .unwrap();
+        let eps = [main_entry("index.js")];
+        let fs_walk = walk(&root, &eps);
+        let idx_walk = walk_index(&index_of(&root), &eps);
+        assert_eq!(fs_walk.files_analyzed, 1);
+        assert_eq!(fs_walk.files_analyzed, idx_walk.files_analyzed);
+        let mut a: Vec<_> = fs_walk
+            .references
+            .iter()
+            .map(|r| r.package.clone())
+            .collect();
+        let mut b: Vec<_> = idx_walk
+            .references
+            .iter()
+            .map(|r| r.package.clone())
+            .collect();
+        a.sort();
+        b.sort();
+        assert_eq!(a, b);
+        assert_eq!(a, vec!["real".to_string()]);
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/crates/nub-phantom-scan/src/lib.rs
+++ b/crates/nub-phantom-scan/src/lib.rs
@@ -1,0 +1,297 @@
+//! nub-phantom-scan — scan an already-extracted package version's PUBLISHED,
+//! reachable code for UNDECLARED (phantom) dependencies, and reduce it to the
+//! target-agnostic boolean the disk-eject decision needs.
+//!
+//! This is the shared home of the reachable-graph walk + verdict layer, lifted
+//! out of the excluded `nub-phantom` eval tool so the shipped `nub` CLI's dynamic
+//! per-version scan-on-link drives ejection from the SAME pipeline. The pipeline:
+//!
+//!   walk the module graph from `exports`/`main`/`bin` → extract import/require
+//!   specifiers (via `nub-phantom-core`'s oxc parser) → classify each against the
+//!   declared surface.
+//!
+//! (The `extract_optimized` static-imports-only ladder was investigated + proven
+//! output-identical but MEASURED to regress the scan — production uses the
+//! baseline extractor; see `graph::extract_file` for the finding.)
+//!
+//! For the dynamic detector the actionable output is [`ScanResult`]: a single
+//! `has_unguarded_phantom` boolean (does this version statically, unguardedly
+//! import a package it does not declare?) plus the offending target set with
+//! provenance. Disk-eject is target-agnostic, so the boolean is all the eject
+//! DECISION consults; the targets carry the provenance a later transitive
+//! (subtree) reachability query would use.
+
+pub mod classify;
+pub mod graph;
+pub mod manifest;
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use classify::Finding;
+pub use classify::Verdict;
+use manifest::Manifest;
+
+/// One undeclared target a scanned version pulls in, with the provenance bits the
+/// eject reachability query needs. Serialized into the per-integrity sidecar.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PhantomTarget {
+    /// The undeclared package name (`zod`, `@apify/datastructures`).
+    pub name: String,
+    /// Reached from the package's main entry surface.
+    pub from_main: bool,
+    /// Reached from a non-`.` `exports` subpath (the adapter surface).
+    pub from_subpath: bool,
+}
+
+/// The per-version scan verdict — the immutable, per-content-integrity payload
+/// the dynamic detector caches and feeds to disk-eject.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScanResult {
+    /// The eject DECISION: at least one HARD (unguarded) undeclared import in the
+    /// reachable published graph. Disk-eject is target-agnostic, so this boolean
+    /// is what the eject decision consults.
+    pub has_unguarded_phantom: bool,
+    /// The offending undeclared targets (empty when `has_unguarded_phantom` is
+    /// false). Provenance-tagged for the later transitive/subtree reachability
+    /// query; the per-package eject decision itself needs only the boolean.
+    pub targets: Vec<PhantomTarget>,
+    /// Reachable files parsed (diagnostic — lets the caller see scan breadth).
+    pub files_analyzed: usize,
+}
+
+/// Scan an already-extracted package tree rooted at `root` (the dir holding
+/// `package.json`) and reduce to a [`ScanResult`]. A tree that can't be parsed
+/// (no/!readable `package.json`) yields `None` — the caller treats it as
+/// "nothing to eject" (a scan miss must never itself force materialization).
+pub fn scan_extracted(root: &Path) -> Option<ScanResult> {
+    let raw = std::fs::read(root.join("package.json")).ok()?;
+    let manifest = Manifest::parse(&raw)?;
+    let walk = graph::walk(root, &manifest.entry_points);
+    Some(reduce(&manifest, &walk))
+}
+
+/// Scan a package straight from its CAS-backed file index — the EXTRACT-TIME
+/// entry, run inside the store's tarball import before any navigable tree
+/// exists. `files` are `(package-relative-path, absolute CAS-blob-path)` pairs
+/// projected from a `PackageIndex`: resolution runs over the relpath key set and
+/// content is read from the paired blob. Returns the SAME [`ScanResult`] as
+/// [`scan_extracted`] over the equivalent extracted tree (both reduce a shared
+/// [`graph`] walk). `None` when the package has no parseable `package.json`.
+pub fn scan_index(files: &[(String, PathBuf)]) -> Option<ScanResult> {
+    let pkg_json = files.iter().find(|(rel, _)| rel == "package.json")?;
+    let raw = std::fs::read(&pkg_json.1).ok()?;
+    let manifest = Manifest::parse(&raw)?;
+    let walk = graph::walk_index(files, &manifest.entry_points);
+    Some(reduce(&manifest, &walk))
+}
+
+/// Reduce a completed reachable-graph walk to the eject [`ScanResult`]: classify
+/// each reference, keep the HARD (unguarded) undeclared ones as targets, and set
+/// the boolean. The single reduction shared by both scan entries — output
+/// identity of `scan_index` and `scan_extracted` rests on this.
+fn reduce(manifest: &Manifest, walk: &graph::Walk) -> ScanResult {
+    let findings = classify::classify(manifest, &walk.references);
+    let targets: Vec<PhantomTarget> = findings
+        .iter()
+        .filter(|f| f.verdict == Verdict::HardPhantom)
+        .map(|f| PhantomTarget {
+            name: f.package.clone(),
+            from_main: f.from_main,
+            from_subpath: f.from_subpath,
+        })
+        .collect();
+    ScanResult {
+        has_unguarded_phantom: !targets.is_empty(),
+        targets,
+        files_analyzed: walk.files_analyzed,
+    }
+}
+
+/// The full per-package report (all verdict categories, not just hard phantoms) —
+/// used by the eval tool and the A/B corpus harness. `scan_extracted` is the lean
+/// production entry; this is the diagnostic one.
+#[derive(Debug, Serialize)]
+pub struct PackageReport {
+    pub name: String,
+    pub version: String,
+    pub findings: Vec<Finding>,
+    pub files_analyzed: usize,
+    pub unresolved_relative: usize,
+}
+
+impl PackageReport {
+    pub fn count(&self, v: Verdict) -> usize {
+        self.findings.iter().filter(|f| f.verdict == v).count()
+    }
+    pub fn hard_phantoms(&self) -> impl Iterator<Item = &Finding> {
+        self.findings
+            .iter()
+            .filter(|f| f.verdict == Verdict::HardPhantom)
+    }
+    pub fn subpath_adapter_phantoms(&self) -> impl Iterator<Item = &Finding> {
+        self.findings.iter().filter(|f| f.is_subpath_adapter())
+    }
+    pub fn naive_phantom_count(&self) -> usize {
+        self.findings
+            .iter()
+            .filter(|f| {
+                matches!(
+                    f.verdict,
+                    Verdict::HardPhantom | Verdict::SoftPhantom | Verdict::DeclaredOptionalPeer
+                )
+            })
+            .count()
+    }
+}
+
+/// Analyze an already-extracted package tree into a full [`PackageReport`].
+pub fn analyze_extracted(root: &Path, version: &str) -> Result<PackageReport, String> {
+    let raw =
+        std::fs::read(root.join("package.json")).map_err(|e| format!("read package.json: {e}"))?;
+    let manifest = Manifest::parse(&raw).ok_or("unparseable package.json / no name")?;
+    let walk = graph::walk(root, &manifest.entry_points);
+    let findings = classify::classify(&manifest, &walk.references);
+    Ok(PackageReport {
+        name: manifest.name,
+        version: version.to_string(),
+        findings,
+        files_analyzed: walk.files_analyzed,
+        unresolved_relative: walk.unresolved_relative,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PathBuf, Verdict, analyze_extracted, scan_extracted, scan_index};
+    use std::fs;
+
+    /// `(relpath, blob-path)` pairs for an on-disk tree — the blob is the real
+    /// file, so `scan_index` reads byte-identical content to `scan_extracted`.
+    fn index_of(root: &std::path::Path) -> Vec<(String, PathBuf)> {
+        fn rec(base: &std::path::Path, cur: &std::path::Path, out: &mut Vec<(String, PathBuf)>) {
+            for e in fs::read_dir(cur).unwrap().flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    rec(base, &p, out);
+                } else {
+                    let rel = p
+                        .strip_prefix(base)
+                        .unwrap()
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    out.push((rel, p));
+                }
+            }
+        }
+        let mut out = Vec::new();
+        rec(root, root, &mut out);
+        out
+    }
+
+    fn fixture() -> std::path::PathBuf {
+        // Per-call unique dir: several tests build a fixture concurrently under
+        // cargo's parallel runner, so a shared `process::id()`-only path would
+        // let one test's cleanup wipe another's tree mid-scan.
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static SEQ: AtomicU32 = AtomicU32::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "nub-phantom-scan-e2e-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("package.json"),
+            r#"{
+                "name": "demo",
+                "main": "index.js",
+                "exports": { ".": "./index.js", "./adapter": "./adapter.js" },
+                "dependencies": { "declared-dep": "1" },
+                "peerDependencies": { "zod": "*" },
+                "peerDependenciesMeta": { "zod": { "optional": true } }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("index.js"),
+            r#"const a = require('declared-dep');
+               const ghost = require('undeclared-ghost');
+               let opt; try { opt = require('soft-ghost'); } catch {}
+               require('./reached');"#,
+        )
+        .unwrap();
+        fs::write(root.join("reached.js"), "import x from 'reached-ghost';").unwrap();
+        fs::write(root.join("adapter.js"), "import 'backend-lib';").unwrap();
+        root
+    }
+
+    #[test]
+    fn scan_result_flags_hard_phantoms_only() {
+        let root = fixture();
+        let r = scan_extracted(&root).unwrap();
+        assert!(r.has_unguarded_phantom);
+        let names: Vec<&str> = r.targets.iter().map(|t| t.name.as_str()).collect();
+        // Hard phantoms: undeclared-ghost, reached-ghost, backend-lib. NOT the
+        // optional peer (zod), NOT the soft/try-guarded (soft-ghost).
+        assert!(names.contains(&"undeclared-ghost"));
+        assert!(names.contains(&"reached-ghost"));
+        assert!(names.contains(&"backend-lib"));
+        assert!(!names.contains(&"soft-ghost"));
+        assert!(!names.contains(&"zod"));
+        // Provenance: backend-lib is subpath-only (the adapter class).
+        let backend = r.targets.iter().find(|t| t.name == "backend-lib").unwrap();
+        assert!(backend.from_subpath && !backend.from_main);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn clean_package_has_no_phantom() {
+        let root =
+            std::env::temp_dir().join(format!("nub-phantom-scan-clean-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("package.json"),
+            r#"{"name":"clean","main":"index.js","dependencies":{"lodash":"1"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("index.js"),
+            "const _ = require('lodash'); const fs = require('node:fs');",
+        )
+        .unwrap();
+        let r = scan_extracted(&root).unwrap();
+        assert!(!r.has_unguarded_phantom);
+        assert!(r.targets.is_empty());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_index_is_output_identical_to_scan_extracted() {
+        // The hard requirement: an extract-time index scan yields the exact same
+        // verdict + target set + file count as a post-link tree scan. Uses the
+        // full phantom fixture (main graph + `./adapter` subpath, hard/soft/peer
+        // mix) so provenance and classification are both exercised.
+        let root = fixture();
+        let from_tree = scan_extracted(&root).unwrap();
+        let from_index = scan_index(&index_of(&root)).unwrap();
+        assert_eq!(
+            from_index, from_tree,
+            "extract-time index scan diverged from post-link tree scan"
+        );
+        assert!(from_index.has_unguarded_phantom);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn full_report_still_available() {
+        let root = fixture();
+        let r = analyze_extracted(&root, "1.2.3").unwrap();
+        assert_eq!(r.count(Verdict::HardPhantom), 3);
+        assert_eq!(r.version, "1.2.3");
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/crates/nub-phantom-scan/src/manifest.rs
+++ b/crates/nub-phantom-scan/src/manifest.rs
@@ -1,0 +1,278 @@
+//! Parse a package's `package.json` into (a) its DECLARED dependency surface —
+//! the sets a specifier is checked against — and (b) its published ENTRY POINTS,
+//! the roots of the reachable-module walk.
+//!
+//! The declared surface deliberately mirrors what a consumer install actually
+//! makes resolvable at runtime: `dependencies`, `optionalDependencies`, and
+//! `peerDependencies` (split by the `peerDependenciesMeta.<x>.optional` flag),
+//! plus bundled deps. `devDependencies` are intentionally EXCLUDED — they are not
+//! installed for consumers, so an import of one from published code is a phantom.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+/// The declared dependency surface a specifier is classified against.
+#[derive(Debug, Default)]
+pub struct Manifest {
+    pub name: String,
+    /// `dependencies` ∪ `optionalDependencies` — hard-declared, always resolvable.
+    pub deps: BTreeSet<String>,
+    /// Required peers (`peerDependencies` without an `optional` meta flag).
+    pub required_peers: BTreeSet<String>,
+    /// Optional peers (`peerDependenciesMeta.<x>.optional === true`). Declared —
+    /// NOT phantoms — but reported as their own category (the pick-your-plugin
+    /// pattern that a naive detector over-flags).
+    pub optional_peers: BTreeSet<String>,
+    /// `bundledDependencies` / `bundleDependencies` — shipped inside the tarball.
+    pub bundled: BTreeSet<String>,
+    /// Published entry files (relative paths from the package root) — the roots
+    /// of the reachable-module walk, each tagged by whether it is the main entry
+    /// or a non-`.` `exports` subpath (the adapter surface).
+    pub entry_points: Vec<Entry>,
+}
+
+/// Which published surface an entry belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    /// `main` / `module` / `bin` / the `exports."."` root.
+    Main,
+    /// A non-`.` `exports` subpath (`./zod`, `./vitest`) — the adapter surface a
+    /// consumer opts into by importing `<pkg>/<subpath>`.
+    Subpath,
+}
+
+/// A published entry file + its surface kind.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    pub path: String,
+    pub kind: EntryKind,
+}
+
+impl Manifest {
+    /// Parse from raw `package.json` bytes. Returns `None` if the JSON is
+    /// unparseable or has no name (a package with no identity can't be analyzed).
+    pub fn parse(raw: &[u8]) -> Option<Manifest> {
+        let v: Value = serde_json::from_slice(raw).ok()?;
+        let name = v.get("name")?.as_str()?.to_string();
+
+        let mut m = Manifest {
+            name: name.clone(),
+            ..Default::default()
+        };
+
+        collect_keys(&v, "dependencies", &mut m.deps);
+        collect_keys(&v, "optionalDependencies", &mut m.deps);
+        collect_keys(&v, "peerDependencies", &mut m.required_peers);
+
+        // Move any peer flagged optional out of required_peers into optional_peers.
+        if let Some(meta) = v.get("peerDependenciesMeta").and_then(Value::as_object) {
+            for (peer, cfg) in meta {
+                let optional = cfg
+                    .get("optional")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                if optional {
+                    m.required_peers.remove(peer);
+                    m.optional_peers.insert(peer.clone());
+                }
+            }
+        }
+
+        collect_bundled(&v, &mut m.bundled);
+        m.entry_points = collect_entry_points(&v);
+        Some(m)
+    }
+}
+
+fn collect_keys(v: &Value, field: &str, out: &mut BTreeSet<String>) {
+    if let Some(obj) = v.get(field).and_then(Value::as_object) {
+        for k in obj.keys() {
+            out.insert(k.clone());
+        }
+    }
+}
+
+/// `bundledDependencies`/`bundleDependencies` is an ARRAY of names (both spellings
+/// are valid npm).
+fn collect_bundled(v: &Value, out: &mut BTreeSet<String>) {
+    for field in ["bundledDependencies", "bundleDependencies"] {
+        if let Some(arr) = v.get(field).and_then(Value::as_array) {
+            for item in arr {
+                if let Some(s) = item.as_str() {
+                    out.insert(s.to_string());
+                }
+            }
+        }
+    }
+}
+
+/// Gather the published entry files from `main`, `module`, `bin`, and `exports`,
+/// each tagged Main or Subpath. Only JS-like relative paths are kept;
+/// `types`/`.d.ts` and asset conditions are filtered (they carry no runtime
+/// imports).
+fn collect_entry_points(v: &Value) -> Vec<Entry> {
+    // Dedup on (kind, path) so a file exported at both `.` and a subpath seeds
+    // both surfaces into the walk.
+    let mut seen: BTreeSet<(u8, String)> = BTreeSet::new();
+    let mut out = Vec::new();
+    let mut push =
+        |p: &str, kind: EntryKind, out: &mut Vec<Entry>, seen: &mut BTreeSet<(u8, String)>| {
+            let norm = normalize_rel(p);
+            let key = (kind as u8, norm.clone());
+            if is_js_like(&norm) && seen.insert(key) {
+                out.push(Entry { path: norm, kind });
+            }
+        };
+
+    for field in ["main", "module"] {
+        if let Some(s) = v.get(field).and_then(Value::as_str) {
+            push(s, EntryKind::Main, &mut out, &mut seen);
+        }
+    }
+
+    match v.get("bin") {
+        Some(Value::String(s)) => push(s, EntryKind::Main, &mut out, &mut seen),
+        Some(Value::Object(map)) => {
+            for b in map.values() {
+                if let Some(s) = b.as_str() {
+                    push(s, EntryKind::Main, &mut out, &mut seen);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    // The top level of `exports` decides the kind: a `.`-keyed subpath map splits
+    // `.` (Main) from every `./x` (Subpath); a bare condition map or string is the
+    // main entry (sugar for `.`).
+    if let Some(exports) = v.get("exports") {
+        match exports {
+            Value::Object(map) if map.keys().any(|k| k.starts_with('.')) => {
+                for (k, child) in map {
+                    let kind = if k == "." {
+                        EntryKind::Main
+                    } else {
+                        EntryKind::Subpath
+                    };
+                    walk_exports(child, kind, &mut out, &mut seen, &mut push);
+                }
+            }
+            other => walk_exports(other, EntryKind::Main, &mut out, &mut seen, &mut push),
+        }
+    }
+
+    // Fallback: a package with no explicit entry resolves `./index.js` (Node's
+    // default main). Give the walk a root so an entry-less legacy package is
+    // still analyzed.
+    if out.is_empty() {
+        out.push(Entry {
+            path: "index.js".to_string(),
+            kind: EntryKind::Main,
+        });
+    }
+    out
+}
+
+/// Recursively collect every relative-path leaf of an `exports` subtree, carrying
+/// the surface `kind` down. Skips `types`/`typings` (they point at `.d.ts`).
+fn walk_exports(
+    node: &Value,
+    kind: EntryKind,
+    out: &mut Vec<Entry>,
+    seen: &mut BTreeSet<(u8, String)>,
+    push: &mut impl FnMut(&str, EntryKind, &mut Vec<Entry>, &mut BTreeSet<(u8, String)>),
+) {
+    match node {
+        Value::String(s) => push(s, kind, out, seen),
+        Value::Object(map) => {
+            for (k, child) in map {
+                if k == "types" || k == "typings" {
+                    continue;
+                }
+                walk_exports(child, kind, out, seen, push);
+            }
+        }
+        Value::Array(arr) => {
+            for child in arr {
+                walk_exports(child, kind, out, seen, push);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Strip a leading `./` and collapse a leading `/`; entry paths are relative to
+/// the package root.
+fn normalize_rel(p: &str) -> String {
+    p.trim_start_matches("./")
+        .trim_start_matches('/')
+        .to_string()
+}
+
+/// A JS-like runtime file (extension we can parse for imports). Excludes `.json`,
+/// `.node`, `.wasm`, `.css`, and `.d.ts` type stubs.
+pub fn is_js_like(path: &str) -> bool {
+    if path.ends_with(".d.ts") || path.ends_with(".d.mts") || path.ends_with(".d.cts") {
+        return false;
+    }
+    matches!(
+        extension(path),
+        Some("js" | "cjs" | "mjs" | "jsx" | "ts" | "tsx" | "mts" | "cts")
+    )
+}
+
+fn extension(path: &str) -> Option<&str> {
+    let file = path.rsplit('/').next().unwrap_or(path);
+    file.rsplit_once('.').map(|(_, e)| e)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Manifest;
+
+    #[test]
+    fn splits_optional_peers_out_of_required_and_excludes_dev() {
+        let raw = br#"{
+            "name": "pkg",
+            "dependencies": { "a": "1" },
+            "devDependencies": { "jest": "1" },
+            "peerDependencies": { "react": "*", "zod": "*" },
+            "peerDependenciesMeta": { "zod": { "optional": true } }
+        }"#;
+        let m = Manifest::parse(raw).unwrap();
+        assert!(m.deps.contains("a"));
+        // devDependencies are NOT in any resolvable set → phantom-eligible.
+        assert!(!m.deps.contains("jest") && !m.required_peers.contains("jest"));
+        assert!(m.required_peers.contains("react"));
+        assert!(m.optional_peers.contains("zod")); // optional peer moved out of required
+        assert!(!m.required_peers.contains("zod"));
+    }
+
+    #[test]
+    fn collects_entry_points_from_exports_and_filters_types() {
+        let raw = br#"{
+            "name": "pkg",
+            "exports": {
+                ".": { "import": "./dist/index.mjs", "require": "./dist/index.cjs", "types": "./dist/index.d.ts" },
+                "./sub": "./dist/sub.js"
+            }
+        }"#;
+        let m = Manifest::parse(raw).unwrap();
+        let entry = |p: &str| m.entry_points.iter().find(|e| e.path == p);
+        assert_eq!(
+            entry("dist/index.mjs").unwrap().kind,
+            super::EntryKind::Main
+        );
+        assert_eq!(
+            entry("dist/index.cjs").unwrap().kind,
+            super::EntryKind::Main
+        );
+        // `./sub` is a non-`.` export → the adapter surface.
+        assert_eq!(
+            entry("dist/sub.js").unwrap().kind,
+            super::EntryKind::Subpath
+        );
+        assert!(!m.entry_points.iter().any(|e| e.path.contains(".d.ts")));
+    }
+}

--- a/vendor/aube/crates/aube-store/src/lib.rs
+++ b/vendor/aube/crates/aube-store/src/lib.rs
@@ -7,6 +7,7 @@ mod cas;
 mod git;
 mod index;
 mod integrity;
+mod phantom_hook;
 mod tarball;
 
 pub use git::{
@@ -28,6 +29,8 @@ pub use integrity::{
     validate_and_encode_name, validate_pkg_content, validate_version, verify_integrity,
     verify_precomputed_sha512,
 };
+pub(crate) use phantom_hook::run_extract_hook;
+pub use phantom_hook::set_extract_hook;
 #[cfg(test)]
 pub(crate) use tarball::normalize_tar_entry_path;
 pub(crate) use tarball::{

--- a/vendor/aube/crates/aube-store/src/phantom_hook.rs
+++ b/vendor/aube/crates/aube-store/src/phantom_hook.rs
@@ -1,0 +1,31 @@
+//! Optional embedder hook for an extract-time package scanner.
+//!
+//! A process-global set-once cell, mirroring `aube_settings::set_embedder_defaults`:
+//! standalone aube never registers a hook, so [`run_extract_hook`] is a no-op and
+//! the default path pulls in no scanner dependency and stays byte-identical. The
+//! concrete scanner (an oxc-based parser) lives entirely in the embedder; aube
+//! only invokes an opaque closure, so no parser weight leaks into the store crate.
+
+use crate::PackageIndex;
+use std::sync::OnceLock;
+
+/// A scanner the embedder runs against a freshly-imported package's file index
+/// at CAS-extract time. Invoked at the end of `import_tarball_reader`, on the
+/// fetch/blocking fan-out thread, so per-version analysis overlaps ongoing
+/// downloads. `Send + Sync` because tarball import fans out across rayon workers.
+type ExtractHook = Box<dyn Fn(&PackageIndex) + Send + Sync>;
+
+static EXTRACT_HOOK: OnceLock<ExtractHook> = OnceLock::new();
+
+/// Register the extract-time scan hook. Set-once; later calls are ignored.
+pub fn set_extract_hook(hook: ExtractHook) {
+    let _ = EXTRACT_HOOK.set(hook);
+}
+
+/// Invoke the registered extract hook, if any. No-op for standalone aube (one
+/// relaxed atomic load, then return).
+pub(crate) fn run_extract_hook(index: &PackageIndex) {
+    if let Some(hook) = EXTRACT_HOOK.get() {
+        hook(index);
+    }
+}

--- a/vendor/aube/crates/aube-store/src/tarball.rs
+++ b/vendor/aube/crates/aube-store/src/tarball.rs
@@ -324,6 +324,11 @@ impl Store {
                 )
             },
         );
+        // Extract point: the index is fully built, its CAS blobs are fresh and
+        // page-cache hot, and we're on the fetch/blocking fan-out thread — so an
+        // embedder-registered scanner overlaps ongoing downloads. No-op (one
+        // atomic load) for standalone aube, which never registers a hook.
+        crate::run_extract_hook(&index);
         Ok(index)
     }
 }


### PR DESCRIPTION
Follow-on to #319. Wires nub's extract-time phantom detector into #319's selective-subtree force-materialization as the auto-source for phantom importers and their undeclared targets, replacing the provisional hardcoded list. Everything stays behind the pre-existing default-off `NUB_DYNAMIC_PHANTOM_EJECT` flag.

## What changed

- **Producer** — an aube-store extract hook scans each fetched package for unguarded undeclared imports and writes a per-content-integrity verdict sidecar; a pre-install backfill fills sidecars for warm-cached packages on `install`/`ci`. Gated additive seam — standalone aube registers nothing, so the default path is a no-op.
- **Consumer** — `phantom_closure::expand` reads those sidecars to drive #319's closure: rung-1 seeds gain each flagged importer, rung-2 hoists its scanned targets within the materialized package.
- **Retires** the provisional `KNOWN_PHANTOM_TARGETS` map — the per-version sidecars are now the source, so there is no hand-maintained list.
- **Precision seed-selection** — a flagged importer is skipped only when every undeclared target is both reachable inside its own subtree and absent from the project top level; it seeds on any uncertainty, since a wrong skip re-introduces a real phantom break.
- Drops the superseded link-time eject consumer and its aube-store sidecar-dir seam.

## Scope

Flag off installs no hook and touches no sidecar, so the default install path is byte-identical to #319. Does not flip the default and does not retire the static `NUB_FORCE_MATERIALIZE_PACKAGES` seed.

## Verification

Gates green (`fmt`, `clippy --all-targets`, scoped tests for nub-cli / aube-linker / aube-store / nub-phantom-scan). End-to-end on a genuinely cold store: `@firebase/database` ejects project-local through the dynamic source (flag off leaves it symlinked) with `@firebase/app` hoisted as a sibling (rung-2); a scanner-flagged but transitively-satisfied `es-abstract` stays symlinked (the precision filter); neutralizing a package's sidecar removes its eject and restoring it brings it back. The `vendor/aube` diff is gated additions only (39 lines across three aube-store files), and aube stays oxc-free.

Refs #319
