### PR TITLE
feat(phantom): default-on dynamic phantom eject; purge static materialize/GVS lists

### DIFF
--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -26,7 +26,8 @@ nub-core = { path = "../nub-core" }
 # crate's Cargo.toml for why that keeps the shipped CLI's build graph lean.
 nub-phantom-core = { path = "../nub-phantom-core" }
 # The reachable-graph phantom SCANNER (graph walk + classify) for the dynamic
-# per-version scan → sidecar path (behind NUB_DYNAMIC_PHANTOM_EJECT). Lean by
+# per-version scan → sidecar path (default-on; NUB_DYNAMIC_PHANTOM_EJECT=0 opts
+# out). Lean by
 # construction — same oxc-parser weight as nub-phantom-core, no fetch stack. The
 # `ScanResult` it defines is the sidecar payload phantom_closure deserializes.
 nub-phantom-scan = { path = "../nub-phantom-scan" }

--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -1,12 +1,12 @@
-//! Dynamic per-version phantom scan → disk-eject (behind the default-off
-//! `NUB_DYNAMIC_PHANTOM_EJECT` flag).
+//! Dynamic per-version phantom scan → disk-eject (the default; the
+//! `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out disables it).
 //!
-//! The static curated `NUB_FORCE_MATERIALIZE_PACKAGES` list (hand-maintained,
-//! capped at a corpus, stale on new versions) is augmented by SCANNING each
-//! installed dependency version's real published code: does it, along its
-//! reachable `exports`/`main`/`bin` graph, statically and unguardedly import a
-//! package it does not declare? A version's code is immutable, so the verdict is
-//! computed once per content-fingerprint and cached machine-wide.
+//! This REPLACES the old hand-curated static force-materialize list (capped at a
+//! corpus, stale on new versions) by SCANNING each installed dependency
+//! version's real published code: does it, along its reachable
+//! `exports`/`main`/`bin` graph, statically and unguardedly import a package it
+//! does not declare? A version's code is immutable, so the verdict is computed
+//! once per content-fingerprint and cached machine-wide.
 //!
 //! Placement — EXTRACT TIME, not post-link. The scan is registered as an aube
 //! store extract hook ([`aube_store::set_extract_hook`]) that fires at the end of
@@ -23,8 +23,9 @@
 //! consumer half. The two share [`store_v1_dir`]/[`phantom_cache_dir`] so their
 //! store handle and sidecar path derive from ONE base and cannot drift apart.
 //!
-//! With the flag OFF this module registers nothing — no extract hook — so the
-//! default install path is byte-identical to a build without the scanner.
+//! With the opt-out set (`NUB_DYNAMIC_PHANTOM_EJECT=0`) this module registers
+//! nothing — no extract hook — so the install path is byte-identical to a build
+//! without the scanner (a pure-symlink tree).
 
 use std::path::{Path, PathBuf};
 
@@ -32,24 +33,42 @@ use aube_store::{PackageIndex, index_content_fingerprint};
 use nub_phantom_scan::scan_index;
 use rayon::prelude::*;
 
-/// Whether the dynamic phantom scanner is armed. Truthy `NUB_DYNAMIC_PHANTOM_EJECT`
-/// (`1`/`true`/`yes`, or any non-falsey value) arms it; unset or a falsey value
-/// (`0`/`false`/`no`/`off`/empty) is off — the default.
-fn enabled() -> bool {
+/// Whether dynamic phantom detection + ancestor-closure eject is armed — the
+/// DEFAULT. Unset (or empty, or any non-falsey value) is ON; only an explicit
+/// falsey `NUB_DYNAMIC_PHANTOM_EJECT` (`0`/`false`/`no`/`off`) is the opt-out to
+/// a pure-symlink tree. This is the SINGLE arm both halves gate on — the
+/// extract-time PRODUCER here and the link-time CONSUMER
+/// ([`crate::pm_engine::phantom_closure`]) call this one function, and the
+/// install-state fingerprint ([`settings_fingerprint`]) folds THIS value, so
+/// detection, closure, and warm-tree invalidation can never drift.
+pub(crate) fn enabled() -> bool {
     match std::env::var("NUB_DYNAMIC_PHANTOM_EJECT") {
         Ok(v) => !matches!(
             v.trim().to_ascii_lowercase().as_str(),
-            "" | "0" | "false" | "no" | "off"
+            "0" | "false" | "no" | "off"
         ),
-        Err(_) => false,
+        Err(_) => true,
     }
 }
 
+/// The effective phantom-eject setting as a stable token, folded into aube's
+/// install-state `settings_hash` through the embedder `extra_settings_fingerprint`
+/// hook (nub's [`crate::pm_engine::identity::NUB`] profile points that hook here).
+/// The flag is nub's, not an aube setting, so it can't ride the resolved-settings
+/// hash — this seam is what makes flipping it invalidate the warm tree: nub's
+/// default moving across an upgrade, or a user's `NUB_DYNAMIC_PHANTOM_EJECT=0`
+/// opt-out, changes this token, so the link phase re-runs and converts the tree
+/// to the new materialization shape instead of trusting a stale node_modules.
+pub(crate) fn settings_fingerprint() -> String {
+    format!("dynamic_phantom_eject={}", enabled())
+}
+
 /// Register the extract-time scan hook with the embedded engine. Called once at
-/// engine-session build. No-op unless the flag is on, so the default path pulls
-/// in nothing and stays byte-identical. The registration is process-global
-/// set-once; a second call is ignored. The link-time consumption of the sidecars
-/// this writes lives in [`crate::pm_engine::phantom_closure`], not here.
+/// engine-session build. No-op only under the `NUB_DYNAMIC_PHANTOM_EJECT=0`
+/// opt-out, in which case the path pulls in nothing and stays byte-identical.
+/// The registration is process-global set-once; a second call is ignored. The
+/// link-time consumption of the sidecars this writes lives in
+/// [`crate::pm_engine::phantom_closure`], not here.
 pub fn register() {
     if !enabled() {
         return;
@@ -161,9 +180,10 @@ pub(crate) fn phantom_cache_dir() -> Option<PathBuf> {
 /// fingerprint keying, sidecar-hit skip, panic-guard, and atomic write are one
 /// implementation.
 ///
-/// Flag-OFF is a STRICT no-op: it returns before any lockfile parse, store
-/// access, or fs touch, so the default install path is byte-identical. No
-/// lockfile / an unparseable one is also a no-op — a fresh install has nothing
+/// The `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out is a STRICT no-op: it returns
+/// before any lockfile parse, store access, or fs touch, so that install path is
+/// byte-identical. No lockfile / an unparseable one is also a no-op — a fresh
+/// install has nothing
 /// cached to backfill, and the extract hook covers whatever it fetches. The scan
 /// is CPU-bound and per-package independent, so it fans out across rayon; a
 /// warm re-install where every sidecar already exists does zero scanning (each

--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -226,6 +226,12 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     // in the window that matters. An explicit user `trustPolicyIgnoreAfter=0`
     // opts back into the full strict check. Standalone aube keeps `None`.
     trust_policy_ignore_after_default: Some(14 * 24 * 60),
+    // Fold nub's phantom-eject flag (`NUB_DYNAMIC_PHANTOM_EJECT`) into aube's
+    // install-state `settings_hash`: it shapes which packages materialize but
+    // rides no aube setting, so without this a flag flip (the default moving
+    // across an upgrade, or a user opt-out) would leave a warm tree stale. The
+    // hook returns a stable on/off token; standalone aube's `None` skips the fold.
+    extra_settings_fingerprint: Some(crate::dynamic_phantom::settings_fingerprint),
 };
 
 /// Register [`NUB`] as the active embedder profile. Idempotent (the engine's
@@ -268,4 +274,5 @@ const _: () = {
     assert!(NUB.tty_progress);
     assert!(!NUB.warm_trust_revalidate);
     assert!(matches!(NUB.trust_policy_ignore_after_default, Some(20160)));
+    assert!(NUB.extra_settings_fingerprint.is_some());
 };

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -766,17 +766,18 @@ fn engine_session_inner(
     // (which calls it again as its first step, alongside the project-state-
     // dependent config surface) is a no-op for the registration.
     identity::register();
-    // Install nub's selective-subtree force-materialize expansion hook (behind
-    // the default-off `NUB_DYNAMIC_PHANTOM_EJECT` flag). No-op when the flag is
-    // off, so the default install path is byte-identical; when armed it expands
-    // the force-materialize seed to its ancestor-closure + phantom-target hoists
-    // at link time. Idempotent set-once, like `identity::register()`.
+    // Install nub's selective-subtree force-materialize expansion hook (the
+    // DEFAULT; the `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out disables it). When armed
+    // it expands the force-materialize seed to its ancestor-closure +
+    // phantom-target hoists at link time; under the opt-out it's a no-op and the
+    // install path is byte-identical (pure symlink). Idempotent set-once, like
+    // `identity::register()`.
     phantom_closure::register();
     // Arm the dynamic per-version phantom PRODUCER: an extract-time store hook
     // that scans each fetched package and writes a per-content verdict sidecar
     // (`phantom_closure`, above, is the CONSUMER that reads those sidecars to seed
-    // the closure). No-op unless the same default-off `NUB_DYNAMIC_PHANTOM_EJECT`
-    // flag is set, so the default path is unchanged. Idempotent set-once.
+    // the closure). On by default; a no-op only under the same
+    // `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out. Idempotent set-once.
     crate::dynamic_phantom::register();
     // Initialize the diagnostics recorder from NUB_DIAG_* env vars so that
     // `NUB_DIAG_SUMMARY=1 nub install` surfaces the same per-phase/per-op
@@ -2082,62 +2083,6 @@ fn strip_yarnrc_value(rest: &str) -> &str {
     rest.split('#').next().map(str::trim).unwrap_or(rest)
 }
 
-/// Curated `forceMaterializePackages` list. Each entry ships a file that
-/// references an undeclared sibling — either a runtime backend (`import` of a
-/// consumer-installed peer) or an ambient `@types/*` its `.d.ts` consumes — and
-/// resolution of that sibling depends on the entry's realpath staying inside the
-/// project. Under nub's default GVS a store entry's realpath is the machine-global
-/// virtual store, so the upward `node_modules` walk from it escapes the project and
-/// the sibling is never found. Force-materializing the entry makes it a real
-/// project-local directory, so the walk stays in-project and reaches the sibling at
-/// the project root. Two offender classes, one mechanism:
-/// - Runtime subpath adapters that statically import a backend they don't declare
-///   (`@hookform/resolvers/zod` → the app's `zod`).
-/// - Ambient-`@types` consumers whose shipped `.d.ts` import an undeclared
-///   `@types/react` (`next-themes`, `@react-pdf/renderer` — #286). Force-materialize
-///   restores tsc parity with pnpm: the project-local realpath's `@types` walk
-///   reaches the app's own `@types/react` (verified 0-error parity for next-themes,
-///   exact residual-error parity for @react-pdf, whose remaining errors are upstream
-///   package issues present under pnpm too).
-///
-/// The runtime entries are derived from the phantom-dep detector's top-5000
-/// subpath-adapter offenders, minus the entries whose imported target is a
-/// ubiquitous BUILD tool (`@babel/*`, `babel-plugin-macros`, `tslib`, `typescript`)
-/// rather than a runtime consumer-backend — those resolve anyway and aren't the
-/// pick-your-backend class. Users grow or shrink the list via the
-/// `forceMaterializePackages` setting (embedder-tier, so any user config still wins).
-///
-/// `@storybook/addon-interactions`, `@storybook/core`, `storybook`, and
-/// `@storybook/builder-webpack5` were removed (differential-verified against a real
-/// `storybook build`, not just static analysis): the flagged `react`/`@storybook/icons`
-/// imports live solely in `dist/manager.js`, which Storybook's manager-builder consumes
-/// as an esbuild entry — esbuild's global-externals plugin intercepts those specifiers
-/// before Node module resolution ever runs, so force-materializing never mattered
-/// ("Manager built" succeeds identically with or without it). Worse,
-/// `@storybook/builder-webpack5` force-materialized ALONE regressed a working case:
-/// its declared dependent `@storybook/react-webpack5` (not on this list) stays
-/// store-resident and can no longer find its own dependency once pulled out, turning a
-/// passing `storybook build` into `Cannot find module '@storybook/builder-webpack5'`.
-///
-/// A THIRD offender class: postinstall codegen that writes generated output back into
-/// its own installed directory via realpath. `@prisma/client`'s postinstall runs
-/// `prisma generate`, which resolves the default output dir relative to the package's
-/// realpath and writes the generated client (`.prisma/client`) into the enclosing
-/// `node_modules`. Under GVS that realpath is the machine-global shared store, whose
-/// entry key is package-identity-scoped, NOT project- or schema-scoped — so two
-/// projects with different Prisma schemas share ONE mutable generated client and
-/// silently corrupt each other (last-writer-wins; #286-shape data corruption).
-/// Force-materialize makes the entry project-local, so `generate` writes into the
-/// project's own tree, matching pnpm's isolated virtual store. Orphan-safety verified:
-/// `@prisma/client` is a leaf runtime consumed by the app root (adapters like
-/// `@auth/prisma-adapter` take it as a peer, satisfied at the top level), so pulling it
-/// project-local orphans no store-resident dependent (the builder-webpack5 failure mode
-/// above does not apply).
-const NUB_FORCE_MATERIALIZE_PACKAGES: &str = "@hookform/resolvers,cypress,langsmith,\
-@testing-library/jest-dom,drizzle-orm,swiper,@angular/common,@angular/router,\
-@apollo/client,@vercel/analytics,preact,next-themes,\
-@react-pdf/renderer,@prisma/client";
-
 /// - Layout policy: EVERY project defaults to the isolated layout
 ///   (`nodeLinker=isolated`) — strict (no phantom deps) and GVS-fast; a project
 ///   that relies on phantom deps opts back into the flat tree with one `.npmrc`
@@ -2168,6 +2113,17 @@ fn nub_setting_defaults(
     store_locality: VirtualStoreLocality,
 ) -> Vec<(String, String)> {
     let fresh_format = if truly_fresh { "aube" } else { "pnpm" };
+    // The phantom-adapter force-materialize list is no longer hand-curated: the
+    // dynamic per-version scanner (`dynamic_phantom` → `phantom_closure`, on by
+    // default) detects undeclared-import phantoms per content-fingerprint and
+    // ejects them through #319's ancestor-closure, subsuming the old 14-entry
+    // const (incl. the singleton-hazard adapters the closure now makes sound). So
+    // this embedder default carries ONLY the #315 vite eject; empty otherwise
+    // (aube's `parse_string_list` drops the empty entry). A user's own
+    // `forceMaterializePackages`/`diskMaterializePackages` still wins — the
+    // embedder default is the lowest precedence tier — so the additive escape
+    // hatch is intact.
+    //
     // Vite symlink-GVS compat (#315): eject the `vite` package project-local so
     // its dist can be patched with the backported fs.allow sniff (< 8.1) without
     // touching the shared CAS store. Scoped to a DIRECT-dep vite (a raw `vite`
@@ -2177,16 +2133,17 @@ fn nub_setting_defaults(
     // sibling symlink, so ejecting for it would be wasted dedup (Unit A's
     // `.modules.yaml` covers those for Vite ≥ 8.1). Only under the machine-global
     // store (`Default`) — `nub ci`'s project-local store is already under the
-    // workspace root, so Vite serves it with no override. The post-install
-    // writer/patcher lives in [`vite_compat`]; this is its materialization half.
-    // A user-set `forceMaterializePackages` still wins (embedder-tier).
+    // workspace root, so Vite serves it with no override. This seed also carries
+    // #315 on the phantom-eject opt-out path, where the closure hook is not
+    // installed. The post-install writer/patcher lives in [`vite_compat`]; this is
+    // its materialization half.
     let force_materialize = if store_locality == VirtualStoreLocality::Default
         && vite_compat::enabled()
         && vite_compat::manifest_declares_vite(detected.map(|d| d.dir.as_path()).unwrap_or(cwd))
     {
-        format!("{NUB_FORCE_MATERIALIZE_PACKAGES},vite")
+        "vite".to_string()
     } else {
-        NUB_FORCE_MATERIALIZE_PACKAGES.to_string()
+        String::new()
     };
     let mut defaults = vec![
         (
@@ -2201,16 +2158,22 @@ fn nub_setting_defaults(
         ("stateDir".to_string(), "node_modules/.nub".to_string()),
         (
             "disableGlobalVirtualStoreForPackages".to_string(),
-            // `react-native` joins next/nuxt/parcel: bare RN's Metro bundler
-            // (`@react-native/metro-config`) crawls by realpath and only sees
-            // its project root, so the machine-global GVS store is out of scope
-            // and even DECLARED deps (`@babel/runtime`) report unresolved. A
-            // whole-install GVS-off puts the store project-local, back in
-            // Metro's crawl scope. Expo's `@expo/metro-config` is store-aware so
-            // it works either way; this only flips Expo to project-local
-            // (harmless, small dedup regression). A store-LOCALITY break, not a
-            // phantom-dep class, so force-materialize is the wrong lever.
-            "next,nuxt,parcel,react-native".to_string(),
+            // The whole-install GVS-off last resort — reserved for a store-LOCALITY
+            // break (a tool whose resolver can't reach the machine-global store),
+            // NOT a phantom-dep class (those the dynamic detector + closure now
+            // eject per-package). `nuxt` was DROPPED: its walk-up is only 2 phantom
+            // edges (~2.3% closure), so it's closure-ejectable at rung 1 —
+            // symlink-GVS works (see [[nuxt-gvs-unlock]]). What remains:
+            // - `next` — Turbopack canonicalizes through symlinks and chroots to a
+            //   single project root; irreducible, so the store must be project-local.
+            // - `parcel` — resolver walks up for `.parcelrc` (unverified against the
+            //   closure; kept as the safe last resort).
+            // - `react-native` — bare RN's Metro (`@react-native/metro-config`)
+            //   crawls by realpath and only sees the project root, so the global
+            //   store is out of scope and even DECLARED deps (`@babel/runtime`)
+            //   report unresolved. Expo's `@expo/metro-config` is store-aware
+            //   (works either way; this only flips it project-local, harmless).
+            "next,parcel,react-native".to_string(),
         ),
         ("forceMaterializePackages".to_string(), force_materialize),
     ];
@@ -2802,66 +2765,43 @@ mod tests {
     }
 
     #[test]
-    fn force_materialize_default_seeds_the_curated_adapter_list() {
-        // nub seeds the per-package force-materialize list (subpath adapters
-        // that import a consumer-installed backend they don't declare) as an
-        // embedder default so they resolve under the default GVS. The exemplar
-        // `@hookform/resolvers` is present; build-time/helper subpath imports
-        // are excluded (not the runtime consumer-backend class).
+    fn phantom_force_materialize_list_is_retired_in_favor_of_the_detector() {
+        // The 14-entry hand-curated adapter list is gone: the dynamic per-version
+        // scanner + #319 ancestor-closure (on by default) detect and eject those
+        // phantoms, so nub no longer seeds them as an embedder default. A fresh,
+        // non-vite project's `forceMaterializePackages` default is therefore
+        // empty (the vite #315 seed is the only remaining embedder-default entry,
+        // and this fixture declares no vite).
         let dir = tempfile::tempdir().unwrap();
         let fresh = nub_setting_defaults(None, true, dir.path(), VirtualStoreLocality::Default);
-        let list = get(&fresh, "forceMaterializePackages")
-            .expect("nub must seed forceMaterializePackages");
-        let names: Vec<&str> = list.split(',').collect();
-        assert!(
-            names.contains(&"@hookform/resolvers"),
-            "the exemplar adapter must be on the list: {list}"
-        );
-        // The #286 ambient-`@types` class: consumers whose shipped `.d.ts` import
-        // an undeclared `@types/react` need the same project-local realpath so
-        // tsc's `@types` walk reaches the app's own `@types/react` under GVS.
-        for types_consumer in ["next-themes", "@react-pdf/renderer"] {
+        let list = get(&fresh, "forceMaterializePackages").unwrap_or_default();
+        let names: Vec<&str> = list.split(',').filter(|s| !s.is_empty()).collect();
+        for retired in [
+            "@hookform/resolvers",
+            "@prisma/client",
+            "next-themes",
+            "@react-pdf/renderer",
+            "preact",
+            "drizzle-orm",
+        ] {
             assert!(
-                names.contains(&types_consumer),
-                "{types_consumer} (#286 ambient-@types class) must be on the list: {list}"
+                !names.contains(&retired),
+                "{retired} must no longer be a hardcoded default (detector subsumes it): {list:?}"
             );
         }
-        // The postinstall-codegen class: `@prisma/client`'s `prisma generate`
-        // writes the generated client into its own realpath, which under GVS is
-        // the machine-global store — two projects with different schemas then
-        // corrupt each other. Force-materialize keeps `generate` project-local.
-        assert!(
-            names.contains(&"@prisma/client"),
-            "@prisma/client (postinstall-codegen class) must be on the list: {list}"
-        );
-        for excluded in ["ox", "event-target-shim", "@nestjs/swagger"] {
-            assert!(
-                !names.contains(&excluded),
-                "{excluded} is a build-time/helper import and must be excluded"
-            );
-        }
-        // List-1 (whole-install GVS-off): the validated-clean trio plus
-        // `react-native` (bare-RN Metro store-locality break).
-        assert_eq!(
-            get(&fresh, "disableGlobalVirtualStoreForPackages"),
-            Some("next,nuxt,parcel,react-native"),
-        );
     }
 
     #[test]
-    fn react_native_is_on_the_disable_gvs_default() {
-        // Bare React-Native's Metro bundler crawls by realpath from the project
-        // root and can't see the machine-global GVS store, so DECLARED deps
-        // (`@babel/runtime`) report unresolved. `react-native` on the
-        // whole-install GVS-off list forces the store project-local (back in
-        // Metro's scope). Same lever/precedent as next/nuxt/parcel.
+    fn disable_gvs_default_drops_nuxt_and_keeps_the_store_locality_breakers() {
+        // The whole-install GVS-off list is now reserved for store-LOCALITY
+        // breaks. `nuxt` is closure-ejectable at rung 1 ([[nuxt-gvs-unlock]]) so
+        // it was dropped; `next` (Turbopack chroot), `parcel`, and `react-native`
+        // (bare-RN Metro realpath crawl) remain irreducible.
         let dir = tempfile::tempdir().unwrap();
         let fresh = nub_setting_defaults(None, true, dir.path(), VirtualStoreLocality::Default);
-        let list = get(&fresh, "disableGlobalVirtualStoreForPackages")
-            .expect("nub must seed disableGlobalVirtualStoreForPackages");
-        assert!(
-            list.split(',').any(|p| p == "react-native"),
-            "react-native must be on the GVS-off list: {list}"
+        assert_eq!(
+            get(&fresh, "disableGlobalVirtualStoreForPackages"),
+            Some("next,parcel,react-native"),
         );
     }
 

--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -1,5 +1,5 @@
 //! Selective-subtree force-materialization policy — nub's force-materialize
-//! expansion hook (behind the default-off `NUB_DYNAMIC_PHANTOM_EJECT` flag).
+//! expansion hook (the default; disabled by `NUB_DYNAMIC_PHANTOM_EJECT=0`).
 //!
 //! Force-materializing a package project-local is only SOUND for a
 //! transitively-consumed package if its whole ancestor-closure materializes with
@@ -31,10 +31,10 @@
 //! are all already reachable inside its own subtree and absent from the project
 //! top level, so a transitively-satisfied over-flag never ejects.
 //!
-//! Flag OFF ⇒ no hook installed ⇒ aube's `expand_force_materialize` returns the
-//! seed verbatim ⇒ the force-materialize pass is byte-for-byte the shipped
-//! behavior. All policy lives here; aube owns only the neutral seam + the graph
-//! primitive.
+//! Opt-out (`NUB_DYNAMIC_PHANTOM_EJECT=0`) ⇒ no hook installed ⇒ aube's
+//! `expand_force_materialize` returns the seed verbatim ⇒ the force-materialize
+//! pass is byte-for-byte the pre-productionization pure-symlink behavior. All
+//! policy lives here; aube owns only the neutral seam + the graph primitive.
 
 use std::collections::{BTreeMap, HashSet, VecDeque};
 
@@ -43,35 +43,23 @@ use aube_lockfile::{LockedPackage, LockfileGraph};
 use nub_phantom_scan::ScanResult;
 use rayon::prelude::*;
 
-/// Whether selective-subtree force-materialization is armed. Truthy
-/// `NUB_DYNAMIC_PHANTOM_EJECT` (`1`/`true`/`yes`, or any non-falsey value) arms
-/// it; unset or a falsey value (`0`/`false`/`no`/`off`/empty) is off — the
-/// default. The SAME flag the extract-time producer (`crate::dynamic_phantom`)
-/// gates on, so the scanner (detection) and this closure (transitive soundness)
-/// share one arm.
-///
-/// LIMITATION (experimental-flag scope): the flag is NOT folded into the
-/// install-state fingerprint, which hashes only the raw `forceMaterializePackages`
-/// setting + the lockfile. So flipping this flag on an ALREADY-installed tree
-/// (unchanged lockfile) is a no-op — the link phase is skipped as "up to date". A
-/// clean install (or one whose lockfile changed) picks it up. Acceptable for a
-/// default-off experimental flag; folding the flag into the fingerprint is the
-/// productionization fix (an aube `state.rs` change, kept default-preserving).
+/// The SINGLE phantom-eject arm — [`crate::dynamic_phantom::enabled`] — shared
+/// with the extract-time producer so detection (the scanner), transitive
+/// soundness (this closure), and warm-tree invalidation (the fingerprint) can
+/// never disagree. On by DEFAULT; `NUB_DYNAMIC_PHANTOM_EJECT=0` is the opt-out.
+/// The flag IS now folded into the install-state fingerprint (via the embedder
+/// `extra_settings_fingerprint` hook; see [`crate::dynamic_phantom::settings_fingerprint`]),
+/// so flipping it on an already-installed tree re-links to the new
+/// materialization shape rather than accepting a stale node_modules.
 fn enabled() -> bool {
-    match std::env::var("NUB_DYNAMIC_PHANTOM_EJECT") {
-        Ok(v) => !matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "" | "0" | "false" | "no" | "off"
-        ),
-        Err(_) => false,
-    }
+    crate::dynamic_phantom::enabled()
 }
 
 /// Register nub's force-materialize expansion hook with the embedded engine.
-/// No-op unless `NUB_DYNAMIC_PHANTOM_EJECT` is armed, so the default path installs
-/// nothing and `aube_linker::expand_force_materialize` stays the identity —
-/// byte-for-byte the shipped force-materialize behavior. Set-once (idempotent);
-/// safe to call once per engine-session build.
+/// No-op only under the `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out, in which case
+/// `aube_linker::expand_force_materialize` stays the identity — byte-for-byte the
+/// pure-symlink force-materialize behavior. Set-once (idempotent); safe to call
+/// once per engine-session build.
 pub(crate) fn register() {
     if !enabled() {
         return;
@@ -79,9 +67,24 @@ pub(crate) fn register() {
     aube_linker::set_force_materialize_expand_hook(Box::new(expand));
 }
 
-/// The hook body: resolved graph + flat seed → graph-aware materialization plan.
-/// See the module docs for the two rungs.
+/// The hook entry: read the per-version scanner's sidecars (the store-IO half)
+/// then hand off to the pure planner. Split so [`plan_from_flags`] — all the
+/// closure/seed policy — is unit-tested with injected flags and never touches
+/// the host store.
 fn expand(graph: &LockfileGraph, seed_names: &[String]) -> ForceMaterializePlan {
+    plan_from_flags(graph, seed_names, &dynamic_phantom_flags(graph))
+}
+
+/// Pure planner: resolved graph + flat seed + dynamic phantom flags → graph-aware
+/// materialization plan. See the module docs for the two rungs. `flags` is each
+/// surviving-candidate importer's `(dep_path, name, undeclared-target-names)`,
+/// supplied by [`dynamic_phantom_flags`] in production and injected directly in
+/// tests.
+fn plan_from_flags(
+    graph: &LockfileGraph,
+    seed_names: &[String],
+    flags: &[(String, String, Vec<String>)],
+) -> ForceMaterializePlan {
     // Top-level presence: default-hoist top level = the importer DIRECT deps. See
     // `should_seed` for why this gate is load-bearing and its non-default-hoist
     // scope caveat.
@@ -102,9 +105,8 @@ fn expand(graph: &LockfileGraph, seed_names: &[String]) -> ForceMaterializePlan 
     // importer's undeclared targets keyed by dep_path, for the rung-2 hoist; only
     // survivors are kept, so a hoist only ever lands in a package the seed actually
     // materializes.
-    let flags = dynamic_phantom_flags(graph);
     let mut dynamic_targets: BTreeMap<&str, &[String]> = BTreeMap::new();
-    for (dep_path, name, targets) in &flags {
+    for (dep_path, name, targets) in flags {
         if should_seed(targets, &reachable_dep_names(dep_path, graph), is_top_level) {
             seed_names_set.insert(name.as_str());
             dynamic_targets.insert(dep_path.as_str(), targets.as_slice());
@@ -192,10 +194,10 @@ fn expand(graph: &LockfileGraph, seed_names: &[String]) -> ForceMaterializePlan 
 /// rayon; the backfill already warmed the sidecars, so each item is a small
 /// cached-JSON index load + a blake3 fingerprint + a small sidecar read.
 ///
-/// Flag-gated to empty unless armed. In production `expand` is only installed when
-/// armed, so this is belt-and-suspenders; the gate also keeps the pure vite/empty
-/// unit tests hermetic — they call `expand` directly with the flag off and must
-/// not touch the host's real store.
+/// Empty under the `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out. In production `expand`
+/// installs the hook only when armed, so this gate is belt-and-suspenders; the
+/// pure planning logic is tested through [`plan_from_flags`] with injected flags,
+/// so the unit tests never reach this store-IO path.
 fn dynamic_phantom_flags(graph: &LockfileGraph) -> Vec<(String, String, Vec<String>)> {
     if !enabled() {
         return Vec::new();
@@ -381,8 +383,9 @@ mod tests {
         xs.iter().map(|s| s.to_string()).collect()
     }
 
-    // Rung-1 vite seeding is independent of the dynamic source (a flag-off unit
-    // test sees no dynamic flags), so these exercise the closure end to end.
+    // Rung-1 vite seeding is independent of the dynamic source, so these inject
+    // an EMPTY flag set and exercise the pure planner (`plan_from_flags`) end to
+    // end — no host-store IO.
 
     #[test]
     fn embedded_vite_lt_8_1_seeds_its_framework_closure() {
@@ -394,7 +397,7 @@ mod tests {
             // an unrelated modern vite direct dep must NOT drag anything in
             ("lodash@4.17.21", "lodash", &[]),
         ]);
-        let plan = expand(&g, &[]);
+        let plan = plan_from_flags(&g, &[], &[]);
         let plan_names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
         assert!(plan_names.contains("vite"), "embedded vite<8.1 seeded");
         assert!(plan_names.contains("astro"), "framework in the closure");
@@ -410,7 +413,7 @@ mod tests {
             ("app@1.0.0", "app", &[("vite", "8.1.3")]),
             ("vite@8.1.3", "vite", &[]),
         ]);
-        let plan = expand(&g, &[]);
+        let plan = plan_from_flags(&g, &[], &[]);
         assert!(
             plan.names.is_empty(),
             "vite>=8.1 needs no eject (Unit A covers it)"
@@ -420,8 +423,39 @@ mod tests {
     #[test]
     fn no_seeds_yields_empty_plan() {
         let g = graph(&[("lodash@4.17.21", "lodash", &[])]);
-        let plan = expand(&g, &[]);
+        let plan = plan_from_flags(&g, &[], &[]);
         assert!(plan.names.is_empty() && plan.hoist_within.is_empty());
+    }
+
+    #[test]
+    fn dynamic_flag_seeds_importer_and_records_hoist() {
+        // The now-default path: a phantom adapter (`@hookform/resolvers`)
+        // statically imports an undeclared `zod`. The target isn't reachable
+        // within the adapter's own subtree, so `should_seed` SEEDS it; rung-2
+        // resolves `zod` to its dep_path and records the hoist into the adapter's
+        // materialized `node_modules`.
+        let g = graph(&[
+            ("@hookform/resolvers@1.0.0", "@hookform/resolvers", &[]),
+            ("zod@3.0.0", "zod", &[]),
+        ]);
+        let flags = vec![(
+            "@hookform/resolvers@1.0.0".to_string(),
+            "@hookform/resolvers".to_string(),
+            vec!["zod".to_string()],
+        )];
+        let plan = plan_from_flags(&g, &[], &flags);
+        let names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
+        assert!(
+            names.contains("@hookform/resolvers"),
+            "the flagged phantom importer is seeded"
+        );
+        assert_eq!(
+            plan.hoist_within
+                .get("@hookform/resolvers@1.0.0")
+                .map(Vec::as_slice),
+            Some(["zod@3.0.0".to_string()].as_slice()),
+            "rung-2 records the undeclared target's hoist"
+        );
     }
 
     // Precision seed-selection (`should_seed`) — the port of the retired link-time

--- a/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -44,6 +44,7 @@ static MYTOOL: Embedder = Embedder {
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 #[test]

--- a/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/embedder_identity_detection.rs
@@ -50,6 +50,7 @@ static MYTOOL: Embedder = Embedder {
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 fn project(files: &[(&str, &str)]) -> tempfile::TempDir {

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -54,6 +54,7 @@ static NO_CHURN_TOOL: Embedder = Embedder {
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 fn pkg(name: &str, version: &str, integrity: &str) -> LockedPackage {

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -47,6 +47,7 @@ static STRICT: Embedder = Embedder {
     strict_unsupported_source: true,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 fn parse(files: &[(&str, &str)]) -> Result<LockfileGraph, Error> {

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -50,6 +50,7 @@ static ROOT_TOOL: Embedder = Embedder {
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 fn read_manifest(dir: &std::path::Path) -> serde_json::Value {

--- a/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-registry/tests/user_agent_product.rs
@@ -46,6 +46,7 @@ static MYTOOL: Embedder = Embedder {
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 #[tokio::test]

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -41,6 +41,7 @@ static ROOT_TOOL: Embedder = Embedder {
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 fn build_decision(manifest: &PackageJson, name: &str, version: &str) -> AllowDecision {

--- a/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
+++ b/vendor/aube/crates/aube-scripts/tests/user_agent_product.rs
@@ -40,6 +40,7 @@ static MYTOOL: Embedder = Embedder {
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 #[test]

--- a/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
+++ b/vendor/aube/crates/aube-settings/tests/branded_settings_env_gate.rs
@@ -55,6 +55,7 @@ static MYTOOL_NO_BRANDED_ENV: Embedder = Embedder {
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 fn ctx<'a>(

--- a/vendor/aube/crates/aube-util/src/identity.rs
+++ b/vendor/aube/crates/aube-util/src/identity.rs
@@ -364,6 +364,18 @@ pub struct Embedder {
     /// relief, the same quarantine logic as `minimumReleaseAge`, mirrored.
     /// Embedder-fixed: the host's supply-chain posture, not a per-project knob.
     pub trust_policy_ignore_after_default: Option<u64>,
+    /// Optional hook contributing extra bytes to the install-state
+    /// `settings_hash` (see `crate::state::hash_settings` in the `aube` crate)
+    /// for a host that shapes the installed tree through an input aube's
+    /// resolved settings don't capture. `None` (aube's default) ⇒ the fold is
+    /// skipped entirely, so the hash is byte-for-byte unchanged for standalone
+    /// aube. A host returns a stable token for its own install-shape input so
+    /// flipping that input invalidates the warm tree and forces a re-link
+    /// instead of trusting a now-stale `node_modules`. nub folds in its
+    /// phantom-eject flag here — it shapes which packages materialize but rides
+    /// no aube setting. Same function-pointer hook shape as
+    /// [`cpu_budget`](Self::cpu_budget); embedder-fixed pluggability.
+    pub extra_settings_fingerprint: Option<fn() -> String>,
 }
 
 /// Standalone aube's embedder profile. Reproduces every hardcoded branding
@@ -416,6 +428,9 @@ pub const AUBE: Embedder = Embedder {
     // Standalone aube leaves `trustPolicyIgnoreAfter` unset, so the downgrade
     // check applies to every version — behavior byte-for-byte unchanged.
     trust_policy_ignore_after_default: None,
+    // No extra settings-fingerprint fold: standalone aube's `settings_hash` is
+    // byte-for-byte unchanged (the hook block is skipped when `None`).
+    extra_settings_fingerprint: None,
 };
 
 static ACTIVE: OnceLock<&'static Embedder> = OnceLock::new();
@@ -592,6 +607,7 @@ mod tests {
         assert_eq!(id.primer_ttl, None);
         assert!(!id.tty_progress);
         assert_eq!(id.trust_policy_ignore_after_default, None);
+        assert!(id.extra_settings_fingerprint.is_none());
     }
 
     /// Under the default (AUBE) profile the source-branding helpers reproduce

--- a/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -53,6 +53,7 @@ static NUBLIKE: Embedder = Embedder {
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 /// Restore the previous value of an env var around a closure. Integration-test

--- a/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/vendor/aube/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -49,6 +49,7 @@ static NUBLIKE: Embedder = Embedder {
     strict_unsupported_source: false,
     warm_trust_revalidate: true,
     trust_policy_ignore_after_default: None,
+    extra_settings_fingerprint: None,
 };
 
 #[test]

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -1277,6 +1277,18 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
         hasher.update(b"\x1f");
     }
     hasher.update(b"\0");
+    // Embedder-supplied extra fingerprint: an install-shape input the host
+    // controls outside aube's resolved settings (nub's phantom-eject flag,
+    // which changes which packages materialize but rides no setting). `None`
+    // for standalone aube ⇒ the block is skipped ⇒ the hash is byte-for-byte
+    // unchanged; a host that sets it invalidates the warm tree when its input
+    // flips (an upgrade moving the default, or a user opt-out), forcing a
+    // re-link instead of trusting a stale node_modules.
+    if let Some(ext) = aube_util::embedder().extra_settings_fingerprint {
+        hasher.update(b"embedder_ext=");
+        hasher.update(ext().as_bytes());
+        hasher.update(b"\0");
+    }
     // map shaped workspace settings live in yaml. raw byte hash catches
     // catalog edits, overrides bumps, packageExtensions, allowBuilds list.
     // any of those mean re-resolve is needed, yaml bytes are the source.


### PR DESCRIPTION
Makes dynamic per-version phantom detection + ancestor-closure eject the default install behavior. Previously this was behind the default-off `NUB_DYNAMIC_PHANTOM_EJECT` flag (the detector→closure integration landed in the #319/#320 stack). Now the detector is the source of truth for which packages force-materialize project-local, and `NUB_DYNAMIC_PHANTOM_EJECT=0` is the opt-out to a pure-symlink tree.

## What changed

- **Flag default → on.** The on/off arm is centralized in one function (`dynamic_phantom::enabled`) shared by the extract-time scanner, the link-time closure, and the fingerprint, so they cannot drift. Unset/empty/any non-falsey value is on; `0`/`false`/`no`/`off` is the opt-out.
- **Retired the 14-entry static `NUB_FORCE_MATERIALIZE_PACKAGES` const.** The dynamic detector subsumes it, including the singleton-hazard adapters (preact, @angular/common, @angular/router, @apollo/client) that #319's ancestor-closure now makes sound. The user `forceMaterializePackages` override is unchanged; the embedder default now carries only the vite eject (#315).
- **Dropped `nuxt` from `disableGlobalVirtualStoreForPackages`** (closure-ejectable at rung 1). `next` (Turbopack single-root chroot), `parcel`, and `react-native` (Metro realpath crawl) remain.
- **Folded the effective flag into aube's install-state `settings_hash`** via a new default-preserving embedder hook (`Embedder::extra_settings_fingerprint`, `None` for standalone aube), so flipping the flag — an upgrade moving the default, or a user opt-out — invalidates a warm tree and re-links instead of trusting a stale `node_modules`.
- **Split `phantom_closure::expand`** into a store-IO entry + a pure `plan_from_flags` planner so the closure unit tests stay hermetic under the new default.

Standalone aube is byte-preserved on its default path (the fingerprint hook is `None`, the `disableGlobalVirtualStoreForPackages` schema default is untouched).

## Verification

`clippy --all-targets --all-features -D warnings` clean, `fmt` clean, nub-cli unit tests + integration suite (install_engine, pm_two_mode, pm_verbs, integration) green, aube identity-neutrality + `settings_hash` tests green. e2e on real fixtures: `@hookform/resolvers` + `preact` eject by default; `NUB_DYNAMIC_PHANTOM_EJECT=0` returns to pure symlink; a clean vite+react app stays ~97% symlink (only the vite compat eject); `settings_hash` differs by flag state.

Refs #319, #320.
