### PR TITLE
test(framework-matrix): fix driver.sh dev-server leak; add fresh-build acceptance runner

### DIFF
--- a/tests/framework-matrix/run.sh
+++ b/tests/framework-matrix/run.sh
@@ -65,11 +65,11 @@ if [ "$dev_cmd" != "-" ]; then
     sleep 0.5
     pp=$(grep -oE 'https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]):[0-9]+' "$devlog" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
     [ -n "$pp" ] && bound="$pp"
-    if [ -n "$bound" ]; then curl -s -o /dev/null "http://127.0.0.1:$bound/" 2>/dev/null && { up=1; break; }; fi
+    if [ -n "$bound" ]; then curl -s -o /dev/null "http://localhost:$bound/" 2>/dev/null && { up=1; break; }; fi
     kill -0 "$devpid" 2>/dev/null || break   # dev process died
   done
   if [ -n "$up" ]; then
-    dev_code=$(curl -s -o /tmp/fm-$name-dev-body.html -w '%{http_code}' "http://127.0.0.1:$bound/" 2>/dev/null)
+    dev_code=$(curl -s -o /tmp/fm-$name-dev-body.html -w '%{http_code}' "http://localhost:$bound/" 2>/dev/null)
     # error scan: server log + served HTML for the common SSR/runtime error markers
     if grep -qiE 'error:|ReferenceError|TypeError|Cannot find|MODULE_NOT_FOUND|ERR_|Internal Server Error|failed to (load|resolve)|is not allowed|outside of .* allow list|Unhandled' "$devlog" 2>/dev/null; then dev_err="log-errors"; else dev_err="clean"; fi
     grep -qiE 'Internal Server Error|Application error|Hydration failed|500 - ' /tmp/fm-$name-dev-body.html 2>/dev/null && dev_err="html-error"
@@ -101,11 +101,11 @@ if [ "$preview_cmd" != "-" ] && [ "$build_result" != "FAIL" ]; then
     sleep 0.5
     pp=$(grep -oE 'https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]):[0-9]+' "$prevlog" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
     [ -n "$pp" ] && pbound="$pp"
-    if [ -n "$pbound" ]; then curl -s -o /dev/null "http://127.0.0.1:$pbound/" 2>/dev/null && { pup=1; break; }; fi
+    if [ -n "$pbound" ]; then curl -s -o /dev/null "http://localhost:$pbound/" 2>/dev/null && { pup=1; break; }; fi
     kill -0 "$prevpid" 2>/dev/null || break
   done
   if [ -n "$pup" ]; then
-    prev_code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$pbound/" 2>/dev/null)
+    prev_code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:$pbound/" 2>/dev/null)
     [ "$prev_code" = "200" ] && prev_result="ok" || prev_result="FAIL"
   else
     prev_result="FAIL"; prev_code="no-listen"

--- a/tests/framework-matrix/run.sh
+++ b/tests/framework-matrix/run.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# run.sh — one framework's out-of-the-box acceptance run for the fresh-build
+# matrix. Given an already-scaffolded project, it exercises the THREE distinct
+# code paths (dev server, production build, serve-the-build) and asserts each,
+# plus verifies the symlink-GVS / eject linking layout is actually in use.
+#
+# Usage: run.sh <name> <proj-dir> <dev-cmd> <build-cmd> <preview-cmd> [dep-to-probe]
+#   Commands run from inside <proj-dir>; "-" skips a step. Server commands must
+#   bind 127.0.0.1 and print their URL to stdout/stderr (the port is parsed from
+#   the log; pass --port/--host through where the framework needs it).
+#   <dep-to-probe> is a node_modules dep whose realpath decides the layout verdict
+#   (default: pick the first top-level dep). Set NUB=<path> to the nub binary.
+#
+# Emits one ROW| line per step plus a final VERDICT| line. Behavioral assertions
+# (HTTP status, build exit code) are load-INDEPENDENT — no wall-clock gating.
+set -u
+
+NUB="${NUB:?set NUB to the nub binary path}"
+name="$1"; proj="$2"; dev_cmd="$3"; build_cmd="$4"; preview_cmd="$5"; probe="${6:-}"
+
+log() { echo "ROW|$name|$*"; }
+
+kill_tree() { local p="$1" c; for c in $(pgrep -P "$p" 2>/dev/null); do kill_tree "$c"; done; kill -TERM "$p" 2>/dev/null; }
+kill_group() { local g="$1"; kill -TERM -"$g" 2>/dev/null; sleep 0.4; kill -KILL -"$g" 2>/dev/null; kill_tree "$g"; kill -KILL "$g" 2>/dev/null; }
+
+cd "$proj" || { log "step=setup result=FAIL detail=no-dir"; echo "VERDICT|$name|FAIL"; exit 2; }
+
+# ── install ──────────────────────────────────────────────────────────────────
+"$NUB" install >/tmp/fm-$name-install.log 2>&1; inst=$?
+if [ $inst -ne 0 ]; then
+  log "step=install result=FAIL exit=$inst"; tail -8 /tmp/fm-$name-install.log | sed "s/^/  install> /"
+  echo "VERDICT|$name|FAIL"; exit 2
+fi
+log "step=install result=ok"
+
+# ── linking layout: realpath a real dep, does it escape the project root? ─────
+# escape → symlink into the global virtual store (GVS on); stays inside proj →
+# ejected / disableGVS project-local. Reports the resolved realpath either way.
+read -r layout rp probe_used < <(NUBPROBE="$probe" node -e '
+const fs=require("fs"),p=require("path"),cwd=process.cwd();
+const nm=p.join(cwd,"node_modules");
+function realOf(name){try{const l=p.join(nm,name);const st=fs.lstatSync(l);const r=fs.realpathSync(l);return r;}catch{return null}}
+let probe=process.env.NUBPROBE||"";
+let cand=[];
+if(probe) cand=[probe];
+else {
+  // pick a few ordinary deps, skip .bin/.nub/.modules and scoped-dir noise
+  for(const e of fs.readdirSync(nm)){ if(e[0]==="."||e==="node_modules") continue; if(e[0]==="@"){ for(const s of fs.readdirSync(p.join(nm,e))) cand.push(e+"/"+s);} else cand.push(e);}
+}
+let chosen=null,real=null;
+for(const c of cand){ const r=realOf(c); if(r){chosen=c;real=r;break;} }
+if(!real){console.log("unknown - -");process.exit(0)}
+const escapes=!real.startsWith(cwd+p.sep);
+console.log((escapes?"gvs-store":"project-local")+" "+real+" "+chosen);
+' 2>/dev/null)
+log "step=linking layout=${layout:-err} probe=${probe_used:-?} realpath=${rp:-?}"
+
+# ── dev server ────────────────────────────────────────────────────────────────
+dev_result="skip"; dev_code="n/a"; dev_err="n/a"
+if [ "$dev_cmd" != "-" ]; then
+  devlog=/tmp/fm-$name-dev.log; : >"$devlog"
+  set -m; ( cd "$proj" && exec $dev_cmd ) >"$devlog" 2>&1 & devpid=$!; set +m
+  bound=""; up=""
+  for i in $(seq 1 120); do
+    sleep 0.5
+    pp=$(grep -oE 'https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]):[0-9]+' "$devlog" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
+    [ -n "$pp" ] && bound="$pp"
+    if [ -n "$bound" ]; then curl -s -o /dev/null "http://127.0.0.1:$bound/" 2>/dev/null && { up=1; break; }; fi
+    kill -0 "$devpid" 2>/dev/null || break   # dev process died
+  done
+  if [ -n "$up" ]; then
+    dev_code=$(curl -s -o /tmp/fm-$name-dev-body.html -w '%{http_code}' "http://127.0.0.1:$bound/" 2>/dev/null)
+    # error scan: server log + served HTML for the common SSR/runtime error markers
+    if grep -qiE 'error:|ReferenceError|TypeError|Cannot find|MODULE_NOT_FOUND|ERR_|Internal Server Error|failed to (load|resolve)|is not allowed|outside of .* allow list|Unhandled' "$devlog" 2>/dev/null; then dev_err="log-errors"; else dev_err="clean"; fi
+    grep -qiE 'Internal Server Error|Application error|Hydration failed|500 - ' /tmp/fm-$name-dev-body.html 2>/dev/null && dev_err="html-error"
+    [ "$dev_code" = "200" ] && [ "$dev_err" = "clean" ] && dev_result="ok" || dev_result="FAIL"
+  else
+    dev_result="FAIL"; dev_code="no-listen"
+  fi
+  kill_group "$devpid"; wait "$devpid" 2>/dev/null
+  log "step=dev result=$dev_result http=$dev_code errors=$dev_err"
+  [ "$dev_result" = "FAIL" ] && { echo "  dev-log tail:"; tail -15 "$devlog" | sed 's/^/  dev> /'; }
+fi
+
+# ── production build ──────────────────────────────────────────────────────────
+build_result="skip"
+if [ "$build_cmd" != "-" ]; then
+  ( cd "$proj" && eval "$build_cmd" ) >/tmp/fm-$name-build.log 2>&1; bx=$?
+  [ $bx -eq 0 ] && build_result="ok" || build_result="FAIL"
+  log "step=build result=$build_result exit=$bx"
+  [ "$build_result" = "FAIL" ] && { echo "  build-log tail:"; tail -20 /tmp/fm-$name-build.log | sed 's/^/  build> /'; }
+fi
+
+# ── serve the built output (preview / start) ─────────────────────────────────
+prev_result="skip"; prev_code="n/a"
+if [ "$preview_cmd" != "-" ] && [ "$build_result" != "FAIL" ]; then
+  prevlog=/tmp/fm-$name-preview.log; : >"$prevlog"
+  set -m; ( cd "$proj" && exec $preview_cmd ) >"$prevlog" 2>&1 & prevpid=$!; set +m
+  pbound=""; pup=""
+  for i in $(seq 1 120); do
+    sleep 0.5
+    pp=$(grep -oE 'https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]):[0-9]+' "$prevlog" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
+    [ -n "$pp" ] && pbound="$pp"
+    if [ -n "$pbound" ]; then curl -s -o /dev/null "http://127.0.0.1:$pbound/" 2>/dev/null && { pup=1; break; }; fi
+    kill -0 "$prevpid" 2>/dev/null || break
+  done
+  if [ -n "$pup" ]; then
+    prev_code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$pbound/" 2>/dev/null)
+    [ "$prev_code" = "200" ] && prev_result="ok" || prev_result="FAIL"
+  else
+    prev_result="FAIL"; prev_code="no-listen"
+  fi
+  kill_group "$prevpid"; wait "$prevpid" 2>/dev/null
+  log "step=preview result=$prev_result http=$prev_code"
+  [ "$prev_result" = "FAIL" ] && { echo "  preview-log tail:"; tail -15 "$prevlog" | sed 's/^/  prev> /'; }
+fi
+
+# ── verdict ──────────────────────────────────────────────────────────────────
+verdict="PASS"
+for r in "$dev_result" "$build_result" "$prev_result"; do [ "$r" = "FAIL" ] && verdict="FAIL"; done
+echo "VERDICT|$name|$verdict|dev=$dev_result build=$build_result preview=$prev_result layout=${layout:-err}"

--- a/tests/framework-matrix/run.sh
+++ b/tests/framework-matrix/run.sh
@@ -33,27 +33,31 @@ if [ $inst -ne 0 ]; then
 fi
 log "step=install result=ok"
 
-# ── linking layout: realpath a real dep, does it escape the project root? ─────
+# ── linking layout: realpath deps, do they escape the project root? ──────────
 # escape → symlink into the global virtual store (GVS on); stays inside proj →
-# ejected / disableGVS project-local. Reports the resolved realpath either way.
-read -r layout rp probe_used < <(NUBPROBE="$probe" node -e '
+# ejected / disableGVS project-local. A single-dep probe misleads: a legitimately
+# ejected dep (e.g. a `@scope/dev` CLI pulled project-local by the phantom-peer
+# closure to hold a `vite` sibling symlink) sorts first and would headline
+# "project-local" for an otherwise fully-GVS install. So SAMPLE the whole top
+# level and report the MAJORITY layout plus the exact escape/local tallies and
+# which deps are project-local — the majority is the verdict, the tally is the
+# evidence. A caller-supplied <probe> still reports that one dep's own layout too.
+read -r layout escaped local_ct locals rp probe_used < <(NUBPROBE="$probe" node -e '
 const fs=require("fs"),p=require("path"),cwd=process.cwd();
 const nm=p.join(cwd,"node_modules");
-function realOf(name){try{const l=p.join(nm,name);const st=fs.lstatSync(l);const r=fs.realpathSync(l);return r;}catch{return null}}
-let probe=process.env.NUBPROBE||"";
-let cand=[];
-if(probe) cand=[probe];
-else {
-  // pick a few ordinary deps, skip .bin/.nub/.modules and scoped-dir noise
-  for(const e of fs.readdirSync(nm)){ if(e[0]==="."||e==="node_modules") continue; if(e[0]==="@"){ for(const s of fs.readdirSync(p.join(nm,e))) cand.push(e+"/"+s);} else cand.push(e);}
-}
-let chosen=null,real=null;
-for(const c of cand){ const r=realOf(c); if(r){chosen=c;real=r;break;} }
-if(!real){console.log("unknown - -");process.exit(0)}
-const escapes=!real.startsWith(cwd+p.sep);
-console.log((escapes?"gvs-store":"project-local")+" "+real+" "+chosen);
+function realOf(name){try{return fs.realpathSync(p.join(nm,name));}catch{return null}}
+let all=[];
+for(const e of fs.readdirSync(nm)){ if(e[0]==="."||e==="node_modules") continue; if(e[0]==="@"){ for(const s of fs.readdirSync(p.join(nm,e))) all.push(e+"/"+s);} else all.push(e);}
+let esc=0,loc=[];
+for(const c of all){ const r=realOf(c); if(!r) continue; if(r.startsWith(cwd+p.sep)) loc.push(c); else esc++; }
+const majority=(esc>=loc.length)?"gvs-store":"project-local";
+// caller-supplied single probe, if any
+let probe=process.env.NUBPROBE||"", prLayout="-", prName="-";
+if(probe){ const r=realOf(probe); if(r){ prName=probe; prLayout=r.startsWith(cwd+p.sep)?"project-local":"gvs-store"; } }
+const localsStr=loc.length?loc.slice(0,8).join(","):"none";
+console.log([majority,esc,loc.length,localsStr,prLayout,prName].join(" "));
 ' 2>/dev/null)
-log "step=linking layout=${layout:-err} probe=${probe_used:-?} realpath=${rp:-?}"
+log "step=linking layout=${layout:-err} escaped=${escaped:-?} project_local=${local_ct:-?} locals=${locals:-?} probe=${probe_used:-none}/${rp:-none}"
 
 # ── dev server ────────────────────────────────────────────────────────────────
 dev_result="skip"; dev_code="n/a"; dev_err="n/a"

--- a/tests/vite-compat/driver.sh
+++ b/tests/vite-compat/driver.sh
@@ -36,15 +36,32 @@ name="$(basename "$proj")"
 
 fail() { echo "FAIL[$name]: $*" >&2; }
 
-# Kill a process AND all its descendants. A bare `kill $pid` / the old
-# `pkill -f "vite.*--port"` misses the child processes an `astro dev` / `nuxt dev`
-# / `vite` parent spawns, so a server LEAKS onto the port; the next run then binds
-# a DIFFERENT port while the harness curls the stale (unpatched) server → false
-# 403s. Recursing children-first (pgrep -P) tears the whole tree down.
+# Kill a dev server AND its whole descendant tree. A dev server (`astro dev`,
+# `nuxt dev`, `vite`) forks workers (the optimizer, Nitro, an esbuild/SWC service)
+# that a bare `kill $pid` — and even a `pgrep -P` walk — miss once a grandchild
+# reparents to init before the walk snapshots it, so a worker LEAKS onto the port;
+# the next run then binds a DIFFERENT port while the harness curls the stale
+# (unpatched) server → false 403s. The robust fix is a process GROUP: the dev
+# server is launched as its own group leader (via `set -m`, so PGID == the job
+# pid), and `kill -SIGNAL -PGID` signals the ENTIRE group atomically — no
+# reparenting race, no missed grandchild. `pgrep -P` recursion remains only as a
+# best-effort fallback for a process that somehow escaped the group.
 kill_tree() {
   local p="$1" c
   for c in $(pgrep -P "$p" 2>/dev/null); do kill_tree "$c"; done
   kill -TERM "$p" 2>/dev/null
+}
+
+# Tear down the dev server's process group, then KILL-sweep, then fall back to the
+# pgrep walk. `-$pgid` (negative) targets the group; a leading `kill 0`-style
+# guard is unnecessary because $pgid is a real job-leader pid captured under -m.
+kill_group() {
+  local pgid="$1"
+  kill -TERM -"$pgid" 2>/dev/null
+  sleep 0.3
+  kill -KILL -"$pgid" 2>/dev/null
+  kill_tree "$pgid"
+  kill -KILL "$pgid" 2>/dev/null
 }
 
 cd "$proj" || { fail "no dir"; exit 2; }
@@ -104,10 +121,14 @@ fi
 if [ -n "$dev_cmd" ] && [ "$dev_cmd" != "-" ]; then
   devlog=/tmp/vc-$name-dev.log
   : >"$devlog"
-  # `exec` so devpid IS the dev process (astro/nuxt/vite), not a wrapper subshell,
-  # making kill_tree reach the real tree.
+  # `set -m` (job control) makes this background job its OWN process-group leader,
+  # so `devpid` is both the group leader PID and the PGID — `kill_group` can then
+  # tear down the whole tree via `-$devpid`. `exec` keeps devpid pinned to the real
+  # dev process (astro/nuxt/vite), not a wrapper subshell.
+  set -m
   ( cd "$proj" && exec $dev_cmd ) >"$devlog" 2>&1 &
   devpid=$!
+  set +m
   # Parse the ACTUAL bound port from the dev log — a framework re-picks a free
   # port if the requested one is taken (e.g. after a prior leak), so curling the
   # requested port would hit the wrong/stale server. Fall back to the requested.
@@ -128,7 +149,7 @@ if [ -n "$dev_cmd" ] && [ "$dev_cmd" != "-" ]; then
   else
     log_403="no-403"
   fi
-  kill_tree "$devpid"; sleep 0.3; kill -KILL "$devpid" 2>/dev/null; wait "$devpid" 2>/dev/null
+  kill_group "$devpid"; wait "$devpid" 2>/dev/null
 fi
 
 # ── 5. build ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Test-harness only — no runtime or PM behavior change.

**driver.sh dev-server leak.** The Vite-compat driver tore down the dev server with a `pgrep -P` walk, which misses a worker once it reparents to init before the walk snapshots it. A leaked worker held the port, so the next run bound a different port and curled the stale (unpatched) server, producing false 403s. The dev server is now launched as its own process-group leader (`set -m`) and killed via `kill -SIGNAL -PGID`, which signals the whole tree atomically; the `pgrep` walk remains only as a fallback.

**New framework-matrix runner.** `tests/framework-matrix/run.sh` drives one scaffolded app through the three distinct code paths — dev server, production build, serve-the-build — asserting each on HTTP status / exit code, plus a realpath-escape probe reporting whether a dep symlinks into the global virtual store or is materialized project-local. It reuses the process-group teardown above.
