### PR TITLE
refactor(pm): rename forceMaterializePackages to diskMaterializePackages

### DIFF
--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -37,8 +37,8 @@ nub-phantom-scan = { path = "../nub-phantom-scan" }
 # `nub ci` route through `aube::commands::install::run` in-process instead of
 # shelling out. See vendor/aube/AGENTS.md and src/pm_engine/.
 aube-lockfile = { path = "../../vendor/aube/crates/aube-lockfile" }
-# aube-linker: nub installs a force-materialize expansion hook (selective-subtree
-# materialization) via `aube_linker::set_force_materialize_expand_hook`; a pure
+# aube-linker: nub installs a disk-materialize expansion hook (selective-subtree
+# materialization) via `aube_linker::set_disk_materialize_expand_hook`; a pure
 # library crate (no CLI/tokio surface), same lean-graph rationale as aube-lockfile.
 aube-linker = { path = "../../vendor/aube/crates/aube-linker" }
 aube-manifest = { path = "../../vendor/aube/crates/aube-manifest" }

--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -1,7 +1,7 @@
 //! Dynamic per-version phantom scan → disk-eject (the default; the
 //! `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out disables it).
 //!
-//! This REPLACES the old hand-curated static force-materialize list (capped at a
+//! This REPLACES the old hand-curated static disk-materialize list (capped at a
 //! corpus, stale on new versions) by SCANNING each installed dependency
 //! version's real published code: does it, along its reachable
 //! `exports`/`main`/`bin` graph, statically and unguardedly import a package it
@@ -15,7 +15,7 @@
 //! fetch's idle cores) instead of adding a serial post-link pass. Each verdict is
 //! written to a per-content sidecar.
 //!
-//! The sidecars are CONSUMED by the force-materialize expansion hook
+//! The sidecars are CONSUMED by the disk-materialize expansion hook
 //! ([`crate::pm_engine::phantom_closure`]): it reads them to seed the
 //! selective-subtree closure with each flagged importer, so a poisoned version is
 //! ejected project-local through #319's graph-aware materialization plan. This
@@ -98,7 +98,7 @@ pub fn register() {
 /// The written JSON is the serialized [`nub_phantom_scan::ScanResult`], read back
 /// by the CONSUMER ([`crate::pm_engine::phantom_closure`]) — which, being in
 /// nub-cli, deserializes it into the typed `ScanResult` (no cross-fork string
-/// coupling) to seed the force-materialize closure.
+/// coupling) to seed the disk-materialize closure.
 fn scan_and_cache(dir: &Path, index: &PackageIndex) {
     let fingerprint = index_content_fingerprint(index);
     let sidecar = dir.join(format!("{fingerprint}.json"));
@@ -222,7 +222,7 @@ pub fn backfill_from_lockfile(project_dir: &Path) {
         // Not in the CAS ⇒ skip: the resolve/fetch phase fetches it and the
         // extract hook covers it. `registry_name()` + `integrity` key the index
         // the SAME way the linker's own eject-gate read does (`builder.rs`
-        // `force_materialize` path), so npm-alias deps resolve to the right blob.
+        // `disk_materialize` path), so npm-alias deps resolve to the right blob.
         let Some(index) =
             store.load_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref())
         else {

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -370,7 +370,7 @@ fn run_add(typed: &str, args: &[String]) -> Result<i32> {
     stamp_if_virgin(&session, code);
     // `nub add vite` (or adding any dep to a vite project) changes the graph;
     // refresh `.modules.yaml` + the < 8.1 patch. Note: a FIRST `nub add vite`
-    // can't have force-materialized vite yet (the manifest didn't declare it at
+    // can't have disk-materialized vite yet (the manifest didn't declare it at
     // settings time), so Unit A applies immediately (≥ 8.1) and the < 8.1 dist
     // patch lands on the next `nub install` once vite is a declared direct dep.
     apply_vite_compat(&session, code);

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -766,9 +766,9 @@ fn engine_session_inner(
     // (which calls it again as its first step, alongside the project-state-
     // dependent config surface) is a no-op for the registration.
     identity::register();
-    // Install nub's selective-subtree force-materialize expansion hook (the
+    // Install nub's selective-subtree disk-materialize expansion hook (the
     // DEFAULT; the `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out disables it). When armed
-    // it expands the force-materialize seed to its ancestor-closure +
+    // it expands the disk-materialize seed to its ancestor-closure +
     // phantom-target hoists at link time; under the opt-out it's a no-op and the
     // install path is byte-identical (pure symlink). Idempotent set-once, like
     // `identity::register()`.
@@ -2113,14 +2113,14 @@ fn nub_setting_defaults(
     store_locality: VirtualStoreLocality,
 ) -> Vec<(String, String)> {
     let fresh_format = if truly_fresh { "aube" } else { "pnpm" };
-    // The phantom-adapter force-materialize list is no longer hand-curated: the
+    // The phantom-adapter disk-materialize list is no longer hand-curated: the
     // dynamic per-version scanner (`dynamic_phantom` → `phantom_closure`, on by
     // default) detects undeclared-import phantoms per content-fingerprint and
     // ejects them through #319's ancestor-closure, subsuming the old 14-entry
     // const (incl. the singleton-hazard adapters the closure now makes sound). So
     // this embedder default carries ONLY the #315 vite eject; empty otherwise
     // (aube's `parse_string_list` drops the empty entry). A user's own
-    // `forceMaterializePackages`/`diskMaterializePackages` still wins — the
+    // `diskMaterializePackages`/`diskMaterializePackages` still wins — the
     // embedder default is the lowest precedence tier — so the additive escape
     // hatch is intact.
     //
@@ -2137,7 +2137,7 @@ fn nub_setting_defaults(
     // #315 on the phantom-eject opt-out path, where the closure hook is not
     // installed. The post-install writer/patcher lives in [`vite_compat`]; this is
     // its materialization half.
-    let force_materialize = if store_locality == VirtualStoreLocality::Default
+    let disk_materialize = if store_locality == VirtualStoreLocality::Default
         && vite_compat::enabled()
         && vite_compat::manifest_declares_vite(detected.map(|d| d.dir.as_path()).unwrap_or(cwd))
     {
@@ -2175,7 +2175,7 @@ fn nub_setting_defaults(
             //   (works either way; this only flips it project-local, harmless).
             "next,parcel,react-native".to_string(),
         ),
-        ("forceMaterializePackages".to_string(), force_materialize),
+        ("diskMaterializePackages".to_string(), disk_materialize),
     ];
     if let Some(data) = nub_data_dir() {
         defaults.push((
@@ -2765,16 +2765,16 @@ mod tests {
     }
 
     #[test]
-    fn phantom_force_materialize_list_is_retired_in_favor_of_the_detector() {
+    fn phantom_disk_materialize_list_is_retired_in_favor_of_the_detector() {
         // The 14-entry hand-curated adapter list is gone: the dynamic per-version
         // scanner + #319 ancestor-closure (on by default) detect and eject those
         // phantoms, so nub no longer seeds them as an embedder default. A fresh,
-        // non-vite project's `forceMaterializePackages` default is therefore
+        // non-vite project's `diskMaterializePackages` default is therefore
         // empty (the vite #315 seed is the only remaining embedder-default entry,
         // and this fixture declares no vite).
         let dir = tempfile::tempdir().unwrap();
         let fresh = nub_setting_defaults(None, true, dir.path(), VirtualStoreLocality::Default);
-        let list = get(&fresh, "forceMaterializePackages").unwrap_or_default();
+        let list = get(&fresh, "diskMaterializePackages").unwrap_or_default();
         let names: Vec<&str> = list.split(',').filter(|s| !s.is_empty()).collect();
         for retired in [
             "@hookform/resolvers",

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2120,7 +2120,7 @@ fn nub_setting_defaults(
     // const (incl. the singleton-hazard adapters the closure now makes sound). So
     // this embedder default carries ONLY the #315 vite eject; empty otherwise
     // (aube's `parse_string_list` drops the empty entry). A user's own
-    // `diskMaterializePackages`/`diskMaterializePackages` still wins — the
+    // `diskMaterializePackages` still wins — the
     // embedder default is the lowest precedence tier — so the additive escape
     // hatch is intact.
     //

--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -1,11 +1,11 @@
-//! Selective-subtree force-materialization policy — nub's force-materialize
+//! Selective-subtree disk-materialization policy — nub's disk-materialize
 //! expansion hook (the default; disabled by `NUB_DYNAMIC_PHANTOM_EJECT=0`).
 //!
-//! Force-materializing a package project-local is only SOUND for a
+//! Disk-materializing a package project-local is only SOUND for a
 //! transitively-consumed package if its whole ancestor-closure materializes with
 //! it — otherwise a store-resident importer keeps resolving the un-materialized
 //! shared-store copy, a silent singleton split (two realpaths, two module
-//! instances). This hook expands aube's flat force-materialize seed into a
+//! instances). This hook expands aube's flat disk-materialize seed into a
 //! graph-aware plan against the resolved lockfile:
 //!
 //! - **Rung 1 — ancestor-closure.** Each seed grows to
@@ -32,13 +32,13 @@
 //! top level, so a transitively-satisfied over-flag never ejects.
 //!
 //! Opt-out (`NUB_DYNAMIC_PHANTOM_EJECT=0`) ⇒ no hook installed ⇒ aube's
-//! `expand_force_materialize` returns the seed verbatim ⇒ the force-materialize
+//! `expand_disk_materialize` returns the seed verbatim ⇒ the disk-materialize
 //! pass is byte-for-byte the pre-productionization pure-symlink behavior. All
 //! policy lives here; aube owns only the neutral seam + the graph primitive.
 
 use std::collections::{BTreeMap, HashSet, VecDeque};
 
-use aube_linker::ForceMaterializePlan;
+use aube_linker::DiskMaterializePlan;
 use aube_lockfile::{LockedPackage, LockfileGraph};
 use nub_phantom_scan::ScanResult;
 use rayon::prelude::*;
@@ -55,23 +55,23 @@ fn enabled() -> bool {
     crate::dynamic_phantom::enabled()
 }
 
-/// Register nub's force-materialize expansion hook with the embedded engine.
+/// Register nub's disk-materialize expansion hook with the embedded engine.
 /// No-op only under the `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out, in which case
-/// `aube_linker::expand_force_materialize` stays the identity — byte-for-byte the
-/// pure-symlink force-materialize behavior. Set-once (idempotent); safe to call
+/// `aube_linker::expand_disk_materialize` stays the identity — byte-for-byte the
+/// pure-symlink disk-materialize behavior. Set-once (idempotent); safe to call
 /// once per engine-session build.
 pub(crate) fn register() {
     if !enabled() {
         return;
     }
-    aube_linker::set_force_materialize_expand_hook(Box::new(expand));
+    aube_linker::set_disk_materialize_expand_hook(Box::new(expand));
 }
 
 /// The hook entry: read the per-version scanner's sidecars (the store-IO half)
 /// then hand off to the pure planner. Split so [`plan_from_flags`] — all the
 /// closure/seed policy — is unit-tested with injected flags and never touches
 /// the host store.
-fn expand(graph: &LockfileGraph, seed_names: &[String]) -> ForceMaterializePlan {
+fn expand(graph: &LockfileGraph, seed_names: &[String]) -> DiskMaterializePlan {
     plan_from_flags(graph, seed_names, &dynamic_phantom_flags(graph))
 }
 
@@ -84,7 +84,7 @@ fn plan_from_flags(
     graph: &LockfileGraph,
     seed_names: &[String],
     flags: &[(String, String, Vec<String>)],
-) -> ForceMaterializePlan {
+) -> DiskMaterializePlan {
     // Top-level presence: default-hoist top level = the importer DIRECT deps. See
     // `should_seed` for why this gate is load-bearing and its non-default-hoist
     // scope caveat.
@@ -95,7 +95,7 @@ fn plan_from_flags(
         .collect();
     let is_top_level = |name: &str| root_provided.contains(name);
 
-    // Seed set by NAME: the caller's force-materialize list ∪ every dynamically-
+    // Seed set by NAME: the caller's disk-materialize list ∪ every dynamically-
     // flagged importer that SURVIVES the precision seed-selection filter. Embedded
     // vite<8.1 is seeded by dep_path below.
     let mut seed_names_set: HashSet<&str> = seed_names.iter().map(String::as_str).collect();
@@ -175,7 +175,7 @@ fn plan_from_flags(
         }
     }
 
-    ForceMaterializePlan {
+    DiskMaterializePlan {
         names: names.into_iter().collect(),
         hoist_within,
     }
@@ -389,7 +389,7 @@ mod tests {
 
     #[test]
     fn embedded_vite_lt_8_1_seeds_its_framework_closure() {
-        // astro → vite@6.4.3 (embedded, <8.1). The closure force-materializes
+        // astro → vite@6.4.3 (embedded, <8.1). The closure disk-materializes
         // BOTH so the ejected vite is project-local for the #318 patch.
         let g = graph(&[
             ("astro@5.0.0", "astro", &[("vite", "6.4.3")]),

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -180,7 +180,7 @@ const NPMRC_KEYS: &[&str] = &[
     "linkConcurrency",
     "hoistingLimits",
     "disableGlobalVirtualStoreForPackages",
-    "forceMaterializePackages",
+    "diskMaterializePackages",
 ];
 
 /// Keys the engine has zero implementation for: warn-drop, naming each and

--- a/crates/nub-cli/src/pm_engine/vite_compat.rs
+++ b/crates/nub-cli/src/pm_engine/vite_compat.rs
@@ -18,8 +18,8 @@
 //!   plain data — read regardless of whether nub is in the process.
 //!
 //! - **Unit B (Vite < 8.1): backport Vite's own 8.1 sniff.** The sniff predates
-//!   the majority of installed Vite, so for < 8.1 nub force-materializes just the
-//!   `vite` package project-local (the linker's `forceMaterializePackages` path —
+//!   the majority of installed Vite, so for < 8.1 nub disk-materializes just the
+//!   `vite` package project-local (the linker's `diskMaterializePackages` path —
 //!   the shared CAS store stays pristine, only the local ejected copy is touched)
 //!   and codegen-inserts the sniff at Vite's own `fs.allow`-default computation
 //!   site in the bundled (non-minified) dist. That site is upstream of
@@ -72,7 +72,7 @@ pub(crate) fn enabled() -> bool {
 /// project-local ejected copy), so the dist backport cannot reach it CAS-safely
 /// — but Unit A (`.modules.yaml`) fixes it for Vite ≥ 8.1 (the framework's
 /// store Vite reads the file natively). Direct-dep Vite IS loaded from the
-/// force-materialized project-local copy, so the < 8.1 backport reaches it.
+/// disk-materialized project-local copy, so the < 8.1 backport reaches it.
 pub(crate) fn apply(root: &Path) {
     if !enabled() {
         return;
@@ -179,7 +179,7 @@ fn read_vite_version(pkg_dir: &Path) -> Option<String> {
 
 /// Whether the project manifest at `root` declares `vite` as a DIRECT dependency
 /// (any of dependencies / devDependencies / optionalDependencies). Drives the
-/// force-materialize decision: only a direct-dep Vite is loaded from the ejected
+/// disk-materialize decision: only a direct-dep Vite is loaded from the ejected
 /// project-local copy the backport patches, so ejecting for a library-embedded
 /// Vite (which loads its store copy) would be wasted dedup. Best-effort — an
 /// unreadable/absent manifest ⇒ `false`.

--- a/crates/nub-phantom/README.md
+++ b/crates/nub-phantom/README.md
@@ -2,7 +2,7 @@
 
 An internal/eval tool that detects **undeclared (phantom) dependencies** of npm
 packages, and scans the top-N most-downloaded packages to build the empirical
-`packageExtensions`/force-materialize dataset from ecosystem data instead of
+`packageExtensions`/disk-materialize dataset from ecosystem data instead of
 guesswork.
 
 It is **not** part of the shipped `nub` binary — it is its own Cargo workspace,

--- a/crates/nub-phantom/src/lib.rs
+++ b/crates/nub-phantom/src/lib.rs
@@ -11,7 +11,7 @@
 //! The classifier's whole job is to NOT false-flag: declared optional peers, soft
 //! (try/catch) loads, type-only imports, and unreached dev files are each handled
 //! so the emitted phantom set is trustworthy enough to drive the vendored
-//! `packageExtensions`/force-materialize list.
+//! `packageExtensions`/disk-materialize list.
 
 pub mod classify;
 pub mod fetch;

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -473,7 +473,7 @@ The same treatment covers packages that write generated code back into their own
 Add your own with one line in `.npmrc`:
 
 ```ini
-forceMaterializePackages[]=my-adapter
+diskMaterializePackages[]=my-adapter
 ```
 
 A bundler that resolves modules by their real path — Metro (bare React Native), Next.js, Nuxt, Parcel — only crawls the project directory, so it can't see the shared store. Nub gives those projects a self-contained, project-local store automatically. Extend the list in `.npmrc`:

--- a/tests/vite-compat/README.md
+++ b/tests/vite-compat/README.md
@@ -14,19 +14,19 @@ Two units, both in `crates/nub-cli/src/pm_engine/vite_compat.rs`, default-on
 - **Unit A — `node_modules/.modules.yaml`** (all Vite versions). nub writes JSON
   `{"virtualStoreDir":"<abs store>"}`. Vite ≥ 8.1 reads it natively and allows
   the store.
-- **Unit B — dist backport** (Vite < 8.1). nub force-materializes just the
+- **Unit B — dist backport** (Vite < 8.1). nub disk-materializes just the
   `vite` package project-local (CAS store untouched) and codegen-inserts Vite's
   own 8.1 `.modules.yaml` sniff at the `fs.allow`-default computation site
   (`let allowDirs = server.fs.allow;` for v6/v7; `[searchForWorkspaceRoot(root)]`
   for v5). The sniff is YAML-tolerant + PM-agnostic (reads whatever
   `virtualStoreDir` any tool wrote — never hardcodes nub's path).
 
-Unit B as shipped force-materializes vite ONLY when it is a **direct** dep — a
+Unit B as shipped disk-materializes vite ONLY when it is a **direct** dep — a
 raw `vite dev` app. A framework that embeds vite **transitively** (Astro 5 pins
 `vite@^6`, `< 8.1`) loads its vite from a store-to-store sibling symlink, so the
 direct-dep eject never reaches it and the store `/@fs` stays 403 (the #315
 residual). Behind the default-off `NUB_DYNAMIC_PHANTOM_EJECT` flag, nub now
-auto-detects an embedded vite `< 8.1` and force-materializes its
+auto-detects an embedded vite `< 8.1` and disk-materializes its
 `[framework … vite]` **ancestor closure** (measured 5 packages for Astro 5,
 `~1.5%` of the tree — everything else stays symlinked), so the framework loads a
 project-local vite that Unit B patches. With the flag OFF the behavior is
@@ -101,14 +101,14 @@ NUB_DYNAMIC_PHANTOM_EJECT=1 tests/vite-compat/driver.sh <dir> "<dev-cmd>" "<buil
 ```
 
 - **Astro 5 (rung 1 — the vite closure).** `astro@^5` pins `vite@6.4.3` (`< 8.1`),
-  loaded library-embedded. The flag force-materializes the `[astro, vite, …]`
+  loaded library-embedded. The flag disk-materializes the `[astro, vite, …]`
   closure → the ejected vite gets Unit B's sniff → a bare `astro dev` (no nub in
   the process) serves a store-resident `/@fs` module `200` (was `403`).
   Acceptance: `/@fs=200`, `log=no-403`, `patched>=1`, and only the framework
   closure ejected (the rest of the tree stays symlinked).
 - **Nuxt 4 (both rungs).** `nuxt@^4` embeds `vite@7.3.6` (`< 8.1`) AND breaks on
   transitive undeclared imports the closure alone can't place. The flag
-  force-materializes the `[nuxt, @nuxt/vite-builder, vite, vue-router,
+  disk-materializes the `[nuxt, @nuxt/vite-builder, vite, vue-router,
   @nuxt/devtools]` closure (rung 1) and hoists the two already-resolved phantom
   targets within their importers — `@vue/compiler-sfc` into `vue-router`,
   `unstorage` into `@nuxt/devtools` (rung 2). Acceptance: `nuxt prepare` →

--- a/vendor/aube/crates/aube-linker/src/builder.rs
+++ b/vendor/aube/crates/aube-linker/src/builder.rs
@@ -43,7 +43,7 @@ impl Linker {
             aube_dir_override: None,
             no_integrity_read_keys: std::collections::BTreeMap::new(),
             link_progress: None,
-            force_materialize: std::collections::HashSet::new(),
+            disk_materialize: std::collections::HashSet::new(),
             phantom_hoist: std::collections::BTreeMap::new(),
         }
     }
@@ -52,19 +52,19 @@ impl Linker {
     /// even under the global virtual store (see the field docs on [`Linker`]).
     /// Names are matched exactly against each graph package. Standalone aube and
     /// every test omit this → the set is empty and the GVS pass is unchanged.
-    pub fn with_force_materialize(mut self, names: &[String]) -> Self {
-        self.force_materialize = names.iter().cloned().collect();
+    pub fn with_disk_materialize(mut self, names: &[String]) -> Self {
+        self.disk_materialize = names.iter().cloned().collect();
         self
     }
 
-    /// Whether `pkg_name` is on the force-materialize list. Consulted only in
+    /// Whether `pkg_name` is on the disk-materialize list. Consulted only in
     /// the global-virtual-store link pass; always false when the list is empty.
-    pub(crate) fn force_materialize_matches(&self, pkg_name: &str) -> bool {
-        !self.force_materialize.is_empty() && self.force_materialize.contains(pkg_name)
+    pub(crate) fn disk_materialize_matches(&self, pkg_name: &str) -> bool {
+        !self.disk_materialize.is_empty() && self.disk_materialize.contains(pkg_name)
     }
 
     /// Rung 2 of selective-subtree materialization: the undeclared phantom
-    /// targets to hoist-within each force-materialized package's `node_modules`,
+    /// targets to hoist-within each disk-materialized package's `node_modules`,
     /// keyed by importer dep_path → already-resolved target dep_paths (see the
     /// `phantom_hoist` field docs on [`Linker`]). Standalone aube and every test
     /// omit this → the map is empty and the materialize pass is unchanged.
@@ -77,7 +77,7 @@ impl Linker {
     }
 
     /// The phantom-hoist targets for the package at `dep_path`, if any. Consulted
-    /// only in the force-materialize branch of the GVS link pass; `None` when the
+    /// only in the disk-materialize branch of the GVS link pass; `None` when the
     /// map is empty (the standalone/default path) or the dep_path has no entry.
     pub(crate) fn phantom_hoist_for(&self, dep_path: &str) -> Option<&[String]> {
         if self.phantom_hoist.is_empty() {

--- a/vendor/aube/crates/aube-linker/src/disk_materialize.rs
+++ b/vendor/aube/crates/aube-linker/src/disk_materialize.rs
@@ -1,10 +1,10 @@
-//! Force-materialize plan expansion — the embedder-pluggable seam that turns a
+//! Disk-materialize plan expansion — the embedder-pluggable seam that turns a
 //! flat seed list into a graph-aware selective-subtree materialization plan.
 //!
-//! Standalone aube installs NO hook, so [`expand_force_materialize`] returns the
+//! Standalone aube installs NO hook, so [`expand_disk_materialize`] returns the
 //! seed verbatim (rung-1 names = the seed, no rung-2 hoist) and the linker's
-//! force-materialize pass is byte-for-byte unchanged. An embedder (nub) installs
-//! a hook via [`set_force_materialize_expand_hook`] that consults the resolved
+//! disk-materialize pass is byte-for-byte unchanged. An embedder (nub) installs
+//! a hook via [`set_disk_materialize_expand_hook`] that consults the resolved
 //! graph to (1) expand each seed to its ancestor-closure — every package that
 //! transitively imports it — so a transitively-consumed package materializes
 //! together with its importers (else a store-resident importer resolves the
@@ -12,7 +12,7 @@
 //! phantom-target hoists for undeclared imports the closure alone can't place.
 //!
 //! The hook receives only `&LockfileGraph` + the seed names and returns a pure
-//! [`ForceMaterializePlan`], so all embedder-specific policy (which packages
+//! [`DiskMaterializePlan`], so all embedder-specific policy (which packages
 //! seed, the flag gate, vite<8.1 detection) lives in the embedder; aube owns
 //! only the neutral seam and the graph primitive ([`LockfileGraph::importer_closure`]).
 
@@ -21,45 +21,45 @@ use std::sync::OnceLock;
 
 use aube_lockfile::LockfileGraph;
 
-/// The materialization plan an [`FmExpandHook`] produces from the resolved graph.
+/// The materialization plan a [`DmExpandHook`] produces from the resolved graph.
 #[derive(Debug, Default, Clone)]
-pub struct ForceMaterializePlan {
-    /// Rung 1 — the expanded set of package NAMES to force-materialize
+pub struct DiskMaterializePlan {
+    /// Rung 1 — the expanded set of package NAMES to disk-materialize
     /// project-local (the seed UNION its ancestor-closure). Fed to
-    /// [`Linker::with_force_materialize`](crate::Linker::with_force_materialize),
+    /// [`Linker::with_disk_materialize`](crate::Linker::with_disk_materialize),
     /// matched by exact name, exactly as the raw seed was.
     pub names: Vec<String>,
-    /// Rung 2 — undeclared phantom targets to hoist-within a force-materialized
+    /// Rung 2 — undeclared phantom targets to hoist-within a disk-materialized
     /// package's own `node_modules`, keyed by the importer's dep_path → the
     /// already-resolved target dep_paths. Empty unless a hook populates it.
     pub hoist_within: BTreeMap<String, Vec<String>>,
 }
 
-/// A hook that expands a force-materialize seed into a graph-aware plan. `Send +
+/// A hook that expands a disk-materialize seed into a graph-aware plan. `Send +
 /// Sync` because it is stored in a process-global consulted from the install
 /// pipeline; `'static` because it outlives any single install.
-pub type FmExpandHook =
-    Box<dyn Fn(&LockfileGraph, &[String]) -> ForceMaterializePlan + Send + Sync + 'static>;
+pub type DmExpandHook =
+    Box<dyn Fn(&LockfileGraph, &[String]) -> DiskMaterializePlan + Send + Sync + 'static>;
 
-static FM_EXPAND_HOOK: OnceLock<FmExpandHook> = OnceLock::new();
+static DM_EXPAND_HOOK: OnceLock<DmExpandHook> = OnceLock::new();
 
-/// Install the embedder's force-materialize expansion hook. Set-once: a second
+/// Install the embedder's disk-materialize expansion hook. Set-once: a second
 /// call is ignored (the first registration wins), matching aube's other
 /// process-global embedder seams. Called once at engine-session build; standalone
 /// aube never calls it, so the default path stays hook-free.
-pub fn set_force_materialize_expand_hook(hook: FmExpandHook) {
-    let _ = FM_EXPAND_HOOK.set(hook);
+pub fn set_disk_materialize_expand_hook(hook: DmExpandHook) {
+    let _ = DM_EXPAND_HOOK.set(hook);
 }
 
-/// Expand a force-materialize `seed` (the resolved `forceMaterializePackages`
+/// Expand a disk-materialize `seed` (the resolved `diskMaterializePackages`
 /// names) into a plan against `graph`. With no hook installed — standalone aube,
 /// every test — returns the seed verbatim as rung-1 names with an empty rung-2
-/// map, so the caller's `with_force_materialize(&plan.names)` is identical to the
-/// pre-existing `with_force_materialize(&seed)` and nothing else changes.
-pub fn expand_force_materialize(graph: &LockfileGraph, seed: &[String]) -> ForceMaterializePlan {
-    match FM_EXPAND_HOOK.get() {
+/// map, so the caller's `with_disk_materialize(&plan.names)` is identical to the
+/// pre-existing `with_disk_materialize(&seed)` and nothing else changes.
+pub fn expand_disk_materialize(graph: &LockfileGraph, seed: &[String]) -> DiskMaterializePlan {
+    match DM_EXPAND_HOOK.get() {
         Some(hook) => hook(graph, seed),
-        None => ForceMaterializePlan {
+        None => DiskMaterializePlan {
             names: seed.to_vec(),
             hoist_within: BTreeMap::new(),
         },

--- a/vendor/aube/crates/aube-linker/src/lib.rs
+++ b/vendor/aube/crates/aube-linker/src/lib.rs
@@ -11,8 +11,8 @@ use std::path::Path;
 
 mod builder;
 mod clonedir;
+mod disk_materialize;
 mod error;
-mod force_materialize;
 mod hoisted;
 mod link;
 mod materialize;
@@ -26,10 +26,10 @@ mod public_hoist_tests;
 #[cfg(test)]
 mod tests;
 
-pub use error::Error;
-pub use force_materialize::{
-    ForceMaterializePlan, expand_force_materialize, set_force_materialize_expand_hook,
+pub use disk_materialize::{
+    DiskMaterializePlan, expand_disk_materialize, set_disk_materialize_expand_hook,
 };
+pub use error::Error;
 pub use hoisted::HoistedPlacements;
 pub use link::build_nested_link_targets;
 pub(crate) use materialize::{
@@ -265,13 +265,13 @@ pub struct Linker {
     /// Matched by exact name against each graph package. Empty for standalone
     /// callers and every existing test → the GVS pass is byte-for-byte
     /// unchanged.
-    force_materialize: std::collections::HashSet<String>,
+    disk_materialize: std::collections::HashSet<String>,
     /// Rung 2 of selective-subtree materialization: undeclared phantom targets
-    /// to HOIST-WITHIN a force-materialized package's own `node_modules`, keyed
+    /// to HOIST-WITHIN a disk-materialized package's own `node_modules`, keyed
     /// by the importer's dep_path → the target dep_paths. A transitively-phantom
     /// package (`@nuxt/devtools` → the undeclared `unstorage`, `vue-router` →
     /// the optional-peer-but-unlinked `@vue/compiler-sfc`) doesn't declare the
-    /// import, so once it's force-materialized its own `node_modules` has no
+    /// import, so once it's disk-materialized its own `node_modules` has no
     /// sibling for it and Node's walk still 404s. Injecting the target as an
     /// extra sibling (reusing the materialize sibling-wiring, so the target
     /// resolves through its existing `.aube/<entry>`) makes the walk succeed.

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -57,7 +57,7 @@ impl Linker {
             virtual_store_only: self.virtual_store_only,
             no_integrity_read_keys: self.no_integrity_read_keys.clone(),
             link_progress: self.link_progress.clone(),
-            force_materialize: self.force_materialize.clone(),
+            disk_materialize: self.disk_materialize.clone(),
             phantom_hoist: self.phantom_hoist.clone(),
         }
     }
@@ -313,7 +313,7 @@ impl Linker {
                             let local_aube_entry = aube_dir.join(entry_name);
                             let global_entry = self.virtual_store.join(subdir);
 
-                            // Force-materialize: this package must be a real
+                            // Disk-materialize: this package must be a real
                             // project-local directory (not a shared-store
                             // symlink) so its realpath stays inside the project
                             // and Node's upward node_modules walk from inside it
@@ -326,7 +326,7 @@ impl Linker {
                             // Only registry packages reach here — source deps
                             // (git/tarball/file/link) were filtered from
                             // `step1_prep` above and keep the shared-store path;
-                            // the curated force-materialize list is registry-only,
+                            // the curated disk-materialize list is registry-only,
                             // so that gap is unreachable in practice. A
                             // prior GVS install or the fetch prewarm may have left
                             // a symlink here; replace it. An existing real
@@ -340,8 +340,8 @@ impl Linker {
                             // and junction reparse points and returns `InvalidInput`
                             // on a real directory — the same signal `classify_entry_state`
                             // and `detect_aube_dir_gvs_mode` rely on.
-                            if self.force_materialize_matches(&pkg.name) {
-                                // Orphan-safety invariant: force-materialize gives X
+                            if self.disk_materialize_matches(&pkg.name) {
+                                // Orphan-safety invariant: disk-materialize gives X
                                 // a real project-local dir so X's OWN undeclared
                                 // consumer-provided import resolves via the project
                                 // root — but every STORE-RESIDENT dependent of X
@@ -354,16 +354,16 @@ impl Linker {
                                 // which can differ from the link-phase `subdir` a
                                 // dependent's sibling points at (they diverge
                                 // whenever the link phase folds a fingerprint the
-                                // prewarm didn't). A non-force-materialized install
+                                // prewarm didn't). A non-disk-materialized install
                                 // would still WRITE X's store copy at `subdir` here
                                 // (the normal branch below), keeping every dependent
-                                // resolvable; the pre-fix force-materialize branch
+                                // resolvable; the pre-fix disk-materialize branch
                                 // skipped that write, dangling the sibling — the
                                 // `@storybook/builder-webpack5` ← `react-webpack5`
                                 // regression. So ALWAYS keep X's store copy at
                                 // `subdir` IN ADDITION to the project-local dir. The
                                 // store copy is reflinked/CoW and is exactly what a
-                                // non-force-materialized install writes, so this only
+                                // non-disk-materialized install writes, so this only
                                 // RESTORES it — it is not a second full byte copy.
                                 let store_pkg_dir = self
                                     .virtual_store

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -459,10 +459,10 @@ fn test_link_all_creates_pnpm_virtual_store() {
 }
 
 #[test]
-fn force_materialize_makes_only_listed_package_a_real_dir_under_gvs() {
+fn disk_materialize_makes_only_listed_package_a_real_dir_under_gvs() {
     // Under the global virtual store every `.aube/<dep>` is normally a symlink
     // into the shared store, so the package realpath escapes the project. A
-    // package on the force-materialize list must instead be a real
+    // package on the disk-materialize list must instead be a real
     // project-local directory (its realpath back inside the project) so Node's
     // upward walk from inside it reaches a consumer-installed, undeclared
     // backend at the project root — while every OTHER package stays a symlink.
@@ -473,12 +473,12 @@ fn force_materialize_makes_only_listed_package_a_real_dir_under_gvs() {
     let (store, indices) = setup_store_with_files(dir.path());
     let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
         .with_hoist(false)
-        .with_force_materialize(&["foo".to_string()]);
+        .with_disk_materialize(&["foo".to_string()]);
     let graph = make_graph();
 
     linker.link_all(&project_dir, &graph, &indices).unwrap();
 
-    // foo is force-materialized: a real directory, not a shared-store symlink,
+    // foo is disk-materialized: a real directory, not a shared-store symlink,
     // with its files materialized project-local.
     let aube_foo = project_dir.join("node_modules/.aube/foo@1.0.0");
     let foo_is_symlink = aube_foo
@@ -488,7 +488,7 @@ fn force_materialize_makes_only_listed_package_a_real_dir_under_gvs() {
         .is_symlink();
     assert!(
         !foo_is_symlink,
-        "force-materialized foo must be a real dir, not a global-store symlink"
+        "disk-materialized foo must be a real dir, not a global-store symlink"
     );
     assert_eq!(
         std::fs::read_to_string(aube_foo.join("node_modules/foo/index.js")).unwrap(),
@@ -524,12 +524,12 @@ fn force_materialize_makes_only_listed_package_a_real_dir_under_gvs() {
 }
 
 #[test]
-fn force_materialize_keeps_store_copy_so_store_resident_dependents_dont_orphan() {
+fn disk_materialize_keeps_store_copy_so_store_resident_dependents_dont_orphan() {
     // Orphan-safety regression (the shipped @storybook/builder-webpack5 ←
     // @storybook/react-webpack5 class). The graph is root → foo → bar; here bar
-    // is force-materialized while foo stays a store symlink. foo reaches bar
+    // is disk-materialized while foo stays a store symlink. foo reaches bar
     // through its store entry's sibling symlink, which targets
-    // `<store>/<subdir(bar)>/node_modules/bar`. If the force-materialize branch
+    // `<store>/<subdir(bar)>/node_modules/bar`. If the disk-materialize branch
     // only wrote bar's project-local real dir and skipped bar's store copy, that
     // sibling would dangle — the exact orphan the builder-webpack5 case hit. The
     // fix keeps bar's store copy at its subdir IN ADDITION to the project-local
@@ -541,12 +541,12 @@ fn force_materialize_keeps_store_copy_so_store_resident_dependents_dont_orphan()
     let (store, indices) = setup_store_with_files(dir.path());
     let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
         .with_hoist(false)
-        .with_force_materialize(&["bar".to_string()]);
+        .with_disk_materialize(&["bar".to_string()]);
     let graph = make_graph(); // root -> foo -> bar
 
     linker.link_all(&project_dir, &graph, &indices).unwrap();
 
-    // bar is force-materialized: a real project-local dir.
+    // bar is disk-materialized: a real project-local dir.
     let aube_bar = project_dir.join("node_modules/.aube/bar@2.0.0");
     assert!(
         !aube_bar
@@ -554,7 +554,7 @@ fn force_materialize_keeps_store_copy_so_store_resident_dependents_dont_orphan()
             .unwrap()
             .file_type()
             .is_symlink(),
-        "force-materialized bar must be a real project-local dir"
+        "disk-materialized bar must be a real project-local dir"
     );
 
     // The orphan-safety invariant: bar's store copy still exists at exactly the
@@ -566,7 +566,7 @@ fn force_materialize_keeps_store_copy_so_store_resident_dependents_dont_orphan()
     assert_eq!(
         std::fs::read_to_string(&bar_store_copy).unwrap(),
         "module.exports = 'bar';",
-        "force-materialized bar's store copy must remain at its subdir so a \
+        "disk-materialized bar's store copy must remain at its subdir so a \
          store-resident dependent's sibling symlink still resolves"
     );
 
@@ -578,7 +578,7 @@ fn force_materialize_keeps_store_copy_so_store_resident_dependents_dont_orphan()
     assert_eq!(
         std::fs::read_to_string(&foo_sibling_bar).unwrap(),
         "module.exports = 'bar';",
-        "store-resident foo's sibling to force-materialized bar must resolve (no orphan)"
+        "store-resident foo's sibling to disk-materialized bar must resolve (no orphan)"
     );
 }
 

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -744,7 +744,7 @@ impl LockfileGraph {
     /// is a *foundational* seed (everything imports it); phantom breakers are
     /// empirically never foundational, so a large closure is a signal, not a norm.
     ///
-    /// Why the closure and not the package alone: force-materializing only a
+    /// Why the closure and not the package alone: disk-materializing only a
     /// transitively-consumed package leaves every store-resident importer
     /// resolving the un-materialized shared-store copy — a silent singleton
     /// split (two realpaths, two module instances). Materializing the whole
@@ -759,7 +759,7 @@ impl LockfileGraph {
     /// rebuilt as the plain `{name}@{tail}`, NOT the `name@git+<hash>` /
     /// `name@url+<hash>` form a git/tarball dep carries, so an importer reached
     /// ONLY through a git/tarball intermediary is not walked. This does not weaken
-    /// the force-materialize soundness in practice: force-materialize is
+    /// the disk-materialize soundness in practice: disk-materialize is
     /// registry-only, so such an intermediary could not materialize anyway — the
     /// split it would cause is a boundary of registry-only materialization, not a
     /// missed closure member.

--- a/vendor/aube/crates/aube-manifest/src/workspace/config.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace/config.rs
@@ -99,7 +99,7 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub disable_global_virtual_store_for_packages: Option<Vec<String>>,
 
-    /// Package names force-materialized project-local even under the
+    /// Package names disk-materialized project-local even under the
     /// global virtual store. Unlike
     /// `disable_global_virtual_store_for_packages` (which disables the
     /// GVS for the whole install), this materializes only the named
@@ -111,7 +111,7 @@ pub struct WorkspaceConfig {
     /// `settings.toml`'s workspaceYaml source stays in sync with the
     /// actual deserialize surface.
     #[serde(default)]
-    pub force_materialize_packages: Option<Vec<String>>,
+    pub disk_materialize_packages: Option<Vec<String>>,
 
     /// Package import method: "auto", "hardlink", "copy", "clone", "clone-or-copy".
     #[serde(default)]

--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -1117,8 +1117,8 @@ sources.npmrc = ["disableGlobalVirtualStoreForPackages", "disable-global-virtual
 sources.workspaceYaml = ["disableGlobalVirtualStoreForPackages"]
 examples = []
 
-[forceMaterializePackages]
-description = "Package names force-materialized project-local even under the global virtual store."
+[diskMaterializePackages]
+description = "Package names disk-materialized project-local even under the global virtual store."
 type = "list<string>"
 default = "[]"
 docs = """
@@ -1131,7 +1131,7 @@ a subpath adapter importing a consumer-installed backend it picks at runtime
 reach the project's `node_modules/` from inside the shared store and fails to
 resolve.
 
-Listing the adapter here force-materializes THAT package as a real
+Listing the adapter here disk-materializes THAT package as a real
 project-local directory (reflink/hardlink/copy from the store, near-zero on
 copy-on-write filesystems) while every other package stays a shared-store
 symlink. Its realpath is then project-local, so Node's upward directory walk
@@ -1144,9 +1144,9 @@ The default is empty. `CI=1` and `disableGlobalVirtualStoreForPackages`
 already force per-project materialization, where this setting is a no-op.
 """
 sources.cli = []
-sources.env = ["npm_config_force_materialize_packages", "NPM_CONFIG_FORCE_MATERIALIZE_PACKAGES", "AUBE_FORCE_MATERIALIZE_PACKAGES"]
-sources.npmrc = ["forceMaterializePackages", "force-materialize-packages"]
-sources.workspaceYaml = ["forceMaterializePackages"]
+sources.env = ["npm_config_disk_materialize_packages", "NPM_CONFIG_DISK_MATERIALIZE_PACKAGES", "AUBE_DISK_MATERIALIZE_PACKAGES"]
+sources.npmrc = ["diskMaterializePackages", "disk-materialize-packages"]
+sources.workspaceYaml = ["diskMaterializePackages"]
 examples = []
 
 # ========================================= Store =========================================

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -167,13 +167,13 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     let virtual_store_only = aube_settings::resolved::virtual_store_only(settings_ctx);
     let node_linker = resolve_node_linker(settings_ctx)?;
     tracing::debug!("node-linker: {:?}", node_linker);
-    // Per-package force-materialize: subpath adapters that must be real
+    // Per-package disk-materialize: subpath adapters that must be real
     // project-local dirs even under GVS so their realpath stays inside the
-    // project (see `Linker::with_force_materialize`). Empty on standalone aube
+    // project (see `Linker::with_disk_materialize`). Empty on standalone aube
     // (settings default `[]`); nub seeds the curated list as an embedder
     // default. Consulted by the linker only in the GVS pass.
-    let force_materialize_packages =
-        aube_settings::resolved::force_materialize_packages(settings_ctx);
+    let disk_materialize_packages =
+        aube_settings::resolved::disk_materialize_packages(settings_ctx);
     // Embedder-pluggable expansion (selective-subtree materialization): a host
     // (nub) installs a hook that expands the flat seed into a graph-aware plan —
     // rung 1 grows each seed to its ancestor-closure so a transitively-consumed
@@ -181,8 +181,7 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     // rung 2 adds per-package undeclared-phantom-target hoists. Standalone aube
     // installs no hook, so the plan is the seed verbatim with no hoist —
     // byte-for-byte the prior behavior.
-    let fm_plan =
-        aube_linker::expand_force_materialize(graph_for_link, &force_materialize_packages);
+    let dm_plan = aube_linker::expand_disk_materialize(graph_for_link, &disk_materialize_packages);
 
     let mut linker = aube_linker::Linker::new(store, strategy)
         .with_shamefully_hoist(shamefully_hoist)
@@ -208,8 +207,8 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
             cwd,
             graph_for_link.packages.values(),
         ))
-        .with_force_materialize(&fm_plan.names)
-        .with_phantom_hoist(fm_plan.hoist_within);
+        .with_disk_materialize(&dm_plan.names)
+        .with_phantom_hoist(dm_plan.hoist_within);
     if let Some(enabled) = use_global_virtual_store_override {
         linker = linker.with_use_global_virtual_store(enabled);
     }

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -172,7 +172,7 @@ pub(super) fn find_gvs_incompatible_trigger<'a>(
 ///
 /// Symlink-PRIORITY classification: any single symlink entry means the tree
 /// is in global-virtual-store mode. GVS-on trees are NOT necessarily uniform
-/// — `forceMaterializePackages` makes a handful of adapter entries real dirs
+/// — `diskMaterializePackages` makes a handful of adapter entries real dirs
 /// while the rest stay shared-store symlinks, a legitimately MIXED tree — so
 /// classifying from the first `read_dir` entry would be order-dependent (a
 /// forced real dir landing first would misread the whole tree as per-project
@@ -1264,8 +1264,8 @@ mod gvs_mode_detect_tests {
     use super::*;
     use std::os::unix::fs::symlink;
 
-    // `forceMaterializePackages` produces a MIXED `.aube` tree — some entries
-    // are shared-store symlinks, some are force-materialized real dirs. The
+    // `diskMaterializePackages` produces a MIXED `.aube` tree — some entries
+    // are shared-store symlinks, some are disk-materialized real dirs. The
     // detector must classify such a tree as GVS-on regardless of `read_dir`
     // order; a forced real dir landing first must NOT misread it as per-project
     // (which would wipe node_modules on every install).

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -1265,14 +1265,14 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
         hasher.update(b"\x1f");
     }
     hasher.update(b"\0");
-    // force_materialize_packages changes which `.aube/<dep>` entries are real
+    // disk_materialize_packages changes which `.aube/<dep>` entries are real
     // dirs vs shared-store symlinks under GVS. Introducing or editing the list
     // must invalidate the install state so the link phase re-runs and converts
     // a stale symlink to a materialized dir (or back) — else the existence-gated
     // step1 accepts the wrong on-disk shape as cached.
-    let force_materialize_packages = aube_settings::resolved::force_materialize_packages(&ctx);
-    hasher.update(b"force_materialize_packages=");
-    for p in &force_materialize_packages {
+    let disk_materialize_packages = aube_settings::resolved::disk_materialize_packages(&ctx);
+    hasher.update(b"disk_materialize_packages=");
+    for p in &disk_materialize_packages {
         hasher.update(p.as_bytes());
         hasher.update(b"\x1f");
     }


### PR DESCRIPTION
Clean rename aligning the per-package materialization knob with the locked `install.materialization: symlink|disk` axis. Nothing shipped in a nub release, so no alias — every occurrence renamed:

- Setting `forceMaterializePackages` → `diskMaterializePackages` (settings.toml + npmrc/env/yaml keys; `resolved::disk_materialize_packages` accessor follows).
- Linker internals `force_materialize*`/`ForceMaterializePlan`/`FmExpandHook` → `disk_materialize`/`DiskMaterialize`; module renamed.

Default is the empty list, so the resolved layout is byte-for-byte unchanged (aube + nub). First of two PRs; the GVS/hoist structural collapse follows stacked.