### PR TITLE
docs(install): drop Nuxt from the whole-install project-local-store list

### DIFF
--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -476,7 +476,7 @@ Add your own with one line in `.npmrc`:
 forceMaterializePackages[]=my-adapter
 ```
 
-A bundler that resolves modules by their real path — Metro (bare React Native), Next.js, Nuxt, Parcel — only crawls the project directory, so it can't see the shared store. Nub gives those projects a self-contained, project-local store automatically. Extend the list in `.npmrc`:
+A bundler that resolves modules by their real path — Metro (bare React Native), Next.js, Parcel — only crawls the project directory, so it can't see the shared store. Nub gives those projects a self-contained, project-local store automatically. Extend the list in `.npmrc`:
 
 ```ini
 disableGlobalVirtualStoreForPackages[]=my-bundler


### PR DESCRIPTION
The whole-install project-local-store list on the install page named Nuxt, but Nuxt no longer takes a whole-install store. Under the default shared store it ejects only `nuxt` and its phantom closure project-local; ordinary deps stay symlinked into the global virtual store. Verified out of the box — install, dev, build, and preview all pass on a fresh Nuxt 4 scaffold, with `vue`/`vue-router` resolving into the global store and only `nuxt` ejected. The list is now Metro (bare React Native), Next.js, and Parcel.
