### PR TITLE
fix(resolver): auto-installed peers bind a resolved major, not the registry highest

### DIFF
--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -787,3 +787,53 @@ fn frozen_install_with_trust_downgrade_still_aborts() {
         "no package may be linked when the trust gate aborts resolution"
     );
 }
+
+/// Regression (Expo/RN out-of-box failure): an auto-installed WILDCARD peer
+/// must bind to a major already present in the resolved graph, never a
+/// registry-highest major nothing declared a dependency on.
+///
+/// `react-native-worklets@0.10.1` declares `@babel/core: "*"` as a peer with
+/// no co-declared dependency, while `react-native@0.86.0` hard-deps
+/// `@babel/core: "^7.25.2"` (→ a 7.x). pnpm binds the `*` peer to that 7.x.
+/// nub used to resolve the auto-installed peer inline mid-BFS, racing the hard
+/// dep; when the peer won it fetched the registry-highest `@babel/core` (8.x)
+/// that no range asked for, so Metro's Worklets babel plugin rejected the tree
+/// (`Requires Babel "^7.0.0-0", but was loaded with "8.0.1"`) and `expo
+/// export` failed. The fix parks auto-installed peers until the tree resolves,
+/// so the peer reuses the graph's 7.x. Assert no `@babel/core` 8.x lands.
+#[test]
+#[ignore = "network: installs react-native + react-native-worklets from the npm registry"]
+fn wildcard_peer_binds_resolved_major_not_registry_highest() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("wildcard-peer");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"wp","version":"1.0.0","dependencies":{"react-native":"0.86.0","react-native-worklets":"0.10.1"}}"#,
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run_install(&dir, &["install"]);
+    assert_eq!(code, 0, "install must succeed: {stdout}{stderr}");
+
+    // The isolated store keys every resolved version as `@babel+core@<ver>`;
+    // @babel/core declares no peers so its own dirs carry no peer suffix.
+    let store = dir.join("node_modules/.nub");
+    let babel_majors: Vec<String> = std::fs::read_dir(&store)
+        .expect("virtual store must exist under node_modules/.nub")
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter_map(|n| n.strip_prefix("@babel+core@").map(str::to_string))
+        .collect();
+    assert!(
+        !babel_majors.is_empty(),
+        "react-native hard-deps @babel/core, so a version must resolve: {stderr}"
+    );
+    assert!(
+        babel_majors.iter().all(|v| v.starts_with("7.")),
+        "the `*` @babel/core peer must reuse the resolved 7.x, never introduce \
+         a higher major; store held: {babel_majors:?}"
+    );
+}

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -106,6 +106,15 @@ pub(crate) struct ResolveDriver<'a> {
     /// (i.e. wave 0 of direct deps hasn't finished). Re-enqueued in
     /// FIFO order once the cutoff fires.
     deferred_transitives: Vec<ResolveTask>,
+    /// Auto-installed (`auto-install-peers=true`) transitive peers, parked
+    /// until the ENTIRE main tree has resolved and drained in the
+    /// queue-empty branch of `bfs_loop`. Mirrors pnpm's peer hoist as a
+    /// second phase: a missing peer binds to the highest ALREADY-RESOLVED
+    /// version satisfying its range, never the registry-wide highest — so a
+    /// wildcard/loose peer resolved before the hard deps that constrain it
+    /// can't drag a major nothing depends on into the graph (the Expo/RN
+    /// `@babel/core` 8-vs-7 break). Full rationale at the drain site.
+    deferred_auto_peers: Vec<ResolveTask>,
 
     /// ISO-8601 UTC cutoff string used by the version picker. Seeded
     /// from `minimum_release_age` for supply-chain mitigation;
@@ -265,6 +274,7 @@ impl<'a> ResolveDriver<'a> {
             failed_fetches: FxHashMap::default(),
             catalog_picks: BTreeMap::new(),
             deferred_transitives: Vec::new(),
+            deferred_auto_peers: Vec::new(),
             published_by,
             time_cutoff: None,
             age_gate_cutoff,
@@ -418,6 +428,26 @@ impl<'a> ResolveDriver<'a> {
                             self.deferred_transitives.len()
                         ),
                     ));
+                }
+                // Main tree fully resolved: bind the parked auto-installed
+                // peers against the complete preferred pool, one at a time so a
+                // genuinely-missing peer that must hit the registry contributes
+                // its own transitives (and nested peers) back before the next
+                // is bound. `try_peer_reuse` reuses the highest already-resolved
+                // satisfying version; a peer nothing satisfies (or one whose
+                // range is a `catalog:`/`npm:` spec that fails the semver check)
+                // falls through to `process_task` via `queue`, which applies
+                // the catalog/alias/override rewrites. We deliberately do NOT
+                // pre-apply overrides to the reuse path: pnpm applies a
+                // `parent>child` override to a real dependency edge (which
+                // seeds `resolved_versions`, so the peer already reuses the
+                // overridden version) but NOT to a peer edge, so reusing the
+                // raw range here matches pnpm — verified empirically.
+                if let Some(peer_task) = self.deferred_auto_peers.pop() {
+                    if !self.try_peer_reuse(&peer_task) {
+                        self.queue.push_back(peer_task);
+                    }
+                    continue;
                 }
                 return Ok(());
             };
@@ -1177,8 +1207,10 @@ impl<'a> ResolveDriver<'a> {
         // for aliased packages where `name` alone (`h3-v2`)
         // would 404.
         if let Some(ref tx) = self.resolver.resolved_tx {
-            let pending =
-                self.queue.len() + self.fetcher.in_flight_count() + self.deferred_transitives.len();
+            let pending = self.queue.len()
+                + self.fetcher.in_flight_count()
+                + self.deferred_transitives.len()
+                + self.deferred_auto_peers.len();
             let _ = tx
                 .send(ResolvedPackage {
                     dep_path: dep_path.clone(),
@@ -1533,7 +1565,11 @@ impl<'a> ResolveDriver<'a> {
                 {
                     self.ensure_fetch(dep_name);
                 }
-                self.queue.push_back(ResolveTask::transitive(
+                // Park, don't enqueue: bound only after the main tree drains
+                // (see `deferred_auto_peers` / the drain in `bfs_loop`), so the
+                // peer reuses an already-resolved version instead of racing the
+                // hard deps and pulling in a registry-highest major.
+                self.deferred_auto_peers.push(ResolveTask::transitive(
                     dep_name.clone(),
                     dep_range.clone(),
                     DepType::Production,
@@ -1792,7 +1828,8 @@ impl<'a> ResolveDriver<'a> {
             if let Some(ref tx) = self.resolver.resolved_tx {
                 let pending = self.queue.len()
                     + self.fetcher.in_flight_count()
-                    + self.deferred_transitives.len();
+                    + self.deferred_transitives.len()
+                    + self.deferred_auto_peers.len();
                 let _ = tx
                     .send(ResolvedPackage {
                         dep_path: dep_path.clone(),
@@ -2208,7 +2245,8 @@ impl<'a> ResolveDriver<'a> {
             if let Some(ref tx) = self.resolver.resolved_tx {
                 let pending = self.queue.len()
                     + self.fetcher.in_flight_count()
-                    + self.deferred_transitives.len();
+                    + self.deferred_transitives.len()
+                    + self.deferred_auto_peers.len();
                 let _ = tx
                     .send(ResolvedPackage {
                         dep_path: dep_path.clone(),
@@ -2355,6 +2393,40 @@ impl<'a> ResolveDriver<'a> {
             return false;
         };
         self.link_to_existing_version(task, &matched_ver);
+        true
+    }
+
+    /// Bind a parked auto-installed peer to the HIGHEST already-resolved
+    /// version satisfying its range — pnpm's `maxSatisfying(preferredVersions,
+    /// range)` for a hoisted missing peer. Distinct from `try_sibling_dedupe`
+    /// (first-satisfying): a `*` peer must pick the tallest resolved major the
+    /// graph actually settled on, matching what pnpm hoists, rather than
+    /// whichever happened to resolve first. Runs only in the drain phase, when
+    /// `resolved_versions` holds the full preferred pool. Returns false when
+    /// nothing resolved satisfies the range — a genuinely missing peer the
+    /// caller then routes to the registry fetch path.
+    fn try_peer_reuse(&mut self, task: &ResolveTask) -> bool {
+        let Some(best) = self.resolved_versions.get(&task.name).and_then(|versions| {
+            versions
+                .iter()
+                .filter(|v| {
+                    version_satisfies(v, &task.range)
+                        && !is_vulnerable(task.registry_name(), v, &self.resolver.vulnerable_ranges)
+                })
+                .max_by(|a, b| {
+                    match (
+                        node_semver::Version::parse(a),
+                        node_semver::Version::parse(b),
+                    ) {
+                        (Ok(av), Ok(bv)) => av.cmp(&bv),
+                        _ => a.as_str().cmp(b.as_str()),
+                    }
+                })
+                .cloned()
+        }) else {
+            return false;
+        };
+        self.link_to_existing_version(task, &best);
         true
     }
 }


### PR DESCRIPTION
Fixes an out-of-box install failure on Expo / React Native: a fresh scaffold with `react-native-reanimated` installs cleanly, but `expo export` (and Metro dev bundling) fails with:

```
[Worklets] Requires Babel "^7.0.0-0", but was loaded with "8.0.1".
```

No open issue tracks this; it was found by a framework install-matrix sweep.

## Root cause

`react-native-worklets` declares `@babel/core: "*"` as a peer with no co-declared dependency, and `react-native` hard-deps `@babel/core: "^7.25.2"` (→ 7.29.7). Nothing in the graph hard-deps a babel 8 — `@babel/core@8.0.1` is only an uninstalled transitive devDependency.

With `auto-install-peers=true` (pnpm's default), a missing peer like this gets auto-installed. pnpm hoists missing peers as a second phase *after* the dependency tree is built, binding each to `maxSatisfying(preferredVersions, range)` over versions already resolved in the graph — so the `*` peer resolves to 7.29.7 and babel 8 never enters the tree.

nub resolved the auto-installed peer inline in its single resolution pass. When a `*` peer's version pick won the race against the hard dependency that constrains it, `pick_version` took the registry-highest satisfying version (8.0.1) — a major nothing declared a dependency on. That poisoned the resolved-version pool, so the whole tree bound babel 8 and Metro's Worklets plugin rejected it.

## Fix

Auto-installed transitive peers are parked in a new `deferred_auto_peers` queue instead of the main resolution queue, and drained only once the whole tree has resolved — mirroring pnpm's post-tree peer hoist. Each parked peer binds to the highest already-resolved version satisfying its range; only a genuinely missing peer (nothing resolved satisfies) falls through to a registry fetch. This makes the aube resolver match pnpm and never introduce a major that no dependency requested.

## Verification

Minimal fixture (`react-native@0.86.0` + `react-native-worklets@0.10.1`), before → after:

- Before: `@babel/core` resolves to both 7.29.7 and 8.0.1; worklets binds 8.0.1.
- After: only 7.29.7; worklets binds 7.29.7. Matches pnpm 10.

Full Expo scaffold with reanimated:

- Before: `expo export` fails with the Worklets babel error above.
- After: `expo export` succeeds (iOS bundle, 938 modules).

Gates: `clippy --all-targets --all-features -D warnings` clean, `fmt` clean, the aube-resolver suite passes (259 tests), and a new `#[ignore]` network regression test (`wildcard_peer_binds_resolved_major_not_registry_highest`) passes with the fix and fails without it.

The change is scoped to transitive auto-installed peers, where the failure occurs.

https://claude.ai/code/session_01Xuh9u8b93eMNu53fTQTWX7
