### PR TITLE
fix(ci-watch): never hang on a nameless/stuck-pending ghost check

### DIFF
--- a/.claude/skills/ci-watch/SKILL.md
+++ b/.claude/skills/ci-watch/SKILL.md
@@ -42,7 +42,7 @@ node scripts/ci-watch.ts --pr  <number> [--repo o/r] [--timeout <min>]
 - `--pr <number>` — watch a PR's check rollup (polls `gh pr view --json statusCheckRollup,…`).
 - `--repo <owner/repo>` — defaults to the current repo.
 - `--timeout <minutes>` — wall-clock cap before giving up as pending (default 45).
-- `--required <names>` — comma-separated branch-protection check names to gate on (e.g. `--required "CI gate"`). Success fires the instant every required check is green; any ghost / non-required pending check is non-blocking. The precise, hang-proof gate for a merge watcher — prefer it when you know the required check name.
+- `--required <names>` — comma-separated branch-protection check names to gate on (e.g. `--required "CI gate"`). Success fires the instant every required check is green; a ghost or a non-required check — pending *or* failed — never blocks, matching branch-protection semantics. The precise, hang-proof gate for a merge watcher — prefer it when you know the required check name.
 - `--no-progress <minutes>` — how long an unchanged incomplete set (all required/named checks already green, only a ghost left) may sit before exiting 4 STUCK-but-safe (default 8).
 
 What it fixes: **waits for the target to EXIST** (a not-found / no-jobs-yet target is "keep polling," never "done"); polls **authoritative** terminal state (`status == "completed"` / every required/named rollup item terminal+green); **fails fast** on the first FAILURE/CANCELLED/TIMED_OUT/STARTUP_FAILURE; **never hangs on a ghost** (see below); **tolerates transient** gh/API errors (retried with backoff, not treated as a run failure); uses gh's stored token implicitly (high rate limit) with exponential jittered backoff (10s → cap 60s, 90s if unauthenticated).

--- a/.claude/skills/ci-watch/SKILL.md
+++ b/.claude/skills/ci-watch/SKILL.md
@@ -42,8 +42,14 @@ node scripts/ci-watch.ts --pr  <number> [--repo o/r] [--timeout <min>]
 - `--pr <number>` — watch a PR's check rollup (polls `gh pr view --json statusCheckRollup,…`).
 - `--repo <owner/repo>` — defaults to the current repo.
 - `--timeout <minutes>` — wall-clock cap before giving up as pending (default 45).
+- `--required <names>` — comma-separated branch-protection check names to gate on (e.g. `--required "CI gate"`). Success fires the instant every required check is green; any ghost / non-required pending check is non-blocking. The precise, hang-proof gate for a merge watcher — prefer it when you know the required check name.
+- `--no-progress <minutes>` — how long an unchanged incomplete set (all required/named checks already green, only a ghost left) may sit before exiting 4 STUCK-but-safe (default 8).
 
-What it fixes: **waits for the target to EXIST** (a not-found / no-jobs-yet target is "keep polling," never "done"); polls **authoritative** terminal state (`status == "completed"` / all rollup items terminal); **fails fast** on the first FAILURE/CANCELLED/TIMED_OUT/STARTUP_FAILURE; **tolerates transient** gh/API errors (retried with backoff, not treated as a run failure); uses gh's stored token implicitly (high rate limit) with exponential jittered backoff (10s → cap 60s, 90s if unauthenticated).
+What it fixes: **waits for the target to EXIST** (a not-found / no-jobs-yet target is "keep polling," never "done"); polls **authoritative** terminal state (`status == "completed"` / every required/named rollup item terminal+green); **fails fast** on the first FAILURE/CANCELLED/TIMED_OUT/STARTUP_FAILURE; **never hangs on a ghost** (see below); **tolerates transient** gh/API errors (retried with backoff, not treated as a run failure); uses gh's stored token implicitly (high rate limit) with exponential jittered backoff (10s → cap 60s, 90s if unauthenticated).
+
+### The #327 ghost — why a strict "all checks terminal" gate hangs
+
+GitHub occasionally registers a check-run that never reports a status: it stays PENDING, nameless, forever. A watcher that waits for *every* rollup item to be terminal then blocks indefinitely even though every real check is green — PR [#327](https://github.com/nubjs/nub/issues/327) sat reviewed-and-green for hours this way, its merge watcher parked on one nameless ghost. The fix: a nameless / never-terminating non-required check does not block a green verdict. Once every named check is green and the incomplete set has been unchanged for `--no-progress` minutes, the watcher exits **4 (STUCK-but-safe)** with an actionable summary — the caller `--admin` merges instead of hanging. A *named* pending check is never treated as a ghost, so a real in-flight check is never green-lit early.
 
 ### Exit-code contract
 
@@ -51,10 +57,11 @@ What it fixes: **waits for the target to EXIST** (a not-found / no-jobs-yet targ
 | ---- | ------- |
 | 0 | completed AND all green |
 | 1 | a check/job failed (the summary names which + the URL) |
-| 2 | still pending after `--timeout` |
+| 2 | required/named checks still NOT green after `--timeout` (genuinely stuck) |
 | 3 | usage / target-unresolvable / unrecoverable error |
+| 4 | STUCK-but-safe — required/named checks all green, but a ghost check will never terminate; safe to `--admin` merge (the caller decides) |
 
-The final stdout line is a single self-describing summary, e.g. `CI-WATCH run 27972328590: SUCCESS (25 job(s) green)` or `CI-WATCH pr 73: FAILURE — check "Test (ubuntu-latest, node 22.13)" → FAILURE (https://…)`.
+The final stdout line is a single self-describing summary, e.g. `CI-WATCH run 27972328590: SUCCESS (25 job(s) green)`, `CI-WATCH pr 73: FAILURE — check "Test (ubuntu-latest, node 22.13)" → FAILURE (https://…)`, or `CI-WATCH pr 327: STUCK — required/named checks GREEN (51), 1 non-terminal ghost/non-required check(s): (unnamed); safe to --admin merge`.
 
 ### Run it detached (CAVEAT: a long wait STRANDS — see the cron-heartbeat section below; this is for SHORT, synchronously-observed gates only)
 

--- a/scripts/ci-watch.test.mjs
+++ b/scripts/ci-watch.test.mjs
@@ -106,3 +106,37 @@ test("chunk cap: exits 2 with a RERUN message when the chunk deadline passes (lo
   assert.equal(exit.code, 2);
   assert.match(exit.summary, /RERUN/);
 });
+
+// --- review-hardening: branch-protection-faithful --required + deadline-during-gh-streak ---
+
+test("--required mode: a FAILING non-required check does NOT block (branch-protection faithful)", () => {
+  const rollup = [check("CI gate", "SUCCESS"), check("optional lint", "FAILURE"), ghost()];
+  const v = classifyPr(JSON.stringify({ statusCheckRollup: rollup }), new Set(["CI gate"]));
+  assert.equal(v.kind, "success", "an optional red check must not refuse to merge a mergeable PR");
+});
+
+test("--required mode: a FAILING required check DOES block → exit 1 failure", () => {
+  const v = classifyPr(JSON.stringify({ statusCheckRollup: [check("CI gate", "FAILURE"), check("optional", "SUCCESS")] }), new Set(["CI gate"]));
+  assert.equal(v.kind, "failure");
+  assert.match(v.reason, /CI gate/);
+});
+
+test("--required mode: duplicate required name (first green, second pending) blocks — every occurrence must be green", () => {
+  const rollup = [check("CI gate", "SUCCESS"), { __typename: "CheckRun", name: "CI gate", status: "IN_PROGRESS", startedAt: "t" }];
+  const b = classifyRollup(rollup, new Set(["CI gate"]));
+  assert.deepEqual(b.requiredMissing, ["CI gate"], "a same-named still-running required check must not be green-lit");
+  assert.equal(verdictForBuckets(b, true).kind, "pending");
+});
+
+test("deadline fires during a gh-failure streak: null verdict past the overall deadline → exit 2, does not hang", () => {
+  const exit = resolvePendingExit(null, "pr 9", 10, { lastSig: null, lastProgressAt: 0 }, cfg({ deadline: 0 }));
+  assert.ok(exit, "a stalled poll must not wait forever");
+  assert.equal(exit.code, 2);
+  assert.match(exit.summary, /no check status resolved/);
+});
+
+test("deadline fires during a gh-failure streak: chunk cap on a null verdict → exit 2 RERUN", () => {
+  const exit = resolvePendingExit(null, "pr 9", 10, { lastSig: null, lastProgressAt: 0 }, cfg({ chunkDeadline: 0, chunkMin: 9 }));
+  assert.equal(exit.code, 2);
+  assert.match(exit.summary, /RERUN/);
+});

--- a/scripts/ci-watch.test.mjs
+++ b/scripts/ci-watch.test.mjs
@@ -1,0 +1,108 @@
+// Tests for scripts/ci-watch.ts — the anti-hang logic that closed the #327 drop.
+// Pure classifier/resolver only (no gh, no real clock). Run: node --test scripts/ci-watch.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyRollup, verdictForBuckets, classifyPr, signatureOf, resolvePendingExit } from "./ci-watch.ts";
+
+const NP_MS = 8 * 60_000;
+// Config with a far-future overall deadline so tests exercise the no-progress
+// path in isolation unless they deliberately set `deadline` in the past.
+const cfg = (over = {}) => ({ deadline: Date.now() + 60 * 60_000, chunkDeadline: null, noProgressMs: NP_MS, chunkMin: null, timeoutMin: 45, ...over });
+
+const check = (name, conclusion) => ({ __typename: "CheckRun", name, status: "COMPLETED", conclusion, startedAt: "t", completedAt: "t" });
+const ghost = () => ({ __typename: "CheckRun", status: "IN_PROGRESS" }); // nameless, never-terminating (the #327 shape)
+const the327 = () => [...Array.from({ length: 51 }, (_, i) => check(`check ${i}`, "SUCCESS")), ghost()];
+
+test("#327 shape: 51 green named checks + 1 nameless ghost → ghostsOnly, not success/failure", () => {
+  const v = verdictForBuckets(classifyRollup(the327(), new Set()), false);
+  assert.equal(v.kind, "pending");
+  assert.equal(v.ghostsOnly, true);
+  assert.equal(v.greenNamed, 51);
+  assert.deepEqual(v.ghosts, ["(unnamed)"]);
+});
+
+test("#327 ghost is given up on after the no-progress window → exit 4 STUCK-but-safe, promptly", () => {
+  const v = classifyPr(JSON.stringify({ statusCheckRollup: the327() }), new Set());
+  const timing = { lastSig: signatureOf(v), lastProgressAt: 0 }; // stalled long ago
+  const exit = resolvePendingExit(v, "pr 327", NP_MS + 1, timing, cfg());
+  assert.ok(exit, "must exit, not hang");
+  assert.equal(exit.code, 4);
+  assert.match(exit.summary, /STUCK/);
+  assert.match(exit.summary, /safe to --admin merge/);
+  assert.match(exit.summary, /GREEN \(51\)/);
+});
+
+test("ghost has NOT yet stalled long enough → keep waiting (null), never premature-exit-4", () => {
+  const v = classifyPr(JSON.stringify({ statusCheckRollup: the327() }), new Set());
+  const now = 1_000_000;
+  const timing = { lastSig: signatureOf(v), lastProgressAt: now - (NP_MS - 5_000) }; // 5s short of window
+  assert.equal(resolvePendingExit(v, "pr 327", now, timing, cfg()), null);
+});
+
+test("a REAL named pending check is NEVER green-lit early — waits, then exits 2 (not safe) at the deadline", () => {
+  const rollup = [check("fast", "SUCCESS"), { __typename: "CheckRun", name: "CI gate", status: "IN_PROGRESS", startedAt: "t" }];
+  const v = classifyPr(JSON.stringify({ statusCheckRollup: rollup }), new Set());
+  assert.equal(v.kind, "pending");
+  assert.equal(v.ghostsOnly, false, "a named pending check is real, not a ghost");
+  // No-progress window must NOT fire for a real pending check (would green-light a running check).
+  const timing = { lastSig: signatureOf(v), lastProgressAt: 0 };
+  assert.equal(resolvePendingExit(v, "pr 9", NP_MS + 1, timing, cfg()), null);
+  // Only the overall deadline stops it — and reports NOT green (exit 2).
+  const exit = resolvePendingExit(v, "pr 9", 10, timing, cfg({ deadline: 0 }));
+  assert.equal(exit.code, 2);
+  assert.match(exit.summary, /TIMEOUT/);
+  assert.match(exit.summary, /NOT green/);
+  assert.match(exit.summary, /CI gate/);
+});
+
+test("fail-fast: a terminal failing check short-circuits to failure", () => {
+  const v = verdictForBuckets(classifyRollup([check("ok", "SUCCESS"), check("build", "FAILURE"), ghost()], new Set()), false);
+  assert.equal(v.kind, "failure");
+  assert.match(v.reason, /build/);
+});
+
+test("--required mode: required gate green + nameless ghost pending → immediate SUCCESS (ghost ignored)", () => {
+  const rollup = [check("CI gate", "SUCCESS"), check("some job", "SUCCESS"), ghost()];
+  const v = classifyPr(JSON.stringify({ statusCheckRollup: rollup }), new Set(["CI gate"]));
+  assert.equal(v.kind, "success");
+});
+
+test("--required mode: required gate still pending → pending, and exits 2 (not safe) at the deadline", () => {
+  const rollup = [check("some job", "SUCCESS"), { __typename: "CheckRun", name: "CI gate", status: "IN_PROGRESS", startedAt: "t" }];
+  const v = classifyPr(JSON.stringify({ statusCheckRollup: rollup }), new Set(["CI gate"]));
+  assert.equal(v.kind, "pending");
+  const exit = resolvePendingExit(v, "pr 9", 10, { lastSig: signatureOf(v), lastProgressAt: 0 }, cfg({ deadline: 0 }));
+  assert.equal(exit.code, 2);
+  assert.match(exit.summary, /CI gate/);
+});
+
+test("--required mode: a required check entirely ABSENT from the rollup blocks (partial-rollup guard)", () => {
+  const b = classifyRollup([check("some job", "SUCCESS")], new Set(["CI gate"]));
+  assert.deepEqual(b.requiredMissing, ["CI gate"]);
+  assert.equal(verdictForBuckets(b, true).kind, "pending");
+});
+
+test("StatusContext is named by its `context` field (Vercel), not misread as unnamed", () => {
+  const rollup = [check("job", "SUCCESS"), { __typename: "StatusContext", context: "Vercel", state: "PENDING" }];
+  const b = classifyRollup(rollup, new Set());
+  assert.deepEqual(b.realPending, ["Vercel"], "a named legacy status is a real pending check, not a ghost");
+  assert.deepEqual(b.ghosts, []);
+});
+
+test("empty rollup → pending 'no checks registered yet' (wait-for-existence preserved)", () => {
+  const v = classifyPr(JSON.stringify({ statusCheckRollup: [] }), new Set());
+  assert.equal(v.kind, "pending");
+  assert.match(v.reason, /no checks registered yet/);
+});
+
+test("all checks terminal + green, no ghost → clean SUCCESS (exit 0 path)", () => {
+  const v = classifyPr(JSON.stringify({ statusCheckRollup: [check("a", "SUCCESS"), check("b", "NEUTRAL"), check("c", "SKIPPED")] }), new Set());
+  assert.equal(v.kind, "success");
+});
+
+test("chunk cap: exits 2 with a RERUN message when the chunk deadline passes (loop signal preserved)", () => {
+  const v = classifyPr(JSON.stringify({ statusCheckRollup: [{ __typename: "CheckRun", name: "CI gate", status: "IN_PROGRESS", startedAt: "t" }] }), new Set());
+  const exit = resolvePendingExit(v, "pr 9", 100, { lastSig: signatureOf(v), lastProgressAt: 100 }, cfg({ chunkDeadline: 0, chunkMin: 9 }));
+  assert.equal(exit.code, 2);
+  assert.match(exit.summary, /RERUN/);
+});

--- a/scripts/ci-watch.ts
+++ b/scripts/ci-watch.ts
@@ -94,9 +94,10 @@ Flags:
   --timeout <minutes>   Max wall-clock before giving up as pending (default 45).
   --required <names>    Comma-separated branch-protection check names to gate on
                         (e.g. --required "CI gate"). Success fires as soon as
-                        every required check is green; ghost / non-required
-                        pending checks never block. The precise, hang-proof gate
-                        for a merge watcher.
+                        every required check is green; a ghost or a non-required
+                        check (pending OR failed) never blocks — branch
+                        protection doesn't gate on it. The precise, hang-proof
+                        gate for a merge watcher.
   --no-progress <min>   How long an UNCHANGED incomplete set (all required/named
                         checks already green, only a ghost remaining) may sit
                         before exiting 4 STUCK-but-safe (default 8).
@@ -155,6 +156,7 @@ function parseArgs(argv: string[]): Opts {
     } else if (a === "--required") {
       const csv = argv[++i] ?? die("--required requires a check name (or comma-separated list)");
       for (const n of csv.split(",").map((s) => s.trim()).filter(Boolean)) required.add(n);
+      if (required.size === 0) die("--required was given no non-empty check name");
     } else if (a === "--timeout") {
       timeoutMin = Number(argv[++i]);
       if (!Number.isFinite(timeoutMin) || timeoutMin <= 0) die("--timeout must be a positive number of minutes");
@@ -263,6 +265,7 @@ type Buckets = {
 };
 
 function classifyRollup(rollup: RollupItem[], required: Set<string>): Buckets {
+  const scoped = required.size > 0;
   const failures: string[] = [];
   const realPending: string[] = [];
   const ghosts: string[] = [];
@@ -270,23 +273,34 @@ function classifyRollup(rollup: RollupItem[], required: Set<string>): Buckets {
   for (const it of rollup) {
     const name = itemName(it);
     const st = itemState(it);
+    // In --required mode a NON-required check never blocks — pass OR fail. Branch
+    // protection doesn't gate on it, so a red optional check must not report
+    // FAILURE (that would refuse to merge a mergeable PR). It is non-blocking;
+    // a non-terminal one is surfaced as a ghost, a terminal one is ignored.
+    if (scoped && !required.has(name)) {
+      if (!st.terminal) ghosts.push(name || "(unnamed)");
+      continue;
+    }
     if (st.terminal) {
       if (st.failed) failures.push(name || "(unnamed)");
       else if (name) greenNamed++;
       continue;
     }
-    // Non-terminal. Nameless → ghost. In --required mode a NAMED but non-required
-    // pending check is also non-blocking (branch protection doesn't gate on it).
+    // Non-terminal required-or-any check. Nameless → ghost (the #327 ghost);
+    // named → a real pending check that genuinely gates.
     if (name === "") ghosts.push("(unnamed)");
-    else if (required.size > 0 && !required.has(name)) ghosts.push(name);
     else realPending.push(name);
   }
+  // A required check is satisfied only when EVERY occurrence of its name is
+  // terminal+green — a matrix / re-run can list the same name twice, and branch
+  // protection keys on the latest, so the first-match `find` would green-light a
+  // still-pending same-named check.
   const requiredMissing: string[] = [];
-  if (required.size > 0) {
+  if (scoped) {
     for (const rname of required) {
-      const found = rollup.find((it) => itemName(it) === rname);
-      const st = found ? itemState(found) : null;
-      if (!st || !st.terminal || st.failed) requiredMissing.push(rname);
+      const matches = rollup.filter((it) => itemName(it) === rname);
+      const allGreen = matches.length > 0 && matches.every((it) => { const st = itemState(it); return st.terminal && !st.failed; });
+      if (!allGreen) requiredMissing.push(rname);
     }
   }
   return { failures, realPending, ghosts, greenNamed, total: rollup.length, requiredMissing };
@@ -310,7 +324,7 @@ function verdictForBuckets(b: Buckets, hasRequired: boolean): Verdict {
   if (hasRequired) {
     if (b.requiredMissing.length > 0)
       return { kind: "pending", reason: `required check(s) not green: ${joinCapped(b.requiredMissing, 4)}`, ghostsOnly: false, realPending: b.requiredMissing, ghosts: b.ghosts, greenNamed: b.greenNamed };
-    return { kind: "success", reason: `all required check(s) green (${b.greenNamed}/${b.total} check(s) terminal+green)` };
+    return { kind: "success", reason: `all ${b.greenNamed} required check(s) green (of ${b.total} total; non-required checks non-blocking)` };
   }
   if (b.realPending.length > 0)
     return { kind: "pending", reason: `${b.realPending.length} check(s) pending: ${joinCapped(b.realPending, 4)}`, ghostsOnly: false, realPending: b.realPending, ghosts: b.ghosts, greenNamed: b.greenNamed };
@@ -367,16 +381,22 @@ function signatureOf(v: Verdict): string {
 
 type Timing = { lastSig: string | null; lastProgressAt: number };
 
-// Decide, for a PENDING verdict, whether the watch may keep waiting or must exit
-// now with an actionable verdict — the anti-hang core. Returns null to keep
-// polling, or a terminal {code, summary}. Kept pure (no gh, no clock, no sleep)
-// so the #327 ghost shape is unit-testable without real time or network.
+// Decide whether the watch may keep waiting or must exit now with an actionable
+// verdict — the anti-hang core. Returns null to keep polling, or a terminal
+// {code, summary}. Kept pure (no gh, no clock, no sleep) so the #327 ghost shape
+// is unit-testable without real time or network.
+//
+// `v` is the LAST pending verdict, or null when no successful poll has produced
+// one yet (a gh-failure streak from the start). Called EVERY iteration, including
+// on a failed poll — the deadline/chunk caps must fire even during a transient-gh
+// streak, or a `--chunk` invocation can blow past the Bash-tool timeout and be
+// killed mid-watch.
 //   exit 4 — ghostsOnly persisted past the no-progress window OR the overall
 //            deadline hit with only ghosts left: required/named green, safe.
 //   exit 2 — chunk cap hit (RERUN) or overall deadline hit with a REAL/required
-//            check still pending: genuinely not green, NOT safe to merge.
+//            check still pending (or no status ever resolved): NOT safe to merge.
 function resolvePendingExit(
-  v: Verdict & { kind: "pending" },
+  v: (Verdict & { kind: "pending" }) | null,
   label: string,
   now: number,
   timing: Timing,
@@ -384,14 +404,14 @@ function resolvePendingExit(
 ): { code: number; summary: string } | null {
   const stuckSafe = () => ({
     code: 4,
-    summary: `CI-WATCH ${label}: STUCK — required/named checks GREEN (${v.greenNamed}), ${v.ghosts.length} non-terminal ghost/non-required check(s): ${joinCapped(v.ghosts, 4)}; safe to --admin merge`,
+    summary: `CI-WATCH ${label}: STUCK — required/named checks GREEN (${v ? v.greenNamed : 0}), ${v ? v.ghosts.length : 0} non-terminal ghost/non-required check(s): ${joinCapped(v ? v.ghosts : [], 4)}; safe to --admin merge`,
   });
 
   // A ghost that will never report must not park the watcher forever: once the
   // incomplete set has been UNCHANGED for the no-progress window (all real checks
   // already green), stop and surface it. Progress (a new named check registering)
   // resets lastProgressAt in the caller, so this only fires on a genuine stall.
-  if (v.ghostsOnly && now - timing.lastProgressAt >= cfg.noProgressMs) return stuckSafe();
+  if (v && v.ghostsOnly && now - timing.lastProgressAt >= cfg.noProgressMs) return stuckSafe();
 
   // Chunk cap: sub-agent foreground loop — exit 2 with a RERUN message so it loops.
   if (cfg.chunkDeadline !== null && now > cfg.chunkDeadline) {
@@ -399,10 +419,11 @@ function resolvePendingExit(
   }
 
   // Overall deadline: only-ghosts-left is STUCK-but-safe (exit 4); a real/required
-  // check still pending after the full timeout is genuinely stuck (exit 2).
+  // check still pending (or nothing resolved) after the full timeout is exit 2.
   if (now > cfg.deadline) {
-    if (v.ghostsOnly) return stuckSafe();
-    return { code: 2, summary: `CI-WATCH ${label}: TIMEOUT — required/named check(s) NOT green after ${cfg.timeoutMin}min: ${joinCapped(v.realPending, 4)}` };
+    if (v && v.ghostsOnly) return stuckSafe();
+    const pending = v && v.realPending.length > 0 ? joinCapped(v.realPending, 4) : "no check status resolved";
+    return { code: 2, summary: `CI-WATCH ${label}: TIMEOUT — required/named check(s) NOT green after ${cfg.timeoutMin}min: ${pending}` };
   }
   return null;
 }
@@ -436,11 +457,16 @@ async function watch(opts: Opts): Promise<{ code: number; summary: string }> {
   const deadline = Date.now() + opts.timeoutMin * 60_000;
   const chunkDeadline = opts.chunkMin !== null ? Date.now() + opts.chunkMin * 60_000 : null;
   const noProgressMs = opts.noProgressMin * 60_000;
+  const cfg = { deadline, chunkDeadline, noProgressMs, chunkMin: opts.chunkMin, timeoutMin: opts.timeoutMin };
   let delay = 10_000;
   let consecutiveErrors = 0;
   // Tracks whether the incomplete-check set is still changing — a stuck ghost is
   // only "given up on" after the set has been unchanged for the no-progress window.
   const timing: Timing = { lastSig: null, lastProgressAt: Date.now() };
+  // The last pending verdict a successful poll produced. Retained so the deadline
+  // check below can run — and message accurately — even on an iteration whose poll
+  // failed transiently (null until the first successful poll).
+  let lastPending: (Verdict & { kind: "pending" }) | null = null;
 
   for (;;) {
     const out = ghTry(viewArgs);
@@ -460,17 +486,20 @@ async function watch(opts: Opts): Promise<{ code: number; summary: string }> {
         const url = ghTry(opts.mode === "run" ? ["run", "view", opts.target, ...repoArgs(opts.repo), "--json", "url", "--jq", ".url"] : ["pr", "view", opts.target, ...repoArgs(opts.repo), "--json", "url", "--jq", ".url"]);
         return { code: 1, summary: `CI-WATCH ${label}: FAILURE — ${v.reason}${url ? ` (${url})` : ""}` };
       }
-      // pending: track progress, then let the pure resolver decide exit-vs-wait.
+      // pending: record it and mark progress when the incomplete set changes.
+      lastPending = v;
       const sig = signatureOf(v);
-      const now = Date.now();
       if (sig !== timing.lastSig) {
         timing.lastSig = sig;
-        timing.lastProgressAt = now;
+        timing.lastProgressAt = Date.now();
       }
-      const exit = resolvePendingExit(v, label, now, timing, { deadline, chunkDeadline, noProgressMs, chunkMin: opts.chunkMin, timeoutMin: opts.timeoutMin });
-      if (exit) return exit;
       process.stderr.write(`    … ${v.reason}\n`);
     }
+
+    // Deadline/ghost check runs EVERY iteration (even after a failed poll) so the
+    // overall timeout and the --chunk cap always fire on schedule.
+    const exit = resolvePendingExit(lastPending, label, Date.now(), timing, cfg);
+    if (exit) return exit;
 
     await sleep(delay);
     delay = nextDelay(delay, cap);

--- a/scripts/ci-watch.ts
+++ b/scripts/ci-watch.ts
@@ -9,7 +9,8 @@
 // Runs under BOTH plain Node (type-stripping) and nub:
 //   node scripts/ci-watch.ts --run <run-id>  [--repo o/r] [--timeout <min>]
 //   nub  scripts/ci-watch.ts --pr  <number>  [--repo o/r] [--timeout <min>]
-//   nub  scripts/ci-watch.ts --pr  <number>  --chunk[=<min>]   # foreground sub-agent loop
+//   nub  scripts/ci-watch.ts --pr  <number>  --required "CI gate"   # gate on branch-protection checks
+//   nub  scripts/ci-watch.ts --pr  <number>  --chunk[=<min>]        # foreground sub-agent loop
 //
 // Erasable TypeScript only (no enums/namespaces/parameter-properties) so plain
 // modern `node` runs it with no build step — same constraint as the other
@@ -17,26 +18,43 @@
 //
 // ORCHESTRATOR tooling — designed to run as a detached `run_in_background` task
 // that re-invokes the orchestrator on exit. The final stdout line is a single
-// self-describing summary (CI-WATCH …: SUCCESS/FAILURE/TIMEOUT/ERROR) so the
-// outcome is readable from the tail.
+// self-describing summary (CI-WATCH …: SUCCESS/FAILURE/STUCK/TIMEOUT/ERROR) so
+// the outcome is readable from the tail.
 //
 // Exit codes (the contract the orchestrator gates on):
 //   0  completed AND all green
 //   1  a check/job concluded FAILURE/CANCELLED/TIMED_OUT/STARTUP_FAILURE
-//   2  still pending after --timeout wall-clock (or --chunk cap)
+//   2  required/named checks still NOT green after --timeout (genuinely stuck)
 //   3  usage / target-unresolvable / unrecoverable error
+//   4  STUCK-but-SAFE — every required/named check is GREEN, but a non-terminal
+//      GHOST check (nameless / never-terminating) remains, so a strict "all
+//      checks terminal" gate would hang forever. The caller reads this + the
+//      summary and DECIDES (e.g. `gh pr merge --admin`) instead of the process
+//      hanging on a check that never reports. See "the #327 ghost" below.
+//
+// The #327 ghost: GitHub occasionally registers a check-run that NEVER reports a
+// status — it stays PENDING with no name forever. A watcher that waits for ALL
+// rollup items to be terminal then hangs indefinitely even though every REAL
+// check is green (PR #327 sat green-but-unmerged for hours this way). The fix:
+// a nameless / never-terminating non-required check does NOT block a green
+// verdict — it is surfaced as exit 4 (STUCK-but-safe), never waited on forever.
 //
 // Core fixes over the raw watchers:
 //   * WAIT-FOR-EXISTENCE: a not-found / no-jobs-yet target is "keep polling",
 //     never "done". This is the premature-exit fix.
 //   * AUTHORITATIVE terminal check: done only when status == "completed" (run) /
-//     every rollup item terminal (pr) — never inferred from "nothing running".
+//     every REQUIRED/named rollup item terminal+green (pr) — never inferred from
+//     "nothing running".
 //   * FAIL-FAST: exit non-zero the instant ANY job/check is a failure, without
 //     waiting for the rest (mirrors the AGENTS.md fail-fast rule).
+//   * NEVER-HANG: a ghost (nameless / stuck-pending non-required) check can
+//     never park the watcher forever — a no-progress window converts it to an
+//     actionable exit-4 verdict.
 //   * TRANSIENT-ERROR TOLERANCE: a gh/API hiccup is retried with backoff, not
 //     treated as a run failure.
 
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 // ---- args -------------------------------------------------------------------
 
@@ -46,6 +64,15 @@ type Opts = {
   target: string;
   repo: string | null;
   timeoutMin: number;
+  // --required: the branch-protection checks that actually gate merge. When set,
+  // success fires the instant every named required check is terminal+green — any
+  // other pending check (a ghost, or a non-required job) is non-blocking, so the
+  // watcher matches branch-protection semantics and structurally cannot hang.
+  required: Set<string>;
+  // --no-progress: how long the incomplete-check set may sit UNCHANGED with all
+  // required/named checks already green before the watcher gives up on the
+  // remaining ghost(s) and exits 4 (STUCK-but-safe). Bounds the ghost wait.
+  noProgressMin: number;
   // --chunk: per-invocation wall-clock cap for sub-agent foreground loops.
   // When set and the cap expires, exits 2 with a RERUN message instead of the
   // generic TIMEOUT message, signalling the agent to re-run the same command.
@@ -63,15 +90,25 @@ Modes (exactly one):
   --pr  <number>     Watch a PR's check rollup (gh pr view).
 
 Flags:
-  --repo <owner/repo>  Repository (default: current repo from gh).
-  --timeout <minutes>  Max wall-clock before giving up as pending (default 45).
-  --chunk[=<minutes>]  Sub-agent foreground-loop mode (default 9 min). Caps each
-                       invocation under the 10-min Bash tool timeout; exits 2 with
-                       a RERUN message when the cap expires so the agent can loop.
-                       While exit 2 (pending): re-run the SAME command to continue.
-  -h, --help           Show this help.
+  --repo <owner/repo>   Repository (default: current repo from gh).
+  --timeout <minutes>   Max wall-clock before giving up as pending (default 45).
+  --required <names>    Comma-separated branch-protection check names to gate on
+                        (e.g. --required "CI gate"). Success fires as soon as
+                        every required check is green; ghost / non-required
+                        pending checks never block. The precise, hang-proof gate
+                        for a merge watcher.
+  --no-progress <min>   How long an UNCHANGED incomplete set (all required/named
+                        checks already green, only a ghost remaining) may sit
+                        before exiting 4 STUCK-but-safe (default 8).
+  --chunk[=<minutes>]   Sub-agent foreground-loop mode (default 9 min). Caps each
+                        invocation under the 10-min Bash tool timeout; exits 2
+                        with a RERUN message when the cap expires so the agent
+                        can loop. While exit 2 (pending): re-run the SAME command.
+  -h, --help            Show this help.
 
-Exit codes: 0 success · 1 a check failed · 2 timed out / chunk pending · 3 usage/error.
+Exit codes: 0 all green · 1 a check failed · 2 required/named not green after
+            timeout · 3 usage/error · 4 STUCK-but-safe (required green, a ghost
+            check will never terminate — safe to --admin merge).
 
 Designed to run as a detached run_in_background task; the final stdout line is a
 single CI-WATCH summary the orchestrator reads from the tail.
@@ -79,7 +116,8 @@ single CI-WATCH summary the orchestrator reads from the tail.
 Sub-agent foreground-loop pattern (use when a sub-agent must gate on its own CI):
   # Bash tool: foreground (NOT run_in_background), timeout: 570000
   nub scripts/ci-watch.ts --pr <N> --chunk
-  # exit 0 → green   exit 1 → red, fix + re-push   exit 2 → pending, re-run   exit 3 → error
+  # exit 0 → green   1 → red, fix + re-push   2 → pending, re-run   3 → error
+  # exit 4 → required green but a ghost check is stuck; decide (--admin merge)
   # While exit code is 2, call the same command again. Each chunk completes within
   # the Bash timeout cap so no call is ever killed mid-watch.`;
 
@@ -89,13 +127,16 @@ function die(msg: string): never {
 }
 
 const CHUNK_DEFAULT_MIN = 9;
+const NO_PROGRESS_DEFAULT_MIN = 8;
 
 function parseArgs(argv: string[]): Opts {
   let mode: Mode | null = null;
   let target = "";
   let repo: string | null = null;
   let timeoutMin = 45;
+  let noProgressMin = NO_PROGRESS_DEFAULT_MIN;
   let chunkMin: number | null = null;
+  const required = new Set<string>();
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "-h" || a === "--help") {
@@ -111,9 +152,15 @@ function parseArgs(argv: string[]): Opts {
       target = argv[++i] ?? die("--pr requires a number");
     } else if (a === "--repo") {
       repo = argv[++i] ?? die("--repo requires owner/repo");
+    } else if (a === "--required") {
+      const csv = argv[++i] ?? die("--required requires a check name (or comma-separated list)");
+      for (const n of csv.split(",").map((s) => s.trim()).filter(Boolean)) required.add(n);
     } else if (a === "--timeout") {
       timeoutMin = Number(argv[++i]);
       if (!Number.isFinite(timeoutMin) || timeoutMin <= 0) die("--timeout must be a positive number of minutes");
+    } else if (a === "--no-progress") {
+      noProgressMin = Number(argv[++i]);
+      if (!Number.isFinite(noProgressMin) || noProgressMin <= 0) die("--no-progress must be a positive number of minutes");
     } else if (a === "--chunk") {
       // bare --chunk: use the next arg as the value only if it looks like a number
       const next = argv[i + 1];
@@ -133,7 +180,7 @@ function parseArgs(argv: string[]): Opts {
     }
   }
   if (!mode) die("specify --run <run-id> or --pr <number>");
-  return { mode, target, repo, timeoutMin, chunkMin };
+  return { mode, target, repo, timeoutMin, required, noProgressMin, chunkMin };
 }
 
 // ---- gh plumbing ------------------------------------------------------------
@@ -168,17 +215,130 @@ function hasAuthToken(): boolean {
 const FAILURE_CONCLUSIONS = new Set(["FAILURE", "CANCELLED", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED", "STALE"]);
 const OK_CONCLUSIONS = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
 
-type Verdict = { kind: "pending"; reason: string } | { kind: "success"; reason: string } | { kind: "failure"; reason: string };
+type RollupItem = { name?: string; context?: string; status?: string; conclusion?: string; state?: string; startedAt?: string };
+
+// A rollup item is either a CheckRun (name/status/conclusion) or a StatusContext
+// (context/state) — distinguished by which fields gh populated, and their display
+// names live in DIFFERENT fields: CheckRun.name vs StatusContext.context. Reading
+// only `.name` (the pre-hardening bug) rendered every legacy status as "(unnamed)".
+function itemName(it: RollupItem): string {
+  if (it.name) return it.name;
+  if (it.context) return it.context;
+  return "";
+}
+
+// { terminal, failed } for one item. A non-terminal item is neither. A COMPLETED
+// CheckRun with an empty conclusion is treated as non-failing (matches the prior
+// classifier: only a KNOWN-bad conclusion fails); an item with neither status nor
+// state is treated as a non-terminal ghost rather than a failure.
+function itemState(it: RollupItem): { terminal: boolean; failed: boolean } {
+  if (it.status !== undefined) {
+    if ((it.status || "").toUpperCase() !== "COMPLETED") return { terminal: false, failed: false };
+    const c = (it.conclusion || "").toUpperCase();
+    if (c === "" || OK_CONCLUSIONS.has(c)) return { terminal: true, failed: false };
+    return { terminal: true, failed: true };
+  }
+  if (it.state !== undefined) {
+    const s = (it.state || "").toUpperCase();
+    if (s === "" || s === "PENDING") return { terminal: false, failed: false };
+    if (s === "SUCCESS") return { terminal: true, failed: false };
+    return { terminal: true, failed: true };
+  }
+  return { terminal: false, failed: false };
+}
+
+// The partition that drives every verdict. GHOSTS are the never-hang carve-out:
+// a non-terminal check that either has NO NAME (the #327 ghost) or — when a
+// --required set is supplied — is simply not one of the required checks. Neither
+// blocks a green verdict; both are surfaced, never waited on forever. REAL-
+// PENDING are the named checks that genuinely gate (in --required mode, only the
+// required ones), and DO block until terminal.
+type Buckets = {
+  failures: string[];
+  realPending: string[];
+  ghosts: string[];
+  greenNamed: number;
+  total: number;
+  requiredMissing: string[]; // populated only in --required mode
+};
+
+function classifyRollup(rollup: RollupItem[], required: Set<string>): Buckets {
+  const failures: string[] = [];
+  const realPending: string[] = [];
+  const ghosts: string[] = [];
+  let greenNamed = 0;
+  for (const it of rollup) {
+    const name = itemName(it);
+    const st = itemState(it);
+    if (st.terminal) {
+      if (st.failed) failures.push(name || "(unnamed)");
+      else if (name) greenNamed++;
+      continue;
+    }
+    // Non-terminal. Nameless → ghost. In --required mode a NAMED but non-required
+    // pending check is also non-blocking (branch protection doesn't gate on it).
+    if (name === "") ghosts.push("(unnamed)");
+    else if (required.size > 0 && !required.has(name)) ghosts.push(name);
+    else realPending.push(name);
+  }
+  const requiredMissing: string[] = [];
+  if (required.size > 0) {
+    for (const rname of required) {
+      const found = rollup.find((it) => itemName(it) === rname);
+      const st = found ? itemState(found) : null;
+      if (!st || !st.terminal || st.failed) requiredMissing.push(rname);
+    }
+  }
+  return { failures, realPending, ghosts, greenNamed, total: rollup.length, requiredMissing };
+}
+
+// ghostsOnly marks the STUCK-but-safe shape: no real/required check is pending,
+// yet a ghost remains non-terminal. The loop converts a persistent ghostsOnly
+// state into exit 4 rather than waiting forever.
+type Verdict =
+  | { kind: "pending"; reason: string; ghostsOnly: boolean; realPending: string[]; ghosts: string[]; greenNamed: number }
+  | { kind: "success"; reason: string }
+  | { kind: "failure"; reason: string };
+
+function joinCapped(names: string[], n: number): string {
+  return `${names.slice(0, n).join(", ")}${names.length > n ? " …" : ""}`;
+}
+
+function verdictForBuckets(b: Buckets, hasRequired: boolean): Verdict {
+  if (b.failures.length > 0) return { kind: "failure", reason: `failing check(s): ${joinCapped(b.failures, 4)}` };
+  if (b.total === 0) return { kind: "pending", reason: "no checks registered yet", ghostsOnly: false, realPending: [], ghosts: [], greenNamed: 0 };
+  if (hasRequired) {
+    if (b.requiredMissing.length > 0)
+      return { kind: "pending", reason: `required check(s) not green: ${joinCapped(b.requiredMissing, 4)}`, ghostsOnly: false, realPending: b.requiredMissing, ghosts: b.ghosts, greenNamed: b.greenNamed };
+    return { kind: "success", reason: `all required check(s) green (${b.greenNamed}/${b.total} check(s) terminal+green)` };
+  }
+  if (b.realPending.length > 0)
+    return { kind: "pending", reason: `${b.realPending.length} check(s) pending: ${joinCapped(b.realPending, 4)}`, ghostsOnly: false, realPending: b.realPending, ghosts: b.ghosts, greenNamed: b.greenNamed };
+  if (b.ghosts.length > 0)
+    return { kind: "pending", reason: `${b.greenNamed} named check(s) green; ${b.ghosts.length} non-terminal ghost check(s) that may never report: ${joinCapped(b.ghosts, 4)}`, ghostsOnly: true, realPending: [], ghosts: b.ghosts, greenNamed: b.greenNamed };
+  return { kind: "success", reason: `${b.total} check(s) green` };
+}
+
+function classifyPr(json: string, required: Set<string>): Verdict {
+  let d: { statusCheckRollup?: RollupItem[] };
+  try {
+    d = JSON.parse(json);
+  } catch {
+    return { kind: "pending", reason: "unparseable PR JSON (transient)", ghostsOnly: false, realPending: [], ghosts: [], greenNamed: 0 };
+  }
+  return verdictForBuckets(classifyRollup(d.statusCheckRollup || [], required), required.size > 0);
+}
 
 // A run is done only when its top-level status is "completed". Until then —
 // including QUEUED with zero jobs (the premature-exit case) — it is pending.
 // Fail-fast: a failed job short-circuits to failure without waiting for siblings.
+// Jobs always carry names, so the ghost carve-out does not apply to run mode.
 function classifyRun(json: string): Verdict {
   let d: { status?: string; conclusion?: string; jobs?: { name?: string; status?: string; conclusion?: string }[] };
   try {
     d = JSON.parse(json);
   } catch {
-    return { kind: "pending", reason: "unparseable run JSON (transient)" };
+    return { kind: "pending", reason: "unparseable run JSON (transient)", ghostsOnly: false, realPending: [], ghosts: [], greenNamed: 0 };
   }
   const jobs = d.jobs || [];
   for (const j of jobs) {
@@ -188,49 +348,63 @@ function classifyRun(json: string): Verdict {
     }
   }
   if ((d.status || "").toLowerCase() !== "completed") {
-    const running = jobs.filter((j) => (j.status || "").toLowerCase() !== "completed").length;
-    return { kind: "pending", reason: jobs.length === 0 ? "no jobs registered yet (queued)" : `${running}/${jobs.length} job(s) still running` };
+    const running = jobs.filter((j) => (j.status || "").toLowerCase() !== "completed").map((j) => j.name || "?");
+    return { kind: "pending", reason: jobs.length === 0 ? "no jobs registered yet (queued)" : `${running.length}/${jobs.length} job(s) still running`, ghostsOnly: false, realPending: running, ghosts: [], greenNamed: jobs.length - running.length };
   }
-  // status==completed: trust the run-level conclusion.
   const c = (d.conclusion || "").toUpperCase();
   if (OK_CONCLUSIONS.has(c)) return { kind: "success", reason: `${jobs.length} job(s) green (${c})` };
   return { kind: "failure", reason: `run concluded ${c || "no-conclusion"}` };
 }
 
-type RollupItem = { name?: string; status?: string; conclusion?: string; state?: string };
+// ---- pending-state timing (pure; unit-tested) -------------------------------
 
-// A PR rollup is done only when EVERY item is terminal. An empty rollup is "no
-// checks registered yet" — pending, not done (the PR-side premature-exit case).
-// Fail-fast on the first failing item.
-function classifyPr(json: string): Verdict {
-  let d: { statusCheckRollup?: RollupItem[] };
-  try {
-    d = JSON.parse(json);
-  } catch {
-    return { kind: "pending", reason: "unparseable PR JSON (transient)" };
+// The incomplete-set fingerprint. When it stops changing while the verdict is
+// ghostsOnly, nothing more will ever happen — that is the signal to stop waiting.
+function signatureOf(v: Verdict): string {
+  if (v.kind !== "pending") return v.kind;
+  return JSON.stringify([[...v.realPending].sort(), [...v.ghosts].sort(), v.greenNamed]);
+}
+
+type Timing = { lastSig: string | null; lastProgressAt: number };
+
+// Decide, for a PENDING verdict, whether the watch may keep waiting or must exit
+// now with an actionable verdict — the anti-hang core. Returns null to keep
+// polling, or a terminal {code, summary}. Kept pure (no gh, no clock, no sleep)
+// so the #327 ghost shape is unit-testable without real time or network.
+//   exit 4 — ghostsOnly persisted past the no-progress window OR the overall
+//            deadline hit with only ghosts left: required/named green, safe.
+//   exit 2 — chunk cap hit (RERUN) or overall deadline hit with a REAL/required
+//            check still pending: genuinely not green, NOT safe to merge.
+function resolvePendingExit(
+  v: Verdict & { kind: "pending" },
+  label: string,
+  now: number,
+  timing: Timing,
+  cfg: { deadline: number; chunkDeadline: number | null; noProgressMs: number; chunkMin: number | null; timeoutMin: number },
+): { code: number; summary: string } | null {
+  const stuckSafe = () => ({
+    code: 4,
+    summary: `CI-WATCH ${label}: STUCK — required/named checks GREEN (${v.greenNamed}), ${v.ghosts.length} non-terminal ghost/non-required check(s): ${joinCapped(v.ghosts, 4)}; safe to --admin merge`,
+  });
+
+  // A ghost that will never report must not park the watcher forever: once the
+  // incomplete set has been UNCHANGED for the no-progress window (all real checks
+  // already green), stop and surface it. Progress (a new named check registering)
+  // resets lastProgressAt in the caller, so this only fires on a genuine stall.
+  if (v.ghostsOnly && now - timing.lastProgressAt >= cfg.noProgressMs) return stuckSafe();
+
+  // Chunk cap: sub-agent foreground loop — exit 2 with a RERUN message so it loops.
+  if (cfg.chunkDeadline !== null && now > cfg.chunkDeadline) {
+    return { code: 2, summary: `CI-WATCH ${label}: PENDING after ${cfg.chunkMin}m — RERUN the SAME command to continue` };
   }
-  const rollup = d.statusCheckRollup || [];
-  if (rollup.length === 0) return { kind: "pending", reason: "no checks registered yet" };
-  const pending: string[] = [];
-  for (const it of rollup) {
-    const name = it.name || "(unnamed)";
-    if (it.status !== undefined) {
-      // CheckRun: QUEUED | IN_PROGRESS | COMPLETED
-      if ((it.status || "").toUpperCase() !== "COMPLETED") {
-        pending.push(name);
-      } else {
-        const c = (it.conclusion || "").toUpperCase();
-        if (FAILURE_CONCLUSIONS.has(c) || (!OK_CONCLUSIONS.has(c) && c !== "")) return { kind: "failure", reason: `check "${name}" → ${c || "no-conclusion"}` };
-      }
-    } else if (it.state !== undefined) {
-      // StatusContext (legacy commit status): SUCCESS | PENDING | FAILURE | ERROR
-      const s = (it.state || "").toUpperCase();
-      if (s === "PENDING" || s === "") pending.push(name);
-      else if (s !== "SUCCESS") return { kind: "failure", reason: `status "${name}" → ${s}` };
-    }
+
+  // Overall deadline: only-ghosts-left is STUCK-but-safe (exit 4); a real/required
+  // check still pending after the full timeout is genuinely stuck (exit 2).
+  if (now > cfg.deadline) {
+    if (v.ghostsOnly) return stuckSafe();
+    return { code: 2, summary: `CI-WATCH ${label}: TIMEOUT — required/named check(s) NOT green after ${cfg.timeoutMin}min: ${joinCapped(v.realPending, 4)}` };
   }
-  if (pending.length > 0) return { kind: "pending", reason: `${pending.length} check(s) pending: ${pending.slice(0, 4).join(", ")}${pending.length > 4 ? " …" : ""}` };
-  return { kind: "success", reason: `${rollup.length} check(s) green` };
+  return null;
 }
 
 // ---- poll loop --------------------------------------------------------------
@@ -256,16 +430,17 @@ async function watch(opts: Opts): Promise<{ code: number; summary: string }> {
     opts.mode === "run"
       ? ["run", "view", opts.target, ...repoArgs(opts.repo), "--json", "status,conclusion,jobs"]
       : ["pr", "view", opts.target, ...repoArgs(opts.repo), "--json", "statusCheckRollup,mergeable,mergeStateStatus"];
-  const classify = opts.mode === "run" ? classifyRun : classifyPr;
+  const classify = opts.mode === "run" ? (out: string) => classifyRun(out) : (out: string) => classifyPr(out, opts.required);
 
   const cap = authed ? 60_000 : 90_000;
   const deadline = Date.now() + opts.timeoutMin * 60_000;
-  // chunk deadline: per-invocation cap for sub-agent foreground loops. When hit,
-  // exits 2 with a RERUN message (distinct from the generic TIMEOUT message) so
-  // the agent knows to call the same command again rather than give up.
   const chunkDeadline = opts.chunkMin !== null ? Date.now() + opts.chunkMin * 60_000 : null;
+  const noProgressMs = opts.noProgressMin * 60_000;
   let delay = 10_000;
   let consecutiveErrors = 0;
+  // Tracks whether the incomplete-check set is still changing — a stuck ghost is
+  // only "given up on" after the set has been unchanged for the no-progress window.
+  const timing: Timing = { lastSig: null, lastProgressAt: Date.now() };
 
   for (;;) {
     const out = ghTry(viewArgs);
@@ -273,8 +448,6 @@ async function watch(opts: Opts): Promise<{ code: number; summary: string }> {
       // gh call failed: target may not exist YET (just pushed) or a transient
       // API error. Either way → keep polling. Never treat as completion.
       consecutiveErrors++;
-      // A long run of hard failures (e.g. genuinely unresolvable target / auth
-      // wholly broken) is fatal rather than spinning to the timeout.
       if (consecutiveErrors >= 12) {
         return { code: 3, summary: `CI-WATCH ${label}: ERROR — gh unreachable / target unresolvable after ${consecutiveErrors} attempts` };
       }
@@ -287,15 +460,18 @@ async function watch(opts: Opts): Promise<{ code: number; summary: string }> {
         const url = ghTry(opts.mode === "run" ? ["run", "view", opts.target, ...repoArgs(opts.repo), "--json", "url", "--jq", ".url"] : ["pr", "view", opts.target, ...repoArgs(opts.repo), "--json", "url", "--jq", ".url"]);
         return { code: 1, summary: `CI-WATCH ${label}: FAILURE — ${v.reason}${url ? ` (${url})` : ""}` };
       }
+      // pending: track progress, then let the pure resolver decide exit-vs-wait.
+      const sig = signatureOf(v);
+      const now = Date.now();
+      if (sig !== timing.lastSig) {
+        timing.lastSig = sig;
+        timing.lastProgressAt = now;
+      }
+      const exit = resolvePendingExit(v, label, now, timing, { deadline, chunkDeadline, noProgressMs, chunkMin: opts.chunkMin, timeoutMin: opts.timeoutMin });
+      if (exit) return exit;
       process.stderr.write(`    … ${v.reason}\n`);
     }
 
-    const now = Date.now();
-    // Chunk cap takes priority: exit with a RERUN message so the agent loops.
-    if (chunkDeadline !== null && now > chunkDeadline) {
-      return { code: 2, summary: `CI-WATCH ${label}: PENDING after ${opts.chunkMin}m — RERUN the SAME command to continue` };
-    }
-    if (now > deadline) return { code: 2, summary: `CI-WATCH ${label}: TIMEOUT — still pending after ${opts.timeoutMin}min` };
     await sleep(delay);
     delay = nextDelay(delay, cap);
   }
@@ -309,4 +485,10 @@ async function main(): Promise<void> {
   process.exit(code);
 }
 
-main();
+// Run main() only when invoked directly; when imported by a test, expose the pure
+// classifiers/resolver without side effects.
+const isMain = process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main();
+
+export { classifyRollup, verdictForBuckets, classifyPr, classifyRun, signatureOf, resolvePendingExit };
+export type { Buckets, Verdict, RollupItem, Timing };


### PR DESCRIPTION
## Problem

GitHub occasionally registers a check-run that never reports a status — it stays PENDING, nameless, forever. `ci-watch.ts` waited for *every* rollup item to be terminal before declaring success, so one such ghost parked the watcher indefinitely.

This stranded PR #327: all 51 real checks were SUCCESS, but a nameless ghost stayed pending, so the `--fail-fast` merge watcher watching it hung. The PR sat reviewed and green for hours without merging, and the orchestrator read "watcher still running" as "nothing to do."

## Fix

Gate the green verdict on the required/named checks instead of literally-all:

- A **nameless** non-terminal check (the #327 ghost) — or, in `--required` mode, any **non-required** non-terminal check — is a ghost that never blocks a green verdict.
- When every named check is green and only ghosts remain, a **no-progress window** (`--no-progress`, default 8 min) fires an actionable **exit 4 (STUCK-but-safe)** with a summary the caller acts on (`--admin` merge), instead of hanging.
- A **named** pending check is never a ghost, so a genuinely in-flight required check is never green-lit early — it waits, then reports NOT-green (exit 2) at the overall timeout.

New surface:

- `--required <names>` — comma-separated branch-protection check names to gate on (e.g. `--required "CI gate"`). Success fires the instant every required check is green; ghosts and non-required checks never block. The precise, hang-proof gate for a merge watcher.
- `--no-progress <min>` — bounds how long an unchanged all-green-plus-ghost set may sit before exiting 4.
- **Exit code 4** — STUCK-but-safe. Exit 2's message now names the required/named checks that are actually not green.

Fail-fast, wait-for-existence, and transient-error tolerance are unchanged. Also fixes a latent bug: a legacy `StatusContext` (e.g. Vercel) was read via `.name` and always rendered `(unnamed)`; it is now named by its `context` field, so a named legacy status is correctly treated as a real pending check rather than a ghost.

## `--required` semantics (one decision worth a look)

A fresh-context self-review flagged this as a product call: in `--required` mode, should a *non-required* check that *fails* block? This PR makes it non-blocking — `--required` gates *exactly* on branch protection, and branch protection doesn't gate on non-required checks, so an optional red check must not make the watcher report FAILURE and refuse to `--admin` merge a mergeable PR. Required-check failures still block (exit 1). Flag if you'd rather a failing optional check block.

## Verification

- `node --test scripts/ci-watch.test.mjs` — 17/17 green. Covers the #327 shape (51 green + 1 nameless ghost → prompt exit 4), the safety property (a real named pending check is never green-lit early), fail-fast, `--required` gating (including a failing non-required check not blocking, a failing required check blocking, and a duplicate required name requiring every occurrence green), the deadline firing during a gh-failure streak, the partial-rollup guard, and `StatusContext` naming.
- Full-loop no-hang proof: a fake `gh` returning the #327 shape drives `watch()` to exit 4 in ~11s (one backoff cycle) instead of hanging to the overall timeout.
- Live smoke against #327 (`--pr 327`, default and `--required "CI gate"`) exits 0 promptly; runs under both `node` (type-stripping) and `nub`.

## Scope note

`scripts/merge-cascade.ts` has its own rollup loop that shares the same ghost-hang shape (it also requires zero pending checks). Left for a follow-up; this PR hardens `ci-watch.ts` only.

Refs #327
