### PR TITLE
fix(merge-cascade): never hang on a #327 ghost check; gate on the required set

### DIFF
--- a/.claude/skills/ci-watch/SKILL.md
+++ b/.claude/skills/ci-watch/SKILL.md
@@ -81,7 +81,7 @@ What stranded EVERY merge in the v0.2.2 floor-fix batch (#163/#164) was NOT back
 
 Recipe:
 1. **Enqueue:** append `{"pr":N,"branch":"…","thread":"…","note":"…"}` (optional `"hold":true`) to `.fray/merge-queue.jsonl`. Enqueue UNHELD only once the PR's FINAL head is pushed — a stale head can be green-but-wrong, so verify the head/rebase before it's mergeable.
-2. **Watch:** the ORCHESTRATOR runs `node scripts/merge-cascade.ts --max-minutes 40` with `run_in_background: true`. It gates positively (every check SUCCESS/NEUTRAL/SKIPPED + `CI gate` present+SUCCESS + mergeable), merges `--squash --admin`, ff-pulls, dequeues, exits → re-invokes the orchestrator.
+2. **Watch:** the ORCHESTRATOR runs `node scripts/merge-cascade.ts --max-minutes 40` with `run_in_background: true`. It gates positively on the required `CI gate` (present + SUCCESS) + mergeable, merges `--squash --admin`, ff-pulls, dequeues, exits → re-invokes the orchestrator. It shares ci-watch's #327 ghost carve-out (`scripts/lib/ci-rollup.ts`): a nameless/never-terminating ghost — or any non-required check, pending OR failed — is non-blocking, so the drain can't hang the way #327 stranded a merge; a still-running or failed REQUIRED gate always holds/blocks, so a red PR is never mis-merged.
 3. **Landing agents PUSH-THEN-EXIT** — they never watch; they report `pushed <sha>, queued`. The orchestrator's background watcher owns merge-on-green.
 
 A `CronCreate` heartbeat (every ~4 min, one non-blocking `gh pr view` poll per queued PR, merge-on-green) is a FALLBACK only if a background shell ever proves unreliable — the orchestrator background shell above is the default and what historically worked. Reach for the blocking `ci-watch.ts` directly only for a single-run gate you observe synchronously.

--- a/scripts/ci-watch.ts
+++ b/scripts/ci-watch.ts
@@ -55,6 +55,10 @@
 
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+// The #327 ghost-carve-out classifier is shared with scripts/merge-cascade.ts so
+// the two tools cannot drift on the merge-safety verdict — one source of truth.
+import { FAILURE_CONCLUSIONS, OK_CONCLUSIONS, classifyRollup, joinCapped, verdictForBuckets } from "./lib/ci-rollup.ts";
+import type { RollupItem, Buckets, Verdict } from "./lib/ci-rollup.ts";
 
 // ---- args -------------------------------------------------------------------
 
@@ -213,125 +217,11 @@ function hasAuthToken(): boolean {
 }
 
 // ---- terminal-state classification ------------------------------------------
-
-const FAILURE_CONCLUSIONS = new Set(["FAILURE", "CANCELLED", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED", "STALE"]);
-const OK_CONCLUSIONS = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
-
-type RollupItem = { name?: string; context?: string; status?: string; conclusion?: string; state?: string; startedAt?: string };
-
-// A rollup item is either a CheckRun (name/status/conclusion) or a StatusContext
-// (context/state) — distinguished by which fields gh populated, and their display
-// names live in DIFFERENT fields: CheckRun.name vs StatusContext.context. Reading
-// only `.name` (the pre-hardening bug) rendered every legacy status as "(unnamed)".
-function itemName(it: RollupItem): string {
-  if (it.name) return it.name;
-  if (it.context) return it.context;
-  return "";
-}
-
-// { terminal, failed } for one item. A non-terminal item is neither. A COMPLETED
-// CheckRun with an empty conclusion is treated as non-failing (matches the prior
-// classifier: only a KNOWN-bad conclusion fails); an item with neither status nor
-// state is treated as a non-terminal ghost rather than a failure.
-function itemState(it: RollupItem): { terminal: boolean; failed: boolean } {
-  if (it.status !== undefined) {
-    if ((it.status || "").toUpperCase() !== "COMPLETED") return { terminal: false, failed: false };
-    const c = (it.conclusion || "").toUpperCase();
-    if (c === "" || OK_CONCLUSIONS.has(c)) return { terminal: true, failed: false };
-    return { terminal: true, failed: true };
-  }
-  if (it.state !== undefined) {
-    const s = (it.state || "").toUpperCase();
-    if (s === "" || s === "PENDING") return { terminal: false, failed: false };
-    if (s === "SUCCESS") return { terminal: true, failed: false };
-    return { terminal: true, failed: true };
-  }
-  return { terminal: false, failed: false };
-}
-
-// The partition that drives every verdict. GHOSTS are the never-hang carve-out:
-// a non-terminal check that either has NO NAME (the #327 ghost) or — when a
-// --required set is supplied — is simply not one of the required checks. Neither
-// blocks a green verdict; both are surfaced, never waited on forever. REAL-
-// PENDING are the named checks that genuinely gate (in --required mode, only the
-// required ones), and DO block until terminal.
-type Buckets = {
-  failures: string[];
-  realPending: string[];
-  ghosts: string[];
-  greenNamed: number;
-  total: number;
-  requiredMissing: string[]; // populated only in --required mode
-};
-
-function classifyRollup(rollup: RollupItem[], required: Set<string>): Buckets {
-  const scoped = required.size > 0;
-  const failures: string[] = [];
-  const realPending: string[] = [];
-  const ghosts: string[] = [];
-  let greenNamed = 0;
-  for (const it of rollup) {
-    const name = itemName(it);
-    const st = itemState(it);
-    // In --required mode a NON-required check never blocks — pass OR fail. Branch
-    // protection doesn't gate on it, so a red optional check must not report
-    // FAILURE (that would refuse to merge a mergeable PR). It is non-blocking;
-    // a non-terminal one is surfaced as a ghost, a terminal one is ignored.
-    if (scoped && !required.has(name)) {
-      if (!st.terminal) ghosts.push(name || "(unnamed)");
-      continue;
-    }
-    if (st.terminal) {
-      if (st.failed) failures.push(name || "(unnamed)");
-      else if (name) greenNamed++;
-      continue;
-    }
-    // Non-terminal required-or-any check. Nameless → ghost (the #327 ghost);
-    // named → a real pending check that genuinely gates.
-    if (name === "") ghosts.push("(unnamed)");
-    else realPending.push(name);
-  }
-  // A required check is satisfied only when EVERY occurrence of its name is
-  // terminal+green — a matrix / re-run can list the same name twice, and branch
-  // protection keys on the latest, so the first-match `find` would green-light a
-  // still-pending same-named check.
-  const requiredMissing: string[] = [];
-  if (scoped) {
-    for (const rname of required) {
-      const matches = rollup.filter((it) => itemName(it) === rname);
-      const allGreen = matches.length > 0 && matches.every((it) => { const st = itemState(it); return st.terminal && !st.failed; });
-      if (!allGreen) requiredMissing.push(rname);
-    }
-  }
-  return { failures, realPending, ghosts, greenNamed, total: rollup.length, requiredMissing };
-}
-
-// ghostsOnly marks the STUCK-but-safe shape: no real/required check is pending,
-// yet a ghost remains non-terminal. The loop converts a persistent ghostsOnly
-// state into exit 4 rather than waiting forever.
-type Verdict =
-  | { kind: "pending"; reason: string; ghostsOnly: boolean; realPending: string[]; ghosts: string[]; greenNamed: number }
-  | { kind: "success"; reason: string }
-  | { kind: "failure"; reason: string };
-
-function joinCapped(names: string[], n: number): string {
-  return `${names.slice(0, n).join(", ")}${names.length > n ? " …" : ""}`;
-}
-
-function verdictForBuckets(b: Buckets, hasRequired: boolean): Verdict {
-  if (b.failures.length > 0) return { kind: "failure", reason: `failing check(s): ${joinCapped(b.failures, 4)}` };
-  if (b.total === 0) return { kind: "pending", reason: "no checks registered yet", ghostsOnly: false, realPending: [], ghosts: [], greenNamed: 0 };
-  if (hasRequired) {
-    if (b.requiredMissing.length > 0)
-      return { kind: "pending", reason: `required check(s) not green: ${joinCapped(b.requiredMissing, 4)}`, ghostsOnly: false, realPending: b.requiredMissing, ghosts: b.ghosts, greenNamed: b.greenNamed };
-    return { kind: "success", reason: `all ${b.greenNamed} required check(s) green (of ${b.total} total; non-required checks non-blocking)` };
-  }
-  if (b.realPending.length > 0)
-    return { kind: "pending", reason: `${b.realPending.length} check(s) pending: ${joinCapped(b.realPending, 4)}`, ghostsOnly: false, realPending: b.realPending, ghosts: b.ghosts, greenNamed: b.greenNamed };
-  if (b.ghosts.length > 0)
-    return { kind: "pending", reason: `${b.greenNamed} named check(s) green; ${b.ghosts.length} non-terminal ghost check(s) that may never report: ${joinCapped(b.ghosts, 4)}`, ghostsOnly: true, realPending: [], ghosts: b.ghosts, greenNamed: b.greenNamed };
-  return { kind: "success", reason: `${b.total} check(s) green` };
-}
+//
+// The rollup classifier (itemName/itemState/classifyRollup → Buckets →
+// verdictForBuckets) lives in ./lib/ci-rollup.ts, shared with merge-cascade.ts.
+// This file keeps only the single-PR-watcher concerns: PR/run JSON parsing, the
+// pending-state timing (signatureOf/resolvePendingExit), and the poll loop.
 
 function classifyPr(json: string, required: Set<string>): Verdict {
   let d: { statusCheckRollup?: RollupItem[] };
@@ -519,5 +409,7 @@ async function main(): Promise<void> {
 const isMain = process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
 if (isMain) main();
 
+// Re-export the shared classifier alongside the watcher-local symbols so existing
+// importers (scripts/ci-watch.test.mjs) keep their `from "./ci-watch.ts"` path.
 export { classifyRollup, verdictForBuckets, classifyPr, classifyRun, signatureOf, resolvePendingExit };
 export type { Buckets, Verdict, RollupItem, Timing };

--- a/scripts/lib/ci-rollup.ts
+++ b/scripts/lib/ci-rollup.ts
@@ -1,0 +1,139 @@
+// ci-rollup — the shared #327 ghost-carve-out primitives for classifying a GitHub
+// PR check rollup, used by BOTH scripts/ci-watch.ts (the single-PR watcher) and
+// scripts/merge-cascade.ts (the queue-drain merger). ONE source of truth for
+// "is this check a ghost" and "are the required (or all named) checks green,
+// ignoring ghosts" — so the two tools cannot drift on the merge-safety verdict.
+//
+// The #327 ghost: GitHub occasionally registers a check-run that NEVER reports a
+// status — it stays non-terminal with no name forever. A gate that waits for
+// ALL rollup items to be terminal then hangs indefinitely even though every REAL
+// check is green (PR #327 sat green-but-unmerged for hours this way). The carve-
+// out: a nameless / never-terminating non-required check does NOT block a green
+// verdict — it is a ghost, surfaced but never waited on forever.
+//
+// Erasable TypeScript only (no enums/namespaces/parameter-properties) so plain
+// modern `node` type-strips it with no build step — same constraint as its
+// importers.
+
+const FAILURE_CONCLUSIONS = new Set(["FAILURE", "CANCELLED", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED", "STALE"]);
+const OK_CONCLUSIONS = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
+
+type RollupItem = { name?: string; context?: string; status?: string; conclusion?: string; state?: string; startedAt?: string };
+
+// A rollup item is either a CheckRun (name/status/conclusion) or a StatusContext
+// (context/state) — distinguished by which fields gh populated, and their display
+// names live in DIFFERENT fields: CheckRun.name vs StatusContext.context. Reading
+// only `.name` (the pre-hardening bug) rendered every legacy status as "(unnamed)".
+function itemName(it: RollupItem): string {
+  if (it.name) return it.name;
+  if (it.context) return it.context;
+  return "";
+}
+
+// { terminal, failed } for one item. A non-terminal item is neither. A COMPLETED
+// CheckRun with an empty conclusion is treated as non-failing (matches the prior
+// classifier: only a KNOWN-bad conclusion fails); an item with neither status nor
+// state is treated as a non-terminal ghost rather than a failure.
+function itemState(it: RollupItem): { terminal: boolean; failed: boolean } {
+  if (it.status !== undefined) {
+    if ((it.status || "").toUpperCase() !== "COMPLETED") return { terminal: false, failed: false };
+    const c = (it.conclusion || "").toUpperCase();
+    if (c === "" || OK_CONCLUSIONS.has(c)) return { terminal: true, failed: false };
+    return { terminal: true, failed: true };
+  }
+  if (it.state !== undefined) {
+    const s = (it.state || "").toUpperCase();
+    if (s === "" || s === "PENDING") return { terminal: false, failed: false };
+    if (s === "SUCCESS") return { terminal: true, failed: false };
+    return { terminal: true, failed: true };
+  }
+  return { terminal: false, failed: false };
+}
+
+// The partition that drives every verdict. GHOSTS are the never-hang carve-out:
+// a non-terminal check that either has NO NAME (the #327 ghost) or — when a
+// --required set is supplied — is simply not one of the required checks. Neither
+// blocks a green verdict; both are surfaced, never waited on forever. REAL-
+// PENDING are the named checks that genuinely gate (in --required mode, only the
+// required ones), and DO block until terminal.
+type Buckets = {
+  failures: string[];
+  realPending: string[];
+  ghosts: string[];
+  greenNamed: number;
+  total: number;
+  requiredMissing: string[]; // populated only when a required set is supplied
+};
+
+function classifyRollup(rollup: RollupItem[], required: Set<string>): Buckets {
+  const scoped = required.size > 0;
+  const failures: string[] = [];
+  const realPending: string[] = [];
+  const ghosts: string[] = [];
+  let greenNamed = 0;
+  for (const it of rollup) {
+    const name = itemName(it);
+    const st = itemState(it);
+    // In --required mode a NON-required check never blocks — pass OR fail. Branch
+    // protection doesn't gate on it, so a red optional check must not report
+    // FAILURE (that would refuse to merge a mergeable PR). It is non-blocking;
+    // a non-terminal one is surfaced as a ghost, a terminal one is ignored.
+    if (scoped && !required.has(name)) {
+      if (!st.terminal) ghosts.push(name || "(unnamed)");
+      continue;
+    }
+    if (st.terminal) {
+      if (st.failed) failures.push(name || "(unnamed)");
+      else if (name) greenNamed++;
+      continue;
+    }
+    // Non-terminal required-or-any check. Nameless → ghost (the #327 ghost);
+    // named → a real pending check that genuinely gates.
+    if (name === "") ghosts.push("(unnamed)");
+    else realPending.push(name);
+  }
+  // A required check is satisfied only when EVERY occurrence of its name is
+  // terminal+green — a matrix / re-run can list the same name twice, and branch
+  // protection keys on the latest, so the first-match `find` would green-light a
+  // still-pending same-named check.
+  const requiredMissing: string[] = [];
+  if (scoped) {
+    for (const rname of required) {
+      const matches = rollup.filter((it) => itemName(it) === rname);
+      const allGreen = matches.length > 0 && matches.every((it) => { const st = itemState(it); return st.terminal && !st.failed; });
+      if (!allGreen) requiredMissing.push(rname);
+    }
+  }
+  return { failures, realPending, ghosts, greenNamed, total: rollup.length, requiredMissing };
+}
+
+// ghostsOnly marks the STUCK-but-safe shape: no real/required check is pending,
+// yet a ghost remains non-terminal. A single-PR watcher converts a persistent
+// ghostsOnly state into an actionable exit rather than waiting forever; a merger
+// that positively gates on the required set treats it as merge-ready.
+type Verdict =
+  | { kind: "pending"; reason: string; ghostsOnly: boolean; realPending: string[]; ghosts: string[]; greenNamed: number }
+  | { kind: "success"; reason: string }
+  | { kind: "failure"; reason: string };
+
+function joinCapped(names: string[], n: number): string {
+  return `${names.slice(0, n).join(", ")}${names.length > n ? " …" : ""}`;
+}
+
+function verdictForBuckets(b: Buckets, hasRequired: boolean): Verdict {
+  if (b.failures.length > 0) return { kind: "failure", reason: `failing check(s): ${joinCapped(b.failures, 4)}` };
+  if (b.total === 0) return { kind: "pending", reason: "no checks registered yet", ghostsOnly: false, realPending: [], ghosts: [], greenNamed: 0 };
+  if (hasRequired) {
+    if (b.requiredMissing.length > 0)
+      return { kind: "pending", reason: `required check(s) not green: ${joinCapped(b.requiredMissing, 4)}`, ghostsOnly: false, realPending: b.requiredMissing, ghosts: b.ghosts, greenNamed: b.greenNamed };
+    return { kind: "success", reason: `all ${b.greenNamed} required check(s) green (of ${b.total} total; non-required checks non-blocking)` };
+  }
+  if (b.realPending.length > 0)
+    return { kind: "pending", reason: `${b.realPending.length} check(s) pending: ${joinCapped(b.realPending, 4)}`, ghostsOnly: false, realPending: b.realPending, ghosts: b.ghosts, greenNamed: b.greenNamed };
+  if (b.ghosts.length > 0)
+    return { kind: "pending", reason: `${b.greenNamed} named check(s) green; ${b.ghosts.length} non-terminal ghost check(s) that may never report: ${joinCapped(b.ghosts, 4)}`, ghostsOnly: true, realPending: [], ghosts: b.ghosts, greenNamed: b.greenNamed };
+  return { kind: "success", reason: `${b.total} check(s) green` };
+}
+
+export { FAILURE_CONCLUSIONS, OK_CONCLUSIONS, itemName, itemState, classifyRollup, joinCapped, verdictForBuckets };
+export type { RollupItem, Buckets, Verdict };

--- a/scripts/merge-cascade.test.mjs
+++ b/scripts/merge-cascade.test.mjs
@@ -1,0 +1,83 @@
+// Tests for scripts/merge-cascade.ts — the mergeDecision gate that drives the
+// queue-drain auto-merge. Focus: the #327 ghost carve-out (a nameless/non-
+// required non-terminal check must not park the merger forever) AND the
+// never-mis-merge invariants (a real required pending/failed check always holds/
+// blocks; only MERGEABLE proceeds). Pure decision logic — no gh, no real merge.
+// Run: node --test scripts/merge-cascade.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mergeDecision, REQUIRED_GATE } from "./merge-cascade.ts";
+
+const check = (name, conclusion) => ({ name, status: "COMPLETED", conclusion });
+const running = (name) => ({ name, status: "IN_PROGRESS" });
+const ghost = () => ({ status: "IN_PROGRESS" }); // nameless, never-terminating (the #327 shape)
+const gateGreen = () => check(REQUIRED_GATE, "SUCCESS");
+
+const decide = (over = {}) => mergeDecision({ state: "OPEN", mergeable: "MERGEABLE", rollup: [], ...over });
+
+test("#327 shape: required gate green + named checks green + 1 nameless ghost → MERGE (not park-forever)", () => {
+  const rollup = [gateGreen(), check("build", "SUCCESS"), check("test", "SUCCESS"), ghost()];
+  const d = decide({ rollup });
+  assert.equal(d.verdict, "merge", "a nameless ghost must not block a mergeable PR whose required gate is green");
+});
+
+test("#327 at scale: 51 green named checks + gate green + 1 ghost → MERGE", () => {
+  const rollup = [gateGreen(), ...Array.from({ length: 51 }, (_, i) => check(`check ${i}`, "SUCCESS")), ghost()];
+  assert.equal(decide({ rollup }).verdict, "merge");
+});
+
+test("never mis-merge: required gate still RUNNING (with a nameless ghost) → WAIT, never merge", () => {
+  const rollup = [running(REQUIRED_GATE), check("build", "SUCCESS"), ghost()];
+  const d = decide({ rollup });
+  assert.equal(d.verdict, "wait", "a real in-flight required gate must hold");
+  assert.match(d.reason, /CI gate/);
+});
+
+test("never mis-merge: required gate FAILED → BLOCK", () => {
+  const d = decide({ rollup: [check(REQUIRED_GATE, "FAILURE"), check("build", "SUCCESS")] });
+  assert.equal(d.verdict, "block");
+  assert.match(d.reason, /CI gate/);
+});
+
+test("never mis-merge: required gate ABSENT (partial rollup, only fast jobs green) → WAIT", () => {
+  const d = decide({ rollup: [check("fast", "SUCCESS")] });
+  assert.equal(d.verdict, "wait", "the aggregator gate not yet registered is not done");
+  assert.match(d.reason, /CI gate/);
+});
+
+test("never mis-merge: duplicate required name (one green, one still running) → WAIT (every occurrence must be green)", () => {
+  const rollup = [gateGreen(), running(REQUIRED_GATE)];
+  assert.equal(decide({ rollup }).verdict, "wait");
+});
+
+test("branch-protection faithful: a FAILING non-required check does NOT block (gate green + mergeable → MERGE)", () => {
+  const rollup = [gateGreen(), check("optional lint", "FAILURE"), ghost()];
+  assert.equal(decide({ rollup }).verdict, "merge", "an optional red check must not refuse to merge a mergeable PR");
+});
+
+test("mergeability is gated POSITIVELY: gate green but mergeable UNKNOWN → WAIT (not merge)", () => {
+  const rollup = [gateGreen(), ghost()];
+  assert.equal(decide({ rollup, mergeable: "UNKNOWN" }).verdict, "wait");
+  assert.equal(decide({ rollup, mergeable: "" }).verdict, "wait");
+});
+
+test("mergeability CONFLICTING → BLOCK even with the gate green", () => {
+  const d = decide({ rollup: [gateGreen()], mergeable: "CONFLICTING" });
+  assert.equal(d.verdict, "block");
+  assert.match(d.reason, /CONFLICTING/);
+});
+
+test("a non-OPEN PR → BLOCK regardless of checks", () => {
+  assert.equal(decide({ state: "MERGED", rollup: [gateGreen()] }).verdict, "block");
+});
+
+test("empty rollup (no checks yet) → WAIT (wait-for-existence preserved)", () => {
+  const d = decide({ rollup: [] });
+  assert.equal(d.verdict, "wait");
+  assert.match(d.reason, /no checks/);
+});
+
+test("clean happy path: gate + all named green, no ghost, mergeable → MERGE", () => {
+  const rollup = [gateGreen(), check("build", "SUCCESS"), check("test", "NEUTRAL")];
+  assert.equal(decide({ rollup }).verdict, "merge");
+});

--- a/scripts/merge-cascade.ts
+++ b/scripts/merge-cascade.ts
@@ -38,6 +38,11 @@ import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { dirname, resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
+// The #327 ghost-carve-out classifier is shared with scripts/ci-watch.ts — one
+// source of truth for "is this check a ghost / are the required checks green,
+// ignoring ghosts" so the merger and the watcher never diverge on merge-safety.
+import { classifyRollup, verdictForBuckets } from "./lib/ci-rollup.ts";
+import type { RollupItem } from "./lib/ci-rollup.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
@@ -143,13 +148,6 @@ function holdReason(e: QueueEntry): string | null {
 
 // ---- CI status --------------------------------------------------------------
 
-type RollupItem = {
-  name?: string;
-  status?: string; // CheckRun: QUEUED | IN_PROGRESS | COMPLETED
-  conclusion?: string; // CheckRun: SUCCESS | FAILURE | NEUTRAL | SKIPPED | CANCELLED | TIMED_OUT | ...
-  state?: string; // StatusContext: SUCCESS | PENDING | FAILURE | ERROR
-};
-
 function prState(pr: number): { state: string; mergeable: string; rollup: RollupItem[] } {
   const json = gh([
     "pr",
@@ -164,41 +162,15 @@ function prState(pr: number): { state: string; mergeable: string; rollup: Rollup
   return { state: d.state, mergeable: d.mergeable, rollup: d.statusCheckRollup || [] };
 }
 
-// Classify a rollup into pending / failed / all-green.
-function classifyRollup(rollup: RollupItem[]): {
-  pending: string[];
-  failed: string[];
-} {
-  const pending: string[] = [];
-  const failed: string[] = [];
-  for (const it of rollup) {
-    const name = it.name || "(unnamed)";
-    if (it.status !== undefined) {
-      // CheckRun
-      if (it.status !== "COMPLETED") {
-        pending.push(name);
-      } else {
-        const c = (it.conclusion || "").toUpperCase();
-        if (c === "SUCCESS" || c === "NEUTRAL" || c === "SKIPPED") {
-          /* ok */
-        } else {
-          failed.push(`${name} (${c || "no-conclusion"})`);
-        }
-      }
-    } else if (it.state !== undefined) {
-      // StatusContext (legacy commit status)
-      const s = (it.state || "").toUpperCase();
-      if (s === "PENDING" || s === "") pending.push(name);
-      else if (s !== "SUCCESS") failed.push(`${name} (${s})`);
-    }
-  }
-  return { pending, failed };
-}
-
-// The single required branch-protection check for this repo — the aggregator
-// gate that `needs:` every conditional job and registers LAST. Merging before
-// it is present + green can merge a PR whose heavy matrix never ran.
+// The required branch-protection check(s) for this repo — the aggregator gate
+// that `needs:` every conditional job and registers LAST. It is the ONLY thing
+// branch protection gates on; passing it as the required set to the shared
+// classifier makes the #327 ghost-immunity fall out for free (a nameless ghost,
+// or a non-required check like the workflow_dispatch-only Pullfrog leg, is never
+// one of these names, so it lands in the non-blocking ghost bucket). Merging
+// before the gate is present + green would merge a PR whose heavy matrix never ran.
 const REQUIRED_GATE = "CI gate";
+const REQUIRED_CHECKS = new Set([REQUIRED_GATE]);
 
 // THE single source of truth for "may this PR be merged right now?" — used by
 // the watch loop, the dry-run preview, and the pre-merge re-read, so the gating
@@ -206,9 +178,19 @@ const REQUIRED_GATE = "CI gate";
 //
 // Verdicts:
 //   merge   — safe to merge NOW.
-//   wait    — not ready yet; keep polling (no checks, pending checks, mergeable
-//             still UNKNOWN, or the required gate not yet present/green).
-//   block   — terminal NOT-mergeable; do not merge (failing check or conflict).
+//   wait    — not ready yet; keep polling (no checks, the required gate not yet
+//             present/green, or mergeable still UNKNOWN).
+//   block   — terminal NOT-mergeable; do not merge (required check failed, or
+//             the PR is closed / conflicting).
+//
+// #327 ghost-immunity: the rollup verdict comes from the SHARED classifier gated
+// on REQUIRED_CHECKS, so a nameless/never-terminating ghost — or any non-required
+// check, pending OR failed — is non-blocking (branch protection doesn't gate on
+// it, and --admin bypasses it regardless). The merge fires the instant every
+// occurrence of the required gate is terminal+green and the PR is MERGEABLE; a
+// still-running or failed REQUIRED gate always holds/blocks, so a red PR is never
+// mis-merged. This replaces the old "wait for LITERALLY every check terminal"
+// gate that parked forever on the #327 ghost.
 function mergeDecision(st: {
   state: string;
   mergeable: string;
@@ -216,42 +198,22 @@ function mergeDecision(st: {
 }): { verdict: "merge" | "wait" | "block"; reason: string } {
   if (st.state !== "OPEN") return { verdict: "block", reason: `PR is ${st.state}, not OPEN` };
 
-  const { pending, failed } = classifyRollup(st.rollup);
-  if (failed.length > 0) return { verdict: "block", reason: `failing checks: ${failed.join(", ")}` };
+  const v = verdictForBuckets(classifyRollup(st.rollup, REQUIRED_CHECKS), true);
+  // A required check concluded bad → hard block. A required check absent/pending,
+  // or no checks yet → keep polling. (verdictForBuckets in required mode returns
+  // success ONLY when every occurrence of the gate is terminal+green.)
+  if (v.kind === "failure") return { verdict: "block", reason: v.reason };
+  if (v.kind === "pending") return { verdict: "wait", reason: v.reason };
 
-  if (st.rollup.length === 0) return { verdict: "wait", reason: "no checks registered yet" };
-  if (pending.length > 0) {
-    return {
-      verdict: "wait",
-      reason: `${pending.length} check(s) pending: ${pending.slice(0, 4).join(", ")}${pending.length > 4 ? " …" : ""}`,
-    };
-  }
-
-  // BLOCK 2 fix: the registered checks being all-green is NOT sufficient — the
-  // required aggregator gate must be PRESENT and SUCCESS. A partial rollup
-  // (a few fast jobs green, the matrix + `CI gate` not yet registered) has
-  // zero pending but is not actually done. Require the gate explicitly.
-  const gate = st.rollup.find((it) => (it.name || "") === REQUIRED_GATE);
-  if (!gate) {
-    return { verdict: "wait", reason: `required "${REQUIRED_GATE}" check not present yet (rollup still filling in)` };
-  }
-  const gateOk =
-    gate.status !== undefined
-      ? gate.status === "COMPLETED" && (gate.conclusion || "").toUpperCase() === "SUCCESS"
-      : (gate.state || "").toUpperCase() === "SUCCESS";
-  if (!gateOk) {
-    return { verdict: "wait", reason: `"${REQUIRED_GATE}" not green yet (${gate.status || gate.state || "?"}/${gate.conclusion || ""})` };
-  }
-
-  // BLOCK 1 fix: gate POSITIVELY on mergeability. GitHub returns UNKNOWN while
-  // it lazily computes mergeability (and the poll itself nudges the compute) —
-  // UNKNOWN is NOT green. Only MERGEABLE proceeds; CONFLICTING blocks; anything
-  // else (UNKNOWN, "") is wait-and-repoll.
+  // Required gate green, ghosts ignored. Now gate POSITIVELY on mergeability:
+  // GitHub returns UNKNOWN while it lazily computes it (and the poll itself nudges
+  // the compute) — UNKNOWN is NOT green. Only MERGEABLE proceeds; CONFLICTING
+  // blocks; anything else (UNKNOWN, "") is wait-and-repoll.
   const m = (st.mergeable || "").toUpperCase();
   if (m === "CONFLICTING") return { verdict: "block", reason: "merge conflict (CONFLICTING)" };
   if (m !== "MERGEABLE") return { verdict: "wait", reason: `mergeability ${m || "unknown"} (GitHub still computing)` };
 
-  return { verdict: "merge", reason: "all green + gate passed + mergeable" };
+  return { verdict: "merge", reason: `${v.reason}; mergeable` };
 }
 
 // ---- thread flip ------------------------------------------------------------
@@ -432,4 +394,9 @@ async function main() {
   console.log(`\nmerge-cascade: merged ${merged}, skipped ${skipped}.`);
 }
 
-main();
+// Run main() only when invoked directly; when imported by a test, expose the pure
+// mergeDecision (+ the required-gate name) without draining any real queue.
+const isMain = process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main();
+
+export { mergeDecision, REQUIRED_GATE };


### PR DESCRIPTION
`scripts/merge-cascade.ts` — the queue-drain merger the ci-watch skill recommends — shared the hang that stranded PR #327 for hours: its rollup gate required ZERO pending checks, so a nameless, never-terminating ghost check-run parked the drain forever even with every real check green. This ports the carve-out landed for `ci-watch.ts` in #331.

## The change

- Extracted the ghost-aware rollup classifier out of `ci-watch.ts` into a new shared `scripts/lib/ci-rollup.ts`. Both tools import it, so the merger and the watcher cannot drift on the merge-safety verdict. `ci-watch.ts` re-exports the moved symbols, so its test is unaffected.
- Rebuilt `mergeDecision` on the shared classifier, gated on the required `"CI gate"` set. A nameless ghost — or any non-required check, pending OR failed — is non-blocking; the merge fires the instant every occurrence of the required gate is terminal + green and the PR is `MERGEABLE`.
- A still-running or failed REQUIRED gate always holds/blocks; mergeability stays positively gated (only `MERGEABLE` proceeds), so a red PR is never mis-merged.

## Tests

`scripts/merge-cascade.test.mjs` (12): the #327 shape now decides MERGE; a real required pending/failed/absent gate holds or blocks; positive mergeability gating. `ci-watch.test.mjs` (17) stays green after the extraction.

Refs #331, #327.

https://claude.ai/code/session_01Xuh9u8b93eMNu53fTQTWX7
