### PR TITLE
fix(phantom): scan extensionless main/exports entries instead of dropping them

### DIFF
--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -221,7 +221,7 @@ pub(crate) fn phantom_cache_dir() -> Option<PathBuf> {
 /// after upgrade; harmless and expected (the whole point is to pick up the better
 /// verdict). Just bump the number when the scanner logic changes — the coupling
 /// is structural, nothing else to remember.
-pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 1;
+pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 2;
 
 /// THE single source of truth for a phantom sidecar's location: the versioned
 /// subdir `<phantom_cache_dir>/s<PHANTOM_SCANNER_VERSION>/<fingerprint>.json`.

--- a/crates/nub-phantom-scan/src/lib.rs
+++ b/crates/nub-phantom-scan/src/lib.rs
@@ -266,6 +266,56 @@ mod tests {
     }
 
     #[test]
+    fn extensionless_and_directory_main_are_scanned() {
+        // Regression (the @vercel/static-build shape): a package whose `main` has
+        // no file extension (`"./dist/index"`) or points at a directory
+        // (`"./dist"`) must still be scanned. Before the entry-candidate fix the
+        // `is_js_like`-only gate dropped these mains → `files_analyzed: 0` → the
+        // phantom `require('@vercel/build-utils')` inside `dist/index.js` was never
+        // seen, so the package silently ejected nothing and broke at runtime.
+        let build = |main: &str| {
+            use std::sync::atomic::{AtomicU32, Ordering};
+            static SEQ: AtomicU32 = AtomicU32::new(0);
+            let root = std::env::temp_dir().join(format!(
+                "nub-phantom-scan-extless-{}-{}",
+                std::process::id(),
+                SEQ.fetch_add(1, Ordering::Relaxed)
+            ));
+            let _ = fs::remove_dir_all(&root);
+            fs::create_dir_all(root.join("dist")).unwrap();
+            fs::write(
+                root.join("package.json"),
+                format!(r#"{{"name":"pkg","main":"{main}","dependencies":{{"react":"*"}}}}"#),
+            )
+            .unwrap();
+            fs::write(
+                root.join("dist/index.js"),
+                "const b = require('undeclared-phantom'); require('react');",
+            )
+            .unwrap();
+            root
+        };
+
+        for main in ["./dist/index", "./dist"] {
+            let root = build(main);
+            let r = scan_extracted(&root).unwrap();
+            assert!(
+                r.files_analyzed > 0,
+                "main {main:?}: entry must resolve and scan (files_analyzed > 0)"
+            );
+            assert!(
+                r.has_unguarded_phantom,
+                "main {main:?}: undeclared-phantom must be flagged"
+            );
+            assert!(
+                r.targets.iter().any(|t| t.name == "undeclared-phantom"),
+                "main {main:?}: phantom target present"
+            );
+            let _ = fs::remove_dir_all(&root);
+        }
+    }
+
+    #[test]
     fn scan_index_is_output_identical_to_scan_extracted() {
         // The hard requirement: an extract-time index scan yields the exact same
         // verdict + target set + file count as a post-link tree scan. Uses the

--- a/crates/nub-phantom-scan/src/manifest.rs
+++ b/crates/nub-phantom-scan/src/manifest.rs
@@ -108,9 +108,10 @@ fn collect_bundled(v: &Value, out: &mut BTreeSet<String>) {
 }
 
 /// Gather the published entry files from `main`, `module`, `bin`, and `exports`,
-/// each tagged Main or Subpath. Only JS-like relative paths are kept;
-/// `types`/`.d.ts` and asset conditions are filtered (they carry no runtime
-/// imports).
+/// each tagged Main or Subpath. A recognized JS file is kept directly; an
+/// extensionless / directory-style target (`"./dist/index"`, `"./dist"`) is kept
+/// as a candidate and resolved Node-style by the graph walk; `types`/`.d.ts` and
+/// asset conditions carry no runtime imports and are filtered.
 fn collect_entry_points(v: &Value) -> Vec<Entry> {
     // Dedup on (kind, path) so a file exported at both `.` and a subpath seeds
     // both surfaces into the walk.
@@ -120,7 +121,7 @@ fn collect_entry_points(v: &Value) -> Vec<Entry> {
         |p: &str, kind: EntryKind, out: &mut Vec<Entry>, seen: &mut BTreeSet<(u8, String)>| {
             let norm = normalize_rel(p);
             let key = (kind as u8, norm.clone());
-            if is_js_like(&norm) && seen.insert(key) {
+            if is_entry_candidate(&norm) && seen.insert(key) {
                 out.push(Entry { path: norm, kind });
             }
         };
@@ -210,6 +211,20 @@ fn normalize_rel(p: &str) -> String {
         .to_string()
 }
 
+/// Whether a `main`/`module`/`bin`/`exports` target should SEED the reachable
+/// walk. Admits a recognized JS file (parsed directly) OR an EXTENSIONLESS /
+/// directory-style target — Node resolves `"./dist/index"` → `./dist/index.js`
+/// and `"./dist"` → `./dist/index.js` at runtime, and the graph walk's
+/// `resolve_entry` runs that SAME ladder, so on-disk resolution is deferred to
+/// it (a path that resolves to nothing is simply never analyzed — no false
+/// entry). A non-JS asset/type extension (`.json`/`.node`/`.wasm`/`.css`, a
+/// `.d.ts` stub) carries no analyzable imports, so it is dropped here and never
+/// costs a resolver probe. The `is_js_like`-only gate this replaced dropped
+/// extensionless mains outright → `files_analyzed: 0` → every phantom missed.
+fn is_entry_candidate(path: &str) -> bool {
+    is_js_like(path) || extension(path).is_none()
+}
+
 /// A JS-like runtime file (extension we can parse for imports). Excludes `.json`,
 /// `.node`, `.wasm`, `.css`, and `.d.ts` type stubs.
 pub fn is_js_like(path: &str) -> bool {
@@ -274,5 +289,44 @@ mod tests {
             super::EntryKind::Subpath
         );
         assert!(!m.entry_points.iter().any(|e| e.path.contains(".d.ts")));
+    }
+
+    #[test]
+    fn keeps_extensionless_and_directory_entries_drops_asset_mains() {
+        // The recall bug: an extensionless `main` (Node resolves `./dist/index`
+        // → `./dist/index.js`) must survive as a candidate for the graph walk to
+        // resolve — not be dropped for lacking a literal JS extension. A
+        // directory-style main is the same shape. `.json`/`.node`/`.d.ts` targets
+        // carry no analyzable imports and stay filtered.
+        let has = |m: &Manifest, p: &str| m.entry_points.iter().any(|e| e.path == p);
+
+        let ext = Manifest::parse(br#"{"name":"p","main":"./dist/index"}"#).unwrap();
+        assert!(
+            has(&ext, "dist/index"),
+            "extensionless main kept as candidate"
+        );
+
+        let dir = Manifest::parse(br#"{"name":"p","main":"./dist"}"#).unwrap();
+        assert!(has(&dir, "dist"), "directory-style main kept as candidate");
+
+        let json = Manifest::parse(br#"{"name":"p","main":"./data.json"}"#).unwrap();
+        assert!(
+            !has(&json, "data.json"),
+            ".json main dropped (not analyzable)"
+        );
+        // No entry survived → the entry-less fallback (`index.js`) seeds instead.
+        assert_eq!(json.entry_points.len(), 1);
+        assert_eq!(json.entry_points[0].path, "index.js");
+
+        let native = Manifest::parse(br#"{"name":"p","main":"./addon.node"}"#).unwrap();
+        assert!(!has(&native, "addon.node"), ".node main dropped");
+
+        // Extensionless conditional target inside an `exports` map is admitted too.
+        let exp = Manifest::parse(
+            br#"{"name":"p","exports":{".":{"import":"./dist/index","types":"./dist/index.d.ts"}}}"#,
+        )
+        .unwrap();
+        assert!(has(&exp, "dist/index"), "extensionless exports target kept");
+        assert!(!exp.entry_points.iter().any(|e| e.path.contains(".d.ts")));
     }
 }


### PR DESCRIPTION
The phantom scanner discovers a package's entry points from `main`/`module`/`bin`/`exports`, then walks the reachable module graph to find undeclared (phantom) imports the installer must disk-eject. `collect_entry_points` gated each candidate entry path on a literal JS extension, so an extensionless entry was dropped before the walk ever ran. Node resolves `main: "./dist/index"` to `./dist/index.js` and a directory `main: "./dist"` to `./dist/index.js`, but the scanner saw no extension and discarded the entry — the package scanned zero files, no phantom was flagged, nothing was ejected.

`@vercel/static-build@2.11.4` declares `main: "./dist/index"` and imports `@vercel/build-utils` without declaring it. Before this change a default install scanned zero files for it, so the phantom was never ejected and the import failed at runtime:

```
Error: Cannot find module '@vercel/build-utils'
```

## Fix

Admit extensionless and directory-style candidates and defer their resolution to the graph walk's existing `resolve_entry`, which already runs Node's own ladder (exact file → `<path>.{js,mjs,cjs,…}` → `<path>/index.{…}` → `package.json` `main`). A candidate that resolves to nothing contributes nothing, so no false entry is introduced. Non-JS asset/type targets (`.json`, `.node`, `.wasm`, `.css`, `.d.ts`) are still dropped and never probed. The change is monotonic toward recall — every path the old gate admitted is still admitted, so no currently-detected phantom is lost.

`PHANTOM_SCANNER_VERSION` bumps 1 → 2 so content already scanned under the old logic (its sidecar recorded no phantom) is re-scanned instead of served stale.

## Verification

- `@vercel/static-build@2.11.4`, fresh isolated install: the scanner now flags `@vercel/build-utils`, the package ejects, and the import resolves. With `NUB_DYNAMIC_PHANTOM_EJECT=0` the `MODULE_NOT_FOUND` reproduces, confirming the eject is what closes the gap.
- A verdict differential across 148 installed packages (including `firebase`, `@hookform/resolvers`, and their trees) changes exactly one verdict — `@vercel/static-build` — and leaves every other package byte-identical.
- Odd `main` shapes each behave correctly: a missing file, a directory with no index, a `.json` main, a `.node` main, no `main`, and an exports-only map with extensionless conditional targets all resolve to the right file or to nothing — no crash, no false entry.

New regression tests cover the extensionless and directory `main` shapes end-to-end (`files_analyzed > 0` and the phantom flagged); both fail on the old gate and pass after the fix.

This is the producer-side (scanner recall) complement to #330's consumer-side reachability fix.

Refs #330

https://claude.ai/code/session_01Xuh9u8b93eMNu53fTQTWX7
