### PR TITLE
Make phantom-eject unconditional for users; keep an internal test seam

### DIFF
--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -26,8 +26,7 @@ nub-core = { path = "../nub-core" }
 # crate's Cargo.toml for why that keeps the shipped CLI's build graph lean.
 nub-phantom-core = { path = "../nub-phantom-core" }
 # The reachable-graph phantom SCANNER (graph walk + classify) for the dynamic
-# per-version scan → sidecar path (default-on; NUB_DYNAMIC_PHANTOM_EJECT=0 opts
-# out). Lean by
+# per-version scan → sidecar path (unconditionally on for users). Lean by
 # construction — same oxc-parser weight as nub-phantom-core, no fetch stack. The
 # `ScanResult` it defines is the sidecar payload phantom_closure deserializes.
 nub-phantom-scan = { path = "../nub-phantom-scan" }

--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -1,5 +1,11 @@
-//! Dynamic per-version phantom scan → disk-eject (the default; the
-//! `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out disables it).
+//! Dynamic per-version phantom scan → disk-eject. Unconditionally ON for users
+//! (maintainer decision 2026-07-06): there is no user-facing opt-out. The one
+//! escape hatch for a suspected eject bug is disabling the global virtual store
+//! entirely (full disk materialization via `node-linker`/`disableGlobalVirtualStore`),
+//! which sidesteps the whole symlink+eject machinery. [`enabled`] carries the sole
+//! remaining off-switch: an INTERNAL, undocumented `__NUB_*` test seam the phantom
+//! test suite + framework/verify agents use to reproduce the pre-eject break as an
+//! A/B control.
 //!
 //! This REPLACES the old hand-curated static disk-materialize list (capped at a
 //! corpus, stale on new versions) by SCANNING each installed dependency
@@ -28,7 +34,7 @@
 //! cached content instead of serving the stale verdict its immutable bytes would
 //! otherwise key forever.
 //!
-//! With the opt-out set (`NUB_DYNAMIC_PHANTOM_EJECT=0`) this module registers
+//! Under the internal A/B seam ([`enabled`] returns false) this module registers
 //! nothing — no extract hook — so the install path is byte-identical to a build
 //! without the scanner (a pure-symlink tree).
 
@@ -38,59 +44,72 @@ use aube_store::{PackageIndex, index_content_fingerprint};
 use nub_phantom_scan::scan_index;
 use rayon::prelude::*;
 
-/// Whether dynamic phantom detection + ancestor-closure eject is armed — the
-/// DEFAULT. Unset (or empty, or any non-falsey value) is ON; only an explicit
-/// falsey `NUB_DYNAMIC_PHANTOM_EJECT` (`0`/`false`/`no`/`off`) is the opt-out to
-/// a pure-symlink tree. This is the SINGLE arm both halves gate on — the
+/// Whether dynamic phantom detection + ancestor-closure eject is armed.
+/// Unconditionally ON for users — there is NO user-facing opt-out (the removed
+/// `NUB_DYNAMIC_PHANTOM_EJECT` user knob is dead and ignored). Off only under the
+/// internal A/B seam below. This is the SINGLE arm both halves gate on — the
 /// extract-time PRODUCER here and the link-time CONSUMER
 /// ([`crate::pm_engine::phantom_closure`]) call this one function, and the
 /// install-state fingerprint ([`settings_fingerprint`]) folds THIS value, so
 /// detection, closure, and warm-tree invalidation can never drift.
 pub(crate) fn enabled() -> bool {
-    match std::env::var("NUB_DYNAMIC_PHANTOM_EJECT") {
-        Ok(v) => !matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "0" | "false" | "no" | "off"
-        ),
-        Err(_) => true,
-    }
+    !eject_disabled(std::env::var(INTERNAL_EJECT_DISABLE_VAR).ok().as_deref())
+}
+
+/// INTERNAL, UNDOCUMENTED test seam — NOT a user knob. Truthy turns phantom-eject
+/// OFF so the phantom test suite + framework/verify agents can reproduce the
+/// pre-eject break as an A/B control against a real built binary (the `cfg(test)`
+/// route can't, since those agents run `target/fast/nub`, not a test build). The
+/// `__NUB_` double-underscore prefix marks internal plumbing — the brand boundary
+/// exempts internal `__NUB_*` sentinels; this one is never documented and users
+/// must not rely on it. Deliberately distinct from the removed public var so a
+/// stale `NUB_DYNAMIC_PHANTOM_EJECT=0` in a user's env has zero effect.
+const INTERNAL_EJECT_DISABLE_VAR: &str = "__NUB_PHANTOM_EJECT_DISABLE";
+
+/// Pure predicate for the internal disable seam, split from the env read so its
+/// truthiness contract is testable without mutating the process-global env. A
+/// truthy value disables; unset / empty / any other value keeps eject ON.
+fn eject_disabled(raw: Option<&str>) -> bool {
+    matches!(
+        raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
 }
 
 /// The effective phantom-eject setting as a stable token, folded into aube's
 /// install-state `settings_hash` through the embedder `extra_settings_fingerprint`
 /// hook (nub's [`crate::pm_engine::identity::NUB`] profile points that hook here).
-/// The flag is nub's, not an aube setting, so it can't ride the resolved-settings
-/// hash — this seam is what makes flipping it invalidate the warm tree: nub's
-/// default moving across an upgrade, or a user's `NUB_DYNAMIC_PHANTOM_EJECT=0`
-/// opt-out, changes this token, so the link phase re-runs and converts the tree
-/// to the new materialization shape instead of trusting a stale node_modules.
+/// The setting is nub's, not an aube setting, so it can't ride the resolved-settings
+/// hash — this seam is what makes it invalidate the warm tree.
 ///
-/// When ENABLED the token also folds [`PHANTOM_SCANNER_VERSION`], which is what
-/// makes a scanner-logic bump COMPLETE rather than a half-fix: the version bump
-/// re-scans content into a new sidecar path, but on a warm tree with an unchanged
-/// lockfile + flag aube would SKIP the link phase and never apply the improved
-/// verdict — folding the version here changes the token, so the link re-runs and
-/// the consumer picks up the new-version sidecars. The fold is inside the enabled
-/// branch ONLY: the opt-out's token stays byte-identical to a build without the
-/// scanner (`dynamic_phantom_eject=false`), preserving the strict no-op install
-/// path (a scanner version can't matter when nothing scans).
+/// For users the token is CONSTANT-ON: the dead on/off toggle is gone, so it folds
+/// only [`PHANTOM_SCANNER_VERSION`]. That fold is what makes a scanner-logic bump
+/// COMPLETE rather than a half-fix — the bump re-scans content into a new sidecar
+/// path, but on a warm tree with an unchanged lockfile aube would SKIP the link
+/// phase and never apply the improved verdict; changing this token forces the link
+/// to re-run so the consumer picks up the new-version sidecars.
+///
+/// The token still branches on [`enabled`] SOLELY for the internal A/B seam: when
+/// an agent flips [`INTERNAL_EJECT_DISABLE_VAR`] the token changes, so a warm tree
+/// re-links to the pure-symlink shape and the pre-eject break reproduces. Users
+/// never reach that branch (the seam is undocumented internal plumbing).
 pub(crate) fn settings_fingerprint() -> String {
     settings_token(enabled())
 }
 
-/// Pure token builder, split from [`settings_fingerprint`] so the byte-identity
-/// contract is testable without mutating the process-global `enabled()` env.
+/// Pure token builder, split from [`settings_fingerprint`] so the fold contract is
+/// testable without mutating the process-global `enabled()` env.
 fn settings_token(enabled: bool) -> String {
     if enabled {
-        format!("dynamic_phantom_eject=true;phantom_scanner={PHANTOM_SCANNER_VERSION}")
+        format!("phantom_scanner={PHANTOM_SCANNER_VERSION}")
     } else {
-        "dynamic_phantom_eject=false".to_string()
+        "phantom_eject=disabled".to_string()
     }
 }
 
 /// Register the extract-time scan hook with the embedded engine. Called once at
-/// engine-session build. No-op only under the `NUB_DYNAMIC_PHANTOM_EJECT=0`
-/// opt-out, in which case the path pulls in nothing and stays byte-identical.
+/// engine-session build. No-op only under the internal A/B seam ([`enabled`]
+/// false), in which case the path pulls in nothing and stays byte-identical.
 /// The registration is process-global set-once; a second call is ignored. The
 /// link-time consumption of the sidecars this writes lives in
 /// [`crate::pm_engine::phantom_closure`], not here.
@@ -255,7 +274,7 @@ pub(crate) fn sidecar_path(base: &Path, fingerprint: &str) -> PathBuf {
 /// fingerprint keying, sidecar-hit skip, panic-guard, and atomic write are one
 /// implementation.
 ///
-/// The `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out is a STRICT no-op: it returns
+/// The internal A/B seam ([`enabled`] false) is a STRICT no-op: it returns
 /// before any lockfile parse, store access, or fs touch, so that install path is
 /// byte-identical. No lockfile / an unparseable one is also a no-op — a fresh
 /// install has nothing
@@ -326,16 +345,39 @@ mod tests {
         );
     }
 
-    /// The opt-out's install-state token must never carry the scanner version, so
-    /// `NUB_DYNAMIC_PHANTOM_EJECT=0` keeps a byte-identical `settings_hash` (the
-    /// strict no-op). The enabled token folds the version so a bump invalidates
-    /// the warm tree. Pins both against a future refactor.
+    /// The user (enabled) token folds the scanner version so a bump invalidates a
+    /// warm tree and forces a re-scan/relink; the dead on/off toggle is gone, so the
+    /// token is just the scanner segment. The disabled token (reachable only via the
+    /// internal A/B seam) is version-free and distinct, so flipping the seam still
+    /// re-links to the pure-symlink shape. Pins both against a future refactor.
     #[test]
-    fn disabled_token_stays_version_free_enabled_folds_version() {
-        assert_eq!(settings_token(false), "dynamic_phantom_eject=false");
+    fn enabled_token_folds_version_disabled_seam_token_is_distinct() {
         assert_eq!(
             settings_token(true),
-            format!("dynamic_phantom_eject=true;phantom_scanner={PHANTOM_SCANNER_VERSION}")
+            format!("phantom_scanner={PHANTOM_SCANNER_VERSION}")
         );
+        assert_eq!(settings_token(false), "phantom_eject=disabled");
+        assert_ne!(settings_token(true), settings_token(false));
+    }
+
+    /// The internal disable seam's truthiness contract: only an explicit truthy
+    /// value turns eject off; unset, empty, `0`, and any other string keep it ON.
+    /// This is the sole off-switch — there is no user knob — so a wrong parse here
+    /// would either strand the A/B control or hand users a hidden opt-out.
+    #[test]
+    fn internal_seam_only_truthy_disables_eject() {
+        for on in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("no"),
+            Some("off"),
+        ] {
+            assert!(!eject_disabled(on), "eject must stay ON for {on:?}");
+        }
+        for off in [Some("1"), Some("true"), Some("YES"), Some(" on ")] {
+            assert!(eject_disabled(off), "internal seam disables for {off:?}");
+        }
     }
 }

--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -226,11 +226,10 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     // in the window that matters. An explicit user `trustPolicyIgnoreAfter=0`
     // opts back into the full strict check. Standalone aube keeps `None`.
     trust_policy_ignore_after_default: Some(14 * 24 * 60),
-    // Fold nub's phantom-eject flag (`NUB_DYNAMIC_PHANTOM_EJECT`) into aube's
-    // install-state `settings_hash`: it shapes which packages materialize but
-    // rides no aube setting, so without this a flag flip (the default moving
-    // across an upgrade, or a user opt-out) would leave a warm tree stale. The
-    // hook returns a stable on/off token; standalone aube's `None` skips the fold.
+    // Fold nub's phantom-eject state into aube's install-state `settings_hash`: it
+    // shapes which packages materialize but rides no aube setting. For users the
+    // token is constant-on and folds the scanner version, so a scanner-logic bump
+    // invalidates a warm tree and re-links; standalone aube's `None` skips the fold.
     extra_settings_fingerprint: Some(crate::dynamic_phantom::settings_fingerprint),
 };
 

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -766,18 +766,17 @@ fn engine_session_inner(
     // (which calls it again as its first step, alongside the project-state-
     // dependent config surface) is a no-op for the registration.
     identity::register();
-    // Install nub's selective-subtree disk-materialize expansion hook (the
-    // DEFAULT; the `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out disables it). When armed
-    // it expands the disk-materialize seed to its ancestor-closure +
-    // phantom-target hoists at link time; under the opt-out it's a no-op and the
-    // install path is byte-identical (pure symlink). Idempotent set-once, like
-    // `identity::register()`.
+    // Install nub's selective-subtree disk-materialize expansion hook
+    // (unconditionally on for users). It expands the disk-materialize seed to its
+    // ancestor-closure + phantom-target hoists at link time; under the internal A/B
+    // seam it's a no-op and the install path is byte-identical (pure symlink).
+    // Idempotent set-once, like `identity::register()`.
     phantom_closure::register();
     // Arm the dynamic per-version phantom PRODUCER: an extract-time store hook
     // that scans each fetched package and writes a per-content verdict sidecar
     // (`phantom_closure`, above, is the CONSUMER that reads those sidecars to seed
-    // the closure). On by default; a no-op only under the same
-    // `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out. Idempotent set-once.
+    // the closure). On for users; a no-op only under the same internal A/B seam.
+    // Idempotent set-once.
     crate::dynamic_phantom::register();
     // Initialize the diagnostics recorder from NUB_DIAG_* env vars so that
     // `NUB_DIAG_SUMMARY=1 nub install` surfaces the same per-phase/per-op

--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -1,5 +1,6 @@
 //! Selective-subtree disk-materialization policy — nub's disk-materialize
-//! expansion hook (the default; disabled by `NUB_DYNAMIC_PHANTOM_EJECT=0`).
+//! expansion hook. Unconditionally on for users; off only under the internal A/B
+//! seam ([`crate::dynamic_phantom::enabled`]).
 //!
 //! Disk-materializing a package project-local is only SOUND for a
 //! transitively-consumed package if its whole ancestor-closure materializes with
@@ -31,10 +32,10 @@
 //! are all already resolvable as its own DIRECT (depth-1) siblings and absent from
 //! the project top level, so a directly-satisfied over-flag never ejects.
 //!
-//! Opt-out (`NUB_DYNAMIC_PHANTOM_EJECT=0`) ⇒ no hook installed ⇒ aube's
-//! `expand_disk_materialize` returns the seed verbatim ⇒ the disk-materialize
-//! pass is byte-for-byte the pre-productionization pure-symlink behavior. All
-//! policy lives here; aube owns only the neutral seam + the graph primitive.
+//! Internal A/B seam off ⇒ no hook installed ⇒ aube's `expand_disk_materialize`
+//! returns the seed verbatim ⇒ the disk-materialize pass is byte-for-byte the
+//! pre-productionization pure-symlink behavior. All policy lives here; aube owns
+//! only the neutral seam + the graph primitive.
 
 use std::collections::{BTreeMap, HashSet};
 
@@ -46,17 +47,17 @@ use rayon::prelude::*;
 /// The SINGLE phantom-eject arm — [`crate::dynamic_phantom::enabled`] — shared
 /// with the extract-time producer so detection (the scanner), transitive
 /// soundness (this closure), and warm-tree invalidation (the fingerprint) can
-/// never disagree. On by DEFAULT; `NUB_DYNAMIC_PHANTOM_EJECT=0` is the opt-out.
-/// The flag IS now folded into the install-state fingerprint (via the embedder
+/// never disagree. Unconditionally on for users; off only under the internal A/B
+/// seam. The arm IS folded into the install-state fingerprint (via the embedder
 /// `extra_settings_fingerprint` hook; see [`crate::dynamic_phantom::settings_fingerprint`]),
-/// so flipping it on an already-installed tree re-links to the new
-/// materialization shape rather than accepting a stale node_modules.
+/// so flipping the seam on an already-installed tree re-links to the pure-symlink
+/// shape rather than accepting a stale node_modules.
 fn enabled() -> bool {
     crate::dynamic_phantom::enabled()
 }
 
 /// Register nub's disk-materialize expansion hook with the embedded engine.
-/// No-op only under the `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out, in which case
+/// No-op only under the internal A/B seam ([`enabled`] false), in which case
 /// `aube_linker::expand_disk_materialize` stays the identity — byte-for-byte the
 /// pure-symlink disk-materialize behavior. Set-once (idempotent); safe to call
 /// once per engine-session build.
@@ -94,9 +95,9 @@ fn plan_from_flags(
     // `vite_lt_8_1` check), which fires for every < 8.1 copy the name-seed caught,
     // so pruning the name-seed loses nothing for < 8.1 and stops the ≥ 8.1
     // over-eject. This is the ONLY version-aware chokepoint: the mod.rs seed runs
-    // pre-resolve and can't see the concrete version. (The
-    // `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out installs no hook, so its raw name-seed
-    // still over-ejects vite ≥ 8.1 — an accepted cost of that rare opt-out path.)
+    // pre-resolve and can't see the concrete version. (Under the internal A/B seam
+    // no hook installs, so the raw name-seed still over-ejects vite ≥ 8.1 — an
+    // accepted cost of that internal-only path.)
     // Provenance-blind: this also strips a user's explicit `vite` in
     // `diskMaterializePackages`, which is fine — vite ≥ 8.1 works symlinked and
     // vite < 8.1 is re-seeded below regardless of source, so a working vite is
@@ -216,7 +217,7 @@ fn plan_from_flags(
 /// rayon; the backfill already warmed the sidecars, so each item is a small
 /// cached-JSON index load + a blake3 fingerprint + a small sidecar read.
 ///
-/// Empty under the `NUB_DYNAMIC_PHANTOM_EJECT=0` opt-out. In production `expand`
+/// Empty under the internal A/B seam ([`enabled`] false). In production `expand`
 /// installs the hook only when armed, so this gate is belt-and-suspenders; the
 /// pure planning logic is tested through [`plan_from_flags`] with injected flags,
 /// so the unit tests never reach this store-IO path.

--- a/tests/vite-compat/README.md
+++ b/tests/vite-compat/README.md
@@ -25,12 +25,13 @@ Unit B as shipped disk-materializes vite ONLY when it is a **direct** dep — a
 raw `vite dev` app. A framework that embeds vite **transitively** (Astro 5 pins
 `vite@^6`, `< 8.1`) loads its vite from a store-to-store sibling symlink, so the
 direct-dep eject never reaches it and the store `/@fs` stays 403 (the #315
-residual). Behind the default-off `NUB_DYNAMIC_PHANTOM_EJECT` flag, nub now
-auto-detects an embedded vite `< 8.1` and disk-materializes its
-`[framework … vite]` **ancestor closure** (measured 5 packages for Astro 5,
-`~1.5%` of the tree — everything else stays symlinked), so the framework loads a
-project-local vite that Unit B patches. With the flag OFF the behavior is
-byte-for-byte the shipped Unit B.
+residual). Phantom-eject (unconditionally on for users) auto-detects an embedded
+vite `< 8.1` and disk-materializes its `[framework … vite]` **ancestor closure**
+(measured 5 packages for Astro 5, `~1.5%` of the tree — everything else stays
+symlinked), so the framework loads a project-local vite that Unit B patches. The
+pre-eject baseline (byte-for-byte the shipped Unit B) is reproducible via the
+internal test seam `__NUB_PHANTOM_EJECT_DISABLE=1` — an undocumented A/B control,
+not a user knob.
 
 Because the fix lives in `node_modules` on disk (`.modules.yaml` + the patched
 vite dist) and nothing is injected at runtime, it works regardless of whether
@@ -91,13 +92,13 @@ island/route hydrates and is interactive, read the console for 403s) is a
 stronger check and SHOULD be run for the flagship Astro+React case when that MCP
 is available; the HTTP + log-scan floor here is the CI-portable substitute.
 
-## The closure acceptance cases (behind `NUB_DYNAMIC_PHANTOM_EJECT=1`)
+## The closure acceptance cases
 
-The two cases the selective-subtree closure must satisfy. Run the driver with the
-flag armed:
+The two cases the selective-subtree closure must satisfy. Eject is on by default,
+so just run the driver:
 
 ```sh
-NUB_DYNAMIC_PHANTOM_EJECT=1 tests/vite-compat/driver.sh <dir> "<dev-cmd>" "<build-cmd>" <port>
+tests/vite-compat/driver.sh <dir> "<dev-cmd>" "<build-cmd>" <port>
 ```
 
 - **Astro 5 (rung 1 — the vite closure).** `astro@^5` pins `vite@6.4.3` (`< 8.1`),


### PR DESCRIPTION
Maintainer decision (2026-07-06): users cannot disable phantom-eject. The escape hatch for a suspected eject bug is disabling the global virtual store (`node-linker`/`disableGlobalVirtualStore`), not a phantom toggle.

- `enabled()` no longer reads `NUB_DYNAMIC_PHANTOM_EJECT`; a stale `=0` now has no effect.
- Sole off-switch is `__NUB_PHANTOM_EJECT_DISABLE`, an undocumented internal test seam for the A/B control.
- #328 fold simplified: the user token folds only `PHANTOM_SCANNER_VERSION`, so a scanner bump still relinks a warm tree.

No `vendor/aube` change. Clippy/fmt/phantom tests (299) green; e2e confirms the old var is ignored, the seam disables, the default ejects, and a scanner bump relinks.