### PR TITLE
fix(gvs): host-filter the prewarm graph so the shared store doesn't over-split @parcel/core

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2162,17 +2162,25 @@ fn nub_setting_defaults(
             // NOT a phantom-dep class (those the dynamic detector + closure now
             // eject per-package). `nuxt` was DROPPED: its walk-up is only 2 phantom
             // edges (~2.3% closure), so it's closure-ejectable at rung 1 —
-            // symlink-GVS works (see [[nuxt-gvs-unlock]]). What remains:
+            // symlink-GVS works (see [[nuxt-gvs-unlock]]). `parcel` was DROPPED: its
+            // real break was never `.parcelrc` walk-up but a GVS store-dir over-split
+            // — the prewarm hashed the widened (all-platform) graph while the link
+            // phase hashed the host-filtered one, so parcel's native subtree
+            // materialized `@parcel/core` at two byte-identical store dirs; two
+            // consumers loaded different copies → two serializer registries →
+            // `DataCloneError` at worker-farm startup. Fixed at the source (the
+            // prewarm now host-filters its graph to match the link phase), verified
+            // green across parcel 2.9–2.13 + 2.16. What remains:
             // - `next` — Turbopack canonicalizes through symlinks and chroots to a
             //   single project root; irreducible, so the store must be project-local.
-            // - `parcel` — resolver walks up for `.parcelrc` (unverified against the
-            //   closure; kept as the safe last resort).
+            //   (It hit the same store-split, now also fixed, but the chroot break is
+            //   independent and keeps it here pending its own verification.)
             // - `react-native` — bare RN's Metro (`@react-native/metro-config`)
             //   crawls by realpath and only sees the project root, so the global
             //   store is out of scope and even DECLARED deps (`@babel/runtime`)
             //   report unresolved. Expo's `@expo/metro-config` is store-aware
             //   (works either way; this only flips it project-local, harmless).
-            "next,parcel,react-native".to_string(),
+            "next,react-native".to_string(),
         ),
         ("diskMaterializePackages".to_string(), disk_materialize),
     ];
@@ -2801,16 +2809,19 @@ mod tests {
     }
 
     #[test]
-    fn disable_gvs_default_drops_nuxt_and_keeps_the_store_locality_breakers() {
+    fn disable_gvs_default_drops_nuxt_and_parcel_and_keeps_the_store_locality_breakers() {
         // The whole-install GVS-off list is now reserved for store-LOCALITY
         // breaks. `nuxt` is closure-ejectable at rung 1 ([[nuxt-gvs-unlock]]) so
-        // it was dropped; `next` (Turbopack chroot), `parcel`, and `react-native`
-        // (bare-RN Metro realpath crawl) remain irreducible.
+        // it was dropped; `parcel` was dropped once its real break — a GVS
+        // store-dir over-split from the prewarm/link graph mismatch — was fixed at
+        // the source (see `run_gvs_prewarm_materializer`). `next` (Turbopack
+        // chroot) and `react-native` (bare-RN Metro realpath crawl) remain
+        // irreducible store-locality breaks.
         let dir = tempfile::tempdir().unwrap();
         let fresh = nub_setting_defaults(None, true, dir.path(), VirtualStoreLocality::Default);
         assert_eq!(
             get(&fresh, "disableGlobalVirtualStoreForPackages"),
-            Some("next,parcel,react-native"),
+            Some("next,react-native"),
         );
     }
 

--- a/tests/parcel-gvs/README.md
+++ b/tests/parcel-gvs/README.md
@@ -1,0 +1,24 @@
+# Parcel under the global virtual store — regression harness
+
+This directory regression-tests a global-virtual-store (GVS) bug that broke `parcel build`: the shared store materialized `@parcel/core` as two byte-identical directories, so the main thread and a worker thread loaded different `@parcel/core` instances, ended up with two module-scoped serializer registries, and threw `DataCloneError` at worker-farm startup.
+
+## The bug
+
+The resolver widens its graph with every common platform's optional native deps so the committed lockfile is portable. The link phase runs `filter_graph` to trim that back to the host before hashing. The GVS prewarm materializer — which populates the shared store concurrently with fetch — hashed the **widened** graph instead. Any package whose subtree contains a platform-specific optional native dep (all of Parcel's tree: `@parcel/watcher-<platform>`, `@swc/core-<platform>`, `lmdb`, `msgpackr`) then hashed differently in the two phases, so the same `dep_path` landed at two shared-store directories. The existence-gated link step never rewired over the prewarm cohort, so `parcel` resolved one copy of `@parcel/core` and `@parcel/workers` resolved the other.
+
+The fix host-filters the prewarm graph to match the link phase (`run_gvs_prewarm_materializer` in `vendor/aube/crates/aube/src/commands/install/materialize.rs`). A hermetic unit test guards the graph-hash agreement invariant: `gvs_prewarm_and_link_agree_only_after_host_filtering_the_widened_graph` in `vendor/aube/crates/aube-resolver/src/platform.rs`.
+
+## Running the harness
+
+```sh
+tests/parcel-gvs/run.sh target/fast/nub                      # default version matrix
+tests/parcel-gvs/run.sh target/fast/nub 2.12.0 2.16.4        # specific versions
+```
+
+For each Parcel version, `run.sh` builds a minimal worker-farm fixture (`make-fixture.sh`), installs it into a **fresh, isolated** global store with the GVS forced on, and asserts exactly one `@parcel/core` store directory plus a `parcel build` that exits 0. Store isolation (`XDG_CACHE_HOME`/`XDG_DATA_HOME` per version) is load-bearing: a polluted machine-global store accumulates directories across installs and masks the over-split.
+
+Verified against 2.9.3, 2.10.3, 2.11.0, 2.12.0, 2.13.3, and 2.16.4.
+
+## Why an end-to-end harness
+
+The runtime failure only reproduces against a real Parcel dependency tree materialized into a real shared store — the split is in on-disk store-directory naming and Parcel's own module-singleton assumption, neither of which a Rust unit test can stand in for. The unit test covers the hashing invariant; this harness covers the whole install-and-build path across Parcel versions.

--- a/tests/parcel-gvs/make-fixture.sh
+++ b/tests/parcel-gvs/make-fixture.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Build a minimal Parcel app whose build spins up @parcel/workers — the
+# shape that exercises @parcel/core's module-scoped serializer registry
+# (registerCoreWithSerializer.js) across the worker-farm boundary. That
+# registry is what breaks with a DataCloneError when @parcel/core is
+# materialized as two separate module instances (the GVS store-dir
+# over-split this harness regression-tests).
+#
+# Usage: make-fixture.sh [dest] [parcel-version]
+set -euo pipefail
+DEST="${1:-/tmp/nub-parcel-gvs-fixture}"
+VERSION="${2:-2.12.0}"
+rm -rf "$DEST"
+mkdir -p "$DEST/src"
+cat > "$DEST/package.json" <<EOF
+{
+  "name": "nub-parcel-gvs-fixture",
+  "version": "1.0.0",
+  "source": "src/index.html",
+  "scripts": { "build": "parcel build --no-cache" },
+  "devDependencies": { "parcel": "$VERSION" }
+}
+EOF
+cat > "$DEST/src/index.html" <<'EOF'
+<!doctype html><html><body><script type="module" src="./index.js"></script></body></html>
+EOF
+cat > "$DEST/src/index.js" <<'EOF'
+import { greet } from './greet.js';
+console.log(greet('parcel'));
+EOF
+cat > "$DEST/src/greet.js" <<'EOF'
+export const greet = (n) => `hello ${n}`;
+EOF
+echo "fixture at $DEST (parcel@$VERSION)"

--- a/tests/parcel-gvs/run.sh
+++ b/tests/parcel-gvs/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Regression harness for the GVS @parcel/core store-dir over-split.
+#
+# For each Parcel version: fresh fixture + fresh isolated global store
+# (XDG_CACHE_HOME/XDG_DATA_HOME), install with the global virtual store
+# forced on, then assert:
+#   1. exactly ONE @parcel/core store dir (no over-split), and
+#   2. `parcel build` exits 0 (no worker-farm DataCloneError).
+#
+# The shared CAS is isolated per run so results never depend on a
+# polluted machine-global store — the accumulation trap that masked the
+# original root-cause. See README.md for the mechanism.
+#
+# Usage: run.sh <nub-binary> [version ...]
+#   default versions: 2.9.3 2.10.3 2.11.0 2.12.0 2.13.3 2.16.4
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+NUB="${1:?usage: run.sh <nub-binary> [version ...]}"
+shift || true
+VERSIONS=("$@")
+[ ${#VERSIONS[@]} -eq 0 ] && VERSIONS=(2.9.3 2.10.3 2.11.0 2.12.0 2.13.3 2.16.4)
+
+fail=0
+printf "%-10s %-8s %-6s %-8s %s\n" VERSION INSTALL CORES BUILD RESULT
+for V in "${VERSIONS[@]}"; do
+  DEST=$(mktemp -d "/tmp/nub-parcel-gvs-$V-XXXXXX")
+  ISO=$(mktemp -d "/tmp/nub-parcel-gvs-iso-$V-XXXXXX")
+  "$HERE/make-fixture.sh" "$DEST" "$V" >/dev/null
+  ( cd "$DEST"
+    XDG_CACHE_HOME="$ISO/cache" XDG_DATA_HOME="$ISO/data" \
+      NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=true "$NUB" install >install.log 2>&1
+  ); IEXIT=$?
+  VS="$ISO/cache/nub/pm/virtual-store"
+  CORES=$(ls -1 "$VS" 2>/dev/null | grep -cE '^@parcel\+core@' || true)
+  ( cd "$DEST"
+    XDG_CACHE_HOME="$ISO/cache" XDG_DATA_HOME="$ISO/data" "$NUB" run build >build.log 2>&1
+  ); BEXIT=$?
+  RESULT=PASS
+  if [ "$IEXIT" -ne 0 ] || [ "$BEXIT" -ne 0 ] || [ "$CORES" != 1 ]; then RESULT=FAIL; fail=1; fi
+  printf "%-10s %-8s %-6s %-8s %s\n" "$V" \
+    "$([ $IEXIT -eq 0 ] && echo ok || echo ERR)" "$CORES" \
+    "$([ $BEXIT -eq 0 ] && echo ok || echo ERR)" "$RESULT"
+  [ "$RESULT" = PASS ] && rm -rf "$DEST" "$ISO"
+done
+[ $fail -eq 0 ] && echo "ALL PASS" || { echo "FAILURES — kept failing fixtures under /tmp for inspection"; exit 1; }

--- a/vendor/aube/crates/aube-resolver/src/platform.rs
+++ b/vendor/aube/crates/aube-resolver/src/platform.rs
@@ -988,4 +988,148 @@ mod tests {
         let sup = SupportedArchitectures::default();
         assert!(!is_supported(&[], &[], &s(&["musl"]), &sup));
     }
+
+    // --- GVS prewarm/link graph-hash agreement (parcel worker-farm regression) ---
+
+    // A parcel-worker-farm-shaped graph: `@parcel/core` peers with
+    // `@parcel/workers`, and pulls in `@parcel/watcher`, whose subtree
+    // carries a platform-specific optional native variant per OS — exactly
+    // the shape (`@parcel/watcher-<platform>`, `@swc/core-<platform>`, lmdb,
+    // `@next/swc-<platform>`) that made the resolver widen the graph for a
+    // portable lockfile. Built with `optional_dependencies` set so
+    // `filter_graph` drops the host-mismatched leaf.
+    fn parcel_worker_farm_graph() -> aube_lockfile::LockfileGraph {
+        use aube_lockfile::{DirectDep, LockedPackage, LockfileGraph};
+        let mk = |name: &str, dep_path: &str| LockedPackage {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            integrity: Some(format!("sha512-{name}")),
+            dep_path: dep_path.to_string(),
+            ..Default::default()
+        };
+        let mut graph = LockfileGraph::default();
+        graph.importers.insert(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "parcel".to_string(),
+                dep_path: "parcel@2.12.0".to_string(),
+                dep_type: aube_lockfile::DepType::Production,
+                specifier: Some("2.12.0".to_string()),
+            }],
+        );
+
+        let mut parcel = mk("parcel", "parcel@2.12.0");
+        parcel.dependencies = [
+            ("@parcel/core".to_string(), "2.12.0".to_string()),
+            (
+                "@parcel/workers".to_string(),
+                "2.12.0(@parcel/core@2.12.0)".to_string(),
+            ),
+        ]
+        .into();
+        graph.packages.insert("parcel@2.12.0".to_string(), parcel);
+
+        let mut core = mk("@parcel/core", "@parcel/core@2.12.0");
+        core.dependencies = [
+            (
+                "@parcel/workers".to_string(),
+                "2.12.0(@parcel/core@2.12.0)".to_string(),
+            ),
+            ("@parcel/watcher".to_string(), "2.5.6".to_string()),
+        ]
+        .into();
+        graph
+            .packages
+            .insert("@parcel/core@2.12.0".to_string(), core);
+
+        let mut workers = mk(
+            "@parcel/workers",
+            "@parcel/workers@2.12.0(@parcel/core@2.12.0)",
+        );
+        workers.dependencies = [("@parcel/core".to_string(), "2.12.0".to_string())].into();
+        graph.packages.insert(
+            "@parcel/workers@2.12.0(@parcel/core@2.12.0)".to_string(),
+            workers,
+        );
+
+        // The native package with per-OS optional variants — the widening
+        // source. `watcher-linux` is host-mismatched on the darwin target
+        // the test filters against, so `filter_graph` prunes it and the
+        // parent `watcher` (and everything above it) re-hashes.
+        let mut watcher = mk("@parcel/watcher", "@parcel/watcher@2.5.6");
+        watcher.dependencies = [
+            ("@parcel/watcher-darwin".to_string(), "2.5.6".to_string()),
+            ("@parcel/watcher-linux".to_string(), "2.5.6".to_string()),
+        ]
+        .into();
+        watcher.optional_dependencies = watcher.dependencies.clone();
+        graph
+            .packages
+            .insert("@parcel/watcher@2.5.6".to_string(), watcher);
+
+        let mut darwin = mk("@parcel/watcher-darwin", "@parcel/watcher-darwin@2.5.6");
+        darwin.os = s(&["darwin"]).into();
+        darwin.cpu = s(&["arm64"]).into();
+        graph
+            .packages
+            .insert("@parcel/watcher-darwin@2.5.6".to_string(), darwin);
+
+        let mut linux = mk("@parcel/watcher-linux", "@parcel/watcher-linux@2.5.6");
+        linux.os = s(&["linux"]).into();
+        linux.cpu = s(&["x64"]).into();
+        graph
+            .packages
+            .insert("@parcel/watcher-linux@2.5.6".to_string(), linux);
+
+        graph
+    }
+
+    #[test]
+    fn gvs_prewarm_and_link_agree_only_after_host_filtering_the_widened_graph() {
+        // The GVS prewarm materializes into the shared store while hashing the
+        // resolver's WIDENED (all-platform) graph; the link phase hashes the
+        // host-FILTERED graph. Any package whose subtree contains a
+        // platform-specific optional native dep then recursively hashes
+        // differently in the two phases, so the SAME dep_path lands at two
+        // byte-identical global store dirs — and symlink-shared consumers split
+        // across the copies (for parcel: two `@parcel/core` instances, two
+        // serializer registries, `DataCloneError` at worker-farm startup). The
+        // fix host-filters the prewarm graph so both phases hash the same graph.
+        // This pins BOTH halves: a widened-vs-filtered hash genuinely diverges
+        // (why the bug existed), and filtering both sides makes every node hash
+        // agree (one store dir per dep_path).
+        use aube_lockfile::graph_hash::compute_graph_hashes;
+
+        let widened = parcel_worker_farm_graph();
+        let host = SupportedArchitectures {
+            os: s(&["darwin"]),
+            cpu: s(&["arm64"]),
+            ..Default::default()
+        };
+        let core = "@parcel/core@2.12.0";
+
+        let prewarm_widened = compute_graph_hashes(&widened, &|_| false, None);
+        let mut filtered = widened.clone();
+        filter_graph(&mut filtered, &host, &Default::default());
+        let link = compute_graph_hashes(&filtered, &|_| false, None);
+
+        assert!(
+            !filtered
+                .packages
+                .contains_key("@parcel/watcher-linux@2.5.6"),
+            "host filter must drop the linux-only native leaf"
+        );
+        assert_ne!(
+            prewarm_widened.node_hash[core], link.node_hash[core],
+            "hashing the widened graph must diverge from the host-filtered graph \
+             — that divergence is what split @parcel/core into two store dirs"
+        );
+
+        let prewarm_fixed = compute_graph_hashes(&filtered, &|_| false, None);
+        assert_eq!(
+            prewarm_fixed.node_hash, link.node_hash,
+            "with the prewarm host-filtering its graph, prewarm and link must \
+             agree on every node hash so no dep_path materializes at two dirs"
+        );
+    }
 }

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -317,12 +317,15 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
 
         // Reuse the prewarm task's `compute_graph_hashes` output when
         // the link-phase graph matches what the prewarm hashed. The
-        // prewarm hashed the unfiltered post-resolve graph; if no
-        // dep-selection or workspace filter applied, `graph_for_link`
-        // == that graph by node count + key set, so the cached
-        // hashes are byte-identical to a fresh compute. Falling
-        // through to a fresh compute keeps the contract simple
-        // whenever the graphs diverge.
+        // prewarm host-filters its graph clone with the SAME
+        // `filter_graph` inputs this branch applied (see
+        // `run_gvs_prewarm_materializer` / `prewarm_host_filter_inputs`),
+        // so absent a dep-selection or workspace filter `graph_for_link`
+        // == the prewarm's graph by node count + key set and the cached
+        // hashes are byte-identical to a fresh compute. Falling through
+        // to a fresh compute keeps the contract simple whenever the
+        // graphs diverge (e.g. a dep/workspace filter narrowed this
+        // branch's graph but not the prewarm's).
         //
         // The prewarm runs concurrently with fetch and so can't see the
         // not-yet-imported source-dep trees; when any globally-shared

--- a/vendor/aube/crates/aube/src/commands/install/materialize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/materialize.rs
@@ -22,6 +22,14 @@ pub(super) struct GvsPrewarmInputs {
     /// from the probe linker's built-in `<modulesDir>/.aube` fallback
     /// instead materialized a SECOND store next to the configured one.
     pub virtual_store_dir: std::path::PathBuf,
+    /// Host platform + `ignoredOptionalDependencies`, applied to the
+    /// prewarm's graph clone (GVS path only) via
+    /// [`aube_resolver::platform::filter_graph`] so it hashes and
+    /// materializes the SAME host-only graph the link phase will. See
+    /// the filter call in [`run_gvs_prewarm_materializer`] for why a
+    /// graph mismatch here splits a shared-store singleton.
+    pub supported_architectures: aube_resolver::SupportedArchitectures,
+    pub ignored_optional_dependencies: std::collections::BTreeSet<String>,
 }
 
 /// Initial capacity for the (canonical_key, PackageIndex) channel
@@ -115,6 +123,8 @@ pub(super) async fn run_gvs_prewarm_materializer(
         build_policy,
         use_global_virtual_store_override,
         virtual_store_dir,
+        supported_architectures,
+        ignored_optional_dependencies,
     } = inputs;
 
     let engine = node_version
@@ -147,6 +157,34 @@ pub(super) async fn run_gvs_prewarm_materializer(
         return run_aube_dir_materializer(probe, graph, cwd, link_concurrency, materialize_rx)
             .await;
     }
+
+    // Host-filter the prewarm's graph to exactly what the link phase
+    // hashes. The resolver widens the graph with every common platform's
+    // optional native deps so the committed lockfile is portable; the
+    // link phase then runs `filter_graph` to host-only before hashing.
+    // Prewarm ran with the WIDENED graph, so any package whose subtree
+    // contains a platform-specific optional (all of a native-touching
+    // tree — parcel, next, anything pulling lmdb/@swc/@parcel/watcher)
+    // recursively hashes differently here than at link, and the two
+    // phases materialize the SAME dep_path at two byte-identical global
+    // store dirs. The existence-gated link step then never rewires over
+    // the prewarm cohort, so one consumer resolves the prewarm copy and
+    // another the link copy of a would-be singleton — for parcel that is
+    // two `@parcel/core` instances, two module-scoped serializer
+    // registries, and a `DataCloneError` at worker-farm startup.
+    // filter_graph is the only transform between prewarm-spawn and link
+    // that changes a node's graph hash (the intervening lockfile-metadata
+    // mutations don't feed the hash), so applying it here makes the two
+    // phases agree and the reuse fast-path in the link phase re-engages.
+    let graph = {
+        let mut host_graph = (*graph).clone();
+        aube_resolver::platform::filter_graph(
+            &mut host_graph,
+            &supported_architectures,
+            &ignored_optional_dependencies,
+        );
+        std::sync::Arc::new(host_graph)
+    };
 
     // Hash compute walks every package BLAKE3-style. spawn_blocking
     // pushes it off the tokio worker so the canonical_to_contextualized

--- a/vendor/aube/crates/aube/src/commands/install/materialize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/materialize.rs
@@ -172,10 +172,17 @@ pub(super) async fn run_gvs_prewarm_materializer(
     // another the link copy of a would-be singleton — for parcel that is
     // two `@parcel/core` instances, two module-scoped serializer
     // registries, and a `DataCloneError` at worker-farm startup.
-    // filter_graph is the only transform between prewarm-spawn and link
-    // that changes a node's graph hash (the intervening lockfile-metadata
-    // mutations don't feed the hash), so applying it here makes the two
-    // phases agree and the reuse fast-path in the link phase re-engages.
+    // filter_graph is the hash-affecting transform between prewarm-spawn
+    // and link for a public-registry tree: the intervening lockfile-metadata
+    // mutations (pnpm-config checksums, `optional`/transitivePeerDeps
+    // stamping) don't feed the node hash. `apply_computed_integrities` also
+    // feeds it (integrity is folded into `full_pkg_id`), but only for a
+    // package that resolved WITHOUT integrity — a no-op for registry
+    // packages whose packument carries the SRI at resolve time (all of
+    // Parcel's tree). Integrity-less-at-resolve nodes are the git/tarball
+    // deps the prewarm already defers via `content_affected`. So filtering
+    // here makes the two phases agree on this path and the link phase's
+    // reuse fast-path re-engages.
     let graph = {
         let mut host_graph = (*graph).clone();
         aube_resolver::platform::filter_graph(

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -558,6 +558,33 @@ fn reachable_package_dep_paths(
     reachable
 }
 
+/// The `(supported architectures, ignoredOptionalDependencies)` pair for
+/// [`aube_resolver::platform::filter_graph`]. Shared by the GVS-prewarm
+/// materializer and the pre-link host-filter (below) so both trim the
+/// widened, cross-platform resolve graph to the SAME host-installable set.
+/// A mismatch would have the two phases hash one dep_path's subtree
+/// differently and split a shared-store singleton — see
+/// `run_gvs_prewarm_materializer`.
+fn prewarm_host_filter_inputs(
+    manifest: &aube_manifest::PackageJson,
+    ws_config: &aube_manifest::workspace::WorkspaceConfig,
+    settings_ctx: &aube_settings::ResolveCtx<'_>,
+) -> (
+    aube_resolver::SupportedArchitectures,
+    std::collections::BTreeSet<String>,
+) {
+    let (os, cpu, libc) =
+        settings::effective_supported_architectures(manifest, ws_config, settings_ctx);
+    let supported = aube_resolver::SupportedArchitectures {
+        os,
+        cpu,
+        libc,
+        ..Default::default()
+    };
+    let ignored = aube_manifest::effective_ignored_optional_dependencies(manifest, ws_config);
+    (supported, ignored)
+}
+
 pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     let mode = opts.mode;
     let cwd = resolve_project_cwd(&opts)?;
@@ -1263,6 +1290,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let lock_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
             let (lock_patches, lock_patch_hashes) =
                 crate::patches::load_patches_for_linker(&cwd, &graph.patched_dependencies)?;
+            let (lock_supported_architectures, lock_ignored_optional) =
+                prewarm_host_filter_inputs(&manifest, &ws_config_shared, &settings_ctx);
             let (lock_materialize_tx, lock_materialize_rx) = materialize_channel();
             let lock_prewarm_inputs = GvsPrewarmInputs {
                 graph: std::sync::Arc::new(graph.clone()),
@@ -1277,6 +1306,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 build_policy: lock_build_policy,
                 use_global_virtual_store_override: prewarm_gvs_override,
                 virtual_store_dir: aube_dir.clone(),
+                supported_architectures: lock_supported_architectures,
+                ignored_optional_dependencies: lock_ignored_optional,
             };
             let lock_materialize_handle =
                 spawn_gvs_prewarm(lock_prewarm_inputs, lock_materialize_rx);
@@ -2152,6 +2183,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let materialize_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
             let (materialize_patches, materialize_patch_hashes) =
                 crate::patches::load_patches_for_linker(&cwd, &graph.patched_dependencies)?;
+            let (prewarm_supported_architectures, prewarm_ignored_optional) =
+                prewarm_host_filter_inputs(&manifest, &ws_config_shared, &settings_ctx);
             let materialize_inputs = GvsPrewarmInputs {
                 graph: materialize_graph_arc.clone(),
                 store: store.clone(),
@@ -2165,6 +2198,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 build_policy: build_policy_for_prewarm.clone(),
                 use_global_virtual_store_override: prewarm_gvs_override,
                 virtual_store_dir: aube_dir.clone(),
+                supported_architectures: prewarm_supported_architectures,
+                ignored_optional_dependencies: prewarm_ignored_optional,
             };
             aube_util::diag::instant(
                 aube_util::diag::Category::Install,
@@ -2373,21 +2408,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // filter pass the lockfile-happy branch above runs against a
             // parsed lockfile. A no-op when the manifest didn't trigger
             // widening (graph was already host-only).
-            let (sup_os, sup_cpu, sup_libc) = settings::effective_supported_architectures(
-                &manifest,
-                &ws_config_shared,
-                &settings_ctx,
-            );
-            let install_supported_architectures = aube_resolver::SupportedArchitectures {
-                os: sup_os,
-                cpu: sup_cpu,
-                libc: sup_libc,
-                ..Default::default()
-            };
-            let install_ignored_optional = aube_manifest::effective_ignored_optional_dependencies(
-                &manifest,
-                &ws_config_shared,
-            );
+            // Same host-filter inputs the GVS prewarm applied to its graph
+            // clone, so the prewarm and link phases hash and materialize the
+            // identical host-only graph (`prewarm_host_filter_inputs`).
+            let (install_supported_architectures, install_ignored_optional) =
+                prewarm_host_filter_inputs(&manifest, &ws_config_shared, &settings_ctx);
             aube_resolver::platform::filter_graph(
                 &mut graph,
                 &install_supported_architectures,


### PR DESCRIPTION
## Root cause

Parcel failed under the global virtual store with `DataCloneError` at worker-farm startup: `@parcel/core` was materialized at two byte-identical store dirs, so `parcel` and `@parcel/workers` loaded different `@parcel/core` instances → two serializer registries → structured-clone failure across the worker boundary.

The resolver widens its graph with every platform's optional native deps for a portable lockfile; the link phase runs `filter_graph` to host-only before hashing. The GVS prewarm materializer hashed the **widened** graph instead. Any package whose subtree carries a platform-specific optional native dep (Parcel's whole tree: `@parcel/watcher-*`, `@swc/core-*`, `lmdb`, `msgpackr`) then hashed differently in the two phases, so the same `dep_path` landed at two store dirs; the existence-gated link step never rewired over the prewarm cohort. Reproduced on a pristine store: 206 dirs vs 158 distinct (48 dups = Parcel's native subtree).

## Fix

Host-filter the prewarm graph to match the link phase. `filter_graph` is the only transform between prewarm-spawn and link that changes a node's graph hash (the intervening mutations touch only lockfile metadata the hash ignores), so both phases now hash the identical host-only graph and every `dep_path` resolves to one store dir. `prewarm_host_filter_inputs` shares the filter inputs across both prewarm sites and the pre-link filter so they can't drift. The filter sits after the non-GVS early return, so aube's default non-GVS path is unchanged.

`parcel` is dropped from `disableGlobalVirtualStoreForPackages`.

## Verification

- One `@parcel/core` dir + `parcel build` exit 0 across 2.9.3, 2.10.3, 2.11.0, 2.12.0, 2.13.3, 2.16.4.
- Hermetic test `gvs_prewarm_and_link_agree_only_after_host_filtering_the_widened_graph` pins the graph-hash agreement.
- E2E harness under `tests/parcel-gvs/`.
- `next` hit the same over-split and is also fixed, but its Turbopack chroot break is independent, so it stays blocklisted pending separate verification.

## Fork discipline

Default-preserving on aube's non-GVS default; corrects the GVS path (a latent aube bug). Changes shared-store dir names for affected installs — a one-time re-materialization; old dirs are orphaned, not corrupted.
