### PR TITLE
fix(runtime): async-tier registration when composing with a foreign loader on Node 22.15–24.11.0

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3518,6 +3518,14 @@ fn build_script_command(
     // `node` was resolved above (its path fed npm_node_execpath).
     let nub_binary = nub_core::node::spawn::current_nub_binary()?;
     let pnp_ctx = nub_core::pnp::detect(&project.root);
+    // Force-async-tier decision, captured before `node.version` is moved into
+    // compute_augmentation_env below: the common `nub run dev` = `tsx …` case
+    // crashes with ERR_METHOD_NOT_IMPLEMENTED on a broken-compose Node.
+    let force_async_tier = nub_core::node::spawn::force_async_tier_env(
+        &node.version,
+        cmd.split_whitespace()
+            .chain(args.iter().map(String::as_str)),
+    );
     let aug = nub_core::node::spawn::compute_augmentation_env(
         &nub_binary,
         node.version,
@@ -3609,6 +3617,16 @@ fn build_script_command(
         aug.apply_localstorage_env(|k, v| {
             command.env(k, v);
         });
+    }
+
+    // Force nub's async tier for a script that runs a foreign async loader
+    // (tsx/ts-node) on a broken-compose Node — the common `nub run dev` = `tsx …`
+    // case that otherwise crashes with ERR_METHOD_NOT_IMPLEMENTED. Only when we
+    // establish augmentation (`aug` is Some); a re-entrant child inherits the var.
+    if aug.is_some()
+        && let Some((k, val)) = force_async_tier
+    {
+        command.env(k, val);
     }
 
     // `npm_config_node_gyp`: npm/pnpm always point this at a runnable node-gyp
@@ -4770,6 +4788,18 @@ fn apply_exec_augmentation(cmd: &mut std::process::Command, cwd: &Path) {
     };
     let node = nub_core::node::discovery::discover_node(cwd)
         .unwrap_or_else(|_| nub_core::node::discovery::ResolvedNode::fallback());
+    // Force-async-tier decision for a foreign async loader (`nubx tsx …`) on a
+    // broken-compose Node — captured now, before `node.version` is moved into
+    // compute_augmentation_env below and before `cmd` is mutated (the returned
+    // pair is 'static, so it outlives both). Applied only once aug is confirmed.
+    let exec_tokens: Vec<String> = std::iter::once(cmd.get_program())
+        .chain(cmd.get_args())
+        .map(|s| s.to_string_lossy().into_owned())
+        .collect();
+    let force_async_tier = nub_core::node::spawn::force_async_tier_env(
+        &node.version,
+        exec_tokens.iter().map(String::as_str),
+    );
     // Exec-path parity with `nub run`/lifecycle: a launched non-node bin (a
     // create-* scaffolder, a tool that shells out) must see the same role-aware
     // `npm_config_user_agent` so it detects nub as the invoking PM instead of a
@@ -4801,6 +4831,9 @@ fn apply_exec_augmentation(cmd: &mut std::process::Command, cwd: &Path) {
     aug.apply_localstorage_env(|k, v| {
         cmd.env(k, v);
     });
+    if let Some((k, val)) = force_async_tier {
+        cmd.env(k, val);
+    }
     if let Some(node_options) = aug.node_options {
         cmd.env("NODE_OPTIONS", node_options);
     }

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -379,3 +379,77 @@ fn compat_tier_rejects_require_of_esm_ts_with_clean_error() {
         "the pre-check must fire BEFORE Node's special-require crashes: stderr={stderr:?}"
     );
 }
+
+/// Run `nub run <script>` in a fixture dir with PATH pinned to the requested
+/// Node (same discovery + skip-if-absent contract as `run_nub_against_node`).
+fn run_nub_script(
+    want: (u32, u32, u32),
+    fixture: &str,
+    script: &str,
+) -> Option<(String, String, i32)> {
+    let bin_dir = find_node_bin_dir(want)?;
+    let fixture_path = fixtures_dir().join(fixture);
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![bin_dir];
+    paths.extend(std::env::split_paths(&existing));
+    let new_path = std::env::join_paths(paths).expect("join PATH");
+
+    let output = Command::new(nub_binary())
+        .arg("run")
+        .arg(script)
+        .current_dir(&fixture_path)
+        .env("PATH", new_path)
+        .output()
+        .expect("failed to spawn nub run");
+    Some((
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    ))
+}
+
+/// The resolveSync hook-composition fix (nodejs/node#59666). On the broken band
+/// (22.15.0–24.11.0) nub's sync `module.registerHooks` fast tier crashes with
+/// ERR_METHOD_NOT_IMPLEMENTED when it composes with a foreign async loader
+/// (tsx/ts-node), because the async loader's `resolveSync` is a throwing stub
+/// there. nub avoids it by registering its own hooks via the async tier for that
+/// process, signalled by `__NUB_FORCE_ASYNC_TIER`. The tier CHOICE is the
+/// contract, so this asserts the signal directly (a hermetic proxy for the crash,
+/// which needs a real tsx to reproduce — see the PR for the manual tsx validation).
+#[test]
+fn force_async_tier_signal_gated_on_broken_band_and_foreign_loader() {
+    // Broken band (22.16.0): a script carrying `--import` (a foreign async loader)
+    // forces the async tier; the signal propagates to the child that prints it.
+    if let Some((out, err, code)) = run_nub_script((22, 16, 0), "force-async-tier", "loader") {
+        assert_eq!(code, 0, "loader script must run: stderr={err}");
+        assert!(
+            out.contains("FORCE=1"),
+            "a loader-hosting script on the broken band must force the async tier: {out:?}"
+        );
+        // Broken band + a PLAIN script keeps the sync fast tier (no common-case
+        // degradation) — the whole point of gating on foreign-loader presence.
+        let (plain, _e, c) = run_nub_script((22, 16, 0), "force-async-tier", "plain").unwrap();
+        assert_eq!(c, 0);
+        assert!(
+            plain.contains("FORCE=unset"),
+            "a plain script must keep the sync fast tier on the broken band: {plain:?}"
+        );
+    } else {
+        eprintln!("skipping: Node 22.16.0 not installed (broken-band representative)");
+    }
+
+    // Fixed Node (26.2.0): even a loader-hosting script keeps the fast tier —
+    // Node implemented the sync methods, so there is nothing to work around.
+    if let Some((out, err, code)) = run_nub_script((26, 2, 0), "force-async-tier", "loader") {
+        assert_eq!(
+            code, 0,
+            "loader script must run on fixed Node: stderr={err}"
+        );
+        assert!(
+            out.contains("FORCE=unset"),
+            "a fixed Node must NOT force the async tier (fast tier is safe there): {out:?}"
+        );
+    } else {
+        eprintln!("skipping: Node 26.2.0 not installed (fixed-band representative)");
+    }
+}

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -545,6 +545,17 @@ pub fn spawn_node(config: &SpawnConfig<'_>) -> Result<SpawnResult> {
         // and re-entrant child shells skip it for free.
         cmd.env(VERSION_ENV, env!("CARGO_PKG_VERSION"));
 
+        // Force the async loader-worker tier when this child hosts a foreign async
+        // loader (tsx/ts-node/--import) on a Node whose sync/async hook composition
+        // is broken — the sync fast tier would otherwise crash with
+        // ERR_METHOD_NOT_IMPLEMENTED (see force_async_tier_env / node_hook_compose_broken).
+        if let Some((k, val)) = force_async_tier_env(
+            &config.node.version,
+            config.user_args.iter().map(String::as_str),
+        ) {
+            cmd.env(k, val);
+        }
+
         // Value-bearing preload/PnP `--require`/`--import` flags are NOT passed via
         // argv here — ONLY via NODE_OPTIONS (assembled below). The direct child
         // inherits that NODE_OPTIONS, so it is still fully augmented; keeping the
@@ -1275,6 +1286,68 @@ pub(crate) const NEUTRALIZE_LOCALSTORAGE_ENV: &str = "__NUB_NEUTRALIZE_LOCALSTOR
 /// the same preload via NODE_OPTIONS) and they advertise the marker too.
 pub(crate) const VERSION_ENV: &str = "__NUB_VERSION";
 
+/// Tells nub's fast-tier preload to register its module hooks via the ASYNC
+/// loader-worker path (`module.register`) instead of the sync
+/// `module.registerHooks`, even on a Node that supports the sync fast tier. Set
+/// only when nub is about to host a FOREIGN async `module.register` loader
+/// (tsx/ts-node) on a Node whose sync/async hook composition is broken
+/// ([`node_hook_compose_broken`]). Inherited by the whole augmented subtree
+/// (like [`VERSION_ENV`]) so every child in a tsx run composes async. An internal
+/// `__NUB_*` plumbing var, NOT a user knob — explicitly permitted by the brand
+/// boundary.
+pub(crate) const FORCE_ASYNC_TIER_ENV: &str = "__NUB_FORCE_ASYNC_TIER";
+
+/// Node versions where the async `module.register` loader's `resolveSync`/
+/// `loadSync` are unimplemented stubs that throw `ERR_METHOD_NOT_IMPLEMENTED`.
+/// nub's sync `module.registerHooks` fast tier forces resolution synchronous, so
+/// composing it with a foreign async loader (tsx/ts-node) reaches that throwing
+/// stub and crashes the run. Node implemented these methods in 24.11.1
+/// (block-on-loader-worker), so the broken window is 22.15.0 ..= 24.11.0
+/// inclusive; 24.11.1+/25.2+/26 are fine. Refs nodejs/node#59666. (A later 22.x
+/// that backported the fix would be over-covered here — harmless, since the
+/// async tier composes correctly on every version.)
+pub(crate) fn node_hook_compose_broken(v: &super::version::NodeVersion) -> bool {
+    use super::version::NodeVersion;
+    *v >= NodeVersion::new(22, 15, 0) && *v <= NodeVersion::new(24, 11, 0)
+}
+
+/// Whether the child nub is about to launch hosts a FOREIGN async ESM loader — a
+/// tsx/ts-node executable, or an explicit `--import`/`--loader`/
+/// `--experimental-loader` that registers one. Scans ALL tokens (not just
+/// argv[0]) so an env-prefixed/compound script (`NODE_ENV=prod tsx x`) is still
+/// caught; a rare false positive (a literal `echo tsx`) only makes that one
+/// process use nub's async tier, which is always correct — never a crash.
+pub(crate) fn child_hosts_async_loader<'a>(tokens: impl IntoIterator<Item = &'a str>) -> bool {
+    tokens.into_iter().any(|tok| {
+        let flag = tok.split_once('=').map_or(tok, |(f, _)| f);
+        if matches!(flag, "--import" | "--loader" | "--experimental-loader") {
+            return true;
+        }
+        let base = tok.rsplit(['/', '\\']).next().unwrap_or(tok);
+        // Strip the Windows launcher-shim suffixes npm generates (`tsx.cmd`,
+        // `tsx.ps1`, a native `.exe`) so the basename compares as the tool name.
+        let base = base
+            .strip_suffix(".cmd")
+            .or_else(|| base.strip_suffix(".exe"))
+            .or_else(|| base.strip_suffix(".ps1"))
+            .unwrap_or(base);
+        matches!(base, "tsx" | "ts-node" | "ts-node-esm")
+    })
+}
+
+/// The `(key, "1")` env pair that forces nub's async tier for a child that will
+/// host a foreign async loader on a broken-compose Node — or `None` when the
+/// fast tier is safe. Callers set it on the child only when nub is establishing
+/// augmentation (not compat/`--node`, not re-entrant); a re-entrant descendant
+/// inherits the already-set var through the environment.
+pub fn force_async_tier_env<'a>(
+    node_version: &super::version::NodeVersion,
+    child_tokens: impl IntoIterator<Item = &'a str>,
+) -> Option<(&'static str, &'static str)> {
+    (node_hook_compose_broken(node_version) && child_hosts_async_loader(child_tokens))
+        .then_some((FORCE_ASYNC_TIER_ENV, "1"))
+}
+
 /// Whether Node's test-runner coverage is active for this invocation — i.e. the
 /// user passed `--experimental-test-coverage` directly in argv or via NODE_OPTIONS.
 /// (`nub` has no separate coverage verb; coverage is engaged solely by that flag,
@@ -1937,6 +2010,71 @@ mod tests {
             &[s("--no-experimental-webstorage")],
             None
         ));
+    }
+
+    #[test]
+    fn hook_compose_broken_band_is_22_15_through_24_11_0_inclusive() {
+        // Broken (async-loader resolveSync stub throws): the whole 22.15.0–24.11.0 window.
+        for v in [
+            NodeVersion::new(22, 15, 0),
+            NodeVersion::new(22, 16, 0),
+            NodeVersion::new(23, 11, 0),
+            NodeVersion::new(24, 11, 0),
+        ] {
+            assert!(
+                node_hook_compose_broken(&v),
+                "{v:?} must be in the broken band"
+            );
+        }
+        // Fixed at 24.11.1 (Node implemented resolveSync/loadSync), and below the
+        // fast-tier floor there is no sync registerHooks to force the crash.
+        for v in [
+            NodeVersion::new(22, 14, 99),
+            NodeVersion::new(24, 11, 1),
+            NodeVersion::new(24, 12, 0),
+            NodeVersion::new(25, 2, 0),
+            NodeVersion::new(26, 2, 0),
+        ] {
+            assert!(
+                !node_hook_compose_broken(&v),
+                "{v:?} must be outside the broken band"
+            );
+        }
+    }
+
+    #[test]
+    fn child_hosts_async_loader_detects_tsx_ts_node_and_loader_flags() {
+        let t = |toks: &[&str]| child_hosts_async_loader(toks.iter().copied());
+        // Bare + path-prefixed + platform-suffixed tsx/ts-node launchers.
+        assert!(t(&["tsx", "--conditions", "@zod/source"]));
+        assert!(t(&["node_modules/.bin/tsx", "x.ts"]));
+        assert!(t(&["ts-node", "x.ts"]));
+        assert!(t(&["C:\\proj\\node_modules\\.bin\\tsx.cmd", "x.ts"]));
+        assert!(t(&["C:\\proj\\node_modules\\.bin\\tsx.ps1", "x.ts"]));
+        // Loader flags in either form register an async loader.
+        assert!(t(&["node", "--import", "tsx/esm", "app.mjs"]));
+        assert!(t(&["node", "--loader=ts-node/esm", "app.mjs"]));
+        assert!(t(&["node", "--experimental-loader", "x.mjs"]));
+        // No foreign loader → fast tier stays. A stray `tsx` SUBSTRING must not match.
+        assert!(!t(&["webpack", "--mode", "production"]));
+        assert!(!t(&["node", "server.js"]));
+        assert!(!t(&["mytsx", "x"]));
+        assert!(!t(&["tsx.ts"]));
+    }
+
+    #[test]
+    fn force_async_tier_env_gated_on_band_and_loader() {
+        let broken = NodeVersion::new(22, 16, 0);
+        let fixed = NodeVersion::new(24, 12, 0);
+        // Broken band + foreign loader → the signal.
+        assert_eq!(
+            force_async_tier_env(&broken, ["tsx", "x.ts"]),
+            Some((FORCE_ASYNC_TIER_ENV, "1"))
+        );
+        // Broken band, no foreign loader → fast tier (None).
+        assert_eq!(force_async_tier_env(&broken, ["node", "x.js"]), None);
+        // Foreign loader but a fixed Node → no need to force (None).
+        assert_eq!(force_async_tier_env(&fixed, ["tsx", "x.ts"]), None);
     }
 
     // `ctrl_c::CURRENT_CHILD` is a process-global AtomicU32. The two tests that

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -93,7 +93,19 @@ try {
 
 const { installSyncPolyfills } = __require("./polyfills.cjs");
 
-if (!requireEsmDisabled) {
+// Force the async loader-worker tier when nub's launcher detected this process
+// will host a FOREIGN async `module.register` loader (tsx/ts-node) on a Node
+// whose sync/async hook composition is broken (22.15.0–24.11.0, fixed in
+// Node 24.11.1; nodejs/node#59666). There, nub's sync `module.registerHooks`
+// forces resolution synchronous and reaches the foreign loader's unimplemented
+// `resolveSync` stub → ERR_METHOD_NOT_IMPLEMENTED. Registering nub's hooks via
+// the async path instead keeps BOTH loaders async, so Node's all-async resolve
+// composes cleanly. The signal (__NUB_FORCE_ASYNC_TIER) is set by the Rust
+// spawn path only for the specific loader-hosting process; every other run on
+// this Node keeps the sync fast tier. See crates/nub-core/src/node/spawn.rs.
+const forceAsyncTier = !!process.env.__NUB_FORCE_ASYNC_TIER;
+
+if (!requireEsmDisabled && !forceAsyncTier) {
   // ── Fast tier (sync require(esm) available) ───────────────────────
 
   // ── Watch-mode dependency reporting + hooks ───────────────────────
@@ -150,10 +162,12 @@ if (!requireEsmDisabled) {
   // ── Compile-cache: re-enable for the USER's modules (R8) ──────────
   common.reenableUserCompileCache();
 } else {
-  // ── Fallback tier (`--no-experimental-require-module`): async hooks ─
-  // The user disabled require(esm), so the in-thread sync `module.registerHooks`
-  // core can't be loaded here. Register the SAME hooks the compat tier uses, run
-  // in a dedicated loader worker via `module.register`; that worker imports
+  // ── Async loader-worker tier ──────────────────────────────────────
+  // Entered when EITHER require(esm) is disabled (`--no-experimental-require-module`,
+  // so the in-thread sync core can't load) OR `forceAsyncTier` is set (nub composes
+  // with a foreign async loader on a broken-compose Node — see above). Register the
+  // SAME hooks the compat tier uses, run in a dedicated loader worker via
+  // `module.register`; that worker imports
   // transform-core.mjs as a static ESM import (not gated by the flag). The
   // main-thread CJS require() transpile shim, which would need the core
   // synchronously in-thread, is unavailable in this mode — an honest, additive

--- a/tests/fixtures/force-async-tier/package.json
+++ b/tests/fixtures/force-async-tier/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "force-async-tier-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "loader": "node --import ./loader.mjs -e \"console.log('FORCE=' + (process.env.__NUB_FORCE_ASYNC_TIER || 'unset'))\"",
+    "plain": "node -e \"console.log('FORCE=' + (process.env.__NUB_FORCE_ASYNC_TIER || 'unset'))\""
+  }
+}


### PR DESCRIPTION
Fixes a crash: `nub run <tsx-script>` on Node 22.15.0–24.11.0 throws `ERR_METHOD_NOT_IMPLEMENTED: resolveSync`. nub's sync `module.registerHooks` forces synchronous resolution; a foreign async loader (tsx/ts-node) is then reached via its `resolveSync` stub, unimplemented on that Node band (fixed in Node 24.11.1; nodejs/node#59666).

Fix: on that band, when the child hosts a foreign async loader (`tsx`/`ts-node` basename, or `--import`/`--loader`), the launcher signals the preload to register hooks via the async loader-worker tier instead of sync `registerHooks`. Per-process — other runs keep the fast tier.

Verified: real tsx on 22.16 runs; unit + e2e tests; clippy/fmt/version_tiers pass. Full detail in the commit body.