### PR TITLE
feat(pm): make Vite symlink-GVS compat unconditional; drop NUB_VITE_COMPAT opt-out

### DIFF
--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1101,8 +1101,8 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     // Vite symlink-GVS serving compat (#315): after a successful install, write
     // `node_modules/.modules.yaml` and (for Vite < 8.1) patch the ejected vite
     // dist so its dev server serves the machine-global store. Gated internally on
-    // vite-in-graph + the `NUB_VITE_COMPAT` opt-out; best-effort, never fails the
-    // install.
+    // vite-in-graph only (unconditional — no user opt-out); best-effort, never
+    // fails the install.
     apply_vite_compat(&session, code);
     // Virgin install only: stamp a caret RANGE into `devEngines.packageManager`
     // so the project advertises nub the standard, cross-tool way WITHOUT locking

--- a/crates/nub-cli/src/pm_engine/vite_compat.rs
+++ b/crates/nub-cli/src/pm_engine/vite_compat.rs
@@ -29,32 +29,44 @@
 //!   `virtualStoreDir` any PM wrote — nub's store path lives ONLY in the
 //!   `.modules.yaml` data file, never hardcoded into the patch.
 //!
-//! Both units are gated on `vite` being in the installed graph and on the
-//! `NUB_VITE_COMPAT` opt-out (a falsey value disables both). The materialization
-//! decision lives in [`super::mod`]'s setting defaults; this module writes the
-//! file and patches the ejected copy post-install. Fail-open throughout: a
-//! missing anchor / unwritable copy is a no-op, never a corrupt Vite.
+//! Both units are gated ONLY on `vite` being in the installed graph (and the
+//! machine-global store locality) — there is NO user opt-out: this is core GVS
+//! correctness, so it is unconditional (maintainer 2026-07-07). The
+//! materialization decision lives in [`super::mod`]'s setting defaults; this
+//! module writes the file and patches the ejected copy post-install. Fail-open
+//! throughout: a missing anchor / unwritable copy is a no-op, never a corrupt
+//! Vite.
 
 use std::path::{Path, PathBuf};
 
-/// User-facing opt-out. Default-on (nub's goal is Vite just-working under the
-/// global store); a falsey value disables BOTH units. `NUB_*` is a sanctioned PM
-/// knob. Read at the setting-defaults site (materialize decision) and here (the
-/// post-install writer/patcher) so the two stay in lockstep.
-pub(crate) const VITE_COMPAT_ENV: &str = "NUB_VITE_COMPAT";
+/// INTERNAL, UNDOCUMENTED test seam — NOT a user knob. Truthy turns Vite compat
+/// OFF so the `tests/vite-compat/` matrix can reproduce the pre-fix `403 …
+/// outside of Vite serving allow list` break as an A/B control against a real
+/// built binary (those driver runs use `target/fast/nub`, not a `cfg(test)`
+/// build). The `__NUB_` double-underscore prefix marks internal plumbing — the
+/// brand boundary exempts internal `__NUB_*` sentinels; this one is never
+/// documented and users must not rely on it. Mirrors phantom-eject's
+/// `__NUB_PHANTOM_EJECT_DISABLE`; the removed public `NUB_VITE_COMPAT` knob is
+/// dead and ignored, so a stale `NUB_VITE_COMPAT=0` in a user's env has no effect.
+const INTERNAL_COMPAT_DISABLE_VAR: &str = "__NUB_VITE_COMPAT_DISABLE";
 
-/// Whether the Vite compat behavior is enabled. Disabled only by an explicit
-/// falsey `NUB_VITE_COMPAT` (`0`/`false`/`no`/`off`, case-insensitive); unset or
-/// any other value keeps it on. Same spelling as nub's other positive-default
-/// knobs (`NUB_SELF_SHIM`).
+/// Whether the Vite compat behavior is enabled. Unconditionally ON for users —
+/// this is core GVS correctness, not a preference (maintainer 2026-07-07). Off
+/// ONLY under the internal A/B seam ([`INTERNAL_COMPAT_DISABLE_VAR`]). Read at
+/// the setting-defaults site (materialize decision) and here (the post-install
+/// writer/patcher) so the two stay in lockstep.
 pub(crate) fn enabled() -> bool {
-    match std::env::var(VITE_COMPAT_ENV) {
-        Ok(v) => !matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "0" | "false" | "no" | "off"
-        ),
-        Err(_) => true,
-    }
+    !compat_disabled(std::env::var(INTERNAL_COMPAT_DISABLE_VAR).ok().as_deref())
+}
+
+/// Pure predicate for the internal disable seam, split from the env read so its
+/// truthiness contract is testable without mutating the process-global env. A
+/// truthy value disables; unset / empty / any other value keeps compat ON.
+fn compat_disabled(raw: Option<&str>) -> bool {
+    matches!(
+        raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
 }
 
 /// Post-install entry: write `.modules.yaml` for every install that has Vite
@@ -406,23 +418,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn opt_out_only_on_explicit_falsey() {
-        // Default-on when unset; the test mutates process env, so it is the sole
-        // reader in-process (serialized by cargo per-test-binary is not enough —
-        // keep the assertions in one test to avoid cross-test env races).
-        let key = VITE_COMPAT_ENV;
-        // SAFETY: single-threaded test body; restored at the end.
-        unsafe { std::env::remove_var(key) };
-        assert!(enabled(), "unset ⇒ on");
-        for falsey in ["0", "false", "FALSE", "no", "Off", " off "] {
-            unsafe { std::env::set_var(key, falsey) };
-            assert!(!enabled(), "{falsey:?} ⇒ off");
+    fn compat_is_unconditional_except_internal_seam() {
+        // Pure predicate — no process-env mutation. Unset/empty/any non-truthy
+        // value keeps compat ON; only an explicit truthy internal seam disables.
+        assert!(!compat_disabled(None), "unset ⇒ on");
+        assert!(!compat_disabled(Some("")), "empty ⇒ on");
+        assert!(!compat_disabled(Some("0")), "0 ⇒ on (not a disable value)");
+        for truthy in ["1", "true", "TRUE", "yes", "on", " On "] {
+            assert!(compat_disabled(Some(truthy)), "{truthy:?} ⇒ off");
         }
-        for truthy in ["1", "true", "yes", "anything"] {
-            unsafe { std::env::set_var(key, truthy) };
-            assert!(enabled(), "{truthy:?} ⇒ on");
-        }
-        unsafe { std::env::remove_var(key) };
     }
 
     #[test]

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -177,7 +177,7 @@ A project is Nub's own in three cases: it declares Nub through `nub pm use nub`,
 
 - **Lockfile:** `nub.lock` — the pnpm v9 schema byte-for-byte, under Nub's own basename
 - **Package fields:** `workspaces`, `overrides`, `resolutions`, `patchedDependencies`, `allowBuilds`, `engines.node`, `scripts`
-- **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`, `NUB_VITE_COMPAT`
+- **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`
 - **Install state:** `node_modules/.nub/`, `.nub-state`, and the global store under Nub's own directories
 
 A fresh `nub install` records Nub as the manager with a non-locking range — `devEngines.packageManager` set to `{ name: "nub", version: "^<version>", onFail: "warn" }`, never an exact `packageManager` pin. Tools that read `devEngines` by name see the signal, and the caret is a floor, so upgrading Nub just works. To freeze the project at an exact Nub version — the corepack-visible hard pin — opt in with `nub pm use nub@<version>`; the bare `nub pm use nub` writes only the range.
@@ -482,7 +482,7 @@ A bundler that resolves modules by their real path — Metro (bare React Native)
 disableGlobalVirtualStoreForPackages[]=my-bundler
 ```
 
-Vite is the exception that keeps the shared store. Its dev server gates real-path file access through a configurable allow-list, not a resolver crawl, so a store-resident module served over `/@fs` would otherwise be rejected with `403 … outside of Vite serving allow list`. Nub tells Vite about the store automatically: it writes `node_modules/.modules.yaml`, which Vite 8.1+ reads natively, and for older Vite it backports the same check into the project's own copy. `vite dev` then serves the store with no `vite.config` change, and the fix lives on disk in `node_modules` — so it works whether or not Nub is in the process (a teammate on plain Vite, or CI). Turn it off with `NUB_VITE_COMPAT=0`.
+Vite is the exception that keeps the shared store. Its dev server gates real-path file access through a configurable allow-list, not a resolver crawl, so a store-resident module served over `/@fs` would otherwise be rejected with `403 … outside of Vite serving allow list`. Nub tells Vite about the store automatically: it writes `node_modules/.modules.yaml`, which Vite 8.1+ reads natively, and for older Vite it backports the same check into the project's own copy. `vite dev` then serves the store with no `vite.config` change, and the fix lives on disk in `node_modules` — so it works whether or not Nub is in the process (a teammate on plain Vite, or CI).
 
 ### Offline installs
 

--- a/tests/vite-compat/README.md
+++ b/tests/vite-compat/README.md
@@ -8,8 +8,10 @@ runs correctly when its dev server is invoked with no nub in the process).
 
 ## The fix under test
 
-Two units, both in `crates/nub-cli/src/pm_engine/vite_compat.rs`, default-on
-(opt out with `NUB_VITE_COMPAT=0`), gated on `vite` being in the graph:
+Two units, both in `crates/nub-cli/src/pm_engine/vite_compat.rs`, unconditional
+(core GVS correctness, no user opt-out), gated on `vite` being in the graph. The
+pre-fix `403` break is reproducible against a built binary via the internal test
+seam `__NUB_VITE_COMPAT_DISABLE=1` — an undocumented A/B control, not a user knob:
 
 - **Unit A — `node_modules/.modules.yaml`** (all Vite versions). nub writes JSON
   `{"virtualStoreDir":"<abs store>"}`. Vite ≥ 8.1 reads it natively and allows


### PR DESCRIPTION
Removes the public `NUB_VITE_COMPAT` opt-out. The Vite symlink-GVS shim (`.modules.yaml` + a dist backport for Vite <8.1) is core correctness for the global virtual store, so it is now unconditional — gated only on `vite` being in the graph plus the machine-global store locality.

Mirrors #335: drops the public knob, keeps an internal undocumented `__NUB_VITE_COMPAT_DISABLE` test seam for the `tests/vite-compat/` A/B baseline.

Verified: clippy + fmt clean; 8 unit tests pass; e2e fires with no env var, skips non-vite projects, ignores a stale `NUB_VITE_COMPAT=0`.

https://claude.ai/code/session_01UVBNLm9SkJGM8P8K6jnKLJ