### PR TITLE
site: per-heading OG cards for shared docs sections

### DIFF
--- a/site/mdx-components.tsx
+++ b/site/mdx-components.tsx
@@ -9,6 +9,7 @@ import { PmSupport } from '@/components/pm-support-table';
 import { InstallTabs } from '@/components/install-tabs';
 import { TypesSetup } from '@/components/types-setup';
 import { Yes, No, ColGlow } from '@/components/runner-table';
+import { SectionHeading } from '@/components/section-heading';
 
 // Neutral info glyph (lucide "info" path) drawn with currentColor so it inherits a
 // muted tone — no loud accent. Inline SVG keeps us off a runtime icon dependency,
@@ -63,6 +64,14 @@ function Callout({
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    // Override the heading anchors so a copied section link carries a
+    // server-visible `?section=<slug>` param (drives per-heading OG cards).
+    h1: (props: ComponentProps<'h1'>) => <SectionHeading as="h1" {...props} />,
+    h2: (props: ComponentProps<'h2'>) => <SectionHeading as="h2" {...props} />,
+    h3: (props: ComponentProps<'h3'>) => <SectionHeading as="h3" {...props} />,
+    h4: (props: ComponentProps<'h4'>) => <SectionHeading as="h4" {...props} />,
+    h5: (props: ComponentProps<'h5'>) => <SectionHeading as="h5" {...props} />,
+    h6: (props: ComponentProps<'h6'>) => <SectionHeading as="h6" {...props} />,
     Callout,
     Bench,
     ShimDemo,

--- a/site/src/app/docs/[[...slug]]/page.tsx
+++ b/site/src/app/docs/[[...slug]]/page.tsx
@@ -148,25 +148,63 @@ const EYEBROW_BY_URL: Record<string, string> = {
   '/docs/watch': 'nub watch',
 };
 
-/* Build the per-page social-card URL handled by `app/og/route.tsx`. The card
-   shows the eyebrow and title only — no description (it rarely fit). */
-function ogImageUrl({ url, title }: { url: string; title: string }): string {
-  const params = new URLSearchParams({
-    title,
-    eyebrow: EYEBROW_BY_URL[url] ?? 'Documentation',
-  });
+/* Build the social-card URL handled by `app/og/route.tsx`. The card shows the
+   eyebrow and title only — no description (it rarely fit). */
+function ogImageUrl({ title, eyebrow }: { title: string; eyebrow: string }): string {
+  const params = new URLSearchParams({ title, eyebrow });
   return `/og?${params.toString()}`;
+}
+
+/* Flatten a TOC entry's `title` (a ReactNode — plain text, or an element tree
+   when the heading contains inline code/formatting) to its visible text, so a
+   heading like `nub pm which` resolves to that string for the OG card. */
+function nodeToText(node: React.ReactNode): string {
+  if (node == null || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(nodeToText).join('');
+  if (typeof node === 'object' && 'props' in node) {
+    return nodeToText((node as { props?: { children?: React.ReactNode } }).props?.children);
+  }
+  return '';
+}
+
+/* Resolve a section slug to its heading text via the page TOC. Heading slugs are
+   unique per page, so a direct `#<slug>` match returns the right heading at any
+   depth (h2/h3/…) — the deepest/most-specific heading the reader shared. */
+function headingTextForSlug(
+  toc: { url: string; title: React.ReactNode }[],
+  slug: string,
+): string | undefined {
+  const item = toc.find((entry) => entry.url === `#${slug}`);
+  if (!item) return undefined;
+  const text = nodeToText(item.title).trim();
+  return text.length > 0 ? text : undefined;
 }
 
 export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>;
+  searchParams: Promise<{ section?: string | string[] }>;
 }): Promise<Metadata> {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
   const { title, description } = page.data;
-  const ogImage = ogImageUrl({ url: page.url, title });
+
+  // A shared section link (`?section=<slug>#<slug>`) recasts the card: the
+  // heading becomes the main title and the page title moves to the eyebrow.
+  // Absent (or unresolvable) `section` keeps the page-level card. Only the OG
+  // image varies on `section`; the page body/metadata are otherwise identical.
+  const searchParams = await props.searchParams;
+  const rawSection = searchParams.section;
+  const sectionSlug = typeof rawSection === 'string' ? rawSection : undefined;
+  const sectionTitle = sectionSlug
+    ? headingTextForSlug(page.data.toc, sectionSlug)
+    : undefined;
+
+  const ogImage = sectionTitle
+    ? ogImageUrl({ title: sectionTitle, eyebrow: title })
+    : ogImageUrl({ title, eyebrow: EYEBROW_BY_URL[page.url] ?? 'Documentation' });
 
   return {
     title,

--- a/site/src/components/section-heading.tsx
+++ b/site/src/components/section-heading.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { useCopyButton } from 'fumadocs-ui/utils/use-copy-button';
+import { buttonVariants } from 'fumadocs-ui/components/ui/button';
+
+/* Drop-in replacement for fumadocs-ui's MDX `Heading`. Identical markup and
+   affordance — a `data-card` anchor around the heading text plus a hover-reveal
+   copy button — with one change: the copy button yields a SECTION-shareable URL
+   carrying a `?section=<slug>` query param (kept alongside the `#<slug>`
+   fragment) instead of the bare `#<slug>` fragment fumadocs copies.
+
+   The query param is what makes a shared heading link render its own OG card:
+   a `#fragment` never reaches the server, so `generateMetadata` can't see it,
+   but `?section=` does — see `docs/[[...slug]]/page.tsx`. The visible text
+   anchor stays a plain `#<slug>` for pure in-page scroll; only the copy action
+   emits the section URL, so navigating the page never triggers the dynamic
+   metadata path. Icons are inline SVG per the site's no-icon-dependency
+   convention (matching GitHubIcon/InfoGlyph elsewhere). */
+
+function cn(...parts: (string | undefined | false)[]): string {
+  return parts.filter(Boolean).join(' ');
+}
+
+function LinkGlyph() {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-3.5"
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+function CheckGlyph() {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-3.5"
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
+type HeadingProps = ComponentPropsWithoutRef<'h1'> & {
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  children?: ReactNode;
+};
+
+export function SectionHeading({ as, children, className, ...props }: HeadingProps) {
+  const As = as ?? 'h1';
+
+  const [checked, onCopy] = useCopyButton(() => {
+    if (!props.id) return;
+    const { origin, pathname } = window.location;
+    const slug = encodeURIComponent(props.id);
+    return navigator.clipboard.writeText(
+      `${origin}${pathname}?section=${slug}#${props.id}`,
+    );
+  });
+
+  // Headings without an id (rare) get no anchor affordance — mirror fumadocs.
+  if (!props.id) {
+    return (
+      <As className={className} {...props}>
+        {children}
+      </As>
+    );
+  }
+
+  return (
+    <As
+      className={cn(
+        'group/heading flex scroll-m-28 flex-row items-center gap-1',
+        className,
+      )}
+      {...props}
+    >
+      <a data-card="" href={`#${props.id}`}>
+        {children}
+      </a>
+      <button
+        type="button"
+        aria-label="Copy link to section"
+        onClick={onCopy}
+        className={cn(
+          buttonVariants({ variant: 'ghost', size: 'icon-xs' }),
+          'not-prose shrink-0 text-fd-muted-foreground opacity-0 transition-opacity group-hover/heading:opacity-100',
+        )}
+      >
+        {checked ? <CheckGlyph /> : <LinkGlyph />}
+      </button>
+    </As>
+  );
+}


### PR DESCRIPTION
Share a specific docs heading and its social card now shows that heading as the main title with the page title as the eyebrow — instead of every section falling back to the page-level card.

## How it works

A `#fragment` never reaches the server, so it can't drive `generateMetadata`. A shared section link therefore carries a server-visible `?section=<slug>` query param alongside the `#<slug>` fragment (the fragment still handles in-page scroll):

```
/docs/pm?section=cli#cli
```

- The docs heading copy button (the hover-reveal link icon) now emits that `?section=…#…` URL, so pasting a copied heading link renders that heading's card.
- `generateMetadata` reads `section`, resolves the slug to its heading text via the page TOC (flattening inline code like `nub pm which` to plain text), and builds `/og?title=<heading>&eyebrow=<page title>`.
- No `section`, or an unresolvable one, keeps the existing page-level card unchanged.

The `/og` route already accepts arbitrary `title` + `eyebrow`, so it needed no change.

## Examples to eyeball

| Shared URL | Resulting OG image |
| --- | --- |
| `/docs/pm?section=cli#cli` | `/og?title=CLI&eyebrow=Package+meta-manager` |
| `/docs/pm?section=nub-pm-which#nub-pm-which` | `/og?title=nub+pm+which&eyebrow=Package+meta-manager` |
| `/docs/pm` (no section) | `/og?title=Package+meta-manager&eyebrow=nub+pm` (unchanged) |

## SSG tradeoff

Reading `searchParams` opts the docs route into dynamic rendering (`● SSG` → `ƒ Dynamic` in the build output). This is inherent to the feature: static generation ignores query params, but serving a section-correct `og:image` to a crawler requires the server to honor `?section=`. The page body and base metadata are otherwise untouched, the compiled MDX makes the per-request render cheap, and the canonical stays the query-less URL. Reclaiming a fully static shell would need PPR, deliberately left out of this focused change.

## Verification

Tested against the dev server via chrome-devtools: the section, inline-code-heading, no-section, and bogus-section cases all produce the expected `og:image`; the copy button emits the `?section=…#…` URL while the heading text anchor stays a plain `#slug` scroll; no console errors; `/og?title=CLI&eyebrow=Package+meta-manager` rasterizes with "CLI" as the title and "PACKAGE META-MANAGER" as the eyebrow. `npm run build` and `tsc --noEmit` pass.
