### PR TITLE
fix(install): install Nuxt project-local to resolve its optional-peer gap

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2160,9 +2160,26 @@ fn nub_setting_defaults(
             // The whole-install GVS-off last resort — reserved for a store-LOCALITY
             // break (a tool whose resolver can't reach the machine-global store),
             // NOT a phantom-dep class (those the dynamic detector + closure now
-            // eject per-package). `nuxt` was DROPPED: its walk-up is only 2 phantom
-            // edges (~2.3% closure), so it's closure-ejectable at rung 1 —
-            // symlink-GVS works (see [[nuxt-gvs-unlock]]). `parcel` was DROPPED: its
+            // eject per-package). `nuxt` is here because of an OPTIONAL-PEER gap the
+            // per-package closure eject cannot cover: Nuxt pulls `vue-router@5`,
+            // which declares `@vue/compiler-sfc` as an OPTIONAL PEER and unguardedly
+            // imports it from its `/vite` unplugin. pnpm threads that peer down the
+            // Nuxt subtree and links it as a sibling; nub's resolver does not thread
+            // it in this graph, so it stays unlinked. The phantom scanner correctly
+            // classifies an optional peer as NOT a hard phantom, so the rung-2 hoist
+            // never targets it — and under symlink-GVS there is no store-root
+            // public-hoist `node_modules` (it cannot live in a cross-project shared
+            // store), so `nuxt prepare` fails with `Cannot find package
+            // '@vue/compiler-sfc'`. Project-local install builds the
+            // `.nub/node_modules/` hidden hoist tree (pnpm-parity public-hoist) that
+            // Node's upward walk reaches → the optional peer resolves, `nuxt prepare`
+            // succeeds. The proper fix is resolver optional-peer-threading parity
+            // (its lockfile-churn blast radius makes it a separate, maintainer-owned
+            // effort); until then Nuxt installs project-local. (This re-adds `nuxt`,
+            // dropped in #321 on the earlier vue-router@4 true-undeclared analysis —
+            // the current tree resolves vue-router@5, an optional-peer edge the
+            // closure eject does not cover; see [[nuxt-phantom-hoist-fix]].)
+            // `parcel` was DROPPED: its
             // real break was never `.parcelrc` walk-up but a GVS store-dir over-split
             // — the prewarm hashed the widened (all-platform) graph while the link
             // phase hashed the host-filtered one, so parcel's native subtree
@@ -2180,7 +2197,7 @@ fn nub_setting_defaults(
             //   store is out of scope and even DECLARED deps (`@babel/runtime`)
             //   report unresolved. Expo's `@expo/metro-config` is store-aware
             //   (works either way; this only flips it project-local, harmless).
-            "next,react-native".to_string(),
+            "next,nuxt,react-native".to_string(),
         ),
         ("diskMaterializePackages".to_string(), disk_materialize),
     ];
@@ -2809,19 +2826,24 @@ mod tests {
     }
 
     #[test]
-    fn disable_gvs_default_drops_nuxt_and_parcel_and_keeps_the_store_locality_breakers() {
-        // The whole-install GVS-off list is now reserved for store-LOCALITY
-        // breaks. `nuxt` is closure-ejectable at rung 1 ([[nuxt-gvs-unlock]]) so
-        // it was dropped; `parcel` was dropped once its real break — a GVS
-        // store-dir over-split from the prewarm/link graph mismatch — was fixed at
-        // the source (see `run_gvs_prewarm_materializer`). `next` (Turbopack
-        // chroot) and `react-native` (bare-RN Metro realpath crawl) remain
-        // irreducible store-locality breaks.
+    fn disable_gvs_default_covers_nuxt_and_the_store_locality_breakers() {
+        // The whole-install GVS-off list carries the store-LOCALITY breaks plus
+        // `nuxt`. `parcel` was dropped once its real break — a GVS store-dir
+        // over-split from the prewarm/link graph mismatch — was fixed at the source
+        // (see `run_gvs_prewarm_materializer`). `nuxt` is here for an OPTIONAL-PEER
+        // gap the per-package closure eject cannot cover: vue-router@5 declares
+        // `@vue/compiler-sfc` an optional peer + unguardedly imports it, nub's
+        // resolver doesn't thread the peer in the Nuxt graph, and under symlink-GVS
+        // there is no store-root public-hoist to catch it, so `nuxt prepare` fails.
+        // Project-local install builds the `.nub/node_modules/` hidden hoist tree
+        // that resolves it (see [[nuxt-phantom-hoist-fix]]). `next` (Turbopack
+        // chroot) and `react-native` (bare-RN Metro realpath crawl) are irreducible
+        // store-locality breaks.
         let dir = tempfile::tempdir().unwrap();
         let fresh = nub_setting_defaults(None, true, dir.path(), VirtualStoreLocality::Default);
         assert_eq!(
             get(&fresh, "disableGlobalVirtualStoreForPackages"),
-            Some("next,react-native"),
+            Some("next,nuxt,react-native"),
         );
     }
 

--- a/tests/vite-compat/README.md
+++ b/tests/vite-compat/README.md
@@ -109,21 +109,28 @@ tests/vite-compat/driver.sh <dir> "<dev-cmd>" "<build-cmd>" <port>
   the process) serves a store-resident `/@fs` module `200` (was `403`).
   Acceptance: `/@fs=200`, `log=no-403`, `patched>=1`, and only the framework
   closure ejected (the rest of the tree stays symlinked).
-- **Nuxt 4 (both rungs).** `nuxt@^4` embeds `vite@7.3.6` (`< 8.1`) AND breaks on
-  transitive undeclared imports the closure alone can't place. The flag
-  disk-materializes the `[nuxt, @nuxt/vite-builder, vite, vue-router,
-  @nuxt/devtools]` closure (rung 1) and hoists the two already-resolved phantom
-  targets within their importers — `@vue/compiler-sfc` into `vue-router`,
-  `unstorage` into `@nuxt/devtools` (rung 2). Acceptance: `nuxt prepare` →
-  "Types generated", `nuxt dev` page `200` with SSR-rendered markup, store
-  `/@fs=200`, `0` errors, bare `nuxt dev` (no nub in the process). The closure is
-  bounded to the Nuxt subtree (`~2.1%` of a realistic 1200-package project), so a
-  large app's unrelated deps keep symlink speed.
+- **Nuxt 4 (project-local, not symlink-GVS).** `nuxt@^4` embeds `vite@7.3.6`
+  (`< 8.1`) AND pulls `vue-router@5`, which declares `@vue/compiler-sfc` an
+  OPTIONAL PEER and unguardedly imports it from its `/vite` unplugin. That peer is
+  the sticking point: the phantom scanner correctly treats an optional peer as NOT
+  a hard phantom, so the rung-2 hoist never targets it (the `unstorage` →
+  `@nuxt/devtools` HARD-phantom hoist DOES fire), and under symlink-GVS there is no
+  store-root public-hoist `node_modules` to catch it — pnpm threads the peer down
+  the Nuxt subtree and links it, nub's resolver does not in this graph, so `nuxt
+  prepare` fails with `Cannot find package '@vue/compiler-sfc'`. So `nuxt` is on
+  `disableGlobalVirtualStoreForPackages` and installs project-local, which builds
+  the `.nub/node_modules/` hidden hoist tree (pnpm-parity public-hoist) that Node's
+  upward walk reaches → the optional peer resolves. Acceptance: `nuxt prepare` →
+  "Types generated", `nuxt dev` page `200` with SSR-rendered markup, `0` errors,
+  bare `nuxt dev` (no nub in the process). The proper symlink-GVS fix is resolver
+  optional-peer-threading parity (a separate, maintainer-owned effort because of
+  its lockfile-churn blast radius).
 
 ## The Nuxt trigger note
 
 `nuxt` is on nub's `disableGlobalVirtualStoreForPackages` trigger (installs
-all-disk, project-local), so as shipped it does NOT run symlink-GVS. The closure
-above lets Nuxt work UNDER symlink-GVS (both its vite gap and its phantom class),
-which makes removing it from the trigger a candidate — but the flag is default-off
-and changing the trigger default is a maintainer decision, not part of this PR.
+all-disk, project-local), so it does NOT run symlink-GVS — this is deliberate (see
+the Nuxt case above): the optional-peer edge Nuxt pulls via `vue-router@5` is not
+placeable under symlink-GVS, and the project-local hidden hoist tree resolves it.
+Keeping Nuxt under symlink-GVS is unblocked only by resolver optional-peer-threading
+parity, which is out of scope here.


### PR DESCRIPTION
Nuxt 4 crashed at `nub install`: `nuxt prepare` → `Cannot find package '@vue/compiler-sfc'`. Nuxt's `vue-router@5` declares it an optional peer and unguardedly imports it; nub's resolver doesn't thread the peer, the scanner treats an optional peer as not a hard phantom (eject skips it), and symlink-GVS has no store-root public-hoist to catch it. Full cause in the commit.

Fix: add `nuxt` to `disableGlobalVirtualStoreForPackages` so it installs project-local, whose `.nub/node_modules/` hidden hoist tree resolves the peer. Same as `next`/`react-native`.

Verified: install exit 0, types generated, `nuxt dev` serves 200 with SSR markup. Gates green; self-review: ship.