### PR TITLE
fix(install): exempt --lockfile-only from the CI auto-frozen default

### DIFF
--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -53,6 +53,24 @@ fn run_install(dir: &Path, args: &[&str]) -> (String, String, i32) {
     )
 }
 
+/// Like [`run_install`], but with `CI=true` in the environment so the
+/// install hits nub's CI-aware frozen-mode auto-default.
+fn run_install_ci(dir: &Path, args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .env("CI", "true")
+        .env("XDG_DATA_HOME", pm_tmpdir("xdg-data"))
+        .env("XDG_CACHE_HOME", pm_tmpdir("xdg-cache"))
+        .output()
+        .expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
 /// Offline guard for the `#[ignore]` network tests: true when the registry
 /// answers a TCP connect within 3s.
 fn registry_reachable() -> bool {
@@ -493,6 +511,67 @@ fn install_refuses_to_mutate_a_drifted_yarn_lock() {
     assert!(
         !dir.join("aube-lock.yaml").exists(),
         "the gate must not leave an aube-lock.yaml behind"
+    );
+}
+
+/// pnpm parity (`opts.ci && !opts.lockfileOnly`): under `CI=true` nub
+/// auto-selects frozen mode for a plain install, but a `--lockfile-only`
+/// run is exempt — it exists to regenerate the lock, so it re-resolves a
+/// drifted manifest and rewrites the lock instead of erroring. Regression
+/// for the CI-frozen-default swallowing `--lockfile-only`. The contrast
+/// arm proves the auto-default is unchanged for a non-lockfile-only run.
+#[test]
+#[ignore = "network: resolves is-positive@{1.0.0,3.1.0} from the npm registry"]
+fn ci_lockfile_only_regenerates_a_drifted_lock() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+
+    // Seed a project whose nub.lock pins is-positive@1.0.0, then bump the
+    // manifest to 3.1.0 so the lock is drifted (stale) relative to it.
+    let seed = |tag: &str| -> PathBuf {
+        let dir = pm_tmpdir(tag);
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"drift","version":"1.0.0","dependencies":{"is-positive":"1.0.0"}}"#,
+        )
+        .unwrap();
+        let (out, err, code) = run_install(&dir, &["install"]);
+        assert_eq!(code, 0, "seed install must succeed: {out}\n{err}");
+        assert!(
+            dir.join("nub.lock").is_file(),
+            "seed writes nub.lock: {err}"
+        );
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"drift","version":"1.0.0","dependencies":{"is-positive":"3.1.0"}}"#,
+        )
+        .unwrap();
+        dir
+    };
+
+    // `--lockfile-only` under CI: exempt from the frozen auto-default, so
+    // it re-resolves the bumped 3.1.0 spec and rewrites the lock, rc=0.
+    let dir = seed("lockonly");
+    let (out, err, code) = run_install_ci(&dir, &["install", "--lockfile-only"]);
+    assert_eq!(
+        code, 0,
+        "CI=true install --lockfile-only must regenerate a drifted lock, not error: {out}\n{err}"
+    );
+    let lock = std::fs::read_to_string(dir.join("nub.lock")).unwrap();
+    assert!(
+        lock.contains("3.1.0"),
+        "the lock must be re-resolved to the bumped 3.1.0 spec: {lock}"
+    );
+
+    // Contrast: a plain install under CI stays frozen and rejects the same
+    // drift — the auto-default is unchanged for non-lockfile-only runs.
+    let dir2 = seed("plain");
+    let (_out2, err2, code2) = run_install_ci(&dir2, &["install"]);
+    assert_ne!(
+        code2, 0,
+        "CI=true plain install must still auto-freeze and reject a drifted lock: {err2}"
     );
 }
 

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -573,6 +573,12 @@ fn ci_lockfile_only_regenerates_a_drifted_lock() {
         code2, 0,
         "CI=true plain install must still auto-freeze and reject a drifted lock: {err2}"
     );
+    // Pin the failure to the frozen-drift path (not an unrelated network/store
+    // error), so the contrast can't pass vacuously.
+    assert!(
+        err2.contains("ERR_NUB_OUTDATED_LOCKFILE"),
+        "the rejection must be the frozen outdated-lockfile error: {err2}"
+    );
 }
 
 /// A truly-fresh `nub add` claims nub identity exactly like a fresh `install`:

--- a/vendor/aube/crates/aube/src/commands/install/args.rs
+++ b/vendor/aube/crates/aube/src/commands/install/args.rs
@@ -261,7 +261,7 @@ impl InstallArgs {
             // `--force` without an explicit frozen mode re-resolves.
             FrozenMode::No
         } else {
-            FrozenMode::from_override(global, yaml_prefer_frozen)
+            FrozenMode::from_override(global, yaml_prefer_frozen, self.lockfile_only)
         };
         let network_mode = if self.offline {
             aube_registry::NetworkMode::Offline

--- a/vendor/aube/crates/aube/src/commands/install/frozen.rs
+++ b/vendor/aube/crates/aube/src/commands/install/frozen.rs
@@ -87,7 +87,16 @@ impl FrozenMode {
     /// Resolve the user's flag combination to a single mode. If no CLI
     /// override is given, honor `preferFrozenLockfile` from the
     /// workspace config; otherwise fall back to the env-aware default.
-    pub fn from_override(cli: Option<FrozenOverride>, yaml_prefer_frozen: Option<bool>) -> Self {
+    ///
+    /// `lockfile_only` gates only the CI-auto-frozen default (see
+    /// [`Self::default_for_env`]); it is irrelevant when an explicit CLI
+    /// override or `preferFrozenLockfile` decides the mode, so callers
+    /// that always pass an override may pass `false`.
+    pub fn from_override(
+        cli: Option<FrozenOverride>,
+        yaml_prefer_frozen: Option<bool>,
+        lockfile_only: bool,
+    ) -> Self {
         match cli {
             Some(FrozenOverride::Frozen) => Self::Frozen,
             Some(FrozenOverride::No) => Self::No,
@@ -95,14 +104,19 @@ impl FrozenMode {
             None => match yaml_prefer_frozen {
                 Some(true) => Self::Prefer,
                 Some(false) => Self::No,
-                None => Self::default_for_env(),
+                None => Self::default_for_env(lockfile_only),
             },
         }
     }
 
     /// pnpm's default: `frozen-lockfile=true` in CI, `prefer-frozen-lockfile=true` otherwise.
-    fn default_for_env() -> Self {
-        if aube_util::env::is_ci() {
+    ///
+    /// A lockfile-only run is exempt from the CI-frozen default: it
+    /// exists to regenerate the lock, so rejecting manifest drift would
+    /// defeat its purpose. Mirrors pnpm's `opts.ci && !opts.lockfileOnly`
+    /// (installing/commands/src/install.ts).
+    fn default_for_env(lockfile_only: bool) -> Self {
+        if aube_util::env::is_ci() && !lockfile_only {
             Self::Frozen
         } else {
             Self::Prefer
@@ -116,19 +130,38 @@ mod tests {
 
     #[test]
     fn cli_frozen_beats_yaml() {
-        let m = FrozenMode::from_override(Some(FrozenOverride::Frozen), Some(false));
+        let m = FrozenMode::from_override(Some(FrozenOverride::Frozen), Some(false), false);
         assert!(matches!(m, FrozenMode::Frozen));
     }
 
     #[test]
     fn yaml_prefer_true_maps_to_prefer() {
-        let m = FrozenMode::from_override(None, Some(true));
+        let m = FrozenMode::from_override(None, Some(true), false);
         assert!(matches!(m, FrozenMode::Prefer));
     }
 
     #[test]
     fn yaml_prefer_false_maps_to_no() {
-        let m = FrozenMode::from_override(None, Some(false));
+        let m = FrozenMode::from_override(None, Some(false), false);
         assert!(matches!(m, FrozenMode::No));
+    }
+
+    // `default_for_env` reads the ambient `CI` env var live, so the
+    // false→Frozen branch is env-coupled and can't be pinned here without
+    // mutating a process global under the parallel runner. Assert only the
+    // env-independent invariant; the CI=true contrast is covered by the
+    // integration test that spawns the binary with a hermetic env.
+    #[test]
+    fn lockfile_only_never_ci_frozen() {
+        // pnpm's `opts.ci && !opts.lockfileOnly`: a lockfile-only run must
+        // never hard-select Frozen regardless of CI — it regenerates the lock.
+        assert!(matches!(
+            FrozenMode::default_for_env(true),
+            FrozenMode::Prefer
+        ));
+        assert!(matches!(
+            FrozenMode::from_override(None, None, true),
+            FrozenMode::Prefer
+        ));
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install_test.rs
+++ b/vendor/aube/crates/aube/src/commands/install_test.rs
@@ -44,6 +44,9 @@ pub async fn run(script_args: ScriptArgs) -> miette::Result<Option<i32>> {
         let mode = install::FrozenMode::from_override(
             None,
             aube_settings::resolved::prefer_frozen_lockfile(&ctx),
+            // `install-test` is not lockfile-only; it behaves like
+            // argumentless `aube install`, so the CI-frozen default applies.
+            false,
         );
         // `install-test` is a pnpm-compat alias for `install && test`,
         // so the install phase needs to behave like argumentless `aube

--- a/vendor/aube/crates/aube/src/commands/settings_context.rs
+++ b/vendor/aube/crates/aube/src/commands/settings_context.rs
@@ -201,7 +201,7 @@ pub(crate) fn load_global_config_yaml() -> std::collections::BTreeMap<String, ya
 /// to the given default when none was set on the command line.
 pub(crate) fn chained_frozen_mode(default: install::FrozenMode) -> install::FrozenMode {
     match global_frozen_override() {
-        Some(ovr) => install::FrozenMode::from_override(Some(ovr), None),
+        Some(ovr) => install::FrozenMode::from_override(Some(ovr), None, false),
         None => default,
     }
 }


### PR DESCRIPTION
Under `CI`, an install auto-selects frozen mode, which errors on lockfile drift — making `--lockfile-only` (whose job is to regenerate the lock) fail with `ERR_NUB_OUTDATED_LOCKFILE` on the drift it exists to resolve.

The CI auto-default now gates on `is_ci() && !lockfile_only`, mirroring pnpm's `opts.ci && !opts.lockfileOnly`. Plain CI installs stay auto-frozen; explicit `--frozen-lockfile` still forces frozen.

Verified against pnpm 10.15.1 on an identical drifted fixture: `--lockfile-only` rc=0 (re-resolves), plain install frozen-errors — both match. Adds a network integration test + a unit test. Embedder-agnostic, so not profile-gated.