### PR TITLE
feat(env): select .env mode from --env > APP_ENV, drop NODE_ENV (breaking)

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -168,6 +168,27 @@ fn env_file_flag_present() -> bool {
     ENV_FILE_PRESENT.get().copied().unwrap_or(false)
 }
 
+/// The explicit env-file *mode* from `--env <mode>`, captured once at startup —
+/// the highest-precedence mode source (over `APP_ENV`/`NODE_ENV`) that
+/// `env_file_names` resolves. Distinct from `--env-file <path>` (a specific file);
+/// `--env` selects which `.env.{mode}` files auto-discovery loads. Set once on the
+/// file-run and `nub watch` paths (the only ones that reach `.env` auto-loading).
+static ENV_MODE_OVERRIDE: OnceLock<String> = OnceLock::new();
+
+/// The `--env <mode>` override, if any. Read by the file-run and watch paths and
+/// handed to `load_env_files`/`discover_env_files` as the top-precedence mode.
+fn env_mode_override() -> Option<String> {
+    ENV_MODE_OVERRIDE.get().cloned()
+}
+
+/// Record the `--env <mode>` value (once; empty values are not a selection and are
+/// ignored). Idempotent — a later re-entry (e.g. the node shim) can't clobber it.
+fn set_env_mode_override(mode: &str) {
+    if !mode.is_empty() {
+        let _ = ENV_MODE_OVERRIDE.set(mode.to_string());
+    }
+}
+
 /// Overlay the `--env-file` vars onto an env map bound for a child's
 /// `Command::env`. Shell env still wins (skip keys already in this process's
 /// environment); `--env-file` overrides `.env` (insert over existing entries).
@@ -465,6 +486,10 @@ pub enum Command {
 
     /// Run a file in watch mode (restarts on change).
     Watch {
+        /// Select the env-file mode (loads `.env.{mode}`); highest precedence, over APP_ENV/NODE_ENV.
+        #[arg(long, value_name = "MODE")]
+        env: Option<String>,
+
         /// File to watch and execute.
         file: String,
 
@@ -1238,6 +1263,20 @@ fn run_nub() -> Result<i32> {
             s if s.starts_with("--loglevel=") => {
                 loglevel_val = Some(s["--loglevel=".len()..].to_string());
             }
+            // `--env <mode>` selects the env-file mode (`.env.{mode}`), the
+            // top-precedence source over APP_ENV/NODE_ENV. Distinct from
+            // `--env-file <path>` below (matched first — `--env-file` is neither
+            // `--env` nor `--env=…`, so the two never collide). Consumed here so it
+            // never reaches Node; after the entrypoint it forwards to the script.
+            "--env" => {
+                i += 1;
+                if i < raw_args.len() {
+                    set_env_mode_override(&raw_args[i]);
+                }
+            }
+            s if s.starts_with("--env=") => {
+                set_env_mode_override(&s["--env=".len()..]);
+            }
             s if s == "--env-file"
                 || s.starts_with("--env-file=")
                 || s == "--env-file-if-exists"
@@ -1649,7 +1688,10 @@ fn value_consuming_flags(subcommand: &str) -> &'static [&'static str] {
             "-p",
             "--cwd",
         ],
-        "watch" => &["--cwd"],
+        // `--env <mode>` takes a following token, so the positional-boundary scan
+        // must skip its value — else `nub watch --env production app.ts` mistakes
+        // `production` for the file and clap sees no positional.
+        "watch" => &["--cwd", "--env"],
         _ => &[],
     }
 }
@@ -1907,8 +1949,15 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             };
             run_script(script.as_deref(), node, &ws_opts, &args)
         }
-        Some(Command::Watch { file, mut args }) => {
+        Some(Command::Watch {
+            env,
+            file,
+            mut args,
+        }) => {
             args.extend(suffix);
+            if let Some(mode) = env.as_deref() {
+                set_env_mode_override(mode);
+            }
             run_watch(&file, &args)
         }
         Some(Command::Exec {
@@ -2433,10 +2482,11 @@ fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path, exec_ua: bool
     // (only the named file(s) load; the maintainer, 2026-06-15). `merge_child_env` applies the
     // gate. --env-file vars apply even in compat mode (explicit user flag).
     let project = nub_core::workspace::detect::detect_project(cwd);
+    let mode_override = env_mode_override();
     let auto_env = if !compat_mode {
         project
             .as_ref()
-            .map(|p| nub_core::workspace::env::load_env_files(&p.root))
+            .map(|p| nub_core::workspace::env::load_env_files(&p.root, mode_override.as_deref()))
             .unwrap_or_default()
     } else {
         Default::default()
@@ -4403,13 +4453,16 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     // the child. This keeps `nub --watch --env-file …` consistent with the direct
     // file runner.
     let env_file_present = env_file_flag_present();
+    let mode_override = env_mode_override();
     let project = nub_core::workspace::detect::detect_project(&cwd);
     let env_file_paths = if env_file_present {
         Vec::new()
     } else {
         project
             .as_ref()
-            .map(|p| nub_core::workspace::env::discover_env_files(&p.root))
+            .map(|p| {
+                nub_core::workspace::env::discover_env_files(&p.root, mode_override.as_deref())
+            })
             .unwrap_or_default()
     };
     // Load the `.env*` files ONCE: `raw_env` is the unexpanded merge (the values
@@ -4425,7 +4478,9 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     } else {
         project
             .as_ref()
-            .map(|p| nub_core::workspace::env::load_env_files_raw(&p.root))
+            .map(|p| {
+                nub_core::workspace::env::load_env_files_raw(&p.root, mode_override.as_deref())
+            })
             .unwrap_or_default()
     };
     // Pre-expand the auto base to the same map the direct file runner's

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -3435,9 +3435,11 @@ fn env_file_flag_preserves_unquoted_json_value_without_auto_dotenv() {
 }
 
 #[test]
-fn env_precedence_with_node_env() {
+fn env_precedence_with_app_env_mode() {
+    // `APP_ENV` selects the mode (`.env.development` here); `NODE_ENV` no longer
+    // does (dropped as a mode source — it is the app's own dev/prod variable).
     let (stdout, stderr, code) =
-        run_nub_with_env("env-test", "precedence.ts", &[("NODE_ENV", "development")]);
+        run_nub_with_env("env-test", "precedence.ts", &[("APP_ENV", "development")]);
     assert_eq!(code, 0, "stderr: {stderr}");
     assert!(
         stdout.contains("SHARED=local-wins"),
@@ -3503,12 +3505,13 @@ fn npm_run_threads_node_execpath() {
 ///   2. CORRECTNESS — a NODE tool (`node -e …`) in the same script MUST still
 ///      see `.env`, because the node-hijack loads it at the node child's own
 ///      startup. This is nub's advantage over Bun's blunt "load nothing".
-///   3. NODE_ENV-cascade (bun#9635) — `NODE_ENV=production node …` must read
-///      `.env.production`, not `.env.development`/`.env`. The old eager-outer
+///   3. Mode-cascade, node-scoped (bun#9635) — `APP_ENV=production node …` must
+///      read `.env.production`, not `.env.development`/`.env`. The old eager-outer
 ///      load froze the wrong env-file values into the process before the inline
-///      `NODE_ENV` could correct them; node-scoped loading reads the right file.
+///      mode could correct them; node-scoped loading reads the right file. (Mode
+///      is `--env`/`APP_ENV`; `NODE_ENV` is no longer a file selector.)
 ///
-/// Unix-only: the `printenv` probe and inline `NODE_ENV=…` script syntax are
+/// Unix-only: the `printenv` probe and inline `APP_ENV=…` script syntax are
 /// POSIX `sh`; the node-scoping itself is platform-agnostic (build_script_command
 /// drops the load on every OS), validated here on the runner that can express it.
 #[cfg(unix)]
@@ -3548,13 +3551,13 @@ fn run_script_env_is_node_scoped_not_process_scoped() {
         "a node tool under `nub run` must still get `.env` (node-scoped load): stdout={node_out:?}"
     );
 
-    // 3. NODE_ENV-cascade: inline `NODE_ENV=production` ⇒ the node child loads
+    // 3. Mode-cascade: inline `APP_ENV=production` ⇒ the node child loads
     //    `.env.production`, not the base `.env` (and not `.env.development`).
     let (cascade_out, cascade_err, cascade_code) = run("cascade", &[]);
     assert_eq!(cascade_code, 0, "cascade script failed: {cascade_err}");
     assert!(
         cascade_out.contains("ENVFILE=from-production"),
-        "NODE_ENV=production must read `.env.production` (bun#9635 cascade fix); got {cascade_out:?}"
+        "APP_ENV=production must read `.env.production` (bun#9635 cascade fix); got {cascade_out:?}"
     );
 }
 
@@ -5115,11 +5118,12 @@ fn env_file_flag_reaches_child_and_shell_wins() {
 
 /// #263, end-to-end through the binary — the differential that broke `next build`.
 /// A `.env` FILE must NOT leak its `NODE_ENV` into the spawned child (dotenv/
-/// @next/env/Vite parity), yet an AMBIENT `NODE_ENV` must both pass through
-/// untouched AND still select the `.env.<NODE_ENV>` file. Child ambient is set via
-/// `Command::env`, so the test never mutates its own process env (hermetic).
+/// @next/env/Vite parity). An AMBIENT `NODE_ENV` passes through untouched but does
+/// NOT select `.env.<mode>` files — `NODE_ENV` is no longer a mode source; only
+/// `APP_ENV` (or `--env`) selects. Child ambient is set via `Command::env`, so the
+/// test never mutates its own process env (hermetic).
 #[test]
-fn dotenv_node_env_stripped_but_ambient_selects_env_file() {
+fn dotenv_node_env_stripped_and_app_env_selects_env_file() {
     let work = unique_test_cache();
     let proj = work.join("proj");
     std::fs::create_dir_all(&proj).unwrap();
@@ -5132,15 +5136,19 @@ fn dotenv_node_env_stripped_but_ambient_selects_env_file() {
     )
     .unwrap();
 
-    let run = |ambient: Option<&str>| {
+    let run = |node_env: Option<&str>, app_env: Option<&str>| {
         let mut cmd = Command::new(nub_binary());
         cmd.arg(proj.join("print.mjs").to_str().unwrap())
             .current_dir(&proj)
-            .env("XDG_CACHE_HOME", unique_test_cache());
-        match ambient {
+            .env("XDG_CACHE_HOME", unique_test_cache())
+            .env_remove("APP_ENV");
+        match node_env {
             Some(v) => cmd.env("NODE_ENV", v),
             None => cmd.env_remove("NODE_ENV"),
         };
+        if let Some(v) = app_env {
+            cmd.env("APP_ENV", v);
+        }
         let out = cmd.output().expect("failed to spawn nub");
         (
             String::from_utf8_lossy(&out.stdout).to_string(),
@@ -5149,9 +5157,9 @@ fn dotenv_node_env_stripped_but_ambient_selects_env_file() {
         )
     };
 
-    // (a) ambient NODE_ENV unset: the `.env` NODE_ENV is dropped (not "development"),
-    //     so `.env` — not `.env.production` — is selected, and nub warns once.
-    let (out_a, err_a, code_a) = run(None);
+    // (a) no mode set: the `.env` NODE_ENV is dropped (not "development"), so `.env`
+    //     — not `.env.production` — is selected, and nub warns once.
+    let (out_a, err_a, code_a) = run(None, None);
     assert_eq!(code_a, 0, "run must succeed; stderr: {err_a}");
     assert!(
         out_a.contains("NE=[]"),
@@ -5163,29 +5171,42 @@ fn dotenv_node_env_stripped_but_ambient_selects_env_file() {
     );
     assert!(
         out_a.contains("PROD=[]"),
-        "ambient NODE_ENV unset must select `.env`, never `.env.production`: {out_a}"
+        "no mode must select `.env`, never `.env.production`: {out_a}"
     );
     assert!(
         err_a.contains("ignoring NODE_ENV set in .env"),
         "nub must warn that a `.env` NODE_ENV was ignored: {err_a}"
     );
 
-    // (b) ambient NODE_ENV=production: passes through untouched AND selects
-    //     `.env.production` (selection keys off ambient, never the `.env` value),
-    //     with no spurious warning (ambient wins before the strip).
-    let (out_b, err_b, code_b) = run(Some("production"));
+    // (b) ambient NODE_ENV=production: passes through untouched but does NOT select
+    //     `.env.production` — NODE_ENV is no longer a mode source. No spurious
+    //     warning (the ambient value wins over the `.env` value before the strip).
+    let (out_b, err_b, code_b) = run(Some("production"), None);
     assert_eq!(code_b, 0, "run must succeed; stderr: {err_b}");
     assert!(
         out_b.contains("NE=[production]"),
         "ambient NODE_ENV must pass through: {out_b}"
     );
     assert!(
-        out_b.contains("PROD=[prod]"),
-        "ambient NODE_ENV must select `.env.production`: {out_b}"
+        out_b.contains("PROD=[]"),
+        "ambient NODE_ENV must NOT select `.env.production` (no longer a mode source): {out_b}"
     );
     assert!(
         !err_b.contains("ignoring NODE_ENV set in .env"),
         "no warning when an ambient NODE_ENV wins over the `.env` value: {err_b}"
+    );
+
+    // (c) APP_ENV=production selects `.env.production` (the mode mechanism), while
+    //     the `.env` file's own NODE_ENV is still stripped + warned.
+    let (out_c, err_c, code_c) = run(None, Some("production"));
+    assert_eq!(code_c, 0, "run must succeed; stderr: {err_c}");
+    assert!(
+        out_c.contains("PROD=[prod]"),
+        "APP_ENV=production must select `.env.production`: {out_c}"
+    );
+    assert!(
+        out_c.contains("NE=[]"),
+        "`.env` NODE_ENV must still not leak into the child: {out_c}"
     );
 
     let _ = std::fs::remove_dir_all(&work);

--- a/crates/nub-core/src/workspace/env.rs
+++ b/crates/nub-core/src/workspace/env.rs
@@ -27,25 +27,78 @@ pub fn read_env_file(path: &Path) -> Option<String> {
 }
 
 /// The `.env*` filenames Nub loads, in descending priority order (the file
-/// listed first wins a key over later ones). Driven by `NODE_ENV`, matching
-/// Node's own `.env` precedence. Shared by [`load_env_files`] (first-writer-wins
-/// merge) and [`discover_env_files`] (the watch path's `--env-file` args).
-fn env_file_names() -> Vec<String> {
-    let node_env = std::env::var("NODE_ENV").unwrap_or_default();
-    let is_test = node_env == "test";
+/// listed first wins a key over later ones). Driven by the resolved *mode*. The
+/// `.env` / `.env.local` / `.env.{mode}` cascade mirrors the dotenv-flow / Next /
+/// Vite ecosystem convention — NOT Node core, which has no mode cascade (its
+/// `--env-file` loads named files only). Shared by [`load_env_files`]
+/// (first-writer-wins merge) and [`discover_env_files`] (the watch path's
+/// `--env-file` args), so this one function governs mode selection on both paths.
+///
+/// Mode precedence: an explicit `mode_override` (the `--env <mode>` CLI flag)
+/// wins, else `APP_ENV` (when non-empty). `NODE_ENV` is deliberately NOT a mode
+/// source — nub treats it as the application's own dev/prod behavior variable,
+/// never a file selector (dropped as a breaking change; a non-dev/prod/test
+/// `NODE_ENV` used as a file selector silently flips frameworks into development
+/// mode, the footgun the modern ecosystem decoupled away). `APP_ENV` is the
+/// framework-neutral selector (Vite, and others); when neither is set there is no
+/// mode, so only `.env` / `.env.local` load.
+fn env_file_names(mode_override: Option<&str>) -> Vec<String> {
+    env_file_names_for_mode(&resolve_env_mode(mode_override))
+}
+
+/// Resolve the env-file mode: the `--env` override, else the ambient `APP_ENV`.
+/// Reads process env once; [`resolve_mode`] holds the pure precedence logic
+/// (hermetically testable).
+fn resolve_env_mode(mode_override: Option<&str>) -> String {
+    resolve_mode(
+        mode_override.map(str::to_string),
+        std::env::var("APP_ENV").ok(),
+    )
+}
+
+/// Pure `--env > APP_ENV` precedence: the override wins when non-empty, else
+/// `APP_ENV` when non-empty, else no mode. `NODE_ENV` is intentionally absent —
+/// see [`env_file_names`].
+fn resolve_mode(mode_override: Option<String>, app_env: Option<String>) -> String {
+    mode_override
+        .filter(|v| !v.is_empty())
+        .or_else(|| app_env.filter(|v| !v.is_empty()))
+        .unwrap_or_default()
+}
+
+/// The `.env*` precedence list for a resolved mode. `is_test` (mode `test`) omits
+/// `.env.local`, matching dotenv/Next; an empty mode yields only `.env.local` +
+/// `.env`. Pure in `mode`, so callers pass any resolution and the ordering is
+/// tested without touching process env.
+fn env_file_names_for_mode(mode: &str) -> Vec<String> {
+    // The mode is interpolated raw into `.env.{mode}` / `.env.{mode}.local` joined
+    // to the project root, so a value carrying a path separator (`APP_ENV=x/../y`)
+    // would escape the root; restrict the mode charset and treat anything outside
+    // `[A-Za-z0-9_.-]` as no-mode (quietly loads only `.env` / `.env.local`). Real
+    // modes are in-charset; `..` alone can't traverse without a `/`.
+    let mode = if is_safe_mode(mode) { mode } else { "" };
+    let is_test = mode == "test";
 
     let mut files = Vec::new();
-    if !node_env.is_empty() {
-        files.push(format!(".env.{node_env}.local"));
+    if !mode.is_empty() {
+        files.push(format!(".env.{mode}.local"));
     }
     if !is_test {
         files.push(".env.local".to_string());
     }
-    if !node_env.is_empty() {
-        files.push(format!(".env.{node_env}"));
+    if !mode.is_empty() {
+        files.push(format!(".env.{mode}"));
     }
     files.push(".env".to_string());
     files
+}
+
+/// A mode is safe to interpolate into a root-joined `.env.{mode}` path iff it
+/// contains only `[A-Za-z0-9_.-]` — no path separator can appear, so it cannot
+/// traverse out of the project root. An empty mode is trivially safe (no files).
+fn is_safe_mode(mode: &str) -> bool {
+    mode.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
 }
 
 /// The existing `.env*` file paths under `project_root`, in descending priority
@@ -59,8 +112,11 @@ fn env_file_names() -> Vec<String> {
 /// NOTE — precedence inversion: Node's `--env-file` is *last*-writer-wins, the
 /// inverse of this list's *first*-writer-wins order, so the caller must pass
 /// these to Node in reverse for the priorities to line up.
-pub fn discover_env_files(project_root: &Path) -> Vec<std::path::PathBuf> {
-    env_file_names()
+pub fn discover_env_files(
+    project_root: &Path,
+    mode_override: Option<&str>,
+) -> Vec<std::path::PathBuf> {
+    env_file_names(mode_override)
         .iter()
         .map(|name| project_root.join(name))
         .filter(|path| read_env_file(path).is_some())
@@ -100,8 +156,11 @@ pub fn expand_env_map(map: &mut HashMap<String, String>) -> &mut HashMap<String,
 /// restart), so injecting it would freeze the startup value (#207). Only the
 /// expansion-changed keys — which Node's `--env-file` can't reproduce — get
 /// injected.
-pub fn load_env_files_raw(project_root: &Path) -> HashMap<String, String> {
-    load_env_files_raw_reporting(project_root).0
+pub fn load_env_files_raw(
+    project_root: &Path,
+    mode_override: Option<&str>,
+) -> HashMap<String, String> {
+    load_env_files_raw_reporting(project_root, mode_override).0
 }
 
 /// The raw loader, additionally reporting whether a `.env` FILE declared
@@ -110,8 +169,11 @@ pub fn load_env_files_raw(project_root: &Path) -> HashMap<String, String> {
 /// injection path) to warn the user; the plain [`load_env_files_raw`] wrapper
 /// discards it because the watch path defers `NODE_ENV` to Node's own `--env-file`
 /// and so is NOT the one ignoring it — warning there would be false.
-fn load_env_files_raw_reporting(project_root: &Path) -> (HashMap<String, String>, bool) {
-    let files = env_file_names();
+fn load_env_files_raw_reporting(
+    project_root: &Path,
+    mode_override: Option<&str>,
+) -> (HashMap<String, String>, bool) {
+    let files = env_file_names(mode_override);
 
     let mut result = HashMap::new();
     let mut node_env_ignored = false;
@@ -165,8 +227,8 @@ fn warn_node_env_from_dotenv_ignored() {
 /// pairs to inject into the child process environment. Shell env
 /// (from the parent process) always wins — values already set in
 /// the process environment are not overridden.
-pub fn load_env_files(project_root: &Path) -> HashMap<String, String> {
-    let (mut result, node_env_ignored) = load_env_files_raw_reporting(project_root);
+pub fn load_env_files(project_root: &Path, mode_override: Option<&str>) -> HashMap<String, String> {
+    let (mut result, node_env_ignored) = load_env_files_raw_reporting(project_root, mode_override);
 
     // Expand ${VAR} references within values. Multi-pass to handle
     // nested references like A=hello, B=${A}_world, C=${B}_!.
@@ -395,6 +457,71 @@ mod tests {
         );
     }
 
+    /// Mode selection is `--env > APP_ENV` (v0.4): the CLI override wins, else
+    /// `APP_ENV` (non-empty), else no mode. `NODE_ENV` is NOT a mode source —
+    /// `resolve_mode` takes no `NODE_ENV` argument, so it cannot participate.
+    #[test]
+    fn resolve_mode_prefers_override_then_app_env_no_node_env() {
+        let s = |v: &str| Some(v.to_string());
+        // APP_ENV set → APP_ENV.
+        assert_eq!(resolve_mode(None, s("production")), "production");
+        // `--env` override beats APP_ENV.
+        assert_eq!(resolve_mode(s("staging"), s("development")), "staging");
+        // `--env` alone.
+        assert_eq!(resolve_mode(s("production"), None), "production");
+        // Neither set → no mode.
+        assert_eq!(resolve_mode(None, None), "");
+        // Empty override falls through to APP_ENV; empty APP_ENV yields no mode.
+        assert_eq!(resolve_mode(s(""), s("development")), "development");
+        assert_eq!(resolve_mode(s(""), None), "");
+        assert_eq!(resolve_mode(None, s("")), "");
+    }
+
+    /// A mode carrying a path separator (a hostile `APP_ENV`/`NODE_ENV`/`--env`)
+    /// must not build `.env.{mode}` filenames — it would traverse out of the
+    /// project root when joined. Such a value is treated as no-mode (only `.env` /
+    /// `.env.local` load); real modes stay in-charset and are unaffected.
+    #[test]
+    fn out_of_charset_mode_is_treated_as_no_mode() {
+        // Separator-bearing values collapse to the base cascade — no `.env.<x>`.
+        for hostile in ["x/../../etc", "../secrets", "a\\b", "a b", "$(x)"] {
+            assert_eq!(
+                env_file_names_for_mode(hostile),
+                vec![".env.local", ".env"],
+                "hostile mode {hostile:?} must not build a `.env.{{mode}}` name"
+            );
+        }
+        // In-charset values (incl. dots and dashes) remain valid modes.
+        assert!(is_safe_mode("production"));
+        assert!(is_safe_mode("test.ci-1"));
+        assert!(!is_safe_mode("x/../y"));
+    }
+
+    /// The resolved mode drives which `.env.{mode}` files are selected, so the
+    /// precedence table's outcome (which value wins `WHICH`) is `.env.{mode}`
+    /// ranking above `.env`. Highest-priority-first; `.env.{mode}.local` and
+    /// `.env.{mode}` bracket `.env.local`, and `test` mode omits `.env.local`.
+    #[test]
+    fn env_file_names_for_mode_orders_mode_files_above_base() {
+        assert_eq!(
+            env_file_names_for_mode("production"),
+            vec![
+                ".env.production.local",
+                ".env.local",
+                ".env.production",
+                ".env",
+            ]
+        );
+        // Empty mode (neither var set) → only `.env.local` + `.env`, so `.env` wins.
+        assert_eq!(env_file_names_for_mode(""), vec![".env.local", ".env"]);
+        // `test` mode drops `.env.local` (dotenv/Next parity), keyed off the
+        // resolved mode — so `APP_ENV=test` skips it too, not just `NODE_ENV=test`.
+        assert_eq!(
+            env_file_names_for_mode("test"),
+            vec![".env.test.local", ".env.test", ".env"]
+        );
+    }
+
     #[test]
     fn parse_quoted_values() {
         let pairs = parse_env("A=\"hello world\"\nB='single'\n");
@@ -580,7 +707,7 @@ mod tests {
         std::fs::write(dir.join(".env"), "X=1\n").unwrap();
         std::fs::write(dir.join(".env.local"), "X=2\n").unwrap();
 
-        let found = discover_env_files(&dir);
+        let found = discover_env_files(&dir, None);
 
         assert!(
             found.iter().all(|p| p.is_file()),
@@ -620,7 +747,7 @@ mod tests {
         )
         .unwrap();
 
-        let vars = load_env_files(&dir);
+        let vars = load_env_files(&dir, None);
 
         assert_eq!(
             vars.get("DATABASE_URL").map(String::as_str),
@@ -648,8 +775,8 @@ mod tests {
         )
         .unwrap();
 
-        let raw = load_env_files_raw(&dir);
-        let expanded = load_env_files(&dir);
+        let raw = load_env_files_raw(&dir, None);
+        let expanded = load_env_files(&dir, None);
 
         // Plain var: identical in both → the watch path leaves it to `--env-file`.
         assert_eq!(raw.get("PLAIN"), expanded.get("PLAIN"));
@@ -684,7 +811,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join(".env"), "NODE_ENV=development\nAPP_KEY=secret\n").unwrap();
 
-        let vars = load_env_files(&dir);
+        let vars = load_env_files(&dir, None);
 
         assert!(
             !vars.contains_key("NODE_ENV"),

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -1,6 +1,6 @@
 ---
 title: Environment files
-description: Automatic environment-file loading — the file set, precedence, variable expansion, the skip under the test environment, and how an explicit env-file flag disables auto-discovery.
+description: Automatic environment-file loading — the file set, how the mode is selected, precedence, variable expansion, the skip under the test environment, and how an explicit env-file flag disables auto-discovery.
 ---
 
 Nub reads your `.env*` files and injects them into the environment before Node starts — no `dotenv` import, no `--env-file` flag. Loading happens from the nearest directory with a `package.json` (walking up from your cwd), matching Vite's single-directory model. Works on every Node version Nub supports (18.19+).
@@ -13,31 +13,47 @@ nub server.ts   # .env* in the project root are loaded automatically
 
 Four filenames are loaded, highest priority first. The shell environment always wins over all of them — a value already set in the process environment is never overridden.
 
-1. `.env.[NODE_ENV].local`
+1. `.env.[mode].local`
 2. `.env.local`
-3. `.env.[NODE_ENV]`
+3. `.env.[mode]`
 4. `.env`
 
-The `[NODE_ENV]` slots only exist when `NODE_ENV` is set; the example below resolves them under `NODE_ENV=production`. Among the `.env*` files, the first one to define a key wins (first-writer-wins); the shell env sits above all of them.
+The `[mode]` slots only exist when a mode is set; the example below resolves them under `production`. Among the `.env*` files, the first one to define a key wins (first-writer-wins); the shell env sits above all of them.
 
 ```bash
 # reads .env.production.local, .env.local, .env.production, .env
-NODE_ENV=production nub server.ts
+nub --env production server.ts
 ```
 
-## Setting NODE_ENV
+## Selecting the mode
 
-A `.env` file can't set `NODE_ENV`. That key is ignored on load — matching dotenv, Next.js, and Vite — and Nub prints a warning when a loaded file defines it. Because `NODE_ENV` chooses which files load, set it in the environment instead:
+The mode fills the `[mode]` slots above. It comes from one of two sources, the flag winning over the variable:
+
+1. The `--env <mode>` flag.
+2. `APP_ENV`, when set to a non-empty value.
+
+When neither is set there is no mode — only `.env.local` and `.env` load.
 
 ```bash
-NODE_ENV=production nub server.ts
+nub --env production server.ts   # reads .env.production*
+APP_ENV=staging nub server.ts    # reads .env.staging*
 ```
 
-Otherwise a `.env` pinning `NODE_ENV=development` leaks into production tooling: `next build`, for one, then runs its prerender workers in development mode against production-compiled output.
+`APP_ENV` is a framework-neutral selector: it drives which `.env` files load without also flipping `NODE_ENV`, which many tools read to switch between development and production behavior.
+
+A mode is only used to build filenames when it contains just letters, digits, `_`, `.`, and `-`. A value with a path separator (a stray `APP_ENV=../other`) is ignored — the `[mode]` files are skipped, `.env` and `.env.local` still load, and no error is raised.
+
+The `--env` flag applies to the file runner and to `nub watch`; it is distinct from `--env-file` below, which names a specific file rather than selecting a mode.
+
+## NODE_ENV
+
+Nub treats `NODE_ENV` as your application's variable: it never sets it, never reads it to select env files, and won't let an env file change it. It is not a mode source — set `APP_ENV` (or pass `--env`) to choose which `.env.[mode]` files load.
+
+A `.env` file that assigns `NODE_ENV` has that one key ignored on load — matching dotenv, Next.js, and Vite — and Nub warns. Otherwise a `.env` pinning `NODE_ENV=development` leaks into production tooling: `next build`, for one, then runs its prerender workers in development mode against production-compiled output.
 
 ## Test environment
 
-Under `NODE_ENV=test`, the `.env.local` slot is skipped — only `.env.test.local`, `.env.test`, and `.env` load. This keeps developer-machine secrets in `.env.local` out of the test environment.
+When the mode is `test` (from `--env test` or `APP_ENV=test`), the `.env.local` slot is skipped — only `.env.test.local`, `.env.test`, and `.env` load. This keeps developer-machine secrets in `.env.local` out of the test environment.
 
 ## Variable expansion
 

--- a/tests/fixtures/env-scope/package.json
+++ b/tests/fixtures/env-scope/package.json
@@ -3,6 +3,6 @@
   "scripts": {
     "leak-nonnode": "printenv SECRET",
     "node-secret": "node -e \"console.log('SECRET=' + (process.env.SECRET ?? 'unset'))\"",
-    "cascade": "NODE_ENV=production node -e \"console.log('ENVFILE=' + (process.env.ENVFILE ?? 'unset'))\""
+    "cascade": "APP_ENV=production node -e \"console.log('ENVFILE=' + (process.env.ENVFILE ?? 'unset'))\""
   }
 }


### PR DESCRIPTION
Env-file mode (which `.env.{mode}` files load) is now resolved `--env <mode>` (new flag) > `APP_ENV` (non-empty). Neither set → no mode (only `.env.local` + `.env`).

**Breaking (v0.x):** `NODE_ENV` is no longer a mode source. nub treats it as the application's own dev/prod variable — never sets it, never reads it to select env files, won't let a `.env` change it. Migrate an ambient `NODE_ENV=<mode>` to `APP_ENV=<mode>` (or `--env <mode>`). A non-dev/prod/test `NODE_ENV` used as a file selector silently flips frameworks into development — the footgun Vite/varlock/dotenvx/Node/Deno all decoupled.

One source — `env_file_names`/`resolve_mode` in `crates/nub-core/src/workspace/env.rs` — shared by the file-run and watch paths. `--env` (captured in a `OnceLock`) coexists with `--env-file <path>`. Mode is restricted to `[A-Za-z0-9_.-]`, closing a traversal vector.

Tests cover the `--env > APP_ENV` precedence, `.env.{mode}` ordering + `test`-skip, and the guard. `env.mdx` updated.