### PR TITLE
feat(linker): collective hidden tree as the sole phantom mechanism under GVS (replaces per-importer hoist) + flatten Materialization

### DIFF
--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -7,22 +7,26 @@
 //! it — otherwise a store-resident importer keeps resolving the un-materialized
 //! shared-store copy, a silent singleton split (two realpaths, two module
 //! instances). This hook expands aube's flat disk-materialize seed into a
-//! graph-aware plan against the resolved lockfile:
+//! graph-aware plan against the resolved lockfile — the ancestor-closure
+//! (rung 1). Each seed grows to [`LockfileGraph::importer_closure`] — the seed
+//! UNION every package that transitively imports it. Bounded to the affected
+//! subtree by construction (unrelated top-level subtrees are not importers),
+//! measured 0.3–2.1% of real large trees. Also SUBSUMES the #315
+//! library-embedded-vite<8.1 residual: an embedded vite<8.1 (a framework's
+//! transitive engine, no direct-dep symlink) is auto-detected and its
+//! `[framework…vite]` closure ejected, so #318's dist sniff patch reaches a
+//! now-project-local vite.
 //!
-//! - **Rung 1 — ancestor-closure.** Each seed grows to
-//!   [`LockfileGraph::importer_closure`] — the seed UNION every package that
-//!   transitively imports it. Bounded to the affected subtree by construction
-//!   (unrelated top-level subtrees are not importers), measured 0.3–2.1% of real
-//!   large trees. Also SUBSUMES the #315 library-embedded-vite<8.1 residual: an
-//!   embedded vite<8.1 (a framework's transitive engine, no direct-dep symlink)
-//!   is auto-detected and its `[framework…vite]` closure ejected, so #318's dist
-//!   sniff patch reaches a now-project-local vite.
-//! - **Rung 2 — hoist-within.** For a transitively-phantom importer whose
-//!   undeclared target the closure alone can't place, the already-resolved target
-//!   is hoisted as an extra sibling within the importer's own materialized
-//!   `node_modules`.
+//! Undeclared phantoms an ejected member imports are resolved by the linker's
+//! COLLECTIVE project-local hidden hoist tree over the whole ejected set (see
+//! `aube_linker::link_hidden_hoist`): each ejected member's realpath is
+//! project-local, so Node's upward `node_modules` walk from inside it passes
+//! through `.nub/node_modules/`, a blanket first-write-wins alias for every graph
+//! package — detection-free and pnpm-parity. So this hook only needs to grow the
+//! eject set; it records no per-importer target hoist. (This replaced the former
+//! per-importer hoist-within mechanism.)
 //!
-//! The phantom importers + their undeclared targets are the DYNAMIC output of the
+//! The phantom importers are the DYNAMIC output of the
 //! extract-time per-version scanner (`crate::dynamic_phantom`, the PRODUCER): it
 //! scans each fetched version's real published code for unguarded undeclared
 //! imports and writes a per-content verdict sidecar. This hook (the CONSUMER)
@@ -37,7 +41,7 @@
 //! pre-productionization pure-symlink behavior. All policy lives here; aube owns
 //! only the neutral seam + the graph primitive.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 
 use aube_linker::DiskMaterializePlan;
 use aube_lockfile::{LockedPackage, LockfileGraph};
@@ -124,15 +128,14 @@ fn plan_from_flags(
     let mut seed_names_set: HashSet<&str> = seed_names.iter().copied().collect();
 
     // Dynamic phantom source (the per-version scanner's sidecars) — the replacement
-    // for the retired hand-curated map. `dynamic_targets` keeps each SURVIVING
-    // importer's undeclared targets keyed by dep_path, for the rung-2 hoist; only
-    // survivors are kept, so a hoist only ever lands in a package the seed actually
-    // materializes.
-    let mut dynamic_targets: BTreeMap<&str, &[String]> = BTreeMap::new();
+    // for the retired hand-curated map. Each SURVIVING flagged importer seeds the
+    // eject closure by NAME; the collective project-local hidden hoist tree the
+    // linker builds over the ejected set (see `aube_linker::link_hidden_hoist`)
+    // then resolves every undeclared phantom for those members via Node's walk-up,
+    // so no per-importer target hoist is recorded.
     for (dep_path, name, targets) in flags {
         if should_seed(targets, &direct_dep_names(dep_path, graph), is_top_level) {
             seed_names_set.insert(name.as_str());
-            dynamic_targets.insert(dep_path.as_str(), targets.as_slice());
         }
     }
 
@@ -179,69 +182,17 @@ fn plan_from_flags(
         }
     }
 
-    // Rung-2 hoist map: for each closure member that is a surviving dynamically-
-    // flagged importer, resolve its undeclared target(s) to a dep_path present in
-    // the graph and record importer_dep_path → [target_dep_paths]. A survivor is
-    // seeded by name, so its dep_path is in the closure by construction; iterating
-    // the closure keeps this aligned to what actually materializes.
-    let mut hoist_within: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for dep_path in &closure {
-        let Some(targets) = dynamic_targets.get(dep_path.as_str()) else {
-            continue;
-        };
-        let resolved: Vec<String> = targets
-            .iter()
-            .filter_map(|t| resolve_target_dep_path(graph, t))
-            .collect();
-        if !resolved.is_empty() {
-            hoist_within.insert(dep_path.clone(), resolved);
-        }
-    }
-
-    // Rung 2b — SATISFIED optional-peer reachability. An optional peer a package
-    // STATICALLY imports (`vue-router/vite` → `@vue/compiler-sfc`) is a hard
-    // requirement mis-declared optional: the scanner correctly classifies it
-    // DeclaredOptionalPeer (not a hard phantom, so rung-2 never targets it) and
-    // the resolver doesn't thread it into this deep graph, so under GVS the
-    // member's store-resident-or-materialized realpath walk can't reach it. For
-    // each ALREADY-ejected closure member, hoist its optional peers that are
-    // PRESENT in the tree, RANGE-SATISFYING, and NOT already a resolved sibling —
-    // matching pnpm, which links present optional peers down the subtree. Safe by
-    // construction: it only ever RESTORES reachability a hoisted layout would give
-    // (a present, declared, satisfying copy the tree already carries) into a
-    // subtree that already materializes — it never expands the closure and never
-    // places a package the tree lacks. CAVEAT: "free" only while something else
-    // ejects the member (today the Nuxt closure ejects via embedded vite<8.1 + the
-    // `@nuxt/devtools`→`unstorage` phantom); a member that is NOT ejected has no
-    // project-local `node_modules` to hoist into, so a future eject-free layout
-    // would need to SEED the importer (grow the eject set) — out of scope here.
-    for dep_path in &closure {
-        let Some(pkg) = graph.packages.get(dep_path) else {
-            continue;
-        };
-        for (peer_name, meta) in &pkg.peer_dependencies_meta {
-            // A resolved sibling (active-optional / threaded peer mirrored into
-            // `dependencies`) is already reachable — hoisting would duplicate it.
-            if !meta.optional || pkg.dependencies.contains_key(peer_name) {
-                continue;
-            }
-            let range = pkg
-                .peer_dependencies
-                .get(peer_name)
-                .map_or("*", String::as_str);
-            let Some(target) = resolve_satisfying_dep_path(graph, peer_name, range) else {
-                continue;
-            };
-            let entry = hoist_within.entry(dep_path.clone()).or_default();
-            if !entry.contains(&target) {
-                entry.push(target);
-            }
-        }
-    }
-
+    // Undeclared phantoms — every class the retired per-importer hoist used to
+    // place (a scanner-flagged undeclared import; a statically-imported but
+    // optional peer like `vue-router/vite` → `@vue/compiler-sfc`) — are now
+    // resolved uniformly by the linker's collective project-local hidden hoist
+    // tree over the ejected set: each ejected member's realpath is project-local,
+    // so Node's upward walk from inside it passes through `.nub/node_modules/`,
+    // which carries a blanket first-write-wins alias for every graph package.
+    // Detection-free and pnpm-parity, so this planner only needs to grow the
+    // eject set (rung 1) — it records no per-importer target hoist.
     DiskMaterializePlan {
         names: names.into_iter().collect(),
-        hoist_within,
     }
 }
 
@@ -364,7 +315,7 @@ fn should_seed(
 /// it reachable, which let a depth-≥2 phantom target (`@crawlee/basic` →
 /// `@crawlee/core` → `@apify/datastructures`, #280) wrongly SKIP its eject and
 /// break. Depth-≥2 and absent targets now fall through to SEED — the safe
-/// direction (the ejected copy hoists the target in as a real sibling, rung 2).
+/// direction (the ejected copy resolves the target via the collective hidden tree).
 ///
 /// Reads `dependencies` ONLY: per [`LockedPackage`]'s contract that map is the
 /// resolved edge set with ACTIVE optionals and RESOLVED peer versions already
@@ -383,44 +334,6 @@ fn direct_dep_names(root_dep_path: &str, graph: &LockfileGraph) -> HashSet<Strin
         }
     }
     names
-}
-
-/// Resolve a target package NAME to a dep_path present in the graph. `packages`
-/// is a `BTreeMap`, so `.find` yields the lexically-first matching dep_path —
-/// deterministic, and unambiguous for the single-version phantom classes. The
-/// scanner reports targets by name; per-version target dep_paths would need the
-/// scanner to also record the resolved coordinate.
-fn resolve_target_dep_path(graph: &LockfileGraph, target_name: &str) -> Option<String> {
-    graph
-        .packages
-        .iter()
-        .find(|(_, pkg)| pkg.name == target_name)
-        .map(|(dep_path, _)| dep_path.clone())
-}
-
-/// Resolve an optional-peer NAME + its declared RANGE to a PRESENT, range-
-/// satisfying dep_path, picking the HIGHEST satisfying version in the tree
-/// (deterministic; unambiguous for the single-version peer classes this targets).
-/// Uses npm range semantics (`node-semver`, which handles `*`, `||` unions, and
-/// x-ranges), NOT Cargo's. `None` when the peer is absent or no present version
-/// satisfies — so a hoist is only ever recorded for a copy the tree already
-/// carries at a satisfying version.
-fn resolve_satisfying_dep_path(
-    graph: &LockfileGraph,
-    peer_name: &str,
-    range: &str,
-) -> Option<String> {
-    let req = node_semver::Range::parse(range).ok()?;
-    graph
-        .packages
-        .iter()
-        .filter(|(_, pkg)| pkg.name == peer_name)
-        .filter_map(|(dep_path, pkg)| {
-            let v = node_semver::Version::parse(&pkg.version).ok()?;
-            v.satisfies(&req).then(|| (v, dep_path.clone()))
-        })
-        .max_by(|(a, _), (b, _)| a.cmp(b))
-        .map(|(_, dep_path)| dep_path)
 }
 
 #[cfg(test)]
@@ -551,16 +464,16 @@ mod tests {
     fn no_seeds_yields_empty_plan() {
         let g = graph(&[("lodash@4.17.21", "lodash", &[])]);
         let plan = plan_from_flags(&g, &[], &[]);
-        assert!(plan.names.is_empty() && plan.hoist_within.is_empty());
+        assert!(plan.names.is_empty());
     }
 
     #[test]
-    fn dynamic_flag_seeds_importer_and_records_hoist() {
+    fn dynamic_flag_seeds_importer() {
         // The now-default path: a phantom adapter (`@hookform/resolvers`)
-        // statically imports an undeclared `zod`. The target isn't reachable
-        // within the adapter's own subtree, so `should_seed` SEEDS it; rung-2
-        // resolves `zod` to its dep_path and records the hoist into the adapter's
-        // materialized `node_modules`.
+        // statically imports an undeclared `zod`. The target isn't reachable within
+        // the adapter's own subtree, so `should_seed` SEEDS it (ejects it). The
+        // collective hidden tree then resolves the undeclared `zod` at link time —
+        // the planner only needs to grow the eject set, not record a target hoist.
         let g = graph(&[
             ("@hookform/resolvers@1.0.0", "@hookform/resolvers", &[]),
             ("zod@3.0.0", "zod", &[]),
@@ -574,25 +487,19 @@ mod tests {
         let names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
         assert!(
             names.contains("@hookform/resolvers"),
-            "the flagged phantom importer is seeded"
-        );
-        assert_eq!(
-            plan.hoist_within
-                .get("@hookform/resolvers@1.0.0")
-                .map(Vec::as_slice),
-            Some(["zod@3.0.0".to_string()].as_slice()),
-            "rung-2 records the undeclared target's hoist"
+            "the flagged phantom importer is seeded (ejected)"
         );
     }
 
     #[test]
-    fn satisfied_optional_peer_of_closure_member_is_hoisted() {
+    fn optional_peer_host_still_ejects_via_embedded_vite() {
         // Nuxt shape at the planner boundary: vue-router embeds vite<8.1 (so its
         // ancestor-closure ejects) and declares `@vue/compiler-sfc` an OPTIONAL
-        // peer that its `/vite` subpath statically imports. compiler-sfc is present
-        // and satisfies the range, so rung-2b hoists it into vue-router's
-        // materialized `node_modules` — the reachability the store-resident/
-        // materialized realpath walk lacks under GVS (the `nuxt prepare` crash).
+        // peer that its `/vite` subpath statically imports. The eject is what
+        // matters — once vue-router is project-local, the collective hidden tree
+        // resolves the undeclared `@vue/compiler-sfc` for it (the reachability the
+        // store-resident realpath walk lacked under GVS, the `nuxt prepare` crash).
+        // The planner records no per-importer hoist.
         let mut g = graph(&[
             ("vue-router@5.1.0", "vue-router", &[("vite", "7.0.0")]),
             ("vite@7.0.0", "vite", &[]),
@@ -611,56 +518,6 @@ mod tests {
         assert!(
             names.contains("vue-router"),
             "the embedded-vite<8.1 closure ejects vue-router: {names:?}"
-        );
-        assert_eq!(
-            plan.hoist_within.get("vue-router@5.1.0").map(Vec::as_slice),
-            Some(["@vue/compiler-sfc@3.5.39".to_string()].as_slice()),
-            "the satisfied optional peer hoists into the ejected member"
-        );
-    }
-
-    #[test]
-    fn optional_peer_not_hoisted_when_unsatisfied_or_already_linked() {
-        // The three guards, on one ejected member: a present-but-out-of-range peer
-        // (`old-peer@1.0.0` vs `^2`) is not a valid target; an already-resolved
-        // sibling (`linked@1.0.0` in `dependencies`) is already reachable; an
-        // absent peer has no target. None may hoist — so the member gets NO
-        // rung-2b entry, guarding against over-hoisting a peer the tree can't
-        // satisfy or already reaches.
-        let mut g = graph(&[
-            (
-                "host@1.0.0",
-                "host",
-                &[("vite", "7.0.0"), ("linked", "1.0.0")],
-            ),
-            ("vite@7.0.0", "vite", &[]),
-            ("old-peer@1.0.0", "old-peer", &[]),
-            ("linked@1.0.0", "linked", &[]),
-        ]);
-        let host = g.packages.get_mut("host@1.0.0").unwrap();
-        for (name, range) in [
-            ("old-peer", "^2.0.0"), // present but out of range
-            ("linked", "^1.0.0"),   // already a resolved sibling
-            ("absent", "^1.0.0"),   // not in the tree
-        ] {
-            host.peer_dependencies
-                .insert(name.to_string(), range.to_string());
-            host.peer_dependencies_meta.insert(
-                name.to_string(),
-                aube_lockfile::PeerDepMeta { optional: true },
-            );
-        }
-
-        let plan = plan_from_flags(&g, &[], &[]);
-        assert!(
-            names(&["host", "vite"])
-                .is_subset(&plan.names.iter().cloned().collect::<HashSet<String>>()),
-            "host still ejects via the embedded vite<8.1 seed"
-        );
-        assert!(
-            !plan.hoist_within.contains_key("host@1.0.0"),
-            "no satisfied+unlinked+present optional peer → no hoist: {:?}",
-            plan.hoist_within
         );
     }
 
@@ -759,11 +616,12 @@ mod tests {
         // `core`, and `core` declares `datastructures` (depth 2 from `basic`).
         // `basic` phantom-imports `datastructures`, which is NOT a symlinked sibling
         // in `basic`'s own private node_modules under isolated layout, so the
-        // un-ejected copy cannot resolve it — the flag MUST SEED (eject + rung-2
-        // hoist), never skip as "transitively reachable". `datastructures` is absent
-        // from the (empty) project top level, so only the depth fix drives the seed.
-        // FAILS before the fix (multi-hop BFS marks `datastructures` reachable →
-        // SKIP → `basic` absent from the plan); passes after.
+        // un-ejected copy cannot resolve it — the flag MUST SEED (eject), never skip
+        // as "transitively reachable". `datastructures` is absent from the (empty)
+        // project top level, so only the depth fix drives the seed. FAILS before the
+        // fix (multi-hop BFS marks `datastructures` reachable → SKIP → `basic` absent
+        // from the plan); passes after. Once `basic` is ejected the collective hidden
+        // tree resolves the undeclared `datastructures` for it.
         let g = graph(&[
             ("basic@1.0.0", "basic", &[("core", "1.0.0")]),
             ("core@1.0.0", "core", &[("datastructures", "2.0.0")]),
@@ -779,11 +637,6 @@ mod tests {
         assert!(
             names.contains("basic"),
             "depth-2 phantom target must SEED the importer, not skip: {names:?}"
-        );
-        assert_eq!(
-            plan.hoist_within.get("basic@1.0.0").map(Vec::as_slice),
-            Some(["datastructures@2.0.0".to_string()].as_slice()),
-            "rung-2 hoists the depth-2 target into the ejected importer"
         );
     }
 
@@ -804,7 +657,7 @@ mod tests {
         )];
         let plan = plan_from_flags(&g, &[], &flags);
         assert!(
-            plan.names.is_empty() && plan.hoist_within.is_empty(),
+            plan.names.is_empty(),
             "a depth-1-satisfied phantom target stays skipped: {:?}",
             plan.names
         );

--- a/vendor/aube/crates/aube-linker/src/builder.rs
+++ b/vendor/aube/crates/aube-linker/src/builder.rs
@@ -44,7 +44,6 @@ impl Linker {
             no_integrity_read_keys: std::collections::BTreeMap::new(),
             link_progress: None,
             disk_materialize: std::collections::HashSet::new(),
-            phantom_hoist: std::collections::BTreeMap::new(),
         }
     }
 
@@ -61,29 +60,6 @@ impl Linker {
     /// the global-virtual-store link pass; always false when the list is empty.
     pub(crate) fn disk_materialize_matches(&self, pkg_name: &str) -> bool {
         !self.disk_materialize.is_empty() && self.disk_materialize.contains(pkg_name)
-    }
-
-    /// Rung 2 of selective-subtree materialization: the undeclared phantom
-    /// targets to hoist-within each disk-materialized package's `node_modules`,
-    /// keyed by importer dep_path → already-resolved target dep_paths (see the
-    /// `phantom_hoist` field docs on [`Linker`]). Standalone aube and every test
-    /// omit this → the map is empty and the materialize pass is unchanged.
-    pub fn with_phantom_hoist(
-        mut self,
-        map: std::collections::BTreeMap<String, Vec<String>>,
-    ) -> Self {
-        self.phantom_hoist = map;
-        self
-    }
-
-    /// The phantom-hoist targets for the package at `dep_path`, if any. Consulted
-    /// only in the disk-materialize branch of the GVS link pass; `None` when the
-    /// map is empty (the standalone/default path) or the dep_path has no entry.
-    pub(crate) fn phantom_hoist_for(&self, dep_path: &str) -> Option<&[String]> {
-        if self.phantom_hoist.is_empty() {
-            return None;
-        }
-        self.phantom_hoist.get(dep_path).map(Vec::as_slice)
     }
 
     /// Supply a shared counter the materialize pass bumps once per linked

--- a/vendor/aube/crates/aube-linker/src/disk_materialize.rs
+++ b/vendor/aube/crates/aube-linker/src/disk_materialize.rs
@@ -2,21 +2,21 @@
 //! flat seed list into a graph-aware selective-subtree materialization plan.
 //!
 //! Standalone aube installs NO hook, so [`expand_disk_materialize`] returns the
-//! seed verbatim (rung-1 names = the seed, no rung-2 hoist) and the linker's
-//! disk-materialize pass is byte-for-byte unchanged. An embedder (nub) installs
-//! a hook via [`set_disk_materialize_expand_hook`] that consults the resolved
-//! graph to (1) expand each seed to its ancestor-closure — every package that
-//! transitively imports it — so a transitively-consumed package materializes
-//! together with its importers (else a store-resident importer resolves the
-//! un-materialized copy, a silent singleton split), and (2) compute per-package
-//! phantom-target hoists for undeclared imports the closure alone can't place.
+//! seed verbatim (names = the seed) and the linker's disk-materialize pass is
+//! byte-for-byte unchanged. An embedder (nub) installs a hook via
+//! [`set_disk_materialize_expand_hook`] that consults the resolved graph to expand
+//! each seed to its ancestor-closure — every package that transitively imports it
+//! — so a transitively-consumed package materializes together with its importers
+//! (else a store-resident importer resolves the un-materialized copy, a silent
+//! singleton split). Undeclared imports an ejected package makes are resolved by
+//! the linker's collective project-local hidden hoist tree over the ejected set,
+//! not a per-importer hoist.
 //!
 //! The hook receives only `&LockfileGraph` + the seed names and returns a pure
 //! [`DiskMaterializePlan`], so all embedder-specific policy (which packages
 //! seed, the flag gate, vite<8.1 detection) lives in the embedder; aube owns
 //! only the neutral seam and the graph primitive ([`LockfileGraph::importer_closure`]).
 
-use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
 use aube_lockfile::LockfileGraph;
@@ -24,15 +24,14 @@ use aube_lockfile::LockfileGraph;
 /// The materialization plan a [`DmExpandHook`] produces from the resolved graph.
 #[derive(Debug, Default, Clone)]
 pub struct DiskMaterializePlan {
-    /// Rung 1 — the expanded set of package NAMES to disk-materialize
-    /// project-local (the seed UNION its ancestor-closure). Fed to
+    /// The expanded set of package NAMES to disk-materialize project-local (the
+    /// seed UNION its ancestor-closure). Fed to
     /// [`Linker::with_disk_materialize`](crate::Linker::with_disk_materialize),
-    /// matched by exact name, exactly as the raw seed was.
+    /// matched by exact name, exactly as the raw seed was. Undeclared phantoms an
+    /// ejected package imports are resolved by the linker's collective
+    /// project-local hidden hoist tree over this set (see
+    /// [`Linker::link_hidden_hoist`](crate::Linker)), not a per-importer hoist.
     pub names: Vec<String>,
-    /// Rung 2 — undeclared phantom targets to hoist-within a disk-materialized
-    /// package's own `node_modules`, keyed by the importer's dep_path → the
-    /// already-resolved target dep_paths. Empty unless a hook populates it.
-    pub hoist_within: BTreeMap<String, Vec<String>>,
 }
 
 /// A hook that expands a disk-materialize seed into a graph-aware plan. `Send +
@@ -53,15 +52,14 @@ pub fn set_disk_materialize_expand_hook(hook: DmExpandHook) {
 
 /// Expand a disk-materialize `seed` (the resolved `diskMaterializePackages`
 /// names) into a plan against `graph`. With no hook installed — standalone aube,
-/// every test — returns the seed verbatim as rung-1 names with an empty rung-2
-/// map, so the caller's `with_disk_materialize(&plan.names)` is identical to the
-/// pre-existing `with_disk_materialize(&seed)` and nothing else changes.
+/// every test — returns the seed verbatim as the plan names, so the caller's
+/// `with_disk_materialize(&plan.names)` is identical to the pre-existing
+/// `with_disk_materialize(&seed)` and nothing else changes.
 pub fn expand_disk_materialize(graph: &LockfileGraph, seed: &[String]) -> DiskMaterializePlan {
     match DM_EXPAND_HOOK.get() {
         Some(hook) => hook(graph, seed),
         None => DiskMaterializePlan {
             names: seed.to_vec(),
-            hoist_within: BTreeMap::new(),
         },
     }
 }

--- a/vendor/aube/crates/aube-linker/src/lib.rs
+++ b/vendor/aube/crates/aube-linker/src/lib.rs
@@ -265,20 +265,13 @@ pub struct Linker {
     /// Matched by exact name against each graph package. Empty for standalone
     /// callers and every existing test → the GVS pass is byte-for-byte
     /// unchanged.
+    /// Undeclared imports an ejected package makes are resolved by the collective
+    /// project-local hidden hoist tree the linker builds over this whole set under
+    /// GVS (see [`Linker::link_hidden_hoist`]) — each ejected package's realpath is
+    /// project-local, so Node's upward walk from inside it passes through
+    /// `.aube/node_modules/`, a blanket alias for every graph package. That
+    /// replaced the former per-importer phantom-target hoist.
     disk_materialize: std::collections::HashSet<String>,
-    /// Rung 2 of selective-subtree materialization: undeclared phantom targets
-    /// to HOIST-WITHIN a disk-materialized package's own `node_modules`, keyed
-    /// by the importer's dep_path → the target dep_paths. A transitively-phantom
-    /// package (`@nuxt/devtools` → the undeclared `unstorage`, `vue-router` →
-    /// the optional-peer-but-unlinked `@vue/compiler-sfc`) doesn't declare the
-    /// import, so once it's disk-materialized its own `node_modules` has no
-    /// sibling for it and Node's walk still 404s. Injecting the target as an
-    /// extra sibling (reusing the materialize sibling-wiring, so the target
-    /// resolves through its existing `.aube/<entry>`) makes the walk succeed.
-    /// The target must already be resolved in the graph (this is reachability,
-    /// not install). Empty for standalone callers and every existing test → the
-    /// materialize pass is byte-for-byte unchanged.
-    phantom_hoist: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 /// Strategy for linking files from the store to node_modules.

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -1487,6 +1487,33 @@ impl Linker {
     /// cross-project state. Remove any stale shared mirror left by older
     /// linkers and keep the only hidden-hoist tree project-local.
     fn link_hidden_hoist(&self, aube_dir: &Path, graph: &LockfileGraph) -> Result<(), Error> {
+        // GVS active with a non-empty disk-materialize (ejected) subset: each
+        // ejected package is a real project-local directory, so its realpath is
+        // inside the project and Node's upward `node_modules` walk from inside it
+        // passes through `.aube/node_modules/`. Build ONE COLLECTIVE project-local
+        // hidden hoist tree there over the whole graph so any ejected package
+        // resolves any undeclared phantom via that walk — blanket, detection-free,
+        // the pnpm-parity successor to the per-importer `phantom_hoist`. Two
+        // invariants make this sound:
+        //   - #6-safe: the tree lives in the PROJECT (`node_modules/.aube/
+        //     node_modules/`), never the shared store, so its bare-name aliases
+        //     are per-project state — not the cross-project-mutable shared-store
+        //     alias issue #6 forbids (the `Materialization::Symlink` "no hidden
+        //     tree" rule is about the SHARED-store tree; a project-local one is a
+        //     distinct, safe location).
+        //   - leak-free: only the ejected (project-local-realpath) packages reach
+        //     this tree on their walk-up. A symlinked package's realpath is in the
+        //     shared store, so its walk ascends the store, never the project — it
+        //     can NEVER consume this tree. So the ejected subset gets pnpm's
+        //     blanket phantom tolerance while the symlinked majority is untouched.
+        // Standalone aube always has an empty `disk_materialize`, so this branch
+        // is unreachable there and the pass stays byte-for-byte unchanged.
+        if self.use_global_virtual_store && !self.disk_materialize.is_empty() {
+            let packages = self.collect_hidden_hoist_packages(graph, &|_| true);
+            self.write_hidden_hoist_entries(aube_dir, aube_dir, &packages, false, true)?;
+            remove_hidden_hoist_tree(&self.virtual_store.join("node_modules"));
+            return Ok(());
+        }
         self.link_hidden_hoist_at(aube_dir, aube_dir, graph, false, true)?;
         if self.use_global_virtual_store {
             remove_hidden_hoist_tree(&self.virtual_store.join("node_modules"));
@@ -1502,39 +1529,6 @@ impl Linker {
         use_hashed_subdirs: bool,
         sweep_stale_entries: bool,
     ) -> Result<(), Error> {
-        let hidden = hidden_root.join("node_modules");
-        // FxHashSet over the borrowed name (lives for the lockfile graph
-        // lifetime) drops the SipHash overhead and the per-insert
-        // `String` clone the `HashSet<String>` version forced.
-        let mut claimed: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
-        let mut packages = Vec::new();
-        if self.hoist {
-            for direct in graph.root_deps() {
-                let Some(pkg) = graph.packages.get(&direct.dep_path) else {
-                    continue;
-                };
-                if pkg.local_source.is_some() || !self.hoist_matches(&pkg.name) {
-                    continue;
-                }
-                if claimed.insert(pkg.name.as_str()) {
-                    packages.push((direct.dep_path.as_str(), pkg));
-                }
-            }
-            for (dep_path, pkg) in &graph.packages {
-                if pkg.local_source.is_some() || !self.hoist_matches(&pkg.name) {
-                    continue;
-                }
-                // Root direct dependencies reserve their package names
-                // before the deterministic transitive sweep. That matches
-                // pnpm's undeclared-import fallback when the app and a
-                // transitive dependency bring different versions of the
-                // same package into the graph.
-                if claimed.insert(pkg.name.as_str()) {
-                    packages.push((dep_path.as_str(), pkg));
-                }
-            }
-        }
-
         if !self.hoist {
             // Previous install may have populated this tree with
             // hoist=true. Drop entries so Node doesn't keep resolving
@@ -1542,6 +1536,7 @@ impl Linker {
             // hidden hoist owns the whole tree and can remove it in
             // one shot; the shared GVS mirror only reclaims broken
             // entries because live links may belong to another project.
+            let hidden = hidden_root.join("node_modules");
             if sweep_stale_entries {
                 remove_hidden_hoist_tree(&hidden);
             } else {
@@ -1549,6 +1544,70 @@ impl Linker {
             }
             return Ok(());
         }
+        let packages = self.collect_hidden_hoist_packages(graph, &|name| self.hoist_matches(name));
+        self.write_hidden_hoist_entries(
+            hidden_root,
+            source_root,
+            &packages,
+            use_hashed_subdirs,
+            sweep_stale_entries,
+        )
+    }
+
+    /// Select the non-local graph packages to symlink into a hidden hoist tree,
+    /// deduplicated by name with root direct dependencies reserving their name
+    /// before the deterministic transitive sweep — pnpm's undeclared-import
+    /// version choice when the app and a transitive dep bring different versions
+    /// of the same name. `select` is the per-name gate: `hoist_matches` for the
+    /// pattern-driven GVS-off tree, `|_| true` for the blanket collective tree.
+    fn collect_hidden_hoist_packages<'g>(
+        &self,
+        graph: &'g LockfileGraph,
+        select: &dyn Fn(&str) -> bool,
+    ) -> Vec<(&'g str, &'g LockedPackage)> {
+        // FxHashSet over the borrowed name (lives for the lockfile graph
+        // lifetime) drops the SipHash overhead and the per-insert `String`
+        // clone the `HashSet<String>` version forced.
+        let mut claimed: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
+        let mut packages = Vec::new();
+        for direct in graph.root_deps() {
+            let Some(pkg) = graph.packages.get(&direct.dep_path) else {
+                continue;
+            };
+            if pkg.local_source.is_some() || !select(&pkg.name) {
+                continue;
+            }
+            if claimed.insert(pkg.name.as_str()) {
+                packages.push((direct.dep_path.as_str(), pkg));
+            }
+        }
+        for (dep_path, pkg) in &graph.packages {
+            if pkg.local_source.is_some() || !select(&pkg.name) {
+                continue;
+            }
+            if claimed.insert(pkg.name.as_str()) {
+                packages.push((dep_path.as_str(), pkg));
+            }
+        }
+        packages
+    }
+
+    /// Wipe then repopulate a hidden hoist tree at `hidden_root/node_modules/`
+    /// with `<name>` → `<source_root>/<subdir(dep_path)>/node_modules/<name>`
+    /// symlinks. Shared by the pattern-driven `link_hidden_hoist_at` and the
+    /// collective GVS tree. Under GVS the source entry is itself a symlink into
+    /// the shared store, so `<name>` resolves through it to the store copy — a
+    /// project-local alias whose bytes live machine-global, which is exactly
+    /// what a phantom import from an ejected package needs to reach.
+    fn write_hidden_hoist_entries(
+        &self,
+        hidden_root: &Path,
+        source_root: &Path,
+        packages: &[(&str, &LockedPackage)],
+        use_hashed_subdirs: bool,
+        sweep_stale_entries: bool,
+    ) -> Result<(), Error> {
+        let hidden = hidden_root.join("node_modules");
         // Wipe before repopulating so a dependency removed from the
         // graph (or a pattern that no longer matches) doesn't linger.
         // The shared GVS hidden hoist only prunes broken entries:
@@ -1559,7 +1618,7 @@ impl Linker {
         } else {
             sweep_dead_hidden_hoist_entries(&hidden);
         }
-        for (dep_path, pkg) in packages {
+        for &(dep_path, pkg) in packages {
             let source_subdir = if use_hashed_subdirs {
                 self.virtual_store_subdir(dep_path)
             } else {

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -16,21 +16,6 @@ use aube_store::PackageIndex;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-/// Split a resolved dep_path into `(name, dep_path_tail)` — the inverse of the
-/// `format!("{name}@{tail}")` reconstruction used across the graph walk. The
-/// version `@` is the last `@` BEFORE any peer suffix `(...)`, since a peer
-/// suffix can itself contain `@` (`@vue/compiler-sfc@1.2.3(vue@3.4.0)` →
-/// `("@vue/compiler-sfc", "1.2.3(vue@3.4.0)")`). Returns `None` when there is no
-/// version boundary (a bare scope or malformed key), which the caller skips.
-fn split_dep_path_name_tail(dep_path: &str) -> Option<(&str, &str)> {
-    let core_end = dep_path.find('(').unwrap_or(dep_path.len());
-    let at = dep_path[..core_end].rfind('@')?;
-    if at == 0 {
-        return None;
-    }
-    Some((&dep_path[..at], dep_path.get(at + 1..)?))
-}
-
 impl Linker {
     fn without_global_virtual_store(&self) -> Self {
         Self {
@@ -58,7 +43,6 @@ impl Linker {
             no_integrity_read_keys: self.no_integrity_read_keys.clone(),
             link_progress: self.link_progress.clone(),
             disk_materialize: self.disk_materialize.clone(),
-            phantom_hoist: self.phantom_hoist.clone(),
         }
     }
 
@@ -429,40 +413,18 @@ impl Linker {
                                     let _ = std::fs::remove_dir(&local_aube_entry)
                                         .or_else(|_| std::fs::remove_file(&local_aube_entry));
                                 }
-                                // Rung 2 (selective-subtree): if this package has
-                                // undeclared phantom targets to hoist-within,
-                                // materialize the PROJECT-LOCAL copy with those
-                                // targets added as extra dependency edges.
-                                // `materialize_into`'s sibling-wiring then creates
-                                // `<P>/node_modules/<T>` → the target's existing
-                                // `.aube/<entry>`, so P's undeclared import
-                                // resolves. Applied ONLY here (the project-local
-                                // copy) — the shared-store copy written above keeps
-                                // the original edges, since the hoist is
-                                // project-specific and the store is cross-project.
-                                let hoisted_pkg;
-                                let pkg_for_local = match self.phantom_hoist_for(dep_path) {
-                                    Some(targets) if !targets.is_empty() => {
-                                        let mut p = pkg.clone();
-                                        for target in targets {
-                                            if let Some((name, tail)) =
-                                                split_dep_path_name_tail(target)
-                                            {
-                                                p.dependencies
-                                                    .entry(name.to_string())
-                                                    .or_insert_with(|| tail.to_string());
-                                            }
-                                        }
-                                        hoisted_pkg = p;
-                                        &hoisted_pkg
-                                    }
-                                    _ => pkg,
-                                };
+                                // Undeclared imports this ejected package makes are
+                                // resolved by the collective project-local hidden
+                                // hoist tree (built in `link_hidden_hoist` over the
+                                // whole ejected set) — its realpath is project-local,
+                                // so Node's upward walk from inside it reaches
+                                // `.aube/node_modules/`. So materialize the copy with
+                                // its own edges; no per-importer sibling injection.
                                 self.materialize_into(
                                     &aube_dir,
                                     &aube_dir,
                                     dep_path,
-                                    pkg_for_local,
+                                    pkg,
                                     index,
                                     &mut local_stats,
                                     false,
@@ -1493,8 +1455,8 @@ impl Linker {
         // passes through `.aube/node_modules/`. Build ONE COLLECTIVE project-local
         // hidden hoist tree there over the whole graph so any ejected package
         // resolves any undeclared phantom via that walk — blanket, detection-free,
-        // the pnpm-parity successor to the per-importer `phantom_hoist`. Two
-        // invariants make this sound:
+        // pnpm-parity, and the SOLE phantom-resolution mechanism (it replaced the
+        // former per-importer phantom-target hoist). Two invariants make this sound:
         //   - #6-safe: the tree lives in the PROJECT (`node_modules/.aube/
         //     node_modules/`), never the shared store, so its bare-name aliases
         //     are per-project state — not the cross-project-mutable shared-store

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -582,6 +582,160 @@ fn disk_materialize_keeps_store_copy_so_store_resident_dependents_dont_orphan() 
     );
 }
 
+/// Graph where the root declares `foo` and `bar` as siblings and `foo` declares
+/// NOTHING — so `bar` is a pure phantom target of `foo` (foo imports it without
+/// declaring it). Reuses the foo@1.0.0 / bar@2.0.0 store indices from
+/// `setup_store_with_files`.
+fn make_graph_phantom() -> LockfileGraph {
+    let mut packages = BTreeMap::new();
+    packages.insert(
+        "foo@1.0.0".to_string(),
+        LockedPackage {
+            name: "foo".to_string(),
+            version: "1.0.0".to_string(),
+            dependencies: BTreeMap::new(),
+            dep_path: "foo@1.0.0".to_string(),
+            ..Default::default()
+        },
+    );
+    packages.insert(
+        "bar@2.0.0".to_string(),
+        LockedPackage {
+            name: "bar".to_string(),
+            version: "2.0.0".to_string(),
+            dependencies: BTreeMap::new(),
+            dep_path: "bar@2.0.0".to_string(),
+            ..Default::default()
+        },
+    );
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        vec![
+            DirectDep {
+                name: "foo".to_string(),
+                dep_path: "foo@1.0.0".to_string(),
+                dep_type: DepType::Production,
+                specifier: None,
+            },
+            DirectDep {
+                name: "bar".to_string(),
+                dep_path: "bar@2.0.0".to_string(),
+                dep_type: DepType::Production,
+                specifier: None,
+            },
+        ],
+    );
+    LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn collective_hidden_hoist_over_ejected_set_resolves_undeclared_phantom_under_gvs() {
+    // The collective project-local hidden hoist tree. Under GVS an ejected
+    // (disk-materialized) package is a real project-local dir, so Node's upward
+    // node_modules walk from inside it passes through `.aube/node_modules/`.
+    // Building that tree over the graph lets the ejected `foo` resolve its
+    // UNDECLARED phantom `bar` (a sibling at the project root here) via the
+    // walk-up — the detection-free, blanket successor to per-importer hoisting.
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let (store, indices) = setup_store_with_files(dir.path());
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
+        .with_hoist(false)
+        .with_disk_materialize(&["foo".to_string()]);
+
+    linker
+        .link_all(&project_dir, &make_graph_phantom(), &indices)
+        .unwrap();
+
+    // foo is ejected: a real project-local dir (its realpath is in the project,
+    // so its walk-up reaches `.aube/node_modules/`).
+    let aube_foo = project_dir.join("node_modules/.aube/foo@1.0.0");
+    assert!(
+        !aube_foo
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "disk-materialized foo must be a real project-local dir"
+    );
+
+    // The collective hidden tree exists and carries the phantom target `bar`,
+    // resolving all the way to bar's content — so foo's undeclared `require('bar')`
+    // succeeds via the walk-up. foo lists itself in the blanket tree too.
+    let hidden = project_dir.join("node_modules/.aube/node_modules");
+    assert!(
+        hidden.join("bar").symlink_metadata().unwrap().is_symlink(),
+        "collective tree must carry the phantom target bar"
+    );
+    assert_eq!(
+        std::fs::read_to_string(hidden.join("bar/index.js")).unwrap(),
+        "module.exports = 'bar';",
+        "the phantom target resolves to bar's real content through the tree"
+    );
+    assert!(
+        hidden.join("foo").symlink_metadata().unwrap().is_symlink(),
+        "the blanket collective tree lists every non-local package, incl. foo"
+    );
+
+    // #6 safety: the tree is project-local ONLY — the shared store carries no
+    // hidden tree (its bare-name aliases would be cross-project-mutable state).
+    assert!(
+        store
+            .virtual_store_dir()
+            .join("node_modules")
+            .symlink_metadata()
+            .is_err(),
+        "no hidden hoist tree may live in the shared global store (#6)"
+    );
+
+    // Isolation: bar stays a shared-store symlink (its realpath escapes the
+    // project), so bar's own walk-up ascends the store and never reaches this
+    // project-local tree — only the ejected foo consumes it.
+    assert!(
+        project_dir
+            .join("node_modules/.aube/bar@2.0.0")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the symlinked majority (bar) stays a shared-store symlink, off this walk-up"
+    );
+}
+
+#[test]
+fn no_collective_hidden_hoist_when_ejected_set_empty_under_gvs() {
+    // The collective tree is gated on a non-empty disk-materialize (ejected)
+    // set. With none, plain GVS has no project-local-realpath consumer, so no
+    // tree is built — the pass stays byte-for-byte the swept-empty behavior
+    // (and standalone aube, whose disk-materialize is always empty, is
+    // unaffected).
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let (store, indices) = setup_store_with_files(dir.path());
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true).with_hoist(false);
+
+    linker
+        .link_all(&project_dir, &make_graph(), &indices)
+        .unwrap();
+
+    assert!(
+        project_dir
+            .join("node_modules/.aube/node_modules")
+            .symlink_metadata()
+            .is_err(),
+        "no collective tree without an ejected set"
+    );
+}
+
 #[test]
 fn test_link_file_fresh_reports_missing_cas_shard_and_invalidates_cache() {
     // Reproduces jdx/aube#393: a partially corrupt CAS leaves the

--- a/vendor/aube/crates/aube/src/commands/install/gvs.rs
+++ b/vendor/aube/crates/aube/src/commands/install/gvs.rs
@@ -59,15 +59,16 @@ pub(super) fn planned_global_virtual_store(
         .unwrap_or_else(|| !env_snapshot.iter().any(|(k, _)| k == "CI"))
 }
 
-/// How each isolated-layout `.aube/<dep_path>` entry is materialized on disk.
+/// How the isolated-layout `.aube/<dep_path>` entries are materialized on disk —
+/// a flat three-valued decision.
 ///
 /// Makes the "hidden hoist tree inside the SHARED global store" state
 /// UNREPRESENTABLE (aube issue #6: a bare-name alias inside the shared store is
-/// cross-project-mutable, so a live shared store must never carry one). The
-/// hidden tree is a field only of [`Disk`](Materialization::Disk) — the
-/// project-local real-directory materialization; [`Symlink`](Materialization::Symlink),
-/// which points into the shared store, carries none by construction. This
-/// replaces the former loose `(effective_gvs, build_hidden_tree)` bool pair,
+/// cross-project-mutable, so a live shared store must never carry one): there is
+/// simply no `Symlink`-with-hidden-tree variant. Only the project-local disk
+/// materialization carries the hidden tree, split into two flat sibling variants
+/// (with / without) rather than the former `Disk { hidden_tree: bool }` nesting.
+/// This replaces the former loose `(effective_gvs, build_hidden_tree)` bool pair,
 /// whose `(true, true)` combination was a representable contradiction.
 ///
 /// The write METHOD ([`aube_linker::LinkStrategy`] = `package-import-method`)
@@ -75,15 +76,24 @@ pub(super) fn planned_global_virtual_store(
 /// already-orthogonal axes resolved independently — this type is only the
 /// symlink-vs-disk × hidden-tree decision the `gvs_over_default_hoist` +
 /// `hoist` + `enableGlobalVirtualStore` tangle used to fold into two bools.
+///
+/// (Orthogonal to this type, under GVS the linker still builds a COLLECTIVE
+/// project-local hidden hoist tree over the disk-materialized ejected SUBSET —
+/// see [`aube_linker::Linker::link_hidden_hoist`]. That tree is gated on the
+/// ejected set, not on this enum, and is #6-safe for the same project-local
+/// reason; the [`Symlink`](Self::Symlink) "no hidden tree" here is about the
+/// pnpm-parity whole-graph tree, which the shared store cannot carry.)
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum Materialization {
     /// Symlink into the shared global virtual store; files live machine-global.
-    /// A hidden hoist tree can't live in a shared store, so there is none.
+    /// The whole-graph hidden hoist tree can't live in a shared store, so there
+    /// is none of it under this variant.
     Symlink,
-    /// Project-local real directories (reflink/hardlink/copy from the CAS).
-    /// `hidden_tree` builds the pnpm-parity `node_modules/.<store>/node_modules/`
-    /// hidden hoist fallback.
-    Disk { hidden_tree: bool },
+    /// Project-local real directories (reflink/hardlink/copy from the CAS) WITH
+    /// the pnpm-parity `node_modules/.<store>/node_modules/` hidden hoist tree.
+    DiskWithHiddenTree,
+    /// Project-local real directories WITHOUT the hidden hoist tree.
+    DiskNoHiddenTree,
 }
 
 impl Materialization {
@@ -117,10 +127,10 @@ impl Materialization {
         };
         if isolated && planned_gvs && !hoist_vetoes_store {
             Self::Symlink
+        } else if resolved_hoist {
+            Self::DiskWithHiddenTree
         } else {
-            Self::Disk {
-                hidden_tree: resolved_hoist,
-            }
+            Self::DiskNoHiddenTree
         }
     }
 
@@ -130,10 +140,11 @@ impl Materialization {
         matches!(self, Self::Symlink)
     }
 
-    /// Whether the isolated linker builds the hidden hoist tree. Never true
-    /// under [`Symlink`](Self::Symlink) — the constraint that motivates the type.
+    /// Whether the isolated linker builds the pnpm-parity whole-graph hidden hoist
+    /// tree. Never true under [`Symlink`](Self::Symlink) — the constraint that
+    /// motivates the type.
     pub(super) fn build_hidden_tree(self) -> bool {
-        matches!(self, Self::Disk { hidden_tree: true })
+        matches!(self, Self::DiskWithHiddenTree)
     }
 }
 
@@ -330,7 +341,7 @@ mod tests {
         // per-project + hidden tree, even off-CI.
         assert_eq!(
             Materialization::resolve(true, true, true, Some(true), NodeLinker::Isolated),
-            Materialization::Disk { hidden_tree: true }
+            Materialization::DiskWithHiddenTree
         );
     }
 

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -169,12 +169,13 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     let disk_materialize_packages =
         aube_settings::resolved::disk_materialize_packages(settings_ctx);
     // Embedder-pluggable expansion (selective-subtree materialization): a host
-    // (nub) installs a hook that expands the flat seed into a graph-aware plan —
-    // rung 1 grows each seed to its ancestor-closure so a transitively-consumed
-    // package materializes with its importers (no store-resident-consumer split);
-    // rung 2 adds per-package undeclared-phantom-target hoists. Standalone aube
-    // installs no hook, so the plan is the seed verbatim with no hoist —
-    // byte-for-byte the prior behavior.
+    // (nub) installs a hook that expands the flat seed into a graph-aware plan,
+    // growing each seed to its ancestor-closure so a transitively-consumed package
+    // materializes with its importers (no store-resident-consumer split).
+    // Undeclared imports an ejected package makes are then resolved by the linker's
+    // collective project-local hidden hoist tree over the ejected set. Standalone
+    // aube installs no hook, so the plan is the seed verbatim — byte-for-byte the
+    // prior behavior.
     let dm_plan = aube_linker::expand_disk_materialize(graph_for_link, &disk_materialize_packages);
 
     let mut linker = aube_linker::Linker::new(store, strategy)
@@ -201,8 +202,7 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
             cwd,
             graph_for_link.packages.values(),
         ))
-        .with_disk_materialize(&dm_plan.names)
-        .with_phantom_hoist(dm_plan.hoist_within);
+        .with_disk_materialize(&dm_plan.names);
     if let Some(enabled) = use_global_virtual_store_override {
         linker = linker.with_use_global_virtual_store(enabled);
     }


### PR DESCRIPTION
## Collective project-local hidden hoist tree — the sole phantom mechanism under GVS

Under the global virtual store, most packages are symlinks into the machine-global shared store, so their realpath escapes the project. The disk-materialized (ejected) subset is the exception: those are real project-local directories, so Node's upward `node_modules` walk from inside an ejected package passes through `node_modules/.nub/node_modules/`. Before this change that tree was always swept under GVS, so an ejected package could only resolve an undeclared phantom that a per-importer mechanism specifically detected and placed as an extra sibling.

This builds one collective project-local hidden hoist tree at `node_modules/.nub/node_modules/` over the whole graph (blanket, first-write-wins by name — pnpm's undeclared-import version choice) whenever GVS is active and the ejected set is non-empty. Any ejected package then resolves any undeclared phantom via the walk-up — detection-free.

Because the collective tree covers every undeclared phantom for the ejected set, the per-importer hoist is now redundant, and this PR **removes it entirely** — it is the sole phantom-resolution mechanism under GVS.

### What this removes

- The per-importer phantom-hoist (`hoist_within`) — both the scanner-flagged undeclared-target rung and the optional-peer rung added in #350. The linker's `phantom_hoist` field, `with_phantom_hoist`, `phantom_hoist_for`, and the sibling-injection in the disk-materialize branch all go; `DiskMaterializePlan` carries `names` only.
- In nub's disk-materialize hook (`phantom_closure.rs`), the planner now only grows the eject set (the ancestor-closure). The rung-2 target map, the rung-2b optional-peer loop, and the `resolve_target_dep_path` / `resolve_satisfying_dep_path` helpers are gone.

### Materialization enum flattened

The materialization decision was `Symlink | Disk { hidden_tree: bool }` — a nested bool. It is now three flat sibling variants: `Symlink | DiskWithHiddenTree | DiskNoHiddenTree`. The illegal shared-store-with-hidden-tree state stays unrepresentable (there is no `Symlink`-with-tree variant), without the nesting. `resolve()`, `uses_shared_store()`, and `build_hidden_tree()` keep their exact semantics.

### Why it is safe

- **Not aube issue #6.** #6 forbids the hidden tree at the shared machine-global store root, where a bare-name alias is cross-project-mutable. This tree is project-local — its aliases are per-project, so that collision cannot occur. The shared-store tree is still purged.
- **Leak-free.** Only ejected (project-local-realpath) packages reach the tree on their walk-up. A symlinked package's realpath is in the shared store, so its walk ascends the store and never the project — it can never consume the tree. Verified empirically (vue-ts: all 5 ejected realpaths project-local; all 44 symlinked realpaths escape the project).
- **No worse than pnpm.** pnpm's GVS-off hidden tree is this same blanket tree, on the walk-up of every package. Here only the ejected subset sees it, so the behavior is a strict subset of pnpm's.
- **Standalone aube unchanged.** `disk_materialize` is empty for standalone aube and every existing test, so the new branch is unreachable there — the pass is byte-for-byte identical.

### Verification

Nuxt 4 under GVS, with the per-importer mechanism removed: `nub install` rc=0, `nuxt prepare` rc=0, `nuxt dev` HTTP 200 (SSR). vue-router's own `@vue/compiler-sfc` sibling is absent (mechanism gone); `.nub/node_modules/@vue/compiler-sfc` is present and used — the exact case #350 patched per-importer, now covered by the collective tree alone.

Framework corpus, all green with the per-importer mechanism removed, zero regressions:

| project | install | dev | build | preview | collective tree |
|---|---|---|---|---|---|
| nuxt4 | ok | 200 | ok | — | built |
| vue-ts | ok | 200 | ok | 200 | 33 entries |
| vitepress | ok | 200 | ok | — | 77 entries |
| sveltekit | ok | 200 | ok | — | 47 entries |
| react-ts | ok | 200 | ok | 200 | none (ejected set empty) |
| astro-min | ok | 200 | ok | 200 | none (ejected set empty) |

The tree is a strict no-op where nothing ejects (react-ts, astro-min).

Refs #350.

https://claude.ai/code/session_01UVBNLm9SkJGM8P8K6jnKLJ
