### PR TITLE
docs: env-file mode is selected by --env/APP_ENV, not NODE_ENV

### DIFF
--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -35,7 +35,7 @@ Running `nub <file>` is flag-for-flag compatible with `node <file>` — same arg
 - **TypeScript first** — full TS surface, not just type stripping (enums, namespaces, parameter properties, decorators, `import =` / `export =`, extensionless `.ts` imports, inline source maps)
 - **Respects `tsconfig.json`** — `paths`, `baseUrl`, `extends` chains, `jsx` all applied at runtime
 - **JSX support** — `.jsx` / `.tsx` files execute directly, runtime sourced from `compilerOptions.jsx` / `jsxImportSource`
-- **Env files** — `.env` and `.env.${NODE_ENV}` loaded eagerly with Vite-compatible precedence
+- **Env files** — `.env` and `.env.[mode]` (mode from `--env` / `APP_ENV`) loaded eagerly with Vite-compatible precedence
 - **YAML / TOML / JSON5 / JSONC / text loaders** — `import config from "./config.yaml"` works the way `import data from "./data.json"` already does
 - **Automatic polyfills** — `Temporal`, `URLPattern`, browser-shape `Worker`, WinterTC gap globals, version-detected and feature-gated
 - **Unflagged experimentals** — `EventSource`, `WebSocket`, `localStorage` / `sessionStorage`, `vm.Module`, `node:sqlite` — flags Node already ships but keeps gated, auto-injected in exact per-version bands where each is still behind `--experimental-*`
@@ -165,16 +165,16 @@ For restart-on-change, yes: `nub watch script.ts` (or `nub --watch script.ts`) r
 Not needed. Nub loads your env files automatically — with the Vite/Bun-style precedence rules — and injects them into the process environment *before* Node starts:
 
 ```text
-.env
+.env.[mode].local
 .env.local
-.env.<NODE_ENV>
-.env.<NODE_ENV>.local
+.env.[mode]
+.env
 ```
 
-Expansion of `${VAR}` and `$VAR` is supported, including nested references and cycle detection.
+The `[mode]` slot comes from `--env <mode>` or `APP_ENV` — not `NODE_ENV`. Expansion of `${VAR}` and `$VAR` is supported, including nested references and cycle detection.
 
-<Callout title="NODE_ENV=test">
-Under `NODE_ENV=test`, `.env.local` is skipped, following the Next.js convention — local secrets shouldn't leak into your test suite.
+<Callout title="Test mode">
+Under the test mode (`--env test` or `APP_ENV=test`), `.env.local` is skipped, following the Next.js convention — local secrets shouldn't leak into your test suite.
 </Callout>
 
 Full details: [Runtime → Environment variables](/docs/runtime/env).

--- a/site/content/docs/watch.mdx
+++ b/site/content/docs/watch.mdx
@@ -42,7 +42,7 @@ Restarting 'src/server.ts'
 The watch set is loader-instrumented, not glob-based: `nub watch` only watches files that were actually loaded as part of the run, plus a small set of off-graph files that invalidate the process when they change. Concretely, a restart fires on a change to:
 
 - Any file in the **resolved dependency graph** of the entry — including `.ts` / `.tsx` files transpiled in-memory through `module.registerHooks()` that Node never sees on disk.
-- Your **`.env*` files** in their normal precedence (`.env`, `.env.local`, `.env.<NODE_ENV>`, …) — these are read once at boot and aren't in any import graph, so Nub reports them to the watcher explicitly.
+- Your **`.env*` files** in their normal precedence (`.env`, `.env.local`, `.env.[mode]`, …) — these are read once at boot and aren't in any import graph, so Nub reports them to the watcher explicitly.
 - The **`tsconfig.json` extends chain** — editing a tsconfig (for example, changing a `paths` mapping) restarts the process even though tsconfig isn't imported by anything.
 - **`package.json`**.
 


### PR DESCRIPTION
Sweep the shipped docs for stale references implying `NODE_ENV` selects `.env.{mode}` files, following the breaking change in #351 (mode is now `--env <mode>` > `APP_ENV`, and `NODE_ENV` is never read to pick an env file).

`runtime/env.mdx` was already updated on main. This fixes the two remaining shipped pages:

- **faq.mdx** — the "How is it different from plain `node`?" env bullet showed `.env.${NODE_ENV}`; the "dotenv-cli" file list showed `.env.<NODE_ENV>` / `.env.<NODE_ENV>.local`; the test callout read `NODE_ENV=test`. Now `.env.[mode]` driven by `--env` / `APP_ENV`, with a "Test mode" callout.
- **watch.mdx** — the restart-trigger precedence list showed `.env.<NODE_ENV>`; now `.env.[mode]`.

Every remaining `NODE_ENV` mention in the docs is legitimate (it states NODE_ENV is *not* the selector, or describes the ignore-and-warn behavior when a `.env` file assigns it).

Refs #351