### PR TITLE
feat(pm): accept `update <pkg>@<version>` and `add --lockfile-only` (pnpm-compat)

### DIFF
--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -278,10 +278,120 @@ fn update_latest_moves_the_manifest_and_lockfile_forward() {
         manifest.contains("3.1.0"),
         "--latest must rewrite the manifest past the pin: {manifest}"
     );
-    let lock = std::fs::read_to_string(dir.join("pnpm-lock.yaml")).unwrap();
+    // Fresh project with no incumbent lockfile → nub writes its neutral
+    // nub.lock; a project already on pnpm-lock.yaml keeps that.
+    let lock = std::fs::read_to_string(dir.join("nub.lock"))
+        .or_else(|_| std::fs::read_to_string(dir.join("pnpm-lock.yaml")))
+        .expect("update must write a lockfile");
     assert!(
         lock.contains("3.1.0") && !lock.contains("is-positive@3.0.0"),
         "the lockfile must resolve the updated version: {lock}"
+    );
+}
+
+/// `nub up <pkg>@<version>` pins the named dep to that version, preserving
+/// the manifest's existing range operator (`^3.0.0` + `is-positive@3.1.0` ->
+/// `^3.1.0`) — matching `pnpm update <pkg>@<version>`. The pre-fix engine
+/// rejected any non-`latest` spec here.
+#[test]
+#[ignore = "network: resolves is-positive from the npm registry"]
+fn update_pins_named_version_preserving_manifest_operator() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("updatepin");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"updatepin","version":"1.0.0","dependencies":{"is-positive":"^3.0.0"}}"#,
+    )
+    .unwrap();
+
+    let up = run_nub(&dir, &["up", "is-positive@3.1.0"]);
+    assert_eq!(up.code, 0, "stdout: {}\nstderr: {}", up.stdout, up.stderr);
+    up.assert_brand_clean();
+    let manifest = std::fs::read_to_string(dir.join("package.json")).unwrap();
+    assert!(
+        manifest.contains("\"is-positive\": \"^3.1.0\""),
+        "the caret operator must be preserved on the pinned version: {manifest}"
+    );
+    // Fresh project with no incumbent lockfile → nub writes its neutral
+    // nub.lock; a project already on pnpm-lock.yaml keeps that.
+    let lock = std::fs::read_to_string(dir.join("nub.lock"))
+        .or_else(|_| std::fs::read_to_string(dir.join("pnpm-lock.yaml")))
+        .expect("update must write a lockfile");
+    assert!(
+        lock.contains("3.1.0") && !lock.contains("is-positive@3.0.0"),
+        "the lockfile must resolve the pinned version: {lock}"
+    );
+}
+
+/// `nub up <pkg>@<protocol-spec>` (npm alias, `link:`, `file:`, git, a
+/// tarball URL, a non-`latest` dist-tag) is rejected up front with a
+/// non-zero exit and the manifest left untouched — pinning one of those
+/// into a semver slot would silently corrupt package.json. The rejection
+/// is a pre-flight, so this needs no network.
+#[test]
+fn update_rejects_non_semver_specs_without_touching_the_manifest() {
+    let dir = pm_tmpdir("updatereject");
+    let manifest_src =
+        r#"{"name":"updatereject","version":"1.0.0","dependencies":{"is-odd":"^3.0.0"}}"#;
+    for spec in [
+        "is-odd@npm:is-even@1.0.0",
+        "is-odd@link:../bar",
+        "is-odd@file:./bar",
+        "is-odd@github:a/b",
+        "is-odd@https://example.com/is-odd.tgz",
+        "is-odd@next",
+    ] {
+        std::fs::write(dir.join("package.json"), manifest_src).unwrap();
+        let out = run_nub(&dir, &["up", spec]);
+        assert_ne!(out.code, 0, "`{spec}` must be rejected: {}", out.combined());
+        out.assert_brand_clean();
+        let after = std::fs::read_to_string(dir.join("package.json")).unwrap();
+        assert_eq!(
+            after, manifest_src,
+            "a rejected `{spec}` must leave package.json byte-identical"
+        );
+    }
+}
+
+/// `nub add <pkg>@<version> --lockfile-only` resolves and writes the
+/// lockfile + manifest but never links `node_modules` — the grammar the
+/// pre-fix `add` rejected outright (`unexpected argument '--lockfile-only'`).
+#[test]
+#[ignore = "network: resolves is-positive from the npm registry"]
+fn add_lockfile_only_writes_lockfile_without_linking_node_modules() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("addlockonly");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"addlockonly","version":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let add = run_nub(&dir, &["add", "is-positive@3.1.0", "--lockfile-only"]);
+    assert_eq!(
+        add.code, 0,
+        "stdout: {}\nstderr: {}",
+        add.stdout, add.stderr
+    );
+    add.assert_brand_clean();
+    let manifest = std::fs::read_to_string(dir.join("package.json")).unwrap();
+    assert!(
+        manifest.contains("is-positive"),
+        "add must still persist the dependency to package.json: {manifest}"
+    );
+    assert!(
+        dir.join("nub.lock").exists() || dir.join("pnpm-lock.yaml").exists(),
+        "the lockfile must be written"
+    );
+    assert!(
+        !dir.join("node_modules/is-positive").exists(),
+        "--lockfile-only must skip linking node_modules"
     );
 }
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -288,6 +288,8 @@ nub add -w <pkg>               # write to the workspace root
 nub add --save-catalog <pkg>   # add into the workspace catalog
 nub add --allow-build=<pkg>    # pre-approve its build scripts for this install
 nub add --no-save <pkg>        # link without persisting to package.json
+nub add <pkg>@<version>        # pin an exact version
+nub add <pkg>@<version> --lockfile-only  # refresh the lockfile, skip node_modules
 ```
 
 ### `nub remove`
@@ -308,6 +310,7 @@ Re-resolves dependencies within their ranges; `--latest` rewrites the `package.j
 ```bash
 nub update                 # up — refresh all deps within range
 nub update <pkg>           # update a single dependency
+nub update <pkg>@<version> # pin one dep to a version, keeping its ^/~ operator
 nub update -L              # --latest: move past the manifest range
 nub update -E -L           # pin the rewritten range to an exact version
 nub update -D              # devDependencies only

--- a/vendor/aube/crates/aube/src/commands/add/filtered.rs
+++ b/vendor/aube/crates/aube/src/commands/add/filtered.rs
@@ -82,6 +82,8 @@ pub(super) async fn run(
         // See the sibling `aube add` codepath for why this flag is set:
         // live OSV API on the resolved transitives.
         install_opts.osv_transitive_check = true;
+        // `--lockfile-only`: write the lockfile + manifests, skip linking.
+        install_opts.lockfile_only = args.lockfile_only;
         install::run(install_opts).await?;
         Ok(())
     }

--- a/vendor/aube/crates/aube/src/commands/add/global.rs
+++ b/vendor/aube/crates/aube/src/commands/add/global.rs
@@ -184,6 +184,10 @@ async fn run_global_inner(
         // of the check here keeps `aube add -g` robust against that
         // regression without relying on the chdir-ordering invariant.
         ignore_workspace_root_check: true,
+        // Global installs always link into the global store; a
+        // lockfile-only global add makes no sense, so the synthetic
+        // inner add never sets it.
+        lockfile_only: false,
         workspace: false,
         save_catalog: false,
         save_catalog_name: None,

--- a/vendor/aube/crates/aube/src/commands/add/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/add/mod.rs
@@ -92,6 +92,18 @@ pub struct AddArgs {
     /// Skip lifecycle scripts (no-op; aube already skips by default).
     #[arg(long, hide = true)]
     pub ignore_scripts: bool,
+    /// Resolve and write the lockfile (and `package.json`), but skip
+    /// linking `node_modules`.
+    ///
+    /// The manifest still gains the new dependency and the lockfile is
+    /// updated to match; only the on-disk `node_modules` link pass is
+    /// skipped. Mirrors `pnpm add --lockfile-only` — handy for tooling
+    /// (Dependabot and friends) that only needs the lockfile refreshed.
+    // Declared here (between `--ignore-scripts` and `--no-save`) to keep
+    // the default-heading long-only flags alphabetically ordered, which
+    // `cli_ordering_tests::test_cli_ordering` enforces.
+    #[arg(long, conflicts_with = "no_save")]
+    pub lockfile_only: bool,
     /// Install without persisting the dependency to `package.json`.
     ///
     /// Snapshots `package.json` and the lockfile, links the named
@@ -211,6 +223,7 @@ pub async fn run(
         ignore_scripts: _,
         no_save,
         ignore_workspace_root_check,
+        lockfile_only,
         save_catalog,
         save_catalog_name,
         allow_build,
@@ -400,6 +413,9 @@ pub async fn run(
     let mut install_opts =
         install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Fix));
     install_opts.osv_transitive_check = true;
+    // `--lockfile-only`: the resolver still runs and the lockfile +
+    // manifest are written, but the linker never touches `node_modules`.
+    install_opts.lockfile_only = lockfile_only;
     let pipeline_result: miette::Result<()> = install::run(install_opts).await;
 
     // 5. Under `--no-save`, restore the snapshotted `package.json` and

--- a/vendor/aube/crates/aube/src/commands/update.rs
+++ b/vendor/aube/crates/aube/src/commands/update.rs
@@ -141,20 +141,30 @@ pub async fn run(
         return run_filtered(args, &filter).await;
     }
     reject_unsupported_pkg_specs(&args.packages)?;
-    // Parse `<pkg>@<spec>` arg syntax. Today only `@latest` is honored —
-    // it's the syntactic equivalent of `--latest` scoped to that one
-    // entry, which is how pnpm phrases the manifest-rewrite-past-range
-    // case (`pnpm update foo@latest`). Non-`latest` specs are rejected
-    // by `reject_unsupported_pkg_specs` above so they don't silently
-    // get swallowed.
-    let mut explicit_latest_keys: BTreeSet<String> = BTreeSet::new();
+    // Parse `<pkg>@<spec>` arg syntax into a per-key target spec. A
+    // concrete version or range (`foo@3.0.1`, `foo@~2`) pins the named
+    // entry to that spec (`pnpm update foo@3.0.1`); `@latest` is the
+    // dist-tag bump-past-range case (`pnpm update foo@latest`). Both are
+    // honored by injecting the spec as the resolver range for that key
+    // below, then gluing the manifest's existing operator back onto the
+    // resolved version — so `^3.0.0` + `foo@3.0.1` yields `^3.0.1`,
+    // matching pnpm (the arg's own operator, if any, is discarded). The
+    // `latest` dist-tag is just one possible spec value; the separate
+    // `--latest` FLAG (`args.latest`, whole-project scope) keeps its
+    // own `preserve_pin` downgrade guard below.
+    let mut explicit_specs: BTreeMap<String, String> = BTreeMap::new();
     let parsed_packages: Vec<String> = args
         .packages
         .iter()
         .map(|raw| {
             let (name, spec) = split_pkg_arg(raw);
-            if spec == Some("latest") {
-                explicit_latest_keys.insert(name.to_string());
+            // A concrete `<spec>` pins the entry; an empty spec (`foo@`)
+            // is pnpm's bare in-range update, so leave it unmapped and it
+            // flows the same path as bare `foo`.
+            if let Some(s) = spec
+                && !s.is_empty()
+            {
+                explicit_specs.insert(name.to_string(), s.to_string());
             }
             name.to_string()
         })
@@ -163,10 +173,11 @@ pub async fn run(
     let latest = args.latest;
     let no_save = args.no_save;
     // `--latest` flag triggers manifest rewrites for every direct dep;
-    // `<pkg>@latest` triggers it only for that one entry. Combine them
-    // into a per-key predicate so the same code path serves both.
-    let effective_latest = latest || !explicit_latest_keys.is_empty();
-    let should_rewrite_key = |key: &str| -> bool { latest || explicit_latest_keys.contains(key) };
+    // an explicit `<pkg>@<spec>` triggers it only for that one entry.
+    // Combine them into a per-key predicate so the same rewrite path
+    // serves both.
+    let effective_latest = latest || !explicit_specs.is_empty();
+    let should_rewrite_key = |key: &str| -> bool { latest || explicit_specs.contains_key(key) };
     let mut cwd = crate::dirs::project_root()?;
     // `-w/--workspace-root`: act on the workspace root manifest
     // regardless of which sub-package the user ran from. Mirrors
@@ -509,10 +520,17 @@ pub async fn run(
                 // the package.json rewrite loop below.
                 continue;
             }
+            // Concrete `<pkg>@<spec>` args inject their own spec as the
+            // resolver range; the `--latest` flag (no per-key spec) and
+            // `<pkg>@latest` inject the `latest` dist-tag.
+            let target = explicit_specs
+                .get(key)
+                .map(String::as_str)
+                .unwrap_or("latest");
             let new_spec = if original.starts_with("npm:") {
-                format!("npm:{real_name}@latest")
+                format!("npm:{real_name}@{target}")
             } else {
-                "latest".to_string()
+                target.to_string()
             };
             if m.dependencies.contains_key(key) {
                 m.dependencies.insert(key.clone(), new_spec);
@@ -555,30 +573,31 @@ pub async fn run(
                     .as_deref()
                     .is_some_and(|a| indirect_set.contains(a))
         });
-        // Indirect-arg dist-tag forwarding. When the user passes
-        // `<indirect>@latest`, dropping the indirect's own snapshot
+        // Indirect-arg spec forwarding. When the user passes
+        // `<indirect>@<spec>`, dropping the indirect's own snapshot
         // entry isn't enough on its own — the resolver's lockfile-reuse
         // path (aube_resolver::resolve.rs:1164) iterates each parent's
         // locked `dependencies` map and enqueues transitive tasks using
         // the *locked version* as the range. So a parent locked at
         // `pkg-with-1-dep@100.0.0` with `dependencies: { dep-of: 100.0.0 }`
         // still re-resolves dep-of at exactly 100.0.0, even after we
-        // dropped dep-of from `packages`. Rewriting the edge to `latest`
-        // rebroadcasts it as a dist-tag spec, so the transitive task
-        // resolves through the registry packument and picks the new
-        // latest. Only applied for entries the user named with
-        // `@latest`; bare `update <indirect>` keeps the locked edge so
-        // we don't silently bump something the user didn't ask to bump.
-        if !explicit_latest_keys.is_empty() {
+        // dropped dep-of from `packages`. Rewriting the edge to the
+        // named spec (a `latest` dist-tag or a concrete version/range)
+        // rebroadcasts it, so the transitive task resolves through the
+        // registry packument and picks the requested version. Only
+        // applied for entries the user named with an explicit `@<spec>`;
+        // bare `update <indirect>` keeps the locked edge so we don't
+        // silently bump something the user didn't ask to bump.
+        if !explicit_specs.is_empty() {
             for parent_pkg in filtered.packages.values_mut() {
                 for indirect_name in &indirect_arg_names {
-                    if !explicit_latest_keys.contains(indirect_name) {
+                    let Some(target) = explicit_specs.get(indirect_name) else {
                         continue;
-                    }
+                    };
                     if parent_pkg.dependencies.contains_key(indirect_name.as_str()) {
                         parent_pkg
                             .dependencies
-                            .insert(indirect_name.clone(), "latest".to_string());
+                            .insert(indirect_name.clone(), target.clone());
                     }
                 }
             }
@@ -658,7 +677,18 @@ pub async fn run(
                 eprintln!("  {manifest_key}: {old} -> {new}");
             }
             (Some(ver), Some(_)) => {
-                eprintln!("  {manifest_key}: {ver} (already latest)");
+                // A concrete `<pkg>@<version>` pin that resolved to the
+                // version already installed isn't "already latest" — say
+                // so precisely; the `--latest`/`@latest`/bare paths keep
+                // their original wording.
+                if explicit_specs
+                    .get(manifest_key)
+                    .is_some_and(|s| s != "latest")
+                {
+                    eprintln!("  {manifest_key}: {ver} (already at target)");
+                } else {
+                    eprintln!("  {manifest_key}: {ver} (already latest)");
+                }
             }
             (None, Some(new)) => {
                 eprintln!("  {manifest_key}: (new) {new}");
@@ -1560,21 +1590,37 @@ fn split_pkg_arg(arg: &str) -> (&str, Option<&str>) {
     }
 }
 
-/// Reject any `<pkg>@<spec>` arg whose spec isn't `latest`. Other forms
-/// (`foo@^2.0.0`, `foo@1.2.3`) are *parsed* by `split_pkg_arg` but the
-/// rest of the update path only acts on `@latest` — silently swallowing
-/// them would leave the user wondering why their spec didn't take. Hard
-/// error early with the supported alternatives so it's discoverable;
-/// future work can lift the restriction by threading the spec into the
-/// resolver_manifest rewrite + manifest write paths.
+/// Validate each `<pkg>@<spec>` arg against the specs the update-pin
+/// path can actually resolve. This is a positive ALLOWLIST — a spec is
+/// accepted iff nub can pin it to a registry version:
+///   - a semver version or range (`foo@3.0.1`, `foo@~2`, `foo@^2.0.0`,
+///     `foo@>=1`) — injected as the resolver range for that entry, then
+///     glued back onto the manifest's existing operator (matching
+///     `pnpm update foo@3.0.1`).
+///   - the `latest` dist-tag (`foo@latest`) — bump past the range.
+///   - an empty spec (`foo@`) — pnpm treats this as a bare in-range
+///     update (`foo`); the parse loop leaves it unmapped so it flows
+///     the bare path.
+///
+/// Everything else is REJECTED with a clean error rather than silently
+/// injected into the pin path. This is the load-bearing safety net: the
+/// alias/protocol/URL forms (`npm:is-even@1`, `link:../bar`, `file:./x`,
+/// `portal:../x`, `workspace:*`, `catalog:`, `git+https://…`,
+/// `github:u/r`, a tarball URL) carry no plain semver target, so pinning
+/// one would corrupt the manifest/lockfile — wrong package (an `npm:`
+/// alias loses its real-name intent) or a bogus `^0.0.0` — while exiting
+/// 0. Non-`latest` dist-tags (`next`, `beta`) are likewise rejected: the
+/// update path only ever honored `latest`. The check reuses
+/// `node_semver::Range::parse`, so the allowlist tracks exactly what the
+/// resolver can consume (every protocol/alias/URL form fails to parse).
 fn reject_unsupported_pkg_specs(packages: &[String]) -> miette::Result<()> {
     for raw in packages {
         let (name, spec) = split_pkg_arg(raw);
-        if let Some(s) = spec
-            && s != "latest"
-        {
+        let Some(s) = spec else { continue };
+        let supported = s.is_empty() || s == "latest" || node_semver::Range::parse(s).is_ok();
+        if !supported {
             return Err(miette!(
-                "package spec '{name}@{s}' is not supported by `update` — use `--latest` (or `<pkg>@latest`) to bump past the manifest range, or omit the spec to refresh in-range",
+                "package spec '{name}@{s}' is not supported by `update` — pass a version, range, or `latest` (e.g. `{name}@3.0.1`, `{name}@^2`, `{name}@latest`)",
             ));
         }
     }
@@ -1955,5 +2001,65 @@ mod tests {
         let versions = workspace_package_versions(root).unwrap();
         assert_eq!(versions.get("@my/root").unwrap(), "3.0.0");
         assert_eq!(versions.get("@my/docs").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn update_pin_preserves_manifest_operator_over_arg_version() {
+        // `update <pkg>@<version>` glues the manifest's existing operator
+        // onto the resolved version (the arg's own operator is discarded),
+        // matching `pnpm update`: `^3.0.0` + resolve `3.0.1` -> `^3.0.1`,
+        // an exact pin stays exact, out-of-range downgrades keep the caret.
+        assert_eq!(rewrite_specifier("^3.0.0", "p", "3.0.1", false), "^3.0.1");
+        assert_eq!(rewrite_specifier("~3.0.0", "p", "3.4.0", false), "~3.4.0");
+        assert_eq!(rewrite_specifier("3.0.0", "p", "3.0.1", false), "3.0.1");
+        assert_eq!(rewrite_specifier("^3.1.0", "p", "3.0.0", false), "^3.0.0");
+        // `--save-exact`/`-E` forces an exact pin regardless of operator.
+        assert_eq!(rewrite_specifier("^3.0.0", "p", "3.0.1", true), "3.0.1");
+        // `npm:` aliases round-trip through the alias, operator preserved.
+        assert_eq!(
+            rewrite_specifier("npm:real@^1.0.0", "real", "1.2.0", false),
+            "npm:real@^1.2.0"
+        );
+    }
+
+    #[test]
+    fn reject_unsupported_pkg_specs_allowlists_semver_rejects_protocols() {
+        // Registry versions, ranges, `latest`, bare names, and the empty
+        // spec (pnpm's bare in-range update) are all honored.
+        for ok in [
+            "is-odd@3.0.1",
+            "is-odd@^2",
+            "is-odd@~3.0",
+            "is-odd@>=1.0.0",
+            "is-odd@1.2.3-rc.0",
+            "is-odd@latest",
+            "is-odd@",
+            "is-odd",
+        ] {
+            assert!(
+                reject_unsupported_pkg_specs(&[ok.to_string()]).is_ok(),
+                "{ok} should be accepted"
+            );
+        }
+        // Alias/protocol/URL forms and non-`latest` dist-tags carry no
+        // plain semver target — pinning them would silently corrupt the
+        // manifest, so they must hard-error (the pre-pin safety net).
+        for bad in [
+            "is-odd@npm:is-even@1.0.0",
+            "is-odd@link:../bar",
+            "is-odd@file:./bar",
+            "is-odd@portal:../bar",
+            "is-odd@workspace:*",
+            "is-odd@catalog:",
+            "is-odd@github:a/b",
+            "is-odd@git+https://example.com/a/b.git",
+            "is-odd@https://example.com/is-odd-3.0.1.tgz",
+            "is-odd@next",
+        ] {
+            assert!(
+                reject_unsupported_pkg_specs(&[bad.to_string()]).is_err(),
+                "{bad} should be rejected"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

nub's PM CLI rejected two valid pnpm grammars, both surfaced by the Dependabot ecosystem work (which pins a dependency to an exact version and refreshes only the lockfile):

- `nub update <pkg>@<version>` — the aube engine hard-errored any non-`latest` spec (`package spec 'is-odd@3.0.1' is not supported by 'update'`).
- `nub add <pkg>@<version> --lockfile-only` — `--lockfile-only` was absent from aube's `AddArgs` (`unexpected argument '--lockfile-only'`).

Both are accepted by real pnpm. This closes the gap in nub's own PM CLI frontend.

## Behavior, matched to pnpm empirically

`update <pkg>@<version>` glues the manifest's **existing** range operator onto the resolved version — the arg's own operator is discarded, and out-of-range downgrades keep the operator. Verified against pnpm 10.15.1 on identical fixtures:

| from | command | pnpm | nub |
|------|---------|------|-----|
| `^3.0.0` | `up is-positive@3.1.0` | `^3.1.0` | `^3.1.0` |
| `3.1.0` | `up is-positive@3.0.0` | `3.0.0` | `3.0.0` |
| `^3.1.0` | `up is-positive@3.0.0` (downgrade, out of range) | `^3.0.0` | `^3.0.0` |
| `^3.0.0` | `up is-positive@~3.1.0` (arg operator discarded) | `^3.1.0` | `^3.1.0` |
| `^3.0.0` | `up is-positive@3.1.0 --lockfile-only` | `^3.1.0` | `^3.1.0` |

## Implementation

- **update** — generalizes the existing `@latest`/`--latest` machinery to any concrete version or range. The arg spec is injected as the resolver range for that entry, then the manifest rewrite preserves the existing operator (the same `rewrite_specifier` path `@latest` already used). The rejection now only blocks specs with no registry semver target (empty, `workspace:`, `catalog:`, git). `update --lockfile-only` was already wired in aube, so `update <pkg>@<version> --lockfile-only` now works end-to-end.
- **add** — threads a `--lockfile-only` flag through `AddArgs` into the install pipeline so the linker is skipped while the lockfile + manifest are written.

Fork-discipline: this is a pnpm-compat fix to the vendored aube engine; the `--latest`/`@latest`/bare-`update` paths keep their exact prior behavior (byte-identical output, including the "already latest" wording).

## Tests

- aube unit tests: operator-preservation across caret/tilde/exact/downgrade/`-E`/alias; the reject filter accepts versions/ranges/`latest`, rejects empty/`workspace:`/`catalog:`/git.
- nub e2e (`pm_verbs.rs`, network `#[ignore]` per convention): `up <pkg>@<version>` preserves the caret and resolves the lockfile; `add <pkg>@<version> --lockfile-only` writes the lockfile without linking `node_modules`. Both pass against the live registry.
- Gates green locally: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` (aube + nub-cli), the new tests.

## Docs

`install/index.mdx` gains the two grammar forms under `nub add` and `nub update`.

Refs the nub-update-pin-version-grammar thread.
