### PR TITLE
tests(framework-matrix): official create-*-driven full-lifecycle GVS harness

### DIFF
--- a/tests/framework-matrix/README.md
+++ b/tests/framework-matrix/README.md
@@ -1,0 +1,111 @@
+# Framework GVS acceptance matrix
+
+Regression harness that proves real front-end frameworks work under nub's
+**global virtual store (GVS)** — the default install layout where a project's
+deps are symlinked into the machine-global store (`~/.cache/nub/pm/virtual-store`,
+OUTSIDE the project root) rather than copied project-local. Frameworks are the
+hard case for GVS because their bundlers/dev-servers resolve modules by
+**realpath** and enforce **fs allow-lists**, so a symlinked-out-of-tree dep is
+exactly what breaks them if the linker gets it wrong.
+
+Every fixture here is scaffolded by the framework's **official `create-*`
+generator** — never hand-rolled — so the dependency tree, the pinned
+framework/bundler versions, and the injected-dep shape are what a real user gets.
+Each framework is driven through its **full lifecycle**:
+
+```
+install → dev-serve + page-load 200 → production build → build-serve + page-load 200
+```
+
+The production build and the served-build load are not redundant with dev: they
+exercise different code paths (bundler realpath resolution, prerender/SSG, the
+SSR/preview server), which is where a GVS break that dev masks tends to surface.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `frameworks.sh` | The manifest: framework name → official `create-*` command (pinned) + the `DEV`/`BUILD`/`PREVIEW`/`PROBE`/`GVS` keys. ONE place to add a framework. |
+| `matrix.sh` | Orchestrator: scaffold each framework → drive `run.sh` under GVS → collect the per-stage pass/fail, the linking layout, and the injected deps → print a summary table. |
+| `run.sh` | Per-project runner: the four-stage lifecycle + a linking-layout probe, for one already-scaffolded project. Framework-agnostic; `matrix.sh` calls it once per framework. |
+
+## Running
+
+```sh
+# build the dev binary first (see AGENTS.md dev-loop): cargo build -p nub-cli --profile fast
+tests/framework-matrix/matrix.sh -b target/fast/nub                    # all frameworks
+tests/framework-matrix/matrix.sh -b target/fast/nub vite-react astro   # a subset
+tests/framework-matrix/matrix.sh -b target/fast/nub --force-gvs        # force GVS on (non-excluded)
+tests/framework-matrix/matrix.sh -b target/fast/nub --isolate-store    # fresh per-framework store (genuine cold)
+```
+
+`frameworks.sh list` prints the known names. Each scaffolder is pinned via a
+`*_CREATE` env var (`VITE_CREATE`, `ASTRO_CREATE`, `SVELTE_CREATE`, `NUXT_CREATE`,
+`NEXT_CREATE`) — pin a major (e.g. `VITE_CREATE=vite@7`) to freeze the emitted
+framework/bundler version. `run.sh` records the exact resolved versions and
+layout in each row, so any generator drift is visible, not silent.
+
+## The scaffolders (exact commands)
+
+| Framework | Official generator | Command (as run) |
+|---|---|---|
+| `vite-react` / `vite-vue` / `vite-svelte` | create-vite | `npm create vite@latest <dir> -- --template {react,vue,svelte}-ts` |
+| `astro` | create-astro | `npm create astro@latest <dir> -- --template minimal --install false --git false --skip-houston --yes` |
+| `sveltekit` | `sv create` (SvelteKit CLI) | `npx sv@latest create <dir> --template minimal --types ts --no-add-ons` |
+| `nuxt` | `nuxi init` | `npx nuxi@latest init <dir> --template minimal --no-install --packageManager npm --gitInit false` |
+| `next` | create-next-app | `npx create-next-app@latest <dir> --ts --no-eslint --no-tailwind --no-src-dir --app --no-turbopack --import-alias '@/*' --use-npm --skip-install` |
+
+Generator CLIs change flags often; treat these as the verified starting point and
+adjust per release. Adding a framework is one `case` arm in `frameworks.sh` (its
+`create-*` command + the four lifecycle keys) plus its name in `FRAMEWORKS`.
+
+## What "injected deps" means (the GVS finding)
+
+Under GVS most deps are **symlinked** into the machine-global store (their
+realpath ESCAPES the project root). A dep whose realpath stays **inside** the
+project root was **injected** — disk-materialized project-local while the rest of
+the tree stayed symlinked. nub does this deliberately in three cases:
+
+1. **vite dist backport** (`vite_compat`) — a *direct* `vite < 8.1` dep is ejected
+   project-local and its dist patched so its `/@fs` fs-allow-list admits the store
+   (the #315 `403 … outside of Vite serving allow list` fix).
+2. **phantom-eject ancestor closure** (#352 collective hidden tree) — a framework
+   that embeds `vite < 8.1` *transitively* (Astro, Nuxt) has its `[framework … vite]`
+   ancestor closure disk-materialized so the framework loads a project-local vite
+   the backport can patch. Bounded to the framework subtree; the rest stays symlinked.
+3. **`diskMaterializePackages`** — an explicit force-eject list.
+
+`matrix.sh`'s `INJECTED DEPS` column is exactly the set of project-local deps
+`run.sh`'s probe found under an otherwise-GVS install — the empirical evidence of
+which packages nub had to materialize for that framework. `none` means the whole
+tree stayed symlinked (e.g. a `vite ≥ 8.1` app needs no eject).
+
+## GVS-excluded frameworks (expected project-local)
+
+Two frameworks are on nub's `disableGlobalVirtualStoreForPackages` realpath-locality
+trigger and install **project-local by design** — GVS off, not a bug:
+
+- **`next`** — Turbopack canonicalizes through symlinks and chroots to a single
+  project root, so the machine-global store is unreachable.
+- **`react-native`** (bare RN) — Metro crawls by realpath and only sees the
+  project root; even declared deps report unresolved under GVS.
+
+The matrix runs these with the DEFAULT install (the trigger flips them
+project-local), asserts they build/serve, and asserts the layout is
+`project-local` — forcing GVS on for them would test an unsupported config, so
+`--force-gvs` never applies to a `GVS=exclude` framework. For these the
+`INJECTED` column is `n/a` (the whole tree is project-local — GVS isn't engaged).
+
+## Known issue flagged (not a matrix regression)
+
+- **Nuxt under GVS** — a scule-phantom bug (a transitive undeclared import the
+  closure alone can't place) can fail Nuxt's dev/prepare under GVS; a fix is in
+  flight. A `nuxt` failure here is that known issue, not a new one — the row
+  records the actual observed behavior.
+
+## Acceptance
+
+A framework PASSes when install, dev-serve (HTTP 200 + a clean server log),
+production build, and build-serve (HTTP 200) all succeed. A `GVS=exclude`
+framework additionally must land `project-local`. `matrix.sh` exits non-zero on
+any non-excluded FAIL.

--- a/tests/framework-matrix/frameworks.sh
+++ b/tests/framework-matrix/frameworks.sh
@@ -56,7 +56,12 @@ _vite() {
 }
 
 scaffold() {
-  local name="$1" dest="$2" parent base
+  local name="$1" dest="$2" parent base known
+  # Validate the name against the known set BEFORE any destructive fs op. `dest`
+  # is derived from a CLI arg; an unknown/garbage name (`..`, a stray path) must
+  # never reach `rm -rf "$dest"` — `rm -rf "$OUT/.."` would wipe $OUT's parent.
+  known=0; for f in "${FRAMEWORKS[@]}"; do [ "$f" = "$name" ] && known=1; done
+  [ "$known" -eq 1 ] || { echo "UNKNOWN_FRAMEWORK: $name" >&2; return 2; }
   parent="$(dirname "$dest")"; base="$(basename "$dest")"
   rm -rf "$dest"; mkdir -p "$parent"
   # Every generator scaffolds into a CWD-relative <base>; cd to the parent first

--- a/tests/framework-matrix/frameworks.sh
+++ b/tests/framework-matrix/frameworks.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# frameworks.sh — the framework manifest for the GVS acceptance matrix. ONE place
+# that maps a framework name to its OFFICIAL `create-*` scaffolder + the four
+# commands `run.sh` drives (dev / build / preview / probe). Every fixture here is
+# scaffolded by the framework's own real generator (`create-vite`, `create-astro`,
+# `sv create`, `nuxi init`, `create-next-app`) — never hand-rolled — so the tree,
+# the pinned framework/bundler versions, and the injected-dep shape are what a
+# real user gets, not a synthetic approximation.
+#
+# Usage:  frameworks.sh scaffold <name> <dest>   # scaffolds into <dest>, prints DEV=/BUILD=/PREVIEW=/PROBE=/GVS=
+#         frameworks.sh list                      # print the framework names
+#
+# Reproducibility: each scaffolder is pinned via a `*_CREATE` env var (below) —
+# override to move a case to a different generator release. The scaffolder version
+# fixes the framework/bundler major it emits; `run.sh` records the exact resolved
+# versions at install time, so a drift is visible in the row, not silent.
+#
+# The five printed keys `run.sh`/`matrix.sh` consume (a value of `-` skips a step):
+#   DEV=      dev-server command (binds 127.0.0.1:$PORT; run.sh parses the real port)
+#   BUILD=    production build command
+#   PREVIEW=  serve-the-build command (binds 127.0.0.1:$PPORT) — SSR/preview/start
+#   PROBE=    a node_modules dep whose realpath headlines the layout verdict
+#   GVS=      auto   → default install (respects nub's triggers; GVS engages)
+#             exclude→ a realpath-locality-excluded framework (next/react-native):
+#                      the trigger flips it PROJECT-LOCAL by design — never force GVS on
+set -u
+
+# ── pinned scaffolder versions (override via env for a different major) ────────
+# `npm create <x>` runs the `create-<x>` initializer, so VITE/ASTRO carry the
+# bare `<x>@<ver>` npm passes to `create-`. sv/nuxi/next are `npx <pkg>` (full
+# package name). Pin the major (e.g. VITE_CREATE=vite@7) to freeze the emitted
+# framework/bundler version for reproducibility.
+VITE_CREATE="${VITE_CREATE:-vite@latest}"       # → npm create vite@latest  (create-vite)
+ASTRO_CREATE="${ASTRO_CREATE:-astro@latest}"     # → npm create astro@latest (create-astro)
+SVELTE_CREATE="${SVELTE_CREATE:-sv@latest}"       # → npx sv create           (the SvelteKit CLI)
+NUXT_CREATE="${NUXT_CREATE:-nuxi@latest}"         # → npx nuxi init
+NEXT_CREATE="${NEXT_CREATE:-create-next-app@latest}" # → npx create-next-app
+
+# The framework names this manifest knows. Keep in sync with the case block below.
+FRAMEWORKS=(vite-react vite-vue vite-svelte astro sveltekit nuxt next)
+
+_list() { printf '%s\n' "${FRAMEWORKS[@]}"; }
+
+# create-vite: an official template. All create-vite@latest templates ship the
+# current Vite (8.1+ today ⇒ native `.modules.yaml` allow-list path). $1=template.
+# Runs from the parent dir with a bare project name — create-vite (and the other
+# generators) treat the target as CWD-RELATIVE and strip a leading `/`.
+_vite() {
+  local base="$1" template="$2"
+  npm create "$VITE_CREATE" "$base" -- --template "$template" >/dev/null 2>&1 || return 1
+  echo "DEV=npx vite dev --port \$PORT --host 127.0.0.1"
+  echo "BUILD=npx vite build"
+  echo "PREVIEW=npx vite preview --port \$PPORT --host 127.0.0.1 --strictPort"
+  echo "PROBE=vite"
+  echo "GVS=auto"
+}
+
+scaffold() {
+  local name="$1" dest="$2" parent base
+  parent="$(dirname "$dest")"; base="$(basename "$dest")"
+  rm -rf "$dest"; mkdir -p "$parent"
+  # Every generator scaffolds into a CWD-relative <base>; cd to the parent first
+  # so an absolute $dest lands at $dest (not $CWD/$dest with the slash stripped).
+  cd "$parent" || return 1
+  case "$name" in
+    vite-react)  _vite "$base" react-ts ;;
+    vite-vue)    _vite "$base" vue-ts ;;
+    vite-svelte) _vite "$base" svelte-ts ;;
+
+    # create-astro minimal: a static (SSG) Astro app. Astro embeds Vite
+    # TRANSITIVELY (no top-level vite symlink) — the case that exercises the
+    # phantom-eject ancestor-closure disk-materialization when its Vite is < 8.1.
+    astro)
+      npm create "$ASTRO_CREATE" "$base" -- --template minimal --install false --git false --skip-houston --yes >/dev/null 2>&1 || return 1
+      echo "DEV=npx astro dev --port \$PORT --host 127.0.0.1"
+      echo "BUILD=npx astro build"
+      echo "PREVIEW=npx astro preview --port \$PPORT --host 127.0.0.1"
+      echo "PROBE=astro"
+      echo "GVS=auto" ;;
+
+    # SvelteKit via the official `sv create` (successor to create-svelte).
+    # adapter-auto → `vite preview` serves the built app.
+    sveltekit)
+      npx --yes "$SVELTE_CREATE" create "$base" --template minimal --types ts --no-add-ons >/dev/null 2>&1 || return 1
+      echo "DEV=npx vite dev --port \$PORT --host 127.0.0.1"
+      echo "BUILD=npx vite build"
+      echo "PREVIEW=npx vite preview --port \$PPORT --host 127.0.0.1 --strictPort"
+      echo "PROBE=@sveltejs/kit"
+      echo "GVS=auto" ;;
+
+    # Nuxt via `nuxi init`. SSR meta-framework: build emits `.output/`,
+    # `nuxi preview` serves it (reads PORT from the env). Embeds Vite
+    # transitively. KNOWN: Nuxt has a scule-phantom bug under GVS (fix in
+    # flight) — a dev/prepare failure here is that known issue, not a new one.
+    nuxt)
+      npx --yes "$NUXT_CREATE" init "$base" --template minimal --no-install --packageManager npm --gitInit false >/dev/null 2>&1 || return 1
+      echo "DEV=npx nuxi dev --port \$PORT --host 127.0.0.1"
+      echo "BUILD=npx nuxi build"
+      echo "PREVIEW=env PORT=\$PPORT npx nuxi preview"
+      echo "PROBE=nuxt"
+      echo "GVS=auto" ;;
+
+    # Next via create-next-app (App Router, no turbopack for a stable build path).
+    # next is REALPATH-LOCALITY-EXCLUDED from GVS (Turbopack chroots to one
+    # project root) — the trigger installs it PROJECT-LOCAL. GVS=exclude tells
+    # the matrix to expect (and accept) project-local, and to NEVER force GVS on.
+    next)
+      npx --yes "$NEXT_CREATE" "$base" --ts --no-eslint --no-tailwind --no-src-dir --app --no-turbopack --import-alias '@/*' --use-npm --skip-install >/dev/null 2>&1 || return 1
+      echo "DEV=npx next dev --port \$PORT"
+      echo "BUILD=npx next build"
+      echo "PREVIEW=npx next start --port \$PPORT"
+      echo "PROBE=next"
+      echo "GVS=exclude" ;;
+
+    *) echo "UNKNOWN_FRAMEWORK: $name" >&2; return 2 ;;
+  esac
+}
+
+case "${1:-}" in
+  list)     _list ;;
+  scaffold) scaffold "$2" "$3" ;;
+  *) echo "usage: frameworks.sh {list | scaffold <name> <dest>}" >&2; exit 2 ;;
+esac

--- a/tests/framework-matrix/matrix.sh
+++ b/tests/framework-matrix/matrix.sh
@@ -29,16 +29,19 @@
 # PASSes (an excluded framework is asserted to land PROJECT-LOCAL, not GVS).
 set -u
 
-# Needs bash 4+ (associative arrays + mapfile). macOS ships bash 3.2, where these
-# silently misbehave — re-exec under a newer bash if one is on PATH, else error
-# clearly rather than collapsing the summary.
-if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+# Needs bash 4.4+: associative arrays + mapfile are 4.0, but the "empty array +
+# ${arr[@]} under set -u = unbound variable" bug (which bites the default
+# no-flag path where env_prefix=()) was only fixed in 4.4. macOS ships 3.2 —
+# re-exec under a newer bash if one is on PATH, else error clearly.
+_bash_ge_44() { [ "${BASH_VERSINFO[0]}" -gt 4 ] || { [ "${BASH_VERSINFO[0]}" -eq 4 ] && [ "${BASH_VERSINFO[1]}" -ge 4 ]; }; }
+if ! _bash_ge_44; then
   for b in /opt/homebrew/bin/bash /usr/local/bin/bash bash; do
-    if command -v "$b" >/dev/null 2>&1 && [ "$("$b" -c 'echo ${BASH_VERSINFO:-0}')" -ge 4 ]; then
+    if command -v "$b" >/dev/null 2>&1 && \
+       "$b" -c '[ "${BASH_VERSINFO[0]}" -gt 4 ] || { [ "${BASH_VERSINFO[0]}" -eq 4 ] && [ "${BASH_VERSINFO[1]}" -ge 4 ]; }' 2>/dev/null; then
       exec "$b" "$0" "$@"
     fi
   done
-  echo "error: matrix.sh needs bash 4+ (macOS system bash is 3.2 — 'brew install bash')" >&2
+  echo "error: matrix.sh needs bash 4.4+ (macOS system bash is 3.2 — 'brew install bash')" >&2
   exit 2
 fi
 

--- a/tests/framework-matrix/matrix.sh
+++ b/tests/framework-matrix/matrix.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# matrix.sh — the committed framework GVS acceptance matrix. For each framework:
+# scaffold it via its OFFICIAL create-* generator (frameworks.sh), then drive the
+# full lifecycle through run.sh UNDER nub's global virtual store:
+#
+#     install → dev-serve + page-load 200 → production build → build-serve + 200
+#
+# and record, per framework: the pass/fail of each stage, the resolved
+# framework/bundler versions, the on-disk linking layout, and — the key GVS
+# finding — WHICH deps were INJECTED (disk-materialized / ejected project-local
+# while the rest of the tree stays symlinked into the machine-global store).
+#
+# Usage: matrix.sh [-b <nub>] [--force-gvs] [--keep] [--isolate-store] [framework ...]
+#   -b <nub>         nub binary (default: target/fast/nub, then the shared build)
+#   --force-gvs      set NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=true for every
+#                    non-excluded framework (proves GVS specifically; the default
+#                    already engages GVS but respects triggers). NEVER applied to a
+#                    GVS=exclude framework (next/react-native) — that is an
+#                    unsupported config for them.
+#   --isolate-store  give each framework a fresh XDG_CACHE_HOME/XDG_DATA_HOME so
+#                    the shared machine-global store can't mask a result (slower —
+#                    a genuine cold fetch per framework). Default reuses the real
+#                    warm store (the honest "what a user gets", and fast).
+#   --keep           keep scaffolded fixtures under $OUT on success.
+#   [framework ...]  subset to run (default: all — `frameworks.sh list`).
+#
+# Emits per-framework ROW/VERDICT lines (from run.sh) plus a final summary table
+# and an INJECTED| line per framework. Exit 0 iff every non-excluded framework
+# PASSes (an excluded framework is asserted to land PROJECT-LOCAL, not GVS).
+set -u
+
+# Needs bash 4+ (associative arrays + mapfile). macOS ships bash 3.2, where these
+# silently misbehave — re-exec under a newer bash if one is on PATH, else error
+# clearly rather than collapsing the summary.
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for b in /opt/homebrew/bin/bash /usr/local/bin/bash bash; do
+    if command -v "$b" >/dev/null 2>&1 && [ "$("$b" -c 'echo ${BASH_VERSINFO:-0}')" -ge 4 ]; then
+      exec "$b" "$0" "$@"
+    fi
+  done
+  echo "error: matrix.sh needs bash 4+ (macOS system bash is 3.2 — 'brew install bash')" >&2
+  exit 2
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── args ──────────────────────────────────────────────────────────────────────
+NUB=""; FORCE_GVS=0; KEEP=0; ISOLATE=0; SEL=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -b) NUB="$2"; shift 2 ;;
+    --force-gvs) FORCE_GVS=1; shift ;;
+    --keep) KEEP=1; shift ;;
+    --isolate-store) ISOLATE=1; shift ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) SEL+=("$1"); shift ;;
+  esac
+done
+
+if [ -z "$NUB" ]; then
+  for c in "$HERE/../../target/fast/nub" "$HOME/.cache/nub/shared-target/fast/nub"; do
+    [ -x "$c" ] && { NUB="$c"; break; }
+  done
+fi
+[ -n "$NUB" ] && [ -x "$NUB" ] || { echo "error: no nub binary (pass -b <path>)" >&2; exit 2; }
+NUB="$(cd "$(dirname "$NUB")" && pwd)/$(basename "$NUB")"
+
+[ ${#SEL[@]} -eq 0 ] && mapfile -t SEL < <(bash "$HERE/frameworks.sh" list)
+
+OUT="${OUT:-$(mktemp -d "${TMPDIR:-/tmp}/nub-fw-matrix.XXXXXX")}"
+echo "== framework GVS matrix =="
+echo "nub:   $NUB ($("$NUB" --version 2>/dev/null | head -1))"
+echo "out:   $OUT"
+echo "force-gvs=$FORCE_GVS  isolate-store=$ISOLATE  frameworks: ${SEL[*]}"
+echo
+
+declare -A VERDICT INJECTED LAYOUT
+port=5180
+fail=0
+
+for fw in "${SEL[@]}"; do
+  echo "── $fw ───────────────────────────────────────────────────────────────"
+  dest="$OUT/$fw"
+  meta="$(bash "$HERE/frameworks.sh" scaffold "$fw" "$dest")" || {
+    echo "SCAFFOLD FAIL: $fw"; VERDICT[$fw]="SCAFFOLD-FAIL"; fail=1; continue; }
+  # Pull the five keys out of the scaffolder's stdout.
+  dev=$(sed -n 's/^DEV=//p'         <<<"$meta")
+  build=$(sed -n 's/^BUILD=//p'     <<<"$meta")
+  preview=$(sed -n 's/^PREVIEW=//p' <<<"$meta")
+  probe=$(sed -n 's/^PROBE=//p'     <<<"$meta")
+  gvs=$(sed -n 's/^GVS=//p'         <<<"$meta")
+
+  # Assign a distinct dev/preview port pair per framework (run.sh reads the REAL
+  # bound port from the server log, but distinct requests avoid a same-run clash).
+  dport=$port; pport=$((port+5)); port=$((port+10))
+  dev="${dev//\$PORT/$dport}"; dev="${dev//\$PPORT/$pport}"
+  preview="${preview//\$PPORT/$pport}"; preview="${preview//\$PORT/$dport}"
+
+  # GVS policy. Excluded frameworks run default (trigger → project-local); the
+  # rest optionally force GVS on to prove the shared store specifically.
+  env_prefix=()
+  if [ "$gvs" != "exclude" ] && [ "$FORCE_GVS" -eq 1 ]; then
+    env_prefix=(env NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=true)
+  fi
+  if [ "$ISOLATE" -eq 1 ]; then
+    iso="$OUT/.store-$fw"; mkdir -p "$iso/cache" "$iso/data"
+    env_prefix=(env XDG_CACHE_HOME="$iso/cache" XDG_DATA_HOME="$iso/data" "${env_prefix[@]}")
+  fi
+
+  out="$OUT/$fw.runlog"
+  NUB="$NUB" "${env_prefix[@]}" bash "$HERE/run.sh" "$fw" "$dest" "$dev" "$build" "$preview" "$probe" 2>&1 | tee "$out"
+
+  v=$(sed -n 's/^VERDICT|'"$fw"'|\([A-Z]*\).*/\1/p' "$out" | head -1)
+  lay=$(sed -n 's/.*layout=\([a-z-]*\).*/\1/p' "$out" | head -1)
+  inj=$(sed -n 's/.*step=linking .*locals=\([^ ]*\).*/\1/p' "$out" | head -1)
+  VERDICT[$fw]="${v:-NO-VERDICT}"; LAYOUT[$fw]="${lay:-?}"; INJECTED[$fw]="${inj:-?}"
+
+  # Verdict interpretation per GVS policy.
+  if [ "$gvs" = "exclude" ]; then
+    # Excluded frameworks: success = builds/serves AND landed project-local.
+    if [ "${VERDICT[$fw]}" = "PASS" ] && [ "${LAYOUT[$fw]}" = "project-local" ]; then
+      echo "  → $fw PASS (project-local by trigger, as expected — GVS-excluded)"
+    else
+      echo "  → $fw check: verdict=${VERDICT[$fw]} layout=${LAYOUT[$fw]} (expected PASS+project-local)"
+      [ "${VERDICT[$fw]}" != "PASS" ] && fail=1
+    fi
+    INJECTED[$fw]="n/a (GVS-excluded → project-local)"
+  else
+    [ "${VERDICT[$fw]}" != "PASS" ] && fail=1
+  fi
+  echo
+done
+
+# ── summary ───────────────────────────────────────────────────────────────────
+echo "================================ SUMMARY ================================"
+printf "%-12s %-8s %-14s %s\n" FRAMEWORK VERDICT LAYOUT "INJECTED DEPS (project-local under GVS)"
+for fw in "${SEL[@]}"; do
+  printf "%-12s %-8s %-14s %s\n" "$fw" "${VERDICT[$fw]:-?}" "${LAYOUT[$fw]:-?}" "${INJECTED[$fw]:-?}"
+done
+echo
+if [ "$KEEP" -eq 1 ]; then echo "fixtures kept under $OUT"; else rm -rf "$OUT"; fi
+[ "$fail" -eq 0 ] && echo "MATRIX: ALL PASS" || echo "MATRIX: FAILURES (see rows above)"
+exit "$fail"

--- a/tests/framework-matrix/run.sh
+++ b/tests/framework-matrix/run.sh
@@ -67,7 +67,7 @@ if [ "$dev_cmd" != "-" ]; then
   bound=""; up=""
   for i in $(seq 1 120); do
     sleep 0.5
-    pp=$(grep -oE 'https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]):[0-9]+' "$devlog" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
+    pp=$(grep -oE 'https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[[0-9a-fA-F:]*\]):[0-9]+' "$devlog" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
     [ -n "$pp" ] && bound="$pp"
     if [ -n "$bound" ]; then curl -s -o /dev/null "http://localhost:$bound/" 2>/dev/null && { up=1; break; }; fi
     kill -0 "$devpid" 2>/dev/null || break   # dev process died
@@ -103,7 +103,7 @@ if [ "$preview_cmd" != "-" ] && [ "$build_result" != "FAIL" ]; then
   pbound=""; pup=""
   for i in $(seq 1 120); do
     sleep 0.5
-    pp=$(grep -oE 'https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]):[0-9]+' "$prevlog" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
+    pp=$(grep -oE 'https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[[0-9a-fA-F:]*\]):[0-9]+' "$prevlog" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
     [ -n "$pp" ] && pbound="$pp"
     if [ -n "$pbound" ]; then curl -s -o /dev/null "http://localhost:$pbound/" 2>/dev/null && { pup=1; break; }; fi
     kill -0 "$prevpid" 2>/dev/null || break

--- a/tests/framework-matrix/run.sh
+++ b/tests/framework-matrix/run.sh
@@ -20,7 +20,11 @@ name="$1"; proj="$2"; dev_cmd="$3"; build_cmd="$4"; preview_cmd="$5"; probe="${6
 
 log() { echo "ROW|$name|$*"; }
 
-kill_tree() { local p="$1" c; for c in $(pgrep -P "$p" 2>/dev/null); do kill_tree "$c"; done; kill -TERM "$p" 2>/dev/null; }
+# TERM then KILL each descendant — a dev-server worker that ignores SIGTERM must
+# not survive to hold a port into the next stage. The group-kill in kill_group is
+# the primary reaper; this PID-walk is the fallback for anything that escaped the
+# group (e.g. via its own setsid), so it also needs the follow-up KILL.
+kill_tree() { local p="$1" c; for c in $(pgrep -P "$p" 2>/dev/null); do kill_tree "$c"; done; kill -TERM "$p" 2>/dev/null; kill -KILL "$p" 2>/dev/null; }
 kill_group() { local g="$1"; kill -TERM -"$g" 2>/dev/null; sleep 0.4; kill -KILL -"$g" 2>/dev/null; kill_tree "$g"; kill -KILL "$g" 2>/dev/null; }
 
 cd "$proj" || { log "step=setup result=FAIL detail=no-dir"; echo "VERDICT|$name|FAIL"; exit 2; }
@@ -89,7 +93,9 @@ fi
 # ── production build ──────────────────────────────────────────────────────────
 build_result="skip"
 if [ "$build_cmd" != "-" ]; then
-  ( cd "$proj" && eval "$build_cmd" ) >/tmp/fm-$name-build.log 2>&1; bx=$?
+  # Word-split (not eval) — consistent with how dev/preview are run; build_cmd is
+  # a plain command from the trusted manifest with no shell metacharacters.
+  ( cd "$proj" && $build_cmd ) >/tmp/fm-$name-build.log 2>&1; bx=$?
   [ $bx -eq 0 ] && build_result="ok" || build_result="FAIL"
   log "step=build result=$build_result exit=$bx"
   [ "$build_result" = "FAIL" ] && { echo "  build-log tail:"; tail -20 /tmp/fm-$name-build.log | sed 's/^/  build> /'; }


### PR DESCRIPTION
Scaffolds every framework fixture via its official `create-*` generator (pinned) and drives install → dev-serve+200 → build → build-serve+200 under the global virtual store.

- `frameworks.sh` — manifest: framework → create-* command + dev/build/preview/probe keys.
- `matrix.sh` — scaffold each → `run.sh` under GVS → summary + per-framework injected deps; `next`/`react-native` asserted project-local.
- `run.sh` — port-parse now matches the `[::]` host `nuxi preview` prints.
- `README.md` — runbook + injected-deps semantics.

Verified: vite-react/vue/svelte, astro, sveltekit, nuxt, next all PASS. Refs #352.