### PR TITLE
pm: rename project-local virtual store to node_modules/.store

### DIFF
--- a/crates/nub-cli/src/pm_engine/info_family.rs
+++ b/crates/nub-cli/src/pm_engine/info_family.rs
@@ -79,7 +79,7 @@
 //!   spellings rebrand ("`aube outdated -w`" reads "`nub outdated -w`") and
 //!   config-location spellings map to nub's configured contract
 //!   (`aube-workspace.yaml` → `pnpm-workspace.yaml`, `why`'s
-//!   `.aube/<dep_path>` example → `.nub/<dep_path>`).
+//!   `.aube/<dep_path>` example → `.store/<dep_path>`).
 //! - `outdated` / `audit` / `peers check` signal "findings exist" via
 //!   `std::process::exit(1)` *inside* the engine (pnpm-compat), after the
 //!   report is fully printed — they bypass this file's `Result<i32>` return
@@ -509,7 +509,7 @@ fn run_check(typed: &str, args: &[String]) -> Result<i32> {
         Parsed::Done(code) => return Ok(code),
     };
     let session = super::engine_session_quiet(cli.dir.as_deref())?;
-    // Reads the *resolved* virtual store (node_modules/.nub under nub's
+    // Reads the *resolved* virtual store (node_modules/.store under nub's
     // defaults); a never-installed project reports `checked 0 packages`
     // rather than erroring, so no pre-flight applies. Broken links exit 1
     // via std::process::exit inside the engine (pnpm-compat), like

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -453,7 +453,7 @@ fn run_prune(typed: &str, args: &[String]) -> Result<i32> {
     let session = super::engine_session(globals.dir.as_deref())?;
     // prune prints its summary via raw eprintln with a hardcoded `.aube`
     // store label (the walked directory is the *resolved* virtualStoreDir —
-    // node_modules/.nub here — only the label lies). Capture + neutralize.
+    // node_modules/.store here — only the label lies). Capture + neutralize.
     // Under `--silent` the output guard redirects stderr, so the rebranded
     // reprint is suppressed too; the guard drops before `finish`.
     let result = with_output(&globals.output, || {

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -635,7 +635,7 @@ pub(crate) fn engine_session(dir: Option<&Path>) -> Result<EngineSession> {
 /// (GVS off, isolation kept). `nub ci` is the frozen, ephemeral, deploy-oriented
 /// install; its `node_modules` is almost always COPY-relocated (multi-stage
 /// Docker) or thrown away, and a machine-global virtual store makes that tree
-/// non-relocatable — every `.nub/<dep>` becomes an absolute symlink into
+/// non-relocatable — every `.store/<dep>` becomes an absolute symlink into
 /// `~/.cache/nub/pm/virtual-store` that a `COPY --from` leaves dangling (#241).
 /// Forcing the store project-local yields the self-contained, COPY-safe tree
 /// `CI=1 nub install` already produces, while keeping the isolated layout's
@@ -742,7 +742,7 @@ enum ConfigScopeNoise {
 /// Where the isolated layout's virtual store materializes. `Default` engages
 /// the machine-global virtual store (the shared, cross-project fast path) per
 /// the embedder default; `ProjectLocal` forces GVS off so the store lands
-/// inside `node_modules/.nub` (real dirs + relative symlinks) — a self-
+/// inside `node_modules/.store` (real dirs + relative symlinks) — a self-
 /// contained, COPY-relocatable tree. Only `nub ci` requests `ProjectLocal`
 /// (see [`engine_session_ci`]); isolation/phantom-dep protection is preserved
 /// either way.
@@ -1220,6 +1220,17 @@ pub(crate) fn scope_warning_uses_dim() -> bool {
 /// epics/v0.2-aube). A `packageManager`/`devEngines` pin always outranks this:
 /// the UA impersonates the pinned version when one exists.
 pub(crate) const PNPM_PARITY_VERSION: &str = "11.3.0";
+
+/// The project-local virtual-store directory leaf under `node_modules/`.
+/// `.store` is the vendor-neutral isolated-store convention (npm isolated-mode
+/// RFC-0042, Yarn-berry's pnpm-linker `pnpmStoreFolder`, cnpm), so tools that
+/// walk `node_modules` for a project root — simple-git-hooks and its class —
+/// recognize it as an install marker; the former `.nub` leaf was invisible to
+/// them. Single source of truth for the name: `nub_setting_defaults` sets
+/// `virtualStoreDir`/`stateDir` to `node_modules/<leaf>`, and vite_compat scans
+/// it. Standalone aube is unaffected — its default stays `.aube`; this is a
+/// nub-embedder value.
+pub(crate) const PROJECT_VIRTUAL_STORE_LEAF: &str = ".store";
 
 /// Compose the lifecycle-script UA product tokens for the resolved role —
 /// everything before the `<os> <arch>` tail the engine appends. The dialect is
@@ -1946,11 +1957,11 @@ fn read_file_head(path: &Path, max_bytes: usize) -> std::io::Result<String> {
 ///   of any kind) writes nub's neutral `nub.lock` (`=aube`); every other
 ///   surface writes `pnpm-lock.yaml` (`=pnpm`) for drop-in interop. See
 ///   [`nub_setting_defaults`]'s `truly_fresh` arm.
-/// - `virtualStoreDir` / `stateDir` = `node_modules/.nub` — the isolated
-///   store (and the engine's install-state sidecar) live under `.nub`.
+/// - `virtualStoreDir` / `stateDir` = `node_modules/.store` — the isolated
+///   store (and the engine's install-state sidecar) live under `.store`.
 ///   Corner: this replaces the engine's `<modulesDir>/.aube` derivation, so
 ///   a project that renames `modulesDir` without setting `virtualStoreDir`
-///   gets the store at `node_modules/.nub` rather than `<modulesDir>/.nub`.
+///   gets the store at `node_modules/.store` rather than `<modulesDir>/.store`.
 /// - `storeDir` = `$XDG_DATA_HOME/nub/store` (else `~/.local/share/nub/store`)
 ///   — the global CAS store lives in nub's own XDG namespace, not aube's
 ///   (the engine appends its `v1` schema suffix, so content lands at
@@ -2091,7 +2102,7 @@ fn strip_yarnrc_value(rest: &str) -> &str {
 ///   longer vetoes the shared store — so the global virtual store engages
 ///   wherever it's active (off-CI, no next/nuxt/parcel trigger, no explicit
 ///   `enableGlobalVirtualStore=false`) with NO hidden tree, and the pnpm-parity
-///   hidden hoist tree (`node_modules/.nub/node_modules/`) is built wherever GVS
+///   hidden hoist tree (`node_modules/.store/node_modules/`) is built wherever GVS
 ///   is OFF (CI, `nub ci`, a trigger, an explicit GVS opt-out, dlx), restoring
 ///   ambient `@types/*` resolution for store-resident packages (#286). The ONE
 ///   carve-out is injected deps (`dependenciesMeta.*.injected`): they need the
@@ -2144,17 +2155,15 @@ fn nub_setting_defaults(
     } else {
         String::new()
     };
+    let store_dir = format!("node_modules/{PROJECT_VIRTUAL_STORE_LEAF}");
     let mut defaults = vec![
         (
             "defaultLockfileFormat".to_string(),
             fresh_format.to_string(),
         ),
         ("defaultTrust".to_string(), "true".to_string()),
-        (
-            "virtualStoreDir".to_string(),
-            "node_modules/.nub".to_string(),
-        ),
-        ("stateDir".to_string(), "node_modules/.nub".to_string()),
+        ("virtualStoreDir".to_string(), store_dir.clone()),
+        ("stateDir".to_string(), store_dir),
         (
             "disableGlobalVirtualStoreForPackages".to_string(),
             // The whole-install GVS-off last resort — reserved for a store-LOCALITY
@@ -2214,9 +2223,9 @@ fn nub_setting_defaults(
     }
     // `nub ci` forces the virtual store PROJECT-LOCAL by pushing an explicit
     // `enableGlobalVirtualStore=false` (GVS off). With GVS off and the default
-    // `hoist=true`, the isolated linker yields real `node_modules/.nub/<dep>`
+    // `hoist=true`, the isolated linker yields real `node_modules/.store/<dep>`
     // dirs + relative symlinks AND the pnpm-parity hidden hoist tree
-    // (`node_modules/.nub/node_modules/`) — a self-contained tree that survives a
+    // (`node_modules/.store/node_modules/`) — a self-contained tree that survives a
     // multi-stage-Docker `COPY --from`, unlike the machine-global store the
     // default install engages (#241). Isolation (phantom-dep protection) is
     // unchanged; only the store LOCATION moves. Embedder-tier, so an explicit
@@ -2959,7 +2968,7 @@ mod tests {
 
     #[test]
     fn setting_defaults_always_carry_the_nub_identity_settings() {
-        // Every engine command gets the `.nub` store/state location and the
+        // Every engine command gets the `.store` store/state location and the
         // nub-namespaced global dirs regardless of detection; the non-truly-
         // fresh surfaces also get the pnpm lockfile fresh-write default (the
         // truly-fresh `aube`/`lock.yaml` flip is covered separately). (These
@@ -2985,8 +2994,11 @@ mod tests {
                 VirtualStoreLocality::Default,
             );
             assert_eq!(get(&defaults, "defaultLockfileFormat"), Some("pnpm"));
-            assert_eq!(get(&defaults, "virtualStoreDir"), Some("node_modules/.nub"));
-            assert_eq!(get(&defaults, "stateDir"), Some("node_modules/.nub"));
+            assert_eq!(
+                get(&defaults, "virtualStoreDir"),
+                Some("node_modules/.store")
+            );
+            assert_eq!(get(&defaults, "stateDir"), Some("node_modules/.store"));
             // The global store lands in nub's XDG data namespace (dev boxes
             // always resolve a home dir, so the entry is present here).
             let store = get(&defaults, "storeDir").expect("storeDir default");

--- a/crates/nub-cli/src/pm_engine/present.rs
+++ b/crates/nub-cli/src/pm_engine/present.rs
@@ -74,7 +74,7 @@ pub(crate) fn info(msg: &str) {
 /// embedder seams actually configure: `defaultLockfileFormat=pnpm` (fresh
 /// lockfiles are `pnpm-lock.yaml`), the workspace-yaml list restricted to
 /// `pnpm-workspace.yaml`, the manifest config namespace restricted to
-/// `pnpm`, and `virtualStoreDir=node_modules/.nub`. Runtime messages must
+/// `pnpm`, and `virtualStoreDir=node_modules/.store`. Runtime messages must
 /// keep using [`rewrite`]: they may truthfully name on-disk files (a real
 /// `aube-lock.yaml` sitting in a project), which the word pass deliberately
 /// preserves and this map would falsify.
@@ -123,7 +123,7 @@ pub(crate) fn rewrite_help(text: impl AsRef<str>) -> String {
             "`global-links` in the engine's data directory",
         ),
         // `why --paths` example path: nub's virtualStoreDir default.
-        (".aube/<dep_path>", ".nub/<dep_path>"),
+        (".aube/<dep_path>", ".store/<dep_path>"),
         // The GVS location in engine docs;
         // described structurally — the literal path is engine cache state.
         (
@@ -461,7 +461,7 @@ mod tests {
         for name in [
             "aube-lock.yaml",
             "aube-workspace.yaml",
-            "node_modules/.nub/.aube-state",
+            "node_modules/.store/.aube-state",
             "node_modules/.aube-applied-patches.json",
             "~/.local/share/aube/store/v1",
         ] {

--- a/crates/nub-cli/src/pm_engine/vite_compat.rs
+++ b/crates/nub-cli/src/pm_engine/vite_compat.rs
@@ -80,7 +80,7 @@ fn compat_disabled(raw: Option<&str>) -> bool {
 /// Vite reaches the graph two ways, and both are handled: as a DIRECT dep (a raw
 /// `vite` app / a `vite dev` CLI project — the top-level `node_modules/vite`),
 /// and TRANSITIVELY as a framework's embedded engine (Astro/SvelteKit/VitePress
-/// — the `.nub/vite@*` isolated-store entries, no top-level symlink). A
+/// — the `.store/vite@*` isolated-store entries, no top-level symlink). A
 /// library-embedded framework is itself store-resident and loads ITS Vite via a
 /// store-to-store sibling symlink (the shared virtual-store copy, NOT the
 /// project-local ejected copy), so the dist backport cannot reach it CAS-safely
@@ -130,7 +130,7 @@ struct ViteCopy {
 }
 
 /// Enumerate every distinct Vite package in the install: the top-level
-/// `node_modules/vite` (direct dep) plus each `node_modules/.nub/vite@*`
+/// `node_modules/vite` (direct dep) plus each `node_modules/.store/vite@*`
 /// isolated-store entry (transitive/library-embedded). Deduplicated by realpath;
 /// each entry carries its version and whether it is project-local.
 fn discover_vite(node_modules: &Path) -> Vec<ViteCopy> {
@@ -143,7 +143,7 @@ fn discover_vite(node_modules: &Path) -> Vec<ViteCopy> {
         &mut seen,
         &mut out,
     );
-    if let Ok(entries) = std::fs::read_dir(node_modules.join(".nub")) {
+    if let Ok(entries) = std::fs::read_dir(node_modules.join(super::PROJECT_VIRTUAL_STORE_LEAF)) {
         for e in entries.flatten() {
             if e.file_name().to_string_lossy().starts_with("vite@") {
                 let pkg = e.path().join("node_modules").join("vite");

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -86,7 +86,7 @@ fn registry_reachable() -> bool {
 
 /// Truly-fresh project (no lockfile, no PM declaration, no pnpm-named file):
 /// nub claims identity via the neutral lockfile only. The engine resolves, links
-/// the isolated (pnpm-style) layout under `node_modules/.nub`, and writes nub's
+/// the isolated (pnpm-style) layout under `node_modules/.store`, and writes nub's
 /// neutral `nub.lock` — the quiet identity marker. It must NOT auto-stamp
 /// `packageManager` / `devEngines` into `package.json`: that exclusivity claim
 /// is reserved for the explicit `nub pm use nub` command.
@@ -115,7 +115,7 @@ fn install_truly_fresh_project_claims_nub_identity() {
     );
 
     // Isolated layout: the top-level entry is a symlink into the virtual
-    // store, which nub relocates to `node_modules/.nub`.
+    // store, which nub relocates to `node_modules/.store`.
     let dep = dir.join("node_modules/is-positive");
     assert!(
         dep.join("package.json").is_file(),
@@ -123,17 +123,24 @@ fn install_truly_fresh_project_claims_nub_identity() {
     );
     assert!(
         dep.symlink_metadata().unwrap().file_type().is_symlink(),
-        "no-lockfile projects default to the isolated layout (symlink into .nub)"
+        "no-lockfile projects default to the isolated layout (symlink into .store)"
     );
     let target = std::fs::read_link(&dep).unwrap();
     assert!(
-        target.to_string_lossy().contains(".nub/"),
-        "the virtual store must live under node_modules/.nub, got: {}",
+        target.to_string_lossy().contains(".store/"),
+        "the virtual store must live under node_modules/.store, got: {}",
         target.display()
     );
     assert!(
         !dir.join("node_modules/.aube").exists(),
         "no .aube directory may materialize"
+    );
+
+    // A patch-free install writes no applied-patches sidecar (an empty `{}`
+    // manifest is information-free clutter; a missing file reads back the same).
+    assert!(
+        !dir.join("node_modules/.nub-applied-patches.json").exists(),
+        "a patch-free install must not write an empty applied-patches sidecar"
     );
 
     assert!(
@@ -369,12 +376,12 @@ fn install_with_package_lock_isolates_and_preserves_the_npm_lockfile() {
         "is-positive must be installed: stderr: {stderr}"
     );
     // npm/yarn/bun incumbents now default to the isolated layout (the GVS flip):
-    // a declared dep is a top-level SYMLINK into the `.nub` virtual store, not a
+    // a declared dep is a top-level SYMLINK into the `.store` virtual store, not a
     // real directory. (GVS engagement itself is off-CI-gated, but the isolated
     // symlink layout holds regardless.)
     assert!(
         dep.symlink_metadata().unwrap().file_type().is_symlink(),
-        "package-lock projects default to the isolated layout (a symlink into .nub)"
+        "package-lock projects default to the isolated layout (a symlink into .store)"
     );
     assert!(
         dir.join("package-lock.json").is_file(),
@@ -905,9 +912,9 @@ fn wildcard_peer_binds_resolved_major_not_registry_highest() {
 
     // The isolated store keys every resolved version as `@babel+core@<ver>`;
     // @babel/core declares no peers so its own dirs carry no peer suffix.
-    let store = dir.join("node_modules/.nub");
+    let store = dir.join("node_modules/.store");
     let babel_majors: Vec<String> = std::fs::read_dir(&store)
-        .expect("virtual store must exist under node_modules/.nub")
+        .expect("virtual store must exist under node_modules/.store")
         .filter_map(|e| e.ok())
         .filter_map(|e| e.file_name().into_string().ok())
         .filter_map(|n| n.strip_prefix("@babel+core@").map(str::to_string))

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -6741,7 +6741,7 @@ fn external_subcommand_never_shadows_an_engine_verb() {
 /// under a flat node_modules fails — and the runtime resolve hooks annotate
 /// that specific failure with the one-line `node-linker=hoisted` opt-out.
 /// Hand-built minimal layout (no real install / network): the bare-package
-/// presence in `node_modules/.nub` plus top-level reachability is the entire
+/// presence in `node_modules/.store` plus top-level reachability is the entire
 /// discriminator, so a directory tree is enough. Guards the three branches that
 /// the gate must get right (the middle one is the regression the reachability
 /// check fixes): a true phantom hints, a subpath miss of a DECLARED dep does
@@ -6769,11 +6769,11 @@ fn phantom_dependency_miss_points_at_the_hoisted_opt_out() {
     // A graph package present ONLY in the virtual store (a phantom: installed,
     // not reachable from the project root).
     mk(
-        "node_modules/.nub/phantom-pkg@1.0.0/node_modules/phantom-pkg/package.json",
+        "node_modules/.store/phantom-pkg@1.0.0/node_modules/phantom-pkg/package.json",
         r#"{"name":"phantom-pkg","version":"1.0.0","main":"index.js"}"#,
     );
     mk(
-        "node_modules/.nub/phantom-pkg@1.0.0/node_modules/phantom-pkg/index.js",
+        "node_modules/.store/phantom-pkg@1.0.0/node_modules/phantom-pkg/index.js",
         "module.exports = 'phantom';",
     );
     let _ = &nm; // node_modules is created lazily by the writes above.
@@ -6795,7 +6795,7 @@ fn phantom_dependency_miss_points_at_the_hoisted_opt_out() {
     let phantom = run("phantom.cjs");
     assert!(
         phantom.contains("phantom dependency") && phantom.contains("node-linker=hoisted"),
-        "an undeclared transitive present in .nub must surface the opt-out hint: {phantom}"
+        "an undeclared transitive present in .store must surface the opt-out hint: {phantom}"
     );
     assert!(
         phantom.matches("phantom dependency").count() == 1,
@@ -6811,6 +6811,6 @@ fn phantom_dependency_miss_points_at_the_hoisted_opt_out() {
     let typo = run("typo.cjs");
     assert!(
         !typo.contains("phantom dependency"),
-        "a package absent from .nub is a genuine miss, not a phantom dep — no hint: {typo}"
+        "a package absent from .store is a genuine miss, not a phantom dep — no hint: {typo}"
     );
 }

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -341,7 +341,7 @@ function resolveViaParentRequire(specifier, parentURL) {
 //
 // Two conditions, both required, so the hint fires ONLY for a true phantom dep:
 //   (1) the bare package is in the project's graph — nub names every graph
-//       package `<name>@<version>` (scoped `/` → `+`) under `node_modules/.nub`,
+//       package `<name>@<version>` (scoped `/` → `+`) under `node_modules/.store`,
 //       so a matching entry means it's installed (GVS: symlinks into the global
 //       store; non-GVS: real dirs);
 //   (2) the bare package is NOT reachable at any `node_modules/<pkg>` up the
@@ -349,7 +349,7 @@ function resolveViaParentRequire(specifier, parentURL) {
 //       missing SUBPATH/file inside it (`react-dom/client-typo`), not a phantom.
 // A genuine typo / absent dep fails (1); a subpath miss of a declared dep fails
 // (2); the hoisted opt-out leaves no `<name>@*` entries (only internal state),
-// and node-suite / plain-Node trees have no `.nub` at all — none get the hint.
+// and node-suite / plain-Node trees have no `.store` at all — none get the hint.
 // NOT COVERED: the compat-tier ESM loader (Node 18.19–22.14 `import`) resolves
 // in preload-async-hooks.mjs and can't reach this CJS helper, so that band
 // surfaces Node's standard error without the hint; the fast tier (22.15+) and
@@ -379,9 +379,9 @@ function phantomDepHint(specifier, fromPath) {
     if (existsSync(join(nm, pkg))) return null;
     if (!inStore) {
       try {
-        inStore = readdirSync(join(nm, ".nub")).some((e) => e.startsWith(prefix));
+        inStore = readdirSync(join(nm, ".store")).some((e) => e.startsWith(prefix));
       } catch {
-        /* no `.nub` at this level */
+        /* no `.store` at this level */
       }
     }
     const parent = dirname(dir);

--- a/setup/DESIGN.md
+++ b/setup/DESIGN.md
@@ -16,7 +16,7 @@ The central fact that reshapes everything: **nub already does jobs (1) and (3) i
 | Provisioned Node toolchains: `<cache>/node/<version>/` (dir name IS the version) | `discovery.rs:817`; `wiki/commands/node-versions.md:33` |
 | PM engine cache (packuments, git-clone, node-gyp): `$XDG_CACHE_HOME/nub/pm` | `pm_engine/identity.rs:60-65` (`cache_namespace="nub/pm"`) |
 | Global CAS store: `$XDG_DATA_HOME/nub/store/v1` else `~/.local/share/nub/store/v1` | `identity.rs:66-68`, `mod.rs:1427` (`data_namespace="nub"`, `storeDir`) |
-| Per-project virtual store: `node_modules/.nub` | `mod.rs:1422` (`virtualStoreDir`) |
+| Per-project virtual store: `node_modules/.store` | `mod.rs` `PROJECT_VIRTUAL_STORE_LEAF` → `nub_setting_defaults` (`virtualStoreDir`) |
 | Bare `nub node install` provisions the project pin (manual form of the implicit path) | `node-versions.md:33` |
 | `nub <file>` / `nub install` auto-provision the pinned Node if absent | `node-versions.md:15,65` |
 | Node-version files read: `.node-version` (precedence #1), `.nvmrc`, `package.json` `engines.node`/`volta`/`packageManager` | `node-versions.md:44`, `discovery.rs:123` |
@@ -82,7 +82,7 @@ $XDG_CACHE_HOME/nub/pm           # packument cache, git-clone cache, node-gyp to
 $XDG_CACHE_HOME/nub/node         # provisioned Node toolchains (else ~/.cache/nub/node)
 ```
 
-Do NOT cache `node_modules/.nub` (the per-project virtual store) — it's reconstructed from the CAS store on each install and is cheap to relink; caching it fights nub's own reflink/relink path.
+Do NOT cache `node_modules/.store` (the per-project virtual store) — it's reconstructed from the CAS store on each install and is cheap to relink; caching it fights nub's own reflink/relink path.
 
 > **Correction (2026-06-16 verification pass):** the PM packument cache may NOT land at `$XDG_CACHE_HOME/nub/pm`. `store_config_family.rs:16-19` documents a KNOWN GAP — `cacheDir` can't ride the embedder-defaults tier at the pinned aube API, so the engine's `cache` operates on `<XDG_CACHE_HOME>/aube/…`. The `nub/pm` namespace is *configured* but the packument cache specifically escapes it. The load-bearing cache layers are the **store** (`nub store path`, `$XDG_DATA_HOME/nub/store/v1`) and the **Node toolchain** (`<cache>/node`) — derive both at runtime, never hardcode. Treat the PM-cache dir as best-effort (packuments are small + re-fetchable; a wrong path is a cheap miss, not breakage), and resolve the `nub/pm`-vs-`aube/` ambiguity (or drop that cache line) before flipping `cache` default to `true`.
 
@@ -250,7 +250,7 @@ Recommended: a `v0` branch (or lightweight tag) the release workflow advances to
 3. **Accept and ignore `token` / `check-latest` / `architecture` / `mirror` / `mirror-token` in v1** (setup-node compatibility).
 4. **`cache` default** (HQ2) — `false` (opt-in, pnpm-like) vs `true` (aggressive, setup-node-like). **Recommend: `false` for v1, flip after the smoke matrix proves the paths.**
 5. **`cache` is a boolean, not a pm-name enum** (HQ2) — confirm nub's single-store model means we diverge from `setup-node`'s `cache: npm|yarn|pnpm`. **Recommend: boolean.**
-6. **Cache the three dirs** (`store/v1`, `pm`, `node`), NOT `node_modules/.nub`; key on lockfile + node-version with the `restore-keys` ladder (HQ2). **Recommend: as specified.**
+6. **Cache the three dirs** (`store/v1`, `pm`, `node`), NOT `node_modules/.store`; key on lockfile + node-version with the `restore-keys` ladder (HQ2). **Recommend: as specified.**
 7. **Reuse `NODE_AUTH_TOKEN`** (not `NUB_AUTH_TOKEN`) for the `.npmrc` auth token (HQ3). **Recommend: reuse — ecosystem convention, brand-clean, drop-in.**
 8. **Emit `node-version` output unconditionally** (extra `nub node which` per run) vs only when provisioning happened (HQ4). **Recommend: unconditional — cheap, preserves contract.**
 9. **Create + maintain a floating `v0` ref** separate from `v0.0.x` (release-process, but blocks adoption). **Recommend: do it before promoting the action.**

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -178,7 +178,7 @@ A project is Nub's own in three cases: it declares Nub through `nub pm use nub`,
 - **Lockfile:** `nub.lock` — the pnpm v9 schema byte-for-byte, under Nub's own basename
 - **Package fields:** `workspaces`, `overrides`, `resolutions`, `patchedDependencies`, `allowBuilds`, `engines.node`, `scripts`
 - **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`
-- **Install state:** `node_modules/.nub/`, `.nub-state`, and the global store under Nub's own directories
+- **Install state:** `node_modules/.store/`, `.nub-state`, and the global store under Nub's own directories
 
 A fresh `nub install` records Nub as the manager with a non-locking range — `devEngines.packageManager` set to `{ name: "nub", version: "^<version>", onFail: "warn" }`, never an exact `packageManager` pin. Tools that read `devEngines` by name see the signal, and the caret is a floor, so upgrading Nub just works. To freeze the project at an exact Nub version — the corepack-visible hard pin — opt in with `nub pm use nub@<version>`; the bare `nub pm use nub` writes only the range.
 
@@ -444,7 +444,7 @@ Files materialize into `node_modules` by reflink (APFS/btrfs), hardlink (ext4), 
 
 ### Virtual store
 
-The default `node_modules` layout is **isolated**: direct dependencies sit at the top level, transitive packages link into a per-project virtual store, and phantom dependencies fail instead of resolving by accident. Nub's virtual store is `node_modules/.nub/` (pnpm uses `node_modules/.pnpm/`) — same shape, not byte-shared, so alternating tools relinks the tree.
+The default `node_modules` layout is **isolated**: direct dependencies sit at the top level, transitive packages link into a per-project virtual store, and phantom dependencies fail instead of resolving by accident. Nub's virtual store is `node_modules/.store/` (pnpm uses `node_modules/.pnpm/`) — same shape, not byte-shared, so alternating tools relinks the tree.
 
 Every incumbent defaults to **isolated** — npm, Yarn, and Bun included, alongside pnpm and Nub-identity projects. A project that relies on phantom (undeclared) dependencies opts into the flat, npm-style layout with one line in `.npmrc`:
 

--- a/site/content/docs/install/virtual-store.mdx
+++ b/site/content/docs/install/virtual-store.mdx
@@ -48,4 +48,4 @@ node-linker=hoisted
 enableGlobalVirtualStore=false
 ```
 
-The `enableGlobalVirtualStore=false` form keeps isolation and its phantom-dependency protection; it only relocates the store from the shared per-machine location to `node_modules/.nub/` inside the project. That makes the tree self-contained — it survives a Docker `COPY --from` into a fresh image, where the shared store would not exist. Nub already does this automatically in CI and under `nub ci`, so you rarely set it by hand. See [store and disk layout](/docs/install#store-and-disk-layout) for the shared-versus-project-local store in full.
+The `enableGlobalVirtualStore=false` form keeps isolation and its phantom-dependency protection; it only relocates the store from the shared per-machine location to `node_modules/.store/` inside the project. That makes the tree self-contained — it survives a Docker `COPY --from` into a fresh image, where the shared store would not exist. Nub already does this automatically in CI and under `nub ci`, so you rarely set it by hand. See [store and disk layout](/docs/install#store-and-disk-layout) for the shared-versus-project-local store in full.

--- a/tests/aube-bats/README.md
+++ b/tests/aube-bats/README.md
@@ -12,7 +12,7 @@ The default curated subset is the install family: `install.bats ci.bats add.bats
 
 Tests that cannot pass under nub are annotated at staging time (a `skip` line injected into a patched copy — `vendor/aube` is never modified) from two separate files, and the distinction is load-bearing:
 
-- [`skips.txt`](skips.txt) — **permanent, intended divergences** (`skip "nub-divergence: …"`): aube-branded behavior nub deliberately toggles off — the `node_modules/.aube` virtual-store stem (nub: `node_modules/.nub`), `aube-lock.yaml` as the fresh-project lockfile (nub: `pnpm-lock.yaml` via the `defaultLockfileFormat` embedder default), and verb/flag collisions where nub's own surface wins (`run` is nub's script runner; `-v` is `--version`).
+- [`skips.txt`](skips.txt) — **permanent, intended divergences** (`skip "nub-divergence: …"`): aube-branded behavior nub deliberately toggles off — the `node_modules/.aube` virtual-store stem (nub: `node_modules/.store`), `aube-lock.yaml` as the fresh-project lockfile (nub: `pnpm-lock.yaml` via the `defaultLockfileFormat` embedder default), and verb/flag collisions where nub's own surface wins (`run` is nub's script runner; `-v` is `--version`).
 - [`known-gaps.txt`](known-gaps.txt) — **real gaps in-flight work must close** (`skip "KNOWN-GAP: …"`): unwired verbs/flags/aliases (`recursive`, `clean-install`, `--fix-lockfile`, `--lockfile-dir`, `--reporter`, `--network-concurrency`), engine info/warn lines that don't surface through nub's presentation yet, and exit-code mapping. **This list must shrink** — when the wiring lands, delete the entries so the tests assert for real. `run.sh` hard-fails if an entry matches no test, so stale entries can't linger silently.
 
 ## Running locally

--- a/tests/aube-bats/skips.txt
+++ b/tests/aube-bats/skips.txt
@@ -6,19 +6,19 @@
 # work go in known-gaps.txt instead; tests failing for any other reason are
 # real defects to fix, not to list.
 
-# ── virtual store / engine state are nub-named (node_modules/.nub) ──────────
-install.bats|aube install creates node_modules|virtual store lands at node_modules/.nub, not node_modules/.aube
-install.bats|aube install creates .aube virtual store|virtual store lands at node_modules/.nub
-install.bats|aube install creates transitive dep symlinks in .aube|virtual store lands at node_modules/.nub
+# ── virtual store / engine state are nub-named (node_modules/.store) ──────────
+install.bats|aube install creates node_modules|virtual store lands at node_modules/.store, not node_modules/.aube
+install.bats|aube install creates .aube virtual store|virtual store lands at node_modules/.store
+install.bats|aube install creates transitive dep symlinks in .aube|virtual store lands at node_modules/.store
 install.bats|aube install writes state at node_modules/.aube-state|engine state stem follows nub's store naming (rename of the leaf-fixed .aube-state basename is tracked separately)
 install.bats|aube install self-heals when a CAS shard goes missing under a cached index|asserts the node_modules/.aube path
 install.bats|aube install preserves npm-alias as folder on fresh resolve|walks the node_modules/.aube tree
 add.bats|aube add jsr: resolves against the @jsr scope and writes jsr:<range>|asserts the node_modules/.aube path
-lockfile_settings.bats|modulesDir=custom installs into the configured directory|asserts <modulesDir>/.aube; nub's virtual store stem is .nub
+lockfile_settings.bats|modulesDir=custom installs into the configured directory|asserts <modulesDir>/.aube; nub's virtual store stem is .store
 prune.bats|aube prune --help|nub's clap help omits aube's "Remove extraneous packages" about line
-prune.bats|aube prune removes orphaned .aube entries|fixture seeds an orphan under node_modules/.aube; nub's virtual store is node_modules/.nub
+prune.bats|aube prune removes orphaned .aube entries|fixture seeds an orphan under node_modules/.aube; nub's virtual store is node_modules/.store
 prune.bats|aube prune honors virtualStoreDir|asserts the prune summary's ".aube" label; nub rebrands it to "the virtual store"
-prune.bats|aube prune removes orphan scoped .aube entries and cleans empty scope dir|fixture seeds an orphan under node_modules/.aube; nub's virtual store is node_modules/.nub
+prune.bats|aube prune removes orphan scoped .aube entries and cleans empty scope dir|fixture seeds an orphan under node_modules/.aube; nub's virtual store is node_modules/.store
 
 # ── fresh projects default to pnpm-lock.yaml (defaultLockfileFormat=pnpm) ───
 install.bats|aube install in CI generates a lockfile when none is present|fresh projects write pnpm-lock.yaml, not aube-lock.yaml

--- a/tests/bench/install/README.md
+++ b/tests/bench/install/README.md
@@ -19,7 +19,7 @@ bash tests/bench/install/run.sh --materialized
 
 ## Warm install — GVS eligibility
 
-`nub install`'s warm-install speed comes from its global virtual store. `node_modules` stays project-local, but with GVS on the inner package under `.nub/` is hardlinked from a shared store instead of materialized per project. A warm reinstall becomes a relink against an already-materialized store.
+`nub install`'s warm-install speed comes from its global virtual store. `node_modules` stays project-local, but with GVS on the inner package under `.store/` is hardlinked from a shared store instead of materialized per project. A warm reinstall becomes a relink against an already-materialized store.
 
 The main harness exercises both sides of the compatibility split:
 

--- a/tests/bench/install/run-warm-gvs.sh
+++ b/tests/bench/install/run-warm-gvs.sh
@@ -127,11 +127,11 @@ run_warm() {
   env -u CI "$NUB" install --frozen-lockfile --cwd "$WD_NUB" 2>&1 | tail -6 || true
 
   # Report which linking path nub actually took. Both GVS-on and GVS-off use the
-  # node_modules/<pkg> -> .nub/<pkg>/node_modules/<pkg> symlink layout, so the
-  # top-level symlink is NOT the signal. The real signal is INSIDE .nub: with GVS
+  # node_modules/<pkg> -> .store/<pkg>/node_modules/<pkg> symlink layout, so the
+  # top-level symlink is NOT the signal. The real signal is INSIDE .store: with GVS
   # ON the inner package is HARDLINKED from the shared global virtual store
   # (nlink>=2); with GVS OFF it is materialized fresh per-project (nlink==1).
-  local inner="$WD_NUB/node_modules/.nub/lodash@4.18.1/node_modules/lodash/package.json"
+  local inner="$WD_NUB/node_modules/.store/lodash@4.18.1/node_modules/lodash/package.json"
   if [[ -f "$inner" ]]; then
     local nlink; nlink=$(stat -f '%l' "$inner" 2>/dev/null || stat -c '%h' "$inner" 2>/dev/null)
     if [[ "${nlink:-1}" -ge 2 ]]; then

--- a/tests/brand-sweep/run.sh
+++ b/tests/brand-sweep/run.sh
@@ -11,7 +11,7 @@
 #      the sandbox must have zero effect (engine_preflight enables only the
 #      NPM + EXTERNAL env families, never the engine's own AUBE family);
 #   3. layout is nub-branded — the isolated virtual store lands at
-#      node_modules/.nub, and no node_modules/.aube or ~/.local/share/aube
+#      node_modules/.store, and no node_modules/.aube or ~/.local/share/aube
 #      (or any other aube-named path) appears anywhere in the sandbox;
 #   4. lifecycle identity is nub — npm_config_user_agent observed by a real
 #      postinstall script starts with "nub/".
@@ -85,10 +85,10 @@ pass "no aube/jdx.dev identity in install output"
 pass "AUBE_VIRTUAL_STORE_DIR canary ignored"
 
 # 3a. The install actually ran through the engine with nub's layout policy:
-# no lockfile detected -> isolated linker, virtual store at node_modules/.nub.
-[ -d node_modules/.nub ] || fail "expected isolated virtual store at node_modules/.nub"
+# no lockfile detected -> isolated linker, virtual store at node_modules/.store.
+[ -d node_modules/.store ] || fail "expected isolated virtual store at node_modules/.store"
 [ -e node_modules/left-pad ] || fail "left-pad was not installed"
-pass "isolated install landed at node_modules/.nub"
+pass "isolated install landed at node_modules/.store"
 
 # 3b. No aube-named paths anywhere in the sandbox — node_modules/.aube,
 # ~/.local/share/aube, XDG dirs, and anything else. The allowlist is EMPTY:
@@ -106,7 +106,7 @@ fi
 # The engine's freshness sidecar must carry nub's stem (product-identity
 # derivation in vendor/aube): .nub-state under the virtual store, and no
 # .aube-state anywhere (covered by the find above).
-[ -d node_modules/.nub/.nub-state ] || fail "expected install state at node_modules/.nub/.nub-state"
+[ -d node_modules/.store/.nub-state ] || fail "expected install state at node_modules/.store/.nub-state"
 # The engine cache must land in nub's namespace (set_cache_root seam):
 # packument caches under $XDG_CACHE_HOME/nub/pm/.
 [ -d "$XDG_CACHE_HOME/nub/pm" ] || fail "expected engine cache at \$XDG_CACHE_HOME/nub/pm"
@@ -180,9 +180,9 @@ fi
 if grep -inE 'aube|jdx\.dev' "$SANDBOX/install-output2.txt"; then
   fail "engine-branded identity reached nub's output under $other_mode (above)"
 fi
-[ -d node_modules/.nub ] || fail "($other_mode) expected isolated virtual store at node_modules/.nub"
+[ -d node_modules/.store ] || fail "($other_mode) expected isolated virtual store at node_modules/.store"
 [ ! -e node_modules/.aube ] || fail "($other_mode) engine created node_modules/.aube"
-[ -d node_modules/.nub/.nub-state ] || fail "($other_mode) expected install state at node_modules/.nub/.nub-state"
+[ -d node_modules/.store/.nub-state ] || fail "($other_mode) expected install state at node_modules/.store/.nub-state"
 leaks=$(find "$SANDBOX" -name '*aube*' ! -path "$AUBE_VIRTUAL_STORE_DIR" 2>/dev/null || true)
 if [ -n "$leaks" ]; then
   echo "$leaks"

--- a/tests/vite-compat/driver.sh
+++ b/tests/vite-compat/driver.sh
@@ -72,9 +72,9 @@ inst=$?
 [ $inst -eq 0 ] || { fail "nub install exit $inst"; tail -5 /tmp/vc-$name-install.log >&2; exit 2; }
 
 # Vite reaches the graph as a direct dep (top-level node_modules/vite) OR
-# transitively as a framework's embedded engine (only .nub/vite@* entries, no
+# transitively as a framework's embedded engine (only .store/vite@* entries, no
 # top-level symlink). Detect + resolve the LOADED vite either way: prefer what
-# the framework/CLI actually imports (node resolution), else the first .nub entry.
+# the framework/CLI actually imports (node resolution), else the first .store entry.
 read -r vite_ver realpath_vite < <(node -e '
 const fs=require("fs"),p=require("path");
 function ver(d){try{return require(p.join(d,"package.json")).version}catch{return null}}
@@ -82,8 +82,8 @@ let dir=null;
 try{ // what would `vite dev` / the framework load?
   dir=p.dirname(fs.realpathSync(require.resolve("vite/package.json",{paths:[process.cwd()]})));
 }catch{}
-if(!dir){ // transitive-only: scan .nub/vite@*
-  const nb=p.join("node_modules",".nub");
+if(!dir){ // transitive-only: scan .store/vite@*
+  const nb=p.join("node_modules",".store");
   for(const e of (fs.existsSync(nb)?fs.readdirSync(nb):[])){
     if(e.startsWith("vite@")){const c=p.join(nb,e,"node_modules","vite");if(fs.existsSync(c)){dir=fs.realpathSync(c);break}}
   }

--- a/vendor/aube/crates/aube-linker/src/patches.rs
+++ b/vendor/aube/crates/aube-linker/src/patches.rs
@@ -63,9 +63,23 @@ pub(crate) fn write_applied_patches(
     map: &BTreeMap<String, String>,
 ) -> std::io::Result<()> {
     let path = nm_dir.join(applied_patches_sidecar_name());
-    let out = serde_json::to_string(map)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    aube_util::fs_atomic::atomic_write(&path, out.as_bytes())
+    // No patches applied ⇒ no sidecar: an empty `{}` manifest carries no
+    // information (a missing file already reads back as the empty map in
+    // read_applied_patches, so wipe-on-change is unchanged), and writing it
+    // clutters every patch-free `node_modules` with a stray dotfile. Remove a
+    // stale non-empty sidecar too, so `patch-remove`'ing the last patch cleans
+    // up after itself. Best-effort unlink — a missing file is the success case.
+    if map.is_empty() {
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    } else {
+        let out = serde_json::to_string(map)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        aube_util::fs_atomic::atomic_write(&path, out.as_bytes())
+    }
 }
 
 /// Wipe `.aube/<dep_path>` for any package whose patch fingerprint
@@ -727,6 +741,34 @@ fn split_patch_sections(text: &str) -> Vec<PatchSection> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn empty_patch_set_writes_no_sidecar_and_cleans_a_stale_one() {
+        // A patch-free install must not litter `node_modules` with an empty
+        // `{}` manifest — a missing file already reads back as the empty map,
+        // so the sidecar carries no information. And removing the last patch
+        // (non-empty → empty) must delete the now-stale sidecar.
+        let dir = tempfile::tempdir().unwrap();
+        let nm = dir.path();
+        let sidecar = nm.join(applied_patches_sidecar_name());
+
+        write_applied_patches(nm, &BTreeMap::new()).unwrap();
+        assert!(
+            !sidecar.exists(),
+            "empty patch set must not create the sidecar"
+        );
+
+        let one: BTreeMap<String, String> =
+            [("left-pad@1.0.0".to_string(), "deadbeef".to_string())].into();
+        write_applied_patches(nm, &one).unwrap();
+        assert!(sidecar.exists(), "a real patch set writes the sidecar");
+
+        write_applied_patches(nm, &BTreeMap::new()).unwrap();
+        assert!(
+            !sidecar.exists(),
+            "dropping the last patch must remove the stale sidecar"
+        );
+    }
 
     #[cfg(windows)]
     #[test]

--- a/vendor/aube/crates/aube/src/commands/config/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/config/mod.rs
@@ -1010,7 +1010,7 @@ mod tests {
         let _lock = config_test_lock();
         aube_settings::set_embedder_defaults(vec![(
             "virtualStoreDir".to_string(),
-            "node_modules/.nub".to_string(),
+            "node_modules/.store".to_string(),
         )]);
         let dir = tempfile::tempdir().unwrap();
         let project = dir.path();
@@ -1020,7 +1020,7 @@ mod tests {
 
         assert_eq!(
             get_cmd::find_value(&entries, &aliases).as_deref(),
-            Some("node_modules/.nub"),
+            Some("node_modules/.store"),
             "config get must report embedder defaults when no higher source overrides them"
         );
 
@@ -1029,7 +1029,7 @@ mod tests {
             seen.get("virtualStoreDir")
                 .or_else(|| seen.get("virtual-store-dir"))
                 .map(String::as_str),
-            Some("node_modules/.nub"),
+            Some("node_modules/.store"),
             "config list must include embedder defaults"
         );
     }

--- a/vendor/aube/crates/aube/src/commands/prune.rs
+++ b/vendor/aube/crates/aube/src/commands/prune.rs
@@ -161,7 +161,7 @@ pub async fn run(args: PruneArgs) -> miette::Result<()> {
         } else {
             None
         };
-        // The virtual-store leaf (e.g. `.nub`) scopes the dangling-symlink
+        // The virtual-store leaf (e.g. `.store`) scopes the dangling-symlink
         // sweep to store-pointing symlinks, sparing `link:`/`portal:` deps.
         prune_top_level(
             &nm,

--- a/vendor/aube/crates/aube/src/commands/settings_context.rs
+++ b/vendor/aube/crates/aube/src/commands/settings_context.rs
@@ -634,7 +634,7 @@ pub(crate) fn resolve_virtual_store_dir(
     });
     // An embedder-supplied default (keyed by canonical setting name) counts
     // as explicit too — without this check a `virtualStoreDir` registered via
-    // `set_embedder_defaults` (e.g. a host that wants `node_modules/.nub`)
+    // `set_embedder_defaults` (e.g. a host that wants `node_modules/.store`)
     // would be silently discarded in favor of the `<modulesDir>/.aube`
     // derivation, since `resolved::virtual_store_dir` *does* honor the
     // embedder-defaults source via the ctx. Standalone aube registers no


### PR DESCRIPTION
Renames the project-local isolated virtual-store directory from `node_modules/.nub` to `node_modules/.store`, and stops writing an empty applied-patches sidecar.

## Why `.store`

`.store` is the vendor-neutral isolated-store convention — npm's own isolated-mode RFC-0042, Yarn-berry's pnpm-linker (`pnpmStoreFolder`), and cnpm all default to `node_modules/.store`. Tools that walk `node_modules` to find a project root recognize it as an install marker; `.nub` was invisible to them. It is also brand-cleaner.

The concrete fix is the simple-git-hooks class. simple-git-hooks looks for a `.store` (or `.pnpm`/`.deno`) path segment to locate the project root in its postinstall — it does not know `.nub`. Under a project-local store the package lands at `node_modules/.nub/simple-git-hooks@2.13.1/node_modules/simple-git-hooks`, so the old resolver fell through to its "ends in `node_modules/<pkg>`" branch and returned the store slot dir as the root, then crashed with `ENOENT` reading a `package.json` that isn't there. With `.store` the marker resolves to the real project root:

```
OLD .nub  -> resolved root: <proj>/node_modules/.nub/simple-git-hooks@2.13.1   (no package.json -> ENOENT)
NEW .store -> resolved root: <proj>                                            (correct)
```

## Empty applied-patches sidecar

A patch-free install wrote `node_modules/.nub-applied-patches.json` containing `{}` — information-free clutter, since a missing file already reads back as the empty map. `write_applied_patches` now skips the write when the patch set is empty and removes a stale sidecar when the last patch is dropped. This is correct for standalone aube too (an empty manifest carries nothing).

## Scope

- Project-local store only. The machine-global store (`~/.cache/nub/pm/virtual-store/`) is unchanged — a separate, larger blast radius, and it isn't under the project so it doesn't affect the store-marker case.
- The nub-branded state filenames (`.nub-state`, `.nub-applied-patches.json`) are embedder-name-derived, not store-marker directories, so they keep the nub brand; only the containing store dir renamed. The install state now lives at `node_modules/.store/.nub-state/`.
- Standalone aube's default (`.aube`) is unchanged — this is a nub-embedder value. The store-dir name has a single source of truth (`PROJECT_VIRTUAL_STORE_LEAF`), consumed by the setting defaults, the vite-compat scan, and the runtime phantom-dep detector.

## Verification

- `nub install` on a fresh fixture lands the store at `node_modules/.store/`, with top-level symlinks pointing into it and no applied-patches sidecar.
- simple-git-hooks fixture (project-local store): `nub install` exits 0 with no ENOENT; run from the store package dir the postinstall resolves the correct project root and installs the hook.
- Under the default global virtual store the store entry's realpath is the machine-global store (outside the project), so the marker is out of reach there regardless of its name — the fix lands for the project-local store (CI / `nub ci` / GVS-off), which is where postinstall root-resolution runs.
- Gates green: `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, updated unit + e2e tests (store-defaults, rewrite passthrough, phantom-dep hint, a new empty-sidecar test, and an install assertion that no sidecar is written).
