### PR TITLE
feat(env): add --no-env-file to disable all env-file loading

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -2220,12 +2220,11 @@ fn run_nubx() -> Result<i32> {
     // two mechanisms are needed (clap fails-closed on a future Node flag).
     let mut args: Vec<String> = env::args().skip(1).collect();
 
-    // `--help`/`--version`/`--no-env-file` are nubx's own flags only when they
-    // appear BEFORE the subject (the three-position rule: a flag after the subject
-    // reaches the resolved runner verbatim — `nubx eslint --help` is eslint's
-    // help). When no subject has been seen yet and one of these leading flags
-    // appears, honor it like `nub --help`/`nub --version`/`nub --no-env-file`.
-    let mut no_env_file_seen = false;
+    // `--help`/`--version` are nubx's own flags only when they appear BEFORE the
+    // subject (the three-position rule: a flag after the subject reaches the
+    // resolved runner verbatim — `nubx eslint --help` is eslint's help). When no
+    // subject has been seen yet and one of these leading flags appears, honor it
+    // like `nub --help`/`nub --version`.
     for arg in &args {
         if arg == "--" || !arg.starts_with('-') {
             break; // subject (or its `--` separator) — stop scanning
@@ -2239,23 +2238,62 @@ fn run_nubx() -> Result<i32> {
                 print_version();
                 return Ok(0);
             }
-            // Record + strip below; this is nub's own flag (Node has no
-            // `--no-env-file`), so it must not reach the file runner's Node argv.
-            "--no-env-file" => no_env_file_seen = true,
             _ => {}
         }
     }
+
+    // `--no-env-file` in the LEADING region. Because it WINS over `--env-file`,
+    // and the standalone-nubx File tier would otherwise FORWARD a leading
+    // `--env-file`/`--env-file-if-exists` to Node (which loads it), the whole
+    // `--env-file*` family is stripped alongside `--no-env-file` — otherwise
+    // `--no-env-file` fails to win on this surface (the Nub-entry path already
+    // captures those flags itself, so the leak is nubx-only). Both scans below
+    // account for the space-form value token so a flag's value is never taken as
+    // the subject; the leading-only scope preserves a post-subject occurrence as
+    // the program's own arg.
+    let is_env_file_value_flag = |a: &str| a == "--env-file" || a == "--env-file-if-exists";
+    let mut no_env_file_seen = false;
+    let mut idx = 0;
+    while idx < args.len() {
+        let a = args[idx].as_str();
+        if a == "--" || !a.starts_with('-') {
+            break; // subject / separator
+        }
+        if a == "--no-env-file" {
+            no_env_file_seen = true;
+        } else if is_env_file_value_flag(a) {
+            idx += 1; // its value is not a subject — skip it
+        }
+        idx += 1;
+    }
     if no_env_file_seen {
         let _ = NO_ENV_FILE.set(true);
-        // Drop the LEADING `--no-env-file` tokens so they never reach Node; one
-        // after the subject is the program's own arg and passes through untouched.
+        let mut stripped = Vec::with_capacity(args.len());
         let mut in_leading = true;
-        args.retain(|arg| {
-            if in_leading && (arg == "--" || !arg.starts_with('-')) {
+        let mut idx = 0;
+        while idx < args.len() {
+            let a = args[idx].as_str();
+            if in_leading && (a == "--" || !a.starts_with('-')) {
                 in_leading = false;
             }
-            !(in_leading && arg == "--no-env-file")
-        });
+            if in_leading {
+                if a == "--no-env-file" {
+                    idx += 1;
+                    continue;
+                }
+                if is_env_file_value_flag(a) {
+                    idx += 2; // drop the flag and its value token
+                    continue;
+                }
+                if a.starts_with("--env-file=") || a.starts_with("--env-file-if-exists=") {
+                    idx += 1;
+                    continue;
+                }
+            }
+            stripped.push(args[idx].clone());
+            idx += 1;
+        }
+        args = stripped;
     }
 
     let cwd = env::current_dir().ok();

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -168,12 +168,31 @@ fn env_file_flag_present() -> bool {
     ENV_FILE_PRESENT.get().copied().unwrap_or(false)
 }
 
+/// Whether `--no-env-file` was passed. It means "load ZERO env files": eager
+/// `.env*` auto-discovery is suppressed AND any explicit `--env-file` is ignored
+/// (`--no-env-file` WINS over `--env-file`, decided 2026-07-07). All non-env
+/// augmentation (TS/JSX/module hooks) is unaffected. Flag-only, no env-var
+/// companion and no tree-wide inheritance — the same per-process boundary as
+/// `--env-file` (a child `nub`/`node` it spawns does not inherit the suppression).
+static NO_ENV_FILE: OnceLock<bool> = OnceLock::new();
+
+/// True iff the user passed `--no-env-file`. The authoritative kill-switch read
+/// by every env-file consumer ([`merge_child_env`], [`overlay_env_file_vars`],
+/// [`apply_env_file_vars`], and the auto-discovery load sites).
+fn no_env_file() -> bool {
+    NO_ENV_FILE.get().copied().unwrap_or(false)
+}
+
 /// Overlay the `--env-file` vars onto an env map bound for a child's
 /// `Command::env`. Shell env still wins (skip keys already in this process's
 /// environment); `--env-file` overrides `.env` (insert over existing entries).
 /// `--env-file` vars are thus handled uniformly with `.env` vars — both flow
 /// through the same per-spawn `Command::env` application.
 fn overlay_env_file_vars(env_map: &mut HashMap<String, String>) {
+    // `--no-env-file` wins over `--env-file`: overlay nothing.
+    if no_env_file() {
+        return;
+    }
     if let Some(vars) = ENV_FILE_VARS.get() {
         for (k, v) in vars {
             if env::var_os(k).is_none() {
@@ -193,13 +212,20 @@ fn overlay_env_file_vars(env_map: &mut HashMap<String, String>) {
 /// `auto_env` is the already-loaded `.env*` map (callers pass `load_env_files`'s
 /// result, which honors NODE_ENV + ${VAR} expansion); `env_file_present` is the
 /// flag-presence signal; `explicit_vars` is `ENV_FILE_VARS` (the parsed
-/// `--env-file` contents). This is a pure function over its inputs so the
-/// suppression contract can be unit-tested without spawning a child.
+/// `--env-file` contents); `no_env_file` is the `--no-env-file` kill-switch. This
+/// is a pure function over its inputs so the suppression contract can be
+/// unit-tested without spawning a child.
 fn merge_child_env(
     auto_env: HashMap<String, String>,
     env_file_present: bool,
     explicit_vars: &HashMap<String, String>,
+    no_env_file: bool,
 ) -> HashMap<String, String> {
+    // `--no-env-file` WINS over everything: load ZERO env files — both auto-
+    // discovery and explicit `--env-file` are suppressed (decided 2026-07-07).
+    if no_env_file {
+        return HashMap::new();
+    }
     // Explicit `--env-file` opts out of auto-discovery: start from an empty map,
     // not the auto-loaded one, so none of the four `.env*` files leak through.
     let mut env_map = if env_file_present {
@@ -243,6 +269,10 @@ fn watch_inject_vars<'a>(
 /// (`nubx` non-node launchers, the dlx fallback) that don't build an env map.
 /// Same precedence as [`overlay_env_file_vars`].
 fn apply_env_file_vars(cmd: &mut std::process::Command) {
+    // `--no-env-file` wins over `--env-file`: apply nothing.
+    if no_env_file() {
+        return;
+    }
     if let Some(vars) = ENV_FILE_VARS.get() {
         for (k, v) in vars {
             if env::var_os(k).is_none() {
@@ -1170,6 +1200,9 @@ fn run_nub() -> Result<i32> {
     // yielded vars (an empty file still counts as intent). Drives suppression of
     // the eager `.env*` auto-discovery.
     let mut env_file_present = false;
+    // `--no-env-file`: load zero env files. Wins over `--env-file` regardless of
+    // order (both are captured, the flag decides at the end of the scan).
+    let mut no_env_file = false;
 
     let mut i = 0;
     while i < raw_args.len() {
@@ -1238,6 +1271,12 @@ fn run_nub() -> Result<i32> {
             s if s.starts_with("--loglevel=") => {
                 loglevel_val = Some(s["--loglevel=".len()..].to_string());
             }
+            // `--no-env-file` suppresses ALL env-file loading (auto-discovery +
+            // any explicit `--env-file`). Consumed here so it never reaches Node
+            // (which has no such flag); after the entrypoint it forwards to the
+            // script (the three-position rule). Wins over `--env-file` regardless
+            // of order — the two flags may both appear, this decides at scan end.
+            "--no-env-file" => no_env_file = true,
             s if s == "--env-file"
                 || s.starts_with("--env-file=")
                 || s == "--env-file-if-exists"
@@ -1388,6 +1427,8 @@ fn run_nub() -> Result<i32> {
     // Record flag presence so the run/watch paths can suppress eager `.env*`
     // auto-discovery when the user named explicit env file(s).
     let _ = ENV_FILE_PRESENT.set(env_file_present);
+    // Record `--no-env-file` so every env-file consumer loads nothing.
+    let _ = NO_ENV_FILE.set(no_env_file);
 
     SHOW_WARNINGS.store(show_warnings, Ordering::Relaxed);
     SILENT.store(silent, Ordering::Relaxed);
@@ -2177,13 +2218,14 @@ fn run_nubx() -> Result<i32> {
     // re-dispatch to `nub run`). The classifier is `crate::nubx_resolve::classify`;
     // this function only maps each route to its runner. See that module for why the
     // two mechanisms are needed (clap fails-closed on a future Node flag).
-    let args: Vec<String> = env::args().skip(1).collect();
+    let mut args: Vec<String> = env::args().skip(1).collect();
 
-    // `--help`/`--version` are nubx's own flags only when they appear BEFORE the
-    // subject (the three-position rule: a flag after the subject reaches the
-    // resolved runner verbatim — `nubx eslint --help` is eslint's help). When no
-    // subject has been seen yet and one of these leading flags appears, honor it
-    // like `nub --help`/`nub --version`.
+    // `--help`/`--version`/`--no-env-file` are nubx's own flags only when they
+    // appear BEFORE the subject (the three-position rule: a flag after the subject
+    // reaches the resolved runner verbatim — `nubx eslint --help` is eslint's
+    // help). When no subject has been seen yet and one of these leading flags
+    // appears, honor it like `nub --help`/`nub --version`/`nub --no-env-file`.
+    let mut no_env_file_seen = false;
     for arg in &args {
         if arg == "--" || !arg.starts_with('-') {
             break; // subject (or its `--` separator) — stop scanning
@@ -2197,8 +2239,23 @@ fn run_nubx() -> Result<i32> {
                 print_version();
                 return Ok(0);
             }
+            // Record + strip below; this is nub's own flag (Node has no
+            // `--no-env-file`), so it must not reach the file runner's Node argv.
+            "--no-env-file" => no_env_file_seen = true,
             _ => {}
         }
+    }
+    if no_env_file_seen {
+        let _ = NO_ENV_FILE.set(true);
+        // Drop the LEADING `--no-env-file` tokens so they never reach Node; one
+        // after the subject is the program's own arg and passes through untouched.
+        let mut in_leading = true;
+        args.retain(|arg| {
+            if in_leading && (arg == "--" || !arg.starts_with('-')) {
+                in_leading = false;
+            }
+            !(in_leading && arg == "--no-env-file")
+        });
     }
 
     let cwd = env::current_dir().ok();
@@ -2438,10 +2495,11 @@ fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path, exec_ua: bool
 
     // .env loading: eager for all non-compat invocations per wiki/runtime/env-loading.md —
     // UNLESS the user passed `--env-file`, which suppresses auto-discovery entirely
-    // (only the named file(s) load; the maintainer, 2026-06-15). `merge_child_env` applies the
-    // gate. --env-file vars apply even in compat mode (explicit user flag).
+    // (only the named file(s) load; the maintainer, 2026-06-15), OR `--no-env-file`,
+    // which suppresses everything. `merge_child_env` applies the gate. --env-file
+    // vars apply even in compat mode (explicit user flag); --no-env-file wins.
     let project = nub_core::workspace::detect::detect_project(cwd);
-    let auto_env = if !compat_mode {
+    let auto_env = if !compat_mode && !no_env_file() {
         project
             .as_ref()
             .map(|p| nub_core::workspace::env::load_env_files(&p.root))
@@ -2453,6 +2511,7 @@ fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path, exec_ua: bool
         auto_env,
         env_file_flag_present(),
         ENV_FILE_VARS.get().unwrap_or(&HashMap::new()),
+        no_env_file(),
     );
 
     // Bin-exec parity with `nub run`: when this spawn is nub LAUNCHING a resolved
@@ -4409,10 +4468,12 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     // — neither the `discover_env_files` `--env-file` Node args nor the pre-expanded
     // `load_env_files` map are populated, so only the user's explicit file(s) reach
     // the child. This keeps `nub --watch --env-file …` consistent with the direct
-    // file runner.
+    // file runner. `--no-env-file` suppresses BOTH the auto args and the explicit
+    // `--env-file` overlay — the watched Node receives no `--env-file` args at all.
     let env_file_present = env_file_flag_present();
+    let no_env_file = no_env_file();
     let project = nub_core::workspace::detect::detect_project(&cwd);
-    let env_file_paths = if env_file_present {
+    let env_file_paths = if env_file_present || no_env_file {
         Vec::new()
     } else {
         project
@@ -4425,10 +4486,11 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     // single read (rather than `load_env_files` + a second `load_env_files_raw`)
     // avoids re-parsing every file twice and closes the TOCTOU window where a file
     // changing between two reads could spuriously inject a plain var.
-    let raw_env = if env_file_present {
+    let raw_env = if env_file_present || no_env_file {
         // `--env-file` suppresses auto-discovery: no auto `--env-file` args reach
         // Node, so injection is the only delivery channel — leave `raw_env` empty
-        // so the inject loop injects every var (see `watch_inject_vars`).
+        // so the inject loop injects every var (see `watch_inject_vars`). Under
+        // `--no-env-file` `merge_child_env` returns empty, so nothing is injected.
         HashMap::new()
     } else {
         project
@@ -4448,6 +4510,7 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
         auto_env,
         env_file_present,
         ENV_FILE_VARS.get().unwrap_or(&HashMap::new()),
+        no_env_file,
     );
 
     let nub_binary = nub_core::node::spawn::current_nub_binary()?;
@@ -5926,6 +5989,7 @@ nub {v} — the all-in-one Node.js toolkit
   --color[=<when>]     color mode: auto (default), always, never
   --env-file <file>    load environment variables from <file>
   --env-file-if-exists <file>  like --env-file, but skip silently if <file> is absent
+  --no-env-file        load no env files: no `.env*` auto-discovery, no --env-file
   --node               run on plain Node, no augmentation (the compat escape hatch)
   -v, --version        print the nub version
   -h, --help           print help (`-h` curated, `--help` this full reference)
@@ -7915,7 +7979,7 @@ mod tests {
         let explicit = HashMap::from([("NUB_TEST_BAZ".to_string(), "from_explicit".to_string())]);
 
         // (a) flag present → autos suppressed, only the explicit var survives.
-        let merged = merge_child_env(auto(), true, &explicit);
+        let merged = merge_child_env(auto(), true, &explicit, false);
         assert_eq!(
             merged.get("NUB_TEST_BAZ").map(String::as_str),
             Some("from_explicit"),
@@ -7927,7 +7991,7 @@ mod tests {
         );
 
         // (b) no flag → autos load, explicit map is empty so nothing else appears.
-        let merged = merge_child_env(auto(), false, &HashMap::new());
+        let merged = merge_child_env(auto(), false, &HashMap::new(), false);
         assert_eq!(
             merged.get("NUB_TEST_FOO").map(String::as_str),
             Some("from_dotenv")
@@ -7941,7 +8005,7 @@ mod tests {
         // explicit file's value that wins, never a leaked auto value (autos are gone).
         let explicit_override =
             HashMap::from([("NUB_TEST_FOO".to_string(), "from_explicit".to_string())]);
-        let merged = merge_child_env(auto(), true, &explicit_override);
+        let merged = merge_child_env(auto(), true, &explicit_override, false);
         assert_eq!(
             merged.get("NUB_TEST_FOO").map(String::as_str),
             Some("from_explicit"),
@@ -7950,6 +8014,15 @@ mod tests {
         assert!(
             !merged.contains_key("NUB_TEST_BAR"),
             "non-overridden auto var stays suppressed; got {merged:?}"
+        );
+
+        // (d) `--no-env-file` WINS over everything: no autos, and the explicit
+        // `--env-file` map is ignored too — the child gets ZERO env-file vars,
+        // even when `--env-file` was also present (decided 2026-07-07).
+        let merged = merge_child_env(auto(), true, &explicit, true);
+        assert!(
+            merged.is_empty(),
+            "--no-env-file must suppress both auto-discovery and explicit --env-file; got {merged:?}"
         );
     }
 

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -3435,6 +3435,141 @@ fn env_file_flag_preserves_unquoted_json_value_without_auto_dotenv() {
 }
 
 #[test]
+fn no_env_file_suppresses_auto_dotenv_but_keeps_augmentation() {
+    // `--no-env-file` means "load zero env files": the auto-discovered `.env`
+    // must not reach the child, while the OTHER augmentation stays ON — a `.ts`
+    // entrypoint (type-annotated source) still runs.
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"noenvfile"}"#).unwrap();
+    std::fs::write(dir.join(".env"), "SECRET=from-dotenv\n").unwrap();
+    std::fs::write(
+        dir.join("main.ts"),
+        "const answer: number = 7;\n\
+         console.log('TS=' + answer);\n\
+         console.log('SECRET=[' + (process.env.SECRET ?? '') + ']');\n",
+    )
+    .unwrap();
+
+    let out = Command::new(nub_binary())
+        .arg("--no-env-file")
+        .arg("main.ts")
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", dir.join("cache"))
+        .output()
+        .expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(out.status.code(), Some(0), "stderr: {stderr}");
+    assert!(
+        stdout.contains("TS=7"),
+        "non-env augmentation (TS enum) must still run under --no-env-file: {stdout}"
+    );
+    assert!(
+        stdout.contains("SECRET=[]"),
+        "--no-env-file must suppress the auto-loaded `.env`: {stdout}"
+    );
+}
+
+#[test]
+fn no_env_file_wins_over_explicit_env_file() {
+    // Precedence (decided 2026-07-07): `--no-env-file` beats `--env-file` — the
+    // explicit file is ignored too, so the child gets ZERO env-file vars.
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"noenvfile-wins"}"#).unwrap();
+    std::fs::write(dir.join(".env"), "SECRET=from-dotenv\n").unwrap();
+    std::fs::write(dir.join("custom.env"), "FROMCUSTOM=custom-val\n").unwrap();
+    std::fs::write(
+        dir.join("app.js"),
+        "console.log('SECRET=[' + (process.env.SECRET ?? '') + ']');\n\
+         console.log('FROMCUSTOM=[' + (process.env.FROMCUSTOM ?? '') + ']');\n",
+    )
+    .unwrap();
+
+    let out = Command::new(nub_binary())
+        .args(["--no-env-file", "--env-file=custom.env", "app.js"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", dir.join("cache"))
+        .output()
+        .expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(out.status.code(), Some(0), "stderr: {stderr}");
+    assert!(
+        stdout.contains("SECRET=[]"),
+        "auto `.env` must stay suppressed under --no-env-file: {stdout}"
+    );
+    assert!(
+        stdout.contains("FROMCUSTOM=[]"),
+        "--no-env-file must ignore the explicit --env-file (precedence): {stdout}"
+    );
+}
+
+/// `--no-env-file` on the watch path: the `.env*` files are neither handed to the
+/// watched Node as `--env-file` args nor injected via `Command::env`, so the child
+/// sees none of them. The watch loop never exits on its own, so the probe writes
+/// its findings to a sentinel file on its first run; the test polls, then kills
+/// the watcher. Unix-only (uses a process kill), mirroring the NODE_COMPAT watch
+/// test.
+#[cfg(unix)]
+#[test]
+fn no_env_file_suppresses_dotenv_under_watch() {
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"noenvfile-watch"}"#).unwrap();
+    std::fs::write(dir.join(".env"), "WATCH_ENV=from_dotenv\n").unwrap();
+    let out_file = dir.join("probe-out.txt");
+    std::fs::write(
+        dir.join("probe.js"),
+        format!(
+            "const fs=require('fs');\n\
+             fs.writeFileSync({out:?}, 'WATCH_ENV='+(process.env.WATCH_ENV||'')+'\\n');\n",
+            out = out_file.to_string_lossy()
+        ),
+    )
+    .unwrap();
+
+    let mut child = Command::new(nub_binary())
+        .args(["--watch", "--no-env-file", "probe.js"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", dir.join("cache"))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn nub watch");
+
+    let mut snapshot = None;
+    for _ in 0..100 {
+        if let Ok(s) = std::fs::read_to_string(&out_file)
+            && s.contains("WATCH_ENV=")
+        {
+            snapshot = Some(s);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let snapshot = snapshot.expect("`nub watch` probe never ran (no sentinel file)");
+    assert!(
+        snapshot.contains("WATCH_ENV=\n"),
+        "--no-env-file `nub watch` must NOT hand `.env` to Node: {snapshot:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn env_precedence_with_app_env_mode() {
     // `APP_ENV` selects the mode (`.env.development` here); `NODE_ENV` no longer
     // does (dropped as a mode source — it is the app's own dev/prod variable).

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -3512,6 +3512,39 @@ fn no_env_file_wins_over_explicit_env_file() {
     );
 }
 
+#[test]
+fn no_env_file_wins_over_env_file_if_exists() {
+    // `--no-env-file` beats `--env-file-if-exists` too — the whole `--env-file*`
+    // family feeds one collected map that the kill-switch suppresses. The named
+    // file exists (so `-if-exists` would otherwise load it), proving suppression.
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"noenvfile-ifexists"}"#).unwrap();
+    std::fs::write(dir.join("present.env"), "FROMCUSTOM=custom-val\n").unwrap();
+    std::fs::write(
+        dir.join("app.js"),
+        "console.log('FROMCUSTOM=[' + (process.env.FROMCUSTOM ?? '') + ']');\n",
+    )
+    .unwrap();
+
+    let out = Command::new(nub_binary())
+        .args(["--no-env-file", "--env-file-if-exists=present.env", "app.js"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", dir.join("cache"))
+        .output()
+        .expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(out.status.code(), Some(0), "stderr: {stderr}");
+    assert!(
+        stdout.contains("FROMCUSTOM=[]"),
+        "--no-env-file must ignore an existing --env-file-if-exists target: {stdout}"
+    );
+}
+
 /// `--no-env-file` on the watch path: the `.env*` files are neither handed to the
 /// watched Node as `--env-file` args nor injected via `Command::env`, so the child
 /// sees none of them. The watch loop never exits on its own, so the probe writes

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -3529,7 +3529,11 @@ fn no_env_file_wins_over_env_file_if_exists() {
     .unwrap();
 
     let out = Command::new(nub_binary())
-        .args(["--no-env-file", "--env-file-if-exists=present.env", "app.js"])
+        .args([
+            "--no-env-file",
+            "--env-file-if-exists=present.env",
+            "app.js",
+        ])
         .current_dir(&dir)
         .env("XDG_CACHE_HOME", dir.join("cache"))
         .output()
@@ -3542,6 +3546,50 @@ fn no_env_file_wins_over_env_file_if_exists() {
     assert!(
         stdout.contains("FROMCUSTOM=[]"),
         "--no-env-file must ignore an existing --env-file-if-exists target: {stdout}"
+    );
+}
+
+/// The standalone `nubx` binary forwards `--env-file` to Node itself (it is a
+/// Node value-flag, not captured by nub's own arg loop), so `--no-env-file` must
+/// win by STRIPPING the leading `--env-file*` before Node sees it — otherwise the
+/// flag loses on this one surface. Runs the binary AS `nubx` (argv0 dispatch) to
+/// exercise `run_nubx`. Unix-only (symlink).
+#[cfg(unix)]
+#[test]
+fn no_env_file_wins_over_env_file_on_standalone_nubx() {
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let nubx = dir.join("nubx");
+    std::os::unix::fs::symlink(nub_binary(), &nubx).expect("symlink nub -> nubx");
+    std::fs::write(dir.join("package.json"), r#"{"name":"nubx-noenvfile"}"#).unwrap();
+    std::fs::write(dir.join(".env"), "SECRET=from-dotenv\n").unwrap();
+    std::fs::write(dir.join("custom.env"), "FROMCUSTOM=custom-val\n").unwrap();
+    std::fs::write(
+        dir.join("check.js"),
+        "console.log('SECRET=[' + (process.env.SECRET ?? '') + ']');\n\
+         console.log('FROMCUSTOM=[' + (process.env.FROMCUSTOM ?? '') + ']');\n",
+    )
+    .unwrap();
+
+    let out = Command::new(&nubx)
+        .args(["--no-env-file", "--env-file=custom.env", "check.js"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", dir.join("cache"))
+        .output()
+        .expect("failed to spawn nubx");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(out.status.code(), Some(0), "stderr: {stderr}");
+    assert!(
+        stdout.contains("SECRET=[]"),
+        "standalone nubx --no-env-file must suppress auto `.env`: {stdout}"
+    );
+    assert!(
+        stdout.contains("FROMCUSTOM=[]"),
+        "standalone nubx --no-env-file must win over a forwarded --env-file: {stdout}"
     );
 }
 

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -87,11 +87,11 @@ nub --env-file-if-exists=.env.local server.ts
 
 ## Loading nothing
 
-Pass `--no-env-file` to load zero env files: the automatic `.env*` discovery is suppressed and any `--env-file` is ignored. Everything else Nub does — TypeScript, JSX, the module hooks — stays on. Reach for it when the environment is already managed elsewhere (CI, a secret manager, `direnv`) and you want Nub to keep its hands off.
+Pass `--no-env-file` to load zero env files: the automatic `.env*` discovery is suppressed and any `--env-file` or `--env-file-if-exists` is ignored. Everything else Nub does — TypeScript, JSX, the module hooks — stays on. Reach for it when the environment is already managed elsewhere (CI, a secret manager, `direnv`) and you want Nub to keep its hands off.
 
 ```bash
 # no .env* auto-discovery, and the --env-file is ignored — the child sees neither
 nub --no-env-file --env-file=.env.ci server.ts
 ```
 
-It wins over `--env-file` on every surface — a file run, `nub run`, `nubx`, and `nub watch` (where no `.env*` file is handed to the watched Node). For a persistent, whole-tree opt-out that also disables the rest of Nub's augmentation, use `--node` or `NODE_COMPAT=1` instead.
+It wins over both `--env-file` and `--env-file-if-exists`, on every surface — a file run, `nub run`, `nubx`, and `nub watch` (where no `.env*` file is handed to the watched Node). For a persistent, whole-tree opt-out that also disables the rest of Nub's augmentation, use `--node` or `NODE_COMPAT=1` instead.

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -1,6 +1,6 @@
 ---
 title: Environment files
-description: Automatic environment-file loading — the file set, the APP_ENV mode, precedence, variable expansion, the skip under the test environment, and loading explicit files with --env-file.
+description: Automatic environment-file loading — the file set, the APP_ENV mode, precedence, variable expansion, the skip under the test environment, loading explicit files with --env-file, and disabling all loading with --no-env-file.
 ---
 
 Nub reads your `.env*` files and injects them into the environment before Node starts — no `dotenv` import, no `--env-file` flag. Loading happens from the nearest directory with a `package.json` (walking up from your cwd), matching Vite's single-directory model. Works on every Node version Nub supports (18.19+).
@@ -84,3 +84,14 @@ A missing file is an error. To load a file only when it is present and skip sile
 # loads .env.local if present; no error if it isn't
 nub --env-file-if-exists=.env.local server.ts
 ```
+
+## Loading nothing
+
+Pass `--no-env-file` to load zero env files: the automatic `.env*` discovery is suppressed and any `--env-file` is ignored. Everything else Nub does — TypeScript, JSX, the module hooks — stays on. Reach for it when the environment is already managed elsewhere (CI, a secret manager, `direnv`) and you want Nub to keep its hands off.
+
+```bash
+# no .env* auto-discovery, and the --env-file is ignored — the child sees neither
+nub --no-env-file --env-file=.env.ci server.ts
+```
+
+It wins over `--env-file` on every surface — a file run, `nub run`, `nubx`, and `nub watch` (where no `.env*` file is handed to the watched Node). For a persistent, whole-tree opt-out that also disables the rest of Nub's augmentation, use `--node` or `NODE_COMPAT=1` instead.


### PR DESCRIPTION
Adds `--no-env-file`: load zero env files. It suppresses the eager `.env*` auto-discovery **and** any explicit `--env-file` / `--env-file-if-exists`, while every other augmentation (TypeScript, JSX, the module hooks) stays on. For when the environment is already managed elsewhere — CI, a secret manager, `direnv` — and you want nub to keep its hands off.

```bash
# no .env* auto-discovery, and the --env-file is ignored — the child sees neither
nub --no-env-file --env-file=.env.ci server.ts
```

## Behavior

- **Wins over `--env-file` and `--env-file-if-exists`**, regardless of arg order — it means "load nothing, period."
- **All surfaces**: the file run (`nub <file>`), `nub run`, `nubx` (both the standalone binary and `nub x`/`dlx`), and `nub watch` — where no `.env*` file is handed to the watched Node.
- **Flag-only.** No env-var companion and no tree-wide inheritance: the same per-process boundary as `--env-file`. For a persistent, whole-tree opt-out that also disables the rest of nub's augmentation, `--node` / `NODE_COMPAT=1` remain the tools.

Like `--env-file`, the flag is a pre-subcommand option: `nub --no-env-file run build`, not `nub run --no-env-file build`.

## Implementation

`--no-env-file` is captured in the hand-parsed arg loop into a `NO_ENV_FILE` process flag. `merge_child_env` short-circuits to an empty map, `overlay_env_file_vars` / `apply_env_file_vars` early-return, and the auto-discovery load sites (file run + watch) gate on it. The standalone `nubx` binary forwards `--env-file` to Node directly (it is a Node value-flag, not captured by nub's loop), so when `--no-env-file` is present `run_nubx` strips the whole `--env-file*` family from its leading argv before Node sees it — arity-aware for the space form — so the flag wins on that surface too.

## Tests

Six committed tests: the `merge_child_env` unit contract plus five integration tests — auto-`.env` suppressed while TS still runs, precedence over `--env-file` and `--env-file-if-exists`, the standalone-`nubx` forwarding case, and the watch path.

## Docs

`site/content/docs/runtime/env.mdx` gains a "Loading nothing" section.
