### PR TITLE
pm: abort install on unresolvable bun.lock sources

### DIFF
--- a/crates/nub-cli/tests/abort_eagerly.rs
+++ b/crates/nub-cli/tests/abort_eagerly.rs
@@ -146,3 +146,78 @@ fn install_proceeds_on_optional_unresolvable_source() {
         "the optional skip should warn; got:\n{out}"
     );
 }
+
+const BUN_EXOTIC_PKG: &str =
+    r#"{"name":"t","version":"1.0.0","dependencies":{"foo":"exotic:bar"}}"#;
+const BUN_EXOTIC_LOCK: &str = r#"{
+  "lockfileVersion": 1,
+  "workspaces": { "": { "dependencies": { "foo": "exotic:bar" } } },
+  "packages": { "foo": ["foo@exotic:bar", {}] }
+}"#;
+
+#[test]
+fn install_aborts_on_unresolvable_bun_lock_source() {
+    // The bun twin of the yarn case: an unknown-protocol bun.lock entry is
+    // a plan-time fatal, not a silent reclassify-to-registry that 404s
+    // mid-install. (No real bun protocol triggers this today — the fixture
+    // is the future-proof/defense-in-depth path.)
+    for verb in ["install", "ci"] {
+        let dir = tmpdir("bun");
+        write(
+            &dir,
+            &[
+                ("package.json", BUN_EXOTIC_PKG),
+                ("bun.lock", BUN_EXOTIC_LOCK),
+            ],
+        );
+        let (out, code) = run(&dir, &[verb]);
+        assert_ne!(code, 0, "`nub {verb}` must abort on an unresolvable source");
+        assert!(
+            out.contains("ERR_NUB_LOCKFILE_UNSUPPORTED_SOURCE"),
+            "`nub {verb}` output should carry the rebranded code; got:\n{out}"
+        );
+        let flat: String = out.split_whitespace().collect();
+        assert!(
+            flat.contains("foo@exotic:bar") && flat.contains("exotic"),
+            "`nub {verb}` should name the offending entry and protocol; got:\n{out}"
+        );
+        assert!(!out.contains("ERR_AUBE_LOCKFILE_UNSUPPORTED_SOURCE"));
+        assert!(
+            !dir.join("node_modules").exists(),
+            "`nub {verb}` must abort before writing node_modules"
+        );
+    }
+}
+
+#[test]
+fn ci_proceeds_on_optional_unresolvable_bun_lock_source() {
+    // The optional carve-out on the bun reader: warn + skip, recorded as a
+    // consciously-skipped optional so the frozen drift check tolerates it.
+    let dir = tmpdir("bun-opt");
+    write(
+        &dir,
+        &[
+            (
+                "package.json",
+                r#"{"name":"t","version":"1.0.0","optionalDependencies":{"foo":"exotic:bar"}}"#,
+            ),
+            (
+                "bun.lock",
+                r#"{
+  "lockfileVersion": 1,
+  "workspaces": { "": { "optionalDependencies": { "foo": "exotic:bar" } } },
+  "packages": { "foo": ["foo@exotic:bar", {}] }
+}"#,
+            ),
+        ],
+    );
+    let (out, code) = run(&dir, &["ci"]);
+    assert_eq!(
+        code, 0,
+        "an optional unresolvable dep must not abort; got:\n{out}"
+    );
+    assert!(
+        out.contains("WARN_NUB_LOCKFILE_UNSUPPORTED_SOURCE"),
+        "the optional skip should warn; got:\n{out}"
+    );
+}

--- a/vendor/aube/crates/aube-lockfile/src/bun/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/read.rs
@@ -3,6 +3,7 @@ use super::raw::{BunEntry, RawBunLockfile};
 use super::source::{
     bin_value_to_map, bun_key_to_alias_name, classify_bun_ident,
     rebase_workspace_scoped_local_source, resolve_nested_bun, resolve_workspace_dep, split_ident,
+    unrecognized_protocol,
 };
 use crate::{DepType, DirectDep, Error, LockedPackage, LockfileGraph, PeerDepMeta};
 use std::collections::{BTreeMap, BTreeSet};
@@ -65,6 +66,16 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     // path ("parent/foo") when multiple versions exist.
     let mut key_info: BTreeMap<String, (String, String)> = BTreeMap::new();
     let mut packages: BTreeMap<String, LockedPackage> = BTreeMap::new();
+    // Under `strict_unsupported_source` (nub), an entry whose ident tail
+    // carries a protocol the classifier can't resolve is RECORDED here
+    // (keyed by its bun.lock key) and withheld from `key_info`/`packages`,
+    // instead of being reclassified to a registry `name@version` that 404s
+    // at fetch — the edge sites below (where optionality is known) raise
+    // an eager fatal / warn+skip. Empty (and inert) for standalone aube,
+    // which keeps the reclassify default.
+    let strict = aube_util::embedder().strict_unsupported_source;
+    let mut unsupported: BTreeMap<String, crate::UnsupportedSpec> = BTreeMap::new();
+    let mut skipped_optional: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
 
     for (key, entry) in &entries {
         let Some((raw_name, raw_version)) = split_ident(&entry.ident) else {
@@ -93,6 +104,24 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             &raw_version,
             entry.integrity.as_deref(),
         )?;
+        // A protocol-shaped tail that fell through the classifier means a
+        // source this reader can't resolve. Withhold the entry so the edge
+        // sites below fatal / warn+skip instead of resolving to a bogus
+        // registry pin.
+        if strict
+            && local_source.is_none()
+            && let Some(protocol) = unrecognized_protocol(&raw_version)
+        {
+            unsupported.insert(
+                key.clone(),
+                crate::UnsupportedSpec {
+                    name: name.clone(),
+                    key: entry.ident.clone(),
+                    protocol: protocol.to_string(),
+                },
+            );
+            continue;
+        }
         let local_source = local_source
             .map(|local| rebase_workspace_scoped_local_source(key, local, &workspace_scopes));
         key_info.insert(key.clone(), (name.clone(), version.clone()));
@@ -215,7 +244,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             .keys()
             .chain(entry.meta.optional_dependencies.keys())
         {
-            if let Some(target_key) = resolve_nested_bun(key, dep_name, &key_info)
+            if let Some(target_key) =
+                resolve_nested_bun(key, dep_name, |k| key_info.contains_key(k))
                 && let Some((dname, dver)) = key_info.get(&target_key)
             {
                 let target_dep_path = format!("{dname}@{dver}");
@@ -223,6 +253,15 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                     dep_name.clone(),
                     crate::npm::dep_path_tail(dname, &target_dep_path).to_string(),
                 );
+            } else if let Some(u_key) =
+                resolve_nested_bun(key, dep_name, |k| unsupported.contains_key(k))
+            {
+                // The by-name walk lands on an entry withheld as
+                // unsupported: fatal for a required edge, warn+skip for an
+                // optional one (a name in both maps is required). Inert
+                // unless strict — the map is empty otherwise.
+                let optional = !entry.meta.dependencies.contains_key(dep_name);
+                crate::unsupported_edge(&unsupported[&u_key], optional, path)?;
             }
         }
         resolved_by_dep_path.insert(dep_path, resolved);
@@ -275,27 +314,63 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             .then(|| ws_raw.extra.get("name").and_then(serde_json::Value::as_str))
             .flatten();
         let mut direct: Vec<DirectDep> = Vec::new();
-        let push_dep =
-            |name: &str, specifier: &str, dep_type: DepType, direct: &mut Vec<DirectDep>| {
-                if let Some(target_key) = resolve_workspace_dep(ws_path, ws_name, name, &key_info)
-                    && let Some((dname, dver)) = key_info.get(&target_key)
-                {
-                    direct.push(DirectDep {
-                        name: dname.clone(),
-                        dep_path: format!("{dname}@{dver}"),
-                        dep_type,
-                        specifier: Some(specifier.to_string()),
-                    });
+        let push_dep = |name: &str,
+                        specifier: &str,
+                        dep_type: DepType,
+                        direct: &mut Vec<DirectDep>,
+                        skipped: &mut BTreeMap<String, BTreeMap<String, String>>|
+         -> Result<(), Error> {
+            if let Some(target_key) =
+                resolve_workspace_dep(ws_path, ws_name, name, |k| key_info.contains_key(k))
+                && let Some((dname, dver)) = key_info.get(&target_key)
+            {
+                direct.push(DirectDep {
+                    name: dname.clone(),
+                    dep_path: format!("{dname}@{dver}"),
+                    dep_type,
+                    specifier: Some(specifier.to_string()),
+                });
+                return Ok(());
+            }
+            // The dep's entry was withheld as unsupported: fatal for a
+            // required edge, warn for an optional one — recorded as a
+            // consciously-skipped optional so a frozen install's drift
+            // check tolerates the absent dep (same as a platform-filtered
+            // optional). Inert unless strict — the map is empty otherwise.
+            if let Some(u_key) =
+                resolve_workspace_dep(ws_path, ws_name, name, |k| unsupported.contains_key(k))
+            {
+                let optional = matches!(dep_type, DepType::Optional);
+                crate::unsupported_edge(&unsupported[&u_key], optional, path)?;
+                if optional {
+                    skipped
+                        .entry(importer_path.clone())
+                        .or_default()
+                        .insert(name.to_string(), specifier.to_string());
                 }
-            };
+            }
+            Ok(())
+        };
         for (n, spec) in &ws_raw.dependencies {
-            push_dep(n, spec, DepType::Production, &mut direct);
+            push_dep(
+                n,
+                spec,
+                DepType::Production,
+                &mut direct,
+                &mut skipped_optional,
+            )?;
         }
         for (n, spec) in &ws_raw.dev_dependencies {
-            push_dep(n, spec, DepType::Dev, &mut direct);
+            push_dep(n, spec, DepType::Dev, &mut direct, &mut skipped_optional)?;
         }
         for (n, spec) in &ws_raw.optional_dependencies {
-            push_dep(n, spec, DepType::Optional, &mut direct);
+            push_dep(
+                n,
+                spec,
+                DepType::Optional,
+                &mut direct,
+                &mut skipped_optional,
+            )?;
         }
         // Required workspace peers. bun links a workspace's
         // `peerDependencies` entry into that workspace's `node_modules`
@@ -326,7 +401,13 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                     continue;
                 }
                 let spec = spec.as_str().unwrap_or_default();
-                push_dep(n, spec, DepType::Production, &mut direct);
+                push_dep(
+                    n,
+                    spec,
+                    DepType::Production,
+                    &mut direct,
+                    &mut skipped_optional,
+                )?;
             }
         }
         importers.insert(importer_path.clone(), direct);
@@ -401,6 +482,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         catalogs: catalogs_map,
         extra_fields: raw.extra,
         workspace_extra_fields,
+        skipped_optional_dependencies: skipped_optional,
         ..Default::default()
     })
 }

--- a/vendor/aube/crates/aube-lockfile/src/bun/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/read.rs
@@ -244,24 +244,28 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             .keys()
             .chain(entry.meta.optional_dependencies.keys())
         {
-            if let Some(target_key) =
-                resolve_nested_bun(key, dep_name, |k| key_info.contains_key(k))
-                && let Some((dname, dver)) = key_info.get(&target_key)
-            {
-                let target_dep_path = format!("{dname}@{dver}");
-                resolved.insert(
-                    dep_name.clone(),
-                    crate::npm::dep_path_tail(dname, &target_dep_path).to_string(),
-                );
-            } else if let Some(u_key) =
-                resolve_nested_bun(key, dep_name, |k| unsupported.contains_key(k))
-            {
-                // The by-name walk lands on an entry withheld as
-                // unsupported: fatal for a required edge, warn+skip for an
-                // optional one (a name in both maps is required). Inert
-                // unless strict — the map is empty otherwise.
-                let optional = !entry.meta.dependencies.contains_key(dep_name);
-                crate::unsupported_edge(&unsupported[&u_key], optional, path)?;
+            // ONE walk over the union of both key sets, so the withheld
+            // entry keeps its position in bun's nesting resolution: a
+            // withheld `parent/foo` must not be shadowed by a supported
+            // hoisted `foo` (that would silently resolve the WRONG
+            // package — the exact divergence this policy exists to
+            // refuse). Union == key_info alone unless strict — the
+            // unsupported map is empty otherwise.
+            if let Some(target_key) = resolve_nested_bun(key, dep_name, |k| {
+                key_info.contains_key(k) || unsupported.contains_key(k)
+            }) {
+                if let Some((dname, dver)) = key_info.get(&target_key) {
+                    let target_dep_path = format!("{dname}@{dver}");
+                    resolved.insert(
+                        dep_name.clone(),
+                        crate::npm::dep_path_tail(dname, &target_dep_path).to_string(),
+                    );
+                } else if let Some(u) = unsupported.get(&target_key) {
+                    // Fatal for a required edge, warn+skip for an optional
+                    // one (a name in both meta maps is required).
+                    let optional = !entry.meta.dependencies.contains_key(dep_name);
+                    crate::unsupported_edge(u, optional, path)?;
+                }
             }
         }
         resolved_by_dep_path.insert(dep_path, resolved);
@@ -320,33 +324,33 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                         direct: &mut Vec<DirectDep>,
                         skipped: &mut BTreeMap<String, BTreeMap<String, String>>|
          -> Result<(), Error> {
-            if let Some(target_key) =
-                resolve_workspace_dep(ws_path, ws_name, name, |k| key_info.contains_key(k))
-                && let Some((dname, dver)) = key_info.get(&target_key)
-            {
-                direct.push(DirectDep {
-                    name: dname.clone(),
-                    dep_path: format!("{dname}@{dver}"),
-                    dep_type,
-                    specifier: Some(specifier.to_string()),
-                });
-                return Ok(());
-            }
-            // The dep's entry was withheld as unsupported: fatal for a
-            // required edge, warn for an optional one — recorded as a
-            // consciously-skipped optional so a frozen install's drift
-            // check tolerates the absent dep (same as a platform-filtered
-            // optional). Inert unless strict — the map is empty otherwise.
-            if let Some(u_key) =
-                resolve_workspace_dep(ws_path, ws_name, name, |k| unsupported.contains_key(k))
-            {
-                let optional = matches!(dep_type, DepType::Optional);
-                crate::unsupported_edge(&unsupported[&u_key], optional, path)?;
-                if optional {
-                    skipped
-                        .entry(importer_path.clone())
-                        .or_default()
-                        .insert(name.to_string(), specifier.to_string());
+            // Same union walk as the transitive pass above: a withheld
+            // scoped override (`<ws>/<dep>`) must not be shadowed by a
+            // supported hoisted entry. When the walk lands on a withheld
+            // entry: fatal for a required edge, warn for an optional one —
+            // recorded as a consciously-skipped optional so a frozen
+            // install's drift check tolerates the absent dep (same as a
+            // platform-filtered optional). Inert unless strict — the
+            // unsupported map is empty otherwise.
+            if let Some(target_key) = resolve_workspace_dep(ws_path, ws_name, name, |k| {
+                key_info.contains_key(k) || unsupported.contains_key(k)
+            }) {
+                if let Some((dname, dver)) = key_info.get(&target_key) {
+                    direct.push(DirectDep {
+                        name: dname.clone(),
+                        dep_path: format!("{dname}@{dver}"),
+                        dep_type,
+                        specifier: Some(specifier.to_string()),
+                    });
+                } else if let Some(u) = unsupported.get(&target_key) {
+                    let optional = matches!(dep_type, DepType::Optional);
+                    crate::unsupported_edge(u, optional, path)?;
+                    if optional {
+                        skipped
+                            .entry(importer_path.clone())
+                            .or_default()
+                            .insert(name.to_string(), specifier.to_string());
+                    }
                 }
             }
             Ok(())

--- a/vendor/aube/crates/aube-lockfile/src/bun/source.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/source.rs
@@ -150,6 +150,27 @@ pub(super) fn classify_bun_ident(
     Ok((name, raw_version.to_string(), None, alias_of))
 }
 
+/// The protocol token of a version tail that reached
+/// [`classify_bun_ident`]'s registry-pin fall-through while carrying a
+/// `<token>:` protocol prefix — i.e. a source the classifier has no
+/// branch for (an unknown/future bun protocol, or a malformed spec like
+/// a `git+…` tail `parse_git_spec` rejected). A genuine registry pin is
+/// an exact semver version, which can never contain `:`, so a
+/// protocol-shaped tail here means "unresolvable from this lockfile",
+/// not "registry". Consulted only under `strict_unsupported_source`;
+/// the lenient default keeps the historical reclassify-to-registry
+/// behavior without ever calling this.
+pub(super) fn unrecognized_protocol(raw_version: &str) -> Option<&str> {
+    let token = &raw_version[..raw_version.find(':')?];
+    let mut chars = token.chars();
+    if !chars.next()?.is_ascii_alphabetic() {
+        return None;
+    }
+    chars
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '-'))
+        .then_some(token)
+}
+
 pub(super) fn rebase_workspace_scoped_local_source(
     key: &str,
     local: LocalSource,
@@ -223,10 +244,16 @@ pub(super) fn bin_value_to_map(
 /// We walk up the key's ancestors, first checking the package's own nested
 /// scope then each ancestor's, finally falling back to the hoisted entry
 /// at just the bare `dep_name`.
+///
+/// `contains` abstracts the key set being walked: the reader passes the
+/// parsed `key_info` for normal resolution, and (under
+/// `strict_unsupported_source`) re-walks with the unsupported-entry set
+/// so an edge whose target was withheld as unsupported is distinguished
+/// from a genuinely absent one.
 pub(super) fn resolve_nested_bun(
     pkg_key: &str,
     dep_name: &str,
-    key_info: &BTreeMap<String, (String, String)>,
+    contains: impl Fn(&str) -> bool,
 ) -> Option<String> {
     let mut base = pkg_key.to_string();
     loop {
@@ -235,7 +262,7 @@ pub(super) fn resolve_nested_bun(
         } else {
             format!("{base}/{dep_name}")
         };
-        if key_info.contains_key(&candidate) {
+        if contains(&candidate) {
             return Some(candidate);
         }
         if base.is_empty() {
@@ -274,21 +301,21 @@ pub(super) fn resolve_workspace_dep(
     ws_path: &str,
     ws_name: Option<&str>,
     dep_name: &str,
-    key_info: &BTreeMap<String, (String, String)>,
+    contains: impl Fn(&str) -> bool,
 ) -> Option<String> {
     if let Some(ws_name) = ws_name {
         let ws_specific = format!("{ws_name}/{dep_name}");
-        if key_info.contains_key(&ws_specific) {
+        if contains(&ws_specific) {
             return Some(ws_specific);
         }
     }
     if !ws_path.is_empty() {
         let ws_specific = format!("{ws_path}/{dep_name}");
-        if key_info.contains_key(&ws_specific) {
+        if contains(&ws_specific) {
             return Some(ws_specific);
         }
     }
-    if key_info.contains_key(dep_name) {
+    if contains(dep_name) {
         return Some(dep_name.to_string());
     }
     None

--- a/vendor/aube/crates/aube-lockfile/src/bun/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/tests.rs
@@ -2202,3 +2202,28 @@ fn test_parse_rejects_unsupported_lockfile_version() {
         "unsupported version error should name the version and the supported set, got: {msg}"
     );
 }
+
+/// The LENIENT default (standalone aube, `strict_unsupported_source:
+/// false`): an ident tail with an unrecognized protocol falls through to
+/// a plain registry pin, exactly as before the strict policy existed —
+/// the in-crate suite runs under the default embedder, so this pins the
+/// fork-discipline guarantee that only a strict profile changes behavior.
+#[test]
+fn test_unknown_protocol_tail_stays_a_registry_pin_by_default() {
+    assert!(!aube_util::embedder().strict_unsupported_source);
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+  "lockfileVersion": 1,
+  "workspaces": { "": { "dependencies": { "foo": "exotic:bar" } } },
+  "packages": { "foo": ["foo@exotic:bar", {}] }
+}"#;
+    std::fs::write(tmp.path(), content).unwrap();
+    let graph = parse(tmp.path()).expect("lenient default must not fatal");
+    let foo = graph
+        .packages
+        .values()
+        .find(|p| p.name == "foo")
+        .expect("foo reclassified as a registry package");
+    assert_eq!(foo.version, "exotic:bar");
+    assert!(foo.local_source.is_none());
+}

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -361,6 +361,23 @@ pub(crate) fn resolve_dep_spec(
     let Some(u) = unsupported.get(spec) else {
         return Ok(None);
     };
+    unsupported_edge(u, optional, path)?;
+    Ok(None)
+}
+
+/// Apply the abort-eagerly policy to an edge that resolved to an
+/// [`UnsupportedSpec`], once the edge's optionality is known: warn + skip
+/// for an OPTIONAL edge (`Ok`, matching the incumbent's tolerance of a
+/// missing optional), `Err(UnsupportedSource)` for a non-optional one —
+/// the eager, pre-mutation plan-time refusal. Shared by the yarn readers'
+/// spec-keyed resolution ([`resolve_dep_spec`]) and the bun reader's
+/// by-name nested-key walk, so the warning code and message stay
+/// identical across formats.
+pub(crate) fn unsupported_edge(
+    u: &UnsupportedSpec,
+    optional: bool,
+    path: &std::path::Path,
+) -> Result<(), Error> {
     if optional {
         tracing::warn!(
             code = aube_codes::warnings::WARN_AUBE_LOCKFILE_UNSUPPORTED_SOURCE,
@@ -368,7 +385,7 @@ pub(crate) fn resolve_dep_spec(
             u.name,
             u.protocol,
         );
-        Ok(None)
+        Ok(())
     } else {
         Err(Error::unsupported_source(path, &u.key, &u.protocol))
     }

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -291,6 +291,35 @@ fn bun_transitive_unknown_protocol_dep_is_a_fatal() {
 }
 
 #[test]
+fn bun_hoisted_entry_does_not_mask_a_withheld_nested_one() {
+    // The nested-key walk must treat a withheld `parent/bar` as still
+    // occupying its position in bun's nesting resolution: falling through
+    // to the supported hoisted `bar` would silently hand parent the WRONG
+    // version — the exact divergence the policy refuses.
+    aube_util::set_embedder(&STRICT);
+    let lock = format!(
+        r#"{{
+  "lockfileVersion": 1,
+  "workspaces": {{ "": {{ "dependencies": {{ "parent": "^1.0.0", "bar": "^2.0.0" }} }} }},
+  "packages": {{
+    "parent": ["parent@1.0.0", "", {{ "dependencies": {{ "bar": "exotic:x" }} }}, "{0}"],
+    "parent/bar": ["bar@exotic:x", {{}}],
+    "bar": ["bar@2.0.0", "", {{}}, "{0}"]
+  }}
+}}"#,
+        sri()
+    );
+    let r = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","dependencies":{"parent":"^1.0.0","bar":"^2.0.0"}}"#,
+        ),
+        ("bun.lock", &lock),
+    ]);
+    assert_unsupported(r, "exotic");
+}
+
+#[test]
 fn bun_transitive_optional_unknown_protocol_is_skipped() {
     aube_util::set_embedder(&STRICT);
     let lock = format!(

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -208,3 +208,145 @@ fn clean_classic_lockfile_does_not_fatal() {
     assert!(graph.importers["."].iter().any(|d| d.name == "lodash"));
     assert!(graph.importers["."].iter().any(|d| d.name == "link-dep"));
 }
+
+// ─── bun.lock — the by-name-walk adaptation of the same policy ───
+
+/// A syntactically-valid sha512 SRI for hand-authored registry entries.
+fn sri() -> String {
+    format!("sha512-{}==", "a".repeat(86))
+}
+
+#[test]
+fn bun_unknown_protocol_dep_is_a_fatal() {
+    aube_util::set_embedder(&STRICT);
+    let lock = r#"{
+  "lockfileVersion": 1,
+  "workspaces": { "": { "dependencies": { "foo": "exotic:bar" } } },
+  "packages": { "foo": ["foo@exotic:bar", {}] }
+}"#;
+    let r = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","dependencies":{"foo":"exotic:bar"}}"#,
+        ),
+        ("bun.lock", lock),
+    ]);
+    assert_unsupported(r, "exotic");
+}
+
+#[test]
+fn bun_optional_unknown_protocol_warns_and_is_skipped() {
+    aube_util::set_embedder(&STRICT);
+    let lock = r#"{
+  "lockfileVersion": 1,
+  "workspaces": { "": { "optionalDependencies": { "foo": "exotic:bar" } } },
+  "packages": { "foo": ["foo@exotic:bar", {}] }
+}"#;
+    let graph = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","optionalDependencies":{"foo":"exotic:bar"}}"#,
+        ),
+        ("bun.lock", lock),
+    ])
+    .expect("an optional unsupported bun dep must NOT be fatal");
+    assert!(
+        !graph.importers["."].iter().any(|d| d.name == "foo"),
+        "the optional unsupported dep should be dropped from the importer"
+    );
+    assert_eq!(
+        graph.skipped_optional_dependencies["."]
+            .get("foo")
+            .map(String::as_str),
+        Some("exotic:bar"),
+        "the dropped optional must be recorded as skipped for drift tolerance"
+    );
+}
+
+#[test]
+fn bun_transitive_unknown_protocol_dep_is_a_fatal() {
+    // The bun-specific edge shape: transitive deps resolve BY NAME through
+    // the nested-key walk, not per-spec — the walk must land on the
+    // withheld entry and fatal, instead of silently dropping the edge.
+    aube_util::set_embedder(&STRICT);
+    let lock = format!(
+        r#"{{
+  "lockfileVersion": 1,
+  "workspaces": {{ "": {{ "dependencies": {{ "a": "^1.0.0" }} }} }},
+  "packages": {{
+    "a": ["a@1.0.0", "", {{ "dependencies": {{ "foo": "exotic:bar" }} }}, "{0}"],
+    "foo": ["foo@exotic:bar", {{}}]
+  }}
+}}"#,
+        sri()
+    );
+    let r = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","dependencies":{"a":"^1.0.0"}}"#,
+        ),
+        ("bun.lock", &lock),
+    ]);
+    assert_unsupported(r, "exotic");
+}
+
+#[test]
+fn bun_transitive_optional_unknown_protocol_is_skipped() {
+    aube_util::set_embedder(&STRICT);
+    let lock = format!(
+        r#"{{
+  "lockfileVersion": 1,
+  "workspaces": {{ "": {{ "dependencies": {{ "a": "^1.0.0" }} }} }},
+  "packages": {{
+    "a": ["a@1.0.0", "", {{ "optionalDependencies": {{ "foo": "exotic:bar" }} }}, "{0}"],
+    "foo": ["foo@exotic:bar", {{}}]
+  }}
+}}"#,
+        sri()
+    );
+    let graph = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","dependencies":{"a":"^1.0.0"}}"#,
+        ),
+        ("bun.lock", &lock),
+    ])
+    .expect("a transitive OPTIONAL unsupported bun dep must NOT be fatal");
+    let a = graph
+        .packages
+        .values()
+        .find(|p| p.name == "a")
+        .expect("a must be in the graph");
+    assert!(
+        !a.dependencies.contains_key("foo"),
+        "the unsupported optional edge should be dropped, not resolved"
+    );
+}
+
+#[test]
+fn clean_bun_lockfile_does_not_fatal() {
+    // Anti-regression twin of the classic case: every recognized bun source
+    // (registry pin, link) must still parse under strict — no false positive.
+    aube_util::set_embedder(&STRICT);
+    let lock = format!(
+        r#"{{
+  "lockfileVersion": 1,
+  "workspaces": {{ "": {{ "dependencies": {{ "lodash": "^4.17.0", "link-dep": "link:./local" }} }} }},
+  "packages": {{
+    "lodash": ["lodash@4.17.21", "", {{}}, "{0}"],
+    "link-dep": ["link-dep@link:./local"]
+  }}
+}}"#,
+        sri()
+    );
+    let graph = parse(&[
+        (
+            "package.json",
+            r#"{"name":"t","dependencies":{"lodash":"^4.17.0","link-dep":"link:./local"}}"#,
+        ),
+        ("bun.lock", &lock),
+    ])
+    .expect("a clean bun.lock must not fatal under strict");
+    assert!(graph.importers["."].iter().any(|d| d.name == "lodash"));
+    assert!(graph.importers["."].iter().any(|d| d.name == "link-dep"));
+}


### PR DESCRIPTION
Extends #217's abort-eagerly policy (yarn) to the bun lockfile reader. Refs #217.

Under nub's `strict_unsupported_source` toggle, a `bun.lock` entry with an unrecognized source protocol fails at plan time (`ERR_NUB_LOCKFILE_UNSUPPORTED_SOURCE`) instead of silently reclassifying to a registry pin that 404s mid-install. Optional deps warn + skip, recorded so frozen/`ci` drift tolerates them. bun resolves transitive deps by name, so the edge check walks the union of parsed and withheld key sets. Standalone aube keeps its lenient default (pinned by a unit test). No real bun protocol triggers this today — defense-in-depth.

https://claude.ai/code/session_01EZAM6j11iDztC76fx61J17