### PR TITLE
feat(install): retire the user-facing diskMaterializePackages knob under nub

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2129,10 +2129,11 @@ fn nub_setting_defaults(
     // ejects them through #319's ancestor-closure, subsuming the old 14-entry
     // const (incl. the singleton-hazard adapters the closure now makes sound). So
     // this embedder default carries ONLY the #315 vite eject; empty otherwise
-    // (aube's `parse_string_list` drops the empty entry). A user's own
-    // `diskMaterializePackages` still wins — the
-    // embedder default is the lowest precedence tier — so the additive escape
-    // hatch is intact.
+    // (aube's `parse_string_list` drops the empty entry). nub exposes NO
+    // user-facing `diskMaterializePackages` knob (maintainer 2026-07-07): the
+    // detector is the sole eject mechanism, and nub's hook drops every user-source
+    // seed name (`phantom_closure::nub_internal_seed`), keeping only this internal
+    // vite entry. (Standalone aube installs no hook and still honors the knob.)
     //
     // Vite symlink-GVS compat (#315): eject the `vite` package project-local so
     // its dist can be patched with the backported fs.allow sniff (< 8.1) without

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2152,7 +2152,9 @@ fn nub_setting_defaults(
         && vite_compat::enabled()
         && vite_compat::manifest_declares_vite(detected.map(|d| d.dir.as_path()).unwrap_or(cwd))
     {
-        "vite".to_string()
+        // Draw from the hook's allowlist so the embedder default and the seed the
+        // hook keeps ([`phantom_closure::nub_internal_seed`]) can't drift.
+        phantom_closure::NUB_INTERNAL_DISK_MATERIALIZE_SEED.join(",")
     } else {
         String::new()
     };

--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -80,7 +80,11 @@ pub(crate) fn register() {
 /// from a user source (`.npmrc`/env/`pnpm-workspace.yaml`) and is dropped by
 /// [`nub_internal_seed`]. Standalone aube installs no hook and honors the full
 /// seed verbatim, so its `diskMaterializePackages` knob is unaffected.
-const NUB_INTERNAL_DISK_MATERIALIZE_SEED: &[&str] = &["vite"];
+///
+/// SHARED with [`super::nub_setting_defaults`], which seeds exactly this name as
+/// the embedder default — sourcing both from one const so a future internal
+/// default can't be added in one place and silently dropped by the other.
+pub(super) const NUB_INTERNAL_DISK_MATERIALIZE_SEED: &[&str] = &["vite"];
 
 /// Keep only nub's own embedder-default seed names, dropping every user-source
 /// entry — the mechanism that retires the user-facing `diskMaterializePackages`

--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -71,12 +71,40 @@ pub(crate) fn register() {
     aube_linker::set_disk_materialize_expand_hook(Box::new(expand));
 }
 
+/// nub's own embedder-default names that may seed the eject set. nub exposes NO
+/// user-facing `diskMaterializePackages` knob (maintainer 2026-07-07): the dynamic
+/// phantom detector is the sole eject mechanism, so a hand-listed package is
+/// redundant. The resolved seed still carries nub's INTERNAL vite #315 embedder
+/// default ([`super::mod::nub_setting_defaults`]) — kept so the phantom-eject
+/// opt-out (no-hook) path still ejects vite<8.1 — but every OTHER name arrived
+/// from a user source (`.npmrc`/env/`pnpm-workspace.yaml`) and is dropped by
+/// [`nub_internal_seed`]. Standalone aube installs no hook and honors the full
+/// seed verbatim, so its `diskMaterializePackages` knob is unaffected.
+const NUB_INTERNAL_DISK_MATERIALIZE_SEED: &[&str] = &["vite"];
+
+/// Keep only nub's own embedder-default seed names, dropping every user-source
+/// entry — the mechanism that retires the user-facing `diskMaterializePackages`
+/// knob under nub while leaving standalone aube's byte-for-byte.
+fn nub_internal_seed(resolved_seed: &[String]) -> Vec<String> {
+    resolved_seed
+        .iter()
+        .filter(|n| NUB_INTERNAL_DISK_MATERIALIZE_SEED.contains(&n.as_str()))
+        .cloned()
+        .collect()
+}
+
 /// The hook entry: read the per-version scanner's sidecars (the store-IO half)
 /// then hand off to the pure planner. Split so [`plan_from_flags`] — all the
 /// closure/seed policy — is unit-tested with injected flags and never touches
-/// the host store.
+/// the host store. The resolved seed is first filtered to nub's internal names
+/// ([`nub_internal_seed`]) so a user's `diskMaterializePackages` value has no
+/// effect under nub.
 fn expand(graph: &LockfileGraph, seed_names: &[String]) -> DiskMaterializePlan {
-    plan_from_flags(graph, seed_names, &dynamic_phantom_flags(graph))
+    plan_from_flags(
+        graph,
+        &nub_internal_seed(seed_names),
+        &dynamic_phantom_flags(graph),
+    )
 }
 
 /// Pure planner: resolved graph + flat seed + dynamic phantom flags → graph-aware
@@ -462,6 +490,22 @@ mod tests {
         let g = graph(&[("lodash@4.17.21", "lodash", &[])]);
         let plan = plan_from_flags(&g, &[], &[]);
         assert!(plan.names.is_empty());
+    }
+
+    #[test]
+    fn user_seed_names_are_dropped_only_internal_vite_survives() {
+        // The user-facing `diskMaterializePackages` knob is retired under nub: a
+        // value the user set in `.npmrc`/env/`pnpm-workspace.yaml` reaches the hook
+        // merged with nub's internal vite embedder default, and the filter must keep
+        // ONLY vite. So a hand-listed `lodash`/`@hookform/resolvers` is dropped
+        // (the detector, not a manual list, ejects real phantoms).
+        let kept = nub_internal_seed(&[
+            "lodash".to_string(),
+            "vite".to_string(),
+            "@hookform/resolvers".to_string(),
+        ]);
+        assert_eq!(kept, vec!["vite".to_string()]);
+        assert!(nub_internal_seed(&["lodash".to_string()]).is_empty());
     }
 
     #[test]

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -471,13 +471,7 @@ Either layout resolves the same packages — including type packages (`@types/*`
 
 A few packages statically import a backend you pick at runtime — `@hookform/resolvers/zod` imports the `zod` your app installs, without declaring it. Under the shared store the adapter's real path sits outside the project, so Node's directory walk can't reach that backend and the import throws. Nub materializes those adapters into the project automatically so they resolve, while the rest of the tree keeps sharing.
 
-The same treatment covers packages that write generated code back into their own install directory. Prisma's postinstall runs `prisma generate`, which writes the generated client next to `@prisma/client` on disk — and under the shared store that spot is machine-global, keyed by version rather than by project or schema. Two projects with different Prisma schemas would otherwise share one generated client and silently overwrite each other's models. Nub materializes `@prisma/client` into each project so `generate` stays project-local, matching pnpm.
-
-Add your own with one line in `.npmrc`:
-
-```ini
-diskMaterializePackages[]=my-adapter
-```
+The same treatment covers packages that write generated code back into their own install directory. Prisma's postinstall runs `prisma generate`, which writes the generated client next to `@prisma/client` on disk — and under the shared store that spot is machine-global, keyed by version rather than by project or schema. Two projects with different Prisma schemas would otherwise share one generated client and silently overwrite each other's models. Nub materializes `@prisma/client` into each project so `generate` stays project-local, matching pnpm. This detection is automatic — it scans each package's real published code, so there is no list to maintain.
 
 A bundler that resolves modules by their real path — Metro (bare React Native), Next.js, Parcel — only crawls the project directory, so it can't see the shared store. Nub gives those projects a self-contained, project-local store automatically. Extend the list in `.npmrc`:
 


### PR DESCRIPTION
## What

Retires the user-facing `diskMaterializePackages` npmrc/env/`pnpm-workspace.yaml` knob under nub. The dynamic phantom detector (#352, on by default) auto-ejects undeclared-import adapters, so a hand-listed force-eject is redundant for its documented purpose.

## Why

`diskMaterializePackages` let a user force a package project-local under the global virtual store so a phantom subpath import (`@hookform/resolvers/zod` reaching the app's `zod`) could resolve. Since #352, the detector scans each package's real published code and ejects those adapters automatically — the manual list no longer adds anything for its documented case. Verified empirically under default GVS:

- `@hookform/resolvers@3.9.1 + zod`, no knob set → `@hookform/resolvers` auto-ejected, `import('@hookform/resolvers/zod')` resolves.
- With `diskMaterializePackages=lodash` set, lodash is no longer ejected after this change (it was before).

Any residual detector miss stays covered by the coarser, retained `disableGlobalVirtualStoreForPackages`.

## How

nub's disk-materialize expansion hook (nub-side, registered only by nub) now filters the resolved seed through `nub_internal_seed()`, keeping only nub's own embedder-default names (the internal `vite` #315 seed) and dropping every user-source entry before planning.

Fork-disciplined: `vendor/aube/**` is untouched. Standalone aube installs no hook, so it keeps honoring the setting byte-for-byte. The internal `vite` embedder default is kept for the phantom-eject opt-out (no-hook) path. Docs drop the `diskMaterializePackages` instruction; `disableGlobalVirtualStoreForPackages` remains the documented escape hatch.

## Test

- New unit test asserts the hook drops user-source seed names, keeping only the internal `vite`.
- Existing vite / phantom-closure unit tests unchanged and green (14 total).
- fmt + clippy (`-D warnings`) clean; e2e verified on a dev binary.
