### PR TITLE
Fix save-catalog writes under nub identity

### DIFF
--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -88,6 +88,27 @@ fn run_nub(dir: &Path, args: &[&str]) -> Output {
     run_nub_with(dir, args, &pm_tmpdir("xdg-data"), &pm_tmpdir("xdg-cache"))
 }
 
+fn run_nub_no_self_shim_with(
+    dir: &Path,
+    args: &[&str],
+    xdg_data: &Path,
+    xdg_cache: &Path,
+) -> Output {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .env("NUB_SELF_SHIM", "0")
+        .env("XDG_DATA_HOME", xdg_data)
+        .env("XDG_CACHE_HOME", xdg_cache)
+        .output()
+        .expect("failed to spawn nub");
+    Output {
+        stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
 /// Offline guard for the `#[ignore]` network tests: true when the registry
 /// answers a TCP connect within 3s.
 fn registry_reachable() -> bool {
@@ -173,6 +194,74 @@ fn add_then_remove_round_trips_manifest_lockfile_and_node_modules() {
     assert!(
         !manifest.contains("is-positive"),
         "remove must strip the dependency: {manifest}"
+    );
+}
+
+/// Regression for #369: under nub identity the `--save-catalog` writer must
+/// seed the root manifest's neutral `workspaces.catalog` field, not emit an
+/// unread `pnpm-workspace.yaml` and leave the member manifest pointing at an
+/// undefined `catalog:`.
+#[test]
+#[ignore = "network: resolves + fetches @types/node from the npm registry"]
+fn add_save_catalog_under_nub_identity_writes_workspaces_catalog() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("save-catalog-nub");
+    let server = dir.join("apps/server");
+    std::fs::create_dir_all(&server).unwrap();
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{
+  "name": "root",
+  "workspaces": { "packages": ["apps/*"] },
+  "devEngines": {
+    "packageManager": { "name": "nub", "version": "^0.0.0", "onFail": "warn" }
+  }
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        server.join("package.json"),
+        r#"{"name":"server","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    let (data, cache) = (
+        pm_tmpdir("save-catalog-nub-data"),
+        pm_tmpdir("save-catalog-nub-cache"),
+    );
+
+    let add = run_nub_no_self_shim_with(
+        &server,
+        &["add", "--save-catalog", "@types/node@26.1.0", "-D"],
+        &data,
+        &cache,
+    );
+    assert_eq!(
+        add.code, 0,
+        "stdout: {}\nstderr: {}",
+        add.stdout, add.stderr
+    );
+    add.assert_brand_clean();
+
+    let root_manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dir.join("package.json")).unwrap()).unwrap();
+    assert_eq!(
+        root_manifest["workspaces"]["catalog"]["@types/node"],
+        "26.1.0"
+    );
+    let member_manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(server.join("package.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        member_manifest["devDependencies"]["@types/node"],
+        "catalog:"
+    );
+    assert!(
+        !dir.join("pnpm-workspace.yaml").exists(),
+        "nub identity must not write an unread pnpm-workspace.yaml"
     );
 }
 

--- a/vendor/aube/crates/aube/src/commands/add/manifest.rs
+++ b/vendor/aube/crates/aube/src/commands/add/manifest.rs
@@ -566,19 +566,33 @@ pub(super) async fn update_manifest_for_add(
     }
 
     // Apply queued `--save-catalog` upserts. Lands once at the end of
-    // the per-package loop so the workspace yaml is rewritten at most
-    // once per command — `edit_workspace_yaml` no-ops when nothing
-    // structural changes (preserving comments under filtered/recursive
-    // re-runs that all target the same catalog).
+    // the per-package loop so the catalog config is rewritten at most
+    // once per command. A manifest-root embedder under its own identity
+    // writes the neutral `workspaces.catalog(s)` surface it reads; other
+    // surfaces keep the workspace-yaml path for pnpm/aube compatibility.
     if !catalog_upserts.is_empty() {
-        let yaml_root = crate::dirs::find_workspace_yaml_root(cwd)
+        let workspace_root = crate::dirs::find_workspace_yaml_root(cwd)
             .or_else(|| crate::dirs::find_workspace_root(cwd))
             .unwrap_or_else(|| cwd.to_path_buf());
-        let yaml_path = aube_manifest::workspace::workspace_yaml_target(&yaml_root);
-        crate::commands::catalogs::upsert_catalog_entries(&yaml_path, &catalog_upserts)?;
+        if write_catalogs_to_manifest_root() {
+            crate::commands::catalogs::upsert_catalog_entries_in_manifest(
+                &workspace_root,
+                &catalog_upserts,
+            )?;
+        } else {
+            let yaml_path = aube_manifest::workspace::workspace_yaml_target(&workspace_root);
+            crate::commands::catalogs::upsert_catalog_entries(&yaml_path, &catalog_upserts)?;
+        }
     }
 
     Ok(())
+}
+
+fn write_catalogs_to_manifest_root() -> bool {
+    let ctx = aube_util::engine_context();
+    aube_util::embedder().manifest_namespace.is_empty()
+        && ctx.read_manifest_root_config
+        && !ctx.read_branded_pnpm_config
 }
 
 /// Resolve a `pkg@workspace:<range>` spec against the local workspace

--- a/vendor/aube/crates/aube/src/commands/catalogs.rs
+++ b/vendor/aube/crates/aube/src/commands/catalogs.rs
@@ -327,30 +327,36 @@ fn normalize_workspaces_object<'a>(
             .ok_or_else(|| miette::miette!("package.json `workspaces` must be an object"));
     }
 
-    let current = root.remove("workspaces");
-    let workspaces = match current {
-        Some(serde_json::Value::Array(packages)) => {
-            let mut obj = serde_json::Map::new();
-            obj.insert("packages".to_string(), serde_json::Value::Array(packages));
-            serde_json::Value::Object(obj)
-        }
-        Some(serde_json::Value::String(package)) => {
-            let mut obj = serde_json::Map::new();
-            obj.insert(
-                "packages".to_string(),
-                serde_json::Value::Array(vec![serde_json::Value::String(package)]),
-            );
-            serde_json::Value::Object(obj)
-        }
-        Some(other) => {
-            root.insert("workspaces".to_string(), other);
-            return Err(miette::miette!(
-                "package.json `workspaces` must be an object, array, or string to update catalogs"
-            ));
-        }
-        None => serde_json::Value::Object(serde_json::Map::new()),
-    };
-    root.insert("workspaces".to_string(), workspaces);
+    if let Some(current) = root.get_mut("workspaces") {
+        let workspaces = match std::mem::take(current) {
+            serde_json::Value::Array(packages) => {
+                let mut obj = serde_json::Map::new();
+                obj.insert("packages".to_string(), serde_json::Value::Array(packages));
+                serde_json::Value::Object(obj)
+            }
+            serde_json::Value::String(package) => {
+                let mut obj = serde_json::Map::new();
+                obj.insert(
+                    "packages".to_string(),
+                    serde_json::Value::Array(vec![serde_json::Value::String(package)]),
+                );
+                serde_json::Value::Object(obj)
+            }
+            other => {
+                *current = other;
+                return Err(miette::miette!(
+                    "package.json `workspaces` must be an object, array, or string to update catalogs"
+                ));
+            }
+        };
+        *current = workspaces;
+    } else {
+        root.insert(
+            "workspaces".to_string(),
+            serde_json::Value::Object(serde_json::Map::new()),
+        );
+    }
+
     root.get_mut("workspaces")
         .and_then(serde_json::Value::as_object_mut)
         .ok_or_else(|| miette::miette!("package.json `workspaces` must be an object"))
@@ -539,6 +545,44 @@ mod tests {
                 .unwrap();
         assert_eq!(json["workspaces"]["packages"][0], "packages/*");
         assert_eq!(json["workspaces"]["catalog"]["react"], "^19.0.0");
+    }
+
+    #[test]
+    fn manifest_catalog_upsert_preserves_key_order_when_converting_workspace_array() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"archie","private":true,"workspaces":["apps/*","packages/*"],"scripts":{"lint":"lint"},"devEngines":{"packageManager":{"name":"nub"}},"engines":{"node":">=24"}}"#,
+        )
+        .unwrap();
+
+        upsert_catalog_entries_in_manifest(
+            dir.path(),
+            &[CatalogUpsert {
+                catalog: "default".into(),
+                package: "@types/node".into(),
+                range: "^26.1.1".into(),
+            }],
+        )
+        .unwrap();
+
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join("package.json")).unwrap())
+                .unwrap();
+        let keys: Vec<&str> = json.as_object().unwrap().keys().map(String::as_str).collect();
+        assert_eq!(
+            keys,
+            vec![
+                "name",
+                "private",
+                "workspaces",
+                "scripts",
+                "devEngines",
+                "engines"
+            ]
+        );
+        assert_eq!(json["workspaces"]["packages"][0], "apps/*");
+        assert_eq!(json["workspaces"]["catalog"]["@types/node"], "^26.1.1");
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/catalogs.rs
+++ b/vendor/aube/crates/aube/src/commands/catalogs.rs
@@ -275,6 +275,91 @@ pub(crate) fn upsert_catalog_entries(
     Ok(())
 }
 
+/// Upsert a batch of catalog entries into `package.json#workspaces.catalog(s)`.
+///
+/// This is the manifest-root companion to [`upsert_catalog_entries`]. It is
+/// used when the active embedder reads neutral root manifest config (Nub
+/// identity) and does not read pnpm-named workspace YAML. Existing entries are
+/// never overwritten, matching pnpm's `--save-catalog` behavior.
+pub(crate) fn upsert_catalog_entries_in_manifest(
+    workspace_root: &Path,
+    entries: &[CatalogUpsert],
+) -> miette::Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let path = workspace_root.join("package.json");
+    crate::commands::update_manifest_json_object(&path, |root| {
+        let workspaces = normalize_workspaces_object(root)?;
+        for entry in entries {
+            let CatalogUpsert {
+                catalog,
+                package,
+                range,
+            } = entry;
+            let map = if catalog == "default" {
+                json_submap(workspaces, "catalog")?
+            } else {
+                let catalogs = json_submap(workspaces, "catalogs")?;
+                json_submap(catalogs, catalog)?
+            };
+            map.entry(package.clone())
+                .or_insert_with(|| serde_json::Value::String(range.clone()));
+        }
+        Ok(())
+    })
+    .wrap_err_with(|| {
+        format!(
+            "failed to write {} after --save-catalog",
+            path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn normalize_workspaces_object<'a>(
+    root: &'a mut serde_json::Map<String, serde_json::Value>,
+) -> miette::Result<&'a mut serde_json::Map<String, serde_json::Value>> {
+    let current = root.remove("workspaces");
+    let workspaces = match current {
+        Some(serde_json::Value::Object(obj)) => serde_json::Value::Object(obj),
+        Some(serde_json::Value::Array(packages)) => {
+            let mut obj = serde_json::Map::new();
+            obj.insert("packages".to_string(), serde_json::Value::Array(packages));
+            serde_json::Value::Object(obj)
+        }
+        Some(serde_json::Value::String(package)) => {
+            let mut obj = serde_json::Map::new();
+            obj.insert(
+                "packages".to_string(),
+                serde_json::Value::Array(vec![serde_json::Value::String(package)]),
+            );
+            serde_json::Value::Object(obj)
+        }
+        Some(other) => {
+            root.insert("workspaces".to_string(), other);
+            return Err(miette::miette!(
+                "package.json `workspaces` must be an object, array, or string to update catalogs"
+            ));
+        }
+        None => serde_json::Value::Object(serde_json::Map::new()),
+    };
+    root.insert("workspaces".to_string(), workspaces);
+    root.get_mut("workspaces")
+        .and_then(serde_json::Value::as_object_mut)
+        .ok_or_else(|| miette::miette!("package.json `workspaces` must be an object"))
+}
+
+fn json_submap<'a>(
+    map: &'a mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> miette::Result<&'a mut serde_json::Map<String, serde_json::Value>> {
+    map.entry(key.to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()))
+        .as_object_mut()
+        .ok_or_else(|| miette::miette!("package.json `workspaces.{key}` must be an object"))
+}
+
 /// Inner-mapping accessor mirroring `aube-manifest::workspace::workspace_yaml_submap`,
 /// duplicated here so this crate doesn't have to re-export the private helper.
 /// Errors when the key exists but isn't a mapping.
@@ -330,6 +415,97 @@ mod tests {
             false,
         );
         assert!(matches!(r, CatalogRewrite::UseDefaultCatalog));
+    }
+
+    #[test]
+    fn manifest_catalog_upsert_writes_default_and_named_without_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"root","workspaces":{"packages":["packages/*"]}}"#,
+        )
+        .unwrap();
+
+        upsert_catalog_entries_in_manifest(
+            dir.path(),
+            &[
+                CatalogUpsert {
+                    catalog: "default".into(),
+                    package: "react".into(),
+                    range: "^19.0.0".into(),
+                },
+                CatalogUpsert {
+                    catalog: "server".into(),
+                    package: "@types/node".into(),
+                    range: "^26.1.0".into(),
+                },
+            ],
+        )
+        .unwrap();
+
+        assert!(
+            !dir.path().join("pnpm-workspace.yaml").exists(),
+            "manifest catalog writes must not create a workspace yaml"
+        );
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join("package.json")).unwrap())
+                .unwrap();
+        assert_eq!(json["workspaces"]["catalog"]["react"], "^19.0.0");
+        assert_eq!(
+            json["workspaces"]["catalogs"]["server"]["@types/node"],
+            "^26.1.0"
+        );
+    }
+
+    #[test]
+    fn manifest_catalog_upsert_preserves_existing_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"workspaces":{"packages":["apps/*"],"catalog":{"react":"^18.0.0"}}}"#,
+        )
+        .unwrap();
+
+        upsert_catalog_entries_in_manifest(
+            dir.path(),
+            &[CatalogUpsert {
+                catalog: "default".into(),
+                package: "react".into(),
+                range: "^19.0.0".into(),
+            }],
+        )
+        .unwrap();
+
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join("package.json")).unwrap())
+                .unwrap();
+        assert_eq!(json["workspaces"]["catalog"]["react"], "^18.0.0");
+    }
+
+    #[test]
+    fn manifest_catalog_upsert_converts_workspace_array() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"workspaces":["packages/*"]}"#,
+        )
+        .unwrap();
+
+        upsert_catalog_entries_in_manifest(
+            dir.path(),
+            &[CatalogUpsert {
+                catalog: "default".into(),
+                package: "react".into(),
+                range: "^19.0.0".into(),
+            }],
+        )
+        .unwrap();
+
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join("package.json")).unwrap())
+                .unwrap();
+        assert_eq!(json["workspaces"]["packages"][0], "packages/*");
+        assert_eq!(json["workspaces"]["catalog"]["react"], "^19.0.0");
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/catalogs.rs
+++ b/vendor/aube/crates/aube/src/commands/catalogs.rs
@@ -320,9 +320,15 @@ pub(crate) fn upsert_catalog_entries_in_manifest(
 fn normalize_workspaces_object<'a>(
     root: &'a mut serde_json::Map<String, serde_json::Value>,
 ) -> miette::Result<&'a mut serde_json::Map<String, serde_json::Value>> {
+    if matches!(root.get("workspaces"), Some(serde_json::Value::Object(_))) {
+        return root
+            .get_mut("workspaces")
+            .and_then(serde_json::Value::as_object_mut)
+            .ok_or_else(|| miette::miette!("package.json `workspaces` must be an object"));
+    }
+
     let current = root.remove("workspaces");
     let workspaces = match current {
-        Some(serde_json::Value::Object(obj)) => serde_json::Value::Object(obj),
         Some(serde_json::Value::Array(packages)) => {
             let mut obj = serde_json::Map::new();
             obj.insert("packages".to_string(), serde_json::Value::Array(packages));
@@ -480,6 +486,33 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(dir.path().join("package.json")).unwrap())
                 .unwrap();
         assert_eq!(json["workspaces"]["catalog"]["react"], "^18.0.0");
+    }
+
+    #[test]
+    fn manifest_catalog_upsert_preserves_existing_workspaces_key_order() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"workspaces":{"packages":["apps/*"]},"devEngines":{"packageManager":{"name":"nub"}},"engines":{"node":">=24"}}"#,
+        )
+        .unwrap();
+
+        upsert_catalog_entries_in_manifest(
+            dir.path(),
+            &[CatalogUpsert {
+                catalog: "default".into(),
+                package: "react".into(),
+                range: "^19.0.0".into(),
+            }],
+        )
+        .unwrap();
+
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join("package.json")).unwrap())
+                .unwrap();
+        let keys: Vec<&str> = json.as_object().unwrap().keys().map(String::as_str).collect();
+        assert_eq!(keys, vec!["workspaces", "devEngines", "engines"]);
+        assert_eq!(json["workspaces"]["catalog"]["react"], "^19.0.0");
     }
 
     #[test]


### PR DESCRIPTION
Route `nub add --save-catalog` catalog upserts to the root manifest's neutral `workspaces.catalog(s)` surface when the project is under nub identity, instead of writing an unread `pnpm-workspace.yaml`.

Closes #369