### PR TITLE
bench(install): fix SIGPIPE killing run-4way.sh on Linux

### DIFF
--- a/tests/bench/install/run-4way.sh
+++ b/tests/bench/install/run-4way.sh
@@ -111,7 +111,7 @@ report_nub_layout() {
   rm -rf "$WORK/nub/node_modules"
   ( cd "$WORK/nub" && eval "$ci_env \"$NUB\" install --frozen-lockfile -s" ) >/dev/null 2>&1 || true
   local entry
-  entry="$(find "$WORK/nub/node_modules/.store" -maxdepth 1 -mindepth 1 ! -name '.nub-state' 2>/dev/null | head -1)"
+  entry="$(find "$WORK/nub/node_modules/.store" -maxdepth 1 -mindepth 1 ! -name '.nub-state' -print -quit 2>/dev/null)"
   if [ -z "$entry" ]; then
     echo "  [$label: no .store entries found]"
   elif [ -L "$entry" ]; then


### PR DESCRIPTION
`report_nub_layout`'s `find .store … | head -1` trips SIGPIPE → `pipefail` → `set -e` when `.store` has many entries (252 in the tanstack-start fixture): `find` keeps enumerating after `head` closes the pipe, so the pipeline returns 141 and the script dies before the timed block. Surfaces on Linux; macOS timing survived.

It's untimed diagnostic output, so the numbers are unaffected — but `make bench` fails outright on Linux.

Fix: `find … -print -quit` (first match, no pipe, no `head`; BSD + GNU). Verified `bash -n` clean and the layout signal still prints with 300+ entries under `set -euo pipefail`.

Refs #367