### PR TITLE
site: warm-install bench updated to Linux CI numbers (large fixture)

### DIFF
--- a/site/content/blog/introducing-nub.mdx
+++ b/site/content/blog/introducing-nub.mdx
@@ -439,20 +439,26 @@ Second, on a pnpm project, support is complete: Nub reads and honors every confi
 
 ### Performance
 
-Like pnpm, Nub keeps package files in a global content-addressed store and links them into `node_modules` with reflinks or hardlinks when the filesystem supports them. The benchmark below is the warm path for a TanStack Start app: packages are already on disk, `node_modules` is removed, and the installer rebuilds the project layout.
+Like pnpm, Nub keeps package files in a global content-addressed store and links them into `node_modules`. The default layout goes further: a warm install relinks one symlink per package instead of one hardlink per file, so the work scales with package count rather than file count.
+
+The benchmark below is the warm path on a large tree — 1,168 packages, 81,398 files: frozen lockfile, packages already in each tool's store, `node_modules` wiped between runs, no network. It runs on Linux because Linux is the shared primitive — Bun and Nub's hoisted mode both link with per-file hardlinks there, so the comparison is syscall-for-syscall (macOS pushes both onto clonefile). There are two Nub rows because they isolate two different claims: with `--node-linker hoisted`, Nub produces Bun's exact flat layout with the same per-file hardlink calls — the apples-to-apples row. The default row is the same install with the per-package relink.
 
 <Bench
-  label="warm frozen install · TanStack Start · 313 deps · macOS"
+  label="warm frozen install · 1168 packages · Linux (ubuntu-latest)"
   source="https://github.com/nubjs/nub/tree/main/tests/bench/install"
   accent="pink"
-  max={5316}
+  max={12945}
+  caption="hyperfine, 25 runs / 6 warmup, near-idle ubuntu-latest runner · bun 1.3.14, pnpm 10.34.4, npm on Node 24."
   rows={[
-    { cmd: 'nub', ms: 171, us: true },
-    { cmd: 'bun', ms: 686, ratio: 4.0 },
-    { cmd: 'pnpm', ms: 3193, ratio: 18.7 },
-    { cmd: 'npm', ms: 5316, ratio: 31.1 },
+    { cmd: 'nub', ms: 346, us: true },
+    { cmd: 'nub (hoisted)', ms: 1461, ratio: 4.2 },
+    { cmd: 'bun', ms: 1896, ratio: 5.5 },
+    { cmd: 'pnpm', ms: 3453, ratio: 10 },
+    { cmd: 'npm', ms: 12945, ratio: 37.4 },
   ]}
 />
+
+The ordering holds on thinner trees with a smaller lead — 1.7× over Bun on a 313-package TanStack Start app. The per-package relink pays off more as dependency trees get larger.
 
 ### Secure by default
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -483,17 +483,19 @@ Vite is the exception that keeps the shared store. Its dev server gates real-pat
 
 ### Offline installs
 
-Like pnpm, Nub relinks files from the global store into `node_modules` via reflink (APFS/btrfs) or hardlink (ext4) when the store already holds every package — no re-download, no byte-for-byte copy. The benchmark below measures the warm reinstall case: `node_modules` is removed, packages are already on disk, and the installer rebuilds the project layout.
+Like pnpm, Nub relinks from the global store into `node_modules` when the store already holds every package — no re-download, no byte-for-byte copy. With the default shared virtual store the relink is one symlink per package rather than one link per file. The benchmark below measures the warm reinstall case on a large tree (1,168 packages, 81,398 files): `node_modules` is removed between runs, packages are already on disk, no network. It runs on Linux, where Bun and Nub's hoisted mode both link with per-file hardlinks, so the hoisted row is a same-layout, same-syscall comparison; the default row is the same install with the per-package relink.
 
 <Bench
-  label="warm reinstall · TanStack Start · macOS"
+  label="warm reinstall · 1168 packages · Linux (ubuntu-latest)"
   accent="pink"
-  max={5316}
+  max={12945}
+  caption="hyperfine, 25 runs / 6 warmup, near-idle ubuntu-latest runner · bun 1.3.14, pnpm 10.34.4, npm on Node 24."
   rows={[
-    { cmd: 'nub install', ms: 171, us: true },
-    { cmd: 'bun install', ms: 686, ratio: 4.0 },
-    { cmd: 'pnpm install', ms: 3193, ratio: 18.7 },
-    { cmd: 'npm ci', ms: 5316, ratio: 31.1 },
+    { cmd: 'nub install', ms: 346, us: true },
+    { cmd: 'nub install --node-linker hoisted', ms: 1461, ratio: 4.2 },
+    { cmd: 'bun install', ms: 1896, ratio: 5.5 },
+    { cmd: 'pnpm install', ms: 3453, ratio: 10 },
+    { cmd: 'npm ci', ms: 12945, ratio: 37.4 },
   ]}
   source="https://github.com/nubjs/nub/tree/main/tests/bench/install"
 />

--- a/site/src/app/(home)/page.tsx
+++ b/site/src/app/(home)/page.tsx
@@ -1180,36 +1180,42 @@ function HypermanagerBand() {
             body={
               <>
                 Like pnpm, Nub keeps package files in a global content-addressed store and links
-                them into{' '}<Mono>node_modules</Mono>. Nub embeds{' '}
+                them into{' '}<Mono>node_modules</Mono>. The default layout relinks one symlink per
+                package instead of one hardlink per file, so a warm install scales with package
+                count, not file count. Nub embeds{' '}
                 <DocLink href="https://github.com/jdx/aube">aube</DocLink>, a highly optimized
                 Rust-based resolver and linker.
               </>
             }
             visual={
               <div className="nub-code-panel rounded-xl border p-6">
-                {/* Source: tests/bench/install/results/warm-tanstack-start-20260706-115125.json (TanStack Start, 313 deps), warm + frozen + offline, node_modules wiped between runs; hyperfine, 12 timed runs. Lowest-contention of 3 back-to-back runs (all committed); ratios are load-robust, absolute wall-clock is contention-affected and understates nub. */}
+                {/* Source: `large` fixture (1168 packages, 81398 files), warm + frozen + offline, node_modules wiped between runs; hyperfine, 25 runs / 6 warmup, near-idle ubuntu-latest CI. Linux is the honest shared primitive: bun and nub's hoisted mode both link with per-file hardlinks there (macOS forces both onto clonefile). The hoisted row is bun's exact layout + syscall — the same-regime bar; the default row adds the O(packages) GVS relink. bun 1.3.14, pnpm 10.34.4, npm on Node 24. */}
                 <p className="nub-code-muted mb-5 font-mono text-[0.7rem] uppercase tracking-[0.14em]">
-                  warm frozen install · TanStack Start · 313 deps · macOS
+                  warm frozen install · 1168 packages · Linux
                 </p>
                 <BenchBars
                   accent="pink"
-                  max={5316}
+                  max={12945}
                   unit="ms"
                   rows={[
-                    { cmd: 'nub', ms: 171, us: true },
-                    { cmd: 'bun', ms: 686, ratio: 4.0 },
-                    { cmd: 'pnpm', ms: 3193, ratio: 18.7 },
-                    { cmd: 'npm', ms: 5316, ratio: 31.1 },
+                    { cmd: 'nub', ms: 346, us: true },
+                    { cmd: 'nub (hoisted)', ms: 1461, ratio: 4.2 },
+                    { cmd: 'bun', ms: 1896, ratio: 5.5 },
+                    { cmd: 'pnpm', ms: 3453, ratio: 10 },
+                    { cmd: 'npm', ms: 12945, ratio: 37.4 },
                   ]}
                 />
-                <a
-                  href="https://github.com/nubjs/nub/blob/main/tests/bench/install/README.md"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="nub-code-link nub-code-muted mt-3 inline-block py-1.5 font-mono text-[0.7rem] uppercase tracking-[0.14em] underline decoration-dotted underline-offset-4"
-                >
-                  View methodology →
-                </a>
+                <p className="nub-code-muted mt-4 font-mono text-[0.7rem] uppercase tracking-[0.14em]">
+                  ubuntu-latest · hyperfine, 25 runs ·{' '}
+                  <a
+                    href="https://github.com/nubjs/nub/blob/main/tests/bench/install/README.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="nub-code-link underline decoration-dotted underline-offset-4"
+                  >
+                    methodology →
+                  </a>
+                </p>
               </div>
             }
           />


### PR DESCRIPTION
Updates the warm-install bench on the homepage, the introducing-nub post, and the install docs to the ubuntu-latest CI run on the `large` fixture (1168 packages, 81398 files): hyperfine, 25 runs / 6 warmup, warm store, frozen lockfile, `node_modules` wiped between runs. bun 1.3.14, pnpm 10.34.4, npm on Node 24.

Adds a `nub --node-linker hoisted` row (bun's flat layout, same per-file hardlink syscall) alongside the default symlink-per-package relink; each bench now labels platform + methodology. Removes the prior macOS numbers, which did not reproduce. Rendered output verified in-browser.

https://claude.ai/code/session_01UVBNLm9SkJGM8P8K6jnKLJ