### PR TITLE
v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "nub-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "aube",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "nub-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "nub-phantom-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "nub-phantom-scan"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "nub-phantom-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ opt-level = 2
 split-debuginfo = "unpacked"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/nub-native/Cargo.lock
+++ b/crates/nub-native/Cargo.lock
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "nub-native"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "blake3",
  "json5",

--- a/crates/nub-native/Cargo.toml
+++ b/crates/nub-native/Cargo.toml
@@ -29,7 +29,7 @@ members = ["."]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/npm/nub-darwin-arm64/package.json
+++ b/npm/nub-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nubjs/nub-darwin-arm64",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Nub binary for macOS ARM64 (Apple Silicon)",
   "license": "MIT",
   "repository": "https://github.com/nubjs/nub",

--- a/npm/nub-darwin-x64/package.json
+++ b/npm/nub-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nubjs/nub-darwin-x64",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Nub binary for darwin-x64",
   "license": "MIT",
   "repository": "https://github.com/nubjs/nub",

--- a/npm/nub-linux-arm64-musl/package.json
+++ b/npm/nub-linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nubjs/nub-linux-arm64-musl",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Nub binary for linux-arm64-musl",
   "license": "MIT",
   "repository": "https://github.com/nubjs/nub",

--- a/npm/nub-linux-arm64/package.json
+++ b/npm/nub-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nubjs/nub-linux-arm64",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Nub binary for linux-arm64",
   "license": "MIT",
   "repository": "https://github.com/nubjs/nub",

--- a/npm/nub-linux-x64-musl/package.json
+++ b/npm/nub-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nubjs/nub-linux-x64-musl",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Nub binary for linux-x64-musl",
   "license": "MIT",
   "repository": "https://github.com/nubjs/nub",

--- a/npm/nub-linux-x64/package.json
+++ b/npm/nub-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nubjs/nub-linux-x64",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Nub binary for linux-x64",
   "license": "MIT",
   "repository": "https://github.com/nubjs/nub",

--- a/npm/nub-types/package.json
+++ b/npm/nub-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nubjs/types",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "TypeScript ambient declarations for code authored against the Nub runtime",
   "license": "MIT",
   "repository": "https://github.com/nubjs/nub",

--- a/npm/nub-win32-arm64/package.json
+++ b/npm/nub-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nubjs/nub-win32-arm64",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Nub binary for win32-arm64",
   "license": "MIT",
   "repository": "https://github.com/nubjs/nub",

--- a/npm/nub-win32-x64/package.json
+++ b/npm/nub-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nubjs/nub-win32-x64",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Nub binary for win32-x64",
   "license": "MIT",
   "repository": "https://github.com/nubjs/nub",

--- a/npm/nub/package.json
+++ b/npm/nub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nubjs/nub",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "TypeScript-first developer supertool — a fast script runner and TS runtime powered by Node.js",
   "license": "MIT",
   "repository": "https://github.com/nubjs/nub",
@@ -36,13 +36,13 @@
     "LICENSE"
   ],
   "optionalDependencies": {
-    "@nubjs/nub-darwin-arm64": "0.4.2",
-    "@nubjs/nub-darwin-x64": "0.4.2",
-    "@nubjs/nub-linux-x64": "0.4.2",
-    "@nubjs/nub-linux-x64-musl": "0.4.2",
-    "@nubjs/nub-linux-arm64": "0.4.2",
-    "@nubjs/nub-linux-arm64-musl": "0.4.2",
-    "@nubjs/nub-win32-x64": "0.4.2",
-    "@nubjs/nub-win32-arm64": "0.4.2"
+    "@nubjs/nub-darwin-arm64": "0.4.3",
+    "@nubjs/nub-darwin-x64": "0.4.3",
+    "@nubjs/nub-linux-x64": "0.4.3",
+    "@nubjs/nub-linux-x64-musl": "0.4.3",
+    "@nubjs/nub-linux-arm64": "0.4.3",
+    "@nubjs/nub-linux-arm64-musl": "0.4.3",
+    "@nubjs/nub-win32-x64": "0.4.3",
+    "@nubjs/nub-win32-arm64": "0.4.3"
   }
 }

--- a/runtime/version.mjs
+++ b/runtime/version.mjs
@@ -9,4 +9,4 @@
 // previously lived as a literal inside preload.mjs, which `make version` patched,
 // while the worker carried a hand-maintained "…-compat" copy that `make version`
 // never touched — a latent staleness bug this module closes.)
-export const NUB_VERSION = "0.4.2";
+export const NUB_VERSION = "0.4.3";


### PR DESCRIPTION
Version bump to v0.4.3. Ships everything on main since v0.4.2 — yarn berry workspace-member enumeration and closure fixes (#374), bun.lock unresolvable-source abort (#363), plus benchmark/site/prose updates. Tag push after merge triggers the 8-platform release build.

Refs #374