### PR TITLE
docs(virtual-store): linker mechanism, phantom ejection, performance

### DIFF
--- a/site/content/docs/install/virtual-store.mdx
+++ b/site/content/docs/install/virtual-store.mdx
@@ -1,9 +1,71 @@
 ---
 title: The virtual store
-description: Nub links an isolated, symlinked virtual store by default. Opt into a plain, flat node_modules — npm's layout — for one command or a whole project, and see how each package manager's own layout config maps onto it.
+description: How Nub's default linker works — one symlink per package into a machine-global store, with install-time phantom detection and per-package ejection — its warm-install performance, and the flat and project-local opt-outs.
 ---
 
-Every install links an **isolated virtual store** by default: direct dependencies sit at the top of `node_modules`, transitive packages link into a per-machine store, and undeclared (phantom) dependencies fail instead of resolving by accident. To get a plain, flat `node_modules` instead — npm's layout, no virtual store — set one line in `.npmrc`:
+Every install links an **isolated virtual store** by default: direct dependencies sit at the top of `node_modules`, transitive packages link into a per-machine store, and undeclared (phantom) dependencies fail instead of resolving by accident. This page covers how the linker works, what it costs, and the opt-outs.
+
+## One symlink per package
+
+Incumbent package managers build `node_modules` file by file. npm copies every file into every project; pnpm and Bun hardlink every file from a machine cache — faster, but still one syscall per file, tens of thousands for a typical app.
+
+Nub's default layout links **one symlink per package**. Package files live in a machine-global store, one real copy per package version, deduplicated by content hash:
+
+```console
+$ nub store path
+/Users/you/.local/share/nub/store/v1
+```
+
+Each store entry holds a package version's real files plus symlinks to its **declared** dependencies. The project's `node_modules` then symlinks each package straight into the store:
+
+```text
+my-app/
+└── node_modules/
+    ├── ms     →  ~/.local/share/nub/store/…/ms@2.1.3
+    └── react  →  ~/.local/share/nub/store/…/react@19.2.0
+```
+
+Two properties fall out of this layout:
+
+- **Warm installs scale with package count, not file count.** Linking a project is O(packages) symlinks instead of O(files) hardlinks or copies.
+- **The store is a sealed world.** Node resolves a symlink to its real path before loading, so code loaded from the store resolves imports from inside its store entry — its declared dependencies and nothing else. An undeclared import fails at resolve time instead of working by accident.
+
+No other package manager ships this as its default. Bun shipped it for its isolated linker and reverted to opt-in three weeks later; pnpm keeps it behind the off-by-default `enableGlobalVirtualStore` flag. The blocker is the same in both trackers: widely-used packages import **phantom dependencies** — packages they never declare — and a sealed store breaks them. The deep dive on that history and the mechanism below is the blog post: [how we built a 5x faster package manager](/blog/unblocking-the-global-virtual-store).
+
+## Phantom detection and ejection
+
+Nub can make this layout the default because the install detects the packages that would break, and only those fall back.
+
+As each tarball is imported into the store, Nub parses that version's published code with [Oxc](https://oxc.rs): it walks the module graph from the package's `exports`, `main`, and `bin` entry points and checks every static, unguarded import against the dependencies the package declares. Published versions are immutable, so each verdict is computed once per content fingerprint and cached machine-wide next to the store. The scan runs on the download fan-out threads, overlapped with network time.
+
+At link time, a flagged package is **ejected**: hardlinked into the project as real files instead of symlinked into the store, so its resolution walk passes through the project again — and the undeclared target is linked where that walk finds it. Everything that transitively imports the flagged package is ejected with it; ejecting the offender alone would leave its store-resident importers loading the shared copy — two real paths, two module instances. The ejected closure measures 0.3–2.1% of real large trees, and the symlinked majority keeps the one-link-per-package relink.
+
+Detection and ejection are on for every install, with no configuration. Two toolchains whose resolvers cannot follow symlinks out of the project — Next.js, whose Turbopack canonicalizes paths and confines the module graph to a single project root, and bare React Native, whose Metro config crawls by real path — automatically get a **project-local** store instead: the same isolated layout, with every link staying inside `node_modules`. See [shared vs per-project store](/docs/install#shared-vs-per-project-store).
+
+## Performance
+
+A warm install — store populated, frozen lockfile — is where the layout pays: relinking costs O(packages) while every other installer pays O(files), so the gap widens as trees get fatter.
+
+<Bench
+  label="warm install · 1168 packages · Linux (ubuntu-latest)"
+  source="https://github.com/nubjs/nub/tree/main/tests/bench/install"
+  accent="pink"
+  max={12945}
+  caption="hyperfine, 25 runs / 6 warmup, near-idle ubuntu-latest runner · bun 1.3.14, pnpm 10.34.4, npm on Node 24."
+  rows={[
+    { cmd: 'nub install', ms: 346, us: true },
+    { cmd: 'nub install --node-linker hoisted', ms: 1461, ratio: 4.2 },
+    { cmd: 'bun install', ms: 1896, ratio: 5.5 },
+    { cmd: 'pnpm install', ms: 3453, ratio: 10 },
+    { cmd: 'npm ci', ms: 12945, ratio: 37.4 },
+  ]}
+/>
+
+The two Nub rows isolate the layout's contribution. With `--node-linker hoisted`, Nub links Bun's exact flat layout with the same per-file hardlink syscall — 1.3× faster than Bun on the same work. The default row is the same install with the one-symlink-per-package relink: 4.2× faster than Nub's own hoisted mode, 5.5× faster than Bun. On a thinner 313-package tree the default's lead over Bun is 1.7× — the advantage grows with the tree.
+
+## The flat opt-out
+
+To get a plain, flat `node_modules` instead — npm's layout, no virtual store — set one line in `.npmrc`:
 
 ```ini
 # .npmrc — flat, npm-style node_modules for the whole project


### PR DESCRIPTION
Expands `/docs/install/virtual-store` beyond layout config: the one-symlink-per-package machine-global layout and sealed-world isolation, the extract-time Oxc phantom scan (verdicts cached per content fingerprint), the link-time ancestor-closure eject (0.3–2.1% of large trees), and the next/react-native project-local fallback — grounded in `dynamic_phantom.rs` / `phantom_closure.rs` / `pm_engine/mod.rs`. Adds the Linux warm-install bench (same numbers as homepage/blog) and links the GVS post as the deep dive. Existing opt-out sections kept. Rendered page verified in-browser.

https://claude.ai/code/session_01UVBNLm9SkJGM8P8K6jnKLJ