### PR TITLE
blog: retitle GVS post

### DIFF
--- a/site/content/blog/unblocking-the-global-virtual-store.mdx
+++ b/site/content/blog/unblocking-the-global-virtual-store.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Node.js and the phantom dependency problem; or, how we built a 5x faster package manager"
+title: "Node’s phantom dependency problem and the path to a 5x faster package manager"
 description: One copy of every package per machine, symlinked into every project — and the mechanisms that make that layout work across the ecosystem.
 author: The Nub Team
 date: 2026-07-07T12:00:00Z


### PR DESCRIPTION
Retitle the GVS blog post to 'Node's phantom dependency problem and the path to a 5x faster package manager' (maintainer wording). The OG image + blog-list title regenerate from this frontmatter. Content-only.