### PR TITLE
docs: correct GVS auto-disable trigger list (next + react-native)

### DIFF
--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -473,7 +473,7 @@ A few packages statically import a backend you pick at runtime — `@hookform/re
 
 The same treatment covers packages that write generated code back into their own install directory. Prisma's postinstall runs `prisma generate`, which writes the generated client next to `@prisma/client` on disk — and under the shared store that spot is machine-global, keyed by version rather than by project or schema. Two projects with different Prisma schemas would otherwise share one generated client and silently overwrite each other's models. Nub materializes `@prisma/client` into each project so `generate` stays project-local, matching pnpm. This detection is automatic — it scans each package's real published code, so there is no list to maintain.
 
-A bundler that resolves modules by their real path — Metro (bare React Native), Next.js, Parcel — only crawls the project directory, so it can't see the shared store. Nub gives those projects a self-contained, project-local store automatically. Extend the list in `.npmrc`:
+A bundler that resolves modules by their real path — Metro (bare React Native), Next.js — only crawls the project directory, so it can't see the shared store. Nub gives those projects a self-contained, project-local store automatically. Extend the list in `.npmrc`:
 
 ```ini
 disableGlobalVirtualStoreForPackages[]=my-bundler

--- a/tests/bench/install/README.md
+++ b/tests/bench/install/README.md
@@ -30,7 +30,7 @@ The main harness exercises both sides of the compatibility split:
 | GVS eligible | `run-warm-gvs.sh --fixture gvs-eligible` | `nub install` warm-install time vs pnpm where GVS stays on. |
 | GVS ineligible | `run-warm-gvs.sh --fixture gvs-ineligible` | A `next` project where GVS auto-disables and nub is roughly pnpm parity. |
 
-Nub's trigger list is `next`, `nuxt`, and `parcel`. `vite`, `vitepress`, and `@sveltejs/kit` are not triggers in Nub.
+Nub's trigger list is `next` and `react-native`. `vite`, `vitepress`, and `@sveltejs/kit` are not triggers in Nub.
 
 ```bash
 NUB=/path/to/target/release/nub bash tests/bench/install/run-warm-gvs.sh


### PR DESCRIPTION
The code auto-disables the global virtual store only for `next` and `react-native` (pm_engine/mod.rs:2192). Docs still listed the dropped `nuxt`/`parcel`. Fixes the install-docs bundler list and the bench README trigger line. Dated release blogs are correct point-in-time and untouched.