### PR TITLE
site: step long OG title sizes down so they clear the footer

### DIFF
--- a/site/src/lib/og.tsx
+++ b/site/src/lib/og.tsx
@@ -74,14 +74,18 @@ type CardProps = {
 };
 
 /* Size the headline by length: short titles read large, long ones step down so
-   they still fit one or two lines. Sized generously — these cards render small
-   in a feed, so the title has to carry from a thumbnail. Element titles (the
-   home tagline) use a fixed size since their length can't be measured here. */
+   they still fit the card with clear space above the footer wordmark (the
+   longest bucket wraps to three lines). Sized generously — these cards render
+   small in a feed, so the title has to carry from a thumbnail. Element titles
+   (the home tagline) use a fixed size since their length can't be measured
+   here. */
 function titleFontSize(title: ReactElement | string): string {
   if (typeof title !== 'string') return '108px';
   if (title.length <= 16) return '132px';
   if (title.length <= 24) return '112px';
-  return '92px';
+  if (title.length <= 40) return '92px';
+  if (title.length <= 58) return '80px';
+  return '72px';
 }
 
 /* The card body, shared by the home and per-page cards. The ember glow, ink


### PR DESCRIPTION
The OG card sized the longest title bucket (>24 chars) at 92px, wrapping a 77-char blog title to four lines that crowded the `nub.` wordmark.

Add finer steps to `titleFontSize`: `<=40` → 92px, `<=58` → 80px, else 72px. The 77-char title now wraps to three lines with clear space above the footer; short/medium sizing is unchanged.

Verified visually against the live `/og` route at four lengths (13/28/52/77 chars). Long clears the wordmark; short and medium do not regress. No console errors.

Site-only (path-filtered CI).