### PR TITLE
feat(env): clamped NODE_ENV fallback for .env-file mode selection

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -205,12 +205,13 @@ fn overlay_env_file_vars(env_map: &mut HashMap<String, String>) {
 /// Build the env map for a child, merging eager `.env*` auto-discovery with the
 /// explicit `--env-file` vars. The gate (the maintainer, 2026-06-15): when the user passed
 /// any `--env-file` flag, auto-discovery is **suppressed entirely** — none of the
-/// four auto files (`.env.<NODE_ENV>.local`, `.env.local`, `.env.<NODE_ENV>`,
-/// `.env`) load, and only the explicit file(s) reach the child. With no
-/// `--env-file`, the autos load as before.
+/// four auto files (`.env.<mode>.local`, `.env.local`, `.env.<mode>`, `.env`)
+/// load, and only the explicit file(s) reach the child. With no `--env-file`, the
+/// autos load as before.
 ///
 /// `auto_env` is the already-loaded `.env*` map (callers pass `load_env_files`'s
-/// result, which honors NODE_ENV + ${VAR} expansion); `env_file_present` is the
+/// result, whose `<mode>` comes from `APP_ENV`, else a clamped `NODE_ENV`
+/// fallback, with `${VAR}` expansion); `env_file_present` is the
 /// flag-presence signal; `explicit_vars` is `ENV_FILE_VARS` (the parsed
 /// `--env-file` contents); `no_env_file` is the `--no-env-file` kill-switch. This
 /// is a pure function over its inputs so the suppression contract can be

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -5447,9 +5447,10 @@ fn dotenv_node_env_stripped_and_app_env_selects_env_file() {
         "nub must warn that a `.env` NODE_ENV was ignored: {err_a}"
     );
 
-    // (b) ambient NODE_ENV=production: passes through untouched but does NOT select
-    //     `.env.production` — NODE_ENV is no longer a mode source. No spurious
-    //     warning (the ambient value wins over the `.env` value before the strip).
+    // (b) ambient NODE_ENV=production (APP_ENV unset): passes through untouched AND
+    //     selects `.env.production` as the clamped fallback (`production` is
+    //     canonical — Next.js/Bun parity). No spurious warning (the ambient value
+    //     wins over the `.env` value before the strip).
     let (out_b, err_b, code_b) = run(Some("production"), None);
     assert_eq!(code_b, 0, "run must succeed; stderr: {err_b}");
     assert!(
@@ -5457,12 +5458,26 @@ fn dotenv_node_env_stripped_and_app_env_selects_env_file() {
         "ambient NODE_ENV must pass through: {out_b}"
     );
     assert!(
-        out_b.contains("PROD=[]"),
-        "ambient NODE_ENV must NOT select `.env.production` (no longer a mode source): {out_b}"
+        out_b.contains("PROD=[prod]"),
+        "canonical ambient NODE_ENV must select `.env.production` (clamped fallback): {out_b}"
     );
     assert!(
         !err_b.contains("ignoring NODE_ENV set in .env"),
         "no warning when an ambient NODE_ENV wins over the `.env` value: {err_b}"
+    );
+
+    // (b2) ambient NODE_ENV=staging: NON-canonical, so it is ignored for file
+    //      selection — only `.env` loads, never `.env.production`. Use APP_ENV for
+    //      arbitrary modes.
+    let (out_b2, err_b2, code_b2) = run(Some("staging"), None);
+    assert_eq!(code_b2, 0, "run must succeed; stderr: {err_b2}");
+    assert!(
+        out_b2.contains("NE=[staging]"),
+        "ambient NODE_ENV must pass through: {out_b2}"
+    );
+    assert!(
+        out_b2.contains("PROD=[]"),
+        "non-canonical NODE_ENV must NOT select a `.env.<mode>` file: {out_b2}"
     );
 
     // (c) APP_ENV=production selects `.env.production` (the mode mechanism), while

--- a/crates/nub-core/src/workspace/env.rs
+++ b/crates/nub-core/src/workspace/env.rs
@@ -99,6 +99,14 @@ pub fn read_env_file(path: &Path) -> Option<String> {
     fs::read_to_string(path).ok()
 }
 
+/// The canonical `NODE_ENV` values that may act as a mode fallback. Kept EXACT —
+/// `development` / `production` / `test`, no short forms — for parity with Next.js
+/// and Bun, which couple `.env.{mode}` to `NODE_ENV` only on these values. Any
+/// other `NODE_ENV` (e.g. `staging`) is ignored for file selection, so an
+/// arbitrary value can't silently flip the loaded file set (the footgun the modern
+/// ecosystem decoupled away); use `APP_ENV` for arbitrary modes.
+const CLAMPED_NODE_ENV_MODES: &[&str] = &["development", "production", "test"];
+
 /// The `.env*` filenames Nub loads, in descending priority order (the file
 /// listed first wins a key over later ones). Driven by the resolved *mode*. The
 /// `.env` / `.env.local` / `.env.{mode}` cascade mirrors the dotenv-flow / Next /
@@ -107,28 +115,37 @@ pub fn read_env_file(path: &Path) -> Option<String> {
 /// (first-writer-wins merge) and [`discover_env_files`] (the watch path's
 /// `--env-file` args), so this one function governs mode selection on both paths.
 ///
-/// Mode = `APP_ENV` when non-empty, else no mode. `APP_ENV` is the sole,
-/// framework-neutral selector (Vite, and others); to load a specific file
-/// directly, pass `--env-file <path>` (repeatable). `NODE_ENV` is deliberately NOT
-/// a mode source — nub treats it as the application's own dev/prod behavior
-/// variable, never a file selector (a non-dev/prod/test `NODE_ENV` used as a file
-/// selector silently flips frameworks into development mode, the footgun the
-/// modern ecosystem decoupled away). When `APP_ENV` is unset there is no mode, so
-/// only `.env` / `.env.local` load.
+/// Mode precedence: `APP_ENV` (non-empty) is the primary, framework-neutral
+/// selector (Vite and others) and wins even when `NODE_ENV` is also set. When
+/// `APP_ENV` is unset, `NODE_ENV` is a CLAMPED fallback — it selects a mode only
+/// when it is exactly `development` / `production` / `test`
+/// ([`CLAMPED_NODE_ENV_MODES`], Next.js / Bun parity). Any other `NODE_ENV` value
+/// yields no mode, as does both being unset — only `.env` / `.env.local` load. To
+/// load a specific file directly, pass `--env-file <path>` (repeatable).
 fn env_file_names() -> Vec<String> {
     env_file_names_for_mode(&resolve_env_mode())
 }
 
-/// Resolve the env-file mode from the ambient `APP_ENV`. Reads process env once;
-/// [`resolve_mode`] holds the pure logic (hermetically testable).
+/// Resolve the env-file mode from the ambient `APP_ENV` and `NODE_ENV`. Reads
+/// process env once; [`resolve_mode`] holds the pure logic (hermetically testable).
 fn resolve_env_mode() -> String {
-    resolve_mode(std::env::var("APP_ENV").ok())
+    resolve_mode(
+        std::env::var("APP_ENV").ok(),
+        std::env::var("NODE_ENV").ok(),
+    )
 }
 
-/// Pure mode resolution: `APP_ENV` when non-empty, else no mode. `NODE_ENV` is
-/// intentionally absent (see [`env_file_names`]).
-fn resolve_mode(app_env: Option<String>) -> String {
-    app_env.filter(|v| !v.is_empty()).unwrap_or_default()
+/// Pure mode resolution. `APP_ENV` (non-empty) is the primary selector and wins
+/// even when `NODE_ENV` is also set. Otherwise `NODE_ENV` is a clamped fallback:
+/// it yields a mode only when it is one of [`CLAMPED_NODE_ENV_MODES`]; any other
+/// value (`staging`, empty) — or both being unset — resolves to no mode.
+fn resolve_mode(app_env: Option<String>, node_env: Option<String>) -> String {
+    if let Some(app_env) = app_env.filter(|v| !v.is_empty()) {
+        return app_env;
+    }
+    node_env
+        .filter(|v| CLAMPED_NODE_ENV_MODES.contains(&v.as_str()))
+        .unwrap_or_default()
 }
 
 /// The `.env*` precedence list for a resolved mode. `is_test` (mode `test`) omits
@@ -246,8 +263,10 @@ fn load_env_files_raw_reporting(
             for (key, value) in parse_env(&content) {
                 // Shell env wins: don't override existing env vars. An AMBIENT
                 // `NODE_ENV` (set in the real process env) therefore passes through
-                // untouched and still selects `.env.<NODE_ENV>` files above — only a
-                // `.env`-FILE `NODE_ENV` is dropped below.
+                // untouched and, when `APP_ENV` is unset and it is canonical
+                // (development/production/test), selects `.env.<NODE_ENV>` files above
+                // as the clamped fallback — only a `.env`-FILE `NODE_ENV` is dropped
+                // below.
                 if std::env::var_os(&key).is_some() {
                     continue;
                 }
@@ -534,18 +553,37 @@ mod tests {
         );
     }
 
-    /// Mode selection is `APP_ENV` only: the non-empty ambient value is the mode,
-    /// else no mode. `NODE_ENV` is NOT a mode source, and there is no `--env` flag —
-    /// `resolve_mode` takes only `APP_ENV`, so nothing else can participate.
+    /// Mode precedence: `APP_ENV` (non-empty) is primary and wins even when
+    /// `NODE_ENV` is also set; otherwise `NODE_ENV` is a CLAMPED fallback that
+    /// selects only on the canonical `development`/`production`/`test` values. A
+    /// non-canonical `NODE_ENV` (`staging`) or both-unset yields no mode.
     #[test]
-    fn resolve_mode_is_app_env_only() {
+    fn resolve_mode_app_env_primary_node_env_clamped_fallback() {
         let s = |v: &str| Some(v.to_string());
-        // APP_ENV set → that mode.
-        assert_eq!(resolve_mode(s("production")), "production");
-        assert_eq!(resolve_mode(s("staging")), "staging");
-        // Unset or empty → no mode.
-        assert_eq!(resolve_mode(None), "");
-        assert_eq!(resolve_mode(s("")), "");
+
+        // APP_ENV set → that mode, even an arbitrary one (APP_ENV isn't clamped).
+        assert_eq!(resolve_mode(s("production"), None), "production");
+        assert_eq!(resolve_mode(s("staging"), None), "staging");
+        // APP_ENV wins over NODE_ENV when both are set.
+        assert_eq!(resolve_mode(s("staging"), s("production")), "staging");
+        assert_eq!(resolve_mode(s("production"), s("test")), "production");
+
+        // APP_ENV unset → NODE_ENV as a clamped fallback, canonical values only.
+        assert_eq!(resolve_mode(None, s("production")), "production");
+        assert_eq!(resolve_mode(None, s("development")), "development");
+        assert_eq!(resolve_mode(None, s("test")), "test");
+        // Empty APP_ENV is treated as unset, so the fallback still applies.
+        assert_eq!(resolve_mode(s(""), s("production")), "production");
+
+        // Non-canonical NODE_ENV is ignored for file selection (no arbitrary-value
+        // footgun) — and short forms are NOT accepted, matching Next.js/Bun.
+        assert_eq!(resolve_mode(None, s("staging")), "");
+        assert_eq!(resolve_mode(None, s("prod")), "");
+        assert_eq!(resolve_mode(None, s("dev")), "");
+        assert_eq!(resolve_mode(None, s("")), "");
+
+        // Both unset → no mode.
+        assert_eq!(resolve_mode(None, None), "");
     }
 
     /// A mode carrying a path separator (a hostile `APP_ENV`/`NODE_ENV`)
@@ -590,6 +628,45 @@ mod tests {
         assert_eq!(
             env_file_names_for_mode("test"),
             vec![".env.test.local", ".env.test", ".env"]
+        );
+    }
+
+    /// End-to-end file-set selection through the clamped `NODE_ENV` fallback,
+    /// composing `resolve_mode` with `env_file_names_for_mode` (hermetic — no
+    /// process env). `NODE_ENV=production` (APP_ENV unset) selects the production
+    /// cascade; `NODE_ENV=test` inherits the `.env.local` skip, consistent with
+    /// `APP_ENV=test`; a non-canonical `NODE_ENV=staging` selects no mode.
+    #[test]
+    fn clamped_node_env_fallback_selects_the_expected_file_set() {
+        let names = |app: Option<&str>, node: Option<&str>| {
+            env_file_names_for_mode(&resolve_mode(
+                app.map(str::to_string),
+                node.map(str::to_string),
+            ))
+        };
+
+        assert_eq!(
+            names(None, Some("production")),
+            vec![
+                ".env.production.local",
+                ".env.local",
+                ".env.production",
+                ".env"
+            ],
+        );
+        // NODE_ENV=test → the same `.env.local` skip as APP_ENV=test.
+        assert_eq!(
+            names(None, Some("test")),
+            vec![".env.test.local", ".env.test", ".env"],
+        );
+        // Non-canonical NODE_ENV → no mode: only the base cascade.
+        assert_eq!(names(None, Some("staging")), vec![".env.local", ".env"]);
+        // Both unset → no mode.
+        assert_eq!(names(None, None), vec![".env.local", ".env"]);
+        // APP_ENV wins even when NODE_ENV is also a canonical value.
+        assert_eq!(
+            names(Some("staging"), Some("production")),
+            vec![".env.staging.local", ".env.local", ".env.staging", ".env"],
         );
     }
 

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -1,6 +1,6 @@
 ---
 title: Environment files
-description: Automatic environment-file loading — the file set, the APP_ENV mode, precedence, variable expansion, the skip under the test environment, loading explicit files with --env-file, and disabling all loading with --no-env-file.
+description: Automatic environment-file loading — the file set, mode selection from APP_ENV or a clamped NODE_ENV fallback, precedence, variable expansion, the skip under the test environment, loading explicit files with --env-file, and disabling all loading with --no-env-file.
 ---
 
 Nub reads your `.env*` files and injects them into the environment before Node starts — no `dotenv` import, no `--env-file` flag. Loading happens from the nearest directory with a `package.json` (walking up from your cwd), matching Vite's single-directory model. Works on every Node version Nub supports (18.19+).
@@ -27,26 +27,35 @@ APP_ENV=production nub server.ts
 
 ## Selecting the mode
 
-The mode fills the `[mode]` slots above. It comes from `APP_ENV` — set it to a non-empty value, and the matching `.env.[mode]` files load. When `APP_ENV` is unset there is no mode, so only `.env.local` and `.env` load.
+The mode fills the `[mode]` slots above. `APP_ENV` is the primary selector: set it to a non-empty value, and the matching `.env.[mode]` files load. When `APP_ENV` is unset, `NODE_ENV` acts as a fallback — but only for the three canonical values `development`, `production`, and `test`.
 
 ```bash
 APP_ENV=production nub server.ts   # reads .env.production*
 APP_ENV=staging nub server.ts      # reads .env.staging*
+NODE_ENV=production nub server.ts  # APP_ENV unset → reads .env.production*
 ```
 
-`APP_ENV` is a framework-neutral selector: it drives which `.env` files load without also flipping `NODE_ENV`, which many tools read to switch between development and production behavior. To load a specific file rather than a mode, name it with `--env-file` (below).
+`APP_ENV` is a framework-neutral selector: it drives which `.env` files load without also flipping `NODE_ENV`, which many tools read to switch between development and production behavior. It accepts any mode name, and it wins over `NODE_ENV` when both are set. To load a specific file rather than a mode, name it with `--env-file` (below).
 
 A mode is only used to build filenames when it contains just letters, digits, `_`, `.`, and `-`. A value with a path separator (a stray `APP_ENV=../other`) is ignored — the `[mode]` files are skipped, `.env` and `.env.local` still load, and no error is raised.
 
 ## NODE_ENV
 
-Nub treats `NODE_ENV` as your application's variable: it never sets it, never reads it to select env files, and won't let an env file change it. It is not a mode source — set `APP_ENV` to choose which `.env.[mode]` files load.
+When `APP_ENV` is unset, `NODE_ENV` selects the mode — but Nub clamps it to `development`, `production`, or `test`, matching Next.js and Bun. Those three values select the corresponding `.env.[mode]` files; any other value (a `NODE_ENV=staging`) is ignored for file selection, and only `.env` and `.env.local` load. For an arbitrary mode name, use `APP_ENV`.
 
-A `.env` file that assigns `NODE_ENV` has that one key ignored on load — matching dotenv, Next.js, and Vite — and Nub warns. Otherwise a `.env` pinning `NODE_ENV=development` leaks into production tooling: `next build`, for one, then runs its prerender workers in development mode against production-compiled output.
+```bash
+NODE_ENV=production nub server.ts  # reads .env.production*
+NODE_ENV=staging nub server.ts     # not canonical → reads only .env, .env.local
+APP_ENV=staging nub server.ts      # use APP_ENV for arbitrary modes
+```
+
+The clamp exists because `NODE_ENV` is overloaded: many tools read it to switch between development and production behavior, so an unrecognized value silently flips them into development mode. Clamping the file selection to the three canonical values gives migration parity with Next.js and Bun without reintroducing that footgun.
+
+Nub never *sets* `NODE_ENV`, and a `.env` file cannot change it. A `.env` file that assigns `NODE_ENV` has that one key ignored on load — matching dotenv, Next.js, and Vite — and Nub warns. Otherwise a `.env` pinning `NODE_ENV=development` leaks into production tooling: `next build`, for one, then runs its prerender workers in development mode against production-compiled output.
 
 ## Test environment
 
-When the mode is `test` (from `APP_ENV=test`), the `.env.local` slot is skipped — only `.env.test.local`, `.env.test`, and `.env` load. This keeps developer-machine secrets in `.env.local` out of the test environment.
+When the mode is `test` — from `APP_ENV=test` or `NODE_ENV=test` — the `.env.local` slot is skipped, so only `.env.test.local`, `.env.test`, and `.env` load. This keeps developer-machine secrets in `.env.local` out of the test environment.
 
 ## Variable expansion
 


### PR DESCRIPTION
Adds a clamped `NODE_ENV` fallback for `.env.{mode}` file selection. Maintainer-greenlit behavior change; partially reverses #351/#354.

## Contract

Mode resolution for `.env.{mode}` file selection:

- `APP_ENV` non-empty → mode = `APP_ENV` (primary; wins even when `NODE_ENV` is also set).
- else `NODE_ENV` exactly `development` / `production` / `test` → mode = that value (clamped — exact Next.js/Bun parity; no short forms).
- else (both unset, or a non-canonical `NODE_ENV` like `staging`) → no mode; only `.env` and `.env.local` load.

The charset guard and the `test`-mode `.env.local` skip apply to the resolved mode, so `NODE_ENV=test` skips `.env.local`, consistent with `APP_ENV=test`. A non-canonical `NODE_ENV` is silently ignored for file selection — use `APP_ENV` for arbitrary modes.

## Why

The earlier decision dropped `NODE_ENV` as a mode selector entirely. This restores it as a fallback for migration parity with Next.js and Bun (a `NODE_ENV=production` invocation loads `.env.production`), while the clamp neutralizes the arbitrary-value footgun that motivated the original drop: a non-canonical value can no longer silently flip the loaded file set.

## Changes

- `resolve_mode(app_env, node_env)` — pure, hermetically tested resolver; `resolve_env_mode()` reads both from process env. `CLAMPED_NODE_ENV_MODES = [development, production, test]`.
- Regression tests: hermetic unit tests for every contract branch, a composition test tying resolution to the file set, and the updated `dotenv_node_env_stripped_and_app_env_selects_env_file` integration test (NODE_ENV=production selects `.env.production`; NODE_ENV=staging does not).
- Docs: `site/content/docs/runtime/env.mdx` rewritten (the `## NODE_ENV` section no longer claims NODE_ENV never selects files). Stale comments in `env.rs` and `cli.rs` corrected to the APP_ENV -> clamped-NODE_ENV model.

## Verification

`cargo fmt --check`, `cargo clippy -p nub-core -p nub-cli --all-targets --all-features -- -D warnings`, and `cargo test -p nub-core` all green.

Refs #351, #354

https://claude.ai/code/session_01UVBNLm9SkJGM8P8K6jnKLJ
