### PR TITLE
fix(patches): support name-only and range pnpm patch keys

### DIFF
--- a/vendor/aube/crates/aube-codes/src/errors.rs
+++ b/vendor/aube/crates/aube-codes/src/errors.rs
@@ -62,6 +62,8 @@ pub const ERR_AUBE_GIT_ERROR: &str = "ERR_AUBE_GIT_ERROR";
 // ── linker ──────────────────────────────────────────────────────────
 pub const ERR_AUBE_LINK_FAILED: &str = "ERR_AUBE_LINK_FAILED";
 pub const ERR_AUBE_PATCH_FAILED: &str = "ERR_AUBE_PATCH_FAILED";
+#[rustfmt::skip] pub const ERR_AUBE_PATCH_KEY_CONFLICT: &str = "ERR_AUBE_PATCH_KEY_CONFLICT";
+#[rustfmt::skip] pub const ERR_AUBE_PATCH_NON_SEMVER_RANGE: &str = "ERR_AUBE_PATCH_NON_SEMVER_RANGE";
 pub const ERR_AUBE_MISSING_PACKAGE_INDEX: &str = "ERR_AUBE_MISSING_PACKAGE_INDEX";
 pub const ERR_AUBE_UNSAFE_INDEX_KEY: &str = "ERR_AUBE_UNSAFE_INDEX_KEY";
 pub const ERR_AUBE_UNSAFE_PACKAGE_NAME: &str = "ERR_AUBE_UNSAFE_PACKAGE_NAME";
@@ -401,6 +403,18 @@ pub const ALL: &[CodeMeta] = &[
         category: category::LINKER,
         description: "Applying a `pnpm.patchedDependencies` patch failed.",
         exit_code: Some(60),
+    },
+    CodeMeta {
+        name: ERR_AUBE_PATCH_KEY_CONFLICT,
+        category: category::LINKER,
+        description: "Two `patchedDependencies` version ranges both match one resolved package.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_PATCH_NON_SEMVER_RANGE,
+        category: category::LINKER,
+        description: "A `patchedDependencies` key's version selector is not a valid semver range.",
+        exit_code: None,
     },
     CodeMeta {
         name: ERR_AUBE_LINK_FAILED,

--- a/vendor/aube/crates/aube-lockfile/src/io.rs
+++ b/vendor/aube/crates/aube-lockfile/src/io.rs
@@ -246,17 +246,42 @@ fn lockfile_write_is_noop(
     // closure reads from its source graph's `patched_dependency_hashes`
     // (selector `name@version` → sha256 hex), matching how the link /
     // materialize paths derive their patch fingerprints.
-    let graph_patch = |name: &str, version: &str| -> Option<String> {
-        graph
-            .patched_dependency_hashes
-            .get(&format!("{name}@{version}"))
-            .cloned()
+    // The declared keys carried into `patched_dependency_hashes` may be
+    // ranges / `*` / bare names, so a package's fold hash is found by
+    // resolving its concrete `name@version` through the patch groups,
+    // not by a direct `name@version` lookup. An invalid range here means
+    // the graph is unwritable as-is — return `false` (treat as NOT
+    // equivalent) so the caller proceeds to the real write, which
+    // surfaces the branded error rather than silently suppressing it.
+    // A per-package conflict resolves to `None` (swallowed): the two
+    // graphs then fold differently and the write proceeds, again
+    // deferring the error to the writer.
+    let Ok(graph_groups) = crate::patch_groups::PatchGroups::build(
+        graph.patched_dependency_hashes.keys().map(String::as_str),
+    ) else {
+        return false;
     };
-    let existing_patch = |name: &str, version: &str| -> Option<String> {
+    let Ok(existing_groups) = crate::patch_groups::PatchGroups::build(
         existing
             .patched_dependency_hashes
-            .get(&format!("{name}@{version}"))
-            .cloned()
+            .keys()
+            .map(String::as_str),
+    ) else {
+        return false;
+    };
+    let graph_patch = |name: &str, version: &str| -> Option<String> {
+        graph_groups
+            .resolve(name, version)
+            .ok()
+            .flatten()
+            .and_then(|source_key| graph.patched_dependency_hashes.get(source_key).cloned())
+    };
+    let existing_patch = |name: &str, version: &str| -> Option<String> {
+        existing_groups
+            .resolve(name, version)
+            .ok()
+            .flatten()
+            .and_then(|source_key| existing.patched_dependency_hashes.get(source_key).cloned())
     };
     crate::graph_hash::graph_identity_hash_with_patches(graph, &no_build, &graph_patch)
         == crate::graph_hash::graph_identity_hash_with_patches(
@@ -985,6 +1010,19 @@ pub enum Error {
         /// The unsupported protocol token (`git`, `jsr`, `exec`, …).
         protocol: String,
     },
+    /// Two `patchedDependencies` version ranges both match one resolved
+    /// package, so the patch is ambiguous. Mirrors pnpm's
+    /// `PATCH_KEY_CONFLICT`. `message`/`hint` are pre-rendered by
+    /// [`crate::patch_groups::PatchKeyConflict`] so the wording stays in
+    /// one place.
+    #[error("{message}")]
+    #[diagnostic(code(ERR_AUBE_PATCH_KEY_CONFLICT), help("{hint}"))]
+    PatchKeyConflict { message: String, hint: String },
+    /// A `patchedDependencies` key's non-`*` version selector is not a
+    /// valid semver range. Mirrors pnpm's `PATCH_NON_SEMVER_RANGE`.
+    #[error("{0}")]
+    #[diagnostic(code(ERR_AUBE_PATCH_NON_SEMVER_RANGE))]
+    PatchNonSemverRange(String),
     /// Deserialization failure with a byte offset into the source
     /// content, so miette's `fancy` handler can draw a pointer at the
     /// offending byte of the lockfile. Reuses `aube_manifest`'s

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -7,6 +7,7 @@ mod io;
 pub mod merge;
 pub mod npm;
 mod override_match;
+pub mod patch_groups;
 pub mod pnpm;
 mod source;
 pub mod yarn;

--- a/vendor/aube/crates/aube-lockfile/src/patch_groups.rs
+++ b/vendor/aube/crates/aube-lockfile/src/patch_groups.rs
@@ -1,0 +1,477 @@
+//! Patch-key grouping + per-package resolution — a port of pnpm's
+//! `groupPatchedDependencies` (`patching/config`) and `getPatchInfo`.
+//!
+//! A `patchedDependencies` key is one of four shapes: an exact
+//! `name@1.2.3`, a semver range `name@>=1`, a wildcard `name@*`, or a
+//! bare `name`. The last two mean "patch every resolved version of the
+//! package". [`PatchGroups`] indexes the declared keys by package name;
+//! [`PatchGroups::resolve`] maps a concrete resolved `name@version` to
+//! the single patch that applies, by pnpm's priority: an exact match
+//! wins over a range match wins over an "all" (wildcard/bare) match.
+//! Two ranges matching one version is a hard error, exactly as pnpm's
+//! `PATCH_KEY_CONFLICT`.
+//!
+//! Callers keep the *source key* (the verbatim declared string) as the
+//! lockfile identity — pnpm records it unresolved in the
+//! `patchedDependencies` block — and use the resolved concrete
+//! `name@version` only for the linker apply, the graph-hash fold, and
+//! the `(patch_hash=…)` dep-path suffix.
+
+use std::collections::BTreeMap;
+
+/// Classification of a single `patchedDependencies` key. The `name` is
+/// the group a resolved version is matched against; borrows the source
+/// key so grouping keeps the verbatim string as the patch identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PatchKeyForm<'a> {
+    /// `name@1.2.3` — patches exactly that version.
+    Exact { name: &'a str, version: &'a str },
+    /// `name@<range>` — patches the resolved version if it satisfies.
+    Range { name: &'a str, range: &'a str },
+    /// `name@*` or bare `name` — patches every resolved version.
+    All { name: &'a str },
+}
+
+/// A `patchedDependencies` key carried a non-`*` version selector that
+/// is not a valid semver range (pnpm's `PATCH_NON_SEMVER_RANGE`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidPatchRange {
+    pub range: String,
+}
+
+impl InvalidPatchRange {
+    /// Byte-identical to pnpm's `PATCH_NON_SEMVER_RANGE` message.
+    pub fn message(&self) -> String {
+        format!("{} is not a valid semantic version range.", self.range)
+    }
+}
+
+/// Two or more range keys matched one resolved version, so the patch is
+/// ambiguous (pnpm's `PATCH_KEY_CONFLICT`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatchKeyConflict {
+    /// `name@version` of the package that matched multiple ranges.
+    pub pkg_id: String,
+    /// The satisfying range selectors, in group order.
+    pub ranges: Vec<String>,
+}
+
+impl PatchKeyConflict {
+    /// pnpm's `PATCH_KEY_CONFLICT` message. The satisfying-range SET is
+    /// identical to pnpm's; the list ORDER follows sorted key order
+    /// (pnpm lists them in config-declaration order, which is lost when
+    /// the keys pass through a sorted `BTreeMap` upstream) — cosmetic,
+    /// in an error path.
+    pub fn message(&self) -> String {
+        format!(
+            "Unable to choose between {} version ranges to patch {}: {}",
+            self.ranges.len(),
+            self.pkg_id,
+            self.ranges.join(", ")
+        )
+    }
+
+    /// pnpm attaches this as the error hint.
+    pub fn hint(&self) -> String {
+        format!(
+            "Explicitly set the exact version ({}) to resolve conflict",
+            self.pkg_id
+        )
+    }
+}
+
+/// Split a patch key into `(name, version_selector)` at the first `@`
+/// past index 0, mirroring pnpm's `dp.parse` (`indexOf('@', 1)`). A
+/// scope-only `@` at index 0 is not a separator, so a bare scoped name
+/// (`@babel/core`) has no version. Returns `None` when there is no
+/// separator or the version selector is empty (both route to "all" in
+/// pnpm, keyed on the whole string).
+fn split_name_selector(key: &str) -> Option<(&str, &str)> {
+    // `find` on `key[1..]` skips a scope `@`; offset by 1 to index `key`.
+    let at = key.get(1..)?.find('@').map(|i| i + 1)?;
+    let selector = &key[at + 1..];
+    if selector.is_empty() {
+        return None;
+    }
+    Some((&key[..at], selector))
+}
+
+/// Classify one `patchedDependencies` key. Mirrors pnpm's `dp.parse`
+/// plus the branch selection in `groupPatchedDependencies`: an exact
+/// semver version → `Exact`; otherwise a valid range → `All` when it
+/// trims to `*`, else `Range`; an invalid non-`*` selector errors; a
+/// bare/empty-selector key → `All`.
+pub fn classify_patch_key(key: &str) -> Result<PatchKeyForm<'_>, InvalidPatchRange> {
+    let Some((name, selector)) = split_name_selector(key) else {
+        return Ok(PatchKeyForm::All { name: key });
+    };
+    // pnpm's `semver.valid(version)` gate: a parseable exact version is
+    // `Exact`, everything else falls through to the range branch.
+    if node_semver::Version::parse(selector).is_ok() {
+        return Ok(PatchKeyForm::Exact {
+            name,
+            version: selector,
+        });
+    }
+    if node_semver::Range::parse(selector).is_err() {
+        return Err(InvalidPatchRange {
+            range: selector.to_string(),
+        });
+    }
+    if selector.trim() == "*" {
+        Ok(PatchKeyForm::All { name })
+    } else {
+        Ok(PatchKeyForm::Range {
+            name,
+            range: selector,
+        })
+    }
+}
+
+/// One package name's patch selectors. Source keys are borrowed so a
+/// caller can look the resolved source key back up in its own path/hash
+/// maps.
+struct Group<'a> {
+    /// `version string → source key`. String-keyed like pnpm's
+    /// `exact[pkgVersion]` — an exact match is literal, not semver.
+    exact: BTreeMap<&'a str, &'a str>,
+    /// `(display range, parsed range, source key)`, in insertion order.
+    /// The range is parsed once here so `resolve` doesn't reparse per
+    /// package.
+    range: Vec<(&'a str, node_semver::Range, &'a str)>,
+    /// The wildcard / bare-name catch-all, if declared.
+    all: Option<&'a str>,
+}
+
+impl Group<'_> {
+    fn new() -> Self {
+        Group {
+            exact: BTreeMap::new(),
+            range: Vec::new(),
+            all: None,
+        }
+    }
+}
+
+/// Declared `patchedDependencies` keys indexed by package name.
+pub struct PatchGroups<'a> {
+    groups: BTreeMap<&'a str, Group<'a>>,
+}
+
+impl<'a> PatchGroups<'a> {
+    /// Build groups from source keys. Callers pass DEDUPLICATED keys —
+    /// a duplicate range key would push twice and manufacture a false
+    /// conflict; the only union call site (the lockfile writer) dedups
+    /// via a set first. Errors on the first invalid range.
+    pub fn build(keys: impl Iterator<Item = &'a str>) -> Result<Self, InvalidPatchRange> {
+        let mut groups: BTreeMap<&'a str, Group<'a>> = BTreeMap::new();
+        for key in keys {
+            match classify_patch_key(key)? {
+                PatchKeyForm::Exact { name, version } => {
+                    groups
+                        .entry(name)
+                        .or_insert_with(Group::new)
+                        .exact
+                        .insert(version, key);
+                }
+                PatchKeyForm::Range { name, range } => {
+                    // `classify_patch_key` already validated the range,
+                    // so the reparse cannot fail — but avoid `unwrap` at
+                    // the boundary and treat a parse miss as "no range".
+                    if let Ok(parsed) = node_semver::Range::parse(range) {
+                        groups
+                            .entry(name)
+                            .or_insert_with(Group::new)
+                            .range
+                            .push((range, parsed, key));
+                    }
+                }
+                PatchKeyForm::All { name } => {
+                    groups.entry(name).or_insert_with(Group::new).all = Some(key);
+                }
+            }
+        }
+        Ok(PatchGroups { groups })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.groups.is_empty()
+    }
+
+    /// Resolve a concrete `name@version` to the source key of the patch
+    /// that applies, by pnpm's `getPatchInfo` priority: exact match,
+    /// then the single satisfying range (2+ → [`PatchKeyConflict`]),
+    /// then the wildcard/bare catch-all. `Ok(None)` when nothing
+    /// matches.
+    pub fn resolve(&self, name: &str, version: &str) -> Result<Option<&'a str>, PatchKeyConflict> {
+        let Some(group) = self.groups.get(name) else {
+            return Ok(None);
+        };
+        if let Some(&source_key) = group.exact.get(version) {
+            return Ok(Some(source_key));
+        }
+        // A non-semver resolved version (git/exotic) parses to `None`;
+        // no range can satisfy it, matching `semver.satisfies` returning
+        // false, so it falls through to `all`.
+        if let Ok(parsed) = node_semver::Version::parse(version) {
+            let satisfied: Vec<&(&'a str, node_semver::Range, &'a str)> = group
+                .range
+                .iter()
+                .filter(|(_, r, _)| r.satisfies(&parsed))
+                .collect();
+            if satisfied.len() > 1 {
+                return Err(PatchKeyConflict {
+                    pkg_id: format!("{name}@{version}"),
+                    ranges: satisfied
+                        .iter()
+                        .map(|(disp, _, _)| disp.to_string())
+                        .collect(),
+                });
+            }
+            if let Some((_, _, source_key)) = satisfied.first() {
+                return Ok(Some(source_key));
+            }
+        }
+        Ok(group.all)
+    }
+}
+
+/// Either failure mode of resolving a whole graph's patches — an
+/// invalid range in the declared set, or a per-package conflict.
+#[derive(Debug, Clone)]
+pub enum PatchResolveError {
+    InvalidRange(InvalidPatchRange),
+    Conflict(PatchKeyConflict),
+}
+
+impl From<InvalidPatchRange> for PatchResolveError {
+    fn from(e: InvalidPatchRange) -> Self {
+        PatchResolveError::InvalidRange(e)
+    }
+}
+
+/// Resolve a source-key-keyed patch map into one keyed by the concrete
+/// `name@version` each package resolves to, applying pnpm's per-package
+/// `getPatchInfo`. The value is cloned from the winning source key.
+/// Packages are deduplicated by `spec_key` (peer-context variants share
+/// one). An all-exact source resolves each key to its own
+/// `name@version`, so the output equals the input restricted to
+/// installed packages — the pre-resolution behavior for exact keys.
+pub fn resolve_patched_by_version<V: Clone>(
+    source: &BTreeMap<String, V>,
+    packages: &BTreeMap<String, crate::LockedPackage>,
+) -> Result<BTreeMap<String, V>, PatchResolveError> {
+    if source.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let groups = PatchGroups::build(source.keys().map(String::as_str))?;
+    let mut out = BTreeMap::new();
+    for pkg in packages.values() {
+        let spec = pkg.spec_key();
+        if out.contains_key(&spec) {
+            continue;
+        }
+        if let Some(source_key) = groups
+            .resolve(&pkg.name, &pkg.version)
+            .map_err(PatchResolveError::Conflict)?
+            && let Some(value) = source.get(source_key)
+        {
+            out.insert(spec, value.clone());
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_exact_plain_and_scoped() {
+        assert_eq!(
+            classify_patch_key("is-positive@3.1.0").unwrap(),
+            PatchKeyForm::Exact {
+                name: "is-positive",
+                version: "3.1.0"
+            }
+        );
+        assert_eq!(
+            classify_patch_key("@babel/core@7.0.0").unwrap(),
+            PatchKeyForm::Exact {
+                name: "@babel/core",
+                version: "7.0.0"
+            }
+        );
+    }
+
+    #[test]
+    fn classify_bare_name_is_all() {
+        assert_eq!(
+            classify_patch_key("sonda").unwrap(),
+            PatchKeyForm::All { name: "sonda" }
+        );
+        assert_eq!(
+            classify_patch_key("@babel/core").unwrap(),
+            PatchKeyForm::All {
+                name: "@babel/core"
+            }
+        );
+    }
+
+    #[test]
+    fn classify_wildcard_is_all() {
+        assert_eq!(
+            classify_patch_key("is-positive@*").unwrap(),
+            PatchKeyForm::All {
+                name: "is-positive"
+            }
+        );
+    }
+
+    #[test]
+    fn classify_range() {
+        assert_eq!(
+            classify_patch_key("is-positive@>=3.0.0").unwrap(),
+            PatchKeyForm::Range {
+                name: "is-positive",
+                range: ">=3.0.0"
+            }
+        );
+        assert_eq!(
+            classify_patch_key("is-positive@^3").unwrap(),
+            PatchKeyForm::Range {
+                name: "is-positive",
+                range: "^3"
+            }
+        );
+    }
+
+    #[test]
+    fn classify_invalid_range_errors_with_pnpm_message() {
+        let err = classify_patch_key("is-positive@not-a-range").unwrap_err();
+        assert_eq!(
+            err.message(),
+            "not-a-range is not a valid semantic version range."
+        );
+    }
+
+    #[test]
+    fn resolve_exact_wins_over_range_and_all() {
+        let keys = ["foo@1.2.3", "foo@>=1.0.0", "foo"];
+        let groups = PatchGroups::build(keys.iter().copied()).unwrap();
+        assert_eq!(groups.resolve("foo", "1.2.3").unwrap(), Some("foo@1.2.3"));
+    }
+
+    #[test]
+    fn resolve_range_matches_satisfying_version() {
+        let groups = PatchGroups::build(["foo@>=3.0.0"].into_iter()).unwrap();
+        assert_eq!(groups.resolve("foo", "3.1.0").unwrap(), Some("foo@>=3.0.0"));
+        assert_eq!(groups.resolve("foo", "2.0.0").unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_all_patches_every_version() {
+        let groups = PatchGroups::build(["sonda"].into_iter()).unwrap();
+        assert_eq!(groups.resolve("sonda", "0.9.0").unwrap(), Some("sonda"));
+        assert_eq!(groups.resolve("sonda", "1.4.2").unwrap(), Some("sonda"));
+    }
+
+    #[test]
+    fn resolve_wildcard_behaves_like_bare_name() {
+        let groups = PatchGroups::build(["sonda@*"].into_iter()).unwrap();
+        assert_eq!(groups.resolve("sonda", "0.9.0").unwrap(), Some("sonda@*"));
+    }
+
+    #[test]
+    fn resolve_conflicting_ranges_errors_with_pnpm_message() {
+        let keys = ["foo@>=3.0.0", "foo@^3.1.0"];
+        let groups = PatchGroups::build(keys.iter().copied()).unwrap();
+        let err = groups.resolve("foo", "3.1.0").unwrap_err();
+        assert_eq!(
+            err.message(),
+            "Unable to choose between 2 version ranges to patch foo@3.1.0: >=3.0.0, ^3.1.0"
+        );
+        assert_eq!(
+            err.hint(),
+            "Explicitly set the exact version (foo@3.1.0) to resolve conflict"
+        );
+    }
+
+    #[test]
+    fn resolve_unknown_name_is_none() {
+        let groups = PatchGroups::build(["foo@1.0.0"].into_iter()).unwrap();
+        assert_eq!(groups.resolve("bar", "1.0.0").unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_non_semver_version_falls_through_to_all() {
+        let groups = PatchGroups::build(["foo", "foo@>=1.0.0"].into_iter()).unwrap();
+        // A git/exotic version can't satisfy the range but still hits `all`.
+        assert_eq!(
+            groups.resolve("foo", "git-sha-nonsemver").unwrap(),
+            Some("foo")
+        );
+    }
+
+    fn mk_pkg(name: &str, version: &str) -> crate::LockedPackage {
+        crate::LockedPackage {
+            name: name.into(),
+            version: version.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolve_by_version_maps_source_keys_to_concrete_package_versions() {
+        let mut packages = BTreeMap::new();
+        packages.insert("foo@1.0.0".to_string(), mk_pkg("foo", "1.0.0"));
+        // A peer-context variant shares one spec_key and must not duplicate.
+        packages.insert(
+            "foo@1.0.0(react@18.2.0)".to_string(),
+            mk_pkg("foo", "1.0.0"),
+        );
+        packages.insert("foo@2.0.0".to_string(), mk_pkg("foo", "2.0.0"));
+        packages.insert("bar@3.1.0".to_string(), mk_pkg("bar", "3.1.0"));
+
+        // Bare `foo` patches every foo; range `bar@>=3` patches bar@3.1.0.
+        let source: BTreeMap<String, String> = [
+            ("foo".to_string(), "patches/foo.patch".to_string()),
+            ("bar@>=3.0.0".to_string(), "patches/bar.patch".to_string()),
+        ]
+        .into();
+
+        let resolved = resolve_patched_by_version(&source, &packages).unwrap();
+        assert_eq!(
+            resolved.get("foo@1.0.0").map(String::as_str),
+            Some("patches/foo.patch")
+        );
+        assert_eq!(
+            resolved.get("foo@2.0.0").map(String::as_str),
+            Some("patches/foo.patch")
+        );
+        assert_eq!(
+            resolved.get("bar@3.1.0").map(String::as_str),
+            Some("patches/bar.patch")
+        );
+        assert_eq!(
+            resolved.len(),
+            3,
+            "peer-context variant must collapse to one entry"
+        );
+    }
+
+    #[test]
+    fn resolve_by_version_propagates_conflict() {
+        let mut packages = BTreeMap::new();
+        packages.insert("foo@3.1.0".to_string(), mk_pkg("foo", "3.1.0"));
+        let source: BTreeMap<String, String> = [
+            ("foo@>=3.0.0".to_string(), "a".to_string()),
+            ("foo@^3.1.0".to_string(), "b".to_string()),
+        ]
+        .into();
+        assert!(matches!(
+            resolve_patched_by_version(&source, &packages),
+            Err(PatchResolveError::Conflict(_))
+        ));
+    }
+}

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
@@ -91,19 +91,43 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
     // without a recorded hash (bun.lock conversions, pnpm v8 lockfiles)
     // get no suffix, matching the hash-less bare-path block we emit
     // for them.
-    let patched_by_dep_path: BTreeMap<&str, &str> = graph
-        .packages
-        .iter()
-        .filter(|(_, pkg)| pkg.local_source.is_none())
-        .filter_map(|(dep_path, pkg)| {
-            let selector = format!("{}@{}", pkg.name, pkg.version);
-            graph
-                .patched_dependency_hashes
-                .get(&selector)
-                .filter(|_| graph.patched_dependencies.contains_key(&selector))
-                .map(|hash| (dep_path.as_str(), hash.as_str()))
-        })
+    // The declared patch keys may be exact, a range, `*`, or a bare
+    // name; resolve each REGISTRY package's concrete `name@version` to
+    // the patch that applies (pnpm's `getPatchInfo`) so the suffix lands
+    // on the right resolved version. Groups build from the DEDUPED union
+    // of both selector maps — a key present in both would otherwise
+    // double-push into a range group and manufacture a false conflict.
+    // The suffix is stamped only when the winning source key carries
+    // both a hash and a path (the `{ hash, path }` block form). For
+    // all-exact keys the resolved source key equals `name@version`, so
+    // this is byte-identical to the pre-resolution lookup.
+    let patch_selectors: std::collections::BTreeSet<&str> = graph
+        .patched_dependency_hashes
+        .keys()
+        .chain(graph.patched_dependencies.keys())
+        .map(String::as_str)
         .collect();
+    let patch_groups = crate::patch_groups::PatchGroups::build(patch_selectors.into_iter())
+        .map_err(|e| Error::PatchNonSemverRange(e.message()))?;
+    let mut patched_by_dep_path: BTreeMap<&str, &str> = BTreeMap::new();
+    for (dep_path, pkg) in &graph.packages {
+        if pkg.local_source.is_some() {
+            continue;
+        }
+        let source_key =
+            patch_groups
+                .resolve(&pkg.name, &pkg.version)
+                .map_err(|c| Error::PatchKeyConflict {
+                    message: c.message(),
+                    hint: c.hint(),
+                })?;
+        if let Some(source_key) = source_key
+            && let Some(hash) = graph.patched_dependency_hashes.get(source_key)
+            && graph.patched_dependencies.contains_key(source_key)
+        {
+            patched_by_dep_path.insert(dep_path.as_str(), hash.as_str());
+        }
+    }
     // Translate a *flat* peer reference from aube's internal FS-safe
     // hashed dep_path (`request@url+<hash>` / `request@git+<hash>`) to the
     // resolved spec pnpm writes inside a peer suffix

--- a/vendor/aube/crates/aube-lockfile/src/yarn/berry.rs
+++ b/vendor/aube/crates/aube-lockfile/src/yarn/berry.rs
@@ -796,6 +796,26 @@ pub fn write_berry(
     // specifiers in the same map.
     let canonical = crate::build_canonical_map(graph);
 
+    // Berry's `patch:` protocol keys resolutions by the concrete
+    // `name@version`, but the declared patch keys may be ranges / `*` /
+    // bare names. Resolve them against the graph up front (pnpm's
+    // `getPatchInfo`) so the exact `spec_key()` lookups below find the
+    // patch instead of silently dropping it from the emitted lockfile.
+    // For all-exact keys this equals `graph.patched_dependencies`.
+    let resolved_patched = crate::patch_groups::resolve_patched_by_version(
+        &graph.patched_dependencies,
+        &graph.packages,
+    )
+    .map_err(|e| match e {
+        crate::patch_groups::PatchResolveError::InvalidRange(r) => {
+            Error::PatchNonSemverRange(r.message())
+        }
+        crate::patch_groups::PatchResolveError::Conflict(c) => Error::PatchKeyConflict {
+            message: c.message(),
+            hint: c.hint(),
+        },
+    })?;
+
     // `extra_specs[canonical_key]` is the set of range-form
     // specifiers (e.g. `"foo@npm:^1.0.0"`) that should appear in the
     // block header alongside the exact `foo@npm:1.2.3` one. Collecting
@@ -830,10 +850,10 @@ pub fn write_berry(
         };
         let manifest_spec = format_berry_spec(&dep.name, range);
         let pkg = canonical.get(&canonical_key).copied().unwrap();
-        if patch_spec_matches(&manifest_spec, pkg, &graph.patched_dependencies) {
+        if patch_spec_matches(&manifest_spec, pkg, &resolved_patched) {
             patch_specs.insert(canonical_key.clone(), manifest_spec.clone());
         }
-        let exact_spec = berry_exact_spec(pkg, &graph.patched_dependencies, &patch_specs);
+        let exact_spec = berry_exact_spec(pkg, &resolved_patched, &patch_specs);
         if manifest_spec != exact_spec {
             extra_specs
                 .entry(canonical_key)
@@ -854,11 +874,10 @@ pub fn write_berry(
                 continue;
             };
             let manifest_spec = format_berry_spec(dep_name, range);
-            if patch_spec_matches(&manifest_spec, target_pkg, &graph.patched_dependencies) {
+            if patch_spec_matches(&manifest_spec, target_pkg, &resolved_patched) {
                 patch_specs.insert(target.clone(), manifest_spec.clone());
             }
-            let exact_spec =
-                berry_exact_spec(target_pkg, &graph.patched_dependencies, &patch_specs);
+            let exact_spec = berry_exact_spec(target_pkg, &resolved_patched, &patch_specs);
             if manifest_spec != exact_spec {
                 extra_specs.entry(target).or_default().insert(manifest_spec);
             }
@@ -901,7 +920,7 @@ pub fn write_berry(
         // (a package nothing in this graph references by range — rare, e.g.
         // an orphaned transitive) do we fall back to the exact spec so the
         // block still has a parseable header.
-        let exact_spec = berry_exact_spec(pkg, &graph.patched_dependencies, &patch_specs);
+        let exact_spec = berry_exact_spec(pkg, &resolved_patched, &patch_specs);
         let mut header_specs: Vec<String> = Vec::new();
         if let Some(extras) = extra_specs.get(canonical_key) {
             for s in extras {
@@ -948,7 +967,7 @@ pub fn write_berry(
             &pkg.dependencies,
             &pkg.declared_dependencies,
             &canonical,
-            &graph.patched_dependencies,
+            &resolved_patched,
             &patch_specs,
         );
         write_berry_dep_map(
@@ -957,7 +976,7 @@ pub fn write_berry(
             &pkg.optional_dependencies,
             &pkg.declared_dependencies,
             &canonical,
-            &graph.patched_dependencies,
+            &resolved_patched,
             &patch_specs,
         );
         write_berry_peer_deps(&mut out, &pkg.peer_dependencies);

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -221,7 +221,7 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     // the `changed` bucket and side-effects skip can't trust a stale
     // marker.
     let (patches_for_linker, patch_hashes) =
-        crate::patches::load_patches_for_linker(cwd, &graph_for_link.patched_dependencies)?;
+        crate::patches::load_patches_for_linker(cwd, graph_for_link)?;
 
     // Compute leaf + subtree hashes together when both are needed.
     // Linker invalidation reads `current_subtree_hashes`; the late

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -1289,7 +1289,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let lock_build_policy = std::sync::Arc::new(build_policy.clone());
             let lock_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
             let (lock_patches, lock_patch_hashes) =
-                crate::patches::load_patches_for_linker(&cwd, &graph.patched_dependencies)?;
+                crate::patches::load_patches_for_linker(&cwd, &graph)?;
             let (lock_supported_architectures, lock_ignored_optional) =
                 prewarm_host_filter_inputs(&manifest, &ws_config_shared, &settings_ctx);
             let (lock_materialize_tx, lock_materialize_rx) = materialize_channel();
@@ -2182,7 +2182,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let materialize_graph_arc = std::sync::Arc::new(graph.clone());
             let materialize_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
             let (materialize_patches, materialize_patch_hashes) =
-                crate::patches::load_patches_for_linker(&cwd, &graph.patched_dependencies)?;
+                crate::patches::load_patches_for_linker(&cwd, &graph)?;
             let (prewarm_supported_architectures, prewarm_ignored_optional) =
                 prewarm_host_filter_inputs(&manifest, &ws_config_shared, &settings_ctx);
             let materialize_inputs = GvsPrewarmInputs {

--- a/vendor/aube/crates/aube/src/patches.rs
+++ b/vendor/aube/crates/aube/src/patches.rs
@@ -12,17 +12,17 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-/// One resolved patch entry. The key is `name@version` (the same
-/// string used as the `pnpm.patchedDependencies` map key), `path` is
-/// the absolute path on disk, and `content` is the raw patch text the
-/// linker applies.
+/// One resolved patch entry. `key` is the VERBATIM declared
+/// `patchedDependencies` key — exact (`ms@2.1.3`), range (`ms@>=2`),
+/// wildcard (`ms@*`), or bare name (`ms`) — and is the string the
+/// lockfile's `patchedDependencies:` block records unresolved, matching
+/// pnpm. `path` is the absolute path on disk, `content` is the raw
+/// patch text the linker applies. Mapping a concrete resolved
+/// `name@version` to the entry that applies is
+/// [`aube_lockfile::patch_groups`]'s job.
 #[derive(Debug, Clone)]
 pub struct ResolvedPatch {
     pub key: String,
-    #[allow(dead_code)]
-    pub name: String,
-    #[allow(dead_code)]
-    pub version: String,
     #[allow(dead_code)]
     pub path: PathBuf,
     /// The project-relative patch path exactly as declared
@@ -76,58 +76,60 @@ fn is_safe_patch_rel(rel: &str) -> bool {
     })
 }
 
-/// Split a `name@version` patch key into its parts. Mirrors
-/// `commands::split_name_spec` but always requires a version (a bare
-/// name is rejected — patches are always per-version).
-pub fn split_patch_key(key: &str) -> Result<(String, String)> {
-    let (name, ver) = if let Some(rest) = key.strip_prefix('@') {
-        let slash = rest
-            .find('/')
-            .ok_or_else(|| miette!("invalid patch key {key:?}: scoped name missing slash"))?;
-        let after = &rest[slash + 1..];
-        let at = after
-            .find('@')
-            .ok_or_else(|| miette!("invalid patch key {key:?}: missing version"))?;
-        let split = 1 + slash + 1 + at;
-        (&key[..split], &key[split + 1..])
-    } else {
-        let at = key
-            .find('@')
-            .ok_or_else(|| miette!("invalid patch key {key:?}: missing version"))?;
-        (&key[..at], &key[at + 1..])
-    };
-    if name.is_empty() || ver.is_empty() {
-        return Err(miette!("invalid patch key {key:?}"));
-    }
-    Ok((name.to_string(), ver.to_string()))
+/// Validate a `patchedDependencies` key's shape, rejecting only a
+/// non-`*` selector that isn't a valid semver range (pnpm's
+/// `PATCH_NON_SEMVER_RANGE`). Every other shape — exact, range, `*`,
+/// bare name — is accepted; mapping the key to concrete resolved
+/// versions is [`aube_lockfile::patch_groups`]'s job. Kept a thin
+/// wrapper so the invalid-range error carries the branded code.
+fn validate_patch_key(key: &str) -> Result<()> {
+    aube_lockfile::patch_groups::classify_patch_key(key).map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_PATCH_NON_SEMVER_RANGE,
+            "{}",
+            e.message()
+        )
+    })?;
+    Ok(())
 }
 
-/// Read every patch declared in the active lockfile, `package.json`,
-/// and `pnpm-workspace.yaml`, then return them keyed by `name@version`.
-/// Workspace-yaml entries (pnpm v10+ canonical location) win over
-/// `package.json`, which wins over lockfile entries, on key conflict.
-/// Missing patch files become a hard error — that matches pnpm, which
-/// refuses to install with a declared-but-missing patch.
-/// Load patches and pre-build the two shapes the linker + GVS-prewarm
-/// materializer want: a `(name@version, content)` map and a
-/// `(name@version, content_hash)` map. Both materializer call sites
-/// (lockfile + no-lockfile) and the link phase compute these from the
-/// same `load_patches` output, hoisted here so the BTreeMap walks
-/// happen once per install.
+/// Build the two shapes the linker + GVS-prewarm materializer want,
+/// keyed by the CONCRETE resolved `name@version` those stages apply
+/// patches by: a `(name@version, content)` content map and a
+/// `(name@version, content_hash)` fold map. The declared keys may be
+/// exact (`ms@2.1.3`), a range (`ms@>=2`), a wildcard (`ms@*`), or a
+/// bare name (`ms`); each graph package resolves to at most one patch
+/// by pnpm's `getPatchInfo` priority (exact > range > all). An
+/// all-exact project resolves each key to its own `name@version`, so
+/// the maps are byte-identical to the pre-resolution behavior.
 ///
-/// Result is cached per cwd for the lifetime of the process. The 2-3
-/// call sites within a single install hit the cache on calls 2+ instead
-/// of re-walking `patches/` from disk. pnpm.patchedDependencies is
-/// resolved at install entry; patch files are static across the run.
+/// Two ranges matching one version → [`aube_codes::errors::ERR_AUBE_PATCH_KEY_CONFLICT`];
+/// an invalid non-`*` range → [`aube_codes::errors::ERR_AUBE_PATCH_NON_SEMVER_RANGE`].
 pub fn load_patches_for_linker(
     cwd: &Path,
-    lockfile_patched_dependencies: &BTreeMap<String, String>,
+    graph: &aube_lockfile::LockfileGraph,
 ) -> Result<(aube_linker::Patches, BTreeMap<String, String>)> {
-    use std::sync::{Mutex, OnceLock};
+    let resolved = load_resolved_patches_cached(cwd, &graph.patched_dependencies)?;
+    resolve_patches_against_graph(&resolved, graph)
+}
+
+/// Cache the DISK read of the declared patch set (source key →
+/// [`ResolvedPatch`]) per cwd for the process lifetime. The 2-3 link /
+/// materialize / prewarm call sites within one install hit the cache on
+/// calls 2+ instead of re-walking `patches/` from disk. Resolving the
+/// cached set against the graph is cheap and stays out of the cache, so
+/// the cache is correctly graph-independent (the same cwd is only ever
+/// queried with one graph per install process anyway).
+fn load_resolved_patches_cached(
+    cwd: &Path,
+    lockfile_patched_dependencies: &BTreeMap<String, String>,
+) -> Result<std::sync::Arc<BTreeMap<String, ResolvedPatch>>> {
+    use std::sync::{Arc, Mutex, OnceLock};
     type CacheKey = (PathBuf, BTreeMap<String, String>);
-    type CachedShape = (aube_linker::Patches, BTreeMap<String, String>);
-    static CACHE: OnceLock<Mutex<std::collections::HashMap<CacheKey, CachedShape>>> =
-        OnceLock::new();
+    #[allow(clippy::type_complexity)]
+    static CACHE: OnceLock<
+        Mutex<std::collections::HashMap<CacheKey, Arc<BTreeMap<String, ResolvedPatch>>>>,
+    > = OnceLock::new();
     let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
     // Canonicalize so `cwd` and `cwd.canonicalize()` collapse to one
     // key. Windows `\\?\C:\foo` vs `C:\foo`, Unix `cwd` vs `cwd/.`
@@ -143,19 +145,54 @@ pub fn load_patches_for_linker(
     {
         return Ok(hit.clone());
     }
-    let resolved = load_patches_with_lockfile_entries(cwd, lockfile_patched_dependencies)?;
-    let patches: aube_linker::Patches = resolved
-        .values()
-        .map(|p| (p.key.clone(), p.content.clone()))
-        .collect();
-    let hashes: BTreeMap<String, String> = resolved
-        .values()
-        .map(|p| (p.key.clone(), p.content_hash()))
-        .collect();
+    let resolved = Arc::new(load_patches_with_lockfile_entries(
+        cwd,
+        lockfile_patched_dependencies,
+    )?);
     if let Ok(mut guard) = cache.lock() {
-        guard.insert(key, (patches.clone(), hashes.clone()));
+        guard.insert(key, resolved.clone());
+    }
+    Ok(resolved)
+}
+
+/// Map every resolved graph package to the declared patch that applies
+/// (pnpm's `getPatchInfo` priority), keying the linker's content map
+/// and the graph-hash fold map by the concrete `name@version` those
+/// stages look up. No `local_source` filter — the linker applies to any
+/// `spec_key` match, matching the pre-resolution unfiltered behavior.
+fn resolve_patches_against_graph(
+    resolved: &BTreeMap<String, ResolvedPatch>,
+    graph: &aube_lockfile::LockfileGraph,
+) -> Result<(aube_linker::Patches, BTreeMap<String, String>)> {
+    let by_version =
+        aube_lockfile::patch_groups::resolve_patched_by_version(resolved, &graph.packages)
+            .map_err(map_patch_resolve_err)?;
+    let mut patches = aube_linker::Patches::new();
+    let mut hashes = BTreeMap::new();
+    for (spec, patch) in by_version {
+        hashes.insert(spec.clone(), patch.content_hash());
+        patches.insert(spec, patch.content);
     }
     Ok((patches, hashes))
+}
+
+/// Brand a patch-group resolution failure with the matching
+/// `ERR_AUBE_PATCH_*` code (rewritten to `ERR_NUB_*` by the embedder).
+fn map_patch_resolve_err(e: aube_lockfile::patch_groups::PatchResolveError) -> miette::Report {
+    use aube_lockfile::patch_groups::PatchResolveError;
+    match e {
+        PatchResolveError::InvalidRange(r) => miette!(
+            code = aube_codes::errors::ERR_AUBE_PATCH_NON_SEMVER_RANGE,
+            "{}",
+            r.message()
+        ),
+        PatchResolveError::Conflict(c) => miette!(
+            code = aube_codes::errors::ERR_AUBE_PATCH_KEY_CONFLICT,
+            help = c.hint(),
+            "{}",
+            c.message()
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -186,7 +223,7 @@ fn load_patches_with_lockfile_entries(
 
     let mut out = BTreeMap::new();
     for (key, rel) in entries {
-        let (name, version) = split_patch_key(&key)?;
+        validate_patch_key(&key)?;
         // Refuse absolute paths and `..` traversal in the manifest-
         // declared patch path so a hostile `package.json` cannot
         // coerce `aube install` into reading an arbitrary file off
@@ -215,8 +252,6 @@ fn load_patches_with_lockfile_entries(
             key.clone(),
             ResolvedPatch {
                 key,
-                name,
-                version,
                 path,
                 rel,
                 content,
@@ -339,6 +374,14 @@ pub fn effective_patch_config(
 /// install.
 pub fn record_patches_on_graph(cwd: &Path, graph: &mut aube_lockfile::LockfileGraph) -> Result<()> {
     let (paths, hashes) = effective_patch_config(cwd)?;
+    // Surface a range CONFLICT (two ranges matching one resolved
+    // version) here at resolve time — the earliest, most uniform gate,
+    // matching pnpm's "raise during config grouping". Without it the
+    // conflict would only surface later at link / write, and a
+    // `--lockfile-only` no-op write could suppress it entirely. An
+    // invalid range already errored inside `effective_patch_config`.
+    aube_lockfile::patch_groups::resolve_patched_by_version(&paths, &graph.packages)
+        .map_err(map_patch_resolve_err)?;
     graph.patched_dependencies = paths;
     graph.patched_dependency_hashes = hashes;
     Ok(())
@@ -533,30 +576,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn split_simple() {
-        let (n, v) = split_patch_key("is-positive@3.1.0").unwrap();
-        assert_eq!(n, "is-positive");
-        assert_eq!(v, "3.1.0");
-    }
-
-    #[test]
-    fn split_scoped() {
-        let (n, v) = split_patch_key("@babel/core@7.0.0").unwrap();
-        assert_eq!(n, "@babel/core");
-        assert_eq!(v, "7.0.0");
-    }
-
-    #[test]
-    fn split_missing_version_errors() {
-        assert!(split_patch_key("is-positive").is_err());
-        assert!(split_patch_key("@babel/core").is_err());
+    fn validate_accepts_all_pnpm_key_shapes() {
+        // The parse-time gate now rejects ONLY a non-`*` invalid range;
+        // exact, range, `*`, and bare-name keys all pass.
+        for key in [
+            "is-positive@3.1.0",
+            "@babel/core@7.0.0",
+            "sonda",
+            "sonda@*",
+            "sonda@>=1",
+        ] {
+            assert!(validate_patch_key(key).is_ok(), "should accept {key:?}");
+        }
+        assert!(validate_patch_key("sonda@not-a-range").is_err());
     }
 
     fn patch_with_content(content: &str) -> ResolvedPatch {
         ResolvedPatch {
             key: "ms@2.1.3".into(),
-            name: "ms".into(),
-            version: "2.1.3".into(),
             path: PathBuf::from("patches/ms@2.1.3.patch"),
             rel: "patches/ms@2.1.3.patch".into(),
             content: content.into(),
@@ -798,7 +835,10 @@ mod tests {
         )
         .unwrap();
 
-        let (patches, hashes) = load_patches_for_linker(
+        // A lockfile-carried patch entry is merged into the declared set
+        // (keyed by the verbatim source key). Resolving it against a graph
+        // is covered by `aube_lockfile::patch_groups` unit tests.
+        let resolved = load_patches_with_lockfile_entries(
             dir.path(),
             &BTreeMap::from([(
                 "is-number@7.0.0".to_string(),
@@ -807,11 +847,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            patches.get("is-number@7.0.0").map(String::as_str),
-            Some("diff --git a/index.js b/index.js\n")
-        );
-        assert!(hashes.contains_key("is-number@7.0.0"));
+        let entry = resolved.get("is-number@7.0.0").expect("entry present");
+        assert_eq!(entry.content, "diff --git a/index.js b/index.js\n");
+        assert_eq!(entry.rel, ".yarn/patches/is-number.patch");
     }
 
     #[test]

--- a/vendor/aube/docs/error-codes.data.json
+++ b/vendor/aube/docs/error-codes.data.json
@@ -19,6 +19,12 @@
       "exit_code": 12
     },
     {
+      "name": "ERR_AUBE_LOCKFILE_UNSUPPORTED_SOURCE",
+      "category": "Lockfile",
+      "description": "A lockfile entry's dependency source (protocol) can't be resolved from that lockfile — e.g. a git or jsr source in a yarn.lock — so the installed tree would silently diverge from the incumbent's. Install with the original package manager, or remove the dependency.",
+      "exit_code": 14
+    },
+    {
       "name": "ERR_AUBE_RESOLUTION_SHAPE_MISMATCH",
       "category": "Lockfile",
       "description": "A registry-style lockfile dependency path is backed by a git, local directory, or direct tarball resolution.",
@@ -159,8 +165,14 @@
     {
       "name": "ERR_AUBE_UNAUTHORIZED",
       "category": "Registry / network",
-      "description": "Registry returned 401/403 — missing or invalid auth. Run `aube login`.",
+      "description": "Registry returned 401 — missing or invalid auth. Run `aube login`.",
       "exit_code": 42
+    },
+    {
+      "name": "ERR_AUBE_FORBIDDEN",
+      "category": "Registry / network",
+      "description": "Registry returned 403 — authenticated but forbidden (insufficient permissions, token scope, or blocked by policy). The registry's message is included.",
+      "exit_code": null
     },
     {
       "name": "ERR_AUBE_OFFLINE",
@@ -245,6 +257,18 @@
       "category": "Linker",
       "description": "Applying a `pnpm.patchedDependencies` patch failed.",
       "exit_code": 60
+    },
+    {
+      "name": "ERR_AUBE_PATCH_KEY_CONFLICT",
+      "category": "Linker",
+      "description": "Two `patchedDependencies` version ranges both match one resolved package.",
+      "exit_code": null
+    },
+    {
+      "name": "ERR_AUBE_PATCH_NON_SEMVER_RANGE",
+      "category": "Linker",
+      "description": "A `patchedDependencies` key's version selector is not a valid semver range.",
+      "exit_code": null
     },
     {
       "name": "ERR_AUBE_LINK_FAILED",
@@ -340,6 +364,12 @@
       "name": "ERR_AUBE_CONFIG_NESTED_AUBE_KEY",
       "category": "Engine / CLI",
       "description": "`aube config set <prefix>.<sub> …` was used for a key whose prefix is an aube map setting (e.g. `allowBuilds.<pkg>`). Such nested writes would otherwise land in `.npmrc` where aube doesn't read them and npm warns/errors about the unknown key — set the map in workspace yaml or `package.json#aube.<prefix>` instead.",
+      "exit_code": null
+    },
+    {
+      "name": "ERR_AUBE_NO_BRANDED_CONFIG_FILE",
+      "category": "Engine / CLI",
+      "description": "A `config set` write targeted the tool's own user/project config file, but the active embedder profile has no branded config file (`config_namespace = None`) — it keeps settings on the neutral `.npmrc` + environment surface. Set the value in `.npmrc`, `pnpm-workspace.yaml`/`package.json`, or via an environment variable instead. Unreachable for standalone aube, which always has a `~/.config/aube/config.toml`.",
       "exit_code": null
     },
     {
@@ -480,6 +510,12 @@
       "name": "WARN_AUBE_IGNORED_BUILD_SCRIPTS",
       "category": "Install lifecycle",
       "description": "Dep had `preinstall`/`install`/`postinstall` scripts but isn't on the `allowBuilds` allowlist. Run `aube approve-builds`.",
+      "exit_code": null
+    },
+    {
+      "name": "WARN_AUBE_DEFAULT_TRUST_BUILDS",
+      "category": "Install lifecycle",
+      "description": "The `defaultTrust` floor let listed packages run build scripts without an explicit `allowBuilds` entry. Disclosure, not an error — set `defaultTrust=false` or an explicit `allowBuilds: false` entry to opt out.",
       "exit_code": null
     },
     {
@@ -795,6 +831,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_LOCKFILE_UNSUPPORTED_SOURCE",
+      "category": "Lockfile",
+      "description": "An OPTIONAL dependency's source (protocol) can't be resolved from the lockfile (e.g. a git or jsr source). It was skipped; the install continues. A non-optional such dependency is a hard error (ERR_AUBE_LOCKFILE_UNSUPPORTED_SOURCE) instead.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX",
       "category": "Lockfile",
       "description": "A pnpm dep_path peer suffix had unbalanced parentheses (a truncated or hand-corrupted lockfile entry). The key is preserved verbatim instead of silently dropping everything after the `(`, so a later install surfaces the bad entry rather than mis-resolving it.",
@@ -804,6 +846,12 @@
       "name": "WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE",
       "category": "Lockfile",
       "description": "`aube outdated -g` found a global install without a lockfile and skipped that install.",
+      "exit_code": null
+    },
+    {
+      "name": "WARN_AUBE_LOCKFILE_LEGACY_INCOMPLETE_GRAPH",
+      "category": "Lockfile",
+      "description": "A legacy npm lockfile (lockfileVersion 1 / pre-2017 npm-shrinkwrap.json) hoists a package to the top level with no recorded dependency edge — pre-npm-5 shrinkwraps omit the `requires` links that record which package depends on it. The package is unreachable from the project's dependencies and will not be installed. Re-lock with npm 7+ (or `nub install` then commit the regenerated lockfile) for a complete graph.",
       "exit_code": null
     },
     {


### PR DESCRIPTION
`nub install` rejected any pnpm `patchedDependencies` key that wasn't exact `name@version`, hard-erroring at parse time:

```
× invalid patch key "sonda": missing version
```

A name-only key — "patch every resolved version of `sonda`" — is valid pnpm. pnpm accepts four forms, grouped by package name and resolved per package (`getPatchInfo`): exact `name@1.2.3`, range `name@>=1`, wildcard `name@*`, and bare `name`.

## Change

- New `aube_lockfile::patch_groups` module ports pnpm's `groupPatchedDependencies` + `getPatchInfo`: classify each declared key, then resolve each concrete resolved `name@version` to the patch that applies (priority: exact > single satisfying range > all).
- The verbatim source key stays the lockfile identity — pnpm records it unresolved in the `patchedDependencies` block. The concrete `name@version` is used only where a version is required: the linker apply, the graph-hash fold, the `(patch_hash=…)` dep-path suffix, the no-churn write guard, and the yarn/berry writer.
- Two ranges matching one resolved version raise `ERR_NUB_PATCH_KEY_CONFLICT`; an invalid non-`*` range raises `ERR_NUB_PATCH_NON_SEMVER_RANGE`, matching pnpm's messages.
- Exact-only keys resolve to their own `name@version`, so an all-exact project's install, lockfile bytes, and virtual-store paths are unchanged.

## Verification

Against real pnpm 10.15 on a name-only-key fixture:

- `nub install` succeeds and applies the patch; the `patchedDependencies` block and the `name@version(patch_hash=…)` dep-path suffix are byte-identical to pnpm's.
- Real pnpm accepts nub's generated lockfile under `--frozen-lockfile`.
- Range (`name@>=3`), wildcard (`name@*`), conflict, and invalid-range cases match pnpm's behavior and error messages.

Known limitation: converting a project that declares a non-exact patch key to `bun.lock` records the key unresolved (bun supports only exact keys); bun-incumbent projects are unaffected.

Closes #376
