### PR TITLE
Defer to native import-text on Node 26.5+

### DIFF
--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -263,6 +263,32 @@ pub static FEATURES: &[Feature] = &[
         ],
         evidence: "flag added 23.6.0 (23.x) / 22.20.0 (22.x backport); Stability 1.0; never default-on through Node 27",
     },
+    // ── import-text (importing source as text via import attributes) ─────────
+    // `import txt from './x.txt' with { type: 'text' }` — the module's default export
+    // is the file's string contents. Node gained this behind `--experimental-import-text`
+    // on the 26.x line at 26.5.0 (SEMVER-MINOR, #62300); the flag does not exist below
+    // 26.5.0, where injecting it is a "bad option" startup abort, and is still flag-gated
+    // (never default-on) through Node 27 nightly — so this open-ended Unflag band injects
+    // it on [26.5.0, ∞).
+    //
+    // This row is ONLY the native side. nub ALSO provides import-text on EVERY version
+    // that can parse the `with` syntax (Node 18.20+) via a loader polyfill —
+    // `loadTextImport` in runtime/transform-core.mjs, dispatched by the load hooks on
+    // `importAttributes.type === "text"`. Per the additive contract, the fast-tier hook
+    // (preload-common.cjs) feature-detects native support (`--experimental-import-text`
+    // in `process.allowedNodeEnvironmentFlags`, i.e. Node 26.5+) and STEPS ASIDE to
+    // Node's own textStrategy there — this injected flag is what makes that native path
+    // work; below 26.5 the polyfill owns it. The polyfill is a load-hook, not a
+    // typeof-global, so it does not fit the `Polyfill` mitigation shape and lives in the
+    // runtime rather than as a band here.
+    Feature {
+        name: "import-text",
+        mitigations: &[(
+            band((26, 5, 0), None),
+            Mitigation::Unflag("--experimental-import-text"),
+        )],
+        evidence: "flag added Node 26.5.0 (#62300); still flag-gated through Node 27 nightly; nub loader-polyfills below via runtime/transform-core.mjs loadTextImport",
+    },
     // ── WebSocket global ────────────────────────────────────────────────────
     // Flag-gated on [20.10.0, 22.0.0) — the global exists on 20.10+ and all of the
     // 21.x line behind `--experimental-websocket`, then becomes default-on at
@@ -780,6 +806,12 @@ mod tests {
         assert!(unflag_flags_for(&v(22, 4, 0)).contains(&"--experimental-webstorage"));
         assert!(unflag_flags_for(&v(24, 99, 0)).contains(&"--experimental-webstorage"));
         assert!(!unflag_flags_for(&v(25, 0, 0)).contains(&"--experimental-webstorage"));
+        // import-text: open-ended [26.5.0, ∞); the flag doesn't exist below 26.5.0.
+        let it = "--experimental-import-text";
+        assert!(!unflag_flags_for(&v(26, 4, 0)).contains(&it));
+        assert!(unflag_flags_for(&v(26, 5, 0)).contains(&it));
+        assert!(unflag_flags_for(&v(27, 0, 0)).contains(&it));
+        assert_eq!(unflag_floor(it), Some(v(26, 5, 0)));
     }
 
     #[test]

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -396,6 +396,24 @@ mod tests {
     }
 
     #[test]
+    fn import_text_injected_from_26_5_open_ended() {
+        // `--experimental-import-text` was added in Node 26.5.0 (#62300) and is not
+        // default-on through Node 27 — inject from 26.5.0 upward, never below (the
+        // flag is a "bad option" there). Also verify it snips out of an inherited
+        // NODE_OPTIONS on a child below the 26.5.0 floor.
+        let it = "--experimental-import-text";
+        assert!(!compute_inject_flags(v(26, 4, 0), &[], None, false).contains(&it));
+        assert!(compute_inject_flags(v(26, 5, 0), &[], None, false).contains(&it));
+        assert!(compute_inject_flags(v(27, 0, 0), &[], None, false).contains(&it));
+        // A user opt-out subtracts it.
+        let argv = vec!["--no-experimental-import-text".to_string()];
+        assert!(!compute_inject_flags(v(26, 5, 0), &argv, None, false).contains(&it));
+        // Inherited NODE_OPTIONS: stripped below the floor, kept at/above it.
+        assert_eq!(strip_unsupported_node_options(it, &v(26, 4, 0)), "");
+        assert_eq!(strip_unsupported_node_options(it, &v(26, 5, 0)), it);
+    }
+
+    #[test]
     fn shadow_realm_never_injected() {
         // ShadowRealm is DELIBERATELY not auto-unflagged (the harmony-flag policy):
         // `--experimental-shadow-realm` implies V8's `--harmony-shadow-realm`, which

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -88,7 +88,10 @@ export async function load(url, context, nextLoad) {
   // checked BEFORE extension dispatch so `import s from "./c.yaml" with {type:"text"}`
   // returns the raw text, not parsed YAML. shortCircuits, so Node never runs its own
   // unknown-'text'-attribute validation. (Node 18.20+ parses the `with` syntax; the
-  // 18.19.x floor cannot parse it at all — see the import-text thread.)
+  // 18.19.x floor cannot parse it at all — see the import-text thread.) Unlike the
+  // fast-tier hook (preload-common.cjs) this ALWAYS polyfills, with no native
+  // fall-through gate: native import-text is Node 26.5+, but the compat tier tops out
+  // at Node 22.14, so a native-capable Node never reaches this loader worker.
   if (context?.importAttributes?.type === "text") return loadTextImport(url);
   const ext = extname(url);
   // node_modules deps are NEVER transpiled (the byte-parity boundary). This guard is

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -24,6 +24,14 @@ const { join, dirname, extname: pathExtname } = require("node:path");
 // the Rust spawn layer, coupled to preload injection). Read by installVersionMarker.
 const VERSION_ENV = "__NUB_VERSION";
 
+// Whether this Node natively supports import-text (`--experimental-import-text`,
+// added Node 26.5.0, #62300). Feature-DETECTED via the accepted-flag set rather
+// than version-parsed — the flag is in `allowedNodeEnvironmentFlags` iff Node
+// knows it (26.5+). When true, the load hook steps aside and lets Node's own
+// textStrategy own `type:"text"` imports (nub injects the flag in spawn.rs), per
+// the additive contract; below 26.5 nub polyfills them via `loadTextImport`.
+const NATIVE_IMPORT_TEXT = process.allowedNodeEnvironmentFlags.has("--experimental-import-text");
+
 // ── data: URL unknown-format fidelity helpers ───────────────────────
 // Mirror Node's internal/modules/esm/get_format.js so nub's sync registerHooks load
 // hook surfaces ERR_UNKNOWN_MODULE_FORMAT for an unsupported `data:` MIME exactly as
@@ -504,13 +512,20 @@ function makeHooks(core, watchReporting) {
 
     // Import Text (attribute-keyed): honor `with { type: "text" }` on ANY extension,
     // ahead of extension dispatch so `import s from "./c.yaml" with {type:"text"}`
-    // returns raw text, not parsed YAML. Placed after watch reporting (so a text file
-    // gets the same watch treatment as any other), and before the extension/data
-    // dispatch (so the attribute wins over the `.txt`/`.yaml`/… data loaders and
-    // Node-native JSON). shortCircuits, so Node's own unknown-'text'-attribute
-    // validation never runs. Mirror of the compat-tier hook in preload-async-hooks.mjs.
+    // returns raw text, not parsed YAML. On Node 26.5+ (NATIVE_IMPORT_TEXT) step aside
+    // and let Node's own textStrategy own it — nub injects --experimental-import-text,
+    // so the additive "would plain Node + the flag do the same?" test holds and users
+    // get Node's exact semantics. Below 26.5 Node has no text-import support, so nub
+    // polyfills via loadTextImport (placed after watch reporting so a text file gets
+    // the same watch treatment, and before the extension/data dispatch so the attribute
+    // wins over the `.txt`/`.yaml`/… data loaders and Node-native JSON; it shortCircuits
+    // so Node's own unknown-'text'-attribute validation never runs). The compat-tier
+    // hook in preload-async-hooks.mjs always polyfills — that tier tops out at Node
+    // 22.14, below 26.5, so native import-text is never reachable there.
     // (Node 18.20+ parses the `with` syntax; the 18.19.x floor cannot.)
-    if (context?.importAttributes?.type === "text") return core.loadTextImport(url);
+    if (context?.importAttributes?.type === "text") {
+      return NATIVE_IMPORT_TEXT ? nextLoad(url, context) : core.loadTextImport(url);
+    }
 
     // A USER resolve hook (a ts-node/tsx-style transpiler registered AFTER nub's
     // own preload hook) claimed this file with the bare 'typescript' format: defer

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -101,6 +101,7 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) | Node 20.18 | unflagged below the native line, native above |
 | [`node:sqlite`](https://nodejs.org/api/sqlite.html) | Node 22.5 | unflagged below Node 22.13, native above |
 | [`addon imports`](https://nodejs.org/api/esm.html#node-addons) | Node 22.20 | unflagged, never native |
+| [`text imports`](https://nodejs.org/api/esm.html#import-attributes) | Node 18.20 | polyfilled below Node 26.5, native above |
 
 A dash means the API works across the full supported range, 18.19 and up. The floored rows have a real cutoff, because the underlying Node mechanism doesn't exist below it:
 
@@ -108,6 +109,7 @@ A dash means the API works across the full supported range, 18.19 and up. The fl
 - The `EventSource` global needs Node 20.18, the patch where Node added the flag on the 20 LTS line.
 - The `node:sqlite` module needs Node 22.5, where Node first shipped it.
 - Importing a native `.node` addon from an ES module needs Node 22.20 (or 23.6 on the 23 line), where Node added the flag Nub injects. It is never native — Node keeps the import behind the flag — so Nub injects it on every version that has it.
+- Importing a file as text — `import readme from "./README.md" with { type: "text" }` — needs Node 18.20, the first version whose parser accepts the `with` import-attribute syntax. Nub polyfills the feature below Node 26.5, then steps aside to Node's native text imports on 26.5 and up (where it injects the `--experimental-import-text` flag).
 
 ## Node version resolution
 


### PR DESCRIPTION
Node 26.5.0 added `--experimental-import-text` ([nodejs/node#62300](https://github.com/nodejs/node/pull/62300)) for `import x from './f' with { type: "text" }`. nub already polyfills text imports; this defers to native `textStrategy` where it exists.

- feature_matrix: `import-text` Unflag `[26.5.0, ∞)` → inject the flag; stripped below the floor.
- preload-common.cjs: feature-detect via `allowedNodeEnvironmentFlags`; 26.5+ `nextLoad`s to native, else polyfills.
- docs: "polyfilled below 26.5, native above", floor 18.20.

Byte-parity vs `node --experimental-import-text` on 26.5.0; polyfill on 26.4.0/18.20.4.