### PR TITLE
feat(runtime): structured-probe auto-backport of experimental Node flags

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3632,11 +3632,17 @@ fn build_script_command(
         cmd.split_whitespace()
             .chain(args.iter().map(String::as_str)),
     );
+    // Probe which experimental flags this Node accepts (cache-amortized). Skip on
+    // compat mode, where compute_augmentation_env injects nothing anyway.
+    let accepted = (!compat_mode)
+        .then(|| nub_core::node::discovery::accepted_experimental_flags(node.path.as_std_path()))
+        .flatten();
     let aug = nub_core::node::spawn::compute_augmentation_env(
         &nub_binary,
         node.version,
         compat_mode,
         pnp_ctx.as_ref().map(|c| c.pnp_cjs.as_path()),
+        accepted.as_ref(),
     );
 
     let mut command = StdCommand::new(shell);
@@ -4558,11 +4564,13 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     let mut node_args = vec!["--watch".to_string(), "--watch-preserve-output".to_string()];
 
     let node_options = env::var("NODE_OPTIONS").ok();
+    let accepted = nub_core::node::discovery::accepted_experimental_flags(node.path.as_std_path());
     let inject = nub_core::node::flags::compute_inject_flags(
         node.version.clone(),
         args,
         node_options.as_deref(),
         false,
+        accepted.as_ref(),
     );
     for flag in &inject {
         node_args.push(flag.to_string());
@@ -4921,11 +4929,13 @@ fn apply_exec_augmentation(cmd: &mut std::process::Command, cwd: &Path) {
         exec_user_agent(cwd, &node.version.to_string()),
     );
     let pnp_ctx = nub_core::pnp::detect(cwd);
+    let accepted = nub_core::node::discovery::accepted_experimental_flags(node.path.as_std_path());
     let Some(aug) = nub_core::node::spawn::compute_augmentation_env(
         &nub_binary,
         node.version,
         false,
         pnp_ctx.as_ref().map(|c| c.pnp_cjs.as_path()),
+        accepted.as_ref(),
     ) else {
         return;
     };

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1391,6 +1391,7 @@ fn apply_lifecycle_augmentation(cwd: &Path) {
     let node = nub_core::node::discovery::discover_node(cwd)
         .unwrap_or_else(|_| nub_core::node::discovery::ResolvedNode::fallback());
     let pnp_ctx = nub_core::pnp::detect(cwd);
+    let accepted = nub_core::node::discovery::accepted_experimental_flags(node.path.as_std_path());
     let Some(aug) = nub_core::node::spawn::compute_augmentation_env(
         &nub_binary,
         node.version,
@@ -1398,6 +1399,7 @@ fn apply_lifecycle_augmentation(cwd: &Path) {
         // no `--node` lifecycle path).
         false,
         pnp_ctx.as_ref().map(|c| c.pnp_cjs.as_path()),
+        accepted.as_ref(),
     ) else {
         return;
     };

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -258,6 +258,34 @@ fn import_text_works_via_native_on_26_5() {
     );
 }
 
+/// Module syntax detection is the headline verification case for the structured-probe
+/// mechanism. Node 20.11.0 accepts `--experimental-detect-module` but does not default
+/// it on (that came at 20.19), so an ambiguous ESM `.js` — ES-module syntax, `.js`
+/// extension, a `package.json` with no `"type"` field — that BARE Node 20.11 refuses
+/// ("To load an ES module, set type: module", exit 1) must run as ESM under nub. nub
+/// probes 20.11, sees it accepts the flag (a wanted enabler), and injects it — no
+/// hand-coded version band, the probe is the gate. This is the differential the
+/// mechanism closes; a default-on Node needs no injection so it is not the interesting
+/// case.
+#[test]
+fn detect_module_backport_runs_ambiguous_esm_on_compat_tier() {
+    let Some((stdout, stderr, code)) = run_nub_against_node((20, 11, 0), "detect-module", "amb.js")
+    else {
+        eprintln!(
+            "skipping: Node 20.11.0 not installed (set TEST_NODE_BIN_20_11_0 or nvm install)"
+        );
+        return;
+    };
+    assert_eq!(
+        code, 0,
+        "compat-tier ambiguous ESM .js must run as ESM under nub (bare Node 20.11 refuses it): stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("detect-module:ran-as-esm:true"),
+        "ambiguous .js must be detected + run as an ES module: stdout={stdout:?}"
+    );
+}
+
 /// Node 18.18.0 is one patch below the 18.19 floor — the boundary case
 /// for the hard-error tier. Contract: stderr carries the canonical
 /// refusal text, exit is non-zero, and (implicitly) Node was never

--- a/crates/nub-core/src/node/discovery.rs
+++ b/crates/nub-core/src/node/discovery.rs
@@ -1,9 +1,10 @@
 //! Node binary discovery: pin-file walk-up, PATH probe, nvm scan.
 
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use camino::Utf8PathBuf;
 use thiserror::Error;
@@ -857,11 +858,22 @@ fn which_node_in(
     Err(DiscoveryError::NoNodeOnPath)
 }
 
-/// Run `node --version` and parse the output, with a disk cache
-/// keyed on the binary's path + mtime to avoid spawning on repeat calls.
+/// Detect a binary's Node version, with a disk cache keyed on path + mtime to avoid
+/// spawning on repeat calls. The one spawn nub already pays here is FOLDED with the
+/// structured flag probe (see [`probe_node`]): it returns the version AND the binary's
+/// accepted `--experimental-*` flags in a single spawn, both cached in the same entry,
+/// so the injection path never pays a second spawn for a binary discovered this way.
+/// If the probe spawn fails (a build that rejects `--expose-internals`, or not-a-node),
+/// fall back to plain `node --version` so version detection keeps its prior robustness,
+/// and negative-cache the flags so the injection path doesn't re-probe it every run.
 fn detect_version(node_path: &Path) -> Result<NodeVersion, DiscoveryError> {
     if let Some(cached) = read_version_cache(node_path) {
         return Ok(cached);
+    }
+
+    if let Some((version, flags)) = probe_node(node_path) {
+        upsert_discovery_entry(node_path, Some(&version), Some(&flags), true);
+        return Ok(version);
     }
 
     let output = Command::new(node_path)
@@ -882,8 +894,245 @@ fn detect_version(node_path: &Path) -> Result<NodeVersion, DiscoveryError> {
         .parse::<NodeVersion>()
         .map_err(|e| DiscoveryError::VersionDetection(e.to_string()))?;
 
-    write_version_cache(node_path, &version);
+    // Probe spawn failed but --version worked → negative-cache the flags (probed,
+    // introspection unavailable) so the injection path fails safe without re-probing.
+    upsert_discovery_entry(node_path, Some(&version), None, true);
     Ok(version)
+}
+
+/// A probed Node's accepted `--experimental-*` option flags → `(OptionType,
+/// envVarSettings)`, read from Node's own option table via `internalBinding('options')`.
+/// Drives the injection-policy seam in [`super::flags`]: the arity guard (bare-inject
+/// only `type ∈ {kNoOp=0, kBoolean=2}`) and the NODE_OPTIONS-legality gate (`env == 0`).
+pub type AcceptedFlags = HashMap<String, (u8, u8)>;
+
+/// The structured introspection script, run in nub's OWN throwaway spawn (never user
+/// code). Reachable behind `--expose-internals`; the accessor name drifts across
+/// versions (`getCLIOptionsInfo()` newer, `getCLIOptions()` older — verified 18.19→26.5)
+/// so it tries both. Line 1 is `process.version` (identical to `node --version`, so the
+/// version fold is transparent); line 2 is a JSON object `{flag: [type, env]}`, or empty
+/// when introspection is unavailable — the caller then fails safe. `internalBinding`'s
+/// `options` is an internal-realm Map (`instanceof Map` is false) but is iterable, so
+/// `for..of` yields `[name, meta]`.
+const FLAG_PROBE_SCRIPT: &str = "let v=process.version,f=null;\
+try{const{internalBinding:b}=require('internal/test/binding');\
+const o=b('options');const i=o.getCLIOptionsInfo?o.getCLIOptionsInfo():o.getCLIOptions();\
+f={};for(const[n,m]of i.options){\
+if(typeof n==='string'&&n.startsWith('--experimental-')&&typeof m.type==='number'&&typeof m.envVarSettings==='number')\
+f[n]=[m.type,m.envVarSettings];}}catch{f=null;}\
+process.stdout.write(v+'\\n'+(f?JSON.stringify(f):''));";
+
+/// Run the structured flag probe. Returns `Some((version, flags))` when the spawn
+/// succeeded and line 1 parsed as a version — `flags` may be EMPTY when line 2 was
+/// absent/unparseable (introspection unavailable on this build; the caller
+/// negative-caches that). Returns `None` when the spawn failed or line 1 didn't parse
+/// (transient error, or not a Node binary). HERMETIC: `NODE_OPTIONS` is cleared — the
+/// `-e` eval would otherwise run an inherited preload that could write to stdout and
+/// corrupt the two-line parse, and an inherited below-floor flag could abort the probe —
+/// and `--no-warnings` suppresses the internal-binding notice.
+fn probe_node(node_path: &Path) -> Option<(NodeVersion, AcceptedFlags)> {
+    let output = Command::new(node_path)
+        .args([
+            "--no-warnings",
+            "--expose-internals",
+            "-e",
+            FLAG_PROBE_SCRIPT,
+        ])
+        .env_remove("NODE_OPTIONS")
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.splitn(2, '\n');
+    let version: NodeVersion = lines.next()?.trim().parse().ok()?;
+    let flags = lines.next().and_then(parse_probe_flags).unwrap_or_default();
+    Some((version, flags))
+}
+
+/// Parse the probe's line-2 JSON object `{flag: [type, env]}` defensively — any shape
+/// mismatch (empty, non-object, malformed tuple) yields `None`, never a panic.
+fn parse_probe_flags(line: &str) -> Option<AcceptedFlags> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+    let value = serde_json::from_str::<serde_json::Value>(line).ok()?;
+    let map = flags_from_json_object(value.as_object()?);
+    (!map.is_empty()).then_some(map)
+}
+
+/// Build an [`AcceptedFlags`] from a `{flag: [type, env]}` JSON object, skipping any
+/// entry that isn't a two-element numeric array. Shared by the probe parser and the
+/// cache reader; both must decode the same on-disk/on-wire shape identically.
+fn flags_from_json_object(obj: &serde_json::Map<String, serde_json::Value>) -> AcceptedFlags {
+    let byte = |v: &serde_json::Value| v.as_u64().filter(|n| *n <= u8::MAX as u64).map(|n| n as u8);
+    let mut map = AcceptedFlags::with_capacity(obj.len());
+    for (name, te) in obj {
+        if let Some(arr) = te.as_array()
+            && arr.len() == 2
+            && let (Some(t), Some(e)) = (byte(&arr[0]), byte(&arr[1]))
+        {
+            map.insert(name.clone(), (t, e));
+        }
+    }
+    map
+}
+
+/// The binary's accepted `--experimental-*` flags for the injection-policy seam.
+/// Reads the mtime-checked cache first; on a cold entry (pre-feature, or a mtime
+/// change) runs [`probe_node`] once and caches the result. `None` means "inject via
+/// the fail-safe path" — either the binary doesn't accept introspection (negative-
+/// cached so we never re-probe it) or the probe failed. Cache-amortized: a binary
+/// already discovered via [`detect_version`] is a cache hit here (no second spawn).
+pub fn accepted_experimental_flags(node_path: &Path) -> Option<AcceptedFlags> {
+    // Only probe a real, resolved binary. A relative path — chiefly the
+    // `ResolvedNode::fallback()` sentinel `"node"` — must not be probed: `Command::new`
+    // would resolve it via `$PATH` (a spawn that didn't happen before, possibly
+    // re-entering nub's own node shim), and its metadata read fails so the cache would
+    // accrue a mtime-less junk entry that re-probes every run. Fall safe to the matrix
+    // version bands instead (what the fallback path already did).
+    if !node_path.is_absolute() {
+        return None;
+    }
+    match read_flags_cache(node_path) {
+        FlagsCache::Fresh(flags) => return Some(flags),
+        FlagsCache::NegativeCached => return None,
+        FlagsCache::Cold => {}
+    }
+    match probe_node(node_path) {
+        Some((version, flags)) => {
+            let has = !flags.is_empty();
+            upsert_discovery_entry(node_path, Some(&version), Some(&flags), true);
+            has.then_some(flags)
+        }
+        None => {
+            // Probe SPAWN failed (transient, or a build that rejects --expose-internals).
+            // Do NOT write here: we have no version to record, so a negative-cache write
+            // would risk pairing a stale version with the fresh mtime. A transient failure
+            // simply retries next run; a persistently-unintrospectable binary reached via
+            // PATH is already negative-cached (with its correct version) by detect_version.
+            None
+        }
+    }
+}
+
+/// Cache state for a binary's probed flags.
+enum FlagsCache {
+    /// Probed, introspection succeeded — the accepted-flags map.
+    Fresh(AcceptedFlags),
+    /// Probed, introspection unavailable (empty/absent flags) — do NOT re-probe.
+    NegativeCached,
+    /// No completed probe for this (path, mtime) — probe now.
+    Cold,
+}
+
+/// Read a binary's probed flags from the discovery cache. `flags_probed:true` marks a
+/// COMPLETED probe, distinguishing a negative result (probed, empty) from a pre-feature
+/// entry (no marker → cold → probe). mtime-keyed exactly like [`read_version_cache`].
+fn read_flags_cache(node_path: &Path) -> FlagsCache {
+    let Some(cache) = cache_dir().map(|d| d.join("node-discovery.json")) else {
+        return FlagsCache::Cold;
+    };
+    let Some(data) = fs::read_to_string(&cache)
+        .ok()
+        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+    else {
+        return FlagsCache::Cold;
+    };
+    let key = node_path.to_string_lossy();
+    let Some(entry) = data.get(key.as_ref()) else {
+        return FlagsCache::Cold;
+    };
+    if entry.get("mtime").and_then(|m| m.as_u64()) != mtime_secs(node_path) {
+        return FlagsCache::Cold;
+    }
+    if entry.get("flags_probed").and_then(|v| v.as_bool()) != Some(true) {
+        return FlagsCache::Cold; // pre-feature entry → probe to populate flags
+    }
+    match entry.get("flags").and_then(|f| f.as_object()) {
+        Some(obj) if !obj.is_empty() => {
+            let map = flags_from_json_object(obj);
+            if map.is_empty() {
+                FlagsCache::NegativeCached
+            } else {
+                FlagsCache::Fresh(map)
+            }
+        }
+        _ => FlagsCache::NegativeCached,
+    }
+}
+
+/// The binary's mtime in whole seconds since the epoch, matching the cache key format.
+fn mtime_secs(node_path: &Path) -> Option<u64> {
+    fs::metadata(node_path)
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
+/// Merge `{version?, mtime, flags?, flags_probed?}` into this path's discovery-cache
+/// entry (read-modify-write of the whole JSON, preserving sibling entries + any field
+/// not being updated). `flags_probed` set writes the `flags` object (possibly empty —
+/// the negative-cache marker). Written atomically (temp + rename) so a concurrent reader
+/// never sees a torn file (which would parse-fail → cold → a spawn storm across callers).
+fn upsert_discovery_entry(
+    node_path: &Path,
+    version: Option<&NodeVersion>,
+    flags: Option<&AcceptedFlags>,
+    flags_probed: bool,
+) {
+    let Some(dir) = cache_dir() else { return };
+    let _ = fs::create_dir_all(&dir);
+    let cache = dir.join("node-discovery.json");
+
+    let mut data: serde_json::Value = fs::read_to_string(&cache)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    let key = node_path.to_string_lossy().to_string();
+    let mut entry = data
+        .get(&key)
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    if let Some(v) = version {
+        entry.insert("version".into(), serde_json::json!(v.to_string()));
+    }
+    entry.insert(
+        "mtime".into(),
+        serde_json::json!(mtime_secs(node_path).unwrap_or(0)),
+    );
+    if flags_probed {
+        entry.insert("flags_probed".into(), serde_json::json!(true));
+        let fobj: serde_json::Map<String, serde_json::Value> = flags
+            .into_iter()
+            .flatten()
+            .map(|(name, (t, e))| (name.clone(), serde_json::json!([t, e])))
+            .collect();
+        entry.insert("flags".into(), serde_json::Value::Object(fobj));
+    }
+    data[key] = serde_json::Value::Object(entry);
+    write_cache_atomic(&cache, &data);
+}
+
+/// Atomically replace the cache file: write a per-PID temp sibling, then rename over
+/// the target (atomic on POSIX + Windows). Prevents a concurrent reader from seeing a
+/// half-written file.
+fn write_cache_atomic(cache: &Path, data: &serde_json::Value) {
+    let tmp = cache.with_extension(format!("json.tmp.{}", std::process::id()));
+    if fs::write(&tmp, serde_json::to_string_pretty(data).unwrap_or_default()).is_ok() {
+        if fs::rename(&tmp, cache).is_err() {
+            let _ = fs::remove_file(&tmp);
+        }
+    }
 }
 
 /// Resolve the `NODE_EXECUTABLE` override, if set. Split from the env read so the
@@ -1066,35 +1315,6 @@ fn read_version_cache(node_path: &Path) -> Option<NodeVersion> {
     } else {
         None
     }
-}
-
-fn write_version_cache(node_path: &Path, version: &NodeVersion) {
-    let Some(dir) = cache_dir() else { return };
-    let _ = fs::create_dir_all(&dir);
-    let cache = dir.join("node-discovery.json");
-
-    let mut data: serde_json::Value = fs::read_to_string(&cache)
-        .ok()
-        .and_then(|c| serde_json::from_str(&c).ok())
-        .unwrap_or_else(|| serde_json::json!({}));
-
-    let mtime = fs::metadata(node_path)
-        .ok()
-        .and_then(|m| m.modified().ok())
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
-    let key = node_path.to_string_lossy().to_string();
-    data[key] = serde_json::json!({
-        "version": version.to_string(),
-        "mtime": mtime,
-    });
-
-    let _ = fs::write(
-        &cache,
-        serde_json::to_string_pretty(&data).unwrap_or_default(),
-    );
 }
 
 /// Scan the nvm install directory for a version matching the pin.
@@ -1365,6 +1585,31 @@ mod tests {
             let version = detect_version(&path).unwrap();
             assert!(version.major() >= 18, "expected Node 18+, got {version}");
         }
+    }
+
+    #[test]
+    fn parse_probe_flags_reads_the_probe_shape() {
+        let m =
+            parse_probe_flags(r#"{"--experimental-sqlite":[2,0],"--experimental-loader":[7,0]}"#)
+                .expect("valid probe JSON parses");
+        assert_eq!(m.get("--experimental-sqlite"), Some(&(2u8, 0u8)));
+        assert_eq!(m.get("--experimental-loader"), Some(&(7u8, 0u8)));
+    }
+
+    #[test]
+    fn parse_probe_flags_is_defensive_never_panics() {
+        // Fail-safe: any unusable line-2 (empty, non-JSON, non-object, or a malformed
+        // tuple) yields None — the injection path then falls back to the matrix bands.
+        // A malformed entry alongside a valid one is skipped, not fatal.
+        assert!(parse_probe_flags("").is_none());
+        assert!(parse_probe_flags("   ").is_none());
+        assert!(parse_probe_flags("not json at all").is_none());
+        assert!(parse_probe_flags("[1,2,3]").is_none()); // not an object
+        assert!(parse_probe_flags(r#"{"--experimental-x":"nope"}"#).is_none()); // no valid tuple → empty → None
+        let m = parse_probe_flags(r#"{"--experimental-x":[2,0],"--experimental-bad":[1]}"#)
+            .expect("the one valid entry survives");
+        assert_eq!(m.len(), 1);
+        assert_eq!(m.get("--experimental-x"), Some(&(2u8, 0u8)));
     }
 
     #[test]

--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -615,6 +615,26 @@ pub fn unflag_flags_for(node_version: &NodeVersion) -> Vec<&'static str> {
         .collect()
 }
 
+/// Every distinct flag that ANY `Unflag` band in the matrix injects — nub's set of
+/// deliberately-wanted experimental *enablers* (feature intent, independent of the
+/// per-version bands). The injection-policy seam in [`super::flags`] uses this as the
+/// allowlist it injects wherever the probed binary accepts them (deriving it here keeps
+/// the wanted set single-sourced against the matrix — a new `Unflag` row joins it
+/// automatically). Sorted + deduped for determinism.
+pub fn all_unflag_enabler_names() -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = FEATURES
+        .iter()
+        .flat_map(|f| f.mitigations.iter())
+        .filter_map(|(_, m)| match m {
+            Mitigation::Unflag(flag) => Some(*flag),
+            _ => None,
+        })
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
 /// The lowest Node version at which `flag` EXISTS — the minimum `lo` across every
 /// `Unflag(flag)` band in the matrix — or `None` if no band unflags `flag`.
 ///

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -9,6 +9,7 @@
 //! hygiene injections (`--disable-warning`, `--test-coverage-exclude`) are nub's
 //! own startup hygiene, not user-facing *features*, so they stay local.
 
+use super::discovery::AcceptedFlags;
 use super::feature_matrix::{self, Mitigation};
 use super::version::NodeVersion;
 
@@ -99,6 +100,55 @@ pub fn test_coverage_exclude_supported(node_version: &NodeVersion) -> bool {
     *node_version >= MIN_TEST_COVERAGE_EXCLUDE
 }
 
+/// The injection-policy SEAM — the ONE function to change to swap policy. Given the
+/// `--experimental-*` flags a binary actually accepts (from the structured probe), it
+/// produces the experimental flags nub injects.
+///
+/// DEFAULT = **option 1, allowlist**: inject nub's deliberately-wanted enablers
+/// ([`wanted_experimental_enablers`]) that THIS binary accepts. The probe is the
+/// version gate — no hand-coded version bands — so a flag is injected wherever it
+/// exists and dropped wherever it doesn't (the 21.x eventsource hole, a future
+/// removal, a patched/lying-version build all fall out for free). The arity guard
+/// (`type ∈ {kNoOp=0, kBoolean=2}`) + NODE_OPTIONS-legality (`env == 0`) ensure a
+/// value-taker or env-illegal flag is never bare-injected (that would be exit-9).
+///
+/// To widen to **option 2** (accepted-minus-denylist), change only
+/// [`wanted_experimental_enablers`] to return the full accepted set minus a denylist;
+/// the guard and everything downstream are unchanged. This is the single seam the
+/// maintainer's 1/2/3 policy choice moves.
+fn experimental_inject_set(accepted: &AcceptedFlags) -> Vec<&'static str> {
+    wanted_experimental_enablers()
+        .into_iter()
+        .filter(|flag| match accepted.get(*flag) {
+            // Accepted here AND bare-injectable (boolean/no-op) AND NODE_OPTIONS-legal.
+            Some(&(ty, env)) => (ty == 0 || ty == 2) && env == 0,
+            // Not accepted by this binary → don't inject (removal-/hole-safe).
+            None => false,
+        })
+        .collect()
+}
+
+/// nub's deliberately-wanted experimental enabler flags — the allowlist the mechanism
+/// injects wherever the probed binary accepts them. DERIVED from the feature matrix's
+/// `Unflag` rows (the single source of feature *intent*) plus
+/// `--experimental-detect-module` (a wanted enabler with no matrix band). One flag is
+/// held out on purpose: `--experimental-webstorage` — spawn.rs owns it (paired with a
+/// runtime `--localstorage-file` + a localStorage-neutralization signal); bare-injecting
+/// it here would install a throwing `localStorage` getter.
+///
+/// A `V8_HARMONY_UNFLAG_DENYLIST` flag (e.g. `--experimental-shadow-realm`, which crashes
+/// embedded Node/Electron via a snapshot-hash mismatch, #246) needs no filtering here: it
+/// is never an `Unflag` row, so it is structurally absent from the derived set — asserted
+/// by a test.
+fn wanted_experimental_enablers() -> Vec<&'static str> {
+    let mut set: Vec<&'static str> = feature_matrix::all_unflag_enabler_names()
+        .into_iter()
+        .filter(|f| *f != "--experimental-webstorage")
+        .collect();
+    set.push("--experimental-detect-module");
+    set
+}
+
 /// Compute the flags Nub should inject for the given Node version,
 /// after subtracting any user opt-outs from argv and NODE_OPTIONS.
 ///
@@ -129,11 +179,22 @@ pub fn test_coverage_exclude_supported(node_version: &NodeVersion) -> bool {
 /// (Webstorage's `--experimental-webstorage` is injected in `spawn.rs`, not here —
 /// always-injected on the `webstorage_flag_needed` band, suppressed only when the
 /// user already supplied the flag in either polarity; see there.)
+///
+/// ## Experimental enablers: probe-gated (with a version-band fail-safe)
+///
+/// `accepted` is the binary's accepted `--experimental-*` flag set (structured probe,
+/// [`super::discovery::accepted_experimental_flags`]). When present, the experimental
+/// enablers come from the injection-policy seam ([`experimental_inject_set`]) — injected
+/// wherever the binary accepts them, no version bands. When absent (probe unavailable on
+/// this build), nub FAILS SAFE to the matrix version bands ([`feature_matrix::unflag_flags_for`],
+/// today's crash-safe behavior). The hygiene flags (`--enable-source-maps`,
+/// `--disable-warning`) are version-gated as before and never depend on the probe.
 pub fn compute_inject_flags(
     node_version: NodeVersion,
     user_argv: &[String],
     node_options: Option<&str>,
     show_warnings: bool,
+    accepted: Option<&AcceptedFlags>,
 ) -> Vec<&'static str> {
     // Stage 1: compute the would-inject set.
     let mut flags: Vec<&str> = Vec::new();
@@ -153,21 +214,17 @@ pub fn compute_inject_flags(
         flags.push("--disable-warning=ExperimentalWarning");
     }
 
-    // The version-banded experimental unflags are DERIVED from the canonical
-    // feature matrix — for each feature whose mitigation at this version is
-    // `Unflag(flag)`, the flag is injected. Tuned per band so the flag is present
-    // exactly where it both EXISTS (else "bad option" / "not allowed in
-    // NODE_OPTIONS" startup abort) and is still REQUIRED (not yet default-on). See
-    // `feature_matrix::FEATURES` for the bands + changelog evidence. (webstorage's
-    // flag is injected separately in spawn.rs, since it pairs with a
-    // runtime-computed `--localstorage-file` path — but its bands live in the same
-    // matrix, read via `webstorage_flag_needed` / `webstorage_supported`.)
-    for flag in feature_matrix::unflag_flags_for(&node_version) {
-        // Skip the webstorage flag here: spawn.rs owns its injection (paired with
-        // the workspace-keyed --localstorage-file), gated on the same matrix bands
-        // via `webstorage_flag_needed`. Injecting it in this static set too would
-        // emit it without the file (the global never materializes) and bypass the
-        // user-override suppression spawn.rs applies.
+    // Experimental enablers. With a probe result, inject the wanted enablers THIS
+    // binary accepts (the seam — probe is the version gate, no bands). Without one,
+    // FAIL SAFE to the matrix version bands (crash-safe by construction). The
+    // webstorage flag is skipped on BOTH paths — spawn.rs owns its injection (paired
+    // with the workspace-keyed `--localstorage-file`); emitting it here would install
+    // a throwing `localStorage` getter and bypass spawn.rs's user-override handling.
+    let experimental = match accepted {
+        Some(acc) => experimental_inject_set(acc),
+        None => feature_matrix::unflag_flags_for(&node_version),
+    };
+    for flag in experimental {
         if flag == "--experimental-webstorage" {
             continue;
         }
@@ -304,14 +361,14 @@ mod tests {
 
     #[test]
     fn always_injects_warning_suppression_and_source_maps() {
-        let flags = compute_inject_flags(v(22, 15, 0), &[], None, false);
+        let flags = compute_inject_flags(v(22, 15, 0), &[], None, false, None);
         assert!(flags.contains(&"--disable-warning=ExperimentalWarning"));
         assert!(flags.contains(&"--enable-source-maps"));
     }
 
     #[test]
     fn injects_unflag_set_on_22_15() {
-        let flags = compute_inject_flags(v(22, 15, 0), &[], None, false);
+        let flags = compute_inject_flags(v(22, 15, 0), &[], None, false, None);
         assert!(flags.contains(&"--experimental-vm-modules"));
         assert!(flags.contains(&"--experimental-eventsource"));
         // webstorage is NOT in this static set: spawn.rs owns its injection (it
@@ -327,11 +384,11 @@ mod tests {
         // vm.Module is never unflagged — inject from the 18.19 floor through 26.x.
         // (Regression: the old min:22.15.0 left vm.Module broken on 18.19–22.14.)
         assert!(
-            compute_inject_flags(v(18, 19, 0), &[], None, false)
+            compute_inject_flags(v(18, 19, 0), &[], None, false, None)
                 .contains(&"--experimental-vm-modules")
         );
         assert!(
-            compute_inject_flags(v(26, 2, 0), &[], None, false)
+            compute_inject_flags(v(26, 2, 0), &[], None, false, None)
                 .contains(&"--experimental-vm-modules")
         );
     }
@@ -341,16 +398,16 @@ mod tests {
         // EventSource landed at 22.3.0 + 20.18.0 backport; never shipped on 21.x.
         // Injecting on 21.x is a "bad option" crash — the highest-stakes boundary here.
         let yes = "--experimental-eventsource";
-        assert!(!compute_inject_flags(v(20, 17, 0), &[], None, false).contains(&yes));
-        assert!(compute_inject_flags(v(20, 18, 0), &[], None, false).contains(&yes));
+        assert!(!compute_inject_flags(v(20, 17, 0), &[], None, false, None).contains(&yes));
+        assert!(compute_inject_flags(v(20, 18, 0), &[], None, false, None).contains(&yes));
         // The hole: must NOT inject anywhere on the 21.x line.
         assert!(
-            !compute_inject_flags(v(21, 0, 0), &[], None, false).contains(&yes),
+            !compute_inject_flags(v(21, 0, 0), &[], None, false, None).contains(&yes),
             "must NOT inject --experimental-eventsource on 21.0 (flag never existed there → crash)"
         );
-        assert!(!compute_inject_flags(v(22, 2, 0), &[], None, false).contains(&yes));
-        assert!(compute_inject_flags(v(22, 3, 0), &[], None, false).contains(&yes));
-        assert!(compute_inject_flags(v(26, 2, 0), &[], None, false).contains(&yes));
+        assert!(!compute_inject_flags(v(22, 2, 0), &[], None, false, None).contains(&yes));
+        assert!(compute_inject_flags(v(22, 3, 0), &[], None, false, None).contains(&yes));
+        assert!(compute_inject_flags(v(26, 2, 0), &[], None, false, None).contains(&yes));
     }
 
     #[test]
@@ -358,13 +415,13 @@ mod tests {
         // node:sqlite: flag added 22.5.0, unflagged 22.13.0 (22.x) and 23.4.0 (23.x).
         // Inject only where the flag exists AND is still required.
         let sql = "--experimental-sqlite";
-        assert!(!compute_inject_flags(v(22, 4, 0), &[], None, false).contains(&sql)); // flag absent
-        assert!(compute_inject_flags(v(22, 5, 0), &[], None, false).contains(&sql)); // band 1 floor
-        assert!(compute_inject_flags(v(22, 12, 0), &[], None, false).contains(&sql));
-        assert!(!compute_inject_flags(v(22, 13, 0), &[], None, false).contains(&sql)); // unflagged on 22.x
-        assert!(compute_inject_flags(v(23, 3, 0), &[], None, false).contains(&sql)); // band 2
-        assert!(!compute_inject_flags(v(23, 4, 0), &[], None, false).contains(&sql)); // unflagged on 23.x
-        assert!(!compute_inject_flags(v(24, 0, 0), &[], None, false).contains(&sql)); // unflagged everywhere after
+        assert!(!compute_inject_flags(v(22, 4, 0), &[], None, false, None).contains(&sql)); // flag absent
+        assert!(compute_inject_flags(v(22, 5, 0), &[], None, false, None).contains(&sql)); // band 1 floor
+        assert!(compute_inject_flags(v(22, 12, 0), &[], None, false, None).contains(&sql));
+        assert!(!compute_inject_flags(v(22, 13, 0), &[], None, false, None).contains(&sql)); // unflagged on 22.x
+        assert!(compute_inject_flags(v(23, 3, 0), &[], None, false, None).contains(&sql)); // band 2
+        assert!(!compute_inject_flags(v(23, 4, 0), &[], None, false, None).contains(&sql)); // unflagged on 23.x
+        assert!(!compute_inject_flags(v(24, 0, 0), &[], None, false, None).contains(&sql)); // unflagged everywhere after
     }
 
     #[test]
@@ -372,10 +429,10 @@ mod tests {
         // WebSocket global is flag-gated on [20.10.0, 22.0.0): exists on 20.10+ and all
         // 21.x, default-on from 22.0.0. Below 20.10 the flag doesn't exist ("bad option").
         let ws = "--experimental-websocket";
-        assert!(!compute_inject_flags(v(20, 9, 0), &[], None, false).contains(&ws));
-        assert!(compute_inject_flags(v(20, 10, 0), &[], None, false).contains(&ws));
-        assert!(compute_inject_flags(v(21, 5, 0), &[], None, false).contains(&ws)); // all of 21.x
-        assert!(!compute_inject_flags(v(22, 0, 0), &[], None, false).contains(&ws)); // default-on
+        assert!(!compute_inject_flags(v(20, 9, 0), &[], None, false, None).contains(&ws));
+        assert!(compute_inject_flags(v(20, 10, 0), &[], None, false, None).contains(&ws));
+        assert!(compute_inject_flags(v(21, 5, 0), &[], None, false, None).contains(&ws)); // all of 21.x
+        assert!(!compute_inject_flags(v(22, 0, 0), &[], None, false, None).contains(&ws)); // default-on
     }
 
     #[test]
@@ -385,14 +442,14 @@ mod tests {
         // default-on on the 23.x line (EOL before the backport). Inject on
         // [18.19, 22.19) ∪ [23.0, 24.5).
         let w = "--experimental-wasm-modules";
-        assert!(compute_inject_flags(v(18, 19, 0), &[], None, false).contains(&w)); // floor
-        assert!(compute_inject_flags(v(22, 13, 0), &[], None, false).contains(&w));
-        assert!(compute_inject_flags(v(22, 18, 0), &[], None, false).contains(&w));
-        assert!(!compute_inject_flags(v(22, 19, 0), &[], None, false).contains(&w)); // default-on 22.x
-        assert!(compute_inject_flags(v(23, 2, 0), &[], None, false).contains(&w)); // 23.x stays flagged
-        assert!(compute_inject_flags(v(24, 4, 0), &[], None, false).contains(&w));
-        assert!(!compute_inject_flags(v(24, 5, 0), &[], None, false).contains(&w)); // default-on 24.x
-        assert!(!compute_inject_flags(v(26, 0, 0), &[], None, false).contains(&w));
+        assert!(compute_inject_flags(v(18, 19, 0), &[], None, false, None).contains(&w)); // floor
+        assert!(compute_inject_flags(v(22, 13, 0), &[], None, false, None).contains(&w));
+        assert!(compute_inject_flags(v(22, 18, 0), &[], None, false, None).contains(&w));
+        assert!(!compute_inject_flags(v(22, 19, 0), &[], None, false, None).contains(&w)); // default-on 22.x
+        assert!(compute_inject_flags(v(23, 2, 0), &[], None, false, None).contains(&w)); // 23.x stays flagged
+        assert!(compute_inject_flags(v(24, 4, 0), &[], None, false, None).contains(&w));
+        assert!(!compute_inject_flags(v(24, 5, 0), &[], None, false, None).contains(&w)); // default-on 24.x
+        assert!(!compute_inject_flags(v(26, 0, 0), &[], None, false, None).contains(&w));
     }
 
     #[test]
@@ -402,12 +459,12 @@ mod tests {
         // flag is a "bad option" there). Also verify it snips out of an inherited
         // NODE_OPTIONS on a child below the 26.5.0 floor.
         let it = "--experimental-import-text";
-        assert!(!compute_inject_flags(v(26, 4, 0), &[], None, false).contains(&it));
-        assert!(compute_inject_flags(v(26, 5, 0), &[], None, false).contains(&it));
-        assert!(compute_inject_flags(v(27, 0, 0), &[], None, false).contains(&it));
+        assert!(!compute_inject_flags(v(26, 4, 0), &[], None, false, None).contains(&it));
+        assert!(compute_inject_flags(v(26, 5, 0), &[], None, false, None).contains(&it));
+        assert!(compute_inject_flags(v(27, 0, 0), &[], None, false, None).contains(&it));
         // A user opt-out subtracts it.
         let argv = vec!["--no-experimental-import-text".to_string()];
-        assert!(!compute_inject_flags(v(26, 5, 0), &argv, None, false).contains(&it));
+        assert!(!compute_inject_flags(v(26, 5, 0), &argv, None, false, None).contains(&it));
         // Inherited NODE_OPTIONS: stripped below the floor, kept at/above it.
         assert_eq!(strip_unsupported_node_options(it, &v(26, 4, 0)), "");
         assert_eq!(strip_unsupported_node_options(it, &v(26, 5, 0)), it);
@@ -422,15 +479,15 @@ mod tests {
         // so a self-disable can't catch it (#246). Never inject it, at any version.
         // The categorical guard lives in feature_matrix (no_v8_harmony_flag_in_unflag_set).
         let s = "--experimental-shadow-realm";
-        assert!(!compute_inject_flags(v(18, 19, 0), &[], None, false).contains(&s));
-        assert!(!compute_inject_flags(v(22, 19, 0), &[], None, false).contains(&s));
-        assert!(!compute_inject_flags(v(26, 0, 0), &[], None, false).contains(&s));
+        assert!(!compute_inject_flags(v(18, 19, 0), &[], None, false, None).contains(&s));
+        assert!(!compute_inject_flags(v(22, 19, 0), &[], None, false, None).contains(&s));
+        assert!(!compute_inject_flags(v(26, 0, 0), &[], None, false, None).contains(&s));
     }
 
     #[test]
     fn user_opt_out_via_argv() {
         let argv = vec!["--no-experimental-vm-modules".to_string()];
-        let flags = compute_inject_flags(v(22, 15, 0), &argv, None, false);
+        let flags = compute_inject_flags(v(22, 15, 0), &argv, None, false, None);
         assert!(!flags.contains(&"--experimental-vm-modules"));
         // Other flags still present (eventsource is in-band at 22.15).
         assert!(flags.contains(&"--experimental-eventsource"));
@@ -444,6 +501,7 @@ mod tests {
             &[],
             Some("--no-experimental-sqlite --max-old-space-size=4096"),
             false,
+            None,
         );
         assert!(!flags.contains(&"--experimental-sqlite"));
         assert!(flags.contains(&"--experimental-vm-modules"));
@@ -460,13 +518,19 @@ mod tests {
         // channels (argv and NODE_OPTIONS).
         let argv = vec!["--no-enable-source-maps".to_string()];
         assert!(
-            !compute_inject_flags(v(22, 15, 0), &argv, None, false)
+            !compute_inject_flags(v(22, 15, 0), &argv, None, false, None)
                 .contains(&"--enable-source-maps"),
             "user --no-enable-source-maps (argv) must suppress nub's always-inject"
         );
         assert!(
-            !compute_inject_flags(v(22, 15, 0), &[], Some("--no-enable-source-maps"), false)
-                .contains(&"--enable-source-maps"),
+            !compute_inject_flags(
+                v(22, 15, 0),
+                &[],
+                Some("--no-enable-source-maps"),
+                false,
+                None
+            )
+            .contains(&"--enable-source-maps"),
             "user --no-enable-source-maps (NODE_OPTIONS) must suppress it too"
         );
     }
@@ -485,6 +549,7 @@ mod tests {
             &["--disable-warning=DeprecationWarning".to_string()],
             None,
             false,
+            None,
         );
         assert!(
             flags.contains(&"--disable-warning=ExperimentalWarning"),
@@ -494,7 +559,7 @@ mod tests {
 
     #[test]
     fn show_warnings_suppresses_warning_flag() {
-        let flags = compute_inject_flags(v(22, 15, 0), &[], None, true);
+        let flags = compute_inject_flags(v(22, 15, 0), &[], None, true, None);
         assert!(!flags.contains(&"--disable-warning=ExperimentalWarning"));
         assert!(flags.contains(&"--enable-source-maps"));
     }
@@ -504,7 +569,7 @@ mod tests {
         // At 20.0.0: --enable-source-maps and vm-modules (whole-floor) inject, but the
         // version-gated entries do not — sqlite/eventsource/websocket flags don't exist
         // here ("bad option"), and --disable-warning is below its 20.11 floor.
-        let flags = compute_inject_flags(v(20, 0, 0), &[], None, false);
+        let flags = compute_inject_flags(v(20, 0, 0), &[], None, false, None);
         assert!(flags.contains(&"--enable-source-maps"));
         assert!(flags.contains(&"--experimental-vm-modules"));
         assert!(!flags.contains(&"--experimental-sqlite"));
@@ -519,7 +584,7 @@ mod tests {
         // "not allowed in NODE_OPTIONS"), which crashed the compat tier. It must
         // not be injected below 20.11; from 20.11 onward it is.
         for ver in [v(18, 19, 0), v(20, 0, 0), v(20, 10, 0)] {
-            let flags = compute_inject_flags(ver.clone(), &[], None, false);
+            let flags = compute_inject_flags(ver.clone(), &[], None, false, None);
             assert!(
                 !flags.contains(&"--disable-warning=ExperimentalWarning"),
                 "must NOT inject --disable-warning on {ver:?} (the flag aborts those versions)"
@@ -531,7 +596,7 @@ mod tests {
             );
         }
         for ver in [v(20, 11, 0), v(22, 13, 0)] {
-            let flags = compute_inject_flags(ver.clone(), &[], None, false);
+            let flags = compute_inject_flags(ver.clone(), &[], None, false, None);
             assert!(
                 flags.contains(&"--disable-warning=ExperimentalWarning"),
                 "must inject --disable-warning on {ver:?} (supported there)"
@@ -653,7 +718,7 @@ mod tests {
                 "source maps must be safe to inject on {ver:?}"
             );
             assert!(
-                compute_inject_flags(ver.clone(), &[], None, false)
+                compute_inject_flags(ver.clone(), &[], None, false, None)
                     .contains(&"--enable-source-maps"),
                 "--enable-source-maps must inject on {ver:?}"
             );
@@ -665,10 +730,156 @@ mod tests {
                 "source maps must be withheld on {ver:?}"
             );
             assert!(
-                !compute_inject_flags(ver.clone(), &[], None, false)
+                !compute_inject_flags(ver.clone(), &[], None, false, None)
                     .contains(&"--enable-source-maps"),
                 "--enable-source-maps must NOT inject on {ver:?} (assert→TypeError regression)"
             );
         }
+    }
+
+    // ── The structured-probe injection seam (option 1: allowlist + capability filter) ──
+
+    /// Build an `AcceptedFlags` map from `(name, type, env)` triples — the shape the
+    /// structured probe produces.
+    fn accepted(pairs: &[(&str, u8, u8)]) -> AcceptedFlags {
+        pairs
+            .iter()
+            .map(|(n, t, e)| (n.to_string(), (*t, *e)))
+            .collect()
+    }
+
+    #[test]
+    fn seam_injects_wanted_enablers_the_binary_accepts_and_nothing_else() {
+        // A representative accepted set: wanted enablers (vm/sqlite/detect-module),
+        // a hazard the mechanism must NOT enable (shadow-realm — not on nub's wanted
+        // list), a value-taker (loader), and a net-new experimental flag nub never
+        // chose (ffi). Only the wanted, boolean, env-legal ones inject.
+        let acc = accepted(&[
+            ("--experimental-vm-modules", 2, 0),
+            ("--experimental-sqlite", 2, 0),
+            ("--experimental-detect-module", 2, 0),
+            ("--experimental-shadow-realm", 2, 0), // hazard, NOT wanted → excluded
+            ("--experimental-ffi", 2, 0),          // net-new, NOT wanted → excluded
+            ("--experimental-loader", 7, 0),       // value-taker, NOT wanted → excluded
+        ]);
+        let flags = compute_inject_flags(v(24, 0, 0), &[], None, false, Some(&acc));
+        assert!(flags.contains(&"--experimental-vm-modules"));
+        assert!(flags.contains(&"--experimental-sqlite"));
+        assert!(flags.contains(&"--experimental-detect-module"));
+        assert!(
+            !flags.contains(&"--experimental-shadow-realm"),
+            "shadow-realm is NOT a wanted enabler — the seam must never inject it (#246)"
+        );
+        assert!(!flags.contains(&"--experimental-ffi"));
+        assert!(!flags.contains(&"--experimental-loader"));
+    }
+
+    #[test]
+    fn seam_removal_safety_drops_a_wanted_flag_the_binary_rejects() {
+        // vm-modules is wanted, but if THIS binary doesn't accept it (a hypothetical
+        // future removal), the probe omits it → the seam must not inject it (the
+        // exact crash the mechanism exists to prevent). eventsource, accepted, injects.
+        let acc = accepted(&[("--experimental-eventsource", 2, 0)]);
+        let flags = compute_inject_flags(v(24, 0, 0), &[], None, false, Some(&acc));
+        assert!(flags.contains(&"--experimental-eventsource"));
+        assert!(
+            !flags.contains(&"--experimental-vm-modules"),
+            "a wanted flag the binary rejects must be dropped (removal-safety)"
+        );
+    }
+
+    #[test]
+    fn seam_arity_guard_excludes_value_takers_and_env_illegal_wanted_flags() {
+        // Even a WANTED flag is skipped if the binary reports it as a value-taker
+        // (type ∉ {0,2} → bare-inject is exit-9) or NODE_OPTIONS-illegal (env != 0).
+        // sqlite as a (hypothetical) kString and vm-modules as env-illegal are both
+        // withheld; detect-module (clean boolean, env-legal) still injects.
+        let acc = accepted(&[
+            ("--experimental-sqlite", 5, 0),     // kString value-taker → skip
+            ("--experimental-vm-modules", 2, 1), // env-illegal → skip
+            ("--experimental-detect-module", 2, 0),
+        ]);
+        let flags = compute_inject_flags(v(24, 0, 0), &[], None, false, Some(&acc));
+        assert!(!flags.contains(&"--experimental-sqlite"));
+        assert!(!flags.contains(&"--experimental-vm-modules"));
+        assert!(flags.contains(&"--experimental-detect-module"));
+    }
+
+    #[test]
+    fn seam_injects_detect_module_wherever_accepted_no_band() {
+        // detect-module is a wanted enabler with NO version band — the probe is the
+        // gate. Accepted on an old compat-tier Node → injected; the same version with
+        // detect-module absent from the accepted set → not injected.
+        let with = accepted(&[("--experimental-detect-module", 2, 0)]);
+        assert!(
+            compute_inject_flags(v(20, 11, 0), &[], None, false, Some(&with))
+                .contains(&"--experimental-detect-module")
+        );
+        let without = accepted(&[("--experimental-vm-modules", 2, 0)]);
+        assert!(
+            !compute_inject_flags(v(20, 11, 0), &[], None, false, Some(&without))
+                .contains(&"--experimental-detect-module")
+        );
+    }
+
+    #[test]
+    fn probe_success_injects_where_accepted_even_past_the_bands_failsafe() {
+        // The mechanism's headline difference from the version-band fail-safe: on
+        // Node 22.15 sqlite is default-on (the matrix band stops at 22.13), but it is
+        // still ACCEPTED (a no-op) — so the probe path injects it (harmless), while
+        // the fail-safe (None) path does not.
+        let acc = accepted(&[("--experimental-sqlite", 2, 0)]);
+        assert!(
+            compute_inject_flags(v(22, 15, 0), &[], None, false, Some(&acc))
+                .contains(&"--experimental-sqlite"),
+            "probe path injects an accepted enabler even where the band stopped"
+        );
+        assert!(
+            !compute_inject_flags(v(22, 15, 0), &[], None, false, None)
+                .contains(&"--experimental-sqlite"),
+            "fail-safe (band) path does not inject sqlite on 22.15 (default-on band gap)"
+        );
+    }
+
+    #[test]
+    fn failsafe_none_falls_back_to_matrix_bands() {
+        // With no probe result, injection is exactly today's matrix-band behavior.
+        let flags = compute_inject_flags(v(22, 15, 0), &[], None, false, None);
+        assert!(flags.contains(&"--experimental-vm-modules")); // whole-floor band
+        assert!(flags.contains(&"--experimental-eventsource")); // in-band at 22.15
+        assert!(!flags.contains(&"--experimental-sqlite")); // default-on band gap
+        assert!(flags.contains(&"--enable-source-maps")); // hygiene unaffected by probe
+    }
+
+    #[test]
+    fn wanted_set_excludes_webstorage_and_never_includes_a_harmony_flag() {
+        // webstorage is spawn.rs-owned (paired with --localstorage-file); a
+        // V8_HARMONY_UNFLAG_DENYLIST flag (shadow-realm → #246) must never appear.
+        let wanted = wanted_experimental_enablers();
+        assert!(
+            !wanted.contains(&"--experimental-webstorage"),
+            "webstorage is spawn.rs-owned; the seam must not carry it"
+        );
+        for banned in feature_matrix::V8_HARMONY_UNFLAG_DENYLIST {
+            assert!(
+                !wanted.contains(banned),
+                "harmony flag {banned:?} must never be a wanted enabler (#246)"
+            );
+        }
+        // The wanted set is the matrix Unflag enablers (minus webstorage) + detect-module.
+        assert!(wanted.contains(&"--experimental-detect-module"));
+        assert!(wanted.contains(&"--experimental-vm-modules"));
+    }
+
+    #[test]
+    fn seam_respects_user_negation_over_an_accepted_wanted_flag() {
+        // A user's --no-experimental-vm-modules must still subtract, even on the probe
+        // path (the Stage-3 negation subtraction runs after the seam).
+        let acc = accepted(&[("--experimental-vm-modules", 2, 0)]);
+        let argv = vec!["--no-experimental-vm-modules".to_string()];
+        assert!(
+            !compute_inject_flags(v(24, 0, 0), &argv, None, false, Some(&acc))
+                .contains(&"--experimental-vm-modules")
+        );
     }
 }

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -467,12 +467,17 @@ pub fn spawn_node(config: &SpawnConfig<'_>) -> Result<SpawnResult> {
     // a half-setup (flags + a nested shim, no preload). See
     // wiki/runtime/hijack-by-default.md.
     if !config.compat_mode && !is_reentrant && preload.is_some() {
-        // Flag injection.
+        // Flag injection. The structured probe (cache-amortized once per (path,mtime))
+        // tells compute_inject_flags which experimental flags THIS binary accepts, so
+        // it injects wherever they exist and never emits one the binary would reject.
+        let accepted =
+            super::discovery::accepted_experimental_flags(config.node.path.as_std_path());
         let inject = flags::compute_inject_flags(
             config.node.version.clone(),
             config.user_args,
             node_options.as_deref(),
             config.show_warnings,
+            accepted.as_ref(),
         );
         for flag in &inject {
             cmd.arg(flag);
@@ -1010,6 +1015,7 @@ pub fn compute_augmentation_env(
     node_version: super::version::NodeVersion,
     compat_mode: bool,
     pnp: Option<&Path>,
+    accepted: Option<&super::discovery::AcceptedFlags>,
 ) -> Option<AugmentationEnv> {
     if compat_mode {
         return None;
@@ -1050,6 +1056,7 @@ pub fn compute_augmentation_env(
         &[],
         existing_node_options.as_deref(),
         false,
+        accepted,
     );
     let mut node_opts_parts: Vec<String> = inject.iter().map(|f| f.to_string()).collect();
     // Yarn PnP `--require <.pnp.cjs>` BEFORE nub's preload token so PnP's

--- a/site/content/docs/runtime/typescript.mdx
+++ b/site/content/docs/runtime/typescript.mdx
@@ -50,6 +50,8 @@ const letters = /\p{Letter}/v;
 
 A file with nothing to lower is handed to Node untouched — byte for byte, no reformatting and no source-map footer — so a plain `.js` that needs no transform is exactly the file you wrote. Files inside `node_modules` are never transpiled; they load as the package shipped them, on every tier.
 
+An ambiguous `.js` — ES-module syntax with no `"type"` field in `package.json` — runs as an ES module on Node 20.10 and up, matching a current Node. A bare older Node refuses the same file with `To load an ES module, set "type": "module"`; under Nub it just runs. Add a `"type"` field, or use an `.mjs` / `.cjs` extension, to set the format explicitly.
+
 JSX in a `.js` file is out of scope — use `.jsx`. Nub parses `.js` as JavaScript, not JSX, so a `<` is a comparison, not an element.
 
 ## Explicit resource management

--- a/tests/fixtures/detect-module/amb.js
+++ b/tests/fixtures/detect-module/amb.js
@@ -1,0 +1,8 @@
+// Ambiguous module: ES-module syntax, .js extension, and a package.json with
+// NO "type" field — so Node treats it as ambiguous and needs module syntax
+// detection (--experimental-detect-module, injected by nub below the default-on
+// line) to run it as ESM. Bare old Node (< the detect-module default-on cutover)
+// refuses this file.
+import { fileURLToPath } from "node:url";
+const here = fileURLToPath(import.meta.url);
+console.log("detect-module:ran-as-esm:" + here.endsWith("amb.js"));

--- a/tests/fixtures/detect-module/package.json
+++ b/tests/fixtures/detect-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "detect-module-fixture",
+  "private": true
+}


### PR DESCRIPTION
Replaces the hand-maintained version bands for experimental-flag injection with a per-binary capability probe. nub asks each resolved Node which `--experimental-*` flags it actually accepts — via `internalBinding('options')` under `--expose-internals`, folded into the existing version-detection spawn and cached in `node-discovery.json` — then injects nub's wanted enablers wherever the binary accepts them. The probe is the version gate: a flag is injected where it exists and dropped where it doesn't, so a future removal, the 21.x eventsource hole, and patched/lying-version builds all fall out for free. This closes the exit-9-on-removal blind spot, where injecting a flag a binary rejects aborts the process before user code runs.

## Policy seam

The injection policy is a single swappable function (`flags::experimental_inject_set`). The default is an allowlist: inject `accepted ∩ wanted-enablers`, where the wanted set is the feature matrix's `Unflag` enablers plus `--experimental-detect-module`. Every candidate is guarded by arity (`type ∈ {kNoOp, kBoolean}`) and NODE_OPTIONS-legality (`env == 0`), so a value-taker is never bare-injected into argv or NODE_OPTIONS. Widening to an accepted-minus-denylist policy later is a one-function change.

Hard-excluded from the wanted set: `--experimental-shadow-realm` (the harmony denylist, #246 — crashes embedded Node/Electron on a V8 snapshot-hash mismatch), `--experimental-webstorage` (spawn.rs owns it, paired with `--localstorage-file`), and strip/transform-types (nub's transpiler owns `.ts`). When the probe is unavailable — an old accessor, a hardened build, a spawn failure — injection fails safe to the matrix version bands (today's behavior).

## detect-module

detect-module now falls out of the mechanism with no hand-coded band: an ambiguous ESM `.js` runs as ESM wherever the binary accepts the flag. A `version_tiers` integration test on Node 20.11 is the headline verification — bare 20.11 refuses the ambiguous file (exit 1), nub probes it, sees the flag accepted, and injects it. A differential fixture backs the compat-tier fix.

## Cache

`node-discovery.json` gains a per-binary accepted-flags record with a `flags_probed` marker. The reader is tolerant — pre-feature entries re-probe; a probed-but-unintrospectable build is negative-cached so it never spawn-storms. Writes are atomic (temp + rename), since discovery now has two writers on the same entry.

## Verification

Probe validated on Node 18.19 / 20.11 / 22.14 / 22.15 / 24.4 / 26.5. End-to-end, the injected set is exactly the accepted wanted enablers per binary, and the hazards (shadow-realm, ffi, vfs, print-required-tla, async-context-frame, strip/transform-types) are never injected even on a 26.5 that accepts them. 133 nub-core lib tests and 11 `version_tiers` tests pass; `clippy --all-targets --all-features` and `fmt` clean.

Three fresh-context reviews (correctness, impact-analysis, adversarial fail-safe/value-taker) are folded in.
