### PR TITLE
feat(node): matrix bands for detect-module/ffi/vfs/stream-iter + flag-drift snapshot CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,13 +618,14 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
       # Side-install the off-matrix tier representatives for the version_tiers
-      # integration test (compat 22.13 and unsupported 18.18). actions/setup-node
-      # only manages one PATH-active Node per job; these two go into private
-      # dirs and are exposed to the test via TEST_NODE_BIN_<MAJOR>_<MINOR>_<PATCH>
-      # — the env-var prefix deliberately avoids `NUB_*` (brand-boundary rule
-      # applies even to test-only knobs). Linux-only because the tarball URL
-      # paths differ per OS and the version_tiers contract is runtime-specific,
-      # not OS-specific.
+      # integration test: compat 22.13, unsupported 18.18, detect-module in-band
+      # 20.11 (flag still required there), and 26.5 (carries the node:ffi/vfs/
+      # stream-iter enabler modules). actions/setup-node only manages one
+      # PATH-active Node per job; these go into private dirs and are exposed to
+      # the test via TEST_NODE_BIN_<MAJOR>_<MINOR>_<PATCH> — the env-var prefix
+      # deliberately avoids `NUB_*` (brand-boundary rule applies even to test-only
+      # knobs). Linux-only because the tarball URL paths differ per OS and the
+      # version_tiers contract is runtime-specific, not OS-specific.
       - name: Install side Node binaries for version_tiers
         if: runner.os == 'Linux'
         shell: bash
@@ -641,11 +642,17 @@ jobs:
           }
           dir_22_13=$(install_node 22.13.0)
           dir_18_18=$(install_node 18.18.0)
+          dir_20_11=$(install_node 20.11.0)
+          dir_26_5=$(install_node 26.5.0)
           "$dir_22_13/node" --version
           "$dir_18_18/node" --version
+          "$dir_20_11/node" --version
+          "$dir_26_5/node" --version
           {
             echo "TEST_NODE_BIN_22_13_0=$dir_22_13"
             echo "TEST_NODE_BIN_18_18_0=$dir_18_18"
+            echo "TEST_NODE_BIN_20_11_0=$dir_20_11"
+            echo "TEST_NODE_BIN_26_5_0=$dir_26_5"
           } >> "$GITHUB_ENV"
       - run: pnpm install --frozen-lockfile
       # The data-format loader tests need the nub-native addon (the npm yaml/toml/

--- a/.github/workflows/node-flag-drift.yml
+++ b/.github/workflows/node-flag-drift.yml
@@ -1,0 +1,100 @@
+name: Node flag drift
+
+# Guards the hand-vetted experimental-flag feature matrix against Node changing its
+# --experimental-* flag set underneath us. Two independent checks share one comparison
+# (scripts/check-node-flag-drift.mjs against scripts/node-flag-inventory.snapshot.json):
+#
+#   • snapshot-check — per-PR, Node PINNED to the snapshot's own version. Deterministic:
+#     it only fails if the snapshot or the inventory tool was edited wrong. This is the
+#     stable gate; it never depends on Node nightly moving.
+#   • nightly-drift — scheduled, Node NIGHTLY (and RC when one exists). A diff means Node
+#     added or removed an experimental flag since the snapshot; the job fails loudly so a
+#     human vets the change and, if nub should support it, hand-adds a band to the matrix.
+#     Deliberately NOT a per-PR gate — a Node-nightly change must never block unrelated PRs.
+
+on:
+  pull_request:
+    paths:
+      - scripts/node-flag-inventory.mjs
+      - scripts/check-node-flag-drift.mjs
+      - scripts/node-flag-inventory.snapshot.json
+      - crates/nub-core/src/node/feature_matrix.rs
+      - .github/workflows/node-flag-drift.yml
+  push:
+    branches: [main]
+    paths:
+      - scripts/node-flag-inventory.mjs
+      - scripts/check-node-flag-drift.mjs
+      - scripts/node-flag-inventory.snapshot.json
+      - crates/nub-core/src/node/feature_matrix.rs
+      - .github/workflows/node-flag-drift.yml
+  schedule:
+    # Daily at 06:30 UTC — offset off the hour to dodge cron pile-ups.
+    - cron: "30 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: node-flag-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Deterministic per-PR check: regenerate the inventory on the EXACT Node the snapshot
+  # was captured on and assert byte-identity. Skipped on the nightly schedule.
+  snapshot-check:
+    if: github.event_name != 'schedule'
+    name: Snapshot matches pinned Node
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: Read pinned Node version from the snapshot
+        id: pin
+        run: |
+          set -euo pipefail
+          ver=$(node -e 'process.stdout.write(require("./scripts/node-flag-inventory.snapshot.json").nodeVersion.replace(/^v/,""))')
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          echo "Snapshot pins Node $ver"
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: ${{ steps.pin.outputs.version }}
+      - name: Check snapshot is in sync with pinned Node
+        run: node scripts/check-node-flag-drift.mjs --snapshot scripts/node-flag-inventory.snapshot.json
+
+  # Early-warning against Node's pre-release lines. Downloads the latest nightly (and RC,
+  # when one is published) straight from nodejs.org and diffs its flag set vs the snapshot.
+  nightly-drift:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: Drift vs ${{ matrix.channel }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [nightly, rc]
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: Install latest ${{ matrix.channel }} Node
+        id: node
+        run: |
+          set -euo pipefail
+          base="https://nodejs.org/download/${{ matrix.channel }}"
+          # index.json is newest-first; [0].version is the latest build on the channel.
+          ver=$(curl -fsSL "$base/index.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const a=JSON.parse(s);process.stdout.write(a.length?a[0].version:"")})')
+          if [ -z "$ver" ]; then
+            echo "no $ver build published on the ${{ matrix.channel }} channel right now — skipping"
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Latest ${{ matrix.channel }}: $ver"
+          dest="$RUNNER_TEMP/node-${ver}"
+          curl -fsSL "$base/${ver}/node-${ver}-linux-x64.tar.xz" | tar -xJ -C "$RUNNER_TEMP"
+          echo "bin=$RUNNER_TEMP/node-${ver}-linux-x64/bin" >> "$GITHUB_OUTPUT"
+          echo "present=true" >> "$GITHUB_OUTPUT"
+      - name: Diff ${{ matrix.channel }} flag set vs snapshot
+        if: steps.node.outputs.present == 'true'
+        run: |
+          set -euo pipefail
+          export PATH="${{ steps.node.outputs.bin }}:$PATH"
+          node --version
+          node scripts/check-node-flag-drift.mjs --snapshot scripts/node-flag-inventory.snapshot.json

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -552,11 +552,16 @@ fn project_js_decorator_routes_to_transform() {
 fn js_parent_no_extensionless_probe() {
     // Contract: a non-TS (`.js`) parent does NOT get nub's TS-parent extensionless
     // probing, so `import "./nonexistent"` from a `.js` fails. The EXACT failure is
-    // Node-version-specific (not nub's): with detect-module (default on Node 22+)
-    // the `.js` is treated as ESM and the missing specifier surfaces as
-    // ERR_MODULE_NOT_FOUND; below that the `.js` is CommonJS, so the `import`
-    // keyword itself is a SyntaxError before any resolution. Either way nub didn't
-    // probe — assert the contract (it fails) with the version-appropriate error.
+    // module-syntax-detection-specific: when detection is active the `.js` is treated as
+    // ESM and the missing specifier surfaces as ERR_MODULE_NOT_FOUND ("Cannot find
+    // module"); otherwise the `.js` is CommonJS, so the `import` keyword itself is a
+    // SyntaxError before any resolution. Detection is native default-on from Node
+    // 20.19 / 22.7, and nub's feature matrix ALSO injects `--experimental-detect-module`
+    // on the bands below that (20.10–20.18, 21.1–22.6), so under nub the ESM path applies
+    // from Node 20.10 up. The coarse `>=22` split below picks the ESM assertion for the
+    // native-default range; the below-22 in-band legs (e.g. host Node 20.11) land in the
+    // `else` and match ERR_MODULE_NOT_FOUND via its `|| "Cannot find"` clause. Either way
+    // nub didn't probe — assert the contract (it fails) with the version-appropriate error.
     let (_stdout, stderr, code) = run_nub("vanilla-ts", "js-no-probe.js");
     assert_ne!(code, 0, ".js importing extensionless should fail: {stderr}");
     if node_at_least((22, 0, 0)) {

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -515,3 +515,52 @@ fn force_async_tier_signal_gated_on_broken_band_and_foreign_loader() {
         eprintln!("skipping: Node 26.2.0 not installed (fixed-band representative)");
     }
 }
+
+/// Module syntax detection — the `--experimental-detect-module` matrix bands
+/// [20.10.0, 20.19.0) ∪ [21.1.0, 22.7.0). Node 20.11.0 carries the flag but does not
+/// default it on (that came at 20.19), so an ambiguous ESM `.js` — ES-module syntax, a
+/// `package.json` with no `"type"` field — that bare Node 20.11 refuses ("To load an ES
+/// module, set type: module", exit 1) runs as ESM under nub, which injects the flag from
+/// the matrix band. This is the in-band, still-required case; a default-on Node needs no
+/// injection.
+#[test]
+fn detect_module_ambiguous_esm_runs_as_esm_on_compat_tier() {
+    let Some((stdout, stderr, code)) = run_nub_against_node((20, 11, 0), "detect-module", "amb.js")
+    else {
+        eprintln!(
+            "skipping: Node 20.11.0 not installed (set TEST_NODE_BIN_20_11_0 or nvm install)"
+        );
+        return;
+    };
+    assert_eq!(
+        code, 0,
+        "compat-tier ambiguous ESM .js must run as ESM under nub (bare Node 20.11 refuses it): stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("detect-module:ran-as-esm:true"),
+        "ambiguous .js must be detected and run as an ES module: stdout={stdout:?}"
+    );
+}
+
+/// The node:ffi (26.1+), node:vfs (26.4+), and node:stream/iter (25.9+) enabler bands.
+/// Each module is flag-gated and default-off — bare Node throws
+/// ERR_UNKNOWN_BUILTIN_MODULE on import — so nub injecting the three `--experimental-*`
+/// flags from the matrix is exactly what makes them importable. Run on Node 26.5.0, which
+/// carries all three; the fixture imports each and the markers all read true.
+#[test]
+fn module_enabler_flags_make_ffi_vfs_stream_iter_importable() {
+    let Some((stdout, stderr, code)) =
+        run_nub_against_node((26, 5, 0), "module-enablers", "enablers.mjs")
+    else {
+        eprintln!("skipping: Node 26.5.0 not installed (set TEST_NODE_BIN_26_5_0 or nvm install)");
+        return;
+    };
+    assert_eq!(
+        code, 0,
+        "node:ffi/vfs/stream-iter must import under nub (bare Node rejects them default-off): stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("module-enablers:true,true,true"),
+        "all three enabler modules must load once nub injects their flags: stdout={stdout:?}"
+    );
+}

--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -289,6 +289,80 @@ pub static FEATURES: &[Feature] = &[
         )],
         evidence: "flag added Node 26.5.0 (#62300); still flag-gated through Node 27 nightly; nub loader-polyfills below via runtime/transform-core.mjs loadTextImport",
     },
+    // ── Module syntax detection (ambiguous ESM `.js`) ────────────────────────
+    // `--experimental-detect-module` makes Node parse an ambiguous file — ES-module
+    // syntax, a `.js` extension, and a `package.json` with no `"type"` field — and run it
+    // as ESM when module syntax is found. Bare Node below the default-on cutover refuses
+    // such a file ("To load an ES module, set type: module", exit 1). Introduced on the
+    // 21.x line at 21.1.0 (#50096) and backported to the 20.x LTS line at 20.10.0; the
+    // 21.0.0 release predates the flag, so injecting it there is a "bad option" startup
+    // abort (the same EOL-line hole as eventsource). It became default-on (flag →
+    // default-true, no longer required) at 20.19.0 on the 20.x line and 22.7.0 on the 22.x
+    // line (#53619, "unflag detect-module"). Inject only where the flag both EXISTS and is
+    // still REQUIRED: [20.10.0, 20.19.0) ∪ [21.1.0, 22.7.0). Empirically confirmed —
+    // 20.18.0 needs the flag, 20.19.0 detects by default, 21.0.0 rejects the flag, 21.1.0
+    // needs it, 22.7.0 detects by default.
+    Feature {
+        name: "detect-module",
+        mitigations: &[
+            (
+                band((20, 10, 0), Some((20, 19, 0))),
+                Mitigation::Unflag("--experimental-detect-module"),
+            ),
+            (
+                band((21, 1, 0), Some((22, 7, 0))),
+                Mitigation::Unflag("--experimental-detect-module"),
+            ),
+        ],
+        evidence: "intro 21.1.0 (#50096), backported 20.10.0; default-on 20.19.0 & 22.7.0 (#53619); flag absent on 21.0.0",
+    },
+    // ── node:ffi (foreign function interface) ────────────────────────────────
+    // `--experimental-ffi` gates the `node:ffi` module (loading dynamic libraries and
+    // calling native symbols). Added on the 26.x line at 26.1.0 (#62072); the flag does
+    // not exist on 26.0.0 or below, where injecting it is a "bad option" startup abort.
+    // Snapshot-neutral (a module gate, not a V8 harmony flag — unlike ShadowRealm above),
+    // so it is safe to auto-unflag; enabling the flag only makes the module importable,
+    // and node:ffi is unsafe solely if user code actively misuses it. Stability 1.0 and
+    // still flag-gated (default-off — `import('node:ffi')` throws
+    // ERR_UNKNOWN_BUILTIN_MODULE without the flag) through Node 26.5 / 27 nightly, so this
+    // open-ended band injects it on [26.1.0, ∞). (node:ffi additionally wants --allow-ffi
+    // under the Permission Model; nub does not inject permission flags.)
+    Feature {
+        name: "ffi",
+        mitigations: &[(
+            band((26, 1, 0), None),
+            Mitigation::Unflag("--experimental-ffi"),
+        )],
+        evidence: "node:ffi added Node 26.1.0 (#62072); absent 26.0.0; default-off through Node 27 nightly",
+    },
+    // ── node:vfs (virtual file system) ───────────────────────────────────────
+    // `--experimental-vfs` gates the minimal `node:vfs` subsystem. Added on the 26.x line
+    // at 26.4.0 (#63115); absent on 26.3.0 and below (injecting there is a "bad option"
+    // abort). Snapshot-neutral. Still flag-gated (default-off — `import('node:vfs')` throws
+    // ERR_UNKNOWN_BUILTIN_MODULE without the flag) through Node 26.5 / 27 nightly, so this
+    // open-ended band injects it on [26.4.0, ∞).
+    Feature {
+        name: "vfs",
+        mitigations: &[(
+            band((26, 4, 0), None),
+            Mitigation::Unflag("--experimental-vfs"),
+        )],
+        evidence: "node:vfs added Node 26.4.0 (#63115); absent 26.3.0; default-off through Node 27 nightly",
+    },
+    // ── node:stream/iter (async-iterator stream adapters) ────────────────────
+    // `--experimental-stream-iter` gates the `node:stream/iter` module. Added on the 25.x
+    // line at 25.9.0 (#62066); absent on 25.8.x and below (injecting there is a "bad
+    // option" abort). Snapshot-neutral. Still flag-gated (default-off —
+    // `import('node:stream/iter')` throws ERR_UNKNOWN_BUILTIN_MODULE without the flag)
+    // through Node 26.5 / 27 nightly, so this open-ended band injects it on [25.9.0, ∞).
+    Feature {
+        name: "stream-iter",
+        mitigations: &[(
+            band((25, 9, 0), None),
+            Mitigation::Unflag("--experimental-stream-iter"),
+        )],
+        evidence: "node:stream/iter added Node 25.9.0 (#62066); absent 25.8.1; default-off through Node 27 nightly",
+    },
     // ── WebSocket global ────────────────────────────────────────────────────
     // Flag-gated on [20.10.0, 22.0.0) — the global exists on 20.10+ and all of the
     // 21.x line behind `--experimental-websocket`, then becomes default-on at
@@ -812,6 +886,38 @@ mod tests {
         assert!(unflag_flags_for(&v(26, 5, 0)).contains(&it));
         assert!(unflag_flags_for(&v(27, 0, 0)).contains(&it));
         assert_eq!(unflag_floor(it), Some(v(26, 5, 0)));
+        // detect-module: [20.10.0, 20.19.0) ∪ [21.1.0, 22.7.0). Below the backport
+        // floor and at each default-on cutover it is excluded; the 21.0.0 release
+        // predates the flag (injecting it is a "bad option" crash — the eventsource hole).
+        let dm = "--experimental-detect-module";
+        assert!(!unflag_flags_for(&v(20, 9, 0)).contains(&dm));
+        assert!(unflag_flags_for(&v(20, 10, 0)).contains(&dm));
+        assert!(unflag_flags_for(&v(20, 18, 0)).contains(&dm));
+        assert!(!unflag_flags_for(&v(20, 19, 0)).contains(&dm)); // default-on
+        assert!(!unflag_flags_for(&v(21, 0, 0)).contains(&dm)); // flag absent (hole)
+        assert!(unflag_flags_for(&v(21, 1, 0)).contains(&dm));
+        assert!(unflag_flags_for(&v(22, 6, 0)).contains(&dm));
+        assert!(!unflag_flags_for(&v(22, 7, 0)).contains(&dm)); // default-on
+        assert_eq!(unflag_floor(dm), Some(v(20, 10, 0)));
+        // ffi: open-ended [26.1.0, ∞); the flag doesn't exist on 26.0.0.
+        let ffi = "--experimental-ffi";
+        assert!(!unflag_flags_for(&v(26, 0, 0)).contains(&ffi));
+        assert!(unflag_flags_for(&v(26, 1, 0)).contains(&ffi));
+        assert!(unflag_flags_for(&v(26, 5, 0)).contains(&ffi));
+        assert!(unflag_flags_for(&v(27, 0, 0)).contains(&ffi));
+        assert_eq!(unflag_floor(ffi), Some(v(26, 1, 0)));
+        // vfs: open-ended [26.4.0, ∞); the flag doesn't exist on 26.3.0.
+        let vfs = "--experimental-vfs";
+        assert!(!unflag_flags_for(&v(26, 3, 0)).contains(&vfs));
+        assert!(unflag_flags_for(&v(26, 4, 0)).contains(&vfs));
+        assert!(unflag_flags_for(&v(26, 5, 0)).contains(&vfs));
+        assert_eq!(unflag_floor(vfs), Some(v(26, 4, 0)));
+        // stream-iter: open-ended [25.9.0, ∞); the flag doesn't exist on 25.8.x.
+        let si = "--experimental-stream-iter";
+        assert!(!unflag_flags_for(&v(25, 8, 1)).contains(&si));
+        assert!(unflag_flags_for(&v(25, 9, 0)).contains(&si));
+        assert!(unflag_flags_for(&v(26, 5, 0)).contains(&si));
+        assert_eq!(unflag_floor(si), Some(v(25, 9, 0)));
     }
 
     #[test]

--- a/scripts/check-node-flag-drift.mjs
+++ b/scripts/check-node-flag-drift.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Diff the running Node's --experimental-* flag inventory against a committed snapshot,
+// and FAIL LOUDLY on any drift. Two callers, one comparison:
+//
+//   • snapshot-check (per-PR, Node pinned to the snapshot's version) — must be identical;
+//     a diff means the snapshot or the inventory tool was edited wrong. Deterministic.
+//   • nightly-drift (scheduled, Node nightly / RC) — a diff means Node added or removed an
+//     experimental flag since the snapshot; the report tells a human what to vet and,
+//     if it belongs, hand-add to the feature matrix (nub never auto-injects an unvetted flag).
+//
+// Usage:
+//   node scripts/check-node-flag-drift.mjs --snapshot <path>     # compare, exit 1 on drift
+//   node scripts/check-node-flag-drift.mjs --snapshot <path> --update   # rewrite snapshot from this Node
+//
+// The comparison uses the CURRENT `node` (process.execPath) — pick the Node by putting it
+// first on PATH / via setup-node before invoking this. Needs no flags itself; it spawns the
+// inventory tool with --expose-internals.
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const TYPE_NAME = {
+  0: "kNoOp",
+  1: "kV8Option",
+  2: "kBoolean",
+  3: "kInteger",
+  4: "kUInteger",
+  5: "kString",
+  6: "kHostPort",
+  7: "kStringList",
+};
+
+function parseArgs(argv) {
+  let snapshot = null;
+  let update = false;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--snapshot") snapshot = argv[++i];
+    else if (argv[i] === "--update") update = true;
+    else if (argv[i] === "--help" || argv[i] === "-h") {
+      process.stdout.write("usage: check-node-flag-drift.mjs --snapshot <path> [--update]\n");
+      process.exit(0);
+    }
+  }
+  if (!snapshot) {
+    process.stderr.write("check-node-flag-drift: --snapshot <path> is required\n");
+    process.exit(2);
+  }
+  return { snapshot, update };
+}
+
+// Capture THIS Node's inventory by running the inventory tool with --expose-internals.
+function captureCurrentInventory() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const tool = join(here, "node-flag-inventory.mjs");
+  const res = spawnSync(
+    process.execPath,
+    ["--no-warnings", "--expose-internals", tool],
+    { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  );
+  if (res.status !== 0) {
+    process.stderr.write(
+      `check-node-flag-drift: failed to capture inventory on ${process.version}\n` +
+        (res.stderr || "") +
+        "\nThe flag introspection is unavailable on this build — a human must confirm whether\n" +
+        "the internalBinding('options') shape changed and update the tool.\n",
+    );
+    process.exit(2);
+  }
+  return JSON.parse(res.stdout);
+}
+
+const { snapshot: snapshotPath, update } = parseArgs(process.argv.slice(2));
+const current = captureCurrentInventory();
+
+if (update) {
+  writeFileSync(snapshotPath, JSON.stringify(current, null, 2) + "\n");
+  process.stdout.write(
+    `Updated ${snapshotPath} from ${current.nodeVersion} ` +
+      `(${Object.keys(current.flags).length} experimental flags).\n`,
+  );
+  process.exit(0);
+}
+
+let snapshot;
+try {
+  snapshot = JSON.parse(readFileSync(snapshotPath, "utf8"));
+} catch (err) {
+  process.stderr.write(`check-node-flag-drift: cannot read snapshot ${snapshotPath}: ${err?.message ?? err}\n`);
+  process.exit(2);
+}
+
+const shape = ([t, e]) => `${TYPE_NAME[t] ?? t}, env=${e}`;
+const cur = current.flags;
+const snap = snapshot.flags;
+
+const added = Object.keys(cur).filter((k) => !(k in snap)).sort();
+const removed = Object.keys(snap).filter((k) => !(k in cur)).sort();
+const changed = Object.keys(cur)
+  .filter((k) => k in snap && (cur[k][0] !== snap[k][0] || cur[k][1] !== snap[k][1]))
+  .sort();
+
+if (added.length === 0 && removed.length === 0 && changed.length === 0) {
+  process.stdout.write(
+    `No flag drift. ${current.nodeVersion} matches the snapshot ` +
+      `(${snapshot.nodeVersion}, ${Object.keys(snap).length} experimental flags).\n`,
+  );
+  process.exit(0);
+}
+
+// Drift → loud, actionable report on stderr, non-zero exit.
+const lines = [
+  "EXPERIMENTAL-FLAG DRIFT DETECTED",
+  `  snapshot: ${snapshot.nodeVersion} (${snapshotPath})`,
+  `  current:  ${current.nodeVersion}`,
+  "",
+];
+for (const k of added) lines.push(`  + ADDED    ${k}  [${shape(cur[k])}]`);
+for (const k of removed) lines.push(`  - REMOVED  ${k}  [was ${shape(snap[k])}]`);
+for (const k of changed) lines.push(`  ~ CHANGED  ${k}  [${shape(snap[k])} -> ${shape(cur[k])}]`);
+lines.push(
+  "",
+  "An ADDED flag is a new experimental Node capability — vet it and, if nub should enable",
+  "it, hand-add a band to crates/nub-core/src/node/feature_matrix.rs. A REMOVED flag that",
+  "the matrix still injects would crash on this Node — tighten its band. Once vetted,",
+  "refresh the snapshot: node scripts/check-node-flag-drift.mjs --snapshot " + snapshotPath + " --update",
+  "",
+);
+process.stderr.write(lines.join("\n") + "\n");
+process.exit(1);

--- a/scripts/node-flag-inventory.mjs
+++ b/scripts/node-flag-inventory.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Dump the running Node's --experimental-* CLI-flag inventory as deterministic JSON.
+// Each flag maps to [OptionType, envVarSettings], read from Node's own option table via
+// internalBinding('options') — the same introspection Node's parser uses, so it is the
+// ground truth for "does this binary accept this flag, and how".
+//
+// MUST be invoked with --expose-internals (internal/test/binding is otherwise unreachable):
+//   node --no-warnings --expose-internals scripts/node-flag-inventory.mjs
+//
+// This is the capture half of the flag-drift guard (scripts/check-node-flag-drift.mjs
+// diffs a fresh capture against the committed snapshot). It is BUILD/CI tooling only —
+// nub's runtime never probes a Node; the feature matrix is hand-vetted (see
+// crates/nub-core/src/node/feature_matrix.rs).
+import { createRequire } from "node:module";
+
+// OptionType (src/node_options.h). Only kNoOp/kBoolean flags are bare (value-less);
+// the rest take a value. Recorded so a human vetting a drift sees the shape at a glance.
+const OPTION_TYPE = {
+  0: "kNoOp",
+  1: "kV8Option",
+  2: "kBoolean",
+  3: "kInteger",
+  4: "kUInteger",
+  5: "kString",
+  6: "kHostPort",
+  7: "kStringList",
+};
+// envVarSettings: whether the flag is legal inside NODE_OPTIONS.
+const ENV_VAR_SETTINGS = { 0: "kAllowedInEnvvar", 1: "kDisallowedInEnvvar" };
+
+function readInventory() {
+  const require = createRequire(import.meta.url);
+  const { internalBinding } = require("internal/test/binding");
+  const options = internalBinding("options");
+  // Accessor name drifted across releases: getCLIOptionsInfo() is the newer shape,
+  // getCLIOptions() the older one. Both return { options: Map, aliases: Map }.
+  const info = options.getCLIOptionsInfo
+    ? options.getCLIOptionsInfo()
+    : options.getCLIOptions();
+  const flags = {};
+  for (const [name, meta] of info.options) {
+    if (
+      typeof name === "string" &&
+      name.startsWith("--experimental-") &&
+      typeof meta.type === "number" &&
+      typeof meta.envVarSettings === "number"
+    ) {
+      flags[name] = [meta.type, meta.envVarSettings];
+    }
+  }
+  return flags;
+}
+
+let flags;
+try {
+  flags = readInventory();
+} catch (err) {
+  process.stderr.write(
+    `node-flag-inventory: introspection unavailable on ${process.version} ` +
+      `(need --expose-internals; internalBinding('options') threw): ${err?.message ?? err}\n`,
+  );
+  process.exit(2);
+}
+
+// Sort keys so the serialized inventory is byte-stable across runs and platforms —
+// the whole diff depends on this being deterministic.
+const sorted = Object.fromEntries(Object.keys(flags).sort().map((k) => [k, flags[k]]));
+const out = {
+  nodeVersion: process.version,
+  optionTypeLegend: OPTION_TYPE,
+  envVarSettingsLegend: ENV_VAR_SETTINGS,
+  flags: sorted,
+};
+process.stdout.write(JSON.stringify(out, null, 2) + "\n");

--- a/scripts/node-flag-inventory.snapshot.json
+++ b/scripts/node-flag-inventory.snapshot.json
@@ -1,0 +1,187 @@
+{
+  "nodeVersion": "v26.5.0",
+  "optionTypeLegend": {
+    "0": "kNoOp",
+    "1": "kV8Option",
+    "2": "kBoolean",
+    "3": "kInteger",
+    "4": "kUInteger",
+    "5": "kString",
+    "6": "kHostPort",
+    "7": "kStringList"
+  },
+  "envVarSettingsLegend": {
+    "0": "kAllowedInEnvvar",
+    "1": "kDisallowedInEnvvar"
+  },
+  "flags": {
+    "--experimental-abortcontroller": [
+      0,
+      0
+    ],
+    "--experimental-addon-modules": [
+      2,
+      0
+    ],
+    "--experimental-config-file": [
+      5,
+      1
+    ],
+    "--experimental-detect-module": [
+      2,
+      0
+    ],
+    "--experimental-eventsource": [
+      2,
+      0
+    ],
+    "--experimental-fetch": [
+      0,
+      0
+    ],
+    "--experimental-ffi": [
+      2,
+      0
+    ],
+    "--experimental-global-customevent": [
+      0,
+      0
+    ],
+    "--experimental-global-navigator": [
+      2,
+      0
+    ],
+    "--experimental-global-webcrypto": [
+      0,
+      0
+    ],
+    "--experimental-import-meta-resolve": [
+      2,
+      0
+    ],
+    "--experimental-import-text": [
+      2,
+      0
+    ],
+    "--experimental-inspector-network-resource": [
+      2,
+      1
+    ],
+    "--experimental-json-modules": [
+      0,
+      0
+    ],
+    "--experimental-loader": [
+      7,
+      0
+    ],
+    "--experimental-modules": [
+      0,
+      0
+    ],
+    "--experimental-network-inspection": [
+      2,
+      1
+    ],
+    "--experimental-package-map": [
+      5,
+      0
+    ],
+    "--experimental-print-required-tla": [
+      2,
+      0
+    ],
+    "--experimental-quic": [
+      0,
+      0
+    ],
+    "--experimental-repl-await": [
+      2,
+      0
+    ],
+    "--experimental-report": [
+      0,
+      0
+    ],
+    "--experimental-require-module": [
+      2,
+      0
+    ],
+    "--experimental-sea-config": [
+      5,
+      1
+    ],
+    "--experimental-shadow-realm": [
+      2,
+      0
+    ],
+    "--experimental-specifier-resolution": [
+      0,
+      0
+    ],
+    "--experimental-sqlite": [
+      2,
+      0
+    ],
+    "--experimental-storage-inspection": [
+      2,
+      1
+    ],
+    "--experimental-stream-iter": [
+      2,
+      0
+    ],
+    "--experimental-test-coverage": [
+      2,
+      1
+    ],
+    "--experimental-test-module-mocks": [
+      2,
+      1
+    ],
+    "--experimental-test-snapshots": [
+      0,
+      1
+    ],
+    "--experimental-test-tag-filter": [
+      7,
+      1
+    ],
+    "--experimental-top-level-await": [
+      0,
+      0
+    ],
+    "--experimental-vfs": [
+      2,
+      0
+    ],
+    "--experimental-vm-modules": [
+      2,
+      0
+    ],
+    "--experimental-wasi-unstable-preview1": [
+      0,
+      0
+    ],
+    "--experimental-wasm-modules": [
+      0,
+      0
+    ],
+    "--experimental-websocket": [
+      2,
+      0
+    ],
+    "--experimental-webstorage": [
+      2,
+      0
+    ],
+    "--experimental-worker": [
+      0,
+      0
+    ],
+    "--experimental-worker-inspection": [
+      2,
+      1
+    ]
+  }
+}

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -102,6 +102,10 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`node:sqlite`](https://nodejs.org/api/sqlite.html) | Node 22.5 | unflagged below Node 22.13, native above |
 | [`addon imports`](https://nodejs.org/api/esm.html#node-addons) | Node 22.20 | unflagged, never native |
 | [`text imports`](https://nodejs.org/api/esm.html#import-attributes) | Node 18.20 | polyfilled below Node 26.5, native above |
+| [`node:stream/iter`](https://nodejs.org/api/stream.html) | Node 25.9 | unflagged, never native |
+| [`node:ffi`](https://nodejs.org/api/ffi.html) | Node 26.1 | unflagged, never native |
+| [`node:vfs`](https://nodejs.org/api/vfs.html) | Node 26.4 | unflagged, never native |
+| [module syntax detection](https://nodejs.org/api/packages.html#syntax-detection) | Node 20.10 | unflagged below the default-on line, native above |
 
 A dash means the API works across the full supported range, 18.19 and up. The floored rows have a real cutoff, because the underlying Node mechanism doesn't exist below it:
 
@@ -110,6 +114,8 @@ A dash means the API works across the full supported range, 18.19 and up. The fl
 - The `node:sqlite` module needs Node 22.5, where Node first shipped it.
 - Importing a native `.node` addon from an ES module needs Node 22.20 (or 23.6 on the 23 line), where Node added the flag Nub injects. It is never native — Node keeps the import behind the flag — so Nub injects it on every version that has it.
 - Importing a file as text — `import readme from "./README.md" with { type: "text" }` — needs Node 18.20, the first version whose parser accepts the `with` import-attribute syntax. Nub polyfills the feature below Node 26.5, then steps aside to Node's native text imports on 26.5 and up (where it injects the `--experimental-import-text` flag).
+- The `node:ffi` (Node 26.1), `node:vfs` (26.4), and `node:stream/iter` (25.9) modules are experimental and default-off; Node keeps each behind an `--experimental-*` flag, so Nub injects it on every version that has the module, and it never goes native through Node 27 nightly.
+- Module syntax detection runs an ambiguous `.js` — ES-module syntax with no `"type"` in `package.json` — as an ES module. Node hid it behind `--experimental-detect-module` from 20.10 (and 21.1 on the 21 line) until it became default-on at 20.19 and 22.7; Nub injects the flag in that window so the same file runs the same way on every version.
 
 ## Node version resolution
 

--- a/tests/fixtures/detect-module/amb.js
+++ b/tests/fixtures/detect-module/amb.js
@@ -1,0 +1,8 @@
+// Ambiguous module: ES-module syntax, .js extension, and a package.json with
+// NO "type" field — so Node treats it as ambiguous and needs module syntax
+// detection (--experimental-detect-module, injected by nub below the default-on
+// line) to run it as ESM. Bare old Node (< the detect-module default-on cutover)
+// refuses this file.
+import { fileURLToPath } from "node:url";
+const here = fileURLToPath(import.meta.url);
+console.log("detect-module:ran-as-esm:" + here.endsWith("amb.js"));

--- a/tests/fixtures/detect-module/package.json
+++ b/tests/fixtures/detect-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "detect-module-fixture",
+  "private": true
+}

--- a/tests/fixtures/module-enablers/enablers.mjs
+++ b/tests/fixtures/module-enablers/enablers.mjs
@@ -1,0 +1,11 @@
+// node:ffi (Node 26.1+), node:vfs (26.4+), and node:stream/iter (25.9+) are each
+// gated behind an --experimental-* flag and default-off — bare Node throws
+// ERR_UNKNOWN_BUILTIN_MODULE on import. Under nub the feature matrix injects
+// --experimental-{ffi,vfs,stream-iter} for a Node that has them, so all three import.
+// Run this on a Node that carries all three (26.4+); the markers below all read true.
+import * as ffi from "node:ffi";
+import * as vfs from "node:vfs";
+import * as streamIter from "node:stream/iter";
+
+const loaded = (m) => m != null && typeof m === "object";
+console.log("module-enablers:" + [loaded(ffi), loaded(vfs), loaded(streamIter)].join(","));


### PR DESCRIPTION
Two related changes to how nub tracks Node's experimental flags, in one PR.

## Part A — four hand-vetted feature-matrix bands

Adds `Unflag` bands to the Node feature matrix so nub injects each flag on exactly the versions that accept it and still require it. Every floor was pinned empirically (probed `internalBinding('options')` plus a `node:<module>` load test) and corroborated against the Node changelog:

| flag | band | evidence |
|---|---|---|
| `--experimental-detect-module` | `[20.10.0, 20.19.0)` ∪ `[21.1.0, 22.7.0)` | intro 21.1.0 (#50096), backported 20.10.0; default-on 20.19.0 & 22.7.0 (#53619); the 21.0.0 release predates the flag, so the band excludes it — injecting there is a `bad option` crash, the same EOL-line hole as eventsource |
| `--experimental-ffi` (`node:ffi`) | `[26.1.0, ∞)` | added 26.1.0 (#62072); absent 26.0.0 |
| `--experimental-vfs` (`node:vfs`) | `[26.4.0, ∞)` | added 26.4.0 (#63115); absent 26.3.0 |
| `--experimental-stream-iter` (`node:stream/iter`) | `[25.9.0, ∞)` | added 25.9.0 (#62066); absent 25.8.1 |

The three module flags are default-off through Node 27 nightly (each module throws `ERR_UNKNOWN_BUILTIN_MODULE` without its flag), so the bands are open-ended; all four are `kBoolean`/NODE_OPTIONS-legal and snapshot-neutral (module gates, not V8 harmony flags). Band boundaries are covered by the pure-Rust `unflag_set_matches_known_boundaries` unit test. Two `version_tiers` integration tests plus fixtures verify end-to-end that nub injects the flags — an ambiguous ESM `.js` runs as ESM on Node 20.11, and `node:ffi`/`vfs`/`stream-iter` import on Node 26.5 (bare Node rejects all four). CI side-installs 20.11.0 and 26.5.0 so both tests run there.

## Part B — scheduled flag-drift snapshot guard

A CI/build-time guard (no runtime probe — the matrix stays hand-vetted) that warns when Node changes its `--experimental-*` flag set:

- `scripts/node-flag-inventory.mjs` dumps the running Node's experimental-flag set (`name → [OptionType, envVarSettings]`) via `internalBinding('options')`.
- `scripts/check-node-flag-drift.mjs` diffs a fresh capture against the committed snapshot and lists added/removed/changed flags.
- `scripts/node-flag-inventory.snapshot.json` pins Node 26.5.0 (42 flags).
- `.github/workflows/node-flag-drift.yml` runs a deterministic per-PR `snapshot-check` (Node pinned to the snapshot version, must match) and a scheduled `nightly-drift` job over Node nightly and RC. The nightly job fails loudly with the added/removed flags so a new experimental flag is vetted — and hand-added to the matrix if nub should support it — before nub ever claims it.

Verified against real Node 26.2/26.5 and a live Node 27 nightly: the nightly check correctly flags `--experimental-dtls` (new in 27) as drift to vet, and the introspection accessor still works on nightly.

## Verification

All floors probed on real binaries across Node 18.19–27-nightly. Gates green locally: `unflag_set_matches_known_boundaries` and the full `feature_matrix`/`version_tiers`/`node::` suites pass; `clippy --all-targets --all-features -- -D warnings` clean; `fmt --check` clean on both the default and 1.97.0 toolchains. Two fresh-context reviews (correctness, impact-analysis) folded in.
