### PR TITLE
sandbox: close two baseline secret-leak holes (build-jail .env, npm_config_* creds)

### DIFF
--- a/crates/nub-sandbox/src/compiler/defaults.rs
+++ b/crates/nub-sandbox/src/compiler/defaults.rs
@@ -219,20 +219,56 @@ const BASELINE_ENV_PREFIXES: &[&str] = &["LC_", "npm_config_"];
 /// CREDENTIALS (must never reach sandboxed code). See [`is_npm_config_credential`].
 const NPM_CONFIG_PREFIX: &str = "npm_config_";
 
-/// Whether an `npm_config_*` key (given the part AFTER the `npm_config_` prefix) is
-/// a registry CREDENTIAL rather than a build hint. Grounds .fray/sandbox.md thread
-/// #6: registry auth never rides the lifecycle env — env-scrub's whole point for the
-/// credential class. Covers the bare legacy keys (`_auth`, `_authToken`, `_password`,
-/// `email`) AND the registry-scoped `//host/:_auth…`/`:_password`/`:email` forms.
-/// `_auth`/`_password` carry a leading underscore, so as substrings they can't hit a
-/// build hint (`_author`/`always-auth` are not build hints, and no hint embeds
-/// `_auth`/`_password`). `email` has no such anchor, so it is matched ONLY as the
-/// whole key or a registry-scoped `:email` suffix — otherwise it would wrongly scrub
-/// a hint like `npm_config_nodemailer_binary_host_mirror`. Kept build hints
+/// Unambiguous credential words in an `npm_config_*` key — long/specific enough that
+/// a case-insensitive SUBSTRING hit has no realistic collision with a node-gyp /
+/// node-pre-gyp build hint (none of which embed these). Mirrors the env-name
+/// [`SECRET_SUBSTR_TOKENS`] discipline, scoped to the registry-credential family.
+const NPM_CRED_SUBSTR_TOKENS: &[&str] = &[
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+    "apikey",
+];
+
+/// Short/ambiguous credential words matched ONLY as a whole `_`/`-`/`.` segment, so
+/// `npm_config_key` (npm's inline registry client SSL key) and `npm_config_api_key`
+/// scrub while a package binary-host hint whose name merely contains the letters
+/// (`npm_config_keytar_binary_host_mirror`, `..._monkey_...`) is spared. `auth` is
+/// deliberately NOT here — it stays the anchored `_auth` test below so `always-auth` /
+/// `_author` are not swept.
+const NPM_CRED_SEGMENT_TOKENS: &[&str] = &["key"];
+
+/// Whether an `npm_config_*` key (given the part AFTER the `npm_config_` prefix) is a
+/// registry CREDENTIAL rather than a build hint — such keys must never reach sandboxed
+/// lifecycle code (.fray/sandbox.md thread #6: registry auth never rides the lifecycle
+/// env). Three tiers, all case-insensitive + delimiter-aware. First, the anchored legacy
+/// markers: `_auth*` (the leading `_` spares `always-auth` / `_author`) and `email` as the
+/// whole key or a registry-scoped `:email` suffix (an unanchored `email` would wrongly
+/// scrub `npm_config_nodemailer_binary_host_mirror`). Then the unambiguous credential
+/// words ([`NPM_CRED_SUBSTR_TOKENS`]) anywhere in the key — catching `password` /
+/// `_authToken` / scoped `//host/:_password` and the undelimited `foo_token` / `my_secret`
+/// forms an exact-segment rule would miss. Finally the short `key` family as a whole
+/// segment ([`NPM_CRED_SEGMENT_TOKENS`]). Kept build hints
 /// (`target`/`arch`/`runtime`/`nodedir`/`python`/`*_binary_host_mirror`/…) match none.
+/// Best-effort per §8: the rare native package literally named after a credential word
+/// loses its binary-host MIRROR hint (falling back to the default host), acceptable next
+/// to leaking a token.
 fn is_npm_config_credential(remainder: &str) -> bool {
     let r = remainder.to_ascii_lowercase();
-    r.contains("_auth") || r.contains("_password") || r == "email" || r.ends_with(":email")
+    if r.contains("_auth") || r == "email" || r.ends_with(":email") {
+        return true;
+    }
+    if NPM_CRED_SUBSTR_TOKENS
+        .iter()
+        .any(|w| word_in_substr(w, remainder))
+    {
+        return true;
+    }
+    NPM_CRED_SEGMENT_TOKENS
+        .iter()
+        .any(|w| word_is_segment(w, remainder))
 }
 
 /// Build the curated-baseline child env from the ambient env (the `sandbox: true`
@@ -352,39 +388,29 @@ mod tests {
         // The `npm_config_*` family passes build hints through, but registry auth
         // rides the same prefix and must be scrubbed — thread #6. Both the bare
         // legacy keys and the registry-scoped `//host/:_auth…` forms are excluded.
-        let ambient: BTreeMap<String, String> = [
-            ("npm_config_target", "22.0.0"),
-            ("npm_config_arch", "arm64"),
-            ("npm_config_runtime", "node"),
-            ("npm_config_registry", "https://registry.npmjs.org/"),
-            // A build hint whose package name embeds "email" — must NOT be scrubbed by
-            // the anchored `email` marker (regression guard for the unanchored form).
-            ("npm_config_nodemailer_binary_host_mirror", "https://x/"),
-            ("npm_config__auth", "aGVsbG86d29ybGQ="),
-            ("npm_config__authToken", "npm_LEAK"),
-            ("npm_config__password", "hunter2"),
-            ("npm_config_email", "me@example.com"),
-            (
-                "npm_config_//registry.npmjs.org/:_authToken",
-                "SECRET_TOKEN",
-            ),
-            ("npm_config_//registry.npmjs.org/:_password", "SECRET_PW"),
-            ("npm_config_//registry.npmjs.org/:_auth", "SECRET_BASIC"),
-        ]
-        .iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
-        .collect();
-        let out = curated_baseline_env(&ambient);
-        for k in [
+        // Build hints (kept) — incl. two regression guards for false positives: a
+        // package whose name embeds "email" (`nodemailer`) must survive the anchored
+        // `email` marker, and a package whose name embeds "key" (`keytar`) must survive
+        // the whole-SEGMENT `key` rule. `always-auth` is `-auth`, not `_auth` — kept.
+        let hints = [
             "npm_config_target",
             "npm_config_arch",
+            "npm_config_target_arch",
             "npm_config_runtime",
+            "npm_config_nodedir",
+            "npm_config_python",
+            "npm_config_build_from_source",
             "npm_config_registry",
+            "npm_config_sharp_binary_host",
             "npm_config_nodemailer_binary_host_mirror",
-        ] {
-            assert!(out.contains_key(k), "build hint {k} must pass");
-        }
-        for k in [
+            "npm_config_keytar_binary_host_mirror",
+            "npm_config_always-auth",
+        ];
+        // Credentials (scrubbed) — the anchored legacy markers, the broadened
+        // credential-word set (token/secret/password/passwd/credential/apikey), and
+        // the short `key` family as a delimited segment. Covers undelimited, hyphen,
+        // and dot forms an exact-segment rule would miss.
+        let creds = [
             "npm_config__auth",
             "npm_config__authToken",
             "npm_config__password",
@@ -392,7 +418,29 @@ mod tests {
             "npm_config_//registry.npmjs.org/:_authToken",
             "npm_config_//registry.npmjs.org/:_password",
             "npm_config_//registry.npmjs.org/:_auth",
-        ] {
+            "npm_config_password",
+            "npm_config_passwd",
+            "npm_config_foo_token",
+            "npm_config_authtoken",
+            "npm_config_my_secret",
+            "npm_config_credential",
+            "npm_config_apikey",
+            "npm_config_api_key",
+            "npm_config_signing_key",
+            "npm_config_key",
+            "npm_config_my-token",
+            "npm_config_x.secret.y",
+        ];
+        let ambient: BTreeMap<String, String> = hints
+            .iter()
+            .chain(creds.iter())
+            .map(|k| (k.to_string(), "v".to_string()))
+            .collect();
+        let out = curated_baseline_env(&ambient);
+        for k in hints {
+            assert!(out.contains_key(k), "build hint {k} must pass");
+        }
+        for k in creds {
             assert!(!out.contains_key(k), "credential {k} must be scrubbed");
         }
     }

--- a/crates/nub-sandbox/src/compiler/mod.rs
+++ b/crates/nub-sandbox/src/compiler/mod.rs
@@ -203,7 +203,11 @@ pub(crate) fn compile_scope(
         Value::String(s) => match classify_string(s) {
             StringKind::Preset => {
                 let expanded = preset::resolve(s)?;
-                compile_object(&expanded, parent, ctx, warnings)
+                let mut policy = compile_object(&expanded, parent, ctx, warnings)?;
+                // A preset's broad grants (build-jail's `"./"`) re-open the built-in
+                // secret floor under last-match-wins; re-assert it post-fold.
+                preset::reassert_secret_floor(s, &mut policy, ctx);
+                Ok(policy)
             }
             StringKind::FileRef => Err(CompileError::FileRefUnresolved {
                 path: String::new(),

--- a/crates/nub-sandbox/src/compiler/preset.rs
+++ b/crates/nub-sandbox/src/compiler/preset.rs
@@ -6,7 +6,8 @@
 //! A preset expands to the equivalent granular surface `Value`, which the pipeline
 //! then folds — one code path, no separate preset→IR translator to keep in sync.
 
-use super::CompileError;
+use super::{CompileCtx, CompileError, defaults};
+use crate::policy::SandboxPolicy;
 use serde_json::{Value, json};
 
 /// Resolve a preset name to its granular surface object. `"build-jail"` is the
@@ -15,6 +16,29 @@ pub fn resolve(name: &str) -> Result<Value, CompileError> {
     match name {
         "build-jail" => Ok(build_jail()),
         other => Err(CompileError::unknown_preset(other, &["build-jail"])),
+    }
+}
+
+/// Re-assert a preset's built-in secret floor AFTER its surface object has folded,
+/// closing the last-match-wins hole a broad subtree grant opens.
+///
+/// build-jail's fs (`["...", "./"]`) folds to `[generous-read, <secret denies>,
+/// <project rw>]`; the `"./"` grant re-allows EVERY path under the project —
+/// `<proj>/.env` included — because it is the last matching entry, silently
+/// re-exposing the project's own secrets to the untrusted lifecycle script this jail
+/// exists to confine. Re-appending the built-in secret denies makes them the last
+/// match again, so the floor holds. Reuses the SAME [`defaults::secret_read_denies`]
+/// set the leading `"..."` spliced (identical matchers + Deny/Read access), so the
+/// floor is byte-consistent across the policy rather than a project-anchored
+/// re-derivation — surface `!`-entries would anchor the depth-independent `**/.env`
+/// globs to the project and carry ReadWrite access, a divergence.
+pub fn reassert_secret_floor(name: &str, policy: &mut SandboxPolicy, ctx: &CompileCtx) {
+    if name == "build-jail" {
+        policy
+            .fs
+            .rules
+            .entries
+            .extend(defaults::secret_read_denies(&ctx.homes));
     }
 }
 
@@ -29,7 +53,10 @@ pub fn resolve(name: &str) -> Result<Value, CompileError> {
 /// simple + project-relative so it is meaningful in the frontend-less engine.
 fn build_jail() -> Value {
     json!({
-        // generous read minus secrets (`"..."`), plus the project subtree rw.
+        // generous read minus secrets (`"..."`), plus the project subtree rw. The
+        // `"./"` grant re-opens the secret floor for the project subtree under
+        // last-match-wins; `reassert_secret_floor` re-appends the secret denies
+        // post-fold to close it (it can't be expressed faithfully in surface form).
         "fs": ["...", "./"],
         // deny all egress (the build-jail thread adds prefetch + grants).
         "net": false,

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -232,13 +232,31 @@ fn build_jail_preset_expands() {
         p.env.enforce && p.env.constructed.is_empty(),
         "build-jail strips env"
     );
-    // project subtree is writable, secret set still denied.
+    // The project subtree is writable...
     let m = nub_sandbox::matcher::PathMatcher::new(&p.fs.rules);
     let proj = common::homes().project;
     let d = m.decide(&proj.join("build/out.o"));
     assert!(
         matches!(d.effect, Effect::Allow)
             && matches!(d.access, nub_sandbox::policy::FsAccess::ReadWrite)
+    );
+    // ...but the secret set stays DENIED even though `"./"` grants the whole subtree.
+    // The `"./"` grant is the LAST matching entry for `<proj>/.env`, so without the
+    // post-fold secret-floor re-assertion the jail would leak the project's own
+    // `.env` to the untrusted lifecycle script it exists to confine. Guard the leaf,
+    // a nested `.env`, the `.env` DIRECTORY form, and an outside-project secret.
+    for secret in [".env", "packages/app/.env", ".env/keys.txt", ".envrc"] {
+        assert!(
+            matches!(m.decide(&proj.join(secret)).effect, Effect::Deny),
+            "build-jail must deny <proj>/{secret}"
+        );
+    }
+    assert!(
+        matches!(
+            m.decide(&common::homes().home.join(".ssh/id_rsa")).effect,
+            Effect::Deny
+        ),
+        "build-jail must deny the home secret set"
     );
 }
 


### PR DESCRIPTION
Two pre-existing baseline secret-handling holes, surfaced by U1's adversarial review.

**build-jail leaked `<proj>/.env` (HIGH).** build-jail's `["...", "./"]` folds so the trailing `"./"` grant re-allows `.env` as the last match. `reassert_secret_floor` re-appends the built-in secret denies post-fold.

**`npm_config_*` creds survived the curated env baseline (MED).** `is_npm_config_credential` broadened to delimiter-aware, case-insensitive (`token`/`secret`/`password`/`passwd`/`credential`/`apikey` substrings, `key` whole-segment). Build hints pass; `keytar`/`nodemailer`/`always-auth` guarded.

Verified on macOS Seatbelt + IR coverage. Gates green. Public API unchanged.