### PR TITLE
sandbox(windows): file-only program grant (close neighbor-read leak) + enforcement red-team probes

### DIFF
--- a/crates/nub-sandbox/Cargo.toml
+++ b/crates/nub-sandbox/Cargo.toml
@@ -70,7 +70,7 @@ tempfile = "3"
 # needs a little FFI (token-query + process-liveness) beyond what the lib exposes.
 [target.'cfg(target_os = "windows")'.dev-dependencies.windows-sys]
 version = "0.61"
-features = ["Win32_Foundation", "Win32_Security", "Win32_System_Threading"]
+features = ["Win32_Foundation", "Win32_Security", "Win32_System_Threading", "Win32_System_Diagnostics_Debug", "Win32_System_Pipes", "Win32_Storage_FileSystem"]
 
 # The Windows enforcement probe self-reexecs as the AppContainer child, so it owns
 # `main` (dispatch on argv) rather than the libtest harness. windows-latest CI only; a
@@ -81,3 +81,11 @@ harness = false
 
 [lints]
 workspace = true
+
+[[test]]
+name = "windows_ascendant_env"
+harness = false
+
+[[test]]
+name = "windows_residuals"
+harness = false

--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -145,8 +145,13 @@ SID — so the open is denied (`ERROR_ACCESS_DENIED`), **independent of integrit
 - **Honest bound:** the `PROCESS_VM_READ`-inclusive `OpenProcess` is proven denied; a
   `PROCESS_QUERY_LIMITED_INFORMATION`-only handle was not separately probed, but it cannot
   read the environment block (that requires `PROCESS_VM_READ`), so it does not reopen the axis.
-- **Code follow-up:** `backend/windows.rs` still emits an `env-read-ascendant` `Degradation`
-  when the scrub withholds something — now stale given this result, pending removal.
+- **VM-reconfirmed (burn box, standard `nub` user, 2026-07):** an AppContainer child's
+  `OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION)` AND `(… | QUERY_LIMITED)` on
+  its same-user parent are BOTH denied `ERROR_ACCESS_DENIED` — independent of the CI run
+  (`tests/windows_ascendant_env.rs`, which mounts the full PEB-walk attack, not just the
+  reporting check).
+- **Code state:** `backend/windows.rs` `apply` emits NO `env-read-ascendant` `Degradation`
+  (the enforcement suite locks that in) — the axis is closed by the OS, not merely reported.
 
 ### macOS toolchain read-confine for a non-system interpreter
 
@@ -160,15 +165,21 @@ paths, it does not probe the host).
   the allow-set. A system interpreter is covered by the essential base and never hits
   this.
 
-### Windows confined work dirs must live under a nub-owned store
+### Windows confined work dirs need a CLEAN-DACL root (not a nub-owned store; not ancestor traverse grants)
 
-A LowBox child does not bypass traverse checking, so every ancestor of a granted leaf
-needs an AC-SID traverse grant. Granting traverse on a shared ancestor like
-`C:\Users\<user>` needs `WRITE_DAC` on it, which non-elevated nub lacks.
+Superseded — a LowBox token retains SeChangeNotifyPrivilege (Bypass Traverse Checking) and
+standard NTFS volumes carry `FILE_DEVICE_ALLOW_APPCONTAINER_TRAVERSAL`, so intermediate-dir
+ACLs are NOT access-checked: a leaf-only AC-SID grant is reachable under an ORDINARY
+`%TEMP%`/profile tree with no ancestor traverse grants and no `C:\`-owned store (VM-verified
+under `%TEMP%`, `tests/windows_enforcement.rs` + `windows_residuals.rs`). nub never needs
+`WRITE_DAC` on a shared ancestor.
 
-- **Where fixed:** confined work dirs must live under a **nub-owned** store root (whose
-  DACL nub controls), so the launcher never needs `WRITE_DAC` on a user/system ancestor.
-  A launcher work-dir-layout contract.
+- **Real launcher contract:** the confined root must carry a CLEAN DACL — no inherited
+  `ALL APPLICATION PACKAGES` allow-ACE. Where a work dir inherits an AAP grant (some
+  `%TEMP%`/profile trees), an ungranted secret UNDER it is readable regardless of the
+  allow-set (the AAP grant satisfies the LowBox check before default-deny). Demonstrated by
+  the `windows_residuals.rs` RT-B probe; the fixtures strip inherited ACEs
+  (`icacls /inheritance:r`) to model the clean root the launcher provides.
 
 ### Untrusted-tier tighten-only layering
 
@@ -204,9 +215,13 @@ Each is documented in code at the site noted; none is silently mis-reported.
   non-standard path is not matched, re-exposing `/proc/<pid>/environ`. Bounded: requires
   the ability to bind-mount procfs (prior privilege/setup) before entering the sandbox.
   Fix: a mount namespace, or broader procfs detection.
-- **Windows program-dir subtree read grant.** The program's parent DIR is auto-granted
-  inheritable read so the LowBox child can load sibling DLLs; a project-local tool's
-  neighboring files (a `.env` next to a binary) become readable. Bounded for the
-  build-jail (the program is the toolchain — e.g. `node.exe` — whose dir holds no user
-  secrets). Fix: the front-end owns the program grant explicitly rather than the engine
-  auto-widening it. (`backend/windows.rs` `apply`.)
+- **Windows program grant is file-only (neighbor-read leak CLOSED).** The engine grants
+  read+execute on the program FILE ITSELF, not its parent dir (traverse-bypass makes the
+  leaf-object ACL sufficient to exec), so a `.env` next to a binary is no longer swept
+  into the allow-set. Mirrors the macOS file-only program grant. VM-verified: the neighbor
+  `.env` is DENIED while the child still execs and reads its granted dirs
+  (`tests/windows_residuals.rs` R1, `tests/windows_enforcement.rs`). Residual launcher
+  contract (identical to the macOS "toolchain read-confine" item above): a program that
+  loads SIBLING DLLs from its own dir needs the front-end to supply that toolchain dir in
+  the read allow-set — the engine no longer auto-widens. A self-contained build-jail
+  toolchain (`node.exe`) needs nothing more. (`backend/windows.rs` `apply`.)

--- a/crates/nub-sandbox/src/backend/windows.rs
+++ b/crates/nub-sandbox/src/backend/windows.rs
@@ -136,8 +136,9 @@ fn derive_grants(fs: &FsPolicy) -> (Vec<PathBuf>, Vec<PathBuf>, FsDegrade) {
 /// of trap the AAP denylist hits), so it cannot be carved and must be reported. The
 /// rule is sound and conservative: a depth-independent glob deny (`**/.env`) shadows
 /// EVERY grant, and a deny whose literal prefix is inside a grant (or vice-versa)
-/// shadows it. Matching is case-insensitive (Windows paths are). Run with the FULL read
-/// set (incl. the program-dir grant), since a deny landing under it is defeated too.
+/// shadows it. Matching is case-insensitive (Windows paths are). Run against the
+/// policy-derived SUBTREE grants only — the caller excludes the program-file grant (a
+/// single leaf with no subtree, an exec necessity), which cannot host a deny "inside" it.
 fn deny_shadows_grant(entries: &[FsRule], read_grants: &[PathBuf]) -> bool {
     if read_grants.is_empty() {
         return false;
@@ -316,23 +317,28 @@ pub(crate) fn apply(
 
     let (read_grants, write_grants, fs_degrade) = derive_grants(&policy.fs);
 
-    // Auto-grant read on the program's own directory so the LowBox child can exec +
-    // load its sibling DLLs (system DLLs live under dirs that already grant ALL
-    // APPLICATION PACKAGES, so those need no grant). Unlike macOS (file-only), a Windows
-    // binary commonly loads sibling DLLs, so the DIR is granted. KNOWN EXPOSURE: this
-    // read-grant is subtree-inheritable, so a project-local program's siblings (a `.env`
-    // next to a tool) become readable — bounded for the build-jail (the program is the
-    // toolchain, e.g. node.exe, whose dir holds no user secrets), but for a general
-    // confined run the FRONT-END should own the program grant explicitly rather than the
-    // engine auto-widening it. Documented follow-up, not silently claimed as full.
+    // The deny-shadow degradation is judged against the POLICY-derived subtree grants
+    // ONLY — captured before the program file is folded in below. The program-file grant
+    // is a single leaf with no subtree and is an exec necessity, so no user data-policy
+    // deny can "land inside" it; including it would spuriously flag `fs-read-deny` whenever
+    // the program merely lives under a deny'd dir.
+    let policy_read_grants = read_grants.clone();
+
+    // Auto-grant read+execute on the program FILE ITSELF (not its parent dir) so the
+    // LowBox child can exec — with traverse-bypass the leaf-object ACL is what gates the
+    // image open, so a file grant suffices. This mirrors the macOS backend's file-only
+    // program grant and CLOSES the neighbor-read leak the old parent-dir grant carried (a
+    // `.env` next to a tool is no longer swept into the allow-set). A build-jail toolchain
+    // (e.g. node.exe) is self-contained and needs nothing more; a program that loads
+    // SIBLING DLLs from its own dir needs the FRONT-END to supply that toolchain dir in
+    // the read allow-set — the exact launcher contract the macOS "toolchain read-confine
+    // for a non-system interpreter" residual defines. The engine no longer auto-widens to
+    // the whole program dir.
     let mut read_grants = read_grants;
     if let Some(prog) = resolve_program(&spec.program, spec.cwd.as_deref())
-        && let Some(parent) = prog.parent()
+        && !read_grants.contains(&prog)
     {
-        let parent = parent.to_path_buf();
-        if !read_grants.contains(&parent) {
-            read_grants.push(parent);
-        }
+        read_grants.push(prog);
     }
 
     // ── degradation (fail-safe-not-silent) ──────────────────────────────────────
@@ -354,10 +360,10 @@ pub(crate) fn apply(
                 .to_string()
         });
     }
-    // A read deny landing inside a granted subtree (incl. the program-dir grant) can't
-    // be carved on Windows — the inheritable read-allow defeats it. Checked with the
-    // FULL read set (after the program dir is folded in).
-    if deny_shadows_grant(&policy.fs.rules.entries, &read_grants) {
+    // A read deny landing inside a granted subtree can't be carved on Windows — the
+    // inheritable read-allow defeats it. Checked against the policy-derived subtree grants
+    // only (the program-file grant is excluded — see `policy_read_grants` above).
+    if deny_shadows_grant(&policy.fs.rules.entries, &policy_read_grants) {
         deg.lost.push("fs-read-deny".to_string());
         reason.get_or_insert_with(|| {
             "a read deny landing inside a granted subtree can't be carved on Windows \

--- a/crates/nub-sandbox/tests/windows_ascendant_env.rs
+++ b/crates/nub-sandbox/tests/windows_ascendant_env.rs
@@ -1,0 +1,390 @@
+//! Windows AppContainer — REAL ascendant-env attack probe (windows-latest CI + VM).
+//!
+//! The module doc + backend claim ascendant-env read is OS-CLOSED: a LowBox child
+//! cannot `OpenProcess(PROCESS_VM_READ)` the parent to read nub's environ. The
+//! enforcement suite only asserts `apply()` does not REPORT the degradation — it never
+//! actually MOUNTS the attack. This probe does: the parent holds a secret in its OWN
+//! (unscrubbed) environ, spawns a scrubbed AppContainer child, and the child tries to
+//! recover the secret by opening the parent for VM read and walking its PEB → env block.
+//!
+//! Exit-code contract (child): 5 = OpenProcess DENIED for every VM-read mask (attack
+//! blocked, OS-closed holds); 0 = secret RECOVERED from the parent env (BREAKOUT);
+//! 3 = a VM-read handle was obtained but the env read failed (PARTIAL — still alarming,
+//! the confinement's OpenProcess denial did not hold); 9 = other error.
+
+#[cfg(not(target_os = "windows"))]
+fn main() {}
+
+#[cfg(target_os = "windows")]
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.get(1).map(String::as_str) == Some("__ascchild__") {
+        std::process::exit(win::child_main(&args[2..]));
+    }
+    match win::run() {
+        Ok(()) => println!("ASCENDANT-ENV PROBE: OS-CLOSED CONFIRMED"),
+        Err(n) => {
+            eprintln!("{n} ASCENDANT-ENV PROBE FAILURE(S)");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod win {
+    use nub_sandbox::policy::{
+        CanonGlob, Effect, EnvPolicy, FsAccess, FsPolicy, FsRule, FsRuleSet, NetPolicy, PidPolicy,
+        SandboxPolicy, TmpMode,
+    };
+    use nub_sandbox::{CommandSpec, apply};
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+
+    const SECRET_VAL: &str = "sk-ascendant-leak-DO-NOT-RECOVER";
+
+    // ── the attacker child ────────────────────────────────────────────────────────
+
+    pub fn child_main(a: &[String]) -> i32 {
+        match a.first().map(String::as_str) {
+            // Sanity role: is a var present in the child's OWN (scrubbed) env?
+            Some("getenv") => match std::env::var(&a[1]) {
+                Ok(_) => 0,
+                Err(_) => 4,
+            },
+            // Otherwise arg0 is the parent pid to attack.
+            Some(pidstr) => match pidstr.parse::<u32>() {
+                Ok(pid) => attack_parent_env(pid),
+                Err(_) => 9,
+            },
+            None => 9,
+        }
+    }
+
+    /// Try every VM-read-capable OpenProcess mask on the parent; if any handle opens,
+    /// walk its PEB to the environment block and scan for the secret.
+    fn attack_parent_env(parent_pid: u32) -> i32 {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_QUERY_LIMITED_INFORMATION,
+            PROCESS_VM_READ,
+        };
+        // Masks an attacker would try, most-capable first. Every one includes VM_READ
+        // (the env block lives in the parent's address space).
+        let masks: [(u32, &str); 2] = [
+            (PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, "VM_READ|QUERY"),
+            (
+                PROCESS_VM_READ | PROCESS_QUERY_LIMITED_INFORMATION,
+                "VM_READ|QUERY_LIMITED",
+            ),
+        ];
+        let mut opened: Option<(isize, &str)> = None;
+        for (mask, name) in masks {
+            // SAFETY: query-only OpenProcess by pid; NULL on denial.
+            let h = unsafe { OpenProcess(mask, 0, parent_pid) };
+            if !h.is_null() {
+                opened = Some((h as isize, name));
+                break;
+            } else {
+                let err = std::io::Error::last_os_error();
+                println!("  OpenProcess({name}) DENIED err={:?}", err.raw_os_error());
+            }
+        }
+        let Some((h_raw, name)) = opened else {
+            // Every VM-read mask denied → the attack cannot even begin. OS-CLOSED.
+            return 5;
+        };
+        println!("  OpenProcess({name}) SUCCEEDED — handle obtained on parent");
+        let h = h_raw as windows_sys::Win32::Foundation::HANDLE;
+        let recovered = read_parent_environment(h);
+        // SAFETY: close the parent handle.
+        unsafe { CloseHandle(h) };
+        match recovered {
+            Some(true) => {
+                println!("  !!! SECRET RECOVERED from parent env block — BREAKOUT");
+                0
+            }
+            Some(false) => {
+                println!("  handle obtained; env block read but secret absent");
+                3
+            }
+            None => {
+                println!("  handle obtained; PEB/env read FAILED");
+                3
+            }
+        }
+    }
+
+    // ntdll's NtQueryInformationProcess — windows-sys gates the typed decl (and the PEB /
+    // RTL_USER_PROCESS_PARAMETERS structs redact the `Environment` field), so link it
+    // raw. ProcessBasicInformation = 0 fills a PROCESS_BASIC_INFORMATION whose second
+    // pointer-sized field (offset 0x8 on x64) is PebBaseAddress.
+    #[link(name = "ntdll")]
+    unsafe extern "system" {
+        fn NtQueryInformationProcess(
+            handle: windows_sys::Win32::Foundation::HANDLE,
+            class: u32,
+            info: *mut std::ffi::c_void,
+            len: u32,
+            ret: *mut u32,
+        ) -> i32;
+    }
+
+    /// Walk the parent PEB → ProcessParameters → Environment (raw x64 offsets, since
+    /// windows-sys redacts the fields) and scan for the secret. Returns Some(true) if
+    /// found, Some(false) if the block read but no secret, None if the chain failed.
+    fn read_parent_environment(h: windows_sys::Win32::Foundation::HANDLE) -> Option<bool> {
+        // x64 struct offsets (stable across modern Windows):
+        //   PROCESS_BASIC_INFORMATION.PebBaseAddress          = 0x08
+        //   PEB.ProcessParameters                             = 0x20
+        //   RTL_USER_PROCESS_PARAMETERS.Environment           = 0x80
+        //   RTL_USER_PROCESS_PARAMETERS.EnvironmentSize       = 0x3F0
+        let mut pbi = [0u8; 0x30];
+        let mut ret_len = 0u32;
+        // SAFETY: NtQueryInformationProcess(ProcessBasicInformation) into a 0x30 buffer.
+        let status = unsafe {
+            NtQueryInformationProcess(h, 0, pbi.as_mut_ptr().cast(), pbi.len() as u32, &mut ret_len)
+        };
+        if status != 0 {
+            return None;
+        }
+        let peb_base = usize::from_le_bytes(pbi[0x8..0x10].try_into().ok()?);
+        if peb_base == 0 {
+            return None;
+        }
+        let params_ptr = read_usize(h, peb_base + 0x20)?;
+        if params_ptr == 0 {
+            return None;
+        }
+        let env_ptr = read_usize(h, params_ptr + 0x80)?;
+        if env_ptr == 0 {
+            return None;
+        }
+        // Best-effort EnvironmentSize; fall back to a fixed 64 KiB window.
+        let env_size = read_usize(h, params_ptr + 0x3F0)
+            .filter(|&n| (2..=(1 << 20)).contains(&n))
+            .unwrap_or(64 * 1024);
+        let mut buf = vec![0u8; env_size];
+        if !read_bytes(h, env_ptr as *const u8, &mut buf) {
+            // A short read still lets us scan what we got.
+            let _ = read_prefix(h, env_ptr as *const u8, &mut buf);
+        }
+        let wide: Vec<u16> = buf
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        let text = String::from_utf16_lossy(&wide);
+        Some(text.contains(SECRET_VAL))
+    }
+
+    fn read_usize(h: windows_sys::Win32::Foundation::HANDLE, addr: usize) -> Option<usize> {
+        let mut b = [0u8; 8];
+        if read_bytes(h, addr as *const u8, &mut b) {
+            Some(usize::from_le_bytes(b))
+        } else {
+            None
+        }
+    }
+
+    /// A tolerant read that accepts a partial transfer (for the env-block window).
+    fn read_prefix(
+        h: windows_sys::Win32::Foundation::HANDLE,
+        addr: *const u8,
+        buf: &mut [u8],
+    ) -> bool {
+        use windows_sys::Win32::System::Diagnostics::Debug::ReadProcessMemory;
+        let mut read = 0usize;
+        let ok = unsafe {
+            ReadProcessMemory(h, addr.cast(), buf.as_mut_ptr().cast(), buf.len(), &mut read)
+        };
+        ok != 0 || read > 0
+    }
+
+    fn read_bytes(h: windows_sys::Win32::Foundation::HANDLE, addr: *const u8, buf: &mut [u8]) -> bool {
+        use windows_sys::Win32::System::Diagnostics::Debug::ReadProcessMemory;
+        let mut read = 0usize;
+        // SAFETY: read `buf.len()` bytes from the target's address space.
+        let ok = unsafe {
+            ReadProcessMemory(
+                h,
+                addr.cast(),
+                buf.as_mut_ptr().cast(),
+                buf.len(),
+                &mut read,
+            )
+        };
+        ok != 0 && read == buf.len()
+    }
+
+    // ── the runner (parent) ───────────────────────────────────────────────────────
+
+    pub fn run() -> Result<(), u32> {
+        use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+        let mut fails = 0u32;
+
+        // Copy this binary somewhere the LowBox child can exec (traverse-bypass on C:);
+        // the CI checkout under D:\a\… is unreadable to a LowBox token.
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("nub-asc-{nonce:x}"));
+        std::fs::create_dir_all(&root).unwrap();
+        secure_root(&root);
+        let child = root.join("child.exe");
+        std::fs::copy(std::env::current_exe().unwrap(), &child).unwrap();
+
+        // The parent HOLDS the secret in its OWN environ (simulating nub holding an
+        // ambient secret at spawn). The child's constructed env WITHHOLDS it (scrub).
+        // SAFETY: single-threaded test main.
+        unsafe { std::env::set_var("NUB_ASC_SECRET", SECRET_VAL) };
+
+        let pid = unsafe { GetCurrentProcessId() };
+
+        // An fs read-confine policy engages the AppContainer; env-scrub withholds the
+        // secret from the child's constructed env.
+        let mut policy = read_confine(&[&root]);
+        policy.env = EnvPolicy {
+            enforce: true,
+            constructed: base_env(),
+            schema: Vec::new(),
+            withheld: vec!["NUB_ASC_SECRET".to_string()],
+        };
+
+        // Sanity: the child's OWN env really is scrubbed — the secret is absent from
+        // the child (exit 4), so the ONLY path to it is reading the PARENT's env.
+        expect(
+            &mut fails,
+            "child's own env is scrubbed (secret withheld)",
+            code(&policy, &child, &["__ascchild__", "getenv", "NUB_ASC_SECRET"]),
+            4,
+        );
+
+        // The attack: child tries to recover the secret from the PARENT's env.
+        let attack = code(&policy, &child, &["__ascchild__", &pid.to_string()]);
+        match attack {
+            5 => println!("PASS ascendant-env OS-CLOSED (OpenProcess VM_READ denied on parent)"),
+            0 => {
+                fails += 1;
+                eprintln!(
+                    "FAIL BREAKOUT: AppContainer child recovered the parent's scrubbed env secret"
+                );
+            }
+            3 => {
+                fails += 1;
+                eprintln!(
+                    "FAIL PARTIAL: child obtained a VM-read handle on the parent (OpenProcess NOT denied)"
+                );
+            }
+            other => {
+                fails += 1;
+                eprintln!("FAIL ascendant-env probe: unexpected child exit {other}");
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+        if fails == 0 { Ok(()) } else { Err(fails) }
+    }
+
+    fn secure_root(root: &Path) {
+        let user = std::env::var("USERNAME").expect("USERNAME set on Windows");
+        let status = std::process::Command::new("icacls")
+            .arg(root)
+            .args(["/inheritance:r", "/grant:r"])
+            .arg(format!("{user}:(OI)(CI)F"))
+            .status()
+            .expect("run icacls");
+        assert!(status.success(), "icacls failed to secure the fixture root");
+    }
+
+    fn code(policy: &SandboxPolicy, program: &Path, args: &[&str]) -> i32 {
+        let spec = CommandSpec::new(program.as_os_str()).args(args.iter().copied());
+        let prepared = match apply(policy, spec) {
+            Ok(p) => p,
+            Err(d) => {
+                eprintln!("  [apply Err] {d:?}");
+                return -100;
+            }
+        };
+        match prepared.status() {
+            Ok(s) => s.code().unwrap_or(-1),
+            Err(e) => {
+                eprintln!("  [status Err] {e} os={:?}", e.raw_os_error());
+                -101
+            }
+        }
+    }
+
+    fn expect(fails: &mut u32, label: &str, got: i32, want: i32) {
+        if got == want {
+            println!("PASS {label} (exit {got})");
+        } else {
+            *fails += 1;
+            eprintln!("FAIL {label}: exit {got}, expected {want}");
+        }
+    }
+
+    fn read_confine(read: &[&Path]) -> SandboxPolicy {
+        let mut entries = Vec::new();
+        for r in read {
+            entries.push(FsRule {
+                matcher: CanonGlob(r.to_string_lossy().replace('\\', "/")),
+                effect: Effect::Allow,
+                access: FsAccess::Read,
+            });
+        }
+        SandboxPolicy {
+            fs: FsPolicy {
+                rules: FsRuleSet {
+                    entries,
+                    default_effect: Effect::Deny,
+                },
+                tmp: TmpMode::Private,
+            },
+            net: NetPolicy::default(),
+            env: EnvPolicy::default(),
+            pid: PidPolicy::default(),
+        }
+    }
+
+    fn base_env() -> BTreeMap<String, String> {
+        let mut m = BTreeMap::new();
+        for k in [
+            "SystemRoot",
+            "SystemDrive",
+            "windir",
+            "ComSpec",
+            "PATHEXT",
+            "Path",
+            "TEMP",
+            "TMP",
+            "USERPROFILE",
+            "HOMEDRIVE",
+            "HOMEPATH",
+            "APPDATA",
+            "LOCALAPPDATA",
+            "ProgramData",
+            "ALLUSERSPROFILE",
+            "ProgramFiles",
+            "ProgramFiles(x86)",
+            "ProgramW6432",
+            "CommonProgramFiles",
+            "PUBLIC",
+            "USERNAME",
+            "USERDOMAIN",
+            "COMPUTERNAME",
+            "NUMBER_OF_PROCESSORS",
+            "PROCESSOR_ARCHITECTURE",
+            "OS",
+            "DriverData",
+        ] {
+            if let Ok(v) = std::env::var(k) {
+                m.insert(k.to_string(), v);
+            }
+        }
+        m
+    }
+
+    // silence unused on non-child paths
+    #[allow(dead_code)]
+    fn _unused(_: PathBuf) {}
+}

--- a/crates/nub-sandbox/tests/windows_residuals.rs
+++ b/crates/nub-sandbox/tests/windows_residuals.rs
@@ -1,0 +1,400 @@
+//! Windows AppContainer — documented-residual verification + constraint-only red-team.
+//!
+//! Empirically confirms each Windows residual is REAL and BOUNDED, and probes novel
+//! breakout vectors the enforcement suite does not cover:
+//!   1. program-dir neighbor read leak (documented): a secret next to the child binary
+//!      is readable because the backend auto-grants the program's PARENT DIR.
+//!   2. reparse (junction) escape from a write-granted dir: a junction inside the
+//!      write-granted tree pointing at an ungranted target — does the AC-SID grant
+//!      follow the reparse to the target (escape) or does the OS check the target ACL?
+//!   3. AAP-inheritance trap (documented): a secret under a dir carrying an inherited
+//!      `ALL APPLICATION PACKAGES` allow-ACE is readable regardless of the allow-set —
+//!      i.e. WHY confined work dirs must live under a nub-cleaned DACL root.
+//!
+//! `harness = false`: `__resid__ <role> <args>` runs as the AppContainer child; any
+//! other invocation runs the cases. Child exit: 0 ok, 5 access-denied, 9 other.
+
+#[cfg(not(target_os = "windows"))]
+fn main() {}
+
+#[cfg(target_os = "windows")]
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.get(1).map(String::as_str) == Some("__resid__") {
+        std::process::exit(win::child_main(&args[2..]));
+    }
+    match win::run() {
+        Ok(()) => println!("ALL WINDOWS RESIDUAL PROBES PASSED"),
+        Err(n) => {
+            eprintln!("{n} WINDOWS RESIDUAL PROBE(S) FAILED");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod win {
+    use nub_sandbox::policy::{
+        CanonGlob, Effect, EnvPolicy, FsAccess, FsPolicy, FsRule, FsRuleSet, NetPolicy, PidPolicy,
+        SandboxPolicy, TmpMode,
+    };
+    use nub_sandbox::{CommandSpec, apply};
+    use std::path::{Path, PathBuf};
+
+    pub fn child_main(a: &[String]) -> i32 {
+        match a.first().map(String::as_str) {
+            Some("read") => match std::fs::read(&a[1]) {
+                Ok(_) => 0,
+                Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => 5,
+                Err(_) => 9,
+            },
+            Some("write") => match std::fs::write(&a[1], b"pwned") {
+                Ok(_) => 0,
+                Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => 5,
+                Err(_) => 9,
+            },
+            // Connect to a parent-created named pipe and try to read the secret it serves
+            // (local-IPC exfil, a namespace distinct from the loopback-TCP path). 0 if the
+            // secret is recovered (EXFIL), 5 if the open is denied, 9 otherwise.
+            Some("pipe") => match std::fs::read(&a[1]) {
+                Ok(b) if b.windows(4).any(|w| w == b"leak") => 0,
+                Ok(_) => 8,
+                Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => 5,
+                Err(_) => 9,
+            },
+            // Attempt to spawn a descendant that BREAKS AWAY from the Job. On a Job
+            // without JOB_OBJECT_LIMIT_BREAKAWAY_OK, CreateProcess fails ACCESS_DENIED
+            // (contained → 5); if it succeeds the breakaway was honored (escape → 0).
+            Some("breakaway") => {
+                use std::os::windows::process::CommandExt;
+                const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x0100_0000;
+                let Ok(exe) = std::env::current_exe() else {
+                    return 9;
+                };
+                match std::process::Command::new(exe)
+                    .args(["__resid__", "sleep"])
+                    .creation_flags(CREATE_BREAKAWAY_FROM_JOB)
+                    .spawn()
+                {
+                    Ok(mut c) => {
+                        let _ = c.kill();
+                        let _ = c.wait();
+                        0
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => 5,
+                    Err(_) => 9,
+                }
+            }
+            Some("sleep") => {
+                std::thread::sleep(std::time::Duration::from_secs(30));
+                0
+            }
+            _ => 2,
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────────
+
+    fn secure_root(root: &Path) {
+        let user = std::env::var("USERNAME").expect("USERNAME set on Windows");
+        let status = std::process::Command::new("icacls")
+            .arg(root)
+            .args(["/inheritance:r", "/grant:r"])
+            .arg(format!("{user}:(OI)(CI)F"))
+            .status()
+            .expect("run icacls");
+        assert!(status.success(), "icacls secure_root failed");
+    }
+
+    /// Create an NTFS junction (directory reparse point) `link` → `target` via cmd's
+    /// `mklink /J` (junctions need no privilege, unlike symlinks). Returns success.
+    fn make_junction(link: &Path, target: &Path) -> bool {
+        std::process::Command::new("cmd")
+            .args(["/c", "mklink", "/J"])
+            .arg(link)
+            .arg(target)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    fn canon(p: &Path) -> String {
+        p.to_string_lossy().replace('\\', "/")
+    }
+
+    fn read_confine(read: &[&Path], write: &[&Path]) -> SandboxPolicy {
+        let mut entries = Vec::new();
+        for r in read {
+            entries.push(rule(r, FsAccess::Read));
+        }
+        for w in write {
+            entries.push(rule(w, FsAccess::ReadWrite));
+        }
+        SandboxPolicy {
+            fs: FsPolicy {
+                rules: FsRuleSet {
+                    entries,
+                    default_effect: Effect::Deny,
+                },
+                tmp: TmpMode::Private,
+            },
+            net: NetPolicy::default(),
+            env: EnvPolicy::default(),
+            pid: PidPolicy::default(),
+        }
+    }
+    fn rule(p: &Path, access: FsAccess) -> FsRule {
+        FsRule {
+            matcher: CanonGlob(canon(p)),
+            effect: Effect::Allow,
+            access,
+        }
+    }
+
+    fn code(policy: &SandboxPolicy, program: &Path, args: &[&str]) -> i32 {
+        let spec = CommandSpec::new(program.as_os_str()).args(args.iter().copied());
+        let prepared = match apply(policy, spec) {
+            Ok(p) => p,
+            Err(d) => {
+                eprintln!("  [apply Err] {d:?}");
+                return -100;
+            }
+        };
+        match prepared.status() {
+            Ok(s) => s.code().unwrap_or(-1),
+            Err(e) => {
+                eprintln!("  [status Err] {e} os={:?}", e.raw_os_error());
+                -101
+            }
+        }
+    }
+
+    fn expect(fails: &mut u32, label: &str, got: i32, want: i32) {
+        if got == want {
+            println!("PASS {label} (exit {got})");
+        } else {
+            *fails += 1;
+            eprintln!("FAIL {label}: exit {got}, expected {want}");
+        }
+    }
+    fn expect_in(fails: &mut u32, label: &str, got: i32, want: &[i32]) {
+        if want.contains(&got) {
+            println!("PASS {label} (exit {got})");
+        } else {
+            *fails += 1;
+            eprintln!("FAIL {label}: exit {got}, expected one of {want:?}");
+        }
+    }
+
+    fn native(p: &Path) -> String {
+        p.to_string_lossy().into_owned()
+    }
+
+    /// Start a named-pipe server (DEFAULT security) on a background thread that serves the
+    /// secret `PIPE_SECRET=leak` to the first client, then closes. Returns the pipe path a
+    /// client opens (`\\.\pipe\<name>`). Default security is the realistic case: nub does
+    /// not grant the AppContainer SID on an IPC object it holds.
+    fn start_pipe_server(name: &str) -> String {
+        use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+        use windows_sys::Win32::Storage::FileSystem::PIPE_ACCESS_OUTBOUND;
+        use windows_sys::Win32::System::Pipes::{CreateNamedPipeW, PIPE_TYPE_BYTE, PIPE_WAIT};
+        // windows-sys gates these two behind feature combos that fight the pipe imports;
+        // link them raw from kernel32 (overlapped arg passed NULL for a blocking pipe).
+        #[link(name = "kernel32")]
+        unsafe extern "system" {
+            fn ConnectNamedPipe(h: HANDLE, overlapped: *mut std::ffi::c_void) -> i32;
+            fn WriteFile(
+                h: HANDLE,
+                buf: *const u8,
+                len: u32,
+                wrote: *mut u32,
+                overlapped: *mut std::ffi::c_void,
+            ) -> i32;
+        }
+        let full = format!(r"\\.\pipe\{name}");
+        let wide: Vec<u16> = full.encode_utf16().chain(std::iter::once(0)).collect();
+        std::thread::spawn(move || {
+            // SAFETY: create a byte-mode outbound pipe with DEFAULT security (NULL SA).
+            let h = unsafe {
+                CreateNamedPipeW(
+                    wide.as_ptr(),
+                    PIPE_ACCESS_OUTBOUND,
+                    PIPE_TYPE_BYTE | PIPE_WAIT,
+                    1,
+                    512,
+                    512,
+                    0,
+                    std::ptr::null(),
+                )
+            };
+            if h as isize == -1 {
+                return;
+            }
+            // Block for a client, write the secret, disconnect. Timeout-free: the test
+            // always connects exactly one client; the fixture teardown ends the process.
+            unsafe {
+                let _ = ConnectNamedPipe(h, std::ptr::null_mut());
+                let msg = b"PIPE_SECRET=leak";
+                let mut wrote = 0u32;
+                WriteFile(h, msg.as_ptr(), msg.len() as u32, &mut wrote, std::ptr::null_mut());
+                CloseHandle(h);
+            }
+        });
+        full
+    }
+
+    // ── the cases ─────────────────────────────────────────────────────────────────
+
+    pub fn run() -> Result<(), u32> {
+        let mut fails = 0u32;
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("nub-resid-{nonce:x}"));
+        std::fs::create_dir_all(&root).unwrap();
+        secure_root(&root);
+
+        let bin = root.join("bin");
+        let work = root.join("work");
+        let vault = root.join("vault");
+        for d in [&bin, &work, &vault] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        let child = bin.join("child.exe");
+        std::fs::copy(std::env::current_exe().unwrap(), &child).unwrap();
+
+        // A secret sitting NEXT TO the binary (bin/), and one in an unrelated vault.
+        let neighbor = bin.join("neighbor.env");
+        std::fs::write(&neighbor, b"NEIGHBOR_SECRET=leak").unwrap();
+        let vault_secret = vault.join("secret.env");
+        std::fs::write(&vault_secret, b"VAULT_SECRET=leak").unwrap();
+
+        // Policy: read-confine granting ONLY work/. bin/ and vault/ are NOT in the
+        // allow-set. The backend auto-grants bin/ (the program's parent dir).
+        let confine = read_confine(&[&work], &[]);
+
+        // ── residual 1: program-dir neighbor read leak — CLOSED by the file-only grant.
+        // The backend now grants the program FILE, not its parent dir, so a `.env` next
+        // to the child binary is NO LONGER swept into the allow-set. Regression guard for
+        // the fix: the neighbor is DENIED. (Pre-fix this returned 0 — the leak.)
+        expect_in(
+            &mut fails,
+            "R1 program-dir neighbor .env DENIED (file-only program grant — leak CLOSED)",
+            code(&confine, &child, &["__resid__", "read", &native(&neighbor)]),
+            &[5, 9],
+        );
+        // A secret NOT next to the program and NOT granted stays denied too.
+        expect_in(
+            &mut fails,
+            "R1-bound vault secret (not program-dir, not granted) DENIED",
+            code(
+                &confine,
+                &child,
+                &["__resid__", "read", &native(&vault_secret)],
+            ),
+            &[5, 9],
+        );
+
+        // ── red-team A: reparse (junction) escape from a write-granted dir ──────────
+        // Grant read+write on work/. Place a junction work/esc → vault (ungranted). If
+        // the AC-SID modify grant follows the reparse to vault, a write through it
+        // escapes the write-confine; a read through it escapes the read-confine.
+        let wc = read_confine(&[&work], &[&work]);
+        let esc = work.join("esc");
+        if make_junction(&esc, &vault) {
+            let esc_secret = esc.join("secret.env"); // resolves to vault/secret.env
+            expect_in(
+                &mut fails,
+                "RT-A read vault secret THROUGH work/ junction DENIED (reparse-safe)",
+                code(&wc, &child, &["__resid__", "read", &native(&esc_secret)]),
+                &[5, 9],
+            );
+            let esc_write = esc.join("pwned.txt"); // resolves to vault/pwned.txt
+            expect_in(
+                &mut fails,
+                "RT-A write into vault THROUGH work/ junction DENIED (reparse-safe)",
+                code(&wc, &child, &["__resid__", "write", &native(&esc_write)]),
+                &[5, 9],
+            );
+            // NC: a write to a genuine path inside work/ succeeds (grant is real).
+            expect(
+                &mut fails,
+                "RT-A NC write to a real path inside work/ (grant works)",
+                code(
+                    &wc,
+                    &child,
+                    &["__resid__", "write", &native(&work.join("real.txt"))],
+                ),
+                0,
+            );
+        } else {
+            eprintln!("SKIP RT-A: mklink /J failed (no junction support)");
+        }
+
+        // ── red-team C: named-pipe IPC exfil ───────────────────────────────────────
+        // The parent serves a secret over a DEFAULT-security named pipe (distinct object
+        // namespace from the loopback-TCP path already tested). The AppContainer child
+        // tries to open + read it. Expect DENIED — a LowBox token is not on a normal
+        // pipe's DACL. A successful read would be a local-IPC exfil breakout.
+        let pipe_name = format!("nub-resid-{nonce:x}");
+        let pipe_path = start_pipe_server(&pipe_name);
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        expect_in(
+            &mut fails,
+            "RT-C named-pipe read DENIED (LowBox not on the pipe DACL — no IPC exfil)",
+            code(&confine, &child, &["__resid__", "pipe", &pipe_path]),
+            &[5, 9],
+        );
+
+        // ── red-team D: Job-object breakaway ───────────────────────────────────────
+        // The child tries to spawn a descendant with CREATE_BREAKAWAY_FROM_JOB. The Job
+        // is created without JOB_OBJECT_LIMIT_BREAKAWAY_OK, so the breakaway must fail
+        // (contained). A success would let a descendant outlive the Job's reap.
+        expect_in(
+            &mut fails,
+            "RT-D Job breakaway DENIED (no JOB_OBJECT_LIMIT_BREAKAWAY_OK — contained)",
+            code(&confine, &child, &["__resid__", "breakaway"]),
+            &[5, 9],
+        );
+
+        // ── residual 3 / red-team B: AAP-inheritance trap ──────────────────────────
+        // A SEPARATE root created WITHOUT secure_root, so it inherits %TEMP%'s ACEs
+        // (which on many systems include an inheritable ALL APPLICATION PACKAGES read).
+        // A secret there, NOT in the allow-set, tests whether an inherited AAP grant
+        // defeats default-deny — the reason a nub-cleaned DACL root is required.
+        let dirty = std::env::temp_dir().join(format!("nub-dirty-{nonce:x}"));
+        std::fs::create_dir_all(&dirty).unwrap();
+        let dirty_secret = dirty.join("aap.env");
+        std::fs::write(&dirty_secret, b"AAP_SECRET=leak").unwrap();
+        let r = code(
+            &confine,
+            &child,
+            &["__resid__", "read", &native(&dirty_secret)],
+        );
+        // Report BOTH outcomes explicitly — this is diagnostic, not a hard assert: if
+        // %TEMP% carries AAP the read SUCCEEDS (trap real → clean-root contract needed);
+        // if it does not, the read is denied (this host's %TEMP% has no AAP).
+        match r {
+            0 => println!(
+                "INFO RT-B AAP-TRAP CONFIRMED: secret under a non-cleaned %TEMP% dir READABLE \
+                 (inherited ALL APPLICATION PACKAGES defeats default-deny — clean-DACL root required)"
+            ),
+            5 | 9 => println!(
+                "INFO RT-B: secret under a non-cleaned %TEMP% dir DENIED (this host's %TEMP% \
+                 carries no inherited AAP grant)"
+            ),
+            other => {
+                fails += 1;
+                eprintln!("FAIL RT-B unexpected exit {other}");
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dirty);
+
+        let _ = std::fs::remove_dir_all(&root);
+        if fails == 0 { Ok(()) } else { Err(fails) }
+    }
+
+    #[allow(dead_code)]
+    fn _unused(_: PathBuf) {}
+}


### PR DESCRIPTION
Windows AppContainer red-team (real burn box, standard non-admin): no breakout on any axis — 23/23 enforcement + junction/reparse, named-pipe, Job breakaway, ascendant OpenProcess all denied.

**Fix — program-dir read leak (confirmed → closed):** the old parent-dir program grant was subtree-inheritable, so a `.env` beside the child binary was readable. Now grants read+exec on the program file only, mirroring macOS.

**Tests:** `windows_ascendant_env.rs`, `windows_residuals.rs`; LIMITATIONS.md updated. Verified windows-gnu VM 23/23 + host 69/69; self-review clean.

⚠ HELD for ack: sibling-DLL programs now need the front-end to supply the toolchain dir. Only tightens.