### PR TITLE
sandbox(compiler): env sensitive mark, glob-key optional, unterminated $( error (U2)

### DIFF
--- a/crates/nub-sandbox/src/compiler/env_grammar.rs
+++ b/crates/nub-sandbox/src/compiler/env_grammar.rs
@@ -7,6 +7,11 @@
 //! No comparison/intersection operators. String formats (email/url/…) deliberately
 //! do NOT ship — `/regex/` covers them. Unrecognized → hard error naming the set
 //! (closed vocab, so re-adding later is non-breaking).
+//!
+//! FUTURE (deferred, not implemented): `minLength`/`maxLength` value-length
+//! constraints on the extras object. Left out deliberately (re-add alongside the
+//! string formats if demand appears; non-breaking by the closed-vocab discipline).
+//! Tracked in wiki/sandbox-config.md §5.
 
 use crate::policy::EnvFormat;
 

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -28,6 +28,11 @@ const EMPTY_FS_ENTRY_MSG: &str = "an empty fs entry is not allowed (it would gra
 /// it has no defined meaning, so it is rejected rather than silently treated as a
 /// literal path/host named `...` (fail loud, parity with env-object + the array).
 const OBJECT_SENTINEL_MSG: &str = "`\"...\"` inheritance is only valid in fs/net array form (e.g. [\"...\", …]), not as an object key";
+/// A `$(` opener with no balanced close: nub does no shell substitution outside a
+/// complete `$(…)`, so an unterminated one is named rather than passed through as a
+/// literal or mislabeled "unknown env type" (D18).
+const UNTERMINATED_SUBST_MSG: &str =
+    "unterminated `$(…)` command substitution — expected a closing `)`";
 
 // ── fs ───────────────────────────────────────────────────────────────────────
 
@@ -341,7 +346,7 @@ struct EnvEntry {
     /// The key or glob key the entry governs.
     pattern: String,
     action: EnvAction,
-    secret: bool,
+    sensitive: bool,
     optional: bool,
     format: Option<EnvFormat>,
     /// How `pattern` matches an ambient key. User patterns are case-sensitive
@@ -423,7 +428,7 @@ fn parse_env_array(
             } else {
                 EnvAction::Allow(None)
             },
-            secret: !deny, // an allow defaults sensitive; a deny mark is irrelevant
+            sensitive: !deny, // an allow defaults sensitive; a deny mark is irrelevant
             // The array form is a concise ALLOWLIST (pass-through-if-present),
             // never a required-var declaration — an exact key here means "permit
             // it", not "demand it" (required/optional is an object-form concept
@@ -474,11 +479,14 @@ fn parse_env_object(
                 }
             }
         }
-        // A trailing `?` on the key marks it optional.
+        // A trailing `?` on the key marks it optional; a glob key is inherently
+        // optional (D9 — a glob matches however many keys, zero included), so it is
+        // never a required-var declaration and reports optional in the schema.
         let (key, optional) = match raw_key.strip_suffix('?') {
             Some(k) => (k.to_string(), true),
             None => (raw_key.clone(), false),
         };
+        let optional = optional || is_glob(&key);
         let entry = parse_env_object_value(key, optional, val, ctx, &p)?;
         out.push(entry);
     }
@@ -496,7 +504,7 @@ fn parse_env_object_value(
         Value::Bool(true) => Ok(EnvEntry {
             pattern: key,
             action: EnvAction::Allow(None),
-            secret: true,
+            sensitive: true,
             optional,
             format: None,
             key_match: KeyMatch::User,
@@ -505,7 +513,7 @@ fn parse_env_object_value(
         Value::Bool(false) => Ok(EnvEntry {
             pattern: key,
             action: EnvAction::Deny,
-            secret: true,
+            sensitive: true,
             optional,
             format: None,
             key_match: KeyMatch::User,
@@ -546,12 +554,18 @@ fn parse_env_string_value(
         return Ok(EnvEntry {
             pattern: key,
             action: EnvAction::Literal(resolved),
-            secret: true,
+            sensitive: true,
             optional,
             format: None,
             key_match: KeyMatch::User,
             builtin: false,
         });
+    }
+    // An unterminated `$(` reached here (no balanced close → not a substitution).
+    // Name it as a substitution error instead of falling through to a confusing
+    // "unknown env type `$(…`". Skip regex/union forms, which may hold a literal `$(`.
+    if resolve::has_open_substitution(s) && !s.starts_with('/') && !s.contains('\'') {
+        return Err(CompileError::substitution(path, UNTERMINATED_SUBST_MSG));
     }
     // Otherwise a type from the grammar.
     let ty = parse_env_type(s).map_err(|e| CompileError::shape(path, &e))?;
@@ -559,7 +573,7 @@ fn parse_env_string_value(
     Ok(EnvEntry {
         pattern: key,
         action: EnvAction::Allow(Some(ty)),
-        secret: true,
+        sensitive: true,
         optional,
         format,
         key_match: KeyMatch::User,
@@ -567,7 +581,7 @@ fn parse_env_string_value(
     })
 }
 
-/// The object extras form: `{ secret, public, format, value, optional }`.
+/// The object extras form: `{ sensitive, format, value, optional }`.
 fn parse_env_extras(
     key: String,
     optional_from_key: bool,
@@ -575,7 +589,7 @@ fn parse_env_extras(
     ctx: &CompileCtx,
     path: &str,
 ) -> Result<EnvEntry, CompileError> {
-    const ALLOWED: &[&str] = &["secret", "public", "format", "value", "optional"];
+    const ALLOWED: &[&str] = &["sensitive", "format", "value", "optional"];
     for k in extras.keys() {
         if !ALLOWED.contains(&k.as_str()) {
             return Err(CompileError::shape(
@@ -584,14 +598,12 @@ fn parse_env_extras(
             ));
         }
     }
-    let public = extras
-        .get("public")
+    // Single `sensitive` mark (D17), default-on; `sensitive: false` opts out of
+    // redaction. Collapses the old `secret`/`public` pair.
+    let sensitive = extras
+        .get("sensitive")
         .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let secret = extras
-        .get("secret")
-        .and_then(Value::as_bool)
-        .unwrap_or(!public);
+        .unwrap_or(true);
     let optional = optional_from_key
         || extras
             .get("optional")
@@ -627,6 +639,13 @@ fn parse_env_extras(
             }
             resolve::resolve_with(raw, ctx.runner.as_ref())
                 .map_err(|e| CompileError::substitution(&child(path, "value"), &e))?
+        } else if resolve::has_open_substitution(raw) {
+            // An unterminated `$(` — do NOT pass it through as a literal value
+            // (silently shipping shell-looking text is the footgun); name it.
+            return Err(CompileError::substitution(
+                &child(path, "value"),
+                UNTERMINATED_SUBST_MSG,
+            ));
         } else {
             raw.to_string()
         };
@@ -637,7 +656,7 @@ fn parse_env_extras(
         return Ok(EnvEntry {
             pattern: key,
             action: EnvAction::Literal(resolved),
-            secret,
+            sensitive,
             optional,
             format,
             key_match: KeyMatch::User,
@@ -647,7 +666,7 @@ fn parse_env_extras(
     Ok(EnvEntry {
         pattern: key,
         action: EnvAction::Allow(ty),
-        secret,
+        sensitive,
         optional,
         format,
         key_match: KeyMatch::User,
@@ -665,7 +684,7 @@ fn splice_env_inherit(parent: Option<&EnvPolicy>, out: &mut Vec<EnvEntry>) {
         Some(_) => out.push(EnvEntry {
             pattern: "...".to_string(),
             action: EnvAction::Allow(None),
-            secret: false,
+            sensitive: false,
             optional: true,
             format: None,
             key_match: KeyMatch::InheritedKeys,
@@ -685,7 +704,7 @@ fn splice_env_defaults(out: &mut Vec<EnvEntry>) {
     let secret_deny = |pattern: String, key_match: KeyMatch| EnvEntry {
         pattern,
         action: EnvAction::Deny,
-        secret: true,
+        sensitive: true,
         optional: false,
         format: None,
         key_match,
@@ -710,7 +729,7 @@ fn splice_env_defaults(out: &mut Vec<EnvEntry>) {
     out.push(EnvEntry {
         pattern: "...".to_string(),
         action: EnvAction::Allow(None),
-        secret: false,
+        sensitive: false,
         optional: true,
         format: None,
         key_match: KeyMatch::CuratedBaseline,
@@ -820,7 +839,7 @@ fn construct_env(
         if seen.insert(e.pattern.clone()) {
             policy.schema.push(EnvRule {
                 key: e.pattern.clone(),
-                secret: e.secret,
+                sensitive: e.sensitive,
                 format: e.format,
                 optional: e.optional,
             });

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -28,11 +28,6 @@ const EMPTY_FS_ENTRY_MSG: &str = "an empty fs entry is not allowed (it would gra
 /// it has no defined meaning, so it is rejected rather than silently treated as a
 /// literal path/host named `...` (fail loud, parity with env-object + the array).
 const OBJECT_SENTINEL_MSG: &str = "`\"...\"` inheritance is only valid in fs/net array form (e.g. [\"...\", …]), not as an object key";
-/// A `$(` opener with no balanced close: nub does no shell substitution outside a
-/// complete `$(…)`, so an unterminated one is named rather than passed through as a
-/// literal or mislabeled "unknown env type" (D18).
-const UNTERMINATED_SUBST_MSG: &str =
-    "unterminated `$(…)` command substitution — expected a closing `)`";
 
 // ── fs ───────────────────────────────────────────────────────────────────────
 
@@ -561,14 +556,21 @@ fn parse_env_string_value(
             builtin: false,
         });
     }
-    // An unterminated `$(` reached here (no balanced close → not a substitution).
-    // Name it as a substitution error instead of falling through to a confusing
-    // "unknown env type `$(…`". Skip regex/union forms, which may hold a literal `$(`.
-    if resolve::has_open_substitution(s) && !s.starts_with('/') && !s.contains('\'') {
-        return Err(CompileError::substitution(path, UNTERMINATED_SUBST_MSG));
-    }
-    // Otherwise a type from the grammar.
-    let ty = parse_env_type(s).map_err(|e| CompileError::shape(path, &e))?;
+    // Otherwise a type from the grammar. A string that fails to parse as a type yet
+    // carries a `$(` opener is an unterminated substitution (never a valid type) — a
+    // valid `/regex/` or `'union'` parses cleanly first, so this never mis-flags one,
+    // and an unterminated `$(op read 'x'` / `/$(x` gets the substitution-shaped error
+    // rather than a confusing "unknown env type" (D18).
+    let ty = match parse_env_type(s) {
+        Ok(ty) => ty,
+        Err(e) => {
+            return Err(if resolve::has_open_substitution(s) {
+                CompileError::substitution(path, resolve::UNTERMINATED_SUBST_MSG)
+            } else {
+                CompileError::shape(path, &e)
+            });
+        }
+    };
     let format = ty.format();
     Ok(EnvEntry {
         pattern: key,
@@ -644,7 +646,7 @@ fn parse_env_extras(
             // (silently shipping shell-looking text is the footgun); name it.
             return Err(CompileError::substitution(
                 &child(path, "value"),
-                UNTERMINATED_SUBST_MSG,
+                resolve::UNTERMINATED_SUBST_MSG,
             ));
         } else {
             raw.to_string()

--- a/crates/nub-sandbox/src/compiler/resolve.rs
+++ b/crates/nub-sandbox/src/compiler/resolve.rs
@@ -20,6 +20,12 @@ pub fn has_open_substitution(value: &str) -> bool {
     value.contains("$(")
 }
 
+/// A `$(` opener with no balanced close: nub does no shell substitution outside a
+/// complete `$(…)`, so an unterminated one is named rather than passed through as a
+/// literal or mislabeled "unknown env type" (D18). Shared by every reject site.
+pub(crate) const UNTERMINATED_SUBST_MSG: &str =
+    "unterminated `$(…)` command substitution — expected a closing `)`";
+
 /// Locate the next `$(` … `)` span (with paren nesting) starting at `from`.
 /// Returns `(open_idx, close_idx_exclusive, inner)`.
 fn find_next(value: &str, from: usize) -> Option<(usize, usize, String)> {
@@ -100,6 +106,13 @@ pub fn resolve_with(value: &str, runner: &dyn CommandRunner) -> Result<String, S
         let stdout = runner.run(inner.trim())?;
         out.push_str(stdout.trim_end_matches('\n').trim_end_matches('\r'));
         cursor = close;
+    }
+    // A `$(` left in the trailing literal is an unterminated opener AFTER a balanced
+    // span (e.g. `$(echo hi) $(oops`). `find_next` skips it (never balances), so it
+    // would otherwise ship silently as literal text — reject instead (D18). Only the
+    // tail can hold one: any earlier `$(` would make the FIRST find_next unbalance.
+    if has_open_substitution(&value[cursor..]) {
+        return Err(UNTERMINATED_SUBST_MSG.to_string());
     }
     out.push_str(&value[cursor..]);
     Ok(out)

--- a/crates/nub-sandbox/src/compiler/resolve.rs
+++ b/crates/nub-sandbox/src/compiler/resolve.rs
@@ -11,6 +11,15 @@ pub fn has_substitution(value: &str) -> bool {
     find_next(value, 0).is_some()
 }
 
+/// Does the value contain a `$(` opener at all (balanced or not)? Paired with
+/// [`has_substitution`] to detect an UNTERMINATED substitution: opener present but
+/// no balanced close (`has_substitution` false). nub does no shell substitution
+/// outside a complete `$(…)`, so such a value is named as a substitution error
+/// rather than passed through literally (a footgun) or mislabeled "unknown env type".
+pub fn has_open_substitution(value: &str) -> bool {
+    value.contains("$(")
+}
+
 /// Locate the next `$(` … `)` span (with paren nesting) starting at `from`.
 /// Returns `(open_idx, close_idx_exclusive, inner)`.
 fn find_next(value: &str, from: usize) -> Option<(usize, usize, String)> {

--- a/crates/nub-sandbox/src/policy.rs
+++ b/crates/nub-sandbox/src/policy.rs
@@ -163,7 +163,7 @@ pub enum NetTarget {
 /// Environment confinement. `constructed` is the ACTUAL child env nub builds —
 /// env access is undetectable (a plain memory read of the populated environ), so
 /// enforcement is construction, not interception: a withheld var is simply absent.
-/// `schema` carries per-key validation + secret/public marks for downstream
+/// `schema` carries per-key validation + the `sensitive` mark for downstream
 /// consumers (log redaction); the `$(…)` resolver's output is already baked into
 /// `constructed` by the compiler.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -186,8 +186,9 @@ pub struct EnvPolicy {
 pub struct EnvRule {
     /// The key or glob key (`VITE_*`) the rule governs.
     pub key: String,
-    /// Whether the value is sensitive (default-sensitive unless `public`).
-    pub secret: bool,
+    /// Whether the value is sensitive (default-on; `sensitive: false` opts out of
+    /// redaction). The single mark replacing the old `secret`/`public` pair (D17).
+    pub sensitive: bool,
     /// Optional value type the compiler validated the value against.
     pub format: Option<EnvFormat>,
     /// `true` if the key is optional (object-form trailing `?` / `optional`).

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -496,17 +496,43 @@ fn env_required_missing_key_errors_optional_is_ok() {
 }
 
 #[test]
-fn env_secret_and_public_marks() {
-    let ctx = common::ctx(true, &[("PUB", "1"), ("PRIV", "2")]);
+fn env_sensitive_mark_defaults_on_and_opts_out() {
+    // The single `sensitive` mark (D17): default-on, `sensitive: false` opts out.
+    let ctx = common::ctx(true, &[("PUB", "1"), ("PRIV", "2"), ("DEFLT", "3")]);
     let p = compile(
-        &json!({ "env": { "PUB": { "public": true }, "PRIV": { "secret": true } } }),
+        &json!({ "env": {
+            "PUB": { "sensitive": false },
+            "PRIV": { "sensitive": true },
+            "DEFLT": { "format": "string" },
+        } }),
         &ctx,
     )
     .unwrap();
-    let pub_rule = p.env.schema.iter().find(|r| r.key == "PUB").unwrap();
-    let priv_rule = p.env.schema.iter().find(|r| r.key == "PRIV").unwrap();
-    assert!(!pub_rule.secret, "public opts out of sensitive");
-    assert!(priv_rule.secret);
+    let rule = |k: &str| p.env.schema.iter().find(|r| r.key == k).unwrap();
+    assert!(
+        !rule("PUB").sensitive,
+        "sensitive:false opts out of redaction"
+    );
+    assert!(rule("PRIV").sensitive);
+    assert!(rule("DEFLT").sensitive, "default-on when unmarked");
+}
+
+#[test]
+fn env_extras_reject_the_old_secret_public_keys() {
+    // The collapsed pair (D17): `secret`/`public` are no longer valid extras keys.
+    let ctx = common::ctx(true, &[("X", "1")]);
+    for key in ["secret", "public"] {
+        let err = compile(&json!({ "env": { "X": { key: true } } }), &ctx).unwrap_err();
+        match err {
+            CompileError::Shape { message, .. } => {
+                assert!(
+                    message.contains(key) && message.contains("sensitive"),
+                    "{message}"
+                );
+            }
+            other => panic!("expected a shape error naming `{key}`, got {other:?}"),
+        }
+    }
 }
 
 // ── $(…) substitution + trust gate ────────────────────────────────────────────
@@ -547,6 +573,53 @@ fn substitution_failure_surfaces() {
     let ctx = common::ctx(true, &[]);
     let err = compile(&json!({ "env": { "X": "$(fail)" } }), &ctx).unwrap_err();
     assert!(matches!(err, CompileError::Substitution { .. }));
+}
+
+#[test]
+fn unterminated_substitution_is_named_not_unknown_type() {
+    // D18: a `$(` with no balanced close is a substitution-shaped error at BOTH the
+    // type position and the `value:` position — never a silent literal or a
+    // confusing "unknown env type". The runner must NOT fire (nothing to run).
+    struct PanicRunner;
+    impl nub_sandbox::CommandRunner for PanicRunner {
+        fn run(&self, _: &str) -> Result<String, String> {
+            panic!("an unterminated `$(` must not reach the runner");
+        }
+    }
+    let ctx = nub_sandbox::compiler::CompileCtx {
+        homes: common::homes(),
+        cwd: common::homes().project,
+        trusted: true,
+        ambient_env: std::collections::BTreeMap::new(),
+        runner: Box::new(PanicRunner),
+    };
+    for surface in [
+        json!({ "env": { "X": "$(op read" } }),
+        json!({ "env": { "X": { "value": "postgres://$(op read@h" } } }),
+    ] {
+        match compile(&surface, &ctx).unwrap_err() {
+            CompileError::Substitution { message, .. } => {
+                assert!(
+                    message.contains("$(") && message.contains("closing"),
+                    "{message}"
+                );
+            }
+            other => panic!("expected a substitution-shaped error, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn glob_object_key_reports_optional_in_schema() {
+    // D9: a glob object key is inherently optional (matches however many keys, zero
+    // included) — it reports optional in the schema even without a trailing `?`, and
+    // never triggers the required-var check when it matches nothing.
+    let ctx = common::ctx(true, &[("VITE_URL", "x")]);
+    let p = compile(&json!({ "env": { "VITE_*": true } }), &ctx).unwrap();
+    let rule = p.env.schema.iter().find(|r| r.key == "VITE_*").unwrap();
+    assert!(rule.optional, "a glob key is optional in the schema");
+    // A glob matching nothing does not error (contrast a required exact key).
+    assert!(compile(&json!({ "env": { "NOPE_*": true } }), &ctx).is_ok());
 }
 
 #[test]

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -596,6 +596,11 @@ fn unterminated_substitution_is_named_not_unknown_type() {
     for surface in [
         json!({ "env": { "X": "$(op read" } }),
         json!({ "env": { "X": { "value": "postgres://$(op read@h" } } }),
+        // The command text carries a single quote — must NOT fall through to a
+        // union-parse / "unknown env type" error (the coarse-guard gap).
+        json!({ "env": { "X": "$(op read 'op://vault/db/pw'" } }),
+        // A leading `/` must NOT be mistaken for a regex and skip the check.
+        json!({ "env": { "X": "/$(cmd" } }),
     ] {
         match compile(&surface, &ctx).unwrap_err() {
             CompileError::Substitution { message, .. } => {
@@ -604,7 +609,26 @@ fn unterminated_substitution_is_named_not_unknown_type() {
                     "{message}"
                 );
             }
-            other => panic!("expected a substitution-shaped error, got {other:?}"),
+            other => panic!("expected a substitution-shaped error for {surface}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn mixed_balanced_then_unterminated_substitution_errors() {
+    // D18: a value with a balanced span THEN an unterminated `$(` must not ship the
+    // unterminated tail as a silent literal. The balanced span DOES run (so a real
+    // runner, not a panic-runner), then the residual opener is rejected.
+    let ctx = common::ctx(true, &[]);
+    for surface in [
+        json!({ "env": { "X": "$(echo hi) $(oops" } }),
+        json!({ "env": { "X": { "value": "$(echo hi)$(oops" } } }),
+    ] {
+        match compile(&surface, &ctx).unwrap_err() {
+            CompileError::Substitution { message, .. } => {
+                assert!(message.contains("closing"), "{message}");
+            }
+            other => panic!("expected a substitution-shaped error for {surface}, got {other:?}"),
         }
     }
 }

--- a/tests/sandbox-pentest/README.md
+++ b/tests/sandbox-pentest/README.md
@@ -103,7 +103,7 @@ Top level is one of:
   (construction is default-deny; only a matching allow entry survives).
 - An object: `{ "KEY": true|false }`, `{ "KEY": "<type>" }` (validated
   type-string), `{ "KEY?": … }` (trailing `?` = optional), or the extras form
-  `{ "KEY": { "secret": bool, "public": bool, "format": "...", "value": "...",
+  `{ "KEY": { "sensitive": bool, "format": "...", "value": "...",
   "optional": bool } }`.
 
 ## Verified working policy templates


### PR DESCRIPTION
U2 of the sandbox config-compiler epic.

- **sensitive (D17):** env extras `{secret, public}` collapse to one `sensitive` boolean (default-on; `false` opts out). IR `EnvRule.secret` renamed to `sensitive`.
- **glob-key optional (D9):** a glob object key reports `optional` in the schema; no required-var check.
- **unterminated `$(` (D18):** opener with no balanced close → substitution-shaped error at both type and `value:` positions. Balanced `$(…)` still resolves.
- **minLength/maxLength:** documented deferred.

Gates: fmt, clippy `--all-targets --all-features`, `test -p nub-sandbox` + `sandbox_conformance` green (4 new tests); e2e confirmed.