### PR TITLE
sandbox(linux): carve an essential system dir when a user deny reaches it

### DIFF
--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -194,27 +194,50 @@ front-end posture, not an engine mechanism.
 
 Each is documented in code at the site noted; none is silently mis-reported.
 
-- **Linux `/etc` granted wholesale (no deny-inside carve).** Build toolchains read
-  `/etc` (resolv.conf, CA bundles), so the generous-read path grants it whole rather
-  than per-file. A secret placed *under* `/etc` would be readable. Bounded: user secrets
-  do not live in `/etc`, and a USER-authored deny reaching `/etc` still forces a carve.
-  Fix: selective `/etc` carve. (`backend/linux_grants.rs`.)
-- **Linux write-target widening for a not-yet-existing file.** Landlock cannot grant
-  write to a file that does not yet exist, so a write grant for a not-yet-created FILE
-  widens to its parent DIR. Bounded over-grant within an already-granted write subtree.
-  Fix: none clean at the Landlock layer. (`backend/linux.rs` pre-create.)
-- **Linux hardlink-to-secret.** A pre-existing same-uid hardlink to a secret, reached
-  via a carve `ReadFile`, bypasses a path-based deny (Landlock keys on the inode reached,
-  and the alt path was never denied). Bounded: requires a hardlink created *outside* the
-  sandbox beforehand. Fix: none clean at the Landlock layer.
+- **Linux `/etc` granted wholesale for the loader — a user deny now carves it (FIXED).**
+  Build toolchains read `/etc` (resolv.conf, CA bundles), so the essential-read set grants
+  `/etc` (and `/usr`,`/lib`,…) whole for the dynamic loader. Previously an explicit
+  `!/etc/secret` was NOT honored — the wholesale essential-base grant overrode the carve,
+  so a secret under `/etc` stayed readable despite the deny (VM-verified: `!/etc/**`,
+  `!/etc/secret`, `!/etc/*`, `!/etc` all failed to deny). Now the essential-base grant
+  CARVES an essential dir when a user deny reaches inside it (an implicit-allow walk
+  excluding the denied path), so the deny is honored while the loader's own files stay
+  readable — VM-verified surgical (wholesale vs carved `/etc` differ in exactly the denied
+  file; `ld.so.cache`, `ca-certificates.crt`, dynamic linking all unaffected). Residual:
+  with NO user deny, `/etc` is still granted whole (a secret under it is readable — user
+  secrets do not live in `/etc`, and net-deny blocks exfil). (`backend/linux.rs` +
+  `backend/linux_grants.rs` `essential_dir_needs_carve`/`derive_essential_dir_carve`.)
+- **Linux write-target for a not-yet-existing file becomes a DIRECTORY (not a parent
+  widen).** Landlock cannot grant write to a file that does not yet exist, so the backend
+  pre-creates the target and grants that subtree. VM-verified: `pre_create` uses
+  `create_dir_all`, so the requested leaf is created as a DIRECTORY and its subtree is
+  write-granted — the containing PARENT dir is NOT widened (a sibling in the parent stays
+  denied). Consequences: (a) a tool expecting to write a FILE at that path finds a
+  directory; (b) the over-grant is the target-as-dir subtree, bounded within the named
+  path. Fix: none clean at the Landlock layer. (`backend/linux.rs` `pre_create`.)
+- **Linux hardlink-to-secret (VM-verified).** A pre-existing same-uid hardlink to a
+  secret, at a name the deny never targets, is granted `ReadFile`, which grants read on
+  the SHARED inode — so the path-denied secret is reachable through the alias (and, since
+  the grant is inode-keyed, the denied path itself then leaks too). VM-verified: with the
+  alias present the secret leaks; without it the path-deny holds. Bounded: requires a
+  hardlink created *outside* the sandbox beforehand. Fix: none clean at the Landlock layer
+  (the inode was legitimately named twice). Regression test:
+  `hardlink_to_denied_secret_leaks_via_alias`.
 - **Linux derive→open TOCTOU.** Grant derivation canonicalizes paths on the host, then
   the kernel enforces at `open()` later; a path swapped in between could shift a target.
-  Bounded: a same-uid local race within the confined tree.
+  Bounded: a same-uid local race within the confined tree. (Inherent to a canonicalize-
+  then-enforce split; not deterministically reproducible.)
 - **Linux bind-mounted procfs at a non-standard path.** The `/proc` filter (the
-  ascendant-env boundary) matches the standard mount; a procfs bind-mounted at a
-  non-standard path is not matched, re-exposing `/proc/<pid>/environ`. Bounded: requires
-  the ability to bind-mount procfs (prior privilege/setup) before entering the sandbox.
-  Fix: a mount namespace, or broader procfs detection.
+  ascendant-env boundary) is path-literal (`starts_with("/proc")`), so a procfs
+  bind-mounted at a non-standard path is not filtered and IS grantable when a covering fs
+  grant reaches it — VM-verified: under `{fs:["/tmp"]}` a `/proc` bind-mounted at
+  `/tmp/altproc` was readable (`/tmp/altproc/version` leaked). The environ-secret read
+  itself (`/proc/<pid>/environ`) is additionally gated by `ptrace_may_access`, which held
+  in every VM topology tried (ancestor non-dumpable / sibling non-attachable under
+  `ptrace_scope>=1`), so the specific ascendant-env leak was not reproduced — but the
+  filter bypass is real. Bounded: requires the ability to bind-mount procfs (prior
+  privilege/setup) before entering the sandbox. Fix: a mount namespace, or resolve the
+  mount type rather than the path prefix.
 - **Windows program grant is file-only (neighbor-read leak CLOSED).** The engine grants
   read+execute on the program FILE ITSELF, not its parent dir (traverse-bypass makes the
   leaf-object ACL sufficient to exec), so a `.env` next to a binary is no longer swept

--- a/crates/nub-sandbox/src/backend/linux.rs
+++ b/crates/nub-sandbox/src/backend/linux.rs
@@ -137,7 +137,7 @@ pub fn apply(
         if confine_fs {
             let DerivedGrants {
                 grants,
-                read_partial,
+                mut read_partial,
             } = linux_grants::derive_read_grants(policy);
             for g in grants {
                 push_grant(&mut grant_specs, g, read_bits, rw_bits);
@@ -154,11 +154,28 @@ pub fn apply(
             }
             // Essential system read set + /dev (rw for /dev/null redirects) + the
             // program file, so a dynamically-linked child can exec, link, and
-            // redirect under read-confine. These are granted WHOLESALE for the loader;
-            // an explicit policy deny landing INSIDE one (e.g. `!/etc/x`) is not
-            // carved out of them (documented limitation — net-deny mitigates exfil).
+            // redirect under read-confine. Granted WHOLESALE for the loader in the
+            // common case — but when an explicit policy deny lands INSIDE one (e.g.
+            // `!/etc/secret`) the dir is CARVED instead (implicit-allow walk excluding
+            // the denied path), so a secret placed under `/etc` is not silently
+            // readable while the loader's own files stay granted.
             for dir in ESSENTIAL_READ_DIRS {
-                add_if_exists(&mut grant_specs, Path::new(dir), read_bits);
+                let p = Path::new(dir);
+                if !p.exists() {
+                    continue;
+                }
+                if linux_grants::essential_dir_needs_carve(policy, p) {
+                    let DerivedGrants {
+                        grants: carved,
+                        read_partial: carve_partial,
+                    } = linux_grants::derive_essential_dir_carve(policy, p);
+                    for g in carved {
+                        push_grant(&mut grant_specs, g, read_bits, rw_bits);
+                    }
+                    read_partial |= carve_partial;
+                } else {
+                    add_if_exists(&mut grant_specs, p, read_bits);
+                }
             }
             add_if_exists(&mut grant_specs, Path::new("/dev"), rw_bits);
             if let Some(prog) = resolve_program(&spec.program, spec.cwd.as_deref()) {

--- a/crates/nub-sandbox/src/backend/linux_grants.rs
+++ b/crates/nub-sandbox/src/backend/linux_grants.rs
@@ -163,6 +163,33 @@ pub(crate) fn derive_write_grants(policy: &SandboxPolicy) -> (Vec<Grant>, bool) 
     (out, partial)
 }
 
+/// Whether an explicit USER-authored (non-`.env*`-builtin) deny reaches into the
+/// essential system dir `dir`. The Linux backend grants the essential loader set
+/// (`/usr`,`/etc`,…) WHOLESALE so a dynamically-linked child can exec/link; but an
+/// explicit deny landing inside one (`!/etc/secret`) must still carve — otherwise a
+/// secret placed under `/etc` stays readable despite the user asking to deny it.
+/// Built-in `.env*` globs are excluded: they never target system dirs, and skipping
+/// them keeps the wholesale fast-path for the common no-deny case.
+pub(crate) fn essential_dir_needs_carve(policy: &SandboxPolicy, dir: &Path) -> bool {
+    View::essential(&policy.fs.rules).has_nonbuiltin_deny_reaching(dir)
+}
+
+/// Carve a single essential system dir under the IMPLICIT-ALLOW view: the dir would
+/// otherwise be granted wholesale for the loader, so the base effect is `Allow` and
+/// the policy's rules overlay it — a clean subtree is granted whole, and only a
+/// subtree a user deny reaches is descended into, excluding the denied file. The
+/// loader's files (`/etc/ld.so.cache`, `resolv.conf`, CA bundles) stay readable
+/// while `!/etc/secret` is honored. Budget-capped like [`derive_read_grants`]; on
+/// overflow the remainder is left ungranted (fail-safe) and `read_partial` is set.
+pub(crate) fn derive_essential_dir_carve(policy: &SandboxPolicy, dir: &Path) -> DerivedGrants {
+    let mut out = DerivedGrants::default();
+    let view = View::essential(&policy.fs.rules);
+    let mut visits = 0usize;
+    walk_read(dir, &view, &mut out, &mut visits);
+    dedup(&mut out.grants);
+    out
+}
+
 // ── the carve walks ────────────────────────────────────────────────────────────
 
 /// Directory entries, SORTED by path, symlinks dropped — so the walk (and thus the
@@ -304,6 +331,15 @@ impl View {
             (Effect::Allow, FsAccess::ReadWrite) => Effect::Allow,
             _ => Effect::Deny,
         })
+    }
+
+    /// The essential-dir carve view: an implicit-allow base (the loader dir would be
+    /// granted wholesale) with the policy's rules overlaid, so a USER deny inside a
+    /// system dir carves it while the loader keeps the rest. An `Allow` of any access
+    /// is readable; a `Deny` denies read (same read projection as [`View::read`], only
+    /// the default flips to `Allow`).
+    fn essential(set: &FsRuleSet) -> Self {
+        Self::project(set, Effect::Allow, |r| r.effect)
     }
 
     fn project(
@@ -727,6 +763,52 @@ mod tests {
         assert!(is_builtin_env_glob("**/.envrc"));
         assert!(!is_builtin_env_glob("**/*.pem"));
         assert!(!is_builtin_env_glob("/etc/secret"));
+    }
+
+    #[test]
+    fn essential_dir_carve_honors_user_deny_keeps_rest() {
+        // The essential loader dirs (/usr,/etc,…) are granted wholesale, but an
+        // explicit USER deny landing inside one must CARVE — a secret placed under
+        // /etc is not silently readable despite the deny. Exercised on a fixture
+        // "etc" dir (the derivation is dir-agnostic; the real /etc close is proven by
+        // an ad-hoc VM run). Regression guard for the LIMITATIONS.md "/etc granted
+        // wholesale (no deny-inside carve)" residual now that the carve exists.
+        let f = fixture();
+        let etc = f.root.join("etc");
+        fs::create_dir_all(&etc).unwrap();
+        fs::write(etc.join("resolv.conf"), "nameserver 1.1.1.1").unwrap();
+        fs::write(etc.join("secret.txt"), "ETCSECRET").unwrap();
+        let deny = format!("!{}", etc.join("secret.txt").to_str().unwrap());
+        let policy = f.compile(serde_json::json!({ "fs": [f.root.to_str().unwrap(), deny] }));
+        assert!(
+            essential_dir_needs_carve(&policy, &etc),
+            "a user deny reaching an essential dir must trigger the carve"
+        );
+        let d = derive_essential_dir_carve(&policy, &etc);
+        assert!(
+            read_reachable(&d.grants, &etc.join("resolv.conf")),
+            "loader-essential files stay readable under the essential-dir carve"
+        );
+        assert!(
+            !read_reachable(&d.grants, &etc.join("secret.txt")),
+            "the explicitly-denied secret under the essential dir is carved out"
+        );
+    }
+
+    #[test]
+    fn essential_dir_without_user_deny_stays_wholesale() {
+        // With no user deny reaching it, an essential dir stays on the wholesale
+        // fast-path — the built-in `.env*` secret globs must NOT force a carve (they
+        // never target system dirs, and forcing a carve would regress the common
+        // generous-read path).
+        let f = fixture();
+        let etc = f.root.join("etc");
+        fs::create_dir_all(&etc).unwrap();
+        let policy = f.compile(serde_json::json!({ "fs": ["..."] }));
+        assert!(
+            !essential_dir_needs_carve(&policy, &etc),
+            "the built-in .env carve must not force an essential-dir carve"
+        );
     }
 
     #[test]

--- a/crates/nub-sandbox/tests/linux_enforcement.rs
+++ b/crates/nub-sandbox/tests/linux_enforcement.rs
@@ -141,6 +141,7 @@ fn s(p: &Path) -> String {
 const CAT: &str = "/bin/cat";
 const TOUCH: &str = "/usr/bin/touch";
 const SH: &str = "/bin/sh";
+const TRUE: &str = "/bin/true";
 
 // ── fs read-confine (allowlist) ────────────────────────────────────────────────
 
@@ -573,5 +574,110 @@ fn enforcement_is_full_on_a_landlock_kernel() {
     assert!(
         prepared.degradation.is_full(),
         "read-confine fully enforces on a Landlock kernel"
+    );
+}
+
+// ── documented, bounded residuals — CAPTURED so they are no longer reasoned-only ──
+// These assert the CURRENT (bounded) behavior of a residual recorded in
+// LIMITATIONS.md. If a future mechanism closes one, its assertion flips and flags the
+// change — that is the point (a residual is a known bound, not a silent gap).
+
+#[test]
+fn hardlink_to_denied_secret_leaks_via_alias() {
+    if skip_without_landlock() {
+        return;
+    }
+    // Landlock keys on the INODE reached, not the path. A pre-existing same-uid
+    // hardlink to a secret, at a name the deny never targets, is granted `ReadFile`,
+    // which grants read on the SHARED inode — so the path-denied secret is reachable
+    // through the alias. BOUNDED: requires a hardlink created OUTSIDE the sandbox
+    // beforehand (no clean Landlock fix — the inode was legitimately named twice).
+    let f = fixture();
+    let secret = f.proj.join("secret.txt");
+    std::fs::write(&secret, "REALSECRET").unwrap();
+    let alias = f.proj.join("alias.txt");
+    std::fs::hard_link(&secret, &alias).unwrap();
+    let surface = serde_json::json!({ "fs": [s(&f.proj), format!("!{}", s(&secret))] });
+    // Residual: the alias (un-denied name) reads the secret's inode.
+    let (_c, out) = f.run(surface.clone(), &[], CAT, &[&s(&alias)]);
+    assert!(
+        out.contains("REALSECRET"),
+        "hardlink residual: an alias to the denied inode reads the secret"
+    );
+    // Control: WITHOUT any hardlink, the same path-deny holds (proving the alias, not
+    // a broken carve, is the escape).
+    let f2 = fixture();
+    let secret2 = f2.proj.join("secret.txt");
+    std::fs::write(&secret2, "REALSECRET").unwrap();
+    let surf2 = serde_json::json!({ "fs": [s(&f2.proj), format!("!{}", s(&secret2))] });
+    assert!(
+        !f2.ok(surf2, CAT, &[&s(&secret2)]),
+        "no hardlink: the path-deny denies the secret"
+    );
+}
+
+#[test]
+fn write_grant_to_nonexistent_file_becomes_dir_no_parent_widen() {
+    if skip_without_landlock() {
+        return;
+    }
+    // Landlock cannot grant write to a not-yet-existing FILE, so the backend
+    // pre-creates the target as a DIRECTORY and grants that subtree. Captured
+    // behavior (correcting LIMITATIONS.md "write-target widening"): the leaf becomes a
+    // dir and its subtree is writable, but the PARENT is NOT widened — a sibling in
+    // the parent stays denied.
+    let f = fixture();
+    let target = f.proj.join("writable/newfile.txt");
+    let surface = serde_json::json!({ "fs": ["...", s(&target)] });
+    // Applying the policy pre-creates the target; assert it became a directory.
+    let policy = compile(&surface, &f.ctx(&[])).unwrap();
+    let _ = apply(&policy, CommandSpec::new(TRUE).cwd(&f.proj)).unwrap();
+    assert!(
+        target.is_dir(),
+        "a not-yet-existing write target is pre-created as a directory"
+    );
+    // Writing UNDER the granted target dir succeeds; a sibling in the parent is denied.
+    assert!(
+        f.ok(surface.clone(), TOUCH, &[&s(&target.join("inside"))]),
+        "write under the granted target dir is allowed"
+    );
+    assert!(
+        !f.ok(surface, TOUCH, &[&s(&f.proj.join("writable/sibling"))]),
+        "the parent dir is NOT widened — a sibling stays denied"
+    );
+}
+
+#[test]
+fn etc_user_deny_is_carved_from_the_essential_base() {
+    if skip_without_landlock() {
+        return;
+    }
+    // The essential loader dirs (/etc,…) are granted wholesale, but an explicit user
+    // deny reaching one must CARVE it. End-to-end proof needs a secret planted under
+    // the REAL /etc (root only), so this runs only where /etc is writable (the
+    // conformance real-kernel/root leg); it SKIPS as a non-root user rather than
+    // reporting a hollow pass. The dir-agnostic derivation is covered portably by
+    // `linux_grants::essential_dir_carve_honors_user_deny_keeps_rest`.
+    let secret = Path::new("/etc/nub_sandbox_etc_carve_secret");
+    if std::fs::write(secret, "ETCSECRET").is_err() {
+        return; // not root — the portable unit test covers the derivation
+    }
+    let f = fixture();
+    let surface = serde_json::json!({ "fs": ["...", "!/etc/nub_sandbox_etc_carve_secret"] });
+    let leaked = f.run(
+        surface.clone(),
+        &[],
+        CAT,
+        &["/etc/nub_sandbox_etc_carve_secret"],
+    );
+    let hostname_ok = f.ok(surface, CAT, &["/etc/hostname"]);
+    let _ = std::fs::remove_file(secret);
+    assert!(
+        !leaked.1.contains("ETCSECRET"),
+        "a user deny under /etc must be carved (secret not readable)"
+    );
+    assert!(
+        hostname_ok,
+        "the rest of /etc stays readable for the loader after the carve"
     );
 }


### PR DESCRIPTION
Integrates the Linux `/etc` selective-carve fix onto `sandbox-primitives`.

Hole: the Landlock essential-base grant granted `/etc` (and `/usr`, `/lib`, …) wholesale for the loader, overriding an explicit user deny (`!/etc/secret`) — the secret stayed readable (VM-verified).

Fix: when a non-builtin user deny reaches an essential dir, carve it (an implicit-allow `walk_read` under `View::essential`) instead of granting wholesale — honoring the deny while keeping the loader's own files (`ld.so.cache`, CA bundle, `nsswitch.conf`) readable.

Re-verified on the real-kernel Linux VM at current HEAD: `nub-sandbox` builds; 14 enforcement + 54 lib tests green; clippy clean.
