### PR TITLE
sandbox(macos): extend move/rename block to regex directory-pinning denies

### DIFF
--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -246,10 +246,14 @@ Each is documented in code at the site noted; none is silently mis-reported.
   `mv secrets secretz` can no longer relocate the matched leaves. VM/host-verified: the
   ancestor rename is blocked while a legit write under the pinned dir still succeeds
   (`tests/macos_moveblock.rs`, `emit_move_block` in `backend/macos.rs`). **Residual (bounded):**
-  a floating-name deny with no fixed literal prefix (`!**/secrets/**` — the `secrets` component
-  can appear at any depth) has no single directory to anchor, so renaming an inner `secrets/`
-  dir still relocates it. Bounded — it needs a user-authored floating-glob deny AND a writable
-  container; the file-level deny still blocks renaming the leaves themselves.
+  the pin covers a secret whose container is the deny's literal directory prefix or a FULL glob
+  component below it (`packages/*/.env`). Two shapes stay open: a floating-name deny with no
+  fixed prefix (`!**/secrets/**` — the `secrets` component floats to any depth), and a PARTIAL
+  glob in a non-leaf component (`!sec*/x.key` — the relocation-sensitive `secrets/` dir is
+  matched by `sec*`, not literal, so it sits below the pinned prefix and renaming it to a
+  non-`sec*` name escapes; a literal `}`/`]` in a dir name hits the same corner). Both need a
+  user-authored glob-directory deny AND a writable container; the file-level deny still blocks
+  renaming the matched leaves themselves.
 - **Windows program grant is file-only (neighbor-read leak CLOSED).** The engine grants
   read+execute on the program FILE ITSELF, not its parent dir (traverse-bypass makes the
   leaf-object ACL sufficient to exec), so a `.env` next to a binary is no longer swept

--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -238,6 +238,18 @@ Each is documented in code at the site noted; none is silently mis-reported.
   filter bypass is real. Bounded: requires the ability to bind-mount procfs (prior
   privilege/setup) before entering the sandbox. Fix: a mount namespace, or resolve the
   mount type rather than the path prefix.
+- **macOS move/rename secret-relocation — literal AND regex directory-pinning denies CLOSED.**
+  A write-deny keyed to a secret's path is defeatable by renaming a container dir out from
+  under the deny. Both deny shapes now pin the container: a literal `(subpath)` deny pins its
+  ancestor-dir chain, and a regex directory-pinning deny (`!secrets/*.key` → `/proj/secrets/*.key`)
+  pins its literal directory prefix (`/proj/secrets`) and up to the write-grant root, so
+  `mv secrets secretz` can no longer relocate the matched leaves. VM/host-verified: the
+  ancestor rename is blocked while a legit write under the pinned dir still succeeds
+  (`tests/macos_moveblock.rs`, `emit_move_block` in `backend/macos.rs`). **Residual (bounded):**
+  a floating-name deny with no fixed literal prefix (`!**/secrets/**` — the `secrets` component
+  can appear at any depth) has no single directory to anchor, so renaming an inner `secrets/`
+  dir still relocates it. Bounded — it needs a user-authored floating-glob deny AND a writable
+  container; the file-level deny still blocks renaming the leaves themselves.
 - **Windows program grant is file-only (neighbor-read leak CLOSED).** The engine grants
   read+execute on the program FILE ITSELF, not its parent dir (traverse-bypass makes the
   leaf-object ACL sufficient to exec), so a `.env` next to a binary is no longer swept

--- a/crates/nub-sandbox/src/backend/macos.rs
+++ b/crates/nub-sandbox/src/backend/macos.rs
@@ -332,28 +332,59 @@ fn emit_move_block(policy: &SandboxPolicy, out: &mut String) {
         }
     }
 
-    // Fix 2 — ancestor move-block for ANCHORED (literal) denies. Block unlink/create on
-    // every directory from the secret's parent up to (and including) the outermost write-
-    // grant root enclosing it, so renaming a container dir can't relocate the secret past
-    // its anchored deny. Basename-glob denies (`**/.env` → a regex) have no literal
-    // ancestor and are already immune (the basename survives any rename), so they are
-    // skipped. The `(literal P)` denies are EXACT-path — they block renaming dir `P`
-    // itself, never a create/write INSIDE it, so a legit `echo > proj/other.txt` still
-    // works.
+    // Fix 2 — ancestor move-block for DIRECTORY-PINNING denies. For each deny, pin
+    // unlink/create on the directory chain from the secret's innermost writable container
+    // up to (and including) the enclosing write-grant root, so renaming a container can't
+    // relocate the secret past its path-keyed deny. The chain start differs by deny shape,
+    // because Fix 1's re-asserted deny covers a different innermost path in each:
+    //   • LITERAL `(subpath)` deny (`/proj/.env`, `/proj/secrets` subtree) — Fix 1's subpath
+    //     deny already matches its own root path, so renaming the secret / subtree-root
+    //     itself is blocked; only the ANCESTORS need pinning. Probe = the secret path; the
+    //     walk pins parent(secret) upward.
+    //   • REGEX directory-pinning deny (`!secrets/*.key` → `/proj/secrets/*.key`) — Fix 1's
+    //     regex deny matches only the glob LEAF files, NOT their literal container dir
+    //     `/proj/secrets`, so `mv secrets secretz` relocates the leaves past the deny. Pin
+    //     the deny's literal directory PREFIX itself and up. Probe = `<prefix>/*`, so the
+    //     walk pins `<prefix>` (not just its parent) upward.
+    // A deny with no absolute literal directory prefix under a grant root (`**/secrets/**` —
+    // the matched dir name floats, no fixed anchor) yields nothing to pin; documented as a
+    // residual in LIMITATIONS.md. The `(literal P)` denies are EXACT-path — they block
+    // renaming dir `P` itself, never a create/write INSIDE it, so `echo > proj/other.txt`
+    // and writes under `/proj/secrets/` still work.
     let grant_roots = write_grant_roots(policy);
     for rule in &policy.fs.rules.entries {
         if rule.effect != Effect::Deny {
             continue;
         }
-        let MatchTerm::Subpath(denied) = to_match_term(rule.matcher.as_str()) else {
-            continue;
+        let probe = match to_match_term(rule.matcher.as_str()) {
+            MatchTerm::Subpath(denied) => denied,
+            MatchTerm::Regex(_) => {
+                let Some(prefix) = regex_literal_dir_prefix(rule.matcher.as_str()) else {
+                    continue;
+                };
+                format!("{prefix}/*")
+            }
         };
-        for anc in move_block_ancestors(&denied, &grant_roots) {
+        for anc in move_block_ancestors(&probe, &grant_roots) {
             let lit = format!("(literal \"{}\")", sbpl_escape(&anc));
             out.push_str(&format!("(deny file-write-unlink {lit})\n"));
             out.push_str(&format!("(deny file-write-create {lit})\n"));
         }
     }
+}
+
+/// The literal directory PREFIX of a glob deny — the leading run of glob-free path
+/// components (`/proj/secrets/*.key` → `/proj/secrets`; `/proj/packages/*/.env` →
+/// `/proj/packages`). This is the deepest directory whose rename relocates a matched
+/// secret OUT of the deny: the glob leaf below it stays matched under an in-place rename
+/// (`*` re-matches the new name), but renaming the literal prefix escapes the pattern.
+/// `None` when there is no absolute multi-component prefix to anchor (a first-segment or
+/// leading-`**` glob) — matching the meta set `to_match_term` uses to pick Regex.
+fn regex_literal_dir_prefix(glob: &str) -> Option<String> {
+    let meta = glob.find(['*', '?', '[', ']', '{', '}'])?;
+    let slash = glob[..meta].rfind('/')?;
+    let prefix = &glob[..slash];
+    (prefix.len() > 1 && prefix.starts_with('/')).then(|| prefix.to_string())
 }
 
 /// The write-granted subpath roots: every rw Allow that survives the dangerous-root
@@ -917,6 +948,62 @@ mod tests {
                 rule("**", Effect::Allow, FsAccess::Read),
                 rule("/root", Effect::Allow, FsAccess::ReadWrite),
                 rule("**/.env", Effect::Deny, FsAccess::Read),
+            ],
+        );
+        let prof = build_profile(&p, &spec(), None);
+        assert!(!prof.contains("(deny file-write-unlink (literal \"/root\"))"));
+    }
+
+    #[test]
+    fn move_block_pins_regex_dir_prefix_ancestors() {
+        // A user directory-pinning glob deny (`!secrets/*.key` → `/root/secrets/*.key`) is a
+        // regex, so Fix 1 blocks the leaf `*.key` files but NOT their container `/root/secrets`
+        // — `mv secrets secretz` would relocate them past the deny. Fix 2 pins the literal
+        // prefix dir `/root/secrets` AND its ancestors up to the rw-grant root.
+        let p = fs_policy(
+            Effect::Deny,
+            vec![
+                rule("**", Effect::Allow, FsAccess::Read),
+                rule("/root", Effect::Allow, FsAccess::ReadWrite),
+                rule("/root/secrets/*.key", Effect::Deny, FsAccess::Read),
+            ],
+        );
+        let prof = build_profile(&p, &spec(), None);
+        assert!(prof.contains("(deny file-write-unlink (literal \"/root/secrets\"))"));
+        assert!(prof.contains("(deny file-write-create (literal \"/root/secrets\"))"));
+        assert!(prof.contains("(deny file-write-unlink (literal \"/root\"))"));
+        // EXACT-path, never a subpath — a legit write UNDER secrets/ stays permitted.
+        assert!(!prof.contains("(literal \"/root/secrets/"));
+        // The grant root is the stopping point — nothing above it.
+        assert!(!prof.contains("(deny file-write-unlink (literal \"/\"))"));
+    }
+
+    #[test]
+    fn regex_literal_dir_prefix_extracts_leading_literal_run() {
+        // The leading glob-free component run, dropping the glob leaf/segment.
+        assert_eq!(
+            regex_literal_dir_prefix("/root/secrets/*.key").as_deref(),
+            Some("/root/secrets")
+        );
+        assert_eq!(
+            regex_literal_dir_prefix("/root/packages/*/.env").as_deref(),
+            Some("/root/packages")
+        );
+        // No fixed anchor: a leading `**` (basename/floating glob) or a first-segment glob.
+        assert_eq!(regex_literal_dir_prefix("**/.env"), None);
+        assert_eq!(regex_literal_dir_prefix("/*.key"), None);
+    }
+
+    #[test]
+    fn move_block_no_regex_pin_without_literal_prefix() {
+        // A floating-name deny (`**/secrets/**`) has no absolute literal prefix to anchor, so
+        // Fix 2 emits no `(literal …)` ancestor denies for it — the documented residual.
+        let p = fs_policy(
+            Effect::Deny,
+            vec![
+                rule("**", Effect::Allow, FsAccess::Read),
+                rule("/root", Effect::Allow, FsAccess::ReadWrite),
+                rule("**/secrets/**", Effect::Deny, FsAccess::Read),
             ],
         );
         let prof = build_profile(&p, &spec(), None);

--- a/crates/nub-sandbox/src/backend/macos.rs
+++ b/crates/nub-sandbox/src/backend/macos.rs
@@ -346,9 +346,10 @@ fn emit_move_block(policy: &SandboxPolicy, out: &mut String) {
     //     `/proj/secrets`, so `mv secrets secretz` relocates the leaves past the deny. Pin
     //     the deny's literal directory PREFIX itself and up. Probe = `<prefix>/*`, so the
     //     walk pins `<prefix>` (not just its parent) upward.
-    // A deny with no absolute literal directory prefix under a grant root (`**/secrets/**` —
-    // the matched dir name floats, no fixed anchor) yields nothing to pin; documented as a
-    // residual in LIMITATIONS.md. The `(literal P)` denies are EXACT-path — they block
+    // A deny with no absolute literal directory prefix (`**/secrets/**` — the matched dir
+    // name floats, no fixed anchor), or one whose relocation-sensitive container is itself a
+    // PARTIAL non-leaf glob (`sec*/x.key`), yields nothing (or too shallow) to pin — a bounded
+    // residual documented in LIMITATIONS.md. The `(literal P)` denies are EXACT-path — they block
     // renaming dir `P` itself, never a create/write INSIDE it, so `echo > proj/other.txt`
     // and writes under `/proj/secrets/` still work.
     let grant_roots = write_grant_roots(policy);
@@ -375,11 +376,16 @@ fn emit_move_block(policy: &SandboxPolicy, out: &mut String) {
 
 /// The literal directory PREFIX of a glob deny — the leading run of glob-free path
 /// components (`/proj/secrets/*.key` → `/proj/secrets`; `/proj/packages/*/.env` →
-/// `/proj/packages`). This is the deepest directory whose rename relocates a matched
-/// secret OUT of the deny: the glob leaf below it stays matched under an in-place rename
-/// (`*` re-matches the new name), but renaming the literal prefix escapes the pattern.
+/// `/proj/packages`). Pinning it + its ancestors blocks relocating a secret whose
+/// container is this literal prefix OR a FULL glob component below it (`packages/*/.env`:
+/// renaming the `*`-matched intermediate keeps it matched; renaming `packages` is pinned).
 /// `None` when there is no absolute multi-component prefix to anchor (a first-segment or
-/// leading-`**` glob) — matching the meta set `to_match_term` uses to pick Regex.
+/// leading-`**` glob). The meta set matches `to_match_term`'s Regex classifier.
+///
+/// RESIDUAL (see LIMITATIONS.md): a PARTIAL glob in a NON-LEAF component (`sec*/x.key`)
+/// leaves its relocation-sensitive container (`/proj/secrets`, matched by `sec*`) BELOW this
+/// literal prefix and thus unpinned — renaming it to a name outside the pattern escapes. A
+/// literal `}`/`]` in a dir name hits the same residual (regex-classified, truncates here).
 fn regex_literal_dir_prefix(glob: &str) -> Option<String> {
     let meta = glob.find(['*', '?', '[', ']', '{', '}'])?;
     let slash = glob[..meta].rfind('/')?;

--- a/crates/nub-sandbox/tests/macos_moveblock.rs
+++ b/crates/nub-sandbox/tests/macos_moveblock.rs
@@ -202,3 +202,57 @@ fn anchored_deny_secret_cannot_be_relocated_by_ancestor_rename() {
         "a legit write inside the rw-granted dir must still succeed (got {write_ok:?})"
     );
 }
+
+#[test]
+fn regex_dir_pinning_deny_secret_cannot_be_relocated_by_ancestor_rename() {
+    // HOLE #2, regex twin: a user directory-pinning glob deny `<root>/secrets/*.key` (from
+    // `!secrets/*.key`) is a REGEX, so the re-asserted deny blocks the leaf `*.key` files but
+    // not their literal container `<root>/secrets` — `mv secrets secretz` relocates the whole
+    // dir out from under the pattern. The literal-prefix move-block must pin `<root>/secrets`
+    // so the container rename is blocked; a legit write inside secrets/ must still succeed.
+    let root = TempDir::new_in("/private/tmp").expect("tmp outside $TMPDIR");
+    let root_c = std::fs::canonicalize(root.path()).expect("canon root");
+    std::fs::create_dir(root_c.join("secrets")).expect("mkdir secrets");
+    std::fs::write(root_c.join("secrets/topsecret.key"), MARKER).expect("plant secret");
+
+    let root_s = root_c.to_string_lossy().to_string();
+    let policy = fs_policy(vec![
+        rule("**", Effect::Allow, FsAccess::Read),
+        rule(&root_s, Effect::Allow, FsAccess::ReadWrite),
+        rule(
+            &format!("{root_s}/secrets/*.key"),
+            Effect::Deny,
+            FsAccess::Read,
+        ),
+    ]);
+
+    let relocate =
+        "/bin/mv secrets secretz 2>/dev/null; /bin/cat secretz/topsecret.key 2>/dev/null";
+
+    // NEGATIVE CONTROL: unconfined, the container rename relocates and leaks the leaf.
+    let control = run_unconfined(&root_c, relocate);
+    let _ = std::fs::rename(root_c.join("secretz"), root_c.join("secrets"));
+    assert!(
+        control.contains(MARKER),
+        "neg-control: unconfined `mv secrets secretz; cat secretz/*.key` must leak (got {control:?})"
+    );
+
+    // CONFINED: the container rename is blocked → no relocation, no leak.
+    let confined = run_confined(&policy, &root_c, relocate);
+    assert!(
+        !confined.contains(MARKER),
+        "confined: an ancestor-dir rename must NOT relocate the regex-pinned secret (got {confined:?})"
+    );
+
+    // NON-REGRESSION: a legit write INSIDE secrets/ still works (the pin is exact-path on the
+    // dir, never a subpath, so it blocks renaming secrets/ but not writing under it).
+    let write_ok = run_confined(
+        &policy,
+        &root_c,
+        "echo OKINSIDE > secrets/note.txt; /bin/cat secrets/note.txt",
+    );
+    assert!(
+        write_ok.contains("OKINSIDE"),
+        "a legit write inside the pinned dir must still succeed (got {write_ok:?})"
+    );
+}


### PR DESCRIPTION
Extends the macOS move/rename secret-relocation block to regex directory-pinning denies.

`emit_move_block`'s ancestor walk only pinned container dirs for literal (subpath) denies, so a user glob deny like `!secrets/*.key` left the matched leaves relocatable via `mv secrets secretz`. The regex arm now pins the deny's literal directory prefix (`/proj/secrets`) up to the write-grant root. Not default-reachable — built-in denies are basename globs with no literal prefix.

Adds macOS enforcement + SBPL unit tests. LIMITATIONS.md documents the remaining floating-name / partial-non-leaf-glob residual.