### PR TITLE
sandbox(compiler): net mid-host-glob compile error + trailing-dot strip (U3)

### DIFF
--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -283,20 +283,21 @@ fn push_net_rule(
             }
         }
     } else {
-        // D12: normalize a single FQDN trailing dot away before the IR stores it,
-        // so `example.com.` and `example.com` are the same rule.
-        let host = crate::matcher::host::strip_trailing_dot(target);
-        // D11: only `*` and a leading `*.suffix` wildcard are honored by the
-        // matcher; a mid-host glob would silently match nothing, so reject it.
-        if !crate::matcher::host::host_pattern_is_valid(host) {
+        // D11: validate the SURFACE form before the trailing-dot strip — only a
+        // bare `*` or a leading `*.suffix` wildcard is honored by the matcher; a
+        // mid-host glob would silently match nothing. Validating pre-strip also
+        // keeps a degenerate `*.`/`*..` from collapsing to a bare `*` allow-all.
+        if !crate::matcher::host::host_pattern_is_valid(target) {
             return Err(CompileError::shape(
                 path,
                 &format!(
-                    "`{host}` is not a valid host pattern — a `*` is only allowed as a bare `*` or a leading `*.` subdomain wildcard (e.g. `*.example.com`), not mid-host"
+                    "`{target}` is not a valid host pattern — a `*` is only allowed as a bare `*` or a leading `*.` subdomain wildcard (e.g. `*.example.com`), not mid-host"
                 ),
             ));
         }
-        NetTarget::Host(host.to_string())
+        // D12: normalize a single FQDN trailing dot away so `example.com.` and
+        // `example.com` are the same rule in the IR.
+        NetTarget::Host(crate::matcher::host::strip_trailing_dot(target).to_string())
     };
     out.push(NetRule {
         target: net_target,

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -283,7 +283,20 @@ fn push_net_rule(
             }
         }
     } else {
-        NetTarget::Host(target.to_string())
+        // D12: normalize a single FQDN trailing dot away before the IR stores it,
+        // so `example.com.` and `example.com` are the same rule.
+        let host = crate::matcher::host::strip_trailing_dot(target);
+        // D11: only `*` and a leading `*.suffix` wildcard are honored by the
+        // matcher; a mid-host glob would silently match nothing, so reject it.
+        if !crate::matcher::host::host_pattern_is_valid(host) {
+            return Err(CompileError::shape(
+                path,
+                &format!(
+                    "`{host}` is not a valid host pattern — a `*` is only allowed as a bare `*` or a leading `*.` subdomain wildcard (e.g. `*.example.com`), not mid-host"
+                ),
+            ));
+        }
+        NetTarget::Host(host.to_string())
     };
     out.push(NetRule {
         target: net_target,

--- a/crates/nub-sandbox/src/matcher/host.rs
+++ b/crates/nub-sandbox/src/matcher/host.rs
@@ -82,7 +82,10 @@ pub fn host_pattern_is_valid(pattern: &str) -> bool {
         return true;
     }
     if let Some(rest) = pattern.strip_prefix("*.") {
-        return !rest.contains('*');
+        // The wildcard label must be followed by a real suffix: non-empty, not
+        // itself dot-led (`*.`/`*..` are a degenerate empty apex that would strip
+        // down to a bare `*` allow-all — a fail-OPEN), and no further wildcard.
+        return !rest.is_empty() && !rest.starts_with('.') && !rest.contains('*');
     }
     !pattern.contains('*')
 }

--- a/crates/nub-sandbox/src/matcher/host.rs
+++ b/crates/nub-sandbox/src/matcher/host.rs
@@ -49,10 +49,12 @@ impl<'a> HostMatcher<'a> {
 /// Match a host pattern against a concrete host. Two forms:
 ///   `*.example.com` → apex + any-depth subdomain (case-insensitive);
 ///   a literal `example.com` → exact (case-insensitive).
-/// A bare `*` matches any host.
+/// A bare `*` matches any host. A single FQDN trailing dot on either side
+/// (`example.com.`) is stripped first — the same host per DNS (D12), so a
+/// connect to `example.com.` cannot dodge a rule written as `example.com`.
 pub fn host_glob_matches(pattern: &str, host: &str) -> bool {
-    let pat = pattern.to_ascii_lowercase();
-    let host = host.to_ascii_lowercase();
+    let pat = strip_trailing_dot(pattern).to_ascii_lowercase();
+    let host = strip_trailing_dot(host).to_ascii_lowercase();
     if pat == "*" {
         return true;
     }
@@ -61,4 +63,26 @@ pub fn host_glob_matches(pattern: &str, host: &str) -> bool {
         return host == suffix || host.ends_with(&format!(".{suffix}"));
     }
     pat == host
+}
+
+/// Strip a single FQDN trailing dot (D12). Exactly one — `example.com..` keeps
+/// the inner dot so a genuinely malformed pattern still fails to match.
+pub fn strip_trailing_dot(host: &str) -> &str {
+    host.strip_suffix('.').unwrap_or(host)
+}
+
+/// Whether a host pattern is well-formed per the supported grammar: a bare `*`,
+/// a leading-subdomain wildcard `*.suffix` (the ONLY wildcard position), or a
+/// literal host with no wildcard. A `*` anywhere else (`api.*.com`, `foo*bar`)
+/// is ambiguous and rejected at compile time (D11) rather than silently matching
+/// nothing — the matcher only ever honors the two forms above, so a mid-host
+/// glob is a typo the author must see.
+pub fn host_pattern_is_valid(pattern: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if let Some(rest) = pattern.strip_prefix("*.") {
+        return !rest.contains('*');
+    }
+    !pattern.contains('*')
 }

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -726,6 +726,10 @@ fn net_mid_host_glob_is_a_shape_error_at_its_path() {
         (json!({ "net": ["api.*.com"] }), "net.0"),
         (json!({ "net": ["ok.example", "foo*bar.com"] }), "net.1"),
         (json!({ "net": { "api.*.com": true } }), "net.api.*.com"),
+        // Degenerate empty-apex wildcard: must fail loud, NOT strip down to a
+        // bare `*` allow-all (fail-open in a security primitive).
+        (json!({ "net": ["*."] }), "net.0"),
+        (json!({ "net": ["*.."] }), "net.0"),
     ] {
         match compile(&cfg, &ctx).unwrap_err() {
             CompileError::Shape { path, message } => {

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -716,3 +716,55 @@ fn net_true_disables_enforcement_false_denies_all() {
     let denied = compile(&json!({ "net": false }), &ctx).unwrap();
     assert!(denied.net.enforce && denied.net.rules.is_empty());
 }
+
+#[test]
+fn net_mid_host_glob_is_a_shape_error_at_its_path() {
+    // D11: a `*` outside the leading `*.` position is ambiguous — it would match
+    // nothing at runtime, so it fails loud at compile time.
+    let ctx = common::ctx(true, &[]);
+    for (cfg, want_path) in [
+        (json!({ "net": ["api.*.com"] }), "net.0"),
+        (json!({ "net": ["ok.example", "foo*bar.com"] }), "net.1"),
+        (json!({ "net": { "api.*.com": true } }), "net.api.*.com"),
+    ] {
+        match compile(&cfg, &ctx).unwrap_err() {
+            CompileError::Shape { path, message } => {
+                assert_eq!(path, want_path, "error points at the offending entry");
+                assert!(
+                    message.contains("host pattern"),
+                    "names the problem: {message}"
+                );
+            }
+            other => panic!("expected Shape for {cfg}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn net_leading_wildcard_and_bare_star_still_accepted() {
+    // D11 must not over-reject: the two valid wildcard forms compile.
+    let ctx = common::ctx(true, &[]);
+    let p = compile(&json!({ "net": ["*.example.com", "*"] }), &ctx).unwrap();
+    let m = nub_sandbox::matcher::HostMatcher::new(&p.net);
+    assert!(m.admits("a.b.example.com"));
+    assert!(m.admits("anything.at.all"));
+}
+
+#[test]
+fn net_trailing_dot_is_stripped_so_it_cannot_dodge_a_deny() {
+    // D12: `evil.com.` in config normalizes to `evil.com`, and a connect to the
+    // dotted form matches a dotless rule.
+    let ctx = common::ctx(true, &[]);
+    let p = compile(&json!({ "net": ["ok.example.", "!evil.com."] }), &ctx).unwrap();
+    match &p.net.rules[0].target {
+        nub_sandbox::policy::NetTarget::Host(h) => {
+            assert_eq!(h, "ok.example", "dot stripped in IR")
+        }
+        other => panic!("expected Host, got {other:?}"),
+    }
+    let m = nub_sandbox::matcher::HostMatcher::new(&p.net);
+    assert!(m.admits("ok.example."));
+    assert!(m.admits("ok.example"));
+    assert!(!m.admits("evil.com."), "trailing-dot deny still bites");
+    assert!(!m.admits("evil.com"));
+}

--- a/crates/nub-sandbox/tests/matcher.rs
+++ b/crates/nub-sandbox/tests/matcher.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use nub_sandbox::matcher::host::host_glob_matches;
+use nub_sandbox::matcher::host::{host_glob_matches, host_pattern_is_valid};
 use nub_sandbox::matcher::path::{canonicalize_including_nonexistent, expand_symbolic};
 use nub_sandbox::matcher::{HostMatcher, PathMatcher};
 use nub_sandbox::policy::{Effect, FsAccess, NetPolicy, NetRule, NetTarget};
@@ -152,6 +152,43 @@ fn host_wildcard_matches_apex_and_any_depth() {
 fn host_literal_is_exact_case_insensitive() {
     assert!(host_glob_matches("Example.COM", "example.com"));
     assert!(!host_glob_matches("example.com", "api.example.com"));
+}
+
+#[test]
+fn host_trailing_dot_normalized_on_both_sides() {
+    // D12: a FQDN trailing dot is the same host per DNS — it cannot dodge a rule,
+    // and a rule written with one still matches the dotless connect target.
+    assert!(
+        host_glob_matches("evil.com", "evil.com."),
+        "connect-side dot"
+    );
+    assert!(
+        host_glob_matches("evil.com.", "evil.com"),
+        "pattern-side dot"
+    );
+    assert!(host_glob_matches("evil.com.", "evil.com."), "both");
+    assert!(
+        host_glob_matches("*.example.com", "api.example.com."),
+        "wildcard vs dotted host"
+    );
+    // Exactly one dot stripped: a doubled trailing dot stays malformed.
+    assert!(!host_glob_matches("evil.com", "evil.com.."));
+}
+
+#[test]
+fn host_pattern_grammar_accepts_only_bare_and_leading_wildcard() {
+    // D11: valid forms.
+    assert!(host_pattern_is_valid("*"));
+    assert!(host_pattern_is_valid("*.example.com"));
+    assert!(host_pattern_is_valid("example.com"));
+    assert!(host_pattern_is_valid("api.internal.example.com"));
+    // Mid-host / malformed wildcards are rejected.
+    assert!(!host_pattern_is_valid("api.*.com"));
+    assert!(!host_pattern_is_valid("foo*bar.com"));
+    assert!(!host_pattern_is_valid("*foo.com"));
+    assert!(!host_pattern_is_valid("*.foo*bar.com"));
+    assert!(!host_pattern_is_valid("**.com"));
+    assert!(!host_pattern_is_valid("example.*"));
 }
 
 #[test]

--- a/crates/nub-sandbox/tests/matcher.rs
+++ b/crates/nub-sandbox/tests/matcher.rs
@@ -189,6 +189,10 @@ fn host_pattern_grammar_accepts_only_bare_and_leading_wildcard() {
     assert!(!host_pattern_is_valid("*.foo*bar.com"));
     assert!(!host_pattern_is_valid("**.com"));
     assert!(!host_pattern_is_valid("example.*"));
+    // Degenerate empty-apex wildcards: rejected so they can't strip down to a
+    // bare `*` allow-all (fail loud, never fail open).
+    assert!(!host_pattern_is_valid("*."));
+    assert!(!host_pattern_is_valid("*.."));
 }
 
 #[test]


### PR DESCRIPTION
U3 of the sandbox config compiler — two decided net-matcher rulings.

**D11** — a `*` outside a bare `*` or a leading `*.` label (`api.*.com`, `foo*bar.com`) would silently match nothing; now a path-anchored `CompileError::Shape`. Leading `*.example.com` and bare `*` unaffected.

**D12** — a single FQDN trailing dot (`example.com.`) is stripped at parse time and on the connect side, so it can't dodge a dotless rule and a dotted rule still matches.

Grammar authority in `matcher/host.rs`, folded via `push_net_rule`; `!`-deny and object-key forms both validated. `cargo test -p nub-sandbox` green (5 new tests); clippy + fmt clean.