### PR TITLE
sandbox(compiler): OS-mirror env-key case + normalize deny access (U4)

### DIFF
--- a/crates/nub-sandbox/src/compiler/defaults.rs
+++ b/crates/nub-sandbox/src/compiler/defaults.rs
@@ -170,7 +170,7 @@ fn deny(glob: String) -> FsRule {
     FsRule {
         matcher: CanonGlob(canonicalize_glob_prefix(&glob)),
         effect: Effect::Deny,
-        access: FsAccess::Read,
+        access: FsAccess::DENY,
     }
 }
 

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -152,6 +152,15 @@ fn push_fs_rules(
     ctx: &CompileCtx,
     out: &mut Vec<FsRule>,
 ) {
+    // Normalize a deny's access to the canonical inert value (D20): the array
+    // form grants ReadWrite even to a `!`-deny, the object form emits Read — same
+    // enforcement (a deny removes read+write), divergent IR. Fold both to one here,
+    // the single funnel for user fs rules, so the IR carries a uniform deny.
+    let access = if effect == Effect::Deny {
+        FsAccess::DENY
+    } else {
+        access
+    };
     let expanded = expand_symbolic(pattern, &ctx.homes);
     for g in defaults::subtree_globs(&expanded) {
         out.push(FsRule {
@@ -373,8 +382,10 @@ struct EnvEntry {
 /// How an [`EnvEntry`]'s pattern is matched against an ambient env key.
 #[derive(Clone, Copy)]
 enum KeyMatch {
-    /// A user-authored glob/exact key, matched case-SENSITIVELY (POSIX env keys
-    /// are case-sensitive; an explicit rule means exactly what it says).
+    /// A user-authored glob/exact key. Matched OS-mirrored (D16): case-SENSITIVE
+    /// on POSIX (env names are), case-INSENSITIVE on Windows (env names are one
+    /// var regardless of case by OS contract — a `PATH` rule must catch an ambient
+    /// `Path`). Toggled by [`ENV_KEYS_CASE_INSENSITIVE`].
     User,
     /// A built-in secret-KEY guard (`AWS_*`, `NPM_TOKEN`), matched as a
     /// case-INsensitive glob.
@@ -841,7 +852,11 @@ fn construct_env(
         if e.optional || is_glob(&e.pattern) {
             continue;
         }
-        if matches!(e.action, EnvAction::Allow(_)) && !policy.constructed.contains_key(&e.pattern) {
+        // Case-mirrored (D16): on Windows a `PATH` requirement is satisfied by an
+        // ambient `Path` — `constructed` is keyed by the source casing, so an
+        // exact-string lookup would false-miss. Match how the key matcher matched.
+        let satisfied = policy.constructed.keys().any(|k| env_key_eq(k, &e.pattern));
+        if matches!(e.action, EnvAction::Allow(_)) && !satisfied {
             return Err(CompileError::missing_required(&e.pattern));
         }
     }
@@ -875,12 +890,30 @@ fn is_glob(s: &str) -> bool {
     s.contains(['*', '?', '[', '{'])
 }
 
+/// Env var NAMES are case-insensitive on Windows (OS contract: `PATH`/`Path`/
+/// `path` are one var) and case-sensitive on POSIX. The user env-key matcher
+/// mirrors that (D16) so a `PATH` allow/deny catches an ambient `Path` on Windows
+/// but stays exact on unix. Compile-gated like the fs-matcher `CASE_INSENSITIVE`:
+/// env is folded on the host it runs on, so host OS == target OS. (Env is
+/// Windows-only insensitive, unlike fs which is also macOS-insensitive.)
+const ENV_KEYS_CASE_INSENSITIVE: bool = cfg!(windows);
+
+/// Compare two env keys honoring the OS case rule ([`ENV_KEYS_CASE_INSENSITIVE`]).
+fn env_key_eq(a: &str, b: &str) -> bool {
+    if ENV_KEYS_CASE_INSENSITIVE {
+        a.eq_ignore_ascii_case(b)
+    } else {
+        a == b
+    }
+}
+
 /// A compiled env-key matcher — the runtime form of an entry's [`KeyMatch`].
 enum KeyMatcher {
-    /// A compiled glob (user case-sensitive, or a secret-KEY case-insensitive).
+    /// A compiled glob (user OS-mirrored, or a secret-KEY case-insensitive).
     Glob(GlobMatcher),
-    /// Exact fallback when a user pattern fails to compile as a glob.
-    Exact(String),
+    /// Exact fallback when a pattern fails to compile as a glob; `bool` carries the
+    /// same case-insensitivity the glob would have (OS-mirrored user / secret-KEY).
+    Exact(String, bool),
     /// A secret token matched as a case-insensitive substring.
     SecretSubstr(String),
     /// A secret token matched as a case-insensitive whole segment.
@@ -895,7 +928,13 @@ impl KeyMatcher {
     fn hit(&self, name: &str) -> bool {
         match self {
             KeyMatcher::Glob(m) => m.is_match(name),
-            KeyMatcher::Exact(s) => s == name,
+            KeyMatcher::Exact(s, ci) => {
+                if *ci {
+                    s.eq_ignore_ascii_case(name)
+                } else {
+                    s == name
+                }
+            }
             KeyMatcher::SecretSubstr(word) => defaults::word_in_substr(word, name),
             KeyMatcher::SecretSegment(word) => defaults::word_is_segment(word, name),
             KeyMatcher::Baseline => defaults::baseline_allows(name),
@@ -914,12 +953,14 @@ fn compile_key_matcher(e: &EnvEntry, parent_keys: &BTreeSet<String>) -> KeyMatch
         KeyMatch::CuratedBaseline => KeyMatcher::Baseline,
         KeyMatch::InheritedKeys => KeyMatcher::InheritedKeys(parent_keys.clone()),
         KeyMatch::User | KeyMatch::SecretGlob => {
-            let case_insensitive = matches!(e.key_match, KeyMatch::SecretGlob);
+            // SecretGlob is always case-insensitive; a user key mirrors the OS.
+            let case_insensitive =
+                matches!(e.key_match, KeyMatch::SecretGlob) || ENV_KEYS_CASE_INSENSITIVE;
             GlobBuilder::new(&e.pattern)
                 .case_insensitive(case_insensitive)
                 .build()
                 .map(|g| KeyMatcher::Glob(g.compile_matcher()))
-                .unwrap_or_else(|_| KeyMatcher::Exact(e.pattern.clone()))
+                .unwrap_or_else(|_| KeyMatcher::Exact(e.pattern.clone(), case_insensitive))
         }
     }
 }

--- a/crates/nub-sandbox/src/policy.rs
+++ b/crates/nub-sandbox/src/policy.rs
@@ -109,6 +109,16 @@ pub enum FsAccess {
     ReadWrite,
 }
 
+impl FsAccess {
+    /// The single access every Deny rule carries. A deny removes both read AND
+    /// write regardless of this field (every backend/matcher reads `.access` only
+    /// under an `Effect::Allow` arm; deny arms are `(Effect::Deny, _)`), so the
+    /// mode is inert on a deny — normalized to one value so the IR has a uniform
+    /// deny representation and two denies differing only in an inert access don't
+    /// yield divergent IR/snapshots (D20).
+    pub const DENY: FsAccess = FsAccess::Read;
+}
+
 // ── network ──────────────────────────────────────────────────────────────────
 
 /// Network confinement. `enforce = false` means "no net restriction" (the

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -401,14 +401,101 @@ fn env_array_is_an_allowlist_not_required() {
 }
 
 #[test]
-fn env_user_deny_stays_case_sensitive() {
-    // Only the BUILT-IN secret defaults are case-insensitive; a user's explicit
-    // `!vite_url` must NOT deny `VITE_URL` (POSIX env keys are case-sensitive).
+fn env_user_key_case_mirrors_os() {
+    // D16: a user env key mirrors the OS. On POSIX env names are case-sensitive, so
+    // an explicit `!vite_url` does NOT deny `VITE_URL` (it survives). On Windows env
+    // names are one var regardless of case, so `!vite_url` DOES catch `VITE_URL`
+    // (it is withheld). Same source, opposite verdict — the enforcement follows the
+    // OS resource. (The Windows branch is exercised on the Windows VM / CI.)
     let ctx = common::ctx(true, &[("VITE_URL", "keep")]);
     let p = compile(&json!({ "env": ["VITE_*", "!vite_url"] }), &ctx).unwrap();
+    let got = p.env.constructed.get("VITE_URL").map(String::as_str);
+    if cfg!(windows) {
+        assert_eq!(
+            got, None,
+            "Windows: case-insensitive `!vite_url` denies VITE_URL"
+        );
+    } else {
+        assert_eq!(
+            got,
+            Some("keep"),
+            "POSIX: case-sensitive `!vite_url` spares VITE_URL"
+        );
+    }
+}
+
+#[test]
+fn env_user_exact_key_case_mirrors_os() {
+    // D16 for the EXACT-key form (not only globs): a `path` allow catches ambient
+    // `PATH` only on Windows; on POSIX they are distinct vars.
+    let ctx = common::ctx(true, &[("PATH", "/bin")]);
+    let p = compile(&json!({ "env": ["path"] }), &ctx).unwrap();
     assert_eq!(
-        p.env.constructed.get("VITE_URL").map(String::as_str),
-        Some("keep")
+        p.env.constructed.contains_key("PATH"),
+        cfg!(windows),
+        "exact user key mirrors OS case"
+    );
+}
+
+#[test]
+fn env_required_key_satisfied_case_mirrored() {
+    // D16 for the REQUIRED-key check: a required `PATH` is satisfied by an ambient
+    // `Path` on Windows (constructed is keyed by the source casing, so the check
+    // must compare case-mirrored, not exact) — but errors on POSIX where the
+    // casings are distinct vars.
+    let ctx = common::ctx(true, &[("Path", "/bin")]);
+    let r = compile(&json!({ "env": { "PATH": true } }), &ctx);
+    if cfg!(windows) {
+        assert!(
+            r.unwrap().env.constructed.contains_key("Path"),
+            "Windows: ambient Path satisfies required PATH"
+        );
+    } else {
+        assert!(
+            matches!(r.unwrap_err(), CompileError::MissingRequired { .. }),
+            "POSIX: Path != PATH, required PATH is missing"
+        );
+    }
+}
+
+#[test]
+fn fs_deny_access_is_normalized_to_one_value() {
+    // D20: a deny's access is inert (a deny removes read+write), so every deny rule
+    // carries `FsAccess::DENY` regardless of surface form. Without normalization the
+    // array `!x` deny would emit ReadWrite (the array's allow access) and the object
+    // `x: false` deny Read — divergent IR for identical enforcement.
+    use nub_sandbox::policy::FsAccess;
+    let ctx = common::ctx(true, &[]);
+    let obj = compile(&json!({ "fs": { "/a": "rw", "/b": false } }), &ctx).unwrap();
+    let arr = compile(&json!({ "fs": ["/a", "!/b"] }), &ctx).unwrap();
+    for set in [&obj.fs.rules, &arr.fs.rules] {
+        for rule in &set.entries {
+            if rule.effect == Effect::Deny {
+                assert_eq!(
+                    rule.access,
+                    FsAccess::DENY,
+                    "deny access must be normalized"
+                );
+            }
+        }
+    }
+    // The array `!/b` deny specifically must be Read, not the array-default ReadWrite.
+    let arr_deny = arr
+        .fs
+        .rules
+        .entries
+        .iter()
+        .find(|r| r.effect == Effect::Deny)
+        .expect("array deny present");
+    assert_eq!(arr_deny.access, FsAccess::DENY);
+    // An allow's access is untouched by the normalization.
+    assert!(
+        obj.fs
+            .rules
+            .entries
+            .iter()
+            .any(|r| r.effect == Effect::Allow && r.access == FsAccess::ReadWrite),
+        "an allow's ReadWrite is preserved"
     );
 }
 


### PR DESCRIPTION
U4 — two decided rulings (wiki/sandbox-config.md §8).

**D16** — the user env-key matcher (glob + exact + required-key check) mirrors the OS: case-sensitive on POSIX, case-insensitive on Windows (env names are one var there), via `ENV_KEYS_CASE_INSENSITIVE = cfg!(windows)`. Secret defaults stay always-case-insensitive.

**D20** — `push_fs_rules` normalizes every fs deny to `FsAccess::DENY`, so the IR carries one uniform deny (`!x` no longer emits ReadWrite vs `x: false`'s Read). Inert: backends read `.access` only under an Allow arm.

4 tests; green on macOS + Windows VM. Impact + adversarial self-review CLEAN. Refs epics/sandbox/config-impl-plan.md §5.