### PR TITLE
sandbox: per-axis brace-glob handling (expand in fs, reject in env/net)

### DIFF
--- a/crates/nub-sandbox/src/backend/macos.rs
+++ b/crates/nub-sandbox/src/backend/macos.rs
@@ -608,78 +608,23 @@ fn emit_term(term: &MatchTerm) -> String {
 
 /// Translate a git-style glob into an anchored Seatbelt regex. `**/` spans zero or
 /// more components, `**` spans anything, `*`/`?` stay within one component, `[…]`
-/// stays a character class. A metachar-free pattern gets a subtree `(/.*)?` suffix.
-/// Ported from Codex's `seatbelt_regex_for_unreadable_glob` (Apache-2.0).
+/// stays a character class, `{a,b}` is brace alternation. A metachar-free pattern
+/// gets a subtree `(/.*)?` suffix. Ported from Codex's
+/// `seatbelt_regex_for_unreadable_glob` (Apache-2.0); brace support added by nub.
 fn glob_to_seatbelt_regex(pattern: &str) -> String {
     let chars: Vec<char> = pattern.chars().collect();
     let mut regex = String::from("^");
-    let mut i = 0;
     let mut saw_glob = false;
+    let mut i = 0;
     while i < chars.len() {
-        let ch = chars[i];
-        i += 1;
-        match ch {
-            '*' => {
-                saw_glob = true;
-                if chars.get(i) == Some(&'*') {
-                    i += 1;
-                    if chars.get(i) == Some(&'/') {
-                        i += 1;
-                        regex.push_str("(.*/)?");
-                    } else {
-                        regex.push_str(".*");
-                    }
-                } else {
-                    regex.push_str("[^/]*");
-                }
-            }
-            '?' => {
-                saw_glob = true;
-                regex.push_str("[^/]");
-            }
-            '[' => {
-                saw_glob = true;
-                let class_start = i;
-                let mut class = String::new();
-                let mut closed = false;
-                while i < chars.len() {
-                    let c = chars[i];
-                    i += 1;
-                    if c == ']' {
-                        closed = true;
-                        break;
-                    }
-                    class.push(c);
-                }
-                if !closed {
-                    // Unterminated `[` → literal, reprocess the rest normally.
-                    regex.push_str("\\[");
-                    i = class_start;
-                    continue;
-                }
-                regex.push('[');
-                let mut it = class.chars();
-                if let Some(first) = it.next() {
-                    match first {
-                        '!' => regex.push('^'),
-                        '^' => regex.push_str("\\^"),
-                        _ => regex.push(first),
-                    }
-                }
-                for c in it {
-                    if c == '\\' {
-                        regex.push_str("\\\\");
-                    } else {
-                        regex.push(c);
-                    }
-                }
-                regex.push(']');
-            }
-            ']' => {
-                saw_glob = true;
-                regex.push_str("\\]");
-            }
-            _ => regex.push_str(&regex_escape_char(ch)),
+        // `{` opens a brace group; `}`/`,` are literals at the top level (only a `,`
+        // *inside* a group separates branches). Everything else is one glob unit.
+        if chars[i] == '{' {
+            i += 1;
+            saw_glob = true;
+            regex.push_str(&brace_to_regex(&chars, &mut i, &mut saw_glob));
+        } else {
+            translate_unit(&chars, &mut i, &mut regex, &mut saw_glob);
         }
     }
     if !saw_glob {
@@ -687,6 +632,127 @@ fn glob_to_seatbelt_regex(pattern: &str) -> String {
     }
     regex.push('$');
     regex
+}
+
+/// Expand a brace group `{a,b}` (the `{` already consumed, `*i` at its first inner
+/// char) into a regex alternation `(a|b)`, advancing `*i` past the matching `}`.
+///
+/// WHY (security): braces are STANDARD glob syntax and nub's userspace/Linux matcher
+/// (`globset`) expands them, but Seatbelt has no glob syntax — before this, the
+/// translator escaped `{`/`}` as literals, so an fs deny `!secrets/{a,b}.key` matched
+/// only a file literally named `{a,b}.key` and silently under-enforced (the
+/// sandbox-glob-deny-fidelity leak). Alternation makes macOS consistent with globset.
+///
+/// globset-FIDELITY (the shape correctness that keeps it leak-free):
+///   • nested `{a,{b,c}}` → `(a|(b|c))` and cartesian `{a,b}/{c,d}` → `(a|b)/(c|d)`
+///     fall out for free — each `{` recurses, so two groups in sequence multiply.
+///   • an EMPTY branch is DROPPED, matching globset's default `empty_alternates=false`
+///     (`{a,}` matches `a` only, NOT `a`-or-empty; `{}`/`{,}` emit nothing at all).
+///   • an unbalanced `{` (globset hard-errors on it) is auto-closed at input end so the
+///     emitted regex stays valid AND a deny keeps biting (fail-safe, not fail-open).
+/// A class-internal `,`/`}` (`{a,[,]}`) never splits: `translate_unit` consumes the
+/// whole `[…]` before this loop sees the next char.
+fn brace_to_regex(chars: &[char], i: &mut usize, saw_glob: &mut bool) -> String {
+    let mut branches: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    while *i < chars.len() {
+        match chars[*i] {
+            '}' => {
+                *i += 1;
+                break;
+            }
+            ',' => {
+                *i += 1;
+                branches.push(std::mem::take(&mut cur));
+            }
+            '{' => {
+                *i += 1;
+                cur.push_str(&brace_to_regex(chars, i, saw_glob));
+            }
+            _ => translate_unit(chars, i, &mut cur, saw_glob),
+        }
+    }
+    branches.push(cur);
+    // Drop empty branches (globset default) — an all-empty group (`{}`/`{,}`) emits
+    // nothing, exactly as globset erases empty alternates.
+    let non_empty: Vec<String> = branches.into_iter().filter(|b| !b.is_empty()).collect();
+    if non_empty.is_empty() {
+        String::new()
+    } else {
+        format!("({})", non_empty.join("|"))
+    }
+}
+
+/// Translate ONE glob unit at `chars[*i]` — `*`/`**`/`?`/`[…]`/`]`/literal — into
+/// `out`, advancing `*i`. `{`/`}`/`,` are handled by the callers (top level +
+/// `brace_to_regex`), so this never sees an unescaped brace; a top-level `}`/`,`
+/// reaches the literal arm and is escaped like any other char.
+fn translate_unit(chars: &[char], i: &mut usize, out: &mut String, saw_glob: &mut bool) {
+    let ch = chars[*i];
+    *i += 1;
+    match ch {
+        '*' => {
+            *saw_glob = true;
+            if chars.get(*i) == Some(&'*') {
+                *i += 1;
+                if chars.get(*i) == Some(&'/') {
+                    *i += 1;
+                    out.push_str("(.*/)?");
+                } else {
+                    out.push_str(".*");
+                }
+            } else {
+                out.push_str("[^/]*");
+            }
+        }
+        '?' => {
+            *saw_glob = true;
+            out.push_str("[^/]");
+        }
+        '[' => {
+            *saw_glob = true;
+            let class_start = *i;
+            let mut class = String::new();
+            let mut closed = false;
+            while *i < chars.len() {
+                let c = chars[*i];
+                *i += 1;
+                if c == ']' {
+                    closed = true;
+                    break;
+                }
+                class.push(c);
+            }
+            if !closed {
+                // Unterminated `[` → literal, reprocess the rest normally.
+                out.push_str("\\[");
+                *i = class_start;
+                return;
+            }
+            out.push('[');
+            let mut it = class.chars();
+            if let Some(first) = it.next() {
+                match first {
+                    '!' => out.push('^'),
+                    '^' => out.push_str("\\^"),
+                    _ => out.push(first),
+                }
+            }
+            for c in it {
+                if c == '\\' {
+                    out.push_str("\\\\");
+                } else {
+                    out.push(c);
+                }
+            }
+            out.push(']');
+        }
+        ']' => {
+            *saw_glob = true;
+            out.push_str("\\]");
+        }
+        _ => out.push_str(&regex_escape_char(ch)),
+    }
 }
 
 /// Escape a literal char for embedding in a regex. `/` and ordinary chars pass
@@ -777,6 +843,134 @@ mod tests {
         // The `/**` subtree twin collapses to the same subpath (subpath already
         // covers descendants) — the two IR rows map to one grant.
         assert_eq!(term_str("/proj/data/**"), "(subpath \"/proj/data\")");
+    }
+
+    // ── brace alternation (the sandbox-glob-deny-fidelity fix) ────────────────
+
+    #[test]
+    fn brace_shapes_translate_to_alternation() {
+        // Simple, nested, cartesian, single-element, brace+star, dir-level — the
+        // exact shapes the fidelity audit flagged as silent leaks.
+        assert_eq!(term_str("/p/{a,b}.key"), "(regex #\"^/p/(a|b)\\.key$\")");
+        assert_eq!(
+            term_str("/p/{a,{b,c}}.key"),
+            "(regex #\"^/p/(a|(b|c))\\.key$\")"
+        );
+        assert_eq!(term_str("/p/{a,b}/{c,d}"), "(regex #\"^/p/(a|b)/(c|d)$\")");
+        assert_eq!(term_str("/p/{a}.key"), "(regex #\"^/p/(a)\\.key$\")");
+        assert_eq!(
+            term_str("/p/{a,b}/*.key"),
+            "(regex #\"^/p/(a|b)/[^/]*\\.key$\")"
+        );
+        assert_eq!(
+            term_str("/p/{a,b}/x.key"),
+            "(regex #\"^/p/(a|b)/x\\.key$\")"
+        );
+    }
+
+    #[test]
+    fn brace_empty_branches_are_dropped_like_globset() {
+        // globset compiles with `empty_alternates=false`, so an empty branch VANISHES
+        // (`{a,}` matches `a` only, never `a`-or-empty) and an all-empty group emits
+        // nothing. A `(a|)`/`()` translation would over-match — the `{a,}` adversarial
+        // case that would re-open the leak.
+        assert_eq!(term_str("/p/{a,}.key"), "(regex #\"^/p/(a)\\.key$\")");
+        assert_eq!(term_str("/p/{,a}.key"), "(regex #\"^/p/(a)\\.key$\")");
+        assert_eq!(term_str("/p/{a,,b}.key"), "(regex #\"^/p/(a|b)\\.key$\")");
+        // `{}` / `{,}` collapse to nothing — the group emits no regex, and (seeing a
+        // brace at all set `saw_glob`) no subtree suffix is appended, so the pattern is
+        // its exact literal remainder — matching globset's `^/p/x$` (not a subtree).
+        assert_eq!(term_str("/p/{}x"), "(regex #\"^/p/x$\")");
+        assert_eq!(term_str("/p/{,}x"), "(regex #\"^/p/x$\")");
+    }
+
+    #[test]
+    fn brace_unbalanced_open_is_auto_closed_failsafe() {
+        // globset hard-errors on `{a,b` (unclosed); the translator auto-closes so the
+        // emitted regex stays valid and a deny keeps biting `a`/`b` rather than
+        // producing a broken profile. A stray `}` is a literal.
+        assert_eq!(term_str("/p/{a,b"), "(regex #\"^/p/(a|b)$\")");
+        assert_eq!(term_str("/p/a}b*"), "(regex #\"^/p/a\\}b[^/]*$\")");
+    }
+
+    /// The globset ORACLE: nub's userspace/Linux fs matcher IS globset, so the macOS
+    /// Seatbelt regex must accept EXACTLY the paths globset accepts for the same glob.
+    /// A translation bug re-creates the silent leak, so this cross-checks the emitted
+    /// regex against globset over a shared candidate pool. Case-sensitive on both sides
+    /// isolates brace/glob STRUCTURE (case-folding is a separate, already-refuted axis).
+    #[test]
+    fn brace_regex_matches_globset_oracle() {
+        use globset::GlobBuilder;
+        use regex::Regex;
+
+        let globs = [
+            "/p/{a,b}.key",
+            "/p/{a,{b,c}}.key",
+            "/p/{a,{b,{c,d}}}.k",
+            "/p/{a,b}/{c,d}",
+            "/p/{a}.key",
+            "/p/{a,}.key",
+            "/p/{,a}.key",
+            "/p/{a,,b}.key",
+            "/p/{a,b}/*.key",
+            "/p/{a,[bc]}.k",
+            "/p/pre{a,b}post",
+            "/p/{a,b}/**",
+            // Empty-brace edges cross-checked against real globset (not just the
+            // reasoning-asserts): the group emits nothing, so the pattern is its
+            // literal remainder.
+            "/p/{}x",
+            "/p/{,}x",
+            "/p/pre{}post",
+        ];
+        // A pool that exercises match + non-match for every glob above, including the
+        // literal-brace spelling (must NOT match — the leak was matching only that).
+        let candidates = [
+            "/p/a.key",
+            "/p/b.key",
+            "/p/c.key",
+            "/p/d.key",
+            "/p/.key",
+            "/p/a/c",
+            "/p/a/d",
+            "/p/b/c",
+            "/p/b/e",
+            "/p/a/x.key",
+            "/p/b/y.key",
+            "/p/c/x.key",
+            "/p/a/x.pem",
+            "/p/a.k",
+            "/p/b.k",
+            "/p/c.k",
+            "/p/preapost",
+            "/p/prebpost",
+            "/p/{a,b}.key",
+            "/p/a/deep/nested/file",
+            "/p/b/deep",
+            "/p/x",
+            "/p/prepost",
+            "/p/x/sub",
+        ];
+        for g in globs {
+            let emitted = super::glob_to_seatbelt_regex(g);
+            let re = Regex::new(&emitted)
+                .unwrap_or_else(|e| panic!("emitted regex for `{g}` is invalid: {e}\n{emitted}"));
+            let gs = GlobBuilder::new(g)
+                .literal_separator(true)
+                .build()
+                .unwrap_or_else(|e| panic!("globset rejected `{g}`: {e}"))
+                .compile_matcher();
+            for c in candidates {
+                assert_eq!(
+                    re.is_match(c),
+                    gs.is_match(c),
+                    "DIVERGENCE glob=`{g}` candidate=`{c}` emitted=`{emitted}` \
+                     (seatbelt={}, globset={})",
+                    re.is_match(c),
+                    gs.is_match(c),
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -281,6 +281,19 @@ fn push_net_rule(
     path: &str,
     out: &mut Vec<NetRule>,
 ) -> Result<(), CompileError> {
+    // Brace alternation is not part of the host OR CIDR grammar (only a bare `*` /
+    // leading `*.` wildcard) — reject a `{`/`}` the same class as the mid-host glob
+    // (D11): the matcher would treat it as a literal host and silently match nothing,
+    // so a `!{evil,bad}.com` deny would be inert. Checked BEFORE the CIDR split so a
+    // brace CIDR-lookalike (`{a,b}.com/24`) gets the brace message, not a CIDR one.
+    if target.contains(['{', '}']) {
+        return Err(CompileError::shape(
+            path,
+            &format!(
+                "`{target}` is not a valid host pattern — brace alternation `{{a,b}}` is not supported; list hosts separately (a wildcard is only a bare `*` or a leading `*.` subdomain)"
+            ),
+        ));
+    }
     let net_target = if target.contains('/') {
         match target.parse::<ipnet::IpNet>() {
             Ok(net) => NetTarget::Cidr(net),
@@ -435,6 +448,7 @@ fn parse_env_array(
             Some(rest) => (rest.to_string(), true),
             None => (s.to_string(), false),
         };
+        reject_env_key_braces(&pattern, &p)?;
         // A `$(…)` in array form would have no key to bind to — array entries are
         // key/glob selectors, not values. Reject to avoid silent misuse.
         if resolve::has_substitution(&pattern) {
@@ -508,6 +522,7 @@ fn parse_env_object(
             Some(k) => (k.to_string(), true),
             None => (raw_key.clone(), false),
         };
+        reject_env_key_braces(&key, &p)?;
         let optional = optional || is_glob(&key);
         let entry = parse_env_object_value(key, optional, val, ctx, &p)?;
         out.push(entry);
@@ -888,6 +903,23 @@ fn construct_env(
 
 fn is_glob(s: &str) -> bool {
     s.contains(['*', '?', '[', '{'])
+}
+
+/// Reject brace alternation in an env-var-NAME pattern. Env keys are a NARROWER
+/// grammar than fs globs — `*` prefix/suffix names one variable family — so a
+/// `{`/`}` is rejected the same class as the mid-host net glob (D11): fail loud on
+/// the typo rather than silently expand. (fs globs DO support braces; env keys and
+/// net hosts do not.)
+fn reject_env_key_braces(key: &str, path: &str) -> Result<(), CompileError> {
+    if key.contains(['{', '}']) {
+        return Err(CompileError::shape(
+            path,
+            &format!(
+                "`{key}` is not a valid env key — brace alternation `{{a,b}}` is not supported in env-var-name patterns; list the keys separately or use a `*` wildcard"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 /// Env var NAMES are case-insensitive on Windows (OS contract: `PATH`/`Path`/

--- a/crates/nub-sandbox/src/matcher/host.rs
+++ b/crates/nub-sandbox/src/matcher/host.rs
@@ -78,6 +78,13 @@ pub fn strip_trailing_dot(host: &str) -> &str {
 /// nothing — the matcher only ever honors the two forms above, so a mid-host
 /// glob is a typo the author must see.
 pub fn host_pattern_is_valid(pattern: &str) -> bool {
+    // Brace alternation is not part of the host grammar — the matcher would treat
+    // `{a,b}.com` as a literal host and match nothing. The fold rejects it with a
+    // brace-specific message before reaching here; this keeps the predicate honest
+    // for any direct caller.
+    if pattern.contains(['{', '}']) {
+        return false;
+    }
     if pattern == "*" {
         return true;
     }

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -832,6 +832,50 @@ fn net_mid_host_glob_is_a_shape_error_at_its_path() {
 }
 
 #[test]
+fn net_host_brace_alternation_is_a_shape_error() {
+    // Braces are NOT part of the host grammar (only `*` / `*.suffix`) — a `{a,b}` host
+    // would be a literal that matches nothing, so a `!{evil,bad}.com` deny would be
+    // inert. Fail loud, same class as the mid-host glob. (fs globs DO support braces.)
+    let ctx = common::ctx(true, &[]);
+    for (cfg, want_path) in [
+        (json!({ "net": ["{a,b}.com"] }), "net.0"),
+        (json!({ "net": ["ok.example", "!{evil,bad}.com"] }), "net.1"),
+        (
+            json!({ "net": { "api.{a,b}.com": true } }),
+            "net.api.{a,b}.com",
+        ),
+    ] {
+        match compile(&cfg, &ctx).unwrap_err() {
+            CompileError::Shape { path, message } => {
+                assert_eq!(path, want_path, "error points at the offending entry");
+                assert!(message.contains("brace"), "names the problem: {message}");
+            }
+            other => panic!("expected Shape for {cfg}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn env_key_brace_alternation_is_a_shape_error() {
+    // Env-var-NAME patterns are a narrower grammar than fs globs — a `{`/`}` is
+    // rejected the same class as a mid-host glob (list the keys, or use `*`).
+    let ctx = common::ctx(true, &[("FOO_A", "1"), ("FOO_B", "2")]);
+    for (cfg, want_path) in [
+        (json!({ "env": ["FOO_{A,B}"] }), "env.0"),
+        (json!({ "env": ["OK", "!SECRET_{X,Y}"] }), "env.1"),
+        (json!({ "env": { "FOO_{A,B}": true } }), "env.FOO_{A,B}"),
+    ] {
+        match compile(&cfg, &ctx).unwrap_err() {
+            CompileError::Shape { path, message } => {
+                assert_eq!(path, want_path, "error points at the offending entry");
+                assert!(message.contains("brace"), "names the problem: {message}");
+            }
+            other => panic!("expected Shape for {cfg}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
 fn net_leading_wildcard_and_bare_star_still_accepted() {
     // D11 must not over-reject: the two valid wildcard forms compile.
     let ctx = common::ctx(true, &[]);

--- a/crates/nub-sandbox/tests/macos_enforcement.rs
+++ b/crates/nub-sandbox/tests/macos_enforcement.rs
@@ -249,6 +249,76 @@ fn new_secret_paths_denied_under_generous_read() {
     }
 }
 
+// ── fs brace-alternation deny (the glob-deny-fidelity fix) ─────────────────────
+
+#[test]
+fn brace_deny_denies_every_expanded_path_not_the_literal() {
+    // Braces `{a,b}` in an fs deny must deny EACH expanded path (globset-consistent),
+    // not a file literally named `{a,b}`. Before the fix the Seatbelt regex escaped
+    // the braces as literals, so `a.key`/`b.key` stayed silently readable under a
+    // generous read — the sandbox-glob-deny-fidelity leak. This spawns sandbox-exec,
+    // so it also proves Seatbelt accepts the `(a|b)` alternation regex.
+    let f = fixture();
+    let secrets = f.proj.join("secrets");
+    fs::create_dir_all(&secrets).unwrap();
+    for name in ["a.key", "b.key", "c.key"] {
+        fs::write(secrets.join(name), "SECRET").unwrap();
+    }
+    let deny = format!("!{}/{{a,b}}.key", s(&secrets));
+    let pol = serde_json::json!({ "fs": ["...", deny] });
+    assert!(
+        !f.allowed(pol.clone(), CAT, &[&s(&secrets.join("a.key"))]),
+        "brace-expanded a.key denied"
+    );
+    assert!(
+        !f.allowed(pol.clone(), CAT, &[&s(&secrets.join("b.key"))]),
+        "brace-expanded b.key denied"
+    );
+    // c.key is NOT in the brace set → readable (the deny is selective, not a blanket
+    // over-deny), AND an unrelated file stays readable (the generous base is active).
+    assert!(
+        f.allowed(pol.clone(), CAT, &[&s(&secrets.join("c.key"))]),
+        "c.key (outside the brace) stays readable"
+    );
+    assert!(
+        f.allowed(pol, CAT, &[&s(&f.proj.join("pub.txt"))]),
+        "unrelated file readable"
+    );
+    // negative control — relaxed fs reads a.key fine, so the deny (not a missing file)
+    // is what blocks it above.
+    assert!(
+        f.allowed(
+            serde_json::json!({ "fs": true }),
+            CAT,
+            &[&s(&secrets.join("a.key"))]
+        ),
+        "neg-control: relaxed fs reads a.key"
+    );
+}
+
+#[test]
+fn nested_brace_deny_denies_all_alternatives() {
+    // A nested `{a,{b,c}}` must deny a, b AND c — the recursive-alternation shape.
+    let f = fixture();
+    let secrets = f.proj.join("nsec");
+    fs::create_dir_all(&secrets).unwrap();
+    for name in ["a.key", "b.key", "c.key", "d.key"] {
+        fs::write(secrets.join(name), "SECRET").unwrap();
+    }
+    let deny = format!("!{}/{{a,{{b,c}}}}.key", s(&secrets));
+    let pol = serde_json::json!({ "fs": ["...", deny] });
+    for name in ["a.key", "b.key", "c.key"] {
+        assert!(
+            !f.allowed(pol.clone(), CAT, &[&s(&secrets.join(name))]),
+            "nested-brace {name} denied"
+        );
+    }
+    assert!(
+        f.allowed(pol, CAT, &[&s(&secrets.join("d.key"))]),
+        "d.key (outside the nested brace) readable"
+    );
+}
+
 // ── fs write-confine ──────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/nub-sandbox/tests/matcher.rs
+++ b/crates/nub-sandbox/tests/matcher.rs
@@ -193,6 +193,10 @@ fn host_pattern_grammar_accepts_only_bare_and_leading_wildcard() {
     // bare `*` allow-all (fail loud, never fail open).
     assert!(!host_pattern_is_valid("*."));
     assert!(!host_pattern_is_valid("*.."));
+    // Brace alternation is not part of the host grammar — rejected (fs globs support
+    // braces; net hosts do not).
+    assert!(!host_pattern_is_valid("{a,b}.com"));
+    assert!(!host_pattern_is_valid("api.{a,b}.com"));
 }
 
 #[test]


### PR DESCRIPTION
Closes a confirmed silent leak (`wiki/research/sandbox-glob-deny-fidelity.md`): the macOS Seatbelt translator escaped braces `{a,b}` as literals, so `!secrets/{a,b}.key` left `a.key`/`b.key` readable — while globset (userspace + Linux) expands them.

- fs globs (allow + deny): expand `{a,b}`→`(a|b)`, matching globset. Nested/cartesian recurse; empty branches drop (`{a,}`=`a`); unbalanced `{` auto-closes. Linux/Windows unchanged.
- env-key + net-host globs: reject braces at compile time (narrower grammars, D11 class).

Verified: globset-oracle differential sweep + real macOS `sandbox-exec` enforcement (a/b denied, c readable) + env/net compile-error asserts.