### PR TITLE
sandbox(linux): seccomp-deny userns/mount + pidfd_getfd; narrow /dev to an allowlist

### DIFF
--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -264,3 +264,48 @@ Each is documented in code at the site noted; none is silently mis-reported.
   loads SIBLING DLLs from its own dir needs the front-end to supply that toolchain dir in
   the read allow-set — the engine no longer auto-widens. A self-contained build-jail
   toolchain (`node.exe`) needs nothing more. (`backend/windows.rs` `apply`.)
+
+## Linux syscall-boundary hardening (defense-in-depth, seccomp/`/dev`)
+
+Three former residuals now closed at the syscall boundary so FS/env confinement no longer
+leans on a host-policy chain. All VM-verified (kernel 6.17, Ubuntu 24.04) with differential
+probes carrying positive + negative controls; each has a committed regression test.
+
+- **Linux userns + mount family — the FS-escape now denied in seccomp (O1, CLOSED).** An
+  unprivileged user namespace (`unshare`/`clone(CLONE_NEWUSER)`) plus a bind-mount under a
+  granted dir is the strongest FS-confinement escape. It was previously blocked only by a
+  CHAIN — Landlock never grants `/proc` (so a `uid_map` write fails), the kernel refuses a
+  mount from an unmapped userns, and host AppArmor — none of which the engine owns. The
+  seccomp filter now denies `unshare`, `mount`, `umount2`, `pivot_root`, `move_mount`,
+  `fsopen`, `fsmount`, `fsconfig`, `open_tree` wholesale, and `clone` when its flags register
+  carries `CLONE_NEWUSER`/`CLONE_NEWNS`. `clone3` hides its flags behind a pointer (seccomp
+  cannot inspect them), so a companion filter returns `ENOSYS` for `clone3` — glibc then
+  falls back to the flag-filtered `clone` (the same technique Docker's default profile uses),
+  closing the `clone3(CLONE_NEWUSER)` path without breaking threading. VM-verified: `unshare`
+  and `clone(CLONE_NEWUSER)` return EPERM and `clone3` ENOSYS under sandbox, while the same
+  unprivileged forms succeed unsandboxed; normal `sh`/`python3`/PTY children (which fork via
+  the register `clone`) are unaffected. Residual: a procfs *bind-mounted before* entering the
+  sandbox is still not created via these syscalls (that residual is the "bind-mounted procfs
+  at a non-standard path" item above); O1 removes the in-sandbox mount-creation route to it.
+  (`backend/linux.rs` `build_seccomp`/`clone_userns_newns_rules`/`build_clone3_enosys`;
+  `seccomp_denies_userns_and_mount_family`.)
+- **Linux pidfd fd-theft — `pidfd_getfd` now denied (O2, CLOSED).** `pidfd_getfd` steals an
+  open fd out of another process (needs `PTRACE_MODE_ATTACH`; no legitimate confined use) and
+  was not in the denylist. It is now denied in seccomp. `pidfd_open` stays ALLOWED — it has
+  legitimate self-child uses (`pidfd_send_signal`/`waitid`) and cannot itself steal an fd.
+  VM-verified: under sandbox `pidfd_open` still returns a valid fd while `pidfd_getfd` is
+  EPERM; both go through unsandboxed. (`backend/linux.rs` `build_seccomp`;
+  `seccomp_denies_pidfd_getfd_keeps_pidfd_open`.)
+- **Linux `/dev` narrowed to a least-privilege allowlist (O3, CLOSED).** A read-confined
+  child was granted wholesale `/dev` rw. It is now granted per-node:
+  `null`/`zero`/`full`/`random`/`urandom`/`tty` (standard sink/source/entropy/tty) plus
+  `ptmx` + the `pts` subtree (PTYs). Everything else under `/dev` — and listing `/dev`
+  itself — is denied and fails CLOSED (EACCES, visible), not leaked. Landlock does no
+  directory-traverse check, so a leaf grant suffices to open the node by path without
+  granting the `/dev` directory. VM-verified: `/dev/null` + `/dev/urandom` and a full PTY
+  (ptmx → pts slave) work under read-confine, `python3` still spawns, and a non-allowlisted
+  node (`/dev/shm` write) is denied while relaxed-fs admits it. Residual: the env-scrub-only
+  relaxed path (fs deliberately relaxed) still grants `/dev` among the top-levels — narrowing
+  it there would contradict "fs relaxed"; the allowlist governs the read-confine path where
+  `/dev` is explicitly granted. (`backend/linux.rs` `DEV_ALLOWLIST`;
+  `dev_allowlist_permits_pty_and_nodes_denies_rest`.)

--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -277,16 +277,23 @@ probes carrying positive + negative controls; each has a committed regression te
   CHAIN — Landlock never grants `/proc` (so a `uid_map` write fails), the kernel refuses a
   mount from an unmapped userns, and host AppArmor — none of which the engine owns. The
   seccomp filter now denies `unshare`, `mount`, `umount2`, `pivot_root`, `move_mount`,
-  `fsopen`, `fsmount`, `fsconfig`, `open_tree` wholesale, and `clone` when its flags register
-  carries `CLONE_NEWUSER`/`CLONE_NEWNS`. `clone3` hides its flags behind a pointer (seccomp
-  cannot inspect them), so a companion filter returns `ENOSYS` for `clone3` — glibc then
-  falls back to the flag-filtered `clone` (the same technique Docker's default profile uses),
-  closing the `clone3(CLONE_NEWUSER)` path without breaking threading. VM-verified: `unshare`
-  and `clone(CLONE_NEWUSER)` return EPERM and `clone3` ENOSYS under sandbox, while the same
-  unprivileged forms succeed unsandboxed; normal `sh`/`python3`/PTY children (which fork via
-  the register `clone`) are unaffected. Residual: a procfs *bind-mounted before* entering the
-  sandbox is still not created via these syscalls (that residual is the "bind-mounted procfs
-  at a non-standard path" item above); O1 removes the in-sandbox mount-creation route to it.
+  `fsopen`, `fsmount`, `fsconfig`, `fspick`, `mount_setattr`, `open_tree` wholesale (the
+  classic + new-mount-API surface), and `clone` when its flags register carries
+  `CLONE_NEWUSER`/`CLONE_NEWNS`. `clone3` hides its flags behind a pointer (seccomp cannot
+  inspect them), so a companion filter returns `ENOSYS` for `clone3` — glibc then falls back
+  to the flag-filtered `clone` (the same technique Docker's default profile uses), closing the
+  `clone3(CLONE_NEWUSER)` path without breaking threading. VM-verified: `unshare` and
+  `clone(CLONE_NEWUSER)` return EPERM and `clone3` ENOSYS under sandbox, while the same
+  unprivileged forms succeed unsandboxed; normal `sh`/`python3`/PTY children AND a full Node
+  run (Worker-thread pthread_create → clone3→ENOSYS→clone fallback, plus crypto) are
+  unaffected. Two bounded trade-offs, both accepted: (a) a binary that calls `clone3`
+  DIRECTLY and does not fall back on ENOSYS loses threading — rare, and the same trade Docker's
+  default profile makes; (b) a nub-sandboxed child that builds its OWN user+mount-namespace
+  sandbox (an `unshare`/`bwrap`-based tool, a browser/Electron zygote) is denied under ANY
+  sandboxing axis, env-scrub-only included — the intended defense-in-depth posture, not a bug.
+  Residual: a procfs *bind-mounted before* entering the sandbox is still not created via these
+  syscalls (that residual is the "bind-mounted procfs at a non-standard path" item above); O1
+  removes the in-sandbox mount-creation route to it.
   (`backend/linux.rs` `build_seccomp`/`clone_userns_newns_rules`/`build_clone3_enosys`;
   `seccomp_denies_userns_and_mount_family`.)
 - **Linux pidfd fd-theft — `pidfd_getfd` now denied (O2, CLOSED).** `pidfd_getfd` steals an
@@ -303,9 +310,18 @@ probes carrying positive + negative controls; each has a committed regression te
   itself — is denied and fails CLOSED (EACCES, visible), not leaked. Landlock does no
   directory-traverse check, so a leaf grant suffices to open the node by path without
   granting the `/dev` directory. VM-verified: `/dev/null` + `/dev/urandom` and a full PTY
-  (ptmx → pts slave) work under read-confine, `python3` still spawns, and a non-allowlisted
-  node (`/dev/shm` write) is denied while relaxed-fs admits it. Residual: the env-scrub-only
-  relaxed path (fs deliberately relaxed) still grants `/dev` among the top-levels — narrowing
-  it there would contradict "fs relaxed"; the allowlist governs the read-confine path where
-  `/dev` is explicitly granted. (`backend/linux.rs` `DEV_ALLOWLIST`;
-  `dev_allowlist_permits_pty_and_nodes_denies_rest`.)
+  (ptmx → pts slave) work under read-confine, `python3` and a full Node run still spawn, and a
+  non-allowlisted node (`/dev/shm` write) is denied while relaxed-fs admits it. Bounded
+  trade-offs of the narrowing (each fails CLOSED + visible, never a silent leak): a
+  read-confined child can no longer open `/dev/shm` (POSIX shared memory —
+  `multiprocessing.shared_memory`, some native addons), `/dev/fd` / `/dev/stdin|out|err`
+  (these symlink into `/proc/self/fd`, deliberately ungranted — breaks `bash <(…)` process
+  substitution and `fs.read('/dev/stdin')`), or any device node outside the set; add the node
+  to the policy allow-set if a workload needs it. The granted `/dev/pts` subtree is rw, so a
+  child can reach ANOTHER same-uid process's PTY (Landlock + DAC do not scope by owner within
+  the subtree); on kernels older than the `dev.tty.legacy_tiocsti=0` default this permits
+  TIOCSTI keystroke injection into that terminal — bounded to same-uid, which already shares a
+  trust domain. Residual: the env-scrub-only relaxed path (fs deliberately relaxed) still
+  grants `/dev` among the top-levels — narrowing it there would contradict "fs relaxed"; the
+  allowlist governs the read-confine path where `/dev` is explicitly granted.
+  (`backend/linux.rs` `DEV_ALLOWLIST`; `dev_allowlist_permits_pty_and_nodes_denies_rest`.)

--- a/crates/nub-sandbox/src/backend/linux.rs
+++ b/crates/nub-sandbox/src/backend/linux.rs
@@ -48,6 +48,30 @@ const ESSENTIAL_READ_DIRS: &[&str] = &[
     "/usr", "/bin", "/sbin", "/lib", "/lib64", "/lib32", "/libx32", "/etc", "/opt",
 ];
 
+/// Least-privilege `/dev` allowlist (O3) — the device nodes a normal child actually
+/// opens, replacing the former wholesale `/dev` rw grant. Each node is granted rw
+/// individually; everything else under `/dev` (and `/dev` listing itself) is denied,
+/// failing CLOSED (EACCES, visible) rather than leaking. Why each is present:
+///   - `null`/`zero`/`full` — the standard sink/source char devices (redirects,
+///     `/dev/null` discards, `/dev/zero` fills).
+///   - `random`/`urandom` — entropy; libc/openssl/node CSPRNG seeding reads them.
+///   - `tty` — the process's controlling terminal (interactive I/O, isatty probes).
+///   - `ptmx` + `pts` — the PTY master clone device and the devpts slave directory:
+///     a PTY-spawning child (shells under a pseudo-terminal, `node-pty`, `script`)
+///     opens `/dev/ptmx` then its allocated `/dev/pts/N`, so the `pts` subtree is
+///     granted rw. Absent nodes are skipped by `add_if_exists`, so a host without
+///     devpts simply grants fewer nodes.
+const DEV_ALLOWLIST: &[&str] = &[
+    "/dev/null",
+    "/dev/zero",
+    "/dev/full",
+    "/dev/random",
+    "/dev/urandom",
+    "/dev/tty",
+    "/dev/ptmx",
+    "/dev/pts",
+];
+
 /// The net enforcement mode chosen for this run (resolved from the policy + whether an
 /// egress proxy is running + kernel capability).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -177,7 +201,13 @@ pub fn apply(
                     add_if_exists(&mut grant_specs, p, read_bits);
                 }
             }
-            add_if_exists(&mut grant_specs, Path::new("/dev"), rw_bits);
+            // /dev is granted per-node, NOT wholesale (O3): the least-privilege set a
+            // normal child needs (see [`DEV_ALLOWLIST`]). Landlock does no
+            // directory-traverse check, so a leaf grant suffices to open the node by
+            // path without granting the /dev directory itself.
+            for node in DEV_ALLOWLIST {
+                add_if_exists(&mut grant_specs, Path::new(node), rw_bits);
+            }
             if let Some(prog) = resolve_program(&spec.program, spec.cwd.as_deref()) {
                 add_if_exists(&mut grant_specs, &prog, AccessFs::ReadFile.into());
             }
@@ -232,6 +262,13 @@ pub fn apply(
         lost: vec!["seccomp".to_string()],
         reason: Some(e),
     })?;
+    // Companion filter that forces glibc off the unfilterable `clone3` onto the
+    // flag-filtered `clone` (O1 — see [`build_clone3_enosys`]). Installed alongside
+    // the main filter; the kernel takes the most-restrictive verdict per syscall.
+    let clone3_enosys = build_clone3_enosys().map_err(|e| Degradation {
+        lost: vec!["seccomp".to_string()],
+        reason: Some(e),
+    })?;
 
     // ── connect-notify supervisor (Proxy mode only) ─────────────────────────────
     // Close the port-scoped ConnectTcp residual: the child's pre_exec installs a 2nd
@@ -273,6 +310,9 @@ pub fn apply(
                     .map_err(std::io::Error::other)?;
             }
             seccompiler::apply_filter(&seccomp).map_err(std::io::Error::other)?;
+            if let Some(prog) = &clone3_enosys {
+                seccompiler::apply_filter(prog).map_err(std::io::Error::other)?;
+            }
             // Install the connect→USER_NOTIF filter LAST and hand its listener fd to the
             // parent. After the EPERM filter (which allows seccomp/sendmsg/close), so the
             // handoff syscalls flow; connect gets USER_NOTIF (lower RET value than the
@@ -506,17 +546,48 @@ fn build_seccomp(net_mode: NetMode) -> Result<BpfProgram, String> {
         .map_err(|e| format!("unsupported arch for seccomp: {e}"))?;
     let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
 
-    // Unconditional ptrace-family deny (empty rule-vec → always matches).
+    // Unconditional deny set (empty rule-vec → always matches → EPERM). Three
+    // defense-in-depth families, all closed at the syscall boundary whenever ANY
+    // axis is sandboxed:
+    //   - ptrace family (the env-read second vector — scraping an ancestor's memory).
+    //   - userns + mount family (O1): an unprivileged user namespace + bind-mount
+    //     under a granted dir is the strongest FS-confinement escape. Today it's
+    //     blocked only by a CHAIN (Landlock never grants /proc → uid_map write fails,
+    //     the kernel refuses a mount from an unmapped userns, host AppArmor). Denying
+    //     the namespace/mount syscalls here makes FS confinement self-sufficient. The
+    //     register-flag `clone` (below) + the `clone3` ENOSYS filter close the two
+    //     clone forms; `unshare` and the mount/new-mount-API calls are denied whole.
+    //     Normal children (node/sh/python) call none of these.
+    //   - pidfd_getfd (O2): the fd-theft primitive — steal a parent's open fd via a
+    //     pidfd (needs PTRACE_MODE_ATTACH; zero legit confined use). `pidfd_open`
+    //     stays ALLOWED (legit self-child signaling: pidfd_send_signal/waitid).
     #[allow(clippy::useless_conversion)]
     for syscall in [
         libc::SYS_ptrace,
         libc::SYS_process_vm_readv,
         libc::SYS_process_vm_writev,
+        libc::SYS_unshare,
+        libc::SYS_mount,
+        libc::SYS_umount2,
+        libc::SYS_pivot_root,
+        libc::SYS_move_mount,
+        libc::SYS_fsopen,
+        libc::SYS_fsmount,
+        libc::SYS_fsconfig,
+        libc::SYS_open_tree,
+        libc::SYS_pidfd_getfd,
     ]
     .map(i64::from)
     {
         rules.insert(syscall, Vec::new());
     }
+
+    // clone(CLONE_NEWUSER|CLONE_NEWNS): filter the flags REGISTER (arg0). A plain
+    // fork/thread-creating clone sets neither bit, so it still flows; only a
+    // namespace-creating clone is denied. The `clone3` form carries its flags behind
+    // a POINTER (unfilterable by seccomp) and is handled by a separate ENOSYS filter
+    // (see [`build_clone3_enosys`]) that forces glibc's fallback onto this `clone`.
+    rules.insert(i64_from(libc::SYS_clone), clone_userns_newns_rules()?);
 
     if net_mode != NetMode::Off {
         const EXOTIC: [libc::c_int; 11] = [
@@ -590,6 +661,53 @@ fn build_seccomp(net_mode: NetMode) -> Result<BpfProgram, String> {
     .map_err(|e| format!("seccomp build: {e}"))?
     .try_into()
     .map_err(|e| format!("seccomp compile: {e}"))
+}
+
+/// Deny a namespace-creating `clone`: one rule per unprivileged-escape flag bit,
+/// matching `(flags & bit) == bit` on the flags register (arg0). `CLONE_NEWUSER`
+/// (0x1000_0000) is the unprivileged-userns primitive that unlocks the mount escape;
+/// `CLONE_NEWNS` (0x0002_0000) is the mount-namespace bit. A normal fork/thread clone
+/// sets neither, so this never touches legitimate process/thread creation.
+fn clone_userns_newns_rules() -> Result<Vec<SeccompRule>, String> {
+    const CLONE_NEWNS: u64 = 0x0002_0000;
+    const CLONE_NEWUSER: u64 = 0x1000_0000;
+    let mut out = Vec::with_capacity(2);
+    for bit in [CLONE_NEWUSER, CLONE_NEWNS] {
+        out.push(
+            SeccompRule::new(vec![
+                SeccompCondition::new(0, SeccompCmpArgLen::Dword, SeccompCmpOp::MaskedEq(bit), bit)
+                    .map_err(|e| format!("clone flag cond: {e}"))?,
+            ])
+            .map_err(|e| format!("clone flag rule: {e}"))?,
+        );
+    }
+    Ok(out)
+}
+
+/// A SEPARATE seccomp filter that returns `ENOSYS` for `clone3` (whenever the main
+/// filter is installed). `clone3` carries its flags behind a POINTER, so seccomp
+/// cannot inspect `CLONE_NEWUSER`/`CLONE_NEWNS` the way the register-based `clone`
+/// filter does. Returning `ENOSYS` (not `EPERM`) makes glibc believe the kernel lacks
+/// `clone3` and fall back to the register-based `clone` — which the main filter DOES
+/// flag-filter — so a `clone3(CLONE_NEWUSER)` escape is closed without breaking
+/// threading (the fallback `clone` for a normal thread carries no namespace bit).
+/// This is the same technique Docker's default seccomp profile uses. `None` when the
+/// arch/libc exposes no `clone3` number (nothing to force-fall-back).
+fn build_clone3_enosys() -> Result<Option<BpfProgram>, String> {
+    let arch = TargetArch::try_from(std::env::consts::ARCH)
+        .map_err(|e| format!("unsupported arch for seccomp: {e}"))?;
+    let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
+    rules.insert(i64_from(libc::SYS_clone3), Vec::new());
+    let prog = SeccompFilter::new(
+        rules,
+        SeccompAction::Allow,
+        SeccompAction::Errno(libc::ENOSYS as u32),
+        arch,
+    )
+    .map_err(|e| format!("clone3 seccomp build: {e}"))?
+    .try_into()
+    .map_err(|e| format!("clone3 seccomp compile: {e}"))?;
+    Ok(Some(prog))
 }
 
 /// Deny `socket(AF_INET, _, proto)` for any `proto` other than default (0) or

--- a/crates/nub-sandbox/src/backend/linux.rs
+++ b/crates/nub-sandbox/src/backend/linux.rs
@@ -574,6 +574,8 @@ fn build_seccomp(net_mode: NetMode) -> Result<BpfProgram, String> {
         libc::SYS_fsopen,
         libc::SYS_fsmount,
         libc::SYS_fsconfig,
+        libc::SYS_fspick,
+        libc::SYS_mount_setattr,
         libc::SYS_open_tree,
         libc::SYS_pidfd_getfd,
     ]
@@ -691,8 +693,9 @@ fn clone_userns_newns_rules() -> Result<Vec<SeccompRule>, String> {
 /// `clone3` and fall back to the register-based `clone` — which the main filter DOES
 /// flag-filter — so a `clone3(CLONE_NEWUSER)` escape is closed without breaking
 /// threading (the fallback `clone` for a normal thread carries no namespace bit).
-/// This is the same technique Docker's default seccomp profile uses. `None` when the
-/// arch/libc exposes no `clone3` number (nothing to force-fall-back).
+/// This is the same technique Docker's default seccomp profile uses. The `Option` is
+/// the extension seam for an arch that exposes no `clone3` number; on the supported
+/// x86_64/aarch64 targets `SYS_clone3` always resolves, so this returns `Some`.
 fn build_clone3_enosys() -> Result<Option<BpfProgram>, String> {
     let arch = TargetArch::try_from(std::env::consts::ARCH)
         .map_err(|e| format!("unsupported arch for seccomp: {e}"))?;

--- a/crates/nub-sandbox/tests/linux_enforcement.rs
+++ b/crates/nub-sandbox/tests/linux_enforcement.rs
@@ -787,6 +787,52 @@ fn dev_allowlist_permits_pty_and_nodes_denies_rest() {
     );
 }
 
+// ── node runs cleanly under the full hardening (the ship-blocker check) ──────────
+
+/// A real Node binary if one is installed (CI runners + the dev VM have one). The
+/// hardening MUST NOT break Node — it is the runtime nub augments.
+fn node_bin() -> Option<String> {
+    for p in ["/usr/local/bin/node", "/usr/bin/node"] {
+        if Path::new(p).exists() {
+            return Some(p.to_string());
+        }
+    }
+    None
+}
+
+#[test]
+fn node_threads_and_crypto_under_full_hardening() {
+    if skip_without_landlock() {
+        return;
+    }
+    let Some(node) = node_bin() else {
+        return; // no Node on this host — skip (VM/CI runners have one)
+    };
+    let f = fixture();
+    // Read-confine engages the whole stack at once: O1 seccomp (userns/mount deny +
+    // clone3→ENOSYS) + O2 (pidfd_getfd deny) + O3 (/dev allowlist); the unlisted net
+    // axis floors to deny-all, so seccomp is installed. This is the strictest posture.
+    // The Worker spawns a libuv/V8 thread — glibc issues clone3 for pthread_create, so
+    // this exercises the ENOSYS→clone fallback; crypto.randomBytes exercises the /dev
+    // entropy allowlist FROM the worker thread.
+    let script = "const {Worker}=require('worker_threads');\
+        const w=new Worker(\"const{parentPort}=require('worker_threads');\
+        parentPort.postMessage(require('crypto').randomBytes(4).toString('hex'))\",{eval:true});\
+        w.on('message',m=>{console.log('NODEOK'+m);w.terminate();});\
+        w.on('error',e=>{console.log('NODEERR'+e);});";
+    let (code, out) = f.run(
+        serde_json::json!({ "fs": ["./"] }),
+        &[],
+        &node,
+        &["-e", script],
+    );
+    assert!(
+        out.contains("NODEOK"),
+        "node must start, spawn a Worker thread (clone3→ENOSYS→clone fallback), and use \
+         crypto under the full O1/O2/O3 hardening (exit {code}, out {out:?})"
+    );
+}
+
 // ── graceful degradation is honest ──────────────────────────────────────────────
 
 #[test]

--- a/crates/nub-sandbox/tests/linux_enforcement.rs
+++ b/crates/nub-sandbox/tests/linux_enforcement.rs
@@ -471,17 +471,52 @@ fn probe_bin(dir: &Path) -> Option<PathBuf> {
     ok.then_some(bin)
 }
 
-/// Probe: `probe <socket|vmread|ptrace>` exits 42 when the syscall was DENIED
-/// (EPERM), 0 when it went through. vmread/ptrace target SELF so the verdict is the
-/// seccomp filter's, not the host's yama policy.
+/// Probe: `probe <cmd>` exits 42 when the syscall was DENIED, 0 when it went through
+/// (43 = an over-deny the test flags). vmread/ptrace/pidfd target SELF so the verdict
+/// is the seccomp filter's, not the host's yama policy. Commands:
+///   socket/vmread/ptrace — the net + env-read-vector denies (existing).
+///   unshare  — `unshare(CLONE_FILES)`: an UNPRIVILEGED, host-policy-independent
+///              unshare that succeeds everywhere → proves the wholesale O1 `unshare`
+///              deny (which blocks every flag, incl. CLONE_NEWUSER, by syscall number).
+///   clone3   — `clone3(flags=0)`: a plain unprivileged fork → 42 iff the ENOSYS
+///              companion filter fired (glibc-fallback), proving clone3 (every flag,
+///              incl. CLONE_NEWUSER) is force-failed at the syscall boundary.
+///   clonens  — raw `clone(CLONE_NEWUSER|SIGCHLD)`: the register-flag escape → 42 iff
+///              the flag-filter denied it (unsandboxed it creates a userns child).
+///   pidfd    — `pidfd_open(self)` then `pidfd_getfd`: 42 iff getfd is denied while
+///              pidfd_open stays allowed (O2); 43 iff pidfd_open was wrongly denied.
+///   pty      — open /dev/ptmx, grantpt/unlockpt, open the /dev/pts slave: 0 iff the
+///              O3 allowlist admits a full PTY (nonzero = which step the narrowing broke).
 const PROBE_C: &str = r#"
 #define _GNU_SOURCE
 #include <errno.h>
 #include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <signal.h>
 #include <sys/socket.h>
 #include <sys/ptrace.h>
 #include <sys/uio.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
 #include <unistd.h>
+#ifndef SYS_pidfd_open
+#define SYS_pidfd_open 434
+#endif
+#ifndef SYS_pidfd_getfd
+#define SYS_pidfd_getfd 438
+#endif
+#ifndef SYS_clone3
+#define SYS_clone3 435
+#endif
+#define P_CLONE_NEWNS   0x00020000
+#define P_CLONE_NEWUSER 0x10000000
+#define P_CLONE_FILES   0x00000400
+struct clone_args_probe {
+    uint64_t flags, pidfd, child_tid, parent_tid, exit_signal, stack, stack_size, tls;
+};
 int main(int argc, char** argv) {
     if (argc < 2) return 2;
     if (!strcmp(argv[1], "socket")) {
@@ -499,6 +534,45 @@ int main(int argc, char** argv) {
     if (!strcmp(argv[1], "ptrace")) {
         long r = ptrace(PTRACE_TRACEME, 0, 0, 0);
         if (r == -1 && errno == EPERM) return 42;
+        return 0;
+    }
+    if (!strcmp(argv[1], "unshare")) {
+        int r = unshare(P_CLONE_FILES);
+        if (r < 0 && errno == EPERM) return 42;
+        return 0;
+    }
+    if (!strcmp(argv[1], "clone3")) {
+        struct clone_args_probe a; memset(&a, 0, sizeof a);
+        a.exit_signal = SIGCHLD;
+        long r = syscall(SYS_clone3, &a, sizeof a);
+        if (r == 0) _exit(0);                       /* child */
+        if (r < 0 && (errno == ENOSYS || errno == EPERM)) return 42;
+        if (r > 0) { int st; waitpid((pid_t)r, &st, 0); }
+        return 0;
+    }
+    if (!strcmp(argv[1], "clonens")) {
+        long r = syscall(SYS_clone, (long)(P_CLONE_NEWUSER | SIGCHLD), 0L, 0L, 0L, 0L);
+        if (r == 0) _exit(0);                       /* child (unsandboxed: in a userns) */
+        if (r < 0 && errno == EPERM) return 42;
+        if (r > 0) { int st; waitpid((pid_t)r, &st, 0); }
+        return 0;
+    }
+    if (!strcmp(argv[1], "pidfd")) {
+        long pfd = syscall(SYS_pidfd_open, getpid(), 0);
+        if (pfd < 0) return 43;                     /* pidfd_open must stay allowed */
+        long stolen = syscall(SYS_pidfd_getfd, (int)pfd, 0, 0);
+        if (stolen < 0 && errno == EPERM) return 42;
+        return 0;
+    }
+    if (!strcmp(argv[1], "pty")) {
+        int m = posix_openpt(O_RDWR | O_NOCTTY);
+        if (m < 0) return 10;                        /* /dev/ptmx open blocked */
+        if (grantpt(m) != 0) return 11;
+        if (unlockpt(m) != 0) return 12;
+        char* sn = ptsname(m);
+        if (!sn) return 13;
+        int sfd = open(sn, O_RDWR | O_NOCTTY);
+        if (sfd < 0) return 14;                      /* /dev/pts slave open blocked */
         return 0;
     }
     return 2;
@@ -555,6 +629,161 @@ fn seccomp_denies_net_ptrace_and_vmread() {
         f.run(relaxed, &[], &probe, &["vmread"]).0,
         0,
         "neg: vmread allowed unsandboxed"
+    );
+}
+
+// ── O1: userns + mount-family seccomp deny (FS-escape closed at the boundary) ────
+
+#[test]
+fn seccomp_denies_userns_and_mount_family() {
+    if skip_without_landlock() {
+        return;
+    }
+    let f = fixture();
+    let Some(probe) = probe_bin(&f.proj) else {
+        return; // no cc — skip the syscall probes
+    };
+    let probe = s(&probe);
+    // Sandboxing active via net-enforce; fs relaxed so the probe execs from anywhere
+    // (an unlisted fs axis would floor to deny-all and stop the exec).
+    let sb = serde_json::json!({ "net": false, "fs": true });
+
+    // `unshare` is denied wholesale — proven with CLONE_FILES (unprivileged, succeeds
+    // on every host), so the deny is by syscall NUMBER and covers CLONE_NEWUSER too.
+    assert_eq!(
+        f.run(sb.clone(), &[], &probe, &["unshare"]).0,
+        42,
+        "unshare denied (blocks the userns-creating form by syscall number)"
+    );
+    // `clone3` is force-failed to ENOSYS (the glibc-fallback companion filter) — a
+    // plain fork via clone3 is blocked, so every clone3 flag set (incl. CLONE_NEWUSER)
+    // cannot create a namespace; glibc falls back to the flag-filtered `clone`.
+    assert_eq!(
+        f.run(sb.clone(), &[], &probe, &["clone3"]).0,
+        42,
+        "clone3 forced to ENOSYS (userns via clone3 closed; glibc falls back to clone)"
+    );
+    // The register-flag escape: `clone(CLONE_NEWUSER)` denied by the flag-filter.
+    // Deterministic under sandbox regardless of host unprivileged-userns policy (the
+    // seccomp EPERM precedes the kernel's userns check).
+    assert_eq!(
+        f.run(sb, &[], &probe, &["clonens"]).0,
+        42,
+        "clone(CLONE_NEWUSER) denied by the flag-filter"
+    );
+
+    // Negative controls — unsandboxed, the two unprivileged host-independent forms go
+    // through, proving the blocks above are ours (not a missing-capability artifact).
+    // (`clonens` is intentionally not controlled here: its unsandboxed success needs
+    // host unprivileged-userns; `unshare`/`clone3` carry the negative side robustly.)
+    let relaxed = serde_json::json!(false);
+    assert_eq!(
+        f.run(relaxed.clone(), &[], &probe, &["unshare"]).0,
+        0,
+        "neg: unshare(CLONE_FILES) allowed unsandboxed"
+    );
+    assert_eq!(
+        f.run(relaxed, &[], &probe, &["clone3"]).0,
+        0,
+        "neg: clone3 fork allowed unsandboxed"
+    );
+}
+
+// ── O2: pidfd fd-theft closed (getfd denied; pidfd_open preserved) ───────────────
+
+#[test]
+fn seccomp_denies_pidfd_getfd_keeps_pidfd_open() {
+    if skip_without_landlock() {
+        return;
+    }
+    let f = fixture();
+    let Some(probe) = probe_bin(&f.proj) else {
+        return;
+    };
+    let probe = s(&probe);
+    // Under sandbox: pidfd_open must still succeed (probe returns 43 if wrongly
+    // denied), and pidfd_getfd — the fd-theft primitive — must be EPERM (42).
+    assert_eq!(
+        f.run(
+            serde_json::json!({ "net": false, "fs": true }),
+            &[],
+            &probe,
+            &["pidfd"]
+        )
+        .0,
+        42,
+        "pidfd_getfd denied while pidfd_open stays allowed"
+    );
+    // Negative control — unsandboxed, the fd theft goes through.
+    assert_eq!(
+        f.run(serde_json::json!(false), &[], &probe, &["pidfd"]).0,
+        0,
+        "neg: pidfd_getfd allowed unsandboxed"
+    );
+}
+
+// ── O3: /dev narrowed to an allowlist (least-privilege, PTY still works) ──────────
+
+#[test]
+fn dev_allowlist_permits_pty_and_nodes_denies_rest() {
+    if skip_without_landlock() {
+        return;
+    }
+    let f = fixture();
+    // Read-confine engages the O3 /dev narrowing (wholesale `/dev` rw → per-node).
+    let confine = serde_json::json!({ "fs": ["./"] });
+
+    // Allowlisted nodes are usable: write /dev/null + read /dev/urandom.
+    assert!(
+        f.ok(
+            confine.clone(),
+            SH,
+            &[
+                "-c",
+                "printf x > /dev/null && head -c 4 /dev/urandom > /dev/null"
+            ]
+        ),
+        "allowlisted /dev/null + /dev/urandom usable under read-confine"
+    );
+    // A non-allowlisted node fails CLOSED: /dev/shm (world-writable tmpfs) write denied.
+    assert!(
+        !f.ok(
+            confine.clone(),
+            SH,
+            &["-c", "printf x > /dev/shm/nub_dev_probe"]
+        ),
+        "non-allowlisted /dev/shm write denied under read-confine"
+    );
+    // A PTY-spawning program works: /dev/ptmx + the /dev/pts slave are allowlisted.
+    if let Some(probe) = probe_bin(&f.proj) {
+        assert_eq!(
+            f.run(confine.clone(), &[], &s(&probe), &["pty"]).0,
+            0,
+            "PTY (ptmx + pts slave) opens under the /dev allowlist"
+        );
+    }
+    // A dynamically-linked interpreter still spawns under the narrowed /dev.
+    if Path::new("/usr/bin/python3").exists() {
+        let (_c, out) = f.run(
+            confine.clone(),
+            &[],
+            "/usr/bin/python3",
+            &["-c", "print('ok')"],
+        );
+        assert!(
+            out.contains("ok"),
+            "python3 (dynamic interpreter) runs under the narrowed /dev"
+        );
+    }
+    // Negative control — with fs relaxed, the non-allowlisted /dev/shm write succeeds,
+    // proving the deny above is the narrowing (not a missing tmpfs).
+    assert!(
+        f.ok(
+            serde_json::json!({ "fs": true }),
+            SH,
+            &["-c", "printf x > /dev/shm/nub_dev_probe2"]
+        ),
+        "neg-control: relaxed fs writes /dev/shm"
     );
 }
 


### PR DESCRIPTION
Three Linux defense-in-depth closures so FS/env confinement holds at the syscall boundary, not via a host-policy chain. VM-verified (kernel 6.17); tests carry positive+negative controls.

- **O1 userns/mount:** seccomp denies the `unshare`/`mount`/new-mount-API family and `clone(CLONE_NEWUSER|CLONE_NEWNS)`, and forces `clone3` to `ENOSYS` (glibc falls back to the flag-filtered `clone`; threading unaffected).
- **O2 pidfd:** deny `pidfd_getfd` (fd theft); `pidfd_open` stays allowed.
- **O3 /dev:** read-confined children get a per-node allowlist (`null`/`zero`/`full`/`random`/`urandom`/`tty`/`ptmx`/`pts`) instead of wholesale `/dev` rw; else fails closed. PTYs + `python3` verified.

Base: `sandbox-primitives`. Marks the residuals closed in `LIMITATIONS.md`.
