### PR TITLE
sandbox(net): capability-derived MITM tier — credential brokering (cut-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,7 +2768,11 @@ dependencies = [
  "ipnet",
  "landlock",
  "libc",
+ "pem",
+ "rcgen",
  "regex",
+ "rustls",
+ "rustls-native-certs",
  "seccompiler",
  "serde",
  "serde_json",
@@ -2803,6 +2813,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3396,6 +3412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3634,6 +3656,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -4890,6 +4925,25 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -6216,6 +6270,15 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-iter",
  "tree-sitter-yaml",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/crates/nub-sandbox/Cargo.toml
+++ b/crates/nub-sandbox/Cargo.toml
@@ -31,6 +31,26 @@ globset = "0.4"
 regex = "1"
 ipnet = { version = "2", features = ["serde"] }
 
+# TLS termination for the MITM credential-brokering tier (proxy/mitm.rs, proxy/ca.rs).
+# Engaged ONLY when a net rule uses a capability that cannot be enforced without
+# reading inside the TLS stream (a credential-inject rule); host-only policies never
+# instantiate any of this. rustls (server side, blocking over std::net) + rustls-native-
+# certs (the real platform roots, bundled with the ephemeral CA so blind-tunneled hosts
+# still verify) are ALREADY in the workspace lockfile via reqwest's rustls-tls-native-
+# roots; rcgen (ephemeral CA + per-host leaf minting) is the one added supply-chain
+# surface. All three pinned to the `ring` crypto backend (already in-tree) so there is a
+# single provider — passed EXPLICITLY (no process-global default is installed anywhere).
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-native-certs = "0.8"
+rcgen = { version = "0.13", default-features = false, features = ["ring", "pem"] }
+# pem encodes the real platform roots into the child CA-bundle (rcgen gives the CA cert
+# as PEM directly; the DER roots need encoding). tempfile owns the bundle file's lifetime
+# — it holds ONLY public certs (never the CA key) and is removed when the CA drops. Both
+# already in the workspace lockfile (pem via rcgen; tempfile was a dev-dep) — no new
+# supply-chain surface.
+pem = "3"
+tempfile = "3"
+
 # libc: macOS needs it (confstr scratch-dir lookup in the Seatbelt backend); Linux
 # uses it in the Landlock/seccomp backend (prctl + the raw landlock ABI probe).
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]

--- a/crates/nub-sandbox/src/backend/linux.rs
+++ b/crates/nub-sandbox/src/backend/linux.rs
@@ -84,10 +84,15 @@ pub fn apply(
     policy: &SandboxPolicy,
     spec: CommandSpec,
     proxy_port: Option<u16>,
+    ca_bundle: Option<&std::path::Path>,
 ) -> Result<Prepared, Degradation> {
     let mut command = base_command(&spec, policy);
     if let Some(port) = proxy_port {
         super::set_proxy_env(&mut command, port);
+    }
+    // CA trust for the child (the Landlock read grant is added to the fs ruleset below).
+    if let Some(bundle) = ca_bundle {
+        super::set_ca_env(&mut command, bundle);
     }
 
     let confine_fs = fs_confines(&policy.fs);
@@ -180,6 +185,11 @@ pub fn apply(
             add_if_exists(&mut grant_specs, Path::new("/dev"), rw_bits);
             if let Some(prog) = resolve_program(&spec.program, spec.cwd.as_deref()) {
                 add_if_exists(&mut grant_specs, &prog, AccessFs::ReadFile.into());
+            }
+            // The child must READ the CA bundle to trust the minted leaves — grant it
+            // explicitly so a confining fs policy can't hide nub's own trust infra.
+            if let Some(bundle) = ca_bundle {
+                add_if_exists(&mut grant_specs, bundle, AccessFs::ReadFile.into());
             }
             if read_partial {
                 deg.lost.push("fs-read-partial".to_string());

--- a/crates/nub-sandbox/src/backend/macos.rs
+++ b/crates/nub-sandbox/src/backend/macos.rs
@@ -73,6 +73,7 @@ pub fn apply(
     policy: &SandboxPolicy,
     spec: CommandSpec,
     proxy_port: Option<u16>,
+    ca_bundle: Option<&std::path::Path>,
 ) -> Result<Prepared, Degradation> {
     if !needs_wrap(policy) {
         // Nothing to confine and no withheld secret to protect: the env-scrub is pure
@@ -87,7 +88,7 @@ pub fn apply(
         });
     }
 
-    let profile = build_profile(policy, &spec, proxy_port);
+    let profile = build_profile(policy, &spec, proxy_port, ca_bundle);
     let mut wrapped = Command::new("sandbox-exec");
     wrapped.arg("-p").arg(&profile).arg("--");
     wrapped.arg(&spec.program).args(&spec.args);
@@ -108,6 +109,11 @@ pub fn apply(
     // the real boundary). Set AFTER env_clear so it survives an enforced env scrub.
     if let Some(port) = proxy_port {
         super::set_proxy_env(&mut wrapped, port);
+    }
+    // CA trust for the child (the leaf-verifying bundle). The read grant lives in the
+    // SBPL profile (see build_profile); this is the env half so tools find the bundle.
+    if let Some(bundle) = ca_bundle {
+        super::set_ca_env(&mut wrapped, bundle);
     }
 
     Ok(Prepared {
@@ -167,7 +173,12 @@ fn fs_confines(policy: &SandboxPolicy) -> bool {
 }
 
 /// Build the full SBPL profile text for `policy`.
-fn build_profile(policy: &SandboxPolicy, spec: &CommandSpec, proxy_port: Option<u16>) -> String {
+fn build_profile(
+    policy: &SandboxPolicy,
+    spec: &CommandSpec,
+    proxy_port: Option<u16>,
+    ca_bundle: Option<&std::path::Path>,
+) -> String {
     let mut out = String::with_capacity(MACOS_SEATBELT_BASE.len() + 2048);
     out.push_str(MACOS_SEATBELT_BASE);
     out.push('\n');
@@ -175,6 +186,14 @@ fn build_profile(policy: &SandboxPolicy, spec: &CommandSpec, proxy_port: Option<
     emit_env_read_closure(&mut out);
     emit_net(policy, proxy_port, &mut out);
     emit_fs(policy, spec, &mut out);
+    // The child must READ the CA bundle to trust the minted leaves — grant it explicitly,
+    // AFTER emit_fs so it survives even a deny-all fs floor (nub infra, not user config).
+    if let Some(bundle) = ca_bundle {
+        out.push_str(&format!(
+            "(allow file-read* (literal \"{}\"))\n",
+            sbpl_escape(&bundle.to_string_lossy())
+        ));
+    }
 
     out
 }
@@ -999,7 +1018,7 @@ mod tests {
                 rule("**/.env", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(prof.contains("(allow file-read* (subpath \"/\"))"));
         // The `.env` deny is emitted AFTER the generous allow (last-match-wins).
         let allow_at = prof.find("(allow file-read* (subpath \"/\"))").unwrap();
@@ -1020,7 +1039,7 @@ mod tests {
             Effect::Deny,
             vec![rule("/proj", Effect::Allow, FsAccess::ReadWrite)],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(!prof.contains("(allow file-read* (subpath \"/\"))\n"));
         assert!(prof.contains("(allow file-read* (subpath \"/proj\"))"));
     }
@@ -1037,7 +1056,7 @@ mod tests {
                 rule("/proj/secret", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(prof.contains("(allow file-write* (subpath \"/proj\"))"));
         assert!(prof.contains("(deny file-write* (subpath \"/proj/ro\"))"));
         assert!(prof.contains("(deny file-write* (subpath \"/proj/secret\"))"));
@@ -1056,7 +1075,7 @@ mod tests {
                 rule("/proj", Effect::Allow, FsAccess::ReadWrite),
             ],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         let cap = prof.find("(deny file-write* (subpath \"/\"))").unwrap();
         let confstr = prof
             .find("(allow file-write* (subpath \"/private/var/folders/")
@@ -1080,7 +1099,7 @@ mod tests {
                 rule("**/.env", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         let confstr = prof
             .find("(allow file-write* (subpath \"/private/var/folders/")
             .expect("confstr temp grant present");
@@ -1109,7 +1128,7 @@ mod tests {
                 rule("/proj", Effect::Allow, FsAccess::ReadWrite),
             ],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(!prof.contains("(deny file-write-unlink (subpath \"/\"))"));
         assert!(!prof.contains("(deny file-write-create (subpath \"/\"))"));
         // And the confstr grant is still the last word on the temp dir.
@@ -1129,7 +1148,7 @@ mod tests {
                 rule("/root/proj/.env", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(prof.contains("(deny file-write-unlink (literal \"/root/proj\"))"));
         assert!(prof.contains("(deny file-write-create (literal \"/root/proj\"))"));
         assert!(prof.contains("(deny file-write-unlink (literal \"/root\"))"));
@@ -1150,7 +1169,7 @@ mod tests {
                 rule("**/.env", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(!prof.contains("(deny file-write-unlink (literal \"/root\"))"));
     }
 
@@ -1168,7 +1187,7 @@ mod tests {
                 rule("/root/secrets/*.key", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(prof.contains("(deny file-write-unlink (literal \"/root/secrets\"))"));
         assert!(prof.contains("(deny file-write-create (literal \"/root/secrets\"))"));
         assert!(prof.contains("(deny file-write-unlink (literal \"/root\"))"));
@@ -1206,7 +1225,7 @@ mod tests {
                 rule("**/secrets/**", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(!prof.contains("(deny file-write-unlink (literal \"/root\"))"));
     }
 
@@ -1221,7 +1240,7 @@ mod tests {
                 rule("/root/proj/.env", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(!prof.contains("(deny file-write-unlink (literal \"/root/proj\"))"));
         assert!(!prof.contains("(deny file-write-unlink (literal \"/root\"))"));
     }
@@ -1234,7 +1253,7 @@ mod tests {
             Effect::Deny,
             vec![rule("/proj", Effect::Allow, FsAccess::ReadWrite)],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         if let Some(cache) = confstr_dir(libc::_CS_DARWIN_USER_CACHE_DIR) {
             let cache =
                 normalize_slashes(&canonicalize_including_nonexistent(&cache).to_string_lossy());
@@ -1253,7 +1272,7 @@ mod tests {
             Effect::Deny,
             vec![rule("/private", Effect::Allow, FsAccess::ReadWrite)],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(!prof.contains("(allow file-write* (subpath \"/private\"))"));
         assert!(is_dangerous_write_root(&MatchTerm::Subpath(
             "/private".to_string()
@@ -1289,8 +1308,9 @@ mod tests {
             enforce: true,
             rules: vec![],
             default_effect: Effect::Deny,
+            ..Default::default()
         };
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(prof.contains("(allow file*)"));
     }
 
@@ -1304,8 +1324,9 @@ mod tests {
             enforce: true,
             rules: vec![],
             default_effect: Effect::Deny,
+            ..Default::default()
         };
-        let prof = build_profile(&p, &spec(), Some(54321));
+        let prof = build_profile(&p, &spec(), Some(54321), None);
         assert!(prof.contains("(allow network* (remote ip \"localhost:54321\"))"));
         assert!(
             !prof.contains("localhost:*"),
@@ -1323,8 +1344,9 @@ mod tests {
             enforce: true,
             rules: vec![],
             default_effect: Effect::Deny,
+            ..Default::default()
         };
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(
             !prof.contains("(allow network*"),
             "coarse deny emits no egress carve"
@@ -1338,7 +1360,7 @@ mod tests {
             Effect::Deny,
             vec![rule("/proj", Effect::Allow, FsAccess::ReadWrite)],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(prof.contains("(allow network*)\n"));
         assert!(prof.contains("com.apple.trustd"));
     }
@@ -1353,6 +1375,7 @@ mod tests {
                 effect: Effect::Allow,
             }],
             default_effect: Effect::Deny,
+            ..Default::default()
         };
         // No proxy available → per-host can't be enforced → degraded.
         let deg = degradation(&p, None);
@@ -1400,7 +1423,7 @@ mod tests {
             Effect::Deny,
             vec![rule("/proj", Effect::Allow, FsAccess::ReadWrite)],
         );
-        let prof = build_profile(&p, &spec(), None);
+        let prof = build_profile(&p, &spec(), None, None);
         assert!(prof.contains("(deny process-info*)\n"));
         assert!(prof.contains("(allow process-info* (target self))"));
         assert!(

--- a/crates/nub-sandbox/src/backend/mod.rs
+++ b/crates/nub-sandbox/src/backend/mod.rs
@@ -24,7 +24,8 @@
 //! to `command.status()`; Windows runs its launcher (setup → spawn → wait → RAII
 //! teardown) when a launch plan is attached.
 
-use crate::policy::{Effect, SandboxPolicy};
+use crate::policy::{Effect, Inspection, ProxyMode, SandboxPolicy};
+use crate::proxy::mitm::MitmEngine;
 use crate::proxy::{EgressProxy, StaticDecider};
 use std::process::Command;
 use std::sync::Arc;
@@ -180,12 +181,70 @@ impl Prepared {
 /// that fails to start degrades to coarse-deny (fail-SAFE: denies more, not less), so
 /// this returns `None` on a start failure and the backend reports `net-per-host`.
 fn start_proxy_if_needed(policy: &SandboxPolicy) -> Option<EgressProxy> {
-    if policy.net.enforce && policy.net.rules.iter().any(|r| r.effect == Effect::Allow) {
-        let decider = Arc::new(StaticDecider::new(policy.net.clone()));
-        EgressProxy::start(decider).ok()
-    } else {
-        None
+    if !(policy.net.enforce && policy.net.rules.iter().any(|r| r.effect == Effect::Allow)) {
+        return None;
     }
+    let decider = Arc::new(StaticDecider::new(policy.net.clone()));
+    let mitm = match policy.net.inspection {
+        Inspection::TlsInspect => {
+            let terminate_all = matches!(policy.net.mode, ProxyMode::Terminate);
+            match MitmEngine::new(policy.net.brokers.clone(), terminate_all) {
+                Ok(engine) => Some(engine),
+                // FAIL-CLOSED: the tier required TLS termination but the CA/TLS stack
+                // could not be built. Do NOT downgrade to a blind splice — that would
+                // forward brokered requests UN-injected. Return None so the whole net
+                // coarse-denies (fail-safe over-confine); the backend reports net lost.
+                Err(_) => return None,
+            }
+        }
+        Inspection::Connection => None,
+    };
+    EgressProxy::start(decider, mitm).ok()
+}
+
+/// The CA-trust env keys pointed at the child CA bundle (ephemeral CA + real roots).
+/// A union of the common tool conventions — `NODE_EXTRA_CA_CERTS` is ADDITIVE (Node
+/// keeps its built-in roots); the rest REPLACE the store, which is exactly why the bundle
+/// carries the real roots alongside the CA. Brand-clean: every key is a tool's own
+/// documented convention, none nub's. Set AFTER `env_clear` so it survives the scrub.
+fn set_ca_env(command: &mut Command, bundle: &std::path::Path) {
+    let path = bundle.as_os_str();
+    for key in [
+        "NODE_EXTRA_CA_CERTS", // Node (additive)
+        "SSL_CERT_FILE",       // OpenSSL / curl / most
+        "REQUESTS_CA_BUNDLE",  // python-requests
+        "CURL_CA_BUNDLE",      // curl
+        "GIT_SSL_CAINFO",      // git
+        "PIP_CERT",            // pip
+        "NPM_CONFIG_CAFILE",   // npm
+        "npm_config_cafile",   // npm (lowercase form)
+        "CARGO_HTTP_CAINFO",   // cargo
+        "AWS_CA_BUNDLE",       // aws-cli
+        "DENO_CERT",           // deno
+    ] {
+        command.env(key, path);
+    }
+}
+
+/// One-line stderr notice when TLS termination engages — the honesty bar (§5, option 2):
+/// nub never silently decrypts, even when the user's own config demanded it.
+fn emit_mitm_notice(policy: &SandboxPolicy) {
+    let scope = if policy.net.brokers.is_empty() {
+        "all allowed hosts (proxy: \"terminate\")".to_string()
+    } else {
+        policy
+            .net
+            .brokers
+            .iter()
+            .map(|b| b.host.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    eprintln!(
+        "sandbox: TLS termination engaged for {scope} — request inspection runs in-proxy \
+         (ephemeral per-run CA, child-scoped via NODE_EXTRA_CA_CERTS-class env, never added \
+         to the OS trust store)"
+    );
 }
 
 /// The cooperative proxy-env hint set on the child so ordinary HTTP(S) clients route
@@ -225,15 +284,22 @@ pub fn apply(policy: &SandboxPolicy, spec: CommandSpec) -> Result<Prepared, Degr
     // so it outlives the child (design.md §2.5).
     let proxy = start_proxy_if_needed(policy);
     let proxy_port = proxy.as_ref().map(EgressProxy::port);
+    // The child CA-bundle path, when TLS termination engaged. Threaded into each backend
+    // so the child both TRUSTS the minted leaves (CA-env) and can READ the bundle even
+    // under a confining fs policy (an explicit read grant — nub infra, not user config).
+    let ca_bundle = proxy.as_ref().and_then(|p| p.ca_bundle_path());
+    if ca_bundle.is_some() {
+        emit_mitm_notice(policy);
+    }
 
     #[cfg(target_os = "macos")]
-    let mut prepared = macos::apply(policy, spec, proxy_port)?;
+    let mut prepared = macos::apply(policy, spec, proxy_port, ca_bundle)?;
     #[cfg(target_os = "linux")]
-    let mut prepared = linux::apply(policy, spec, proxy_port)?;
+    let mut prepared = linux::apply(policy, spec, proxy_port, ca_bundle)?;
     #[cfg(target_os = "windows")]
-    let mut prepared = windows::apply(policy, spec, proxy_port)?;
+    let mut prepared = windows::apply(policy, spec, proxy_port, ca_bundle)?;
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    let mut prepared = generic_apply(policy, spec, proxy_port)?;
+    let mut prepared = generic_apply(policy, spec, proxy_port, ca_bundle)?;
 
     prepared.proxy = proxy;
     Ok(prepared)
@@ -246,6 +312,7 @@ fn generic_apply(
     policy: &SandboxPolicy,
     spec: CommandSpec,
     proxy_port: Option<u16>,
+    ca_bundle: Option<&std::path::Path>,
 ) -> Result<Prepared, Degradation> {
     let mut command = Command::new(&spec.program);
     command.args(&spec.args);
@@ -262,6 +329,9 @@ fn generic_apply(
     }
     if let Some(port) = proxy_port {
         set_proxy_env(&mut command, port);
+    }
+    if let Some(bundle) = ca_bundle {
+        set_ca_env(&mut command, bundle);
     }
 
     // fs/net: honestly report what the skeleton does not yet enforce. The skeleton has

--- a/crates/nub-sandbox/src/backend/mod.rs
+++ b/crates/nub-sandbox/src/backend/mod.rs
@@ -288,9 +288,6 @@ pub fn apply(policy: &SandboxPolicy, spec: CommandSpec) -> Result<Prepared, Degr
     // so the child both TRUSTS the minted leaves (CA-env) and can READ the bundle even
     // under a confining fs policy (an explicit read grant — nub infra, not user config).
     let ca_bundle = proxy.as_ref().and_then(|p| p.ca_bundle_path());
-    if ca_bundle.is_some() {
-        emit_mitm_notice(policy);
-    }
 
     #[cfg(target_os = "macos")]
     let mut prepared = macos::apply(policy, spec, proxy_port, ca_bundle)?;
@@ -300,6 +297,20 @@ pub fn apply(policy: &SandboxPolicy, spec: CommandSpec) -> Result<Prepared, Degr
     let mut prepared = windows::apply(policy, spec, proxy_port, ca_bundle)?;
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     let mut prepared = generic_apply(policy, spec, proxy_port, ca_bundle)?;
+
+    // One-line stderr notice when TLS termination ACTUALLY engages — never silent, but
+    // never MISLEADING either: suppress it where the backend degraded net (e.g. Windows,
+    // whose AppContainer child can't reach the loopback proxy, so termination never
+    // happens and the request is fail-safe denied — announcing it would be a false claim).
+    if ca_bundle.is_some()
+        && !prepared
+            .degradation
+            .lost
+            .iter()
+            .any(|l| l.starts_with("net-per"))
+    {
+        emit_mitm_notice(policy);
+    }
 
     prepared.proxy = proxy;
     Ok(prepared)

--- a/crates/nub-sandbox/src/backend/windows.rs
+++ b/crates/nub-sandbox/src/backend/windows.rs
@@ -284,6 +284,12 @@ pub(crate) fn apply(
     policy: &SandboxPolicy,
     spec: super::CommandSpec,
     proxy_port: Option<u16>,
+    // CUT-1: Windows per-host egress-via-proxy is NOT wired (an AppContainer child needs a
+    // loopback exemption — `NetworkIsolationSetAppContainerConfig` — to reach the loopback
+    // proxy), so TLS termination degrades here just as per-host does. The bundle is still
+    // threaded (CA-env set on the plain path) so trust works IF a future change wires the
+    // exemption; today `net-per-host`/`net-per-request` is reported instead.
+    ca_bundle: Option<&std::path::Path>,
 ) -> Result<super::Prepared, super::Degradation> {
     use super::{Degradation, Prepared};
 
@@ -306,6 +312,9 @@ pub(crate) fn apply(
         }
         if let Some(port) = proxy_port {
             super::set_proxy_env(&mut command, port);
+        }
+        if let Some(bundle) = ca_bundle {
+            super::set_ca_env(&mut command, bundle);
         }
         return Ok(Prepared {
             command,

--- a/crates/nub-sandbox/src/backend/windows.rs
+++ b/crates/nub-sandbox/src/backend/windows.rs
@@ -388,6 +388,13 @@ pub(crate) fn apply(
     // branch-scoped windows-latest CI probe investigates the exemption's feasibility.
     if policy.net.enforce && policy.net.rules.iter().any(|r| r.effect == Effect::Allow) {
         deg.lost.push("net-per-host".to_string());
+        // A credential-inject rule is a per-REQUEST capability layered atop per-host: it
+        // degrades identically here (the loopback exemption that per-host needs gates the
+        // MITM proxy the same way), so report it explicitly rather than silently — the
+        // broker is fail-safe DENIED, never forwarded un-inspected (proposal §6).
+        if !policy.net.brokers.is_empty() {
+            deg.lost.push("net-per-request".to_string());
+        }
         reason.get_or_insert_with(|| {
             "per-host egress needs an AppContainer loopback exemption to reach the proxy \
              (not wired) — per-host allows denied (coarse network deny)"

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -10,8 +10,8 @@ use super::resolve;
 use super::{CompileCtx, CompileError};
 use crate::matcher::path::expand_symbolic;
 use crate::policy::{
-    CanonGlob, Effect, EnvFormat, EnvPolicy, EnvRule, FsAccess, FsPolicy, FsRule, FsRuleSet,
-    NetPolicy, NetRule, NetTarget,
+    CanonGlob, CredentialBroker, Effect, EnvFormat, EnvPolicy, EnvRule, FsAccess, FsPolicy, FsRule,
+    FsRuleSet, HeaderInject, NetPolicy, NetRule, NetTarget, Secret,
 };
 use globset::{GlobBuilder, GlobMatcher};
 use serde_json::Value;
@@ -196,13 +196,14 @@ fn splice_fs_defaults(ctx: &CompileCtx, out: &mut Vec<FsRule>) {
 /// `net: false` denies all egress.
 pub fn fold_net(
     value: &Value,
+    ctx: &CompileCtx,
     path: &str,
     parent: Option<&NetPolicy>,
 ) -> Result<NetPolicy, CompileError> {
     let mut policy = NetPolicy {
         enforce: true,
-        rules: Vec::new(),
         default_effect: Effect::Deny,
+        ..Default::default()
     };
     match value {
         Value::Bool(true) => policy.enforce = false,
@@ -223,8 +224,7 @@ pub fn fold_net(
                 if key == "..." {
                     return Err(CompileError::shape(&p, OBJECT_SENTINEL_MSG));
                 }
-                let effect = net_value_effect(val, &p)?;
-                push_net_rule(key, effect, &p, &mut policy.rules)?;
+                fold_net_object_value(key, val, ctx, &p, &mut policy)?;
             }
         }
         _ => {
@@ -262,15 +262,182 @@ fn fold_net_entry(
     push_net_rule(pattern, effect, path, out)
 }
 
-fn net_value_effect(val: &Value, path: &str) -> Result<Effect, CompileError> {
+/// One entry of the net OBJECT form: `"<host>": true | false | { rule object }`. A
+/// bool is a plain allow/deny (host-only, connection-level). A rule OBJECT is the
+/// per-host capability grammar; cut-1's ONLY key is `inject` (credential brokering),
+/// which implicitly ALLOWS the host and forces it to the TlsInspect tier.
+fn fold_net_object_value(
+    host: &str,
+    val: &Value,
+    ctx: &CompileCtx,
+    path: &str,
+    policy: &mut NetPolicy,
+) -> Result<(), CompileError> {
     match val {
-        Value::Bool(true) => Ok(Effect::Allow),
-        Value::Bool(false) => Ok(Effect::Deny),
+        Value::Bool(true) => push_net_rule(host, Effect::Allow, path, &mut policy.rules),
+        Value::Bool(false) => push_net_rule(host, Effect::Deny, path, &mut policy.rules),
+        Value::Object(rule) => fold_net_rule_object(host, rule, ctx, path, policy),
         _ => Err(CompileError::shape(
             path,
-            "net value must be true or false (per-host options are not yet supported)",
+            "net host value must be true, false, or a rule object (e.g. { \"inject\": { … } })",
         )),
     }
+}
+
+/// Parse a per-host net rule OBJECT. Cut-1 vocabulary is credential brokering ONLY;
+/// the request-filter fields the proposal reserves (`methods`/`paths`/`headers`) are
+/// DEFERRED to a future request filter, so naming one fails loud rather than silently
+/// under-enforcing. The brokered host is recorded both as an ordinary Allow rule (a
+/// later explicit `!deny` can still override it — last-match-wins is preserved) and as
+/// a [`CredentialBroker`] (→ TlsInspect tier for that host).
+fn fold_net_rule_object(
+    host: &str,
+    rule: &serde_json::Map<String, Value>,
+    ctx: &CompileCtx,
+    path: &str,
+    policy: &mut NetPolicy,
+) -> Result<(), CompileError> {
+    for key in rule.keys() {
+        if key != "inject" {
+            return Err(CompileError::shape(
+                &child(path, key),
+                &format!(
+                    "`{key}` is not supported in this cut — the only per-host net capability is `inject` (credential brokering); verb/path/header filtering is deferred to a future request filter"
+                ),
+            ));
+        }
+    }
+    let inject = rule.get("inject").ok_or_else(|| {
+        CompileError::shape(
+            path,
+            "a net rule object must contain `inject` (credential brokering) — it is the only per-host capability in this cut",
+        )
+    })?;
+    // Reject an unbrokerable host BEFORE it becomes an allow rule: a CIDR can't carry
+    // HTTP header injection, and a bare `*` would hand the credential to EVERY allowed
+    // host (a laundering footgun — SRT pins injectHosts to named domains).
+    validate_broker_host(host, path)?;
+    let injects = parse_inject(inject, ctx, &child(path, "inject"))?;
+    push_net_rule(host, Effect::Allow, path, &mut policy.rules)?;
+    policy.brokers.push(CredentialBroker {
+        host: crate::matcher::host::strip_trailing_dot(host).to_string(),
+        injects,
+    });
+    Ok(())
+}
+
+/// A broker host must resolve to a concrete/bounded name the credential is scoped to —
+/// never a CIDR (no HTTP layer) and never a bare `*` (would broker into any allowed host).
+fn validate_broker_host(pattern: &str, path: &str) -> Result<(), CompileError> {
+    if pattern.contains('/') {
+        return Err(CompileError::shape(
+            path,
+            "credential brokering targets a host, not a CIDR — name a hostname (or a bounded `*.suffix`)",
+        ));
+    }
+    if pattern == "*" {
+        return Err(CompileError::shape(
+            path,
+            "credential brokering into a bare `*` (every allowed host) is refused — a credential must be scoped to named host(s), never the whole allowlist",
+        ));
+    }
+    if !crate::matcher::host::host_pattern_is_valid(pattern) {
+        return Err(CompileError::shape(
+            path,
+            &format!("`{pattern}` is not a valid host pattern for a credential broker"),
+        ));
+    }
+    Ok(())
+}
+
+/// Parse the `inject` map (header-name → value string) into resolved [`HeaderInject`]s.
+/// A `$(…)` value resolves through the SAME trusted gate as env values — an untrusted
+/// (`dependenciesMeta`) `$(…)` is a hard error, never a silent exec. The resolved
+/// secret is wrapped in [`Secret`] (redacting Debug, serde-skipped) so it never reaches
+/// a dump, a log, or the child env.
+fn parse_inject(
+    value: &Value,
+    ctx: &CompileCtx,
+    path: &str,
+) -> Result<Vec<HeaderInject>, CompileError> {
+    let map = value.as_object().ok_or_else(|| {
+        CompileError::shape(
+            path,
+            "`inject` must be a header-name → value object (e.g. { \"Authorization\": \"Bearer $(op read …)\" })",
+        )
+    })?;
+    if map.is_empty() {
+        return Err(CompileError::shape(
+            path,
+            "`inject` must name at least one header to set",
+        ));
+    }
+    let mut out = Vec::with_capacity(map.len());
+    for (header, raw) in map {
+        let p = child(path, header);
+        validate_header_name(header, &p)?;
+        let raw_str = as_str(raw, &p)?;
+        let resolved = resolve_credential_value(raw_str, ctx, &p)?;
+        if resolved.is_empty() {
+            return Err(CompileError::shape(
+                &p,
+                "an inject header value must not be empty",
+            ));
+        }
+        // CRLF / NUL guard: a resolved value carrying a line break would smuggle a header
+        // (request splitting) into the reconstructed request. Reject at compile time — the
+        // proxy's serializer trusts values to be single-line.
+        if resolved.bytes().any(|b| matches!(b, b'\r' | b'\n' | b'\0')) {
+            return Err(CompileError::shape(
+                &p,
+                "an inject header value must not contain a newline or NUL (request-splitting guard)",
+            ));
+        }
+        out.push(HeaderInject {
+            header: header.clone(),
+            value: Secret(resolved),
+        });
+    }
+    Ok(out)
+}
+
+/// Resolve a credential value's `$(…)` through the trusted gate, mirroring env values.
+fn resolve_credential_value(
+    raw: &str,
+    ctx: &CompileCtx,
+    path: &str,
+) -> Result<String, CompileError> {
+    if resolve::has_substitution(raw) {
+        if !ctx.trusted {
+            return Err(CompileError::untrusted_substitution(path));
+        }
+        resolve::resolve_with(raw, ctx.runner.as_ref())
+            .map_err(|e| CompileError::substitution(path, &e))
+    } else if resolve::has_open_substitution(raw) {
+        Err(CompileError::substitution(
+            path,
+            resolve::UNTERMINATED_SUBST_MSG,
+        ))
+    } else {
+        Ok(raw.to_string())
+    }
+}
+
+/// Conservative HTTP header-name validation (RFC 7230 token subset): ASCII
+/// alphanumerics plus `-`/`_`. Fail-closed on anything exotic so a crafted name can't
+/// smuggle a CRLF or a `:` into the reconstructed request line.
+fn validate_header_name(name: &str, path: &str) -> Result<(), CompileError> {
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    {
+        return Err(CompileError::shape(
+            path,
+            &format!("`{name}` is not a valid HTTP header name (letters, digits, `-`, `_`)"),
+        ));
+    }
+    Ok(())
 }
 
 /// Classify a net target as a CIDR (contains `/` and parses as one) or a host

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -307,6 +307,15 @@ fn fold_net_rule_object(
             ));
         }
     }
+    // Credential brokering is a TRUSTED-ONLY capability. An untrusted grant
+    // (`dependenciesMeta`) must not be able to force TLS termination of an allowed host
+    // or inject ANY header (a literal value would otherwise slip past the `$(…)` gate).
+    if !ctx.trusted {
+        return Err(CompileError::shape(
+            path,
+            "credential brokering (`inject`) is a trusted-only capability — it is not permitted in an untrusted (dependenciesMeta) grant",
+        ));
+    }
     let inject = rule.get("inject").ok_or_else(|| {
         CompileError::shape(
             path,
@@ -314,8 +323,8 @@ fn fold_net_rule_object(
         )
     })?;
     // Reject an unbrokerable host BEFORE it becomes an allow rule: a CIDR can't carry
-    // HTTP header injection, and a bare `*` would hand the credential to EVERY allowed
-    // host (a laundering footgun — SRT pins injectHosts to named domains).
+    // HTTP header injection, and a wildcard would hand the credential to any matching
+    // subdomain (including an attacker-owned one — laundering).
     validate_broker_host(host, path)?;
     let injects = parse_inject(inject, ctx, &child(path, "inject"))?;
     push_net_rule(host, Effect::Allow, path, &mut policy.rules)?;
@@ -326,25 +335,28 @@ fn fold_net_rule_object(
     Ok(())
 }
 
-/// A broker host must resolve to a concrete/bounded name the credential is scoped to —
-/// never a CIDR (no HTTP layer) and never a bare `*` (would broker into any allowed host).
+/// A broker host must be a single LITERAL hostname. No CIDR (no HTTP layer) and — the
+/// security-critical rule — no wildcard: a `*.example.com` broker mints + injects to the
+/// CLIENT-SUPPLIED SNI, so a child connecting to an attacker-owned `evil.example.com`
+/// (with a valid real cert) would receive the `example.com` credential (laundering). A
+/// user needing several hosts lists each one explicitly.
 fn validate_broker_host(pattern: &str, path: &str) -> Result<(), CompileError> {
     if pattern.contains('/') {
         return Err(CompileError::shape(
             path,
-            "credential brokering targets a host, not a CIDR — name a hostname (or a bounded `*.suffix`)",
+            "credential brokering targets a host, not a CIDR — name a literal hostname",
         ));
     }
-    if pattern == "*" {
+    if pattern.contains('*') {
         return Err(CompileError::shape(
             path,
-            "credential brokering into a bare `*` (every allowed host) is refused — a credential must be scoped to named host(s), never the whole allowlist",
+            "credential brokering requires a LITERAL host — a wildcard would hand the credential to any matching subdomain (including an attacker's); list each host explicitly",
         ));
     }
     if !crate::matcher::host::host_pattern_is_valid(pattern) {
         return Err(CompileError::shape(
             path,
-            &format!("`{pattern}` is not a valid host pattern for a credential broker"),
+            &format!("`{pattern}` is not a valid host for a credential broker"),
         ));
     }
     Ok(())
@@ -395,7 +407,7 @@ fn parse_inject(
         }
         out.push(HeaderInject {
             header: header.clone(),
-            value: Secret(resolved),
+            value: Secret::new(resolved),
         });
     }
     Ok(out)

--- a/crates/nub-sandbox/src/compiler/mod.rs
+++ b/crates/nub-sandbox/src/compiler/mod.rs
@@ -21,7 +21,7 @@ pub mod scope;
 pub use resolve::{CommandRunner, ShellRunner};
 
 use crate::matcher::path::Homes;
-use crate::policy::{Effect, EnvPolicy, FsPolicy, NetPolicy, SandboxPolicy};
+use crate::policy::{Effect, EnvPolicy, FsPolicy, Inspection, NetPolicy, ProxyMode, SandboxPolicy};
 use serde_json::Value;
 use std::collections::BTreeMap;
 
@@ -238,7 +238,7 @@ fn compile_object(
     let obj = surface
         .as_object()
         .ok_or_else(|| CompileError::shape("", "expected a { fs, net, env } object"))?;
-    fold::reject_unknown_keys(obj, &["fs", "net", "env", "..."], "")?;
+    fold::reject_unknown_keys(obj, &["fs", "net", "env", "proxy", "..."], "")?;
     let inherit_base = object_spread(obj.get("..."))?;
 
     // Clobber detection runs per ARRAY axis (a total shadow between two entries of
@@ -259,11 +259,15 @@ fn compile_object(
         None if inherit_base => inherit_fs(parent, ctx),
         None => floor_fs(),
     };
-    let net = match obj.get("net") {
-        Some(v) => fold::fold_net(v, "net", parent.map(|p| &p.net))?,
+    let mut net = match obj.get("net") {
+        Some(v) => fold::fold_net(v, ctx, "net", parent.map(|p| &p.net))?,
         None if inherit_base => inherit_net(parent),
         None => floor_net(),
     };
+    // The `proxy` knob is authored at the wrapper level (sibling of net) but governs the
+    // net axis — fold it on, then DERIVE the enforcement tier from the broker set + mode.
+    net.mode = parse_proxy_mode(obj.get("proxy"))?;
+    finalize_net_inspection(&mut net, "net")?;
     let env = match obj.get("env") {
         Some(v) => fold::fold_env(v, ctx, "env", parent.map(|p| &p.env))?,
         None if inherit_base => inherit_env(parent, ctx),
@@ -275,6 +279,52 @@ fn compile_object(
         env,
         pid: Default::default(),
     })
+}
+
+/// Parse the wrapper-level `proxy` knob into a [`ProxyMode`]. Absent = `Auto` (the
+/// default — derive the tier from the rules; most policies never write `proxy`).
+fn parse_proxy_mode(v: Option<&Value>) -> Result<ProxyMode, CompileError> {
+    match v {
+        None => Ok(ProxyMode::Auto),
+        Some(Value::String(s)) => match s.as_str() {
+            "auto" => Ok(ProxyMode::Auto),
+            "passthrough" => Ok(ProxyMode::Passthrough),
+            "terminate" => Ok(ProxyMode::Terminate),
+            other => Err(CompileError::shape(
+                "proxy",
+                &format!(
+                    "`proxy` must be \"auto\", \"passthrough\", or \"terminate\" (got `{other}`)"
+                ),
+            )),
+        },
+        Some(_) => Err(CompileError::shape(
+            "proxy",
+            "`proxy` must be a string: \"auto\", \"passthrough\", or \"terminate\"",
+        )),
+    }
+}
+
+/// Derive the net enforcement tier from the broker set + the `proxy` mode, and enforce
+/// the mode↔rule contradiction. A broker (or an explicit `proxy: "terminate"`) engages
+/// [`Inspection::TlsInspect`]; `proxy: "passthrough"` FORBIDS termination, so a broker
+/// under it is a COMPILE ERROR — never a silent rule drop (proposal §4).
+fn finalize_net_inspection(net: &mut NetPolicy, path: &str) -> Result<(), CompileError> {
+    let needs_tls = !net.brokers.is_empty();
+    net.inspection = match net.mode {
+        ProxyMode::Passthrough => {
+            if needs_tls {
+                return Err(CompileError::shape(
+                    path,
+                    "a credential-inject rule requires TLS termination, but `proxy` is \"passthrough\" — remove the inject rule or set `proxy` to \"auto\"/\"terminate\"",
+                ));
+            }
+            Inspection::Connection
+        }
+        ProxyMode::Terminate => Inspection::TlsInspect,
+        ProxyMode::Auto if needs_tls => Inspection::TlsInspect,
+        ProxyMode::Auto => Inspection::Connection,
+    };
+    Ok(())
 }
 
 /// Parse a top-level object `"..."` key. `true` = inherit the enclosing base for
@@ -324,8 +374,8 @@ fn floor_fs() -> FsPolicy {
 fn floor_net() -> NetPolicy {
     NetPolicy {
         enforce: true,
-        rules: Vec::new(),
         default_effect: Effect::Deny,
+        ..Default::default()
     }
 }
 fn floor_env(ctx: &CompileCtx) -> EnvPolicy {
@@ -409,8 +459,8 @@ fn secure_default_net() -> NetPolicy {
     // baseline owns the trusted-host allows).
     NetPolicy {
         enforce: true,
-        rules: Vec::new(),
         default_effect: Effect::Deny,
+        ..Default::default()
     }
 }
 

--- a/crates/nub-sandbox/src/policy.rs
+++ b/crates/nub-sandbox/src/policy.rs
@@ -239,11 +239,17 @@ pub struct HeaderInject {
 
 /// A resolved secret held in nub's PARENT process only. Serialization drops it (the
 /// containing field is `#[serde(skip)]`) and `Debug` redacts it, so a policy dump, a
-/// trace line, or a panic can never spill the credential.
+/// trace line, or a panic can never spill the credential. The inner field is PRIVATE:
+/// [`Secret::expose`] is the sole read path (grep it to audit every reader), so no
+/// `.0` access can slip past the redaction.
 #[derive(Clone, Default, PartialEq, Eq)]
-pub struct Secret(pub String);
+pub struct Secret(String);
 
 impl Secret {
+    /// Wrap a resolved secret value.
+    pub fn new(value: String) -> Self {
+        Secret(value)
+    }
     /// Borrow the raw value. The ONE call site that needs it is the proxy's egress
     /// header injection; grep for `.expose()` to audit every reader.
     pub fn expose(&self) -> &str {

--- a/crates/nub-sandbox/src/policy.rs
+++ b/crates/nub-sandbox/src/policy.rs
@@ -135,6 +135,23 @@ pub struct NetPolicy {
     pub enforce: bool,
     pub rules: Vec<NetRule>,
     pub default_effect: Effect,
+    /// The `proxy` wrapper knob (default [`ProxyMode::Auto`]). Governs whether the
+    /// egress proxy may TERMINATE TLS to enforce a capability that can't be checked
+    /// from outside the stream. Authored at the wrapper level (sibling of net); the
+    /// compiler folds it onto the net axis it governs.
+    #[serde(default)]
+    pub mode: ProxyMode,
+    /// The tier the compiler DERIVED (default [`Inspection::Connection`]). A pure
+    /// function of `brokers` + `mode`; materialized in the IR so a `--sandbox` dump
+    /// states the posture explicitly (proposal §4). Never a user input.
+    #[serde(default)]
+    pub inspection: Inspection,
+    /// Per-host credential brokers (proposal §5 — cut-1 marquee). Non-empty ⇒ the tier
+    /// is [`Inspection::TlsInspect`] and the proxy terminates each brokered host to
+    /// inject the credential. The resolved secret lives here IN-MEMORY ONLY (see
+    /// [`HeaderInject::value`]) — never the child env, never a serialized dump.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub brokers: Vec<CredentialBroker>,
 }
 
 impl Default for NetPolicy {
@@ -145,8 +162,43 @@ impl Default for NetPolicy {
             enforce: false,
             rules: Vec::new(),
             default_effect: Effect::Deny,
+            mode: ProxyMode::Auto,
+            inspection: Inspection::Connection,
+            brokers: Vec::new(),
         }
     }
+}
+
+/// The `proxy` wrapper knob — whether the egress proxy may terminate TLS (the MITM
+/// tier). The default reading of the maintainer's ask: derive the tier from the rules,
+/// never a user-set boolean.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProxyMode {
+    /// Derive the tier from the rules: terminate only hosts whose own rules require it
+    /// (a credential-inject rule); tunnel everything else blind. The default.
+    #[default]
+    Auto,
+    /// Forbid termination. A rule that REQUIRES it is a COMPILE ERROR (never a silent
+    /// drop) — the explicit "block MITM" posture; net stays connection-level only.
+    Passthrough,
+    /// Force termination of all allowed TLS even under host-only rules (the
+    /// domain-fronting-closure hardening posture).
+    Terminate,
+}
+
+/// The enforcement tier the compiler derived for the net axis. Recorded in the IR for
+/// dump/fixture visibility; recomputed by the compiler, never authored.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Inspection {
+    /// Today's SNI-peek proxy: no TLS code on the path, no CA in existence.
+    #[default]
+    Connection,
+    /// The MITM tier: a per-run ephemeral CA terminates the hosts that need it,
+    /// everything else stays a blind splice.
+    #[serde(rename = "tls-inspect")]
+    TlsInspect,
 }
 
 /// One net rule: a host pattern or a CIDR, plus its effect.
@@ -154,6 +206,59 @@ impl Default for NetPolicy {
 pub struct NetRule {
     pub target: NetTarget,
     pub effect: Effect,
+}
+
+/// A per-host credential broker (proposal §5, cut-1 marquee): on egress to `host` the
+/// terminating proxy STRIPS then re-injects each header, so the sandboxed child
+/// authenticates to an allowlisted upstream WITHOUT ever holding the secret. A broker
+/// forces [`Inspection::TlsInspect`] for its host. HTTPS-only by construction — the
+/// proxy refuses to inject over an unterminated/plaintext channel (never expose a
+/// secret on an unverified wire).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CredentialBroker {
+    /// The host pattern the broker governs — same glob grammar as a net [`NetTarget::Host`].
+    pub host: String,
+    pub injects: Vec<HeaderInject>,
+}
+
+/// One header the broker sets on egress. Strip-then-set: the child's own value for
+/// `header` (if any) is removed FIRST, so a child-supplied — possibly leaked-real —
+/// credential can never survive alongside the injected one.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HeaderInject {
+    /// The HTTP header name to set (e.g. `Authorization`).
+    pub header: String,
+    /// The resolved header value. `#[serde(skip)]` keeps the secret out of EVERY
+    /// serialized IR (a `--sandbox` dump, a conformance fixture) and the redacting
+    /// [`Secret`] `Debug` keeps it out of logs/panics. The IR is compiler-built and
+    /// consumed directly by `apply()` — never deserialized-then-applied — so skipping
+    /// it loses nothing at runtime.
+    #[serde(skip)]
+    pub value: Secret,
+}
+
+/// A resolved secret held in nub's PARENT process only. Serialization drops it (the
+/// containing field is `#[serde(skip)]`) and `Debug` redacts it, so a policy dump, a
+/// trace line, or a panic can never spill the credential.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct Secret(pub String);
+
+impl Secret {
+    /// Borrow the raw value. The ONE call site that needs it is the proxy's egress
+    /// header injection; grep for `.expose()` to audit every reader.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Secret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            f.write_str("Secret(\"\")")
+        } else {
+            f.write_str("Secret(\"<redacted>\")")
+        }
+    }
 }
 
 /// A net rule targets either a host pattern (glob or literal) or a CIDR block.

--- a/crates/nub-sandbox/src/proxy/ca.rs
+++ b/crates/nub-sandbox/src/proxy/ca.rs
@@ -1,0 +1,181 @@
+//! The ephemeral MITM certificate authority for the credential-brokering tier.
+//!
+//! SECURITY POSTURE (proposal §5 + the U5 dispatch requirements) — the invariants this
+//! module exists to hold:
+//!
+//! - **Per-run + ephemeral.** The CA is minted when the proxy starts and gone when it
+//!   drops. Nothing survives the run; no cross-run artifact exists.
+//! - **The CA private key NEVER leaves this process's memory.** It is held only in
+//!   [`MitmCa::ca_key`] and used only to sign leaves in-process — it is NEVER written to
+//!   disk (stronger than SRT, which writes the key to a temp dir). Only the CA
+//!   CERTIFICATE (public) is emitted.
+//! - **The OS trust store is NEVER touched.** No `security add-trusted-cert`, no
+//!   `/etc/ssl` write. Trust reaches the child ONLY through the constructed child env: a
+//!   CA-bundle file the CA-env vars point at (see `backend::set_ca_env`), scoped to the
+//!   child, invisible to every other process, removed when this value drops.
+//! - **The bundle is CA cert + the platform's REAL roots**, never CA-alone — the
+//!   `SSL_CERT_FILE`-class vars REPLACE a tool's store, so a CA-only file would break
+//!   verification of every blind-tunneled (non-terminated) host.
+//!
+//! FAIL-CLOSED: every minting/IO failure is an `io::Error` the caller turns into a
+//! denied connection — there is no plaintext fallback anywhere on this path.
+
+use rcgen::{
+    BasicConstraints, Certificate, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa,
+    KeyPair, KeyUsagePurpose,
+};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// The per-run ephemeral CA plus the child trust bundle it anchors.
+pub(super) struct MitmCa {
+    ca_cert: Certificate,
+    ca_key: KeyPair,
+    /// The platform's real roots (DER), retained for the proxy's OUTBOUND leg — the
+    /// upstream connection verifies the real server cert against these, so nub itself is
+    /// never MITM'd. Also PEM-encoded into the child bundle.
+    native_roots: Vec<CertificateDer<'static>>,
+    /// The child-scoped CA-bundle file (CA cert + real roots). The `NamedTempFile` owns
+    /// the file's lifetime: 0600 on Unix (mkstemp), removed on drop. Holds ONLY public
+    /// certs — never the CA key.
+    _bundle: tempfile::NamedTempFile,
+    bundle_path: PathBuf,
+}
+
+impl MitmCa {
+    /// Mint the ephemeral CA and write the child trust bundle. Fail-closed: an error here
+    /// aborts engaging the tier (the caller degrades / denies), never a silent downgrade.
+    pub(super) fn generate() -> io::Result<MitmCa> {
+        let ca_key = KeyPair::generate().map_err(mint_err)?;
+        // A minimal CA: cert-signing key usage, unconstrained basic-constraints. Its only
+        // job is to sign the per-host leaves this same process presents to the child.
+        let mut params = CertificateParams::new(Vec::<String>::new()).map_err(mint_err)?;
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "nub sandbox ephemeral CA");
+        let ca_cert = params.self_signed(&ca_key).map_err(mint_err)?;
+
+        // Real platform roots. Empty ⇒ fail-closed: without them the child cannot verify
+        // blind-tunneled hosts and the proxy cannot verify upstreams.
+        let native_roots = rustls_native_certs::load_native_certs().certs;
+        if native_roots.is_empty() {
+            return Err(io::Error::other(
+                "no platform root certificates could be loaded for the MITM trust bundle",
+            ));
+        }
+
+        let bundle = write_bundle(&ca_cert, &native_roots)?;
+        let bundle_path = bundle.path().to_path_buf();
+        Ok(MitmCa {
+            ca_cert,
+            ca_key,
+            native_roots,
+            _bundle: bundle,
+            bundle_path,
+        })
+    }
+
+    /// The child-scoped CA-bundle path (what the CA-env vars point at).
+    pub(super) fn bundle_path(&self) -> &Path {
+        &self.bundle_path
+    }
+
+    /// The real platform roots — the proxy's upstream leg verifies against these.
+    pub(super) fn native_roots(&self) -> &[CertificateDer<'static>] {
+        &self.native_roots
+    }
+
+    /// Mint a leaf cert for `host`, signed by the ephemeral CA. Fresh per call (cut-1
+    /// mints per terminated connection — a per-host cache is a perf follow-up, not a
+    /// correctness one). The returned chain is leaf-only: the child trusts the CA
+    /// directly (via the bundle), so the leaf→CA link is verified against that anchor.
+    pub(super) fn leaf_for(
+        &self,
+        host: &str,
+    ) -> io::Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+        let leaf_key = KeyPair::generate().map_err(mint_err)?;
+        let mut params = CertificateParams::new(vec![host.to_string()]).map_err(mint_err)?;
+        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+        params.distinguished_name.push(DnType::CommonName, host);
+        let leaf = params
+            .signed_by(&leaf_key, &self.ca_cert, &self.ca_key)
+            .map_err(mint_err)?;
+        let chain = vec![leaf.der().clone()];
+        // rcgen serializes the private key as PKCS#8 DER.
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(leaf_key.serialize_der()));
+        Ok((chain, key))
+    }
+}
+
+/// Write the child trust bundle (CA cert + real roots, all PUBLIC) to a temp file the
+/// `NamedTempFile` owns. On Unix the file is 0600 (mkstemp); it is removed on drop.
+fn write_bundle(
+    ca_cert: &Certificate,
+    roots: &[CertificateDer<'static>],
+) -> io::Result<tempfile::NamedTempFile> {
+    use std::io::Write;
+    let mut f = tempfile::Builder::new()
+        .prefix("nub-mitm-ca-")
+        .suffix(".pem")
+        .tempfile()?;
+    f.write_all(ca_cert.pem().as_bytes())?;
+    f.write_all(b"\n")?;
+    for der in roots {
+        let block = pem::encode(&pem::Pem::new("CERTIFICATE", der.as_ref().to_vec()));
+        f.write_all(block.as_bytes())?;
+        f.write_all(b"\n")?;
+    }
+    f.flush()?;
+    Ok(f)
+}
+
+fn mint_err(e: rcgen::Error) -> io::Error {
+    io::Error::other(format!("MITM certificate minting failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ca_bundle_holds_public_certs_and_never_the_key() {
+        let ca = MitmCa::generate().expect("CA generates on a host with platform roots");
+        let bundle = std::fs::read_to_string(ca.bundle_path()).expect("bundle readable");
+        // The bundle is CA cert + real roots — multiple CERTIFICATE blocks, at least one
+        // per the CA plus the platform store — and NEVER a PRIVATE KEY block.
+        assert!(
+            bundle.contains("-----BEGIN CERTIFICATE-----"),
+            "bundle must carry the CA certificate"
+        );
+        assert!(
+            !bundle.contains("PRIVATE KEY"),
+            "the CA private key must NEVER be written to disk"
+        );
+        assert!(
+            bundle.matches("-----BEGIN CERTIFICATE-----").count() >= 2,
+            "bundle must include the platform roots alongside the CA (replace-store safety)"
+        );
+    }
+
+    #[test]
+    fn bundle_file_is_removed_when_the_ca_drops() {
+        let path = {
+            let ca = MitmCa::generate().expect("CA generates");
+            ca.bundle_path().to_path_buf()
+        };
+        assert!(
+            !path.exists(),
+            "the ephemeral CA bundle must not outlive the run"
+        );
+    }
+
+    #[test]
+    fn mints_a_leaf_for_a_host() {
+        let ca = MitmCa::generate().expect("CA generates");
+        let (chain, _key) = ca.leaf_for("api.example.com").expect("leaf mints");
+        assert_eq!(chain.len(), 1, "leaf-only chain (child anchors on the CA)");
+    }
+}

--- a/crates/nub-sandbox/src/proxy/mitm.rs
+++ b/crates/nub-sandbox/src/proxy/mitm.rs
@@ -242,6 +242,17 @@ pub(super) mod http1 {
             }
             buf.extend_from_slice(&tmp[..n]);
         };
+        // STRICT CRLF FRAMING (request-smuggling guard). Without this a child could embed
+        // a bare `\n` inside a header value; the split-on-`\r\n` parse would fold the
+        // remainder INTO that value, and on re-serialization the bare LF re-materializes
+        // as a separate header upstream — smuggling a header (e.g. its own `Authorization`)
+        // past strip-then-set and desyncing the request. Reject any bare CR or LF in the
+        // head; every CR must be followed by LF and every LF preceded by CR.
+        if has_bare_crlf(&buf[..head_end]) {
+            return Err(io::Error::other(
+                "request head contains a bare CR or LF (framing guard)",
+            ));
+        }
         let head =
             std::str::from_utf8(&buf[..head_end]).map_err(|_| io::Error::other("non-UTF8 head"))?;
         let mut lines = head.split("\r\n");
@@ -381,6 +392,26 @@ pub(super) mod http1 {
         buf.windows(4).position(|w| w == b"\r\n\r\n")
     }
 
+    /// True if `head` contains a bare CR (not followed by LF) or a bare LF (not part of a
+    /// preceding CRLF) — the request-smuggling framing violation. `\r\n` pairs are
+    /// consumed as a unit; anything else that is a CR/LF is bare.
+    fn has_bare_crlf(head: &[u8]) -> bool {
+        let mut i = 0;
+        while i < head.len() {
+            match head[i] {
+                b'\r' => {
+                    if head.get(i + 1) != Some(&b'\n') {
+                        return true; // bare CR
+                    }
+                    i += 2;
+                }
+                b'\n' => return true, // an LF reached outside a CRLF pair → bare LF
+                _ => i += 1,
+            }
+        }
+        false
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -420,6 +451,21 @@ pub(super) mod http1 {
         fn chunked_request_body_is_refused() {
             let raw = "POST /x HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
             assert!(read_request(&mut Cursor::new(raw.as_bytes())).is_err());
+        }
+
+        #[test]
+        fn bare_lf_header_smuggling_is_refused() {
+            // A child embeds a bare LF in a header value to smuggle its own Authorization
+            // past strip-then-set. The framing guard must reject the whole request.
+            let raw =
+                "GET / HTTP/1.1\r\nHost: h\r\nX-Foo: a\nAuthorization: child-smuggled\r\n\r\n";
+            assert!(read_request(&mut Cursor::new(raw.as_bytes())).is_err());
+            // A bare CR is likewise rejected.
+            let raw_cr = "GET / HTTP/1.1\r\nHost: h\rX-Evil: 1\r\n\r\n";
+            assert!(read_request(&mut Cursor::new(raw_cr.as_bytes())).is_err());
+            // A well-formed request with only CRLF pairs is accepted.
+            let ok = "GET / HTTP/1.1\r\nHost: h\r\nX-Foo: a\r\n\r\n";
+            assert!(read_request(&mut Cursor::new(ok.as_bytes())).is_ok());
         }
     }
 }

--- a/crates/nub-sandbox/src/proxy/mitm.rs
+++ b/crates/nub-sandbox/src/proxy/mitm.rs
@@ -1,0 +1,425 @@
+//! The TLS-termination (MITM) tier — credential brokering (proposal §5, cut-1 marquee).
+//!
+//! ENGAGED per-host, ONLY where a rule demands reading inside the stream (a
+//! credential-inject rule), or globally under `proxy: "terminate"`. Everything else
+//! stays a blind splice ([`super::splice`]) — the default is not "MITM off", it is "MITM
+//! never instantiated": with no broker + Auto mode, [`MitmEngine`] does not exist and no
+//! TLS/CA code runs.
+//!
+//! THE FLOW for a terminated host: mint a leaf for the SNI host → complete the TLS
+//! handshake WITH THE CHILD (which trusts the ephemeral CA via its env bundle) → read the
+//! one HTTP/1.1 request in cleartext → STRIP the child's copy of each brokered header and
+//! INJECT the real secret (strip-then-set, so a child-supplied value never survives) →
+//! open a REAL TLS connection to the upstream (verifying the real cert against the real
+//! roots — nub is never itself MITM'd) → forward the modified request → relay the
+//! response back. The child NEVER holds the secret: direct injection, not a sentinel —
+//! there is no dummy token for the child to log, echo, or persist.
+//!
+//! FAIL-CLOSED everywhere: any handshake / parse / upstream / cert error drops the
+//! connection (the child sees a reset). There is no path that forwards a request WITHOUT
+//! its injection, and no path that injects over an unverified channel.
+//!
+//! CUT-1 FRAMING: one request per terminated connection, `Connection: close` forced —
+//! the response's relayed `close` makes the child reconnect for its next request, so
+//! every request is its own terminated connection and every one is injected. Keep-alive
+//! and request pipelining are cut-1 non-goals; a chunked REQUEST body is refused
+//! (fail-closed) rather than mis-framed.
+
+use super::ca::MitmCa;
+use crate::matcher::host::host_glob_matches;
+use crate::policy::{CredentialBroker, HeaderInject};
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+/// Cap on the buffered request head (request line + headers). Past this a client is
+/// dribbling or hostile → fail closed.
+const MAX_HEAD: usize = 64 * 1024;
+/// Cap on a buffered request body nub will forward. Bodies are read whole to re-frame
+/// with an accurate Content-Length; past this, fail closed rather than buffer unbounded.
+const MAX_BODY: usize = 32 * 1024 * 1024;
+
+/// The MITM engine: the ephemeral CA, a reusable upstream-verifying client config, and
+/// the compiled broker set. Built ONLY when the tier is TlsInspect. `Arc`-shared across
+/// tunnel threads.
+pub struct MitmEngine {
+    ca: MitmCa,
+    /// Upstream (proxy→real-server) TLS config — verifies the real cert against the real
+    /// platform roots. Reused for every upstream leg (roots don't change per connection).
+    client_config: Arc<rustls::ClientConfig>,
+    /// The crypto provider, reused when building each per-host server config.
+    provider: Arc<rustls::crypto::CryptoProvider>,
+    brokers: Vec<CredentialBroker>,
+    /// `proxy: "terminate"` — terminate every allowed TLS host, not only brokered ones.
+    terminate_all: bool,
+}
+
+impl MitmEngine {
+    pub fn new(brokers: Vec<CredentialBroker>, terminate_all: bool) -> io::Result<Arc<MitmEngine>> {
+        let ca = MitmCa::generate()?;
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+
+        let mut roots = rustls::RootCertStore::empty();
+        let (added, _) = roots.add_parsable_certificates(ca.native_roots().iter().cloned());
+        if added == 0 {
+            return Err(io::Error::other(
+                "no usable upstream root certificates for the MITM proxy",
+            ));
+        }
+        let mut client_config = rustls::ClientConfig::builder_with_provider(provider.clone())
+            .with_safe_default_protocol_versions()
+            .map_err(tls_err)?
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        // http/1.1 only — the proxy has an HTTP/1.1 parser, not an h2 framer (SRT makes
+        // the same choice). The child's leaf ALPN is pinned to http/1.1 too, so a client
+        // never negotiates h2 it would then have to parse.
+        client_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+        Ok(Arc::new(MitmEngine {
+            ca,
+            client_config: Arc::new(client_config),
+            provider,
+            brokers,
+            terminate_all,
+        }))
+    }
+
+    /// The child-scoped CA-bundle path — wired into the child's CA-env vars.
+    pub fn bundle_path(&self) -> &std::path::Path {
+        self.ca.bundle_path()
+    }
+
+    /// Whether `host` should be TLS-terminated (a broker demands it, or terminate-all).
+    pub(super) fn should_terminate(&self, host: &str) -> bool {
+        self.terminate_all || self.broker_for(host).is_some()
+    }
+
+    fn broker_for(&self, host: &str) -> Option<&[HeaderInject]> {
+        self.brokers
+            .iter()
+            .find(|b| host_glob_matches(&b.host, host))
+            .map(|b| b.injects.as_slice())
+    }
+}
+
+/// Terminate a client tunnel to `host:port`, inject the broker's credential, forward to
+/// the real upstream, and relay the response. `prelude` is the ClientHello bytes already
+/// read during the SNI gate — replayed into the TLS state machine.
+///
+/// Returns `Ok(())` on a clean completion OR a clean fail-closed drop; an `Err` is an
+/// unexpected IO failure the caller also treats as a dropped connection. In NO case does
+/// this forward an un-injected request or expose the secret to the child.
+pub(super) fn terminate(
+    engine: &MitmEngine,
+    client: TcpStream,
+    prelude: Vec<u8>,
+    host: &str,
+    port: u16,
+) -> io::Result<()> {
+    // A brokered host reached over a NON-TLS or unmintable channel must fail closed —
+    // never inject a credential onto an unverified wire (SRT's allowPlaintextInject
+    // default-false; the whole point is the secret only ever crosses a verified channel).
+    let (chain, key) = engine.ca.leaf_for(host)?;
+    let server_config = rustls::ServerConfig::builder_with_provider(engine.provider.clone())
+        .with_safe_default_protocol_versions()
+        .map_err(tls_err)?
+        .with_no_client_auth()
+        .with_single_cert(chain, key)
+        .map_err(tls_err)?;
+    let mut server_config = server_config;
+    server_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    let mut sconn = rustls::ServerConnection::new(Arc::new(server_config)).map_err(tls_err)?;
+    // No read timeout for the terminated leg: a client may pause between handshake and
+    // request; the parent reaps the whole proxy when the child exits.
+    client.set_read_timeout(None)?;
+    let mut client_io = ReplayIo::new(prelude, client);
+    let mut client_tls = rustls::Stream::new(&mut sconn, &mut client_io);
+
+    // Read the one request in cleartext, broker it, normalize its framing.
+    let mut req = http1::read_request(&mut client_tls)?;
+    if let Some(injects) = engine.broker_for(host) {
+        http1::apply_injects(&mut req, injects);
+    }
+    http1::normalize_for_forward(&mut req);
+
+    // The upstream leg: REAL TLS to the REAL server, verified against REAL roots.
+    let upstream_tcp = super::connect_upstream(&super::Host::Name(host.to_string()), port)?;
+    let server_name = rustls::pki_types::ServerName::try_from(host.to_string())
+        .map_err(|_| io::Error::other("invalid upstream server name for TLS termination"))?;
+    let mut uconn = rustls::ClientConnection::new(engine.client_config.clone(), server_name)
+        .map_err(tls_err)?;
+    let mut up_io = upstream_tcp;
+    let mut upstream_tls = rustls::Stream::new(&mut uconn, &mut up_io);
+    upstream_tls.write_all(&req.serialize())?;
+    upstream_tls.flush()?;
+
+    // Relay the response back to the child. We forced `Connection: close` upstream, so
+    // the server closes after the response body — copy-until-EOF frames it correctly.
+    io::copy(&mut upstream_tls, &mut client_tls)?;
+    // Clean TLS teardown both ways so a client doesn't report truncation.
+    let _ = client_tls.flush();
+    Ok(())
+}
+
+fn tls_err(e: rustls::Error) -> io::Error {
+    io::Error::other(format!("MITM TLS error: {e}"))
+}
+
+/// A Read+Write that first replays the buffered ClientHello prelude, then reads/writes
+/// the live socket. rustls consumes the prelude as if it had just arrived on the wire.
+struct ReplayIo {
+    prelude: io::Cursor<Vec<u8>>,
+    sock: TcpStream,
+    prelude_done: bool,
+}
+
+impl ReplayIo {
+    fn new(prelude: Vec<u8>, sock: TcpStream) -> Self {
+        Self {
+            prelude: io::Cursor::new(prelude),
+            sock,
+            prelude_done: false,
+        }
+    }
+}
+
+impl Read for ReplayIo {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if !self.prelude_done {
+            let n = self.prelude.read(buf)?;
+            if n > 0 {
+                return Ok(n);
+            }
+            self.prelude_done = true;
+        }
+        self.sock.read(buf)
+    }
+}
+
+impl Write for ReplayIo {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.sock.write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.sock.flush()
+    }
+}
+
+/// A hand-rolled minimal HTTP/1.1 request model — enough to broker headers and re-frame,
+/// no more. Deliberately NOT a general HTTP stack: cut-1 forwards one request per
+/// connection with an explicit Content-Length, which keeps framing unambiguous.
+pub(super) mod http1 {
+    use super::{HeaderInject, MAX_BODY, MAX_HEAD, Read};
+    use std::io;
+
+    pub(super) struct Request {
+        method: String,
+        target: String,
+        version: String,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    }
+
+    /// Read one request: head (request-line + headers) then a Content-Length body. A
+    /// chunked request body is REFUSED (fail-closed) rather than risk mis-framing.
+    pub(super) fn read_request(r: &mut impl Read) -> io::Result<Request> {
+        let mut buf = Vec::new();
+        let mut tmp = [0u8; 4096];
+        let head_end = loop {
+            if let Some(pos) = find_crlf_crlf(&buf) {
+                break pos;
+            }
+            if buf.len() > MAX_HEAD {
+                return Err(io::Error::other("request head exceeds cap"));
+            }
+            let n = r.read(&mut tmp)?;
+            if n == 0 {
+                return Err(io::Error::other(
+                    "client closed before a complete request head",
+                ));
+            }
+            buf.extend_from_slice(&tmp[..n]);
+        };
+        let head =
+            std::str::from_utf8(&buf[..head_end]).map_err(|_| io::Error::other("non-UTF8 head"))?;
+        let mut lines = head.split("\r\n");
+        let request_line = lines
+            .next()
+            .ok_or_else(|| io::Error::other("empty request"))?;
+        let mut parts = request_line.splitn(3, ' ');
+        let method = parts
+            .next()
+            .ok_or_else(|| io::Error::other("no method"))?
+            .to_string();
+        let target = parts
+            .next()
+            .ok_or_else(|| io::Error::other("no request target"))?
+            .to_string();
+        let version = parts
+            .next()
+            .ok_or_else(|| io::Error::other("no HTTP version"))?
+            .to_string();
+
+        let mut headers = Vec::new();
+        for line in lines {
+            if line.is_empty() {
+                continue;
+            }
+            let (name, value) = line
+                .split_once(':')
+                .ok_or_else(|| io::Error::other("malformed header line"))?;
+            headers.push((name.trim().to_string(), value.trim().to_string()));
+        }
+
+        // Body framing.
+        let mut body = buf[head_end + 4..].to_vec();
+        if header_get(&headers, "transfer-encoding")
+            .is_some_and(|v| v.to_ascii_lowercase().contains("chunked"))
+        {
+            return Err(io::Error::other(
+                "chunked request bodies are not supported in the MITM cut-1 (fail-closed)",
+            ));
+        }
+        if let Some(cl) = header_get(&headers, "content-length") {
+            let len: usize = cl
+                .trim()
+                .parse()
+                .map_err(|_| io::Error::other("invalid Content-Length"))?;
+            if len > MAX_BODY {
+                return Err(io::Error::other("request body exceeds cap"));
+            }
+            while body.len() < len {
+                let n = r.read(&mut tmp)?;
+                if n == 0 {
+                    return Err(io::Error::other("client closed mid-body"));
+                }
+                body.extend_from_slice(&tmp[..n]);
+            }
+            body.truncate(len);
+        }
+
+        Ok(Request {
+            method,
+            target,
+            version,
+            headers,
+            body,
+        })
+    }
+
+    /// Strip-then-set each brokered header: remove EVERY existing copy (case-insensitive),
+    /// then append the injected value. A child-supplied — possibly leaked-real — header
+    /// can never survive alongside the injected one.
+    pub(super) fn apply_injects(req: &mut Request, injects: &[HeaderInject]) {
+        for inj in injects {
+            req.headers
+                .retain(|(n, _)| !n.eq_ignore_ascii_case(&inj.header));
+            req.headers
+                .push((inj.header.clone(), inj.value.expose().to_string()));
+        }
+    }
+
+    /// Normalize framing for a single-request forward: drop hop-by-hop headers, set an
+    /// accurate Content-Length, force `Connection: close`.
+    pub(super) fn normalize_for_forward(req: &mut Request) {
+        req.headers.retain(|(n, _)| {
+            !n.eq_ignore_ascii_case("connection")
+                && !n.eq_ignore_ascii_case("proxy-connection")
+                && !n.eq_ignore_ascii_case("keep-alive")
+                && !n.eq_ignore_ascii_case("transfer-encoding")
+                && !n.eq_ignore_ascii_case("content-length")
+        });
+        if !req.body.is_empty() {
+            req.headers
+                .push(("Content-Length".to_string(), req.body.len().to_string()));
+        }
+        req.headers
+            .push(("Connection".to_string(), "close".to_string()));
+    }
+
+    /// Serialize the request onto the wire (request-line + headers + CRLF + body).
+    pub(super) fn serialize(req: &Request) -> Vec<u8> {
+        let mut out = Vec::with_capacity(256 + req.body.len());
+        out.extend_from_slice(
+            format!("{} {} {}\r\n", req.method, req.target, req.version).as_bytes(),
+        );
+        for (name, value) in &req.headers {
+            out.extend_from_slice(format!("{name}: {value}\r\n").as_bytes());
+        }
+        out.extend_from_slice(b"\r\n");
+        out.extend_from_slice(&req.body);
+        out
+    }
+
+    impl Request {
+        pub(super) fn serialize(&self) -> Vec<u8> {
+            serialize(self)
+        }
+        #[cfg(test)]
+        pub(super) fn header(&self, name: &str) -> Option<&str> {
+            header_get(&self.headers, name)
+        }
+        #[cfg(test)]
+        pub(super) fn header_count(&self, name: &str) -> usize {
+            self.headers
+                .iter()
+                .filter(|(n, _)| n.eq_ignore_ascii_case(name))
+                .count()
+        }
+    }
+
+    fn header_get<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+        headers
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    }
+
+    fn find_crlf_crlf(buf: &[u8]) -> Option<usize> {
+        buf.windows(4).position(|w| w == b"\r\n\r\n")
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::policy::Secret;
+        use std::io::Cursor;
+
+        fn inject(header: &str, value: &str) -> HeaderInject {
+            HeaderInject {
+                header: header.to_string(),
+                value: Secret(value.to_string()),
+            }
+        }
+
+        #[test]
+        fn strips_child_auth_then_injects_the_real_one() {
+            let raw = "GET /repos HTTP/1.1\r\nHost: api.example.com\r\nAuthorization: Bearer child-guess\r\n\r\n";
+            let mut req = read_request(&mut Cursor::new(raw.as_bytes())).unwrap();
+            apply_injects(&mut req, &[inject("Authorization", "Bearer REAL-SECRET")]);
+            // The child's value is gone; exactly one Authorization remains, the real one.
+            assert_eq!(req.header_count("authorization"), 1);
+            assert_eq!(req.header("Authorization"), Some("Bearer REAL-SECRET"));
+        }
+
+        #[test]
+        fn forwarded_request_forces_close_and_reframes_body() {
+            let raw = "POST /x HTTP/1.1\r\nHost: h\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nhello";
+            let mut req = read_request(&mut Cursor::new(raw.as_bytes())).unwrap();
+            normalize_for_forward(&mut req);
+            let wire = String::from_utf8(req.serialize()).unwrap();
+            assert!(wire.contains("Connection: close"));
+            assert!(!wire.to_ascii_lowercase().contains("keep-alive"));
+            assert!(wire.contains("Content-Length: 5"));
+            assert!(wire.ends_with("\r\n\r\nhello"));
+        }
+
+        #[test]
+        fn chunked_request_body_is_refused() {
+            let raw = "POST /x HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+            assert!(read_request(&mut Cursor::new(raw.as_bytes())).is_err());
+        }
+    }
+}

--- a/crates/nub-sandbox/src/proxy/mitm.rs
+++ b/crates/nub-sandbox/src/proxy/mitm.rs
@@ -36,8 +36,10 @@ use std::sync::Arc;
 /// dribbling or hostile → fail closed.
 const MAX_HEAD: usize = 64 * 1024;
 /// Cap on a buffered request body nub will forward. Bodies are read whole to re-frame
-/// with an accurate Content-Length; past this, fail closed rather than buffer unbounded.
-const MAX_BODY: usize = 32 * 1024 * 1024;
+/// with an accurate Content-Length, so the cap bounds PARENT memory across many child
+/// connections — kept small (credential brokering targets API requests, not uploads);
+/// a larger body fails closed. (Streaming the forward is the follow-up that lifts this.)
+const MAX_BODY: usize = 1024 * 1024;
 
 /// The MITM engine: the ephemeral CA, a reusable upstream-verifying client config, and
 /// the compiled broker set. Built ONLY when the tier is TlsInspect. `Arc`-shared across
@@ -93,6 +95,13 @@ impl MitmEngine {
     /// Whether `host` should be TLS-terminated (a broker demands it, or terminate-all).
     pub(super) fn should_terminate(&self, host: &str) -> bool {
         self.terminate_all || self.broker_for(host).is_some()
+    }
+
+    /// `proxy: "terminate"` — every allowed TLS host must be terminated. Used to FAIL
+    /// CLOSED on a connection that carries no host to terminate (no SNI / IP literal),
+    /// which would otherwise escape termination via a blind splice.
+    pub(super) fn terminates_everything(&self) -> bool {
+        self.terminate_all
     }
 
     fn broker_for(&self, host: &str) -> Option<&[HeaderInject]> {
@@ -421,7 +430,7 @@ pub(super) mod http1 {
         fn inject(header: &str, value: &str) -> HeaderInject {
             HeaderInject {
                 header: header.to_string(),
-                value: Secret(value.to_string()),
+                value: Secret::new(value.to_string()),
             }
         }
 

--- a/crates/nub-sandbox/src/proxy/mod.rs
+++ b/crates/nub-sandbox/src/proxy/mod.rs
@@ -21,7 +21,9 @@
 //! [`apply`](crate::apply) stashes the [`EgressProxy`] in [`Prepared`](crate::Prepared)
 //! so it lives for the child's whole run and shuts down when that value drops.
 
+mod ca;
 mod handshake;
+pub mod mitm;
 mod sni;
 
 use crate::matcher::HostMatcher;
@@ -101,32 +103,50 @@ pub struct EgressProxy {
     port: u16,
     shutdown: Arc<AtomicBool>,
     accept_thread: Option<JoinHandle<()>>,
+    /// The MITM engine, when the policy engages TLS termination (credential brokering /
+    /// `proxy: "terminate"`). `None` for a host-only (connection-tier) policy — in which
+    /// case NO CA exists and NO TLS code runs (the default is "MITM never instantiated").
+    /// Held here so the ephemeral CA + its child bundle live for the child's whole run.
+    mitm: Option<Arc<mitm::MitmEngine>>,
 }
 
 impl EgressProxy {
-    /// Bind a loopback listener and start the accept loop. `decider` gates every
-    /// tunnel. Returns once the port is bound (so a caller can wire the port into the
-    /// backend deny-layer before spawning the child).
-    pub fn start(decider: Arc<dyn GrantDecider>) -> io::Result<EgressProxy> {
+    /// Bind a loopback listener and start the accept loop. `decider` gates every tunnel;
+    /// `mitm` (when present) terminates the hosts whose rules demand inspection. Returns
+    /// once the port is bound (so a caller can wire the port into the backend deny-layer
+    /// before spawning the child).
+    pub fn start(
+        decider: Arc<dyn GrantDecider>,
+        mitm: Option<Arc<mitm::MitmEngine>>,
+    ) -> io::Result<EgressProxy> {
         // Loopback only — the sandboxed child reaches us via 127.0.0.1; nothing off-box
         // should ever see this listener.
         let listener = TcpListener::bind((IpAddr::from([127, 0, 0, 1]), 0))?;
         let port = listener.local_addr()?.port();
         let shutdown = Arc::new(AtomicBool::new(false));
         let sh = shutdown.clone();
+        let engine = mitm.clone();
         let accept_thread = std::thread::Builder::new()
             .name("nub-egress-proxy".into())
-            .spawn(move || accept_loop(listener, sh, decider))?;
+            .spawn(move || accept_loop(listener, sh, decider, engine))?;
         Ok(EgressProxy {
             port,
             shutdown,
             accept_thread: Some(accept_thread),
+            mitm,
         })
     }
 
     /// The loopback port the child must be pointed at (env hint + OS carve-out).
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    /// The child-scoped CA-bundle path, when TLS termination is engaged — the value the
+    /// CA-env vars point the child at so it trusts the minted leaves. `None` for a
+    /// connection-tier policy (no CA exists).
+    pub fn ca_bundle_path(&self) -> Option<&std::path::Path> {
+        self.mitm.as_ref().map(|m| m.bundle_path())
     }
 }
 
@@ -145,26 +165,37 @@ impl Drop for EgressProxy {
 
 /// Accept loop: one detached handler thread per connection. Any handler error just
 /// closes that connection — a single malformed client never takes down the proxy.
-fn accept_loop(listener: TcpListener, shutdown: Arc<AtomicBool>, decider: Arc<dyn GrantDecider>) {
+fn accept_loop(
+    listener: TcpListener,
+    shutdown: Arc<AtomicBool>,
+    decider: Arc<dyn GrantDecider>,
+    mitm: Option<Arc<mitm::MitmEngine>>,
+) {
     for conn in listener.incoming() {
         if shutdown.load(Ordering::SeqCst) {
             break;
         }
         let Ok(stream) = conn else { continue };
         let d = decider.clone();
+        let m = mitm.clone();
         // Best-effort spawn; if the OS refuses a thread we simply drop the connection
         // (fail-closed — no unproxied path opens).
         let _ = std::thread::Builder::new()
             .name("nub-egress-tunnel".into())
             .spawn(move || {
-                let _ = handle_conn(stream, d);
+                let _ = handle_conn(stream, d, m);
             });
     }
 }
 
 /// Handle one client tunnel: parse the request, gate the target host, ACK, gate the
-/// SNI, then connect upstream and blind-forward. Returns `Ok(())` on any clean refusal.
-fn handle_conn(mut stream: TcpStream, decider: Arc<dyn GrantDecider>) -> io::Result<()> {
+/// SNI, then EITHER blind-splice (connection tier) OR terminate + inject (MITM tier).
+/// Returns `Ok(())` on any clean refusal.
+fn handle_conn(
+    mut stream: TcpStream,
+    decider: Arc<dyn GrantDecider>,
+    mitm: Option<Arc<mitm::MitmEngine>>,
+) -> io::Result<()> {
     stream.set_read_timeout(Some(CLIENT_HELLO_TIMEOUT))?;
     let req = read_request(&mut stream)?;
 
@@ -176,12 +207,30 @@ fn handle_conn(mut stream: TcpStream, decider: Arc<dyn GrantDecider>) -> io::Res
     reply_success(&mut stream, req.proto)?;
 
     // Gate 2 — the TLS SNI, read no-MITM from the client's first bytes.
-    let (prelude, allowed) = read_and_check_sni(&mut stream, decider.as_ref())?;
+    let (prelude, allowed, sni_host) = read_and_check_sni(&mut stream, decider.as_ref())?;
     if !allowed {
         return Ok(()); // drop — the client sees a reset tunnel
     }
 
-    // Connect upstream ONLY after both gates pass, replay the buffered prelude, splice.
+    // The host the leaf is minted for + the broker is matched on: the SNI the client
+    // asked for (so its TLS hostname check passes), else the CONNECT/SOCKS authority.
+    let terminate_host = sni_host.or_else(|| match &req.host {
+        Host::Name(n) => Some(n.clone()),
+        Host::Ip(_) => None, // an IP-literal target carries no name to mint a leaf for
+    });
+
+    // MITM tier: terminate + inject ONLY the hosts whose rules demand it; everything else
+    // (and every host under a connection-tier policy) stays a blind splice. Any error on
+    // the terminate path is a fail-closed drop — never a splice fallback that would send
+    // the request un-injected or expose the secret.
+    if let (Some(engine), Some(host)) = (mitm.as_ref(), terminate_host.as_deref())
+        && engine.should_terminate(host)
+    {
+        let _ = mitm::terminate(engine, stream, prelude, host, req.port);
+        return Ok(());
+    }
+
+    // Connection tier — connect upstream, replay the buffered prelude, blind-splice.
     let upstream = connect_upstream(&req.host, req.port)?;
     stream.set_read_timeout(None)?;
     upstream.set_read_timeout(None)?;
@@ -194,7 +243,7 @@ fn handle_conn(mut stream: TcpStream, decider: Arc<dyn GrantDecider>) -> io::Res
 }
 
 /// Read the client's first bytes and decide the SNI gate. Returns the buffered prelude
-/// (to replay upstream) and whether the tunnel is allowed.
+/// (to replay), whether the tunnel is allowed, and the SNI hostname when one was present.
 ///
 /// The rule closes the SNI-evasion vectors: a complete ClientHello's SNI is checked;
 /// a ClientHello with no SNI, or a non-TLS stream, admits (the target host already
@@ -205,7 +254,7 @@ fn handle_conn(mut stream: TcpStream, decider: Arc<dyn GrantDecider>) -> io::Res
 fn read_and_check_sni(
     stream: &mut TcpStream,
     decider: &dyn GrantDecider,
-) -> io::Result<(Vec<u8>, bool)> {
+) -> io::Result<(Vec<u8>, bool, Option<String>)> {
     let mut buf = Vec::new();
     let mut tmp = [0u8; 4096];
     loop {
@@ -215,16 +264,16 @@ fn read_and_check_sni(
                 buf.extend_from_slice(&tmp[..n]);
                 match sni::scan_client_hello(&buf) {
                     SniScan::Sni(host) => {
-                        let ok = decider.decide(&Host::Name(host)) == Decision::Allow;
-                        return Ok((buf, ok));
+                        let ok = decider.decide(&Host::Name(host.clone())) == Decision::Allow;
+                        return Ok((buf, ok, Some(host)));
                     }
                     // Admitted target + no SNI to cross-route on → allow.
-                    SniScan::NoSni | SniScan::NotTls => return Ok((buf, true)),
+                    SniScan::NoSni | SniScan::NotTls => return Ok((buf, true, None)),
                     // TLS-shaped but broken → fail closed.
-                    SniScan::Malformed => return Ok((buf, false)),
+                    SniScan::Malformed => return Ok((buf, false, None)),
                     SniScan::Incomplete => {
                         if buf.len() > MAX_PRELUDE {
-                            return Ok((buf, false)); // dribbling past the cap → fail closed
+                            return Ok((buf, false, None)); // dribbling past the cap → fail closed
                         }
                         // else read more
                     }
@@ -239,16 +288,16 @@ fn read_and_check_sni(
 
 /// Decide on whatever prelude arrived when the read ends (EOF or timeout). A complete
 /// hello is honored; an incomplete/empty TLS stream (the stall) fails closed.
-fn finalize_scan(buf: &[u8], decider: &dyn GrantDecider) -> (Vec<u8>, bool) {
+fn finalize_scan(buf: &[u8], decider: &dyn GrantDecider) -> (Vec<u8>, bool, Option<String>) {
     match sni::scan_client_hello(buf) {
         SniScan::Sni(host) => {
             let ok = decider.decide(&Host::Name(host.clone())) == Decision::Allow;
-            (buf.to_vec(), ok)
+            (buf.to_vec(), ok, Some(host))
         }
-        SniScan::NoSni | SniScan::NotTls => (buf.to_vec(), true),
+        SniScan::NoSni | SniScan::NotTls => (buf.to_vec(), true, None),
         // Incomplete (incl. an empty buffer — client ACK'd then sent nothing) or
         // Malformed → the SNI could not be verified → deny.
-        SniScan::Incomplete | SniScan::Malformed => (buf.to_vec(), false),
+        SniScan::Incomplete | SniScan::Malformed => (buf.to_vec(), false, None),
     }
 }
 
@@ -346,6 +395,7 @@ mod tests {
             enforce: true,
             rules,
             default_effect,
+            ..Default::default()
         }
     }
     fn host(pat: &str, effect: Effect) -> NetRule {

--- a/crates/nub-sandbox/src/proxy/mod.rs
+++ b/crates/nub-sandbox/src/proxy/mod.rs
@@ -223,11 +223,19 @@ fn handle_conn(
     // (and every host under a connection-tier policy) stays a blind splice. Any error on
     // the terminate path is a fail-closed drop — never a splice fallback that would send
     // the request un-injected or expose the secret.
-    if let (Some(engine), Some(host)) = (mitm.as_ref(), terminate_host.as_deref())
-        && engine.should_terminate(host)
-    {
-        let _ = mitm::terminate(engine, stream, prelude, host, req.port);
-        return Ok(());
+    if let Some(engine) = mitm.as_ref() {
+        match terminate_host.as_deref() {
+            Some(host) if engine.should_terminate(host) => {
+                let _ = mitm::terminate(engine, stream, prelude, host, req.port);
+                return Ok(());
+            }
+            // `proxy: "terminate"` but this connection carries no host to terminate (no
+            // SNI / IP literal) — FAIL CLOSED rather than blind-splice past the
+            // terminate-everything guarantee.
+            None if engine.terminates_everything() => return Ok(()),
+            // A connection-tier host, or a broker that didn't match this SNI → splice.
+            _ => {}
+        }
     }
 
     // Connection tier — connect upstream, replay the buffered prelude, blind-splice.

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use nub_sandbox::compiler::{CompileError, compile};
-use nub_sandbox::policy::{Effect, EnvFormat};
+use nub_sandbox::policy::{Effect, EnvFormat, Inspection, NetTarget};
 use serde_json::json;
 
 // ── wrapper trichotomy ────────────────────────────────────────────────────────
@@ -902,4 +902,114 @@ fn net_trailing_dot_is_stripped_so_it_cannot_dodge_a_deny() {
     assert!(m.admits("ok.example"));
     assert!(!m.admits("evil.com."), "trailing-dot deny still bites");
     assert!(!m.admits("evil.com"));
+}
+
+// ── credential brokering (the capability-derived MITM tier) ───────────────────
+
+#[test]
+fn broker_compiles_to_an_allow_rule_plus_a_broker_and_engages_tls_inspect() {
+    let ctx = common::ctx(true, &[]);
+    let p = compile(
+        &json!({ "net": { "api.example.com": { "inject": { "Authorization": "Bearer literal-secret" } } } }),
+        &ctx,
+    )
+    .unwrap();
+    // The brokered host is implicitly ALLOWED.
+    assert!(
+        p.net.rules.iter().any(
+            |r| matches!(&r.target, NetTarget::Host(h) if h == "api.example.com")
+                && matches!(r.effect, Effect::Allow)
+        ),
+        "brokered host must be allowed"
+    );
+    // The broker carries the resolved secret, readable only via `.expose()`.
+    assert_eq!(p.net.brokers.len(), 1);
+    assert_eq!(p.net.brokers[0].host, "api.example.com");
+    assert_eq!(p.net.brokers[0].injects[0].header, "Authorization");
+    assert_eq!(
+        p.net.brokers[0].injects[0].value.expose(),
+        "Bearer literal-secret"
+    );
+    // The tier auto-derives to TlsInspect (a request-level capability is present).
+    assert!(matches!(p.net.inspection, Inspection::TlsInspect));
+}
+
+#[test]
+fn host_only_policy_stays_connection_tier_no_mitm() {
+    let ctx = common::ctx(true, &[]);
+    let p = compile(&json!({ "net": { "api.example.com": true } }), &ctx).unwrap();
+    assert!(p.net.brokers.is_empty());
+    assert!(
+        matches!(p.net.inspection, Inspection::Connection),
+        "host-only config must not engage TLS termination"
+    );
+}
+
+#[test]
+fn wildcard_broker_is_rejected_as_a_laundering_guard() {
+    // A wildcard broker would inject the credential to any matching subdomain — including
+    // an attacker-owned one. Only a literal host is allowed.
+    let ctx = common::ctx(true, &[]);
+    for host in ["*.example.com", "*"] {
+        let err = compile(
+            &json!({ "net": { host: { "inject": { "Authorization": "Bearer x" } } } }),
+            &ctx,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, CompileError::Shape { .. }),
+            "wildcard broker `{host}` must be rejected"
+        );
+    }
+}
+
+#[test]
+fn inject_is_a_trusted_only_capability() {
+    // An untrusted (dependenciesMeta) grant must not be able to broker — even a literal.
+    let ctx = common::ctx(false, &[]);
+    let err = compile(
+        &json!({ "net": { "api.example.com": { "inject": { "Authorization": "Bearer x" } } } }),
+        &ctx,
+    )
+    .unwrap_err();
+    assert!(matches!(err, CompileError::Shape { .. }));
+}
+
+#[test]
+fn passthrough_with_an_inject_rule_is_a_compile_error() {
+    // The `proxy: "passthrough"` block-MITM posture contradicts a rule that requires
+    // termination — a hard error, never a silent drop.
+    let ctx = common::ctx(true, &[]);
+    let err = compile(
+        &json!({
+            "net": { "api.example.com": { "inject": { "Authorization": "Bearer x" } } },
+            "proxy": "passthrough"
+        }),
+        &ctx,
+    )
+    .unwrap_err();
+    assert!(matches!(err, CompileError::Shape { .. }));
+}
+
+#[test]
+fn terminate_mode_engages_tls_inspect_without_a_broker() {
+    let ctx = common::ctx(true, &[]);
+    let p = compile(
+        &json!({ "net": { "api.example.com": true }, "proxy": "terminate" }),
+        &ctx,
+    )
+    .unwrap();
+    assert!(matches!(p.net.inspection, Inspection::TlsInspect));
+    assert!(p.net.brokers.is_empty());
+}
+
+#[test]
+fn crlf_in_an_inject_value_is_rejected() {
+    let ctx = common::ctx(true, &[]);
+    let err = compile(
+        &json!({ "net": { "api.example.com": { "inject": { "Authorization": "Bearer x\r\nX-Evil: 1" } } } }),
+        &ctx,
+    )
+    .unwrap_err();
+    assert!(matches!(err, CompileError::Shape { .. }));
 }

--- a/crates/nub-sandbox/tests/matcher.rs
+++ b/crates/nub-sandbox/tests/matcher.rs
@@ -214,6 +214,7 @@ fn net_matcher_admits_by_last_match_and_cidr() {
                 effect: Effect::Allow,
             },
         ],
+        ..Default::default()
     };
     let m = HostMatcher::new(&policy);
     assert!(m.admits("ingest.sentry.io"));

--- a/crates/nub-sandbox/tests/proxy.rs
+++ b/crates/nub-sandbox/tests/proxy.rs
@@ -162,6 +162,7 @@ fn net(rules: Vec<NetRule>) -> NetPolicy {
         enforce: true,
         rules,
         default_effect: Effect::Deny,
+        ..Default::default()
     }
 }
 fn allow_host(pat: &str) -> NetRule {
@@ -178,7 +179,7 @@ fn allow_cidr(cidr: &str) -> NetRule {
 }
 
 fn start(policy: NetPolicy) -> EgressProxy {
-    EgressProxy::start(Arc::new(StaticDecider::new(policy))).unwrap()
+    EgressProxy::start(Arc::new(StaticDecider::new(policy)), None).unwrap()
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────────
@@ -333,7 +334,7 @@ fn decider_seam_is_consulted_for_target_and_sni() {
     }
     let upstream = echo_server();
     let rec = Arc::new(Recorder::default());
-    let proxy = EgressProxy::start(rec.clone()).unwrap();
+    let proxy = EgressProxy::start(rec.clone(), None).unwrap();
     let mut t = http_connect(proxy.port(), &format!("127.0.0.1:{}", upstream.port())).unwrap();
     assert!(tunnel_forwards(&mut t, "keep.allowed.example"));
     let seen = rec.seen.lock().unwrap().clone();


### PR DESCRIPTION
Cut-1 of the capability-derived MITM tier: **credential brokering**. The egress proxy terminates TLS for a host only when its rule needs to read inside the stream (an `inject` rule), then injects a credential (strip-then-set) so the sandboxed child never holds the secret.

- Auto-derived per-host; host-only config stays the blind-tunnel proxy — no CA exists.
- Ephemeral per-run CA, private key in-memory only, never the OS trust store; trust reaches the child via a scoped CA-bundle env (`NODE_EXTRA_CA_CERTS`-class). Fail-closed on any TLS/cert/parse error.
- Literal-host + trusted-only brokers (laundering + untrusted-grant guards); one-line stderr notice.

Verified end-to-end on macOS; nub-sandbox + the TLS deps compile on windows-gnu (runtime MITM degrades fail-safe pending the AppContainer loopback exemption — a separate workstream). Held for review.
