### PR TITLE
feat(installer) supports basic setup customization

### DIFF
--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -205,3 +205,26 @@ jobs:
             exit 1
           fi
           "$nubx_path" --version
+
+  # Exercises the REPO's install.sh (not the main-served copy) against sandbox
+  # HOMEs to assert the customization knobs: per-shell PATH lines, the .nub-receipt
+  # marker, NUB_INSTALL_DIR relocation, and the NUB_NO_MODIFY_PATH opt-out. This is
+  # the only job that validates the branch's own script changes end-to-end (the
+  # curl-based jobs above fetch from `source`, which defaults to main).
+  harness:
+    name: install.sh harness · ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: Run tests/installer/run.sh
+        shell: bash
+        env:
+          # The harness's install.sh authenticates the releases/latest API call to
+          # dodge the unauthenticated rate-limit (403) on shared CI IPs.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE_COLOR: "0"
+        run: bash tests/installer/run.sh

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -5096,14 +5096,22 @@ fn detect_channel(bin_path: &Path) -> UpgradeChannel {
     if s.contains("/homebrew/") || s.contains("/Cellar/") || s.contains("/linuxbrew/") {
         return UpgradeChannel::Homebrew;
     }
-    // Self-owned: the binary sits at `<install_dir>/bin/nub`, where install_dir
-    // ends in `.nub` (install.sh: `$HOME/.nub/bin/nub`). Derive install_dir by
-    // walking up from the binary so a copied-but-intact `.nub` tree still swaps.
+    // Self-owned: the binary sits at `<install_dir>/bin/nub`. Derive install_dir
+    // by walking up from the binary, then accept it as self-owned when EITHER the
+    // dir is the default `.nub` (covers installs predating the receipt) OR it
+    // carries a `.nub-receipt` marker the installer writes. The receipt is what
+    // makes a relocated `NUB_INSTALL_DIR` in-place-upgradeable, while still
+    // rejecting an unrelated `<dir>/bin/nub` (e.g. a distro `/usr/bin/nub`) that
+    // has neither signal. Order matters: npm/homebrew already returned above, so a
+    // package-managed binary never reaches here.
     let install_dir = bin_path
         .parent()
         .filter(|bin_dir| bin_dir.file_name().is_some_and(|n| n == "bin"))
         .and_then(Path::parent)
-        .filter(|install_dir| install_dir.file_name().is_some_and(|n| n == ".nub"));
+        .filter(|install_dir| {
+            install_dir.file_name().is_some_and(|n| n == ".nub")
+                || install_dir.join(".nub-receipt").is_file()
+        });
     match install_dir {
         Some(dir) => UpgradeChannel::SelfOwned {
             install_dir: dir.to_path_buf(),
@@ -5213,7 +5221,12 @@ fn run_upgrade(version: Option<&str>, dry_run: bool, _yes: bool) -> Result<i32> 
                 println!("  command: {HOMEBREW_UPGRADE_DISPLAY}");
             }
             UpgradeChannel::SelfOwned { install_dir } => {
-                println!("would upgrade to {target} via self-owned (~/.nub)");
+                // Show the resolved dir, not a hardcoded ~/.nub — a receipt-marked
+                // NUB_INSTALL_DIR relocates it.
+                println!(
+                    "would upgrade to {target} via self-owned ({})",
+                    install_dir.display()
+                );
                 if cfg!(windows) {
                     println!(
                         "  note: a real self-owned upgrade is unsupported on Windows; \
@@ -8754,9 +8767,70 @@ mod tests {
             }
             other => panic!("expected SelfOwned, got {other:?}"),
         }
+        // An arbitrary `<dir>/bin/nub` with neither the `.nub` name nor a receipt
+        // stays Unknown — this is what keeps a distro `/usr/bin/nub` from being
+        // mistaken for a self-managed install and overwritten by `nub upgrade`.
+        assert_eq!(
+            detect_channel(Path::new("/some/random/place/bin/nub")),
+            UpgradeChannel::Unknown
+        );
         assert_eq!(
             detect_channel(Path::new("/some/random/place/nub")),
             UpgradeChannel::Unknown
+        );
+    }
+
+    // Receipt-based self-owned detection: a relocated NUB_INSTALL_DIR (not named
+    // `.nub`) is in-place-upgradeable IFF the installer's `.nub-receipt` marker is
+    // present next to bin/. Without it, the same layout stays Unknown. Uses a real
+    // temp dir because the receipt check hits the filesystem.
+    #[test]
+    fn detect_channel_honors_install_receipt_for_relocated_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path().join("custom-nub");
+        let bin = install_dir.join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let nub = bin.join("nub");
+
+        // No receipt yet → not recognized as self-owned.
+        assert_eq!(detect_channel(&nub), UpgradeChannel::Unknown);
+
+        // Installer drops the receipt → recognized, with install_dir recovered.
+        std::fs::write(install_dir.join(".nub-receipt"), "# marker\n").unwrap();
+        match detect_channel(&nub) {
+            UpgradeChannel::SelfOwned { install_dir: dir } => assert_eq!(dir, install_dir),
+            other => panic!("expected SelfOwned once the receipt exists, got {other:?}"),
+        }
+    }
+
+    // The critical repeat-upgrade invariant: a self-owned upgrade swaps only bin/,
+    // so the `.nub-receipt` marker MUST survive it — otherwise the NEXT upgrade
+    // would fail to re-detect a relocated install as self-owned. Exercises the real
+    // `swap_dir` the upgrade uses.
+    #[test]
+    fn install_receipt_survives_a_selfowned_bin_swap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path();
+        std::fs::create_dir_all(install_dir.join("bin")).unwrap();
+        std::fs::write(install_dir.join("bin").join("nub"), b"old").unwrap();
+        let receipt = install_dir.join(".nub-receipt");
+        std::fs::write(&receipt, "# marker\n").unwrap();
+
+        // Stage the replacement bin/ in a sibling dir (same filesystem, as the real
+        // upgrade does) and swap it in.
+        let staged = install_dir.join("staged-bin");
+        std::fs::create_dir_all(&staged).unwrap();
+        std::fs::write(staged.join("nub"), b"new").unwrap();
+        swap_dir(install_dir, "bin", &staged).unwrap();
+
+        assert_eq!(
+            std::fs::read(install_dir.join("bin").join("nub")).unwrap(),
+            b"new",
+            "bin/ should hold the swapped-in binary"
+        );
+        assert!(
+            receipt.is_file(),
+            ".nub-receipt must survive the bin swap so repeat upgrades keep detecting self-owned"
         );
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -27,11 +27,21 @@ if ($Version -eq "latest") {
 Write-Host "Installing nub v$Version for $Target..." -ForegroundColor Cyan
 
 # --- Install ---
-$InstallDir = "$env:USERPROFILE\.nub"
-$BinDir = "$InstallDir\bin"
-$Exe = "$BinDir\nub.exe"
+# Both paths are normalized so the "does nub own this directory?" test at the
+# cleanup step below is exact rather than a string compare of two spellings.
+$DefaultInstallDir = [System.IO.Path]::GetFullPath("$env:USERPROFILE\.nub")
+$InstallDir = if ($env:NUB_INSTALL_DIR) { $env:NUB_INSTALL_DIR } else { $DefaultInstallDir }
 
-New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+try {
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+} catch {
+    Write-Error "Failed to create install directory: $InstallDir"
+    exit 1
+}
+$InstallDir = (Resolve-Path -LiteralPath $InstallDir).Path
+
+$InstallBinDir = "$InstallDir\bin"
+$InstallExe = "$InstallBinDir\nub.exe"
 
 # Download the per-platform archive and extract it into the install dir. nub is a
 # single self-contained binary that embeds its runtime (preload + vendored
@@ -48,10 +58,16 @@ $prevProgressPreference = $ProgressPreference
 try {
     $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
-    # Replace any prior bin\ for a clean upgrade. A stale runtime\ from a
-    # pre-single-binary install is also removed for hygiene, then extract bin\.
-    if (Test-Path $BinDir) { Remove-Item -Recurse -Force $BinDir }
-    if (Test-Path "$InstallDir\runtime") { Remove-Item -Recurse -Force "$InstallDir\runtime" }
+    # nub owns the default dir outright, so replace any prior bin\ for a clean
+    # upgrade and drop a stale runtime\ from a pre-single-binary install. A
+    # user-supplied NUB_INSTALL_DIR may hold foreign files, so there we remove
+    # only the two executables we wrote. Then extract bin\.
+    if ($InstallDir -ieq $DefaultInstallDir) {
+        if (Test-Path $InstallBinDir) { Remove-Item -Recurse -Force $InstallBinDir }
+        if (Test-Path "$InstallDir\runtime") { Remove-Item -Recurse -Force "$InstallDir\runtime" }
+    } else {
+        Remove-Item -Force -ErrorAction SilentlyContinue -LiteralPath "$InstallBinDir\nub.exe", "$InstallBinDir\nubx.exe"
+    }
     Expand-Archive -Path $TmpZip -DestinationPath $InstallDir -Force
 } catch {
     Write-Error "Failed to download/extract nub: $_"
@@ -61,7 +77,7 @@ try {
     if (Test-Path $TmpZip) { Remove-Item -Force $TmpZip }
 }
 
-if (-not (Test-Path $Exe)) {
+if (-not (Test-Path $InstallExe)) {
     Write-Error "Archive did not contain bin\nub.exe"
     exit 1
 }
@@ -71,17 +87,29 @@ if (-not (Test-Path $Exe)) {
 # bin\nub.exe, so create the nubx alias. On Windows we COPY rather than symlink:
 # symlinks require admin/Developer Mode, and a copy reliably yields argv[0]
 # "nubx.exe". Re-extract on upgrade wipes bin\, so this is recreated each run.
-$Exex = "$BinDir\nubx.exe"
-Copy-Item -Path $Exe -Destination $Exex -Force
+$InstallExex = "$InstallBinDir\nubx.exe"
+Copy-Item -Path $InstallExe -Destination $InstallExex -Force
 
-Write-Host "Installed nub (with nubx) to $Exe" -ForegroundColor Green
+Write-Host "Installed nub (with nubx) to $InstallExe" -ForegroundColor Green
 
 # --- PATH setup ---
+$NoModifyPath = if ($env:NUB_NO_MODIFY_PATH) { $env:NUB_NO_MODIFY_PATH.ToLowerInvariant() } else { "0" }
+if ($NoModifyPath -in @("1", "yes", "true", "on")) {
+    Write-Host "Please add the nub bin path to your PATH:"
+    Write-Host "  $InstallBinDir" -ForegroundColor White
+    exit 0
+} elseif ($NoModifyPath -notin @("0", "no", "false", "off")) {
+    Write-Error "Invalid NUB_NO_MODIFY_PATH: $env:NUB_NO_MODIFY_PATH"
+    exit 1
+}
+
+# Split on the separator rather than `-like "*$InstallBinDir*"`: a user-supplied
+# NUB_INSTALL_DIR can carry wildcard characters, which -like would interpret.
 $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-if ($UserPath -notlike "*$BinDir*") {
-    [Environment]::SetEnvironmentVariable("Path", "$BinDir;$UserPath", "User")
-    $env:Path = "$BinDir;$env:Path"
-    Write-Host "Added $BinDir to PATH" -ForegroundColor Green
+if (($UserPath -split ';') -notcontains $InstallBinDir) {
+    [Environment]::SetEnvironmentVariable("Path", "$InstallBinDir;$UserPath", "User")
+    $env:Path = "$InstallBinDir;$env:Path"
+    Write-Host "Added $InstallBinDir to PATH" -ForegroundColor Green
 } else {
     Write-Host "Already in PATH" -ForegroundColor Green
 }

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,10 @@
 #!/usr/bin/env pwsh
 # Nub installer for Windows (PowerShell)
 # Usage: irm https://raw.githubusercontent.com/nubjs/nub/main/install.ps1 | iex
+#
+# Customization (env vars):
+#   NUB_INSTALL_DIR      install location, absolute path (default: %USERPROFILE%\.nub)
+#   NUB_NO_MODIFY_PATH   truthy (1/yes/true/on) to skip editing the User PATH
 
 $ErrorActionPreference = "Stop"
 
@@ -27,21 +31,15 @@ if ($Version -eq "latest") {
 Write-Host "Installing nub v$Version for $Target..." -ForegroundColor Cyan
 
 # --- Install ---
-# Both paths are normalized so the "does nub own this directory?" test at the
-# cleanup step below is exact rather than a string compare of two spellings.
+# The install location is overridable via NUB_INSTALL_DIR (default %USERPROFILE%\.nub).
+# Both the resolved dir and the default are normalized to full paths so the
+# "is this the default location?" test below is an exact comparison.
 $DefaultInstallDir = [System.IO.Path]::GetFullPath("$env:USERPROFILE\.nub")
 $InstallDir = if ($env:NUB_INSTALL_DIR) { $env:NUB_INSTALL_DIR } else { $DefaultInstallDir }
-
-try {
-    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
-} catch {
-    Write-Error "Failed to create install directory: $InstallDir"
-    exit 1
-}
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 $InstallDir = (Resolve-Path -LiteralPath $InstallDir).Path
-
-$InstallBinDir = "$InstallDir\bin"
-$InstallExe = "$InstallBinDir\nub.exe"
+$BinDir = "$InstallDir\bin"
+$Exe = "$BinDir\nub.exe"
 
 # Download the per-platform archive and extract it into the install dir. nub is a
 # single self-contained binary that embeds its runtime (preload + vendored
@@ -58,15 +56,15 @@ $prevProgressPreference = $ProgressPreference
 try {
     $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
-    # nub owns the default dir outright, so replace any prior bin\ for a clean
-    # upgrade and drop a stale runtime\ from a pre-single-binary install. A
-    # user-supplied NUB_INSTALL_DIR may hold foreign files, so there we remove
-    # only the two executables we wrote. Then extract bin\.
+    # Replace any prior nub artifacts for a clean upgrade. In the default ~\.nub —
+    # which nub owns outright — drop the whole bin\ and a stale runtime\ from a
+    # pre-single-binary install. A user-supplied NUB_INSTALL_DIR may hold unrelated
+    # files, so there remove only the two executables we wrote. Then extract bin\.
     if ($InstallDir -ieq $DefaultInstallDir) {
-        if (Test-Path $InstallBinDir) { Remove-Item -Recurse -Force $InstallBinDir }
+        if (Test-Path $BinDir) { Remove-Item -Recurse -Force $BinDir }
         if (Test-Path "$InstallDir\runtime") { Remove-Item -Recurse -Force "$InstallDir\runtime" }
     } else {
-        Remove-Item -Force -ErrorAction SilentlyContinue -LiteralPath "$InstallBinDir\nub.exe", "$InstallBinDir\nubx.exe"
+        Remove-Item -Force -ErrorAction SilentlyContinue -LiteralPath "$BinDir\nub.exe", "$BinDir\nubx.exe"
     }
     Expand-Archive -Path $TmpZip -DestinationPath $InstallDir -Force
 } catch {
@@ -77,7 +75,7 @@ try {
     if (Test-Path $TmpZip) { Remove-Item -Force $TmpZip }
 }
 
-if (-not (Test-Path $InstallExe)) {
+if (-not (Test-Path $Exe)) {
     Write-Error "Archive did not contain bin\nub.exe"
     exit 1
 }
@@ -87,29 +85,41 @@ if (-not (Test-Path $InstallExe)) {
 # bin\nub.exe, so create the nubx alias. On Windows we COPY rather than symlink:
 # symlinks require admin/Developer Mode, and a copy reliably yields argv[0]
 # "nubx.exe". Re-extract on upgrade wipes bin\, so this is recreated each run.
-$InstallExex = "$InstallBinDir\nubx.exe"
-Copy-Item -Path $InstallExe -Destination $InstallExex -Force
+$Exex = "$BinDir\nubx.exe"
+Copy-Item -Path $Exe -Destination $Exex -Force
 
-Write-Host "Installed nub (with nubx) to $InstallExe" -ForegroundColor Green
+# Install receipt: marks this dir as a nub self-managed install so `nub upgrade`
+# recognizes it as in-place-upgradeable even when NUB_INSTALL_DIR relocated it out
+# of the default ~\.nub (cli.rs detect_channel checks for this file).
+$Receipt = @'
+# This file marks a nub self-managed install so `nub upgrade` can update it in
+# place. Created by the nub installer; safe to delete (deleting it disables
+# in-place self-update for a non-default install location).
+'@
+Set-Content -LiteralPath "$InstallDir\.nub-receipt" -Value $Receipt
+
+Write-Host "Installed nub (with nubx) to $Exe" -ForegroundColor Green
 
 # --- PATH setup ---
-$NoModifyPath = if ($env:NUB_NO_MODIFY_PATH) { $env:NUB_NO_MODIFY_PATH.ToLowerInvariant() } else { "0" }
+# Honor NUB_NO_MODIFY_PATH: skip the User PATH edit and just print the dir to add
+# (rustup/uv convention).
+$NoModifyPath = "$env:NUB_NO_MODIFY_PATH".ToLowerInvariant()
 if ($NoModifyPath -in @("1", "yes", "true", "on")) {
-    Write-Host "Please add the nub bin path to your PATH:"
-    Write-Host "  $InstallBinDir" -ForegroundColor White
+    Write-Host "Add the nub bin path to your PATH:"
+    Write-Host "  $BinDir" -ForegroundColor White
     exit 0
-} elseif ($NoModifyPath -notin @("0", "no", "false", "off")) {
-    Write-Error "Invalid NUB_NO_MODIFY_PATH: $env:NUB_NO_MODIFY_PATH"
+} elseif ($NoModifyPath -notin @("", "0", "no", "false", "off")) {
+    Write-Error "Invalid NUB_NO_MODIFY_PATH: $env:NUB_NO_MODIFY_PATH (expected 1/yes/true/on or 0/no/false/off)"
     exit 1
 }
 
-# Split on the separator rather than `-like "*$InstallBinDir*"`: a user-supplied
-# NUB_INSTALL_DIR can carry wildcard characters, which -like would interpret.
 $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-if (($UserPath -split ';') -notcontains $InstallBinDir) {
-    [Environment]::SetEnvironmentVariable("Path", "$InstallBinDir;$UserPath", "User")
-    $env:Path = "$InstallBinDir;$env:Path"
-    Write-Host "Added $InstallBinDir to PATH" -ForegroundColor Green
+# Compare against the exact segments rather than a substring match: a custom
+# NUB_INSTALL_DIR could be a substring of an unrelated existing entry.
+if (($UserPath -split ';') -notcontains $BinDir) {
+    [Environment]::SetEnvironmentVariable("Path", "$BinDir;$UserPath", "User")
+    $env:Path = "$BinDir;$env:Path"
+    Write-Host "Added $BinDir to PATH" -ForegroundColor Green
 } else {
     Write-Host "Already in PATH" -ForegroundColor Green
 }

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 # Nub installer — downloads the latest release binary from GitHub.
 # Usage: curl -fsSL https://raw.githubusercontent.com/nubjs/nub/main/install.sh | bash
+#
+# Customization (env vars):
+#   NUB_INSTALL_DIR      install location, absolute path (default: ~/.nub)
+#   NUB_NO_MODIFY_PATH   truthy (1/yes/true/on) to skip editing your shell profile
 
 # Windows: delegate to PowerShell
 if [[ ${OS:-} = Windows_NT ]]; then
@@ -72,16 +76,24 @@ fi
 
 # --- Install ---
 
-default_install_dir=$(cd "$HOME" && pwd)/.nub
-install_dir=${NUB_INSTALL_DIR:-$default_install_dir}
-mkdir -p "$install_dir" || error "Failed to create install directory: $install_dir"
-install_dir=$(cd "$install_dir" && pwd) || error "Invalid NUB_INSTALL_DIR: $install_dir"
-install_bin_dir="$install_dir/bin"
-install_exe="$install_bin_dir/nub"
+# The install location is overridable via NUB_INSTALL_DIR (default ~/.nub). A
+# custom dir is normalized to an absolute path so the PATH line, the receipt, and
+# the "is this the default location?" test below are all exact. The default keeps
+# the literal "$HOME/.nub" spelling so the emitted PATH line stays $HOME-portable.
+default_install_dir="$HOME/.nub"
+if [[ -n "${NUB_INSTALL_DIR:-}" ]]; then
+    install_dir="$NUB_INSTALL_DIR"
+    mkdir -p "$install_dir" || error "Failed to create install directory: $install_dir"
+    install_dir=$(cd "$install_dir" && pwd) || error "Invalid NUB_INSTALL_DIR: $NUB_INSTALL_DIR"
+else
+    install_dir="$default_install_dir"
+fi
+bin_dir="$install_dir/bin"
+exe="$bin_dir/nub"
 
 info "Installing nub v${version} for ${target}..."
 
-mkdir -p "$install_bin_dir" || error "Failed to create install directory: $install_bin_dir"
+mkdir -p "$bin_dir" || error "Failed to create install directory: $bin_dir"
 
 # Download the per-platform archive and extract it into the install dir. nub is a
 # single self-contained binary that embeds its runtime (preload + vendored
@@ -97,163 +109,139 @@ trap 'rm -f "$tmp_archive"' EXIT
 curl --fail --location --progress-bar --output "$tmp_archive" "$url" ||
     error "Failed to download nub from: $url"
 
-# Replace any prior bin/ for a clean upgrade (other files under $install_dir,
-# e.g. caches, are preserved). A stale runtime/ from a pre-single-binary install
-# is also removed so it can't shadow the embedded runtime. Then extract bin/.
-if test "$install_dir" = "$default_install_dir"; then
-    rm -rf "$install_dir/bin" "$install_dir/runtime"
+# Replace any prior nub artifacts for a clean upgrade. In the default ~/.nub —
+# which nub owns outright — drop the whole bin/ and a stale runtime/ from a
+# pre-single-binary install. A user-supplied NUB_INSTALL_DIR may hold unrelated
+# files, so there remove only the two executables we wrote. Then extract bin/.
+if [[ "$install_dir" == "$default_install_dir" ]]; then
+    rm -rf "${install_dir:?}/bin" "${install_dir:?}/runtime"
 else
-    rm -f "$install_dir/bin/nub" "$install_dir/bin/nubx"
+    rm -f "${bin_dir:?}/nub" "${bin_dir:?}/nubx"
 fi
 tar -xzf "$tmp_archive" -C "$install_dir" ||
     error "Failed to extract nub archive from: $url"
 
-[[ -f "$install_exe" ]] || error "Archive did not contain bin/nub"
-chmod +x "$install_exe" || error "Failed to set permissions on $install_exe"
+[[ -f "$exe" ]] || error "Archive did not contain bin/nub"
+chmod +x "$exe" || error "Failed to set permissions on $exe"
 
 # `nubx` is the same binary as `nub`, dispatched on argv[0] (cli.rs reads
 # args_os()[0].file_stem(): "nubx" -> exec). The release archive ships only
 # bin/nub, so create the nubx alias as a relative symlink alongside it. `-f`
 # makes this idempotent across reinstall/upgrade and harmless if a future
 # archive ever ships its own nubx. Relative target keeps it valid if ~/.nub moves.
-ln -sf nub "$install_bin_dir/nubx" || error "Failed to create nubx symlink in $install_bin_dir"
+ln -sf nub "$bin_dir/nubx" || error "Failed to create nubx symlink in $bin_dir"
 
-success "Installed nub v${version} (with nubx) to $install_exe"
+# Install receipt: marks this dir as a nub self-managed install so `nub upgrade`
+# recognizes it as in-place-upgradeable even when NUB_INSTALL_DIR relocated it out
+# of the default ~/.nub (cli.rs detect_channel checks for this file). Survives an
+# upgrade — the self-owned swap only touches bin/.
+cat > "$install_dir/.nub-receipt" <<'RECEIPT' || error "Failed to write install receipt to $install_dir"
+# This file marks a nub self-managed install so `nub upgrade` can update it in
+# place. Created by the nub installer; safe to delete (deleting it disables
+# in-place self-update for a non-default install location).
+RECEIPT
+
+success "Installed nub v${version} (with nubx) to $exe"
 
 # --- PATH setup ---
 
-configure_shell_path() {
-    local bin_dir=$1
-
-    local shell_name=$(basename "${SHELL:-bash}")
-
-    case "$shell_name" in
-        bash) configure_shell_path__posix "$bin_dir" "$HOME/.bashrc" "$HOME/.bash_profile";;
-        zsh) configure_shell_path__posix "$bin_dir" "$HOME/.zshrc" "$HOME/.zshenv";;
-        fish) configure_shell_path__fish "$bin_dir";;
-        *) configure_shell_path__unknown "$bin_dir";;
-    esac
-}
-configure_shell_path__posix() {
-    local bin_dir=$1
-    shift
-
-    local shell_file="$1"
-
-    for file in "$@"; do
-        if test -w "$file"; then
-            shell_file=$file
-            break
-        fi
-    done
-
-    if test -f "$shell_file" && test ! -w "$shell_file"; then
-        return
+tildify() {
+    if [[ $1 == "$HOME"/* ]]; then
+        echo "~${1#$HOME}"
+    else
+        echo "$1"
     fi
-
-    sed "s/^$(printf '%8s')//" <<END >> "$shell_file"
-
-        # nub
-        $(print_extend_path__posix "$bin_dir")
-END
-
-    RefreshCommand=". $(replace_home_path_with_var "$shell_file")"
-
-    local tilde_bin_dir=$(replace_home_path_with_tilde "$bin_dir")
-    local tilde_shell_file=$(replace_home_path_with_tilde "$shell_file")
-
-    info "Added $tilde_bin_dir to \$PATH in $tilde_shell_file"
-}
-configure_shell_path__fish() {
-    local bin_dir=$1
-
-    local shell_file=${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish
-
-    for file in "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"; do
-        if test -w "$file"; then
-            shell_file=$file
-            break
-        fi
-    done
-
-    if test -f "$shell_file" && test ! -w "$shell_file"; then
-       return
-    fi
-
-    mkdir -p "$(dirname "$shell_file")"
-
-    local bin_dir_portable=$(replace_home_path_with_var "$bin_dir")
-
-    sed "s/^$(printf '%8s')//" <<END >> "$shell_file"
-
-        # nub
-        set --global --export PATH "$bin_dir_portable" \$PATH
-END
-
-    RefreshCommand="source $(replace_home_path_with_var "$shell_file")"
-
-    local tilde_bin_dir=$(replace_home_path_with_tilde "$bin_dir")
-    local tilde_shell_file=$(replace_home_path_with_tilde "$shell_file")
-
-    info "Added $tilde_bin_dir to \$PATH in $tilde_shell_file"
-}
-configure_shell_path__unknown() {
-    local bin_dir=$1
-
-    echo 'Please add the nub bin path to your shell configuration:'
-    echo -e "  ${Bold}$(print_extend_path__posix "$bin_dir")${Color_Off}"
 }
 
-print_extend_path__posix() {
-    local dir=$1
+tilde_bin_dir=$(tildify "$bin_dir")
 
-    local dir_portable=$(replace_home_path_with_var "$dir")
+# PATH export lines reference $HOME (kept $HOME-relative when bin_dir is under home)
+# so they stay portable across machines; an out-of-home custom dir uses its absolute
+# path.
+# Both lines quote the directory so a custom NUB_INSTALL_DIR containing spaces
+# survives (fish word-splits an unquoted path). The default ~/.nub/bin has no
+# spaces, so its emitted lines are unchanged in effect.
+if [[ "$bin_dir" == "$HOME"/* ]]; then
+    posix_path_line="export PATH=\"\$HOME/${bin_dir#"$HOME"/}:\$PATH\""
+    fish_path_line="set -gx PATH \"\$HOME/${bin_dir#"$HOME"/}\" \$PATH"
+else
+    posix_path_line="export PATH=\"$bin_dir:\$PATH\""
+    fish_path_line="set -gx PATH \"$bin_dir\" \$PATH"
+fi
 
-    printf 'export PATH="%s:$PATH"' "$dir_portable"
-}
-
-replace_home_path_with_var() {
-    # We replace home path with $HOME variable reference, so path stays portable across machines.
-    local path=$1
-
-    case "$path" in
-        $HOME/*) printf '%s' "\$HOME/${path#"$HOME"/}";;
-        *) printf '%s' "$path";;
-    esac
-}
-replace_home_path_with_tilde() {
-    # We replace home path with ~ reference, so path stays portable across machines.
-    local path=$1
-
-    case "$path" in
-        $HOME/*) printf '%s' "~/${path#"$HOME"/}";;
-        *) printf '%s' "$path";;
-    esac
-}
-
-no_shell_path=$(printf '%s' "${NUB_NO_MODIFY_PATH:-0}" | tr '[:upper:]' '[:lower:]')
-
-case "$no_shell_path" in
-    0|no|false|off) ;;
-    1|yes|true|on) configure_shell_path__unknown "$install_bin_dir"; exit;;
-    *) error "Invalid NUB_NO_MODIFY_PATH: $NUB_NO_MODIFY_PATH";;
+# Honor NUB_NO_MODIFY_PATH: skip all shell-profile edits and just print the line
+# the user should add themselves (rustup/uv convention). Runs before the
+# already-in-PATH check so the opt-out is unconditional.
+case "$(printf '%s' "${NUB_NO_MODIFY_PATH:-}" | tr '[:upper:]' '[:lower:]')" in
+    ''|0|no|false|off) ;;
+    1|yes|true|on)
+        echo "Add the nub bin path to your shell profile:"
+        echo -e "  ${Bold}${posix_path_line}${Color_Off}"
+        exit 0
+        ;;
+    *) error "Invalid NUB_NO_MODIFY_PATH: ${NUB_NO_MODIFY_PATH} (expected 1/yes/true/on or 0/no/false/off)" ;;
 esac
 
-# Check if already in PATH.
-if echo "$PATH" | tr ':' '\n' | grep -qxF "$install_bin_dir"; then
+# Check if already in PATH
+if echo "$PATH" | tr ':' '\n' | grep -qx "$bin_dir"; then
     success "Already in PATH. Run: nub --version"
-    exit
+    exit 0
 fi
 
-RefreshCommand=''
+refresh_command=""
 
-configure_shell_path "$install_bin_dir"
+case $(basename "${SHELL:-bash}") in
+zsh)
+    config="$HOME/.zshrc"
+    if [[ -w "$config" ]] || [[ ! -f "$config" ]]; then
+        {
+            echo ''
+            echo '# nub'
+            echo "$posix_path_line"
+        } >> "$config"
+        info "Added ${tilde_bin_dir} to \$PATH in ~/.zshrc"
+        refresh_command="exec \$SHELL"
+    fi
+    ;;
+bash)
+    config=""
+    for f in "$HOME/.bashrc" "$HOME/.bash_profile"; do
+        if [[ -w "$f" ]]; then config="$f"; break; fi
+    done
+    if [[ -n "$config" ]]; then
+        {
+            echo ''
+            echo '# nub'
+            echo "$posix_path_line"
+        } >> "$config"
+        info "Added ${tilde_bin_dir} to \$PATH in $(tildify "$config")"
+        refresh_command="source $(tildify "$config")"
+    fi
+    ;;
+fish)
+    config="${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
+    if [[ -w "$config" ]] || [[ ! -f "$config" ]]; then
+        mkdir -p "$(dirname "$config")"
+        {
+            echo ''
+            echo '# nub'
+            echo "$fish_path_line"
+        } >> "$config"
+        info "Added ${tilde_bin_dir} to \$PATH in $(tildify "$config")"
+        refresh_command="source $(tildify "$config")"
+    fi
+    ;;
+*)
+    echo "Manually add to your shell config:"
+    echo -e "  ${Bold}${posix_path_line}${Color_Off}"
+    ;;
+esac
 
-echo ''
-info 'To get started, run:'
-echo ''
-if [[ -n "$RefreshCommand" ]]; then
-    echo -e "  ${Bold}${RefreshCommand}${Color_Off}"
+echo ""
+info "To get started, run:"
+echo ""
+if [[ -n "$refresh_command" ]]; then
+    echo -e "  ${Bold}${refresh_command}${Color_Off}"
 fi
 echo -e "  ${Bold}nub --version${Color_Off}"
-echo ''
+echo ""

--- a/install.sh
+++ b/install.sh
@@ -72,13 +72,16 @@ fi
 
 # --- Install ---
 
-install_dir="$HOME/.nub"
-bin_dir="$install_dir/bin"
-exe="$bin_dir/nub"
+default_install_dir=$(cd "$HOME" && pwd)/.nub
+install_dir=${NUB_INSTALL_DIR:-$default_install_dir}
+mkdir -p "$install_dir" || error "Failed to create install directory: $install_dir"
+install_dir=$(cd "$install_dir" && pwd) || error "Invalid NUB_INSTALL_DIR: $install_dir"
+install_bin_dir="$install_dir/bin"
+install_exe="$install_bin_dir/nub"
 
 info "Installing nub v${version} for ${target}..."
 
-mkdir -p "$bin_dir" || error "Failed to create install directory: $bin_dir"
+mkdir -p "$install_bin_dir" || error "Failed to create install directory: $install_bin_dir"
 
 # Download the per-platform archive and extract it into the install dir. nub is a
 # single self-contained binary that embeds its runtime (preload + vendored
@@ -97,98 +100,160 @@ curl --fail --location --progress-bar --output "$tmp_archive" "$url" ||
 # Replace any prior bin/ for a clean upgrade (other files under $install_dir,
 # e.g. caches, are preserved). A stale runtime/ from a pre-single-binary install
 # is also removed so it can't shadow the embedded runtime. Then extract bin/.
-rm -rf "${install_dir:?}/bin" "${install_dir:?}/runtime"
+if test "$install_dir" = "$default_install_dir"; then
+    rm -rf "$install_dir/bin" "$install_dir/runtime"
+else
+    rm -f "$install_dir/bin/nub" "$install_dir/bin/nubx"
+fi
 tar -xzf "$tmp_archive" -C "$install_dir" ||
     error "Failed to extract nub archive from: $url"
 
-[[ -f "$exe" ]] || error "Archive did not contain bin/nub"
-chmod +x "$exe" || error "Failed to set permissions on $exe"
+[[ -f "$install_exe" ]] || error "Archive did not contain bin/nub"
+chmod +x "$install_exe" || error "Failed to set permissions on $install_exe"
 
 # `nubx` is the same binary as `nub`, dispatched on argv[0] (cli.rs reads
 # args_os()[0].file_stem(): "nubx" -> exec). The release archive ships only
 # bin/nub, so create the nubx alias as a relative symlink alongside it. `-f`
 # makes this idempotent across reinstall/upgrade and harmless if a future
 # archive ever ships its own nubx. Relative target keeps it valid if ~/.nub moves.
-ln -sf nub "$bin_dir/nubx" || error "Failed to create nubx symlink in $bin_dir"
+ln -sf nub "$install_bin_dir/nubx" || error "Failed to create nubx symlink in $install_bin_dir"
 
-success "Installed nub v${version} (with nubx) to $exe"
+success "Installed nub v${version} (with nubx) to $install_exe"
 
 # --- PATH setup ---
 
-tildify() {
-    if [[ $1 == "$HOME"/* ]]; then
-        echo "~${1#$HOME}"
-    else
-        echo "$1"
+configure_shell_path() {
+    local bin_dir=$1
+
+    local shell_name=$(basename "${SHELL:-bash}")
+
+    case "$shell_name" in
+        bash) configure_shell_path__posix "$bin_dir" "$HOME/.bashrc" "$HOME/.bash_profile";;
+        zsh) configure_shell_path__posix "$bin_dir" "$HOME/.zshrc" "$HOME/.zshenv";;
+        fish) configure_shell_path__fish "$bin_dir";;
+        *) configure_shell_path__unknown "$bin_dir";;
+    esac
+}
+configure_shell_path__posix() {
+    local bin_dir=$1
+    shift
+
+    local shell_file="$1"
+
+    for file in "$@"; do
+        if test -w "$file"; then
+            shell_file=$file
+            break
+        fi
+    done
+
+    if test -f "$shell_file" && test ! -w "$shell_file"; then
+        return
     fi
+
+    sed "s/^$(printf '%8s')//" <<END >> "$shell_file"
+
+        # nub
+        $(print_extend_path__posix "$bin_dir")
+END
+
+    RefreshCommand=". $(replace_home_path_with_var "$shell_file")"
+
+    local tilde_bin_dir=$(replace_home_path_with_tilde "$bin_dir")
+    local tilde_shell_file=$(replace_home_path_with_tilde "$shell_file")
+
+    info "Added $tilde_bin_dir to \$PATH in $tilde_shell_file"
+}
+configure_shell_path__fish() {
+    local bin_dir=$1
+
+    local shell_file=${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish
+
+    for file in "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"; do
+        if test -w "$file"; then
+            shell_file=$file
+            break
+        fi
+    done
+
+    if test -f "$shell_file" && test ! -w "$shell_file"; then
+       return
+    fi
+
+    mkdir -p "$(dirname "$shell_file")"
+
+    local bin_dir_portable=$(replace_home_path_with_var "$bin_dir")
+
+    sed "s/^$(printf '%8s')//" <<END >> "$shell_file"
+
+        # nub
+        set --global --export PATH "$bin_dir_portable" \$PATH
+END
+
+    RefreshCommand="source $(replace_home_path_with_var "$shell_file")"
+
+    local tilde_bin_dir=$(replace_home_path_with_tilde "$bin_dir")
+    local tilde_shell_file=$(replace_home_path_with_tilde "$shell_file")
+
+    info "Added $tilde_bin_dir to \$PATH in $tilde_shell_file"
+}
+configure_shell_path__unknown() {
+    local bin_dir=$1
+
+    echo 'Please add the nub bin path to your shell configuration:'
+    echo -e "  ${Bold}$(print_extend_path__posix "$bin_dir")${Color_Off}"
 }
 
-tilde_bin_dir=$(tildify "$bin_dir")
+print_extend_path__posix() {
+    local dir=$1
 
-# PATH export lines reference $HOME so they stay portable across machines.
-posix_path_line='export PATH="$HOME/.nub/bin:$PATH"'
-fish_path_line='set -gx PATH $HOME/.nub/bin $PATH'
+    local dir_portable=$(replace_home_path_with_var "$dir")
 
-# Check if already in PATH
-if echo "$PATH" | tr ':' '\n' | grep -qx "$bin_dir"; then
-    success "Already in PATH. Run: nub --version"
-    exit 0
-fi
+    printf 'export PATH="%s:$PATH"' "$dir_portable"
+}
 
-refresh_command=""
+replace_home_path_with_var() {
+    # We replace home path with $HOME variable reference, so path stays portable across machines.
+    local path=$1
 
-case $(basename "${SHELL:-bash}") in
-zsh)
-    config="$HOME/.zshrc"
-    if [[ -w "$config" ]] || [[ ! -f "$config" ]]; then
-        {
-            echo ''
-            echo '# nub'
-            echo "$posix_path_line"
-        } >> "$config"
-        info "Added ${tilde_bin_dir} to \$PATH in ~/.zshrc"
-        refresh_command="exec \$SHELL"
-    fi
-    ;;
-bash)
-    config=""
-    for f in "$HOME/.bashrc" "$HOME/.bash_profile"; do
-        if [[ -w "$f" ]]; then config="$f"; break; fi
-    done
-    if [[ -n "$config" ]]; then
-        {
-            echo ''
-            echo '# nub'
-            echo "$posix_path_line"
-        } >> "$config"
-        info "Added ${tilde_bin_dir} to \$PATH in $(tildify "$config")"
-        refresh_command="source $(tildify "$config")"
-    fi
-    ;;
-fish)
-    config="${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
-    if [[ -w "$config" ]] || [[ ! -f "$config" ]]; then
-        mkdir -p "$(dirname "$config")"
-        {
-            echo ''
-            echo '# nub'
-            echo "$fish_path_line"
-        } >> "$config"
-        info "Added ${tilde_bin_dir} to \$PATH in $(tildify "$config")"
-        refresh_command="source $(tildify "$config")"
-    fi
-    ;;
-*)
-    echo "Manually add to your shell config:"
-    echo -e "  ${Bold}${posix_path_line}${Color_Off}"
-    ;;
+    case "$path" in
+        $HOME/*) printf '%s' "\$HOME/${path#"$HOME"/}";;
+        *) printf '%s' "$path";;
+    esac
+}
+replace_home_path_with_tilde() {
+    # We replace home path with ~ reference, so path stays portable across machines.
+    local path=$1
+
+    case "$path" in
+        $HOME/*) printf '%s' "~/${path#"$HOME"/}";;
+        *) printf '%s' "$path";;
+    esac
+}
+
+no_shell_path=$(printf '%s' "${NUB_NO_MODIFY_PATH:-0}" | tr '[:upper:]' '[:lower:]')
+
+case "$no_shell_path" in
+    0|no|false|off) ;;
+    1|yes|true|on) configure_shell_path__unknown "$install_bin_dir"; exit;;
+    *) error "Invalid NUB_NO_MODIFY_PATH: $NUB_NO_MODIFY_PATH";;
 esac
 
-echo ""
-info "To get started, run:"
-echo ""
-if [[ -n "$refresh_command" ]]; then
-    echo -e "  ${Bold}${refresh_command}${Color_Off}"
+# Check if already in PATH.
+if echo "$PATH" | tr ':' '\n' | grep -qxF "$install_bin_dir"; then
+    success "Already in PATH. Run: nub --version"
+    exit
+fi
+
+RefreshCommand=''
+
+configure_shell_path "$install_bin_dir"
+
+echo ''
+info 'To get started, run:'
+echo ''
+if [[ -n "$RefreshCommand" ]]; then
+    echo -e "  ${Bold}${RefreshCommand}${Color_Off}"
 fi
 echo -e "  ${Bold}nub --version${Color_Off}"
-echo ""
+echo ''

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -374,6 +374,19 @@ Same as installing — match how you installed: `brew update && brew upgrade nub
 
 Yes. On macOS and Linux, `curl -fsSL https://nubjs.com/install.sh | bash`; on Windows, `powershell -c "irm https://nubjs.com/install.ps1 | iex"`. Both drop a native binary into `~/.nub` and put it on your `PATH`. If you'd rather go through your package manager, `npm install -g --ignore-scripts=false @nubjs/nub` (or `pnpm add -g` / `yarn global add`) does the same thing, and on macOS and Linux `brew install nubjs/tap/nub` works too.
 
+Two environment variables customize the script, following the same convention as rustup and uv:
+
+- `NUB_INSTALL_DIR` — install somewhere other than `~/.nub`. `nub upgrade` still updates it in place.
+- `NUB_NO_MODIFY_PATH` — set it truthy (`1`/`yes`/`true`/`on`) to skip the shell-profile edit; the script prints the `PATH` line for you to add yourself.
+
+Set them on the shell that runs the script — the right side of the pipe, not on `curl`:
+
+```bash
+curl -fsSL https://nubjs.com/install.sh | NUB_INSTALL_DIR="$HOME/.local/nub" NUB_NO_MODIFY_PATH=1 bash
+```
+
+On Windows, set `$env:NUB_INSTALL_DIR` / `$env:NUB_NO_MODIFY_PATH` before the `irm | iex`.
+
 ## Does it have a dev server?
 
 No. Vite already owns this; `nub run dev` runs whatever your project's `dev` script is — faster, because the `nub run` wrapper costs less than the `pnpm run` wrapper, but the dev server itself is still Vite (or Next.js, or whatever you're running).

--- a/site/public/install.ps1
+++ b/site/public/install.ps1
@@ -1,6 +1,10 @@
 #!/usr/bin/env pwsh
 # Nub installer for Windows (PowerShell)
 # Usage: irm https://raw.githubusercontent.com/nubjs/nub/main/install.ps1 | iex
+#
+# Customization (env vars):
+#   NUB_INSTALL_DIR      install location, absolute path (default: %USERPROFILE%\.nub)
+#   NUB_NO_MODIFY_PATH   truthy (1/yes/true/on) to skip editing the User PATH
 
 $ErrorActionPreference = "Stop"
 
@@ -27,11 +31,15 @@ if ($Version -eq "latest") {
 Write-Host "Installing nub v$Version for $Target..." -ForegroundColor Cyan
 
 # --- Install ---
-$InstallDir = "$env:USERPROFILE\.nub"
+# The install location is overridable via NUB_INSTALL_DIR (default %USERPROFILE%\.nub).
+# Both the resolved dir and the default are normalized to full paths so the
+# "is this the default location?" test below is an exact comparison.
+$DefaultInstallDir = [System.IO.Path]::GetFullPath("$env:USERPROFILE\.nub")
+$InstallDir = if ($env:NUB_INSTALL_DIR) { $env:NUB_INSTALL_DIR } else { $DefaultInstallDir }
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+$InstallDir = (Resolve-Path -LiteralPath $InstallDir).Path
 $BinDir = "$InstallDir\bin"
 $Exe = "$BinDir\nub.exe"
-
-New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
 # Download the per-platform archive and extract it into the install dir. nub is a
 # single self-contained binary that embeds its runtime (preload + vendored
@@ -48,10 +56,16 @@ $prevProgressPreference = $ProgressPreference
 try {
     $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
-    # Replace any prior bin\ for a clean upgrade. A stale runtime\ from a
-    # pre-single-binary install is also removed for hygiene, then extract bin\.
-    if (Test-Path $BinDir) { Remove-Item -Recurse -Force $BinDir }
-    if (Test-Path "$InstallDir\runtime") { Remove-Item -Recurse -Force "$InstallDir\runtime" }
+    # Replace any prior nub artifacts for a clean upgrade. In the default ~\.nub —
+    # which nub owns outright — drop the whole bin\ and a stale runtime\ from a
+    # pre-single-binary install. A user-supplied NUB_INSTALL_DIR may hold unrelated
+    # files, so there remove only the two executables we wrote. Then extract bin\.
+    if ($InstallDir -ieq $DefaultInstallDir) {
+        if (Test-Path $BinDir) { Remove-Item -Recurse -Force $BinDir }
+        if (Test-Path "$InstallDir\runtime") { Remove-Item -Recurse -Force "$InstallDir\runtime" }
+    } else {
+        Remove-Item -Force -ErrorAction SilentlyContinue -LiteralPath "$BinDir\nub.exe", "$BinDir\nubx.exe"
+    }
     Expand-Archive -Path $TmpZip -DestinationPath $InstallDir -Force
 } catch {
     Write-Error "Failed to download/extract nub: $_"
@@ -74,11 +88,35 @@ if (-not (Test-Path $Exe)) {
 $Exex = "$BinDir\nubx.exe"
 Copy-Item -Path $Exe -Destination $Exex -Force
 
+# Install receipt: marks this dir as a nub self-managed install so `nub upgrade`
+# recognizes it as in-place-upgradeable even when NUB_INSTALL_DIR relocated it out
+# of the default ~\.nub (cli.rs detect_channel checks for this file).
+$Receipt = @'
+# This file marks a nub self-managed install so `nub upgrade` can update it in
+# place. Created by the nub installer; safe to delete (deleting it disables
+# in-place self-update for a non-default install location).
+'@
+Set-Content -LiteralPath "$InstallDir\.nub-receipt" -Value $Receipt
+
 Write-Host "Installed nub (with nubx) to $Exe" -ForegroundColor Green
 
 # --- PATH setup ---
+# Honor NUB_NO_MODIFY_PATH: skip the User PATH edit and just print the dir to add
+# (rustup/uv convention).
+$NoModifyPath = "$env:NUB_NO_MODIFY_PATH".ToLowerInvariant()
+if ($NoModifyPath -in @("1", "yes", "true", "on")) {
+    Write-Host "Add the nub bin path to your PATH:"
+    Write-Host "  $BinDir" -ForegroundColor White
+    exit 0
+} elseif ($NoModifyPath -notin @("", "0", "no", "false", "off")) {
+    Write-Error "Invalid NUB_NO_MODIFY_PATH: $env:NUB_NO_MODIFY_PATH (expected 1/yes/true/on or 0/no/false/off)"
+    exit 1
+}
+
 $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-if ($UserPath -notlike "*$BinDir*") {
+# Compare against the exact segments rather than a substring match: a custom
+# NUB_INSTALL_DIR could be a substring of an unrelated existing entry.
+if (($UserPath -split ';') -notcontains $BinDir) {
     [Environment]::SetEnvironmentVariable("Path", "$BinDir;$UserPath", "User")
     $env:Path = "$BinDir;$env:Path"
     Write-Host "Added $BinDir to PATH" -ForegroundColor Green

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 # Nub installer — downloads the latest release binary from GitHub.
 # Usage: curl -fsSL https://raw.githubusercontent.com/nubjs/nub/main/install.sh | bash
+#
+# Customization (env vars):
+#   NUB_INSTALL_DIR      install location, absolute path (default: ~/.nub)
+#   NUB_NO_MODIFY_PATH   truthy (1/yes/true/on) to skip editing your shell profile
 
 # Windows: delegate to PowerShell
 if [[ ${OS:-} = Windows_NT ]]; then
@@ -72,7 +76,18 @@ fi
 
 # --- Install ---
 
-install_dir="$HOME/.nub"
+# The install location is overridable via NUB_INSTALL_DIR (default ~/.nub). A
+# custom dir is normalized to an absolute path so the PATH line, the receipt, and
+# the "is this the default location?" test below are all exact. The default keeps
+# the literal "$HOME/.nub" spelling so the emitted PATH line stays $HOME-portable.
+default_install_dir="$HOME/.nub"
+if [[ -n "${NUB_INSTALL_DIR:-}" ]]; then
+    install_dir="$NUB_INSTALL_DIR"
+    mkdir -p "$install_dir" || error "Failed to create install directory: $install_dir"
+    install_dir=$(cd "$install_dir" && pwd) || error "Invalid NUB_INSTALL_DIR: $NUB_INSTALL_DIR"
+else
+    install_dir="$default_install_dir"
+fi
 bin_dir="$install_dir/bin"
 exe="$bin_dir/nub"
 
@@ -94,10 +109,15 @@ trap 'rm -f "$tmp_archive"' EXIT
 curl --fail --location --progress-bar --output "$tmp_archive" "$url" ||
     error "Failed to download nub from: $url"
 
-# Replace any prior bin/ for a clean upgrade (other files under $install_dir,
-# e.g. caches, are preserved). A stale runtime/ from a pre-single-binary install
-# is also removed so it can't shadow the embedded runtime. Then extract bin/.
-rm -rf "${install_dir:?}/bin" "${install_dir:?}/runtime"
+# Replace any prior nub artifacts for a clean upgrade. In the default ~/.nub —
+# which nub owns outright — drop the whole bin/ and a stale runtime/ from a
+# pre-single-binary install. A user-supplied NUB_INSTALL_DIR may hold unrelated
+# files, so there remove only the two executables we wrote. Then extract bin/.
+if [[ "$install_dir" == "$default_install_dir" ]]; then
+    rm -rf "${install_dir:?}/bin" "${install_dir:?}/runtime"
+else
+    rm -f "${bin_dir:?}/nub" "${bin_dir:?}/nubx"
+fi
 tar -xzf "$tmp_archive" -C "$install_dir" ||
     error "Failed to extract nub archive from: $url"
 
@@ -110,6 +130,16 @@ chmod +x "$exe" || error "Failed to set permissions on $exe"
 # makes this idempotent across reinstall/upgrade and harmless if a future
 # archive ever ships its own nubx. Relative target keeps it valid if ~/.nub moves.
 ln -sf nub "$bin_dir/nubx" || error "Failed to create nubx symlink in $bin_dir"
+
+# Install receipt: marks this dir as a nub self-managed install so `nub upgrade`
+# recognizes it as in-place-upgradeable even when NUB_INSTALL_DIR relocated it out
+# of the default ~/.nub (cli.rs detect_channel checks for this file). Survives an
+# upgrade — the self-owned swap only touches bin/.
+cat > "$install_dir/.nub-receipt" <<'RECEIPT' || error "Failed to write install receipt to $install_dir"
+# This file marks a nub self-managed install so `nub upgrade` can update it in
+# place. Created by the nub installer; safe to delete (deleting it disables
+# in-place self-update for a non-default install location).
+RECEIPT
 
 success "Installed nub v${version} (with nubx) to $exe"
 
@@ -125,9 +155,32 @@ tildify() {
 
 tilde_bin_dir=$(tildify "$bin_dir")
 
-# PATH export lines reference $HOME so they stay portable across machines.
-posix_path_line='export PATH="$HOME/.nub/bin:$PATH"'
-fish_path_line='set -gx PATH $HOME/.nub/bin $PATH'
+# PATH export lines reference $HOME (kept $HOME-relative when bin_dir is under home)
+# so they stay portable across machines; an out-of-home custom dir uses its absolute
+# path.
+# Both lines quote the directory so a custom NUB_INSTALL_DIR containing spaces
+# survives (fish word-splits an unquoted path). The default ~/.nub/bin has no
+# spaces, so its emitted lines are unchanged in effect.
+if [[ "$bin_dir" == "$HOME"/* ]]; then
+    posix_path_line="export PATH=\"\$HOME/${bin_dir#"$HOME"/}:\$PATH\""
+    fish_path_line="set -gx PATH \"\$HOME/${bin_dir#"$HOME"/}\" \$PATH"
+else
+    posix_path_line="export PATH=\"$bin_dir:\$PATH\""
+    fish_path_line="set -gx PATH \"$bin_dir\" \$PATH"
+fi
+
+# Honor NUB_NO_MODIFY_PATH: skip all shell-profile edits and just print the line
+# the user should add themselves (rustup/uv convention). Runs before the
+# already-in-PATH check so the opt-out is unconditional.
+case "$(printf '%s' "${NUB_NO_MODIFY_PATH:-}" | tr '[:upper:]' '[:lower:]')" in
+    ''|0|no|false|off) ;;
+    1|yes|true|on)
+        echo "Add the nub bin path to your shell profile:"
+        echo -e "  ${Bold}${posix_path_line}${Color_Off}"
+        exit 0
+        ;;
+    *) error "Invalid NUB_NO_MODIFY_PATH: ${NUB_NO_MODIFY_PATH} (expected 1/yes/true/on or 0/no/false/off)" ;;
+esac
 
 # Check if already in PATH
 if echo "$PATH" | tr ':' '\n' | grep -qx "$bin_dir"; then

--- a/tests/installer/run.sh
+++ b/tests/installer/run.sh
@@ -3,6 +3,15 @@
 set -e # errexit
 set -u # nounset
 
+# Local end-to-end harness for install.sh. Each case runs the REAL installer
+# against a throwaway HOME/NUB_INSTALL_DIR sandbox (so it downloads the actual
+# latest release from GitHub — network required) and asserts the resulting on-disk
+# state: the binaries, the `.nub-receipt` marker, and the shell-profile edits for
+# each shell + the NUB_INSTALL_DIR / NUB_NO_MODIFY_PATH knobs. Cross-OS coverage of
+# the same paths runs in CI via .github/workflows/verify-install.yml.
+#
+# Usage: tests/installer/run.sh   (set TEST_CLEAN=0 to keep the sandbox for debugging)
+
 # Required on MacOS due to a Bash 3.2.57 bug.
 case "$(dirname "$0")" in
     /*|./*) Dir=$(cd "$(dirname "$0")" && pwd);;
@@ -69,7 +78,9 @@ mksandboxdir() {
 
     mkdir -p "$dir"
 
-    printf '%s' "$dir"
+    # Emit the normalized (symlink-resolved) path so callers compare against the
+    # exact string install.sh derives via `cd … && pwd` (macOS' /var → /private/var).
+    (cd "$dir" && pwd)
 }
 test_begin() {
     describe "$@"
@@ -84,6 +95,8 @@ test_end() {
     fi
 }
 
+# Runs the installer (inheriting the caller's env) and asserts the install
+# artifacts landed in $1: both binaries and the self-managed-install receipt.
 test_install() {
     local dir=$1
 
@@ -96,6 +109,8 @@ test_install() {
         || throw 'file does not exist' "$dir/bin/nub"
     test -f "$dir/bin/nubx" \
         || throw 'file does not exist' "$dir/bin/nubx"
+    test -f "$dir/.nub-receipt" \
+        || throw 'install receipt not written' "$dir/.nub-receipt"
 }
 
 test_begin 'install for Bash shell'
@@ -104,6 +119,9 @@ test_begin 'install for Bash shell'
     export SHELL=/bin/bash
     export HOME=$(mksandboxdir)
 
+    # bash appends only to an EXISTING writable rc (unchanged from the shipped
+    # script; the zsh/fish branches create theirs). A real bash user has one.
+    touch "$HOME/.bashrc"
     test_install "$HOME/.nub"
 
     grep -q -F '# nub' "$HOME/.bashrc" \
@@ -139,12 +157,12 @@ test_begin 'install for Fish shell'
 
     grep -q -F '# nub' "$HOME/.config/fish/config.fish" \
         || throw 'shell configuration not found [1]' "$HOME/.config/fish/config.fish"
-    grep -q -F 'set --global --export PATH "$HOME/.nub/bin" $PATH' "$HOME/.config/fish/config.fish" \
+    grep -q -F 'set -gx PATH "$HOME/.nub/bin" $PATH' "$HOME/.config/fish/config.fish" \
         || throw 'shell configuration not found [2]' "$HOME/.config/fish/config.fish"
 )
 test_end $?
 
-test_begin 'install for Dash shell'
+test_begin 'install for Dash shell (unknown shell prints the manual line)'
 (
     set -e
     export SHELL=/bin/dash
@@ -157,7 +175,7 @@ test_begin 'install for Dash shell'
 )
 test_end $?
 
-test_begin 'install without creating shell configuration'
+test_begin 'install with NUB_NO_MODIFY_PATH does not create a shell profile'
 (
     set -e
     export SHELL=/bin/bash
@@ -171,7 +189,7 @@ test_begin 'install without creating shell configuration'
 )
 test_end $?
 
-test_begin 'install without changing shell configuration'
+test_begin 'install with NUB_NO_MODIFY_PATH does not alter an existing shell profile'
 (
     set -e
     export SHELL=/bin/bash
@@ -186,19 +204,38 @@ test_begin 'install without changing shell configuration'
 )
 test_end $?
 
-test_begin 'install for Bash with custom installation dir'
+test_begin 'install with NUB_INSTALL_DIR relocates the install and PATH line'
 (
     set -e
     export SHELL=/bin/bash
     export HOME=$(mksandboxdir home)
     export NUB_INSTALL_DIR=$(mksandboxdir install)
 
+    touch "$HOME/.bashrc"
     test_install "$NUB_INSTALL_DIR"
 
     grep -q -F '# nub' "$HOME/.bashrc" \
         || throw 'shell configuration not found [1]' "$HOME/.bashrc"
+    # An out-of-home custom dir is emitted as its absolute (normalized) path.
     grep -q -F "export PATH=\"$NUB_INSTALL_DIR/bin:\$PATH\"" "$HOME/.bashrc" \
         || throw 'shell configuration not found [2]' "$HOME/.bashrc"
+)
+test_end $?
+
+test_begin 'install for Fish with a custom dir containing a space (quoted PATH line)'
+(
+    set -e
+    export SHELL=/bin/fish
+    export HOME=$(mksandboxdir home)
+    unset XDG_CONFIG_HOME
+    export NUB_INSTALL_DIR="$(mksandboxdir 'my tools')/nub"
+
+    test_install "$NUB_INSTALL_DIR"
+
+    conf="$HOME/.config/fish/config.fish"
+    # The dir must be quoted or fish word-splits the space into two PATH entries.
+    grep -q -F "set -gx PATH \"$NUB_INSTALL_DIR/bin\" \$PATH" "$conf" \
+        || throw 'fish PATH line not quoted for a spaced dir' "$conf"
 )
 test_end $?
 

--- a/tests/installer/run.sh
+++ b/tests/installer/run.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+set -e # errexit
+set -u # nounset
+
+# Required on MacOS due to a Bash 3.2.57 bug.
+case "$(dirname "$0")" in
+    /*|./*) Dir=$(cd "$(dirname "$0")" && pwd);;
+    *) Dir=$(cd "$PWD/$(dirname "$0")" && pwd);;
+esac
+
+ResetStyle=
+BoldStyle=
+ColorBlue=
+ColorGray=
+ColorGreen=
+ColorRed=
+if \
+    test -t 1 \
+    && ! test -p /dev/stdout \
+    && test -z "${NO_COLOR:-}" \
+    || test "${FORCE_COLOR:-0}" = 1 \
+; then
+    ResetStyle='\033[0m'
+    BoldStyle='\033[1m'
+    ColorBlue='\033[36m'
+    ColorGray='\033[30m'
+    ColorGreen='\033[32m'
+    ColorRed='\033[31m'
+fi
+
+test_idx=0
+test_success_idx=0
+test_failure_idx=0
+test_sandbox_dir=$(mktemp -d)
+
+clean() {
+    if test ${TEST_CLEAN:-1} -eq 0; then
+        return
+    fi
+    if test -d "$test_sandbox_dir"; then
+        rm -rf "$test_sandbox_dir"
+    fi
+}
+
+trap clean EXIT
+
+describe() {
+    test_idx=$(expr $test_idx + 1)
+    echo
+    printf "${ResetStyle}${BoldStyle}${ColorBlue}[test]${ResetStyle} ${ColorBlue}%s${ResetStyle}\n" "$*"
+}
+throw() {
+    printf "${ResetStyle}${BoldStyle}${ColorRed}[error]${ResetStyle} ${ColorRed}%s${ResetStyle}\n" "$*"
+    exit 1
+}
+success() {
+    test_success_idx=$(expr $test_success_idx + 1)
+    printf "${ResetStyle}${BoldStyle}${ColorGreen}[done]${ResetStyle}\n"
+    echo
+}
+failure() {
+    test_failure_idx=$(expr $test_failure_idx + 1)
+    printf "${ResetStyle}${BoldStyle}${ColorRed}[failed]${ResetStyle}\n"
+    echo
+}
+mksandboxdir() {
+    local dir="$test_sandbox_dir/$test_idx${1:+/$1}"
+
+    mkdir -p "$dir"
+
+    printf '%s' "$dir"
+}
+test_begin() {
+    describe "$@"
+    set +e
+}
+test_end() {
+    set -e
+    if test $1 -eq 0; then
+        success
+    else
+        failure
+    fi
+}
+
+test_install() {
+    local dir=$1
+
+    "$Dir/../../install.sh" \
+        || throw 'installation failed' "$dir"
+
+    test -d "$dir" \
+        || throw 'directory does not exist' "$dir"
+    test -f "$dir/bin/nub" \
+        || throw 'file does not exist' "$dir/bin/nub"
+    test -f "$dir/bin/nubx" \
+        || throw 'file does not exist' "$dir/bin/nubx"
+}
+
+test_begin 'install for Bash shell'
+(
+    set -e
+    export SHELL=/bin/bash
+    export HOME=$(mksandboxdir)
+
+    test_install "$HOME/.nub"
+
+    grep -q -F '# nub' "$HOME/.bashrc" \
+        || throw 'shell configuration not found [1]' "$HOME/.bashrc"
+    grep -q -F 'export PATH="$HOME/.nub/bin:$PATH"' "$HOME/.bashrc" \
+        || throw 'shell configuration not found [2]' "$HOME/.bashrc"
+)
+test_end $?
+
+test_begin 'install for ZSH shell'
+(
+    set -e
+    export SHELL=/bin/zsh
+    export HOME=$(mksandboxdir)
+
+    test_install "$HOME/.nub"
+
+    grep -q -F '# nub' "$HOME/.zshrc" \
+        || throw 'shell configuration not found [1]' "$HOME/.zshrc"
+    grep -q -F 'export PATH="$HOME/.nub/bin:$PATH"' "$HOME/.zshrc" \
+        || throw 'shell configuration not found [2]' "$HOME/.zshrc"
+)
+test_end $?
+
+test_begin 'install for Fish shell'
+(
+    set -e
+    export SHELL=/bin/fish
+    export HOME=$(mksandboxdir)
+    unset XDG_CONFIG_HOME
+
+    test_install "$HOME/.nub"
+
+    grep -q -F '# nub' "$HOME/.config/fish/config.fish" \
+        || throw 'shell configuration not found [1]' "$HOME/.config/fish/config.fish"
+    grep -q -F 'set --global --export PATH "$HOME/.nub/bin" $PATH' "$HOME/.config/fish/config.fish" \
+        || throw 'shell configuration not found [2]' "$HOME/.config/fish/config.fish"
+)
+test_end $?
+
+test_begin 'install for Dash shell'
+(
+    set -e
+    export SHELL=/bin/dash
+    export HOME=$(mksandboxdir)
+
+    output=$(test_install "$HOME/.nub")
+
+    { printf '%s' "$output" | grep -q -F 'export PATH="$HOME/.nub/bin:$PATH"'; } \
+        || throw 'shell configuration not emitted in output [1]' "$output"
+)
+test_end $?
+
+test_begin 'install without creating shell configuration'
+(
+    set -e
+    export SHELL=/bin/bash
+    export HOME=$(mksandboxdir)
+    export NUB_NO_MODIFY_PATH=1
+
+    test_install "$HOME/.nub"
+
+    ! test -f "$HOME/.bashrc" \
+        || throw 'shell configuration file created' "$HOME/.bashrc"
+)
+test_end $?
+
+test_begin 'install without changing shell configuration'
+(
+    set -e
+    export SHELL=/bin/bash
+    export HOME=$(mksandboxdir)
+    export NUB_NO_MODIFY_PATH=true
+
+    touch "$HOME/.bashrc"
+    test_install "$HOME/.nub"
+
+    ! grep -q -F '# nub' "$HOME/.bashrc" \
+        || throw 'shell configuration altered [1]' "$HOME/.bashrc"
+)
+test_end $?
+
+test_begin 'install for Bash with custom installation dir'
+(
+    set -e
+    export SHELL=/bin/bash
+    export HOME=$(mksandboxdir home)
+    export NUB_INSTALL_DIR=$(mksandboxdir install)
+
+    test_install "$NUB_INSTALL_DIR"
+
+    grep -q -F '# nub' "$HOME/.bashrc" \
+        || throw 'shell configuration not found [1]' "$HOME/.bashrc"
+    grep -q -F "export PATH=\"$NUB_INSTALL_DIR/bin:\$PATH\"" "$HOME/.bashrc" \
+        || throw 'shell configuration not found [2]' "$HOME/.bashrc"
+)
+test_end $?
+
+echo
+if test $test_failure_idx -eq 0; then
+    printf "${ColorGray}%3s failed${ResetStyle}\n" $test_failure_idx
+    printf "${ColorGreen}%3s succeeded${ResetStyle}\n" $test_success_idx
+    printf "${BoldStyle}${ColorGreen}TESTS SUCCEEDED${ResetStyle}\n"
+else
+    printf "${ColorRed}%3s failed${ResetStyle}\n" $test_failure_idx
+    printf "${ColorGray}%3s succeeded${ResetStyle}\n" $test_success_idx
+    printf "${BoldStyle}${ColorRed}TESTS FAILED${ResetStyle}\n"
+fi
+
+exit $test_failure_idx


### PR DESCRIPTION
Initial implementation of https://github.com/nubjs/nub/issues/418

I tested changes against:
- Bash
- ZSH
- Fish
- Dash
- on MacOS 26
- on Debian Linux 13

I implemented the test `tests/installer/run.sh` checking old installer behavior and new installer behavior.

I need steering on these points:
- [x] update the Rust code, if needed (take in mind I don't know the Rust language)
- [x] update the documentation, if needed
- [x] update the CI, if needed

Authored by me:
- `install.sh`
- `tests/installer/run.sh`

Authored by Claude:
- `install.ps1`

---

Maintainer follow-up commit: reworked the two knobs (`NUB_INSTALL_DIR`, `NUB_NO_MODIFY_PATH`) as a minimal diff over the existing script so the default install path is unchanged, added the `.nub-receipt` marker + `detect_channel` support so a relocated install stays in-place-upgradeable via `nub upgrade`, synced the `site/public/` copies, documented both knobs in the FAQ, and added a CI harness job. The steering points above are addressed.

Closes #418
