### PR TITLE
sandbox(net): per-session egress-proxy token + NODE_USE_ENV_PROXY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,6 +2764,8 @@ dependencies = [
 name = "nub-sandbox"
 version = "0.4.5"
 dependencies = [
+ "base64",
+ "getrandom 0.2.17",
  "globset",
  "ipnet",
  "landlock",

--- a/crates/nub-sandbox/Cargo.toml
+++ b/crates/nub-sandbox/Cargo.toml
@@ -31,6 +31,13 @@ globset = "0.4"
 regex = "1"
 ipnet = { version = "2", features = ["serde"] }
 
+# Per-session egress-proxy token: getrandom mints the 256-bit bearer (OS CSPRNG, no
+# userspace-seeded PRNG); base64 decodes the client's HTTP `Proxy-Authorization: Basic`
+# credential + SOCKS5 user/pass. Both already in the workspace lockfile (getrandom via
+# ring/rand; base64 via rustls-pemfile) — no new supply-chain surface.
+getrandom = "0.2"
+base64 = "0.22"
+
 # TLS termination for the MITM credential-brokering tier (proxy/mitm.rs, proxy/ca.rs).
 # Engaged ONLY when a net rule uses a capability that cannot be enforced without
 # reading inside the TLS stream (a credential-inject rule); host-only policies never
@@ -85,6 +92,8 @@ features = [
 
 [dev-dependencies]
 tempfile = "3"
+# Proxy integration tests build the client-side `Proxy-Authorization: Basic` credential.
+base64 = "0.22"
 
 # The Windows enforcement probe is BOTH the runner and the AppContainer child, so it
 # needs a little FFI (token-query + process-liveness) beyond what the lib exposes.

--- a/crates/nub-sandbox/src/backend/linux.rs
+++ b/crates/nub-sandbox/src/backend/linux.rs
@@ -108,11 +108,12 @@ pub fn apply(
     policy: &SandboxPolicy,
     spec: CommandSpec,
     proxy_port: Option<u16>,
+    proxy_token: Option<&str>,
     ca_bundle: Option<&std::path::Path>,
 ) -> Result<Prepared, Degradation> {
     let mut command = base_command(&spec, policy);
     if let Some(port) = proxy_port {
-        super::set_proxy_env(&mut command, port);
+        super::set_proxy_env(&mut command, port, proxy_token);
     }
     // CA trust for the child (the Landlock read grant is added to the fs ruleset below).
     if let Some(bundle) = ca_bundle {

--- a/crates/nub-sandbox/src/backend/macos.rs
+++ b/crates/nub-sandbox/src/backend/macos.rs
@@ -73,6 +73,7 @@ pub fn apply(
     policy: &SandboxPolicy,
     spec: CommandSpec,
     proxy_port: Option<u16>,
+    proxy_token: Option<&str>,
     ca_bundle: Option<&std::path::Path>,
 ) -> Result<Prepared, Degradation> {
     if !needs_wrap(policy) {
@@ -108,7 +109,7 @@ pub fn apply(
     // Point the child at the loopback proxy (cooperative hint; the Seatbelt carve is
     // the real boundary). Set AFTER env_clear so it survives an enforced env scrub.
     if let Some(port) = proxy_port {
-        super::set_proxy_env(&mut wrapped, port);
+        super::set_proxy_env(&mut wrapped, port, proxy_token);
     }
     // CA trust for the child (the leaf-verifying bundle). The read grant lives in the
     // SBPL profile (see build_profile); this is the env half so tools find the bundle.

--- a/crates/nub-sandbox/src/backend/mod.rs
+++ b/crates/nub-sandbox/src/backend/mod.rs
@@ -251,8 +251,24 @@ fn emit_mitm_notice(policy: &SandboxPolicy) {
 /// through the loopback proxy. NOT the boundary (a malicious client ignores it — the
 /// OS deny-layer forces the traffic through); numeric host so the child needs no name
 /// resolution. Both upper/lower case (tools split on which they read).
-fn set_proxy_env(command: &mut Command, port: u16) {
-    let url = format!("http://127.0.0.1:{port}");
+///
+/// The per-session `token` is embedded as the URL userinfo (`http://<token>@127.0.0.1:
+/// <port>`), so proxy-honoring clients send it as `Proxy-Authorization: Basic` (SOCKS
+/// clients as RFC-1929 user-pass) automatically — the proxy rejects any handshake that
+/// lacks it, closing the tokenless-egress-borrow. The token is the CHILD's own (it is
+/// meant to have it); the point is that OTHER same-user processes do not. A `None` token
+/// (defensive — should not occur when a proxy is running) yields a credential-less URL
+/// the proxy will reject, i.e. fail-safe over-confinement, never a bypass.
+///
+/// `NODE_USE_ENV_PROXY=1` makes Node 24+ global `fetch` (undici) honor these proxy env
+/// vars — without it a bare `fetch()` tries a direct connect the deny-layer blocks
+/// (fail-closed but broken), instead of routing through the loopback proxy. Harmless
+/// (ignored) on older Node. Internal nub-set plumbing var — brand-clean.
+fn set_proxy_env(command: &mut Command, port: u16, token: Option<&str>) {
+    let url = match token {
+        Some(t) => format!("http://{t}@127.0.0.1:{port}"),
+        None => format!("http://127.0.0.1:{port}"),
+    };
     for key in [
         "HTTP_PROXY",
         "HTTPS_PROXY",
@@ -262,6 +278,7 @@ fn set_proxy_env(command: &mut Command, port: u16) {
     ] {
         command.env(key, &url);
     }
+    command.env("NODE_USE_ENV_PROXY", "1");
 }
 
 /// Apply a resolved policy to a command, dispatching to the per-OS backend.
@@ -284,19 +301,23 @@ pub fn apply(policy: &SandboxPolicy, spec: CommandSpec) -> Result<Prepared, Degr
     // so it outlives the child (design.md §2.5).
     let proxy = start_proxy_if_needed(policy);
     let proxy_port = proxy.as_ref().map(EgressProxy::port);
+    // The per-session egress-proxy token, delivered to the child via the proxy URL. Same
+    // presence as `proxy_port` (both derive from `proxy`), threaded into each backend so
+    // the child authenticates to the loopback proxy.
+    let proxy_token = proxy.as_ref().map(EgressProxy::token);
     // The child CA-bundle path, when TLS termination engaged. Threaded into each backend
     // so the child both TRUSTS the minted leaves (CA-env) and can READ the bundle even
     // under a confining fs policy (an explicit read grant — nub infra, not user config).
     let ca_bundle = proxy.as_ref().and_then(|p| p.ca_bundle_path());
 
     #[cfg(target_os = "macos")]
-    let mut prepared = macos::apply(policy, spec, proxy_port, ca_bundle)?;
+    let mut prepared = macos::apply(policy, spec, proxy_port, proxy_token, ca_bundle)?;
     #[cfg(target_os = "linux")]
-    let mut prepared = linux::apply(policy, spec, proxy_port, ca_bundle)?;
+    let mut prepared = linux::apply(policy, spec, proxy_port, proxy_token, ca_bundle)?;
     #[cfg(target_os = "windows")]
-    let mut prepared = windows::apply(policy, spec, proxy_port, ca_bundle)?;
+    let mut prepared = windows::apply(policy, spec, proxy_port, proxy_token, ca_bundle)?;
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    let mut prepared = generic_apply(policy, spec, proxy_port, ca_bundle)?;
+    let mut prepared = generic_apply(policy, spec, proxy_port, proxy_token, ca_bundle)?;
 
     // One-line stderr notice when TLS termination ACTUALLY engages — never silent, but
     // never MISLEADING either: suppress it where the backend degraded net (e.g. Windows,
@@ -323,6 +344,7 @@ fn generic_apply(
     policy: &SandboxPolicy,
     spec: CommandSpec,
     proxy_port: Option<u16>,
+    proxy_token: Option<&str>,
     ca_bundle: Option<&std::path::Path>,
 ) -> Result<Prepared, Degradation> {
     let mut command = Command::new(&spec.program);
@@ -339,7 +361,7 @@ fn generic_apply(
         }
     }
     if let Some(port) = proxy_port {
-        set_proxy_env(&mut command, port);
+        set_proxy_env(&mut command, port, proxy_token);
     }
     if let Some(bundle) = ca_bundle {
         set_ca_env(&mut command, bundle);
@@ -376,4 +398,53 @@ fn generic_apply(
 fn fs_confines(policy: &SandboxPolicy) -> bool {
     !matches!(policy.fs.rules.default_effect, crate::policy::Effect::Allow)
         || !policy.fs.rules.entries.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The proxy env embeds the per-session token as the URL userinfo (so proxy-honoring
+    /// clients authenticate automatically) and sets `NODE_USE_ENV_PROXY=1` so Node 24+
+    /// global `fetch` routes through the loopback proxy rather than a direct-connect the
+    /// deny-layer blocks.
+    #[test]
+    fn set_proxy_env_embeds_token_and_enables_node_env_proxy() {
+        let mut cmd = Command::new("true");
+        set_proxy_env(&mut cmd, 4321, Some("abc123"));
+        let envs: std::collections::HashMap<_, _> = cmd
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect();
+        assert_eq!(
+            envs.get("HTTP_PROXY").and_then(|v| v.as_deref()),
+            Some("http://abc123@127.0.0.1:4321"),
+            "the token must be the URL userinfo"
+        );
+        assert_eq!(
+            envs.get("NODE_USE_ENV_PROXY").and_then(|v| v.as_deref()),
+            Some("1"),
+            "NODE_USE_ENV_PROXY must be set so Node 24+ fetch honors the proxy"
+        );
+    }
+
+    /// Defensive: a missing token (should not occur when a proxy is live) yields a
+    /// credential-less URL the proxy will reject — fail-safe over-confinement, not a
+    /// tokenless bypass.
+    #[test]
+    fn set_proxy_env_without_token_is_credential_less() {
+        let mut cmd = Command::new("true");
+        set_proxy_env(&mut cmd, 4321, None);
+        let url = cmd
+            .get_envs()
+            .find(|(k, _)| *k == std::ffi::OsStr::new("HTTP_PROXY"))
+            .and_then(|(_, v)| v)
+            .map(|v| v.to_string_lossy().into_owned());
+        assert_eq!(url.as_deref(), Some("http://127.0.0.1:4321"));
+    }
 }

--- a/crates/nub-sandbox/src/backend/windows.rs
+++ b/crates/nub-sandbox/src/backend/windows.rs
@@ -284,6 +284,7 @@ pub(crate) fn apply(
     policy: &SandboxPolicy,
     spec: super::CommandSpec,
     proxy_port: Option<u16>,
+    proxy_token: Option<&str>,
     // CUT-1: Windows per-host egress-via-proxy is NOT wired (an AppContainer child needs a
     // loopback exemption — `NetworkIsolationSetAppContainerConfig` — to reach the loopback
     // proxy), so TLS termination degrades here just as per-host does. The bundle is still
@@ -311,7 +312,7 @@ pub(crate) fn apply(
             }
         }
         if let Some(port) = proxy_port {
-            super::set_proxy_env(&mut command, port);
+            super::set_proxy_env(&mut command, port, proxy_token);
         }
         if let Some(bundle) = ca_bundle {
             super::set_ca_env(&mut command, bundle);
@@ -420,7 +421,10 @@ pub(crate) fn apply(
         env: policy.env.enforce.then(|| {
             let mut m = policy.env.constructed.clone();
             if let Some(port) = proxy_port {
-                let url = format!("http://127.0.0.1:{port}");
+                let url = match proxy_token {
+                    Some(t) => format!("http://{t}@127.0.0.1:{port}"),
+                    None => format!("http://127.0.0.1:{port}"),
+                };
                 for k in [
                     "HTTP_PROXY",
                     "HTTPS_PROXY",
@@ -430,6 +434,7 @@ pub(crate) fn apply(
                 ] {
                     m.insert(k.to_string(), url.clone());
                 }
+                m.insert("NODE_USE_ENV_PROXY".to_string(), "1".to_string());
             }
             m
         }),

--- a/crates/nub-sandbox/src/proxy/handshake.rs
+++ b/crates/nub-sandbox/src/proxy/handshake.rs
@@ -7,8 +7,19 @@
 //! ACK before it can read the SNI. The target-host check happens BEFORE the ACK
 //! (a denied host is refused outright); the SNI check happens AFTER (read the
 //! ClientHello, then connect-or-drop). Both gates must pass.
+//!
+//! PER-SESSION TOKEN (defense-in-depth). The listener binds loopback with no OS-level
+//! caller authentication, so ANY co-resident same-user process could otherwise borrow
+//! the sandboxed child's egress hole. Every handshake must therefore present the
+//! per-run bearer token BEFORE any host decision: HTTP via `Proxy-Authorization: Basic`
+//! (the token as the userinfo of the `HTTP_PROXY` URL), SOCKS5 via RFC 1929 user/pass.
+//! A missing/mismatched token FAILS CLOSED (407 / SOCKS auth-failure, then the
+//! connection is dropped) — the token is checked before the target host is even read,
+//! so an unauthenticated caller cannot probe policy. The token is 256-bit CSPRNG, so
+//! the compare is high-entropy; it is still done in constant time as hygiene.
 
 use super::Host;
+use base64::Engine;
 use std::io::{self, Read, Write};
 use std::net::IpAddr;
 
@@ -34,13 +45,18 @@ const MAX_HTTP_HEADER: usize = 8 * 1024;
 /// Read + parse the client handshake, dispatching on the first byte (`0x05` = SOCKS5,
 /// otherwise HTTP). Performs the SOCKS5 greeting round-trip (method selection) inline;
 /// does NOT send the final tunnel reply (the caller does, post-decision).
-pub fn read_request(stream: &mut (impl Read + Write)) -> io::Result<Request> {
+///
+/// `token` is the per-session bearer every client must present (HTTP `Proxy-Authorization`
+/// / SOCKS5 RFC-1929 user-pass). A missing/wrong token yields `Err` AFTER the appropriate
+/// auth-failure reply is written — the caller drops the connection (fail-closed), and the
+/// target host is never consulted.
+pub fn read_request(stream: &mut (impl Read + Write), token: &str) -> io::Result<Request> {
     let mut first = [0u8; 1];
     stream.read_exact(&mut first)?;
     if first[0] == 0x05 {
-        read_socks5(stream)
+        read_socks5(stream, token)
     } else {
-        read_http_connect(stream, first[0])
+        read_http_connect(stream, first[0], token)
     }
 }
 
@@ -65,14 +81,20 @@ pub fn reply_failure(stream: &mut impl Write, proto: Proto) -> io::Result<()> {
 // ── SOCKS5 (RFC 1928) ────────────────────────────────────────────────────────────
 
 /// The `0x05` version byte was already consumed by [`read_request`].
-fn read_socks5(stream: &mut (impl Read + Write)) -> io::Result<Request> {
-    // Greeting: NMETHODS(1) + METHODS(n). We accept no-auth unconditionally (the
-    // proxy is loopback-only, reached solely by our own sandboxed child).
+fn read_socks5(stream: &mut (impl Read + Write), token: &str) -> io::Result<Request> {
+    // Greeting: NMETHODS(1) + METHODS(n). We REQUIRE username/password auth (0x02, RFC
+    // 1929) so the per-session token gates every SOCKS tunnel — no-auth (0x00) is refused.
     let mut nmethods = [0u8; 1];
     stream.read_exact(&mut nmethods)?;
     let mut methods = vec![0u8; nmethods[0] as usize];
     stream.read_exact(&mut methods)?;
-    stream.write_all(&[0x05, 0x00])?; // METHOD = no-auth
+    if !methods.contains(&0x02) {
+        // Client did not offer user/pass → no acceptable method; fail closed.
+        stream.write_all(&[0x05, 0xFF])?;
+        return Err(bad("socks5: username/password auth required"));
+    }
+    stream.write_all(&[0x05, 0x02])?; // METHOD = username/password
+    socks5_authenticate(stream, token)?;
 
     // Request: VER(1) CMD(1) RSV(1) ATYP(1) …
     let mut head = [0u8; 4];
@@ -114,10 +136,41 @@ fn read_socks5(stream: &mut (impl Read + Write)) -> io::Result<Request> {
     })
 }
 
+/// RFC 1929 username/password sub-negotiation. VER(1)=0x01 ULEN(1) UNAME PLEN(1) PASSWD.
+/// The token is accepted in EITHER field (the `HTTP_PROXY` userinfo places it as the
+/// username with an empty password; a SOCKS client may split it either way). A mismatch
+/// writes the `0x01 0x01` failure and fails closed.
+fn socks5_authenticate(stream: &mut (impl Read + Write), token: &str) -> io::Result<()> {
+    let mut ver = [0u8; 1];
+    stream.read_exact(&mut ver)?;
+    if ver[0] != 0x01 {
+        return Err(bad("socks5: bad auth version"));
+    }
+    let mut ulen = [0u8; 1];
+    stream.read_exact(&mut ulen)?;
+    let mut uname = vec![0u8; ulen[0] as usize];
+    stream.read_exact(&mut uname)?;
+    let mut plen = [0u8; 1];
+    stream.read_exact(&mut plen)?;
+    let mut passwd = vec![0u8; plen[0] as usize];
+    stream.read_exact(&mut passwd)?;
+    if ct_eq(&uname, token.as_bytes()) || ct_eq(&passwd, token.as_bytes()) {
+        stream.write_all(&[0x01, 0x00])?; // auth success
+        Ok(())
+    } else {
+        stream.write_all(&[0x01, 0x01])?; // auth failure
+        Err(bad("socks5: invalid proxy credentials"))
+    }
+}
+
 // ── HTTP CONNECT (RFC 7231 §4.3.6) ────────────────────────────────────────────────
 
 /// `first` is the already-consumed first byte of the request line.
-fn read_http_connect(stream: &mut (impl Read + Write), first: u8) -> io::Result<Request> {
+fn read_http_connect(
+    stream: &mut (impl Read + Write),
+    first: u8,
+    token: &str,
+) -> io::Result<Request> {
     let mut buf = vec![first];
     // Read until the header terminator `\r\n\r\n`, bounded.
     let mut one = [0u8; 1];
@@ -133,6 +186,17 @@ fn read_http_connect(stream: &mut (impl Read + Write), first: u8) -> io::Result<
         if buf.ends_with(b"\r\n\r\n") {
             break;
         }
+    }
+    // Token gate BEFORE any host decision: an unauthenticated caller gets 407 and is
+    // dropped, so it cannot even probe the host policy. `Proxy-Authenticate: Basic`
+    // lets a reactive client re-offer creds on a fresh connection.
+    if !http_proxy_auth_ok(&buf, token) {
+        let _ = stream.write_all(
+            b"HTTP/1.1 407 Proxy Authentication Required\r\n\
+              Proxy-Authenticate: Basic realm=\"nub\"\r\n\
+              Content-Length: 0\r\nConnection: close\r\n\r\n",
+        );
+        return Err(bad("http connect: proxy authentication required"));
     }
     // First line: `CONNECT host:port HTTP/1.1`.
     let line_end = buf
@@ -200,6 +264,72 @@ fn bad(msg: &str) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, msg.to_string())
 }
 
+// ── per-session token auth ─────────────────────────────────────────────────────────
+
+/// Validate the HTTP `Proxy-Authorization: Basic <base64>` credential against the
+/// per-session token. The token is accepted in EITHER the username or the password
+/// field of the decoded `user:pass` — the `HTTP_PROXY` userinfo places it as the
+/// username with an empty password, but a client that splits it otherwise still passes.
+/// Any missing/malformed piece is a fail-closed `false`.
+fn http_proxy_auth_ok(header_block: &[u8], token: &str) -> bool {
+    let Some(value) = header_value(header_block, b"proxy-authorization") else {
+        return false;
+    };
+    // `Basic <b64>` — scheme is case-insensitive, one SP separator.
+    let Some(sp) = value.iter().position(|&b| b == b' ') else {
+        return false;
+    };
+    let (scheme, creds) = value.split_at(sp);
+    if !scheme.eq_ignore_ascii_case(b"basic") {
+        return false;
+    }
+    let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(creds.trim_ascii()) else {
+        return false;
+    };
+    let colon = decoded
+        .iter()
+        .position(|&b| b == b':')
+        .unwrap_or(decoded.len());
+    let user = &decoded[..colon];
+    let pass = decoded.get(colon + 1..).unwrap_or(&[]);
+    ct_eq(user, token.as_bytes()) || ct_eq(pass, token.as_bytes())
+}
+
+/// Find a header's value in a raw `\r\n`-delimited header block, case-insensitive on the
+/// name, leading whitespace trimmed. `name` is the lowercase header name.
+fn header_value<'a>(block: &'a [u8], name: &[u8]) -> Option<&'a [u8]> {
+    let mut start = 0;
+    while start < block.len() {
+        let end = block[start..]
+            .windows(2)
+            .position(|w| w == b"\r\n")
+            .map(|p| start + p)
+            .unwrap_or(block.len());
+        let line = &block[start..end];
+        if let Some(colon) = line.iter().position(|&b| b == b':')
+            && line[..colon].eq_ignore_ascii_case(name)
+        {
+            return Some(line[colon + 1..].trim_ascii());
+        }
+        start = end + 2;
+    }
+    None
+}
+
+/// Constant-time byte equality. The token is 256-bit CSPRNG so timing is moot, but a
+/// data-independent compare is the correct default for a credential check. Length is
+/// public (fixed-width hex token), so an early length reject is fine.
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,10 +363,39 @@ mod tests {
         }
     }
 
+    /// A fixed high-entropy-shaped session token for the fixtures.
+    const TOK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    /// The `Proxy-Authorization: Basic <b64(token:)>` header line (token as username,
+    /// empty password — the `HTTP_PROXY` userinfo shape).
+    fn basic_auth_line(token: &str) -> Vec<u8> {
+        let b64 = base64::engine::general_purpose::STANDARD.encode(format!("{token}:"));
+        format!("Proxy-Authorization: Basic {b64}\r\n").into_bytes()
+    }
+
+    /// A full HTTP CONNECT header block carrying a valid Basic proxy-auth line.
+    fn http_connect_req(authority: &str, token: &str) -> Vec<u8> {
+        let mut v = format!("CONNECT {authority} HTTP/1.1\r\nHost: x\r\n").into_bytes();
+        v.extend_from_slice(&basic_auth_line(token));
+        v.extend_from_slice(b"\r\n");
+        v
+    }
+
+    /// SOCKS5 greeting (offering user/pass) + the RFC 1929 sub-negotiation carrying
+    /// `token` as the username with an empty password.
+    fn socks5_greeting_auth(token: &str) -> Vec<u8> {
+        let mut v = vec![0x05, 0x01, 0x02]; // ver, 1 method, username/password
+        v.push(0x01); // auth version
+        v.push(token.len() as u8);
+        v.extend_from_slice(token.as_bytes());
+        v.push(0x00); // empty password
+        v
+    }
+
     #[test]
     fn parses_http_connect_hostname() {
-        let mut d = Duplex::new(b"CONNECT example.com:443 HTTP/1.1\r\nHost: x\r\n\r\n".to_vec());
-        let r = read_request(&mut d).unwrap();
+        let mut d = Duplex::new(http_connect_req("example.com:443", TOK));
+        let r = read_request(&mut d, TOK).unwrap();
         assert_eq!(r.proto, Proto::Http);
         assert_eq!(r.host, Host::Name("example.com".into()));
         assert_eq!(r.port, 443);
@@ -244,67 +403,71 @@ mod tests {
 
     #[test]
     fn parses_http_connect_ipv6() {
-        let mut d = Duplex::new(b"CONNECT [::1]:8443 HTTP/1.1\r\n\r\n".to_vec());
-        let r = read_request(&mut d).unwrap();
+        let mut d = Duplex::new(http_connect_req("[::1]:8443", TOK));
+        let r = read_request(&mut d, TOK).unwrap();
         assert_eq!(r.host, Host::Ip("::1".parse().unwrap()));
         assert_eq!(r.port, 8443);
     }
 
     #[test]
-    fn parses_socks5_domain_request_and_selects_no_auth() {
-        // greeting: ver5, 1 method (no-auth); request: connect, domain "a.example", :443
-        let mut bytes = vec![0x05, 0x01, 0x00];
+    fn parses_socks5_domain_request_and_authenticates() {
+        // greeting offers user/pass; request: connect, domain "a.example", :443
+        let mut bytes = socks5_greeting_auth(TOK);
         bytes.extend_from_slice(&[0x05, 0x01, 0x00, 0x03]);
         let host = b"a.example";
         bytes.push(host.len() as u8);
         bytes.extend_from_slice(host);
         bytes.extend_from_slice(&443u16.to_be_bytes());
         let mut d = Duplex::new(bytes);
-        let r = read_request(&mut d).unwrap();
+        let r = read_request(&mut d, TOK).unwrap();
         assert_eq!(r.proto, Proto::Socks5);
         assert_eq!(r.host, Host::Name("a.example".into()));
         assert_eq!(r.port, 443);
-        // The method-selection reply (no-auth) must have been written.
-        assert_eq!(&d.output, &[0x05, 0x00]);
+        // method-selection (user/pass = 0x02) then auth-success (0x01 0x00).
+        assert_eq!(&d.output, &[0x05, 0x02, 0x01, 0x00]);
     }
 
     #[test]
     fn parses_socks5_ipv4_request() {
-        let mut bytes = vec![0x05, 0x01, 0x00];
+        let mut bytes = socks5_greeting_auth(TOK);
         bytes.extend_from_slice(&[0x05, 0x01, 0x00, 0x01, 93, 184, 216, 34]);
         bytes.extend_from_slice(&443u16.to_be_bytes());
         let mut d = Duplex::new(bytes);
-        let r = read_request(&mut d).unwrap();
+        let r = read_request(&mut d, TOK).unwrap();
         assert_eq!(r.host, Host::Ip("93.184.216.34".parse().unwrap()));
     }
 
     #[test]
     fn socks5_rejects_non_connect_command() {
-        // cmd 0x02 = BIND — unsupported in a jail.
-        let mut bytes = vec![0x05, 0x01, 0x00];
+        // cmd 0x02 = BIND — unsupported in a jail (checked after auth passes).
+        let mut bytes = socks5_greeting_auth(TOK);
         bytes.extend_from_slice(&[0x05, 0x02, 0x00, 0x01, 1, 2, 3, 4, 0, 80]);
         let mut d = Duplex::new(bytes);
-        assert!(read_request(&mut d).is_err());
+        assert!(read_request(&mut d, TOK).is_err());
     }
 
     #[test]
     fn http_non_connect_is_rejected() {
-        let mut d = Duplex::new(b"GET http://x/ HTTP/1.1\r\n\r\n".to_vec());
-        assert!(read_request(&mut d).is_err());
+        // Valid auth so the request reaches (and is rejected at) the method check.
+        let mut req = b"GET http://x/ HTTP/1.1\r\nHost: x\r\n".to_vec();
+        req.extend_from_slice(&basic_auth_line(TOK));
+        req.extend_from_slice(b"\r\n");
+        let mut d = Duplex::new(req);
+        assert!(read_request(&mut d, TOK).is_err());
     }
 
     #[test]
     fn socks5_rejects_control_char_in_hostname() {
         // A NUL embedded in the SOCKS5 domain (request-smuggling / parse-confusion) is
         // rejected — a legit host token never carries a control char.
-        let mut bytes = vec![0x05, 0x01, 0x00];
+        let mut bytes = socks5_greeting_auth(TOK);
         bytes.extend_from_slice(&[0x05, 0x01, 0x00, 0x03]);
         let host = b"evil\0.example";
         bytes.push(host.len() as u8);
         bytes.extend_from_slice(host);
         bytes.extend_from_slice(&443u16.to_be_bytes());
         let mut d = Duplex::new(bytes);
-        assert!(read_request(&mut d).is_err());
+        assert!(read_request(&mut d, TOK).is_err());
     }
 
     #[test]
@@ -313,8 +476,50 @@ mod tests {
         // whitespace) and reaches the host token, where the control-char check rejects
         // it — the parse-confusion hardening. (A whitespace-class control like \x0b would
         // instead be swallowed by the tokenizer, so NUL is the faithful exercise.)
-        let mut d = Duplex::new(b"CONNECT ex\x00ample.com:443 HTTP/1.1\r\n\r\n".to_vec());
-        assert!(read_request(&mut d).is_err());
+        let mut req = b"CONNECT ex\x00ample.com:443 HTTP/1.1\r\nHost: x\r\n".to_vec();
+        req.extend_from_slice(&basic_auth_line(TOK));
+        req.extend_from_slice(b"\r\n");
+        let mut d = Duplex::new(req);
+        assert!(read_request(&mut d, TOK).is_err());
+    }
+
+    #[test]
+    fn http_connect_missing_token_gets_407_and_fails() {
+        // No Proxy-Authorization → 407 challenge + fail-closed, BEFORE the host is read.
+        let mut d = Duplex::new(b"CONNECT example.com:443 HTTP/1.1\r\nHost: x\r\n\r\n".to_vec());
+        assert!(read_request(&mut d, TOK).is_err());
+        assert!(
+            d.output.starts_with(b"HTTP/1.1 407"),
+            "a tokenless CONNECT must be answered 407, got {:?}",
+            String::from_utf8_lossy(&d.output)
+        );
+    }
+
+    #[test]
+    fn http_connect_wrong_token_rejected() {
+        let wrong = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        let mut d = Duplex::new(http_connect_req("example.com:443", wrong));
+        assert!(read_request(&mut d, TOK).is_err());
+        assert!(d.output.starts_with(b"HTTP/1.1 407"));
+    }
+
+    #[test]
+    fn socks5_without_userpass_method_is_refused() {
+        // Client offers only no-auth (0x00) → no acceptable method (0x05 0xFF), fail closed.
+        let mut d = Duplex::new(vec![0x05, 0x01, 0x00]);
+        assert!(read_request(&mut d, TOK).is_err());
+        assert_eq!(&d.output, &[0x05, 0xFF]);
+    }
+
+    #[test]
+    fn socks5_wrong_token_rejected() {
+        let wrong = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        let mut bytes = socks5_greeting_auth(wrong);
+        bytes.extend_from_slice(&[0x05, 0x01, 0x00, 0x01, 1, 2, 3, 4, 0, 80]);
+        let mut d = Duplex::new(bytes);
+        assert!(read_request(&mut d, TOK).is_err());
+        // user/pass selected (0x05 0x02) then auth failure (0x01 0x01).
+        assert_eq!(&d.output, &[0x05, 0x02, 0x01, 0x01]);
     }
 
     #[test]

--- a/crates/nub-sandbox/src/proxy/handshake.rs
+++ b/crates/nub-sandbox/src/proxy/handshake.rs
@@ -51,6 +51,9 @@ const MAX_HTTP_HEADER: usize = 8 * 1024;
 /// auth-failure reply is written — the caller drops the connection (fail-closed), and the
 /// target host is never consulted.
 pub fn read_request(stream: &mut (impl Read + Write), token: &str) -> io::Result<Request> {
+    // Invariant: a live proxy always mints a non-empty token. An empty token would make
+    // `Basic base64(":")` (empty user+pass) authenticate — so assert it never happens.
+    debug_assert!(!token.is_empty(), "egress-proxy token must be non-empty");
     let mut first = [0u8; 1];
     stream.read_exact(&mut first)?;
     if first[0] == 0x05 {

--- a/crates/nub-sandbox/src/proxy/mod.rs
+++ b/crates/nub-sandbox/src/proxy/mod.rs
@@ -101,6 +101,11 @@ const MAX_PRELUDE: usize = 16 * 1024;
 /// connections (the parent owns this; it drops after the sandboxed child exits).
 pub struct EgressProxy {
     port: u16,
+    /// The per-session bearer every client must present (HTTP `Proxy-Authorization` /
+    /// SOCKS5 user-pass) — the defense-in-depth guard against a co-resident same-user
+    /// process borrowing the child's loopback egress hole. Minted per [`start`] from the
+    /// OS CSPRNG; delivered to the child as the `HTTP_PROXY` URL userinfo.
+    token: Arc<str>,
     shutdown: Arc<AtomicBool>,
     accept_thread: Option<JoinHandle<()>>,
     /// The MITM engine, when the policy engages TLS termination (credential brokering /
@@ -123,14 +128,17 @@ impl EgressProxy {
         // should ever see this listener.
         let listener = TcpListener::bind((IpAddr::from([127, 0, 0, 1]), 0))?;
         let port = listener.local_addr()?.port();
+        let token: Arc<str> = Arc::from(mint_token());
         let shutdown = Arc::new(AtomicBool::new(false));
         let sh = shutdown.clone();
         let engine = mitm.clone();
+        let tok = token.clone();
         let accept_thread = std::thread::Builder::new()
             .name("nub-egress-proxy".into())
-            .spawn(move || accept_loop(listener, sh, decider, engine))?;
+            .spawn(move || accept_loop(listener, sh, decider, engine, tok))?;
         Ok(EgressProxy {
             port,
+            token,
             shutdown,
             accept_thread: Some(accept_thread),
             mitm,
@@ -140,6 +148,12 @@ impl EgressProxy {
     /// The loopback port the child must be pointed at (env hint + OS carve-out).
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    /// The per-session bearer token the child presents to the proxy — delivered via the
+    /// `HTTP_PROXY` URL userinfo so ordinary proxy-honoring clients send it automatically.
+    pub fn token(&self) -> &str {
+        &self.token
     }
 
     /// The child-scoped CA-bundle path, when TLS termination is engaged — the value the
@@ -170,6 +184,7 @@ fn accept_loop(
     shutdown: Arc<AtomicBool>,
     decider: Arc<dyn GrantDecider>,
     mitm: Option<Arc<mitm::MitmEngine>>,
+    token: Arc<str>,
 ) {
     for conn in listener.incoming() {
         if shutdown.load(Ordering::SeqCst) {
@@ -178,14 +193,30 @@ fn accept_loop(
         let Ok(stream) = conn else { continue };
         let d = decider.clone();
         let m = mitm.clone();
+        let tok = token.clone();
         // Best-effort spawn; if the OS refuses a thread we simply drop the connection
         // (fail-closed — no unproxied path opens).
         let _ = std::thread::Builder::new()
             .name("nub-egress-tunnel".into())
             .spawn(move || {
-                let _ = handle_conn(stream, d, m);
+                let _ = handle_conn(stream, d, m, &tok);
             });
     }
+}
+
+/// Mint the per-session bearer token: 256 bits from the OS CSPRNG, hex-encoded (64
+/// URL-safe chars, so it drops into the `HTTP_PROXY` userinfo with no escaping). A
+/// getrandom failure is unrecoverable for a security token → panic rather than fall
+/// back to a weak source (fail-closed: no proxy, no egress).
+fn mint_token() -> String {
+    let mut bytes = [0u8; 32];
+    getrandom::getrandom(&mut bytes).expect("OS CSPRNG unavailable for egress-proxy token");
+    let mut s = String::with_capacity(64);
+    for b in bytes {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
 }
 
 /// Handle one client tunnel: parse the request, gate the target host, ACK, gate the
@@ -195,9 +226,13 @@ fn handle_conn(
     mut stream: TcpStream,
     decider: Arc<dyn GrantDecider>,
     mitm: Option<Arc<mitm::MitmEngine>>,
+    token: &str,
 ) -> io::Result<()> {
     stream.set_read_timeout(Some(CLIENT_HELLO_TIMEOUT))?;
-    let req = read_request(&mut stream)?;
+    // Token gate FIRST: an unauthenticated caller is answered (407 / SOCKS auth-fail)
+    // and dropped before any host decision. `?` propagates the auth error → connection
+    // closed (fail-closed).
+    let req = read_request(&mut stream, token)?;
 
     // Gate 1 — the CONNECT/SOCKS target host (before the ACK).
     if decider.decide(&req.host) == Decision::Deny {

--- a/crates/nub-sandbox/tests/linux_proxy.rs
+++ b/crates/nub-sandbox/tests/linux_proxy.rs
@@ -151,7 +151,8 @@ fn compile_probe(dir: &Path) -> Option<PathBuf> {
 }
 
 // rawconnect <ip> <port> 0=ok 1=fail; unixconnect <path> 0=ok 1=denied/fail;
-// proxysni <tgt> <port> <sni> 0=forwarded 5=dropped 1=err. Reads HTTP_PROXY.
+// proxysni <tgt> <port> <sni> 0=forwarded 5=dropped 1=err; proxynoauth <tgt> <port>
+// 4=refused-407 0=leaked 1=err. Reads HTTP_PROXY for the port AND the per-session token.
 const PROBE_C: &str = r#"
 #include <arpa/inet.h>
 #include <errno.h>
@@ -179,6 +180,30 @@ static int dial(const char* ip, int port) {
     return fd;
 }
 static int proxy_port(void){const char*p=getenv("HTTP_PROXY");if(!p)return 0;const char*c=strrchr(p,':');return c?atoi(c+1):0;}
+/* Extract the per-session token from HTTP_PROXY (`http://<token>@127.0.0.1:<port>`). */
+static int proxy_token(char* out,int cap){
+    const char*p=getenv("HTTP_PROXY"); if(!p)return 0;
+    const char*s=strstr(p,"//"); if(!s)return 0; s+=2;
+    const char*at=strchr(s,'@'); if(!at)return 0;
+    int n=(int)(at-s); if(n<=0||n>=cap)return 0; memcpy(out,s,n); out[n]=0; return 1;
+}
+static const char B64[]="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static void b64enc(const unsigned char*in,int len,char*out){
+    int o=0,i=0;
+    for(;i+3<=len;i+=3){unsigned v=(in[i]<<16)|(in[i+1]<<8)|in[i+2];
+        out[o++]=B64[(v>>18)&63];out[o++]=B64[(v>>12)&63];out[o++]=B64[(v>>6)&63];out[o++]=B64[v&63];}
+    int rem=len-i;
+    if(rem==1){unsigned v=in[i]<<16;out[o++]=B64[(v>>18)&63];out[o++]=B64[(v>>12)&63];out[o++]='=';out[o++]='=';}
+    else if(rem==2){unsigned v=(in[i]<<16)|(in[i+1]<<8);out[o++]=B64[(v>>18)&63];out[o++]=B64[(v>>12)&63];out[o++]=B64[(v>>6)&63];out[o++]='=';}
+    out[o]=0;
+}
+/* `Proxy-Authorization: Basic <b64(token:)>\r\n` into hdr; 1 if a token was present. */
+static int auth_header(char* hdr,int cap){
+    char tok[128]; if(!proxy_token(tok,sizeof tok)){hdr[0]=0;return 0;}
+    char cred[160]; int n=snprintf(cred,sizeof cred,"%s:",tok);
+    char enc[256]; b64enc((const unsigned char*)cred,n,enc);
+    snprintf(hdr,cap,"Proxy-Authorization: Basic %s\r\n",enc); return 1;
+}
 static int build_hello(const char* sni, unsigned char* out){
     unsigned char body[1024]; int b=0;
     body[b++]=0x03;body[b++]=0x03; for(int i=0;i<32;i++)body[b++]=0; body[b++]=0;
@@ -193,10 +218,11 @@ static int build_hello(const char* sni, unsigned char* out){
     out[o++]=0x01;out[o++]=(b>>16)&0xff;out[o++]=(b>>8)&0xff;out[o++]=b&0xff;
     memcpy(out+o,body,b);o+=b; return o;
 }
-static int proxy_connect(const char* tgt,int tport){
+static int proxy_connect(const char* tgt,int tport,int with_auth){
     int pp=proxy_port(); if(!pp)return -1;
     int fd=dial("127.0.0.1",pp); if(fd<0)return -1;
-    char req[256]; int n=snprintf(req,sizeof req,"CONNECT %s:%d HTTP/1.1\r\nHost: %s\r\n\r\n",tgt,tport,tgt);
+    char hdr[256]; hdr[0]=0; if(with_auth) auth_header(hdr,sizeof hdr);
+    char req[512]; int n=snprintf(req,sizeof req,"CONNECT %s:%d HTTP/1.1\r\nHost: %s\r\n%s\r\n",tgt,tport,tgt,hdr);
     if(write(fd,req,n)!=n){close(fd);return -1;}
     char resp[512];int got=0;
     while(got<4||memcmp(resp+got-4,"\r\n\r\n",4)){int r=read(fd,resp+got,1);if(r<=0){close(fd);return -1;}got+=r;if(got>=(int)sizeof resp)break;}
@@ -222,10 +248,17 @@ int main(int argc,char**argv){
         if(connect(fd,(struct sockaddr*)&a,sizeof a)!=0){close(fd);return 1;} close(fd);return 0;
     }
     if(!strcmp(argv[1],"proxysni")){
-        int fd=proxy_connect(argv[2],atoi(argv[3])); if(fd<0)return 1;
+        int fd=proxy_connect(argv[2],atoi(argv[3]),1); if(fd<0)return 1;
         unsigned char hello[1024];int hl=build_hello(argv[4],hello);
         if(write(fd,hello,hl)!=hl){close(fd);return 1;}
         unsigned char e[64]; int r=read(fd,e,sizeof e); close(fd); return (r>0)?0:5;
+    }
+    /* Like proxysni's CONNECT but WITHOUT the token: proves the per-session gate. A
+       co-resident process lacking the token is refused (407). 4=refused (expected),
+       0=leaked-through (a bug), 1=couldn't reach proxy. */
+    if(!strcmp(argv[1],"proxynoauth")){
+        int fd=proxy_connect(argv[2],atoi(argv[3]),0);
+        if(fd==-2)return 4; if(fd<0)return 1; close(fd); return 0;
     }
     /* Create an AF_INET SOCK_STREAM socket with protocol argv[2] (e.g. IPPROTO_SCTP=132,
        IPPROTO_MPTCP=262, IPPROTO_TCP=6, default=0). 0=created (allowed), 2=EPERM/EACCES
@@ -329,6 +362,39 @@ fn per_host_proxy_forwards_allowed_drops_denied_blocks_direct() {
         ),
         0,
         "neg-control: unenforced net connects directly"
+    );
+}
+
+#[test]
+fn proxy_requires_the_per_session_token() {
+    // Defense-in-depth: the loopback proxy is reachable (Landlock carves the proxy port)
+    // but a caller WITHOUT the per-session token is refused (407). The `proxynoauth` mode
+    // omits the token, standing in for a co-resident same-user process that never learned
+    // it; the paired positive control (WITH the token) forwards.
+    if skip_without_landlock(4) {
+        return; // per-host needs Landlock ABI v4
+    }
+    let f = fixture();
+    let Some(probe) = compile_probe(&f.proj) else {
+        return;
+    };
+    let echo = echo_server();
+    let port = echo.port().to_string();
+    let probe = probe.to_str().unwrap();
+
+    assert_eq!(
+        f.run(net_policy(), probe, &["proxynoauth", "127.0.0.1", &port]),
+        4,
+        "a tokenless CONNECT to an admitted target must be refused (407)"
+    );
+    assert_eq!(
+        f.run(
+            net_policy(),
+            probe,
+            &["proxysni", "127.0.0.1", &port, "api.allowed.example"]
+        ),
+        0,
+        "the child's own token must still forward"
     );
 }
 
@@ -605,10 +671,12 @@ fn nonblocking_client_reaches_proxy_under_connect_notify() {
     let target = format!("127.0.0.1:{}", echo.port());
     let script = r#"
 const net = require('net');
-const pport = parseInt(process.env.HTTP_PROXY.split(':').pop(), 10);
+const u = new URL(process.env.HTTP_PROXY);
+const pport = parseInt(u.port, 10);
+const auth = 'Basic ' + Buffer.from(`${u.username}:`).toString('base64');
 const s = net.connect(pport, '127.0.0.1');
 let buf = '';
-s.on('connect', () => s.write(`CONNECT ${process.argv[1]} HTTP/1.1\r\nHost: x\r\n\r\n`));
+s.on('connect', () => s.write(`CONNECT ${process.argv[1]} HTTP/1.1\r\nHost: x\r\nProxy-Authorization: ${auth}\r\n\r\n`));
 s.on('data', d => { buf += d; if (buf.includes('\r\n\r\n')) { s.destroy(); process.exit(buf.startsWith('HTTP/1.1 200') ? 0 : 5); } });
 s.on('error', () => process.exit(3));
 setTimeout(() => process.exit(7), 5000);

--- a/crates/nub-sandbox/tests/macos_proxy.rs
+++ b/crates/nub-sandbox/tests/macos_proxy.rs
@@ -110,8 +110,9 @@ fn compile_probe(dir: &Path) -> Option<PathBuf> {
     ok.then_some(bin)
 }
 
-// Exit codes: rawconnect 0=ok 1=fail; proxyget 0=200 3=refused 1=err; proxysni
-// 0=forwarded 5=dropped 1=err. The probe reads HTTP_PROXY for the proxy port.
+// Exit codes: rawconnect 0=ok 1=fail; proxyget 0=200 3=refused 1=err; proxynoauth
+// 4=refused-407 0=leaked 1=err; proxysni 0=forwarded 5=dropped 1=err. The probe reads
+// HTTP_PROXY for the proxy port AND the per-session token (`http://<token>@host:port`).
 const PROBE_C: &str = r#"
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -142,6 +143,40 @@ static int proxy_port(void) {
     return c ? atoi(c + 1) : 0;
 }
 
+/* Extract the per-session token from HTTP_PROXY (`http://<token>@127.0.0.1:<port>`),
+   between "//" and "@", into `out`. Returns 1 on success. */
+static int proxy_token(char* out, int cap) {
+    const char* p = getenv("HTTP_PROXY"); if (!p) return 0;
+    const char* s = strstr(p, "//"); if (!s) return 0; s += 2;
+    const char* at = strchr(s, '@'); if (!at) return 0;
+    int n = (int)(at - s); if (n <= 0 || n >= cap) return 0;
+    memcpy(out, s, n); out[n] = 0; return 1;
+}
+
+static const char B64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static void b64enc(const unsigned char* in, int len, char* out) {
+    int o = 0, i = 0;
+    for (; i + 3 <= len; i += 3) {
+        unsigned v = (in[i] << 16) | (in[i+1] << 8) | in[i+2];
+        out[o++] = B64[(v>>18)&63]; out[o++] = B64[(v>>12)&63];
+        out[o++] = B64[(v>>6)&63];  out[o++] = B64[v&63];
+    }
+    int rem = len - i;
+    if (rem == 1) { unsigned v = in[i] << 16; out[o++]=B64[(v>>18)&63]; out[o++]=B64[(v>>12)&63]; out[o++]='='; out[o++]='='; }
+    else if (rem == 2) { unsigned v=(in[i]<<16)|(in[i+1]<<8); out[o++]=B64[(v>>18)&63]; out[o++]=B64[(v>>12)&63]; out[o++]=B64[(v>>6)&63]; out[o++]='='; }
+    out[o] = 0;
+}
+
+/* Build the `Proxy-Authorization: Basic <b64(token:)>\r\n` header line into `hdr`.
+   Returns 1 if a token was present (header written), else 0 (hdr emptied). */
+static int auth_header(char* hdr, int cap) {
+    char tok[128]; if (!proxy_token(tok, sizeof tok)) { hdr[0] = 0; return 0; }
+    char cred[160]; int n = snprintf(cred, sizeof cred, "%s:", tok);
+    char enc[256]; b64enc((const unsigned char*)cred, n, enc);
+    snprintf(hdr, cap, "Proxy-Authorization: Basic %s\r\n", enc);
+    return 1;
+}
+
 static int build_hello(const char* sni, unsigned char* out) {
     unsigned char body[1024]; int b = 0;
     body[b++]=0x03; body[b++]=0x03;
@@ -169,12 +204,16 @@ static int build_hello(const char* sni, unsigned char* out) {
     return o;
 }
 
-/* CONNECT tgt:port through the proxy; return the fd on a 200, else -1. */
-static int proxy_connect(const char* tgt, int tport) {
+/* CONNECT tgt:port through the proxy. `with_auth` toggles sending the per-session
+   Proxy-Authorization header. Returns the fd on a 200, -2 on a non-200 (e.g. 407/403),
+   -1 on a transport error. */
+static int proxy_connect(const char* tgt, int tport, int with_auth) {
     int pp = proxy_port(); if (!pp) return -1;
     int fd = dial("127.0.0.1", pp); if (fd < 0) return -1;
-    char req[256];
-    int n = snprintf(req, sizeof req, "CONNECT %s:%d HTTP/1.1\r\nHost: %s\r\n\r\n", tgt, tport, tgt);
+    char hdr[256]; hdr[0] = 0;
+    if (with_auth) auth_header(hdr, sizeof hdr);
+    char req[512];
+    int n = snprintf(req, sizeof req, "CONNECT %s:%d HTTP/1.1\r\nHost: %s\r\n%s\r\n", tgt, tport, tgt, hdr);
     if (write(fd, req, n) != n) { close(fd); return -1; }
     char resp[512]; int got = 0;
     while (got < 4 || memcmp(resp+got-4, "\r\n\r\n", 4)) {
@@ -193,13 +232,22 @@ int main(int argc, char** argv) {
         if (fd < 0) return 1; close(fd); return 0;
     }
     if (!strcmp(argv[1], "proxyget")) {
-        int fd = proxy_connect(argv[2], atoi(argv[3]));
+        int fd = proxy_connect(argv[2], atoi(argv[3]), 1);
         if (fd == -2) return 3;   /* proxy refused (403) */
         if (fd < 0) return 1;     /* couldn't reach proxy */
         close(fd); return 0;      /* 200 */
     }
+    /* Like proxyget but WITHOUT the token — proves the per-session gate: a co-resident
+       process that lacks the token is refused. 4=refused (407, expected), 0=leaked
+       through (200, a bug), 1=couldn't reach proxy. */
+    if (!strcmp(argv[1], "proxynoauth")) {
+        int fd = proxy_connect(argv[2], atoi(argv[3]), 0);
+        if (fd == -2) return 4;   /* 407 — correctly refused */
+        if (fd < 0) return 1;
+        close(fd); return 0;      /* got a 200 without a token — leak */
+    }
     if (!strcmp(argv[1], "proxysni")) {
-        int fd = proxy_connect(argv[2], atoi(argv[3]));
+        int fd = proxy_connect(argv[2], atoi(argv[3]), 1);
         if (fd < 0) return 1;
         unsigned char hello[1024]; int hl = build_hello(argv[4], hello);
         if (write(fd, hello, hl) != hl) { close(fd); return 1; }
@@ -309,6 +357,33 @@ fn allowed_sni_forwards_denied_sni_dropped_through_proxy() {
         f.run(net_policy(), &probe, &["proxyget", "203.0.113.1", "443"]),
         3,
         "a denied target is refused (403) by the proxy before connecting"
+    );
+}
+
+#[test]
+fn proxy_requires_the_per_session_token() {
+    // Defense-in-depth: the loopback proxy is reachable (carved) but a caller WITHOUT the
+    // per-session token is refused (407). The child holds the token in its own env — the
+    // `proxynoauth` mode deliberately omits it, standing in for a co-resident same-user
+    // process that never learned it. The paired positive control (WITH the token) forwards.
+    let f = fixture();
+    let Some(probe) = compile_probe(&f.proj) else {
+        return;
+    };
+    let echo = echo_server();
+    let port = echo.port().to_string();
+
+    // Without the token → 407, even though the target IP is admitted at gate 1.
+    assert_eq!(
+        f.run(net_policy(), &probe, &["proxynoauth", "127.0.0.1", &port]),
+        4,
+        "a tokenless CONNECT to an admitted target must be refused (407)"
+    );
+    // Positive control: the same target WITH the token gets a 200.
+    assert_eq!(
+        f.run(net_policy(), &probe, &["proxyget", "127.0.0.1", &port]),
+        0,
+        "the child's own token must still forward"
     );
 }
 

--- a/crates/nub-sandbox/tests/proxy.rs
+++ b/crates/nub-sandbox/tests/proxy.rs
@@ -7,6 +7,7 @@
 //! hermetic; no external host is contacted. The "ClientHello" is a well-formed SNI
 //! byte blob (the proxy does NOT terminate TLS, so the echo server just reflects it).
 
+use base64::Engine;
 use nub_sandbox::StaticDecider;
 use nub_sandbox::policy::{Effect, NetPolicy, NetRule, NetTarget};
 use nub_sandbox::proxy::{Decision, EgressProxy, GrantDecider, Host};
@@ -14,6 +15,13 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+/// The `Proxy-Authorization: Basic <b64(token:)>` header line (token as username, empty
+/// password — the shape the child's `HTTP_PROXY` URL userinfo produces).
+fn basic_auth(token: &str) -> String {
+    let b64 = base64::engine::general_purpose::STANDARD.encode(format!("{token}:"));
+    format!("Proxy-Authorization: Basic {b64}\r\n")
+}
 
 // ── throwaway upstream: a loopback echo server ──────────────────────────────────
 
@@ -81,12 +89,18 @@ fn client_hello(sni: &str) -> Vec<u8> {
 
 // ── proxy client helpers ────────────────────────────────────────────────────────
 
-/// HTTP CONNECT to `target` (a `host:port` authority) through the proxy. Returns the
-/// tunnel stream after the `200` ACK, or an error string on a non-2xx response.
-fn http_connect(proxy_port: u16, target: &str) -> Result<TcpStream, String> {
+/// HTTP CONNECT to `target` (a `host:port` authority) through the proxy, presenting
+/// `token` as the Basic proxy credential. Returns the tunnel stream after the `200` ACK,
+/// or the response's status line on a non-2xx (e.g. `407`/`403`).
+fn http_connect(proxy_port: u16, target: &str, token: &str) -> Result<TcpStream, String> {
     let mut s = TcpStream::connect(("127.0.0.1", proxy_port)).unwrap();
     s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
-    write!(s, "CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n").unwrap();
+    write!(
+        s,
+        "CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n{}\r\n",
+        basic_auth(token)
+    )
+    .unwrap();
     let mut resp = Vec::new();
     let mut one = [0u8; 1];
     loop {
@@ -108,15 +122,28 @@ fn http_connect(proxy_port: u16, target: &str) -> Result<TcpStream, String> {
     }
 }
 
-/// SOCKS5 CONNECT to an IPv4 `addr` through the proxy. Returns the tunnel stream after
-/// a success reply, or `Err` on a non-success reply.
-fn socks5_connect_ip(proxy_port: u16, addr: SocketAddr) -> Result<TcpStream, u8> {
+/// SOCKS5 CONNECT to an IPv4 `addr` through the proxy, authenticating with `token` via
+/// RFC 1929 user/pass (token as the username, empty password). Returns the tunnel stream
+/// after a success reply, or `Err` on a non-success request reply.
+fn socks5_connect_ip(proxy_port: u16, addr: SocketAddr, token: &str) -> Result<TcpStream, u8> {
     let mut s = TcpStream::connect(("127.0.0.1", proxy_port)).unwrap();
     s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
-    s.write_all(&[0x05, 0x01, 0x00]).unwrap(); // greeting: 1 method (no-auth)
+    s.write_all(&[0x05, 0x01, 0x02]).unwrap(); // greeting: 1 method (username/password)
     let mut sel = [0u8; 2];
     s.read_exact(&mut sel).unwrap();
-    assert_eq!(sel, [0x05, 0x00]);
+    assert_eq!(
+        sel,
+        [0x05, 0x02],
+        "proxy must select username/password auth"
+    );
+    // RFC 1929 sub-negotiation: token as username, empty password.
+    let mut auth = vec![0x01, token.len() as u8];
+    auth.extend_from_slice(token.as_bytes());
+    auth.push(0x00);
+    s.write_all(&auth).unwrap();
+    let mut ar = [0u8; 2];
+    s.read_exact(&mut ar).unwrap();
+    assert_eq!(ar, [0x01, 0x00], "proxy must accept the token");
     let ip = match addr.ip() {
         std::net::IpAddr::V4(v4) => v4.octets(),
         _ => panic!("ipv4 only"),
@@ -192,7 +219,12 @@ fn http_connect_allowed_host_forwards() {
         allow_cidr("127.0.0.0/8"),
         allow_host("*.allowed.example"),
     ]));
-    let mut t = http_connect(proxy.port(), &format!("127.0.0.1:{}", upstream.port())).unwrap();
+    let mut t = http_connect(
+        proxy.port(),
+        &format!("127.0.0.1:{}", upstream.port()),
+        proxy.token(),
+    )
+    .unwrap();
     assert!(
         tunnel_forwards(&mut t, "api.allowed.example"),
         "an allowed SNI to an admitted target must forward end-to-end"
@@ -207,7 +239,12 @@ fn http_connect_denied_sni_drops() {
         allow_cidr("127.0.0.0/8"),
         allow_host("*.allowed.example"),
     ]));
-    let mut t = http_connect(proxy.port(), &format!("127.0.0.1:{}", upstream.port())).unwrap();
+    let mut t = http_connect(
+        proxy.port(),
+        &format!("127.0.0.1:{}", upstream.port()),
+        proxy.token(),
+    )
+    .unwrap();
     assert!(
         !tunnel_forwards(&mut t, "evil.example"),
         "a denied SNI must be dropped even when the target IP is admitted (shared-IP guard)"
@@ -220,7 +257,12 @@ fn http_connect_denied_target_host_refused_before_ack() {
     // Only a host glob is allowed; the loopback IP target is NOT admitted → gate 1
     // refuses with a non-200 before any tunnel is established.
     let proxy = start(net(vec![allow_host("*.allowed.example")]));
-    let err = http_connect(proxy.port(), &format!("127.0.0.1:{}", upstream.port())).unwrap_err();
+    let err = http_connect(
+        proxy.port(),
+        &format!("127.0.0.1:{}", upstream.port()),
+        proxy.token(),
+    )
+    .unwrap_err();
     assert!(
         err.contains("403"),
         "denied target must get a 403, got {err:?}"
@@ -233,7 +275,12 @@ fn http_connect_hostname_target_resolves_and_forwards() {
     // DNS. SNI `localhost` also admitted.
     let upstream = echo_server();
     let proxy = start(net(vec![allow_host("localhost")]));
-    let mut t = http_connect(proxy.port(), &format!("localhost:{}", upstream.port())).unwrap();
+    let mut t = http_connect(
+        proxy.port(),
+        &format!("localhost:{}", upstream.port()),
+        proxy.token(),
+    )
+    .unwrap();
     assert!(
         tunnel_forwards(&mut t, "localhost"),
         "an allowed hostname target must resolve and forward"
@@ -248,13 +295,13 @@ fn socks5_allowed_forwards_denied_sni_drops() {
         allow_host("*.allowed.example"),
     ]));
     // allowed SNI over SOCKS5
-    let mut ok = socks5_connect_ip(proxy.port(), upstream).unwrap();
+    let mut ok = socks5_connect_ip(proxy.port(), upstream, proxy.token()).unwrap();
     assert!(
         tunnel_forwards(&mut ok, "cdn.allowed.example"),
         "socks5 allow forwards"
     );
     // denied SNI over SOCKS5 → dropped
-    let mut bad = socks5_connect_ip(proxy.port(), upstream).unwrap();
+    let mut bad = socks5_connect_ip(proxy.port(), upstream, proxy.token()).unwrap();
     assert!(
         !tunnel_forwards(&mut bad, "evil.example"),
         "socks5 denied SNI drops"
@@ -266,7 +313,7 @@ fn socks5_denied_target_ip_gets_refusal_reply() {
     let upstream = echo_server();
     // No CIDR allowed → the loopback target IP is refused at the SOCKS request reply.
     let proxy = start(net(vec![allow_host("*.allowed.example")]));
-    let rep = socks5_connect_ip(proxy.port(), upstream).unwrap_err();
+    let rep = socks5_connect_ip(proxy.port(), upstream, proxy.token()).unwrap_err();
     assert_eq!(rep, 0x02, "SOCKS5 refusal REP=2 (not allowed by ruleset)");
 }
 
@@ -276,7 +323,12 @@ fn non_tls_stream_to_admitted_target_forwards() {
     // cross-route on → forwarded. Proves NotTls admits (not fail-closed).
     let upstream = echo_server();
     let proxy = start(net(vec![allow_cidr("127.0.0.0/8")]));
-    let mut t = http_connect(proxy.port(), &format!("127.0.0.1:{}", upstream.port())).unwrap();
+    let mut t = http_connect(
+        proxy.port(),
+        &format!("127.0.0.1:{}", upstream.port()),
+        proxy.token(),
+    )
+    .unwrap();
     let payload = b"PING plain-tcp\n";
     t.write_all(payload).unwrap();
     let mut got = vec![0u8; payload.len()];
@@ -294,7 +346,12 @@ fn stalled_tls_tunnel_fails_closed() {
         allow_cidr("127.0.0.0/8"),
         allow_host("*.allowed.example"),
     ]));
-    let mut t = http_connect(proxy.port(), &format!("127.0.0.1:{}", _upstream.port())).unwrap();
+    let mut t = http_connect(
+        proxy.port(),
+        &format!("127.0.0.1:{}", _upstream.port()),
+        proxy.token(),
+    )
+    .unwrap();
     t.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
     // A handshake record header claiming a large body, then nothing more.
     t.write_all(&[0x16, 0x03, 0x01, 0x02, 0x00, 0x01, 0x00])
@@ -335,7 +392,12 @@ fn decider_seam_is_consulted_for_target_and_sni() {
     let upstream = echo_server();
     let rec = Arc::new(Recorder::default());
     let proxy = EgressProxy::start(rec.clone(), None).unwrap();
-    let mut t = http_connect(proxy.port(), &format!("127.0.0.1:{}", upstream.port())).unwrap();
+    let mut t = http_connect(
+        proxy.port(),
+        &format!("127.0.0.1:{}", upstream.port()),
+        proxy.token(),
+    )
+    .unwrap();
     assert!(tunnel_forwards(&mut t, "keep.allowed.example"));
     let seen = rec.seen.lock().unwrap().clone();
     assert!(
@@ -361,5 +423,83 @@ fn dropping_proxy_stops_the_listener() {
     assert!(
         TcpStream::connect(("127.0.0.1", port)).is_err(),
         "the proxy port must be closed after the handle drops"
+    );
+}
+
+// ── per-session token gate (defense-in-depth) ──────────────────────────────────────
+
+#[test]
+fn http_connect_without_token_is_rejected_with_407() {
+    // A co-resident same-user process that does NOT know the token cannot use the proxy:
+    // a CONNECT with no Proxy-Authorization is answered 407 and dropped — BEFORE the
+    // (admitted) target host is consulted.
+    let upstream = echo_server();
+    let proxy = start(net(vec![allow_cidr("127.0.0.0/8")]));
+    let mut s = TcpStream::connect(("127.0.0.1", proxy.port())).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    write!(
+        s,
+        "CONNECT 127.0.0.1:{} HTTP/1.1\r\nHost: x\r\n\r\n",
+        upstream.port()
+    )
+    .unwrap();
+    let mut resp = Vec::new();
+    let _ = s.read_to_end(&mut resp);
+    assert!(
+        String::from_utf8_lossy(&resp).starts_with("HTTP/1.1 407"),
+        "a tokenless CONNECT to an admitted target must be refused 407, got {:?}",
+        String::from_utf8_lossy(&resp)
+    );
+}
+
+#[test]
+fn http_connect_with_wrong_token_is_rejected() {
+    // A wrong token is refused exactly like a missing one (no oracle for a near-miss).
+    let upstream = echo_server();
+    let proxy = start(net(vec![allow_cidr("127.0.0.0/8")]));
+    let wrong = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    let err = http_connect(
+        proxy.port(),
+        &format!("127.0.0.1:{}", upstream.port()),
+        wrong,
+    )
+    .expect_err("a wrong token must be refused");
+    assert!(err.contains("407"), "wrong token must get 407, got {err:?}");
+}
+
+#[test]
+fn correct_token_still_forwards() {
+    // Positive control paired with the two negatives: the CHILD's own token forwards.
+    let upstream = echo_server();
+    let proxy = start(net(vec![
+        allow_cidr("127.0.0.0/8"),
+        allow_host("*.allowed.example"),
+    ]));
+    let mut t = http_connect(
+        proxy.port(),
+        &format!("127.0.0.1:{}", upstream.port()),
+        proxy.token(),
+    )
+    .unwrap();
+    assert!(
+        tunnel_forwards(&mut t, "api.allowed.example"),
+        "the correct token must forward end-to-end"
+    );
+}
+
+#[test]
+fn socks5_without_userpass_auth_is_refused() {
+    // A SOCKS client offering only no-auth (0x00) gets `0x05 0xFF` (no acceptable method)
+    // — the tokenless SOCKS path is closed just like the HTTP one.
+    let proxy = start(net(vec![allow_cidr("127.0.0.0/8")]));
+    let mut s = TcpStream::connect(("127.0.0.1", proxy.port())).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    s.write_all(&[0x05, 0x01, 0x00]).unwrap(); // greeting: only no-auth offered
+    let mut sel = [0u8; 2];
+    let _ = s.read_exact(&mut sel);
+    assert_eq!(
+        sel,
+        [0x05, 0xFF],
+        "a no-auth-only SOCKS greeting must be refused"
     );
 }


### PR DESCRIPTION
Two disjoint fast-follows on the loopback egress proxy.

Per-session token: the proxy bound 127.0.0.1 with no caller auth, so a co-resident same-user process could borrow the child's egress hole. Mint a per-run 256-bit CSPRNG bearer, require it on every handshake (HTTP Proxy-Authorization: Basic / SOCKS5 RFC-1929) before any host decision, fail closed (407 / auth-fail + drop) otherwise, deliver it via the HTTP_PROXY URL userinfo.

NODE_USE_ENV_PROXY=1: Node 24+ global fetch ignores HTTP(S)_PROXY without it; no-op on older Node.

Verified: macOS Seatbelt + Linux Landlock/seccomp real-kernel e2e; node 26 fetch routing; unit tests.

Refs #413 #414