### PR TITLE
sandbox(test): close F5 coverage gaps — procfs/move-block residuals, env D13/D14/D19, win net-per-host

### DIFF
--- a/crates/nub-sandbox/src/backend/windows.rs
+++ b/crates/nub-sandbox/src/backend/windows.rs
@@ -1317,4 +1317,77 @@ mod tests {
             vec![rule("C:/x", Effect::Deny, FsAccess::Read)]
         )));
     }
+
+    // `apply` is `#[cfg(windows)]`, so this test compiles + runs only on the Windows VM/CI.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn net_enforced_with_allow_rule_degrades_per_host() {
+        use crate::policy::{NetPolicy, NetRule, NetTarget};
+        // CUT-1: Windows per-host egress needs an AppContainer loopback exemption to reach
+        // the parent proxy — unwired — so an enforced net with ANY allow rule degrades to
+        // coarse-deny and MUST report `net-per-host` (fail-safe, not silent). The twin of
+        // the macOS `degradation_reports_lost_per_host_only_without_proxy` unit test.
+        // Asserted at the `apply` fold (the emission point) with a clean deny-all fs so no
+        // fs degradation confounds the net signal.
+        let per_host = SandboxPolicy {
+            fs: fs(Effect::Deny, vec![]),
+            net: NetPolicy {
+                enforce: true,
+                rules: vec![NetRule {
+                    target: NetTarget::Host("example.com".to_string()),
+                    effect: Effect::Allow,
+                }],
+                default_effect: Effect::Deny,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let lost = |port| {
+            apply(
+                &per_host,
+                crate::CommandSpec::new("cmd.exe"),
+                port,
+                None,
+                None,
+            )
+            .expect("apply")
+            .degradation
+            .lost
+        };
+        assert!(
+            lost(None).iter().any(|s| s == "net-per-host"),
+            "an enforced net with an allow rule must report net-per-host"
+        );
+        // Windows-specific contract: unlike macOS (where a proxy resolves per-host), the
+        // exemption is unwired, so a proxy port does NOT resolve it — it STILL degrades.
+        assert!(
+            lost(Some(9999)).iter().any(|s| s == "net-per-host"),
+            "Windows degrades per-host even WITH a proxy port (exemption unwired)"
+        );
+
+        // Positive control: a pure deny-all net (no allow rules) is fully enforced.
+        let deny_all = SandboxPolicy {
+            fs: fs(Effect::Deny, vec![]),
+            net: NetPolicy {
+                enforce: true,
+                default_effect: Effect::Deny,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let deg = apply(
+            &deny_all,
+            crate::CommandSpec::new("cmd.exe"),
+            None,
+            None,
+            None,
+        )
+        .expect("apply")
+        .degradation;
+        assert!(
+            !deg.lost.iter().any(|s| s == "net-per-host"),
+            "a pure deny-all net must not report net-per-host (got {:?})",
+            deg.lost
+        );
+    }
 }

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -622,6 +622,65 @@ fn env_extras_reject_the_old_secret_public_keys() {
     }
 }
 
+#[test]
+fn env_integer_format_leniency_is_the_rust_i64_parse() {
+    // D19: the `integer` format validates via Rust's i64 parse — it ACCEPTS a leading
+    // sign and leading zeros (`+5`, `007`) but REJECTS a radix prefix (`0x10`), a
+    // non-integer shape (`5.0`, `1_000`), and an out-of-i64-range value. Pin the exact
+    // leniency so a future validator swap can't silently widen or narrow it.
+    for good in ["5", "+5", "007", "-42", "0"] {
+        let ctx = common::ctx(true, &[("N", good)]);
+        assert!(
+            compile(&json!({ "env": { "N": "integer" } }), &ctx).is_ok(),
+            "`{good}` must validate as an integer"
+        );
+    }
+    for bad in ["0x10", "99999999999999999999999999", "5.0", "1_000"] {
+        let ctx = common::ctx(true, &[("N", bad)]);
+        assert!(
+            matches!(
+                compile(&json!({ "env": { "N": "integer" } }), &ctx),
+                Err(CompileError::Validation { .. })
+            ),
+            "`{bad}` must be rejected as an integer"
+        );
+    }
+}
+
+#[test]
+fn env_empty_array_is_strip_all_not_passthrough() {
+    // D13: `env: []` is an allowlist with ZERO allow entries → deny base, no allow =
+    // strip-all. The mental-model trap is reading an empty list as "no restrictions";
+    // it is the opposite. Enforcing, every ambient var withheld, none constructed.
+    let ctx = common::ctx(true, &[("FOO", "1"), ("BAR", "2"), ("BAZ", "3")]);
+    let p = compile(&json!({ "env": [] }), &ctx).unwrap();
+    assert!(p.env.enforce, "an explicit env axis always enforces");
+    for k in ["FOO", "BAR", "BAZ"] {
+        assert!(!p.env.constructed.contains_key(k), "{k} must be stripped");
+        assert!(
+            p.env.withheld.contains(&k.to_string()),
+            "{k} must be recorded withheld"
+        );
+    }
+}
+
+#[test]
+fn env_lone_deny_strips_everything_not_all_but_x() {
+    // D14: a lone `["!X"]` is the other trap — it reads like "allow all EXCEPT X", but
+    // an array is an allowlist and there is no allow base, so it strips EVERYTHING (X and
+    // every other var alike). To keep sibling vars you must allow them explicitly first.
+    let ctx = common::ctx(true, &[("X", "1"), ("Y", "2"), ("Z", "3")]);
+    let p = compile(&json!({ "env": ["!X"] }), &ctx).unwrap();
+    assert!(p.env.enforce);
+    for k in ["X", "Y", "Z"] {
+        assert!(
+            !p.env.constructed.contains_key(k),
+            "{k} stripped — no allow base means `!X` does not spare Y/Z"
+        );
+        assert!(p.env.withheld.contains(&k.to_string()), "{k} withheld");
+    }
+}
+
 // ── $(…) substitution + trust gate ────────────────────────────────────────────
 
 #[test]

--- a/crates/nub-sandbox/tests/linux_enforcement.rs
+++ b/crates/nub-sandbox/tests/linux_enforcement.rs
@@ -461,6 +461,109 @@ fn env_passthrough_does_not_close_proc() {
     );
 }
 
+#[test]
+fn bind_mounted_procfs_at_nonstandard_path_is_a_bounded_residual() {
+    if skip_without_landlock() {
+        return;
+    }
+    let f = fixture();
+    // `is_proc_or_sys` filters by `path.starts_with("/proc")` — a path-LITERAL check. A
+    // procfs bind-mounted OUTSIDE that prefix, inside a read-granted subtree, is not
+    // recognized as procfs and IS granted → its non-sensitive files leak. This test
+    // reproduces that residual AND its bound: real `/proc` stays blocked (the canonical
+    // filter works), and the ancestor `environ` stays closed by the ORTHOGONAL ptrace
+    // gate on `/proc/<pid>/environ`, which the alt mount does not bypass.
+    //
+    // The bind-mount needs CAP_SYS_ADMIN. Prefer a PRE-PROVISIONED mount named by
+    // `NUB_SANDBOX_ALTPROC` (a privileged setup step points it at a `mount --bind /proc`
+    // target) so the residual is exercised UNPRIVILEGED — the setting it's documented for
+    // and where the ptrace bound is crisp. Else bind-mount in-test (root). Skip cleanly
+    // (never a hollow pass) when neither yields a live procfs.
+    struct Unmount(Option<String>);
+    impl Drop for Unmount {
+        fn drop(&mut self) {
+            if let Some(p) = &self.0 {
+                let _ = std::process::Command::new("umount").arg(p).status();
+            }
+        }
+    }
+    let (altproc, _guard) = match std::env::var_os("NUB_SANDBOX_ALTPROC") {
+        Some(p) => {
+            let p = PathBuf::from(p);
+            if !p.join("version").exists() {
+                panic!("NUB_SANDBOX_ALTPROC={p:?} is not a live procfs bind mount");
+            }
+            (p, Unmount(None))
+        }
+        None => {
+            let altproc = f.root.join("altproc");
+            std::fs::create_dir_all(&altproc).unwrap();
+            let mounted = std::process::Command::new("mount")
+                .args(["--bind", "/proc", &s(&altproc)])
+                .status()
+                .map(|st| st.success())
+                .unwrap_or(false);
+            if !mounted {
+                eprintln!(
+                    "skipping: no NUB_SANDBOX_ALTPROC and cannot bind-mount /proc (needs CAP_SYS_ADMIN)"
+                );
+                return;
+            }
+            (altproc.clone(), Unmount(Some(s(&altproc))))
+        }
+    };
+
+    // Grant read of the REGULAR PARENT dir that CONTAINS the alt mount — never the mount
+    // itself (a procfs bind mount shares /proc's dentries, so granting it would grant real
+    // /proc too and dissolve the control). The subtree grant on the parent reaches down
+    // into the bind mount during path-walk — that reach is the residual. `**/altproc` is
+    // the covering shape the task documents (`{fs:["/tmp"]}` over `/tmp/altproc`).
+    let grant_dir = altproc
+        .parent()
+        .expect("alt mount has a parent dir")
+        .to_path_buf();
+    let grant = serde_json::json!({ "fs": [s(&grant_dir)] });
+
+    // Canonical `/proc` filter WORKS: real `/proc/version` is denied under read-confine.
+    let (_c, real) = f.run(grant.clone(), &[], CAT, &["/proc/version"]);
+    assert!(
+        !real.contains("Linux"),
+        "real /proc must stay blocked under read-confine (got {real:?})"
+    );
+    // RESIDUAL: the bind-mounted procfs is granted → `version` leaks at the alt path.
+    let alt_version = s(&altproc.join("version"));
+    let (_c, altver) = f.run(grant.clone(), &[], CAT, &[&alt_version]);
+    assert!(
+        altver.contains("Linux"),
+        "residual: procfs bind-mounted outside `/proc` leaks `version` (got {altver:?})"
+    );
+
+    // BOUND: the crown-jewel — the ancestor's `environ` — is read the SAME way (same
+    // `$PPID/environ` path through the alt mount) with and without the sandbox, so the
+    // only variable is confinement. Unconfined it IS readable (a same-uid /proc read;
+    // yama ptrace_scope gates ATTACH, not READ) — that is the negative control proving the
+    // vector is real. Under confinement it is NOT readable: the sandbox's isolation (the
+    // userns/credential boundary) closes the ancestor-environ read even through the alt
+    // procfs. So the path-literal residual leaks only NON-sensitive procfs (`version`),
+    // never the env — the bound.
+    let read_environ = format!("/bin/cat {}/$PPID/environ 2>/dev/null || true", s(&altproc));
+    let (_c, env_confined) = f.run(grant, &[], SH, &["-c", &read_environ]);
+    let (_c, env_control) = f.run(serde_json::json!(false), &[], SH, &["-c", &read_environ]);
+    if env_control.contains("PATH=") {
+        assert!(
+            !env_confined.contains("PATH="),
+            "bound: the ancestor environ must stay closed under confinement via the alt \
+             mount (unconfined control read it; confined must not)"
+        );
+    } else {
+        // The ambient policy (ptrace/root creds) already blocks the read, so the residual
+        // can expose nothing here regardless — no attributable bound to assert.
+        eprintln!(
+            "note: unconfined control could not read the ancestor environ; the bound holds trivially"
+        );
+    }
+}
+
 // ── env-scrub (construction) ────────────────────────────────────────────────────
 
 #[test]

--- a/crates/nub-sandbox/tests/macos_moveblock.rs
+++ b/crates/nub-sandbox/tests/macos_moveblock.rs
@@ -256,3 +256,109 @@ fn regex_dir_pinning_deny_secret_cannot_be_relocated_by_ancestor_rename() {
         "a legit write inside the pinned dir must still succeed (got {write_ok:?})"
     );
 }
+
+// ── documented OPEN residuals (LIMITATIONS.md) ──────────────────────────────────
+// The two closed shapes above (literal `(subpath)` deny + regex-dir-prefix deny) ARE
+// move-blocked and are the positive controls. The two tests below BOUND the residual:
+// a deny whose relocation-sensitive container has NO absolute literal directory prefix
+// to anchor stays relocatable by an ancestor rename. Each asserts the precise bound —
+// the leaf read-deny still holds (only the container rename escapes) — and pairs an
+// UNCONFINED control proving the relocation is a real leak. These pass by REPRODUCING
+// the residual; when a future change closes it, the `confined … must still leak`
+// assertion flips and this test must be updated to a `must NOT leak` (like the two
+// above), turning the residual's closure into a visible, deliberate edit.
+
+#[test]
+fn floating_name_subtree_deny_stays_relocatable_residual() {
+    // `!**/secrets/**` → a subtree deny whose matched dir name FLOATS (no fixed absolute
+    // anchor). `regex_literal_dir_prefix` finds no literal prefix, so no ancestor is
+    // pinned. The leaf read-deny holds, but `mv secrets elsewhere` moves the tree to a
+    // path the pattern no longer matches → readable at the new path.
+    let root = TempDir::new_in("/private/tmp").expect("tmp outside $TMPDIR");
+    let root_c = std::fs::canonicalize(root.path()).expect("canon root");
+    std::fs::create_dir(root_c.join("secrets")).expect("mkdir secrets");
+    std::fs::write(root_c.join("secrets/x.key"), MARKER).expect("plant secret");
+
+    let root_s = root_c.to_string_lossy().to_string();
+    let policy = fs_policy(vec![
+        rule("**", Effect::Allow, FsAccess::Read),
+        rule(&root_s, Effect::Allow, FsAccess::ReadWrite),
+        rule("**/secrets/**", Effect::Deny, FsAccess::Read),
+    ]);
+
+    // BOUND: the direct read at the original path IS denied (the rule's primary read-deny
+    // holds — proving the sandbox applies, so the relocation leak is a genuine residual,
+    // not a non-enforcing sandbox).
+    let direct = run_confined(&policy, &root_c, "/bin/cat secrets/x.key 2>/dev/null");
+    assert!(
+        !direct.contains(MARKER),
+        "confined: the leaf read-deny must hold at the original path (got {direct:?})"
+    );
+
+    let relocate = "/bin/mv secrets elsewhere 2>/dev/null; /bin/cat elsewhere/x.key 2>/dev/null";
+    let control = run_unconfined(&root_c, relocate);
+    let _ = std::fs::rename(root_c.join("elsewhere"), root_c.join("secrets"));
+    assert!(
+        control.contains(MARKER),
+        "neg-control: unconfined `mv secrets elsewhere; cat` must leak (got {control:?})"
+    );
+
+    // RESIDUAL: no literal anchor → the container rename is NOT blocked → the secret is
+    // readable at the relocated path. (If this stops leaking, the residual closed —
+    // update to `must NOT leak`.)
+    let confined = run_confined(&policy, &root_c, relocate);
+    assert!(
+        confined.contains(MARKER),
+        "residual: a floating-name subtree deny stays relocatable — expected the leak to \
+         reproduce (got {confined:?}); if it no longer leaks the residual closed"
+    );
+}
+
+#[test]
+fn partial_component_glob_deny_stays_relocatable_residual() {
+    // `!sec*/x.key` → a PARTIAL glob in a non-leaf component. The literal directory
+    // prefix is only `<root>` (the pin stops above `<root>/secrets`), so the container
+    // `<root>/secrets` — matched by the partial `sec*` — is below the anchor and unpinned.
+    // `mv secrets elsewhere` renames it to a name outside `sec*` → the deny no longer
+    // matches → readable.
+    let root = TempDir::new_in("/private/tmp").expect("tmp outside $TMPDIR");
+    let root_c = std::fs::canonicalize(root.path()).expect("canon root");
+    std::fs::create_dir(root_c.join("secrets")).expect("mkdir secrets");
+    std::fs::write(root_c.join("secrets/x.key"), MARKER).expect("plant secret");
+
+    let root_s = root_c.to_string_lossy().to_string();
+    let policy = fs_policy(vec![
+        rule("**", Effect::Allow, FsAccess::Read),
+        rule(&root_s, Effect::Allow, FsAccess::ReadWrite),
+        rule(
+            &format!("{root_s}/sec*/x.key"),
+            Effect::Deny,
+            FsAccess::Read,
+        ),
+    ]);
+
+    // BOUND: the direct read at the original path IS denied (the rule's primary read-deny
+    // holds — proving the sandbox applies, so the relocation leak is a genuine residual).
+    let direct = run_confined(&policy, &root_c, "/bin/cat secrets/x.key 2>/dev/null");
+    assert!(
+        !direct.contains(MARKER),
+        "confined: the leaf read-deny must hold at the original path (got {direct:?})"
+    );
+
+    let relocate = "/bin/mv secrets elsewhere 2>/dev/null; /bin/cat elsewhere/x.key 2>/dev/null";
+    let control = run_unconfined(&root_c, relocate);
+    let _ = std::fs::rename(root_c.join("elsewhere"), root_c.join("secrets"));
+    assert!(
+        control.contains(MARKER),
+        "neg-control: unconfined `mv secrets elsewhere; cat` must leak (got {control:?})"
+    );
+
+    // RESIDUAL: the `sec*`-matched container is below the literal anchor → unpinned →
+    // relocatable. (If this stops leaking, the residual closed — update to `must NOT leak`.)
+    let confined = run_confined(&policy, &root_c, relocate);
+    assert!(
+        confined.contains(MARKER),
+        "residual: a partial-component glob deny stays relocatable — expected the leak to \
+         reproduce (got {confined:?}); if it no longer leaks the residual closed"
+    );
+}


### PR DESCRIPTION
Committed tests for the last F5 sandbox coverage gaps — each with a positive control + a non-vacuous guard.

- linux: procfs bind-mounted outside `/proc` under a covering grant is readable — bounded residual (`version` leaks, ancestor `environ` stays closed under confinement, real `/proc` blocked). `is_proc_or_sys` is path-literal.
- macos: `**/secrets/**` and `sec*/x.key` move denies stay relocatable — the two documented OPEN move-block residuals.
- compiler: env integer leniency (D19), `env:[]` strip-all (D13), lone `!X` strips all (D14).
- windows: enforced-net-with-allow degrades to `net-per-host` (asserted at the `apply` fold).

Verified: linux VM (kernel 6.17, non-root, ptrace_scope=1), macOS host, windows VM.
