### PR TITLE
sandbox: .env* sub-directory-bypass fix + private/deny tmp mode

### DIFF
--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -330,6 +330,33 @@ Each is documented in code at the site noted; none is silently mis-reported.
   read-granting Windows policy reports reduced mode for the `.env*` carve while the
   read-CONFINE itself (deny everything outside the allow-set) is fully enforced.
 
+### Private tmp (`<tmp>: "private"`/`"deny"`) — macOS ENFORCED; Linux/Windows REPORTED, not enforced
+
+`{ "fs": { "<tmp>": "private" } }` gives the child a fresh per-run temp dir (its `TMPDIR`/
+`TMP`/`TEMP` point there) with the SHARED system tmp hidden; `"deny"` hides the shared tmp
+with no private dir; `"rw"`/`true` is today's shared tmp. Per-OS state:
+
+- **macOS — ENFORCED (real-kernel verified).** The Seatbelt profile denies read+write on the
+  shared tmp roots (the confstr `$TMPDIR` scratch `/private/var/folders/<uid>/T` and the
+  world-shared `/private/tmp`) after the fs grants, and — for `Private` — grants the fresh
+  per-run dir `(allow file* (subpath …))`. The deny is last-match-wins, so it hides the shared
+  tmp even under a generous `(subpath "/")` read. Verified: a file in `/private/tmp` is DENIED
+  under `<tmp>: "private"`/`"deny"` and readable without (`tests/macos_enforcement.rs`
+  `private_tmp_hides_the_shared_system_tmp` / `deny_tmp_hides_the_shared_system_tmp_too`).
+  - **Tradeoff (forced, documented):** the shared-tmp deny INCLUDES the confstr scratch that
+    the backend otherwise write-grants for the Apple toolchain (`xcrun_db`), so a from-source
+    native compile that needs it fails under `Private`/`Deny`. You cannot both hide the shared
+    tmp and keep a grant into it; the mode is opt-in, and a native-build run stays on Shared.
+- **Linux / Windows — REPORTED, not enforced (fail-safe).** The child's temp env is pointed at
+  the fresh dir best-effort, but the shared-tmp is NOT yet hidden, so the backend reports a
+  `tmp-private`/`tmp-deny` `Degradation` (reduced mode) rather than silently running the child
+  on the visible shared tmp. Fix is a MAINTAINER-DECISION follow-up: Linux needs a Landlock
+  allow-only carve that excludes the shared tmp from the read/write grants (allow-only has no
+  deny primitive); Windows needs a decision on redirecting `TEMP`/`TMP` while satisfying the
+  OS-essential temp floor the child needs to start. Wired through the IR + reported so the axis
+  is honest today; enforcement lands per-OS later. (`backend/{linux,windows}.rs` `apply`,
+  `backend::tmp_lost_axis`.)
+
 ## Linux syscall-boundary hardening (defense-in-depth, seccomp/`/dev`)
 
 Three former residuals now closed at the syscall boundary so FS/env confinement no longer

--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -316,6 +316,19 @@ Each is documented in code at the site noted; none is silently mis-reported.
   loads SIBLING DLLs from its own dir needs the front-end to supply that toolchain dir in
   the read allow-set — the engine no longer auto-widens. A self-contained build-jail
   toolchain (`node.exe`) needs nothing more. (`backend/windows.rs` `apply`.)
+- **Windows `.env*` read-deny inside a granted read subtree — REPORTED, not enforced.**
+  The default `.env*` READ-deny (injected on every read-granting fs policy — see
+  `compiler::fold::finalize_env_deny`) is a deny that lands INSIDE the granted read
+  subtree, which the AppContainer allowlist model cannot carve (an inheritable read-allow
+  ACE on the grant defeats a nested deny — the same AAP-class trap). So a `.env*` file
+  under a granted dir stays readable on Windows, and the backend HONESTLY reports it via
+  the `fs-read-deny` `Degradation` (`deny_shadows_grant` in `backend/windows.rs`), never
+  silently. macOS (Seatbelt deny-regex) and Linux (allow-only enumeration carve) enforce
+  it fully. Fix (future): the DACL inheritance-break mechanism (a PROTECTED DACL on the
+  confined root that strips inherited ACEs and re-grants only intended principals) can
+  carve the deny and remove this degradation — not yet built. Consequence today: every
+  read-granting Windows policy reports reduced mode for the `.env*` carve while the
+  read-CONFINE itself (deny everything outside the allow-set) is fully enforced.
 
 ## Linux syscall-boundary hardening (defense-in-depth, seccomp/`/dev`)
 

--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -330,19 +330,23 @@ Each is documented in code at the site noted; none is silently mis-reported.
   read-granting Windows policy reports reduced mode for the `.env*` carve while the
   read-CONFINE itself (deny everything outside the allow-set) is fully enforced.
 
-### Private tmp (`<tmp>: "private"`/`"deny"`) — macOS ENFORCED; Linux/Windows REPORTED, not enforced
+### Private tmp (`<tmp>: "rw"`/`false`) — macOS ENFORCED; Linux/Windows REPORTED, not enforced
 
-`{ "fs": { "<tmp>": "private" } }` gives the child a fresh per-run temp dir (its `TMPDIR`/
-`TMP`/`TEMP` point there) with the SHARED system tmp hidden; `"deny"` hides the shared tmp
-with no private dir; `"rw"`/`true` is today's shared tmp. Per-OS state:
+`<tmp>` is a SENTINEL that always denotes a specially-provisioned per-run PRIVATE dir — never
+the shared system tmp — so its value is a plain fs permission on that dir. `{ "fs": { "<tmp>":
+"rw" } }` (or `true`) gives the child a fresh per-run temp dir (its `TMPDIR`/`TMP`/`TEMP` point
+there) with the SHARED system tmp hidden; `false` hides the shared tmp with no private dir. The
+shared system tmp is a SEPARATE literal path — reach it only by granting `/tmp` (`{ "fs": {
+"/tmp": "r" } }`), which leaves the tmp mode unconfined. Per-OS state:
 
 - **macOS — ENFORCED (real-kernel verified).** The Seatbelt profile denies read+write on the
   shared tmp roots (the confstr `$TMPDIR` scratch `/private/var/folders/<uid>/T` and the
   world-shared `/private/tmp`) after the fs grants, and — for `Private` — grants the fresh
   per-run dir `(allow file* (subpath …))`. The deny is last-match-wins, so it hides the shared
   tmp even under a generous `(subpath "/")` read. Verified: a file in `/private/tmp` is DENIED
-  under `<tmp>: "private"`/`"deny"` and readable without (`tests/macos_enforcement.rs`
-  `private_tmp_hides_the_shared_system_tmp` / `deny_tmp_hides_the_shared_system_tmp_too`).
+  under `<tmp>: "rw"`/`false` and readable without, and reachable via a literal `/tmp` grant
+  (`tests/macos_enforcement.rs` `private_tmp_hides_the_shared_system_tmp` /
+  `deny_tmp_hides_the_shared_system_tmp_too` / `literal_tmp_path_is_the_only_way_to_the_shared_system_tmp`).
   - **Tradeoff (forced, documented):** the shared-tmp deny INCLUDES the confstr scratch that
     the backend otherwise write-grants for the Apple toolchain (`xcrun_db`), so a from-source
     native compile that needs it fails under `Private`/`Deny`. You cannot both hide the shared

--- a/crates/nub-sandbox/src/backend/linux.rs
+++ b/crates/nub-sandbox/src/backend/linux.rs
@@ -110,6 +110,7 @@ pub fn apply(
     proxy_port: Option<u16>,
     proxy_token: Option<&str>,
     ca_bundle: Option<&std::path::Path>,
+    tmp_dir: Option<&std::path::Path>,
 ) -> Result<Prepared, Degradation> {
     let mut command = base_command(&spec, policy);
     if let Some(port) = proxy_port {
@@ -119,20 +120,35 @@ pub fn apply(
     if let Some(bundle) = ca_bundle {
         super::set_ca_env(&mut command, bundle);
     }
+    // Private tmp: point the child's temp env at the fresh dir (best-effort — the
+    // Landlock allow-only carve that HIDES the shared tmp is not yet wired, so the axis
+    // is honestly reported below rather than silently under-enforced).
+    if let Some(dir) = tmp_dir {
+        super::set_tmp_env(&mut command, dir);
+    }
 
     let confine_fs = fs_confines(&policy.fs);
     let sandboxing = confine_fs || policy.net.enforce || policy.env.enforce;
-    if !sandboxing {
-        // Fully relaxed + no env scrub — nothing to enforce (mirrors macOS).
+    // A private/deny tmp is requested but this backend does not yet ENFORCE it (the
+    // Landlock allow-only carve to exclude the shared tmp is a follow-up). Report it lost
+    // (fail-safe honesty: never claim a private tmp we didn't isolate). Also forces the
+    // sandbox on so `tmp` alone still produces a reported policy.
+    let tmp_lost = super::tmp_lost_axis(policy);
+    if !sandboxing && tmp_lost.is_none() {
+        // Fully relaxed + no env scrub + shared tmp — nothing to enforce (mirrors macOS).
         return Ok(Prepared {
             command,
             degradation: Degradation::full(),
             proxy: None,
             connect_notify: None,
+            _private_tmp: None,
         });
     }
 
     let mut deg = Degradation::full();
+    if let Some(axis) = tmp_lost {
+        deg.lost.push(axis.to_string());
+    }
     let mut reason: Option<String> = None;
 
     // Resolve the net mode up front — it drives BOTH the seccomp filter and whether
@@ -262,7 +278,11 @@ pub fn apply(
         }
     }
 
-    deg.reason = reason;
+    // Prefer an existing net reason; else name the tmp gap so the warning isn't reasonless.
+    deg.reason = reason.or_else(|| {
+        tmp_lost
+            .map(|_| "private/deny tmp not yet enforced on Linux (shared tmp visible)".to_string())
+    });
 
     // ── the child-side hook: NNP → Landlock → seccomp ───────────────────────────
     // Precompute the seccomp BPF parent-side (pure byte assembly, no syscalls) so
@@ -340,6 +360,7 @@ pub fn apply(
         degradation: deg,
         proxy: None,
         connect_notify,
+        _private_tmp: None,
     })
 }
 

--- a/crates/nub-sandbox/src/backend/linux_grants.rs
+++ b/crates/nub-sandbox/src/backend/linux_grants.rs
@@ -907,6 +907,32 @@ mod tests {
     }
 
     #[test]
+    fn env_prefixed_directory_allow_does_not_grant_its_secret_contents() {
+        // THE SUB-DIRECTORY BYPASS on Landlock: a `.env*`-NAMED directory is a secret
+        // container. Naming the directory (`{ "./.env.d": "r" }`) keeps the dir LISTABLE
+        // (ReadDir) but must NOT read-grant its `.env*/**`-denied contents — the carve
+        // descends and skips the denied child. The subtree deny (band 2c) is ordered after
+        // the exact-file allows, so no re-emitted directory subtree twin can re-grant them.
+        let f = fixture();
+        let envd = f.proj.join(".env.d");
+        fs::create_dir_all(&envd).unwrap();
+        fs::write(envd.join("prod"), "DIRSECRET").unwrap();
+        let allow = f.proj.join(".env.d").to_str().unwrap().to_string();
+        let d = derive_read_grants(&f.compile(serde_json::json!({ "fs": { allow: "r" } })));
+        assert!(
+            !read_reachable(&d.grants, &envd.join("prod")),
+            "a .env.d directory allow must not read-grant the secret inside it"
+        );
+        // The directory node itself stays listable (a ReadDir, not a subtree read).
+        assert!(
+            d.grants
+                .iter()
+                .any(|g| g.kind == GrantKind::ReadDir && g.path == envd),
+            "the .env.d directory stays listable"
+        );
+    }
+
+    #[test]
     fn literal_prefix_extraction() {
         assert!(matches!(literal_prefix("**"), Prefix::WholeFs));
         assert!(matches!(literal_prefix("/"), Prefix::WholeFs));

--- a/crates/nub-sandbox/src/backend/linux_grants.rs
+++ b/crates/nub-sandbox/src/backend/linux_grants.rs
@@ -331,11 +331,26 @@ impl View {
     /// The write view: only an `Allow` carrying `ReadWrite` grants write; a
     /// read-only allow or a deny caps it. Base is always deny (the caller gates on
     /// `write_confines`, so a relaxed axis never reaches here).
+    ///
+    /// The builtin `.env*` denies are a READ deny only ("writes follow the normal
+    /// write-deny-default") — so they are DROPPED from the write projection. Keeping
+    /// them would make a depth-independent deny "reach into" every rw subtree and force
+    /// a write CARVE, which on allow-only Landlock cannot re-grant a NEW file in the
+    /// carved dir — breaking new-file creation under a broad rw grant for zero write
+    /// security (a `.env*` file's read-exfil is already closed by the read carve, which
+    /// is rename-safe: a carved dir grants only its enumerated children, so renaming
+    /// `.env` to a fresh name yields no read grant). A USER-authored `!.env` deny is
+    /// NOT builtin and still caps write normally.
     fn write(set: &FsRuleSet) -> Self {
-        Self::project(set, Effect::Deny, |r| match (r.effect, r.access) {
-            (Effect::Allow, FsAccess::ReadWrite) => Effect::Allow,
-            _ => Effect::Deny,
-        })
+        Self::project_where(
+            set,
+            Effect::Deny,
+            |r| match (r.effect, r.access) {
+                (Effect::Allow, FsAccess::ReadWrite) => Effect::Allow,
+                _ => Effect::Deny,
+            },
+            |r| !(r.effect == Effect::Deny && is_builtin_env_glob(r.matcher.as_str())),
+        )
     }
 
     /// The essential-dir carve view: an implicit-allow base (the loader dir would be
@@ -352,9 +367,23 @@ impl View {
         default_effect: Effect,
         effect_of: impl Fn(&crate::policy::FsRule) -> Effect,
     ) -> Self {
+        Self::project_where(set, default_effect, effect_of, |_| true)
+    }
+
+    /// [`project`] with an entry FILTER — an entry for which `keep` is false is dropped
+    /// from the view entirely (not merely re-effected), so it neither wins a decision
+    /// nor triggers a carve. Used by the write view to drop the read-only builtin
+    /// `.env*` denies.
+    fn project_where(
+        set: &FsRuleSet,
+        default_effect: Effect,
+        effect_of: impl Fn(&crate::policy::FsRule) -> Effect,
+        keep: impl Fn(&crate::policy::FsRule) -> bool,
+    ) -> Self {
         let entries = set
             .entries
             .iter()
+            .filter(|r| keep(r))
             .filter_map(|r| {
                 compile_glob(r.matcher.as_str()).ok().map(|m| Entry {
                     matcher: m,
@@ -470,26 +499,13 @@ fn literal_prefix(glob: &str) -> Prefix {
     }
 }
 
-/// The built-in `.env*` deny globs the compiler splices via `"..."` (must stay in
-/// sync with `compiler::defaults::SECRET_READ_GLOBS`). These are the ONLY denies the
-/// generous-`**` system-dir seeding is allowed to skip — user secrets live in
-/// home/project (always walked), not under `/usr`,`/etc`,…; a USER-authored deny is
-/// never skipped.
-const BUILTIN_ENV_DENY_GLOBS: &[&str] = &[
-    "**/.env",
-    "**/.env.*",
-    "**/.env/**",
-    "**/.env.*/**",
-    ".env",
-    ".env.*",
-    ".env/**",
-    ".env.*/**",
-    "**/.envrc",
-    ".envrc",
-];
-
+/// The built-in `.env*` deny globs the compiler injects on every read-granting policy
+/// (the shared `crate::compiler::ENV_DENY_GLOBS` — single source of truth, no drift).
+/// These are the ONLY denies the generous-`**` system-dir seeding is allowed to skip —
+/// user secrets live in home/project (always walked), not under `/usr`,`/etc`,…; a
+/// USER-authored deny is never skipped.
 fn is_builtin_env_glob(glob: &str) -> bool {
-    BUILTIN_ENV_DENY_GLOBS.contains(&glob)
+    crate::compiler::ENV_DENY_GLOBS.contains(&glob)
 }
 
 /// Whether a glob could match some path inside `dir`'s subtree. Depth-independent
@@ -831,13 +847,15 @@ mod tests {
 
     #[test]
     fn builtin_env_glob_recognition() {
-        assert!(is_builtin_env_glob("**/.env"));
-        assert!(is_builtin_env_glob(".env.*"));
-        // The subtree + direnv additions must be recognized too, or the
-        // generous-`**` seeding would treat them as user denies and over-carve
-        // every system dir (a perf regression on the generous-read path).
-        assert!(is_builtin_env_glob("**/.env/**"));
-        assert!(is_builtin_env_glob("**/.envrc"));
+        // The compiler-injected `.env*` deny set (basename-prefix, leaf + subtree) must
+        // be recognized as builtin, or the generous-`**` seeding would treat it as a
+        // user deny and over-carve every system dir (a perf regression). Kept in sync
+        // via the shared `compiler::ENV_DENY_GLOBS` const, not a local copy.
+        assert!(is_builtin_env_glob("**/.env*"));
+        assert!(is_builtin_env_glob("**/.env*/**"));
+        assert!(is_builtin_env_glob(".env*"));
+        // A user-authored deny (even a `.env`-shaped literal) is NOT the builtin set.
+        assert!(!is_builtin_env_glob("**/.env"));
         assert!(!is_builtin_env_glob("**/*.pem"));
         assert!(!is_builtin_env_glob("/etc/secret"));
     }

--- a/crates/nub-sandbox/src/backend/macos.rs
+++ b/crates/nub-sandbox/src/backend/macos.rs
@@ -75,6 +75,7 @@ pub fn apply(
     proxy_port: Option<u16>,
     proxy_token: Option<&str>,
     ca_bundle: Option<&std::path::Path>,
+    tmp_dir: Option<&std::path::Path>,
 ) -> Result<Prepared, Degradation> {
     if !needs_wrap(policy) {
         // Nothing to confine and no withheld secret to protect: the env-scrub is pure
@@ -86,10 +87,11 @@ pub fn apply(
             command: base_command(&spec, policy),
             degradation: Degradation::full(),
             proxy: None,
+            _private_tmp: None,
         });
     }
 
-    let profile = build_profile(policy, &spec, proxy_port, ca_bundle);
+    let profile = build_profile(policy, &spec, proxy_port, ca_bundle, tmp_dir);
     let mut wrapped = Command::new("sandbox-exec");
     wrapped.arg("-p").arg(&profile).arg("--");
     wrapped.arg(&spec.program).args(&spec.args);
@@ -116,11 +118,18 @@ pub fn apply(
     if let Some(bundle) = ca_bundle {
         super::set_ca_env(&mut wrapped, bundle);
     }
+    // Private tmp: point the child's TMPDIR/TMP/TEMP at the fresh per-run dir (the SBPL
+    // profile grants it rw + denies the shared system tmp). Set after env_clear so it
+    // survives the scrub. `Deny` sets nothing — the child inherits no usable tmp.
+    if let Some(dir) = tmp_dir {
+        super::set_tmp_env(&mut wrapped, dir);
+    }
 
     Ok(Prepared {
         command: wrapped,
         degradation: degradation(policy, proxy_port),
         proxy: None,
+        _private_tmp: None,
     })
 }
 
@@ -153,9 +162,16 @@ fn needs_wrap(policy: &SandboxPolicy) -> bool {
 }
 
 /// A profile is emitted for an fs or net axis to enforce. A fully relaxed fs +
-/// non-enforcing net needs no kernel confinement (on its own).
+/// non-enforcing net needs no kernel confinement (on its own) — UNLESS the tmp mode
+/// confines (`Private`/`Deny`), which is enforced by an SBPL fs deny on the shared tmp
+/// and so requires a wrap even with an otherwise-relaxed fs.
 fn needs_sandbox(policy: &SandboxPolicy) -> bool {
-    fs_confines(policy) || policy.net.enforce
+    fs_confines(policy) || tmp_confines(policy) || policy.net.enforce
+}
+
+/// Whether the tmp mode confines (anything other than the default `Shared`).
+fn tmp_confines(policy: &SandboxPolicy) -> bool {
+    policy.fs.tmp != crate::policy::TmpMode::Shared
 }
 
 /// Whether the env axis has a secret to protect cross-process. A passthrough
@@ -179,6 +195,7 @@ fn build_profile(
     spec: &CommandSpec,
     proxy_port: Option<u16>,
     ca_bundle: Option<&std::path::Path>,
+    tmp_dir: Option<&std::path::Path>,
 ) -> String {
     let mut out = String::with_capacity(MACOS_SEATBELT_BASE.len() + 2048);
     out.push_str(MACOS_SEATBELT_BASE);
@@ -187,6 +204,10 @@ fn build_profile(
     emit_env_read_closure(&mut out);
     emit_net(policy, proxy_port, &mut out);
     emit_fs(policy, spec, &mut out);
+    // Tmp-mode enforcement — emitted AFTER emit_fs so the shared-tmp deny and the
+    // private-dir grant win last-match-wins over any generous read/write. (No-op for
+    // `Shared`.)
+    emit_tmp(policy, tmp_dir, &mut out);
     // The child must READ the CA bundle to trust the minted leaves — grant it explicitly,
     // AFTER emit_fs so it survives even a deny-all fs floor (nub infra, not user config).
     if let Some(bundle) = ca_bundle {
@@ -197,6 +218,54 @@ fn build_profile(
     }
 
     out
+}
+
+/// The macOS shared-system-tmp roots hidden under `TmpMode::{Private,Deny}`: the per-user
+/// DARWIN confstr scratch (`$TMPDIR` = `/private/var/folders/<uid>/T`) and the world-shared
+/// `/private/tmp` (the `/tmp` firmlink target). Canonical (confstr dirs already resolved;
+/// `/private/tmp` is canonical). These are the only tmp surfaces a child normally reaches.
+fn shared_tmp_dirs() -> Vec<String> {
+    let mut out = confstr_scratch_dirs();
+    out.push("/private/tmp".to_string());
+    out
+}
+
+/// Emit the tmp-mode SBPL. `Shared` is a no-op (the confstr write grant that emit_fs
+/// already emitted stands). `Private`/`Deny` DENY read+write on every shared-tmp root
+/// (last-match-wins over a generous read); `Private` additionally grants the fresh
+/// per-run dir rw (`file*` subpath). Emitted after emit_fs so the shared-tmp deny is
+/// authoritative even under a `(subpath "/")` generous read.
+///
+/// PROVENANCE / tradeoff: the shared-tmp deny INCLUDES the confstr scratch that emit_fs
+/// otherwise write-grants for the Apple toolchain (`xcrun_db`) — so under Private/Deny a
+/// from-source native compile that needs that scratch will fail. This is the forced,
+/// documented consequence of hiding the shared tmp (you cannot both hide it and keep the
+/// grant into it); Private/Deny is opt-in, and a native-build user stays on Shared. See
+/// LIMITATIONS.md.
+fn emit_tmp(policy: &SandboxPolicy, tmp_dir: Option<&std::path::Path>, out: &mut String) {
+    use crate::policy::TmpMode;
+    if policy.fs.tmp == TmpMode::Shared {
+        return;
+    }
+    for dir in shared_tmp_dirs() {
+        let term = format!("(subpath \"{}\")", sbpl_escape(&dir));
+        out.push_str(&format!("(deny file-read* {term})\n"));
+        out.push_str(&format!("(deny file-write* {term})\n"));
+    }
+    if policy.fs.tmp == TmpMode::Private
+        && let Some(dir) = tmp_dir
+    {
+        // Canonicalize (the tempdir root can sit under a firmlink) so the grant matches
+        // the kernel's canonical view; grant read+write+map of the fresh dir.
+        let canon = canonicalize_including_nonexistent(dir);
+        let p = normalize_slashes(&canon.to_string_lossy());
+        if !p.is_empty() && p != "/" {
+            out.push_str(&format!(
+                "(allow file* (subpath \"{}\"))\n",
+                sbpl_escape(&p)
+            ));
+        }
+    }
 }
 
 /// The macOS env-read closure — the load-bearing security default that stops a
@@ -1282,7 +1351,7 @@ mod tests {
                 rule("**/.env", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(prof.contains("(allow file-read* (subpath \"/\"))"));
         // The `.env` deny is emitted AFTER the generous allow (last-match-wins).
         let allow_at = prof.find("(allow file-read* (subpath \"/\"))").unwrap();
@@ -1303,7 +1372,7 @@ mod tests {
             Effect::Deny,
             vec![rule("/proj", Effect::Allow, FsAccess::ReadWrite)],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(!prof.contains("(allow file-read* (subpath \"/\"))\n"));
         assert!(prof.contains("(allow file-read* (subpath \"/proj\"))"));
     }
@@ -1320,7 +1389,7 @@ mod tests {
                 rule("/proj/secret", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(prof.contains("(allow file-write* (subpath \"/proj\"))"));
         assert!(prof.contains("(deny file-write* (subpath \"/proj/ro\"))"));
         assert!(prof.contains("(deny file-write* (subpath \"/proj/secret\"))"));
@@ -1339,7 +1408,7 @@ mod tests {
                 rule("/proj", Effect::Allow, FsAccess::ReadWrite),
             ],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         let cap = prof.find("(deny file-write* (subpath \"/\"))").unwrap();
         let confstr = prof
             .find("(allow file-write* (subpath \"/private/var/folders/")
@@ -1363,7 +1432,7 @@ mod tests {
                 rule("**/.env", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         let confstr = prof
             .find("(allow file-write* (subpath \"/private/var/folders/")
             .expect("confstr temp grant present");
@@ -1392,7 +1461,7 @@ mod tests {
                 rule("/proj", Effect::Allow, FsAccess::ReadWrite),
             ],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(!prof.contains("(deny file-write-unlink (subpath \"/\"))"));
         assert!(!prof.contains("(deny file-write-create (subpath \"/\"))"));
         // And the confstr grant is still the last word on the temp dir.
@@ -1412,7 +1481,7 @@ mod tests {
                 rule("/root/proj/.env", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(prof.contains("(deny file-write-unlink (literal \"/root/proj\"))"));
         assert!(prof.contains("(deny file-write-create (literal \"/root/proj\"))"));
         assert!(prof.contains("(deny file-write-unlink (literal \"/root\"))"));
@@ -1433,7 +1502,7 @@ mod tests {
                 rule("**/.env", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(!prof.contains("(deny file-write-unlink (literal \"/root\"))"));
     }
 
@@ -1451,7 +1520,7 @@ mod tests {
                 rule("/root/secrets/*.key", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(prof.contains("(deny file-write-unlink (literal \"/root/secrets\"))"));
         assert!(prof.contains("(deny file-write-create (literal \"/root/secrets\"))"));
         assert!(prof.contains("(deny file-write-unlink (literal \"/root\"))"));
@@ -1489,7 +1558,7 @@ mod tests {
                 rule("**/secrets/**", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(!prof.contains("(deny file-write-unlink (literal \"/root\"))"));
     }
 
@@ -1504,7 +1573,7 @@ mod tests {
                 rule("/root/proj/.env", Effect::Deny, FsAccess::Read),
             ],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(!prof.contains("(deny file-write-unlink (literal \"/root/proj\"))"));
         assert!(!prof.contains("(deny file-write-unlink (literal \"/root\"))"));
     }
@@ -1517,7 +1586,7 @@ mod tests {
             Effect::Deny,
             vec![rule("/proj", Effect::Allow, FsAccess::ReadWrite)],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         if let Some(cache) = confstr_dir(libc::_CS_DARWIN_USER_CACHE_DIR) {
             let cache =
                 normalize_slashes(&canonicalize_including_nonexistent(&cache).to_string_lossy());
@@ -1536,7 +1605,7 @@ mod tests {
             Effect::Deny,
             vec![rule("/private", Effect::Allow, FsAccess::ReadWrite)],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(!prof.contains("(allow file-write* (subpath \"/private\"))"));
         assert!(is_dangerous_write_root(&MatchTerm::Subpath(
             "/private".to_string()
@@ -1574,7 +1643,7 @@ mod tests {
             default_effect: Effect::Deny,
             ..Default::default()
         };
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(prof.contains("(allow file*)"));
     }
 
@@ -1590,7 +1659,7 @@ mod tests {
             default_effect: Effect::Deny,
             ..Default::default()
         };
-        let prof = build_profile(&p, &spec(), Some(54321), None);
+        let prof = build_profile(&p, &spec(), Some(54321), None, None);
         assert!(prof.contains("(allow network* (remote ip \"localhost:54321\"))"));
         assert!(
             !prof.contains("localhost:*"),
@@ -1610,7 +1679,7 @@ mod tests {
             default_effect: Effect::Deny,
             ..Default::default()
         };
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(
             !prof.contains("(allow network*"),
             "coarse deny emits no egress carve"
@@ -1624,7 +1693,7 @@ mod tests {
             Effect::Deny,
             vec![rule("/proj", Effect::Allow, FsAccess::ReadWrite)],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(prof.contains("(allow network*)\n"));
         assert!(prof.contains("com.apple.trustd"));
     }
@@ -1687,7 +1756,7 @@ mod tests {
             Effect::Deny,
             vec![rule("/proj", Effect::Allow, FsAccess::ReadWrite)],
         );
-        let prof = build_profile(&p, &spec(), None, None);
+        let prof = build_profile(&p, &spec(), None, None, None);
         assert!(prof.contains("(deny process-info*)\n"));
         assert!(prof.contains("(allow process-info* (target self))"));
         assert!(

--- a/crates/nub-sandbox/src/backend/mod.rs
+++ b/crates/nub-sandbox/src/backend/mod.rs
@@ -150,6 +150,11 @@ pub struct Prepared {
     /// `command`.
     #[cfg(target_os = "windows")]
     pub(crate) launch: Option<windows::WindowsLaunch>,
+    /// The fresh per-run PRIVATE tmp dir (`TmpMode::Private`), owned here so it lives for
+    /// the child's whole run and is removed when `Prepared` drops (after the child exits).
+    /// `None` for `Shared`/`Deny`. Held only for its Drop — the backends read its PATH via
+    /// the value threaded into their `apply` before it moves here.
+    pub(crate) _private_tmp: Option<tempfile::TempDir>,
 }
 
 impl Prepared {
@@ -310,14 +315,22 @@ pub fn apply(policy: &SandboxPolicy, spec: CommandSpec) -> Result<Prepared, Degr
     // under a confining fs policy (an explicit read grant — nub infra, not user config).
     let ca_bundle = proxy.as_ref().and_then(|p| p.ca_bundle_path());
 
+    // Create the fresh per-run PRIVATE tmp dir up front (when the policy asks), so its
+    // path is threaded into the backend BEFORE the child profile is built — the backend
+    // grants it rw + points the child's TMPDIR at it + hides the shared system tmp. The
+    // dir is owned by `Prepared` (moved in below) so it outlives the child and is removed
+    // on drop. `None` for Shared/Deny.
+    let private_tmp = make_private_tmp(policy);
+    let tmp_dir = private_tmp.as_ref().map(|d| d.path());
+
     #[cfg(target_os = "macos")]
-    let mut prepared = macos::apply(policy, spec, proxy_port, proxy_token, ca_bundle)?;
+    let mut prepared = macos::apply(policy, spec, proxy_port, proxy_token, ca_bundle, tmp_dir)?;
     #[cfg(target_os = "linux")]
-    let mut prepared = linux::apply(policy, spec, proxy_port, proxy_token, ca_bundle)?;
+    let mut prepared = linux::apply(policy, spec, proxy_port, proxy_token, ca_bundle, tmp_dir)?;
     #[cfg(target_os = "windows")]
-    let mut prepared = windows::apply(policy, spec, proxy_port, proxy_token, ca_bundle)?;
+    let mut prepared = windows::apply(policy, spec, proxy_port, proxy_token, ca_bundle, tmp_dir)?;
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    let mut prepared = generic_apply(policy, spec, proxy_port, proxy_token, ca_bundle)?;
+    let mut prepared = generic_apply(policy, spec, proxy_port, proxy_token, ca_bundle, tmp_dir)?;
 
     // One-line stderr notice when TLS termination ACTUALLY engages — never silent, but
     // never MISLEADING either: suppress it where the backend degraded net (e.g. Windows,
@@ -334,7 +347,29 @@ pub fn apply(policy: &SandboxPolicy, spec: CommandSpec) -> Result<Prepared, Degr
     }
 
     prepared.proxy = proxy;
+    prepared._private_tmp = private_tmp;
     Ok(prepared)
+}
+
+/// Create the fresh per-run private tmp dir for `TmpMode::Private` (else `None`). A
+/// `tempfile::TempDir` under the OS default temp root, removed when it drops (after the
+/// child exits, since `Prepared` owns it). A creation failure yields `None` — the backend
+/// then reports the tmp axis unenforced (fail-safe: it never silently runs the child on
+/// the SHARED tmp while claiming a private one).
+fn make_private_tmp(policy: &SandboxPolicy) -> Option<tempfile::TempDir> {
+    if policy.fs.tmp != crate::policy::TmpMode::Private {
+        return None;
+    }
+    tempfile::Builder::new().prefix("nub-tmp-").tempdir().ok()
+}
+
+/// Point a child's temp-dir env at `dir` (all three conventions: POSIX `TMPDIR`, the
+/// `TMP`/`TEMP` pair Windows + many cross-platform tools read). Set AFTER `env_clear` so
+/// it survives an enforced env scrub.
+fn set_tmp_env(command: &mut Command, dir: &std::path::Path) {
+    for key in ["TMPDIR", "TMP", "TEMP"] {
+        command.env(key, dir);
+    }
 }
 
 /// Env-scrub-only skeleton for an OS with no wired backend. Reports fs and net as
@@ -346,6 +381,7 @@ fn generic_apply(
     proxy_port: Option<u16>,
     proxy_token: Option<&str>,
     ca_bundle: Option<&std::path::Path>,
+    tmp_dir: Option<&std::path::Path>,
 ) -> Result<Prepared, Degradation> {
     let mut command = Command::new(&spec.program);
     command.args(&spec.args);
@@ -366,6 +402,9 @@ fn generic_apply(
     if let Some(bundle) = ca_bundle {
         set_ca_env(&mut command, bundle);
     }
+    if let Some(dir) = tmp_dir {
+        set_tmp_env(&mut command, dir);
+    }
 
     // fs/net: honestly report what the skeleton does not yet enforce. The skeleton has
     // NO OS deny-layer, so even with the proxy running it cannot FORCE the child
@@ -376,6 +415,9 @@ fn generic_apply(
     }
     if policy.net.enforce {
         lost.push("net".to_string());
+    }
+    if let Some(axis) = tmp_lost_axis(policy) {
+        lost.push(axis.to_string());
     }
     let degradation = if lost.is_empty() {
         Degradation::full()
@@ -389,7 +431,24 @@ fn generic_apply(
         command,
         degradation,
         proxy: None,
+        _private_tmp: None,
     })
+}
+
+/// The degradation axis name for a backend that does NOT enforce the requested
+/// [`TmpMode`] — `tmp-private` (a private per-run tmp was requested but the shared
+/// system tmp is not hidden) / `tmp-deny` (tmp was to be denied but is not). `None` for
+/// `Shared` (nothing to enforce). A backend that DOES enforce the mode never calls this;
+/// one that doesn't pushes the axis into `lost` so the caller never mistakes an
+/// unenforced private/deny-tmp for a real one (fail-safe honesty, never silent).
+/// macOS ENFORCES the mode in its SBPL, so it never consults this (hence the cfg).
+#[cfg(not(target_os = "macos"))]
+fn tmp_lost_axis(policy: &SandboxPolicy) -> Option<&'static str> {
+    match policy.fs.tmp {
+        crate::policy::TmpMode::Shared => None,
+        crate::policy::TmpMode::Private => Some("tmp-private"),
+        crate::policy::TmpMode::Deny => Some("tmp-deny"),
+    }
 }
 
 /// Whether the fs policy actually confines anything (a non-relaxed base or any

--- a/crates/nub-sandbox/src/backend/windows.rs
+++ b/crates/nub-sandbox/src/backend/windows.rs
@@ -1368,6 +1368,7 @@ mod tests {
                 port,
                 None,
                 None,
+                None,
             )
             .expect("apply")
             .degradation
@@ -1397,6 +1398,7 @@ mod tests {
         let deg = apply(
             &deny_all,
             crate::CommandSpec::new("cmd.exe"),
+            None,
             None,
             None,
             None,

--- a/crates/nub-sandbox/src/backend/windows.rs
+++ b/crates/nub-sandbox/src/backend/windows.rs
@@ -291,15 +291,20 @@ pub(crate) fn apply(
     // threaded (CA-env set on the plain path) so trust works IF a future change wires the
     // exemption; today `net-per-host`/`net-per-request` is reported instead.
     ca_bundle: Option<&std::path::Path>,
+    // Private-tmp fresh dir. CUT-1: enforcement (redirect TEMP/TMP + hide the shared tmp
+    // without breaking the OS-essential TEMP floor) is a follow-up decision, so the env is
+    // pointed best-effort and the axis is reported lost (never a silent under-enforce).
+    tmp_dir: Option<&std::path::Path>,
 ) -> Result<super::Prepared, super::Degradation> {
     use super::{Degradation, Prepared};
 
     let confine_fs = fs_confines(&policy.fs);
     let sandboxing = confine_fs || policy.net.enforce;
+    let tmp_lost = super::tmp_lost_axis(policy);
 
     // Nothing needs the AppContainer: only env-scrub (or nothing). Use the plain
     // command path — identical contract to the mac/linux relaxed case.
-    if !sandboxing {
+    if !sandboxing && tmp_lost.is_none() {
         let mut command = std::process::Command::new(&spec.program);
         command.args(&spec.args);
         if let Some(cwd) = &spec.cwd {
@@ -317,11 +322,15 @@ pub(crate) fn apply(
         if let Some(bundle) = ca_bundle {
             super::set_ca_env(&mut command, bundle);
         }
+        if let Some(dir) = tmp_dir {
+            super::set_tmp_env(&mut command, dir);
+        }
         return Ok(Prepared {
             command,
             degradation: Degradation::full(),
             proxy: None,
             launch: None,
+            _private_tmp: None,
         });
     }
 
@@ -406,6 +415,15 @@ pub(crate) fn apply(
     // OpenProcess(PROCESS_VM_READ), run 29043151805 — so NO `env-read-ascendant`
     // Degradation is emitted. Reporting it would falsely tell a frontend Windows is
     // degraded when it isn't. See the module doc.)
+    // Private/deny tmp is not yet enforced on Windows — hiding the shared tmp while keeping
+    // the OS-essential TEMP floor the child needs to start is a follow-up decision. Report
+    // the axis lost (fail-safe honesty) rather than silently run on the shared tmp.
+    if let Some(axis) = tmp_lost {
+        deg.lost.push(axis.to_string());
+        reason.get_or_insert_with(|| {
+            "private/deny tmp not yet enforced on Windows (shared tmp visible)".to_string()
+        });
+    }
     deg.reason = reason;
 
     let launch = WindowsLaunch {
@@ -450,6 +468,7 @@ pub(crate) fn apply(
         degradation: deg,
         proxy: None,
         launch: Some(launch),
+        _private_tmp: None,
     })
 }
 

--- a/crates/nub-sandbox/src/compiler/clobber.rs
+++ b/crates/nub-sandbox/src/compiler/clobber.rs
@@ -52,7 +52,13 @@ fn coverable(v: &Value) -> Option<&str> {
     if s == "..." || s == "!..." {
         return None;
     }
-    Some(s.strip_prefix('!').unwrap_or(s))
+    let body = s.strip_prefix('!').unwrap_or(s);
+    // Any `<tmp>`-prefixed entry is a tmp-MODE sentinel (or a malformed one the fold rejects),
+    // never an fs path — excluded from path shadow analysis (it emits no rule).
+    if body.trim_start().starts_with("<tmp>") {
+        return None;
+    }
+    Some(body)
 }
 
 /// Emit one warning per DEAD entry: an entry `i` a later entry `j` fully covers.

--- a/crates/nub-sandbox/src/compiler/defaults.rs
+++ b/crates/nub-sandbox/src/compiler/defaults.rs
@@ -49,28 +49,22 @@ const SECRET_READ_RELPATHS: &[&str] = &[
     ".config/microsoft-edge",
 ];
 
-/// `.env*` / `.envrc` deny globs — legit code reads secrets via the injected
-/// process env, not by `fs.read()`-ing the file, so denying these is
-/// near-zero-breakage. Both `.env` and `.env.<x>` are denied as a leaf (`**/.env`,
-/// `**/.env.*`) AND as a SUBTREE (`**/.env/**`, `**/.env.*/**`) so a `.env/` or
-/// `.env.local/` DIRECTORY holding per-target secret files is covered, not just the
-/// single-file form. `.envrc` is direnv's secret-bearing shell config, project-local
-/// at any depth like `.env`.
+/// The default `.env*` READ-deny globs: any file whose BASENAME starts with `.env`
+/// (`.env`, `.env.local`, `.env.production`, `.envrc`, …), at any depth. These files
+/// hold the exact secrets the sandbox scrubs from the env, so reading them is denied
+/// by DEFAULT on every read-granting fs policy (not only via the `"..."` splice) —
+/// see [`env_deny_rules`] and the injection in `fold::fold_fs`. Denying reads is
+/// near-zero-breakage: legit code reads secrets via the injected process env, not by
+/// `fs.read()`-ing the file. Each basename form is denied as a LEAF (`**/.env*`) AND
+/// as a SUBTREE (`**/.env*/**`) so a `.env.d/`-style DIRECTORY of per-target secret
+/// files is covered too. The rootless twins mirror the leaf/subtree pair for a
+/// depth-0 match. Canonical candidates are absolute, so `**/.env*` is the form that
+/// actually bites; the rootless entries are kept for structural parity.
 ///
-/// MUST STAY IN SYNC with `linux_grants::BUILTIN_ENV_DENY_GLOBS` (the generous-`**`
-/// system-dir seeding skips exactly these depth-independent builtin denies).
-const SECRET_READ_GLOBS: &[&str] = &[
-    "**/.env",
-    "**/.env.*",
-    "**/.env/**",
-    "**/.env.*/**",
-    ".env",
-    ".env.*",
-    ".env/**",
-    ".env.*/**",
-    "**/.envrc",
-    ".envrc",
-];
+/// SINGLE SOURCE OF TRUTH — re-exported as `crate::compiler::ENV_DENY_GLOBS` and
+/// consumed by `linux_grants::is_builtin_env_glob` (the generous-`**` system-dir
+/// seeding skips exactly these builtin denies), so the deny set never drifts.
+pub(crate) const ENV_DENY_GLOBS: &[&str] = &["**/.env*", "**/.env*/**", ".env*", ".env*/**"];
 
 /// Secret name-word tokens matched as a case-insensitive SUBSTRING anywhere in a
 /// key (via [`word_in_substr`]). These are long/specific enough that a substring
@@ -125,8 +119,11 @@ fn segments(s: &str) -> Vec<String> {
         .collect()
 }
 
-/// Build the default fs-read DENY entries (secret paths + `.env*` globs). These
-/// are what `"..."` splices into a read ruleset. Deny access is neutral (Read).
+/// Build the default secret-PATH read DENY entries (`~/.ssh`, `~/.aws`, wallets, …).
+/// These are what `"..."` splices into a read ruleset. Deny access is neutral (Read).
+/// The depth-independent `.env*` denies are handled SEPARATELY (`env_deny_rules`,
+/// injected unconditionally on every read-granting policy) so they get the exact-file
+/// override precedence — see `fold::fold_fs`.
 pub fn secret_read_denies(homes: &Homes) -> Vec<FsRule> {
     let mut out = Vec::new();
     for rel in SECRET_READ_RELPATHS {
@@ -135,13 +132,15 @@ pub fn secret_read_denies(homes: &Homes) -> Vec<FsRule> {
             out.push(deny(g));
         }
     }
-    // `.env*` denies are depth-independent (`**/.env` matches any component
-    // ending in `.env`), so they are NOT anchored under any root — passed to the
-    // matcher verbatim.
-    for g in SECRET_READ_GLOBS {
-        out.push(deny(g.to_string()));
-    }
     out
+}
+
+/// The default `.env*` READ-deny entries ([`ENV_DENY_GLOBS`]). Depth-independent
+/// (matched by basename anywhere), so NOT anchored under any root — passed to the
+/// matcher verbatim. Injected as its own precedence band on every read-granting fs
+/// policy (`fold::fold_fs`), so a broad dir-allow can't re-expose a `.env*` file.
+pub(crate) fn env_deny_rules() -> Vec<FsRule> {
+    ENV_DENY_GLOBS.iter().map(|g| deny(g.to_string())).collect()
 }
 
 /// The generous read base entry: allow everything, then the secret denies (added
@@ -648,15 +647,11 @@ mod tests {
     }
 
     #[test]
-    fn secret_denies_include_the_new_additions() {
+    fn secret_path_denies_are_home_anchored_and_exclude_dotenv() {
         let globs: Vec<String> = secret_read_denies(&homes())
             .into_iter()
             .map(|r| r.matcher.as_str().to_string())
             .collect();
-        // Depth-independent `.env`/`.envrc` globs are verbatim (never anchored).
-        for g in ["**/.env", "**/.env/**", "**/.env.*/**", "**/.envrc"] {
-            assert!(globs.contains(&g.to_string()), "missing verbatim deny {g}");
-        }
         // Home-anchored secret files/dirs appear as subtree denies (substring match
         // tolerates OS firmlink canonicalization of the fake home prefix).
         for frag in [".gnupg", ".pgpass", ".pypirc", ".config/git/credentials"] {
@@ -664,6 +659,24 @@ mod tests {
                 globs.iter().any(|g| g.contains(frag)),
                 "missing home secret deny containing {frag}"
             );
+        }
+        // `.env*` is NOT in the secret-PATH set — it is injected separately (with the
+        // exact-file override precedence) via `env_deny_rules`, so it must not appear here.
+        assert!(
+            globs.iter().all(|g| !g.contains(".env")),
+            "`.env*` must be handled by env_deny_rules, not the secret-path splice"
+        );
+    }
+
+    #[test]
+    fn env_deny_rules_cover_dotenv_basenames_as_deny() {
+        let rules = env_deny_rules();
+        let globs: Vec<&str> = rules.iter().map(|r| r.matcher.as_str()).collect();
+        // Every rule is a Deny with the canonical inert access.
+        assert!(rules.iter().all(|r| r.effect == Effect::Deny));
+        // The leaf + subtree, depth-independent (`**/`) and rootless forms.
+        for g in ["**/.env*", "**/.env*/**", ".env*", ".env*/**"] {
+            assert!(globs.contains(&g), "env_deny_rules missing {g}");
         }
     }
 }

--- a/crates/nub-sandbox/src/compiler/defaults.rs
+++ b/crates/nub-sandbox/src/compiler/defaults.rs
@@ -53,17 +53,28 @@ const SECRET_READ_RELPATHS: &[&str] = &[
 /// (`.env`, `.env.local`, `.env.production`, `.envrc`, …), at any depth. These files
 /// hold the exact secrets the sandbox scrubs from the env, so reading them is denied
 /// by DEFAULT on every read-granting fs policy (not only via the `"..."` splice) —
-/// see [`env_deny_rules`] and the injection in `fold::fold_fs`. Denying reads is
-/// near-zero-breakage: legit code reads secrets via the injected process env, not by
-/// `fs.read()`-ing the file. Each basename form is denied as a LEAF (`**/.env*`) AND
-/// as a SUBTREE (`**/.env*/**`) so a `.env.d/`-style DIRECTORY of per-target secret
-/// files is covered too. The rootless twins mirror the leaf/subtree pair for a
-/// depth-0 match. Canonical candidates are absolute, so `**/.env*` is the form that
-/// actually bites; the rootless entries are kept for structural parity.
+/// see [`env_deny_leaf_rules`]/[`env_deny_subtree_rules`] and the injection in
+/// `fold::finalize_env_deny`. Denying reads is near-zero-breakage: legit code reads
+/// secrets via the injected process env, not by `fs.read()`-ing the file.
 ///
-/// SINGLE SOURCE OF TRUTH — re-exported as `crate::compiler::ENV_DENY_GLOBS` and
-/// consumed by `linux_grants::is_builtin_env_glob` (the generous-`**` system-dir
-/// seeding skips exactly these builtin denies), so the deny set never drifts.
+/// The set splits into a LEAF band ([`ENV_DENY_LEAF_GLOBS`] — `**/.env*`) and a
+/// SUBTREE band ([`ENV_DENY_SUBTREE_GLOBS`] — `**/.env*/**`, covering a `.env.d/`-style
+/// DIRECTORY of per-target secret files). The split is LOAD-BEARING for the exact-file
+/// override precedence: the exact-file allow re-emission is sandwiched BETWEEN the two
+/// (leaf-deny → exact-file allow → subtree-deny-LAST), so naming a `.env*` FILE grants
+/// that leaf while naming a `.env*`-prefixed DIRECTORY can never re-expose its denied
+/// CONTENTS (the subtree deny is unconditionally last). See `fold::finalize_env_deny`.
+/// The rootless twins (`.env*`) mirror each band for a depth-0 match; canonical
+/// candidates are absolute, so `**/…` is the form that bites.
+///
+/// SINGLE SOURCE OF TRUTH — the union is re-exported as `crate::compiler::ENV_DENY_GLOBS`
+/// and consumed by `linux_grants::is_builtin_env_glob` (the generous-`**` system-dir
+/// seeding skips exactly these builtin denies) + the write-view drop, so it never drifts.
+pub(crate) const ENV_DENY_LEAF_GLOBS: &[&str] = &["**/.env*", ".env*"];
+pub(crate) const ENV_DENY_SUBTREE_GLOBS: &[&str] = &["**/.env*/**", ".env*/**"];
+/// The union — the drift-guard the Linux grant derivation recognizes as builtin. Gated to
+/// its consumer's cfg (linux/test) so a macOS/Windows non-test build doesn't warn unused.
+#[cfg(any(target_os = "linux", test))]
 pub(crate) const ENV_DENY_GLOBS: &[&str] = &["**/.env*", "**/.env*/**", ".env*", ".env*/**"];
 
 /// Secret name-word tokens matched as a case-insensitive SUBSTRING anywhere in a
@@ -121,7 +132,7 @@ fn segments(s: &str) -> Vec<String> {
 
 /// Build the default secret-PATH read DENY entries (`~/.ssh`, `~/.aws`, wallets, …).
 /// These are what `"..."` splices into a read ruleset. Deny access is neutral (Read).
-/// The depth-independent `.env*` denies are handled SEPARATELY (`env_deny_rules`,
+/// The depth-independent `.env*` denies are handled SEPARATELY (the env-deny bands,
 /// injected unconditionally on every read-granting policy) so they get the exact-file
 /// override precedence — see `fold::fold_fs`.
 pub fn secret_read_denies(homes: &Homes) -> Vec<FsRule> {
@@ -135,12 +146,26 @@ pub fn secret_read_denies(homes: &Homes) -> Vec<FsRule> {
     out
 }
 
-/// The default `.env*` READ-deny entries ([`ENV_DENY_GLOBS`]). Depth-independent
-/// (matched by basename anywhere), so NOT anchored under any root — passed to the
-/// matcher verbatim. Injected as its own precedence band on every read-granting fs
-/// policy (`fold::fold_fs`), so a broad dir-allow can't re-expose a `.env*` file.
-pub(crate) fn env_deny_rules() -> Vec<FsRule> {
-    ENV_DENY_GLOBS.iter().map(|g| deny(g.to_string())).collect()
+/// The LEAF `.env*` READ-deny entries ([`ENV_DENY_LEAF_GLOBS`]) — the `.env*` file
+/// itself. Depth-independent (matched by basename anywhere), NOT anchored under any
+/// root. Injected BEFORE the exact-file allow band so a broad dir-allow can't expose a
+/// `.env*` file, yet an explicit exact-file allow can still re-grant that one leaf.
+pub(crate) fn env_deny_leaf_rules() -> Vec<FsRule> {
+    ENV_DENY_LEAF_GLOBS
+        .iter()
+        .map(|g| deny(g.to_string()))
+        .collect()
+}
+
+/// The SUBTREE `.env*` READ-deny entries ([`ENV_DENY_SUBTREE_GLOBS`]) — the CONTENTS of
+/// a `.env*`-named directory. Injected as the LAST band (after the exact-file allows),
+/// so it is unconditionally authoritative for a `.env.d/`-style secret directory: an
+/// exact-file allow re-grants only the leaf, never a directory's denied children.
+pub(crate) fn env_deny_subtree_rules() -> Vec<FsRule> {
+    ENV_DENY_SUBTREE_GLOBS
+        .iter()
+        .map(|g| deny(g.to_string()))
+        .collect()
 }
 
 /// The generous read base entry: allow everything, then the secret denies (added
@@ -661,22 +686,40 @@ mod tests {
             );
         }
         // `.env*` is NOT in the secret-PATH set — it is injected separately (with the
-        // exact-file override precedence) via `env_deny_rules`, so it must not appear here.
+        // exact-file override precedence) via the env-deny bands, so it must not appear here.
         assert!(
             globs.iter().all(|g| !g.contains(".env")),
-            "`.env*` must be handled by env_deny_rules, not the secret-path splice"
+            "`.env*` must be handled by the env-deny bands, not the secret-path splice"
         );
     }
 
     #[test]
-    fn env_deny_rules_cover_dotenv_basenames_as_deny() {
-        let rules = env_deny_rules();
-        let globs: Vec<&str> = rules.iter().map(|r| r.matcher.as_str()).collect();
+    fn env_deny_bands_split_leaf_and_subtree_as_deny() {
+        let leaf = env_deny_leaf_rules();
+        let subtree = env_deny_subtree_rules();
         // Every rule is a Deny with the canonical inert access.
-        assert!(rules.iter().all(|r| r.effect == Effect::Deny));
-        // The leaf + subtree, depth-independent (`**/`) and rootless forms.
-        for g in ["**/.env*", "**/.env*/**", ".env*", ".env*/**"] {
-            assert!(globs.contains(&g), "env_deny_rules missing {g}");
+        assert!(
+            leaf.iter()
+                .chain(&subtree)
+                .all(|r| r.effect == Effect::Deny)
+        );
+        let leaf_globs: Vec<&str> = leaf.iter().map(|r| r.matcher.as_str()).collect();
+        let subtree_globs: Vec<&str> = subtree.iter().map(|r| r.matcher.as_str()).collect();
+        // The LEAF band denies the `.env*` file itself; the SUBTREE band denies a
+        // `.env*/`-directory's contents. The split is what lets an exact-file allow sit
+        // between them (leaf-deny → allow → subtree-deny-last).
+        for g in ["**/.env*", ".env*"] {
+            assert!(leaf_globs.contains(&g), "leaf band missing {g}");
+            assert!(!leaf_globs.contains(&format!("{g}/**").as_str()));
         }
+        for g in ["**/.env*/**", ".env*/**"] {
+            assert!(subtree_globs.contains(&g), "subtree band missing {g}");
+        }
+        // The union still equals the drift-guarded ENV_DENY_GLOBS (is_builtin recognition).
+        let mut union: Vec<&str> = leaf_globs.iter().chain(&subtree_globs).copied().collect();
+        union.sort_unstable();
+        let mut all = ENV_DENY_GLOBS.to_vec();
+        all.sort_unstable();
+        assert_eq!(union, all, "leaf+subtree must equal ENV_DENY_GLOBS");
     }
 }

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -11,7 +11,7 @@ use super::{CompileCtx, CompileError};
 use crate::matcher::path::expand_symbolic;
 use crate::policy::{
     CanonGlob, CredentialBroker, Effect, EnvFormat, EnvPolicy, EnvRule, FsAccess, FsPolicy, FsRule,
-    FsRuleSet, HeaderInject, NetPolicy, NetRule, NetTarget, Secret,
+    FsRuleSet, HeaderInject, NetPolicy, NetRule, NetTarget, Secret, TmpMode,
 };
 use globset::{GlobBuilder, GlobMatcher};
 use serde_json::Value;
@@ -48,6 +48,12 @@ pub fn fold_fs(
         entries: Vec::new(),
         default_effect: Effect::Deny,
     };
+    // Throwaway-tmp mode (default Shared). A `{ "<tmp>": "private" | "deny" }` object
+    // entry sets it; the backend owns the private-dir creation + shared-tmp denial at
+    // spawn time (the per-run dir path is not knowable at compile time), so those two
+    // values set the MODE and emit no ordinary fs rule. `<tmp>: "r"|"rw"|true` stays
+    // Shared and folds as a normal path grant.
+    let mut tmp = TmpMode::Shared;
     match value {
         // `true` fully relaxes the axis; `false` fully denies it.
         Value::Bool(true) => set.default_effect = Effect::Allow,
@@ -61,7 +67,12 @@ pub fn fold_fs(
         }
         Value::Object(map) => {
             for (key, val) in map {
-                fold_fs_object_entry(key, val, ctx, &child(path, key), &mut set.entries)?;
+                let p = child(path, key);
+                if let Some(mode) = parse_tmp_mode(key, val, &p)? {
+                    tmp = mode;
+                    continue;
+                }
+                fold_fs_object_entry(key, val, ctx, &p, &mut set.entries)?;
             }
         }
         _ => {
@@ -72,24 +83,53 @@ pub fn fold_fs(
         }
     }
     finalize_env_deny(&mut set);
-    Ok(FsPolicy {
-        rules: set,
-        tmp: Default::default(),
-    })
+    Ok(FsPolicy { rules: set, tmp })
+}
+
+/// Parse a `<tmp>` object entry's tmp-MODE value. Returns `Some(mode)` only for the
+/// two mode-setting strings on the `<tmp>` key — `"private"` (a fresh per-run temp dir,
+/// shared system tmp hidden) and `"deny"` (no tmp) — which the backend enforces from
+/// the mode, so they emit no path rule. Returns `None` for every other key, and for the
+/// `<tmp>` access values (`"r"`/`"rw"`/`true`/`false`) which fold as an ordinary path
+/// grant on the shared tmp (`TmpMode::Shared`). The mode strings are REJECTED on any key
+/// other than the bare `<tmp>` root (they are not fs access values), and `<tmp>` cannot
+/// take BOTH a mode and be a path grant, so the caller treats a `Some` as consumed.
+fn parse_tmp_mode(key: &str, val: &Value, path: &str) -> Result<Option<TmpMode>, CompileError> {
+    let mode = match val {
+        Value::String(s) if s == "private" => TmpMode::Private,
+        Value::String(s) if s == "deny" => TmpMode::Deny,
+        _ => return Ok(None),
+    };
+    if key.trim() != "<tmp>" {
+        return Err(CompileError::shape(
+            path,
+            "`\"private\"`/`\"deny\"` are tmp-mode values valid ONLY on the `<tmp>` key (e.g. `{ \"<tmp>\": \"private\" }`) — a path takes \"r\"/\"rw\"/true/false",
+        ));
+    }
+    Ok(Some(mode))
 }
 
 /// Inject the default `.env*` READ-deny at a precedence a broad dir/glob allow can NOT
 /// override but an EXPLICIT exact-file allow can. `.env*` files hold the exact secrets
 /// the sandbox scrubs, so reading them is denied by default on any read-granting fs
 /// policy — including the OBJECT form, which never spliced the `"..."` secret set. The
-/// rule composes with the last-match-wins fs algebra as three ordered bands (backends
+/// rule composes with the last-match-wins fs algebra as FOUR ordered bands (backends
 /// stay pure IR replicators — every one evaluates last-match-wins over these entries):
-///   band 1 — the folded user + default entries, unchanged;
-///   band 2 — the `.env*` default deny, appended so it beats every band-1 broad/glob
-///            allow (the `["...", "./"]` footgun where a trailing dir-allow re-exposed
-///            `<proj>/.env` is closed here);
-///   band 3 — the user's EXACT-FILE `.env*` allows re-emitted so they beat band 2
-///            (informed consent: `{ "./.env.production": "r" }` grants that one file).
+///   band 1  — the folded user + default entries, unchanged;
+///   band 2a — the `.env*` LEAF deny, appended so it beats every band-1 broad/glob
+///             allow (the `["...", "./"]` footgun where a trailing dir-allow re-exposed
+///             `<proj>/.env` is closed here);
+///   band 3  — the user's EXACT-FILE `.env*` allows re-emitted so they beat band 2a
+///             (informed consent: `{ "./.env.production": "r" }` grants that one file);
+///   band 2c — the `.env*` SUBTREE deny (`**/.env*/**`), appended LAST so it is
+///             unconditionally authoritative for a `.env*`-NAMED DIRECTORY's CONTENTS.
+/// Why the subtree deny goes AFTER the exact-file allows (the sub-directory-bypass fix):
+/// a bare-path allow expands to a leaf grant + a `/**` subtree twin, and a subtree grant
+/// is a SUBPATH on macOS / a ReadSubtree on Linux — so re-emitting the twin of a
+/// `.env*`-prefixed DIRECTORY allow (`{ "./.env.d": "r" }`) would re-expose every secret
+/// under `.env.d/` if the subtree deny preceded it. Ordering the subtree deny last means
+/// an exact-file allow can only re-grant the `.env*` LEAF (a file), never a directory's
+/// denied children — closing the bypass identically on every backend (pure last-match).
 /// A band-1 entry the user later DENIES for that exact path is NOT re-emitted (its
 /// band-1 verdict is Deny), so an explicit `!./.env` stays denied.
 ///
@@ -103,11 +143,12 @@ fn finalize_env_deny(set: &mut FsRuleSet) {
     if fully_relaxed || !grants_read {
         return;
     }
-    // Compute band 3 from band 1 BEFORE appending band 2, so the survivor test reflects
-    // the user's own last-match verdict (not the deny we are about to add).
+    // Compute band 3 from band 1 BEFORE appending any deny, so the survivor test reflects
+    // the user's own last-match verdict (not the denies we are about to add).
     let band3 = exact_env_allows_surviving(set);
-    set.entries.extend(defaults::env_deny_rules());
-    set.entries.extend(band3);
+    set.entries.extend(defaults::env_deny_leaf_rules()); // band 2a: leaf deny
+    set.entries.extend(band3); // band 3: exact-file allows
+    set.entries.extend(defaults::env_deny_subtree_rules()); // band 2c: subtree deny (LAST)
 }
 
 /// The band-3 survivors: each EXACT-FILE `.env*` allow entry whose band-1 (user)

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -48,14 +48,15 @@ pub fn fold_fs(
         entries: Vec::new(),
         default_effect: Effect::Deny,
     };
-    // Throwaway-tmp mode. `<tmp>` is a SENTINEL that ALWAYS denotes the specially-provisioned
-    // per-run PRIVATE dir (never the shared system tmp), so its value is a plain fs permission
-    // on that dir: a truthy grant (`"r"`/`"rw"`/`true`) → `Private` (fresh per-run dir, shared
-    // tmp hidden); `false` → `Deny` (no tmp). The backend owns the private-dir creation +
-    // shared-tmp denial at spawn time (the per-run path is not knowable at compile time), so a
-    // `<tmp>` entry sets only the MODE and emits no ordinary fs rule. Shared system tmp is a
-    // SEPARATE literal path, reached only by granting `/tmp` — never via this sentinel; `Shared`
-    // (the default when `<tmp>` is absent) means "no tmp confinement, host tmp per fs rules".
+    // Throwaway-tmp mode. `<tmp>` (and any `<tmp>/subpath`) is a SENTINEL for the specially-
+    // provisioned per-run PRIVATE dir — a subpath maps INTO that dir, never the shared system
+    // tmp — so its value is a plain fs permission: a truthy grant (`"r"`/`"rw"`/`true`) →
+    // `Private` (fresh per-run dir, shared tmp hidden); `false` → `Deny` (no tmp). The backend
+    // owns the private-dir creation + whole-subtree grant + shared-tmp denial at spawn time (the
+    // per-run path is not knowable at compile time), so a `<tmp>`-prefixed entry sets only the
+    // MODE and emits no ordinary fs rule. Shared system tmp is a SEPARATE literal path, reached
+    // only by granting `/tmp` — never via this sentinel; `Shared` (the default when `<tmp>` is
+    // absent) means "no tmp confinement, host tmp per fs rules".
     let mut tmp = TmpMode::Shared;
     match value {
         // `true` fully relaxes the axis; `false` fully denies it.
@@ -65,6 +66,10 @@ pub fn fold_fs(
             for (i, item) in items.iter().enumerate() {
                 let p = child(path, &i.to_string());
                 let s = as_str(item, &p)?;
+                if let Some(mode) = parse_tmp_mode_array(s, &p)? {
+                    tmp = mode;
+                    continue;
+                }
                 fold_fs_array_entry(s, ctx, parent, &p, &mut set.entries)?;
             }
         }
@@ -89,16 +94,45 @@ pub fn fold_fs(
     Ok(FsPolicy { rules: set, tmp })
 }
 
-/// Fold a `<tmp>` sentinel entry into a tmp MODE. `<tmp>` ALWAYS denotes the per-run PRIVATE
-/// dir, so its value is a plain fs permission on that dir: a truthy grant (`"r"`/`"rw"`/`true`)
-/// → `Private` (provision the fresh dir + grant it rw); `false` → `Deny` (no tmp). Read-only
-/// on a fresh empty dir is degenerate, so `"r"` is treated as `"rw"` — `Private` always grants
-/// rw. Either mode's dir is backend-owned, so the caller consumes a `Some` and emits no path
-/// rule. Returns `None` for every other key (a normal path). Shared system tmp is a SEPARATE
-/// literal path (`/tmp`); `TmpMode::Shared` is unreachable through this sentinel by design.
+/// A `<tmp>` sentinel malformed by a suffix that is neither empty nor a path separator
+/// (`<tmp>*`, `<tmp>x`). Rejected loud rather than folded: `expand_symbolic` would otherwise
+/// root it at the SHARED host tmp (`<tmp>x` → `<host-tmp>/x`), the exact leak the sentinel
+/// exists to prevent — so any `<tmp>`-prefixed form that is not the sentinel is an error.
+const MALFORMED_TMP_MSG: &str = "malformed `<tmp>` sentinel — use `<tmp>` (a fresh per-run private tmp dir) or `<tmp>/subpath` (a path inside it); `<tmp>` followed by anything else is not a path into the shared system tmp — grant the literal `/tmp` for that";
+
+/// Classify a trimmed key/entry against the `<tmp>` sentinel. A `<tmp>`-prefixed string matches
+/// exactly what `expand_symbolic` roots at the host tmp (`strip_prefix("<tmp>")`), so the guard
+/// MUST cover the whole class or a form it misses leaks into the shared tmp. `<tmp>` or
+/// `<tmp>{/,\}subpath` is the sentinel; any other `<tmp>`-prefixed form is malformed.
+enum TmpKey {
+    Sentinel,
+    Malformed,
+    NotTmp,
+}
+fn classify_tmp_key(k: &str) -> TmpKey {
+    let Some(after) = k.strip_prefix("<tmp>") else {
+        return TmpKey::NotTmp;
+    };
+    if after.is_empty() || after.starts_with(['/', '\\']) {
+        TmpKey::Sentinel
+    } else {
+        TmpKey::Malformed
+    }
+}
+
+/// Fold a `<tmp>`-prefixed key into a tmp MODE. `<tmp>` (and any `<tmp>/subpath`) denotes the
+/// per-run PRIVATE dir — a subpath maps INTO that dir, never the shared system tmp — so the
+/// value is a plain fs permission on it: a truthy grant (`"r"`/`"rw"`/`true`) → `Private`
+/// (provision the fresh dir + grant it rw); `false` → `Deny` (no tmp). Read-only on a fresh
+/// empty dir is degenerate, so `"r"` is treated as `"rw"` — `Private` always grants rw. The
+/// whole private subtree is backend-granted, so a `<tmp>/x` key needs no path rule of its own;
+/// the caller consumes a `Some` and emits nothing. `None` for a normal (non-`<tmp>`) key; a
+/// malformed `<tmp>` suffix is a hard error (it would otherwise leak into the shared host tmp).
 fn parse_tmp_mode(key: &str, val: &Value, path: &str) -> Result<Option<TmpMode>, CompileError> {
-    if key.trim() != "<tmp>" {
-        return Ok(None);
+    match classify_tmp_key(key.trim()) {
+        TmpKey::NotTmp => return Ok(None),
+        TmpKey::Malformed => return Err(CompileError::shape(path, MALFORMED_TMP_MSG)),
+        TmpKey::Sentinel => {}
     }
     let mode = match val {
         Value::Bool(true) => TmpMode::Private,
@@ -112,6 +146,25 @@ fn parse_tmp_mode(key: &str, val: &Value, path: &str) -> Result<Option<TmpMode>,
         }
     };
     Ok(Some(mode))
+}
+
+/// Array-form `<tmp>` sentinel → tmp MODE. A `<tmp>` / `<tmp>/subpath` entry is `Private`
+/// (array grants are rw); a `!`-negated one is `Deny`. `None` for a normal entry; a malformed
+/// `<tmp>` suffix errors, same as the object [`parse_tmp_mode`], so the two agree on the class.
+fn parse_tmp_mode_array(entry: &str, path: &str) -> Result<Option<TmpMode>, CompileError> {
+    let (body, deny) = match entry.trim().strip_prefix('!') {
+        Some(rest) => (rest.trim_start(), true),
+        None => (entry.trim(), false),
+    };
+    match classify_tmp_key(body) {
+        TmpKey::NotTmp => Ok(None),
+        TmpKey::Malformed => Err(CompileError::shape(path, MALFORMED_TMP_MSG)),
+        TmpKey::Sentinel => Ok(Some(if deny {
+            TmpMode::Deny
+        } else {
+            TmpMode::Private
+        })),
+    }
 }
 
 /// Inject the default `.env*` READ-deny at a precedence a broad dir/glob allow can NOT

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -107,7 +107,7 @@ fn parse_tmp_mode(key: &str, val: &Value, path: &str) -> Result<Option<TmpMode>,
         _ => {
             return Err(CompileError::shape(
                 path,
-                "`<tmp>` takes an fs permission: \"rw\"/`true` (a fresh per-run private tmp dir, shared system tmp hidden) or `false` (no tmp) — for the shared system tmp, grant the literal path `/tmp`",
+                "`<tmp>` takes an fs permission: \"r\"/\"rw\"/`true` (a fresh per-run private tmp dir, shared system tmp hidden) or `false` (no tmp) — for the shared system tmp, grant the literal path `/tmp`",
             ));
         }
     };

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -48,11 +48,14 @@ pub fn fold_fs(
         entries: Vec::new(),
         default_effect: Effect::Deny,
     };
-    // Throwaway-tmp mode (default Shared). A `{ "<tmp>": "private" | "deny" }` object
-    // entry sets it; the backend owns the private-dir creation + shared-tmp denial at
-    // spawn time (the per-run dir path is not knowable at compile time), so those two
-    // values set the MODE and emit no ordinary fs rule. `<tmp>: "r"|"rw"|true` stays
-    // Shared and folds as a normal path grant.
+    // Throwaway-tmp mode. `<tmp>` is a SENTINEL that ALWAYS denotes the specially-provisioned
+    // per-run PRIVATE dir (never the shared system tmp), so its value is a plain fs permission
+    // on that dir: a truthy grant (`"r"`/`"rw"`/`true`) → `Private` (fresh per-run dir, shared
+    // tmp hidden); `false` → `Deny` (no tmp). The backend owns the private-dir creation +
+    // shared-tmp denial at spawn time (the per-run path is not knowable at compile time), so a
+    // `<tmp>` entry sets only the MODE and emits no ordinary fs rule. Shared system tmp is a
+    // SEPARATE literal path, reached only by granting `/tmp` — never via this sentinel; `Shared`
+    // (the default when `<tmp>` is absent) means "no tmp confinement, host tmp per fs rules".
     let mut tmp = TmpMode::Shared;
     match value {
         // `true` fully relaxes the axis; `false` fully denies it.
@@ -86,26 +89,28 @@ pub fn fold_fs(
     Ok(FsPolicy { rules: set, tmp })
 }
 
-/// Parse a `<tmp>` object entry's tmp-MODE value. Returns `Some(mode)` only for the
-/// two mode-setting strings on the `<tmp>` key — `"private"` (a fresh per-run temp dir,
-/// shared system tmp hidden) and `"deny"` (no tmp) — which the backend enforces from
-/// the mode, so they emit no path rule. Returns `None` for every other key, and for the
-/// `<tmp>` access values (`"r"`/`"rw"`/`true`/`false`) which fold as an ordinary path
-/// grant on the shared tmp (`TmpMode::Shared`). The mode strings are REJECTED on any key
-/// other than the bare `<tmp>` root (they are not fs access values), and `<tmp>` cannot
-/// take BOTH a mode and be a path grant, so the caller treats a `Some` as consumed.
+/// Fold a `<tmp>` sentinel entry into a tmp MODE. `<tmp>` ALWAYS denotes the per-run PRIVATE
+/// dir, so its value is a plain fs permission on that dir: a truthy grant (`"r"`/`"rw"`/`true`)
+/// → `Private` (provision the fresh dir + grant it rw); `false` → `Deny` (no tmp). Read-only
+/// on a fresh empty dir is degenerate, so `"r"` is treated as `"rw"` — `Private` always grants
+/// rw. Either mode's dir is backend-owned, so the caller consumes a `Some` and emits no path
+/// rule. Returns `None` for every other key (a normal path). Shared system tmp is a SEPARATE
+/// literal path (`/tmp`); `TmpMode::Shared` is unreachable through this sentinel by design.
 fn parse_tmp_mode(key: &str, val: &Value, path: &str) -> Result<Option<TmpMode>, CompileError> {
-    let mode = match val {
-        Value::String(s) if s == "private" => TmpMode::Private,
-        Value::String(s) if s == "deny" => TmpMode::Deny,
-        _ => return Ok(None),
-    };
     if key.trim() != "<tmp>" {
-        return Err(CompileError::shape(
-            path,
-            "`\"private\"`/`\"deny\"` are tmp-mode values valid ONLY on the `<tmp>` key (e.g. `{ \"<tmp>\": \"private\" }`) — a path takes \"r\"/\"rw\"/true/false",
-        ));
+        return Ok(None);
     }
+    let mode = match val {
+        Value::Bool(true) => TmpMode::Private,
+        Value::Bool(false) => TmpMode::Deny,
+        Value::String(s) if s == "r" || s == "rw" => TmpMode::Private,
+        _ => {
+            return Err(CompileError::shape(
+                path,
+                "`<tmp>` takes an fs permission: \"rw\"/`true` (a fresh per-run private tmp dir, shared system tmp hidden) or `false` (no tmp) — for the shared system tmp, grant the literal path `/tmp`",
+            ));
+        }
+    };
     Ok(Some(mode))
 }
 

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -71,10 +71,89 @@ pub fn fold_fs(
             ));
         }
     }
+    finalize_env_deny(&mut set);
     Ok(FsPolicy {
         rules: set,
         tmp: Default::default(),
     })
+}
+
+/// Inject the default `.env*` READ-deny at a precedence a broad dir/glob allow can NOT
+/// override but an EXPLICIT exact-file allow can. `.env*` files hold the exact secrets
+/// the sandbox scrubs, so reading them is denied by default on any read-granting fs
+/// policy — including the OBJECT form, which never spliced the `"..."` secret set. The
+/// rule composes with the last-match-wins fs algebra as three ordered bands (backends
+/// stay pure IR replicators — every one evaluates last-match-wins over these entries):
+///   band 1 — the folded user + default entries, unchanged;
+///   band 2 — the `.env*` default deny, appended so it beats every band-1 broad/glob
+///            allow (the `["...", "./"]` footgun where a trailing dir-allow re-exposed
+///            `<proj>/.env` is closed here);
+///   band 3 — the user's EXACT-FILE `.env*` allows re-emitted so they beat band 2
+///            (informed consent: `{ "./.env.production": "r" }` grants that one file).
+/// A band-1 entry the user later DENIES for that exact path is NOT re-emitted (its
+/// band-1 verdict is Deny), so an explicit `!./.env` stays denied.
+///
+/// Skipped only for a FULLY-relaxed axis (`fs: true` / `sandbox: false` — the explicit
+/// escape hatch) and for a policy that grants no reads at all (a deny-all fs), where the
+/// deny would be inert noise.
+fn finalize_env_deny(set: &mut FsRuleSet) {
+    let fully_relaxed = set.default_effect == Effect::Allow && set.entries.is_empty();
+    let grants_read = set.default_effect == Effect::Allow
+        || set.entries.iter().any(|e| e.effect == Effect::Allow);
+    if fully_relaxed || !grants_read {
+        return;
+    }
+    // Compute band 3 from band 1 BEFORE appending band 2, so the survivor test reflects
+    // the user's own last-match verdict (not the deny we are about to add).
+    let band3 = exact_env_allows_surviving(set);
+    set.entries.extend(defaults::env_deny_rules());
+    set.entries.extend(band3);
+}
+
+/// The band-3 survivors: each EXACT-FILE `.env*` allow entry whose band-1 (user)
+/// verdict for its own path is Allow. An exact-file entry is a literal path (or its
+/// `/**` subtree twin) whose basename starts with `.env`; a glob-bearing allow
+/// (`**/.env*`, `./*`) is NOT an exact-file allow and does not override the deny.
+fn exact_env_allows_surviving(set: &FsRuleSet) -> Vec<FsRule> {
+    let mut out = Vec::new();
+    for r in &set.entries {
+        if r.effect != Effect::Allow {
+            continue;
+        }
+        // The literal file identity is the matcher minus a `/**` subtree twin.
+        let literal = r
+            .matcher
+            .as_str()
+            .strip_suffix("/**")
+            .unwrap_or(r.matcher.as_str());
+        if is_glob(literal) || !basename_is_dotenv(literal) {
+            continue;
+        }
+        if band1_verdict_allows(set, literal) {
+            out.push(r.clone());
+        }
+    }
+    out
+}
+
+/// Whether a path's final component's basename starts with `.env` (the deny target).
+fn basename_is_dotenv(path: &str) -> bool {
+    path.rsplit('/').next().unwrap_or(path).starts_with(".env")
+}
+
+/// The band-1 last-match-wins verdict for the concrete `candidate` path over the set's
+/// current (pre-band-2) entries. Pure string glob matching over the canonical IR globs
+/// — deterministic, no filesystem touch (the candidate is already a canonical IR path).
+fn band1_verdict_allows(set: &FsRuleSet, candidate: &str) -> bool {
+    let mut effect = set.default_effect;
+    for r in &set.entries {
+        if let Ok(m) = crate::matcher::path::compile_glob(r.matcher.as_str())
+            && m.is_match(candidate)
+        {
+            effect = r.effect;
+        }
+    }
+    effect == Effect::Allow
 }
 
 fn fold_fs_array_entry(

--- a/crates/nub-sandbox/src/compiler/mod.rs
+++ b/crates/nub-sandbox/src/compiler/mod.rs
@@ -18,6 +18,12 @@ mod preset;
 mod resolve;
 pub mod scope;
 
+/// The default `.env*` deny globs, re-exported as the single source of truth the
+/// Linux grant derivation shares (no drift between the injected deny set and the
+/// system-dir fast-path's builtin-deny recognition). Gated to the `linux_grants`
+/// consumer's cfg so a macOS/Windows build that never references it doesn't warn.
+#[cfg(any(target_os = "linux", test))]
+pub(crate) use defaults::ENV_DENY_GLOBS;
 pub use resolve::{CommandRunner, ShellRunner};
 
 use crate::matcher::path::Homes;

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -106,6 +106,60 @@ fn tmp_mode_folds_from_the_tmp_key() {
         compile(&json!({ "fs": { "<tmp>": "private" } }), &ctx),
         Err(CompileError::Shape { .. })
     ));
+
+    // A `<tmp>/subpath` key maps INTO the private dir (→ Private mode), and — the fix — emits
+    // NO ordinary fs rule pointing at the shared host tmp (`/tmp`).
+    let sub = compile(&json!({ "fs": { "./": "r", "<tmp>/scratch": "rw" } }), &ctx).unwrap();
+    assert_eq!(sub.fs.tmp, TmpMode::Private);
+    assert!(
+        sub.fs
+            .rules
+            .entries
+            .iter()
+            .all(|e| !e.matcher.as_str().contains("/tmp")),
+        "`<tmp>/scratch` must not leak an fs rule into the shared host tmp"
+    );
+    // Array form: a `<tmp>` / `<tmp>/…` entry sets Private; a `!`-negated one sets Deny.
+    assert_eq!(
+        compile(&json!({ "fs": ["./", "<tmp>/scratch"] }), &ctx)
+            .unwrap()
+            .fs
+            .tmp,
+        TmpMode::Private
+    );
+    assert_eq!(
+        compile(&json!({ "fs": ["./", "!<tmp>"] }), &ctx)
+            .unwrap()
+            .fs
+            .tmp,
+        TmpMode::Deny
+    );
+    // A backslash subpath is a subpath too (path-separator), → Private.
+    assert_eq!(
+        compile(&json!({ "fs": { "<tmp>\\scratch": "rw" } }), &ctx)
+            .unwrap()
+            .fs
+            .tmp,
+        TmpMode::Private
+    );
+    // A `<tmp>` prefix with a NON-separator suffix (`<tmp>*`, `<tmp>x`) would otherwise leak
+    // into the shared host tmp via `expand_symbolic`, so it is a hard shape error — object AND
+    // array form. (`<tmpx>`, having no `<tmp>` prefix, stays a normal literal path.)
+    for bad in [
+        json!({ "fs": { "<tmp>*": "rw" } }),
+        json!({ "fs": { "<tmp>x": "r" } }),
+    ] {
+        assert!(
+            matches!(compile(&bad, &ctx), Err(CompileError::Shape { .. })),
+            "malformed `<tmp>` suffix must be a shape error, not a shared-tmp leak"
+        );
+    }
+    assert!(matches!(
+        compile(&json!({ "fs": ["<tmp>*"] }), &ctx),
+        Err(CompileError::Shape { .. })
+    ));
+    // `<tmpx>` is NOT a `<tmp>` sentinel — a normal path, folds without error.
+    assert!(compile(&json!({ "fs": { "<tmpx>": "r" } }), &ctx).is_ok());
 }
 
 #[test]

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -69,29 +69,41 @@ fn absent_granular_axis_floors_complete_statement() {
 #[test]
 fn tmp_mode_folds_from_the_tmp_key() {
     let ctx = common::ctx(true, &[]);
-    // `<tmp>: "private"` / `"deny"` set the TmpMode and emit NO ordinary fs rule (the
-    // backend owns the per-run dir + shared-tmp denial). The rest of the fs axis folds
-    // normally alongside.
-    let p = compile(&json!({ "fs": { "./": "r", "<tmp>": "private" } }), &ctx).unwrap();
+    // `<tmp>` is the private-dir sentinel: a truthy permission → Private (fresh per-run dir),
+    // `false` → Deny. Either sets the TmpMode and emits NO ordinary fs rule (the backend owns
+    // the per-run dir + shared-tmp denial). The rest of the fs axis folds normally alongside.
+    let p = compile(&json!({ "fs": { "./": "r", "<tmp>": "rw" } }), &ctx).unwrap();
     assert_eq!(p.fs.tmp, TmpMode::Private);
-    let p = compile(&json!({ "fs": { "<tmp>": "deny" } }), &ctx).unwrap();
-    assert_eq!(p.fs.tmp, TmpMode::Deny);
-    // The default and the access-value forms stay Shared (a `<tmp>: "rw"` is a plain
-    // shared-tmp path grant, not a mode).
+    assert_eq!(
+        compile(&json!({ "fs": { "<tmp>": true } }), &ctx)
+            .unwrap()
+            .fs
+            .tmp,
+        TmpMode::Private
+    );
+    // `"r"` on a fresh empty dir is degenerate, so it too maps to Private (rw).
+    assert_eq!(
+        compile(&json!({ "fs": { "<tmp>": "r" } }), &ctx)
+            .unwrap()
+            .fs
+            .tmp,
+        TmpMode::Private
+    );
+    assert_eq!(
+        compile(&json!({ "fs": { "<tmp>": false } }), &ctx)
+            .unwrap()
+            .fs
+            .tmp,
+        TmpMode::Deny
+    );
+    // Absent `<tmp>` stays Shared (no tmp confinement); Shared is unreachable via the sentinel.
     assert_eq!(
         compile(&json!({ "fs": ["./"] }), &ctx).unwrap().fs.tmp,
         TmpMode::Shared
     );
-    assert_eq!(
-        compile(&json!({ "fs": { "<tmp>": "rw" } }), &ctx)
-            .unwrap()
-            .fs
-            .tmp,
-        TmpMode::Shared
-    );
-    // The mode strings are rejected on any key other than the bare `<tmp>` root.
+    // A bogus value on `<tmp>` (including the dropped `"private"`/`"deny"` keywords) is rejected.
     assert!(matches!(
-        compile(&json!({ "fs": { "./data": "private" } }), &ctx),
+        compile(&json!({ "fs": { "<tmp>": "private" } }), &ctx),
         Err(CompileError::Shape { .. })
     ));
 }

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use nub_sandbox::compiler::{CompileError, compile};
-use nub_sandbox::policy::{Effect, EnvFormat, Inspection, NetTarget};
+use nub_sandbox::policy::{Effect, EnvFormat, Inspection, NetTarget, TmpMode};
 use serde_json::json;
 
 // ── wrapper trichotomy ────────────────────────────────────────────────────────
@@ -64,6 +64,36 @@ fn absent_granular_axis_floors_complete_statement() {
         p.env.withheld.contains(&"ANYTHING".to_string()),
         "the stripped ambient var is recorded withheld"
     );
+}
+
+#[test]
+fn tmp_mode_folds_from_the_tmp_key() {
+    let ctx = common::ctx(true, &[]);
+    // `<tmp>: "private"` / `"deny"` set the TmpMode and emit NO ordinary fs rule (the
+    // backend owns the per-run dir + shared-tmp denial). The rest of the fs axis folds
+    // normally alongside.
+    let p = compile(&json!({ "fs": { "./": "r", "<tmp>": "private" } }), &ctx).unwrap();
+    assert_eq!(p.fs.tmp, TmpMode::Private);
+    let p = compile(&json!({ "fs": { "<tmp>": "deny" } }), &ctx).unwrap();
+    assert_eq!(p.fs.tmp, TmpMode::Deny);
+    // The default and the access-value forms stay Shared (a `<tmp>: "rw"` is a plain
+    // shared-tmp path grant, not a mode).
+    assert_eq!(
+        compile(&json!({ "fs": ["./"] }), &ctx).unwrap().fs.tmp,
+        TmpMode::Shared
+    );
+    assert_eq!(
+        compile(&json!({ "fs": { "<tmp>": "rw" } }), &ctx)
+            .unwrap()
+            .fs
+            .tmp,
+        TmpMode::Shared
+    );
+    // The mode strings are rejected on any key other than the bare `<tmp>` root.
+    assert!(matches!(
+        compile(&json!({ "fs": { "./data": "private" } }), &ctx),
+        Err(CompileError::Shape { .. })
+    ));
 }
 
 #[test]

--- a/crates/nub-sandbox/tests/ir.rs
+++ b/crates/nub-sandbox/tests/ir.rs
@@ -138,14 +138,25 @@ fn apply_degradation_reflects_backend_capability() {
             );
         }
     }
-    // Windows (AppContainer) has a real backend too: a literal read-confine grant
-    // (`./x`) + coarse deny-all net (`net: false`, no Allow rules) are both fully
-    // expressible, so nothing is degraded.
+    // Windows (AppContainer) enforces the literal read-confine grant (`./x`) + coarse
+    // deny-all net fully — BUT the default `.env*` READ-deny is now injected on every
+    // read-granting policy, and a deny landing INSIDE a granted read subtree can't be
+    // carved under the AppContainer allowlist model (an inheritable read-allow defeats
+    // it — the AAP-class trap). So the backend honestly reports `fs-read-deny` (the
+    // `.env*`-inside-grant residual), never silently leaving it unenforced. Net stays
+    // fully enforced. (A future DACL inheritance-break mechanism would carve it and
+    // remove this degradation.)
     #[cfg(target_os = "windows")]
-    assert!(
-        d.is_full(),
-        "Windows AppContainer enforces literal read-confine + coarse deny-all net"
-    );
+    {
+        assert!(
+            d.lost.contains(&"fs-read-deny".to_string()),
+            "Windows honestly reports the un-carvable `.env*`-inside-grant deny"
+        );
+        assert!(
+            !d.lost.iter().any(|l| l.starts_with("net")),
+            "coarse deny-all net is still fully enforced"
+        );
+    }
     // Any OS with no wired backend still runs the env-scrub skeleton, which honestly
     // reports fs + net as not-enforced.
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]

--- a/crates/nub-sandbox/tests/macos_enforcement.rs
+++ b/crates/nub-sandbox/tests/macos_enforcement.rs
@@ -286,16 +286,16 @@ fn private_tmp_hides_the_shared_system_tmp() {
     let _c = Cleanup(shared.clone());
     let f = fixture();
 
-    // A generous read that WOULD expose the shared-tmp file, plus `<tmp>: "private"`. The
+    // A generous read that WOULD expose the shared-tmp file, plus `<tmp>: "rw"` (private). The
     // private-tmp deny is emitted after the generous read (last-match-wins), so the kernel
     // must DENY the shared-tmp file even though `/` is otherwise readable.
-    let private = serde_json::json!({ "fs": { "/": "r", "<tmp>": "private" } });
+    let private = serde_json::json!({ "fs": { "/": "r", "<tmp>": "rw" } });
     assert!(
         !f.allowed(private, CAT, &[&s(&shared)]),
         "private tmp must hide the shared /private/tmp"
     );
-    // NEG-CONTROL: the SAME generous read WITHOUT private tmp reads the shared-tmp file —
-    // proving the deny is the `<tmp>: private` confinement, not the fixture.
+    // NEG-CONTROL: the SAME generous read WITHOUT the private tmp reads the shared-tmp file —
+    // proving the deny is the `<tmp>: "rw"` private confinement, not the fixture.
     assert!(
         f.allowed(
             serde_json::json!({ "fs": { "/": "r" } }),
@@ -321,14 +321,42 @@ fn deny_tmp_hides_the_shared_system_tmp_too() {
     }
     let _c = Cleanup(shared.clone());
     let f = fixture();
-    // `<tmp>: "deny"` also hides the shared system tmp (no private dir is minted).
+    // `<tmp>: false` also hides the shared system tmp (no private dir is minted).
     assert!(
         !f.allowed(
-            serde_json::json!({ "fs": { "/": "r", "<tmp>": "deny" } }),
+            serde_json::json!({ "fs": { "/": "r", "<tmp>": false } }),
             CAT,
             &[&s(&shared)]
         ),
         "deny tmp must hide the shared /private/tmp"
+    );
+}
+
+#[test]
+fn literal_tmp_path_is_the_only_way_to_the_shared_system_tmp() {
+    // The clarified model: the `<tmp>` sentinel NEVER grants the shared system tmp — the only
+    // way to reach it is granting the literal path `/tmp` (canonicalizes to `/private/tmp`),
+    // which leaves the tmp mode Shared (no confinement).
+    let shared = PathBuf::from(format!(
+        "/private/tmp/nub-tmptest-lit-{}.secret",
+        std::process::id()
+    ));
+    fs::write(&shared, "SHAREDTMPSECRET").unwrap();
+    struct Cleanup(PathBuf);
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
+    let _c = Cleanup(shared.clone());
+    let f = fixture();
+    assert!(
+        f.allowed(
+            serde_json::json!({ "fs": { "/tmp": "r" } }),
+            CAT,
+            &[&s(&shared)]
+        ),
+        "a literal `/tmp` read grant reaches the shared system tmp"
     );
 }
 

--- a/crates/nub-sandbox/tests/macos_enforcement.rs
+++ b/crates/nub-sandbox/tests/macos_enforcement.rs
@@ -193,6 +193,56 @@ fn env_files_denied_under_generous_read() {
     );
 }
 
+// ── fs .env deny under an OBJECT-form allowlist + exact-file override (Feature 2) ─
+
+#[test]
+fn env_files_denied_under_object_form_allowlist() {
+    let f = fixture();
+    // The core Feature-2 gap: an object-form `{ "./": "r" }` grants the project but the
+    // kernel must DENY `<proj>/.env` — before the fix the object form spliced no secret
+    // set, so the LowBox/Seatbelt profile left `.env` readable inside the granted subtree.
+    let confine = serde_json::json!({ "fs": { "./": "r" } });
+    assert!(
+        f.allowed(confine.clone(), CAT, &[&s(&f.proj.join("pub.txt"))]),
+        "project file readable under object-form allow"
+    );
+    assert!(
+        !f.allowed(confine.clone(), CAT, &[&s(&f.proj.join(".env"))]),
+        ".env denied under an object-form dir allow"
+    );
+    assert!(
+        !f.allowed(confine.clone(), CAT, &[&s(&f.proj.join("sub/.env"))]),
+        "nested .env denied under an object-form dir allow"
+    );
+    // negative control — relaxed fs reads .env fine (the deny is the confinement, not the fixture):
+    assert!(
+        f.allowed(
+            serde_json::json!({ "fs": true }),
+            CAT,
+            &[&s(&f.proj.join(".env"))]
+        ),
+        "neg-control: relaxed fs reads .env"
+    );
+}
+
+#[test]
+fn exact_file_allow_grants_that_dotenv_but_siblings_stay_denied() {
+    let f = fixture();
+    fs::write(f.proj.join(".env.production"), "PRODVALUE").unwrap();
+    // Informed consent: naming the exact file grants reading it, while a sibling `.env`
+    // the user did NOT name stays denied — the kernel enforces both, proving the
+    // band-3 exact-file re-emission beats the `.env*` deny and nothing else does.
+    let confine = serde_json::json!({ "fs": { "./": "r", "./.env.production": "r" } });
+    assert!(
+        f.allowed(confine.clone(), CAT, &[&s(&f.proj.join(".env.production"))]),
+        "the explicitly-allowed .env.production is readable"
+    );
+    assert!(
+        !f.allowed(confine, CAT, &[&s(&f.proj.join(".env"))]),
+        "a sibling .env the user did not name stays denied"
+    );
+}
+
 // ── new secret deny-set additions (A2): each denied under a generous read ──────
 
 #[test]

--- a/crates/nub-sandbox/tests/macos_enforcement.rs
+++ b/crates/nub-sandbox/tests/macos_enforcement.rs
@@ -243,6 +243,95 @@ fn exact_file_allow_grants_that_dotenv_but_siblings_stay_denied() {
     );
 }
 
+#[test]
+fn env_prefixed_directory_allow_does_not_expose_its_secret_contents() {
+    // THE SUB-DIRECTORY BYPASS regression guard (real kernel). A `.env*`-NAMED directory
+    // is a secret container (`.env.d/` per-target secret files); the `.env*/**` subtree
+    // deny covers its contents. Naming the DIRECTORY (`{ "./.env.d": "r" }`) must NOT
+    // re-expose those contents — an exact-file allow re-grants only a `.env*` LEAF, never
+    // a directory's denied children (the subtree deny is ordered LAST). On macOS a bare
+    // path becomes a `(subpath …)` grant covering descendants, so a naive re-emission of
+    // the directory's subtree twin WOULD leak here — this asserts the kernel denies it.
+    let f = fixture();
+    fs::create_dir_all(f.proj.join(".env.d")).unwrap();
+    fs::write(f.proj.join(".env.d/prod"), "DIRSECRET").unwrap();
+    let confine = serde_json::json!({ "fs": { "./": "r", "./.env.d": "r" } });
+    assert!(
+        !f.allowed(confine.clone(), CAT, &[&s(&f.proj.join(".env.d/prod"))]),
+        "a .env.d directory allow must NOT expose the secret file inside it"
+    );
+    // The project's own non-secret file is still readable — the deny is surgical.
+    assert!(
+        f.allowed(confine, CAT, &[&s(&f.proj.join("pub.txt"))]),
+        "neg-control: a normal project file stays readable"
+    );
+}
+
+// ── private tmp (TmpMode::Private) — shared system tmp hidden (real kernel) ─────
+
+#[test]
+fn private_tmp_hides_the_shared_system_tmp() {
+    // A file living in the SHARED system tmp (`/private/tmp`, the `/tmp` firmlink target).
+    let shared = PathBuf::from(format!(
+        "/private/tmp/nub-tmptest-{}.secret",
+        std::process::id()
+    ));
+    fs::write(&shared, "SHAREDTMPSECRET").unwrap();
+    struct Cleanup(PathBuf);
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
+    let _c = Cleanup(shared.clone());
+    let f = fixture();
+
+    // A generous read that WOULD expose the shared-tmp file, plus `<tmp>: "private"`. The
+    // private-tmp deny is emitted after the generous read (last-match-wins), so the kernel
+    // must DENY the shared-tmp file even though `/` is otherwise readable.
+    let private = serde_json::json!({ "fs": { "/": "r", "<tmp>": "private" } });
+    assert!(
+        !f.allowed(private, CAT, &[&s(&shared)]),
+        "private tmp must hide the shared /private/tmp"
+    );
+    // NEG-CONTROL: the SAME generous read WITHOUT private tmp reads the shared-tmp file —
+    // proving the deny is the `<tmp>: private` confinement, not the fixture.
+    assert!(
+        f.allowed(
+            serde_json::json!({ "fs": { "/": "r" } }),
+            CAT,
+            &[&s(&shared)]
+        ),
+        "neg-control: a plain generous read reads the shared-tmp file"
+    );
+}
+
+#[test]
+fn deny_tmp_hides_the_shared_system_tmp_too() {
+    let shared = PathBuf::from(format!(
+        "/private/tmp/nub-tmptest-deny-{}.secret",
+        std::process::id()
+    ));
+    fs::write(&shared, "SHAREDTMPSECRET").unwrap();
+    struct Cleanup(PathBuf);
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
+    let _c = Cleanup(shared.clone());
+    let f = fixture();
+    // `<tmp>: "deny"` also hides the shared system tmp (no private dir is minted).
+    assert!(
+        !f.allowed(
+            serde_json::json!({ "fs": { "/": "r", "<tmp>": "deny" } }),
+            CAT,
+            &[&s(&shared)]
+        ),
+        "deny tmp must hide the shared /private/tmp"
+    );
+}
+
 // ── new secret deny-set additions (A2): each denied under a generous read ──────
 
 #[test]

--- a/crates/nub-sandbox/tests/macos_enforcement.rs
+++ b/crates/nub-sandbox/tests/macos_enforcement.rs
@@ -307,6 +307,34 @@ fn private_tmp_hides_the_shared_system_tmp() {
 }
 
 #[test]
+fn tmp_subpath_maps_into_the_private_dir_not_the_shared_tmp() {
+    // A `<tmp>/scratch` key is the private-dir sentinel too (maps INTO the private dir), so it
+    // sets Private and hides the shared system tmp exactly like a bare `<tmp>: "rw"` — it must
+    // NOT resolve to a grant on the shared host tmp.
+    let shared = PathBuf::from(format!(
+        "/private/tmp/nub-tmptest-sub-{}.secret",
+        std::process::id()
+    ));
+    fs::write(&shared, "SHAREDTMPSECRET").unwrap();
+    struct Cleanup(PathBuf);
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
+    let _c = Cleanup(shared.clone());
+    let f = fixture();
+    assert!(
+        !f.allowed(
+            serde_json::json!({ "fs": { "/": "r", "<tmp>/scratch": "rw" } }),
+            CAT,
+            &[&s(&shared)]
+        ),
+        "`<tmp>/scratch` must map into the private dir and hide the shared /private/tmp"
+    );
+}
+
+#[test]
 fn deny_tmp_hides_the_shared_system_tmp_too() {
     let shared = PathBuf::from(format!(
         "/private/tmp/nub-tmptest-deny-{}.secret",

--- a/crates/nub-sandbox/tests/matcher.rs
+++ b/crates/nub-sandbox/tests/matcher.rs
@@ -345,3 +345,122 @@ fn generous_read_still_denies_dotenv_and_ssh() {
         "ssh denied"
     );
 }
+
+// ── the `.env*` default-deny (Feature 2) ──────────────────────────────────────
+// Reads of any `.env*`-basename file are denied by DEFAULT on every read-granting
+// fs policy — including the OBJECT form (which never spliced `"..."`) — and the deny
+// beats a broad dir-allow regardless of order, yet yields to an EXPLICIT exact-file
+// allow (informed consent). Verified at the compiler+matcher (engine-pure) layer,
+// the shared cross-backend contract.
+
+fn read_denied(surface: serde_json::Value, path: &str) -> bool {
+    use nub_sandbox::compiler::compile;
+    let ctx = common::ctx(true, &[]);
+    let policy = compile(&surface, &ctx).unwrap();
+    let m = PathMatcher::new(&policy.fs.rules);
+    matches!(
+        m.decide(&common::homes().project.join(path)).effect,
+        Effect::Deny
+    )
+}
+
+#[test]
+fn object_form_dir_allow_still_denies_dotenv() {
+    use serde_json::json;
+    // The core gap: an object-form `{ "./": "r" }` grants the project but must NOT
+    // expose `<proj>/.env` — the object form never spliced the secret set, so before
+    // Feature 2 this leaked. `src/index.ts` stays readable.
+    assert!(read_denied(json!({ "fs": { "./": "r" } }), ".env"));
+    assert!(read_denied(
+        json!({ "fs": { "./": "r" } }),
+        "sub/.env.local"
+    ));
+    assert!(!read_denied(json!({ "fs": { "./": "r" } }), "src/index.ts"));
+    // Array-form allowlist, same guarantee.
+    assert!(read_denied(json!({ "fs": ["./"] }), ".env"));
+}
+
+#[test]
+fn dotenv_deny_beats_a_trailing_broad_allow() {
+    use serde_json::json;
+    // The `["...", "./"]` footgun: a trailing dir-allow re-matches `<proj>/.env` last,
+    // so under pure last-match it would re-expose it. The `.env*` deny is injected AFTER
+    // every band-1 rule, so it wins regardless of authored order.
+    assert!(read_denied(json!({ "fs": ["...", "./"] }), ".env"));
+    assert!(read_denied(json!({ "fs": ["./", "..."] }), ".env"));
+}
+
+#[test]
+fn exact_file_allow_overrides_the_dotenv_deny_but_a_dir_allow_does_not() {
+    use nub_sandbox::compiler::compile;
+    use nub_sandbox::policy::FsAccess;
+    use serde_json::json;
+    // Naming the exact file grants it (informed consent); a sibling `.env` stays denied.
+    let ctx = common::ctx(true, &[]);
+    let policy = compile(
+        &json!({ "fs": { "./": "r", "./.env.production": "r" } }),
+        &ctx,
+    )
+    .unwrap();
+    let m = PathMatcher::new(&policy.fs.rules);
+    let proj = common::homes().project;
+    let d = m.decide(&proj.join(".env.production"));
+    assert!(
+        matches!(d.effect, Effect::Allow) && matches!(d.access, FsAccess::Read),
+        "the exact-file allow grants <proj>/.env.production"
+    );
+    assert!(
+        matches!(m.decide(&proj.join(".env")).effect, Effect::Deny),
+        "a sibling .env the user did NOT name stays denied"
+    );
+    // A GLOB allow of the same shape is NOT an exact-file allow and does NOT override.
+    assert!(read_denied(
+        json!({ "fs": { "./": "r", "./.env*": "r" } }),
+        ".env"
+    ));
+    // An explicit exact-path DENY after an exact allow stays denied (user's last word).
+    assert!(read_denied(
+        json!({ "fs": ["./", "./.env", "!./.env"] }),
+        ".env"
+    ));
+}
+
+#[test]
+fn fully_relaxed_fs_still_reads_dotenv_escape_hatch() {
+    use nub_sandbox::compiler::compile;
+    use serde_json::json;
+    // `fs: true` / `sandbox: false` is the explicit total-relaxation escape hatch — the
+    // default `.env*` deny does NOT apply to it (it is not a directory allowlist).
+    for surface in [json!({ "fs": true }), json!(false)] {
+        let ctx = common::ctx(true, &[]);
+        let policy = compile(&surface, &ctx).unwrap();
+        let m = PathMatcher::new(&policy.fs.rules);
+        assert!(
+            matches!(
+                m.decide(&common::homes().project.join(".env")).effect,
+                Effect::Allow
+            ),
+            "relaxed fs reads .env ({surface})"
+        );
+    }
+}
+
+#[test]
+fn dotenv_deny_matches_the_env_basename_prefix_at_any_depth() {
+    use serde_json::json;
+    // Basename-prefix `.env`: the dotfile, dotted variants, direnv's `.envrc`, and a
+    // `.env.d/` directory's contents — all denied, at the root and nested.
+    for p in [
+        ".env",
+        ".env.local",
+        ".env.production",
+        ".envrc",
+        "sub/.env",
+        "packages/app/.env.test",
+        ".env.d/secret",
+    ] {
+        assert!(read_denied(json!({ "fs": { "./": "r" } }), p), "{p} denied");
+    }
+    // A non-`.env`-prefixed dotfile is NOT swept.
+    assert!(!read_denied(json!({ "fs": { "./": "r" } }), ".gitignore"));
+}

--- a/crates/nub-sandbox/tests/matcher.rs
+++ b/crates/nub-sandbox/tests/matcher.rs
@@ -464,3 +464,40 @@ fn dotenv_deny_matches_the_env_basename_prefix_at_any_depth() {
     // A non-`.env`-prefixed dotfile is NOT swept.
     assert!(!read_denied(json!({ "fs": { "./": "r" } }), ".gitignore"));
 }
+
+#[test]
+fn env_prefixed_directory_allow_does_not_reexpose_its_contents() {
+    use serde_json::json;
+    // THE SUB-DIRECTORY BYPASS: a `.env*`-NAMED directory is a secret container, and its
+    // contents are covered by the `.env*/**` subtree deny. An exact allow of the DIRECTORY
+    // (or its glob subtree) must NOT re-expose those contents — only a `.env*` LEAF file is
+    // re-grantable (the subtree deny is ordered after the exact-file allows). This is the
+    // regression guard for the band-3 subtree-twin over-grant.
+    for (surface, leaked) in [
+        (json!({ "fs": { "./.env.d": "r" } }), ".env.d/prod"),
+        (json!({ "fs": { "./.env.d": "r" } }), ".env.d/nested/deep"),
+        (
+            json!({ "fs": { "./.environments": "r" } }),
+            ".environments/prod.env",
+        ),
+        // A glob subtree allow of a `.env*` dir is a glob (not an exact FILE) → no override.
+        (json!({ "fs": { "./.env.d/**": "r" } }), ".env.d/prod"),
+        // array (rw) directory allow — same guarantee.
+        (json!({ "fs": ["./.env.d"] }), ".env.d/prod"),
+    ] {
+        assert!(
+            read_denied(surface.clone(), leaked),
+            "{leaked} must stay denied under {surface}"
+        );
+    }
+    // An exact-file allow of a `.env*` FILE inside a subdir still grants THAT one file.
+    assert!(!read_denied(
+        json!({ "fs": { "./": "r", "./sub/.env.local": "r" } }),
+        "sub/.env.local"
+    ));
+    // …but a sibling `.env` in the same subdir stays denied.
+    assert!(read_denied(
+        json!({ "fs": { "./": "r", "./sub/.env.local": "r" } }),
+        "sub/.env"
+    ));
+}

--- a/crates/nub-sandbox/tests/windows_enforcement.rs
+++ b/crates/nub-sandbox/tests/windows_enforcement.rs
@@ -606,6 +606,7 @@ mod win {
             enforce: true,
             rules: Vec::new(),
             default_effect: Effect::Deny,
+            ..Default::default()
         };
         expect_in(
             &mut fails,


### PR DESCRIPTION
Two fs-axis sandbox changes.

## `.env*` default-deny — sub-directory bypass fixed

`.env*` files are denied by default on every read-granting fs policy, at any depth, overridable only by an explicit exact-file allow. A confirmed bypass is now closed: an exact allow of a `.env*`-NAMED DIRECTORY (`{ "./.env.d": "r" }`) re-exposed its entire subtree of secrets — the exact-file override re-emitted the directory's `/**` subtree twin, and the `.env*/**` subtree deny sat before it, so a directory allow's subtree grant won last-match-wins (on macOS via `(subpath …)` semantics too).

Fix: split the deny into a LEAF band (`**/.env*`) and a SUBTREE band (`**/.env*/**`), ordered `user entries → leaf-deny → exact-file allows → subtree-deny LAST`. A genuine exact-FILE allow of a `.env*` file is a leaf (never matched by `.env*/**`) so it survives; a directory's contents are always re-denied. Pure last-match ordering, so it closes identically on macOS (Seatbelt subpath), Linux (allow-only carve), and the engine matcher.

Verified:
- real `.env` files at any depth stay denied (were already);
- `{ "./.env.d": "r" }` / `.environments` / glob / array directory allows no longer expose contents;
- the exact-file allow `{ "./.env.production": "r" }` still grants that one file; a sibling `.env` stays denied.

Regression tests at the engine matcher (`tests/matcher.rs`), real-kernel macOS (`tests/macos_enforcement.rs`), and Linux-carve (`backend/linux_grants.rs`) layers.

## `<tmp>` private tmp — sentinel taking an fs permission

`<tmp>` is a SENTINEL that always denotes a specially-provisioned per-run PRIVATE dir — never the shared system tmp. Its value is a plain fs permission on that dir:

- `<tmp>: "rw"` / `true` (`"r"` is degenerate → treated as `"rw"`) → provision a fresh per-run temp dir (the child's `TMPDIR`/`TMP`/`TEMP` point there) + grant it rw; the shared system tmp stays hidden (`TmpMode::Private`).
- `<tmp>: false` → shared tmp hidden, no private dir (`TmpMode::Deny`).
- `<tmp>` absent → no tmp confinement; the shared system tmp is visible per the normal fs rules (`TmpMode::Shared`).

The shared system tmp is a SEPARATE literal path — reached only by granting `/tmp` (`{ "fs": { "/tmp": "r" } }`), never through `<tmp>`. The `"private"`/`"deny"` string keywords are dropped; `TmpMode::Shared` is no longer reachable through the sentinel (only the absent-`<tmp>` default). The underlying `TmpMode` provisioning mechanism (per-run dir minting owned by `Prepared`, each backend wired) is unchanged — this is a surface re-spelling.

- macOS — ENFORCED (real-kernel verified): Seatbelt denies the shared confstr + `/private/tmp` roots after the fs grants; Private also grants the fresh dir rw. A shared-tmp file is denied under `<tmp>: "rw"`/`false` and readable without; a literal `/tmp` grant is the only way to reach it (`tests/macos_enforcement.rs`).
- Linux / Windows — the temp env is pointed at the fresh dir best-effort and the axis reports a `tmp-private`/`tmp-deny` Degradation (fail-safe — never a silent unenforced private tmp). Enforcement is a follow-up: Linux needs a Landlock allow-only carve to exclude the shared tmp; Windows needs the TEMP-floor decision. Documented in `LIMITATIONS.md`.

Gates green locally: `cargo clippy -p nub-sandbox --all-targets --all-features -- -D warnings`, `cargo fmt --check`, the full `nub-sandbox` suite.

Refs the sandbox fs-axis epic.
