### PR TITLE
sandbox(u5): allow wildcard/glob broker hosts via the universal host matcher

### DIFF
--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -131,8 +131,14 @@ residuals:
   Brokering protects the secret from the child's environment and its outbound view, not
   from a reflecting upstream — only broker to upstreams trusted not to reflect
   credentials back.
-- **Port-agnostic broker scoping.** A literal broker host matches regardless of port —
+- **Port-agnostic broker scoping.** A broker host matches regardless of port —
   brokering configured for `api.example.com` applies to that host on any port.
+- **Wildcard broker scoping is the user's own risk.** A broker host accepts the same
+  universal host-glob syntax as any net rule (`*.example.com`, bare `*`); it brokers to
+  the client-supplied SNI of every matching host. Pointing a broker at too broad a
+  wildcard can hand the credential to an attacker-owned subdomain that presents a valid
+  real cert — identical exposure to any over-broad wildcard net allow, out of the threat
+  model and un-warned (maintainer decision). Scope the wildcard to hosts you trust.
 
 ## Launcher-handoff items (engine correct; launcher must complete the guarantee)
 

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -322,9 +322,11 @@ fn fold_net_rule_object(
             "a net rule object must contain `inject` (credential brokering) — it is the only per-host capability in this cut",
         )
     })?;
-    // Reject an unbrokerable host BEFORE it becomes an allow rule: a CIDR can't carry
-    // HTTP header injection, and a wildcard would hand the credential to any matching
-    // subdomain (including an attacker-owned one — laundering).
+    // Reject a CIDR BEFORE it becomes an allow rule — it can't carry HTTP header
+    // injection. Wildcard/glob broker hosts ARE accepted and match via the same
+    // universal host-glob matcher as net allow/deny (maintainer decision): a
+    // `*.example.com` broker brokers exactly the hosts it would allow, at the user's
+    // own risk (see `validate_broker_host`).
     validate_broker_host(host, path)?;
     let injects = parse_inject(inject, ctx, &child(path, "inject"))?;
     push_net_rule(host, Effect::Allow, path, &mut policy.rules)?;
@@ -335,22 +337,19 @@ fn fold_net_rule_object(
     Ok(())
 }
 
-/// A broker host must be a single LITERAL hostname. No CIDR (no HTTP layer) and — the
-/// security-critical rule — no wildcard: a `*.example.com` broker mints + injects to the
-/// CLIENT-SUPPLIED SNI, so a child connecting to an attacker-owned `evil.example.com`
-/// (with a valid real cert) would receive the `example.com` credential (laundering). A
-/// user needing several hosts lists each one explicitly.
+/// A broker host is any valid net host pattern — a literal, or the SAME universal
+/// host-glob syntax used for net allow/deny (`*.example.com`, bare `*`). Only a CIDR is
+/// rejected: brokering is an HTTP-header capability with no CIDR form. Wildcards are
+/// intentionally permitted (maintainer decision): a `*.example.com` broker mints +
+/// injects to the CLIENT-SUPPLIED SNI, so it brokers exactly the hosts the same pattern
+/// would allow as a net rule — including, if the user points it at a too-broad wildcard,
+/// an attacker-owned subdomain. That laundering-to-a-misconfigured-wildcard is the user's
+/// own risk (identical to any wildcard net allow), out of the threat model — no warning.
 fn validate_broker_host(pattern: &str, path: &str) -> Result<(), CompileError> {
     if pattern.contains('/') {
         return Err(CompileError::shape(
             path,
-            "credential brokering targets a host, not a CIDR — name a literal hostname",
-        ));
-    }
-    if pattern.contains('*') {
-        return Err(CompileError::shape(
-            path,
-            "credential brokering requires a LITERAL host — a wildcard would hand the credential to any matching subdomain (including an attacker's); list each host explicitly",
+            "credential brokering targets a host, not a CIDR — name a hostname (a literal or a `*.` wildcard)",
         ));
     }
     if !crate::matcher::host::host_pattern_is_valid(pattern) {

--- a/crates/nub-sandbox/src/proxy/mitm.rs
+++ b/crates/nub-sandbox/src/proxy/mitm.rs
@@ -457,6 +457,30 @@ pub(super) mod http1 {
         }
 
         #[test]
+        fn wildcard_broker_terminates_and_injects_only_for_matching_hosts() {
+            // A `*.example.com` broker fires `broker_for`/`should_terminate` for the apex
+            // and any-depth subdomain, and NOT for a sibling — the runtime selection uses
+            // the same universal host-glob matcher as net allow/deny.
+            let broker = crate::policy::CredentialBroker {
+                host: "*.example.com".to_string(),
+                injects: vec![inject("Authorization", "Bearer REAL-SECRET")],
+            };
+            let engine = super::super::MitmEngine::new(vec![broker], false)
+                .expect("MITM engine needs a populated native root store");
+            assert!(engine.should_terminate("example.com"));
+            assert!(engine.should_terminate("api.example.com"));
+            assert!(engine.should_terminate("a.b.example.com"));
+            assert_eq!(
+                engine
+                    .broker_for("api.example.com")
+                    .map(|i| i[0].value.expose()),
+                Some("Bearer REAL-SECRET")
+            );
+            assert!(!engine.should_terminate("evil.com"));
+            assert!(engine.broker_for("example.com.evil.com").is_none());
+        }
+
+        #[test]
         fn chunked_request_body_is_refused() {
             let raw = "POST /x HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
             assert!(read_request(&mut Cursor::new(raw.as_bytes())).is_err());

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -1135,21 +1135,53 @@ fn host_only_policy_stays_connection_tier_no_mitm() {
 }
 
 #[test]
-fn wildcard_broker_is_rejected_as_a_laundering_guard() {
-    // A wildcard broker would inject the credential to any matching subdomain — including
-    // an attacker-owned one. Only a literal host is allowed.
+fn wildcard_broker_is_accepted_and_scopes_via_the_universal_matcher() {
+    // A wildcard broker host is admitted (maintainer decision) and matches EXACTLY what
+    // the same pattern matches as a net rule — the runtime `broker_for` selects it via
+    // `host_glob_matches`, so proving the matcher's verdict here proves inject-selection.
+    use nub_sandbox::matcher::host::host_glob_matches;
     let ctx = common::ctx(true, &[]);
-    for host in ["*.example.com", "*"] {
-        let err = compile(
-            &json!({ "net": { host: { "inject": { "Authorization": "Bearer x" } } } }),
+    let p = compile(
+        &json!({ "net": { "*.example.com": { "inject": { "Authorization": "Bearer secret" } } } }),
+        &ctx,
+    )
+    .unwrap();
+    assert_eq!(p.net.brokers.len(), 1);
+    assert_eq!(p.net.brokers[0].host, "*.example.com");
+    // The wildcard host is implicitly allowed and engages TLS inspection.
+    assert!(p.net.rules.iter().any(
+        |r| matches!(&r.target, NetTarget::Host(h) if h == "*.example.com")
+            && matches!(r.effect, Effect::Allow)
+    ));
+    assert!(matches!(p.net.inspection, Inspection::TlsInspect));
+    // Injects for the apex and any-depth subdomain; NOT for a sibling / suffix-confusable.
+    let broker_host = &p.net.brokers[0].host;
+    assert!(host_glob_matches(broker_host, "example.com"));
+    assert!(host_glob_matches(broker_host, "a.example.com"));
+    assert!(host_glob_matches(broker_host, "a.b.example.com"));
+    assert!(!host_glob_matches(broker_host, "evil.com"));
+    assert!(!host_glob_matches(broker_host, "notexample.com"));
+    assert!(!host_glob_matches(broker_host, "example.com.evil.com"));
+    // A bare `*` broker is likewise accepted (same universal syntax, the user's own risk).
+    assert!(
+        compile(
+            &json!({ "net": { "*": { "inject": { "Authorization": "Bearer x" } } } }),
             &ctx,
         )
-        .unwrap_err();
-        assert!(
-            matches!(err, CompileError::Shape { .. }),
-            "wildcard broker `{host}` must be rejected"
-        );
-    }
+        .is_ok()
+    );
+}
+
+#[test]
+fn cidr_broker_is_rejected_no_http_layer() {
+    // Brokering is an HTTP-header capability; a CIDR has no host to terminate/inject on.
+    let ctx = common::ctx(true, &[]);
+    let err = compile(
+        &json!({ "net": { "10.0.0.0/8": { "inject": { "Authorization": "Bearer x" } } } }),
+        &ctx,
+    )
+    .unwrap_err();
+    assert!(matches!(err, CompileError::Shape { .. }));
 }
 
 #[test]


### PR DESCRIPTION
Removes the compile-time literal-host-only restriction on U5 MITM credential brokers. A broker host now accepts the same universal host-glob syntax as any net allow/deny rule (`*.example.com`, bare `*`), matched by the same `host_glob_matches` — one consistent semantics, no special-case. Only a CIDR is rejected (brokering has no HTTP layer for it).

Wildcard scoping is the user's own risk, identical to any over-broad wildcard net allow, and is un-warned by decision. Laundering-to-a-misconfigured-wildcard moves out of the threat model.

All other U5 properties are unchanged and were re-verified by an adversarial + impact self-review: ephemeral CA lifecycle, credential confinement (secret never in child env), upstream cert verification, fail-closed, `inject` trusted-only gating, CRLF/NUL guards. The allow rule and the broker store the identical `strip_trailing_dot(host)` form, so the broker matches exactly what the net rule matches — no over/under-match.

Tests: the old `wildcard_broker_is_rejected_as_a_laundering_guard` is inverted to `wildcard_broker_is_accepted_and_scopes_via_the_universal_matcher` (accepts `*.example.com`, verifies apex + any-depth subdomain match and sibling/suffix-confusable non-match); adds `cidr_broker_is_rejected_no_http_layer` and an in-engine `wildcard_broker_terminates_and_injects_only_for_matching_hosts` exercising `should_terminate`/`broker_for`. `LIMITATIONS.md` updated.

Refs #414