### PR TITLE
sandbox(windows): opt-in elevated strict tier for per-host net + MITM

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -2656,8 +2656,15 @@ fn run_sandboxed(policy_file: &str, program: Option<&str>, args: &[String]) -> R
     }
 
     let spec = nub_sandbox::CommandSpec::new(program).args(prog_args.iter().map(String::as_str));
-    let prepared = nub_sandbox::apply(&policy, spec)
-        .map_err(|d| anyhow::anyhow!("sandbox could not be applied (fail-closed): {d:?}"))?;
+    let prepared = nub_sandbox::apply(&policy, spec).map_err(|d| {
+        // Surface the fail-closed reason cleanly (e.g. Windows per-host/MITM needing
+        // elevation), not a Debug dump — this is the user-facing error.
+        let detail = d
+            .reason
+            .clone()
+            .unwrap_or_else(|| format!("could not enforce {}", d.lost.join(", ")));
+        anyhow::anyhow!("sandbox could not be applied (fail-closed): {detail}")
+    })?;
     if let Some(warning) = prepared.degradation.warning() {
         eprintln!("warning: {warning}");
     }

--- a/crates/nub-sandbox/Cargo.toml
+++ b/crates/nub-sandbox/Cargo.toml
@@ -76,6 +76,9 @@ seccompiler = "0.5"
 # (CreateProcessW + STARTUPINFOEX + SECURITY_CAPABILITIES), per-run inheritable
 # allow-ACE grants (Get/SetNamedSecurityInfoW + SetEntriesInAclW), the
 # CreateAppContainerProfile identity, and the Job-Object KILL_ON_JOB_CLOSE reap.
+# The strict-Windows net tier adds the loopback-exemption RMW
+# (NetworkIsolationGet/SetAppContainerConfig, WindowsFirewall) + the elevation query
+# (OpenProcessToken/GetTokenInformation, Threading/Security).
 # 0.61 is already in the workspace lockfile (transitive via clap/anstyle) — no
 # new supply-chain surface. Raw FFI (no COM), gated `#[cfg(target_os = "windows")]`.
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
@@ -88,6 +91,7 @@ features = [
   "Win32_System_Threading",
   "Win32_System_JobObjects",
   "Win32_System_Memory",
+  "Win32_NetworkManagement_WindowsFirewall",
 ]
 
 [dev-dependencies]
@@ -99,7 +103,7 @@ base64 = "0.22"
 # needs a little FFI (token-query + process-liveness) beyond what the lib exposes.
 [target.'cfg(target_os = "windows")'.dev-dependencies.windows-sys]
 version = "0.61"
-features = ["Win32_Foundation", "Win32_Security", "Win32_System_Threading", "Win32_System_Diagnostics_Debug", "Win32_System_Pipes", "Win32_Storage_FileSystem"]
+features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Isolation", "Win32_System_Threading", "Win32_System_Diagnostics_Debug", "Win32_System_Pipes", "Win32_Storage_FileSystem", "Win32_NetworkManagement_WindowsFirewall"]
 
 # The Windows enforcement probe self-reexecs as the AppContainer child, so it owns
 # `main` (dispatch on argv) rather than the libtest harness. windows-latest CI only; a

--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -3,7 +3,8 @@
 An honest record of what the engine does NOT close, why each residual is bounded, and
 where the fix lives. The sandbox fails safe, not silent: an **axis-level** degradation a
 policy reaches (a per-host net policy with no proxy → coarse deny; per-host Windows egress
-→ coarse deny) is surfaced at runtime via `Degradation`. The **within-axis over-grant**
+without elevation → a fail-CLOSED `Degradation` error, never a silent coarse-degrade) is
+surfaced via `Degradation`. The **within-axis over-grant**
 residuals below are a different class — documented here, NOT signalled: hardlink-to-secret,
 the `/etc` no-deny-carve edge, derive→open TOCTOU, bind-mounted procfs, the macOS
 floating-name move-block shapes, Linux `ConnectTcp` at `ptrace_scope≥2`, and NAT64/6to4.
@@ -103,18 +104,48 @@ an inbound listener remains creatable on an unpredictable port. Explicit `bind()
   for full inbound closure. Same full-close as above (seccomp `user_notify` / netns).
   Documented in `backend/linux.rs` (`apply_landlock`).
 
-### Windows per-host egress is not wired (coarse deny holds)
+### Windows per-host egress + MITM: opt-in elevated "strict Windows" tier
 
-Windows has proven coarse egress-deny (no `internetClient` capability blocks all egress,
-loopback included), but not per-host. An AppContainer child cannot reach the loopback
-proxy without a registered loopback exemption (`NetworkIsolationSetAppContainerConfig`),
-which this phase does not wire.
+Per-host net (Q21) and the MITM/credential-brokering tier (Q22) enforce on Windows the
+same way as macOS/Linux — the confined child's sole egress is nub's loopback proxy — but
+reaching that proxy needs a step the other platforms don't. An AppContainer child is
+WFP-blocked from ALL loopback regardless of capability, and the only lift
+(`NetworkIsolationSetAppContainerConfig`, a per-run AC-SID loopback exemption) requires
+administrator. So per-host/MITM on Windows is an **opt-in elevated tier**; coarse on/off
+(allow-all or deny-all, which need no proxy) stays the unprivileged default, unchanged.
 
-- **Why bounded:** fail-safe — a per-host allow policy degrades to coarse **deny**, not
-  to open egress, and reports a `net-per-host` `Degradation`. Nothing is silently
-  allowed.
-- **Where fixed:** wire the loopback exemption so the child can reach the proxy —
-  build-jail thread or a later hardening slot.
+- **How it enforces (elevated):** before spawn the backend registers the per-run unique AC
+  SID in the machine-wide loopback-exemption list (a read-modify-write that never clobbers
+  other apps' entries), keeps `internetClient` WITHHELD so the exemption opens loopback
+  ONLY — nub's proxy is the child's sole egress — and tears the exemption down when the
+  child exits (RAII, alongside the ACE/profile teardown). MITM rides the same proxy: the
+  ephemeral CA reaches the child through the CA-env bundle, exactly as on mac/Linux.
+- **The widening tradeoff (bounded).** A loopback exemption is not scoped to the proxy
+  port — for the run's lifetime the exempted child can reach EVERY loopback listener (a
+  local DB on `127.0.0.1:5432`, a Docker daemon, an SSH-agent pipe, …), not just nub's
+  proxy. Narrowing it to only the proxy port would need admin WFP filters, which nub does
+  not install. The widening is BOUNDED to the ephemeral per-run AC SID and removed on exit,
+  so it never persists past the sandboxed child's own lifetime. One consequence to note:
+  if a loopback listener is itself an OPEN FORWARDER with external reach (a user's own
+  local proxy, an SSRF-able localhost service), a hostile child could relay egress through
+  it and sidestep the per-host allowlist — the same local-forwarder caveat that applies to
+  any localhost-reachable sandbox, now in scope on the elevated Windows tier because the
+  child can reach all of loopback (macOS/Linux keep loopback closed except the proxy port).
+- **Fail-CLOSED, never silent.** A policy that REQUIRES the proxy (any per-host rule, or a
+  MITM/`inject` broker) on a host where the exemption cannot be registered — nub not
+  elevated, or the write fails — surfaces a clear error naming the elevation requirement
+  and does NOT coarse-degrade an allow-list into a deny-all. A coarse-only policy needs no
+  elevation and is unaffected.
+- **Crash-leak (bounded).** A nub that dies without running teardown leaks one orphaned
+  exemption entry for its per-run AC SID. Since the SID is unique per run and its profile is
+  deleted, no future child is ever created under it, so the stale entry exempts no live
+  process — it only accretes an unused list row. (A subsequent nub run re-reads the list
+  and would preserve, not reuse, the orphan; it is inert until the machine's exemption list
+  is manually pruned.)
+- **Prior art:** Codex and SRT hit the same wall and answer it the same way — per-host net
+  on Windows is an elevated setup with unprivileged reuse, never unprivileged outright.
+  (`backend/windows.rs` `plan_net` / `WindowsLaunch::run`; `tests/windows_enforcement.rs`
+  `net_tier`.)
 
 ### MITM tier: credential-brokering residuals (INFO, doc-only)
 

--- a/crates/nub-sandbox/src/backend/windows.rs
+++ b/crates/nub-sandbox/src/backend/windows.rs
@@ -45,7 +45,7 @@
 //! `Prepared::status()` calls [`WindowsLaunch::run`], which owns setup → spawn → wait
 //! → RAII teardown.
 
-use crate::policy::{Effect, FsAccess, FsPolicy, FsRule};
+use crate::policy::{Effect, FsAccess, FsPolicy, FsRule, NetPolicy};
 // Referenced only by the Windows-gated `apply`; the host build (module-under-test)
 // never names it.
 #[cfg(target_os = "windows")]
@@ -71,6 +71,11 @@ pub(crate) struct WindowsLaunch {
     env: Option<BTreeMap<String, String>>,
     /// Grant the `internetClient` capability (egress allowed). `false` ⇒ coarse deny.
     allow_internet: bool,
+    /// Strict-Windows Tier 1: register a machine-wide loopback exemption for the per-run
+    /// AC SID before spawn (so the child can reach nub's loopback egress proxy — its SOLE
+    /// egress, since `allow_internet` stays `false`), torn down when the child exits.
+    /// Requires elevation; `apply` sets it only when [`plan_net`] chose [`WinNetPlan::Tier1`].
+    register_loopback_exemption: bool,
 }
 
 /// What the allowlist model could NOT express for a policy, so the caller can be told.
@@ -264,6 +269,48 @@ fn fs_confines(fs: &FsPolicy) -> bool {
     fs.rules.default_effect != Effect::Allow || !fs.rules.entries.is_empty()
 }
 
+/// The Windows net posture the backend can achieve for a policy, given whether nub runs
+/// elevated. THE WINDOWS DIFFERENCE (design.md; `wiki/research/sandbox-windows-net-parity.md`):
+/// per-host + MITM ride nub's loopback egress proxy, but an AppContainer child is blocked
+/// from ALL loopback by WFP regardless of capability, and the only lift —
+/// `NetworkIsolationSetAppContainerConfig` — is admin-only. So the per-host/MITM tier is
+/// reachable ONLY when elevated; coarse on/off needs no proxy and stays unprivileged. Pure
+/// fn ⇒ host-unit-tested (the `is_elevated` FFI is factored out into the caller).
+#[derive(Debug, PartialEq, Eq)]
+enum WinNetPlan {
+    /// Net unconfined — grant `internetClient`, no proxy.
+    Unconfined,
+    /// Coarse egress-deny — withhold `internetClient`, no proxy (deny-all; unprivileged).
+    CoarseDeny,
+    /// Strict-Windows Tier 1 — register the per-run AC-SID loopback exemption so the child
+    /// reaches nub's proxy (its SOLE egress, `internetClient` withheld). Per-host + MITM
+    /// enforce. Requires elevation.
+    Tier1,
+    /// Fail-CLOSED: the policy needs per-host/MITM but nub is not elevated, so the loopback
+    /// exemption can't be registered. The maintainer requirement — surface a clear error,
+    /// NEVER silently coarse-degrade an allow-list into a deny-all.
+    FailUnelevated,
+}
+
+/// Decide the net posture. Per-host is signalled by any Allow rule (matches
+/// `backend::start_proxy_if_needed`, which is what actually starts the proxy). A pure
+/// deny-all is coarse (no proxy, no elevation). `elevated` is consulted only on the
+/// per-host branch, so the caller may pass `false` elsewhere without changing the verdict.
+fn plan_net(net: &NetPolicy, elevated: bool) -> WinNetPlan {
+    if !net.enforce {
+        return WinNetPlan::Unconfined;
+    }
+    let needs_proxy = net.rules.iter().any(|r| r.effect == Effect::Allow);
+    if !needs_proxy {
+        return WinNetPlan::CoarseDeny;
+    }
+    if elevated {
+        WinNetPlan::Tier1
+    } else {
+        WinNetPlan::FailUnelevated
+    }
+}
+
 // TRAVERSE MODEL (why a LEAF grant alone suffices — no ancestor traverse grants): a
 // LowBox token retains SeChangeNotifyPrivilege (Bypass Traverse Checking), and standard
 // local NTFS volumes carry FILE_DEVICE_ALLOW_APPCONTAINER_TRAVERSAL on the VOLUME DEVICE
@@ -285,17 +332,61 @@ pub(crate) fn apply(
     spec: super::CommandSpec,
     proxy_port: Option<u16>,
     proxy_token: Option<&str>,
-    // CUT-1: Windows per-host egress-via-proxy is NOT wired (an AppContainer child needs a
-    // loopback exemption — `NetworkIsolationSetAppContainerConfig` — to reach the loopback
-    // proxy), so TLS termination degrades here just as per-host does. The bundle is still
-    // threaded (CA-env set on the plain path) so trust works IF a future change wires the
-    // exemption; today `net-per-host`/`net-per-request` is reported instead.
+    // The MITM child CA-bundle. On the Tier-1 elevated per-host path it is injected into
+    // the child env (CA-trust) AND added to the read allow-set so the confined child can
+    // read it; on the plain path it rides `set_ca_env`.
     ca_bundle: Option<&std::path::Path>,
 ) -> Result<super::Prepared, super::Degradation> {
     use super::{Degradation, Prepared};
 
     let confine_fs = fs_confines(&policy.fs);
     let sandboxing = confine_fs || policy.net.enforce;
+
+    // ── net posture (strict-Windows tier decision) ──────────────────────────────
+    // Per-host + MITM ride nub's loopback proxy, which an AppContainer child can reach
+    // ONLY through an admin-registered loopback exemption. `is_elevated` is queried lazily
+    // (only when a per-host rule is present) so the coarse/unconfined paths pay nothing.
+    let net_plan = plan_net(
+        &policy.net,
+        policy.net.enforce
+            && policy.net.rules.iter().any(|r| r.effect == Effect::Allow)
+            && launch::is_elevated(),
+    );
+    // INFORMATIVE FAIL (maintainer requirement): a per-host / MITM config on an unelevated
+    // Windows host cannot register the exemption, so FAIL CLOSED with a clear message —
+    // never silently collapse an allow-list into a coarse deny-all. Coarse on/off is
+    // unaffected (it never reaches here).
+    if net_plan == WinNetPlan::FailUnelevated {
+        let mut lost = vec!["net-per-host".to_string()];
+        if !policy.net.brokers.is_empty() {
+            lost.push("net-per-request".to_string());
+        }
+        return Err(Degradation {
+            lost,
+            reason: Some(
+                "per-host network rules (and TLS inspection / credential brokering) require \
+                 nub to register a loopback network exemption, which on Windows needs \
+                 administrator elevation. Re-run nub from an elevated (Run as administrator) \
+                 prompt, or use a coarse net policy — allow-all or deny-all — which needs no \
+                 elevation."
+                    .to_string(),
+            ),
+        });
+    }
+    let tier1 = net_plan == WinNetPlan::Tier1;
+    // Tier 1 is meaningless without the running proxy the child routes through; if the
+    // proxy failed to start (CA/TLS build or bind failure) fail closed rather than launch a
+    // child that can reach nothing under a per-host promise.
+    if tier1 && proxy_port.is_none() {
+        return Err(Degradation {
+            lost: vec!["net-per-host".to_string()],
+            reason: Some(
+                "the egress proxy required for per-host / TLS-inspect enforcement could not \
+                 start"
+                    .to_string(),
+            ),
+        });
+    }
 
     // Nothing needs the AppContainer: only env-scrub (or nothing). Use the plain
     // command path — identical contract to the mac/linux relaxed case.
@@ -351,6 +442,17 @@ pub(crate) fn apply(
         read_grants.push(prog);
     }
 
+    // Tier 1 + MITM: the confined child must READ the ephemeral CA bundle to trust the
+    // proxy's minted leaves. Grant it as nub infra (not user config), mirroring the
+    // mac/linux ca-bundle read grant. Only under a real per-host tier (`tier1`); the plain
+    // path handles CA-trust via `set_ca_env` on an unconfined fs.
+    if tier1 && let Some(bundle) = ca_bundle {
+        let b = bundle.to_path_buf();
+        if !read_grants.contains(&b) {
+            read_grants.push(b);
+        }
+    }
+
     // ── degradation (fail-safe-not-silent) ──────────────────────────────────────
     let mut deg = Degradation::full();
     let mut reason: Option<String> = None;
@@ -381,27 +483,10 @@ pub(crate) fn apply(
                 .to_string()
         });
     }
-    // Coarse net: an enforced net with any Allow rule needs the loopback proxy for
-    // per-host. On Windows the proxy runs in the parent, but an AppContainer child
-    // cannot reach a loopback service without a registered loopback exemption
-    // (`NetworkIsolationSetAppContainerConfig`) — NOT wired in this phase — so per-host
-    // is honestly degraded and the coarse egress-deny (no `internetClient`) holds. The
-    // branch-scoped windows-latest CI probe investigates the exemption's feasibility.
-    if policy.net.enforce && policy.net.rules.iter().any(|r| r.effect == Effect::Allow) {
-        deg.lost.push("net-per-host".to_string());
-        // A credential-inject rule is a per-REQUEST capability layered atop per-host: it
-        // degrades identically here (the loopback exemption that per-host needs gates the
-        // MITM proxy the same way), so report it explicitly rather than silently — the
-        // broker is fail-safe DENIED, never forwarded un-inspected (proposal §6).
-        if !policy.net.brokers.is_empty() {
-            deg.lost.push("net-per-request".to_string());
-        }
-        reason.get_or_insert_with(|| {
-            "per-host egress needs an AppContainer loopback exemption to reach the proxy \
-             (not wired) — per-host allows denied (coarse network deny)"
-                .to_string()
-        });
-    }
+    // Net per-host / MITM is NOT a degradation here: an unelevated per-host config already
+    // returned the informative fail-closed above, and an elevated one (`tier1`) ENFORCES
+    // via the loopback exemption registered in `run()` — so there is nothing to report lost.
+    // Coarse deny-all and unconfined net are fully honored with no proxy.
     // (Ascendant-env read is OS-CLOSED — the AppContainer denies the parent
     // OpenProcess(PROCESS_VM_READ), run 29043151805 — so NO `env-read-ascendant`
     // Degradation is emitted. Reporting it would falsely tell a frontend Windows is
@@ -414,33 +499,13 @@ pub(crate) fn apply(
         cwd: spec.cwd,
         read_grants,
         write_grants,
-        // When env is enforced, fold the cooperative proxy hint into the constructed
-        // map (over an enforced env-scrub). If env is NOT enforced, the child inherits
-        // the ambient env and we do not synthesize a block just for the proxy vars —
-        // per-host is degraded on Windows anyway, so the hint would be inert.
-        env: policy.env.enforce.then(|| {
-            let mut m = policy.env.constructed.clone();
-            if let Some(port) = proxy_port {
-                let url = match proxy_token {
-                    Some(t) => format!("http://{t}@127.0.0.1:{port}"),
-                    None => format!("http://127.0.0.1:{port}"),
-                };
-                for k in [
-                    "HTTP_PROXY",
-                    "HTTPS_PROXY",
-                    "http_proxy",
-                    "https_proxy",
-                    "ALL_PROXY",
-                ] {
-                    m.insert(k.to_string(), url.clone());
-                }
-                m.insert("NODE_USE_ENV_PROXY".to_string(), "1".to_string());
-            }
-            m
-        }),
-        // Grant internetClient only when net is unconfined; an enforced net is coarse
-        // deny (no capability). Per-host would need the loopback exemption (above).
+        env: build_child_env(&policy.env, tier1, proxy_port, proxy_token, ca_bundle),
+        // Grant internetClient only when net is unconfined; an enforced net (coarse deny
+        // OR Tier 1) withholds it. For Tier 1 this is LOAD-BEARING: the loopback exemption
+        // opens loopback but withholding internetClient keeps external egress blocked, so
+        // nub's proxy is the child's SOLE egress (matches mac/linux `remote ip localhost`).
         allow_internet: !policy.net.enforce,
+        register_loopback_exemption: tier1,
     };
 
     // The `command` field is unused on the launch path (status() runs `launch`); it
@@ -451,6 +516,78 @@ pub(crate) fn apply(
         proxy: None,
         launch: Some(launch),
     })
+}
+
+/// The child's env block, or `None` to inherit the ambient env untouched.
+///
+/// - env enforced ⇒ start from the constructed scrub map; else (Tier 1 only) snapshot the
+///   ambient env so the proxy/CA overrides ride an otherwise-inherited environment — the
+///   Windows launch block is all-or-nothing, unlike a mac/linux `Command`'s inherit+override,
+///   so "inherit + override" must be materialized here (a non-Unicode var is lossily kept).
+/// - Tier 1 folds in the cooperative proxy hint (clients route through the loopback proxy)
+///   and the MITM CA-trust vars (the child trusts the proxy's minted leaves). A non-Tier-1
+///   enforced env stays the plain scrub — no proxy is running to route to.
+#[cfg(target_os = "windows")]
+fn build_child_env(
+    env: &crate::policy::EnvPolicy,
+    tier1: bool,
+    proxy_port: Option<u16>,
+    proxy_token: Option<&str>,
+    ca_bundle: Option<&std::path::Path>,
+) -> Option<BTreeMap<String, String>> {
+    if !env.enforce && !tier1 {
+        return None;
+    }
+    let mut m = if env.enforce {
+        env.constructed.clone()
+    } else {
+        std::env::vars_os()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.to_string_lossy().into_owned(),
+                )
+            })
+            .collect()
+    };
+    if tier1 {
+        if let Some(port) = proxy_port {
+            let url = match proxy_token {
+                Some(t) => format!("http://{t}@127.0.0.1:{port}"),
+                None => format!("http://127.0.0.1:{port}"),
+            };
+            for k in [
+                "HTTP_PROXY",
+                "HTTPS_PROXY",
+                "http_proxy",
+                "https_proxy",
+                "ALL_PROXY",
+            ] {
+                m.insert(k.to_string(), url.clone());
+            }
+            m.insert("NODE_USE_ENV_PROXY".to_string(), "1".to_string());
+        }
+        if let Some(bundle) = ca_bundle {
+            // The same tool-convention CA-trust keys as `backend::set_ca_env`.
+            let p = bundle.to_string_lossy().into_owned();
+            for k in [
+                "NODE_EXTRA_CA_CERTS",
+                "SSL_CERT_FILE",
+                "REQUESTS_CA_BUNDLE",
+                "CURL_CA_BUNDLE",
+                "GIT_SSL_CAINFO",
+                "PIP_CERT",
+                "NPM_CONFIG_CAFILE",
+                "npm_config_cafile",
+                "CARGO_HTTP_CAINFO",
+                "AWS_CA_BUNDLE",
+                "DENO_CERT",
+            ] {
+                m.insert(k.to_string(), p.clone());
+            }
+        }
+    }
+    Some(m)
 }
 
 /// Resolve a program to an absolute path (best-effort) so its parent dir can be
@@ -507,7 +644,11 @@ mod launch {
     use std::sync::{Mutex, MutexGuard};
     use windows_sys::Win32::Foundation::{
         CloseHandle, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, LocalFree,
-        SetHandleInformation, WAIT_OBJECT_0,
+        SetHandleInformation, WAIT_ABANDONED, WAIT_OBJECT_0,
+    };
+    use windows_sys::Win32::NetworkManagement::WindowsFirewall::{
+        NetworkIsolationFreeAppContainers, NetworkIsolationGetAppContainerConfig,
+        NetworkIsolationSetAppContainerConfig,
     };
     use windows_sys::Win32::Security::Authorization::{
         ConvertStringSidToSidW, EXPLICIT_ACCESS_W, GRANT_ACCESS, GetNamedSecurityInfoW,
@@ -519,7 +660,8 @@ mod launch {
     };
     use windows_sys::Win32::Security::{
         ACL, CONTAINER_INHERIT_ACE, DACL_SECURITY_INFORMATION, FreeSid, GetLengthSid,
-        OBJECT_INHERIT_ACE, PSECURITY_DESCRIPTOR, PSID, SECURITY_CAPABILITIES, SID_AND_ATTRIBUTES,
+        GetTokenInformation, OBJECT_INHERIT_ACE, PSECURITY_DESCRIPTOR, PSID, SECURITY_CAPABILITIES,
+        SID_AND_ATTRIBUTES, TOKEN_ELEVATION, TOKEN_QUERY, TokenElevation,
     };
     use windows_sys::Win32::System::JobObjects::{
         AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
@@ -527,11 +669,12 @@ mod launch {
         SetInformationJobObject,
     };
     use windows_sys::Win32::System::Threading::{
-        CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateProcessW,
-        DeleteProcThreadAttributeList, EXTENDED_STARTUPINFO_PRESENT, GetExitCodeProcess, INFINITE,
-        InitializeProcThreadAttributeList, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
-        PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES, PROCESS_INFORMATION, ResumeThread,
-        STARTUPINFOEXW, UpdateProcThreadAttribute, WaitForSingleObject,
+        CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateMutexW, CreateProcessW,
+        DeleteProcThreadAttributeList, EXTENDED_STARTUPINFO_PRESENT, GetCurrentProcess,
+        GetExitCodeProcess, INFINITE, InitializeProcThreadAttributeList, OpenProcessToken,
+        PROC_THREAD_ATTRIBUTE_HANDLE_LIST, PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
+        PROCESS_INFORMATION, ReleaseMutex, ResumeThread, STARTUPINFOEXW, UpdateProcThreadAttribute,
+        WaitForSingleObject,
     };
 
     // Generic access rights (avoid a Storage_FileSystem feature dep for FILE_GENERIC_*).
@@ -557,6 +700,151 @@ mod launch {
     /// then missing). A single global lock is ample — ACL edits are brief and rare.
     static ACL_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Machine-wide named mutex serializing the loopback-exemption RMW (below). The
+    /// exemption list is MACHINE-WIDE state, so a process-local lock is insufficient — two
+    /// concurrent elevated nub processes would race the get→set and lose each other's
+    /// entry. `Global\` needs `SeCreateGlobalPrivilege`, which the elevated Tier-1 path
+    /// holds. Versioned so a future format change can't collide with an old holder.
+    const EXEMPTION_MUTEX_NAME: &str = "Global\\nub_sbx_loopback_exempt_v1";
+
+    /// Whether nub runs with an ELEVATED (full admin) token — the exact condition under
+    /// which the loopback-exemption write (`NetworkIsolationSetAppContainerConfig`) succeeds
+    /// (a standard user or an admin's filtered Medium-IL token both report `false` and both
+    /// get ACCESS_DENIED on the write — empirically confirmed on the nub-win VM). So this is
+    /// the honest gate for whether the strict-Windows per-host/MITM tier is available.
+    pub(super) fn is_elevated() -> bool {
+        let mut token: HANDLE = std::ptr::null_mut();
+        // SAFETY: query-only handle into our own process token.
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+            return false;
+        }
+        let mut elevation = TOKEN_ELEVATION { TokenIsElevated: 0 };
+        let mut ret_len: u32 = 0;
+        // SAFETY: `elevation` is a correctly-sized TOKEN_ELEVATION out-buffer.
+        let ok = unsafe {
+            GetTokenInformation(
+                token,
+                TokenElevation,
+                std::ptr::from_mut(&mut elevation).cast(),
+                std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+                &mut ret_len,
+            )
+        };
+        unsafe { CloseHandle(token) };
+        ok != 0 && elevation.TokenIsElevated != 0
+    }
+
+    /// Run `f` holding the machine-wide loopback-exemption mutex, so the get→modify→set of
+    /// the firewall's shared exemption list is atomic across concurrent nub processes.
+    /// Best-effort: on a create/timeout failure `f` still runs (the RMW race is fail-SAFE —
+    /// a lost entry only REMOVES a child's loopback reach, never widens egress). A 10s cap
+    /// keeps a wedged holder from deadlocking teardown.
+    fn with_exemption_lock<T>(f: impl FnOnce() -> T) -> T {
+        let name = to_wide(EXEMPTION_MUTEX_NAME);
+        // SAFETY: standard named-mutex create; NULL security attrs, not initially owned.
+        let h = unsafe { CreateMutexW(std::ptr::null(), 0, name.as_ptr()) };
+        // WAIT_ABANDONED also means WE now OWN the mutex (a prior holder died mid-RMW): treat
+        // it as held so we RELEASE it afterwards rather than re-abandon it on CloseHandle. The
+        // protected state may be inconsistent, but our RMW re-reads the whole list, so a
+        // crashed predecessor is self-healing — the lock is only about atomicity, not the data.
+        let held = !h.is_null()
+            && matches!(
+                unsafe { WaitForSingleObject(h, 10_000) },
+                WAIT_OBJECT_0 | WAIT_ABANDONED
+            );
+        let out = f();
+        if !h.is_null() {
+            if held {
+                unsafe { ReleaseMutex(h) };
+            }
+            unsafe { CloseHandle(h) };
+        }
+        out
+    }
+
+    /// Add or remove `sid` in the machine-wide AppContainer loopback-exemption list via a
+    /// read-modify-write (`NetworkIsolationSetAppContainerConfig` REPLACES the whole list,
+    /// so the current entries must be preserved — never clobber other apps' exemptions).
+    /// Held under [`with_exemption_lock`]. A stale copy of `sid` is always dropped first, so
+    /// register is idempotent and remove is exact.
+    fn set_loopback_exemption(sid: PSID, add: bool) -> io::Result<()> {
+        with_exemption_lock(|| {
+            let mut count: u32 = 0;
+            let mut arr: *mut SID_AND_ATTRIBUTES = std::ptr::null_mut();
+            // SAFETY: out-params for the current exemption list (count + heap array).
+            let rc = unsafe { NetworkIsolationGetAppContainerConfig(&mut count, &mut arr) };
+            if rc != 0 {
+                return Err(io::Error::from_raw_os_error(rc as i32));
+            }
+            let existing: &[SID_AND_ATTRIBUTES] = if arr.is_null() || count == 0 {
+                &[]
+            } else {
+                // SAFETY: `arr` points at `count` entries per the successful Get above.
+                unsafe { std::slice::from_raw_parts(arr, count as usize) }
+            };
+            let mut new_list: Vec<SID_AND_ATTRIBUTES> = existing
+                .iter()
+                .filter(|e| !sids_equal(e.Sid, sid))
+                .copied()
+                .collect();
+            if add {
+                new_list.push(SID_AND_ATTRIBUTES {
+                    Sid: sid,
+                    Attributes: 0,
+                });
+            }
+            // SAFETY: `new_list` outlives the Set call; its Sid pointers reference either
+            // the still-live `arr` allocation or the caller's `sid` (freed only after).
+            let set_rc = unsafe {
+                NetworkIsolationSetAppContainerConfig(
+                    new_list.len() as u32,
+                    if new_list.is_empty() {
+                        std::ptr::null()
+                    } else {
+                        new_list.as_ptr()
+                    },
+                )
+            };
+            // Free the got list AFTER Set (new_list borrowed its Sid pointers).
+            if !arr.is_null() {
+                unsafe { NetworkIsolationFreeAppContainers(arr.cast()) };
+            }
+            if set_rc != 0 {
+                return Err(io::Error::from_raw_os_error(set_rc as i32));
+            }
+            Ok(())
+        })
+    }
+
+    /// Byte-equality of two SIDs (both are self-relative fixed-length structures).
+    fn sids_equal(a: PSID, b: PSID) -> bool {
+        if a.is_null() || b.is_null() {
+            return false;
+        }
+        let (la, lb) = unsafe { (GetLengthSid(a), GetLengthSid(b)) };
+        if la != lb {
+            return false;
+        }
+        // SAFETY: GetLengthSid reports each SID's exact byte length.
+        let sa = unsafe { std::slice::from_raw_parts(a.cast::<u8>(), la as usize) };
+        let sb = unsafe { std::slice::from_raw_parts(b.cast::<u8>(), lb as usize) };
+        sa == sb
+    }
+
+    /// Removes the per-run loopback exemption on drop. Owned SID copy (independent of the
+    /// profile-owned SID pointer). Best-effort remove — a failure only leaves an ORPHANED
+    /// exemption for a now-deleted AC SID (harmless: it grants nothing, but accretes a list
+    /// entry; the crash-leak is documented in LIMITATIONS.md).
+    struct ExemptionGuard {
+        sid: Vec<u8>,
+    }
+    impl Drop for ExemptionGuard {
+        fn drop(&mut self) {
+            let sid = self.sid.as_ptr() as PSID;
+            let _ = set_loopback_exemption(sid, false);
+        }
+    }
+
     impl WindowsLaunch {
         /// Own the full spawn lifecycle: create a per-run AppContainer profile, grant
         /// the inheritable allow-ACEs, launch the child under the LowBox token inside a
@@ -573,6 +861,28 @@ mod launch {
             // An owned copy of the SID bytes, so ACE revoke doesn't depend on the
             // profile-owned SID pointer surviving.
             let sid_copy = copy_sid(ac_sid)?;
+
+            // 1b. Strict-Windows Tier 1: register the machine-wide loopback exemption for
+            //     this per-run AC SID so the child can reach nub's loopback egress proxy
+            //     (its SOLE egress — internetClient stays withheld). `_exemption` removes it
+            //     on drop (RAII, owned SID copy so it's independent of the profile SID).
+            //     FAIL-CLOSED: a failed register aborts the launch rather than spawn a child
+            //     that can't reach its proxy under a per-host promise. TRADEOFF (bounded +
+            //     documented, LIMITATIONS.md): the exemption widens the child to ALL loopback
+            //     services for the run's lifetime — scoped to this ephemeral SID and torn
+            //     down on exit, but not narrowable to only the proxy port without admin WFP.
+            let _exemption = if self.register_loopback_exemption {
+                let owned = copy_sid(ac_sid)?;
+                set_loopback_exemption(ac_sid, true).map_err(|e| {
+                    io::Error::other(format!(
+                        "sandbox: could not register the loopback network exemption required \
+                         for per-host net / TLS inspection (needs elevation): {e}"
+                    ))
+                })?;
+                Some(ExemptionGuard { sid: owned })
+            } else {
+                None
+            };
 
             // 2. Grant the leaf allow-ACEs; `_aces` revokes them on drop (declared before
             //    the job ⇒ revoked after the tree is reaped, before profile delete). Leaf
@@ -1318,63 +1628,58 @@ mod tests {
         )));
     }
 
+    #[test]
+    fn plan_net_decides_windows_net_posture() {
+        use crate::policy::{NetPolicy, NetRule, NetTarget};
+        let allow = |h: &str| NetRule {
+            target: NetTarget::Host(h.to_string()),
+            effect: Effect::Allow,
+        };
+
+        // Unconfined net — grant internetClient, no proxy (elevation-irrelevant).
+        let unconfined = NetPolicy::default();
+        assert_eq!(plan_net(&unconfined, false), WinNetPlan::Unconfined);
+        assert_eq!(plan_net(&unconfined, true), WinNetPlan::Unconfined);
+
+        // Pure deny-all — coarse egress-deny, unprivileged (elevation-irrelevant).
+        let deny_all = NetPolicy {
+            enforce: true,
+            default_effect: Effect::Deny,
+            ..Default::default()
+        };
+        assert_eq!(plan_net(&deny_all, false), WinNetPlan::CoarseDeny);
+        assert_eq!(plan_net(&deny_all, true), WinNetPlan::CoarseDeny);
+
+        // Per-host (any Allow rule) needs the elevated loopback exemption: Tier 1 when
+        // elevated, fail-CLOSED (never silent coarse-degrade) when not.
+        let per_host = NetPolicy {
+            enforce: true,
+            rules: vec![allow("example.com")],
+            default_effect: Effect::Deny,
+            ..Default::default()
+        };
+        assert_eq!(plan_net(&per_host, true), WinNetPlan::Tier1);
+        assert_eq!(plan_net(&per_host, false), WinNetPlan::FailUnelevated);
+    }
+
     // `apply` is `#[cfg(windows)]`, so this test compiles + runs only on the Windows VM/CI.
     #[cfg(target_os = "windows")]
     #[test]
-    fn net_enforced_with_allow_rule_degrades_per_host() {
+    fn apply_windows_net_tiers() {
         use crate::policy::{NetPolicy, NetRule, NetTarget};
-        // CUT-1: Windows per-host egress needs an AppContainer loopback exemption to reach
-        // the parent proxy — unwired — so an enforced net with ANY allow rule degrades to
-        // coarse-deny and MUST report `net-per-host` (fail-safe, not silent). The twin of
-        // the macOS `degradation_reports_lost_per_host_only_without_proxy` unit test.
-        // Asserted at the `apply` fold (the emission point) with a clean deny-all fs so no
-        // fs degradation confounds the net signal.
-        let per_host = SandboxPolicy {
+        let mk = |net: NetPolicy| SandboxPolicy {
             fs: fs(Effect::Deny, vec![]),
-            net: NetPolicy {
-                enforce: true,
-                rules: vec![NetRule {
-                    target: NetTarget::Host("example.com".to_string()),
-                    effect: Effect::Allow,
-                }],
-                default_effect: Effect::Deny,
-                ..Default::default()
-            },
+            net,
             ..Default::default()
         };
-        let lost = |port| {
-            apply(
-                &per_host,
-                crate::CommandSpec::new("cmd.exe"),
-                port,
-                None,
-                None,
-            )
-            .expect("apply")
-            .degradation
-            .lost
-        };
-        assert!(
-            lost(None).iter().any(|s| s == "net-per-host"),
-            "an enforced net with an allow rule must report net-per-host"
-        );
-        // Windows-specific contract: unlike macOS (where a proxy resolves per-host), the
-        // exemption is unwired, so a proxy port does NOT resolve it — it STILL degrades.
-        assert!(
-            lost(Some(9999)).iter().any(|s| s == "net-per-host"),
-            "Windows degrades per-host even WITH a proxy port (exemption unwired)"
-        );
 
-        // Positive control: a pure deny-all net (no allow rules) is fully enforced.
-        let deny_all = SandboxPolicy {
-            fs: fs(Effect::Deny, vec![]),
-            net: NetPolicy {
-                enforce: true,
-                default_effect: Effect::Deny,
-                ..Default::default()
-            },
+        // Pure deny-all: coarse egress-deny, fully enforced — never a net-per-host loss.
+        // Elevation-independent (no proxy, no exemption).
+        let deny_all = mk(NetPolicy {
+            enforce: true,
+            default_effect: Effect::Deny,
             ..Default::default()
-        };
+        });
         let deg = apply(
             &deny_all,
             crate::CommandSpec::new("cmd.exe"),
@@ -1382,12 +1687,56 @@ mod tests {
             None,
             None,
         )
-        .expect("apply")
+        .expect("apply deny-all")
         .degradation;
         assert!(
             !deg.lost.iter().any(|s| s == "net-per-host"),
-            "a pure deny-all net must not report net-per-host (got {:?})",
+            "deny-all is coarse-enforced, not degraded (got {:?})",
             deg.lost
         );
+
+        // Per-host: Tier 1 (enforced, no degradation) when elevated; fail-CLOSED with a
+        // clear elevation message otherwise — NEVER a silent coarse-degrade.
+        let per_host = mk(NetPolicy {
+            enforce: true,
+            rules: vec![NetRule {
+                target: NetTarget::Host("example.com".to_string()),
+                effect: Effect::Allow,
+            }],
+            default_effect: Effect::Deny,
+            ..Default::default()
+        });
+        let res = apply(
+            &per_host,
+            crate::CommandSpec::new("cmd.exe"),
+            Some(9999),
+            None,
+            None,
+        );
+        if launch::is_elevated() {
+            let deg = res.expect("elevated: Tier 1 applies").degradation;
+            assert!(
+                !deg.lost.iter().any(|s| s == "net-per-host"),
+                "Tier 1 enforces per-host — no net-per-host degradation (got {:?})",
+                deg.lost
+            );
+        } else {
+            // `expect_err` would require `Prepared: Debug` (the Ok type), which it does not
+            // implement; match instead.
+            let err = match res {
+                Ok(_) => panic!("unelevated per-host must fail-closed, not degrade"),
+                Err(d) => d,
+            };
+            assert!(
+                err.lost.iter().any(|s| s == "net-per-host"),
+                "the fail-closed Degradation must name net-per-host (got {:?})",
+                err.lost
+            );
+            assert!(
+                err.reason.as_deref().unwrap_or_default().contains("elevat"),
+                "the fail message must name the elevation requirement (got {:?})",
+                err.reason
+            );
+        }
     }
 }

--- a/crates/nub-sandbox/tests/windows_enforcement.rs
+++ b/crates/nub-sandbox/tests/windows_enforcement.rs
@@ -43,8 +43,8 @@ fn main() {
 #[cfg(target_os = "windows")]
 mod win {
     use nub_sandbox::policy::{
-        CanonGlob, Effect, EnvPolicy, FsAccess, FsPolicy, FsRule, FsRuleSet, NetPolicy, PidPolicy,
-        SandboxPolicy, TmpMode,
+        CanonGlob, Effect, EnvPolicy, FsAccess, FsPolicy, FsRule, FsRuleSet, NetPolicy, NetRule,
+        NetTarget, PidPolicy, SandboxPolicy, TmpMode,
     };
     use nub_sandbox::{CommandSpec, apply};
     use std::collections::BTreeMap;
@@ -70,6 +70,7 @@ mod win {
                 Err(_) => 9,
             },
             Some("connect") => connect(&a[1], a[2].parse().unwrap_or(0)),
+            Some("connectenvproxy") => connect_env_proxy(),
             Some("getenv") => match std::env::var(&a[1]) {
                 Ok(_) => 0,
                 Err(_) => 4,
@@ -127,6 +128,27 @@ mod win {
             Err(e) if e.kind() == std::io::ErrorKind::TimedOut => 6,
             Err(_) => 9,
         }
+    }
+
+    /// Connect to the loopback egress proxy the parent injected via `HTTP_PROXY`
+    /// (`http://[token@]127.0.0.1:<port>`). A successful TCP connect proves the confined
+    /// AppContainer child can REACH the loopback proxy — i.e. the per-run loopback
+    /// exemption is live (absent it, AppContainer→loopback is WFP-blocked → WSAEACCES).
+    /// Exit 4 if the hint was not injected. Same connect exit-code contract otherwise.
+    fn connect_env_proxy() -> i32 {
+        let Ok(url) = std::env::var("HTTP_PROXY") else {
+            return 4;
+        };
+        let after = url.split("://").nth(1).unwrap_or(&url);
+        let hostport = after
+            .rsplit('@')
+            .next()
+            .unwrap_or(after)
+            .trim_end_matches('/');
+        let Some((host, port)) = hostport.rsplit_once(':') else {
+            return 9;
+        };
+        connect(host, port.parse().unwrap_or(0))
     }
 
     /// Spawn a detached grandchild (`sleep`), record its pid, exit — so the parent can
@@ -606,6 +628,7 @@ mod win {
             enforce: true,
             rules: Vec::new(),
             default_effect: Effect::Deny,
+            ..Default::default()
         };
         expect_in(
             &mut fails,
@@ -856,10 +879,234 @@ mod win {
             unsafe { windows_sys::Win32::Foundation::CloseHandle(event) };
         }
 
+        // ── strict-Windows net tier (Q21/Q22): per-host + MITM ride nub's loopback
+        //    egress proxy, reachable only through an admin-registered loopback exemption.
+        //    Prove the mechanism end-to-end against the REAL backend — the admin-gated
+        //    exemption write, the exemption→proxy reach with external egress still sealed,
+        //    the RAII teardown, and the unelevated fail-CLOSED path. Elevation-branched:
+        //    the elevated legs run under nubadmin (High IL), the fail-closed leg under a
+        //    standard user (Medium IL). ────────────────────────────────────────────────
+        net_tier(&mut fails, &f, &child);
+
         // ── process-reap (Job Object KILL_ON_JOB_CLOSE) ──────────────────────────
         job_reap(&mut fails, &f);
 
         if fails == 0 { Ok(()) } else { Err(fails) }
+    }
+
+    /// A single Host Allow rule (per-host ⇒ Tier 1 when elevated).
+    fn allow_rule(host: &str) -> NetRule {
+        NetRule {
+            target: NetTarget::Host(host.to_string()),
+            effect: Effect::Allow,
+        }
+    }
+
+    /// A per-host strict policy: fs read-confine (engages the AppContainer + grants the
+    /// child exe) plus an enforced net with one Allow rule (the per-host signal that,
+    /// elevated, selects Tier 1 — proxy started, loopback exemption registered).
+    fn per_host_policy(f: &Fixture) -> SandboxPolicy {
+        let mut policy = read_confine(&[&f.work], &[]);
+        policy.net = NetPolicy {
+            enforce: true,
+            rules: vec![allow_rule("example.com")],
+            default_effect: Effect::Deny,
+            ..Default::default()
+        };
+        policy
+    }
+
+    /// Whether THIS test process runs elevated (full admin token) — the exact condition
+    /// under which the backend selects Tier 1 (`launch::is_elevated`). Determines which
+    /// legs of the net tier are live.
+    fn test_is_elevated() -> bool {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::Security::{
+            GetTokenInformation, TOKEN_ELEVATION, TOKEN_QUERY, TokenElevation,
+        };
+        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+        // SAFETY: query-only token handle into our own process; TOKEN_ELEVATION is exactly
+        // sized for the TokenElevation class.
+        unsafe {
+            let mut tok = std::ptr::null_mut();
+            if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut tok) == 0 {
+                return false;
+            }
+            let mut elev = TOKEN_ELEVATION { TokenIsElevated: 0 };
+            let mut ret = 0u32;
+            let ok = GetTokenInformation(
+                tok,
+                TokenElevation,
+                std::ptr::from_mut(&mut elev).cast(),
+                std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+                &mut ret,
+            );
+            CloseHandle(tok);
+            ok != 0 && elev.TokenIsElevated != 0
+        }
+    }
+
+    /// Size of the machine-wide AppContainer loopback-exemption list (read path is open
+    /// even unprivileged). Used to prove per-run teardown leaves no accretion.
+    fn exemption_count() -> u32 {
+        use windows_sys::Win32::NetworkManagement::WindowsFirewall::{
+            NetworkIsolationFreeAppContainers, NetworkIsolationGetAppContainerConfig,
+        };
+        use windows_sys::Win32::Security::SID_AND_ATTRIBUTES;
+        let mut count: u32 = 0;
+        let mut arr: *mut SID_AND_ATTRIBUTES = std::ptr::null_mut();
+        // SAFETY: out-params for the current list; the returned array is freed immediately.
+        let rc = unsafe { NetworkIsolationGetAppContainerConfig(&mut count, &mut arr) };
+        if !arr.is_null() {
+            unsafe { NetworkIsolationFreeAppContainers(arr.cast()) };
+        }
+        if rc == 0 { count } else { 0 }
+    }
+
+    /// STEP-1 fact #1 — the exemption write is admin-gated. Derive a throwaway AC SID (no
+    /// profile created) and attempt to add it to the machine-wide list via a read-modify-
+    /// write that PRESERVES existing entries; on success (elevated) restore the prior list
+    /// exactly. Unelevated ⇒ the Set must return ACCESS_DENIED; elevated ⇒ it must succeed.
+    fn exemption_admin_gate(fails: &mut u32, elevated: bool) {
+        use windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED;
+        use windows_sys::Win32::NetworkManagement::WindowsFirewall::{
+            NetworkIsolationFreeAppContainers, NetworkIsolationGetAppContainerConfig,
+            NetworkIsolationSetAppContainerConfig,
+        };
+        use windows_sys::Win32::Security::Isolation::DeriveAppContainerSidFromAppContainerName;
+        use windows_sys::Win32::Security::{FreeSid, PSID, SID_AND_ATTRIBUTES};
+
+        let name: Vec<u16> = "nub_sbx_gate_probe\0".encode_utf16().collect();
+        let mut sid: PSID = std::ptr::null_mut();
+        // SAFETY: derive-only (no profile); `sid` is an out-param freed below with FreeSid.
+        let hr = unsafe { DeriveAppContainerSidFromAppContainerName(name.as_ptr(), &mut sid) };
+        if hr != 0 || sid.is_null() {
+            *fails += 1;
+            eprintln!("FAIL exemption-gate setup: DeriveAppContainerSid hr=0x{hr:08x}");
+            return;
+        }
+        let mut count: u32 = 0;
+        let mut arr: *mut SID_AND_ATTRIBUTES = std::ptr::null_mut();
+        // SAFETY: read the current list (open unprivileged); `arr`/`count` are out-params.
+        let grc = unsafe { NetworkIsolationGetAppContainerConfig(&mut count, &mut arr) };
+        let existing: &[SID_AND_ATTRIBUTES] = if grc != 0 || arr.is_null() || count == 0 {
+            &[]
+        } else {
+            // SAFETY: `arr` names `count` entries per the successful Get.
+            unsafe { std::slice::from_raw_parts(arr, count as usize) }
+        };
+        let mut new_list = existing.to_vec();
+        new_list.push(SID_AND_ATTRIBUTES {
+            Sid: sid,
+            Attributes: 0,
+        });
+        // SAFETY: `new_list` outlives the call; its Sid pointers reference the live `arr`
+        // allocation or the caller-owned `sid` (freed only after).
+        let set_rc = unsafe {
+            NetworkIsolationSetAppContainerConfig(new_list.len() as u32, new_list.as_ptr())
+        };
+        // If the write actually landed (elevated), restore the exact prior list.
+        if set_rc == 0 {
+            let restore = if existing.is_empty() {
+                std::ptr::null()
+            } else {
+                existing.as_ptr()
+            };
+            // SAFETY: `existing` (borrowing `arr`) is still alive here.
+            unsafe { NetworkIsolationSetAppContainerConfig(count, restore) };
+        }
+        if !arr.is_null() {
+            unsafe { NetworkIsolationFreeAppContainers(arr.cast()) };
+        }
+        unsafe { FreeSid(sid) };
+
+        if elevated {
+            expect(
+                fails,
+                "exemption write SUCCEEDS when elevated",
+                set_rc as i32,
+                0,
+            );
+        } else {
+            expect(
+                fails,
+                "exemption write ACCESS_DENIED when NOT elevated (admin-gated)",
+                set_rc as i32,
+                ERROR_ACCESS_DENIED as i32,
+            );
+        }
+    }
+
+    /// STEP-1 facts #2/#3 (elevated) + the fail-closed path (unelevated), against the real
+    /// `apply`/`status` backend.
+    fn net_tier(fails: &mut u32, f: &Fixture, child: &Path) {
+        let elevated = test_is_elevated();
+        println!("== net tier: test process is_elevated = {elevated} ==");
+
+        // Fact #1: the exemption write is admin-gated (both branches assert the OS verdict).
+        exemption_admin_gate(fails, elevated);
+
+        if elevated {
+            let policy = per_host_policy(f);
+            let baseline = exemption_count();
+
+            // Fact #2a: the confined child REACHES nub's loopback egress proxy — the per-run
+            // exemption is live (contrast the "AppContainer child DENIED loopback" baseline
+            // above, which runs WITHOUT an exemption).
+            expect(
+                fails,
+                "Tier1: confined child REACHES the loopback egress proxy (exemption live)",
+                code(&policy, child, &["__sbxchild__", "connectenvproxy"]),
+                0,
+            );
+            // Fact #2b: direct external egress stays SEALED (internetClient withheld) — the
+            // exemption opens loopback ONLY, so nub's proxy is the child's sole egress.
+            expect_in(
+                fails,
+                "Tier1: direct external egress DENIED (proxy is the sole egress)",
+                code(
+                    &policy,
+                    child,
+                    &["__sbxchild__", "connect", "1.1.1.1", "443"],
+                ),
+                &[5, 6],
+            );
+            // Fact #3: the RAII teardown removed the per-run exemption — no list accretion.
+            let after = exemption_count();
+            if after == baseline {
+                println!("PASS Tier1 teardown: exemption list returned to baseline ({baseline})");
+            } else {
+                *fails += 1;
+                eprintln!(
+                    "FAIL Tier1 teardown: exemption list {after} != baseline {baseline} (leak)"
+                );
+            }
+        } else {
+            // Unelevated per-host must FAIL CLOSED with an elevation message — NEVER a silent
+            // coarse-degrade (the maintainer's informative-fail requirement).
+            let policy = per_host_policy(f);
+            let spec =
+                CommandSpec::new(child.as_os_str()).args(["__sbxchild__", "token"].iter().copied());
+            match apply(&policy, spec) {
+                Ok(_) => {
+                    *fails += 1;
+                    eprintln!("FAIL unelevated per-host must fail-closed, but apply() succeeded");
+                }
+                Err(d) => {
+                    let named = d.lost.iter().any(|s| s == "net-per-host");
+                    let explains = d.reason.as_deref().unwrap_or_default().contains("elevat");
+                    if named && explains {
+                        println!("PASS unelevated per-host FAILS CLOSED with an elevation message");
+                    } else {
+                        *fails += 1;
+                        eprintln!(
+                            "FAIL fail-closed shape: lost={:?} reason={:?}",
+                            d.lost, d.reason
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// The sandboxed run reaps the grandchild when `status()` closes the Job handle; the


### PR DESCRIPTION
Enables per-host network policy (Q21) and the MITM/credential-brokering tier (Q22) on Windows through an opt-in, UAC-elevated "strict Windows" tier, mirroring Codex and SRT.

## Why

A Windows AppContainer child is WFP-blocked from all loopback regardless of capability, so nub's loopback egress proxy — which per-host net and MITM both ride — is unreachable. The only lift, `NetworkIsolationSetAppContainerConfig` (a per-run AC-SID loopback exemption), requires administrator. On Windows, unlike macOS/Linux, OS-enforced per-host egress is unavoidably an elevated tier.

## What

- Coarse on/off (allow-all / deny-all) stays the unprivileged default, unchanged.
- Strict tier (elevated): register the per-run AC SID in the machine-wide loopback-exemption list (RMW, never clobbering other apps' entries); keep `internetClient` withheld so the exemption opens loopback only — nub's proxy is the child's sole egress; tear the exemption down on exit (RAII). MITM rides the same proxy via the existing CA-env bundle.
- Informative fail-closed: a per-host / MITM policy on a host where the exemption can't be registered (not elevated, or the write fails) returns a clear error naming the elevation requirement — never a silent coarse-degrade. A coarse-only policy is unaffected.
- The all-loopback widening during an exempted run is bounded to the per-run AC SID + teardown; documented in `LIMITATIONS.md` with the local-forwarder caveat.

## Validation

`net_tier` in `tests/windows_enforcement.rs` drives the real backend; run on a Windows Server 2022 VM under both a standard user (Medium IL) and an admin (High IL):

- Exemption write → `ACCESS_DENIED` unelevated / succeeds elevated.
- Elevated Tier-1 child reaches `127.0.0.1:<proxy>` but a direct external connect returns `WSAEACCES` (proxy is the sole egress).
- Teardown returns the exemption list to baseline.
- Unelevated per-host `apply()` fails closed with an elevation message.

Also fixes a latent break: the coarse-net case in `windows_enforcement.rs` did not compile after the MITM `NetPolicy` fields landed, and the `WAIT_ABANDONED` path in the exemption-RMW mutex re-abandoned the lock instead of releasing it.

Refs the sandbox Windows net-parity work (Q21/Q22). The one-time-UAC-persistent variant and the elevation UX are a follow-up product decision, not in this PR.
