### PR TITLE
sandbox(windows): fix E0063 in windows_enforcement NetPolicy initializer

### DIFF
--- a/crates/nub-sandbox/tests/windows_enforcement.rs
+++ b/crates/nub-sandbox/tests/windows_enforcement.rs
@@ -606,6 +606,7 @@ mod win {
             enforce: true,
             rules: Vec::new(),
             default_effect: Effect::Deny,
+            ..Default::default()
         };
         expect_in(
             &mut fails,


### PR DESCRIPTION
The U5 MITM tier (#414) added `mode`/`inspection`/`brokers` to `NetPolicy`; the net-only initializer in `tests/windows_enforcement.rs` wasn't updated, breaking the windows-only compile with `error[E0063]`. Adds `..Default::default()` (inert `Auto`/`Connection`/no-brokers) to match the `backend/windows.rs` initializers — no net behavior change.

Verified on the Windows VM: `cargo build -p nub-sandbox --all-targets` and `cargo clippy --all-targets --all-features -- -D warnings` exit 0; fmt clean.

Refs #414

https://claude.ai/code/session_01XFM2HhhMQFJCjuThKdwNt3