### PR TITLE
sandbox: resolve $(command) substitution in fs path values

### DIFF
--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -98,8 +98,10 @@ fn fold_fs_array_entry(
         Some(rest) => (rest, Effect::Deny),
         None => (s, Effect::Allow),
     };
-    // Array grants are ReadWrite; denies deny both.
-    push_fs_rules(pattern, effect, FsAccess::ReadWrite, ctx, out);
+    // `$(…)` resolves AFTER the `!` strip so a command's stdout is a path, never a
+    // deny operator it could smuggle in. Array grants are ReadWrite; denies deny both.
+    let pattern = resolve_fs_path(pattern, ctx, path)?;
+    push_fs_rules(&pattern, effect, FsAccess::ReadWrite, ctx, out);
     Ok(())
 }
 
@@ -139,7 +141,10 @@ fn fold_fs_object_entry(
             ));
         }
     };
-    push_fs_rules(key, effect, access, ctx, out);
+    // Resolve `$(…)` in the path key AFTER validating the access value, so an
+    // invalid `val` errors before any command runs (no wasted exec side effect).
+    let pattern = resolve_fs_path(key, ctx, path)?;
+    push_fs_rules(&pattern, effect, access, ctx, out);
     Ok(())
 }
 
@@ -168,6 +173,48 @@ fn push_fs_rules(
             effect,
             access,
         });
+    }
+}
+
+/// Resolve any `$(…)` command substitution in an fs PATH at config-LOAD time, via
+/// the shared [`resolve`] machinery: the command runs once and its stdout becomes
+/// the path, whole or embedded (`"$(pnpm store path)/v3"`), then flows into
+/// [`push_fs_rules`] exactly as a literal would (symbolic-expand + subtree-glob +
+/// canonicalize).
+///
+/// Fail-CLOSED corners — a resolved grant must never silently surprise. A command
+/// FAILURE surfaces via `resolve_with` as a hard [`CompileError::Substitution`]
+/// naming it. EMPTY output errors: an empty path would expand to a whole-fs `**`
+/// grant (fail-OPEN). MULTI-LINE output errors rather than silently truncating to a
+/// line that could grant the wrong subtree. Trailing whitespace is trimmed so a
+/// path is clean; interior whitespace is a legitimate path character and preserved.
+fn resolve_fs_path(raw: &str, ctx: &CompileCtx, path: &str) -> Result<String, CompileError> {
+    if resolve::has_substitution(raw) {
+        let resolved = resolve::resolve_with(raw, ctx.runner.as_ref())
+            .map_err(|e| CompileError::substitution(path, &e))?;
+        let resolved = resolved.trim_end().to_string();
+        if resolved.is_empty() {
+            return Err(CompileError::substitution(
+                path,
+                "`$(…)` produced empty output — expected a filesystem path",
+            ));
+        }
+        if resolved.contains(['\n', '\r']) {
+            return Err(CompileError::substitution(
+                path,
+                "`$(…)` produced multi-line output — a filesystem path must be a single line",
+            ));
+        }
+        Ok(resolved)
+    } else if resolve::has_open_substitution(raw) {
+        // A `$(` with no balanced close — name it rather than ship shell-looking
+        // text as a literal path (the same footgun the env path guards against).
+        Err(CompileError::substitution(
+            path,
+            resolve::UNTERMINATED_SUBST_MSG,
+        ))
+    } else {
+        Ok(raw.to_string())
     }
 }
 

--- a/crates/nub-sandbox/tests/common/mod.rs
+++ b/crates/nub-sandbox/tests/common/mod.rs
@@ -16,6 +16,11 @@ impl CommandRunner for StubRunner {
         match command {
             "echo hi" => Ok("hi\n".to_string()),
             "fail" => Err("stub failure".to_string()),
+            // Path-shaped stubs for fs `$(…)` tests: a clean single-line path (with
+            // the usual trailing newline), empty output, and multi-line output.
+            "store path" => Ok("/home/u/.store\n".to_string()),
+            "empty path" => Ok("\n".to_string()),
+            "two paths" => Ok("/home/u/a\n/home/u/b\n".to_string()),
             other => Ok(format!("STUB[{other}]")),
         }
     }

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -1234,3 +1234,78 @@ fn crlf_in_an_inject_value_is_rejected() {
     .unwrap_err();
     assert!(matches!(err, CompileError::Shape { .. }));
 }
+
+// ── fs $(…) command substitution ───────────────────────────────────────────────
+
+#[test]
+fn fs_substitution_resolves_and_grants_whole_and_embedded() {
+    // A `$(…)` fs path resolves at load time and flows into the matcher exactly as
+    // a literal would: whole-value (object key), embedded in a larger path, and the
+    // array form (ReadWrite). The stub `store path` → `/home/u/.store`.
+    use nub_sandbox::matcher::PathMatcher;
+    use nub_sandbox::policy::FsAccess;
+    let ctx = common::ctx(true, &[]);
+
+    let obj = compile(&json!({ "fs": { "$(store path)": "rw" } }), &ctx).unwrap();
+    let d = PathMatcher::new(&obj.fs.rules).decide(&common::homes().home.join(".store/x"));
+    assert!(matches!(d.effect, Effect::Allow) && matches!(d.access, FsAccess::ReadWrite));
+
+    let emb = compile(&json!({ "fs": { "$(store path)/v3": "r" } }), &ctx).unwrap();
+    let d = PathMatcher::new(&emb.fs.rules).decide(&common::homes().home.join(".store/v3/pkg"));
+    assert!(matches!(d.effect, Effect::Allow) && matches!(d.access, FsAccess::Read));
+
+    let arr = compile(&json!({ "fs": ["$(store path)"] }), &ctx).unwrap();
+    let d = PathMatcher::new(&arr.fs.rules).decide(&common::homes().home.join(".store/y"));
+    assert!(matches!(d.effect, Effect::Allow) && matches!(d.access, FsAccess::ReadWrite));
+
+    // `$(…)` resolution is UNCONDITIONAL — nub has no trust axis to gate on, so the
+    // `ctx` trust flag does not change whether a command runs.
+    let untrusted = compile(
+        &json!({ "fs": ["$(store path)"] }),
+        &common::ctx(false, &[]),
+    )
+    .unwrap();
+    let d = PathMatcher::new(&untrusted.fs.rules).decide(&common::homes().home.join(".store/z"));
+    assert!(matches!(d.effect, Effect::Allow));
+}
+
+#[test]
+fn fs_substitution_failure_empty_and_multiline_fail_closed() {
+    // Fail-CLOSED corners: a non-zero exit, empty output (would fail-OPEN to a
+    // whole-fs grant), and multi-line output are each a hard compile error naming
+    // the substitution — never a silently-dropped or wrong grant.
+    let ctx = common::ctx(true, &[]);
+    for (surface, needle) in [
+        (json!({ "fs": ["$(fail)"] }), "failure"),
+        (json!({ "fs": ["$(empty path)"] }), "empty"),
+        (json!({ "fs": ["$(two paths)"] }), "multi-line"),
+    ] {
+        match compile(&surface, &ctx).unwrap_err() {
+            CompileError::Substitution { message, .. } => {
+                assert!(message.contains(needle), "{message} (want {needle})");
+            }
+            other => panic!("expected a substitution error for {surface}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn fs_substitution_deny_prefix_and_unterminated() {
+    // `!$(…)` resolves the DENY target (the `!` is stripped before the command
+    // runs, so its output is a path, never a smuggled operator); an unterminated
+    // `$(` is named, not shipped as a literal path.
+    use nub_sandbox::matcher::PathMatcher;
+    let ctx = common::ctx(true, &[]);
+
+    let deny = compile(&json!({ "fs": [".", "!$(store path)"] }), &ctx).unwrap();
+    let d = PathMatcher::new(&deny.fs.rules).decide(&common::homes().home.join(".store/secret"));
+    assert!(
+        matches!(d.effect, Effect::Deny),
+        "!$(…) denies the resolved path"
+    );
+
+    match compile(&json!({ "fs": ["$(store path"] }), &ctx).unwrap_err() {
+        CompileError::Substitution { message, .. } => assert!(message.contains("closing")),
+        other => panic!("expected an unterminated-substitution error, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Adds `$(command)` substitution inside filesystem path values of the sandbox config language, so a cross-platform sandbox can resolve a machine-varying path instead of hard-coding it:

```jsonc
"fs": {
  "$(pnpm store path)": "r",       // pnpm's content-addressed store, wherever it lives
  "$(npm config get cache)": "rw", // the npm cache dir
  "$(pnpm store path)/v3": "rw"    // embedded — command output plus a suffix
}
```

A `$(command)` in an fs path (whole entry or embedded) runs once at config-load time; its stdout becomes the path, then flows into the fs policy exactly as a literal would (symbolic-root expansion, subtree glob, canonicalization, the `.env*` secret-deny, and the rest of the fs algebra). It resolves unconditionally — there is no trust gate on the substitution (nub has no trust axis to gate on).

## Mechanism

Reuses the shared env `$()` resolver (`compiler::resolve` — `resolve_with`, `has_substitution`, `has_open_substitution`) rather than forking a second one. The new `resolve_fs_path` in `fold.rs` is called from the two fs-fold entry points (`fold_fs_array_entry`, `fold_fs_object_entry`); a path with no `$(` is a byte-identical passthrough. In the array form the `!` deny prefix is stripped before resolution, so a command's output is always a path, never a smuggled operator.

## Fail-closed corners

| Corner | Result |
|---|---|
| command failure (non-zero exit / spawn error) | compile error naming the substitution — never a silently dropped grant |
| empty output | compile error (an empty path would fail-open to a whole-filesystem grant) |
| multi-line output | compile error (never truncated to a line that could grant the wrong subtree) |
| trailing whitespace / newline | trimmed; interior whitespace kept (paths may contain spaces) |
| unterminated `$(` | compile error (never shipped as a literal path) |

## Verification

- `cargo clippy -p nub-sandbox --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and the full `nub-sandbox` suite — green locally.
- Distilled tests added to `tests/compiler.rs` (resolve + grant whole/embedded/array, ungated resolution, the fail-closed corners, `!$(…)` deny, unterminated).
- Real-shell e2e (throwaway, not committed): `$(echo /tmp/x)` grants, embedded resolves, `$(false)`/empty/multi-line each error.

Changes are localized to the `$()`-path-resolution path to keep the merge with the concurrent fs-axis work (#431) small.

Refs the sandbox config-language epic.
