### PR TITLE
sandbox(windows): fix STATUS_HEAP_CORRUPTION in the loopback-exemption free (#433 net tier)

### DIFF
--- a/crates/nub-sandbox/Cargo.toml
+++ b/crates/nub-sandbox/Cargo.toml
@@ -103,7 +103,7 @@ base64 = "0.22"
 # needs a little FFI (token-query + process-liveness) beyond what the lib exposes.
 [target.'cfg(target_os = "windows")'.dev-dependencies.windows-sys]
 version = "0.61"
-features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Isolation", "Win32_System_Threading", "Win32_System_Diagnostics_Debug", "Win32_System_Pipes", "Win32_Storage_FileSystem", "Win32_NetworkManagement_WindowsFirewall"]
+features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Isolation", "Win32_System_Threading", "Win32_System_Memory", "Win32_System_Diagnostics_Debug", "Win32_System_Pipes", "Win32_Storage_FileSystem", "Win32_NetworkManagement_WindowsFirewall"]
 
 # The Windows enforcement probe self-reexecs as the AppContainer child, so it owns
 # `main` (dispatch on argv) rather than the libtest harness. windows-latest CI only; a

--- a/crates/nub-sandbox/src/backend/windows.rs
+++ b/crates/nub-sandbox/src/backend/windows.rs
@@ -647,8 +647,7 @@ mod launch {
         SetHandleInformation, WAIT_ABANDONED, WAIT_OBJECT_0,
     };
     use windows_sys::Win32::NetworkManagement::WindowsFirewall::{
-        NetworkIsolationFreeAppContainers, NetworkIsolationGetAppContainerConfig,
-        NetworkIsolationSetAppContainerConfig,
+        NetworkIsolationGetAppContainerConfig, NetworkIsolationSetAppContainerConfig,
     };
     use windows_sys::Win32::Security::Authorization::{
         ConvertStringSidToSidW, EXPLICIT_ACCESS_W, GRANT_ACCESS, GetNamedSecurityInfoW,
@@ -668,6 +667,7 @@ mod launch {
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
         SetInformationJobObject,
     };
+    use windows_sys::Win32::System::Memory::{GetProcessHeap, HeapFree};
     use windows_sys::Win32::System::Threading::{
         CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateMutexW, CreateProcessW,
         DeleteProcThreadAttributeList, EXTENDED_STARTUPINFO_PRESENT, GetCurrentProcess,
@@ -762,6 +762,32 @@ mod launch {
         out
     }
 
+    /// Free the buffer `NetworkIsolationGetAppContainerConfig` hands back. That buffer is a
+    /// process-heap allocation — the `SID_AND_ATTRIBUTES` array plus a separate heap block per
+    /// entry `Sid` — so the matching deallocator is `HeapFree` on the process heap for each
+    /// `Sid` then the array (the MSDN `FreeAppContainerConfig` sample). It is NOT freed with
+    /// `NetworkIsolationFreeAppContainers`: that is the deallocator for
+    /// `NetworkIsolationEnumAppContainers`'s much larger `INET_FIREWALL_APP_CONTAINER` records,
+    /// and pointing it at a `SID_AND_ATTRIBUTES` array type-confuses the walk into freeing
+    /// garbage interior pointers → STATUS_HEAP_CORRUPTION (windows-latest MSVC; #433).
+    fn free_app_container_config(arr: *mut SID_AND_ATTRIBUTES, count: u32) {
+        if arr.is_null() {
+            return;
+        }
+        // SAFETY: `arr`/`count` come from a successful `NetworkIsolationGetAppContainerConfig`,
+        // which allocates the array and each entry's `Sid` on the process heap.
+        unsafe {
+            let heap = GetProcessHeap();
+            for i in 0..count as usize {
+                let sid = (*arr.add(i)).Sid;
+                if !sid.is_null() {
+                    HeapFree(heap, 0, sid.cast());
+                }
+            }
+            HeapFree(heap, 0, arr.cast());
+        }
+    }
+
     /// Add or remove `sid` in the machine-wide AppContainer loopback-exemption list via a
     /// read-modify-write (`NetworkIsolationSetAppContainerConfig` REPLACES the whole list,
     /// so the current entries must be preserved — never clobber other apps' exemptions).
@@ -806,9 +832,7 @@ mod launch {
                 )
             };
             // Free the got list AFTER Set (new_list borrowed its Sid pointers).
-            if !arr.is_null() {
-                unsafe { NetworkIsolationFreeAppContainers(arr.cast()) };
-            }
+            free_app_container_config(arr, count);
             if set_rc != 0 {
                 return Err(io::Error::from_raw_os_error(set_rc as i32));
             }

--- a/crates/nub-sandbox/tests/windows_enforcement.rs
+++ b/crates/nub-sandbox/tests/windows_enforcement.rs
@@ -946,20 +946,39 @@ mod win {
         }
     }
 
+    /// Free the `NetworkIsolationGetAppContainerConfig` buffer with its matching process-heap
+    /// deallocator (HeapFree each entry's `Sid`, then the array — the MSDN `FreeAppContainerConfig`
+    /// sample). NOT `NetworkIsolationFreeAppContainers`, whose `INET_FIREWALL_APP_CONTAINER` walk
+    /// type-confuses a `SID_AND_ATTRIBUTES` array into a STATUS_HEAP_CORRUPTION (#433).
+    fn free_ac_config(arr: *mut windows_sys::Win32::Security::SID_AND_ATTRIBUTES, count: u32) {
+        use windows_sys::Win32::System::Memory::{GetProcessHeap, HeapFree};
+        if arr.is_null() {
+            return;
+        }
+        // SAFETY: `arr`/`count` come from a successful Get, which allocates the array and each
+        // entry's `Sid` on the process heap.
+        unsafe {
+            let heap = GetProcessHeap();
+            for i in 0..count as usize {
+                let sid = (*arr.add(i)).Sid;
+                if !sid.is_null() {
+                    HeapFree(heap, 0, sid.cast());
+                }
+            }
+            HeapFree(heap, 0, arr.cast());
+        }
+    }
+
     /// Size of the machine-wide AppContainer loopback-exemption list (read path is open
     /// even unprivileged). Used to prove per-run teardown leaves no accretion.
     fn exemption_count() -> u32 {
-        use windows_sys::Win32::NetworkManagement::WindowsFirewall::{
-            NetworkIsolationFreeAppContainers, NetworkIsolationGetAppContainerConfig,
-        };
+        use windows_sys::Win32::NetworkManagement::WindowsFirewall::NetworkIsolationGetAppContainerConfig;
         use windows_sys::Win32::Security::SID_AND_ATTRIBUTES;
         let mut count: u32 = 0;
         let mut arr: *mut SID_AND_ATTRIBUTES = std::ptr::null_mut();
         // SAFETY: out-params for the current list; the returned array is freed immediately.
         let rc = unsafe { NetworkIsolationGetAppContainerConfig(&mut count, &mut arr) };
-        if !arr.is_null() {
-            unsafe { NetworkIsolationFreeAppContainers(arr.cast()) };
-        }
+        free_ac_config(arr, count);
         if rc == 0 { count } else { 0 }
     }
 
@@ -970,8 +989,7 @@ mod win {
     fn exemption_admin_gate(fails: &mut u32, elevated: bool) {
         use windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED;
         use windows_sys::Win32::NetworkManagement::WindowsFirewall::{
-            NetworkIsolationFreeAppContainers, NetworkIsolationGetAppContainerConfig,
-            NetworkIsolationSetAppContainerConfig,
+            NetworkIsolationGetAppContainerConfig, NetworkIsolationSetAppContainerConfig,
         };
         use windows_sys::Win32::Security::Isolation::DeriveAppContainerSidFromAppContainerName;
         use windows_sys::Win32::Security::{FreeSid, PSID, SID_AND_ATTRIBUTES};
@@ -1015,9 +1033,7 @@ mod win {
             // SAFETY: `existing` (borrowing `arr`) is still alive here.
             unsafe { NetworkIsolationSetAppContainerConfig(count, restore) };
         }
-        if !arr.is_null() {
-            unsafe { NetworkIsolationFreeAppContainers(arr.cast()) };
-        }
+        free_ac_config(arr, count);
         unsafe { FreeSid(sid) };
 
         if elevated {


### PR DESCRIPTION
The #433 net-tier test crashed the windows-latest conformance run with exit code `0xC0000374` (STATUS_HEAP_CORRUPTION), immediately after `PASS exemption write SUCCEEDS when elevated`. The windows-gnu VM validation had passed, so the break only surfaced on CI.

## Root cause

`NetworkIsolationGetAppContainerConfig` returns a process-heap array of `SID_AND_ATTRIBUTES` (16 bytes each). #433 freed it with `NetworkIsolationFreeAppContainers`, casting the pointer to `*const INET_FIREWALL_APP_CONTAINER`. That function is the deallocator for `NetworkIsolationEnumAppContainers`'s much larger (88-byte) records — it walks each element freeing interior pointers, so over a `SID_AND_ATTRIBUTES` array it frees garbage and corrupts the process heap.

The corruption is nondeterministic and toolchain-surfacing: on windows-msvc the bad free faults; on windows-gnu the same call returns an error code without corrupting — which is why the gnu VM passed and MSVC CI did not.

## Fix

Free the buffer with its matching deallocator — `HeapFree(GetProcessHeap(), 0, ...)` for each entry's `Sid` then the array, per the MSDN `FreeAppContainerConfig` sample. Applied at all three call sites (backend `set_loopback_exemption` plus the `exemption_count` / `exemption_admin_gate` test helpers), plus the `Win32_System_Memory` dev-dependency feature the test now uses. The exemption register/teardown semantics are unchanged; no macOS/Linux path is touched.

## Verification

Reproduced and fixed on real MSVC. A branch-scoped windows-latest run of the actual `windows_enforcement` net-tier test is green under the elevated runner — exemption write succeeds, the confined child reaches the loopback proxy, direct external egress stays denied, and the RAII teardown returns the list to baseline. windows-gnu `check --all-targets` + `clippy -D warnings` and `fmt` are clean.

Refs #414
