### PR TITLE
fix(lockfile): tolerate nested-map engines values in pnpm-lock.yaml

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/pnpm/raw.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/raw.rs
@@ -288,7 +288,10 @@ pub(super) struct RawCatalogEntry {
 #[serde(rename_all = "camelCase")]
 pub(super) struct RawPackageInfo {
     pub(super) resolution: Option<Resolution>,
-    #[serde(default)]
+    // Legacy packages (e.g. cordova plugins) carry a nested `cordovaDependencies`
+    // map under `engines`, which pnpm preserves verbatim; keep string-valued
+    // engine entries and drop the nested non-string ones (engine-check-irrelevant).
+    #[serde(default, deserialize_with = "aube_manifest::engines_tolerant")]
     pub(super) engines: BTreeMap<String, String>,
     pub(super) peer_dependencies: Option<BTreeMap<String, String>>,
     pub(super) peer_dependencies_meta: Option<BTreeMap<String, RawPeerDepMeta>>,

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
@@ -321,6 +321,59 @@ snapshots:
 }
 
 #[test]
+fn pnpm_engines_tolerates_nested_map_value() {
+    // Legacy packages (cordova-plugin-inappbrowser, #417) write a nested
+    // `cordovaDependencies` map under `engines`; a strict map<string,string>
+    // deserializer trips on it and fails the whole install.
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &lockfile_path,
+        r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      cordova-plugin-inappbrowser:
+        specifier: 6.0.0
+        version: 6.0.0
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+
+packages:
+  cordova-plugin-inappbrowser@6.0.0:
+    resolution: {integrity: sha512-nested}
+    engines: {cordovaDependencies: {0.2.3: {cordova: '>=3.1.0'}, 6.0.0: {cordova: '>=9.0.0'}}}
+  lodash@4.17.21:
+    resolution: {integrity: sha512-ordinary}
+    engines: {node: '>=8'}
+
+snapshots:
+  cordova-plugin-inappbrowser@6.0.0: {}
+  lodash@4.17.21: {}
+"#,
+    )
+    .unwrap();
+
+    let graph = parse(&lockfile_path).unwrap();
+    // Nested-map entry is dropped (not an engine range), so the package
+    // parses with no engine constraints...
+    assert!(
+        graph.packages["cordova-plugin-inappbrowser@6.0.0"]
+            .engines
+            .is_empty(),
+        "nested cordovaDependencies map must be dropped from engines"
+    );
+    // ...while an ordinary string-valued engines map is preserved intact.
+    assert_eq!(
+        graph.packages["lodash@4.17.21"].engines.get("node"),
+        Some(&">=8".to_string()),
+    );
+}
+
+#[test]
 fn parse_local_snapshot_optional_dependencies_as_edges() {
     let dir = tempfile::tempdir().unwrap();
     let lockfile_path = dir.path().join("pnpm-lock.yaml");


### PR DESCRIPTION
`nub install` aborted with `ERR_NUB_MANIFEST_PARSE` on a valid `pnpm-lock.yaml` when a package's `engines:` value was a nested map. Legacy packages such as `cordova-plugin-inappbrowser` write `engines: {cordovaDependencies: {...}}`, which pnpm preserves verbatim.

Cause: the pnpm parser typed `RawPackageInfo.engines` as a strict `BTreeMap<String, String>`, so serde failed with "invalid type: map, expected a string".

Fix: apply the `aube_manifest::engines_tolerant` deserializer the manifest parser already uses for this shape — keep string-valued engine entries, drop nested/non-string ones (engine-check-irrelevant). Both pnpm parse paths build `RawPackageInfo` via serde, so the one field attribute covers both.

Regression test `pnpm_engines_tolerates_nested_map_value` parses a lockfile carrying the nested `cordovaDependencies` shape alongside an ordinary `engines: {node: '>=8'}`, and asserts the nested entry is dropped while the ordinary one is preserved.

Fixes #417