### PR TITLE
fix(install): resolve a newly-added workspace member on the shared lockfile layout

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/drift.rs
+++ b/vendor/aube/crates/aube-lockfile/src/drift.rs
@@ -483,8 +483,19 @@ impl LockfileGraph {
             .map(|v| v.as_slice())
             .unwrap_or(&[]);
 
-        // Skip the check entirely if no DirectDep has a specifier (non-pnpm format).
-        if importer_deps.iter().all(|d| d.specifier.is_none()) {
+        // Skip the check entirely if the importer's recorded deps carry no
+        // specifier (a non-pnpm lockfile format that doesn't record them).
+        // Guard on the importer actually being present in the lockfile: a
+        // brand-new workspace member absent from it has an empty
+        // `importer_deps`, for which `all(specifier.is_none())` is vacuously
+        // true — skipping here would wrongly report the new member Fresh and
+        // its declared deps would never resolve (nubjs/nub#441). Falling
+        // through instead makes each manifest dep read as added against the
+        // empty locked specs (Stale), while a depless new member still reads
+        // Fresh (nothing to add — matches a `workspace:*` link with no deps).
+        if self.importers.contains_key(importer_path)
+            && importer_deps.iter().all(|d| d.specifier.is_none())
+        {
             return DriftStatus::Fresh;
         }
         let lockfile_specs: BTreeMap<&str, &str> = importer_deps
@@ -2364,6 +2375,67 @@ mod drift_tests {
         assert_eq!(
             graph.check_drift_workspace(
                 &workspace_manifests,
+                &BTreeMap::new(),
+                &[],
+                &BTreeMap::new(),
+                true,
+            ),
+            DriftStatus::Fresh
+        );
+    }
+
+    #[test]
+    fn workspace_drift_stale_when_member_added_with_deps_but_absent_from_lockfile() {
+        // A newly-added workspace member with deps (present in the manifests,
+        // absent from the lockfile importers) must invalidate the lockfile so
+        // its deps get resolved — the `Prefer`-mode counterpart to the
+        // warm-path new-member check (nubjs/nub#441). The per-importer loop's
+        // `all(specifier.is_none())` early-return is vacuously true for the
+        // empty lockfile entry, so without the presence guard the member reads
+        // Fresh and its deps silently never resolve. A depless new member,
+        // however, legitimately has no importer entry and stays Fresh (see
+        // `workspace_drift_allows_root_links_for_workspace_packages`).
+        let root_dep = DirectDep {
+            name: "lodash".into(),
+            dep_path: "lodash@4.17.21".into(),
+            dep_type: DepType::Production,
+            specifier: Some("^4.17.0".into()),
+        };
+        let mut importers = BTreeMap::new();
+        importers.insert(".".to_string(), vec![root_dep]);
+        let graph = LockfileGraph {
+            importers,
+            packages: BTreeMap::new(),
+            ..Default::default()
+        };
+        let root = (".".to_string(), make_manifest(&[("lodash", "^4.17.0")]));
+
+        // New member WITH deps → stale (its react dep can't be satisfied by a
+        // non-existent importer entry).
+        assert_eq!(
+            graph.check_drift_workspace(
+                &[
+                    root.clone(),
+                    (
+                        "packages/web".to_string(),
+                        make_manifest(&[("react", "^19.0.0")]),
+                    ),
+                ],
+                &BTreeMap::new(),
+                &[],
+                &BTreeMap::new(),
+                true,
+            ),
+            DriftStatus::Stale {
+                reason: "packages/web: manifest adds react@^19.0.0".to_string()
+            }
+        );
+
+        // New member with NO deps → fresh (nothing to install; matches the
+        // depless `workspace:*` link invariant).
+        assert_eq!(
+            graph.check_drift_workspace(
+                &[root, ("packages/web".to_string(), make_manifest(&[]))],
                 &BTreeMap::new(),
                 &[],
                 &BTreeMap::new(),

--- a/vendor/aube/crates/aube-util/src/hash.rs
+++ b/vendor/aube/crates/aube-util/src/hash.rs
@@ -245,6 +245,10 @@ pub const INSTALL_SHAPE_FIELDS: &[&str] = &[
     "catalog",
     "catalogs",
     "dependencies",
+    // `dependenciesMeta.<dep>.injected` reshapes the tree (top-level symlink
+    // ⇄ injected hard copy) and `.built` flips a dep's build policy, so a
+    // change to it must invalidate the install — it was silently ignored.
+    "dependenciesMeta",
     "devDependencies",
     "engines",
     "name",
@@ -255,6 +259,9 @@ pub const INSTALL_SHAPE_FIELDS: &[&str] = &[
     "pnpm",
     "publishConfig",
     "resolutions",
+    // Bun/Yarn build-policy allowlist: a newly-trusted dep must re-run its
+    // (previously-skipped) build script, so an edit must invalidate the install.
+    "trustedDependencies",
     "version",
     "workspaces",
 ];
@@ -426,6 +433,38 @@ mod tests {
             serde_json::from_str(r#"{"dependencies":{"react":"19.0.0"}}"#).unwrap();
         let b: serde_json::Value =
             serde_json::from_str(r#"{"dependencies":{"react":"19.1.0"}}"#).unwrap();
+        assert_ne!(
+            manifest_install_shape_digest(&a),
+            manifest_install_shape_digest(&b)
+        );
+    }
+
+    #[test]
+    fn manifest_digest_reacts_to_dependencies_meta_change() {
+        // Toggling `dependenciesMeta.<dep>.injected` reshapes the on-disk tree,
+        // so it must change the shape digest (was silently ignored).
+        let a: serde_json::Value =
+            serde_json::from_str(r#"{"dependencies":{"@x/lib":"workspace:*"}}"#).unwrap();
+        let b: serde_json::Value = serde_json::from_str(
+            r#"{"dependencies":{"@x/lib":"workspace:*"},"dependenciesMeta":{"@x/lib":{"injected":true}}}"#,
+        )
+        .unwrap();
+        assert_ne!(
+            manifest_install_shape_digest(&a),
+            manifest_install_shape_digest(&b)
+        );
+    }
+
+    #[test]
+    fn manifest_digest_reacts_to_trusted_dependencies_change() {
+        // Adding a dep to `trustedDependencies` allow-lists its build script,
+        // which must re-run — so the shape digest must change.
+        let a: serde_json::Value =
+            serde_json::from_str(r#"{"dependencies":{"esbuild":"0.24.0"}}"#).unwrap();
+        let b: serde_json::Value = serde_json::from_str(
+            r#"{"dependencies":{"esbuild":"0.24.0"},"trustedDependencies":["esbuild"]}"#,
+        )
+        .unwrap();
         assert_ne!(
             manifest_install_shape_digest(&a),
             manifest_install_shape_digest(&b)

--- a/vendor/aube/crates/aube/src/commands/install/workspace.rs
+++ b/vendor/aube/crates/aube/src/commands/install/workspace.rs
@@ -223,8 +223,10 @@ pub(super) fn importer_project_dir(
 /// closure in. Members already present in `graph` (the cold/resolve path
 /// produces every importer) are skipped, so this is a no-op there.
 /// Best-effort: a member without a parseable lockfile is skipped — a
-/// genuinely new member busts the warm path through its manifest hash and
-/// gets a full resolve instead.
+/// genuinely new member busts the warm path (via `state::new_workspace_member`,
+/// or `member_lockfiles_stale` under `sharedWorkspaceLockfile=false`) and gets
+/// a full resolve instead, so this merge only ever runs on the warm path for
+/// members already present at the last install.
 pub(super) fn merge_member_lockfile_graphs(
     workspace_root: &std::path::Path,
     graph: &mut aube_lockfile::LockfileGraph,

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -379,6 +379,22 @@ fn check_needs_install_compute(
     }
     drop(_diag_pjs);
 
+    // `package_jsons_stale` only revisits members recorded at the last
+    // install, so a member added *since* has no recorded manifest hash and
+    // is invisible to it. Under `sharedWorkspaceLockfile=false` the
+    // `member_lockfiles_stale` check above already busts on a new member,
+    // but the default shared layout records no per-member lockfile state,
+    // so nothing there re-enumerates the workspace — a newly-added member
+    // silently reports "up to date" (nubjs/nub#441). Fill that gap by
+    // re-enumerating current members whenever no per-member lockfile state
+    // was recorded (shared layout, and a per-project layout that had no
+    // members last install); the non-empty case is already covered above.
+    if state.member_lockfile_hashes.is_empty()
+        && let Some(reason) = new_workspace_member(project_dir, &state)
+    {
+        return Some(reason);
+    }
+
     if state.section_filtered {
         return Some(
             "previous install omitted dependency sections; auto-installing full graph".into(),
@@ -548,6 +564,27 @@ fn member_lockfiles_stale(project_dir: &Path, state: &FreshnessState) -> Option<
     for key in state.member_lockfile_hashes.keys() {
         if !seen.contains(key) {
             return Some(format!("{key} was removed from the workspace"));
+        }
+    }
+    None
+}
+
+/// Detect a workspace member added since the last install. Complements
+/// [`package_jsons_stale`], which only revisits members it *recorded* (so it
+/// catches an edited or deleted member but never a newly-added one). Every
+/// current member's manifest is keyed the way the state file records it —
+/// `relative_path_or_original` of the member's `package.json`, matching
+/// [`collect_package_json_hashes_from_manifests`] — and a member whose key is
+/// absent from `package_json_hashes` is new. Returns `Some(reason)` on the
+/// first new member, `None` when every current member was already recorded.
+/// Non-workspace projects enumerate to nothing and no-op.
+fn new_workspace_member(project_dir: &Path, state: &FreshnessState) -> Option<String> {
+    let members = aube_workspace::find_workspace_packages(project_dir).unwrap_or_default();
+    for member_dir in &members {
+        let manifest_key = relative_path_or_original(&member_dir.join("package.json"), project_dir);
+        if !state.package_json_hashes.contains_key(&manifest_key) {
+            let dir_key = relative_path_or_original(member_dir, project_dir);
+            return Some(format!("{dir_key} is a new workspace member"));
         }
     }
     None
@@ -1449,8 +1486,9 @@ mod tests {
     use super::{
         InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
         collect_package_json_hashes_from_manifests, empty_blake3_hash, fresh_state_file, hash_file,
-        hash_settings, install_state_file, member_lockfiles_stale, read_or_migrate_fresh_state,
-        relative_path_or_original, remove_state, verify_install_layout,
+        hash_settings, install_state_file, member_lockfiles_stale, new_workspace_member,
+        read_or_migrate_fresh_state, relative_path_or_original, remove_state,
+        verify_install_layout,
     };
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -2044,6 +2082,64 @@ mod tests {
         assert_eq!(
             member_lockfiles_stale(&dir, &state),
             Some("packages/b was removed from the workspace".to_string())
+        );
+    }
+
+    #[test]
+    fn new_workspace_member_busts_warm_path_on_shared_layout() {
+        // The default `sharedWorkspaceLockfile=true` layout records no
+        // per-member lockfile state, so `member_lockfiles_stale` never runs
+        // and a member added after the last install is otherwise invisible
+        // to the warm path (nubjs/nub#441). `new_workspace_member` fills the
+        // gap by re-enumerating current members against the recorded manifest
+        // hashes — keyed by the member's `package.json` path, matching
+        // `collect_package_json_hashes_from_manifests`.
+        let dir = temp_project_dir("new-workspace-member");
+        std::fs::write(dir.join("pnpm-workspace.yaml"), "packages:\n  - 'apps/*'\n").unwrap();
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"root","private":true}"#,
+        )
+        .unwrap();
+        let write_member = |name: &str| {
+            let d = dir.join("apps").join(name);
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(d.join("package.json"), format!("{{\"name\":\"{name}\"}}")).unwrap();
+        };
+        write_member("server");
+
+        // State from the last install: only the root and `apps/server` are
+        // recorded, keyed by their package.json paths. No member lockfile
+        // state (shared layout).
+        let mut package_json_hashes = BTreeMap::new();
+        package_json_hashes.insert(".".to_string(), hash_file(&dir.join("package.json")));
+        package_json_hashes.insert(
+            "apps/server/package.json".to_string(),
+            hash_file(&dir.join("apps/server/package.json")),
+        );
+        let state = super::FreshnessState {
+            lockfile_hash: String::new(),
+            lockfile_snapshot_name: None,
+            member_lockfile_hashes: BTreeMap::new(),
+            member_lockfile_meta: BTreeMap::new(),
+            package_json_hashes,
+            package_json_meta: BTreeMap::new(),
+            section_filtered: false,
+            settings_hash: String::new(),
+            dep_build_policy_hash: String::new(),
+            package_json_shape_digests: BTreeMap::new(),
+            layout: None,
+            unreviewed_builds: Vec::new(),
+        };
+
+        // Every current member was recorded → fresh.
+        assert_eq!(new_workspace_member(&dir, &state), None);
+
+        // Adding `apps/web` after the last install busts the warm path.
+        write_member("web");
+        assert_eq!(
+            new_workspace_member(&dir, &state),
+            Some("apps/web is a new workspace member".to_string())
         );
     }
 

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -571,19 +571,29 @@ fn member_lockfiles_stale(project_dir: &Path, state: &FreshnessState) -> Option<
 
 /// Detect a workspace member added since the last install. Complements
 /// [`package_jsons_stale`], which only revisits members it *recorded* (so it
-/// catches an edited or deleted member but never a newly-added one). Every
-/// current member's manifest is keyed the way the state file records it —
-/// `relative_path_or_original` of the member's `package.json`, matching
-/// [`collect_package_json_hashes_from_manifests`] — and a member whose key is
-/// absent from `package_json_hashes` is new. Returns `Some(reason)` on the
-/// first new member, `None` when every current member was already recorded.
+/// catches an edited or deleted member but never a newly-added one). Each
+/// current member is keyed exactly the way [`collect_package_json_hashes_from_manifests`]
+/// records it — the root-as-member (`packages: ['.']`) under `.`, every other
+/// member under `<rel>/package.json` — and a member whose key is absent from
+/// `package_json_hashes` is new. Returns `Some(reason)` on the first new
+/// member, `None` when every current member was already recorded.
 /// Non-workspace projects enumerate to nothing and no-op.
 fn new_workspace_member(project_dir: &Path, state: &FreshnessState) -> Option<String> {
     let members = aube_workspace::find_workspace_packages(project_dir).unwrap_or_default();
     for member_dir in &members {
-        let manifest_key = relative_path_or_original(&member_dir.join("package.json"), project_dir);
+        let rel = relative_path_or_original(member_dir, project_dir);
+        // A workspace that lists its own root (`packages: ['.']`) yields an
+        // empty rel for the root member, recorded under "." — mirror that
+        // special-case so the root never reads as a spurious "new member"
+        // and churns the warm path on every install.
+        let is_root = rel.is_empty() || rel == ".";
+        let manifest_key = if is_root {
+            ".".to_string()
+        } else {
+            relative_path_or_original(&member_dir.join("package.json"), project_dir)
+        };
         if !state.package_json_hashes.contains_key(&manifest_key) {
-            let dir_key = relative_path_or_original(member_dir, project_dir);
+            let dir_key = if is_root { ".".to_string() } else { rel };
             return Some(format!("{dir_key} is a new workspace member"));
         }
     }
@@ -2141,6 +2151,54 @@ mod tests {
             new_workspace_member(&dir, &state),
             Some("apps/web is a new workspace member".to_string())
         );
+    }
+
+    #[test]
+    fn new_workspace_member_root_as_member_does_not_churn() {
+        // A workspace that lists its own root (`packages: ['.']`, the pnpm
+        // pattern where the root is itself a package members depend on) must
+        // not read the root as a spurious "new member": the root is recorded
+        // under "." but enumerates with an empty rel, so a naive
+        // `<rel>/package.json` key would never match and bust the warm path on
+        // every install.
+        let dir = temp_project_dir("new-member-root-as-member");
+        std::fs::write(
+            dir.join("pnpm-workspace.yaml"),
+            "packages:\n  - '.'\n  - 'apps/*'\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"root","private":true}"#,
+        )
+        .unwrap();
+        let app = dir.join("apps/server");
+        std::fs::create_dir_all(&app).unwrap();
+        std::fs::write(app.join("package.json"), r#"{"name":"server"}"#).unwrap();
+
+        let mut package_json_hashes = BTreeMap::new();
+        package_json_hashes.insert(".".to_string(), hash_file(&dir.join("package.json")));
+        package_json_hashes.insert(
+            "apps/server/package.json".to_string(),
+            hash_file(&app.join("package.json")),
+        );
+        let state = super::FreshnessState {
+            lockfile_hash: String::new(),
+            lockfile_snapshot_name: None,
+            member_lockfile_hashes: BTreeMap::new(),
+            member_lockfile_meta: BTreeMap::new(),
+            package_json_hashes,
+            package_json_meta: BTreeMap::new(),
+            section_filtered: false,
+            settings_hash: String::new(),
+            dep_build_policy_hash: String::new(),
+            package_json_shape_digests: BTreeMap::new(),
+            layout: None,
+            unreviewed_builds: Vec::new(),
+        };
+
+        // Root + apps/server both recorded → fresh (no churn on the root).
+        assert_eq!(new_workspace_member(&dir, &state), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes warm-path freshness gaps where `nub install` reported "up to date" despite a real change.

**#441**: a workspace member added after the first install (shared-lockfile layout) was skipped — only `--force` worked. Two gates missed it: `check_needs_install` (added `new_workspace_member`, re-enumerating members) and the drift check (guarded a vacuous `Fresh` for a new importer). Also fixed `packages: ['.']` root-member warm-path churn.

**Plus** two sibling gaps: `manifest_install_shape_digest` ignored `dependenciesMeta` (injected/built) and `trustedDependencies`, so edits to either silently no-op'd — added both.

Verified e2e; edit/remove/depless/root/injected/trusted regression-checked. Unit tests at each gate.

Closes #441