### PR TITLE
feat(pm): version-gate the Expo GVS eject on SDK 56

### DIFF
--- a/crates/nub-cli/src/pm_engine/expo_compat.rs
+++ b/crates/nub-cli/src/pm_engine/expo_compat.rs
@@ -1,0 +1,122 @@
+//! Version-gated GVS eject for Expo.
+//!
+//! Expo gained global-virtual-store compatibility in **SDK 56** via its
+//! "On-demand Filesystem" (`@expo/cli` 56.0.0 / the `@expo/metro-file-map`
+//! fork), which lets Metro follow symlinks out of `watchFolders` into a
+//! machine-global store. Below SDK 56 Expo uses the eager `metro-file-map`
+//! realpath crawl, which cannot reach nub's machine-global store — the same
+//! store-locality break as bare `react-native`, so those projects must fall
+//! back to a project-local store.
+//!
+//! `react-native` ejects unconditionally (no version gates it — On-demand FS is
+//! an Expo-CLI feature, absent from upstream Metro at every RN version). `expo`
+//! is version-conditional: eject below the floor, leave GVS on at/above it. The
+//! SDK number tracks the top-level `expo` major exactly (SDK 56 → `expo@56.x`),
+//! which is Expo's own doctor predicate (`semver.satisfies(sdkVersion,
+//! '>=56.0.0')`), so the declared `expo` range is the signal.
+//!
+//! Defaults are computed before resolution, so only the DECLARED range in the
+//! root manifest is available (not a resolved version). A range whose major
+//! can't be read pre-resolution (`*`, `latest`, a compound `>=50 <60`, a
+//! `catalog:`/`workspace:` protocol spec) is treated as below-floor and EJECTS —
+//! the safe direction, matching `react-native`: the worst case is a redundant
+//! project-local install, never a broken one. The residual case the version
+//! gate can't see is a 56+ project that disables On-demand FS via
+//! `experiments.onDemandFilesystem: false`, which lives in `app.json`/
+//! `app.config.*` rather than `package.json`; that is an accepted, documented
+//! edge case.
+
+use std::path::Path;
+
+/// The `expo` major at and above which the On-demand Filesystem makes a project
+/// GVS-compatible (Expo SDK 56).
+const EXPO_GVS_FLOOR: u32 = 56;
+
+/// Whether the project at `root` declares an `expo` dependency whose SDK is
+/// below the GVS floor — i.e. GVS must be ejected for it. `false` when `expo`
+/// is not a direct dependency (not an Expo project) or its declared major is
+/// `>= EXPO_GVS_FLOOR`; `true` when it is below the floor OR the range can't be
+/// floor-parsed (eject-on-ambiguity). Matches the aube trigger's dependency
+/// scope (dependencies / devDependencies / optionalDependencies; peer excluded).
+pub(crate) fn expo_below_gvs_floor(root: &Path) -> bool {
+    let Some(range) = declared_expo_range(root) else {
+        return false;
+    };
+    match expo_major_floor(&range) {
+        Some(major) => major < EXPO_GVS_FLOOR,
+        None => true,
+    }
+}
+
+/// The declared `expo` range from the root manifest's direct-dependency fields,
+/// if any. Uses the shared mtime-cached parse so the extra read is free.
+fn declared_expo_range(root: &Path) -> Option<String> {
+    let manifest = super::cached_aube_manifest(&root.join("package.json"))?;
+    manifest
+        .dependencies
+        .get("expo")
+        .or_else(|| manifest.dev_dependencies.get("expo"))
+        .or_else(|| manifest.optional_dependencies.get("expo"))
+        .cloned()
+}
+
+/// Best-effort major from a declared semver RANGE. `Some(major)` for a single
+/// concrete/caret/tilde/x-range or a lower bound (`56.0.15`, `^56.0.0`, `~56`,
+/// `56.x`, `v56`, `>=56`); `None` for anything we can't floor pre-resolution —
+/// empty, `*`/`latest`/`x`, a compound range (whitespace / `|`), a protocol spec
+/// (`:`), or an UPPER bound (`<`). `<` is rejected rather than stripped because
+/// its major is the ceiling, not the floor: `<56` selects a below-floor version
+/// yet reads as major 56, so flooring it would wrongly KEEP GVS — treating it as
+/// ambiguous ejects instead (the safe direction). A `None` drives
+/// eject-on-ambiguity in [`expo_below_gvs_floor`].
+fn expo_major_floor(range: &str) -> Option<u32> {
+    let r = range.trim();
+    if r.is_empty() || r.contains([' ', ':', '|', '<']) {
+        return None;
+    }
+    let core = r.trim_start_matches(['^', '~', 'v', 'V', '>', '=']);
+    let digits: String = core.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse::<u32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn major_floor_parses_common_range_shapes() {
+        for (range, want) in [
+            ("56.0.15", Some(56)),
+            ("^56.0.0", Some(56)),
+            ("~56.0.0", Some(56)),
+            ("56", Some(56)),
+            ("56.x", Some(56)),
+            ("v56.0.0", Some(56)),
+            (">=56.0.0", Some(56)),
+            ("52.0.0", Some(52)),
+            ("^51.0.0", Some(51)),
+        ] {
+            assert_eq!(expo_major_floor(range), want, "range={range}");
+        }
+    }
+
+    #[test]
+    fn major_floor_is_none_for_unfloorable_specs() {
+        for range in [
+            "",
+            "*",
+            "latest",
+            "x",
+            ">=50 <60",
+            "50 - 60",
+            "^55 || ^56",
+            "catalog:",
+            "workspace:*",
+            "npm:expo@56.0.0",
+            "<56",
+            "<=56.0.0",
+        ] {
+            assert_eq!(expo_major_floor(range), None, "range={range}");
+        }
+    }
+}

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -53,6 +53,7 @@
 
 mod bun_config;
 pub mod config_scope;
+mod expo_compat;
 pub mod identity;
 pub mod info_family;
 pub mod install_family;
@@ -2159,6 +2160,17 @@ fn nub_setting_defaults(
     } else {
         String::new()
     };
+    // The whole-install GVS-off list. `next`/`react-native` eject unconditionally
+    // (a resolver that canonicalizes node_modules by realpath — Turbopack, bare-RN
+    // Metro — can't reach the machine-global store at any version). `expo` is
+    // version-gated: it gained store-awareness only in SDK 56 (On-demand
+    // Filesystem), so a project declaring `expo` below the floor is ejected while
+    // 56+ keeps GVS. See [`expo_compat`].
+    let gvs_root = detected.map(|d| d.dir.as_path()).unwrap_or(cwd);
+    let mut gvs_off: Vec<&str> = vec!["next", "react-native"];
+    if expo_compat::expo_below_gvs_floor(gvs_root) {
+        gvs_off.push("expo");
+    }
     let store_dir = format!("node_modules/{PROJECT_VIRTUAL_STORE_LEAF}");
     let mut defaults = vec![
         (
@@ -2191,9 +2203,13 @@ fn nub_setting_defaults(
             // - `react-native` — bare RN's Metro (`@react-native/metro-config`)
             //   crawls by realpath and only sees the project root, so the global
             //   store is out of scope and even DECLARED deps (`@babel/runtime`)
-            //   report unresolved. Expo's `@expo/metro-config` is store-aware
-            //   (works either way; this only flips it project-local, harmless).
-            "next,react-native".to_string(),
+            //   report unresolved.
+            // - `expo` — the SAME break, but ONLY below SDK 56. Expo's Metro fork
+            //   became store-aware in SDK 56 (the On-demand Filesystem); pre-56
+            //   Expo uses the eager realpath crawl and breaks under GVS, so it is
+            //   ejected version-conditionally ([`expo_compat`]) rather than by a
+            //   flat name — 56+ keeps GVS.
+            gvs_off.join(","),
         ),
         ("diskMaterializePackages".to_string(), disk_materialize),
     ];
@@ -2835,6 +2851,56 @@ mod tests {
         assert_eq!(
             get(&fresh, "disableGlobalVirtualStoreForPackages"),
             Some("next,react-native"),
+        );
+    }
+
+    #[test]
+    fn expo_below_sdk_56_is_gvs_ejected_but_56_plus_keeps_gvs() {
+        // Expo's Metro fork became store-aware in SDK 56 (On-demand Filesystem),
+        // so `expo` ejects version-conditionally: below the floor joins the
+        // store-locality breakers, at/above it keeps GVS. A range whose major
+        // can't be floored pre-resolution ejects (safe direction).
+        let disable_list = |manifest: &str| {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::write(dir.path().join("package.json"), manifest).unwrap();
+            let defaults =
+                nub_setting_defaults(None, false, dir.path(), VirtualStoreLocality::Default);
+            get(&defaults, "disableGlobalVirtualStoreForPackages")
+                .unwrap()
+                .to_string()
+        };
+
+        // Below the floor → ejected (dependencies and devDependencies both count).
+        assert_eq!(
+            disable_list(r#"{"name":"x","dependencies":{"expo":"~52.0.0"}}"#),
+            "next,react-native,expo",
+        );
+        assert_eq!(
+            disable_list(r#"{"name":"x","devDependencies":{"expo":"^51.0.0"}}"#),
+            "next,react-native,expo",
+        );
+        assert_eq!(
+            disable_list(r#"{"name":"x","optionalDependencies":{"expo":"50.0.0"}}"#),
+            "next,react-native,expo",
+        );
+        // Unfloorable range → eject-on-ambiguity.
+        assert_eq!(
+            disable_list(r#"{"name":"x","dependencies":{"expo":"*"}}"#),
+            "next,react-native,expo",
+        );
+        // At/above the floor → GVS stays on (expo absent from the list).
+        assert_eq!(
+            disable_list(r#"{"name":"x","dependencies":{"expo":"~56.0.0"}}"#),
+            "next,react-native",
+        );
+        assert_eq!(
+            disable_list(r#"{"name":"x","dependencies":{"expo":"^57.0.4"}}"#),
+            "next,react-native",
+        );
+        // Not an Expo project → unchanged.
+        assert_eq!(
+            disable_list(r#"{"name":"x","dependencies":{"react":"19.2.0"}}"#),
+            "next,react-native",
         );
     }
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -473,7 +473,7 @@ A few packages statically import a backend you pick at runtime — `@hookform/re
 
 The same treatment covers packages that write generated code back into their own install directory. Prisma's postinstall runs `prisma generate`, which writes the generated client next to `@prisma/client` on disk — and under the shared store that spot is machine-global, keyed by version rather than by project or schema. Two projects with different Prisma schemas would otherwise share one generated client and silently overwrite each other's models. Nub materializes `@prisma/client` into each project so `generate` stays project-local, matching pnpm. This detection is automatic — it scans each package's real published code, so there is no list to maintain.
 
-A bundler that resolves modules by their real path — Metro (bare React Native), Next.js — only crawls the project directory, so it can't see the shared store. Nub gives those projects a self-contained, project-local store automatically. Extend the list in `.npmrc`:
+A bundler that resolves modules by their real path — Metro (bare React Native, and Expo before SDK 56), Next.js — only crawls the project directory, so it can't see the shared store. Nub gives those projects a self-contained, project-local store automatically. Expo gained store support in SDK 56 (its On-demand Filesystem), so newer Expo apps keep the shared store. Extend the list in `.npmrc`:
 
 ```ini
 disableGlobalVirtualStoreForPackages[]=my-bundler


### PR DESCRIPTION
Expo's Metro became global-virtual-store-aware in **SDK 56** (On-demand Filesystem). Below 56 it crawls by realpath and can't reach the machine-global store — the same break as bare `react-native`. Expo was left on the shared store unconditionally, so pre-56 projects broke.

Now ejects GVS (project-local store) when the root manifest declares `expo` below major 56; keeps the shared store at 56+. Unfloorable ranges eject (safe direction). Nub-side only.

Limitation: root-manifest only (workspace-member Expo undetected, same scope as `vite_compat`; escape hatch `disableGlobalVirtualStoreForPackages[]=expo`). Unit-tested; clippy/fmt clean; docs updated.