### PR TITLE
sandbox(net): block RFC1918/ULA egress by default, `<private>` opt-in

### DIFF
--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -56,13 +56,14 @@ address. Three halves:
   Loopback (`127/8`, `::1`) is in NEITHER tier — the proxy's own listener + loopback
   upstreams stay reachable unconditionally. See `proxy/mod.rs` (`is_private_range`,
   `net_allows_private`) and `NetTarget::Private`.
-- **OPEN residual (impractical) — NAT64 / 6to4 IPv6 embeddings of link-local.** A
-  link-local address wrapped in the NAT64 well-known prefix (`64:ff9b::169.254.169.254`)
-  or 6to4 (`2002:a9fe:a9fe::`) is NOT unwrapped, so it dodges the block. Reaching IMDS this
-  way needs a NAT64/6to4 *translating gateway* on-path routing to a link-local target —
-  absent in a normal cloud environment — so it is not a practical metadata reach. Left
-  unblocked rather than partly-covered because only the well-known prefixes are detectable
-  (a network-specific NAT64 `/96` is not), and partial coverage would misrepresent the
+- **OPEN residual (impractical) — NAT64 / 6to4 IPv6 embeddings of link-local AND private
+  ranges.** A link-local or RFC1918/ULA address wrapped in the NAT64 well-known prefix
+  (`64:ff9b::169.254.169.254`, `64:ff9b::10.0.0.1`) or 6to4 (`2002:a9fe:a9fe::`,
+  `2002:0a00:0001::`) is NOT unwrapped, so it dodges both tiers of the block. Reaching an
+  internal target this way needs a NAT64/6to4 *translating gateway* on-path routing to it —
+  absent in a normal cloud environment — so it is not a practical reach. Left unblocked
+  rather than partly-covered because only the well-known prefixes are detectable (a
+  network-specific NAT64 `/96` is not), and partial coverage would misrepresent the
   guarantee. Same `is_blocked_egress_ip` seam if the threat model later wants it.
 
 ### Linux per-host egress: the port-scoped `ConnectTcp` residual (CLOSED via seccomp user_notify)

--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -24,30 +24,38 @@ Two kinds of residual appear here:
 
 ## Network
 
-### Egress SSRF: cloud-metadata / link-local blocked; broad RFC1918 is a posture call (partly open by design)
+### Egress SSRF: cloud-metadata / link-local AND RFC1918 blocked by default; `<private>` opt-in
 
 The loopback egress proxy resolves an allowed host and connects to the resolved IP, so an
 allowed hostname whose DNS points at an internal address — or an attacker DNS-*rebinding*
 an allowed domain to one between validation and connect — could reach an off-limits
-address. Two halves:
+address. Three halves:
 
-- **CLOSED — cloud-metadata / link-local + rebinding.** The proxy fails closed at the
-  outbound connect on the IMDS / link-local surface: IPv4 `169.254.0.0/16` (incl. the
-  `169.254.169.254` metadata endpoint), IPv6 link-local `fe80::/10`, and the AWS IPv6 IMDS
-  `fd00:ec2::254` — regardless of what the policy admits. IPv4-in-IPv6 encodings
-  (`::ffff:169.254.169.254`, `::169.254.169.254`) are unmapped before classification, and
-  integer/octal/hex host forms are moot because classification runs on the RESOLVED
-  `IpAddr`, not the child's token. Rebinding is pinned out: the host is resolved exactly
-  once and the connect targets that same address — no re-resolution between check and
-  connect. See `proxy/mod.rs` (`is_blocked_egress_ip`, `connect_upstream`).
-- **OPEN BY DESIGN (maintainer posture call) — broad RFC1918 private ranges.** `10/8`,
-  `172.16/12`, and `192.168/16` are NOT blocked by default. Blocking them wholesale breaks
-  legitimate private-host allowlisting and collides with the deliberate loopback carve
-  (the proxy's own listener and loopback upstreams must stay reachable), so it is a
-  separate posture decision rather than folded into this guard. The seam is clean: a
-  policy/config toggle can extend `is_blocked_egress_ip` to the private ranges when the
-  maintainer decides the default. Until then, private-range egress is admitted iff the
-  active policy admits the host.
+- **CLOSED (hard, no opt-out) — cloud-metadata / link-local + rebinding.** The proxy fails
+  closed at the outbound connect on the IMDS / link-local surface: IPv4 `169.254.0.0/16`
+  (incl. the `169.254.169.254` metadata endpoint), IPv6 link-local `fe80::/10`, and the AWS
+  IPv6 IMDS `fd00:ec2::254` — regardless of what the policy admits, and NOT re-opened by the
+  `<private>` opt-in below (the AWS IPv6 IMDS sits inside ULA but is caught by this hard tier
+  first). IPv4-in-IPv6 encodings (`::ffff:169.254.169.254`, `::169.254.169.254`) are unmapped
+  before classification, and integer/octal/hex host forms are moot because classification
+  runs on the RESOLVED `IpAddr`, not the child's token. Rebinding is pinned out: the host is
+  resolved exactly once and the connect targets that same address — no re-resolution between
+  check and connect. See `proxy/mod.rs` (`is_hard_blocked_ip`, `connect_upstream`).
+- **CLOSED by default, `<private>` opt-in — broad RFC1918 / IPv6 ULA.** `10/8`, `172.16/12`,
+  `192.168/16`, and IPv6 ULA `fc00::/7` are BLOCKED by default at the outbound connect, even
+  when the policy admits the host (SSRF fail-closed, following Codex's block-by-default
+  posture for agent-driven code). A project re-permits them with the explicit symbolic net
+  target `<private>` (alias `<local>`), e.g. `net: ["<private>", "10.0.0.5"]` to reach a
+  local service. A bare wildcard `*` does NOT re-open the private ranges — only the explicit
+  `<private>` target does (mirrors Codex's non-wildcard local-allowlist). The opt-in is a
+  policy-level flag (`net_allows_private`) that lifts the private tier of the SSRF guard.
+  A raw private-range CIDR (`net: ["192.168.0.0/16"]`) admits at gate 1 but does NOT by
+  itself lift the SSRF tier — the `<private>` token is what unlocks it. To narrow WHICH
+  private hosts are reachable, compose `<private>` (unlock) with last-match-wins denies at
+  gate 1: `net: ["<private>", "!10.0.0.0/8"]` reaches all private ranges except `10/8`.
+  Loopback (`127/8`, `::1`) is in NEITHER tier — the proxy's own listener + loopback
+  upstreams stay reachable unconditionally. See `proxy/mod.rs` (`is_private_range`,
+  `net_allows_private`) and `NetTarget::Private`.
 - **OPEN residual (impractical) — NAT64 / 6to4 IPv6 embeddings of link-local.** A
   link-local address wrapped in the NAT64 well-known prefix (`64:ff9b::169.254.169.254`)
   or 6to4 (`2002:a9fe:a9fe::`) is NOT unwrapped, so it dodges the block. Reaching IMDS this

--- a/crates/nub-sandbox/src/compiler/clobber.rs
+++ b/crates/nub-sandbox/src/compiler/clobber.rs
@@ -104,7 +104,16 @@ fn fs_covers(outer: &str, inner: &str) -> bool {
 /// net: `outer` covers `inner` iff equal, `*` (all hosts), or a `*.suffix` glob
 /// whose suffix `inner` is / ends under.
 fn net_covers(outer: &str, inner: &str) -> bool {
-    if outer == inner || outer == "*" {
+    if outer == inner {
+        return true;
+    }
+    // A symbolic target (`<private>` / `<local>`) is its own class: no host glob,
+    // including a bare `*`, covers it — that is precisely why `*` does not re-open the
+    // private ranges. Only an equal token (handled above) shadows it.
+    if inner.starts_with('<') {
+        return false;
+    }
+    if outer == "*" {
         return true;
     }
     if let Some(suffix) = outer.strip_prefix("*.") {

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -519,6 +519,17 @@ fn push_net_rule(
             ),
         ));
     }
+    // The symbolic private-range opt-in (`<private>`, alias `<local>`): the ONLY way to
+    // re-permit the RFC1918 / IPv6-ULA ranges the egress proxy blocks by default. Matched
+    // BEFORE the CIDR/host split so the angle-bracket token is not mistaken for a literal
+    // host (which would silently match nothing).
+    if target == "<private>" || target == "<local>" {
+        out.push(NetRule {
+            target: NetTarget::Private,
+            effect,
+        });
+        return Ok(());
+    }
     let net_target = if target.contains('/') {
         match target.parse::<ipnet::IpNet>() {
             Ok(net) => NetTarget::Cidr(net),

--- a/crates/nub-sandbox/src/compiler/fold.rs
+++ b/crates/nub-sandbox/src/compiler/fold.rs
@@ -530,6 +530,17 @@ fn push_net_rule(
         });
         return Ok(());
     }
+    // Reject an unknown angle-bracket token loudly — `<...>` is not a legal hostname
+    // char, so a `<privat>` typo must error, not silently fold to a literal host that
+    // matches nothing (which would fail-OPEN a private-range deny the author intended).
+    if target.starts_with('<') || target.ends_with('>') {
+        return Err(CompileError::shape(
+            path,
+            &format!(
+                "`{target}` is not a recognized net target — the only symbolic net target is `<private>` (alias `<local>`), which re-permits the RFC1918 / IPv6-ULA private ranges"
+            ),
+        ));
+    }
     let net_target = if target.contains('/') {
         match target.parse::<ipnet::IpNet>() {
             Ok(net) => NetTarget::Cidr(net),

--- a/crates/nub-sandbox/src/matcher/host.rs
+++ b/crates/nub-sandbox/src/matcher/host.rs
@@ -6,7 +6,7 @@
 //! fewer footguns than TLS's single-label wildcard (.fray/sandbox.md matcher spec).
 
 use crate::policy::{Effect, NetPolicy, NetRule, NetTarget};
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 
 /// A compiled last-match-wins matcher over a [`NetPolicy`]'s rules.
 pub struct HostMatcher<'a> {
@@ -37,6 +37,7 @@ impl<'a> HostMatcher<'a> {
             let hit = match &rule.target {
                 NetTarget::Host(pat) => host_glob_matches(pat, host),
                 NetTarget::Cidr(net) => ip.is_some_and(|ip| net.contains(&ip)),
+                NetTarget::Private => ip.is_some_and(is_private_range),
             };
             if hit {
                 winner = rule.effect;
@@ -95,4 +96,42 @@ pub fn host_pattern_is_valid(pattern: &str) -> bool {
         return !rest.is_empty() && !rest.starts_with('.') && !rest.contains('*');
     }
     !pattern.contains('*')
+}
+
+/// The RFC1918 IPv4 private ranges (`10/8`, `172.16/12`, `192.168/16`) plus IPv6 ULA
+/// (`fc00::/7`) — the `<private>` class the egress proxy blocks by default. Loopback
+/// (`127/8`, `::1`) and link-local are deliberately NOT here: loopback is the proxy's
+/// own carve, and link-local is the separate always-blocked SSRF surface. An IPv4-mapped
+/// / IPv4-compatible IPv6 form is classified on its embedded v4, so a v4 private address
+/// cannot be smuggled past as a v6 literal.
+pub fn is_private_range(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_private_v4(v4),
+        IpAddr::V6(v6) => match v6.to_ipv4() {
+            Some(v4) => is_private_v4(v4),
+            // fc00::/7 (ULA) hand-rolled: the top 7 bits are `1111 110`.
+            None => (v6.segments()[0] & 0xfe00) == 0xfc00,
+        },
+    }
+}
+
+fn is_private_v4(v4: Ipv4Addr) -> bool {
+    // `Ipv4Addr::is_private` is exactly 10/8 + 172.16/12 + 192.168/16.
+    v4.is_private()
+}
+
+/// Whether the policy EXPLICITLY opted into private-range egress via a `<private>`
+/// target (last-match-wins over `<private>` allow/deny entries). A bare `*` allow-all
+/// does NOT set this — the private class stays blocked unless the user names it, mirroring
+/// Codex's `is_explicit_local_allowlisted` wildcard rejection. Independent of `enforce`:
+/// a non-enforcing (`net: true`) policy carries no `<private>` rule, so private stays
+/// blocked there too.
+pub fn net_allows_private(policy: &NetPolicy) -> bool {
+    let mut opted_in = false;
+    for rule in &policy.rules {
+        if matches!(rule.target, NetTarget::Private) {
+            opted_in = matches!(rule.effect, Effect::Allow);
+        }
+    }
+    opted_in
 }

--- a/crates/nub-sandbox/src/policy.rs
+++ b/crates/nub-sandbox/src/policy.rs
@@ -267,7 +267,8 @@ impl std::fmt::Debug for Secret {
     }
 }
 
-/// A net rule targets either a host pattern (glob or literal) or a CIDR block.
+/// A net rule targets a host pattern (glob or literal), a CIDR block, or the
+/// symbolic private-range class.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NetTarget {
@@ -277,6 +278,12 @@ pub enum NetTarget {
     Host(String),
     /// A CIDR block for IP-literal egress.
     Cidr(ipnet::IpNet),
+    /// The symbolic `<private>` (`<local>`) target: the RFC1918 IPv4 ranges
+    /// (`10/8`, `172.16/12`, `192.168/16`) plus IPv6 ULA (`fc00::/7`), which are
+    /// blocked by default at the egress proxy. Only this EXPLICIT target re-permits
+    /// them — a bare `*` does not (mirrors Codex's non-wildcard local-allowlist).
+    /// The always-blocked cloud-metadata / link-local surface is NOT re-opened by it.
+    Private,
 }
 
 // ── environment ──────────────────────────────────────────────────────────────

--- a/crates/nub-sandbox/src/proxy/mitm.rs
+++ b/crates/nub-sandbox/src/proxy/mitm.rs
@@ -125,6 +125,7 @@ pub(super) fn terminate(
     prelude: Vec<u8>,
     host: &str,
     port: u16,
+    allow_private: bool,
 ) -> io::Result<()> {
     // A brokered host reached over a NON-TLS or unmintable channel must fail closed —
     // never inject a credential onto an unverified wire (SRT's allowPlaintextInject
@@ -154,7 +155,8 @@ pub(super) fn terminate(
     http1::normalize_for_forward(&mut req);
 
     // The upstream leg: REAL TLS to the REAL server, verified against REAL roots.
-    let upstream_tcp = super::connect_upstream(&super::Host::Name(host.to_string()), port)?;
+    let upstream_tcp =
+        super::connect_upstream(&super::Host::Name(host.to_string()), port, allow_private)?;
     let server_name = rustls::pki_types::ServerName::try_from(host.to_string())
         .map_err(|_| io::Error::other("invalid upstream server name for TLS termination"))?;
     let mut uconn = rustls::ClientConnection::new(engine.client_config.clone(), server_name)

--- a/crates/nub-sandbox/src/proxy/mod.rs
+++ b/crates/nub-sandbox/src/proxy/mod.rs
@@ -58,6 +58,15 @@ pub enum Decision {
 /// policy ([`StaticDecider`]); the build-jail thread swaps in an interactive prompt.
 pub trait GrantDecider: Send + Sync + 'static {
     fn decide(&self, host: &Host) -> Decision;
+
+    /// Whether the policy EXPLICITLY opted into private-range (RFC1918 / IPv6-ULA)
+    /// egress via a `<private>` target. Consulted by the SSRF guard to lift the
+    /// default private-range block on the resolved upstream IP. Defaults to `false`
+    /// (fail-closed: a decider that hasn't opted in keeps private egress blocked), so
+    /// the interactive/build-jail decider stays safe without overriding this.
+    fn allows_private(&self) -> bool {
+        false
+    }
 }
 
 /// The static-policy decider: evaluates a resolved [`NetPolicy`] last-match-wins via
@@ -84,6 +93,10 @@ impl GrantDecider for StaticDecider {
         } else {
             Decision::Deny
         }
+    }
+
+    fn allows_private(&self) -> bool {
+        crate::matcher::host::net_allows_private(&self.policy)
     }
 }
 
@@ -229,6 +242,9 @@ fn handle_conn(
     token: &str,
 ) -> io::Result<()> {
     stream.set_read_timeout(Some(CLIENT_HELLO_TIMEOUT))?;
+    // Whether the policy opted into private-range egress (governs the SSRF guard's
+    // private tier only). Computed once per connection from the static decider.
+    let allow_private = decider.allows_private();
     // Token gate FIRST: an unauthenticated caller is answered (407 / SOCKS auth-fail)
     // and dropped before any host decision. `?` propagates the auth error → connection
     // closed (fail-closed).
@@ -261,7 +277,7 @@ fn handle_conn(
     if let Some(engine) = mitm.as_ref() {
         match terminate_host.as_deref() {
             Some(host) if engine.should_terminate(host) => {
-                let _ = mitm::terminate(engine, stream, prelude, host, req.port);
+                let _ = mitm::terminate(engine, stream, prelude, host, req.port, allow_private);
                 return Ok(());
             }
             // `proxy: "terminate"` but this connection carries no host to terminate (no
@@ -274,7 +290,7 @@ fn handle_conn(
     }
 
     // Connection tier — connect upstream, replay the buffered prelude, blind-splice.
-    let upstream = connect_upstream(&req.host, req.port)?;
+    let upstream = connect_upstream(&req.host, req.port, allow_private)?;
     stream.set_read_timeout(None)?;
     upstream.set_read_timeout(None)?;
     let mut up = upstream;
@@ -346,17 +362,31 @@ fn finalize_scan(buf: &[u8], decider: &dyn GrantDecider) -> (Vec<u8>, bool, Opti
 
 /// Egress addresses the proxy must NEVER connect to, even when policy admits the host.
 ///
-/// SSRF / DNS-rebinding guard. An allowed hostname that resolves — or an attacker's DNS
-/// rebinds — to the cloud-metadata / link-local surface is refused at the connect. It
-/// covers IPv4 link-local `169.254.0.0/16` (incl. the `169.254.169.254` IMDS endpoint),
-/// IPv6 link-local `fe80::/10`, and the AWS IPv6 IMDS `fd00:ec2::254`; an IPv4-in-IPv6
-/// form (`::ffff:169.254.169.254`, `::169.254.169.254`) is unmapped to its embedded v4
-/// FIRST so the encoding can't smuggle a metadata address past as an IPv6 literal. All
-/// integer/octal/hex host encodings are already normalized away here because we classify
-/// the RESOLVED [`IpAddr`], not the child-supplied token. Loopback is deliberately NOT
-/// blocked (the proxy's own carve is loopback, and a legit upstream may be); broad RFC1918
-/// private-range blocking is a separate maintainer posture call (see LIMITATIONS.md).
-fn is_blocked_egress_ip(ip: IpAddr) -> bool {
+/// SSRF / DNS-rebinding guard, two tiers on the RESOLVED [`IpAddr`] (so integer/octal/hex
+/// host encodings are already normalized away — we classify the address, not the token):
+///
+/// - HARD block (never opt-out-able, [`is_hard_blocked_ip`]): the cloud-metadata /
+///   link-local surface — IPv4 link-local `169.254.0.0/16` (incl. the `169.254.169.254`
+///   IMDS endpoint), IPv6 link-local `fe80::/10`, and the AWS IPv6 IMDS `fd00:ec2::254`.
+///   An IPv4-in-IPv6 form (`::ffff:169.254.169.254`, `::169.254.169.254`) is unmapped to
+///   its embedded v4 first so the encoding can't smuggle a metadata address past.
+/// - PRIVATE block (default-on, lifted by an explicit `<private>` allow): RFC1918
+///   `10/8`+`172.16/12`+`192.168/16` and IPv6 ULA `fc00::/7` ([`is_private_range`]).
+///   `allow_private` is `true` only when the policy names `<private>` — a bare `*` does
+///   not lift it. The AWS IPv6 IMDS lives inside ULA but is caught by the HARD tier first,
+///   so `<private>` re-opens the private ranges WITHOUT re-opening the metadata endpoint.
+///
+/// Loopback (`127/8`, `::1`) is deliberately in NEITHER tier: it is the proxy's own carve
+/// and a legit upstream may be loopback, so it is always reachable.
+fn is_blocked_egress_ip(ip: IpAddr, allow_private: bool) -> bool {
+    if is_hard_blocked_ip(ip) {
+        return true;
+    }
+    !allow_private && crate::matcher::host::is_private_range(ip)
+}
+
+/// The always-blocked cloud-metadata / link-local surface (no policy opt-out).
+fn is_hard_blocked_ip(ip: IpAddr) -> bool {
     const AWS_IMDS_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254);
     match ip {
         IpAddr::V4(v4) => v4.is_link_local(),
@@ -378,17 +408,19 @@ fn is_blocked_egress_ip(ip: IpAddr) -> bool {
 /// no second resolution between the check and the connect, so DNS cannot swap in a
 /// metadata IP after validation. A resolved address on the blocked surface is skipped
 /// (fail-closed); a host that resolves ONLY to blocked addresses yields the block error.
-fn connect_upstream(host: &Host, port: u16) -> io::Result<TcpStream> {
+/// `allow_private` (derived from the policy's `<private>` opt-in) governs only the
+/// private-range tier; the metadata/link-local block is unconditional.
+fn connect_upstream(host: &Host, port: u16, allow_private: bool) -> io::Result<TcpStream> {
     let addrs: Vec<SocketAddr> = match host {
         Host::Ip(ip) => vec![SocketAddr::new(*ip, port)],
         Host::Name(name) => (name.as_str(), port).to_socket_addrs()?.collect(),
     };
     let mut last_err = io::Error::other("no address resolved");
     for addr in addrs {
-        if is_blocked_egress_ip(addr.ip()) {
+        if is_blocked_egress_ip(addr.ip(), allow_private) {
             last_err = io::Error::new(
                 io::ErrorKind::PermissionDenied,
-                "egress to a link-local/metadata address is blocked",
+                "egress to a metadata/link-local or private-range address is blocked",
             );
             continue;
         }
@@ -482,44 +514,79 @@ mod tests {
 
     #[test]
     fn blocks_metadata_and_link_local_egress() {
-        let blocked = [
+        // The HARD tier — always blocked, regardless of the private opt-in.
+        let hard = [
             "169.254.169.254",        // AWS/GCP/Azure IMDS (IPv4 link-local)
             "169.254.0.1",            // link-local edge
             "fe80::1",                // IPv6 link-local
             "fe80::a9fe:a9fe",        // IPv6 link-local, arbitrary suffix
             "febf::1",                // fe80::/10 upper edge
-            "fd00:ec2::254",          // AWS IPv6 IMDS
+            "fd00:ec2::254",          // AWS IPv6 IMDS (inside ULA, but hard-blocked)
             "::ffff:169.254.169.254", // IPv4-mapped metadata (encoding smuggle)
             "::169.254.169.254",      // IPv4-compat metadata (encoding smuggle)
         ];
-        for ip in blocked {
+        for ip in hard {
+            let ip: IpAddr = ip.parse().unwrap();
             assert!(
-                is_blocked_egress_ip(ip.parse().unwrap()),
-                "{ip} must be classified as blocked egress"
+                is_blocked_egress_ip(ip, false),
+                "{ip} must be blocked (private disallowed)"
+            );
+            assert!(
+                is_blocked_egress_ip(ip, true),
+                "{ip} must STAY blocked even with the private opt-in (hard tier)"
             );
         }
-        // NOT blocked: loopback (the proxy carve + loopback upstreams), public, and —
-        // deliberately, pending the maintainer posture call — RFC1918 private ranges.
-        let allowed = [
+        // Loopback + public are in NEITHER tier — always reachable.
+        for ip in [
             "127.0.0.1",
             "::1",
             "8.8.8.8",
             "203.0.113.10",
             "2606:4700:4700::1111",
-            "10.0.0.1",
-            "172.16.0.1",
-            "192.168.1.1", // RFC1918: NOT blocked in this change
+        ] {
+            let ip: IpAddr = ip.parse().unwrap();
+            assert!(!is_blocked_egress_ip(ip, false), "{ip} must be reachable");
+            assert!(!is_blocked_egress_ip(ip, true), "{ip} must be reachable");
+        }
+    }
+
+    #[test]
+    fn rfc1918_and_ula_blocked_by_default_but_opt_in_reachable() {
+        // The PRIVATE tier: blocked when `<private>` is NOT opted in, reachable when it is.
+        let private = [
+            "10.0.0.1",           // 10/8
+            "10.255.255.254",     // 10/8 edge
+            "172.16.0.1",         // 172.16/12 lower edge
+            "172.31.255.254",     // 172.16/12 upper edge
+            "192.168.1.1",        // 192.168/16
+            "fc00::1",            // ULA lower edge
+            "fdff:ffff::1",       // ULA upper edge (fc00::/7)
+            "::ffff:10.0.0.1",    // IPv4-mapped RFC1918 (encoding smuggle)
+            "::ffff:192.168.0.1", // IPv4-mapped RFC1918
         ];
-        for ip in allowed {
+        for ip in private {
+            let ip: IpAddr = ip.parse().unwrap();
             assert!(
-                !is_blocked_egress_ip(ip.parse().unwrap()),
-                "{ip} must NOT be classified as blocked egress"
+                is_blocked_egress_ip(ip, false),
+                "{ip} must be BLOCKED by default (no <private> opt-in)"
+            );
+            assert!(
+                !is_blocked_egress_ip(ip, true),
+                "{ip} must be REACHABLE once <private> is opted in"
+            );
+        }
+        // Boundary negatives: 172.15/172.32 are OUTSIDE 172.16/12 → public, never private.
+        for ip in ["172.15.255.255", "172.32.0.0", "11.0.0.1", "192.167.0.1"] {
+            let ip: IpAddr = ip.parse().unwrap();
+            assert!(
+                !is_blocked_egress_ip(ip, false),
+                "{ip} is public, not private"
             );
         }
     }
 
     #[test]
-    fn connect_upstream_denies_link_local_but_reaches_allowed_target() {
+    fn connect_upstream_blocks_by_tier_but_reaches_allowed_target() {
         // Negative control: an allowed (non-blocked) target actually connects.
         let echo = TcpListener::bind((IpAddr::from([127, 0, 0, 1]), 0)).unwrap();
         let port = echo.local_addr().unwrap().port();
@@ -527,15 +594,56 @@ mod tests {
             let _ = echo.accept();
         });
         assert!(
-            connect_upstream(&Host::Ip(IpAddr::from([127, 0, 0, 1])), port).is_ok(),
-            "an allowed target must still connect through the guard"
+            connect_upstream(&Host::Ip(IpAddr::from([127, 0, 0, 1])), port, false).is_ok(),
+            "loopback must still connect through the guard"
         );
 
-        // The guard denies a metadata target immediately (PermissionDenied), without
-        // attempting the connect — so a live metadata endpoint would never be reached.
-        let err = connect_upstream(&Host::Ip("169.254.169.254".parse().unwrap()), 80)
-            .expect_err("link-local egress must be blocked");
+        // Metadata is denied immediately (PermissionDenied), even with the private opt-in.
+        let err = connect_upstream(&Host::Ip("169.254.169.254".parse().unwrap()), 80, true)
+            .expect_err("metadata egress must be blocked even with <private>");
         assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+
+        // RFC1918 is denied without the opt-in, allowed with it.
+        let err = connect_upstream(&Host::Ip("192.168.1.1".parse().unwrap()), 80, false)
+            .expect_err("RFC1918 egress must be blocked by default");
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn allows_private_only_on_explicit_target_not_wildcard() {
+        // A bare `*` allow-all does NOT re-open the private ranges.
+        let d = StaticDecider::new(net(vec![host("*", Effect::Allow)], Effect::Deny));
+        assert!(!d.allows_private(), "`*` must NOT set the private opt-in");
+
+        // An explicit `<private>` allow does.
+        let priv_rule = |e| NetRule {
+            target: NetTarget::Private,
+            effect: e,
+        };
+        let d = StaticDecider::new(net(vec![priv_rule(Effect::Allow)], Effect::Deny));
+        assert!(d.allows_private(), "`<private>` must set the opt-in");
+
+        // Last-match-wins: `<private>` then `!<private>` turns it back off.
+        let d = StaticDecider::new(net(
+            vec![priv_rule(Effect::Allow), priv_rule(Effect::Deny)],
+            Effect::Deny,
+        ));
+        assert!(
+            !d.allows_private(),
+            "a later `!<private>` must reclose the opt-in"
+        );
+
+        // The `<private>` target admits an RFC1918 IP literal at gate 1 (matcher).
+        let d = StaticDecider::new(net(vec![priv_rule(Effect::Allow)], Effect::Deny));
+        assert_eq!(
+            d.decide(&Host::Ip("10.1.2.3".parse().unwrap())),
+            Decision::Allow
+        );
+        assert_eq!(
+            d.decide(&Host::Ip("8.8.8.8".parse().unwrap())),
+            Decision::Deny,
+            "a public IP is NOT admitted by <private>"
+        );
     }
 
     #[test]

--- a/crates/nub-sandbox/tests/compiler.rs
+++ b/crates/nub-sandbox/tests/compiler.rs
@@ -1065,6 +1065,46 @@ fn env_key_brace_alternation_is_a_shape_error() {
 }
 
 #[test]
+fn net_private_symbolic_target_folds_and_gates_the_opt_in() {
+    use nub_sandbox::matcher::host::net_allows_private;
+    let ctx = common::ctx(true, &[]);
+
+    // `<private>` (and its `<local>` alias) fold to NetTarget::Private and set the opt-in.
+    for tok in ["<private>", "<local>"] {
+        let p = compile(&json!({ "net": [tok] }), &ctx).unwrap();
+        assert_eq!(p.net.rules.len(), 1);
+        assert!(matches!(p.net.rules[0].target, NetTarget::Private), "{tok}");
+        assert!(
+            net_allows_private(&p.net),
+            "{tok} must set the private opt-in"
+        );
+    }
+
+    // A bare `*` allow-all does NOT set the opt-in — the private ranges stay blocked.
+    let p = compile(&json!({ "net": ["*"] }), &ctx).unwrap();
+    assert!(
+        !net_allows_private(&p.net),
+        "`*` must NOT re-open the private ranges"
+    );
+
+    // `!<private>` after an opt-in reclose it (last-match-wins on the token).
+    let p = compile(&json!({ "net": ["<private>", "!<private>"] }), &ctx).unwrap();
+    assert!(
+        !net_allows_private(&p.net),
+        "a later `!<private>` must reclose the opt-in"
+    );
+
+    // An unknown angle-bracket token is a loud shape error, not a silent no-match host.
+    match compile(&json!({ "net": ["<privat>"] }), &ctx).unwrap_err() {
+        CompileError::Shape { path, message } => {
+            assert_eq!(path, "net.0");
+            assert!(message.contains("recognized net target"), "{message}");
+        }
+        other => panic!("expected Shape, got {other:?}"),
+    }
+}
+
+#[test]
 fn net_leading_wildcard_and_bare_star_still_accepted() {
     // D11 must not over-reject: the two valid wildcard forms compile.
     let ctx = common::ctx(true, &[]);

--- a/crates/nub-sandbox/tests/linux_proxy.rs
+++ b/crates/nub-sandbox/tests/linux_proxy.rs
@@ -439,6 +439,49 @@ fn ssrf_metadata_target_dropped_even_when_policy_admits_it() {
 }
 
 #[test]
+fn rfc1918_egress_dropped_by_default_even_when_cidr_admits_it() {
+    // SSRF private tier: RFC1918 is blocked at the outbound connect BY DEFAULT, even when
+    // gate 1 admits the target via an explicit CIDR (`192.168.0.0/16`). A raw private CIDR
+    // admits the host but does NOT lift the SSRF private tier — only the `<private>` token
+    // does — so `connect_upstream` still refuses `192.168.1.1`. The negative control (an
+    // admitted loopback echo under the SAME policy forwards) proves this is a targeted,
+    // selective egress block, not a broken tunnel. (That the `<private>` opt-in flips the
+    // classifier is proven deterministically by the `is_blocked_egress_ip`/`connect_upstream`
+    // unit tests; a live private-range upstream isn't bindable on the test host.)
+    if skip_without_landlock(4) {
+        return; // per-host needs Landlock ABI v4
+    }
+    let f = fixture();
+    let Some(probe) = compile_probe(&f.proj) else {
+        return;
+    };
+    let echo = echo_server();
+    let port = echo.port().to_string();
+    let probe = probe.to_str().unwrap();
+    let policy =
+        json!({ "fs": true, "net": ["192.168.0.0/16", "127.0.0.0/8", "*.allowed.example"] });
+
+    assert_eq!(
+        f.run(
+            policy.clone(),
+            probe,
+            &["proxysni", "192.168.1.1", "80", "api.allowed.example"]
+        ),
+        5,
+        "RFC1918 target must be dropped at connect by default even though the CIDR admits it"
+    );
+    assert_eq!(
+        f.run(
+            policy,
+            probe,
+            &["proxysni", "127.0.0.1", &port, "api.allowed.example"]
+        ),
+        0,
+        "neg-control: an admitted loopback target still forwards under the same policy"
+    );
+}
+
+#[test]
 fn sctp_and_mptcp_egress_denied_in_proxy_mode() {
     // Landlock's ConnectTcp governs ONLY IPPROTO_TCP, so an AF_INET SOCK_STREAM socket
     // over SCTP or MPTCP passes the SOCK_STREAM narrowing yet dodges the connect hook —


### PR DESCRIPTION
Blocks RFC1918 (`10/8`, `172.16/12`, `192.168/16`) + IPv6 ULA (`fc00::/7`) at the egress proxy's SSRF guard by default, alongside the existing metadata/link-local block, classified on the resolved upstream IP.

Opt back in with the explicit `<private>` (alias `<local>`) net target; a bare `*` does NOT re-open the ranges. Metadata/link-local stays hard-blocked. Loopback is exempt — the block gates the proxy→upstream hop, not the proxy's own loopback.

Classifier/opt-in/wildcard units + Linux e2e on a real Landlock-v4 kernel. `LIMITATIONS.md` updated. Stacked on `sandbox-primitives`.