### PR TITLE
feat(run): cross-platform script shell via deno_task_shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
  "diffy",
  "glob",
  "hex",
- "junction",
+ "junction 2.0.0",
  "libc",
  "miette",
  "pathdiff",
@@ -1171,6 +1171,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_error"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3007d3f1ea92ea503324ae15883aac0c2de2b8cf6fead62203ff6a67161007ab"
+dependencies = [
+ "deno_error_macro",
+ "libc",
+ "url",
+]
+
+[[package]]
+name = "deno_error_macro"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b565e60a9685cdf312c888665b5f8647ac692a7da7e058a5e2268a466da8eaf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deno_path_util"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c7e98943f0d068928906db0c7bde89de684fa32c6a8018caacc4cee2cdd72b"
+dependencies = [
+ "deno_error",
+ "percent-encoding",
+ "sys_traits",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "deno_task_shell"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd069c87eb3cdc25e9898fe633a07ec7f20218e92ad3e7eccab3db324764d4fb"
+dependencies = [
+ "bitflags",
+ "deno_path_util",
+ "futures",
+ "glob",
+ "monch",
+ "nix 0.29.0",
+ "path-dedot",
+ "sys_traits",
+ "thiserror 2.0.18",
+ "tokio",
+ "which",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1519,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,6 +1548,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1514,6 +1595,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2282,6 +2364,16 @@ dependencies = [
 
 [[package]]
 name = "junction"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "junction"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
@@ -2547,6 +2639,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "monch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bcc6ad3b93f756f2532d29f7c7291b8d246a2c460a99a3611327bb726830014"
+
+[[package]]
 name = "munge"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,6 +2669,18 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nix"
@@ -2676,6 +2786,7 @@ dependencies = [
  "clap",
  "clx",
  "console",
+ "deno_task_shell",
  "dirs-next",
  "dotenvy",
  "jsonc-parser",
@@ -3146,6 +3257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -4716,6 +4836,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys_traits"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88826d6169418c98e8bc52a43f79d50907dfa3e87ba5161930d42c6f980b35ee"
+dependencies = [
+ "junction 1.4.2",
+ "libc",
+ "sys_traits_macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "sys_traits_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "181f22127402abcf8ee5c83ccd5b408933fec36a6095cf82cda545634692657e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5578,6 +5721,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5811,6 +5960,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -116,8 +116,21 @@ jsonc-parser.workspace = true
 console.workspace = true
 # Multi-thread runtime for the embedded aube install engine (pm_engine.rs).
 # Mirrors aube's own cli_main runtime shape; tokio is dormant on every other
-# nub code path.
-tokio = { version = "1", features = ["rt-multi-thread"] }
+# nub code path EXCEPT the shell emulator (src/shell_emulator.rs), which drives
+# deno_task_shell on a current-thread runtime + LocalSet. `signal` powers the
+# SIGTERM/SIGINT → KillSignal forwarder there; the rest mirror deno's own tokio
+# set so `enable_all()` and its spawned children work.
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "fs",
+    "io-std",
+    "io-util",
+    "process",
+    "sync",
+    "time",
+    "macros",
+    "signal",
+] }
 tracing-subscriber.workspace = true
 url = "2.5"
 # Only to SIZE the rayon GLOBAL pool under a detected PID/thread constraint
@@ -133,6 +146,11 @@ rayon = "1"
 # exactly the automaxprocs algorithm, maintained, 2-dep. Closes the v1-quota +
 # affinity-blocked gaps in std's `available_parallelism()`.
 num_cpus = "1"
+# Bundled cross-platform POSIX-subset script shell (MIT, by the Deno authors).
+# The default `nub run` script engine (src/shell_emulator.rs): parse() + async
+# execute() with Rust builtins (cp/mv/rm/mkdir/echo/test/…) so package scripts
+# get identical POSIX behavior on every platform, no system `sh` required.
+deno_task_shell = "0.33"
 
 [target.'cfg(unix)'.dependencies]
 # fd-level capture of the engine's raw println/eprintln hint lines so the

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3522,13 +3522,38 @@ enum StreamMode {
     Prefixed,
 }
 
-/// Build the shell `Command` for a package script with Nub's augmentation
-/// applied exactly once: `NODE_OPTIONS` (injected flags + preload + webstorage),
-/// the PATH shim prepended to the `node_modules/.bin` walk-up chain, `.env`
-/// files, and the `npm_*` lifecycle vars.
+/// How a resolved script body is executed. The default (`shellEmulator` on) is
+/// [`Emulated`] — the bundled `deno_task_shell` POSIX-subset shell — so scripts
+/// behave identically across platforms; an explicit `--script-shell`/`.npmrc`
+/// `script-shell`, or `shellEmulator=false`, selects [`Native`] (a real shell
+/// binary). Both carry the SAME assembled environment (see
+/// [`build_script_command`]); `full_cmd` (the display + exec string) is returned
+/// alongside by that builder.
+enum ScriptInvocation {
+    /// Run via a real shell binary: `sh -c` / `cmd /d /s /c`, or the
+    /// `--script-shell`/`.npmrc script-shell` binary.
+    Native(std::process::Command),
+    /// Run via the bundled cross-platform shell emulator ([`crate::shell_emulator`]).
+    /// `env` is the ordered augmentation-override pairs the emulator layers over
+    /// the parent environment; `cwd` is the project root.
+    Emulated {
+        body: String,
+        env: Vec<(std::ffi::OsString, std::ffi::OsString)>,
+        cwd: std::path::PathBuf,
+    },
+}
+
+/// Resolve how a package script runs, with Nub's augmentation assembled exactly
+/// once: `NODE_OPTIONS` (injected flags + preload + webstorage), the PATH shim
+/// prepended to the `node_modules/.bin` walk-up chain, `.env` files, and the
+/// `npm_*` lifecycle vars.
 ///
-/// This is the single augmentation path shared by inherited and prefixed
-/// (streamed) execution — there is no second, divergent block. The PATH shim
+/// Returns a [`ScriptInvocation`] — the bundled emulator (default) or a native
+/// shell `Command` — plus the display/exec string (`full_cmd`). The environment
+/// is assembled into ONE ordered pair list that BOTH paths consume, so a script
+/// child sees an identical environment either way (the native `Command` layers
+/// the pairs over the inherited parent env; the emulator seeds the parent env
+/// then applies the same pairs — see [`crate::shell_emulator`]). The PATH shim
 /// temp dir is process-wide and reclaimed once on exit (see
 /// [`nub_core::node::spawn::cleanup_shim`]), so no per-call guard is returned.
 fn build_script_command(
@@ -3539,7 +3564,7 @@ fn build_script_command(
     lifecycle_event: &str,
     stream: StreamMode,
     script_shell_override: Option<&str>,
-) -> Result<(std::process::Command, String)> {
+) -> Result<(ScriptInvocation, String)> {
     use std::process::Command as StdCommand;
 
     // `.env` is NODE-SCOPED, not process-scoped (security + correctness, decided
@@ -3586,37 +3611,36 @@ fn build_script_command(
         &ua_product,
     );
 
-    // Shell precedence: the explicit `--script-shell <path>` flag wins, then a
-    // `.npmrc` `script-shell=` setting, then the platform default. A custom
-    // POSIX shell uses `-c`; only the implicit Windows `cmd` default uses `/d /s /c`.
+    // Shell precedence: an explicit `--script-shell <path>` flag wins, then a
+    // `.npmrc` `script-shell=` setting — either pins that real shell binary (the
+    // Native path). With neither, the bundled POSIX-subset emulator is the
+    // DEFAULT (`shellEmulator` on — nub's deliberate divergence from pnpm, whose
+    // default is off), unless `shellEmulator=false` opts back out to the
+    // platform-native `sh`/`cmd`.
     let custom_shell = script_shell_override
         .map(str::to_string)
         .or_else(|| nub_core::workspace::scripts::script_shell(&project.root));
-    let (shell, shell_flag) = if let Some(ref s) = custom_shell {
-        (s.as_str(), "-c")
-    } else if cfg!(windows) {
-        // npm's exact flags: `/d` (skip AutoRun), `/s` (strip outer quotes), `/c`.
-        ("cmd", "/d /s /c")
-    } else {
-        ("sh", "-c")
-    };
-    // The implicit Windows `cmd` default must spawn with verbatim arguments — the
-    // script body is passed to cmd.exe exactly as written (npm's
-    // `windowsVerbatimArguments: true`), so Rust's MSVCRT re-quoting never mangles
-    // a `node -e "…"` body or undoes the per-arg cmd escaping below. A custom POSIX
-    // shell (e.g. Git-Bash `sh.exe` via `--script-shell`) does its own parsing,
-    // so it takes the normal escaped-`arg` path.
-    let cmd_verbatim = custom_shell.is_none() && cfg!(windows);
+    let use_emulator =
+        custom_shell.is_none() && nub_core::workspace::scripts::shell_emulator(&project.root);
 
     // Append the user's extra args the way npm does (@npmcli/promise-spawn):
     // each arg is escaped for the target shell and spliced onto the UNescaped
     // script body, so multi-word / metachar args reach the script as single
-    // literal tokens while the body's own globs/expansions still run. A raw
-    // join (the prior behavior) let the shell re-split/expand the args. Compat,
-    // not security — the args are the user's own argv (A42). The returned
-    // `full_cmd` is also what the `$ <cmd>` preamble echoes, so the displayed
-    // command matches the effective one (issue #146).
-    let full_cmd = nub_core::workspace::shell_escape::splice_args(cmd, args, shell);
+    // literal tokens while the body's own globs/expansions still run. The
+    // emulator always parses POSIX, so it uses the `sh` escaper on EVERY platform
+    // (never the `cmd` branch); a native shell uses the escaper matching it. The
+    // returned `full_cmd` is also what the `$ <cmd>` preamble echoes, so the
+    // displayed command matches the effective one (issue #146 / A42).
+    let escaping_shell: &str = if use_emulator {
+        "sh"
+    } else if let Some(ref s) = custom_shell {
+        s.as_str()
+    } else if cfg!(windows) {
+        "cmd"
+    } else {
+        "sh"
+    };
+    let full_cmd = nub_core::workspace::shell_escape::splice_args(cmd, args, escaping_shell);
 
     // Augmentation: NODE_OPTIONS + PATH shim so child `node` processes inside
     // the script inherit transpilation, polyfills, flag injection, and
@@ -3640,12 +3664,161 @@ fn build_script_command(
         pnp_ctx.as_ref().map(|c| c.pnp_cjs.as_path()),
     );
 
+    // === Environment: the SINGLE source of truth for a script's augmentation
+    // overrides, assembled once and consumed by BOTH the native `Command` and
+    // the emulator so a script child sees an identical environment either way.
+    // ORDER MATTERS — later pairs win: the `.env`/`npm_env` overlays sit LAST so
+    // a user-set value overrides nub's. The native path layers these over the
+    // inherited parent env; the emulator seeds the parent env first then applies
+    // the same pairs (deno spawns children with `env_clear`, so its map must be
+    // complete — see crate::shell_emulator). ===
+    let mut env_pairs: Vec<(std::ffi::OsString, std::ffi::OsString)> = Vec::new();
+
+    // PATH: shim dir (when augmenting) → `.bin` walk-up chain → system PATH.
+    // `bin_path` is already `<.bin dirs>:<system PATH>`, so prepending the bare
+    // shim dir gives `shim:.bin:system` — `.bin` BEFORE the system PATH so a local
+    // tool shadows a global one (npm/pnpm parity), with the system PATH appearing
+    // exactly once.
+    let path: std::ffi::OsString = match aug.as_ref().and_then(|a| a.shim_dir.as_deref()) {
+        Some(shim) => {
+            let mut combined = std::ffi::OsString::from(shim);
+            if !bin_path.is_empty() {
+                combined.push(nub_core::PATH_LIST_SEPARATOR);
+                combined.push(std::ffi::OsString::from(bin_path.clone()));
+            }
+            combined
+        }
+        None => std::ffi::OsString::from(bin_path.clone()),
+    };
+    env_pairs.push(("PATH".into(), path));
+
+    // Default-on compile cache for script children (same decision as spawn_node,
+    // 2026-06-10): a script's node subtree inherits this env, so heavyweight
+    // single-file tools it launches (tsc/eslint/prettier-class bundles) load
+    // their V8 blobs instead of reparsing. Only the UNSET case is filled — a
+    // user value already lives in the parent env both paths carry.
+    if std::env::var_os("NODE_COMPILE_CACHE").is_none()
+        && let Some(dir) = nub_core::node::spawn::default_compile_cache_dir()
+    {
+        env_pairs.push(("NODE_COMPILE_CACHE".into(), dir));
+    }
+
+    // $NODE: npm/pnpm point this at the node binary running the script so userland
+    // `$NODE child.js` / `spawn(process.env.NODE, …)` invoke "the same Node." When
+    // we augment, point it at the PATH-shim `node` (→ nub) instead of the raw binary
+    // so an absolute-path `$NODE` re-enters nub and the child stays transpiled —
+    // identical to bare `node child.js` (which hits the shim via PATH). Falls back to
+    // the real binary with no shim (compat / re-entrant), where the inherited
+    // NODE_OPTIONS preload still augments it. `npm_node_execpath` deliberately stays
+    // the real binary (set in npm_env) — tooling derives Node's install prefix from
+    // it, and the shim dir has no such layout. Before the .env/npm_env overlays so a
+    // user `.env`-set NODE still wins (shell/.env precedence).
+    let node_env = aug
+        .as_ref()
+        .and_then(|a| a.node_shim_exe())
+        .unwrap_or_else(|| std::ffi::OsString::from(node.path.as_str()));
+    env_pairs.push(("NODE".into(), node_env));
+
+    if let Some(node_opts) = aug.as_ref().and_then(|a| a.node_options.as_ref()) {
+        env_pairs.push(("NODE_OPTIONS".into(), node_opts.clone().into()));
+    }
+    if let Some(node_path) = aug.as_ref().and_then(|a| a.node_path.as_ref()) {
+        env_pairs.push(("NODE_PATH".into(), node_path.clone()));
+    }
+    // localStorage-neutralize signal for the script subtree's node children (webstorage
+    // flag-needed band, no user --localstorage-file): the preload reads + deletes it.
+    if let Some(aug) = aug.as_ref() {
+        aug.apply_localstorage_env(|k, v| {
+            env_pairs.push((k.into(), v.into()));
+        });
+    }
+
+    // Force nub's async tier for a script that runs a foreign async loader
+    // (tsx/ts-node) on a broken-compose Node — the common `nub run dev` = `tsx …`
+    // case that otherwise crashes with ERR_METHOD_NOT_IMPLEMENTED. Only when we
+    // establish augmentation (`aug` is Some); a re-entrant child inherits the var.
+    if aug.is_some()
+        && let Some((k, val)) = force_async_tier
+    {
+        env_pairs.push((k.into(), val.into()));
+    }
+
+    // `npm_config_node_gyp`: npm/pnpm always point this at a runnable node-gyp
+    // (their bundled `node-gyp/bin/node-gyp.js`) so a script's `node
+    // $npm_config_node_gyp …` resolves without a global node-gyp install. nub
+    // hands out the engine's lazy `node-gyp.js` shim, which trampolines back
+    // into nub via `AUBE_NODE_GYP_EXE` (handled by `__node-gyp-bootstrap`) to
+    // bootstrap the real node-gyp on first use. Mirrors what the engine's
+    // lifecycle path stamps (`aube-scripts::apply_script_settings_env`) so the
+    // run and lifecycle paths agree. Before the `npm_env` overlay so a user-set
+    // value still wins; the bootstrap markers are nub-internal env (brand-exempt)
+    // and only meaningful to the shim. Failure to write the (cheap) shim degrades
+    // to leaving the var unset — same as a plain Node.
+    if let Ok(node_gyp_js) = aube::commands::install::node_gyp_bootstrap::lazy_js_shim_path() {
+        env_pairs.push(("npm_config_node_gyp".into(), node_gyp_js.into_os_string()));
+        env_pairs.push((
+            "AUBE_NODE_GYP_EXE".into(),
+            nub_binary.clone().into_os_string(),
+        ));
+        env_pairs.push((
+            "AUBE_NODE_GYP_PROJECT_DIR".into(),
+            project.root.clone().into_os_string(),
+        ));
+    }
+
+    // `npm_config_registry`: pnpm always exports the resolved registry to a
+    // script's environment (defaulting to `https://registry.npmjs.org/`); npm
+    // exports it whenever a registry is configured. nub left it unset, so a
+    // script reading `$npm_config_registry` (publish wrappers, custom fetch
+    // tooling) saw `undefined` under nub but a real URL under npm/pnpm. Read
+    // the resolved registry from the project's `.npmrc`/config chain — the same
+    // `NpmConfig` the engine resolves installs against — and export it. Before
+    // the `npm_env` overlay so a user-set value still wins.
+    let registry = aube_registry::config::NpmConfig::load(&project.root)
+        .registry_for("")
+        .to_string();
+    env_pairs.push(("npm_config_registry".into(), registry.into()));
+
+    // The `.env` (`--env-file`) overlay, then the `npm_*` lifecycle vars — both
+    // consumed by value (locals used only here) and placed last so a user-set
+    // value wins over nub's.
+    for (k, v) in env_vars {
+        env_pairs.push((k.into(), v.into()));
+    }
+    for (k, v) in npm_env {
+        env_pairs.push((k.into(), v.into()));
+    }
+
+    if use_emulator {
+        return Ok((
+            ScriptInvocation::Emulated {
+                body: full_cmd.clone(),
+                env: env_pairs,
+                cwd: project.root.clone(),
+            },
+            full_cmd,
+        ));
+    }
+
+    // Native shell: `sh -c` / `cmd /d /s /c`, or the `--script-shell`/`.npmrc`
+    // shell binary (custom POSIX shells use `-c`).
+    let (shell, shell_flag) = if let Some(ref s) = custom_shell {
+        (s.as_str(), "-c")
+    } else if cfg!(windows) {
+        // npm's exact flags: `/d` (skip AutoRun), `/s` (strip outer quotes), `/c`.
+        ("cmd", "/d /s /c")
+    } else {
+        ("sh", "-c")
+    };
+    // The implicit Windows `cmd` default must spawn with verbatim arguments — the
+    // script body is passed to cmd.exe exactly as written (npm's
+    // `windowsVerbatimArguments: true`), so Rust's MSVCRT re-quoting never mangles
+    // a `node -e "…"` body or undoes the per-arg cmd escaping. A custom POSIX
+    // shell (e.g. Git-Bash `sh.exe` via `--script-shell`) does its own parsing,
+    // so it takes the normal escaped-`arg` path.
+    let cmd_verbatim = custom_shell.is_none() && cfg!(windows);
+
     let mut command = StdCommand::new(shell);
-    // Windows cmd: split the multi-token flag (`/d /s /c`) and pass the body
-    // verbatim via `raw_arg`, the Rust equivalent of Node's
-    // `windowsVerbatimArguments: true`, so MSVCRT re-quoting never mangles a
-    // `node -e "…"` body or undoes the per-arg cmd escaping. A custom POSIX shell
-    // (e.g. Git-Bash `sh.exe`) does its own parsing → the escaped-`arg` path.
     #[cfg(windows)]
     let spawned = if cmd_verbatim {
         use std::os::windows::process::CommandExt;
@@ -3667,109 +3840,7 @@ fn build_script_command(
     }
     command.current_dir(&project.root);
 
-    // PATH: shim dir (when augmenting) → `.bin` walk-up chain → system PATH.
-    // `bin_path` is already `<.bin dirs>:<system PATH>`, so prepending the bare
-    // shim dir gives `shim:.bin:system` — `.bin` BEFORE the system PATH so a local
-    // tool shadows a global one (npm/pnpm parity), with the system PATH appearing
-    // exactly once.
-    let path: std::ffi::OsString = match aug.as_ref().and_then(|a| a.shim_dir.as_deref()) {
-        Some(shim) => {
-            let mut combined = std::ffi::OsString::from(shim);
-            if !bin_path.is_empty() {
-                combined.push(nub_core::PATH_LIST_SEPARATOR);
-                combined.push(std::ffi::OsString::from(bin_path.clone()));
-            }
-            combined
-        }
-        None => std::ffi::OsString::from(bin_path.clone()),
-    };
-    command.env("PATH", path);
-
-    // Default-on compile cache for script children (same decision as spawn_node,
-    // 2026-06-10): a script's node subtree inherits this env, so heavyweight
-    // single-file tools it launches (tsc/eslint/prettier-class bundles) load
-    // their V8 blobs instead of reparsing. User-set values are untouched —
-    // they're already in the inherited env and this only fills the unset case.
-    if std::env::var_os("NODE_COMPILE_CACHE").is_none() {
-        if let Some(dir) = nub_core::node::spawn::default_compile_cache_dir() {
-            command.env("NODE_COMPILE_CACHE", dir);
-        }
-    }
-
-    // $NODE: npm/pnpm point this at the node binary running the script so userland
-    // `$NODE child.js` / `spawn(process.env.NODE, …)` invoke "the same Node." When
-    // we augment, point it at the PATH-shim `node` (→ nub) instead of the raw binary
-    // so an absolute-path `$NODE` re-enters nub and the child stays transpiled —
-    // identical to bare `node child.js` (which hits the shim via PATH). Falls back to
-    // the real binary with no shim (compat / re-entrant), where the inherited
-    // NODE_OPTIONS preload still augments it. `npm_node_execpath` deliberately stays
-    // the real binary (set in npm_env) — tooling derives Node's install prefix from
-    // it, and the shim dir has no such layout. Set before the .env/npm_env loops so a
-    // user `.env`-set NODE still wins (shell/.env precedence).
-    let node_env = aug
-        .as_ref()
-        .and_then(|a| a.node_shim_exe())
-        .unwrap_or_else(|| std::ffi::OsString::from(node.path.as_str()));
-    command.env("NODE", node_env);
-
-    if let Some(node_opts) = aug.as_ref().and_then(|a| a.node_options.as_ref()) {
-        command.env("NODE_OPTIONS", node_opts);
-    }
-    if let Some(node_path) = aug.as_ref().and_then(|a| a.node_path.as_ref()) {
-        command.env("NODE_PATH", node_path);
-    }
-    // localStorage-neutralize signal for the script subtree's node children (webstorage
-    // flag-needed band, no user --localstorage-file): the preload reads + deletes it.
-    if let Some(aug) = aug.as_ref() {
-        aug.apply_localstorage_env(|k, v| {
-            command.env(k, v);
-        });
-    }
-
-    // Force nub's async tier for a script that runs a foreign async loader
-    // (tsx/ts-node) on a broken-compose Node — the common `nub run dev` = `tsx …`
-    // case that otherwise crashes with ERR_METHOD_NOT_IMPLEMENTED. Only when we
-    // establish augmentation (`aug` is Some); a re-entrant child inherits the var.
-    if aug.is_some()
-        && let Some((k, val)) = force_async_tier
-    {
-        command.env(k, val);
-    }
-
-    // `npm_config_node_gyp`: npm/pnpm always point this at a runnable node-gyp
-    // (their bundled `node-gyp/bin/node-gyp.js`) so a script's `node
-    // $npm_config_node_gyp …` resolves without a global node-gyp install. nub
-    // hands out the engine's lazy `node-gyp.js` shim, which trampolines back
-    // into nub via `AUBE_NODE_GYP_EXE` (handled by `__node-gyp-bootstrap`) to
-    // bootstrap the real node-gyp on first use. Mirrors what the engine's
-    // lifecycle path stamps (`aube-scripts::apply_script_settings_env`) so the
-    // run and lifecycle paths agree. Set before the `npm_env` loop so a
-    // user-set value still wins; the bootstrap markers are nub-internal env
-    // (brand-exempt) and only meaningful to the shim. Failure to write the
-    // (cheap) shim degrades to leaving the var unset — same as a plain Node.
-    if let Ok(node_gyp_js) = aube::commands::install::node_gyp_bootstrap::lazy_js_shim_path() {
-        command.env("npm_config_node_gyp", node_gyp_js);
-        command.env("AUBE_NODE_GYP_EXE", &nub_binary);
-        command.env("AUBE_NODE_GYP_PROJECT_DIR", &project.root);
-    }
-
-    // `npm_config_registry`: pnpm always exports the resolved registry to a
-    // script's environment (defaulting to `https://registry.npmjs.org/`); npm
-    // exports it whenever a registry is configured. nub left it unset, so a
-    // script reading `$npm_config_registry` (publish wrappers, custom fetch
-    // tooling) saw `undefined` under nub but a real URL under npm/pnpm. Read
-    // the resolved registry from the project's `.npmrc`/config chain — the same
-    // `NpmConfig` the engine resolves installs against — and export it. Set
-    // before the `npm_env` loop so a user-set value still wins.
-    let registry = aube_registry::config::NpmConfig::load(&project.root)
-        .registry_for("")
-        .to_string();
-    command.env("npm_config_registry", registry);
-
-    for (k, v) in &env_vars {
-        command.env(k, v);
-    }
-    for (k, v) in &npm_env {
+    for (k, v) in env_pairs {
         command.env(k, v);
     }
 
@@ -3778,7 +3849,7 @@ fn build_script_command(
         command.stderr(std::process::Stdio::piped());
     }
 
-    Ok((command, full_cmd))
+    Ok((ScriptInvocation::Native(command), full_cmd))
 }
 
 fn spawn_script(
@@ -3789,7 +3860,7 @@ fn spawn_script(
     lifecycle_event: &str,
     exec: &ScriptExecOpts,
 ) -> Result<i32> {
-    let (mut command, display_cmd) = build_script_command(
+    let (invocation, display_cmd) = build_script_command(
         cmd,
         project,
         compat_mode,
@@ -3808,12 +3879,21 @@ fn spawn_script(
     if !SILENT.load(Ordering::Relaxed) {
         eprintln!("$ {display_cmd}");
     }
-    // Forward terminating signals to the `sh -c <script>` child while it runs, so
-    // `docker stop` / Ctrl-C / systemd reach the workload — not just Nub's leader.
-    // A raw `command.status()` left the child orphaned on SIGTERM (the file-run
-    // path already forwards via spawn_node; this path did not).
-    let status = nub_core::node::spawn::status_forwarding_signals(&mut command)?;
-    Ok(nub_core::node::spawn::exit_code_from_status(&status))
+    match invocation {
+        // Forward terminating signals to the `sh -c <script>` child while it runs,
+        // so `docker stop` / Ctrl-C / systemd reach the workload — not just Nub's
+        // leader. A raw `command.status()` left the child orphaned on SIGTERM (the
+        // file-run path already forwards via spawn_node; this path did not).
+        ScriptInvocation::Native(mut command) => {
+            let status = nub_core::node::spawn::status_forwarding_signals(&mut command)?;
+            Ok(nub_core::node::spawn::exit_code_from_status(&status))
+        }
+        // The emulator wires its own signal forwarding to deno's KillSignal (it
+        // has no `std::process::Command` to hand the nub-core forwarder).
+        ScriptInvocation::Emulated { body, env, cwd } => {
+            crate::shell_emulator::run_inherit(&body, env, cwd)
+        }
+    }
 }
 
 /// Streamed analog of [`run_single_script`]: runs the `pre<x>` → `<x>` →
@@ -3923,7 +4003,7 @@ static AGGREGATE_FLUSH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 /// [`PipeReaders`]) so a failed thread-spawn never loses the pipe: the policy
 /// can always still drain the stream inline.
 #[derive(Clone)]
-struct DrainPolicy {
+pub(crate) struct DrainPolicy {
     ndjson: bool,
     aggregate: bool,
     is_stderr: bool,
@@ -3952,7 +4032,7 @@ impl DrainPolicy {
     }
 
     /// Drain `stream` to EOF on the CURRENT thread, returning the collected lines.
-    fn run<R: std::io::Read>(&self, stream: R) -> Vec<String> {
+    pub(crate) fn run<R: std::io::Read>(&self, stream: R) -> Vec<String> {
         use std::io::BufRead as _;
         let mut lines = Vec::new();
         for line in std::io::BufReader::new(stream)
@@ -4273,7 +4353,7 @@ fn spawn_script_prefixed(
 ) -> Result<(i32, String)> {
     use std::io::Write;
 
-    let (mut command, display_cmd) = build_script_command(
+    let (invocation, display_cmd) = build_script_command(
         cmd,
         project,
         compat_mode,
@@ -4282,8 +4362,6 @@ fn spawn_script_prefixed(
         StreamMode::Prefixed,
         exec.script_shell,
     )?;
-
-    nub_core::node::spawn::group_on_spawn(&mut command);
 
     // `--reporter=ndjson`: every output site emits a JSON object on stdout instead
     // of the prefixed human line. The package `name` is the manifest name (falling
@@ -4309,52 +4387,67 @@ fn spawn_script_prefixed(
         eprintln!("{cmd_prefix}{display_cmd}");
     }
 
-    let mut child = nub_core::node::spawn::spawn_with_eagain_retry(&mut command)?;
-    // Relay docker stop / Ctrl-C to the streamed child's whole process group too
-    // (workspace `-r` runs) — the `sh -c` won't pass a forwarded signal to node.
-    nub_core::node::spawn::track_child_group(child.id());
-    let mut output_buf = String::new();
-
-    let stdout = child.stdout.take();
-    let stderr = child.stderr.take();
-
+    // Per-stream policies (shared by both execution paths). In aggregate mode the
+    // drains COLLECT prefixed lines instead of emitting them live; the parent
+    // flushes the buffered blocks once, below.
     let prefix_out = format_stream_prefix(prefix, script_name, color_idx);
-    let prefix_err = prefix_out.clone();
+    let out_policy = DrainPolicy {
+        ndjson,
+        aggregate,
+        is_stderr: false,
+        prefix: prefix_out.clone(),
+        name: pkg_name.clone(),
+        script: script_name.to_string(),
+    };
+    let err_policy = DrainPolicy {
+        ndjson,
+        aggregate,
+        is_stderr: true,
+        prefix: prefix_out,
+        name: pkg_name.clone(),
+        script: script_name.to_string(),
+    };
 
-    let (name_out, script_out) = (pkg_name.clone(), script_name.to_string());
-    let (name_err, script_err) = (pkg_name.clone(), script_name.to_string());
+    // Spawn + drain both pipes concurrently (never deadlocks), yielding the exit
+    // code and the collected (prefixed) lines. The native path spawns a real
+    // shell child and drains its pipes via `PipeReaders`; the emulator runs
+    // deno_task_shell on a current-thread runtime, draining its pipes on threads.
+    let (exit_code, out_lines, err_lines) = match invocation {
+        ScriptInvocation::Native(mut command) => {
+            nub_core::node::spawn::group_on_spawn(&mut command);
+            let mut child = nub_core::node::spawn::spawn_with_eagain_retry(&mut command)?;
+            // Relay docker stop / Ctrl-C to the streamed child's whole process
+            // group too (workspace `-r` runs) — the `sh -c` won't pass a forwarded
+            // signal to node.
+            nub_core::node::spawn::track_child_group(child.id());
+            let stdout = child.stdout.take();
+            let stderr = child.stderr.take();
+            // `PipeReaders` drains both pipes CONCURRENTLY and never deadlocks —
+            // stdout on its own thread + stderr inline normally, or both
+            // interleaved on one thread via `poll(2)` when OS thread-create EAGAIN
+            // forces the inline fallback (the `nub ci` exit-101 family, where a
+            // bare `thread::spawn` would panic/abort).
+            let (out_lines, err_lines) = PipeReaders {
+                stdout,
+                stderr,
+                out_policy,
+                err_policy,
+            }
+            .drain();
+            let status = child.wait()?;
+            nub_core::node::spawn::untrack_child();
+            (
+                nub_core::node::spawn::exit_code_from_status(&status),
+                out_lines,
+                err_lines,
+            )
+        }
+        ScriptInvocation::Emulated { body, env, cwd } => {
+            crate::shell_emulator::run_prefixed(&body, env, cwd, out_policy, err_policy)?
+        }
+    };
 
-    // In aggregate mode the drains collect prefixed lines instead of emitting
-    // them live; the parent flushes the buffered blocks once, below. `PipeReaders`
-    // drains both pipes CONCURRENTLY and never deadlocks — stdout on its own
-    // thread + stderr inline normally, or both interleaved on one thread via
-    // `poll(2)` when OS thread-create EAGAIN forces the inline fallback (the
-    // `nub ci` exit-101 family, where a bare `thread::spawn` would panic/abort).
-    let (out_lines, err_lines) = PipeReaders {
-        stdout,
-        stderr,
-        out_policy: DrainPolicy {
-            ndjson,
-            aggregate,
-            is_stderr: false,
-            prefix: prefix_out,
-            name: name_out,
-            script: script_out,
-        },
-        err_policy: DrainPolicy {
-            ndjson,
-            aggregate,
-            is_stderr: true,
-            prefix: prefix_err,
-            name: name_err,
-            script: script_err,
-        },
-    }
-    .drain();
-
-    let status = child.wait()?;
-    nub_core::node::spawn::untrack_child();
-    let exit_code = nub_core::node::spawn::exit_code_from_status(&status);
+    let mut output_buf = String::new();
     if ndjson {
         emit_ndjson(
             "end",

--- a/crates/nub-cli/src/main.rs
+++ b/crates/nub-cli/src/main.rs
@@ -12,6 +12,7 @@ mod nubx_resolve;
 mod phantom_scan;
 mod pm_engine;
 mod self_shim;
+mod shell_emulator;
 mod verify_deps;
 
 use anyhow::Result;

--- a/crates/nub-cli/src/shell_emulator.rs
+++ b/crates/nub-cli/src/shell_emulator.rs
@@ -31,10 +31,39 @@ use deno_task_shell::{
 
 use crate::cli::DrainPolicy;
 
+/// Appended to every parse error. The emulator is default-on (a breaking change
+/// vs a native shell), so a user hitting a construct outside the subset —
+/// arithmetic `$((…))`, unbalanced quotes — must be pointed at the escape hatch,
+/// not left with a bare parse error. (Control-flow keywords like `for`/`if` do
+/// NOT parse-error here — deno treats them as command words → `for: command not
+/// found`, exit 127 — so they can't be intercepted; the docs cover that case.)
+const EMULATOR_OPT_OUT_HINT: &str = "\n(nub runs scripts through a POSIX-subset shell by default; set shell-emulator=false in .npmrc to use your platform's native shell)";
+
+/// Parse a script body, tagging any failure with the opt-out hint.
+fn parse_body(body: &str) -> Result<parser::SequentialList> {
+    parser::parse(body)
+        .map_err(|e| anyhow::anyhow!("shell parse error: {e}{EMULATOR_OPT_OUT_HINT}"))
+}
+
+/// deno's `ShellState::new` asserts the cwd is absolute, so a relative project
+/// root would hard-abort under `panic = "abort"`. The native `Command` path
+/// tolerates a relative root via `current_dir`; absolutize here (lexically, or
+/// joined onto the process cwd) so the emulator matches instead of panicking,
+/// surfacing a clean error if the cwd can't be resolved.
+fn absolute_cwd(cwd: PathBuf) -> Result<PathBuf> {
+    if cwd.is_absolute() {
+        Ok(cwd)
+    } else {
+        std::path::absolute(&cwd)
+            .with_context(|| format!("resolve script working directory {}", cwd.display()))
+    }
+}
+
 /// Run a script body through the emulator with inherited stdio (single-package
 /// `nub run`). Returns the shell's exit code.
 pub(crate) fn run_inherit(body: &str, env: Vec<(OsString, OsString)>, cwd: PathBuf) -> Result<i32> {
-    let list = parser::parse(body).map_err(|e| anyhow::anyhow!("shell parse error: {e}"))?;
+    let list = parse_body(body)?;
+    let cwd = absolute_cwd(cwd)?;
     let env_map = build_env_map(env);
     run_on_local_runtime(async move {
         let kill = KillSignal::default();
@@ -54,7 +83,8 @@ pub(crate) fn run_prefixed(
     out_policy: DrainPolicy,
     err_policy: DrainPolicy,
 ) -> Result<(i32, Vec<String>, Vec<String>)> {
-    let list = parser::parse(body).map_err(|e| anyhow::anyhow!("shell parse error: {e}"))?;
+    let list = parse_body(body)?;
+    let cwd = absolute_cwd(cwd)?;
     let env_map = build_env_map(env);
 
     let (out_reader, out_writer) = deno_task_shell::pipe();
@@ -174,6 +204,10 @@ async fn forward_signals(kill: KillSignal) {
     loop {
         tokio::select! {
             _ = next(&mut term) => kill.send(SignalKind::SIGTERM),
+            // SIGHUP maps to `Other(1)`, which deno delivers to the in-flight
+            // child (OS `kill(pid, SIGHUP)`) but does NOT treat as an abort, so a
+            // `;`-separated command after it could still run. Acceptable: SIGHUP
+            // reaching the running workload is the load-bearing behavior.
             _ = next(&mut hup) => kill.send(SignalKind::Other(1)),
             _ = next(&mut quit) => kill.send(SignalKind::SIGQUIT),
             _ = next(&mut int) => kill.send(SignalKind::SIGINT),

--- a/crates/nub-cli/src/shell_emulator.rs
+++ b/crates/nub-cli/src/shell_emulator.rs
@@ -1,0 +1,192 @@
+//! The bundled cross-platform POSIX-subset script shell, backed by
+//! `deno_task_shell`. This is the DEFAULT engine for `nub run` package scripts
+//! (opt out with `.npmrc` `shell-emulator=false`, or override to a real shell
+//! binary with `--script-shell`). It gives scripts the same POSIX behavior on
+//! Windows as on Unix without requiring a system `sh` — `rm -rf`, `&&`, `$VAR`,
+//! `cp`/`mkdir`, and friends run through Rust builtins or a `PATH`/`which`
+//! lookup that spawns the real binary.
+//!
+//! The load-bearing correctness property: deno spawns unresolved commands with
+//! `.env_clear().envs(state.env_vars())`, so the env map handed to `execute` is
+//! the COMPLETE environment a `node`/`tsc` launched inside a script sees. It
+//! must therefore carry the full parent environment PLUS nub's augmentation
+//! overrides (PATH shim, `NODE_OPTIONS`, …) — exactly what the native `sh -c`
+//! child inherits — or transpilation would silently not reach script children.
+//! `build_env_map` seeds from the parent env and layers the same override pairs
+//! the native `Command` path applies (assembled once in `cli::build_script_command`).
+//!
+//! deno's executor is `!Send` (it holds `Rc`s and uses `spawn_local` for `&`
+//! background jobs), so it MUST run on a current-thread tokio runtime driven
+//! through a `LocalSet` — a plain `block_on` panics the moment a script uses a
+//! trailing `&`.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use deno_task_shell::{
+    KillSignal, ShellPipeReader, ShellState, SignalKind, execute, execute_with_pipes, parser,
+};
+
+use crate::cli::DrainPolicy;
+
+/// Run a script body through the emulator with inherited stdio (single-package
+/// `nub run`). Returns the shell's exit code.
+pub(crate) fn run_inherit(body: &str, env: Vec<(OsString, OsString)>, cwd: PathBuf) -> Result<i32> {
+    let list = parser::parse(body).map_err(|e| anyhow::anyhow!("shell parse error: {e}"))?;
+    let env_map = build_env_map(env);
+    run_on_local_runtime(async move {
+        let kill = KillSignal::default();
+        spawn_signal_forwarder(kill.clone());
+        execute(list, env_map, cwd, Default::default(), kill).await
+    })
+}
+
+/// Run a script body through the emulator with piped stdout/stderr so each line
+/// can be prefixed/collected (workspace `-r`, `--stream`, ndjson, aggregate).
+/// The two [`DrainPolicy`] instances format+emit each line exactly as the native
+/// piped path does. Returns `(exit_code, stdout_lines, stderr_lines)`.
+pub(crate) fn run_prefixed(
+    body: &str,
+    env: Vec<(OsString, OsString)>,
+    cwd: PathBuf,
+    out_policy: DrainPolicy,
+    err_policy: DrainPolicy,
+) -> Result<(i32, Vec<String>, Vec<String>)> {
+    let list = parser::parse(body).map_err(|e| anyhow::anyhow!("shell parse error: {e}"))?;
+    let env_map = build_env_map(env);
+
+    let (out_reader, out_writer) = deno_task_shell::pipe();
+    let (err_reader, err_writer) = deno_task_shell::pipe();
+
+    // Drain both pipes on dedicated threads: `block_on` occupies THIS thread
+    // driving `execute`, so if nothing reads the pipes concurrently deno blocks
+    // forever once a pipe buffer fills. `Builder::spawn` (not `thread::spawn`)
+    // so thread-create pressure surfaces as an error, never a `panic = "abort"`
+    // process abort. The moved writers are the pipes' only write ends; `execute`
+    // drops them on completion → the readers hit EOF → these threads finish.
+    let out_handle = std::thread::Builder::new()
+        .name("nub-emul-out".into())
+        .spawn(move || out_policy.run(into_pipe_reader(out_reader)))
+        .context("spawn shell-emulator stdout drain thread")?;
+    let err_handle = std::thread::Builder::new()
+        .name("nub-emul-err".into())
+        .spawn(move || err_policy.run(into_pipe_reader(err_reader)))
+        .context("spawn shell-emulator stderr drain thread")?;
+
+    let code = run_on_local_runtime(async move {
+        let kill = KillSignal::default();
+        spawn_signal_forwarder(kill.clone());
+        let state = ShellState::new(env_map, cwd, Default::default(), kill);
+        execute_with_pipes(
+            list,
+            state,
+            ShellPipeReader::stdin(),
+            out_writer,
+            err_writer,
+        )
+        .await
+    })?;
+
+    let out_lines = out_handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("shell-emulator stdout drain thread panicked"))?;
+    let err_lines = err_handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("shell-emulator stderr drain thread panicked"))?;
+    Ok((code, out_lines, err_lines))
+}
+
+/// Seed the map from the parent environment, then layer nub's augmentation
+/// overrides on top (last-wins, the same order the native `Command` path applies
+/// them). See the module doc for why the full parent env must be present.
+fn build_env_map(overrides: Vec<(OsString, OsString)>) -> HashMap<OsString, OsString> {
+    let mut map: HashMap<OsString, OsString> = std::env::vars_os().collect();
+    for (k, v) in overrides {
+        map.insert(k, v);
+    }
+    map
+}
+
+/// `pipe()` always yields the `OsPipe` variant; extract the inner reader (which
+/// implements `Read + Send`) so a `DrainPolicy` can consume it on a thread.
+fn into_pipe_reader(reader: ShellPipeReader) -> std::io::PipeReader {
+    match reader {
+        ShellPipeReader::OsPipe(r) => r,
+        ShellPipeReader::StdFile(_) => {
+            unreachable!("deno_task_shell::pipe() always returns an OsPipe reader")
+        }
+    }
+}
+
+/// Build a current-thread runtime + `LocalSet` and drive `fut` to completion.
+/// deno's executor is `!Send`; a `LocalSet` is what lets a trailing-`&` job's
+/// `spawn_local` run instead of panicking. Called from sync code (never inside
+/// another runtime), so `block_on` is safe.
+fn run_on_local_runtime<F: std::future::Future>(fut: F) -> Result<F::Output> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("build tokio runtime for shell emulator")?;
+    let local = tokio::task::LocalSet::new();
+    Ok(local.block_on(&rt, fut))
+}
+
+/// Forward terminating OS signals to deno's `KillSignal` so `docker stop` /
+/// systemd / `kill` reach the emulated script's children — without it a child
+/// `node` is orphaned on SIGTERM (deno kills tracked children on abort). Runs as
+/// a `spawn_local` task on the same thread as the executor (both `!Send`), and
+/// is cancelled when the `LocalSet` is dropped after the script exits.
+///
+/// SIGINT is forwarded ONLY when stdin is not a TTY: on a terminal the kernel
+/// already delivers Ctrl-C's SIGINT to the whole foreground group (deno's child
+/// included), so forwarding it too would deliver it twice (the double-`SIGINT`
+/// class of bug, cf. issue #26). SIGTERM/SIGHUP/SIGQUIT are group-independent
+/// and always forwarded.
+fn spawn_signal_forwarder(kill: KillSignal) {
+    tokio::task::spawn_local(async move { forward_signals(kill).await });
+}
+
+#[cfg(unix)]
+async fn forward_signals(kill: KillSignal) {
+    use std::io::IsTerminal;
+    use tokio::signal::unix::{Signal, SignalKind as Unix, signal};
+
+    async fn next(sig: &mut Option<Signal>) {
+        match sig {
+            Some(s) => {
+                s.recv().await;
+            }
+            None => std::future::pending::<()>().await,
+        }
+    }
+
+    let mut term = signal(Unix::terminate()).ok();
+    let mut hup = signal(Unix::hangup()).ok();
+    let mut quit = signal(Unix::quit()).ok();
+    let mut int = if std::io::stdin().is_terminal() {
+        None
+    } else {
+        signal(Unix::interrupt()).ok()
+    };
+
+    loop {
+        tokio::select! {
+            _ = next(&mut term) => kill.send(SignalKind::SIGTERM),
+            _ = next(&mut hup) => kill.send(SignalKind::Other(1)),
+            _ = next(&mut quit) => kill.send(SignalKind::SIGQUIT),
+            _ = next(&mut int) => kill.send(SignalKind::SIGINT),
+        }
+    }
+}
+
+#[cfg(not(unix))]
+async fn forward_signals(kill: KillSignal) {
+    // Windows: deno associates children with a Job Object that kills them when
+    // nub exits, so orphaning is already handled; forward Ctrl-C so an
+    // interactive interrupt still aborts a running child promptly.
+    while tokio::signal::ctrl_c().await.is_ok() {
+        kill.send(SignalKind::SIGINT);
+    }
+}

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -4109,10 +4109,12 @@ fn single_package_run_echoes_command_to_stderr_unless_silent() {
     // #146: forwarded CLI args appear in the echoed preamble, spliced + escaped
     // exactly as executed, so the displayed command matches the effective one. A
     // metachar arg is shell-quoted in the echo (and reaches the script as one
-    // literal token), proving the echo reflects the real escaped command. The
-    // escaping is shell-specific: POSIX `sh` single-quotes, Windows `cmd.exe`
-    // caret-escapes, so the expected preamble and echoed output differ per OS.
-    // The post-target `--` is forwarded verbatim (Option A) — byte-identical to
+    // literal token), proving the echo reflects the real escaped command. Scripts
+    // run through the default POSIX-subset emulator on EVERY platform, so the echo
+    // and the execution share ONE `sh`-escaped string (single-quoted) — including
+    // on Windows, where the emulator supersedes `cmd.exe`. This is the
+    // host-agnostic guard that the emulated display uses the sh escaper. The
+    // post-target `--` is forwarded verbatim (Option A) — byte-identical to
     // `pnpm 10 run greet -- "brave new world"`.
     let out_args = Command::new(nub_binary())
         .args(["run", "greet", "--", "brave new world"])
@@ -4122,23 +4124,12 @@ fn single_package_run_echoes_command_to_stderr_unless_silent() {
     let stderr_args = String::from_utf8_lossy(&out_args.stderr);
     let stdout_args = String::from_utf8_lossy(&out_args.stdout);
     assert_eq!(out_args.status.code(), Some(0), "stderr: {stderr_args}");
-    let (want_preamble, want_output) = if cfg!(windows) {
-        (
-            "$ echo hello -- ^\"brave^ new^ world^\"",
-            "hello -- \"brave new world\"",
-        )
-    } else {
-        (
-            "$ echo hello -- 'brave new world'",
-            "hello -- brave new world",
-        )
-    };
     assert!(
-        stderr_args.contains(want_preamble),
-        "the preamble must include the escaped forwarded args: {stderr_args:?}"
+        stderr_args.contains("$ echo hello -- 'brave new world'"),
+        "the preamble must show the sh-escaped forwarded args on every platform: {stderr_args:?}"
     );
     assert!(
-        stdout_args.contains(want_output),
+        stdout_args.contains("hello -- brave new world"),
         "the forwarded args must still reach the script unchanged: {stdout_args:?}"
     );
 }

--- a/crates/nub-cli/tests/shell_emulator.rs
+++ b/crates/nub-cli/tests/shell_emulator.rs
@@ -140,6 +140,14 @@ fn forwarded_args_are_posix_escaped_as_single_tokens() {
         out.contains("a b|c"),
         "spaced arg should arrive as one token, got stdout: {out:?}"
     );
+    // The echoed `$ …` preamble is the SAME sh-escaped string the emulator runs
+    // (#146), on every platform — so the display shows `'a b'`, never the native
+    // shell's quoting. Host-agnostic guard for the Windows display regression:
+    // the preamble must not diverge from what the emulator executes.
+    assert!(
+        err.contains("'a b'"),
+        "the preamble must show the sh-escaped arg on every platform, got stderr: {err:?}"
+    );
 }
 
 #[test]

--- a/crates/nub-cli/tests/shell_emulator.rs
+++ b/crates/nub-cli/tests/shell_emulator.rs
@@ -178,12 +178,18 @@ fn shell_emulator_false_opts_out_to_native_shell() {
     let root = tmp_dir("optout");
     write_manifest(&root, r#"{"loop":"for i in a b c; do printf $i; done"}"#);
 
-    // Default (emulator): the `for` construct isn't in the subset, so it does not
-    // print `abc` — proving the default engine is the emulator, not native `sh`.
-    let (out_default, _e, _c) = run_nub(&root, &["run", "loop"]);
+    // Default (emulator): `for` isn't in the subset — deno reads it as a command
+    // word, so nothing prints `abc` AND the run exits nonzero (`for: command not
+    // found`). Asserting the failure documents the accepted regression instead of
+    // hiding it: a control-flow script must opt out (shellEmulator=false).
+    let (out_default, _e, code_default) = run_nub(&root, &["run", "loop"]);
     assert!(
         !out_default.contains("abc"),
         "default emulator should not run a POSIX `for` loop, got: {out_default:?}"
+    );
+    assert_ne!(
+        code_default, 0,
+        "emulated `for` should fail (control flow is outside the subset), got exit {code_default}"
     );
 
     // Opt out → native `sh` runs the loop and prints `abc`.

--- a/crates/nub-cli/tests/shell_emulator.rs
+++ b/crates/nub-cli/tests/shell_emulator.rs
@@ -1,0 +1,197 @@
+//! `nub run` through the bundled cross-platform shell emulator
+//! (`deno_task_shell`), which is the DEFAULT script engine on every platform.
+//! These run end-to-end through the binary against throwaway fixtures — no
+//! install needed (the scripts are bare `rm`/`echo`/`node`), so they run
+//! offline. The real payoff is the Windows CI leg: a POSIX script that `cmd.exe`
+//! could never run now works there because it routes through the emulator.
+//!
+//! Contracts pinned:
+//!   - a POSIX-ism script (`rm -rf` + `&&` + redirection) runs green by default;
+//!   - nub's augmentation + lifecycle env reaches the emulated script;
+//!   - forwarded args are POSIX-escaped and arrive as single literal tokens;
+//!   - a child process's exit code propagates through the emulator;
+//!   - a trailing-`&` background job runs (proves the tokio `LocalSet` is wired
+//!     — deno's `spawn_local` panics without it);
+//!   - `shellEmulator=false` opts back out to the native shell.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // <profile>/
+    path.push("nub");
+    path
+}
+
+fn tmp_dir(tag: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nub-emul-{tag}-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+/// Run `nub <args>` in `dir` with global caches redirected to temp dirs so the
+/// run can't read or write the host's real config/cache. `NODE_OPTIONS` is
+/// cleared so the harness's own value can't masquerade as one nub injected.
+fn run_nub(dir: &Path, args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .env_remove("NODE_OPTIONS")
+        .env("XDG_DATA_HOME", tmp_dir("xdg-data"))
+        .env("XDG_CACHE_HOME", tmp_dir("xdg-cache"))
+        .output()
+        .expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+fn write_manifest(root: &Path, scripts: &str) {
+    write(
+        &root.join("package.json"),
+        &format!(r#"{{"name":"emul-fixture","version":"1.0.0","scripts":{scripts}}}"#),
+    );
+}
+
+#[test]
+fn posix_script_runs_green_under_default_emulator() {
+    // The headline case: a script that mixes `rm -rf`, `&&`, `mkdir`, and output
+    // redirection — none of which `cmd.exe` runs — succeeds by default because it
+    // routes through the emulator on every platform.
+    let root = tmp_dir("posix");
+    write_manifest(
+        &root,
+        r#"{"clean":"rm -rf dist && mkdir dist && echo ok > dist/marker"}"#,
+    );
+
+    let (_out, err, code) = run_nub(&root, &["run", "clean"]);
+    assert_eq!(
+        code, 0,
+        "clean script should succeed under the emulator: {err}"
+    );
+    let marker = std::fs::read_to_string(root.join("dist/marker")).expect("dist/marker written");
+    assert_eq!(marker.trim(), "ok");
+}
+
+#[test]
+fn augmentation_env_reaches_emulated_script() {
+    // The load-bearing property: nub's augmentation + lifecycle env must reach
+    // the emulator's env map (deno spawns children with `env_clear`, so anything
+    // missing from the map is missing from a `node`/`tsc` launched by a script).
+    // `$NODE` (nub points it at the Node running the script), `$npm_lifecycle_event`
+    // (the script name), and `$npm_config_registry` are always set by the shared
+    // env assembly regardless of Node version — unlike `NODE_OPTIONS`, which nub
+    // leaves empty on Nodes new enough to need no injected flags.
+    let root = tmp_dir("augenv");
+    write_manifest(
+        &root,
+        r#"{"probe":"echo evt=$npm_lifecycle_event node=[$NODE] reg=$npm_config_registry"}"#,
+    );
+
+    let (out, err, code) = run_nub(&root, &["run", "probe"]);
+    assert_eq!(code, 0, "probe script failed: {err}");
+    assert!(
+        out.contains("evt=probe"),
+        "npm_lifecycle_event missing: {out:?}"
+    );
+    assert!(
+        !out.contains("node=[]"),
+        "nub's $NODE override should reach the emulated script: {out:?}"
+    );
+    assert!(
+        out.contains("reg=http"),
+        "npm_config_registry should reach the emulated script: {out:?}"
+    );
+}
+
+#[test]
+fn forwarded_args_are_posix_escaped_as_single_tokens() {
+    // Args after `--` are spliced onto the body with the POSIX (`sh`) escaper on
+    // every platform, so a metachar/space arg reaches the script as ONE literal
+    // token. `node -e` leaves no script-path element in argv, so the forwarded
+    // args are argv[1..] (slice(1)); joining by `|` makes token boundaries visible.
+    let root = tmp_dir("args");
+    write_manifest(
+        &root,
+        r#"{"echoargs":"node -e \"console.log(process.argv.slice(1).join('|'))\""}"#,
+    );
+
+    let (out, err, code) = run_nub(&root, &["run", "echoargs", "--", "a b", "c"]);
+    assert_eq!(code, 0, "echoargs failed: {err}");
+    assert!(
+        out.contains("a b|c"),
+        "spaced arg should arrive as one token, got stdout: {out:?}"
+    );
+}
+
+#[test]
+fn exit_code_propagates_from_emulated_child() {
+    // A child process's exit code flows back through the emulator unchanged.
+    let root = tmp_dir("exit");
+    write_manifest(&root, r#"{"boom":"node -e \"process.exit(3)\""}"#);
+
+    let (_out, err, code) = run_nub(&root, &["run", "boom"]);
+    assert_eq!(code, 3, "expected the child's exit 3 to propagate: {err}");
+}
+
+#[test]
+fn trailing_background_job_runs_without_panicking() {
+    // A trailing `&` makes deno `spawn_local` the job, which PANICS unless the
+    // executor runs inside a tokio `LocalSet`. Exit 0 (not an abort code) proves
+    // the LocalSet entry is wired.
+    let root = tmp_dir("bg");
+    write_manifest(&root, r#"{"bg":"echo hi &"}"#);
+
+    let (_out, err, code) = run_nub(&root, &["run", "bg"]);
+    assert_eq!(
+        code, 0,
+        "trailing-& job should run under the LocalSet, not panic: {err}"
+    );
+}
+
+/// The opt-out flips the engine from the emulator back to the platform shell.
+/// Unix-only: the differentiator is a `for` loop, which the deno subset can't
+/// parse but POSIX `sh` runs — so the default (emulator) yields no `abc`, and
+/// `shellEmulator=false` (native `sh`) prints it. On Windows the native shell is
+/// `cmd`, whose syntax differs, so this precise differential is Unix-scoped.
+#[cfg(unix)]
+#[test]
+fn shell_emulator_false_opts_out_to_native_shell() {
+    let root = tmp_dir("optout");
+    write_manifest(&root, r#"{"loop":"for i in a b c; do printf $i; done"}"#);
+
+    // Default (emulator): the `for` construct isn't in the subset, so it does not
+    // print `abc` — proving the default engine is the emulator, not native `sh`.
+    let (out_default, _e, _c) = run_nub(&root, &["run", "loop"]);
+    assert!(
+        !out_default.contains("abc"),
+        "default emulator should not run a POSIX `for` loop, got: {out_default:?}"
+    );
+
+    // Opt out → native `sh` runs the loop and prints `abc`.
+    write(&root.join(".npmrc"), "shell-emulator=false\n");
+    let (out_native, err, code) = run_nub(&root, &["run", "loop"]);
+    assert_eq!(code, 0, "native sh loop failed: {err}");
+    assert!(
+        out_native.contains("abc"),
+        "shellEmulator=false should run the loop on native sh, got: {out_native:?}"
+    );
+}

--- a/crates/nub-core/src/workspace/scripts.rs
+++ b/crates/nub-core/src/workspace/scripts.rs
@@ -394,10 +394,37 @@ pub fn script_shell(project_root: &Path) -> Option<String> {
     npmrc_value(project_root, "script-shell")
 }
 
+/// Whether package scripts run through the bundled POSIX-subset shell emulator
+/// (`deno_task_shell`) rather than the platform's native `sh`/`cmd`.
+///
+/// DEFAULT ON — nub's deliberate divergence from pnpm, whose `shellEmulator`
+/// defaults off. Routing every platform through one engine gives scripts the
+/// same POSIX behavior on Windows as on Unix. Only an explicit falsey value
+/// opts back out to the native shell; `--script-shell` / `.npmrc script-shell`
+/// still win over both (resolved by the caller). Env (`npm_config_shell_emulator`,
+/// what a parent PM exports) takes precedence over `.npmrc`, matching npm's
+/// config layering; both the pnpm-style `shell-emulator` and the camelCase
+/// `shellEmulator` `.npmrc` spellings are honored.
+pub fn shell_emulator(project_root: &Path) -> bool {
+    let explicit = env::var("npm_config_shell_emulator")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| npmrc_value(project_root, "shell-emulator"))
+        .or_else(|| npmrc_value(project_root, "shellEmulator"));
+    match explicit {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "false" | "0" | "no" | "off"
+        ),
+        None => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         ScriptSelection, bin_path, find_bin, npm_env, npmrc_value, script_shell, select_scripts,
+        shell_emulator,
     };
     use std::fs;
 
@@ -527,6 +554,32 @@ mod tests {
         assert!(npmrc_value(&tmp, "nub-no-such-key").is_none());
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn shell_emulator_defaults_on_and_reads_explicit_opt_out() {
+        // Hermetic to a project `.npmrc` so a maintainer's `~/.npmrc` can't sway
+        // it (project entries win over user-level in `npmrc_value`). The env
+        // override is exercised e2e, not here, to avoid mutating a process global.
+        let base = std::env::temp_dir().join(format!("nub-shellemu-{}", std::process::id()));
+
+        let on = base.join("on");
+        fs::create_dir_all(&on).unwrap();
+        fs::write(on.join(".npmrc"), "shell-emulator=true\n").unwrap();
+        assert!(shell_emulator(&on));
+
+        let off = base.join("off");
+        fs::create_dir_all(&off).unwrap();
+        fs::write(off.join(".npmrc"), "shell-emulator=false\n").unwrap();
+        assert!(!shell_emulator(&off));
+
+        // The camelCase spelling is honored too.
+        let off_camel = base.join("off-camel");
+        fs::create_dir_all(&off_camel).unwrap();
+        fs::write(off_camel.join(".npmrc"), "shellEmulator = 0\n").unwrap();
+        assert!(!shell_emulator(&off_camel));
+
+        let _ = fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/site/content/docs/runner/run.mdx
+++ b/site/content/docs/runner/run.mdx
@@ -217,7 +217,7 @@ Script bodies run through a bundled POSIX-subset shell ([`deno_task_shell`](http
 nub run clean   # identical on Windows, macOS, and Linux
 ```
 
-It is a subset, not a full shell. Covered: the built-ins (`rm`, `cp`, `mv`, `mkdir`, `cat`, `echo`, `test`, `xargs`, `pwd`, `sleep`, …), pipes, `&&` / `||`, `;`, `$VAR` and `$(…)` expansion, `~`, brace expansion, redirection, and background `&` jobs. Not covered: shell control flow (`for`, `while`, `if`, `case`), functions, and arithmetic `$((…))`. A command that isn't a built-in is resolved on `PATH` and run as a real process, so `node`, `tsc`, and your `node_modules/.bin` tools work as usual. The subset is not byte-identical to `bash`, `sh`, or pnpm's `@yarnpkg/shell`.
+It is a subset, not a full shell. Covered: the built-ins (`rm`, `cp`, `mv`, `mkdir`, `cat`, `echo`, `test`, `xargs`, `pwd`, `sleep`, …), pipes, `&&` / `||`, `;`, `$VAR` and `$(…)` expansion, `~`, brace expansion, redirection, and background `&` jobs. Not covered: shell control flow (`for`, `while`, `if`, `case`), functions, and arithmetic `$((…))` — a script that needs those must opt out (below). Control-flow keywords aren't a clean parse error; they read as an unknown command, so a `for` loop fails with `for: command not found`. A command that isn't a built-in is resolved on `PATH` and run as a real process, so `node`, `tsc`, and your `node_modules/.bin` tools work as usual. The subset is not byte-identical to `bash`, `sh`, or pnpm's `@yarnpkg/shell`.
 
 Turn it off with `shell-emulator` in `.npmrc` to fall back to the platform shell — `sh` on Unix, `cmd.exe` on Windows:
 

--- a/site/content/docs/runner/run.mdx
+++ b/site/content/docs/runner/run.mdx
@@ -201,9 +201,36 @@ INIT_CWD                   # the directory you invoked `nub run` from
 
 Inside a script, spawning `node` (by shebang or `child_process.spawn("node", …)`) re-enters Nub through the PATH shim, so child processes stay transpiled and augmented — see [`--node`](#--node) below.
 
+## Cross-platform script shell
+
+Script bodies run through a bundled POSIX-subset shell ([`deno_task_shell`](https://github.com/denoland/deno_task_shell)) on every platform, so the same script behaves the same on macOS, Linux, and Windows — no system shell required. POSIX constructs that `cmd.exe` can't run work on Windows unchanged:
+
+```json
+{
+  "scripts": {
+    "clean": "rm -rf dist && mkdir -p dist && cp README.md dist/"
+  }
+}
+```
+
+```bash
+nub run clean   # identical on Windows, macOS, and Linux
+```
+
+It is a subset, not a full shell. Covered: the built-ins (`rm`, `cp`, `mv`, `mkdir`, `cat`, `echo`, `test`, `xargs`, `pwd`, `sleep`, …), pipes, `&&` / `||`, `;`, `$VAR` and `$(…)` expansion, `~`, brace expansion, redirection, and background `&` jobs. Not covered: shell control flow (`for`, `while`, `if`, `case`), functions, and arithmetic `$((…))`. A command that isn't a built-in is resolved on `PATH` and run as a real process, so `node`, `tsc`, and your `node_modules/.bin` tools work as usual. The subset is not byte-identical to `bash`, `sh`, or pnpm's `@yarnpkg/shell`.
+
+Turn it off with `shell-emulator` in `.npmrc` to fall back to the platform shell — `sh` on Unix, `cmd.exe` on Windows:
+
+```ini
+# .npmrc
+shell-emulator = false
+```
+
+This is a deliberate divergence from pnpm, where `shellEmulator` defaults off. To pin a specific real shell instead of the platform default, use `--script-shell` below — it overrides the emulator.
+
 ## `--script-shell`
 
-If your `.npmrc` sets `script-shell`, Nub uses it to invoke script bodies. The rest of `.npmrc` (registry, auth, `node-linker`, `hoist-pattern`) is package-manager territory and is not read here.
+Setting `script-shell` in `.npmrc` runs script bodies through that shell binary instead of the emulator. The rest of `.npmrc` (registry, auth, `node-linker`, `hoist-pattern`) is package-manager territory and is not read here.
 
 ```ini
 # .npmrc


### PR DESCRIPTION
Implements pnpm's `shellEmulator` via `deno_task_shell` (MIT): `nub run` script bodies run through a bundled POSIX-subset shell **by default on every platform**, so POSIX-isms (`rm -rf`, `&&`, `$VAR`) work on Windows without a system `sh`.

- Default-on is a deliberate divergence from pnpm (defaults off).
- Opt out: `shell-emulator=false` → native `sh`/`cmd`; `--script-shell <path>` overrides to a real shell.
- The augmentation env (PATH shim, `NODE_OPTIONS`, `npm_*`) reaches both paths, so `node`/`tsc` stays transpiled. deno's `KillSignal` handles SIGTERM/SIGINT.
- Scope: `nub run` only.

Behavior change; warrants a minor release.

Closes #399