### PR TITLE
sandbox(macos): hardlink-alias residual test + LIMITATIONS parity

### DIFF
--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -323,11 +323,15 @@ Each is documented in code at the site noted; none is silently mis-reported.
   hardlink created *outside* the sandbox beforehand. Fix: none clean at the Landlock layer
   (the inode was legitimately named twice). Regression test:
   `hardlink_to_denied_secret_leaks_via_alias`.
-- **macOS hardlink-to-secret (same class as the Linux residual above).** Seatbelt file-read
-  rules are path-pattern based, like Landlock's, so the same alias holds: a pre-existing
-  same-uid hardlink to a secret, at a name the deny never targets, reads through the shared
-  inode. Bounded the same way — requires a hardlink created outside the sandbox beforehand;
-  fix: none clean at the Seatbelt layer either (the inode was legitimately named twice).
+- **macOS hardlink-to-secret (host-verified).** Seatbelt file-read rules are path-pattern
+  based, like Landlock's, so the same alias holds: a pre-existing same-uid hardlink to a
+  secret, at a name the deny never targets, is readable, and reading it reads the SHARED
+  inode — so the path-denied secret leaks through the alias. Host-verified: with the alias
+  present the secret leaks; without it the path-deny holds. Unlike Landlock's inode-keyed
+  grant, Seatbelt matches the PATH, so the denied path itself stays denied — only the alias
+  name reads. Bounded: requires a hardlink created *outside* the sandbox beforehand. Fix:
+  none clean at the Seatbelt layer (the inode was legitimately named twice). Regression
+  test: `hardlink_to_denied_secret_leaks_via_alias` (`tests/macos_enforcement.rs`).
 - **Linux derive→open TOCTOU.** Grant derivation canonicalizes paths on the host, then
   the kernel enforces at `open()` later; a path swapped in between could shift a target.
   Bounded: a same-uid local race within the confined tree. (Inherent to a canonicalize-

--- a/crates/nub-sandbox/tests/macos_enforcement.rs
+++ b/crates/nub-sandbox/tests/macos_enforcement.rs
@@ -678,3 +678,43 @@ fn deny_not_dodgeable_via_dotdot_or_symlink() {
         "symlink escaping confine denied"
     );
 }
+
+// ── documented, bounded residuals — CAPTURED so they are no longer reasoned-only ──
+
+#[test]
+fn hardlink_to_denied_secret_leaks_via_alias() {
+    // Seatbelt file-read rules are path-pattern based, like Landlock's: a `!<secret>`
+    // deny matches the PATH, not the inode. A pre-existing same-uid hardlink to the
+    // secret, at a name the deny never targets, is readable — and reading it reads the
+    // SHARED inode, so the path-denied secret leaks through the alias. BOUNDED: needs a
+    // hardlink created OUTSIDE the sandbox beforehand (no clean Seatbelt fix — the inode
+    // was legitimately named twice). The macOS twin of the Linux residual of the same
+    // name; if a future mechanism closes it, this assertion flips and flags the change.
+    let f = fixture();
+    let secret = f.proj.join("secret.txt");
+    fs::write(&secret, "REALSECRET").unwrap();
+    let alias = f.proj.join("alias.txt");
+    fs::hard_link(&secret, &alias).unwrap();
+    let surface = serde_json::json!({ "fs": [s(&f.proj), format!("!{}", s(&secret))] });
+    // Residual: the alias (un-denied name) reads the secret's inode.
+    assert!(
+        f.allowed(surface.clone(), CAT, &[&s(&alias)]),
+        "hardlink residual: an alias to the denied inode reads the secret"
+    );
+    // Divergence from Landlock (inode-keyed): Seatbelt matches the PATH, so WITH the alias
+    // present the secret's OWN denied path still reads EPERM — only the alias name leaks.
+    assert!(
+        !f.allowed(surface, CAT, &[&s(&secret)]),
+        "path-based deny: the secret's own denied path stays denied even with the alias present"
+    );
+    // Control: WITHOUT any hardlink, the same path-deny holds (proving the alias, not a
+    // broken carve, is the escape).
+    let f2 = fixture();
+    let secret2 = f2.proj.join("secret.txt");
+    fs::write(&secret2, "REALSECRET").unwrap();
+    let surf2 = serde_json::json!({ "fs": [s(&f2.proj), format!("!{}", s(&secret2))] });
+    assert!(
+        !f2.allowed(surf2, CAT, &[&s(&secret2)]),
+        "no hardlink: the path-deny denies the secret"
+    );
+}


### PR DESCRIPTION
Host-verified the hardlink-alias residual on macOS — previously tested/verified on Linux, only reasoned on macOS.

With a real sandbox-exec-confined `cat`: a pre-existing same-uid hardlink to a deny-listed secret reads it via the alias (Seatbelt matches the path, not the inode). Control (no hardlink): the direct denied path stays EPERM — non-vacuous.

- Add the macOS analog test in `tests/macos_enforcement.rs`, mirroring the Linux one.
- Tighten the `LIMITATIONS.md` macOS line to host-verified + test citation; note the divergence: on macOS only the alias leaks, unlike Landlock's inode-keyed grant.

Coverage + doc only; no code/behavior change.