### PR TITLE
fix(phantom): detect type phantoms in the .d.ts and SFC type surfaces under GVS

### DIFF
--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -297,7 +297,7 @@ pub(crate) fn phantom_cache_dir() -> Option<PathBuf> {
 /// after upgrade; harmless and expected (the whole point is to pick up the better
 /// verdict). Just bump the number when the scanner logic changes — the coupling
 /// is structural, nothing else to remember.
-pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 3;
+pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 4;
 
 /// THE single source of truth for a phantom sidecar's location: the versioned
 /// subdir `<phantom_cache_dir>/s<PHANTOM_SCANNER_VERSION>/<fingerprint>.json`.

--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -297,7 +297,7 @@ pub(crate) fn phantom_cache_dir() -> Option<PathBuf> {
 /// after upgrade; harmless and expected (the whole point is to pick up the better
 /// verdict). Just bump the number when the scanner logic changes — the coupling
 /// is structural, nothing else to remember.
-pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 2;
+pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 3;
 
 /// THE single source of truth for a phantom sidecar's location: the versioned
 /// subdir `<phantom_cache_dir>/s<PHANTOM_SCANNER_VERSION>/<fingerprint>.json`.

--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -111,15 +111,25 @@ fn expand(graph: &LockfileGraph, seed_names: &[String]) -> DiskMaterializePlan {
     )
 }
 
+/// One dynamically-flagged importer the planner may seed. Two INDEPENDENT reasons
+/// to eject, either sufficient: an undeclared-phantom carrier (`targets`, the
+/// runtime + `.d.ts`-undeclared class) and/or a `.d.ts` peer-type carrier
+/// (`type_peers`, nub#450). `dep_path`/`name` locate it in the graph.
+pub(super) struct FlaggedImporter {
+    pub dep_path: String,
+    pub name: String,
+    pub targets: Vec<String>,
+    pub type_peers: Vec<String>,
+}
+
 /// Pure planner: resolved graph + flat seed + dynamic phantom flags → graph-aware
 /// materialization plan. See the module docs for the two rungs. `flags` is each
-/// surviving-candidate importer's `(dep_path, name, undeclared-target-names)`,
-/// supplied by [`dynamic_phantom_flags`] in production and injected directly in
-/// tests.
+/// surviving-candidate importer, supplied by [`dynamic_phantom_flags`] in
+/// production and injected directly in tests.
 fn plan_from_flags(
     graph: &LockfileGraph,
     seed_names: &[String],
-    flags: &[(String, String, Vec<String>)],
+    flags: &[FlaggedImporter],
 ) -> DiskMaterializePlan {
     // Drop the version-BLIND `vite` name-seed and decide vite version-aware here.
     // The embedder default (mod.rs) seeds the literal `vite` for ANY direct-dep
@@ -164,9 +174,32 @@ fn plan_from_flags(
     // linker builds over the ejected set (see `aube_linker::link_hidden_hoist`)
     // then resolves every undeclared phantom for those members via Node's walk-up,
     // so no per-importer target hoist is recorded.
-    for (dep_path, name, targets) in flags {
-        if should_seed(targets, &direct_dep_names(dep_path, graph), is_top_level) {
-            seed_names_set.insert(name.as_str());
+    for flag in flags {
+        // (a) Undeclared phantoms — the existing runtime + `.d.ts`-undeclared class.
+        // Guard on non-empty targets: `should_seed` returns SEED for an empty target
+        // set (its "can't prove safe" default), which is correct for a phantom flag
+        // that lost its targets but WRONG for a pure type-peer flag (no undeclared
+        // phantom at all) — that must seed only via path (b).
+        let seed_for_targets = !flag.targets.is_empty()
+            && should_seed(
+                &flag.targets,
+                &direct_dep_names(&flag.dep_path, graph),
+                is_top_level,
+            );
+        // (b) `.d.ts` peer-type coupling (nub#450): a declared peer imported from
+        // the type surface breaks the type-checker only when the peer's types come
+        // from a SEPARATE top-level `@types/<peer>` the store realpath can't reach.
+        // Ejecting the importer makes its realpath project-local so the collective
+        // hidden tree provides `@types/<peer>`. Gate on the `@types/<peer>` actually
+        // being a top-level package: this both makes the eject load-bearing and
+        // BOUNDS it to the peer-typed set (a peer that ships its own types, e.g.
+        // `vue`, has no top-level `@types/vue`, so it never seeds — GVS stays on).
+        let seed_for_type_peers = flag
+            .type_peers
+            .iter()
+            .any(|peer| is_top_level(&types_package_name(peer)));
+        if seed_for_targets || seed_for_type_peers {
+            seed_names_set.insert(flag.name.as_str());
         }
     }
 
@@ -244,7 +277,7 @@ fn plan_from_flags(
 /// installs the hook only when armed, so this gate is belt-and-suspenders; the
 /// pure planning logic is tested through [`plan_from_flags`] with injected flags,
 /// so the unit tests never reach this store-IO path.
-fn dynamic_phantom_flags(graph: &LockfileGraph) -> Vec<(String, String, Vec<String>)> {
+fn dynamic_phantom_flags(graph: &LockfileGraph) -> Vec<FlaggedImporter> {
     if !enabled() {
         return Vec::new();
     }
@@ -277,13 +310,33 @@ fn dynamic_phantom_flags(graph: &LockfileGraph) -> Vec<(String, String, Vec<Stri
             // `cached_or_scan_verdict` scans + caches here so the decision is
             // correct at the point the resolved graph + CAS index are both in hand.
             let result = crate::dynamic_phantom::cached_or_scan_verdict(&sidecar_dir, &index)?;
-            if !result.has_unguarded_phantom {
+            // A package flags for EITHER an undeclared phantom (`targets`) OR a
+            // `.d.ts` peer-type coupling (`type_coupled_peers`, nub#450). react-pdf
+            // has NO undeclared phantom — only the react peer typed in its `.d.ts` —
+            // so gating on `has_unguarded_phantom` alone would drop it.
+            if !result.has_unguarded_phantom && result.type_coupled_peers.is_empty() {
                 return None;
             }
             let targets: Vec<String> = result.targets.into_iter().map(|t| t.name).collect();
-            Some((dep_path.clone(), pkg.name.clone(), targets))
+            Some(FlaggedImporter {
+                dep_path: dep_path.clone(),
+                name: pkg.name.clone(),
+                targets,
+                type_peers: result.type_coupled_peers,
+            })
         })
         .collect()
+}
+
+/// The DefinitelyTyped package name for a runtime package: `react` → `@types/react`,
+/// and a scoped `@scope/name` → `@types/scope__name` (the `__` mangling). This is
+/// the package whose top-level presence makes a `.d.ts` peer-type eject
+/// load-bearing (nub#450).
+fn types_package_name(pkg: &str) -> String {
+    match pkg.strip_prefix('@').and_then(|r| r.split_once('/')) {
+        Some((scope, name)) => format!("@types/{scope}__{name}"),
+        None => format!("@types/{pkg}"),
+    }
 }
 
 /// Whether a dynamically-flagged package must SEED the closure — the precision
@@ -406,6 +459,43 @@ mod tests {
         xs.iter().map(|s| s.to_string()).collect()
     }
 
+    /// A flagged importer carrying undeclared phantom `targets` (no peer-types).
+    fn flag(dep_path: &str, name: &str, targets: &[&str]) -> FlaggedImporter {
+        FlaggedImporter {
+            dep_path: dep_path.to_string(),
+            name: name.to_string(),
+            targets: targets.iter().map(|s| s.to_string()).collect(),
+            type_peers: Vec::new(),
+        }
+    }
+
+    /// A flagged importer carrying only `.d.ts` type-coupled peers (nub#450).
+    fn type_flag(dep_path: &str, name: &str, type_peers: &[&str]) -> FlaggedImporter {
+        FlaggedImporter {
+            dep_path: dep_path.to_string(),
+            name: name.to_string(),
+            targets: Vec::new(),
+            type_peers: type_peers.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    /// Register `names` as the root importer's direct deps — what `is_top_level`
+    /// reads (the `@types/<peer>` presence gate for the type-peer eject).
+    fn top_level(g: &mut LockfileGraph, names: &[&str]) {
+        g.importers.insert(
+            ".".to_string(),
+            names
+                .iter()
+                .map(|n| aube_lockfile::DirectDep {
+                    name: n.to_string(),
+                    dep_path: format!("{n}@0.0.0"),
+                    dep_type: aube_lockfile::DepType::Dev,
+                    specifier: None,
+                })
+                .collect(),
+        );
+    }
+
     // Rung-1 vite seeding is independent of the dynamic source, so these inject
     // an EMPTY flag set and exercise the pure planner (`plan_from_flags`) end to
     // end — no host-store IO.
@@ -523,10 +613,10 @@ mod tests {
             ("@hookform/resolvers@1.0.0", "@hookform/resolvers", &[]),
             ("zod@3.0.0", "zod", &[]),
         ]);
-        let flags = vec![(
-            "@hookform/resolvers@1.0.0".to_string(),
-            "@hookform/resolvers".to_string(),
-            vec!["zod".to_string()],
+        let flags = vec![flag(
+            "@hookform/resolvers@1.0.0",
+            "@hookform/resolvers",
+            &["zod"],
         )];
         let plan = plan_from_flags(&g, &[], &flags);
         let names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
@@ -672,11 +762,7 @@ mod tests {
             ("core@1.0.0", "core", &[("datastructures", "2.0.0")]),
             ("datastructures@2.0.0", "datastructures", &[]),
         ]);
-        let flags = vec![(
-            "basic@1.0.0".to_string(),
-            "basic".to_string(),
-            vec!["datastructures".to_string()],
-        )];
+        let flags = vec![flag("basic@1.0.0", "basic", &["datastructures"])];
         let plan = plan_from_flags(&g, &[], &flags);
         let names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
         assert!(
@@ -695,16 +781,80 @@ mod tests {
             ("adapter@1.0.0", "adapter", &[("helper", "1.0.0")]),
             ("helper@1.0.0", "helper", &[]),
         ]);
-        let flags = vec![(
-            "adapter@1.0.0".to_string(),
-            "adapter".to_string(),
-            vec!["helper".to_string()],
-        )];
+        let flags = vec![flag("adapter@1.0.0", "adapter", &["helper"])];
         let plan = plan_from_flags(&g, &[], &flags);
         assert!(
             plan.names.is_empty(),
             "a depth-1-satisfied phantom target stays skipped: {:?}",
             plan.names
         );
+    }
+
+    // Type-coupled peers (nub#450): the `.d.ts` peer-type eject path.
+
+    #[test]
+    fn type_peer_ejects_only_when_types_pkg_is_top_level() {
+        // react-pdf shape: it declares `react` a peer and imports it from its
+        // `.d.ts`. The eject is load-bearing ONLY because the project has a
+        // top-level `@types/react` the store realpath can't otherwise reach.
+        let mut g = graph(&[
+            ("@react-pdf/renderer@4.5.1", "@react-pdf/renderer", &[]),
+            ("@types/react@18.3.0", "@types/react", &[]),
+        ]);
+        top_level(&mut g, &["@react-pdf/renderer", "react", "@types/react"]);
+        let flags = vec![type_flag(
+            "@react-pdf/renderer@4.5.1",
+            "@react-pdf/renderer",
+            &["react"],
+        )];
+        let plan = plan_from_flags(&g, &[], &flags);
+        let names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
+        assert!(
+            names.contains("@react-pdf/renderer"),
+            "peer-type importer seeds when @types/react is top-level: {names:?}"
+        );
+    }
+
+    #[test]
+    fn type_peer_does_not_eject_without_top_level_types_pkg() {
+        // A self-typed peer (vue ships its own types → no `@types/vue` in the tree)
+        // must NOT eject — this is the bound that keeps GVS on for the common case.
+        let mut g = graph(&[
+            ("some-vue-lib@1.0.0", "some-vue-lib", &[]),
+            ("vue@3.5.0", "vue", &[]),
+        ]);
+        // vue is top-level but ships its own types → NO `@types/vue` in the tree.
+        top_level(&mut g, &["some-vue-lib", "vue"]);
+        let flags = vec![type_flag("some-vue-lib@1.0.0", "some-vue-lib", &["vue"])];
+        let plan = plan_from_flags(&g, &[], &flags);
+        assert!(
+            plan.names.is_empty(),
+            "no top-level @types/vue → no eject (GVS stays on): {:?}",
+            plan.names
+        );
+    }
+
+    #[test]
+    fn type_peer_handles_scoped_types_mangling() {
+        // A scoped peer's DefinitelyTyped name mangles the slash: `@scope/pkg` →
+        // `@types/scope__pkg`. The top-level check must use the mangled name.
+        let mut g = graph(&[
+            ("uses-babel@1.0.0", "uses-babel", &[]),
+            ("@types/babel__core@7.0.0", "@types/babel__core", &[]),
+        ]);
+        top_level(&mut g, &["uses-babel", "@types/babel__core"]);
+        let flags = vec![type_flag(
+            "uses-babel@1.0.0",
+            "uses-babel",
+            &["@babel/core"],
+        )];
+        let plan = plan_from_flags(&g, &[], &flags);
+        let names: HashSet<&str> = plan.names.iter().map(String::as_str).collect();
+        assert!(
+            names.contains("uses-babel"),
+            "scoped @types/scope__name mangling drives the seed: {names:?}"
+        );
+        assert_eq!(types_package_name("@babel/core"), "@types/babel__core");
+        assert_eq!(types_package_name("react"), "@types/react");
     }
 }

--- a/crates/nub-phantom-core/src/extract.rs
+++ b/crates/nub-phantom-core/src/extract.rs
@@ -160,7 +160,8 @@ impl<'a> Visit<'a> for SpecVisitor {
             // an inline all-`type` named import is likewise erased. A bare
             // `import "x"` (side effect) and any value specifier are runtime.
             Statement::ImportDeclaration(decl)
-                if self.capture_types || (!decl.import_kind.is_type() && import_has_value(decl)) =>
+                if self.capture_types
+                    || (!decl.import_kind.is_type() && import_has_value(decl)) =>
             {
                 self.record(&decl.source.value, RefKind::StaticImport);
             }
@@ -246,7 +247,10 @@ fn astro_frontmatter(source: &str) -> String {
     let Some(after) = s.strip_prefix("---") else {
         return String::new();
     };
-    let Some(body) = after.strip_prefix("\r\n").or_else(|| after.strip_prefix('\n')) else {
+    let Some(body) = after
+        .strip_prefix("\r\n")
+        .or_else(|| after.strip_prefix('\n'))
+    else {
         return String::new();
     };
     match body.find("\n---") {
@@ -264,7 +268,7 @@ fn script_blocks(source: &str) -> String {
     let mut rest = source.as_str();
     while let Some(open) = rest.find("<script") {
         let after = &rest[open..];
-        let Some(gt) = after.find('>') else { break };
+        let Some(gt) = open_tag_end(after) else { break };
         let body_start = open + gt + 1;
         let Some(close) = rest[body_start..].find("</script>") else {
             break;
@@ -274,6 +278,28 @@ fn script_blocks(source: &str) -> String {
         rest = &rest[body_start + close + "</script>".len()..];
     }
     out
+}
+
+/// Index of the `>` that closes an open tag, skipping any `>` inside a quoted
+/// attribute value — Vue 3.3 `<script setup generic="T extends Record<string, X>">`
+/// carries one, and a naive `find('>')` would slice the body mid-attribute.
+fn open_tag_end(s: &str) -> Option<usize> {
+    let mut quote: Option<u8> = None;
+    for (i, &b) in s.as_bytes().iter().enumerate() {
+        match quote {
+            Some(q) => {
+                if b == q {
+                    quote = None;
+                }
+            }
+            None => match b {
+                b'"' | b'\'' => quote = Some(b),
+                b'>' => return Some(i),
+                _ => {}
+            },
+        }
+    }
+    None
 }
 
 /// Remove `<!-- … -->` comment spans (best-effort textual strip; a phantom scan
@@ -468,11 +494,33 @@ mod tests {
         // A commented-out <script> must not be parsed as real component code, or
         // its imports would false-flag a phantom and force a needless disk eject.
         let vue = "<template><div/></template>\n<!-- <script>import 'ghost';</script> -->\n<script setup lang=\"ts\">\nimport type { Foo } from \"real-backend\";\n</script>\n";
-        let names: Vec<_> = extract("Comp.vue", vue).into_iter().map(|o| o.spec).collect();
-        assert!(names.iter().any(|s| s == "real-backend"), "real <script> scanned");
+        let names: Vec<_> = extract("Comp.vue", vue)
+            .into_iter()
+            .map(|o| o.spec)
+            .collect();
+        assert!(
+            names.iter().any(|s| s == "real-backend"),
+            "real <script> scanned"
+        );
         assert!(
             !names.iter().any(|s| s == "ghost"),
             "commented <script> ignored: {names:?}"
+        );
+    }
+
+    #[test]
+    fn generic_script_setup_attribute_with_gt_is_sliced_correctly() {
+        // Vue 3.3 generics: the open tag carries a `>` inside the attribute
+        // value; the body must start after the real tag end or the parse is
+        // garbled and the block's imports are silently missed.
+        let vue = "<script setup lang=\"ts\" generic=\"T extends Record<string, unknown>\">\nimport type { Foo } from \"generic-backend\";\n</script>\n";
+        let names: Vec<_> = extract("Comp.vue", vue)
+            .into_iter()
+            .map(|o| o.spec)
+            .collect();
+        assert!(
+            names.iter().any(|s| s == "generic-backend"),
+            "generic <script setup> body scanned: {names:?}"
         );
     }
 

--- a/crates/nub-phantom-core/src/extract.rs
+++ b/crates/nub-phantom-core/src/extract.rs
@@ -58,8 +58,27 @@ pub struct Occurrence {
 /// static-imports-only fast-path ladder was built and benchmarked but regressed
 /// the parse-dominated scan, so it was removed.)
 pub fn extract(path: &str, source: &str) -> Vec<Occurrence> {
-    let allocator = Allocator::default();
+    // Framework single-file components (Astro/Vue/Svelte) keep their imports in a
+    // frontmatter / `<script>` block. A backend imported there for TYPES ONLY still
+    // breaks resolution under the global virtual store: the package's realpath
+    // escapes into the shared store, so a type-checker's upward `node_modules` walk
+    // can't reach the hoisted backend (nub#450). So for an SFC we parse only its
+    // script region, as TS, and DO keep type-only imports. Plain `.js`/`.ts` are
+    // unchanged — type-only imports stay dropped, so a devDep-typed package is
+    // never false-flagged as a runtime phantom.
+    if let Some(script) = sfc_script(path, source) {
+        let ts = SourceType::from_path("_.mts").unwrap_or_else(|_| SourceType::mjs());
+        return parse_and_visit(&script, ts, true);
+    }
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::mjs());
+    parse_and_visit(source, source_type, false)
+}
+
+/// Parse `source` as `source_type` and collect specifier occurrences.
+/// `capture_types` retains type-only import/re-export specifiers — set only for
+/// SFC script blocks; false on the runtime path preserves the type-only drop.
+fn parse_and_visit(source: &str, source_type: SourceType, capture_types: bool) -> Vec<Occurrence> {
+    let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source, source_type).parse();
     if ret.panicked {
         return Vec::new();
@@ -67,6 +86,7 @@ pub fn extract(path: &str, source: &str) -> Vec<Occurrence> {
     let mut v = SpecVisitor {
         guard_depth: 0,
         out: Vec::new(),
+        capture_types,
     };
     v.visit_program(&ret.program);
     v.out
@@ -78,6 +98,9 @@ struct SpecVisitor {
     /// guard → any load here is soft.
     guard_depth: u32,
     out: Vec<Occurrence>,
+    /// Retain type-only import/re-export specifiers. Set only for SFC script
+    /// blocks, where a type-position phantom still breaks GVS resolution (nub#450).
+    capture_types: bool,
 }
 
 impl SpecVisitor {
@@ -137,21 +160,24 @@ impl<'a> Visit<'a> for SpecVisitor {
             // an inline all-`type` named import is likewise erased. A bare
             // `import "x"` (side effect) and any value specifier are runtime.
             Statement::ImportDeclaration(decl)
-                if !decl.import_kind.is_type() && import_has_value(decl) =>
+                if self.capture_types || (!decl.import_kind.is_type() && import_has_value(decl)) =>
             {
                 self.record(&decl.source.value, RefKind::StaticImport);
             }
             // Runtime re-exports. `export { x } from 'y'` (value) and
-            // `export * from 'y'` load the module; `export type { … }` does not.
+            // `export * from 'y'` load the module; `export type { … }` does not
+            // (unless `capture_types`, for SFC script blocks).
             Statement::ExportNamedDeclaration(decl) => {
                 if let Some(src) = &decl.source
-                    && !decl.export_kind.is_type()
-                    && export_named_has_value(decl)
+                    && (self.capture_types
+                        || (!decl.export_kind.is_type() && export_named_has_value(decl)))
                 {
                     self.record(&src.value, RefKind::ReExport);
                 }
             }
-            Statement::ExportAllDeclaration(decl) if !decl.export_kind.is_type() => {
+            Statement::ExportAllDeclaration(decl)
+                if self.capture_types || !decl.export_kind.is_type() =>
+            {
                 self.record(&decl.source.value, RefKind::ReExport);
             }
             _ => {}
@@ -199,6 +225,72 @@ fn import_has_value(decl: &oxc_ast::ast::ImportDeclaration<'_>) -> bool {
 /// is inline-`type`.
 fn export_named_has_value(decl: &oxc_ast::ast::ExportNamedDeclaration<'_>) -> bool {
     decl.specifiers.is_empty() || decl.specifiers.iter().any(|s| !s.export_kind.is_type())
+}
+
+/// The analyzable script region of a single-file component, or `None` for a
+/// non-SFC path. `.astro` → the frontmatter between the leading `---` fence and
+/// its close; `.vue`/`.svelte` → the concatenated `<script>…</script>` bodies.
+fn sfc_script(path: &str, source: &str) -> Option<String> {
+    let file = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    match file.rsplit_once('.').map(|(_, e)| e) {
+        Some("astro") => Some(astro_frontmatter(source)),
+        Some("vue" | "svelte") => Some(script_blocks(source)),
+        _ => None,
+    }
+}
+
+/// Astro frontmatter: the region between a leading `---` fence (its own line) and
+/// the next line that begins `---`. Empty when the file has no frontmatter.
+fn astro_frontmatter(source: &str) -> String {
+    let s = source.trim_start_matches('\u{feff}');
+    let Some(after) = s.strip_prefix("---") else {
+        return String::new();
+    };
+    let Some(body) = after.strip_prefix("\r\n").or_else(|| after.strip_prefix('\n')) else {
+        return String::new();
+    };
+    match body.find("\n---") {
+        Some(end) => body[..end].to_string(),
+        None => body.to_string(),
+    }
+}
+
+/// Concatenate the bodies of every `<script …>…</script>` block (Vue/Svelte),
+/// ignoring blocks inside `<!-- … -->` comments so a commented-out `<script>` is
+/// never mistaken for real component code (a false phantom).
+fn script_blocks(source: &str) -> String {
+    let source = strip_html_comments(source);
+    let mut out = String::new();
+    let mut rest = source.as_str();
+    while let Some(open) = rest.find("<script") {
+        let after = &rest[open..];
+        let Some(gt) = after.find('>') else { break };
+        let body_start = open + gt + 1;
+        let Some(close) = rest[body_start..].find("</script>") else {
+            break;
+        };
+        out.push_str(&rest[body_start..body_start + close]);
+        out.push('\n');
+        rest = &rest[body_start + close + "</script>".len()..];
+    }
+    out
+}
+
+/// Remove `<!-- … -->` comment spans (best-effort textual strip; a phantom scan
+/// tolerates the rare `-->` inside a string literal). An unterminated comment
+/// drops the remainder — commented-out code never counts.
+fn strip_html_comments(source: &str) -> String {
+    let mut out = String::new();
+    let mut rest = source;
+    while let Some(start) = rest.find("<!--") {
+        out.push_str(&rest[..start]);
+        match rest[start + 4..].find("-->") {
+            Some(end) => rest = &rest[start + 4 + end + 3..],
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
 }
 
 /// If `call` is `require("lit")`, `require.resolve("lit")`, or the immediately-
@@ -341,6 +433,57 @@ mod tests {
             "all-inline-type erased"
         );
         assert!(names.contains(&"mixed-pkg"), "mixed import is runtime");
+    }
+
+    #[test]
+    fn astro_frontmatter_keeps_type_only_backend() {
+        // astro-icon's Icon.astro imports `astro/types` for TYPES ONLY; under the
+        // global virtual store that still breaks resolution (nub#450), so the SFC
+        // path parses the frontmatter and keeps the type import. The HTML template
+        // after the fence is not parsed.
+        let src = "---\nimport type { HTMLAttributes } from \"astro/types\";\nimport { getIconData } from \"@iconify/utils\";\n---\n<svg {...rest} />\n";
+        let names: Vec<_> = extract("components/Icon.astro", src)
+            .into_iter()
+            .map(|o| o.spec)
+            .collect();
+        assert!(
+            names.iter().any(|s| s == "astro/types"),
+            "type-only SFC import kept"
+        );
+        assert!(names.iter().any(|s| s == "@iconify/utils"));
+    }
+
+    #[test]
+    fn vue_svelte_script_block_scanned() {
+        let vue = "<template><div/></template>\n<script lang=\"ts\">\nimport type { Foo } from \"backend\";\n</script>\n";
+        let names: Vec<_> = extract("Comp.vue", vue)
+            .into_iter()
+            .map(|o| o.spec)
+            .collect();
+        assert!(names.iter().any(|s| s == "backend"), "vue <script> scanned");
+    }
+
+    #[test]
+    fn commented_out_script_block_is_ignored() {
+        // A commented-out <script> must not be parsed as real component code, or
+        // its imports would false-flag a phantom and force a needless disk eject.
+        let vue = "<template><div/></template>\n<!-- <script>import 'ghost';</script> -->\n<script setup lang=\"ts\">\nimport type { Foo } from \"real-backend\";\n</script>\n";
+        let names: Vec<_> = extract("Comp.vue", vue).into_iter().map(|o| o.spec).collect();
+        assert!(names.iter().any(|s| s == "real-backend"), "real <script> scanned");
+        assert!(
+            !names.iter().any(|s| s == "ghost"),
+            "commented <script> ignored: {names:?}"
+        );
+    }
+
+    #[test]
+    fn non_sfc_type_only_still_dropped() {
+        // The runtime path is unchanged: a type-only import in a .ts stays dropped.
+        let names: Vec<_> = extract("x.ts", "import type { T } from \"type-pkg\";\n")
+            .into_iter()
+            .map(|o| o.spec)
+            .collect();
+        assert!(names.is_empty(), "type-only import in .ts still dropped");
     }
 
     #[test]

--- a/crates/nub-phantom-core/src/extract.rs
+++ b/crates/nub-phantom-core/src/extract.rs
@@ -70,6 +70,17 @@ pub fn extract(path: &str, source: &str) -> Vec<Occurrence> {
         let ts = SourceType::from_path("_.mts").unwrap_or_else(|_| SourceType::mjs());
         return parse_and_visit(&script, ts, true);
     }
+    // A `.d.ts` (`.d.mts`/`.d.cts`) is a package's TYPE surface. Its imports are
+    // type-position by nature (`import * as React from 'react'`, `import type …`),
+    // yet under the global virtual store they still drive TS's resolution: the
+    // package's realpath escapes into the shared store, so a type import of a
+    // top-level-only backend (`@types/react`, `astro/types`) fails to resolve
+    // (nub#450). So a declaration file is parsed with type imports KEPT, exactly
+    // like an SFC script region. Plain `.js`/`.ts` still drop type-only imports.
+    if is_dts(path) {
+        let ts = SourceType::from_path("_.mts").unwrap_or_else(|_| SourceType::mjs());
+        return parse_and_visit(source, ts, true);
+    }
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::mjs());
     parse_and_visit(source, source_type, false)
 }
@@ -226,6 +237,13 @@ fn import_has_value(decl: &oxc_ast::ast::ImportDeclaration<'_>) -> bool {
 /// is inline-`type`.
 fn export_named_has_value(decl: &oxc_ast::ast::ExportNamedDeclaration<'_>) -> bool {
     decl.specifiers.is_empty() || decl.specifiers.iter().any(|s| !s.export_kind.is_type())
+}
+
+/// A TypeScript declaration file (`.d.ts`/`.d.mts`/`.d.cts`) — a package's type
+/// surface, parsed with type imports kept (see [`extract`]).
+fn is_dts(path: &str) -> bool {
+    let file = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    file.ends_with(".d.ts") || file.ends_with(".d.mts") || file.ends_with(".d.cts")
 }
 
 /// The analyzable script region of a single-file component, or `None` for a
@@ -532,6 +550,26 @@ mod tests {
             .map(|o| o.spec)
             .collect();
         assert!(names.is_empty(), "type-only import in .ts still dropped");
+    }
+
+    #[test]
+    fn dts_keeps_type_surface_imports() {
+        // A declaration file's imports are type-position but still drive TS
+        // resolution under GVS (nub#450): both the value-syntax `import * as React`
+        // and a `import type` are kept, and a relative type re-export.
+        let dts = "import * as React from 'react';\nimport type { FormApi } from '@tanstack/form-core';\nexport type { Foo } from './internal';\n";
+        for path in ["index.d.ts", "dist/index.d.mts", "types.d.cts"] {
+            let names: Vec<_> = extract(path, dts).into_iter().map(|o| o.spec).collect();
+            assert!(names.iter().any(|s| s == "react"), "{path}: react kept");
+            assert!(
+                names.iter().any(|s| s == "@tanstack/form-core"),
+                "{path}: type-only import kept"
+            );
+            assert!(
+                names.iter().any(|s| s == "./internal"),
+                "{path}: relative type re-export kept (walked for .d.ts graph)"
+            );
+        }
     }
 
     #[test]

--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -61,6 +61,9 @@ pub struct Finding {
     pub from_main: bool,
     /// Reachable from a non-`.` `exports` subpath (the adapter surface).
     pub from_subpath: bool,
+    /// Reachable from the `.d.ts` TYPE surface — a DECLARED PEER with this set is
+    /// the nub#450 peer-type class (its `@types/<peer>` must be project-local).
+    pub from_types: bool,
     /// Example raw specifiers (deduped) showing how it was referenced.
     pub specifiers: Vec<String>,
 }
@@ -84,6 +87,7 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
         all_soft: bool,
         from_main: bool,
         from_subpath: bool,
+        from_types: bool,
         specs: Vec<String>,
     }
     let mut by_pkg: BTreeMap<String, Agg> = BTreeMap::new();
@@ -92,11 +96,13 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
             all_soft: true,
             from_main: false,
             from_subpath: false,
+            from_types: false,
             specs: Vec::new(),
         });
         e.all_soft &= r.soft;
         e.from_main |= r.from_main;
         e.from_subpath |= r.from_subpath;
+        e.from_types |= r.from_types;
         if !e.specs.contains(&r.raw) {
             e.specs.push(r.raw.clone());
         }
@@ -112,6 +118,7 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
                 soft: agg.all_soft,
                 from_main: agg.from_main,
                 from_subpath: agg.from_subpath,
+                from_types: agg.from_types,
                 specifiers: agg.specs,
             }
         })
@@ -163,6 +170,7 @@ mod tests {
                 soft: *soft,
                 from_main: true,
                 from_subpath: false,
+                from_types: false,
             })
             .collect()
     }
@@ -220,6 +228,7 @@ mod tests {
             soft: false,
             from_main: false,
             from_subpath: true,
+            from_types: false,
         };
         let main_reached = Reference {
             package: "junk".into(),
@@ -227,6 +236,7 @@ mod tests {
             soft: false,
             from_main: true,
             from_subpath: false,
+            from_types: false,
         };
         let f = classify(&m, &[subpath_only, main_reached]);
         let zod = f.iter().find(|x| x.package == "zod").unwrap();

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -284,7 +284,7 @@ fn is_js_file(p: &Path) -> bool {
         return false;
     }
     let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    crate::manifest::is_js_like(name)
+    crate::manifest::is_js_like(name) || crate::manifest::is_sfc_like(name)
 }
 
 /// Lexically normalize `.`/`..` segments WITHOUT touching the filesystem (we do
@@ -336,7 +336,8 @@ impl IndexSource {
     /// True if `rel` is a JS-like file present in the index — the index analogue
     /// of `is_js_file` (name check + existence), which the fs ladder relies on.
     fn contains_js(&self, rel: &str) -> bool {
-        crate::manifest::is_js_like(rel) && self.files.contains_key(rel)
+        (crate::manifest::is_js_like(rel) || crate::manifest::is_sfc_like(rel))
+            && self.files.contains_key(rel)
     }
 
     /// Index analogue of [`fs_resolve`], step-for-step: exact → `base.<ext>` →
@@ -541,6 +542,44 @@ mod tests {
             .find(|r| r.package == "main-dep")
             .unwrap();
         assert!(main.from_main && !main.from_subpath, "main-graph dep");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn astro_sfc_subpath_reexport_reaches_type_only_backend() {
+        // Mirrors astro-icon: a `./components` subpath re-exports an `.astro` whose
+        // frontmatter type-imports an undeclared backend (`astro`). With SFC
+        // resolution + type capture the backend must surface as
+        // from_subpath && !from_main, so it classifies as a subpath adapter and
+        // gets project-local materialization under GVS (nub#450).
+        let root = scratch("astro-sfc");
+        fs::create_dir_all(root.join("components")).unwrap();
+        fs::write(
+            root.join("components/index.ts"),
+            r#"export { default as Icon } from "./Icon.astro";"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("components/Icon.astro"),
+            "---\nimport type { HTMLAttributes } from \"astro/types\";\n---\n<svg/>",
+        )
+        .unwrap();
+        let w = walk(
+            &root,
+            &[Entry {
+                path: "components/index.ts".to_string(),
+                kind: EntryKind::Subpath,
+            }],
+        );
+        let astro = w
+            .references
+            .iter()
+            .find(|r| r.package == "astro")
+            .expect("astro reached via .astro re-export");
+        assert!(
+            astro.from_subpath && !astro.from_main,
+            "subpath-only backend"
+        );
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -23,9 +23,14 @@ use nub_phantom_core::extract::{Occurrence, extract};
 use nub_phantom_core::specifier::{self, SpecKind};
 
 /// Provenance bit: reached from the main surface (`main`/`bin`/`exports."."`).
-const FROM_MAIN: u8 = 0b01;
+const FROM_MAIN: u8 = 0b001;
 /// Provenance bit: reached from a non-`.` `exports` subpath (the adapter surface).
-const FROM_SUBPATH: u8 = 0b10;
+const FROM_SUBPATH: u8 = 0b010;
+/// Provenance bit: reached from the `.d.ts` TYPE surface (`types`/`typings`/an
+/// `exports` `types` condition/`index.d.ts`). A type-position peer import carries
+/// this and NOT the runtime bits, so `@types/<peer>` reachability (nub#450) is
+/// separable from a runtime require of the same peer.
+const FROM_TYPES: u8 = 0b100;
 
 /// A bare-specifier reference collected from a reachable file.
 #[derive(Debug, Clone)]
@@ -43,6 +48,10 @@ pub struct Reference {
     /// `<pkg>/<subpath>`" adapter surface. A hard phantom reachable ONLY from a
     /// subpath (not main) is the subpath-adapter class.
     pub from_subpath: bool,
+    /// Reachable from the `.d.ts` TYPE surface. A DECLARED PEER reached only via
+    /// this surface is the nub#450 peer-type class: its `@types/<peer>` must be
+    /// project-local for the type-checker's realpath walk to reach it.
+    pub from_types: bool,
 }
 
 /// Result of the reachable-module walk.
@@ -96,6 +105,7 @@ fn walk_generic<S: FileSource>(source: &S, entry_points: &[Entry]) -> Walk {
             let bit = match ep.kind {
                 EntryKind::Main => FROM_MAIN,
                 EntryKind::Subpath => FROM_SUBPATH,
+                EntryKind::Types => FROM_TYPES,
             };
             if add_flags(&mut flags, &resolved, bit) {
                 queue.push_back(resolved);
@@ -147,6 +157,7 @@ fn walk_generic<S: FileSource>(source: &S, entry_points: &[Entry]) -> Walk {
                     soft: occ.soft,
                     from_main: fflags & FROM_MAIN != 0,
                     from_subpath: fflags & FROM_SUBPATH != 0,
+                    from_types: fflags & FROM_TYPES != 0,
                 });
             }
         }
@@ -188,8 +199,15 @@ fn add_flags<K: Ord + Clone>(flags: &mut BTreeMap<K, u8>, key: &K, bit: u8) -> b
 /// the cap is a hard robustness requirement, not a nicety.
 const MAX_RESOLVE_DEPTH: u32 = 16;
 
-/// Node-style resolution extensions, in priority order.
-const RESOLVE_EXTS: [&str; 8] = ["js", "cjs", "mjs", "jsx", "ts", "tsx", "mts", "cts"];
+/// Node-style resolution extensions, in priority order. The runtime JS
+/// extensions come first (so a `./foo` with both `foo.js` and `foo.d.ts` picks
+/// the JS); the `.d.ts` declaration extensions follow so a TYPE-surface walk (a
+/// `.d.ts` re-exporting `./internal`) resolves its `.d.ts` graph (nub#450). A
+/// declaration file carries only type imports, so admitting it on the runtime
+/// ladder is inert where a `.js` exists.
+const RESOLVE_EXTS: [&str; 11] = [
+    "js", "cjs", "mjs", "jsx", "ts", "tsx", "mts", "cts", "d.ts", "d.mts", "d.cts",
+];
 
 // --- Filesystem-backed source (extracted tree) ---------------------------------
 
@@ -284,7 +302,9 @@ fn is_js_file(p: &Path) -> bool {
         return false;
     }
     let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    crate::manifest::is_js_like(name) || crate::manifest::is_sfc_like(name)
+    crate::manifest::is_js_like(name)
+        || crate::manifest::is_sfc_like(name)
+        || crate::manifest::is_dts_like(name)
 }
 
 /// Lexically normalize `.`/`..` segments WITHOUT touching the filesystem (we do
@@ -336,7 +356,9 @@ impl IndexSource {
     /// True if `rel` is a JS-like file present in the index — the index analogue
     /// of `is_js_file` (name check + existence), which the fs ladder relies on.
     fn contains_js(&self, rel: &str) -> bool {
-        (crate::manifest::is_js_like(rel) || crate::manifest::is_sfc_like(rel))
+        (crate::manifest::is_js_like(rel)
+            || crate::manifest::is_sfc_like(rel)
+            || crate::manifest::is_dts_like(rel))
             && self.files.contains_key(rel)
     }
 

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -76,8 +76,12 @@ trait FileSource {
     /// A resolved, canonical file identifier within the package.
     type Key: Ord + Clone;
     /// Resolve a published entry path (package-root-relative) to a file.
-    fn resolve_entry(&self, entry_path: &str) -> Option<Self::Key>;
-    /// Resolve a relative specifier as written inside `from`.
+    /// `prefer_dts` selects the type surface (a `Types` entry) so a `.d.ts` root
+    /// resolves to its declaration graph instead of a colocated `.js`.
+    fn resolve_entry(&self, entry_path: &str, prefer_dts: bool) -> Option<Self::Key>;
+    /// Resolve a relative specifier as written inside `from`. The surface is taken
+    /// from `from`'s own kind — a `.d.ts` resolves its edges to `.d.ts`, a runtime
+    /// file to JS — so a type re-export never diverts to a runtime sibling.
     fn resolve_rel(&self, from: &Self::Key, spec: &str) -> Option<Self::Key>;
     /// Read a file's UTF-8 content (None on read/decode failure).
     fn read(&self, key: &Self::Key) -> Option<String>;
@@ -101,7 +105,8 @@ fn walk_generic<S: FileSource>(source: &S, entry_points: &[Entry]) -> Walk {
     let mut queue: VecDeque<S::Key> = VecDeque::new();
 
     for ep in entry_points {
-        if let Some(resolved) = source.resolve_entry(&ep.path) {
+        let prefer_dts = ep.kind == EntryKind::Types;
+        if let Some(resolved) = source.resolve_entry(&ep.path, prefer_dts) {
             let bit = match ep.kind {
                 EntryKind::Main => FROM_MAIN,
                 EntryKind::Subpath => FROM_SUBPATH,
@@ -199,15 +204,48 @@ fn add_flags<K: Ord + Clone>(flags: &mut BTreeMap<K, u8>, key: &K, bit: u8) -> b
 /// the cap is a hard robustness requirement, not a nicety.
 const MAX_RESOLVE_DEPTH: u32 = 16;
 
-/// Node-style resolution extensions, in priority order. The runtime JS
-/// extensions come first (so a `./foo` with both `foo.js` and `foo.d.ts` picks
-/// the JS); the `.d.ts` declaration extensions follow so a TYPE-surface walk (a
-/// `.d.ts` re-exporting `./internal`) resolves its `.d.ts` graph (nub#450). A
-/// declaration file carries only type imports, so admitting it on the runtime
-/// ladder is inert where a `.js` exists.
-const RESOLVE_EXTS: [&str; 11] = [
-    "js", "cjs", "mjs", "jsx", "ts", "tsx", "mts", "cts", "d.ts", "d.mts", "d.cts",
-];
+/// Node-style RUNTIME resolution extensions, in priority order — used when
+/// resolving from a runtime (`.js`/`.ts`/SFC) source or a Main/Subpath entry.
+const JS_EXTS: [&str; 8] = ["js", "cjs", "mjs", "jsx", "ts", "tsx", "mts", "cts"];
+
+/// TypeScript DECLARATION extensions — used when resolving from a `.d.ts` source
+/// or a `Types` entry. A type-surface edge is resolved to `.d.ts` ONLY and never
+/// diverts to a `.js` sibling: the standard compiled layout ships `widgets.js`
+/// beside `widgets.d.ts`, and resolving a type re-export to the `.js` would both
+/// capture that `.js`'s RUNTIME imports as type references (over-eject, nub#450)
+/// and skip the real `widgets.d.ts` (missed type imports).
+const DTS_EXTS: [&str; 3] = ["d.ts", "d.mts", "d.cts"];
+
+/// Extension ladder + file-acceptance predicate keyed to the resolution surface.
+/// The runtime surface admits JS/SFC files (byte-identical to the pre-type-surface
+/// behavior); the type surface admits `.d.ts` only.
+fn surface_exts(prefer_dts: bool) -> &'static [&'static str] {
+    if prefer_dts { &DTS_EXTS } else { &JS_EXTS }
+}
+
+fn resolvable_name(name: &str, prefer_dts: bool) -> bool {
+    if prefer_dts {
+        crate::manifest::is_dts_like(name)
+    } else {
+        crate::manifest::is_js_like(name) || crate::manifest::is_sfc_like(name)
+    }
+}
+
+/// On the type surface, TS resolves a `./widgets.js` re-export's TYPES at
+/// `./widgets.d.ts` (the NodeNext convention: the specifier keeps the runtime
+/// extension, the declaration sits beside it). Strip any runtime/declaration
+/// extension so the `.d.ts` ladder re-appends the declaration form. `./widgets` →
+/// `./widgets`; `./widgets.js` → `./widgets`; `./widgets.d.ts` → `./widgets`.
+fn dts_stem(spec: &str) -> &str {
+    for ext in [
+        ".d.ts", ".d.mts", ".d.cts", ".js", ".cjs", ".mjs", ".jsx", ".ts", ".tsx", ".mts", ".cts",
+    ] {
+        if let Some(stem) = spec.strip_suffix(ext) {
+            return stem;
+        }
+    }
+    spec
+}
 
 // --- Filesystem-backed source (extracted tree) ---------------------------------
 
@@ -218,13 +256,18 @@ struct FsSource<'a> {
 impl FileSource for FsSource<'_> {
     type Key = PathBuf;
 
-    fn resolve_entry(&self, entry_path: &str) -> Option<PathBuf> {
-        fs_resolve(self.root, self.root, entry_path, 0)
+    fn resolve_entry(&self, entry_path: &str, prefer_dts: bool) -> Option<PathBuf> {
+        fs_resolve(self.root, self.root, entry_path, prefer_dts, 0)
     }
 
     fn resolve_rel(&self, from: &PathBuf, spec: &str) -> Option<PathBuf> {
         let from_dir = from.parent().unwrap_or(self.root);
-        fs_resolve(self.root, from_dir, spec, 0)
+        // Surface follows the SOURCE file: a `.d.ts` resolves its edges to `.d.ts`.
+        let prefer_dts = from
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(crate::manifest::is_dts_like);
+        fs_resolve(self.root, from_dir, spec, prefer_dts, 0)
     }
 
     fn read(&self, key: &PathBuf) -> Option<String> {
@@ -239,10 +282,19 @@ impl FileSource for FsSource<'_> {
     }
 }
 
-fn fs_resolve(root: &Path, from_dir: &Path, spec: &str, depth: u32) -> Option<PathBuf> {
+fn fs_resolve(
+    root: &Path,
+    from_dir: &Path,
+    spec: &str,
+    prefer_dts: bool,
+    depth: u32,
+) -> Option<PathBuf> {
     if depth > MAX_RESOLVE_DEPTH {
         return None;
     }
+    // On the type surface, `./widgets.js` re-exports resolve types at
+    // `./widgets.d.ts`; strip the extension so the `.d.ts` ladder re-appends it.
+    let spec = if prefer_dts { dts_stem(spec) } else { spec };
     let joined = from_dir.join(spec);
     // Keep the walk inside the package tree (a `../../` that climbs out is not
     // part of the published surface).
@@ -250,42 +302,68 @@ fn fs_resolve(root: &Path, from_dir: &Path, spec: &str, depth: u32) -> Option<Pa
     if !base.starts_with(root) {
         return None;
     }
+    let exts = surface_exts(prefer_dts);
 
-    // 1. Exact file.
-    if is_js_file(&base) {
+    // 1. Exact file (runtime surface only — the type surface always stems + appends).
+    if !prefer_dts && is_resolvable_file(&base, prefer_dts) {
         return Some(base);
     }
     // 2. `base.<ext>`.
-    for ext in RESOLVE_EXTS {
+    for ext in exts {
         let cand = with_appended_ext(&base, ext);
-        if is_js_file(&cand) {
+        if is_resolvable_file(&cand, prefer_dts) {
             return Some(cand);
         }
     }
     // 3. `base/index.<ext>`.
-    for ext in RESOLVE_EXTS {
+    for ext in exts {
         let cand = base.join(format!("index.{ext}"));
-        if is_js_file(&cand) {
+        if is_resolvable_file(&cand, prefer_dts) {
             return Some(cand);
         }
     }
-    // 4. `base/package.json` → its `main` (depth-bounded; see MAX_RESOLVE_DEPTH).
+    // 4. `base/package.json` → its `types`/`main` (depth-bounded). The type surface
+    // chases `types`/`typings`; the runtime surface chases `main`.
     let pkg = base.join("package.json");
     if let Ok(raw) = fs::read(&pkg) {
         if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&raw)
-            && let Some(main) = v.get("main").and_then(|m| m.as_str())
+            && let Some(entry) = manifest_entry(&v, prefer_dts)
         {
-            return fs_resolve(root, &base, main, depth + 1);
+            return fs_resolve(root, &base, &entry, prefer_dts, depth + 1);
         }
-        // package.json with no main → default index.js in that dir.
-        for ext in RESOLVE_EXTS {
+        // package.json with no entry → default `index.<ext>` in that dir.
+        for ext in exts {
             let cand = base.join(format!("index.{ext}"));
-            if is_js_file(&cand) {
+            if is_resolvable_file(&cand, prefer_dts) {
                 return Some(cand);
             }
         }
     }
     None
+}
+
+/// The relevant entry field of a nested `package.json` for the current surface:
+/// `types`/`typings` for the type walk, `main` for runtime.
+fn manifest_entry(v: &serde_json::Value, prefer_dts: bool) -> Option<String> {
+    let fields: &[&str] = if prefer_dts {
+        &["types", "typings"]
+    } else {
+        &["main"]
+    };
+    fields
+        .iter()
+        .find_map(|f| v.get(*f).and_then(|m| m.as_str()))
+        .map(str::to_string)
+}
+
+/// Existence + surface-appropriate extension check (`.d.ts` on the type surface,
+/// JS/SFC on the runtime surface).
+fn is_resolvable_file(p: &Path, prefer_dts: bool) -> bool {
+    if !p.is_file() {
+        return false;
+    }
+    let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    resolvable_name(name, prefer_dts)
 }
 
 /// Append an extension to a path's file name (`a/b` + `js` → `a/b.js`), rather
@@ -295,16 +373,6 @@ fn with_appended_ext(base: &Path, ext: &str) -> PathBuf {
     s.push(".");
     s.push(ext);
     PathBuf::from(s)
-}
-
-fn is_js_file(p: &Path) -> bool {
-    if !p.is_file() {
-        return false;
-    }
-    let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    crate::manifest::is_js_like(name)
-        || crate::manifest::is_sfc_like(name)
-        || crate::manifest::is_dts_like(name)
 }
 
 /// Lexically normalize `.`/`..` segments WITHOUT touching the filesystem (we do
@@ -335,12 +403,14 @@ struct IndexSource {
 impl FileSource for IndexSource {
     type Key = String;
 
-    fn resolve_entry(&self, entry_path: &str) -> Option<String> {
-        self.resolve("", entry_path, 0)
+    fn resolve_entry(&self, entry_path: &str, prefer_dts: bool) -> Option<String> {
+        self.resolve("", entry_path, prefer_dts, 0)
     }
 
     fn resolve_rel(&self, from: &String, spec: &str) -> Option<String> {
-        self.resolve(parent_rel(from), spec, 0)
+        // Surface follows the SOURCE file (its rel-path basename).
+        let prefer_dts = crate::manifest::is_dts_like(from);
+        self.resolve(parent_rel(from), spec, prefer_dts, 0)
     }
 
     fn read(&self, key: &String) -> Option<String> {
@@ -353,37 +423,37 @@ impl FileSource for IndexSource {
 }
 
 impl IndexSource {
-    /// True if `rel` is a JS-like file present in the index — the index analogue
-    /// of `is_js_file` (name check + existence), which the fs ladder relies on.
-    fn contains_js(&self, rel: &str) -> bool {
-        (crate::manifest::is_js_like(rel)
-            || crate::manifest::is_sfc_like(rel)
-            || crate::manifest::is_dts_like(rel))
-            && self.files.contains_key(rel)
+    /// True if `rel` is present in the index AND matches the surface's extension
+    /// class (`.d.ts` on the type surface, JS/SFC on the runtime surface) — the
+    /// index analogue of [`is_resolvable_file`].
+    fn contains_surface(&self, rel: &str, prefer_dts: bool) -> bool {
+        resolvable_name(rel, prefer_dts) && self.files.contains_key(rel)
     }
 
-    /// Index analogue of [`fs_resolve`], step-for-step: exact → `base.<ext>` →
-    /// `base/index.<ext>` → `base/package.json` `main`. Resolution is over the
-    /// relpath key set; the `main` chase reads the package.json blob.
-    fn resolve(&self, from_dir: &str, spec: &str, depth: u32) -> Option<String> {
+    /// Index analogue of [`fs_resolve`], step-for-step, surface-aware: the type
+    /// walk stems + appends `.d.ts` and never diverts to a JS sibling; the runtime
+    /// walk is the pre-type-surface JS resolution.
+    fn resolve(&self, from_dir: &str, spec: &str, prefer_dts: bool, depth: u32) -> Option<String> {
         if depth > MAX_RESOLVE_DEPTH {
             return None;
         }
+        let spec = if prefer_dts { dts_stem(spec) } else { spec };
         // `None` == escaped the package root, mirroring fs `!starts_with(root)`.
         let base = normalize_rel_join(from_dir, spec)?;
+        let exts = surface_exts(prefer_dts);
 
-        if self.contains_js(&base) {
+        if !prefer_dts && self.contains_surface(&base, prefer_dts) {
             return Some(base);
         }
-        for ext in RESOLVE_EXTS {
+        for ext in exts {
             let cand = format!("{base}.{ext}");
-            if self.contains_js(&cand) {
+            if self.contains_surface(&cand, prefer_dts) {
                 return Some(cand);
             }
         }
-        for ext in RESOLVE_EXTS {
+        for ext in exts {
             let cand = join_rel(&base, &format!("index.{ext}"));
-            if self.contains_js(&cand) {
+            if self.contains_surface(&cand, prefer_dts) {
                 return Some(cand);
             }
         }
@@ -392,13 +462,13 @@ impl IndexSource {
             && let Ok(raw) = fs::read(blob)
         {
             if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&raw)
-                && let Some(main) = v.get("main").and_then(|m| m.as_str())
+                && let Some(entry) = manifest_entry(&v, prefer_dts)
             {
-                return self.resolve(&base, main, depth + 1);
+                return self.resolve(&base, &entry, prefer_dts, depth + 1);
             }
-            for ext in RESOLVE_EXTS {
+            for ext in exts {
                 let cand = join_rel(&base, &format!("index.{ext}"));
-                if self.contains_js(&cand) {
+                if self.contains_surface(&cand, prefer_dts) {
                     return Some(cand);
                 }
             }

--- a/crates/nub-phantom-scan/src/lib.rs
+++ b/crates/nub-phantom-scan/src/lib.rs
@@ -324,6 +324,61 @@ mod tests {
     }
 
     #[test]
+    fn type_walk_does_not_leak_runtime_imports_from_a_js_sibling() {
+        // Finding-1 regression: a `.d.ts` re-exports `./widgets`, and the standard
+        // compiled layout ships BOTH `widgets.js` and `widgets.d.ts`. The type walk
+        // must resolve `./widgets` to `widgets.d.ts` (NOT `widgets.js`), so
+        // `widgets.js`'s runtime `require('react')` is NOT captured as a type-peer
+        // (no spurious eject) and the real `widgets.d.ts` IS walked.
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static SEQ: AtomicU32 = AtomicU32::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "nub-phantom-dtsleak-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("package.json"),
+            r#"{"name":"ui-lib","main":"./index.js","peerDependencies":{"react":"*"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("index.js"),
+            "module.exports = require('./widgets');",
+        )
+        .unwrap();
+        fs::write(root.join("index.d.ts"), "export * from './widgets';\n").unwrap();
+        // widgets.js runtime-requires react; widgets.d.ts does NOT type-import it.
+        fs::write(
+            root.join("widgets.js"),
+            "const React = require('react');\nmodule.exports = {};",
+        )
+        .unwrap();
+        fs::write(
+            root.join("widgets.d.ts"),
+            "import type { Backend } from 'the-backend';\nexport declare const Widget: Backend;\n",
+        )
+        .unwrap();
+
+        let r = scan_extracted(&root).unwrap();
+        assert!(
+            !r.type_coupled_peers.contains(&"react".to_string()),
+            "react (runtime-only, in widgets.js) must NOT leak into type_coupled_peers: {:?}",
+            r.type_coupled_peers
+        );
+        // The real widgets.d.ts WAS walked: its undeclared type import surfaced.
+        assert!(
+            r.targets.iter().any(|t| t.name == "the-backend"),
+            "widgets.d.ts should be walked from the type surface: {:?}",
+            r.targets
+        );
+        assert_eq!(scan_index(&index_of(&root)).unwrap(), r);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn clean_package_has_no_phantom() {
         let root =
             std::env::temp_dir().join(format!("nub-phantom-scan-clean-{}", std::process::id()));

--- a/crates/nub-phantom-scan/src/lib.rs
+++ b/crates/nub-phantom-scan/src/lib.rs
@@ -53,6 +53,17 @@ pub struct ScanResult {
     /// false). Provenance-tagged for the later transitive/subtree reachability
     /// query; the per-package eject decision itself needs only the boolean.
     pub targets: Vec<PhantomTarget>,
+    /// DECLARED PEERS this package imports from its `.d.ts` TYPE surface — the
+    /// nub#450 peer-type class. Distinct from `targets` (undeclared phantoms): a
+    /// peer is DECLARED, so it is not a phantom, but under the global virtual store
+    /// its `@types/<peer>` (a separate top-level package) is unreachable from the
+    /// package's store realpath, so the type-checker loses the peer's types. The
+    /// CONSUMER ejects this package only when the project actually has a top-level
+    /// `@types/<peer>` (see `phantom_closure`), which both fixes it and bounds the
+    /// eject to the peer-typed set. `#[serde(default)]` so a pre-field sidecar
+    /// deserializes (the scanner-version bump re-scans it anyway).
+    #[serde(default)]
+    pub type_coupled_peers: Vec<String>,
     /// Reachable files parsed (diagnostic — lets the caller see scan breadth).
     pub files_analyzed: usize,
 }
@@ -98,9 +109,25 @@ fn reduce(manifest: &Manifest, walk: &graph::Walk) -> ScanResult {
             from_subpath: f.from_subpath,
         })
         .collect();
+    // Declared peers imported from the `.d.ts` type surface (nub#450). A peer is
+    // DECLARED (not a phantom → not in `targets`), but its `@types/<peer>` is a
+    // separate top-level package the store realpath can't reach; the consumer
+    // decides the eject against the real project graph.
+    let type_coupled_peers: Vec<String> = findings
+        .iter()
+        .filter(|f| {
+            f.from_types
+                && matches!(
+                    f.verdict,
+                    Verdict::DeclaredPeer | Verdict::DeclaredOptionalPeer
+                )
+        })
+        .map(|f| f.package.clone())
+        .collect();
     ScanResult {
         has_unguarded_phantom: !targets.is_empty(),
         targets,
+        type_coupled_peers,
         files_analyzed: walk.files_analyzed,
     }
 }
@@ -240,6 +267,59 @@ mod tests {
         // Provenance: backend-lib is subpath-only (the adapter class).
         let backend = r.targets.iter().find(|t| t.name == "backend-lib").unwrap();
         assert!(backend.from_subpath && !backend.from_main);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn dts_peer_type_surface_reports_type_coupled_peer() {
+        // react-pdf shape (nub#450): declares `react` a PEER, ships no `types`
+        // field, and its default `index.d.ts` imports react. The peer is DECLARED
+        // (not an undeclared phantom → no target, has_unguarded_phantom false), but
+        // it surfaces as a type-coupled peer so the consumer can eject on a
+        // top-level `@types/react`. A relative `.d.ts` re-export is followed.
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static SEQ: AtomicU32 = AtomicU32::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "nub-phantom-dts-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("package.json"),
+            r#"{"name":"@react-pdf/renderer","main":"./index.js","peerDependencies":{"react":"*"}}"#,
+        )
+        .unwrap();
+        fs::write(root.join("index.js"), "module.exports = {};").unwrap();
+        fs::write(
+            root.join("index.d.ts"),
+            "import * as React from 'react';\nexport type { Doc } from './types';\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("types.d.ts"),
+            "import type { ReactNode } from 'react';\nexport type Doc = ReactNode;\n",
+        )
+        .unwrap();
+
+        let r = scan_extracted(&root).unwrap();
+        assert!(
+            r.type_coupled_peers.contains(&"react".to_string()),
+            "declared peer imported from the .d.ts surface is a type-coupled peer: {:?}",
+            r.type_coupled_peers
+        );
+        assert!(
+            !r.has_unguarded_phantom,
+            "a declared peer is NOT an undeclared phantom"
+        );
+        assert!(
+            r.targets.is_empty(),
+            "no undeclared targets: {:?}",
+            r.targets
+        );
+        // Output-identical between the two scan entries (the hard invariant).
+        assert_eq!(scan_index(&index_of(&root)).unwrap(), r);
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/crates/nub-phantom-scan/src/manifest.rs
+++ b/crates/nub-phantom-scan/src/manifest.rs
@@ -40,6 +40,13 @@ pub enum EntryKind {
     /// A non-`.` `exports` subpath (`./zod`, `./vitest`) — the adapter surface a
     /// consumer opts into by importing `<pkg>/<subpath>`.
     Subpath,
+    /// A `.d.ts` TYPE surface (`types`/`typings` field, an `exports` `types`
+    /// condition, or the `index.d.ts` default) — the root of the declaration-file
+    /// graph. Reached references carry `from_types` so a type-position peer import
+    /// (`import * as React from 'react'` in a `.d.ts`) is separable from a runtime
+    /// one; this is what drives the nub#450 `@types/<peer>` reachability eject
+    /// without touching runtime-phantom detection.
+    Types,
 }
 
 /// A published entry file + its surface kind.
@@ -108,10 +115,12 @@ fn collect_bundled(v: &Value, out: &mut BTreeSet<String>) {
 }
 
 /// Gather the published entry files from `main`, `module`, `bin`, and `exports`,
-/// each tagged Main or Subpath. A recognized JS file is kept directly; an
-/// extensionless / directory-style target (`"./dist/index"`, `"./dist"`) is kept
-/// as a candidate and resolved Node-style by the graph walk; `types`/`.d.ts` and
-/// asset conditions carry no runtime imports and are filtered.
+/// each tagged Main or Subpath, PLUS the `.d.ts` TYPE surface (`types`/`typings`,
+/// `exports` `types` conditions, or the TS default roots) tagged Types. A
+/// recognized JS file is kept directly; an extensionless / directory-style target
+/// (`"./dist/index"`, `"./dist"`) is kept as a candidate and resolved Node-style
+/// by the graph walk; non-JS asset conditions (`.json`/`.node`/`.wasm`/`.css`)
+/// carry no analyzable imports and are filtered.
 fn collect_entry_points(v: &Value) -> Vec<Entry> {
     // Dedup on (kind, path) so a file exported at both `.` and a subpath seeds
     // both surfaces into the walk.
@@ -172,7 +181,73 @@ fn collect_entry_points(v: &Value) -> Vec<Entry> {
             kind: EntryKind::Main,
         });
     }
+
+    // TYPE-surface roots (`.d.ts`) — the explicit `types`/`typings` field and every
+    // `exports` `types` condition, else the TS default roots. Seeded as
+    // `EntryKind::Types` so reached references carry `from_types` (nub#450). Runtime
+    // entry collection above is untouched.
+    let mut type_targets: Vec<String> = Vec::new();
+    for field in ["types", "typings"] {
+        if let Some(s) = v.get(field).and_then(Value::as_str) {
+            type_targets.push(s.to_string());
+        }
+    }
+    if let Some(exports) = v.get("exports") {
+        collect_export_types(exports, &mut type_targets);
+    }
+    if type_targets.is_empty() {
+        // No explicit type surface → TS's defaults: each Main entry's colocated
+        // `.d.ts` (`x.js` → `x.d.ts`) plus the root `index.d.ts`. Only when no
+        // explicit `types` exists — an authoritative field must not be shadowed by
+        // a synthesized root that may not exist.
+        let colocated: Vec<String> = out
+            .iter()
+            .filter(|e| e.kind == EntryKind::Main)
+            .map(|e| swap_to_dts(&e.path))
+            .collect();
+        type_targets.extend(colocated);
+        type_targets.push("index.d.ts".to_string());
+    }
+    for p in &type_targets {
+        push(p, EntryKind::Types, &mut out, &mut seen);
+    }
+
     out
+}
+
+/// Recursively gather every `types`/`typings` condition target inside an
+/// `exports` subtree (the type surface of `.` and every subpath).
+fn collect_export_types(node: &Value, out: &mut Vec<String>) {
+    match node {
+        Value::Object(map) => {
+            for (k, child) in map {
+                if (k == "types" || k == "typings")
+                    && let Some(s) = child.as_str()
+                {
+                    out.push(s.to_string());
+                } else {
+                    collect_export_types(child, out);
+                }
+            }
+        }
+        Value::Array(arr) => {
+            for child in arr {
+                collect_export_types(child, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// `./dist/index.js` → `./dist/index.d.ts` (TS colocated-types default). A path
+/// with no recognized JS extension gets `.d.ts` appended.
+fn swap_to_dts(path: &str) -> String {
+    for ext in [".js", ".cjs", ".mjs", ".jsx", ".ts", ".tsx", ".mts", ".cts"] {
+        if let Some(stem) = path.strip_suffix(ext) {
+            return format!("{stem}.d.ts");
+        }
+    }
+    format!("{path}.d.ts")
 }
 
 /// Recursively collect every relative-path leaf of an `exports` subtree, carrying
@@ -222,7 +297,13 @@ fn normalize_rel(p: &str) -> String {
 /// costs a resolver probe. The `is_js_like`-only gate this replaced dropped
 /// extensionless mains outright → `files_analyzed: 0` → every phantom missed.
 fn is_entry_candidate(path: &str) -> bool {
-    is_js_like(path) || is_sfc_like(path) || extension(path).is_none()
+    is_js_like(path) || is_sfc_like(path) || is_dts_like(path) || extension(path).is_none()
+}
+
+/// A TypeScript declaration file (`.d.ts`/`.d.mts`/`.d.cts`) — the type surface a
+/// `Types` entry seeds and the file class the graph walk resolves for that entry.
+pub fn is_dts_like(path: &str) -> bool {
+    path.ends_with(".d.ts") || path.ends_with(".d.mts") || path.ends_with(".d.cts")
 }
 
 /// A JS-like runtime file (extension we can parse for imports). Excludes `.json`,
@@ -276,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    fn collects_entry_points_from_exports_and_filters_types() {
+    fn collects_entry_points_from_exports_including_type_surface() {
         let raw = br#"{
             "name": "pkg",
             "exports": {
@@ -299,7 +380,32 @@ mod tests {
             entry("dist/sub.js").unwrap().kind,
             super::EntryKind::Subpath
         );
-        assert!(!m.entry_points.iter().any(|e| e.path.contains(".d.ts")));
+        // The `types` condition IS collected — as a Types entry, the `.d.ts` type
+        // surface the peer-type walk seeds (nub#450). An explicit `types` suppresses
+        // the `index.d.ts` fallback, so no synthesized default appears.
+        assert_eq!(
+            entry("dist/index.d.ts").unwrap().kind,
+            super::EntryKind::Types
+        );
+        assert!(!m.entry_points.iter().any(|e| e.path == "index.d.ts"));
+    }
+
+    #[test]
+    fn synthesizes_default_type_roots_only_without_explicit_types() {
+        // No `types` field / `exports` types condition → TS's defaults: each Main
+        // entry's colocated `.d.ts` plus the root `index.d.ts`, all as Types
+        // entries (nub#450). react-pdf's shape (no types field, real index.d.ts).
+        let m = Manifest::parse(br#"{"name":"p","main":"./index.js"}"#).unwrap();
+        let types: Vec<&str> = m
+            .entry_points
+            .iter()
+            .filter(|e| e.kind == super::EntryKind::Types)
+            .map(|e| e.path.as_str())
+            .collect();
+        assert!(
+            types.contains(&"index.d.ts"),
+            "root index.d.ts default: {types:?}"
+        );
     }
 
     #[test]
@@ -346,19 +452,34 @@ mod tests {
             !has(&json, "data.json"),
             ".json main dropped (not analyzable)"
         );
-        // No entry survived → the entry-less fallback (`index.js`) seeds instead.
-        assert_eq!(json.entry_points.len(), 1);
-        assert_eq!(json.entry_points[0].path, "index.js");
+        // No RUNTIME entry survived → the entry-less fallback (`index.js`) seeds it.
+        // (A synthesized `index.d.ts` Types entry also appears — the type-surface
+        // default — so filter to the Main surface here.)
+        let mains: Vec<&str> = json
+            .entry_points
+            .iter()
+            .filter(|e| e.kind == super::EntryKind::Main)
+            .map(|e| e.path.as_str())
+            .collect();
+        assert_eq!(mains, vec!["index.js"]);
 
         let native = Manifest::parse(br#"{"name":"p","main":"./addon.node"}"#).unwrap();
         assert!(!has(&native, "addon.node"), ".node main dropped");
 
-        // Extensionless conditional target inside an `exports` map is admitted too.
+        // Extensionless conditional target inside an `exports` map is admitted too,
+        // and its `types` condition is collected as the Types surface.
         let exp = Manifest::parse(
             br#"{"name":"p","exports":{".":{"import":"./dist/index","types":"./dist/index.d.ts"}}}"#,
         )
         .unwrap();
         assert!(has(&exp, "dist/index"), "extensionless exports target kept");
-        assert!(!exp.entry_points.iter().any(|e| e.path.contains(".d.ts")));
+        assert_eq!(
+            exp.entry_points
+                .iter()
+                .find(|e| e.path == "dist/index.d.ts")
+                .unwrap()
+                .kind,
+            super::EntryKind::Types
+        );
     }
 }

--- a/crates/nub-phantom-scan/src/manifest.rs
+++ b/crates/nub-phantom-scan/src/manifest.rs
@@ -222,7 +222,7 @@ fn normalize_rel(p: &str) -> String {
 /// costs a resolver probe. The `is_js_like`-only gate this replaced dropped
 /// extensionless mains outright → `files_analyzed: 0` → every phantom missed.
 fn is_entry_candidate(path: &str) -> bool {
-    is_js_like(path) || extension(path).is_none()
+    is_js_like(path) || is_sfc_like(path) || extension(path).is_none()
 }
 
 /// A JS-like runtime file (extension we can parse for imports). Excludes `.json`,
@@ -235,6 +235,17 @@ pub fn is_js_like(path: &str) -> bool {
         extension(path),
         Some("js" | "cjs" | "mjs" | "jsx" | "ts" | "tsx" | "mts" | "cts")
     )
+}
+
+/// A single-file component (Astro/Vue/Svelte) whose imports live in a
+/// frontmatter / `<script>` block. Under the global virtual store a backend it
+/// imports there — even for TYPES ONLY — still needs project-local
+/// materialization: the package's realpath escapes into the shared store, so a
+/// type-checker's upward `node_modules` walk can't reach the hoisted backend
+/// otherwise (nub#450). The graph walk resolves these and `extract` reads their
+/// script region.
+pub fn is_sfc_like(path: &str) -> bool {
+    matches!(extension(path), Some("astro" | "vue" | "svelte"))
 }
 
 fn extension(path: &str) -> Option<&str> {
@@ -289,6 +300,27 @@ mod tests {
             super::EntryKind::Subpath
         );
         assert!(!m.entry_points.iter().any(|e| e.path.contains(".d.ts")));
+    }
+
+    #[test]
+    fn direct_sfc_export_is_collected_as_entry() {
+        // A package publishing an .astro/.vue/.svelte directly (not via a JS
+        // re-export) must still be scanned, or its type-only phantoms are missed
+        // under GVS (nub#450, codex review P1).
+        let raw = br#"{
+            "name": "pkg",
+            "exports": { "./Icon": "./components/Icon.astro", "./Widget": "./Widget.vue" }
+        }"#;
+        let m = Manifest::parse(raw).unwrap();
+        assert_eq!(
+            m.entry_points
+                .iter()
+                .find(|e| e.path == "components/Icon.astro")
+                .unwrap()
+                .kind,
+            super::EntryKind::Subpath
+        );
+        assert!(m.entry_points.iter().any(|e| e.path == "Widget.vue"));
     }
 
     #[test]

--- a/crates/nub-phantom-scan/src/manifest.rs
+++ b/crates/nub-phantom-scan/src/manifest.rs
@@ -197,13 +197,16 @@ fn collect_entry_points(v: &Value) -> Vec<Entry> {
     }
     if type_targets.is_empty() {
         // No explicit type surface → TS's defaults: each Main entry's colocated
-        // `.d.ts` (`x.js` → `x.d.ts`) plus the root `index.d.ts`. Only when no
-        // explicit `types` exists — an authoritative field must not be shadowed by
-        // a synthesized root that may not exist.
+        // declaration (`x.js` → `x.d.ts`, `./dist` → `./dist/index.d.ts`) plus the
+        // root `index.d.ts`. The Types-surface resolver stems the runtime extension
+        // and re-appends `.d.ts` (see `graph::dts_stem`), so the RAW main path is
+        // passed through and resolves to its declaration — no path rewrite here.
+        // Only synthesized when no explicit `types` exists; an authoritative field
+        // must not be shadowed by a default that may not exist.
         let colocated: Vec<String> = out
             .iter()
             .filter(|e| e.kind == EntryKind::Main)
-            .map(|e| swap_to_dts(&e.path))
+            .map(|e| e.path.clone())
             .collect();
         type_targets.extend(colocated);
         type_targets.push("index.d.ts".to_string());
@@ -237,17 +240,6 @@ fn collect_export_types(node: &Value, out: &mut Vec<String>) {
         }
         _ => {}
     }
-}
-
-/// `./dist/index.js` → `./dist/index.d.ts` (TS colocated-types default). A path
-/// with no recognized JS extension gets `.d.ts` appended.
-fn swap_to_dts(path: &str) -> String {
-    for ext in [".js", ".cjs", ".mjs", ".jsx", ".ts", ".tsx", ".mts", ".cts"] {
-        if let Some(stem) = path.strip_suffix(ext) {
-            return format!("{stem}.d.ts");
-        }
-    }
-    format!("{path}.d.ts")
 }
 
 /// Recursively collect every relative-path leaf of an `exports` subtree, carrying

--- a/crates/nub-phantom/Cargo.lock
+++ b/crates/nub-phantom/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "nub-phantom-core"
-version = "0.2.10"
+version = "0.4.11"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "nub-phantom-scan"
-version = "0.2.10"
+version = "0.4.11"
 dependencies = [
  "nub-phantom-core",
  "serde",


### PR DESCRIPTION
## Problem

Under nub's default isolated layout the virtual store is global, so a package's realpath lives outside the project. TypeScript resolves types by realpath and walks `node_modules` upward from there, so a package whose type surface imports something reachable only at the project top level loses those types — a class of `astro check` / `tsc` failures that don't reproduce under pnpm (its store is project-local) or under `node-linker=hoisted`. Three real manifestations from #450:

- **astro-icon** — `components/Icon.astro` does `import type { HTMLAttributes } from "astro/types"` and declares no `astro`, so `<Icon>` loses its HTML-attribute props.
- **@react-pdf/renderer** — its `.d.ts` does `import * as React from "react"`; `react` ships no types and the project's `@types/react` sits only at the top level, so `<Document>`/`<Page>`/… fail as JSX components (TS2786/TS2607).
- **@tanstack/react-form** and similar — the same `@types/react` escape collapses generic inference through the peer graph (TS7031/TS7006).

`disk_materialize` already fixes this class for runtime phantoms by ejecting the package project-local — its realpath returns in-project and the collective hidden tree resolves its imports. The detector just never saw the type surface: `.astro/.vue/.svelte` weren't parsed, `.d.ts` type entries were dropped, and type-only imports were erased.

## Fix

- **SFCs** — parse the `.astro` frontmatter and `.vue`/`.svelte` `<script>` region as TS, keeping type-only imports (an undeclared one flows through the existing phantom eject). Covers astro-icon.
- **`.d.ts` type surface** — seed a Types entry from `types`/`typings`, `exports` `types` conditions, and the `index.d.ts` default; walk the declaration graph keeping type imports; and record declared peers reached there as `type_coupled_peers`. The consumer ejects such a package only when the project has a top-level `@types/<peer>` — which makes the eject load-bearing and bounds it to the peer-typed set, so GVS stays on for everything else. Covers react-pdf and the TanStack peer-type case.
- Plain `.js`/`.ts` still drop type-only imports, so runtime-phantom detection is unchanged. `PHANTOM_SCANNER_VERSION` 3 → 4.

## Validation

- Unit — SFC and `.d.ts` extraction, type-entry collection (including the `index.d.ts` fallback), the peer-type eject gate (ejects with a top-level `@types/<peer>`, skips without), and the scoped `@types/scope__pkg` mangling.
- End-to-end, real `nub install` — react-pdf 5 → 0 `tsc` errors, TanStack 1 → 0, astro-icon realpath project-local. A plain non-React lib ejects nothing (GVS fully on); a 13-dependency all-React-UI app ejects only its peer-typed packages and stays under the bounded-subtree guard, the rest symlinked.

Fixes #450
