### PR TITLE
fix(import): run the peer pass in aube's own import; cover the bun parser

### DIFF
--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -816,7 +816,7 @@ fn import_to_pnpm_lock(force: bool) -> miette::Result<String> {
         }
     };
 
-    let (mut graph, kind) = match aube_lockfile::parse_for_import(&root, &manifest) {
+    let (graph, kind) = match aube_lockfile::parse_for_import(&root, &manifest) {
         Ok(pair) => pair,
         Err(aube_lockfile::Error::NotFound(_)) => {
             restore(&backup);
@@ -831,47 +831,18 @@ fn import_to_pnpm_lock(force: bool) -> miette::Result<String> {
         }
     };
 
-    // npm/bun lockfiles serialize a flat, pre-hoisted tree with no peer context.
-    // A pnpm-lock is expected to carry peer-context suffixes, and the install
-    // path deliberately skips its peer pass for pnpm incumbents on exactly that
-    // assumption (aube's `apply_lockfile_graph_platform_rules`). Writing a
-    // suffix-less pnpm-lock here violates that invariant: under the isolated
-    // store layout a peer-dependent package lands with no sibling peer link and
-    // dies at runtime with `Cannot find package` (#453). Re-establish the edges
-    // with the same pass the install path runs — `hoist_auto_installed_peers`
-    // then `apply_peer_contexts`, both pure offline graph transforms (no
-    // registry). `filter_graph` is intentionally omitted: an imported lockfile
-    // stays cross-platform, so no platform pruning. Yarn is excluded because
-    // real `yarn.lock` files don't record per-entry `peerDependencies`, so the
-    // pass would be a no-op without a packument fetch — a separate, deeper change.
-    //
-    // Uses pnpm's default peer options (import has no settings ctx here); those
-    // defaults match aube's own settings defaults, so a project without peer-knob
-    // overrides gets install-identical suffixes. A project that DOES override a
-    // knob (e.g. `dedupe-peers`) won't see it reflected in the import, but a later
-    // `nub install` reads this as a pnpm incumbent and skips its own peer pass, so
-    // the suffixes are consumed as-is — a fidelity gap, never a runtime break.
-    if matches!(
-        kind,
-        LockfileKind::Npm | LockfileKind::NpmShrinkwrap | LockfileKind::Bun
-    ) {
-        let (hoisted, auto_installed) = aube_resolver::hoist_auto_installed_peers(graph);
-        match aube_resolver::apply_peer_contexts(
-            hoisted,
-            &aube_resolver::PeerContextOptions::default(),
-        ) {
-            Ok(contextualized) => {
-                graph = contextualized;
-                aube_resolver::remove_auto_installed_peers(&mut graph, &auto_installed);
-            }
-            // Restore a moved-aside pnpm-lock like every other error path here;
-            // a bare `?` would orphan the user's original as `.import-backup`.
-            Err(e) => {
-                restore(&backup);
-                return Err(miette!("peer-context pass failed: {e}"));
-            }
+    // install skips its own peer pass for a pnpm incumbent, assuming a pnpm-lock
+    // is already peer-resolved — so a suffix-less source (npm / bun) has to be
+    // contextualized here or nothing downstream ever restores the edges (#453).
+    let graph = match aube_resolver::peer_pass_for_import(graph, kind) {
+        Ok(graph) => graph,
+        // Restore a moved-aside pnpm-lock like every other error path here;
+        // a bare `?` would orphan the user's original as `.import-backup`.
+        Err(e) => {
+            restore(&backup);
+            return Err(miette!("peer-context pass failed: {e}"));
         }
-    }
+    };
 
     match aube_lockfile::write_lockfile_as(&root, &graph, &manifest, LockfileKind::Pnpm) {
         Ok(_) => {

--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -651,15 +651,21 @@ fn import_writes_peer_suffixes_for_bun_lock_source() {
         lock.contains("ajv-keywords@3.5.2(ajv@6.12.6)"),
         "bun-sourced import must carry the peer-context suffix: {lock}"
     );
-    // Only the snapshots section carries the suffixed key (the packages
-    // section's resolution key stays bare), so the split yields two parts.
+    // Bound the check to ajv-keywords' OWN snapshot block: split on its
+    // suffixed key (unique to the snapshots section — the packages key stays
+    // bare), then cut at the blank line that separates snapshot entries. The
+    // whole-file remainder would let a peer edge that landed on the wrong
+    // snapshot still pass.
     let snapshot = lock
         .split("ajv-keywords@3.5.2(ajv@6.12.6):")
         .nth(1)
+        .unwrap_or("")
+        .split("\n\n")
+        .next()
         .unwrap_or("");
     assert!(
         snapshot.contains("ajv: 6.12.6"),
-        "resolved peer must be mirrored into dependencies: {snapshot}"
+        "resolved peer must be mirrored into ajv-keywords' snapshot deps: {snapshot}"
     );
 }
 

--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -129,6 +129,39 @@ const IS_POSITIVE_PACKAGE_LOCK: &str = r#"{
 /// `demo-plugin@1.0.0(demo-host@1.0.0)`; the #453 bug wrote a bare
 /// `demo-plugin@1.0.0`. `import` reads peer data straight from the lockfile —
 /// no registry — so synthetic package names exercise the pass fully offline.
+/// bun.lock counterpart of [`PEER_DEP_PACKAGE_LOCK`]: ajv@6.12.6 +
+/// ajv-keywords@3.5.2 (a real published peer pair, captured from `bun install`).
+/// Exercises the same import peer pass through the BUN parser, whose
+/// peer-dependency plumbing is separate from the npm one.
+const AJV_PEER_BUN_LOCK: &str = r#"{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "fixture",
+      "dependencies": {
+        "ajv": "6.12.6",
+        "ajv-keywords": "3.5.2",
+      },
+    },
+  },
+  "packages": {
+    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+  }
+}"#;
+
 const PEER_DEP_PACKAGE_LOCK: &str = r#"{
   "name": "fixture",
   "version": "1.0.0",
@@ -590,6 +623,43 @@ fn import_writes_peer_suffixes_for_suffixless_source() {
     assert!(
         lock.contains("demo-plugin@1.0.0(demo-host@1.0.0)"),
         "imported pnpm-lock must peer-suffix the plugin key (#453): {lock}"
+    );
+}
+
+/// Same guarantee through the BUN lockfile parser: a real published peer pair
+/// (ajv-keywords peers on ajv) must come out suffixed with the resolved peer
+/// mirrored into the snapshot's dependencies — the edge that gives the
+/// store-resident copy its sibling link under the isolated layout (#453).
+#[test]
+fn import_writes_peer_suffixes_for_bun_lock_source() {
+    let dir = pm_tmpdir("import-peer-bun");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"fixture","version":"1.0.0","dependencies":{"ajv":"6.12.6","ajv-keywords":"3.5.2"}}"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("bun.lock"), AJV_PEER_BUN_LOCK).unwrap();
+
+    let out = run_nub(&dir, &["import"]);
+    assert_eq!(
+        out.code, 0,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    let lock = std::fs::read_to_string(dir.join("pnpm-lock.yaml")).unwrap();
+    assert!(
+        lock.contains("ajv-keywords@3.5.2(ajv@6.12.6)"),
+        "bun-sourced import must carry the peer-context suffix: {lock}"
+    );
+    // Only the snapshots section carries the suffixed key (the packages
+    // section's resolution key stays bare), so the split yields two parts.
+    let snapshot = lock
+        .split("ajv-keywords@3.5.2(ajv@6.12.6):")
+        .nth(1)
+        .unwrap_or("");
+    assert!(
+        snapshot.contains("ajv: 6.12.6"),
+        "resolved peer must be mirrored into dependencies: {snapshot}"
     );
 }
 

--- a/vendor/aube/crates/aube-resolver/src/lib.rs
+++ b/vendor/aube/crates/aube-resolver/src/lib.rs
@@ -26,7 +26,7 @@ pub use local_source::resolve_exec_script_path;
 pub use package_ext::is_deprecation_allowed;
 pub use peer_context::{
     AutoInstalledPeers, PeerContextOptions, UnmetPeer, apply_peer_contexts, detect_unmet_peers,
-    hoist_auto_installed_peers, remove_auto_installed_peers,
+    hoist_auto_installed_peers, peer_pass_for_import, remove_auto_installed_peers,
 };
 pub use platform::{SupportedArchitectures, is_supported};
 pub use primer::{PruneStats as PrimerPruneStats, prune_cache as prune_primer_cache};

--- a/vendor/aube/crates/aube-resolver/src/peer_context.rs
+++ b/vendor/aube/crates/aube-resolver/src/peer_context.rs
@@ -26,7 +26,7 @@
 
 use crate::version_satisfies;
 use crate::{FxHashMap, FxHashSet};
-use aube_lockfile::{DepType, DirectDep, LockedPackage, LockfileGraph};
+use aube_lockfile::{DepType, DirectDep, LockedPackage, LockfileGraph, LockfileKind};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// A peer dependency whose declared range doesn't match the version the
@@ -456,6 +456,48 @@ pub fn apply_peer_contexts(
         current
     };
     Ok(result)
+}
+
+/// The peer pass every *import* path runs after parsing a foreign lockfile,
+/// before writing the converted one. A no-op for source formats that already
+/// carry peer context.
+///
+/// npm/bun lockfiles serialize a flat, pre-hoisted tree with no peer-context
+/// suffixes and no mirrored peer edges — while install deliberately SKIPS its
+/// own peer pass for pnpm/aube incumbents, on the assumption that such a
+/// lockfile is already peer-resolved. An import that writes a suffix-less
+/// target therefore breaks that invariant: under the isolated store layout a
+/// peer-dependent package lands with no sibling peer link and dies at runtime
+/// with `Cannot find package` (#453).
+///
+/// Deliberately narrower than install's equivalent sequence:
+///
+/// * [`platform::filter_graph`](crate::platform::filter_graph) is NOT run — an
+///   imported lockfile stays cross-platform, so no host pruning.
+/// * Yarn is excluded because real `yarn.lock` files record no per-entry
+///   `peerDependencies`; the pass would be a no-op without a packument fetch,
+///   which is a separate, deeper change.
+/// * [`PeerContextOptions::default()`] is used because import threads no
+///   settings context. Those defaults match aube's own settings defaults, so a
+///   project with no peer-knob overrides gets install-identical suffixes; one
+///   that DOES override a knob (e.g. `dedupe-peers`) won't see it reflected —
+///   a fidelity gap, never a runtime break, since a later install reads the
+///   written lockfile as an already-resolved incumbent and consumes the
+///   suffixes as-is.
+pub fn peer_pass_for_import(
+    graph: LockfileGraph,
+    kind: LockfileKind,
+) -> Result<LockfileGraph, crate::Error> {
+    if !matches!(
+        kind,
+        LockfileKind::Npm | LockfileKind::NpmShrinkwrap | LockfileKind::Bun
+    ) {
+        return Ok(graph);
+    }
+    let (hoisted, auto_installed) = hoist_auto_installed_peers(graph);
+    let mut graph = apply_peer_contexts(hoisted, &PeerContextOptions::default())?;
+    remove_auto_installed_peers(&mut graph, &auto_installed);
+    Ok(graph)
 }
 
 /// Cross-subtree peer-variant dedupe. When `dedupe-peer-dependents` is

--- a/vendor/aube/crates/aube/src/commands/import.rs
+++ b/vendor/aube/crates/aube/src/commands/import.rs
@@ -52,7 +52,7 @@ pub async fn run(args: ImportArgs) -> miette::Result<()> {
         ));
     }
 
-    let (mut graph, kind) = match aube_lockfile::parse_for_import(&cwd, &manifest) {
+    let (graph, kind) = match aube_lockfile::parse_for_import(&cwd, &manifest) {
         Ok(pair) => pair,
         Err(aube_lockfile::Error::NotFound(_)) => {
             return Err(miette!(
@@ -65,29 +65,11 @@ pub async fn run(args: ImportArgs) -> miette::Result<()> {
         }
     };
 
-    // A suffix-less source (npm / bun) carries no peer-context suffixes and no
-    // mirrored peer edges, but install treats aube-lock.yaml as an already
-    // peer-resolved incumbent and skips its peer pass — writing the parsed graph
-    // verbatim would leave store-resident packages with no sibling peer links at
-    // runtime (#453). Same pass, gating, and rationale as the pnpm-lock import
-    // path in nub's install_family (#471): hoist → apply with pnpm-default peer
-    // options → strip the hoist scaffolding; `filter_graph` intentionally
-    // omitted so the imported lockfile stays cross-platform; yarn excluded
-    // because yarn.lock records no per-entry `peerDependencies`.
-    if matches!(
-        kind,
-        aube_lockfile::LockfileKind::Npm
-            | aube_lockfile::LockfileKind::NpmShrinkwrap
-            | aube_lockfile::LockfileKind::Bun
-    ) {
-        let (hoisted, auto_installed) = aube_resolver::hoist_auto_installed_peers(graph);
-        graph = aube_resolver::apply_peer_contexts(
-            hoisted,
-            &aube_resolver::PeerContextOptions::default(),
-        )
+    // install treats aube-lock.yaml as an already peer-resolved incumbent, so a
+    // suffix-less source (npm / bun) has to be contextualized here or the
+    // written lockfile is missing peer edges nothing downstream restores (#453).
+    let graph = aube_resolver::peer_pass_for_import(graph, kind)
         .map_err(|e| miette!("peer-context pass failed: {e}"))?;
-        aube_resolver::remove_auto_installed_peers(&mut graph, &auto_installed);
-    }
 
     let pkg_count = graph.packages.len();
     aube_lockfile::write_lockfile(&cwd, &graph, &manifest)

--- a/vendor/aube/crates/aube/src/commands/import.rs
+++ b/vendor/aube/crates/aube/src/commands/import.rs
@@ -52,7 +52,7 @@ pub async fn run(args: ImportArgs) -> miette::Result<()> {
         ));
     }
 
-    let (graph, kind) = match aube_lockfile::parse_for_import(&cwd, &manifest) {
+    let (mut graph, kind) = match aube_lockfile::parse_for_import(&cwd, &manifest) {
         Ok(pair) => pair,
         Err(aube_lockfile::Error::NotFound(_)) => {
             return Err(miette!(
@@ -64,6 +64,30 @@ pub async fn run(args: ImportArgs) -> miette::Result<()> {
             return Err(miette::Report::new(e)).wrap_err("failed to parse source lockfile");
         }
     };
+
+    // A suffix-less source (npm / bun) carries no peer-context suffixes and no
+    // mirrored peer edges, but install treats aube-lock.yaml as an already
+    // peer-resolved incumbent and skips its peer pass — writing the parsed graph
+    // verbatim would leave store-resident packages with no sibling peer links at
+    // runtime (#453). Same pass, gating, and rationale as the pnpm-lock import
+    // path in nub's install_family (#471): hoist → apply with pnpm-default peer
+    // options → strip the hoist scaffolding; `filter_graph` intentionally
+    // omitted so the imported lockfile stays cross-platform; yarn excluded
+    // because yarn.lock records no per-entry `peerDependencies`.
+    if matches!(
+        kind,
+        aube_lockfile::LockfileKind::Npm
+            | aube_lockfile::LockfileKind::NpmShrinkwrap
+            | aube_lockfile::LockfileKind::Bun
+    ) {
+        let (hoisted, auto_installed) = aube_resolver::hoist_auto_installed_peers(graph);
+        graph = aube_resolver::apply_peer_contexts(
+            hoisted,
+            &aube_resolver::PeerContextOptions::default(),
+        )
+        .map_err(|e| miette!("peer-context pass failed: {e}"))?;
+        aube_resolver::remove_auto_installed_peers(&mut graph, &auto_installed);
+    }
 
     let pkg_count = graph.packages.len();
     aube_lockfile::write_lockfile(&cwd, &graph, &manifest)


### PR DESCRIPTION
Rebased after #471 landed the nub-cli half of this independently — this PR is now the complementary delta it left open:

1. **`aube import` (→ aube-lock.yaml) still wrote suffix-less lockfiles** from npm/bun sources. Same #453 failure class: install treats aube-lock.yaml as an already peer-resolved incumbent and skips its peer pass, so store-resident packages get no sibling peer links at runtime. This mirrors #471's exact pass, gating (`Npm | NpmShrinkwrap | Bun`), and rationale (no `filter_graph`, yarn excluded) at that call site.
2. **bun-parser regression test**: #471's test exercises the npm lockfile parser only; bun's peer-dependency plumbing is a separate parse path. Added `import_writes_peer_suffixes_for_bun_lock_source` with a real published peer pair (ajv-keywords → ajv, pinned integrities, offline), asserting both the suffixed snapshot key and the mirrored peer edge.

All three import tests green (`import_converts_package_lock_to_pnpm_lock`, #471's `import_writes_peer_suffixes_for_suffixless_source`, and the new bun one).

Fixes #453