### PR TITLE
install: verify release archive checksums

### DIFF
--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -6,7 +6,7 @@ name: Verify install scripts
 # no publish step required. Complements the release's `Test install` jobs, which
 # only exercise `npm install -g` and never touch the curl/irm script path.
 #
-# Three guarantees enforced here beyond a basic smoke:
+# Four guarantees enforced here beyond a basic smoke:
 #   1. drift-guard: site/public/install.{sh,ps1} must be byte-for-byte identical to
 #      root install.{sh,ps1} (catches stale site-served copies before they reach users).
 #   2. nubx: every job asserts nubx exists AND runs after install (argv[0] dispatch is
@@ -14,6 +14,8 @@ name: Verify install scripts
 #   3. macOS 403 fix: curl uses a token-auth header on raw.githubusercontent.com so the
 #      CI runner never hits the unauthenticated rate-limit that caused intermittent 403s
 #      on macos-14.
+#   4. checksum ordering: local fixtures prove malformed or mismatched sidecars fail
+#      before the existing install is removed or the archive is extracted.
 
 on:
   workflow_dispatch:
@@ -32,6 +34,8 @@ on:
       - install.ps1
       - site/public/install.sh
       - site/public/install.ps1
+      - tests/installer/checksums.sh
+      - tests/installer/checksums.ps1
       - .github/workflows/verify-install.yml
 
 concurrency:
@@ -73,6 +77,10 @@ jobs:
         os: [windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: Verify checksum handling against local fixtures
+        shell: pwsh
+        run: pwsh -NoProfile -File tests/installer/checksums.ps1
       - name: Install via install.ps1 (the real `irm | iex` path)
         shell: pwsh
         env:
@@ -220,6 +228,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: Verify checksum handling against local fixtures
+        shell: bash
+        run: bash tests/installer/checksums.sh
       - name: Run tests/installer/run.sh
         shell: bash
         env:

--- a/install.ps1
+++ b/install.ps1
@@ -46,16 +46,35 @@ $Exe = "$BinDir\nub.exe"
 # node_modules + native addon) and JIT-extracts it to the user cache on first run.
 # The archive ships bin\ plus a vestigial empty runtime\ (kept only to satisfy the
 # sidecar-era `nub upgrade`; the binary ignores it — see release.yml).
-$Url = "https://github.com/nubjs/nub/releases/download/v$Version/nub-$Target.zip"
+$ArchiveName = "nub-$Target.zip"
+$Url = "https://github.com/nubjs/nub/releases/download/v$Version/$ArchiveName"
+$ChecksumUrl = "$Url.sha256"
 Write-Host "Downloading from $Url..."
 
 $TmpZip = Join-Path $env:TEMP "nub-$Target-$PID.zip"
+$TmpChecksum = Join-Path $env:TEMP "nub-$Target-$PID.zip.sha256"
 # Suppress the per-chunk progress bar — it re-renders on every received byte
 # and dominates the total download time in PowerShell.
 $prevProgressPreference = $ProgressPreference
 try {
     $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
+    Invoke-WebRequest -Uri $ChecksumUrl -OutFile $TmpChecksum -UseBasicParsing
+
+    # The sidecar detects corrupt, truncated, stale-cache, or mismatched assets. It
+    # is not an independent authenticity check because both files share an origin.
+    $ChecksumBytes = [System.IO.File]::ReadAllBytes($TmpChecksum)
+    $ChecksumText = [System.Text.Encoding]::ASCII.GetString($ChecksumBytes)
+    $ChecksumPattern = "\A(?<Digest>[0-9A-Fa-f]{64})  $([regex]::Escape($ArchiveName))`n\z"
+    if ($ChecksumText -cnotmatch $ChecksumPattern) {
+        throw "Malformed checksum from: $ChecksumUrl"
+    }
+    $ExpectedSha256 = $Matches["Digest"]
+    $ActualSha256 = (Get-FileHash -LiteralPath $TmpZip -Algorithm SHA256).Hash
+    if (-not [string]::Equals($ActualSha256, $ExpectedSha256, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Checksum mismatch for $Url (expected $ExpectedSha256, got $ActualSha256). Refusing to install a corrupt or mismatched archive."
+    }
+
     # Replace any prior nub artifacts for a clean upgrade. In the default ~\.nub —
     # which nub owns outright — drop the whole bin\ and a stale runtime\ from a
     # pre-single-binary install. A user-supplied NUB_INSTALL_DIR may hold unrelated
@@ -68,11 +87,12 @@ try {
     }
     Expand-Archive -Path $TmpZip -DestinationPath $InstallDir -Force
 } catch {
-    Write-Error "Failed to download/extract nub: $_"
+    Write-Error "Failed to download/verify/extract nub: $_"
     exit 1
 } finally {
     $ProgressPreference = $prevProgressPreference
     if (Test-Path $TmpZip) { Remove-Item -Force $TmpZip }
+    if (Test-Path $TmpChecksum) { Remove-Item -Force $TmpChecksum }
 }
 
 if (-not (Test-Path $Exe)) {

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,50 @@ error() { echo -e "${Red}error${Color_Off}: $*" >&2; exit 1; }
 info() { echo -e "${Dim}$*${Color_Off}"; }
 success() { echo -e "${Green}$*${Color_Off}"; }
 
+parse_sha256_sidecar() {
+    local sidecar=$1
+    local archive_name=$2
+    local expected_size actual_size
+
+    expected_size=$((67 + ${#archive_name}))
+    actual_size=$(wc -c < "$sidecar" | tr -d '[:space:]') || return 1
+    [[ "$actual_size" == "$expected_size" ]] || return 1
+
+    LC_ALL=C awk -v name="$archive_name" '
+        NR != 1 { exit 1 }
+        {
+            digest = substr($0, 1, 64)
+            if (length(digest) != 64 || digest ~ /[^0-9A-Fa-f]/ ||
+                substr($0, 65, 2) != "  " || substr($0, 67) != name) {
+                exit 1
+            }
+            print tolower(digest)
+        }
+        END { if (NR != 1) exit 1 }
+    ' "$sidecar"
+}
+
+sha256_file() {
+    local file=$1
+    local output digest
+
+    if command -v sha256sum >/dev/null 2>&1 && output=$(sha256sum "$file" 2>/dev/null); then
+        digest=$(printf '%s\n' "$output" | LC_ALL=C awk 'NR == 1 && length($1) == 64 && $1 !~ /[^0-9A-Fa-f]/ { print tolower($1); exit }')
+        if [[ -n "$digest" ]]; then
+            printf '%s\n' "$digest"
+            return 0
+        fi
+    fi
+    if command -v shasum >/dev/null 2>&1 && output=$(shasum -a 256 "$file" 2>/dev/null); then
+        digest=$(printf '%s\n' "$output" | LC_ALL=C awk 'NR == 1 && length($1) == 64 && $1 !~ /[^0-9A-Fa-f]/ { print tolower($1); exit }')
+        if [[ -n "$digest" ]]; then
+            printf '%s\n' "$digest"
+            return 0
+        fi
+    fi
+    return 1
+}
+
 # --- Platform detection ---
 
 platform=$(uname -ms)
@@ -101,13 +145,30 @@ mkdir -p "$bin_dir" || error "Failed to create install directory: $bin_dir"
 # The archive ships bin/ plus a vestigial empty runtime/ (kept only to satisfy the
 # sidecar-era `nub upgrade`; the binary ignores ~/.nub/runtime — see release.yml).
 # (Windows is handled by install.ps1 above, so $target is always darwin/linux.)
-url="https://github.com/nubjs/nub/releases/download/v${version}/nub-${target}.tar.gz"
+archive_name="nub-${target}.tar.gz"
+url="https://github.com/nubjs/nub/releases/download/v${version}/${archive_name}"
+checksum_url="${url}.sha256"
 
 tmp_archive=$(mktemp) || error "Failed to create temp file"
-trap 'rm -f "$tmp_archive"' EXIT
+tmp_checksum=$(mktemp) || { rm -f "$tmp_archive"; error "Failed to create temp file"; }
+trap 'rm -f "$tmp_archive" "$tmp_checksum"' EXIT
 
 curl --fail --location --progress-bar --output "$tmp_archive" "$url" ||
     error "Failed to download nub from: $url"
+curl --fail --location --progress-bar --output "$tmp_checksum" "$checksum_url" ||
+    error "Failed to download checksum from: $checksum_url"
+
+# The sidecar detects corrupt, truncated, stale-cache, or mismatched assets. It
+# is not an independent authenticity check because both files share an origin.
+if ! expected_sha256=$(parse_sha256_sidecar "$tmp_checksum" "$archive_name"); then
+    error "Malformed checksum from: $checksum_url"
+fi
+if ! actual_sha256=$(sha256_file "$tmp_archive"); then
+    error "No usable SHA-256 tool found (install sha256sum or shasum)"
+fi
+if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+    error "Checksum mismatch for $url (expected $expected_sha256, got $actual_sha256). Refusing to install a corrupt or mismatched archive."
+fi
 
 # Replace any prior nub artifacts for a clean upgrade. In the default ~/.nub —
 # which nub owns outright — drop the whole bin/ and a stale runtime/ from a

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -372,7 +372,7 @@ Same as installing — match how you installed: `brew update && brew upgrade nub
 
 ## Is there a curl install script?
 
-Yes. On macOS and Linux, `curl -fsSL https://nubjs.com/install.sh | bash`; on Windows, `powershell -c "irm https://nubjs.com/install.ps1 | iex"`. Both drop a native binary into `~/.nub` and put it on your `PATH`. If you'd rather go through your package manager, `npm install -g --ignore-scripts=false @nubjs/nub` (or `pnpm add -g` / `yarn global add`) does the same thing, and on macOS and Linux `brew install nubjs/tap/nub` works too.
+Yes. On macOS and Linux, `curl -fsSL https://nubjs.com/install.sh | bash`; on Windows, `powershell -c "irm https://nubjs.com/install.ps1 | iex"`. Both drop a native binary into `~/.nub` and put it on your `PATH`. The scripts verify the release archive against its SHA-256 sidecar before replacing an existing installation. This detects corrupt, truncated, stale-cache, or mismatched assets; it is not an independent authenticity guarantee because the archive and checksum share the same release origin. If you'd rather go through your package manager, `npm install -g --ignore-scripts=false @nubjs/nub` (or `pnpm add -g` / `yarn global add`) does the same thing, and on macOS and Linux `brew install nubjs/tap/nub` works too.
 
 Two environment variables customize the script, following the same convention as rustup and uv:
 
@@ -402,4 +402,3 @@ No. The bundlers your project already uses (Vite / Rollup / Rolldown / esbuild /
 ## What's the hot-reload story?
 
 Watch mode restarts the process when files change — the watch set is the resolved dependency graph plus your `.env*` files and `tsconfig.json`, so it Just Works for TypeScript projects with no glob hygiene. It does not preserve in-memory state or hot-swap modules in place; a restart is a restart. See [Watch mode](/docs/watch).
-

--- a/site/public/install.ps1
+++ b/site/public/install.ps1
@@ -46,16 +46,35 @@ $Exe = "$BinDir\nub.exe"
 # node_modules + native addon) and JIT-extracts it to the user cache on first run.
 # The archive ships bin\ plus a vestigial empty runtime\ (kept only to satisfy the
 # sidecar-era `nub upgrade`; the binary ignores it — see release.yml).
-$Url = "https://github.com/nubjs/nub/releases/download/v$Version/nub-$Target.zip"
+$ArchiveName = "nub-$Target.zip"
+$Url = "https://github.com/nubjs/nub/releases/download/v$Version/$ArchiveName"
+$ChecksumUrl = "$Url.sha256"
 Write-Host "Downloading from $Url..."
 
 $TmpZip = Join-Path $env:TEMP "nub-$Target-$PID.zip"
+$TmpChecksum = Join-Path $env:TEMP "nub-$Target-$PID.zip.sha256"
 # Suppress the per-chunk progress bar — it re-renders on every received byte
 # and dominates the total download time in PowerShell.
 $prevProgressPreference = $ProgressPreference
 try {
     $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
+    Invoke-WebRequest -Uri $ChecksumUrl -OutFile $TmpChecksum -UseBasicParsing
+
+    # The sidecar detects corrupt, truncated, stale-cache, or mismatched assets. It
+    # is not an independent authenticity check because both files share an origin.
+    $ChecksumBytes = [System.IO.File]::ReadAllBytes($TmpChecksum)
+    $ChecksumText = [System.Text.Encoding]::ASCII.GetString($ChecksumBytes)
+    $ChecksumPattern = "\A(?<Digest>[0-9A-Fa-f]{64})  $([regex]::Escape($ArchiveName))`n\z"
+    if ($ChecksumText -cnotmatch $ChecksumPattern) {
+        throw "Malformed checksum from: $ChecksumUrl"
+    }
+    $ExpectedSha256 = $Matches["Digest"]
+    $ActualSha256 = (Get-FileHash -LiteralPath $TmpZip -Algorithm SHA256).Hash
+    if (-not [string]::Equals($ActualSha256, $ExpectedSha256, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Checksum mismatch for $Url (expected $ExpectedSha256, got $ActualSha256). Refusing to install a corrupt or mismatched archive."
+    }
+
     # Replace any prior nub artifacts for a clean upgrade. In the default ~\.nub —
     # which nub owns outright — drop the whole bin\ and a stale runtime\ from a
     # pre-single-binary install. A user-supplied NUB_INSTALL_DIR may hold unrelated
@@ -68,11 +87,12 @@ try {
     }
     Expand-Archive -Path $TmpZip -DestinationPath $InstallDir -Force
 } catch {
-    Write-Error "Failed to download/extract nub: $_"
+    Write-Error "Failed to download/verify/extract nub: $_"
     exit 1
 } finally {
     $ProgressPreference = $prevProgressPreference
     if (Test-Path $TmpZip) { Remove-Item -Force $TmpZip }
+    if (Test-Path $TmpChecksum) { Remove-Item -Force $TmpChecksum }
 }
 
 if (-not (Test-Path $Exe)) {

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -32,6 +32,50 @@ error() { echo -e "${Red}error${Color_Off}: $*" >&2; exit 1; }
 info() { echo -e "${Dim}$*${Color_Off}"; }
 success() { echo -e "${Green}$*${Color_Off}"; }
 
+parse_sha256_sidecar() {
+    local sidecar=$1
+    local archive_name=$2
+    local expected_size actual_size
+
+    expected_size=$((67 + ${#archive_name}))
+    actual_size=$(wc -c < "$sidecar" | tr -d '[:space:]') || return 1
+    [[ "$actual_size" == "$expected_size" ]] || return 1
+
+    LC_ALL=C awk -v name="$archive_name" '
+        NR != 1 { exit 1 }
+        {
+            digest = substr($0, 1, 64)
+            if (length(digest) != 64 || digest ~ /[^0-9A-Fa-f]/ ||
+                substr($0, 65, 2) != "  " || substr($0, 67) != name) {
+                exit 1
+            }
+            print tolower(digest)
+        }
+        END { if (NR != 1) exit 1 }
+    ' "$sidecar"
+}
+
+sha256_file() {
+    local file=$1
+    local output digest
+
+    if command -v sha256sum >/dev/null 2>&1 && output=$(sha256sum "$file" 2>/dev/null); then
+        digest=$(printf '%s\n' "$output" | LC_ALL=C awk 'NR == 1 && length($1) == 64 && $1 !~ /[^0-9A-Fa-f]/ { print tolower($1); exit }')
+        if [[ -n "$digest" ]]; then
+            printf '%s\n' "$digest"
+            return 0
+        fi
+    fi
+    if command -v shasum >/dev/null 2>&1 && output=$(shasum -a 256 "$file" 2>/dev/null); then
+        digest=$(printf '%s\n' "$output" | LC_ALL=C awk 'NR == 1 && length($1) == 64 && $1 !~ /[^0-9A-Fa-f]/ { print tolower($1); exit }')
+        if [[ -n "$digest" ]]; then
+            printf '%s\n' "$digest"
+            return 0
+        fi
+    fi
+    return 1
+}
+
 # --- Platform detection ---
 
 platform=$(uname -ms)
@@ -101,13 +145,30 @@ mkdir -p "$bin_dir" || error "Failed to create install directory: $bin_dir"
 # The archive ships bin/ plus a vestigial empty runtime/ (kept only to satisfy the
 # sidecar-era `nub upgrade`; the binary ignores ~/.nub/runtime — see release.yml).
 # (Windows is handled by install.ps1 above, so $target is always darwin/linux.)
-url="https://github.com/nubjs/nub/releases/download/v${version}/nub-${target}.tar.gz"
+archive_name="nub-${target}.tar.gz"
+url="https://github.com/nubjs/nub/releases/download/v${version}/${archive_name}"
+checksum_url="${url}.sha256"
 
 tmp_archive=$(mktemp) || error "Failed to create temp file"
-trap 'rm -f "$tmp_archive"' EXIT
+tmp_checksum=$(mktemp) || { rm -f "$tmp_archive"; error "Failed to create temp file"; }
+trap 'rm -f "$tmp_archive" "$tmp_checksum"' EXIT
 
 curl --fail --location --progress-bar --output "$tmp_archive" "$url" ||
     error "Failed to download nub from: $url"
+curl --fail --location --progress-bar --output "$tmp_checksum" "$checksum_url" ||
+    error "Failed to download checksum from: $checksum_url"
+
+# The sidecar detects corrupt, truncated, stale-cache, or mismatched assets. It
+# is not an independent authenticity check because both files share an origin.
+if ! expected_sha256=$(parse_sha256_sidecar "$tmp_checksum" "$archive_name"); then
+    error "Malformed checksum from: $checksum_url"
+fi
+if ! actual_sha256=$(sha256_file "$tmp_archive"); then
+    error "No usable SHA-256 tool found (install sha256sum or shasum)"
+fi
+if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+    error "Checksum mismatch for $url (expected $expected_sha256, got $actual_sha256). Refusing to install a corrupt or mismatched archive."
+fi
 
 # Replace any prior nub artifacts for a clean upgrade. In the default ~/.nub —
 # which nub owns outright — drop the whole bin/ and a stale runtime/ from a

--- a/tests/installer/checksums.ps1
+++ b/tests/installer/checksums.ps1
@@ -1,0 +1,126 @@
+$ErrorActionPreference = "Stop"
+if (-not $env:TEMP) { $env:TEMP = [System.IO.Path]::GetTempPath() }
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$Installer = Join-Path $RepoRoot "install.ps1"
+$Pwsh = (Get-Command pwsh).Source
+$Target = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
+    "X64" { "win32-x64" }
+    "Arm64" { "win32-arm64" }
+    default { throw "Unsupported test architecture" }
+}
+$ArchiveName = "nub-$Target.zip"
+$Fixture = Join-Path ([System.IO.Path]::GetTempPath()) "nub-installer-checksums-$([guid]::NewGuid())"
+$Assets = Join-Path $Fixture "assets"
+$Build = Join-Path $Fixture "build"
+$Wrapper = Join-Path $Fixture "invoke-installer.ps1"
+
+try {
+    New-Item -ItemType Directory -Force -Path $Assets, (Join-Path $Build "bin"), (Join-Path $Build "runtime") | Out-Null
+    [System.IO.File]::WriteAllText((Join-Path $Build "bin\nub.exe"), "NEW-NUB`n")
+    [System.IO.File]::WriteAllText((Join-Path $Build "runtime\from-archive"), "FROM-ARCHIVE`n")
+    Compress-Archive -Path (Join-Path $Build "bin"), (Join-Path $Build "runtime") -DestinationPath (Join-Path $Assets $ArchiveName)
+    $Digest = (Get-FileHash -LiteralPath (Join-Path $Assets $ArchiveName) -Algorithm SHA256).Hash.ToLowerInvariant()
+
+    @'
+param(
+    [string]$Installer,
+    [string]$Assets,
+    [string]$HomeDir,
+    [string]$TempDir,
+    [int]$NoModifyPath
+)
+$ErrorActionPreference = "Stop"
+function global:Invoke-WebRequest {
+    param(
+        [uri]$Uri,
+        [string]$OutFile,
+        [switch]$UseBasicParsing
+    )
+    $Name = [System.IO.Path]::GetFileName($Uri.AbsolutePath)
+    Copy-Item -LiteralPath (Join-Path $Assets $Name) -Destination $OutFile -Force
+}
+$env:USERPROFILE = $HomeDir
+$env:NUB_INSTALL_DIR = $null
+$env:TEMP = $TempDir
+if ($NoModifyPath) {
+    $env:NUB_NO_MODIFY_PATH = "1"
+} else {
+    $env:NUB_NO_MODIFY_PATH = $null
+}
+& $Installer 9.9.9
+'@ | Set-Content -LiteralPath $Wrapper -Encoding utf8
+
+    function Invoke-Case {
+        param(
+            [string]$Name,
+            [AllowNull()][string]$Sidecar,
+            [string]$ExpectedMessage,
+            [bool]$ExpectSuccess
+        )
+        $CaseRoot = Join-Path $Fixture "case-$script:CaseIndex"
+        $script:CaseIndex++
+        $HomeDir = Join-Path $CaseRoot "home"
+        $CaseTemp = Join-Path $CaseRoot "tmp"
+        $InstallDir = Join-Path $HomeDir ".nub"
+        New-Item -ItemType Directory -Force -Path (Join-Path $InstallDir "bin"), (Join-Path $InstallDir "runtime"), $CaseTemp | Out-Null
+        [System.IO.File]::WriteAllText((Join-Path $InstallDir "bin\nub.exe"), "OLD-NUB`n")
+        [System.IO.File]::WriteAllText((Join-Path $InstallDir "runtime\existing"), "EXISTING-RUNTIME`n")
+
+        $SidecarPath = Join-Path $Assets "$ArchiveName.sha256"
+        Remove-Item -Force -ErrorAction SilentlyContinue -LiteralPath $SidecarPath
+        if ($null -ne $Sidecar) {
+            [System.IO.File]::WriteAllBytes($SidecarPath, [System.Text.Encoding]::ASCII.GetBytes($Sidecar))
+        }
+
+        $PriorPreference = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        $UserPathBefore = [Environment]::GetEnvironmentVariable("Path", "User")
+        $Output = (& $Pwsh -NoProfile -File $Wrapper -Installer $Installer -Assets $Assets -HomeDir $HomeDir -TempDir $CaseTemp -NoModifyPath ([int]$ExpectSuccess) 2>&1 | Out-String)
+        $Status = $LASTEXITCODE
+        $UserPathAfter = [Environment]::GetEnvironmentVariable("Path", "User")
+        if (-not [string]::Equals($UserPathBefore, $UserPathAfter, [System.StringComparison]::Ordinal)) {
+            [Environment]::SetEnvironmentVariable("Path", $UserPathBefore, "User")
+        }
+        $ErrorActionPreference = $PriorPreference
+
+        if ($ExpectSuccess) {
+            if ($Status -ne 0) { throw "$Name expected success, got ${Status}: $Output" }
+            if ((Get-Content -Raw (Join-Path $InstallDir "bin\nub.exe")) -ne "NEW-NUB`n") { throw "$Name did not install the new binary" }
+            if (-not (Test-Path (Join-Path $InstallDir "runtime\from-archive"))) { throw "$Name did not extract the verified archive" }
+        } else {
+            if ($Status -eq 0) { throw "$Name expected failure" }
+            if ($Output -notlike "*$ExpectedMessage*") { throw "$Name missing error '$ExpectedMessage': $Output" }
+            if ((Get-Content -Raw (Join-Path $InstallDir "bin\nub.exe")) -ne "OLD-NUB`n") { throw "$Name changed the existing binary before verification" }
+            if ((Get-Content -Raw (Join-Path $InstallDir "runtime\existing")) -ne "EXISTING-RUNTIME`n") { throw "$Name changed the existing runtime before verification" }
+            if (Test-Path (Join-Path $InstallDir "runtime\from-archive")) { throw "$Name extracted the archive before verification" }
+            if (Test-Path (Join-Path $InstallDir ".nub-receipt")) { throw "$Name wrote a receipt after verification failure" }
+            if (-not [string]::Equals($UserPathBefore, $UserPathAfter, [System.StringComparison]::Ordinal)) { throw "$Name changed the User PATH before verification" }
+            if (Get-ChildItem -Force -LiteralPath $CaseTemp) { throw "$Name did not clean up temporary download files" }
+        }
+        Write-Host "ok - $Name"
+    }
+
+    $script:CaseIndex = 0
+    $Valid = "$Digest  $ArchiveName`n"
+    Invoke-Case "matching checksum" $Valid "" $true
+    Invoke-Case "mismatched checksum" "$('0' * 64)  $ArchiveName`n" "Checksum mismatch" $false
+    Invoke-Case "missing sidecar" $null "Failed to download/verify/extract nub" $false
+
+    $MalformedCases = @(
+        @{ Name = "wrong basename"; Sidecar = "$Digest  wrong.zip`n" },
+        @{ Name = "wrong basename case"; Sidecar = "$Digest  $($ArchiveName.ToUpperInvariant())`n" },
+        @{ Name = "extra record"; Sidecar = "$Valid$Valid" },
+        @{ Name = "extra field"; Sidecar = "$Digest  $ArchiveName extra`n" },
+        @{ Name = "invalid digest"; Sidecar = "g$($Digest.Substring(1))  $ArchiveName`n" },
+        @{ Name = "short digest"; Sidecar = "$($Digest.Substring(0, 63))  $ArchiveName`n" },
+        @{ Name = "CRLF ending"; Sidecar = "$Digest  $ArchiveName`r`n" },
+        @{ Name = "missing LF"; Sidecar = "$Digest  $ArchiveName" },
+        @{ Name = "excess trailing newline"; Sidecar = "$Digest  $ArchiveName`n`n" }
+    )
+    foreach ($Malformed in $MalformedCases) {
+        Invoke-Case $Malformed.Name $Malformed.Sidecar "Malformed checksum" $false
+    }
+} finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue -LiteralPath $Fixture
+}

--- a/tests/installer/checksums.sh
+++ b/tests/installer/checksums.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/../.." && pwd)
+fixture=$(mktemp -d)
+original_path=$PATH
+trap 'rm -rf "$fixture"' EXIT
+
+case "$(uname -ms)" in
+    'Darwin arm64') target=darwin-arm64 ;;
+    'Darwin x86_64') target=darwin-x64 ;;
+    'Linux aarch64' | 'Linux arm64') target=linux-arm64 ;;
+    'Linux x86_64') target=linux-x64 ;;
+    *) echo "unsupported test platform" >&2; exit 1 ;;
+esac
+if [[ "$target" == linux-* ]] && { [[ -f /etc/alpine-release ]] || ldd --version 2>&1 | grep -qi musl; }; then
+    target="${target}-musl"
+fi
+
+archive_name="nub-${target}.tar.gz"
+assets="$fixture/assets"
+build="$fixture/build"
+mock_bin="$fixture/mock-bin"
+fallback_bin="$fixture/fallback-bin"
+nohash_bin="$fixture/nohash-bin"
+mkdir -p "$assets" "$build/bin" "$build/runtime" "$mock_bin" "$fallback_bin" "$nohash_bin"
+printf 'NEW-NUB\n' > "$build/bin/nub"
+printf 'FROM-ARCHIVE\n' > "$build/runtime/from-archive"
+tar -czf "$assets/$archive_name" -C "$build" bin runtime
+
+if command -v sha256sum >/dev/null 2>&1; then
+    digest=$(sha256sum "$assets/$archive_name" | awk '{print $1}')
+else
+    digest=$(shasum -a 256 "$assets/$archive_name" | awk '{print $1}')
+fi
+
+cat > "$mock_bin/curl" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+output=
+url=
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output) output=$2; shift 2 ;;
+        *) url=$1; shift ;;
+    esac
+done
+[[ -n "$output" && -n "$url" ]]
+cp "$NUB_TEST_ASSET_DIR/${url##*/}" "$output"
+MOCK
+chmod +x "$mock_bin/curl"
+
+cat > "$fallback_bin/sha256sum" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+chmod +x "$fallback_bin/sha256sum"
+
+for tool in sha256sum shasum; do
+    cat > "$nohash_bin/$tool" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+    chmod +x "$nohash_bin/$tool"
+done
+
+case_index=0
+run_case() {
+    local name=$1
+    local sidecar=$2
+    local expected_message=$3
+    local expect_success=$4
+    local hash_mode=${5:-default}
+    local case_root install_dir output status test_path profile_before
+
+    case_index=$((case_index + 1))
+    case_root="$fixture/case-$case_index"
+    install_dir="$case_root/home/.nub"
+    mkdir -p "$install_dir/bin" "$install_dir/runtime" "$case_root/tmp"
+    printf 'OLD-NUB\n' > "$install_dir/bin/nub"
+    printf 'EXISTING-RUNTIME\n' > "$install_dir/runtime/existing"
+    printf 'EXISTING-PROFILE\n' > "$case_root/home/.zshrc"
+    profile_before=$(cat "$case_root/home/.zshrc")
+
+    rm -f "$assets/$archive_name.sha256"
+    if [[ "$sidecar" != MISSING ]]; then
+        printf '%b' "$sidecar" > "$assets/$archive_name.sha256"
+    fi
+
+    test_path="$mock_bin:$original_path"
+    case "$hash_mode" in
+        fallback) test_path="$fallback_bin:$test_path" ;;
+        none) test_path="$nohash_bin:$test_path" ;;
+    esac
+
+    set +e
+    if [[ "$expect_success" == 1 ]]; then
+        output=$(HOME="$case_root/home" NUB_INSTALL_DIR="$install_dir" NUB_NO_MODIFY_PATH=1 \
+            NUB_TEST_ASSET_DIR="$assets" PATH="$test_path" TMPDIR="$case_root/tmp" SHELL=/bin/zsh \
+            "$repo_root/install.sh" 9.9.9 2>&1)
+    else
+        output=$(HOME="$case_root/home" NUB_INSTALL_DIR="$install_dir" \
+            NUB_TEST_ASSET_DIR="$assets" PATH="$test_path" TMPDIR="$case_root/tmp" SHELL=/bin/zsh \
+            "$repo_root/install.sh" 9.9.9 2>&1)
+    fi
+    status=$?
+    set -e
+
+    if [[ "$expect_success" == 1 ]]; then
+        [[ $status -eq 0 ]] || { echo "$name: expected success, got $status: $output" >&2; return 1; }
+        [[ $(cat "$install_dir/bin/nub") == NEW-NUB ]] || { echo "$name: new binary was not installed" >&2; return 1; }
+        [[ -f "$install_dir/runtime/from-archive" ]] || { echo "$name: verified archive was not extracted" >&2; return 1; }
+    else
+        [[ $status -ne 0 ]] || { echo "$name: expected failure" >&2; return 1; }
+        [[ "$output" == *"$expected_message"* ]] || { echo "$name: missing error '$expected_message': $output" >&2; return 1; }
+        [[ $(cat "$install_dir/bin/nub") == OLD-NUB ]] || { echo "$name: existing binary changed before verification" >&2; return 1; }
+        [[ $(cat "$install_dir/runtime/existing") == EXISTING-RUNTIME ]] || { echo "$name: existing runtime changed before verification" >&2; return 1; }
+        [[ ! -e "$install_dir/runtime/from-archive" ]] || { echo "$name: archive was extracted before verification" >&2; return 1; }
+        [[ ! -e "$install_dir/.nub-receipt" ]] || { echo "$name: receipt was written after verification failure" >&2; return 1; }
+        [[ $(cat "$case_root/home/.zshrc") == "$profile_before" ]] || { echo "$name: shell profile changed before verification" >&2; return 1; }
+        [[ -z $(ls -A "$case_root/tmp") ]] || { echo "$name: temporary download files were not cleaned up" >&2; return 1; }
+    fi
+    printf 'ok - %s\n' "$name"
+}
+
+valid="${digest}  ${archive_name}\\n"
+run_case "matching checksum" "$valid" "" 1
+run_case "mismatched checksum" "$(printf '0%.0s' {1..64})  ${archive_name}\\n" "Checksum mismatch" 0
+run_case "missing sidecar" MISSING "Failed to download checksum" 0
+run_case "unavailable hash tools" "$valid" "No usable SHA-256 tool found" 0 none
+
+malformed_cases=(
+    "wrong basename|${digest}  wrong.tar.gz\\n"
+    "wrong basename case|${digest}  $(printf '%s' "$archive_name" | tr '[:lower:]' '[:upper:]')\\n"
+    "extra record|${valid}${valid}"
+    "extra field|${digest}  ${archive_name} extra\\n"
+    "invalid digest|g${digest:1}  ${archive_name}\\n"
+    "short digest|${digest:0:63}  ${archive_name}\\n"
+    "CRLF ending|${digest}  ${archive_name}\\r\\n"
+    "missing LF|${digest}  ${archive_name}"
+    "excess trailing newline|${digest}  ${archive_name}\\n\\n"
+)
+for malformed in "${malformed_cases[@]}"; do
+    run_case "${malformed%%|*}" "${malformed#*|}" "Malformed checksum" 0
+done
+
+if command -v shasum >/dev/null 2>&1; then
+    run_case "shasum fallback" "$valid" "" 1 fallback
+else
+    echo "skip - shasum fallback (shasum unavailable)"
+fi


### PR DESCRIPTION
## Summary

- verify bootstrap release archives against their SHA-256 sidecars before replacing installed files
- keep the root and site installer copies synchronized and document the same-origin authenticity limitation
- add hermetic Bash and PowerShell coverage for matching, missing, mismatched, and malformed sidecars

## Verification

- `/bin/bash tests/installer/checksums.sh`
- PowerShell 7.5 Docker: parser checks and `tests/installer/checksums.ps1`
- `GITHUB_TOKEN="$(gh auth token)" FORCE_COLOR=0 bash tests/installer/run.sh`
- live v0.4.11 archive and sidecar install
- `actionlint .github/workflows/verify-install.yml`
- `shellcheck --exclude=SC2295 install.sh site/public/install.sh tests/installer/checksums.sh`