### PR TITLE
runtime: align Web Locks dictionary conversion

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -742,14 +742,11 @@ fn urlpattern_available() {
 
 #[test]
 fn web_locks_spec_behavior() {
-    // Web Locks works to the spec under nub on every supported Node: the hand-rolled
-    // polyfill below 24.5, native at/above. The fixture asserts steal, option/name
-    // validation, reader/writer fairness, AbortSignal, and core mutual exclusion —
-    // every assertion holds on BOTH paths, so this is a true differential test (a
-    // regression on either turns it red). On the 18.19–20.x compat legs it also proves
-    // the navigator backfill hosts navigator.locks. Verified against the WPT web-locks
-    // suite (68/68 of the runnable subtests, matching native Node) across 18.19/20.19/
-    // 22.15/24.4 at implementation time.
+    // The fixture asserts shared Web Locks behavior across the hand-rolled polyfill
+    // below Node 24.5 and native Web Locks at/above it. For known native Node Web IDL
+    // conversion divergences, it requires the spec behavior on the polyfill tier and
+    // records the native result separately. On the 18.19–20.x compat legs it also
+    // proves the navigator backfill hosts navigator.locks.
     let (stdout, stderr, code) = run_nub("web-locks", "main.mjs");
     assert_eq!(
         code, 0,

--- a/runtime/navigator-locks.mjs
+++ b/runtime/navigator-locks.mjs
@@ -3,15 +3,14 @@
 // scope: the common in-process serialization use is covered; cross-thread coordination
 // would need a SharedArrayBuffer waitlist and is out of scope until there's demand).
 //
-// Spec: https://w3c.github.io/web-locks/. Modeled to match Node's own
-// internal/locks.js (the native impl on 24.5+) so behavior is identical across the
-// version boundary — including `steal`, AbortSignal integration, and the option/name
-// validation that the WPT web-locks suite exercises. Requires a `navigator` object to
-// host `navigator.locks`; navigator-shim.mjs backfills that on Node < 21 and MUST run
-// first.
+// Spec: https://w3c.github.io/web-locks/. Follows the Web Locks algorithms and
+// Web IDL conversion order, including where Node's native implementation diverges.
+// Requires a `navigator` object to host `navigator.locks`; navigator-shim.mjs
+// backfills that on Node < 21 and MUST run first.
 
 if (typeof globalThis.navigator === "object" && typeof globalThis.navigator.locks === "undefined") {
   const AbortSig = globalThis.AbortSignal;
+  const emptyOptions = Object.create(null);
 
   const abortError = (msg) => new DOMException(msg || "The operation was aborted", "AbortError");
   const stolenError = () => abortError("The lock was stolen by another request");
@@ -148,29 +147,40 @@ if (typeof globalThis.navigator === "object" && typeof globalThis.navigator.lock
 
   class LockManager {
     async request(name, optionsOrCallback, maybeCallback) {
+      if (arguments.length < 2) {
+        throw new TypeError("Failed to execute 'request' on 'LockManager': 2 arguments required.");
+      }
       let options = optionsOrCallback;
       let callback = maybeCallback;
-      if (callback === undefined) {
+      if (arguments.length < 3) {
         callback = options;
         options = undefined;
       }
 
       // WebIDL DOMString coercion (throws TypeError on a Symbol, like the binding).
       name = `${name}`;
-      if (typeof callback !== "function") {
-        throw new TypeError("Failed to execute 'request' on 'LockManager': parameter 2 is not a function.");
+      if (options == null) {
+        options = emptyOptions;
+      } else if (typeof options !== "object" && typeof options !== "function") {
+        throw new TypeError("Failed to execute 'request' on 'LockManager': options cannot be converted to a dictionary.");
       }
-      if (options === undefined || typeof options === "function") options = {};
 
-      const mode = options.mode === undefined ? "exclusive" : options.mode;
+      const ifAvailable = !!options.ifAvailable;
+      const modeValue = options.mode;
+      const mode = modeValue === undefined ? "exclusive" : `${modeValue}`;
       if (mode !== "exclusive" && mode !== "shared") {
         throw new TypeError(`Failed to execute 'request' on 'LockManager': '${mode}' is not a valid value for enumeration LockMode.`);
       }
-      const ifAvailable = !!options.ifAvailable;
-      const steal = !!options.steal;
       const signal = options.signal;
-      if (signal !== undefined && signal !== null && !(AbortSig && signal instanceof AbortSig)) {
+      if (signal !== undefined && (signal === null || (typeof signal !== "object" && typeof signal !== "function"))) {
+        throw new TypeError("Failed to execute 'request' on 'LockManager': member signal is not an object.");
+      }
+      if (signal !== undefined && !(AbortSig && signal instanceof AbortSig)) {
         throw new TypeError("Failed to execute 'request' on 'LockManager': member signal is not of type AbortSignal.");
+      }
+      const steal = !!options.steal;
+      if (typeof callback !== "function") {
+        throw new TypeError("Failed to execute 'request' on 'LockManager': callback is not a function.");
       }
 
       // Already-aborted signal rejects with its reason BEFORE the option-combo checks

--- a/tests/fixtures/web-locks/main.mjs
+++ b/tests/fixtures/web-locks/main.mjs
@@ -1,9 +1,8 @@
-// Differential web-locks check: every assertion holds on BOTH nub's polyfill
-// (Node < 24.5) and native Web Locks (24.5+), so it passes on every CI Node leg —
-// a regression on either path turns it red. Covers the spec behaviors that the WPT
-// suite exercises and that the hand-rolled polyfill previously got wrong: steal,
-// option/name validation, reader/writer fairness, AbortSignal, and core mutual
-// exclusion. Hang-proof: each scenario is time-bounded and the process exits.
+// Cross-version Web Locks check. Shared behavior is asserted on both nub's polyfill
+// (Node < 24.5) and native Web Locks (24.5+). Where current native Node diverges
+// from Web IDL dictionary conversion, the fixture requires spec behavior from the
+// polyfill and records the native deviation explicitly. Hang-proof: each scenario
+// is time-bounded and the process exits.
 const checks = [];
 const withTimeout = (p, ms, label) =>
   Promise.race([p, new Promise((_, rej) => setTimeout(() => rej(new Error("timeout/deadlock " + label)), ms))]);
@@ -14,6 +13,8 @@ const check = async (name, fn) => {
 let n = 0;
 const uniq = () => `r-${++n}`;
 const locks = globalThis.navigator.locks;
+const [nodeMajor, nodeMinor] = process.versions.node.split(".").map(Number);
+const nativeLocksTier = nodeMajor > 24 || (nodeMajor === 24 && nodeMinor >= 5);
 
 await check("core mutual exclusion serializes exclusive holders", async () => {
   const r = uniq();
@@ -89,6 +90,107 @@ await check("signal: already-aborted rejects with the reason", async () => {
   let err = null;
   try { await locks.request(uniq(), { signal: ctrl.signal }, () => { throw new Error("callback ran"); }); } catch (e) { err = e; }
   if (err !== reason) throw new Error("reason mismatch: " + err);
+});
+
+await check("option dictionaries follow the WebIDL object boundary", async () => {
+  for (const options of [null, undefined]) {
+    await locks.request(uniq(), options, () => {});
+  }
+
+  let functionModeReads = 0;
+  let grantedMode = null;
+  const fn = () => {};
+  Object.defineProperty(fn, "mode", { get() { functionModeReads++; return "shared"; } });
+  await locks.request(uniq(), fn, (lock) => { grantedMode = lock.mode; });
+  if (nativeLocksTier) {
+    // Native Node through 26.5 diverges by treating callable objects as empty dictionaries.
+    if (functionModeReads !== 0 || grantedMode !== "exclusive") {
+      throw new Error(`native callable-options behavior changed: reads=${functionModeReads}, mode=${grantedMode}`);
+    }
+  } else if (functionModeReads !== 1 || grantedMode !== "shared") {
+    throw new Error(`polyfill callable dictionary: reads=${functionModeReads}, mode=${grantedMode}`);
+  }
+
+  for (const [label, options] of [
+    ["number", 1], ["string", "x"], ["boolean", true],
+    ["bigint", 1n], ["symbol", Symbol("x")],
+  ]) {
+    let err = null;
+    let called = false;
+    try { await locks.request(uniq(), options, () => { called = true; }); } catch (e) { err = e; }
+    if (!(err instanceof TypeError) || called) throw new Error(`${label}: ${err && err.constructor.name}, callback=${called}`);
+  }
+});
+
+await check("overload arity is resolved before argument conversion", async () => {
+  let nameConversions = 0;
+  const name = { toString() { nameConversions++; return uniq(); } };
+  let err = null;
+  try { await locks.request(name); } catch (e) { err = e; }
+  if (!(err instanceof TypeError)) throw new Error("one argument: " + err);
+  if (nativeLocksTier) {
+    // Native Node through 26.5 diverges by converting the name before rejecting.
+    if (nameConversions !== 1) throw new Error("native name conversions: " + nameConversions);
+  } else if (nameConversions !== 0) {
+    throw new Error("polyfill name conversions: " + nameConversions);
+  }
+
+  const marker = new Error("explicit undefined kept the three-argument overload");
+  let optionReads = 0;
+  const options = Object.create(null, {
+    ifAvailable: { get() { optionReads++; throw marker; } },
+  });
+  err = null;
+  try { await locks.request(uniq(), options, undefined); } catch (e) { err = e; }
+  if (nativeLocksTier) {
+    // Native Node through 26.5 selects its two-argument path from the callback value.
+    if (!(err instanceof TypeError) || optionReads !== 0) {
+      throw new Error(`native explicit-undefined order: ${err}, reads=${optionReads}`);
+    }
+  } else if (err !== marker || optionReads !== 1) {
+    throw new Error(`polyfill explicit-undefined order: ${err}, reads=${optionReads}`);
+  }
+});
+
+await check("three-argument options convert before the callback", async () => {
+  const marker = new Error("options converted first");
+  let reads = 0;
+  const options = Object.create(null, {
+    ifAvailable: { get() { reads++; throw marker; } },
+  });
+  let err = null;
+  try { await locks.request(uniq(), options, null); } catch (e) { err = e; }
+  if (nativeLocksTier) {
+    // Native Node through 26.5 diverges by validating the callback first.
+    if (!(err instanceof TypeError) || reads !== 0) throw new Error(`native order: ${err}, reads=${reads}`);
+  } else if (err !== marker || reads !== 1) {
+    throw new Error(`polyfill order: ${err}, reads=${reads}`);
+  }
+});
+
+await check("option dictionary members convert in WebIDL order", async () => {
+  const events = [];
+  const name = { toString() { events.push("convert:name"); return uniq(); } };
+  const values = {
+    ifAvailable: false,
+    mode: { toString() { events.push("convert:mode"); return "exclusive"; } },
+    signal: {},
+    steal: false,
+  };
+  const options = new Proxy(values, {
+    get(target, key, receiver) {
+      events.push(`get:${String(key)}`);
+      return Reflect.get(target, key, receiver);
+    },
+  });
+  let err = null;
+  try { await locks.request(name, options, () => { events.push("callback"); }); } catch (e) { err = e; }
+  if (!(err instanceof TypeError)) throw new Error("got " + (err && err.constructor.name));
+  // Native Node through 26.5 defers AbortSignal validation until every member is read.
+  const expected = nativeLocksTier
+    ? "convert:name,get:ifAvailable,get:mode,convert:mode,get:signal,get:steal"
+    : "convert:name,get:ifAvailable,get:mode,convert:mode,get:signal";
+  if (events.join(",") !== expected) throw new Error("order: " + events.join(","));
 });
 
 await check("name starting with '-' rejects NotSupportedError", async () => {


### PR DESCRIPTION
## Summary
- follow Web IDL overload and dictionary conversion order for `navigator.locks.request`
- accept callable option dictionaries while rejecting non-object primitives
- cover the polyfill contract while recording current native Node deviations

## Verification
- `scripts/rust-build.sh fast build -p nub-cli`
- `node --check runtime/navigator-locks.mjs`
- `node --check tests/fixtures/web-locks/main.mjs`
- Web Locks fixture on Node 18.19, 20.19, 22.15, 24.4, 24.14, and 26.5