### PR TITLE
fix(run): arm PR_SET_PDEATHSIG on the script child so SIGKILL on the leader can't orphan the workload

### DIFF
--- a/crates/nub-cli/tests/pdeathsig.rs
+++ b/crates/nub-cli/tests/pdeathsig.rs
@@ -1,0 +1,83 @@
+//! Orphan-regression for #463: SIGKILL on the Nub leader must not orphan the
+//! `nub run` workload. The signal FORWARDER cannot cover SIGKILL (never
+//! delivered to userspace), so this exercises the Linux kernel-side backstop —
+//! `PR_SET_PDEATHSIG(SIGTERM)` armed in the script child's `pre_exec`
+//! (`group_on_spawn`). Linux-only by nature; macOS has no pdeathsig.
+
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/
+    path.push("nub");
+    path
+}
+
+/// `nub run serve` (a plain `sleep`, which `sh -c` execs so the sleeper IS the
+/// pdeathsig'd child) → SIGKILL the nub leader → the sleeper must die within a
+/// grace window instead of running on orphaned.
+#[test]
+fn sigkill_on_nub_leader_terminates_the_script_child() {
+    let dir = std::env::temp_dir().join(format!("nub-pdeathsig-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("package.json"),
+        // `$$` is the sh pid; `exec sleep` replaces sh in-place, so child.pid
+        // names the surviving sleeper the pdeathsig is armed on.
+        r#"{"name":"f","version":"1.0.0","scripts":{"serve":"echo $$ > child.pid && exec sleep 30"}}"#,
+    )
+    .unwrap();
+
+    let mut nub = std::process::Command::new(nub_binary())
+        .args(["run", "serve"])
+        .current_dir(&dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn nub run");
+
+    // Wait for the script to write its pid (bounded).
+    let pid_file = dir.join("child.pid");
+    let mut child_pid: Option<i32> = None;
+    for _ in 0..100 {
+        if let Ok(s) = std::fs::read_to_string(&pid_file) {
+            if let Ok(pid) = s.trim().parse::<i32>() {
+                child_pid = Some(pid);
+                break;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    let child_pid = child_pid.expect("script child never wrote its pid");
+    assert!(
+        unsafe { libc::kill(child_pid, 0) } == 0,
+        "sleeper must be alive before the kill"
+    );
+
+    // The unforwardable path: SIGKILL the leader directly.
+    unsafe { libc::kill(nub.id() as i32, libc::SIGKILL) };
+    let _ = nub.wait();
+
+    // The kernel delivers the pdeathsig on leader death; give it a grace window.
+    let mut died = false;
+    for _ in 0..50 {
+        if unsafe { libc::kill(child_pid, 0) } != 0 {
+            died = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    if !died {
+        // Never leak a 30s sleeper into the test environment on failure.
+        unsafe { libc::kill(child_pid, libc::SIGKILL) };
+    }
+    assert!(
+        died,
+        "script child (pid {child_pid}) survived SIGKILL of the nub leader — pdeathsig backstop missing"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/nub-cli/tests/pdeathsig.rs
+++ b/crates/nub-cli/tests/pdeathsig.rs
@@ -44,11 +44,11 @@ fn sigkill_on_nub_leader_terminates_the_script_child() {
     let pid_file = dir.join("child.pid");
     let mut child_pid: Option<i32> = None;
     for _ in 0..100 {
-        if let Ok(s) = std::fs::read_to_string(&pid_file) {
-            if let Ok(pid) = s.trim().parse::<i32>() {
-                child_pid = Some(pid);
-                break;
-            }
+        if let Ok(s) = std::fs::read_to_string(&pid_file)
+            && let Ok(pid) = s.trim().parse::<i32>()
+        {
+            child_pid = Some(pid);
+            break;
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
     }

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -298,16 +298,39 @@ impl Drop for ForegroundGuard {
 }
 
 /// Put the spawned child in its own process group (`setpgid(0, 0)` at exec) so
-/// [`track_child_group`] can signal the whole subtree. No-op off Unix.
+/// [`track_child_group`] can signal the whole subtree. On Linux, additionally
+/// arm `PR_SET_PDEATHSIG(SIGTERM)` as the kernel-side backstop for signals the
+/// forwarder structurally cannot relay: SIGKILL on the Nub leader (Playwright's
+/// default `webServer` teardown, `docker kill`, CI cancellation, the OOM killer)
+/// is never delivered to userspace, so the forward thread never runs and the
+/// `sh -c` subtree would run on orphaned (#463). With the pdeathsig armed the
+/// kernel itself TERMs the child when Nub's spawning thread dies, no matter how.
+/// No-op off Unix; macOS has no pdeathsig equivalent, so it keeps the
+/// forwarding-only behavior (the group forward covers every catchable signal).
 pub fn group_on_spawn(cmd: &mut Command) {
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
-        // SAFETY: setpgid(0, 0) only repoints the child's own process-group id
-        // between fork and exec — async-signal-safe, touches no parent state.
+        // Captured BEFORE fork: the child's TOCTOU re-check below must compare
+        // getppid() against the REAL parent, not a post-fork read that would
+        // already name the reaper if the parent died between fork and prctl.
+        #[cfg(target_os = "linux")]
+        let parent = unsafe { libc::getpid() };
+        // SAFETY: setpgid(0, 0) / prctl / getppid / raise between fork and exec
+        // are all async-signal-safe and touch no parent state.
         unsafe {
-            cmd.pre_exec(|| {
+            cmd.pre_exec(move || {
                 libc::setpgid(0, 0);
+                #[cfg(target_os = "linux")]
+                {
+                    libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM);
+                    // The pdeathsig only fires for deaths AFTER registration; if
+                    // the parent died in the fork→prctl window, deliver the same
+                    // signal ourselves instead of running on orphaned.
+                    if libc::getppid() != parent {
+                        libc::raise(libc::SIGTERM);
+                    }
+                }
                 Ok(())
             });
         }

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -303,8 +303,11 @@ impl Drop for ForegroundGuard {
 /// forwarder structurally cannot relay: SIGKILL on the Nub leader (Playwright's
 /// default `webServer` teardown, `docker kill`, CI cancellation, the OOM killer)
 /// is never delivered to userspace, so the forward thread never runs and the
-/// `sh -c` subtree would run on orphaned (#463). With the pdeathsig armed the
-/// kernel itself TERMs the child when Nub's spawning thread dies, no matter how.
+/// child subtree would run on orphaned (#463). This guards BOTH callers: the
+/// `nub run` script child (`sh -c` subtree) and the `nub <file>` file-run
+/// `node` leaf — the orphan exposure is identical. With the pdeathsig armed
+/// the kernel itself TERMs the child when Nub's spawning thread dies, no
+/// matter how.
 /// No-op off Unix; macOS has no pdeathsig equivalent, so it keeps the
 /// forwarding-only behavior (the group forward covers every catchable signal).
 pub fn group_on_spawn(cmd: &mut Command) {


### PR DESCRIPTION
## Problem

The signal forwarder (`track_child_group` + `group_on_spawn`) correctly relays every catchable signal to the script's process group — but **SIGKILL is never delivered to userspace**, so the forward thread never runs and the `sh -c` subtree runs on orphaned. Hit in production via Playwright's default `webServer` teardown (SIGKILL): the orphaned vite held a CI job open for ~2h. Same exposure for `docker kill`, CI cancellation, and OOM-killer hits on the leader.

## Fix

Arm `PR_SET_PDEATHSIG(SIGTERM)` in the **same `pre_exec` as `setpgid`** (Linux), per the constraints discussed on the issue:

- Registered after `setpgid`, in the child, between fork and exec (all async-signal-safe calls).
- TOCTOU guard: the parent pid is captured **before fork**; after `prctl` the child re-checks `getppid()` against it and `raise(SIGTERM)`s itself if the parent already died in the fork→prctl window.
- macOS unchanged (no pdeathsig equivalent) — the group forward still covers every catchable signal there, and the doc comment states the Linux-only guarantee.

## Validation

New Linux orphan-regression test (`crates/nub-cli/tests/pdeathsig.rs`): `nub run serve` (an `exec sleep`, so the sleeper IS the pdeathsig'd child) → SIGKILL the nub leader → asserts the sleeper dies within a grace window (and reaps it on failure so a red run can't leak a sleeper). Verified green on Linux (rust:1-bookworm container): `1 passed, 0 failed, 0.11s`. `cargo check -p nub-core -p nub-cli` clean on macOS.

Closes #463