### PR TITLE
fix: filter runtime env keys across watch restarts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
       # --all-features enables `embed-runtime`, whose build.rs bakes the integrity
       # digest of runtime/addons/nub-native.node (gitignored — built locally / staged
       # in release.yml) and fails loud if it's absent. Stage a placeholder so the lint
-      # build's three-entrypoint set is complete; clippy never runs the binary.
+      # build's four-entrypoint set is complete; clippy never runs the binary.
       - name: Stage placeholder addon for the embed-runtime lint build
         run: |
           mkdir -p runtime/addons
@@ -209,7 +209,7 @@ jobs:
   # request as c_int on musl vs c_ulong on glibc; fixed to `as _` so inference picks the
   # per-target type. It was test-only, so the released musl binary was never affected.)
   # The addon is gitignored (built locally
-  # / staged in release.yml), so a placeholder is staged so build.rs's three-entrypoint
+  # / staged in release.yml), so a placeholder is staged so build.rs's four-entrypoint
   # hash set is complete; it is never dlopen'd here (the tests verify hash CONSISTENCY —
   # baked == extracted — not native loading).
   embed-runtime:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2700,6 +2700,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -146,6 +146,13 @@ libc.workspace = true
 # (pm_engine/mod.rs::with_fd_captured). Without it the substitution silently
 # breaks and the default registry is never surfaced on Windows.
 libc.workspace = true
+# Expand 8.3 path components before auto-discovered env files reach Node's
+# Windows watcher. Node 24's bundled libuv aborts when an event path and watched
+# directory use short and long spellings of the same directory.
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+] }
 
 [lints]
 workspace = true

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -176,6 +176,11 @@ fn env_file_flag_present() -> bool {
 /// `--env-file` (a child `nub`/`node` it spawns does not inherit the suppression).
 static NO_ENV_FILE: OnceLock<bool> = OnceLock::new();
 
+/// Per-child watch cleanup state. The long-lived Node watch supervisor skips
+/// preloads, so this survives there and is consumed independently by every
+/// restarted child before user preloads run.
+const WATCH_ENV_GUARD_ENV: &str = "__NUB_WATCH_ENV_GUARD";
+
 /// True iff the user passed `--no-env-file`. The authoritative kill-switch read
 /// by every env-file consumer ([`merge_child_env`], [`overlay_env_file_vars`],
 /// [`apply_env_file_vars`], and the auto-discovery load sites).
@@ -263,6 +268,142 @@ fn watch_inject_vars<'a>(
     env_vars
         .iter()
         .filter(|(k, v)| raw_env.get(*k) != Some(*v))
+        .collect()
+}
+
+/// Render an auto-discovered watch env file for Node's platform-specific watcher.
+/// Node 20.11 on Linux rejects absolute `--env-file` paths even when the file
+/// exists. Node 24's Windows watcher also aborts when an argv path contains an
+/// 8.3 component (for example `RUNNER~1`) but the filesystem event arrives with
+/// the long spelling. Keep Windows absolute and expand only short components;
+/// make Unix cwd-relative without canonicalizing so symlink and watch identity
+/// stay unchanged.
+fn watch_env_file_arg(path: &Path, cwd: &Path, windows: bool) -> Result<String> {
+    if !path.is_absolute() || !cwd.is_absolute() {
+        bail!("watch env-file paths and cwd must be absolute");
+    }
+
+    if windows {
+        let path = windows_long_watch_path(path)?;
+        let path = path
+            .to_str()
+            .context("watch env-file path is not valid UTF-8")?;
+        let path = strip_windows_verbatim_prefix(path);
+        return Ok(format!("--env-file={path}"));
+    }
+
+    for (parent_count, ancestor) in cwd.ancestors().enumerate() {
+        let Ok(suffix) = path.strip_prefix(ancestor) else {
+            continue;
+        };
+        let mut relative = PathBuf::new();
+        for _ in 0..parent_count {
+            relative.push("..");
+        }
+        relative.push(suffix);
+        if relative.as_os_str().is_empty() {
+            bail!("watch env-file path must name a file");
+        }
+        let relative = relative
+            .to_str()
+            .context("watch env-file relative path is not valid UTF-8")?;
+        return Ok(format!("--env-file={relative}"));
+    }
+
+    bail!(
+        "watch env-file path {} cannot be made relative to {}",
+        path.display(),
+        cwd.display()
+    )
+}
+
+/// Expand Windows 8.3 components without resolving symlinks or junctions.
+/// libuv normalizes filesystem-event paths with this same API; doing it for the
+/// watched path keeps both sides of its prefix comparison in one spelling.
+/// Callers pass either an existing auto-discovered env file or the existing
+/// watcher cwd, so failure is exceptional and should be reported rather than
+/// letting Node hit its process-aborting assertion.
+#[cfg(windows)]
+fn windows_long_watch_path(path: &Path) -> Result<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt as _, OsStringExt as _};
+    use windows_sys::Win32::Storage::FileSystem::GetLongPathNameW;
+
+    let mut input: Vec<u16> = path.as_os_str().encode_wide().collect();
+    input.push(0);
+
+    // SAFETY: `input` is NUL-terminated and lives across both calls. The first
+    // call requests the required capacity without writing an output buffer.
+    let mut capacity = unsafe { GetLongPathNameW(input.as_ptr(), std::ptr::null_mut(), 0) };
+    if capacity == 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("could not expand Windows watch path {}", path.display()));
+    }
+
+    loop {
+        let mut output = vec![0u16; capacity as usize];
+        // SAFETY: the output pointer is valid for `capacity` UTF-16 code units;
+        // the input remains NUL-terminated and neither buffer aliases the other.
+        let written =
+            unsafe { GetLongPathNameW(input.as_ptr(), output.as_mut_ptr(), output.len() as u32) };
+        if written == 0 {
+            return Err(std::io::Error::last_os_error()).with_context(|| {
+                format!("could not expand Windows watch path {}", path.display())
+            });
+        }
+        if (written as usize) < output.len() {
+            output.truncate(written as usize);
+            return Ok(PathBuf::from(OsString::from_wide(&output)));
+        }
+        // The path changed between calls or the first capacity became stale.
+        // `GetLongPathNameW` returns the required size when the buffer is short.
+        capacity = written.saturating_add(1);
+    }
+}
+
+#[cfg(not(windows))]
+fn windows_long_watch_path(path: &Path) -> Result<PathBuf> {
+    Ok(path.to_path_buf())
+}
+
+/// Rust canonicalization and some Windows APIs emit verbatim paths, but Node's
+/// option parser expects the ordinary drive/UNC spelling. Handle UNC first so
+/// `\\?\UNC\server\share` becomes `\\server\share`, not `UNC\server\share`.
+fn strip_windows_verbatim_prefix(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else {
+        path.strip_prefix(r"\\?\").unwrap_or(path).to_string()
+    }
+}
+
+/// Exact ambient spellings for the env-file runtime-control denylist. A Unix
+/// process may carry both canonical and mixed-case spellings; Windows collapses
+/// them through its case-insensitive environment.
+fn ambient_denied_env_file_keys() -> Vec<String> {
+    env::vars_os()
+        .filter_map(|(key, _)| key.into_string().ok())
+        .filter(|key| nub_core::workspace::env::is_denied_env_file_key(key))
+        .collect()
+}
+
+/// Canonical placeholders the watch supervisor must carry so Node's early
+/// startup consumers cannot read a value from a raw env file. Unix startup
+/// lookup is exact-case, so a mixed-case ambient key does not cover the canonical
+/// spelling; Windows lookup is case-insensitive.
+fn watch_env_guard_placeholders(ambient_keys: &[String], windows: bool) -> Vec<&'static str> {
+    nub_core::workspace::env::denied_env_file_keys()
+        .iter()
+        .copied()
+        .filter(|denied| {
+            !ambient_keys.iter().any(|ambient| {
+                if windows {
+                    ambient.eq_ignore_ascii_case(denied)
+                } else {
+                    ambient == denied
+                }
+            })
+        })
         .collect()
 }
 
@@ -4449,6 +4590,28 @@ fn list_scripts(manifest: &serde_json::Value) -> String {
 
 fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     let cwd = env::current_dir()?;
+    let compat_mode = node_compat_env();
+    let env_file_present = env_file_flag_present();
+    let no_env_file = no_env_file();
+    let project = nub_core::workspace::detect::detect_project(&cwd);
+    let env_file_paths = if env_file_present || no_env_file {
+        Vec::new()
+    } else {
+        project
+            .as_ref()
+            .map(|p| nub_core::workspace::env::discover_env_files(&p.root))
+            .unwrap_or_default()
+    };
+    // A raw env-file path arms the child guard for the watch lifetime. Validate
+    // its serialized ambient state before Node discovery: an uncached
+    // `node --version` probe inherits NODE_OPTIONS, so waiting until command
+    // assembly would let invalid bytes fail with an unrelated Node error first.
+    if !compat_mode
+        && !env_file_paths.is_empty()
+        && env::var_os("NODE_OPTIONS").is_some_and(|value| value.to_str().is_none())
+    {
+        bail!("watch env-file filtering requires NODE_OPTIONS to be valid UTF-8");
+    }
     // Fire point (running a file): provision a pinned-but-uncached version.
     let node = nub_core::node::discovery::discover_or_provision_node(&cwd)?;
     if let Some(w) = nub_core::node::discovery::engines_disagreement_warning(&cwd, &node) {
@@ -4463,7 +4626,7 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     // user's argv — no flag injection, no preload, no eager `.env*` — matching the
     // zero-augmentation contract of `--node`/compat everywhere else. Version
     // provisioning above still applies (compat = no augmentation, not no-pinning).
-    if node_compat_env() {
+    if compat_mode {
         let mut node_args = vec!["--watch".to_string(), "--watch-preserve-output".to_string()];
         node_args.push(file.to_string());
         node_args.extend(args.iter().cloned());
@@ -4510,17 +4673,6 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     // the child. This keeps `nub --watch --env-file …` consistent with the direct
     // file runner. `--no-env-file` suppresses BOTH the auto args and the explicit
     // `--env-file` overlay — the watched Node receives no `--env-file` args at all.
-    let env_file_present = env_file_flag_present();
-    let no_env_file = no_env_file();
-    let project = nub_core::workspace::detect::detect_project(&cwd);
-    let env_file_paths = if env_file_present || no_env_file {
-        Vec::new()
-    } else {
-        project
-            .as_ref()
-            .map(|p| nub_core::workspace::env::discover_env_files(&p.root))
-            .unwrap_or_default()
-    };
     // Load the `.env*` files ONCE: `raw_env` is the unexpanded merge (the values
     // Node's `--env-file` args deliver), `auto_env` is the same map expanded. A
     // single read (rather than `load_env_files` + a second `load_env_files_raw`)
@@ -4558,23 +4710,29 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
 
     let mut node_args = vec!["--watch".to_string(), "--watch-preserve-output".to_string()];
 
-    let node_options = env::var("NODE_OPTIONS").ok();
+    let node_options_os = env::var_os("NODE_OPTIONS");
+    let node_options = node_options_os.as_ref().and_then(|value| value.to_str());
     let accepted = nub_core::node::discovery::accepted_env_flags(node.path.as_std_path());
     let inject = nub_core::node::flags::compute_inject_flags(
         node.version.clone(),
         args,
-        node_options.as_deref(),
+        node_options,
         false,
         accepted.as_ref(),
     );
     for flag in &inject {
         node_args.push(flag.to_string());
     }
+    let sanitized_node_options = node_options.map(|existing| {
+        nub_core::node::flags::strip_unsupported_node_options(existing, &node.version)
+    });
 
     // Reverse so the highest-priority `.env*` file lands last (Node's
     // last-writer-wins ⇒ nub's first-writer-wins precedence).
     for path in env_file_paths.iter().rev() {
-        node_args.push(format!("--env-file={}", path.display()));
+        // `cmd` inherits `cwd`; the helper chooses the path form required by the
+        // platform watcher without changing cwd or file precedence.
+        node_args.push(watch_env_file_arg(path, &cwd, cfg!(windows))?);
     }
 
     if let Some(preload) = &preload_path {
@@ -4596,6 +4754,18 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit());
+    // Node's Windows watch supervisor first registers the long-spelled env-file
+    // directory, then registers module paths reported by the watched child. If
+    // the inherited cwd contains an 8.3 component (for example RUNNER~1), those
+    // child paths use the short spelling and Node installs a second watcher for
+    // the same directory. libuv reports the event under the long spelling and
+    // older bundled versions abort on the mismatch. Align only this raw-env
+    // watch path's supervisor cwd; GetLongPathNameW preserves symlink/junction
+    // identity and non-Windows behavior stays byte-for-byte unchanged.
+    #[cfg(windows)]
+    if !env_file_paths.is_empty() {
+        cmd.current_dir(windows_long_watch_path(&cwd)?);
+    }
     // Inject ONLY the .env* vars whose `${VAR}` expansion changed the raw value
     // (#207) — see [`watch_inject_vars`]. A var Node's `--env-file` already
     // delivers identically is left to Node so the long-lived watcher re-reads it
@@ -4604,16 +4774,63 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     for (k, v) in watch_inject_vars(&env_vars, &raw_env) {
         cmd.env(k, v);
     }
-    // This path spawns `node` directly and otherwise relies on OS env inheritance
-    // for NODE_OPTIONS, so an inherited below-floor version-gated flag (e.g.
-    // --experimental-webstorage on Node <22.4) would reach the child unstripped and
-    // abort it with exit 9 ("not allowed in NODE_OPTIONS"). Snip such flags against
-    // this watch invocation's resolved Node version before spawning — mirror of the
-    // two direct-spawn sites in spawn.rs. See flags::strip_unsupported_node_options.
-    if let Some(existing) = &node_options {
-        let stripped =
-            nub_core::node::flags::strip_unsupported_node_options(existing, &node.version);
-        cmd.env("NODE_OPTIONS", stripped);
+    // Node receives the auto-discovered files as raw `--env-file` paths and
+    // re-reads them in each watched child. Keep canonical placeholders in the
+    // preload-free supervisor so startup consumers cannot act on file values;
+    // an early child-only `--require` then removes every non-ambient denied
+    // spelling and restores the sanitized ambient NODE_OPTIONS before user
+    // preloads run. Arming by path presence, rather than current contents, keeps
+    // edits made after startup behind the same boundary.
+    if !env_file_paths.is_empty() {
+        if node_options_os.is_some() && node_options.is_none() {
+            bail!("watch env-file filtering requires NODE_OPTIONS to be valid UTF-8");
+        }
+        let preload = preload_path
+            .as_deref()
+            .context("watch env-file filtering requires the Nub runtime preload")?;
+        let cleanup_preload = Path::new(preload).with_file_name("watch-env-guard.cjs");
+        if !cleanup_preload.is_file() {
+            bail!(
+                "watch env-file filtering preload is missing: {}",
+                cleanup_preload.display()
+            );
+        }
+        let cleanup_preload = cleanup_preload
+            .to_str()
+            .context("watch env-file filtering preload path is not valid UTF-8")?;
+        let cleanup_token = nub_core::node::spawn::PreloadInjection {
+            flag: "--require",
+            value: cleanup_preload.to_string(),
+        }
+        .node_options_token();
+
+        let ambient_keys = ambient_denied_env_file_keys();
+        for key in watch_env_guard_placeholders(&ambient_keys, cfg!(windows)) {
+            cmd.env(key, "");
+        }
+        let state = serde_json::json!({
+            "denylist": nub_core::workspace::env::denied_env_file_keys(),
+            "ambientKeys": ambient_keys,
+            "nodeOptions": &sanitized_node_options,
+        });
+        cmd.env(
+            WATCH_ENV_GUARD_ENV,
+            serde_json::to_string(&state).context("could not serialize watch env-file guard")?,
+        );
+
+        let mut effective_node_options = cleanup_token;
+        if let Some(existing) = sanitized_node_options
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            effective_node_options.push(' ');
+            effective_node_options.push_str(existing);
+        }
+        cmd.env("NODE_OPTIONS", effective_node_options);
+    } else if let Some(existing) = sanitized_node_options {
+        // This path spawns Node directly and otherwise relies on OS inheritance.
+        // Strip below-floor version-gated flags just as the direct-spawn sites do.
+        cmd.env("NODE_OPTIONS", existing);
     }
     let status = cmd.status()?;
 
@@ -8111,8 +8328,7 @@ mod tests {
     // ONLY the vars whose `${VAR}` expansion changed their raw value. Plain vars are
     // left to Node's `--env-file` (which re-reads on every restart), so editing
     // `.env` is picked up live instead of freezing at startup. `watch_inject_vars`
-    // is the selection; locking it here covers the fix without a flaky long-lived
-    // watcher + timed-file-edit integration test.
+    // is the selection; the integration suite separately locks the real restart.
     #[test]
     fn watch_injects_only_expansion_changed_vars() {
         // A plain var (raw == expanded) and an expansion-changed var.
@@ -8161,6 +8377,140 @@ mod tests {
             2,
             "with no raw_env (--env-file present) every var is injected; got {all:?}"
         );
+    }
+
+    #[test]
+    fn watch_env_file_arg_is_relative_to_the_watcher_cwd() {
+        let root = std::env::temp_dir().join("nub-watch-env-arg-root");
+        assert_eq!(
+            watch_env_file_arg(&root.join(".env"), &root, false).unwrap(),
+            "--env-file=.env"
+        );
+
+        let member = root.join("packages").join("app");
+        let one_level = Path::new("..").join(".env.local");
+        assert_eq!(
+            watch_env_file_arg(&root.join("packages").join(".env.local"), &member, false,).unwrap(),
+            format!("--env-file={}", one_level.to_str().unwrap())
+        );
+        let two_levels = Path::new("..").join("..").join(".env");
+        assert_eq!(
+            watch_env_file_arg(&root.join(".env"), &member, false).unwrap(),
+            format!("--env-file={}", two_levels.to_str().unwrap())
+        );
+    }
+
+    #[test]
+    fn watch_env_file_arg_stays_absolute_for_windows_watchers() {
+        let root = std::env::temp_dir().join("nub-watch-env-arg-windows");
+        let path = root.join(".env");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(&path, "A=1\n").unwrap();
+        let arg = watch_env_file_arg(&path, &root, true).unwrap();
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert!(arg.starts_with("--env-file="), "{arg}");
+        assert!(arg.ends_with(".env"), "{arg}");
+        assert!(!arg.starts_with(r"--env-file=\\?\"), "{arg}");
+    }
+
+    #[test]
+    fn windows_verbatim_prefix_stripping_handles_drive_and_unc_paths() {
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"\\?\D:\project\.env"),
+            r"D:\project\.env"
+        );
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"\\?\UNC\server\share\.env"),
+            r"\\server\share\.env"
+        );
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"D:\project\.env"),
+            r"D:\project\.env"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_long_watch_path_keeps_existing_file_and_cwd_in_one_spelling() {
+        let root = std::env::temp_dir().join("nub-watch-env-long-path");
+        let path = root.join(".env");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(&path, "A=1\n").unwrap();
+
+        let expanded_root = windows_long_watch_path(&root).unwrap();
+        let expanded = windows_long_watch_path(&path).unwrap();
+        assert_eq!(expanded.parent(), Some(expanded_root.as_path()));
+
+        let expanded_root = expanded_root.to_str().unwrap();
+        let ordinary_root = strip_windows_verbatim_prefix(expanded_root);
+        let expanded = expanded.to_str().unwrap();
+        let ordinary = strip_windows_verbatim_prefix(expanded);
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert!(Path::new(&ordinary_root).is_absolute(), "{ordinary_root}");
+        assert!(!ordinary_root.starts_with(r"\\?\"), "{ordinary_root}");
+        assert!(Path::new(&ordinary).is_absolute(), "{ordinary}");
+        assert!(ordinary.ends_with(".env"), "{ordinary}");
+        assert!(!ordinary.starts_with(r"\\?\"), "{ordinary}");
+    }
+
+    #[test]
+    fn watch_env_file_arg_rejects_relative_inputs() {
+        let absolute = std::env::temp_dir().join("nub-watch-env-arg-absolute");
+        assert!(watch_env_file_arg(Path::new(".env"), &absolute, false).is_err());
+        assert!(watch_env_file_arg(&absolute.join(".env"), Path::new("project"), true).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn watch_env_file_arg_handles_non_utf8_paths_without_lossy_argv() {
+        use std::os::unix::ffi::OsStringExt as _;
+
+        let base = std::env::temp_dir();
+        let non_utf8 = std::ffi::OsString::from_vec(vec![b'n', 0xff]);
+        let ancestor = base.join(&non_utf8);
+        let cwd = ancestor.join("member");
+        assert_eq!(
+            watch_env_file_arg(&ancestor.join(".env"), &cwd, false).unwrap(),
+            format!("--env-file={}", Path::new("..").join(".env").display())
+        );
+
+        let non_utf8_file = cwd.join(std::ffi::OsString::from_vec(vec![b'.', 0xff]));
+        assert!(
+            watch_env_file_arg(&non_utf8_file, &cwd, false)
+                .unwrap_err()
+                .to_string()
+                .contains("not valid UTF-8")
+        );
+        assert!(
+            watch_env_file_arg(&non_utf8_file, &cwd, true)
+                .unwrap_err()
+                .to_string()
+                .contains("not valid UTF-8")
+        );
+    }
+
+    #[test]
+    fn watch_env_guard_placeholders_follow_os_key_semantics() {
+        let ambient = vec![
+            "NODE_OPTIONS".to_string(),
+            "node_extra_ca_certs".to_string(),
+        ];
+
+        let unix = watch_env_guard_placeholders(&ambient, false);
+        assert!(!unix.contains(&"NODE_OPTIONS"));
+        assert!(unix.contains(&"NODE_EXTRA_CA_CERTS"));
+        assert!(unix.contains(&"NODE_TLS_REJECT_UNAUTHORIZED"));
+        assert!(unix.contains(&"NODE_REPL_EXTERNAL_MODULE"));
+
+        let windows = watch_env_guard_placeholders(&ambient, true);
+        assert!(!windows.contains(&"NODE_OPTIONS"));
+        assert!(!windows.contains(&"NODE_EXTRA_CA_CERTS"));
+        assert!(windows.contains(&"NODE_TLS_REJECT_UNAUTHORIZED"));
+        assert!(windows.contains(&"NODE_REPL_EXTERNAL_MODULE"));
     }
 
     #[test]

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -3598,6 +3598,625 @@ fn no_env_file_wins_over_env_file_on_standalone_nubx() {
     );
 }
 
+fn remove_ambient_watch_control_vars(cmd: &mut Command) {
+    for (key, _) in std::env::vars_os() {
+        if key
+            .to_str()
+            .is_some_and(nub_core::workspace::env::is_denied_env_file_key)
+        {
+            cmd.env_remove(key);
+        }
+    }
+    cmd.env_remove("__NUB_WATCH_ENV_GUARD");
+}
+
+fn spawn_watch_probe(cmd: &mut Command) -> std::process::Child {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        cmd.process_group(0);
+    }
+    cmd.spawn().expect("spawn nub watch")
+}
+
+fn finish_watch_probe(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    // SAFETY: `spawn_watch_probe` makes the child the leader of a fresh process
+    // group. A negative pid targets only that probe's Nub + Node subtree.
+    unsafe {
+        libc::kill(-(child.id() as i32), libc::SIGKILL);
+    }
+    #[cfg(not(unix))]
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn wait_for_watch_snapshot(
+    path: &Path,
+    needle: &str,
+    child: &mut std::process::Child,
+    stderr: &Path,
+) -> String {
+    for _ in 0..150 {
+        if let Ok(snapshot) = std::fs::read_to_string(path)
+            && snapshot.contains(needle)
+        {
+            return snapshot;
+        }
+        if let Ok(Some(status)) = child.try_wait() {
+            finish_watch_probe(child);
+            panic!(
+                "watch probe exited {status} before writing {needle:?}; stderr: {:?}",
+                std::fs::read_to_string(stderr).ok()
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    finish_watch_probe(child);
+    panic!(
+        "watch probe never wrote {needle:?}; last snapshot: {:?}; stderr: {:?}",
+        std::fs::read_to_string(path).ok(),
+        std::fs::read_to_string(stderr).ok()
+    );
+}
+
+fn node_supports_watch_env_files() -> bool {
+    target_node_version() >= (20, 6, 0)
+}
+
+fn node_reloads_watched_env_files() -> bool {
+    target_node_version() >= (22, 0, 0)
+}
+
+/// The guard marker is internal cross-process state. If it is absent or corrupt,
+/// the preload must clear every known denied key and abort before user code can
+/// observe a raw env-file value.
+#[test]
+fn watch_env_guard_fails_closed_on_malformed_state() {
+    let guard = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../runtime/watch-env-guard.cjs");
+    let script = r#"
+      try {
+        require(process.argv[1]);
+        throw new Error('guard unexpectedly accepted malformed state');
+      } catch (error) {
+        const denied = ['NODE_OPTIONS','NODE_TLS_REJECT_UNAUTHORIZED','NODE_EXTRA_CA_CERTS','NODE_REPL_EXTERNAL_MODULE'];
+        const visible = Object.keys(process.env).filter((key) => denied.includes(key.toUpperCase()));
+        process.stdout.write(JSON.stringify({ code: error.code, visible, markerPresent: Object.hasOwn(process.env, '__NUB_WATCH_ENV_GUARD') }));
+      }
+    "#;
+    let mut cmd = Command::new("node");
+    cmd.args(["-e", script]).arg(guard);
+    remove_ambient_watch_control_vars(&mut cmd);
+    cmd.env("__NUB_WATCH_ENV_GUARD", "{not-json")
+        .env("NODE_OPTIONS", "--no-warnings")
+        .env("NODE_TLS_REJECT_UNAUTHORIZED", "0")
+        .env("NODE_EXTRA_CA_CERTS", "/file-derived-ca.pem")
+        .env("NODE_REPL_EXTERNAL_MODULE", "./file-derived-repl.cjs");
+    let output = cmd.output().expect("run malformed watch env guard probe");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["code"], "ERR_NUB_WATCH_ENV_GUARD", "{value}");
+    assert_eq!(value["visible"], serde_json::json!([]), "{value}");
+    assert_eq!(value["markerPresent"], false, "{value}");
+}
+
+/// Missing marker state on the main thread is not a compat-worker re-entry. It
+/// must clear every denied key and abort before user code can observe a value.
+#[test]
+fn watch_env_guard_missing_main_state_clears_denied_and_aborts() {
+    let guard = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../runtime/watch-env-guard.cjs");
+    let script = r#"
+      try {
+        require(process.argv[1]);
+        throw new Error('guard unexpectedly accepted missing main-thread state');
+      } catch (error) {
+        const denied = ['NODE_OPTIONS','NODE_TLS_REJECT_UNAUTHORIZED','NODE_EXTRA_CA_CERTS','NODE_REPL_EXTERNAL_MODULE'];
+        const visible = Object.keys(process.env).filter((key) => denied.includes(key.toUpperCase()));
+        process.stdout.write(JSON.stringify({ code: error.code, visible, markerPresent: Object.hasOwn(process.env, '__NUB_WATCH_ENV_GUARD') }));
+      }
+    "#;
+    let mut cmd = Command::new("node");
+    cmd.args(["-e", script]).arg(guard);
+    remove_ambient_watch_control_vars(&mut cmd);
+    cmd.env("NODE_OPTIONS", "--no-warnings")
+        .env("NODE_TLS_REJECT_UNAUTHORIZED", "0")
+        .env("NODE_EXTRA_CA_CERTS", "/file-derived-ca.pem")
+        .env("NODE_REPL_EXTERNAL_MODULE", "./file-derived-repl.cjs");
+    let output = cmd.output().expect("run missing watch env guard probe");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["code"], "ERR_NUB_WATCH_ENV_GUARD", "{value}");
+    assert_eq!(value["visible"], serde_json::json!([]), "{value}");
+    assert_eq!(value["markerPresent"], false, "{value}");
+}
+
+/// An ordinary Worker can also re-run the guard off the main thread. With no
+/// marker, it must preserve the already-sanitized ambient environment.
+#[test]
+fn watch_env_guard_non_main_reentry_preserves_sanitized_ambient() {
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let guard = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../runtime/watch-env-guard.cjs");
+    let worker = dir.join("worker.cjs");
+    std::fs::write(
+        &worker,
+        "const { parentPort } = require('node:worker_threads');\n\
+         parentPort.postMessage({\n\
+           nodeOptions: process.env.NODE_OPTIONS,\n\
+           tls: process.env.NODE_TLS_REJECT_UNAUTHORIZED,\n\
+           ca: process.env.NODE_EXTRA_CA_CERTS,\n\
+           repl: process.env.NODE_REPL_EXTERNAL_MODULE,\n\
+           markerPresent: Object.hasOwn(process.env, '__NUB_WATCH_ENV_GUARD')\n\
+         });\n",
+    )
+    .unwrap();
+    let script = r#"
+      const { Worker } = require('node:worker_threads');
+      const worker = new Worker(process.argv[1], { execArgv: ['--require', process.argv[2]] });
+      worker.once('message', (value) => process.stdout.write(JSON.stringify(value)));
+      worker.once('error', (error) => { throw error; });
+    "#;
+    let mut cmd = Command::new("node");
+    cmd.args(["-e", script]).arg(&worker).arg(&guard);
+    remove_ambient_watch_control_vars(&mut cmd);
+    cmd.env("NODE_OPTIONS", "--no-warnings")
+        .env("NODE_TLS_REJECT_UNAUTHORIZED", "1")
+        .env("NODE_EXTRA_CA_CERTS", "/ambient-ca.pem")
+        .env("NODE_REPL_EXTERNAL_MODULE", "./ambient-repl.cjs");
+    let output = cmd.output().expect("run Worker watch env guard probe");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["nodeOptions"], "--no-warnings", "{value}");
+    assert_eq!(value["tls"], "1", "{value}");
+    assert_eq!(value["ca"], "/ambient-ca.pem", "{value}");
+    assert_eq!(value["repl"], "./ambient-repl.cjs", "{value}");
+    assert_eq!(value["markerPresent"], false, "{value}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// On the compat tier, `module.register()` creates a loader worker that re-runs
+/// NODE_OPTIONS preloads after the main guard consumed its marker. Both the next
+/// user preload and the loader hook must observe the restored ambient values.
+#[test]
+fn watch_env_guard_compat_loader_worker_preserves_ambient() {
+    if !node_at_least((20, 6, 0)) || node_at_least((22, 15, 0)) {
+        eprintln!("skipping: target Node is outside the compat loader-worker tier");
+        return;
+    }
+
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let guard = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../runtime/watch-env-guard.cjs");
+    let user_snapshot = dir.join("user-preload.json");
+    let loader_snapshot = dir.join("loader.json");
+    std::fs::write(
+        dir.join("user-preload.cjs"),
+        format!(
+            "if (!require('node:worker_threads').isMainThread) {{\n\
+               require('fs').writeFileSync({path:?}, JSON.stringify({{\n\
+                 nodeOptions: process.env.NODE_OPTIONS,\n\
+                 tls: process.env.NODE_TLS_REJECT_UNAUTHORIZED,\n\
+                 ca: process.env.NODE_EXTRA_CA_CERTS,\n\
+                 repl: process.env.NODE_REPL_EXTERNAL_MODULE,\n\
+                 markerPresent: Object.hasOwn(process.env, '__NUB_WATCH_ENV_GUARD')\n\
+               }}));\n\
+             }}\n",
+            path = user_snapshot.to_string_lossy()
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("loader.mjs"),
+        format!(
+            "import fs from 'node:fs';\n\
+             fs.writeFileSync({path:?}, JSON.stringify({{\n\
+               nodeOptions: process.env.NODE_OPTIONS,\n\
+               tls: process.env.NODE_TLS_REJECT_UNAUTHORIZED,\n\
+               ca: process.env.NODE_EXTRA_CA_CERTS,\n\
+               repl: process.env.NODE_REPL_EXTERNAL_MODULE,\n\
+               markerPresent: Object.hasOwn(process.env, '__NUB_WATCH_ENV_GUARD')\n\
+             }}));\n\
+             export async function resolve(specifier, context, nextResolve) {{\n\
+               return nextResolve(specifier, context);\n\
+             }}\n",
+            path = loader_snapshot.to_string_lossy()
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("bootstrap.mjs"),
+        "import { register } from 'node:module';\n\
+         register('./loader.mjs', import.meta.url);\n",
+    )
+    .unwrap();
+    std::fs::write(dir.join("entry.cjs"), "// loader probe entry\n").unwrap();
+
+    let ambient_node_options = format!("--require={}", dir.join("user-preload.cjs").display());
+    let effective_node_options = format!("--require={} {ambient_node_options}", guard.display());
+    let state = serde_json::json!({
+        "denylist": nub_core::workspace::env::denied_env_file_keys(),
+        "ambientKeys": nub_core::workspace::env::denied_env_file_keys(),
+        "nodeOptions": ambient_node_options,
+    });
+    let mut cmd = Command::new("node");
+    cmd.args(["--import", "./bootstrap.mjs", "entry.cjs"])
+        .current_dir(&dir);
+    remove_ambient_watch_control_vars(&mut cmd);
+    cmd.env(
+        "__NUB_WATCH_ENV_GUARD",
+        serde_json::to_string(&state).unwrap(),
+    )
+    .env("NODE_OPTIONS", effective_node_options)
+    .env("NODE_TLS_REJECT_UNAUTHORIZED", "1")
+    .env("NODE_EXTRA_CA_CERTS", "/ambient-ca.pem")
+    .env("NODE_REPL_EXTERNAL_MODULE", "./ambient-repl.cjs");
+    let output = cmd.output().expect("run compat loader-worker guard probe");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for (label, path) in [
+        ("user preload", &user_snapshot),
+        ("loader hook", &loader_snapshot),
+    ] {
+        let value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        assert_eq!(
+            value["nodeOptions"], ambient_node_options,
+            "{label}: {value}"
+        );
+        assert_eq!(value["tls"], "1", "{label}: {value}");
+        assert_eq!(value["ca"], "/ambient-ca.pem", "{label}: {value}");
+        assert_eq!(value["repl"], "./ambient-repl.cjs", "{label}: {value}");
+        assert_eq!(value["markerPresent"], false, "{label}: {value}");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Raw auto-discovered env files are re-read on every Node watch restart. A
+/// runtime-control key added after Nub starts must stay filtered for the whole
+/// watcher lifetime, while an ordinary sibling still live-reloads.
+#[test]
+fn watch_filters_late_runtime_control_env_keys_but_reloads_ordinary_vars() {
+    if !node_reloads_watched_env_files() {
+        eprintln!("skipping: target Node does not restart on --env-file edits");
+        return;
+    }
+
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"watch-env-filter"}"#).unwrap();
+    std::fs::write(dir.join(".env"), "ORDINARY=one\n").unwrap();
+    let snapshots = dir.join("snapshots.ndjson");
+    let stderr = dir.join("stderr.txt");
+    let attacker = dir.join("attacker-ran.txt");
+    std::fs::write(
+        dir.join("attacker.cjs"),
+        format!(
+            "require('fs').appendFileSync({path:?}, 'ran\\n');\n",
+            path = attacker.to_string_lossy()
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("probe.cjs"),
+        format!(
+            "const fs = require('fs');\n\
+             const denied = ['NODE_OPTIONS','NODE_TLS_REJECT_UNAUTHORIZED','NODE_EXTRA_CA_CERTS','NODE_REPL_EXTERNAL_MODULE'];\n\
+             const visible = Object.keys(process.env).filter((key) => denied.includes(key.toUpperCase()));\n\
+             const snapshot = {{ ordinary: process.env.ORDINARY, denied: visible, markerPresent: Object.hasOwn(process.env, '__NUB_WATCH_ENV_GUARD') }};\n\
+             fs.appendFileSync({path:?}, JSON.stringify(snapshot) + '\\n');\n",
+            path = snapshots.to_string_lossy()
+        ),
+    )
+    .unwrap();
+
+    let stderr_file = std::fs::File::create(&stderr).unwrap();
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(["--watch", "probe.cjs"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", dir.join("cache"))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::from(stderr_file));
+    remove_ambient_watch_control_vars(&mut cmd);
+    let mut child = spawn_watch_probe(&mut cmd);
+
+    let first = wait_for_watch_snapshot(&snapshots, r#""ordinary":"one""#, &mut child, &stderr);
+    assert!(first.contains(r#""denied":[]"#), "first child: {first}");
+    assert!(
+        first.contains(r#""markerPresent":false"#),
+        "first child: {first}"
+    );
+
+    std::fs::write(
+        dir.join(".env"),
+        "NODE_OPTIONS=--require ./attacker.cjs\n\
+         NODE_TLS_REJECT_UNAUTHORIZED=0\n\
+         NODE_EXTRA_CA_CERTS=/definitely/not/a/ca.pem\n\
+         node_repl_external_module=./attacker.cjs\n\
+         ORDINARY=two\n",
+    )
+    .unwrap();
+    let snapshots_text =
+        wait_for_watch_snapshot(&snapshots, r#""ordinary":"two""#, &mut child, &stderr);
+    finish_watch_probe(&mut child);
+
+    for line in snapshots_text.lines() {
+        assert!(line.contains(r#""denied":[]"#), "snapshot: {line}");
+        assert!(
+            line.contains(r#""markerPresent":false"#),
+            "snapshot: {line}"
+        );
+    }
+    assert!(
+        !attacker.exists(),
+        "file-sourced NODE_OPTIONS preload must never execute"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Ambient runtime-control values remain shell-wins. The cleanup preload must run
+/// before the user's ambient preload and restore the sanitized NODE_OPTIONS text
+/// rather than exposing Nub's temporary guard token.
+#[test]
+fn watch_preserves_ambient_runtime_control_env_values() {
+    if !node_supports_watch_env_files() {
+        eprintln!("skipping: target Node predates --env-file support");
+        return;
+    }
+
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"watch-env-ambient"}"#).unwrap();
+    std::fs::write(
+        dir.join(".env"),
+        "NODE_OPTIONS=--require ./attacker.cjs\n\
+         NODE_TLS_REJECT_UNAUTHORIZED=0\n\
+         NODE_EXTRA_CA_CERTS=/file-ca.pem\n\
+         NODE_REPL_EXTERNAL_MODULE=./file-repl.cjs\n",
+    )
+    .unwrap();
+    let preload_snapshot = dir.join("preload.json");
+    let entry_snapshot = dir.join("entry.json");
+    let stderr = dir.join("stderr.txt");
+    let attacker = dir.join("attacker-ran.txt");
+    std::fs::write(
+        dir.join("attacker.cjs"),
+        format!(
+            "require('fs').writeFileSync({path:?}, 'ran');\n",
+            path = attacker.to_string_lossy()
+        ),
+    )
+    .unwrap();
+    let snapshot_source = |path: &Path| {
+        format!(
+            "require('fs').writeFileSync({path:?}, JSON.stringify({{\n\
+               nodeOptions: process.env.NODE_OPTIONS,\n\
+               tls: process.env.NODE_TLS_REJECT_UNAUTHORIZED,\n\
+               ca: process.env.NODE_EXTRA_CA_CERTS,\n\
+               repl: process.env.NODE_REPL_EXTERNAL_MODULE,\n\
+               commonPreloaded: Object.keys(require.cache).some((key) => key.endsWith('preload-common.cjs')),\n\
+               markerPresent: Object.hasOwn(process.env, '__NUB_WATCH_ENV_GUARD')\n\
+             }}));\n",
+            path = path.to_string_lossy()
+        )
+    };
+    std::fs::write(
+        dir.join("user-preload.cjs"),
+        snapshot_source(&preload_snapshot),
+    )
+    .unwrap();
+    std::fs::write(dir.join("probe.cjs"), snapshot_source(&entry_snapshot)).unwrap();
+    // Resolve through the watch supervisor's cwd so the preload and env file
+    // share one directory spelling in Node's Windows watcher.
+    let node_options = "--require=./user-preload.cjs".to_string();
+
+    let stderr_file = std::fs::File::create(&stderr).unwrap();
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(["--watch", "probe.cjs"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", dir.join("cache"))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::from(stderr_file));
+    remove_ambient_watch_control_vars(&mut cmd);
+    cmd.env("NODE_OPTIONS", &node_options)
+        .env("NODE_TLS_REJECT_UNAUTHORIZED", "1")
+        .env("NODE_EXTRA_CA_CERTS", "/ambient-ca.pem")
+        .env("NODE_REPL_EXTERNAL_MODULE", "./ambient-repl.cjs");
+    let mut child = spawn_watch_probe(&mut cmd);
+
+    wait_for_watch_snapshot(&entry_snapshot, "nodeOptions", &mut child, &stderr);
+    finish_watch_probe(&mut child);
+    for (label, path) in [
+        ("user preload", &preload_snapshot),
+        ("entry", &entry_snapshot),
+    ] {
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(value["nodeOptions"], node_options, "{label}: {value}");
+        assert_eq!(value["tls"], "1", "{label}: {value}");
+        assert_eq!(value["ca"], "/ambient-ca.pem", "{label}: {value}");
+        assert_eq!(value["repl"], "./ambient-repl.cjs", "{label}: {value}");
+        assert_eq!(
+            value["commonPreloaded"],
+            label == "entry",
+            "{label}: {value}"
+        );
+        assert_eq!(value["markerPresent"], false, "{label}: {value}");
+    }
+    assert!(!attacker.exists(), "file NODE_OPTIONS must lose to ambient");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Auto-discovered watch env files are passed relative to the watcher's cwd.
+/// This is required by Node 20.11 on Linux, which rejects an existing absolute
+/// `--env-file` path. Cover the ancestor-project case where the relative path
+/// must traverse upward rather than being the simple root-level `.env` form.
+#[test]
+fn watch_loads_auto_env_file_from_ancestor_project_root() {
+    if !node_supports_watch_env_files() {
+        eprintln!("skipping: target Node predates --env-file support");
+        return;
+    }
+
+    let root = unique_test_cache();
+    let member = root.join("packages").join("app");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&member).unwrap();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"watch-env-ancestor"}"#,
+    )
+    .unwrap();
+    std::fs::write(root.join(".env"), "FROM_ROOT=from-root\n").unwrap();
+    let snapshot = member.join("snapshot.txt");
+    let stderr = member.join("stderr.txt");
+    std::fs::write(
+        member.join("probe.cjs"),
+        format!(
+            "require('fs').writeFileSync({path:?}, process.env.FROM_ROOT || 'missing');\n",
+            path = snapshot.to_string_lossy()
+        ),
+    )
+    .unwrap();
+
+    let stderr_file = std::fs::File::create(&stderr).unwrap();
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(["--watch", "probe.cjs"])
+        .current_dir(&member)
+        .env("XDG_CACHE_HOME", root.join("cache"))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::from(stderr_file));
+    remove_ambient_watch_control_vars(&mut cmd);
+    let mut child = spawn_watch_probe(&mut cmd);
+
+    let snapshot_text = wait_for_watch_snapshot(&snapshot, "from-root", &mut child, &stderr);
+    finish_watch_probe(&mut child);
+    assert_eq!(snapshot_text, "from-root");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Unix permits a mixed-case ambient key alongside the canonical spelling Node
+/// consumes at startup. The mixed-case value must survive, while a canonical raw
+/// env-file value is occupied in the supervisor and then removed in the child.
+#[cfg(unix)]
+#[test]
+fn watch_mixed_case_ambient_key_does_not_unblock_canonical_env_file_key() {
+    if !node_supports_watch_env_files() {
+        eprintln!("skipping: target Node predates --env-file support");
+        return;
+    }
+
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"watch-env-case"}"#).unwrap();
+    let invalid_ca = dir.join("file-derived-invalid-ca.pem");
+    std::fs::write(
+        dir.join(".env"),
+        format!("NODE_EXTRA_CA_CERTS={}\n", invalid_ca.display()),
+    )
+    .unwrap();
+    let snapshot = dir.join("snapshot.json");
+    let stderr = dir.join("stderr.txt");
+    std::fs::write(
+        dir.join("probe.cjs"),
+        format!(
+            "const denied = Object.fromEntries(Object.keys(process.env)\n\
+               .filter((key) => key.toUpperCase() === 'NODE_EXTRA_CA_CERTS')\n\
+               .map((key) => [key, process.env[key]]));\n\
+             require('fs').writeFileSync({path:?}, JSON.stringify({{ denied, lookalike: process.env['NODE_OPTION\\u017f'], markerPresent: Object.hasOwn(process.env, '__NUB_WATCH_ENV_GUARD') }}));\n\
+             process.kill(process.ppid, 'SIGTERM');\n",
+            path = snapshot.to_string_lossy()
+        ),
+    )
+    .unwrap();
+
+    let stderr_file = std::fs::File::create(&stderr).unwrap();
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(["--watch", "probe.cjs"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", dir.join("cache"))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::from(stderr_file));
+    remove_ambient_watch_control_vars(&mut cmd);
+    cmd.env("node_extra_ca_certs", "ambient-lower")
+        .env("NODE_OPTION\u{017f}", "ordinary-unicode");
+    let mut child = spawn_watch_probe(&mut cmd);
+
+    let snapshot_text = wait_for_watch_snapshot(&snapshot, "ambient-lower", &mut child, &stderr);
+    finish_watch_probe(&mut child);
+    let value: serde_json::Value = serde_json::from_str(&snapshot_text).unwrap();
+    assert_eq!(value["denied"]["node_extra_ca_certs"], "ambient-lower");
+    assert!(
+        value["denied"].get("NODE_EXTRA_CA_CERTS").is_none(),
+        "canonical file key must be absent: {value}"
+    );
+    assert_eq!(value["lookalike"], "ordinary-unicode");
+    assert_eq!(value["markerPresent"], false);
+    let stderr_text = std::fs::read_to_string(&stderr).unwrap();
+    assert!(
+        !stderr_text.contains(invalid_ca.to_string_lossy().as_ref()),
+        "Node consumed the canonical file-derived CA before cleanup: {stderr_text}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The cleanup marker is JSON and Node exposes environment values as strings, so
+/// a non-UTF-8 ambient NODE_OPTIONS value cannot be restored losslessly. Refuse
+/// the guarded raw-file path instead of silently replacing the shell value.
+#[cfg(unix)]
+#[test]
+fn watch_env_guard_rejects_non_utf8_ambient_node_options() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"watch-env-bytes"}"#).unwrap();
+    std::fs::write(dir.join(".env"), "ORDINARY=one\n").unwrap();
+    std::fs::write(dir.join("probe.cjs"), "throw new Error('must not run');\n").unwrap();
+
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(["--watch", "probe.cjs"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", dir.join("cache"));
+    remove_ambient_watch_control_vars(&mut cmd);
+    cmd.env(
+        "NODE_OPTIONS",
+        std::ffi::OsString::from_vec(vec![b'-', b'-', 0xff]),
+    );
+    let output = cmd.output().expect("run nub watch preflight");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("watch env-file filtering requires NODE_OPTIONS to be valid UTF-8"),
+        "stderr: {stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// `--no-env-file` on the watch path: the `.env*` files are neither handed to the
 /// watched Node as `--env-file` args nor injected via `Command::env`, so the child
 /// sees none of them. The watch loop never exits on its own, so the probe writes

--- a/crates/nub-core/build.rs
+++ b/crates/nub-core/build.rs
@@ -113,12 +113,13 @@ fn main() {
     // BLAKE3 — see the runtime dep note. Hashing the STAGED file is equivalent to
     // hashing the EXTRACTED file (tar is byte-exact), which the
     // `embedded_blob_verifies_clean` test confirms end-to-end against the real blob.
-    // All three are required (fail loud): release.yml always stages the real addon,
+    // All four are required (fail loud): release.yml always stages the real addon,
     // and the addon-less ubuntu `embed-runtime` PR job stages a placeholder — so a
     // release can never silently ship an unhashed entrypoint.
     for (rel, var) in [
         ("preload.mjs", "NUB_RUNTIME_HASH_PRELOAD_MJS"),
         ("preload.cjs", "NUB_RUNTIME_HASH_PRELOAD_CJS"),
+        ("watch-env-guard.cjs", "NUB_RUNTIME_HASH_WATCH_ENV_GUARD"),
         ("addons/nub-native.node", "NUB_RUNTIME_HASH_ADDON"),
     ] {
         let p = staging.join(rel);

--- a/crates/nub-core/src/node/runtime_cache.rs
+++ b/crates/nub-core/src/node/runtime_cache.rs
@@ -28,8 +28,9 @@
 //!   there is no shared-temp planted-dir class; the unix stat checks are skipped.
 //!
 //! - **R2 — verify the loaded code against a baked-in hash (integrity backstop).**
-//!   `build.rs` bakes the BLAKE3 digest of the three directly-loaded entrypoints
-//!   (`preload.mjs`, `preload.cjs`, `addons/nub-native.node`) into the binary. On
+//!   `build.rs` bakes the BLAKE3 digest of the four directly-loaded entrypoints
+//!   (`preload.mjs`, `preload.cjs`, `watch-env-guard.cjs`, and
+//!   `addons/nub-native.node`) into the binary. On
 //!   the load path (once per process, inside the OnceLock init, ~6 ms for the ~9 MB
 //!   addon on aarch64 — BLAKE3 over software SHA-256's ~28 ms there) the EXTRACTED
 //!   entrypoints are re-hashed against those consts. On mismatch we
@@ -66,17 +67,19 @@ const CACHE_KEY: &str = env!("NUB_RUNTIME_CACHE_KEY");
 /// (signed) binary so a tampered on-disk file can't swap its own hash alongside it.
 const HASH_PRELOAD_MJS: &str = env!("NUB_RUNTIME_HASH_PRELOAD_MJS");
 const HASH_PRELOAD_CJS: &str = env!("NUB_RUNTIME_HASH_PRELOAD_CJS");
+const HASH_WATCH_ENV_GUARD: &str = env!("NUB_RUNTIME_HASH_WATCH_ENV_GUARD");
 const HASH_ADDON: &str = env!("NUB_RUNTIME_HASH_ADDON");
 
-/// The three directly-loaded entrypoints and their baked digests. The native addon
-/// (`dlopen`'d) and the preload scripts (`--require`d) are the actual code-load
+/// The four directly-loaded entrypoints and their baked digests. The native addon
+/// (`dlopen`'d) and the preload scripts (`--require`d/`--import`ed) are the actual code-load
 /// surface; the vendored `node_modules` polyfills are intentionally OUT of the
 /// per-load hash (R1's 0700 owner-only base already closes their planted-file
 /// vector, and hashing the whole ~13 MB tree every run would be a real regression
 /// for a fast script runner — the entrypoints keep the cost ~1-2 ms).
-const VERIFIED_ENTRYPOINTS: [(&str, &str); 3] = [
+const VERIFIED_ENTRYPOINTS: [(&str, &str); 4] = [
     ("preload.mjs", HASH_PRELOAD_MJS),
     ("preload.cjs", HASH_PRELOAD_CJS),
+    ("watch-env-guard.cjs", HASH_WATCH_ENV_GUARD),
     ("addons/nub-native.node", HASH_ADDON),
 ];
 
@@ -355,7 +358,7 @@ fn file_blake3_hex(path: &Path) -> Option<String> {
     Some(blake3::hash(&bytes).to_hex().to_string())
 }
 
-/// Re-hash the extracted entrypoints in `dir` against the baked digests. All three
+/// Re-hash the extracted entrypoints in `dir` against the baked digests. All four
 /// must read AND match. ~6 ms (entrypoints only, addon-dominated), paid at most once
 /// per process (the caller runs inside the `EXTRACTED` OnceLock init).
 fn verify_entrypoints(dir: &Path) -> bool {
@@ -699,7 +702,7 @@ mod tests {
 
     #[test]
     fn tampered_entrypoint_is_detected_and_self_healed() {
-        // A WARM cache whose addon was swapped (planted / AV-corrupted) must be
+        // A WARM cache whose watch guard was swapped (planted / AV-corrupted) must be
         // detected and self-healed: re-extract the trusted in-binary blob over it,
         // restoring the verified bytes — never bricked, never silently loaded.
         let base = tmp_base("nub-rtc-heal");
@@ -711,7 +714,7 @@ mod tests {
             "fresh real-blob extraction verifies"
         );
 
-        fs::write(target.join("addons/nub-native.node"), b"malicious").unwrap();
+        fs::write(target.join("watch-env-guard.cjs"), b"malicious").unwrap();
         assert!(!verify_entrypoints(&target), "tamper must be detected");
 
         let healed = verify_or_heal(&base, &target, false).expect("self-heal returns the dir");

--- a/crates/nub-core/src/workspace/env.rs
+++ b/crates/nub-core/src/workspace/env.rs
@@ -37,6 +37,15 @@ const ENV_FILE_DENYLIST: &[&str] = &[
     "NODE_REPL_EXTERNAL_MODULE",
 ];
 
+/// The runtime-control keys Nub refuses to source from env files.
+///
+/// The watch launcher uses this same canonical set to guard Node's raw
+/// `--env-file` path at the process boundary. Keep the policy defined here so
+/// parsed-map filtering and raw-file delegation cannot drift.
+pub fn denied_env_file_keys() -> &'static [&'static str] {
+    ENV_FILE_DENYLIST
+}
+
 /// Whether `key` is a denylisted runtime-control variable nub ignores from a
 /// `.env*` / `--env-file` source. ASCII case-insensitive — environment variable
 /// lookups are case-insensitive on Windows, so a lowercased spelling must not slip
@@ -242,12 +251,11 @@ pub fn load_env_files_raw(project_root: &Path) -> HashMap<String, String> {
 /// The raw loader, additionally reporting (1) whether a `.env` FILE declared
 /// `NODE_ENV` (always dropped — dotenv/@next/env/Vite parity, #263) and (2) which
 /// denylisted runtime-control keys were dropped ([`ENV_FILE_DENYLIST`]). Both
-/// drops happen HERE at load, so every consumer of the returned map —
-/// [`load_env_files`] (direct run/file injection) and [`load_env_files_raw`]
-/// (watch injection) — is covered by construction; a denylisted key can never
-/// enter the map that flows to a spawned child. The reports are consumed by
-/// [`load_env_files`] to warn; the plain [`load_env_files_raw`] wrapper discards
-/// them (the watch path defers the corresponding warnings to avoid false claims).
+/// drops happen HERE at load, so every consumer of the returned map is covered by
+/// construction. The reports are consumed by [`load_env_files`] to warn. The
+/// plain [`load_env_files_raw`] wrapper discards them because watch separately
+/// delegates the raw files to Node; that spawn boundary installs a stable guard
+/// for this same denylist before handing Node the paths.
 fn load_env_files_raw_reporting(
     project_root: &Path,
 ) -> (HashMap<String, String>, bool, Vec<String>) {
@@ -331,8 +339,8 @@ pub fn load_env_files(project_root: &Path) -> HashMap<String, String> {
     // Warn only here — this map is injected straight into the child via
     // `Command::env`, so a dropped `.env` `NODE_ENV` / denylisted var truly never
     // reaches it. The watch path (plain `load_env_files_raw`) hands the files to
-    // Node's `--env-file` instead, so nub isn't the one ignoring them there and must
-    // not claim to.
+    // Node's `--env-file` behind a per-restart process guard, but avoids repeating
+    // this load-time warning for a long-lived watcher.
     if node_env_ignored {
         warn_node_env_from_dotenv_ignored();
     }
@@ -976,10 +984,10 @@ mod tests {
 
     /// Env hygiene (Deno parity): a `.env` FILE must never inject a runtime-control
     /// var ([`ENV_FILE_DENYLIST`]) — those configure Node's own start-up, not the
-    /// user's program. `NODE_OPTIONS` is the load-bearing case and
-    /// `NODE_TLS_REJECT_UNAUTHORIZED` confirms the case-insensitive match; benign
-    /// siblings must still load. The strip runs in the shared per-file loop, so
-    /// `.env` coverage exercises it for every `.env*` file — mode-file SELECTION is a
+    /// user's program. Every canonical key is exercised directly, with one
+    /// mixed-case spelling to lock the case-insensitive match; benign siblings
+    /// must still load. The strip runs in the shared per-file loop, so `.env`
+    /// coverage exercises it for every `.env*` file — mode-file SELECTION is a
     /// separate concern (tested by `env_file_names*`) and needs no ambient env here.
     #[test]
     fn denylisted_runtime_control_vars_never_injected() {
@@ -988,21 +996,21 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             dir.join(".env"),
-            "NODE_OPTIONS=--require ./x.js\nnode_tls_reject_unauthorized=0\nAPP_KEY=safe\n",
+            "NODE_OPTIONS=--require ./x.js\n\
+             node_tls_reject_unauthorized=0\n\
+             NODE_EXTRA_CA_CERTS=/x.pem\n\
+             NODE_REPL_EXTERNAL_MODULE=./repl.js\n\
+             APP_KEY=safe\n",
         )
         .unwrap();
 
         let base = load_env_files(&dir);
-        assert!(
-            !base.contains_key("NODE_OPTIONS"),
-            "a `.env` NODE_OPTIONS must not reach the child; got {base:?}"
-        );
-        assert!(
-            !base
-                .keys()
-                .any(|k| k.eq_ignore_ascii_case("NODE_TLS_REJECT_UNAUTHORIZED")),
-            "a `.env` NODE_TLS_REJECT_UNAUTHORIZED must be dropped case-insensitively; got {base:?}"
-        );
+        for denied in denied_env_file_keys() {
+            assert!(
+                !base.keys().any(|key| key.eq_ignore_ascii_case(denied)),
+                "a `.env` {denied} must not reach the child; got {base:?}"
+            );
+        }
         assert_eq!(
             base.get("APP_KEY").map(String::as_str),
             Some("safe"),

--- a/runtime/watch-env-guard.cjs
+++ b/runtime/watch-env-guard.cjs
@@ -1,0 +1,75 @@
+// Node's watch supervisor skips preload modules and spawns each restarted child
+// from its unchanged environment. Each child has already parsed the raw
+// `--env-file` values when this first `NODE_OPTIONS` preload runs. Remove
+// file-derived runtime-control spellings and restore the ambient values before
+// any user preload or entry module can observe them. This stays separate from
+// Nub's full preload so user/PnP preloads still patch the runtime before Nub
+// captures any built-in functions.
+
+const WATCH_ENV_GUARD = "__NUB_WATCH_ENV_GUARD";
+const { isMainThread } = require("node:worker_threads");
+const FALLBACK_DENYLIST = [
+  "NODE_OPTIONS",
+  "NODE_TLS_REJECT_UNAUTHORIZED",
+  "NODE_EXTRA_CA_CERTS",
+  "NODE_REPL_EXTERNAL_MODULE",
+];
+const asciiUpper = (value) => value.replace(
+  /[a-z]/g,
+  (character) => String.fromCharCode(character.charCodeAt(0) - 32),
+);
+const clearDenied = (denylist, ambientKeys = []) => {
+  const denied = new Set(denylist.map(asciiUpper));
+  const ambientKey = process.platform === "win32"
+    ? asciiUpper
+    : (key) => key;
+  const ambient = new Set(ambientKeys.map(ambientKey));
+  for (const key of Object.keys(process.env)) {
+    if (denied.has(asciiUpper(key)) && !ambient.has(ambientKey(key))) {
+      delete process.env[key];
+    }
+  }
+};
+
+const watchEnvGuardRaw = process.env[WATCH_ENV_GUARD];
+delete process.env[WATCH_ENV_GUARD];
+
+try {
+  const state = JSON.parse(watchEnvGuardRaw);
+  if (
+    !state ||
+    !Array.isArray(state.denylist) ||
+    !state.denylist.every((key) => typeof key === "string") ||
+    !Array.isArray(state.ambientKeys) ||
+    !state.ambientKeys.every((key) => typeof key === "string") ||
+    (state.nodeOptions !== null && typeof state.nodeOptions !== "string")
+  ) {
+    throw new TypeError("invalid watch env guard state");
+  }
+  const denied = new Set(state.denylist.map(asciiUpper));
+  if (!FALLBACK_DENYLIST.every((key) => denied.has(key))) {
+    throw new TypeError("incomplete watch env guard denylist");
+  }
+  clearDenied(state.denylist, state.ambientKeys);
+  if (typeof state.nodeOptions === "string") {
+    process.env.NODE_OPTIONS = state.nodeOptions;
+  } else {
+    delete process.env.NODE_OPTIONS;
+  }
+} catch (cause) {
+  // Compat-tier `--import` creates a loader worker that re-runs NODE_OPTIONS
+  // preloads after the main child consumed this marker. Missing state is that
+  // legitimate re-entry only off the main thread, where the inherited env was
+  // already sanitized. Preserve its ambient values. Missing main-thread state
+  // or any present-but-invalid state is corruption: clear and abort before user
+  // preloads or the entry module can observe an unfiltered value.
+  if (watchEnvGuardRaw === undefined && !isMainThread) {
+    // The main child already removed file-derived values and restored ambient.
+  } else {
+    clearDenied(FALLBACK_DENYLIST);
+    const detail = watchEnvGuardRaw === undefined ? "missing" : "invalid";
+    const error = new Error(`Nub watch env-file guard state is ${detail}`, { cause });
+    error.code = "ERR_NUB_WATCH_ENV_GUARD";
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

- keep env-file runtime-control keys filtered across Node watch restarts
- preserve ambient runtime values and user/PnP preload ordering
- fail closed on invalid guard state and verify the guard in the embedded runtime

## Verification

- focused watch and runtime-cache tests
- scoped nub-cli/nub-core clippy with all targets and features
- built-binary watch fixture covering late env-file edits
- direct malformed-state guard probes