### PR TITLE
build: set nub-native Rust 1.95 floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,10 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo check --all-targets
       - run: cargo check --manifest-path crates/nub-phantom/Cargo.toml --all-targets
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # 1.95.0
+        with:
+          toolchain: 1.95.0
+      - run: cd crates/nub-native && cargo check --locked --all-targets --all-features
       # Real Windows compile + test coverage is the windows-latest leg of the
       # `test` job. The previous fast `x86_64-pc-windows-gnu` cross-check needed
       # mingw-w64 + ring's C build, which was fragile on the runner; the native

--- a/crates/nub-native/Cargo.toml
+++ b/crates/nub-native/Cargo.toml
@@ -31,7 +31,7 @@ resolver = "3"
 [workspace.package]
 version = "0.4.11"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.95"
 license = "MIT"
 repository = "https://github.com/nubjs/nub"
 

--- a/crates/nub-native/src/lib.rs
+++ b/crates/nub-native/src/lib.rs
@@ -6,9 +6,9 @@
 //! function transpiles TS/JSX, mirroring `oxc-transform@0.132.0`'s `transformSync`
 //! for byte-for-byte emit parity.
 
-// `collapsible_if` fires on nested `if let { if let }` once the workspace MSRV
-// (1.88) unlocks let-chain suggestions; collapsing every site is cosmetic churn
-// (and tsconfig.rs is a verbatim get-tsconfig mirror), so allow it.
+// `collapsible_if` fires on intentional nested `if let { if let }` sites;
+// collapsing every site is cosmetic churn (and tsconfig.rs is a verbatim
+// get-tsconfig mirror), so allow it.
 #![allow(clippy::collapsible_if)]
 
 mod cache;


### PR DESCRIPTION
## Summary

- declare Rust 1.95 for the standalone `nub-native` workspace
- check `nub-native` under exact Rust 1.95 after the root and phantom Rust 1.93 checks
- remove the obsolete 1.88 reference from the Clippy allowance comment

## Verification

- Rust 1.93.0 and 1.94.1 reproduce E0658 in pinned `oxc_transformer` 0.132.0; Rust 1.95.0 passes
- `cargo +1.95.0 check --locked --all-targets --all-features`
- `cargo +1.95.0 clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 build --release --locked --all-features`
- `cargo +1.95.0 fmt --check`
- `actionlint .github/workflows/ci.yml`
