### PR TITLE
fix(import): run peer-context pass when importing bun/npm to pnpm-lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,6 +2667,7 @@ dependencies = [
  "aube-lockfile",
  "aube-manifest",
  "aube-registry",
+ "aube-resolver",
  "aube-scripts",
  "aube-settings",
  "aube-store",

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -40,6 +40,11 @@ aube-lockfile = { path = "../../vendor/aube/crates/aube-lockfile" }
 # materialization) via `aube_linker::set_disk_materialize_expand_hook`; a pure
 # library crate (no CLI/tokio surface), same lean-graph rationale as aube-lockfile.
 aube-linker = { path = "../../vendor/aube/crates/aube-linker" }
+# aube-resolver: `nub import` runs the peer-context pass (hoist_auto_installed_peers
+# + apply_peer_contexts) on a bun/npm-parsed graph before writing pnpm-lock, so the
+# imported lockfile carries peer suffixes the install path assumes pnpm-locks have
+# (#453). Pure offline graph transforms; a lean library crate already in the graph.
+aube-resolver = { path = "../../vendor/aube/crates/aube-resolver" }
 aube-manifest = { path = "../../vendor/aube/crates/aube-manifest" }
 # default-features = false drops aube's default set (`mimalloc`, `config-tui`),
 # neither of which nub uses: aube's `config-tui` (ratatui/crossterm) only feeds

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -816,7 +816,7 @@ fn import_to_pnpm_lock(force: bool) -> miette::Result<String> {
         }
     };
 
-    let (graph, kind) = match aube_lockfile::parse_for_import(&root, &manifest) {
+    let (mut graph, kind) = match aube_lockfile::parse_for_import(&root, &manifest) {
         Ok(pair) => pair,
         Err(aube_lockfile::Error::NotFound(_)) => {
             restore(&backup);
@@ -830,6 +830,48 @@ fn import_to_pnpm_lock(force: bool) -> miette::Result<String> {
             return Err(miette::Report::new(e)).wrap_err("failed to parse source lockfile");
         }
     };
+
+    // npm/bun lockfiles serialize a flat, pre-hoisted tree with no peer context.
+    // A pnpm-lock is expected to carry peer-context suffixes, and the install
+    // path deliberately skips its peer pass for pnpm incumbents on exactly that
+    // assumption (aube's `apply_lockfile_graph_platform_rules`). Writing a
+    // suffix-less pnpm-lock here violates that invariant: under the isolated
+    // store layout a peer-dependent package lands with no sibling peer link and
+    // dies at runtime with `Cannot find package` (#453). Re-establish the edges
+    // with the same pass the install path runs — `hoist_auto_installed_peers`
+    // then `apply_peer_contexts`, both pure offline graph transforms (no
+    // registry). `filter_graph` is intentionally omitted: an imported lockfile
+    // stays cross-platform, so no platform pruning. Yarn is excluded because
+    // real `yarn.lock` files don't record per-entry `peerDependencies`, so the
+    // pass would be a no-op without a packument fetch — a separate, deeper change.
+    //
+    // Uses pnpm's default peer options (import has no settings ctx here); those
+    // defaults match aube's own settings defaults, so a project without peer-knob
+    // overrides gets install-identical suffixes. A project that DOES override a
+    // knob (e.g. `dedupe-peers`) won't see it reflected in the import, but a later
+    // `nub install` reads this as a pnpm incumbent and skips its own peer pass, so
+    // the suffixes are consumed as-is — a fidelity gap, never a runtime break.
+    if matches!(
+        kind,
+        LockfileKind::Npm | LockfileKind::NpmShrinkwrap | LockfileKind::Bun
+    ) {
+        let (hoisted, auto_installed) = aube_resolver::hoist_auto_installed_peers(graph);
+        match aube_resolver::apply_peer_contexts(
+            hoisted,
+            &aube_resolver::PeerContextOptions::default(),
+        ) {
+            Ok(contextualized) => {
+                graph = contextualized;
+                aube_resolver::remove_auto_installed_peers(&mut graph, &auto_installed);
+            }
+            // Restore a moved-aside pnpm-lock like every other error path here;
+            // a bare `?` would orphan the user's original as `.import-backup`.
+            Err(e) => {
+                restore(&backup);
+                return Err(miette!("peer-context pass failed: {e}"));
+            }
+        }
+    }
 
     match aube_lockfile::write_lockfile_as(&root, &graph, &manifest, LockfileKind::Pnpm) {
         Ok(_) => {

--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -124,6 +124,37 @@ const IS_POSITIVE_PACKAGE_LOCK: &str = r#"{
 }
 "#;
 
+/// A minimal npm lockfile where `demo-plugin` declares a peer on `demo-host`,
+/// with both as direct deps. An organic pnpm-lock keys the plugin as
+/// `demo-plugin@1.0.0(demo-host@1.0.0)`; the #453 bug wrote a bare
+/// `demo-plugin@1.0.0`. `import` reads peer data straight from the lockfile —
+/// no registry — so synthetic package names exercise the pass fully offline.
+const PEER_DEP_PACKAGE_LOCK: &str = r#"{
+  "name": "fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fixture",
+      "version": "1.0.0",
+      "dependencies": { "demo-plugin": "1.0.0", "demo-host": "1.0.0" }
+    },
+    "node_modules/demo-host": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/demo-host/-/demo-host-1.0.0.tgz",
+      "integrity": "sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q=="
+    },
+    "node_modules/demo-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/demo-plugin/-/demo-plugin-1.0.0.tgz",
+      "integrity": "sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==",
+      "peerDependencies": { "demo-host": "^1.0.0" }
+    }
+  }
+}
+"#;
+
 /// `nub add` then `nub rm` (alias) round-trip on a truly-fresh project: add
 /// persists the dep + writes nub's neutral `nub.lock` + links node_modules;
 /// remove strips the dep from the manifest again. Both outputs brand-clean.
@@ -531,6 +562,35 @@ fn import_converts_package_lock_to_pnpm_lock() {
     );
     let forced = run_nub(&dir, &["import", "--force"]);
     assert_eq!(forced.code, 0, "stderr: {}", forced.stderr);
+}
+
+/// Regression for #453: importing a suffix-less source (npm/bun) must run the
+/// peer-context pass so the written pnpm-lock carries peer suffixes. The install
+/// path skips that pass for pnpm incumbents, assuming a pnpm-lock already has
+/// them; a bare `demo-plugin@1.0.0` would leave the store-resident plugin with
+/// no peer sibling under the isolated layout and fail at runtime with
+/// `Cannot find package 'demo-host'`.
+#[test]
+fn import_writes_peer_suffixes_for_suffixless_source() {
+    let dir = pm_tmpdir("import-peer");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"fixture","version":"1.0.0","dependencies":{"demo-plugin":"1.0.0","demo-host":"1.0.0"}}"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("package-lock.json"), PEER_DEP_PACKAGE_LOCK).unwrap();
+
+    let out = run_nub(&dir, &["import"]);
+    assert_eq!(
+        out.code, 0,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    let lock = std::fs::read_to_string(dir.join("pnpm-lock.yaml")).unwrap();
+    assert!(
+        lock.contains("demo-plugin@1.0.0(demo-host@1.0.0)"),
+        "imported pnpm-lock must peer-suffix the plugin key (#453): {lock}"
+    );
 }
 
 /// `nub link` (register) → `nub link <name>` (consume) → `nub unlink <name>`


### PR DESCRIPTION
`nub import` wrote pnpm-lock.yaml without peer-context suffixes. The install path skips its peer pass for pnpm-lock incumbents, so imported locks left peer-dependent packages with no sibling under the isolated store layout — failing at runtime with `Cannot find package`.

Fix: run the peer pass (hoist → apply_peer_contexts → remove) in the import path for npm/npm-shrinkwrap/bun before writing. Yarn stays excluded, matching the install gate.

Verified: offline regression test; e2e on a real bun.lock now writes the `(vite@…)` suffix and the runtime error is gone.

Closes #453