### PR TITLE
fix(runtime): auto-select async hook tier for a preload-detected foreign loader

### DIFF
--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -231,6 +231,56 @@ function userAsyncLoaderActive() {
   return __userAsyncLoaderRegistered || cliAsyncLoaderPresent();
 }
 
+// The Node band where the async `module.register` loader's `resolveSync`/`loadSync`
+// are unimplemented stubs that throw `ERR_METHOD_NOT_IMPLEMENTED`: 22.15.0 ..= 24.11.0
+// (fixed in 24.11.1, nodejs/node#59666). Mirrors the Rust `node_hook_compose_broken`
+// (spawn.rs) for every RELEASE version; a pre-release like `22.15.0-rc.1` reads as in-band
+// here (the numeric parse ignores the `-rc` tag) where the Rust semver sorts it just below
+// the 22.15.0 floor — a harmless over-selection (the async tier is always correct and the
+// two signals are OR'd), never a crash. Outside this band a foreign async loader composes
+// with nub's sync hooks natively, so the fast tier stays.
+function nodeHookComposeBroken() {
+  const p = String(process.versions.node).split(".");
+  const maj = parseInt(p[0], 10) || 0;
+  const min = parseInt(p[1], 10) || 0;
+  const pat = parseInt(p[2], 10) || 0;
+  const geFloor = maj > 22 || (maj === 22 && min >= 15);
+  const leCeil = maj < 24 || (maj === 24 && (min < 11 || (min === 11 && pat === 0)));
+  return geFloor && leCeil;
+}
+
+// Does a foreign async ESM loader flag (`--import` / `--loader` / `--experimental-loader`)
+// ride in THIS process's own startup flags, via EITHER channel? tsx/ts-node deliver their
+// loader through one of two paths, and they land in different places:
+//   • re-exec argv → `process.execArgv` (tsx's bin re-execs `node --import <loader>`), and
+//   • `NODE_OPTIONS="--import tsx/esm"` → `process.env.NODE_OPTIONS` (NOT hoisted into
+//     execArgv — verified on Node 24.x), the common CI/shell-config delivery.
+// Both must be scanned. nub's own fast-tier injection is `--require` (never `--import`/
+// `--loader`) on this band, and its compat-tier `--import preload.mjs` lives below 22.15
+// (outside the broken band this gates on), so any such flag here is FOREIGN.
+function foreignAsyncLoaderFlagPresent() {
+  if (cliAsyncLoaderPresent()) return true; // execArgv channel
+  const opts = process.env.NODE_OPTIONS;
+  if (typeof opts !== "string" || opts === "") return false;
+  return /(?:^|\s)--(?:experimental-)?(?:import|loader)(?:=|\s|$)/.test(opts);
+}
+
+// Should nub auto-select its async loader-worker tier at PRELOAD time because a foreign
+// async ESM loader (tsx/ts-node) rides in THIS process's own startup flags, on the
+// broken-compose band? This is the INTRINSIC counterpart to the launcher's predictive argv
+// scan (`__NUB_FORCE_ASYNC_TIER`, spawn.rs): because it reads the process's OWN flags, it
+// fires regardless of how the process was launched — a nested `nub run`, a `child_process`
+// spawn (Playwright's globalSetup), or a shell wrapper — all spawn shapes the launcher-side
+// scan cannot see (nub#460). nub's `--require` preload runs before `--import` executes, so
+// the flag is observable here before the foreign loader registers, letting nub pick the
+// composable tier up front (a mid-flight sync→async swap is impossible — the loader-worker
+// cannot be registered from inside another loader's registration on this band). Deliberately
+// conservative: any such flag on the band takes the async tier, even the rare one that
+// registers no loader — a small worker-startup cost on a shrinking Node band, never a crash.
+function shouldAutoAsyncTierAtPreload() {
+  return nodeHookComposeBroken() && foreignAsyncLoaderFlagPresent();
+}
+
 // ── Internal `module.register()` without the DEP0205 leak ────────────
 // `module.register()` is the loader-WORKER registration surface (async ESM hooks in
 // a dedicated thread). nub uses it for the compat tier (18.19–22.14, where the sync
@@ -1236,6 +1286,7 @@ module.exports = {
   installWatchReporting,
   registerLoaderWorker,
   makeHooks,
+  shouldAutoAsyncTierAtPreload,
   installCjsRequireHooks,
   preloadPolyfillPackages,
   installTemporalLazyGlobal,

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -93,17 +93,21 @@ try {
 
 const { installSyncPolyfills } = __require("./polyfills.cjs");
 
-// Force the async loader-worker tier when nub's launcher detected this process
-// will host a FOREIGN async `module.register` loader (tsx/ts-node) on a Node
-// whose sync/async hook composition is broken (22.15.0–24.11.0, fixed in
-// Node 24.11.1; nodejs/node#59666). There, nub's sync `module.registerHooks`
-// forces resolution synchronous and reaches the foreign loader's unimplemented
-// `resolveSync` stub → ERR_METHOD_NOT_IMPLEMENTED. Registering nub's hooks via
-// the async path instead keeps BOTH loaders async, so Node's all-async resolve
-// composes cleanly. The signal (__NUB_FORCE_ASYNC_TIER) is set by the Rust
-// spawn path only for the specific loader-hosting process; every other run on
-// this Node keeps the sync fast tier. See crates/nub-core/src/node/spawn.rs.
-const forceAsyncTier = !!process.env.__NUB_FORCE_ASYNC_TIER;
+// Force the async loader-worker tier when this process will host a FOREIGN async
+// `module.register` loader (tsx/ts-node) on a Node whose sync/async hook composition
+// is broken (22.15.0–24.11.0, fixed in Node 24.11.1; nodejs/node#59666). There, nub's
+// sync `module.registerHooks` forces resolution synchronous and reaches the foreign
+// loader's unimplemented `resolveSync` stub → ERR_METHOD_NOT_IMPLEMENTED. Registering
+// nub's hooks via the async path instead keeps BOTH loaders async, so Node's all-async
+// resolve composes cleanly. TWO signals, either sufficient:
+//   • __NUB_FORCE_ASYNC_TIER — the launcher's PREDICTIVE argv scan (spawn.rs), set when
+//     nub itself spawns a tsx/ts-node child. Blind to nested `nub run`, a `child_process`
+//     spawn, or a shell wrapper (nub#460), where nub never sees the tsx argv.
+//   • shouldAutoAsyncTierAtPreload() — the INTRINSIC runtime signal: reads THIS process's
+//     own startup flags (execArgv AND NODE_OPTIONS) for a foreign `--import`/`--loader` on
+//     the broken band, so it fires for every spawn shape the scan misses. This is the
+//     load-bearing half of the nub#460 fix.
+const forceAsyncTier = !!process.env.__NUB_FORCE_ASYNC_TIER || common.shouldAutoAsyncTierAtPreload();
 
 if (!requireEsmDisabled && !forceAsyncTier) {
   // ── Fast tier (sync require(esm) available) ───────────────────────

--- a/tests/node-matrix/fixtures/import-flag-async-loader/entry.mjs
+++ b/tests/node-matrix/fixtures/import-flag-async-loader/entry.mjs
@@ -1,0 +1,45 @@
+// nub#460 regression guard — nub must select the hook tier that COMPOSES with a foreign
+// async ESM loader riding in this process's own startup flags (`--import`/`--loader`).
+//
+// A synthetic pass-through loader can't reproduce the real crash (nub's stub-recovery and
+// builtin short-circuits absorb it; only tsx's query-suffixed internal graph defeats them),
+// so this guards the FIX'S MECHANISM directly: on the broken-compose band (Node 22.15–24.11)
+// nub must switch OFF its sync `module.registerHooks` fast tier onto the async loader-worker
+// tier, or a real foreign loader (tsx) reaches the `resolveSync`/`loadSync` stub and crashes
+// with ERR_METHOD_NOT_IMPLEMENTED. Outside the band the sync fast tier composes natively and
+// must stay (it is faster). The end-to-end crash path is covered by manual real-tsx runs
+// across the Node matrix (see the PR); this is the self-contained CI guard.
+//
+// Tier is observable: the fast tier wraps `module.registerHooks` (sets `__nubWrapped`); the
+// async tier registers via `module.register` and leaves `registerHooks` unwrapped.
+import nodeModule from "node:module";
+import { writeSync } from "node:fs";
+
+// SELF-GUARD: process.versions.nub is published in BOTH tiers, so a missing marker means
+// nub's preload never loaded and the tier is not under test — fail loud, don't pass vacuously.
+if (!process.versions.nub) {
+  writeSync(2, "TIER_FAIL: nub augmentation not active (process.versions.nub unset) — preload did not load; not under test\n");
+  process.exit(3);
+}
+
+const [maj, min, pat] = process.versions.node.split(".").map((n) => parseInt(n, 10));
+const brokenBand =
+  (maj > 22 || (maj === 22 && min >= 15)) &&
+  (maj < 24 || (maj === 24 && (min < 11 || (min === 11 && pat === 0))));
+// The fast tier stamps `__nubWrapped` on registerHooks (installUserHookDetector, in
+// runtime/preload-common.cjs) — the same marker production relies on. Keep this in sync if
+// that sentinel is ever renamed, or this guard silently stops discriminating the tiers.
+const fastTier =
+  typeof nodeModule.registerHooks === "function" && nodeModule.registerHooks.__nubWrapped === true;
+
+if (brokenBand && fastTier) {
+  writeSync(
+    2,
+    `TIER_FAIL: Node ${process.versions.node} is on the broken-compose band and a foreign async ` +
+      `loader flag is present, but nub stayed on the SYNC fast tier — a real tsx loader would crash ` +
+      `here on the resolveSync stub (nub#460 regressed)\n`,
+  );
+  process.exit(1);
+}
+
+writeSync(1, `TIER_OK band=${brokenBand ? "broken" : "ok"} tier=${fastTier ? "fast" : "async"}\n`);

--- a/tests/node-matrix/fixtures/import-flag-async-loader/passthrough-loader.mjs
+++ b/tests/node-matrix/fixtures/import-flag-async-loader/passthrough-loader.mjs
@@ -1,0 +1,5 @@
+// Minimal pass-through async ESM loader — the shape tsx's registered loader takes. Its mere
+// presence (async resolve/load, no sync surface) is the whole trigger; it does no work.
+export async function resolve(specifier, context, nextResolve) {
+  return nextResolve(specifier, context);
+}

--- a/tests/node-matrix/fixtures/import-flag-async-loader/register-async-loader.mjs
+++ b/tests/node-matrix/fixtures/import-flag-async-loader/register-async-loader.mjs
@@ -1,0 +1,10 @@
+// A foreign async ESM loader registered via `--import` — the tsx/ts-node shape that rides
+// in the PROCESS's OWN execArgv (nub#460). The launcher-side argv scan can't see this when
+// nub is invoked nested (`nub run` → `nub run` → tsx), via a `child_process` spawn
+// (Playwright globalSetup), or behind a shell wrapper — so nub must detect the loader at
+// PRELOAD time from its own execArgv (shouldAutoAsyncTierAtPreload) and take its async
+// loader-worker tier. If it stays on the sync `module.registerHooks` fast tier, resolving
+// this loader's own specifier reaches its unimplemented `resolveSync` stub on the broken
+// band (Node 22.15–24.11) → ERR_METHOD_NOT_IMPLEMENTED, aborting the process.
+import { register } from "node:module";
+register("./passthrough-loader.mjs", import.meta.url);

--- a/tests/node-matrix/run.sh
+++ b/tests/node-matrix/run.sh
@@ -82,5 +82,39 @@ else
   fail "async-loader collision: unexpected failure (exit=$coll_rc, stdout=[$coll_out], stderr=[$coll_err])"
 fi
 
+# ── Scenario C: preload async-tier selection for a foreign loader flag (nub#460) ──
+# tsx/ts-node deliver their async ESM loader through THIS process's own startup flags — a
+# `--import <loader>` in execArgv (tsx's bin re-execs node) or `NODE_OPTIONS="--import tsx/esm"`.
+# When nub is invoked nested (`nub run` → `nub run` → tsx), via a `child_process` spawn
+# (Playwright globalSetup), or behind a shell wrapper, the launcher's argv scan never sees
+# that tsx — so nub must detect the loader flag INTRINSICALLY at preload
+# (shouldAutoAsyncTierAtPreload) and switch to its async tier. On the broken-compose band
+# (22.15–24.11) staying on the sync `module.registerHooks` fast tier is the #460 crash; off
+# the band the fast tier composes natively and must stay. entry.mjs asserts the correct tier
+# (TIER_OK) and fails (TIER_FAIL) if nub stayed sync on the band — teeth on exactly the
+# broken versions. Exercises the NODE_OPTIONS delivery channel (execArgv is covered by the
+# real-tsx e2e in the PR). Distinct from Scenario B (loader registered from USER code at
+# runtime, recovered via stub-recovery); this is the preload tier-selection path.
+imp_reg="file://$FIX/import-flag-async-loader/register-async-loader.mjs"
+# Both delivery channels a foreign loader flag can arrive through — they land in different
+# places (NODE_OPTIONS stays in process.env.NODE_OPTIONS; a re-exec/CLI --import lands in
+# process.execArgv), and the detection must catch each.
+#   C1: NODE_OPTIONS="--import <loader>"  (the CI/shell-config shape)
+#   C2: nub --import <loader> entry.mjs   (the execArgv/re-exec shape tsx's bin uses)
+c1_out="$(cd "$FIX/import-flag-async-loader" && NODE_OPTIONS="--import $imp_reg" "$NUB" entry.mjs 2>/tmp/nm-imp-err.txt)"; c1_rc=$?
+c1_err="$(cat /tmp/nm-imp-err.txt)"
+if [[ $c1_rc -eq 0 && "$c1_out" == *"TIER_OK"* ]]; then
+  pass "foreign loader flag via NODE_OPTIONS → correct hook tier ($c1_out)"
+else
+  fail "foreign loader flag via NODE_OPTIONS (exit=$c1_rc, stdout=[$c1_out], stderr=[$c1_err])"
+fi
+c2_out="$(cd "$FIX/import-flag-async-loader" && "$NUB" --import "$imp_reg" entry.mjs 2>/tmp/nm-imp2-err.txt)"; c2_rc=$?
+c2_err="$(cat /tmp/nm-imp2-err.txt)"
+if [[ $c2_rc -eq 0 && "$c2_out" == *"TIER_OK"* ]]; then
+  pass "foreign loader flag via execArgv → correct hook tier ($c2_out)"
+else
+  fail "foreign loader flag via execArgv (exit=$c2_rc, stdout=[$c2_out], stderr=[$c2_err])"
+fi
+
 echo "== Node $NODE_VER: $fails failure(s) =="
 exit $((fails > 0 ? 1 : 0))


### PR DESCRIPTION
On Node 22.15.0–24.11.0 the async `module.register` loader's `resolveSync`/`loadSync` are unimplemented stubs (fixed in 24.11.1, nodejs/node#59666). nub's sync `module.registerHooks` fast tier forces resolution synchronous and hits those stubs when a foreign loader (tsx/ts-node) is active → `ERR_METHOD_NOT_IMPLEMENTED`.

nub already forces its async tier when the launcher argv scan sees a tsx child (`__NUB_FORCE_ASYNC_TIER`), but that scan is blind to tsx spawned via a nested `nub run` (the reported case), a `child_process` spawn (Playwright `globalSetup`), or a shell wrapper — nub never sees the tsx argv, so the process crashes.

## Fix

Detect the foreign loader intrinsically at preload from the process's own `--import`/`--loader` flags — scanning both `execArgv` and `NODE_OPTIONS` — on the broken band, and register nub's hooks via the async loader-worker tier so both loaders compose. Because it reads the process's own flags, it covers every spawn shape the launcher scan cannot see. Conservative by design: any such flag on the band takes the async tier (a worker-startup cost on a shrinking Node band, never a crash).

A mid-flight sync→async swap on foreign registration was prototyped and does not work — the loader worker cannot be registered from inside another loader's registration on this band — so preload-time selection is the viable point.

## Validation

- Real tsx, both crash reproductions (nested `nub run` + `child_process` spawn), fixed on Node 22.16 and 24.10.
- node-matrix green on 22.16 / 24.10 (broken) and 24.14 (fixed); new Scenario C guards both delivery channels and fails without the fix on the band.
- Fresh-context correctness + impact-analysis review: no false-positive risk (the `NODE_OPTIONS` scan rejects nub's own `--experimental-import-text`; nub never injects `--import`/`--loader` on the broken band).

## Follow-up (separate)

The Rust argv-scan apparatus (`child_hosts_async_loader` / `force_async_tier_env`) is now redundant with the intrinsic detection (strictly broader). Left in place to keep this diff tight.

Closes #460

https://claude.ai/code/session_013KZKJdgxVzFjyGxASsyhCy