### PR TITLE
feat(node): resolve the Node version from .tool-versions (asdf/mise)

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -6382,7 +6382,7 @@ fn discover_node_for_status(cwd: &Path) -> Result<nub_core::node::discovery::Res
             "pinned Node version {pin} not found\n\
              \x20\x20Active shell Node: {shell_version} (does not satisfy the pin)\n\
              \x20\x20Provision it: nub node install {pin} (or run a file — nub installs the pin on demand)\n\
-             \x20\x20The pin comes from .node-version / .nvmrc / engines.node / devEngines.runtime."
+             \x20\x20The pin comes from .node-version / .nvmrc / .tool-versions / engines.node / devEngines.runtime."
         ),
         other => anyhow::Error::new(other),
     })

--- a/crates/nub-core/src/node/discovery.rs
+++ b/crates/nub-core/src/node/discovery.rs
@@ -125,9 +125,9 @@ fn format_unsupported(version: &NodeVersion, pin_source: Option<&str>) -> String
 ///
 /// 1. Resolve the pin chain: `package.json#devEngines.runtime` (#1, may refuse
 ///    when the declared runtime isn't Node) → `.node-version` (#2) → `.nvmrc`
-///    (#3) → `package.json#engines.node` (#4, a resolution range).
-///    `devEngines.runtime` `onFail: "warn"` notices print here (once per
-///    invocation), then resolution falls through.
+///    (#3) → `.tool-versions` (#4, asdf/mise) → `package.json#engines.node`
+///    (#5, a resolution range). `devEngines.runtime` `onFail: "warn"` notices
+///    print here (once per invocation), then resolution falls through.
 /// 2. If no pin: use `node` on PATH.
 /// 3. If pinned: PATH node satisfies → nub's own download store
 ///    (`~/.cache/nub/node/<version>/`) → nvm scan → error. (The download +
@@ -442,16 +442,20 @@ pub fn check_min_version(node: &ResolvedNode) -> Result<(), DiscoveryError> {
 }
 
 /// Walk up from `cwd` looking for a pin file. Returns the raw pin string, parsed
-/// pin, and the filename that produced it (`.node-version` or `.nvmrc`) for
-/// user-facing messages. Bounded by $HOME, filesystem root, and 16 ancestors.
+/// pin, and the filename that produced it (`.node-version`, `.nvmrc`, or
+/// `.tool-versions`) for user-facing messages. Bounded by $HOME, filesystem root,
+/// and 16 ancestors.
 ///
-/// Precedence within a directory is `.node-version` BEFORE `.nvmrc`, per
-/// `wiki/runtime/node-version-management.md` §"Resolution order" (#2 `.node-version`,
-/// #3 `.nvmrc`). `.node-version` is the tool-agnostic standard, so it wins when a
-/// project carries both. Precedence #1, `package.json#devEngines.runtime`, sits
-/// ABOVE both and #4, `package.json#engines.node`, BELOW both —
-/// [`resolve_pin_chain`] orders all four; this helper is only the pin-file
-/// middle of the chain.
+/// Precedence within a directory is `.node-version` BEFORE `.nvmrc` BEFORE
+/// `.tool-versions`, per `wiki/runtime/node-version-management.md` §"Resolution
+/// order" (#2 `.node-version`, #3 `.nvmrc`, #4 `.tool-versions`). It is a
+/// specificity-of-intent gradient: the Node-specific pin files outrank the
+/// polyglot asdf/mise file, whose `nodejs`/`node` line is one tool among many, so
+/// a deliberately-added `.node-version` wins when a project carries both. (A
+/// project with only `.tool-versions` — the common asdf/mise case — never hits the
+/// conflict.) Precedence #1, `package.json#devEngines.runtime`, sits ABOVE all
+/// three and #5, `package.json#engines.node`, BELOW them — [`resolve_pin_chain`]
+/// orders all five; this helper is only the pin-file middle of the chain.
 pub fn walk_up_for_pin(cwd: &Path) -> Option<(String, VersionPin, String)> {
     let home = dirs_next::home_dir();
     let mut dir = cwd.to_path_buf();
@@ -491,6 +495,13 @@ pub fn walk_up_for_pin(cwd: &Path) -> Option<(String, VersionPin, String)> {
                     }
                 }
             }
+
+            // #4: `.tool-versions` (asdf/mise), checked AFTER the Node-specific pin
+            // files above so they win in a directory that carries both.
+            if let Some((raw, pin)) = tool_versions_node_pin(&dir) {
+                tracing::debug!(dir = %dir.display(), pin = raw, "found .tool-versions node pin");
+                return Some((raw, pin, ".tool-versions".to_string()));
+            }
         }
 
         // Stop at home dir or filesystem root.
@@ -502,16 +513,46 @@ pub fn walk_up_for_pin(cwd: &Path) -> Option<(String, VersionPin, String)> {
     None
 }
 
+/// Read the Node pin from an asdf/mise `.tool-versions` in `dir` (precedence #4).
+/// Returns the raw version token and parsed pin, or `None` when the file is
+/// absent, carries no Node line, or the version is one nub can't model.
+///
+/// `.tool-versions` is line-oriented — `<tool> <version...>`, `#` comments. The
+/// Node line's key is `nodejs` (asdf's plugin short-name) or `node` (a mise
+/// alias); accept either. A line may list fallback versions (`nodejs 20 18`); we
+/// take the first, matching how a single Node is provisioned. Non-modelable
+/// specifiers (`system`, `ref:<sha>`) fail [`VersionPin`] parsing and yield
+/// `None` here — the walk then falls through, exactly as an unparseable
+/// `.node-version` does. Only the Node line is read; every other tool in the file
+/// is ignored (nub provisions Node, not the whole toolchain).
+fn tool_versions_node_pin(dir: &Path) -> Option<(String, VersionPin)> {
+    let content = fs::read_to_string(dir.join(".tool-versions")).ok()?;
+    let content = content.strip_prefix('\u{FEFF}').unwrap_or(&content);
+    for line in content.lines() {
+        // Drop an inline `# comment`; a version token never contains `#`.
+        let code = line.split('#').next().unwrap_or("");
+        let mut tokens = code.split_whitespace();
+        let Some(tool) = tokens.next() else { continue };
+        if tool != "nodejs" && tool != "node" {
+            continue;
+        }
+        let version = tokens.next()?;
+        let pin = version.parse::<VersionPin>().ok()?;
+        return Some((version.to_string(), pin));
+    }
+    None
+}
+
 /// Source label for the `devEngines.runtime` pin channel (precedence #1),
 /// shaped like the `package.json#engines.node` label.
 const DEV_ENGINES_RUNTIME_SOURCE: &str = "package.json#devEngines.runtime";
 
-/// Source label for the `engines.node` pin channel (precedence #4).
+/// Source label for the `engines.node` pin channel (precedence #5).
 const ENGINES_NODE_SOURCE: &str = "package.json#engines.node";
 
 /// The governing `package.json` for `cwd`, parsed: the WORKSPACE ROOT's manifest
 /// when one exists above `cwd`, else the nearest one. This is the one manifest
-/// both `devEngines.runtime` (#1) and `engines.node` (#4) read from.
+/// both `devEngines.runtime` (#1) and `engines.node` (#5) read from.
 ///
 /// Workspace-root, not nearest, deliberately: a monorepo pins its Node once at
 /// the root (pnpm — the field's model implementation — reads `devEngines.runtime`
@@ -532,7 +573,7 @@ fn project_manifest(cwd: &Path) -> Option<serde_json::Value> {
     }
 }
 
-/// Read `package.json#engines.node` (precedence #4, a semver *range*) from the
+/// Read `package.json#engines.node` (precedence #5, a semver *range*) from the
 /// governing manifest ([`project_manifest`]). Returns `(range, source_label)`,
 /// or `None` when the manifest has no `engines.node`.
 fn read_engines_node(cwd: &Path) -> Option<(String, String)> {
@@ -679,9 +720,10 @@ pub struct PinChain {
 /// The pin-source chain in spec precedence order
 /// (`wiki/runtime/node-version-management.md` §"Resolution order"):
 /// `package.json#devEngines.runtime` (#1) → `.node-version` (#2) → `.nvmrc`
-/// (#3) → `package.json#engines.node` (#4, a resolution range). Errs with
-/// [`DiscoveryError::RuntimeNotNode`] when `devEngines.runtime` declares a
-/// non-Node runtime that refuses (its default).
+/// (#3) → `.tool-versions` (#4, asdf/mise) → `package.json#engines.node`
+/// (#5, a resolution range). The middle three (#2–#4) resolve in
+/// [`walk_up_for_pin`]. Errs with [`DiscoveryError::RuntimeNotNode`] when
+/// `devEngines.runtime` declares a non-Node runtime that refuses (its default).
 pub fn resolve_pin_chain(cwd: &Path) -> Result<PinChain, DiscoveryError> {
     let mut warnings = Vec::new();
     let manifest = project_manifest(cwd);
@@ -709,7 +751,7 @@ pub fn resolve_pin_chain(cwd: &Path) -> Result<PinChain, DiscoveryError> {
             warnings,
         });
     }
-    // #4: engines.node — a resolution *range* ("resolve to the newest available
+    // #5: engines.node — a resolution *range* ("resolve to the newest available
     // version satisfying the range"). A PATH node inside the range satisfies it
     // like any range pin; provisioning resolves newest-satisfying.
     if let Some((range, source)) = read_engines_node(cwd) {
@@ -767,7 +809,7 @@ pub fn engines_disagreement_warning(cwd: &Path, node: &ResolvedNode) -> Option<S
         ));
     }
 
-    // The winning pin vs package.json#engines.node (#4) — unless engines.node
+    // The winning pin vs package.json#engines.node (#5) — unless engines.node
     // IS the winning source (it can't disagree with itself).
     if pin_source != ENGINES_NODE_SOURCE
         && let Some((range, engines_source)) = read_engines_node(cwd)
@@ -1672,8 +1714,8 @@ mod tests {
     }
 
     #[test]
-    fn engines_node_is_the_fourth_chain_source_below_pin_files() {
-        // engines.node alone is a resolution range (#4) — including the legal
+    fn engines_node_is_the_last_chain_source_below_pin_files() {
+        // engines.node alone is a resolution range (#5) — including the legal
         // operator-space form (">= 20"), which must not silently degrade to
         // no-constraint.
         let dir = resolution_tmpdir("eng-chain");
@@ -1685,11 +1727,84 @@ mod tests {
         assert!(NodeVersion::new(22, 13, 0).satisfies(&pin));
         assert!(!NodeVersion::new(18, 19, 0).satisfies(&pin));
 
-        // A pin file outranks it (#2 beats #4).
+        // A pin file outranks it (#2 beats #5).
         std::fs::write(dir.join(".node-version"), "20.11.0\n").unwrap();
         let chain = resolve_pin_chain(&dir).unwrap();
         let (_, _, source) = chain.pin.expect("a pin");
         assert_eq!(source, ".node-version", "a pin file must beat engines.node");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn tool_versions_pins_node_and_ranks_below_node_specific_files() {
+        // .tool-versions (#4) resolves the `nodejs` line and sits below the
+        // Node-specific pin files (#2/#3): the Node-only files win when a project
+        // carries both, but a .tool-versions-only project (the asdf/mise norm)
+        // resolves cleanly.
+        let dir = resolution_tmpdir("tv-prec");
+        std::fs::write(
+            dir.join(".tool-versions"),
+            "python 3.12.0\nnodejs 20.11.0\n",
+        )
+        .unwrap();
+        let (raw, _pin, source) = walk_up_for_pin(&dir).expect("the nodejs line resolves");
+        assert_eq!(source, ".tool-versions");
+        assert_eq!(raw, "20.11.0", "only the nodejs line is read, not python");
+
+        // .nvmrc (#3) outranks it, and .node-version (#2) outranks that.
+        std::fs::write(dir.join(".nvmrc"), "18.19.0\n").unwrap();
+        let (_, _, source) = walk_up_for_pin(&dir).expect("a pin");
+        assert_eq!(source, ".nvmrc", ".nvmrc must beat .tool-versions");
+        std::fs::write(dir.join(".node-version"), "22.15.0\n").unwrap();
+        let (_, _, source) = walk_up_for_pin(&dir).expect("a pin");
+        assert_eq!(
+            source, ".node-version",
+            ".node-version must beat .tool-versions"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn tool_versions_beats_engines_node_in_the_chain() {
+        // #4 (.tool-versions, an exact pin) outranks #5 (engines.node, a range).
+        let dir = resolution_tmpdir("tv-eng");
+        std::fs::write(dir.join("package.json"), r#"{"engines":{"node":">= 18"}}"#).unwrap();
+        std::fs::write(dir.join(".tool-versions"), "nodejs 20.11.0\n").unwrap();
+        let chain = resolve_pin_chain(&dir).unwrap();
+        let (raw, _, source) = chain.pin.expect("a pin");
+        assert_eq!(
+            source, ".tool-versions",
+            ".tool-versions must beat engines.node"
+        );
+        assert_eq!(raw, "20.11.0");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn tool_versions_parsing_covers_the_real_shapes() {
+        // The `node` alias key (mise), a trailing inline comment, and a
+        // multi-version fallback line (first version wins) — the shapes a real
+        // .tool-versions carries.
+        let dir = resolution_tmpdir("tv-parse");
+        std::fs::write(
+            dir.join(".tool-versions"),
+            "# toolchain\nruby 3.3.0\nnode 20.11.0 18.19.0  # fallback\n",
+        )
+        .unwrap();
+        let (raw, _pin, source) = walk_up_for_pin(&dir).expect("the node line resolves");
+        assert_eq!(source, ".tool-versions");
+        assert_eq!(
+            raw, "20.11.0",
+            "the `node` key is honored; first version wins"
+        );
+
+        // A non-modelable specifier (asdf `system`) yields no pin — the walk falls
+        // through exactly as an unparseable .node-version does.
+        std::fs::write(dir.join(".tool-versions"), "nodejs system\n").unwrap();
+        assert!(
+            walk_up_for_pin(&dir).is_none(),
+            "`nodejs system` is not a version nub can model — fall through"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/nub-core/src/version_management/manage.rs
+++ b/crates/nub-core/src/version_management/manage.rs
@@ -184,7 +184,7 @@ pub fn install_from_pin(store: &Path, cwd: &Path) -> Result<InstallOutcome> {
     let Some((raw, pin, source)) = chain.pin else {
         bail!(
             "nub node install: no version given and no Node pin (devEngines.runtime, \
-             .node-version, .nvmrc, or engines.node) found in this project"
+             .node-version, .nvmrc, .tool-versions, or engines.node) found in this project"
         );
     };
     match &pin {

--- a/site/content/docs/deployment/github-action.mdx
+++ b/site/content/docs/deployment/github-action.mdx
@@ -30,7 +30,8 @@ The action installs the `nub` CLI, then eagerly provisions the project's pinned 
 1. `package.json#/devEngines/runtime`
 2. `.node-version`
 3. `.nvmrc`
-4. `package.json#/engines/node`
+4. `.tool-versions` (the asdf/mise file's `nodejs` line)
+5. `package.json#/engines/node`
 
 That resolved Node's bin directory is added to the global PATH, so bare `node`/`npm`/`npx` and every subsequent step see the pinned version — the same PATH guarantee setup-node gives. A project with no pin is fine: the eager step skips cleanly and Nub provisions at runtime instead.
 

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -125,6 +125,7 @@ Like Corepack's shims, `nub` itself auto-installs Node versions as needed. When 
 - `package.json#/devEngines/runtime`
 - `.node-version`
 - `.nvmrc`
+- `.tool-versions` — the asdf/mise file; its `nodejs` line
 - `package.json#/engines/node` (a range)
 - the `node` on your `PATH`, when nothing is pinned
 


### PR DESCRIPTION
Resolve the project's Node version from `.tool-versions` (the asdf/mise file), so asdf/mise-driven projects that pin `nodejs` there provision the right Node under nub without a redundant `.node-version`.

## Resolution order

`.tool-versions` slots at precedence **#4** — below the Node-specific pin files, above the `engines.node` range:

1. `package.json#devEngines.runtime`
2. `.node-version`
3. `.nvmrc`
4. **`.tool-versions`** (new)
5. `package.json#engines.node`

The ordering is a specificity-of-intent gradient: a polyglot pin's `nodejs` line is one tool among many, so a deliberately-added `.node-version` wins when a project carries both. A `.tool-versions`-only project — the asdf/mise norm — never hits the conflict.

## Behavior

- Reads the `nodejs` (asdf plugin key) or `node` (mise alias) line; strips inline `#` comments; takes the first version on a multi-version fallback line (`nodejs 20 18` → `20`).
- Reuses `VersionPin` parsing, so aliases resolve and unmodelable specifiers (`system`, `ref:<sha>`) fall through to the next source exactly as an unparseable `.node-version` does.
- Only the Node line is read; every other tool in the file is ignored (nub provisions Node, not the whole toolchain).
- The source label, provenance line (`resolved from .tool-versions`), and disagreement warnings come through `walk_up_for_pin` with no extra plumbing.

## Scope

`.tool-versions` only; `mise.toml` (TOML, mise-only) is out of scope. The setup-nub GitHub Action provisions via nub, so it inherits this automatically once a release ships.

## Testing

Unit: 3 tests in `discovery.rs` (precedence vs `.node-version`/`.nvmrc`, beats `engines.node`, the `node`-key/inline-comment/multi-version/`system` shapes). Full `node::discovery` suite green; `clippy --all-targets --all-features -D warnings` and `fmt --check` clean.

E2e against the dev binary (`nub node which`): `.tool-versions nodejs 26.4.0` → `resolved from .tool-versions (26.4.0)`; adding `.nvmrc`/`.node-version` flips the winner correctly; `nodejs system` falls through to node on PATH.

Docs updated: runtime overview + the GitHub Action resolution list.
