### PR TITLE
fix(pm): eject curated project-context packages from the global virtual store

### DIFF
--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -82,11 +82,17 @@ fn eject_disabled(raw: Option<&str>) -> bool {
 /// hash — this seam is what makes it invalidate the warm tree.
 ///
 /// For users the token is CONSTANT-ON: the dead on/off toggle is gone, so it folds
-/// only [`PHANTOM_SCANNER_VERSION`]. That fold is what makes a scanner-logic bump
-/// COMPLETE rather than a half-fix — the bump re-scans content into a new sidecar
-/// path, but on a warm tree with an unchanged lockfile aube would SKIP the link
-/// phase and never apply the improved verdict; changing this token forces the link
-/// to re-run so the consumer picks up the new-version sidecars.
+/// [`PHANTOM_SCANNER_VERSION`] plus the curated-eject list token
+/// ([`crate::pm_engine::phantom_closure::project_context_eject_token`]). The scanner
+/// fold makes a scanner-logic bump COMPLETE rather than a half-fix — the bump
+/// re-scans content into a new sidecar path, but on a warm tree with an unchanged
+/// lockfile aube would SKIP the link phase and never apply the improved verdict;
+/// changing this token forces the link to re-run so the consumer picks up the
+/// new-version sidecars. The curated-eject fold does the same for the #457 list: its
+/// members are injected inside the expand hook, past aube's `disk_materialize_packages`
+/// settings fold, so folding the list token here is what invalidates a warm tree on
+/// the initial ship AND on any future list edit (else the stale symlinked shape is
+/// accepted and #457 stays unfixed on existing installs).
 ///
 /// The token still branches on [`enabled`] SOLELY for the internal A/B seam: when
 /// an agent flips [`INTERNAL_EJECT_DISABLE_VAR`] the token changes, so a warm tree
@@ -100,7 +106,10 @@ pub(crate) fn settings_fingerprint() -> String {
 /// testable without mutating the process-global `enabled()` env.
 fn settings_token(enabled: bool) -> String {
     if enabled {
-        format!("phantom_scanner={PHANTOM_SCANNER_VERSION}")
+        format!(
+            "phantom_scanner={PHANTOM_SCANNER_VERSION};project_context={}",
+            crate::pm_engine::phantom_closure::project_context_eject_token()
+        )
     } else {
         "phantom_eject=disabled".to_string()
     }
@@ -332,16 +341,20 @@ mod tests {
         );
     }
 
-    /// The user (enabled) token folds the scanner version so a bump invalidates a
-    /// warm tree and forces a re-scan/relink; the dead on/off toggle is gone, so the
-    /// token is just the scanner segment. The disabled token (reachable only via the
-    /// internal A/B seam) is version-free and distinct, so flipping the seam still
-    /// re-links to the pure-symlink shape. Pins both against a future refactor.
+    /// The user (enabled) token folds the scanner version AND the curated-eject list
+    /// token, so a scanner bump or a #457 list edit invalidates a warm tree and forces
+    /// a re-scan/relink; the dead on/off toggle is gone. The disabled token (reachable
+    /// only via the internal A/B seam) is version-free and distinct, so flipping the
+    /// seam still re-links to the pure-symlink shape. Pins both against a future
+    /// refactor.
     #[test]
     fn enabled_token_folds_version_disabled_seam_token_is_distinct() {
         assert_eq!(
             settings_token(true),
-            format!("phantom_scanner={PHANTOM_SCANNER_VERSION}")
+            format!(
+                "phantom_scanner={PHANTOM_SCANNER_VERSION};project_context={}",
+                crate::pm_engine::phantom_closure::project_context_eject_token()
+            )
         );
         assert_eq!(settings_token(false), "phantom_eject=disabled");
         assert_ne!(settings_token(true), settings_token(false));

--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -135,6 +135,36 @@ pub(super) const NUB_PROJECT_CONTEXT_EJECT: &[&str] = &[
     "storage-engine",
 ];
 
+/// Stable, order-independent fingerprint token for the curated eject list, folded
+/// into the install-state settings hash via [`crate::dynamic_phantom::settings_token`]
+/// (the `extra_settings_fingerprint` embedder hook). Load-bearing for warm/upgrade
+/// trees (nub#457): the curated seed is injected INSIDE the expand hook, after
+/// aube's `disk_materialize_packages` settings fold, so without this token an
+/// existing install — one from a nub predating the list, or after any FUTURE list
+/// edit — keeps an identical `settings_hash`, and aube's existence-gated fast path
+/// accepts the stale symlinked tree and skips the relink, leaving #457 unfixed.
+/// Folding this token forces the relink that converts the stale symlink to an
+/// ejected dir. Hashing the SORTED names makes the token move on any add/remove and
+/// hold steady on a pure reorder; FNV-1a keeps it dependency-free and stable across
+/// platforms/releases (std's `DefaultHasher` is not guaranteed stable across Rust
+/// versions).
+pub(crate) fn project_context_eject_token() -> String {
+    eject_list_token(NUB_PROJECT_CONTEXT_EJECT)
+}
+
+fn eject_list_token(names: &[&str]) -> String {
+    let mut sorted: Vec<&str> = names.to_vec();
+    sorted.sort_unstable();
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for name in sorted {
+        for byte in name.bytes().chain(std::iter::once(0x1f)) {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    format!("{hash:016x}")
+}
+
 /// Keep only nub's own embedder-default seed names, dropping every user-source
 /// entry — the mechanism that retires the user-facing `diskMaterializePackages`
 /// knob under nub while leaving standalone aube's byte-for-byte.
@@ -678,6 +708,29 @@ mod tests {
             plan.names.is_empty(),
             "a self-contained build is not ejected: {:?}",
             plan.names
+        );
+    }
+
+    #[test]
+    fn eject_list_token_is_order_independent_and_edit_sensitive() {
+        // The token feeds the install-state fingerprint (#457 warm-tree fix): a pure
+        // reorder is a no-op (it's a set), while any add/remove MUST move it so an
+        // existing install relinks. And it is deterministic — a stable fingerprint,
+        // not a per-run value.
+        assert_eq!(
+            eject_list_token(&["a", "b", "c"]),
+            eject_list_token(&["c", "a", "b"]),
+            "a pure reorder does not change the token"
+        );
+        assert_ne!(
+            eject_list_token(&["a", "b"]),
+            eject_list_token(&["a", "b", "c"]),
+            "an added name changes the token"
+        );
+        assert_eq!(
+            project_context_eject_token(),
+            project_context_eject_token(),
+            "deterministic across calls"
         );
     }
 

--- a/crates/nub-cli/src/pm_engine/phantom_closure.rs
+++ b/crates/nub-cli/src/pm_engine/phantom_closure.rs
@@ -86,6 +86,55 @@ pub(crate) fn register() {
 /// default can't be added in one place and silently dropped by the other.
 pub(super) const NUB_INTERNAL_DISK_MATERIALIZE_SEED: &[&str] = &["vite"];
 
+/// Curated "project-context" packages (nub#457): each one's build script READS or
+/// MUTATES the CONSUMING project rather than only its own dir — git-hook installers
+/// walk up from `cwd` to the project root and write `.git/hooks`; the rest generate
+/// project-local files or resolve peers/bridges against the host tree. Under GVS a
+/// build runs in the shared global store, DETACHED from any project, so a
+/// cwd/upward-walk lands on the per-package store wrapper (which has no
+/// package.json) and the script crashes — #457: `simple-git-hooks` postinstall →
+/// ENOENT — or silently emits shared-mutable wrong output. Ejecting them
+/// (disk-materialize project-local, via the SAME importer-closure + expand hook the
+/// phantom seeds use) restores a real project above `cwd`.
+///
+/// DELIBERATELY curated, NOT "all script-havers": self-contained builds (node-gyp
+/// native compiles, prebuilt-binary downloaders like esbuild) read only their own
+/// dir, produce identical output anywhere, and share it cross-project via the
+/// side-effects cache — ejecting them would erode the symlink-in-store sharing win
+/// for zero correctness gain, so they STAY in GVS (built once, shared). Every name
+/// here is verified category-C (build reads/mutates the host project); absent names
+/// cost nothing (the seed union is presence-gated against the resolved graph).
+///
+/// Gate: this rides the same [`enabled`] seam as phantom eject, so disabling the
+/// internal eject seam also disables curated eject (reintroducing #457) — an
+/// accepted property of that internal-only escape hatch.
+pub(super) const NUB_PROJECT_CONTEXT_EJECT: &[&str] = &[
+    // Git-hook installers — walk up from cwd to the project root, write `.git/hooks`.
+    "simple-git-hooks",
+    "lefthook",
+    "@evilmartians/lefthook",
+    "@arkweid/lefthook",
+    "pre-commit",
+    "pre-push",
+    "ghooks",
+    "git-validate",
+    "shared-git-hooks",
+    "yorkie",
+    "git-commit-msg-linter",
+    // Other host-project reader/mutators (generate project-local files, resolve
+    // peers/bridges against the consuming tree).
+    "install-peers",
+    "msw",
+    "@bahmutov/add-typescript-to-cypress",
+    "@cypress/snapshot",
+    "cordova.plugins.diagnostic",
+    "vue-demi",
+    "vue-inbrowser-compiler-demi",
+    "@intlify/vue-i18n-bridge",
+    "@intlify/vue-router-bridge",
+    "storage-engine",
+];
+
 /// Keep only nub's own embedder-default seed names, dropping every user-source
 /// entry — the mechanism that retires the user-facing `diskMaterializePackages`
 /// knob under nub while leaving standalone aube's byte-for-byte.
@@ -200,6 +249,20 @@ fn plan_from_flags(
             .any(|peer| is_top_level(&types_package_name(peer)));
         if seed_for_targets || seed_for_type_peers {
             seed_names_set.insert(flag.name.as_str());
+        }
+    }
+
+    // Curated project-context eject (nub#457): union every `NUB_PROJECT_CONTEXT_EJECT`
+    // name PRESENT in the resolved graph. Their builds read/mutate the consuming
+    // project, so a GVS store-detached materialization crashes or emits
+    // shared-mutable wrong output; seeding them here routes them through the SAME
+    // importer-closure + disk-materialize path as the phantom seeds (a git-hook leaf
+    // has ~0 importers, so its closure is just itself). The presence gate keeps an
+    // absent name free.
+    let graph_names: HashSet<&str> = graph.packages.values().map(|p| p.name.as_str()).collect();
+    for &name in NUB_PROJECT_CONTEXT_EJECT {
+        if graph_names.contains(name) {
+            seed_names_set.insert(name);
         }
     }
 
@@ -583,6 +646,39 @@ mod tests {
         let g = graph(&[("lodash@4.17.21", "lodash", &[])]);
         let plan = plan_from_flags(&g, &[], &[]);
         assert!(plan.names.is_empty());
+    }
+
+    // Curated project-context eject (nub#457): a build that reads/mutates the
+    // consuming project ejects from GVS; a self-contained build stays symlinked.
+
+    #[test]
+    fn project_context_pkg_ejects_from_gvs() {
+        // `simple-git-hooks` postinstall walks up from cwd to the project root; under
+        // GVS the store-detached copy crashes (#457 ENOENT). As a curated
+        // project-context leaf it seeds its own closure (no importers, no phantom
+        // flag) purely by name.
+        let g = graph(&[("simple-git-hooks@2.13.1", "simple-git-hooks", &[])]);
+        let plan = plan_from_flags(&g, &[], &[]);
+        assert!(
+            plan.names.iter().any(|n| n == "simple-git-hooks"),
+            "a curated project-context package ejects: {:?}",
+            plan.names
+        );
+    }
+
+    #[test]
+    fn self_contained_build_stays_symlinked() {
+        // esbuild ships a prebuilt-binary downloader — self-contained, output shared
+        // cross-project via the side-effects cache — so it is deliberately NOT
+        // curated and stays in GVS (symlinked, built once). No phantom flag, so
+        // nothing seeds it: the eject is curated, not blanket-on-every-script-haver.
+        let g = graph(&[("esbuild@0.20.0", "esbuild", &[])]);
+        let plan = plan_from_flags(&g, &[], &[]);
+        assert!(
+            plan.names.is_empty(),
+            "a self-contained build is not ejected: {:?}",
+            plan.names
+        );
     }
 
     #[test]


### PR DESCRIPTION
`nub i simple-git-hooks` crashes: its `postinstall` runs inside the global virtual store, detached from any project. simple-git-hooks walks up from `cwd` to find a project root, lands on the per-package store wrapper (which has no `package.json`), and throws ENOENT. The same package builds cleanly with GVS disabled, where it materializes project-local — so ejection is the fix.

This adds `NUB_PROJECT_CONTEXT_EJECT`, a curated list of packages whose build reads or mutates the *consuming* project, as an additional disk-materialize seed. Every listed name present in the resolved graph unions into the existing phantom-eject seed set and flows through the same importer-closure + disk-materialize path, so the package materializes project-local (a real project above `cwd`) instead of symlinked into the shared store.

**Curated, not blanket.** Self-contained builds — node-gyp native compiles, prebuilt-binary downloaders like esbuild — read only their own dir and share output across projects via the side-effects cache, so they stay symlinked in the store (built once, shared). Only the project-context class ejects.

Notes on the list:

- Git-hook installers (simple-git-hooks, lefthook, pre-commit, …) are leaves — the closure is the package itself, so ejecting them is free.
- `vue-demi` / `@intlify/*` bridges carry real importer closures in Vue projects. They are included because their build rewrites which output to expose based on the consuming project's installed Vue major, so their built content is project-specific — the eject is a correctness requirement, not only the #457 crash.
- `msw` and `install-peers` are included conservatively; they may already resolve the consuming project via `INIT_CWD`, but ejecting them is safe and removes the dependence on that.

The curated seed is injected inside the disk-materialize expand hook, past aube's `disk_materialize_packages` settings fold, so a warm/upgrade tree would otherwise keep an identical install-state fingerprint and skip the relink — leaving the fix inert on existing installs. A stable, order-independent token of the list is folded into the install-state fingerprint so the initial upgrade and any future list edit invalidate the warm tree and force the relink.

Verified end-to-end: `nub i simple-git-hooks` in a fresh project exits 0 and materializes project-local (was ENOENT); a bare re-`install` hits the up-to-date fast path with no re-materialize (no wipe-loop); `nub i esbuild` stays symlinked into the global store. Unit tests cover the eject, the stays-symlinked contract, and the fingerprint token's order-independence and edit-sensitivity.

Closes #457
