### PR TITLE
feat(run): fall back to node_modules/.bin on a script miss

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -2803,13 +2803,24 @@ fn run_script(
             nub_core::workspace::detect::detect_project(&ws_root).ok_or_else(|| {
                 anyhow::anyhow!("--workspace-root: no package.json at {}", ws_root.display())
             })?;
-        let cmd = nub_core::workspace::scripts::resolve_script(&root_project.manifest, script)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "missing script: \"{script}\" in the workspace root\n\nAvailable scripts:\n{}",
+        let cmd = match nub_core::workspace::scripts::resolve_script(&root_project.manifest, script)
+        {
+            Some(cmd) => cmd,
+            None => {
+                // The same `.bin` fallback as the single-package path, resolved
+                // against the workspace root's chain (see `run_selected_scripts`).
+                if let Some(code) =
+                    run_bin_fallback_for_plain_name(script, &ws_root, compat_mode, args)?
+                {
+                    return Ok(code);
+                }
+                let bin_note = bin_miss_note(script);
+                anyhow::bail!(
+                    "missing script: \"{script}\" in the workspace root{bin_note}\n\nAvailable scripts:\n{}",
                     list_scripts(&root_project.manifest)
-                )
-            })?;
+                );
+            }
+        };
         let exec = ScriptExecOpts {
             ignore_scripts: ws.ignore_scripts,
             script_shell: ws.script_shell.as_deref(),
@@ -2846,11 +2857,20 @@ fn run_selected_scripts(
             bail!("RegExp flags are not supported in script command selector");
         }
         ScriptSelection::None => {
+            // A plain (non-regex) name that matches no script may still name a
+            // local binary: the bun/aube-style `.bin` fallback, tried BEFORE
+            // `--if-present` (a bin on disk is "present" — aube's order).
+            if let Some(code) =
+                run_bin_fallback_for_plain_name(selector, &project.root, compat_mode, args)?
+            {
+                return Ok(code);
+            }
             if ws.if_present {
                 return Ok(0);
             }
+            let bin_note = bin_miss_note(selector);
             bail!(
-                "missing script: \"{selector}\"\n\nAvailable scripts:\n{}",
+                "missing script: \"{selector}\"{bin_note}\n\nAvailable scripts:\n{}",
                 list_scripts(&project.manifest)
             );
         }
@@ -4842,6 +4862,86 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
 
 fn run_exec(bin: &str, compat_mode: bool, args: &[String]) -> Result<i32> {
     run_exec_with_dlx(bin, compat_mode, args, None)
+}
+
+/// The `.bin` fallback gated to plain names: a `/regex/` selector never falls
+/// back (a bin name can't contain the selector's slashes).
+fn run_bin_fallback_for_plain_name(
+    name: &str,
+    dir: &Path,
+    compat_mode: bool,
+    args: &[String],
+) -> Result<Option<i32>> {
+    if name.starts_with('/') {
+        return Ok(None);
+    }
+    try_run_bin_fallback(name, dir, compat_mode, args)
+}
+
+/// The missing-script error's `.bin` addendum — empty for a regex selector,
+/// which never consulted `.bin`.
+fn bin_miss_note(name: &str) -> String {
+    if name.starts_with('/') {
+        String::new()
+    } else {
+        format!(" (and no node_modules/.bin/{name})")
+    }
+}
+
+/// `nub run <name>` fallback tier: when `<name>` matches no package.json
+/// script, resolve it as a local binary instead of erroring — bun/aube parity
+/// (aube's run.md: "If no script matches, aube falls back to
+/// node_modules/.bin/<name>"). Resolution reuses the `nub exec` machinery
+/// verbatim: `find_bin` walks up (a hoisted workspace-root `.bin` counts) and
+/// `launch_bin` runs the entry shebang-aware; on a Yarn PnP tree (no
+/// node_modules) the pnp-bin-run runner resolves via pnpapi. Local only — a
+/// miss NEVER falls through to the registry (that is `nubx`/`dlx` territory);
+/// the caller turns `Ok(None)` into `--if-present` or the missing-script
+/// error. No lifecycle hooks or `npm_lifecycle_*` env: a bin is not a script.
+fn try_run_bin_fallback(
+    name: &str,
+    dir: &Path,
+    compat_mode: bool,
+    args: &[String],
+) -> Result<Option<i32>> {
+    // Echo the same `$ <cmd>` preamble a script run prints (stderr, `--silent`
+    // suppresses) so a fallback run reads like the script run it replaces.
+    // Args display sh-escaped for token boundaries; the launch itself passes
+    // argv directly, no shell involved.
+    let echo = || {
+        if !SILENT.load(Ordering::Relaxed) {
+            let mut display = name.to_string();
+            for a in args {
+                display.push(' ');
+                display.push_str(&nub_core::workspace::shell_escape::sh(a));
+            }
+            eprintln!("$ {display}");
+        }
+    };
+
+    if let Some(bin_path) = nub_core::workspace::scripts::find_bin(name, dir) {
+        echo();
+        return launch_bin(&bin_path, args, compat_mode, dir).map(Some);
+    }
+
+    // Yarn PnP: no node_modules/.bin, so probe then run through the pnp
+    // runner, exactly as `nub exec` does. The probe keeps a bin MISS silent
+    // here — the runner itself exits 127 with its own not-found message,
+    // which would shadow the missing-script error the caller owns.
+    if !compat_mode && nub_core::pnp::detect(dir).is_some() {
+        if let Some(runner) = pnp_bin_runner_path() {
+            let probe_args = vec![runner.clone(), "--probe".to_string(), name.to_string()];
+            if run_file_in_dir(&probe_args, compat_mode, dir, false)? != 0 {
+                return Ok(None);
+            }
+            echo();
+            let mut cmd_args = vec![runner, name.to_string()];
+            cmd_args.extend(args.iter().cloned());
+            return run_file_in_dir(&cmd_args, compat_mode, dir, true).map(Some);
+        }
+    }
+
+    Ok(None)
 }
 
 /// `run_exec`, plus the `nubx` npx-parity flags that steer the DLX fallback.

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4864,27 +4864,33 @@ fn run_exec(bin: &str, compat_mode: bool, args: &[String]) -> Result<i32> {
     run_exec_with_dlx(bin, compat_mode, args, None)
 }
 
-/// The `.bin` fallback gated to plain names: a `/regex/` selector never falls
-/// back (a bin name can't contain the selector's slashes).
+/// A name the `.bin` fallback may resolve: no path separators, so a
+/// `/regex/` selector never falls back and `../foo` can't traverse out of
+/// `.bin` via the walk-up (bin names on disk are always flat).
+fn is_plain_bin_name(name: &str) -> bool {
+    !name.contains('/') && !name.contains('\\')
+}
+
+/// The `.bin` fallback gated to plain names (see `is_plain_bin_name`).
 fn run_bin_fallback_for_plain_name(
     name: &str,
     dir: &Path,
     compat_mode: bool,
     args: &[String],
 ) -> Result<Option<i32>> {
-    if name.starts_with('/') {
+    if !is_plain_bin_name(name) {
         return Ok(None);
     }
     try_run_bin_fallback(name, dir, compat_mode, args)
 }
 
-/// The missing-script error's `.bin` addendum — empty for a regex selector,
-/// which never consulted `.bin`.
+/// The missing-script error's `.bin` addendum — empty for a name the fallback
+/// never consulted (regex selector, path-shaped).
 fn bin_miss_note(name: &str) -> String {
-    if name.starts_with('/') {
-        String::new()
-    } else {
+    if is_plain_bin_name(name) {
         format!(" (and no node_modules/.bin/{name})")
+    } else {
+        String::new()
     }
 }
 

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -6559,6 +6559,317 @@ fn run_prefers_local_node_modules_bin_over_system_path() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// Spawn `nub run <args>` in an arbitrary (temp) directory — the `run_in`
+/// fixture-dir helper's sibling for runtime-built projects (node_modules is
+/// gitignored, so `.bin` fixtures must be created at runtime).
+fn run_in_dir(dir: &Path, args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(nub_binary())
+        .arg("run")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("spawn nub run");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// Write a platform-shaped `node_modules/.bin` entry: a bare shebang file on
+/// Unix (0o755), plus the `.cmd` shim npm/pnpm write on Windows — `find_bin`
+/// only matches the executable extensions there. The `.cmd` runs
+/// `node <bare> %*` so args forward and the node-shebang body executes.
+fn write_local_bin(dir: &Path, name: &str, body: &str) {
+    let bin_dir = dir.join("node_modules").join(".bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let bare = bin_dir.join(name);
+    std::fs::write(&bare, body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&bare, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    #[cfg(windows)]
+    std::fs::write(
+        bin_dir.join(format!("{name}.cmd")),
+        format!("@ECHO off\nnode \"%~dp0\\{name}\" %*\n"),
+    )
+    .unwrap();
+}
+
+/// A temp single-package project for the run-.bin-fallback tests.
+fn run_bin_project(tag: &str, package_json: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("nub-runbin-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), package_json).unwrap();
+    dir
+}
+
+const NODE_BIN_BODY: &str =
+    "#!/usr/bin/env node\nconsole.log('BIN:' + JSON.stringify(process.argv.slice(2)));\n";
+
+/// bun/aube parity: `nub run <name>` with no matching script falls back to
+/// `node_modules/.bin/<name>` and forwards trailing args, so a locally
+/// installed CLI (astro, vite, wrangler) runs without a pass-through script.
+#[test]
+fn run_bin_fallback_runs_local_bin_and_forwards_args() {
+    let dir = run_bin_project(
+        "basic",
+        r#"{"name":"t","scripts":{"build":"node -e \"console.log('BUILD')\""}}"#,
+    );
+    write_local_bin(&dir, "greet", NODE_BIN_BODY);
+
+    let (stdout, stderr, code) = run_in_dir(&dir, &["greet", "a", "b c"]);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains("BIN:[\"a\",\"b c\"]"),
+        "the bin runs with args forwarded: {stdout}"
+    );
+    // Same `$ <cmd>` preamble a script run prints, args sh-escaped for display.
+    assert!(
+        stderr.contains("$ greet a 'b c'"),
+        "the preamble echoes the bin launch: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A same-named script always wins over the bin — the manifest is the
+/// explicit surface, the bin only the fallback.
+#[test]
+fn run_bin_fallback_script_wins_over_same_named_bin() {
+    let dir = run_bin_project(
+        "wins",
+        r#"{"name":"t","scripts":{"greet":"node -e \"console.log('SCRIPT')\""}}"#,
+    );
+    write_local_bin(&dir, "greet", NODE_BIN_BODY);
+
+    let (stdout, stderr, code) = run_in_dir(&dir, &["greet"]);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("SCRIPT"), "the script must run: {stdout}");
+    assert!(
+        !stdout.contains("BIN:"),
+        "the bin must not shadow the script: {stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The fallback is shebang-aware (via `launch_bin`): a non-node `#!/bin/sh`
+/// tool execs directly rather than choking on `node <path>`. Unix-only, same
+/// platform split as `exec_runs_node_and_non_node_bins`.
+#[cfg(unix)]
+#[test]
+fn run_bin_fallback_runs_non_node_bin() {
+    let dir = run_bin_project("nonode", r#"{"name":"t","scripts":{}}"#);
+    write_local_bin(&dir, "shtool", "#!/bin/sh\necho \"SH:$*\"\n");
+
+    let (stdout, stderr, code) = run_in_dir(&dir, &["shtool", "x", "y"]);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("SH:x y"), "the sh bin runs: {stdout}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `find_bin` walks up, so a member without its own `.bin` still resolves the
+/// workspace ROOT's hoisted entry — the pnpm-isolated-layout case.
+#[test]
+fn run_bin_fallback_walks_up_to_workspace_root() {
+    let dir = run_bin_project(
+        "walkup",
+        r#"{"name":"ws","workspaces":["packages/*"],"scripts":{}}"#,
+    );
+    write_local_bin(&dir, "greet", NODE_BIN_BODY);
+    let member = dir.join("packages").join("app");
+    std::fs::create_dir_all(&member).unwrap();
+    std::fs::write(
+        member.join("package.json"),
+        r#"{"name":"app","scripts":{}}"#,
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run_in_dir(&member, &["greet"]);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains("BIN:"),
+        "the hoisted root bin resolves from a member: {stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `--silent` suppresses the fallback's `$ <name>` preamble exactly as it
+/// suppresses a script's `$ <cmd>` echo.
+#[test]
+fn run_bin_fallback_silent_suppresses_preamble() {
+    let dir = run_bin_project("silent", r#"{"name":"t","scripts":{}}"#);
+    write_local_bin(&dir, "greet", NODE_BIN_BODY);
+
+    let (stdout, stderr, code) = run_in_dir(&dir, &["--silent", "greet"]);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("BIN:"), "the bin still runs: {stdout}");
+    assert!(
+        !stderr.contains("$ greet"),
+        "--silent suppresses the preamble: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `--if-present` treats a resolvable bin as present (bin on disk runs);
+/// with neither script nor bin it exits 0 silently, as before.
+#[test]
+fn run_bin_fallback_if_present() {
+    let dir = run_bin_project("ifpresent", r#"{"name":"t","scripts":{}}"#);
+    write_local_bin(&dir, "greet", NODE_BIN_BODY);
+
+    let (stdout, stderr, code) = run_in_dir(&dir, &["--if-present", "greet"]);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains("BIN:"),
+        "a bin on disk is 'present' and runs: {stdout}"
+    );
+
+    let (stdout, stderr, code) = run_in_dir(&dir, &["--if-present", "nope"]);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        !stderr.contains("missing script"),
+        "--if-present stays silent when nothing resolves: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A bin is not a lifecycle: `pre<name>`/`post<name>` scripts must NOT fire
+/// around a bin fallback, even when they exist in the manifest.
+#[test]
+fn run_bin_fallback_skips_pre_post_lifecycle() {
+    let dir = run_bin_project(
+        "hooks",
+        r#"{"name":"t","scripts":{"pregreet":"node -e \"console.log('PRE')\"","postgreet":"node -e \"console.log('POST')\""}}"#,
+    );
+    write_local_bin(&dir, "greet", NODE_BIN_BODY);
+
+    let (stdout, stderr, code) = run_in_dir(&dir, &["greet"]);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("BIN:"), "the bin runs: {stdout}");
+    assert!(
+        !stdout.contains("PRE") && !stdout.contains("POST"),
+        "no lifecycle hooks fire for a bin: {stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Double miss (no script, no bin): the missing-script error keeps exit 1
+/// and its available-scripts list, now noting the `.bin` lookup also failed.
+/// Local only — never a registry fetch (that is `nubx`/`dlx` territory).
+#[test]
+fn run_bin_fallback_double_miss_keeps_missing_script_error() {
+    let dir = run_bin_project(
+        "miss",
+        r#"{"name":"t","scripts":{"build":"node -e \"console.log('BUILD')\""}}"#,
+    );
+
+    let (_, stderr, code) = run_in_dir(&dir, &["nope"]);
+    assert_eq!(code, 1, "missing script stays exit 1: {stderr}");
+    assert!(
+        stderr.contains("missing script: \"nope\""),
+        "the missing-script shape is preserved: {stderr}"
+    );
+    assert!(
+        stderr.contains("node_modules/.bin/nope"),
+        "the error notes the failed .bin lookup: {stderr}"
+    );
+    assert!(
+        stderr.contains("build"),
+        "available scripts are still listed: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A `/regex/` selector never triggers the fallback — a no-match regex keeps
+/// its plain missing-script error even when a like-named bin exists.
+#[test]
+fn run_bin_fallback_regex_selector_never_falls_back() {
+    let dir = run_bin_project("regex", r#"{"name":"t","scripts":{}}"#);
+    write_local_bin(&dir, "greet", NODE_BIN_BODY);
+
+    let (stdout, stderr, code) = run_in_dir(&dir, &["/greet/"]);
+    assert_eq!(code, 1, "a no-match regex still errors: {stderr}");
+    assert!(
+        !stdout.contains("BIN:"),
+        "the bin must not run for a regex selector: {stdout}"
+    );
+    assert!(
+        stderr.contains("missing script"),
+        "the regex keeps its missing-script error: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `-w` applies the same `.bin` fallback against the workspace ROOT package's
+/// chain: from a member, a scriptless name resolves the root's bin.
+#[test]
+fn run_bin_fallback_workspace_root() {
+    let dir = run_bin_project(
+        "wsroot",
+        r#"{"name":"ws","workspaces":["packages/*"],"scripts":{}}"#,
+    );
+    write_local_bin(&dir, "roottool", NODE_BIN_BODY);
+    let member = dir.join("packages").join("app");
+    std::fs::create_dir_all(&member).unwrap();
+    std::fs::write(
+        member.join("package.json"),
+        r#"{"name":"app","scripts":{"roottool":"node -e \"console.log('MEMBER')\""}}"#,
+    )
+    .unwrap();
+
+    // The member's own script must NOT win: -w targets only the root, whose
+    // bin is the fallback.
+    let (stdout, stderr, code) = run_in_dir(&member, &["-w", "roottool"]);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains("BIN:"),
+        "the root bin runs under -w: {stdout}"
+    );
+    assert!(
+        !stdout.contains("MEMBER"),
+        "-w never touches the member's script: {stdout}"
+    );
+
+    // A root script still wins over the root bin.
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"ws","workspaces":["packages/*"],"scripts":{"roottool":"node -e \"console.log('ROOT-SCRIPT')\""}}"#,
+    )
+    .unwrap();
+    let (stdout, stderr, code) = run_in_dir(&member, &["-w", "roottool"]);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains("ROOT-SCRIPT"),
+        "the root script wins over the root bin: {stdout}"
+    );
+
+    // Double miss keeps the workspace-root error, extended with the bin note.
+    let (_, stderr, code) = run_in_dir(&member, &["-w", "nope"]);
+    assert_eq!(code, 1, "missing root script stays exit 1: {stderr}");
+    assert!(
+        stderr.contains("missing script: \"nope\" in the workspace root"),
+        "the workspace-root error shape is preserved: {stderr}"
+    );
+    assert!(
+        stderr.contains("node_modules/.bin/nope"),
+        "the error notes the failed .bin lookup: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// npm/pnpm set `$NODE` to the node binary running the script so `$NODE child.js`
 /// invokes "the same Node." nub points it at the PATH-shim node (→ nub) so an
 /// absolute-path `$NODE` re-enters nub and the child stays augmented (it used to be

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -6870,6 +6870,40 @@ fn run_bin_fallback_workspace_root() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// The fallback never resolves path-shaped names: `../evil` must NOT traverse
+/// out of `.bin` via the walk-up, and `sub/tool` must not reach a nested file
+/// (real .bin entries are always flat). Both keep the missing-script error.
+#[test]
+fn run_bin_fallback_never_resolves_path_shaped_names() {
+    let dir = run_bin_project("traversal", r#"{"name":"t","scripts":{}}"#);
+    // A node-shebang file OUTSIDE .bin that a naive `.bin.join("../evil")`
+    // would resolve, and a nested file a `.bin.join("sub/tool")` would reach.
+    write_local_bin(&dir, "tool", NODE_BIN_BODY);
+    std::fs::write(
+        dir.join("node_modules").join("evil.js"),
+        "#!/usr/bin/env node\nconsole.log('TRAVERSED');\n",
+    )
+    .unwrap();
+    let nested = dir.join("node_modules").join(".bin").join("sub");
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::write(nested.join("tool"), NODE_BIN_BODY).unwrap();
+
+    for name in ["../evil.js", "sub/tool"] {
+        let (stdout, stderr, code) = run_in_dir(&dir, &[name]);
+        assert_eq!(code, 1, "{name} must not resolve: {stdout}{stderr}");
+        assert!(
+            !stdout.contains("TRAVERSED") && !stdout.contains("BIN:"),
+            "{name} must not execute anything: {stdout}"
+        );
+        assert!(
+            stderr.contains("missing script"),
+            "{name} keeps the missing-script error: {stderr}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// npm/pnpm set `$NODE` to the node binary running the script so `$NODE child.js`
 /// invokes "the same Node." nub points it at the PATH-shim node (→ nub) so an
 /// absolute-path `$NODE` re-enters nub and the child stays augmented (it used to be

--- a/runtime/pnp-bin-run.cjs
+++ b/runtime/pnp-bin-run.cjs
@@ -3,6 +3,12 @@
 // `--require .pnp.cjs`, so `findPnpApi` is set up and the zipfs `fs` patch is live.
 //
 // Invoked as:  nub <this> <binName> [args...]
+//              nub <this> --probe <binName>   (resolve-only: exit 0 found, 1 not
+//                                             found, printing nothing — `nub run`'s
+//                                             .bin fallback uses it to keep a PnP bin
+//                                             miss silent so its missing-script error
+//                                             owns the double-miss case, not this
+//                                             runner's 127)
 //
 // Two things matter:
 //   1. PnP has no `node_modules/.bin`, so we find the bin by walking the top-level
@@ -21,15 +27,16 @@ const fs = require("node:fs");
 const { pathToFileURL } = require("node:url");
 const { cwdIssuer } = require("./pnp-util.cjs");
 
-const want = process.argv[2];
-const rest = process.argv.slice(3);
+const probe = process.argv[2] === "--probe";
+const want = probe ? process.argv[3] : process.argv[2];
+const rest = probe ? process.argv.slice(4) : process.argv.slice(3);
 
 // `require("pnpapi")` throws for an out-of-tree issuer (this file lives in nub's
 // install dir); `findPnpApi` resolves by the queried path, so it works here.
 const api = require("node:module").findPnpApi(cwdIssuer());
 if (!api) {
-  process.stderr.write("nubx: not a Yarn PnP project\n");
-  process.exit(127);
+  if (!probe) process.stderr.write("nubx: not a Yarn PnP project\n");
+  process.exit(probe ? 1 : 127);
 }
 
 // bin name -> relative script path. A string `bin` is named after the package
@@ -67,12 +74,15 @@ for (const [name, reference] of top.packageDependencies) {
 }
 
 if (!script) {
+  if (probe) process.exit(1);
   process.stderr.write(
     `nubx: '${want}' not found in Yarn PnP dependencies.\n` +
       `      add it (yarn add ${want}), or run it ad-hoc with: yarn dlx ${want}\n`,
   );
   process.exit(127);
 }
+
+if (probe) process.exit(0);
 
 // Run the bin as if it were the entry: present its own argv, then load it via the
 // zip-safe CJS path. Fall back to dynamic import for an ESM bin.

--- a/runtime/pnp-bin-run.cjs
+++ b/runtime/pnp-bin-run.cjs
@@ -34,10 +34,19 @@ const rest = probe ? process.argv.slice(4) : process.argv.slice(3);
 // `require("pnpapi")` throws for an out-of-tree issuer (this file lives in nub's
 // install dir); `findPnpApi` resolves by the queried path, so it works here.
 const api = require("node:module").findPnpApi(cwdIssuer());
-if (!api) {
-  if (!probe) process.stderr.write("nubx: not a Yarn PnP project\n");
-  process.exit(probe ? 1 : 127);
+if (!api && !probe) {
+  process.stderr.write("nubx: not a Yarn PnP project\n");
+  process.exit(127);
 }
+
+// No explicit process.exit() anywhere on the probe path: on Windows, exit()
+// with piped stdio races libuv's handle teardown and can abort on the
+// UV_HANDLE_CLOSING assert, surfacing a crash code instead of the intended
+// 0/1 — nub then reads a bin HIT as a miss (the windows-latest PnP leg caught
+// this). Set exitCode and let the event loop drain instead.
+const probeMiss = () => {
+  process.exitCode = 1;
+};
 
 // bin name -> relative script path. A string `bin` is named after the package
 // (its unscoped tail); an object maps explicit names.
@@ -49,53 +58,58 @@ function binsOf(pkg) {
 }
 
 let script = null;
-// Anchor on the package that OWNS cwd — a workspace member, or the project root for a
-// single-package install. Its dependencies are the bins runnable here, matching
-// `yarn bin`. Using `api.topLevel` (the workspace ROOT) would, in a monorepo, list
-// only the member packages and miss a member's own dep/devDep bins. `findPackageLocator`
-// falls back to topLevel for the single-package case (cwd === root).
-const locator = api.findPackageLocator(cwdIssuer()) || api.topLevel;
-const top = api.getPackageInformation(locator);
-for (const [name, reference] of top.packageDependencies) {
-  if (reference == null) continue;
-  const info = api.getPackageInformation(api.getLocator(name, reference));
-  if (!info) continue;
-  let pkg;
-  try {
-    pkg = JSON.parse(fs.readFileSync(path.join(info.packageLocation, "package.json"), "utf8"));
-  } catch {
-    continue;
-  }
-  const rel = binsOf(pkg)[want];
-  if (rel) {
-    script = path.join(info.packageLocation, rel);
-    break;
+if (api) {
+  // Anchor on the package that OWNS cwd — a workspace member, or the project root for a
+  // single-package install. Its dependencies are the bins runnable here, matching
+  // `yarn bin`. Using `api.topLevel` (the workspace ROOT) would, in a monorepo, list
+  // only the member packages and miss a member's own dep/devDep bins. `findPackageLocator`
+  // falls back to topLevel for the single-package case (cwd === root).
+  const locator = api.findPackageLocator(cwdIssuer()) || api.topLevel;
+  const top = api.getPackageInformation(locator);
+  for (const [name, reference] of top.packageDependencies) {
+    if (reference == null) continue;
+    const info = api.getPackageInformation(api.getLocator(name, reference));
+    if (!info) continue;
+    let pkg;
+    try {
+      pkg = JSON.parse(fs.readFileSync(path.join(info.packageLocation, "package.json"), "utf8"));
+    } catch {
+      continue;
+    }
+    const rel = binsOf(pkg)[want];
+    if (rel) {
+      script = path.join(info.packageLocation, rel);
+      break;
+    }
   }
 }
 
 if (!script) {
-  if (probe) process.exit(1);
-  process.stderr.write(
-    `nubx: '${want}' not found in Yarn PnP dependencies.\n` +
-      `      add it (yarn add ${want}), or run it ad-hoc with: yarn dlx ${want}\n`,
-  );
-  process.exit(127);
-}
-
-if (probe) process.exit(0);
-
-// Run the bin as if it were the entry: present its own argv, then load it via the
-// zip-safe CJS path. Fall back to dynamic import for an ESM bin.
-process.argv = [process.argv[0], script, ...rest];
-try {
-  require(script);
-} catch (e) {
-  if (e && e.code === "ERR_REQUIRE_ESM") {
-    import(pathToFileURL(script).href).catch((err) => {
-      console.error(err);
-      process.exit(1);
-    });
+  if (probe) {
+    probeMiss();
   } else {
-    throw e;
+    process.stderr.write(
+      `nubx: '${want}' not found in Yarn PnP dependencies.\n` +
+        `      add it (yarn add ${want}), or run it ad-hoc with: yarn dlx ${want}\n`,
+    );
+    process.exit(127);
+  }
+} else if (probe) {
+  process.exitCode = 0;
+} else {
+  // Run the bin as if it were the entry: present its own argv, then load it
+  // via the zip-safe CJS path. Fall back to dynamic import for an ESM bin.
+  process.argv = [process.argv[0], script, ...rest];
+  try {
+    require(script);
+  } catch (e) {
+    if (e && e.code === "ERR_REQUIRE_ESM") {
+      import(pathToFileURL(script).href).catch((err) => {
+        console.error(err);
+        process.exit(1);
+      });
+    } else {
+      throw e;
+    }
   }
 }

--- a/site/content/docs/runner/exec.mdx
+++ b/site/content/docs/runner/exec.mdx
@@ -11,7 +11,7 @@ nub exec tsc --noEmit
 nub exec vitest run --coverage
 ```
 
-The `nub exec` command resolves an executable on the `node_modules/.bin` chain — the nearest `node_modules/.bin`, then up through parent directories to the workspace root — and exec's it directly. It never reaches the registry: when nothing matches, it prints an install hint and exits 127. For a name that might need fetching, use [`nubx`](/docs/runner), which falls through to the registry instead.
+The `nub exec` command resolves an executable on the `node_modules/.bin` chain — the nearest `node_modules/.bin`, then up through parent directories to the workspace root — and exec's it directly. It never reaches the registry: when nothing matches, it prints an install hint and exits 127. For a name that might need fetching, use [`nubx`](/docs/runner), which falls through to the registry instead. (`nub run` also resolves these bins, but only as a fallback when no script matches — `exec` is the explicit form, and the one to use in scripts where a coincidental script name would otherwise win.)
 
 The walk-up happens in Rust, so the wrapper overhead that `npx` and `pnpm exec` pay on every call — a full Node bootstrap — approximately disappears.
 

--- a/site/content/docs/runner/run.mdx
+++ b/site/content/docs/runner/run.mdx
@@ -22,7 +22,7 @@ A few flags behave differently. The `--report-summary` flag streams results live
 
 ## `nub run <script>`
 
-Pass the script name after `run`. The name must match a key in your `package.json`'s `"scripts"` field.
+Pass the script name after `run`. The name matches a key in your `package.json`'s `"scripts"` field — or, failing that, a binary in `node_modules/.bin`.
 
 ```bash
 nub run build
@@ -31,6 +31,19 @@ nub run test
 ```
 
 Running a script is always `nub run <script>` — barewords like `nub dev` do not fall through to scripts. (If you type `nub build` and `build` is a real script, Nub's error tells you to type `nub run build`.) See [Running files](/docs/runtime) for how `nub <file>` works.
+
+### Local binaries
+
+When the name matches no script, Nub resolves `node_modules/.bin/<name>` — walking up to the workspace root, so a hoisted install counts — and runs it with your arguments forwarded. Locally installed CLIs just work, no pass-through script required:
+
+```bash
+nub run astro dev        # no "astro": "astro" boilerplate in package.json
+nub run tsc --noEmit     # args forward exactly as with a script
+```
+
+A script always wins over a same-named bin, and the fallback is local-only: it never fetches from the registry (that is [`nubx`](/docs/runner/dlx) territory). On Yarn PnP projects the bin resolves through the PnP runtime instead of `node_modules`. A bin is not a lifecycle, so `pre<name>`/`post<name>` hooks do not fire and no `npm_lifecycle_*` variables are set. `--if-present` treats a resolvable bin as present. When neither script nor bin exists, the error is the same `missing script` you already know, noting the `.bin` lookup too.
+
+This is the one place `nub run` deliberately goes beyond `pnpm run`/`npm run`, matching `bun run` instead — everywhere else the drop-in contract holds.
 
 Dispatch is handled in Rust with no Node bootstrap in the wrapper, so the runner adds only a few milliseconds before your script's first byte — faster than Node's own `node --run`:
 

--- a/tests/conformance/cmdflag/expectations.txt
+++ b/tests/conformance/cmdflag/expectations.txt
@@ -24,7 +24,7 @@ audit-json       same, --json
 audit-dev        same, --dev
 audit-level      same, --audit-level high
 outdated         outdated deps present → exit 1 (conventional)
-run-missing-script  missing script → exit 1 (correct; pnpm also errors WITHOUT --if-present)
+run-missing-script  missing script → exit 1 (correct; pnpm also errors WITHOUT --if-present). Since the .bin fallback, exit 1 also requires the bin lookup to miss — __nub_conformance_no_such_script__ names no installed bin, so the pin holds
 add-dep          monorepo root refuses bare add (needs -W) → exit 1 (correct guard)
 add-dev          same, -D
 remove-dep       removing an absent dep → non-zero (correct)

--- a/tests/pnp/run-pnp-matrix.sh
+++ b/tests/pnp/run-pnp-matrix.sh
@@ -96,6 +96,12 @@ $(echo "$2" | sed 's/^/    /')"
   # the bin via require() (zip-safe) instead of as a node entry, mirroring `yarn
   # exec`. `nub exec` and the `nubx` argv0 alias share this run_exec path.
   check exec "$(run "$bin" "$NUB" exec cowsay hi)" "< hi >"
+  # run-fallback: a scriptless name falls back to the PnP-resolved bin via the
+  # runner's --probe + run branch — the same pnpapi resolution as `exec`, owned
+  # by `nub run`. run-bin-miss pins the probe-silent double miss: `nub run`'s
+  # missing-script error owns it, NOT the runner's 127 not-found message.
+  check run-bin     "$(run "$bin" "$NUB" run cowsay hi)"   "< hi >"
+  check run-bin-miss "$(run "$bin" "$NUB" run nosuchtool)"  "missing script"
 
   # ── Workspace (monorepo), run from a member subdir ──────────────────────────────
   # ws-esm/ws-cjs: resolve a workspace sibling + an external dep from the member.
@@ -109,6 +115,7 @@ $(echo "$2" | sed 's/^/    /')"
   # ws-run: `nub run <script>` from a member (PnP augmentation injected from a subdir).
   # ws-scoped-bin: nubx a SCOPED package's string bin (named after its unscoped tail).
   check ws-run        "$(runws "$bin" "$NUB" run start)"          "WS-RUN-OK"
+  check ws-run-bin    "$(runws "$bin" "$NUB" run cowsay wsmember)" "< wsmember >"
   check ws-scoped-bin "$(runws "$bin" "$NUB" exec tool)"          "SCOPED-STRING-BIN-OK"
 
   printf "%-12s %d/%d %s\n" "v$nv" "$ok" "$tot" "$line"


### PR DESCRIPTION
## Summary

`nub run <name>` now falls back to `node_modules/.bin/<name>` when the name matches no script, so locally installed CLIs run without a pass-through script. `nub run astro dev` works in a project with no `"astro": "astro"` boilerplate — matching `bun run` and aube's own documented contract ("If no script matches, aube falls back to `node_modules/.bin/<name>`"), which nub's Rust `run` path had not implemented.

```bash
nub run astro dev        # no script needed; args forward as with a script
nub run tsc --noEmit
```

Behavior, in short:

- A script always wins over a same-named bin.
- Resolution walks up to the workspace root, so hoisted installs work; Yarn PnP trees resolve through the PnP bin-runner `nub exec` already uses.
- Local only — a bin miss never reaches the registry (that stays `nubx`/`dlx` territory).
- A bin is not a lifecycle: no `pre`/`post` hooks, no `npm_lifecycle_*` env. `--if-present` treats a resolvable bin as present. `/regex/` selectors never fall back.
- Double miss keeps exit 1 and the existing `missing script` error, extended to note the `.bin` lookup.

## Design decisions

- **Hook at the two script-miss sites** (single-package selector and `-w` root lookup), trying the bin before `--if-present`, matching aube's order. Resolution and launch reuse the `nub exec` machinery (`find_bin` walk-up, shebang-aware `launch_bin`) — no new resolution logic.
- **PnP probe mode**: the shared `pnp-bin-run.cjs` runner gained a quiet `--probe` (exit 0/1, no output) so a PnP bin miss doesn't shadow the `missing-script` error with the runner's own 127 message.
- **Plain names only**: the fallback refuses path-shaped names, so `nub run ../foo` can't traverse out of `.bin` via the walk-up (found in review; regression test included).
- **Recursive fan-out unchanged**: `-r`/`--filter` keep script-only resolution; per-member bin fallback is a deliberate follow-up.

Session-settled decisions carried from planning: fallback scope limited to single-package + `-w` (user-approved, over including `-r`/`--filter` now); no lifecycle hooks for bins (user-approved, over honoring `pre<name>`/`post<name>`); PnP parity included via the existing runner (user-approved, over node_modules-only); double miss keeps exit 1 (user-approved, over exec's 127 shape).

## Test plan

- 11 new integration tests (written red-first): fallback + arg forwarding, script precedence, non-node (`#!/bin/sh`) bins, walk-up to the workspace root, `--silent` preamble suppression, `--if-present` semantics, no lifecycle hooks, double-miss error shape, regex selectors never falling back, `-w` root bin + root-script precedence, path-traversal guard.
- `cargo test -p nub-core -p nub-cli`: full suite green.
- PnP matrix: 18/18, including 3 new checks — `run-bin` (PnP fallback), `run-bin-miss` (probe-silent double miss keeps the `missing-script` error), `ws-run-bin` (from a member).
- Conformance `run-missing-script` cell still pins exit 1; expectation note updated to record the new requirement (bin lookup must also miss).
- Windows is exercised by the `.cmd`-shaped fixtures on the windows CI leg; `find_bin`'s extension handling is already unit-tested.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a local CLI behavior change with no service, telemetry, or data-path impact; the conformance suite and PnP matrix pin the behavior on every CI run.

## Documentation

`runner/run.mdx` gains a "Local binaries" section (precedence, no-registry boundary, PnP, `--if-present`, the deliberate `pnpm run`/`npm run` deviation), and `runner/exec.mdx` notes when `exec` remains the explicit form.
