### PR TITLE
Fall back to webpki roots and system DNS on Android (no-JVM builds)

### DIFF
--- a/vendor/aube/crates/aube-registry/src/client/http.rs
+++ b/vendor/aube/crates/aube-registry/src/client/http.rs
@@ -193,8 +193,11 @@ fn build_http_client_inner(
         // In-process DNS caching via hickory-dns. The system resolver
         // does not cache and uses a thread pool for `getaddrinfo`,
         // which serializes the first cold lookup per origin. hickory
-        // resolves async + caches for the process lifetime.
-        .hickory_dns(true)
+        // resolves async + caches for the process lifetime. Not on
+        // Android: hickory reads the OS DNS config through JNI and
+        // aborts without a JVM (Termux/CLI builds), so the getaddrinfo
+        // resolver stays in place there.
+        .hickory_dns(cfg!(not(target_os = "android")))
         // `strict-ssl=false` disables cert validation entirely. This
         // is a security hole on purpose: corporate registries should
         // prefer per-registry `ca` / `cafile` so validation stays on.

--- a/vendor/aube/crates/aube-util/src/http/mod.rs
+++ b/vendor/aube/crates/aube-util/src/http/mod.rs
@@ -20,23 +20,37 @@ pub mod ticket_cache;
 /// reqwest's rustls-platform-verifier OS trust store active.
 ///
 /// reqwest 0.13 can merge extra roots with the platform verifier on Unix
-/// (except Android) and Windows. On other targets, leave the builder alone
-/// so client construction does not fail at runtime.
+/// (except Android) and Windows. On Android the platform verifier resolves
+/// the OS trust store through JNI and aborts without a JVM (`ndk-context:
+/// android context was not initialized`) — the Termux/CLI case, where no
+/// app context exists — so there the webpki roots become the ONLY trust
+/// roots (`tls_certs_only`), bypassing the verifier entirely. Hickory DNS
+/// is disabled on Android for the same reason: reqwest's `hickory-dns`
+/// feature defaults the resolver on for every client, and hickory reads
+/// Android's DNS config through the same JNI surface. On other targets,
+/// leave the builder alone so client construction does not fail at runtime.
 pub fn with_webpki_root_fallback(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+    #[cfg(any(unix, target_os = "windows"))]
+    let certs = webpki_root_certs::TLS_SERVER_ROOT_CERTS
+        .iter()
+        .map(|cert| {
+            reqwest::Certificate::from_der(cert.as_ref())
+                // webpki-root-certs is generated as valid DER; failure means the dependency is corrupt.
+                .expect("webpki root certificate must be valid DER")
+        })
+        .collect::<Vec<_>>();
+
     #[cfg(any(all(unix, not(target_os = "android")), target_os = "windows"))]
     {
-        let certs = webpki_root_certs::TLS_SERVER_ROOT_CERTS
-            .iter()
-            .map(|cert| {
-                reqwest::Certificate::from_der(cert.as_ref())
-                    // webpki-root-certs is generated as valid DER; failure means the dependency is corrupt.
-                    .expect("webpki root certificate must be valid DER")
-            })
-            .collect::<Vec<_>>();
         builder.tls_certs_merge(certs)
     }
 
-    #[cfg(not(any(all(unix, not(target_os = "android")), target_os = "windows")))]
+    #[cfg(target_os = "android")]
+    {
+        builder.tls_certs_only(certs).no_hickory_dns()
+    }
+
+    #[cfg(not(any(unix, target_os = "windows")))]
     {
         builder
     }

--- a/vendor/aube/crates/aube/src/commands/global.rs
+++ b/vendor/aube/crates/aube/src/commands/global.rs
@@ -87,7 +87,10 @@ fn resolve_home() -> miette::Result<PathBuf> {
     platform_default()
 }
 
-#[cfg(target_os = "linux")]
+// Android is the Termux/CLI case: bionic userland with a Linux-shaped
+// HOME/XDG layout, so it shares the linux default rather than needing
+// its own arm.
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn platform_default() -> miette::Result<PathBuf> {
     if let Some(xdg) = aube_util::env::xdg_data_home() {
         return Ok(xdg.join("pnpm"));


### PR DESCRIPTION
On Android without a JVM (Termux), any HTTPS request aborts: rustls-platform-verifier and reqwest 0.13's default-on hickory-dns both require JNI/ndk-context, and `platform_default()` had no `android` cfg arm. Adds compile-time Android arms: webpki-roots-only TLS trust, getaddrinfo DNS, and the linux global-dir default. Byte-identical on all shipped targets.

Residual: `nub publish --provenance` builds its own clients and may still abort on Android.

Clippy/fmt/tests green; Android-only reqwest calls type-checked against pinned 0.13.4; reporter verified the equivalent change on-device.

Closes #490

https://claude.ai/code/session_017uZpUP88BDZdorSBR1H33S