### PR TITLE
pm: exclude workspace link packages from dedupe diff

### DIFF
--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -512,6 +512,73 @@ fn yarn_gate_refuses_mutating_verbs_and_names_the_remedy() {
     );
 }
 
+/// Workspace `link:` deps must not surface in dedupe's diff (#494): the
+/// lockfile parser synthesizes `<name>@link+<hash>` package entries that a
+/// fresh resolve never produces, so dedupe reported every workspace link as
+/// "removed" on each run — while the lockfile stayed byte-identical (the
+/// writer never serializes links) and `--check` failed forever. Offline by
+/// construction: the fixture's only deps are workspace members.
+#[test]
+fn dedupe_ignores_workspace_links_and_check_passes() {
+    let dir = pm_tmpdir("dedupe-ws");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"fixture","private":true,"devDependencies":{"@repro/a":"workspace:*"}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\n",
+    )
+    .unwrap();
+    for (rel, manifest) in [
+        (
+            "packages/a",
+            r#"{"name":"@repro/a","version":"1.0.0","dependencies":{"@repro/b":"workspace:*"}}"#,
+        ),
+        ("packages/b", r#"{"name":"@repro/b","version":"1.0.0"}"#),
+    ] {
+        let pkg = dir.join(rel);
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("package.json"), manifest).unwrap();
+    }
+
+    let (xdg_data, xdg_cache) = (pm_tmpdir("dedupe-ws-data"), pm_tmpdir("dedupe-ws-cache"));
+    let install = run_nub_with(&dir, &["install"], &xdg_data, &xdg_cache);
+    assert_eq!(
+        install.code, 0,
+        "stdout: {}\nstderr: {}",
+        install.stdout, install.stderr
+    );
+    let lock_before = std::fs::read_to_string(dir.join("pnpm-lock.yaml")).unwrap();
+
+    let dedupe = run_nub_with(&dir, &["dedupe"], &xdg_data, &xdg_cache);
+    assert_eq!(
+        dedupe.code, 0,
+        "stdout: {}\nstderr: {}",
+        dedupe.stdout, dedupe.stderr
+    );
+    assert!(
+        dedupe.combined().contains("already deduped"),
+        "workspace links must not be reported as dedupe changes: {}",
+        dedupe.combined()
+    );
+    dedupe.assert_brand_clean();
+    assert_eq!(
+        std::fs::read_to_string(dir.join("pnpm-lock.yaml")).unwrap(),
+        lock_before,
+        "dedupe must not change the lockfile"
+    );
+
+    let check = run_nub_with(&dir, &["dedupe", "--check"], &xdg_data, &xdg_cache);
+    assert_eq!(
+        check.code,
+        0,
+        "dedupe --check must pass on a deduped workspace: {}",
+        check.combined()
+    );
+}
+
 /// `nub import` converts a foreign lockfile to pnpm-lock.yaml (nub's
 /// canonical format — never aube-lock.yaml), refuses a second run without
 /// `--force`, and works fully offline.

--- a/vendor/aube/crates/aube/src/commands/dedupe.rs
+++ b/vendor/aube/crates/aube/src/commands/dedupe.rs
@@ -103,7 +103,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
         "Dedupe: {} removed, {} added (net {} packages)",
         removed.len(),
         added.len(),
-        graph.packages.len() as i64 - existing.as_ref().map_or(0, |g| g.packages.len()) as i64,
+        added.len() as i64 - removed.len() as i64,
     );
 
     if args.check {
@@ -125,14 +125,38 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
 /// Diff two lockfile graphs by dep_path. Returns `(removed, added)` — packages
 /// present in `old` but not `new`, and vice versa. Versions that are in both
 /// are omitted (they're untouched).
+///
+/// Only packages the lockfile writer actually serializes participate.
+/// `link:`/`exec:` entries are excluded because the two graphs represent
+/// them asymmetrically: the parser synthesizes a `<name>@link+<hash>`
+/// package for every workspace link it reads back, while a fresh resolve
+/// binds workspace members by version and records no package entry at
+/// all. Since the writer skips them on both paths, they can never be a
+/// real lockfile change — diffing them reported workspace links as
+/// "removed" on every run while the lockfile stayed byte-identical, and
+/// `--check` failed forever.
 fn diff_graphs(
     existing: Option<&aube_lockfile::LockfileGraph>,
     new: &aube_lockfile::LockfileGraph,
 ) -> (Vec<String>, Vec<String>) {
+    fn serialized_keys(
+        pkgs: &BTreeMap<String, aube_lockfile::LockedPackage>,
+    ) -> BTreeSet<&String> {
+        use aube_lockfile::LocalSource;
+        pkgs.iter()
+            .filter(|(_, pkg)| {
+                !matches!(
+                    pkg.local_source,
+                    Some(LocalSource::Link(_) | LocalSource::Exec(_))
+                )
+            })
+            .map(|(key, _)| key)
+            .collect()
+    }
+
     let empty: BTreeMap<String, aube_lockfile::LockedPackage> = BTreeMap::new();
-    let old_pkgs = existing.map(|g| &g.packages).unwrap_or(&empty);
-    let old_keys: BTreeSet<&String> = old_pkgs.keys().collect();
-    let new_keys: BTreeSet<&String> = new.packages.keys().collect();
+    let old_keys = serialized_keys(existing.map(|g| &g.packages).unwrap_or(&empty));
+    let new_keys = serialized_keys(&new.packages);
 
     let removed: Vec<String> = old_keys
         .difference(&new_keys)

--- a/vendor/aube/crates/aube/src/commands/dedupe.rs
+++ b/vendor/aube/crates/aube/src/commands/dedupe.rs
@@ -126,15 +126,18 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
 /// present in `old` but not `new`, and vice versa. Versions that are in both
 /// are omitted (they're untouched).
 ///
-/// Only packages the lockfile writer actually serializes participate.
-/// `link:`/`exec:` entries are excluded because the two graphs represent
-/// them asymmetrically: the parser synthesizes a `<name>@link+<hash>`
-/// package for every workspace link it reads back, while a fresh resolve
-/// binds workspace members by version and records no package entry at
-/// all. Since the writer skips them on both paths, they can never be a
-/// real lockfile change — diffing them reported workspace links as
-/// "removed" on every run while the lockfile stayed byte-identical, and
-/// `--check` failed forever.
+/// Only packages the lockfile writer actually serializes participate:
+/// `link:`/`exec:` entries are excluded, exactly mirroring the writer's
+/// skip set for the `packages:`/`snapshots:` sections (`pnpm/write.rs`),
+/// so a key that can never reach the lockfile can never be reported as a
+/// change. The case that made this bite is workspace-member links, where
+/// the two graphs are also asymmetric: the parser synthesizes a
+/// `<name>@link+<hash>` package for every workspace link it reads back,
+/// while a fresh resolve binds members by version and records no package
+/// entry at all — so dedupe reported them as "removed" on every run
+/// while the lockfile stayed byte-identical, and `--check` failed
+/// forever. (`exec:` and non-member `link:` deps resolve symmetrically;
+/// they are excluded on the writer-parity ground alone.)
 fn diff_graphs(
     existing: Option<&aube_lockfile::LockfileGraph>,
     new: &aube_lockfile::LockfileGraph,


### PR DESCRIPTION
The lockfile parser keys workspace `link:` deps as `<name>@link+<hash>`; a fresh resolve binds them by version and records no package entry, and the writer never serializes them. Dedupe's raw key diff therefore reported the links as removed on every run while the lockfile stayed byte-identical, and `dedupe --check` exited 1 permanently.

Fix: diff only entries the writer serializes (filter `link:`/`exec:` from both sides); derive the net count from the filtered sets.

Closes #494

Verified on the issue's fixture: dedupe reports "already deduped", lockfile unchanged, `--check` exits 0 — matching pnpm 10.15.1. Adds an offline workspace regression test.