### PR TITLE
pm: run approved build scripts during approve-builds

### DIFF
--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -511,16 +511,16 @@ fn run_approve_builds(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::approve_builds::ApproveBuildsArgs) =
         parse_or_return!(typed, args);
     let session = super::engine_session(globals.dir.as_deref())?;
-    // The success summary ends with a raw `` Run `aube install` (or `aube
-    // rebuild`) … `` println on stdout. Capture + rewrite; the interactive
-    // picker is unaffected (it prompts on stderr and reads stdin).
-    let (result, captured) = super::with_fd_captured(1, || {
-        session
-            .runtime
-            .block_on(aube::commands::approve_builds::run(verb))
-    });
-    print!("{}", present::rewrite(&captured));
-    finish(result)
+    // No fd capture: the engine's remaining prints brand through
+    // `prog()`/`cmd()` (already profile-aware), and the verb now runs the
+    // approved packages' build scripts in-process — buffering fd 1 for the
+    // whole call would hold back live script output until the end, reading
+    // as a hang during long native builds. Same shape as `run_rebuild`.
+    finish_quieted(
+        &globals.output,
+        &session,
+        aube::commands::approve_builds::run(verb),
+    )
 }
 
 fn run_ignored_builds(typed: &str, args: &[String]) -> Result<i32> {

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -362,11 +362,13 @@ The two compose: `nub pm shim` routes bare `npm` / `pnpm` / `yarn` through the p
 Some dependencies run build steps on install — `preinstall`, `install`, and `postinstall` scripts declared in their own `package.json` (across pnpm, npm, and Bun). Nub ships a **deny-by-default** posture: it does not run them indiscriminately the way npm does. You control which packages build.
 
 ```bash
-nub approve-builds                # interactively approve packages to build
+nub approve-builds                # approve packages to build, then build them
 nub add --allow-build=<pkg> <pkg> # pre-approve its build scripts as you add it
 nub rebuild                       # re-run scripts for already-approved packages
 nub install --ignore-scripts      # skip dependency build scripts this install
 ```
+
+Approval takes effect immediately: `nub approve-builds` records the decision and runs the just-approved packages' build scripts in the same invocation, matching pnpm — no follow-up `nub install` or `nub rebuild` needed.
 
 Which manifest field grants permission tracks the inferred incumbent: pnpm projects use `pnpm.onlyBuiltDependencies` / `pnpm.allowBuilds`, Bun projects use `trustedDependencies`, and the neutral `allowBuilds` field plus `nub approve-builds` apply in any project. An explicit denial (`allowBuilds: { pkg: false }`, `neverBuiltDependencies`) always wins. A package that wants to build but isn't allowed is skipped, with `WARN_NUB_IGNORED_BUILD_SCRIPTS` naming it and `nub approve-builds` as the remedy.
 

--- a/site/content/docs/install/pnpm.mdx
+++ b/site/content/docs/install/pnpm.mdx
@@ -150,7 +150,7 @@ $ nub install
   │ `hoisted`
 ```
 
-Lifecycle scripts for dependencies are skipped by default, exactly as pnpm 10 does. A package runs install scripts only when allowlisted via `pnpm.onlyBuiltDependencies` (or `pnpm.allowBuilds`), or when Nub's gated default-trust floor vouches for it (see [the default-trust floor](/docs/install#default-trust-floor)); `nub approve-builds` adds an entry interactively. `pnpm.neverBuiltDependencies` is a denylist that wins over any allow and over the floor.
+Lifecycle scripts for dependencies are skipped by default, exactly as pnpm 10 does. A package runs install scripts only when allowlisted via `pnpm.onlyBuiltDependencies` (or `pnpm.allowBuilds`), or when Nub's gated default-trust floor vouches for it (see [the default-trust floor](/docs/install#default-trust-floor)); `nub approve-builds` adds an entry and builds the approved packages in the same invocation. `pnpm.neverBuiltDependencies` is a denylist that wins over any allow and over the floor.
 
 ## Unsupported
 

--- a/vendor/aube/crates/aube-util/src/hash.rs
+++ b/vendor/aube/crates/aube-util/src/hash.rs
@@ -240,6 +240,13 @@ where
 /// install. The active embedder's `manifest_namespace` is folded in at the
 /// digest site (it sorts ahead of these for standalone aube → `"aube"`).
 pub const INSTALL_SHAPE_FIELDS: &[&str] = &[
+    // Brand-neutral build-policy review map (the namespaced variants ride
+    // the `pnpm` / manifest-namespace entries below): a newly-allowed dep
+    // must re-run its previously-skipped build script, so an edit must
+    // invalidate the install — without this, an approval written to the
+    // neutral field left the warm fast path reporting "up to date" and
+    // the script never ran.
+    "allowBuilds",
     "bundleDependencies",
     "bundledDependencies",
     "catalog",
@@ -433,6 +440,23 @@ mod tests {
             serde_json::from_str(r#"{"dependencies":{"react":"19.0.0"}}"#).unwrap();
         let b: serde_json::Value =
             serde_json::from_str(r#"{"dependencies":{"react":"19.1.0"}}"#).unwrap();
+        assert_ne!(
+            manifest_install_shape_digest(&a),
+            manifest_install_shape_digest(&b)
+        );
+    }
+
+    #[test]
+    fn manifest_digest_reacts_to_allow_builds_change() {
+        // The neutral `allowBuilds` review map gates which dep build scripts
+        // run, so an approval must invalidate the install (a stale digest let
+        // the warm fast path skip newly-approved scripts).
+        let a: serde_json::Value =
+            serde_json::from_str(r#"{"dependencies":{"esbuild":"0.20.2"}}"#).unwrap();
+        let b: serde_json::Value = serde_json::from_str(
+            r#"{"dependencies":{"esbuild":"0.20.2"},"allowBuilds":{"esbuild":true}}"#,
+        )
+        .unwrap();
         assert_ne!(
             manifest_install_shape_digest(&a),
             manifest_install_shape_digest(&b)

--- a/vendor/aube/crates/aube/src/commands/approve_builds.rs
+++ b/vendor/aube/crates/aube/src/commands/approve_builds.rs
@@ -1,15 +1,23 @@
 //! `aube approve-builds` — flip packages to `true` in the workspace
-//! yaml's `allowBuilds` map so their install scripts run on the next
-//! `aube install`. Writes to `aube-workspace.yaml` by default, or
-//! mutates an existing `pnpm-workspace.yaml` in place.
+//! yaml's `allowBuilds` map and run their install scripts in the same
+//! invocation. Writes to `aube-workspace.yaml` by default, or mutates
+//! an existing `pnpm-workspace.yaml` in place.
 //!
 //! Walks the lockfile via `ignored_builds::collect_ignored`, presents an
 //! interactive multi-select picker (or approves everything under
-//! `--all`), then merges the selections into the workspace yaml's
-//! `allowBuilds` map. Matches pnpm v11, which collapsed the old
-//! allow/deny list keys into one review map. Entries are added as bare
-//! package names so a future resolution of the same dep under a
-//! different version keeps working without re-prompting.
+//! `--all`), merges the selections into the workspace yaml's
+//! `allowBuilds` map, then runs a rebuild scoped to the approved names
+//! (dep scripts only; root lifecycle hooks stay untouched). Matches
+//! pnpm v11, which collapsed the old allow/deny list keys into one
+//! review map and builds approved packages as part of `approve-builds`
+//! itself. Entries are added as bare package names so a future
+//! resolution of the same dep under a different version keeps working
+//! without re-prompting.
+//!
+//! The global path stays write-only: pnpm 11 removed `approve-builds
+//! --global` outright, so there is no reference behavior to mirror,
+//! and each global install dir would need its own retargeted rebuild —
+//! the printed hint keeps that flow explicit instead.
 
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
@@ -43,22 +51,63 @@ pub async fn run(args: ApproveBuildsArgs) -> miette::Result<()> {
     }
 
     let cwd = crate::dirs::project_root()?;
-    let _lock = super::take_project_lock(&cwd)?;
-    run_project(&cwd, args.all, args.packages)
+    // The lock covers only the config write. It is dropped before the
+    // build step: rebuild does not take the project lock, and holding a
+    // write lock across arbitrarily long lifecycle scripts would block
+    // every other engine command on the project for the whole build.
+    let approved = {
+        let _lock = super::take_project_lock(&cwd)?;
+        run_project(&cwd, args.all, args.packages)?
+    };
+    if approved.is_empty() {
+        return Ok(());
+    }
+    // pnpm parity: the same invocation runs the just-approved packages'
+    // scripts. The scoped form of rebuild is exactly the right shape —
+    // it runs only the named deps' scripts, skips the root lifecycle
+    // hooks, and treats the explicit names as the policy opt-in.
+    super::rebuild::run(
+        super::rebuild::RebuildArgs { packages: approved },
+        aube_workspace::selector::EffectiveFilter::default(),
+    )
+    .await
 }
 
-fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<()> {
+/// Approve builds for the current project and return the approved
+/// names (empty when nothing was ignored, nothing was selected, or the
+/// interactive confirmation was declined — the caller skips the build
+/// step in all three cases).
+fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<Vec<String>> {
     let ignored = super::ignored_builds::collect_ignored(cwd)?;
     if ignored.is_empty() {
         println!("No ignored builds to approve.");
-        return Ok(());
+        return Ok(Vec::new());
     }
 
+    let interactive = !all && packages.is_empty();
     let selected = select_project(&ignored, all, packages)?;
 
     if selected.is_empty() {
         println!("No packages selected.");
-        return Ok(());
+        return Ok(Vec::new());
+    }
+
+    // The picker only toggles names; scripts running is a separate
+    // consent. pnpm gates the interactive path behind the same
+    // default-No confirmation (`--all` and positional approvals are
+    // themselves the explicit consent, so they build straight away).
+    if interactive {
+        let confirmed = demand::Confirm::new(format!(
+            "The next packages will now be built: {}. Do you approve?",
+            selected.join(", ")
+        ))
+        .selected(false)
+        .run()
+        .into_diagnostic()
+        .wrap_err("failed to read approve-builds confirmation")?;
+        if !confirmed {
+            return Ok(Vec::new());
+        }
     }
 
     let written = aube_manifest::workspace::add_to_allow_builds(cwd, &selected)
@@ -73,12 +122,7 @@ fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<(
     for name in &selected {
         println!("  {name}");
     }
-    println!(
-        "Run `{}` (or `{}`) to execute their scripts.",
-        aube_util::cmd("install"),
-        aube_util::cmd("rebuild")
-    );
-    Ok(())
+    Ok(selected)
 }
 
 fn run_global(args: ApproveBuildsArgs) -> miette::Result<()> {

--- a/vendor/aube/test/approve_builds.bats
+++ b/vendor/aube/test/approve_builds.bats
@@ -3,8 +3,9 @@
 # Tests for `aube approve-builds` and `aube ignored-builds`. Uses the
 # same `aube-test-builds-marker` fixture package as `allow_builds.bats`:
 # it declares a `postinstall` that writes a marker file, so its
-# presence after a second install proves the approve-builds write
-# round-tripped into the project's `allowBuilds`.
+# presence right after `approve-builds` proves the approval both
+# round-tripped into the project's `allowBuilds` and triggered the
+# in-invocation build of the approved packages.
 
 setup() {
 	load 'test_helper/common_setup'
@@ -140,7 +141,13 @@ JSON
 	run grep -q 'onlyBuiltDependencies' package.json
 	assert_failure
 
-	# A re-install should run the previously-ignored postinstall.
+	# approve-builds runs the approved postinstall in the same
+	# invocation (pnpm parity) — no follow-up install required.
+	assert_file_exists aube-builds-marker.txt
+
+	# And a later install still honors the written policy.
+	rm aube-builds-marker.txt
+	rm -rf node_modules
 	run aube install
 	assert_success
 	assert_file_exists aube-builds-marker.txt
@@ -185,10 +192,8 @@ JSON
 	run grep -q '"aube-test-builds-marker": true' package.json
 	assert_success
 
-	# Round-trip: a re-install must honor the policy and run the
-	# previously-skipped postinstall.
-	run aube install
-	assert_success
+	# The workspace member's approved postinstall ran in the same
+	# invocation (pnpm parity) — no follow-up install required.
 	assert_file_exists aube-builds-marker.txt
 }
 


### PR DESCRIPTION
Closes #498.

`approve-builds` now runs a rebuild scoped to the just-approved packages in the same invocation, matching pnpm: interactive selections get pnpm's default-No confirmation first; `--all` and positional approvals build immediately; the global path stays write-only (pnpm 11 removed `approve-builds --global`).

Also adds `allowBuilds` to `INSTALL_SHAPE_FIELDS` — an approval written to package.json previously left the warm install fast path up-to-date, so the hinted `nub install` never ran the scripts.

https://claude.ai/code/session_01UzNyZsp64TeLSjbsVbXeAF