### PR TITLE
fix(spawn): macOS group-reaper watcher so SIGKILL of the nub process group can't orphan the workload

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1515,12 +1515,14 @@ fn run_nub() -> Result<i32> {
             _ => {
                 // Check if this is the first positional and matches a subcommand
                 // (nub-native, a verb registered to the embedded PM engine, or
-                // the engine's hidden node-gyp re-entry verb — its lazy shims
-                // re-invoke current_exe() with it mid-lifecycle-script).
+                // a hidden re-entry verb: the engine's lazy node-gyp shims and
+                // the macOS parent-death watcher both re-invoke current_exe()
+                // with theirs).
                 if rest.is_empty()
                     && !arg.starts_with('-')
                     && (SUBCOMMANDS.contains(&arg.as_str())
                         || arg == "__node-gyp-bootstrap"
+                        || (cfg!(unix) && arg == "__pdeath-watch")
                         || crate::pm_engine::lookup_verb(arg).is_some())
                 {
                     subcommand_found = true;
@@ -1952,6 +1954,14 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
     // to the engine's bootstrap entry point.
     if subcommand == "__node-gyp-bootstrap" {
         return crate::pm_engine::run_node_gyp_bootstrap(&rest[1..]);
+    }
+
+    // The macOS parent-death watcher (#480) re-invokes current_exe() with this
+    // hidden verb; intercept before clap and run the minimal watcher loop
+    // directly (see nub_core::node::spawn::spawn_group_reaper).
+    #[cfg(unix)]
+    if subcommand == "__pdeath-watch" {
+        return Ok(nub_core::node::spawn::run_pdeath_watch(&rest[1..]));
     }
 
     // Compatibility alias: npm and pnpm treat `install <pkg>` / `i <pkg>` (and
@@ -4456,6 +4466,10 @@ fn spawn_script_prefixed(
     // Relay docker stop / Ctrl-C to the streamed child's whole process group too
     // (workspace `-r` runs) — the `sh -c` won't pass a forwarded signal to node.
     nub_core::node::spawn::track_child_group(child.id());
+    // SIGKILL-on-the-leader backstop (#480) — macOS-only inside; held across
+    // the wait below, dropped (disarmed) on return.
+    #[cfg(unix)]
+    let _reaper = nub_core::node::spawn::spawn_group_reaper(child.id());
     let mut output_buf = String::new();
 
     let stdout = child.stdout.take();

--- a/crates/nub-cli/tests/pdeath_watch.rs
+++ b/crates/nub-cli/tests/pdeath_watch.rs
@@ -1,0 +1,153 @@
+//! Orphan-regression for #480: SIGKILL of the nub process GROUP must not
+//! orphan the workload on macOS. Linux covers leader death kernel-side with
+//! `PR_SET_PDEATHSIG` (see `pdeathsig.rs`); macOS has no equivalent, so nub
+//! plants a watcher process inside the workload's own process group
+//! (`spawn_group_reaper`) that tears the group down on pipe EOF. These tests
+//! exercise the three halves of that contract: the kill path, the no-leak
+//! normal path, and the disarm (don't kill deliberate survivors) path.
+
+#![cfg(target_os = "macos")]
+
+use std::path::{Path, PathBuf};
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/
+    path.push("nub");
+    path
+}
+
+fn write_fixture(dir: &Path, script: &str) {
+    let _ = std::fs::remove_dir_all(dir);
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("package.json"),
+        format!(r#"{{"name":"f","version":"1.0.0","scripts":{{"serve":"{script}"}}}}"#),
+    )
+    .unwrap();
+}
+
+/// Spawn `nub run serve` in the fixture as its OWN process-group leader (the
+/// supervised topology from #480) and return the handle.
+fn spawn_nub_run(dir: &Path) -> std::process::Child {
+    use std::os::unix::process::CommandExt;
+    let mut cmd = std::process::Command::new(nub_binary());
+    cmd.args(["run", "serve"])
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    // SAFETY: setpgid(0, 0) between fork and exec is async-signal-safe.
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setpgid(0, 0);
+            Ok(())
+        });
+    }
+    cmd.spawn().expect("spawn nub run")
+}
+
+/// Poll `path` for a pid written by the script (bounded).
+fn read_pid(path: &Path) -> i32 {
+    for _ in 0..100 {
+        if let Ok(s) = std::fs::read_to_string(path)
+            && let Ok(pid) = s.trim().parse::<i32>()
+        {
+            return pid;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    panic!("script never wrote its pid to {}", path.display());
+}
+
+fn alive(pid: i32) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+/// The #480 repro: SIGKILL the whole nub GROUP (which no forwarder or
+/// pdeathsig can see on macOS) → the watcher must tear the workload down
+/// within a grace window instead of leaving it running under PID 1.
+#[test]
+fn sigkill_on_nub_group_terminates_the_script_child() {
+    let dir = std::env::temp_dir().join(format!("nub-pdw-kill-{}", std::process::id()));
+    // `$$` is the sh pid; `exec sleep` replaces sh in-place, so child.pid names
+    // the surviving sleeper (the workload group's leader).
+    write_fixture(&dir, "echo $$ > child.pid && exec sleep 30");
+    let mut nub = spawn_nub_run(&dir);
+    let child_pid = read_pid(&dir.join("child.pid"));
+    assert!(alive(child_pid), "sleeper must be alive before the kill");
+
+    // SIGKILL the entire nub process group — the unforwardable supervisor path.
+    unsafe { libc::kill(-(nub.id() as i32), libc::SIGKILL) };
+    let _ = nub.wait();
+
+    let mut died = false;
+    for _ in 0..50 {
+        if !alive(child_pid) {
+            died = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    if !died {
+        // Never leak a 30s sleeper into the test environment on failure.
+        unsafe { libc::kill(child_pid, libc::SIGKILL) };
+    }
+    assert!(
+        died,
+        "script child (pid {child_pid}) survived SIGKILL of the nub group — \
+         group-reaper backstop missing"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Normal completion must not leak a watcher: the guard disarms and reaps it
+/// before nub exits, so no `__pdeath-watch <child-pid>` process may remain.
+#[test]
+fn normal_exit_leaves_no_watcher_process() {
+    let dir = std::env::temp_dir().join(format!("nub-pdw-clean-{}", std::process::id()));
+    write_fixture(&dir, "echo $$ > child.pid");
+    let mut nub = spawn_nub_run(&dir);
+    let status = nub.wait().expect("wait nub");
+    assert!(status.success(), "nub run must succeed");
+
+    let child_pid = read_pid(&dir.join("child.pid"));
+    // The watcher's argv is exactly `__pdeath-watch <child-pid> <fd>`, so this
+    // match can't collide with concurrent nub instances on the host.
+    let ps = std::process::Command::new("ps")
+        .args(["-ax", "-o", "command"])
+        .output()
+        .expect("ps");
+    let needle = format!("__pdeath-watch {child_pid} ");
+    assert!(
+        !String::from_utf8_lossy(&ps.stdout).contains(&needle),
+        "a watcher for exited child {child_pid} is still running"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The disarm half of the contract: a background process the script
+/// DELIBERATELY leaves behind survives nub's normal exit, exactly as it would
+/// under plain sh/node — the watcher must stand down, not sweep the group.
+#[test]
+fn deliberate_background_survivor_outlives_normal_exit() {
+    let dir = std::env::temp_dir().join(format!("nub-pdw-bg-{}", std::process::id()));
+    // The backgrounded sleeper stays in the script's process group; sh writes
+    // its pid and exits, then nub exits normally.
+    write_fixture(&dir, "sleep 30 & echo $! > survivor.pid");
+    let mut nub = spawn_nub_run(&dir);
+    let status = nub.wait().expect("wait nub");
+    assert!(status.success(), "nub run must succeed");
+
+    let survivor = read_pid(&dir.join("survivor.pid"));
+    // Give a mis-armed watcher's SIGTERM time to land before asserting.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let survived = alive(survivor);
+    unsafe { libc::kill(survivor, libc::SIGKILL) }; // always reap the sleeper
+    assert!(
+        survived,
+        "deliberate background survivor (pid {survivor}) was killed on nub's \
+         normal exit — the watcher failed to disarm"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -428,6 +428,230 @@ pub fn group_on_spawn(cmd: &mut Command) {
     let _ = cmd;
 }
 
+/// The disarm byte [`GroupReaper::drop`] writes on the NORMAL teardown path, so
+/// the watcher can tell "Nub reaped the workload and is shutting down cleanly"
+/// (leave any deliberate background survivors alone, matching what plain
+/// node/sh leave behind) from "Nub died" (bare EOF — tear the group down).
+#[cfg(unix)]
+const PDEATH_DISARM: u8 = b'D';
+
+/// macOS backstop for the one signal the forwarder structurally cannot relay
+/// and that Linux's pdeathsig (see [`group_on_spawn`]) covers kernel-side:
+/// SIGKILL of the Nub leader — or of Nub's whole process group — must not
+/// orphan the workload (#480). macOS has no `PR_SET_PDEATHSIG`, so Nub instead
+/// plants a tiny WATCHER process inside the CHILD's process group:
+///
+/// - The watcher holds the read end of a pipe whose only write end lives in
+///   Nub (both ends CLOEXEC; the read end is re-armed by `dup2` for the
+///   watcher alone, so the workload never sees either fd). It blocks in
+///   `read(2)`.
+/// - Nub dying by ANY means — including SIGKILL, where the kernel closes its
+///   fds — delivers EOF, and the watcher SIGTERMs the child's group (the same
+///   signal pdeathsig delivers on Linux) and exits. EOF is level-triggered, so
+///   unlike pdeathsig there is no died-before-registration TOCTOU window to
+///   re-check.
+/// - Living in the CHILD's group is what makes it SIGKILL-proof: a supervisor's
+///   group-kill aimed at Nub's group cannot touch it. Membership also PINS the
+///   pgid — a process group cannot be recycled while a member lives — so the
+///   group kill can never land on a reused pgid.
+///
+/// On the normal path the guard writes [`PDEATH_DISARM`] before closing, and
+/// the watcher exits without signaling anyone. The guard then reaps the
+/// watcher, so nub processes that spawn many sequential children (workspace
+/// `-r` runs) don't accumulate zombies. (`nub watch` is NOT covered: its
+/// spawn path predates `group_on_spawn` entirely, so it has neither pdeathsig
+/// nor this reaper — a pre-existing gap on both platforms.)
+///
+/// Returns `None` off macOS (Linux is already covered kernel-side; a second
+/// mechanism would be redundant) and on any setup failure — the backstop
+/// degrades to the status quo rather than failing the run. Known residual
+/// windows, both milliseconds wide and of the same class as pdeathsig's
+/// fork→prctl gap:
+/// - a group-kill landing between the workload spawn and the watcher's own
+///   `setpgid` still orphans (the watcher dies in Nub's group);
+/// - macOS has no `pipe2(O_CLOEXEC)`, so a CONCURRENT `Command::spawn` on
+///   another thread (workspace `--parallel`) forking between `pipe()` and the
+///   `fcntl` below can duplicate the write end into an unrelated workload,
+///   deferring the watcher's EOF until that workload also dies. The disarm
+///   path is unaffected (the byte travels regardless of extra writers).
+///
+/// Divergence note: on Nub death this TERMs the whole GROUP (matching what
+/// the forwarder does for catchable signals), while Linux's pdeathsig TERMs
+/// only the direct child — a deliberate background survivor outlives a
+/// force-killed nub on Linux but not on macOS. Group scope is what #480 asks
+/// for; the asymmetry is accepted.
+#[cfg(unix)]
+pub fn spawn_group_reaper(child_pid: u32) -> Option<GroupReaper> {
+    use std::os::unix::process::CommandExt;
+    // cfg!(test) guard: nub-core's own in-process unit tests call the spawn
+    // paths directly, where current_exe() is the libtest harness — re-invoking
+    // THAT with watcher argv would re-run any test whose name substring-matches
+    // the argv. The integration suite (pdeath_watch.rs) spawns the real `nub`
+    // binary and exercises the watcher fully.
+    if !cfg!(target_os = "macos") || cfg!(test) {
+        return None;
+    }
+    let mut fds = [0 as libc::c_int; 2];
+    // SAFETY: pipe(2) into a local array; F_SETFD on the two fresh fds.
+    unsafe {
+        if libc::pipe(fds.as_mut_ptr()) != 0 {
+            return None;
+        }
+        for fd in fds {
+            libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC);
+        }
+    }
+    let (read_fd, write_fd) = (fds[0], fds[1]);
+    let close_both = || {
+        // SAFETY: closing the two fds this function just opened.
+        unsafe {
+            libc::close(read_fd);
+            libc::close(write_fd);
+        }
+    };
+    let Ok(exe) = std::env::current_exe() else {
+        close_both();
+        return None;
+    };
+    let mut cmd = Command::new(exe);
+    cmd.arg("__pdeath-watch")
+        .arg(child_pid.to_string())
+        .arg("3")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let pgid = child_pid as libc::pid_t;
+    // SAFETY: setpgid / signal / dup2 / fcntl between fork and exec are
+    // async-signal-safe and touch no parent state.
+    unsafe {
+        cmd.pre_exec(move || {
+            // Join the WORKLOAD's group. It exists while its leader lives; if
+            // the workload already exited there is nothing left to protect and
+            // the watcher's membership self-check exits it immediately.
+            libc::setpgid(0, pgid);
+            // Ignore, HERE rather than after exec, everything the watcher can
+            // be hit with as a group member: the forwarder's terminating set
+            // (a docker-stop relay landing before the watcher's main ran would
+            // otherwise kill it and silently drop the backstop — SIG_IGN
+            // dispositions survive execve, unlike handlers) and the job-control
+            // stops (a TTY Ctrl-Z would otherwise STOP it, and the guard's
+            // reaping wait() would then hang on a stopped, never-dead child).
+            for sig in [
+                libc::SIGINT,
+                libc::SIGTERM,
+                libc::SIGHUP,
+                libc::SIGUSR1,
+                libc::SIGUSR2,
+                libc::SIGQUIT,
+                libc::SIGTSTP,
+                libc::SIGTTIN,
+                libc::SIGTTOU,
+            ] {
+                libc::signal(sig, libc::SIG_IGN);
+            }
+            // Re-arm ONLY the read end across the exec, at a fixed fd. dup2
+            // clears CLOEXEC on the destination — except when src == dst, where
+            // it is a no-op and the flag must be cleared explicitly.
+            if read_fd == 3 {
+                if libc::fcntl(3, libc::F_SETFD, 0) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            } else if libc::dup2(read_fd, 3) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    match spawn_with_eagain_retry(&mut cmd) {
+        Ok(watcher) => {
+            // SAFETY: Nub's copy of the read end; the watcher holds its own.
+            unsafe { libc::close(read_fd) };
+            Some(GroupReaper { write_fd, watcher })
+        }
+        Err(_) => {
+            close_both();
+            None
+        }
+    }
+}
+
+/// Keeps the parent-death watcher's pipe write end open for the workload's
+/// lifetime — hold it across `wait()`, drop it after. See [`spawn_group_reaper`].
+#[cfg(unix)]
+pub struct GroupReaper {
+    write_fd: libc::c_int,
+    watcher: std::process::Child,
+}
+
+#[cfg(unix)]
+impl Drop for GroupReaper {
+    fn drop(&mut self) {
+        // Normal teardown: disarm (so deliberate background survivors in the
+        // workload's group are left running, exactly as plain node/sh leave
+        // them), close Nub's sole write end, and reap the watcher — it exits
+        // within microseconds of the EOF, and reaping here keeps a long-lived
+        // `nub watch` loop from accumulating zombies.
+        // SAFETY: write/close on the fd this guard owns.
+        unsafe {
+            let byte = [PDEATH_DISARM];
+            // EINTR-retry: a lost disarm byte would read as bare EOF — Nub
+            // "died" — and TERM deliberate background survivors on a NORMAL
+            // exit, the exact additivity break the byte exists to prevent.
+            while libc::write(self.write_fd, byte.as_ptr().cast(), 1) < 0
+                && std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR)
+            {}
+            libc::close(self.write_fd);
+        }
+        let _ = self.watcher.wait();
+    }
+}
+
+/// The `__pdeath-watch` hidden-verb entry: `<child-pgid> <read-fd>` — the
+/// watcher half of [`spawn_group_reaper`]. Returns the process exit code.
+#[cfg(unix)]
+pub fn run_pdeath_watch(args: &[String]) -> i32 {
+    let (Some(pgid), Some(fd)) = (
+        args.first().and_then(|s| s.parse::<libc::pid_t>().ok()),
+        args.get(1).and_then(|s| s.parse::<libc::c_int>().ok()),
+    ) else {
+        return 2;
+    };
+    // SAFETY: getpgrp/read/kill FFI on values this process owns.
+    unsafe {
+        // Signal dispositions were already set in the spawner's pre_exec (they
+        // survive execve): the forwarded terminating set and the job-control
+        // stops are all SIG_IGN, so the watcher acts on exactly one stimulus —
+        // the pipe — and exits on its own. (SIGKILL still takes it down with
+        // the group, as it should.)
+        //
+        // Membership self-check: pre_exec's setpgid can only have failed if the
+        // workload group was already gone — nothing to protect. Being a member
+        // is load-bearing (SIGKILL immunity + pgid pinning, see
+        // `spawn_group_reaper`), so never watch from outside the group.
+        if libc::getpgrp() != pgid {
+            return 0;
+        }
+        let mut buf = [0u8; 1];
+        loop {
+            let n = libc::read(fd, buf.as_mut_ptr().cast(), 1);
+            if n == 1 && buf[0] == PDEATH_DISARM {
+                // Nub reaped the workload and is exiting cleanly: stand down
+                // without signaling, leaving any deliberate background
+                // survivors exactly as plain node/sh would.
+                return 0;
+            }
+            if n < 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            // EOF (Nub died) — or an unreadable pipe, where killing beats
+            // orphaning.
+            break;
+        }
+        libc::kill(-pgid, libc::SIGTERM);
+    }
+    0
+}
+
 /// Spawn `cmd` in its own process group and wait, forwarding terminating signals
 /// to the whole group while it runs — the signal-faithful, subtree-reaching
 /// equivalent of `cmd.status()` for a `sh -c <script>` child. Use for the `nub
@@ -437,6 +661,10 @@ pub fn status_forwarding_signals(cmd: &mut Command) -> std::io::Result<ExitStatu
     group_on_spawn(cmd);
     let mut child = spawn_with_eagain_retry(cmd)?;
     track_child_group(child.id());
+    // SIGKILL-on-the-leader backstop (#480) — macOS-only inside; see
+    // `spawn_group_reaper`. Held across the wait, dropped (disarmed) after.
+    #[cfg(unix)]
+    let _reaper = spawn_group_reaper(child.id());
     // Interactive path (stdin is a TTY + inherited stdio): hand the terminal
     // foreground to the child so a full-screen TUI can read it / receive Ctrl-C
     // (issue #27); the guard restores nub's foreground group on drop. No-op off a
@@ -942,6 +1170,11 @@ pub fn spawn_node(config: &SpawnConfig<'_>) -> Result<SpawnResult> {
     // negative target signals the child and its descendants exactly once.
     // (No-op off Unix.)
     track_child_group(child.id());
+
+    // SIGKILL-on-the-leader backstop (#480) — macOS-only inside; see
+    // `spawn_group_reaper`. Held across the wait, dropped (disarmed) after.
+    #[cfg(unix)]
+    let _reaper = spawn_group_reaper(child.id());
 
     // Interactive path: hand the terminal foreground to the child (issue #27) so a
     // `nub <file>` that draws a full-screen TUI can read the terminal and receive


### PR DESCRIPTION
On macOS, SIGKILL of nub or its process group orphaned the workload: the child is its own process group (#26), SIGKILL can't be forwarded, and macOS lacks `PR_SET_PDEATHSIG` (#463's Linux backstop).

Fix: a watcher (`__pdeath-watch`) planted in the workload's group holds a pipe whose only write end lives in nub. Nub dying — any means, incl. SIGKILL — delivers EOF; the watcher SIGTERMs the group. Normal teardown writes a disarm byte first, so deliberate background survivors are left alone. Armed at all three `group_on_spawn` sites; Linux/Windows unchanged.

Verified with the issue's repro; 3 regression tests added.

Closes #480

https://claude.ai/code/session_019qrd384BeSgQHua8gqojY9