### PR TITLE
fix(pm): cache dist-tag resolution and slim registry metadata fetches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,11 @@ blake3 = "1"
 # blocking + rustls (no OpenSSL/cross-compile pain), native roots so corporate
 # MITM CAs work, socks for SOCKS proxies. reqwest gives HTTP(S)_PROXY/NO_PROXY
 # for free. NOT async — provisioning is a short at-most-once-per-version step.
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "rustls-tls-native-roots", "socks"] }
+# gzip: without it reqwest sends no Accept-Encoding, so the registry serves
+# packuments identity-encoded (the full `npm` packument is ~25 MB raw vs ~6 MB
+# gzipped — a per-invocation cost on unpinned shim calls, #491). Tarballs are
+# unaffected: registries serve .tgz without Content-Encoding.
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "rustls-tls-native-roots", "socks", "gzip"] }
 # xz extraction of the dist tarball. liblzma's "static" vendors its own C liblzma
 # (no system dependency, no shell-out to tar/xz); the maintained xz2 successor.
 liblzma = { version = "0.4", features = ["static"] }

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -7868,11 +7868,11 @@ fn shim_plan(
             };
             // A name-only pin (devEngines.packageManager without a version)
             // constrains the NAME, not the version — prefer the user's own
-            // matching PM on PATH: zero network (a spec like "latest" or a
-            // lockfile family re-resolves against the registry on EVERY
-            // invocation) and no run-to-run drift as new versions publish.
-            // Provision the lockfile-implied family / registry latest only on
-            // a true PATH miss.
+            // matching PM on PATH: zero network (a lockfile-family range still
+            // re-resolves against the registry per invocation; "latest" is
+            // TTL-cached but pays a resolve on expiry) and no run-to-run drift
+            // as new versions publish. Provision the lockfile-implied family /
+            // registry latest only on a true PATH miss.
             if pin.version.is_none() {
                 let shim_dir = shim::shim_dir()?;
                 if let Some(system) = shim::find_system_pm(invoked.as_str(), &shim_dir) {
@@ -7917,12 +7917,15 @@ fn shim_plan(
                     env: Vec::new(),
                 });
             }
-            // True PATH miss: provision a dynamic default of the INVOKED PM —
+            // True PATH miss: run a dynamic default of the INVOKED PM —
             // announced, never a baked version, and the shim never writes a pin.
+            // "using", not "provisioning": with the dist-tag TTL cache a warm
+            // call resolves and execs with zero network, and the install path
+            // prints its own Installing…/Installed… lines when it does run.
             let root = shim_lockfile_root(cwd);
             let (spec, why) = dynamic_default_spec(invoked.pm(), &root)?;
             eprintln!(
-                "nub: no {} on PATH — provisioning {}@{spec} ({why}); one-time default, no pin written",
+                "nub: no {} on PATH — using {}@{spec} ({why}); one-time default, no pin written",
                 invoked.as_str(),
                 invoked.pm()
             );

--- a/crates/nub-core/src/pm/provision.rs
+++ b/crates/nub-core/src/pm/provision.rs
@@ -1044,9 +1044,8 @@ mod tests {
         // Round-trip, preserving a sibling registry's entry.
         record_tag_resolution(&pm_store, "https://registry.npmjs.org/", "latest", "12.0.1");
         record_tag_resolution(&pm_store, "https://mirror.example.com", "latest", "11.9.9");
-        let (version, age) =
-            read_tag_resolution(&pm_store, "https://registry.npmjs.org", "latest")
-                .expect("fresh record reads back");
+        let (version, age) = read_tag_resolution(&pm_store, "https://registry.npmjs.org", "latest")
+            .expect("fresh record reads back");
         assert_eq!(version, "12.0.1");
         assert!(age <= TAG_TTL, "a just-written record is fresh");
         assert_eq!(

--- a/crates/nub-core/src/pm/provision.rs
+++ b/crates/nub-core/src/pm/provision.rs
@@ -15,7 +15,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 
@@ -138,15 +138,46 @@ pub fn provision_pm_announced(
     // (It was read from the cache-store root before — a dir no project commits
     // anything into — so project mirrors/auth were silently ignored.)
     let cfg = registry::registry_config(project_root);
+
+    // 2b. Dist-tag TTL cache: a tag spec (`latest`) is not exact, so it skipped
+    // the cache check above and used to pay a registry round-trip on EVERY
+    // invocation — the shim's dynamic default made that a per-`npx`-call cost
+    // (#491). A tag resolution recorded within [`TAG_TTL`] whose version is
+    // still installed short-circuits to the zero-network path; freshness lags
+    // the registry by at most the TTL, the same trade corepack makes.
+    let is_tag = is_dist_tag(spec);
+    if is_tag
+        && let Some((version, age)) = read_tag_resolution(&pm_store, &cfg.base, spec)
+        && age <= TAG_TTL
+        && let Some(bin) = cached_bin(&pm_store, &version)
+    {
+        if let Some(cb) = on_resolved {
+            cb(&version);
+        }
+        return Ok(ProvisionedPm { bin, version }); // cache hit — silent
+    }
+
     let dist = match registry::resolve_version_authed(&cfg, &pm.to_string(), spec) {
-        Ok(dist) => dist,
-        // 3. Registry unreachable: a range can still resolve against the cache.
-        // Exact pins were handled above (and an exact spec parses as a *caret*
-        // VersionReq, so it must not reach the range match); dist-tags have no
-        // offline meaning. Announced — a stale-vs-fresh divergence from the
-        // online behavior should never be silent.
+        Ok(dist) => {
+            if is_tag {
+                record_tag_resolution(&pm_store, &cfg.base, spec, &dist.version);
+            }
+            dist
+        }
+        // 3. Registry unreachable: a range can still resolve against the cache,
+        // and a dist-tag against its last RECORDED resolution (any age — stale
+        // beats down). Exact pins were handled above (and an exact spec parses
+        // as a *caret* VersionReq, so it must not reach the range match).
+        // Announced — a stale-vs-fresh divergence from the online behavior
+        // should never be silent.
         Err(err) if semver::Version::parse(spec).is_err() => {
-            match best_cached_match(&pm_store, spec) {
+            let fallback = if is_tag {
+                read_tag_resolution(&pm_store, &cfg.base, spec)
+                    .and_then(|(version, _)| cached_bin(&pm_store, &version).map(|b| (version, b)))
+            } else {
+                best_cached_match(&pm_store, spec)
+            };
+            match fallback {
                 Some((version, bin)) => {
                     if let Some(cb) = on_resolved {
                         cb(&version);
@@ -248,6 +279,83 @@ pub fn provision_pm_from_tarball(
         bin,
         version: dist.version.clone(),
     })
+}
+
+/// How long a recorded dist-tag resolution (`latest` → `12.0.1`) is trusted
+/// without re-consulting the registry. The trade is freshness-lag vs. a network
+/// round-trip on every unpinned shim invocation; 24h matches the cadence other
+/// tools accept for the same default (corepack's known-good pin, npm's own
+/// update-notifier). Deliberately NOT configurable until real demand exists —
+/// every knob is a doc + support surface (AGENTS.md knob discipline).
+const TAG_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Whether `spec` is a dist-tag (`latest`, `next`) — i.e. neither an exact
+/// version nor a semver range. Mirrors [`resolve_dist`]'s precedence safely:
+/// npm rejects publishing a tag that parses as a version or range, so the three
+/// classes are disjoint.
+fn is_dist_tag(spec: &str) -> bool {
+    semver::Version::parse(spec).is_err()
+        && semver::VersionReq::parse(&registry::normalize_range(spec)).is_err()
+}
+
+/// The tag-resolution record: `<pm_store>/.resolved-tags.json`, a flat
+/// `{"<registry-base>#<tag>": {"version": "...", "at": <unix-secs>}}` map. Lives
+/// INSIDE the per-PM store dir so [`best_cached_match`]'s version-dir scan
+/// parse-fails it out, and a registry switch (mirror vs public) misses the other
+/// registry's entries by key.
+fn tag_cache_file(pm_store: &Path) -> PathBuf {
+    pm_store.join(".resolved-tags.json")
+}
+
+fn tag_cache_key(registry_base: &str, tag: &str) -> String {
+    format!("{}#{tag}", registry_base.trim_end_matches('/'))
+}
+
+/// The recorded resolution of `tag` on `registry_base`, as `(version, age)`.
+/// Returns `None` for a missing/corrupt record file (never an error — the cache
+/// is advisory), and rejects a non-semver `version` value: the string becomes a
+/// store path component via [`cached_bin`], and while nub only ever records
+/// validated versions, a hand-edited file must not become a path-escape vector.
+fn read_tag_resolution(
+    pm_store: &Path,
+    registry_base: &str,
+    tag: &str,
+) -> Option<(String, Duration)> {
+    let raw = std::fs::read_to_string(tag_cache_file(pm_store)).ok()?;
+    let map: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let entry = map.get(tag_cache_key(registry_base, tag))?;
+    let version = entry.get("version")?.as_str()?;
+    semver::Version::parse(version).ok()?;
+    let at = entry.get("at")?.as_u64()?;
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+    let age = Duration::from_secs(now.saturating_sub(at));
+    Some((version.to_string(), age))
+}
+
+/// Record `tag` → `version` (just resolved online) with the current time,
+/// preserving other registries'/tags' entries. Best-effort: a failure to record
+/// only costs the next invocation a re-resolve, so errors are swallowed. The
+/// write is temp-file + rename so a concurrent reader never sees a torn file
+/// (last writer wins, both wrote a fresh resolution).
+fn record_tag_resolution(pm_store: &Path, registry_base: &str, tag: &str, version: &str) {
+    let file = tag_cache_file(pm_store);
+    let mut map = std::fs::read_to_string(&file)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+    let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+        return;
+    };
+    map.insert(
+        tag_cache_key(registry_base, tag),
+        serde_json::json!({ "version": version, "at": now.as_secs() }),
+    );
+    let _ = std::fs::create_dir_all(pm_store);
+    let tmp = pm_store.join(format!(".resolved-tags-{}.tmp", std::process::id()));
+    if std::fs::write(&tmp, serde_json::Value::Object(map).to_string()).is_ok() {
+        let _ = std::fs::rename(&tmp, &file);
+    }
 }
 
 /// The runnable bin of an already-installed `<pm_store>/<version>/`, or `None`
@@ -858,6 +966,111 @@ mod tests {
             vec!["9.5.0".to_string()],
             "the hook fires exactly once with the concrete cached version"
         );
+        let _ = std::fs::remove_dir_all(&store);
+    }
+
+    #[test]
+    fn fresh_tag_resolution_short_circuits_the_registry() {
+        if ambient_registry_override() {
+            return; // env registry outranks the dead-registry .npmrc — see helper
+        }
+        // A recorded, TTL-fresh `latest` → 9.5.0 with the version installed must
+        // exec with ZERO network — the dead-registry .npmrc proves it (a resolve
+        // would error against 127.0.0.1:1). This is the #491 warm path.
+        let store = offline_store_with("tag-fresh", "9.5.0");
+        let pm_store = store.join("pm").join("pnpm");
+        record_tag_resolution(&pm_store, "http://127.0.0.1:1/", "latest", "9.5.0");
+
+        let pin = PmPin {
+            pm: Pm::Pnpm,
+            version: Some("latest".to_string()),
+        };
+        let seen = std::cell::RefCell::new(Vec::<String>::new());
+        let prov = provision_pm_announced(
+            &pin,
+            &store,
+            &store,
+            None,
+            Some(&|v: &str| {
+                seen.borrow_mut().push(v.to_string());
+            }),
+        )
+        .expect("fresh tag record + cached install resolves offline");
+        assert_eq!(prov.version, "9.5.0");
+        assert_eq!(
+            *seen.borrow(),
+            vec!["9.5.0".to_string()],
+            "the shim-header hook still fires on the tag-cache hit"
+        );
+        let _ = std::fs::remove_dir_all(&store);
+    }
+
+    #[test]
+    fn stale_tag_resolution_survives_a_registry_outage() {
+        if ambient_registry_override() {
+            return; // env registry outranks the dead-registry .npmrc — see helper
+        }
+        // An EXPIRED record is not trusted for freshness (the resolve runs), but
+        // when the registry is unreachable it is the offline answer — stale
+        // beats down. Written by hand with at=1 (record_tag_resolution always
+        // stamps now).
+        let store = offline_store_with("tag-stale", "9.5.0");
+        let pm_store = store.join("pm").join("pnpm");
+        std::fs::write(
+            tag_cache_file(&pm_store),
+            format!(
+                "{{\"{}\": {{\"version\": \"9.5.0\", \"at\": 1}}}}",
+                tag_cache_key("http://127.0.0.1:1/", "latest")
+            ),
+        )
+        .unwrap();
+
+        let pin = PmPin {
+            pm: Pm::Pnpm,
+            version: Some("latest".to_string()),
+        };
+        let prov = provision_pm(&pin, &store, &store, None)
+            .expect("stale tag record is the offline fallback");
+        assert_eq!(prov.version, "9.5.0");
+        let _ = std::fs::remove_dir_all(&store);
+    }
+
+    #[test]
+    fn tag_record_round_trips_and_rejects_junk() {
+        let store = std::env::temp_dir().join(format!("nub-pm-tagrec-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&store);
+        let pm_store = store.join("pm").join("npm");
+
+        // Round-trip, preserving a sibling registry's entry.
+        record_tag_resolution(&pm_store, "https://registry.npmjs.org/", "latest", "12.0.1");
+        record_tag_resolution(&pm_store, "https://mirror.example.com", "latest", "11.9.9");
+        let (version, age) =
+            read_tag_resolution(&pm_store, "https://registry.npmjs.org", "latest")
+                .expect("fresh record reads back");
+        assert_eq!(version, "12.0.1");
+        assert!(age <= TAG_TTL, "a just-written record is fresh");
+        assert_eq!(
+            read_tag_resolution(&pm_store, "https://mirror.example.com/", "latest")
+                .expect("sibling registry entry preserved")
+                .0,
+            "11.9.9"
+        );
+
+        // A non-semver version value is refused — the string becomes a store
+        // path component, so a hand-edited file must not smuggle one in.
+        std::fs::write(
+            tag_cache_file(&pm_store),
+            format!(
+                "{{\"{}\": {{\"version\": \"../evil\", \"at\": 999999999999}}}}",
+                tag_cache_key("https://registry.npmjs.org", "latest")
+            ),
+        )
+        .unwrap();
+        assert!(read_tag_resolution(&pm_store, "https://registry.npmjs.org", "latest").is_none());
+
+        // Corrupt JSON is advisory-cache tolerated: read yields None, no panic.
+        std::fs::write(tag_cache_file(&pm_store), "not json").unwrap();
+        assert!(read_tag_resolution(&pm_store, "https://registry.npmjs.org", "latest").is_none());
         let _ = std::fs::remove_dir_all(&store);
     }
 

--- a/crates/nub-core/src/pm/provision.rs
+++ b/crates/nub-core/src/pm/provision.rs
@@ -328,7 +328,14 @@ fn read_tag_resolution(
     semver::Version::parse(version).ok()?;
     let at = entry.get("at")?.as_u64()?;
     let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
-    let age = Duration::from_secs(now.saturating_sub(at));
+    // A future-dated record (clock skew at write, a hand-edited file) must not
+    // read as maximally fresh until wall-clock catches up — treat it as stale.
+    // The offline fallback still honors it; only freshness is denied.
+    let age = if at > now {
+        Duration::MAX
+    } else {
+        Duration::from_secs(now - at)
+    };
     Some((version.to_string(), age))
 }
 
@@ -969,17 +976,56 @@ mod tests {
         let _ = std::fs::remove_dir_all(&store);
     }
 
+    /// A loopback registry answering EVERY request with 200 + a pnpm@9.9.9
+    /// version manifest whose dist.tarball points back at the mock (where a GET
+    /// yields this same JSON — never a valid tarball, so any install attempt
+    /// against it fails on integrity). This makes the tag-cache tests
+    /// DISCRIMINATING: a run that consults the registry observably resolves
+    /// 9.9.9 (and then fails to install it), which a cache short-circuit never
+    /// does. The accept loop rides a detached thread for the remaining test
+    /// process — a few KB, no cleanup needed.
+    fn mock_registry_serving_pnpm_9_9_9() -> String {
+        use std::io::{Read as _, Write as _};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let body = format!(
+            r#"{{ "name": "pnpm", "version": "9.9.9", "bin": {{ "pnpm": "bin/pnpm.cjs" }},
+                 "dist": {{ "tarball": "http://127.0.0.1:{port}/pnpm-9.9.9.tgz", "integrity": "sha512-AAAA" }} }}"#
+        );
+        std::thread::spawn(move || {
+            for conn in listener.incoming() {
+                let Ok(mut conn) = conn else { break };
+                let mut buf = [0u8; 4096];
+                let _ = conn.read(&mut buf); // drain the request head
+                let _ = conn.write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                         content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                    .as_bytes(),
+                );
+            }
+        });
+        format!("http://127.0.0.1:{port}")
+    }
+
     #[test]
     fn fresh_tag_resolution_short_circuits_the_registry() {
         if ambient_registry_override() {
-            return; // env registry outranks the dead-registry .npmrc — see helper
+            return; // env registry outranks the test .npmrc — see helper
         }
         // A recorded, TTL-fresh `latest` → 9.5.0 with the version installed must
-        // exec with ZERO network — the dead-registry .npmrc proves it (a resolve
-        // would error against 127.0.0.1:1). This is the #491 warm path.
+        // return WITHOUT consulting the registry. The registry is a live mock
+        // that resolves `latest` to a DIFFERENT version (9.9.9, uninstallable),
+        // so a run that consults it cannot produce Ok(9.5.0) — the assertion
+        // distinguishes the short-circuit from the offline-fallback path, which
+        // a dead registry alone could not.
         let store = offline_store_with("tag-fresh", "9.5.0");
+        let mock = mock_registry_serving_pnpm_9_9_9();
+        std::fs::write(store.join(".npmrc"), format!("registry={mock}\n")).unwrap();
         let pm_store = store.join("pm").join("pnpm");
-        record_tag_resolution(&pm_store, "http://127.0.0.1:1/", "latest", "9.5.0");
+        record_tag_resolution(&pm_store, &mock, "latest", "9.5.0");
 
         let pin = PmPin {
             pm: Pm::Pnpm,
@@ -995,13 +1041,50 @@ mod tests {
                 seen.borrow_mut().push(v.to_string());
             }),
         )
-        .expect("fresh tag record + cached install resolves offline");
+        .expect("fresh tag record + cached install must not consult the registry");
         assert_eq!(prov.version, "9.5.0");
         assert_eq!(
             *seen.borrow(),
             vec!["9.5.0".to_string()],
             "the shim-header hook still fires on the tag-cache hit"
         );
+        let _ = std::fs::remove_dir_all(&store);
+    }
+
+    #[test]
+    fn stale_tag_resolution_is_not_trusted_for_freshness() {
+        if ambient_registry_override() {
+            return; // env registry outranks the test .npmrc — see helper
+        }
+        // The TTL boundary: an EXPIRED record must NOT short-circuit — the
+        // resolve must run. Against the live mock, `latest` resolves to 9.9.9
+        // whose "tarball" is JSON, so the run fails at install; a wrongly-firing
+        // short-circuit would instead return Ok(9.5.0). Future-dated records
+        // (at > now) are equally untrusted.
+        let store = offline_store_with("tag-expired", "9.5.0");
+        let mock = mock_registry_serving_pnpm_9_9_9();
+        std::fs::write(store.join(".npmrc"), format!("registry={mock}\n")).unwrap();
+        let pm_store = store.join("pm").join("pnpm");
+        for at in [1u64, u64::MAX] {
+            std::fs::write(
+                tag_cache_file(&pm_store),
+                format!(
+                    "{{\"{}\": {{\"version\": \"9.5.0\", \"at\": {at}}}}}",
+                    tag_cache_key(&mock, "latest")
+                ),
+            )
+            .unwrap();
+            let pin = PmPin {
+                pm: Pm::Pnpm,
+                version: Some("latest".to_string()),
+            };
+            let result = provision_pm(&pin, &store, &store, None);
+            assert!(
+                result.is_err(),
+                "an untrusted record (at={at}) must re-resolve, reaching the mock's \
+                 uninstallable 9.9.9 — got {result:?}"
+            );
+        }
         let _ = std::fs::remove_dir_all(&store);
     }
 

--- a/crates/nub-core/src/pm/registry.rs
+++ b/crates/nub-core/src/pm/registry.rs
@@ -583,15 +583,55 @@ pub fn resolve_version(base: &str, pkg: &str, spec: &str) -> Result<VersionDist>
     )
 }
 
-/// Networked wrapper: fetch the packument from `cfg.base` (presenting `cfg.auth`
-/// to an auth-required mirror) and resolve `spec` against it. `pkg` is the package
-/// name (`pnpm`, `npm`, `yarn`). The resolved `dist.tarball` is rewritten onto the
-/// configured registry's origin ([`rewrite_tarball_origin`]) so a mirrored install
-/// fetches the tarball from the same host the packument came from, not a hardcoded
+/// npm's abbreviated ("corgi") packument media type. Same `dist-tags` /
+/// `versions[]` / `dist` / `bin` shape [`resolve_dist`] consumes, at a fraction
+/// of the bytes — the full `npm` packument is ~25 MB identity-encoded, the corgi
+/// form ~2.4 MB. The public registry and the mainstream private ones (Verdaccio,
+/// Artifactory, GitHub Packages) honor it; a registry that ignores the `Accept`
+/// header serves the full document, which resolves identically.
+const CORGI_ACCEPT: &str = "application/vnd.npm.install-v1+json";
+
+/// Networked wrapper: resolve `spec` against `cfg.base` (presenting `cfg.auth`
+/// to an auth-required mirror). `pkg` is the package name (`pnpm`, `npm`,
+/// `yarn`). The resolved `dist.tarball` is rewritten onto the configured
+/// registry's origin ([`rewrite_tarball_origin`]) so a mirrored install fetches
+/// the tarball from the same host the metadata came from, not a hardcoded
 /// public URL.
+///
+/// An exact version or dist-tag resolves via `GET /{pkg}/{spec}` — the
+/// registry's version-manifest endpoint, a few KB — because the shim's dynamic
+/// default re-resolves `latest` on real invocations and paying a whole packument
+/// per call was the dominant cost of #491 (25 MB, uncompressed, per `npx` run).
+/// Only a RANGE needs the version-enumerating packument, fetched with the corgi
+/// `Accept`. A registry that doesn't implement the version endpoint answers with
+/// an HTTP error → fall back to the packument; a TRANSPORT failure (host
+/// unreachable) propagates instead, since the packument fetch would only re-run
+/// the same doomed connect (and take its own retries doing it).
 pub fn resolve_version_authed(cfg: &RegistryConfig, pkg: &str, spec: &str) -> Result<VersionDist> {
-    let url = format!("{}/{pkg}", cfg.base.trim_end_matches('/'));
-    let body = download::fetch_text_auth(&url, cfg.auth.as_ref())
+    let spec = spec.trim();
+    let base = cfg.base.trim_end_matches('/');
+    let is_exact = semver::Version::parse(spec).is_ok();
+    let is_range = !is_exact && semver::VersionReq::parse(&normalize_range(spec)).is_ok();
+    if !is_range {
+        let url = format!("{base}/{pkg}/{spec}");
+        match download::fetch_text_accept_auth(&url, None, cfg.auth.as_ref()) {
+            Ok(body) => {
+                let meta: Value = serde_json::from_str(&body)
+                    .with_context(|| format!("parsing version manifest {url}"))?;
+                let mut dist = resolve_dist_from_version_manifest(&meta)
+                    .with_context(|| format!("resolving {pkg}@{spec}"))?;
+                dist.tarball = rewrite_tarball_origin(&dist.tarball, &cfg.base);
+                return Ok(dist);
+            }
+            Err(e) if e.status.is_none() => {
+                return Err(e.error).with_context(|| format!("fetching {url}"));
+            }
+            Err(_) => {} // endpoint unsupported/404 on this registry → packument
+        }
+    }
+    let url = format!("{base}/{pkg}");
+    let body = download::fetch_text_accept_auth(&url, Some(CORGI_ACCEPT), cfg.auth.as_ref())
+        .map_err(|e| e.error)
         .with_context(|| format!("fetching packument {url}"))?;
     let packument: Value =
         serde_json::from_str(&body).with_context(|| format!("parsing packument {url}"))?;
@@ -599,6 +639,21 @@ pub fn resolve_version_authed(cfg: &RegistryConfig, pkg: &str, spec: &str) -> Re
         resolve_dist(&packument, spec).with_context(|| format!("resolving {pkg}@{spec}"))?;
     dist.tarball = rewrite_tarball_origin(&dist.tarball, &cfg.base);
     Ok(dist)
+}
+
+/// Build a [`VersionDist`] from a VERSION-MANIFEST document (`GET
+/// /{pkg}/{version-or-tag}`) — the same `name`/`bin`/`dist` shape as one
+/// packument `versions[]` entry, plus its own top-level `version`. PURE — no
+/// network — so the parsing is unit-tested offline. Routes through
+/// [`dist_from_meta`], the single `VersionDist` chokepoint, so the
+/// store-path guard ([`validate_version`]) and the bin-path guard apply to this
+/// server-controlled document exactly as to a packument.
+pub fn resolve_dist_from_version_manifest(meta: &Value) -> Result<VersionDist> {
+    let version = meta
+        .get("version")
+        .and_then(Value::as_str)
+        .context("version manifest has no \"version\" field")?;
+    dist_from_meta(version, meta)
 }
 
 /// Verify a downloaded tarball against its dist integrity. Fail-closed: a mismatch
@@ -756,6 +811,48 @@ mod tests {
         // node-semver space-separated comparators (`>=9 <10`) — npm/devEngines
         // write these; Cargo's semver needs commas, so the normalizer bridges it.
         assert_eq!(resolve_dist(&p, ">=9 <10").unwrap().version, "9.5.0");
+    }
+
+    #[test]
+    fn version_manifest_resolves_through_the_same_guards_as_a_packument() {
+        // The version-manifest endpoint (`GET /{pkg}/{version-or-tag}`) returns
+        // one versions[] entry with its own top-level "version" — the fast path
+        // for exact/tag specs (#491). It must flow through dist_from_meta, the
+        // VersionDist chokepoint, so the store-path guard holds.
+        let meta: Value = serde_json::from_str(
+            r#"{
+                "name": "npm", "version": "12.0.1",
+                "bin": { "npm": "bin/npm-cli.js", "npx": "bin/npx-cli.js" },
+                "dist": {
+                    "tarball": "https://registry.npmjs.org/npm/-/npm-12.0.1.tgz",
+                    "integrity": "sha512-DDDD"
+                }
+            }"#,
+        )
+        .unwrap();
+        let dist = resolve_dist_from_version_manifest(&meta).unwrap();
+        assert_eq!(dist.version, "12.0.1");
+        assert_eq!(dist.integrity, Integrity::Sha512("DDDD".into()));
+        assert_eq!(dist.bin_subpath, PathBuf::from("bin/npm-cli.js"));
+
+        // No "version" field → error, never a guessed store path.
+        let no_version: Value = serde_json::from_str(r#"{ "name": "npm" }"#).unwrap();
+        assert!(resolve_dist_from_version_manifest(&no_version).is_err());
+
+        // A server-controlled version that would escape the store join is
+        // refused — same F0c posture as the packument dist-tag branch.
+        let escaping: Value = serde_json::from_str(
+            r#"{ "name": "npm", "version": "..", "bin": "bin/npm-cli.js",
+                 "dist": { "tarball": "https://x/t.tgz", "integrity": "sha512-EEEE" } }"#,
+        )
+        .unwrap();
+        let err = resolve_dist_from_version_manifest(&escaping)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("unsafe version string"),
+            "escaping version must be refused: {err}"
+        );
     }
 
     #[test]

--- a/crates/nub-core/src/pm/registry.rs
+++ b/crates/nub-core/src/pm/registry.rs
@@ -603,10 +603,12 @@ const CORGI_ACCEPT: &str = "application/vnd.npm.install-v1+json";
 /// default re-resolves `latest` on real invocations and paying a whole packument
 /// per call was the dominant cost of #491 (25 MB, uncompressed, per `npx` run).
 /// Only a RANGE needs the version-enumerating packument, fetched with the corgi
-/// `Accept`. A registry that doesn't implement the version endpoint answers with
-/// an HTTP error → fall back to the packument; a TRANSPORT failure (host
-/// unreachable) propagates instead, since the packument fetch would only re-run
-/// the same doomed connect (and take its own retries doing it).
+/// `Accept`. A registry that doesn't implement the version endpoint — an HTTP
+/// error, or a 200 whose body isn't a usable manifest (a path-prefix proxy
+/// serving the whole packument, an HTML error page) — falls back to the
+/// packument, so no registry the packument path handled regresses. A TRANSPORT
+/// failure (host unreachable) propagates instead, since the packument fetch
+/// would only re-run the same doomed connect (and take its own retries doing it).
 pub fn resolve_version_authed(cfg: &RegistryConfig, pkg: &str, spec: &str) -> Result<VersionDist> {
     let spec = spec.trim();
     let base = cfg.base.trim_end_matches('/');
@@ -616,12 +618,13 @@ pub fn resolve_version_authed(cfg: &RegistryConfig, pkg: &str, spec: &str) -> Re
         let url = format!("{base}/{pkg}/{spec}");
         match download::fetch_text_accept_auth(&url, None, cfg.auth.as_ref()) {
             Ok(body) => {
-                let meta: Value = serde_json::from_str(&body)
-                    .with_context(|| format!("parsing version manifest {url}"))?;
-                let mut dist = resolve_dist_from_version_manifest(&meta)
-                    .with_context(|| format!("resolving {pkg}@{spec}"))?;
-                dist.tarball = rewrite_tarball_origin(&dist.tarball, &cfg.base);
-                return Ok(dist);
+                if let Ok(meta) = serde_json::from_str::<Value>(&body)
+                    && let Ok(mut dist) = resolve_dist_from_version_manifest(&meta)
+                {
+                    dist.tarball = rewrite_tarball_origin(&dist.tarball, &cfg.base);
+                    return Ok(dist);
+                }
+                // 200 but not a version manifest → packument fallback below.
             }
             Err(e) if e.status.is_none() => {
                 return Err(e.error).with_context(|| format!("fetching {url}"));

--- a/crates/nub-core/src/version_management/download.rs
+++ b/crates/nub-core/src/version_management/download.rs
@@ -290,7 +290,14 @@ fn try_download(
     auth: Option<&Auth>,
     progress: &mut impl FnMut(u64, Option<u64>),
 ) -> std::result::Result<String, Attempt> {
+    // Integrity is verified over the on-disk bytes, so the wire body must BE the
+    // published artifact. The client's `gzip` feature (wanted for packument
+    // fetches) would otherwise advertise `Accept-Encoding: gzip` here and
+    // transparently decompress a `Content-Encoding`d response — inviting a proxy
+    // to re-encode an already-compressed tarball and fail the checksum. Ask for
+    // identity: artifacts gain nothing from transfer compression.
     let resp = with_auth(client.get(url), auth)
+        .header(reqwest::header::ACCEPT_ENCODING, "identity")
         .send()
         .map_err(Attempt::from_send)?;
     let mut resp = resp.error_for_status().map_err(Attempt::from_status)?;

--- a/crates/nub-core/src/version_management/download.rs
+++ b/crates/nub-core/src/version_management/download.rs
@@ -126,18 +126,52 @@ pub fn fetch_text(url: &str) -> Result<String> {
 /// [`fetch_text`] with an optional private-registry `Authorization` header and the
 /// bounded transient-failure retry.
 pub fn fetch_text_auth(url: &str, auth: Option<&Auth>) -> Result<String> {
-    let client = client()?;
+    fetch_text_accept_auth(url, None, auth).map_err(|e| e.error)
+}
+
+/// A failed text fetch, split by WHERE it failed: `status` carries the HTTP
+/// status when the server ANSWERED with a non-2xx (after retries) — the signal a
+/// caller can use to fall back to a different endpoint on the same host — and is
+/// `None` for a transport-level failure (unreachable host, TLS, timeout), where
+/// any sibling-endpoint fallback would only re-run the same doomed connect.
+pub struct FetchTextError {
+    pub status: Option<u16>,
+    pub error: anyhow::Error,
+}
+
+/// [`fetch_text_auth`] with an optional `Accept` header (the npm registry varies
+/// its packument representation on it) and a status-carrying error so callers can
+/// distinguish "endpoint said no" from "host unreachable".
+pub fn fetch_text_accept_auth(
+    url: &str,
+    accept: Option<&str>,
+    auth: Option<&Auth>,
+) -> std::result::Result<String, FetchTextError> {
+    let client = match client() {
+        Ok(c) => c,
+        Err(e) => {
+            return Err(FetchTextError {
+                status: None,
+                error: e,
+            });
+        }
+    };
     let mut attempt = 0;
     loop {
         attempt += 1;
         let last = attempt >= MAX_ATTEMPTS;
-        match try_fetch_text(&client, url, auth) {
+        match try_fetch_text(&client, url, accept, auth) {
             Ok(body) => return Ok(body),
             Err(e) if !last && e.transient => {
                 backoff(attempt);
                 continue;
             }
-            Err(e) => return Err(e.error).with_context(|| format!("GET {url}")),
+            Err(e) => {
+                return Err(FetchTextError {
+                    status: e.status,
+                    error: e.error.context(format!("GET {url}")),
+                });
+            }
         }
     }
 }
@@ -147,20 +181,26 @@ pub fn fetch_text_auth(url: &str, auth: Option<&Auth>) -> Result<String> {
 fn try_fetch_text(
     client: &reqwest::blocking::Client,
     url: &str,
+    accept: Option<&str>,
     auth: Option<&Auth>,
 ) -> std::result::Result<String, Attempt> {
-    let resp = with_auth(client.get(url), auth)
-        .send()
-        .map_err(Attempt::from_send)?;
+    let mut req = with_auth(client.get(url), auth);
+    if let Some(media_type) = accept {
+        req = req.header(reqwest::header::ACCEPT, media_type);
+    }
+    let resp = req.send().map_err(Attempt::from_send)?;
     let resp = resp.error_for_status().map_err(Attempt::from_status)?;
     resp.text()
         .map_err(|e| Attempt::transient(anyhow::Error::new(e)))
 }
 
-/// A failed attempt plus whether the retry loop should try again.
+/// A failed attempt plus whether the retry loop should try again. `status` is
+/// the HTTP status when the server answered non-2xx (`None` for transport
+/// failures) — surfaced through [`FetchTextError`] for endpoint fallback.
 struct Attempt {
     error: anyhow::Error,
     transient: bool,
+    status: Option<u16>,
 }
 
 impl Attempt {
@@ -168,12 +208,14 @@ impl Attempt {
         Self {
             error,
             transient: true,
+            status: None,
         }
     }
     fn fatal(error: anyhow::Error) -> Self {
         Self {
             error,
             transient: false,
+            status: None,
         }
     }
     /// A send/connect/timeout failure (no HTTP status yet).
@@ -182,14 +224,17 @@ impl Attempt {
         Self {
             error: anyhow::Error::new(err),
             transient,
+            status: None,
         }
     }
     /// A non-2xx status from `error_for_status`: only 5xx/429 retry.
     fn from_status(err: reqwest::Error) -> Self {
         let transient = err.status().map(status_is_transient).unwrap_or(false);
+        let status = err.status().map(|s| s.as_u16());
         Self {
             error: anyhow::Error::new(err),
             transient,
+            status,
         }
     }
 }

--- a/site/content/docs/pm/pm-shim.mdx
+++ b/site/content/docs/pm/pm-shim.mdx
@@ -43,3 +43,7 @@ and node_modules.
 ```
 
 Runner commands stay transparent. The `npx` and `pnpx` tools and the `init` / `create` / `dlx` / `exec` verbs fall through to the system tool whatever the pin, so `npm create vite` works in a pnpm project. A package manager spawned by a running install — a lifecycle script shelling out to a different one — also falls through, so an install you never typed directly isn't broken.
+
+## No manager on PATH
+
+An unpinned invocation falls through to the system manager. When there is none — a fresh machine, a minimal container — the shim runs a dynamic default instead of failing: the version family the committed lockfile implies, or the registry `latest` when there is no lockfile. It announces the choice on stderr and writes no pin. The `latest` resolution is remembered for 24 hours, so repeat invocations dispatch with no registry round-trip, and when the registry is unreachable the last resolved version keeps working.


### PR DESCRIPTION
The shim's dynamic default (`npm@latest`) re-resolved the tag every invocation via the full packument (~25 MB for npm) and failed hard offline. Now: dist-tag resolutions are recorded per registry with a 24h TTL (zero-network warm path, offline fallback to the last resolution), exact/tag specs resolve via `GET /{pkg}/{spec}` with packument fallback, ranges use the corgi `Accept` header, and metadata fetches are gzipped.

Closes #491

Verified e2e: warm shim `npx --version` 22–35s → 0.5s; offline warm run now succeeds. `make verify` green (1097 tests, 5 new).

https://claude.ai/code/session_01XG9SP8UzkBpFWeP5Jp3brP