### PR TITLE
feat(pm): sanction top-level packageExtensions under nub identity

### DIFF
--- a/crates/nub-cli/src/pm_engine/unsupported_config.rs
+++ b/crates/nub-cli/src/pm_engine/unsupported_config.rs
@@ -304,8 +304,10 @@ fn scan_fatal(role: Role, root: &Path) -> Option<FatalField> {
                     field: "`legacy-peer-deps`",
                     detail: "nub always resolves peer dependencies; npm's legacy escape hatch \
                              would produce a different peer graph",
-                    remedy: "remove `legacy-peer-deps` from .npmrc and fix the peer conflict, \
-                             or pin the conflicting versions in `overrides`",
+                    remedy: "remove `legacy-peer-deps` from .npmrc and fix the peer conflict — \
+                             pin the conflicting versions in `overrides`, or correct a \
+                             package's peer metadata (e.g. mark a peer optional) in \
+                             `packageExtensions`",
                 });
             }
             if let Some(strategy) = npmrc_project_value(root, "install-strategy")

--- a/crates/nub-cli/tests/package_extensions.rs
+++ b/crates/nub-cli/tests/package_extensions.rs
@@ -1,0 +1,132 @@
+//! Top-level `package.json#packageExtensions` under Nub identity (#492).
+//!
+//! `packageExtensions` is a sanctioned neutral field: it patches a
+//! dependency's manifest at resolve time — adding to its dependencies /
+//! optionalDependencies / peerDependencies / peerDependenciesMeta, add-only,
+//! never overriding a declared range — matching pnpm's `packageExtensions`.
+//! This proves two contracts end-to-end in one shared-store install loop: the
+//! field shapes the resolved graph, and EDITING it after an install invalidates
+//! freshness (the install shape digest folds `packageExtensions`, so the edit
+//! is not treated as cosmetic and the fast path re-resolves).
+//!
+//! Network (`#[ignore]`, self-skips when the registry is unreachable), per the
+//! install-test convention — run via
+//! `cargo test -p nub-cli --test package_extensions -- --ignored`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/
+    path.push("nub");
+    path
+}
+
+fn pm_tmpdir(tag: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nub-pkgext-{tag}-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn registry_reachable() -> bool {
+    use std::net::{TcpStream, ToSocketAddrs};
+    "registry.npmjs.org:443"
+        .to_socket_addrs()
+        .ok()
+        .and_then(|mut addrs| addrs.next())
+        .is_some_and(|addr| {
+            TcpStream::connect_timeout(&addr, std::time::Duration::from_secs(3)).is_ok()
+        })
+}
+
+/// Run `nub <args>` in `dir` against a CALLER-OWNED store/cache so the second
+/// install warm-hits the first's node_modules + freshness state. A fresh store
+/// per call would re-resolve unconditionally and mask the freshness contract.
+fn run_install_in_store(dir: &Path, store: &Path, cache: &Path, args: &[&str]) -> (String, i32) {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .env("XDG_DATA_HOME", store)
+        .env("XDG_CACHE_HOME", cache)
+        .output()
+        .expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// Whether the virtual store under `node_modules/.store` holds any version of
+/// `name`.
+fn store_has(dir: &Path, name: &str) -> bool {
+    let prefix = format!("{name}@");
+    std::fs::read_dir(dir.join("node_modules/.store"))
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| e.file_name().into_string().ok())
+        .any(|n| n.starts_with(&prefix))
+}
+
+/// A top-level `packageExtensions` entry injecting a dependency into a resolved
+/// package must shape the graph under Nub identity, and editing it after an
+/// install must invalidate the fast path so the injected dep lands.
+#[test]
+#[ignore = "network: resolves is-positive@3.1.0 + the injected is-number@7.0.0 from the npm registry"]
+fn top_level_package_extensions_shapes_resolution_and_invalidates_freshness() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("shape");
+    let store = pm_tmpdir("store");
+    let cache = pm_tmpdir("cache");
+
+    // Nub-identity project (no lockfile, no PM declaration): one zero-dep
+    // dependency, no packageExtensions yet.
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"pkgext","version":"1.0.0","dependencies":{"is-positive":"3.1.0"}}"#,
+    )
+    .unwrap();
+
+    let (err1, code1) = run_install_in_store(&dir, &store, &cache, &["install"]);
+    assert_eq!(code1, 0, "baseline install failed: {err1}");
+    assert!(
+        dir.join("nub.lock").is_file(),
+        "the nub-identity install writes nub.lock: {err1}"
+    );
+    assert!(
+        !store_has(&dir, "is-number"),
+        "without the extension the graph must not contain is-number: {err1}"
+    );
+
+    // Add a top-level packageExtensions entry injecting is-number into
+    // is-positive. is-positive declares no deps, so the add-only merge adds it.
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"pkgext","version":"1.0.0","dependencies":{"is-positive":"3.1.0"},"packageExtensions":{"is-positive@3.1.0":{"dependencies":{"is-number":"7.0.0"}}}}"#,
+    )
+    .unwrap();
+
+    // Re-install against the SAME store. The packageExtensions edit changes the
+    // install shape digest, so the fast path re-resolves and pulls the injected
+    // is-number. Without packageExtensions in the shape digest the install
+    // short-circuits ("Already up to date") and is-number never lands.
+    let (err2, code2) = run_install_in_store(&dir, &store, &cache, &["install"]);
+    assert_eq!(code2, 0, "extended install failed: {err2}");
+    assert!(
+        store_has(&dir, "is-number"),
+        "top-level packageExtensions must inject is-number into is-positive, and \
+         the edit must invalidate the install fast path so it re-resolves: {err2}"
+    );
+}

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -156,6 +156,7 @@ Under its own identity, Nub reads only neutral, cross-tool config — never anot
         { code: '.npmrc', ok: true },
         { code: 'overrides', ok: true },
         { code: 'resolutions', ok: true },
+        { code: 'packageExtensions', ok: true },
         { code: 'patchedDependencies', ok: true },
         { code: 'catalog:', ok: true },
         { code: 'workspace:', ok: true },
@@ -176,7 +177,7 @@ The installer is optional. Keep running `npm`, `pnpm`, `yarn`, or `bun` exactly 
 A project is Nub's own in three cases: it declares Nub through `nub pm use nub`, `nub.lock` is the only lockfile signal, or a fresh project has no declaration and no lockfile. The switch aligns the manifest and lockfile, migrates pnpm workspace config into neutral `package.json` fields, and moves the project onto a neutral surface:
 
 - **Lockfile:** `nub.lock` — the pnpm v9 schema byte-for-byte, under Nub's own basename
-- **Package fields:** `workspaces`, `overrides`, `resolutions`, `patchedDependencies`, `allowBuilds`, `engines.node`, `scripts`
+- **Package fields:** `workspaces`, `overrides`, `resolutions`, `packageExtensions`, `patchedDependencies`, `allowBuilds`, `engines.node`, `scripts`
 - **Config and env:** the `.npmrc` cascade, `npm_config_*`, neutral env (`CI`, proxies), plus `NUB_CACHE_DIR`, `NUB_CONCURRENCY`, `NUB_PRIMER_TTL`
 - **Install state:** `node_modules/.store/`, `.nub-state`, and the global store under Nub's own directories
 
@@ -220,6 +221,25 @@ Under Nub identity, `nub.lock` beside a foreign lockfile is the ambiguity error.
 <Callout title="Inference vs the pinned PM">
 This inference picks the *install engine's* incumbent — the format Nub reads and writes. It is separate from the version `nub pm` provisions: the meta-manager resolves a *pin* (`.yarnrc.yml` `yarnPath` → `packageManager` → `devEngines`) to fetch and run an exact PM binary. Same signals, different questions: "which format do I install in?" versus "which PM binary do I run?".
 </Callout>
+
+### Package extensions
+
+A published package sometimes declares a peer dependency it doesn't actually need, or is missing one it does — and its `package.json` isn't yours to edit. A top-level `packageExtensions` field patches a dependency's manifest at resolve time, adding to its `dependencies`, `optionalDependencies`, `peerDependencies`, or `peerDependenciesMeta`. The selector is a package name, optionally pinned to a version range:
+
+```json
+// package.json
+{
+  "packageExtensions": {
+    "react-server-dom-webpack@19.2.7": {
+      "peerDependenciesMeta": {
+        "react": { "optional": true }   // relax a peer the package over-declares
+      }
+    }
+  }
+}
+```
+
+An extension only *adds* what's missing — it never overrides a range the package already declares. To change the version of a dependency a package does declare, use `overrides` instead. The semantics match pnpm's `packageExtensions`, so a project moving off pnpm keeps the same escape hatch under a neutral field.
 
 ### Compat mode
 

--- a/vendor/aube/crates/aube-util/src/hash.rs
+++ b/vendor/aube/crates/aube-util/src/hash.rs
@@ -254,6 +254,11 @@ pub const INSTALL_SHAPE_FIELDS: &[&str] = &[
     "name",
     "optionalDependencies",
     "overrides",
+    // `packageExtensions` extends a package's declared deps/optionalDeps/
+    // peerDeps/peerDependenciesMeta at resolve time, so an edit reshapes the
+    // resolved graph — it must invalidate the install, else the fast path
+    // silently skips the re-resolve the new extension demands.
+    "packageExtensions",
     "peerDependencies",
     "peerDependenciesMeta",
     "pnpm",
@@ -463,6 +468,24 @@ mod tests {
             serde_json::from_str(r#"{"dependencies":{"esbuild":"0.24.0"}}"#).unwrap();
         let b: serde_json::Value = serde_json::from_str(
             r#"{"dependencies":{"esbuild":"0.24.0"},"trustedDependencies":["esbuild"]}"#,
+        )
+        .unwrap();
+        assert_ne!(
+            manifest_install_shape_digest(&a),
+            manifest_install_shape_digest(&b)
+        );
+    }
+
+    #[test]
+    fn manifest_digest_reacts_to_package_extensions_change() {
+        // A top-level `packageExtensions` edit reshapes the resolved graph
+        // (here marking a peer optional), so the shape digest must change —
+        // otherwise the install fast path treats the edit as cosmetic and
+        // skips the re-resolve.
+        let a: serde_json::Value =
+            serde_json::from_str(r#"{"dependencies":{"is-positive":"3.1.0"}}"#).unwrap();
+        let b: serde_json::Value = serde_json::from_str(
+            r#"{"dependencies":{"is-positive":"3.1.0"},"packageExtensions":{"is-positive@3.1.0":{"peerDependenciesMeta":{"react":{"optional":true}}}}}"#,
         )
         .unwrap();
         assert_ne!(


### PR DESCRIPTION
Sanctions top-level `package.json#packageExtensions` as a neutral nub-identity field, matching pnpm's semantics: it patches a dependency's manifest at resolve time, add-only (never overriding a declared range). The engine already read it ungated; this adds the docs and a test, and closes two gaps:

- Fold `packageExtensions` into the install shape digest (`INSTALL_SHAPE_FIELDS`) so editing it invalidates the fast path — previously a cosmetic edit that skipped re-resolve, the freshness gap this issue reports.
- Extend the `legacy-peer-deps` remedy to point at `packageExtensions` for peer-metadata fixes (e.g. marking a wrongly-required peer optional), which `overrides` cannot express.

Tests: a hermetic aube-util unit test proving the shape digest now reacts to a `packageExtensions` edit, and a network-gated integration test proving a top-level extension shapes the resolved graph and that editing it re-resolves.

Closes #492
