### PR TITLE
node install: stream extraction during download, overlap checksum fetch

### DIFF
--- a/crates/nub-core/src/version_management/download.rs
+++ b/crates/nub-core/src/version_management/download.rs
@@ -356,10 +356,22 @@ fn try_download_extract(
         })
     };
 
+    let join_extractor = |h: std::thread::JoinHandle<Result<PathBuf>>| -> Result<PathBuf> {
+        h.join()
+            .unwrap_or_else(|_| bail!("extractor thread panicked unpacking {source_name}"))
+    };
+
+    let mut extractor = Some(extractor);
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 64 * 1024];
     let mut written = 0u64;
     let mut transport: std::result::Result<(), Attempt> = Ok(());
+    // Set when the extractor exits before the body ends (a send fails). A tar
+    // reader legitimately stops at the end-of-archive marker, before trailing
+    // padding — then we keep DRAINING the body so the hash covers every byte;
+    // an extraction FAILURE stops the download (its error is the story, and the
+    // rest of the body is wasted bandwidth).
+    let mut early: Option<Result<PathBuf>> = None;
     loop {
         let n = match resp.read(&mut buf) {
             Ok(n) => n,
@@ -377,30 +389,39 @@ fn try_download_extract(
         hasher.update(&buf[..n]);
         written += n as u64;
         progress(written, total);
-        if tx.send(buf[..n].to_vec()).is_err() {
-            // The extractor exited early — its join result carries the real error.
-            break;
+        if early.is_none() && tx.send(buf[..n].to_vec()).is_err() {
+            // A failed send means the receiver is gone, i.e. the extractor
+            // thread already returned — join is immediate.
+            let result = join_extractor(extractor.take().expect("joined once"));
+            let failed = result.is_err();
+            early = Some(result);
+            if failed {
+                break;
+            }
         }
     }
     drop(tx); // signals EOF to the extractor
-    let extracted = extractor.join();
+    let extracted = match early {
+        Some(r) => r,
+        None => join_extractor(extractor.take().expect("joined once")),
+    };
 
     // Precedence: a transport fault outranks the extractor's (symptomatic,
-    // truncated-stream) error; then a short-but-cleanly-closed body retries too.
+    // truncated-stream) error; a genuine extraction failure outranks the
+    // short-body check (the body IS short because we stopped downloading — a
+    // transient retry would just re-download and re-fail, masking the cause);
+    // a short-but-cleanly-closed body retries.
     transport?;
     if let Some(t) = total {
-        if written != t {
+        if written != t && extracted.is_ok() {
             return Err(Attempt::transient(anyhow::anyhow!(
                 "short response body: got {written} of {t} bytes"
             )));
         }
     }
     match extracted {
-        Ok(Ok(top)) => Ok((hex_lower(&hasher.finalize()), top)),
-        Ok(Err(e)) => Err(Attempt::fatal(e)),
-        Err(_) => Err(Attempt::fatal(anyhow::anyhow!(
-            "extractor thread panicked unpacking {source_name}"
-        ))),
+        Ok(top) => Ok((hex_lower(&hasher.finalize()), top)),
+        Err(e) => Err(Attempt::fatal(e)),
     }
 }
 
@@ -414,7 +435,10 @@ struct ChannelReader {
 
 impl Read for ChannelReader {
     fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
-        if self.pos >= self.buf.len() {
+        // `while` (not `if`): an empty chunk must never read as EOF — the
+        // download side doesn't send them, but a clean EOF here is load-bearing
+        // enough not to rest on that invariant alone.
+        while self.pos >= self.buf.len() {
             match self.rx.recv() {
                 Ok(chunk) => {
                     self.buf = chunk;

--- a/crates/nub-core/src/version_management/download.rs
+++ b/crates/nub-core/src/version_management/download.rs
@@ -15,7 +15,7 @@
 //! number of times ([`MAX_ATTEMPTS`]); 4xx and integrity failures fail fast.
 
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
@@ -278,6 +278,156 @@ fn try_download(
     }
     file.flush().ok();
     Ok(hex_lower(&hasher.finalize()))
+}
+
+/// Download a `.tar.xz` and extract it WHILE it streams in (#496): the response
+/// bytes are hashed and fed through a bounded channel to an extractor thread, so
+/// the wall clock is max(download, decode+extract) instead of their sum. The
+/// extraction lands under `stage_parent` (the provisioner's quarantine `.tmp-`
+/// work dir) — the caller MUST verify the returned SHA-256 against
+/// `SHASUMS256.txt` before committing the tree anywhere, and must discard the
+/// work dir on mismatch (`provision_node`'s `WorkGuard` covers every exit path).
+/// Returns `(sha256_hex, extracted_top_dir)`.
+///
+/// Retry mirrors [`download_to_file_auth`]: a mid-stream transport fault or a
+/// short body (known `Content-Length`, connection closed early) retries from
+/// scratch with a fresh stage dir; an extraction failure (corrupt xz, bomb-cap
+/// trip, disk error) is fatal — TLS already guarantees stream integrity, so
+/// corrupt bytes won't improve on a retry.
+pub fn download_and_extract_tar_xz(
+    url: &str,
+    stage_parent: &Path,
+    mut progress: impl FnMut(u64, Option<u64>),
+) -> Result<(String, PathBuf)> {
+    let client = client()?;
+    let source_name = url.rsplit('/').next().unwrap_or(url).to_string();
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        let last = attempt >= MAX_ATTEMPTS;
+        match try_download_extract(&client, url, &source_name, stage_parent, &mut progress) {
+            Ok(ok) => return Ok(ok),
+            Err(e) if !last && e.transient => {
+                backoff(attempt);
+                continue;
+            }
+            Err(e) => return Err(e.error).with_context(|| format!("downloading {url}")),
+        }
+    }
+}
+
+/// One streamed download+extract attempt. The stage dir is wiped at the top so a
+/// retry never extracts on top of a partial tree.
+fn try_download_extract(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    source_name: &str,
+    stage_parent: &Path,
+    progress: &mut impl FnMut(u64, Option<u64>),
+) -> std::result::Result<(String, PathBuf), Attempt> {
+    let resp = with_auth(client.get(url), None)
+        .send()
+        .map_err(Attempt::from_send)?;
+    let mut resp = resp.error_for_status().map_err(Attempt::from_status)?;
+    let total = resp.content_length();
+
+    let stage = stage_parent.join("stream-extract");
+    let _ = std::fs::remove_dir_all(&stage);
+    std::fs::create_dir_all(&stage)
+        .with_context(|| format!("create {}", stage.display()))
+        .map_err(Attempt::fatal)?;
+
+    // Bounded channel = backpressure: at most 16 × 64 KiB in flight, so a slow
+    // disk can't balloon memory and a fast disk never starves the socket.
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(16);
+    let extractor = {
+        let stage = stage.clone();
+        let name = source_name.to_string();
+        std::thread::spawn(move || {
+            crate::version_management::extract::extract_tar_xz_stream(
+                ChannelReader {
+                    rx,
+                    buf: Vec::new(),
+                    pos: 0,
+                },
+                &name,
+                &stage,
+            )
+        })
+    };
+
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    let mut written = 0u64;
+    let mut transport: std::result::Result<(), Attempt> = Ok(());
+    loop {
+        let n = match resp.read(&mut buf) {
+            Ok(n) => n,
+            Err(e) => {
+                // Mid-stream transport drop → retry (after collecting the thread).
+                transport = Err(Attempt::transient(
+                    anyhow::Error::new(e).context("reading response body"),
+                ));
+                break;
+            }
+        };
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        written += n as u64;
+        progress(written, total);
+        if tx.send(buf[..n].to_vec()).is_err() {
+            // The extractor exited early — its join result carries the real error.
+            break;
+        }
+    }
+    drop(tx); // signals EOF to the extractor
+    let extracted = extractor.join();
+
+    // Precedence: a transport fault outranks the extractor's (symptomatic,
+    // truncated-stream) error; then a short-but-cleanly-closed body retries too.
+    transport?;
+    if let Some(t) = total {
+        if written != t {
+            return Err(Attempt::transient(anyhow::anyhow!(
+                "short response body: got {written} of {t} bytes"
+            )));
+        }
+    }
+    match extracted {
+        Ok(Ok(top)) => Ok((hex_lower(&hasher.finalize()), top)),
+        Ok(Err(e)) => Err(Attempt::fatal(e)),
+        Err(_) => Err(Attempt::fatal(anyhow::anyhow!(
+            "extractor thread panicked unpacking {source_name}"
+        ))),
+    }
+}
+
+/// `Read` over the download→extractor channel: each `recv` hands the next chunk,
+/// a disconnected sender is EOF. (The download side never sends an empty chunk.)
+struct ChannelReader {
+    rx: std::sync::mpsc::Receiver<Vec<u8>>,
+    buf: Vec<u8>,
+    pos: usize,
+}
+
+impl Read for ChannelReader {
+    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+        if self.pos >= self.buf.len() {
+            match self.rx.recv() {
+                Ok(chunk) => {
+                    self.buf = chunk;
+                    self.pos = 0;
+                }
+                Err(_) => return Ok(0),
+            }
+        }
+        let n = out.len().min(self.buf.len() - self.pos);
+        out[..n].copy_from_slice(&self.buf[self.pos..self.pos + n]);
+        self.pos += n;
+        Ok(n)
+    }
 }
 
 /// SHA-256 (lowercase hex) of a file already on disk.

--- a/crates/nub-core/src/version_management/extract.rs
+++ b/crates/nub-core/src/version_management/extract.rs
@@ -1,4 +1,5 @@
-//! Extract a verified Node dist archive into nub's store.
+//! Extract a Node dist archive into nub's store (or its quarantine temp dir,
+//! for the streamed path — commit into the store stays gated on the checksum).
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -10,9 +11,10 @@ use anyhow::{Context, Result, bail};
 /// `aube_store::MAX_TARBALL_DECOMPRESSED_BYTES`. A stock Node dist tarball
 /// unpacks to well under 100 MiB, so this sits an order of magnitude above any
 /// real artifact while stopping a malicious/mirror-served small-compressed /
-/// huge-decompressed payload from exhausting disk or memory. The download is
-/// already checksum-verified against `SHASUMS256.txt` before extraction, so this
-/// is defense-in-depth against a MITM/mirror that also forged the checksum.
+/// huge-decompressed payload from exhausting disk or memory. On the streamed
+/// path extraction overlaps the download, so these caps are the live guard while
+/// bytes are still unverified; the SHA-256 gate then decides whether the
+/// extracted tree is COMMITTED into the store at all (`provision_node`).
 ///
 /// The cap is wired through the `_capped` extractor variants as a parameter
 /// rather than read from this const directly, so a bomb test can inject a tiny
@@ -106,6 +108,25 @@ pub fn extract_tar_xz(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
     )
 }
 
+/// [`extract_tar_xz`] over an arbitrary byte stream instead of a file on disk —
+/// the seam the streamed download path (#496) feeds while the tarball is still
+/// arriving. `source_name` only labels error messages (there is no file path).
+/// Same caps, same traversal guard; the CALLER owns gating any commit of the
+/// extracted tree on checksum verification (see `provision_node`).
+pub(crate) fn extract_tar_xz_stream(
+    reader: impl Read,
+    source_name: &str,
+    dest_parent: &Path,
+) -> Result<PathBuf> {
+    extract_tar_xz_reader_capped(
+        reader,
+        Path::new(source_name),
+        dest_parent,
+        MAX_ARCHIVE_DECOMPRESSED_BYTES,
+        MAX_ARCHIVE_ENTRIES,
+    )
+}
+
 /// [`extract_tar_xz`] with the decompression + entry-count caps as explicit
 /// parameters — the seam a bomb test uses to inject tiny caps (the public entry
 /// uses the prod constants).
@@ -117,6 +138,18 @@ fn extract_tar_xz_capped(
 ) -> Result<PathBuf> {
     let file =
         std::fs::File::open(archive).with_context(|| format!("open {}", archive.display()))?;
+    extract_tar_xz_reader_capped(file, archive, dest_parent, decompressed_cap, max_entries)
+}
+
+/// The shared extractor body: xz-decode + unpack any `Read`, capped. `archive`
+/// only labels error messages (a file path, or a URL basename for the stream).
+fn extract_tar_xz_reader_capped(
+    reader: impl Read,
+    archive: &Path,
+    dest_parent: &Path,
+    decompressed_cap: u64,
+    max_entries: usize,
+) -> Result<PathBuf> {
     // Cap the DECOMPRESSED stream against a decompression bomb (N2). Node
     // tarballs legitimately ship intra-tree symlinks (`bin/npm → ../lib/…`), so
     // unlike the PM-tgz extractor this path allows them — `Entry::unpack_in`
@@ -133,7 +166,7 @@ fn extract_tar_xz_capped(
     // canonicalization (unreachable — Windows Node ships as `.zip`, handled by
     // `extract_zip`). File data, exec bits, symlink targets, and the `..`/absolute
     // traversal guard are all preserved by `unpack_in`.
-    let decoder = CappedReader::new(liblzma::read::XzDecoder::new(file), decompressed_cap);
+    let decoder = CappedReader::new(liblzma::read::XzDecoder::new(reader), decompressed_cap);
     let mut tar = tar::Archive::new(decoder);
     std::fs::create_dir_all(dest_parent)
         .with_context(|| format!("create {}", dest_parent.display()))?;
@@ -319,6 +352,32 @@ mod tests {
         assert_eq!(top.file_name().unwrap(), "top");
         assert!(top.join("bin").join("node").is_file());
         assert!(top.join("README").is_file());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The streamed variant must behave identically to the file one on the same
+    /// bytes — build the archive in memory and feed it through a plain `Read`.
+    #[test]
+    fn extract_tar_xz_stream_matches_the_file_path() {
+        let mut bytes = Vec::new();
+        {
+            let enc = liblzma::write::XzEncoder::new(&mut bytes, 6);
+            let mut builder = tar::Builder::new(enc);
+            let mut h = tar::Header::new_gnu();
+            h.set_size(3);
+            h.set_mode(0o755);
+            h.set_cksum();
+            builder
+                .append_data(&mut h, "top/bin/node", &b"#!\n"[..])
+                .unwrap();
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        let dir = std::env::temp_dir().join(format!("nub-xz-stream-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let top =
+            extract_tar_xz_stream(std::io::Cursor::new(bytes), "sample.tar.xz", &dir).unwrap();
+        assert_eq!(top.file_name().unwrap(), "top");
+        assert!(top.join("bin").join("node").is_file());
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/nub-core/src/version_management/mod.rs
+++ b/crates/nub-core/src/version_management/mod.rs
@@ -549,16 +549,24 @@ mod tests {
     /// connection is handled on its own thread — the checksum fetch and the
     /// tarball download arrive CONCURRENTLY by design. The daemon accept loop
     /// dies with the test process.
-    fn serve_dist(shasums: String, tarball_name: String, tarball: Vec<u8>) -> String {
+    fn serve_dist(
+        shasums: String,
+        tarball_name: String,
+        tarball: Vec<u8>,
+    ) -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
         use std::io::{Read as _, Write as _};
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let base = format!("http://{}", listener.local_addr().unwrap());
+        // Counts tarball GETs — the retry-behavior tests assert on it.
+        let hits = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hits_out = hits.clone();
         std::thread::spawn(move || {
             for stream in listener.incoming() {
                 let Ok(mut stream) = stream else { continue };
                 let shasums = shasums.clone();
                 let tarball_name = tarball_name.clone();
                 let tarball = tarball.clone();
+                let hits = hits.clone();
                 std::thread::spawn(move || {
                     let mut req = [0u8; 2048];
                     let n = stream.read(&mut req).unwrap_or(0);
@@ -567,6 +575,7 @@ mod tests {
                     let (status, body): (&str, Vec<u8>) = if path.ends_with("/SHASUMS256.txt") {
                         ("200 OK", shasums.into_bytes())
                     } else if path.ends_with(&tarball_name) {
+                        hits.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                         ("200 OK", tarball)
                     } else {
                         ("404 Not Found", Vec::new())
@@ -580,7 +589,7 @@ mod tests {
                 });
             }
         });
-        base
+        (base, hits_out)
     }
 
     /// A tiny but valid Node-shaped `.tar.xz` (top dir with `bin/node`) built in
@@ -614,7 +623,7 @@ mod tests {
         let version = ver("99.99.99");
         let name = "node-v99.99.99-linux-x64";
         let (tarball, sha) = node_fixture_tar_xz(name);
-        let base = serve_dist(
+        let (base, _hits) = serve_dist(
             format!("{sha}  {name}.tar.xz\n"),
             format!("{name}.tar.xz"),
             tarball,
@@ -647,7 +656,7 @@ mod tests {
         let name = "node-v99.99.98-linux-x64";
         let (tarball, _sha) = node_fixture_tar_xz(name);
         let wrong = "0".repeat(64);
-        let base = serve_dist(
+        let (base, _hits) = serve_dist(
             format!("{wrong}  {name}.tar.xz\n"),
             format!("{name}.tar.xz"),
             tarball,
@@ -670,6 +679,47 @@ mod tests {
             .filter(|e| e.file_name().to_string_lossy().starts_with(".tmp-"))
             .collect();
         assert!(leftovers.is_empty(), "work dir leaked: {leftovers:?}");
+        let _ = std::fs::remove_dir_all(&store);
+    }
+
+    /// A mid-stream extraction failure (corrupt archive under a truthful
+    /// Content-Length) must surface the EXTRACTION error, fail fast (one
+    /// download attempt, no transient retry), and leave nothing behind. Guards
+    /// the exit-reason precedence in `download_and_extract_tar_xz`: without it,
+    /// the extractor's early exit reads as a short body and retries 3× with a
+    /// misleading error. The body is sized well past the channel's backpressure
+    /// window so the extractor provably dies while bytes are still unread.
+    #[test]
+    fn provision_fails_fast_on_mid_stream_corruption() {
+        let h = host(NodeOs::Linux, NodeArch::X64, false);
+        let version = ver("99.99.97");
+        let name = "node-v99.99.97-linux-x64";
+        // Valid xz magic, then 4 MiB of garbage — the decoder errors on the
+        // first chunk while the download still has megabytes unread.
+        let mut corrupt = b"\xfd7zXZ\x00".to_vec();
+        corrupt.extend(std::iter::repeat_n(0xAAu8, 4 << 20));
+        use sha2::{Digest, Sha256};
+        let sha = format!("{:x}", Sha256::digest(&corrupt));
+        let (base, hits) = serve_dist(
+            format!("{sha}  {name}.tar.xz\n"),
+            format!("{name}.tar.xz"),
+            corrupt,
+        );
+        let store = std::env::temp_dir().join(format!("nub-prov-corrupt-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&store);
+
+        let err = provision_node_from(&version, &h, &store, None, &base).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            !msg.contains("short response body"),
+            "the extraction error must not be masked as a short body: {msg}"
+        );
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a corrupt archive is fatal — it must not be re-downloaded"
+        );
+        assert!(!store.join("node").join(version.to_string()).exists());
         let _ = std::fs::remove_dir_all(&store);
     }
 

--- a/crates/nub-core/src/version_management/mod.rs
+++ b/crates/nub-core/src/version_management/mod.rs
@@ -8,7 +8,9 @@
 //! extraction (`extract`), and dist-index resolver (`node_index`) are sibling
 //! submodules. Security posture: HTTPS authenticates `SHASUMS256.txt` (TLS to
 //! nodejs.org), a mandatory fail-closed SHA-256 check authenticates the tarball
-//! before extraction. GPG signature verification is intentionally NOT a v0.1 gate
+//! before it is COMMITTED into the store (extraction streams into a quarantine
+//! temp dir concurrently with the download — #496; the rename into the store is
+//! what the checksum gates). GPG signature verification is intentionally NOT a v0.1 gate
 //! (ratified by the maintainer 2026-05-30 — GPG-by-default is an ecosystem outlier and
 //! bundled keys break on Node's key rotation; see the spec's Decisions log and
 //! `wiki/research/node-provisioning-implementation.md`).
@@ -236,11 +238,21 @@ impl Drop for WorkGuard {
 /// session shows two lines. Non-TTY (CI logs, pipes) keeps all three.
 /// `resolved_from` is preformatted pin provenance (e.g. `.node-version`) for
 /// the `Using` line so logs say WHY this version was chosen; `None` for
-/// explicit installs (`nub node install`), where the user just typed it. The
-/// SHA-256 is verified BEFORE extraction (executables landing on disk), and the
-/// install is atomic — extract into a sibling temp dir, then `rename` into
-/// place, so a crash or a concurrent run never leaves a half-extracted dir
-/// masquerading as a cached version. An already-installed version
+/// explicit installs (`nub node install`), where the user just typed it.
+///
+/// Pipeline shape (#496): the `SHASUMS256.txt` fetch runs CONCURRENT with the
+/// tarball download, and on the `.tar.xz` path the archive is decoded +
+/// extracted while it streams in — into the quarantine `.tmp-` work dir, never
+/// executed, never visible to lookups. The SHA-256 gate moves from
+/// before-extraction to before-COMMIT: only after the streamed hash verifies
+/// against `SHASUMS256.txt` is the tree `rename`d into the store; on mismatch
+/// the guard wipes the work dir, so fail-closed holds (the unverified tarball
+/// already landed on disk under the old order — the trust boundary is the
+/// store commit, and that stays gated). The install is atomic — extract into a
+/// sibling temp dir, then `rename` into place, so a crash or a concurrent run
+/// never leaves a half-extracted dir masquerading as a cached version. The
+/// Windows `.zip` needs random access, so it keeps download-then-extract
+/// (still with the overlapped checksum fetch). An already-installed version
 /// short-circuits with no network + no output.
 pub fn provision_node(
     version: &NodeVersion,
@@ -248,15 +260,38 @@ pub fn provision_node(
     store_root: &Path,
     resolved_from: Option<&str>,
 ) -> Result<PathBuf> {
+    provision_node_from(
+        version,
+        host,
+        store_root,
+        resolved_from,
+        &resolve_mirror_base(host),
+    )
+}
+
+/// [`provision_node`] with the mirror base explicit — the seam the local-server
+/// provisioning tests drive (env mutation would race the parallel harness).
+pub fn provision_node_from(
+    version: &NodeVersion,
+    host: &HostTarget,
+    store_root: &Path,
+    resolved_from: Option<&str>,
+    mirror_base: &str,
+) -> Result<PathBuf> {
     let node_store = store_root.join("node");
     let final_dir = node_store.join(version.to_string());
     if version_dir_has_node(&final_dir) {
         return Ok(final_dir); // cache hit — silent
     }
 
-    let art = node_artifact(version, host, &resolve_mirror_base(host));
-    let shasums = download::fetch_text(&art.shasums_url)
-        .with_context(|| format!("fetching checksums for Node {version}"))?;
+    let art = node_artifact(version, host, mirror_base);
+    // Overlapped with the tarball download below; joined at the verify gate. On
+    // an early download error the thread is left to finish on its own (bounded
+    // by the client timeout) — the process/caller isn't blocked on it.
+    let shasums_thread = {
+        let url = art.shasums_url.clone();
+        std::thread::spawn(move || download::fetch_text(&url))
+    };
 
     // Sibling temp dir on the same filesystem → the final placement is an atomic
     // rename. The guard cleans it up on every exit path.
@@ -266,14 +301,13 @@ pub fn provision_node(
     let _guard = WorkGuard(work.clone());
 
     let started = Instant::now();
-    let tarball = work.join(&art.tarball_filename);
     let tty = std::io::IsTerminal::is_terminal(&std::io::stderr());
     match resolved_from {
         Some(p) => eprintln!("Using Node.js {version} (resolved from {p})"),
         None => eprintln!("Using Node.js {version}"),
     }
     let mut announced = false;
-    let sha = download::download_to_file(&art.tarball_url, &tarball, |_done, total| {
+    let mut on_progress = |_done: u64, total: Option<u64>| {
         if !announced {
             announced = true;
             let size = match total {
@@ -286,13 +320,34 @@ pub fn provision_node(
                 eprintln!("Installing from nodejs.org...{size}");
             }
         }
-    })
-    .with_context(|| format!("downloading Node {version}"))?;
+    };
 
-    // Verify BEFORE extracting.
+    // `.tar.xz` streams straight into the extractor; `.zip` (Windows) downloads
+    // to disk first (central directory needs random access).
+    let (sha, streamed_top) = if art.tarball_filename.ends_with(".tar.xz") {
+        let (sha, top) =
+            download::download_and_extract_tar_xz(&art.tarball_url, &work, &mut on_progress)
+                .with_context(|| format!("downloading Node {version}"))?;
+        (sha, Some(top))
+    } else {
+        let tarball = work.join(&art.tarball_filename);
+        let sha = download::download_to_file(&art.tarball_url, &tarball, &mut on_progress)
+            .with_context(|| format!("downloading Node {version}"))?;
+        (sha, None)
+    };
+
+    let shasums = shasums_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("checksum fetch thread panicked"))?
+        .with_context(|| format!("fetching checksums for Node {version}"))?;
+    // The commit gate: nothing below runs — and the streamed tree never leaves
+    // the guarded work dir — unless the hash matches.
     download::verify_checksum(&sha, &shasums, &art.tarball_filename)?;
 
-    let extracted = extract::extract_archive(&tarball, &work)?;
+    let extracted = match streamed_top {
+        Some(top) => top,
+        None => extract::extract_archive(&work.join(&art.tarball_filename), &work)?,
+    };
 
     // Atomic place. If a concurrent run already installed it, keep theirs.
     if !version_dir_has_node(&final_dir) {
@@ -487,6 +542,135 @@ mod tests {
         // The dev box + every CI runner is a published platform.
         let h = HostTarget::detect().expect("host should be a published Node platform");
         assert!(!h.platform_token().is_empty());
+    }
+
+    /// A minimal HTTP server for the streamed-provisioning tests: serves
+    /// `SHASUMS256.txt` and one tarball from memory on a loopback port. Each
+    /// connection is handled on its own thread — the checksum fetch and the
+    /// tarball download arrive CONCURRENTLY by design. The daemon accept loop
+    /// dies with the test process.
+    fn serve_dist(shasums: String, tarball_name: String, tarball: Vec<u8>) -> String {
+        use std::io::{Read as _, Write as _};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let shasums = shasums.clone();
+                let tarball_name = tarball_name.clone();
+                let tarball = tarball.clone();
+                std::thread::spawn(move || {
+                    let mut req = [0u8; 2048];
+                    let n = stream.read(&mut req).unwrap_or(0);
+                    let head = String::from_utf8_lossy(&req[..n]);
+                    let path = head.split_whitespace().nth(1).unwrap_or("").to_string();
+                    let (status, body): (&str, Vec<u8>) = if path.ends_with("/SHASUMS256.txt") {
+                        ("200 OK", shasums.into_bytes())
+                    } else if path.ends_with(&tarball_name) {
+                        ("200 OK", tarball)
+                    } else {
+                        ("404 Not Found", Vec::new())
+                    };
+                    let _ = write!(
+                        stream,
+                        "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = stream.write_all(&body);
+                });
+            }
+        });
+        base
+    }
+
+    /// A tiny but valid Node-shaped `.tar.xz` (top dir with `bin/node`) built in
+    /// memory, plus its SHA-256 — the fixture the streamed pipeline consumes.
+    fn node_fixture_tar_xz(top: &str) -> (Vec<u8>, String) {
+        let mut bytes = Vec::new();
+        {
+            let enc = liblzma::write::XzEncoder::new(&mut bytes, 6);
+            let mut builder = tar::Builder::new(enc);
+            let mut h = tar::Header::new_gnu();
+            h.set_size(3);
+            h.set_mode(0o755);
+            h.set_cksum();
+            builder
+                .append_data(&mut h, format!("{top}/bin/node"), &b"#!\n"[..])
+                .unwrap();
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        use sha2::{Digest, Sha256};
+        let sha = format!("{:x}", Sha256::digest(&bytes));
+        (bytes, sha)
+    }
+
+    /// End-to-end streamed provisioning against a local server: concurrent
+    /// checksum fetch + streamed download/extract + verify + atomic commit, no
+    /// real network. Asserts the installed layout, the cleaned work dir, and the
+    /// second-call cache hit.
+    #[test]
+    fn provision_streams_and_commits_after_verify() {
+        let h = host(NodeOs::Linux, NodeArch::X64, false);
+        let version = ver("99.99.99");
+        let name = "node-v99.99.99-linux-x64";
+        let (tarball, sha) = node_fixture_tar_xz(name);
+        let base = serve_dist(
+            format!("{sha}  {name}.tar.xz\n"),
+            format!("{name}.tar.xz"),
+            tarball,
+        );
+        let store = std::env::temp_dir().join(format!("nub-prov-stream-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&store);
+
+        let dir = provision_node_from(&version, &h, &store, None, &base).expect("provision");
+        assert!(dir.join("bin").join("node").is_file());
+        // The quarantine work dir must be gone after commit.
+        let leftovers: Vec<_> = std::fs::read_dir(store.join("node"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".tmp-"))
+            .collect();
+        assert!(leftovers.is_empty(), "work dir leaked: {leftovers:?}");
+        // Second call: silent cache hit, no server contact needed.
+        let again = provision_node_from(&version, &h, &store, None, &base).expect("cache hit");
+        assert_eq!(again, dir);
+        let _ = std::fs::remove_dir_all(&store);
+    }
+
+    /// The commit gate: a forged/mismatched checksum must abort AFTER the
+    /// streamed extraction but BEFORE anything reaches the store, leaving no
+    /// version dir and no work-dir residue.
+    #[test]
+    fn provision_refuses_to_commit_on_checksum_mismatch() {
+        let h = host(NodeOs::Linux, NodeArch::X64, false);
+        let version = ver("99.99.98");
+        let name = "node-v99.99.98-linux-x64";
+        let (tarball, _sha) = node_fixture_tar_xz(name);
+        let wrong = "0".repeat(64);
+        let base = serve_dist(
+            format!("{wrong}  {name}.tar.xz\n"),
+            format!("{name}.tar.xz"),
+            tarball,
+        );
+        let store = std::env::temp_dir().join(format!("nub-prov-mismatch-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&store);
+
+        let err = provision_node_from(&version, &h, &store, None, &base).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("checksum mismatch"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            !store.join("node").join(version.to_string()).exists(),
+            "a mismatched tarball must never be committed"
+        );
+        let leftovers: Vec<_> = std::fs::read_dir(store.join("node"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".tmp-"))
+            .collect();
+        assert!(leftovers.is_empty(), "work dir leaked: {leftovers:?}");
+        let _ = std::fs::remove_dir_all(&store);
     }
 
     /// Full real provisioning: download + verify + extract Node 22.13.0 into a


### PR DESCRIPTION
Closes #496.

The install pipeline was serial: checksums GET → full download → SHA-256 → xz decode → extract. Now the `.tar.xz` path extracts while the tarball streams in, and the `SHASUMS256.txt` fetch runs concurrently with the download. The SHA-256 gate moves to before-commit: the streamed tree stays in the quarantine `.tmp-` dir and is renamed into the store only after the checksum verifies; a mismatch wipes it. Windows `.zip` keeps download-then-extract. Kept `.tar.xz` — with decode overlapped, the smaller archive wins at any link speed; dist archives have 2 xz blocks (91% in one), so multithreaded decode was ruled out.

https://claude.ai/code/session_01TujMcGxpD3FUudua4mk97W