### PR TITLE
fix(pm): enforce + role-scope packageExtensions under nub identity

### DIFF
--- a/crates/nub-cli/src/pm_engine/config_scope.rs
+++ b/crates/nub-cli/src/pm_engine/config_scope.rs
@@ -336,6 +336,79 @@ pub(crate) fn scope_overrides(
     (effective, ignored)
 }
 
+/// The manifest's effective `packageExtensions`, scoped to the active `role`,
+/// plus the top-level field to warn about when it's dropped.
+///
+/// Top-level `packageExtensions` is a nub-identity neutral field: NO package
+/// manager reads it from `package.json` root (pnpm reads `pnpm.packageExtensions`
+/// / `pnpm-workspace.yaml`; yarn reads `.yarnrc.yml`; npm and bun have no such
+/// feature). So nub honors the top-level home ONLY under its own identity;
+/// under an npm/pnpm/yarn/bun compat role it applies exactly what the incumbent
+/// would — pnpm's `pnpm.packageExtensions` under pnpm, nothing from the manifest
+/// under npm/yarn/bun (yarn's own extensions ride the `.yarnrc.yml` config
+/// cascade, not this manifest map). This is the packageExtensions arm of the
+/// same "mirror the active PM, never silently" policy [`scope_overrides`]
+/// implements for override fields.
+///
+/// The returned map is the manifest's sole packageExtensions contribution, fed
+/// to the engine via `EngineContext::embedder_package_extensions`. The config
+/// cascade (`.npmrc` / `pnpm-workspace.yaml` / `.yarnrc.yml`) is layered on top
+/// by the engine and is unaffected — only the top-level manifest read leaks.
+pub(crate) fn scope_package_extensions(
+    role: Role,
+    manifest: &PackageJson,
+) -> (BTreeMap<String, serde_json::Value>, Option<IgnoredField>) {
+    let object = |v: &serde_json::Value| v.as_object().cloned();
+    let top_level = manifest.extra.get("packageExtensions").and_then(object);
+    let pnpm_ns = manifest
+        .extra
+        .get("pnpm")
+        .and_then(|p| p.get("packageExtensions"))
+        .and_then(object);
+
+    let mut effective: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    let keep = match role {
+        // nub identity: the top-level home is nub's neutral surface.
+        Role::Nub => top_level.as_ref(),
+        // pnpm compat: mirror pnpm — its branded home, never the top-level one.
+        Role::Pnpm => pnpm_ns.as_ref(),
+        // npm/yarn/bun: no manifest packageExtensions home to mirror.
+        Role::Npm | Role::Yarn | Role::Bun => None,
+    };
+    if let Some(obj) = keep {
+        for (k, v) in obj {
+            effective.insert(k.clone(), v.clone());
+        }
+    }
+
+    // Warn iff a top-level block was present under a role that drops it AND the
+    // drop actually changes the applied set — a portable repo mirroring the
+    // same extensions into the kept home (pnpm's branded field) stays silent,
+    // matching the "not annoying" guard in `scope_overrides`.
+    let ignored = match (role, &top_level) {
+        (Role::Nub, _) | (_, None) => None,
+        (_, Some(obj)) => obj
+            .iter()
+            .any(|(k, v)| effective.get(k) != Some(v))
+            .then(|| IgnoredField {
+                field: "packageExtensions",
+                fix: package_extensions_fix(role),
+            }),
+    };
+
+    (effective, ignored)
+}
+
+/// The fix clause for a dropped top-level `packageExtensions`, per active PM.
+fn package_extensions_fix(role: Role) -> String {
+    match role {
+        Role::Pnpm => "move it to `pnpm.packageExtensions`".to_string(),
+        Role::Yarn => "move it to `.yarnrc.yml` `packageExtensions`".to_string(),
+        // npm and bun have no package-extensions feature.
+        _ => "remove it, or switch the project to nub".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -472,5 +545,62 @@ mod tests {
         assert!(!honors_trusted_dependencies(Role::Npm));
         assert!(!honors_trusted_dependencies(Role::Yarn));
         assert!(!honors_trusted_dependencies(Role::Nub));
+    }
+
+    fn manifest(json: &str) -> PackageJson {
+        serde_json::from_str(json).expect("manifest parses")
+    }
+
+    #[test]
+    fn nub_identity_honors_top_level_package_extensions() {
+        let m = manifest(
+            r#"{"name":"t","packageExtensions":{"foo@*":{"dependencies":{"bar":"1.0.0"}}}}"#,
+        );
+        let (eff, ignored) = scope_package_extensions(Role::Nub, &m);
+        assert!(eff.contains_key("foo@*"), "nub honors the top-level home");
+        assert!(ignored.is_none(), "nothing dropped under nub identity");
+    }
+
+    #[test]
+    fn pnpm_role_drops_top_level_keeps_branded_and_warns() {
+        let m = manifest(
+            r#"{
+                "name":"t",
+                "packageExtensions":{"foo@*":{"dependencies":{"bar":"1.0.0"}}},
+                "pnpm":{"packageExtensions":{"baz@*":{"peerDependencies":{"qux":"2.0.0"}}}}
+            }"#,
+        );
+        let (eff, ignored) = scope_package_extensions(Role::Pnpm, &m);
+        assert!(eff.contains_key("baz@*"), "pnpm keeps its branded home");
+        assert!(!eff.contains_key("foo@*"), "pnpm drops the top-level home");
+        let f = ignored.expect("dropped top-level warns");
+        assert_eq!(f.field, "packageExtensions");
+        assert!(f.fix.contains("pnpm.packageExtensions"));
+    }
+
+    #[test]
+    fn npm_role_drops_top_level_with_warning() {
+        let m = manifest(
+            r#"{"name":"t","packageExtensions":{"foo@*":{"dependencies":{"bar":"1.0.0"}}}}"#,
+        );
+        let (eff, ignored) = scope_package_extensions(Role::Npm, &m);
+        assert!(eff.is_empty(), "npm has no packageExtensions home");
+        let f = ignored.expect("dropped top-level warns");
+        assert_eq!(f.field, "packageExtensions");
+        assert!(f.fix.contains("nub"), "npm fix suggests removing or nub");
+    }
+
+    #[test]
+    fn portable_repo_mirrored_extensions_stays_silent_under_pnpm() {
+        // The same extension declared in both top-level and pnpm.* for
+        // cross-PM portability: pnpm applies the branded copy, so dropping the
+        // top-level one changes nothing — no warning.
+        let ext = r#"{"foo@*":{"dependencies":{"bar":"1.0.0"}}}"#;
+        let m = manifest(&format!(
+            r#"{{"name":"t","packageExtensions":{ext},"pnpm":{{"packageExtensions":{ext}}}}}"#
+        ));
+        let (eff, ignored) = scope_package_extensions(Role::Pnpm, &m);
+        assert!(eff.contains_key("foo@*"));
+        assert!(ignored.is_none(), "mirrored extension drop stays silent");
     }
 }

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -967,14 +967,18 @@ fn apply_config_scope(
     // Scope the override sources to the role's dialect.
     let tagged = config_scope::gather_tagged_overrides(&manifest);
     let (effective, ignored) = config_scope::scope_overrides(role, major, minor, &tagged);
+    // Scope packageExtensions the same way: the top-level home is nub's neutral
+    // surface, honored only under nub identity and dropped under a compat role
+    // whose incumbent ignores it (see `scope_package_extensions`).
+    let (effective_pe, pe_ignored) = config_scope::scope_package_extensions(role, &manifest);
 
-    // Register the scoped source as the engine's sole override source, and
-    // the trusted-deps toggle (only bun honors `trustedDependencies`). Both
-    // are idempotent OnceLocks.
+    // Register the scoped sources as the engine's sole override / packageExtensions
+    // sources, and the trusted-deps toggle (only bun honors `trustedDependencies`).
     let trusted = config_scope::honors_trusted_dependencies(role);
     aube_util::update_engine_context(|c| {
         c.embedder_overrides = Some(effective);
         c.trusted_dependencies_honored = trusted;
+        c.embedder_package_extensions = Some(effective_pe);
     });
 
     if noise == ConfigScopeNoise::Warn {
@@ -986,6 +990,8 @@ fn apply_config_scope(
         {
             return Err(catalog_unsupported_error(role, &spec));
         }
+        let mut ignored = ignored;
+        ignored.extend(pe_ignored);
         emit_scope_warnings(role, &ignored);
 
         // Curated unsupported-config scan: FATAL-abort on the genuinely-hard
@@ -1672,6 +1678,13 @@ pub(crate) fn engine_brand_preflight() {
         // bool because that posture defaults `true` in standalone aube, which
         // would activate the feature there and break default-preservation.
         c.named_registries_enabled = read_branded_pnpm_config;
+        // nub treats packageExtensions as a checksummed, drift-enforced config
+        // like pnpm: it stamps `packageExtensionsChecksum` on its own generic
+        // lockfile (nub.lock) and re-resolves / frozen-fails on a mismatch.
+        // Unconditional (not surface-gated) — harmless under lockfile kinds that
+        // carry no checksum (npm/yarn/bun locks), where stored and computed both
+        // resolve to `None`. Standalone aube leaves the default `false`.
+        c.enforce_package_extensions_checksum = true;
     });
     match surface {
         ConfigSurface::NubIdentity(dir) => {

--- a/vendor/aube/crates/aube-lockfile/src/drift.rs
+++ b/vendor/aube/crates/aube-lockfile/src/drift.rs
@@ -445,6 +445,35 @@ impl LockfileGraph {
         DriftStatus::Fresh
     }
 
+    /// Compare the lockfile's recorded `packageExtensionsChecksum` against the
+    /// project's freshly-computed effective checksum. A mismatch means the
+    /// packageExtensions config changed since the lockfile was written — the
+    /// resolved graph is stale, since an extension adds/relaxes deps and can
+    /// alter resolution. Mirrors pnpm's `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`
+    /// `packageExtensionsChecksum` rule.
+    ///
+    /// `effective_checksum` is the caller-computed hash of the effective
+    /// packageExtensions (`None` when there are none). A stale
+    /// checksum carried over from a renamed pnpm-lock.yaml is validated here,
+    /// not trusted — a divergence re-resolves (or frozen-fails) and the write
+    /// path restamps the current value.
+    ///
+    /// Meaningful only for embedders that STAMP the checksum on every lockfile
+    /// kind they write (so the check reaches a fixpoint); the caller gates the
+    /// invocation on that embedder posture
+    /// (`EngineContext::enforce_package_extensions_checksum`), so standalone
+    /// aube — which stamps only pnpm-lock.yaml and never enforces — never
+    /// reaches it.
+    pub fn check_package_extensions_drift(&self, effective_checksum: Option<&str>) -> DriftStatus {
+        if self.package_extensions_checksum.as_deref() == effective_checksum {
+            DriftStatus::Fresh
+        } else {
+            DriftStatus::Stale {
+                reason: "packageExtensions changed since the lockfile was written".to_string(),
+            }
+        }
+    }
+
     /// Compare a single importer's `DirectDep` list against the corresponding
     /// `package.json`. Used by both [`check_drift`] and [`check_drift_workspace`].
     ///
@@ -1062,6 +1091,40 @@ mod drift_tests {
             graph.check_drift(&manifest, &BTreeMap::new(), &[], &BTreeMap::new()),
             DriftStatus::Fresh
         );
+    }
+
+    #[test]
+    fn package_extensions_drift_fires_on_checksum_mismatch() {
+        let mut graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
+        graph.package_extensions_checksum = Some("sha256-abc".to_string());
+
+        // Match → Fresh; both-absent → Fresh; any divergence → Stale.
+        assert_eq!(
+            graph.check_package_extensions_drift(Some("sha256-abc")),
+            DriftStatus::Fresh
+        );
+        assert!(matches!(
+            graph.check_package_extensions_drift(Some("sha256-xyz")),
+            DriftStatus::Stale { .. }
+        ));
+        // Extensions removed from the project (effective None) drifts a
+        // lockfile that still records a checksum.
+        assert!(matches!(
+            graph.check_package_extensions_drift(None),
+            DriftStatus::Stale { .. }
+        ));
+
+        // No checksum stored (a lockfile written before extensions existed):
+        // absent-vs-absent is Fresh, absent-vs-present drifts.
+        graph.package_extensions_checksum = None;
+        assert_eq!(
+            graph.check_package_extensions_drift(None),
+            DriftStatus::Fresh
+        );
+        assert!(matches!(
+            graph.check_package_extensions_drift(Some("sha256-abc")),
+            DriftStatus::Stale { .. }
+        ));
     }
 
     #[test]

--- a/vendor/aube/crates/aube-lockfile/src/io.rs
+++ b/vendor/aube/crates/aube-lockfile/src/io.rs
@@ -233,6 +233,20 @@ fn lockfile_write_is_noop(
     let Ok(existing) = parse_one(path, kind, manifest) else {
         return false;
     };
+    // Under an enforcing embedder (nub), a differing `packageExtensionsChecksum`
+    // is a real config change that must be persisted — fold it into the no-op
+    // decision, exactly like the patch fingerprints below. Without this the
+    // guard suppresses the very write that would record the checksum whenever
+    // the resolved graph is otherwise unchanged (the mainline case: an existing
+    // lockfile that already applied the same extensions, just never stamped the
+    // checksum), leaving `--frozen-lockfile` permanently mismatched with no
+    // install-based remedy. Standalone aube never stamps the generic lock
+    // (posture off), so this is inert for it.
+    if aube_util::engine_context().enforce_package_extensions_checksum
+        && graph.package_extensions_checksum != existing.package_extensions_checksum
+    {
+        return false;
+    }
     // `allow_build` doesn't affect the engine-agnostic identity hash
     // (the engine taint it would gate is computed with `engine: None`),
     // so a trivial policy is correct here.

--- a/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/no_churn_write_guard.rs
@@ -217,3 +217,45 @@ fn guard_rewrites_when_only_patch_config_is_added() {
         "an unchanged patched lockfile must stay a no-op (zero churn)"
     );
 }
+
+/// Regression (nubjs/nub#492): under an enforcing embedder, stamping
+/// `packageExtensionsChecksum` over an otherwise-identical package set must
+/// NOT be treated as a no-op. Without folding the checksum into the guard,
+/// the write that records it is suppressed whenever the resolved graph is
+/// unchanged — the mainline upgrade case for a project that already applied
+/// top-level packageExtensions — so the checksum never lands and a frozen
+/// install stays permanently mismatched with no install-based remedy.
+#[test]
+fn guard_rewrites_when_only_package_extensions_checksum_is_added() {
+    aube_util::set_embedder(&NO_CHURN_TOOL);
+    // The checksum fold is gated on the engine-context posture, not the
+    // embedder; set it, and restore it so sibling tests see the default.
+    aube_util::update_engine_context(|c| c.enforce_package_extensions_checksum = true);
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("package.json"), r#"{"name":"t"}"#).unwrap();
+    let manifest = PackageJson::default();
+
+    // An existing lockfile that already applied the extensions but predates
+    // checksum stamping (no `packageExtensionsChecksum`) hits disk first.
+    let graph = graph_with(vec![pkg("ms", "2.1.3", "sha512-AAA==")]);
+    let path = write_lockfile_as(dir.path(), &graph, &manifest, LockfileKind::Pnpm).unwrap();
+    let first = mtime(&path);
+
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    // Same package set, now carrying the stamped checksum: must rewrite.
+    let mut stamped = graph.clone();
+    stamped.package_extensions_checksum = Some("sha256-deadbeef".to_string());
+    write_lockfile_as(dir.path(), &stamped, &manifest, LockfileKind::Pnpm).unwrap();
+    aube_util::update_engine_context(|c| c.enforce_package_extensions_checksum = false);
+    assert!(
+        mtime(&path) > first,
+        "stamping packageExtensionsChecksum must rewrite the lockfile, not be skipped as a no-op"
+    );
+    let written = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        written.contains("packageExtensionsChecksum:"),
+        "rewritten lockfile must record the checksum:\n{written}"
+    );
+}

--- a/vendor/aube/crates/aube-manifest/src/lib.rs
+++ b/vendor/aube/crates/aube-manifest/src/lib.rs
@@ -878,6 +878,13 @@ impl PackageJson {
     /// `pnpm.packageExtensions`, `aube.packageExtensions`, top-level
     /// `packageExtensions` — later writes win for duplicate selectors.
     pub fn package_extensions(&self) -> BTreeMap<String, serde_json::Value> {
+        // Embedder seam: a host that scopes which packageExtensions home
+        // applies per active PM (e.g. honoring the top-level home only under
+        // its own identity) supplies the pre-scoped map; use it verbatim and
+        // skip the per-source walk below. Default `None` ⇒ upstream behavior.
+        if let Some(scoped) = aube_util::engine_context().embedder_package_extensions {
+            return scoped;
+        }
         let mut out = BTreeMap::new();
         for ns in self.pnpm_aube_objects() {
             if let Some(obj) = ns.get("packageExtensions").and_then(|v| v.as_object()) {

--- a/vendor/aube/crates/aube-manifest/tests/engine_context_seams.rs
+++ b/vendor/aube/crates/aube-manifest/tests/engine_context_seams.rs
@@ -25,17 +25,24 @@ fn embedder_overrides_and_trusted_deps_gates_route_through_engine_context() {
         r#"{
             "name": "t",
             "resolutions": { "lodash": "4.17.21" },
-            "pnpm": { "overrides": { "minimist": "1.2.8" } },
+            "pnpm": {
+                "overrides": { "minimist": "1.2.8" },
+                "packageExtensions": { "foo@*": { "dependencies": { "bar": "1.0.0" } } }
+            },
+            "packageExtensions": { "baz@*": { "peerDependencies": { "qux": "2.0.0" } } },
             "trustedDependencies": ["esbuild"]
         }"#,
     );
 
     // --- upstream-neutral default: both gates open ---
-    // overrides_map folds every source; trusted_dependencies honors the array.
+    // overrides_map folds every source; trusted_dependencies honors the array;
+    // package_extensions merges pnpm.* and top-level.
     let folded = pkg.overrides_map();
     assert_eq!(folded.get("lodash").map(String::as_str), Some("4.17.21"));
     assert_eq!(folded.get("minimist").map(String::as_str), Some("1.2.8"));
     assert_eq!(pkg.trusted_dependencies(), vec!["esbuild".to_string()]);
+    let pe = pkg.package_extensions();
+    assert!(pe.contains_key("foo@*") && pe.contains_key("baz@*"));
 
     // --- embedder_overrides: a scoped map replaces the fold verbatim ---
     let scoped: BTreeMap<String, String> = [("only-this".to_string(), "9.9.9".to_string())]
@@ -55,14 +62,33 @@ fn embedder_overrides_and_trusted_deps_gates_route_through_engine_context() {
         "a non-Bun incumbent suppresses trustedDependencies entirely"
     );
 
-    // --- restore the upstream-neutral context, confirm both gates reopen ---
+    // --- embedder_package_extensions: a scoped map replaces the walk verbatim ---
+    let scoped_pe: BTreeMap<String, serde_json::Value> = [(
+        "only-ext@*".to_string(),
+        serde_json::json!({ "dependencies": { "dep": "1.0.0" } }),
+    )]
+    .into_iter()
+    .collect();
+    update_engine_context(|c| c.embedder_package_extensions = Some(scoped_pe.clone()));
+    assert_eq!(
+        pkg.package_extensions(),
+        scoped_pe,
+        "a Some(map) packageExtensions source is returned verbatim, skipping the walk"
+    );
+
+    // --- restore the upstream-neutral context, confirm every gate reopens ---
     update_engine_context(|c| {
         c.embedder_overrides = None;
         c.trusted_dependencies_honored = true;
+        c.embedder_package_extensions = None;
     });
     assert!(
         pkg.overrides_map().contains_key("lodash"),
         "clearing embedder_overrides restores the manifest fold"
     );
     assert_eq!(pkg.trusted_dependencies(), vec!["esbuild".to_string()]);
+    assert!(
+        pkg.package_extensions().contains_key("baz@*"),
+        "clearing embedder_package_extensions restores the manifest walk"
+    );
 }

--- a/vendor/aube/crates/aube-util/src/engine_context.rs
+++ b/vendor/aube/crates/aube-util/src/engine_context.rs
@@ -310,6 +310,38 @@ pub struct EngineContext {
     /// sets this to the same value it computes for `read_branded_pnpm_config`
     /// (pnpm incumbent or fresh nub-as-pnpm-drop-in).
     pub named_registries_enabled: bool,
+
+    /// Replacement `packageExtensions` source. `Some(map)` makes the supplied
+    /// map the manifest's *sole* packageExtensions contribution —
+    /// `PackageJson::package_extensions` returns it verbatim instead of
+    /// walking the manifest's `pnpm.packageExtensions` / `aube.packageExtensions`
+    /// / top-level `packageExtensions` sources. `None` (default) leaves upstream
+    /// behavior untouched (walk every source).
+    ///
+    /// The embedder seam for tools that scope which packageExtensions home
+    /// applies per active PM — top-level `packageExtensions` is a nub-identity
+    /// neutral field (no PM reads it except through a branded home), so nub
+    /// honors it only under its own identity and drops it under an npm/pnpm/
+    /// yarn/bun compat role. Same shape and contract as [`embedder_overrides`].
+    ///
+    /// [`embedder_overrides`]: Self::embedder_overrides
+    pub embedder_package_extensions: Option<BTreeMap<String, serde_json::Value>>,
+
+    /// Whether the embedder treats `packageExtensions` as a checksummed,
+    /// drift-enforced config like pnpm does. `false` (default) preserves
+    /// upstream behavior: aube stamps `packageExtensionsChecksum` only onto
+    /// `pnpm-lock.yaml` (registry byte-parity with pnpm) and never validates
+    /// it, so a packageExtensions edit never re-resolves or frozen-fails.
+    ///
+    /// When `true` (nub), the embedder additionally (1) stamps the checksum
+    /// onto its own generic lockfile (the `Aube` kind = `nub.lock`, pnpm-v9
+    /// bytes) so the drift check reaches a fixpoint, and (2) treats a
+    /// stored-vs-computed checksum mismatch as lockfile drift — a normal
+    /// install re-resolves, a `--frozen-lockfile` install aborts — mirroring
+    /// pnpm's `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Harmless under lockfile
+    /// kinds that carry no checksum (npm/yarn/bun): stored and computed both
+    /// resolve to `None`, so the check is a no-op.
+    pub enforce_package_extensions_checksum: bool,
 }
 
 impl Default for EngineContext {
@@ -337,6 +369,8 @@ impl Default for EngineContext {
             lifecycle_user_agent_product: None,
             npm_save_prefix_on_bare_exact: false,
             named_registries_enabled: false,
+            embedder_package_extensions: None,
+            enforce_package_extensions_checksum: false,
         }
     }
 }
@@ -405,5 +439,7 @@ mod tests {
         assert_eq!(ctx.lifecycle_user_agent_product, None);
         assert!(!ctx.npm_save_prefix_on_bare_exact);
         assert!(!ctx.named_registries_enabled);
+        assert_eq!(ctx.embedder_package_extensions, None);
+        assert!(!ctx.enforce_package_extensions_checksum);
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -884,6 +884,21 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     let existing_for_resolver: Option<&aube_lockfile::LockfileGraph> =
         lockfile_pre_parse.as_ref().map(|(g, _)| g);
 
+    // The project's effective packageExtensions checksum, for the lockfile
+    // drift check. Computed only under an enforcing embedder (nub); standalone
+    // aube leaves it `None` and the drift check (gated on the same posture) is
+    // a no-op. Uses the same `effective_package_extensions` the stamp path
+    // does, so a fresh install and the drift check agree.
+    let effective_package_extensions_checksum =
+        if aube_util::engine_context().enforce_package_extensions_checksum {
+            aube_lockfile::pnpm::package_extensions_checksum(&settings::effective_package_extensions(
+                &manifest,
+                &settings_ctx,
+            ))
+        } else {
+            None
+        };
+
     // `--lockfile-only` short-circuit. Resolves (or reuses a fresh
     // lockfile), writes the new lockfile, and exits before any tarball
     // fetch / link / lifecycle work. Runs *before* the FrozenMode match
@@ -909,6 +924,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 workspace_catalogs: &workspace_catalogs,
                 is_workspace_project,
                 lockfile_pre_parse: lockfile_pre_parse.as_ref(),
+                effective_package_extensions_checksum: effective_package_extensions_checksum
+                    .clone(),
             })? {
                 Ok(_) => {}
                 Err(aube_lockfile::Error::NotFound(_)) => {
@@ -1105,6 +1122,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         workspace_catalogs: &workspace_catalogs,
         is_workspace_project,
         lockfile_pre_parse: lockfile_pre_parse.as_ref(),
+        effective_package_extensions_checksum,
     })?;
 
     // Deprecation messages from freshly-resolved packages. Only the

--- a/vendor/aube/crates/aube/src/commands/install/resolve.rs
+++ b/vendor/aube/crates/aube/src/commands/install/resolve.rs
@@ -164,6 +164,18 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
     // other drift — same rule as pnpm's lockfile-config mismatch.
     let (effective_patch_paths, effective_patch_hashes) =
         crate::patches::effective_patch_config(cwd)?;
+    // packageExtensions drift (nub-only): a packageExtensions edit re-generates
+    // the lockfile like patch/override drift. Computed only under the enforcing
+    // embedder (nub) so standalone aube's `--lockfile-only` path does no extra
+    // work; `package_extensions_drift` also gates on the same posture.
+    let effective_package_extensions_checksum =
+        if aube_util::engine_context().enforce_package_extensions_checksum {
+            aube_lockfile::pnpm::package_extensions_checksum(
+                &super::settings::effective_package_extensions(manifest, settings_ctx),
+            )
+        } else {
+            None
+        };
     let fresh = !force_resolve
         && matches!(
             parsed,
@@ -185,6 +197,13 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
                             k,
                             &effective_patch_paths,
                             &effective_patch_hashes
+                        ),
+                        DriftStatus::Fresh
+                    )
+                    && matches!(
+                        package_extensions_drift(
+                            g,
+                            effective_package_extensions_checksum.as_deref()
                         ),
                         DriftStatus::Fresh
                     )
@@ -395,6 +414,23 @@ pub(super) struct SelectLockfileInput<'a> {
     pub workspace_catalogs: &'a crate::commands::CatalogMap,
     pub is_workspace_project: bool,
     pub lockfile_pre_parse: Option<&'a (LockfileGraph, LockfileKind)>,
+    /// The project's freshly-computed effective `packageExtensions` checksum
+    /// (`None` when there are none, or when the embedder doesn't enforce it).
+    /// Compared against the lockfile's recorded value under an enforcing
+    /// embedder to catch a packageExtensions edit; see
+    /// [`package_extensions_drift`].
+    pub effective_package_extensions_checksum: Option<String>,
+}
+
+/// packageExtensions drift, gated on the embedder posture. Returns `Fresh`
+/// when the embedder doesn't enforce the checksum (standalone aube), so the
+/// check is a nub-only layer that never fires on aube's default path.
+fn package_extensions_drift(graph: &LockfileGraph, effective_checksum: Option<&str>) -> DriftStatus {
+    if aube_util::engine_context().enforce_package_extensions_checksum {
+        graph.check_package_extensions_drift(effective_checksum)
+    } else {
+        DriftStatus::Fresh
+    }
 }
 
 pub(super) fn select_lockfile_result(
@@ -412,6 +448,7 @@ pub(super) fn select_lockfile_result(
         workspace_catalogs,
         is_workspace_project,
         lockfile_pre_parse,
+        effective_package_extensions_checksum,
     } = input;
     if !lockfile_enabled {
         tracing::debug!("lockfile=false: skipping lockfile parse, re-resolving");
@@ -473,6 +510,19 @@ pub(super) fn select_lockfile_result(
                          help: run without --frozen-lockfile to update the lockfile"
                     ));
                 }
+                // Same hard-fail for packageExtensions drift (nub-only layer,
+                // gated on the enforcing embedder) — pnpm rejects this as
+                // ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+                if let DriftStatus::Stale { reason } = package_extensions_drift(
+                    graph,
+                    effective_package_extensions_checksum.as_deref(),
+                ) {
+                    return Err(miette!(
+                        code = aube_codes::errors::ERR_AUBE_OUTDATED_LOCKFILE,
+                        "lockfile is out of date with the project's packageExtensions configuration: {reason}\n\
+                         help: run without --frozen-lockfile to update the lockfile"
+                    ));
+                }
             }
             Ok(parsed)
         }
@@ -503,11 +553,17 @@ pub(super) fn select_lockfile_result(
                             is_workspace_project,
                             *kind,
                         ) {
-                            DriftStatus::Fresh => graph.check_patched_dependencies_drift(
+                            DriftStatus::Fresh => match graph.check_patched_dependencies_drift(
                                 *kind,
                                 &effective_patch_paths,
                                 &effective_patch_hashes,
-                            ),
+                            ) {
+                                DriftStatus::Fresh => package_extensions_drift(
+                                    graph,
+                                    effective_package_extensions_checksum.as_deref(),
+                                ),
+                                stale => stale,
+                            },
                             stale => stale,
                         };
                         match drift {

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -527,9 +527,16 @@ pub(crate) fn effective_supported_architectures(
 /// Stamp pnpm's `packageExtensionsChecksum` / `pnpmfileChecksum` onto
 /// `graph` so a written pnpm-lock.yaml matches what pnpm itself records,
 /// keeping config-drift detection in sync (a wrong/absent value makes
-/// pnpm re-resolve, or abort a frozen install). No-op for non-pnpm
-/// lockfiles: aube-lock.yaml shares the writer and must not grow
-/// pnpm-only fields.
+/// pnpm re-resolve, or abort a frozen install).
+///
+/// `packageExtensionsChecksum` is stamped on `pnpm-lock.yaml` always
+/// (registry byte-parity with pnpm) and on the embedder's own generic
+/// lockfile (the `Aube` kind, pnpm-v9 bytes) when the embedder enforces the
+/// checksum (`enforce_package_extensions_checksum` — nub) — so its own
+/// packageExtensions drift check reaches a fixpoint. Standalone aube leaves
+/// that posture off, so its aube-lock.yaml never grows the field (unchanged).
+/// `pnpmfileChecksum` stays pnpm-lock-only: the generic lockfile never
+/// carried it, and nub identity disables the default pnpmfile anyway.
 ///
 /// `local_pnpmfile` is the project-local pnpmfile that participates in
 /// the checksum — the caller resolves it via `crate::pnpmfile::detect`
@@ -543,12 +550,19 @@ pub(crate) async fn stamp_pnpm_config_checksums(
     ctx: &aube_settings::ResolveCtx<'_>,
     local_pnpmfile: Option<&std::path::Path>,
 ) {
-    if !matches!(write_kind, aube_lockfile::LockfileKind::Pnpm) {
+    let is_pnpm = matches!(write_kind, aube_lockfile::LockfileKind::Pnpm);
+    let stamp_package_extensions = is_pnpm
+        || (matches!(write_kind, aube_lockfile::LockfileKind::Aube)
+            && aube_util::engine_context().enforce_package_extensions_checksum);
+    if !stamp_package_extensions {
         return;
     }
     let package_extensions = effective_package_extensions(manifest, ctx);
     graph.package_extensions_checksum =
         aube_lockfile::pnpm::package_extensions_checksum(&package_extensions);
+    if !is_pnpm {
+        return;
+    }
 
     // Always reflect the *current* pnpmfile state: a missing, hook-less,
     // or unreadable pnpmfile must clear any checksum the graph carried
@@ -1454,10 +1468,15 @@ mod finalize_lockfile_graph_tests {
         );
     }
 
-    /// aube-lock.yaml must never grow pnpm-only checksum fields — the
-    /// stamp is a no-op when no pnpm lockfile is present.
+    /// The generic (`Aube`) lockfile grows `packageExtensionsChecksum` ONLY
+    /// when the embedder enforces the checksum (nub). Standalone aube leaves
+    /// the posture off, so its aube-lock.yaml never grows the pnpm-only field
+    /// — the byte-for-byte default. `pnpmfileChecksum` stays pnpm-lock-only
+    /// under either posture. Both branches run in one test fn (with a
+    /// save/restore of the process-global posture) so the enforce window can't
+    /// race the sibling pnpm-lock stamp tests.
     #[tokio::test]
-    async fn finalize_skips_checksums_on_aube_lock() {
+    async fn finalize_stamps_generic_lock_checksum_only_when_embedder_enforces() {
         let dir = tempfile::tempdir().unwrap();
         let cwd = dir.path();
         std::fs::write(
@@ -1471,15 +1490,33 @@ mod finalize_lockfile_graph_tests {
         )
         .unwrap();
 
+        // Default posture (standalone aube): no checksum on aube-lock.yaml.
         let mut graph = aube_lockfile::LockfileGraph::default();
         finalize_lockfile_graph(cwd, &mut graph, &manifest(), false, None)
             .await
             .unwrap();
         assert!(
             graph.package_extensions_checksum.is_none(),
-            "aube-lock.yaml must not grow pnpm-only checksum fields"
+            "standalone aube must not stamp packageExtensionsChecksum on aube-lock.yaml"
         );
         assert!(graph.pnpmfile_checksum.is_none());
+
+        // Enforcing embedder (nub): the generic lockfile grows the checksum,
+        // but never the pnpmfile checksum.
+        aube_util::update_engine_context(|c| c.enforce_package_extensions_checksum = true);
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        finalize_lockfile_graph(cwd, &mut graph, &manifest(), false, None)
+            .await
+            .unwrap();
+        aube_util::update_engine_context(|c| c.enforce_package_extensions_checksum = false);
+        assert!(
+            graph.package_extensions_checksum.is_some(),
+            "an enforcing embedder must stamp packageExtensionsChecksum on its generic lockfile"
+        );
+        assert!(
+            graph.pnpmfile_checksum.is_none(),
+            "pnpmfileChecksum stays pnpm-lock-only even under an enforcing embedder"
+        );
     }
 
     /// The pnpmfile half of the same regression: a local pnpmfile that


### PR DESCRIPTION
Two `packageExtensions` hardening gaps for #492, both confirmed against real pnpm. Both behaviors are gated on new `EngineContext` seams (default off / `None`), so standalone aube's behavior and its `aube-lock.yaml` bytes are unchanged.

**GAP A — drift went undetected under nub.** aube stamped pnpm's `packageExtensionsChecksum` only onto `pnpm-lock.yaml` and never read it back, so editing `packageExtensions` after a lock existed was a no-op — plain `nub install` and `--frozen-lockfile` both exited 0 on a stale graph, where real pnpm errors `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Now, under the `enforce_package_extensions_checksum` posture:

- the checksum is stamped onto the generic `nub.lock` too, not just `pnpm-lock.yaml`;
- `check_package_extensions_drift` compares stored vs freshly-computed checksum, wired into the frozen path (`ERR_NUB_OUTDATED_LOCKFILE`), the prefer path (re-resolve), and `--lockfile-only`;
- the no-churn write guard folds the checksum into its no-op decision, so the stamping write is never suppressed.

**GAP B — compat-role leak.** The engine read top-level `packageExtensions` unconditionally, applying it even under an npm/pnpm/yarn/bun incumbent that ignores a root `packageExtensions` — a lockfile-round-trip divergence against the mirror-the-active-PM policy. Now top-level `packageExtensions` is honored only under nub identity; under a compat role it is dropped with one dim warning (fix clause per PM), via the `embedder_package_extensions` seam that `PackageJson::package_extensions` consumes verbatim.

Migration note: an existing nub project that already applied top-level `packageExtensions` will have its first `--frozen-lockfile` fail once after upgrade (stored `None` vs a freshly-computed checksum); a normal `nub install` restamps it and the frozen install then passes — the intended pnpm-parity behavior.

Tests: drift-method and role-scoping unit tests, the engine-context seam test, the generic-lock stamp test, and a no-churn-guard regression (a checksum-only change must rewrite).

Refs #492
