### PR TITLE
linker: workspace-spanning hoisted planning for nodeLinker=hoisted

### DIFF
--- a/vendor/aube/crates/aube-linker/src/hoisted.rs
+++ b/vendor/aube/crates/aube-linker/src/hoisted.rs
@@ -72,17 +72,28 @@ impl HoistedPlacements {
         hoisting_limits: HoistingLimits,
     ) -> Result<Self, Error> {
         let mut placements = Self::default();
-        for (importer_path, deps) in &graph.importers {
-            if !crate::is_physical_importer(importer_path) {
-                continue;
-            }
-            let importer_dir = if importer_path == "." {
-                root_dir.to_path_buf()
+        let importer_nm = |importer_path: &str| -> PathBuf {
+            if importer_path == "." {
+                root_dir.join(modules_dir_name)
             } else {
-                root_dir.join(importer_path)
-            };
-            let nm = importer_dir.join(modules_dir_name);
-            let plan = plan_importer(&nm, deps, graph, hoisting_limits)?;
+                // Match the link path's lexical `..` collapse so a
+                // `../sibling` importer key recomputes the same on-disk dir.
+                aube_util::path::normalize_lexical(
+                    &root_dir.join(importer_path).join(modules_dir_name),
+                )
+            }
+        };
+        let physical: Vec<(&String, &Vec<DirectDep>)> = graph
+            .importers
+            .iter()
+            .filter(|(p, _)| crate::is_physical_importer(p))
+            .collect();
+
+        // Match the linker: the default (`None`) hoists a multi-importer
+        // workspace into ONE shared tree; every other case plans per
+        // importer. Recomputing with the wrong planner would return paths
+        // that don't exist on disk.
+        let record = |plan: &PlacementPlan, placements: &mut Self| {
             for node in &plan.nodes {
                 let (Some(dep_path), Some(pkg_dir)) = (&node.dep_path, &node.pkg_dir) else {
                     continue;
@@ -90,6 +101,27 @@ impl HoistedPlacements {
                 if pkg_dir.exists() {
                     placements.record(dep_path, pkg_dir.clone());
                 }
+            }
+        };
+        if matches!(hoisting_limits, HoistingLimits::None) && physical.len() > 1 {
+            let mut importers: Vec<(PathBuf, Vec<DirectDep>)> =
+                Vec::with_capacity(physical.len());
+            // Root first, so it becomes the arena root in `plan_workspace`.
+            if let Some((_, deps)) = physical.iter().find(|(p, _)| p.as_str() == ".") {
+                importers.push((importer_nm("."), (*deps).clone()));
+            }
+            for (path, deps) in &physical {
+                if path.as_str() != "." {
+                    importers.push((importer_nm(path), (*deps).clone()));
+                }
+            }
+            let plan = plan_workspace(&importers, graph)?;
+            record(&plan, &mut placements);
+        } else {
+            for (importer_path, deps) in physical {
+                let nm = importer_nm(importer_path);
+                let plan = plan_importer(&nm, deps, graph, hoisting_limits)?;
+                record(&plan, &mut placements);
             }
         }
         Ok(placements)
@@ -149,9 +181,18 @@ struct TreeNode {
 }
 
 /// Arena-backed placement tree.
+///
+/// A single plan can span a whole workspace: the arena root is the
+/// workspace-root `node_modules`, and each additional physical importer
+/// (a workspace member) is an *importer node* — a child of the root with
+/// its own physical `nm_dir` (`<member>/node_modules`) and no `pkg_dir`
+/// (it is an existing directory, never materialized). `importer_nodes`
+/// lists the root plus every member node; the materializer sweeps and
+/// tallies each importer's own `node_modules` from that list.
 pub(crate) struct PlacementPlan {
     nodes: Vec<TreeNode>,
     root_idx: usize,
+    importer_nodes: Vec<usize>,
 }
 
 struct PlaceOutcome {
@@ -171,7 +212,33 @@ impl PlacementPlan {
         Self {
             nodes: vec![root],
             root_idx: 0,
+            importer_nodes: vec![0],
         }
+    }
+
+    /// Add a workspace-member importer node whose `node_modules` is
+    /// `nm_dir`. The node hangs off the root so a member dep's ancestor
+    /// walk reaches root (and can hoist there), but it is deliberately
+    /// NOT inserted into `root.children`: it is not a package placement,
+    /// so it must not shadow a same-named package at root nor appear in
+    /// the root's stale-entry sweep set.
+    fn add_importer_node(&mut self, nm_dir: PathBuf) -> usize {
+        let idx = self.nodes.len();
+        self.nodes.push(TreeNode {
+            pkg_dir: None,
+            nm_dir,
+            parent: Some(self.root_idx),
+            children: BTreeMap::new(),
+            dep_path: None,
+        });
+        self.importer_nodes.push(idx);
+        idx
+    }
+
+    /// Package names placed directly in importer node `idx`'s
+    /// `node_modules/`. Drives the per-importer stale-entry sweep.
+    pub(crate) fn child_names_of(&self, idx: usize) -> impl Iterator<Item = &str> {
+        self.nodes[idx].children.keys().map(|s| s.as_str())
     }
 
     /// Place `(name, dep_path)` under the ancestor chain rooted at
@@ -277,10 +344,7 @@ impl PlacementPlan {
     /// Names placed directly in the importer root's `node_modules/`.
     /// Drives the stale-entry sweep in `link_hoisted_importer`.
     pub(crate) fn root_names(&self) -> impl Iterator<Item = &str> {
-        self.nodes[self.root_idx]
-            .children
-            .keys()
-            .map(|s| s.as_str())
+        self.child_names_of(self.root_idx)
     }
 }
 
@@ -309,8 +373,13 @@ fn is_ancestor_or_self(nodes: &[TreeNode], ancestor: usize, mut node: usize) -> 
 /// dep_path with the most consumer edges (direct deps weighted so they always
 /// own their name's slot; ties broken by dep_path for determinism).
 /// Single-version names are omitted — the plain BFS already hoists them right.
-fn preferred_root_versions(
-    root_deps: &[DirectDep],
+///
+/// `root_deps` is every seed edge competing for the root slot. For a
+/// single importer that is its direct deps; for a workspace-spanning
+/// plan it is the union of every importer's direct deps, so the argmax
+/// is taken over consumer edges across the whole workspace.
+fn preferred_root_versions<'a>(
+    root_deps: impl IntoIterator<Item = &'a DirectDep>,
     graph: &LockfileGraph,
 ) -> Vec<(String, String)> {
     // name -> dep_path -> consumer-edge count over the reachable graph.
@@ -381,6 +450,57 @@ fn preferred_root_versions(
         .collect()
 }
 
+/// Enqueue every registry-resolvable transitive edge of `pkg` for
+/// placement under `node_idx` with `child_floor`. `link:` packages own
+/// their own `node_modules` (Node resolves through the live target), so
+/// their edges are skipped rather than materialized into the tree.
+fn enqueue_transitives(
+    queue: &mut VecDeque<(usize, usize, String, String)>,
+    node_idx: usize,
+    child_floor: usize,
+    pkg: &LockedPackage,
+    graph: &LockfileGraph,
+) {
+    if matches!(pkg.local_source.as_ref(), Some(LocalSource::Link(_))) {
+        return;
+    }
+    for (dep_name, dep_tail) in &pkg.dependencies {
+        // 3-convention edge resolution: the yarn readers store the VALUE as
+        // the full dep_path (`is-plain-obj@4.1.0`), npm/pnpm the bare tail,
+        // git/tarball the resolved URL. A convention mismatch here silently
+        // drops the dep's whole subtree, so route through the shared resolver.
+        let Some(child_dep_path) =
+            aube_lockfile::resolve_dep_edge(dep_name, dep_tail, |k| graph.packages.contains_key(k))
+        else {
+            continue;
+        };
+        queue.push_back((node_idx, child_floor, dep_name.clone(), child_dep_path));
+    }
+}
+
+/// Seat the most-referenced version of every multi-version name at the
+/// plan root up front and enqueue its transitives, so the majority
+/// version wins the slot and only minority versions nest. Without this
+/// the BFS arrival-order winner can be a low-use version, exploding the
+/// widely-used one into dozens of nested copies (see
+/// `preferred_root_versions`). No-op when nothing conflicts. `seed_deps`
+/// is the same competing-edge set passed to `preferred_root_versions`.
+fn preplace_root_winners<'a>(
+    plan: &mut PlacementPlan,
+    queue: &mut VecDeque<(usize, usize, String, String)>,
+    seed_deps: impl IntoIterator<Item = &'a DirectDep>,
+    graph: &LockfileGraph,
+) {
+    let root_idx = plan.root_idx;
+    for (name, dep_path) in preferred_root_versions(seed_deps, graph) {
+        let node_idx = plan.preplace_root_child(&name, &dep_path);
+        let Some(pkg) = graph.packages.get(&dep_path) else {
+            continue;
+        };
+        enqueue_transitives(queue, node_idx, root_idx, pkg, graph);
+    }
+}
+
 /// Build a placement plan for a single importer.
 pub(crate) fn plan_importer(
     importer_nm: &Path,
@@ -391,37 +511,11 @@ pub(crate) fn plan_importer(
     let mut plan = PlacementPlan::new(importer_nm.to_path_buf());
     let mut queue: VecDeque<(usize, usize, String, String)> = VecDeque::new();
 
-    // Full-hoist deterministic root selection: seat the most-referenced
-    // version of every multi-version name at root up front and enqueue its
-    // transitives, so the majority version wins the slot and only minority
-    // versions nest. Without this the BFS arrival-order winner can be a
-    // low-use version, exploding the widely-used one into dozens of nested
-    // copies (see `preferred_root_versions`). No-op when nothing conflicts.
     if matches!(
         hoisting_limits,
         HoistingLimits::None | HoistingLimits::Workspaces
     ) {
-        for (name, dep_path) in preferred_root_versions(root_deps, graph) {
-            let node_idx = plan.preplace_root_child(&name, &dep_path);
-            let Some(pkg) = graph.packages.get(&dep_path) else {
-                continue;
-            };
-            if matches!(pkg.local_source.as_ref(), Some(LocalSource::Link(_))) {
-                continue;
-            }
-            for (dep_name, dep_tail) in &pkg.dependencies {
-                // 3-convention edge resolution — see the note in
-                // `preferred_root_versions`.
-                let Some(child_dep_path) =
-                    aube_lockfile::resolve_dep_edge(dep_name, dep_tail, |k| {
-                        graph.packages.contains_key(k)
-                    })
-                else {
-                    continue;
-                };
-                queue.push_back((node_idx, plan.root_idx, dep_name.clone(), child_dep_path));
-            }
-        }
+        preplace_root_winners(&mut plan, &mut queue, root_deps, graph);
     }
 
     // Seed the queue with the importer's direct deps in declaration
@@ -447,34 +541,77 @@ pub(crate) fn plan_importer(
         let Some(pkg) = graph.packages.get(&dep_path) else {
             continue;
         };
-        // Skip transitives for `link:` deps — their target directory
-        // holds its own node_modules and Node resolves through it
-        // naturally. Materializing a copy would fight with a live
-        // workspace package.
-        if matches!(pkg.local_source.as_ref(), Some(LocalSource::Link(_))) {
-            continue;
-        }
         let child_floor = match hoisting_limits {
             HoistingLimits::None | HoistingLimits::Workspaces => plan.root_idx,
             HoistingLimits::Dependencies => outcome.node_idx,
         };
-        for (dep_name, dep_tail) in &pkg.dependencies {
-            // 3-convention edge resolution — see the note in
-            // `preferred_root_versions`. Covers the yarn full-dep_path value,
-            // the pnpm tail, and the short-keyed git/remote-tarball form; a
-            // convention mismatch here silently drops the dep's whole subtree.
-            let Some(child_dep_path) = aube_lockfile::resolve_dep_edge(dep_name, dep_tail, |k| {
-                graph.packages.contains_key(k)
-            }) else {
+        enqueue_transitives(&mut queue, outcome.node_idx, child_floor, pkg, graph);
+    }
+
+    Ok(plan)
+}
+
+/// Build ONE placement plan spanning an entire workspace, matching real
+/// pnpm's `nodeLinker=hoisted` default (`hoistingLimits=none`): every
+/// importer's dependencies compete for a single shared tree rooted at the
+/// workspace-root `node_modules`, so a dependency shared across members
+/// materializes ONCE at the root and only version conflicts nest under
+/// the importer that needs them.
+///
+/// `importers` is `(node_modules_dir, direct_deps)` per physical
+/// importer, ROOT FIRST. The root becomes the arena root; each member
+/// becomes an importer node (see [`PlacementPlan::add_importer_node`])
+/// whose deps are seeded with `floor = root`, so they hoist to the root
+/// unless blocked by a nearer different-version placement. Deps that
+/// resolve to a workspace sibling are not in `graph.packages` and are
+/// skipped here — the caller symlinks them separately.
+pub(crate) fn plan_workspace(
+    importers: &[(PathBuf, Vec<DirectDep>)],
+    graph: &LockfileGraph,
+) -> Result<PlacementPlan, Error> {
+    let (root_nm, root_deps) = importers
+        .first()
+        .expect("plan_workspace requires at least the root importer");
+    let mut plan = PlacementPlan::new(root_nm.clone());
+    let mut queue: VecDeque<(usize, usize, String, String)> = VecDeque::new();
+
+    // (importer node index, its direct deps) — root plus every member.
+    let mut seeds: Vec<(usize, &[DirectDep])> = Vec::with_capacity(importers.len());
+    seeds.push((plan.root_idx, root_deps.as_slice()));
+    for (nm_dir, deps) in &importers[1..] {
+        let idx = plan.add_importer_node(nm_dir.clone());
+        seeds.push((idx, deps.as_slice()));
+    }
+
+    // Deterministic root winner over consumer edges across ALL importers,
+    // then seed each importer's direct deps under its own node with
+    // `floor = root` so shared deps hoist to the single shared root.
+    let all_seed_deps = seeds.iter().flat_map(|(_, deps)| deps.iter());
+    preplace_root_winners(&mut plan, &mut queue, all_seed_deps, graph);
+
+    for (importer_idx, deps) in &seeds {
+        for dep in *deps {
+            if !graph.packages.contains_key(&dep.dep_path) {
                 continue;
-            };
+            }
             queue.push_back((
-                outcome.node_idx,
-                child_floor,
-                dep_name.clone(),
-                child_dep_path,
+                *importer_idx,
+                plan.root_idx,
+                dep.name.clone(),
+                dep.dep_path.clone(),
             ));
         }
+    }
+
+    while let Some((requester, floor, name, dep_path)) = queue.pop_front() {
+        let outcome = plan.place(requester, floor, &name, &dep_path)?;
+        if !outcome.created {
+            continue;
+        }
+        let Some(pkg) = graph.packages.get(&dep_path) else {
+            continue;
+        };
+        enqueue_transitives(&mut queue, outcome.node_idx, plan.root_idx, pkg, graph);
     }
 
     Ok(plan)
@@ -661,22 +798,42 @@ pub(crate) fn link_hoisted_importer(
     stats: &mut LinkStats,
     placements: &mut HoistedPlacements,
 ) -> Result<(), Error> {
-    let root_dir = dirs.root;
-    let importer_dir = dirs.importer;
-    let nm = importer_dir.join(linker.modules_dir_name());
-    crate::mkdirp(&nm)?;
-
+    let nm = dirs.importer.join(linker.modules_dir_name());
     let plan = plan_importer(&nm, root_deps, graph, linker.hoisting_limits)?;
+    materialize_plan(linker, dirs.root, &plan, graph, package_indices, stats, placements)
+}
 
-    // Sweep any top-level entries that are no longer claimed by the
-    // plan. Dotfiles (`.aube`, `.bin`, …) are preserved — .aube in
-    // particular may hold a previous isolated tree that the user
-    // hasn't switched off; we leave it alone rather than wiping
-    // bytes the other layout owns.
-    let keep_root: std::collections::HashSet<&str> = plan.root_names().collect();
-    crate::sweep_stale_top_level_entries(&nm, &keep_root, None);
+/// Materialize a whole placement plan onto disk and record every placed
+/// package in `placements`. The plan may span multiple physical importer
+/// `node_modules` (a workspace-spanning `plan_workspace`) or a single one
+/// (`plan_importer`); either way each importer node's `node_modules` is
+/// created + swept of entries the plan no longer claims, then every
+/// placed package is materialized depth level by depth level.
+pub(crate) fn materialize_plan(
+    linker: &Linker,
+    root_dir: &Path,
+    plan: &PlacementPlan,
+    graph: &LockfileGraph,
+    package_indices: &BTreeMap<String, PackageIndex>,
+    stats: &mut LinkStats,
+    placements: &mut HoistedPlacements,
+) -> Result<(), Error> {
+    // Per importer: ensure its `node_modules` exists and sweep any
+    // top-level entries no longer claimed there. Dotfiles (`.aube`,
+    // `.bin`, …) are preserved — `.aube` in particular may hold a
+    // previous isolated tree; we leave it rather than wiping the other
+    // layout's bytes. A member dep that hoisted to the root is no longer
+    // claimed under the member, so this is exactly what converges an
+    // old per-importer tree (react duplicated under every member) onto
+    // the shared-root layout: the stale member copies are swept here.
+    for &imp_idx in &plan.importer_nodes {
+        let nm = plan.nodes[imp_idx].nm_dir.clone();
+        crate::mkdirp(&nm)?;
+        let keep: std::collections::HashSet<&str> = plan.child_names_of(imp_idx).collect();
+        crate::sweep_stale_top_level_entries(&nm, &keep, None);
+    }
 
-    // Materialize every non-root node, parallelized across packages.
+    // Materialize every placed node, parallelized across packages.
     //
     // Correctness hinges on ONE ordering rule: a package may ship a
     // bundled `node_modules/<dep>` inside its own tarball, and the real
@@ -687,12 +844,14 @@ pub(crate) fn link_hoisted_importer(
     // child a higher arena index than its parent, so `depth[idx]` folds
     // in a single forward pass, and within a level every node owns a
     // disjoint directory subtree (no two same-depth nodes are
-    // ancestor/descendant), so their fills never collide. The
-    // `collect()` after each level is the barrier between depths.
+    // ancestor/descendant, and importer nodes have disjoint `nm_dir`
+    // subtrees), so their fills never collide. The `collect()` after each
+    // level is the barrier between depths. Importer nodes (root + members)
+    // carry no `pkg_dir`, so they are skipped below and never materialized.
     //
-    // Placements are folded back in level-then-index order — identical
-    // to the old serial BFS order — so `package_dir()` still returns the
-    // shallowest site for a dep duplicated across nested `node_modules`.
+    // Placements are folded back in level-then-index order so
+    // `package_dir()` returns the shallowest site for a dep duplicated
+    // across nested `node_modules`.
     let mut depth = vec![0usize; plan.nodes.len()];
     let mut max_depth = 0usize;
     for idx in 0..plan.nodes.len() {
@@ -702,6 +861,9 @@ pub(crate) fn link_hoisted_importer(
         }
     }
 
+    // Fallback `nm` for the (unreachable) `link:` node whose `pkg_dir` has
+    // no parent; every real placement lives under an importer's tree.
+    let root_nm = plan.nodes[plan.root_idx].nm_dir.clone();
     let parallelism = linker.link_parallelism();
     for level in 1..=max_depth {
         // Serial prep: clone the (dep_path, pkg_dir) each node needs and
@@ -734,7 +896,7 @@ pub(crate) fn link_hoisted_importer(
                         pkg,
                         package_indices,
                         root_dir,
-                        &nm,
+                        &root_nm,
                     )
                 })
                 .collect()
@@ -750,7 +912,9 @@ pub(crate) fn link_hoisted_importer(
         }
     }
 
-    stats.top_level_linked += plan.nodes[plan.root_idx].children.len();
+    for &imp_idx in &plan.importer_nodes {
+        stats.top_level_linked += plan.nodes[imp_idx].children.len();
+    }
     Ok(())
 }
 

--- a/vendor/aube/crates/aube-linker/src/hoisted.rs
+++ b/vendor/aube/crates/aube-linker/src/hoisted.rs
@@ -72,27 +72,11 @@ impl HoistedPlacements {
         hoisting_limits: HoistingLimits,
     ) -> Result<Self, Error> {
         let mut placements = Self::default();
-        let importer_nm = |importer_path: &str| -> PathBuf {
-            if importer_path == "." {
-                root_dir.join(modules_dir_name)
-            } else {
-                // Match the link path's lexical `..` collapse so a
-                // `../sibling` importer key recomputes the same on-disk dir.
-                aube_util::path::normalize_lexical(
-                    &root_dir.join(importer_path).join(modules_dir_name),
-                )
-            }
-        };
-        let physical: Vec<(&String, &Vec<DirectDep>)> = graph
-            .importers
-            .iter()
-            .filter(|(p, _)| crate::is_physical_importer(p))
-            .collect();
+        // Same seeds the installer derives, so the recomputed paths match
+        // what `link_workspace_hoisted` put on disk (see
+        // `workspace_importer_seeds`).
+        let seeds = workspace_importer_seeds(root_dir, graph, modules_dir_name);
 
-        // Match the linker: the default (`None`) hoists a multi-importer
-        // workspace into ONE shared tree; every other case plans per
-        // importer. Recomputing with the wrong planner would return paths
-        // that don't exist on disk.
         let record = |plan: &PlacementPlan, placements: &mut Self| {
             for node in &plan.nodes {
                 let (Some(dep_path), Some(pkg_dir)) = (&node.dep_path, &node.pkg_dir) else {
@@ -103,24 +87,17 @@ impl HoistedPlacements {
                 }
             }
         };
-        if matches!(hoisting_limits, HoistingLimits::None) && physical.len() > 1 {
-            let mut importers: Vec<(PathBuf, Vec<DirectDep>)> =
-                Vec::with_capacity(physical.len());
-            // Root first, so it becomes the arena root in `plan_workspace`.
-            if let Some((_, deps)) = physical.iter().find(|(p, _)| p.as_str() == ".") {
-                importers.push((importer_nm("."), (*deps).clone()));
-            }
-            for (path, deps) in &physical {
-                if path.as_str() != "." {
-                    importers.push((importer_nm(path), (*deps).clone()));
-                }
-            }
-            let plan = plan_workspace(&importers, graph)?;
+
+        // Mirror the installer's dispatch: the default (`None`) hoists a
+        // multi-importer workspace into ONE shared tree; every other case
+        // plans per importer. Recomputing with the wrong planner would
+        // return paths that don't exist on disk.
+        if matches!(hoisting_limits, HoistingLimits::None) && seeds.len() > 1 {
+            let plan = plan_workspace(&seeds, graph)?;
             record(&plan, &mut placements);
         } else {
-            for (importer_path, deps) in physical {
-                let nm = importer_nm(importer_path);
-                let plan = plan_importer(&nm, deps, graph, hoisting_limits)?;
+            for (nm, deps) in &seeds {
+                let plan = plan_importer(nm, deps, graph, hoisting_limits)?;
                 record(&plan, &mut placements);
             }
         }
@@ -236,7 +213,8 @@ impl PlacementPlan {
     }
 
     /// Package names placed directly in importer node `idx`'s
-    /// `node_modules/`. Drives the per-importer stale-entry sweep.
+    /// `node_modules/`. Drives the per-importer stale-entry sweep in
+    /// `materialize_plan`.
     pub(crate) fn child_names_of(&self, idx: usize) -> impl Iterator<Item = &str> {
         self.nodes[idx].children.keys().map(|s| s.as_str())
     }
@@ -297,6 +275,18 @@ impl PlacementPlan {
         }
 
         let parent_nm = self.nodes[candidate].nm_dir.clone();
+        // Never displace an existing occupant of `candidate`'s slot: the
+        // placement walk stops at the shallowest ancestor NOT already
+        // hosting `name`, so `candidate.children[name]` must be vacant. A
+        // violation means a different version was pre-seated in a slot the
+        // requester also claims and can't nest below (the root importer's
+        // own direct dep vs a preplaced member version) — a correctness bug,
+        // not something to silently overwrite. `preferred_root_versions`
+        // prevents it by giving the root importer's direct deps priority.
+        debug_assert!(
+            !self.nodes[candidate].children.contains_key(name),
+            "place() would overwrite an occupied slot for {name} at node {candidate}"
+        );
         let pkg_dir = parent_nm.join(name);
         let nm_dir = pkg_dir.join("node_modules");
         let new_idx = self.nodes.len();
@@ -340,12 +330,6 @@ impl PlacementPlan {
             .insert(name.to_string(), new_idx);
         new_idx
     }
-
-    /// Names placed directly in the importer root's `node_modules/`.
-    /// Drives the stale-entry sweep in `link_hoisted_importer`.
-    pub(crate) fn root_names(&self) -> impl Iterator<Item = &str> {
-        self.child_names_of(self.root_idx)
-    }
 }
 
 fn is_ancestor_or_self(nodes: &[TreeNode], ancestor: usize, mut node: usize) -> bool {
@@ -374,12 +358,21 @@ fn is_ancestor_or_self(nodes: &[TreeNode], ancestor: usize, mut node: usize) -> 
 /// own their name's slot; ties broken by dep_path for determinism).
 /// Single-version names are omitted — the plain BFS already hoists them right.
 ///
-/// `root_deps` is every seed edge competing for the root slot. For a
-/// single importer that is its direct deps; for a workspace-spanning
-/// plan it is the union of every importer's direct deps, so the argmax
-/// is taken over consumer edges across the whole workspace.
+/// Two priority tiers of direct edge:
+/// - `root_direct` — the ROOT importer's own direct deps. The root package
+///   resolves these from the top-level `node_modules`, so its declared
+///   version MUST own the root slot; a member's differing version of the
+///   same name nests under the member (npm/pnpm/yarn-nm guarantee). These
+///   outrank everything.
+/// - `other_direct` — every non-root importer's direct deps. They own a
+///   name's root slot only when root does not itself declare that name; a
+///   plurality/lexical contest picks the winner among them.
+///
+/// For a single importer, all its direct deps are `root_direct` and
+/// `other_direct` is empty.
 fn preferred_root_versions<'a>(
-    root_deps: impl IntoIterator<Item = &'a DirectDep>,
+    root_direct: &[DirectDep],
+    other_direct: impl IntoIterator<Item = &'a DirectDep>,
     graph: &LockfileGraph,
 ) -> Vec<(String, String)> {
     // name -> dep_path -> consumer-edge count over the reachable graph.
@@ -387,22 +380,35 @@ fn preferred_root_versions<'a>(
     let mut seen: BTreeSet<String> = BTreeSet::new();
     let mut queue: VecDeque<String> = VecDeque::new();
 
-    // A direct dep must own the root slot for its name regardless of how many
-    // transitive consumers a rival version has — the importer resolves it from
-    // root. Weight direct edges so they always win the argmax.
+    // Weight tiers so the argmax respects priority: a ROOT direct edge beats
+    // any number of member direct edges, which beat any number of transitive
+    // consumers. `1<<60` dominates `member_count * (1<<40)` for any realistic
+    // workspace (>1e6 members before it could be caught), and neither tier
+    // can overflow u64 when summed.
+    const ROOT_DIRECT_WEIGHT: u64 = 1 << 60;
     const DIRECT_WEIGHT: u64 = 1 << 40;
-    for dep in root_deps {
+    let seed_direct = |dep: &DirectDep,
+                       weight: u64,
+                       counts: &mut BTreeMap<String, BTreeMap<String, u64>>,
+                       seen: &mut BTreeSet<String>,
+                       queue: &mut VecDeque<String>| {
         if !graph.packages.contains_key(&dep.dep_path) {
-            continue;
+            return;
         }
         *counts
             .entry(dep.name.clone())
             .or_default()
             .entry(dep.dep_path.clone())
-            .or_default() += DIRECT_WEIGHT;
+            .or_default() += weight;
         if seen.insert(dep.dep_path.clone()) {
             queue.push_back(dep.dep_path.clone());
         }
+    };
+    for dep in root_direct {
+        seed_direct(dep, ROOT_DIRECT_WEIGHT, &mut counts, &mut seen, &mut queue);
+    }
+    for dep in other_direct {
+        seed_direct(dep, DIRECT_WEIGHT, &mut counts, &mut seen, &mut queue);
     }
     while let Some(dep_path) = queue.pop_front() {
         let Some(pkg) = graph.packages.get(&dep_path) else {
@@ -483,16 +489,18 @@ fn enqueue_transitives(
 /// version wins the slot and only minority versions nest. Without this
 /// the BFS arrival-order winner can be a low-use version, exploding the
 /// widely-used one into dozens of nested copies (see
-/// `preferred_root_versions`). No-op when nothing conflicts. `seed_deps`
-/// is the same competing-edge set passed to `preferred_root_versions`.
+/// `preferred_root_versions`). No-op when nothing conflicts. `root_direct`
+/// and `other_direct` carry the two priority tiers documented on
+/// `preferred_root_versions`.
 fn preplace_root_winners<'a>(
     plan: &mut PlacementPlan,
     queue: &mut VecDeque<(usize, usize, String, String)>,
-    seed_deps: impl IntoIterator<Item = &'a DirectDep>,
+    root_direct: &[DirectDep],
+    other_direct: impl IntoIterator<Item = &'a DirectDep>,
     graph: &LockfileGraph,
 ) {
     let root_idx = plan.root_idx;
-    for (name, dep_path) in preferred_root_versions(seed_deps, graph) {
+    for (name, dep_path) in preferred_root_versions(root_direct, other_direct, graph) {
         let node_idx = plan.preplace_root_child(&name, &dep_path);
         let Some(pkg) = graph.packages.get(&dep_path) else {
             continue;
@@ -515,7 +523,8 @@ pub(crate) fn plan_importer(
         hoisting_limits,
         HoistingLimits::None | HoistingLimits::Workspaces
     ) {
-        preplace_root_winners(&mut plan, &mut queue, root_deps, graph);
+        // Single importer: all its direct deps own their own root slot.
+        preplace_root_winners(&mut plan, &mut queue, root_deps, std::iter::empty(), graph);
     }
 
     // Seed the queue with the importer's direct deps in declaration
@@ -583,23 +592,30 @@ pub(crate) fn plan_workspace(
         seeds.push((idx, deps.as_slice()));
     }
 
-    // Deterministic root winner over consumer edges across ALL importers,
-    // then seed each importer's direct deps under its own node with
+    // Deterministic root winner. The root importer's OWN direct deps own
+    // their root slot unconditionally (a member's differing version nests
+    // under the member); members' direct deps only win a name root doesn't
+    // declare. Then seed each importer's direct deps under its own node with
     // `floor = root` so shared deps hoist to the single shared root.
-    let all_seed_deps = seeds.iter().flat_map(|(_, deps)| deps.iter());
-    preplace_root_winners(&mut plan, &mut queue, all_seed_deps, graph);
+    let member_direct = seeds.iter().skip(1).flat_map(|(_, deps)| deps.iter());
+    preplace_root_winners(&mut plan, &mut queue, root_deps, member_direct, graph);
 
     for (importer_idx, deps) in &seeds {
         for dep in *deps {
-            if !graph.packages.contains_key(&dep.dep_path) {
+            let Some(pkg) = graph.packages.get(&dep.dep_path) else {
                 continue;
-            }
-            queue.push_back((
-                *importer_idx,
-                plan.root_idx,
-                dep.name.clone(),
-                dep.dep_path.clone(),
-            ));
+            };
+            // A `link:` workspace sibling stays in the requiring member's
+            // own `node_modules` (its target owns its deps; Node resolves
+            // through the live symlink), matching pnpm's hoistWorkspacePackages
+            // layout — do NOT hoist it to the shared root. A registry dep gets
+            // `floor = root` so it hoists workspace-wide.
+            let floor = if matches!(pkg.local_source.as_ref(), Some(LocalSource::Link(_))) {
+                *importer_idx
+            } else {
+                plan.root_idx
+            };
+            queue.push_back((*importer_idx, floor, dep.name.clone(), dep.dep_path.clone()));
         }
     }
 
@@ -615,6 +631,57 @@ pub(crate) fn plan_workspace(
     }
 
     Ok(plan)
+}
+
+/// Physical importers as `(node_modules_dir, direct_deps)` in the
+/// canonical order [`plan_workspace`] expects — ROOT first, then the
+/// remaining physical importers in `graph.importers` (BTreeMap) order.
+///
+/// Both the installer ([`link_hoisted_importer`]'s workspace caller) and
+/// the on-disk recompute ([`HoistedPlacements::from_graph`]) derive the
+/// workspace plan from THIS, so they agree on the tree deterministically.
+/// Deps are passed raw: the planners skip edges absent from
+/// `graph.packages` (workspace siblings, dev-stripped deps), so no
+/// pre-filter is needed here.
+pub(crate) fn workspace_importer_seeds(
+    root_dir: &Path,
+    graph: &LockfileGraph,
+    modules_dir_name: &str,
+) -> Vec<(PathBuf, Vec<DirectDep>)> {
+    let importer_nm = |importer_path: &str| -> PathBuf {
+        if importer_path == "." {
+            root_dir.join(modules_dir_name)
+        } else {
+            // Collapse `..` lexically so a parent-relative importer key
+            // (`../sibling`, when `pnpm-workspace.yaml#packages` uses
+            // `../**`) recomputes the same on-disk dir the linker writes.
+            aube_util::path::normalize_lexical(&root_dir.join(importer_path).join(modules_dir_name))
+        }
+    };
+    let physical: Vec<(&String, &Vec<DirectDep>)> = graph
+        .importers
+        .iter()
+        .filter(|(p, _)| crate::is_physical_importer(p))
+        .collect();
+    // The workspace root (`.`) must be an importer: `plan_workspace` treats
+    // the first seed as the arena root, so its absence would silently root
+    // the whole shared tree under a member's node_modules. The root package
+    // is always an importer in every install path today.
+    debug_assert!(
+        physical.iter().any(|(p, _)| p.as_str() == "."),
+        "workspace_importer_seeds: no '.' importer to anchor the shared tree"
+    );
+    let mut seeds: Vec<(PathBuf, Vec<DirectDep>)> = Vec::with_capacity(physical.len());
+    // Root first: it becomes the arena root in `plan_workspace`.
+    if let Some((_, deps)) = physical.iter().find(|(p, _)| p.as_str() == ".") {
+        seeds.push((importer_nm("."), (*deps).clone()));
+    }
+    for (path, deps) in &physical {
+        if path.as_str() != "." {
+            seeds.push((importer_nm(path), (*deps).clone()));
+        }
+    }
+    seeds
 }
 
 /// Materialize a planned tree onto disk for a single importer.
@@ -800,7 +867,15 @@ pub(crate) fn link_hoisted_importer(
 ) -> Result<(), Error> {
     let nm = dirs.importer.join(linker.modules_dir_name());
     let plan = plan_importer(&nm, root_deps, graph, linker.hoisting_limits)?;
-    materialize_plan(linker, dirs.root, &plan, graph, package_indices, stats, placements)
+    materialize_plan(
+        linker,
+        dirs.root,
+        &plan,
+        graph,
+        package_indices,
+        stats,
+        placements,
+    )
 }
 
 /// Materialize a whole placement plan onto disk and record every placed
@@ -969,6 +1044,262 @@ mod tests {
                 .collect(),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn workspace_shared_dep_hoists_to_root_once() {
+        // Two members both directly depend on is-odd@3.0.1. Real pnpm's
+        // hoisted default (`hoistingLimits=none`) hoists it ONCE to the
+        // workspace root; each member resolves it via Node's
+        // parent-directory walk. The old per-importer planner duplicated
+        // it under every member — issue #484: react duplicated across
+        // members → two React module identities → invalid-hook errors.
+        let root_nm = PathBuf::from("/ws/node_modules");
+        let a_nm = PathBuf::from("/ws/packages/a/node_modules");
+        let b_nm = PathBuf::from("/ws/packages/b/node_modules");
+        let mut graph = LockfileGraph::default();
+        graph
+            .packages
+            .insert("is-odd@3.0.1".into(), pkg("is-odd", "3.0.1", &[]));
+        let seeds = vec![
+            (root_nm.clone(), vec![]),
+            (a_nm.clone(), vec![dep("is-odd", "is-odd@3.0.1")]),
+            (b_nm, vec![dep("is-odd", "is-odd@3.0.1")]),
+        ];
+
+        let plan = plan_workspace(&seeds, &graph).unwrap();
+
+        assert_eq!(package_dir(&plan, "is-odd@3.0.1"), root_nm.join("is-odd"));
+        assert_eq!(
+            plan.nodes
+                .iter()
+                .filter(|n| n.dep_path.as_deref() == Some("is-odd@3.0.1"))
+                .count(),
+            1,
+            "a dep shared across members must materialize once at root, not per member"
+        );
+    }
+
+    #[test]
+    fn workspace_version_conflict_nests_under_requiring_member() {
+        // root + member a want left-pad@1.3.0; member b wants @1.1.3. The
+        // majority (1.3.0, two direct consumers) wins the shared root; the
+        // minority nests under member b only — matching pnpm, which keeps
+        // the shared version at root and nests the conflict.
+        let root_nm = PathBuf::from("/ws/node_modules");
+        let a_nm = PathBuf::from("/ws/packages/a/node_modules");
+        let b_nm = PathBuf::from("/ws/packages/b/node_modules");
+        let mut graph = LockfileGraph::default();
+        graph
+            .packages
+            .insert("left-pad@1.3.0".into(), pkg("left-pad", "1.3.0", &[]));
+        graph
+            .packages
+            .insert("left-pad@1.1.3".into(), pkg("left-pad", "1.1.3", &[]));
+        let seeds = vec![
+            (root_nm.clone(), vec![dep("left-pad", "left-pad@1.3.0")]),
+            (a_nm, vec![dep("left-pad", "left-pad@1.3.0")]),
+            (b_nm.clone(), vec![dep("left-pad", "left-pad@1.1.3")]),
+        ];
+
+        let plan = plan_workspace(&seeds, &graph).unwrap();
+
+        assert_eq!(
+            package_dir(&plan, "left-pad@1.3.0"),
+            root_nm.join("left-pad")
+        );
+        assert_eq!(
+            package_dir(&plan, "left-pad@1.1.3"),
+            b_nm.join("left-pad"),
+            "the conflicting minority version nests under the member that needs it"
+        );
+        assert_eq!(
+            plan.nodes
+                .iter()
+                .filter(|n| n.dep_path.as_deref() == Some("left-pad@1.3.0"))
+                .count(),
+            1,
+            "the shared majority version exists once, at root"
+        );
+    }
+
+    #[test]
+    fn workspace_shared_transitive_hoists_to_root() {
+        // member a → foo → shared; member b → bar → shared. `shared` is a
+        // transitive of two different members at a single version, so it
+        // hoists once to the shared root rather than duplicating under
+        // each member's own tree.
+        let root_nm = PathBuf::from("/ws/node_modules");
+        let a_nm = PathBuf::from("/ws/packages/a/node_modules");
+        let b_nm = PathBuf::from("/ws/packages/b/node_modules");
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            "foo@1.0.0".into(),
+            pkg("foo", "1.0.0", &[("shared", "1.0.0")]),
+        );
+        graph.packages.insert(
+            "bar@1.0.0".into(),
+            pkg("bar", "1.0.0", &[("shared", "1.0.0")]),
+        );
+        graph
+            .packages
+            .insert("shared@1.0.0".into(), pkg("shared", "1.0.0", &[]));
+        let seeds = vec![
+            (root_nm.clone(), vec![]),
+            (a_nm, vec![dep("foo", "foo@1.0.0")]),
+            (b_nm, vec![dep("bar", "bar@1.0.0")]),
+        ];
+
+        let plan = plan_workspace(&seeds, &graph).unwrap();
+
+        assert_eq!(package_dir(&plan, "foo@1.0.0"), root_nm.join("foo"));
+        assert_eq!(package_dir(&plan, "bar@1.0.0"), root_nm.join("bar"));
+        assert_eq!(package_dir(&plan, "shared@1.0.0"), root_nm.join("shared"));
+        assert_eq!(
+            plan.nodes
+                .iter()
+                .filter(|n| n.dep_path.as_deref() == Some("shared@1.0.0"))
+                .count(),
+            1,
+        );
+    }
+
+    #[test]
+    fn workspace_root_direct_dep_owns_root_slot_over_member_version() {
+        // The root importer directly depends on left@1.0.0; a member depends
+        // on left@2.0.0. The ROOT's declared version must own the shared root
+        // slot (the root package resolves `left` from there) and the member's
+        // version nests under the member. Regression guard: an earlier
+        // revision gave every direct edge equal weight, so a member's version
+        // could win the cross-importer contest (here 2.0.0 wins the lexical
+        // tiebreak) and displace root's — producing a SECOND node writing
+        // `root_nm/left`, i.e. a duplicate racing on one directory.
+        let root_nm = PathBuf::from("/ws/node_modules");
+        let a_nm = PathBuf::from("/ws/packages/a/node_modules");
+        let mut graph = LockfileGraph::default();
+        graph
+            .packages
+            .insert("left@1.0.0".into(), pkg("left", "1.0.0", &[]));
+        graph
+            .packages
+            .insert("left@2.0.0".into(), pkg("left", "2.0.0", &[]));
+        let seeds = vec![
+            (root_nm.clone(), vec![dep("left", "left@1.0.0")]),
+            (a_nm.clone(), vec![dep("left", "left@2.0.0")]),
+        ];
+
+        let plan = plan_workspace(&seeds, &graph).unwrap();
+
+        // Exactly one node writes root_nm/left, and it is the root's 1.0.0.
+        let root_left: Vec<&str> = plan
+            .nodes
+            .iter()
+            .filter(|n| n.pkg_dir == Some(root_nm.join("left")))
+            .filter_map(|n| n.dep_path.as_deref())
+            .collect();
+        assert_eq!(
+            root_left,
+            vec!["left@1.0.0"],
+            "root's declared version owns the root slot, with no duplicate node"
+        );
+        // The member's conflicting version nests under the member.
+        assert_eq!(package_dir(&plan, "left@2.0.0"), a_nm.join("left"));
+    }
+
+    #[test]
+    fn workspace_link_sibling_stays_member_local() {
+        // A `link:` workspace sibling must NOT hoist to the shared root: it
+        // is symlinked into the requiring member's own `node_modules` (its
+        // target owns its deps), matching pnpm's hoistWorkspacePackages
+        // layout. A registry dep of the same member still hoists to root.
+        // Regression guard: an earlier revision hoisted `link:` siblings to
+        // the workspace root, emptying the member's `node_modules` and
+        // diverging from pnpm (issue #484 super-calendar: @super-calendar/*
+        // landed at root instead of under packages/native).
+        let root_nm = PathBuf::from("/ws/node_modules");
+        let a_nm = PathBuf::from("/ws/packages/a/node_modules");
+        let mut graph = LockfileGraph::default();
+        let mut core = pkg("@scope/core", "0.0.0", &[]);
+        core.dep_path = "@scope/core@0.0.0".into();
+        core.local_source = Some(LocalSource::Link(PathBuf::from("packages/core")));
+        graph.packages.insert("@scope/core@0.0.0".into(), core);
+        graph
+            .packages
+            .insert("date-fns@4.0.0".into(), pkg("date-fns", "4.0.0", &[]));
+        let seeds = vec![
+            (root_nm.clone(), vec![]),
+            (
+                a_nm.clone(),
+                vec![
+                    dep("@scope/core", "@scope/core@0.0.0"),
+                    dep("date-fns", "date-fns@4.0.0"),
+                ],
+            ),
+        ];
+
+        let plan = plan_workspace(&seeds, &graph).unwrap();
+
+        // The link: sibling stays under the member; the registry dep hoists.
+        assert_eq!(
+            package_dir(&plan, "@scope/core@0.0.0"),
+            a_nm.join("@scope/core"),
+            "a link: sibling must stay in the requiring member's node_modules"
+        );
+        assert_eq!(
+            package_dir(&plan, "date-fns@4.0.0"),
+            root_nm.join("date-fns")
+        );
+        // Nothing named @scope/core at the workspace root.
+        assert!(
+            !plan.nodes.iter().any(|n| n.parent == Some(plan.root_idx)
+                && n.dep_path.as_deref() == Some("@scope/core@0.0.0")),
+            "the link: sibling must not be hoisted to the workspace root"
+        );
+    }
+
+    #[test]
+    fn from_graph_recomputes_workspace_spanning_hoist() {
+        // `from_graph` (rebuild/prune's on-disk recompute) must dispatch to
+        // the SAME workspace-spanning planner the installer uses under the
+        // `none` default, or it would look for a shared dep under a member
+        // where the installer never wrote it.
+        let root = tempfile::tempdir().unwrap();
+        let root_nm = root.path().join("node_modules");
+        let lodash_dir = root_nm.join("lodash");
+        std::fs::create_dir_all(&lodash_dir).unwrap();
+        // Member dirs exist but hold no lodash — it hoisted to the root.
+        std::fs::create_dir_all(root.path().join("packages/a/node_modules")).unwrap();
+        std::fs::create_dir_all(root.path().join("packages/b/node_modules")).unwrap();
+
+        let mut graph = LockfileGraph::default();
+        graph.importers.insert(".".into(), vec![]);
+        graph
+            .importers
+            .insert("packages/a".into(), vec![dep("lodash", "lodash@4.0.0")]);
+        graph
+            .importers
+            .insert("packages/b".into(), vec![dep("lodash", "lodash@4.0.0")]);
+        graph
+            .packages
+            .insert("lodash@4.0.0".into(), pkg("lodash", "4.0.0", &[]));
+
+        let placements = HoistedPlacements::from_graph(
+            root.path(),
+            &graph,
+            "node_modules",
+            HoistingLimits::None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            placements.package_dir("lodash@4.0.0"),
+            Some(lodash_dir.as_path())
+        );
+        assert_eq!(
+            placements.all_package_dirs("lodash@4.0.0").len(),
+            1,
+            "recompute must find the shared dep once, at the workspace root"
+        );
     }
 
     #[test]

--- a/vendor/aube/crates/aube-linker/src/lib.rs
+++ b/vendor/aube/crates/aube-linker/src/lib.rs
@@ -71,11 +71,15 @@ pub enum NodeLinker {
 /// Limit how far packages may be promoted in `NodeLinker::Hoisted`.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum HoistingLimits {
-    /// Hoist as far as possible.
+    /// Hoist as far as possible. In a workspace this hoists across every
+    /// member into the single shared workspace-root `node_modules`, so a
+    /// dependency at one version lives once at the root and only conflicts
+    /// nest (real pnpm's `nodeLinker=hoisted` default).
     #[default]
     None,
-    /// Aube plans hoisted installs per physical importer, so this is
-    /// currently equivalent to `None`.
+    /// Hoist only as far as each workspace package: every member's
+    /// `node_modules` is planned independently, bordered at the member
+    /// root, so transitives never promote across the workspace.
     Workspaces,
     /// Do not hoist transitives above the direct dependency that
     /// introduced them.

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -738,13 +738,21 @@ impl Linker {
         Ok(stats)
     }
 
-    /// Hoisted-mode workspace linker. Runs the per-importer
-    /// hoisted planner once per importer in the graph, accumulating
-    /// stats + placements into a single `LinkStats`. Each importer
-    /// gets its own independent flat tree (no shared root
-    /// virtual-store like the isolated layout), matching npm
-    /// workspaces and what hoisted-mode toolchains expect: a
-    /// self-contained `node_modules/` under every importer.
+    /// Hoisted-mode workspace linker.
+    ///
+    /// The default (`hoistingLimits=none`) plans ONE flat tree spanning the
+    /// whole workspace: every importer's deps compete for the shared
+    /// workspace-root `node_modules`, so a dependency at a single version
+    /// materializes ONCE at the root and only version conflicts nest under
+    /// the member that needs them — matching real pnpm's `nodeLinker=hoisted`
+    /// default (@yarnpkg/nm hoist over the whole project). `hoistingLimits`
+    /// of `workspaces` (border at each member) and `dependencies` (keep
+    /// transitives under their direct dep) instead plan each importer's
+    /// `node_modules` independently.
+    ///
+    /// Either way, sibling workspace packages resolve through symlinks (not
+    /// the placement tree), added in a post-pass gated on
+    /// `hoist_workspace_packages`.
     fn link_workspace_hoisted(
         &self,
         root_dir: &Path,
@@ -754,82 +762,104 @@ impl Linker {
     ) -> Result<LinkStats, Error> {
         let mut stats = LinkStats::default();
         let mut placements = HoistedPlacements::default();
-        for (importer_path, deps) in &graph.importers {
-            if !is_physical_importer(importer_path) {
-                continue;
-            }
-            let importer_dir = if importer_path == "." {
+
+        // `.` => root, else the member dir with `..` collapsed lexically —
+        // a parent-relative importer key (`../sibling`, from a `../**`
+        // workspace glob) must land at the real sibling dir.
+        let importer_dir = |importer_path: &str| -> PathBuf {
+            if importer_path == "." {
                 root_dir.to_path_buf()
             } else {
-                // Collapse `..` segments lexically — a parent-relative
-                // importer key (`../sibling`, possible when
-                // `pnpm-workspace.yaml#packages` uses `../**`) needs
-                // to land at the actual sibling dir before
-                // `pathdiff`/`strip_prefix` see it.
                 aube_util::path::normalize_lexical(&root_dir.join(importer_path))
-            };
-            // Workspace deps resolve through `workspace_dirs` rather
-            // than going through the placement tree, so the hoisted
-            // planner shouldn't try to copy their contents. Filter
-            // them out of the seed set — we'll symlink them in a
-            // post-pass below.
-            //
-            // Same gating as the isolated mode below: the resolver
-            // omits a `LockedPackage` for workspace-resolved siblings,
-            // so a name match plus a missing package entry is the
-            // signal that the resolver picked the sibling. When the
-            // resolved package IS in `graph.packages`, the resolver
-            // pinned a registry version and the dep should follow the
-            // normal hoisted-placement path (otherwise the post-pass
-            // would silently substitute the local copy).
-            let planner_deps: Vec<aube_lockfile::DirectDep> = deps
-                .iter()
-                .filter(|d| {
-                    !workspace_dirs.contains_key(&d.name)
-                        || graph.packages.contains_key(&d.dep_path)
-                })
-                .cloned()
-                .collect();
-            hoisted::link_hoisted_importer(
+            }
+        };
+        let physical: Vec<(&String, &Vec<aube_lockfile::DirectDep>)> = graph
+            .importers
+            .iter()
+            .filter(|(p, _)| is_physical_importer(p))
+            .collect();
+
+        if matches!(self.hoisting_limits, crate::HoistingLimits::None) && physical.len() > 1 {
+            // One shared tree for the whole workspace. `plan_workspace`
+            // skips workspace-sibling edges (absent from `graph.packages`)
+            // itself, so the raw seeds are safe; the symlink post-pass
+            // below wires those siblings in.
+            let seeds = hoisted::workspace_importer_seeds(root_dir, graph, &self.modules_dir_name);
+            let plan = hoisted::plan_workspace(&seeds, graph)?;
+            hoisted::materialize_plan(
                 self,
-                hoisted::HoistedImporterDirs {
-                    root: root_dir,
-                    importer: &importer_dir,
-                },
-                &planner_deps,
+                root_dir,
+                &plan,
                 graph,
                 package_indices,
                 &mut stats,
                 &mut placements,
             )?;
-
-            // Drop workspace deps in as symlinks, same as isolated mode.
-            let nm = importer_dir.join(&self.modules_dir_name);
-            if !self.hoist_workspace_packages {
-                continue;
-            }
-            for dep in deps {
-                crate::validate_package_link_name(&dep.name)?;
-                let Some(ws_dir) = workspace_dirs.get(&dep.name) else {
-                    continue;
-                };
-                // See planner_deps gating above: skip deps the
-                // resolver actually pinned to a registry version.
-                if graph.packages.contains_key(&dep.dep_path) {
-                    continue;
-                }
-                let link_path = nm.join(&dep.name);
-                if let Some(parent) = link_path.parent() {
-                    mkdirp(parent)?;
-                }
-                try_remove_entry(&link_path);
-                let link_parent = link_path.parent().unwrap_or(&nm);
-                let target = pathdiff::diff_paths(ws_dir, link_parent).unwrap_or(ws_dir.clone());
-                sys::create_dir_link(&target, &link_path)
-                    .map_err(|e| Error::Io(link_path.clone(), e))?;
-                stats.top_level_linked += 1;
+        } else {
+            // Per-importer independent trees (`workspaces` / `dependencies`
+            // limits, or a degenerate single-importer workspace).
+            for (importer_path, deps) in &physical {
+                let dir = importer_dir(importer_path);
+                // The resolver omits a `LockedPackage` for workspace-resolved
+                // siblings, so a name match plus a missing package entry means
+                // the sibling was picked — filter those out of the planner
+                // seed (the post-pass symlinks them). A dep whose resolved
+                // package IS in `graph.packages` was pinned to a registry
+                // version and stays on the placement path.
+                let planner_deps: Vec<aube_lockfile::DirectDep> = deps
+                    .iter()
+                    .filter(|d| {
+                        !workspace_dirs.contains_key(&d.name)
+                            || graph.packages.contains_key(&d.dep_path)
+                    })
+                    .cloned()
+                    .collect();
+                hoisted::link_hoisted_importer(
+                    self,
+                    hoisted::HoistedImporterDirs {
+                        root: root_dir,
+                        importer: &dir,
+                    },
+                    &planner_deps,
+                    graph,
+                    package_indices,
+                    &mut stats,
+                    &mut placements,
+                )?;
             }
         }
+
+        // Sibling workspace packages resolve through symlinks, independent
+        // of the placement tree. Runs for both dispatch branches. The
+        // materialize sweep above may have removed a prior install's
+        // symlink (it is not a plan child); re-adding it here converges.
+        if self.hoist_workspace_packages {
+            for (importer_path, deps) in &physical {
+                let nm = importer_dir(importer_path).join(&self.modules_dir_name);
+                for dep in *deps {
+                    crate::validate_package_link_name(&dep.name)?;
+                    let Some(ws_dir) = workspace_dirs.get(&dep.name) else {
+                        continue;
+                    };
+                    // Skip deps the resolver pinned to a registry version.
+                    if graph.packages.contains_key(&dep.dep_path) {
+                        continue;
+                    }
+                    let link_path = nm.join(&dep.name);
+                    if let Some(parent) = link_path.parent() {
+                        mkdirp(parent)?;
+                    }
+                    try_remove_entry(&link_path);
+                    let link_parent = link_path.parent().unwrap_or(&nm);
+                    let target =
+                        pathdiff::diff_paths(ws_dir, link_parent).unwrap_or(ws_dir.clone());
+                    sys::create_dir_link(&target, &link_path)
+                        .map_err(|e| Error::Io(link_path.clone(), e))?;
+                    stats.top_level_linked += 1;
+                }
+            }
+        }
+
         // Same rationale as the non-workspace hoisted path: sweep any
         // `.aube/node_modules/` left behind by a prior isolated
         // install so hoisted's dotfile-preserving cleanup doesn't

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -1141,6 +1141,109 @@ fn test_hoisted_duplicates_same_dep_path_at_multiple_sites() {
 }
 
 #[test]
+fn test_hoisted_workspace_shares_dep_at_root_and_nests_conflict() {
+    // Issue #484: under `nodeLinker=hoisted` a workspace must plan ONE
+    // shared tree, not a full closure per member. Two members share
+    // `shared@1.0.0` (materializes ONCE at the workspace root, never under a
+    // member) while `left` conflicts (root+a want 1.0.0 → root; b wants
+    // 2.0.0 → nests under b). The pre-fix per-importer planner duplicated
+    // the shared dep under every member — two module identities → the
+    // reporter's invalid React hooks.
+    let dir = tempfile::tempdir().unwrap();
+    let root_dir = dir.path().join("ws");
+    for member in ["packages/a", "packages/b"] {
+        std::fs::create_dir_all(root_dir.join(member)).unwrap();
+    }
+
+    let store = Store::at(dir.path().join("store/files"));
+    let mut indices = BTreeMap::new();
+    for (dp, pj, body) in [
+        (
+            "shared@1.0.0",
+            "{\"name\":\"shared\",\"version\":\"1.0.0\"}",
+            "module.exports='shared@1';",
+        ),
+        (
+            "left@1.0.0",
+            "{\"name\":\"left\",\"version\":\"1.0.0\"}",
+            "module.exports='left@1';",
+        ),
+        (
+            "left@2.0.0",
+            "{\"name\":\"left\",\"version\":\"2.0.0\"}",
+            "module.exports='left@2';",
+        ),
+    ] {
+        indices.insert(dp.to_string(), package_index(&store, pj, body));
+    }
+
+    let pkg = |name: &str, version: &str| LockedPackage {
+        name: name.to_string(),
+        version: version.to_string(),
+        dep_path: format!("{name}@{version}"),
+        ..Default::default()
+    };
+    let mut packages = BTreeMap::new();
+    for dp in ["shared@1.0.0", "left@1.0.0", "left@2.0.0"] {
+        let (name, version) = dp.split_once('@').unwrap();
+        packages.insert(dp.to_string(), pkg(name, version));
+    }
+
+    let dep = |name: &str, dep_path: &str| DirectDep {
+        name: name.to_string(),
+        dep_path: dep_path.to_string(),
+        dep_type: DepType::Production,
+        specifier: None,
+    };
+    let mut importers = BTreeMap::new();
+    importers.insert(".".to_string(), vec![dep("left", "left@1.0.0")]);
+    importers.insert(
+        "packages/a".to_string(),
+        vec![dep("shared", "shared@1.0.0"), dep("left", "left@1.0.0")],
+    );
+    importers.insert(
+        "packages/b".to_string(),
+        vec![dep("shared", "shared@1.0.0"), dep("left", "left@2.0.0")],
+    );
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+
+    let linker = Linker::new(&store, LinkStrategy::Copy).with_node_linker(NodeLinker::Hoisted);
+    linker
+        .link_workspace(&root_dir, &graph, &indices, &BTreeMap::new())
+        .unwrap();
+
+    let root_nm = root_dir.join("node_modules");
+    let a_nm = root_dir.join("packages/a/node_modules");
+    let b_nm = root_dir.join("packages/b/node_modules");
+    // The shared single-version dep is hoisted once, to the workspace root.
+    assert_eq!(
+        std::fs::read_to_string(root_nm.join("shared/index.js")).unwrap(),
+        "module.exports='shared@1';"
+    );
+    assert!(
+        !a_nm.join("shared").exists() && !b_nm.join("shared").exists(),
+        "the shared dep must NOT be duplicated under any member"
+    );
+    // The conflict: majority left@1 at root, minority left@2 nested under b.
+    assert_eq!(
+        std::fs::read_to_string(root_nm.join("left/index.js")).unwrap(),
+        "module.exports='left@1';"
+    );
+    assert_eq!(
+        std::fs::read_to_string(b_nm.join("left/index.js")).unwrap(),
+        "module.exports='left@2';"
+    );
+    assert!(
+        !a_nm.join("left").exists(),
+        "member a's left hoisted to root — no member-local copy"
+    );
+}
+
+#[test]
 fn test_global_virtual_store_is_populated() {
     let dir = tempfile::tempdir().unwrap();
     let project_dir = dir.path().join("project");

--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -729,10 +729,12 @@ Controls how far packages can be promoted when `nodeLinker=hoisted` is
 active, mirroring Yarn's `nmHoistingLimits` and pnpm's
 `hoistingLimits` setting:
 
-- `none`: hoist as far as possible (default).
-- `workspaces`: hoist only as far as each workspace package. Aube plans
-  hoisted installs per physical importer, so this currently matches
-  `none`.
+- `none`: hoist as far as possible (default). In a workspace this hoists
+  across every member into the single shared root `node_modules`, so a
+  dependency at one version is stored once and only conflicts nest.
+- `workspaces`: hoist only as far as each workspace package. Every
+  member's `node_modules` is planned independently and bordered at the
+  member root, so transitives never promote across the workspace.
 - `dependencies`: hoist only up to each workspace package's direct
   dependencies. Transitive packages stay under the direct dependency
   that introduced them instead of being promoted to the importer root.

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -1078,7 +1078,22 @@ impl InstallLayoutState {
             };
             let entries = deps
                 .iter()
-                .map(|dep| relative_path_or_original(&modules_base.join(&dep.name), project_dir))
+                .map(|dep| {
+                    // In hoisted mode a member's direct dep may have hoisted
+                    // out of `<importer>/node_modules/<name>` to the shared
+                    // workspace root (or nested under a different member), so
+                    // verify it at its ACTUAL placement — otherwise the
+                    // warm-path check reports it permanently "missing" and
+                    // re-installs on every run. `placements` is `Some` only
+                    // for hoisted; a `link:` sibling created by the post-pass
+                    // (absent from `placements`) and every isolated-mode dep
+                    // fall back to the `<importer>/node_modules/<name>` path.
+                    let path = placements
+                        .and_then(|p| p.package_dir(&dep.dep_path))
+                        .map(|p| p.to_path_buf())
+                        .unwrap_or_else(|| modules_base.join(&dep.name));
+                    relative_path_or_original(&path, project_dir)
+                })
                 .collect();
             direct_entries.insert(importer.clone(), entries);
         }
@@ -1311,6 +1326,17 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     hasher.update(b"hoisting_limits=");
     hasher.update(format!("{hoisting_limits:?}").as_bytes());
     hasher.update(b"\0");
+    // Hoisted-layout algorithm version. A multi-importer workspace under
+    // `nodeLinker=hoisted` now plans ONE shared tree (hoist to the
+    // workspace root) instead of a full per-importer closure. The graph
+    // hash is otherwise identical across the change, so without this a
+    // tree materialized by the old per-importer algorithm would be treated
+    // as current and never relinked. Bump on any future hoisted-layout
+    // change. Gated on the hoisted linker so isolated installs are
+    // unaffected.
+    if matches!(node_linker, aube_settings::resolved::NodeLinker::Hoisted) {
+        hasher.update(b"hoisted_layout_algo=2\0");
+    }
     let dedupe_direct_deps = aube_settings::resolved::dedupe_direct_deps(&ctx);
     hasher.update(format!("dedupe_direct_deps={dedupe_direct_deps}\0").as_bytes());
     let symlink = aube_settings::resolved::symlink(&ctx);
@@ -1664,6 +1690,79 @@ mod tests {
             layout.direct_entries.get("packages/svc"),
             Some(&vec!["packages/svc/node_modules/zod".to_string()])
         );
+    }
+
+    #[test]
+    fn from_graph_tracks_hoisted_member_dep_at_its_shared_root_location() {
+        // Regression guard (issue #484 follow-up): under nodeLinker=hoisted a
+        // member's direct dep hoists to the shared workspace-root
+        // node_modules, so its warm-path entry must point THERE, not at the
+        // (now empty) <member>/node_modules/<dep>. Tracking the assumed
+        // member path would make verify_install_layout report it missing on
+        // every warm install and re-link forever.
+        let project_dir = temp_project_dir("layout-hoisted-shared");
+        let root_nm = project_dir.join("node_modules");
+        std::fs::create_dir_all(root_nm.join("react")).unwrap();
+        std::fs::write(
+            root_nm.join("react/package.json"),
+            "{\"name\":\"react\",\"version\":\"19.2.7\"}",
+        )
+        .unwrap();
+        std::fs::create_dir_all(project_dir.join("packages/app/node_modules")).unwrap();
+
+        let dep = |name: &str, dep_path: &str| aube_lockfile::DirectDep {
+            name: name.to_string(),
+            dep_path: dep_path.to_string(),
+            dep_type: aube_lockfile::DepType::Production,
+            specifier: None,
+        };
+        let mut importers = BTreeMap::new();
+        importers.insert(".".to_string(), vec![]);
+        importers.insert(
+            "packages/app".to_string(),
+            vec![dep("react", "react@19.2.7")],
+        );
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "react@19.2.7".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "react".to_string(),
+                version: "19.2.7".to_string(),
+                dep_path: "react@19.2.7".to_string(),
+                ..Default::default()
+            },
+        );
+        let graph = aube_lockfile::LockfileGraph {
+            importers,
+            packages,
+            ..Default::default()
+        };
+
+        let placements = aube_linker::HoistedPlacements::from_graph(
+            &project_dir,
+            &graph,
+            "node_modules",
+            aube_linker::HoistingLimits::None,
+        )
+        .unwrap();
+
+        let layout = InstallLayoutState::from_graph(
+            &project_dir,
+            &graph,
+            aube_linker::NodeLinker::Hoisted,
+            "node_modules",
+            &root_nm.join(".aube"),
+            120,
+            Some(&placements),
+        );
+
+        // The member's react is tracked at the SHARED ROOT, where it hoisted.
+        assert_eq!(
+            layout.direct_entries.get("packages/app"),
+            Some(&vec!["node_modules/react".to_string()])
+        );
+        // And the warm-path check passes: the root react dir exists.
+        assert!(verify_install_layout(&project_dir, Some(&layout)).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Under `nodeLinker=hoisted` with the default `hoistingLimits=none`, the hoisted linker planned placement per physical importer: every workspace member materialized its full transitive closure under its own `node_modules`, so a dependency shared across members (e.g. `react`) was duplicated on disk. Two copies of `react` meant two module identities and the reporter's invalid-hook errors.

Real pnpm's hoisted default runs one hoist over the whole workspace: a dependency at a single version lives once at the workspace-root `node_modules`, and only version conflicts nest under the requiring member. This change makes nub match that.

- `hoistingLimits=none` (default) plans one workspace-spanning tree; a shared dep hoists to the root once, conflicts nest under the member.
- `hoistingLimits=workspaces` now genuinely borders at each member (per-importer trees); `dependencies` is unchanged; single-package projects are unchanged.
- `link:` workspace siblings stay member-local (pnpm's `hoistWorkspacePackages` layout), not hoisted to the root.
- The install-state hash folds a hoisted-layout marker so a tree written by the old per-importer algorithm is relinked rather than treated as current.

This is a latent-bug fix: aube's hoisted mode documents npm/yarn-classic flat-tree parity, npm hoists workspace-wide to the root, and aube's own docs marked the per-importer behavior "currently equivalent to None."

## Verification

Differential against pnpm 11 on the reporter's repo (super-calendar @ 43e0d0b~1):

| metric | before | after | pnpm 11 |
|---|---|---|---|
| physical `react@19.2.7` copies | 7 | 1 | 1 |
| `packages/native/node_modules` entries | 253 | 1 | 1 |
| `require.resolve('react')` root vs native | different | same dir | same dir |

A minimal two-member workspace (shared dep + one conflicting version) matches pnpm on entry counts, physical copy count, and resolve identity from root and each member. Single-package hoisted installs are unchanged.

Tests: workspace-spanning unit cases in `hoisted.rs` (shared hoists to root once; conflict nests under the member; `link:` sibling stays member-local; `from_graph` recompute) plus an on-disk `link_workspace` materialization test in `tests.rs`.

Closes #484

https://claude.ai/code/session_01EDXu8722BkCGvBYYu549sn
