### PR TITLE
chore: remove dead code and tighten visibility via cargo-hawk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ __pycache__/
 # /target/ above (via crates/nub-native/.cargo/config.toml), but guard against a
 # stray local target/ if it's ever built without that routing.
 /crates/nub-native/target/
+# nub-phantom is its own Cargo workspace too (eval tool, built on demand); its
+# default target/ lands in-tree.
+/crates/nub-phantom/target/
 /dist/
 /build/
 /coverage/

--- a/crates/nub-core/src/node/discovery.rs
+++ b/crates/nub-core/src/node/discovery.rs
@@ -456,7 +456,7 @@ pub fn check_min_version(node: &ResolvedNode) -> Result<(), DiscoveryError> {
 /// conflict.) Precedence #1, `package.json#devEngines.runtime`, sits ABOVE all
 /// three and #5, `package.json#engines.node`, BELOW them — [`resolve_pin_chain`]
 /// orders all five; this helper is only the pin-file middle of the chain.
-pub fn walk_up_for_pin(cwd: &Path) -> Option<(String, VersionPin, String)> {
+fn walk_up_for_pin(cwd: &Path) -> Option<(String, VersionPin, String)> {
     let home = dirs_next::home_dir();
     let mut dir = cwd.to_path_buf();
     let max_depth = 16;
@@ -714,7 +714,7 @@ pub struct PinChain {
     /// `onFail: "warn"`, present-but-unusable version specs) — printed once per
     /// invocation by the entry point ([`discover_node`], or the `nub node`
     /// verbs when they resolve the chain themselves).
-    pub warnings: Vec<String>,
+    pub(crate) warnings: Vec<String>,
 }
 
 /// The pin-source chain in spec precedence order

--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -7,7 +7,7 @@
 //! this table (it iterates [`FEATURES`]); the webstorage gating predicates are
 //! derived from it too. There is no second copy of the bands to drift against.
 //!
-//! ## The three mitigation shapes
+//! ## The mitigation shapes
 //!
 //! A feature reaches the user through exactly one of these per Node version:
 //!
@@ -27,8 +27,10 @@
 //!   intent + the floor; it does **not** version-gate the polyfill in Rust (the
 //!   polyfill bows out on its own when the global is already present). A unit
 //!   test asserts each named file exists and contains the named feature-detect.
-//! - **`Absent`** — below the feature's floor nub does nothing and the feature is
-//!   simply unavailable (the honest compat-tier outcome).
+//!
+//! Below a feature's floor no band matches (`mitigation_for` returns `None`):
+//! nub does nothing and the feature is simply unavailable (the honest
+//! compat-tier outcome).
 //!
 //! ## Why this is THE place
 //!
@@ -64,17 +66,17 @@ use super::version::NodeVersion;
 /// iff `lo <= v && (hi.is_none() || v < hi)`.
 #[derive(Clone)]
 pub struct VersionBand {
-    pub lo: NodeVersion,
-    pub hi: Option<NodeVersion>,
+    lo: NodeVersion,
+    hi: Option<NodeVersion>,
 }
 
 impl VersionBand {
-    pub const fn new(lo: NodeVersion, hi: Option<NodeVersion>) -> Self {
+    const fn new(lo: NodeVersion, hi: Option<NodeVersion>) -> Self {
         Self { lo, hi }
     }
 
     /// Whether `v` falls in this `[lo, hi)` band.
-    pub fn contains(&self, v: &NodeVersion) -> bool {
+    fn contains(&self, v: &NodeVersion) -> bool {
         *v >= self.lo && self.hi.as_ref().is_none_or(|hi| v < hi)
     }
 }
@@ -97,24 +99,26 @@ pub enum Mitigation {
         runtime_file: &'static str,
         global: &'static str,
     },
-    /// Below the feature's floor: nub does nothing, the feature is unavailable.
-    Absent,
 }
 
 /// One user-facing runtime feature and its per-version mitigation.
-pub struct Feature {
+pub(crate) struct Feature {
     /// Stable, human-readable feature name (unique across the table).
-    pub name: &'static str,
+    name: &'static str,
     /// The per-version mitigation bands, sorted ascending and non-overlapping.
     /// A version's mitigation is the band it falls into (or "nothing" if none).
-    pub mitigations: &'static [(VersionBand, Mitigation)],
+    mitigations: &'static [(VersionBand, Mitigation)],
     /// Changelog / PR citation for the whole feature (the bands' evidence).
-    pub evidence: &'static str,
+    /// Documentation-as-data: nothing in the production path reads it (hence the
+    /// allow — the lib target can't see the cfg(test) reader); the
+    /// `every_row_carries_changelog_evidence` test enforces it stays populated.
+    #[allow(dead_code)]
+    evidence: &'static str,
 }
 
 impl Feature {
     /// The mitigation that applies to `v` — the band it falls into, if any.
-    pub fn mitigation_for(&self, v: &NodeVersion) -> Option<Mitigation> {
+    pub(crate) fn mitigation_for(&self, v: &NodeVersion) -> Option<Mitigation> {
         self.mitigations
             .iter()
             .find(|(band, _)| band.contains(v))
@@ -135,7 +139,7 @@ const fn band(lo: (u32, u32, u32), hi: Option<(u32, u32, u32)>) -> VersionBand {
 /// feature with its per-version mitigation and changelog evidence. Everything
 /// version-keyed in [`super::flags`] and the webstorage predicates is derived
 /// from this — do not add a parallel table elsewhere.
-pub static FEATURES: &[Feature] = &[
+static FEATURES: &[Feature] = &[
     // ── vm.Module / vm.SourceTextModule ────────────────────────────────────
     // Flag added in Node 9.6.0 (#14253) and NEVER unflagged through Node 26 —
     // `vm.Module` stays experimental and the flag is always required. So inject
@@ -176,7 +180,7 @@ pub static FEATURES: &[Feature] = &[
     // backported to the 20.x LTS line at 20.18.0. The 21.x line was already EOL
     // when it landed, so the flag NEVER existed there — injecting it on any 21.x
     // is a "bad option" startup crash. Never unflagged through 26. Injection set:
-    // [20.18.0, 21.0.0) ∪ [22.3.0, ∞). Below 20.18 it is Absent.
+    // [20.18.0, 21.0.0) ∪ [22.3.0, ∞). Below 20.18 the feature is absent (no band).
     Feature {
         name: "eventsource",
         mitigations: &[
@@ -382,7 +386,7 @@ pub static FEATURES: &[Feature] = &[
     // ── Web Storage (localStorage / sessionStorage) ─────────────────────────
     // `--experimental-webstorage` + `--localstorage-file` landed in Node 22.4.0;
     // below it both are "bad option" (compat tier 18.19–22.3 runs without
-    // webstorage → Absent). The experimental flag was unflagged (defaults on) in
+    // webstorage — no band). The experimental flag was unflagged (defaults on) in
     // Node 25.0.0 (PR #57666). So:
     //   • [22.4.0, 25.0.0) → Unflag("--experimental-webstorage") + a storage file.
     //   • [25.0.0, ∞)      → StorageFile only (global is native; the
@@ -659,13 +663,14 @@ pub static FEATURES: &[Feature] = &[
 /// V8 context snapshot (Electron) in `Context::FromSnapshot` → `CreateEnvironment`,
 /// before any preload JS can intervene (#246). The
 /// `no_v8_harmony_flag_in_unflag_set` test enforces this against the whole matrix.
-pub const V8_HARMONY_UNFLAG_DENYLIST: &[&str] = &["--experimental-shadow-realm"];
+#[cfg(test)]
+const V8_HARMONY_UNFLAG_DENYLIST: &[&str] = &["--experimental-shadow-realm"];
 
 /// Look up a feature row by name (used by the webstorage-predicate derivation in
 /// [`super::flags`]). Panics if the name is absent — it is only ever called with
 /// a literal that must exist in [`FEATURES`], so an absent name is a programming
 /// error worth failing loudly.
-pub fn feature(name: &str) -> &'static Feature {
+pub(crate) fn feature(name: &str) -> &'static Feature {
     FEATURES
         .iter()
         .find(|f| f.name == name)
@@ -679,7 +684,7 @@ pub fn feature(name: &str) -> &'static Feature {
 ///
 /// Order follows table order (vm-modules, eventsource, sqlite, websocket,
 /// webstorage…) so the produced flag list is deterministic.
-pub fn unflag_flags_for(node_version: &NodeVersion) -> Vec<&'static str> {
+pub(crate) fn unflag_flags_for(node_version: &NodeVersion) -> Vec<&'static str> {
     FEATURES
         .iter()
         .filter_map(|f| match f.mitigation_for(node_version) {
@@ -697,7 +702,7 @@ pub fn unflag_flags_for(node_version: &NodeVersion) -> Vec<&'static str> {
 /// exactly `[0, floor)`. [`super::flags::strip_unsupported_node_options`] uses this
 /// to snip a below-floor gated flag out of an inherited NODE_OPTIONS. Derived from
 /// the same matrix the inject path reads — no parallel floor table.
-pub fn unflag_floor(flag: &str) -> Option<NodeVersion> {
+pub(crate) fn unflag_floor(flag: &str) -> Option<NodeVersion> {
     FEATURES
         .iter()
         .flat_map(|f| f.mitigations.iter())
@@ -731,6 +736,19 @@ mod tests {
             assert!(
                 seen.insert(f.name),
                 "duplicate feature name in matrix: {:?}",
+                f.name
+            );
+        }
+    }
+
+    #[test]
+    fn every_row_carries_changelog_evidence() {
+        // The module doc requires each row to cite its changelog/PR evidence;
+        // an empty string would silently drop the audit trail.
+        for f in FEATURES {
+            assert!(
+                !f.evidence.trim().is_empty(),
+                "feature {:?} has no evidence citation",
                 f.name
             );
         }

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -34,7 +34,7 @@ const ALWAYS_INJECT: &[&str] = &["--enable-source-maps"];
 /// AssertionError. Verified on real Node 26.2.0:
 /// `node --enable-source-maps -e 'try{require("assert").ok(false)}catch(e){console.log(e.constructor.name)}'`
 /// prints `TypeError`; without the flag it prints `AssertionError`.
-pub fn source_maps_safe(node_version: &NodeVersion) -> bool {
+fn source_maps_safe(node_version: &NodeVersion) -> bool {
     !(node_version.major() == 26 && node_version.minor() == 2)
 }
 
@@ -58,8 +58,10 @@ const MIN_DISABLE_WARNING: NodeVersion = NodeVersion::new(20, 11, 0);
 /// NOTE: this is version-detection logic the spawn path uses indirectly via
 /// `webstorage_flag_needed` (which derives from the same matrix). It is the
 /// canonical description of Node's Web Storage banding (the source of truth shared
-/// with the `webstorage` feature_matrix row).
-pub fn webstorage_supported(node_version: &NodeVersion) -> bool {
+/// with the `webstorage` feature_matrix row). Only the banding tests call it
+/// directly — production reaches the matrix via `webstorage_flag_needed`.
+#[cfg(test)]
+fn webstorage_supported(node_version: &NodeVersion) -> bool {
     feature_matrix::feature("webstorage")
         .mitigation_for(node_version)
         .is_some()
@@ -76,7 +78,7 @@ pub fn webstorage_supported(node_version: &NodeVersion) -> bool {
 /// `--experimental-webstorage` (the maintainer, 2026-06-15): on the flag-needed band the
 /// flag is unconditionally injected so `sessionStorage` works out of the box; below
 /// the band it's a "bad option" and on 25+ it's unnecessary (native).
-pub fn webstorage_flag_needed(node_version: &NodeVersion) -> bool {
+pub(crate) fn webstorage_flag_needed(node_version: &NodeVersion) -> bool {
     matches!(
         feature_matrix::feature("webstorage").mitigation_for(node_version),
         Some(Mitigation::Unflag(_))
@@ -92,10 +94,10 @@ pub fn webstorage_flag_needed(node_version: &NodeVersion) -> bool {
 /// On the compat tier below 22.5 the exclude is simply skipped: nub's runtime shows
 /// up in the (rare) coverage report — a cosmetic aggregate quirk, vastly better than
 /// refusing to start. Verified against real Node 18.19 / 20.11 / 22.15.
-pub const MIN_TEST_COVERAGE_EXCLUDE: NodeVersion = NodeVersion::new(22, 5, 0);
+const MIN_TEST_COVERAGE_EXCLUDE: NodeVersion = NodeVersion::new(22, 5, 0);
 
 /// Whether the target Node supports `--test-coverage-exclude` (argv or NODE_OPTIONS).
-pub fn test_coverage_exclude_supported(node_version: &NodeVersion) -> bool {
+pub(crate) fn test_coverage_exclude_supported(node_version: &NodeVersion) -> bool {
     *node_version >= MIN_TEST_COVERAGE_EXCLUDE
 }
 

--- a/crates/nub-core/src/node/mod.rs
+++ b/crates/nub-core/src/node/mod.rs
@@ -9,6 +9,6 @@ pub mod shim;
 // the runtime blob (`embed-runtime`). The default dev build resolves `runtime/`
 // via the in-repo walk in `spawn::find_preload`, so this module is absent.
 #[cfg(feature = "embed-runtime")]
-pub mod runtime_cache;
+pub(crate) mod runtime_cache;
 pub mod spawn;
 pub mod version;

--- a/crates/nub-core/src/node/runtime_cache.rs
+++ b/crates/nub-core/src/node/runtime_cache.rs
@@ -103,7 +103,7 @@ static EXTRACTED: OnceLock<Option<PathBuf>> = OnceLock::new();
 /// process (OnceLock), returning a cheap clone afterward. `None` only on a
 /// genuinely unusable environment (no writable cache dir) — the caller then runs
 /// without augmentation, exactly as it would for a not-found sidecar.
-pub fn ensure_runtime() -> Option<PathBuf> {
+pub(crate) fn ensure_runtime() -> Option<PathBuf> {
     EXTRACTED.get_or_init(extract_once).clone()
 }
 

--- a/crates/nub-core/src/node/shim.rs
+++ b/crates/nub-core/src/node/shim.rs
@@ -36,7 +36,7 @@ use crate::pm::shim::{
 /// The persistent node shim's PATH block — a DEDICATED dir + marker, distinct
 /// from the PM shims' (`~/.nub/shims`, `# nub shims`) so the two install and
 /// uninstall independently.
-pub const NODE_SHIM_BLOCK: ShimBlock = ShimBlock {
+const NODE_SHIM_BLOCK: ShimBlock = ShimBlock {
     marker: "# nub node shim",
     posix_line: r#"export PATH="$HOME/.nub/node-shim:$PATH""#,
     fish_line: "set -gx PATH $HOME/.nub/node-shim $PATH",

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -322,7 +322,7 @@ pub fn untrack_child() {
 /// own-group-without-tcsetpgrp path (correct for non-interactive children).
 #[cfg(unix)]
 #[must_use]
-pub fn foreground_child(child_pid: u32) -> Option<ForegroundGuard> {
+fn foreground_child(child_pid: u32) -> Option<ForegroundGuard> {
     // SAFETY: pure FFI reads; STDIN_FILENO is always valid in this process.
     let stdin_is_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } == 1;
     if !stdin_is_tty {
@@ -703,7 +703,7 @@ pub struct SpawnConfig<'a> {
 
 /// The result of spawning a Node process.
 pub struct SpawnResult {
-    pub status: ExitStatus,
+    status: ExitStatus,
 }
 
 /// Spawn Node with Nub's augmentation pipeline.
@@ -2019,7 +2019,7 @@ fn should_neutralize_localstorage(
 /// internal `__NUB_*` plumbing var, NOT a user knob — explicitly permitted by the
 /// brand boundary. The preload deletes it after reading so it does not leak to
 /// grandchild processes.
-pub(crate) const NEUTRALIZE_LOCALSTORAGE_ENV: &str = "__NUB_NEUTRALIZE_LOCALSTORAGE";
+const NEUTRALIZE_LOCALSTORAGE_ENV: &str = "__NUB_NEUTRALIZE_LOCALSTORAGE";
 
 /// Carries the running binary's version (`env!("CARGO_PKG_VERSION")`) to the
 /// preload, which publishes it as `process.versions.nub` — the universal
@@ -2031,7 +2031,7 @@ pub(crate) const NEUTRALIZE_LOCALSTORAGE_ENV: &str = "__NUB_NEUTRALIZE_LOCALSTOR
 /// permitted by the brand boundary. Unlike the localStorage signal it is NOT
 /// deleted by the preload, so it inherits into augmented descendants (which run
 /// the same preload via NODE_OPTIONS) and they advertise the marker too.
-pub(crate) const VERSION_ENV: &str = "__NUB_VERSION";
+const VERSION_ENV: &str = "__NUB_VERSION";
 
 /// Tells nub's fast-tier preload to register its module hooks via the ASYNC
 /// loader-worker path (`module.register`) instead of the sync
@@ -2042,7 +2042,7 @@ pub(crate) const VERSION_ENV: &str = "__NUB_VERSION";
 /// (like [`VERSION_ENV`]) so every child in a tsx run composes async. An internal
 /// `__NUB_*` plumbing var, NOT a user knob — explicitly permitted by the brand
 /// boundary.
-pub(crate) const FORCE_ASYNC_TIER_ENV: &str = "__NUB_FORCE_ASYNC_TIER";
+const FORCE_ASYNC_TIER_ENV: &str = "__NUB_FORCE_ASYNC_TIER";
 
 /// Node versions where the async `module.register` loader's `resolveSync`/
 /// `loadSync` are unimplemented stubs that throw `ERR_METHOD_NOT_IMPLEMENTED`.
@@ -2053,7 +2053,7 @@ pub(crate) const FORCE_ASYNC_TIER_ENV: &str = "__NUB_FORCE_ASYNC_TIER";
 /// inclusive; 24.11.1+/25.2+/26 are fine. Refs nodejs/node#59666. (A later 22.x
 /// that backported the fix would be over-covered here — harmless, since the
 /// async tier composes correctly on every version.)
-pub(crate) fn node_hook_compose_broken(v: &super::version::NodeVersion) -> bool {
+fn node_hook_compose_broken(v: &super::version::NodeVersion) -> bool {
     use super::version::NodeVersion;
     *v >= NodeVersion::new(22, 15, 0) && *v <= NodeVersion::new(24, 11, 0)
 }
@@ -2064,7 +2064,7 @@ pub(crate) fn node_hook_compose_broken(v: &super::version::NodeVersion) -> bool 
 /// argv[0]) so an env-prefixed/compound script (`NODE_ENV=prod tsx x`) is still
 /// caught; a rare false positive (a literal `echo tsx`) only makes that one
 /// process use nub's async tier, which is always correct — never a crash.
-pub(crate) fn child_hosts_async_loader<'a>(tokens: impl IntoIterator<Item = &'a str>) -> bool {
+fn child_hosts_async_loader<'a>(tokens: impl IntoIterator<Item = &'a str>) -> bool {
     tokens.into_iter().any(|tok| {
         let flag = tok.split_once('=').map_or(tok, |(f, _)| f);
         if matches!(flag, "--import" | "--loader" | "--experimental-loader") {
@@ -2208,12 +2208,6 @@ fn to_file_url(path: &str, windows: bool) -> String {
         // Drive: C:/a/b -> file:///C:/a/b
         format!("file:///{forward}")
     }
-}
-
-/// Public path -> `file://` URL conversion for the current platform. Used wherever
-/// nub injects `--import <url>` for the preload.
-pub fn path_to_file_url(path: &str) -> String {
-    to_file_url(path, cfg!(windows))
 }
 
 /// How nub injects its preload, chosen BY TIER. The fast tier (Node 22.15+) loads a
@@ -2442,7 +2436,7 @@ const REAP_LEGACY_ENTRY_CAP: usize = 256;
 /// a directory scan + per-entry `stat`, which is exactly the synchronous cost the
 /// latency-sensitive run path must not pay. Drive it ONLY off the thread via
 /// [`spawn_stale_shim_reaper`], which detaches it so the run never waits on it.
-pub fn reap_stale_shims() {
+fn reap_stale_shims() {
     reap_stale_shims_in(&env::temp_dir(), std::process::id(), pid_is_alive);
 }
 

--- a/crates/nub-core/src/node/version.rs
+++ b/crates/nub-core/src/node/version.rs
@@ -17,14 +17,11 @@ impl NodeVersion {
         ))
     }
 
-    pub fn major(&self) -> u64 {
+    pub(crate) fn major(&self) -> u64 {
         self.0.major
     }
-    pub fn minor(&self) -> u64 {
+    pub(crate) fn minor(&self) -> u64 {
         self.0.minor
-    }
-    pub fn patch(&self) -> u64 {
-        self.0.patch
     }
 
     /// The minimum Node version Nub supports at all. Below this, Nub
@@ -33,21 +30,21 @@ impl NodeVersion {
     /// `wiki/research/supported-node-versions.md` for the rationale
     /// (no hook API exists below 18.19 that can carry Nub's feature
     /// surface).
-    pub const MIN_SUPPORTED: Self = Self::new(18, 19, 0);
+    const MIN_SUPPORTED: Self = Self::new(18, 19, 0);
 
     /// The minimum Node version for Nub's fast-path augmented mode
     /// (sync `module.registerHooks`). Versions in
     /// `MIN_SUPPORTED..MIN_AUGMENTED` run in compatibility mode
     /// (async `module.register()`); the JS preload picks the
     /// registration shape based on `process.versions.node`.
-    pub const MIN_AUGMENTED: Self = Self::new(22, 15, 0);
+    const MIN_AUGMENTED: Self = Self::new(22, 15, 0);
 
     /// True if this Node version is at or above the hard floor.
-    pub fn is_supported(&self) -> bool {
+    pub(crate) fn is_supported(&self) -> bool {
         *self >= Self::MIN_SUPPORTED
     }
 
-    pub fn supports_augmentation(&self) -> bool {
+    pub(crate) fn supports_augmentation(&self) -> bool {
         *self >= Self::MIN_AUGMENTED
     }
 
@@ -59,7 +56,10 @@ impl NodeVersion {
     ///   Nub feature surface; the spawn path refuses.
     ///
     /// Source of truth for the support model: `wiki/research/supported-node-versions.md`.
-    pub fn tier(&self) -> SupportTier {
+    /// Production gates on [`Self::is_supported`] / [`Self::supports_augmentation`]
+    /// directly; this classifier exists so the tier-boundary tests read as the model.
+    #[cfg(test)]
+    fn tier(&self) -> SupportTier {
         if *self >= Self::MIN_AUGMENTED {
             SupportTier::FastPath
         } else if *self >= Self::MIN_SUPPORTED {
@@ -69,7 +69,7 @@ impl NodeVersion {
         }
     }
 
-    pub fn satisfies(&self, pin: &VersionPin) -> bool {
+    pub(crate) fn satisfies(&self, pin: &VersionPin) -> bool {
         match pin {
             VersionPin::Exact(v) => {
                 self.0.major == v.0.major && self.0.minor == v.0.minor && self.0.patch == v.0.patch
@@ -156,7 +156,7 @@ impl VersionPin {
     /// comma form Cargo's `semver` crate wants. Every alternative must parse, or
     /// the whole spec errors (the caller warns and falls through to the next pin
     /// source — never silently half-honors a range).
-    pub fn parse_allowing_ranges(s: &str) -> Result<Self, VersionParseError> {
+    pub(crate) fn parse_allowing_ranges(s: &str) -> Result<Self, VersionParseError> {
         if let Ok(pin) = s.parse::<VersionPin>() {
             return Ok(pin);
         }
@@ -253,7 +253,7 @@ impl FromStr for VersionPin {
 }
 
 #[derive(Debug, Clone)]
-pub struct VersionParseError(pub String);
+pub struct VersionParseError(String);
 
 impl fmt::Display for VersionParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/nub-core/src/pm/extract.rs
+++ b/crates/nub-core/src/pm/extract.rs
@@ -32,7 +32,7 @@ use crate::version_management::extract::{
 /// is skipped, not written) and preserves the bin's executable mode;
 /// `single_top_dir` enforces the one-dir invariant. The entry COUNT is bounded
 /// too (N2 — the `tar` crate has no count guard), mirroring aube-store's caps.
-pub fn extract_tgz(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
+pub(crate) fn extract_tgz(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
     extract_tgz_capped(
         archive,
         dest_parent,

--- a/crates/nub-core/src/pm/mod.rs
+++ b/crates/nub-core/src/pm/mod.rs
@@ -9,7 +9,7 @@
 //! with nub's download/verify/cache machinery into a runnable, version-addressed
 //! install — reusing the same provisioning skeleton as Node.
 
-pub mod extract;
+pub(crate) mod extract;
 pub mod lockfile_version;
 pub mod provision;
 pub mod registry;

--- a/crates/nub-core/src/pm/registry.rs
+++ b/crates/nub-core/src/pm/registry.rs
@@ -2,7 +2,7 @@
 //! (exact / dist-tag / range), the tarball URL, and the dist integrity that gates
 //! extraction. Mirrors `version_management::node_index`'s split — a PURE resolver
 //! over already-fetched metadata ([`resolve_dist`]) plus a thin networked wrapper
-//! ([`resolve_version`]) — so the resolution logic is unit-tested offline.
+//! ([`resolve_version_authed`]) — so the resolution logic is unit-tested offline.
 //!
 //! Trust model: HTTPS authenticates that the packument came from the registry;
 //! the per-version `dist.integrity` (sha512) authenticates the tarball before it
@@ -29,7 +29,7 @@ pub struct VersionDist {
     pub integrity: Integrity,
     /// The bin entry's path relative to the package root (`bin/pnpm.cjs`). For a
     /// PM the resolver picks the entry whose name matches the package.
-    pub bin_subpath: PathBuf,
+    pub(crate) bin_subpath: PathBuf,
 }
 
 /// The dist checksum that gates extraction. sha512 (the modern `dist.integrity`
@@ -45,7 +45,7 @@ pub enum Integrity {
 
 /// The public npm registry — the floor of the precedence stack and the marker
 /// for "no mirror configured" (the tarball-origin rewrite is a no-op against it).
-pub const PUBLIC_REGISTRY: &str = "https://registry.npmjs.org";
+const PUBLIC_REGISTRY: &str = "https://registry.npmjs.org";
 
 /// The resolved registry for PM downloads: its base URL plus any auth that
 /// applies to the base's host. Carries enough to fetch the packument AND the
@@ -57,7 +57,7 @@ pub struct RegistryConfig {
     /// Trailing-slash-trimmed base URL — callers concatenate `/<pkg>`.
     pub base: String,
     /// The `Authorization` credential for `base`'s host, if any.
-    pub auth: Option<Auth>,
+    auth: Option<Auth>,
 }
 
 /// The registry base URL, in precedence order:
@@ -308,7 +308,7 @@ fn strip_scheme(url: &str) -> &str {
 /// the configured registry's. Only rewritten when a NON-public registry is
 /// configured; a public-registry config leaves the URL untouched (the common
 /// case, and the safe one — never redirect a public tarball).
-pub fn rewrite_tarball_origin(tarball: &str, registry_base: &str) -> String {
+fn rewrite_tarball_origin(tarball: &str, registry_base: &str) -> String {
     // No rewrite when the configured registry is the public one.
     if origin_of(registry_base) == Some(origin_of(PUBLIC_REGISTRY).unwrap()) {
         return tarball.to_string();
@@ -370,7 +370,7 @@ fn origin_of(url: &str) -> Option<&str> {
 /// write) separates them by space. [`normalize_range`] bridges the two so a
 /// `>=9 <11` pin resolves rather than erroring. The `||` OR operator is NOT
 /// supported (Cargo's `semver` has no OR) — vanishingly rare in a PM pin.
-pub fn resolve_dist(packument: &Value, spec: &str) -> Result<VersionDist> {
+fn resolve_dist(packument: &Value, spec: &str) -> Result<VersionDist> {
     let spec = spec.trim();
     let versions = packument
         .get("versions")
@@ -565,22 +565,6 @@ pub(crate) fn named_bin_subpath(meta: &Value, entry: &str) -> Option<PathBuf> {
         return safe_bin_subpath(path);
     }
     safe_bin_subpath(bin.as_object()?.get(entry)?.as_str()?)
-}
-
-/// Networked wrapper over a bare base URL (no auth): fetch the packument from
-/// `base` and resolve `spec` against it. `pkg` is the package name (`pnpm`, `npm`,
-/// `yarn`). Retained for the no-auth `nub pm use` caller; provisioning goes through
-/// [`resolve_version_authed`], which carries the host auth and rewrites the tarball
-/// origin onto a configured mirror.
-pub fn resolve_version(base: &str, pkg: &str, spec: &str) -> Result<VersionDist> {
-    resolve_version_authed(
-        &RegistryConfig {
-            base: base.trim_end_matches('/').to_string(),
-            auth: None,
-        },
-        pkg,
-        spec,
-    )
 }
 
 /// npm's abbreviated ("corgi") packument media type. Same `dist-tags` /

--- a/crates/nub-core/src/pm/resolve.rs
+++ b/crates/nub-core/src/pm/resolve.rs
@@ -86,7 +86,7 @@ pub struct PmTargetResolution {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PmPinResolution {
     pub pin: PmPin,
-    pub source: PinSource,
+    source: PinSource,
     pub warnings: Vec<PinWarning>,
 }
 
@@ -592,7 +592,7 @@ fn root_manifest(cwd: &Path) -> Option<std::sync::Arc<serde_json::Value>> {
 /// write — `nub pm update`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeclaredPmWrite {
-    pub path: PathBuf,
+    path: PathBuf,
     pub dev_engines_range: Option<String>,
 }
 
@@ -853,7 +853,7 @@ fn pin_target_dir(cwd: &Path) -> PathBuf {
 ///
 /// Public so the CLI's pin consumers parse through the SAME pin parser the
 /// `packageManager` reader uses — there is no second spec parser.
-pub fn parse_spec(spec: &str) -> Result<PmPin> {
+fn parse_spec(spec: &str) -> Result<PmPin> {
     let spec = spec.trim();
     let (name, version) = spec.split_once('@').with_context(|| {
         format!("packageManager \"{spec}\" must be in name@version form (e.g. pnpm@9.1.0)")

--- a/crates/nub-core/src/pm/shim.rs
+++ b/crates/nub-core/src/pm/shim.rs
@@ -89,7 +89,7 @@ impl ShimName {
 
     /// `npx` / `pnpx` are runner binaries — transparent ALWAYS, whatever the
     /// first verb (corepack's allowlist shape; ratified 2026-06-09).
-    pub fn always_transparent(self) -> bool {
+    fn always_transparent(self) -> bool {
         matches!(self, Self::Npx | Self::Pnpx)
     }
 }
@@ -98,7 +98,7 @@ impl ShimName {
 /// `npm create vite` in a pnpm repo must work (corepack's allowlist shape).
 /// Matched against the FIRST argv token verbatim; a flag before the verb
 /// (`npm --yes create x`) is not recognized — strictness errs toward refusing.
-pub const TRANSPARENT_VERBS: [&str; 4] = ["init", "create", "dlx", "exec"];
+const TRANSPARENT_VERBS: [&str; 4] = ["init", "create", "dlx", "exec"];
 
 /// Whether this shim invocation was spawned by an already-running package
 /// manager (a nested call), versus typed by the user at a shell (a top-level
@@ -375,7 +375,7 @@ pub fn safe_redirect(pinned: Pm, args: &[String]) -> Option<String> {
 /// `install.sh` already puts `~/.nub/bin/nub` on PATH, and a `nub` argv0 is
 /// dispatched by [`Argv0`](../../../nub_cli/cli/enum.Argv0.html) regardless of
 /// the shim dir, so a `~/.nub/shims/nub` hardlink intercepts nothing.
-pub const PM_SHIM_NAMES: [&str; 6] = ["npm", "npx", "pnpm", "pnpx", "yarn", "yarnpkg"];
+const PM_SHIM_NAMES: [&str; 6] = ["npm", "npx", "pnpm", "pnpx", "yarn", "yarnpkg"];
 
 /// Everything [`install_shims`] links — the six PM names. Kept as a named alias
 /// of [`PM_SHIM_NAMES`] so the install/report path reads as "the full shim set"
@@ -525,7 +525,7 @@ pub fn install_shims_into(dir: &Path, nub_binary: &Path) -> Result<Vec<Installed
 /// of [`install_shims_into`]. The PM shim installs all six [`SHIM_NAMES`]; the
 /// persistent `node` shim (`crate::node::shim`) installs the single `["node"]`
 /// through the SAME lock + hardlink-then-copy + same-inode-idempotency path.
-pub fn install_named_shims(
+pub(crate) fn install_named_shims(
     dir: &Path,
     names: &[&'static str],
     nub_binary: &Path,
@@ -594,7 +594,7 @@ pub fn remove_shims() -> Result<bool> {
 }
 
 /// [`remove_shims`] with an explicit dir (the testable body).
-pub fn remove_shims_from(dir: &Path) -> Result<bool> {
+pub(crate) fn remove_shims_from(dir: &Path) -> Result<bool> {
     // Same writer-serializing lock as [`install_shims_into`]: an `unshim`
     // racing a re-link must not remove the dir mid-link. Held until return.
     let _lock = ShimLock::acquire(dir);
@@ -697,8 +697,8 @@ pub fn dir_is_noexec(_dir: &Path) -> bool {
 
 /// The PATH lines, exactly install.sh's shape (`$HOME`-relative so the profile
 /// stays portable across machines), pointing at the SHIMS dir.
-pub const SHIMS_POSIX_PATH_LINE: &str = r#"export PATH="$HOME/.nub/shims:$PATH""#;
-pub const SHIMS_FISH_PATH_LINE: &str = "set -gx PATH $HOME/.nub/shims $PATH";
+const SHIMS_POSIX_PATH_LINE: &str = r#"export PATH="$HOME/.nub/shims:$PATH""#;
+const SHIMS_FISH_PATH_LINE: &str = "set -gx PATH $HOME/.nub/shims $PATH";
 
 /// The block's marker comment. install.sh writes `# nub` above its `~/.nub/bin`
 /// line; this is deliberately DISTINCT so `nub pm unshim` strips exactly the
@@ -711,20 +711,20 @@ const BLOCK_MARKER: &str = "# nub shims";
 /// persistent `node` shim (`crate::node::shim`) without duplicating it. Each
 /// family carries a DISTINCT marker so an unshim strips exactly its own block —
 /// never a sibling's, never install.sh's `# nub` block.
-pub struct ShimBlock {
+pub(crate) struct ShimBlock {
     /// The marker comment written on its own line above the PATH line.
-    pub marker: &'static str,
+    pub(crate) marker: &'static str,
     /// The POSIX (bash/zsh) `export PATH="…:$PATH"` line.
-    pub posix_line: &'static str,
+    pub(crate) posix_line: &'static str,
     /// The fish `set -gx PATH … $PATH` line.
-    pub fish_line: &'static str,
+    pub(crate) fish_line: &'static str,
     /// A substring the PATH line must contain for [`strip_block`]'s defensive
     /// "is this really our line" guard — the `$HOME`-relative dir (`.nub/shims`).
-    pub dir_marker: &'static str,
+    pub(crate) dir_marker: &'static str,
 }
 
 /// The PM shims' block (`~/.nub/shims`, `# nub shims`).
-pub const PM_SHIM_BLOCK: ShimBlock = ShimBlock {
+pub(crate) const PM_SHIM_BLOCK: ShimBlock = ShimBlock {
     marker: BLOCK_MARKER,
     posix_line: SHIMS_POSIX_PATH_LINE,
     fish_line: SHIMS_FISH_PATH_LINE,
@@ -787,7 +787,7 @@ pub fn add_path_block() -> Result<ProfileOutcome> {
 /// the line it's `AlreadyPresent` (naming the first); if nothing could be
 /// written it's `Manual`. Non-interactive files are wired silently as extra
 /// coverage — the per-file detail isn't surfaced to keep one headline outcome.
-pub fn add_path_block_for(
+pub(crate) fn add_path_block_for(
     shell: &str,
     home: &Path,
     xdg_config: Option<&Path>,
@@ -957,7 +957,7 @@ pub fn remove_path_block() -> Result<Vec<PathBuf>> {
 }
 
 /// [`remove_path_block`] with the environment made explicit (the testable body).
-pub fn remove_path_block_from_profiles(
+pub(crate) fn remove_path_block_from_profiles(
     home: &Path,
     xdg_config: Option<&Path>,
     block: &ShimBlock,
@@ -1102,7 +1102,7 @@ fn check_shims_reachable_in(shim_dir: &Path, path_var: &OsStr) -> Vec<ShimReacha
 /// first PATH hit for `name` the entry in `shim_dir`? The single-name check the
 /// persistent `node` shim's post-install warning uses (parity with the PM
 /// sweep's per-name diagnosis).
-pub fn check_shim_reachable(shim_dir: &Path, name: &'static str) -> ShimReachability {
+pub(crate) fn check_shim_reachable(shim_dir: &Path, name: &'static str) -> ShimReachability {
     shim_reachability_in(
         shim_dir,
         name,

--- a/crates/nub-core/src/version_management/download.rs
+++ b/crates/nub-core/src/version_management/download.rs
@@ -119,7 +119,7 @@ fn backoff(attempt: u32) {
 }
 
 /// GET a small text resource (e.g. `SHASUMS256.txt`), fail-closed on non-2xx.
-pub fn fetch_text(url: &str) -> Result<String> {
+pub(crate) fn fetch_text(url: &str) -> Result<String> {
     fetch_text_auth(url, None)
 }
 
@@ -243,7 +243,7 @@ impl Attempt {
 /// returning the SHA-256 (lowercase hex) of the bytes written. `progress` is
 /// called as chunks arrive with `(bytes_so_far, total_len_if_known)` so callers
 /// can render a stderr progress line.
-pub fn download_to_file(
+pub(crate) fn download_to_file(
     url: &str,
     dest: &Path,
     progress: impl FnMut(u64, Option<u64>),
@@ -506,8 +506,10 @@ impl Read for ChannelReader {
     }
 }
 
-/// SHA-256 (lowercase hex) of a file already on disk.
-pub fn sha256_file(path: &Path) -> Result<String> {
+/// SHA-256 (lowercase hex) of a file already on disk. The production path hashes
+/// the stream during download; tests use this to independently verify the result.
+#[cfg(test)]
+fn sha256_file(path: &Path) -> Result<String> {
     let mut file = std::fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 64 * 1024];
@@ -534,7 +536,7 @@ fn hex_lower(bytes: &[u8]) -> String {
 /// Find the expected SHA-256 for `filename` in a `SHASUMS256.txt` body. Each line
 /// is `<64-hex>  <filename>` (sha256sum format — two spaces). Returns the
 /// lowercase hex, or `None` when the file isn't listed.
-pub fn checksum_for(shasums: &str, filename: &str) -> Option<String> {
+fn checksum_for(shasums: &str, filename: &str) -> Option<String> {
     shasums.lines().find_map(|line| {
         let (hash, rest) = line.split_once(char::is_whitespace)?;
         let name = rest.trim_start(); // collapse the leading space(s) before the name
@@ -545,7 +547,11 @@ pub fn checksum_for(shasums: &str, filename: &str) -> Option<String> {
 
 /// Verify a downloaded artifact's SHA-256 against `SHASUMS256.txt`. Fail-closed:
 /// errors when `filename` isn't listed or the hashes differ.
-pub fn verify_checksum(actual_sha256_hex: &str, shasums: &str, filename: &str) -> Result<()> {
+pub(crate) fn verify_checksum(
+    actual_sha256_hex: &str,
+    shasums: &str,
+    filename: &str,
+) -> Result<()> {
     let expected = checksum_for(shasums, filename)
         .with_context(|| format!("{filename} is not listed in SHASUMS256.txt — refusing"))?;
     if actual_sha256_hex.eq_ignore_ascii_case(&expected) {

--- a/crates/nub-core/src/version_management/extract.rs
+++ b/crates/nub-core/src/version_management/extract.rs
@@ -24,7 +24,7 @@ pub(crate) const MAX_ARCHIVE_DECOMPRESSED_BYTES: u64 = 1 << 30;
 
 /// Maximum bytes for a single archive entry (zip per-file cap). 512 MiB, the
 /// same shape as `aube_store::MAX_TARBALL_ENTRY_BYTES`.
-pub(crate) const MAX_ARCHIVE_ENTRY_BYTES: u64 = 512 << 20;
+const MAX_ARCHIVE_ENTRY_BYTES: u64 = 512 << 20;
 
 /// Maximum number of entries in a single archive — the third aube-store cap
 /// (`aube_store::MAX_TARBALL_ENTRIES`), bounding the per-entry `File::create`
@@ -99,7 +99,7 @@ pub(crate) fn single_top_dir(dest_parent: &Path, archive: &Path) -> Result<PathB
 /// Decode a `.tar.xz` and unpack it under `dest_parent`, returning the single
 /// top-level directory it created (the `node-v<ver>-<plat>` dir). The `tar` crate
 /// guards against path-traversal (`..` / absolute entries) during `unpack`.
-pub fn extract_tar_xz(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
+fn extract_tar_xz(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
     extract_tar_xz_capped(
         archive,
         dest_parent,
@@ -206,7 +206,7 @@ fn extract_tar_xz_reader_capped(
 /// runnable automatically). Stock Node `.zip`s carry POSIX modes in their extra
 /// fields, so a unix build extracting one keeps `node.exe` readable; the normal
 /// Windows-only path doesn't depend on it.
-pub fn extract_zip(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
+fn extract_zip(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
     extract_zip_capped(
         archive,
         dest_parent,
@@ -303,7 +303,7 @@ fn extract_zip_capped(
 /// paths verify the archive against its published SHA-256 before this call (see
 /// `provision_node`) and unpack in-process — no `tar`/`xz`/`Expand-Archive`
 /// shell-out — so the same verify-then-extract guarantee holds on every host.
-pub fn extract_archive(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
+pub(crate) fn extract_archive(archive: &Path, dest_parent: &Path) -> Result<PathBuf> {
     let name = archive
         .file_name()
         .and_then(|n| n.to_str())

--- a/crates/nub-core/src/version_management/manage.rs
+++ b/crates/nub-core/src/version_management/manage.rs
@@ -78,14 +78,6 @@ pub enum InstallOutcome {
     Installed(NodeVersion),
 }
 
-impl InstallOutcome {
-    pub fn version(&self) -> &NodeVersion {
-        match self {
-            Self::AlreadyCached(v) | Self::AlreadyOnPath(v) | Self::Installed(v) => v,
-        }
-    }
-}
-
 /// Resolve a spec (`22`, `lts`, `22.13.0`, `latest`, …) to a concrete published
 /// version against the dist index. An exact `X.Y.Z` is still routed through the
 /// index so a typo'd nonexistent version fails fast rather than 404ing mid-download.

--- a/crates/nub-core/src/version_management/mod.rs
+++ b/crates/nub-core/src/version_management/mod.rs
@@ -16,7 +16,7 @@
 //! `wiki/research/node-provisioning-implementation.md`).
 
 pub mod download;
-pub mod extract;
+pub(crate) mod extract;
 pub mod manage;
 pub mod node_index;
 
@@ -52,16 +52,16 @@ pub enum NodeArch {
 /// a musl host must route to unofficial-builds).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HostTarget {
-    pub os: NodeOs,
-    pub arch: NodeArch,
+    os: NodeOs,
+    arch: NodeArch,
     /// Linux/musl host — official dist has no musl build, so the address routes
     /// to unofficial-builds and the token gains a `-musl` suffix.
-    pub musl: bool,
+    musl: bool,
 }
 
 impl HostTarget {
     /// Detect the host. Returns `None` for an OS/arch nodejs.org doesn't publish.
-    pub fn detect() -> Option<Self> {
+    pub(crate) fn detect() -> Option<Self> {
         let os = match std::env::consts::OS {
             "macos" => NodeOs::Darwin,
             "linux" => NodeOs::Linux,
@@ -83,7 +83,7 @@ impl HostTarget {
 
     /// The `<platform>-<arch>` token in a dist filename, e.g. `darwin-arm64`,
     /// `linux-x64`, `linux-x64-musl`, `win-arm64`.
-    pub fn platform_token(&self) -> String {
+    fn platform_token(&self) -> String {
         let os = match self.os {
             NodeOs::Darwin => "darwin",
             NodeOs::Linux => "linux",
@@ -107,7 +107,7 @@ impl HostTarget {
     /// Archive extension dist uses for this OS: `zip` on Windows, `tar.xz`
     /// elsewhere. (`.tar.xz` is also published for Windows, but `.zip` needs no
     /// xz support — the extractor picks per this.)
-    pub fn archive_ext(&self) -> &'static str {
+    fn archive_ext(&self) -> &'static str {
         match self.os {
             NodeOs::Windows => "zip",
             _ => "tar.xz",
@@ -142,16 +142,16 @@ fn detect_musl() -> bool {
 /// one-line `format!` to reconstruct if the deferred best-effort GPG layer lands.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeArtifact {
-    pub tarball_url: String,
-    pub shasums_url: String,
+    tarball_url: String,
+    shasums_url: String,
     /// The tarball's basename — the key to find its line in `SHASUMS256.txt`.
-    pub tarball_filename: String,
+    tarball_filename: String,
 }
 
 /// Build the dist addresses for `version` on `host`, rooted at `base` (the mirror
 /// base URL, e.g. `https://nodejs.org/dist` — or unofficial-builds for musl; see
 /// [`resolve_mirror_base`]). Pure: no network, no env.
-pub fn node_artifact(version: &NodeVersion, host: &HostTarget, base: &str) -> NodeArtifact {
+pub(crate) fn node_artifact(version: &NodeVersion, host: &HostTarget, base: &str) -> NodeArtifact {
     let base = base.trim_end_matches('/');
     let filename = format!(
         "node-v{version}-{}.{}",
@@ -169,7 +169,7 @@ pub fn node_artifact(version: &NodeVersion, host: &HostTarget, base: &str) -> No
 /// The mirror base for `host`: the ecosystem-standard `NODEJS_ORG_MIRROR` env
 /// override (the nodenv / `n` convention — NODE-namespaced, not a brand
 /// violation) if set, else `nodejs.org/dist` (glibc) or unofficial-builds (musl).
-pub fn resolve_mirror_base(host: &HostTarget) -> String {
+pub(crate) fn resolve_mirror_base(host: &HostTarget) -> String {
     let root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
     resolve_mirror_base_in(host, &root)
 }
@@ -188,7 +188,7 @@ pub fn resolve_mirror_base(host: &HostTarget) -> String {
 /// An explicit mirror (env or key) overrides BOTH libc flavors — it's a user
 /// override, trusted as given; musl users need their mirror to carry the
 /// unofficial-builds layout (documented on the site).
-pub fn resolve_mirror_base_in(host: &HostTarget, project_root: &std::path::Path) -> String {
+fn resolve_mirror_base_in(host: &HostTarget, project_root: &std::path::Path) -> String {
     if let Ok(m) = std::env::var("NODEJS_ORG_MIRROR") {
         let m = m.trim_end_matches('/');
         if !m.is_empty() {
@@ -254,7 +254,7 @@ impl Drop for WorkGuard {
 /// Windows `.zip` needs random access, so it keeps download-then-extract
 /// (still with the overlapped checksum fetch). An already-installed version
 /// short-circuits with no network + no output.
-pub fn provision_node(
+pub(crate) fn provision_node(
     version: &NodeVersion,
     host: &HostTarget,
     store_root: &Path,

--- a/crates/nub-core/src/version_management/node_index.rs
+++ b/crates/nub-core/src/version_management/node_index.rs
@@ -24,10 +24,10 @@ const INDEX_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 /// One row of nodejs.org's `index.json`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexEntry {
-    pub version: NodeVersion,
+    version: NodeVersion,
     /// The LTS codename (e.g. `Jod`, `Iron`) when this is an LTS release; `None`
     /// for a non-LTS / current-line release.
-    pub lts: Option<String>,
+    lts: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -39,7 +39,7 @@ struct RawEntry {
 
 /// Parse the `index.json` body into entries (pure — the unit-test seam). Bad rows
 /// (unparseable version) are skipped rather than failing the whole index.
-pub fn parse_index(body: &str) -> Result<Vec<IndexEntry>> {
+fn parse_index(body: &str) -> Result<Vec<IndexEntry>> {
     let raw: Vec<RawEntry> = serde_json::from_str(body).context("decoding Node index.json")?;
     Ok(raw
         .into_iter()
@@ -56,7 +56,10 @@ pub fn parse_index(body: &str) -> Result<Vec<IndexEntry>> {
 }
 
 /// Fetch + parse the index from `mirror_base` (e.g. `https://nodejs.org/dist`).
-pub fn fetch_index(mirror_base: &str) -> Result<Vec<IndexEntry>> {
+/// Production goes through [`load_index`] (which caches the raw body); this is
+/// the ignored real-network test's direct entry.
+#[cfg(test)]
+fn fetch_index(mirror_base: &str) -> Result<Vec<IndexEntry>> {
     let url = format!("{}/index.json", mirror_base.trim_end_matches('/'));
     let body = download::fetch_text(&url).with_context(|| format!("fetching {url}"))?;
     parse_index(&body)
@@ -65,7 +68,7 @@ pub fn fetch_index(mirror_base: &str) -> Result<Vec<IndexEntry>> {
 /// Load the index, preferring a fresh on-disk cache
 /// (`<cache_root>/node-index.json`, refetched after `INDEX_TTL`). On a fetch
 /// failure but a stale-cache hit, fall back to the stale cache (offline-tolerant).
-pub fn load_index(cache_root: &Path, mirror_base: &str) -> Result<Vec<IndexEntry>> {
+pub(crate) fn load_index(cache_root: &Path, mirror_base: &str) -> Result<Vec<IndexEntry>> {
     let cache = cache_root.join("node-index.json");
     if let Ok(meta) = std::fs::metadata(&cache)
         && let Ok(modified) = meta.modified()
@@ -104,7 +107,7 @@ pub fn load_index(cache_root: &Path, mirror_base: &str) -> Result<Vec<IndexEntry
 /// `<major>` and `<major.minor>`, and an exact `[v]X.Y.Z`. Returns `None` when
 /// nothing matches. (`rc/<major>` lives on a different mirror — handled by the
 /// caller passing the rc index; this picks the newest entry there too.)
-pub fn resolve_spec(spec: &str, index: &[IndexEntry]) -> Option<NodeVersion> {
+pub(crate) fn resolve_spec(spec: &str, index: &[IndexEntry]) -> Option<NodeVersion> {
     let spec = spec.trim();
     let lower = spec.to_ascii_lowercase();
 
@@ -173,7 +176,7 @@ fn all_digits(s: &str) -> bool {
 /// `wiki/runtime/node-version-management.md` §"Resolution order".
 /// `alternatives` carries node-semver `||` branches (OR semantics — the shape
 /// `VersionPin::Range` holds); a plain range is a one-element slice.
-pub fn resolve_range(
+pub(crate) fn resolve_range(
     alternatives: &[semver::VersionReq],
     index: &[IndexEntry],
 ) -> Option<NodeVersion> {

--- a/crates/nub-core/src/workspace/detect.rs
+++ b/crates/nub-core/src/workspace/detect.rs
@@ -78,7 +78,7 @@ pub fn detect_project(cwd: &Path) -> Option<Project> {
 /// keying on the cwd keeps the count immune to sibling tests walking other dirs
 /// concurrently (cargo runs tests in parallel). Test-only; zero cost in release.
 #[cfg(test)]
-pub(crate) static WALKED_CWDS: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex::new(Vec::new());
+static WALKED_CWDS: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex::new(Vec::new());
 
 /// The walk itself — the pre-memo body of [`detect_project`]. A cache miss (and
 /// any path where canonicalization fails) runs exactly this, so the memoized and
@@ -274,44 +274,6 @@ impl ProjectCache {
 fn cache() -> &'static ProjectCache {
     static CACHE: ProjectCache = ProjectCache::new();
     &CACHE
-}
-
-/// List workspace member package.json paths matching a filter.
-pub fn find_workspace_members(workspace_root: &Path, _filter: Option<&str>) -> Vec<PathBuf> {
-    // Simplified: read the workspace root's package.json for the
-    // workspaces field and glob-match. Full glob support deferred.
-    let pkg_path = workspace_root.join("package.json");
-    let Ok(content) = fs::read_to_string(&pkg_path) else {
-        return vec![];
-    };
-    let Ok(manifest) = serde_json::from_str::<serde_json::Value>(crate::strip_utf8_bom(&content))
-    else {
-        return vec![];
-    };
-
-    let patterns = match manifest.get("workspaces") {
-        Some(serde_json::Value::Array(arr)) => arr
-            .iter()
-            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-            .collect::<Vec<_>>(),
-        _ => return vec![],
-    };
-
-    let mut members = Vec::new();
-    for pattern in &patterns {
-        let base = pattern.trim_end_matches("/*").trim_end_matches("/**");
-        let search_dir = workspace_root.join(base);
-        if let Ok(entries) = fs::read_dir(&search_dir) {
-            for entry in entries.flatten() {
-                let member_pkg = entry.path().join("package.json");
-                if member_pkg.is_file() {
-                    members.push(entry.path());
-                }
-            }
-        }
-    }
-
-    members
 }
 
 #[cfg(test)]

--- a/crates/nub-core/src/workspace/filter.rs
+++ b/crates/nub-core/src/workspace/filter.rs
@@ -20,12 +20,12 @@ use std::path::{Path, PathBuf};
 /// A parsed filter expression.
 #[derive(Debug, Clone)]
 pub struct Filter {
-    pub pattern: String,
-    pub include_dependencies: bool,
-    pub include_dependents: bool,
-    pub exclude_self: bool,
-    pub git_ref: Option<String>,
-    pub exclude: bool,
+    pattern: String,
+    include_dependencies: bool,
+    include_dependents: bool,
+    exclude_self: bool,
+    git_ref: Option<String>,
+    exclude: bool,
 }
 
 impl Filter {
@@ -112,7 +112,7 @@ impl Filter {
 ///   tree against the ref directly, so a branch that diverged from `<ref>` still
 ///   selects members touched on EITHER side. Three-dot (merge-base..HEAD) would
 ///   drop the diverged side and `fatal: no merge base` on unrelated histories.
-pub fn packages_changed_since(
+fn packages_changed_since(
     workspace_root: &Path,
     members: &[WorkspacePackage],
     git_ref: &str,
@@ -523,8 +523,10 @@ fn raw_matched_set(
 
 /// Apply a single filter to workspace members, returning the matched set in
 /// topological order (dependencies first). This is the single-`--filter` base
-/// case; [`apply_filters`] generalizes it to several filters at once.
-pub fn apply_filter(
+/// case; [`apply_filters`] generalizes it to several filters at once. Production
+/// always goes through `apply_filters`; the selector tests use this base case.
+#[cfg(test)]
+fn apply_filter(
     members: &[WorkspacePackage],
     filter: &Filter,
     workspace_root: Option<&Path>,

--- a/crates/nub-core/src/workspace/scripts.rs
+++ b/crates/nub-core/src/workspace/scripts.rs
@@ -360,7 +360,7 @@ pub fn find_bin(name: &str, cwd: &Path) -> Option<PathBuf> {
 /// user-level `~/.npmrc`), returning the first match's value with surrounding
 /// quotes stripped. The one `.npmrc` reader in the crate — `script_shell` and
 /// (P1) the PM registry lookup both go through it.
-pub fn npmrc_value(project_root: &Path, key: &str) -> Option<String> {
+pub(crate) fn npmrc_value(project_root: &Path, key: &str) -> Option<String> {
     // Check project .npmrc first, then ~/.npmrc
     let candidates = [
         project_root.join(".npmrc"),

--- a/crates/nub-core/src/workspace/shell_escape.rs
+++ b/crates/nub-core/src/workspace/shell_escape.rs
@@ -18,7 +18,7 @@
 /// otherwise it is wrapped in single quotes with embedded `'` rendered as
 /// `'\''`, then npm's two cosmetic cleanups are applied (they shorten the string
 /// without changing how `sh` tokenizes it).
-pub fn sh(input: &str) -> String {
+fn sh(input: &str) -> String {
     if input.is_empty() {
         return "''".to_string();
     }
@@ -87,7 +87,7 @@ fn strip_leading_empty_quote_pairs(s: &str) -> String {
 /// whitespace/`"` per the MS command-line rules, then prefixes cmd metacharacters
 /// with `^`. `double_escape` repeats the `^` pass — npm does this when the script
 /// target is a `.cmd`/`.bat` file, which re-parses its arguments once more.
-pub fn cmd(input: &str, double_escape: bool) -> String {
+fn cmd(input: &str, double_escape: bool) -> String {
     if input.is_empty() {
         return "\"\"".to_string();
     }
@@ -175,7 +175,7 @@ pub fn splice_args(body: &str, args: &[String], shell: &str) -> String {
 /// Does `shell` invoke `cmd.exe`? Mirrors npm's `/(?:^|\\)cmd(?:\.exe)?$/i`, so a
 /// custom `script-shell` of `bash`/`zsh` selects POSIX escaping while the Windows
 /// default (`cmd`) selects cmd escaping.
-pub fn is_cmd(shell: &str) -> bool {
+fn is_cmd(shell: &str) -> bool {
     let lower = shell.to_ascii_lowercase();
     let stem = lower.strip_suffix(".exe").unwrap_or(&lower);
     stem == "cmd" || stem.ends_with("\\cmd")
@@ -190,7 +190,7 @@ pub fn is_cmd(shell: &str) -> bool {
 /// whose `eslint` resolves to `eslint.cmd` is treated as non-batch and
 /// single-escaped. Closing that needs Windows PATHEXT resolution and Windows
 /// validation; tracked as the residual Windows gap on A42.
-pub fn body_targets_batch_file(script_body: &str) -> bool {
+fn body_targets_batch_file(script_body: &str) -> bool {
     let first = script_body.split_whitespace().next().unwrap_or("");
     let lower = first.to_ascii_lowercase();
     lower.ends_with(".cmd") || lower.ends_with(".bat")

--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -36,34 +36,20 @@ pub enum Verdict {
     SelfRef,
 }
 
-impl Verdict {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Verdict::HardPhantom => "hard-phantom",
-            Verdict::SoftPhantom => "soft-phantom",
-            Verdict::DeclaredOptionalPeer => "declared-optional-peer",
-            Verdict::DeclaredPeer => "declared-peer",
-            Verdict::Declared => "declared",
-            Verdict::Builtin => "builtin",
-            Verdict::SelfRef => "self",
-        }
-    }
-}
-
 /// One classified package reference.
 #[derive(Debug, Clone, Serialize)]
 pub struct Finding {
     pub package: String,
     pub verdict: Verdict,
     /// True if every occurrence was guarded (try/catch or a conditional branch).
-    pub soft: bool,
+    soft: bool,
     /// Reachable from the package's main entry surface.
-    pub from_main: bool,
+    pub(crate) from_main: bool,
     /// Reachable from a non-`.` `exports` subpath (the adapter surface).
-    pub from_subpath: bool,
+    pub(crate) from_subpath: bool,
     /// Reachable from the `.d.ts` TYPE surface — a DECLARED PEER with this set is
     /// the nub#450 peer-type class (its `@types/<peer>` must be project-local).
-    pub from_types: bool,
+    pub(crate) from_types: bool,
     /// Example raw specifiers (deduped) showing how it was referenced.
     pub specifiers: Vec<String>,
 }

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -36,22 +36,22 @@ const FROM_TYPES: u8 = 0b100;
 #[derive(Debug, Clone)]
 pub struct Reference {
     /// Package name the specifier resolves to (`@scope/name` or `name`).
-    pub package: String,
+    pub(crate) package: String,
     /// The raw specifier (kept for the report — shows the exact subpath).
-    pub raw: String,
+    pub(crate) raw: String,
     /// Guarded (try/catch or a conditional branch) at every occurrence collapses
     /// to soft; a single unguarded occurrence makes the package hard.
-    pub soft: bool,
+    pub(crate) soft: bool,
     /// Reachable from the main entry surface.
-    pub from_main: bool,
+    pub(crate) from_main: bool,
     /// Reachable from a non-`.` `exports` subpath — the "consumer opts into
     /// `<pkg>/<subpath>`" adapter surface. A hard phantom reachable ONLY from a
     /// subpath (not main) is the subpath-adapter class.
-    pub from_subpath: bool,
+    pub(crate) from_subpath: bool,
     /// Reachable from the `.d.ts` TYPE surface. A DECLARED PEER reached only via
     /// this surface is the nub#450 peer-type class: its `@types/<peer>` must be
     /// project-local for the type-checker's realpath walk to reach it.
-    pub from_types: bool,
+    pub(crate) from_types: bool,
 }
 
 /// Result of the reachable-module walk.
@@ -182,7 +182,7 @@ pub fn walk(root: &Path, entry_points: &[Entry]) -> Walk {
 /// tree (both drive [`walk_generic`]) for all real package layouts; see
 /// [`normalize_rel_join`] for the one accepted divergence on malformed
 /// (escape-and-re-enter-by-root-name) specifiers that never appear in practice.
-pub fn walk_index(files: &[(String, PathBuf)], entry_points: &[Entry]) -> Walk {
+pub(crate) fn walk_index(files: &[(String, PathBuf)], entry_points: &[Entry]) -> Walk {
     let map: BTreeMap<String, PathBuf> = files.iter().cloned().collect();
     walk_generic(&IndexSource { files: map }, entry_points)
 }

--- a/crates/nub-phantom-scan/src/lib.rs
+++ b/crates/nub-phantom-scan/src/lib.rs
@@ -25,8 +25,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use classify::Finding;
-pub use classify::Verdict;
+pub(crate) use classify::Verdict;
 use manifest::Manifest;
 
 /// One undeclared target a scanned version pulls in, with the provenance bits the
@@ -36,9 +35,9 @@ pub struct PhantomTarget {
     /// The undeclared package name (`zod`, `@apify/datastructures`).
     pub name: String,
     /// Reached from the package's main entry surface.
-    pub from_main: bool,
+    from_main: bool,
     /// Reached from a non-`.` `exports` subpath (the adapter surface).
-    pub from_subpath: bool,
+    from_subpath: bool,
 }
 
 /// The per-version scan verdict — the immutable, per-content-integrity payload
@@ -65,7 +64,7 @@ pub struct ScanResult {
     #[serde(default)]
     pub type_coupled_peers: Vec<String>,
     /// Reachable files parsed (diagnostic — lets the caller see scan breadth).
-    pub files_analyzed: usize,
+    files_analyzed: usize,
 }
 
 /// Scan an already-extracted package tree rooted at `root` (the dir holding
@@ -132,62 +131,9 @@ fn reduce(manifest: &Manifest, walk: &graph::Walk) -> ScanResult {
     }
 }
 
-/// The full per-package report (all verdict categories, not just hard phantoms) —
-/// used by the eval tool and the A/B corpus harness. `scan_extracted` is the lean
-/// production entry; this is the diagnostic one.
-#[derive(Debug, Serialize)]
-pub struct PackageReport {
-    pub name: String,
-    pub version: String,
-    pub findings: Vec<Finding>,
-    pub files_analyzed: usize,
-    pub unresolved_relative: usize,
-}
-
-impl PackageReport {
-    pub fn count(&self, v: Verdict) -> usize {
-        self.findings.iter().filter(|f| f.verdict == v).count()
-    }
-    pub fn hard_phantoms(&self) -> impl Iterator<Item = &Finding> {
-        self.findings
-            .iter()
-            .filter(|f| f.verdict == Verdict::HardPhantom)
-    }
-    pub fn subpath_adapter_phantoms(&self) -> impl Iterator<Item = &Finding> {
-        self.findings.iter().filter(|f| f.is_subpath_adapter())
-    }
-    pub fn naive_phantom_count(&self) -> usize {
-        self.findings
-            .iter()
-            .filter(|f| {
-                matches!(
-                    f.verdict,
-                    Verdict::HardPhantom | Verdict::SoftPhantom | Verdict::DeclaredOptionalPeer
-                )
-            })
-            .count()
-    }
-}
-
-/// Analyze an already-extracted package tree into a full [`PackageReport`].
-pub fn analyze_extracted(root: &Path, version: &str) -> Result<PackageReport, String> {
-    let raw =
-        std::fs::read(root.join("package.json")).map_err(|e| format!("read package.json: {e}"))?;
-    let manifest = Manifest::parse(&raw).ok_or("unparseable package.json / no name")?;
-    let walk = graph::walk(root, &manifest.entry_points);
-    let findings = classify::classify(&manifest, &walk.references);
-    Ok(PackageReport {
-        name: manifest.name,
-        version: version.to_string(),
-        findings,
-        files_analyzed: walk.files_analyzed,
-        unresolved_relative: walk.unresolved_relative,
-    })
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{PathBuf, Verdict, analyze_extracted, scan_extracted, scan_index};
+    use super::{PathBuf, scan_extracted, scan_index};
     use std::fs;
 
     /// `(relpath, blob-path)` pairs for an on-disk tree — the blob is the real
@@ -464,15 +410,6 @@ mod tests {
             "extract-time index scan diverged from post-link tree scan"
         );
         assert!(from_index.has_unguarded_phantom);
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn full_report_still_available() {
-        let root = fixture();
-        let r = analyze_extracted(&root, "1.2.3").unwrap();
-        assert_eq!(r.count(Verdict::HardPhantom), 3);
-        assert_eq!(r.version, "1.2.3");
         let _ = fs::remove_dir_all(&root);
     }
 }

--- a/crates/nub-phantom-scan/src/manifest.rs
+++ b/crates/nub-phantom-scan/src/manifest.rs
@@ -17,15 +17,15 @@ use serde_json::Value;
 pub struct Manifest {
     pub name: String,
     /// `dependencies` ∪ `optionalDependencies` — hard-declared, always resolvable.
-    pub deps: BTreeSet<String>,
+    pub(crate) deps: BTreeSet<String>,
     /// Required peers (`peerDependencies` without an `optional` meta flag).
-    pub required_peers: BTreeSet<String>,
+    pub(crate) required_peers: BTreeSet<String>,
     /// Optional peers (`peerDependenciesMeta.<x>.optional === true`). Declared —
     /// NOT phantoms — but reported as their own category (the pick-your-plugin
     /// pattern that a naive detector over-flags).
-    pub optional_peers: BTreeSet<String>,
+    pub(crate) optional_peers: BTreeSet<String>,
     /// `bundledDependencies` / `bundleDependencies` — shipped inside the tarball.
-    pub bundled: BTreeSet<String>,
+    pub(crate) bundled: BTreeSet<String>,
     /// Published entry files (relative paths from the package root) — the roots
     /// of the reachable-module walk, each tagged by whether it is the main entry
     /// or a non-`.` `exports` subpath (the adapter surface).
@@ -52,8 +52,8 @@ pub enum EntryKind {
 /// A published entry file + its surface kind.
 #[derive(Debug, Clone)]
 pub struct Entry {
-    pub path: String,
-    pub kind: EntryKind,
+    pub(crate) path: String,
+    pub(crate) kind: EntryKind,
 }
 
 impl Manifest {
@@ -294,13 +294,13 @@ fn is_entry_candidate(path: &str) -> bool {
 
 /// A TypeScript declaration file (`.d.ts`/`.d.mts`/`.d.cts`) — the type surface a
 /// `Types` entry seeds and the file class the graph walk resolves for that entry.
-pub fn is_dts_like(path: &str) -> bool {
+pub(crate) fn is_dts_like(path: &str) -> bool {
     path.ends_with(".d.ts") || path.ends_with(".d.mts") || path.ends_with(".d.cts")
 }
 
 /// A JS-like runtime file (extension we can parse for imports). Excludes `.json`,
 /// `.node`, `.wasm`, `.css`, and `.d.ts` type stubs.
-pub fn is_js_like(path: &str) -> bool {
+pub(crate) fn is_js_like(path: &str) -> bool {
     if path.ends_with(".d.ts") || path.ends_with(".d.mts") || path.ends_with(".d.cts") {
         return false;
     }
@@ -317,7 +317,7 @@ pub fn is_js_like(path: &str) -> bool {
 /// type-checker's upward `node_modules` walk can't reach the hoisted backend
 /// otherwise (nub#450). The graph walk resolves these and `extract` reads their
 /// script region.
-pub fn is_sfc_like(path: &str) -> bool {
+pub(crate) fn is_sfc_like(path: &str) -> bool {
     matches!(extension(path), Some("astro" | "vue" | "svelte"))
 }
 

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,0 +1,12 @@
+# hawk (astral-sh/hawk) visibility-lint config.
+# vendor/aube is NOT a workspace member (own workspace, path deps) so hawk
+# treats it as external and never lints it — aube stays byte-for-byte untouched.
+
+[[production]]
+package = "nub-cli"
+bin = "nub"
+reason = "the shipped nub CLI binary"
+
+[[feature-profile]]
+name = "all"
+all-features = true

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,6 +1,15 @@
 # hawk (astral-sh/hawk) visibility-lint config.
 # vendor/aube is NOT a workspace member (own workspace, path deps) so hawk
 # treats it as external and never lints it — aube stays byte-for-byte untouched.
+#
+# BLIND SPOT hawk cannot see: two crates OUTSIDE this workspace consume
+# workspace members — crates/nub-native (own workspace) uses nub-cache-key, and
+# crates/nub-phantom (own workspace, the eval tool) uses nub-phantom-scan +
+# nub-phantom-core. Items they need look dead/over-public to hawk; the
+# [[override]] entries below pin them. Before applying any future `--fix`,
+# verify both consumers still build:
+#   cargo check --manifest-path crates/nub-phantom/Cargo.toml
+#   cargo check --manifest-path crates/nub-native/Cargo.toml
 
 [[production]]
 package = "nub-cli"
@@ -10,3 +19,129 @@ reason = "the shipped nub CLI binary"
 [[feature-profile]]
 name = "all"
 all-features = true
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_cache_key"
+item = "cache_key"
+level = "allow"
+reason = "called by crates/nub-native (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_core"
+item = "pm::shim::SHIM_NAMES"
+level = "allow"
+reason = "used by the Windows-only test pm_shim_windows.rs (not compiled on a non-Windows analysis host)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_core"
+item = "pm::shim::install_shims_into"
+level = "allow"
+reason = "used by the Windows-only test pm_shim_windows.rs (not compiled on a non-Windows analysis host)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_core"
+item = "pm::shim::InstalledShim::name"
+level = "allow"
+reason = "used by the Windows-only test pm_shim_windows.rs (not compiled on a non-Windows analysis host)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_core"
+item = "pm::shim::InstalledShim::path"
+level = "allow"
+reason = "used by the Windows-only test pm_shim_windows.rs (not compiled on a non-Windows analysis host)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_core"
+item = "extract::Occurrence::kind"
+level = "allow"
+reason = "read by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "classify::classify"
+level = "allow"
+reason = "called by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "classify::Finding::verdict"
+level = "allow"
+reason = "read by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "classify::Finding::package"
+level = "allow"
+reason = "read by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "classify::Finding::specifiers"
+level = "allow"
+reason = "read by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "classify::Finding::is_subpath_adapter"
+level = "allow"
+reason = "called by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "graph::walk"
+level = "allow"
+reason = "called by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "graph::Walk::references"
+level = "allow"
+reason = "read by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "graph::Walk::files_analyzed"
+level = "allow"
+reason = "read by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "graph::Walk::unresolved_relative"
+level = "allow"
+reason = "read by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "manifest::Manifest::name"
+level = "allow"
+reason = "read by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "manifest::Manifest::entry_points"
+level = "allow"
+reason = "read by crates/nub-phantom (separate workspace; invisible to hawk)"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "nub_phantom_scan"
+item = "manifest::Manifest::parse"
+level = "allow"
+reason = "called by crates/nub-phantom (separate workspace; invisible to hawk)"


### PR DESCRIPTION
Runs [astral-sh/hawk](https://github.com/astral-sh/hawk) over the workspace; acts on all 172 findings.

- Deletes 10 verified-dead public items and the duplicated `PackageReport` diagnostic path.
- Tightens ~150 declarations to `pub(crate)` or private; gates six test-only helpers behind `#[cfg(test)]`.
- Adds `hawk.toml` with overrides for the 14 items consumed by the out-of-workspace crates `nub-native`/`nub-phantom`.

`vendor/aube` is outside the workspace — zero changes there. `cargo hawk check` clean; clippy/fmt/tests green; both out-of-workspace consumers build.

https://claude.ai/code/session_01BiQbNq3NLZHNWfH9jGp9fN