### PR TITLE
fix(spawn): dispatch the parent-death watcher verb above argv0 detection

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1079,6 +1079,26 @@ pub enum ColorWhen {
 
 /// Top-level entry point. Returns the process exit code.
 pub fn run() -> Result<i32> {
+    // The macOS parent-death watcher (#480) re-invokes `current_exe()` with this
+    // hidden verb — and `current_exe()` is whatever NAME nub is running under,
+    // which for any workload spawned through nub's own PATH shim is `node`, not
+    // `nub`. Dispatching it here, BEFORE `Argv0::detect()`, is what makes the
+    // verb argv0-independent. Routing it through the argv0 match instead let
+    // `Argv0::Node` treat `__pdeath-watch` as a SCRIPT to run, which spawned a
+    // workload — and therefore another watcher — per level, an unbounded
+    // self-replicating chain that exhausted the process table (regression from #504).
+    //
+    // Landing above the guards below is also deliberate: the watcher must not
+    // reclaim or reap PATH shim dirs, which belong to the nub that spawned it.
+    #[cfg(unix)]
+    {
+        let mut args = env::args().skip(1);
+        if args.next().as_deref() == Some("__pdeath-watch") {
+            let rest: Vec<String> = args.collect();
+            return Ok(nub_core::node::spawn::run_pdeath_watch(&rest));
+        }
+    }
+
     // Reclaim the active PATH shim temp dir exactly once, on return. The shim
     // is created lazily/idempotently by the spawn paths and is process-wide; it
     // must outlive every — possibly parallel — child, so
@@ -1629,14 +1649,14 @@ fn run_nub() -> Result<i32> {
             _ => {
                 // Check if this is the first positional and matches a subcommand
                 // (nub-native, a verb registered to the embedded PM engine, or
-                // a hidden re-entry verb: the engine's lazy node-gyp shims and
-                // the macOS parent-death watcher both re-invoke current_exe()
-                // with theirs).
+                // the engine's hidden node-gyp re-entry verb — its lazy shims
+                // re-invoke current_exe() with it mid-lifecycle-script). The
+                // parent-death watcher's verb is handled in `run()`, above
+                // argv0 dispatch, so it never reaches here.
                 if rest.is_empty()
                     && !arg.starts_with('-')
                     && (SUBCOMMANDS.contains(&arg.as_str())
                         || arg == "__node-gyp-bootstrap"
-                        || (cfg!(unix) && arg == "__pdeath-watch")
                         || crate::pm_engine::lookup_verb(arg).is_some())
                 {
                     subcommand_found = true;
@@ -2064,14 +2084,6 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
     // to the engine's bootstrap entry point.
     if subcommand == "__node-gyp-bootstrap" {
         return crate::pm_engine::run_node_gyp_bootstrap(&rest[1..]);
-    }
-
-    // The macOS parent-death watcher (#480) re-invokes current_exe() with this
-    // hidden verb; intercept before clap and run the minimal watcher loop
-    // directly (see nub_core::node::spawn::spawn_group_reaper).
-    #[cfg(unix)]
-    if subcommand == "__pdeath-watch" {
-        return Ok(nub_core::node::spawn::run_pdeath_watch(&rest[1..]));
     }
 
     // Compatibility alias: npm and pnpm treat `install <pkg>` / `i <pkg>` (and

--- a/crates/nub-cli/tests/pdeath_watch.rs
+++ b/crates/nub-cli/tests/pdeath_watch.rs
@@ -126,6 +126,54 @@ fn normal_exit_leaves_no_watcher_process() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// The watcher is re-invoked through `current_exe()`, which carries whatever
+/// NAME nub is running under — `node` for anything spawned through nub's own
+/// PATH shim, not `nub`. So the hidden verb must be honored under EVERY argv0
+/// identity nub answers to. When it hung off the `nub`-only argv0 arm, a
+/// shim-named re-invocation ran `__pdeath-watch` as a script, spawning a
+/// workload (and thus another watcher) per level until the process table was
+/// exhausted (regression from #504).
+#[test]
+fn pdeath_watch_verb_is_honored_under_every_argv0() {
+    // Alongside the binary, so the aliases can be HARDLINKS — same-filesystem,
+    // no 78MB copy per name, and the same shape as nub's real PATH shims.
+    let nub = nub_binary();
+    let dir = nub
+        .parent()
+        .unwrap()
+        .join(format!("nub-pdw-argv0-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // `getpgrp() + 1` can never equal the child's own group (children inherit
+    // ours), so the watcher deterministically takes its membership self-check
+    // exit. That keeps the assertion on "the verb was RECOGNIZED" alone — no
+    // pipe timing, and it never reaches the group kill.
+    let foreign_pgid = (unsafe { libc::getpgrp() } + 1).to_string();
+    for name in ["nub", "node", "nubx", "npm"] {
+        let aliased = dir.join(name);
+        std::fs::hard_link(&nub, &aliased).unwrap();
+        let out = std::process::Command::new(&aliased)
+            .args(["__pdeath-watch", &foreign_pgid, "3"])
+            .output()
+            .expect("spawn aliased nub");
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "nub invoked as `{name}` did not honor __pdeath-watch (stderr: {})",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            out.stdout.is_empty() && out.stderr.is_empty(),
+            "nub invoked as `{name}` ran __pdeath-watch as a workload instead of \
+             the watcher loop (stdout: {}, stderr: {})",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// The disarm half of the contract: a background process the script
 /// DELIBERATELY leaves behind survives nub's normal exit, exactly as it would
 /// under plain sh/node — the watcher must stand down, not sweep the group.

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -509,6 +509,11 @@ pub fn spawn_group_reaper(child_pid: u32) -> Option<GroupReaper> {
             libc::close(write_fd);
         }
     };
+    // `current_exe()` is whatever NAME nub is running under — for any workload
+    // spawned through nub's own PATH shim that is `node`, not `nub`. The verb
+    // below is therefore dispatched in `cli::run()` ABOVE argv0 detection; when
+    // it hung off the `nub`-only argv0 arm, a shim-named re-invocation ran
+    // `__pdeath-watch` as a SCRIPT and spawned another watcher per level (regression from #504).
     let Ok(exe) = std::env::current_exe() else {
         close_both();
         return None;


### PR DESCRIPTION
Trunk CI has been red on `Test (macos-14, node 24)` since #504: 87/208 integration tests failing with `EAGAIN (os error 35)` on spawn, the process table exhausted.

The watcher re-invokes `current_exe()` with the hidden `__pdeath-watch` verb, dispatched only on the `nub` argv0 arm. Under nub's own PATH shim `current_exe()` is `node`, so `run_as_node()` ran it as a script — spawning a workload plus another watcher per level, each then blocked in `GroupReaper::drop` on the one below.

Fix: dispatch it at the top of `cli::run()`, above `Argv0::detect()`.

Peak watchers over one integration run, same host: 3516 and climbing before, 1 after. Full suite after: 208 passed.

Refs #504, #480
