### PR TITLE
fix(pm): export npm_config_user_agent to dlx/create/exec children

### DIFF
--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -450,6 +450,39 @@ fn dlx_installs_and_runs_a_bin_from_a_scratch_project() {
     );
 }
 
+/// dlx/create children carry the role-aware `npm_config_user_agent` (pnpm
+/// parity) — create-* scaffolders sniff it to emit the invoking PM's commands
+/// and fall back to npm-mode when it's absent.
+#[test]
+#[ignore = "network: installs uuid into a dlx scratch project"]
+fn dlx_child_sees_nub_user_agent() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("dlxua");
+    let out = run_nub(
+        &dir,
+        &[
+            "dlx",
+            "--shell-mode",
+            "-p",
+            "uuid",
+            "node -p process.env.npm_config_user_agent",
+        ],
+    );
+    assert_eq!(
+        out.code, 0,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    assert!(
+        out.stdout.contains("nub/"),
+        "dlx child must see a nub-first user agent, got: {}",
+        out.stdout
+    );
+}
+
 /// The yarn write gate on the mutating daily drivers: a yarn project refuses
 /// add/remove/update/dedupe outright (no network — the gate is a pre-flight),
 /// yarn.lock stays byte-identical, and `dedupe --check` is still allowed

--- a/vendor/aube/crates/aube/src/runtime.rs
+++ b/vendor/aube/crates/aube/src/runtime.rs
@@ -219,8 +219,17 @@ pub fn path_entries() -> Vec<PathBuf> {
     .collect()
 }
 
-/// Set the npm-compat env vars naming the node binary on a child
-/// command (`npm_node_execpath`, and `NODE` which npm also exports).
+/// Set the npm-compat env vars on a child command: `npm_node_execpath` (and
+/// `NODE`, which npm also exports) naming the node binary, and
+/// `npm_config_user_agent` naming the running PM.
+///
+/// The UA is pnpm parity for the dlx/exec bin paths (the four callers of this
+/// fn): pnpm exports `npm_config_user_agent` to `pnpm dlx` / `pnpm create` /
+/// `pnpm exec` children exactly as it does to lifecycle scripts, and create-*
+/// scaffolders sniff it to emit the invoking PM's commands — without it they
+/// fall back to npm-mode. Same product/format as the lifecycle export
+/// ([`aube_scripts::aube_user_agent`]), so a tool sees one UA whether it ran
+/// as a postinstall or under dlx.
 ///
 /// Prefers the switched runtime's node; then the embedder-provisioned node
 /// ([`EngineContext::runtime_node_bin`]) when an embedder owns provisioning —
@@ -231,6 +240,7 @@ pub fn path_entries() -> Vec<PathBuf> {
 ///
 /// [`EngineContext::runtime_node_bin`]: aube_util::EngineContext::runtime_node_bin
 pub fn apply_child_env(cmd: &mut tokio::process::Command) {
+    cmd.env("npm_config_user_agent", aube_scripts::aube_user_agent());
     let node_bin = resolve_node_bin(
         current().and_then(|ctx| ctx.node_bin.clone()),
         aube_util::engine_context().runtime_node_bin,


### PR DESCRIPTION
dlx/exec child spawns set `npm_node_execpath` but never `npm_config_user_agent`, so create-* scaffolders under `nub create` fell back to npm-mode output. pnpm exports the UA to these children as it does to lifecycle scripts. `runtime::apply_child_env` now exports the role-aware UA; `nub create vue` prints `nub install` / `nub run dev`. Regression test on the dlx path.

https://claude.ai/code/session_01XeVYy7YT1M3wrVzrwwirbS