### PR TITLE
fix(pm): key the GVS engine fingerprint off the project's Node, not the shell's

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1385,18 +1385,31 @@ fn augmentation_to_lifecycle_overlay(
 /// Install nub's runtime augmentation onto the engine's lifecycle-script spawn
 /// env (via aube's generic [`aube::set_script_settings`] overlay), so dependency
 /// build scripts run under the project's provisioned + augmented Node — the same
-/// env `nub run` / `nub exec` give scripts. No-op (overlay stays default-empty,
-/// behavior preserved) when augmentation can't be computed (compat / re-entrant
-/// / broken install). Called once per command from [`engine_session`].
+/// env `nub run` / `nub exec` give scripts. The overlay stays default-empty
+/// (behavior preserved) when augmentation can't be computed (compat /
+/// re-entrant / broken install); the resolved Node *version* is published to the
+/// engine either way. Called once per command from [`engine_session`].
 fn apply_lifecycle_augmentation(cwd: &Path) {
-    let Ok(nub_binary) = nub_core::node::spawn::current_nub_binary() else {
-        return;
-    };
     // The project's Node — pin-aware (`.nvmrc`/`.node-version`/`engines`), NOT
     // the ambient PATH node. This resolved version drives flag injection and its
     // path pins npm_node_execpath. Mirrors build_script_command's discovery.
-    let node = nub_core::node::discovery::discover_node(cwd)
-        .unwrap_or_else(|_| nub_core::node::discovery::ResolvedNode::fallback());
+    let discovered = nub_core::node::discovery::discover_node(cwd);
+    // Published ABOVE the early returns: the engine keys its GVS virtual-store
+    // paths — and validates `engines.node` — off this version, so it has to name
+    // the Node dependency build scripts actually compile against. That stays the
+    // project's pin under `--node` / NODE_COMPAT, which disable augmentation but
+    // not version provisioning. Otherwise aube probes the ambient PATH node and
+    // two majors silently share one store entry. Deliberately left unset when
+    // discovery FAILS: build scripts then fall back to a bare `node`, so the
+    // PATH probe is the honest answer and a fabricated version would not be.
+    if let Ok(node) = &discovered {
+        let version = node.version.to_string();
+        aube_util::update_engine_context(|c| c.runtime_node_version = Some(version));
+    }
+    let Ok(nub_binary) = nub_core::node::spawn::current_nub_binary() else {
+        return;
+    };
+    let node = discovered.unwrap_or_else(|_| nub_core::node::discovery::ResolvedNode::fallback());
     let pnp_ctx = nub_core::pnp::detect(cwd);
     let Some(aug) = nub_core::node::spawn::compute_augmentation_env(
         &nub_binary,

--- a/vendor/aube/crates/aube-util/src/engine_context.rs
+++ b/vendor/aube/crates/aube-util/src/engine_context.rs
@@ -261,6 +261,22 @@ pub struct EngineContext {
     /// (default) keeps the ambient-`node` fallback — upstream behavior.
     pub runtime_node_bin: Option<PathBuf>,
 
+    /// The version of that node, bare (`22.15.0`, no `v`). Same provenance as
+    /// [`runtime_node_bin`](Self::runtime_node_bin) — an embedder that owns Node
+    /// provisioning already holds it, so aube neither probes nor re-derives it.
+    /// `engines::effective_node_version` consults this at the resolver's tier:
+    /// below an explicit `node-version` `.npmrc` override (pnpm's
+    /// validation-only knob), above the ambient `node --version` PATH probe.
+    ///
+    /// Load-bearing beyond the `engines.node` check: this version's major is the
+    /// GVS engine fingerprint (`<os>-<arch>-node<major>`) folded into the
+    /// virtual-store path of every subtree containing a build-allowed package.
+    /// Under `runtime_switching = false` the resolver is inert, so without this
+    /// the fingerprint would record the ambient shell node while lifecycle
+    /// scripts compiled against the embedder's — two majors sharing one store
+    /// entry. `None` (default) keeps the PATH probe — upstream behavior.
+    pub runtime_node_version: Option<String>,
+
     /// Replacement lifecycle `npm_config_user_agent` product token. `None`
     /// (default) falls back to the compile-time [`Embedder::user_agent`] —
     /// standalone aube reports `aube/<version>`. An embedder sets `Some` when
@@ -366,6 +382,7 @@ impl Default for EngineContext {
             env_overlay: Vec::new(),
             runtime_node_dir: None,
             runtime_node_bin: None,
+            runtime_node_version: None,
             lifecycle_user_agent_product: None,
             npm_save_prefix_on_bare_exact: false,
             named_registries_enabled: false,
@@ -436,6 +453,7 @@ mod tests {
         assert!(ctx.env_overlay.is_empty());
         assert_eq!(ctx.runtime_node_dir, None);
         assert_eq!(ctx.runtime_node_bin, None);
+        assert_eq!(ctx.runtime_node_version, None);
         assert_eq!(ctx.lifecycle_user_agent_product, None);
         assert!(!ctx.npm_save_prefix_on_bare_exact);
         assert!(!ctx.named_registries_enabled);

--- a/vendor/aube/crates/aube/src/engines.rs
+++ b/vendor/aube/crates/aube/src/engines.rs
@@ -95,7 +95,16 @@ pub fn resolve_node_version(override_: Option<&str>) -> Option<String> {
 /// 2. otherwise the resolved runtime context's version — engines must
 ///    validate the node scripts will actually run on, not whatever
 ///    PATH happened to carry;
-/// 3. otherwise the memoized `node --version` probe.
+/// 3. otherwise the version an embedder provisioned
+///    ([`EngineContext::runtime_node_version`]) — the same rule as (2)
+///    for a host that owns provisioning itself and so leaves the
+///    resolver inert;
+/// 4. otherwise the memoized `node --version` probe.
+///
+/// Also the source of the GVS engine fingerprint, so a wrong answer
+/// here mis-keys virtual-store paths, not just the warning text.
+///
+/// [`EngineContext::runtime_node_version`]: aube_util::EngineContext::runtime_node_version
 pub fn effective_node_version(override_: Option<&str>) -> Option<String> {
     if override_.is_some() {
         return resolve_node_version(override_);
@@ -104,6 +113,9 @@ pub fn effective_node_version(override_: Option<&str>) -> Option<String> {
         && let Some(v) = &rt.version
     {
         return Some(v.clone());
+    }
+    if let Some(v) = aube_util::engine_context().runtime_node_version {
+        return Some(v);
     }
     resolve_node_version(None)
 }
@@ -784,6 +796,28 @@ mod tests {
             result.is_err(),
             "permission-denied read must propagate, got {result:?}"
         );
+    }
+
+    #[test]
+    fn embedder_node_version_outranks_probe_but_not_override() {
+        // An embedder that owns Node provisioning leaves aube's resolver inert,
+        // so without this tier `effective_node_version` falls to the ambient
+        // PATH probe — and the GVS engine fingerprint keyed off it then names a
+        // different node than the one lifecycle scripts build against. The
+        // `.npmrc` `node-version` knob still outranks it (pnpm semantics).
+        let prev = aube_util::engine_context().runtime_node_version;
+        aube_util::update_engine_context(|c| c.runtime_node_version = Some("18.19.0".into()));
+        assert_eq!(
+            effective_node_version(None).as_deref(),
+            Some("18.19.0"),
+            "the embedder's provisioned version must win over the PATH probe"
+        );
+        assert_eq!(
+            effective_node_version(Some("v20.11.0")).as_deref(),
+            Some("20.11.0"),
+            "an explicit `node-version` override must still win"
+        );
+        aube_util::update_engine_context(|c| c.runtime_node_version = prev);
     }
 
     #[test]


### PR DESCRIPTION
## The bug

nub's embedder profile sets `runtime_switching: false` — nub owns Node provisioning, so aube's runtime resolver stays inert and `runtime::current()` carries no version. `engines::effective_node_version` then fell through to its ambient `node --version` PATH probe, and that version's **major** is what `engine_name_default` folds into the GVS (global virtual store) subdir hash of every subtree containing a build-allowed package.

Meanwhile lifecycle scripts already run under the project's **pinned** Node: `apply_lifecycle_augmentation` resolves it via `discover_node` (pin-aware — `.nvmrc` / `.node-version` / `engines`) and pins `npm_node_execpath` to it. So dependency build scripts compiled against the project's Node while the store key recorded the developer's shell Node — two majors could share one virtual-store entry, and the same project rehashed whenever the shell Node changed.

## Empirical reproduction

One pinned project (`.nvmrc` → `22.15.0`, one dependency with a build script), installed twice with two different ambient shell Node majors on PATH.

```
# before (main): the GVS subdir hash tracks the SHELL node, not the pin
ambient node v22.15.0  → node_modules/.store/core-js@3.39.0 -> …/store/core-js@3.39.0-e481e56a79d379fc
ambient node v26.5.0   → node_modules/.store/core-js@3.39.0 -> …/store/core-js@3.39.0-b9c157bb9ee7a614   # ❌ different entry, same pin
lockfile sha256: 0d2735… (identical across both)

# after: the hash tracks the project's pinned node, stable across shells
ambient node v22.15.0  → …/store/core-js@3.39.0-e481e56a79d379fc
ambient node v26.5.0   → …/store/core-js@3.39.0-e481e56a79d379fc   # ✓ same entry
lockfile sha256: 0d2735… (unchanged)
```

The lockfile bytes are identical in every arm, before and after: `graph_identity_hash` is deliberately engine-agnostic (`engine: None`), so the engine taint never reaches the recorded lockfile identity.

## The fix

Carry the resolved version across the existing per-invocation embedder seam. A new `EngineContext::runtime_node_version: Option<String>` is set beside `runtime_node_bin` from the same `discover_node` call, and consulted by `effective_node_version` at the resolver's tier: below an explicit `.npmrc` `node-version` override (pnpm's validation-only knob keeps winning), above the PATH probe.

The version is published **above** `apply_lifecycle_augmentation`'s early returns, since `--node` / `NODE_COMPAT` disable augmentation but not version provisioning — the store key should still reflect the project's pinned Node in compat mode. It is left unset when discovery itself fails, so the PATH probe still answers for the bare `node` those scripts would fall back to.

This also corrects the `engines.node` check, which aube's own doc comment says must validate the Node scripts will actually run on, not whatever PATH happened to carry. The check is warn-only unless the project sets `engine-strict`.

### Why not `seed_embedder_node`

The v1.32 sync added `runtime::seed_embedder_node`, but it is the wrong mechanism here: it fabricates a full `RuntimeContext` whose provenance is hardcoded `Mise` (so `nub doctor` would report the Node as "provided by mise"), derives `node_bin` from a single bin dir when nub's shim dir and provisioned node are different paths, re-spawns `node --version` though nub already holds the version, and only reaches `install` / `ci`. The `EngineContext` seam runs once per command from `engine_session`, so it covers every engine-routed verb, and it carries the version nub already resolved.

## Invalidation cost

One-time, and cheap: a **re-link** of the affected subtrees. No re-download, and no re-run of build scripts. The content-addressable store is keyed by integrity, so the package bytes are already present and the subtree re-materializes under the corrected hash from the CAS; the side-effects cache is keyed independently of the engine name, so previously-built outputs are restored rather than rebuilt. Verified against an isolated cache: after flipping the engine and clearing `node_modules`, `nub install --offline` exits 0 with `side-effects-cache: restored` in the log, and the CAS is unchanged in size.

## Fork discipline

Default-preserving for standalone aube: `runtime_node_version` defaults to `None`, the new tier is skipped, and every existing aube path is byte-for-byte unchanged (the `default_is_upstream_neutral` test carries the new field).

## Relationship to the v1.32 aube sync (#519)

The bug persists unchanged after the v1.32 sync — `seed_embedder_node` arriving upstream does not fix it unless nub opts in — so this is not made redundant by #519. `effective_node_version` and the two touched `EngineContext` neighbors are byte-identical on both branches, so this merges cleanly with #519 in either landing order.

## Tests

`engines.rs` gains one unit test pinning the contract: with `runtime_node_version` set, `effective_node_version` returns it rather than the PATH probe, and the explicit `.npmrc` override still outranks it. The existing upstream-neutrality assertion is extended to cover the new field.

