### PR TITLE
fix(pm): strip time: from the catch-up integrity-rewrite lockfile

### DIFF
--- a/vendor/aube/crates/aube/src/commands/install/lockfile_dir.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lockfile_dir.rs
@@ -116,3 +116,37 @@ pub(super) fn write_lockfile_dir_remapped(
     remapped.importers.insert(importer_key.to_string(), deps);
     aube_lockfile::write_lockfile_as(lockfile_dir, &remapped, manifest, kind)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::lockfile_graph_for_write;
+    use std::borrow::Cow;
+
+    /// The resolver keeps publish times in `graph.times` whenever
+    /// minimumReleaseAge / trustPolicy / the defaultTrust floor is active,
+    /// but pnpm serializes a `time:` block only under time-based
+    /// resolution. Every lockfile write — the main write and the catch-up
+    /// integrity rewrite — routes through this helper, so pinning its two
+    /// branches guards the #520 parity leak (the rewrite path once wrote
+    /// its own un-stripped clone, re-introducing `time:` on a
+    /// non-time-based lockfile).
+    #[test]
+    fn strips_times_only_when_not_persisting() {
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph
+            .times
+            .insert("foo@1.0.0".into(), "2020-01-01T00:00:00.000Z".into());
+
+        // Non-time-based: the writer's view is `time:`-free, and the strip
+        // is on a clone — the shared graph keeps its times for the floor.
+        let stripped = lockfile_graph_for_write(&graph, false);
+        assert!(stripped.times.is_empty());
+        assert!(matches!(stripped, Cow::Owned(_)));
+        assert!(!graph.times.is_empty());
+
+        // Time-based: times persist, no clone made.
+        let kept = lockfile_graph_for_write(&graph, true);
+        assert_eq!(kept.times.len(), 1);
+        assert!(matches!(kept, Cow::Borrowed(_)));
+    }
+}

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -2475,6 +2475,18 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             // default `aube-lock.yaml`. Skipped entirely when
             // `lockfile=false`.
             let write_kind = source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube);
+            // pnpm persists a top-level `time:` block only under
+            // `resolution-mode=time-based`; every other mode writes a
+            // `time:`-free lockfile even when the resolver kept publish
+            // times in memory (minimumReleaseAge / trustPolicy / the
+            // defaultTrust floor). Decided once here so EVERY lockfile
+            // write below — the main overlapped/inline write and the
+            // catch-up integrity rewrite alike — routes its graph through
+            // `lockfile_graph_for_write(_, persist_times)` and cannot
+            // diverge on the `time:` axis (the integrity rewrite once
+            // wrote its own un-stripped clone, re-introducing `time:`).
+            let persist_times = settings::resolve_resolution_mode(&settings_ctx)
+                == aube_resolver::ResolutionMode::TimeBased;
             if lockfile_enabled {
                 // When `lockfileIncludeTarballUrl=true`, record the
                 // registry tarball URL on every registry-sourced
@@ -2539,18 +2551,12 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 // snapshot metadata (`optional: true`, `transitivePeerDependencies`)
                 // before the write and before the host-only `filter_graph` below.
                 crate::commands::prepare_resolved_graph_for_lockfile_write(&mut graph);
-                // pnpm persists a top-level `time:` block only under
-                // `resolution-mode=time-based`; in every other mode the
-                // lockfile stays `time:`-free even when the resolver kept
-                // publish times in memory for `minimumReleaseAge` /
-                // `trustPolicy` / the `defaultTrust` floor. Strip them on
-                // the writer's view (a clone) WITHOUT mutating the shared
-                // `graph` — the floor clones `graph` further down and
-                // still needs `graph.times`. Both write paths below
-                // consume this same view, so the overlapped write and the
-                // killswitch write stay byte-identical to each other.
-                let persist_times = settings::resolve_resolution_mode(&settings_ctx)
-                    == aube_resolver::ResolutionMode::TimeBased;
+                // Strip `time:` on the writer's view (a clone) WITHOUT
+                // mutating the shared `graph` — the `defaultTrust` floor
+                // clones `graph` further down and still needs
+                // `graph.times`. Both write paths below consume this same
+                // view, so the overlapped write and the killswitch write
+                // stay byte-identical to each other.
                 let write_graph = lockfile_dir::lockfile_graph_for_write(&graph, persist_times);
                 // The serialize + reformat + atomic write is the slowest
                 // serial span before the linker (10-55 ms on large trees).
@@ -2716,11 +2722,17 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                         if let Some(handle) = lockfile_write_handle.take() {
                             lockfile_write_overlap::join(handle).await?;
                         }
+                        // Same `time:`-strip the main write applied: this
+                        // rewrite overwrites that output, so it must honor
+                        // `persist_times` identically or it re-introduces a
+                        // `time:` block on non-time-based lockfiles.
+                        let lock_write_graph =
+                            lockfile_dir::lockfile_graph_for_write(lock_graph, persist_times);
                         if shared_workspace_lockfile || !has_workspace {
                             write_lockfile_dir_remapped(
                                 &lockfile_dir,
                                 &lockfile_importer_key,
-                                lock_graph,
+                                &lock_write_graph,
                                 &manifest,
                                 write_kind,
                             )
@@ -2729,7 +2741,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                         } else {
                             write_per_project_lockfiles(
                                 &cwd,
-                                lock_graph,
+                                &lock_write_graph,
                                 &manifests,
                                 write_kind,
                                 per_project_write_selection.as_ref(),


### PR DESCRIPTION
The catch-up integrity rewrite built its write graph from a clone of the resolved graph taken *after* the main write, so it still carried `graph.times` and re-emitted a top-level `time:` block. pnpm persists `time:` only under `resolution-mode=time-based`, so on that path a non-time-based lockfile got a `time:` block the main write had already stripped — a pnpm-parity leak.

## Fix

Route the rewrite through `lockfile_graph_for_write` with the same `persist_times` decision the main write uses, hoisted to one source of truth so the two writes cannot diverge on the `time:` axis. The `--lockfile-only` path already routed through the same helper; this was the last write site that bypassed it.

## Verified

- `cargo test -p aube-lockfile --lib` and `cargo test --workspace --lib` green; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- New unit test pins both branches of the strip helper: a times-carrying graph serializes `time:`-free when not persisting and keeps it under time-based.

The full end-to-end trigger — a required (non-optional) package with a host-mismatched `os`/`cpu` plus a times-populating setting like `minimumReleaseAge` — needs a mock registry the hermetic harness lacks, so the guard sits at the write-graph level.

Closes #520
