### PR TITLE
fix(pm): approve-builds surfaces and approves local-source deps

### DIFF
--- a/vendor/aube/crates/aube/src/commands/approve_builds.rs
+++ b/vendor/aube/crates/aube/src/commands/approve_builds.rs
@@ -92,14 +92,26 @@ fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<V
         return Ok(Vec::new());
     }
 
+    // A source-backed package (`file:`/tarball/git/…) is authorized by its
+    // source key, never its bare name, so the `allowBuilds` write must use
+    // `approval_key`. The follow-up rebuild instead matches deps by graph
+    // `name` (pnpm's `rebuild <name>` contract), so the two lists diverge
+    // for source-backed deps and must be threaded separately.
+    let entries = selected_entries(&ignored, &selected);
+    let approval_keys = dedupe(entries.iter().map(|e| e.approval_key.clone()).collect());
+    let display = entries
+        .iter()
+        .map(|e| e.display_spec())
+        .collect::<Vec<_>>()
+        .join(", ");
+
     // The picker only toggles names; scripts running is a separate
     // consent. pnpm gates the interactive path behind the same
     // default-No confirmation (`--all` and positional approvals are
     // themselves the explicit consent, so they build straight away).
     if interactive {
         let confirmed = demand::Confirm::new(format!(
-            "The next packages will now be built: {}. Do you approve?",
-            selected.join(", ")
+            "The next packages will now be built: {display}. Do you approve?"
         ))
         .selected(false)
         .run()
@@ -110,7 +122,7 @@ fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<V
         }
     }
 
-    let written = aube_manifest::workspace::add_to_allow_builds(cwd, &selected)
+    let written = aube_manifest::workspace::add_to_allow_builds(cwd, &approval_keys)
         .into_diagnostic()
         .wrap_err("failed to update workspace yaml")?;
 
@@ -118,11 +130,27 @@ fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<V
         .strip_prefix(cwd)
         .unwrap_or(written.as_path())
         .display();
-    println!("Approved {} package(s) in {rel}:", selected.len());
-    for name in &selected {
-        println!("  {name}");
+    println!("Approved {} package(s) in {rel}:", approval_keys.len());
+    for entry in &entries {
+        println!("  {}", entry.display_spec());
     }
     Ok(selected)
+}
+
+/// The `IgnoredEntry`s whose bare `name` the caller selected, preserving
+/// `ignored`'s sorted order. Bridges the name-keyed selection surface
+/// (picker values, positional args, `--all`) to the entries' richer
+/// identity — `approval_key` for the `allowBuilds` write and
+/// `display_spec` for user-facing output.
+fn selected_entries<'a>(
+    ignored: &'a [super::ignored_builds::IgnoredEntry],
+    selected: &[String],
+) -> Vec<&'a super::ignored_builds::IgnoredEntry> {
+    let want: HashSet<&str> = selected.iter().map(String::as_str).collect();
+    ignored
+        .iter()
+        .filter(|e| want.contains(e.name.as_str()))
+        .collect()
 }
 
 fn run_global(args: ApproveBuildsArgs) -> miette::Result<()> {
@@ -143,7 +171,11 @@ fn run_global(args: ApproveBuildsArgs) -> miette::Result<()> {
             .map(|entry| {
                 (
                     entry.install_dir.clone(),
-                    entry.ignored.iter().map(|i| i.name.clone()).collect(),
+                    entry
+                        .ignored
+                        .iter()
+                        .map(|i| i.approval_key.clone())
+                        .collect(),
                 )
             })
             .collect()
@@ -163,19 +195,19 @@ fn run_global(args: ApproveBuildsArgs) -> miette::Result<()> {
 
     let mut approved = 0usize;
     let mut written_dirs = 0usize;
-    for (install_dir, names) in selected {
-        let written = aube_manifest::workspace::add_to_allow_builds(&install_dir, &names)
+    for (install_dir, approval_keys) in selected {
+        let written = aube_manifest::workspace::add_to_allow_builds(&install_dir, &approval_keys)
             .into_diagnostic()
             .wrap_err("failed to update global install workspace yaml")?;
         written_dirs += 1;
-        approved += names.len();
+        approved += approval_keys.len();
         println!(
             "Approved {} package(s) in {}:",
-            names.len(),
+            approval_keys.len(),
             written.display()
         );
-        for name in &names {
-            println!("  {name}");
+        for key in &approval_keys {
+            println!("  {key}");
         }
     }
 
@@ -277,14 +309,17 @@ fn select_global_packages(
     let wanted: HashSet<&str> = wanted.iter().map(String::as_str).collect();
     let mut selected = BTreeMap::new();
     for entry in global_ignored {
-        let names: Vec<String> = entry
+        // Match on the user-typed bare `name`, but record the
+        // `approval_key` — the source key authorizes a source-backed
+        // build; the bare name would be silently ignored by the policy.
+        let keys: Vec<String> = entry
             .ignored
             .iter()
             .filter(|ignored| wanted.contains(ignored.name.as_str()))
-            .map(|ignored| ignored.name.clone())
+            .map(|ignored| ignored.approval_key.clone())
             .collect();
-        if !names.is_empty() {
-            selected.insert(entry.install_dir.clone(), names);
+        if !keys.is_empty() {
+            selected.insert(entry.install_dir.clone(), keys);
         }
     }
     Ok(selected)
@@ -317,7 +352,7 @@ fn pick_interactively(
         .description("Space to toggle, Enter to confirm")
         .min(1);
     for entry in ignored {
-        let label = format_picker_label(&entry.name, &entry.version, &entry.suspicions);
+        let label = format_picker_label(&entry.display_spec(), &entry.suspicions);
         picker = picker.option(demand::DemandOption::new(entry.name.clone()).label(&label));
     }
     picker
@@ -326,25 +361,21 @@ fn pick_interactively(
         .wrap_err("failed to read approve-builds selection")
 }
 
-/// `name@version` plus a compact suspicious-shape tag when the
+/// The entry's display spec plus a compact suspicious-shape tag when the
 /// content-sniff fired against any of the package's lifecycle
 /// scripts. One picker row is narrow, so only the first match's
 /// category gets a tag; `+N more` follows when more than one
 /// matched. The full breakdown lives in `print_suspicion_summary`.
-fn format_picker_label(
-    name: &str,
-    version: &str,
-    suspicions: &[aube_scripts::Suspicion],
-) -> String {
+fn format_picker_label(spec: &str, suspicions: &[aube_scripts::Suspicion]) -> String {
     if suspicions.is_empty() {
-        return format!("{name}@{version}");
+        return spec.to_string();
     }
     let first = suspicions[0].kind.category();
     let extra = suspicions.len() - 1;
     if extra == 0 {
-        format!("{name}@{version}  ⚠ suspicious: {first}")
+        format!("{spec}  ⚠ suspicious: {first}")
     } else {
-        format!("{name}@{version}  ⚠ suspicious: {first} +{extra} more")
+        format!("{spec}  ⚠ suspicious: {first} +{extra} more")
     }
 }
 
@@ -389,10 +420,14 @@ fn pick_global_interactively(
     for (idx, entry) in global_ignored.iter().enumerate() {
         let aliases = entry.aliases.join(", ");
         for ignored in &entry.ignored {
-            // split_once below keeps the full package name even if a
-            // private registry allows ':' inside it.
-            let value = format!("{idx}:{}", ignored.name);
-            let base = format_picker_label(&ignored.name, &ignored.version, &ignored.suspicions);
+            // `split_once(':')` below splits on the FIRST colon, so `idx`
+            // (digits only) is cleanly separated even when the payload
+            // `approval_key` itself carries colons (a `name@file:…`
+            // source key). Recording the approval_key — not the bare
+            // name — is what lets a source-backed global build be
+            // authorized rather than silently ignored by the policy.
+            let value = format!("{idx}:{}", ignored.approval_key);
+            let base = format_picker_label(&ignored.display_spec(), &ignored.suspicions);
             let label = format!("{aliases}: {base}");
             picker = picker.option(demand::DemandOption::new(value).label(&label));
         }
@@ -404,7 +439,7 @@ fn pick_global_interactively(
         .wrap_err("failed to read approve-builds selection")?;
     let mut selected: BTreeMap<std::path::PathBuf, Vec<String>> = BTreeMap::new();
     for item in picked {
-        let Some((idx, name)) = item.split_once(':') else {
+        let Some((idx, approval_key)) = item.split_once(':') else {
             continue;
         };
         let Ok(idx) = idx.parse::<usize>() else {
@@ -416,7 +451,7 @@ fn pick_global_interactively(
         selected
             .entry(entry.install_dir.clone())
             .or_default()
-            .push(name.to_string());
+            .push(approval_key.to_string());
     }
     Ok(selected)
 }
@@ -428,10 +463,7 @@ mod tests {
 
     #[test]
     fn label_for_clean_package_is_bare_spec() {
-        assert_eq!(
-            format_picker_label("esbuild", "0.20.2", &[]),
-            "esbuild@0.20.2"
-        );
+        assert_eq!(format_picker_label("esbuild@0.20.2", &[]), "esbuild@0.20.2");
     }
 
     #[test]
@@ -441,7 +473,7 @@ mod tests {
             hook: "postinstall",
         }];
         assert_eq!(
-            format_picker_label("lodash", "1.0.0", &s),
+            format_picker_label("lodash@1.0.0", &s),
             "lodash@1.0.0  ⚠ suspicious: curl|sh"
         );
     }
@@ -463,8 +495,13 @@ mod tests {
             },
         ];
         assert_eq!(
-            format_picker_label("evil-pkg", "9.9.9", &s),
+            format_picker_label("evil-pkg@9.9.9", &s),
             "evil-pkg@9.9.9  ⚠ suspicious: curl|sh +2 more"
         );
+    }
+
+    #[test]
+    fn label_for_source_backed_package_uses_source_key() {
+        assert_eq!(format_picker_label("dep@file:./dep", &[]), "dep@file:./dep");
     }
 }

--- a/vendor/aube/crates/aube/src/commands/ignored_builds.rs
+++ b/vendor/aube/crates/aube/src/commands/ignored_builds.rs
@@ -1,13 +1,18 @@
 //! `aube ignored-builds` — print packages whose lifecycle scripts were
 //! skipped by the `pnpm.allowBuilds` allowlist.
 //!
-//! Walks the lockfile, reads each dep's stored `package.json` from the
-//! global store, and reports any package that declares a
+//! Walks the lockfile and reports any package that declares a
 //! `preinstall` / `install` / `postinstall` script but isn't explicitly
-//! allowed by the current `BuildPolicy`. Shared with `approve-builds`,
-//! which re-uses [`collect_ignored`] to drive its interactive picker.
+//! allowed by the current `BuildPolicy`. Registry packages are classified
+//! from their stored `package.json` in the global store; source-backed
+//! (`file:`/tarball/git/…) packages, which have no store index, are taken
+//! from the install-recorded unreviewed set instead (see [`collect_ignored`]).
+//! Shared with `approve-builds`, which re-uses `collect_ignored` to drive
+//! its interactive picker.
 //!
-//! Pure read — no network, no writes, no project lock.
+//! A pure read of project state — no network, no project-file writes, no
+//! project lock (the install-state read may lazily migrate its own
+//! on-disk format, an internal, idempotent housekeeping write).
 
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
@@ -60,7 +65,7 @@ pub async fn run(args: IgnoredBuildsArgs) -> miette::Result<()> {
 /// followed by `<indent>  ⚠ <hook>: <description>` lines for each
 /// content-sniff match against the package's lifecycle scripts.
 fn print_entry_line(indent: &str, entry: &IgnoredEntry) {
-    println!("{indent}{}@{}", entry.name, entry.version);
+    println!("{indent}{}", entry.display_spec());
     for sus in &entry.suspicions {
         println!("{indent}  ⚠ {} — {}", sus.hook, sus.kind.description());
     }
@@ -103,17 +108,21 @@ fn run_global() -> miette::Result<()> {
 
 /// One package whose lifecycle scripts were skipped because it was not
 /// allowed by the current `BuildPolicy`. `name` is the pnpm package name,
-/// `version` is the resolved version from the lockfile. `suspicions`
-/// is the result of running the content-sniff against the stored
-/// manifest's lifecycle script bodies — empty when the scripts look
-/// clean, populated when one or more dangerous-shape heuristics
-/// fired. Used by the `approve-builds` picker to flag suspicious
-/// entries so the user has more than `name@version` to judge by.
+/// `version` is the resolved version from the lockfile. `approval_key` is
+/// the `allowBuilds` entry that authorizes the build: the bare package
+/// name for registry packages, but the source key (`name@file:…`,
+/// `name@<git-url>#<sha>`, …) for source-backed packages, which a bare
+/// name must never approve. `suspicions` is the result of running the
+/// content-sniff against the stored manifest's lifecycle script bodies —
+/// empty when the scripts look clean, populated when one or more
+/// dangerous-shape heuristics fired. Used by the `approve-builds` picker
+/// to flag suspicious entries so the user has more than `name@version` to
+/// judge by.
 ///
 /// Field order matters: derived `Ord` compares by declaration
 /// order, so `(name, version)` orders identically to the prior
 /// manual impl. `collect_ignored` already deduplicates on
-/// `(name, version)`, so the `suspicions` tiebreak is unreachable
+/// `(name, version)`, so the tiebreak fields are unreachable
 /// in practice — keeping the derived shape avoids the
 /// `Eq`/`Ord` inconsistency that an explicit Ord-on-prefix impl
 /// would introduce.
@@ -121,7 +130,30 @@ fn run_global() -> miette::Result<()> {
 pub(super) struct IgnoredEntry {
     pub name: String,
     pub version: String,
+    pub approval_key: String,
     pub suspicions: Vec<aube_scripts::Suspicion>,
+}
+
+impl IgnoredEntry {
+    /// Whether this entry must be approved by its source key rather than
+    /// its bare name — true for `file:`/tarball/git/… packages, where
+    /// `approval_key` carries the source identity instead of the name.
+    pub(super) fn is_source_backed(&self) -> bool {
+        self.approval_key != self.name
+    }
+
+    /// The `name@…` spec to show the user. Registry packages read as
+    /// `name@version`; source-backed packages read as their source key
+    /// (`name@file:./dep`), matching the install-time warning and pnpm's
+    /// `ignored-builds` output so the displayed identity is exactly what
+    /// gets written to `allowBuilds`.
+    pub(super) fn display_spec(&self) -> String {
+        if self.is_source_backed() {
+            self.approval_key.clone()
+        } else {
+            format!("{}@{}", self.name, self.version)
+        }
+    }
 }
 
 /// Load the lockfile and build policy for `project_dir`, then return the
@@ -154,6 +186,20 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
     let no_integrity_index =
         crate::state::read_no_integrity_index_for(project_dir, graph.packages.values());
 
+    // Source-backed (`file:`/tarball/git/…) packages have no
+    // `(name, version)`-keyed store index — their content is imported by
+    // dep_path, not a registry integrity — so the store read below always
+    // misses for them and they'd be silently dropped (the `approve-builds`
+    // dead-end this closes). The install already decided which have
+    // unreviewed builds and recorded their source approval keys in install
+    // state; this is the same set the `WARN_..._IGNORED_BUILD_SCRIPTS`
+    // warning enumerates via `unreviewed_dep_builds`, so keying off it here
+    // makes the warning and this command agree by construction.
+    let recorded_source_builds: BTreeSet<String> =
+        crate::state::read_state_unreviewed_builds(project_dir)
+            .into_iter()
+            .collect();
+
     let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
     let mut out: Vec<IgnoredEntry> = Vec::new();
 
@@ -167,19 +213,36 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
         if !seen.insert((pkg.name.clone(), pkg.version.clone())) {
             continue;
         }
-        let read_key = pkg.integrity.as_deref().or_else(|| {
-            no_integrity_index
-                .get(&format!("{}@{}", pkg.registry_name(), pkg.version))
-                .map(String::as_str)
-        });
-        let Some(suspicions) =
-            lifecycle_scripts_with_suspicions(&store, &pkg.name, &pkg.version, read_key)
-        else {
-            continue;
+        // A source-backed dep is authorized by its source key, not its bare
+        // name, so surface it under that key. Suspicions stay empty: the
+        // content-sniff ran at install time and the warning already
+        // surfaced any findings; re-deriving them would mean re-reading each
+        // dep's materialized manifest, which this pure lockfile read avoids.
+        // A stale recorded set is self-correcting — the policy check above
+        // drops an already-approved dep before it reaches here.
+        let (approval_key, suspicions) = match pkg.source_approval_key() {
+            Some(source_key) if recorded_source_builds.contains(&source_key) => {
+                (source_key, Vec::new())
+            }
+            Some(_) => continue,
+            None => {
+                let read_key = pkg.integrity.as_deref().or_else(|| {
+                    no_integrity_index
+                        .get(&format!("{}@{}", pkg.registry_name(), pkg.version))
+                        .map(String::as_str)
+                });
+                let Some(suspicions) =
+                    lifecycle_scripts_with_suspicions(&store, &pkg.name, &pkg.version, read_key)
+                else {
+                    continue;
+                };
+                (pkg.name.clone(), suspicions)
+            }
         };
         out.push(IgnoredEntry {
             name: pkg.name.clone(),
             version: pkg.version.clone(),
+            approval_key,
             suspicions,
         });
     }

--- a/vendor/aube/crates/aube/tests/e2e.rs
+++ b/vendor/aube/crates/aube/tests/e2e.rs
@@ -60,6 +60,36 @@ impl Sandbox {
     fn write_manifest(&self, contents: &str) {
         fs::write(self.project.join("package.json"), contents).unwrap();
     }
+
+    fn write_file(&self, rel: &str, contents: &str) {
+        let path = self.project.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+}
+
+/// Whether any file named `marker` exists anywhere under `dir`. Used to
+/// find a lifecycle script's output without hard-coding the hashed
+/// virtual-store path it lands in.
+fn marker_exists_under(dir: &std::path::Path, marker: &str) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if file_type.is_dir() {
+            if marker_exists_under(&path, marker) {
+                return true;
+            }
+        } else if entry.file_name() == marker {
+            return true;
+        }
+    }
+    false
 }
 
 fn e2e_lock() -> MutexGuard<'static, ()> {
@@ -192,4 +222,80 @@ fn run_failing_pre_script_short_circuits_with_its_code() {
         .assert()
         .code(5)
         .stdout(predicates::str::contains("MAIN_RAN").not());
+}
+
+#[test]
+fn approve_builds_surfaces_and_runs_a_local_source_dep() {
+    // Regression for the `file:`-dep approve-builds dead-end: install
+    // warns about a local-source dependency's build script, but
+    // `ignored-builds` / `approve-builds` then reported nothing to
+    // approve — the warned dep was keyed only in the install-recorded
+    // set, never in the store the enumeration read. This pins the whole
+    // contract: the dep is listed, approving it writes the *source* key
+    // (a bare name never authorizes a source-backed build), and the
+    // build then runs on reinstall while the warning clears.
+    let _guard = e2e_lock();
+    let sbx = Sandbox::new();
+
+    // A directory dependency is fully offline — no registry, no network.
+    // Its postinstall drops a marker so we can prove the script ran.
+    sbx.write_file(
+        "dep/package.json",
+        r#"{
+            "name": "dep",
+            "version": "1.0.0",
+            "scripts": { "postinstall": "node -e \"require('fs').writeFileSync('BUILT_527_MARKER','ok')\"" }
+        }"#,
+    );
+    sbx.write_manifest(
+        r#"{
+            "name": "e2e-approve-local",
+            "version": "0.0.0",
+            "dependencies": { "dep": "file:./dep" }
+        }"#,
+    );
+
+    // Install gates the build: the marker must not exist yet, and the
+    // ignored-build warning must fire naming the source key.
+    sbx.cmd()
+        .arg("install")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("dep@file:./dep"));
+    let node_modules = sbx.project.join("node_modules");
+    assert!(
+        !marker_exists_under(&node_modules, "BUILT_527_MARKER"),
+        "postinstall must not run before approval"
+    );
+
+    // The dead-end: `ignored-builds` must now list the local dep by its
+    // source key (it previously printed "No ignored builds").
+    sbx.cmd()
+        .arg("ignored-builds")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("dep@file:./dep"));
+
+    // Approving records the source key in the build policy.
+    sbx.cmd().args(["approve-builds", "--all"]).assert().success();
+
+    // The now-approved build runs on the next install, and the warning
+    // is gone. (A source-backed dep's virtual-store path folds in build
+    // state, so — unlike a registry dep — the scoped rebuild inside
+    // `approve-builds` can't reach the freshly-approved tree; the full
+    // install re-materializes and builds it.)
+    sbx.cmd()
+        .arg("install")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("dep@file:./dep").not());
+    assert!(
+        marker_exists_under(&node_modules, "BUILT_527_MARKER"),
+        "approving a local-source dep must let its build script run on reinstall"
+    );
+    sbx.cmd()
+        .arg("ignored-builds")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("No ignored builds"));
 }


### PR DESCRIPTION
`nub install` warns `WARN_NUB_IGNORED_BUILD_SCRIPTS` for local-source dependencies (`file:./dep`, `file:*.tgz`, git) that ship a build script, but `nub approve-builds` / `nub ignored-builds` then reported nothing to approve — a dead-end with no way to enable those builds.

## Root cause

The warning and `approve-builds` derive the ignored set from different sources. The install warning enumerates the materialized tree (recorded in install state); `collect_ignored` instead classified each dep from its `(name, version)` index in the global store. A source-backed dep has no store index — its content is imported by dep_path, not a registry integrity — so the lookup always missed and the dep was dropped. Approving also needs the source key: a bare package name never authorizes a source-backed build.

## Fix

- `collect_ignored` now also surfaces source-backed deps from the install-recorded unreviewed set — the same set the warning enumerates — keyed by the source approval key (`dep@file:./dep`), so the two paths agree by construction.
- `approve-builds` writes that source key to `allowBuilds` (so the policy authorizes the build) while still targeting the follow-up rebuild by package name.
- `ignored-builds` and the picker show the source key, matching the warning and pnpm 11.

Mirrors pnpm 11, which lists `dep@file:./dep` in `ignored-builds` and approves by the source key.

## Verified

Fixture with a `file:` directory dep and a `file:*.tgz` dep, each with a `postinstall`: before, `ignored-builds` and `approve-builds --all` both reported nothing; after, both are listed, `approve-builds --all` writes `dep@file:./dep: true`, and the next install runs the postinstall (marker written) and clears the warning. Registry-dep approval is unchanged. Adds an e2e test covering the contract.

## Known limitation (follow-up)

approve-builds' in-invocation rebuild does not build a source-backed dep immediately: its virtual-store path folds in build state, so approving shifts the path and the scoped rebuild can't reach the pre-approval tree. The build runs on the next install. Registry deps are unaffected — this is a separate, deeper linker issue.

Closes #527
