### PR TITLE
fix(pm): key the side-effects cache on the Node engine, not just the platform

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/graph_hash.rs
+++ b/vendor/aube/crates/aube-lockfile/src/graph_hash.rs
@@ -63,14 +63,24 @@ pub struct EngineName(pub String);
 /// store directories look familiar next to `process.arch` output.
 /// Libc detection is a known gap (TODO: musl vs glibc).
 pub fn engine_name_default(node_version: &str) -> EngineName {
-    let os = std::env::consts::OS;
-    let arch = node_arch(std::env::consts::ARCH);
     let major = node_version
         .trim_start_matches('v')
         .split('.')
         .next()
         .unwrap_or("");
-    EngineName(format!("{os}-{arch}-node{major}"))
+    EngineName(format!("{}-node{major}", platform_name()))
+}
+
+/// The `<os>-<arch>` prefix of [`engine_name_default`] on its own, for
+/// callers that key build artifacts but could not resolve a Node
+/// version: they degrade to the platform axis instead of naming an
+/// engine nobody observed.
+pub fn platform_name() -> String {
+    format!(
+        "{}-{}",
+        std::env::consts::OS,
+        node_arch(std::env::consts::ARCH)
+    )
 }
 
 /// Map Rust `std::env::consts::ARCH` values to Node's `process.arch`

--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -2195,7 +2195,10 @@ default = "true"
 docs = """
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
 the post-build package directory under the cache dir keyed by
-`(name, version, input hash)`. Future installs with the same inputs
+`(name, version, engine, input hash)`, where the engine is the same
+`<os>-<arch>-node<major>` fingerprint the virtual store uses, so a
+native addon built for one Node ABI is never restored into another.
+Future installs with the same inputs
 hardlink that cached tree back into the materialized package and skip
 the build. Packages still have to pass the active `allowBuilds` /
 `onlyBuiltDependencies` policy before scripts can run or populate the

--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -2,7 +2,9 @@ use super::dep_selection::DepSelection;
 use super::lifecycle::{
     JailBuildPolicy, run_dep_lifecycle_scripts, run_root_lifecycle, unreviewed_dep_builds,
 };
-use super::side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root};
+use super::side_effects_cache::{
+    SideEffectsCacheConfig, SideEffectsCacheLocation, side_effects_cache_root,
+};
 use super::summary::{print_direct_dependency_summary, should_print_human_install_summary};
 use super::sweep::sweep_orphaned_aube_entries;
 use super::workspace::importer_project_dir;
@@ -38,6 +40,10 @@ pub(super) struct FinalizePhaseInput<'a> {
     pub(super) aube_dir: &'a std::path::Path,
     pub(super) virtual_store_dir_max_length: usize,
     pub(super) child_concurrency: usize,
+    /// Node the dep lifecycle scripts will run under, keying the
+    /// side-effects cache so post-build artifacts never cross an ABI.
+    /// `None` when discovery failed.
+    pub(super) node_version: Option<&'a str>,
     pub(super) side_effects_cache_setting: bool,
     pub(super) side_effects_cache_readonly_setting: bool,
     pub(super) strict_dep_builds_setting: bool,
@@ -169,6 +175,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         aube_dir,
         virtual_store_dir_max_length,
         child_concurrency,
+        node_version,
         side_effects_cache_setting,
         side_effects_cache_readonly_setting,
         strict_dep_builds_setting,
@@ -263,10 +270,11 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         let side_effects_cache = side_effects_cache_root
             .as_deref()
             .map(|root| {
+                let location = SideEffectsCacheLocation { root, node_version };
                 if side_effects_cache_readonly_setting {
-                    SideEffectsCacheConfig::RestoreOnly(root)
+                    SideEffectsCacheConfig::RestoreOnly(location)
                 } else {
-                    SideEffectsCacheConfig::RestoreAndSave(root)
+                    SideEffectsCacheConfig::RestoreAndSave(location)
                 }
             })
             .unwrap_or(SideEffectsCacheConfig::Disabled);

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -546,8 +546,8 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             continue;
         }
         let cache_entry = side_effects_cache
-            .root()
-            .map(|root| SideEffectsCacheEntry::new(root, &pkg.name, &pkg.version, &package_dir))
+            .location()
+            .map(|loc| SideEffectsCacheEntry::new(loc, &pkg.name, &pkg.version, &package_dir))
             .transpose()?;
         let dep_modules_dir = dep_modules_dir_for(&package_dir, &pkg.name);
         if via_floor {

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -68,7 +68,9 @@ use materialize::{
 pub(crate) use settings::PeerDependencyRules;
 pub(crate) use settings::resolve_minimum_release_age;
 pub(crate) use settings::{ResolverConfigInputs, configure_resolver, finalize_lockfile_graph};
-pub(crate) use side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root};
+pub(crate) use side_effects_cache::{
+    SideEffectsCacheConfig, SideEffectsCacheLocation, side_effects_cache_root,
+};
 
 use settings::{
     check_unmet_peers, default_lockfile_network_concurrency, default_streaming_network_concurrency,
@@ -2963,6 +2965,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         aube_dir: &aube_dir,
         virtual_store_dir_max_length,
         child_concurrency,
+        node_version: node_version.as_deref(),
         side_effects_cache_setting,
         side_effects_cache_readonly_setting,
         strict_dep_builds_setting,

--- a/vendor/aube/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/vendor/aube/crates/aube/src/commands/install/side_effects_cache.rs
@@ -6,21 +6,35 @@ const SIDE_EFFECTS_CACHE_TMP_PREFIX: &str = ".tmp-side-effects-";
 const SIDE_EFFECTS_CACHE_TMP_STALE_AFTER: std::time::Duration =
     std::time::Duration::from_secs(60 * 60);
 
+/// Where cache entries live, paired with the Node the lifecycle
+/// scripts run under. The two travel together so no call site can name
+/// a root without also naming the engine: an entry holds *post-build*
+/// artifacts — a native addon's `build/Release/*.node` among them — and
+/// those are only loadable by the ABI that compiled them.
+///
+/// `node_version` is `None` only when the version could not be
+/// resolved at all.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SideEffectsCacheLocation<'a> {
+    pub(crate) root: &'a std::path::Path,
+    pub(crate) node_version: Option<&'a str>,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum SideEffectsCacheConfig<'a> {
     Disabled,
-    RestoreOnly(&'a std::path::Path),
-    RestoreAndSave(&'a std::path::Path),
-    SaveOnlyOverwrite(&'a std::path::Path),
+    RestoreOnly(SideEffectsCacheLocation<'a>),
+    RestoreAndSave(SideEffectsCacheLocation<'a>),
+    SaveOnlyOverwrite(SideEffectsCacheLocation<'a>),
 }
 
 impl<'a> SideEffectsCacheConfig<'a> {
-    pub(super) fn root(self) -> Option<&'a std::path::Path> {
+    pub(super) fn location(self) -> Option<SideEffectsCacheLocation<'a>> {
         match self {
             Self::Disabled => None,
-            Self::RestoreOnly(root)
-            | Self::RestoreAndSave(root)
-            | Self::SaveOnlyOverwrite(root) => Some(root),
+            Self::RestoreOnly(loc) | Self::RestoreAndSave(loc) | Self::SaveOnlyOverwrite(loc) => {
+                Some(loc)
+            }
         }
     }
 
@@ -51,7 +65,7 @@ pub(super) enum SideEffectsCacheRestore {
 
 impl SideEffectsCacheEntry {
     pub(super) fn new(
-        root: &std::path::Path,
+        location: SideEffectsCacheLocation<'_>,
         name: &str,
         version: &str,
         package_dir: &std::path::Path,
@@ -61,11 +75,19 @@ impl SideEffectsCacheEntry {
             None => hash_dir_for_side_effects_cache(package_dir)?,
         };
         let safe_name = name.replace('/', "__");
-        let platform = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+        // `input_hash` fingerprints the package *before* its scripts run,
+        // so it can never stand in for the engine. Reuse the virtual
+        // store's own engine name rather than a second spelling of it, so
+        // the two caches segregate on identical axes.
+        let engine = match location.node_version {
+            Some(v) => aube_lockfile::graph_hash::engine_name_default(v).0,
+            None => aube_lockfile::graph_hash::platform_name(),
+        };
         Ok(Self {
-            path: root
+            path: location
+                .root
                 .join(format!("{safe_name}@{version}"))
-                .join(platform)
+                .join(engine)
                 .join(&input_hash),
             input_hash,
         })
@@ -425,18 +447,69 @@ fn create_symlink_like(
 mod tests {
     use super::*;
 
+    fn entry_path(
+        root: &std::path::Path,
+        package_dir: &std::path::Path,
+        node_version: Option<&str>,
+    ) -> std::path::PathBuf {
+        SideEffectsCacheEntry::new(
+            SideEffectsCacheLocation { root, node_version },
+            "p",
+            "1.0.0",
+            package_dir,
+        )
+        .unwrap()
+        .path
+    }
+
+    fn package_fixture(root: &std::path::Path) -> std::path::PathBuf {
+        let pkg = root.join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("package.json"), "{\"name\":\"p\"}\n").unwrap();
+        pkg
+    }
+
     #[test]
     fn cache_path_segregates_by_platform() {
         let dir = tempfile::tempdir().unwrap();
-        let pkg = dir.path().join("pkg");
-        std::fs::create_dir_all(&pkg).unwrap();
-        std::fs::write(pkg.join("package.json"), "{\"name\":\"p\"}\n").unwrap();
-        let entry = SideEffectsCacheEntry::new(dir.path(), "p", "1.0.0", &pkg).unwrap();
-        let s = entry.path.to_string_lossy().into_owned();
-        let segment = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+        let pkg = package_fixture(dir.path());
+        let s = entry_path(dir.path(), &pkg, Some("22.15.0"))
+            .to_string_lossy()
+            .into_owned();
+        let segment = aube_lockfile::graph_hash::platform_name();
         assert!(
             s.contains(&segment),
             "cache path lacks platform segment {segment}: {s}"
+        );
+    }
+
+    #[test]
+    fn cache_path_segregates_by_node_major() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = package_fixture(dir.path());
+        let node22 = entry_path(dir.path(), &pkg, Some("22.15.0"));
+        let node26 = entry_path(dir.path(), &pkg, Some("26.5.0"));
+        let unknown = entry_path(dir.path(), &pkg, None);
+        assert_ne!(
+            node22, node26,
+            "a native build under one Node major must not be restorable into another"
+        );
+        assert_eq!(
+            node22,
+            entry_path(dir.path(), &pkg, Some("22.16.0")),
+            "NODE_MODULE_VERSION tracks the major, so a minor bump must stay a cache hit"
+        );
+        assert_ne!(
+            unknown, node22,
+            "an unresolved Node version must not collide with a known engine"
+        );
+        assert_ne!(unknown, node26);
+        assert!(
+            unknown
+                .to_string_lossy()
+                .contains(&aube_lockfile::graph_hash::platform_name()),
+            "unresolved Node version should still key on the platform: {}",
+            unknown.display()
         );
     }
 

--- a/vendor/aube/crates/aube/src/commands/rebuild.rs
+++ b/vendor/aube/crates/aube/src/commands/rebuild.rs
@@ -150,6 +150,9 @@ pub async fn run(
                 } else {
                     None
                 };
+            let node_version = crate::engines::effective_node_version(
+                aube_settings::resolved::node_version(&settings_ctx).as_deref(),
+            );
             // Re-emit per-dep `.bin/` shims so a rebuild on a tree
             // that pre-dates the transitive-bin fix still lands them
             // on PATH for the lifecycle scripts. `link_bins_for_dep`
@@ -199,7 +202,12 @@ pub async fn run(
                         if aube_settings::resolved::side_effects_cache_readonly(&settings_ctx) {
                             super::install::SideEffectsCacheConfig::Disabled
                         } else {
-                            super::install::SideEffectsCacheConfig::SaveOnlyOverwrite(root)
+                            super::install::SideEffectsCacheConfig::SaveOnlyOverwrite(
+                                super::install::SideEffectsCacheLocation {
+                                    root,
+                                    node_version: node_version.as_deref(),
+                                },
+                            )
                         }
                     })
                     .unwrap_or(super::install::SideEffectsCacheConfig::Disabled),

--- a/vendor/aube/docs/settings/index.md
+++ b/vendor/aube/docs/settings/index.md
@@ -2149,7 +2149,10 @@ Cache the results of install hooks.
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
 the post-build package directory under the cache dir keyed by
-`(name, version, input hash)`. Future installs with the same inputs
+`(name, version, engine, input hash)`, where the engine is the same
+`<os>-<arch>-node<major>` fingerprint the virtual store uses, so a
+native addon built for one Node ABI is never restored into another.
+Future installs with the same inputs
 hardlink that cached tree back into the materialized package and skip
 the build. Packages still have to pass the active `allowBuilds` /
 `onlyBuiltDependencies` policy before scripts can run or populate the


### PR DESCRIPTION
The side-effects cache stored post-build package directories at `<name>@<version>/<os>-<arch>/<input-hash>`. The input hash fingerprints the package *before* its lifecycle scripts run, so nothing in that key described the Node the artifacts were built with. A native addon compiled under one `NODE_MODULE_VERSION` was a cache hit for an install pinned to a different Node major, and the whole post-build directory — `build/Release/*.node` included — was restored into it.

That is a broken install, not cache churn. The virtual store already segregates on `<os>-<arch>-node<major>` via `graph_hash::engine_name_default`, so the two caches disagreed about whether the engine mattered and artifacts leaked across a boundary the store path was busy keeping apart.

## Repro

A node-gyp addon registered with `NODE_MODULE` (not N-API, so ABI-sensitive), installed under Node 22.15.0 and then Node 26.5.0 in one project with `allowBuilds` on and an isolated store:

```
$ echo 22.15.0 > .nvmrc && nub install
side-effects-cache: saved    .../abi-probe@1.0.0/macos-aarch64/e8c24316…

$ rm -rf node_modules && echo 26.5.0 > .nvmrc && nub install
side-effects-cache: restored .../abi-probe@1.0.0/macos-aarch64/e8c24316…
```

Same path, one compile. The Node 22 build, the cache entry, and the Node 26 store copy of `abi_probe.node` all share sha256 `d925f2c284788219…`. Loading it under Node 26:

```
Error: The module '.../abi-probe/build/Release/abi_probe.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 127. This version of Node.js requires
NODE_MODULE_VERSION 147.
```

After the change the two arms land at `macos-arm64-node22` and `macos-arm64-node26`, compile separately, and both load. Re-installing under Node 22 with the store entry wiped still logs `side-effects-cache: restored` and runs node-gyp zero times, so the cache is segregated rather than disabled.

## Change

Entries key on `engine_name_default`, the same fingerprint the virtual store uses, so both caches segregate on identical axes. The cache root and the resolved Node version travel together as `SideEffectsCacheLocation`, so no call site can name one without the other — `install` threads the version it already resolved for the engines check, `rebuild` resolves its own. An unresolved version falls back to the platform alone rather than naming an engine nobody observed.

Factoring `platform_name()` out of `engine_name_default` gives that fallback one shared spelling of `<os>-<arch>`. The output of `engine_name_default` is byte-identical, so virtual-store paths do not move.

## Fork discipline

This is not default-preserving: standalone aube's cache paths change too. It lands under the latent-bug-fix clause. Restoring an ABI-mismatched native build is a defect for standalone aube on exactly the same terms, and there is no posture under which the old key is correct, so the fix is unconditional rather than embedder-gated.

## Invalidation

Existing entries are orphaned by the path change, so affected native modules rebuild once. That is the intended cost — the old entries are ABI-ambiguous and must not be trusted. Nothing else invalidates: lockfiles are untouched, and the unchanged `engine_name_default` output means the virtual store does not re-key.

Refs #530


## Notes

The side-effects path's arch spelling changes from Rust's `aarch64` to Node's `arm64`, since the segment now comes from `engine_name_default` rather than raw `std::env::consts::ARCH`. Existing entries orphan on the engine segment regardless, so this costs nothing extra, and it is what makes the two caches segregate on identical axes.

Under standalone aube, `rebuild` cannot reach `runtime::current()` (it never enters a `runtime::scope`), so with runtime switching plus a version pin it resolves a different Node than `install` and primes an entry `install` will not read. Nub is unaffected: both verbs route through `engine_session`, which publishes the discovered version. The prior behavior was worse, since both wrote the same platform-only path, so `rebuild` could prime a wrong-ABI entry that `install` would then restore; the mismatch now degrades to lost priming rather than a bad restore.
