### PR TITLE
fix(pm): record the engine in the side-effects cache marker

### DIFF
--- a/vendor/aube/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/vendor/aube/crates/aube/src/commands/install/side_effects_cache.rs
@@ -53,6 +53,7 @@ impl<'a> SideEffectsCacheConfig<'a> {
 
 #[derive(Debug, Clone)]
 pub(super) struct SideEffectsCacheEntry {
+    engine: String,
     input_hash: String,
     path: std::path::PathBuf,
 }
@@ -70,8 +71,14 @@ impl SideEffectsCacheEntry {
         version: &str,
         package_dir: &std::path::Path,
     ) -> miette::Result<Self> {
+        // Take only the hash half of the marker: it fingerprints the
+        // package *before* its scripts ran, which is what keys this entry
+        // no matter which engine last built the directory. Reading it
+        // engine-agnostically is also what keeps a marker written before
+        // engines were recorded from forcing a rehash of the post-build
+        // tree, which would key the entry off the wrong bytes.
         let input_hash = match read_valid_side_effects_marker(package_dir) {
-            Some(hash) => hash,
+            Some(marker) => marker.input_hash,
             None => hash_dir_for_side_effects_cache(package_dir)?,
         };
         let safe_name = name.replace('/', "__");
@@ -87,8 +94,9 @@ impl SideEffectsCacheEntry {
             path: location
                 .root
                 .join(format!("{safe_name}@{version}"))
-                .join(engine)
+                .join(&engine)
                 .join(&input_hash),
+            engine,
             input_hash,
         })
     }
@@ -97,7 +105,7 @@ impl SideEffectsCacheEntry {
         &self,
         package_dir: &std::path::Path,
     ) -> miette::Result<SideEffectsCacheRestore> {
-        if marker_matches(package_dir, &self.input_hash) && self.path.is_dir() {
+        if self.marker_matches(package_dir) && self.path.is_dir() {
             tracing::debug!(
                 "side-effects-cache: already applied {}",
                 self.path.display()
@@ -113,8 +121,27 @@ impl SideEffectsCacheEntry {
                 self.path.display()
             )
         })?;
+        // The copy carries the entry's own marker across, so restamping is
+        // a no-op except for an entry saved before markers named an engine
+        // — that one would fail every future match and re-copy forever.
+        write_side_effects_marker(package_dir, &self.engine, &self.input_hash)?;
         tracing::debug!("side-effects-cache: restored {}", self.path.display());
         Ok(SideEffectsCacheRestore::Restored)
+    }
+
+    /// True when this package directory's contents were produced by *this*
+    /// entry. Both halves are load-bearing: entries segregate by engine, so
+    /// several now share one input hash, and matching on the hash alone
+    /// would let the skip above fire for a build made under a different
+    /// Node ABI — leaving that build's `.node` in place for a runtime
+    /// `NODE_MODULE_VERSION` failure. A marker with no engine (written
+    /// before this was recorded) never matches, so it degrades to a restore
+    /// or a rebuild, never to a silent skip.
+    fn marker_matches(&self, package_dir: &std::path::Path) -> bool {
+        read_valid_side_effects_marker(package_dir).is_some_and(|marker| {
+            marker.engine.as_deref() == Some(self.engine.as_str())
+                && marker.input_hash == self.input_hash
+        })
     }
 
     pub(super) fn save(
@@ -128,7 +155,7 @@ impl SideEffectsCacheEntry {
                     .into_diagnostic()
                     .wrap_err_with(|| format!("failed to remove {}", self.path.display()))?;
             } else {
-                write_side_effects_marker(package_dir, &self.input_hash)?;
+                write_side_effects_marker(package_dir, &self.engine, &self.input_hash)?;
                 return Ok(());
             }
         }
@@ -142,7 +169,7 @@ impl SideEffectsCacheEntry {
             .into_diagnostic()
             .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
         sweep_stale_side_effects_tmp_dirs(parent);
-        write_side_effects_marker(package_dir, &self.input_hash)?;
+        write_side_effects_marker(package_dir, &self.engine, &self.input_hash)?;
 
         let tmp = parent.join(format!(
             "{SIDE_EFFECTS_CACHE_TMP_PREFIX}{}-{}",
@@ -220,14 +247,28 @@ pub(crate) fn side_effects_cache_root(store: &aube_store::Store) -> std::path::P
         .join("side-effects-v1")
 }
 
-fn marker_matches(package_dir: &std::path::Path, input_hash: &str) -> bool {
-    read_valid_side_effects_marker(package_dir).is_some_and(|s| s == input_hash)
+/// Parsed marker contents: `<engine>:<input_hash>`. `engine` is `None` for
+/// the bare-hash form written before the engine was recorded.
+struct SideEffectsMarker {
+    engine: Option<String>,
+    input_hash: String,
 }
 
-fn read_valid_side_effects_marker(package_dir: &std::path::Path) -> Option<String> {
+/// Only the hash half is validated, because only the hash is ever joined
+/// into a path — the engine a lookup keys on comes from the install's own
+/// resolved Node, and the marker's copy is compared, never trusted as a
+/// path segment.
+fn read_valid_side_effects_marker(package_dir: &std::path::Path) -> Option<SideEffectsMarker> {
     let marker = std::fs::read_to_string(package_dir.join(SIDE_EFFECTS_CACHE_MARKER)).ok()?;
     let marker = marker.trim();
-    is_side_effects_cache_hash(marker).then(|| marker.to_ascii_lowercase())
+    let (engine, hash) = match marker.rsplit_once(':') {
+        Some((engine, hash)) => (Some(engine), hash),
+        None => (None, marker),
+    };
+    is_side_effects_cache_hash(hash).then(|| SideEffectsMarker {
+        engine: engine.map(str::to_owned),
+        input_hash: hash.to_ascii_lowercase(),
+    })
 }
 
 fn is_side_effects_cache_hash(value: &str) -> bool {
@@ -236,11 +277,12 @@ fn is_side_effects_cache_hash(value: &str) -> bool {
 
 fn write_side_effects_marker(
     package_dir: &std::path::Path,
+    engine: &str,
     input_hash: &str,
 ) -> miette::Result<()> {
     aube_util::fs_atomic::atomic_write(
         &package_dir.join(SIDE_EFFECTS_CACHE_MARKER),
-        input_hash.as_bytes(),
+        format!("{engine}:{input_hash}").as_bytes(),
     )
     .into_diagnostic()
     .wrap_err_with(|| {
@@ -447,11 +489,11 @@ fn create_symlink_like(
 mod tests {
     use super::*;
 
-    fn entry_path(
+    fn entry(
         root: &std::path::Path,
         package_dir: &std::path::Path,
         node_version: Option<&str>,
-    ) -> std::path::PathBuf {
+    ) -> SideEffectsCacheEntry {
         SideEffectsCacheEntry::new(
             SideEffectsCacheLocation { root, node_version },
             "p",
@@ -459,7 +501,14 @@ mod tests {
             package_dir,
         )
         .unwrap()
-        .path
+    }
+
+    fn entry_path(
+        root: &std::path::Path,
+        package_dir: &std::path::Path,
+        node_version: Option<&str>,
+    ) -> std::path::PathBuf {
+        entry(root, package_dir, node_version).path
     }
 
     fn package_fixture(root: &std::path::Path) -> std::path::PathBuf {
@@ -519,12 +568,106 @@ mod tests {
         let marker_path = dir.path().join(SIDE_EFFECTS_CACHE_MARKER);
 
         std::fs::write(&marker_path, "../../evil").unwrap();
-        assert_eq!(read_valid_side_effects_marker(dir.path()), None);
+        assert!(read_valid_side_effects_marker(dir.path()).is_none());
+
+        std::fs::write(
+            &marker_path,
+            format!("darwin-arm64-node26:{}", "z".repeat(128)),
+        )
+        .unwrap();
+        assert!(
+            read_valid_side_effects_marker(dir.path()).is_none(),
+            "a non-hex hash must be rejected however it is prefixed"
+        );
 
         std::fs::write(&marker_path, format!("{}\n", "A".repeat(128))).unwrap();
+        let legacy = read_valid_side_effects_marker(dir.path()).unwrap();
+        assert_eq!(legacy.engine, None);
+        assert_eq!(legacy.input_hash, "a".repeat(128));
+
+        std::fs::write(
+            &marker_path,
+            format!("darwin-arm64-node26:{}\n", "A".repeat(128)),
+        )
+        .unwrap();
+        let current = read_valid_side_effects_marker(dir.path()).unwrap();
+        assert_eq!(current.engine.as_deref(), Some("darwin-arm64-node26"));
+        assert_eq!(current.input_hash, "a".repeat(128));
+    }
+
+    #[test]
+    fn already_applied_requires_the_marker_to_name_the_same_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = package_fixture(dir.path());
+        let root = dir.path().join("cache");
+
+        entry(&root, &pkg, Some("26.5.0"))
+            .save(&pkg, false)
+            .unwrap();
+        assert!(
+            matches!(
+                entry(&root, &pkg, Some("26.5.0"))
+                    .restore_if_available(&pkg)
+                    .unwrap(),
+                SideEffectsCacheRestore::AlreadyApplied
+            ),
+            "the same engine that built this directory must still skip the rebuild"
+        );
+
+        let node22 = entry(&root, &pkg, Some("22.15.0"));
+        assert!(
+            matches!(
+                node22.restore_if_available(&pkg).unwrap(),
+                SideEffectsCacheRestore::Miss
+            ),
+            "another engine's marker must not stand in for this engine's missing entry"
+        );
+        node22.save(&pkg, false).unwrap();
+
+        // The directory now holds Node 22's build while Node 26's entry
+        // still exists under the same input hash — the case that used to
+        // skip and leave a wrong-ABI addon in place.
+        assert!(
+            matches!(
+                entry(&root, &pkg, Some("26.5.0"))
+                    .restore_if_available(&pkg)
+                    .unwrap(),
+                SideEffectsCacheRestore::Restored
+            ),
+            "a directory built under another engine must be restored, not skipped"
+        );
+    }
+
+    #[test]
+    fn engineless_marker_restores_rather_than_skipping() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = package_fixture(dir.path());
+        let root = dir.path().join("cache");
+
+        let saved = entry(&root, &pkg, Some("26.5.0"));
+        saved.save(&pkg, false).unwrap();
+        std::fs::write(pkg.join(SIDE_EFFECTS_CACHE_MARKER), &saved.input_hash).unwrap();
+
+        let reread = entry(&root, &pkg, Some("26.5.0"));
         assert_eq!(
-            read_valid_side_effects_marker(dir.path()),
-            Some("a".repeat(128))
+            reread.input_hash, saved.input_hash,
+            "an engineless marker must still supply the input hash, so the entry keeps its key"
+        );
+        assert!(
+            matches!(
+                reread.restore_if_available(&pkg).unwrap(),
+                SideEffectsCacheRestore::Restored
+            ),
+            "an engineless marker must degrade to a restore, never to a skip"
+        );
+        assert!(
+            matches!(
+                entry(&root, &pkg, Some("26.5.0"))
+                    .restore_if_available(&pkg)
+                    .unwrap(),
+                SideEffectsCacheRestore::AlreadyApplied
+            ),
+            "the restore restamps the marker, so the skip returns on the next install"
         );
     }
 }


### PR DESCRIPTION
The side-effects cache skips a package's lifecycle scripts when `.aube-side-effects-cache` in the package directory matches the entry's input hash — `restore_if_available` returns `AlreadyApplied` and copies nothing. That hash fingerprints the package *before* its scripts run, so it describes the input a build started from, never the engine that produced the directory's current contents. It only had to describe the input while one input hash named one entry.

Entries now segregate by engine (#537), so several share an input hash and the marker can no longer tell them apart. Install under Node 26, then Node 22, then Node 26 again and the third install finds Node 26's entry on disk, sees a marker whose hash matches, and skips — leaving Node 22's `build/Release/*.node` in place.

## Reproduction

A node-gyp addon (`NODE_MODULE`-registered, so ABI-sensitive) on `enableGlobalVirtualStore=false` — the default under CI, for `dlx`, and for packages on the compat-disable list. That layout materializes into a per-project `node_modules/.store/<name>@<version>`, which is not engine-keyed, so the directory and its marker survive a Node switch.

```
STEP 1: node v26.5.0 (nub install)
  side-effects-cache:  saved
  node-gyp ran:        2
  artifact sha256:     c0e3511d206e861f
  require('abi-probe'): LOADED OK: pong

STEP 2: node v22.15.0 — allowBuilds gains another package
  side-effects-cache:  saved
  node-gyp ran:        2
  artifact sha256:     5ecebd5c45b8f978        # rebuilt for Node 22
  require('abi-probe'): LOADED OK: pong

STEP 3: node v26.5.0 — allowBuilds gains another package
  side-effects-cache:  already applied         # ❌ nothing restored
  node-gyp ran:        0
  artifact sha256:     5ecebd5c45b8f978        # still Node 22's build
  require('abi-probe'):
    Error: The module '.../node_modules/.store/abi-probe@1.0.0/node_modules/abi-probe/build/Release/abi_probe.node'
    was compiled against a different Node.js version using
    NODE_MODULE_VERSION 127. This version of Node.js requires
    NODE_MODULE_VERSION 147.
      code: 'ERR_DLOPEN_FAILED'
```

Reaching the skip needs the install to re-enter the dependency lifecycle phase, which a warm tree normally narrows to deps whose `dep_path` changed. It widens to a full scan whenever the recorded build policy changes — approving another package's builds, as above — or when the state is gone, as with `nub install --force`. Both reproduce.

The isolated layout with the shared virtual store is unaffected: its store directory is engine-keyed, so `AlreadyApplied` there is correct. So is `nodeLinker: hoisted`, which re-materializes `node_modules/<pkg>` on every link and so never carries a marker across a Node switch. Rebuild is unaffected — it saves without restoring.

## The change

The marker records `<engine>:<input-hash>`, and a skip requires both halves to match. It now identifies the entry that produced the directory rather than the input that entry was built from. The engine half is compared, never joined into a path — a lookup takes its engine from the install's own resolved Node — so only the hash is validated, as before.

Same fixture on the built binary:

```
STEP 3: node v26.5.0 (nub install --force)
  side-effects-cache:  restored                # ✓ Node 26's entry copied back
  node-gyp ran:        0
  artifact sha256:     93ec9782d897e2a4
  marker:              macos-arm64-node26:e8c24316d8399bf63fccd...
  require('abi-probe'): LOADED OK: pong
```

Dropping the shortcut and always restoring would also be correct, but it trades a skip for a full directory copy on every repeat install of every build-allowed package. Recording the engine keeps the optimization and makes the invariant structural.

## Existing markers

The marker file is excluded from the input hash, so changing its format cannot perturb that hash: existing cache entries keep their paths and are reused, with no re-download and no rebuild. A marker written before this parses as a hash with no engine, which still supplies the input hash the entry is keyed on but never matches, so it degrades to a restore — or to a rebuild when no entry exists — and never to a skip. The restore restamps it, so one install converges.

Verified across binaries: steps 1–2 on `main`, steps 3–4 on this branch.

```
STEP 3: NEW nub, node v26.5.0
  side-effects-cache:  restored                # engineless marker, no skip
  node-gyp ran:        0                       # existing entry reused
  marker:              macos-arm64-node26:e8c24316d8399bf63fc...
  require('abi-probe'): LOADED OK: pong

STEP 4: NEW nub, node v26.5.0
  side-effects-cache:  already applied         # optimization back
```

## Engine behavior

This changes the marker format for every consumer of the engine, not only the embedder, so it is not default-preserving. It belongs to the latent-bug fix begun in #537, and the two are best read as one change split across two commits.

Being precise about which half fixes what: before #537 a single machine had exactly one `<os>-<arch>` segment, so one input hash named exactly one entry and the marker was sufficient to identify it. #537 made entries engine-segregated, which is what leaves several entries sharing an input hash and makes the marker ambiguous. So this commit is not repairing an ambiguity that predates the stack — it completes the fix #537 started. Shipped alone, #537 closes the cross-ABI restore while leaving this skip open; the pair is what makes the invariant hold. Leaving a wrong-ABI addon in place is a broken install on any host, which is what justifies a non-default-preserving change.

The other behavior change is that a successful restore now rewrites the marker file.

Refs #537
Refs #530

