### PR TITLE
Trim the default trust build warning

### DIFF
--- a/.github/workflows/native-deps.yml
+++ b/.github/workflows/native-deps.yml
@@ -6,7 +6,7 @@ name: Native-dep floor
 # Two fixture legs:
 #   floor-allowed: esbuild + better-sqlite3 (both on the allowlist). Asserts:
 #     (a) install exits 0 and artifacts materialize,
-#     (b) WARN_NUB_DEFAULT_TRUST_BUILDS discloses both packages by name — the
+#     (b) the defaultTrust warning discloses both packages by name — the
 #         floor is NOT a silent allow path,
 #     (c) native modules are loadable after install.
 #   floor-denied:  core-js (not on the allowlist). Asserts:

--- a/crates/nub-cli/src/pm_engine/log.rs
+++ b/crates/nub-cli/src/pm_engine/log.rs
@@ -108,9 +108,10 @@ pub fn set_engine_loglevel(level: &str) {
     }
 }
 
-/// Minimal event renderer: `LEVEL message [field=value …]`, no
-/// timestamp, no module-path target (a Rust module path is engine
-/// internals, not user output), the whole line brand-rewritten.
+/// Minimal event renderer: `LEVEL message [field=value …]`, no timestamp or
+/// module-path target (a Rust module path is engine internals, not user output).
+/// Redundant human-facing fields may be collapsed before the whole line is
+/// brand-rewritten.
 struct RewriteLayer;
 
 impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for RewriteLayer {
@@ -121,15 +122,36 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for RewriteLayer {
     ) {
         let mut fields = LineVisitor::default();
         event.record(&mut fields);
-        let mut line = format!("{} {}", event.metadata().level(), fields.message);
-        for (name, value) in &fields.rest {
-            line.push(' ');
-            line.push_str(name);
-            line.push('=');
-            line.push_str(value);
-        }
+        let line = format_line(event.metadata().level().as_str(), &fields);
         eprintln!("{}", present::rewrite(&line));
     }
+}
+
+fn format_line(level: &str, fields: &LineVisitor) -> String {
+    let is_default_trust_disclosure = fields.rest.iter().any(|(name, value)| {
+        *name == "code" && value == aube_codes::warnings::WARN_AUBE_DEFAULT_TRUST_BUILDS
+    });
+    let message = if is_default_trust_disclosure {
+        fields
+            .message
+            .split_once("package(s): ")
+            .map(|(_, packages)| format!("defaultTrust: running build scripts for {packages}"))
+            .unwrap_or_else(|| fields.message.clone())
+    } else {
+        fields.message.clone()
+    };
+
+    let mut line = format!("{level} {message}");
+    for (name, value) in &fields.rest {
+        if is_default_trust_disclosure && matches!(*name, "count" | "packages") {
+            continue;
+        }
+        line.push(' ');
+        line.push_str(name);
+        line.push('=');
+        line.push_str(value);
+    }
+    line
 }
 
 #[derive(Default)]
@@ -156,9 +178,27 @@ impl Visit for LineVisitor {
     }
 }
 
-// Untested at the unit level on purpose: the layer's contract (engine
-// warnings reach stderr, rewritten, by default) spans the global
-// subscriber + fd 2, which unit tests can't observe honestly. It is
-// verified at the binary level — `nub install` of a package with
-// unapproved build scripts must print the WARN_NUB_IGNORED_BUILD_SCRIPTS
-// line — which tests/brand-sweep/run.sh asserts.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_trust_disclosure_does_not_repeat_count_and_packages() {
+        let fields = LineVisitor {
+            message: "defaultTrust: running build scripts for 1 default-trusted package(s): msgpackr-extract@3.0.4".into(),
+            rest: vec![
+                (
+                    "code",
+                    aube_codes::warnings::WARN_AUBE_DEFAULT_TRUST_BUILDS.into(),
+                ),
+                ("count", "1".into()),
+                ("packages", "[\"msgpackr-extract@3.0.4\"]".into()),
+            ],
+        };
+
+        assert_eq!(
+            format_line("WARN", &fields),
+            "WARN defaultTrust: running build scripts for msgpackr-extract@3.0.4 code=WARN_AUBE_DEFAULT_TRUST_BUILDS"
+        );
+    }
+}

--- a/crates/nub-cli/src/pm_engine/log.rs
+++ b/crates/nub-cli/src/pm_engine/log.rs
@@ -143,7 +143,7 @@ fn format_line(level: &str, fields: &LineVisitor) -> String {
 
     let mut line = format!("{level} {message}");
     for (name, value) in &fields.rest {
-        if is_default_trust_disclosure && matches!(*name, "count" | "packages") {
+        if is_default_trust_disclosure && matches!(*name, "code" | "count" | "packages") {
             continue;
         }
         line.push(' ');
@@ -198,7 +198,7 @@ mod tests {
 
         assert_eq!(
             format_line("WARN", &fields),
-            "WARN defaultTrust: running build scripts for msgpackr-extract@3.0.4 code=WARN_AUBE_DEFAULT_TRUST_BUILDS"
+            "WARN defaultTrust: running build scripts for msgpackr-extract@3.0.4"
         );
     }
 }

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -425,8 +425,7 @@ A fresh resolve, or a lockfile Nub itself wrote (which carries the `time:` block
 ```console
 # captured: nub 0.0.44, pnpm-incumbent, esbuild@0.21.5 — no allowBuilds entry
 $ nub install
-WARN defaultTrust: running build scripts for esbuild@0.21.5
-     code=WARN_NUB_DEFAULT_TRUST_BUILDS   # ✓ all three gates passed
+WARN defaultTrust: running build scripts for esbuild@0.21.5   # ✓ all three gates passed
 dependencies:
 + esbuild@0.21.5
 ```

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -425,9 +425,8 @@ A fresh resolve, or a lockfile Nub itself wrote (which carries the `time:` block
 ```console
 # captured: nub 0.0.44, pnpm-incumbent, esbuild@0.21.5 — no allowBuilds entry
 $ nub install
-WARN defaultTrust: running build scripts for 1 default-trusted
-     package(s): esbuild@0.21.5 code=WARN_NUB_DEFAULT_TRUST_BUILDS
-     count=1 packages=["esbuild@0.21.5"]   # ✓ all three gates passed
+WARN defaultTrust: running build scripts for esbuild@0.21.5
+     code=WARN_NUB_DEFAULT_TRUST_BUILDS   # ✓ all three gates passed
 dependencies:
 + esbuild@0.21.5
 ```

--- a/tests/brand-sweep/run.sh
+++ b/tests/brand-sweep/run.sh
@@ -232,7 +232,6 @@ grep -q 'WARN_NUB_IGNORED_BUILD_SCRIPTS' "$out3" || fail_with_output "warning co
 # allow path: the one-line disclosure names esbuild, rewritten like every
 # other warning-channel line.
 grep -q 'WARN defaultTrust: running build scripts for esbuild@' "$out3" || fail_with_output "defaultTrust disclosure line missing (floor allowed builds silently)"
-grep -q 'WARN_NUB_DEFAULT_TRUST_BUILDS' "$out3" || fail_with_output "defaultTrust disclosure code not rewritten to WARN_NUB_*"
 grep -q 'core-js' "$out3" || fail_with_output "deny-side probe (core-js) missing from ignored-builds warning"
 # NB: plain backticks inside single quotes — '\`' would be a literal
 # backslash-backtick, which GNU grep parses as the buffer-start anchor

--- a/tests/brand-sweep/run.sh
+++ b/tests/brand-sweep/run.sh
@@ -231,7 +231,7 @@ grep -q 'WARN_NUB_IGNORED_BUILD_SCRIPTS' "$out3" || fail_with_output "warning co
 # The defaultTrust floor (on by default under nub) must never be a silent
 # allow path: the one-line disclosure names esbuild, rewritten like every
 # other warning-channel line.
-grep -q 'WARN defaultTrust: running build scripts' "$out3" || fail_with_output "defaultTrust disclosure line missing (floor allowed builds silently)"
+grep -q 'WARN defaultTrust: running build scripts for esbuild@' "$out3" || fail_with_output "defaultTrust disclosure line missing (floor allowed builds silently)"
 grep -q 'WARN_NUB_DEFAULT_TRUST_BUILDS' "$out3" || fail_with_output "defaultTrust disclosure code not rewritten to WARN_NUB_*"
 grep -q 'core-js' "$out3" || fail_with_output "deny-side probe (core-js) missing from ignored-builds warning"
 # NB: plain backticks inside single quotes — '\`' would be a literal

--- a/tests/native-deps/README.md
+++ b/tests/native-deps/README.md
@@ -6,13 +6,13 @@ Tests nub's default-trust floor policy end-to-end against real packages that run
 
 | Package | Build type | Expected outcome |
 | --- | --- | --- |
-| `esbuild@0.28.0` | Downloads a platform binary in postinstall | Floor-allowed: build runs, `WARN_NUB_DEFAULT_TRUST_BUILDS` disclosure emitted, binary materialized |
+| `esbuild@0.28.0` | Downloads a platform binary in postinstall | Floor-allowed: build runs, `defaultTrust` disclosure emitted, binary materialized |
 | `better-sqlite3@11.10.0` | Compiles a C++ N-API addon via node-gyp | Floor-allowed: build runs, addon loadable, disclosed in same warning |
 | `core-js@3.40.0` | Runs build scripts not on the floor allowlist | Floor-denied: build blocked, `WARN_NUB_IGNORED_BUILD_SCRIPTS` emitted naming core-js |
 
 The three-part pass condition for floor-allowed builds is:
 1. **Allowed** — `nub install` exits 0 and the module materializes.
-2. **Disclosed** — `WARN_NUB_DEFAULT_TRUST_BUILDS` names the package. The floor is not a silent allow path.
+2. **Disclosed** — the `defaultTrust` warning names the package. The floor is not a silent allow path.
 3. **Loadable** — `node -e require(...)` succeeds — the native artifact actually runs.
 
 ## Prerequisites

--- a/tests/native-deps/run.sh
+++ b/tests/native-deps/run.sh
@@ -9,8 +9,8 @@
 #                              package is on the floor allowlist (it is a
 #                              long-lived, registry-only, well-known build tool).
 #                              The floor must: (a) allow the build to run,
-#                              (b) emit WARN_NUB_DEFAULT_TRUST_BUILDS disclosing
-#                              the package by name, (c) produce a working module.
+#                              (b) disclose the package by name, (c) produce a
+#                              working module.
 #
 #   better-sqlite3 (11.10.0) — compiles a C++ N-API addon via node-gyp at
 #                              postinstall. Also on the floor allowlist. Same
@@ -63,7 +63,7 @@ trap cleanup EXIT
 # depends on nub's packument cache, which lives in $XDG_CACHE_HOME/nub/pm/ —
 # a completely cold sandbox defeats the gate, causing the floor to fall back to
 # deny+warn (`WARN_NUB_IGNORED_BUILD_SCRIPTS`) instead of the expected allow+
-# disclose path (`WARN_NUB_DEFAULT_TRUST_BUILDS`). On CI (ubuntu-latest),
+# disclose path. On CI (ubuntu-latest),
 # the runner has network access and the XDG cache starts cold — but the
 # resolver warms it during the resolve phase before the scripts phase, so the
 # OSV gate runs and the floor fires correctly. Sandboxing the project dirs
@@ -90,10 +90,10 @@ if echo "$install_out" | grep -qiE 'aube|jdx\.dev'; then
 fi
 
 # Default-trust disclosure: both floor-allowed packages must be named in the
-# WARN_NUB_DEFAULT_TRUST_BUILDS line — the floor is NOT a silent allow path.
+# defaultTrust warning — the floor is NOT a silent allow path.
 # This fires before the lifecycle script phase, so it is present even when a
 # build (e.g. better-sqlite3's node-gyp compile) fails afterward.
-echo "$install_out" | grep -q 'WARN_NUB_DEFAULT_TRUST_BUILDS' \
+echo "$install_out" | grep -q 'WARN defaultTrust: running build scripts' \
   || fail "defaultTrust disclosure missing from output (floor allowed builds silently). Output: $install_out"
 echo "$install_out" | grep -q 'esbuild' \
   || fail "esbuild not named in defaultTrust disclosure. Output: $install_out"
@@ -151,7 +151,7 @@ if echo "$frozen_out" | grep -qiE 'aube|jdx\.dev'; then
 fi
 
 # The floor must fire on the frozen install exactly as on the fresh one.
-echo "$frozen_out" | grep -q 'WARN_NUB_DEFAULT_TRUST_BUILDS' \
+echo "$frozen_out" | grep -q 'WARN defaultTrust: running build scripts' \
   || fail "FROZEN INSTALL: defaultTrust disclosure missing — the floor fell closed on a frozen install (Decision 2 bug). Output: $frozen_out"
 echo "$frozen_out" | grep -q 'esbuild' \
   || fail "FROZEN INSTALL: esbuild not named in defaultTrust disclosure. Output: $frozen_out"


### PR DESCRIPTION
## Summary
- shorten the human-facing `defaultTrust` build disclosure
- keep the stable warning code while omitting duplicate count and package fields
- update the captured output and warning-channel regression check

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -p nub-cli -- --check`
- `cargo test -p nub-cli --bin nub default_trust_disclosure_does_not_repeat_count_and_packages`
- real `msgpackr-extract@3.0.4` install emitted the compact warning and completed successfully

`cargo fmt --check` also reports existing formatting drift under `vendor/aube/**` on the base commit.