### PR TITLE
fix(pm): fold the Node engine into the install freshness and delta gates

### DIFF
--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -59,18 +59,31 @@ pub(super) struct FinalizePhaseInput<'a> {
     pub(super) phase_timings: &'a mut InstallPhaseTimings,
 }
 
+/// Gates whether the next install may narrow its lifecycle phase to changed
+/// packages. The engine belongs in it because build scripts compile against a
+/// specific Node ABI: without it, switching Node majors leaves the prior
+/// install's state looking current, the delta filter selects nothing, and a
+/// native addon built for the old major survives untouched — the cache layers
+/// downstream never get consulted. Engine-name granularity (major, os, arch)
+/// rather than the raw version keeps a patch bump from forcing a full scan.
 fn dep_build_policy_hash(
     build_policy: &aube_scripts::BuildPolicy,
     default_trust_floor: &super::default_trust::DefaultTrustFloor,
+    node_version: Option<&str>,
 ) -> String {
     let policy = build_policy.fingerprint();
     let floor = default_trust_floor.fingerprint();
+    let engine = node_version.map_or_else(aube_lockfile::graph_hash::platform_name, |v| {
+        aube_lockfile::graph_hash::engine_name_default(v).0
+    });
     let mut hasher = blake3::Hasher::new();
-    hasher.update(b"dep-build-policy-v1");
+    hasher.update(b"dep-build-policy-v2");
     hasher.update(&(policy.len() as u64).to_le_bytes());
     hasher.update(policy.as_bytes());
     hasher.update(&(floor.len() as u64).to_le_bytes());
     hasher.update(floor.as_bytes());
+    hasher.update(&(engine.len() as u64).to_le_bytes());
+    hasher.update(engine.as_bytes());
     hasher.finalize().to_hex().to_string()
 }
 
@@ -228,7 +241,8 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
     }
 
     let filtered_install = !workspace_filter_empty || dep_selection.is_filtered();
-    let dep_build_policy_hash = dep_build_policy_hash(build_policy, default_trust_floor);
+    let dep_build_policy_hash =
+        dep_build_policy_hash(build_policy, default_trust_floor, node_version);
     let lifecycle_delta_filter = if ignore_scripts {
         None
     } else {
@@ -651,6 +665,37 @@ mod tests {
             "unexpected policy warnings: {warnings:?}"
         );
         policy
+    }
+
+    #[test]
+    fn dep_build_policy_hash_tracks_the_node_major() {
+        // The delta filter reuses the prior install's selection whenever this
+        // hash is unchanged, so a Node major switch has to move it — otherwise
+        // the lifecycle phase is skipped and a native addon built for the old
+        // ABI is never rebuilt. A patch bump must NOT move it: the engine name
+        // is major-granular, and rescanning every build on a 22.15.0 → 22.15.1
+        // upgrade would be pure cost.
+        let (policy, floor) = (
+            policy(),
+            super::super::default_trust::DefaultTrustFloor::disabled(),
+        );
+        let h = |v: Option<&str>| dep_build_policy_hash(&policy, &floor, v);
+
+        assert_ne!(
+            h(Some("22.15.0")),
+            h(Some("26.5.0")),
+            "a Node major switch must widen the lifecycle scan"
+        );
+        assert_eq!(
+            h(Some("22.15.0")),
+            h(Some("22.15.1")),
+            "a patch bump shares the ABI and must stay a narrow scan"
+        );
+        assert_ne!(
+            h(None),
+            h(Some("22.15.0")),
+            "an unresolved version must not collide with a resolved one"
+        );
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -430,7 +430,7 @@ fn check_needs_install_compute(
             aube_util::diag::Span::new(aube_util::diag::Category::Frozen, "settings_hash");
         let current_settings_hash = hash_settings(project_dir, cli_flags);
         if current_settings_hash != state.settings_hash {
-            return Some(".npmrc or workspace config has changed".into());
+            return Some("install settings or the active Node version have changed".into());
         }
     }
 
@@ -1447,6 +1447,21 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
         hasher.update(p.as_bytes());
         hasher.update(b"\x1f");
     }
+    hasher.update(b"\0");
+    // The Node engine builds run against. Without it a Node major switch leaves
+    // this hash unchanged, the install reports itself current, and a native
+    // addon compiled for the previous ABI is never revisited — the delta filter
+    // and the side-effects cache downstream never get the chance. Engine-name
+    // granularity (major, os, arch) rather than the raw version keeps a patch
+    // bump from invalidating a warm tree.
+    let engine = crate::engines::effective_node_version(
+        aube_settings::resolved::node_version(&ctx).as_deref(),
+    )
+    .map_or_else(aube_lockfile::graph_hash::platform_name, |v| {
+        aube_lockfile::graph_hash::engine_name_default(&v).0
+    });
+    hasher.update(b"engine=");
+    hasher.update(engine.as_bytes());
     hasher.update(b"\0");
     // Embedder-supplied extra fingerprint: an install-shape input the host
     // controls outside aube's resolved settings (nub's phantom-eject flag,

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -1451,18 +1451,30 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     // The Node engine builds run against. Without it a Node major switch leaves
     // this hash unchanged, the install reports itself current, and a native
     // addon compiled for the previous ABI is never revisited — the delta filter
-    // and the side-effects cache downstream never get the chance. Engine-name
-    // granularity (major, os, arch) rather than the raw version keeps a patch
-    // bump from invalidating a warm tree.
-    let engine = crate::engines::effective_node_version(
-        aube_settings::resolved::node_version(&ctx).as_deref(),
-    )
-    .map_or_else(aube_lockfile::graph_hash::platform_name, |v| {
-        aube_lockfile::graph_hash::engine_name_default(&v).0
-    });
-    hasher.update(b"engine=");
-    hasher.update(engine.as_bytes());
-    hasher.update(b"\0");
+    // and the side-effects cache downstream never get the chance.
+    //
+    // Gated on the embedder owning Node provisioning, because only then is the
+    // value STABLE ACROSS THIS HASH'S TWO CALL SITES. The freshness check runs
+    // before `runtime::ensure` populates `runtime::current()`, the state write
+    // runs after; under runtime switching those observe different versions, so
+    // folding a resolver-derived value would hash differently at check time and
+    // write time and never converge — a permanent warm-path miss. An embedder
+    // that provisions Node publishes its resolved version into the engine
+    // context before any install code runs, so both sites read one value.
+    // Standalone aube keeps its byte-for-byte hash; its own delta gate
+    // (`dep_build_policy_hash`) is engine-aware and computed after `ensure`,
+    // where the resolver has settled.
+    if !aube_util::embedder().runtime_switching {
+        let engine = crate::engines::effective_node_version(
+            aube_settings::resolved::node_version(&ctx).as_deref(),
+        )
+        .map_or_else(aube_lockfile::graph_hash::platform_name, |v| {
+            aube_lockfile::graph_hash::engine_name_default(&v).0
+        });
+        hasher.update(b"engine=");
+        hasher.update(engine.as_bytes());
+        hasher.update(b"\0");
+    }
     // Embedder-supplied extra fingerprint: an install-shape input the host
     // controls outside aube's resolved settings (nub's phantom-eject flag,
     // which changes which packages materialize but rides no setting). `None`


### PR DESCRIPTION
## The bug

A Node major switch could leave a native addon compiled against the previous ABI in place, with the install reporting success.

Two gates sit upstream of the side-effects cache, and both were engine-blind:

- `check_needs_install` decides the tree is current from `hash_settings`, which enumerates `node_linker`, the hoist family, `modules_dir`, import method and the rest, but carried no Node input. A plain repeat install after a switch short-circuited before any lifecycle work.
- `lifecycle_delta_filter` then narrows the phase to packages whose `dep_path` changed, gated on `dep_build_policy_hash` — also engine-free. So even a full install skipped the unchanged addon.

The cache layers keyed by engine in #537 and #538 sit downstream of both, so on a plain switch they were never reached.

## Reproduction

One project, one native addon (`NODE_MODULE`-registered, so ABI-sensitive), default layout. Nothing changes between the two installs except the Node on `PATH` — no manifest edit, no `--force`, no policy change.

```
STEP 1: node v22.15.0 (NODE_MODULE_VERSION=127)
  side-effects-cache:   saved
  ran N scripts:        allowBuilds: ran 1 dep lifecycle
  artifact sha256:      a3731d6d406e3615
  require('abi-probe'): LOADED OK: pong

STEP 2: node v26.5.0 (NODE_MODULE_VERSION=147)
  needs-install reason: (none)              # short-circuited
  delta verdict:        (none)              # the delta filter never ran
  side-effects-cache:   (none)              # never consulted
  ran N scripts:        (none)
  artifact sha256:      a3731d6d406e3615    # still the ABI-127 build
  require('abi-probe'):
      Error: The module '.../abi_probe.node' was compiled against a different
      Node.js version using NODE_MODULE_VERSION 127. This version of Node.js
      requires NODE_MODULE_VERSION 147.
```

`install rc=0` throughout. That the cache is never consulted in step 2 is what shows the freshness check short-circuits ahead of the delta filter: fixing only the delta filter leaves the behavior unchanged.

## After the fix

The same fixture, reduced to the gates themselves: a dependency whose `postinstall` stamps `process.versions.modules`, so the recorded major shows directly whether the build re-ran. Nothing changes between arms but the Node on `PATH`.

```
                          base (main)          with this change
STEP 1  node v22.15.0
  ran N scripts:          ran 1 dep lifecycle  ran 1 dep lifecycle
  built by MODULE_VERSION 127                  127

STEP 2  node v26.5.0
  settings/Node changed:  (silent)             install settings or the active
                                               Node version have changed
  ran N scripts:          (none)               ran 1 dep lifecycle
  built by MODULE_VERSION 127  <- stale        147  <- rebuilt
```

## The fix

Fold the engine name into both gates. `hash_settings` resolves it through the existing override-aware ctx, so an `.npmrc` `node-version` is still honored, and `dep_build_policy_hash` takes it alongside the policy and floor fingerprints.

Granularity is the engine name (`<os>-<arch>-node<major>`), not the raw version, so a `22.15.0` to `22.15.1` bump does not invalidate a warm tree. The same string now identifies the engine in all four layers: the virtual-store path, the side-effects cache path, its marker, and these two gates.

`dep-build-policy-v1` becomes `-v2`, so the first install after upgrading runs one full eligible-build scan.

The settings-change reason now reads "install settings or the active Node version have changed" — a Node switch reaching that branch would otherwise report an `.npmrc` edit that never happened.

## Cost

A Node major switch now invalidates the warm install state, so the next install re-links and revisits build-allowed packages instead of reporting the tree current. That is the point: the prior behavior reported success over a broken addon. Within a major, nothing changes.

## Fork discipline

Not default-preserving — the two hashes move for standalone aube too, which is the latent-bug-fix clause: an install that leaves a wrong-ABI addon in place and exits 0 is broken on any host, not only under the embedder.

Closes #539
Refs #530, #537, #538



## Scope of the settings-hash half

The freshness hash folds the engine only when the embedder owns Node provisioning. That gate is load-bearing rather than conservative: `hash_settings` is computed once by the freshness check, before `runtime::ensure` resolves the runtime, and once by the state write, after it. Under runtime switching those two points see different values of `runtime::current()`, so a resolver-derived engine would make the two hashes disagree permanently — every install would report the settings changed and rewrite a value the next check could never match. An embedder that provisions Node publishes its resolved version before any install code runs, so both sites read one value.

Standalone aube therefore keeps this hash byte-for-byte, and its delta gate still tightens: `dep_build_policy_hash` is computed after `ensure`, where the resolver has settled. What stays open there is a pin change that alters the major without touching any hashed setting; closing it needs the runtime resolved before the fast path, which is a larger reordering than this fix.

Not covered by a test: that the fold stays absent under runtime switching. Asserting it means mutating the process-global engine context, which would race the engine-context tests in the same binary — a flake this repo treats as a defect. The gate is structural instead.
