### PR TITLE
pm: report linked files through the embedder events reporter, and roll back legacy lockfiles

### DIFF
--- a/vendor/aube/crates/aube/src/commands/add/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/add/mod.rs
@@ -80,6 +80,13 @@ pub async fn add_to_project(
         .wrap_err("failed to snapshot package.json before embedded add")?;
     let lockfile_path = no_save::lockfile_path_for_project(lock.project_dir())?;
     let original_lockfile = no_save::snapshot_lockfile(&lockfile_path)?;
+    // The rollback set must match what `--no-save` snapshots (`no_save::Snapshot`
+    // and the filtered add's root snapshot): the current-name lockfile *plus*
+    // every pre-rename legacy basename. A write during the add MIGRATES the
+    // legacy name (writes the current name, deletes the legacy file), so
+    // restoring only `lockfile_path` would leave the host's checked-in legacy
+    // lockfile deleted. Empty — hence inert — for standalone aube.
+    let original_legacy = no_save::snapshot_legacy_lockfiles(&lockfile_path)?;
     let mutation_control = options.control.clone();
     let mutation_result = install::control::scope(options.control.clone(), async {
         tokio::select! {
@@ -141,6 +148,16 @@ pub async fn add_to_project(
             let manifest_restore =
                 aube_util::fs_atomic::atomic_write(&manifest_path, &original_manifest);
             let lockfile_restore = no_save::restore_lockfile(&lockfile_path, &original_lockfile);
+            // Every path is attempted before any error is surfaced, so one
+            // unwritable file cannot strand the rest half-restored.
+            let mut legacy_restore: Result<(), miette::Report> = Ok(());
+            for (path, bytes) in &original_legacy {
+                if let Err(error) = no_save::restore_lockfile(path, bytes)
+                    && legacy_restore.is_ok()
+                {
+                    legacy_restore = Err(error);
+                }
+            }
             if let Err(restore_error) = manifest_restore {
                 return Err(miette!(
                     code = aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED,
@@ -148,6 +165,12 @@ pub async fn add_to_project(
                 ));
             }
             if let Err(restore_error) = lockfile_restore {
+                return Err(miette!(
+                    code = aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED,
+                    "install cancelled and lockfile rollback failed: {restore_error}"
+                ));
+            }
+            if let Err(restore_error) = legacy_restore {
                 return Err(miette!(
                     code = aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED,
                     "install cancelled and lockfile rollback failed: {restore_error}"

--- a/vendor/aube/crates/aube/src/commands/install/control.rs
+++ b/vendor/aube/crates/aube/src/commands/install/control.rs
@@ -39,6 +39,11 @@ pub struct InstallProgressSnapshot {
     pub downloaded: usize,
     pub downloaded_bytes: u64,
     pub estimated_bytes: u64,
+    /// Files — not packages — the linker has materialized so far. This is
+    /// the same live counter the CLI renderers show as `N files` during
+    /// linking; it only advances once the install driver hands the linker
+    /// its counter, so a host that takes no progress UI sees `0`.
+    pub files_linked: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -177,6 +182,9 @@ impl InstallControl {
             downloaded: 0,
             downloaded_bytes: 0,
             estimated_bytes: 0,
+            // Fast path: freshness state was already satisfied, so no link
+            // pass ran and no file was materialized.
+            files_linked: 0,
         }));
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -208,10 +208,14 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     }
     // Feed the progress UI its live file-linking counter so the linking
     // phase surfaces a ticking file count. Gated on the embedder opting
-    // into the redesigned progress UX (nub); standalone aube leaves it
-    // off, so its link pass never touches the counter (byte-identical).
+    // into the redesigned progress UX (nub), OR on Events mode, whose
+    // `InstallProgressSnapshot.files_linked` is otherwise pinned at zero for
+    // a host that consumes events without the TTY UX. Standalone aube sets
+    // neither on its default path, so its link pass never touches the
+    // counter (byte-identical).
     if let Some(p) = prog_ref
-        && aube_util::embedder().tty_progress
+        && (aube_util::embedder().tty_progress
+            || super::control::current().output_mode() == super::control::InstallOutputMode::Events)
     {
         linker = linker.with_link_progress(p.link_progress_counter());
     }

--- a/vendor/aube/crates/aube/src/progress/mod.rs
+++ b/vendor/aube/crates/aube/src/progress/mod.rs
@@ -321,6 +321,12 @@ struct EventState {
     downloaded: AtomicUsize,
     downloaded_bytes: AtomicU64,
     estimated_bytes: AtomicU64,
+    /// The *same* `Arc` the linker bumps per file — handed over by
+    /// `InstallProgress::link_progress_counter` — so a snapshot reads the
+    /// live count instead of a private zero. Events mode runs no ticker of
+    /// its own (unlike the TTY and CI renderers), so the value reaches the
+    /// host on whatever snapshot the install emits next.
+    files_linked: Arc<AtomicUsize>,
 }
 
 impl EventState {
@@ -344,6 +350,7 @@ impl EventState {
                 downloaded: self.downloaded.load(Ordering::Relaxed),
                 downloaded_bytes: self.downloaded_bytes.load(Ordering::Relaxed),
                 estimated_bytes: self.estimated_bytes.load(Ordering::Relaxed),
+                files_linked: self.files_linked.load(Ordering::Relaxed),
             }));
     }
 }
@@ -383,6 +390,12 @@ impl InstallProgress {
         match control.output_mode() {
             InstallOutputMode::Events => {
                 let reporter = control.reporter()?;
+                // One counter, two holders — same handoff as `new_ci`: the
+                // linker gets this `Arc` through `link_progress_counter()` and
+                // `EventState` reads it when building a snapshot. Constructing
+                // a second atomic here would leave the reported count pinned
+                // at zero.
+                let files_linked = Arc::new(AtomicUsize::new(0));
                 return Some(Self {
                     mode: Mode::Events(Arc::new(EventState {
                         reporter,
@@ -393,14 +406,10 @@ impl InstallProgress {
                         downloaded: AtomicUsize::new(0),
                         downloaded_bytes: AtomicU64::new(0),
                         estimated_bytes: AtomicU64::new(0),
+                        files_linked: files_linked.clone(),
                     })),
                     unpacked_sizes: Arc::new(Mutex::new(HashMap::new())),
-                    // The linker still bumps this through
-                    // `link_progress_counter()`, but `InstallProgressSnapshot`
-                    // carries no file-linking field, so Events mode has nowhere
-                    // to report it. Kept live rather than special-cased so the
-                    // linker handoff stays mode-agnostic.
-                    files_linked: Arc::new(AtomicUsize::new(0)),
+                    files_linked,
                 });
             }
             InstallOutputMode::Silent => return None,
@@ -1806,6 +1815,37 @@ mod tests {
                     && snapshot.downloaded == 1
                     && snapshot.downloaded_bytes == 512
         )));
+    }
+
+    /// Events mode must observe the linker's own counter, not a private copy:
+    /// the linker only ever touches the `Arc` it received from
+    /// `link_progress_counter()`, so a duplicate atomic would report `0` for
+    /// every install no matter how many files were materialized.
+    #[tokio::test]
+    async fn event_mode_reports_the_linkers_own_file_counter() {
+        let reporter = Arc::new(RecordingReporter::default());
+        let control = crate::commands::install::InstallControl::events(reporter.clone());
+
+        crate::commands::install::control::scope(control, async {
+            let progress = InstallProgress::try_new().unwrap();
+            progress.set_phase("linking");
+            // Stands in for the linker's materialize pass, which holds this
+            // exact counter and bumps it once per file.
+            progress
+                .link_progress_counter()
+                .fetch_add(7, Ordering::Relaxed);
+            progress.finish(false);
+        })
+        .await;
+
+        let events = reporter.0.lock().unwrap();
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                InstallEvent::Progress(snapshot) if snapshot.files_linked == 7
+            )),
+            "no snapshot carried the linker's file count: {events:?}"
+        );
     }
 
     /// Display width of a styled string: strip SGR escapes, then count chars

--- a/vendor/aube/crates/aube/tests/embed_legacy_lockfile.rs
+++ b/vendor/aube/crates/aube/tests/embed_legacy_lockfile.rs
@@ -1,0 +1,118 @@
+//! Cancellation rollback of the embed `add` API for a host mid-lockfile-rename.
+//!
+//! A host that renames its lockfile carries the prior basename in
+//! `lockfile_legacy_basenames` (nub: `lock.yaml`, superseded by `nub.lock`), and
+//! the first real write during an add MIGRATES it — writing the current name and
+//! deleting the legacy file. So `add_to_project`'s cancellation rollback has to
+//! restore the legacy name too, exactly as the `--no-save` paths do; restoring
+//! only the current name drops the host's checked-in lockfile.
+//!
+//! Its own test binary because the embedder profile is process-global and
+//! first-write-wins: `embed.rs`'s host has no legacy basenames (standalone
+//! aube's list is empty, so none of this is reachable there) and is deliberately
+//! shaped to mirror upstream's `Host`.
+
+use aube::embed::{AUBE, Host, InstallControl, InstallEvent, InstallReporter};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+const LEGACY_LOCKFILE: &str = "renamehost-legacy-lock.yaml";
+/// Minimal parseable lockfile in the pnpm-v9 form aube's canonical writer emits.
+const LOCKFILE_BYTES: &str = "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n";
+
+static RENAME_HOST: Host = Host {
+    name: "renamehost",
+    display_name: "renamehost",
+    version: "1.0.0",
+    user_agent: "renamehost/1.0.0",
+    self_names: &["renamehost"],
+    lockfile_basename: "renamehost-lock.yaml",
+    lockfile_legacy_basenames: &[LEGACY_LOCKFILE],
+    workspace_yaml: None,
+    manifest_namespace: "renamehost",
+    env_prefix: None,
+    config_env_prefix: None,
+    cache_namespace: "renamehost",
+    data_namespace: "renamehost",
+    runtime_switching: false,
+    self_engines_check: false,
+    self_update_enabled: false,
+    ..AUBE
+};
+
+/// Stands in for the migrating lockfile write. A real add deletes the legacy
+/// file from inside `write_lockfile_as`, but the install pipeline's last
+/// cancellation checkpoint sits at the head of the link phase — ahead of every
+/// event a reporter can observe after that write — so the write-then-cancel
+/// ordering cannot be driven from outside the pipeline. Deleting the file at a
+/// point where cancellation *is* honored reproduces the on-disk state the
+/// rollback has to undo.
+struct MigrateThenCancel {
+    legacy: PathBuf,
+    control: Mutex<Option<InstallControl>>,
+}
+
+impl InstallReporter for MigrateThenCancel {
+    fn report(&self, _event: InstallEvent) {
+        if let Some(control) = self.control.lock().unwrap().take() {
+            std::fs::remove_file(&self.legacy).expect("legacy lockfile must exist to be migrated");
+            control.cancel();
+        }
+    }
+}
+
+#[tokio::test]
+async fn cancelled_add_restores_migrated_legacy_lockfile() {
+    aube::embed::initialize(
+        &RENAME_HOST,
+        vec![("minimumReleaseAge".to_string(), "0".to_string())],
+    );
+
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"app","version":"1.0.0"}
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(project.path().join("localdep")).unwrap();
+    std::fs::write(
+        project.path().join("localdep/package.json"),
+        r#"{"name":"localdep","version":"1.0.0"}
+"#,
+    )
+    .unwrap();
+    let legacy = project.path().join(LEGACY_LOCKFILE);
+    std::fs::write(&legacy, LOCKFILE_BYTES).unwrap();
+
+    let reporter = Arc::new(MigrateThenCancel {
+        legacy: legacy.clone(),
+        control: Mutex::new(None),
+    });
+    let control = InstallControl::events(reporter.clone());
+    *reporter.control.lock().unwrap() = Some(control.clone());
+
+    let error = aube::embed::add(
+        project.path(),
+        &["localdep@file:./localdep".to_string()],
+        aube::embed::AddToProjectOptions {
+            offline: true,
+            control,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(
+        aube::embed::error_code(&error).as_deref(),
+        Some(aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED),
+        "the add must fail as cancelled, not for some unrelated reason"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&legacy).ok().as_deref(),
+        Some(LOCKFILE_BYTES),
+        "cancellation must restore {} — the legacy-named lockfile the add migrated away",
+        legacy.display()
+    );
+}


### PR DESCRIPTION
Two fixes to aube's embedding API — the surface nub vendors but does not itself consume. nub calls `aube::commands::<verb>::run()` directly and never selects Events mode, so neither bug is reachable from nub's CLI today; both are fixed so the vendored tree is correct if that surface is ever wired.

## Linked-file count reaches the events reporter

`InstallProgressSnapshot` gains `files_linked`. The counter is the linker's own `Arc`, reached through `link_progress_counter()`, so a host consuming events sees the same live linking signal nub's TTY line already renders.

`link.rs` previously handed that counter to the linker only when the embedder opted into the TTY progress UX. That would have pinned the new field at zero for exactly the host Events mode exists to serve — a field that always reports `0` is worse than no field — so it now also passes it under Events. Standalone aube selects neither, leaving its link pass byte-identical.

**Known limitation, stated rather than hidden:** Events mode has no heartbeat, so nothing emits between the linking phase start and `finish()`. A host reads `0` on the Linking snapshot and the true total on Complete. The value is loaded per snapshot rather than latched, so it starts ticking the moment any mid-link emission exists; adding an Events heartbeat thread is a larger change and deliberately out of scope here.

## Cancellation restores legacy lockfiles

`add_to_project`'s rollback restored only the current-name lockfile. A write during the add migrates a legacy basename — writes the current name, deletes the legacy file — so a cancelled embedded add could leave the host's checked-in legacy lockfile deleted.

It now snapshots and restores the same set `--no-save` does, through the existing `no_save::snapshot_legacy_lockfiles`, so all three rollback paths agree rather than drifting apart. Every path is attempted before an error surfaces, so one unwritable file cannot strand the rest half-restored. Standalone aube's profile carries no legacy basenames, making the loop inert there.

## Verification

- aube: `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo test --workspace --lib` 2,612 passed / 0 failed; the new `embed_legacy_lockfile` test passes.
- nub: `check -p nub-cli --all-targets`, `clippy --all-targets --all-features -- -D warnings`, and `fmt --check` all clean.
- The `files_linked` test bumps the counter through `link_progress_counter()` — the linker's only handle — so a duplicate atomic in `EventState` would read `0` and fail it.
- Tests are unit-level by necessity: nub's CLI never selects Events mode and `add_to_project` has no nub call sites, so an end-to-end through nub is unreachable for either path.

Closes #521
Closes #522
