### PR TITLE
Polish nub init and enforce the release-age floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ It's fast — avoids the per-command Node.js bootstrap lag incurred by JS-based 
 - 🛡️ Blocks postinstall by default
 - 🦠 Checks [osv.dev](https://osv.dev) for known-malicious package versions during resolution by default
 - 🔻 Refuses provenance downgrades by default
-- ⏳ 24-hour `minimumReleaseAge` by default
+- ⏳ Strict 24-hour `minimumReleaseAge` by default
 
 ### Compatibility
 

--- a/crates/nub-cli/src/init.rs
+++ b/crates/nub-cli/src/init.rs
@@ -96,7 +96,7 @@ pub(crate) fn run_init(opts: InitOptions) -> Result<i32> {
         false
     } else if interactive {
         match prompt_choice(
-            "Initialize a git repository?",
+            "Initialize a Git repository?",
             &[("Yes", true), ("No", false)],
         )? {
             None => return Ok(130),
@@ -156,7 +156,9 @@ pub(crate) fn run_init(opts: InitOptions) -> Result<i32> {
     } else {
         println!();
     }
-    println!("next: nub {entry}");
+    use clx::style;
+    println!("Your project is ready!");
+    println!("Try running `{}`", style::ecyan(format!("nub {entry}")));
     Ok(0)
 }
 
@@ -215,12 +217,18 @@ const TSCONFIG: &str = r#"{
 }
 "#;
 
-/// Keep demand's text editor, but replace its broken submitted frame. The
-/// library under-counts its two-line input by one, leaving the title behind;
-/// it also renders the raw empty input instead of the default Nub applies.
+/// Keep demand's text editor, but use its inline mode so editing and submitted
+/// states occupy the same row. Demand cannot use a different separator after
+/// submission, so replace its success row with Nub's dim-label `:` form.
 fn prompt_name(default_name: &str) -> Result<Option<String>> {
+    let mut theme = demand::Theme::new();
+    theme.title.set_dimmed(true);
+    theme.input_prompt.set_dimmed(true);
     let input = demand::Input::new("Project name")
+        .inline(true)
+        .prompt("> ")
         .placeholder(default_name)
+        .theme(&theme)
         .validation(|s| {
             if s.is_empty() || !sanitize_name(s).is_empty() {
                 Ok(())
@@ -237,16 +245,12 @@ fn prompt_name(default_name: &str) -> Result<Option<String>> {
             } else {
                 sanitize_name(&raw)
             };
-            // demand leaves both its original title and its empty/raw success
-            // line in the terminal. Replace them with the resolved value once.
-            term.clear_last_lines(2)
+            term.clear_last_lines(1)
                 .context("clearing project-name prompt")?;
             write_prompt_answer(&term, "Project name", &name)?;
             Ok(Some(name))
         }
         Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
-            // Its interrupted path clears only the editable row, leaving the
-            // title behind for the same off-by-one reason.
             term.clear_last_lines(1)
                 .context("clearing cancelled project-name prompt")?;
             Ok(None)
@@ -305,7 +309,7 @@ fn prompt_choice<T: Copy>(title: &str, options: &[(&str, T)]) -> Result<Option<T
 
 fn render_choice_frame<T>(title: &str, options: &[(&str, T)], selected: usize) -> String {
     use clx::style;
-    let mut out = format!("{}\n", style::estyle(title).bold());
+    let mut out = format!("{}\n", style::estyle(title).dim());
     for (index, (label, _)) in options.iter().enumerate() {
         if index == selected {
             out.push_str(&format!("{} ■ {label}\n", style::ecyan("❯")));
@@ -324,8 +328,17 @@ fn render_choice_frame<T>(title: &str, options: &[(&str, T)], selected: usize) -
 
 fn write_prompt_answer(term: &Term, title: &str, answer: &str) -> Result<()> {
     use clx::style;
-    term.write_line(&format!("{title} {}", style::egreen(answer)))
+    let label = prompt_answer_label(title);
+    term.write_line(&format!("{} {answer}", style::estyle(label).dim()))
         .with_context(|| format!("writing {title} answer"))
+}
+
+fn prompt_answer_label(title: &str) -> String {
+    if title.ends_with('?') {
+        title.to_string()
+    } else {
+        format!("{title}:")
+    }
 }
 
 fn print_created_tree(name: &str, files: &[(&str, String)], git_ran: bool) {
@@ -512,6 +525,16 @@ mod tests {
         assert!(
             !frame.contains("48;"),
             "choice prompt must never set an ANSI background: {frame:?}"
+        );
+    }
+
+    #[test]
+    fn submitted_prompt_labels_use_colons_without_double_punctuating_questions() {
+        assert_eq!(prompt_answer_label("Project name"), "Project name:");
+        assert_eq!(prompt_answer_label("Language"), "Language:");
+        assert_eq!(
+            prompt_answer_label("Initialize a Git repository?"),
+            "Initialize a Git repository?"
         );
     }
 }

--- a/crates/nub-cli/src/init.rs
+++ b/crates/nub-cli/src/init.rs
@@ -6,9 +6,11 @@
 //! fields `nub pm pin` writes, via the same writer.
 
 use std::io::IsTerminal;
+use std::io::Write;
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
+use console::{Key, Term};
 use serde_json::{Map, Value, json};
 
 /// `@types/node` range written into the scaffold. Tracks the docs' latest-major
@@ -45,7 +47,7 @@ pub(crate) fn run_init(opts: InitOptions) -> Result<i32> {
 
     let cwd = std::env::current_dir().context("resolving the current directory")?;
     let interactive =
-        !opts.yes && std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+        !opts.yes && std::io::stdin().is_terminal() && std::io::stderr().is_terminal();
 
     // A basename that sanitizes to nothing (non-Latin script, all-symbol) must
     // not become `"name": ""` — an invalid manifest that fails silently later.
@@ -68,33 +70,16 @@ pub(crate) fn run_init(opts: InitOptions) -> Result<i32> {
             }
             s
         }
-        (None, true) => {
-            let input = demand::Input::new("Project name")
-                .placeholder(&default_name)
-                .validation(|s| {
-                    if s.is_empty() || !sanitize_name(s).is_empty() {
-                        Ok(())
-                    } else {
-                        Err("not a valid package name")
-                    }
-                })
-                .run();
-            match prompt_result(input)? {
-                None => return Ok(130),
-                Some(s) if s.trim().is_empty() => default_name,
-                Some(s) => sanitize_name(&s),
-            }
-        }
+        (None, true) => match prompt_name(&default_name)? {
+            None => return Ok(130),
+            Some(s) => s,
+        },
         (None, false) => default_name,
     };
     let typescript = if opts.js {
         false
     } else if interactive {
-        let pick = demand::Select::new("Language")
-            .option(demand::DemandOption::new(true).label("TypeScript"))
-            .option(demand::DemandOption::new(false).label("JavaScript"))
-            .run();
-        match prompt_result(pick)? {
+        match prompt_choice("Language", &[("TypeScript", true), ("JavaScript", false)])? {
             None => return Ok(130),
             Some(ts) => ts,
         }
@@ -106,7 +91,10 @@ pub(crate) fn run_init(opts: InitOptions) -> Result<i32> {
     let git = if opts.no_git || in_repo {
         false
     } else if interactive {
-        match prompt_result(demand::Confirm::new("Initialize a git repository?").run())? {
+        match prompt_choice(
+            "Initialize a git repository?",
+            &[("Yes", true), ("No", false)],
+        )? {
             None => return Ok(130),
             Some(yes) => yes,
         }
@@ -151,13 +139,7 @@ pub(crate) fn run_init(opts: InitOptions) -> Result<i32> {
 
     let git_ran = git && git_init(&cwd);
 
-    println!("created {name}");
-    for (file, _) in &files {
-        println!("  {file}");
-    }
-    if git_ran {
-        println!("  .git/ initialized");
-    }
+    print_created_tree(&name, &files, git_ran);
 
     // The engine's install output already ends with a blank line; only the
     // no-install path needs its own separator before the next-step line.
@@ -228,13 +210,132 @@ const TSCONFIG: &str = r#"{
 }
 "#;
 
-/// Ctrl-C / Esc on a prompt is a deliberate cancel: `None` (caller exits 130,
-/// the conventional SIGINT code), never an error report.
-fn prompt_result<T>(r: std::io::Result<T>) -> Result<Option<T>> {
-    match r {
-        Ok(v) => Ok(Some(v)),
-        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => Ok(None),
-        Err(e) => Err(e).context("reading prompt input"),
+/// Keep demand's text editor, but replace its broken submitted frame. The
+/// library under-counts its two-line input by one, leaving the title behind;
+/// it also renders the raw empty input instead of the default Nub applies.
+fn prompt_name(default_name: &str) -> Result<Option<String>> {
+    let input = demand::Input::new("Project name")
+        .placeholder(default_name)
+        .validation(|s| {
+            if s.is_empty() || !sanitize_name(s).is_empty() {
+                Ok(())
+            } else {
+                Err("not a valid package name")
+            }
+        })
+        .run();
+    let term = Term::stderr();
+    match input {
+        Ok(raw) => {
+            let name = if raw.trim().is_empty() {
+                default_name.to_string()
+            } else {
+                sanitize_name(&raw)
+            };
+            // demand leaves both its original title and its empty/raw success
+            // line in the terminal. Replace them with the resolved value once.
+            term.clear_last_lines(2)
+                .context("clearing project-name prompt")?;
+            write_prompt_answer(&term, "Project name", &name)?;
+            Ok(Some(name))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+            // Its interrupted path clears only the editable row, leaving the
+            // title behind for the same off-by-one reason.
+            term.clear_last_lines(1)
+                .context("clearing cancelled project-name prompt")?;
+            Ok(None)
+        }
+        Err(e) => Err(e).context("reading project-name prompt"),
+    }
+}
+
+struct CursorGuard<'a>(&'a Term);
+
+impl Drop for CursorGuard<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.show_cursor();
+    }
+}
+
+/// Nub's compact multiple-choice prompt: the same filled/hollow square cells
+/// and cyan focus cursor as `update -i`, without demand's button backgrounds.
+fn prompt_choice<T: Copy>(title: &str, options: &[(&str, T)]) -> Result<Option<T>> {
+    debug_assert!(!options.is_empty());
+    let term = Term::stderr();
+    let _guard = CursorGuard(&term);
+    term.hide_cursor().context("hiding prompt cursor")?;
+    let mut selected = 0usize;
+    let lines = options.len() + 2;
+
+    loop {
+        let frame = render_choice_frame(title, options, selected);
+        write!(&term, "{frame}").context("rendering choice prompt")?;
+        term.flush().context("flushing choice prompt")?;
+        // Raw here means Ctrl-C is returned as a key instead of re-raised as a
+        // process signal, so the cursor guard and frame cleanup still run.
+        let key = match term.read_key_raw() {
+            Ok(key) => key,
+            Err(error) => {
+                let _ = term.clear_last_lines(lines);
+                return Err(error).context("reading choice prompt");
+            }
+        };
+        term.clear_last_lines(lines)
+            .context("clearing choice prompt")?;
+        match key {
+            Key::ArrowDown | Key::Char('j') => selected = (selected + 1) % options.len(),
+            Key::ArrowUp | Key::Char('k') => {
+                selected = (selected + options.len() - 1) % options.len()
+            }
+            Key::Enter => {
+                write_prompt_answer(&term, title, options[selected].0)?;
+                return Ok(Some(options[selected].1));
+            }
+            Key::Escape | Key::CtrlC => return Ok(None),
+            _ => {}
+        }
+    }
+}
+
+fn render_choice_frame<T>(title: &str, options: &[(&str, T)], selected: usize) -> String {
+    use clx::style;
+    let mut out = format!("{}\n", style::estyle(title).bold());
+    for (index, (label, _)) in options.iter().enumerate() {
+        if index == selected {
+            out.push_str(&format!("{} ■ {label}\n", style::ecyan("❯")));
+        } else {
+            out.push_str(&format!("  {} {label}\n", style::estyle("□").dim()));
+        }
+    }
+    out.push_str(
+        &style::estyle("↑/↓ move · enter confirm · esc cancel")
+            .dim()
+            .to_string(),
+    );
+    out.push('\n');
+    out
+}
+
+fn write_prompt_answer(term: &Term, title: &str, answer: &str) -> Result<()> {
+    use clx::style;
+    term.write_line(&format!("{title} {}", style::egreen(answer)))
+        .with_context(|| format!("writing {title} answer"))
+}
+
+fn print_created_tree(name: &str, files: &[(&str, String)], git_ran: bool) {
+    println!("created {name}");
+    let entries = files.len() + usize::from(git_ran);
+    for (index, (file, _)) in files.iter().enumerate() {
+        let branch = if index + 1 == entries {
+            "└──"
+        } else {
+            "├──"
+        };
+        println!("{branch} {file}");
+    }
+    if git_ran {
+        println!("└── .git/");
     }
 }
 
@@ -366,5 +467,22 @@ mod tests {
         let v: Value = serde_json::from_str(&manifest_json("demo", "index.js", false)).unwrap();
         assert!(v.get("devDependencies").is_none());
         assert_eq!(v["scripts"]["start"], "nub index.js");
+    }
+
+    #[test]
+    fn choice_frame_uses_square_cells_without_background_colors() {
+        let frame = render_choice_frame(
+            "Language",
+            &[("TypeScript", true), ("JavaScript", false)],
+            0,
+        );
+        let plain = console::strip_ansi_codes(&frame);
+        assert!(plain.contains("❯ ■ TypeScript"));
+        assert!(plain.contains("  □ JavaScript"));
+        assert!(plain.contains("↑/↓ move · enter confirm · esc cancel"));
+        assert!(
+            !frame.contains("48;"),
+            "choice prompt must never set an ANSI background: {frame:?}"
+        );
     }
 }

--- a/crates/nub-cli/src/init.rs
+++ b/crates/nub-cli/src/init.rs
@@ -15,10 +15,14 @@ use serde_json::{Map, Value, json};
 
 /// `@types/node` range written into the scaffold. Tracks the docs' latest-major
 /// rule (AGENTS.md: examples always use the newest Node major) — bump on a new
-/// `@types/node` major at release time. `@nubjs/types` needs no constant: it is
-/// version-locked to nub itself (`make version` bumps npm/nub-types with the
-/// binary), so its range derives from CARGO_PKG_VERSION.
+/// `@types/node` major at release time.
 const TYPES_NODE_RANGE: &str = "^26";
+
+/// Oldest declarations that cover the scaffold's `Worker`-era ambient surface.
+/// The upper bound is filled from the running Nub version: init may install an
+/// older mature release under the 24-hour age gate, but never declarations for
+/// runtime behavior newer than the binary being used.
+const NUB_TYPES_FLOOR: &str = "0.4.13";
 
 /// `typescript` range written into the scaffold. Nub transpiles TS itself, so
 /// the compiler package exists for the editor's typechecking (`tsc --noEmit`,
@@ -158,10 +162,11 @@ pub(crate) fn run_init(opts: InitOptions) -> Result<i32> {
 
 /// The scaffolded manifest, in display order. Identity fields come from the
 /// same writer `nub pm pin` uses so the two surfaces can't drift; both the pin
-/// and the `@nubjs/types` range derive from the running version (nub-types is
-/// release-locked to the binary).
+/// and the `@nubjs/types` ceiling derive from the running version (nub-types is
+/// released in lockstep with the binary).
 fn manifest_json(name: &str, entry: &str, typescript: bool) -> String {
     let ver = env!("CARGO_PKG_VERSION");
+    let nub_types_range = format!(">={NUB_TYPES_FLOOR} <={ver}");
     let mut root = Map::new();
     root.insert("name".into(), Value::String(name.into()));
     root.insert("version".into(), Value::String("0.0.1".into()));
@@ -172,7 +177,7 @@ fn manifest_json(name: &str, entry: &str, typescript: bool) -> String {
         root.insert(
             "devDependencies".into(),
             json!({
-                "@nubjs/types": format!("^{ver}"),
+                "@nubjs/types": nub_types_range,
                 "@types/node": TYPES_NODE_RANGE,
                 "typescript": TYPESCRIPT_RANGE,
             }),
@@ -452,12 +457,36 @@ mod tests {
     }
 
     #[test]
-    fn manifest_carries_identity_pin_and_lockstep_types_range() {
+    fn manifest_carries_identity_pin_and_age_gate_compatible_types_range() {
         let v: Value = serde_json::from_str(&manifest_json("demo", "index.ts", true)).unwrap();
         let ver = env!("CARGO_PKG_VERSION");
         assert_eq!(v["packageManager"], format!("nub@{ver}"));
         assert_eq!(v["devEngines"]["packageManager"]["name"], "nub");
-        assert_eq!(v["devDependencies"]["@nubjs/types"], format!("^{ver}"));
+        assert_eq!(
+            v["devDependencies"]["@nubjs/types"],
+            format!(">={NUB_TYPES_FLOOR} <={ver}")
+        );
+        let types_range =
+            node_semver::Range::parse(v["devDependencies"]["@nubjs/types"].as_str().unwrap())
+                .unwrap();
+        assert!(
+            node_semver::Version::parse(NUB_TYPES_FLOOR)
+                .unwrap()
+                .satisfies(&types_range),
+            "the oldest mature declaration release must remain selectable"
+        );
+        assert!(
+            node_semver::Version::parse(ver)
+                .unwrap()
+                .satisfies(&types_range),
+            "the running Nub release must remain selectable after it matures"
+        );
+        assert!(
+            !node_semver::Version::parse("99.0.0")
+                .unwrap()
+                .satisfies(&types_range),
+            "declarations newer than the running Nub runtime must not be selected"
+        );
         assert_eq!(v["devDependencies"]["typescript"], TYPESCRIPT_RANGE);
         assert_eq!(v["scripts"]["start"], "nub index.ts");
     }

--- a/crates/nub-cli/src/init.rs
+++ b/crates/nub-cli/src/init.rs
@@ -218,8 +218,9 @@ const TSCONFIG: &str = r#"{
 "#;
 
 /// Keep demand's text editor, but use its inline mode so editing and submitted
-/// states occupy the same row. Demand cannot use a different separator after
-/// submission, so replace its success row with Nub's dim-label `:` form.
+/// states occupy the same row. Demand under-counts an inline input's height as
+/// zero, so its editing row survives submission alongside its success row;
+/// clear both before writing Nub's dim-label `:` form.
 fn prompt_name(default_name: &str) -> Result<Option<String>> {
     let mut theme = demand::Theme::new();
     theme.title.set_dimmed(true);
@@ -245,7 +246,7 @@ fn prompt_name(default_name: &str) -> Result<Option<String>> {
             } else {
                 sanitize_name(&raw)
             };
-            term.clear_last_lines(1)
+            term.clear_last_lines(2)
                 .context("clearing project-name prompt")?;
             write_prompt_answer(&term, "Project name", &name)?;
             Ok(Some(name))

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2249,6 +2249,12 @@ fn nub_setting_defaults(
             fresh_format.to_string(),
         ),
         ("defaultTrust".to_string(), "true".to_string()),
+        // Nub advertises a real 24-hour trust floor, not an advisory one. Pin
+        // both halves at Nub's embedder tier rather than inheriting the engine's
+        // current built-in values: 1440 minutes, and fail closed when no mature
+        // version satisfies the range. Explicit user config still wins.
+        ("minimumReleaseAge".to_string(), "1440".to_string()),
+        ("minimumReleaseAgeStrict".to_string(), "true".to_string()),
         ("virtualStoreDir".to_string(), store_dir.clone()),
         ("stateDir".to_string(), store_dir),
         (
@@ -3200,6 +3206,16 @@ mod tests {
                 VirtualStoreLocality::Default,
             );
             assert_eq!(get(&defaults, "defaultLockfileFormat"), Some("pnpm"));
+            assert_eq!(
+                get(&defaults, "minimumReleaseAge"),
+                Some("1440"),
+                "Nub's release-age floor must default to 24 hours"
+            );
+            assert_eq!(
+                get(&defaults, "minimumReleaseAgeStrict"),
+                Some("true"),
+                "Nub's 24-hour release-age floor must fail closed by default"
+            );
             assert_eq!(
                 get(&defaults, "virtualStoreDir"),
                 Some("node_modules/.store")

--- a/crates/nub-cli/tests/init_cmd.rs
+++ b/crates/nub-cli/tests/init_cmd.rs
@@ -74,7 +74,11 @@ fn scaffolds_five_files_with_identity_pin_and_type_devdeps() {
     let ver = env!("CARGO_PKG_VERSION");
     assert_eq!(pkg["packageManager"], format!("nub@{ver}"));
     assert_eq!(pkg["devEngines"]["packageManager"]["name"], "nub");
-    assert_eq!(pkg["devDependencies"]["@nubjs/types"], format!("^{ver}"));
+    assert_eq!(
+        pkg["devDependencies"]["@nubjs/types"],
+        format!(">=0.4.13 <={ver}"),
+        "the type range must let the age gate choose an older mature release"
+    );
     assert!(pkg["devDependencies"]["@types/node"].is_string());
     assert!(pkg["devDependencies"]["typescript"].is_string());
     assert_eq!(pkg["type"], "module");

--- a/crates/nub-cli/tests/init_cmd.rs
+++ b/crates/nub-cli/tests/init_cmd.rs
@@ -1,11 +1,19 @@
 //! `nub init` through the real binary — scaffold contents, refuse-don't-
 //! clobber, the JS variant, and the non-TTY prompt fallback. Everything here
-//! is offline by construction (`--no-install`); the install-by-default path
-//! rides the engine's own install coverage plus manual e2e. Design record:
+//! is offline by construction: scaffold-only cases use `--no-install`, while
+//! the install-by-default case uses an in-process registry. Design record:
 //! wiki/commands/init.md.
 
+use base64::Engine as _;
+use sha2::{Digest, Sha512};
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
 
 fn nub_binary() -> PathBuf {
     let mut path = std::env::current_exe().unwrap();
@@ -39,18 +47,218 @@ struct Out {
 /// Piped stdio — every run here exercises the non-TTY path (prompts must
 /// fall back to defaults, never hang).
 fn run_init(dir: &Path, args: &[&str]) -> Out {
-    let out = Command::new(nub_binary())
+    run_init_with_home(dir, args, None)
+}
+
+fn run_init_with_home(dir: &Path, args: &[&str], home: Option<&Path>) -> Out {
+    let mut command = Command::new(nub_binary());
+    command
         .arg("init")
         .args(args)
         .current_dir(dir)
-        .stdin(std::process::Stdio::piped())
-        .output()
-        .expect("failed to spawn nub");
+        .stdin(std::process::Stdio::piped());
+    if let Some(home) = home {
+        command
+            .env("HOME", home)
+            .env("USERPROFILE", home)
+            .env("XDG_CONFIG_HOME", home.join("xdg-config"))
+            .env("XDG_DATA_HOME", home.join("xdg-data"))
+            .env("XDG_CACHE_HOME", home.join("xdg-cache"))
+            .env("NUB_SELF_SHIM", "0");
+    }
+    let out = command.output().expect("failed to spawn nub");
     Out {
         stdout: String::from_utf8_lossy(&out.stdout).to_string(),
         stderr: String::from_utf8_lossy(&out.stderr).to_string(),
         code: out.status.code().unwrap_or(-1),
     }
+}
+
+fn package_tarball(name: &str, version: &str) -> Vec<u8> {
+    // Deterministic npm tarballs containing only package/package.json. Keeping
+    // these inline makes the registry fixture portable without test-only deps.
+    let encoded = match (name, version) {
+        ("@nubjs/types", "0.4.13") => {
+            "H4sIAAAAAAAC/+3JQQrCMBBG4RwlzFrS1KZduPIqUYJYMQ1NK4h4d6MuBNcigu/bvOGf5LcHvwtVetb0eYjqw2zROfdo8V5r2+Xrvu913XaN0lZ9wZwnP2qt/tRFoj8GWck6zps+V9M5hSwLOYUx74dYHtY4UzdyVQAAAAAAAAAAAAAAAACAH3IDKfXZJwAoAAA="
+        }
+        ("@nubjs/types", "0.5.0") => {
+            "H4sIAAAAAAAC/+3JQQrCMBBG4RwlZC3pRJouXHmVKEGsmIamFUS8u1EXgmsRwfdt3vBPDttD2MUmP2v7MiT1YVJ1bfto9V4R7173fXfOd0ulRX3BXKYwaq3+1MWkcIxmZdZp3vSlmc45FrMwpziW/ZDqQ6y3Yq4KAAAAAAAAAAAAAAAAAPBLbnGuIdkAKAAA"
+        }
+        ("@types/node", "26.1.1") => {
+            "H4sIAAAAAAAC/+3IsQrCMBhF4TxK+GdJk9JmcPJVggZRMQ1NFYr47kYdBGcRwfMt53JzWB/CNjb5WbMvQ1IfZivfdY9W77W2d699/53rfau0VV9wKlMYtVZ/6iIpHKMsZTXNOZYmDZsoCznHseyGVP/WG2ecXBUAAAAAAAAAAAAAAAAA4JfcAHOReCIAKAAA"
+        }
+        ("typescript", "7.0.2") => {
+            "H4sIAAAAAAAC/+3IwQoCIRhFYR9F/nWYEzZCbyODxBQ5olMQ0btntQhaRwSdb3MuN4dhH7ZxmZ81uzol9WG26Z17tHmvtc6/9v3vunXvlbbqC451DkVr9acuksIhykbmc451KGOeZSGnWOo4pXZ7Y81KrgoAAAAAAAAAAAAAAAAA8FturWWPWwAoAAA"
+        }
+        _ => panic!("missing registry fixture tarball for {name}@{version}"),
+    };
+    base64::engine::general_purpose::STANDARD_NO_PAD
+        .decode(encoded.trim_end_matches('='))
+        .unwrap()
+}
+
+fn integrity(bytes: &[u8]) -> String {
+    format!(
+        "sha512-{}",
+        base64::engine::general_purpose::STANDARD.encode(Sha512::digest(bytes))
+    )
+}
+
+struct RegistryFixture {
+    url: String,
+    stop: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl RegistryFixture {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+
+        let packages: [(&str, &[&str]); 3] = [
+            ("@nubjs/types", &["0.4.13", "0.5.0"]),
+            ("@types/node", &["26.1.1"]),
+            ("typescript", &["7.0.2"]),
+        ];
+        let mut responses = HashMap::<String, (String, Vec<u8>)>::new();
+        for (name, versions) in packages {
+            let mut version_entries = serde_json::Map::new();
+            let mut times = serde_json::Map::new();
+            for version in versions {
+                let tarball = package_tarball(name, version);
+                let tarball_path =
+                    format!("/tarballs/{}-{version}.tgz", name.replace(['@', '/'], "_"));
+                version_entries.insert(
+                    (*version).to_string(),
+                    serde_json::json!({
+                        "name": name,
+                        "version": version,
+                        "dist": {
+                            "tarball": format!("{url}{}", &tarball_path[1..]),
+                            "integrity": integrity(&tarball),
+                        }
+                    }),
+                );
+                times.insert(
+                    (*version).to_string(),
+                    serde_json::Value::String(
+                        if *version == "0.5.0" {
+                            "2999-01-01T00:00:00.000Z"
+                        } else {
+                            "2020-01-01T00:00:00.000Z"
+                        }
+                        .to_string(),
+                    ),
+                );
+                responses.insert(
+                    tarball_path,
+                    ("application/octet-stream".to_string(), tarball),
+                );
+            }
+            let latest = versions.last().unwrap();
+            let packument = serde_json::to_vec(&serde_json::json!({
+                "name": name,
+                "dist-tags": { "latest": latest },
+                "versions": version_entries,
+                "time": times,
+            }))
+            .unwrap();
+            let encoded_name = name.replace('/', "%2f");
+            responses.insert(
+                format!("/{encoded_name}"),
+                ("application/json".to_string(), packument),
+            );
+        }
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let server_stop = stop.clone();
+        let responses = Arc::new(responses);
+        let server = thread::spawn(move || {
+            while !server_stop.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let responses = responses.clone();
+                        thread::spawn(move || {
+                            let mut request = [0_u8; 4096];
+                            let size = stream.read(&mut request).unwrap_or(0);
+                            let first_line = String::from_utf8_lossy(&request[..size])
+                                .lines()
+                                .next()
+                                .unwrap_or_default()
+                                .to_ascii_lowercase();
+                            let path = first_line.split_whitespace().nth(1).unwrap_or("/");
+                            let (status, content_type, body) =
+                                if let Some((content_type, body)) = responses.get(path) {
+                                    ("200 OK", content_type.as_str(), body.as_slice())
+                                } else {
+                                    ("404 Not Found", "text/plain", b"not found".as_slice())
+                                };
+                            let headers = format!(
+                                "HTTP/1.1 {status}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                                body.len()
+                            );
+                            stream.write_all(headers.as_bytes()).unwrap();
+                            stream.write_all(body).unwrap();
+                        });
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(std::time::Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("registry fixture failed: {error}"),
+                }
+            }
+        });
+
+        Self {
+            url,
+            stop,
+            thread: Some(server),
+        }
+    }
+}
+
+impl Drop for RegistryFixture {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(thread) = self.thread.take() {
+            thread.join().unwrap();
+        }
+    }
+}
+
+#[test]
+fn default_install_uses_a_mature_types_release_under_the_strict_age_floor() {
+    let registry = RegistryFixture::start();
+    let dir = tmpdir("strict-install");
+    let home = tmpdir("strict-install-home");
+    std::fs::write(
+        dir.join(".npmrc"),
+        format!("registry={}\nfetch-retries=0\n", registry.url),
+    )
+    .unwrap();
+
+    let out = run_init_with_home(
+        &dir,
+        &["-y", "--no-git", "--name", "strict-install"],
+        Some(&home),
+    );
+    assert_eq!(
+        out.code, 0,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    let installed: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.join("node_modules/@nubjs/types/package.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(installed["version"], "0.4.13");
+    assert!(
+        !std::fs::read_to_string(dir.join(".npmrc"))
+            .unwrap()
+            .contains("minimumReleaseAgeExclude"),
+        "strict mode must not persist a release-age exclusion"
+    );
 }
 
 #[test]

--- a/crates/nub-cli/tests/init_cmd.rs
+++ b/crates/nub-cli/tests/init_cmd.rs
@@ -56,7 +56,7 @@ fn run_init(dir: &Path, args: &[&str]) -> Out {
 #[test]
 fn scaffolds_five_files_with_identity_pin_and_type_devdeps() {
     let dir = tmpdir("basic");
-    let out = run_init(&dir, &["-y", "--no-install"]);
+    let out = run_init(&dir, &["-y", "--no-install", "--name", "basic"]);
     assert_eq!(out.code, 0, "stderr: {}", out.stderr);
     for f in [
         "package.json",
@@ -89,6 +89,19 @@ fn scaffolds_five_files_with_identity_pin_and_type_devdeps() {
         "summary names the next command: {}",
         out.stdout
     );
+    assert!(
+        out.stdout.contains(
+            "created basic\n\
+             ├── package.json\n\
+             ├── tsconfig.json\n\
+             ├── index.ts\n\
+             ├── .gitignore\n\
+             ├── README.md\n\
+             └── .git/"
+        ),
+        "summary renders the generated structure as a tree: {}",
+        out.stdout
+    );
 }
 
 #[test]
@@ -108,6 +121,17 @@ fn js_variant_skips_tsconfig_and_type_devdeps() {
     assert_eq!(pkg["name"], "my-app", "--name is sanitized");
     assert!(pkg.get("devDependencies").is_none());
     assert_eq!(pkg["scripts"]["start"], "nub index.js");
+    assert!(
+        out.stdout.contains(
+            "created my-app\n\
+             ├── package.json\n\
+             ├── index.js\n\
+             ├── .gitignore\n\
+             └── README.md"
+        ),
+        "no-git JS tree closes on README: {}",
+        out.stdout
+    );
 }
 
 /// `git check-ignore` is the only honest test of a `.gitignore`: the scaffold's

--- a/crates/nub-cli/tests/init_cmd.rs
+++ b/crates/nub-cli/tests/init_cmd.rs
@@ -297,7 +297,8 @@ fn scaffolds_five_files_with_identity_pin_and_type_devdeps() {
         "tsconfig must wire the type packages: {tsconfig}"
     );
     assert!(
-        out.stdout.contains("next: nub index.ts"),
+        out.stdout
+            .contains("Your project is ready!\nTry running `nub index.ts`"),
         "summary names the next command: {}",
         out.stdout
     );

--- a/crates/nub-cli/tests/pm_identity.rs
+++ b/crates/nub-cli/tests/pm_identity.rs
@@ -60,6 +60,33 @@ fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
 
 const EMPTY_PNPM: &str = r#"{"name":"app","version":"1.0.0","packageManager":"pnpm@9.1.0"}"#;
 
+#[test]
+fn nub_defaults_to_a_strict_24_hour_release_age_floor() {
+    let dir = project("release-age-default", r#"{"name":"app","version":"1.0.0"}"#);
+    let (age, stderr, code) = run(&dir, &["config", "get", "minimumReleaseAge"]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(age.trim(), "1440");
+    let (strict, stderr, code) = run(&dir, &["config", "get", "minimumReleaseAgeStrict"]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(strict.trim(), "true");
+
+    std::fs::write(
+        dir.join(".npmrc"),
+        "registry=http://127.0.0.1:1/\nminimumReleaseAge=0\nminimumReleaseAgeStrict=false\n",
+    )
+    .unwrap();
+    let (age, stderr, code) = run(&dir, &["config", "get", "minimumReleaseAge"]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(age.trim(), "0", "explicit project config must still win");
+    let (strict, stderr, code) = run(&dir, &["config", "get", "minimumReleaseAgeStrict"]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(
+        strict.trim(),
+        "false",
+        "explicit project config must still win"
+    );
+}
+
 /// Rows "none|none → nub identity" (truly-fresh) and "declared X|none → X's
 /// format" (the fresh-with-pin row): an empty-deps install writes the
 /// identity's lockfile without any network.

--- a/site/content/blog/nub-0-5-0.mdx
+++ b/site/content/blog/nub-0-5-0.mdx
@@ -10,12 +10,12 @@ Nub 0.5.0 ships `nub init` — one command scaffolds a TypeScript project that r
 ```console
 $ nub init -y
 created my-app
-  package.json
-  tsconfig.json
-  index.ts
-  .gitignore
-  README.md
-  .git/ initialized
+├── package.json
+├── tsconfig.json
+├── index.ts
+├── .gitignore
+├── README.md
+└── .git/
 
 devDependencies:
 + @nubjs/types@0.5.0

--- a/site/content/blog/nub-0-5-0.mdx
+++ b/site/content/blog/nub-0-5-0.mdx
@@ -22,7 +22,8 @@ devDependencies:
 + @types/node@26.1.1
 + typescript@7.0.2
 
-next: nub index.ts
+Your project is ready!
+Try running `nub index.ts`
 ```
 
 ## nub init

--- a/site/content/blog/nub-0-5-0.mdx
+++ b/site/content/blog/nub-0-5-0.mdx
@@ -18,7 +18,7 @@ created my-app
 └── .git/
 
 devDependencies:
-+ @nubjs/types@0.5.0
++ @nubjs/types@0.4.13
 + @types/node@26.1.1
 + typescript@7.0.2
 

--- a/site/content/docs/init.mdx
+++ b/site/content/docs/init.mdx
@@ -8,12 +8,12 @@ Running `nub init` scaffolds a minimal TypeScript project that runs and typechec
 ```console
 $ nub init -y
 created my-app
-  package.json
-  tsconfig.json
-  index.ts
-  .gitignore
-  README.md
-  .git/ initialized
+├── package.json
+├── tsconfig.json
+├── index.ts
+├── .gitignore
+├── README.md
+└── .git/
 
 devDependencies:
 + @nubjs/types@0.4.13

--- a/site/content/docs/init.mdx
+++ b/site/content/docs/init.mdx
@@ -20,7 +20,8 @@ devDependencies:
 + @types/node@26.1.1
 + typescript@7.0.2
 
-next: nub index.ts
+Your project is ready!
+Try running `nub index.ts`
 ```
 
 The scaffold has zero runtime dependencies — the entry file runs right away:

--- a/site/content/docs/init.mdx
+++ b/site/content/docs/init.mdx
@@ -39,22 +39,25 @@ The manifest makes this a Nub-native project — the same `packageManager` pin a
   "name": "my-app",
   "version": "0.0.1",
   "type": "module",
-  "packageManager": "nub@0.4.13",
+  "packageManager": "nub@0.5.0",
   "devEngines": {
-    "packageManager": { "name": "nub", "version": "^0.4.13", "onFail": "warn" }
+    "packageManager": { "name": "nub", "version": "^0.5.0", "onFail": "warn" }
   },
   "scripts": {
     "start": "nub index.ts"
   },
   "devDependencies": {
-    "@nubjs/types": "^0.4.13",
+    "@nubjs/types": ">=0.4.13 <=0.5.0",
     "@types/node": "^26",
     "typescript": "^7"
   }
 }
 ```
 
-The install step resolves those and writes Nub's neutral lockfile, `nub.lock`.
+The `@nubjs/types` range is capped at the running Nub version, but allows an
+older release so the default 24-hour cooling window can select the newest
+mature declarations. The install step resolves the dependencies and writes
+Nub's neutral lockfile, `nub.lock`.
 
 The tsconfig targets Node's own TypeScript semantics — `nodenext` resolution, `verbatimModuleSyntax`, strict mode, `noEmit` (Nub transpiles; the installed `typescript` is for the editor and typechecking) — and wires the installed type packages:
 


### PR DESCRIPTION
## Summary

- standardize `nub init` choices on square-cell controls and collapse the project-name prompt correctly
- render generated files as a tree
- make Nub’s 24-hour release-age floor strict by default while allowing init to select mature `@nubjs/types` declarations

## Verification

- `scripts/rust-build.sh test -p nub-cli init::tests`
- `scripts/rust-build.sh test -p nub-cli --test init_cmd`
- `scripts/rust-build.sh test -p nub-cli --test pm_identity nub_defaults_to_a_strict_24_hour_release_age_floor`
- `scripts/rust-build.sh clippy -p nub-cli --all-targets --all-features -- -D warnings`
- real PTY checks for default, JavaScript/no-git, and cancellation flows