### PR TITLE
test(pm): pin that approve-builds runs a local-source dep's build immediately

### DIFF
--- a/vendor/aube/crates/aube/tests/e2e.rs
+++ b/vendor/aube/crates/aube/tests/e2e.rs
@@ -233,7 +233,8 @@ fn approve_builds_surfaces_and_runs_a_local_source_dep() {
     // set, never in the store the enumeration read. This pins the whole
     // contract: the dep is listed, approving it writes the *source* key
     // (a bare name never authorizes a source-backed build), and the
-    // build then runs on reinstall while the warning clears.
+    // build runs during that same `approve-builds` call, then survives
+    // the next install while the warning clears.
     let _guard = e2e_lock();
     let sbx = Sandbox::new();
 
@@ -276,14 +277,20 @@ fn approve_builds_surfaces_and_runs_a_local_source_dep() {
         .success()
         .stdout(predicates::str::contains("dep@file:./dep"));
 
-    // Approving records the source key in the build policy.
+    // Approving records the source key AND runs the build in the same
+    // invocation, exactly like a registry dep. The scoped rebuild reaches
+    // the tree because approval cannot move a local dep's cell: the
+    // build-state-sensitive graph hash is applied only by
+    // `virtual_store_subdir` (the shared global store, which `file:` deps
+    // never enter), never by the `aube_dir_entry_name` that
+    // `materialized_pkg_dir` reconstructs.
     sbx.cmd().args(["approve-builds", "--all"]).assert().success();
+    assert!(
+        marker_exists_under(&node_modules, "BUILT_527_MARKER"),
+        "approve-builds must run a local-source dep's build in the same invocation"
+    );
 
-    // The now-approved build runs on the next install, and the warning
-    // is gone. (A source-backed dep's virtual-store path folds in build
-    // state, so — unlike a registry dep — the scoped rebuild inside
-    // `approve-builds` can't reach the freshly-approved tree; the full
-    // install re-materializes and builds it.)
+    // Reinstalling keeps the build and clears the warning.
     sbx.cmd()
         .arg("install")
         .assert()
@@ -291,7 +298,7 @@ fn approve_builds_surfaces_and_runs_a_local_source_dep() {
         .stderr(predicates::str::contains("dep@file:./dep").not());
     assert!(
         marker_exists_under(&node_modules, "BUILT_527_MARKER"),
-        "approving a local-source dep must let its build script run on reinstall"
+        "the approved build must survive a reinstall"
     );
     sbx.cmd()
         .arg("ignored-builds")


### PR DESCRIPTION
PR #534 shipped a "known limitation" in a test comment: that a source-backed (`file:`) dependency, unlike a registry dep, could not build during the `approve-builds` invocation and only built on the next install. It is false. A `file:` dep builds during `approve-builds`, exactly like a registry dep.

## Why it's stable

`LocalSource::dep_path` derives a directory dep's virtual-store cell from the normalized path alone (`source.rs`) — no build state enters it — and `is_globally_shareable` covers only git and remote tarballs, so a `file:` dep never enters the global store whose subdir folds in the build-state graph hash. Approval therefore cannot move the cell, and the scoped rebuild inside `approve-builds` reaches it.

## Verified against the built binary

Across three fresh fixtures, each with a uniquely-named `file:` dependency carrying a `postinstall`: the marker is absent after `install` and present immediately after `approve-builds`.

A unique name per fixture is load-bearing here — `file:` deps key the global virtual store by `name@version`, so a fixture reusing a name from an earlier run links that run's already-built cell and the build is (correctly) skipped, which reads as a false confirmation of the limitation.

## Change

The `#527` e2e test asserted the marker only after the follow-up install, so nothing pinned the real behavior and the false claim sat unchallenged in a comment. It now asserts the build ran during `approve-builds`, keeps the survives-a-reinstall assertion, and records why the path is stable. Test-only; `cargo test -p aube --test e2e` green.

Refs #534
