### PR TITLE
refactor(pm): document the default-trust log-collapse invariant

### DIFF
--- a/crates/nub-cli/src/pm_engine/log.rs
+++ b/crates/nub-cli/src/pm_engine/log.rs
@@ -25,6 +25,7 @@
 //! revisit if the fork ever exports the pausing writer.
 
 use super::present;
+use std::borrow::Cow;
 use std::sync::OnceLock;
 use tracing::field::{Field, Visit};
 use tracing_subscriber::layer::SubscriberExt as _;
@@ -127,19 +128,28 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for RewriteLayer {
     }
 }
 
+/// Render one event as `LEVEL message [field=value …]`.
+///
+/// The default-trust disclosure collapses to just its message: the engine
+/// already names every package the floor let through, so `count`/`packages`
+/// restate the list verbatim and `code` buys nothing on an allow-side notice
+/// with no action to take (the deny-side warning keeps its code — that one is
+/// actionable). Matched on the pre-rewrite `WARN_AUBE_*` spelling because this
+/// runs *before* [`present::rewrite`] flips the prefix to `WARN_NUB_*`; swap
+/// that order and the match silently stops firing.
 fn format_line(level: &str, fields: &LineVisitor) -> String {
     let is_default_trust_disclosure = fields.rest.iter().any(|(name, value)| {
         *name == "code" && value == aube_codes::warnings::WARN_AUBE_DEFAULT_TRUST_BUILDS
     });
-    let message = if is_default_trust_disclosure {
-        fields
-            .message
-            .split_once("package(s): ")
-            .map(|(_, packages)| format!("defaultTrust: running build scripts for {packages}"))
-            .unwrap_or_else(|| fields.message.clone())
-    } else {
-        fields.message.clone()
-    };
+    // Upstream renders "…for {n} default-trusted package(s): {list}" — keep the
+    // list, drop the count it already implies. If that wording ever moves, the
+    // message survives whole rather than truncating to nothing.
+    let mut message = Cow::Borrowed(fields.message.as_str());
+    if is_default_trust_disclosure
+        && let Some((_, packages)) = fields.message.split_once("package(s): ")
+    {
+        message = format!("defaultTrust: running build scripts for {packages}").into();
+    }
 
     let mut line = format!("{level} {message}");
     for (name, value) in &fields.rest {
@@ -183,7 +193,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_trust_disclosure_does_not_repeat_count_and_packages() {
+    fn default_trust_disclosure_collapses_to_the_package_list() {
         let fields = LineVisitor {
             message: "defaultTrust: running build scripts for 1 default-trusted package(s): msgpackr-extract@3.0.4".into(),
             rest: vec![
@@ -199,6 +209,45 @@ mod tests {
         assert_eq!(
             format_line("WARN", &fields),
             "WARN defaultTrust: running build scripts for msgpackr-extract@3.0.4"
+        );
+    }
+
+    /// The collapse is keyed on one code — every other engine warning keeps its
+    /// fields, including the deny-side counterpart the user must act on.
+    #[test]
+    fn other_warnings_keep_their_fields() {
+        let fields = LineVisitor {
+            message: "Ignored build scripts: core-js@3.40.0".into(),
+            rest: vec![
+                (
+                    "code",
+                    aube_codes::warnings::WARN_AUBE_IGNORED_BUILD_SCRIPTS.into(),
+                ),
+                ("count", "1".into()),
+            ],
+        };
+
+        assert_eq!(
+            format_line("WARN", &fields),
+            "WARN Ignored build scripts: core-js@3.40.0 code=WARN_AUBE_IGNORED_BUILD_SCRIPTS count=1"
+        );
+    }
+
+    /// If upstream ever rewords the message, the packages must still reach the
+    /// user — the floor is never a silent allow path.
+    #[test]
+    fn default_trust_disclosure_survives_an_upstream_reword() {
+        let fields = LineVisitor {
+            message: "defaultTrust: reworded upstream, esbuild@0.21.5".into(),
+            rest: vec![(
+                "code",
+                aube_codes::warnings::WARN_AUBE_DEFAULT_TRUST_BUILDS.into(),
+            )],
+        };
+
+        assert_eq!(
+            format_line("WARN", &fields),
+            "WARN defaultTrust: reworded upstream, esbuild@0.21.5"
         );
     }
 }


### PR DESCRIPTION
Follow-up polish on the `format_line` collapse from #541. No behavior change.

- Document why the collapse is correct: `format_line` must run before `present::rewrite` so it matches the pre-rewrite `WARN_AUBE_*` code — reordering silently breaks it. Undocumented until now.
- Drop the redundant `message.clone()` via `Cow`.
- Rename the test and cover two untested branches: other warnings keep their fields; the disclosure survives an upstream reword.

Local test run relied on CI — an environment limit was killing local builds.