### PR TITLE
fix(pm): make every remaining install cache layer engine-aware

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1390,10 +1390,21 @@ fn augmentation_to_lifecycle_overlay(
 /// re-entrant / broken install); the resolved Node *version* is published to the
 /// engine either way. Called once per command from [`engine_session`].
 fn apply_lifecycle_augmentation(cwd: &Path) {
+    // Anchor Node discovery at the workspace root — the directory aube keys its
+    // install state and virtual store at (`dirs::workspace_or_project_root`). An
+    // install from a member materializes the ONE shared tree for the whole
+    // workspace, so the Node its build scripts compile against — and the engine
+    // that keys the ABI caches — must be the root's pin, not whichever member the
+    // shell sits in. Discovering from the raw cwd instead lets a member's own
+    // `.nvmrc` flip the engine key against a root-anchored state file, thrashing
+    // the warm path. `detect_project` walks up by the same rule aube's root does.
+    let anchor = nub_core::workspace::detect::detect_project(cwd)
+        .map(|p| p.workspace_root.unwrap_or(p.root))
+        .unwrap_or_else(|| cwd.to_path_buf());
     // The project's Node — pin-aware (`.nvmrc`/`.node-version`/`engines`), NOT
     // the ambient PATH node. This resolved version drives flag injection and its
     // path pins npm_node_execpath. Mirrors build_script_command's discovery.
-    let discovered = nub_core::node::discovery::discover_node(cwd);
+    let discovered = nub_core::node::discovery::discover_node(&anchor);
     // Published ABOVE the early returns: the engine keys its GVS virtual-store
     // paths — and validates `engines.node` — off this version, so it has to name
     // the Node dependency build scripts actually compile against. That stays the

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -50,6 +50,9 @@ pub(super) struct LinkPhaseInput<'a> {
     pub(super) manifests: &'a [(String, aube_manifest::PackageJson)],
     pub(super) manifest: &'a aube_manifest::PackageJson,
     pub(super) build_policy: &'a aube_scripts::BuildPolicy,
+    /// Mirrors the lifecycle phase's floor gate so the engine fold covers every
+    /// package that can build. See [`super::build_may_key_engine`].
+    pub(super) default_trust_enabled: bool,
     pub(super) node_version: Option<&'a str>,
     pub(super) prewarm_graph_hashes:
         Option<&'a std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>>,
@@ -101,6 +104,7 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         manifests,
         manifest,
         build_policy,
+        default_trust_enabled,
         node_version,
         prewarm_graph_hashes,
         aube_dir,
@@ -345,7 +349,7 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         } else {
             let engine = node_version.map(aube_lockfile::graph_hash::engine_name_default);
             let allow = |pkg: &aube_lockfile::LockedPackage| {
-                super::package_build_is_allowed(build_policy, pkg)
+                super::build_may_key_engine(build_policy, pkg, default_trust_enabled)
             };
             aube_lockfile::graph_hash::compute_graph_hashes_full(
                 graph_for_link,

--- a/vendor/aube/crates/aube/src/commands/install/materialize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/materialize.rs
@@ -14,6 +14,9 @@ pub(super) struct GvsPrewarmInputs {
     pub patch_hashes: std::collections::BTreeMap<String, String>,
     pub node_version: Option<String>,
     pub build_policy: std::sync::Arc<aube_scripts::BuildPolicy>,
+    /// See [`super::build_may_key_engine`] — the prewarm must key exactly as the
+    /// link phase will, or link discards these hashes and recomputes.
+    pub default_trust_enabled: bool,
     pub use_global_virtual_store_override: Option<bool>,
     /// The RESOLVED per-project virtual store dir (the same value the
     /// link phase applies via `with_aube_dir_override`). Threaded here
@@ -121,6 +124,7 @@ pub(super) async fn run_gvs_prewarm_materializer(
         patch_hashes,
         node_version,
         build_policy,
+        default_trust_enabled,
         use_global_virtual_store_override,
         virtual_store_dir,
         supported_architectures,
@@ -213,7 +217,7 @@ pub(super) async fn run_gvs_prewarm_materializer(
             "graph_hash_compute",
         );
         let allow = |pkg: &aube_lockfile::LockedPackage| {
-            super::package_build_is_allowed(&build_policy_for_hash, pkg)
+            super::build_may_key_engine(&build_policy_for_hash, pkg, default_trust_enabled)
         };
         let patch_hash_fn = |name: &str, version: &str| -> Option<String> {
             let key = format!("{name}@{version}");

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -231,6 +231,34 @@ pub(crate) fn package_build_is_allowed(
     )
 }
 
+/// Whether a package's virtual-store path must carry the engine fingerprint.
+///
+/// Deliberately a SUPERSET of the policy decision: the lifecycle phase also
+/// builds packages the `defaultTrust` floor clears, and a package that builds
+/// writes its artifacts into that directory. Keying only on an explicit allow
+/// would give a floor-built native addon an engine-agnostic path — shared
+/// across every project on the machine — so two Node majors would overwrite
+/// each other's `build/Release/*.node` there.
+///
+/// The floor's dynamic gates (advisory vetting, the cooling window) are
+/// deliberately NOT consulted: they only ever narrow what builds, and they are
+/// unknown at prewarm time, which computes these same hashes before the floor
+/// exists. Folding the engine for a package that then does not build costs a
+/// little store dedup; omitting it for one that does is the ABI bug.
+pub(crate) fn build_may_key_engine(
+    policy: &aube_scripts::BuildPolicy,
+    pkg: &aube_lockfile::LockedPackage,
+    default_trust_enabled: bool,
+) -> bool {
+    package_build_is_allowed(policy, pkg)
+        || (default_trust_enabled
+            // Registry-resolved only, matching `DefaultTrustFloor::trusts` so an
+            // alias or a file:/git package cannot borrow a listed name's bucket.
+            && pkg.local_source.is_none()
+            && !pkg.registry_git_hosted
+            && aube_scripts::is_default_trusted(pkg.registry_name()))
+}
+
 #[derive(serde::Deserialize, serde::Serialize)]
 struct TrustPolicyValidationStamp {
     key: String,
@@ -1018,10 +1046,9 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // does, so a fresh install and the drift check agree.
     let effective_package_extensions_checksum =
         if aube_util::engine_context().enforce_package_extensions_checksum {
-            aube_lockfile::pnpm::package_extensions_checksum(&settings::effective_package_extensions(
-                &manifest,
-                &settings_ctx,
-            ))
+            aube_lockfile::pnpm::package_extensions_checksum(
+                &settings::effective_package_extensions(&manifest, &settings_ctx),
+            )
         } else {
             None
         };
@@ -1445,9 +1472,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             let network_mode = opts.network_mode;
             let cwd_for_client = cwd.clone();
 
-            let lock_node_version = crate::engines::effective_node_version(
-                aube_settings::resolved::node_version(&settings_ctx).as_deref(),
-            );
+            let lock_node_version = crate::engines::build_node_version();
             let lock_build_policy = std::sync::Arc::new(build_policy.clone());
             let lock_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
             let (lock_patches, lock_patch_hashes) =
@@ -1466,6 +1491,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 patch_hashes: lock_patch_hashes,
                 node_version: lock_node_version,
                 build_policy: lock_build_policy,
+                default_trust_enabled,
                 use_global_virtual_store_override: prewarm_gvs_override,
                 virtual_store_dir: aube_dir.clone(),
                 supported_architectures: lock_supported_architectures,
@@ -1603,9 +1629,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             // await) can compute the same graph hashes the link phase
             // will. Keeping a single source of truth avoids any
             // subdir-name drift between prewarm and link step 1.
-            let node_version_for_prewarm = crate::engines::effective_node_version(
-                aube_settings::resolved::node_version(&settings_ctx).as_deref(),
-            );
+            let node_version_for_prewarm = crate::engines::build_node_version();
             let build_policy_for_prewarm = std::sync::Arc::new(build_policy.clone());
             let client =
                 std::sync::Arc::new(make_client(&cwd).with_network_mode(opts.network_mode));
@@ -2380,6 +2404,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 patch_hashes: materialize_patch_hashes,
                 node_version: node_version_for_prewarm.clone(),
                 build_policy: build_policy_for_prewarm.clone(),
+                default_trust_enabled,
                 use_global_virtual_store_override: prewarm_gvs_override,
                 virtual_store_dir: aube_dir.clone(),
                 supported_architectures: prewarm_supported_architectures,
@@ -2869,7 +2894,12 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     let (jail_policy, jail_policy_warnings) =
         JailBuildPolicy::from_settings(&settings_ctx, &ws_config_shared);
     let node_version_override = aube_settings::resolved::node_version(&settings_ctx);
+    // Two questions with two answers: the `engines.node` check honors the
+    // validation-only `node-version` override; the ABI cache keys must reflect
+    // the Node that actually compiles the artifacts, which the override never
+    // switches.
     let node_version = crate::engines::effective_node_version(node_version_override.as_deref());
+    let build_node_version = crate::engines::build_node_version();
     crate::engines::run_checks(
         &aube_dir,
         &manifest,
@@ -2927,7 +2957,8 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         manifests: &manifests,
         manifest: &manifest,
         build_policy: &build_policy,
-        node_version: node_version.as_deref(),
+        default_trust_enabled,
+        node_version: build_node_version.as_deref(),
         prewarm_graph_hashes: prewarm_graph_hashes.as_ref(),
         aube_dir: &aube_dir,
         modules_dir_name: &modules_dir_name,
@@ -2977,7 +3008,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         aube_dir: &aube_dir,
         virtual_store_dir_max_length,
         child_concurrency,
-        node_version: node_version.as_deref(),
+        node_version: build_node_version.as_deref(),
         side_effects_cache_setting,
         side_effects_cache_readonly_setting,
         strict_dep_builds_setting,
@@ -3010,6 +3041,59 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod build_may_key_engine_tests {
+    use super::*;
+
+    fn pkg(name: &str) -> aube_lockfile::LockedPackage {
+        aube_lockfile::LockedPackage {
+            name: name.into(),
+            version: "1.0.0".into(),
+            dep_path: format!("{name}@1.0.0"),
+            ..Default::default()
+        }
+    }
+
+    fn empty_policy() -> aube_scripts::BuildPolicy {
+        aube_scripts::BuildPolicy::from_config(&BTreeMap::new(), &[], &[], false).0
+    }
+
+    #[test]
+    fn floor_trusted_package_keys_the_engine_without_an_explicit_allow() {
+        // The regression: the lifecycle phase builds `better-sqlite3` off the
+        // default-trust floor, but the virtual-store path folded the engine
+        // only for an explicitly allowed package — so its native build landed
+        // in a machine-global directory shared by every Node major.
+        let policy = empty_policy();
+        assert!(
+            build_may_key_engine(&policy, &pkg("better-sqlite3"), true),
+            "a floor-built package writes native artifacts and must key the engine"
+        );
+        assert!(
+            !build_may_key_engine(&policy, &pkg("better-sqlite3"), false),
+            "with the floor off the package cannot build, so the path stays engine-agnostic"
+        );
+        assert!(
+            !build_may_key_engine(&policy, &pkg("left-pad"), true),
+            "an unlisted package the floor never trusts must not fold the engine"
+        );
+    }
+
+    #[test]
+    fn floor_trust_does_not_extend_to_non_registry_sources() {
+        // Mirrors `DefaultTrustFloor::trusts`: an alias or a file:/git package
+        // must not borrow a listed name's bucket.
+        let policy = empty_policy();
+        let mut local = pkg("better-sqlite3");
+        local.local_source = Some(aube_lockfile::LocalSource::Directory("../vendored".into()));
+        assert!(!build_may_key_engine(&policy, &local, true));
+
+        let mut hosted = pkg("better-sqlite3");
+        hosted.registry_git_hosted = true;
+        assert!(!build_may_key_engine(&policy, &hosted, true));
+    }
 }
 
 #[cfg(test)]

--- a/vendor/aube/crates/aube/src/commands/rebuild.rs
+++ b/vendor/aube/crates/aube/src/commands/rebuild.rs
@@ -150,9 +150,7 @@ pub async fn run(
                 } else {
                     None
                 };
-            let node_version = crate::engines::effective_node_version(
-                aube_settings::resolved::node_version(&settings_ctx).as_deref(),
-            );
+            let node_version = crate::engines::build_node_version();
             // Re-emit per-dep `.bin/` shims so a rebuild on a tree
             // that pre-dates the transitive-bin fix still lands them
             // on PATH for the lifecycle scripts. `link_bins_for_dep`

--- a/vendor/aube/crates/aube/src/engines.rs
+++ b/vendor/aube/crates/aube/src/engines.rs
@@ -87,28 +87,24 @@ pub fn resolve_node_version(override_: Option<&str>) -> Option<String> {
     PROBED.get_or_init(probe_node_version).clone()
 }
 
-/// The Node version aube should report for engines checks once
-/// runtime switching is in play:
+/// The Node the install's build artifacts are actually compiled by. This is
+/// what every ABI-sensitive cache key must fold in — the virtual-store path,
+/// the side-effects cache and its marker, the delta and freshness gates:
 ///
-/// 1. an explicit `node-version` `.npmrc` override always wins
-///    (validation-only knob, pnpm semantics);
-/// 2. otherwise the resolved runtime context's version — engines must
-///    validate the node scripts will actually run on, not whatever
-///    PATH happened to carry;
-/// 3. otherwise the version an embedder provisioned
-///    ([`EngineContext::runtime_node_version`]) — the same rule as (2)
-///    for a host that owns provisioning itself and so leaves the
-///    resolver inert;
-/// 4. otherwise the memoized `node --version` probe.
+/// 1. the resolved runtime context's version — the Node scripts will run on;
+/// 2. otherwise the version an embedder provisioned
+///    ([`EngineContext::runtime_node_version`]) — the same, for a host that
+///    owns provisioning itself and so leaves the resolver inert;
+/// 3. otherwise the memoized `node --version` probe.
 ///
-/// Also the source of the GVS engine fingerprint, so a wrong answer
-/// here mis-keys virtual-store paths, not just the warning text.
+/// Deliberately NOT the `.npmrc` `node-version` override: that knob is
+/// validation-only (pnpm semantics — it never switches the runtime scripts
+/// run on), so letting it name the engine would key artifacts to a Node that
+/// never compiled them. Use [`effective_node_version`] where the override is
+/// meant to win — the `engines.node` check and `doctor`.
 ///
 /// [`EngineContext::runtime_node_version`]: aube_util::EngineContext::runtime_node_version
-pub fn effective_node_version(override_: Option<&str>) -> Option<String> {
-    if override_.is_some() {
-        return resolve_node_version(override_);
-    }
+pub fn build_node_version() -> Option<String> {
     if let Some(rt) = crate::runtime::current()
         && let Some(v) = &rt.version
     {
@@ -118,6 +114,18 @@ pub fn effective_node_version(override_: Option<&str>) -> Option<String> {
         return Some(v);
     }
     resolve_node_version(None)
+}
+
+/// The Node version for the `engines.node` check and `doctor` display: the
+/// `.npmrc` `node-version` override wins (validation-only knob, pnpm
+/// semantics), else [`build_node_version`]. Do NOT use this to key an
+/// ABI-sensitive cache — the override does not switch the runtime, so it would
+/// mis-key. That is [`build_node_version`]'s job.
+pub fn effective_node_version(override_: Option<&str>) -> Option<String> {
+    if override_.is_some() {
+        return resolve_node_version(override_);
+    }
+    build_node_version()
 }
 
 fn probe_node_version() -> Option<String> {
@@ -816,6 +824,28 @@ mod tests {
             effective_node_version(Some("v20.11.0")).as_deref(),
             Some("20.11.0"),
             "an explicit `node-version` override must still win"
+        );
+        aube_util::update_engine_context(|c| c.runtime_node_version = prev);
+    }
+
+    #[test]
+    fn build_node_version_ignores_the_validation_only_override() {
+        // `build_node_version` keys the ABI-sensitive caches, so it must reflect
+        // the Node that actually compiles — the provisioned/resolved one — never
+        // the `.npmrc` `node-version` knob, which is validation-only and never
+        // switches the runtime. `effective_node_version` still honors the
+        // override for the `engines.node` check.
+        let prev = aube_util::engine_context().runtime_node_version;
+        aube_util::update_engine_context(|c| c.runtime_node_version = Some("22.15.0".into()));
+        assert_eq!(
+            build_node_version().as_deref(),
+            Some("22.15.0"),
+            "the build version is the provisioned Node, regardless of any override"
+        );
+        assert_eq!(
+            effective_node_version(Some("v18.19.0")).as_deref(),
+            Some("18.19.0"),
+            "the validation path still honors the override — the split is intentional"
         );
         aube_util::update_engine_context(|c| c.runtime_node_version = prev);
     }

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -1465,12 +1465,10 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     // (`dep_build_policy_hash`) is engine-aware and computed after `ensure`,
     // where the resolver has settled.
     if !aube_util::embedder().runtime_switching {
-        let engine = crate::engines::effective_node_version(
-            aube_settings::resolved::node_version(&ctx).as_deref(),
-        )
-        .map_or_else(aube_lockfile::graph_hash::platform_name, |v| {
-            aube_lockfile::graph_hash::engine_name_default(&v).0
-        });
+        let engine = crate::engines::build_node_version()
+            .map_or_else(aube_lockfile::graph_hash::platform_name, |v| {
+                aube_lockfile::graph_hash::engine_name_default(&v).0
+            });
         hasher.update(b"engine=");
         hasher.update(engine.as_bytes());
         hasher.update(b"\0");


### PR DESCRIPTION
Three install cache layers still ignored the Node the artifacts are compiled by, so a native addon built under one Node major could be served to, or shared with, an install running a different major. Each is confirmed by a differential fixture (`better-sqlite3`, two Node majors) and pinned by a unit test. This continues the engine-keying work in #530, #537, #538, and #542 — the layers those closed all sit downstream of these.

## 1. GVS fold was blind to `defaultTrust`-floored builds

The virtual-store engine fingerprint folded in only for an explicitly allowed package, but the lifecycle phase also builds packages the `defaultTrust` floor clears. nub enables that floor by default, and its curated list is exactly the native-ABI packages (`better-sqlite3`, `sharp`, `bcrypt`, `canvas`, `node-pty`, …). So a floor-built addon got an engine-agnostic, machine-global, cross-project store path — two majors overwriting each other's `build/Release/*.node` there. Worse than the earlier layers: the victim install reports "Already up to date", so it is not repairable by a plain `nub install`, only `--force`.

```
# before: floor-built better-sqlite3 shares one bucket across majors
floor node22.15.0 -> better-sqlite3@12.11.1-4c55e1943396abea
floor node26.5.0  -> better-sqlite3@12.11.1-4c55e1943396abea

# after: segregated, and identical to an explicitly-allowed build
floor node22.15.0 -> better-sqlite3@12.11.1-aeb6e8ed40c40bc4
floor node26.5.0  -> better-sqlite3@12.11.1-527b3af3c84991cb
```

`build_may_key_engine` over-approximates the lifecycle gate on purpose: the floor's dynamic checks (advisory vetting, the cooling window) only ever narrow what builds, and are unknown at prewarm time where these hashes are first computed — and the link phase reuses the prewarm's hashes wholesale, so the two sites must agree. Threaded via one `default_trust_enabled` bool. Gated on that flag, so standalone aube — floor off by default — is byte-for-byte unchanged.

## 2. The validation-only `node-version` override keyed the ABI caches

`.npmrc node-version` is documented as validation-only (pnpm semantics — it never switches the runtime scripts run on), yet it was the top tier of `effective_node_version`, which feeds every ABI key. So it named a Node that never compiled the artifacts.

```
# real node 26, override node-version=22.15.0
before -> better-sqlite3@12.11.1-aeb6e8ed40c40bc4   # node22's bucket — wrong
after  -> better-sqlite3@12.11.1-527b3af3c84991cb   # real node26's bucket
```

`build_node_version` drops the override tier and feeds the six ABI-keying sites; `effective_node_version` keeps the override for the `engines.node` check and `doctor`, where it is meant to win. A justified latent-bug fix, not default-preserving: keying build artifacts off the override contradicts aube's own documented semantics on any host.

## 3. Workspace-member cwd flipped the engine key against root-anchored state

Install anchors its state and store at the workspace root, but nub published the engine from `discover_node(cwd)` — the process cwd. A member with its own `.nvmrc` then keyed a different major than the root, thrashing the warm path (a #542 regression on the freshness half).

```
# workspace root .nvmrc=22, member .nvmrc=26, install run from the member
before -> better-sqlite3@12.11.1-527b3af3c84991cb   # member's node26 — thrash
after  -> better-sqlite3@12.11.1-aeb6e8ed40c40bc4   # root's node22 — stable
```

Discovery is anchored at `detect_project(cwd).workspace_root` — the same directory aube keys state at, resolved by the same walk-up rule. nub-side only; standalone aube unaffected. A member install now builds the one shared tree against the root's Node, which is also the more correct behavior.

## Migration

Each fix moves a store path for the affected projects, so the next install re-materializes and rebuilds those subtrees once — no re-download (the CAS is integrity-keyed). Correct: the old entries were ABI-ambiguous.

Refs #530, #537, #538, #542
