### PR TITLE
ci: bun-style canary channel — build and publish every code push to main

### DIFF
--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -24,9 +24,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         # Writes /tmp/gh-releases.json: array of { tag, assets: [{ name, download_count }] }
+        # Prereleases are excluded: the rolling `canary` release is deleted and
+        # recreated on every main push, so its asset counts reset constantly and
+        # would corrupt the between-snapshot deltas.
         run: |
           gh api repos/nubjs/nub/releases --paginate \
-            --jq '[.[] | {tag: .tag_name, assets: [.assets[] | {name: .name, download_count: .download_count}]}]' \
+            --jq '[.[] | select(.prerelease | not) | {tag: .tag_name, assets: [.assets[] | {name: .name, download_count: .download_count}]}]' \
             > /tmp/gh-releases.json
 
       - name: Fetch npm download counts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,9 +130,25 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ github.token }}
+          # Event data flows in via env, not ${{ }}-interpolation into the
+          # script body — head_commit.message is attacker-shaped text.
+          BEFORE: ${{ github.event.before }}
+          HEAD_TS: ${{ github.event.head_commit.timestamp }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
         run: |
+          # The release flow (`git push origin main --tags`) delivers the
+          # version-bump commit as a main push AND the v* tag as a tag push.
+          # The tag run builds this exact tree, so a canary of it is a wasted
+          # 8-platform matrix — skip when the head commit is the release bump
+          # (subject exactly `v<semver>`, per the release runbook).
+          FIRST_LINE="$(printf '%s' "$HEAD_MSG" | head -1)"
+          if [[ "$FIRST_LINE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "canary=false" >> "$GITHUB_OUTPUT"
+            echo "canary_version=" >> "$GITHUB_OUTPUT"
+            echo "release-bump push ($FIRST_LINE) — the tag run builds this tree; skipping the canary build"
+            exit 0
+          fi
           BUILD=true
-          BEFORE="${{ github.event.before }}"
           if [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
             COMPARE=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BEFORE}...${GITHUB_SHA}" 2>/dev/null) || COMPARE=""
             if [ -n "$COMPARE" ]; then
@@ -153,7 +169,13 @@ jobs:
             fi
           fi
           BASE=$(node -e "console.log(require('./npm/nub/package.json').version)")
-          CANARY_VERSION="${BASE}-canary.$(date -u +%Y%m%d).${GITHUB_RUN_NUMBER}"
+          # Date from the head commit's timestamp, not wall clock: a re-run of a
+          # failed canary run keeps its run_number, and a wall-clock date would
+          # mint a DIFFERENT version for the same run after UTC midnight —
+          # semver-sorting it past newer same-base canaries. The commit
+          # timestamp is stable across re-runs.
+          DATE=$(date -u -d "$HEAD_TS" +%Y%m%d 2>/dev/null) || DATE=$(date -u +%Y%m%d)
+          CANARY_VERSION="${BASE}-canary.${DATE}.${GITHUB_RUN_NUMBER}"
           echo "canary=$BUILD" >> "$GITHUB_OUTPUT"
           echo "canary_version=$CANARY_VERSION" >> "$GITHUB_OUTPUT"
           if [ "$BUILD" = "true" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,24 @@
 name: Release
 
+# Two publish paths share this file (npm OIDC trusted publishing binds ONE
+# workflow filename per package, so the canary publish cannot live in its own
+# workflow):
+#   - TAG (v*): the versioned release — unchanged: npm `latest`, a versioned
+#     GitHub Release, docker/homebrew/winget, post-publish install smokes.
+#   - CANARY (push to main): bun-style rolling prerelease. Every code push to
+#     main builds the full 8-platform matrix with an uncommitted
+#     `<base>-canary.<yyyymmdd>.<run#>` version stamp, publishes all packages to
+#     npm under the `canary` dist-tag, and recreates the rolling `canary`
+#     GitHub prerelease at the built commit. Docs-only pushes are skipped (the
+#     `verify` job's canary gate); the test/conformance gates are skipped too —
+#     ci.yml runs them on the same commit, and the canary contract is "newest
+#     main, built and installable," not a second CI.
+# Tag-only jobs gate on `startsWith(github.ref, 'refs/tags/')`; canary-only jobs
+# gate on `github.ref == 'refs/heads/main'` (both under event_name == 'push').
+# A main push must NEVER reach the tag publish path.
 on:
   push:
+    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
     inputs:
@@ -17,6 +34,16 @@ on:
 permissions:
   id-token: write
   contents: write
+
+# Canary runs coalesce WITHOUT cancellation: all main pushes share one group, a
+# running build always finishes (cancelling mid-`npm publish` could strand a
+# half-published canary version), and GitHub keeps only the NEWEST pending run —
+# intermediate pushes are superseded, so the rolling canary converges on the
+# newest commit at a max lag of one build. Tag/dispatch runs get per-run groups:
+# never queued against each other, never cancelled.
+concurrency:
+  group: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'canary' || format('release-{0}', github.run_id) }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,6 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      # Canary plumbing (empty on tag/dispatch runs): whether this main push
+      # warrants a canary build, and the prerelease version it publishes as.
+      canary: ${{ steps.canary.outputs.canary }}
+      canary_version: ${{ steps.canary.outputs.canary_version }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
@@ -47,11 +78,12 @@ jobs:
       # preload.mjs is shipped as-is, so the tag MUST match what's committed —
       # otherwise the published npm version (set from the tag) would disagree
       # with the binary's reported version and the transpile-cache key.
-      # Only meaningful on a tag push — a workflow_dispatch has no tag
-      # (GITHUB_REF_NAME is the branch, e.g. "main"). The internal consistency
-      # check above (make version-check) already runs on dispatch.
+      # Only meaningful on a tag push — a workflow_dispatch has no tag and a
+      # canary (main) push has no tag to match (GITHUB_REF_NAME is the branch,
+      # e.g. "main"). The internal consistency check above (make version-check)
+      # already runs on every trigger.
       - name: Check tag matches committed version
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           COMMITTED=$(node -e "console.log(require('./npm/nub/package.json').version)")
@@ -83,10 +115,61 @@ jobs:
             SEL=$(echo "$FULL" | jq -c '.')
           fi
           echo "matrix={\"include\":$SEL}" >> "$GITHUB_OUTPUT"
+      # Canary gate + version, main pushes only. The version mirrors bun's
+      # scheme (`1.3.13-canary.20260425.1`): the committed base version plus
+      # `-canary.<utc-date>.<run#>` — run_number is monotonic per workflow, so
+      # every canary version is unique and semver-orders after the previous one.
+      # The gate skips the 8-platform build for pushes that cannot change the
+      # binary or its packaging. Polarity is deliberate: BUILD unless every
+      # changed file is provably inert (markdown anywhere; site/; .claude/;
+      # .github/ except this workflow), and BUILD on any compare-API failure,
+      # force-push, or truncated file list — a wasted build is cheap, a missing
+      # canary is a silent gap.
+      - id: canary
+        name: Canary gate + version (main pushes only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BUILD=true
+          BEFORE="${{ github.event.before }}"
+          if [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
+            COMPARE=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BEFORE}...${GITHUB_SHA}" 2>/dev/null) || COMPARE=""
+            if [ -n "$COMPARE" ]; then
+              COUNT=$(echo "$COMPARE" | jq '.files | length')
+              # The compare API caps .files at 300 — a truncated list could hide
+              # a code file, so only trust a complete one.
+              if [ "$COUNT" -gt 0 ] && [ "$COUNT" -lt 300 ]; then
+                BUILD=false
+                while IFS= read -r f; do
+                  case "$f" in
+                    .github/workflows/release.yml) BUILD=true; break ;;
+                    *.md) ;;
+                    site/*|.claude/*|.github/*) ;;
+                    *) BUILD=true; break ;;
+                  esac
+                done < <(echo "$COMPARE" | jq -r '.files[].filename')
+              fi
+            fi
+          fi
+          BASE=$(node -e "console.log(require('./npm/nub/package.json').version)")
+          CANARY_VERSION="${BASE}-canary.$(date -u +%Y%m%d).${GITHUB_RUN_NUMBER}"
+          echo "canary=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "canary_version=$CANARY_VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$BUILD" = "true" ]; then
+            echo "canary build: $CANARY_VERSION at ${GITHUB_SHA}"
+          else
+            echo "docs-only push — skipping the canary build"
+          fi
 
   primer:
     name: Generate metadata primer (once, shared to all builds)
     needs: verify
+    # Runs for tag + dispatch always; for a main push only when the canary gate
+    # said build. Skipping primer here is what skips the whole canary pipeline
+    # on a docs-only push — build `needs:` primer, and everything heavier
+    # `needs:` build, so the skip cascades.
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/') || needs.verify.outputs.canary == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Must match what vendor/aube/crates/aube-resolver/build.rs computes for a
@@ -248,6 +331,11 @@ jobs:
   test:
     name: Test gate (cargo test + compat suite)
     needs: verify
+    # Tag + dispatch only. Canary runs skip this gate: ci.yml runs the same
+    # suite on the same commit, and the canary contract is "newest main, built
+    # and installable" — a broken canary is what canary means, and doubling the
+    # test run per main push only burns the shared runner pool.
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     steps:
       # No release without a green `cargo test` (fast unit + integration suite).
@@ -289,6 +377,9 @@ jobs:
   conformance:
     name: Lockfile conformance gate (real PMs)
     needs: verify
+    # Tag + dispatch only — same rationale as the `test` gate above: the
+    # aube-parity workflow covers main, and canary doesn't re-gate.
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     # The lockfile-compat regression gate that 0.0.35/0.0.36 slipped through:
     # those releases shipped with the conformance suite RED because publish only
     # gated on the fast `test:` job, and the conformance/daily-driver/native-dep
@@ -384,6 +475,18 @@ jobs:
 
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
+
+      # Canary builds self-report the canary version: `--version` is asserted by
+      # the pre-publish gate and NUB_VERSION keys the transpile cache, so every
+      # version surface must carry the canary string BEFORE the addon + binary
+      # builds embed it. Stamped locally on the runner, never committed. Plain
+      # node (not `make version`) because the Windows runners can't be trusted
+      # to have make, and the Cargo.lock refresh the make target adds is
+      # unnecessary here — the build below reconciles the lock itself.
+      - name: Stamp canary version (uncommitted)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: bash
+        run: node scripts/set-version.mjs "${{ needs.verify.outputs.canary_version }}"
 
       - name: Install cross
         if: matrix.cross
@@ -590,7 +693,8 @@ jobs:
     # and exec's the staged binary once.
     name: Pre-publish smoke gate (${{ matrix.platform }})
     if: ${{ github.event_name == 'push' || inputs.publish }}
-    needs: build
+    # verify supplies the expected canary version on main pushes.
+    needs: [verify, build]
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container }}
     strategy:
@@ -641,16 +745,23 @@ jobs:
           REPORTED="$("$BIN" --version 2>/dev/null | head -1 | tr -d '[:space:]')"
           REPORTED="${REPORTED#v}"
           echo "${{ matrix.platform }} binary reports: '$REPORTED'"
-          # On a tag push the expected version is the tag (minus the leading v); on a
-          # manual publish dispatch there's no tag, so just assert it runs + prints a
-          # non-empty semver-ish string.
+          # On a tag push the expected version is the tag (minus the leading v);
+          # on a canary (main) push it's the stamped canary version from verify;
+          # on a manual publish dispatch there's no expectation, so just assert
+          # it runs + prints a non-empty semver-ish string.
+          EXPECTED=""
           if [ "${{ github.event_name }}" = "push" ]; then
-            EXPECTED="${GITHUB_REF_NAME#v}"
+            case "${{ github.ref }}" in
+              refs/tags/*) EXPECTED="${GITHUB_REF_NAME#v}" ;;
+              *)           EXPECTED="${{ needs.verify.outputs.canary_version }}" ;;
+            esac
+          fi
+          if [ -n "$EXPECTED" ]; then
             if [ "$REPORTED" != "$EXPECTED" ]; then
-              echo "::error::built ${{ matrix.platform }} binary reports version '$REPORTED' but the release tag is '$EXPECTED'. A broken/stale build must not publish."
+              echo "::error::built ${{ matrix.platform }} binary reports version '$REPORTED' but this run publishes '$EXPECTED'. A broken/stale build must not publish."
               exit 1
             fi
-            echo "✓ ${{ matrix.platform }} binary reports the release version ($EXPECTED) — safe to publish"
+            echo "✓ ${{ matrix.platform }} binary reports the publish version ($EXPECTED) — safe to publish"
           else
             if [ -z "$REPORTED" ]; then
               echo "::error::built ${{ matrix.platform }} binary produced no --version output — refusing to publish a non-runnable build."
@@ -672,7 +783,9 @@ jobs:
     # 9/16 archives → curl-install 404'd on 3 platforms). publish-npm does ONLY the
     # 10-package npm publish; github-release does ONLY the release + assets and is
     # independently re-runnable.
-    if: ${{ github.event_name == 'push' || inputs.publish }}
+    # TAG pushes (and explicit publish dispatches) ONLY — a canary (main) push
+    # must never reach this job; it publishes via canary-publish-npm below.
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || inputs.publish }}
     # Gate on the test, conformance, glibc-floor, AND pre-publish smoke jobs: a
     # broken test, a lockfile-compat regression, a glibc-floor regression, or a
     # build that can't run / reports the wrong version must block publish — not
@@ -777,7 +890,9 @@ jobs:
     # artifacts (deterministic), creates/updates the release, then VERIFIES all 16
     # expected assets are present — re-uploading any missing and FAILING LOUD if a
     # gap survives the retries. This codifies the v0.0.48 manual fix.
-    if: ${{ github.event_name == 'push' || inputs.publish }}
+    # TAG pushes (and explicit publish dispatches) ONLY — canary (main) pushes
+    # update the rolling `canary` prerelease via canary-release below.
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || inputs.publish }}
     needs: publish-npm
     runs-on: ubuntu-latest
     steps:
@@ -928,6 +1043,229 @@ jobs:
           fi
           echo "✓ all ${#EXPECTED[@]} release assets present on $TAG"
 
+  canary-publish-npm:
+    name: Publish canary to npm
+    # Canary (main) pushes only — the npm half of the bun-style canary channel.
+    # Mirrors publish-npm above (keep the two in sync) with three differences:
+    # the version is the uncommitted canary stamp from verify, every publish
+    # carries `--tag canary` so `latest` never moves, and the gates are build +
+    # glibc-floor + pre-publish smoke — not test/conformance, which canary runs
+    # skip (see the `test` job comment). Deliberately its OWN job rather than a
+    # conditional branch of publish-npm: threading canary through the tag job
+    # would loosen its needs/if gating, and the tag path must stay untouched.
+    # Publish ORDER is the safety property shared with publish-npm: all 8
+    # platform packages first, the root package LAST — so `@nubjs/nub@canary`
+    # only ever resolves to a version whose exact-pinned platform deps all
+    # published.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [verify, build, glibc-floor-guard, pre-publish-gate]
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.verify.outputs.canary_version }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          path: artifacts
+
+      - name: Prepare and publish platform packages (idempotent)
+        run: |
+          # Same idempotent loop as publish-npm: a re-run skips already-published
+          # versions instead of aborting on npm's E403.
+          for platform in darwin-arm64 darwin-x64 linux-x64 linux-x64-musl linux-arm64 linux-arm64-musl win32-x64 win32-arm64; do
+            PKG="artifacts/nub-$platform"
+            if [ ! -d "$PKG" ]; then
+              echo "⚠️  Skipping $platform (not built)"
+              continue
+            fi
+            cp "npm/nub-$platform/package.json" "$PKG/package.json"
+            node -e "
+              const fs = require('fs');
+              const p = JSON.parse(fs.readFileSync('$PKG/package.json', 'utf8'));
+              p.version = process.env.VERSION;
+              fs.writeFileSync('$PKG/package.json', JSON.stringify(p, null, 2));
+            "
+            NAME="@nubjs/nub-$platform"
+            if [ "$(npm view "$NAME@$VERSION" version 2>/dev/null)" = "$VERSION" ]; then
+              echo "✓ $NAME@$VERSION already published — skipping"
+              continue
+            fi
+            echo "→ $NAME@$VERSION (canary)"
+            (cd "$PKG" && npm publish --access public --tag canary)
+          done
+
+      - name: Prepare and publish root package (idempotent)
+        run: |
+          node -e "
+            const fs = require('fs');
+            const p = JSON.parse(fs.readFileSync('npm/nub/package.json', 'utf8'));
+            p.version = process.env.VERSION;
+            for (const k of Object.keys(p.optionalDependencies || {})) {
+              p.optionalDependencies[k] = process.env.VERSION;
+            }
+            fs.writeFileSync('npm/nub/package.json', JSON.stringify(p, null, 2));
+          "
+          if [ "$(npm view "@nubjs/nub@$VERSION" version 2>/dev/null)" = "$VERSION" ]; then
+            echo "✓ @nubjs/nub@$VERSION already published — skipping"
+          else
+            echo "→ @nubjs/nub@$VERSION (canary)"
+            (cd npm/nub && npm publish --access public --tag canary)
+          fi
+
+      - name: Prepare and publish types package (idempotent)
+        run: |
+          # @nubjs/types tracks the binary version in lockstep on the canary
+          # channel too, so a canary install can pull matching declarations.
+          node -e "
+            const fs = require('fs');
+            const p = JSON.parse(fs.readFileSync('npm/nub-types/package.json', 'utf8'));
+            p.version = process.env.VERSION;
+            fs.writeFileSync('npm/nub-types/package.json', JSON.stringify(p, null, 2) + '\n');
+          "
+          if [ "$(npm view "@nubjs/types@$VERSION" version 2>/dev/null)" = "$VERSION" ]; then
+            echo "✓ @nubjs/types@$VERSION already published — skipping"
+          else
+            echo "→ @nubjs/types@$VERSION (canary)"
+            (cd npm/nub-types && npm publish --access public --tag canary)
+          fi
+
+  canary-release:
+    name: Update rolling canary release
+    # The GitHub half of the canary channel: recreate the rolling `canary`
+    # prerelease at the built commit, carrying the same 16 assets a versioned
+    # release ships (so the future `nub upgrade --canary` and the curl installer
+    # can read `releases/download/canary/...`). Runs AFTER the npm publish so
+    # the release never points at a commit whose npm canary didn't go out.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [verify, canary-publish-npm]
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.verify.outputs.canary_version }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          path: artifacts
+
+      - name: Package release archives (single binary)
+        run: |
+          # Mirrors github-release's packaging (keep in sync): bin/ plus the
+          # vestigial empty runtime/ the sidecar-era self-upgrader needs (see
+          # that job's comment for the full story), +x re-applied before tarring
+          # (the artifact round-trip strips mode bits), and a `.sha256` sidecar
+          # per archive for download verification.
+          mkdir -p release-archives
+          for platform in darwin-arm64 darwin-x64 linux-x64 linux-x64-musl linux-arm64 linux-arm64-musl win32-x64 win32-arm64; do
+            PKG="artifacts/nub-$platform"
+            [ -d "$PKG" ] || { echo "skip $platform (not built)"; continue; }
+            mkdir -p "$PKG/runtime"
+            if [[ "$platform" == win32-* ]]; then
+              archive="nub-$platform.zip"
+              (cd "$PKG" && zip -qr "$GITHUB_WORKSPACE/release-archives/$archive" bin runtime)
+            else
+              chmod +x "$PKG/bin/nub" "$PKG/bin/nubx"
+              archive="nub-$platform.tar.gz"
+              tar -czf "release-archives/$archive" -C "$PKG" bin runtime
+            fi
+            (cd release-archives && sha256sum "$archive" > "$archive.sha256")
+          done
+          ls -la release-archives
+
+      - name: Recreate rolling canary release
+        run: |
+          # Rolling tag: delete the previous release + tag, recreate at the
+          # built commit. The brief no-canary window between the two self-heals
+          # on the next run, and the shared `canary` concurrency group keeps two
+          # canary runs from interleaving here.
+          gh release delete canary --yes 2>/dev/null || true
+          # The tag deletion must NOT be error-swallowed: `gh release create`
+          # silently attaches to an EXISTING tag (ignoring --target), so a
+          # leftover `canary` tag would pin the "new" release to the old commit.
+          # Tolerate only genuine absence (first run); fail loud otherwise.
+          if git ls-remote --exit-code --tags origin canary >/dev/null 2>&1; then
+            git push origin :refs/tags/canary
+          fi
+          {
+            echo "Rolling canary build of \`main\`, rebuilt on every code push."
+            echo
+            echo "- Version: \`$VERSION\`"
+            echo "- Commit: $GITHUB_SHA"
+            echo "- Install: \`npm install -g @nubjs/nub@canary\`"
+            echo
+            echo "Prerelease channel — the assets below always track the newest main commit."
+          } > canary-notes.md
+          gh release create canary \
+            --target "$GITHUB_SHA" \
+            --prerelease \
+            --title "Canary $VERSION" \
+            --notes-file canary-notes.md \
+            release-archives/*
+
+      - name: Verify all canary assets present (re-upload missing, else FAIL)
+        shell: bash
+        run: |
+          set -uo pipefail
+          # Same 16-asset completeness check as github-release (keep in sync),
+          # against the rolling `canary` tag: list, re-upload any missing with
+          # retries, fail loud if a gap survives.
+          EXPECTED=(
+            nub-darwin-arm64.tar.gz nub-darwin-arm64.tar.gz.sha256
+            nub-darwin-x64.tar.gz nub-darwin-x64.tar.gz.sha256
+            nub-linux-x64.tar.gz nub-linux-x64.tar.gz.sha256
+            nub-linux-x64-musl.tar.gz nub-linux-x64-musl.tar.gz.sha256
+            nub-linux-arm64.tar.gz nub-linux-arm64.tar.gz.sha256
+            nub-linux-arm64-musl.tar.gz nub-linux-arm64-musl.tar.gz.sha256
+            nub-win32-x64.zip nub-win32-x64.zip.sha256
+            nub-win32-arm64.zip nub-win32-arm64.zip.sha256
+          )
+          TAG="canary"
+
+          missing_assets() {
+            local present
+            present="$(gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null || true)"
+            local m=()
+            for a in "${EXPECTED[@]}"; do
+              if ! grep -qxF "$a" <<<"$present"; then m+=("$a"); fi
+            done
+            printf '%s\n' "${m[@]}"
+          }
+
+          for pass in 1 2 3; do
+            mapfile -t MISSING < <(missing_assets)
+            [ "${#MISSING[@]}" -eq 1 ] && [ -z "${MISSING[0]}" ] && MISSING=()
+            if [ "${#MISSING[@]}" -eq 0 ]; then
+              echo "✓ all ${#EXPECTED[@]} canary assets present"
+              exit 0
+            fi
+            echo "--- pass $pass: ${#MISSING[@]} asset(s) missing: ${MISSING[*]} ---"
+            for a in "${MISSING[@]}"; do
+              f="release-archives/$a"
+              if [ ! -f "$f" ]; then
+                echo "::error::expected asset $a was never built (no $f) — cannot complete the canary release. Check the build matrix."
+                exit 1
+              fi
+              echo "re-uploading $a"
+              gh release upload "$TAG" "$f" --clobber || echo "  (upload of $a failed this pass; will retry)"
+            done
+            sleep 10
+          done
+
+          mapfile -t STILL < <(missing_assets)
+          [ "${#STILL[@]}" -eq 1 ] && [ -z "${STILL[0]}" ] && STILL=()
+          if [ "${#STILL[@]}" -ne 0 ]; then
+            echo "::error::canary release is STILL missing ${#STILL[@]} asset(s) after retries: ${STILL[*]}"
+            exit 1
+          fi
+          echo "✓ all ${#EXPECTED[@]} canary assets present"
+
   docker:
     name: Publish Docker images
     # Republish the official Docker images (ghcr.io/nubjs/nub) for THIS release, as a
@@ -939,9 +1277,10 @@ jobs:
     # `workflow_call` runs the build+push INSIDE this run (no cascade) and `needs:
     # publish-npm` sequences it after `@nubjs/nub@<version>` is live on npm, which the
     # image installs at build time. Real tag-push releases only (mirrors bump-homebrew-
-    # tap / submit-winget) — a build-only debug dispatch must not push an image.
+    # tap / submit-winget) — a build-only debug dispatch or a canary (main) push
+    # must not push an image.
     needs: publish-npm
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     # The called workflow inherits the calling job's token scope; the GHCR push needs
     # packages:write (release.yml's top-level token has only id-token+contents).
     permissions:
@@ -1045,10 +1384,10 @@ jobs:
   bump-homebrew-tap:
     name: Bump Homebrew tap formula
     # Update the nubjs/homebrew-tap formula to this release. Runs ONLY on a real
-    # tag-push release (never the debug `workflow_dispatch` build-only path) and
-    # AFTER github-release, because it reads the published `.sha256` sidecar
-    # assets from the release this run created.
-    if: github.event_name == 'push'
+    # tag-push release (never the debug `workflow_dispatch` build-only path, nor
+    # a canary main push) and AFTER github-release, because it reads the
+    # published `.sha256` sidecar assets from the release this run created.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: github-release
     runs-on: ubuntu-latest
     steps:
@@ -1108,9 +1447,10 @@ jobs:
   submit-winget:
     name: Submit winget manifest
     # Open/refresh the Nubjs.Nub manifest in microsoft/winget-pkgs for this release.
-    # Runs ONLY on a real tag-push release (never the debug workflow_dispatch path)
-    # and AFTER github-release, because the manifest references the published
-    # release-asset URLs + their SHA256 sidecars this run created.
+    # Runs ONLY on a real tag-push release (never the debug workflow_dispatch path,
+    # nor a canary main push) and AFTER github-release, because the manifest
+    # references the published release-asset URLs + their SHA256 sidecars this
+    # run created.
     #
     # HELD FOR MAINTAINER ENABLEMENT — this is an EXTERNAL, effectively-irreversible
     # publish under the nubjs publisher identity (winget-releaser opens a PR on
@@ -1120,7 +1460,7 @@ jobs:
     # fires NOTHING. winget-releaser also UPDATES an existing package — the FIRST
     # version (Nubjs.Nub v1) is bootstrapped manually from the committed
     # winget/manifests/... set. Both are documented in winget/README.md.
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: github-release
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -107,40 +107,14 @@ clean:
 # Set version across all npm packages + Cargo.toml + preload.mjs. Usage: make version V=0.0.3
 # Portable (node-based, no macOS-only sed). preload.mjs NUB_VERSION must stay in
 # lockstep with the binary version — it is the transpile-cache key, so a stale
-# value would serve stale cached output after an upgrade.
+# value would serve stale cached output after an upgrade. The file-stamping body
+# lives in scripts/set-version.mjs so release.yml's canary stamp (which can't
+# rely on `make` on the Windows runners) shares it; this target adds the
+# Cargo.lock refresh a committed bump wants.
 version:
 	@test -n "$(V)" || (echo "Usage: make version V=0.0.3" && exit 1)
 	@echo "Setting version to $(V) across all packages, Cargo.toml, and preload.mjs..."
-	@node -e " \
-		const fs = require('fs'); \
-		const v = '$(V)'; \
-		const pkgs = ['npm/nub/package.json', 'npm/nub-types/package.json', \
-			'npm/nub-darwin-arm64/package.json', 'npm/nub-darwin-x64/package.json', \
-			'npm/nub-linux-x64/package.json', 'npm/nub-linux-x64-musl/package.json', \
-			'npm/nub-linux-arm64/package.json', 'npm/nub-linux-arm64-musl/package.json', \
-			'npm/nub-win32-x64/package.json', 'npm/nub-win32-arm64/package.json']; \
-		for (const f of pkgs) { \
-			const p = JSON.parse(fs.readFileSync(f, 'utf8')); \
-			p.version = v; \
-			if (p.optionalDependencies) { \
-				for (const k of Object.keys(p.optionalDependencies)) p.optionalDependencies[k] = v; \
-			} \
-			fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n'); \
-		} \
-		const q = String.fromCharCode(34); \
-		let cargo = fs.readFileSync('Cargo.toml', 'utf8'); \
-		const cargoNext = cargo.replace(/^version = .*/m, 'version = ' + q + v + q); \
-		if (cargoNext === cargo) { console.error('ERROR: workspace version line not found in Cargo.toml'); process.exit(1); } \
-		fs.writeFileSync('Cargo.toml', cargoNext); \
-		let nativeCargo = fs.readFileSync('crates/nub-native/Cargo.toml', 'utf8'); \
-		const nativeCargoNext = nativeCargo.replace(/^version = .*/m, 'version = ' + q + v + q); \
-		if (nativeCargoNext === nativeCargo) { console.error('ERROR: workspace version line not found in crates/nub-native/Cargo.toml'); process.exit(1); } \
-		fs.writeFileSync('crates/nub-native/Cargo.toml', nativeCargoNext); \
-		let version = fs.readFileSync('runtime/version.mjs', 'utf8'); \
-		const versionNext = version.replace(/export const NUB_VERSION = .*/, 'export const NUB_VERSION = ' + q + v + q + ';'); \
-		if (versionNext === version) { console.error('ERROR: NUB_VERSION not found in runtime/version.mjs'); process.exit(1); } \
-		fs.writeFileSync('runtime/version.mjs', versionNext); \
-		"
+	@node scripts/set-version.mjs "$(V)"
 	@cargo update -p nub-cli -p nub-cache-key -p nub-core --precise $(V)
 	@# nub-native is its own workspace (split for panic=abort vs unwind); its
 	@# version + Cargo.lock entry live under crates/nub-native, updated separately.

--- a/scripts/download-stats.mjs
+++ b/scripts/download-stats.mjs
@@ -111,7 +111,10 @@ function githubReleases() {
     ["api", `repos/${REPO}/releases`, "--paginate"],
     { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
   );
-  const releases = JSON.parse(raw.replace(/\]\s*\[/g, ",")); // join paginated arrays
+  // Join paginated arrays, and drop prereleases: the rolling `canary` release
+  // is recreated on every main push, so its counts reset and would corrupt the
+  // snapshot deltas.
+  const releases = JSON.parse(raw.replace(/\]\s*\[/g, ",")).filter((r) => !r.prerelease);
   const header = "snapshot_date,tag,published_at,asset,download_count";
   const rows = releases.flatMap((rel) =>
     rel.assets.map(

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -1,0 +1,56 @@
+// Stamp one version across every version surface: the 10 npm package.jsons
+// (root optionalDependencies pinned exact), both workspace Cargo.tomls, and
+// runtime/version.mjs (NUB_VERSION — the transpile-cache key, which must stay in
+// lockstep with the binary version or a stale cache would serve stale output
+// after an upgrade). Shared by `make version V=<v>` (committed release bumps —
+// the Makefile also refreshes the Cargo.lock entries) and release.yml's canary
+// stamp (an UNCOMMITTED prerelease set on the build runners, where `make` isn't
+// dependable on Windows; the lockfiles self-heal on the next cargo invocation).
+// Run from the repo root: node scripts/set-version.mjs <version>
+import fs from "node:fs";
+
+const v = process.argv[2];
+if (!v) {
+  console.error("Usage: node scripts/set-version.mjs <version>");
+  process.exit(1);
+}
+
+const pkgs = [
+  "npm/nub/package.json",
+  "npm/nub-types/package.json",
+  "npm/nub-darwin-arm64/package.json",
+  "npm/nub-darwin-x64/package.json",
+  "npm/nub-linux-x64/package.json",
+  "npm/nub-linux-x64-musl/package.json",
+  "npm/nub-linux-arm64/package.json",
+  "npm/nub-linux-arm64-musl/package.json",
+  "npm/nub-win32-x64/package.json",
+  "npm/nub-win32-arm64/package.json",
+];
+for (const f of pkgs) {
+  const p = JSON.parse(fs.readFileSync(f, "utf8"));
+  p.version = v;
+  if (p.optionalDependencies) {
+    for (const k of Object.keys(p.optionalDependencies)) p.optionalDependencies[k] = v;
+  }
+  fs.writeFileSync(f, JSON.stringify(p, null, 2) + "\n");
+}
+
+const replaceOrDie = (file, re, replacement) => {
+  const src = fs.readFileSync(file, "utf8");
+  const next = src.replace(re, replacement);
+  if (next === src) {
+    console.error(`ERROR: version line not found in ${file}`);
+    process.exit(1);
+  }
+  fs.writeFileSync(file, next);
+};
+replaceOrDie("Cargo.toml", /^version = .*/m, `version = "${v}"`);
+replaceOrDie("crates/nub-native/Cargo.toml", /^version = .*/m, `version = "${v}"`);
+replaceOrDie(
+  "runtime/version.mjs",
+  /export const NUB_VERSION = .*/,
+  `export const NUB_VERSION = "${v}";`,
+);
+
+console.log(`✓ npm packages, both Cargo.tomls, and runtime/version.mjs set to ${v}`);


### PR DESCRIPTION
Every code push to `main` builds the 8-platform matrix with an uncommitted `<base>-canary.<yyyymmdd>.<run#>` stamp, publishes all ten packages under the npm `canary` dist-tag, and recreates the rolling `canary` GitHub prerelease. The publish lives in `release.yml` (npm trusted publishing binds one workflow file per package); tag-path jobs are gated to `refs/tags/`, so a main push cannot touch `latest`. Docs-only and release-bump pushes skip; glibc-floor + smoke gates still run; `releases/latest` never sees the prerelease. `make version` stamping moved to `scripts/set-version.mjs`.

https://claude.ai/code/session_01KbVuigZQd5uHVjYcusfFMo