### PR TITLE
test(pm): pin engine-key invariants #548 relies on

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1382,6 +1382,23 @@ fn augmentation_to_lifecycle_overlay(
     (overlay, prepends)
 }
 
+/// The directory lifecycle Node discovery is anchored at: the workspace root
+/// when `cwd` sits in a member, else the project root, else `cwd` itself.
+///
+/// aube keys its install state and virtual store at the workspace root
+/// (`dirs::workspace_or_project_root`), and an install from a member
+/// materializes the ONE shared tree for the whole workspace — so the Node its
+/// build scripts compile against, which is also the engine that keys the ABI
+/// caches, must be the root's pin rather than whichever member the shell sits
+/// in. Anchoring at the raw cwd instead lets a member's own `.nvmrc` flip the
+/// engine key against a root-anchored state file, thrashing the warm path.
+/// `detect_project` walks up by the same rule aube's root does.
+fn lifecycle_node_anchor(cwd: &Path) -> PathBuf {
+    nub_core::workspace::detect::detect_project(cwd)
+        .map(|p| p.workspace_root.unwrap_or(p.root))
+        .unwrap_or_else(|| cwd.to_path_buf())
+}
+
 /// Install nub's runtime augmentation onto the engine's lifecycle-script spawn
 /// env (via aube's generic [`aube::set_script_settings`] overlay), so dependency
 /// build scripts run under the project's provisioned + augmented Node — the same
@@ -1390,17 +1407,7 @@ fn augmentation_to_lifecycle_overlay(
 /// re-entrant / broken install); the resolved Node *version* is published to the
 /// engine either way. Called once per command from [`engine_session`].
 fn apply_lifecycle_augmentation(cwd: &Path) {
-    // Anchor Node discovery at the workspace root — the directory aube keys its
-    // install state and virtual store at (`dirs::workspace_or_project_root`). An
-    // install from a member materializes the ONE shared tree for the whole
-    // workspace, so the Node its build scripts compile against — and the engine
-    // that keys the ABI caches — must be the root's pin, not whichever member the
-    // shell sits in. Discovering from the raw cwd instead lets a member's own
-    // `.nvmrc` flip the engine key against a root-anchored state file, thrashing
-    // the warm path. `detect_project` walks up by the same rule aube's root does.
-    let anchor = nub_core::workspace::detect::detect_project(cwd)
-        .map(|p| p.workspace_root.unwrap_or(p.root))
-        .unwrap_or_else(|| cwd.to_path_buf());
+    let anchor = lifecycle_node_anchor(cwd);
     // The project's Node — pin-aware (`.nvmrc`/`.node-version`/`engines`), NOT
     // the ambient PATH node. This resolved version drives flag injection and its
     // path pins npm_node_execpath. Mirrors build_script_command's discovery.
@@ -4080,5 +4087,42 @@ mod tests {
         let m = root_manifest(d.path());
         assert!(first_catalog_specifier(&m, d.path()).is_some());
         assert!(role_honors_catalog(Role::Yarn, Some(4), Some(10)));
+    }
+
+    #[test]
+    fn a_member_install_resolves_the_workspace_roots_node_pin() {
+        // aube anchors install state and the virtual store at the workspace root,
+        // and a member install materializes that ONE shared tree. So the engine
+        // published for it has to name the root's Node: keyed off the member's own
+        // pin, the ABI caches describe a Node the root-anchored state file never
+        // saw, and alternating root/member installs each rebuild the other's tree.
+        let d = workspace(&[
+            (
+                "package.json",
+                r#"{"name":"ws","workspaces":["packages/*"]}"#,
+            ),
+            (".nvmrc", "22.15.0\n"),
+            ("packages/member/package.json", r#"{"name":"member"}"#),
+            ("packages/member/.nvmrc", "20.19.0\n"),
+        ]);
+        let member = d.path().join("packages/member");
+        let pin_at = |dir: &Path| {
+            nub_core::node::discovery::resolve_pin_chain(dir)
+                .expect("pin chain resolves")
+                .pin
+                .expect("a pin file is in scope")
+                .0
+        };
+
+        // Control: from the raw cwd the member's own pin wins — the key the engine
+        // carried before discovery was anchored.
+        assert_eq!(pin_at(&member), "20.19.0");
+        assert_eq!(
+            pin_at(&lifecycle_node_anchor(&member)),
+            "22.15.0",
+            "a member install builds the workspace's one shared tree, so anchoring \
+             Node discovery anywhere but the root keys the ABI caches to a Node the \
+             install state never saw"
+        );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -3096,6 +3096,134 @@ mod build_may_key_engine_tests {
     }
 }
 
+/// The GVS prewarm ([`materialize`]) and the link phase ([`link`]) hash the same
+/// graph independently, and link REUSES the prewarm's hashes whenever the key
+/// sets match — its filter compares key presence and count, never hash VALUES.
+/// So a gate that folds the engine in one phase but not the other never surfaces
+/// as a mismatch: link silently serves the prewarm's hashes, and a native addon
+/// lands at a virtual-store path shared across Node majors. Nothing at runtime
+/// can catch that, which is why it is pinned here.
+#[cfg(test)]
+mod engine_fold_agreement_tests {
+    use super::*;
+
+    const LINK_SRC: &str = include_str!("link.rs");
+    const PREWARM_SRC: &str = include_str!("materialize.rs");
+
+    /// The engine-fold gate's arguments at a file's graph-hash site, minus the
+    /// leading policy binding (each phase holds the policy differently) and with
+    /// whitespace collapsed.
+    fn engine_fold_gate(src: &str, file: &str) -> String {
+        let mut calls = src.match_indices("build_may_key_engine(");
+        let (idx, marker) = calls.next().unwrap_or_else(|| {
+            panic!(
+                "{file} no longer gates its graph-hash `allow` closure on \
+                 `build_may_key_engine`; the two phases must agree or link serves \
+                 wrong-ABI hashes"
+            )
+        });
+        assert!(
+            calls.next().is_none(),
+            "{file} gained a second `build_may_key_engine` call — this check only \
+             knows how to compare one graph-hash site per phase"
+        );
+        let open = idx + marker.len();
+        let args = &src[open..open + src[open..].find(')').expect("unterminated call")];
+        let (_policy, rest) = args
+            .split_once(',')
+            .expect("engine-fold gate takes (policy, pkg, default_trust_enabled)");
+        rest.split_whitespace().collect()
+    }
+
+    #[test]
+    fn the_prewarm_and_the_link_phase_gate_the_engine_fold_identically() {
+        assert_eq!(
+            engine_fold_gate(PREWARM_SRC, "materialize.rs"),
+            engine_fold_gate(LINK_SRC, "link.rs"),
+            "the prewarm and the link phase disagree on which packages fold the \
+             engine into their virtual-store path; link reuses the prewarm's \
+             hashes on a key-set match without comparing values, so this ships as \
+             a wrong-ABI store path rather than a failure"
+        );
+    }
+
+    #[test]
+    fn a_floor_built_package_taints_its_dependents_under_both_phases_hashers() {
+        // `better-sqlite3` builds off the `defaultTrust` floor rather than an
+        // explicit allow — the case #548 fixed, and the one link's reuse path
+        // hits on a plain warm install.
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        let mut consumer = locked("app-db");
+        consumer
+            .dependencies
+            .insert("better-sqlite3".into(), "1.0.0".into());
+        graph.packages.insert("app-db@1.0.0".into(), consumer);
+        graph
+            .packages
+            .insert("better-sqlite3@1.0.0".into(), locked("better-sqlite3"));
+
+        let policy = aube_scripts::BuildPolicy::from_config(&BTreeMap::new(), &[], &[], false).0;
+        let engine = aube_lockfile::graph_hash::engine_name_default("22.15.0");
+        let no_patch = |_: &str, _: &str| -> Option<String> { None };
+        // Link only reuses the prewarm's hashes when it has no content
+        // fingerprints of its own, so this is the shape that matters.
+        let no_content = |_: &str| -> Option<String> { None };
+
+        let allow = |pkg: &aube_lockfile::LockedPackage| build_may_key_engine(&policy, pkg, true);
+        let prewarm = aube_lockfile::graph_hash::compute_graph_hashes_with_patches(
+            &graph,
+            &allow,
+            Some(&engine),
+            &no_patch,
+        );
+        let link = aube_lockfile::graph_hash::compute_graph_hashes_full(
+            &graph,
+            &allow,
+            Some(&engine),
+            &no_patch,
+            &no_content,
+        );
+        assert_eq!(
+            prewarm.node_hash, link.node_hash,
+            "the prewarm's hashes are reused verbatim by the link phase; they must \
+             be byte-identical to what link would have computed itself"
+        );
+
+        // Control: without the floor nothing in this graph may build, so the
+        // hashes stay engine-agnostic. That the two differ is what proves the
+        // assertion above compared engine-KEYED hashes rather than passing
+        // vacuously.
+        let floor_off =
+            |pkg: &aube_lockfile::LockedPackage| build_may_key_engine(&policy, pkg, false);
+        let unkeyed = aube_lockfile::graph_hash::compute_graph_hashes_with_patches(
+            &graph,
+            &floor_off,
+            Some(&engine),
+            &no_patch,
+        );
+        assert_ne!(
+            prewarm.node_hash["better-sqlite3@1.0.0"], unkeyed.node_hash["better-sqlite3@1.0.0"],
+            "a floor-built native package must not share one virtual-store path \
+             across Node majors"
+        );
+        assert_ne!(
+            prewarm.node_hash["app-db@1.0.0"], unkeyed.node_hash["app-db@1.0.0"],
+            "the engine taint must cascade to every dependent, or a consumer's \
+             path points at an ABI it did not key"
+        );
+    }
+
+    fn locked(name: &str) -> aube_lockfile::LockedPackage {
+        aube_lockfile::LockedPackage {
+            name: name.into(),
+            version: "1.0.0".into(),
+            integrity: Some(format!("sha512-{name}")),
+            dep_path: format!("{name}@1.0.0"),
+            ..Default::default()
+        }
+    }
+}
+
 #[cfg(test)]
 mod trust_policy_validation_cache_tests {
     use super::*;


### PR DESCRIPTION
Two regression tests pinning invariants [#548](https://github.com/nubjs/nub/issues/548) relies on but left uncovered. Tests only — no behavior change.

## Prewarm ≡ link engine-fold agreement

The GVS prewarm and the link phase hash the same graph independently, and link reuses the prewarm's hashes on a key-set match without comparing values. If the two `allow` closures diverge, link silently serves prewarm's hashes and the engine keying is wrong with no failure.

`engine_fold_agreement_tests` (`vendor/aube/crates/aube/src/commands/install/mod.rs`) pins it two ways:
- a source-level check that both phases gate the fold on identical `build_may_key_engine` arguments — fails if one closure is edited and not the other;
- a hash-level check that both hashers produce byte-identical `node_hash` for a `defaultTrust`-floor-built native package and its dependent (the case #548 fixed), with an engine-off control so the equality can't pass vacuously.

## Workspace-root Node anchor

`apply_lifecycle_augmentation` anchors Node discovery at the workspace root, so a member install keys the ABI caches off the root's pin. The anchor is factored into `lifecycle_node_anchor` (behavior-preserving), and `a_member_install_resolves_the_workspace_roots_node_pin` (`crates/nub-cli/src/pm_engine/mod.rs`) asserts a workspace with a root pin and a different member pin resolves the root's pin from a member cwd, with the raw-cwd member pin as the control.

Both tests were verified to fail when the invariant is broken (one `allow` closure changed; the anchor pointed at the raw cwd) and pass on revert.

Refs #548
