### PR TITLE
fix(run): repair a nub-installed tree built for a different Node major

### DIFF
--- a/crates/nub-cli/src/install_engine.rs
+++ b/crates/nub-cli/src/install_engine.rs
@@ -1,0 +1,152 @@
+//! Which Node engine a nub install built `node_modules` for (issue #548).
+//!
+//! A native addon is compiled against exactly one `NODE_MODULE_VERSION`, so a
+//! tree whose lifecycle scripts ran under Node 22 dies with
+//! `ERR_DLOPEN_FAILED … NODE_MODULE_VERSION 127 … requires 147` the moment the
+//! project's Node moves to 26. The pre-run freshness walk cannot see that: the
+//! wrong-ABI package is present and its version satisfies the manifest, so the
+//! walk is engine-blind by construction. Nub therefore records, beside the tree
+//! it built, WHICH engine built it, and the run path compares that stamp
+//! against the engine it is about to run under (see
+//! [`verify_deps`](crate::verify_deps)).
+//!
+//! Only a successful nub install writes the stamp, which is what scopes the
+//! auto-repair: nub redoes nub's OWN work, and never reshapes a tree
+//! npm/pnpm/yarn owns. The recorded value is the engine's own artifact-keying
+//! axis (`<os>-<arch>-node<major>` — what the virtual store and the
+//! side-effects cache already segregate builds on), so the stamp cannot
+//! disagree with how the artifacts were actually keyed.
+
+use std::path::{Path, PathBuf};
+
+use nub_core::workspace::detect::detect_project;
+
+const STAMP_FILE: &str = ".nub-engine";
+
+/// The directory a nub install keys its tree at: the workspace root when the
+/// project is a member, else the project root. Same rule
+/// `pm_engine::apply_lifecycle_augmentation` anchors Node discovery on — one
+/// workspace materializes ONE tree, so a member's own `.nvmrc` must not name a
+/// different engine than the root the install actually wrote.
+pub(crate) fn anchor(cwd: &Path) -> Option<PathBuf> {
+    detect_project(cwd).map(|p| p.workspace_root.unwrap_or(p.root))
+}
+
+fn stamp_path(anchor: &Path) -> PathBuf {
+    anchor.join("node_modules").join(STAMP_FILE)
+}
+
+/// `<os>-<arch>-node<major>` for a resolved Node version.
+pub(crate) fn engine_name(node_version: &str) -> String {
+    aube_lockfile::graph_hash::engine_name_default(node_version).0
+}
+
+/// The engine a nub install last built `anchor`'s tree for. `None` when nub
+/// never installed it, or installed it before this stamp existed — both
+/// degrade to the pre-#548 behavior (no repair), never to a wrong verdict.
+pub(crate) fn recorded(anchor: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(stamp_path(anchor)).ok()?;
+    let engine = raw.trim();
+    (!engine.is_empty()).then(|| engine.to_string())
+}
+
+/// Record the engine after a tree-materializing verb. Takes the version from
+/// the engine context, where `apply_lifecycle_augmentation` published the SAME
+/// value the engine keyed its build artifacts with — re-discovering here could
+/// name a different Node and stamp a lie. Best-effort: an install that already
+/// succeeded must not fail on an unwritable stamp.
+pub(crate) fn record(cwd: &Path, code: i32) {
+    if code != 0 {
+        return;
+    }
+    let Some(version) = aube_util::engine_context().runtime_node_version else {
+        return;
+    };
+    let Some(anchor) = anchor(cwd) else {
+        return;
+    };
+    write_stamp(&anchor, &engine_name(&version));
+}
+
+/// Write the stamp INTO an existing tree only. A verb that installed nothing
+/// (no `node_modules` on disk) has no tree to describe, and conjuring the
+/// directory just to hold a stamp would make the next run believe a nub
+/// install had happened.
+fn write_stamp(anchor: &Path, engine: &str) {
+    let path = stamp_path(anchor);
+    if path.parent().is_some_and(Path::is_dir) {
+        let _ = std::fs::write(path, engine);
+    }
+}
+
+/// Human phrasing for an engine change: Node majors when both names carry one
+/// (the ABI axis users actually move along), the raw engine names otherwise so
+/// a platform-only change still reads truthfully.
+pub(crate) fn describe(recorded: &str, current: &str) -> (String, String) {
+    match (node_major(recorded), node_major(current)) {
+        (Some(was), Some(now)) if was != now => (format!("Node {was}"), format!("Node {now}")),
+        _ => (recorded.to_string(), current.to_string()),
+    }
+}
+
+fn node_major(engine: &str) -> Option<&str> {
+    let major = engine.rsplit_once("-node")?.1;
+    (!major.is_empty() && major.bytes().all(|b| b.is_ascii_digit())).then_some(major)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_stamp_round_trips_only_through_an_installed_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let anchor = dir.path();
+
+        // No node_modules: there is no tree to describe, so write_stamp must not
+        // create one just to hold the marker — a later run would then believe a
+        // nub install had happened here.
+        write_stamp(anchor, "darwin-arm64-node22");
+        assert_eq!(recorded(anchor), None);
+        assert!(!anchor.join("node_modules").exists());
+
+        // With a tree present, the marker round-trips; a blank marker reads back
+        // as "no record" rather than an empty engine name.
+        std::fs::create_dir(anchor.join("node_modules")).unwrap();
+        write_stamp(anchor, "darwin-arm64-node22");
+        assert_eq!(recorded(anchor), Some("darwin-arm64-node22".to_string()));
+        std::fs::write(anchor.join("node_modules/.nub-engine"), "  \n").unwrap();
+        assert_eq!(recorded(anchor), None, "a blank marker is not a record");
+    }
+
+    #[test]
+    fn engine_name_tracks_the_node_major_only() {
+        assert_eq!(engine_name("22.15.0"), engine_name("22.16.3"));
+        assert_ne!(engine_name("22.15.0"), engine_name("26.5.0"));
+        assert!(engine_name("26.5.0").ends_with("-node26"));
+    }
+
+    #[test]
+    fn describe_names_majors_when_both_engines_carry_one() {
+        assert_eq!(
+            describe("darwin-arm64-node22", "darwin-arm64-node26"),
+            ("Node 22".to_string(), "Node 26".to_string())
+        );
+        // Platform-only move: majors alone would read "Node 26 → Node 26".
+        assert_eq!(
+            describe("darwin-x64-node26", "darwin-arm64-node26"),
+            (
+                "darwin-x64-node26".to_string(),
+                "darwin-arm64-node26".to_string()
+            )
+        );
+        // A stamp written when no Node version resolved carries no major.
+        assert_eq!(
+            describe("darwin-arm64", "darwin-arm64-node26"),
+            (
+                "darwin-arm64".to_string(),
+                "darwin-arm64-node26".to_string()
+            )
+        );
+    }
+}

--- a/crates/nub-cli/src/install_engine.rs
+++ b/crates/nub-cli/src/install_engine.rs
@@ -56,16 +56,28 @@ pub(crate) fn recorded(anchor: &Path) -> Option<String> {
 /// name a different Node and stamp a lie. Best-effort: an install that already
 /// succeeded must not fail on an unwritable stamp.
 pub(crate) fn record(cwd: &Path, code: i32) {
+    record_for(
+        cwd,
+        code,
+        aube_util::engine_context().runtime_node_version.as_deref(),
+    );
+}
+
+/// The gated write, split from its process-global engine-context read so the
+/// success gate is unit-testable without touching that global. A non-zero exit
+/// records nothing — a failed install must not stamp the tree as built for this
+/// engine — and an unresolved version has nothing to record.
+fn record_for(cwd: &Path, code: i32, version: Option<&str>) {
     if code != 0 {
         return;
     }
-    let Some(version) = aube_util::engine_context().runtime_node_version else {
+    let Some(version) = version else {
         return;
     };
     let Some(anchor) = anchor(cwd) else {
         return;
     };
-    write_stamp(&anchor, &engine_name(&version));
+    write_stamp(&anchor, &engine_name(version));
 }
 
 /// Write the stamp INTO an existing tree only. A verb that installed nothing
@@ -117,6 +129,24 @@ mod tests {
         assert_eq!(recorded(anchor), Some("darwin-arm64-node22".to_string()));
         std::fs::write(anchor.join("node_modules/.nub-engine"), "  \n").unwrap();
         assert_eq!(recorded(anchor), None, "a blank marker is not a record");
+    }
+
+    #[test]
+    fn only_a_successful_install_records_the_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        let anchor = dir.path();
+        std::fs::write(anchor.join("package.json"), "{\"name\":\"app\"}").unwrap();
+        std::fs::create_dir(anchor.join("node_modules")).unwrap();
+
+        // A failed verb must not claim the tree is built for this engine…
+        record_for(anchor, 1, Some("22.15.0"));
+        assert_eq!(recorded(anchor), None);
+        // …nor may an install with no resolved Node version stamp a guess.
+        record_for(anchor, 0, None);
+        assert_eq!(recorded(anchor), None);
+        // A success with a known engine records it.
+        record_for(anchor, 0, Some("22.15.0"));
+        assert_eq!(recorded(anchor), Some(engine_name("22.15.0")));
     }
 
     #[test]

--- a/crates/nub-cli/src/main.rs
+++ b/crates/nub-cli/src/main.rs
@@ -8,6 +8,7 @@ mod cli;
 mod config;
 mod dynamic_phantom;
 mod init;
+mod install_engine;
 mod nubx_consent;
 mod phantom_scan;
 mod pm_engine;

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -368,6 +368,7 @@ fn run_add(typed: &str, args: &[String]) -> Result<i32> {
     )?;
     super::min_release_age::persist(&session.cwd, code == 0, &globals.output);
     stamp_if_virgin(&session, code);
+    crate::install_engine::record(&session.cwd, code);
     // `nub add vite` (or adding any dep to a vite project) changes the graph;
     // refresh `.modules.yaml` + the < 8.1 patch. Note: a FIRST `nub add vite`
     // can't have disk-materialized vite yet (the manifest didn't declare it at
@@ -393,6 +394,7 @@ fn run_remove(typed: &str, args: &[String]) -> Result<i32> {
         aube::commands::remove::run(verb, globals.effective_filter()),
     )?;
     stamp_if_virgin(&session, code);
+    crate::install_engine::record(&session.cwd, code);
     Ok(code)
 }
 
@@ -424,6 +426,7 @@ fn run_update(typed: &str, args: &[String]) -> Result<i32> {
     )?;
     super::min_release_age::persist(&session.cwd, code == 0, &globals.output);
     stamp_if_virgin(&session, code);
+    crate::install_engine::record(&session.cwd, code);
     // `nub update` re-resolves; a vite bump can cross the 8.1 boundary, so
     // refresh `.modules.yaml` + the < 8.1 patch to match the new graph.
     apply_vite_compat(&session, code);
@@ -1134,6 +1137,7 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     // declaration). Any incumbent signal ⇒ `false` ⇒ no write — nub never imposes
     // its brand on another PM's project (the symmetric brand boundary).
     stamp_if_virgin(&session, code);
+    crate::install_engine::record(&session.cwd, code);
     Ok(code)
 }
 
@@ -1344,7 +1348,9 @@ pub fn run_ci(flags: CiFlags) -> Result<i32> {
             ));
         }
     }
-    run_engine(&session, opts, yarn, &flags.output)
+    let code = run_engine(&session, opts, yarn, &flags.output)?;
+    crate::install_engine::record(&session.cwd, code);
+    Ok(code)
 }
 
 /// Yarn-kind drift pre-flight, at the nub layer.

--- a/crates/nub-cli/src/verify_deps.rs
+++ b/crates/nub-cli/src/verify_deps.rs
@@ -282,9 +282,15 @@ fn parse_policy_value(value: &serde_json::Value) -> Option<Policy> {
 /// because the script at hand may not touch the native dependency at all, and
 /// aborting a run that works today would be a regression.
 fn repair_engine_mismatch(project: &Project, policy: Policy) {
-    let Some(anchor) = crate::install_engine::anchor(&project.root) else {
-        return;
-    };
+    // The install root, derived from the `project` the gate already walked —
+    // NOT a fresh `install_engine::anchor()` call, which would re-run
+    // `detect_project` (a whole manifest-tree walk, and a cache miss when the
+    // run is invoked from a subdir) on every run of a nub project. Same value
+    // `anchor()` computes (`workspace_root.unwrap_or(root)`), zero extra I/O.
+    let anchor = project
+        .workspace_root
+        .clone()
+        .unwrap_or_else(|| project.root.clone());
     // Anchored at the install root, matching how the installer resolved the
     // Node it built against (`pm_engine::apply_lifecycle_augmentation`). Only a
     // tree carrying nub's stamp reaches this closure (see `engine_repair_needed`),

--- a/crates/nub-cli/src/verify_deps.rs
+++ b/crates/nub-cli/src/verify_deps.rs
@@ -115,6 +115,12 @@ pub(crate) fn gate(cwd: &Path, compat_mode: bool) -> Option<i32> {
         return None;
     }
 
+    // Engine repair runs BEFORE the staleness walk: a tree built for another
+    // Node major is stale in a way the walk cannot see (the wrong-ABI package
+    // is present and version-satisfying), and the reinstall that fixes it also
+    // settles whatever the walk would have reported.
+    repair_engine_mismatch(&project, policy);
+
     let reason = needs_install_reason(&project)?; // fresh / uncertain → proceed silently
     // Defense-in-depth brand pass: the reason strings are nub-native today, but
     // route them through the same rewrite all engine-adjacent output uses so no
@@ -253,6 +259,94 @@ fn parse_policy_value(value: &serde_json::Value) -> Option<Policy> {
         serde_json::Value::String(s) => parse_policy(s),
         _ => None,
     }
+}
+
+/// Reinstall a nub-installed tree that was built for a different Node engine.
+///
+/// The carve-out this makes to the no-auto-install posture documented on
+/// [`parse_policy`] is deliberate and narrow. That posture says nub will not
+/// reshape a tree ANOTHER package manager installed; the stamp is written only
+/// by a successful nub install, so a mismatch here means nub is redoing nub's
+/// own work. Every other kind of staleness still only warns.
+///
+/// The reinstall is a PLAIN `nub install` — the exact command the warning path
+/// tells users to run — with default flags: the engine folds into the install's
+/// own freshness/delta hash (`state.rs`, `finalize.rs`), so a present,
+/// satisfying lockfile is not re-resolved (nub's no-churn write leaves it
+/// untouched) while the native dependency is relinked from its per-engine store
+/// build, or rebuilt when this engine was never built before. A frozen install
+/// is deliberately NOT used — it forces a full lifecycle re-run even when the
+/// store already holds the build, defeating the relink.
+///
+/// Best-effort throughout — a failed repair prints and lets the run continue,
+/// because the script at hand may not touch the native dependency at all, and
+/// aborting a run that works today would be a regression.
+fn repair_engine_mismatch(project: &Project, policy: Policy) {
+    let Some(anchor) = crate::install_engine::anchor(&project.root) else {
+        return;
+    };
+    // Anchored at the install root, matching how the installer resolved the
+    // Node it built against (`pm_engine::apply_lifecycle_augmentation`). Only a
+    // tree carrying nub's stamp reaches this closure (see `engine_repair_needed`),
+    // so a foreign tree pays a single failed file read, never a Node resolution.
+    // The spawn-free cached resolver runs first; its under-report (`None` on a
+    // cold version cache) is unacceptable here — the first run after a switch is
+    // the whole point — so it falls through to the full resolution the launch is
+    // about to perform anyway.
+    let resolve_current = || {
+        let node = nub_core::node::discovery::discover_node_cached(&anchor)
+            .or_else(|| nub_core::node::discovery::discover_node(&anchor).ok())?;
+        Some(crate::install_engine::engine_name(
+            &node.version.to_string(),
+        ))
+    };
+    let Some((recorded, current)) = engine_repair_needed(policy, &anchor, resolve_current) else {
+        return;
+    };
+
+    let (was, now) = crate::install_engine::describe(&recorded, &current);
+    eprintln!(
+        "nub: dependencies were installed for {was}, this run uses {now}. \
+         Reinstalling — native addons are built per Node major."
+    );
+    let flags = crate::pm_engine::InstallFlags {
+        dir: Some(anchor),
+        ..Default::default()
+    };
+    // `-C <dir>` chdirs the process and never restores it (a PM verb exits right
+    // after), but here the RUN still has to happen — from its own cwd, which the
+    // caller may have set explicitly (a workspace member under `nub exec -r`).
+    let restore = std::env::current_dir().ok();
+    let outcome = crate::pm_engine::run_install(flags);
+    if let Some(cwd) = restore {
+        let _ = std::env::set_current_dir(cwd);
+    }
+    match outcome {
+        Ok(0) => {}
+        // A non-zero code already carried the engine's own diagnostic.
+        Ok(_) => eprintln!("nub: reinstall failed; continuing with the tree as installed."),
+        Err(e) => eprintln!("nub: reinstall failed: {e}"),
+    }
+}
+
+/// `(engine the tree was built for, engine this run uses)` when they differ.
+///
+/// The stamp read comes FIRST and `current` is a closure, so the run path's cost
+/// on a tree nub did not install is a single failed file read — no Node
+/// resolution at all. Pure over the on-disk stamp, so the three cases that
+/// matter — a real mismatch, a matching engine (never repair on the happy path),
+/// and the `off` opt-out — are testable without switching Node.
+fn engine_repair_needed(
+    policy: Policy,
+    anchor: &Path,
+    current: impl FnOnce() -> Option<String>,
+) -> Option<(String, String)> {
+    if policy == Policy::Off {
+        return None;
+    }
+    let recorded = crate::install_engine::recorded(anchor)?;
+    let current = current()?;
+    (recorded != current).then_some((recorded, current))
 }
 
 /// The staleness verdict for `project`: `Some(reason)` if the tree looks stale,
@@ -444,6 +538,52 @@ mod tests {
         assert!(version_mismatch("foo", "^2.0.0", &at("1.0.0-beta.1")).is_none());
         // No readable installed version → skip.
         assert!(version_mismatch("foo", "^2.0.0", &InstalledPkg { version: None }).is_none());
+    }
+
+    /// The whole engine-repair contract, at the decision boundary: a tree nub
+    /// built for another Node major is repaired; a matching one never is (a
+    /// false positive here would reinstall on EVERY run); a tree nub did not
+    /// install is untouched; and `off` opts out of all of it.
+    #[test]
+    fn engine_repair_fires_only_on_a_nub_tree_built_for_another_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        let anchor = dir.path();
+        let stamp = |engine: &str| {
+            std::fs::create_dir_all(anchor.join("node_modules")).unwrap();
+            std::fs::write(anchor.join("node_modules/.nub-engine"), engine).unwrap();
+        };
+        let node26 = crate::install_engine::engine_name("26.5.0");
+        let node22 = crate::install_engine::engine_name("22.15.0");
+        let running_26 = || Some(node26.clone());
+        let moved = || Some((node22.clone(), node26.clone()));
+
+        // No stamp: another PM's tree (or a pre-stamp nub install). The current
+        // engine is never even resolved.
+        assert_eq!(
+            engine_repair_needed(Policy::Warn, anchor, || panic!(
+                "a tree nub did not install must not cost a Node resolution"
+            )),
+            None
+        );
+
+        stamp(&node22);
+        assert_eq!(
+            engine_repair_needed(Policy::Warn, anchor, running_26),
+            moved()
+        );
+        assert_eq!(
+            engine_repair_needed(Policy::Error, anchor, running_26),
+            moved(),
+            "`error` is a stricter policy, not an opt-out of the repair"
+        );
+        assert_eq!(engine_repair_needed(Policy::Off, anchor, running_26), None);
+
+        stamp(&node26);
+        assert_eq!(
+            engine_repair_needed(Policy::Warn, anchor, running_26),
+            None,
+            "the engine that built the tree must never trigger a reinstall"
+        );
     }
 
     #[test]

--- a/site/content/docs/runner/run.mdx
+++ b/site/content/docs/runner/run.mdx
@@ -148,6 +148,14 @@ NUB_VERIFY_DEPS_BEFORE_RUN=off nub run build
 
 Nub does not install on your behalf here — `install` is accepted as a value but behaves like `warn`, since Nub won't reshape a tree another package manager set up. Run `nub install` when you see the warning. The check also applies to `nub <file>`, `nub exec`, and `nubx`, and is skipped in [`--node` / compat mode](#--node) and inside an already-running script (so a script that spawns `node` doesn't re-check).
 
+The one exception is a tree Nub installed for a different Node major than the one about to run it. Native addons are compiled against a specific Node ABI, so switching Node — bumping `.nvmrc` or `engines.node`, or moving between installed versions — leaves them unloadable, and the run would otherwise die with a raw `ERR_DLOPEN_FAILED … NODE_MODULE_VERSION` from deep inside a dependency. Nub records which engine built the tree, notices the mismatch, and reinstalls once before the run:
+
+```
+nub: dependencies were installed for Node 22, this run uses Node 26. Reinstalling — native addons are built per Node major.
+```
+
+Because Nub keeps a build per engine in its store, the reinstall is a fast re-link once you have run under that Node before; only an engine it has never built for pays a real rebuild. This repair is scoped to trees Nub itself installed and to an engine change — every other kind of staleness still only warns — and `off` disables it along with the rest of the check.
+
 ## Undeclared dependencies
 
 Nub also flags a *phantom* dependency — a package your own source imports but never declares, that resolves today only because some dependency-of-a-dependency hoisted it into `node_modules`. It works under a flat npm or Yarn install and breaks the moment the tree is installed isolated, so Nub names the file and the fix before that happens:


### PR DESCRIPTION
Native addons compile against one Node ABI (`NODE_MODULE_VERSION`). When a project's Node major changes between install and run — a bumped `.nvmrc`/`engines.node`, or a switched Node — `node_modules` still holds addons built for the old ABI. `nub run` didn't notice: the pre-run freshness walk in `verify_deps` compares declared deps against what resolves on disk, and a wrong-ABI addon is present and version-satisfying, so the walk reports the tree fresh and the run crashes with a raw error from inside a dependency.

## Before / after

Node 22 → 26 switch, a dependency with a native addon (captured from the dev binary):

```
$ nub run probe            # under Node 26; tree was installed under Node 22
Error: The module '…/probe.node' was compiled against a different Node.js
version using NODE_MODULE_VERSION 127. This version of Node.js requires
NODE_MODULE_VERSION 147. …  code: 'ERR_DLOPEN_FAILED'
```

```
$ nub run probe
nub: dependencies were installed for Node 22, this run uses Node 26. Reinstalling — native addons are built per Node major.
nub 0.5.0 · ✓ installed 1 package in 1.9s
addon loaded: ok
```

A second run under Node 26 is clean (stamp matches, no reinstall); `NUB_VERIFY_DEPS_BEFORE_RUN=off` suppresses the repair and the raw crash returns.

## Detection

Each successful nub install writes `node_modules/.nub-engine` = `<os>-<arch>-node<major>` — the engine string the store and side-effects cache already key builds on. The run path reads that stamp and compares it to the engine it is about to use.

Hot-path cost: the stamp read comes first and the current engine is resolved lazily, so a tree nub did not install pays a single failed file read — no Node resolution. A nub-installed tree resolves the current engine spawn-free from the discovery cache, falling back only to the resolution the launch is about to perform anyway. There is no `node_modules` walk.

## Repair

On a mismatch, a plain `nub install` — the command the warning path already tells users to run. The engine folds into the install's own freshness/delta hash, so a present, satisfying lockfile is not re-resolved (the no-churn write leaves it untouched) while the native dep is relinked from its per-engine store build, or rebuilt when this engine was never built before. It prints what it is doing, and `Policy::Off` skips it along with the rest of the check.

## Posture

`verify_deps` deliberately maps `install`→`warn`, with the rationale that nub won't reshape a tree another PM installed. That is scoped to *other* PMs' trees. Only a nub install writes the stamp, so a mismatch here is nub redoing nub's own work, not reshaping npm/pnpm/yarn's — a narrow carve-out, not a reversal. Ordinary staleness and foreign trees keep today's warn behavior.

Refs #548
