### PR TITLE
fix(release): grant the canary jobs the permissions the workflow baseline denies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1149,7 +1149,7 @@ jobs:
     env:
       VERSION: ${{ needs.verify.outputs.canary_version }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           persist-credentials: false
       # ACCEPTED TRADEOFF (maintainer, 2026-07-24): zizmor's cache-poisoning
@@ -1249,7 +1249,7 @@ jobs:
       VERSION: ${{ needs.verify.outputs.canary_version }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           persist-credentials: false
       - name: Download all platform artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1148,7 +1148,14 @@ jobs:
       VERSION: ${{ needs.verify.outputs.canary_version }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+      # ACCEPTED TRADEOFF (maintainer, 2026-07-24): zizmor's cache-poisoning
+      # audit flags publishing from a main-push-triggered workflow whose build
+      # jobs restore rust/pnpm caches — a poisoned Actions cache could in
+      # theory reach published canary bits. Accepted: the tag-path stable
+      # releases build from these same caches, and cold-building 8 platforms
+      # per push is not worth the surface reduction (bun/deno ship canaries
+      # the same way). setup-node is v5-pinned by SHA like every other action.
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # zizmor: ignore[cache-poisoning]
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -785,6 +785,10 @@ jobs:
           path: nub-pkg
       - name: Assert the built binary runs and reports the release version
         shell: bash
+        env:
+          # Hoisted from the run block: an expression expanding inside the
+          # script is zizmor error-level template injection; env is inert.
+          CANARY_VERSION: ${{ needs.verify.outputs.canary_version }}
         run: |
           set -euo pipefail
           BIN="nub-pkg/${{ matrix.bin }}"
@@ -807,12 +811,12 @@ jobs:
           # it runs + prints a non-empty semver-ish string.
           EXPECTED=""
           if [ "${{ github.event_name }}" = "push" ]; then
-            # $GITHUB_REF (the ambient env var) not ${{ github.ref }}: same
-            # value, but the expression form is a zizmor error-level
-            # template-injection finding that reds the whole workflow audit.
+            # $GITHUB_REF (the ambient env var), never the github.ref
+            # expression form — expressions expand into the script text
+            # (zizmor error-level template injection).
             case "$GITHUB_REF" in
               refs/tags/*) EXPECTED="${GITHUB_REF_NAME#v}" ;;
-              *)           EXPECTED="${{ needs.verify.outputs.canary_version }}" ;;
+              *)           EXPECTED="$CANARY_VERSION" ;;
             esac
           fi
           if [ -n "$EXPECTED" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1128,6 +1128,15 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [verify, build, glibc-floor-guard, pre-publish-gate]
     runs-on: ubuntu-latest
+    permissions:
+      # Same grant as publish-npm (the job this mirrors): checkout reads; npm
+      # publish authenticates via OIDC trusted publishing, which mints its
+      # token from the job's OIDC identity (id-token: write). The workflow
+      # baseline is `permissions: {}`, so omitting this block deny-alls the
+      # job — the maiden canary run failed exactly here (npm PUT E404 from the
+      # unauthenticated fallback).
+      contents: read
+      id-token: write
     env:
       VERSION: ${{ needs.verify.outputs.canary_version }}
     steps:
@@ -1213,6 +1222,11 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [verify, canary-publish-npm]
     runs-on: ubuntu-latest
+    permissions:
+      # Deletes + recreates the rolling release and the canary tag ref with
+      # GITHUB_TOKEN (same grant as github-release). The workflow baseline is
+      # `permissions: {}`, so without this block every gh/git write here 403s.
+      contents: write
     env:
       VERSION: ${{ needs.verify.outputs.canary_version }}
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -529,7 +529,9 @@ jobs:
       - name: Stamp canary version (uncommitted)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
-        run: node scripts/set-version.mjs "${{ needs.verify.outputs.canary_version }}"
+        env:
+          CANARY_VERSION: ${{ needs.verify.outputs.canary_version }}
+        run: node scripts/set-version.mjs "$CANARY_VERSION"
 
       - name: Install cross
         if: matrix.cross
@@ -1148,6 +1150,8 @@ jobs:
       VERSION: ${{ needs.verify.outputs.canary_version }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          persist-credentials: false
       # ACCEPTED TRADEOFF (maintainer, 2026-07-24): zizmor's cache-poisoning
       # audit flags publishing from a main-push-triggered workflow whose build
       # jobs restore rust/pnpm caches — a poisoned Actions cache could in
@@ -1246,6 +1250,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          persist-credentials: false
       - name: Download all platform artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -1287,7 +1293,9 @@ jobs:
           # leftover `canary` tag would pin the "new" release to the old commit.
           # Tolerate only genuine absence (first run); fail loud otherwise.
           if git ls-remote --exit-code --tags origin canary >/dev/null 2>&1; then
-            git push origin :refs/tags/canary
+            # gh api, not `git push :refs/tags/canary`: the checkout no longer
+            # persists credentials (artipacked), and GH_TOKEN authenticates gh.
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/canary"
           fi
           {
             echo "Rolling canary build of \`main\`, rebuilt on every code push."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -807,7 +807,10 @@ jobs:
           # it runs + prints a non-empty semver-ish string.
           EXPECTED=""
           if [ "${{ github.event_name }}" = "push" ]; then
-            case "${{ github.ref }}" in
+            # $GITHUB_REF (the ambient env var) not ${{ github.ref }}: same
+            # value, but the expression form is a zizmor error-level
+            # template-injection finding that reds the whole workflow audit.
+            case "$GITHUB_REF" in
               refs/tags/*) EXPECTED="${GITHUB_REF_NAME#v}" ;;
               *)           EXPECTED="${{ needs.verify.outputs.canary_version }}" ;;
             esac


### PR DESCRIPTION
Two #551 follow-ups that keep the canary pipeline from running:

- The maiden canary run ([30131216108](https://github.com/nubjs/nub/actions/runs/30131216108)) failed at the npm publish with E404 on PUT: the workflow baseline is `permissions: {}` and `canary-publish-npm` declares no permissions block, so it lacks `id-token: write` and the OIDC trusted-publishing PUT goes out unauthenticated. `canary-release` has the same gap for its contents writes. Both jobs now carry the grants of the tag-path jobs they mirror.
- zizmor turned red on #551's merge: the pre-publish gate's `case "${{ github.ref }}"` is an error-level template-injection finding. Replaced with the ambient `$GITHUB_REF`.

Refs #551