### PR TITLE
fix(watch): gate auto-discovered --env-file on Node 20.6, and stop a .env NODE_ENV leaking

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -273,20 +273,32 @@ fn merge_child_env(
 /// injecting a var Node already delivers identically would FREEZE it at the `nub
 /// watch` startup value (Node's `--env-file` never overrides an already-present
 /// env var). Inject a key iff nub's `${VAR}` expansion changed it from the raw
-/// value Node's `--env-file` delivers (`raw_env` is the unexpanded `.env*` merge);
-/// every plain var is left to Node's `--env-file` and live-reloads on restart. A
-/// key absent from `raw_env` is injected — that is the explicit `--env-file` case
-/// (`raw_env` is empty there: auto-discovery is suppressed and Node gets no
-/// `--env-file` args, so injection is the only delivery channel). Pure over its
-/// inputs so the selection can be unit-tested without spawning Node.
+/// value Node actually delivers — `forwarded_raw` is the unexpanded merge of the
+/// files that really reach Node as `--env-file` args; every plain var is left to
+/// Node's `--env-file` and live-reloads on restart. A key absent from
+/// `forwarded_raw` is injected, because injection is then its only delivery
+/// channel: that covers the explicit `--env-file` case (auto-discovery is
+/// suppressed) and every source below Node's 20.6.0 `--env-file` floor, where
+/// nothing is forwarded at all. Pure over its inputs so the selection can be
+/// unit-tested without spawning Node.
 fn watch_inject_vars<'a>(
     env_vars: &'a HashMap<String, String>,
-    raw_env: &HashMap<String, String>,
+    forwarded_raw: &HashMap<String, String>,
 ) -> Vec<(&'a String, &'a String)> {
     env_vars
         .iter()
-        .filter(|(k, v)| raw_env.get(*k) != Some(*v))
+        .filter(|(k, v)| forwarded_raw.get(*k) != Some(*v))
         .collect()
+}
+
+/// Node's `--env-file` floor (landed 20.6.0). Below it Node aborts on the
+/// unknown option *before executing anything*, so a watch child handed the flag
+/// dies instantly with no output — every env-file source must fall back to
+/// whole-map injection instead. nub supports Node from 18.19, so this range is
+/// live, not theoretical. Gates the auto-discovered cascade as well as the
+/// explicit flags.
+fn node_accepts_env_file(version: &nub_core::node::version::NodeVersion) -> bool {
+    *version >= nub_core::node::version::NodeVersion::new(20, 6, 0)
 }
 
 /// Whether the watch path forwards the explicit `--env-file` flags to the
@@ -304,8 +316,7 @@ fn should_forward_explicit_env_files(
         return false;
     }
     let needs_if_exists = explicit.iter().any(|(_, if_exists)| *if_exists);
-    *version >= NodeVersion::new(20, 6, 0)
-        && (!needs_if_exists || *version >= NodeVersion::new(22, 9, 0))
+    node_accepts_env_file(version) && (!needs_if_exists || *version >= NodeVersion::new(22, 9, 0))
 }
 
 /// Render a forwarded watch env file (auto-discovered or explicit) for Node's
@@ -4836,11 +4847,11 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     // the child. This keeps `nub --watch --env-file …` consistent with the direct
     // file runner. `--no-env-file` suppresses BOTH the auto args and the explicit
     // `--env-file` overlay — the watched Node receives no `--env-file` args at all.
-    // Load the `.env*` files ONCE: `raw_env` is the unexpanded merge (the values
-    // Node's `--env-file` args deliver), `auto_env` is the same map expanded. A
-    // single read (rather than `load_env_files` + a second `load_env_files_raw`)
-    // avoids re-parsing every file twice and closes the TOCTOU window where a file
-    // changing between two reads could spuriously inject a plain var.
+    // Load the `.env*` files ONCE: `auto_raw_env` is the unexpanded merge,
+    // `auto_env` is the same map expanded. A single read (rather than
+    // `load_env_files` + a second `load_env_files_raw`) avoids re-parsing every
+    // file twice and closes the TOCTOU window where a file changing between two
+    // reads could spuriously inject a plain var.
     // Forward the explicit `--env-file` files only when the pinned Node accepts
     // every flag flavor present (#479). All-or-nothing: mixing forwarded and
     // injected explicit files would corrupt last-writer-wins precedence (an
@@ -4848,31 +4859,48 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     // forwarded later one — Node's `--env-file` never overrides an already-set
     // var). Below the gate, fall back to whole-map injection: values freeze at
     // their startup snapshot (the pre-#479 behavior — degraded, never broken).
+    // The auto cascade needs the SAME floor. It never had one: `--env-file` args
+    // for the discovered `.env*` files were pushed unconditionally, so on Node
+    // 18.19–20.5 every `nub watch` in a project with a `.env` died on `bad
+    // option: --env-file=…` before running a line. Gate it exactly like the
+    // explicit flags (the autos always use the plain `--env-file` spelling, so
+    // only the 20.6.0 floor applies to them).
+    let forward_auto = node_accepts_env_file(&node.version);
     let forward_explicit = should_forward_explicit_env_files(&node.version, explicit_env_files);
-    let raw_env = if env_file_present || no_env_file {
-        if forward_explicit {
-            // The explicit files reach Node as `--env-file` args below, so the
-            // inject loop must skip everything Node delivers identically — hand
-            // it the raw (unexpanded) explicit merge, same as the auto path.
-            ENV_FILE_VARS_RAW.get().cloned().unwrap_or_default()
-        } else {
-            // No `--env-file` args reach Node, so injection is the only delivery
-            // channel — leave `raw_env` empty so the inject loop injects every
-            // var (see `watch_inject_vars`). Under `--no-env-file`
-            // `merge_child_env` returns empty, so nothing is injected.
-            HashMap::new()
-        }
+    // The auto `.env*` cascade, unexpanded. Loaded whenever auto-discovery is
+    // live, INDEPENDENT of forwarding: `auto_env` below needs it as the injection
+    // base even when the files never reach Node.
+    let auto_raw_env = if env_file_present || no_env_file {
+        HashMap::new()
     } else {
         project
             .as_ref()
             .map(|p| nub_core::workspace::env::load_env_files_raw(&p.root))
             .unwrap_or_default()
     };
+    // The raw values the watched Node receives through forwarded `--env-file`
+    // args — precisely the set the inject loop must SKIP, since injecting a var
+    // Node already delivers freezes it at the startup value (#207). A family that
+    // is not forwarded contributes nothing here, which makes injection its only
+    // delivery channel and restores the pre-#207 freeze-at-startup behavior:
+    // degraded live-reload, never a dead watcher.
+    let mut forwarded_raw_env = if forward_auto {
+        auto_raw_env.clone()
+    } else {
+        HashMap::new()
+    };
+    if forward_explicit {
+        // The explicit files reach Node as `--env-file` args below, so the inject
+        // loop must skip everything Node delivers identically.
+        if let Some(explicit) = ENV_FILE_VARS_RAW.get() {
+            forwarded_raw_env.extend(explicit.clone());
+        }
+    }
     // Pre-expand the auto base to the same map the direct file runner's
     // `load_env_files` produces. When `--env-file` is present `merge_child_env`
-    // discards this (auto-discovery suppressed), so the empty `raw_env` clone is
-    // fine — only the explicit `--env-file` overlay survives there.
-    let mut auto_env = raw_env.clone();
+    // discards this (auto-discovery suppressed), so the empty map is fine — only
+    // the explicit `--env-file` overlay survives there.
+    let mut auto_env = auto_raw_env;
     nub_core::workspace::env::expand_env_map(&mut auto_env);
     // `merge_child_env` applies the `--env-file` suppression gate and overlays the
     // explicit `--env-file` vars (shell still wins).
@@ -4907,10 +4935,12 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
 
     // Reverse so the highest-priority `.env*` file lands last (Node's
     // last-writer-wins ⇒ nub's first-writer-wins precedence).
-    for path in env_file_paths.iter().rev() {
-        // `cmd` inherits `cwd`; the helper chooses the path form required by the
-        // platform watcher without changing cwd or file precedence.
-        node_args.push(watch_env_file_arg(path, &cwd, cfg!(windows), false)?);
+    if forward_auto {
+        for path in env_file_paths.iter().rev() {
+            // `cmd` inherits `cwd`; the helper chooses the path form required by
+            // the platform watcher without changing cwd or file precedence.
+            node_args.push(watch_env_file_arg(path, &cwd, cfg!(windows), false)?);
+        }
     }
     // Explicit `--env-file` files forward in USER order — no reverse: Node is
     // last-writer-wins and nub's parse across repeated flags is last-wins too,
@@ -4950,7 +4980,7 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     // identity and non-Windows behavior stays byte-for-byte unchanged.
     // Whether ANY env file (auto-discovered or explicit) reaches Node as a raw
     // `--env-file` arg — the trigger for the per-child guard machinery below.
-    let any_env_forwarded = !env_file_paths.is_empty() || forward_explicit;
+    let any_env_forwarded = (forward_auto && !env_file_paths.is_empty()) || forward_explicit;
     #[cfg(windows)]
     if any_env_forwarded {
         cmd.current_dir(windows_long_watch_path(&cwd)?);
@@ -4960,7 +4990,7 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     // delivers identically is left to Node so the long-lived watcher re-reads it
     // from the file on every restart (a changed `.env` value is picked up) instead
     // of freezing at startup.
-    for (k, v) in watch_inject_vars(&env_vars, &raw_env) {
+    for (k, v) in watch_inject_vars(&env_vars, &forwarded_raw_env) {
         cmd.env(k, v);
     }
     // Node receives the forwarded files (auto-discovered + explicit) as raw
@@ -8948,6 +8978,19 @@ mod tests {
         let arg = watch_env_file_arg(&root.join("missing.env"), &root, true, true).unwrap();
         assert!(arg.starts_with("--env-file-if-exists="), "{arg}");
         assert!(arg.ends_with("missing.env"), "{arg}");
+    }
+
+    /// The floor the auto-discovered cascade shares with the explicit flags.
+    /// Empirically pinned against installed Nodes: 19.3.0 rejects `--env-file`,
+    /// 20.10.0 accepts it — bracketing the documented 20.6.0 landing.
+    #[test]
+    fn auto_env_file_forwarding_gates_on_node_version() {
+        use nub_core::node::version::NodeVersion;
+        assert!(!node_accepts_env_file(&NodeVersion::new(18, 19, 0)));
+        assert!(!node_accepts_env_file(&NodeVersion::new(19, 3, 0)));
+        assert!(!node_accepts_env_file(&NodeVersion::new(20, 5, 0)));
+        assert!(node_accepts_env_file(&NodeVersion::new(20, 6, 0)));
+        assert!(node_accepts_env_file(&NodeVersion::new(26, 0, 0)));
     }
 
     #[test]

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4900,7 +4900,7 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     } else {
         project
             .as_ref()
-            .map(|p| nub_core::workspace::env::load_env_files_raw(&p.root))
+            .map(|p| nub_core::workspace::env::load_env_files_raw_warning(&p.root))
             .unwrap_or_default()
     };
     // The raw values the watched Node receives through forwarded `--env-file`

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -439,13 +439,34 @@ fn strip_windows_verbatim_prefix(path: &str) -> String {
     }
 }
 
-/// Exact ambient spellings for the env-file runtime-control denylist. A Unix
-/// process may carry both canonical and mixed-case spellings; Windows collapses
-/// them through its case-insensitive environment.
-fn ambient_denied_env_file_keys() -> Vec<String> {
+/// The keys the watch guard strips from a forwarded env file's values.
+///
+/// The runtime-control denylist is unconditional. `NODE_ENV` joins it only when
+/// the AUTO `.env*` cascade is the live source, which is what keeps `nub watch`
+/// byte-identical to `nub <file>`: `load_env_files` drops a file-set `NODE_ENV`
+/// (#263 — a `.env` pinning it broke `next build`, whose prerender forks
+/// inherited the wrong mode), while the explicit `--env-file` map deliberately
+/// does not. Forwarding the raw files to Node bypasses that load-time drop
+/// entirely, so the watch path has to re-apply it at the process boundary. The
+/// two families never co-occur — an explicit flag suppresses auto-discovery — so
+/// keying the extra drop on which family is live reproduces each one's
+/// direct-runner behavior exactly.
+fn watch_guarded_env_file_keys(auto_cascade: bool) -> Vec<&'static str> {
+    let mut keys = nub_core::workspace::env::denied_env_file_keys().to_vec();
+    if auto_cascade {
+        keys.push("NODE_ENV");
+    }
+    keys
+}
+
+/// Exact ambient spellings of the guarded keys. A Unix process may carry both
+/// canonical and mixed-case spellings; Windows collapses them through its
+/// case-insensitive environment. An ambient value is the user's own and must
+/// survive untouched — only file-derived values are stripped.
+fn ambient_guarded_env_file_keys(guarded: &[&'static str]) -> Vec<String> {
     env::vars_os()
         .filter_map(|(key, _)| key.into_string().ok())
-        .filter(|key| nub_core::workspace::env::is_denied_env_file_key(key))
+        .filter(|key| guarded.iter().any(|g| key.eq_ignore_ascii_case(g)))
         .collect()
 }
 
@@ -453,8 +474,12 @@ fn ambient_denied_env_file_keys() -> Vec<String> {
 /// startup consumers cannot read a value from a raw env file. Unix startup
 /// lookup is exact-case, so a mixed-case ambient key does not cover the canonical
 /// spelling; Windows lookup is case-insensitive.
-fn watch_env_guard_placeholders(ambient_keys: &[String], windows: bool) -> Vec<&'static str> {
-    nub_core::workspace::env::denied_env_file_keys()
+fn watch_env_guard_placeholders(
+    guarded: &[&'static str],
+    ambient_keys: &[String],
+    windows: bool,
+) -> Vec<&'static str> {
+    guarded
         .iter()
         .copied()
         .filter(|denied| {
@@ -5024,12 +5049,16 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
         }
         .node_options_token();
 
-        let ambient_keys = ambient_denied_env_file_keys();
-        for key in watch_env_guard_placeholders(&ambient_keys, cfg!(windows)) {
+        // The auto cascade is the live family exactly when no explicit flag
+        // suppressed it; that decides whether `NODE_ENV` is guarded here (see
+        // `watch_guarded_env_file_keys`).
+        let guarded_keys = watch_guarded_env_file_keys(!env_file_present && !no_env_file);
+        let ambient_keys = ambient_guarded_env_file_keys(&guarded_keys);
+        for key in watch_env_guard_placeholders(&guarded_keys, &ambient_keys, cfg!(windows)) {
             cmd.env(key, "");
         }
         let state = serde_json::json!({
-            "denylist": nub_core::workspace::env::denied_env_file_keys(),
+            "denylist": guarded_keys,
             "ambientKeys": ambient_keys,
             "nodeOptions": &sanitized_node_options,
         });
@@ -9134,22 +9163,41 @@ mod tests {
 
     #[test]
     fn watch_env_guard_placeholders_follow_os_key_semantics() {
+        let guarded = watch_guarded_env_file_keys(false);
         let ambient = vec![
             "NODE_OPTIONS".to_string(),
             "node_extra_ca_certs".to_string(),
         ];
 
-        let unix = watch_env_guard_placeholders(&ambient, false);
+        let unix = watch_env_guard_placeholders(&guarded, &ambient, false);
         assert!(!unix.contains(&"NODE_OPTIONS"));
         assert!(unix.contains(&"NODE_EXTRA_CA_CERTS"));
         assert!(unix.contains(&"NODE_TLS_REJECT_UNAUTHORIZED"));
         assert!(unix.contains(&"NODE_REPL_EXTERNAL_MODULE"));
 
-        let windows = watch_env_guard_placeholders(&ambient, true);
+        let windows = watch_env_guard_placeholders(&guarded, &ambient, true);
         assert!(!windows.contains(&"NODE_OPTIONS"));
         assert!(!windows.contains(&"NODE_EXTRA_CA_CERTS"));
         assert!(windows.contains(&"NODE_TLS_REJECT_UNAUTHORIZED"));
         assert!(windows.contains(&"NODE_REPL_EXTERNAL_MODULE"));
+    }
+
+    /// `NODE_ENV` is guarded only for the auto `.env*` cascade, matching what the
+    /// direct runner does for each family (#263 drops a file-set `NODE_ENV` from
+    /// the cascade; the explicit `--env-file` map keeps it). An ambient value is
+    /// the user's own and never gets a placeholder.
+    #[test]
+    fn node_env_is_guarded_only_for_the_auto_cascade() {
+        assert!(watch_guarded_env_file_keys(true).contains(&"NODE_ENV"));
+        assert!(!watch_guarded_env_file_keys(false).contains(&"NODE_ENV"));
+
+        let guarded = watch_guarded_env_file_keys(true);
+        assert!(watch_env_guard_placeholders(&guarded, &[], false).contains(&"NODE_ENV"));
+        assert!(
+            !watch_env_guard_placeholders(&guarded, &["NODE_ENV".to_string()], false)
+                .contains(&"NODE_ENV"),
+            "an ambient NODE_ENV must pass through untouched"
+        );
     }
 
     #[test]

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -4238,6 +4238,60 @@ fn watch_loads_auto_env_file_from_ancestor_project_root() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// Deliberately UNGATED on the Node version — that gate is exactly what let this
+/// regression ship. Every other watch env-file test skips below 20.6, so no CI
+/// leg exercised the auto-discovered cascade on the compat tier, where nub was
+/// handing the watched Node a `--env-file` it does not understand: Node aborted
+/// with `bad option` before executing a line. Assert only that the value ARRIVES,
+/// not how — forwarding above the floor, injection below it — so the test pins
+/// the user-visible contract without freezing the delivery mechanism.
+#[test]
+fn watch_delivers_auto_env_values_on_every_supported_node() {
+    let dir = unique_test_cache();
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), r#"{"name":"watch-env-floor"}"#).unwrap();
+    // A plain value and an expansion-dependent one: below the floor both travel
+    // by injection, above it the plain one rides Node's `--env-file` while the
+    // expanded one is injected. Both must land either way.
+    std::fs::write(
+        dir.join(".env"),
+        "PLAIN=plain\nEXPANDED=${PLAIN}-expanded\n",
+    )
+    .unwrap();
+    let snapshot = dir.join("snapshot.txt");
+    let stderr = dir.join("stderr.txt");
+    std::fs::write(
+        dir.join("probe.cjs"),
+        format!(
+            "require('fs').writeFileSync({path:?}, \
+             `${{process.env.PLAIN || 'missing'}}|${{process.env.EXPANDED || 'missing'}}`);\n",
+            path = snapshot.to_string_lossy()
+        ),
+    )
+    .unwrap();
+
+    let stderr_file = std::fs::File::create(&stderr).unwrap();
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(["--watch", "probe.cjs"])
+        .current_dir(&dir)
+        .env("XDG_CACHE_HOME", dir.join("cache"))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::from(stderr_file));
+    remove_ambient_watch_control_vars(&mut cmd);
+    let mut child = spawn_watch_probe(&mut cmd);
+
+    let snapshot_text =
+        wait_for_watch_snapshot(&snapshot, "plain|plain-expanded", &mut child, &stderr);
+    finish_watch_probe(&mut child);
+    assert_eq!(
+        snapshot_text, "plain|plain-expanded",
+        "auto-discovered .env values must reach the watched child on every supported Node"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// Unix permits a mixed-case ambient key alongside the canonical spelling Node
 /// consumes at startup. The mixed-case value must survive, while a canonical raw
 /// env-file value is occupied in the supervisor and then removed in the child.

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -4280,6 +4280,9 @@ fn watch_delivers_auto_env_values_on_every_supported_node() {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::from(stderr_file));
     remove_ambient_watch_control_vars(&mut cmd);
+    // The mode selectors decide which `.env.[mode]` slots load; clear both so an
+    // ambient value on the developer's machine cannot change the cascade.
+    cmd.env_remove("APP_ENV").env_remove("NODE_ENV");
     let mut child = spawn_watch_probe(&mut cmd);
 
     let snapshot_text =
@@ -4328,6 +4331,7 @@ fn watch_drops_dotenv_node_env_but_keeps_the_ambient_one() {
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::from(stderr_file));
         remove_ambient_watch_control_vars(&mut cmd);
+        cmd.env_remove("APP_ENV");
         match ambient {
             Some(value) => cmd.env("NODE_ENV", value),
             // `.env.production` never exists here, so clearing this only removes
@@ -4342,6 +4346,14 @@ fn watch_drops_dotenv_node_env_but_keeps_the_ambient_one() {
         assert_eq!(
             snapshot_text, expected,
             "ambient={ambient:?}: a .env NODE_ENV must be dropped and an ambient one kept"
+        );
+        // Dropping the value silently is the failure the warning exists to
+        // prevent: without it the user has nothing explaining why their mode did
+        // not apply. The direct runner has always warned here.
+        let stderr_text = std::fs::read_to_string(&stderr).unwrap_or_default();
+        assert!(
+            stderr_text.contains("ignoring NODE_ENV set in .env"),
+            "ambient={ambient:?}: watch must explain the dropped .env NODE_ENV; stderr was {stderr_text:?}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -4292,6 +4292,61 @@ fn watch_delivers_auto_env_values_on_every_supported_node() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// `nub watch` must drop a `.env`-set `NODE_ENV` exactly like the direct runner
+/// does (#263): forwarding the raw file to Node bypassed the load-time drop, so
+/// the watched child saw a mode the same project run without `--watch` never
+/// would. An AMBIENT `NODE_ENV` is the user's own and still passes through — the
+/// distinction the guard's ambient set already draws for the denylist.
+#[test]
+fn watch_drops_dotenv_node_env_but_keeps_the_ambient_one() {
+    for ambient in [None, Some("test")] {
+        let dir = unique_test_cache();
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("package.json"), r#"{"name":"watch-node-env"}"#).unwrap();
+        std::fs::write(dir.join(".env"), "NODE_ENV=production\nSENTINEL=ok\n").unwrap();
+        let snapshot = dir.join("snapshot.txt");
+        let stderr = dir.join("stderr.txt");
+        // SENTINEL proves the cascade was loaded at all, so an absent NODE_ENV
+        // reads as "dropped" and never as "the .env was ignored wholesale".
+        std::fs::write(
+            dir.join("probe.cjs"),
+            format!(
+                "require('fs').writeFileSync({path:?}, \
+                 `${{process.env.SENTINEL || 'missing'}}|${{process.env.NODE_ENV || 'unset'}}`);\n",
+                path = snapshot.to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        let stderr_file = std::fs::File::create(&stderr).unwrap();
+        let mut cmd = Command::new(nub_binary());
+        cmd.args(["--watch", "probe.cjs"])
+            .current_dir(&dir)
+            .env("XDG_CACHE_HOME", dir.join("cache"))
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::from(stderr_file));
+        remove_ambient_watch_control_vars(&mut cmd);
+        match ambient {
+            Some(value) => cmd.env("NODE_ENV", value),
+            // `.env.production` never exists here, so clearing this only removes
+            // an inherited value — it does not change which files load.
+            None => cmd.env_remove("NODE_ENV"),
+        };
+        let mut child = spawn_watch_probe(&mut cmd);
+
+        let expected = format!("ok|{}", ambient.unwrap_or("unset"));
+        let snapshot_text = wait_for_watch_snapshot(&snapshot, &expected, &mut child, &stderr);
+        finish_watch_probe(&mut child);
+        assert_eq!(
+            snapshot_text, expected,
+            "ambient={ambient:?}: a .env NODE_ENV must be dropped and an ambient one kept"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
 /// Unix permits a mixed-case ambient key alongside the canonical spelling Node
 /// consumes at startup. The mixed-case value must survive, while a canonical raw
 /// env-file value is occupied in the supervisor and then removed in the child.

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -4347,13 +4347,21 @@ fn watch_drops_dotenv_node_env_but_keeps_the_ambient_one() {
             snapshot_text, expected,
             "ambient={ambient:?}: a .env NODE_ENV must be dropped and an ambient one kept"
         );
-        // Dropping the value silently is the failure the warning exists to
-        // prevent: without it the user has nothing explaining why their mode did
-        // not apply. The direct runner has always warned here.
+        // The notice tracks the #263 DROP, not shell-wins. With no ambient value
+        // the `.env` line is dropped and must be explained — dropping it silently
+        // leaves the user nothing to go on when their mode does not apply. With an
+        // ambient value the `.env` line loses to ordinary shell-wins precedence
+        // before the drop is ever reached, so there is nothing to report and the
+        // notice must stay quiet. Both directions match the direct runner exactly,
+        // which is the whole point; the negative half also guards the contract
+        // `dotenv_node_env_is_ignored` already pins for a non-watch run.
         let stderr_text = std::fs::read_to_string(&stderr).unwrap_or_default();
-        assert!(
-            stderr_text.contains("ignoring NODE_ENV set in .env"),
-            "ambient={ambient:?}: watch must explain the dropped .env NODE_ENV; stderr was {stderr_text:?}"
+        let warned = stderr_text.contains("ignoring NODE_ENV set in .env");
+        assert_eq!(
+            warned,
+            ambient.is_none(),
+            "ambient={ambient:?}: the notice must appear only when the .env NODE_ENV \
+             was actually dropped; stderr was {stderr_text:?}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/nub-core/src/workspace/env.rs
+++ b/crates/nub-core/src/workspace/env.rs
@@ -354,11 +354,12 @@ pub fn load_env_files(project_root: &Path) -> HashMap<String, String> {
     // nested references like A=hello, B=${A}_world, C=${B}_!.
     expand_env_map(&mut result);
 
-    // Warn only here — this map is injected straight into the child via
-    // `Command::env`, so a dropped `.env` `NODE_ENV` / denylisted var truly never
-    // reaches it. The watch path (plain `load_env_files_raw`) hands the files to
-    // Node's `--env-file` behind a per-restart process guard, but avoids repeating
-    // this load-time warning for a long-lived watcher.
+    // This map is injected straight into the child via `Command::env`, so a
+    // dropped `.env` `NODE_ENV` / denylisted var truly never reaches it. The watch
+    // path re-applies the same drops at its spawn boundary and reports them
+    // through [`load_env_files_raw_warning`]; both sites share the `Once` guards
+    // inside these two calls, so a long-lived watcher still emits each notice at
+    // most once.
     if node_env_ignored {
         warn_node_env_from_dotenv_ignored();
     }

--- a/crates/nub-core/src/workspace/env.rs
+++ b/crates/nub-core/src/workspace/env.rs
@@ -248,6 +248,21 @@ pub fn load_env_files_raw(project_root: &Path) -> HashMap<String, String> {
     load_env_files_raw_reporting(project_root).0
 }
 
+/// [`load_env_files_raw`], plus the same load-time notices [`load_env_files`]
+/// emits. The watch path uses this so a dropped `NODE_ENV` or runtime-control key
+/// is explained exactly once, as it is on a direct file run — without it, `nub
+/// watch` silently ignores a `.env`-set `NODE_ENV` and the user has nothing to go
+/// on when their mode does not apply. `Once` inside each warning keeps a
+/// long-lived watcher to a single notice.
+pub fn load_env_files_raw_warning(project_root: &Path) -> HashMap<String, String> {
+    let (result, node_env_ignored, denied_keys) = load_env_files_raw_reporting(project_root);
+    if node_env_ignored {
+        warn_node_env_from_dotenv_ignored();
+    }
+    warn_denied_env_file_keys(&denied_keys);
+    result
+}
+
 /// The raw loader, additionally reporting (1) whether a `.env` FILE declared
 /// `NODE_ENV` (always dropped — dotenv/@next/env/Vite parity, #263) and (2) which
 /// denylisted runtime-control keys were dropped ([`ENV_FILE_DENYLIST`]). Both
@@ -315,8 +330,9 @@ fn load_env_files_raw_reporting(
 /// Emit the "ignoring `.env` `NODE_ENV`" notice at most once per process. Called
 /// only on the direct run/file injection path ([`load_env_files`]), where the
 /// dropped `NODE_ENV` genuinely never reaches the child; the watch path re-applies
-/// the drop at its spawn boundary instead, and does not warn (the value is kept
-/// out of the child either way). `Once` guards against any repeat.
+/// the drop at its spawn boundary and warns through
+/// [`load_env_files_raw_warning`]. `Once` guards against any repeat, so a
+/// long-lived watcher still emits this at most once.
 fn warn_node_env_from_dotenv_ignored() {
     use std::sync::Once;
     static WARNED: Once = Once::new();

--- a/crates/nub-core/src/workspace/env.rs
+++ b/crates/nub-core/src/workspace/env.rs
@@ -254,8 +254,9 @@ pub fn load_env_files_raw(project_root: &Path) -> HashMap<String, String> {
 /// drops happen HERE at load, so every consumer of the returned map is covered by
 /// construction. The reports are consumed by [`load_env_files`] to warn. The
 /// plain [`load_env_files_raw`] wrapper discards them because watch separately
-/// delegates the raw files to Node; that spawn boundary installs a stable guard
-/// for this same denylist before handing Node the paths.
+/// delegates the raw files to Node; that spawn boundary re-applies these same
+/// drops — this denylist, plus `NODE_ENV` when the auto cascade is the live
+/// source — before handing Node the paths.
 fn load_env_files_raw_reporting(
     project_root: &Path,
 ) -> (HashMap<String, String>, bool, Vec<String>) {
@@ -313,8 +314,9 @@ fn load_env_files_raw_reporting(
 
 /// Emit the "ignoring `.env` `NODE_ENV`" notice at most once per process. Called
 /// only on the direct run/file injection path ([`load_env_files`]), where the
-/// dropped `NODE_ENV` genuinely never reaches the child; the watch path defers to
-/// Node's `--env-file` and does not warn. `Once` guards against any repeat.
+/// dropped `NODE_ENV` genuinely never reaches the child; the watch path re-applies
+/// the drop at its spawn boundary instead, and does not warn (the value is kept
+/// out of the child either way). `Once` guards against any repeat.
 fn warn_node_env_from_dotenv_ignored() {
     use std::sync::Once;
     static WARNED: Once = Once::new();

--- a/runtime/watch-env-guard.cjs
+++ b/runtime/watch-env-guard.cjs
@@ -8,6 +8,13 @@
 
 const WATCH_ENV_GUARD = "__NUB_WATCH_ENV_GUARD";
 const { isMainThread } = require("node:worker_threads");
+// The INVARIANT floor, not the full guarded set: state.denylist is a superset,
+// because the launcher also guards NODE_ENV when the auto `.env*` cascade is the
+// live source. Do NOT add NODE_ENV here — the completeness check below requires
+// every fallback key to be present in state.denylist, and the explicit
+// `--env-file` family deliberately omits NODE_ENV, so every
+// `nub watch --env-file=…` run would then abort. The corrupt-state path clears
+// only these and then throws, so a NODE_ENV it misses is never observable.
 const FALLBACK_DENYLIST = [
   "NODE_OPTIONS",
   "NODE_TLS_REJECT_UNAUTHORIZED",

--- a/site/content/docs/watch.mdx
+++ b/site/content/docs/watch.mdx
@@ -42,7 +42,7 @@ Restarting 'src/server.ts'
 The watch set is loader-instrumented, not glob-based: `nub watch` only watches files that were actually loaded as part of the run, plus a small set of off-graph files that invalidate the process when they change. Concretely, a restart fires on a change to:
 
 - Any file in the **resolved dependency graph** of the entry — including `.ts` / `.tsx` files transpiled in-memory through `module.registerHooks()` that Node never sees on disk.
-- Your **`.env*` files** in their normal precedence (`.env`, `.env.local`, `.env.[mode]`, …) — these are read once at boot and aren't in any import graph, so Nub reports them to the watcher explicitly. Files named with `--env-file` or `--env-file-if-exists` are watched the same way, and every restart re-reads them, so an edited value is live on the next run.
+- Your **`.env*` files** in their normal precedence (`.env`, `.env.local`, `.env.[mode]`, …) — these are read once at boot and aren't in any import graph, so Nub reports them to the watcher explicitly. Files named with `--env-file` or `--env-file-if-exists` are watched the same way, and every restart re-reads them, so an edited value is live on the next run. Re-reading on restart needs Node 20.6 or newer, the version that introduced the underlying flag; below it the values are captured once at startup, and an edit applies only after you restart `nub watch` itself.
 - The **`tsconfig.json` extends chain** — editing a tsconfig (for example, changing a `paths` mapping) restarts the process even though tsconfig isn't imported by anything.
 - **`package.json`**.
 


### PR DESCRIPTION
`nub watch` was unusable on Node 18.19–20.5 in any project with a `.env` file: the watched Node aborted with `bad option: --env-file=.env` before executing a line.

## The bug

To make `.env` edits live across restarts (#207), the watch path hands the watched `node --watch` its env files as raw `--env-file=<path>` args, so Node re-reads them on every restart. Node's `--env-file` landed in **20.6.0**, and nub supports Node from **18.19**.

The explicit `--env-file` flags were already gated on that floor by #479. The auto-discovered `.env*` cascade never was — those args were pushed unconditionally. Node rejects an unknown option before running anything, so the result was a dead watcher with no output at all.

Reproduced with only the Node version varying:

| Node | `nub watch probe.cjs` |
| --- | --- |
| v18.19.1 | exit 9, zero stdout, `bad option: --env-file=.env` |
| v24.14.0 | runs and watches normally |

The flag floors were pinned empirically across the installed Nodes rather than read off a comment: v19.3.0 rejects `--env-file` and v20.10.0 accepts it; v22.7.0 rejects `--env-file-if-exists` and v22.11.0 accepts it.

## The fix

Apply the same 20.6.0 floor to the auto cascade. Below it the values fall back to whole-map injection — live-reload of `.env` edits is lost there, but that is the only delivery Node offers, and it is the behavior that predates #207.

The care is in one variable. `raw_env` served double duty: the expansion base for the injected map, and the set of values Node already delivers that the inject loop must skip (injecting one would freeze it at startup). Only the second half may go empty below the floor, so it is now split — `auto_raw_env` stays loaded for the base, `forwarded_raw_env` carries what Node actually receives. On Node 20.6+ the behavior is unchanged.

## Also: a `.env`-set `NODE_ENV` leaked through watch

Forwarding raw files to Node bypasses the load-time drop in `load_env_files_raw_reporting`, so `nub watch` set `NODE_ENV` from `.env` while `nub <file>` on the same project did not — the #263 failure mode (`next build`'s prerender forks inheriting a mode the project never asked for), reachable again through watch.

Re-applied at the process boundary with the guard that already exists for the runtime-control denylist: a canonical placeholder in the preload-free supervisor stops Node's `--env-file` from setting the key, and the child-only `--require` removes it before user preloads run. An **ambient** `NODE_ENV` is the user's own and passes through untouched, exactly as `NODE_OPTIONS` does today.

Guarded only when the auto cascade is the live family. The explicit `--env-file` map does not drop `NODE_ENV` on the direct path either, and the two families never co-occur, so keying on which is live reproduces each one's direct-runner behavior rather than imposing a new policy on the explicit flag.

The drop is also now explained. Watch loaded the cascade through the report-discarding `load_env_files_raw`, so it changed `NODE_ENV` under the user with nothing to point at, while the docs promise a warning on every surface. Both notices are `Once`-guarded, so a long-lived watcher emits each at most once.

## Verification

Every watch run prints, including the version that used to die. `leak` is whether the `.env`-set `NODE_OPTIONS` reached the child.

| run | `GREETING` | expanded | `NODE_ENV` | leak |
| --- | --- | --- | --- | --- |
| watch v18.19.1 | hello | hello_world | null | false |
| watch v20.10.0 | hello | hello_world | null | false |
| watch v24.14.0 | hello | hello_world | null | false |
| direct v24.14.0 | hello | hello_world | null | false |
| watch, ambient `NODE_ENV=test` | hello | hello_world | test | false |

Gates: `cargo fmt --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean, unit tests pass, and both new integration tests pass on v18.19.1 and v24.14.0.

One pre-existing failure is unrelated to this change: `node_compat_env_forces_vanilla_under_watch` fails identically on `origin/main` with the same Node 24.14.0, in the `NODE_COMPAT=1` branch that returns before any code this PR touches.

## Why it shipped, and the test that stops it recurring

Every watch env-file test skips below Node 20.6, so no CI leg exercised the auto cascade on the compat tier — and CI does run `ubuntu-latest` on Node 18.19. The two new integration tests are deliberately ungated and assert only that the values arrive, not which mechanism delivered them, so they cover both sides of the floor.

Refs #207, #479, #263.
