### PR TITLE
feat(runtime): polyfill Promise.allKeyed / allSettledKeyed (TC39 await dictionary)

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1287,9 +1287,21 @@ try {
 } catch (e) {
   rejected = e.message;
 }
+// Promise.withResolvers: native on Node 22+, polyfilled on the 18.19-21.x compat
+// tier where it was previously missing entirely.
+const wr = Promise.withResolvers();
+wr.resolve("wr-ok");
+const withResolvers =
+  Object.getPrototypeOf(wr) === Object.prototype &&
+  Object.keys(wr).join(",") === "promise,resolve,reject" &&
+  (await wr.promise) === "wr-ok";
 // The additive contract: nub's additions stay invisible to enumeration.
-const hidden = Object.keys(Promise).filter((k) => k.endsWith("Keyed")).length;
-console.log(JSON.stringify({ keyed, scoped, nullProto, statuses, rejected, hidden }));
+const hidden = Object.keys(Promise).filter(
+  (k) => k.endsWith("Keyed") || k === "withResolvers",
+).length;
+console.log(
+  JSON.stringify({ keyed, scoped, nullProto, statuses, rejected, withResolvers, hidden }),
+);
 "#,
     )
     .unwrap();
@@ -1307,7 +1319,7 @@ console.log(JSON.stringify({ keyed, scoped, nullProto, statuses, rejected, hidde
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert_eq!(
         stdout,
-        r#"{"keyed":true,"scoped":true,"nullProto":true,"statuses":"fulfilled/rejected/nope","rejected":"first","hidden":0}"#,
+        r#"{"keyed":true,"scoped":true,"nullProto":true,"statuses":"fulfilled/rejected/nope","rejected":"first","withResolvers":true,"hidden":0}"#,
         "stderr: {stderr}"
     );
 }

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1244,6 +1244,74 @@ console.log(JSON.stringify({ okB64, okUrl, okHex, order: order.join(","), agg, a
     );
 }
 
+#[test]
+fn keyed_promise_combinator_polyfills() {
+    // Promise.allKeyed / Promise.allSettledKeyed (TC39 "await dictionary", Stage 3)
+    // ship in no engine, so this exercises the polyfill on every Node — there is no
+    // native branch to fall through to. Spec fidelity is verified separately by the
+    // differential battery (18.19 through 26.5); this asserts the API is reachable
+    // and correct through nub's real preload chain, on the three semantics a naive
+    // implementation gets wrong: the result object's NULL prototype, own-enumerable
+    // keys INCLUDING symbols, and non-enumerable installation on `Promise`.
+    // Isolated tmpdir + cache for the same hermeticity reasons as
+    // `polyfills_available`.
+    let work = unique_test_cache();
+    std::fs::create_dir_all(&work).unwrap();
+    let test_file = work.join("_keyed_check.mjs");
+    std::fs::write(
+        &test_file,
+        r#"
+const sym = Symbol("s");
+const src = Object.create(
+  { inherited: Promise.resolve("leaked") },
+  {
+    shape: { value: Promise.resolve("square"), enumerable: true },
+    mass: { value: 12, enumerable: true },
+    hidden: { value: Promise.resolve("leaked"), enumerable: false },
+    [sym]: { value: Promise.resolve("sym"), enumerable: true },
+  },
+);
+const dict = await Promise.allKeyed(src);
+const { shape, mass } = dict;
+const keyed = shape === "square" && mass === 12 && dict[sym] === "sym";
+const scoped = !("hidden" in dict) && !("inherited" in dict);
+const nullProto = Object.getPrototypeOf(dict) === null;
+const settled = await Promise.allSettledKeyed({
+  ok: Promise.resolve(1),
+  bad: Promise.reject(new Error("nope")),
+});
+const statuses = settled.ok.status + "/" + settled.bad.status + "/" + settled.bad.reason.message;
+let rejected = "";
+try {
+  await Promise.allKeyed({ a: Promise.reject(new Error("first")), b: Promise.resolve(2) });
+} catch (e) {
+  rejected = e.message;
+}
+// The additive contract: nub's additions stay invisible to enumeration.
+const hidden = Object.keys(Promise).filter((k) => k.endsWith("Keyed")).length;
+console.log(JSON.stringify({ keyed, scoped, nullProto, statuses, rejected, hidden }));
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(nub_binary())
+        .arg(test_file.to_str().unwrap())
+        .current_dir(&work)
+        .env("XDG_CACHE_HOME", unique_test_cache())
+        .output()
+        .expect("failed to spawn nub");
+
+    let _ = std::fs::remove_dir_all(&work);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stdout,
+        r#"{"keyed":true,"scoped":true,"nullProto":true,"statuses":"fulfilled/rejected/nope","rejected":"first","hidden":0}"#,
+        "stderr: {stderr}"
+    );
+}
+
 /// Child processes spawned via `execSync("node ...")` inside a Nub-run
 /// script should inherit Nub's TypeScript augmentation through the PATH
 /// shim — `node` resolves to the shim symlink which points back to `nub`.

--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -494,6 +494,25 @@ static FEATURES: &[Feature] = &[
         ],
         evidence: "native on Node 24+",
     },
+    // ── Promise.withResolvers ───────────────────────────────────────────────
+    // TC39 Stage 4 / ES2024; native on Node 22+, absent on the 18.19–21.x compat
+    // tier. It went unpolyfilled until 2026-07 because the candidates survey
+    // judged it "native on Nub's floor" while the floor was still 22.15; the
+    // verdict was never revisited when the floor moved to 18.19.
+    Feature {
+        name: "Promise.withResolvers",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((22, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "Promise.withResolvers",
+                },
+            ),
+            (band((22, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "TC39 Stage 4 / ES2024; native on Node 22.0+ (V8 12.4)",
+    },
     // ── Promise.allKeyed / Promise.allSettledKeyed ──────────────────────────
     // TC39 "await dictionary", Stage 3. Shipped by NO engine, so unlike the rows
     // above there is no Native band to fall through to — the whole supported range

--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -494,6 +494,33 @@ static FEATURES: &[Feature] = &[
         ],
         evidence: "native on Node 24+",
     },
+    // ── Promise.allKeyed / Promise.allSettledKeyed ──────────────────────────
+    // TC39 "await dictionary", Stage 3. Shipped by NO engine, so unlike the rows
+    // above there is no Native band to fall through to — the whole supported range
+    // is polyfilled, the same shape as reportError. The runtime feature-detect is
+    // what steps aside once V8 lands it, so this row needs no revision then.
+    Feature {
+        name: "Promise.allKeyed",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Polyfill {
+                runtime_file: "polyfills.cjs",
+                global: "Promise.allKeyed",
+            },
+        )],
+        evidence: "TC39 Stage 3 (proposal-await-dictionary); absent on every Node through 26.5",
+    },
+    Feature {
+        name: "Promise.allSettledKeyed",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Polyfill {
+                runtime_file: "polyfills.cjs",
+                global: "Promise.allSettledKeyed",
+            },
+        )],
+        evidence: "TC39 Stage 3 (proposal-await-dictionary); absent on every Node through 26.5",
+    },
     // ── Float16Array ────────────────────────────────────────────────────────
     // TC39 Stage 4; native on Node 24+, absent on the 22.x floor, polyfilled from
     // the vendored `@petamoriken/float16` package. See

--- a/npm/nub-types/index.d.ts
+++ b/npm/nub-types/index.d.ts
@@ -164,6 +164,21 @@ interface ImportMeta {
   };
 }
 
+// ── Promise.allKeyed / Promise.allSettledKeyed (TC39 "await dictionary", Stage 3;
+//    runtime/polyfills.cjs) ──
+// In no engine, in no @types/node, in no TypeScript lib. The mapped types mirror
+// the proposal README's own signatures: the key set is preserved and each value is
+// `Awaited`. Two runtime facts TypeScript cannot express — the result object has a
+// null prototype, and its keys are the argument's own ENUMERABLE keys (so a
+// non-enumerable or inherited property is absent at runtime while `keyof` still
+// includes it). Neither affects the destructuring this API exists for.
+interface PromiseConstructor {
+  allKeyed<T extends object>(promises: T): Promise<{ -readonly [K in keyof T]: Awaited<T[K]> }>;
+  allSettledKeyed<T extends object>(
+    promises: T,
+  ): Promise<{ -readonly [K in keyof T]: PromiseSettledResult<Awaited<T[K]>> }>;
+}
+
 // ── Date.prototype.toTemporalInstant (runtime/preload-common.cjs installs it) ──
 // Nub assigns the polyfill's `toTemporalInstant` onto Date.prototype on the floor
 // (matching native Node, which ships it once Temporal is native).

--- a/npm/nub-types/test/fixtures/positive/index.ts
+++ b/npm/nub-types/test/fixtures/positive/index.ts
@@ -41,6 +41,21 @@ void inlineWorker;
 // reportError (WinterTC global; not in @types/node).
 reportError(new Error("boom"));
 
+// Promise.allKeyed / Promise.allSettledKeyed (TC39 await dictionary). The result
+// properties are pinned to concrete types so a mapped-type regression — losing
+// `Awaited`, or widening a value to `any` — fails this fixture instead of
+// silently typechecking.
+const dict = await Promise.allKeyed({ shape: Promise.resolve("square"), mass: 12 });
+const dictShape: string = dict.shape;
+const dictMass: number = dict.mass;
+void dictShape;
+void dictMass;
+const settledDict = await Promise.allSettledKeyed({ ok: Promise.resolve(1) });
+if (settledDict.ok.status === "fulfilled") {
+  const okValue: number = settledDict.ok.value;
+  void okValue;
+}
+
 // Temporal namespace (inlined from @js-temporal/polyfill).
 const instant: Temporal.Instant = Temporal.Now.instant();
 const duration: Temporal.Duration = Temporal.Duration.from({ hours: 2, minutes: 30 });

--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -11,11 +11,17 @@
 //
 // All polyfills feature-detect and bow out if the global is already present.
 //
-// Node 22.15+ (our floor) already has: navigator, navigator.locks,
-// navigator.hardwareConcurrency, WebSocket. No polyfills needed.
+// nub's SUPPORT floor is Node 18.19; 22.15 is the FAST-TIER boundary, NOT the
+// floor. Judging "do we need a polyfill?" against 22.15 silently skips the
+// 18.19–21.x compat tier — which is how Promise.withResolvers (native since Node
+// 22.0) went unpolyfilled here until 2026-07, on a "native on our floor" verdict
+// that was written when the floor really was 22.15.
 //
-// Node 24+ adds: URLPattern, RegExp.escape, Error.isError, Promise.try.
-// We polyfill those on Node 22.x only.
+// Node 22.15+ already has: navigator, navigator.locks,
+// navigator.hardwareConcurrency, WebSocket.
+//
+// Node 22+ adds: Promise.withResolvers. Node 24+ adds: URLPattern,
+// RegExp.escape, Error.isError, Promise.try. Each is polyfilled below its line.
 //
 // No Node version ships: Temporal, reportError, browser-shape Worker,
 // Promise.allKeyed / Promise.allSettledKeyed.
@@ -268,6 +274,7 @@ function installSyncPolyfills(preloaded) {
   installUint8ArrayBase64();
   installDisposableStacks();
   installKeyedPromiseCombinators();
+  installPromiseWithResolvers();
 }
 
 // ── Uint8Array base64/hex (TC39 Stage 3; native Node 25+, absent below) ──
@@ -823,27 +830,49 @@ function installDisposableStacks() {
 //
 // Both are installed non-enumerable to match how the engine will define them
 // (and this file's additive contract: invisible to enumeration).
+// NewPromiseCapability(C), shared by the keyed combinators and withResolvers.
+// Every caller reaches it through a spec step marked `?`, so a non-constructor
+// `this` throws SYNCHRONOUSLY — there is no promise yet to reject.
+function newPromiseCapability(C, name) {
+  if (typeof C !== "function") {
+    throw new TypeError(`Promise.${name} called on a non-constructor`);
+  }
+  let resolve;
+  let reject;
+  const promise = new C((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  if (typeof resolve !== "function" || typeof reject !== "function") {
+    throw new TypeError("promise capability functions are not callable");
+  }
+  return { promise, resolve, reject };
+}
+
+// ── Promise.withResolvers (TC39 Stage 4 / ES2024; native on Node 22+) ──
+// Absent on the whole 18.19–21.x compat tier with no polyfill until now. The
+// 2026-05 candidates survey marked it "No action — native on Nub's floor", which
+// was true when the floor WAS 22.15; the verdict was never revisited after the
+// floor moved down to 18.19, so the gap survived silently. Spec: a capability
+// plus a %Object.prototype% record of {promise, resolve, reject}, generic on
+// `this` so a Promise subclass drives the promise.
+function installPromiseWithResolvers() {
+  if (typeof Promise.withResolvers === "function") return;
+  Object.defineProperty(Promise, "withResolvers", {
+    value: function withResolvers() {
+      const { promise, resolve, reject } = newPromiseCapability(this, "withResolvers");
+      return { promise, resolve, reject };
+    },
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
 function installKeyedPromiseCombinators() {
   const needAll = typeof Promise.allKeyed !== "function";
   const needAllSettled = typeof Promise.allSettledKeyed !== "function";
   if (!needAll && !needAllSettled) return;
-
-  // NewPromiseCapability(C).
-  const newCapability = (C, name) => {
-    if (typeof C !== "function") {
-      throw new TypeError(`Promise.${name} called on a non-constructor`);
-    }
-    let resolve;
-    let reject;
-    const promise = new C((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
-    if (typeof resolve !== "function" || typeof reject !== "function") {
-      throw new TypeError("promise capability functions are not callable");
-    }
-    return { promise, resolve, reject };
-  };
 
   // CreateKeyedPromiseCombinatorResultObject. Plain assignment IS
   // CreateDataPropertyOrThrow here: with no prototype there is no inherited
@@ -893,7 +922,7 @@ function installKeyedPromiseCombinators() {
   const install = (name, isSettled) => {
     const fn = function (promises) {
       const ctor = this;
-      const capability = newCapability(ctor, name);
+      const capability = newPromiseCapability(ctor, name);
       try {
         const promiseResolve = ctor.resolve;
         if (typeof promiseResolve !== "function") {

--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -17,7 +17,8 @@
 // Node 24+ adds: URLPattern, RegExp.escape, Error.isError, Promise.try.
 // We polyfill those on Node 22.x only.
 //
-// No Node version ships: Temporal, reportError, browser-shape Worker.
+// No Node version ships: Temporal, reportError, browser-shape Worker,
+// Promise.allKeyed / Promise.allSettledKeyed.
 // These need polyfills on all supported versions. (Temporal is a lazy global
 // installed by the preload entry, NOT here — see preload.cjs / preload.mjs.)
 
@@ -266,6 +267,7 @@ function installSyncPolyfills(preloaded) {
 
   installUint8ArrayBase64();
   installDisposableStacks();
+  installKeyedPromiseCombinators();
 }
 
 // ── Uint8Array base64/hex (TC39 Stage 3; native Node 25+, absent below) ──
@@ -797,6 +799,131 @@ function installDisposableStacks() {
     });
     defGlobal("AsyncDisposableStack", AsyncDisposableStack);
   }
+}
+
+// ── Promise.allKeyed / Promise.allSettledKeyed (TC39 "await dictionary",
+//    Stage 3) ──
+// Spec-faithful port of PerformPromiseAllKeyed. No engine and no Node ships
+// these yet, so unlike the rest of this file the feature-detect is not a version
+// gate — it is the step-aside for whenever V8 does, the same posture as Temporal.
+// Four observable details are load-bearing and easy to get wrong:
+//
+//   1. The result object has a NULL prototype (OrdinaryObjectCreate(null)), so
+//      `result.hasOwnProperty` is undefined and util.inspect prints it as
+//      `[Object: null prototype]`. Destructuring — the entire point of the API —
+//      is unaffected.
+//   2. Keys are the argument's own ENUMERABLE keys in [[OwnPropertyKeys]] order,
+//      symbols INCLUDED. That is the proposal's deliberate divergence from the
+//      userland precedents it replaces (bluebird's Promise.props, p-props), which
+//      follow Object.keys and silently drop symbol keys.
+//   3. A non-object argument and a non-callable `this.resolve` REJECT the
+//      returned promise; only a `this` that isn't a constructor throws
+//      synchronously (spec step 2's `?` vs steps 3 and 5).
+//   4. `this` is the constructor, so a Promise subclass drives the result.
+//
+// Both are installed non-enumerable to match how the engine will define them
+// (and this file's additive contract: invisible to enumeration).
+function installKeyedPromiseCombinators() {
+  const needAll = typeof Promise.allKeyed !== "function";
+  const needAllSettled = typeof Promise.allSettledKeyed !== "function";
+  if (!needAll && !needAllSettled) return;
+
+  // NewPromiseCapability(C).
+  const newCapability = (C, name) => {
+    if (typeof C !== "function") {
+      throw new TypeError(`Promise.${name} called on a non-constructor`);
+    }
+    let resolve;
+    let reject;
+    const promise = new C((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    if (typeof resolve !== "function" || typeof reject !== "function") {
+      throw new TypeError("promise capability functions are not callable");
+    }
+    return { promise, resolve, reject };
+  };
+
+  // CreateKeyedPromiseCombinatorResultObject. Plain assignment IS
+  // CreateDataPropertyOrThrow here: with no prototype there is no inherited
+  // setter to intercept (not even `__proto__`), and the keys came from
+  // [[OwnPropertyKeys]] so they are already distinct.
+  const resultObject = (entries) => {
+    const obj = Object.create(null);
+    for (let i = 0; i < entries.length; i++) obj[entries[i].key] = entries[i].value;
+    return obj;
+  };
+
+  // PerformPromiseAllKeyed. `remaining` starts at 1 and is decremented only once
+  // the loop is done, so a dictionary of already-settled promises cannot resolve
+  // the combinator before every key has been visited.
+  const perform = (isSettled, promises, ctor, capability, promiseResolve) => {
+    const entries = [];
+    const remaining = { value: 1 };
+    for (const key of Reflect.ownKeys(promises)) {
+      const desc = Reflect.getOwnPropertyDescriptor(promises, key);
+      if (desc === undefined || !desc.enumerable) continue;
+      const value = promises[key];
+      const index = entries.push({ key, value: undefined }) - 1;
+      const nextPromise = promiseResolve.call(ctor, value);
+      const alreadyCalled = { value: false };
+      const settle = (entryValue) => {
+        if (alreadyCalled.value) return;
+        alreadyCalled.value = true;
+        entries[index].value = entryValue;
+        remaining.value -= 1;
+        if (remaining.value === 0) capability.resolve(resultObject(entries));
+      };
+      remaining.value += 1;
+      // allKeyed: the first rejection rejects the whole combinator through the
+      // capability's own reject function. allSettledKeyed: the rejection is
+      // recorded, and its handler SHARES `alreadyCalled` with the fulfill
+      // handler, so exactly one of the pair counts even for a thenable that
+      // calls both.
+      nextPromise.then(
+        isSettled ? (v) => settle({ status: "fulfilled", value: v }) : settle,
+        isSettled ? (reason) => settle({ status: "rejected", reason }) : capability.reject,
+      );
+    }
+    remaining.value -= 1;
+    if (remaining.value === 0) capability.resolve(resultObject(entries));
+  };
+
+  const install = (name, isSettled) => {
+    const fn = function (promises) {
+      const ctor = this;
+      const capability = newCapability(ctor, name);
+      try {
+        const promiseResolve = ctor.resolve;
+        if (typeof promiseResolve !== "function") {
+          throw new TypeError("Promise resolve is not a function");
+        }
+        if (
+          promises === null ||
+          (typeof promises !== "object" && typeof promises !== "function")
+        ) {
+          throw new TypeError(`Promise.${name} argument must be an object`);
+        }
+        perform(isSettled, promises, ctor, capability, promiseResolve);
+      } catch (err) {
+        capability.reject(err);
+      }
+      return capability.promise;
+    };
+    // A builtin's `name` and `length` are observable; the anonymous function
+    // expression above gives length 1 but an empty name.
+    Object.defineProperty(fn, "name", { value: name, configurable: true });
+    Object.defineProperty(Promise, name, {
+      value: fn,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  };
+
+  if (needAll) install("allKeyed", false);
+  if (needAllSettled) install("allSettledKeyed", true);
 }
 
 // Load the two ESM side-effect modules — Web Locks (navigator.locks) and the

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -78,6 +78,7 @@ const route = new URLPattern({ pathname: "/u/:id" });
 const ws = new WebSocket("wss://api.example.com");
 const stream = new EventSource("https://api/stream");
 const { DatabaseSync } = require("node:sqlite");
+const { me, feed } = await Promise.allKeyed({ me: getMe(), feed: getFeed() });
 ```
 
 Two mechanisms do the work, picked per API: Nub either preloads a JS polyfill (feature-detected, so it steps aside the moment the native global appears) or injects the `--experimental-*` flag that an older Node hides the API behind. Once Node stabilizes an API, it's native and Nub does nothing.
@@ -91,6 +92,8 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`RegExp.escape`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape) | — | polyfilled below Node 24, native above |
 | [`Error.isError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError) | — | polyfilled below Node 24, native above |
 | [`Promise.try`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try) | — | polyfilled below Node 24, native above |
+| [`Promise.allKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
+| [`Promise.allSettledKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
 | [`Float16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array) | — | polyfilled below Node 24, native above |
 | [`navigator`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator) | — | backfilled below Node 21, native above |
 | [`navigator.locks`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) | — | polyfilled below Node 24.5, native above |

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -92,6 +92,7 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`RegExp.escape`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape) | — | polyfilled below Node 24, native above |
 | [`Error.isError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError) | — | polyfilled below Node 24, native above |
 | [`Promise.try`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try) | — | polyfilled below Node 24, native above |
+| [`Promise.withResolvers`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers) | — | polyfilled below Node 22, native above |
 | [`Promise.allKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
 | [`Promise.allSettledKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
 | [`Float16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array) | — | polyfilled below Node 24, native above |

--- a/tests/fixtures/worker/unhandled-error-fatal-main.ts
+++ b/tests/fixtures/worker/unhandled-error-fatal-main.ts
@@ -10,7 +10,18 @@ const w = new Worker(new URL("./does-not-exist.mjs", import.meta.url), {
 
 // If the error is swallowed, the underlying worker still emits `exit`. Use that
 // event as the failure oracle so a slow worker load cannot race a fixed deadline.
+//
+// The oracle must not fire in the same turn as `exit`, though: the fatality is a
+// deliberately-DEFERRED `process.nextTick` throw (worker-polyfill.mjs re-throws on
+// a fresh tick so a user `uncaughtException` handler still sees it), and
+// `process.exit` does NOT drain the tick queue. Whenever `exit` is delivered before
+// that queue drains, exiting 0 here reports a false swallow — which is what made
+// this test flake on CI. `setImmediate` is ordered strictly after the nextTick
+// queue by the event-loop contract, so a scheduled fatality always wins, while a
+// genuinely swallowed error still reaches the oracle and fails the test.
 w.once("exit", () => {
-  console.log("swallowed-and-survived");
-  process.exit(0);
+  setImmediate(() => {
+    console.log("swallowed-and-survived");
+    process.exit(0);
+  });
 });


### PR DESCRIPTION
Adds `Promise.allKeyed` / `Promise.allSettledKeyed` — TC39 [await dictionary](https://github.com/tc39/proposal-await-dictionary), Stage 3 as of the week of 2026-07-20 — as a spec-faithful polyfill in `runtime/polyfills.cjs`. No engine and no Node ships them, so the whole supported range is polyfilled and the feature-detect is the step-aside for whenever V8 lands it, the same posture as Temporal.

```js
const { me, feed } = await Promise.allKeyed({ me: getMe(), feed: getFeed() });
```

Ported deliberately, since each is observable and easy to get wrong: the result object's null prototype, own-enumerable keys including symbols (the proposal's divergence from `combine-promises` / `p-props`, which follow `Object.keys`), reject-vs-sync-throw on a bad argument or `this`, and subclass support through `this`.

Verified by a 69-assertion battery derived from the spec text, green on 18.19.0 / 20.19.0 / 22.14.0 / 22.15.0 / 24.17.0 / 25.9.0 / 26.5.0. Three controls make that meaningful: `typeof Promise.allKeyed` is `undefined` on every version before install, so nothing passes against a native implementation; the battery dies on the first call with the installer removed; and a pre-installed sentinel survives untouched. The `@nubjs/types` declarations carry their own control confirming the mapped type infers concrete properties rather than widening to `any`.

Also lands feature-matrix rows for both globals, the `@nubjs/types` declaration plus positive fixture, the docs Modern APIs table row, and an integration test through the real preload chain.

---

Second commit is **unrelated to the polyfill** — `worker_unhandled_error_is_fatal` failed once on the ubuntu node-24 leg (every other leg green), and it is racy by construction: the fatality is a deferred `process.nextTick` throw, while the fixture's swallow oracle calls `process.exit(0)` straight out of the worker's `exit` event, and `process.exit` does not drain the tick queue. Moving the oracle into `setImmediate` makes the ordering fixed. Positive control: with the `nextTick` throw neutered the hardened fixture still reports the swallow and fails 10/10, so the test keeps its teeth.

---

Third commit adds **`Promise.withResolvers`** (Stage 4 / ES2024, native from Node 22.0), which was absent with no polyfill across the whole 18.19–21.x compat tier. The gap existed because `wiki/research/v0.1-additional-candidates.md` marked it "No action — native on Nub's floor" back when the floor was 22.15; the floor later moved to 18.19 and the verdict was never revisited. Three sibling rows rest on the same premise and are also absent on 18.19–21.x — `Array.fromAsync`, the seven Set methods, and `URL.parse` — left open here rather than bundled, with the survey and its changelog corrected so the premise stops misleading.

Bands were measured empirically across eight Node versions rather than read off release notes, which is also how the 21.x hole in `URL.parse` surfaced. The 15-assertion battery doubles as a differential oracle: it reports whether the method was native before installing, so on Node 22+ it passes against the **engine's** implementation, pinning the polyfill's observable shape to native.
