### PR TITLE
fix(resolver): enforce minimumReleaseAge without the full-packument cache

### DIFF
--- a/vendor/aube/crates/aube-registry/src/client/packument.rs
+++ b/vendor/aube/crates/aube-registry/src/client/packument.rs
@@ -349,6 +349,22 @@ impl RegistryClient {
         Ok(packument)
     }
 
+    /// Fetch the full (non-corgi) packument fresh — no disk cache — and
+    /// parse it into [`Packument`], `time` map included. The uncached
+    /// sibling of [`Self::fetch_packument_with_time_cached`], for callers
+    /// that need publish times (`minimumReleaseAge`, time-based mode,
+    /// `trustPolicy=no-downgrade`) while deliberately running without the
+    /// full-packument disk cache (`aube update`'s dist-tag freshness
+    /// rule). Falling back to [`Self::fetch_packument`] there instead
+    /// returns the abbreviated corgi document, whose missing `time` map
+    /// silently disables the age gate at the pick site.
+    pub async fn fetch_packument_with_time(&self, name: &str) -> Result<Packument, Error> {
+        let value = self.fetch_packument_json_fresh(name).await?;
+        let packument: Packument = serde_json::from_value(value)
+            .map_err(|e| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))?;
+        Ok(packument)
+    }
+
     pub async fn fetch_packument_with_time_cached_after_lookup(
         &self,
         name: &str,

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -854,7 +854,12 @@ impl<'a> ResolveDriver<'a> {
                                 .fetch_packument_with_time_cached(&registry_name, dir)
                                 .await
                         }
-                        None => self.resolver.client.fetch_packument(&registry_name).await,
+                        None => {
+                            self.resolver
+                                .client
+                                .fetch_packument_with_time(&registry_name)
+                                .await
+                        }
                     }
                     .map_err(|e| Error::Registry(registry_name.clone(), e.to_string()))?;
                     self.packument_fetch_time += fetch_start.elapsed();
@@ -930,7 +935,12 @@ impl<'a> ResolveDriver<'a> {
                                     .fetch_packument_with_time_cached(&registry_name, dir)
                                     .await
                             }
-                            None => self.resolver.client.fetch_packument(&registry_name).await,
+                            None => {
+                                self.resolver
+                                    .client
+                                    .fetch_packument_with_time(&registry_name)
+                                    .await
+                            }
                         }
                     } else {
                         match self.resolver.client.fetch_packument(&registry_name).await {
@@ -965,7 +975,12 @@ impl<'a> ResolveDriver<'a> {
                                     .fetch_packument_with_time_cached(&registry_name, dir)
                                     .await
                             }
-                            None => self.resolver.client.fetch_packument(&registry_name).await,
+                            None => {
+                                self.resolver
+                                    .client
+                                    .fetch_packument_with_time(&registry_name)
+                                    .await
+                            }
                         }
                     } else {
                         match self.resolver.client.fetch_packument(&registry_name).await {

--- a/vendor/aube/crates/aube-resolver/src/resolve/fetch.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/fetch.rs
@@ -261,7 +261,12 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
                     .fetch_packument_with_time_cached_after_lookup(&name, dir, cached)
                     .await
             }
-            None => client.fetch_packument(&name).await,
+            // No full-packument disk cache (update's dist-tag freshness
+            // rule) still needs the `time` map: the corgi fallback here
+            // silently disabled the `minimumReleaseAge` gate, because a
+            // version with no publish time bypasses the cutoff at the
+            // pick site.
+            None => client.fetch_packument_with_time(&name).await,
         }
     } else if let Some(ref dir) = cache_dir {
         client

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -1452,6 +1452,112 @@ async fn highest_mode_with_minimum_release_age_keeps_in_memory_times() {
     let _ = std::fs::remove_dir_all(base);
 }
 
+/// Regression: `minimumReleaseAge` must hold when the resolver runs
+/// WITHOUT the full-packument disk cache — the `aube update` / `add` /
+/// `dedupe` / `audit` configuration (`cache_full_packuments: false`,
+/// their dist-tag freshness rule). Against a registry whose abbreviated
+/// (corgi) document omits the `time` map — npmjs does — the uncached
+/// `needs_time` fallback used to fetch that corgi document, and a
+/// version with no publish time bypasses the age cutoff at the pick
+/// site: `aube update` crossed the gate onto a fresh publish that
+/// `aube install` (full cache on) had just refused, then rewrote
+/// `package.json` onto it. The fix fetches the full document (time
+/// included) when the full cache dir is absent. This test mocks
+/// npmjs's Accept-dependent shape and pins the gated pick.
+#[tokio::test]
+async fn minimum_release_age_holds_without_full_packument_cache() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // 1.0.0 is years old; 1.1.0 was "published" moments ago.
+    let now_iso = crate::types::format_iso8601_utc(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    );
+    let mut full = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    full.modified = Some(now_iso.clone());
+    full.time
+        .insert("1.0.0".to_string(), "2024-01-01T00:00:00.000Z".to_string());
+    full.time.insert("1.1.0".to_string(), now_iso);
+    // npmjs's corgi document: same versions, NO time map.
+    let mut corgi = full.clone();
+    corgi.time.clear();
+    corgi.modified = None;
+    let full_body = serde_json::to_vec(&full).unwrap();
+    let corgi_body = serde_json::to_vec(&corgi).unwrap();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            let full_body = full_body.clone();
+            let corgi_body = corgi_body.clone();
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 4096];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                // npmjs serves the abbreviated (time-less) document when
+                // the request prefers `application/vnd.npm.install-v1+json`.
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let body = if request.contains("install-v1") {
+                    corgi_body
+                } else {
+                    full_body
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+                socket.write_all(&body).await.unwrap();
+            });
+        }
+    });
+
+    let base = std::env::temp_dir().join(format!(
+        "aube-resolver-mra-nofullcache-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let cache_dir = base.join("packuments");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    // Abbreviated cache only — deliberately NO `with_packument_full_cache`,
+    // matching `build_resolver`'s `cache_full_packuments: false` posture.
+    let mut resolver = Resolver::new(client)
+        .with_packument_cache(cache_dir)
+        .with_minimum_release_age(Some(MinimumReleaseAge {
+            minutes: 1440,
+            ..Default::default()
+        }));
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("foo".to_string(), "^1.0.0".to_string());
+
+    let graph = resolver.resolve(&manifest, None).await.unwrap();
+
+    assert!(
+        graph_has_package(&graph, "foo", "1.0.0"),
+        "the mature 1.0.0 must be picked; graph: {:?}",
+        graph.packages.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !graph_has_package(&graph, "foo", "1.1.0"),
+        "the fresh 1.1.0 must stay behind the minimumReleaseAge cutoff \
+         even without the full-packument cache"
+    );
+    server.abort();
+    let _ = std::fs::remove_dir_all(base);
+}
+
 /// Regression: a primer-seeded pick that satisfies the range must still
 /// record the package's publish time when `minimumReleaseAge` is active.
 /// The bundled primer's `time` data is sparse, so a primer hit could


### PR DESCRIPTION
## Problem

`nub update` crosses `minimumReleaseAge` onto publishes minutes old — versions that `nub install` (correctly) refuses — and rewrites `package.json` onto them. Nub's own strict 1440-minute default is silently disabled on the whole update path; the same hole covers `add`/`dedupe`/`audit` via `build_resolver`.

Live repro (while `@types/node@26.1.2` was ~20h old):

```
$ nub install          # range ^26.1.1
+ @types/node@26.1.1  latest 26.1.2     # gate holds
$ nub update
+ @types/node@26.1.2                     # gate gone; manifest rewritten to ^26.1.2
```

The resulting lockfile is then rejected by pnpm 11 (`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`) in pnpm-compat projects, which is how this was found.

## Root cause

`update`/`add`/`dedupe`/`audit` deliberately resolve without the full-packument disk cache (`cache_full_packuments: false` — the dist-tag freshness rule). When `needs_time` is on and that cache dir is `None`, the initial fetch (`fetch.rs`) and all three pick-site heal arms (`driver.rs`) fall back to `client.fetch_packument()` — the **abbreviated corgi document, which npmjs serves without a `time` map**. A version with no publish time bypasses the cutoff inside `pick_version`, so the gate self-destructs exactly on the paths that rewrite manifests.

Instrumented pick-site trace, same project, same cutoff:

```
install: PICK @types/node ^26.1.1 cutoff=… strict=true time_len=2357 -> Found 26.1.1
update:  PICK @types/node ^26.1.1 cutoff=… strict=true time_len=100  -> Found 26.1.1   (primer)
         PICK @types/node ^26.1.1 cutoff=… strict=true time_len=0    -> Found 26.1.2   (post-refetch corgi)
```

## Fix

Add `RegistryClient::fetch_packument_with_time` — the uncached sibling of `fetch_packument_with_time_cached` (full Accept header via `fetch_packument_json_fresh`, `time` included, no disk cache, so the dist-tag freshness property is preserved) — and use it in all four `needs_time` fallbacks.

## Test

The regression test mocks npmjs's Accept-dependent shape (corgi without `time`, full document with it) and resolves with `minimumReleaseAge` active but no full cache configured — red before the fix (picks the immature version), green after.

A Verdaccio bats test can't catch this: Verdaccio serves the `time` map even for the corgi Accept header, unlike npmjs, so the unit test pins the registry shape explicitly.

Verified end-to-end against npmjs: `nub update` now stays on the mature version ("Already up to date") and leaves the manifest untouched.

Related design question (independent of this fix): #581 — whether strict mode should fail closed on missing time data at the pick site.