### PR TITLE
fix(manifest): preserve package.json indent, line endings, and EOF newline

### DIFF
--- a/vendor/aube/crates/aube-manifest/src/lib.rs
+++ b/vendor/aube/crates/aube-manifest/src/lib.rs
@@ -1590,6 +1590,62 @@ pub fn serialize_json_with_indent<T: serde::Serialize>(
         .map_err(|e| serde_json::Error::io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))
 }
 
+/// The surface style of an existing JSON manifest: indent unit, line-ending
+/// flavor, and trailing-newline state. Reproducing all three keeps an
+/// `update`/`add`/settings edit diffing as the changed keys rather than as a
+/// whole-file reformat. Deliberately the UNION of what the reference PMs
+/// preserve, since each drops one: npm reproduces the indent and line ending
+/// but always appends a final newline, pnpm reproduces the indent and the
+/// trailing-newline state but never CRLF.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonStyle {
+    pub indent: String,
+    pub crlf: bool,
+    pub trailing_newline: bool,
+}
+
+impl Default for JsonStyle {
+    /// The style used when there is no original to imitate (a manifest created
+    /// from scratch): two-space indent, LF, trailing newline.
+    fn default() -> Self {
+        JsonStyle {
+            indent: "  ".to_string(),
+            crlf: false,
+            trailing_newline: true,
+        }
+    }
+}
+
+/// Detect the [`JsonStyle`] of an existing JSON document. Indent detection is
+/// [`detect_json_indent`]; a raw `\r\n` can only be a line terminator (JSON
+/// escapes a carriage return inside a string), so its presence marks the file
+/// CRLF.
+pub fn detect_json_style(raw: &str) -> JsonStyle {
+    JsonStyle {
+        indent: detect_json_indent(raw).to_string(),
+        crlf: raw.contains("\r\n"),
+        trailing_newline: raw.ends_with('\n'),
+    }
+}
+
+/// Serialize `value` as pretty JSON in `style`: [`serialize_json_with_indent`]
+/// for the body, then the source's line ending and trailing-newline state.
+pub fn serialize_json_with_style<T: serde::Serialize>(
+    value: &T,
+    style: &JsonStyle,
+) -> Result<String, serde_json::Error> {
+    let mut out = serialize_json_with_indent(value, &style.indent)?;
+    if style.crlf {
+        // The serialized body carries no `\r` of its own, so the replace is
+        // exact.
+        out = out.replace('\n', "\r\n");
+    }
+    if style.trailing_newline {
+        out.push_str(if style.crlf { "\r\n" } else { "\n" });
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1630,6 +1686,31 @@ mod tests {
             serialize_json_with_indent(&val, "\t").unwrap(),
             "{\n\t\"name\": \"foo\",\n\t\"version\": \"1.0.0\"\n}"
         );
+    }
+
+    #[test]
+    fn detect_json_style_reads_line_endings_and_trailing_newline() {
+        let style = detect_json_style("{\r\n    \"name\": \"x\"\r\n}");
+        assert_eq!(style.indent, "    ");
+        assert!(style.crlf);
+        assert!(!style.trailing_newline);
+
+        // Nothing to imitate — no indented line, LF, ends with a newline.
+        assert_eq!(detect_json_style("{}\n"), JsonStyle::default());
+    }
+
+    #[test]
+    fn serialize_json_with_style_round_trips_the_source_shape() {
+        let original =
+            "{\r\n\t\"name\": \"x\",\r\n\t\"dependencies\": {\r\n\t\t\"a\": \"^1.0.0\"\r\n\t}\r\n}";
+        let value: serde_json::Value = serde_json::from_str(original).unwrap();
+        let rewritten = serialize_json_with_style(&value, &detect_json_style(original)).unwrap();
+        assert_eq!(rewritten, original);
+
+        // A CRLF source's *trailing* newline is `\r\n` too.
+        let with_eof = format!("{original}\r\n");
+        let rewritten = serialize_json_with_style(&value, &detect_json_style(&with_eof)).unwrap();
+        assert_eq!(rewritten, with_eof);
     }
 
     fn parse(json: &str) -> PackageJson {

--- a/vendor/aube/crates/aube-manifest/src/workspace/edits.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace/edits.rs
@@ -40,7 +40,7 @@ pub fn remove_setting_entry(cwd: &Path, key: &str, entry_key: &str) -> Result<bo
         return Ok(false);
     }
     let raw = std::fs::read_to_string(&path).map_err(|e| crate::Error::Io(path.clone(), e))?;
-    let indent = crate::detect_json_indent(&raw).to_string();
+    let style = crate::detect_json_style(&raw);
     let mut value = crate::parse_json::<serde_json::Value>(&path, raw)?;
     let obj = value.as_object_mut().ok_or_else(|| {
         crate::Error::YamlParse(path.clone(), "package.json is not an object".to_string())
@@ -70,9 +70,8 @@ pub fn remove_setting_entry(cwd: &Path, key: &str, entry_key: &str) -> Result<bo
         return Ok(existed);
     }
 
-    let mut out = crate::serialize_json_with_indent(&value, &indent)
+    let out = crate::serialize_json_with_style(&value, &style)
         .map_err(|e| crate::Error::YamlParse(path.clone(), format!("failed to serialize: {e}")))?;
-    out.push('\n');
     std::fs::write(&path, out).map_err(|e| crate::Error::Io(path, e))?;
     Ok(existed)
 }
@@ -103,7 +102,7 @@ where
 {
     let path = cwd.join("package.json");
     let raw = std::fs::read_to_string(&path).map_err(|e| crate::Error::Io(path.clone(), e))?;
-    let indent = crate::detect_json_indent(&raw).to_string();
+    let style = crate::detect_json_style(&raw);
     let mut value = crate::parse_json::<serde_json::Value>(&path, raw)?;
 
     let obj = value.as_object_mut().ok_or_else(|| {
@@ -228,9 +227,8 @@ where
         return Ok(());
     }
 
-    let mut out = crate::serialize_json_with_indent(&value, &indent)
+    let out = crate::serialize_json_with_style(&value, &style)
         .map_err(|e| crate::Error::YamlParse(path.clone(), format!("failed to serialize: {e}")))?;
-    out.push('\n');
     std::fs::write(&path, out).map_err(|e| crate::Error::Io(path, e))?;
     Ok(())
 }
@@ -274,6 +272,7 @@ pub fn add_to_pnpm_only_built_dependencies(
 
     let path = cwd.join("package.json");
     let raw = std::fs::read_to_string(&path).map_err(|e| crate::Error::Io(path.clone(), e))?;
+    let style = crate::detect_json_style(&raw);
     let mut value = crate::parse_json::<serde_json::Value>(&path, raw)?;
     let obj = value.as_object_mut().ok_or_else(|| {
         crate::Error::YamlParse(path.clone(), "package.json is not an object".to_string())
@@ -305,9 +304,8 @@ pub fn add_to_pnpm_only_built_dependencies(
     if *obj == before {
         return Ok(());
     }
-    let mut out = serde_json::to_string_pretty(&value)
+    let out = crate::serialize_json_with_style(&value, &style)
         .map_err(|e| crate::Error::YamlParse(path.clone(), format!("failed to serialize: {e}")))?;
-    out.push('\n');
     std::fs::write(&path, out).map_err(|e| crate::Error::Io(path, e))?;
     Ok(())
 }
@@ -339,6 +337,7 @@ pub fn set_pnpm_allow_builds_entries(
 
     let path = cwd.join("package.json");
     let raw = std::fs::read_to_string(&path).map_err(|e| crate::Error::Io(path.clone(), e))?;
+    let style = crate::detect_json_style(&raw);
     let mut json = crate::parse_json::<serde_json::Value>(&path, raw)?;
     let obj = json.as_object_mut().ok_or_else(|| {
         crate::Error::YamlParse(path.clone(), "package.json is not an object".to_string())
@@ -364,9 +363,8 @@ pub fn set_pnpm_allow_builds_entries(
     if *obj == before {
         return Ok(());
     }
-    let mut out = serde_json::to_string_pretty(&json)
+    let out = crate::serialize_json_with_style(&json, &style)
         .map_err(|e| crate::Error::YamlParse(path.clone(), format!("failed to serialize: {e}")))?;
-    out.push('\n');
     std::fs::write(&path, out).map_err(|e| crate::Error::Io(path, e))?;
     Ok(())
 }
@@ -691,5 +689,33 @@ mod tests {
         );
         // The non-chosen `aube` namespace is scrubbed of `allowBuilds`.
         assert!(obj.get("aube").and_then(|a| a.get("allowBuilds")).is_none());
+    }
+
+    /// A settings edit reproduces the manifest's own surface style, so it
+    /// diffs as the changed keys rather than as a CRLF→LF whole-file rewrite.
+    #[test]
+    fn setting_edit_preserves_tabs_crlf_and_a_missing_trailing_newline() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(tmp.path(), "{\r\n\t\"name\": \"x\"\r\n}");
+
+        edit_setting_map(tmp.path(), "allowBuilds", |m| {
+            m.insert("esbuild".to_string(), serde_json::Value::Bool(true));
+        })
+        .unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join("package.json")).unwrap();
+        // Positive control: every style assertion below also holds on a file
+        // nobody rewrote, so prove the write happened first.
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            parsed["aube"]["allowBuilds"]["esbuild"],
+            serde_json::Value::Bool(true)
+        );
+        assert!(raw.starts_with("{\r\n\t\"name\""), "style lost:\n{raw:?}");
+        assert!(
+            !raw.contains("\n  \""),
+            "reindented to two spaces:\n{raw:?}"
+        );
+        assert!(raw.ends_with('}'), "trailing newline added:\n{raw:?}");
     }
 }

--- a/vendor/aube/crates/aube/src/commands/manifest_io.rs
+++ b/vendor/aube/crates/aube/src/commands/manifest_io.rs
@@ -23,9 +23,10 @@ pub(crate) fn load_manifest_or_default(root: &Path) -> miette::Result<aube_manif
     }
 }
 
-/// Serialize `value` as pretty JSON with a trailing newline and
-/// atomically write it to `path`. Wraps the serialize + atomic-write
-/// pair used by add/remove/update/audit when mutating `package.json`.
+/// Serialize `value` as pretty JSON in the file's own surface style (indent
+/// unit, line endings, trailing-newline state) and atomically write it to
+/// `path`. Wraps the serialize + atomic-write pair used by
+/// add/remove/update/audit when mutating `package.json`.
 pub(crate) fn write_manifest_json<T: serde::Serialize>(
     path: &Path,
     value: &T,
@@ -39,14 +40,17 @@ pub(crate) fn write_manifest_json<T: serde::Serialize>(
                 .wrap_err("failed to read package.json");
         }
     };
-    let json = aube_manifest::serialize_json_with_indent(
-        value,
-        aube_manifest::detect_json_indent(&existing),
-    )
-    .into_diagnostic()
-    .wrap_err("failed to serialize package.json")?;
-    write_manifest_atomic(path, format!("{json}\n").as_bytes())
-        .wrap_err("failed to write package.json")
+    // An absent (or empty) manifest has no style to imitate, and detecting one
+    // from `""` would read as "no trailing newline".
+    let style = if existing.is_empty() {
+        aube_manifest::JsonStyle::default()
+    } else {
+        aube_manifest::detect_json_style(&existing)
+    };
+    let json = aube_manifest::serialize_json_with_style(value, &style)
+        .into_diagnostic()
+        .wrap_err("failed to serialize package.json")?;
+    write_manifest_atomic(path, json.as_bytes()).wrap_err("failed to write package.json")
 }
 
 pub(crate) fn update_manifest_json_object<F>(path: &Path, update: F) -> miette::Result<()>
@@ -56,7 +60,7 @@ where
     let content = std::fs::read_to_string(path)
         .into_diagnostic()
         .wrap_err("failed to read package.json")?;
-    let indent = aube_manifest::detect_json_indent(&content).to_string();
+    let style = aube_manifest::detect_json_style(&content);
     let mut json: serde_json::Value = serde_json::from_str(&content)
         .into_diagnostic()
         .wrap_err("failed to parse package.json")?;
@@ -66,10 +70,10 @@ where
 
     update(obj)?;
 
-    let json = aube_manifest::serialize_json_with_indent(&json, &indent)
+    let json = aube_manifest::serialize_json_with_style(&json, &style)
         .into_diagnostic()
         .wrap_err("failed to serialize package.json")?;
-    write_manifest_atomic(path, format!("{json}\n").as_bytes())
+    write_manifest_atomic(path, json.as_bytes())
 }
 
 pub(crate) fn write_manifest_dep_sections(
@@ -223,6 +227,39 @@ mod tests {
                 )
             );
         }
+    }
+
+    #[test]
+    fn write_manifest_json_preserves_crlf_and_a_missing_trailing_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        std::fs::write(
+            &path,
+            "{\r\n    \"name\": \"example\",\r\n    \"license\": \"MIT\"\r\n}",
+        )
+        .unwrap();
+
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        write_manifest_json(&path, &value).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "{\r\n    \"name\": \"example\",\r\n    \"license\": \"MIT\"\r\n}"
+        );
+    }
+
+    #[test]
+    fn write_manifest_json_gives_a_new_manifest_the_default_style() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("package.json");
+
+        write_manifest_json(&path, &serde_json::json!({ "name": "example" })).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "{\n  \"name\": \"example\"\n}\n"
+        );
     }
 
     fn root_key_order(raw: &str) -> Vec<String> {

--- a/vendor/aube/crates/aube/src/patches.rs
+++ b/vendor/aube/crates/aube/src/patches.rs
@@ -534,6 +534,7 @@ fn upsert_manifest_patched_dependency(
     let raw = std::fs::read_to_string(&path)
         .into_diagnostic()
         .map_err(|e| miette!("failed to read {}: {e}", path.display()))?;
+    let style = aube_manifest::detect_json_style(&raw);
     let mut value =
         aube_manifest::parse_json::<serde_json::Value>(&path, raw).map_err(miette::Report::new)?;
     let mut obj = value
@@ -556,10 +557,9 @@ fn upsert_manifest_patched_dependency(
         key.to_string(),
         serde_json::Value::String(rel_patch_path.to_string()),
     );
-    let mut out = serde_json::to_string_pretty(&value)
+    let out = aube_manifest::serialize_json_with_style(&value, &style)
         .into_diagnostic()
         .map_err(|e| miette!("failed to serialize {}: {e}", path.display()))?;
-    out.push('\n');
     std::fs::write(&path, out)
         .into_diagnostic()
         .map_err(|e| miette!("failed to write {}: {e}", path.display()))?;
@@ -574,7 +574,7 @@ fn remove_bun_patched_dependency(cwd: &Path, key: &str) -> Result<bool> {
     let raw = std::fs::read_to_string(&path)
         .into_diagnostic()
         .map_err(|e| miette!("failed to read {}: {e}", path.display()))?;
-    let indent = aube_manifest::detect_json_indent(&raw).to_string();
+    let style = aube_manifest::detect_json_style(&raw);
     let mut value =
         aube_manifest::parse_json::<serde_json::Value>(&path, raw).map_err(miette::Report::new)?;
     let obj = value
@@ -602,10 +602,9 @@ fn remove_bun_patched_dependency(cwd: &Path, key: &str) -> Result<bool> {
         return Ok(removed);
     }
 
-    let mut out = aube_manifest::serialize_json_with_indent(&value, &indent)
+    let out = aube_manifest::serialize_json_with_style(&value, &style)
         .into_diagnostic()
         .map_err(|e| miette!("failed to serialize {}: {e}", path.display()))?;
-    out.push('\n');
     std::fs::write(&path, out)
         .into_diagnostic()
         .map_err(|e| miette!("failed to write {}: {e}", path.display()))?;
@@ -837,6 +836,46 @@ mod tests {
                 .map(|p| p.path.strip_prefix(dir.path()).unwrap()),
             Some(Path::new("patches/is-number.patch"))
         );
+    }
+
+    #[test]
+    fn bun_patch_writers_preserve_the_manifest_style() {
+        // The `bun.lock` is what selects the two writers under test:
+        // `upsert_manifest_patched_dependency` and
+        // `remove_bun_patched_dependency`. Without a lockfile the upsert
+        // takes the `config_write_target` → `edit_setting_map` path instead,
+        // which `edits.rs` already covers.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("bun.lock"), "{}").unwrap();
+        let manifest = dir.path().join("package.json");
+        std::fs::write(&manifest, "{\r\n\t\"name\": \"x\"\r\n}").unwrap();
+
+        upsert_patched_dependency(dir.path(), "a@1.0.0", "patches/a@1.0.0.patch").unwrap();
+        let raw = std::fs::read_to_string(&manifest).unwrap();
+        // The bun arm writes the un-branded top-level field — proof the
+        // routing reached the writer under test, not `edit_setting_map`.
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            parsed["patchedDependencies"]["a@1.0.0"],
+            "patches/a@1.0.0.patch"
+        );
+        assert!(raw.starts_with("{\r\n\t\"name\""), "style lost:\n{raw:?}");
+        assert!(
+            !raw.contains("\n  \""),
+            "reindented to two spaces:\n{raw:?}"
+        );
+        assert!(raw.ends_with('}'), "trailing newline added:\n{raw:?}");
+
+        remove_patched_dependency(dir.path(), "a@1.0.0").unwrap();
+        let raw = std::fs::read_to_string(&manifest).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert!(parsed["patchedDependencies"].is_null());
+        assert!(raw.starts_with("{\r\n\t\"name\""), "style lost:\n{raw:?}");
+        assert!(
+            !raw.contains("\n  \""),
+            "reindented to two spaces:\n{raw:?}"
+        );
+        assert!(raw.ends_with('}'), "trailing newline added:\n{raw:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Any package.json rewrite through the aube command layer — `update`/`add`/`audit` dep-section syncs and the namespace settings editors — reformats the whole file: a tab- or 4-space-indented manifest is reindented to two spaces, CRLF becomes LF, and a missing EOF newline gets appended. A one-key change diffs as the entire file:

```
$ cat package.json   # tab-indented
{
	"name": "x",
	"devDependencies": { … }
}
$ nub update         # bumps one specifier…
$ git diff --stat package.json
 1 file changed, 44 insertions(+), 44 deletions(-)   # …and reindents everything
```

npm and pnpm both detect and reproduce the file's own style (`detect-indent` in `@npmcli/package-json` / `@pnpm/read-project-manifest`). nub-core's pin writer (`edit_manifest` in `pm/resolve.rs`) already does this for the `devEngines` stamp — the command-layer writers just never got the same treatment.

## Root cause

Six writers serialize with `serde_json::to_string_pretty` (hardwired two-space indent, LF) and append `\n` unconditionally:

- `aube/src/commands/manifest_io.rs`: `write_manifest_json`, `update_manifest_json_object`
- `aube-manifest/src/workspace/edits.rs`: `remove_setting_entry`, `edit_setting_map`, `add_to_pnpm_only_built_dependencies`, `set_pnpm_allow_builds_entries`

## Fix

Add `detect_json_style` / `serialize_json_with_style` to `aube-manifest` (first indented line's whitespace run as the indent unit, CRLF reproduction, trailing-newline state — the same rules as nub-core's `detect_format`) and route all six writers through them. Files with no indentation to imitate keep the previous two-space/LF/trailing-newline output, so freshly created manifests are byte-identical to before.

## Tests

- Style helpers: tab/4-space/CRLF/EOF-newline detection, style-faithful serialization, and a byte-for-byte round-trip of a tabbed document.
- `write_manifest_dep_sections` preserves tab indentation (the `nub update` repro) and never two-space-reindents.
- `write_manifest_json` preserves CRLF + absent trailing newline.
- `edit_setting_map` preserves tab indentation through a settings write.

Verified end-to-end: `nub update` on a tab-indented manifest bumps the one specifier and leaves every other byte alone (including the devEngines stamp interplay).