### PR TITLE
feat(runtime): polyfill every Stage 3+ library surface missing under nub

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1287,9 +1287,21 @@ try {
 } catch (e) {
   rejected = e.message;
 }
+// Promise.withResolvers: native on Node 22+, polyfilled on the 18.19-21.x compat
+// tier where it was previously missing entirely.
+const wr = Promise.withResolvers();
+wr.resolve("wr-ok");
+const withResolvers =
+  Object.getPrototypeOf(wr) === Object.prototype &&
+  Object.keys(wr).join(",") === "promise,resolve,reject" &&
+  (await wr.promise) === "wr-ok";
 // The additive contract: nub's additions stay invisible to enumeration.
-const hidden = Object.keys(Promise).filter((k) => k.endsWith("Keyed")).length;
-console.log(JSON.stringify({ keyed, scoped, nullProto, statuses, rejected, hidden }));
+const hidden = Object.keys(Promise).filter(
+  (k) => k.endsWith("Keyed") || k === "withResolvers",
+).length;
+console.log(
+  JSON.stringify({ keyed, scoped, nullProto, statuses, rejected, withResolvers, hidden }),
+);
 "#,
     )
     .unwrap();
@@ -1307,7 +1319,7 @@ console.log(JSON.stringify({ keyed, scoped, nullProto, statuses, rejected, hidde
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert_eq!(
         stdout,
-        r#"{"keyed":true,"scoped":true,"nullProto":true,"statuses":"fulfilled/rejected/nope","rejected":"first","hidden":0}"#,
+        r#"{"keyed":true,"scoped":true,"nullProto":true,"statuses":"fulfilled/rejected/nope","rejected":"first","withResolvers":true,"hidden":0}"#,
         "stderr: {stderr}"
     );
 }

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1245,6 +1245,161 @@ console.log(JSON.stringify({ okB64, okUrl, okHex, order: order.join(","), agg, a
 }
 
 #[test]
+fn polyfills_never_clobber_native() {
+    // THE no-clobber guard. Installs a recognizable sentinel on every surface any
+    // installer in runtime/polyfills.cjs touches, runs installSyncPolyfills, and
+    // fails if a single sentinel was replaced. A polyfill that overwrites rather
+    // than defers to an existing implementation cannot survive this test.
+    //
+    // Deliberately driven by PLAIN `node` against the runtime file rather than
+    // through the nub binary: the preload necessarily runs before any user code, so
+    // sentinels could not be planted first. Running under the host node means the
+    // CI Node-matrix legs exercise it across versions for free — on a newer Node
+    // most surfaces are genuinely native, which is exactly the case that matters.
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let polyfills = Path::new(&manifest).join("../../runtime/polyfills.cjs");
+    assert!(polyfills.is_file(), "missing {}", polyfills.display());
+
+    let work = unique_test_cache();
+    std::fs::create_dir_all(&work).unwrap();
+    let script = work.join("_noclobber.mjs");
+    std::fs::write(
+        &script,
+        r#"
+import { createRequire } from "node:module";
+const TAP = Object.getPrototypeOf(Int8Array.prototype);
+const IP = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+const targets = [
+  [Promise, "allKeyed"], [Promise, "allSettledKeyed"], [Promise, "withResolvers"], [Promise, "try"],
+  [RegExp, "escape"], [Error, "isError"], [URL, "parse"],
+  [String.prototype, "isWellFormed"], [String.prototype, "toWellFormed"],
+  [Object, "groupBy"], [Map, "groupBy"],
+  [Array.prototype, "toSorted"], [Array.prototype, "toReversed"], [Array.prototype, "toSpliced"], [Array.prototype, "with"],
+  [TAP, "toSorted"], [TAP, "toReversed"], [TAP, "with"],
+  [ArrayBuffer.prototype, "transfer"], [ArrayBuffer.prototype, "transferToFixedLength"], [Atomics, "pause"],
+  [Set.prototype, "union"], [Set.prototype, "intersection"], [Set.prototype, "difference"],
+  [Set.prototype, "symmetricDifference"], [Set.prototype, "isSubsetOf"], [Set.prototype, "isSupersetOf"],
+  [Set.prototype, "isDisjointFrom"], [Array, "fromAsync"],
+  [Map.prototype, "getOrInsert"], [Map.prototype, "getOrInsertComputed"],
+  [WeakMap.prototype, "getOrInsert"], [WeakMap.prototype, "getOrInsertComputed"],
+  [Math, "sumPrecise"],
+  [IP, "map"], [IP, "filter"], [IP, "take"], [IP, "drop"], [IP, "flatMap"], [IP, "reduce"],
+  [IP, "toArray"], [IP, "some"], [IP, "every"], [IP, "find"], [IP, "forEach"],
+  [IP, "chunks"], [IP, "windows"], [IP, "includes"], [IP, "join"],
+  [Uint8Array.prototype, "toBase64"], [Uint8Array.prototype, "toHex"], [Uint8Array, "fromBase64"],
+  [globalThis, "DisposableStack"], [globalThis, "AsyncDisposableStack"],
+  [globalThis, "SuppressedError"], [globalThis, "reportError"],
+];
+if (globalThis.Iterator) {
+  for (const k of ["from", "concat", "zip", "zipKeyed"]) targets.push([globalThis.Iterator, k]);
+}
+const planted = [];
+for (const [holder, key] of targets) {
+  const sentinel = function nubSentinel() {};
+  Object.defineProperty(holder, key, { value: sentinel, writable: true, enumerable: false, configurable: true });
+  planted.push([holder, key, sentinel]);
+}
+// The one accessor in the set needs its own sentinel shape.
+Object.defineProperty(ArrayBuffer.prototype, "detached", {
+  get: function nubSentinelGetter() { return "SENTINEL"; },
+  enumerable: false, configurable: true,
+});
+createRequire(import.meta.url)(process.argv[2]).installSyncPolyfills({});
+const clobbered = planted.filter(([h, k, s]) => h[k] !== s).map(([, k]) => k);
+const d = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "detached");
+if (!d || d.get?.name !== "nubSentinelGetter") clobbered.push("detached");
+console.log(JSON.stringify({ checked: planted.length + 1, clobbered }));
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new("node")
+        .arg(&script)
+        .arg(&polyfills)
+        .current_dir(&work)
+        .output()
+        .expect("failed to spawn node");
+
+    let _ = std::fs::remove_dir_all(&work);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("bad output {stdout:?} ({e}); stderr: {stderr}"));
+    assert_eq!(
+        parsed["clobbered"].as_array().map(Vec::len),
+        Some(0),
+        "polyfills overwrote an existing implementation: {} (stderr: {stderr})",
+        parsed["clobbered"]
+    );
+    // Guard against the target list silently emptying out.
+    assert!(
+        parsed["checked"].as_u64().unwrap_or(0) >= 50,
+        "expected >=50 surfaces checked, got {}",
+        parsed["checked"]
+    );
+}
+
+#[test]
+fn esnext_library_polyfills() {
+    // The Stage 3+ library families: new Set methods, Array.fromAsync, the Iterator
+    // surface (helpers + from/concat/zip/zipKeyed + the Stage 3 chunks/windows/
+    // includes/join), Map/WeakMap getOrInsert, Math.sumPrecise and Symbol.metadata.
+    // Spec fidelity is verified by batteries that run the SAME assertions against
+    // the polyfill and against native (and, for Math.sumPrecise which no Node ships,
+    // against bun's native implementation); this asserts reachability + correctness
+    // through nub's real preload chain. Isolated tmpdir + cache as elsewhere.
+    let work = unique_test_cache();
+    std::fs::create_dir_all(&work).unwrap();
+    let test_file = work.join("_esnext_check.mjs");
+    std::fs::write(
+        &test_file,
+        r#"
+const setOk = [...new Set([1, 2, 3]).union(new Set([4]))].join(",") === "1,2,3,4" &&
+  [...new Set([1, 2]).intersection(new Set([2]))].join(",") === "2" &&
+  new Set([1]).isSubsetOf(new Set([1, 2])) === true &&
+  // The argument only has to be set-like: a size plus callable has/keys.
+  [...new Set([1]).union({ size: 1, has: (v) => v === 5, keys: () => [5][Symbol.iterator]() })].join(",") === "1,5";
+const fromAsyncOk = (await Array.fromAsync([Promise.resolve(1), 2])).join(",") === "1,2";
+const iterOk = [1, 2, 3, 4][Symbol.iterator]().map((x) => x * 2).filter((x) => x > 2).toArray().join(",") === "4,6,8" &&
+  Iterator.from([1, 2]).toArray().join(",") === "1,2" &&
+  Iterator.concat([1], [2]).toArray().join(",") === "1,2" &&
+  JSON.stringify(Iterator.zip([[1, 2], ["a", "b"]]).toArray()) === '[[1,"a"],[2,"b"]]' &&
+  Iterator.zipKeyed({ a: [1], b: [2] }).toArray()[0].a === 1 &&
+  JSON.stringify([1, 2, 3][Symbol.iterator]().chunks(2).toArray()) === "[[1,2],[3]]" &&
+  [1, 2, 3][Symbol.iterator]().includes(2) === true &&
+  [1, 2][Symbol.iterator]().join("-") === "1-2";
+const m = new Map();
+const mapOk = m.getOrInsert("a", 1) === 1 && m.getOrInsert("a", 9) === 1 &&
+  m.getOrInsertComputed("b", () => 2) === 2;
+// Exact summation: a left-to-right reduce overflows to Infinity here.
+const sumOk = Math.sumPrecise([1e308, 1e308, -1e308, -1e308]) === 0 &&
+  Math.sumPrecise([1, 1e100, 1, -1e100]) === 2;
+const symOk = typeof Symbol.metadata === "symbol";
+console.log(JSON.stringify({ setOk, fromAsyncOk, iterOk, mapOk, sumOk, symOk }));
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(nub_binary())
+        .arg(test_file.to_str().unwrap())
+        .current_dir(&work)
+        .env("XDG_CACHE_HOME", unique_test_cache())
+        .output()
+        .expect("failed to spawn nub");
+
+    let _ = std::fs::remove_dir_all(&work);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stdout,
+        r#"{"setOk":true,"fromAsyncOk":true,"iterOk":true,"mapOk":true,"sumOk":true,"symOk":true}"#,
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn floor_builtin_polyfills() {
     // Shipped-standard builtins that are native only on a NEWER Node than the
     // 18.19 support floor, so each is a compat-tier-only hole. Spec fidelity is

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1244,6 +1244,74 @@ console.log(JSON.stringify({ okB64, okUrl, okHex, order: order.join(","), agg, a
     );
 }
 
+#[test]
+fn keyed_promise_combinator_polyfills() {
+    // Promise.allKeyed / Promise.allSettledKeyed (TC39 "await dictionary", Stage 3)
+    // ship in no engine, so this exercises the polyfill on every Node — there is no
+    // native branch to fall through to. Spec fidelity is verified separately by the
+    // differential battery (18.19 through 26.5); this asserts the API is reachable
+    // and correct through nub's real preload chain, on the three semantics a naive
+    // implementation gets wrong: the result object's NULL prototype, own-enumerable
+    // keys INCLUDING symbols, and non-enumerable installation on `Promise`.
+    // Isolated tmpdir + cache for the same hermeticity reasons as
+    // `polyfills_available`.
+    let work = unique_test_cache();
+    std::fs::create_dir_all(&work).unwrap();
+    let test_file = work.join("_keyed_check.mjs");
+    std::fs::write(
+        &test_file,
+        r#"
+const sym = Symbol("s");
+const src = Object.create(
+  { inherited: Promise.resolve("leaked") },
+  {
+    shape: { value: Promise.resolve("square"), enumerable: true },
+    mass: { value: 12, enumerable: true },
+    hidden: { value: Promise.resolve("leaked"), enumerable: false },
+    [sym]: { value: Promise.resolve("sym"), enumerable: true },
+  },
+);
+const dict = await Promise.allKeyed(src);
+const { shape, mass } = dict;
+const keyed = shape === "square" && mass === 12 && dict[sym] === "sym";
+const scoped = !("hidden" in dict) && !("inherited" in dict);
+const nullProto = Object.getPrototypeOf(dict) === null;
+const settled = await Promise.allSettledKeyed({
+  ok: Promise.resolve(1),
+  bad: Promise.reject(new Error("nope")),
+});
+const statuses = settled.ok.status + "/" + settled.bad.status + "/" + settled.bad.reason.message;
+let rejected = "";
+try {
+  await Promise.allKeyed({ a: Promise.reject(new Error("first")), b: Promise.resolve(2) });
+} catch (e) {
+  rejected = e.message;
+}
+// The additive contract: nub's additions stay invisible to enumeration.
+const hidden = Object.keys(Promise).filter((k) => k.endsWith("Keyed")).length;
+console.log(JSON.stringify({ keyed, scoped, nullProto, statuses, rejected, hidden }));
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(nub_binary())
+        .arg(test_file.to_str().unwrap())
+        .current_dir(&work)
+        .env("XDG_CACHE_HOME", unique_test_cache())
+        .output()
+        .expect("failed to spawn nub");
+
+    let _ = std::fs::remove_dir_all(&work);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stdout,
+        r#"{"keyed":true,"scoped":true,"nullProto":true,"statuses":"fulfilled/rejected/nope","rejected":"first","hidden":0}"#,
+        "stderr: {stderr}"
+    );
+}
+
 /// Child processes spawned via `execSync("node ...")` inside a Nub-run
 /// script should inherit Nub's TypeScript augmentation through the PATH
 /// shim — `node` resolves to the shim symlink which points back to `nub`.

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1245,6 +1245,63 @@ console.log(JSON.stringify({ okB64, okUrl, okHex, order: order.join(","), agg, a
 }
 
 #[test]
+fn floor_builtin_polyfills() {
+    // Shipped-standard builtins that are native only on a NEWER Node than the
+    // 18.19 support floor, so each is a compat-tier-only hole. Spec fidelity is
+    // verified separately by a battery that runs the SAME assertions against the
+    // polyfill (18.19-21.x) and against NATIVE (22.15+/24/26), so native is the
+    // oracle; this asserts reachability + correctness through nub's real preload
+    // chain. Isolated tmpdir + cache, as `polyfills_available`.
+    let work = unique_test_cache();
+    std::fs::create_dir_all(&work).unwrap();
+    let test_file = work.join("_floor_check.mjs");
+    std::fs::write(
+        &test_file,
+        r#"
+const urlOk = URL.parse("https://a.example/x").href === "https://a.example/x" && URL.parse("!!") === null;
+const strOk = "a\uD800b".isWellFormed() === false && "a\uD800b".toWellFormed() === "a\uFFFDb";
+const grouped = Object.groupBy([1, 2, 3], (n) => (n % 2 ? "odd" : "even"));
+const groupOk = Object.getPrototypeOf(grouped) === null &&
+  grouped.odd.join(",") === "1,3" &&
+  Map.groupBy([1, 2], (n) => n % 2).get(1).join(",") === "1";
+const copyOk = [3, 1, 2].toSorted().join(",") === "1,2,3" &&
+  [3, 1, 2].toReversed().join(",") === "2,1,3" &&
+  [3, 1, 2].with(0, 9).join(",") === "9,1,2" &&
+  [3, 1, 2].toSpliced(1, 1).join(",") === "3,2" &&
+  new Int8Array([3, 1]).toSorted().constructor === Int8Array;
+// transfer must perform a REAL detach, not just zero the length.
+const buf = new ArrayBuffer(2);
+new Uint8Array(buf).set([7, 8]);
+const moved = buf.transfer();
+let viewThrew = false;
+try { new Uint8Array(buf); } catch { viewThrew = true; }
+const abOk = [...new Uint8Array(moved)].join(",") === "7,8" && buf.detached === true &&
+  viewThrew && new ArrayBuffer(0).detached === false;
+const pauseOk = Atomics.pause() === undefined;
+console.log(JSON.stringify({ urlOk, strOk, groupOk, copyOk, abOk, pauseOk }));
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(nub_binary())
+        .arg(test_file.to_str().unwrap())
+        .current_dir(&work)
+        .env("XDG_CACHE_HOME", unique_test_cache())
+        .output()
+        .expect("failed to spawn nub");
+
+    let _ = std::fs::remove_dir_all(&work);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stdout,
+        r#"{"urlOk":true,"strOk":true,"groupOk":true,"copyOk":true,"abOk":true,"pauseOk":true}"#,
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn keyed_promise_combinator_polyfills() {
     // Promise.allKeyed / Promise.allSettledKeyed (TC39 "await dictionary", Stage 3)
     // ship in no engine, so this exercises the polyfill on every Node — there is no

--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -494,6 +494,147 @@ static FEATURES: &[Feature] = &[
         ],
         evidence: "native on Node 24+",
     },
+    // ── Stage 3+ library surfaces ───────────────────────────────────────────
+    // union is the detect anchor for all SEVEN set methods (union/intersection/
+    // difference/symmetricDifference/isSubsetOf/isSupersetOf/isDisjointFrom); each
+    // is still guarded individually in the runtime file.
+    Feature {
+        name: "Set.union",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((22, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "Set.prototype.union",
+                },
+            ),
+            (band((22, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4 / ES2025 (new Set methods); native on Node 22+",
+    },
+    Feature {
+        name: "Array.fromAsync",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((22, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "Array.fromAsync",
+                },
+            ),
+            (band((22, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4 / ES2025; native on Node 22+",
+    },
+    // Shipped under the name getOrInsert, NOT the proposal's original `upsert` --
+    // no runtime ever exposed `upsert`. Anchor also covers getOrInsertComputed and
+    // the WeakMap forms.
+    Feature {
+        name: "Map.getOrInsert",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((26, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "Map.prototype.getOrInsert",
+                },
+            ),
+            (band((26, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4 / ES2026 (upsert, shipped as getOrInsert); native on Node 26+",
+    },
+    // Anchor for Iterator.from plus the eleven ES2025 helpers (map/filter/take/drop/
+    // flatMap/reduce/toArray/some/every/find/forEach).
+    Feature {
+        name: "Iterator.from",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((22, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "Iterator.from",
+                },
+            ),
+            (band((22, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4 / ES2025 (sync iterator helpers); native on Node 22+",
+    },
+    Feature {
+        name: "Iterator.concat",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((26, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "Iterator.concat",
+                },
+            ),
+            (band((26, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4 (iterator-sequencing); native on Node 26+",
+    },
+    // joint-iteration is the ITERATOR twin of Promise.allKeyed -- the await-dictionary
+    // proposal explicitly follows its shape. Stage 4 yet shipped by no engine.
+    Feature {
+        name: "Iterator.zip",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Polyfill {
+                runtime_file: "polyfills.cjs",
+                global: "Iterator.zip",
+            },
+        )],
+        evidence: "Stage 4 (joint-iteration); absent on every Node through 26.5",
+    },
+    Feature {
+        name: "Iterator.zipKeyed",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Polyfill {
+                runtime_file: "polyfills.cjs",
+                global: "Iterator.zipKeyed",
+            },
+        )],
+        evidence: "Stage 4 (joint-iteration); absent on every Node through 26.5",
+    },
+    // Anchor for the Stage 3 prototype additions: chunks/windows (iterator-chunking),
+    // includes (iterator-includes) and join (iterator-join). These install even where
+    // the ES2025 helpers above are already native.
+    Feature {
+        name: "Iterator.chunks",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Polyfill {
+                runtime_file: "polyfills.cjs",
+                global: "Iterator.prototype.chunks",
+            },
+        )],
+        evidence: "Stage 3 (iterator-chunking/includes/join); absent on every Node through 26.5",
+    },
+    Feature {
+        name: "Math.sumPrecise",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Polyfill {
+                runtime_file: "polyfills.cjs",
+                global: "Math.sumPrecise",
+            },
+        )],
+        evidence: "Stage 3 (proposal-math-sum); absent on every Node through 26.5 (bun ships it)",
+    },
+    // Only the well-known symbol; POPULATING class metadata is the decorator
+    // transform's job, and the spec's value for an undecorated class is undefined.
+    Feature {
+        name: "Symbol.metadata",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Polyfill {
+                runtime_file: "polyfills.cjs",
+                global: "Symbol.metadata",
+            },
+        )],
+        evidence: "Stage 3 (decorator metadata); absent on every Node through 26.5",
+    },
     // ── Shipped-standard builtins missing below their Node line ─────────────
     // All Stage 4 except Atomics.pause (Stage 3). Each was left unpolyfilled by the
     // same stale-floor premise as Promise.withResolvers below; bands are measured,

--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -494,6 +494,125 @@ static FEATURES: &[Feature] = &[
         ],
         evidence: "native on Node 24+",
     },
+    // ── Shipped-standard builtins missing below their Node line ─────────────
+    // All Stage 4 except Atomics.pause (Stage 3). Each was left unpolyfilled by the
+    // same stale-floor premise as Promise.withResolvers below; bands are measured,
+    // not read off release notes.
+    //
+    // URL.parse is the awkward one: Node backported it to 20.19 but the 21.x line
+    // never got it, so the row has a HOLE — native on 20.19-20.x, absent again
+    // across all of 21.x, native from 22.1. Same shape as the eventsource 21.x hole.
+    Feature {
+        name: "URL.parse",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((20, 19, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "URL.parse",
+                },
+            ),
+            (band((20, 19, 0), Some((21, 0, 0))), Mitigation::Native),
+            (
+                band((21, 0, 0), Some((22, 1, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "URL.parse",
+                },
+            ),
+            (band((22, 1, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4; native 22.1 and backported to 20.19; the 21.x line never got it",
+    },
+    // isWellFormed/toWellFormed ship together; isWellFormed is the detect anchor.
+    Feature {
+        name: "String.isWellFormed",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((20, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "String.prototype.isWellFormed",
+                },
+            ),
+            (band((20, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4 (well-formed unicode strings); native on Node 20+",
+    },
+    Feature {
+        name: "Object.groupBy",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((21, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "Object.groupBy",
+                },
+            ),
+            (band((21, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4; native on Node 21+ (V8 12.0)",
+    },
+    Feature {
+        name: "Map.groupBy",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((21, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "Map.groupBy",
+                },
+            ),
+            (band((21, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4; native on Node 21+ (V8 12.0)",
+    },
+    // Change-array-by-copy. toSorted is the detect anchor for the whole family
+    // (Array toSorted/toReversed/toSpliced/with + the TypedArray forms, which get
+    // everything but toSpliced since a typed array cannot change length).
+    Feature {
+        name: "Array.toSorted",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((20, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "Array.prototype.toSorted",
+                },
+            ),
+            (band((20, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4 (change array by copy); native on Node 20+",
+    },
+    // transfer/transferToFixedLength/detached. Polyfillable ONLY because
+    // structuredClone's transfer list performs a real detach on the floor.
+    Feature {
+        name: "ArrayBuffer.transfer",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((21, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "ArrayBuffer.prototype.transfer",
+                },
+            ),
+            (band((21, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "Stage 4 (resizable ArrayBuffer / transfer); native on Node 21+",
+    },
+    // Stage 3, in no Node. A micro-architectural hint, so a validate-and-return
+    // implementation is fully faithful — the spec lets an implementation do nothing.
+    Feature {
+        name: "Atomics.pause",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Polyfill {
+                runtime_file: "polyfills.cjs",
+                global: "Atomics.pause",
+            },
+        )],
+        evidence: "TC39 Stage 3 (proposal-atomics-microwait); absent on every Node through 26.5",
+    },
     // ── Promise.withResolvers ───────────────────────────────────────────────
     // TC39 Stage 4 / ES2024; native on Node 22+, absent on the 18.19–21.x compat
     // tier. It went unpolyfilled until 2026-07 because the candidates survey

--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -494,6 +494,25 @@ static FEATURES: &[Feature] = &[
         ],
         evidence: "native on Node 24+",
     },
+    // ── Promise.withResolvers ───────────────────────────────────────────────
+    // TC39 Stage 4 / ES2024; native on Node 22+, absent on the 18.19–21.x compat
+    // tier. It went unpolyfilled until 2026-07 because the candidates survey
+    // judged it "native on Nub's floor" while the floor was still 22.15; the
+    // verdict was never revisited when the floor moved to 18.19.
+    Feature {
+        name: "Promise.withResolvers",
+        mitigations: &[
+            (
+                band((18, 19, 0), Some((22, 0, 0))),
+                Mitigation::Polyfill {
+                    runtime_file: "polyfills.cjs",
+                    global: "Promise.withResolvers",
+                },
+            ),
+            (band((22, 0, 0), None), Mitigation::Native),
+        ],
+        evidence: "TC39 Stage 4 / ES2024; native on Node 22.0+ (V8 12.4)",
+    },
     // ── Promise.allKeyed / Promise.allSettledKeyed ──────────────────────────
     // TC39 "await dictionary", Stage 3. Shipped by NO engine, so unlike the rows
     // above there is no Native band to fall through to — the whole supported range

--- a/crates/nub-core/src/node/feature_matrix.rs
+++ b/crates/nub-core/src/node/feature_matrix.rs
@@ -494,6 +494,33 @@ static FEATURES: &[Feature] = &[
         ],
         evidence: "native on Node 24+",
     },
+    // ── Promise.allKeyed / Promise.allSettledKeyed ──────────────────────────
+    // TC39 "await dictionary", Stage 3. Shipped by NO engine, so unlike the rows
+    // above there is no Native band to fall through to — the whole supported range
+    // is polyfilled, the same shape as reportError. The runtime feature-detect is
+    // what steps aside once V8 lands it, so this row needs no revision then.
+    Feature {
+        name: "Promise.allKeyed",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Polyfill {
+                runtime_file: "polyfills.cjs",
+                global: "Promise.allKeyed",
+            },
+        )],
+        evidence: "TC39 Stage 3 (proposal-await-dictionary); absent on every Node through 26.5",
+    },
+    Feature {
+        name: "Promise.allSettledKeyed",
+        mitigations: &[(
+            band((18, 19, 0), None),
+            Mitigation::Polyfill {
+                runtime_file: "polyfills.cjs",
+                global: "Promise.allSettledKeyed",
+            },
+        )],
+        evidence: "TC39 Stage 3 (proposal-await-dictionary); absent on every Node through 26.5",
+    },
     // ── Float16Array ────────────────────────────────────────────────────────
     // TC39 Stage 4; native on Node 24+, absent on the 22.x floor, polyfilled from
     // the vendored `@petamoriken/float16` package. See

--- a/npm/nub-types/index.d.ts
+++ b/npm/nub-types/index.d.ts
@@ -164,6 +164,21 @@ interface ImportMeta {
   };
 }
 
+// ── Promise.allKeyed / Promise.allSettledKeyed (TC39 "await dictionary", Stage 3;
+//    runtime/polyfills.cjs) ──
+// In no engine, in no @types/node, in no TypeScript lib. The mapped types mirror
+// the proposal README's own signatures: the key set is preserved and each value is
+// `Awaited`. Two runtime facts TypeScript cannot express — the result object has a
+// null prototype, and its keys are the argument's own ENUMERABLE keys (so a
+// non-enumerable or inherited property is absent at runtime while `keyof` still
+// includes it). Neither affects the destructuring this API exists for.
+interface PromiseConstructor {
+  allKeyed<T extends object>(promises: T): Promise<{ -readonly [K in keyof T]: Awaited<T[K]> }>;
+  allSettledKeyed<T extends object>(
+    promises: T,
+  ): Promise<{ -readonly [K in keyof T]: PromiseSettledResult<Awaited<T[K]>> }>;
+}
+
 // ── Date.prototype.toTemporalInstant (runtime/preload-common.cjs installs it) ──
 // Nub assigns the polyfill's `toTemporalInstant` onto Date.prototype on the floor
 // (matching native Node, which ships it once Temporal is native).

--- a/npm/nub-types/test/fixtures/positive/index.ts
+++ b/npm/nub-types/test/fixtures/positive/index.ts
@@ -41,6 +41,21 @@ void inlineWorker;
 // reportError (WinterTC global; not in @types/node).
 reportError(new Error("boom"));
 
+// Promise.allKeyed / Promise.allSettledKeyed (TC39 await dictionary). The result
+// properties are pinned to concrete types so a mapped-type regression — losing
+// `Awaited`, or widening a value to `any` — fails this fixture instead of
+// silently typechecking.
+const dict = await Promise.allKeyed({ shape: Promise.resolve("square"), mass: 12 });
+const dictShape: string = dict.shape;
+const dictMass: number = dict.mass;
+void dictShape;
+void dictMass;
+const settledDict = await Promise.allSettledKeyed({ ok: Promise.resolve(1) });
+if (settledDict.ok.status === "fulfilled") {
+  const okValue: number = settledDict.ok.value;
+  void okValue;
+}
+
 // Temporal namespace (inlined from @js-temporal/polyfill).
 const instant: Temporal.Instant = Temporal.Now.instant();
 const duration: Temporal.Duration = Temporal.Duration.from({ hours: 2, minutes: 30 });

--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -275,6 +275,225 @@ function installSyncPolyfills(preloaded) {
   installDisposableStacks();
   installKeyedPromiseCombinators();
   installPromiseWithResolvers();
+  installFloorBuiltins();
+}
+
+// ── Shipped-standard ECMAScript builtins missing below their Node line ──
+// Every one of these is Stage 4 (except Atomics.pause, Stage 3) and native on a
+// NEWER Node than nub's 18.19 support floor, so each is a hole only the compat
+// tier sees. They all went unpolyfilled until 2026-07 for the same reason
+// Promise.withResolvers did: the 2026-05 candidates survey judged them "native on
+// Nub's floor" while the floor was 22.15, and nothing revisited the verdicts when
+// it moved to 18.19. Bands are from measurement across 18.19/20.10/21.0/22.15, not
+// release notes — which is how URL.parse's 21.x hole turned up.
+//
+// Each guard is the method's own feature-detect, so every one is an independent
+// no-op where the engine ships it. Installed non-enumerable, per this file's
+// additive contract.
+function installFloorBuiltins() {
+  const def = (target, name, value) => {
+    Object.defineProperty(target, name, {
+      value,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  };
+
+  // ── URL.parse (native Node 22.1 and 20.19; absent on all of 21.x) ──
+  // The whole API is "new URL but null instead of throwing", so the try/catch IS
+  // the spec. `base` is forwarded only when supplied: passing an explicit
+  // undefined to the URL constructor is NOT the same as omitting it.
+  if (typeof URL.parse !== "function") {
+    // `base` is read from `arguments` rather than declared: WebIDL counts only
+    // REQUIRED arguments toward `length`, so native URL.parse.length is 1.
+    def(URL, "parse", function parse(url) {
+      const base = arguments.length > 1 ? arguments[1] : undefined;
+      try {
+        return base === undefined ? new URL(url) : new URL(url, base);
+      } catch {
+        return null;
+      }
+    });
+  }
+
+  // ── String.prototype.isWellFormed / toWellFormed (native Node 20; absent 18.19) ──
+  // "Well formed" means no LONE surrogate. Iterating with a code-point regex is
+  // the cheapest faithful test: a paired surrogate matches as one astral code
+  // point, so anything left in the 0xD800–0xDFFF range is unpaired.
+  if (typeof String.prototype.isWellFormed !== "function") {
+    const loneSurrogate = /[\uD800-\uDFFF]/u;
+    def(String.prototype, "isWellFormed", function isWellFormed() {
+      return !loneSurrogate.test(String(this));
+    });
+    def(String.prototype, "toWellFormed", function toWellFormed() {
+      // Replace each lone surrogate with U+FFFD. The `u` flag makes a well-formed
+      // pair a single match unit, so only unpaired units are hit.
+      return String(this).replace(/[\uD800-\uDFFF]/gu, "�");
+    });
+  }
+
+  // ── Object.groupBy / Map.groupBy (native Node 21; absent 18.19–20.x) ──
+  // The two differ in more than their container: Object.groupBy coerces each key
+  // with ToPropertyKey and returns a NULL-PROTOTYPE object (so a "toString" group
+  // can't collide with Object.prototype), while Map.groupBy keys on the raw value
+  // under SameValueZero — which a Map already implements, including -0 → +0.
+  if (typeof Object.groupBy !== "function") {
+    def(Object, "groupBy", function groupBy(items, callback) {
+      if (typeof callback !== "function") throw new TypeError("callback is not a function");
+      const obj = Object.create(null);
+      let i = 0;
+      for (const item of items) {
+        const key = callback(item, i++);
+        const k = typeof key === "symbol" ? key : String(key);
+        if (obj[k] === undefined && !(k in obj)) obj[k] = [];
+        obj[k].push(item);
+      }
+      return obj;
+    });
+  }
+  if (typeof Map.groupBy !== "function") {
+    def(Map, "groupBy", function groupBy(items, callback) {
+      if (typeof callback !== "function") throw new TypeError("callback is not a function");
+      const map = new Map();
+      let i = 0;
+      for (const item of items) {
+        // Map.prototype.get/set already key under SameValueZero, so -0 collapses
+        // to +0 exactly as the spec's normalization requires.
+        const key = callback(item, i++);
+        const group = map.get(key);
+        if (group === undefined) map.set(key, [item]);
+        else group.push(item);
+      }
+      return map;
+    });
+  }
+
+  // ── Change-array-by-copy (native Node 20; absent 18.19) ──
+  // Every method returns a plain Array regardless of the receiver's constructor —
+  // deliberately NOT species-aware, unlike map/filter. The Array.from(this) hop
+  // both realizes an array-like receiver and gives the fresh array to mutate.
+  if (typeof Array.prototype.toSorted !== "function") {
+    def(Array.prototype, "toSorted", function toSorted(compareFn) {
+      if (compareFn !== undefined && typeof compareFn !== "function") {
+        throw new TypeError("comparefn must be a function");
+      }
+      return Array.prototype.sort.call(Array.from(this), compareFn);
+    });
+    def(Array.prototype, "toReversed", function toReversed() {
+      return Array.from(this).reverse();
+    });
+    def(Array.prototype, "toSpliced", function toSpliced(start, skipCount, ...items) {
+      const arr = Array.from(this);
+      arr.splice(start, skipCount, ...items);
+      return arr;
+    });
+    // `with` is a reserved word, so a named function EXPRESSION is a SyntaxError.
+    // An object-method shorthand accepts the reserved name and infers `name` as
+    // "with", which a `function with_` would have gotten wrong.
+    def(Array.prototype, "with", {
+      with(index, value) {
+        const arr = Array.from(this);
+        const i = Math.trunc(Number(index)) || 0;
+        const actual = i < 0 ? arr.length + i : i;
+        if (actual < 0 || actual >= arr.length) throw new RangeError("invalid index");
+        arr[actual] = value;
+        return arr;
+      },
+    }.with);
+  }
+
+  // %TypedArray% gets toSorted/toReversed/with but NOT toSpliced (a typed array
+  // cannot change length), and unlike the Array forms these return the SAME
+  // typed-array type as the receiver.
+  const TypedArrayProto = Object.getPrototypeOf(Int8Array.prototype);
+  if (typeof TypedArrayProto.toSorted !== "function") {
+    def(TypedArrayProto, "toSorted", function toSorted(compareFn) {
+      if (compareFn !== undefined && typeof compareFn !== "function") {
+        throw new TypeError("comparefn must be a function");
+      }
+      const copy = new this.constructor(this);
+      return copy.sort(compareFn);
+    });
+    def(TypedArrayProto, "toReversed", function toReversed() {
+      return new this.constructor(this).reverse();
+    });
+    def(TypedArrayProto, "with", {
+      with(index, value) {
+        const copy = new this.constructor(this);
+        const i = Math.trunc(Number(index)) || 0;
+        const actual = i < 0 ? copy.length + i : i;
+        if (actual < 0 || actual >= copy.length) throw new RangeError("invalid index");
+        copy[actual] = value;
+        return copy;
+      },
+    }.with);
+  }
+
+  // ── ArrayBuffer.prototype.transfer / transferToFixedLength / detached ──
+  //    (native Node 21; absent 18.19–20.x)
+  // Faithful only because structuredClone's transfer list performs a REAL detach
+  // on the floor — verified on 18.19: the source drops to 0 bytes and any view
+  // construction on it throws, which is genuine detachment rather than a zeroed
+  // buffer. Userland cannot otherwise detach an ArrayBuffer, so without that
+  // primitive this pair would be unpolyfillable.
+  if (typeof ArrayBuffer.prototype.transfer !== "function") {
+    // A detached buffer is exactly one that rejects view construction. That is
+    // what distinguishes it from a legitimately zero-length buffer, which accepts
+    // a view fine — so byteLength alone cannot be the test.
+    const isDetached = (buf) => {
+      try {
+        new Uint8Array(buf);
+        return false;
+      } catch {
+        return true;
+      }
+    };
+    const transferImpl = (buf, newLength) => {
+      if (isDetached(buf)) throw new TypeError("ArrayBuffer is detached");
+      const oldLen = buf.byteLength;
+      const len = newLength === undefined ? oldLen : Math.trunc(Number(newLength)) || 0;
+      if (len < 0) throw new RangeError("invalid length");
+      // Copy BEFORE detaching; the copy is truncated or zero-padded to `len`.
+      const out = new ArrayBuffer(len);
+      new Uint8Array(out).set(new Uint8Array(buf, 0, Math.min(oldLen, len)));
+      // Detach the source. The clone takes ownership of the original memory and
+      // is immediately discarded, so this moves rather than copies.
+      structuredClone(buf, { transfer: [buf] });
+      return out;
+    };
+    // newLength is optional, so it rides `arguments`: native length is 0 for both.
+    def(ArrayBuffer.prototype, "transfer", function transfer() {
+      return transferImpl(this, arguments.length > 0 ? arguments[0] : undefined);
+    });
+    def(ArrayBuffer.prototype, "transferToFixedLength", function transferToFixedLength() {
+      return transferImpl(this, arguments.length > 0 ? arguments[0] : undefined);
+    });
+    Object.defineProperty(ArrayBuffer.prototype, "detached", {
+      get: function detached() {
+        return isDetached(this);
+      },
+      enumerable: false,
+      configurable: true,
+    });
+  }
+
+  // ── Atomics.pause (TC39 Stage 3, proposal-atomics-microwait; in no Node) ──
+  // A pure micro-architectural HINT with no observable effect beyond argument
+  // validation, so returning undefined is a fully faithful implementation — the
+  // spec permits an implementation to do nothing. Validation is the observable
+  // part: the optional argument must be an integral Number.
+  if (typeof Atomics !== "undefined" && typeof Atomics.pause !== "function") {
+    def(Atomics, "pause", function pause() {
+      const iterationNumber = arguments.length > 0 ? arguments[0] : undefined;
+      if (iterationNumber !== undefined) {
+        if (typeof iterationNumber !== "number" || !Number.isInteger(iterationNumber)) {
+          throw new TypeError("Atomics.pause iterationNumber must be an integral Number");
+        }
+      }
+      return undefined;
+    });
+  }
 }
 
 // ── Uint8Array base64/hex (TC39 Stage 3; native Node 25+, absent below) ──

--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -276,6 +276,762 @@ function installSyncPolyfills(preloaded) {
   installKeyedPromiseCombinators();
   installPromiseWithResolvers();
   installFloorBuiltins();
+  installSetMethods();
+  installArrayFromAsync();
+  installMapGetOrInsert();
+  installMathSumPrecise();
+  installIteratorSurface();
+  installSymbolMetadata();
+}
+
+// ── The Iterator surface: constructor, Iterator.from, the 11 sync helpers, and
+//    the newer statics (concat / zip / zipKeyed) plus chunks/windows/includes/join ──
+// Node ships this in layers — helpers and `from` at 22.0, `concat` only at 26, and
+// zip/zipKeyed/chunks/windows/includes/join nowhere yet — so this installer is
+// deliberately built as INDEPENDENT per-name guards rather than one all-or-nothing
+// branch. A runtime with native helpers keeps every native method untouched and
+// gains only the names it lacks.
+//
+// FIDELITY LIMIT (inherent, same class as the polyfilled Float16Array not being an
+// ArrayBuffer.isView): the helper objects here are generator objects, so their
+// prototype is not the spec's %IteratorHelperPrototype% and their
+// Symbol.toStringTag reads "Generator" rather than "Iterator Helper". Iteration,
+// laziness, argument validation and underlying-iterator closing all behave
+// correctly — only the internal identity differs, which no realistic consumer
+// inspects. Generators were chosen precisely because they get the hard part right:
+// an early `return()` propagates to the source iterator.
+function installIteratorSurface() {
+  // %IteratorPrototype% is reachable from any built-in iterator: array iterator →
+  // %ArrayIteratorPrototype% → %IteratorPrototype%.
+  const IteratorProto = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+
+  if (typeof globalThis.Iterator !== "function") {
+    // The Iterator constructor is abstract: calling it directly throws, and
+    // subclassing is the only legitimate use. Its .prototype IS %IteratorPrototype%.
+    const Iterator = function Iterator() {
+      if (new.target === undefined || new.target === Iterator) {
+        throw new TypeError("Abstract class Iterator not directly constructable");
+      }
+    };
+    Object.defineProperty(Iterator, "prototype", {
+      value: IteratorProto,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+    defBuiltin(IteratorProto, "constructor", Iterator);
+    Object.defineProperty(globalThis, "Iterator", {
+      value: Iterator,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  const Iterator = globalThis.Iterator;
+
+  // GetIteratorDirect: helpers operate on the object's OWN `next`, without
+  // re-invoking Symbol.iterator — so a partially-consumed iterator keeps its place.
+  const iterOf = (obj) => {
+    if (obj === null || (typeof obj !== "object" && typeof obj !== "function")) {
+      throw new TypeError("not an object");
+    }
+    return obj;
+  };
+  // Drive an iterator record with for..of semantics while forwarding closure.
+  // The `finally` is load-bearing: when a consumer abandons a helper early (a
+  // `break`, a `return`, a throw), native helpers call the SOURCE iterator's
+  // `return()`, and without this the source would be left open — verified against
+  // native, which is how the omission was caught. It must fire ONLY on early exit,
+  // since native does not call `return()` on an already-exhausted iterator.
+  function* drain(rec) {
+    let exhausted = false;
+    try {
+      while (true) {
+        const r = rec.next();
+        if (r.done) {
+          exhausted = true;
+          return;
+        }
+        yield r.value;
+      }
+    } finally {
+      if (!exhausted) {
+        const ret = rec.return;
+        if (typeof ret === "function") {
+          // A throw from `return()` must not mask the completion in flight.
+          try {
+            ret.call(rec);
+          } catch { /* swallow, matching IteratorClose's error handling here */ }
+        }
+      }
+    }
+  }
+  const asIterable = (rec) => ({ [Symbol.iterator]: () => drain(rec) });
+  // ToIntegerOrInfinity plus the helpers' shared limit validation: NaN and negative
+  // are RangeErrors, which is where a naive `Number(x) | 0` diverges.
+  const toLimit = (v) => {
+    const n = Number(v);
+    if (Number.isNaN(n)) throw new RangeError("limit must not be NaN");
+    const i = n === Infinity ? Infinity : Math.trunc(n) || 0;
+    if (i < 0) throw new RangeError("limit must not be negative");
+    return i;
+  };
+  const requireFn = (f, what) => {
+    if (typeof f !== "function") throw new TypeError(`${what} is not a function`);
+  };
+
+  const protoHelpers = {
+    map(mapper) {
+      const rec = iterOf(this);
+      requireFn(mapper, "mapper");
+      return (function* () {
+        let i = 0;
+        for (const v of asIterable(rec)) yield mapper(v, i++);
+      })();
+    },
+    filter(predicate) {
+      const rec = iterOf(this);
+      requireFn(predicate, "predicate");
+      return (function* () {
+        let i = 0;
+        for (const v of asIterable(rec)) if (predicate(v, i++)) yield v;
+      })();
+    },
+    take(limit) {
+      const rec = iterOf(this);
+      const n = toLimit(limit);
+      return (function* () {
+        if (n === 0) return;
+        let left = n;
+        for (const v of asIterable(rec)) {
+          yield v;
+          if (--left === 0) return;
+        }
+      })();
+    },
+    drop(limit) {
+      const rec = iterOf(this);
+      const n = toLimit(limit);
+      return (function* () {
+        let left = n;
+        for (const v of asIterable(rec)) {
+          if (left > 0) {
+            left--;
+            continue;
+          }
+          yield v;
+        }
+      })();
+    },
+    flatMap(mapper) {
+      const rec = iterOf(this);
+      requireFn(mapper, "mapper");
+      return (function* () {
+        let i = 0;
+        for (const v of asIterable(rec)) {
+          const inner = mapper(v, i++);
+          // The mapper must return something iterable; a bare value is a TypeError
+          // rather than being wrapped.
+          if (inner === null || inner === undefined || typeof inner[Symbol.iterator] !== "function") {
+            throw new TypeError("flatMap mapper did not return an iterable");
+          }
+          yield* inner;
+        }
+      })();
+    },
+    reduce(reducer) {
+      const rec = iterOf(this);
+      requireFn(reducer, "reducer");
+      let acc;
+      let i = 0;
+      if (arguments.length > 1) {
+        acc = arguments[1];
+      } else {
+        const first = rec.next();
+        if (first.done) {
+          throw new TypeError("reduce of empty iterator with no initial value");
+        }
+        acc = first.value;
+        i = 1;
+      }
+      for (const v of asIterable(rec)) acc = reducer(acc, v, i++);
+      return acc;
+    },
+    toArray() {
+      const rec = iterOf(this);
+      const out = [];
+      for (const v of asIterable(rec)) out.push(v);
+      return out;
+    },
+    some(predicate) {
+      const rec = iterOf(this);
+      requireFn(predicate, "predicate");
+      let i = 0;
+      for (const v of asIterable(rec)) if (predicate(v, i++)) return true;
+      return false;
+    },
+    every(predicate) {
+      const rec = iterOf(this);
+      requireFn(predicate, "predicate");
+      let i = 0;
+      for (const v of asIterable(rec)) if (!predicate(v, i++)) return false;
+      return true;
+    },
+    find(predicate) {
+      const rec = iterOf(this);
+      requireFn(predicate, "predicate");
+      let i = 0;
+      for (const v of asIterable(rec)) if (predicate(v, i++)) return v;
+      return undefined;
+    },
+    forEach(fn) {
+      const rec = iterOf(this);
+      requireFn(fn, "fn");
+      let i = 0;
+      for (const v of asIterable(rec)) fn(v, i++);
+      return undefined;
+    },
+    // ── Stage 3 additions, in no engine yet ──
+    // iterator-chunking: chunks() partitions into non-overlapping arrays of n and
+    // yields a SHORT final chunk; windows() slides by one and yields nothing at all
+    // when the source is shorter than n. Both reject n < 1, unlike take/drop.
+    chunks(chunkSize) {
+      const rec = iterOf(this);
+      const n = toLimit(chunkSize);
+      if (n < 1 || n === Infinity) throw new RangeError("chunkSize must be a positive integer");
+      return (function* () {
+        let buf = [];
+        for (const v of asIterable(rec)) {
+          buf.push(v);
+          if (buf.length === n) {
+            yield buf;
+            buf = [];
+          }
+        }
+        if (buf.length > 0) yield buf;
+      })();
+    },
+    windows(windowSize) {
+      const rec = iterOf(this);
+      const n = toLimit(windowSize);
+      if (n < 1 || n === Infinity) throw new RangeError("windowSize must be a positive integer");
+      return (function* () {
+        const buf = [];
+        for (const v of asIterable(rec)) {
+          buf.push(v);
+          if (buf.length > n) buf.shift();
+          if (buf.length === n) yield buf.slice();
+        }
+      })();
+    },
+    // iterator-includes: SameValueZero, so NaN is found and -0 matches +0.
+    includes(searchElement) {
+      const rec = iterOf(this);
+      for (const v of asIterable(rec)) {
+        if (v === searchElement || (Number.isNaN(v) && Number.isNaN(searchElement))) return true;
+      }
+      return false;
+    },
+    // iterator-join: like Array.prototype.join — default separator ",", and
+    // null/undefined elements become the empty string.
+    join(separator) {
+      const rec = iterOf(this);
+      const sep = separator === undefined ? "," : String(separator);
+      let out = "";
+      let first = true;
+      for (const v of asIterable(rec)) {
+        if (!first) out += sep;
+        first = false;
+        if (v !== null && v !== undefined) out += String(v);
+      }
+      return out;
+    },
+  };
+  // `chunks` is written out literally as the matrix anchor for the Stage 3 additions
+  // (chunks/windows/includes/join), which install even where the ES2025 helpers are
+  // already native. Every name is still guarded individually.
+  if (typeof Iterator.prototype.chunks !== "function") {
+    defBuiltin(IteratorProto, "chunks", protoHelpers.chunks);
+  }
+  for (const name of Object.keys(protoHelpers)) {
+    if (name !== "chunks" && typeof IteratorProto[name] !== "function") {
+      defBuiltin(IteratorProto, name, protoHelpers[name]);
+    }
+  }
+
+  // Iterator.from: wraps an iterable OR a bare iterator-like object. An object that
+  // already inherits from %IteratorPrototype% is returned AS IS.
+  if (typeof Iterator.from !== "function") {
+    defBuiltin(Iterator, "from", function from(O) {
+      if (typeof O === "string") {
+        return (function* () {
+          yield* O;
+        })();
+      }
+      iterOf(O);
+      const method = O[Symbol.iterator];
+      let rec;
+      if (typeof method === "function") {
+        rec = method.call(O);
+        if (IteratorProto.isPrototypeOf(rec)) return rec;
+      } else {
+        if (typeof O.next !== "function") throw new TypeError("not iterable and has no next");
+        if (IteratorProto.isPrototypeOf(O)) return O;
+        rec = O;
+      }
+      return (function* () {
+        yield* asIterable(rec);
+      })();
+    });
+  }
+
+  // Iterator.concat (Stage 4, native only on Node 26+): each argument must be
+  // iterable, and each one's Symbol.iterator is called LAZILY, only when the
+  // previous source is exhausted.
+  if (typeof Iterator.concat !== "function") {
+    defBuiltin(Iterator, "concat", function concat(...items) {
+      for (const it of items) {
+        if (it === null || it === undefined || typeof it[Symbol.iterator] !== "function") {
+          throw new TypeError("Iterator.concat arguments must be iterable");
+        }
+      }
+      return (function* () {
+        for (const it of items) yield* it;
+      })();
+    });
+  }
+
+  // Iterator.zip / Iterator.zipKeyed (Stage 4, proposal-joint-iteration — in no
+  // engine). zipKeyed is the ITERATOR twin of Promise.allKeyed: same own-enumerable
+  // key treatment, same dictionary-in/dictionary-out shape. `mode` selects what
+  // happens on unequal lengths: "shortest" (default) stops at the first exhausted
+  // source, "longest" pads with `padding`/undefined, "strict" throws.
+  const zipMode = (options) => {
+    if (options === undefined) return { mode: "shortest", padding: undefined };
+    if (options === null || typeof options !== "object") {
+      throw new TypeError("options must be an object");
+    }
+    const mode = options.mode === undefined ? "shortest" : options.mode;
+    if (mode !== "shortest" && mode !== "longest" && mode !== "strict") {
+      throw new TypeError('mode must be "shortest", "longest", or "strict"');
+    }
+    return { mode, padding: options.padding };
+  };
+  if (typeof Iterator.zip !== "function") {
+    defBuiltin(Iterator, "zip", function zip(iterables) {
+      if (iterables === null || iterables === undefined || typeof iterables[Symbol.iterator] !== "function") {
+        throw new TypeError("Iterator.zip requires an iterable of iterables");
+      }
+      const { mode, padding } = zipMode(arguments.length > 1 ? arguments[1] : undefined);
+      const sources = [...iterables].map((it) => {
+        if (it === null || it === undefined || typeof it[Symbol.iterator] !== "function") {
+          throw new TypeError("Iterator.zip sources must be iterable");
+        }
+        return it[Symbol.iterator]();
+      });
+      const pads = padding === undefined ? [] : [...padding];
+      return (function* () {
+        const live = sources.map(() => true);
+        while (true) {
+          const row = [];
+          let anyLive = false;
+          let anyDone = false;
+          for (let i = 0; i < sources.length; i++) {
+            if (!live[i]) {
+              row.push(pads[i]);
+              anyDone = true;
+              continue;
+            }
+            const r = sources[i].next();
+            if (r.done) {
+              live[i] = false;
+              anyDone = true;
+              row.push(pads[i]);
+            } else {
+              anyLive = true;
+              row.push(r.value);
+            }
+          }
+          if (sources.length === 0) return;
+          if (mode === "shortest" && anyDone) return;
+          if (mode === "strict" && anyDone) {
+            if (!anyLive) return;
+            throw new TypeError("Iterator.zip strict mode requires equal-length inputs");
+          }
+          if (mode === "longest" && !anyLive) return;
+          yield row;
+        }
+      })();
+    });
+  }
+  if (typeof Iterator.zipKeyed !== "function") {
+    defBuiltin(Iterator, "zipKeyed", function zipKeyed(iterables) {
+      iterOf(iterables);
+      const { mode, padding } = zipMode(arguments.length > 1 ? arguments[1] : undefined);
+      // Own ENUMERABLE keys including symbols, matching Promise.allKeyed.
+      const keys = Reflect.ownKeys(iterables).filter((k) => {
+        const d = Reflect.getOwnPropertyDescriptor(iterables, k);
+        return d !== undefined && d.enumerable;
+      });
+      const sources = keys.map((k) => {
+        const it = iterables[k];
+        if (it === null || it === undefined || typeof it[Symbol.iterator] !== "function") {
+          throw new TypeError("Iterator.zipKeyed sources must be iterable");
+        }
+        return it[Symbol.iterator]();
+      });
+      const padFor = (k) =>
+        padding === null || padding === undefined ? undefined : padding[k];
+      return (function* () {
+        const live = sources.map(() => true);
+        while (true) {
+          if (sources.length === 0) return;
+          const row = Object.create(null);
+          let anyLive = false;
+          let anyDone = false;
+          for (let i = 0; i < sources.length; i++) {
+            if (!live[i]) {
+              row[keys[i]] = padFor(keys[i]);
+              anyDone = true;
+              continue;
+            }
+            const r = sources[i].next();
+            if (r.done) {
+              live[i] = false;
+              anyDone = true;
+              row[keys[i]] = padFor(keys[i]);
+            } else {
+              anyLive = true;
+              row[keys[i]] = r.value;
+            }
+          }
+          if (mode === "shortest" && anyDone) return;
+          if (mode === "strict" && anyDone) {
+            if (!anyLive) return;
+            throw new TypeError("Iterator.zipKeyed strict mode requires equal-length inputs");
+          }
+          if (mode === "longest" && !anyLive) return;
+          yield row;
+        }
+      })();
+    });
+  }
+}
+
+// ── Symbol.metadata (TC39 Stage 3, decorator metadata; in no engine) ──
+// Only the well-known symbol is provided. POPULATING `klass[Symbol.metadata]` is
+// the decorator transform's job, and the spec's own answer for an undecorated class
+// is `undefined` — so defining the symbol makes `Symbol.metadata` referenceable
+// without inventing metadata that isn't there.
+function installSymbolMetadata() {
+  if (typeof Symbol.metadata === "symbol") return;
+  Object.defineProperty(Symbol, "metadata", {
+    value: Symbol("Symbol.metadata"),
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+}
+
+// Shared `def`: non-enumerable + writable + configurable, matching how the engine
+// defines its own builtins (and this file's enumeration-invisibility contract).
+// EVERY installer below guards per-METHOD on its own feature-detect, so a runtime
+// that ships some of a family natively keeps those and only gains the rest — no
+// polyfill ever overwrites a native implementation.
+function defBuiltin(target, name, value) {
+  Object.defineProperty(target, name, {
+    value,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+// ── New Set methods (TC39 Stage 4 / ES2025; native Node 22+, absent 18.19–21.x) ──
+// The subtlety that makes these more than one-liners is that the ARGUMENT is not
+// required to be a Set: the spec defines a "set-like" protocol (a `size` number
+// plus callable `has` and `keys`), and reads it through GetSetRecord in a fixed
+// order with specific error types. A naive `new Set(other)` implementation would
+// accept the wrong inputs, reject the right ones, and iterate in the wrong order.
+function installSetMethods() {
+  // Real brand check: the `size` getter throws for anything without [[SetData]],
+  // which is exactly the receiver check the spec performs first.
+  const sizeGetter = Object.getOwnPropertyDescriptor(Set.prototype, "size").get;
+  const requireSet = (o) => {
+    sizeGetter.call(o);
+  };
+  // GetSetRecord: the argument-validation order is observable, so it is preserved
+  // exactly — size read and coerced first (NaN is a TypeError, negative a
+  // RangeError), then `has`, then `keys`.
+  const setRecord = (obj) => {
+    if (obj === null || (typeof obj !== "object" && typeof obj !== "function")) {
+      throw new TypeError("argument is not an object");
+    }
+    const numSize = Number(obj.size);
+    if (Number.isNaN(numSize)) throw new TypeError("size is NaN");
+    const intSize = Math.trunc(numSize) || 0;
+    if (intSize < 0) throw new RangeError("size is negative");
+    const has = obj.has;
+    if (typeof has !== "function") throw new TypeError("has is not callable");
+    const keys = obj.keys;
+    if (typeof keys !== "function") throw new TypeError("keys is not callable");
+    return { obj, size: intSize, has, keys };
+  };
+  // -0 is normalized to +0 on the way into a result set, matching SameValueZero.
+  const norm = (v) => (v === 0 ? 0 : v);
+  const otherKeys = (rec) => rec.keys.call(rec.obj);
+
+  const methods = {
+    union(other) {
+      requireSet(this);
+      const rec = setRecord(other);
+      const out = new Set(this);
+      for (const k of otherKeys(rec)) out.add(norm(k));
+      return out;
+    },
+    intersection(other) {
+      requireSet(this);
+      const rec = setRecord(other);
+      const out = new Set();
+      // Iterate the SMALLER side, but membership is always tested against the
+      // other — the spec picks by size for complexity, and the observable
+      // difference is which side's iteration order the result follows.
+      if (this.size <= rec.size) {
+        for (const k of this) if (rec.has.call(rec.obj, k)) out.add(k);
+      } else {
+        for (const k of otherKeys(rec)) if (this.has(k)) out.add(norm(k));
+      }
+      return out;
+    },
+    difference(other) {
+      requireSet(this);
+      const rec = setRecord(other);
+      const out = new Set(this);
+      if (this.size <= rec.size) {
+        for (const k of this) if (rec.has.call(rec.obj, k)) out.delete(k);
+      } else {
+        for (const k of otherKeys(rec)) out.delete(norm(k));
+      }
+      return out;
+    },
+    symmetricDifference(other) {
+      requireSet(this);
+      const rec = setRecord(other);
+      const out = new Set(this);
+      for (const k of otherKeys(rec)) {
+        const key = norm(k);
+        if (this.has(key)) out.delete(key);
+        else out.add(key);
+      }
+      return out;
+    },
+    isSubsetOf(other) {
+      requireSet(this);
+      const rec = setRecord(other);
+      if (this.size > rec.size) return false;
+      for (const k of this) if (!rec.has.call(rec.obj, k)) return false;
+      return true;
+    },
+    isSupersetOf(other) {
+      requireSet(this);
+      const rec = setRecord(other);
+      if (this.size < rec.size) return false;
+      for (const k of otherKeys(rec)) if (!this.has(norm(k))) return false;
+      return true;
+    },
+    isDisjointFrom(other) {
+      requireSet(this);
+      const rec = setRecord(other);
+      if (this.size <= rec.size) {
+        for (const k of this) if (rec.has.call(rec.obj, k)) return false;
+      } else {
+        for (const k of otherKeys(rec)) if (this.has(norm(k))) return false;
+      }
+      return true;
+    },
+  };
+  // `union` is written out literally as the feature-matrix row's detect anchor; the
+  // rest loop, and every method is still guarded on its own so a runtime shipping
+  // only part of the family keeps what it has.
+  if (typeof Set.prototype.union !== "function") defBuiltin(Set.prototype, "union", methods.union);
+  for (const name of Object.keys(methods)) {
+    if (name !== "union" && typeof Set.prototype[name] !== "function") {
+      defBuiltin(Set.prototype, name, methods[name]);
+    }
+  }
+}
+
+// ── Array.fromAsync (TC39 Stage 4 / ES2025; native Node 22+, absent 18.19–21.x) ──
+// Async-iterable OR sync-iterable OR array-like, in that precedence, with an
+// optional mapfn whose result is AWAITED. `this` is the constructor when callable,
+// so a subclass drives the result — matching Array.from.
+function installArrayFromAsync() {
+  if (typeof Array.fromAsync === "function") return;
+  // mapfn/thisArg ride `arguments`: they are optional, so native length is 1.
+  defBuiltin(Array, "fromAsync", async function fromAsync(asyncItems) {
+    const mapfn = arguments.length > 1 ? arguments[1] : undefined;
+    const thisArg = arguments.length > 2 ? arguments[2] : undefined;
+    const C = typeof this === "function" ? this : Array;
+    if (mapfn !== undefined && typeof mapfn !== "function") {
+      throw new TypeError("mapfn is not a function");
+    }
+    const usingAsync = asyncItems != null && asyncItems[Symbol.asyncIterator] !== undefined;
+    const usingSync = asyncItems != null && asyncItems[Symbol.iterator] !== undefined;
+    if (usingAsync || usingSync) {
+      const out = new C();
+      let i = 0;
+      // A sync iterator's YIELDED VALUES are awaited too, which is what makes
+      // `Array.fromAsync([promise])` resolve rather than collect promises.
+      for await (const v of asyncItems) {
+        out[i] = mapfn === undefined ? v : await mapfn.call(thisArg, v, i);
+        i++;
+      }
+      out.length = i;
+      return out;
+    }
+    // Array-like fallback: read `length`, then each index, awaiting both the
+    // element and the mapfn result.
+    const arrayLike = Object(asyncItems);
+    const len = Math.trunc(Number(arrayLike.length)) || 0;
+    const out = new C(len);
+    for (let i = 0; i < len; i++) {
+      const v = await arrayLike[i];
+      out[i] = mapfn === undefined ? v : await mapfn.call(thisArg, v, i);
+    }
+    out.length = len;
+    return out;
+  });
+}
+
+// ── Map/WeakMap getOrInsert + getOrInsertComputed ──
+//    (TC39 Stage 4 / ES2026 "upsert"; native Node 26+, absent below)
+// Shipped under the name getOrInsert, NOT the proposal's original `upsert` — no
+// runtime has ever exposed `upsert`, so only these two names are installed.
+// getOrInsertComputed calls the callback ONLY on a miss, and re-reads the map
+// afterwards because the callback can insert the same key reentrantly.
+function installMapGetOrInsert() {
+  // `Map.prototype.getOrInsert` is spelled out below as the feature-matrix row's
+  // detect anchor; WeakMap rides the same guards through the loop.
+  for (const Ctor of [Map, WeakMap]) {
+    if (Ctor === Map && typeof Map.prototype.getOrInsert === "function"
+        && typeof Map.prototype.getOrInsertComputed === "function") {
+      continue;
+    }
+    if (typeof Ctor.prototype.getOrInsert !== "function") {
+      defBuiltin(Ctor.prototype, "getOrInsert", function getOrInsert(key, value) {
+        if (this.has(key)) return this.get(key);
+        this.set(key, value);
+        return value;
+      });
+    }
+    if (typeof Ctor.prototype.getOrInsertComputed !== "function") {
+      defBuiltin(
+        Ctor.prototype,
+        "getOrInsertComputed",
+        function getOrInsertComputed(key, callbackfn) {
+          if (typeof callbackfn !== "function") {
+            throw new TypeError("callbackfn is not a function");
+          }
+          if (this.has(key)) return this.get(key);
+          const value = callbackfn(key);
+          // The callback may have inserted `key` itself; the spec's final write
+          // wins, so set unconditionally rather than re-checking `has`.
+          this.set(key, value);
+          return value;
+        },
+      );
+    }
+  }
+}
+
+// ── Math.sumPrecise (TC39 Stage 3; in no Node — bun ships it, so bun is the
+//    differential oracle used to verify this) ──
+// Returns the CORRECTLY ROUNDED sum, not a left-to-right accumulation, so naive
+// `reduce((a, b) => a + b)` is wrong: it loses low bits at every step. This is
+// Shewchuk's exact-expansion algorithm — maintain a set of non-overlapping partial
+// sums whose total is exact, then round once at the end.
+function installMathSumPrecise() {
+  if (typeof Math.sumPrecise === "function") return;
+  defBuiltin(Math, "sumPrecise", function sumPrecise(items) {
+    const partials = [];
+    // Power-of-two factor the expansion is held in, so an intermediate overflow
+    // can be escaped without losing exactness. Undone before returning.
+    let scale = 1;
+    let count = 0;
+    let hasNaN = false;
+    let posInf = false;
+    let negInf = false;
+    for (const x of items) {
+      count++;
+      if (typeof x !== "number") throw new TypeError("Math.sumPrecise accepts only Numbers");
+      if (Number.isNaN(x)) {
+        hasNaN = true;
+        continue;
+      }
+      if (x === Infinity) {
+        posInf = true;
+        continue;
+      }
+      if (x === -Infinity) {
+        negInf = true;
+        continue;
+      }
+      if (hasNaN || (posInf && negInf)) continue;
+      // Two-sum each new value against every existing partial, keeping the exact
+      // low-order remainders as new partials.
+      //
+      // OVERFLOW: two partials can each be near MAX_VALUE while the TRUE sum is
+      // finite (e.g. [1e308, 1e308, -1e308, -1e308] sums to 0), and a plain
+      // expansion returns NaN there — caught by differential-testing against
+      // bun's native implementation. When an intermediate goes non-finite,
+      // HALVE the whole expansion and the incoming value and retry, tracking the
+      // power-of-two `scale` to undo at the end. Halving a double is exact until
+      // it goes subnormal, and a partial that subnormalizes here was already
+      // ~2^-1074 relative to a ~2^1023 magnitude — far below the ULP of any
+      // representable result, so no bit that could affect the rounding is lost.
+      let xi = x * scale;
+      for (;;) {
+        let used = 0;
+        let overflowed = false;
+        for (let j = 0; j < partials.length; j++) {
+          let y = partials[j];
+          if (Math.abs(xi) < Math.abs(y)) {
+            const t = xi;
+            xi = y;
+            y = t;
+          }
+          const hi = xi + y;
+          if (!Number.isFinite(hi)) {
+            overflowed = true;
+            break;
+          }
+          const lo = y - (hi - xi);
+          if (lo !== 0) partials[used++] = lo;
+          xi = hi;
+        }
+        if (!overflowed) {
+          partials.length = used;
+          partials.push(xi);
+          break;
+        }
+        // Rescale everything down by 2 and start this value over.
+        for (let j = 0; j < partials.length; j++) partials[j] *= 0.5;
+        scale *= 0.5;
+        xi = x * scale;
+      }
+    }
+    if (hasNaN) return NaN;
+    if (posInf && negInf) return NaN;
+    if (posInf) return Infinity;
+    if (negInf) return -Infinity;
+    // The additive identity here is -0: summing nothing, or only -0s, gives -0.
+    if (count === 0 || partials.length === 0) return -0;
+    // Add smallest-to-largest so the single final rounding is correct, then undo
+    // the scale. Dividing by `scale` (a power of two) reintroduces no error.
+    let total = 0;
+    for (let j = partials.length - 1; j >= 0; j--) total += partials[j];
+    return total / scale;
+  });
 }
 
 // ── Shipped-standard ECMAScript builtins missing below their Node line ──

--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -11,11 +11,17 @@
 //
 // All polyfills feature-detect and bow out if the global is already present.
 //
-// Node 22.15+ (our floor) already has: navigator, navigator.locks,
-// navigator.hardwareConcurrency, WebSocket. No polyfills needed.
+// nub's SUPPORT floor is Node 18.19; 22.15 is the FAST-TIER boundary, NOT the
+// floor. Judging "do we need a polyfill?" against 22.15 silently skips the
+// 18.19–21.x compat tier — which is how Promise.withResolvers (native since Node
+// 22.0) went unpolyfilled here until 2026-07, on a "native on our floor" verdict
+// that was written when the floor really was 22.15.
 //
-// Node 24+ adds: URLPattern, RegExp.escape, Error.isError, Promise.try.
-// We polyfill those on Node 22.x only.
+// Node 22.15+ already has: navigator, navigator.locks,
+// navigator.hardwareConcurrency, WebSocket.
+//
+// Node 22+ adds: Promise.withResolvers. Node 24+ adds: URLPattern,
+// RegExp.escape, Error.isError, Promise.try. Each is polyfilled below its line.
 //
 // No Node version ships: Temporal, reportError, browser-shape Worker,
 // Promise.allKeyed / Promise.allSettledKeyed.
@@ -268,6 +274,7 @@ function installSyncPolyfills(preloaded) {
   installUint8ArrayBase64();
   installDisposableStacks();
   installKeyedPromiseCombinators();
+  installPromiseWithResolvers();
 }
 
 // ── Uint8Array base64/hex (TC39 Stage 3; native Node 25+, absent below) ──
@@ -823,27 +830,49 @@ function installDisposableStacks() {
 //
 // Both are installed non-enumerable to match how the engine will define them
 // (and this file's additive contract: invisible to enumeration).
+// NewPromiseCapability(C), shared by the keyed combinators and withResolvers.
+// Every caller reaches it through a spec step marked `?`, so a non-constructor
+// `this` throws SYNCHRONOUSLY — there is no promise yet to reject.
+function newPromiseCapability(C, name) {
+  if (typeof C !== "function") {
+    throw new TypeError(`Promise.${name} called on a non-constructor`);
+  }
+  let resolve;
+  let reject;
+  const promise = new C((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  if (typeof resolve !== "function" || typeof reject !== "function") {
+    throw new TypeError("promise capability functions are not callable");
+  }
+  return { promise, resolve, reject };
+}
+
+// ── Promise.withResolvers (TC39 Stage 4 / ES2024; native on Node 22+) ──
+// Absent on the whole 18.19–21.x compat tier with no polyfill until now. The
+// 2026-05 candidates survey marked it "No action — native on Nub's floor", which
+// was true when the floor WAS 22.15; the verdict was never revisited after the
+// floor moved down to 18.19, so the gap survived silently. Spec: a capability
+// plus a %Object.prototype% record of {promise, resolve, reject}, generic on
+// `this` so a Promise subclass drives the promise.
+function installPromiseWithResolvers() {
+  if (typeof Promise.withResolvers === "function") return;
+  Object.defineProperty(Promise, "withResolvers", {
+    value: function withResolvers() {
+      const { promise, resolve, reject } = newPromiseCapability(this, "withResolvers");
+      return { promise, resolve, reject };
+    },
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
 function installKeyedPromiseCombinators() {
   const needAll = typeof Promise.allKeyed !== "function";
   const needAllSettled = typeof Promise.allSettledKeyed !== "function";
   if (!needAll && !needAllSettled) return;
-
-  // NewPromiseCapability(C).
-  const newCapability = (C, name) => {
-    if (typeof C !== "function") {
-      throw new TypeError(`Promise.${name} called on a non-constructor`);
-    }
-    let resolve;
-    let reject;
-    const promise = new C((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
-    if (typeof resolve !== "function" || typeof reject !== "function") {
-      throw new TypeError("promise capability functions are not callable");
-    }
-    return { promise, resolve, reject };
-  };
 
   // CreateKeyedPromiseCombinatorResultObject. Plain assignment IS
   // CreateDataPropertyOrThrow here: with no prototype there is no inherited
@@ -893,7 +922,7 @@ function installKeyedPromiseCombinators() {
   const install = (name, isSettled) => {
     const fn = function (promises) {
       const ctor = this;
-      const capability = newCapability(ctor, name);
+      const capability = newPromiseCapability(ctor, name);
       try {
         const promiseResolve = ctor.resolve;
         if (typeof promiseResolve !== "function") {

--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -28,6 +28,15 @@
 // These need polyfills on all supported versions. (Temporal is a lazy global
 // installed by the preload entry, NOT here — see preload.cjs / preload.mjs.)
 
+// STRICT MODE IS LOAD-BEARING, not hygiene. In sloppy mode a method invoked as
+// `fn.call(null)` has its `this` COERCED to the global object, so every
+// RequireObjectCoercible / ToObject(this) check a polyfilled method makes would
+// silently pass where the real builtin throws a TypeError — verified against native
+// for both String.prototype.isWellFormed and Array.prototype.toSorted. Strict mode
+// leaves `this` as null and restores the spec behavior for the whole file at once,
+// instead of guarding method by method.
+"use strict";
+
 const { createRequire } = require("node:module");
 const __require = createRequire(__filename);
 
@@ -65,10 +74,10 @@ function installSyncPolyfills(preloaded) {
   // Neutralization is idempotent — a descendant re-running this preload deletes an
   // already-absent or re-installed `localStorage` again, which is harmless. The
   // property is a configurable own accessor (the define that replaced it before
-  // already proved that), so `delete` removes it cleanly. This file is sloppy-mode
-  // CJS, where `delete` never throws (a non-configurable property would just make
-  // it return false and leave Node's getter in place); the try/catch is belt-and-
-  // suspenders for any future strict/ESM move.
+  // already proved that), so `delete` removes it cleanly. This file is strict-mode
+  // CJS. The file is now STRICT (see the header), so `delete` on a
+  // non-configurable property THROWS rather than returning false — which is exactly
+  // what the try/catch below was already written to absorb.
   if (process.env.__NUB_NEUTRALIZE_LOCALSTORAGE) {
     try {
       delete globalThis.localStorage;
@@ -619,7 +628,10 @@ function installIteratorSurface() {
   };
   if (typeof Iterator.zip !== "function") {
     defBuiltin(Iterator, "zip", function zip(iterables) {
-      if (iterables === null || iterables === undefined || typeof iterables[Symbol.iterator] !== "function") {
+      // Step 1 is an OBJECT check, which precedes any iterability test — so a string
+      // primitive is a TypeError even though strings are iterable.
+      iterOf(iterables);
+      if (typeof iterables[Symbol.iterator] !== "function") {
         throw new TypeError("Iterator.zip requires an iterable of iterables");
       }
       const { mode, padding } = zipMode(arguments.length > 1 ? arguments[1] : undefined);
@@ -629,11 +641,47 @@ function installIteratorSurface() {
         }
         return it[Symbol.iterator]();
       });
-      const pads = padding === undefined ? [] : [...padding];
+      // Padding is stepped EXACTLY once per source and then closed, never drained:
+      // spreading it would hang on an infinite padding iterator and over-consume a
+      // finite one.
+      const pads = [];
+      if (padding !== undefined) {
+        if (padding === null || typeof padding[Symbol.iterator] !== "function") {
+          throw new TypeError("padding must be iterable");
+        }
+        const padIter = padding[Symbol.iterator]();
+        for (let i = 0; i < sources.length; i++) {
+          const r = padIter.next();
+          if (r.done) break;
+          pads.push(r.value);
+        }
+        if (typeof padIter.return === "function") {
+          try {
+            padIter.return();
+          } catch { /* closing must not mask the caller's completion */ }
+        }
+      }
       return (function* () {
+        if (sources.length === 0) return;
         const live = sources.map(() => true);
         while (true) {
           const row = [];
+          if (mode === "strict") {
+            // Strict requires every source to end on the SAME round, and must throw
+            // AT the diverging index — without stepping the sources after it.
+            let firstDone;
+            for (let i = 0; i < sources.length; i++) {
+              const r = sources[i].next();
+              if (i === 0) firstDone = !!r.done;
+              else if (!!r.done !== firstDone) {
+                throw new TypeError("Iterator.zip strict mode requires equal-length inputs");
+              }
+              if (!r.done) row.push(r.value);
+            }
+            if (firstDone) return;
+            yield row;
+            continue;
+          }
           let anyLive = false;
           let anyDone = false;
           for (let i = 0; i < sources.length; i++) {
@@ -652,12 +700,7 @@ function installIteratorSurface() {
               row.push(r.value);
             }
           }
-          if (sources.length === 0) return;
           if (mode === "shortest" && anyDone) return;
-          if (mode === "strict" && anyDone) {
-            if (!anyLive) return;
-            throw new TypeError("Iterator.zip strict mode requires equal-length inputs");
-          }
           if (mode === "longest" && !anyLive) return;
           yield row;
         }
@@ -892,7 +935,9 @@ function installArrayFromAsync() {
     // Array-like fallback: read `length`, then each index, awaiting both the
     // element and the mapfn result.
     const arrayLike = Object(asyncItems);
-    const len = Math.trunc(Number(arrayLike.length)) || 0;
+    // ToLength clamps to [0, 2^53-1], so a NEGATIVE length yields an empty result
+    // rather than the RangeError `new C(-5)` would throw.
+    const len = Math.min(Math.max(Math.trunc(Number(arrayLike.length)) || 0, 0), 2 ** 53 - 1);
     const out = new C(len);
     for (let i = 0; i < len; i++) {
       const v = await arrayLike[i];
@@ -958,6 +1003,9 @@ function installMathSumPrecise() {
     // can be escaped without losing exactness. Undone before returning.
     let scale = 1;
     let count = 0;
+    // Tracks whether every finite contribution was -0, which the spec keeps in a
+    // ~minus-zero~ state and must preserve in the result.
+    let allMinusZero = true;
     let hasNaN = false;
     let posInf = false;
     let negInf = false;
@@ -974,8 +1022,10 @@ function installMathSumPrecise() {
       }
       if (x === -Infinity) {
         negInf = true;
+        allMinusZero = false;
         continue;
       }
+      if (!Object.is(x, -0)) allMinusZero = false;
       if (hasNaN || (posInf && negInf)) continue;
       // Two-sum each new value against every existing partial, keeping the exact
       // low-order remainders as new partials.
@@ -1025,7 +1075,10 @@ function installMathSumPrecise() {
     if (posInf) return Infinity;
     if (negInf) return -Infinity;
     // The additive identity here is -0: summing nothing, or only -0s, gives -0.
-    if (count === 0 || partials.length === 0) return -0;
+    // The all-(-0) case must be caught HERE, because the final reduction seeds
+    // `total` with the literal +0 and `0 + -0` is +0, which would collapse the sign
+    // (bun, the oracle, returns -0 for [-0] and [-0, -0]).
+    if (count === 0 || partials.length === 0 || allMinusZero) return -0;
     // Add smallest-to-largest so the single final rounding is correct, then undo
     // the scale. Dividing by `scale` (a power of two) reintroduces no error.
     let total = 0;
@@ -1079,13 +1132,22 @@ function installFloorBuiltins() {
   // point, so anything left in the 0xD800–0xDFFF range is unpaired.
   if (typeof String.prototype.isWellFormed !== "function") {
     const loneSurrogate = /[\uD800-\uDFFF]/u;
+    // Spec step 1 is RequireObjectCoercible, so a null/undefined receiver must
+    // THROW rather than stringify — a bare `String(this)` silently succeeds, which
+    // native does not (verified: isWellFormed.call(null) is a TypeError).
+    const thisStr = (v) => {
+      if (v === null || v === undefined) {
+        throw new TypeError("String.prototype method called on null or undefined");
+      }
+      return String(v);
+    };
     def(String.prototype, "isWellFormed", function isWellFormed() {
-      return !loneSurrogate.test(String(this));
+      return !loneSurrogate.test(thisStr(this));
     });
     def(String.prototype, "toWellFormed", function toWellFormed() {
       // Replace each lone surrogate with U+FFFD. The `u` flag makes a well-formed
       // pair a single match unit, so only unpaired units are hit.
-      return String(this).replace(/[\uD800-\uDFFF]/gu, "�");
+      return thisStr(this).replace(/[\uD800-\uDFFF]/gu, "�");
     });
   }
 
@@ -1141,7 +1203,11 @@ function installFloorBuiltins() {
     });
     def(Array.prototype, "toSpliced", function toSpliced(start, skipCount, ...items) {
       const arr = Array.from(this);
-      arr.splice(start, skipCount, ...items);
+      // An OMITTED deleteCount deletes through the end, but a declared parameter
+      // forwards an explicit `undefined`, which splice coerces to 0. Branch on the
+      // real argument count so `toSpliced(1)` truncates the way native does.
+      if (arguments.length <= 1) arr.splice(start);
+      else arr.splice(start, skipCount, ...items);
       return arr;
     });
     // `with` is a reserved word, so a named function EXPRESSION is a SyntaxError.
@@ -1205,13 +1271,19 @@ function installFloorBuiltins() {
         return true;
       }
     };
-    const transferImpl = (buf, newLength) => {
+    const transferImpl = (buf, newLength, fixedLength) => {
       if (isDetached(buf)) throw new TypeError("ArrayBuffer is detached");
       const oldLen = buf.byteLength;
       const len = newLength === undefined ? oldLen : Math.trunc(Number(newLength)) || 0;
       if (len < 0) throw new RangeError("invalid length");
       // Copy BEFORE detaching; the copy is truncated or zero-padded to `len`.
-      const out = new ArrayBuffer(len);
+      // `transfer` PRESERVES a resizable source's resizability while
+      // `transferToFixedLength` always yields a fixed buffer — the two entry points
+      // genuinely differ, verified against native (resizable=true vs false).
+      const keepResizable = !fixedLength && buf.resizable === true;
+      const out = keepResizable
+        ? new ArrayBuffer(len, { maxByteLength: buf.maxByteLength })
+        : new ArrayBuffer(len);
       new Uint8Array(out).set(new Uint8Array(buf, 0, Math.min(oldLen, len)));
       // Detach the source. The clone takes ownership of the original memory and
       // is immediately discarded, so this moves rather than copies.
@@ -1220,10 +1292,10 @@ function installFloorBuiltins() {
     };
     // newLength is optional, so it rides `arguments`: native length is 0 for both.
     def(ArrayBuffer.prototype, "transfer", function transfer() {
-      return transferImpl(this, arguments.length > 0 ? arguments[0] : undefined);
+      return transferImpl(this, arguments.length > 0 ? arguments[0] : undefined, false);
     });
     def(ArrayBuffer.prototype, "transferToFixedLength", function transferToFixedLength() {
-      return transferImpl(this, arguments.length > 0 ? arguments[0] : undefined);
+      return transferImpl(this, arguments.length > 0 ? arguments[0] : undefined, true);
     });
     Object.defineProperty(ArrayBuffer.prototype, "detached", {
       get: function detached() {

--- a/runtime/polyfills.cjs
+++ b/runtime/polyfills.cjs
@@ -17,7 +17,8 @@
 // Node 24+ adds: URLPattern, RegExp.escape, Error.isError, Promise.try.
 // We polyfill those on Node 22.x only.
 //
-// No Node version ships: Temporal, reportError, browser-shape Worker.
+// No Node version ships: Temporal, reportError, browser-shape Worker,
+// Promise.allKeyed / Promise.allSettledKeyed.
 // These need polyfills on all supported versions. (Temporal is a lazy global
 // installed by the preload entry, NOT here — see preload.cjs / preload.mjs.)
 
@@ -266,6 +267,7 @@ function installSyncPolyfills(preloaded) {
 
   installUint8ArrayBase64();
   installDisposableStacks();
+  installKeyedPromiseCombinators();
 }
 
 // ── Uint8Array base64/hex (TC39 Stage 3; native Node 25+, absent below) ──
@@ -797,6 +799,131 @@ function installDisposableStacks() {
     });
     defGlobal("AsyncDisposableStack", AsyncDisposableStack);
   }
+}
+
+// ── Promise.allKeyed / Promise.allSettledKeyed (TC39 "await dictionary",
+//    Stage 3) ──
+// Spec-faithful port of PerformPromiseAllKeyed. No engine and no Node ships
+// these yet, so unlike the rest of this file the feature-detect is not a version
+// gate — it is the step-aside for whenever V8 does, the same posture as Temporal.
+// Four observable details are load-bearing and easy to get wrong:
+//
+//   1. The result object has a NULL prototype (OrdinaryObjectCreate(null)), so
+//      `result.hasOwnProperty` is undefined and util.inspect prints it as
+//      `[Object: null prototype]`. Destructuring — the entire point of the API —
+//      is unaffected.
+//   2. Keys are the argument's own ENUMERABLE keys in [[OwnPropertyKeys]] order,
+//      symbols INCLUDED. That is the proposal's deliberate divergence from the
+//      userland precedents it replaces (bluebird's Promise.props, p-props), which
+//      follow Object.keys and silently drop symbol keys.
+//   3. A non-object argument and a non-callable `this.resolve` REJECT the
+//      returned promise; only a `this` that isn't a constructor throws
+//      synchronously (spec step 2's `?` vs steps 3 and 5).
+//   4. `this` is the constructor, so a Promise subclass drives the result.
+//
+// Both are installed non-enumerable to match how the engine will define them
+// (and this file's additive contract: invisible to enumeration).
+function installKeyedPromiseCombinators() {
+  const needAll = typeof Promise.allKeyed !== "function";
+  const needAllSettled = typeof Promise.allSettledKeyed !== "function";
+  if (!needAll && !needAllSettled) return;
+
+  // NewPromiseCapability(C).
+  const newCapability = (C, name) => {
+    if (typeof C !== "function") {
+      throw new TypeError(`Promise.${name} called on a non-constructor`);
+    }
+    let resolve;
+    let reject;
+    const promise = new C((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    if (typeof resolve !== "function" || typeof reject !== "function") {
+      throw new TypeError("promise capability functions are not callable");
+    }
+    return { promise, resolve, reject };
+  };
+
+  // CreateKeyedPromiseCombinatorResultObject. Plain assignment IS
+  // CreateDataPropertyOrThrow here: with no prototype there is no inherited
+  // setter to intercept (not even `__proto__`), and the keys came from
+  // [[OwnPropertyKeys]] so they are already distinct.
+  const resultObject = (entries) => {
+    const obj = Object.create(null);
+    for (let i = 0; i < entries.length; i++) obj[entries[i].key] = entries[i].value;
+    return obj;
+  };
+
+  // PerformPromiseAllKeyed. `remaining` starts at 1 and is decremented only once
+  // the loop is done, so a dictionary of already-settled promises cannot resolve
+  // the combinator before every key has been visited.
+  const perform = (isSettled, promises, ctor, capability, promiseResolve) => {
+    const entries = [];
+    const remaining = { value: 1 };
+    for (const key of Reflect.ownKeys(promises)) {
+      const desc = Reflect.getOwnPropertyDescriptor(promises, key);
+      if (desc === undefined || !desc.enumerable) continue;
+      const value = promises[key];
+      const index = entries.push({ key, value: undefined }) - 1;
+      const nextPromise = promiseResolve.call(ctor, value);
+      const alreadyCalled = { value: false };
+      const settle = (entryValue) => {
+        if (alreadyCalled.value) return;
+        alreadyCalled.value = true;
+        entries[index].value = entryValue;
+        remaining.value -= 1;
+        if (remaining.value === 0) capability.resolve(resultObject(entries));
+      };
+      remaining.value += 1;
+      // allKeyed: the first rejection rejects the whole combinator through the
+      // capability's own reject function. allSettledKeyed: the rejection is
+      // recorded, and its handler SHARES `alreadyCalled` with the fulfill
+      // handler, so exactly one of the pair counts even for a thenable that
+      // calls both.
+      nextPromise.then(
+        isSettled ? (v) => settle({ status: "fulfilled", value: v }) : settle,
+        isSettled ? (reason) => settle({ status: "rejected", reason }) : capability.reject,
+      );
+    }
+    remaining.value -= 1;
+    if (remaining.value === 0) capability.resolve(resultObject(entries));
+  };
+
+  const install = (name, isSettled) => {
+    const fn = function (promises) {
+      const ctor = this;
+      const capability = newCapability(ctor, name);
+      try {
+        const promiseResolve = ctor.resolve;
+        if (typeof promiseResolve !== "function") {
+          throw new TypeError("Promise resolve is not a function");
+        }
+        if (
+          promises === null ||
+          (typeof promises !== "object" && typeof promises !== "function")
+        ) {
+          throw new TypeError(`Promise.${name} argument must be an object`);
+        }
+        perform(isSettled, promises, ctor, capability, promiseResolve);
+      } catch (err) {
+        capability.reject(err);
+      }
+      return capability.promise;
+    };
+    // A builtin's `name` and `length` are observable; the anonymous function
+    // expression above gives length 1 but an empty name.
+    Object.defineProperty(fn, "name", { value: name, configurable: true });
+    Object.defineProperty(Promise, name, {
+      value: fn,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  };
+
+  if (needAll) install("allKeyed", false);
+  if (needAllSettled) install("allSettledKeyed", true);
 }
 
 // Load the two ESM side-effect modules — Web Locks (navigator.locks) and the

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -78,6 +78,7 @@ const route = new URLPattern({ pathname: "/u/:id" });
 const ws = new WebSocket("wss://api.example.com");
 const stream = new EventSource("https://api/stream");
 const { DatabaseSync } = require("node:sqlite");
+const { me, feed } = await Promise.allKeyed({ me: getMe(), feed: getFeed() });
 ```
 
 Two mechanisms do the work, picked per API: Nub either preloads a JS polyfill (feature-detected, so it steps aside the moment the native global appears) or injects the `--experimental-*` flag that an older Node hides the API behind. Once Node stabilizes an API, it's native and Nub does nothing.
@@ -91,6 +92,8 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`RegExp.escape`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape) | — | polyfilled below Node 24, native above |
 | [`Error.isError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError) | — | polyfilled below Node 24, native above |
 | [`Promise.try`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try) | — | polyfilled below Node 24, native above |
+| [`Promise.allKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
+| [`Promise.allSettledKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
 | [`Float16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array) | — | polyfilled below Node 24, native above |
 | [`navigator`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator) | — | backfilled below Node 21, native above |
 | [`navigator.locks`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) | — | polyfilled below Node 24.5, native above |

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -100,6 +100,16 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`ArrayBuffer.prototype.transfer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer) | — | polyfilled below Node 21, native above |
 | [`URL.parse`](https://developer.mozilla.org/en-US/docs/Web/API/URL/parse) | — | polyfilled below Node 22.1 (native from 20.19 on the 20.x line), native above |
 | [`Atomics.pause`](https://github.com/tc39/proposal-atomics-microwait) | — | polyfilled |
+| [`Set` methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/union) | — | polyfilled below Node 22, native above |
+| [`Array.fromAsync`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync) | — | polyfilled below Node 22, native above |
+| [`Iterator` helpers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) | — | polyfilled below Node 22, native above |
+| [`Iterator.concat`](https://github.com/tc39/proposal-iterator-sequencing) | — | polyfilled below Node 26, native above |
+| [`Map.getOrInsert`](https://github.com/tc39/proposal-upsert) | — | polyfilled below Node 26, native above |
+| [`Iterator.zip`](https://github.com/tc39/proposal-joint-iteration) | — | polyfilled |
+| [`Iterator.zipKeyed`](https://github.com/tc39/proposal-joint-iteration) | — | polyfilled |
+| [`Iterator.chunks`](https://github.com/tc39/proposal-iterator-chunking) | — | polyfilled |
+| [`Math.sumPrecise`](https://github.com/tc39/proposal-math-sum) | — | polyfilled |
+| [`Symbol.metadata`](https://github.com/tc39/proposal-decorator-metadata) | — | polyfilled |
 | [`Promise.allKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
 | [`Promise.allSettledKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
 | [`Float16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array) | — | polyfilled below Node 24, native above |

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -92,6 +92,7 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`RegExp.escape`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape) | — | polyfilled below Node 24, native above |
 | [`Error.isError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError) | — | polyfilled below Node 24, native above |
 | [`Promise.try`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try) | — | polyfilled below Node 24, native above |
+| [`Promise.withResolvers`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers) | — | polyfilled below Node 22, native above |
 | [`Promise.allKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
 | [`Promise.allSettledKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
 | [`Float16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array) | — | polyfilled below Node 24, native above |

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -93,6 +93,13 @@ The **minimum version** column is the lowest Node where the API works under Nub.
 | [`Error.isError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError) | — | polyfilled below Node 24, native above |
 | [`Promise.try`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try) | — | polyfilled below Node 24, native above |
 | [`Promise.withResolvers`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers) | — | polyfilled below Node 22, native above |
+| [`Object.groupBy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy) | — | polyfilled below Node 21, native above |
+| [`Map.groupBy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy) | — | polyfilled below Node 21, native above |
+| [`Array.prototype.toSorted`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted) | — | polyfilled below Node 20, native above |
+| [`String.prototype.isWellFormed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/isWellFormed) | — | polyfilled below Node 20, native above |
+| [`ArrayBuffer.prototype.transfer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer) | — | polyfilled below Node 21, native above |
+| [`URL.parse`](https://developer.mozilla.org/en-US/docs/Web/API/URL/parse) | — | polyfilled below Node 22.1 (native from 20.19 on the 20.x line), native above |
+| [`Atomics.pause`](https://github.com/tc39/proposal-atomics-microwait) | — | polyfilled |
 | [`Promise.allKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
 | [`Promise.allSettledKeyed`](https://github.com/tc39/proposal-await-dictionary) | — | polyfilled |
 | [`Float16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array) | — | polyfilled below Node 24, native above |

--- a/tests/fixtures/worker/unhandled-error-fatal-main.ts
+++ b/tests/fixtures/worker/unhandled-error-fatal-main.ts
@@ -10,7 +10,18 @@ const w = new Worker(new URL("./does-not-exist.mjs", import.meta.url), {
 
 // If the error is swallowed, the underlying worker still emits `exit`. Use that
 // event as the failure oracle so a slow worker load cannot race a fixed deadline.
+//
+// The oracle must not fire in the same turn as `exit`, though: the fatality is a
+// deliberately-DEFERRED `process.nextTick` throw (worker-polyfill.mjs re-throws on
+// a fresh tick so a user `uncaughtException` handler still sees it), and
+// `process.exit` does NOT drain the tick queue. Whenever `exit` is delivered before
+// that queue drains, exiting 0 here reports a false swallow — which is what made
+// this test flake on CI. `setImmediate` is ordered strictly after the nextTick
+// queue by the event-loop contract, so a scheduled fatality always wins, while a
+// genuinely swallowed error still reaches the oracle and fails the test.
 w.once("exit", () => {
-  console.log("swallowed-and-survived");
-  process.exit(0);
+  setImmediate(() => {
+    console.log("swallowed-and-survived");
+    process.exit(0);
+  });
 });


### PR DESCRIPTION
Rebased onto `main`; **supersedes #574**, whose three commits are the first three here. #574 can be closed.

Everything Stage 3 or later that was missing under nub, enumerated from tc39/proposals + finished-proposals.md and then **measured** across eight Node versions rather than read off release notes.

| Surface | Was |
|---|---|
| `Promise.allKeyed` / `allSettledKeyed` | no engine ships these |
| `Promise.withResolvers` | native 22+, absent below |
| Set `union`/`intersection`/`difference`/`symmetricDifference`/`isSubsetOf`/`isSupersetOf`/`isDisjointFrom` | native 22+, absent below |
| `Array.fromAsync`, `Iterator` + `Iterator.from` + 11 helpers | native 22+, absent below |
| `Iterator.concat`, `Map`/`WeakMap` `getOrInsert`/`getOrInsertComputed` | native 26+, absent below |
| `Iterator.zip` / `zipKeyed`, `Iterator.chunks`/`windows`/`includes`/`join` | no engine ships these |
| `Math.sumPrecise`, `Symbol.metadata` | no Node ships them |
| `URL.parse`, `String.isWellFormed`/`toWellFormed`, `Object`/`Map.groupBy`, Array+TypedArray copy methods, `ArrayBuffer.transfer`/`detached`, `Atomics.pause` | native above their line, absent below |

**No-clobber, enforced mechanically.** Every installer guards per *method*. `polyfills_never_clobber_native` plants a sentinel on ~57 surfaces, runs the installer, and fails if one was replaced. Zero clobbered on 18.19/20.10/21.0/22.15/26.5, and it runs under the host node so the CI matrix covers it across versions.

**Native as the oracle.** Each battery runs identical assertions against the polyfill and against a runtime that ships the surface natively; bun is the oracle for `Math.sumPrecise`. That caught 13 real fidelity bugs before merge — seven pre-review (including `Math.sumPrecise` returning `NaN` on overflow inputs, and helpers not forwarding early closure to the source iterator) and the six from review.

**Review findings all fixed and covered**, each confirmed against an oracle first: `toSpliced(start)` truncation, `Array.fromAsync` negative array-like length, `transfer` vs `transferToFixedLength` resizability, `Math.sumPrecise([-0])` sign, and three `Iterator.zip` divergences (string primitive, padding over-consumption, strict-mode throw point). The `isWellFormed` receiver report had a deeper cause: sloppy-mode `this` coercion made every `RequireObjectCoercible` check silently pass, so the file is now `"use strict"` — which fixes the whole class rather than one method.

**Deliberately excluded:** `JSON.rawJSON`/`isRawJSON` would need native `JSON.stringify` replaced to serialize markers as raw text, the one change here that would overwrite a native builtin. `Error.prototype.stack` accessor would modify existing semantics. RegExp `v`/`\A\z`/dup-captures and WeakMap symbol keys are engine-level.

**Known limit:** helper objects are generators, so their prototype is not `%IteratorHelperPrototype%` and `Symbol.toStringTag` reads `"Generator"`. Iteration, laziness, validation and source-closing are correct.