### PR TITLE
build: bring the prebuilt addon into new worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -34,3 +34,13 @@ symlink wiki
 # isolation:worktree worktrees do NOT run new-worktree.ts — those rely on the
 # dispatch-prompt step-0 `ln -s <abs-shared-root>/.fray .fray`.
 symlink .fray
+
+# The prebuilt N-API addon. `--all-features` turns on `embed-runtime`, whose
+# build script hashes every runtime entrypoint and PANICS when this file is
+# absent — so `cargo clippy --all-targets --all-features`, the pre-push gate
+# AGENTS.md prescribes, cannot run at all in a fresh worktree without it.
+# COPIED, never symlinked: `make addon-fast` writes this exact path, and a
+# symlink would send a worktree's addon build through into the shared tree,
+# clobbering it for every sibling. A missing source is skipped, so a tree that
+# has never built the addon still creates worktrees fine.
+copy runtime/addons/nub-native.node


### PR DESCRIPTION
`cargo clippy --all-targets --all-features` — the pre-push gate AGENTS.md prescribes — cannot run in a fresh worktree. `--all-features` enables `embed-runtime`, whose build script hashes every runtime entrypoint and panics on the missing `runtime/addons/nub-native.node`:

```
embed-runtime: cannot read entrypoint …/runtime/addons/nub-native.node for integrity
hashing: No such file or directory (os error 2) (stage the full runtime incl.
addons/nub-native.node before the build)
```

The addon is gitignored, so `git worktree add` never brings it along and every new worktree hits this until someone stages the file by hand. It reads as a build failure on correct source, which is what makes it cost time rather than a moment.

Adding it to `.worktreeinclude` closes that.

Copied, not symlinked: `make addon-fast` writes that exact path, so a symlink would send a worktree's addon build through into the shared tree and clobber it for every sibling. A missing source is skipped by the existing loop, so a tree that has never built the addon still creates worktrees fine.
