### PR TITLE
fix(linker): reclaim a per-project virtual store when relinking on Windows

### DIFF
--- a/.github/workflows/aube-parity.yml
+++ b/.github/workflows/aube-parity.yml
@@ -40,10 +40,10 @@ on:
       - "tests/aube-conformance/**"
   schedule:
     # Nightly at 06:30 UTC. The Windows conformance leg is gated off
-    # pull_request (it is the only Windows-runner contributor in this workflow);
-    # the nightly schedule keeps that Windows coverage running on a cadence even
-    # between vendor/aube bumps. Scheduled runs ignore the path filters above and
-    # exercise the full workflow, Windows leg included.
+    # pull_request; the nightly schedule keeps that coverage running on a
+    # cadence even between vendor/aube bumps. (The Windows `cargo test` leg
+    # does gate PRs — see the rationale on that job.) Scheduled runs ignore
+    # the path filters above and exercise the full workflow.
     - cron: "30 6 * * *"
 
 concurrency:
@@ -84,6 +84,40 @@ jobs:
       # NUB-ADAPTED bats run below is a different animal: it needs only the
       # vendored bats + committed Verdaccio fixtures, with nub standing in
       # for aube.
+
+  aube-parity-windows:
+    name: aube cargo test (windows)
+    # UNLIKE the conformance Windows leg below, this one DOES gate pull
+    # requests. The linker's Windows arm is a genuinely separate
+    # implementation — NTFS junctions instead of symlinks, reparse-point
+    # attributes instead of file types, a different error-code space — and
+    # running aube's suite on ubuntu only meant none of it was ever
+    # executed. nub#566 / nub#576 are what that cost: `read_link` failing
+    # with `InvalidInput` was used as the "this is a real directory" test,
+    # which is Unix-only (Windows gives ERROR_NOT_A_REPARSE_POINT), and the
+    # test that would have caught it was itself `#[cfg(all(test, unix))]`.
+    # Both defects reached users. The workflow is path-filtered to
+    # vendor/aube edits, so this leg costs zero runner minutes on every PR
+    # that does not touch the vendored tree.
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    timeout-minutes: 60
+    steps:
+      # The runner image ships core.autocrlf=true, which would CRLF-ify the
+      # committed fixtures the suite asserts against. Must precede checkout.
+      - name: Force LF checkout
+        run: git config --global core.autocrlf false
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: vendor/aube
+      - name: Run aube's own test suite
+        working-directory: vendor/aube
+        run: cargo test --workspace
 
   aube-bats-nub:
     name: aube bats, nub-adapted (ubuntu)

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -334,16 +334,10 @@ impl Linker {
                             // so that gap is unreachable in practice. A
                             // prior GVS install or the fetch prewarm may have left
                             // a symlink here; replace it. An existing real
-                            // directory is reused as cached. Classification uses
-                            // `read_link`, not `file_type().is_symlink()`: on
-                            // Windows the GVS entry is an NTFS junction (created by
-                            // `sys::create_dir_link`) whose `is_symlink()` is false
-                            // and `is_dir()` is true, so the file-type bit would
-                            // misread a stale junction as a real dir and skip the
-                            // conversion. `read_link` succeeds on both Unix symlinks
-                            // and junction reparse points and returns `InvalidInput`
-                            // on a real directory — the same signal `classify_entry_state`
-                            // and `detect_aube_dir_gvs_mode` rely on.
+                            // directory is reused as cached. Neither
+                            // `file_type().is_symlink()` nor a `read_link` error
+                            // kind classifies that correctly on both platforms —
+                            // `aube_util::fs::is_real_dir` carries the split.
                             if self.disk_materialize_matches(&pkg.name) {
                                 // Orphan-safety invariant: disk-materialize gives X
                                 // a real project-local dir so X's OWN undeclared
@@ -374,13 +368,8 @@ impl Linker {
                                     .join(subdir)
                                     .join("node_modules")
                                     .join(&pkg.name);
-                                // `InvalidInput` from `read_link` == a real dir (not
-                                // a symlink/junction). See the classification note
-                                // above for why this beats `is_symlink()`.
-                                let local_is_real_dir = matches!(
-                                    std::fs::read_link(&local_aube_entry),
-                                    Err(e) if e.kind() == std::io::ErrorKind::InvalidInput
-                                );
+                                let local_is_real_dir =
+                                    aube_util::fs::is_real_dir(&local_aube_entry);
                                 if store_pkg_dir.exists() && local_is_real_dir {
                                     // Both placements already correct.
                                     local_stats.packages_cached += 1;
@@ -505,17 +494,20 @@ impl Linker {
                                 nested_link_targets.as_ref(),
                             )?;
 
-                            // Only pay the `remove_dir`/`remove_file` syscalls
-                            // when we actually have something to remove.
-                            // On Windows, `.aube/<dep_path>` is an NTFS
-                            // junction (created via `sys::create_dir_link`);
-                            // `remove_file` can't unlink those, so try
-                            // `remove_dir` first and fall back to
-                            // `remove_file` for the unix case (where
-                            // `symlink` produces a file-style link).
+                            // Only pay the removal syscalls when there is
+                            // something to remove. `Stale` covers more than a
+                            // wrong-target link: a POPULATED real directory
+                            // lands here whenever a package leaves the
+                            // disk-materialize eject set, or a per-project tree
+                            // was only partly converted to the shared store. A
+                            // non-recursive `remove_dir` cannot clear that, and
+                            // the swallowed error then resurfaces as EEXIST /
+                            // os-183 from the junction/symlink creation below.
+                            // `try_remove_entry` clears dir, symlink, junction,
+                            // and dangling-link shapes alike — the same call
+                            // the git/tarball sibling path already uses.
                             if matches!(state, EntryState::Stale) {
-                                let _ = std::fs::remove_dir(&local_aube_entry)
-                                    .or_else(|_| std::fs::remove_file(&local_aube_entry));
+                                try_remove_entry(&local_aube_entry);
                             }
                             // Parent dirs were pre-created above the
                             // par_iter; no per-package `mkdirp` here.

--- a/vendor/aube/crates/aube-linker/src/sweep.rs
+++ b/vendor/aube/crates/aube-linker/src/sweep.rs
@@ -124,12 +124,18 @@ pub(crate) fn remove_hidden_hoist_tree(path: &Path) {
 }
 
 /// Best-effort unlink of `path` regardless of whether it's a file,
-/// symlink, junction, or directory. Errors are intentionally ignored
-/// because this is a "clear the slot" operation — the caller is about
-/// to place something else here and any residual entry that survives
-/// will surface as a downstream error.
+/// symlink, junction, or populated directory. Errors are intentionally
+/// ignored because this is a "clear the slot" operation — the caller is
+/// about to place something else here and any residual entry that
+/// survives will surface as a downstream error.
+///
+/// Goes through the Windows retry (a plain passthrough on Unix): the
+/// slots this clears live inside `node_modules`, where a dev server,
+/// watcher, or AV scanner holding a handle turns the delete into a
+/// transient os-5/32 failure. Swallowed here, that failure re-emerges
+/// as an `ERROR_ALREADY_EXISTS` from whatever the caller places next.
 pub(crate) fn try_remove_entry(path: &Path) {
-    let _ = std::fs::remove_dir_all(path);
+    let _ = remove_dir_all_with_retry(path);
     let _ = std::fs::remove_file(path);
 }
 

--- a/vendor/aube/crates/aube-linker/src/sys.rs
+++ b/vendor/aube/crates/aube-linker/src/sys.rs
@@ -61,7 +61,30 @@ use std::path::{Component, Path, PathBuf};
 /// - Unix: a plain symlink (relative or absolute target OK).
 /// - Windows: an NTFS junction (relative targets are resolved to
 ///   absolute against `link`'s parent first).
+///
+/// A leftover link, dangling link, or EMPTY directory occupying `link`
+/// is cleared and the create retried once — `junction::create` opens
+/// with `fs::create_dir`, so anything at the path surfaces as
+/// `ERROR_ALREADY_EXISTS` (os 183) before the reparse write, and the
+/// Unix `symlink` gives the equivalent `EEXIST`. Same shape as
+/// `write_shim_file` below, and the same deliberate restraint: the
+/// non-recursive `remove_dir` will NOT wipe a POPULATED directory, so a
+/// real package tree in the slot still surfaces the error rather than
+/// being silently destroyed by a generic helper. Callers that own the
+/// slot and know a full clear is correct do it themselves before
+/// calling (see the `Stale` branch in `link.rs`).
 pub fn create_dir_link(target: &Path, link: &Path) -> io::Result<()> {
+    match create_dir_link_once(target, link) {
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+            let _ = std::fs::remove_file(link);
+            let _ = std::fs::remove_dir(link);
+            create_dir_link_once(target, link)
+        }
+        other => other,
+    }
+}
+
+fn create_dir_link_once(target: &Path, link: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
         std::os::unix::fs::symlink(target, link)

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -2226,3 +2226,97 @@ fn clonedir_materialize_matches_per_file_byte_for_byte() {
     // Stats parity: the clone counts every index entry as linked.
     assert_eq!(stats.files_linked, index.len());
 }
+
+// nub#566 / nub#576: a POPULATED real directory sitting in a
+// shared-store entry's slot must be replaced by the link, not collide
+// with it. The slot gets that shape whenever a tree materialized
+// per-project (a `CI=1` / project-local-store install, or a package
+// leaving the disk-materialize eject set) is relinked with the shared
+// store on. `classify_entry_state` correctly calls it `Stale`, but the
+// removal that used to run was non-recursive, so it failed silently and
+// the link creation then aborted the whole install with `EEXIST` on
+// Unix / `ERROR_ALREADY_EXISTS` (os 183) on Windows.
+#[test]
+fn gvs_relink_replaces_a_populated_real_dir_in_the_entry_slot() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    let (store, indices) = setup_store_with_files(dir.path());
+    let graph = make_graph();
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true).with_hoist(false);
+
+    linker.link_all(&project_dir, &graph, &indices).unwrap();
+
+    // Rewrite one entry into the per-project shape: a real directory
+    // holding the package, exactly what a GVS-off install leaves behind.
+    let entry = project_dir
+        .join("node_modules/.aube")
+        .join(dep_path_to_filename(
+            "bar@2.0.0",
+            DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+        ));
+    try_remove_entry(&entry);
+    let pkg_dir = entry.join("node_modules/bar");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(pkg_dir.join("index.js"), b"stale per-project copy").unwrap();
+    assert!(aube_util::fs::is_real_dir(&entry));
+
+    linker
+        .link_all(&project_dir, &graph, &indices)
+        .expect("relink must reclaim a populated per-project entry, not collide with it");
+
+    assert!(
+        std::fs::read_link(&entry).is_ok(),
+        "entry must end up a link into the shared store"
+    );
+    assert!(entry.join("node_modules/bar/index.js").exists());
+}
+
+// `is_real_dir` exists to tell a plain directory apart from a
+// directory-SHAPED link, so the link case is the whole point — and it is
+// only meaningful against the real primitive: `create_dir_link` writes a
+// Unix symlink on Unix and an NTFS junction on Windows, and a junction
+// reports `is_dir() == true` / `is_symlink() == false`, which is what
+// defeats the obvious file-type test.
+#[test]
+fn is_real_dir_distinguishes_a_plain_dir_from_a_dir_shaped_link() {
+    let tmp = tempfile::tempdir().unwrap();
+    let real = tmp.path().join("real");
+    std::fs::create_dir(&real).unwrap();
+    let file = tmp.path().join("file");
+    std::fs::write(&file, b"x").unwrap();
+    let link = tmp.path().join("link");
+    sys::create_dir_link(&real, &link).unwrap();
+
+    assert!(aube_util::fs::is_real_dir(&real));
+    assert!(!aube_util::fs::is_real_dir(&link));
+    assert!(!aube_util::fs::is_real_dir(&file));
+    assert!(!aube_util::fs::is_real_dir(&tmp.path().join("missing")));
+}
+
+// `create_dir_link` is the last writer before the install aborts, so it
+// carries its own clear-and-retry for a leftover link in the slot. The
+// restraint is deliberate and load-bearing: a POPULATED directory is a
+// real conflict a generic helper must not silently destroy, and the
+// caller that owns the slot clears it instead (see the test above).
+#[test]
+fn create_dir_link_reclaims_a_leftover_link_but_not_a_populated_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let target = tmp.path().join("target");
+    let other = tmp.path().join("other");
+    std::fs::create_dir(&target).unwrap();
+    std::fs::create_dir(&other).unwrap();
+
+    let slot = tmp.path().join("slot");
+    sys::create_dir_link(&other, &slot).unwrap();
+    sys::create_dir_link(&target, &slot).expect("a stale link in the slot is reclaimed");
+
+    let occupied = tmp.path().join("occupied");
+    std::fs::create_dir_all(occupied.join("node_modules/pkg")).unwrap();
+    assert_eq!(
+        sys::create_dir_link(&target, &occupied)
+            .expect_err("a populated dir must surface, not be wiped")
+            .kind(),
+        std::io::ErrorKind::AlreadyExists
+    );
+    assert!(occupied.join("node_modules/pkg").exists());
+}

--- a/vendor/aube/crates/aube-registry/src/config/tests.rs
+++ b/vendor/aube/crates/aube-registry/src/config/tests.rs
@@ -2505,7 +2505,17 @@ fn test_load_npmrc_entries_orders_user_before_project() {
     );
 }
 
+// Windows-quarantined: these three build their `auth.ini` fixture at
+// `pnpm_config_dir_with(Some(tmp_home), None)`, and that helper DISCARDS the
+// injected home on Windows — it returns the real `%LOCALAPPDATA%\pnpm\config`
+// (`aube_util::env::pnpm_config_dir_with`). So the fixture escapes its tempdir
+// into the actual user profile, where it both contaminates every sibling test
+// that resolves a token and would clobber a real developer's pnpm credentials.
+// The XDG short-circuit in that helper is hermetic on every platform, but these
+// tests deliberately exercise the per-OS branch, so the fix is to make that
+// branch injectable rather than to reroute the tests. Tracked in nub#605.
 #[test]
+#[cfg_attr(windows, ignore = "escapes its tempdir on Windows; nub#605")]
 fn pnpm_global_auth_ini_loads_and_overrides_user_rc() {
     // `~/.config/pnpm/auth.ini` is pnpm's out-of-band credential
     // file. Aube needs to read it so users who stash tokens there
@@ -2589,6 +2599,7 @@ fn pnpm_global_auth_ini_honors_xdg_config_home_override() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore = "escapes its tempdir on Windows; nub#605")]
 fn pnpm_global_auth_ini_loses_to_project_npmrc() {
     // Project `.npmrc` pins still win — per-repo configuration is
     // the most specific layer, and a user's global auth.ini
@@ -2622,6 +2633,7 @@ fn pnpm_global_auth_ini_loses_to_project_npmrc() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore = "escapes its tempdir on Windows; nub#605")]
 fn pnpm_global_auth_ini_not_read_when_gate_disabled() {
     // The pnpm-NAMED GLOBAL `~/.config/pnpm/auth.ini` is gated by the
     // GLOBAL-scope `read_pnpm_global_config` posture — NOT the project-scope

--- a/vendor/aube/crates/aube-util/src/fs.rs
+++ b/vendor/aube/crates/aube-util/src/fs.rs
@@ -2,6 +2,34 @@
 
 use std::path::Path;
 
+/// True when `path` is a plain directory — NOT a Unix symlink, and NOT
+/// a Windows junction.
+///
+/// The install path distinguishes "per-project materialized package" (a
+/// real directory of files) from "shared-store entry" (a link) in
+/// several places, and the obvious spelling of the negative test is
+/// silently Unix-only. Call sites used to write it as `read_link`
+/// failing with `InvalidInput`, which is the errno a Unix `readlink(2)`
+/// returns for a non-link. Windows has no equivalent: `read_link` over a
+/// plain directory fails with `ERROR_NOT_A_REPARSE_POINT` (4390), and
+/// std's error table has no entry for it, so it arrives as
+/// `Uncategorized`. Every such site therefore answered "not a real
+/// directory" for every real directory on Windows (nub#566).
+///
+/// So key off whether the entry is a link AT ALL rather than off the
+/// error kind of a failed `read_link`. That is the same property
+/// `create_dir_link`'s callers already rely on — `read_link` succeeds on
+/// both a Unix symlink and a junction reparse point — and it leaves
+/// reparse points that are NOT links (cloud-file placeholders on a
+/// OneDrive-synced tree, dedup stubs) correctly classified as the real
+/// directories they are.
+pub fn is_real_dir(path: &Path) -> bool {
+    if std::fs::read_link(path).is_ok() {
+        return false;
+    }
+    std::fs::symlink_metadata(path).is_ok_and(|md| md.is_dir())
+}
+
 /// True when `a` and `b` live on different volumes (Windows) or
 /// mounts (Linux/Mac). Used by the linker probe and warning paths to
 /// detect when hardlink/reflink can't cross the device boundary so

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -194,19 +194,25 @@ pub(super) fn detect_aube_dir_gvs_mode(aube_dir: &std::path::Path) -> Option<boo
         if name_str == "node_modules" || name_str.starts_with('.') {
             continue;
         }
-        // Classify via `read_link`, not `file_type().is_symlink()`.
-        // On Windows, `sys::create_dir_link` produces an NTFS junction
-        // whose `is_symlink()` is `false` and `is_dir()` is `true`,
-        // making a gvs-on entry indistinguishable from a per-project
-        // real directory via the file-type bit. `read_link` succeeds on
-        // both Unix symlinks and Windows junction reparse points, and
-        // returns `Err(InvalidInput)` on a regular directory — exactly
-        // the signal we need. Non-link IO errors just skip the entry
-        // and move on to the next candidate.
-        match std::fs::read_link(entry.path()) {
-            Ok(_) => return Some(true),
-            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => saw_real_dir = true,
-            Err(_) => continue,
+        // `read_link` is the positive test for a link: it succeeds on
+        // both a Unix symlink and a Windows junction reparse point,
+        // which is what `sys::create_dir_link` writes on each platform.
+        // The negative half is NOT its inverse — a failed `read_link`
+        // reports a DIFFERENT error kind per platform, and reading a
+        // plain directory off that kind is why this function could never
+        // return `Some(false)` on Windows (nub#566; see
+        // `aube_util::fs::is_real_dir`). With the mode change therefore
+        // invisible there, `reset_on_mode_change` never wiped a
+        // per-project tree and the gvs link pass that followed collided
+        // with the surviving directories (`ERROR_ALREADY_EXISTS`).
+        // Anything that is neither a link nor a real directory is
+        // skipped.
+        let path = entry.path();
+        if std::fs::read_link(&path).is_ok() {
+            return Some(true);
+        }
+        if aube_util::fs::is_real_dir(&path) {
+            saw_real_dir = true;
         }
     }
     saw_real_dir.then_some(false)
@@ -1281,22 +1287,38 @@ mod network_concurrency_tests {
     }
 }
 
-#[cfg(all(test, unix))]
+// These ran `unix`-only, which is what let the Windows half of the
+// detector stay broken (nub#566): on Windows the real-dir arm never
+// fired, `all_real_dirs_reads_as_per_project` was the test that would
+// have caught it, and it was compiled out. Every entry is now built
+// through `create_dir_link` / `create_dir_all`, so the same three cases
+// assert against a real junction on Windows and a real symlink on Unix.
+#[cfg(test)]
 mod gvs_mode_detect_tests {
     use super::*;
-    use std::os::unix::fs::symlink;
+
+    // A link target that does not exist — the detector classifies by the
+    // entry's own shape and must not care whether the target resolves.
+    fn dangling_link(store_leaf: &str, at: std::path::PathBuf) {
+        let target = at
+            .parent()
+            .expect("entry has a parent")
+            .join("nonexistent-store")
+            .join(store_leaf);
+        aube_linker::sys::create_dir_link(&target, &at).unwrap();
+    }
 
     // `diskMaterializePackages` produces a MIXED `.aube` tree — some entries
-    // are shared-store symlinks, some are disk-materialized real dirs. The
+    // are shared-store links, some are disk-materialized real dirs. The
     // detector must classify such a tree as GVS-on regardless of `read_dir`
     // order; a forced real dir landing first must NOT misread it as per-project
     // (which would wipe node_modules on every install).
     #[test]
-    fn mixed_tree_with_any_symlink_reads_as_gvs() {
+    fn mixed_tree_with_any_link_reads_as_gvs() {
         let dir = tempfile::tempdir().unwrap();
         let aube = dir.path();
         std::fs::create_dir_all(aube.join("real@1.0.0/node_modules/real")).unwrap();
-        symlink("/nonexistent-store/dep@2.0.0", aube.join("dep@2.0.0")).unwrap();
+        dangling_link("dep@2.0.0", aube.join("dep@2.0.0"));
         assert_eq!(detect_aube_dir_gvs_mode(aube), Some(true));
     }
 
@@ -1310,11 +1332,11 @@ mod gvs_mode_detect_tests {
     }
 
     #[test]
-    fn all_symlinks_reads_as_gvs() {
+    fn all_links_reads_as_gvs() {
         let dir = tempfile::tempdir().unwrap();
         let aube = dir.path();
-        symlink("/store/a@1.0.0", aube.join("a@1.0.0")).unwrap();
-        symlink("/store/b@1.0.0", aube.join("b@1.0.0")).unwrap();
+        dangling_link("a@1.0.0", aube.join("a@1.0.0"));
+        dangling_link("b@1.0.0", aube.join("b@1.0.0"));
         assert_eq!(detect_aube_dir_gvs_mode(aube), Some(true));
     }
 }


### PR DESCRIPTION
`nub add` / `nub remove` aborted on Windows with `os error 183`, leaving the tree unlinked.

`read_link` failing with `InvalidInput` was the "is a real directory" test. That errno is Unix-only, so `detect_aube_dir_gvs_mode` never returned `Some(false)` on Windows and `reset_on_mode_change` never wiped a per-project tree. The surviving directories were cleared with a non-recursive `remove_dir`, so junction creation aborted.

`is_real_dir` now keys on whether the entry is a link; cleanup uses `try_remove_entry`, as the git/url path already did (#341).

aube's suite ran ubuntu-only and the covering test was `unix`-gated. Both fixed, plus a PR-gating windows-latest leg.

Closes #566
Closes #576