### PR TITLE
fix(install): link bins of hoisted transitive deps

### DIFF
--- a/vendor/aube/crates/aube-scripts/src/lib.rs
+++ b/vendor/aube/crates/aube-scripts/src/lib.rs
@@ -1434,14 +1434,12 @@ fn unshare_one_file(path: &Path, mode: u32) -> std::io::Result<()> {
 /// `node_modules/.aube/<dep_path>/node_modules/<name>`). The manifest
 /// is the dependency's own `package.json`, *not* the project root's.
 ///
-/// `dep_modules_dir` is the dep's sibling `node_modules/` — i.e.
-/// `package_dir`'s parent for unscoped packages, or `package_dir`'s
-/// grandparent for scoped (`@scope/name`). `<dep_modules_dir>/.bin`
-/// is prepended to `PATH` so the dep's postinstall can spawn tools
-/// declared in its own `dependencies` (the transitive-bin case —
-/// `prebuild-install`, `node-gyp`, `napi-postinstall`). The install
-/// driver writes shims there via `link_dep_bins`; `rebuild` mirrors
-/// the same pass.
+/// Every `<modules_dir>/.bin` from the package's own out to the project
+/// root is prepended to `PATH`, closest first, so the dep's postinstall
+/// can spawn tools declared in its own `dependencies` (the transitive-bin
+/// case — `prebuild-install`, `node-gyp`, `napi-postinstall`). The install
+/// driver writes those shims via `link_dep_bins` (isolated) and
+/// `link_hoisted_placement_bins` (hoisted).
 ///
 /// For the `install` hook specifically, if the manifest leaves both
 /// `install` and `preinstall` empty but the package has a top-level
@@ -1457,10 +1455,42 @@ fn unshare_one_file(path: &Path, mode: u32) -> std::io::Result<()> {
 ///
 /// The caller is responsible for gating on `BuildPolicy` and
 /// `--ignore-scripts`. Returns `Ok(false)` if the hook wasn't defined.
+/// The `.bin` chain Node's own resolution implies for a package's
+/// lifecycle script: the package's own `<modules_dir>/.bin`, then every
+/// enclosing `<modules_dir>/.bin` out to `project_root`. Closest first, so
+/// a nearer copy shadows a farther one — npm/pnpm semantics.
+///
+/// Walking (rather than taking a fixed pair of levels) is load-bearing
+/// under the hoisted layout: a conflicting version nests under whichever
+/// ancestor still had the name free, so the dependency a script reaches
+/// for can sit at ANY level between the package and the root. A package at
+/// `a/<md>/b/<md>/c` whose dependency was placed at `a/<md>/` is invisible
+/// to its own level, its parent's, and the root's alike — the exact 127
+/// this chain exists to prevent.
+///
+/// Under the isolated layout this yields the dep's own
+/// `.aube/<dep_path>/<modules_dir>/.bin` plus the project root and nothing
+/// else, since no other directory on the way up carries the name.
+/// `run_script` appends the project root's `.bin` after these, so the
+/// duplicate entry there is harmless.
+fn dep_bin_chain(package_dir: &Path, project_root: &Path, modules_dir_name: &str) -> Vec<PathBuf> {
+    let mut chain = vec![package_dir.join(modules_dir_name).join(".bin")];
+    let mut cursor = Some(package_dir);
+    while let Some(dir) = cursor {
+        if dir == project_root {
+            break;
+        }
+        if dir.file_name().is_some_and(|n| n == modules_dir_name) {
+            chain.push(dir.join(".bin"));
+        }
+        cursor = dir.parent();
+    }
+    chain
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_dep_hook(
     package_dir: &Path,
-    dep_modules_dir: &Path,
     project_root: &Path,
     modules_dir_name: &str,
     manifest: &PackageJson,
@@ -1479,19 +1509,9 @@ pub async fn run_dep_hook(
             _ => return Ok(false),
         },
     };
-    // Closest-ancestor-first, matching npm/pnpm's `.bin` chain. The
-    // hoisted layout nests a version conflict under the requester, so a
-    // package's own `node_modules/` can hold children that live nowhere
-    // else; their bins sit in THAT directory's `.bin` (see
-    // `link_hoisted_placement_bins`), which is exactly where Node resolves
-    // the nested copy from — so the script has to look there too, and
-    // first. Absent under the isolated layout and in the flat hoisted
-    // case, where it is simply an inert PATH entry.
-    let nested_bin_dir = package_dir.join("node_modules").join(".bin");
-    let dep_bin_dir = dep_modules_dir.join(".bin");
-    let mut bin_dirs: Vec<&Path> = Vec::with_capacity(tool_bin_dirs.len() + 2);
-    bin_dirs.push(&nested_bin_dir);
-    bin_dirs.push(&dep_bin_dir);
+    let chain = dep_bin_chain(package_dir, project_root, modules_dir_name);
+    let mut bin_dirs: Vec<&Path> = Vec::with_capacity(chain.len() + tool_bin_dirs.len());
+    bin_dirs.extend(chain.iter().map(PathBuf::as_path));
     bin_dirs.extend(tool_bin_dirs.iter().copied());
     run_script(
         package_dir,
@@ -2183,5 +2203,79 @@ mod break_cas_hardlinks_tests {
             std::path::Path::new("real.txt")
         );
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+}
+
+#[cfg(test)]
+mod dep_bin_chain_tests {
+    use super::dep_bin_chain;
+    use std::path::{Path, PathBuf};
+
+    /// The depth->=3 shape a two-level approximation misses. Package `c`
+    /// sits at `a/node_modules/b/node_modules/c`; a dependency the hoister
+    /// placed at `a/node_modules/` is reachable from NEITHER `c`'s own
+    /// level, NOR its enclosing `b/node_modules`, NOR the project root, so
+    /// omitting the intermediate ancestor is a live 127 rather than a
+    /// cosmetic gap. Order is load-bearing too: closest first, so a nearer
+    /// copy shadows a farther one.
+    #[test]
+    fn dep_bin_chain_covers_every_intermediate_ancestor_closest_first() {
+        let root = Path::new("/p");
+        let chain = dep_bin_chain(
+            Path::new("/p/node_modules/a/node_modules/b/node_modules/c"),
+            root,
+            "node_modules",
+        );
+        assert_eq!(
+            chain,
+            vec![
+                PathBuf::from("/p/node_modules/a/node_modules/b/node_modules/c/node_modules/.bin"),
+                PathBuf::from("/p/node_modules/a/node_modules/b/node_modules/.bin"),
+                PathBuf::from("/p/node_modules/a/node_modules/.bin"),
+                PathBuf::from("/p/node_modules/.bin"),
+            ],
+            "every enclosing modules dir must appear, closest first"
+        );
+    }
+
+    /// The isolated layout must be unaffected: the virtual-store hop is
+    /// the only intermediate directory carrying the name, so the walk
+    /// reproduces exactly the dep-local `.bin` plus the project root.
+    #[test]
+    fn dep_bin_chain_is_inert_under_the_isolated_layout() {
+        let chain = dep_bin_chain(
+            Path::new("/p/node_modules/.aube/lmdb@3.0.0/node_modules/lmdb"),
+            Path::new("/p"),
+            "node_modules",
+        );
+        assert_eq!(
+            chain,
+            vec![
+                PathBuf::from("/p/node_modules/.aube/lmdb@3.0.0/node_modules/lmdb/node_modules/.bin"),
+                PathBuf::from("/p/node_modules/.aube/lmdb@3.0.0/node_modules/.bin"),
+                PathBuf::from("/p/node_modules/.bin"),
+            ]
+        );
+    }
+
+    /// A custom `modulesDir` renames every level, including the scoped
+    /// case: `@scope/name` adds a directory hop that is NOT named after
+    /// the modules dir, so it must not contribute an entry.
+    #[test]
+    fn dep_bin_chain_honors_a_custom_modules_dir_and_skips_the_scope_hop() {
+        let chain = dep_bin_chain(
+            Path::new("/p/mods/@scope/name"),
+            Path::new("/p"),
+            "mods",
+        );
+        assert_eq!(
+            chain,
+            vec![
+                PathBuf::from("/p/mods/@scope/name/mods/.bin"),
+                PathBuf::from("/p/mods/.bin"),
+            ],
+            "the `@scope` directory is not a modules dir and contributes nothing"
+        );
     }
 }

--- a/vendor/aube/crates/aube-scripts/src/lib.rs
+++ b/vendor/aube/crates/aube-scripts/src/lib.rs
@@ -1428,33 +1428,6 @@ fn unshare_one_file(path: &Path, mode: u32) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Run a lifecycle hook against an installed dependency's package
-/// directory. Mirrors [`run_root_hook`] but spawns inside `package_dir`
-/// (the actual linked package directory, e.g.
-/// `node_modules/.aube/<dep_path>/node_modules/<name>`). The manifest
-/// is the dependency's own `package.json`, *not* the project root's.
-///
-/// Every `<modules_dir>/.bin` from the package's own out to the project
-/// root is prepended to `PATH`, closest first, so the dep's postinstall
-/// can spawn tools declared in its own `dependencies` (the transitive-bin
-/// case — `prebuild-install`, `node-gyp`, `napi-postinstall`). The install
-/// driver writes those shims via `link_dep_bins` (isolated) and
-/// `link_hoisted_placement_bins` (hoisted).
-///
-/// For the `install` hook specifically, if the manifest leaves both
-/// `install` and `preinstall` empty but the package has a top-level
-/// `binding.gyp`, this falls back to running `node-gyp rebuild` — the
-/// node-gyp default that npm and pnpm both honor so native modules
-/// without a prebuilt binary still compile on install.
-///
-/// `tool_bin_dirs` are prepended to `PATH` *after* the dep's own
-/// `.bin` so that aube-bootstrapped tools (e.g. node-gyp) fill the
-/// gap for deps that shell out to them without declaring them as
-/// their own `dependencies`. The dep's local bin still wins if it
-/// shipped its own copy.
-///
-/// The caller is responsible for gating on `BuildPolicy` and
-/// `--ignore-scripts`. Returns `Ok(false)` if the hook wasn't defined.
 /// The `.bin` chain Node's own resolution implies for a package's
 /// lifecycle script: the package's own `<modules_dir>/.bin`, then every
 /// enclosing `<modules_dir>/.bin` out to `project_root`. Closest first, so
@@ -1488,6 +1461,33 @@ fn dep_bin_chain(package_dir: &Path, project_root: &Path, modules_dir_name: &str
     chain
 }
 
+/// Run a lifecycle hook against an installed dependency's package
+/// directory. Mirrors [`run_root_hook`] but spawns inside `package_dir`
+/// (the actual linked package directory, e.g.
+/// `node_modules/.aube/<dep_path>/node_modules/<name>`). The manifest
+/// is the dependency's own `package.json`, *not* the project root's.
+///
+/// Every `<modules_dir>/.bin` from the package's own out to the project
+/// root is prepended to `PATH`, closest first, so the dep's postinstall
+/// can spawn tools declared in its own `dependencies` (the transitive-bin
+/// case — `prebuild-install`, `node-gyp`, `napi-postinstall`). The install
+/// driver writes those shims via `link_dep_bins` (isolated) and
+/// `link_hoisted_placement_bins` (hoisted).
+///
+/// For the `install` hook specifically, if the manifest leaves both
+/// `install` and `preinstall` empty but the package has a top-level
+/// `binding.gyp`, this falls back to running `node-gyp rebuild` — the
+/// node-gyp default that npm and pnpm both honor so native modules
+/// without a prebuilt binary still compile on install.
+///
+/// `tool_bin_dirs` are prepended to `PATH` *after* the dep's own
+/// `.bin` so that aube-bootstrapped tools (e.g. node-gyp) fill the
+/// gap for deps that shell out to them without declaring them as
+/// their own `dependencies`. The dep's local bin still wins if it
+/// shipped its own copy.
+///
+/// The caller is responsible for gating on `BuildPolicy` and
+/// `--ignore-scripts`. Returns `Ok(false)` if the hook wasn't defined.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_dep_hook(
     package_dir: &Path,
@@ -2204,7 +2204,6 @@ mod break_cas_hardlinks_tests {
         );
         let _ = std::fs::remove_dir_all(&root);
     }
-
 }
 
 #[cfg(test)]
@@ -2252,7 +2251,9 @@ mod dep_bin_chain_tests {
         assert_eq!(
             chain,
             vec![
-                PathBuf::from("/p/node_modules/.aube/lmdb@3.0.0/node_modules/lmdb/node_modules/.bin"),
+                PathBuf::from(
+                    "/p/node_modules/.aube/lmdb@3.0.0/node_modules/lmdb/node_modules/.bin"
+                ),
                 PathBuf::from("/p/node_modules/.aube/lmdb@3.0.0/node_modules/.bin"),
                 PathBuf::from("/p/node_modules/.bin"),
             ]
@@ -2264,11 +2265,7 @@ mod dep_bin_chain_tests {
     /// the modules dir, so it must not contribute an entry.
     #[test]
     fn dep_bin_chain_honors_a_custom_modules_dir_and_skips_the_scope_hop() {
-        let chain = dep_bin_chain(
-            Path::new("/p/mods/@scope/name"),
-            Path::new("/p"),
-            "mods",
-        );
+        let chain = dep_bin_chain(Path::new("/p/mods/@scope/name"), Path::new("/p"), "mods");
         assert_eq!(
             chain,
             vec![

--- a/vendor/aube/crates/aube-scripts/src/lib.rs
+++ b/vendor/aube/crates/aube-scripts/src/lib.rs
@@ -1479,8 +1479,18 @@ pub async fn run_dep_hook(
             _ => return Ok(false),
         },
     };
+    // Closest-ancestor-first, matching npm/pnpm's `.bin` chain. The
+    // hoisted layout nests a version conflict under the requester, so a
+    // package's own `node_modules/` can hold children that live nowhere
+    // else; their bins sit in THAT directory's `.bin` (see
+    // `link_hoisted_placement_bins`), which is exactly where Node resolves
+    // the nested copy from — so the script has to look there too, and
+    // first. Absent under the isolated layout and in the flat hoisted
+    // case, where it is simply an inert PATH entry.
+    let nested_bin_dir = package_dir.join("node_modules").join(".bin");
     let dep_bin_dir = dep_modules_dir.join(".bin");
-    let mut bin_dirs: Vec<&Path> = Vec::with_capacity(tool_bin_dirs.len() + 1);
+    let mut bin_dirs: Vec<&Path> = Vec::with_capacity(tool_bin_dirs.len() + 2);
+    bin_dirs.push(&nested_bin_dir);
     bin_dirs.push(&dep_bin_dir);
     bin_dirs.extend(tool_bin_dirs.iter().copied());
     run_script(

--- a/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
+++ b/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
@@ -168,22 +168,109 @@ pub(super) fn link_bins_for_dep(
         virtual_store_dir_max_length,
         placements,
     );
-    if let Some(pkg_json) = read_materialized_pkg_json_cached(
+    let pkg_json = read_materialized_pkg_json_cached(
         cache,
         aube_dir,
         dep_path,
         name,
         virtual_store_dir_max_length,
         placements,
-    )? {
+    )?;
+    link_bins_of_pkg_dir(
+        bin_dir,
+        &pkg_dir,
+        name,
+        pkg_json.as_ref(),
+        graph,
+        dep_path,
+        shim_opts,
+    )
+}
+
+/// Shim one package's own bins (plus its bundled deps') into `bin_dir`,
+/// resolving every target against the caller's `pkg_dir`.
+///
+/// Split out of [`link_bins_for_dep`] so the hoisted pass can hand in a
+/// *concrete* placement directory. A package whose name conflicts with a
+/// shallower version is materialized once per site, and each site's shims
+/// must point at its own copy — `materialized_pkg_dir` only ever returns
+/// the shallowest, so the deeper sites need their path passed in.
+fn link_bins_of_pkg_dir(
+    bin_dir: &std::path::Path,
+    pkg_dir: &std::path::Path,
+    name: &str,
+    pkg_json: Option<&serde_json::Value>,
+    graph: &aube_lockfile::LockfileGraph,
+    dep_path: &str,
+    shim_opts: aube_linker::BinShimOptions,
+) -> miette::Result<()> {
+    if let Some(pkg_json) = pkg_json {
         if let Some(bin) = pkg_json.get("bin") {
-            link_bin_entries(bin_dir, &pkg_dir, Some(name), bin, shim_opts)?;
+            link_bin_entries(bin_dir, pkg_dir, Some(name), bin, shim_opts)?;
         } else if let Some(dir_bin) = pkg_json.get("directories").and_then(|d| d.get("bin")) {
             // `bin` wins; `directories.bin` is the fallback only.
-            link_dir_bins(bin_dir, &pkg_dir, dir_bin, shim_opts)?;
+            link_dir_bins(bin_dir, pkg_dir, dir_bin, shim_opts)?;
         }
     }
-    link_bundled_bins(bin_dir, &pkg_dir, graph, dep_path, shim_opts)?;
+    link_bundled_bins(bin_dir, pkg_dir, graph, dep_path, shim_opts)?;
+    Ok(())
+}
+
+/// Hoisted layout: shim every placed package's bins into the `.bin` of
+/// the `node_modules/` it was hoisted into.
+///
+/// The isolated layout gets this for free — each package owns a private
+/// `.aube/<dep_path>/node_modules/`, and `link_dep_bins` fills that
+/// directory's `.bin`. Hoisted has no per-dep directory: transitives share
+/// a `node_modules/` with everything else hoisted to that level, and the
+/// only pass covering that directory handled the importer's *direct* deps.
+/// A hoisted transitive's bins were therefore linked nowhere, and any
+/// lifecycle script invoking one exited 127 (#570 — `bufferutil`'s
+/// `install` script shells out to `node-gyp-build`).
+///
+/// Mirrors pnpm's hoisted layout, which runs `linkBins(modulesDir,
+/// binsDir)` once per `node_modules/` in the tree and links the bins of
+/// every package sitting directly inside it.
+///
+/// ORDERING is the conflict resolution. This pass runs before the
+/// direct-dep and self-bin passes, whose writes then overwrite it
+/// (`create_bin_shim` unlinks first), reproducing pnpm's
+/// `preferDirectCmds` — a direct dep's bin beats a hoisted transitive's —
+/// without a separate conflict table. Among colliding transitives,
+/// `HoistedPlacements::iter` yields dep_paths in `BTreeMap` order, so the
+/// greatest dep_path wins: deterministic across runs and platforms, and
+/// the same package pnpm's `localeCompare` tiebreak lands on.
+fn link_hoisted_placement_bins(
+    aube_dir: &std::path::Path,
+    graph: &aube_lockfile::LockfileGraph,
+    virtual_store_dir_max_length: usize,
+    placements: &aube_linker::HoistedPlacements,
+    shim_opts: aube_linker::BinShimOptions,
+    cache: &mut PkgJsonCache,
+) -> miette::Result<()> {
+    for (dep_path, pkg_dir) in placements.iter() {
+        let Some(pkg) = graph.get_package(dep_path) else {
+            continue;
+        };
+        let pkg_json = read_materialized_pkg_json_cached(
+            cache,
+            aube_dir,
+            dep_path,
+            &pkg.name,
+            virtual_store_dir_max_length,
+            Some(placements),
+        )?;
+        let bin_dir = dep_modules_dir_for(pkg_dir, &pkg.name).join(".bin");
+        link_bins_of_pkg_dir(
+            &bin_dir,
+            pkg_dir,
+            &pkg.name,
+            pkg_json.as_ref(),
+            graph,
+            dep_path,
+            shim_opts,
+        )?;
+    }
     Ok(())
 }
 
@@ -301,6 +388,42 @@ pub(crate) fn link_all_bins(input: LinkAllBinsInput<'_>) -> miette::Result<()> {
     let mut pkg_json_cache = PkgJsonCache::new();
     let mut ws_pkg_json_cache = WsPkgJsonCache::new();
     let ws_dirs_for_bins = has_workspace.then_some(ws_dirs);
+    // Lowest-precedence bin writers run first; every later pass overwrites
+    // a same-named shim (`create_bin_shim` unlinks before it writes), so
+    // the sequence below IS the conflict-resolution order:
+    //   dep-lifecycle bins < hoisted placements < direct deps < self-bin.
+    //
+    // The first two are hoisted-only in practice. Under isolated both write
+    // exclusively into `.aube/<dep_path>/node_modules/.bin`, which no other
+    // pass touches, so their position here is immaterial there.
+    //
+    // Gate matches the lifecycle phase's (`finalize.rs`) via the shared
+    // `dep_build_scripts_may_run` predicate, threaded through
+    // `maybe_link_dep_bins`: the `defaultTrust` floor can authorize a
+    // package's build scripts with no explicit allow rule, and those
+    // scripts call binaries declared in the package's own `dependencies`
+    // — which must be shimmed into the dep's `.bin` and put on PATH.
+    maybe_link_dep_bins(
+        ignore_scripts,
+        has_any_allow_rule,
+        floor_may_allow_any,
+        aube_dir,
+        graph_for_link,
+        virtual_store_dir_max_length,
+        placements,
+        shim_opts,
+        &mut pkg_json_cache,
+    )?;
+    if let Some(placements) = placements {
+        link_hoisted_placement_bins(
+            aube_dir,
+            graph_for_link,
+            virtual_store_dir_max_length,
+            placements,
+            shim_opts,
+            &mut pkg_json_cache,
+        )?;
+    }
     link_bins(
         cwd,
         modules_dir_name,
@@ -397,23 +520,6 @@ pub(crate) fn link_all_bins(input: LinkAllBinsInput<'_>) -> miette::Result<()> {
             }
         }
     }
-    // Gate matches the lifecycle phase's (`finalize.rs`) via the shared
-    // `dep_build_scripts_may_run` predicate, threaded through
-    // `maybe_link_dep_bins`: the `defaultTrust` floor can authorize a
-    // package's build scripts with no explicit allow rule, and those
-    // scripts call binaries declared in the package's own `dependencies`
-    // — which must be shimmed into the dep's `.bin` and put on PATH.
-    maybe_link_dep_bins(
-        ignore_scripts,
-        has_any_allow_rule,
-        floor_may_allow_any,
-        aube_dir,
-        graph_for_link,
-        virtual_store_dir_max_length,
-        placements,
-        shim_opts,
-        &mut pkg_json_cache,
-    )?;
     Ok(())
 }
 
@@ -479,10 +585,12 @@ pub(super) fn link_bins_for_workspace_dep(
 /// dep-local `.bin` (via `dep_modules_dir_for`) before the
 /// project-level one so the dep's own transitive bins always win.
 ///
-/// Isolated mode only. Hoisted mode materializes deps at the project
-/// root's `node_modules/` and generally relies on the single top-level
-/// `.bin`; nested transitive bins under hoisted are a known rough edge
-/// and out of scope here.
+/// Runs under both layouts. Under hoisted, `dep_modules_dir_for` resolves
+/// to whichever `node_modules/` the dep was hoisted into, so a nested
+/// child's bins land in the directory the parent's script actually gets on
+/// PATH — `run_dep_hook` prepends exactly one dep `.bin`, and for a nested
+/// child that is *not* the child's own sibling `.bin`. This pass is what
+/// closes that gap; `link_hoisted_placement_bins` handles the layout side.
 /// Gate + run the per-dep `.bin` linking pass.
 ///
 /// The link site in `run_link_phase` and the lifecycle site in
@@ -534,10 +642,6 @@ pub(crate) fn link_dep_bins(
     shim_opts: aube_linker::BinShimOptions,
     cache: &mut PkgJsonCache,
 ) -> miette::Result<()> {
-    if placements.is_some() {
-        // Hoisted — skip. See function doc.
-        return Ok(());
-    }
     for (dep_path, pkg) in &graph.packages {
         if pkg.dependencies.is_empty() {
             continue;
@@ -1501,6 +1605,115 @@ mod tests {
         assert!(
             !bin.join("escaped").exists(),
             "a file reachable only through a symlinked subdir must NOT link"
+        );
+    }
+
+    /// Hoisted precedence. Both passes write `node_modules/.bin/probe`;
+    /// the ORDER in `link_all_bins` is what resolves the collision, so a
+    /// direct dep's bin must survive a hoisted transitive's. Names are
+    /// chosen so dep_path order alone would pick the WRONG winner:
+    /// `z-transitive` sorts last, so it wins inside the placements pass
+    /// and only the later direct-dep pass can dislodge it. Reordering the
+    /// two calls flips this assertion.
+    #[test]
+    fn hoisted_direct_dep_bin_beats_a_hoisted_transitive_of_the_same_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let modules = root.join("node_modules");
+
+        let write_pkg = |name: &str| {
+            let pkg_dir = modules.join(name);
+            std::fs::create_dir_all(&pkg_dir).unwrap();
+            std::fs::write(
+                pkg_dir.join("package.json"),
+                format!(
+                    r#"{{"name":"{name}","version":"1.0.0","bin":{{"probe":"cli.js"}}}}"#
+                ),
+            )
+            .unwrap();
+            std::fs::write(pkg_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
+        };
+        write_pkg("a-direct");
+        write_pkg("z-transitive");
+
+        let bin_with_probe = || {
+            let mut b = BTreeMap::new();
+            b.insert("probe".to_string(), "cli.js".to_string());
+            b
+        };
+        let mut direct = locked("a-direct", "1.0.0", bin_with_probe());
+        direct
+            .dependencies
+            .insert("z-transitive".to_string(), "1.0.0".to_string());
+
+        let mut packages = BTreeMap::new();
+        packages.insert("a-direct@1.0.0".to_string(), direct);
+        packages.insert(
+            "z-transitive@1.0.0".to_string(),
+            locked("z-transitive", "1.0.0", bin_with_probe()),
+        );
+        let mut importers = BTreeMap::new();
+        importers.insert(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "a-direct".to_string(),
+                dep_path: "a-direct@1.0.0".to_string(),
+                dep_type: DepType::Production,
+                specifier: Some("^1.0.0".to_string()),
+            }],
+        );
+        let graph = LockfileGraph {
+            packages,
+            importers,
+            ..Default::default()
+        };
+
+        let placements = aube_linker::HoistedPlacements::from_graph(
+            root,
+            &graph,
+            "node_modules",
+            aube_linker::HoistingLimits::None,
+        )
+        .unwrap();
+        assert!(
+            placements.package_dir("z-transitive@1.0.0").is_some(),
+            "fixture is inert unless the transitive was actually placed"
+        );
+
+        let aube_dir = modules.join(".aube");
+        let shim_opts = aube_linker::BinShimOptions::default();
+        let mut cache = PkgJsonCache::new();
+        // Same order as `link_all_bins`: placements, then direct deps.
+        link_hoisted_placement_bins(&aube_dir, &graph, 120, &placements, shim_opts, &mut cache)
+            .unwrap();
+        assert!(
+            modules.join(".bin/probe").symlink_metadata().is_ok(),
+            "the hoisted transitive's bin must be linked at all (the bug)"
+        );
+        link_bins(
+            root,
+            "node_modules",
+            &aube_dir,
+            &graph,
+            120,
+            Some(&placements),
+            shim_opts,
+            &mut cache,
+            None,
+            &mut WsPkgJsonCache::new(),
+        )
+        .unwrap();
+
+        // Canonicalize BOTH sides: on macOS a tempdir lives under `/var`, a
+        // symlink to `/private/var`, so resolving only one side fails the
+        // prefix check on the path spelling rather than on the behavior.
+        let resolved = std::fs::canonicalize(modules.join(".bin/probe")).unwrap();
+        let expected_owner = std::fs::canonicalize(modules.join("a-direct")).unwrap();
+        assert!(
+            resolved.starts_with(&expected_owner),
+            "direct dep must win the name collision; `probe` resolved to {}, expected a target under {}",
+            resolved.display(),
+            expected_owner.display()
         );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
+++ b/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
@@ -578,27 +578,6 @@ pub(super) fn link_bins_for_workspace_dep(
     Ok(())
 }
 
-/// Write per-dep `.bin/` directories holding shims for each package's
-/// *own* declared dependencies. Mirrors pnpm's post-link pass that
-/// populates `node_modules/.pnpm/<dep_path>/node_modules/.bin/`.
-///
-/// Without this, a dep's lifecycle script (e.g. `unrs-resolver`'s
-/// postinstall that calls `prebuild-install`) can't find transitive
-/// binaries on PATH — the project-level `node_modules/.bin` only holds
-/// shims for the root's *direct* deps. `run_dep_hook` prepends the
-/// dep-local `.bin` (via `dep_modules_dir_for`) before the
-/// project-level one so the dep's own transitive bins always win.
-///
-/// Isolated mode only. Under hoisted, `link_hoisted_placement_bins` already
-/// puts every placed package's bins in the `.bin` beside it, which is where
-/// Node resolves that copy from; a nested child's bins therefore sit in the
-/// requester's own `node_modules/.bin`, and `run_dep_hook` puts that
-/// directory on PATH ahead of the shared one. Running this pass under
-/// hoisted would instead write a nested child's bins into the *enclosing*
-/// (often root) `.bin` — a shared directory whose contents are decided by
-/// pass order inside `link_all_bins`, which standalone callers like
-/// `rebuild` do not reproduce. Skipping keeps that directory owned by the
-/// ordered passes alone.
 /// Gate + run the per-dep `.bin` linking pass.
 ///
 /// The link site in `run_link_phase` and the lifecycle site in
@@ -642,6 +621,24 @@ pub(crate) fn maybe_link_dep_bins(
     )
 }
 
+/// Write per-dep `.bin/` directories holding shims for each package's
+/// *own* declared dependencies. Mirrors pnpm's post-link pass that
+/// populates `node_modules/.pnpm/<dep_path>/node_modules/.bin/`.
+///
+/// Without this, a dep's lifecycle script (e.g. `unrs-resolver`'s
+/// postinstall that calls `prebuild-install`) can't find transitive
+/// binaries on PATH — the project-level `node_modules/.bin` only holds
+/// shims for the root's *direct* deps. `run_dep_hook` walks the enclosing
+/// `.bin` chain closest-first, so the dep's own transitive bins win.
+///
+/// Isolated mode only. Under hoisted, `link_hoisted_placement_bins` already
+/// puts every placed package's bins in the `.bin` beside it, which is where
+/// Node resolves that copy from, and `run_dep_hook`'s chain walk reaches
+/// every one of those directories. Running this pass under hoisted would
+/// instead write a nested child's bins into the *enclosing* (often root)
+/// `.bin` — a shared directory whose contents are decided by pass order
+/// inside `link_all_bins`, which standalone callers like `rebuild` do not
+/// reproduce. Skipping keeps that directory owned by the ordered passes.
 pub(crate) fn link_dep_bins(
     aube_dir: &std::path::Path,
     graph: &aube_lockfile::LockfileGraph,

--- a/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
+++ b/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
@@ -1641,9 +1641,7 @@ mod tests {
             std::fs::create_dir_all(&pkg_dir).unwrap();
             std::fs::write(
                 pkg_dir.join("package.json"),
-                format!(
-                    r#"{{"name":"{name}","version":"1.0.0","bin":{{"probe":"cli.js"}}}}"#
-                ),
+                format!(r#"{{"name":"{name}","version":"1.0.0","bin":{{"probe":"cli.js"}}}}"#),
             )
             .unwrap();
             std::fs::write(pkg_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();

--- a/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
+++ b/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
@@ -238,8 +238,12 @@ fn link_bins_of_pkg_dir(
 /// `preferDirectCmds` — a direct dep's bin beats a hoisted transitive's —
 /// without a separate conflict table. Among colliding transitives,
 /// `HoistedPlacements::iter` yields dep_paths in `BTreeMap` order, so the
-/// greatest dep_path wins: deterministic across runs and platforms, and
-/// the same package pnpm's `localeCompare` tiebreak lands on.
+/// greatest dep_path wins — deterministic across runs and platforms.
+/// That matches only the MIDDLE tier of pnpm's `compareCommandsInConflict`
+/// (`pkgOwnsBin` first, then `pkgName.localeCompare`, then `semver`), so a
+/// collision where one package's bin is named after the package itself —
+/// the common CLI-tool shape — can still pick the other one. Closing that
+/// gap needs a real conflict table, not a write order.
 fn link_hoisted_placement_bins(
     aube_dir: &std::path::Path,
     graph: &aube_lockfile::LockfileGraph,
@@ -388,32 +392,15 @@ pub(crate) fn link_all_bins(input: LinkAllBinsInput<'_>) -> miette::Result<()> {
     let mut pkg_json_cache = PkgJsonCache::new();
     let mut ws_pkg_json_cache = WsPkgJsonCache::new();
     let ws_dirs_for_bins = has_workspace.then_some(ws_dirs);
-    // Lowest-precedence bin writers run first; every later pass overwrites
-    // a same-named shim (`create_bin_shim` unlinks before it writes), so
-    // the sequence below IS the conflict-resolution order:
-    //   dep-lifecycle bins < hoisted placements < direct deps < self-bin.
-    //
-    // The first two are hoisted-only in practice. Under isolated both write
-    // exclusively into `.aube/<dep_path>/node_modules/.bin`, which no other
-    // pass touches, so their position here is immaterial there.
-    //
-    // Gate matches the lifecycle phase's (`finalize.rs`) via the shared
-    // `dep_build_scripts_may_run` predicate, threaded through
-    // `maybe_link_dep_bins`: the `defaultTrust` floor can authorize a
-    // package's build scripts with no explicit allow rule, and those
-    // scripts call binaries declared in the package's own `dependencies`
-    // — which must be shimmed into the dep's `.bin` and put on PATH.
-    maybe_link_dep_bins(
-        ignore_scripts,
-        has_any_allow_rule,
-        floor_may_allow_any,
-        aube_dir,
-        graph_for_link,
-        virtual_store_dir_max_length,
-        placements,
-        shim_opts,
-        &mut pkg_json_cache,
-    )?;
+    // Writers into a SHARED `.bin` run lowest-precedence first, because
+    // every later pass overwrites a same-named shim (`create_bin_shim`
+    // unlinks before it writes). That makes the order below the whole
+    // conflict resolution for the hoisted layout:
+    //   hoisted placements < direct deps < self-bin.
+    // `maybe_link_dep_bins` is deliberately NOT part of this sequence — it
+    // is isolated-only, and its per-dep targets are disjoint from every
+    // `.bin` written here, so it stays at the end where standalone callers
+    // (`rebuild`) can reuse it without inheriting an ordering contract.
     if let Some(placements) = placements {
         link_hoisted_placement_bins(
             aube_dir,
@@ -520,6 +507,23 @@ pub(crate) fn link_all_bins(input: LinkAllBinsInput<'_>) -> miette::Result<()> {
             }
         }
     }
+    // Gate matches the lifecycle phase's (`finalize.rs`) via the shared
+    // `dep_build_scripts_may_run` predicate, threaded through
+    // `maybe_link_dep_bins`: the `defaultTrust` floor can authorize a
+    // package's build scripts with no explicit allow rule, and those
+    // scripts call binaries declared in the package's own `dependencies`
+    // — which must be shimmed into the dep's `.bin` and put on PATH.
+    maybe_link_dep_bins(
+        ignore_scripts,
+        has_any_allow_rule,
+        floor_may_allow_any,
+        aube_dir,
+        graph_for_link,
+        virtual_store_dir_max_length,
+        placements,
+        shim_opts,
+        &mut pkg_json_cache,
+    )?;
     Ok(())
 }
 
@@ -585,12 +589,16 @@ pub(super) fn link_bins_for_workspace_dep(
 /// dep-local `.bin` (via `dep_modules_dir_for`) before the
 /// project-level one so the dep's own transitive bins always win.
 ///
-/// Runs under both layouts. Under hoisted, `dep_modules_dir_for` resolves
-/// to whichever `node_modules/` the dep was hoisted into, so a nested
-/// child's bins land in the directory the parent's script actually gets on
-/// PATH — `run_dep_hook` prepends exactly one dep `.bin`, and for a nested
-/// child that is *not* the child's own sibling `.bin`. This pass is what
-/// closes that gap; `link_hoisted_placement_bins` handles the layout side.
+/// Isolated mode only. Under hoisted, `link_hoisted_placement_bins` already
+/// puts every placed package's bins in the `.bin` beside it, which is where
+/// Node resolves that copy from; a nested child's bins therefore sit in the
+/// requester's own `node_modules/.bin`, and `run_dep_hook` puts that
+/// directory on PATH ahead of the shared one. Running this pass under
+/// hoisted would instead write a nested child's bins into the *enclosing*
+/// (often root) `.bin` — a shared directory whose contents are decided by
+/// pass order inside `link_all_bins`, which standalone callers like
+/// `rebuild` do not reproduce. Skipping keeps that directory owned by the
+/// ordered passes alone.
 /// Gate + run the per-dep `.bin` linking pass.
 ///
 /// The link site in `run_link_phase` and the lifecycle site in
@@ -642,6 +650,10 @@ pub(crate) fn link_dep_bins(
     shim_opts: aube_linker::BinShimOptions,
     cache: &mut PkgJsonCache,
 ) -> miette::Result<()> {
+    if placements.is_some() {
+        // Hoisted — skip. See function doc.
+        return Ok(());
+    }
     for (dep_path, pkg) in &graph.packages {
         if pkg.dependencies.is_empty() {
             continue;
@@ -1615,6 +1627,12 @@ mod tests {
     /// `z-transitive` sorts last, so it wins inside the placements pass
     /// and only the later direct-dep pass can dislodge it. Reordering the
     /// two calls flips this assertion.
+    ///
+    /// Unix-only: it reads the winner back by canonicalizing the `.bin`
+    /// entry, which requires the symlink layout. On Windows
+    /// `create_bin_shim` writes `probe`/`probe.cmd`/`probe.ps1` as regular
+    /// files, so `canonicalize` would resolve to the shim itself.
+    #[cfg(unix)]
     #[test]
     fn hoisted_direct_dep_bin_beats_a_hoisted_transitive_of_the_same_name() {
         let dir = tempfile::tempdir().unwrap();

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -1,6 +1,6 @@
 use miette::{Context, IntoDiagnostic, miette};
 
-use super::bin_linking::{dep_modules_dir_for, materialized_pkg_dir};
+use super::bin_linking::materialized_pkg_dir;
 use super::node_gyp_bootstrap;
 use super::side_effects_cache::{
     SideEffectsCacheConfig, SideEffectsCacheEntry, SideEffectsCacheRestore,
@@ -424,12 +424,6 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         source_key: Option<String>,
         git_repository_key: Option<String>,
         package_dir: std::path::PathBuf,
-        /// Directory containing the dep package and its sibling
-        /// symlinks — i.e. `package_dir`'s enclosing `node_modules/`.
-        /// `<dep_modules_dir>/.bin` is prepended to PATH so the
-        /// postinstall can call binaries declared in the dep's own
-        /// `dependencies`. See `link_dep_bins` for the write side.
-        dep_modules_dir: std::path::PathBuf,
         manifest: aube_manifest::PackageJson,
         cache_entry: Option<SideEffectsCacheEntry>,
     }
@@ -549,7 +543,6 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             .location()
             .map(|loc| SideEffectsCacheEntry::new(loc, &pkg.name, &pkg.version, &package_dir))
             .transpose()?;
-        let dep_modules_dir = dep_modules_dir_for(&package_dir, &pkg.name);
         if via_floor {
             floor_trusted.push(pkg.spec_key());
         }
@@ -560,7 +553,6 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             source_key: pkg.source_approval_key(),
             git_repository_key: pkg.git_repository_approval_key(),
             package_dir,
-            dep_modules_dir,
             manifest: dep_manifest,
             cache_entry,
         });
@@ -698,7 +690,6 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             for hook in aube_scripts::DEP_LIFECYCLE_HOOKS {
                 let did_run = aube_scripts::run_dep_hook(
                     &job.package_dir,
-                    &job.dep_modules_dir,
                     &project_dir,
                     &modules_dir_name,
                     &job.manifest,

--- a/vendor/aube/test/hoisted.bats
+++ b/vendor/aube/test/hoisted.bats
@@ -104,3 +104,36 @@ YAML
 	assert_failure
 	assert_output --partial "unknown --node-linker value"
 }
+
+# Regression: hoisted layout did not link the bins of hoisted transitive
+# deps. `link_bins` walked only the root importer's direct deps, and the
+# per-dep pass short-circuited under hoisted, so a transitive hoisted into
+# the shared `node_modules/` had its bins linked nowhere — every lifecycle
+# script invoking one exited 127. pnpm's hoisted layout links the bins of
+# every package sitting in a `node_modules/` into that directory's `.bin`.
+#
+# `aube-test-transitive-consumer` postinstalls `aube-transitive-bin-probe`,
+# a bin owned by its transitive `aube-test-transitive-bin`. The probe writes
+# a marker into `$INIT_CWD`, so the marker proves the bin resolved on PATH
+# during the script; the `.bin` assertion pins the layout independently of
+# whether any script ran.
+@test "hoisted mode links bins of hoisted transitive deps" {
+	cat >package.json <<'JSON'
+{
+  "name": "hoisted-transitive-bin-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "aube-test-transitive-consumer": "^1.0.0"
+  },
+  "pnpm": {
+    "allowBuilds": {
+      "aube-test-transitive-consumer": true
+    }
+  }
+}
+JSON
+	run aube install --node-linker=hoisted
+	assert_success
+	assert_file_exists aube-transitive-bin-probe.txt
+	assert_file_exists node_modules/.bin/aube-transitive-bin-probe
+}


### PR DESCRIPTION
Under the hoisted linker, bins were linked only for the root importer's direct deps and the per-dep pass skipped hoisted, so a hoisted transitive's bins landed nowhere and any lifecycle script invoking one exited 127.

Mirrors pnpm's hoisted layout: every package in a `node_modules/` gets its bins in that directory's `.bin`, driven off `HoistedPlacements`. The per-dep pass now runs under hoisted too, since a script gets only its containing directory's `.bin` on PATH. Passes run lowest-precedence first (dep-lifecycle, placements, direct deps, self-bin), so a direct dep still wins a name collision.

Verified on the issue's `bufferutil@4.1.0` fixture: hoisted goes 1 → 0.

Closes #570
