### PR TITLE
fix(linker): stage every materialize so a failed link cannot poison the store

### DIFF
--- a/vendor/aube/crates/aube-linker/src/hoisted.rs
+++ b/vendor/aube/crates/aube-linker/src/hoisted.rs
@@ -817,7 +817,8 @@ fn materialize_hoisted_node(
             }
         }
         for parent in &parents {
-            std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.clone(), e))?;
+            crate::sweep::with_transient_retry(|| std::fs::create_dir_all(parent))
+                .map_err(|e| Error::Io(parent.clone(), e))?;
         }
 
         for (rel_path, stored) in index {

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -1896,7 +1896,16 @@ fn reconcile_top_level_link(link_path: &Path, expected_target: &Path) -> Result<
         if link_path.symlink_metadata().is_err() {
             return Ok(false);
         }
-        match std::fs::remove_dir(link_path).or_else(|_| std::fs::remove_file(link_path)) {
+        // Retried: this is a top-level `node_modules/<name>` entry, the most
+        // likely thing in the tree to be held open by something the user is
+        // running — a dev server, a `--watch` task, an editor, Defender
+        // mid-scan. Failure here is FATAL to the install (the `Err` arm below),
+        // so an unretried sharing violation aborts a whole reinstall over a
+        // handle that would have cleared in milliseconds.
+        let removed = crate::sweep::with_transient_retry(|| {
+            std::fs::remove_dir(link_path).or_else(|_| std::fs::remove_file(link_path))
+        });
+        match removed {
             Ok(()) => Ok(false),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
             Err(e) => Err(Error::Io(link_path.to_path_buf(), e)),

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -242,21 +242,23 @@ impl Linker {
                     ));
                 }
             }
-            if !aube_entry.exists() {
-                self.materialize_into(
-                    &aube_dir,
-                    &aube_dir,
-                    dep_path,
-                    graph,
-                    pkg,
-                    index,
-                    &mut stats,
-                    false,
-                    nested_link_targets.as_ref(),
-                )?;
-            } else {
-                stats.packages_cached += 1;
-            }
+            // Staged through `.tmp-<pid>-<id>` + atomic rename rather than
+            // written straight into the final entry. A direct write that fails
+            // partway leaves a half-populated `<dep_path>/` behind — and every
+            // later run's `exists()` gate then reports that package as already
+            // linked, so the tree never converges and `rm -rf node_modules` is
+            // the only way out (#552). Staging makes the failure atomic: the
+            // remains are a `.tmp-*` dir, which `sweep_stale_tmp_dirs` reclaims
+            // on the next install.
+            self.ensure_in_aube_dir(
+                &aube_dir,
+                dep_path,
+                graph,
+                pkg,
+                index,
+                &mut stats,
+                nested_link_targets.as_ref(),
+            )?;
         }
 
         if self.use_global_virtual_store {
@@ -430,9 +432,26 @@ impl Linker {
                                 // Drop a stale shared-store symlink/junction left by
                                 // a prior GVS install or the fetch prewarm before
                                 // materializing the real project-local dir.
+                                //
+                                // The removal must be checked, not best-effort:
+                                // `ensure_in_aube_dir` opens with an `exists()` gate,
+                                // and `exists()` FOLLOWS a symlink. A surviving link
+                                // whose target is live would read as "already
+                                // materialized" and silently skip the ejection — the
+                                // package would stay a store symlink, which is exactly
+                                // what disk-materialize exists to prevent. Fail loudly
+                                // instead.
                                 if std::fs::read_link(&local_aube_entry).is_ok() {
-                                    let _ = std::fs::remove_dir(&local_aube_entry)
-                                        .or_else(|_| std::fs::remove_file(&local_aube_entry));
+                                    try_remove_entry(&local_aube_entry);
+                                    if std::fs::symlink_metadata(&local_aube_entry).is_ok() {
+                                        return Err(Error::Io(
+                                            local_aube_entry.clone(),
+                                            std::io::Error::other(
+                                                "failed to remove stale shared-store link before \
+                                                 disk-materializing the package",
+                                            ),
+                                        ));
+                                    }
                                 }
                                 // Undeclared imports this ejected package makes are
                                 // resolved by the collective project-local hidden
@@ -441,15 +460,16 @@ impl Linker {
                                 // so Node's upward walk from inside it reaches
                                 // `.aube/node_modules/`. So materialize the copy with
                                 // its own edges; no per-importer sibling injection.
-                                self.materialize_into(
-                                    &aube_dir,
+                                // Staged (see the note in step 1) so a partial
+                                // failure leaves no entry to be mistaken for a
+                                // complete one.
+                                self.ensure_in_aube_dir(
                                     &aube_dir,
                                     dep_path,
                                     graph,
                                     pkg,
                                     index,
                                     &mut local_stats,
-                                    false,
                                     nested_link_targets.as_ref(),
                                 )?;
                                 return Ok(local_stats);
@@ -590,15 +610,17 @@ impl Linker {
                                     &owned_index
                                 }
                             };
-                            self.materialize_into(
-                                &aube_dir,
+                            // Staged (see the note in `link_all` step 1). The
+                            // `exists()` fast path above stays — it is what
+                            // keeps a warm run off `load_index` — and the
+                            // re-check inside costs one stat on the cold path.
+                            self.ensure_in_aube_dir(
                                 &aube_dir,
                                 dep_path,
                                 graph,
                                 pkg,
                                 index,
                                 &mut local_stats,
-                                false,
                                 nested_link_targets.as_ref(),
                             )?;
                             Ok(local_stats)
@@ -918,6 +940,12 @@ impl Linker {
         mkdirp(&aube_dir)?;
         mkdirp(&root_nm)?;
 
+        // Mirrors `link_all`. A crash or Ctrl+C between materialize and the
+        // atomic rename strands a `.tmp-<pid>-*` dir, and nothing else
+        // reclaims them — `link_workspace` was missing this sweep entirely, so
+        // its staged materializations leaked one per aborted install.
+        sweep_stale_tmp_dirs(&aube_dir);
+
         let mut stats = LinkStats::default();
 
         // Patch reconciliation. Mirrors `link_all`'s logic: wipe
@@ -996,19 +1024,15 @@ impl Linker {
                     ));
                 }
             }
-            if aube_entry.exists() {
-                stats.packages_cached += 1;
-                continue;
-            }
-            self.materialize_into(
-                &aube_dir,
+            // Staged (see the note in `link_all` step 1); `ensure_in_aube_dir`
+            // owns the exists-is-cached check as well.
+            self.ensure_in_aube_dir(
                 &aube_dir,
                 dep_path,
                 graph,
                 pkg,
                 index,
                 &mut stats,
-                false,
                 nested_link_targets.as_ref(),
             )?;
         }
@@ -1155,15 +1179,17 @@ impl Linker {
                                     &owned_index
                                 }
                             };
-                            self.materialize_into(
-                                &aube_dir,
+                            // Staged (see the note in `link_all` step 1). The
+                            // `exists()` fast path above stays — it is what
+                            // keeps a warm run off `load_index` — and the
+                            // re-check inside costs one stat on the cold path.
+                            self.ensure_in_aube_dir(
                                 &aube_dir,
                                 dep_path,
                                 graph,
                                 pkg,
                                 index,
                                 &mut local_stats,
-                                false,
                                 nested_link_targets.as_ref(),
                             )?;
                             Ok(local_stats)

--- a/vendor/aube/crates/aube-linker/src/materialize.rs
+++ b/vendor/aube/crates/aube-linker/src/materialize.rs
@@ -42,13 +42,42 @@ fn place_materialized_entry(src: &Path, dst: &Path) -> io::Result<MaterializePla
 }
 
 fn is_transient_rename_error(err: &io::Error) -> bool {
-    matches!(
+    if matches!(
         err.kind(),
         io::ErrorKind::AlreadyExists
             | io::ErrorKind::PermissionDenied
             | io::ErrorKind::Interrupted
             | io::ErrorKind::WouldBlock
-    )
+    ) {
+        return true;
+    }
+    // `ERROR_SHARING_VIOLATION` (32) has no `ErrorKind` mapping in std — it
+    // decodes to `Uncategorized`, which no `matches!` arm can name — so the
+    // list above was silently blind to the most common transient this rename
+    // hits (#552). Gated to Windows because raw 32 is EPIPE on Unix, an
+    // unrelated errno that must not be treated as a retriable rename.
+    #[cfg(windows)]
+    {
+        return crate::sweep::is_transient_fs_error(err);
+    }
+    #[cfg(not(windows))]
+    false
+}
+
+/// The terminal byte-transfer of a materialized file, retried through
+/// transient Windows sharing violations.
+///
+/// Every strategy in `link_file_fresh` ends here: reflink and hardlink both
+/// degrade to a copy, and `LinkStrategy::Copy` starts here. That makes this
+/// the one place where a lost race with another process's handle is FATAL to
+/// the whole install rather than recoverable — a single `ERROR_SHARING_VIOLATION`
+/// on any one of tens of thousands of files aborted the entire link (#552),
+/// while the junction and directory-removal paths had carried a retry all
+/// along. The upstream `hard_link`/`reflink` attempts deliberately do NOT
+/// retry: they already fall through to this copy, so retrying them too would
+/// double the worst-case stall per file for no added recovery.
+fn copy_through_transients(src: &Path, dst: &Path) -> io::Result<u64> {
+    crate::sweep::with_transient_retry(|| std::fs::copy(src, dst))
 }
 
 /// Test-only switch that forces the reflink attempt in
@@ -792,8 +821,7 @@ impl Linker {
 
     /// Hardlink-or-copy a file into a freshly-created destination.
     /// Assumes `dst` does not exist — callers (`materialize_into`)
-    /// always write into a `.tmp-<pid>-...` staging dir or a
-    /// just-wiped per-project `.aube/<dep_path>`, so the defensive
+    /// always write into a `.tmp-<pid>-...` staging dir, so the defensive
     /// `remove_file(dst)` an idempotent variant would need is skipped.
     /// Eliminates one syscall per linked file (~45k on the medium
     /// benchmark fixture).
@@ -834,7 +862,7 @@ impl Linker {
                 let auto = matches!(self.strategy, LinkStrategy::ReflinkAuto);
                 #[cfg(target_os = "macos")]
                 if matches!(stored.size, Some(size) if size <= SMALL_FILE_COPY_MAX) {
-                    std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
+                    copy_through_transients(&stored.store_path, dst).map_err(map_io)?;
                     if let Some(t0) = diag_t0 {
                         aube_util::diag::event(
                             aube_util::diag::Category::Linker,
@@ -910,7 +938,7 @@ impl Linker {
                         if !auto {
                             trace!("reflink failed, falling back to copy: {e}");
                         }
-                        std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
+                        copy_through_transients(&stored.store_path, dst).map_err(map_io)?;
                         realized = "reflink_fallback_copy";
                     }
                 } else {
@@ -925,14 +953,14 @@ impl Linker {
                     }
                     // Fall back to copy on cross-filesystem errors (EXDEV)
                     trace!("hardlink failed, falling back to copy: {e}");
-                    std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
+                    copy_through_transients(&stored.store_path, dst).map_err(map_io)?;
                     realized = "hardlink_fallback_copy";
                 } else {
                     realized = "hardlink";
                 }
             }
             LinkStrategy::Copy => {
-                std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
+                copy_through_transients(&stored.store_path, dst).map_err(map_io)?;
                 realized = "copy";
             }
         }
@@ -1385,6 +1413,35 @@ fn is_safe_package_component(component: &str) -> bool {
                 | std::path::Component::Prefix(_)
         )
     })
+}
+
+#[cfg(test)]
+mod transient_error_tests {
+    use super::*;
+
+    #[test]
+    fn sharing_violation_is_retriable_only_on_windows() {
+        // Rust maps ERROR_SHARING_VIOLATION (32) to no `ErrorKind` at all — it
+        // decodes to `Uncategorized` — so the ErrorKind-only predicate this
+        // guards silently never fired for the most common Windows transient
+        // (#552). Raw 32 is EPIPE on Unix, an unrelated errno that must NOT
+        // become a retriable rename.
+        assert_eq!(
+            is_transient_rename_error(&io::Error::from_raw_os_error(32)),
+            cfg!(windows),
+            "os 32 = SHARING_VIOLATION on Windows (retriable), EPIPE on Unix (not)"
+        );
+    }
+
+    #[test]
+    fn mapped_error_kinds_stay_retriable_everywhere() {
+        assert!(is_transient_rename_error(&io::Error::from(
+            io::ErrorKind::AlreadyExists
+        )));
+        assert!(!is_transient_rename_error(&io::Error::from(
+            io::ErrorKind::NotFound
+        )));
+    }
 }
 
 #[cfg(test)]

--- a/vendor/aube/crates/aube-linker/src/patches.rs
+++ b/vendor/aube/crates/aube-linker/src/patches.rs
@@ -467,9 +467,7 @@ fn evaluate_hunk(
     }
     let mut context_index = base as usize;
     // `fileLines.length - contextIndex < original.length` → null.
-    if file_lines.len() < context_index
-        || file_lines.len() - context_index < hunk.original_length
-    {
+    if file_lines.len() < context_index || file_lines.len() - context_index < hunk.original_length {
         return None;
     }
 
@@ -532,7 +530,9 @@ fn apply_hunks(base_image: &str, hunks: &[Hunk]) -> Result<String, String> {
                 -fuzzing_offset - 1
             };
             if fuzzing_offset.abs() > 20 {
-                return Err(format!("could not apply hunk {i} (offset drift > 20 lines)"));
+                return Err(format!(
+                    "could not apply hunk {i} (offset drift > 20 lines)"
+                ));
             }
         };
         all_mods.push(mods);
@@ -551,7 +551,9 @@ fn apply_hunks(base_image: &str, hunks: &[Hunk]) -> Result<String, String> {
                 } => {
                     let at = (*index as isize + diff_offset) as usize;
                     let end = (at + num_to_delete).min(file_lines.len());
-                    let removed: Vec<String> = file_lines.splice(at..end, lines_to_insert.iter().cloned()).collect();
+                    let removed: Vec<String> = file_lines
+                        .splice(at..end, lines_to_insert.iter().cloned())
+                        .collect();
                     diff_offset += lines_to_insert.len() as isize - removed.len() as isize;
                 }
                 Modification::Pop => {
@@ -1191,7 +1193,8 @@ mod tests {
         // no-trailing-newline EOF. With the newline-agnostic line array
         // this round-trips for free — the marker is informational here.
         let original = "a\nb\nlast";
-        let body = "--- a/x\n+++ b/x\n@@ -1,3 +1,3 @@\n a\n-b\n+B\n last\n\\ No newline at end of file\n";
+        let body =
+            "--- a/x\n+++ b/x\n@@ -1,3 +1,3 @@\n a\n-b\n+B\n last\n\\ No newline at end of file\n";
         assert_eq!(apply_body(original, body).unwrap(), "a\nB\nlast");
     }
 
@@ -1237,7 +1240,10 @@ mod tests {
         // comparing; the old diffy byte-exact match rejected. We match.
         let original = "alpha   \nbeta\ngamma\n"; // "alpha" has trailing spaces
         let body = "--- a/x\n+++ b/x\n@@ -1,3 +1,3 @@\n alpha\n-beta\n+BETA\n gamma\n";
-        assert_eq!(apply_body(original, body).unwrap(), "alpha   \nBETA\ngamma\n");
+        assert_eq!(
+            apply_body(original, body).unwrap(),
+            "alpha   \nBETA\ngamma\n"
+        );
     }
 
     #[test]
@@ -1300,8 +1306,12 @@ mod tests {
     #[test]
     fn happy_path_simple_edit_byte_identical() {
         let original = "module.exports = 'old';\n";
-        let body = "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-module.exports = 'old';\n+module.exports = 'new';\n";
-        assert_eq!(apply_body(original, body).unwrap(), "module.exports = 'new';\n");
+        let body =
+            "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-module.exports = 'old';\n+module.exports = 'new';\n";
+        assert_eq!(
+            apply_body(original, body).unwrap(),
+            "module.exports = 'new';\n"
+        );
     }
 
     #[test]
@@ -1310,7 +1320,10 @@ mod tests {
         let body = "--- a/x\n+++ b/x\n\
                     @@ -1,3 +1,3 @@\n 1\n-2\n+TWO\n 3\n\
                     @@ -6,3 +6,3 @@\n 6\n-7\n+SEVEN\n 8\n";
-        assert_eq!(apply_body(original, body).unwrap(), "1\nTWO\n3\n4\n5\n6\nSEVEN\n8\n");
+        assert_eq!(
+            apply_body(original, body).unwrap(),
+            "1\nTWO\n3\n4\n5\n6\nSEVEN\n8\n"
+        );
     }
 
     #[test]

--- a/vendor/aube/crates/aube-linker/src/sweep.rs
+++ b/vendor/aube/crates/aube-linker/src/sweep.rs
@@ -160,16 +160,34 @@ pub(crate) fn remove_hidden_hoist_tree(path: &Path) {
 /// to place something else here and any residual entry that survives
 /// will surface as a downstream error.
 pub(crate) fn try_remove_entry(path: &Path) {
-    let _ = std::fs::remove_dir_all(path);
+    // Retried: on Windows a single handle held by a watcher, an editor, or
+    // Defender mid-scan makes `remove_dir_all` abort PARTWAY, leaving some of
+    // the old tree behind. Callers refill the slot afterwards, and a refill
+    // over a surviving old tree silently blends two package versions — files
+    // the old version had and the new one does not are never overwritten, so
+    // they persist and stay resolvable. Backing off clears the common case.
+    let _ = with_transient_retry(|| std::fs::remove_dir_all(path));
     let _ = std::fs::remove_file(path);
 }
 
-/// `xx::file::mkdirp` wrapped with the linker's `Error::Xx` conversion.
-/// Every materialize pass calls this before creating a symlink /
-/// junction, so the lossy `.to_string()` wrap lives in exactly one
-/// place.
+/// Recursive directory creation, retried through Windows' transient
+/// sharing errors. Every materialize pass calls this before creating a
+/// symlink / junction, so the retry and the path-carrying error
+/// conversion live in exactly one place.
 pub fn mkdirp(dir: &Path) -> Result<(), Error> {
-    xx::file::mkdirp(dir).map_err(|e| Error::Xx(e.to_string()))
+    // Calls `std::fs::create_dir_all` rather than `xx::file::mkdirp` so the
+    // raw OS error survives: `xx` wraps it in its own error type, and the
+    // retry predicate below matches on `raw_os_error()`, so a wrapped error
+    // would silently never be retriable. `xx::file::mkdirp` is an `exists()`
+    // check plus this same call, and `create_dir_all` is already a no-op on an
+    // existing directory, so dropping the check changes nothing.
+    //
+    // Retried because creating a directory whose slot is in Windows'
+    // pending-delete state returns ACCESS_DENIED — a state reachable precisely
+    // because a wipe just ran against a path something else holds open.
+    // Failure here is fatal to the install.
+    with_transient_retry(|| std::fs::create_dir_all(dir))
+        .map_err(|e| Error::Io(dir.to_path_buf(), e))
 }
 
 /// Classification of a `.aube/<dep_path>` symlink relative to the

--- a/vendor/aube/crates/aube-linker/src/sweep.rs
+++ b/vendor/aube/crates/aube-linker/src/sweep.rs
@@ -61,29 +61,44 @@ pub(crate) fn is_transient_fs_error(e: &std::io::Error) -> bool {
     matches!(e.raw_os_error(), Some(5 | 32))
 }
 
-/// Retry ladder shared by every operation that can lose a race with
-/// another process's handle: 10 attempts, 50ms doubling to a 2s cap,
-/// ~10s worst case. Long enough to outlast an AV scan, short enough that
-/// a genuinely stuck file fails the install rather than hanging it.
-///
-/// Unix is a straight passthrough — the failure mode does not exist there
-/// (an open file can be replaced or unlinked freely), so behavior off
-/// Windows is byte-for-byte unchanged.
+/// Full ladder for an operation whose failure is FATAL to the install:
+/// 10 attempts, 50ms doubling to a 2s cap, ~10s worst case. Long enough to
+/// outlast an AV scan, short enough that a genuinely stuck file fails the
+/// install rather than hanging it.
 pub(crate) fn with_transient_retry<T>(
+    op: impl FnMut() -> std::io::Result<T>,
+) -> std::io::Result<T> {
+    with_transient_retry_bounded(10, op)
+}
+
+/// Short ladder for a BEST-EFFORT operation the caller proceeds past either
+/// way: 4 attempts, ~750ms worst case.
+///
+/// The distinction is about where the call sits, not how much we want it to
+/// succeed. Best-effort removals run once per entry inside sweep loops, so a
+/// ~10s ladder does not cost 10s — it costs 10s PER LOCKED ENTRY, and a branch
+/// switch with a dev server running turns that into a multi-minute stall on
+/// what is supposed to be a cleanup pass. The transient being waited out (an
+/// AV scan window) clears well inside a second, so the short ladder catches
+/// essentially all of what the long one would.
+pub(crate) fn with_transient_retry_bounded<T>(
+    #[cfg_attr(not(windows), allow(unused_variables))] attempts: u32,
     mut op: impl FnMut() -> std::io::Result<T>,
 ) -> std::io::Result<T> {
+    // Unix is a straight passthrough — the failure mode does not exist there
+    // (an open file can be replaced or unlinked freely), so behavior off
+    // Windows is byte-for-byte unchanged.
     #[cfg(not(windows))]
     {
         op()
     }
     #[cfg(windows)]
     {
-        const ATTEMPTS: u32 = 10;
-        for attempt in 0..ATTEMPTS {
+        for attempt in 0..attempts.max(1) {
             match op() {
                 Ok(v) => return Ok(v),
                 Err(e) => {
-                    if !is_transient_fs_error(&e) || attempt == ATTEMPTS - 1 {
+                    if !is_transient_fs_error(&e) || attempt == attempts.max(1) - 1 {
                         return Err(e);
                     }
                     let delay = (50u64 << attempt.min(6)).min(2000);
@@ -166,7 +181,10 @@ pub(crate) fn try_remove_entry(path: &Path) {
     // over a surviving old tree silently blends two package versions — files
     // the old version had and the new one does not are never overwritten, so
     // they persist and stay resolvable. Backing off clears the common case.
-    let _ = with_transient_retry(|| std::fs::remove_dir_all(path));
+    //
+    // Short ladder: this runs once per entry inside the sweep loops, where the
+    // full one would multiply into a multi-minute stall.
+    let _ = with_transient_retry_bounded(4, || std::fs::remove_dir_all(path));
     let _ = std::fs::remove_file(path);
 }
 

--- a/vendor/aube/crates/aube-linker/src/sweep.rs
+++ b/vendor/aube/crates/aube-linker/src/sweep.rs
@@ -43,6 +43,58 @@ pub fn sweep_stale_tmp_dirs(virtual_store: &Path) {
     }
 }
 
+/// Whether a Windows filesystem error is the transient
+/// somebody-else-holds-a-handle kind that backing off will clear:
+/// `ERROR_SHARING_VIOLATION` (32) or `ERROR_ACCESS_DENIED` (5), raised
+/// whenever another process has the file open — Defender mid-scan, the
+/// search indexer, a dev server, a `--watch` task, an editor.
+///
+/// Test the RAW code, never `ErrorKind` alone. Rust maps
+/// `ERROR_ACCESS_DENIED` to `PermissionDenied` but has NO mapping for
+/// `ERROR_SHARING_VIOLATION` — it falls through `decode_error_kind` into
+/// `Uncategorized`, which no `matches!` arm can name. An `ErrorKind`-only
+/// predicate therefore silently never fires for the single most common
+/// transient on Windows, which is how the rename retry in
+/// `place_materialized_entry` came to be dead code for os 32 (#552).
+#[cfg(windows)]
+pub(crate) fn is_transient_fs_error(e: &std::io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(5 | 32))
+}
+
+/// Retry ladder shared by every operation that can lose a race with
+/// another process's handle: 10 attempts, 50ms doubling to a 2s cap,
+/// ~10s worst case. Long enough to outlast an AV scan, short enough that
+/// a genuinely stuck file fails the install rather than hanging it.
+///
+/// Unix is a straight passthrough — the failure mode does not exist there
+/// (an open file can be replaced or unlinked freely), so behavior off
+/// Windows is byte-for-byte unchanged.
+pub(crate) fn with_transient_retry<T>(
+    mut op: impl FnMut() -> std::io::Result<T>,
+) -> std::io::Result<T> {
+    #[cfg(not(windows))]
+    {
+        op()
+    }
+    #[cfg(windows)]
+    {
+        const ATTEMPTS: u32 = 10;
+        for attempt in 0..ATTEMPTS {
+            match op() {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    if !is_transient_fs_error(&e) || attempt == ATTEMPTS - 1 {
+                        return Err(e);
+                    }
+                    let delay = (50u64 << attempt.min(6)).min(2000);
+                    std::thread::sleep(std::time::Duration::from_millis(delay));
+                }
+            }
+        }
+        unreachable!("the loop returns on the final attempt")
+    }
+}
+
 /// Remove a directory with retry on Windows sharing violations.
 ///
 /// Windows does not let you delete a file while another process holds
@@ -51,10 +103,6 @@ pub fn sweep_stale_tmp_dirs(virtual_store: &Path) {
 /// 32 (SHARING_VIOLATION) or ERROR 5 (ACCESS_DENIED, AV scanner
 /// mid-scan) and leaves a half-deleted virtual store. pnpm, npm,
 /// rimraf all retry with backoff. Do the same. Unix passthrough.
-///
-/// Retries 10 times with exponential backoff starting at 50ms. Total
-/// worst case around 10 seconds which is tolerable for an install
-/// already paying for filesystem work.
 pub fn remove_dir_all_with_retry(path: &Path) -> std::io::Result<()> {
     #[cfg(not(windows))]
     {
@@ -62,29 +110,12 @@ pub fn remove_dir_all_with_retry(path: &Path) -> std::io::Result<()> {
     }
     #[cfg(windows)]
     {
-        use std::io::ErrorKind;
-        let mut delay_ms = 50u64;
-        for attempt in 0..10 {
-            match std::fs::remove_dir_all(path) {
-                Ok(()) => return Ok(()),
-                Err(e) if e.kind() == ErrorKind::NotFound => return Ok(()),
-                Err(e) => {
-                    // Sharing violation and PermissionDenied both
-                    // map to retriable Windows errors. Bail on
-                    // attempt 10.
-                    let retriable =
-                        matches!(e.kind(), ErrorKind::PermissionDenied | ErrorKind::Other)
-                            || e.raw_os_error() == Some(32);
-                    if !retriable || attempt == 9 {
-                        return Err(e);
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-                    delay_ms = (delay_ms * 2).min(2000);
-                }
-            }
+        // Already gone — including a concurrent remover winning the race —
+        // is success, not failure.
+        match with_transient_retry(|| std::fs::remove_dir_all(path)) {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            other => other,
         }
-        // Unreachable, loop always returns by attempt 10.
-        Ok(())
     }
 }
 

--- a/vendor/aube/crates/aube-linker/src/sys.rs
+++ b/vendor/aube/crates/aube-linker/src/sys.rs
@@ -121,17 +121,6 @@ fn create_junction_with_retry(target: &Path, link: &Path) -> io::Result<()> {
     loop {
         match junction::create(target, link) {
             Ok(()) => return Ok(()),
-            // `ERROR_ALREADY_EXISTS` when the junction ALREADY points where we
-            // were going to point it is a no-op, not a conflict. Callers reach
-            // here after their own stale-entry reconciliation, so a surviving
-            // correct entry means a concurrent writer (the fetch-phase prewarm,
-            // a parallel install) got there first — the outcome we wanted.
-            // Treating it as fatal is what surfaced as `os error 183` on a
-            // sibling entry during an incremental `add` (#576). A junction
-            // pointing SOMEWHERE ELSE is still a real error and still fails.
-            Err(e) if e.raw_os_error() == Some(183) && junction_points_at(link, target) => {
-                return Ok(());
-            }
             Err(e) if is_retriable_link_error(&e) && attempt < 9 => {
                 std::thread::sleep(std::time::Duration::from_millis(delay_ms));
                 delay_ms = (delay_ms * 2).min(2000);
@@ -139,21 +128,6 @@ fn create_junction_with_retry(target: &Path, link: &Path) -> io::Result<()> {
             }
             Err(e) => return Err(e),
         }
-    }
-}
-
-/// Whether `link` is already a reparse point resolving to `target`.
-///
-/// Compared through `canonicalize` on both sides so an `8.3` short name, a
-/// case difference, or a `\\?\` verbatim prefix on one side alone does not
-/// read as a mismatch and turn a benign collision back into a hard failure.
-#[cfg(windows)]
-fn junction_points_at(link: &Path, target: &Path) -> bool {
-    match (std::fs::canonicalize(link), std::fs::canonicalize(target)) {
-        (Ok(l), Ok(t)) => l == t,
-        // Cannot prove they match — treat as a mismatch so the caller still
-        // sees the error rather than silently accepting a wrong entry.
-        _ => false,
     }
 }
 
@@ -1166,40 +1140,6 @@ mod tests {
     fn normalize_collapses_parent_and_cur_dir() {
         let p = Path::new(r"C:\a\b\.\..\c\d\..\e");
         assert_eq!(normalize_path(p), PathBuf::from(r"C:\a\c\e"));
-    }
-
-    // nubjs/nub#576: `ERROR_ALREADY_EXISTS` on a junction that already points
-    // where we wanted it is the concurrent-writer outcome we asked for, not a
-    // conflict. Runs only on the windows-latest CI leg — junctions have no
-    // POSIX equivalent to exercise.
-    #[cfg(windows)]
-    #[test]
-    fn recreating_a_junction_at_its_existing_target_succeeds() {
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("target");
-        let link = dir.path().join("link");
-        std::fs::create_dir_all(&target).unwrap();
-
-        create_dir_link(&target, &link).expect("first junction must be created");
-        create_dir_link(&target, &link)
-            .expect("recreating at the SAME target must be a no-op, not os 183");
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn recreating_a_junction_at_a_different_target_still_fails() {
-        let dir = tempfile::tempdir().unwrap();
-        let first = dir.path().join("first");
-        let second = dir.path().join("second");
-        let link = dir.path().join("link");
-        std::fs::create_dir_all(&first).unwrap();
-        std::fs::create_dir_all(&second).unwrap();
-
-        create_dir_link(&first, &link).expect("first junction must be created");
-        // A junction pointing somewhere else is a genuine conflict — silently
-        // accepting it would leave the package resolving to the wrong tree.
-        create_dir_link(&second, &link)
-            .expect_err("a junction at a DIFFERENT target must still be an error");
     }
 
     #[cfg(windows)]

--- a/vendor/aube/crates/aube-linker/src/sys.rs
+++ b/vendor/aube/crates/aube-linker/src/sys.rs
@@ -98,6 +98,17 @@ fn create_junction_with_retry(target: &Path, link: &Path) -> io::Result<()> {
     loop {
         match junction::create(target, link) {
             Ok(()) => return Ok(()),
+            // `ERROR_ALREADY_EXISTS` when the junction ALREADY points where we
+            // were going to point it is a no-op, not a conflict. Callers reach
+            // here after their own stale-entry reconciliation, so a surviving
+            // correct entry means a concurrent writer (the fetch-phase prewarm,
+            // a parallel install) got there first — the outcome we wanted.
+            // Treating it as fatal is what surfaced as `os error 183` on a
+            // sibling entry during an incremental `add` (#576). A junction
+            // pointing SOMEWHERE ELSE is still a real error and still fails.
+            Err(e) if e.raw_os_error() == Some(183) && junction_points_at(link, target) => {
+                return Ok(());
+            }
             Err(e) if is_retriable_link_error(&e) && attempt < 9 => {
                 std::thread::sleep(std::time::Duration::from_millis(delay_ms));
                 delay_ms = (delay_ms * 2).min(2000);
@@ -105,6 +116,21 @@ fn create_junction_with_retry(target: &Path, link: &Path) -> io::Result<()> {
             }
             Err(e) => return Err(e),
         }
+    }
+}
+
+/// Whether `link` is already a reparse point resolving to `target`.
+///
+/// Compared through `canonicalize` on both sides so an `8.3` short name, a
+/// case difference, or a `\\?\` verbatim prefix on one side alone does not
+/// read as a mismatch and turn a benign collision back into a hard failure.
+#[cfg(windows)]
+fn junction_points_at(link: &Path, target: &Path) -> bool {
+    match (std::fs::canonicalize(link), std::fs::canonicalize(target)) {
+        (Ok(l), Ok(t)) => l == t,
+        // Cannot prove they match — treat as a mismatch so the caller still
+        // sees the error rather than silently accepting a wrong entry.
+        _ => false,
     }
 }
 
@@ -1117,6 +1143,40 @@ mod tests {
     fn normalize_collapses_parent_and_cur_dir() {
         let p = Path::new(r"C:\a\b\.\..\c\d\..\e");
         assert_eq!(normalize_path(p), PathBuf::from(r"C:\a\c\e"));
+    }
+
+    // nubjs/nub#576: `ERROR_ALREADY_EXISTS` on a junction that already points
+    // where we wanted it is the concurrent-writer outcome we asked for, not a
+    // conflict. Runs only on the windows-latest CI leg — junctions have no
+    // POSIX equivalent to exercise.
+    #[cfg(windows)]
+    #[test]
+    fn recreating_a_junction_at_its_existing_target_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        std::fs::create_dir_all(&target).unwrap();
+
+        create_dir_link(&target, &link).expect("first junction must be created");
+        create_dir_link(&target, &link)
+            .expect("recreating at the SAME target must be a no-op, not os 183");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn recreating_a_junction_at_a_different_target_still_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first");
+        let second = dir.path().join("second");
+        let link = dir.path().join("link");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+
+        create_dir_link(&first, &link).expect("first junction must be created");
+        // A junction pointing somewhere else is a genuine conflict — silently
+        // accepting it would leave the package resolving to the wrong tree.
+        create_dir_link(&second, &link)
+            .expect_err("a junction at a DIFFERENT target must still be an error");
     }
 
     #[cfg(windows)]

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -792,6 +792,56 @@ fn test_link_file_fresh_reports_missing_cas_shard_and_invalidates_cache() {
 }
 
 #[test]
+fn failed_materialize_leaves_no_entry_to_be_mistaken_for_a_complete_one() {
+    // nubjs/nub#552. Step 1 of the non-GVS link used to materialize straight
+    // into the final `.aube/<dep_path>` with no staging, and the parent-dir
+    // pre-pass creates that directory BEFORE any file is linked. So a failure
+    // partway through left a half-populated entry that every later run's
+    // `if aube_entry.exists() { cached }` gate reported as already linked —
+    // the tree never converged and `rm -rf node_modules` was the only fix.
+    //
+    // Any mid-materialize failure exercises the invariant; a missing CAS shard
+    // is the one that reproduces deterministically. `PackageIndex` iterates in
+    // hash order, so whether the good file links before the bad one is
+    // unspecified — that does not matter, because the directory is created up
+    // front either way.
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let (store, indices) = setup_store_with_files(dir.path());
+    let pkgjson_store_path = indices
+        .get("foo@1.0.0")
+        .unwrap()
+        .get("package.json")
+        .unwrap()
+        .store_path
+        .clone();
+    std::fs::remove_file(&pkgjson_store_path).unwrap();
+
+    // GVS off: the branch whose five call sites wrote directly into the final
+    // entry. GVS-on packages were always staged through the shared store.
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, false);
+    linker
+        .link_all(&project_dir, &make_graph(), &indices)
+        .expect_err("link must fail when a referenced CAS shard is gone");
+
+    let entry = project_dir
+        .join("node_modules/.aube")
+        .join(dep_path_to_filename(
+            "foo@1.0.0",
+            DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+        ));
+    assert!(
+        !entry.exists(),
+        "a failed materialize must leave NO entry behind — {} survived, and the \
+         next install's exists() gate would report this half-written package as \
+         complete",
+        entry.display()
+    );
+}
+
+#[test]
 #[cfg(unix)]
 fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
     // Hardlink path used to silently fall through to `std::fs::copy`


### PR DESCRIPTION
A link that failed partway left a half-written package under `node_modules/.store`, which the next run's `exists()` gate counted as already linked — installs then printed "Already up to date" over an unresolvable `node_modules`, recoverable only by deleting it.

Five `link.rs` sites wrote straight into the final entry. All now stage through `.tmp-<pid>-<id>` + atomic rename, so a failure leaves only a sweepable tmp dir.

Retried, each previously fatal: the per-file copy on a Windows sharing violation; the stale top-level entry removal; `mkdirp`. `is_transient_rename_error` never matched os 32 at all, because Rust decodes it to `Uncategorized`.

Prevention only — an already-broken tree still needs one `rm -rf node_modules`.

Merged with #595, which independently fixed the overlapping Windows failure and closed #566/#576.

Closes #552
