### PR TITLE
fix(resolve): probe extensions for bare package subpaths

### DIFF
--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -222,6 +222,30 @@ console.log("LOADED");
     );
 }
 
+/// A traversing subpath must never resolve outside the package root. The guard
+/// splits on both separators, since lexical normalization honors `\` on Windows;
+/// this pins the separator-independent half on every platform.
+#[test]
+fn traversing_subpath_never_escapes_the_package_root() {
+    let dir = fixture("traversal");
+    write(&dir.join("outside-secret.js"), r#"module.exports={};"#);
+    write(
+        &dir.join("entry.ts"),
+        r#"import "thirdparty/../../outside-secret";
+console.log("ESCAPED");
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.ts");
+    assert!(
+        !stdout.contains("ESCAPED"),
+        "a traversing subpath escaped the package root: {stdout}"
+    );
+    assert!(
+        stderr.contains("ERR_"),
+        "expected the traversal to stay unresolved, got: {stderr}"
+    );
+}
+
 /// THE ENCAPSULATION GUARD. A package that declares `exports` owns its subpath
 /// map; probing must never reach a path it withheld. Without this, #562's fix
 /// would be a sandbox escape out of every `exports` map on disk.

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -65,6 +65,23 @@ fn fixture(name: &str) -> PathBuf {
     dir
 }
 
+/// `(major, minor)` of the `node` first on PATH. 22.15 is the fast-tier floor,
+/// and one test below is a fast-tier-only contract.
+fn path_node_version() -> Option<(u32, u32)> {
+    let out = Command::new("node").arg("--version").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8_lossy(&out.stdout);
+    let v = v.trim().trim_start_matches('v');
+    let mut parts = v.split('.');
+    Some((parts.next()?.parse().ok()?, parts.next()?.parse().ok()?))
+}
+
+fn on_fast_tier() -> bool {
+    matches!(path_node_version(), Some((m, n)) if (m, n) >= (22, 15))
+}
+
 fn run(dir: &Path, entry: &str) -> (String, String) {
     let out = Command::new(nub_binary())
         .arg(dir.join(entry).to_str().unwrap())
@@ -165,8 +182,18 @@ console.log("from:" + s.from);
 /// directory, so `sub.ts` would beat `sub/index.js`, and the `.ts` is then a path
 /// the load hooks refuse. Node's CJS resolver loads `sub/index.js` here, and so
 /// must nub.
+///
+/// FAST TIER ONLY, and the reason is a separate pre-existing divergence rather
+/// than anything this probe does. Below 22.15 nub registers a `.ts` handler in
+/// `require.extensions`, so Node's OWN CJS resolver finds `sub.ts` during
+/// LOAD_AS_FILE and never reaches LOAD_AS_DIRECTORY — the additive resolver has
+/// already declined the file by then. Verified against nub v0.5.0, which predates
+/// this branch and behaves identically on 20.11 and 18.19.
 #[test]
 fn directory_index_outranks_an_unloadable_ts_sibling() {
+    if !on_fast_tier() {
+        return;
+    }
     let dir = fixture("dir-vs-ts");
     write(
         &dir.join("node_modules/pkg/package.json"),

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -268,10 +268,19 @@ module.exports = { who: v };
 /// `.cjs` on purpose; a `.cts` entry trips a SEPARATE pre-existing issue, where the
 /// load-side node_modules gate refuses the symlinked package's TS under this flag,
 /// which nub v0.5.0 exhibits identically and which is not what this pins.
+///
+/// COUPLING, for whoever adds the load-side gate: the classic TS-family
+/// `require.extensions` handler transpiles unconditionally today, and this package
+/// loads through it on a path that still reads `/node_modules/` under this flag.
+/// Gating that handler on the LITERAL filename would break this test and quietly
+/// undo the resolution-side fix. Resolve the path there the way `isDepTsHit` does —
+/// better, factor the one "is this really a dependency?" predicate both layers call,
+/// so the two definitions cannot drift apart.
 #[cfg(unix)]
 #[test]
 fn preserve_symlinks_keeps_a_workspace_package_loadable() {
     if !on_compat_tier() {
+        eprintln!("skipping: needs the compat tier (PATH node below 22.15)");
         return;
     }
     let dir = fixture("preserve-symlinks");

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -264,15 +264,12 @@ module.exports = { who: v };
 /// COMPAT TIER ONLY, because that is the only band where the behavior exists at
 /// all: resolving an extensionless `main` onto TS source depends on the classic
 /// `require.extensions` keys, which the fast tier never registers — Node 26 reports
-/// the same package missing both before and after this branch. The entry is plain
-/// `.cjs` on purpose; a `.cts` entry trips a SEPARATE pre-existing issue, where the
-/// load-side node_modules gate refuses the symlinked package's TS under this flag,
-/// which nub v0.5.0 exhibits identically and which is not what this pins.
+/// the same package missing both before and after this branch.
 ///
-/// COUPLING with the load side: the classic TS-family `require.extensions` handler
-/// bails on a dependency through the same `isDependencyPath` predicate the
-/// resolve-side retry uses, so it decides on the file's REAL location too. Testing
-/// the literal filename there would break this test and quietly undo the
+/// COUPLING with the load side: every gate that decides how a file loads — the
+/// classic `require.extensions` handler included — goes through the shared
+/// `isDependency` predicate, so all of them judge the file's REAL location. Testing
+/// the literal filename in any of them would break this test and quietly undo the
 /// resolution-side fix.
 #[cfg(unix)]
 #[test]

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -671,6 +671,54 @@ try {
     );
 }
 
+/// The same directory rule on the RELATIVE branch, which had it too: `./sub/` names
+/// a directory, so it must never be answered with a sibling `./sub.ts`. An interior
+/// dot-segment is a different matter and must still resolve — Node normalizes
+/// `./d/./x` and loads it — which is why only the LAST segment decides.
+#[test]
+fn a_trailing_slash_means_the_directory_for_relative_specifiers_too() {
+    let dir = fixture("relative-trailing-slash");
+    write(&dir.join("sub.ts"), r#"export const w = "SIBLING-FILE";"#);
+    write(
+        &dir.join("sub/index.ts"),
+        r#"export const w = "DIR-INDEX";"#,
+    );
+    write(&dir.join("d/x.ts"), r#"export const w = "INTERIOR-OK";"#);
+    write(
+        &dir.join("entry.ts"),
+        r#"const out: string[] = [];
+try {
+  const m = await import("./sub/");
+  out.push("dir:" + m.w);
+} catch (e) {
+  out.push("dir:" + (e as { code?: string }).code);
+}
+const i = await import("./d/./x");
+out.push("interior:" + i.w);
+const p = await import("./sub");
+out.push("plain:" + p.w);
+console.log(out.join(" "));
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.ts");
+    assert!(
+        !stdout.contains("dir:SIBLING-FILE"),
+        "a trailing-slash relative specifier resolved a sibling file: {stdout} / {stderr}"
+    );
+    assert!(
+        stdout.contains("dir:ERR_UNSUPPORTED_DIR_IMPORT"),
+        "expected Node's own directory-import error: {stdout} / {stderr}"
+    );
+    assert!(
+        stdout.contains("interior:INTERIOR-OK"),
+        "an interior dot-segment must still resolve: {stdout} / {stderr}"
+    );
+    assert!(
+        stdout.contains("plain:SIBLING-FILE"),
+        "an ordinary relative TS import must be untouched: {stdout} / {stderr}"
+    );
+}
+
 /// THE ENCAPSULATION GUARD. A package that declares `exports` owns its subpath
 /// map; probing must never reach a path it withheld. Without this, #562's fix
 /// would be a sandbox escape out of every `exports` map on disk.

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -183,12 +183,16 @@ console.log("from:" + s.from);
 /// the load hooks refuse. Node's CJS resolver loads `sub/index.js` here, and so
 /// must nub.
 ///
-/// FAST TIER ONLY, and the reason is a separate pre-existing divergence rather
-/// than anything this probe does. Below 22.15 nub registers a `.ts` handler in
-/// `require.extensions`, so Node's OWN CJS resolver finds `sub.ts` during
-/// LOAD_AS_FILE and never reaches LOAD_AS_DIRECTORY — the additive resolver has
-/// already declined the file by then. Verified against nub v0.5.0, which predates
-/// this branch and behaves identically on 20.11 and 18.19.
+/// FAST TIER ONLY, and the reason is a separate pre-existing bug rather than
+/// anything this probe does. Below 22.15 nub registers a classic
+/// `require.extensions` handler for the TS family, so Node's OWN CJS resolver
+/// finds `sub.ts` during LOAD_AS_FILE and never reaches LOAD_AS_DIRECTORY — the
+/// additive resolver has already declined the file by then. That handler carries
+/// no `node_modules` bail, unlike its `.js`/`.cjs` sibling, so the outcome is not
+/// merely a different error: the dependency's unshipped source is transpiled and
+/// returned, and `require("pkg/sub")` hands back `sub.ts`'s exports where plain
+/// Node hands back `sub/index.js`'s. Verified against nub v0.5.0, which predates
+/// this branch and is identical on 20.11 and 18.19.
 #[test]
 fn directory_index_outranks_an_unloadable_ts_sibling() {
     if !on_fast_tier() {

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -160,6 +160,68 @@ console.log("from:" + s.from);
     assert_eq!(stdout, "from:js", "stderr: {stderr}");
 }
 
+/// A `.ts` that outranks a sibling DIRECTORY Node resolves today would be a
+/// working-to-broken regression: probing settles on a file before it considers a
+/// directory, so `sub.ts` would beat `sub/index.js`, and the `.ts` is then a path
+/// the load hooks refuse. Node's CJS resolver loads `sub/index.js` here, and so
+/// must nub.
+#[test]
+fn directory_index_outranks_an_unloadable_ts_sibling() {
+    let dir = fixture("dir-vs-ts");
+    write(
+        &dir.join("node_modules/pkg/package.json"),
+        r#"{"name":"pkg","main":"index.js"}"#,
+    );
+    write(&dir.join("node_modules/pkg/index.js"), "module.exports={};");
+    write(&dir.join("node_modules/pkg/sub.ts"), "export const x = 1;");
+    write(
+        &dir.join("node_modules/pkg/sub/index.js"),
+        r#"module.exports={who:"dir-index"};"#,
+    );
+    write(
+        &dir.join("entry.cts"),
+        r#"const m = require("pkg/sub");
+console.log("who:" + m.who);
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.cts");
+    assert_eq!(stdout, "who:dir-index", "stderr: {stderr}");
+}
+
+/// A published package shipping ONLY TypeScript source must surface Node's own
+/// ERR_MODULE_NOT_FOUND. Resolving the `.ts` would hand back a file nub declines
+/// to transpile, turning a clear "no such module" into a type-stripping error
+/// that points the reader at the wrong problem.
+#[test]
+fn ts_only_published_package_keeps_nodes_own_error() {
+    let dir = fixture("ts-only");
+    write(
+        &dir.join("node_modules/tsonly/package.json"),
+        r#"{"name":"tsonly","main":"index.js"}"#,
+    );
+    write(
+        &dir.join("node_modules/tsonly/index.js"),
+        "module.exports={};",
+    );
+    write(
+        &dir.join("node_modules/tsonly/deep.ts"),
+        "export const v = 1;",
+    );
+    write(
+        &dir.join("entry.ts"),
+        r#"import "tsonly/deep";
+console.log("LOADED");
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.ts");
+    assert!(!stdout.contains("LOADED"), "unexpectedly loaded: {stdout}");
+    assert!(
+        stderr.contains("ERR_MODULE_NOT_FOUND")
+            && !stderr.contains("ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING"),
+        "expected Node's own ERR_MODULE_NOT_FOUND, got: {stderr}"
+    );
+}
+
 /// THE ENCAPSULATION GUARD. A package that declares `exports` owns its subpath
 /// map; probing must never reach a path it withheld. Without this, #562's fix
 /// would be a sandbox escape out of every `exports` map on disk.

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -572,6 +572,55 @@ console.log("got:" + x);
     );
 }
 
+/// Every other `--preserve-symlinks` fixture here uses the workspace package as the
+/// import TARGET. This one makes it the IMPORTER, which is the other half: the
+/// resolver has to classify the importing file the same way the load gates do, or a
+/// symlinked workspace package reads as a dependency and its own imports silently
+/// lose the additive resolution they get without the flag.
+#[cfg(unix)]
+#[test]
+fn preserve_symlinks_keeps_additive_resolution_inside_a_workspace_package() {
+    let dir = fixture("ws-importer");
+    write(
+        &dir.join("packages/lib/package.json"),
+        r#"{"name":"@repro/lib","main":"./index.ts"}"#,
+    );
+    write(
+        &dir.join("packages/lib/index.ts"),
+        r#"import p from "thirdparty/components/prism-python";
+export const lang: string = p.lang;
+"#,
+    );
+    std::fs::create_dir_all(dir.join("node_modules/@repro")).unwrap();
+    std::os::unix::fs::symlink(
+        dir.join("packages/lib"),
+        dir.join("node_modules/@repro/lib"),
+    )
+    .unwrap();
+    write(
+        &dir.join("entry.ts"),
+        r#"import { lang } from "@repro/lib";
+console.log("lang:" + lang);
+"#,
+    );
+    let out = Command::new(nub_binary())
+        .arg(dir.join("entry.ts").to_str().unwrap())
+        .current_dir(&dir)
+        .env("NODE_OPTIONS", "--preserve-symlinks")
+        .env(
+            "XDG_CACHE_HOME",
+            std::env::temp_dir().join(format!("nub-subpath-cache-{}", std::process::id())),
+        )
+        .output()
+        .expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("lang:python"),
+        "a symlinked workspace package lost additive resolution for its own imports: {stdout} / {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 /// THE ENCAPSULATION GUARD. A package that declares `exports` owns its subpath
 /// map; probing must never reach a path it withheld. Without this, #562's fix
 /// would be a sandbox escape out of every `exports` map on disk.

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -65,23 +65,6 @@ fn fixture(name: &str) -> PathBuf {
     dir
 }
 
-/// `(major, minor)` of the `node` first on PATH. 22.15 is the fast-tier floor,
-/// and one test below is a fast-tier-only contract.
-fn path_node_version() -> Option<(u32, u32)> {
-    let out = Command::new("node").arg("--version").output().ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let v = String::from_utf8_lossy(&out.stdout);
-    let v = v.trim().trim_start_matches('v');
-    let mut parts = v.split('.');
-    Some((parts.next()?.parse().ok()?, parts.next()?.parse().ok()?))
-}
-
-fn on_fast_tier() -> bool {
-    matches!(path_node_version(), Some((m, n)) if (m, n) >= (22, 15))
-}
-
 fn run(dir: &Path, entry: &str) -> (String, String) {
     let out = Command::new(nub_binary())
         .arg(dir.join(entry).to_str().unwrap())
@@ -183,21 +166,14 @@ console.log("from:" + s.from);
 /// the load hooks refuse. Node's CJS resolver loads `sub/index.js` here, and so
 /// must nub.
 ///
-/// FAST TIER ONLY, and the reason is a separate pre-existing bug rather than
-/// anything this probe does. Below 22.15 nub registers a classic
-/// `require.extensions` handler for the TS family, so Node's OWN CJS resolver
-/// finds `sub.ts` during LOAD_AS_FILE and never reaches LOAD_AS_DIRECTORY — the
-/// additive resolver has already declined the file by then. That handler carries
-/// no `node_modules` bail, unlike its `.js`/`.cjs` sibling, so the outcome is not
-/// merely a different error: the dependency's unshipped source is transpiled and
-/// returned, and `require("pkg/sub")` hands back `sub.ts`'s exports where plain
-/// Node hands back `sub/index.js`'s. Verified against nub v0.5.0, which predates
-/// this branch and is identical on 20.11 and 18.19.
+/// Runs on EVERY tier. Below 22.15 the classic `require.extensions` handlers put
+/// the TS family into `Module._extensions`, which Node's `_findPath` walks during
+/// LOAD_AS_FILE before it ever tries LOAD_AS_DIRECTORY — so this used to hand back
+/// a dependency's unshipped `sub.ts` instead. The require-side resolver now
+/// re-resolves without those keys whenever Node's answer is a TS file under
+/// node_modules, which is what keeps the two tiers agreeing here.
 #[test]
 fn directory_index_outranks_an_unloadable_ts_sibling() {
-    if !on_fast_tier() {
-        return;
-    }
     let dir = fixture("dir-vs-ts");
     write(
         &dir.join("node_modules/pkg/package.json"),
@@ -217,6 +193,49 @@ console.log("who:" + m.who);
     );
     let (stdout, stderr) = run(&dir, "entry.cts");
     assert_eq!(stdout, "who:dir-index", "stderr: {stderr}");
+}
+
+/// A dependency's own relative require must not reach its unshipped TS source
+/// either. Plain Node reports `./util` missing when only `util.ts` exists, and so
+/// must nub — deps are never transpiled, on any tier. Below 22.15 the classic
+/// `require.extensions` keys made this resolve and load, silently.
+#[test]
+fn dep_internal_relative_require_does_not_reach_ts_source() {
+    let dir = fixture("dep-internal-ts");
+    write(
+        &dir.join("node_modules/depts/package.json"),
+        r#"{"name":"depts","main":"index.js"}"#,
+    );
+    write(
+        &dir.join("node_modules/depts/index.js"),
+        r#"const u = require("./util");
+module.exports = { who: u.who };
+"#,
+    );
+    write(
+        &dir.join("node_modules/depts/util.ts"),
+        r#"const v: string = "unshipped";
+module.exports = { who: v };
+"#,
+    );
+    write(
+        &dir.join("entry.cts"),
+        r#"try {
+  console.log("who:" + require("depts").who);
+} catch (e) {
+  console.log("threw:" + (e as { code?: string }).code);
+}
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.cts");
+    assert!(
+        !stdout.contains("who:unshipped"),
+        "a dep's relative require reached its unshipped TS source: {stdout} / {stderr}"
+    );
+    assert!(
+        stdout.contains("threw:MODULE_NOT_FOUND"),
+        "expected Node's own MODULE_NOT_FOUND, got: {stdout} / {stderr}"
+    );
 }
 
 /// A published package shipping ONLY TypeScript source must surface Node's own

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -621,6 +621,56 @@ console.log("lang:" + lang);
     );
 }
 
+/// A trailing `/` names a DIRECTORY, and probing must not answer it with a sibling
+/// file. Node's CJS resolver goes straight to LOAD_AS_DIRECTORY here, so
+/// `require("pkg/sub/")` is `sub/index.js` — never `sub.js`. Lexical normalization
+/// drops the empty component, which is exactly how this went wrong: silently, with
+/// no error, returning a different module than Node loads.
+#[test]
+fn a_trailing_slash_still_means_the_directory() {
+    let dir = fixture("trailing-slash");
+    write(
+        &dir.join("node_modules/ts/package.json"),
+        r#"{"name":"ts","main":"index.js"}"#,
+    );
+    write(
+        &dir.join("node_modules/ts/index.js"),
+        r#"module.exports="IDX";"#,
+    );
+    write(
+        &dir.join("node_modules/ts/sub.js"),
+        r#"module.exports="THE-FILE";"#,
+    );
+    write(
+        &dir.join("node_modules/ts/sub/index.js"),
+        r#"module.exports="THE-DIR-INDEX";"#,
+    );
+    // A sibling file with no directory at all: Node reports it missing, and so must nub.
+    write(
+        &dir.join("node_modules/ts/lone.js"),
+        r#"module.exports="LONE";"#,
+    );
+    write(
+        &dir.join("entry.cjs"),
+        r#"console.log("dir:" + require("ts/sub/"));
+try {
+  console.log("lone:" + require("ts/lone/"));
+} catch (e) {
+  console.log("lone:" + e.code);
+}
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.cjs");
+    assert!(
+        stdout.contains("dir:THE-DIR-INDEX"),
+        "a trailing-slash directory specifier resolved to a sibling file: {stdout} / {stderr}"
+    );
+    assert!(
+        stdout.contains("lone:MODULE_NOT_FOUND"),
+        "a trailing-slash specifier resolved a file Node reports missing: {stdout} / {stderr}"
+    );
+}
+
 /// THE ENCAPSULATION GUARD. A package that declares `exports` owns its subpath
 /// map; probing must never reach a path it withheld. Without this, #562's fix
 /// would be a sandbox escape out of every `exports` map on disk.

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -433,6 +433,12 @@ fn emit_swap_onto_dep_mts_and_cts_is_discarded() {
         r#"export const v: string = "unshipped-mts";"#,
     );
     write(
+        &dir.join("node_modules/mp/other.cts"),
+        r#"const v: string = "unshipped-cts";
+module.exports = { v };
+"#,
+    );
+    write(
         &dir.join("entry.ts"),
         r#"import { v } from "mp/deep.mjs";
 console.log("LOADED:" + v);
@@ -443,7 +449,27 @@ console.log("LOADED:" + v);
     assert!(
         stderr.contains("ERR_MODULE_NOT_FOUND")
             && !stderr.contains("ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING"),
-        "expected Node's own ERR_MODULE_NOT_FOUND, got: {stderr}"
+        "expected Node's own ERR_MODULE_NOT_FOUND for .mts, got: {stderr}"
+    );
+
+    // The symmetric `.cjs`→`.cts` arm, through require so it exercises the CJS path.
+    write(
+        &dir.join("entry.cts"),
+        r#"try {
+  console.log("LOADED:" + require("mp/other.cjs").v);
+} catch {
+  console.log("refused");
+}
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.cts");
+    assert!(
+        !stdout.contains("LOADED"),
+        "the .cjs→.cts swap reached a dependency's unshipped source: {stdout} / {stderr}"
+    );
+    assert!(
+        stdout.contains("refused"),
+        "the require neither loaded nor threw: {stdout} / {stderr}"
     );
 }
 
@@ -496,6 +522,55 @@ console.log("same:" + (viaBare === viaSubpath));
     assert!(
         stdout.contains("same:true"),
         "the same module was instantiated twice under --preserve-symlinks: {stdout} / {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The #562 headline shape must survive `--preserve-symlinks` on every tier. This is
+/// the combination the resolver and the load hooks have to agree on: the resolver
+/// deliberately keys the module by its symlink path so it is not instantiated twice,
+/// and every load gate has to recognise that same path as project source anyway.
+/// Deciding it on the literal URL in either place refuses the workspace package's
+/// TypeScript — which is exactly the import #562 was filed about.
+#[cfg(unix)]
+#[test]
+fn preserve_symlinks_still_loads_a_workspace_ts_subpath() {
+    let dir = fixture("preserve-symlinks-ts");
+    write(
+        &dir.join("packages/lib/package.json"),
+        r#"{"name":"@repro/lib","main":"./index.ts"}"#,
+    );
+    write(&dir.join("packages/lib/index.ts"), "export const root = 1;");
+    write(
+        &dir.join("packages/lib/prompt.ts"),
+        r#"export const x: string = "ws-ts-subpath";"#,
+    );
+    std::fs::create_dir_all(dir.join("node_modules/@repro")).unwrap();
+    std::os::unix::fs::symlink(
+        dir.join("packages/lib"),
+        dir.join("node_modules/@repro/lib"),
+    )
+    .unwrap();
+    write(
+        &dir.join("entry.ts"),
+        r#"import { x } from "@repro/lib/prompt";
+console.log("got:" + x);
+"#,
+    );
+    let out = Command::new(nub_binary())
+        .arg(dir.join("entry.ts").to_str().unwrap())
+        .current_dir(&dir)
+        .env("NODE_OPTIONS", "--preserve-symlinks")
+        .env(
+            "XDG_CACHE_HOME",
+            std::env::temp_dir().join(format!("nub-subpath-cache-{}", std::process::id())),
+        )
+        .output()
+        .expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("got:ws-ts-subpath"),
+        "a symlinked workspace package's TS subpath was refused under --preserve-symlinks: {stdout} / {}",
         String::from_utf8_lossy(&out.stderr)
     );
 }

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -65,6 +65,23 @@ fn fixture(name: &str) -> PathBuf {
     dir
 }
 
+/// `(major, minor)` of the `node` first on PATH. 22.15 is the fast-tier floor; the
+/// classic `require.extensions` behavior one test below pins exists only under it.
+fn path_node_version() -> Option<(u32, u32)> {
+    let out = Command::new("node").arg("--version").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8_lossy(&out.stdout);
+    let v = v.trim().trim_start_matches('v');
+    let mut parts = v.split('.');
+    Some((parts.next()?.parse().ok()?, parts.next()?.parse().ok()?))
+}
+
+fn on_compat_tier() -> bool {
+    matches!(path_node_version(), Some((m, n)) if (m, n) < (22, 15))
+}
+
 fn run(dir: &Path, entry: &str) -> (String, String) {
     let out = Command::new(nub_binary())
         .arg(dir.join(entry).to_str().unwrap())
@@ -235,6 +252,62 @@ module.exports = { who: v };
     assert!(
         stdout.contains("threw:MODULE_NOT_FOUND"),
         "expected Node's own MODULE_NOT_FOUND, got: {stdout} / {stderr}"
+    );
+}
+
+/// The dependency test has to decide on where a file REALLY lives. Under
+/// `--preserve-symlinks` Node hands back the un-realpathed path, so a workspace
+/// package symlinked into node_modules still carries a `/node_modules/` segment —
+/// and treating it as a dependency would cost it the TypeScript source that is its
+/// actual build output.
+///
+/// COMPAT TIER ONLY, because that is the only band where the behavior exists at
+/// all: resolving an extensionless `main` onto TS source depends on the classic
+/// `require.extensions` keys, which the fast tier never registers — Node 26 reports
+/// the same package missing both before and after this branch. The entry is plain
+/// `.cjs` on purpose; a `.cts` entry trips a SEPARATE pre-existing issue, where the
+/// load-side node_modules gate refuses the symlinked package's TS under this flag,
+/// which nub v0.5.0 exhibits identically and which is not what this pins.
+#[cfg(unix)]
+#[test]
+fn preserve_symlinks_keeps_a_workspace_package_loadable() {
+    if !on_compat_tier() {
+        return;
+    }
+    let dir = fixture("preserve-symlinks");
+    write(
+        &dir.join("packages/ws/package.json"),
+        r#"{"name":"@repro/ws","main":"./index"}"#,
+    );
+    write(
+        &dir.join("packages/ws/index.ts"),
+        r#"const v: string = "ws-source";
+module.exports = { who: v };
+"#,
+    );
+    std::fs::create_dir_all(dir.join("node_modules/@repro")).unwrap();
+    std::os::unix::fs::symlink(dir.join("packages/ws"), dir.join("node_modules/@repro/ws"))
+        .unwrap();
+    write(
+        &dir.join("entry.cjs"),
+        r#"console.log("who:" + require("@repro/ws").who);
+"#,
+    );
+    let out = Command::new(nub_binary())
+        .arg(dir.join("entry.cjs").to_str().unwrap())
+        .current_dir(&dir)
+        .env("NODE_OPTIONS", "--preserve-symlinks")
+        .env(
+            "XDG_CACHE_HOME",
+            std::env::temp_dir().join(format!("nub-subpath-cache-{}", std::process::id())),
+        )
+        .output()
+        .expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("who:ws-source"),
+        "workspace package was treated as a dependency under --preserve-symlinks: {stdout} / {}",
+        String::from_utf8_lossy(&out.stderr)
     );
 }
 

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -1,0 +1,286 @@
+//! Extension probing for bare package SUBPATHS (`pkg/sub`) — nubjs/nub#562.
+//!
+//! Node's ESM resolver gives a subpath no probing at all, so an extensionless
+//! `pkg/sub` is a hard `ERR_MODULE_NOT_FOUND` there even where the CJS
+//! `require()` of the same specifier works. nub probes it, but ONLY into a
+//! dependency that declares no `exports` — the tests below pin both halves: the
+//! probing that #562 asked for, and the `exports` encapsulation it must not
+//! breach.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/
+    path.push(format!("nub{}", std::env::consts::EXE_SUFFIX));
+    path
+}
+
+fn work_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("nub-subpath-{}-{name}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(path: &Path, body: &str) {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, body).unwrap();
+}
+
+/// A project with `thirdparty` (published CJS shape: no `exports`, a subpath
+/// `.js`) and `exp` (an `exports` map that deliberately withholds `lib/private`).
+fn fixture(name: &str) -> PathBuf {
+    let dir = work_dir(name);
+    write(
+        &dir.join("package.json"),
+        r#"{"name":"root","private":true}"#,
+    );
+
+    write(
+        &dir.join("node_modules/thirdparty/package.json"),
+        r#"{"name":"thirdparty","main":"index.js"}"#,
+    );
+    write(
+        &dir.join("node_modules/thirdparty/index.js"),
+        "module.exports={};",
+    );
+    write(
+        &dir.join("node_modules/thirdparty/components/prism-python.js"),
+        r#"module.exports={lang:"python"};"#,
+    );
+
+    write(
+        &dir.join("node_modules/exp/package.json"),
+        r#"{"name":"exp","main":"index.js","exports":{".":"./index.js"}}"#,
+    );
+    write(&dir.join("node_modules/exp/index.js"), "module.exports={};");
+    write(
+        &dir.join("node_modules/exp/lib/private.js"),
+        "module.exports={};",
+    );
+
+    dir
+}
+
+fn run(dir: &Path, entry: &str) -> (String, String) {
+    let out = Command::new(nub_binary())
+        .arg(dir.join(entry).to_str().unwrap())
+        .current_dir(dir)
+        .env(
+            "XDG_CACHE_HOME",
+            std::env::temp_dir().join(format!("nub-subpath-cache-{}", std::process::id())),
+        )
+        .output()
+        .expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn extensionless_subpath_into_exportless_package_resolves() {
+    let dir = fixture("thirdparty");
+    write(
+        &dir.join("entry.ts"),
+        r#"import p from "thirdparty/components/prism-python";
+console.log("lang:" + p.lang);
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.ts");
+    assert_eq!(stdout, "lang:python", "stderr: {stderr}");
+}
+
+/// The `.js`→`.ts` emit-convention swap, which TypeScript's `module: node16`
+/// guidance tells users to write, must apply across a subpath too — not just
+/// relative specifiers.
+///
+/// The target has to be a symlinked WORKSPACE package rather than a published
+/// one, and that is a property of the feature, not a quirk of the fixture: a
+/// `.ts` sitting in a real `node_modules` directory is unshipped source that
+/// nub declines to transpile, so swapping onto it would resolve a file that
+/// then fails to load. The swap is only reachable where the `.ts` is genuinely
+/// the built artifact — i.e. a workspace package.
+#[cfg(unix)]
+#[test]
+fn js_specifier_swaps_to_ts_across_a_subpath() {
+    let dir = fixture("emit-swap");
+    write(
+        &dir.join("packages/ui/package.json"),
+        r#"{"name":"@repro/ui","main":"./index.ts"}"#,
+    );
+    write(&dir.join("packages/ui/index.ts"), "export const root = 1;");
+    write(&dir.join("packages/ui/deep/mod.ts"), "export const v = 7;");
+    std::fs::create_dir_all(dir.join("node_modules/@repro")).unwrap();
+    std::os::unix::fs::symlink(dir.join("packages/ui"), dir.join("node_modules/@repro/ui"))
+        .unwrap();
+    write(
+        &dir.join("entry.ts"),
+        r#"import { v } from "@repro/ui/deep/mod.js";
+console.log("v:" + v);
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.ts");
+    assert_eq!(stdout, "v:7", "stderr: {stderr}");
+}
+
+/// A published package that ships BOTH a built `.js` and its unshipped `.ts`
+/// source must resolve to the `.js`. nub declines to transpile anything under a
+/// `node_modules/` path, so preferring the `.ts` would resolve to a file that
+/// then fails to load.
+#[test]
+fn built_js_wins_over_unshipped_ts_source() {
+    let dir = fixture("probe-order");
+    write(
+        &dir.join("node_modules/dual/package.json"),
+        r#"{"name":"dual","main":"index.js"}"#,
+    );
+    write(
+        &dir.join("node_modules/dual/index.js"),
+        "module.exports={};",
+    );
+    write(
+        &dir.join("node_modules/dual/sub.js"),
+        r#"module.exports={from:"js"};"#,
+    );
+    write(
+        &dir.join("node_modules/dual/sub.ts"),
+        r#"export default {from:"ts"};"#,
+    );
+    write(
+        &dir.join("entry.ts"),
+        r#"import s from "dual/sub";
+console.log("from:" + s.from);
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.ts");
+    assert_eq!(stdout, "from:js", "stderr: {stderr}");
+}
+
+/// THE ENCAPSULATION GUARD. A package that declares `exports` owns its subpath
+/// map; probing must never reach a path it withheld. Without this, #562's fix
+/// would be a sandbox escape out of every `exports` map on disk.
+#[test]
+fn exports_map_subpath_is_never_probed() {
+    let dir = fixture("exports-guard");
+    write(
+        &dir.join("entry.ts"),
+        r#"import "exp/lib/private";
+console.log("LEAKED");
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.ts");
+    assert!(
+        !stdout.contains("LEAKED"),
+        "probe breached an exports map: {stdout}"
+    );
+    assert!(
+        stderr.contains("ERR_PACKAGE_PATH_NOT_EXPORTED"),
+        "expected Node's exports error, got: {stderr}"
+    );
+}
+
+/// `"exports": null` is the deliberate "export nothing" form, NOT an absent map.
+/// Treating it as absent would probe straight past a package that blocked every
+/// subpath on purpose.
+#[test]
+fn null_exports_blocks_probing() {
+    let dir = fixture("null-exports");
+    write(
+        &dir.join("node_modules/sealed/package.json"),
+        r#"{"name":"sealed","main":"index.js","exports":null}"#,
+    );
+    write(
+        &dir.join("node_modules/sealed/index.js"),
+        "module.exports={};",
+    );
+    write(
+        &dir.join("node_modules/sealed/inner.js"),
+        "module.exports={};",
+    );
+    write(
+        &dir.join("entry.ts"),
+        r#"import "sealed/inner";
+console.log("LEAKED");
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.ts");
+    assert!(
+        !stdout.contains("LEAKED"),
+        "probed past an `exports: null` package: {stdout}"
+    );
+    // Node reports the sealed subpath as ERR_MODULE_NOT_FOUND, not
+    // ERR_PACKAGE_PATH_NOT_EXPORTED (verified against plain `node` on the same
+    // fixture) — the point is that nub defers and Node's own error survives.
+    assert!(
+        stderr.contains("ERR_MODULE_NOT_FOUND"),
+        "expected Node's own error to survive, got: {stderr}"
+    );
+}
+
+/// A workspace package symlinked into `node_modules` with `main` pointing at TS
+/// source — the shape #562 was filed against. Also pins the realpath step: the
+/// probe hits a path under `node_modules/`, and only resolving the symlink moves
+/// it somewhere nub will transpile.
+#[cfg(unix)]
+#[test]
+fn symlinked_workspace_package_subpath_resolves_to_ts_source() {
+    let dir = fixture("workspace");
+    write(
+        &dir.join("packages/lib/package.json"),
+        r#"{"name":"@repro/lib","main":"./index.ts"}"#,
+    );
+    write(&dir.join("packages/lib/index.ts"), "export const root = 1;");
+    write(
+        &dir.join("packages/lib/prompt.ts"),
+        r#"export const createPrompt = (): string => "hi";"#,
+    );
+    std::fs::create_dir_all(dir.join("node_modules/@repro")).unwrap();
+    std::os::unix::fs::symlink(
+        dir.join("packages/lib"),
+        dir.join("node_modules/@repro/lib"),
+    )
+    .unwrap();
+    write(
+        &dir.join("entry.ts"),
+        r#"import { createPrompt } from "@repro/lib/prompt";
+console.log("prompt:" + createPrompt());
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.ts");
+    assert_eq!(stdout, "prompt:hi", "stderr: {stderr}");
+}
+
+/// `require()` of the same shape. Node's CJS resolver probes `.js`/`.json` but
+/// never `.ts`, so the TS half of the gap exists on the require side too.
+#[cfg(unix)]
+#[test]
+fn require_of_a_ts_subpath_resolves() {
+    let dir = fixture("require-ts");
+    write(
+        &dir.join("packages/lib/package.json"),
+        r#"{"name":"@repro/lib","main":"./index.ts"}"#,
+    );
+    write(&dir.join("packages/lib/index.ts"), "export const root = 1;");
+    write(
+        &dir.join("packages/lib/prompt.ts"),
+        "module.exports = { tag: 9 };",
+    );
+    std::fs::create_dir_all(dir.join("node_modules/@repro")).unwrap();
+    std::os::unix::fs::symlink(
+        dir.join("packages/lib"),
+        dir.join("node_modules/@repro/lib"),
+    )
+    .unwrap();
+    write(
+        &dir.join("entry.cts"),
+        r#"const m = require("@repro/lib/prompt");
+console.log("tag:" + m.tag);
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.cts");
+    assert_eq!(stdout, "tag:9", "stderr: {stderr}");
+}

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -269,13 +269,11 @@ module.exports = { who: v };
 /// load-side node_modules gate refuses the symlinked package's TS under this flag,
 /// which nub v0.5.0 exhibits identically and which is not what this pins.
 ///
-/// COUPLING, for whoever adds the load-side gate: the classic TS-family
-/// `require.extensions` handler transpiles unconditionally today, and this package
-/// loads through it on a path that still reads `/node_modules/` under this flag.
-/// Gating that handler on the LITERAL filename would break this test and quietly
-/// undo the resolution-side fix. Resolve the path there the way `isDepTsHit` does —
-/// better, factor the one "is this really a dependency?" predicate both layers call,
-/// so the two definitions cannot drift apart.
+/// COUPLING with the load side: the classic TS-family `require.extensions` handler
+/// bails on a dependency through the same `isDependencyPath` predicate the
+/// resolve-side retry uses, so it decides on the file's REAL location too. Testing
+/// the literal filename there would break this test and quietly undo the
+/// resolution-side fix.
 #[cfg(unix)]
 #[test]
 fn preserve_symlinks_keeps_a_workspace_package_loadable() {
@@ -354,6 +352,10 @@ module.exports = { who: v };
     assert!(
         !stdout.contains("who:dep-ts-explicit"),
         "a dependency's TypeScript was transpiled through an explicit path: {stdout} / {stderr}"
+    );
+    assert!(
+        stdout.contains("refused"),
+        "the require neither loaded nor threw — the run produced nothing: {stdout} / {stderr}"
     );
 }
 

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -320,6 +320,43 @@ module.exports = { who: v };
     );
 }
 
+/// Naming a dependency's TypeScript by explicit path skips resolution entirely, so
+/// the "deps are never transpiled" invariant has to hold at the LOAD step too. nub
+/// hands the file to Node's own `.js` handler — the same fallback Node uses for an
+/// extension it does not register — so the failure is Node's, not one nub invented.
+/// The exact error differs by version (a raw-JS `SyntaxError` below 22.15, type-
+/// stripping's own refusal above it), so this pins the invariant: the dependency's
+/// TypeScript never becomes a loaded module.
+#[test]
+fn explicit_path_require_of_dep_ts_is_not_transpiled() {
+    let dir = fixture("explicit-dep-ts");
+    write(
+        &dir.join("node_modules/xp/package.json"),
+        r#"{"name":"xp","main":"index.js"}"#,
+    );
+    write(&dir.join("node_modules/xp/index.js"), "module.exports={};");
+    write(
+        &dir.join("node_modules/xp/inner.ts"),
+        r#"const v: string = "dep-ts-explicit";
+module.exports = { who: v };
+"#,
+    );
+    write(
+        &dir.join("entry.cjs"),
+        r#"try {
+  console.log("who:" + require("./node_modules/xp/inner.ts").who);
+} catch {
+  console.log("refused");
+}
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.cjs");
+    assert!(
+        !stdout.contains("who:dep-ts-explicit"),
+        "a dependency's TypeScript was transpiled through an explicit path: {stdout} / {stderr}"
+    );
+}
+
 /// A published package shipping ONLY TypeScript source must surface Node's own
 /// ERR_MODULE_NOT_FOUND. Resolving the `.ts` would hand back a file nub declines
 /// to transpile, turning a clear "no such module" into a type-stripping error

--- a/crates/nub-cli/tests/bare_subpath_resolution.rs
+++ b/crates/nub-cli/tests/bare_subpath_resolution.rs
@@ -417,6 +417,89 @@ console.log("ESCAPED");
     );
 }
 
+/// The emit swaps reach `.mts` and `.cts` as well as `.ts`/`.tsx`, and a swap that
+/// lands on one inside a dependency is exactly as unloadable — so the discard has to
+/// cover the whole TypeScript family, not just what the probe order can hit.
+#[test]
+fn emit_swap_onto_dep_mts_and_cts_is_discarded() {
+    let dir = fixture("mts-cts-discard");
+    write(
+        &dir.join("node_modules/mp/package.json"),
+        r#"{"name":"mp","main":"index.js"}"#,
+    );
+    write(&dir.join("node_modules/mp/index.js"), "module.exports={};");
+    write(
+        &dir.join("node_modules/mp/deep.mts"),
+        r#"export const v: string = "unshipped-mts";"#,
+    );
+    write(
+        &dir.join("entry.ts"),
+        r#"import { v } from "mp/deep.mjs";
+console.log("LOADED:" + v);
+"#,
+    );
+    let (stdout, stderr) = run(&dir, "entry.ts");
+    assert!(!stdout.contains("LOADED"), "unexpectedly loaded: {stdout}");
+    assert!(
+        stderr.contains("ERR_MODULE_NOT_FOUND")
+            && !stderr.contains("ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING"),
+        "expected Node's own ERR_MODULE_NOT_FOUND, got: {stderr}"
+    );
+}
+
+/// Under `--preserve-symlinks` Node keys a symlinked workspace package by the path
+/// it was reached through, so the probe has to hand back that same path. Returning
+/// the real one instead keys the SAME file two ways and the module instantiates
+/// twice — silently, since both halves "work".
+#[cfg(unix)]
+#[test]
+fn preserve_symlinks_does_not_duplicate_a_workspace_module() {
+    let dir = fixture("dual-instance");
+    write(
+        &dir.join("packages/jslib/package.json"),
+        r#"{"name":"@repro/jslib","main":"./index.js"}"#,
+    );
+    write(
+        &dir.join("packages/jslib/index.js"),
+        r#"const s = require("./state");
+module.exports = { id: s.id };
+"#,
+    );
+    write(
+        &dir.join("packages/jslib/state.js"),
+        r#"module.exports = { id: {} };"#,
+    );
+    std::fs::create_dir_all(dir.join("node_modules/@repro")).unwrap();
+    std::os::unix::fs::symlink(
+        dir.join("packages/jslib"),
+        dir.join("node_modules/@repro/jslib"),
+    )
+    .unwrap();
+    write(
+        &dir.join("entry.cjs"),
+        r#"const viaBare = require("@repro/jslib").id;
+const viaSubpath = require("@repro/jslib/state").id;
+console.log("same:" + (viaBare === viaSubpath));
+"#,
+    );
+    let out = Command::new(nub_binary())
+        .arg(dir.join("entry.cjs").to_str().unwrap())
+        .current_dir(&dir)
+        .env("NODE_OPTIONS", "--preserve-symlinks")
+        .env(
+            "XDG_CACHE_HOME",
+            std::env::temp_dir().join(format!("nub-subpath-cache-{}", std::process::id())),
+        )
+        .output()
+        .expect("failed to spawn nub");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("same:true"),
+        "the same module was instantiated twice under --preserve-symlinks: {stdout} / {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 /// THE ENCAPSULATION GUARD. A package that declares `exports` owns its subpath
 /// map; probing must never reach a path it withheld. Without this, #562's fix
 /// would be a sandbox escape out of every `exports` map on disk.

--- a/crates/nub-native/src/resolve.rs
+++ b/crates/nub-native/src/resolve.rs
@@ -126,11 +126,23 @@ fn resolve_bare_subpath(
     };
     let subpath = segs.collect::<Vec<_>>().join("/");
     // A bare NAME (no subpath) resolves through `main`/`exports` — never ours.
-    // A traversing subpath would escape the package root: split on BOTH separators,
-    // because `path_join_resolve`'s lexical normalization goes through
-    // `Path::components`, which honors `\` on Windows — so a `/`-only guard would
-    // let `pkg/a\..\..\other` walk straight out of the package.
-    if subpath.is_empty() || subpath.split(['/', '\\']).any(|s| s == "..") {
+    //
+    // Beyond that, a subpath carrying a dot-segment or an empty segment belongs to
+    // Node, because lexical normalization erases the very thing that gives such a
+    // specifier its meaning:
+    //   - `..` would escape the package root. Split on BOTH separators, since
+    //     `path_join_resolve` goes through `Path::components`, which honors `\` on
+    //     Windows — a `/`-only guard would let `pkg/a\..\..\other` walk straight out.
+    //   - a trailing `/` or `/.` names a DIRECTORY. Node's CJS resolver goes straight
+    //     to LOAD_AS_DIRECTORY and its ESM resolver raises ERR_UNSUPPORTED_DIR_IMPORT,
+    //     but normalization drops that empty component — so probing would answer
+    //     `pkg/sub/` with a sibling `pkg/sub.js` (a DIFFERENT module than Node loads)
+    //     and would resolve `pkg/lone/` where Node reports it missing.
+    if subpath.is_empty()
+        || subpath
+            .split(['/', '\\'])
+            .any(|s| s.is_empty() || s == "." || s == "..")
+    {
         return None;
     }
 
@@ -157,7 +169,12 @@ fn resolve_bare_subpath(
     // transpile anything under a `node_modules/` path. A workspace package symlinked
     // into node_modules (the `main: ./index.ts` monorepo shape) is only loadable once
     // that hop is resolved away.
-    let candidate = try_resolve_file(&target, true, &NODE_MODULES_PROBE)?;
+    // `allow_dir_main: false`. Directory INDEX probing is deliberate — tsx resolves
+    // `pkg/dir` to `dir/index.js` and that is the parity target — but honoring a
+    // nested directory's own `package.json` `main` goes beyond both tsx and Node's
+    // ESM resolver, and CJS does not need it: declining here falls through to Node,
+    // whose LOAD_AS_DIRECTORY already reads that `main`.
+    let candidate = try_resolve_file(&target, false, &NODE_MODULES_PROBE)?;
     let resolved = real_path(&candidate);
 
     // A TS hit STILL under node_modules after the symlink hop is unshipped source the

--- a/crates/nub-native/src/resolve.rs
+++ b/crates/nub-native/src/resolve.rs
@@ -80,7 +80,7 @@ pub fn resolve_ts(
 
     // Extensionless / emit-swap branch — only when the importer is itself a TS
     // file and the specifier is relative.
-    if is_ts_parent(&parent_ext) && is_relative {
+    if is_ts_parent(&parent_ext) && is_relative && !names_a_directory(&specifier) {
         let target = path_join_resolve(&parent_dir, &specifier);
         if let Some(resolved) = try_resolve_file(&target, true, probe_order(&parent_ext)) {
             return Some(resolved);
@@ -165,16 +165,17 @@ fn resolve_bare_subpath(
         return None;
     }
 
-    // Node realpaths a resolved module by default, and nub's load hooks REFUSE to
-    // transpile anything under a `node_modules/` path. A workspace package symlinked
-    // into node_modules (the `main: ./index.ts` monorepo shape) is only loadable once
-    // that hop is resolved away.
     // `allow_dir_main: false`. Directory INDEX probing is deliberate — tsx resolves
     // `pkg/dir` to `dir/index.js` and that is the parity target — but honoring a
     // nested directory's own `package.json` `main` goes beyond both tsx and Node's
     // ESM resolver, and CJS does not need it: declining here falls through to Node,
     // whose LOAD_AS_DIRECTORY already reads that `main`.
     let candidate = try_resolve_file(&target, false, &NODE_MODULES_PROBE)?;
+
+    // Node realpaths a resolved module by default, and nub's load hooks REFUSE to
+    // transpile anything under a `node_modules/` path. A workspace package symlinked
+    // into node_modules (the `main: ./index.ts` monorepo shape) is only loadable once
+    // that hop is resolved away.
     let resolved = real_path(&candidate);
 
     // A TS hit STILL under node_modules after the symlink hop is unshipped source the
@@ -202,6 +203,25 @@ fn resolve_bare_subpath(
     } else {
         resolved
     })
+}
+
+/// Does this specifier NAME A DIRECTORY rather than a file — a trailing separator
+/// (`./sub/`) or a trailing `.` (`./sub/.`)?
+///
+/// Node treats that as decisive: its CJS resolver reads the trailing slash off the
+/// RAW request and goes straight to LOAD_AS_DIRECTORY, skipping file probing
+/// entirely, and its ESM resolver carries it through URL resolution to
+/// `ERR_UNSUPPORTED_DIR_IMPORT`. Lexical normalization erases it — `Path::components`
+/// yields nothing for a trailing separator — so probing would answer `./sub/` with a
+/// sibling `./sub.ts` and resolve `./lone/` where Node reports it missing, both
+/// silently.
+///
+/// Only the LAST segment is consulted, which is what separates this from the
+/// stricter rule in [`resolve_bare_subpath`]. An interior dot-segment is legitimate
+/// in a relative specifier — Node normalizes `./sub/./x` and resolves it — whereas a
+/// package subpath carrying one is Node's to answer.
+fn names_a_directory(specifier: &str) -> bool {
+    matches!(specifier.rsplit(['/', '\\']).next(), Some("") | Some("."))
 }
 
 /// Probe order for a bare package subpath — JS FIRST, and deliberately NOT

--- a/crates/nub-native/src/resolve.rs
+++ b/crates/nub-native/src/resolve.rs
@@ -118,13 +118,30 @@ fn resolve_bare_subpath(specifier: &str, parent_dir: &str) -> Option<String> {
     }
 
     let target = path_join_resolve(&pkg_dir, &subpath);
-    let resolved = try_resolve_file(&target, true, &NODE_MODULES_PROBE)?;
+    // An exact-extension hit is not an additive case — Node resolves `pkg/dist/foo.js`
+    // in an `exports`-less package identically, down to its own symlink decision. Leave
+    // it to Node so this function owns only what genuinely needed probing.
+    if !extname(&target).is_empty() && is_file(&target) {
+        return None;
+    }
+
     // Node realpaths a resolved module by default, and nub's load hooks REFUSE to
-    // transpile anything still under a `node_modules/` path. A workspace package
-    // symlinked into node_modules (the `main: ./index.ts` monorepo shape) is only
-    // loadable once that hop is resolved away — without this the probe would trade
-    // ERR_MODULE_NOT_FOUND for ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING.
-    Some(real_path(&resolved))
+    // transpile anything under a `node_modules/` path. A workspace package symlinked
+    // into node_modules (the `main: ./index.ts` monorepo shape) is only loadable once
+    // that hop is resolved away.
+    let resolved = real_path(&try_resolve_file(&target, true, &NODE_MODULES_PROBE)?);
+
+    // A TS hit STILL under node_modules after the symlink hop is unshipped source the
+    // load hooks refuse, so winning here is worse than not resolving at all: it turns
+    // Node's ERR_MODULE_NOT_FOUND into a misleading
+    // ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING, and — because probing settles on a
+    // file before it ever considers a directory — `sub.ts` would outrank a sibling
+    // `sub/index.js` that Node's CJS resolver loads today. Fall through instead, so
+    // Node's own precedence and its own error both survive.
+    if is_node_modules(&resolved) && matches!(extname(&resolved).as_str(), ".ts" | ".tsx") {
+        return None;
+    }
+    Some(resolved)
 }
 
 /// Probe order for a bare package subpath — JS FIRST, and deliberately NOT
@@ -132,22 +149,31 @@ fn resolve_bare_subpath(specifier: &str, parent_dir: &str) -> Option<String> {
 ///
 /// What decides the right file inside a dependency is the package's own shape,
 /// not the importer's extension. In a PUBLISHED package a `.ts` sibling is
-/// unshipped source that nub declines to transpile (the `!isNodeModules` gate in
-/// the load hooks), so preferring it would resolve to an unloadable file; in a
-/// symlinked WORKSPACE package there is no `.js` at all, so JS-first still lands
-/// on the `.ts`. Both shapes want the same order. Matches tsx's set exactly —
-/// `.mjs`/`.cjs`/`.mts`/`.cts` are not probed, as an extensionless import of one
-/// is not a pattern that occurs.
+/// unshipped source, so JS must win; in a symlinked WORKSPACE package there is no
+/// `.js` at all, so JS-first still lands on the `.ts`. Both shapes want the same
+/// order. Matches tsx's set exactly — `.mjs`/`.cjs`/`.mts`/`.cts` are not probed,
+/// as an extensionless import of one is not a pattern that occurs.
+///
+/// Ordering alone is not sufficient: a `.ts` with no `.js` sibling still wins the
+/// probe, which is why [`resolve_bare_subpath`] discards a TS hit that is still
+/// under node_modules after realpathing.
 const NODE_MODULES_PROBE: [&str; 4] = [".js", ".json", ".ts", ".tsx"];
 
 /// Resolve symlinks, keeping a plain path on Windows (`std::fs::canonicalize`
 /// yields a `\\?\` verbatim path there, which Node and `pathToFileURL` choke on).
 /// Falls back to the input when the path cannot be canonicalized.
+///
+/// The UNC arm mirrors `strip_verbatim` in nub-core: a canonicalized network path
+/// is `\\?\UNC\server\share\x`, so stripping only `\\?\` would leave
+/// `UNC\server\share\x` — not an absolute path at all.
 fn real_path(path: &str) -> String {
     let Ok(canonical) = std::fs::canonicalize(path) else {
         return path.to_string();
     };
     let s = canonical.to_string_lossy();
+    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+        return format!(r"\\{rest}");
+    }
     match s.strip_prefix(r"\\?\") {
         Some(stripped) => stripped.to_string(),
         None => s.into_owned(),

--- a/crates/nub-native/src/resolve.rs
+++ b/crates/nub-native/src/resolve.rs
@@ -28,8 +28,16 @@ const TS_PARENT_EXTS: [&str; 4] = [".ts", ".tsx", ".mts", ".cts"];
 /// The additive TS resolution. `Some(absolute path)` ⇒ nub short-circuits; `None`
 /// ⇒ fall through to Node (the compat boundary). `parent_path` is the importer's
 /// absolute filesystem path (empty for the entry).
+/// `preserve_symlinks` mirrors Node's flag of the same name. The caller passes it
+/// because the flag reaches a process two ways — argv and `NODE_OPTIONS` — and only
+/// the JS side sees both.
 #[napi]
-pub fn resolve_ts(specifier: String, parent_path: String) -> Option<String> {
+pub fn resolve_ts(
+    specifier: String,
+    parent_path: String,
+    preserve_symlinks: Option<bool>,
+) -> Option<String> {
+    let preserve_symlinks = preserve_symlinks.unwrap_or(false);
     let parent_ext = extname(&parent_path);
     let parent_dir = if parent_path.is_empty() {
         std::env::current_dir().ok()?.to_string_lossy().into_owned()
@@ -54,7 +62,7 @@ pub fn resolve_ts(specifier: String, parent_path: String) -> Option<String> {
         // No alias matched. A bare package NAME still belongs entirely to Node
         // (`main`/`exports`); only a SUBPATH into an `exports`-less dependency is
         // ours to probe.
-        return resolve_bare_subpath(&specifier, &parent_dir);
+        return resolve_bare_subpath(&specifier, &parent_dir, preserve_symlinks);
     }
 
     // Extensionless / emit-swap branch — only when the importer is itself a TS
@@ -86,7 +94,11 @@ pub fn resolve_ts(specifier: String, parent_path: String) -> Option<String> {
 /// Not gated on a TS importer: a `checkJs`/`allowJs` project's `.js` files sit in
 /// the same graph as its `.ts` files and import the same package subpaths, so
 /// gating would split resolution down the middle of one project.
-fn resolve_bare_subpath(specifier: &str, parent_dir: &str) -> Option<String> {
+fn resolve_bare_subpath(
+    specifier: &str,
+    parent_dir: &str,
+    preserve_symlinks: bool,
+) -> Option<String> {
     // `#foo` is an `imports` specifier — the package's own private map, Node's.
     if specifier.starts_with('#') {
         return None;
@@ -132,7 +144,8 @@ fn resolve_bare_subpath(specifier: &str, parent_dir: &str) -> Option<String> {
     // transpile anything under a `node_modules/` path. A workspace package symlinked
     // into node_modules (the `main: ./index.ts` monorepo shape) is only loadable once
     // that hop is resolved away.
-    let resolved = real_path(&try_resolve_file(&target, true, &NODE_MODULES_PROBE)?);
+    let candidate = try_resolve_file(&target, true, &NODE_MODULES_PROBE)?;
+    let resolved = real_path(&candidate);
 
     // A TS hit STILL under node_modules after the symlink hop is unshipped source the
     // load hooks refuse, so winning here is worse than not resolving at all: it turns
@@ -141,10 +154,24 @@ fn resolve_bare_subpath(specifier: &str, parent_dir: &str) -> Option<String> {
     // file before it ever considers a directory — `sub.ts` would outrank a sibling
     // `sub/index.js` that Node's CJS resolver loads today. Fall through instead, so
     // Node's own precedence and its own error both survive.
-    if is_node_modules(&resolved) && matches!(extname(&resolved).as_str(), ".ts" | ".tsx") {
+    //
+    // The whole TS family, not just what [`NODE_MODULES_PROBE`] can land on: the
+    // emit-convention swaps above reach `.mts` and `.cts` too (`pkg/sub.mjs` →
+    // `sub.mts`), and those are exactly as unloadable inside a dependency.
+    if is_node_modules(&resolved) && TS_PARENT_EXTS.contains(&extname(&resolved).as_str()) {
         return None;
     }
-    Some(resolved)
+
+    // Decide on `resolved` above, but hand back what NODE would hand back. Those
+    // differ only under `--preserve-symlinks`, and there the distinction is the whole
+    // ballgame: every other resolution in the process keys a symlinked workspace
+    // package by its un-realpathed path, so returning the real one here would key the
+    // SAME file two ways and instantiate its module twice.
+    Some(if preserve_symlinks {
+        candidate
+    } else {
+        resolved
+    })
 }
 
 /// Probe order for a bare package subpath — JS FIRST, and deliberately NOT

--- a/crates/nub-native/src/resolve.rs
+++ b/crates/nub-native/src/resolve.rs
@@ -5,12 +5,14 @@
 //! **The boundary is load-bearing.** [`resolve_ts`] returns `Some(absolute path)`
 //! ONLY for the additive cases nub owns: tsconfig `paths` aliases, `.ts/.tsx/.mts/
 //! .cts/.jsx` extension probing, the `.js`→`.ts` (and `.jsx→.tsx`, `.mjs→.mts`,
-//! `.cjs→.cts`) emit-convention swap, directory-index probing, and reading a
-//! directory's `package.json#main` (main ONLY). For EVERYTHING else — node_modules
-//! resolution, `exports`/`imports` maps, export conditions, scoped packages, bare
-//! specifiers — it returns `None`, and the JS hook turns that into
-//! `nextResolve(...)` / `origResolveFilename(...)`. Reimplementing Node's own
-//! resolution here is forbidden; `None` is where byte-for-byte compat is preserved.
+//! `.cjs→.cts`) emit-convention swap, directory-index probing, reading a
+//! directory's `package.json#main` (main ONLY), and — see
+//! [`resolve_bare_subpath`] — extension probing of a bare package SUBPATH into a
+//! dependency that declares no `exports`. For EVERYTHING else — package-name
+//! resolution, `exports`/`imports` maps, export conditions — it returns `None`,
+//! and the JS hook turns that into `nextResolve(...)` /
+//! `origResolveFilename(...)`. Reimplementing Node's own resolution here is
+//! forbidden; `None` is where byte-for-byte compat is preserved.
 //!
 //! The `node:`/`data:`/builtin guards, the nub-internal-graph bypass, vendored
 //! packages, and the clobber map all stay in JS and run BEFORE this is called.
@@ -45,20 +47,21 @@ pub fn resolve_ts(specifier: String, parent_path: String) -> Option<String> {
     if !is_relative && !is_absolute && !is_file_url && !is_node_modules(&parent_path) {
         let candidates = tsconfig::match_paths(&parent_dir, &specifier);
         for candidate in candidates {
-            if let Some(resolved) = try_resolve_file(&candidate, &parent_ext, true) {
+            if let Some(resolved) = try_resolve_file(&candidate, true, probe_order(&parent_ext)) {
                 return Some(resolved);
             }
         }
-        // A bare package with no matching alias → let Node resolve from
-        // node_modules. NEVER probe node_modules ourselves.
-        return None;
+        // No alias matched. A bare package NAME still belongs entirely to Node
+        // (`main`/`exports`); only a SUBPATH into an `exports`-less dependency is
+        // ours to probe.
+        return resolve_bare_subpath(&specifier, &parent_dir);
     }
 
     // Extensionless / emit-swap branch — only when the importer is itself a TS
     // file and the specifier is relative.
     if is_ts_parent(&parent_ext) && is_relative {
         let target = path_join_resolve(&parent_dir, &specifier);
-        if let Some(resolved) = try_resolve_file(&target, &parent_ext, true) {
+        if let Some(resolved) = try_resolve_file(&target, true, probe_order(&parent_ext)) {
             return Some(resolved);
         }
     }
@@ -66,9 +69,99 @@ pub fn resolve_ts(specifier: String, parent_path: String) -> Option<String> {
     None
 }
 
+/// Extension probing for a bare package SUBPATH (`pkg/sub`, `@scope/pkg/a/b`).
+///
+/// Node's ESM resolver gives a subpath no probing at all, so `import
+/// "prismjs/components/prism-python"` is a hard `ERR_MODULE_NOT_FOUND` on plain
+/// Node even though the CJS `require()` of the same specifier works. tsc accepts
+/// it, tsx resolves it, and a TS monorepo whose workspace packages point `main`
+/// at `.ts` source depends on it — so this is nub's additive layer. (#562)
+///
+/// THE ENCAPSULATION RULE: a dependency that declares `exports` owns its own
+/// subpath map completely — we return `None` and let Node apply it, so a probe
+/// can never reach a path the package deliberately did not export. Only the
+/// legacy `exports`-less shape, where a subpath is just a path join, is probed.
+/// tsx draws the line in the same place.
+///
+/// Not gated on a TS importer: a `checkJs`/`allowJs` project's `.js` files sit in
+/// the same graph as its `.ts` files and import the same package subpaths, so
+/// gating would split resolution down the middle of one project.
+fn resolve_bare_subpath(specifier: &str, parent_dir: &str) -> Option<String> {
+    // `#foo` is an `imports` specifier — the package's own private map, Node's.
+    if specifier.starts_with('#') {
+        return None;
+    }
+
+    let mut segs = specifier.split('/');
+    let first = segs.next()?;
+    let pkg = if first.starts_with('@') {
+        format!("{first}/{}", segs.next()?)
+    } else {
+        first.to_string()
+    };
+    let subpath = segs.collect::<Vec<_>>().join("/");
+    // A bare NAME (no subpath) resolves through `main`/`exports` — never ours.
+    // A traversing subpath would escape the package root.
+    if subpath.is_empty() || subpath.split('/').any(|s| s == "..") {
+        return None;
+    }
+
+    let pkg_dir = tsconfig::find_up_dir(parent_dir, &format!("node_modules/{pkg}"))?;
+    let pkg_json = Path::new(&pkg_dir).join("package.json");
+    let text = std::fs::read_to_string(&pkg_json).ok()?;
+    let manifest: serde_json::Value = serde_json::from_str(&text).ok()?;
+    // The mere PRESENCE of the key hands the package its own subpath map. Note
+    // `"exports": null` is the deliberate "export nothing" form, not an absent
+    // map — so this tests presence, never truthiness.
+    if manifest.get("exports").is_some() {
+        return None;
+    }
+
+    let target = path_join_resolve(&pkg_dir, &subpath);
+    let resolved = try_resolve_file(&target, true, &NODE_MODULES_PROBE)?;
+    // Node realpaths a resolved module by default, and nub's load hooks REFUSE to
+    // transpile anything still under a `node_modules/` path. A workspace package
+    // symlinked into node_modules (the `main: ./index.ts` monorepo shape) is only
+    // loadable once that hop is resolved away — without this the probe would trade
+    // ERR_MODULE_NOT_FOUND for ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING.
+    Some(real_path(&resolved))
+}
+
+/// Probe order for a bare package subpath — JS FIRST, and deliberately NOT
+/// parent-extension-aware like [`probe_order`].
+///
+/// What decides the right file inside a dependency is the package's own shape,
+/// not the importer's extension. In a PUBLISHED package a `.ts` sibling is
+/// unshipped source that nub declines to transpile (the `!isNodeModules` gate in
+/// the load hooks), so preferring it would resolve to an unloadable file; in a
+/// symlinked WORKSPACE package there is no `.js` at all, so JS-first still lands
+/// on the `.ts`. Both shapes want the same order. Matches tsx's set exactly —
+/// `.mjs`/`.cjs`/`.mts`/`.cts` are not probed, as an extensionless import of one
+/// is not a pattern that occurs.
+const NODE_MODULES_PROBE: [&str; 4] = [".js", ".json", ".ts", ".tsx"];
+
+/// Resolve symlinks, keeping a plain path on Windows (`std::fs::canonicalize`
+/// yields a `\\?\` verbatim path there, which Node and `pathToFileURL` choke on).
+/// Falls back to the input when the path cannot be canonicalized.
+fn real_path(path: &str) -> String {
+    let Ok(canonical) = std::fs::canonicalize(path) else {
+        return path.to_string();
+    };
+    let s = canonical.to_string_lossy();
+    match s.strip_prefix(r"\\?\") {
+        Some(stripped) => stripped.to_string(),
+        None => s.into_owned(),
+    }
+}
+
 /// Port of the JS `tryResolveFile`: existing-extension hit, emit-convention
-/// swaps, extensionless probing, and directory `main`/index resolution.
-fn try_resolve_file(target: &str, parent_ext: &str, allow_dir_main: bool) -> Option<String> {
+/// swaps, extensionless probing, and directory `main`/index resolution. `probe`
+/// is the extensionless-probe order (see [`probe_order`], [`NODE_MODULES_PROBE`]).
+fn try_resolve_file(
+    target: &str,
+    allow_dir_main: bool,
+    probe: &'static [&'static str],
+) -> Option<String> {
     let existing_ext = extname(target);
 
     // 1. Existing extension that exists → use it (a real .cjs beats a sibling .cts).
@@ -111,7 +204,6 @@ fn try_resolve_file(target: &str, parent_ext: &str, allow_dir_main: bool) -> Opt
 
     // 3. Extensionless: probe in parent-ext-aware order.
     if existing_ext.is_empty() || !TS_PARENT_EXTS.contains(&existing_ext.as_str()) {
-        let probe = probe_order(parent_ext);
         for ext in probe {
             let candidate = format!("{target}{ext}");
             if is_file(&candidate) {
@@ -125,7 +217,7 @@ fn try_resolve_file(target: &str, parent_ext: &str, allow_dir_main: bool) -> Opt
                     let main_target = path_join_resolve(target, &main);
                     // Node's LOAD_AS_DIRECTORY does NOT recurse a main target's
                     // own nested main → allow_dir_main=false.
-                    if let Some(resolved) = try_resolve_file(&main_target, parent_ext, false) {
+                    if let Some(resolved) = try_resolve_file(&main_target, false, probe) {
                         return Some(resolved);
                     }
                 }

--- a/crates/nub-native/src/resolve.rs
+++ b/crates/nub-native/src/resolve.rs
@@ -101,8 +101,11 @@ fn resolve_bare_subpath(specifier: &str, parent_dir: &str) -> Option<String> {
     };
     let subpath = segs.collect::<Vec<_>>().join("/");
     // A bare NAME (no subpath) resolves through `main`/`exports` — never ours.
-    // A traversing subpath would escape the package root.
-    if subpath.is_empty() || subpath.split('/').any(|s| s == "..") {
+    // A traversing subpath would escape the package root: split on BOTH separators,
+    // because `path_join_resolve`'s lexical normalization goes through
+    // `Path::components`, which honors `\` on Windows — so a `/`-only guard would
+    // let `pkg/a\..\..\other` walk straight out of the package.
+    if subpath.is_empty() || subpath.split(['/', '\\']).any(|s| s == "..") {
         return None;
     }
 

--- a/crates/nub-native/src/resolve.rs
+++ b/crates/nub-native/src/resolve.rs
@@ -38,6 +38,19 @@ pub fn resolve_ts(
     preserve_symlinks: Option<bool>,
 ) -> Option<String> {
     let preserve_symlinks = preserve_symlinks.unwrap_or(false);
+    // Classify and DISCOVER from where the importer really lives. Under
+    // `--preserve-symlinks` Node hands over the un-realpathed path, so a file inside a
+    // workspace package symlinked into node_modules would read as a dependency and
+    // lose the additive resolution its own imports get without the flag. Both uses
+    // have to move together: `parent_dir` drives tsconfig discovery and the
+    // node_modules walk, so testing the real path while discovering from the symlink
+    // would find the project root's tsconfig instead of the package's own. What the
+    // resolver RETURNS is a separate question, settled per-case below.
+    let parent_path = if preserve_symlinks && !parent_path.is_empty() {
+        real_path(&parent_path)
+    } else {
+        parent_path
+    };
     let parent_ext = extname(&parent_path);
     let parent_dir = if parent_path.is_empty() {
         std::env::current_dir().ok()?.to_string_lossy().into_owned()

--- a/crates/nub-native/src/tsconfig.rs
+++ b/crates/nub-native/src/tsconfig.rs
@@ -751,7 +751,7 @@ fn resolve_conditional(target: &Value, conditions: &[&str]) -> Option<String> {
 /// `findUp` for a relative *path* (not just a filename): walk up from `start`
 /// joining `rel`, returning the first existing hit (get-tsconfig calls `O` with a
 /// `node_modules/<pkg>` relative path).
-fn find_up_dir(start: &str, rel: &str) -> Option<String> {
+pub(crate) fn find_up_dir(start: &str, rel: &str) -> Option<String> {
     let mut dir = PathBuf::from(start);
     loop {
         let candidate = dir.join(rel);

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -29,7 +29,7 @@
 import "./floor-builtin.mjs";
 import {
   TRANSPILE_EXTS, PLAIN_JS_EXTS, DATA_EXTS,
-  extname, resolveSpec, loadTranspile, maybeTranspilePlainJs, loadData, loadTextImport, isNodeModules,
+  extname, resolveSpec, loadTranspile, maybeTranspilePlainJs, loadData, loadTextImport, isNodeModules, isDependency,
 } from "./transform-core.mjs";
 import { createRequire, isBuiltin } from "node:module";
 import { existsSync } from "node:fs";
@@ -99,7 +99,7 @@ export async function load(url, context, nextLoad) {
   // the compat tier would route every dependency `.js` through oxc. (loadTranspile's
   // own skip-gate handles the project-source no-op case; this keeps deps off the
   // pipeline entirely.) Mirrors the fast-tier sync hook's `!isNodeModules` gate.
-  if (TRANSPILE_EXTS.has(ext) && !isNodeModules(url)) {
+  if (TRANSPILE_EXTS.has(ext) && !isDependency(url)) {
     // Module-format + decorator detection inside loadTranspile is a synchronous
     // native call (nub's addon), available on every supported Node — no parser
     // warm-up needed (the old `await ensureParser()` for the ESM-only oxc-parser
@@ -110,7 +110,7 @@ export async function load(url, context, nextLoad) {
   // no-op plain-JS file returns null and falls through to `nextLoad` — Node's own
   // loader handles it byte-identically, preserving every native CJS/ESM behavior.
   // node_modules excluded (the byte-parity boundary).
-  if (PLAIN_JS_EXTS.has(ext) && !isNodeModules(url)) {
+  if (PLAIN_JS_EXTS.has(ext) && !isDependency(url)) {
     const r = maybeTranspilePlainJs(url, ext);
     if (r) return r;
   }

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -29,7 +29,7 @@
 import "./floor-builtin.mjs";
 import {
   TRANSPILE_EXTS, PLAIN_JS_EXTS, DATA_EXTS,
-  extname, resolveSpec, loadTranspile, maybeTranspilePlainJs, loadData, loadTextImport, isNodeModules, isDependency,
+  extname, resolveSpec, loadTranspile, maybeTranspilePlainJs, loadData, loadTextImport, isDependency,
 } from "./transform-core.mjs";
 import { createRequire, isBuiltin } from "node:module";
 import { existsSync } from "node:fs";
@@ -98,7 +98,7 @@ export async function load(url, context, nextLoad) {
   // make-or-break now that TRANSPILE_EXTS includes `.js`/`.mjs`/`.cjs`: without it,
   // the compat tier would route every dependency `.js` through oxc. (loadTranspile's
   // own skip-gate handles the project-source no-op case; this keeps deps off the
-  // pipeline entirely.) Mirrors the fast-tier sync hook's `!isNodeModules` gate.
+  // pipeline entirely.) Mirrors the fast-tier sync hook's `!isDependency` gate.
   if (TRANSPILE_EXTS.has(ext) && !isDependency(url)) {
     // Module-format + decorator detection inside loadTranspile is a synchronous
     // native call (nub's addon), available on every supported Node — no parser

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -809,10 +809,16 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   // the two tiers in agreement. The check is on Node's ANSWER rather than a guess about
   // the request, so nothing is re-resolved unless our own keys actually changed the
   // outcome; the retry then reports whatever Node itself would, error included.
-  const TS_CLASSIC_EXTS = [".ts", ".cts", ".mts", ".tsx", ".jsx"];
-  const withoutTsExtensions = (fn) => {
+  // Every extension nub adds to `Module._extensions` that Node does not have of its
+  // own. `.cjs` belongs here with the TypeScript family: Node registers only `.js`,
+  // `.json` and `.node`, so nub's `.cjs` handler likewise widens LOAD_AS_FILE and
+  // lets `require("dep/x/sub")` find a dependency's `sub.cjs` that plain Node reports
+  // missing. An explicit `require("dep/x/sub.cjs")` is unaffected either way — an
+  // exact path is found by stat, without consulting the extension list at all.
+  const NUB_ADDED_EXTS = [".ts", ".cts", ".mts", ".tsx", ".jsx", ".cjs"];
+  const withoutNubAddedExtensions = (fn) => {
     const saved = [];
-    for (const ext of TS_CLASSIC_EXTS) {
+    for (const ext of NUB_ADDED_EXTS) {
       if (Object.hasOwn(module_._extensions, ext)) {
         saved.push([ext, module_._extensions[ext]]);
         delete module_._extensions[ext];
@@ -824,9 +830,9 @@ function installCjsRequireHooks(core, withClassicTranspile) {
       for (const [ext, handler] of saved) module_._extensions[ext] = handler;
     }
   };
-  const isDepTsHit = (filename) =>
+  const isDepAddedExtHit = (filename) =>
     typeof filename === "string" &&
-    TS_CLASSIC_EXTS.includes(pathExtname(filename)) &&
+    NUB_ADDED_EXTS.includes(pathExtname(filename)) &&
     core.isDependency(pathToFileURL(filename).href);
 
   module_._resolveFilename = function (request, parent, isMain, options) {
@@ -836,6 +842,19 @@ function installCjsRequireHooks(core, withClassicTranspile) {
       resolved = core.resolveCjsPath(request, parentPath);
     } catch { /* fall through to Node */ }
     if (resolved) {
+      // This pre-check stays at RESOLVE time even though `_resolveFilename` also
+      // answers `require.resolve()`, for which a path lookup is not a load. Below the
+      // Node #60380 fix, `require()` of a transpiled ES module dies inside the
+      // loader-worker translator with an opaque `cjsCache.get(...)` TypeError, and
+      // that happens before any load hook of ours can run — so a load-time refusal
+      // never gets its turn and Node's own crash is what the user sees.
+      //
+      // The cost is that `require.resolve()` of an ESM-syntax TS target throws here
+      // instead of returning the path. Telling the two callers apart is not reliable
+      // across the band this is live on: Node passes 3 arguments from `Module._load`
+      // and 4 from `require.resolve` up to 22.14, but 22.15 and 22.16 pass 4 for both
+      // while still lacking native TS — and the translator crash is present on
+      // exactly those versions. A clean error beats an opaque crash, so this stays.
       if (withClassicTranspile && core.requireTargetIsEsm(resolved, pathExtname(resolved))) {
         throw requireEsmError(resolved);
       }
@@ -863,7 +882,7 @@ function installCjsRequireHooks(core, withClassicTranspile) {
     }
     try {
       const byNode = origResolveFilename.call(this, request, parent, isMain, options);
-      if (withClassicTranspile && isDepTsHit(byNode)) {
+      if (withClassicTranspile && isDepAddedExtHit(byNode)) {
         // `_findPath` memoizes into `Module._pathCache` and returns that entry before
         // it ever consults the extension list, so the retry would be handed the same
         // TS hit and the removal below would look like a no-op. Drop the memo first.
@@ -872,7 +891,7 @@ function installCjsRequireHooks(core, withClassicTranspile) {
         for (const key of Object.keys(module_._pathCache)) {
           if (module_._pathCache[key] === byNode) delete module_._pathCache[key];
         }
-        return withoutTsExtensions(() =>
+        return withoutNubAddedExtensions(() =>
           origResolveFilename.call(this, request, parent, isMain, options),
         );
       }

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -824,24 +824,28 @@ function installCjsRequireHooks(core, withClassicTranspile) {
       for (const [ext, handler] of saved) module_._extensions[ext] = handler;
     }
   };
-  const isDepTsHit = (filename) => {
+  // "Is this really a dependency?" — the ONE definition the resolve-side retry and
+  // the load-side bail both use, so the two layers cannot drift into disagreeing.
+  //
+  // A path that doesn't even mention node_modules is project source, answered
+  // without touching the disk. Only a path that LOOKS like a dependency pays a stat,
+  // and it has to: under `--preserve-symlinks` Node hands back un-realpathed paths,
+  // so a workspace package symlinked into node_modules still carries a
+  // `/node_modules/` segment and would otherwise be misread as a dependency —
+  // costing it the TypeScript that IS its build output.
+  const isDependencyPath = (filename) => {
     if (typeof filename !== "string") return false;
-    if (!TS_CLASSIC_EXTS.includes(pathExtname(filename))) return false;
-    // Decide on where the file REALLY lives, not on the path Node happened to hand
-    // back. Under `--preserve-symlinks` Node's `tryFile` skips `toRealPath`, so a
-    // workspace package symlinked into node_modules still carries a `/node_modules/`
-    // segment and would read as a dependency — costing it the TS source that IS its
-    // build output. Resolving first makes the test independent of Node's symlink
-    // policy rather than coincidentally agreeing with the default. Only TS-extension
-    // hits get here, so the extra stat is off the hot path.
-    let real = filename;
+    if (!core.isNodeModules(pathToFileURL(filename).href)) return false;
     try {
-      real = realpathSync(filename);
+      return core.isNodeModules(pathToFileURL(realpathSync(filename)).href);
     } catch {
-      /* unreadable: fall back to the literal path */
+      return true; // unreadable: trust the literal path
     }
-    return core.isNodeModules(pathToFileURL(real).href);
   };
+  const isDepTsHit = (filename) =>
+    typeof filename === "string" &&
+    TS_CLASSIC_EXTS.includes(pathExtname(filename)) &&
+    isDependencyPath(filename);
 
   module_._resolveFilename = function (request, parent, isMain, options) {
     let resolved = null;
@@ -918,7 +922,20 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   // decorator guard, and module-format detection are all identical to the fast
   // tier. The path is already a real TS file (Module._resolveFilename ran first).
   // A module-format source can't be _compile'd as CJS — same clean error as above.
+  //
+  // A dependency's TypeScript is never transpiled — the same invariant the `.js`/
+  // `.cjs` handler below states as its case (1). The resolution-side retry keeps
+  // most dep TS from ever reaching here, but an explicit path (`require(
+  // "./node_modules/pkg/inner.ts")`) names the file directly and skips resolution
+  // entirely, so the bail has to live at the load step too. Delegating to the native
+  // `.js` handler rather than throwing is what Node itself does: an extension it has
+  // no handler for falls back to `.js` via `findLongestRegisteredExtension`, so this
+  // reproduces plain Node's own error instead of inventing one nub would have to own.
+  const nativeJs = module_._extensions[".js"];
   const transpileExtension = (mod, filename) => {
+    if (isDependencyPath(filename)) {
+      return nativeJs.call(module_._extensions, mod, filename);
+    }
     const { source, format } = core.loadTranspile(pathToFileURL(filename).href, pathExtname(filename));
     if (format === "module") throw requireEsmError(filename);
     mod._compile(source, filename);
@@ -943,7 +960,7 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   //       native CJS behavior is byte-identical.
   // `.mjs` is ESM-only; Node registers no require.extensions handler for it, so a
   // `require()` of `.mjs` throws ERR_REQUIRE_ESM as before — we don't override it.
-  const nativeJs = module_._extensions[".js"];
+  // (`nativeJs` is captured above, before the TS handlers are registered.)
   for (const ext of [".js", ".cjs"]) {
     const origExtension = module_._extensions[ext] || nativeJs;
     module_._extensions[ext] = (mod, filename) => {

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -809,6 +809,7 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   // the two tiers in agreement. The check is on Node's ANSWER rather than a guess about
   // the request, so nothing is re-resolved unless our own keys actually changed the
   // outcome; the retry then reports whatever Node itself would, error included.
+  //
   // Every extension nub adds to `Module._extensions` that Node does not have of its
   // own. `.cjs` belongs here with the TypeScript family: Node registers only `.js`,
   // `.json` and `.node`, so nub's `.cjs` handler likewise widens LOAD_AS_FILE and

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -795,6 +795,40 @@ function requireEsmError(filename) {
 // already cover resolution + transpile.
 function installCjsRequireHooks(core, withClassicTranspile) {
   const origResolveFilename = module_._resolveFilename;
+
+  // The classic transpile handlers registered below put `.ts`/`.cts`/`.mts`/`.tsx`/
+  // `.jsx` into `Module._extensions`, and Node's `_findPath` runs `tryExtensions` over
+  // EVERY key of that object during LOAD_AS_FILE — before it ever tries
+  // LOAD_AS_DIRECTORY. Registering them therefore reorders Node's own resolution
+  // INSIDE dependencies: `require("pkg/sub")` picks a dep's unshipped `sub.ts` over the
+  // `sub/index.js` Node loads, and a dep's internal `require("./util")` picks `util.ts`
+  // where Node reports it missing. Both hand back a silently different module.
+  //
+  // Deps are NEVER transpiled — the same invariant the `.js`/`.cjs` handler below
+  // states — and the fast tier already resolves both shapes Node's way, so this keeps
+  // the two tiers in agreement. The check is on Node's ANSWER rather than a guess about
+  // the request, so nothing is re-resolved unless our own keys actually changed the
+  // outcome; the retry then reports whatever Node itself would, error included.
+  const TS_CLASSIC_EXTS = [".ts", ".cts", ".mts", ".tsx", ".jsx"];
+  const withoutTsExtensions = (fn) => {
+    const saved = [];
+    for (const ext of TS_CLASSIC_EXTS) {
+      if (Object.hasOwn(module_._extensions, ext)) {
+        saved.push([ext, module_._extensions[ext]]);
+        delete module_._extensions[ext];
+      }
+    }
+    try {
+      return fn();
+    } finally {
+      for (const [ext, handler] of saved) module_._extensions[ext] = handler;
+    }
+  };
+  const isDepTsHit = (filename) =>
+    typeof filename === "string" &&
+    TS_CLASSIC_EXTS.includes(pathExtname(filename)) &&
+    core.isNodeModules(pathToFileURL(filename).href);
+
   module_._resolveFilename = function (request, parent, isMain, options) {
     let resolved = null;
     try {
@@ -828,7 +862,21 @@ function installCjsRequireHooks(core, withClassicTranspile) {
       delete options.conditions;
     }
     try {
-      return origResolveFilename.call(this, request, parent, isMain, options);
+      const byNode = origResolveFilename.call(this, request, parent, isMain, options);
+      if (withClassicTranspile && isDepTsHit(byNode)) {
+        // `_findPath` memoizes into `Module._pathCache` and returns that entry before
+        // it ever consults the extension list, so the retry would be handed the same
+        // TS hit and the removal below would look like a no-op. Drop the memo first.
+        // Purging by VALUE rather than rebuilding the cache key keeps this off Node's
+        // internal key format, which differs across the supported range.
+        for (const key of Object.keys(module_._pathCache)) {
+          if (module_._pathCache[key] === byNode) delete module_._pathCache[key];
+        }
+        return withoutTsExtensions(() =>
+          origResolveFilename.call(this, request, parent, isMain, options),
+        );
+      }
+      return byNode;
     } catch (e) {
       // Under PnP, an in-tree issuer requiring a dep NOT in its manifest makes PnP
       // throw. That is nub's OWN transpile helpers (e.g. `@oxc-project/runtime`),

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -523,13 +523,13 @@ function makeHooks(core, watchReporting) {
   function loadViaDisk(url, ext) {
     try {
       const path = fileURLToPath(url);
-      if (core.TRANSPILE_EXTS.has(ext) && !core.isNodeModules(url)) {
+      if (core.TRANSPILE_EXTS.has(ext) && !core.isDependency(url)) {
         return core.loadTranspile(url, ext);
       }
       // Plain JS: transpile only when transformable; else fall through to the raw-
       // source path below (which hands CJS back as `source:null` → Node's native
       // CJS loader), byte-identical to a non-intercepted file.
-      if (core.PLAIN_JS_EXTS.has(ext) && !core.isNodeModules(url)) {
+      if (core.PLAIN_JS_EXTS.has(ext) && !core.isDependency(url)) {
         const r = core.maybeTranspilePlainJs(url, ext);
         if (r) return r;
       }
@@ -606,7 +606,7 @@ function makeHooks(core, watchReporting) {
     // handling (and its error) applies. (The TS-parent extensionless resolution in
     // the resolve hook is intended and stays — only this load-time transpile is
     // gated.)
-    if (core.TRANSPILE_EXTS.has(ext) && !core.isNodeModules(url)) {
+    if (core.TRANSPILE_EXTS.has(ext) && !core.isDependency(url)) {
       return core.loadTranspile(url, ext);
     }
     // Project-source plain JS (`.js`/`.mjs`/`.cjs`): transpile ONLY when it carries
@@ -614,7 +614,7 @@ function makeHooks(core, watchReporting) {
     // to Node's native loader (the `nextLoad`/relabel path below) BYTE-FOR-BYTE — it
     // is never intercepted, so native CJS/ESM behavior (the relabel, require.cache,
     // the require-of-ESM-syntax-`.cjs` error) is preserved. node_modules excluded.
-    if (core.PLAIN_JS_EXTS.has(ext) && !core.isNodeModules(url)) {
+    if (core.PLAIN_JS_EXTS.has(ext) && !core.isDependency(url)) {
       const r = core.maybeTranspilePlainJs(url, ext);
       if (r) return r;
     }
@@ -824,28 +824,10 @@ function installCjsRequireHooks(core, withClassicTranspile) {
       for (const [ext, handler] of saved) module_._extensions[ext] = handler;
     }
   };
-  // "Is this really a dependency?" — the ONE definition the resolve-side retry and
-  // the load-side bail both use, so the two layers cannot drift into disagreeing.
-  //
-  // A path that doesn't even mention node_modules is project source, answered
-  // without touching the disk. Only a path that LOOKS like a dependency pays a stat,
-  // and it has to: under `--preserve-symlinks` Node hands back un-realpathed paths,
-  // so a workspace package symlinked into node_modules still carries a
-  // `/node_modules/` segment and would otherwise be misread as a dependency —
-  // costing it the TypeScript that IS its build output.
-  const isDependencyPath = (filename) => {
-    if (typeof filename !== "string") return false;
-    if (!core.isNodeModules(pathToFileURL(filename).href)) return false;
-    try {
-      return core.isNodeModules(pathToFileURL(realpathSync(filename)).href);
-    } catch {
-      return true; // unreadable: trust the literal path
-    }
-  };
   const isDepTsHit = (filename) =>
     typeof filename === "string" &&
     TS_CLASSIC_EXTS.includes(pathExtname(filename)) &&
-    isDependencyPath(filename);
+    core.isDependency(pathToFileURL(filename).href);
 
   module_._resolveFilename = function (request, parent, isMain, options) {
     let resolved = null;
@@ -933,7 +915,7 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   // reproduces plain Node's own error instead of inventing one nub would have to own.
   const nativeJs = module_._extensions[".js"];
   const transpileExtension = (mod, filename) => {
-    if (isDependencyPath(filename)) {
+    if (core.isDependency(pathToFileURL(filename).href)) {
       return nativeJs.call(module_._extensions, mod, filename);
     }
     const { source, format } = core.loadTranspile(pathToFileURL(filename).href, pathExtname(filename));
@@ -964,7 +946,7 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   for (const ext of [".js", ".cjs"]) {
     const origExtension = module_._extensions[ext] || nativeJs;
     module_._extensions[ext] = (mod, filename) => {
-      if (core.isNodeModules(pathToFileURL(filename).href)) {
+      if (core.isDependency(pathToFileURL(filename).href)) {
         return origExtension.call(module_._extensions, mod, filename); // (1)
       }
       const r = core.maybeTranspilePlainJs(pathToFileURL(filename).href, pathExtname(filename));

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -16,7 +16,7 @@
 // (it imported them as ESM), so this module never require()s the core there.
 
 const module_ = require("node:module");
-const { readdirSync, existsSync, realpathSync } = require("node:fs");
+const { readdirSync, existsSync } = require("node:fs");
 const { fileURLToPath, pathToFileURL } = require("node:url");
 const { join, dirname, extname: pathExtname } = require("node:path");
 

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -16,7 +16,7 @@
 // (it imported them as ESM), so this module never require()s the core there.
 
 const module_ = require("node:module");
-const { readdirSync, existsSync } = require("node:fs");
+const { readdirSync, existsSync, realpathSync } = require("node:fs");
 const { fileURLToPath, pathToFileURL } = require("node:url");
 const { join, dirname, extname: pathExtname } = require("node:path");
 
@@ -824,10 +824,24 @@ function installCjsRequireHooks(core, withClassicTranspile) {
       for (const [ext, handler] of saved) module_._extensions[ext] = handler;
     }
   };
-  const isDepTsHit = (filename) =>
-    typeof filename === "string" &&
-    TS_CLASSIC_EXTS.includes(pathExtname(filename)) &&
-    core.isNodeModules(pathToFileURL(filename).href);
+  const isDepTsHit = (filename) => {
+    if (typeof filename !== "string") return false;
+    if (!TS_CLASSIC_EXTS.includes(pathExtname(filename))) return false;
+    // Decide on where the file REALLY lives, not on the path Node happened to hand
+    // back. Under `--preserve-symlinks` Node's `tryFile` skips `toRealPath`, so a
+    // workspace package symlinked into node_modules still carries a `/node_modules/`
+    // segment and would read as a dependency — costing it the TS source that IS its
+    // build output. Resolving first makes the test independent of Node's symlink
+    // policy rather than coincidentally agreeing with the default. Only TS-extension
+    // hits get here, so the extra stat is off the hot path.
+    let real = filename;
+    try {
+      real = realpathSync(filename);
+    } catch {
+      /* unreadable: fall back to the literal path */
+    }
+    return core.isNodeModules(pathToFileURL(real).href);
+  };
 
   module_._resolveFilename = function (request, parent, isMain, options) {
     let resolved = null;

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -266,8 +266,10 @@ export function isNodeModules(url) {
   return url.includes("/node_modules/") || url.includes("\\node_modules\\");
 }
 
-// "Is this really a dependency?" — the ONE definition every gate uses, so the resolve
-// step and each load step cannot disagree about the same file.
+// "Is this really a dependency?" — the ONE definition every gate that decides how a
+// file LOADS uses, so the resolve step and each load step cannot disagree about the
+// same file. (Watch-mode config reporting still uses the plain check: it asks which
+// files to watch, not how they load.)
 //
 // A `/node_modules/` segment normally settles it: Node realpaths a resolved module,
 // so the path we are handed IS the real one. Under `--preserve-symlinks` it does not
@@ -409,7 +411,7 @@ export function resolveSpec(specifier, parentURL) {
   }
 
   // 3. Package clobbering.
-  if (CLOBBER_MAP.has(bare) && !isNodeModules(parentURL || "")) {
+  if (CLOBBER_MAP.has(bare) && !isDependency(parentURL || "")) {
     return { url: `data:text/javascript,${encodeURIComponent(CLOBBER_MAP.get(bare)())}`, shortCircuit: true };
   }
 

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -112,7 +112,7 @@ function __getBuiltin(id) {
 // Builtin bindings + the native addon, populated by __ensureBuiltins(). They stay
 // `let` (not `const`) because on the floor they are filled on first hook use rather
 // than at module eval — see the lazy-vs-eager note above.
-let createRequire, __require, module, readFileSync, writeFileSync, mkdirSync, statSync;
+let createRequire, __require, module, readFileSync, writeFileSync, mkdirSync, statSync, realpathSync;
 let fileURLToPath, pathToFileURL, join, dirname;
 // Nub's N-API addon — the in-process TS/JSX transpiler (`transform`,
 // `transformCached`, `detectModuleInfo`), the tsconfig reader + additive
@@ -138,7 +138,7 @@ function __ensureBuiltins() {
   ({ createRequire } = __getBuiltin("node:module"));
   __require = createRequire(import.meta.url);
   module = __getBuiltin("node:module");
-  ({ readFileSync, writeFileSync, mkdirSync, statSync } = __getBuiltin("node:fs"));
+  ({ readFileSync, writeFileSync, mkdirSync, statSync, realpathSync } = __getBuiltin("node:fs"));
   ({ fileURLToPath, pathToFileURL } = __getBuiltin("node:url"));
   ({ join, dirname } = __getBuiltin("node:path"));
   for (const rel of ["./addons/nub-native.node", "../runtime/addons/nub-native.node"]) {
@@ -264,6 +264,26 @@ export function extname(url) {
 
 export function isNodeModules(url) {
   return url.includes("/node_modules/") || url.includes("\\node_modules\\");
+}
+
+// "Is this really a dependency?" — the ONE definition every gate uses, so the resolve
+// step and each load step cannot disagree about the same file.
+//
+// A `/node_modules/` segment normally settles it: Node realpaths a resolved module,
+// so the path we are handed IS the real one. Under `--preserve-symlinks` it does not
+// — a workspace package symlinked into node_modules keeps that segment while its
+// files genuinely live in the project, and calling it a dependency would refuse the
+// TypeScript that is its build output. The stat therefore happens only under the
+// flag, and only for paths that already look like a dependency; the default path
+// stays the pure substring test it always was.
+export function isDependency(url) {
+  if (!isNodeModules(url)) return false;
+  if (!PRESERVE_SYMLINKS) return true;
+  try {
+    return isNodeModules(pathToFileURL(realpathSync(fileURLToPath(url))).href);
+  } catch {
+    return true; // unreadable: trust the literal path
+  }
 }
 
 export function fileExists(filePath) {

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -293,10 +293,21 @@ export function barePkg(specifier) {
 // nub is forbidden. The `node:`/`data:`/builtin guards, the nub-internal-graph
 // bypass, vendored packages, and the clobber map all stay in JS and run BEFORE the
 // native resolver (see resolveSpec / resolveCjsPath).
+// Node's `--preserve-symlinks` decides whether a resolved module is keyed by its
+// real path or the path it was reached through, and the native resolver has to hand
+// back whichever one Node itself would — otherwise a symlinked workspace package
+// reached two ways instantiates twice. The flag arrives by argv OR `NODE_OPTIONS`,
+// and only one of those shows up in `execArgv`, so both are checked. The word
+// boundary matters: `--preserve-symlinks-main` is a DIFFERENT flag that governs only
+// the entry point.
+const PRESERVE_SYMLINKS =
+  process.execArgv.includes("--preserve-symlinks") ||
+  /(^|\s)--preserve-symlinks(\s|$)/.test(process.env.NODE_OPTIONS || "");
+
 function resolveTs(specifier, parentPath) {
   if (!nubNative) return null;
   try {
-    return nubNative.resolveTs(specifier, parentPath || "");
+    return nubNative.resolveTs(specifier, parentPath || "", PRESERVE_SYMLINKS);
   } catch {
     return null;
   }

--- a/site/content/docs/runtime/resolution.mdx
+++ b/site/content/docs/runtime/resolution.mdx
@@ -113,6 +113,14 @@ JavaScript sorts first because a published package's `.ts` is unshipped source t
 
 Because the rule is about the dependency's shape rather than the importer's, it is not scoped to TypeScript-family parents — a `.js` file in a `checkJs` project resolves these the same way.
 
+A subpath naming a directory resolves that directory's `index` file, the way a `require` of the same subpath already does:
+
+```ts
+import { parse } from "qs/lib";   // resolves qs/lib/index.js
+```
+
+Only `index` is consulted. A directory's own `package.json` `main` is not read for a subpath — Node's `require` reads it, and deferring keeps both resolvers on the same answer. A trailing slash means what it says: `qs/lib/` is the directory, never a `qs/lib.js` beside it.
+
 <Callout>A dependency that declares `exports` is never probed. Its map decides what is reachable, exactly as on Node, so a subpath it withholds stays an error.</Callout>
 
 ## .js → .ts resolution

--- a/site/content/docs/runtime/resolution.mdx
+++ b/site/content/docs/runtime/resolution.mdx
@@ -117,11 +117,14 @@ Because the rule is about the dependency's shape rather than the importer's, it 
 
 ## .js → .ts resolution
 
-With `moduleResolution: "nodenext"`, `tsc` wants a `.js` extension on relative imports even though the file on disk is `.ts`. Nub reverses that at runtime, so the same source runs before and after a build.
+With `moduleResolution: "nodenext"`, `tsc` wants a `.js` extension even though the file on disk is `.ts`. Nub reverses that at runtime, so the same source runs before and after a build.
 
 ```ts
 // resolves ./handler.ts when no ./handler.js exists
 import { handler } from "./handler.js";
+
+// and across a package subpath, into a workspace package built from TS source
+import { createPrompt } from "@repo/lib/prompt.js";
 ```
 
 The literal extension always wins first: a real on-disk `./handler.js` is used as-is, and the swap only fires when the written extension points at a file that doesn't exist. The same rewrite covers `.jsx → .tsx`, `.mjs → .mts`, and `.cjs → .cts` — and likewise, a real `.cjs` beats a sibling `.cts`. This is the `tsc`/`tsx` emit convention, not a guess at the file's type.

--- a/site/content/docs/runtime/resolution.mdx
+++ b/site/content/docs/runtime/resolution.mdx
@@ -16,7 +16,7 @@ import { config } from "./config";
 import { handler } from "./handler.js";
 ```
 
-If your editor's Go-to-Definition works on an import and `tsc` accepts it, Nub resolves it the same way at runtime — no `tsconfig-paths` package, no build step. Nub owns exactly the cases Node has no opinion on: `tsconfig.json` path aliases, extensionless imports in TypeScript files, and the `.js`→`.ts` emit-convention swap. Everything else (node_modules, `exports` / `imports` maps, export conditions, package names) falls through to Node unchanged.
+If your editor's Go-to-Definition works on an import and `tsc` accepts it, Nub resolves it the same way at runtime — no `tsconfig-paths` package, no build step. Nub owns exactly the cases Node has no opinion on: `tsconfig.json` path aliases, extensionless imports in TypeScript files, the `.js`→`.ts` emit-convention swap, and subpaths into dependencies that declare no `exports`. Everything else — package names, `exports` / `imports` maps, export conditions — falls through to Node unchanged.
 
 ## `tsconfig.json`
 
@@ -45,7 +45,7 @@ import { Button } from "@/components/Button";
 
 Matching follows the `tsc` rules: an exact pattern wins outright, and among wildcard patterns the longest matching prefix wins. Node builtins always take precedence — `import "os"` is `node:os`, never `baseUrl/os.ts`.
 
-Path aliases work from any file, not just TypeScript ones — a `.js` file that imports a `paths` alias resolves it too. (The extensionless and `.js`→`.ts` behaviors below are the ones scoped to TypeScript-family parents.)
+Path aliases work from any file, not just TypeScript ones — a `.js` file that imports a `paths` alias resolves it too. (The relative extensionless and `.js`→`.ts` behaviors below are the ones scoped to TypeScript-family parents.)
 
 ### `baseUrl`
 
@@ -89,7 +89,31 @@ The probe order is extension-aware — it depends on the parent file's extension
 
 A directory import honors the directory's `package.json` `"main"` before falling back to probing `index.<ext>` in that same parent-aware order. Only `"main"` is consulted — `exports` is never read for a directory-path import, matching Node, which honors `exports` only for package-name resolution.
 
-This probing is scoped to TypeScript-family parent files (`.ts` / `.tsx` / `.mts` / `.cts`) with a relative specifier. A plain `.js` file stays strict about extensions, exactly like vanilla Node.
+This probing is scoped to TypeScript-family parent files (`.ts` / `.tsx` / `.mts` / `.cts`) with a relative specifier. A plain `.js` file stays strict about relative extensions, exactly like vanilla Node. Subpaths into a dependency are covered below and follow a different rule.
+
+## Package subpaths
+
+A subpath into a dependency gets the same probing, so an extensionless import finds the file on disk and a workspace package whose `main` points at TypeScript source resolves by subpath too.
+
+```ts
+// finds node_modules/prismjs/components/prism-python.js
+import "prismjs/components/prism-python";
+
+// a workspace package with "main": "./index.ts" and no exports map
+import { createPrompt } from "@repo/lib/prompt";   // resolves packages/lib/prompt.ts
+```
+
+The order here is fixed, and unlike relative imports it does not vary with the importing file's extension:
+
+```text
+.js  .json  .ts  .tsx
+```
+
+JavaScript sorts first because a published package's `.ts` is unshipped source that Nub does not transpile inside node_modules. A workspace package symlinked into node_modules ships no `.js` at all, so the same order still lands on its TypeScript.
+
+Because the rule is about the dependency's shape rather than the importer's, it is not scoped to TypeScript-family parents — a `.js` file in a `checkJs` project resolves these the same way.
+
+<Callout>A dependency that declares `exports` is never probed. Its map decides what is reachable, exactly as on Node, so a subpath it withholds stays an error.</Callout>
 
 ## .js → .ts resolution
 
@@ -106,10 +130,10 @@ The literal extension always wins first: a real on-disk `./handler.js` is used a
 
 Nub resolves only the TypeScript-aware cases Node has no opinion on. Everything else is Node's job, handled by Node's own resolver unchanged:
 
-- `node_modules` resolution
+- package names
 - `exports` / `imports` maps
 - export conditions
-- package names
+- every subpath into a dependency that declares `exports`
 
 ## Yarn Plug'n'Play
 


### PR DESCRIPTION
Extensionless subpaths (`pkg/sub`) got no probing, failing `ERR_MODULE_NOT_FOUND` where `tsc` and `require()` both work — `resolve_ts` probed relative specifiers only.

Probing now covers bare subpaths. A dependency declaring `exports` is never probed: key presence defers to Node, so a withheld subpath stays an error (`"exports": null` included). Order `.js .json .ts .tsx`, importer-independent. Result is realpathed, so a symlinked workspace package lands outside `node_modules` and transpiles.

Not gated on a TypeScript importer, matching tsx. Additive.

7 tests; docs updated. Parity corpus reports 3 divergences, identical on unmodified `main`.

Closes #562