### PR TITLE
fix(resolver): fail closed when publish time can't prove a version's age

### DIFF
--- a/vendor/aube/crates/aube-manifest/src/workspace/config.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace/config.rs
@@ -544,6 +544,14 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub minimum_release_age_strict: Option<bool>,
 
+    /// Whether the configured registry returns per-version `time:` data in
+    /// its abbreviated (corgi) packument, letting the resolver skip the
+    /// extra full-packument fetch when a publish-age cutoff is active.
+    /// pnpm reads this from `pnpm-workspace.yaml` only, so the yaml is the
+    /// source that matters for mirroring a pnpm incumbent.
+    #[serde(default)]
+    pub registry_supports_time_field: Option<bool>,
+
     /// OSV `MAL-*` advisory check policy for `aube add`. One of
     /// `"on"` (default, fail open on fetch error), `"required"` (fail
     /// closed on fetch error), or `"off"`.

--- a/vendor/aube/crates/aube-resolver/src/resolve/vulnerable.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/vulnerable.rs
@@ -41,18 +41,18 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
     // waves a version past the minimumReleaseAge gate here too (still
     // subject to `exempt_cutoff`, the time-based wall), otherwise the
     // re-pick could discard the exempt safe version and keep the
-    // vulnerable one.
+    // vulnerable one. The wall itself is the shared
+    // [`crate::semver_util::version_clears_cutoff`] — this path had its own
+    // copy of the comparison and so kept the missing-time fail-open after
+    // `pick_version` dropped it (#581); sharing the helper is what stops the
+    // two drifting again.
     let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
         let effective = if is_age_exempt(ver, parsed) {
             exempt_cutoff
         } else {
             cutoff
         };
-        let Some(c) = effective else { return true };
-        match packument.time.get(ver) {
-            Some(t) => t.as_str() <= c,
-            None => true,
-        }
+        crate::semver_util::version_clears_cutoff(packument, ver, effective)
     };
     let mut best: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> = None;
     for (ver_str, meta) in &packument.versions {

--- a/vendor/aube/crates/aube-resolver/src/resolve/vulnerable.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/vulnerable.rs
@@ -48,7 +48,7 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
         } else {
             cutoff
         };
-        crate::semver_util::version_clears_cutoff(packument, ver, effective)
+        crate::semver_util::version_clears_cutoff(packument, ver, effective, true)
     };
 
     // Two tiers, because this function is a PREFERENCE, not a gate: its only

--- a/vendor/aube/crates/aube-resolver/src/resolve/vulnerable.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/vulnerable.rs
@@ -41,11 +41,7 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
     // waves a version past the minimumReleaseAge gate here too (still
     // subject to `exempt_cutoff`, the time-based wall), otherwise the
     // re-pick could discard the exempt safe version and keep the
-    // vulnerable one. The wall itself is the shared
-    // [`crate::semver_util::version_clears_cutoff`] — this path had its own
-    // copy of the comparison and so kept the missing-time fail-open after
-    // `pick_version` dropped it (#581); sharing the helper is what stops the
-    // two drifting again.
+    // vulnerable one.
     let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
         let effective = if is_age_exempt(ver, parsed) {
             exempt_cutoff
@@ -54,18 +50,41 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
         };
         crate::semver_util::version_clears_cutoff(packument, ver, effective)
     };
+
+    // Two tiers, because this function is a PREFERENCE, not a gate: its only
+    // caller already holds a version it knows to be vulnerable, and whatever
+    // this returns is what gets installed. So the age wall ranks candidates
+    // here; it never vetoes one down to the vulnerable fallback.
+    //
+    // Tier 1 is a non-vulnerable version that also clears the wall. Tier 2 is
+    // a non-vulnerable version whose publish age is merely UNDETERMINABLE.
+    // Tier 2 still beats returning `fallback`: a confirmed advisory hit is a
+    // concrete harm, an unprovable publish date is a hypothetical one, and
+    // trading the former for the latter is not a trade worth making. This is
+    // the deliberate asymmetry with `pick_version`, which has no such
+    // second-worst option to fall to and so blocks outright (#581).
+    //
+    // A version with a KNOWN publish time that is too new belongs to NEITHER
+    // tier: that is the freshly-published-compromise case the gate exists to
+    // stop, and it stays excluded even against a vulnerable fallback.
     let mut best: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> = None;
+    let mut best_undated: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> = None;
     for (ver_str, meta) in &packument.versions {
         let Ok(version) = node_semver::Version::parse(ver_str) else {
             continue;
         };
-        if !version.satisfies(&range)
-            || !passes_cutoff(ver_str, Some(&version))
-            || is_vulnerable(package_name, ver_str, vulnerable_ranges)
-        {
+        if !version.satisfies(&range) || is_vulnerable(package_name, ver_str, vulnerable_ranges) {
             continue;
         }
-        let replace = best.as_ref().is_none_or(|(cur, _)| {
+        let tier = if passes_cutoff(ver_str, Some(&version)) {
+            &mut best
+        } else if packument.time.contains_key(ver_str) {
+            // Dated and too new — excluded outright.
+            continue;
+        } else {
+            &mut best_undated
+        };
+        let replace = tier.as_ref().is_none_or(|(cur, _)| {
             if pick_lowest {
                 version < *cur
             } else {
@@ -73,8 +92,74 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
             }
         });
         if replace {
-            best = Some((version, meta));
+            *tier = Some((version, meta));
         }
     }
-    best.map(|(_, meta)| meta).unwrap_or(fallback)
+    best.or(best_undated)
+        .map(|(_, meta)| meta)
+        .unwrap_or(fallback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::make_packument;
+
+    const CUTOFF: &str = "2020-01-01T00:00:00.000Z";
+
+    fn ranges(name: &str, range: &str) -> BTreeMap<String, Vec<String>> {
+        BTreeMap::from([(name.to_string(), vec![range.to_string()])])
+    }
+
+    /// The re-pick ranks by publish age but never vetoes down to the
+    /// vulnerable fallback: an undated non-vulnerable version is a better
+    /// outcome than a confirmed advisory hit. A DATED-but-too-new version is
+    /// still excluded outright — that is the fresh-compromise case.
+    #[test]
+    fn undated_safe_version_beats_a_vulnerable_fallback_but_a_fresh_one_does_not() {
+        let vuln = ranges("foo", "<1.1.0");
+
+        // 1.1.0 has no time entry; 1.0.0 is vulnerable. Prefer the undated
+        // safe version rather than keeping the known-vulnerable one.
+        let mut undated = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+        undated
+            .time
+            .insert("1.0.0".to_string(), "2019-01-01T00:00:00.000Z".to_string());
+        let fallback = undated.versions.get("1.0.0").unwrap();
+        let picked = prefer_non_vulnerable_pick(
+            "foo",
+            &undated,
+            "^1.0.0",
+            fallback,
+            false,
+            Some(CUTOFF),
+            None,
+            &vuln,
+            |_, _| false,
+        );
+        assert_eq!(picked.version, "1.1.0");
+
+        // Same shape, but 1.1.0 is dated and too new: its age is KNOWN to
+        // violate the floor, so it stays excluded and the fallback stands.
+        let mut fresh = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+        fresh
+            .time
+            .insert("1.0.0".to_string(), "2019-01-01T00:00:00.000Z".to_string());
+        fresh
+            .time
+            .insert("1.1.0".to_string(), "2026-01-01T00:00:00.000Z".to_string());
+        let fallback = fresh.versions.get("1.0.0").unwrap();
+        let picked = prefer_non_vulnerable_pick(
+            "foo",
+            &fresh,
+            "^1.0.0",
+            fallback,
+            false,
+            Some(CUTOFF),
+            None,
+            &vuln,
+            |_, _| false,
+        );
+        assert_eq!(picked.version, "1.0.0");
+    }
 }

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -81,27 +81,33 @@ pub fn pick_version_for_add<'a>(
 /// Does `ver` clear `effective`, the publish-age cutoff that applies to it?
 /// `None` means no wall is in effect, so everything clears.
 ///
-/// A missing publish time is NOT a silent bypass (#581): the gate is only as
-/// strong as the metadata feeding it, so an undeterminable age FAILS CLOSED.
-/// Three cases, matching pnpm's `pickPackageFromMeta` +
-/// `filterPkgMetadataByPublishDate`:
+/// A known publish time is always compared. When one is missing, the packument's
+/// `modified` timestamp is tried first as an UPPER BOUND on every version's
+/// publish time: `modified <= cutoff` proves the whole document predates the
+/// wall, so every version in it is mature. That is what keeps abbreviated
+/// (corgi) metadata usable without a full-packument fetch for the dormant
+/// majority of a dependency tree.
 ///
-/// - **time known** — compare it.
-/// - **times present, this one absent** — block. A hole in an otherwise
-///   populated map is anomalous, never a reason to admit a version.
-/// - **no per-version times at all** — fall back to the packument's `modified`,
-///   an UPPER BOUND on every version's publish time: `modified <= cutoff`
-///   proves the whole document predates the wall, so every version in it is
-///   mature. This is what keeps abbreviated (corgi) metadata usable without a
-///   full-packument fetch for the dormant majority of a dependency tree. When
-///   `modified` is absent or itself too new, nothing is provable — block.
+/// When even that cannot settle it, the age is UNDETERMINABLE and `strict`
+/// decides:
 ///
-/// Shared with the vulnerability re-pick (`resolve::vulnerable`), which applies
-/// the same wall and must not drift from it.
+/// - **`strict`** — block. A gate is only as strong as the metadata feeding it,
+///   and an unprovable age must not be a silent bypass (#581). nub pins
+///   `minimumReleaseAgeStrict` on, so this is nub's posture.
+/// - **lenient** — stay eligible, preserving upstream aube's default: lenient
+///   mode already means "fall back rather than fail", and gating it here would
+///   change standalone aube's out-of-box behavior rather than the embedder's.
+///
+/// A hole in an otherwise-populated `time` map is treated as undeterminable
+/// too — anomalous, and not evidence of maturity.
+///
+/// Shared with the vulnerability re-pick (`resolve::vulnerable`), which passes
+/// `strict` to mean "provably mature" for its first-choice tier.
 pub(crate) fn version_clears_cutoff(
     packument: &Packument,
     ver: &str,
     effective: Option<&str>,
+    strict: bool,
 ) -> bool {
     let Some(c) = effective else { return true };
     match packument.time.get(ver) {
@@ -115,7 +121,9 @@ pub(crate) fn version_clears_cutoff(
                 .time
                 .keys()
                 .any(|k| k != "created" && k != "modified");
-            !has_version_times && packument.modified.as_deref().is_some_and(|m| m <= c)
+            let modified_proves_maturity =
+                !has_version_times && packument.modified.as_deref().is_some_and(|m| m <= c);
+            modified_proves_maturity || !strict
         }
     }
 }
@@ -126,12 +134,11 @@ pub(crate) fn version_clears_cutoff(
 /// `resolution-mode=time-based` for direct deps. `cutoff` filters out
 /// versions whose registry publish time is later than the cutoff
 /// (lexicographic compare on ISO-8601 UTC strings, which sort
-/// correctly). When the packument carries no `time` entry for a version
-/// the cutoff FAILS CLOSED rather than waving the version through — an
-/// undeterminable publish age must not silently disable the gate
-/// (#581) — except where the packument's `modified` timestamp is itself
-/// at or before the cutoff, which proves every version in the document
-/// is old enough. See `passes_effective_cutoff` for the three cases.
+/// correctly). When the packument carries no `time` entry for a version,
+/// the packument's `modified` timestamp can still prove the whole
+/// document mature; failing that the age is undeterminable, and `strict`
+/// decides whether it blocks (#581) or stays eligible. See
+/// [`version_clears_cutoff`].
 ///
 /// `strict` controls fallback when the cutoff filters out every
 /// satisfying version: with `strict=true` we return `None` and the
@@ -208,8 +215,9 @@ pub(crate) fn pick_version<'a>(
         }
     };
 
-    let passes_effective_cutoff =
-        |ver: &str, effective: Option<&str>| version_clears_cutoff(packument, ver, effective);
+    let passes_effective_cutoff = |ver: &str, effective: Option<&str>| {
+        version_clears_cutoff(packument, ver, effective, strict)
+    };
 
     // A version's effective cutoff: exempt versions answer to the
     // time-based wall (`exempt_cutoff`) only; everyone else answers to

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -78,6 +78,48 @@ pub fn pick_version_for_add<'a>(
     )
 }
 
+/// Does `ver` clear `effective`, the publish-age cutoff that applies to it?
+/// `None` means no wall is in effect, so everything clears.
+///
+/// A missing publish time is NOT a silent bypass (#581): the gate is only as
+/// strong as the metadata feeding it, so an undeterminable age FAILS CLOSED.
+/// Three cases, matching pnpm's `pickPackageFromMeta` +
+/// `filterPkgMetadataByPublishDate`:
+///
+/// - **time known** — compare it.
+/// - **times present, this one absent** — block. A hole in an otherwise
+///   populated map is anomalous, never a reason to admit a version.
+/// - **no per-version times at all** — fall back to the packument's `modified`,
+///   an UPPER BOUND on every version's publish time: `modified <= cutoff`
+///   proves the whole document predates the wall, so every version in it is
+///   mature. This is what keeps abbreviated (corgi) metadata usable without a
+///   full-packument fetch for the dormant majority of a dependency tree. When
+///   `modified` is absent or itself too new, nothing is provable — block.
+///
+/// Shared with the vulnerability re-pick (`resolve::vulnerable`), which applies
+/// the same wall and must not drift from it.
+pub(crate) fn version_clears_cutoff(
+    packument: &Packument,
+    ver: &str,
+    effective: Option<&str>,
+) -> bool {
+    let Some(c) = effective else { return true };
+    match packument.time.get(ver) {
+        Some(t) => t.as_str() <= c,
+        // npm's FULL `time` map always carries the `created`/`modified`
+        // bookkeeping keys beside the version keys, so a raw `is_empty()` would
+        // misread a mirror serving only those as "populated, with holes" and
+        // gate every version. Key on any non-bookkeeping entry instead.
+        None => {
+            let has_version_times = packument
+                .time
+                .keys()
+                .any(|k| k != "created" && k != "modified");
+            !has_version_times && packument.modified.as_deref().is_some_and(|m| m <= c)
+        }
+    }
+}
+
 /// Pick the best version from a packument that satisfies the given range.
 ///
 /// `pick_lowest` flips the scan order — used by
@@ -166,41 +208,8 @@ pub(crate) fn pick_version<'a>(
         }
     };
 
-    // Whether the packument carries per-version publish times at all. npm's
-    // FULL `time` map always includes the `created`/`modified` bookkeeping keys
-    // alongside the version keys, so a raw `is_empty()` would misread a mirror
-    // serving only those as "has times, with holes" and gate every version.
-    // Keyed on the presence of any non-bookkeeping key instead.
-    let has_version_times = packument
-        .time
-        .keys()
-        .any(|k| k != "created" && k != "modified");
-
-    // Does `ver` clear `effective` (the cutoff that applies to it)?
-    // `None` => no wall, keep the version. A missing publish time is NOT a
-    // silent bypass (#581): the gate's guarantee is only as strong as the
-    // metadata feeding it, so an undeterminable age FAILS CLOSED. Three cases,
-    // matching pnpm's `pickPackageFromMeta` + `filterPkgMetadataByPublishDate`:
-    //   - time known                -> compare it
-    //   - times present, this one    -> block. An anomalous hole in an otherwise
-    //     absent                        populated map, never a reason to admit.
-    //   - no per-version times at all-> fall back to the packument's `modified`,
-    //                                   an UPPER BOUND on every version's publish
-    //                                   time: `modified <= cutoff` proves the whole
-    //                                   document predates the wall, so every version
-    //                                   is mature. This is what keeps abbreviated
-    //                                   (corgi) metadata usable without a full fetch
-    //                                   for the dormant majority of a tree. When
-    //                                   `modified` is absent or too new, nothing is
-    //                                   provable and the version is blocked.
-    let passes_effective_cutoff = |ver: &str, effective: Option<&str>| -> bool {
-        let Some(c) = effective else { return true };
-        match packument.time.get(ver) {
-            Some(t) => t.as_str() <= c,
-            None if has_version_times => false,
-            None => packument.modified.as_deref().is_some_and(|m| m <= c),
-        }
-    };
+    let passes_effective_cutoff =
+        |ver: &str, effective: Option<&str>| version_clears_cutoff(packument, ver, effective);
 
     // A version's effective cutoff: exempt versions answer to the
     // time-based wall (`exempt_cutoff`) only; everyone else answers to

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -84,9 +84,12 @@ pub fn pick_version_for_add<'a>(
 /// `resolution-mode=time-based` for direct deps. `cutoff` filters out
 /// versions whose registry publish time is later than the cutoff
 /// (lexicographic compare on ISO-8601 UTC strings, which sort
-/// correctly). When the packument has no `time` entry for a version
-/// (e.g. abbreviated corgi payload in `Highest` mode), the cutoff is
-/// ignored and the version stays eligible.
+/// correctly). When the packument carries no `time` entry for a version
+/// the cutoff FAILS CLOSED rather than waving the version through — an
+/// undeterminable publish age must not silently disable the gate
+/// (#581) — except where the packument's `modified` timestamp is itself
+/// at or before the cutoff, which proves every version in the document
+/// is old enough. See `passes_effective_cutoff` for the three cases.
 ///
 /// `strict` controls fallback when the cutoff filters out every
 /// satisfying version: with `strict=true` we return `None` and the
@@ -163,15 +166,39 @@ pub(crate) fn pick_version<'a>(
         }
     };
 
+    // Whether the packument carries per-version publish times at all. npm's
+    // FULL `time` map always includes the `created`/`modified` bookkeeping keys
+    // alongside the version keys, so a raw `is_empty()` would misread a mirror
+    // serving only those as "has times, with holes" and gate every version.
+    // Keyed on the presence of any non-bookkeeping key instead.
+    let has_version_times = packument
+        .time
+        .keys()
+        .any(|k| k != "created" && k != "modified");
+
     // Does `ver` clear `effective` (the cutoff that applies to it)?
-    // `None` => no wall, keep the version. Missing time => keep it: we'd
-    // rather risk a slightly newer transitive than fail to resolve the
-    // range entirely.
+    // `None` => no wall, keep the version. A missing publish time is NOT a
+    // silent bypass (#581): the gate's guarantee is only as strong as the
+    // metadata feeding it, so an undeterminable age FAILS CLOSED. Three cases,
+    // matching pnpm's `pickPackageFromMeta` + `filterPkgMetadataByPublishDate`:
+    //   - time known                -> compare it
+    //   - times present, this one    -> block. An anomalous hole in an otherwise
+    //     absent                        populated map, never a reason to admit.
+    //   - no per-version times at all-> fall back to the packument's `modified`,
+    //                                   an UPPER BOUND on every version's publish
+    //                                   time: `modified <= cutoff` proves the whole
+    //                                   document predates the wall, so every version
+    //                                   is mature. This is what keeps abbreviated
+    //                                   (corgi) metadata usable without a full fetch
+    //                                   for the dormant majority of a tree. When
+    //                                   `modified` is absent or too new, nothing is
+    //                                   provable and the version is blocked.
     let passes_effective_cutoff = |ver: &str, effective: Option<&str>| -> bool {
         let Some(c) = effective else { return true };
         match packument.time.get(ver) {
             Some(t) => t.as_str() <= c,
-            None => true,
+            None if has_version_times => false,
+            None => packument.modified.as_deref().is_some_and(|m| m <= c),
         }
     };
 

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -2301,10 +2301,10 @@ fn test_format_iso8601_known_epoch() {
     assert_eq!(format_iso8601_utc(0), "1970-01-01T00:00:00.000Z");
 }
 
-/// The three missing-publish-time cases (#581). Together these pin the whole
-/// contract: an undeterminable age never silently clears the gate, but a
-/// packument whose `modified` predates the cutoff still resolves offline from
-/// abbreviated metadata — the property that keeps corgi registries usable.
+/// Missing publish time under STRICT mode (#581): an undeterminable age never
+/// silently clears the gate, but a packument whose `modified` predates the
+/// cutoff still resolves offline from abbreviated metadata — the property that
+/// keeps corgi registries usable. Lenient mode is pinned separately, below.
 #[test]
 fn pick_version_missing_time_fails_closed_unless_modified_proves_maturity() {
     const CUTOFF: &str = "2020-01-01T00:00:00.000Z";
@@ -2361,6 +2361,26 @@ fn pick_version_missing_time_fails_closed_unless_modified_proves_maturity() {
         "1.0.0",
         "an undated version in a dated map is excluded, not admitted"
     );
+}
+
+/// Lenient mode keeps upstream aube's default: an undeterminable publish age
+/// stays eligible rather than blocking. Only the embedder's strict posture
+/// (which nub pins on) turns it into a wall, so this change is default-
+/// preserving for standalone aube.
+#[test]
+fn pick_version_lenient_mode_keeps_undated_versions_eligible() {
+    let bare = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    let picked = pick_version(
+        &bare,
+        "^1.0.0",
+        None,
+        false,
+        Some("2020-01-01T00:00:00.000Z"),
+        None,
+        false,
+        |_, _| false,
+    );
+    assert_eq!(picked.unwrap().version, "1.1.0");
 }
 
 /// npm's full `time` map always carries `created`/`modified` bookkeeping keys

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -625,7 +625,7 @@ fn test_dep_path_for() {
     assert_eq!(dep_path_for("@babel/core", "7.24.0"), "@babel/core@7.24.0");
 }
 
-fn make_version(name: &str, version: &str) -> VersionMetadata {
+pub(crate) fn make_version(name: &str, version: &str) -> VersionMetadata {
     VersionMetadata {
         name: name.to_string(),
         version: version.to_string(),
@@ -656,7 +656,7 @@ fn make_version(name: &str, version: &str) -> VersionMetadata {
     }
 }
 
-fn make_packument(name: &str, versions: &[&str], latest: &str) -> Packument {
+pub(crate) fn make_packument(name: &str, versions: &[&str], latest: &str) -> Packument {
     let mut ver_map = BTreeMap::new();
     for v in versions {
         ver_map.insert(v.to_string(), make_version(name, v));

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -2301,25 +2301,91 @@ fn test_format_iso8601_known_epoch() {
     assert_eq!(format_iso8601_utc(0), "1970-01-01T00:00:00.000Z");
 }
 
+/// The three missing-publish-time cases (#581). Together these pin the whole
+/// contract: an undeterminable age never silently clears the gate, but a
+/// packument whose `modified` predates the cutoff still resolves offline from
+/// abbreviated metadata — the property that keeps corgi registries usable.
 #[test]
-fn test_pick_version_cutoff_allows_missing_time_entries() {
-    let packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
-    // Packument has no `time` entries at all — cutoff must not
-    // remove every candidate, or the resolver can never make
-    // progress on abbreviated-packument registries.
-    let cutoff = "2000-01-01T00:00:00.000Z";
-    let result = pick_version(
-        &packument,
-        "^1.0.0",
-        None,
-        false,
-        Some(cutoff),
-        None,
-        false,
-        |_, _| false,
-    )
-    .unwrap();
-    assert_eq!(result.version, "1.1.0");
+fn pick_version_missing_time_fails_closed_unless_modified_proves_maturity() {
+    const CUTOFF: &str = "2020-01-01T00:00:00.000Z";
+    fn pick(p: &Packument) -> PickResult<'_> {
+        pick_version(
+            p,
+            "^1.0.0",
+            None,
+            false,
+            Some(CUTOFF),
+            None,
+            true,
+            |_, _| false,
+        )
+    }
+
+    // No per-version times and no `modified`: nothing proves either version is
+    // old enough, so both are gated rather than waved through.
+    let bare = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    assert!(
+        matches!(pick(&bare), PickResult::AgeGated),
+        "a packument with no time data at all must not clear the cutoff"
+    );
+
+    // `modified` is an upper bound on every version's publish time, so a
+    // document last touched before the cutoff has no immature versions in it.
+    let mut dormant = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    dormant.modified = Some("2019-06-01T00:00:00.000Z".to_string());
+    assert_eq!(
+        pick(&dormant).unwrap().version,
+        "1.1.0",
+        "modified <= cutoff proves the whole document is mature"
+    );
+
+    // Same shape, but the document was touched after the cutoff — some version
+    // in it is too new and we cannot tell which, so nothing is admitted.
+    let mut churning = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    churning.modified = Some("2026-06-01T00:00:00.000Z".to_string());
+    assert!(
+        matches!(pick(&churning), PickResult::AgeGated),
+        "modified > cutoff leaves each version's age undeterminable"
+    );
+
+    // A hole in an otherwise-populated map is anomalous, not a corgi payload:
+    // 1.0.0 is dated and mature, 1.1.0 is undated and must be excluded even
+    // though `modified` would have vouched for the document as a whole.
+    let mut holed = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    holed.modified = Some("2019-06-01T00:00:00.000Z".to_string());
+    holed
+        .time
+        .insert("1.0.0".to_string(), "2019-01-01T00:00:00.000Z".to_string());
+    assert_eq!(
+        pick(&holed).unwrap().version,
+        "1.0.0",
+        "an undated version in a dated map is excluded, not admitted"
+    );
+}
+
+/// npm's full `time` map always carries `created`/`modified` bookkeeping keys
+/// beside the version keys. A mirror that serves ONLY those must still read as
+/// "no per-version times" and take the `modified` path, not as a fully-holed
+/// map that gates everything.
+#[test]
+fn pick_version_treats_bookkeeping_only_time_map_as_timeless() {
+    let cutoff = "2020-01-01T00:00:00.000Z";
+    let mut p = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    p.modified = Some("2019-06-01T00:00:00.000Z".to_string());
+    p.time.insert(
+        "created".to_string(),
+        "2018-01-01T00:00:00.000Z".to_string(),
+    );
+    p.time.insert(
+        "modified".to_string(),
+        "2019-06-01T00:00:00.000Z".to_string(),
+    );
+    assert_eq!(
+        pick_version(&p, "^1.0.0", None, false, Some(cutoff), None, true, |_, _| false)
+            .unwrap()
+            .version,
+        "1.1.0"
+    );
 }
 
 #[test]

--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -2814,10 +2814,19 @@ JSR, and most in-house mirrors derived from those — and leave at the
 default for npmjs.org. The flag has no effect when neither time-based
 resolution nor `minimumReleaseAge` is active, since nothing asks for
 `time` on the hot path then.
+
+Enabling it against a registry that does NOT carry `time` in its
+abbreviated response does not disable `minimumReleaseAge`: with no
+per-version times the gate falls back to the packument's `modified`
+timestamp, admitting only documents that provably predate the cutoff
+and blocking the rest. Getting this flag wrong costs over-blocking,
+never a silent bypass.
 """
 sources.cli = []
 sources.env = ["npm_config_registry_supports_time_field", "NPM_CONFIG_REGISTRY_SUPPORTS_TIME_FIELD", "AUBE_REGISTRY_SUPPORTS_TIME_FIELD"]
 sources.npmrc = ["registry-supports-time-field", "registrySupportsTimeField"]
+sources.workspaceYaml = ["registrySupportsTimeField"]
+precedence = ["workspaceYaml", "npmrc"]
 examples = [
     "echo 'registry-supports-time-field=true' >> .npmrc",
 ]

--- a/vendor/aube/crates/aube-settings/src/values.rs
+++ b/vendor/aube/crates/aube-settings/src/values.rs
@@ -1636,6 +1636,30 @@ mod tests {
         );
     }
 
+    /// `pnpm-workspace.yaml` is the file pnpm actually reads
+    /// `registrySupportsTimeField` from — never `.npmrc` — so the yaml source
+    /// is what mirroring a pnpm incumbent depends on. Asserts the value
+    /// RESOLVES, not merely that the metadata names a real struct field: the
+    /// `meta.rs` self-test covers the latter and would pass on a key nothing
+    /// ever reads.
+    #[test]
+    fn registry_supports_time_field_resolves_from_workspace_yaml() {
+        let ws = raw_yaml("registrySupportsTimeField: true\n");
+        let ctx = ResolveCtx {
+            managed_aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &[],
+            user_npmrc: &[],
+            workspace_yaml: &ws,
+            global_config_yaml: empty_yaml_map(),
+            env: &[],
+            cli: &[],
+            embedder_defaults: &[],
+        };
+        assert!(resolved::registry_supports_time_field(&ctx));
+    }
+
     #[test]
     fn global_config_yaml_wins_over_project_npmrc_by_default() {
         // pnpm v11 ranks the global `<configDir>/config.yaml` above the

--- a/vendor/aube/crates/aube/src/commands/add/manifest.rs
+++ b/vendor/aube/crates/aube/src/commands/add/manifest.rs
@@ -323,9 +323,18 @@ pub(super) async fn update_manifest_for_add(
             // lives in `packuments-full-v1` while an ungated one lives
             // in the corgi cache — an offline retry must not fail on a
             // package that's on disk in the other format. The full
-            // payload is a superset of corgi, and corgi's missing
-            // `time` map keeps its versions cutoff-eligible in
-            // `pick_version`, so either format picks correctly.
+            // payload is a superset of corgi, so that direction always
+            // picks correctly.
+            //
+            // The corgi direction is WEAKER than it once was. A missing
+            // `time` map no longer keeps versions cutoff-eligible —
+            // #581 made an undeterminable publish age fail closed — so an
+            // offline add falling back to a corgi-cached packument
+            // resolves only what the document's `modified` timestamp
+            // proves mature, and otherwise reports the age gate instead
+            // of silently installing. Intended: an offline fallback must
+            // not be a way around the gate. But it does mean this
+            // fallback can now fail where it previously succeeded.
             let packument = match primary {
                 Ok(packument) => Ok(packument),
                 Err(primary_err) if offline => {


### PR DESCRIPTION
`minimumReleaseAge` treated a version with no `time:` entry as eligible, so a packument without publish times silently disabled the gate, even under `minimumReleaseAgeStrict=true`.

Repro: with a 10-year cutoff and strict on, adding `registry-supports-time-field=true` to `.npmrc` flipped `nub add strip-ansi-cjs` from `ERR_NUB_NO_MATURE_MATCHING_VERSION` to a clean install.

A missing time is now resolved against the packument's `modified` — an upper bound proving every version in the document is mature, which keeps abbreviated metadata usable without a full fetch. When even that can't settle it, `strict` decides: strict blocks, lenient stays eligible as before, so standalone aube's default is preserved. The `modified` bound is pnpm 11's mechanism (`pickPackageFromMeta`); the terminal default differs, since pnpm warns-and-skips where nub blocks.

The vulnerability re-pick ranks in two tiers rather than vetoing: an undated safe version still beats returning a known-vulnerable fallback, but a dated-and-too-new one stays excluded.

Also gives `registrySupportsTimeField` a `workspaceYaml` source and field — pnpm reads it only from `pnpm-workspace.yaml`.

BEHAVIOR CHANGE: under strict, a registry serving no `time` map blocks packages whose `modified` is newer than the cutoff. Escapes: `minimumReleaseAgeExclude`, `minimumReleaseAge=0`.

Overlaps #587, which carries the same `strict` gate without the `modified` bound.

Closes #581
