### PR TITLE
fix(linker): converge directory-link creation on a re-link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,13 +780,21 @@ jobs:
       # linker included. That gap is why the Windows-only `read_link` /
       # `junction::create` divergences behind #576 and #566 went unnoticed: the
       # semantics they depend on differ per-OS and nothing exercised them off Unix.
-      # Run the linker's platform-semantics suite from inside the aube workspace on
-      # every OS leg. Scoped to `-p aube-linker --lib` deliberately: a light
-      # dependency subtree, no network or registry fixture, and it covers the
-      # link-creation and entry-classification primitives every install rides on.
+      # Run the engine's platform-semantics suites from inside the aube workspace.
+      # Both crates are needed: the link-creation and entry-classification
+      # primitives live in `aube-linker`, but `detect_aube_dir_gvs_mode`'s tests
+      # live in `aube` — and those are the ones that were `#[cfg(all(test, unix))]`.
+      # `--lib` keeps it to unit tests: no network, no registry fixture.
+      #
+      # Linux is excluded on purpose. These are Node-independent Rust unit tests,
+      # so the five Linux Node-tier legs would run them five identical times, and
+      # aube-parity.yml already runs the whole aube workspace on ubuntu. Windows
+      # (and macOS on the full matrix) is where the divergent path semantics that
+      # motivated these tests actually differ.
       - name: Vendored engine — linker platform semantics
+        if: runner.os != 'Linux'
         working-directory: vendor/aube
-        run: cargo test -p aube-linker --lib
+        run: cargo test -p aube-linker -p aube --lib
       # Brand-boundary sweep for the embedded PM engine: a real `nub install`
       # in a sandboxed fixture (HOME/XDG_* inside a temp dir) must never leak
       # the engine's upstream identity — no ERR_AUBE_/WARN_AUBE_/aube.jdx.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -771,6 +771,18 @@ jobs:
         shell: bash
         run: echo "__NUB_BUSYBOX_EXE=$GITHUB_WORKSPACE/vendor/busybox-w32/busybox64.exe" >> "$GITHUB_ENV"
       - run: cargo test
+      # `vendor/aube` is EXCLUDED from the root workspace (see Cargo.toml), so the
+      # `cargo test` above never reaches the vendored engine's own unit tests — the
+      # linker included. That gap is why the Windows-only `read_link` /
+      # `junction::create` divergences behind #576 and #566 went unnoticed: the
+      # semantics they depend on differ per-OS and nothing exercised them off Unix.
+      # Run the linker's platform-semantics suite from inside the aube workspace on
+      # every OS leg. Scoped to `-p aube-linker --lib` deliberately: a light
+      # dependency subtree, no network or registry fixture, and it covers the
+      # link-creation and entry-classification primitives every install rides on.
+      - name: Vendored engine — linker platform semantics
+        working-directory: vendor/aube
+        run: cargo test -p aube-linker --lib
       # Brand-boundary sweep for the embedded PM engine: a real `nub install`
       # in a sandboxed fixture (HOME/XDG_* inside a temp dir) must never leak
       # the engine's upstream identity — no ERR_AUBE_/WARN_AUBE_/aube.jdx.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,9 +666,13 @@ jobs:
         with:
           shared-key: ci-test-${{ runner.os }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          # vendor/aube is its own workspace with its own target dir, so without
+          # an entry here the linker-semantics step below pays a cold dep build
+          # on every leg.
           workspaces: |
             .
             crates/nub-native
+            vendor/aube
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5
         with:
           version: 10

--- a/vendor/aube/crates/aube-linker/src/lib.rs
+++ b/vendor/aube/crates/aube-linker/src/lib.rs
@@ -38,7 +38,9 @@ pub(crate) use materialize::{
 pub use patches::Patches;
 pub(crate) use patches::apply_multi_file_patch;
 pub use pool::default_linker_parallelism;
-pub use sweep::{is_physical_importer, mkdirp, remove_dir_all_with_retry, sweep_stale_tmp_dirs};
+pub use sweep::{
+    is_physical_importer, is_real_dir, mkdirp, remove_dir_all_with_retry, sweep_stale_tmp_dirs,
+};
 pub(crate) use sweep::{sweep_stale_top_level_entries, try_remove_entry};
 pub use sys::{
     BinShimOptions, create_bin_shim, create_dir_link, is_native_executable,

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -341,9 +341,10 @@ impl Linker {
                             // and `is_dir()` is true, so the file-type bit would
                             // misread a stale junction as a real dir and skip the
                             // conversion. `read_link` succeeds on both Unix symlinks
-                            // and junction reparse points and returns `InvalidInput`
-                            // on a real directory — the same signal `classify_entry_state`
-                            // and `detect_aube_dir_gvs_mode` rely on.
+                            // and junction reparse points and fails on a real
+                            // directory — but with DIFFERENT errors per platform, so
+                            // the test goes through `crate::is_real_dir` rather than a
+                            // bare `InvalidInput` match (see `sweep::is_not_a_link_error`).
                             if self.disk_materialize_matches(&pkg.name) {
                                 // Orphan-safety invariant: disk-materialize gives X
                                 // a real project-local dir so X's OWN undeclared
@@ -374,13 +375,7 @@ impl Linker {
                                     .join(subdir)
                                     .join("node_modules")
                                     .join(&pkg.name);
-                                // `InvalidInput` from `read_link` == a real dir (not
-                                // a symlink/junction). See the classification note
-                                // above for why this beats `is_symlink()`.
-                                let local_is_real_dir = matches!(
-                                    std::fs::read_link(&local_aube_entry),
-                                    Err(e) if e.kind() == std::io::ErrorKind::InvalidInput
-                                );
+                                let local_is_real_dir = crate::is_real_dir(&local_aube_entry);
                                 if store_pkg_dir.exists() && local_is_real_dir {
                                     // Both placements already correct.
                                     local_stats.packages_cached += 1;
@@ -505,17 +500,18 @@ impl Linker {
                                 nested_link_targets.as_ref(),
                             )?;
 
-                            // Only pay the `remove_dir`/`remove_file` syscalls
-                            // when we actually have something to remove.
-                            // On Windows, `.aube/<dep_path>` is an NTFS
-                            // junction (created via `sys::create_dir_link`);
-                            // `remove_file` can't unlink those, so try
-                            // `remove_dir` first and fall back to
-                            // `remove_file` for the unix case (where
-                            // `symlink` produces a file-style link).
+                            // Only pay the removal syscalls when we actually
+                            // have something to remove. `Stale` covers three
+                            // shapes — a Unix symlink, a Windows junction, and
+                            // a populated real directory left by a per-project
+                            // install — and `try_remove_entry` is the only
+                            // helper that evicts all three (a bare `remove_dir`
+                            // returns `ERROR_DIR_NOT_EMPTY` on the last one and
+                            // the `remove_file` fallback then returns
+                            // `ERROR_ACCESS_DENIED`, leaving the entry in place
+                            // for `create_dir_link` to collide with — #566).
                             if matches!(state, EntryState::Stale) {
-                                let _ = std::fs::remove_dir(&local_aube_entry)
-                                    .or_else(|_| std::fs::remove_file(&local_aube_entry));
+                                try_remove_entry(&local_aube_entry);
                             }
                             // Parent dirs were pre-created above the
                             // par_iter; no per-package `mkdirp` here.
@@ -1093,9 +1089,11 @@ impl Linker {
                                 nested_link_targets.as_ref(),
                             )?;
 
+                            // Evicts all three `Stale` shapes; see the matching
+                            // block in `link_isolated` for why `remove_dir`
+                            // alone cannot (#566).
                             if matches!(state, EntryState::Stale) {
-                                let _ = std::fs::remove_dir(&local_aube_entry)
-                                    .or_else(|_| std::fs::remove_file(&local_aube_entry));
+                                try_remove_entry(&local_aube_entry);
                             }
                             // Parent dirs were pre-created above the
                             // par_iter; no per-package `mkdirp` here.
@@ -1870,7 +1868,17 @@ fn reconcile_top_level_link(link_path: &Path, expected_target: &Path) -> Result<
         if link_path.symlink_metadata().is_err() {
             return Ok(false);
         }
-        match std::fs::remove_dir(link_path).or_else(|_| std::fs::remove_file(link_path)) {
+        // Widening order: `remove_dir` unlinks a junction or an empty dir
+        // without a recursive walk, `remove_dir_all` handles a POPULATED real
+        // directory (an incumbent npm/yarn tree being taken over — `remove_dir`
+        // returns `ERROR_DIR_NOT_EMPTY` there and the old `remove_file`
+        // fallback then returned `ERROR_ACCESS_DENIED`, aborting the install
+        // with a bare `os error 5` on the first hoisted dep), and `remove_file`
+        // covers a plain file. Matches what the Unix branch below already does.
+        match std::fs::remove_dir(link_path)
+            .or_else(|_| std::fs::remove_dir_all(link_path))
+            .or_else(|_| std::fs::remove_file(link_path))
+        {
             Ok(()) => Ok(false),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
             Err(e) => Err(Error::Io(link_path.to_path_buf(), e)),

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -425,6 +425,11 @@ impl Linker {
                                 // Drop a stale shared-store symlink/junction left by
                                 // a prior GVS install or the fetch prewarm before
                                 // materializing the real project-local dir.
+                                // The narrow `remove_dir`/`remove_file` pair is
+                                // correct HERE, unlike the `Stale` sites below:
+                                // the `read_link` guard proves the entry is a
+                                // link, so there is no populated directory for
+                                // it to fail to evict.
                                 if std::fs::read_link(&local_aube_entry).is_ok() {
                                     let _ = std::fs::remove_dir(&local_aube_entry)
                                         .or_else(|_| std::fs::remove_file(&local_aube_entry));
@@ -1869,14 +1874,23 @@ fn reconcile_top_level_link(link_path: &Path, expected_target: &Path) -> Result<
             return Ok(false);
         }
         // Widening order: `remove_dir` unlinks a junction or an empty dir
-        // without a recursive walk, `remove_dir_all` handles a POPULATED real
-        // directory (an incumbent npm/yarn tree being taken over — `remove_dir`
-        // returns `ERROR_DIR_NOT_EMPTY` there and the old `remove_file`
-        // fallback then returned `ERROR_ACCESS_DENIED`, aborting the install
-        // with a bare `os error 5` on the first hoisted dep), and `remove_file`
-        // covers a plain file. Matches what the Unix branch below already does.
+        // without a recursive walk; a POPULATED REAL directory (an incumbent
+        // npm/yarn tree being taken over) needs the recursive delete, because
+        // `remove_dir` returns `ERROR_DIR_NOT_EMPTY` there and the old
+        // `remove_file` fallback then returned `ERROR_ACCESS_DENIED`, aborting
+        // the install with a bare `os error 5` on the first hoisted dep; a
+        // plain file falls through to `remove_file`. The recursive delete is
+        // gated on `is_real_dir` rather than tried unconditionally so it can
+        // only ever reach the one shape it was added for — the Unix branch
+        // below is likewise recursive only in its not-a-link arm.
         match std::fs::remove_dir(link_path)
-            .or_else(|_| std::fs::remove_dir_all(link_path))
+            .or_else(|e| {
+                if crate::is_real_dir(link_path) {
+                    std::fs::remove_dir_all(link_path)
+                } else {
+                    Err(e)
+                }
+            })
             .or_else(|_| std::fs::remove_file(link_path))
         {
             Ok(()) => Ok(false),

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -334,17 +334,11 @@ impl Linker {
                             // so that gap is unreachable in practice. A
                             // prior GVS install or the fetch prewarm may have left
                             // a symlink here; replace it. An existing real
-                            // directory is reused as cached. Classification uses
-                            // `read_link`, not `file_type().is_symlink()`: on
-                            // Windows the GVS entry is an NTFS junction (created by
-                            // `sys::create_dir_link`) whose `is_symlink()` is false
-                            // and `is_dir()` is true, so the file-type bit would
-                            // misread a stale junction as a real dir and skip the
-                            // conversion. `read_link` succeeds on both Unix symlinks
-                            // and junction reparse points and fails on a real
-                            // directory — but with DIFFERENT errors per platform, so
-                            // the test goes through `crate::is_real_dir` rather than a
-                            // bare `InvalidInput` match (see `sweep::is_not_a_link_error`).
+                            // directory is reused as cached. `crate::is_real_dir`
+                            // owns the distinction: a Windows junction carries a
+                            // name-surrogate reparse tag, so std reports it as a
+                            // symlink and NOT as a directory, which is exactly the
+                            // classification wanted here.
                             if self.disk_materialize_matches(&pkg.name) {
                                 // Orphan-safety invariant: disk-materialize gives X
                                 // a real project-local dir so X's OWN undeclared

--- a/vendor/aube/crates/aube-linker/src/materialize.rs
+++ b/vendor/aube/crates/aube-linker/src/materialize.rs
@@ -12,6 +12,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 use std::time::Duration;
 
+/// Whether path lookup folds case on this platform. Windows always does, and
+/// the default macOS volume does; Linux does not. Governs the self-reference
+/// skip in the transitive-sibling pass, where two package names differing only
+/// by case would otherwise resolve to one directory.
+const CASE_INSENSITIVE_PATHS: bool = cfg!(any(windows, target_os = "macos"));
+
 enum MaterializePlacement {
     Placed,
     LostRace,
@@ -700,7 +706,18 @@ impl Linker {
             // self-reference: `require('<self>')` from inside the
             // package resolves to its own files, matching what npm /
             // pnpm / yarn end up with after their hoisting passes.
-            if dep_name == &pkg.name {
+            //
+            // The comparison has to tolerate case wherever the filesystem
+            // does. On Windows and a default macOS volume `Foo` and `foo`
+            // name the SAME directory, so an exact-match skip lets a `foo`
+            // edge on a package named `Foo` compute a `symlink_path` that
+            // IS `pkg_nm_dir`. `create_dir_link` converges by clearing
+            // whatever occupies the slot, so that would recursively delete
+            // the package's own just-materialized files — where it used to
+            // surface as the loud EEXIST this comment describes.
+            if dep_name == &pkg.name
+                || (CASE_INSENSITIVE_PATHS && dep_name.eq_ignore_ascii_case(&pkg.name))
+            {
                 continue;
             }
             let symlink_path = pkg_nm_parent.join(dep_name);

--- a/vendor/aube/crates/aube-linker/src/materialize.rs
+++ b/vendor/aube/crates/aube-linker/src/materialize.rs
@@ -701,19 +701,27 @@ impl Linker {
             // package resolves to its own files, matching what npm /
             // pnpm / yarn end up with after their hoisting passes.
             //
-            // Case folding makes this an exact-match skip over a path
-            // comparison that is not exact: where the filesystem folds case
-            // (Windows, a default macOS volume, a casefold ext4 directory, a
-            // Docker-on-macOS bind mount) a `foo` edge on a package named
-            // `Foo` computes a `symlink_path` that IS `pkg_nm_dir`. That is
-            // not detectable from the name alone — the property belongs to the
-            // mount, not the platform — so the backstop lives in
-            // `create_dir_link`, which refuses to clear a populated real
-            // directory and keeps the collision a loud error everywhere.
-            if dep_name == &pkg.name {
+            // Case folding widens "same name" to "same directory": where the
+            // mount folds case (Windows, a default macOS volume, a casefold
+            // ext4 directory, a Docker-on-macOS bind mount) a `foo` edge on a
+            // package named `Foo` resolves to `pkg_nm_dir` itself. Folding is a
+            // property of the MOUNT, not the platform, so it is settled by
+            // asking the filesystem rather than by a `cfg!`: `pkg_nm_dir` is
+            // already materialized here, so on a folding mount the two paths
+            // canonicalize to one and on a non-folding one the sibling path
+            // does not resolve at all. The name test short-circuits first, so
+            // the common edge pays no syscall. `create_dir_link` refusing to
+            // clear a populated real directory is the backstop if this misses.
+            let symlink_path = pkg_nm_parent.join(dep_name);
+            if dep_name == &pkg.name
+                || (dep_name.eq_ignore_ascii_case(&pkg.name)
+                    && matches!(
+                        (symlink_path.canonicalize(), pkg_nm_dir.canonicalize()),
+                        (Ok(a), Ok(b)) if a == b
+                    ))
+            {
                 continue;
             }
-            let symlink_path = pkg_nm_parent.join(dep_name);
             // `link:` transitive: the resolver pinned an absolute
             // on-disk target. Skip the virtual-store sibling lookup
             // (there is no `.aube/<dep>@link+...` entry for these) and

--- a/vendor/aube/crates/aube-linker/src/materialize.rs
+++ b/vendor/aube/crates/aube-linker/src/materialize.rs
@@ -12,12 +12,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 use std::time::Duration;
 
-/// Whether path lookup folds case on this platform. Windows always does, and
-/// the default macOS volume does; Linux does not. Governs the self-reference
-/// skip in the transitive-sibling pass, where two package names differing only
-/// by case would otherwise resolve to one directory.
-const CASE_INSENSITIVE_PATHS: bool = cfg!(any(windows, target_os = "macos"));
-
 enum MaterializePlacement {
     Placed,
     LostRace,
@@ -707,17 +701,16 @@ impl Linker {
             // package resolves to its own files, matching what npm /
             // pnpm / yarn end up with after their hoisting passes.
             //
-            // The comparison has to tolerate case wherever the filesystem
-            // does. On Windows and a default macOS volume `Foo` and `foo`
-            // name the SAME directory, so an exact-match skip lets a `foo`
-            // edge on a package named `Foo` compute a `symlink_path` that
-            // IS `pkg_nm_dir`. `create_dir_link` converges by clearing
-            // whatever occupies the slot, so that would recursively delete
-            // the package's own just-materialized files — where it used to
-            // surface as the loud EEXIST this comment describes.
-            if dep_name == &pkg.name
-                || (CASE_INSENSITIVE_PATHS && dep_name.eq_ignore_ascii_case(&pkg.name))
-            {
+            // Case folding makes this an exact-match skip over a path
+            // comparison that is not exact: where the filesystem folds case
+            // (Windows, a default macOS volume, a casefold ext4 directory, a
+            // Docker-on-macOS bind mount) a `foo` edge on a package named
+            // `Foo` computes a `symlink_path` that IS `pkg_nm_dir`. That is
+            // not detectable from the name alone — the property belongs to the
+            // mount, not the platform — so the backstop lives in
+            // `create_dir_link`, which refuses to clear a populated real
+            // directory and keeps the collision a loud error everywhere.
+            if dep_name == &pkg.name {
                 continue;
             }
             let symlink_path = pkg_nm_parent.join(dep_name);

--- a/vendor/aube/crates/aube-linker/src/sweep.rs
+++ b/vendor/aube/crates/aube-linker/src/sweep.rs
@@ -324,9 +324,12 @@ pub(crate) fn classify_entry_state(link_path: &Path, expected: &Path) -> EntrySt
         }
         Ok(_) => EntryState::Stale,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => EntryState::Missing,
-        // Some other error (permission, etc.): treat as Stale and
-        // let the removal/recreate path try its best-effort cleanup
-        // + surface the real error on symlink creation if unlucky.
+        // Not a link. Dominated by "it is a real directory" — a per-project
+        // entry where a shared-store one is wanted, which on Windows arrives as
+        // the raw `ERROR_NOT_A_REPARSE_POINT` rather than any mapped kind (see
+        // `is_not_a_link_error`) — plus genuine IO errors like permission.
+        // `Stale` is the right action for both: the caller clears the entry and
+        // recreates it, and a real failure resurfaces at that point.
         Err(_) => EntryState::Stale,
     }
 }
@@ -364,6 +367,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let target = tmp.path().join("target");
         std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("keep.txt"), b"keep").unwrap();
 
         let populated = tmp.path().join("populated");
         std::fs::create_dir_all(populated.join("nested")).unwrap();
@@ -381,8 +385,10 @@ mod tests {
                 path.display()
             );
         }
-        // Clearing a link must unlink the entry, not recurse through it.
-        assert!(target.is_dir());
+        // Clearing a link must unlink the entry, not recurse through it. An
+        // empty `target` could not tell the two apart — a follow-through would
+        // delete the contents and still leave the directory standing.
+        assert_eq!(std::fs::read(target.join("keep.txt")).unwrap(), b"keep");
     }
 
     #[test]

--- a/vendor/aube/crates/aube-linker/src/sweep.rs
+++ b/vendor/aube/crates/aube-linker/src/sweep.rs
@@ -133,6 +133,31 @@ pub(crate) fn try_remove_entry(path: &Path) {
     let _ = std::fs::remove_file(path);
 }
 
+/// True when a `read_link` failure means "an entry is here but it is not
+/// a link" rather than "nothing is here".
+///
+/// Unix `readlink(2)` reports EINVAL for a non-link, which std maps to
+/// `ErrorKind::InvalidInput`. Windows answers the same question through
+/// `DeviceIoControl(FSCTL_GET_REPARSE_POINT)`, which fails with the raw
+/// `ERROR_NOT_A_REPARSE_POINT` (4390); std has no `ErrorKind` for that
+/// code, so it arrives as `Uncategorized`. Matching `InvalidInput` alone
+/// therefore answers "is this a real directory?" with `false` for EVERY
+/// real directory on Windows — the classification hole behind nubjs/nub#576
+/// and #566. Callers that need the distinction must go through here.
+pub(crate) fn is_not_a_link_error(e: &std::io::Error) -> bool {
+    const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
+    e.kind() == std::io::ErrorKind::InvalidInput
+        || e.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT)
+}
+
+/// Whether `path` is a real directory — it exists and is not a symlink
+/// or a reparse point. Goes through `is_not_a_link_error` rather than a
+/// bare `InvalidInput` match, which answers `false` for every real
+/// directory on Windows.
+pub fn is_real_dir(path: &Path) -> bool {
+    matches!(std::fs::read_link(path), Err(e) if is_not_a_link_error(&e)) && path.is_dir()
+}
+
 /// `xx::file::mkdirp` wrapped with the linker's `Error::Xx` conversion.
 /// Every materialize pass calls this before creating a symlink /
 /// junction, so the lossy `.to_string()` wrap lives in exactly one
@@ -308,7 +333,57 @@ pub(crate) fn classify_entry_state(link_path: &Path, expected: &Path) -> EntrySt
 
 #[cfg(test)]
 mod tests {
-    use super::is_physical_importer;
+    use super::{is_physical_importer, is_real_dir, try_remove_entry};
+
+    /// The classification the GVS-mode detector and the disk-materialize
+    /// cache check are built on. Asserting it per-shape on every platform is
+    /// what a bare `read_link(..) == InvalidInput` match failed on Windows,
+    /// where a real directory reports `ERROR_NOT_A_REPARSE_POINT` instead.
+    #[test]
+    fn is_real_dir_distinguishes_dirs_from_links_and_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        let file = tmp.path().join("file");
+        std::fs::write(&file, b"x").unwrap();
+        let link = tmp.path().join("link");
+        crate::sys::create_dir_link(&real, &link).unwrap();
+
+        assert!(is_real_dir(&real));
+        assert!(!is_real_dir(&link), "a link to a dir is not a real dir");
+        assert!(!is_real_dir(&file));
+        assert!(!is_real_dir(&tmp.path().join("missing")));
+    }
+
+    /// `remove_dir` alone returns `ERROR_DIR_NOT_EMPTY` on a populated real
+    /// directory and `remove_file` then returns `ERROR_ACCESS_DENIED`, which
+    /// is how a stale per-project store entry survived into the following
+    /// link creation (nubjs/nub#566).
+    #[test]
+    fn try_remove_entry_evicts_every_occupant_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        std::fs::create_dir_all(&target).unwrap();
+
+        let populated = tmp.path().join("populated");
+        std::fs::create_dir_all(populated.join("nested")).unwrap();
+        std::fs::write(populated.join("f.txt"), b"x").unwrap();
+        let link = tmp.path().join("link");
+        crate::sys::create_dir_link(&target, &link).unwrap();
+        let file = tmp.path().join("file");
+        std::fs::write(&file, b"x").unwrap();
+
+        for path in [&populated, &link, &file] {
+            try_remove_entry(path);
+            assert!(
+                path.symlink_metadata().is_err(),
+                "{} survived try_remove_entry",
+                path.display()
+            );
+        }
+        // Clearing a link must unlink the entry, not recurse through it.
+        assert!(target.is_dir());
+    }
 
     #[test]
     fn root_is_physical() {

--- a/vendor/aube/crates/aube-linker/src/sweep.rs
+++ b/vendor/aube/crates/aube-linker/src/sweep.rs
@@ -133,29 +133,20 @@ pub(crate) fn try_remove_entry(path: &Path) {
     let _ = std::fs::remove_file(path);
 }
 
-/// True when a `read_link` failure means "an entry is here but it is not
-/// a link" rather than "nothing is here".
+/// Whether `path` is a real directory — it exists, and is not a symlink or a
+/// reparse point.
 ///
-/// Unix `readlink(2)` reports EINVAL for a non-link, which std maps to
-/// `ErrorKind::InvalidInput`. Windows answers the same question through
-/// `DeviceIoControl(FSCTL_GET_REPARSE_POINT)`, which fails with the raw
-/// `ERROR_NOT_A_REPARSE_POINT` (4390); std has no `ErrorKind` for that
-/// code, so it arrives as `Uncategorized`. Matching `InvalidInput` alone
-/// therefore answers "is this a real directory?" with `false` for EVERY
-/// real directory on Windows — the classification hole behind nubjs/nub#576
-/// and #566. Callers that need the distinction must go through here.
-pub(crate) fn is_not_a_link_error(e: &std::io::Error) -> bool {
-    const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
-    e.kind() == std::io::ErrorKind::InvalidInput
-        || e.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT)
-}
-
-/// Whether `path` is a real directory — it exists and is not a symlink
-/// or a reparse point. Goes through `is_not_a_link_error` rather than a
-/// bare `InvalidInput` match, which answers `false` for every real
-/// directory on Windows.
+/// One `lstat`. `FileType::is_dir` is already `!is_symlink && is_directory`,
+/// and on Windows std derives `is_symlink` from the reparse TAG — a junction
+/// carries `IO_REPARSE_TAG_MOUNT_POINT`, whose name-surrogate bit is set, so a
+/// junction reports `is_symlink() == true` and `is_dir() == false`. Classifying
+/// off the error code of `read_link` instead (`InvalidInput` on Unix, raw
+/// `ERROR_NOT_A_REPARSE_POINT` on Windows) needs a magic number, costs a handle
+/// open plus a `DeviceIoControl`, and answers `false` for every directory on a
+/// volume whose driver reports that ioctl differently — FAT32, exFAT, ReFS, a
+/// network share.
 pub fn is_real_dir(path: &Path) -> bool {
-    matches!(std::fs::read_link(path), Err(e) if is_not_a_link_error(&e)) && path.is_dir()
+    matches!(std::fs::symlink_metadata(path), Ok(md) if md.file_type().is_dir())
 }
 
 /// `xx::file::mkdirp` wrapped with the linker's `Error::Xx` conversion.
@@ -325,11 +316,11 @@ pub(crate) fn classify_entry_state(link_path: &Path, expected: &Path) -> EntrySt
         Ok(_) => EntryState::Stale,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => EntryState::Missing,
         // Not a link. Dominated by "it is a real directory" — a per-project
-        // entry where a shared-store one is wanted, which on Windows arrives as
-        // the raw `ERROR_NOT_A_REPARSE_POINT` rather than any mapped kind (see
-        // `is_not_a_link_error`) — plus genuine IO errors like permission.
-        // `Stale` is the right action for both: the caller clears the entry and
-        // recreates it, and a real failure resurfaces at that point.
+        // entry where a shared-store one is wanted, which arrives as EINVAL on
+        // Unix and the raw `ERROR_NOT_A_REPARSE_POINT` on Windows — plus
+        // genuine IO errors like permission. `Stale` is the right action for
+        // both: the caller clears the entry and recreates it, and a real
+        // failure resurfaces at that point.
         Err(_) => EntryState::Stale,
     }
 }

--- a/vendor/aube/crates/aube-linker/src/sys.rs
+++ b/vendor/aube/crates/aube-linker/src/sys.rs
@@ -61,10 +61,41 @@ use std::path::{Component, Path, PathBuf};
 /// - Unix: a plain symlink (relative or absolute target OK).
 /// - Windows: an NTFS junction (relative targets are resolved to
 ///   absolute against `link`'s parent first).
+///
+/// **Convergent**: an occupied `link` that already points at `target` is a
+/// no-op success, and any other occupant is cleared and replaced. Callers
+/// re-link into live `node_modules` trees on every `add` / `remove`, so a
+/// create that hard-failed on collision aborted whole installs over entries
+/// that survived the previous run (nubjs/nub#576, #566). The clean-create
+/// fast path is unchanged — the reconcile costs nothing until a collision.
 pub fn create_dir_link(target: &Path, link: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
-        std::os::unix::fs::symlink(target, link)
+        match std::os::unix::fs::symlink(target, link) {
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                // Same convergence contract as the Windows branch below, so
+                // callers get one platform-independent guarantee. A POSIX
+                // symlink stores the caller's target bytes verbatim, so the
+                // "already correct" test is a direct compare.
+                if matches!(std::fs::read_link(link), Ok(existing) if existing == target) {
+                    return Ok(());
+                }
+                crate::try_remove_entry(link);
+                match std::os::unix::fs::symlink(target, link) {
+                    // A concurrent linker thread refilled the slot between the
+                    // clear and the retry. It writes the same target we do, so
+                    // an identical entry is success, not a collision.
+                    Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                        match std::fs::read_link(link) {
+                            Ok(existing) if existing == target => Ok(()),
+                            _ => Err(e),
+                        }
+                    }
+                    other => other,
+                }
+            }
+            other => other,
+        }
     }
     #[cfg(windows)]
     {
@@ -95,9 +126,34 @@ pub fn create_dir_link(target: &Path, link: &Path) -> io::Result<()> {
 fn create_junction_with_retry(target: &Path, link: &Path) -> io::Result<()> {
     let mut attempt = 0;
     let mut delay_ms = 50u64;
+    let mut reconciled = false;
     loop {
         match junction::create(target, link) {
             Ok(()) => return Ok(()),
+            // `junction::create` opens with `fs::create_dir(link)`, so ANY
+            // occupied path — an identical junction included — comes back as
+            // `ERROR_ALREADY_EXISTS`. The linker re-links into a live
+            // `node_modules` on every `add` / `remove`, so a non-idempotent
+            // create aborts the whole install the moment one entry survives
+            // from the previous run (nubjs/nub#576, #566). Converge instead:
+            // accept an entry that already points where we want, otherwise
+            // clear the slot and try again. The "already correct" test runs on
+            // EVERY collision (a concurrent linker thread that refilled the
+            // slot wrote the same target we want, so that is success), but the
+            // slot is cleared at most ONCE — a second collision against a
+            // DIFFERENT target means something outside the linker owns the
+            // path, and clearing again would be an unbounded delete/recreate
+            // fight with whoever that is.
+            Err(e) if is_already_exists(&e) => {
+                if junction_points_at(link, target) {
+                    return Ok(());
+                }
+                if reconciled {
+                    return Err(e);
+                }
+                reconciled = true;
+                crate::try_remove_entry(link);
+            }
             Err(e) if is_retriable_link_error(&e) && attempt < 9 => {
                 std::thread::sleep(std::time::Duration::from_millis(delay_ms));
                 delay_ms = (delay_ms * 2).min(2000);
@@ -106,6 +162,30 @@ fn create_junction_with_retry(target: &Path, link: &Path) -> io::Result<()> {
             Err(e) => return Err(e),
         }
     }
+}
+
+/// `junction::create` normalizes its target through `GetFullPathName` and
+/// stores it absolute; `read_link` hands that same absolute path back with no
+/// `\??\` / `\\?\` prefix, so a direct compare round-trips. Canonicalize both
+/// sides when the raw strings differ — 8.3 short names and drive-letter case
+/// make the textual compare miss links that do resolve to the same directory.
+#[cfg(windows)]
+fn junction_points_at(link: &Path, target: &Path) -> bool {
+    let Ok(existing) = std::fs::read_link(link) else {
+        return false;
+    };
+    if existing == target {
+        return true;
+    }
+    matches!(
+        (existing.canonicalize(), target.canonicalize()),
+        (Ok(a), Ok(b)) if a == b
+    )
+}
+
+#[cfg(windows)]
+fn is_already_exists(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::AlreadyExists || error.raw_os_error() == Some(183)
 }
 
 #[cfg(windows)]
@@ -1134,6 +1214,90 @@ mod tests {
         create_dir_link(&rel, &link).unwrap();
 
         assert_eq!(std::fs::read(link.join("marker.txt")).unwrap(), b"hi");
+    }
+
+    /// The convergence contract of `create_dir_link`, exercised against every
+    /// shape an occupied link path takes across a re-link of a live
+    /// `node_modules`. Regression for nubjs/nub#576 (a surviving sibling link
+    /// inside `.store/<entry>/node_modules/`) and #566 (a surviving
+    /// `.store/<entry>` itself). Runs on both platforms — the failure was
+    /// Windows-only because `junction::create` reports EVERY occupant as
+    /// `ERROR_ALREADY_EXISTS`, but the contract is the same either way.
+    ///
+    /// `occupy` builds the occupant; the assertion is that a subsequent
+    /// `create_dir_link` succeeds, the link resolves to `target`, and the
+    /// target's own contents were not recursed into while clearing the slot.
+    fn assert_converges(occupy: impl FnOnce(&Path)) {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("marker.txt"), b"hi").unwrap();
+
+        let link = dir.path().join("link");
+        occupy(&link);
+        create_dir_link(&target, &link).unwrap();
+
+        assert_eq!(
+            std::fs::read(link.join("marker.txt")).unwrap(),
+            b"hi",
+            "link does not resolve to the requested target after reconcile"
+        );
+        // The target's own contents must survive the reconcile — clearing the
+        // slot must unlink the entry, never recurse through it.
+        assert!(target.join("marker.txt").exists());
+    }
+
+    #[test]
+    fn create_dir_link_converges_over_empty_dir() {
+        assert_converges(|link| std::fs::create_dir_all(link).unwrap());
+    }
+
+    #[test]
+    fn create_dir_link_converges_over_populated_dir() {
+        assert_converges(|link| {
+            std::fs::create_dir_all(link.join("nested")).unwrap();
+            std::fs::write(link.join("stale.txt"), b"stale").unwrap();
+        });
+    }
+
+    #[test]
+    fn create_dir_link_converges_over_file() {
+        assert_converges(|link| std::fs::write(link, b"stale").unwrap());
+    }
+
+    #[test]
+    fn create_dir_link_converges_over_link_to_other_target() {
+        assert_converges(|link| {
+            let other = link.parent().unwrap().join("other-target");
+            std::fs::create_dir_all(&other).unwrap();
+            create_dir_link(&other, link).unwrap();
+        });
+    }
+
+    /// The hot case, and literally the shape #576 reports: a warm re-link
+    /// where the entry is already exactly right must succeed rather than
+    /// collide. (That it takes the early-return path without churning the
+    /// entry is a property of the code, not of this assertion — a
+    /// clear-and-recreate would also leave the link resolving correctly.)
+    #[test]
+    fn create_dir_link_is_a_noop_when_already_correct() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        let link = dir.path().join("link");
+
+        create_dir_link(&target, &link).unwrap();
+        std::fs::write(target.join("witness.txt"), b"1").unwrap();
+        create_dir_link(&target, &link).unwrap();
+
+        assert!(link.join("witness.txt").exists());
+    }
+
+    #[test]
+    fn create_dir_link_converges_over_dangling_link() {
+        assert_converges(|link| {
+            create_dir_link(Path::new("never-created"), link).unwrap();
+        });
     }
 
     #[cfg(windows)]

--- a/vendor/aube/crates/aube-linker/src/sys.rs
+++ b/vendor/aube/crates/aube-linker/src/sys.rs
@@ -70,13 +70,14 @@ use std::path::{Component, Path, PathBuf};
 /// path is unchanged — the reconcile costs nothing until a collision.
 ///
 /// A POPULATED REAL DIRECTORY is deliberately NOT cleared: this primitive never
-/// recurses. Every caller that legitimately replaces real content clears the
-/// slot itself first (`try_remove_entry` / `remove_existing` /
-/// `reconcile_top_level_link`), so real content still occupying a link path
-/// means the linker is about to write over something it does not own — most
-/// sharply, a package's own just-materialized files when a dependency name
-/// collides with the package's under case folding. That stays a loud error, on
-/// every platform, rather than a silent recursive delete.
+/// recurses. Callers that legitimately replace real content clear the slot
+/// themselves first — `try_remove_entry`, `remove_existing`,
+/// `reconcile_top_level_link`, or an inline removal — and the transitive-sibling
+/// pass in `materialize_into` clears nothing because its slot is expected empty.
+/// That pass is where the refusal earns its keep: under case folding a
+/// dependency name can collide with the package's own, aiming the link at the
+/// package's just-materialized directory. That stays a loud error, on every
+/// platform, rather than a silent recursive delete.
 pub fn create_dir_link(target: &Path, link: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
@@ -216,10 +217,24 @@ fn junction_points_at(link: &Path, target: &Path) -> bool {
 /// stays loud. See `create_dir_link` for why that shape must not be recursed
 /// into. `NotFound` is success — something else already cleared the slot.
 fn clear_link_slot(link: &Path) -> io::Result<()> {
-    match std::fs::remove_dir(link).or_else(|_| std::fs::remove_file(link)) {
+    let dir_err = match std::fs::remove_dir(link) {
+        Ok(()) => return Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        // The refusal case, and the one whose error the caller most needs.
+        // Report `DirectoryNotEmpty` rather than falling through: `remove_file`
+        // on a directory answers with something actively misleading —
+        // `ERROR_ACCESS_DENIED` on Windows, `EPERM` on macOS — which reads as a
+        // permissions problem, and on Windows is the same `os error 5` shape as
+        // the unrelated npm-incumbent-tree abort this PR also fixes.
+        Err(e) if e.kind() == io::ErrorKind::DirectoryNotEmpty => return Err(e),
+        Err(e) => e,
+    };
+    match std::fs::remove_file(link) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(e),
+        // Neither removal applied. `remove_dir`'s error describes the OCCUPANT;
+        // `remove_file`'s describes only its own refusal to unlink a directory.
+        Err(_) => Err(dir_err),
     }
 }
 
@@ -1302,10 +1317,13 @@ mod tests {
         std::fs::create_dir_all(link.join("nested")).unwrap();
         std::fs::write(link.join("precious.txt"), b"precious").unwrap();
 
-        assert!(
-            create_dir_link(&target, &link).is_err(),
-            "populated real directory was silently replaced"
-        );
+        let err = create_dir_link(&target, &link)
+            .expect_err("populated real directory was silently replaced");
+        // The occupant's own error, not `remove_file`'s refusal to unlink a
+        // directory (`PermissionDenied` on Windows/macOS, `IsADirectory` on
+        // Linux) — that one reads as a permissions fault and points the reader
+        // at the wrong problem.
+        assert_eq!(err.kind(), io::ErrorKind::DirectoryNotEmpty, "{err:?}");
         assert_eq!(
             std::fs::read(link.join("precious.txt")).unwrap(),
             b"precious"
@@ -1318,10 +1336,13 @@ mod tests {
         assert_converges(|link| std::fs::write(link, b"stale").unwrap());
     }
 
-    /// Repointing a link must unlink the OLD entry, never recurse through it
-    /// into the directory it referenced. Written out longhand rather than via
-    /// `assert_converges` because the assertion that matters here is about the
-    /// abandoned target, which the helper has no handle on.
+    /// Repointing a link unlinks the OLD entry and leaves the directory it
+    /// referenced alone. Written longhand rather than via `assert_converges`
+    /// because the assertion is about the abandoned target, which the helper
+    /// has no handle on. Note this pins behavior rather than catching a
+    /// regression in it: std's `remove_dir_all` does not follow a reparse point
+    /// or a symlink either, so the assertion also held before the clear was
+    /// made non-recursive.
     #[test]
     fn create_dir_link_repoint_does_not_follow_the_old_link() {
         let dir = tempfile::tempdir().unwrap();

--- a/vendor/aube/crates/aube-linker/src/sys.rs
+++ b/vendor/aube/crates/aube-linker/src/sys.rs
@@ -155,6 +155,18 @@ fn create_junction_with_retry(target: &Path, link: &Path) -> io::Result<()> {
                 crate::try_remove_entry(link);
             }
             Err(e) if is_retriable_link_error(&e) && attempt < 9 => {
+                // `junction::create` is not atomic: it `fs::create_dir`s the
+                // link path and only then opens it to write the reparse point
+                // (junction-2.0.0 internals.rs:37-38), with no cleanup if that
+                // second step fails. A 5/32 here therefore LEAKS an empty
+                // directory, and the next attempt collides with our own debris.
+                // Release the latch so that self-inflicted collision does not
+                // spend the one reconcile the loop allows — otherwise transient
+                // AV/indexer contention exhausts the backoff after two attempts
+                // and reports 183 for what was really a sharing violation.
+                // Termination still holds: `attempt` is the bound, and it only
+                // ever increases.
+                reconciled = false;
                 std::thread::sleep(std::time::Duration::from_millis(delay_ms));
                 delay_ms = (delay_ms * 2).min(2000);
                 attempt += 1;
@@ -1237,14 +1249,13 @@ mod tests {
         occupy(&link);
         create_dir_link(&target, &link).unwrap();
 
+        // Reading the marker THROUGH the link proves both that the link
+        // resolves to `target` and that `target`'s contents survived.
         assert_eq!(
             std::fs::read(link.join("marker.txt")).unwrap(),
             b"hi",
             "link does not resolve to the requested target after reconcile"
         );
-        // The target's own contents must survive the reconcile — clearing the
-        // slot must unlink the entry, never recurse through it.
-        assert!(target.join("marker.txt").exists());
     }
 
     #[test]
@@ -1265,13 +1276,31 @@ mod tests {
         assert_converges(|link| std::fs::write(link, b"stale").unwrap());
     }
 
+    /// Repointing a link must unlink the OLD entry, never recurse through it
+    /// into the directory it referenced. Written out longhand rather than via
+    /// `assert_converges` because the assertion that matters here is about the
+    /// abandoned target, which the helper has no handle on.
     #[test]
-    fn create_dir_link_converges_over_link_to_other_target() {
-        assert_converges(|link| {
-            let other = link.parent().unwrap().join("other-target");
-            std::fs::create_dir_all(&other).unwrap();
-            create_dir_link(&other, link).unwrap();
-        });
+    fn create_dir_link_repoint_does_not_follow_the_old_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("marker.txt"), b"hi").unwrap();
+
+        let other = dir.path().join("other-target");
+        std::fs::create_dir_all(&other).unwrap();
+        std::fs::write(other.join("keep.txt"), b"keep").unwrap();
+
+        let link = dir.path().join("link");
+        create_dir_link(&other, &link).unwrap();
+        create_dir_link(&target, &link).unwrap();
+
+        assert_eq!(std::fs::read(link.join("marker.txt")).unwrap(), b"hi");
+        assert_eq!(
+            std::fs::read(other.join("keep.txt")).unwrap(),
+            b"keep",
+            "clearing the slot recursed through the old link and destroyed its target"
+        );
     }
 
     /// The hot case, and literally the shape #576 reports: a warm re-link

--- a/vendor/aube/crates/aube-linker/src/sys.rs
+++ b/vendor/aube/crates/aube-linker/src/sys.rs
@@ -63,11 +63,20 @@ use std::path::{Component, Path, PathBuf};
 ///   absolute against `link`'s parent first).
 ///
 /// **Convergent**: an occupied `link` that already points at `target` is a
-/// no-op success, and any other occupant is cleared and replaced. Callers
-/// re-link into live `node_modules` trees on every `add` / `remove`, so a
-/// create that hard-failed on collision aborted whole installs over entries
-/// that survived the previous run (nubjs/nub#576, #566). The clean-create
-/// fast path is unchanged — the reconcile costs nothing until a collision.
+/// no-op success, and a stale LINK or empty directory is cleared and replaced.
+/// Callers re-link into live `node_modules` trees on every `add` / `remove`, so
+/// a create that hard-failed on collision aborted whole installs over entries
+/// that survived the previous run (nubjs/nub#576, #566). The clean-create fast
+/// path is unchanged — the reconcile costs nothing until a collision.
+///
+/// A POPULATED REAL DIRECTORY is deliberately NOT cleared: this primitive never
+/// recurses. Every caller that legitimately replaces real content clears the
+/// slot itself first (`try_remove_entry` / `remove_existing` /
+/// `reconcile_top_level_link`), so real content still occupying a link path
+/// means the linker is about to write over something it does not own — most
+/// sharply, a package's own just-materialized files when a dependency name
+/// collides with the package's under case folding. That stays a loud error, on
+/// every platform, rather than a silent recursive delete.
 pub fn create_dir_link(target: &Path, link: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
@@ -80,7 +89,7 @@ pub fn create_dir_link(target: &Path, link: &Path) -> io::Result<()> {
                 if matches!(std::fs::read_link(link), Ok(existing) if existing == target) {
                     return Ok(());
                 }
-                crate::try_remove_entry(link);
+                clear_link_slot(link)?;
                 match std::os::unix::fs::symlink(target, link) {
                     // A concurrent linker thread refilled the slot between the
                     // clear and the retry. It writes the same target we do, so
@@ -144,7 +153,7 @@ fn create_junction_with_retry(target: &Path, link: &Path) -> io::Result<()> {
             // DIFFERENT target means something outside the linker owns the
             // path, and clearing again would be an unbounded delete/recreate
             // fight with whoever that is.
-            Err(e) if is_already_exists(&e) => {
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
                 if junction_points_at(link, target) {
                     return Ok(());
                 }
@@ -152,7 +161,12 @@ fn create_junction_with_retry(target: &Path, link: &Path) -> io::Result<()> {
                     return Err(e);
                 }
                 reconciled = true;
-                crate::try_remove_entry(link);
+                // Surface the CLEAR's own error rather than looping back to a
+                // second 183. When a dev server / watcher / AV scanner holds a
+                // handle on the occupant the removal is what actually failed,
+                // and reporting "already exists" for a sharing violation sends
+                // the reader looking in the wrong place.
+                clear_link_slot(link)?;
             }
             Err(e) if is_retriable_link_error(&e) && attempt < 9 => {
                 // `junction::create` is not atomic: it `fs::create_dir`s the
@@ -195,9 +209,18 @@ fn junction_points_at(link: &Path, target: &Path) -> bool {
     )
 }
 
-#[cfg(windows)]
-fn is_already_exists(error: &io::Error) -> bool {
-    error.kind() == io::ErrorKind::AlreadyExists || error.raw_os_error() == Some(183)
+/// Clear a stale LINK or empty directory out of a link path. Deliberately
+/// non-recursive: `remove_dir` unlinks a junction or an empty directory,
+/// `remove_file` unlinks a POSIX symlink or a plain file, and a populated real
+/// directory matches neither, so its error propagates and the caller's create
+/// stays loud. See `create_dir_link` for why that shape must not be recursed
+/// into. `NotFound` is success — something else already cleared the slot.
+fn clear_link_slot(link: &Path) -> io::Result<()> {
+    match std::fs::remove_dir(link).or_else(|_| std::fs::remove_file(link)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(windows)]
@@ -1263,12 +1286,31 @@ mod tests {
         assert_converges(|link| std::fs::create_dir_all(link).unwrap());
     }
 
+    /// The one occupant shape convergence must NOT swallow. Real content at a
+    /// link path means the linker is about to overwrite something it does not
+    /// own — the case-folding self-collision in `materialize_into`'s sibling
+    /// pass reaches this with the package's OWN freshly-materialized files, so
+    /// a recursive clear here would destroy them silently. Stays a loud error,
+    /// and the contents must be intact afterwards.
     #[test]
-    fn create_dir_link_converges_over_populated_dir() {
-        assert_converges(|link| {
-            std::fs::create_dir_all(link.join("nested")).unwrap();
-            std::fs::write(link.join("stale.txt"), b"stale").unwrap();
-        });
+    fn create_dir_link_refuses_to_clobber_a_populated_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::create_dir_all(&target).unwrap();
+
+        let link = dir.path().join("link");
+        std::fs::create_dir_all(link.join("nested")).unwrap();
+        std::fs::write(link.join("precious.txt"), b"precious").unwrap();
+
+        assert!(
+            create_dir_link(&target, &link).is_err(),
+            "populated real directory was silently replaced"
+        );
+        assert_eq!(
+            std::fs::read(link.join("precious.txt")).unwrap(),
+            b"precious"
+        );
+        assert!(link.join("nested").is_dir());
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -194,25 +194,20 @@ pub(super) fn detect_aube_dir_gvs_mode(aube_dir: &std::path::Path) -> Option<boo
         if name_str == "node_modules" || name_str.starts_with('.') {
             continue;
         }
-        // Classify via `read_link`, not `file_type().is_symlink()`.
-        // On Windows, `sys::create_dir_link` produces an NTFS junction
-        // whose `is_symlink()` is `false` and `is_dir()` is `true`,
-        // making a gvs-on entry indistinguishable from a per-project
-        // real directory via the file-type bit. `read_link` succeeds on
-        // both Unix symlinks and Windows junction reparse points, and
-        // fails on a regular directory — but with a platform-specific
-        // error (EINVAL on Unix, raw `ERROR_NOT_A_REPARSE_POINT` on
-        // Windows, which std leaves `Uncategorized`), so the "real dir"
-        // arm goes through `aube_linker::is_real_dir`. Matching
-        // `InvalidInput` directly made `saw_real_dir` unreachable on
-        // Windows, so a per-project tree returned `None` and the caller's
-        // mode-change wipe never fired.
+        // `read_link` succeeds on both a Unix symlink and a Windows junction
+        // reparse point, so it identifies a gvs-on entry on either platform.
+        // The per-project arm is the one that was broken: it matched
+        // `read_link`'s error against `InvalidInput`, which is EINVAL on Unix
+        // but the raw `ERROR_NOT_A_REPARSE_POINT` on Windows — a code std
+        // leaves `Uncategorized`. `saw_real_dir` was therefore unreachable on
+        // Windows, a per-project tree classified as `None`, and the caller's
+        // mode-change wipe never fired. `aube_linker::is_real_dir` settles it
+        // with one `lstat` instead.
         //
-        // `is_real_dir` additionally requires the entry BE a directory, so a
-        // stray regular file directly under `.aube/` no longer counts as
-        // evidence of a per-project tree (it did on Unix, where `read_link` on
-        // a file is also EINVAL). A loose file is not a package entry, so it
-        // should not decide the mode either way.
+        // It also requires the entry BE a directory, so a stray regular file
+        // directly under `.aube/` no longer counts as evidence of a per-project
+        // tree (it did on Unix, where `read_link` on a file is also EINVAL). A
+        // loose file is not a package entry and should not decide the mode.
         if std::fs::read_link(entry.path()).is_ok() {
             return Some(true);
         }

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -200,13 +200,18 @@ pub(super) fn detect_aube_dir_gvs_mode(aube_dir: &std::path::Path) -> Option<boo
         // making a gvs-on entry indistinguishable from a per-project
         // real directory via the file-type bit. `read_link` succeeds on
         // both Unix symlinks and Windows junction reparse points, and
-        // returns `Err(InvalidInput)` on a regular directory — exactly
-        // the signal we need. Non-link IO errors just skip the entry
-        // and move on to the next candidate.
-        match std::fs::read_link(entry.path()) {
-            Ok(_) => return Some(true),
-            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => saw_real_dir = true,
-            Err(_) => continue,
+        // fails on a regular directory — but with a platform-specific
+        // error (EINVAL on Unix, raw `ERROR_NOT_A_REPARSE_POINT` on
+        // Windows, which std leaves `Uncategorized`), so the "real dir"
+        // arm goes through `aube_linker::is_real_dir`. Matching
+        // `InvalidInput` directly made `saw_real_dir` unreachable on
+        // Windows, so a per-project tree returned `None` and the caller's
+        // mode-change wipe never fired.
+        if std::fs::read_link(entry.path()).is_ok() {
+            return Some(true);
+        }
+        if aube_linker::is_real_dir(&entry.path()) {
+            saw_real_dir = true;
         }
     }
     saw_real_dir.then_some(false)
@@ -1281,10 +1286,22 @@ mod network_concurrency_tests {
     }
 }
 
-#[cfg(all(test, unix))]
+// Runs on every platform. Gating this on `unix` is what let the Windows
+// `read_link` classification hole survive: `all_real_dirs_reads_as_per_project`
+// is exactly the assertion that failed there. `create_dir_link` gives the
+// platform-correct link shape (POSIX symlink / NTFS junction), so the same
+// bodies exercise both.
+#[cfg(test)]
 mod gvs_mode_detect_tests {
     use super::*;
-    use std::os::unix::fs::symlink;
+    use aube_linker::create_dir_link;
+    use std::path::Path;
+
+    /// Point at a sibling that is never created. A dangling entry is still a
+    /// link on both platforms, which is the only property these tests need.
+    fn dangling_link(at: std::path::PathBuf) {
+        create_dir_link(Path::new("nonexistent-store-target"), &at).unwrap();
+    }
 
     // `diskMaterializePackages` produces a MIXED `.aube` tree — some entries
     // are shared-store symlinks, some are disk-materialized real dirs. The
@@ -1296,7 +1313,7 @@ mod gvs_mode_detect_tests {
         let dir = tempfile::tempdir().unwrap();
         let aube = dir.path();
         std::fs::create_dir_all(aube.join("real@1.0.0/node_modules/real")).unwrap();
-        symlink("/nonexistent-store/dep@2.0.0", aube.join("dep@2.0.0")).unwrap();
+        dangling_link(aube.join("dep@2.0.0"));
         assert_eq!(detect_aube_dir_gvs_mode(aube), Some(true));
     }
 
@@ -1313,8 +1330,8 @@ mod gvs_mode_detect_tests {
     fn all_symlinks_reads_as_gvs() {
         let dir = tempfile::tempdir().unwrap();
         let aube = dir.path();
-        symlink("/store/a@1.0.0", aube.join("a@1.0.0")).unwrap();
-        symlink("/store/b@1.0.0", aube.join("b@1.0.0")).unwrap();
+        dangling_link(aube.join("a@1.0.0"));
+        dangling_link(aube.join("b@1.0.0"));
         assert_eq!(detect_aube_dir_gvs_mode(aube), Some(true));
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -207,10 +207,16 @@ pub(super) fn detect_aube_dir_gvs_mode(aube_dir: &std::path::Path) -> Option<boo
         // `InvalidInput` directly made `saw_real_dir` unreachable on
         // Windows, so a per-project tree returned `None` and the caller's
         // mode-change wipe never fired.
+        //
+        // `is_real_dir` additionally requires the entry BE a directory, so a
+        // stray regular file directly under `.aube/` no longer counts as
+        // evidence of a per-project tree (it did on Unix, where `read_link` on
+        // a file is also EINVAL). A loose file is not a package entry, so it
+        // should not decide the mode either way.
         if std::fs::read_link(entry.path()).is_ok() {
             return Some(true);
         }
-        if aube_linker::is_real_dir(&entry.path()) {
+        if !saw_real_dir && aube_linker::is_real_dir(&entry.path()) {
             saw_real_dir = true;
         }
     }


### PR DESCRIPTION
Closes #576
Closes #566

`create_dir_link` failed on any occupied link path, so re-linking a live `node_modules` aborted the install. On Windows `junction::create` begins with `fs::create_dir`, so even an identical junction returns 183. It now no-ops when the entry already points at the target, else clears the slot and retries once. The clear is non-recursive: a populated real directory stays a loud error, since that shape means the linker is about to overwrite content it does not own.

Guards that should have caught it were also wrong on Windows: `read_link` on a real dir gives raw 4390, not `InvalidInput`, and two removals used `remove_dir().or_else(remove_file())`, which cannot evict a populated dir. The second also caused `os error 5` installing over an npm tree. Classification is now one `lstat` — a junction's reparse tag already makes std report it as a symlink, not a directory.

Behavior change: `detect_aube_dir_gvs_mode` can now return `Some(false)` on Windows, arming the `node_modules` wipe on a store-locality flip. Intended, matches Unix, warns.

8 tests. Differentials: reverting `create_dir_link` fails the convergence cases; a recursive clear fails the refusal case. CI now runs the vendored engine tests — `vendor/aube` is excluded from the root workspace, so they never ran anywhere.
