### PR TITLE
fix(resolver): skip optional deps whose version pick finds no match

### DIFF
--- a/vendor/aube/crates/aube-codes/src/warnings.rs
+++ b/vendor/aube/crates/aube-codes/src/warnings.rs
@@ -86,6 +86,7 @@ pub const WARN_AUBE_INVALID_CLIENT_CERT: &str = "WARN_AUBE_INVALID_CLIENT_CERT";
 
 // ── resolver ────────────────────────────────────────────────────────
 pub const WARN_AUBE_UNSUPPORTED_PLATFORM_INSTALL: &str = "WARN_AUBE_UNSUPPORTED_PLATFORM_INSTALL";
+#[rustfmt::skip] pub const WARN_AUBE_SKIPPED_OPTIONAL_NO_MATCHING_VERSION: &str = "WARN_AUBE_SKIPPED_OPTIONAL_NO_MATCHING_VERSION";
 pub const WARN_AUBE_EXOTIC_SUBDEP_SKIPPED: &str = "WARN_AUBE_EXOTIC_SUBDEP_SKIPPED";
 pub const WARN_AUBE_PEER_DEDUPE_COLLISION: &str = "WARN_AUBE_PEER_DEDUPE_COLLISION";
 
@@ -493,6 +494,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_UNSUPPORTED_PLATFORM_INSTALL,
         category: category::RESOLVER,
         description: "A required (non-optional) dep declared a platform aube doesn't satisfy; installing anyway.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_SKIPPED_OPTIONAL_NO_MATCHING_VERSION,
+        category: category::RESOLVER,
+        description: "No version of an optional dep matched its range, so the dep was skipped instead of failing the install.",
         exit_code: None,
     },
     CodeMeta {

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -1007,6 +1007,34 @@ impl<'a> ResolveDriver<'a> {
                         ))));
                     }
                 },
+                // An optional dep whose range matches nothing is skipped
+                // rather than fatal, matching the fetch-failure and
+                // platform-mismatch paths. A registry carrying only some
+                // of a package's platform bindings would otherwise fail
+                // the whole install over a dep the platform filter below
+                // is about to drop anyway. The age-gate arm above stays
+                // fatal on purpose — that's a supply-chain signal the
+                // user opted into, not a package the registry lacks.
+                PickResult::NoMatch if task.dep_type == DepType::Optional => {
+                    tracing::warn!(
+                        code = aube_codes::warnings::WARN_AUBE_SKIPPED_OPTIONAL_NO_MATCHING_VERSION,
+                        "skipping optional dep {}: no version matches `{}`",
+                        task.name,
+                        task.range,
+                    );
+                    if task.is_root
+                        && let Some(spec) = task.original_specifier.as_ref()
+                    {
+                        self.skipped_optional_dependencies
+                            .entry(task.importer.clone())
+                            .or_default()
+                            .insert(task.name.clone(), spec.clone());
+                    }
+                    if task.is_root {
+                        self.note_root_done();
+                    }
+                    return Ok(());
+                }
                 PickResult::NoMatch => {
                     return Err(Error::NoMatch(Box::new(error::build_no_match(
                         &task, packument,

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -6147,3 +6147,66 @@ async fn optional_dep_with_both_fetches_in_flight() {
 
     server.abort();
 }
+
+/// A registry that carries the package but not the requested version —
+/// a mirror holding only the platform bindings its own users have pulled
+/// — must not fail the install when the dep is optional. Reported as
+/// nubjs/nub#580: `rolldown` lists all 15 `@rolldown/binding-*` as
+/// optional, and the version pick runs before the `os`/`cpu` filter, so a
+/// binding that couldn't resolve aborted the whole install even though
+/// the platform filter was about to drop it.
+#[tokio::test]
+async fn optional_dep_with_no_matching_version_is_skipped() {
+    let client = Arc::new(aube_registry::client::RegistryClient::new(
+        "http://127.0.0.1:1/",
+    ));
+    let mut resolver = Resolver::new(client);
+    resolver.cache.insert(
+        "p-map".to_string(),
+        make_packument("p-map", &["7.0.4"], "7.0.4"),
+    );
+    resolver.cache.insert(
+        "native-binding".to_string(),
+        make_packument("native-binding", &["1.1.0", "1.2.0"], "1.2.0"),
+    );
+
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("p-map".to_string(), "7.0.4".to_string());
+    manifest
+        .optional_dependencies
+        .insert("native-binding".to_string(), "1.0.3".to_string());
+
+    let graph = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect("an optional dep with no matching version must not fail the resolve");
+    assert!(graph_has_package(&graph, "p-map", "7.0.4"));
+    assert!(!graph_has_package(&graph, "native-binding", "1.0.3"));
+}
+
+/// The skip above is scoped to optional deps — a required dep whose range
+/// matches nothing is still a hard failure.
+#[tokio::test]
+async fn required_dep_with_no_matching_version_still_fails() {
+    let client = Arc::new(aube_registry::client::RegistryClient::new(
+        "http://127.0.0.1:1/",
+    ));
+    let mut resolver = Resolver::new(client);
+    resolver.cache.insert(
+        "native-binding".to_string(),
+        make_packument("native-binding", &["1.1.0", "1.2.0"], "1.2.0"),
+    );
+
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("native-binding".to_string(), "1.0.3".to_string());
+
+    let err = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect_err("a required dep with no matching version must fail the resolve");
+    assert!(matches!(err, Error::NoMatch(_)), "got {err:?}");
+}


### PR DESCRIPTION
`rolldown` declares 15 `@rolldown/binding-*` packages as `optionalDependencies`. The version pick runs before the `os`/`cpu` filter, so a binding the host will never install could fail the entire install when the registry did not carry it. An optional dependency should never be fatal — the fetch-failure and platform-mismatch paths already skip, but the version-pick path did not.

Optional deps whose range matches no version are now skipped and recorded, with a warning. The age-gate path stays fatal: a version withheld by `minimumReleaseAge` is a supply-chain signal the user opted into, not a package the registry lacks.

## Verification

Differential against a registry with `1.0.3` removed from one wrong-platform binding, fresh cache per leg:

| | released 0.6.0 | this branch |
| --- | --- | --- |
| registry unmodified | exit 0 | exit 0 |
| version removed | `ERR_NUB_NO_MATCHING_VERSION`, exit 20 | exit 0 |

`require('rolldown')` loads after the install, so the tree is usable rather than silently incomplete. npm and pnpm both install cleanly in the same scenario.

New tests cover both directions — an optional dep skips, a required dep still fails. The optional test was confirmed to fail without this change.

Closes #580
