### PR TITLE
fix(resolver): fetch publish times on the paths that resolve without the full-packument cache

### DIFF
--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -412,7 +412,7 @@ Which manifest field grants permission tracks the inferred incumbent: pnpm proje
 
 A registry-resolved version must be older than `minimumReleaseAge` — 24 hours by default — before Nub will install it. The window is what keeps a compromised publish out of your tree during the hours between it going up and being caught.
 
-Publish dates come from the registry's `time` metadata, so the gate is only as strong as what the registry serves. An age Nub cannot establish counts as a failure, not a pass:
+Publish dates come from the registry's `time` metadata, so the gate is only as strong as what the registry serves. Under the default `minimumReleaseAgeStrict=true`, an age Nub cannot establish counts as a failure rather than a pass:
 
 | Registry metadata | Outcome |
 |---|---|
@@ -420,6 +420,8 @@ Publish dates come from the registry's `time` metadata, so the gate is only as s
 | Dates for other versions, none for this one | Blocked |
 | No per-version dates, document older than the window | Allowed — the document's own timestamp bounds every version in it |
 | No per-version dates, document newer than the window | Blocked |
+
+Loosening strictness reverses both blocked rows: an undateable version becomes eligible again, and the lowest satisfying one is picked.
 
 Registries that publish no dates at all — some private mirrors, older Verdaccio — hit the last row, and the error names that as the cause rather than reporting a missed cutoff. Three ways through:
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -408,6 +408,27 @@ Approval takes effect immediately: `nub approve-builds` records the decision and
 
 Which manifest field grants permission tracks the inferred incumbent: pnpm projects use `pnpm.onlyBuiltDependencies` / `pnpm.allowBuilds`, Bun projects use `trustedDependencies`, and the neutral `allowBuilds` field plus `nub approve-builds` apply in any project. An explicit denial (`allowBuilds: { pkg: false }`, `neverBuiltDependencies`) always wins. A package that wants to build but isn't allowed is skipped, with `WARN_NUB_IGNORED_BUILD_SCRIPTS` naming it and `nub approve-builds` as the remedy.
 
+### Cooling window
+
+A registry-resolved version must be older than `minimumReleaseAge` — 24 hours by default — before Nub will install it. The window is what keeps a compromised publish out of your tree during the hours between it going up and being caught.
+
+Publish dates come from the registry's `time` metadata, so the gate is only as strong as what the registry serves. An age Nub cannot establish counts as a failure, not a pass:
+
+| Registry metadata | Outcome |
+|---|---|
+| A publish date for the resolved version | Checked against the window |
+| Dates for other versions, none for this one | Blocked |
+| No per-version dates, document older than the window | Allowed — the document's own timestamp bounds every version in it |
+| No per-version dates, document newer than the window | Blocked |
+
+Registries that publish no dates at all — some private mirrors, older Verdaccio — hit the last row, and the error names that as the cause rather than reporting a missed cutoff. Three ways through:
+
+```ini
+minimumReleaseAgeExclude=internal-pkg   # exempt one package (comma-separated)
+minimumReleaseAgeStrict=false           # fall back to the lowest satisfying version
+minimumReleaseAge=0                     # turn the window off
+```
+
 ### Default-trust floor
 
 Beyond the packages you approve explicitly, a curated set of well-known packages may build without approval — but only when **all three** gates hold at once:
@@ -461,9 +482,9 @@ Nub also weighs trust *evidence* across a package's release history — OIDC pro
 The comparison is by publish date, so a legitimate maintenance release on an older major — shipped after a newer major adopted provenance — can trip it. Nub exempts any version older than 14 days, so an aged, un-yanked backport resolves while a freshly published downgrade is still checked against the full history. Widen the window, clear a single package, or turn the check off in `.npmrc`:
 
 ```ini
-trustPolicyIgnoreAfter=20160          # age exemption in minutes (default 14 days)
-trustPolicyExclude[]=tailwind-merge   # exempt one package regardless of age
-trustPolicy=off                       # disable the check entirely
+trustPolicyIgnoreAfter=20160        # age exemption in minutes (default 14 days)
+trustPolicyExclude=tailwind-merge   # exempt one package regardless of age
+trustPolicy=off                     # disable the check entirely
 ```
 
 ## Store and disk layout

--- a/site/content/docs/runner/dlx.mdx
+++ b/site/content/docs/runner/dlx.mdx
@@ -35,7 +35,7 @@ A fetched package's `preinstall`/`install`/`postinstall` scripts stay skipped â€
 
 ## Cooling window
 
-A fetch runs through Nub's normal install resolver, so the `minimumReleaseAge` cooling window applies: a resolved version must be older than the window (default 24 hours) before it's used. See [the trust floor](/docs/install#default-trust-floor) for the full posture.
+A fetch runs through Nub's normal install resolver, so the `minimumReleaseAge` cooling window applies: a resolved version must be older than the window (default 24 hours) before it's used. See [the cooling window](/docs/install#cooling-window) for the full posture, including what happens when a registry serves no publish dates.
 
 ## Related
 

--- a/site/content/docs/runner/index.mdx
+++ b/site/content/docs/runner/index.mdx
@@ -38,7 +38,7 @@ nubx: refusing to download cowsay in CI.
   A CI job should declare the tool as a dependency, or pass -y to fetch it.
 ```
 
-A fetched package runs through Nub's normal install resolver, so the registry safeguards apply: the `minimumReleaseAge` cooling window (see [the trust floor](/docs/install#default-trust-floor)) and skipped lifecycle scripts. The [remote bin runner](/docs/runner/dlx) is the explicit way to fetch and run a package outside the prompt, and covers both in full.
+A fetched package runs through Nub's normal install resolver, so the registry safeguards apply: the `minimumReleaseAge` cooling window (see [the cooling window](/docs/install#cooling-window)) and skipped lifecycle scripts. The [remote bin runner](/docs/runner/dlx) is the explicit way to fetch and run a package outside the prompt, and covers both in full.
 
 ### `-y`
 

--- a/vendor/aube/crates/aube-registry/src/client/packument.rs
+++ b/vendor/aube/crates/aube-registry/src/client/packument.rs
@@ -349,6 +349,22 @@ impl RegistryClient {
         Ok(packument)
     }
 
+    /// Fetch the full (non-corgi) packument fresh — no disk cache — and
+    /// parse it into [`Packument`], `time` map included. The uncached
+    /// sibling of [`Self::fetch_packument_with_time_cached`], for callers
+    /// that need publish times (`minimumReleaseAge`, time-based mode,
+    /// `trustPolicy=no-downgrade`) while deliberately running without the
+    /// full-packument disk cache (`aube update`'s dist-tag freshness
+    /// rule). Falling back to [`Self::fetch_packument`] there instead
+    /// returns the abbreviated corgi document, whose missing `time` map
+    /// silently disables the age gate at the pick site.
+    pub async fn fetch_packument_with_time(&self, name: &str) -> Result<Packument, Error> {
+        let value = self.fetch_packument_json_fresh(name).await?;
+        let packument: Packument = serde_json::from_value(value)
+            .map_err(|e| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))?;
+        Ok(packument)
+    }
+
     pub async fn fetch_packument_with_time_cached_after_lookup(
         &self,
         name: &str,

--- a/vendor/aube/crates/aube-resolver/src/error.rs
+++ b/vendor/aube/crates/aube-resolver/src/error.rs
@@ -8,10 +8,7 @@ use aube_registry::Packument;
 pub enum Error {
     #[error("no version of {} matches range `{}`", .0.name, .0.range)]
     NoMatch(Box<NoMatchDetails>),
-    #[error(
-        "no version of {} matching {} is older than {} minute(s) (minimumReleaseAgeStrict=true)",
-        .0.name, .0.range, .0.minutes
-    )]
+    #[error("{}", .0.headline())]
     AgeGate(Box<AgeGateDetails>),
     #[error("registry error for {0}: {1}")]
     Registry(String, String),
@@ -86,6 +83,33 @@ pub struct AgeGateDetails {
     /// the age gate, sorted newest-first. Empty when the cutoff was
     /// tighter than every published version.
     pub gated: Vec<String>,
+    /// The packument carried no publish time for ANY satisfying version,
+    /// so nothing was blocked for being too new — every candidate was
+    /// blocked for having an undeterminable age (#581). That is a
+    /// different operator problem with different remedies, and reporting
+    /// it as an ordinary age gate sends people to widen a window that was
+    /// never the cause.
+    pub publish_times_missing: bool,
+}
+
+impl AgeGateDetails {
+    /// The headline. Splitting on `publish_times_missing` keeps one error
+    /// variant and one code while still telling the truth: "nothing is old
+    /// enough" and "nothing's age can be established" are the same refusal
+    /// for opposite reasons.
+    pub(crate) fn headline(&self) -> String {
+        if self.publish_times_missing {
+            format!(
+                "cannot establish the publish age of any version of {} matching `{}` — the registry served no publish times",
+                self.name, self.range
+            )
+        } else {
+            format!(
+                "no version of {} matching {} is older than {} minute(s) (minimumReleaseAgeStrict=true)",
+                self.name, self.range, self.minutes
+            )
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -256,6 +280,14 @@ pub(crate) fn build_age_gate(
         }
     }
     gated.sort_by(|a, b| b.0.cmp(&a.0));
+    // No satisfying version carries a publish time => nothing was blocked for
+    // being too new; the whole range was blocked for being undateable. A
+    // populated map with a hole in it is NOT this case — there the rest of the
+    // document dates fine and the hole is the anomaly worth reporting as one.
+    let publish_times_missing = !gated.is_empty()
+        && !gated
+            .iter()
+            .any(|(_, ver)| packument.time.contains_key(ver));
     AgeGateDetails {
         name: task.name.clone(),
         range: task.range.clone(),
@@ -263,6 +295,7 @@ pub(crate) fn build_age_gate(
         importer: task.importer.clone(),
         ancestors: task.ancestors.to_vec(),
         gated: gated.into_iter().map(|(_, s)| s).collect(),
+        publish_times_missing,
     }
 }
 
@@ -304,6 +337,20 @@ fn format_age_gate_help(d: &AgeGateDetails) -> String {
     let mut s = String::new();
     push_importer(&mut s, &d.importer);
     push_chain(&mut s, &d.ancestors, &d.name);
+    if d.publish_times_missing {
+        s.push_str(
+            "the registry served no `time` data for this package, so no version's age can be \
+             checked against the cutoff\n",
+        );
+        s.push_str("to proceed: add `");
+        s.push_str(&d.name);
+        s.push_str(
+            "` to `minimumReleaseAgeExclude`, set `minimumReleaseAgeStrict=false` to fall back \
+             to the lowest satisfying version, or set `minimumReleaseAge=0` to turn the window \
+             off for this project",
+        );
+        return s;
+    }
     if !d.gated.is_empty() {
         s.push_str(&format!(
             "blocked by age gate: {}\n",

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -854,7 +854,12 @@ impl<'a> ResolveDriver<'a> {
                                 .fetch_packument_with_time_cached(&registry_name, dir)
                                 .await
                         }
-                        None => self.resolver.client.fetch_packument(&registry_name).await,
+                        None => {
+                            self.resolver
+                                .client
+                                .fetch_packument_with_time(&registry_name)
+                                .await
+                        }
                     }
                     .map_err(|e| Error::Registry(registry_name.clone(), e.to_string()))?;
                     self.packument_fetch_time += fetch_start.elapsed();
@@ -930,7 +935,12 @@ impl<'a> ResolveDriver<'a> {
                                     .fetch_packument_with_time_cached(&registry_name, dir)
                                     .await
                             }
-                            None => self.resolver.client.fetch_packument(&registry_name).await,
+                            None => {
+                                self.resolver
+                                    .client
+                                    .fetch_packument_with_time(&registry_name)
+                                    .await
+                            }
                         }
                     } else {
                         match self.resolver.client.fetch_packument(&registry_name).await {
@@ -965,7 +975,12 @@ impl<'a> ResolveDriver<'a> {
                                     .fetch_packument_with_time_cached(&registry_name, dir)
                                     .await
                             }
-                            None => self.resolver.client.fetch_packument(&registry_name).await,
+                            None => {
+                                self.resolver
+                                    .client
+                                    .fetch_packument_with_time(&registry_name)
+                                    .await
+                            }
                         }
                     } else {
                         match self.resolver.client.fetch_packument(&registry_name).await {

--- a/vendor/aube/crates/aube-resolver/src/resolve/fetch.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/fetch.rs
@@ -261,7 +261,12 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
                     .fetch_packument_with_time_cached_after_lookup(&name, dir, cached)
                     .await
             }
-            None => client.fetch_packument(&name).await,
+            // No full-packument disk cache (update's dist-tag freshness
+            // rule) still needs the `time` map: the corgi fallback here
+            // silently disabled the `minimumReleaseAge` gate, because a
+            // version with no publish time bypasses the cutoff at the
+            // pick site.
+            None => client.fetch_packument_with_time(&name).await,
         }
     } else if let Some(ref dir) = cache_dir {
         client

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -199,6 +199,7 @@ fn age_gate_help_lists_gated_versions_and_bypass() {
         importer: "packages/app".into(),
         ancestors: vec![("parent".into(), "1.0.0".into())],
         gated: vec!["4.17.21".into(), "4.17.20".into()],
+        publish_times_missing: false,
     }));
     let help = err.help().expect("help set").to_string();
     assert!(help.contains("importer: packages/app"));
@@ -206,6 +207,66 @@ fn age_gate_help_lists_gated_versions_and_bypass() {
     assert!(help.contains("blocked by age gate: 4.17.21, 4.17.20"));
     assert!(help.contains("minimumReleaseAgeStrict=false"));
     assert!(help.contains("minimumReleaseAgeExclude"));
+}
+
+/// A registry that publishes no `time` data blocks the whole range, but for a
+/// reason the ordinary age-gate wording actively misleads on: it would list a
+/// years-old version as "blocked by age gate" and offer a wider window as the
+/// remedy, when no window would ever have helped.
+#[test]
+fn age_gate_names_missing_publish_times_as_the_cause() {
+    let err = Error::AgeGate(Box::new(AgeGateDetails {
+        name: "lodash".into(),
+        range: "^4".into(),
+        minutes: 1440,
+        importer: ".".into(),
+        ancestors: vec![],
+        gated: vec!["4.17.21".into(), "4.17.20".into()],
+        publish_times_missing: true,
+    }));
+    assert!(
+        err.to_string().contains("served no publish times"),
+        "headline must name the real cause, got: {err}"
+    );
+    let help = err.help().expect("help set").to_string();
+    assert!(
+        !help.contains("blocked by age gate"),
+        "must not imply the versions were too new: {help}"
+    );
+    assert!(
+        !help.contains("loosen `minimumReleaseAge`"),
+        "widening the window is not a remedy here: {help}"
+    );
+    assert!(help.contains("minimumReleaseAgeExclude"));
+    assert!(help.contains("minimumReleaseAge=0"));
+}
+
+/// The mixed case stays an ordinary age gate: a populated `time` map with a
+/// hole for one version dates the rest fine, so the missing-times wording
+/// would be wrong.
+#[test]
+fn age_gate_with_a_partially_dated_packument_is_not_the_missing_times_case() {
+    let mut packument = make_packument("lodash", &["4.17.20", "4.17.21"], "4.17.21");
+    packument
+        .time
+        .insert("4.17.20".to_string(), "2026-07-01T00:00:00.000Z".to_string());
+    let task = ResolveTask {
+        name: "lodash".into(),
+        range: "^4".into(),
+        dep_type: DepType::Production,
+        is_root: true,
+        parent: None,
+        importer: ".".into(),
+        original_specifier: None,
+        real_name: None,
+        ancestors: Arc::from([]),
+        range_from_override: false,
+    };
+    let d = build_age_gate(&task, &packument, 1440);
+    assert!(
+        !d.publish_times_missing,
+        "one dated version is enough to make this an ordinary age gate"
+    );
 }
 
 #[test]

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -1452,6 +1452,112 @@ async fn highest_mode_with_minimum_release_age_keeps_in_memory_times() {
     let _ = std::fs::remove_dir_all(base);
 }
 
+/// Regression: `minimumReleaseAge` must hold when the resolver runs
+/// WITHOUT the full-packument disk cache — the `aube update` / `add` /
+/// `dedupe` / `audit` configuration (`cache_full_packuments: false`,
+/// their dist-tag freshness rule). Against a registry whose abbreviated
+/// (corgi) document omits the `time` map — npmjs does — the uncached
+/// `needs_time` fallback used to fetch that corgi document, and a
+/// version with no publish time bypasses the age cutoff at the pick
+/// site: `aube update` crossed the gate onto a fresh publish that
+/// `aube install` (full cache on) had just refused, then rewrote
+/// `package.json` onto it. The fix fetches the full document (time
+/// included) when the full cache dir is absent. This test mocks
+/// npmjs's Accept-dependent shape and pins the gated pick.
+#[tokio::test]
+async fn minimum_release_age_holds_without_full_packument_cache() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // 1.0.0 is years old; 1.1.0 was "published" moments ago.
+    let now_iso = crate::types::format_iso8601_utc(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    );
+    let mut full = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    full.modified = Some(now_iso.clone());
+    full.time
+        .insert("1.0.0".to_string(), "2024-01-01T00:00:00.000Z".to_string());
+    full.time.insert("1.1.0".to_string(), now_iso);
+    // npmjs's corgi document: same versions, NO time map.
+    let mut corgi = full.clone();
+    corgi.time.clear();
+    corgi.modified = None;
+    let full_body = serde_json::to_vec(&full).unwrap();
+    let corgi_body = serde_json::to_vec(&corgi).unwrap();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            let full_body = full_body.clone();
+            let corgi_body = corgi_body.clone();
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 4096];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                // npmjs serves the abbreviated (time-less) document when
+                // the request prefers `application/vnd.npm.install-v1+json`.
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let body = if request.contains("install-v1") {
+                    corgi_body
+                } else {
+                    full_body
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+                socket.write_all(&body).await.unwrap();
+            });
+        }
+    });
+
+    let base = std::env::temp_dir().join(format!(
+        "aube-resolver-mra-nofullcache-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let cache_dir = base.join("packuments");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    // Abbreviated cache only — deliberately NO `with_packument_full_cache`,
+    // matching `build_resolver`'s `cache_full_packuments: false` posture.
+    let mut resolver = Resolver::new(client)
+        .with_packument_cache(cache_dir)
+        .with_minimum_release_age(Some(MinimumReleaseAge {
+            minutes: 1440,
+            ..Default::default()
+        }));
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("foo".to_string(), "^1.0.0".to_string());
+
+    let graph = resolver.resolve(&manifest, None).await.unwrap();
+
+    assert!(
+        graph_has_package(&graph, "foo", "1.0.0"),
+        "the mature 1.0.0 must be picked; graph: {:?}",
+        graph.packages.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !graph_has_package(&graph, "foo", "1.1.0"),
+        "the fresh 1.1.0 must stay behind the minimumReleaseAge cutoff \
+         even without the full-packument cache"
+    );
+    server.abort();
+    let _ = std::fs::remove_dir_all(base);
+}
+
 /// Regression: a primer-seeded pick that satisfies the range must still
 /// record the package's publish time when `minimumReleaseAge` is active.
 /// The bundled primer's `time` data is sparse, so a primer hit could

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -1480,10 +1480,13 @@ async fn minimum_release_age_holds_without_full_packument_cache() {
     full.time
         .insert("1.0.0".to_string(), "2024-01-01T00:00:00.000Z".to_string());
     full.time.insert("1.1.0".to_string(), now_iso);
-    // npmjs's corgi document: same versions, NO time map.
+    // npmjs's corgi document: same versions, NO time map. It does carry
+    // `modified` — verified against registry.npmjs.org — and for an actively
+    // published package that timestamp is recent, so it cannot stand in as
+    // the maturity proof a time-less document otherwise gets. Keeping it here
+    // is what stops the fixture passing for the wrong reason.
     let mut corgi = full.clone();
     corgi.time.clear();
-    corgi.modified = None;
     let full_body = serde_json::to_vec(&full).unwrap();
     let corgi_body = serde_json::to_vec(&corgi).unwrap();
 
@@ -1535,6 +1538,7 @@ async fn minimum_release_age_holds_without_full_packument_cache() {
         .with_packument_cache(cache_dir)
         .with_minimum_release_age(Some(MinimumReleaseAge {
             minutes: 1440,
+            strict: true,
             ..Default::default()
         }));
     let mut manifest = PackageJson::default();

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -247,9 +247,10 @@ fn age_gate_names_missing_publish_times_as_the_cause() {
 #[test]
 fn age_gate_with_a_partially_dated_packument_is_not_the_missing_times_case() {
     let mut packument = make_packument("lodash", &["4.17.20", "4.17.21"], "4.17.21");
-    packument
-        .time
-        .insert("4.17.20".to_string(), "2026-07-01T00:00:00.000Z".to_string());
+    packument.time.insert(
+        "4.17.20".to_string(),
+        "2026-07-01T00:00:00.000Z".to_string(),
+    );
     let task = ResolveTask {
         name: "lodash".into(),
         range: "^4".into(),
@@ -2572,9 +2573,18 @@ fn pick_version_treats_bookkeeping_only_time_map_as_timeless() {
         "2019-06-01T00:00:00.000Z".to_string(),
     );
     assert_eq!(
-        pick_version(&p, "^1.0.0", None, false, Some(cutoff), None, true, |_, _| false)
-            .unwrap()
-            .version,
+        pick_version(
+            &p,
+            "^1.0.0",
+            None,
+            false,
+            Some(cutoff),
+            None,
+            true,
+            |_, _| false
+        )
+        .unwrap()
+        .version,
         "1.1.0"
     );
 }


### PR DESCRIPTION
Completes the `minimumReleaseAge` fix. #602 made an undeterminable publish age fail closed at the pick site; this lands the other half — making sure the publish times are actually fetched — plus the diagnostic and docs the new fail-closed path needs.

## Why both halves are required

`update` / `add` / `dedupe` / `audit` resolve without the full-packument disk cache (the dist-tag freshness rule, `settings_context.rs:452`), so the `needs_time` fallback fetched npmjs's abbreviated document, which carries no `time` map. Before #602 that silently disabled the gate. **After #602 it hard-fails instead**: no version can be dated, npmjs's corgi `modified` is recent for any actively published package, so every candidate is blocked and strict mode aborts.

Verified on the merged tree — the regression test in strict mode, which is Nub's shipped default:

```
AgeGate(AgeGateDetails { name: "foo", range: "^1.0.0", minutes: 1440,
                         gated: ["1.1.0", "1.0.0"] })
```

Both versions gated, including one published in 2024. Fetching the full document fixes it.

## Contents

- **The fetch fix**, authored by @afonsojramos — `RegistryClient::fetch_packument_with_time`, the uncached full-packument sibling, wired into all four `needs_time` fallbacks. Carried over from #582 with authorship intact; that PR predates #602 and can't merge as-is against it.
- **The regression test, in strict mode.** It ran lenient, where the lowest-satisfying fallback lands on the mature version regardless of the wall — so it would have passed with the gate disabled. The corgi fixture also cleared `modified`, which npmjs does not (verified against registry.npmjs.org: abbreviated metadata carries `modified`, never `time`), and for an active package that timestamp is recent — so it must not stand in as the maturity proof a time-less document otherwise gets.
- **An honest error.** A registry serving no publish dates now blocks the whole range, and the age-gate wording reported that as an ordinary cutoff miss — listing years-old versions as "blocked by age gate" and offering a wider window as the remedy, which would never have helped. Split the headline and help on whether any satisfying version carried a date at all. One dated version keeps it an ordinary age gate.
- **Docs.** The resolution-level window had no page of its own — only the build-script floor that consumes it — so dlx and the runner pointed at the floor for a posture it doesn't describe. Also corrects the `trustPolicyExclude[]=` example: the npmrc reader compares keys verbatim against the settings registry, which carries `trustPolicyExclude` and `trust-policy-exclude`, so the bracket form was silently ignored.

## Verification

290 resolver tests pass. Root `cargo fmt --check` clean and `cargo clippy --all-targets --all-features -- -D warnings` clean. Vendored aube carries 36 pre-existing rustfmt diffs on `main`; this branch has 35 — it fixes one and adds none.

Refs #581. Supersedes #582.
