### PR TITLE
fix(install): clear quarantine on side-effects-cache restores and self-upgrades

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -6352,55 +6352,31 @@ fn ensure_bin_executable(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Drop `com.apple.quarantine` from the freshly swapped-in binary.
+/// Drop `com.apple.quarantine` from a binary nub just downloaded.
 ///
 /// Released nub binaries are ad-hoc signed — `codesign` reports
 /// `adhoc, linker-signed` with no Team ID — and macOS kills a quarantined
 /// ad-hoc-signed executable on exec rather than merely warning about it.
-/// `curl` and `tar` above run as children of this process, so when nub is
-/// invoked from a terminal that inherited quarantine flags (one embedded
-/// in a Gatekeeper-enabled app), everything they write is stamped and the
-/// upgrade would install a nub that cannot start. The archive's SHA-256 is
-/// checked against the published checksum before the swap, so clearing the
-/// attribute afterwards is the same trade Homebrew makes for a verified
-/// download.
+/// `curl` and `tar` run as children of this process, so when nub is invoked
+/// from a terminal that inherited quarantine flags (one embedded in a
+/// Gatekeeper-enabled app), everything they write is stamped: the upgrade
+/// would install a nub that cannot start, and the self-shim would exec one.
+/// Both archives are checksum-verified before use, so clearing the attribute
+/// afterwards is the trade Homebrew makes for a verified download.
 ///
 /// Best-effort by the resilience contract in `perform_selfowned_upgrade`:
-/// the binary is already swapped and executable, so a failure here warns
-/// with the manual fix rather than failing the upgrade.
-#[cfg(target_os = "macos")]
+/// the binary is already swapped and executable, so a failure warns with the
+/// manual fix rather than aborting.
+#[cfg(not(windows))]
 fn drop_quarantine(path: &Path) {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
-
-    let Ok(c_path) = CString::new(path.as_os_str().as_bytes()) else {
-        return;
-    };
-    // SAFETY: both pointers are NUL-terminated C strings that outlive the
-    // call. `XATTR_NOFOLLOW` keeps a symlinked path from redirecting the
-    // removal onto whatever it points at.
-    let rc = unsafe {
-        libc::removexattr(
-            c_path.as_ptr(),
-            c"com.apple.quarantine".as_ptr(),
-            libc::XATTR_NOFOLLOW,
-        )
-    };
-    if rc != 0 {
-        // ENOATTR — nothing to remove — is the overwhelmingly common case.
-        let err = std::io::Error::last_os_error();
-        if err.raw_os_error() != Some(libc::ENOATTR) {
-            eprintln!(
-                "nub upgrade: warning: could not clear com.apple.quarantine on {p} ({err}); \
-                 if macOS refuses to run it, clear it with: xattr -d com.apple.quarantine {p}",
-                p = path.display()
-            );
-        }
+    if let Err(err) = nub_core::quarantine::clear(path) {
+        eprintln!(
+            "nub: warning: could not clear com.apple.quarantine on {p} ({err}); \
+             if macOS refuses to run it, clear it with: xattr -d com.apple.quarantine {p}",
+            p = path.display()
+        );
     }
 }
-
-#[cfg(all(not(target_os = "macos"), not(windows)))]
-fn drop_quarantine(_path: &Path) {}
 
 /// Extract a release archive into `dest` by shelling to `tar`, returning whether
 /// tar succeeded (spawn failure is the `Err`). Handles both artifact formats:

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -6323,11 +6323,18 @@ fn swap_dir(install_dir: &Path, name: &str, new_src: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Set the executable bit (0o755) on a freshly-installed binary. The release
-/// archive ships the binary at 0o644 — CI's upload/download-artifact round-trip
-/// strips the +x install.sh would otherwise rely on — so the self-owned upgrade
-/// path must re-apply it or the upgraded `nub` is non-executable. Not compiled
-/// on Windows (executability is by extension, not a mode bit).
+/// Make a freshly-downloaded binary runnable: set the executable bit
+/// (0o755), then clear `com.apple.quarantine`.
+///
+/// The release archive ships the binary at 0o644 — CI's
+/// upload/download-artifact round-trip strips the +x install.sh would
+/// otherwise rely on — so the self-owned upgrade path must re-apply it or
+/// the upgraded `nub` is non-executable. Both callers hand this an
+/// archive nub itself downloaded and checksum-verified, and both then run
+/// it (the upgrade swap, and the self-shim's provision-then-exec), so the
+/// quarantine strip belongs on the same seam; see `drop_quarantine`.
+/// Not compiled on Windows (executability is by extension, not a mode
+/// bit, and quarantine is a macOS concept).
 #[cfg(not(windows))]
 fn ensure_bin_executable(path: &Path) -> Result<()> {
     #[cfg(unix)]
@@ -6341,8 +6348,59 @@ fn ensure_bin_executable(path: &Path) -> Result<()> {
             )
         })?;
     }
+    drop_quarantine(path);
     Ok(())
 }
+
+/// Drop `com.apple.quarantine` from the freshly swapped-in binary.
+///
+/// Released nub binaries are ad-hoc signed — `codesign` reports
+/// `adhoc, linker-signed` with no Team ID — and macOS kills a quarantined
+/// ad-hoc-signed executable on exec rather than merely warning about it.
+/// `curl` and `tar` above run as children of this process, so when nub is
+/// invoked from a terminal that inherited quarantine flags (one embedded
+/// in a Gatekeeper-enabled app), everything they write is stamped and the
+/// upgrade would install a nub that cannot start. The archive's SHA-256 is
+/// checked against the published checksum before the swap, so clearing the
+/// attribute afterwards is the same trade Homebrew makes for a verified
+/// download.
+///
+/// Best-effort by the resilience contract in `perform_selfowned_upgrade`:
+/// the binary is already swapped and executable, so a failure here warns
+/// with the manual fix rather than failing the upgrade.
+#[cfg(target_os = "macos")]
+fn drop_quarantine(path: &Path) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let Ok(c_path) = CString::new(path.as_os_str().as_bytes()) else {
+        return;
+    };
+    // SAFETY: both pointers are NUL-terminated C strings that outlive the
+    // call. `XATTR_NOFOLLOW` keeps a symlinked path from redirecting the
+    // removal onto whatever it points at.
+    let rc = unsafe {
+        libc::removexattr(
+            c_path.as_ptr(),
+            c"com.apple.quarantine".as_ptr(),
+            libc::XATTR_NOFOLLOW,
+        )
+    };
+    if rc != 0 {
+        // ENOATTR — nothing to remove — is the overwhelmingly common case.
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::ENOATTR) {
+            eprintln!(
+                "nub upgrade: warning: could not clear com.apple.quarantine on {p} ({err}); \
+                 if macOS refuses to run it, clear it with: xattr -d com.apple.quarantine {p}",
+                p = path.display()
+            );
+        }
+    }
+}
+
+#[cfg(all(not(target_os = "macos"), not(windows)))]
+fn drop_quarantine(_path: &Path) {}
 
 /// Extract a release archive into `dest` by shelling to `tar`, returning whether
 /// tar succeeded (spawn failure is the `Err`). Handles both artifact formats:

--- a/crates/nub-core/src/lib.rs
+++ b/crates/nub-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config_cache;
 pub mod node;
 pub mod pm;
 pub mod pnp;
+pub mod quarantine;
 pub mod version_management;
 pub mod workspace;
 

--- a/crates/nub-core/src/node/runtime_cache.rs
+++ b/crates/nub-core/src/node/runtime_cache.rs
@@ -108,7 +108,27 @@ pub(crate) fn ensure_runtime() -> Option<PathBuf> {
 }
 
 fn extract_once() -> Option<PathBuf> {
-    extract_with(&base_candidates())
+    let dir = extract_with(&base_candidates())?;
+    // The addon is a Mach-O with no `codesign` step, so macOS refuses to
+    // `dlopen` it once quarantined — and `transform-core.mjs` swallows that
+    // load failure into a null handle it then calls unguarded, making every
+    // TypeScript transpile a hard failure. The inodes are created in-process
+    // (or adopted from a concurrent winner), so a nub carrying inherited
+    // quarantine flags stamps them itself.
+    //
+    // Deliberately on the warm path too, not just a fresh extract:
+    // `VERIFIED_ENTRYPOINTS` compares content hashes, and an xattr does not
+    // change a file's bytes, so a dir poisoned by an older build verifies
+    // clean forever and the self-heal re-extract never fires. Costs one
+    // syscall per process — this sits behind the `OnceLock`.
+    let addon = dir.join("addons").join("nub-native.node");
+    if let Err(e) = crate::quarantine::clear(&addon) {
+        tracing::debug!(
+            "could not clear com.apple.quarantine on {}: {e}",
+            addon.display()
+        );
+    }
+    Some(dir)
 }
 
 /// The candidate-driven core of [`extract_once`], split out so tests can drive it

--- a/crates/nub-core/src/quarantine.rs
+++ b/crates/nub-core/src/quarantine.rs
@@ -1,0 +1,149 @@
+//! Clear `com.apple.quarantine` from artifacts nub itself writes and then
+//! loads or executes (macOS only; a no-op stub elsewhere).
+//!
+//! macOS stamps the attribute on every inode created by a process that
+//! inherited quarantine flags — a terminal embedded in a Gatekeeper-enabled
+//! app, such as a GUI Git client with `LSFileQuarantineEnabled`. The flags
+//! are inherited across `fork`/`exec`, so a `curl` or `tar` nub spawns
+//! stamps everything it writes too. Gatekeeper then refuses the result, and
+//! every native artifact nub places is ad-hoc signed (`codesign` reports
+//! `adhoc, linker-signed`, no Team ID), which it kills outright rather than
+//! merely warning about.
+//!
+//! Clearing it is sound because each caller has already verified the bytes:
+//! the self-upgrade checks the archive's SHA-256 against the published
+//! checksum, and the embedded runtime checks each entrypoint against a
+//! BLAKE3 digest baked in at build time. That is the same trade Homebrew
+//! makes for a verified download — Gatekeeper's unverified-provenance
+//! signal adds nothing on top of a hash the artifact already had to match.
+//!
+//! Note that content verification cannot substitute for this: an xattr does
+//! not change a file's bytes, so a digest check passes on a quarantined file
+//! and any self-heal keyed on content never fires.
+
+/// Best-effort clear of `com.apple.quarantine` on one path.
+///
+/// Returns whether the attribute was actually removed, which only the
+/// callers that want to report a failure need; the common outcome is
+/// `false` because nothing was there. Never fails: the worst case is an
+/// artifact Gatekeeper may refuse, which is the status quo without this.
+#[cfg(target_os = "macos")]
+pub fn clear(path: &std::path::Path) -> Result<bool, std::io::Error> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let Ok(c_path) = CString::new(path.as_os_str().as_bytes()) else {
+        return Ok(false);
+    };
+    // SAFETY: both pointers are NUL-terminated C strings that outlive the
+    // call. `XATTR_NOFOLLOW` keeps a symlinked path from redirecting the
+    // removal onto whatever it points at.
+    let rc = unsafe {
+        libc::removexattr(
+            c_path.as_ptr(),
+            c"com.apple.quarantine".as_ptr(),
+            libc::XATTR_NOFOLLOW,
+        )
+    };
+    if rc == 0 {
+        return Ok(true);
+    }
+    let err = std::io::Error::last_os_error();
+    match err.raw_os_error() {
+        // ENOATTR — nothing to remove — is the overwhelmingly common case,
+        // and ENOENT means the caller raced a path away. Neither is a
+        // failure worth surfacing.
+        Some(libc::ENOATTR | libc::ENOENT) => Ok(false),
+        _ => Err(err),
+    }
+}
+
+/// Quarantine is a macOS concept; every other platform loads without it.
+#[cfg(not(target_os = "macos"))]
+pub fn clear(_path: &std::path::Path) -> Result<bool, std::io::Error> {
+    Ok(false)
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Path;
+
+    fn seed(path: &Path) {
+        let c = CString::new(path.as_os_str().as_bytes()).unwrap();
+        let v = b"0083;68000000;TestApp;";
+        // SAFETY: NUL-terminated path/name outliving the call.
+        let rc = unsafe {
+            libc::setxattr(
+                c.as_ptr(),
+                c"com.apple.quarantine".as_ptr(),
+                v.as_ptr().cast(),
+                v.len(),
+                0,
+                libc::XATTR_NOFOLLOW,
+            )
+        };
+        assert_eq!(rc, 0, "seeding com.apple.quarantine failed");
+    }
+
+    fn quarantined(path: &Path) -> bool {
+        let c = CString::new(path.as_os_str().as_bytes()).unwrap();
+        let mut buf = [0u8; 512];
+        // SAFETY: `buf` is written up to the length passed; a negative
+        // return means nothing was written.
+        let n = unsafe {
+            libc::getxattr(
+                c.as_ptr(),
+                c"com.apple.quarantine".as_ptr(),
+                buf.as_mut_ptr().cast(),
+                buf.len(),
+                0,
+                libc::XATTR_NOFOLLOW,
+            )
+        };
+        n >= 0
+    }
+
+    /// Matches the crate's existing temp-dir convention (`runtime_cache`
+    /// does the same) rather than pulling in a dev-dependency.
+    fn scratch(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+        let suffix = nanos
+            ^ COUNTER
+                .fetch_add(1, Ordering::Relaxed)
+                .wrapping_mul(0x9E37_79B9);
+        let dir = std::env::temp_dir().join(format!("nub-qtn-{tag}-{suffix}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn clears_the_attribute_and_reports_whether_there_was_one() {
+        let dir = scratch("clear");
+        let f = dir.join("nub-native.node");
+        std::fs::write(&f, b"x").unwrap();
+        seed(&f);
+        assert!(quarantined(&f));
+
+        assert!(super::clear(&f).unwrap(), "should report a removal");
+        assert!(!quarantined(&f));
+        // Idempotent: a second pass finds nothing and is not an error.
+        assert!(!super::clear(&f).unwrap(), "second pass removes nothing");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A missing path is a race, not a failure — callers run this on
+    /// best-effort paths and must not see an error.
+    #[test]
+    fn absent_path_is_not_an_error() {
+        let dir = scratch("absent");
+        assert!(!super::clear(&dir.join("gone")).unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/vendor/aube/crates/aube-linker/src/lib.rs
+++ b/vendor/aube/crates/aube-linker/src/lib.rs
@@ -37,6 +37,7 @@ pub(crate) use materialize::{
     invalidate_stale_index_for_package, validate_index_key, validate_package_link_name,
 };
 pub use patches::Patches;
+pub use quarantine::strip_quarantine_from_tree;
 pub(crate) use patches::apply_multi_file_patch;
 pub use pool::default_linker_parallelism;
 pub use sweep::{is_physical_importer, mkdirp, remove_dir_all_with_retry, sweep_stale_tmp_dirs};

--- a/vendor/aube/crates/aube-linker/src/quarantine.rs
+++ b/vendor/aube/crates/aube-linker/src/quarantine.rs
@@ -64,7 +64,6 @@
 //!   package. Both are real and both are out of this module's reach by
 //!   construction — do not assume this seam covers build output.
 
-use aube_store::StoredFile;
 use std::path::Path;
 
 /// Gatekeeper only inspects Mach-O images, and neither obvious signal
@@ -88,8 +87,8 @@ use std::path::Path;
 /// file the CI gate can reach: aube's suite runs `cargo test --workspace`
 /// on ubuntu, where everything below compiles away.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-fn is_gatekeeper_guarded(rel_path: &str, stored: &StoredFile) -> bool {
-    stored.executable
+fn is_gatekeeper_guarded(rel_path: &str, executable: bool) -> bool {
+    executable
         || matches!(
             Path::new(rel_path).extension().and_then(|ext| ext.to_str()),
             Some("node" | "dylib" | "so")
@@ -164,7 +163,7 @@ mod imp {
     /// the files individually.
     pub(crate) fn strip_from_native_binaries(pkg_dir: &Path, index: &PackageIndex) {
         for (rel_path, stored) in index {
-            if is_gatekeeper_guarded(rel_path, stored) {
+            if is_gatekeeper_guarded(rel_path, stored.executable) {
                 remove_quarantine(&pkg_dir.join(rel_path));
             }
         }
@@ -176,6 +175,37 @@ mod imp {
     /// layout `materialize_into` writes.
     pub(crate) fn strip_cached_entry(entry_dir: &Path, pkg_name: &str, index: &PackageIndex) {
         strip_from_native_binaries(&entry_dir.join("node_modules").join(pkg_name), index);
+    }
+
+    /// Walk `dir` and strip every Gatekeeper-relevant file under it.
+    ///
+    /// The index-driven entry points above cannot serve a caller whose
+    /// files never came from a tarball, which is what build output
+    /// restored from the side-effects cache is. Executability comes from
+    /// the mode bits instead of a `StoredFile`.
+    ///
+    /// Uses `symlink_metadata` and never descends a symlink, so a link
+    /// inside a cached tree cannot walk the strip out of `dir`.
+    pub fn strip_quarantine_from_tree(dir: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(meta) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if meta.is_dir() {
+                strip_quarantine_from_tree(&path);
+            } else if meta.is_file() {
+                let executable = meta.permissions().mode() & 0o111 != 0;
+                if is_gatekeeper_guarded(&entry.file_name().to_string_lossy(), executable) {
+                    remove_quarantine(&path);
+                }
+            }
+        }
     }
 
     /// Behavioural coverage for the strip itself. macOS-only by
@@ -269,6 +299,57 @@ mod imp {
             assert!(
                 is_quarantined(&pkg.join("index.js")),
                 "plain .js left alone"
+            );
+        }
+
+        /// The walk-driven entry point, which serves callers with no
+        /// package index — a side-effects-cache restore. Executability
+        /// comes from the mode bits here, so a `node-gyp` addon nested
+        /// under `build/Release` must be found by extension while an
+        /// ordinary file beside it is left alone.
+        #[test]
+        fn tree_walk_strips_nested_build_output_only() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let dir = tempfile::tempdir().unwrap();
+            let deep = dir.path().join("build/Release");
+            std::fs::create_dir_all(&deep).unwrap();
+            let addon = deep.join("binding.node");
+            let helper = deep.join("helper");
+            let readme = dir.path().join("README.md");
+            for p in [&addon, &helper, &readme] {
+                std::fs::write(p, b"x").unwrap();
+                set_quarantine(p);
+            }
+            // 0755 with no extension: the exec-kill shape.
+            std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+            strip_quarantine_from_tree(dir.path());
+
+            assert!(!is_quarantined(&addon), "nested .node must be stripped");
+            assert!(!is_quarantined(&helper), "0755 binary must be stripped");
+            assert!(is_quarantined(&readme), "plain file must be left alone");
+        }
+
+        /// A symlink planted in a cached tree must not walk the strip out
+        /// of the directory it was pointed at.
+        #[test]
+        fn tree_walk_does_not_follow_symlinks_out_of_the_tree() {
+            let dir = tempfile::tempdir().unwrap();
+            let outside = dir.path().join("outside.node");
+            std::fs::write(&outside, b"x").unwrap();
+            set_quarantine(&outside);
+
+            let tree = dir.path().join("tree");
+            std::fs::create_dir_all(tree.join("sub")).unwrap();
+            symlink(&outside, tree.join("link.node")).unwrap();
+            symlink(dir.path(), tree.join("sub/escape")).unwrap();
+
+            strip_quarantine_from_tree(&tree);
+
+            assert!(
+                is_quarantined(&outside),
+                "the strip escaped the tree through a symlink"
             );
         }
 
@@ -451,6 +532,8 @@ mod imp {
 }
 
 #[cfg(target_os = "macos")]
+pub use imp::strip_quarantine_from_tree;
+#[cfg(target_os = "macos")]
 pub(crate) use imp::{strip_cached_entry, strip_from_native_binaries};
 
 /// Quarantine is a macOS concept; every other platform links without it.
@@ -460,6 +543,10 @@ pub(crate) fn strip_from_native_binaries(
     _index: &aube_store::PackageIndex,
 ) {
 }
+
+/// Quarantine is a macOS concept; every other platform restores without it.
+#[cfg(not(target_os = "macos"))]
+pub fn strip_quarantine_from_tree(_dir: &std::path::Path) {}
 
 #[cfg(not(target_os = "macos"))]
 pub(crate) fn strip_cached_entry(
@@ -477,15 +564,6 @@ pub(crate) fn strip_cached_entry(
 mod filter_tests {
     use super::*;
 
-    fn stored(executable: bool) -> StoredFile {
-        StoredFile {
-            hex_hash: String::new(),
-            store_path: std::path::PathBuf::new(),
-            executable,
-            size: None,
-        }
-    }
-
     /// The union is the whole point: npm ships loadable modules
     /// non-executable and native CLI binaries extension-less, so either
     /// signal alone misses real Mach-O that Gatekeeper will block.
@@ -493,18 +571,18 @@ mod filter_tests {
     fn selects_loadable_modules_and_executables_but_not_plain_files() {
         for rel in ["lib/binding.node", "lib/libvips.dylib", "lib/native.so"] {
             assert!(
-                is_gatekeeper_guarded(rel, &stored(false)),
+                is_gatekeeper_guarded(rel, false),
                 "{rel} is a loadable module and npm ships it mode 0644"
             );
         }
         assert!(
-            is_gatekeeper_guarded("bin/esbuild", &stored(true)),
+            is_gatekeeper_guarded("bin/esbuild", true),
             "extension-less 0755 binaries are the exec-kill case"
         );
-        assert!(!is_gatekeeper_guarded("index.js", &stored(false)));
-        assert!(!is_gatekeeper_guarded("README.md", &stored(false)));
+        assert!(!is_gatekeeper_guarded("index.js", false));
+        assert!(!is_gatekeeper_guarded("README.md", false));
         // Only the final extension counts — `.node` as a directory
         // component must not match.
-        assert!(!is_gatekeeper_guarded("node/index.js", &stored(false)));
+        assert!(!is_gatekeeper_guarded("node/index.js", false));
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -717,6 +717,18 @@ pub(crate) async fn run_dep_lifecycle_scripts(
                     ran_here += 1;
                 }
             }
+            if ran_here > 0 {
+                // A dep build writes its output in place — `node-gyp` emits
+                // `build/Release/*.node` right here — and those inodes are
+                // created by child processes that inherited this one's
+                // quarantine flags. A locally built addon is ad-hoc signed at
+                // best, so Gatekeeper refuses to load it. This runs before the
+                // cache save below so the saved entry is clean as well;
+                // stripping only on restore would leave the install that
+                // *built* the addon broken and seed every later restore from a
+                // poisoned tree. No-op off macOS.
+                aube_linker::strip_quarantine_from_tree(&job.package_dir);
+            }
             if should_save_side_effects_cache
                 && ran_here > 0
                 && let Some(cache_entry) = job.cache_entry.clone()

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -722,12 +722,25 @@ pub(crate) async fn run_dep_lifecycle_scripts(
                 // `build/Release/*.node` right here — and those inodes are
                 // created by child processes that inherited this one's
                 // quarantine flags. A locally built addon is ad-hoc signed at
-                // best, so Gatekeeper refuses to load it. This runs before the
-                // cache save below so the saved entry is clean as well;
-                // stripping only on restore would leave the install that
-                // *built* the addon broken and seed every later restore from a
-                // poisoned tree. No-op off macOS.
-                aube_linker::strip_quarantine_from_tree(&job.package_dir);
+                // best, so Gatekeeper refuses to load it, and without this the
+                // install that *built* the addon ships it unusable while only a
+                // later cache restore heals it.
+                //
+                // This does NOT make the cache entry saved below clean: `save`
+                // copies with `CopyMode::Copy`, so `fs::copy` mints inodes the
+                // kernel stamps again regardless of the now-clean source (route
+                // 2 in `aube-linker`'s module doc). The restore-side strip is
+                // what covers that, and remains load-bearing.
+                //
+                // Off the async worker like every other filesystem step here: a
+                // node-gyp `build/` tree can hold thousands of files, and this
+                // walks all of them. Best-effort, so a join error is ignored
+                // rather than failing an otherwise-complete build.
+                let package_dir = job.package_dir.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    aube_linker::strip_quarantine_from_tree(&package_dir)
+                })
+                .await;
             }
             if should_save_side_effects_cache
                 && ran_here > 0

--- a/vendor/aube/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/vendor/aube/crates/aube/src/commands/install/side_effects_cache.rs
@@ -121,6 +121,17 @@ impl SideEffectsCacheEntry {
                 self.path.display()
             )
         })?;
+        // Build output is locally compiled, so on macOS it is ad-hoc
+        // signed at best and Gatekeeper refuses it outright once
+        // quarantined. Both restore modes carry the attribute in: a
+        // hardlink shares the cache entry's inode and therefore its
+        // xattrs, and the `fs::copy` fallback is `fcopyfile` with
+        // `COPYFILE_ALL`. The copy also mints a new inode, which a
+        // quarantine-enabled process has stamped whatever the source
+        // was — so this belongs after the restore rather than once when
+        // the entry is written. Walk-driven because this output was
+        // never in a package index. No-op off macOS.
+        aube_linker::strip_quarantine_from_tree(package_dir);
         // The copy carries the entry's own marker across, so restamping is
         // a no-op except for an entry saved before markers named an engine
         // — that one would fail every future match and re-copy forever.


### PR DESCRIPTION
Refs #575

Five macOS surfaces the linker fix in #601 could not reach. All write files that are then loaded or executed, and none goes through a package index.

### Side-effects cache — both directions

`restore_if_available` copies a cached build tree into an already-linked package. A hardlink shares the cache entry's inode and therefore its xattrs; the `fs::copy` fallback is `fcopyfile` with `COPYFILE_ALL`, which carries xattrs *and* mints a new inode that a quarantine-enabled process gets stamped regardless of the source. The payload is locally compiled `node-gyp` output — ad-hoc signed at best, so Gatekeeper refuses it. One poisoned cache entry re-poisons every future restore.

The strip runs after the restore, not when the entry is saved: the new-inode stamping happens however clean the source was. Same reason the linker fix landed on the target rather than the store.

The **miss** path needs it too, and matters more: `sideEffectsCache` defaults on, so that is the first install of any package with a native build. `node-gyp` writes `build/Release/*.node` in place, in a child that inherited this process's quarantine flags. Stripping only on restore would leave the install that *built* the addon shipping it unusable. The strip runs after the dep-hook loop, off the async worker via `spawn_blocking` like every other filesystem step there.

Note this does **not** make the saved cache entry clean: `save` copies with `CopyMode::Copy`, so `fs::copy` mints inodes the kernel stamps again regardless of the now-clean source. The restore-side strip stays load-bearing — the two cover different halves rather than one making the other redundant.

### nub's own embedded runtime addon

`addons/nub-native.node` is ad-hoc signed (`codesign`: `adhoc, linker-signed`, no Team ID), inflated in-process from the in-binary blob, and `dlopen`ed by `transform-core.mjs` — which swallows a load failure into a null handle and then calls it unguarded. A quarantined addon is therefore a hard failure for every TypeScript transpile, not a degraded path.

This one strips on the warm path as well as a fresh extract. `VERIFIED_ENTRYPOINTS` compares BLAKE3 content hashes, and an xattr does not change a file's bytes, so a poisoned dir verifies clean forever and the self-heal re-extract never fires. Costs one syscall per process, behind the existing `OnceLock`.

### `nub upgrade`

Released nub binaries are ad-hoc signed — `codesign` reports `adhoc, linker-signed`, no Team ID — and macOS kills a quarantined ad-hoc-signed executable on exec. `curl` and `tar` run as children of nub, so an upgrade from a terminal that inherited quarantine flags installs a nub that cannot start. The same seam also covers the self-shim's provision-then-exec path, whose binary has identical provenance. Both archives are SHA-256 verified before use.

### Not included

Node dist provisioning. Official Node is Developer ID signed with a hardened runtime, so Gatekeeper verifies it rather than blocking, and the other extractor in that crate handles JS bundles. No failure was demonstrable, so it stays unchanged rather than shipping speculative hardening.

### Notes

- Adds walk-driven `strip_quarantine_from_tree` for callers with no index; uses `symlink_metadata` and never descends a symlink.
- The shared filter now takes an `executable` bool so the index- and walk-driven paths cannot drift apart on the union rule.
- `ensure_bin_executable`'s doc updated — it now has two jobs, both prerequisites for running a freshly downloaded binary.
- The syscall wrapper lives in `nub-core::quarantine`, shared by the upgrade path and the runtime cache rather than copied; its tests use the crate's existing temp-dir convention instead of adding a dev-dependency.
- The upgrade warning said `nub upgrade:` on a seam that also serves the self-shim, so it now says `nub:`.

### Verification

Local (re-run after the follow-up commit): aube clippy (`aube-linker` + `aube`, `--all-targets -D warnings`) clean on both the macOS and non-macOS `cfg` paths; full linker suite 141 passed; nub workspace clippy `--all-targets --all-features` clean; new `nub-core::quarantine` tests pass; fmt clean. Two new tests, each with a verified negative control — making the walk follow symlinks fails only the escape test, and dropping the filter's executable arm fails only the tests that depend on it. The #601 install e2e re-run against this build shows no regression (0/3 cold, 0/3 quarantine-enabled installer, and the poisoned-store heal still 3/3 → 0/3).

Not verified end-to-end: a live `nub upgrade` (it would download a real release and swap `~/.nub`), and the Gatekeeper kill itself (that needs executing a quarantined binary). The signing status was verified directly with `codesign`.
