### PR TITLE
fix(lockfile): drop the redundant npm-alias target left by the pnpm reader

### DIFF
--- a/crates/nub-cli/tests/pm_verbs.rs
+++ b/crates/nub-cli/tests/pm_verbs.rs
@@ -645,6 +645,67 @@ fn dedupe_ignores_workspace_links_and_check_passes() {
     );
 }
 
+/// An `npm:` alias must not read as a dedupe change (#578). The pnpm
+/// reader synthesizes an alias-keyed package and used to keep the
+/// canonical real-name entry too, while a fresh resolve emits only the
+/// clone — so `dedupe` reported the target as removed on every run and
+/// `--check` failed forever on a byte-identical lockfile. Needs the
+/// registry: dedupe's whole job is a fresh resolve.
+#[test]
+#[ignore = "network: resolves + fetches is-number@7.0.0 from the npm registry"]
+fn dedupe_ignores_npm_alias_targets_and_check_passes() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("dedupe-alias");
+    // `packageManager` selects pnpm-lock.yaml; the bug is specific to that
+    // format, since only its writer re-keys an alias under the real name.
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"fixture","private":true,"packageManager":"pnpm@11.17.0","dependencies":{"number-alias":"npm:is-number@7.0.0"}}"#,
+    )
+    .unwrap();
+    let (data, cache) = (
+        pm_tmpdir("dedupe-alias-data"),
+        pm_tmpdir("dedupe-alias-cache"),
+    );
+
+    let install = run_nub_with(&dir, &["install"], &data, &cache);
+    assert_eq!(
+        install.code, 0,
+        "stdout: {}\nstderr: {}",
+        install.stdout, install.stderr
+    );
+    let lock_before = std::fs::read_to_string(dir.join("pnpm-lock.yaml")).unwrap();
+
+    let dedupe = run_nub_with(&dir, &["dedupe"], &data, &cache);
+    assert_eq!(
+        dedupe.code, 0,
+        "stdout: {}\nstderr: {}",
+        dedupe.stdout, dedupe.stderr
+    );
+    assert!(
+        dedupe.combined().contains("already deduped"),
+        "an alias target must not be reported as removed: {}",
+        dedupe.combined()
+    );
+    dedupe.assert_brand_clean();
+    assert_eq!(
+        std::fs::read_to_string(dir.join("pnpm-lock.yaml")).unwrap(),
+        lock_before,
+        "dedupe must not change the lockfile"
+    );
+
+    let check = run_nub_with(&dir, &["dedupe", "--check"], &data, &cache);
+    assert_eq!(
+        check.code,
+        0,
+        "dedupe --check must pass on an aliased project: {}",
+        check.combined()
+    );
+}
+
 /// `nub import` converts a foreign lockfile to pnpm-lock.yaml (nub's
 /// canonical format — never aube-lock.yaml), refuses a second run without
 /// `--force`, and works fully offline.

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/read.rs
@@ -11,7 +11,7 @@ use crate::{
     ParseOptions, PeerDepMeta, RuntimePin, RuntimeTarget, RuntimeVariant, git_commits_match,
 };
 use aube_util::path::normalize_lexical;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 fn rebase_importer_local(local: LocalSource, importer_path: &str) -> LocalSource {
@@ -854,6 +854,10 @@ pub fn parse_with_options(path: &Path, options: ParseOptions) -> Result<Lockfile
     // as a filesystem name) and every reference to the raw alias
     // spelling is remapped afterwards.
     let mut alias_local_renames: BTreeMap<String, String> = BTreeMap::new();
+    // Canonical keys the loop below cloned an alias out of. Collected so the
+    // orphan sweep after it can drop the ones nothing else references — see
+    // the sweep for why.
+    let mut alias_clone_sources: BTreeSet<String> = BTreeSet::new();
     for (alias_dep_path, real_dep_path, alias_name, real_name) in alias_remaps {
         // Skip if the alias entry already exists (aube-written
         // lockfile that emitted both `aliasOf:` and an alias-keyed
@@ -893,6 +897,18 @@ pub fn parse_with_options(path: &Path, options: ParseOptions) -> Result<Lockfile
                 ),
             ));
         };
+        // Record the key actually cloned from — `peerless_alias_target`
+        // may resolve to a peerless variant rather than `real_dep_path`.
+        // A `file:`-keyed target reaches this branch too (pnpm writes
+        // `version: <real>@file:<path>` for a local dep consumed under
+        // another name, and the local-rename branch above only fires when
+        // that package is ALSO a local direct dep), so gate on
+        // `local_source` here rather than assuming the branch above caught
+        // every local: the writer keys locals by `pkg.name`, so a swept
+        // local canonical is not regenerable from the clone.
+        if real_pkg.local_source.is_none() {
+            alias_clone_sources.insert(real_pkg.dep_path.clone());
+        }
         let mut aliased = real_pkg.clone();
         aliased.name = alias_name;
         aliased.dep_path = alias_dep_path.clone();
@@ -922,6 +938,59 @@ pub fn parse_with_options(path: &Path, options: ParseOptions) -> Result<Lockfile
                 }
             }
         }
+    }
+
+    // Drop each alias-clone source that nothing else in the graph reaches.
+    //
+    // pnpm v9 writes only the canonical (real-name-keyed) entry for an
+    // `npm:` alias, so the loop above clones it under the alias key. That
+    // left BOTH in the graph, while a fresh resolve produces only the
+    // alias-keyed one — an asymmetry every consumer that walks `packages`
+    // raw then disagreed on (#578: dedupe reported a phantom removal on
+    // every run and `--check` failed forever; `fetch` over-counted and
+    // re-imported the tarball; `rebuild <real-name>` matched a package
+    // that is not an installed dependency). `install`/linker were immune
+    // only because they run `filter_graph`'s reachability GC first.
+    //
+    // Dropping is safe for serialization: the pnpm writer regenerates the
+    // canonical `packages:`/`snapshots:` key from the alias clone via
+    // `alias_of`. It is NOT safe unconditionally — an aliased package is
+    // frequently also a genuine dep of something else (`@isaacs/cliui`
+    // reaches `string-width@4.2.3` both through its `string-width-cjs`
+    // alias and through `wrap-ansi@7.0.0`'s own edge), so the entry only
+    // goes when no importer and no surviving package edge resolves to it.
+    // Edges resolve through `resolve_dep_edge` — the same convention
+    // `filter_graph` uses — so a git/remote-tarball child keyed
+    // `name@url+<hash>` is not mistaken for unreferenced. Both dep maps
+    // are scanned even though the parse loop already folds
+    // `optional_dependencies` into `dependencies`: a missed edge would
+    // drop a live entry, so the scan errs toward keeping.
+    //
+    // Local (`file:`) targets never enter `alias_clone_sources` (see the
+    // `local_source` gate at the insert), so their canonical entry always
+    // survives — the writer keys locals by `pkg.name`, not `alias_of`, and
+    // could not regenerate one from the clone.
+    if !alias_clone_sources.is_empty() {
+        let mut referenced: BTreeSet<String> = BTreeSet::new();
+        for deps in importers.values() {
+            for dep in deps {
+                referenced.insert(dep.dep_path.clone());
+            }
+        }
+        for pkg in packages.values() {
+            for map in [&pkg.dependencies, &pkg.optional_dependencies] {
+                for (dep_name, value) in map {
+                    if let Some(child) =
+                        crate::resolve_dep_edge(dep_name, value, |k| packages.contains_key(k))
+                    {
+                        referenced.insert(child);
+                    }
+                }
+            }
+        }
+        packages.retain(|key, pkg| {
+            pkg.alias_of.is_some() || !alias_clone_sources.contains(key) || referenced.contains(key)
+        });
     }
 
     // Normalize git / remote-tarball references so a lockfile round-trip

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
@@ -3600,11 +3600,75 @@ snapshots:
     assert_eq!(pkg.name, "express-fork");
     assert_eq!(pkg.alias_of.as_deref(), Some("express"));
     assert_eq!(pkg.dep_path, "express-fork@4.22.1");
-    // Real-keyed entry stays in place — other importers may
-    // reference the package directly, and the canonical entry is
-    // needed for byte-identical round-trips back to pnpm format.
-    let real = graph.packages.get("express@4.22.1").expect("real entry");
-    assert_eq!(real.name, "express");
+    // The real-keyed entry is dropped: nothing else in this lockfile
+    // reaches `express@4.22.1`, and the writer regenerates that key
+    // from the alias clone via `alias_of`, so keeping it only made the
+    // parsed graph disagree with a fresh resolve (#578). An entry that
+    // IS still referenced survives — see
+    // `parse_keeps_alias_target_shared_with_another_consumer`.
+    assert!(
+        !graph.packages.contains_key("express@4.22.1"),
+        "unreferenced alias target must not linger as a parse-only artifact"
+    );
+    assert_eq!(graph.packages.len(), 1);
+}
+
+#[test]
+fn parse_keeps_alias_target_shared_with_another_consumer() {
+    // The counterpart to the drop above: `string-width@4.2.3` is reached
+    // BOTH through the `string-width-cjs` alias and through
+    // `wrap-ansi@7.0.0`'s own edge (the real `@isaacs/cliui` shape). The
+    // canonical entry is load-bearing here and must survive.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &path,
+        r#"
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      string-width-cjs:
+        specifier: npm:string-width@^4.2.0
+        version: string-width@4.2.3
+      wrap-ansi:
+        specifier: ^7.0.0
+        version: wrap-ansi@7.0.0
+
+packages:
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-fake1}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-fake2}
+
+snapshots:
+
+  string-width@4.2.3: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      string-width: 4.2.3
+"#,
+    )
+    .unwrap();
+
+    let graph = parse(&path).unwrap();
+
+    let aliased = graph
+        .packages
+        .get("string-width-cjs@4.2.3")
+        .expect("synthesized alias-keyed package");
+    assert_eq!(aliased.alias_of.as_deref(), Some("string-width"));
+
+    let real = graph
+        .packages
+        .get("string-width@4.2.3")
+        .expect("alias target reached by wrap-ansi must survive the sweep");
+    assert_eq!(real.name, "string-width");
     assert!(real.alias_of.is_none());
 }
 
@@ -3711,12 +3775,54 @@ snapshots:
         .expect("synthesized alias-keyed package");
     assert_eq!(pkg.name, "types-alias");
     assert_eq!(pkg.alias_of.as_deref(), Some("@types/node"));
-    let real = graph
-        .packages
-        .get("@types/node@20.11.0")
-        .expect("real entry");
-    assert_eq!(real.name, "@types/node");
-    assert!(real.alias_of.is_none());
+    // Nothing else reaches the scoped target, so it does not linger as a
+    // parse-only artifact — the sweep keys off the full scoped spelling
+    // rather than mis-splitting it (#578).
+    assert!(!graph.packages.contains_key("@types/node@20.11.0"));
+}
+
+#[test]
+fn parse_keeps_a_file_alias_target_the_writer_cannot_regenerate() {
+    // pnpm writes `version: <real>@file:<path>` when a local dep is
+    // consumed under another in-tree name. That reaches the SAME generic
+    // clone branch as a registry alias whenever the package is not also a
+    // local direct dep, so the orphan sweep would see an unreferenced
+    // canonical and drop it — but the writer keys locals by `pkg.name`,
+    // not `alias_of`, so the entry could never be regenerated from the
+    // clone. The `local_source` gate on the sweep is what keeps it.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &path,
+        r#"
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      aliased-dep:
+        specifier: file:./vendor/real-dep
+        version: real-dep@file:vendor/real-dep
+
+packages:
+
+  real-dep@file:vendor/real-dep:
+    resolution: {directory: vendor/real-dep, type: directory}
+"#,
+    )
+    .unwrap();
+
+    let graph = parse(&path).unwrap();
+
+    assert!(
+        graph
+            .packages
+            .keys()
+            .any(|k| k.starts_with("real-dep@file:")),
+        "a file: alias target must survive the sweep: {:?}",
+        graph.packages.keys().collect::<Vec<_>>()
+    );
 }
 
 #[test]
@@ -3890,12 +3996,15 @@ snapshots:
     assert_eq!(alias.alias_of.as_deref(), Some("string-width"));
     assert_eq!(alias.dep_path, "string-width-cjs@4.2.3");
 
-    let real = graph
-        .packages
-        .get("string-width@4.2.3")
-        .expect("real entry stays put");
-    assert_eq!(real.name, "string-width");
-    assert!(real.alias_of.is_none());
+    // In THIS fixture the cjs copy is reached only through the alias, so
+    // the canonical entry goes (#578). The real `@isaacs/cliui` tree also
+    // has `wrap-ansi@7.0.0` depending on `string-width@4.2.3` directly, and
+    // there the entry survives — `parse_keeps_alias_target_shared_with_another_consumer`.
+    assert!(!graph.packages.contains_key("string-width@4.2.3"));
+    assert!(
+        graph.packages.contains_key("string-width@5.1.2"),
+        "the non-aliased sibling version is untouched by the sweep"
+    );
 }
 
 #[test]
@@ -5103,8 +5212,9 @@ snapshots:
 
     assert_eq!(
         graph.packages.keys().collect::<Vec<_>>(),
-        vec!["is-odd@3.0.1", "odd-alias@3.0.1"],
-        "the write-time patch marker must not leak into aube dep_paths"
+        vec!["odd-alias@3.0.1"],
+        "the write-time patch marker must not leak into aube dep_paths, and the \
+         alias-only target must not linger as a parse-only artifact"
     );
     let alias = graph
         .packages
@@ -5113,8 +5223,11 @@ snapshots:
     assert_eq!(alias.alias_of.as_deref(), Some("is-odd"));
     assert_eq!(graph.importers["."][0].dep_path, "odd-alias@3.0.1");
 
-    // The single rule every consumer keys off: both nodes resolve to the
-    // one declared patch, each under its own `spec_key()`.
+    // The rule every consumer keys off: the alias node resolves the patch
+    // declared on the REGISTRY name, under its own `spec_key()`. This is
+    // independent of the canonical entry — `resolve_package` matches on
+    // `registry_name()` per package (`patch_groups.rs`), so dropping the
+    // unreferenced `is-odd@3.0.1` cannot silently unpatch the install.
     let applied = crate::patch_groups::resolve_patched_by_version(
         &graph.patched_dependency_hashes,
         &graph.packages,
@@ -5124,7 +5237,6 @@ snapshots:
         applied.get("odd-alias@3.0.1").map(String::as_str),
         Some(HASH)
     );
-    assert_eq!(applied.get("is-odd@3.0.1").map(String::as_str), Some(HASH));
 
     let out_dir = tempfile::tempdir().unwrap();
     let out = out_dir.path().join("pnpm-lock.yaml");

--- a/vendor/aube/crates/aube/src/commands/approve_builds.rs
+++ b/vendor/aube/crates/aube/src/commands/approve_builds.rs
@@ -73,10 +73,11 @@ pub async fn run(args: ApproveBuildsArgs) -> miette::Result<()> {
     .await
 }
 
-/// Approve builds for the current project and return the approved
-/// names (empty when nothing was ignored, nothing was selected, or the
-/// interactive confirmation was declined — the caller skips the build
-/// step in all three cases).
+/// Approve builds for the current project and return the GRAPH names to
+/// rebuild — the alias spelling for an `npm:`-aliased dep, not the real
+/// name it was approved under. Empty when nothing was ignored, nothing
+/// was selected, or the interactive confirmation was declined (the caller
+/// skips the build step in all three cases).
 fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<Vec<String>> {
     let ignored = super::ignored_builds::collect_ignored(cwd)?;
     if ignored.is_empty() {
@@ -96,7 +97,10 @@ fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<V
     // source key, never its bare name, so the `allowBuilds` write must use
     // `approval_key`. The follow-up rebuild instead matches deps by graph
     // `name` (pnpm's `rebuild <name>` contract), so the two lists diverge
-    // for source-backed deps and must be threaded separately.
+    // for source-backed deps and must be threaded separately. An `npm:`
+    // alias is the second divergence class: the entry is reported and
+    // approved under the REAL name, while the graph node it must rebuild
+    // is keyed by the alias — hence `graph_names` rather than `selected`.
     let entries = selected_entries(&ignored, &selected);
     let approval_keys = dedupe(entries.iter().map(|e| e.approval_key.clone()).collect());
     let display = entries
@@ -134,7 +138,12 @@ fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<V
     for entry in &entries {
         println!("  {}", entry.display_spec());
     }
-    Ok(selected)
+    Ok(dedupe(
+        entries
+            .iter()
+            .flat_map(|e| e.graph_names.iter().cloned())
+            .collect(),
+    ))
 }
 
 /// The `IgnoredEntry`s whose bare `name` the caller selected, preserving
@@ -460,6 +469,34 @@ fn pick_global_interactively(
 mod tests {
     use super::format_picker_label;
     use aube_scripts::{Suspicion, SuspicionKind};
+
+    /// The rebuild handoff must carry the GRAPH names, not the approved
+    /// (registry) name: an `npm:` alias is reported and written to
+    /// `allowBuilds` as the real package, but `rebuild` matches deps by
+    /// their graph name, so returning the approved spelling made
+    /// `approve-builds` dead-end in `no installed dependency matches`.
+    #[test]
+    fn rebuild_handoff_uses_graph_names_not_the_approved_name() {
+        let entry = super::super::ignored_builds::IgnoredEntry {
+            name: "esbuild".to_string(),
+            version: "0.21.5".to_string(),
+            approval_key: "esbuild".to_string(),
+            suspicions: Vec::new(),
+            graph_names: vec!["eb".to_string(), "eb2".to_string()],
+        };
+        let entries = vec![&entry];
+        let handoff = super::dedupe(
+            entries
+                .iter()
+                .flat_map(|e| e.graph_names.iter().cloned())
+                .collect(),
+        );
+        assert_eq!(handoff, vec!["eb".to_string(), "eb2".to_string()]);
+        assert!(
+            !handoff.contains(&"esbuild".to_string()),
+            "the registry name is not a graph node and would not match"
+        );
+    }
 
     #[test]
     fn label_for_clean_package_is_bare_spec() {

--- a/vendor/aube/crates/aube/src/commands/approve_builds.rs
+++ b/vendor/aube/crates/aube/src/commands/approve_builds.rs
@@ -138,12 +138,19 @@ fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<V
     for entry in &entries {
         println!("  {}", entry.display_spec());
     }
-    Ok(dedupe(
+    Ok(rebuild_handoff_names(&entries))
+}
+
+/// The names to hand `rebuild` for a set of approved entries: the GRAPH
+/// spelling, which is the alias for an `npm:`-aliased dep and so differs
+/// from the real name the entry was reported and approved under.
+fn rebuild_handoff_names(entries: &[&super::ignored_builds::IgnoredEntry]) -> Vec<String> {
+    dedupe(
         entries
             .iter()
             .flat_map(|e| e.graph_names.iter().cloned())
             .collect(),
-    ))
+    )
 }
 
 /// The `IgnoredEntry`s whose bare `name` the caller selected, preserving
@@ -484,17 +491,15 @@ mod tests {
             suspicions: Vec::new(),
             graph_names: vec!["eb".to_string(), "eb2".to_string()],
         };
-        let entries = vec![&entry];
-        let handoff = super::dedupe(
-            entries
-                .iter()
-                .flat_map(|e| e.graph_names.iter().cloned())
-                .collect(),
+        // Both aliases must be handed over: one approved build can back
+        // several graph nodes, and `rebuild` names each one separately.
+        assert_eq!(
+            super::rebuild_handoff_names(&[&entry]),
+            vec!["eb".to_string(), "eb2".to_string()],
         );
-        assert_eq!(handoff, vec!["eb".to_string(), "eb2".to_string()]);
         assert!(
-            !handoff.contains(&"esbuild".to_string()),
-            "the registry name is not a graph node and would not match"
+            !super::rebuild_handoff_names(&[&entry]).contains(&entry.name),
+            "the approved registry name is not a graph node and would not match"
         );
     }
 

--- a/vendor/aube/crates/aube/src/commands/audit.rs
+++ b/vendor/aube/crates/aube/src/commands/audit.rs
@@ -171,9 +171,17 @@ pub async fn run(args: AuditArgs) -> miette::Result<Option<i32>> {
 
     // Build the bulk request body: { name: [version, ...] } with versions
     // deduped so the registry doesn't do extra work on a diamond dep.
+    // Key the query on `registry_name()`, not `pkg.name`: an `npm:` alias
+    // carries the alias as `name`, which the advisory endpoint has never
+    // heard of, so the package came back clean no matter how many
+    // advisories it had — and `resolved_versions_by_name` below already
+    // reads the response back by `registry_name()`, so the alias spelling
+    // could never have matched anyway.
     let mut pkg_versions: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for pkg in closure.values() {
-        let entry = pkg_versions.entry(pkg.name.clone()).or_default();
+        let entry = pkg_versions
+            .entry(pkg.registry_name().to_string())
+            .or_default();
         if !entry.contains(&pkg.version) {
             entry.push(pkg.version.clone());
         }

--- a/vendor/aube/crates/aube/src/commands/dedupe.rs
+++ b/vendor/aube/crates/aube/src/commands/dedupe.rs
@@ -196,20 +196,48 @@ mod tests {
         g
     }
 
-    /// The #578 contract, at the layer that turns the graph shape into the
-    /// user-visible symptom. The pnpm reader used to leave the canonical
-    /// `is-number@7.0.0` alongside the alias clone while a fresh resolve
-    /// emitted only the clone, so this diff reported a removal on every
-    /// run and `dedupe --check` failed forever on a byte-identical
-    /// lockfile. The reader now sweeps the orphan; both sides agree.
+    /// Parse `yaml` as a pnpm lockfile, so the fixture below exercises the
+    /// real reader rather than a hand-built stand-in — `diff_graphs` never
+    /// reads `alias_of`, so only the reader's own output can demonstrate
+    /// that the orphan sweep happened.
+    fn parse_pnpm(yaml: &str) -> LockfileGraph {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(&path, yaml).unwrap();
+        aube_lockfile::pnpm::parse(&path).unwrap()
+    }
+
+    /// The #578 contract, end to end from the reader: an `npm:` alias whose
+    /// target nothing else reaches must parse to the same key set a fresh
+    /// resolve emits, so `dedupe` sees no change. The reader used to leave
+    /// the canonical `is-number@7.0.0` beside the alias clone, which made
+    /// this diff report a removal on every run and `--check` fail forever
+    /// on a byte-identical lockfile. Fails if that sweep regresses.
     #[test]
-    fn npm_alias_parses_and_resolves_to_the_same_key_set() {
-        let parsed = graph(vec![pkg(
-            "number-alias@7.0.0",
-            "number-alias",
-            "7.0.0",
-            Some("is-number"),
-        )]);
+    fn an_orphan_alias_target_is_swept_so_dedupe_sees_no_change() {
+        let parsed = parse_pnpm(
+            r#"
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      number-alias:
+        specifier: npm:is-number@7.0.0
+        version: is-number@7.0.0
+
+packages:
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-fake}
+
+snapshots:
+
+  is-number@7.0.0: {}
+"#,
+        );
+        // What the resolver emits for this manifest: the alias key only.
         let fresh = graph(vec![pkg(
             "number-alias@7.0.0",
             "number-alias",
@@ -219,7 +247,8 @@ mod tests {
         assert_eq!(
             diff_graphs(Some(&parsed), &fresh),
             (Vec::new(), Vec::new()),
-            "an aliased dep must not read as a change on a re-resolve"
+            "parsed keys {:?} must match a fresh resolve",
+            parsed.packages.keys().collect::<Vec<_>>()
         );
     }
 
@@ -248,25 +277,60 @@ mod tests {
         assert!(added.is_empty());
     }
 
-    /// An alias target a second consumer also depends on is present in
-    /// BOTH graphs, so it stays out of the diff — the case that makes the
-    /// reader's sweep conditional rather than unconditional.
+    /// The counterpart the sweep must NOT touch: `wrap-ansi` depends on
+    /// `string-width@4.2.3` directly, so the canonical entry is live even
+    /// though `string-width-cjs` also aliases it (the real `@isaacs/cliui`
+    /// shape). An over-eager sweep drops it here and the diff reports an
+    /// addition the lockfile never makes.
     #[test]
-    fn a_shared_alias_target_is_not_a_change() {
-        let shared = || {
-            vec![
-                pkg("string-width@4.2.3", "string-width", "4.2.3", None),
-                pkg(
-                    "string-width-cjs@4.2.3",
-                    "string-width-cjs",
-                    "4.2.3",
-                    Some("string-width"),
-                ),
-            ]
-        };
+    fn an_alias_target_a_second_consumer_needs_survives_the_sweep() {
+        let parsed = parse_pnpm(
+            r#"
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      string-width-cjs:
+        specifier: npm:string-width@^4.2.0
+        version: string-width@4.2.3
+      wrap-ansi:
+        specifier: ^7.0.0
+        version: wrap-ansi@7.0.0
+
+packages:
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-fake1}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-fake2}
+
+snapshots:
+
+  string-width@4.2.3: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      string-width: 4.2.3
+"#,
+        );
+        let fresh = graph(vec![
+            pkg("string-width@4.2.3", "string-width", "4.2.3", None),
+            pkg(
+                "string-width-cjs@4.2.3",
+                "string-width-cjs",
+                "4.2.3",
+                Some("string-width"),
+            ),
+            pkg("wrap-ansi@7.0.0", "wrap-ansi", "7.0.0", None),
+        ]);
         assert_eq!(
-            diff_graphs(Some(&graph(shared())), &graph(shared())),
-            (Vec::new(), Vec::new())
+            diff_graphs(Some(&parsed), &fresh),
+            (Vec::new(), Vec::new()),
+            "parsed keys {:?} must match a fresh resolve",
+            parsed.packages.keys().collect::<Vec<_>>()
         );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/dedupe.rs
+++ b/vendor/aube/crates/aube/src/commands/dedupe.rs
@@ -172,3 +172,101 @@ fn diff_graphs(
         .collect();
     (removed, added)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aube_lockfile::{LockedPackage, LockfileGraph};
+
+    fn pkg(dep_path: &str, name: &str, version: &str, alias_of: Option<&str>) -> LockedPackage {
+        LockedPackage {
+            name: name.to_string(),
+            version: version.to_string(),
+            dep_path: dep_path.to_string(),
+            alias_of: alias_of.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    fn graph(pkgs: Vec<LockedPackage>) -> LockfileGraph {
+        let mut g = LockfileGraph::default();
+        for p in pkgs {
+            g.packages.insert(p.dep_path.clone(), p);
+        }
+        g
+    }
+
+    /// The #578 contract, at the layer that turns the graph shape into the
+    /// user-visible symptom. The pnpm reader used to leave the canonical
+    /// `is-number@7.0.0` alongside the alias clone while a fresh resolve
+    /// emitted only the clone, so this diff reported a removal on every
+    /// run and `dedupe --check` failed forever on a byte-identical
+    /// lockfile. The reader now sweeps the orphan; both sides agree.
+    #[test]
+    fn npm_alias_parses_and_resolves_to_the_same_key_set() {
+        let parsed = graph(vec![pkg(
+            "number-alias@7.0.0",
+            "number-alias",
+            "7.0.0",
+            Some("is-number"),
+        )]);
+        let fresh = graph(vec![pkg(
+            "number-alias@7.0.0",
+            "number-alias",
+            "7.0.0",
+            Some("is-number"),
+        )]);
+        assert_eq!(
+            diff_graphs(Some(&parsed), &fresh),
+            (Vec::new(), Vec::new()),
+            "an aliased dep must not read as a change on a re-resolve"
+        );
+    }
+
+    /// The shape the reader must never hand back: a lingering canonical
+    /// entry the fresh resolve has no counterpart for is exactly what
+    /// reopens #578, so pin that this diff would in fact report it.
+    #[test]
+    fn a_lingering_alias_target_would_report_a_phantom_removal() {
+        let parsed = graph(vec![
+            pkg("is-number@7.0.0", "is-number", "7.0.0", None),
+            pkg(
+                "number-alias@7.0.0",
+                "number-alias",
+                "7.0.0",
+                Some("is-number"),
+            ),
+        ]);
+        let fresh = graph(vec![pkg(
+            "number-alias@7.0.0",
+            "number-alias",
+            "7.0.0",
+            Some("is-number"),
+        )]);
+        let (removed, added) = diff_graphs(Some(&parsed), &fresh);
+        assert_eq!(removed, vec!["is-number@7.0.0".to_string()]);
+        assert!(added.is_empty());
+    }
+
+    /// An alias target a second consumer also depends on is present in
+    /// BOTH graphs, so it stays out of the diff — the case that makes the
+    /// reader's sweep conditional rather than unconditional.
+    #[test]
+    fn a_shared_alias_target_is_not_a_change() {
+        let shared = || {
+            vec![
+                pkg("string-width@4.2.3", "string-width", "4.2.3", None),
+                pkg(
+                    "string-width-cjs@4.2.3",
+                    "string-width-cjs",
+                    "4.2.3",
+                    Some("string-width"),
+                ),
+            ]
+        };
+        assert_eq!(
+            diff_graphs(Some(&graph(shared())), &graph(shared())),
+            (Vec::new(), Vec::new())
+        );
+    }
+}

--- a/vendor/aube/crates/aube/src/commands/ignored_builds.rs
+++ b/vendor/aube/crates/aube/src/commands/ignored_builds.rs
@@ -16,7 +16,7 @@
 
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub const AFTER_LONG_HELP: &str = "\
 Examples:
@@ -132,6 +132,14 @@ pub(super) struct IgnoredEntry {
     pub version: String,
     pub approval_key: String,
     pub suspicions: Vec<aube_scripts::Suspicion>,
+    /// The graph `LockedPackage.name`s behind this build — the spelling
+    /// `rebuild` matches on, which is the ALIAS for an `npm:`-aliased dep
+    /// and so diverges from `name`/`approval_key`. Plural because one
+    /// build can back several graph nodes (two aliases of one package, or
+    /// an alias alongside the real dep), which the dedup collapses.
+    /// Declared last so the derived `Ord`'s `(name, version)` primary
+    /// ordering documented above is unchanged.
+    pub graph_names: Vec<String>,
 }
 
 impl IgnoredEntry {
@@ -200,7 +208,12 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
             .into_iter()
             .collect();
 
-    let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
+    // `(registry_name, version)` → the `out` index that reported it, or
+    // `None` when that pair was examined and deliberately skipped. Both
+    // states must be remembered: a later package sharing the pair has
+    // already been decided for, and a collapsed one still contributes its
+    // own graph node to `graph_names`.
+    let mut seen: BTreeMap<(String, String), Option<usize>> = BTreeMap::new();
     let mut out: Vec<IgnoredEntry> = Vec::new();
 
     for pkg in graph.packages.values() {
@@ -210,7 +223,27 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
         if super::install::package_build_is_allowed(&policy, pkg) {
             continue;
         }
-        if !seen.insert((pkg.name.clone(), pkg.version.clone())) {
+        // Identify the entry by `registry_name()` throughout, not `pkg.name`.
+        // The policy above, the store index, and the `allowBuilds` allowlist
+        // all key on the real package name, so an `npm:` alias reported under
+        // its alias would display a spec that can never authorize the build.
+        // `name` and `approval_key` must move together: `is_source_backed()`
+        // reads their inequality as "source-backed", so changing only the key
+        // would misclassify every aliased registry package. Deduping here also
+        // collapses an alias and the real package into the one build they are.
+        let report_name = pkg.registry_name();
+        let key = (report_name.to_string(), pkg.version.clone());
+        if let Some(slot) = seen.get(&key) {
+            // Already decided. If it produced an entry, this package is a
+            // second graph node behind the same build (two aliases of one
+            // package, or an alias plus the real dep) and the follow-up
+            // rebuild has to name it too.
+            if let Some(idx) = *slot {
+                let names = &mut out[idx].graph_names;
+                if !names.contains(&pkg.name) {
+                    names.push(pkg.name.clone());
+                }
+            }
             continue;
         }
         // A source-backed dep is authorized by its source key, not its bare
@@ -224,7 +257,10 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
             Some(source_key) if recorded_source_builds.contains(&source_key) => {
                 (source_key, Vec::new())
             }
-            Some(_) => continue,
+            Some(_) => {
+                seen.insert(key, None);
+                continue;
+            }
             None => {
                 let read_key = pkg.integrity.as_deref().or_else(|| {
                     no_integrity_index
@@ -232,18 +268,21 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
                         .map(String::as_str)
                 });
                 let Some(suspicions) =
-                    lifecycle_scripts_with_suspicions(&store, &pkg.name, &pkg.version, read_key)
+                    lifecycle_scripts_with_suspicions(&store, report_name, &pkg.version, read_key)
                 else {
+                    seen.insert(key, None);
                     continue;
                 };
-                (pkg.name.clone(), suspicions)
+                (report_name.to_string(), suspicions)
             }
         };
+        seen.insert(key, Some(out.len()));
         out.push(IgnoredEntry {
-            name: pkg.name.clone(),
+            name: report_name.to_string(),
             version: pkg.version.clone(),
             approval_key,
             suspicions,
+            graph_names: vec![pkg.name.clone()],
         });
     }
 

--- a/vendor/aube/crates/aube/src/commands/outdated.rs
+++ b/vendor/aube/crates/aube/src/commands/outdated.rs
@@ -14,7 +14,7 @@ use aube_registry::Packument;
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 pub const AFTER_LONG_HELP: &str = "\
@@ -406,13 +406,32 @@ async fn collect_rows(
     let client = std::sync::Arc::new(make_client(cwd));
     let cache_dir = packument_cache_dir();
 
+    // An `npm:` alias carries the alias as `DirectDep.name`, which the
+    // registry has never heard of — fetching by it produced a bogus
+    // "failed to fetch packument for <alias>" warning and then reported
+    // the dep as up to date forever. The real name lives on the resolved
+    // package, so key every fetch on `registry_name()` while rows keep
+    // displaying the alias the user actually wrote in package.json.
+    let registry_name_for = |dep: &DirectDep| -> String {
+        graph
+            .get_package(&dep.dep_path)
+            .map(|p| p.registry_name().to_string())
+            .unwrap_or_else(|| dep.name.clone())
+    };
+
     // Fetch every packument in parallel via a JoinSet. Failures are surfaced
     // per-row so a single missing package doesn't sink the whole report.
+    // Deduplicated by registry name so two aliases of one package (or an
+    // alias alongside the real dep) don't fetch it twice.
     let mut set = tokio::task::JoinSet::new();
+    let mut fetching: HashSet<String> = HashSet::new();
     for dep in &roots {
+        let name = registry_name_for(dep);
+        if !fetching.insert(name.clone()) {
+            continue;
+        }
         let client = client.clone();
         let cache_dir = cache_dir.clone();
-        let name = dep.name.clone();
         set.spawn(async move {
             let result = client.fetch_packument_cached(&name, &cache_dir).await;
             (name, result)
@@ -426,8 +445,14 @@ async fn collect_rows(
     }
 
     let mut rows: Vec<Row> = Vec::new();
+    // Several deps can share one registry name, and the lookup below reads
+    // the shared entry rather than consuming it, so a failed fetch would
+    // otherwise warn once per dep.
+    let mut warned: HashSet<String> = HashSet::new();
     for dep in &roots {
-        let packument = packuments.remove(&dep.name);
+        let registry_name = registry_name_for(dep);
+        // `get`, not `remove`: several deps can share one registry name.
+        let packument = packuments.get(&registry_name);
         let current = match graph.get_package(&dep.dep_path) {
             Some(p) => p.version.clone(),
             None => "(missing)".to_string(),
@@ -435,7 +460,9 @@ async fn collect_rows(
         let packument = match packument {
             Some(Ok(p)) => p,
             Some(Err(e)) => {
-                eprintln!("warn: failed to fetch packument for {}: {e}", dep.name);
+                if warned.insert(registry_name.clone()) {
+                    eprintln!("warn: failed to fetch packument for {registry_name}: {e}");
+                }
                 continue;
             }
             None => continue,
@@ -452,7 +479,7 @@ async fn collect_rows(
         let wanted = dep
             .specifier
             .as_deref()
-            .and_then(|spec| super::max_satisfying_version(&packument, spec))
+            .and_then(|spec| super::max_satisfying_version(packument, spec))
             .unwrap_or_else(|| current.clone());
 
         let latest_known = latest.is_some();


### PR DESCRIPTION
Closes #578

The pnpm reader kept the canonical real-name entry alongside the alias-keyed clone it synthesizes for an `npm:` alias. A fresh resolve emits only the clone, so consumers walking `packages` raw disagreed with a re-resolved graph: `dedupe` reported a phantom removal every run (`--check` red forever on a byte-identical lockfile), `fetch` over-counted, `rebuild <real-name>` matched a non-installed dep. Usually hit transitively, via `glob@10` reaching `@isaacs/cliui`.

The reader now drops an alias-clone source nothing else reaches; shared targets survive, `file:` targets are excluded.

Also fixed, each blind to aliased packages: `ignored-builds`/`approve-builds` (a prerequisite here), `audit`, `outdated`.

Conformance green against real pnpm 10.15.1 and npm 11.17.0.
