### PR TITLE
fix(resolver): drop primer validators on the abbreviated packument cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,19 @@ addon:
 # The fast profile rebuilds it in a fraction of that. addon-fast builds the
 # native addon under the same profile so a single `cargo build --profile fast`
 # pass serves both.
+# Builds through scripts/rust-build.sh and symlinks to the target dir IT picked.
+# Hardcoding $(CURDIR)/target left nub-dev pointing at a stale binary: every
+# documented rebuild path (the post-merge refresh, the dev-loop) goes through the
+# wrapper, which normally writes to the SHARED dir, so nothing updated
+# ./target/fast/nub and `nub-dev` silently served whatever was built last time
+# make ran. `--print-target` re-resolves the same shared/isolated decision.
 install-dev: addon-fast qos-global
-	$(CARGO) build --profile fast
-	ln -sf $(CURDIR)/target/fast/nub $(BIN_DIR)/nub-dev
-	ln -sf $(CURDIR)/target/fast/nub $(BIN_DIR)/nubx-dev
-	@echo "Installed: $(BIN_DIR)/nub-dev -> target/fast/nub"
-	@echo "Installed: $(BIN_DIR)/nubx-dev -> target/fast/nub"
+	scripts/rust-build.sh build --profile fast
+	@t=$$(scripts/rust-build.sh --print-target); \
+	  ln -sf $$t/fast/nub $(BIN_DIR)/nub-dev; \
+	  ln -sf $$t/fast/nub $(BIN_DIR)/nubx-dev; \
+	  echo "Installed: $(BIN_DIR)/nub-dev -> $$t/fast/nub"; \
+	  echo "Installed: $(BIN_DIR)/nubx-dev -> $$t/fast/nub"
 	@echo ""
 	@nub-dev --version
 

--- a/scripts/rust-build.sh
+++ b/scripts/rust-build.sh
@@ -98,6 +98,15 @@ if [ "${NUB_BUILD_FG:-}" != "1" ] && [ "$(uname)" = "Darwin" ] \
   qos="taskpolicy -c utility"
 fi
 
+# `--print-target` resolves the target dir the SAME way a real build would and
+# prints it, so callers that must locate the artifact afterwards (make
+# install-dev symlinking nub-dev) follow the shared/isolated decision instead of
+# hardcoding a path that is only right in one of the two cases.
+if [ "${1:-}" = "--print-target" ]; then
+  printf '%s\n' "$target"
+  exit 0
+fi
+
 printf 'rust-build: %s\n  CARGO_TARGET_DIR=%s jobs=%s qos=%s\n' \
   "$why" "$target" "${CARGO_BUILD_JOBS:-default}" "${qos:-none}" >&2
 # NUB_* vars are routing input for this wrapper, not part of the command's

--- a/vendor/aube/crates/aube-resolver/src/resolve/fetch.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/fetch.rs
@@ -214,37 +214,31 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
                 });
             }
         }
+        // Deliberately seed WITHOUT the primer's ETag / Last-Modified, on
+        // BOTH cache tiers. The bundled primer is a *truncated* slice
+        // (newest `version_cap` versions) of the packument, but it carries
+        // the registry's real validators for the complete document.
+        // Writing them into a packument cache would let a later range-miss
+        // refetch (driver's `NoMatch` heal) send `If-None-Match`, get a
+        // `304 Not Modified`, and resurrect the *truncated* body as if it
+        // were authoritative — so a range like `^5.1.0` against a
+        // high-churn package whose newest `version_cap` publishes are all
+        // newer (e.g. `eslint-plugin-react-hooks`, 2600+ versions) would
+        // fail to resolve a version that plainly exists. Dropping the
+        // validators forces that heal to be an honest unconditional GET.
+        // The common primer-is-sufficient path never refetches, so it is
+        // unaffected.
+        //
+        // The abbreviated tier needs this as much as the full tier: it is
+        // the one in play whenever the age gate is off or
+        // `registry-supports-time-field` is set, and it was seeded WITH the
+        // validators until this was fixed.
         if needs_time {
             if let Some(dir) = full_cache_dir.as_ref() {
-                // Deliberately seed WITHOUT the primer's ETag /
-                // Last-Modified. The bundled primer is a *truncated*
-                // slice (newest `version_cap` versions) of the full
-                // packument, but it carries the registry's real
-                // validators for the complete document. Writing them
-                // into the full-packument cache would let a later
-                // range-miss refetch (driver's `NoMatch` heal under
-                // `minimumReleaseAge`) send `If-None-Match`, get a
-                // `304 Not Modified`, and resurrect the *truncated*
-                // body as if it were authoritative — so a range like
-                // `^5.1.0` against a high-churn package whose newest
-                // `version_cap` publishes are all newer (e.g.
-                // `eslint-plugin-react-hooks`, 2600+ versions) would
-                // fail to resolve a version that plainly exists.
-                // Dropping the validators forces that heal to be an
-                // honest unconditional full GET. The common
-                // primer-is-sufficient path never refetches, so it is
-                // unaffected.
                 client.seed_full_packument_cache(&name, dir, &packument, None, None, false);
             }
         } else if let Some(dir) = cache_dir.as_ref() {
-            client.seed_packument_cache(
-                &name,
-                dir,
-                &packument,
-                seed.etag.as_deref(),
-                seed.last_modified.as_deref(),
-                false,
-            );
+            client.seed_packument_cache(&name, dir, &packument, None, None, false);
         }
         aube_util::diag::instant_lazy(
             aube_util::diag::Category::Resolver,

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -2250,6 +2250,134 @@ async fn primer_range_miss_heals_past_a_304_on_the_seeded_full_cache() {
     let _ = std::fs::remove_dir_all(base);
 }
 
+/// The ABBREVIATED tier needs the same validator-dropping as the full tier
+/// above. It is the tier in play whenever `needs_time` is false — no
+/// `minimumReleaseAge`, no `NoDowngrade`, or `registry-supports-time-field`
+/// set — and it was seeded WITH the primer's ETag until this was fixed.
+///
+/// The seed writes `fresh: false`, so the entry is stale immediately and the
+/// NEXT resolve revalidates it. Carrying the primer's validators makes that
+/// revalidation conditional, the registry answers `304`, and the *truncated*
+/// primer body is resurrected as authoritative — and because a disk-cache hit
+/// is not flagged primer-seeded, the driver's range-miss heal never fires, so
+/// a version the registry plainly has fails with `ERR_AUBE_NO_MATCHING_VERSION`.
+/// Two resolves against one cache dir is what reproduces it.
+#[tokio::test]
+async fn primer_seeded_abbreviated_cache_does_not_strand_a_range_miss_behind_a_304() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // A primer entry with a DEPENDENCY-FREE version: the mock registry below
+    // serves one synthetic body, so any transitive edge would resolve against
+    // a packument that cannot satisfy it and fail pass 1 for unrelated reasons.
+    let Some((name, primer_version)) = crate::primer::names().find_map(|n| {
+        let packument = crate::primer::get(n)?.packument();
+        let (version, _) = packument.versions.iter().find(|(_, meta)| {
+            meta.dependencies.is_empty()
+                && meta.optional_dependencies.is_empty()
+                && meta.peer_dependencies.is_empty()
+        })?;
+        Some((n.to_string(), version.clone()))
+    }) else {
+        return;
+    };
+    let healed_version = "99999.0.0";
+    let live = make_packument(&name, &[healed_version], healed_version);
+    let live_body = serde_json::to_vec(&live).unwrap();
+
+    let conditional_hits = Arc::new(AtomicUsize::new(0));
+    let conditional_seen = conditional_hits.clone();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            let live_body = live_body.clone();
+            let conditional_seen = conditional_seen.clone();
+            tokio::spawn(async move {
+                let mut buf = vec![0_u8; 8192];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]).to_lowercase();
+                if req.contains("if-none-match:") || req.contains("if-modified-since:") {
+                    conditional_seen.fetch_add(1, Ordering::Relaxed);
+                    let response = "HTTP/1.1 304 Not Modified\r\netag: \"primer\"\r\nconnection: close\r\n\r\n";
+                    let _ = socket.write_all(response.as_bytes()).await;
+                } else {
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\netag: \"live\"\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                        live_body.len()
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.write_all(&live_body).await;
+                }
+            });
+        }
+    });
+
+    let base = std::env::temp_dir().join(format!(
+        "aube-resolver-primer-abbrev-304-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let cache_dir = base.join("packuments");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+
+    // Pass 1 must be SATISFIED BY THE PRIMER: a range miss or a live-edge
+    // freshness refetch both heal by REPLACING the cache with the live body,
+    // which would repair the very state pass 2 needs to exercise.
+    //
+    // Pass 1: served from the primer, which seeds the abbreviated cache.
+    {
+        let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+        let mut resolver = Resolver::new(client)
+            .with_packument_cache(cache_dir.clone())
+            .with_registry_supports_time_field(true)
+            .with_force_metadata_primer(true);
+        let mut manifest = PackageJson::default();
+        manifest
+            .dependencies
+            .insert(name.clone(), format!("={primer_version}"));
+        resolver
+            .resolve(&manifest, None)
+            .await
+            .expect("pass 1 should resolve straight from the primer");
+    }
+
+    // Pass 2: the seeded entry is stale (`fresh: false`), so it revalidates.
+    // With the primer's validators attached that revalidation is conditional,
+    // the registry 304s, and the truncated body comes back as authoritative —
+    // and a disk hit is not primer-seeded, so no heal rescues it.
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let mut resolver = Resolver::new(client)
+        .with_packument_cache(cache_dir.clone())
+        .with_registry_supports_time_field(true)
+        .with_force_metadata_primer(true);
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert(name.clone(), format!("={healed_version}"));
+    let graph = resolver.resolve(&manifest, None).await.unwrap_or_else(|e| {
+        panic!(
+            "pass 2 failed to resolve {name}@{healed_version}: {e} — the seeded \
+             abbreviated cache was resurrected behind a 304 ({} conditional \
+             request(s) seen)",
+            conditional_hits.load(Ordering::Relaxed)
+        )
+    });
+    assert!(
+        graph_has_package(&graph, &name, healed_version),
+        "pass 2 did not resolve {name}@{healed_version}"
+    );
+
+    server.abort();
+    let _ = std::fs::remove_dir_all(base);
+}
+
 /// Regression: when both `minimumReleaseAge` and `trustPolicy=NoDowngrade`
 /// are active, the resolver must use a full packument with `time`;
 /// using an abbreviated corgi packument would make the trust check fail


### PR DESCRIPTION
Two independent fixes, both found while investigating #580.

## Primer validators on the abbreviated packument cache

The bundled primer is a truncated slice of a packument (newest `version_cap` versions) but carries the registry's real validators for the *complete* document. The full cache tier deliberately drops them so a later range-miss refetch is an honest unconditional GET. The abbreviated tier still wrote them, so a revalidation of that entry is conditional, the registry answers `304`, and the truncated body is restored as authoritative — and because a disk-cache hit is not flagged primer-seeded, the driver's range-miss heal never fires. A version the registry plainly serves then fails with `ERR_AUBE_NO_MATCHING_VERSION`.

The abbreviated tier is in play whenever `needs_time` is false, which is where `registry-supports-time-field=true` lands. The regression test pins that configuration, drives two resolves against one cache dir, and fails without the fix — the failure reports the conditional request and the 304 that caused it.

## Stale `nub-dev` symlink

`make install-dev` hardcoded `$(CURDIR)/target` for the `nub-dev` / `nubx-dev` symlinks, but every documented rebuild path goes through `scripts/rust-build.sh`, which normally writes to the shared target dir. Nothing refreshed `./target/fast/nub`, so `nub-dev` kept serving whatever was built the last time `make` ran — days stale, and it made a merged fix look broken during #580.

`rust-build.sh` gains `--print-target`, which re-resolves the same shared/isolated decision a real build makes, and `install-dev` symlinks to that. Verified in both modes: shared for a clean tree, isolated for a worktree that diverges a depended-on crate.

## Verification

- New test fails without the cache fix, passes with it.
- `aube-resolver`: 291 passed, 0 failed.
- `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings`: clean.

Refs #580
