### PR TITLE
fix(linker): reclaim an incumbent node_modules tree on Windows

### DIFF
--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -1862,7 +1862,10 @@ impl Linker {
 /// symlink, Windows normalizes to an absolute path before calling
 /// `junction::create`. A plain `read_link == expected` check that
 /// works on Unix would miss every warm run on Windows.
-fn reconcile_top_level_link(link_path: &Path, expected_target: &Path) -> Result<bool, Error> {
+pub(crate) fn reconcile_top_level_link(
+    link_path: &Path,
+    expected_target: &Path,
+) -> Result<bool, Error> {
     #[cfg(windows)]
     {
         // NTFS junctions store normalized absolute targets
@@ -1916,8 +1919,26 @@ fn reconcile_top_level_link(link_path: &Path, expected_target: &Path) -> Result<
         // mid-scan. Failure here is FATAL to the install (the `Err` arm below),
         // so an unretried sharing violation aborts a whole reinstall over a
         // handle that would have cleared in milliseconds.
+        //
+        // A POPULATED REAL directory is neither of those two shapes:
+        // `remove_dir` answers `ERROR_DIR_NOT_EMPTY` and `remove_file` then
+        // answers `ERROR_ACCESS_DENIED`. That is os 5, which
+        // `is_transient_fs_error` counts as transient, so the pair burns the
+        // whole ~10s ladder and then fails the install — on any project whose
+        // `node_modules` an incumbent npm or yarn wrote. Reclaiming that tree
+        // is the linker's job, and the Unix branch below has always recursed
+        // for it. Gating on `is_real_dir` keeps the recursion aimed at exactly
+        // that shape and away from a junction, whose target must survive.
         let removed = crate::sweep::with_transient_retry(|| {
-            std::fs::remove_dir(link_path).or_else(|_| std::fs::remove_file(link_path))
+            std::fs::remove_dir(link_path)
+                .or_else(|e| {
+                    if aube_util::fs::is_real_dir(link_path) {
+                        std::fs::remove_dir_all(link_path)
+                    } else {
+                        Err(e)
+                    }
+                })
+                .or_else(|_| std::fs::remove_file(link_path))
         });
         match removed {
             Ok(()) => Ok(false),

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -2343,6 +2343,72 @@ fn is_real_dir_distinguishes_a_plain_dir_from_a_dir_shaped_link() {
     assert!(!aube_util::fs::is_real_dir(&tmp.path().join("missing")));
 }
 
+// `node_modules/<name>` written by an incumbent npm or yarn is a POPULATED
+// REAL directory, and reclaiming that slot is the linker's job — unlike the
+// generic-helper case below, this caller OWNS the entry. On Windows
+// `remove_dir` cannot evict one and the `remove_file` fallback answers os 5,
+// which the retry ladder reads as transient, so `nub install` over an npm
+// tree burned ~10s and then aborted with a bare `Access is denied`.
+// Reproduced on 0.6.0 and canary.
+//
+// NOTE: on Unix this exercises the `cfg(not(windows))` branch, which has
+// always recursed — so it passes with or without the fix here. Its value is
+// the windows-latest leg of `aube-parity`; do not read a local green as
+// evidence the fix works.
+#[test]
+fn reconcile_top_level_link_reclaims_an_incumbent_package_manager_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store_pkg = tmp.path().join("store/express");
+    std::fs::create_dir_all(&store_pkg).unwrap();
+    std::fs::write(store_pkg.join("index.js"), b"//ours").unwrap();
+
+    // What `npm install` leaves behind: a real directory holding real files.
+    let link_path = tmp.path().join("node_modules/express");
+    std::fs::create_dir_all(link_path.join("lib")).unwrap();
+    std::fs::write(link_path.join("package.json"), b"{}").unwrap();
+
+    assert!(
+        !crate::link::reconcile_top_level_link(&link_path, &store_pkg).unwrap(),
+        "an incumbent tree must be reclaimed, not reported as already correct"
+    );
+    assert!(
+        link_path.symlink_metadata().is_err(),
+        "incumbent tree survived, so the create_dir_link that follows would collide"
+    );
+
+    // The slot is free and the real link lands in it.
+    sys::create_dir_link(&store_pkg, &link_path).unwrap();
+    assert_eq!(
+        std::fs::read(link_path.join("index.js")).unwrap(),
+        b"//ours"
+    );
+}
+
+// A junction is the other shape reaching that removal, and its TARGET must
+// survive being unlinked — the recursion is gated on `is_real_dir` precisely
+// so it cannot follow one.
+#[test]
+fn reconcile_top_level_link_unlinks_a_stale_link_without_touching_its_target() {
+    let tmp = tempfile::tempdir().unwrap();
+    let old_target = tmp.path().join("store/old");
+    std::fs::create_dir_all(&old_target).unwrap();
+    std::fs::write(old_target.join("keep.js"), b"keep").unwrap();
+    let new_target = tmp.path().join("store/new");
+    std::fs::create_dir_all(&new_target).unwrap();
+
+    let link_path = tmp.path().join("node_modules/pkg");
+    std::fs::create_dir_all(link_path.parent().unwrap()).unwrap();
+    sys::create_dir_link(&old_target, &link_path).unwrap();
+
+    assert!(!crate::link::reconcile_top_level_link(&link_path, &new_target).unwrap());
+    assert!(link_path.symlink_metadata().is_err(), "link not reclaimed");
+    assert_eq!(
+        std::fs::read(old_target.join("keep.js")).unwrap(),
+        b"keep",
+        "reclaiming the link recursed through it and destroyed the old target"
+    );
+}
+
 // `create_dir_link` is the last writer before the install aborts, so it
 // carries its own clear-and-retry for a leftover link in the slot. The
 // restraint is deliberate and load-bearing: a POPULATED directory is a


### PR DESCRIPTION
`nub install` aborted on Windows in any project whose `node_modules` npm or yarn had already written:

```
failed to link node_modules
I/O error at D:\proj\node_modules\express: Access is denied. (os error 5)
```

`reconcile_top_level_link` clears a stale top-level entry with `remove_dir` falling back to `remove_file`. Those cover a junction and a plain file, but an incumbent package manager leaves a populated real directory, which is neither — `remove_dir` answers `ERROR_DIR_NOT_EMPTY`, `remove_file` then answers `ERROR_ACCESS_DENIED`. That is os 5, which `is_transient_fs_error` counts as transient, so it also burns the full ~10s retry ladder first.

Reclaiming that tree is the linker's job, and the Unix branch has always recursed for it — which is why this is Windows-only. The recursion is gated on `is_real_dir` so it reaches that shape and never a junction, whose target must survive, and it sits inside the existing ladder rather than adding a second.

Reproduced on 0.6.0 and canary on a windows-latest runner.

Note the incumbent-tree test exercises the `cfg(not(windows))` branch on Unix, where it passes either way; the windows leg of `aube-parity` is what makes it meaningful. The test says so in place.
