### PR TITLE
fix(linker): stop wiping unchanged packages on every hoisted relink

### DIFF
--- a/vendor/aube/crates/aube-linker/src/builder.rs
+++ b/vendor/aube/crates/aube-linker/src/builder.rs
@@ -44,7 +44,22 @@ impl Linker {
             no_integrity_read_keys: std::collections::BTreeMap::new(),
             link_progress: None,
             disk_materialize: std::collections::HashSet::new(),
+            reusable_hoisted: std::collections::HashSet::new(),
         }
+    }
+
+    /// Vouch that these dep paths are already correctly and completely placed
+    /// on disk, letting the hoisted pass skip its wipe-and-refill for them.
+    ///
+    /// The caller owns this judgement (see the field docs on [`Linker`]): it
+    /// has to combine an unchanged content fingerprint with proof that the
+    /// last link ran to completion. Vouching for a dep path whose tree is
+    /// actually partial would leave that package permanently broken, so the
+    /// driver errs toward not vouching. Standalone aube never calls this, so
+    /// the set stays empty and the hoisted pass is unchanged.
+    pub fn with_reusable_hoisted(mut self, dep_paths: std::collections::HashSet<String>) -> Self {
+        self.reusable_hoisted = dep_paths;
+        self
     }
 
     /// Force a set of packages to materialize as real project-local directories

--- a/vendor/aube/crates/aube-linker/src/hoisted.rs
+++ b/vendor/aube/crates/aube-linker/src/hoisted.rs
@@ -751,6 +751,29 @@ fn materialize_hoisted_node(
         });
     }
 
+    // Reuse an intact placement instead of wiping and refilling it.
+    //
+    // The wipe below is unconditional today, so every relink destroys and
+    // restores each package — including packages nothing touched. That is
+    // what deletes postinstall build output (`build/Release/*.node`, a
+    // downloaded binary), because the refill restores the published tarball
+    // and nothing else. npm and pnpm — including pnpm's own hoisted layout —
+    // leave an unchanged package directory alone, and this brings the hoisted
+    // linker in line.
+    //
+    // `reusable` is the caller's vouch, and it is deliberately NOT derived
+    // from what is on disk: the install driver only vouches for a package
+    // whose content fingerprint is unchanged AND whose tree was left intact
+    // by a link that ran to completion. Disk shape alone cannot tell a
+    // complete directory from one an interrupted install abandoned halfway.
+    if linker.reusable_hoisted.contains(dep_path) && pkg_dir.join("package.json").is_file() {
+        stats.packages_cached += 1;
+        return Ok(NodeOutcome {
+            stats,
+            placement: Some((dep_path.to_string(), pkg_dir)),
+        });
+    }
+
     // Registry (or `file:`) package — needs a PackageIndex to find the
     // store-backed file set. `package_indices` is sparse on warm
     // installs, so lazy-load from the store on miss. `registry_name()`
@@ -987,6 +1010,11 @@ pub(crate) fn materialize_plan(
             let outcome = result?;
             stats.files_linked += outcome.stats.files_linked;
             stats.packages_linked += outcome.stats.packages_linked;
+            // Reused placements land here. Dropping this made a relink that
+            // reused EVERY package report zero work of any kind, which trips
+            // the driver's "no packages were linked" sanity check — a `remove`
+            // that legitimately had nothing to materialize failed the install.
+            stats.packages_cached += outcome.stats.packages_cached;
             if let Some((dep_path, pkg_dir)) = outcome.placement {
                 placements.record(&dep_path, pkg_dir);
             }

--- a/vendor/aube/crates/aube-linker/src/lib.rs
+++ b/vendor/aube/crates/aube-linker/src/lib.rs
@@ -37,9 +37,9 @@ pub(crate) use materialize::{
     invalidate_stale_index_for_package, validate_index_key, validate_package_link_name,
 };
 pub use patches::Patches;
-pub use quarantine::strip_quarantine_from_tree;
 pub(crate) use patches::apply_multi_file_patch;
 pub use pool::default_linker_parallelism;
+pub use quarantine::strip_quarantine_from_tree;
 pub use sweep::{is_physical_importer, mkdirp, remove_dir_all_with_retry, sweep_stale_tmp_dirs};
 pub(crate) use sweep::{sweep_stale_top_level_entries, try_remove_entry};
 pub use sys::{
@@ -279,6 +279,16 @@ pub struct Linker {
     /// `.aube/node_modules/`, a blanket alias for every graph package. That
     /// replaced the former per-importer phantom-target hoist.
     disk_materialize: std::collections::HashSet<String>,
+    /// Dep paths the CALLER vouches are already correctly placed on disk, so
+    /// the hoisted pass may leave their directories alone instead of wiping
+    /// and refilling them.
+    ///
+    /// The vouch has to come from the driver, not from this crate: the only
+    /// trustworthy answer combines the package's content fingerprint against
+    /// the last install's with proof that the last link ran to completion,
+    /// and the linker sees neither. Empty for standalone callers and every
+    /// existing test → the hoisted pass is byte-for-byte unchanged.
+    reusable_hoisted: std::collections::HashSet<String>,
 }
 
 /// Strategy for linking files from the store to node_modules.

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -43,6 +43,7 @@ impl Linker {
             no_integrity_read_keys: self.no_integrity_read_keys.clone(),
             link_progress: self.link_progress.clone(),
             disk_materialize: self.disk_materialize.clone(),
+            reusable_hoisted: self.reusable_hoisted.clone(),
         }
     }
 

--- a/vendor/aube/crates/aube/src/commands/add/manifest.rs
+++ b/vendor/aube/crates/aube/src/commands/add/manifest.rs
@@ -661,7 +661,9 @@ pub(super) async fn update_manifest_for_add(
     let catalog_target = if catalog_upserts.is_empty() {
         None
     } else {
-        Some(crate::commands::catalogs::resolve_catalog_write_target(cwd)?)
+        Some(crate::commands::catalogs::resolve_catalog_write_target(
+            cwd,
+        )?)
     };
 
     // Write the updated package.json. Under `--no-save` callers still

--- a/vendor/aube/crates/aube/src/commands/catalogs.rs
+++ b/vendor/aube/crates/aube/src/commands/catalogs.rs
@@ -331,7 +331,10 @@ pub(crate) fn resolve_catalog_write_target(cwd: &Path) -> miette::Result<Catalog
     // key. Reject up front so the pre-flight fails before any manifest
     // mutation rather than half-way through.
     let manifest = crate::commands::load_manifest(&manifest_path)?;
-    if matches!(manifest.workspaces, Some(aube_manifest::Workspaces::String(_))) {
+    if matches!(
+        manifest.workspaces,
+        Some(aube_manifest::Workspaces::String(_))
+    ) {
         return Err(miette::miette!(
             "cannot save to a catalog: package.json#workspaces is a bare string; \
              convert it to an array or object form to hold a `workspaces.catalog`"
@@ -740,7 +743,10 @@ catalog:
     #[test]
     fn manifest_upsert_adds_default_catalog_preserving_packages() {
         let dir = tempfile::tempdir().unwrap();
-        let path = write_pkg(dir.path(), r#"{"name":"root","workspaces":{"packages":["apps/*"]}}"#);
+        let path = write_pkg(
+            dir.path(),
+            r#"{"name":"root","workspaces":{"packages":["apps/*"]}}"#,
+        );
         upsert_catalog_entries_in_manifest(&path, &[upsert("default", "@types/node", "^26.1.0")])
             .unwrap();
         let v: serde_json::Value =
@@ -785,6 +791,9 @@ catalog:
             .unwrap();
         let v: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(v["workspaces"]["catalogs"]["types"]["@types/node"], "^26.1.0");
+        assert_eq!(
+            v["workspaces"]["catalogs"]["types"]["@types/node"],
+            "^26.1.0"
+        );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/config/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/config/mod.rs
@@ -119,8 +119,8 @@ pub(crate) use aube_config::{
     load_user_entries as load_user_aube_config_entries,
 };
 pub(crate) use get_cmd::GetArgs;
-pub use set_cmd::set_project_scalar_to_workspace_yaml;
 pub(crate) use set_cmd::SetArgs;
+pub use set_cmd::set_project_scalar_to_workspace_yaml;
 
 impl Location {
     pub(super) fn path(self) -> miette::Result<PathBuf> {

--- a/vendor/aube/crates/aube/src/commands/dedupe.rs
+++ b/vendor/aube/crates/aube/src/commands/dedupe.rs
@@ -143,9 +143,7 @@ fn diff_graphs(
     existing: Option<&aube_lockfile::LockfileGraph>,
     new: &aube_lockfile::LockfileGraph,
 ) -> (Vec<String>, Vec<String>) {
-    fn serialized_keys(
-        pkgs: &BTreeMap<String, aube_lockfile::LockedPackage>,
-    ) -> BTreeSet<&String> {
+    fn serialized_keys(pkgs: &BTreeMap<String, aube_lockfile::LockedPackage>) -> BTreeSet<&String> {
         use aube_lockfile::LocalSource;
         pkgs.iter()
             .filter(|(_, pkg)| {

--- a/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
+++ b/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
@@ -489,8 +489,7 @@ pub(crate) fn link_all_bins(input: LinkAllBinsInput<'_>) -> miette::Result<()> {
             // Workspace member's own `bin` (discussion #228). `manifests`
             // was parsed once upstream and keys by importer relpath. See
             // the root self-bin call site for why this forces a POSIX shim.
-            if let Some((_, member_manifest)) =
-                manifests.iter().find(|(p, _)| p == importer_path)
+            if let Some((_, member_manifest)) = manifests.iter().find(|(p, _)| p == importer_path)
                 && let Some(bin) = member_manifest.extra.get("bin")
             {
                 let self_shim_opts = aube_linker::BinShimOptions {

--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -95,30 +95,18 @@ fn lifecycle_delta_filter(
     default_trust_floor: &super::default_trust::DefaultTrustFloor,
     dep_build_policy_hash: &str,
     virtual_store_only: bool,
-    node_linker: aube_linker::NodeLinker,
 ) -> Option<BTreeSet<String>> {
     if virtual_store_only {
         return None;
     }
     // The filter's premise is "content hash unchanged ⇒ this package still has
-    // whatever its build left behind". That holds only for a layout that LEAVES
-    // an unchanged package directory alone.
-    //
-    // Hoisted does not. Its materialize wipes and refills every placed package
-    // on every relink (`aube-linker/src/hoisted.rs`), and the refill comes from
-    // the store index — published tarball contents, not `build/Release/*.node`,
-    // not a downloaded binary, not anything a postinstall produced. A package
-    // excluded here has therefore had its build output deleted and gets neither
-    // a rebuild nor a side-effects-cache restore, because the exclusion happens
-    // before a build job (and so before the restore) exists at all.
-    //
-    // Falling back to the full scan puts every package back on the restore
-    // path, which is a cheap cache hit when the side-effects cache is on and a
-    // real rebuild only when there is genuinely nothing to restore from.
-    if matches!(node_linker, aube_linker::NodeLinker::Hoisted) {
-        tracing::debug!("delta: hoisted layout refills package dirs; running full eligible scan");
-        return None;
-    }
+    // whatever its build left behind". That premise is upheld on the linker
+    // side: the hoisted pass reuses a placement whenever the driver can prove
+    // the fingerprint is unchanged AND the previous link completed (see
+    // `reusable_hoisted_dep_paths`), and anything it cannot prove gets wiped
+    // and refilled — which also moves that package's fingerprint, so it lands
+    // in `selected` here and is rebuilt. The two halves have to stay in step;
+    // loosening either one silently deletes build output (nubjs/nub#610).
     let prior_policy_hash = state::read_state_dep_build_policy_hash(cwd)?;
     if prior_policy_hash != dep_build_policy_hash {
         tracing::debug!("delta: dep build policy changed; running full eligible build scan");
@@ -274,7 +262,6 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             default_trust_floor,
             &dep_build_policy_hash,
             virtual_store_only,
-            node_linker,
         )
     };
 
@@ -574,6 +561,13 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         .wrap_err("failed to write install state")?;
         phase_timings.record("state", phase_start.elapsed());
     }
+
+    // The tree now matches the state just written, so the next hoisted
+    // install may reuse placements. Deliberately after the state write: if
+    // that failed we bailed above and the sentinel stays, which costs a
+    // wipe-and-refill next time rather than trusting a tree we cannot
+    // describe.
+    state::clear_link_in_progress(cwd);
 
     // 8a. Sweep orphaned `.aube/<dep_path>` entries older than
     //     `modulesCacheMaxAge`. The "in use" set is built from the

--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -95,8 +95,28 @@ fn lifecycle_delta_filter(
     default_trust_floor: &super::default_trust::DefaultTrustFloor,
     dep_build_policy_hash: &str,
     virtual_store_only: bool,
+    node_linker: aube_linker::NodeLinker,
 ) -> Option<BTreeSet<String>> {
     if virtual_store_only {
+        return None;
+    }
+    // The filter's premise is "content hash unchanged ⇒ this package still has
+    // whatever its build left behind". That holds only for a layout that LEAVES
+    // an unchanged package directory alone.
+    //
+    // Hoisted does not. Its materialize wipes and refills every placed package
+    // on every relink (`aube-linker/src/hoisted.rs`), and the refill comes from
+    // the store index — published tarball contents, not `build/Release/*.node`,
+    // not a downloaded binary, not anything a postinstall produced. A package
+    // excluded here has therefore had its build output deleted and gets neither
+    // a rebuild nor a side-effects-cache restore, because the exclusion happens
+    // before a build job (and so before the restore) exists at all.
+    //
+    // Falling back to the full scan puts every package back on the restore
+    // path, which is a cheap cache hit when the side-effects cache is on and a
+    // real rebuild only when there is genuinely nothing to restore from.
+    if matches!(node_linker, aube_linker::NodeLinker::Hoisted) {
+        tracing::debug!("delta: hoisted layout refills package dirs; running full eligible scan");
         return None;
     }
     let prior_policy_hash = state::read_state_dep_build_policy_hash(cwd)?;
@@ -254,6 +274,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             default_trust_floor,
             &dep_build_policy_hash,
             virtual_store_only,
+            node_linker,
         )
     };
 

--- a/vendor/aube/crates/aube/src/commands/install/link.rs
+++ b/vendor/aube/crates/aube/src/commands/install/link.rs
@@ -93,6 +93,40 @@ pub(super) struct LinkPhaseOutput {
     pub(super) patch_hashes: BTreeMap<String, String>,
 }
 
+/// Dep paths whose hoisted placement can be left in place rather than wiped
+/// and refilled. See the call site for why each condition is load-bearing.
+///
+/// Returns empty on any doubt — a missing state file, a layout switch, an
+/// interrupted previous link — which degrades exactly to the unconditional
+/// wipe this replaces.
+fn reusable_hoisted_dep_paths(
+    cwd: &std::path::Path,
+    graph: &aube_lockfile::LockfileGraph,
+    patch_hashes: &BTreeMap<String, String>,
+) -> std::collections::HashSet<String> {
+    use crate::state::InstallLayoutMode;
+
+    if !crate::state::link_completed_cleanly(cwd) {
+        tracing::debug!("hoisted: previous link did not complete; refusing to reuse placements");
+        return Default::default();
+    }
+    if !matches!(
+        crate::state::read_state_layout_linker(cwd),
+        Some(InstallLayoutMode::Hoisted)
+    ) {
+        return Default::default();
+    }
+    let Some(prior) = crate::state::read_state_package_content_hashes(cwd) else {
+        return Default::default();
+    };
+    let (current, _) = super::delta::compute_leaf_and_subtree_hashes(graph, patch_hashes, cwd);
+    current
+        .into_iter()
+        .filter(|(dep_path, hash)| prior.get(dep_path) == Some(hash))
+        .map(|(dep_path, _)| dep_path)
+        .collect()
+}
+
 pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPhaseOutput> {
     let LinkPhaseInput {
         cwd,
@@ -368,6 +402,40 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     if !patches_for_linker.is_empty() {
         linker = linker.with_patches(patches_for_linker);
     }
+
+    // Hoisted relinks used to wipe and refill EVERY placed package, which
+    // deletes whatever a postinstall left behind (`build/Release/*.node`, a
+    // downloaded binary) because the refill restores published tarball
+    // contents and nothing else. Vouch for the packages that provably do not
+    // need touching so the linker can leave them alone, matching what npm and
+    // pnpm already do.
+    //
+    // Three conditions, and all three are needed:
+    //   * the last link ran to COMPLETION — the install state is written at
+    //     the end of a successful install but survives a later one that died
+    //     partway, so state alone would happily vouch for a half-written tree;
+    //   * the last install used the SAME layout, since an isolated tree's
+    //     directories are not where the hoisted pass expects them;
+    //   * the package's content fingerprint is UNCHANGED, so the bytes a
+    //     refill would write are the bytes already there.
+    // Any doubt and the dep path is simply left out, which is exactly today's
+    // wipe-and-refill.
+    //
+    // Only computed for hoisted, so the isolated default pays nothing.
+    if matches!(node_linker, aube_linker::NodeLinker::Hoisted) {
+        let reusable = reusable_hoisted_dep_paths(cwd, graph_for_link, &patch_hashes);
+        tracing::debug!(
+            "hoisted: reusing {} of {} placements (rest wiped + refilled)",
+            reusable.len(),
+            graph_for_link.packages.len()
+        );
+        linker = linker.with_reusable_hoisted(reusable);
+    }
+
+    // From here until the install finishes, the tree on disk is not
+    // trustworthy. Cleared in `finalize`.
+    crate::state::mark_link_in_progress(cwd);
+
     let stats = if has_workspace {
         linker
             .link_workspace(cwd, graph_for_link, package_indices, ws_dirs)

--- a/vendor/aube/crates/aube/src/commands/install/resolve.rs
+++ b/vendor/aube/crates/aube/src/commands/install/resolve.rs
@@ -454,7 +454,10 @@ pub(super) struct SelectLockfileInput<'a> {
 /// packageExtensions drift, gated on the embedder posture. Returns `Fresh`
 /// when the embedder doesn't enforce the checksum (standalone aube), so the
 /// check is a nub-only layer that never fires on aube's default path.
-fn package_extensions_drift(graph: &LockfileGraph, effective_checksum: Option<&str>) -> DriftStatus {
+fn package_extensions_drift(
+    graph: &LockfileGraph,
+    effective_checksum: Option<&str>,
+) -> DriftStatus {
     if aube_util::engine_context().enforce_package_extensions_checksum {
         graph.check_package_extensions_drift(effective_checksum)
     } else {

--- a/vendor/aube/crates/aube/src/patches.rs
+++ b/vendor/aube/crates/aube/src/patches.rs
@@ -308,7 +308,11 @@ pub fn upsert_patched_dependency(cwd: &Path, key: &str, rel_patch_path: &str) ->
             // Standalone aube (reads pnpm config): nest under `pnpm` so real
             // pnpm accepts the lockfile. An embedder that ignores pnpm config:
             // write the un-branded top-level field it actually reads.
-            let namespace = if reads_branded_pnpm { Some("pnpm") } else { None };
+            let namespace = if reads_branded_pnpm {
+                Some("pnpm")
+            } else {
+                None
+            };
             upsert_manifest_patched_dependency(cwd, key, rel_patch_path, namespace)
                 .wrap_err("failed to write package.json")?;
             return Ok(cwd.join("package.json"));

--- a/vendor/aube/crates/aube/src/progress/ci.rs
+++ b/vendor/aube/crates/aube/src/progress/ci.rs
@@ -225,54 +225,54 @@ impl CiState {
         let spawned = thread::Builder::new()
             .name("aube-ci-heartbeat".into())
             .spawn(move || {
-            let state = thread_state;
-            loop {
-                let guard = state.wake_lock.lock().unwrap();
-                // Re-check `done` *before* sleeping. `stop()` sets `done`
-                // and then `notify_all()`s without holding `wake_lock`, so
-                // a notification that races with the tick body would
-                // otherwise be lost and the thread would sleep a full
-                // `CI_HEARTBEAT_INTERVAL` before noticing shutdown.
-                if state.done.load(Ordering::Relaxed) {
-                    break;
+                let state = thread_state;
+                loop {
+                    let guard = state.wake_lock.lock().unwrap();
+                    // Re-check `done` *before* sleeping. `stop()` sets `done`
+                    // and then `notify_all()`s without holding `wake_lock`, so
+                    // a notification that races with the tick body would
+                    // otherwise be lost and the thread would sleep a full
+                    // `CI_HEARTBEAT_INTERVAL` before noticing shutdown.
+                    if state.done.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let (guard, _timeout) = state
+                        .wake
+                        .wait_timeout(guard, CI_HEARTBEAT_INTERVAL)
+                        .unwrap();
+                    drop(guard);
+                    if state.done.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let snap = state.snapshot();
+                    // Don't make noise until an install is actually underway.
+                    // Until then there's nothing to bar-graph and no reason to
+                    // print anything — a no-op install should remain
+                    // completely silent.
+                    if snap.resolved == 0 || snap.phase == 0 {
+                        continue;
+                    }
+                    let line = Self::render(snap);
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let mut last = state.last_printed.lock().unwrap();
+                    if *last == line {
+                        // Same rendered line as before — stay quiet.
+                        continue;
+                    }
+                    *last = line.clone();
+                    drop(last);
+                    // First time we actually print, emit the unframed
+                    // `aube VERSION by jdx.dev` header above the bar so
+                    // the CI log shows the aube banner. Only printed
+                    // once per install — `shown` flips true here.
+                    if !state.shown.swap(true, Ordering::Relaxed) {
+                        let _ = writeln!(std::io::stderr(), "{}", Self::render_header());
+                    }
+                    let _ = writeln!(std::io::stderr(), "{line}");
                 }
-                let (guard, _timeout) = state
-                    .wake
-                    .wait_timeout(guard, CI_HEARTBEAT_INTERVAL)
-                    .unwrap();
-                drop(guard);
-                if state.done.load(Ordering::Relaxed) {
-                    break;
-                }
-                let snap = state.snapshot();
-                // Don't make noise until an install is actually underway.
-                // Until then there's nothing to bar-graph and no reason to
-                // print anything — a no-op install should remain
-                // completely silent.
-                if snap.resolved == 0 || snap.phase == 0 {
-                    continue;
-                }
-                let line = Self::render(snap);
-                if line.is_empty() {
-                    continue;
-                }
-                let mut last = state.last_printed.lock().unwrap();
-                if *last == line {
-                    // Same rendered line as before — stay quiet.
-                    continue;
-                }
-                *last = line.clone();
-                drop(last);
-                // First time we actually print, emit the unframed
-                // `aube VERSION by jdx.dev` header above the bar so
-                // the CI log shows the aube banner. Only printed
-                // once per install — `shown` flips true here.
-                if !state.shown.swap(true, Ordering::Relaxed) {
-                    let _ = writeln!(std::io::stderr(), "{}", Self::render_header());
-                }
-                let _ = writeln!(std::io::stderr(), "{line}");
-            }
-        });
+            });
         // On spawn failure (e.g. EAGAIN under thread/PID exhaustion) leave the
         // handle `None` — the install proceeds without the cosmetic ticker.
         *state.heartbeat.lock().unwrap() = spawned.ok();

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -875,6 +875,46 @@ pub fn read_state_layout_linker(project_dir: &Path) -> Option<InstallLayoutMode>
     Some(read_state(&state_dir(project_dir))?.layout?.linker)
 }
 
+/// Name of the sentinel that marks a link phase as IN PROGRESS.
+fn link_sentinel(project_dir: &Path) -> PathBuf {
+    state_dir(project_dir).join("link-in-progress")
+}
+
+/// Mark the tree as mid-link. Called before the linker is allowed to
+/// mutate `node_modules`, and cleared only once the install finishes.
+///
+/// This exists because the install state alone cannot answer "is the tree
+/// on disk intact?". State is rewritten at the END of a successful install
+/// and removed only on `--force` / a GVS switch, so state written by a
+/// SUCCESSFUL install outlives a LATER install that died partway through
+/// relinking. Anything keying reuse on state alone would then treat a
+/// half-materialized package directory as complete — the same class of bug
+/// as nubjs/nub#552, arrived at from the other side.
+///
+/// Best-effort: a sentinel we fail to write just means the next install
+/// declines to reuse and does the full wipe-and-refill, which is exactly
+/// today's behavior. Failing the install over it would be worse.
+pub fn mark_link_in_progress(project_dir: &Path) {
+    let path = link_sentinel(project_dir);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, b"");
+}
+
+/// Clear the mid-link sentinel. Called once the install has completed and
+/// the tree is known to match the state written alongside it.
+pub fn clear_link_in_progress(project_dir: &Path) {
+    let _ = std::fs::remove_file(link_sentinel(project_dir));
+}
+
+/// Whether the last link phase ran to completion. `false` means either a
+/// link is in flight or one died partway, and in both cases nothing on
+/// disk may be reused.
+pub fn link_completed_cleanly(project_dir: &Path) -> bool {
+    !link_sentinel(project_dir).exists()
+}
+
 /// Read the unreviewed-builds spec keys recorded by the last
 /// install. Powers warm-path warning re-emission so repeat
 /// installs keep nudging users about pending build approvals.

--- a/vendor/aube/crates/aube/tests/e2e.rs
+++ b/vendor/aube/crates/aube/tests/e2e.rs
@@ -284,7 +284,10 @@ fn approve_builds_surfaces_and_runs_a_local_source_dep() {
     // `virtual_store_subdir` (the shared global store, which `file:` deps
     // never enter), never by the `aube_dir_entry_name` that
     // `materialized_pkg_dir` reconstructs.
-    sbx.cmd().args(["approve-builds", "--all"]).assert().success();
+    sbx.cmd()
+        .args(["approve-builds", "--all"])
+        .assert()
+        .success();
     assert!(
         marker_exists_under(&node_modules, "BUILT_527_MARKER"),
         "approve-builds must run a local-source dep's build in the same invocation"

--- a/vendor/aube/test/add.bats
+++ b/vendor/aube/test/add.bats
@@ -753,6 +753,7 @@ JSON
 	#
 	# The stand-in artifact is a file the tarball does not contain, which is
 	# exactly the shape of real build output.
+	echo "node-linker=hoisted" >>.npmrc
 	cat >package.json <<'JSON'
 {
   "name": "hoisted-preserve-test",
@@ -762,11 +763,11 @@ JSON
   }
 }
 JSON
-	run aube install --node-linker=hoisted
+	run aube install
 	assert_success
 	echo BUILT >node_modules/abbrev/build-artifact.txt
 
-	run aube add is-odd@3.0.1 --node-linker=hoisted
+	run aube add is-odd@3.0.1
 	assert_success
 	assert_file_exists node_modules/abbrev/build-artifact.txt
 }
@@ -777,6 +778,7 @@ JSON
 	# install finishes, because the install state alone cannot distinguish a
 	# complete tree from one a killed install abandoned halfway — state written
 	# by an earlier SUCCESSFUL install outlives a later failed one.
+	echo "node-linker=hoisted" >>.npmrc
 	cat >package.json <<'JSON'
 {
   "name": "hoisted-interrupted-test",
@@ -786,7 +788,7 @@ JSON
   }
 }
 JSON
-	run aube install --node-linker=hoisted
+	run aube install
 	assert_success
 	echo BUILT >node_modules/abbrev/build-artifact.txt
 
@@ -795,7 +797,7 @@ JSON
 	[ -n "$state_dir" ]
 	touch "$state_dir/link-in-progress"
 
-	run aube add is-odd@3.0.1 --node-linker=hoisted
+	run aube add is-odd@3.0.1
 	assert_success
 	# Wiped and refilled rather than reused, so the unverifiable tree is healed.
 	assert_file_not_exists node_modules/abbrev/build-artifact.txt

--- a/vendor/aube/test/add.bats
+++ b/vendor/aube/test/add.bats
@@ -743,3 +743,60 @@ JSON
 	[ -L node_modules/local-dep ]
 	assert_file_exists node_modules/local-dep/package.json
 }
+
+@test "hoisted add preserves an unchanged package's directory" {
+	# nubjs/nub#610. The hoisted pass used to wipe and refill EVERY placed
+	# package on every relink, and the refill restores published tarball
+	# contents — so anything a postinstall produced (build/Release/*.node, a
+	# downloaded binary) was deleted and never put back. npm and pnpm both
+	# leave an unchanged package directory alone; so does aube now.
+	#
+	# The stand-in artifact is a file the tarball does not contain, which is
+	# exactly the shape of real build output.
+	cat >package.json <<'JSON'
+{
+  "name": "hoisted-preserve-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "abbrev": "4.0.0"
+  }
+}
+JSON
+	run aube install --node-linker=hoisted
+	assert_success
+	echo BUILT >node_modules/abbrev/build-artifact.txt
+
+	run aube add is-odd@3.0.1 --node-linker=hoisted
+	assert_success
+	assert_file_exists node_modules/abbrev/build-artifact.txt
+}
+
+@test "hoisted add refuses to reuse a tree an interrupted link left behind" {
+	# The safety half of the reuse above. Reuse keys on a sentinel that is
+	# written before the linker touches node_modules and cleared only once the
+	# install finishes, because the install state alone cannot distinguish a
+	# complete tree from one a killed install abandoned halfway — state written
+	# by an earlier SUCCESSFUL install outlives a later failed one.
+	cat >package.json <<'JSON'
+{
+  "name": "hoisted-interrupted-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "abbrev": "4.0.0"
+  }
+}
+JSON
+	run aube install --node-linker=hoisted
+	assert_success
+	echo BUILT >node_modules/abbrev/build-artifact.txt
+
+	# Exactly what a link that died partway leaves on disk.
+	state_dir="$(find node_modules -maxdepth 3 -type d -name '*-state' | head -n 1)"
+	[ -n "$state_dir" ]
+	touch "$state_dir/link-in-progress"
+
+	run aube add is-odd@3.0.1 --node-linker=hoisted
+	assert_success
+	# Wiped and refilled rather than reused, so the unverifiable tree is healed.
+	assert_file_not_exists node_modules/abbrev/build-artifact.txt
+}

--- a/vendor/aube/test/allow_builds.bats
+++ b/vendor/aube/test/allow_builds.bats
@@ -100,63 +100,6 @@ JSON
 	assert_file_not_exists aube-builds-marker.txt
 }
 
-@test "hoisted add preserves an unchanged package's directory" {
-	# nubjs/nub#610. The hoisted pass used to wipe and refill EVERY placed
-	# package on every relink, and the refill restores published tarball
-	# contents — so anything a postinstall produced (build/Release/*.node, a
-	# downloaded binary) was deleted and never put back. npm and pnpm both
-	# leave an unchanged package directory alone; so does aube now.
-	#
-	# The stand-in artifact is a file the tarball does not contain, which is
-	# exactly the shape of real build output.
-	cat >package.json <<'JSON'
-{
-  "name": "hoisted-preserve-test",
-  "version": "1.0.0",
-  "dependencies": {
-    "abbrev": "4.0.0"
-  }
-}
-JSON
-	run aube install --node-linker=hoisted
-	assert_success
-	echo BUILT >node_modules/abbrev/build-artifact.txt
-
-	run aube add is-odd@3.0.1 --node-linker=hoisted
-	assert_success
-	assert_file_exists node_modules/abbrev/build-artifact.txt
-}
-
-@test "hoisted add refuses to reuse a tree an interrupted link left behind" {
-	# The safety half of the reuse above. Reuse keys on a sentinel that is
-	# written before the linker touches node_modules and cleared only once the
-	# install finishes, because the install state alone cannot distinguish a
-	# complete tree from one a killed install abandoned halfway — state written
-	# by an earlier SUCCESSFUL install outlives a later failed one.
-	cat >package.json <<'JSON'
-{
-  "name": "hoisted-interrupted-test",
-  "version": "1.0.0",
-  "dependencies": {
-    "abbrev": "4.0.0"
-  }
-}
-JSON
-	run aube install --node-linker=hoisted
-	assert_success
-	echo BUILT >node_modules/abbrev/build-artifact.txt
-
-	# Exactly what a link that died partway leaves on disk.
-	state_dir="$(find node_modules -maxdepth 3 -type d -name '*-state' | head -n 1)"
-	[ -n "$state_dir" ]
-	touch "$state_dir/link-in-progress"
-
-	run aube add is-odd@3.0.1 --node-linker=hoisted
-	assert_success
-	# Wiped and refilled rather than reused, so the unverifiable tree is healed.
-	assert_file_not_exists node_modules/abbrev/build-artifact.txt
-}
-
 @test "aube remove does not rerun unchanged allowlisted dep build scripts" {
 	disable_delta_build_caches
 	cat >package.json <<'JSON'

--- a/vendor/aube/test/allow_builds.bats
+++ b/vendor/aube/test/allow_builds.bats
@@ -100,6 +100,48 @@ JSON
 	assert_file_not_exists aube-builds-marker.txt
 }
 
+@test "aube add DOES rerun unchanged dep build scripts under node-linker=hoisted" {
+	# The inverse of the test above, and deliberately so. Skipping the rerun is
+	# correct only for a layout that leaves an unchanged package directory
+	# alone. Hoisted wipes and refills every placed package on each relink, and
+	# the refill restores published tarball contents — never build output — so
+	# skipping there deletes a package's build artifacts and never puts them
+	# back. The marker is absent after the add on the unfixed code.
+	#
+	# `disable_delta_build_caches` also turns the side-effects cache off, which
+	# is what makes this observable: with the cache on the fix restores the
+	# artifact instead of rerunning, and no marker would be written.
+	disable_delta_build_caches
+	cat >package.json <<'JSON'
+{
+  "name": "allow-builds-hoisted-delta-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "aube-test-builds-marker": "^1.0.0"
+  },
+  "pnpm": {
+    "allowBuilds": {
+      "aube-test-builds-marker": true
+    }
+  }
+}
+JSON
+	run aube install --node-linker=hoisted
+	assert_success
+	assert_file_exists aube-builds-marker.txt
+
+	# Only clear the marker — do NOT poison the installed copy the way the
+	# isolated test does. Hoisted refills the package dir from the store, so a
+	# poisoned manifest would be replaced before the script ever ran.
+	rm -f aube-builds-marker.txt
+
+	run aube add abbrev@4.0.0 --node-linker=hoisted
+	assert_success
+	assert_file_exists aube-builds-marker.txt
+	run cat aube-builds-marker.txt
+	assert_output "ran:aube-test-builds-marker@1.0.0"
+}
+
 @test "aube remove does not rerun unchanged allowlisted dep build scripts" {
 	disable_delta_build_caches
 	cat >package.json <<'JSON'

--- a/vendor/aube/test/allow_builds.bats
+++ b/vendor/aube/test/allow_builds.bats
@@ -100,46 +100,61 @@ JSON
 	assert_file_not_exists aube-builds-marker.txt
 }
 
-@test "aube add DOES rerun unchanged dep build scripts under node-linker=hoisted" {
-	# The inverse of the test above, and deliberately so. Skipping the rerun is
-	# correct only for a layout that leaves an unchanged package directory
-	# alone. Hoisted wipes and refills every placed package on each relink, and
-	# the refill restores published tarball contents — never build output — so
-	# skipping there deletes a package's build artifacts and never puts them
-	# back. The marker is absent after the add on the unfixed code.
+@test "hoisted add preserves an unchanged package's directory" {
+	# nubjs/nub#610. The hoisted pass used to wipe and refill EVERY placed
+	# package on every relink, and the refill restores published tarball
+	# contents — so anything a postinstall produced (build/Release/*.node, a
+	# downloaded binary) was deleted and never put back. npm and pnpm both
+	# leave an unchanged package directory alone; so does aube now.
 	#
-	# `disable_delta_build_caches` also turns the side-effects cache off, which
-	# is what makes this observable: with the cache on the fix restores the
-	# artifact instead of rerunning, and no marker would be written.
-	disable_delta_build_caches
+	# The stand-in artifact is a file the tarball does not contain, which is
+	# exactly the shape of real build output.
 	cat >package.json <<'JSON'
 {
-  "name": "allow-builds-hoisted-delta-test",
+  "name": "hoisted-preserve-test",
   "version": "1.0.0",
   "dependencies": {
-    "aube-test-builds-marker": "^1.0.0"
-  },
-  "pnpm": {
-    "allowBuilds": {
-      "aube-test-builds-marker": true
-    }
+    "abbrev": "4.0.0"
   }
 }
 JSON
 	run aube install --node-linker=hoisted
 	assert_success
-	assert_file_exists aube-builds-marker.txt
+	echo BUILT >node_modules/abbrev/build-artifact.txt
 
-	# Only clear the marker — do NOT poison the installed copy the way the
-	# isolated test does. Hoisted refills the package dir from the store, so a
-	# poisoned manifest would be replaced before the script ever ran.
-	rm -f aube-builds-marker.txt
-
-	run aube add abbrev@4.0.0 --node-linker=hoisted
+	run aube add is-odd@3.0.1 --node-linker=hoisted
 	assert_success
-	assert_file_exists aube-builds-marker.txt
-	run cat aube-builds-marker.txt
-	assert_output "ran:aube-test-builds-marker@1.0.0"
+	assert_file_exists node_modules/abbrev/build-artifact.txt
+}
+
+@test "hoisted add refuses to reuse a tree an interrupted link left behind" {
+	# The safety half of the reuse above. Reuse keys on a sentinel that is
+	# written before the linker touches node_modules and cleared only once the
+	# install finishes, because the install state alone cannot distinguish a
+	# complete tree from one a killed install abandoned halfway — state written
+	# by an earlier SUCCESSFUL install outlives a later failed one.
+	cat >package.json <<'JSON'
+{
+  "name": "hoisted-interrupted-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "abbrev": "4.0.0"
+  }
+}
+JSON
+	run aube install --node-linker=hoisted
+	assert_success
+	echo BUILT >node_modules/abbrev/build-artifact.txt
+
+	# Exactly what a link that died partway leaves on disk.
+	state_dir="$(find node_modules -maxdepth 3 -type d -name '*-state' | head -n 1)"
+	[ -n "$state_dir" ]
+	touch "$state_dir/link-in-progress"
+
+	run aube add is-odd@3.0.1 --node-linker=hoisted
+	assert_success
+	# Wiped and refilled rather than reused, so the unverifiable tree is healed.
+	assert_file_not_exists node_modules/abbrev/build-artifact.txt
 }
 
 @test "aube remove does not rerun unchanged allowlisted dep build scripts" {

--- a/vendor/aube/test/registry/start.bash
+++ b/vendor/aube/test/registry/start.bash
@@ -18,11 +18,48 @@ STORAGE_DIR="$REGISTRY_DIR/storage"
 CONFIG_FILE="$REGISTRY_DIR/config.yaml"
 mkdir -p "$STORAGE_DIR"
 
+# Whether whatever is listening on $1 is OUR registry, rather than merely
+# something that answers HTTP.
+#
+# "Does the port respond?" is not the same question, and getting it wrong is
+# silent: an unrelated dev server on 4873 makes `start_registry` report success
+# while every fixture lookup 404s, so the whole suite fails with "package not
+# found" and no hint that it is talking to a stranger. Probe a package the
+# committed storage is known to hold and require a real packument back.
+registry_is_ours() {
+	local port=$1 body
+	body="$(curl -s --max-time 2 "http://localhost:${port}/${REGISTRY_PROBE_PKG}" 2>/dev/null)" || return 1
+	case "$body" in
+	*'"versions"'*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+REGISTRY_PROBE_PKG="abbrev"
+
 start_registry() {
-	# Check if already running
-	if curl -s "http://localhost:${VERDACCIO_PORT}/" >/dev/null 2>&1; then
+	# Reuse a registry that is genuinely ours (a previous suite left it up).
+	if registry_is_ours "$VERDACCIO_PORT"; then
 		echo "Verdaccio already running on port $VERDACCIO_PORT" >&2
 		return 0
+	fi
+
+	# Something else owns the port. Step to a free one rather than failing or,
+	# worse, silently using it. Every caller reads the port back out of
+	# AUBE_TEST_REGISTRY, so moving is transparent.
+	if curl -s --max-time 2 "http://localhost:${VERDACCIO_PORT}/" >/dev/null 2>&1; then
+		local occupied=$VERDACCIO_PORT probe
+		for probe in $(seq $((VERDACCIO_PORT + 1)) $((VERDACCIO_PORT + 20))); do
+			if ! curl -s --max-time 1 "http://localhost:${probe}/" >/dev/null 2>&1; then
+				VERDACCIO_PORT=$probe
+				break
+			fi
+		done
+		if [ "$VERDACCIO_PORT" = "$occupied" ]; then
+			echo "ERROR: port $occupied is taken by a non-aube server and no free port found in the next 20" >&2
+			return 1
+		fi
+		echo "port $occupied is taken by a non-aube server; using $VERDACCIO_PORT instead" >&2
+		export AUBE_TEST_REGISTRY="http://localhost:${VERDACCIO_PORT}"
 	fi
 
 	# Install verdaccio if not already available (pinned major version)
@@ -31,16 +68,21 @@ start_registry() {
 		npm install --global verdaccio@6 2>&1 | tail -1 >&2
 	fi
 
+	# Absolute config path: verdaccio resolves a relative one against its own
+	# cwd, so a caller that starts the registry from anywhere but this
+	# directory otherwise dies with "cannot open config file".
 	verdaccio --config "$CONFIG_FILE" --listen "$VERDACCIO_PORT" &
 	VERDACCIO_PID=$!
 	export VERDACCIO_PID
 
-	# Wait for it to come up (up to 30 seconds)
+	# Wait for it to SERVE, not merely to bind. A verdaccio that came up
+	# against the wrong storage answers on / immediately and 404s every
+	# package, which is the failure this whole function exists to make loud.
 	local retries=60
-	while ! curl -s "http://localhost:${VERDACCIO_PORT}/" >/dev/null 2>&1; do
+	while ! registry_is_ours "$VERDACCIO_PORT"; do
 		retries=$((retries - 1))
 		if [ "$retries" -le 0 ]; then
-			echo "ERROR: Verdaccio failed to start on port $VERDACCIO_PORT" >&2
+			echo "ERROR: Verdaccio on port $VERDACCIO_PORT never served ${REGISTRY_PROBE_PKG} from $STORAGE_DIR" >&2
 			kill "$VERDACCIO_PID" 2>/dev/null || true
 			return 1
 		fi


### PR DESCRIPTION
Hoisted relinks wiped and refilled every placed package, and the refill restores published tarball contents — so an unrelated `nub add` deleted whatever a postinstall produced (`build/Release/*.node`, a downloaded binary) and never put it back. The delta filter then skipped those packages because their fingerprint was unchanged, so they were neither rebuilt nor restored.

npm and pnpm — including pnpm's hoisted layout — leave an unchanged package directory alone. This does the same, vouching for a package only when the previous link COMPLETED, the layout matches, and the fingerprint is unchanged. Completion is tracked by a sentinel, not the install state: state written by a successful install outlives a later one that died mid-link, so state alone would vouch for a half-written tree.

Faster than what it replaces: ~720ms vs ~920ms per incremental add. Isolated is untouched.

Closes #610
