### PR TITLE
test(init): close the mock registry connection gracefully

### DIFF
--- a/crates/nub-cli/tests/init_cmd.rs
+++ b/crates/nub-cli/tests/init_cmd.rs
@@ -205,18 +205,21 @@ impl RegistryFixture {
 
 /// Serve one request, then close the connection *gracefully*.
 ///
-/// The graceful close is load-bearing on Windows, where `closesocket` on a
-/// socket that still holds unread bytes in its receive buffer is an ABORTIVE
-/// close: it sends RST and discards whatever is still queued in the send
-/// buffer, so the client sees a transport-level error instead of the response
-/// it was mid-read of. The tarball is the largest body here and so the most
-/// exposed, and the age-floor test pins `fetch-retries=0`, leaving no retry
-/// cushion. Hence: read the request to its end, then half-close (FIN) and drain
-/// to EOF so the final close has nothing left to abort over.
+/// Closing a socket that still holds unread bytes in its receive buffer is an
+/// ABORTIVE close: it discards whatever is still queued in the send buffer, so
+/// the client sees a transport-level error instead of the response it was
+/// mid-read of. Not Windows-specific — a CI probe measured 0/15 successes with
+/// the abortive close against 15/15 with this one on windows, ubuntu AND macos;
+/// Windows surfaces it as `ConnectionReset` 10054, macOS stalls to timeout. The
+/// age-floor test pins `fetch-retries=0`, so there is no cushion. Hence: read
+/// the request to its end, then half-close (FIN) and drain to EOF so the final
+/// close has nothing left to abort over.
 ///
-/// `set_nonblocking(false)` is belt-and-braces for the same platform — an
-/// accepted socket can inherit the listener's non-blocking mode, which would
-/// turn the request read into an instant `WouldBlock` and serve a 404.
+/// `set_nonblocking(false)` is REQUIRED, not belt-and-braces, and for macOS
+/// rather than Windows: BSD `accept` inherits the listener's non-blocking flag
+/// onto the accepted socket (Linux explicitly does not). Without it the request
+/// read returns `WouldBlock` before the bytes land, the path parses as `/`, and
+/// the fixture serves a 404 for a package it holds — a second, independent bug.
 fn serve_one(
     mut stream: TcpStream,
     responses: &HashMap<String, (String, Vec<u8>)>,

--- a/crates/nub-cli/tests/init_cmd.rs
+++ b/crates/nub-cli/tests/init_cmd.rs
@@ -8,12 +8,13 @@ use base64::Engine as _;
 use sha2::{Digest, Sha512};
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::net::TcpListener;
+use std::net::{Shutdown, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
+use std::time::Duration;
 
 fn nub_binary() -> PathBuf {
     let mut path = std::env::current_exe().unwrap();
@@ -177,29 +178,13 @@ impl RegistryFixture {
         let server = thread::spawn(move || {
             while !server_stop.load(Ordering::Relaxed) {
                 match listener.accept() {
-                    Ok((mut stream, _)) => {
+                    Ok((stream, _)) => {
                         let responses = responses.clone();
                         thread::spawn(move || {
-                            let mut request = [0_u8; 4096];
-                            let size = stream.read(&mut request).unwrap_or(0);
-                            let first_line = String::from_utf8_lossy(&request[..size])
-                                .lines()
-                                .next()
-                                .unwrap_or_default()
-                                .to_ascii_lowercase();
-                            let path = first_line.split_whitespace().nth(1).unwrap_or("/");
-                            let (status, content_type, body) =
-                                if let Some((content_type, body)) = responses.get(path) {
-                                    ("200 OK", content_type.as_str(), body.as_slice())
-                                } else {
-                                    ("404 Not Found", "text/plain", b"not found".as_slice())
-                                };
-                            let headers = format!(
-                                "HTTP/1.1 {status}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
-                                body.len()
-                            );
-                            stream.write_all(headers.as_bytes()).unwrap();
-                            stream.write_all(body).unwrap();
+                            // A dead client mid-exchange is not a fixture bug,
+                            // and a panic on this detached thread would not fail
+                            // the test anyway — the assertions live in the test.
+                            let _ = serve_one(stream, &responses);
                         });
                     }
                     Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
@@ -216,6 +201,62 @@ impl RegistryFixture {
             thread: Some(server),
         }
     }
+}
+
+/// Serve one request, then close the connection *gracefully*.
+///
+/// The graceful close is load-bearing on Windows, where `closesocket` on a
+/// socket that still holds unread bytes in its receive buffer is an ABORTIVE
+/// close: it sends RST and discards whatever is still queued in the send
+/// buffer, so the client sees a transport-level error instead of the response
+/// it was mid-read of. The tarball is the largest body here and so the most
+/// exposed, and the age-floor test pins `fetch-retries=0`, leaving no retry
+/// cushion. Hence: read the request to its end, then half-close (FIN) and drain
+/// to EOF so the final close has nothing left to abort over.
+///
+/// `set_nonblocking(false)` is belt-and-braces for the same platform — an
+/// accepted socket can inherit the listener's non-blocking mode, which would
+/// turn the request read into an instant `WouldBlock` and serve a 404.
+fn serve_one(
+    mut stream: TcpStream,
+    responses: &HashMap<String, (String, Vec<u8>)>,
+) -> std::io::Result<()> {
+    stream.set_nonblocking(false)?;
+    stream.set_read_timeout(Some(Duration::from_secs(10)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(10)))?;
+
+    let mut buf = [0_u8; 4096];
+    let mut request = Vec::new();
+    // These are all bodyless GETs, so end-of-headers is end-of-request.
+    while !request.windows(4).any(|w| w == b"\r\n\r\n") {
+        match stream.read(&mut buf)? {
+            0 => break,
+            size => request.extend_from_slice(&buf[..size]),
+        }
+    }
+
+    let first_line = String::from_utf8_lossy(&request)
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let path = first_line.split_whitespace().nth(1).unwrap_or("/");
+    let (status, content_type, body) = if let Some((content_type, body)) = responses.get(path) {
+        ("200 OK", content_type.as_str(), body.as_slice())
+    } else {
+        ("404 Not Found", "text/plain", b"not found".as_slice())
+    };
+    let headers = format!(
+        "HTTP/1.1 {status}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(headers.as_bytes())?;
+    stream.write_all(body)?;
+    stream.flush()?;
+
+    stream.shutdown(Shutdown::Write)?;
+    while stream.read(&mut buf)? > 0 {}
+    Ok(())
 }
 
 impl Drop for RegistryFixture {


### PR DESCRIPTION
The age-floor install test failed on Windows CI with a transport error, not an HTTP status, fetching the tarball — the largest body served.

Cause: the fixture read one 4096-byte chunk of the request, wrote the response, and dropped the socket. Closing a socket that still holds unread bytes is an abortive close: it discards the send buffer, so a client mid-read never gets the rest.

The handler now reads the request to its end, half-closes, drains to EOF, and forces blocking mode on the accepted socket.

A probe on branch `probe/win-socket-close` (4 MiB body, 15 requests, run 30473314496) lost every response on Windows, Ubuntu and macOS with the old close, none with the new.

Refs #602
