### PR TITLE
fix(linker): clear a stale workspace store entry recursively

### DIFF
--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -1131,9 +1131,15 @@ impl Linker {
                                 nested_link_targets.as_ref(),
                             )?;
 
+                            // Same `Stale` shapes as `link_all`'s step 1, and
+                            // the same reason a non-recursive `remove_dir`
+                            // cannot clear them — see the comment there. This
+                            // arm is the workspace twin of that code and was
+                            // left on the old removal, so a workspace wedged
+                            // permanently on os-183 where a single-package
+                            // project self-healed.
                             if matches!(state, EntryState::Stale) {
-                                let _ = std::fs::remove_dir(&local_aube_entry)
-                                    .or_else(|_| std::fs::remove_file(&local_aube_entry));
+                                try_remove_entry(&local_aube_entry);
                             }
                             // Parent dirs were pre-created above the
                             // par_iter; no per-package `mkdirp` here.

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -2321,6 +2321,64 @@ fn gvs_relink_replaces_a_populated_real_dir_in_the_entry_slot() {
     assert!(entry.join("node_modules/bar/index.js").exists());
 }
 
+// The workspace twin of the test above. `link_all` and `link_workspace`
+// carry near-duplicate step-1 GVS-populate loops, and the fix for
+// nub#566 / nub#576 landed only in `link_all` — so the identical
+// `EntryState::Stale` arm here kept its non-recursive removal and a
+// WORKSPACE wedged permanently on os-183 where a single-package project
+// recovered. Confirmed on a real Windows box against
+// `0.6.0-canary.20260729.129`: same fixture, same perturbation, same
+// command — single package exit 0, workspace exit 1 with
+// `failed to link workspace node_modules`.
+//
+// Reached deliberately rather than naturally: the mode-change wipe in
+// `detect_aube_dir_gvs_mode` normally pre-empts a mixed tree, and that
+// wipe is a DIFFERENT layer. Any other source of one — a partial cache
+// restore, a crash, external tooling — lands straight here.
+#[test]
+fn gvs_workspace_relink_replaces_a_populated_real_dir_in_the_entry_slot() {
+    let dir = tempfile::tempdir().unwrap();
+    let root_dir = dir.path().join("workspace");
+    let (store, indices) = setup_store_with_files(dir.path());
+
+    // Two members sharing one dependency, so the entry under test is
+    // reached from more than one importer.
+    let mut graph = make_graph();
+    let foo = graph.importers.get(".").cloned().unwrap_or_default();
+    graph
+        .importers
+        .insert("packages/a".to_string(), foo.clone());
+    graph.importers.insert("packages/b".to_string(), foo);
+
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true).with_hoist(false);
+    linker
+        .link_workspace(&root_dir, &graph, &indices, &BTreeMap::new())
+        .unwrap();
+
+    // Rewrite one shared entry into the per-project shape.
+    let entry = root_dir
+        .join("node_modules/.aube")
+        .join(dep_path_to_filename(
+            "bar@2.0.0",
+            DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+        ));
+    try_remove_entry(&entry);
+    let pkg_dir = entry.join("node_modules/bar");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(pkg_dir.join("index.js"), b"stale per-project copy").unwrap();
+    assert!(aube_util::fs::is_real_dir(&entry));
+
+    linker
+        .link_workspace(&root_dir, &graph, &indices, &BTreeMap::new())
+        .expect("workspace relink must reclaim a populated per-project entry, not collide with it");
+
+    assert!(
+        std::fs::read_link(&entry).is_ok(),
+        "entry must end up a link into the shared store"
+    );
+    assert!(entry.join("node_modules/bar/index.js").exists());
+}
+
 // `is_real_dir` exists to tell a plain directory apart from a
 // directory-SHAPED link, so the link case is the whole point — and it is
 // only meaningful against the real primitive: `create_dir_link` writes a


### PR DESCRIPTION
`link_all` and `link_workspace` carry near-duplicate step-1 GVS-populate loops. #595 fixed the `EntryState::Stale` removal in the first — a non-recursive `remove_dir` cannot clear a populated real directory, and the swallowed error resurfaces as EEXIST / os-183 from the link creation right below — and left the identical arm in the workspace loop untouched. A workspace therefore wedged permanently where a single-package project self-healed:

```
× failed to link workspace node_modules
╰─▶ I/O error at C:\ws\node_modules/.store\express@4.18.2: Cannot
    create a file when that file already exists. (os error 183)
```

`nub install`, `nub install --force`, and member-level `nub add` / `nub remove` all failed the same way; only deleting `node_modules` recovered. Confirmed on Windows Server 2022 against `0.6.0-canary.20260729.129`, with a single-package control that recovered under the same perturbation.

Not Windows-specific despite where it surfaced — with this arm reverted the new test fails on macOS too, with EEXIST (os 17).

The trigger is a mixed store (some entries links, one a real directory). `detect_aube_dir_gvs_mode` returns `Some(true)` on the first link it sees, so the mode-change wipe does not fire and the survivor reaches this arm. That wipe is currently the only thing pre-empting the failure and it is a different layer, so this is latent rather than unreachable: a partial cache restore, a crash, or external tooling produce the same shape.
