### PR TITLE
fix(watch): stop nub watch leaking an immortal node --watch supervisor

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4829,12 +4829,15 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
         let mut node_args = vec!["--watch".to_string(), "--watch-preserve-output".to_string()];
         node_args.push(file.to_string());
         node_args.extend(args.iter().cloned());
-        let status = std::process::Command::new(node.path.as_str())
-            .args(&node_args)
+        let mut cmd = std::process::Command::new(node.path.as_str());
+        cmd.args(&node_args)
             .stdin(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
-            .stderr(std::process::Stdio::inherit())
-            .status()?;
+            .stderr(std::process::Stdio::inherit());
+        // Not `.status()` — see the note on the augmented path below. `node --watch`
+        // never exits on its own, so a bare status() leaks the supervisor and its
+        // watched child on leader death.
+        let status = nub_core::node::spawn::status_forwarding_signals(&mut cmd)?;
         return Ok(nub_core::node::spawn::exit_code_from_status(&status));
     }
 
@@ -5081,7 +5084,19 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
         // Strip below-floor version-gated flags just as the direct-spawn sites do.
         cmd.env("NODE_OPTIONS", existing);
     }
-    let status = cmd.status()?;
+    // NOT `cmd.status()`. Every other long-lived spawn in nub goes through a
+    // process-group + reaper path; watch was the sole exception, and it is the one
+    // that matters most: `node --watch` is a supervisor that by design never exits,
+    // and it spawns a watched grandchild of its own. A bare `status()` leaves both
+    // outside nub's group, so when the leader dies (a killed agent session, a test
+    // harness that gives up, a closed terminal) they reparent to launchd and run
+    // forever, each holding an fsevents watch on a source tree. They accumulate
+    // monotonically — 99 such orphans were found on the dev host, the oldest 17h
+    // old, none of them rustc or cargo. `status_forwarding_signals` is the
+    // signal-faithful equivalent of `status()`: own process group, the #480
+    // SIGKILL-on-leader reaper held across the wait, and terminating signals
+    // forwarded to the whole subtree.
+    let status = nub_core::node::spawn::status_forwarding_signals(&mut cmd)?;
 
     // PATH shim cleanup is handled once at the top level (see `run`).
     Ok(nub_core::node::spawn::exit_code_from_status(&status))

--- a/crates/nub-cli/tests/pdeath_watch.rs
+++ b/crates/nub-cli/tests/pdeath_watch.rs
@@ -199,3 +199,88 @@ fn deliberate_background_survivor_outlives_normal_exit() {
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Spawn `nub watch <file>` as its own process-group leader, mirroring
+/// [`spawn_nub_run`]'s topology.
+fn spawn_nub_watch(dir: &Path, file: &str) -> std::process::Child {
+    use std::os::unix::process::CommandExt;
+    let mut cmd = std::process::Command::new(nub_binary());
+    cmd.args(["watch", file])
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    // SAFETY: setpgid(0, 0) between fork and exec is async-signal-safe.
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setpgid(0, 0);
+            Ok(())
+        });
+    }
+    cmd.spawn().expect("spawn nub watch")
+}
+
+/// The watch-path twin of [`sigkill_on_nub_group_terminates_the_script_child`],
+/// and a regression for the leak it did not cover.
+///
+/// `run_watch` was the one long-lived spawn in nub that called `Command::status()`
+/// directly, so its `node --watch` supervisor was never placed in nub's process
+/// group and never covered by the #480 reaper. That matters more here than
+/// anywhere else: `node --watch` is designed never to exit, so a leader death left
+/// it — and the grandchild it supervises — running under PID 1 forever, each
+/// holding an fsevents watch on a source tree. They accumulated monotonically;
+/// 99 such orphans were found on one dev host, the oldest 17 hours old.
+#[test]
+fn sigkill_on_nub_group_terminates_the_watched_node() {
+    let dir = std::env::temp_dir().join(format!("nub-pdw-watch-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    // The watched script records its own pid, then idles. `node --watch` keeps
+    // supervising it after it exits, which is precisely the process that leaked.
+    std::fs::write(
+        dir.join("w.js"),
+        "require('fs').writeFileSync('child.pid', String(process.pid));\nsetTimeout(() => {}, 30000);\n",
+    )
+    .unwrap();
+
+    let mut nub = spawn_nub_watch(&dir, "w.js");
+    let child_pid = read_pid(&dir.join("child.pid"));
+    assert!(
+        alive(child_pid),
+        "watched child must be alive before the kill"
+    );
+
+    // SIGKILL the nub LEADER ONLY — deliberately not the group.
+    //
+    // This distinction is the whole test. Killing the GROUP proves nothing here: on
+    // the unfixed code the watched node INHERITS nub's process group, so a group
+    // signal reaches it directly and the test passes without any reaper at all
+    // (verified — that version passed against unfixed code). Once fixed, node is its
+    // own group leader via `group_on_spawn`, so a group signal cannot reach it and
+    // only the reaper can.
+    //
+    // Killing the leader alone is also the shape of the real leak: an agent session
+    // or test harness dies, nub goes with it, and `node --watch` — which never exits
+    // on its own — reparents to launchd and runs forever.
+    unsafe { libc::kill(nub.id() as i32, libc::SIGKILL) };
+    let _ = nub.wait();
+
+    let mut died = false;
+    for _ in 0..80 {
+        if !alive(child_pid) {
+            died = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    if !died {
+        // Never leak a watcher into the test environment on failure.
+        unsafe { libc::kill(child_pid, libc::SIGKILL) };
+    }
+    assert!(
+        died,
+        "watched node (pid {child_pid}) survived SIGKILL of the nub LEADER — \
+         run_watch is bypassing the group reaper again, so a dying session leaks a \
+         watcher that never exits on its own"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
`run_watch` was the only long-lived spawn in nub that called `Command::status()` directly. Every other one — `spawn.rs:672`, `spawn.rs:1182`, `cli.rs:4647` — goes through a process-group + reaper path.

That single gap is why orphan sweeps on the dev host kept finding stranded processes:

```
rustc:  13 total,   0 orphaned
cargo:   3 total,   0 orphaned
node:  212 total,  99 running --watch, ALL with PPID=1   (oldest: 17 hours)
```

Exclusively `node --watch`. Never rustc, never cargo — because those paths are already guarded.

## Why this path matters most

`node --watch` is a supervisor that **by design never exits**, and it spawns a watched grandchild of its own. With no process group and no reaper, the death of the nub leader — a killed agent session, a test harness that gives up, a closed terminal — reparents both to `launchd`, where they run forever holding an fsevents watch on a source tree. They accumulate monotonically, so the only remedy was clearing them by hand once the machine slowed to a crawl.

## The fix

Both spawn sites (`cli.rs:4832` NODE_COMPAT, `cli.rs:~5084` augmented) now use `status_forwarding_signals()` — the existing helper documented as *"the signal-faithful, subtree-reaching equivalent of `cmd.status()`"*: own process group, the #480 SIGKILL-on-leader reaper held across the wait, and terminating signals forwarded to the whole subtree.

No new machinery. This is #480's reaper applied to the one path that was missing it.

## The regression test kills the LEADER, not the group — and that is the test

A first version killed the process group and **passed against unfixed code**. On the unfixed path the watched node *inherits* nub's group, so a group signal reaches it directly and no reaper is exercised. It would have shipped green forever while protecting nothing.

Killing the leader alone is also the shape of the real failure: a session dies, nub goes with it, `node --watch` does not.

Verified both directions:

| | Result |
|---|---|
| Unfixed + leader-kill test | **FAILED** — `watched node (pid 19633) survived` |
| Fixed + leader-kill test | **5 passed, 0 failed** |

## Gates

`cargo check -p nub-cli` · `cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test -p nub-cli --test pdeath_watch` — all clean locally.

## Scope

This stops *new* orphans. It does not address the separate contention on that host (~20 concurrent builds on 10 cores, 74 live worktrees / 262 GB of target dirs) — those are structural and tracked separately.

Refs #480
