### PR TITLE
fix(resolver): give an undeterminable publish age its own error

### DIFF
--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -421,15 +421,14 @@ Publish dates come from the registry's `time` metadata, so the gate is only as s
 | No per-version dates, document older than the window | Allowed — the document's own timestamp bounds every version in it |
 | No per-version dates, document newer than the window | Blocked |
 
-Loosening strictness reverses both blocked rows: an undateable version becomes eligible again, and the lowest satisfying one is picked.
-
-Registries that publish no dates at all — some private mirrors, older Verdaccio — hit the last row, and the error names that as the cause rather than reporting a missed cutoff. Three ways through:
+Registries that publish no dates at all — some private mirrors, older Verdaccio — hit the last row. That refusal is its own error, `ERR_NUB_RELEASE_AGE_MISSING_TIME`, kept separate from a version being too new because no window would ever have admitted these versions. Two ways through:
 
 ```ini
 minimumReleaseAgeExclude=internal-pkg   # exempt one package (comma-separated)
-minimumReleaseAgeStrict=false           # fall back to the lowest satisfying version
 minimumReleaseAge=0                     # turn the window off
 ```
+
+Loosening strictness is a third, and it is not a smaller window. With `minimumReleaseAgeStrict=false` an undateable version counts as clearing the gate, so the newest version matching your range is installed with no age checked at all. Where versions *are* dated and all of them are too new, the same setting instead falls back to the lowest satisfying version.
 
 ### Default-trust floor
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -421,7 +421,7 @@ Publish dates come from the registry's `time` metadata, so the gate is only as s
 | No per-version dates, document older than the window | Allowed — the document's own timestamp bounds every version in it |
 | No per-version dates, document newer than the window | Blocked |
 
-Registries that publish no dates at all — some private mirrors, older Verdaccio — hit the last row. That refusal is its own error, `ERR_NUB_RELEASE_AGE_MISSING_TIME`, kept separate from a version being too new because no window would ever have admitted these versions. Two ways through:
+Registries that publish no dates at all — some private mirrors, older Verdaccio — hit the last row, and a packument missing a date for just the version you need hits the second. Either way the refusal is its own error, `ERR_NUB_RELEASE_AGE_MISSING_TIME`, kept separate from a version being too new because no window would ever have admitted these versions. Two ways through:
 
 ```ini
 minimumReleaseAgeExclude=internal-pkg   # exempt one package (comma-separated)

--- a/vendor/aube/crates/aube-codes/src/errors.rs
+++ b/vendor/aube/crates/aube-codes/src/errors.rs
@@ -24,6 +24,7 @@ pub const ERR_AUBE_LOCKFILE_AMBIGUOUS: &str = "ERR_AUBE_LOCKFILE_AMBIGUOUS";
 // ── resolver ─────────────────────────────────────────────────────────
 pub const ERR_AUBE_NO_MATCHING_VERSION: &str = "ERR_AUBE_NO_MATCHING_VERSION";
 pub const ERR_AUBE_NO_MATURE_MATCHING_VERSION: &str = "ERR_AUBE_NO_MATURE_MATCHING_VERSION";
+pub const ERR_AUBE_RELEASE_AGE_MISSING_TIME: &str = "ERR_AUBE_RELEASE_AGE_MISSING_TIME";
 pub const ERR_AUBE_REGISTRY_ERROR: &str = "ERR_AUBE_REGISTRY_ERROR";
 pub const ERR_AUBE_UNKNOWN_CATALOG: &str = "ERR_AUBE_UNKNOWN_CATALOG";
 pub const ERR_AUBE_UNKNOWN_CATALOG_ENTRY: &str = "ERR_AUBE_UNKNOWN_CATALOG_ENTRY";
@@ -215,6 +216,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::RESOLVER,
         description: "A version satisfying the range exists but every candidate was younger than `minimumReleaseAge` and `minimumReleaseAgeStrict=true`.",
         exit_code: Some(21),
+    },
+    CodeMeta {
+        name: ERR_AUBE_RELEASE_AGE_MISSING_TIME,
+        category: category::RESOLVER,
+        description: "The registry served no publish time for any version satisfying the range, so `minimumReleaseAge` could not be evaluated (`minimumReleaseAgeStrict=true`). Distinct from `ERR_AUBE_NO_MATURE_MATCHING_VERSION` so CI tooling can tell a registry serving no `time` metadata from a genuinely too-new release.",
+        exit_code: Some(28),
     },
     CodeMeta {
         name: ERR_AUBE_BLOCKED_EXOTIC_SUBDEP,

--- a/vendor/aube/crates/aube-resolver/src/error.rs
+++ b/vendor/aube/crates/aube-resolver/src/error.rs
@@ -8,8 +8,16 @@ use aube_registry::Packument;
 pub enum Error {
     #[error("no version of {} matches range `{}`", .0.name, .0.range)]
     NoMatch(Box<NoMatchDetails>),
-    #[error("{}", .0.headline())]
+    #[error(
+        "no version of {} matching {} is older than {} minute(s) (minimumReleaseAgeStrict=true)",
+        .0.name, .0.range, .0.minutes
+    )]
     AgeGate(Box<AgeGateDetails>),
+    #[error(
+        "cannot check the publish age of {}@{} — the registry served no publish time for any matching version",
+        .0.name, .0.range
+    )]
+    ReleaseAgeMissingTime(Box<UndatedDetails>),
     #[error("registry error for {0}: {1}")]
     Registry(String, String),
     #[error(
@@ -79,37 +87,29 @@ pub struct AgeGateDetails {
     pub minutes: u64,
     pub importer: String,
     pub ancestors: Vec<(String, String)>,
-    /// Version strings that satisfied the range but were blocked by
-    /// the age gate, sorted newest-first. Empty when the cutoff was
-    /// tighter than every published version.
+    /// Version strings that satisfied the range, carried a publish time,
+    /// and were blocked for being newer than the cutoff — sorted
+    /// newest-first. Undated versions are excluded: they were blocked for
+    /// a different reason and listing them here would claim evidence the
+    /// registry never served.
     pub gated: Vec<String>,
-    /// The packument carried no publish time for ANY satisfying version,
-    /// so nothing was blocked for being too new — every candidate was
-    /// blocked for having an undeterminable age (#581). That is a
-    /// different operator problem with different remedies, and reporting
-    /// it as an ordinary age gate sends people to widen a window that was
-    /// never the cause.
-    pub publish_times_missing: bool,
 }
 
-impl AgeGateDetails {
-    /// The headline. Splitting on `publish_times_missing` keeps one error
-    /// variant and one code while still telling the truth: "nothing is old
-    /// enough" and "nothing's age can be established" are the same refusal
-    /// for opposite reasons.
-    pub(crate) fn headline(&self) -> String {
-        if self.publish_times_missing {
-            format!(
-                "cannot establish the publish age of any version of {} matching `{}` — the registry served no publish times",
-                self.name, self.range
-            )
-        } else {
-            format!(
-                "no version of {} matching {} is older than {} minute(s) (minimumReleaseAgeStrict=true)",
-                self.name, self.range, self.minutes
-            )
-        }
-    }
+/// Context for `ReleaseAgeMissingTime`: the gate could not be evaluated at
+/// all because the registry dated none of the candidates (#581). A separate
+/// error from `AgeGate` because the remedies are disjoint — no window would
+/// ever have admitted these versions, so the ordinary "loosen
+/// `minimumReleaseAge`" advice is wrong here.
+#[derive(Debug)]
+pub struct UndatedDetails {
+    pub name: String,
+    pub range: String,
+    pub importer: String,
+    pub ancestors: Vec<(String, String)>,
+    /// Range-satisfying versions the packument carries no publish time for,
+    /// sorted newest-first. Shown so the reader can see the range itself
+    /// matched.
+    pub undated: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -144,6 +144,7 @@ impl miette::Diagnostic for Error {
         Some(Box::new(match self {
             Self::NoMatch(_) => ERR_AUBE_NO_MATCHING_VERSION,
             Self::AgeGate(_) => ERR_AUBE_NO_MATURE_MATCHING_VERSION,
+            Self::ReleaseAgeMissingTime(_) => ERR_AUBE_RELEASE_AGE_MISSING_TIME,
             Self::Registry(_, _) => ERR_AUBE_REGISTRY_ERROR,
             Self::UnknownCatalog(_) => ERR_AUBE_UNKNOWN_CATALOG,
             Self::UnknownCatalogEntry(_) => ERR_AUBE_UNKNOWN_CATALOG_ENTRY,
@@ -158,6 +159,7 @@ impl miette::Diagnostic for Error {
         match self {
             Self::NoMatch(d) => Some(Box::new(format_no_match_help(d))),
             Self::AgeGate(d) => Some(Box::new(format_age_gate_help(d))),
+            Self::ReleaseAgeMissingTime(d) => Some(Box::new(format_undated_help(d))),
             Self::Registry(name, msg) => Some(Box::new(format_registry_help(name, msg))),
             Self::UnknownCatalog(d) => Some(Box::new(format_unknown_catalog_help(d))),
             Self::UnknownCatalogEntry(d) => Some(Box::new(format_unknown_catalog_entry_help(d))),
@@ -274,47 +276,64 @@ fn resolve_dist_tag_range(packument: &Packument, range_str: &str) -> String {
     }
 }
 
+/// Range-satisfying versions, newest-first, partitioned by whether the
+/// packument dates them. `pick_version` has already decided which of the two
+/// age failures happened; this recovers the version lists for the message.
+/// Recomputed from the packument rather than threaded out of the pick because
+/// both age-gate paths are uncommon and the recompute is dwarfed by resolution.
+///
+/// Mirrors `pick_version`'s dist-tag handling: a `task.range` that is a tag
+/// name (`"latest"`, `"next"`) resolves to its concrete version before
+/// parsing. Without it the semver parse fails silently and the diagnostic
+/// drops its version list entirely.
+fn satisfying_versions(task: &ResolveTask, packument: &Packument) -> (Vec<String>, Vec<String>) {
+    let effective = resolve_dist_tag_range(packument, &task.range);
+    let Ok(range) = node_semver::Range::parse(&effective) else {
+        return (Vec::new(), Vec::new());
+    };
+    let mut matching: Vec<(node_semver::Version, String)> = Vec::new();
+    for ver in packument.versions.keys() {
+        let Ok(v) = node_semver::Version::parse(ver) else {
+            continue;
+        };
+        if v.satisfies(&range) {
+            matching.push((v, ver.clone()));
+        }
+    }
+    matching.sort_by(|a, b| b.0.cmp(&a.0));
+    matching
+        .into_iter()
+        .map(|(_, s)| s)
+        .partition(|ver| packument.time.contains_key(ver))
+}
+
 pub(crate) fn build_age_gate(
     task: &ResolveTask,
     packument: &Packument,
     minutes: u64,
 ) -> AgeGateDetails {
-    // Mirror `pick_version`'s dist-tag handling: if `task.range` is a
-    // tag name (e.g. `"latest"`, `"next"`), resolve it to the concrete
-    // version string before parsing. Without this the semver parse
-    // fails silently and the help text drops the "blocked by age gate"
-    // line entirely, losing the most useful diagnostic.
-    let effective = resolve_dist_tag_range(packument, &task.range);
-    let range = node_semver::Range::parse(&effective).ok();
-    let mut gated: Vec<(node_semver::Version, String)> = Vec::new();
-    if let Some(r) = range {
-        for ver in packument.versions.keys() {
-            let Ok(v) = node_semver::Version::parse(ver) else {
-                continue;
-            };
-            if !v.satisfies(&r) {
-                continue;
-            }
-            gated.push((v, ver.clone()));
-        }
-    }
-    gated.sort_by(|a, b| b.0.cmp(&a.0));
-    // No satisfying version carries a publish time => nothing was blocked for
-    // being too new; the whole range was blocked for being undateable. A
-    // populated map with a hole in it is NOT this case — there the rest of the
-    // document dates fine and the hole is the anomaly worth reporting as one.
-    let publish_times_missing = !gated.is_empty()
-        && !gated
-            .iter()
-            .any(|(_, ver)| packument.time.contains_key(ver));
+    let (dated, _) = satisfying_versions(task, packument);
     AgeGateDetails {
         name: task.name.clone(),
         range: task.range.clone(),
         minutes,
         importer: task.importer.clone(),
         ancestors: task.ancestors.to_vec(),
-        gated: gated.into_iter().map(|(_, s)| s).collect(),
-        publish_times_missing,
+        gated: dated,
+    }
+}
+
+pub(crate) fn build_release_age_missing_time(
+    task: &ResolveTask,
+    packument: &Packument,
+) -> UndatedDetails {
+    let (_, undated) = satisfying_versions(task, packument);
+    UndatedDetails {
+        name: task.name.clone(),
+        range: task.range.clone(),
+        importer: task.importer.clone(),
+        ancestors: task.ancestors.to_vec(),
+        undated,
     }
 }
 
@@ -356,20 +375,6 @@ fn format_age_gate_help(d: &AgeGateDetails) -> String {
     let mut s = String::new();
     push_importer(&mut s, &d.importer);
     push_chain(&mut s, &d.ancestors, &d.name);
-    if d.publish_times_missing {
-        s.push_str(
-            "the registry served no `time` data for this package, so no version's age can be \
-             checked against the cutoff\n",
-        );
-        s.push_str("to proceed: add `");
-        s.push_str(&d.name);
-        s.push_str(
-            "` to `minimumReleaseAgeExclude`, set `minimumReleaseAgeStrict=false` to fall back \
-             to the lowest satisfying version, or set `minimumReleaseAge=0` to turn the window \
-             off for this project",
-        );
-        return s;
-    }
     if !d.gated.is_empty() {
         s.push_str(&format!(
             "blocked by age gate: {}\n",
@@ -384,6 +389,38 @@ fn format_age_gate_help(d: &AgeGateDetails) -> String {
     s.push_str("to bypass: loosen `minimumReleaseAge` in .npmrc, set `minimumReleaseAgeStrict=false` to fall back to the lowest satisfying version, or add `");
     s.push_str(&d.name);
     s.push_str("` to `minimumReleaseAgeExclude`");
+    s
+}
+
+/// Deliberately omits `minimumReleaseAgeStrict=false`. Loosening strictness
+/// here does not produce a mature pick — it produces the newest matching
+/// version with no age evidence at all, which is the silent bypass #581
+/// closed. The remedies offered are the ones that leave the gate meaningful.
+fn format_undated_help(d: &UndatedDetails) -> String {
+    let mut s = String::new();
+    push_importer(&mut s, &d.importer);
+    push_chain(&mut s, &d.ancestors, &d.name);
+    if !d.undated.is_empty() {
+        s.push_str(&format!(
+            "undated matching versions: {}\n",
+            d.undated
+                .iter()
+                .take(5)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    s.push_str(
+        "the minimumReleaseAge window is checked against the registry's `time` metadata, which \
+         this packument does not carry — no window would admit these versions\n",
+    );
+    s.push_str("to proceed: point the registry in .npmrc at one that serves publish times, add `");
+    s.push_str(&d.name);
+    s.push_str(
+        "` to `minimumReleaseAgeExclude`, or set `minimumReleaseAge=0` to turn the window off \
+         for this project",
+    );
     s
 }
 

--- a/vendor/aube/crates/aube-resolver/src/error.rs
+++ b/vendor/aube/crates/aube-resolver/src/error.rs
@@ -413,9 +413,12 @@ fn format_undated_help(d: &UndatedDetails) -> String {
     }
     s.push_str(
         "the minimumReleaseAge window is checked against the registry's `time` metadata, which \
-         this packument does not carry — no window would admit these versions\n",
+         omits these versions — no window would admit them\n",
     );
-    s.push_str("to proceed: point the registry in .npmrc at one that serves publish times, add `");
+    s.push_str(
+        "to proceed: unset `registry-supports-time-field` if it is on (it suppresses the \
+         full-packument fetch that carries `time`), check the registry config in .npmrc, add `",
+    );
     s.push_str(&d.name);
     s.push_str(
         "` to `minimumReleaseAgeExclude`, or set `minimumReleaseAge=0` to turn the window off \

--- a/vendor/aube/crates/aube-resolver/src/lib.rs
+++ b/vendor/aube/crates/aube-resolver/src/lib.rs
@@ -21,7 +21,9 @@ mod trust;
 mod types;
 
 pub use direct_dep_info::DirectDepInfo;
-pub use error::{AgeGateDetails, CatalogDetails, Error, ExoticSubdepDetails, NoMatchDetails};
+pub use error::{
+    AgeGateDetails, CatalogDetails, Error, ExoticSubdepDetails, NoMatchDetails, UndatedDetails,
+};
 pub use local_source::resolve_exec_script_path;
 pub use package_ext::is_deprecation_allowed;
 pub use peer_context::{
@@ -32,7 +34,7 @@ pub use platform::{SupportedArchitectures, is_supported};
 pub use primer::{
     PruneStats as PrimerPruneStats, popular_package_names, prune_cache as prune_primer_cache,
 };
-pub use semver_util::{PickResult, pick_version_for_add};
+pub use semver_util::{AgeGateCause, PickResult, pick_version_for_add};
 pub use trust::{
     MissingTimeDetails as MissingTrustTimeDetails, PriorTrustEvidence, TrustCheckError,
     TrustDowngradeDetails, check_no_downgrade, evidence_for, strongest_prior_evidence,
@@ -65,8 +67,8 @@ use aube_lockfile::{DirectDep, LocalSource, LockedPackage, LockfileGraph};
 use aube_manifest::PackageJson;
 #[cfg(test)]
 use error::{
-    RegistryErrorKind, build_age_gate, build_no_match, classify_registry_error,
-    format_registry_help,
+    RegistryErrorKind, build_age_gate, build_no_match, build_release_age_missing_time,
+    classify_registry_error, format_registry_help,
 };
 #[cfg(test)]
 use local_source::{dep_path_for, should_block_exotic_subdep};

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -28,7 +28,7 @@ use crate::package_ext::{
     apply_package_extensions, apply_package_extensions_to_deps, pick_override_spec,
 };
 use crate::semver_util::{
-    PickResult, Regime, classify_regime, pick_version, range_resolves_via_dist_tag,
+    AgeGateCause, PickResult, Regime, classify_regime, pick_version, range_resolves_via_dist_tag,
     version_satisfies,
 };
 use crate::{
@@ -963,7 +963,7 @@ impl<'a> ResolveDriver<'a> {
                     self.resolver.cache.insert(registry_name.clone(), live);
                 }
                 PickResult::Found(meta) => break meta.clone(),
-                PickResult::AgeGated | PickResult::NoMatch
+                PickResult::AgeGated(_) | PickResult::NoMatch
                     if self.fetcher.take_primer_seeded(&registry_name) =>
                 {
                     let fetch_start = std::time::Instant::now();
@@ -1008,20 +1008,32 @@ impl<'a> ResolveDriver<'a> {
                 // never opted into the supply-chain age gate, so
                 // the failure should report as a plain no-match
                 // instead of a misleading "older than 0 minutes".
-                PickResult::AgeGated => match self.resolver.minimum_release_age.as_ref() {
-                    Some(mra) => {
-                        return Err(Error::AgeGate(Box::new(error::build_age_gate(
-                            &task,
-                            packument,
-                            mra.minutes,
-                        ))));
+                PickResult::AgeGated(cause) => {
+                    match (self.resolver.minimum_release_age.as_ref(), cause) {
+                        // An undeterminable age is a different refusal with
+                        // disjoint remedies (#581): no window would have
+                        // admitted these versions, so it carries its own code
+                        // and message rather than an age gate the reader is
+                        // told to widen.
+                        (Some(_), AgeGateCause::Undeterminable) => {
+                            return Err(Error::ReleaseAgeMissingTime(Box::new(
+                                error::build_release_age_missing_time(&task, packument),
+                            )));
+                        }
+                        (Some(mra), AgeGateCause::TooNew) => {
+                            return Err(Error::AgeGate(Box::new(error::build_age_gate(
+                                &task,
+                                packument,
+                                mra.minutes,
+                            ))));
+                        }
+                        (None, _) => {
+                            return Err(Error::NoMatch(Box::new(error::build_no_match(
+                                &task, packument,
+                            ))));
+                        }
                     }
-                    None => {
-                        return Err(Error::NoMatch(Box::new(error::build_no_match(
-                            &task, packument,
-                        ))));
-                    }
-                },
+                }
                 // An optional dep whose range matches nothing is skipped
                 // rather than fatal, matching the fetch-failure and
                 // platform-mismatch paths. A registry carrying only some

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -11,7 +11,29 @@ pub enum PickResult<'a> {
     /// Strict mode (or any caller treating the cutoff as a hard wall):
     /// at least one version satisfied the range, but all of them were
     /// filtered out by the cutoff.
-    AgeGated,
+    AgeGated(AgeGateCause),
+}
+
+/// Why every satisfying version failed the cutoff. The two cases are the
+/// same refusal for opposite reasons and have disjoint remedies — one is
+/// fixed by waiting or widening the window, the other by getting publish
+/// times out of the registry — so the caller reports them under separate
+/// error codes rather than one "blocked by age gate".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgeGateCause {
+    /// At least one candidate carried a publish time later than the cutoff.
+    TooNew,
+    /// No candidate's age could be established at all (#581): the packument
+    /// dated none of them, and its `modified` timestamp did not vouch for
+    /// the document either.
+    Undeterminable,
+}
+
+/// A version's standing against the cutoff that applies to it.
+pub(crate) enum AgeVerdict {
+    Clears,
+    TooNew,
+    Undeterminable,
 }
 
 #[cfg(test)]
@@ -109,9 +131,32 @@ pub(crate) fn version_clears_cutoff(
     effective: Option<&str>,
     strict: bool,
 ) -> bool {
-    let Some(c) = effective else { return true };
+    matches!(
+        classify_version_age(packument, ver, effective, strict),
+        AgeVerdict::Clears
+    )
+}
+
+/// [`version_clears_cutoff`] with the rejection reason kept. Callers that only
+/// need the yes/no answer go through the predicate; [`pick_version`] uses this
+/// so the error it raises can name which of the two refusals happened.
+pub(crate) fn classify_version_age(
+    packument: &Packument,
+    ver: &str,
+    effective: Option<&str>,
+    strict: bool,
+) -> AgeVerdict {
+    let Some(c) = effective else {
+        return AgeVerdict::Clears;
+    };
     match packument.time.get(ver) {
-        Some(t) => t.as_str() <= c,
+        Some(t) => {
+            if t.as_str() <= c {
+                AgeVerdict::Clears
+            } else {
+                AgeVerdict::TooNew
+            }
+        }
         // npm's FULL `time` map always carries the `created`/`modified`
         // bookkeeping keys beside the version keys, so a raw `is_empty()` would
         // misread a mirror serving only those as "populated, with holes" and
@@ -123,7 +168,11 @@ pub(crate) fn version_clears_cutoff(
                 .any(|k| k != "created" && k != "modified");
             let modified_proves_maturity =
                 !has_version_times && packument.modified.as_deref().is_some_and(|m| m <= c);
-            modified_proves_maturity || !strict
+            if modified_proves_maturity || !strict {
+                AgeVerdict::Clears
+            } else {
+                AgeVerdict::Undeterminable
+            }
         }
     }
 }
@@ -225,13 +274,16 @@ pub(crate) fn pick_version<'a>(
     // A version's effective cutoff: exempt versions answer to the
     // time-based wall (`exempt_cutoff`) only; everyone else answers to
     // the merged `cutoff`.
-    let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
+    let classify_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> AgeVerdict {
         let effective = if is_age_exempt(ver, parsed) {
             exempt_cutoff
         } else {
             cutoff
         };
-        passes_effective_cutoff(ver, effective)
+        classify_version_age(packument, ver, effective, strict)
+    };
+    let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
+        matches!(classify_cutoff(ver, parsed), AgeVerdict::Clears)
     };
 
     // Prefer locked version if it satisfies and clears the cutoff.
@@ -264,8 +316,11 @@ pub(crate) fn pick_version<'a>(
 
     // Track whether *any* version satisfied the range — if so but
     // every one was rejected by the cutoff, the failure is age-gate
-    // related, not a real "no match in range".
-    let mut had_satisfying_but_age_gated = false;
+    // related, not a real "no match in range". A provably-too-new
+    // candidate outranks an undateable one: waiting or widening the
+    // window is a real remedy for the former, so the diagnostic must not
+    // hide it behind the latter.
+    let mut gated_cause: Option<AgeGateCause> = None;
 
     let mut best: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> = None;
     let mut fallback_lowest: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> =
@@ -289,12 +344,16 @@ pub(crate) fn pick_version<'a>(
             fallback_lowest = Some((v.clone(), meta));
         }
 
-        if passes_cutoff(ver_str, Some(&v)) {
-            if outranks(&v, meta, best.as_ref(), pick_lowest) {
-                best = Some((v, meta));
+        match classify_cutoff(ver_str, Some(&v)) {
+            AgeVerdict::Clears => {
+                if outranks(&v, meta, best.as_ref(), pick_lowest) {
+                    best = Some((v, meta));
+                }
             }
-        } else {
-            had_satisfying_but_age_gated = true;
+            AgeVerdict::TooNew => gated_cause = Some(AgeGateCause::TooNew),
+            AgeVerdict::Undeterminable => {
+                gated_cause.get_or_insert(AgeGateCause::Undeterminable);
+            }
         }
     }
 
@@ -306,10 +365,9 @@ pub(crate) fn pick_version<'a>(
     // failures so the caller can surface a meaningful error instead of
     // pretending the range itself was wrong.
     if strict || cutoff.is_none() {
-        return if had_satisfying_but_age_gated {
-            PickResult::AgeGated
-        } else {
-            PickResult::NoMatch
+        return match gated_cause {
+            Some(cause) => PickResult::AgeGated(cause),
+            None => PickResult::NoMatch,
         };
     }
 
@@ -324,10 +382,9 @@ pub(crate) fn pick_version<'a>(
     // time-based wall excluded every satisfying version. Report the age
     // gate in the latter case so the caller surfaces a meaningful error
     // rather than a bogus "no matching version".
-    if had_satisfying_but_age_gated {
-        PickResult::AgeGated
-    } else {
-        PickResult::NoMatch
+    match gated_cause {
+        Some(cause) => PickResult::AgeGated(cause),
+        None => PickResult::NoMatch,
     }
 }
 

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -59,7 +59,12 @@ fn no_match_help_flags_prerelease_only_packument() {
 
 #[test]
 fn build_age_gate_resolves_dist_tag_range() {
-    let packument = make_packument("foo", &["1.0.0", "2.0.0", "3.0.0"], "3.0.0");
+    let mut packument = make_packument("foo", &["1.0.0", "2.0.0", "3.0.0"], "3.0.0");
+    // Dated, because `gated` reports only versions the registry actually
+    // dated — an undated one is the separate `ReleaseAgeMissingTime` failure.
+    packument
+        .time
+        .insert("3.0.0".to_string(), "2026-07-01T00:00:00.000Z".to_string());
     let task = ResolveTask {
         name: "foo".into(),
         range: "latest".into(),
@@ -199,7 +204,6 @@ fn age_gate_help_lists_gated_versions_and_bypass() {
         importer: "packages/app".into(),
         ancestors: vec![("parent".into(), "1.0.0".into())],
         gated: vec!["4.17.21".into(), "4.17.20".into()],
-        publish_times_missing: false,
     }));
     let help = err.help().expect("help set").to_string();
     assert!(help.contains("importer: packages/app"));
@@ -212,21 +216,26 @@ fn age_gate_help_lists_gated_versions_and_bypass() {
 /// A registry that publishes no `time` data blocks the whole range, but for a
 /// reason the ordinary age-gate wording actively misleads on: it would list a
 /// years-old version as "blocked by age gate" and offer a wider window as the
-/// remedy, when no window would ever have helped.
+/// remedy, when no window would ever have helped. Loosening strictness is
+/// likewise not offered — it installs the newest match with no age evidence.
 #[test]
-fn age_gate_names_missing_publish_times_as_the_cause() {
-    let err = Error::AgeGate(Box::new(AgeGateDetails {
+fn release_age_missing_time_names_the_registry_as_the_cause() {
+    let err = Error::ReleaseAgeMissingTime(Box::new(UndatedDetails {
         name: "lodash".into(),
         range: "^4".into(),
-        minutes: 1440,
         importer: ".".into(),
         ancestors: vec![],
-        gated: vec!["4.17.21".into(), "4.17.20".into()],
-        publish_times_missing: true,
+        undated: vec!["4.17.21".into(), "4.17.20".into()],
     }));
+    assert_eq!(
+        err.code().expect("code set").to_string(),
+        "ERR_AUBE_RELEASE_AGE_MISSING_TIME",
+        "the two age failures must be branchable by code, not just by wording"
+    );
+    let headline = err.to_string();
     assert!(
-        err.to_string().contains("served no publish times"),
-        "headline must name the real cause, got: {err}"
+        headline.contains("lodash") && headline.contains("served no publish time"),
+        "headline must name the package and the real cause, got: {headline}"
     );
     let help = err.help().expect("help set").to_string();
     assert!(
@@ -234,18 +243,20 @@ fn age_gate_names_missing_publish_times_as_the_cause() {
         "must not imply the versions were too new: {help}"
     );
     assert!(
-        !help.contains("loosen `minimumReleaseAge`"),
-        "widening the window is not a remedy here: {help}"
+        !help.contains("minimumReleaseAgeStrict"),
+        "loosening strictness picks an undated version, so it is not a remedy: {help}"
     );
-    assert!(help.contains("minimumReleaseAgeExclude"));
+    assert!(help.contains("undated matching versions: 4.17.21, 4.17.20"));
+    assert!(help.contains("`lodash` to `minimumReleaseAgeExclude`"));
     assert!(help.contains("minimumReleaseAge=0"));
 }
 
 /// The mixed case stays an ordinary age gate: a populated `time` map with a
 /// hole for one version dates the rest fine, so the missing-times wording
-/// would be wrong.
+/// would be wrong. The gated list carries only the dated version — claiming
+/// the undated one was "blocked by age gate" asserts evidence we never had.
 #[test]
-fn age_gate_with_a_partially_dated_packument_is_not_the_missing_times_case() {
+fn age_gate_lists_only_versions_the_registry_dated() {
     let mut packument = make_packument("lodash", &["4.17.20", "4.17.21"], "4.17.21");
     packument.time.insert(
         "4.17.20".to_string(),
@@ -263,10 +274,10 @@ fn age_gate_with_a_partially_dated_packument_is_not_the_missing_times_case() {
         ancestors: Arc::from([]),
         range_from_override: false,
     };
-    let d = build_age_gate(&task, &packument, 1440);
-    assert!(
-        !d.publish_times_missing,
-        "one dated version is enough to make this an ordinary age gate"
+    assert_eq!(build_age_gate(&task, &packument, 1440).gated, ["4.17.20"]);
+    assert_eq!(
+        build_release_age_missing_time(&task, &packument).undated,
+        ["4.17.21"]
     );
 }
 
@@ -951,7 +962,7 @@ fn test_pick_version_strict_distinguishes_age_gate_from_no_match() {
         true,
         |_, _| false,
     );
-    assert!(matches!(result, PickResult::AgeGated));
+    assert!(matches!(result, PickResult::AgeGated(AgeGateCause::TooNew)));
 
     // No version satisfies the range at all → still NoMatch even
     // in strict mode.
@@ -1189,7 +1200,7 @@ fn test_pick_version_strict_returns_age_gated_when_cutoff_excludes_all() {
         true,
         |_, _| false,
     );
-    assert!(matches!(result, PickResult::AgeGated));
+    assert!(matches!(result, PickResult::AgeGated(AgeGateCause::TooNew)));
 }
 
 #[test]
@@ -1273,7 +1284,7 @@ fn test_pick_version_age_exempt_time_cutoff_age_gates_in_strict_mode() {
         true,
         |_, _| true,
     );
-    assert!(matches!(result, PickResult::AgeGated));
+    assert!(matches!(result, PickResult::AgeGated(AgeGateCause::TooNew)));
 }
 
 #[test]
@@ -1302,7 +1313,7 @@ fn test_pick_version_lenient_fallback_respects_time_cutoff() {
         false,
         |_, _| true,
     );
-    assert!(matches!(result, PickResult::AgeGated));
+    assert!(matches!(result, PickResult::AgeGated(AgeGateCause::TooNew)));
 }
 
 #[test]
@@ -1365,7 +1376,7 @@ fn test_pick_version_minimum_release_age_exclude_version_union() {
         is_age_exempt,
     );
     assert!(
-        matches!(result, PickResult::AgeGated),
+        matches!(result, PickResult::AgeGated(AgeGateCause::TooNew)),
         "a version not on the exclude list stays age-gated"
     );
 }
@@ -2699,7 +2710,10 @@ fn pick_version_missing_time_fails_closed_unless_modified_proves_maturity() {
     // old enough, so both are gated rather than waved through.
     let bare = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
     assert!(
-        matches!(pick(&bare), PickResult::AgeGated),
+        matches!(
+            pick(&bare),
+            PickResult::AgeGated(AgeGateCause::Undeterminable)
+        ),
         "a packument with no time data at all must not clear the cutoff"
     );
 
@@ -2718,7 +2732,10 @@ fn pick_version_missing_time_fails_closed_unless_modified_proves_maturity() {
     let mut churning = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
     churning.modified = Some("2026-06-01T00:00:00.000Z".to_string());
     assert!(
-        matches!(pick(&churning), PickResult::AgeGated),
+        matches!(
+            pick(&churning),
+            PickResult::AgeGated(AgeGateCause::Undeterminable)
+        ),
         "modified > cutoff leaves each version's age undeterminable"
     );
 
@@ -2735,6 +2752,35 @@ fn pick_version_missing_time_fails_closed_unless_modified_proves_maturity() {
         "1.0.0",
         "an undated version in a dated map is excluded, not admitted"
     );
+}
+
+/// When both refusals are in play, the provably-too-new one is what gets
+/// reported: waiting or widening the window is a real remedy for it, and the
+/// undateable wording would hide that. Only an all-undated range reports as
+/// undeterminable.
+#[test]
+fn pick_version_reports_a_dated_too_new_candidate_over_an_undated_one() {
+    const CUTOFF: &str = "2020-01-01T00:00:00.000Z";
+    let mut mixed = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    mixed.modified = Some("2026-06-01T00:00:00.000Z".to_string());
+    // 1.0.0 is dated and too new; 1.1.0 is undated in a map the `created` /
+    // `modified` bookkeeping keys do not populate, so its age is unprovable.
+    mixed
+        .time
+        .insert("1.0.0".to_string(), "2024-01-01T00:00:00.000Z".to_string());
+    assert!(matches!(
+        pick_version(
+            &mixed,
+            "^1.0.0",
+            None,
+            false,
+            Some(CUTOFF),
+            None,
+            true,
+            |_, _| false,
+        ),
+        PickResult::AgeGated(AgeGateCause::TooNew)
+    ));
 }
 
 /// Lenient mode keeps upstream aube's default: an undeterminable publish age
@@ -5653,7 +5699,7 @@ fn pick_version_for_add_strict_refuses_gated_pick() {
     let gate = mra(1440, true, &[]);
     assert!(matches!(
         pick_version_for_add(&packument, "foo", "1.1.0", Some(&gate)),
-        PickResult::AgeGated
+        PickResult::AgeGated(AgeGateCause::TooNew)
     ));
 }
 

--- a/vendor/aube/crates/aube/src/commands/add/manifest.rs
+++ b/vendor/aube/crates/aube/src/commands/add/manifest.rs
@@ -463,7 +463,7 @@ pub(super) async fn update_manifest_for_add(
                 minimum_release_age.as_ref(),
             ) {
                 aube_resolver::PickResult::Found(meta) => Some(meta.version.clone()),
-                aube_resolver::PickResult::NoMatch | aube_resolver::PickResult::AgeGated => None,
+                aube_resolver::PickResult::NoMatch | aube_resolver::PickResult::AgeGated(_) => None,
             }
         };
         let resolved_version = match aube_resolver::pick_version_for_add(
@@ -473,7 +473,28 @@ pub(super) async fn update_manifest_for_add(
             minimum_release_age.as_ref(),
         ) {
             aube_resolver::PickResult::Found(meta) => meta.version.clone(),
-            aube_resolver::PickResult::AgeGated => {
+            // An age the registry gave us no way to check is a different
+            // refusal from a release that is genuinely too new (#581), and
+            // `minimumReleaseAgeStrict=false` is not offered for it: loosening
+            // strictness would take the newest matching version with no age
+            // evidence at all. Mirrors the resolver's split so `add` and a
+            // full install report the same failure the same way.
+            aube_resolver::PickResult::AgeGated(aube_resolver::AgeGateCause::Undeterminable) => {
+                return Err(miette!(
+                    code = aube_codes::errors::ERR_AUBE_RELEASE_AGE_MISSING_TIME,
+                    help = format!(
+                        "the minimumReleaseAge window is checked against the registry's `time` \
+                         metadata, which this packument does not carry — no window would admit \
+                         these versions\nto proceed: point the registry in .npmrc at one that \
+                         serves publish times, add `{}` to `minimumReleaseAgeExclude`, or set \
+                         `minimumReleaseAge=0` to turn the window off for this project",
+                        spec.name
+                    ),
+                    "cannot check the publish age of {}@{effective_range} — the registry served no publish time for any matching version",
+                    spec.name,
+                ));
+            }
+            aube_resolver::PickResult::AgeGated(aube_resolver::AgeGateCause::TooNew) => {
                 // Only reachable in strict mode today (the lenient pick
                 // falls back instead), but derive the label anyway so a
                 // future lenient AgeGated path can't print a lie.

--- a/vendor/aube/crates/aube/src/commands/add/manifest.rs
+++ b/vendor/aube/crates/aube/src/commands/add/manifest.rs
@@ -484,10 +484,11 @@ pub(super) async fn update_manifest_for_add(
                     code = aube_codes::errors::ERR_AUBE_RELEASE_AGE_MISSING_TIME,
                     help = format!(
                         "the minimumReleaseAge window is checked against the registry's `time` \
-                         metadata, which this packument does not carry — no window would admit \
-                         these versions\nto proceed: point the registry in .npmrc at one that \
-                         serves publish times, add `{}` to `minimumReleaseAgeExclude`, or set \
-                         `minimumReleaseAge=0` to turn the window off for this project",
+                         metadata, which omits these versions — no window would admit them\n\
+                         to proceed: unset `registry-supports-time-field` if it is on (it \
+                         suppresses the full-packument fetch that carries `time`), check the \
+                         registry config in .npmrc, add `{}` to `minimumReleaseAgeExclude`, or \
+                         set `minimumReleaseAge=0` to turn the window off for this project",
                         spec.name
                     ),
                     "cannot check the publish age of {}@{effective_range} — the registry served no publish time for any matching version",

--- a/vendor/aube/docs/error-codes.data.json
+++ b/vendor/aube/docs/error-codes.data.json
@@ -61,6 +61,12 @@
       "exit_code": 21
     },
     {
+      "name": "ERR_AUBE_RELEASE_AGE_MISSING_TIME",
+      "category": "Resolver",
+      "description": "The registry served no publish time for any version satisfying the range, so `minimumReleaseAge` could not be evaluated (`minimumReleaseAgeStrict=true`). Distinct from `ERR_AUBE_NO_MATURE_MATCHING_VERSION` so CI tooling can tell a registry serving no `time` metadata from a genuinely too-new release.",
+      "exit_code": 28
+    },
+    {
       "name": "ERR_AUBE_BLOCKED_EXOTIC_SUBDEP",
       "category": "Resolver",
       "description": "Transitive dep used a `git:` / `file:` / `tarball` specifier and `blockExoticSubdeps=true`.",
@@ -924,6 +930,12 @@
       "name": "WARN_AUBE_UNSUPPORTED_PLATFORM_INSTALL",
       "category": "Resolver",
       "description": "A required (non-optional) dep declared a platform aube doesn't satisfy; installing anyway.",
+      "exit_code": null
+    },
+    {
+      "name": "WARN_AUBE_SKIPPED_OPTIONAL_NO_MATCHING_VERSION",
+      "category": "Resolver",
+      "description": "No version of an optional dep matched its range, so the dep was skipped instead of failing the install.",
       "exit_code": null
     },
     {


### PR DESCRIPTION
Refs #581

An undeterminable publish age blocked in strict mode but reported as an ordinary age gate: it listed versions never shown to be too new, and suggested `minimumReleaseAgeStrict=false`, which yields the lenient fallback, not a mature pick.

`pick_version` now returns the cause. With nothing datable, the resolver and `add` raise `ERR_AUBE_RELEASE_AGE_MISSING_TIME` (exit 28), mirroring `ERR_AUBE_TRUST_MISSING_TIME`; its help names the registry, `minimumReleaseAgeExclude` and `minimumReleaseAge=0`, and omits strictness. A dated too-new candidate outranks an undated one, so a mixed range stays an age gate.

Default-preserving: standalone aube defaults strict to false, so neither error is reachable there.