### PR TITLE
compile: target-aware asset-name validation, and file:line in bundler errors

### DIFF
--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -687,16 +687,22 @@ fn snippet(source: &str, start: usize, end: usize) -> String {
 /// `BuildDiagnostic`'s `Debug` prints only severity/kind/message, so `{e:?}` gave
 /// a `PARSE_ERROR` with no indication of WHICH file failed — undebuggable on a
 /// real migration without reproducing each failure standalone. Rolldown carries
-/// the location already; `to_diagnostic_with` is what materializes it (the
-/// message alone never has it, and for plugin-wrapped events it is empty).
+/// the location already; `to_diagnostic_with` is what materializes it.
 fn render_diagnostics(err: &rolldown_error::BatchedBuildDiagnostic) -> String {
     let opts = DiagnosticOptions::default();
     err.iter()
         .map(|d| {
+            let diagnostic = d.to_diagnostic_with(&opts);
             let message = d.to_message_with(&opts);
+            // A plugin-wrapped event's own `message()` is deliberately empty — its
+            // real text is injected by `on_diagnostic` — so fall back to the full
+            // rendered report, which carries its own location.
+            if message.is_empty() {
+                return diagnostic.to_string();
+            }
             // Columns are 0-based here and 1-based in every other diagnostic nub
             // prints, so they are converted rather than passed through.
-            match d.to_diagnostic_with(&opts).get_primary_location() {
+            match diagnostic.get_primary_location() {
                 Some((file, line, column, _)) => {
                     format!(
                         "\x20\x20{file}:{line}:{}\n\x20\x20\x20\x20{message}",

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -185,11 +185,11 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
             .with_options(options)
             .with_plugins(plugins)
             .build()
-            .map_err(|e| anyhow!("rolldown init: {e:?}"))?;
+            .map_err(|e| anyhow!("rolldown init:\n{}", render_diagnostics(&e)))?;
         bundler
             .generate()
             .await
-            .map_err(|e| anyhow!("rolldown bundle failed: {e:?}"))
+            .map_err(|e| anyhow!("the bundler failed:\n{}", render_diagnostics(&e)))
     })?;
 
     reject_unresolved(&scan.take(), &output.warnings)?;
@@ -679,6 +679,43 @@ fn snippet(source: &str, start: usize, end: usize) -> String {
     } else {
         text
     }
+}
+
+/// Render bundler errors as `file:line:column` + message, in the same shape the
+/// unresolved-import and invalid-chunk gates below use.
+///
+/// `BuildDiagnostic`'s `Debug` prints only severity/kind/message, so `{e:?}` gave
+/// a `PARSE_ERROR` with no indication of WHICH file failed — undebuggable on a
+/// real migration without reproducing each failure standalone. Rolldown carries
+/// the location already; `to_diagnostic_with` is what materializes it (the
+/// message alone never has it, and for plugin-wrapped events it is empty).
+fn render_diagnostics(err: &rolldown_error::BatchedBuildDiagnostic) -> String {
+    let opts = DiagnosticOptions::default();
+    err.iter()
+        .map(|d| {
+            let message = d.to_message_with(&opts);
+            // Columns are 0-based here and 1-based in every other diagnostic nub
+            // prints, so they are converted rather than passed through.
+            match d.to_diagnostic_with(&opts).get_primary_location() {
+                Some((file, line, column, _)) => {
+                    format!(
+                        "\x20\x20{file}:{line}:{}\n\x20\x20\x20\x20{message}",
+                        column + 1
+                    )
+                }
+                // No label — a config or resolve error, not a source position.
+                // The module id is still the most locating thing available.
+                None => match d.id() {
+                    Some(id) => format!(
+                        "\x20\x20{}\n\x20\x20\x20\x20{message}",
+                        opts.stabilize_path(id)
+                    ),
+                    None => format!("\x20\x20{message}"),
+                },
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Fail the build on any import the bundler could not resolve — the

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -105,7 +105,7 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
     eprintln!("Bundling {} …", opts.entry);
     let bundled = bundle::bundle(&entry_abs, &opts.bundle)?;
     let mut entry_name = layout.bundle_path(&bundled.entry);
-    let mut app_files = assemble_app(&bundled, &layout)?;
+    let mut app_files = assemble_app(&bundled, &layout, &target)?;
     if !opts.bundle.external.is_empty() {
         let shim = external::shim(&app_files, &entry_name, &opts.bundle.external)?;
         entry_name = shim.entry;
@@ -304,7 +304,11 @@ fn target_defines(target: &TargetPlatform) -> Vec<(String, String)> {
 /// so the entry's own directory is the one position no `--include`d file can
 /// shadow. With no assets the entry is already at the root, so this is the same
 /// file in the same place it has always been.
-fn assemble_app(bundled: &bundle::BundleResult, layout: &assets::Layout) -> Result<AppFiles> {
+fn assemble_app(
+    bundled: &bundle::BundleResult,
+    layout: &assets::Layout,
+    target: &TargetPlatform,
+) -> Result<AppFiles> {
     let mut files: AppFiles = bundled
         .files
         .iter()
@@ -349,16 +353,20 @@ fn assemble_app(bundled: &bundle::BundleResult, layout: &assets::Layout) -> Resu
 
     // The launcher refuses any payload name that could escape its extraction dir.
     // Names are partly user-derived since `--include`, so check the SAME predicate
-    // on the WHOLE set here — the last point where every name exists — rather than
-    // shipping an executable that aborts on someone else's machine. Checked against
-    // the TARGET's rules, since a name that is one component on Linux can be an
-    // escape on Windows.
+    // on the WHOLE set here — rather than shipping an executable that aborts on
+    // someone else's machine. Checked against the TARGET's rules, never the host's:
+    // `a\..\..\x` is one ordinary filename on Linux and a traversal on Windows, so
+    // a host-parsed gate lets a cross-compile bake a name its own launcher refuses.
+    let rules = target.name_rules();
     for (name, _) in &files {
-        if !nub_core::compile::is_safe_relative_name(name) {
+        if !nub_core::compile::is_safe_relative_name_for(rules, name) {
             bail!(
-                "this path cannot be embedded: {name:?}. An --include'd path must sit \
-                 inside the tree that holds the entry, and its name must be a plain \
-                 relative path."
+                "this path cannot be embedded for {}: {name:?}. An --include'd path must \
+                 sit inside the tree that holds the entry, and its name must be a plain \
+                 relative path that is also legal on the target — on Windows that rules \
+                 out `\\`, `<>:\"|?*`, a trailing dot or space, and the reserved device \
+                 names (CON, PRN, AUX, NUL, COM1-9, LPT1-9).",
+                target.triple()
             );
         }
     }
@@ -923,6 +931,45 @@ mod tests {
             msg.contains("NUB_LAUNCHER_TEMPLATE"),
             "should name the override: {msg}"
         );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The name gate must read the TARGET's path rules, not the build host's.
+    /// `a\..\..\x` is one ordinary filename on Unix, so a host-parsed gate lets a
+    /// Unix→win32 cross-compile bake an escaping name — which only surfaces as an
+    /// abort on the Windows user's machine. (The predicate itself is covered in
+    /// nub-core; this pins that the target actually reaches it.)
+    #[test]
+    fn the_payload_name_gate_dispatches_on_the_target_not_the_host() {
+        let dir = fresh_dir("winsafe");
+        let source = dir.join("asset.bin");
+        fs::write(&source, b"x").unwrap();
+
+        let bundled = bundle::BundleResult {
+            entry: "main.js".into(),
+            files: vec![bundle::BundledFile {
+                name: "main.js".into(),
+                bytes: b"export {}".to_vec(),
+            }],
+            detached_maps: Vec::new(),
+        };
+        let layout = assets::Layout {
+            entry_prefix: String::new(),
+            assets: vec![assets::Asset {
+                source,
+                rel: "a\\..\\..\\escaped".into(),
+            }],
+        };
+
+        let win = TargetPlatform::parse("win32-x64").unwrap();
+        let err = assemble_app(&bundled, &layout, &win).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("cannot be embedded"), "{msg}");
+        assert!(msg.contains("win32-x64"), "should name the target: {msg}");
+
+        // The same name on a Unix target is a legal single-component filename.
+        let linux = TargetPlatform::parse("linux-x64").unwrap();
+        assert!(assemble_app(&bundled, &layout, &linux).is_ok());
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -107,6 +107,9 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
     let mut entry_name = layout.bundle_path(&bundled.entry);
     let mut app_files = assemble_app(&bundled, &layout, &target)?;
     if !opts.bundle.external.is_empty() {
+        // These land AFTER assemble_app's payload-name gate. Safe because both are
+        // fixed constants legal on every target — a shim name derived from user
+        // input would have to move the gate here.
         let shim = external::shim(&app_files, &entry_name, &opts.bundle.external)?;
         entry_name = shim.entry;
         app_files.extend(shim.files);
@@ -358,14 +361,22 @@ fn assemble_app(
     // `a\..\..\x` is one ordinary filename on Linux and a traversal on Windows, so
     // a host-parsed gate lets a cross-compile bake a name its own launcher refuses.
     let rules = target.name_rules();
+    // A chunk's name carries `layout.entry_prefix`, so a rejection is not always
+    // an --include's fault — an entry under `src/aux/` trips the Windows device
+    // rule on the directory the source tree already has.
+    let windows_rules = if rules == nub_core::compile::NameRules::Windows {
+        "\n\x20\x20On Windows that rules out `\\`, `<>:\"|?*`, a trailing dot or space, and the \
+         reserved\n\x20\x20device names (CON, PRN, AUX, NUL, COM0-9, LPT0-9) — including as a \
+         directory\n\x20\x20component, or before an extension."
+    } else {
+        ""
+    };
     for (name, _) in &files {
         if !nub_core::compile::is_safe_relative_name_for(rules, name) {
             bail!(
-                "this path cannot be embedded for {}: {name:?}. An --include'd path must \
-                 sit inside the tree that holds the entry, and its name must be a plain \
-                 relative path that is also legal on the target — on Windows that rules \
-                 out `\\`, `<>:\"|?*`, a trailing dot or space, and the reserved device \
-                 names (CON, PRN, AUX, NUL, COM1-9, LPT1-9).",
+                "this path cannot be embedded for {}: {name:?}.\n\
+                 \x20\x20Every file in a compiled binary needs a plain relative name the target \
+                 can create.{windows_rules}",
                 target.triple()
             );
         }
@@ -969,7 +980,8 @@ mod tests {
 
         // The same name on a Unix target is a legal single-component filename.
         let linux = TargetPlatform::parse("linux-x64").unwrap();
-        assert!(assemble_app(&bundled, &layout, &linux).is_ok());
+        assemble_app(&bundled, &layout, &linux)
+            .expect("a backslash name is one legal component on a Unix target");
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/crates/nub-core/src/compile.rs
+++ b/crates/nub-core/src/compile.rs
@@ -190,18 +190,27 @@ fn is_safe_windows_component(part: &str) -> bool {
 }
 
 fn is_dos_device(stem: &str) -> bool {
-    let upper = stem.to_ascii_uppercase();
+    // Win32's device matcher strips trailing spaces off the segment before
+    // comparing, so `con .txt` is the console as much as `CON.txt` is — and the
+    // whole-component trailing-space rule above cannot see a space that sits
+    // before the extension.
+    let upper = stem.trim_end_matches(' ').to_ascii_uppercase();
     if matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL") {
         return true;
     }
-    // COM1-9 and LPT1-9 only; `COM0` is an ordinary name.
-    let Some(digit) = upper
+    // Microsoft's reserved list in full, superscripts included. Erring wide costs
+    // nothing — no real project names a file `COM0` — while erring narrow ships a
+    // binary that writes to a device.
+    let Some(rest) = upper
         .strip_prefix("COM")
         .or_else(|| upper.strip_prefix("LPT"))
     else {
         return false;
     };
-    matches!(digit.as_bytes(), [b'1'..=b'9'])
+    matches!(
+        rest,
+        "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "¹" | "²" | "³"
+    )
 }
 
 /// Encode a payload into the container blob written to the Mach-O section.
@@ -649,7 +658,12 @@ mod tests {
             "con",
             "assets/CON.txt",
             "com1",
+            "COM0",
             "LPT9.dat",
+            // Win32 strips the trailing space off the segment before matching
+            // the device, so the space does not make this an ordinary file.
+            "con .txt",
+            "aux/data.json",
         ] {
             assert!(
                 is_safe_relative_name_for(Unix, win_only),
@@ -660,9 +674,15 @@ mod tests {
                 "{win_only:?} must not be embedded for a Windows target"
             );
         }
-        // Not devices: the digit range is 1-9, and a longer name merely starts
-        // with the prefix.
-        for ok in ["COM0", "COM10", "console.js", "nulls.json"] {
+        // Not devices: a longer name merely starts with the prefix.
+        for ok in [
+            "COM10",
+            "console.js",
+            "nulls.json",
+            "PROGRA~1",
+            "..a",
+            "a..b",
+        ] {
             assert!(is_safe_relative_name_for(Windows, ok), "{ok:?}");
         }
     }

--- a/crates/nub-core/src/compile.rs
+++ b/crates/nub-core/src/compile.rs
@@ -100,9 +100,39 @@ pub struct PayloadView<'a> {
     pub node_blob: &'a [u8],
 }
 
-/// Whether a payload file name is safe to join under the extraction dir: every
-/// component a plain name — no root/prefix, no `..`, no leading separator, no `.`.
-/// Nested `a/b.js` is allowed; anything that could escape is not.
+/// Whose path rules a payload name has to survive.
+///
+/// The machine that BUILDS an artifact and the machine that RUNS it are different
+/// platforms under `--platform`, and `std::path` only ever parses the rules of the
+/// platform it was compiled for. `a\..\..\x` is one ordinary filename on Unix and
+/// a traversal on Windows, so a Unix host cross-compiling `win32-*` must judge
+/// names by the TARGET's rules or it bakes a name its own launcher will refuse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NameRules {
+    Unix,
+    Windows,
+}
+
+impl NameRules {
+    /// The rules of the platform this binary runs on — what the launcher uses,
+    /// since a launcher only ever executes on the target it was built for.
+    pub const HOST: Self = if cfg!(windows) {
+        Self::Windows
+    } else {
+        Self::Unix
+    };
+}
+
+/// Whether a payload file name is safe to join under the extraction dir on the
+/// HOST. See [`is_safe_relative_name_for`]; this is the launcher's spelling.
+pub fn is_safe_relative_name(name: &str) -> bool {
+    is_safe_relative_name_for(NameRules::HOST, name)
+}
+
+/// Whether a payload file name is safe to join under the extraction dir under
+/// `rules`: every component a plain name — no root/prefix, no `..`, no `.`, no
+/// leading/trailing/doubled separator. Nested `a/b.js` is allowed; anything that
+/// could escape, name a device, or collide after the platform normalizes it is not.
 ///
 /// Lives here because BOTH sides of the container must agree. The launcher
 /// enforces it while extracting (a corrupted or hostile section must not write
@@ -110,12 +140,68 @@ pub struct PayloadView<'a> {
 /// `--include` derives payload names from user-supplied paths, a name the
 /// launcher would reject has to fail the BUILD rather than ship an executable
 /// that aborts on the user's machine.
-pub fn is_safe_relative_name(name: &str) -> bool {
-    use std::path::{Component, Path};
-    !name.is_empty()
-        && Path::new(name)
-            .components()
-            .all(|c| matches!(c, Component::Normal(_)))
+///
+/// Parsed by hand rather than through `std::path` precisely because `std::path`
+/// is fixed to the host at compile time; see [`NameRules`].
+pub fn is_safe_relative_name_for(rules: NameRules, name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let separators: &[char] = match rules {
+        NameRules::Unix => &['/'],
+        // Win32 resolves `\` and `/` identically, so a name is split on both
+        // before any component is judged — this is the whole cross-compile hole.
+        NameRules::Windows => &['/', '\\'],
+    };
+    for part in name.split(separators) {
+        // Empty = a leading, trailing, or doubled separator: an absolute path, a
+        // UNC prefix, or a spelling the two platforms disagree about.
+        if part.is_empty() || part == "." || part == ".." || part.contains('\0') {
+            return false;
+        }
+        if rules == NameRules::Windows && !is_safe_windows_component(part) {
+            return false;
+        }
+    }
+    true
+}
+
+/// The Win32-only half: names that are not traversals but still do not denote the
+/// file the payload says they do.
+fn is_safe_windows_component(part: &str) -> bool {
+    // Win32 strips trailing dots and spaces, so `main.js. ` and `main.js` open the
+    // SAME file. Two payload entries differing only there pass the build's
+    // distinct-name check and then overwrite each other at extraction — including
+    // an `--include`d file landing on top of a compiled chunk.
+    if part.ends_with('.') || part.ends_with(' ') {
+        return false;
+    }
+    // `:` opens a drive or an NTFS alternate data stream; the rest are outright
+    // illegal in a Win32 name, so the launcher's write fails on the user's machine
+    // with nothing pointing back at the build that caused it.
+    if part.contains(|c: char| {
+        matches!(c, '<' | '>' | ':' | '"' | '|' | '?' | '*') || (c as u32) < 0x20
+    }) {
+        return false;
+    }
+    // A reserved DOS device resolves to the device at ANY directory depth and
+    // through any extension — writing `CON.txt` writes to the console.
+    !is_dos_device(part.split('.').next().unwrap_or(part))
+}
+
+fn is_dos_device(stem: &str) -> bool {
+    let upper = stem.to_ascii_uppercase();
+    if matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL") {
+        return true;
+    }
+    // COM1-9 and LPT1-9 only; `COM0` is an ordinary name.
+    let Some(digit) = upper
+        .strip_prefix("COM")
+        .or_else(|| upper.strip_prefix("LPT"))
+    else {
+        return false;
+    };
+    matches!(digit.as_bytes(), [b'1'..=b'9'])
 }
 
 /// Encode a payload into the container blob written to the Mach-O section.
@@ -358,6 +444,14 @@ impl TargetPlatform {
         }
     }
 
+    /// The path rules a payload name must survive once this target extracts it.
+    pub fn name_rules(&self) -> NameRules {
+        match self.os {
+            TargetOs::Win32 => NameRules::Windows,
+            _ => NameRules::Unix,
+        }
+    }
+
     /// The executable suffix for this target (`.exe` on Windows).
     pub fn exe_suffix(&self) -> &'static str {
         match self.os {
@@ -502,5 +596,83 @@ mod tests {
         let host = TargetPlatform::host().expect("a dev/CI host is always a supported platform");
         assert!(SUPPORTED_TRIPLES.contains(&host.triple().as_str()));
         assert!(host.is_host());
+    }
+
+    /// The gate runs on the BUILD machine, so both target families must be
+    /// judgeable from either host — these cases all run on every CI platform.
+    #[test]
+    fn a_payload_name_is_judged_by_the_targets_path_rules_not_the_hosts() {
+        use NameRules::{Unix, Windows};
+
+        for rules in [Unix, Windows] {
+            for ok in ["main.js", "chunk-abc.js", "src/nested/chunk.js", "a.b.c"] {
+                assert!(is_safe_relative_name_for(rules, ok), "{rules:?} {ok:?}");
+            }
+            for bad in [
+                "",
+                ".",
+                "..",
+                "./main.js",
+                "../evil",
+                "a/../../evil",
+                "/etc/passwd",
+                "a//b",
+                "a/",
+                "a/\0b",
+            ] {
+                assert!(!is_safe_relative_name_for(rules, bad), "{rules:?} {bad:?}");
+            }
+        }
+
+        // The cross-compile hole: ordinary Unix filenames, traversals on Windows.
+        for backslash in ["a\\..\\..\\x", "..\\evil", "C:\\Windows\\x", "\\etc\\x"] {
+            assert!(
+                is_safe_relative_name_for(Unix, backslash),
+                "{backslash:?} is a legal single-component Unix filename"
+            );
+            assert!(
+                !is_safe_relative_name_for(Windows, backslash),
+                "{backslash:?} escapes under Win32 path rules"
+            );
+        }
+
+        // Win32-only hazards that are not traversals: a name Win32 normalizes
+        // onto another payload entry, an illegal character, a drive/ADS colon,
+        // and a reserved device at any depth or extension.
+        for win_only in [
+            "main.js. ",
+            "main.js.",
+            "main.js ",
+            "a<b",
+            "a|b",
+            "C:x",
+            "con",
+            "assets/CON.txt",
+            "com1",
+            "LPT9.dat",
+        ] {
+            assert!(
+                is_safe_relative_name_for(Unix, win_only),
+                "{win_only:?} is an ordinary name on a Unix target"
+            );
+            assert!(
+                !is_safe_relative_name_for(Windows, win_only),
+                "{win_only:?} must not be embedded for a Windows target"
+            );
+        }
+        // Not devices: the digit range is 1-9, and a longer name merely starts
+        // with the prefix.
+        for ok in ["COM0", "COM10", "console.js", "nulls.json"] {
+            assert!(is_safe_relative_name_for(Windows, ok), "{ok:?}");
+        }
+    }
+
+    #[test]
+    fn the_target_platform_selects_the_rules() {
+        let rules = |t: &str| TargetPlatform::parse(t).unwrap().name_rules();
+        assert_eq!(rules("win32-x64"), NameRules::Windows);
+        assert_eq!(rules("win32-arm64"), NameRules::Windows);
+        assert_eq!(rules("linux-x64-musl"), NameRules::Unix);
+        assert_eq!(rules("darwin-arm64"), NameRules::Unix);
     }
 }


### PR DESCRIPTION
Two independent `nub compile` fixes, into `compile-spike`. Touches `bundle.rs` only at two call sites plus one new helper, to stay clear of the concurrent loaders work.

**Target-aware asset-name gate.** Names from `--include` were validated with `std::path`, which is fixed to the build host. `a\..\..\x` is one ordinary filename on Unix and a traversal on Windows, so a macOS host cross-compiling `--platform win32-x64` baked a name its own launcher then refuses. The gate now dispatches on the target; the Windows rules also reject `<>:"|?*`, control characters, a trailing dot or space, and device names.

**Bundler errors carry file:line:column.** A parse error no longer prints an opaque struct.
