### PR TITLE
compile: text and file asset loaders

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -941,6 +941,12 @@ pub enum Command {
         #[arg(long, value_name = "FROM=TO", action = ArgAction::Append, help_heading = COMPILE_ADVANCED)]
         alias: Vec<String>,
 
+        /// Choose what importing a file extension evaluates to, repeatable:
+        /// `--loader .html=file`. Types: `file` (embeds the file and yields its
+        /// path), `text`, `json`, `base64`, `dataurl`, `binary`, `empty`.
+        #[arg(long, value_name = "EXT=TYPE", action = ArgAction::Append, help_heading = COMPILE_ADVANCED)]
+        loader: Vec<String>,
+
         /// Extra `exports` condition to honor, repeatable. Added to the
         /// defaults rather than replacing them.
         #[arg(long, value_name = "NAME", action = ArgAction::Append, help_heading = COMPILE_ADVANCED)]
@@ -2575,6 +2581,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             no_treeshake,
             ignore_annotations,
             alias,
+            loader,
             conditions,
             external,
             tsconfig,
@@ -2606,6 +2613,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
                 conditions,
                 external,
                 tsconfig: tsconfig.map(PathBuf::from),
+                loaders: loader,
             },
         }),
         Some(Command::Init {

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -213,6 +213,19 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
             .generate()
             .await
             .map_err(|e| anyhow!("the bundler failed:\n{}", render_diagnostics(&e)))
+    });
+    // A case-mismatched extension fails inside Rolldown with a diagnostic that
+    // names neither loaders nor the flag that fixes it, and a plugin cannot
+    // improve that from the hook — Rolldown replaces a plugin error with its own
+    // `UNLOADABLE_DEPENDENCY`. So the hint is attached here, to the failure the
+    // user actually sees.
+    let output = output.map_err(|e| {
+        let hints = files_plugin.case_hints();
+        if hints.is_empty() {
+            e
+        } else {
+            anyhow!("{e}\n\n{}", hints.join("\n"))
+        }
     })?;
 
     reject_unresolved(&scan.take(), &output.warnings)?;

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -117,10 +117,10 @@ pub struct BundleResult {
     pub files: Vec<BundledFile>,
     /// `--sourcemap=external` maps: emitted, unreferenced, not shipped.
     pub detached_maps: Vec<BundledFile>,
-    /// Loader-emitted assets — the `file` loader's payload, plus anything
-    /// Rolldown emitted for a `new URL(…, import.meta.url)` reference. Kept
-    /// APART from [`Self::files`] because those are re-parsed as JavaScript by
-    /// [`reject_invalid_chunks`], which a `.wasm` would rightly fail.
+    /// Loader-emitted assets — in practice the `file` loader's payload, since
+    /// nothing else in nub's configuration makes Rolldown emit a non-map asset.
+    /// Kept APART from [`Self::files`] because those are re-parsed as JavaScript
+    /// by [`reject_invalid_chunks`], which a `.wasm` would rightly fail.
     pub assets: Vec<BundledFile>,
 }
 
@@ -248,13 +248,22 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
                     name: a.filename.to_string(),
                     bytes,
                 };
-                // Everything Rolldown emits that is NOT a source map is an asset
-                // the chunks reference by name — today, the file a `new URL(…,
-                // import.meta.url)` points at. Dropping it (as this arm did
-                // before loaders existed) ships a chunk naming a file that is not
-                // in the payload: a runtime ENOENT with nothing failing at build
-                // time. `--include` still never routes through here — it embeds
-                // bytes straight from disk, which is what makes it verbatim.
+                // Everything Rolldown emits that is NOT a source map is a file
+                // the chunks reference by name, so dropping it (as this arm did
+                // before loaders existed) would ship a chunk naming a file that
+                // is not in the payload — a runtime ENOENT with nothing failing
+                // at build time.
+                //
+                // Nothing reaches this branch today: nub's `file` loader collects
+                // its own bytes, and Rolldown's asset path is gated on
+                // `experimental.resolve_new_url_to_asset`, which defaults off and
+                // nub never sets — so a `new URL(…, import.meta.url)` is left as
+                // a literal and emits nothing. This is kept as the correct
+                // handling rather than a silent drop, so enabling that flag (or
+                // any future emitting plugin) cannot quietly produce a broken
+                // artifact. `--include` never routes through here at all — it
+                // embeds bytes straight from disk, which is what makes it
+                // verbatim.
                 if a.filename.ends_with(".map") {
                     maps.push(file);
                 } else {
@@ -280,6 +289,7 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
     };
     files.extend(maps);
 
+    retain_referenced(&files, &mut assets);
     reject_nested_chunks(&files, &assets)?;
 
     Ok(BundleResult {
@@ -288,6 +298,33 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
         detached_maps,
         assets,
     })
+}
+
+/// Drop assets that no emitted chunk names.
+///
+/// The `file` loader reads and records an asset in its `load` hook, which runs
+/// while the graph is being built — before anything is tree-shaken. So an import
+/// whose binding goes unused still collects its bytes, and without this pass a
+/// stray `import splash from "./splash.mp4"` would embed the file in every
+/// artifact forever. (This is entry-language-dependent and therefore easy to
+/// miss: a `.ts` entry never reaches the hook at all, because the TypeScript
+/// transform elides an unused import as possibly-type-only, while the identical
+/// `.js` entry does. The payload should not depend on which one you wrote.)
+///
+/// Reachability is decided by a substring scan for the asset's name, which is
+/// exact here rather than approximate: the name carries an 8-hex content hash,
+/// and the only way user code can reach the file is through the path string the
+/// loader emitted — a name absent from every chunk is unreachable by
+/// construction. Minification preserves it, since it lives in a string literal.
+fn retain_referenced(chunks: &[BundledFile], assets: &mut Vec<BundledFile>) {
+    if assets.is_empty() {
+        return;
+    }
+    let code: Vec<String> = chunks
+        .iter()
+        .map(|c| String::from_utf8_lossy(&c.bytes).into_owned())
+        .collect();
+    assets.retain(|asset| code.iter().any(|c| c.contains(&asset.name)));
 }
 
 /// Assert the flat-output invariant the `file` loader rests on.
@@ -1141,6 +1178,68 @@ mod tests {
             );
         }
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // An asset the emitted code never names must not ship, and the payload must
+    // NOT depend on whether the entry was written in TypeScript or JavaScript.
+    //
+    // This is the case that made the loader look correct when it was not: the
+    // `load` hook collects bytes during graph construction, before tree-shaking,
+    // so an unused import embeds its file — but only from a `.js` entry, because
+    // the TypeScript transform elides an unused import as possibly-type-only and
+    // the hook never runs. Testing only the `.ts` spelling reports success.
+    #[test]
+    fn an_asset_no_chunk_names_is_not_shipped_from_either_entry_language() {
+        for ext in ["ts", "js"] {
+            let dir = std::env::temp_dir().join(format!("nub-unused-{}-{ext}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("logo.png"), b"UNUSEDPNGBYTES").unwrap();
+            std::fs::write(
+                dir.join(format!("entry.{ext}")),
+                b"import p from './logo.png';\nglobalThis.OUT = 'hi';\n",
+            )
+            .unwrap();
+
+            let mut o = opts();
+            o.minify = false;
+            let res = bundle(&dir.join(format!("entry.{ext}")), &o).expect("compiles");
+            assert!(
+                res.assets.is_empty(),
+                "a .{ext} entry shipped an asset nothing references: {:?}",
+                res.assets.iter().map(|a| &a.name).collect::<Vec<_>>()
+            );
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+
+    // The control for the test above: the SAME asset, actually used, still ships
+    // from both entry languages. Without it, "no assets" would also be satisfied
+    // by a loader that silently stopped working.
+    #[test]
+    fn a_used_asset_ships_from_either_entry_language() {
+        for ext in ["ts", "js"] {
+            let dir = std::env::temp_dir().join(format!("nub-used-{}-{ext}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("logo.png"), b"USEDPNGBYTES").unwrap();
+            std::fs::write(
+                dir.join(format!("entry.{ext}")),
+                b"import p from './logo.png';\nglobalThis.OUT = p;\n",
+            )
+            .unwrap();
+
+            let mut o = opts();
+            o.minify = false;
+            let res = bundle(&dir.join(format!("entry.{ext}")), &o).expect("compiles");
+            assert_eq!(
+                res.assets.len(),
+                1,
+                "a used asset must ship from a .{ext} entry"
+            );
+            assert_eq!(res.assets[0].bytes, b"USEDPNGBYTES");
+            let _ = std::fs::remove_dir_all(&dir);
+        }
     }
 
     // `.md` is the text half. Both spellings must land on the same string: the

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -48,6 +48,8 @@ use rolldown_common::{
 use rolldown_error::{BuildDiagnostic, DiagnosticOptions, EventKind};
 use rolldown_utils::indexmap::FxIndexMap;
 
+use super::loaders;
+
 /// Where the source map goes. `Linked` and `External` both emit a real `.map`;
 /// they differ only in whether the bundle references it — which for a compiled
 /// artifact also decides whether the map ships INSIDE the executable or lands
@@ -97,6 +99,9 @@ pub struct BundleOptions {
     pub external: Vec<String>,
     /// Explicit tsconfig; `None` keeps Rolldown's auto-discovery.
     pub tsconfig: Option<PathBuf>,
+    /// `EXT=TYPE` from `--loader`, applied over nub's defaults. See
+    /// [`crate::compile::loaders`].
+    pub loaders: Vec<String>,
 }
 
 /// One emitted file: a chunk, or a source map that travels with it.
@@ -112,6 +117,11 @@ pub struct BundleResult {
     pub files: Vec<BundledFile>,
     /// `--sourcemap=external` maps: emitted, unreferenced, not shipped.
     pub detached_maps: Vec<BundledFile>,
+    /// Loader-emitted assets — the `file` loader's payload, plus anything
+    /// Rolldown emitted for a `new URL(…, import.meta.url)` reference. Kept
+    /// APART from [`Self::files`] because those are re-parsed as JavaScript by
+    /// [`reject_invalid_chunks`], which a `.wasm` would rightly fail.
+    pub assets: Vec<BundledFile>,
 }
 
 pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
@@ -128,11 +138,20 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_else(|| "main".into());
 
+    let loader_plan = loaders::plan(&opts.loaders)?;
+
     let options = BundlerOptions {
         input: Some(vec![InputItem {
             name: Some(stem),
             import,
         }]),
+        module_types: (!loader_plan.module_types.is_empty()).then(|| {
+            loader_plan
+                .module_types
+                .iter()
+                .map(|(ext, ty)| (ext.clone(), ty.clone()))
+                .collect()
+        }),
         cwd: Some(cwd),
         format: Some(OutputFormat::Esm),
         platform: Some(Platform::Node),
@@ -174,7 +193,11 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
     };
 
     let scan = std::sync::Arc::new(DynamicImportScan::default());
-    let plugins: Vec<SharedPluginable> = vec![std::sync::Arc::clone(&scan) as SharedPluginable];
+    let files_plugin = std::sync::Arc::new(loaders::FilePlugin::new(&loader_plan));
+    let plugins: Vec<SharedPluginable> = vec![
+        std::sync::Arc::clone(&scan) as SharedPluginable,
+        std::sync::Arc::clone(&files_plugin) as SharedPluginable,
+    ];
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -197,6 +220,14 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
     let mut entry = None;
     let mut files = Vec::new();
     let mut maps = Vec::new();
+    let mut assets: Vec<BundledFile> = files_plugin
+        .take()
+        .into_iter()
+        .map(|a| BundledFile {
+            name: a.name,
+            bytes: a.bytes,
+        })
+        .collect();
     for asset in &output.assets {
         match asset {
             Output::Chunk(c) => {
@@ -208,18 +239,28 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
                     bytes: c.code.as_bytes().to_vec(),
                 });
             }
-            // Only source maps are collected. Nothing configures a loader that
-            // emits other assets, and `--include` never routes through the
-            // bundler at all — it embeds bytes straight from disk, which is what
-            // makes it verbatim.
-            Output::Asset(a) if a.filename.ends_with(".map") => maps.push(BundledFile {
-                name: a.filename.to_string(),
-                bytes: match &a.source {
+            Output::Asset(a) => {
+                let bytes = match &a.source {
                     StrOrBytes::Str(s) => s.as_bytes().to_vec(),
                     StrOrBytes::Bytes(b) => b.clone(),
-                },
-            }),
-            Output::Asset(_) => {}
+                };
+                let file = BundledFile {
+                    name: a.filename.to_string(),
+                    bytes,
+                };
+                // Everything Rolldown emits that is NOT a source map is an asset
+                // the chunks reference by name — today, the file a `new URL(…,
+                // import.meta.url)` points at. Dropping it (as this arm did
+                // before loaders existed) ships a chunk naming a file that is not
+                // in the payload: a runtime ENOENT with nothing failing at build
+                // time. `--include` still never routes through here — it embeds
+                // bytes straight from disk, which is what makes it verbatim.
+                if a.filename.ends_with(".map") {
+                    maps.push(file);
+                } else {
+                    assets.push(file);
+                }
+            }
         }
     }
     let entry = entry.context("the bundler emitted no entry chunk")?;
@@ -239,11 +280,54 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
     };
     files.extend(maps);
 
+    reject_nested_chunks(&files, &assets)?;
+
     Ok(BundleResult {
         entry,
         files,
         detached_maps,
+        assets,
     })
+}
+
+/// Assert the flat-output invariant the `file` loader rests on.
+///
+/// A `file` import evaluates to `new URL("./<name>", import.meta.url)`, resolved
+/// against whichever CHUNK the importing module was bundled into. That is only
+/// the asset's location while every chunk and every nub-emitted asset sit in one
+/// directory. Rolldown's defaults do put them there, but `chunkFileNames` is
+/// configurable and a future flag could nest them — at which point every `file`
+/// import would silently resolve to a path that does not exist, on the deploy
+/// machine, with no build-time signal. Checking is a string scan; the failure it
+/// prevents is a shipped-broken binary.
+///
+/// Rolldown's OWN assets are exempt: it rewrites those references itself
+/// (`compute_relative_path`), so a nested `assets/x-HASH.png` stays correct.
+fn reject_nested_chunks(chunks: &[BundledFile], assets: &[BundledFile]) -> Result<()> {
+    let nested: Vec<&str> = chunks
+        .iter()
+        .map(|f| f.name.as_str())
+        .filter(|n| n.contains('/'))
+        .collect();
+    if !nested.is_empty() {
+        bail!(
+            "the bundler emitted chunks in a subdirectory ({}), which breaks the \
+             path a `file` import resolves to — assets are emitted as siblings of \
+             the chunks and located relative to them.",
+            nested.join(", ")
+        );
+    }
+    // nub's own asset names are single components by construction; anything else
+    // here came from a code path that bypassed `loaders::asset_name`.
+    for a in assets {
+        if !nub_core::compile::is_safe_relative_name(&a.name) {
+            bail!(
+                "the bundler emitted an asset with an unusable name: {:?}",
+                a.name
+            );
+        }
+    }
+    Ok(())
 }
 
 fn absolutize(path: &Path) -> PathBuf {
@@ -846,6 +930,7 @@ mod tests {
             conditions: Vec::new(),
             external: Vec::new(),
             tsconfig: None,
+            loaders: Vec::new(),
         }
     }
 
@@ -977,6 +1062,125 @@ mod tests {
         bundle(&dir.join("entry.ts"), &o)
             .expect("externalizing the package removes its unanalyzable site from the graph");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The `file` loader's whole contract, asserted against a REAL bundle: the
+    // asset leaves the graph as bytes in `assets` (never in `files`, which are
+    // re-parsed as JS), and the module it leaves behind resolves its path
+    // against `import.meta.url` rather than the cwd. A relative path — what
+    // Rolldown's built-in asset loader yields — would read from wherever the
+    // binary was launched, which works only in the directory it was tested from.
+    #[test]
+    fn the_file_loader_emits_bytes_and_a_cwd_independent_path() {
+        let dir = std::env::temp_dir().join(format!("nub-file-loader-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("blob.bin"), b"\x00\x01BINARY").unwrap();
+        std::fs::write(
+            dir.join("entry.ts"),
+            b"import p from './blob.bin';\nglobalThis.OUT = p;\n",
+        )
+        .unwrap();
+
+        let mut o = opts();
+        o.minify = false;
+        let res = bundle(&dir.join("entry.ts"), &o).expect("a .bin import must compile");
+
+        assert_eq!(res.assets.len(), 1, "the bytes must ship as an asset");
+        assert_eq!(
+            res.assets[0].bytes, b"\x00\x01BINARY",
+            "the asset must be embedded verbatim"
+        );
+        assert!(
+            res.assets.iter().all(|a| !a.name.contains('/')),
+            "an asset must be a flat sibling of the chunks: {:?}",
+            res.assets.iter().map(|a| &a.name).collect::<Vec<_>>()
+        );
+        let code = String::from_utf8(res.files[0].bytes.clone()).unwrap();
+        assert!(
+            code.contains("import.meta.url"),
+            "the path must be resolved against the module, got:\n{code}"
+        );
+        assert!(
+            code.contains(&res.assets[0].name),
+            "the chunk must name the asset it ships, got:\n{code}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Control for the test above: without the `file` mapping, the SAME source
+    // ships no bytes. Without this the positive test proves nothing — "the .bin
+    // import compiled" is equally true of an import that was quietly ignored.
+    //
+    // The pre-loader outcome is deliberately asserted as "no asset", not "build
+    // error", because it is BOTH depending on the bytes: content that fails to
+    // parse as JavaScript errors, while content that happens to parse (a binary
+    // whose bytes read as identifiers) builds clean and leaves the import
+    // `undefined` at runtime. That second case is the silent one this loader
+    // exists to eliminate, and a control demanding an error would miss it.
+    #[test]
+    fn without_the_file_loader_no_bytes_are_shipped() {
+        let dir = std::env::temp_dir().join(format!("nub-file-ctl-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("blob.bin"), b"\x00\x01BINARY").unwrap();
+        std::fs::write(
+            dir.join("entry.ts"),
+            b"import p from './blob.bin';\nglobalThis.OUT = p;\n",
+        )
+        .unwrap();
+
+        let mut o = opts();
+        o.minify = false;
+        o.loaders = vec![".bin=js".to_string()];
+        if let Ok(res) = bundle(&dir.join("entry.ts"), &o) {
+            assert!(
+                res.assets.is_empty(),
+                "only the file loader may emit asset bytes, got {:?}",
+                res.assets.iter().map(|a| &a.name).collect::<Vec<_>>()
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // `.md` is the text half. Both spellings must land on the same string: the
+    // bare import, and the standards-track attribute — which Rolldown 1.2.0
+    // ignores entirely, so it must not contradict the extension map either.
+    #[test]
+    fn markdown_loads_as_text_with_or_without_the_import_attribute() {
+        for spec in [
+            "import t from './doc.md';",
+            "import t from './doc.md' with { type: 'text' };",
+        ] {
+            let dir = std::env::temp_dir().join(format!(
+                "nub-text-{}-{}",
+                std::process::id(),
+                spec.len()
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("doc.md"), "# Title\n").unwrap();
+            std::fs::write(
+                dir.join("entry.ts"),
+                format!("{spec}\nglobalThis.OUT = t;\n"),
+            )
+            .unwrap();
+
+            let mut o = opts();
+            o.minify = false;
+            let res = bundle(&dir.join("entry.ts"), &o)
+                .unwrap_or_else(|e| panic!("{spec} must compile, got: {e:#}"));
+            let code = String::from_utf8(res.files[0].bytes.clone()).unwrap();
+            assert!(
+                code.contains("# Title"),
+                "{spec} must inline the file's text, got:\n{code}"
+            );
+            assert!(
+                res.assets.is_empty(),
+                "text is inlined, so nothing should be emitted beside the chunk"
+            );
+            let _ = std::fs::remove_dir_all(&dir);
+        }
     }
 
     #[test]

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -278,6 +278,13 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
     }
     // `files` is still chunks-only here — maps are merged in below.
     reject_invalid_chunks(&files)?;
+    // Also while it is chunks-only, because reachability is a property of CODE
+    // and a source map is debug metadata. Scanning maps as well happens to give
+    // the same answer today — measured, on every `--sourcemap` mode — but only
+    // because a shaken-out module leaves nothing behind for its map to describe.
+    // That is a coincidence of Rolldown's map generation, not a rule, so the
+    // narrower input is the one worth depending on.
+    retain_referenced(&files, &mut assets);
 
     // A referenced map has to travel with the chunk that names it; an external
     // one must NOT, or `--sourcemap=external` would ship the sources it exists
@@ -289,7 +296,6 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
     };
     files.extend(maps);
 
-    retain_referenced(&files, &mut assets);
     reject_nested_chunks(&files, &assets)?;
 
     Ok(BundleResult {
@@ -1207,6 +1213,41 @@ mod tests {
             assert!(
                 res.assets.is_empty(),
                 "a .{ext} entry shipped an asset nothing references: {:?}",
+                res.assets.iter().map(|a| &a.name).collect::<Vec<_>>()
+            );
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+
+    // Reachability must not depend on the sourcemap mode. Maps travel in the
+    // same `files` vec as chunks and a map can carry `sourcesContent`, so the
+    // scan's input is easy to widen by accident; this pins the answer across all
+    // four modes rather than only the default the other tests happen to use.
+    #[test]
+    fn an_unused_asset_is_dropped_under_every_sourcemap_mode() {
+        for mode in [
+            SourcemapMode::None,
+            SourcemapMode::Inline,
+            SourcemapMode::Linked,
+            SourcemapMode::External,
+        ] {
+            let dir = std::env::temp_dir().join(format!("nub-map-{}-{mode:?}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("logo.png"), b"UNUSEDBYTES").unwrap();
+            std::fs::write(
+                dir.join("entry.js"),
+                b"import p from './logo.png';\nglobalThis.OUT = 'hi';\n",
+            )
+            .unwrap();
+
+            let mut o = opts();
+            o.minify = false;
+            o.sourcemap = mode;
+            let res = bundle(&dir.join("entry.js"), &o).expect("compiles");
+            assert!(
+                res.assets.is_empty(),
+                "{mode:?} retained an asset nothing references: {:?}",
                 res.assets.iter().map(|a| &a.name).collect::<Vec<_>>()
             );
             let _ = std::fs::remove_dir_all(&dir);

--- a/crates/nub-cli/src/compile/loaders.rs
+++ b/crates/nub-cli/src/compile/loaders.rs
@@ -103,6 +103,9 @@ pub fn plan(raw: &[String]) -> Result<Loaders> {
         // Kept EXACTLY as written, case included — see `FilePlugin::claims` for
         // why matching is case-sensitive on both sides.
         let ext = ext.trim().trim_start_matches('.').to_string();
+        // The VALUE is trimmed too, or `--loader ".png=file "` reports `unknown
+        // loader "file "` while listing `file` as available.
+        let name = name.trim();
         if ext.is_empty() {
             bail!("--loader expects an extension before the `=`, got {token:?}");
         }
@@ -161,25 +164,39 @@ pub struct FileAsset {
 /// the invariant this loader rests on, and [`crate::compile::bundle`] asserts it.
 #[derive(Debug, Default)]
 pub struct FilePlugin {
-    /// Every mapped extension → whether the `file` loader owns it. Both families
-    /// are present so [`FilePlugin::claims`] can resolve specificity across them;
-    /// see its doc comment.
-    by_ext: BTreeMap<String, bool>,
+    /// Every mapped extension → the loader that owns it. Both families are
+    /// present so [`FilePlugin::claims`] can resolve specificity across them; see
+    /// its doc comment. The loader's NAME is kept, not just which family it is
+    /// in, so [`FilePlugin::case_mismatch`] can suggest the flag verbatim.
+    by_ext: BTreeMap<String, &'static str>,
     collected: Mutex<BTreeMap<String, Vec<u8>>>,
+    /// Hints for imports whose extension is mapped only in another case. Kept
+    /// here rather than raised from the hook — see the `load` implementation.
+    case_hints: Mutex<std::collections::BTreeSet<String>>,
 }
 
 impl FilePlugin {
     pub fn new(loaders: &Loaders) -> Self {
-        let mut by_ext: BTreeMap<String, bool> = loaders
+        let mut by_ext: BTreeMap<String, &'static str> = loaders
             .module_types
-            .keys()
-            .map(|ext| (ext.clone(), false))
+            .iter()
+            .map(|(ext, ty)| (ext.clone(), loader_name(ty)))
             .collect();
-        by_ext.extend(loaders.file.iter().map(|ext| (ext.clone(), true)));
+        by_ext.extend(loaders.file.iter().map(|ext| (ext.clone(), "file")));
         Self {
             by_ext,
             collected: Mutex::new(BTreeMap::new()),
+            case_hints: Mutex::new(std::collections::BTreeSet::new()),
         }
+    }
+
+    /// What to add to a failed bundle's error, if a case-mismatched extension
+    /// could explain it.
+    pub fn case_hints(&self) -> Vec<String> {
+        self.case_hints
+            .lock()
+            .map(|h| h.iter().cloned().collect())
+            .unwrap_or_default()
     }
 
     /// Every asset this build emitted, in a deterministic order — `app_sha256`
@@ -225,8 +242,42 @@ impl FilePlugin {
     fn claims(&self, id: &str) -> bool {
         id.match_indices('.')
             .find_map(|(i, _)| self.by_ext.get(&id[i + 1..]))
-            .copied()
-            .unwrap_or(false)
+            .is_some_and(|loader| *loader == "file")
+    }
+
+    /// The mapped spelling of an extension `id` matches in every respect BUT
+    /// case, if there is one.
+    ///
+    /// Case-sensitivity is the deliberate rule (see [`Self::claims`]), and this
+    /// is what keeps it teachable. Without it a `PHOTO.PNG` import fails inside
+    /// Rolldown — `MISSING_EXPORT` for the file family, `PARSE_ERROR` for the
+    /// text family — neither of which names the extension or hints that a
+    /// mapping exists under another case.
+    fn case_mismatch(&self, id: &str) -> Option<(&str, &'static str)> {
+        id.match_indices('.').find_map(|(i, _)| {
+            let suffix = &id[i + 1..];
+            self.by_ext
+                .iter()
+                .find(|(mapped, _)| mapped.eq_ignore_ascii_case(suffix) && *mapped != suffix)
+                .map(|(mapped, loader)| (mapped.as_str(), *loader))
+        })
+    }
+}
+
+/// The `--loader` spelling of a Rolldown module type, for echoing back in a
+/// diagnostic. Only the types [`plan`] admits appear here.
+fn loader_name(ty: &ModuleType) -> &'static str {
+    match ty {
+        ModuleType::Text => "text",
+        ModuleType::Json => "json",
+        ModuleType::Base64 => "base64",
+        ModuleType::Dataurl => "dataurl",
+        ModuleType::Binary => "binary",
+        ModuleType::Empty => "empty",
+        ModuleType::Jsx => "jsx",
+        ModuleType::Ts => "ts",
+        ModuleType::Tsx => "tsx",
+        _ => "js",
     }
 }
 
@@ -297,8 +348,32 @@ impl Plugin for FilePlugin {
         // must both run against the cleaned path.
         let id = clean_url(args.id).to_string();
         let claimed = self.claims(&id);
+        let mismatch = (!claimed)
+            .then(|| {
+                self.case_mismatch(&id)
+                    .map(|(mapped, loader)| (mapped.to_string(), loader))
+            })
+            .flatten();
         async move {
             if !claimed {
+                // Recorded, not raised. A plugin error is swallowed by Rolldown
+                // into a generic `UNLOADABLE_DEPENDENCY: Could not load <file>`
+                // that drops the message entirely, so failing here would replace
+                // one unhelpful diagnostic with another. Letting the module fall
+                // through keeps Rolldown's own failure and lets `compile::bundle`
+                // append this hint to it.
+                if let Some((mapped, loader)) = mismatch
+                    && let Ok(mut seen) = self.case_hints.lock()
+                {
+                    let as_written = Path::new(&id)
+                        .extension()
+                        .map_or_else(|| mapped.clone(), |e| e.to_string_lossy().into_owned());
+                    seen.insert(format!(
+                        "\x20\x20Extensions match exactly, case included, so .{as_written} is not \
+                         covered by the mapping for .{mapped}.\n\
+                         \x20\x20Map this spelling too: --loader .{as_written}={loader}"
+                    ));
+                }
                 return Ok(None);
             }
             let bytes = std::fs::read(&id)
@@ -424,6 +499,34 @@ mod tests {
                 "and point at what to use instead: {msg}"
             );
         }
+    }
+
+    // Case-sensitivity is the rule, so the error a user hits while learning it
+    // has to name the extension and the exact flag — not Rolldown's
+    // MISSING_EXPORT (file family) or PARSE_ERROR (text family), neither of
+    // which mentions loaders at all. The suggested loader must match the family
+    // the mapped extension is in.
+    #[test]
+    fn a_case_mismatched_extension_names_the_flag_that_fixes_it() {
+        let p = FilePlugin::new(&plan(&[]).expect("valid"));
+        assert_eq!(p.case_mismatch("/proj/PHOTO.PNG"), Some(("png", "file")));
+        assert_eq!(p.case_mismatch("/proj/PROMPT.MD"), Some(("md", "text")));
+        assert_eq!(
+            p.case_mismatch("/proj/photo.png"),
+            None,
+            "an exact match is claimed, not reported as a mismatch"
+        );
+        assert_eq!(
+            p.case_mismatch("/proj/notes.rst"),
+            None,
+            "an extension mapped in no case is not this diagnostic's business"
+        );
+    }
+
+    #[test]
+    fn a_loader_value_is_trimmed_like_its_extension() {
+        let l = plan(&[" .png = file ".into()]).expect("padding must not change the mapping");
+        assert!(l.file.contains(&"png".to_string()));
     }
 
     #[test]

--- a/crates/nub-cli/src/compile/loaders.rs
+++ b/crates/nub-cli/src/compile/loaders.rs
@@ -261,9 +261,17 @@ impl Plugin for FilePlugin {
             Ok(Some(HookLoadOutput {
                 code: code.into(),
                 module_type: Some(ModuleType::Js),
-                // Nothing in the emitted module observes anything, so an import
-                // whose binding goes unused should take the asset out of the
-                // payload with it rather than bloating every artifact.
+                // The emitted module observes nothing, so it must not anchor
+                // anything that would otherwise be shaken out.
+                //
+                // Payload bloat is handled a step EARLIER and not by this flag:
+                // under tree-shaking Rolldown elides an import whose bindings
+                // all go unused before it ever loads the module, so this hook
+                // does not run and the bytes are never collected. Verified by
+                // making an imported-but-unused asset unreadable — the build
+                // still succeeds, which it could not if `load` had fired.
+                // (`--no-treeshake` therefore does ship such an asset, which is
+                // exactly what disabling tree-shaking asks for.)
                 side_effects: Some(HookSideEffects::False),
                 ..Default::default()
             }))

--- a/crates/nub-cli/src/compile/loaders.rs
+++ b/crates/nub-cli/src/compile/loaders.rs
@@ -100,19 +100,35 @@ pub fn plan(raw: &[String]) -> Result<Loaders> {
                  \x20\x20For example: --loader .html=file --loader .md=text"
             )
         })?;
-        let ext = ext.trim().trim_start_matches('.');
+        // Lowercased because a filesystem hands back whatever case the file was
+        // created with, and `.PNG`/`.JPG` are routine on macOS and Windows.
+        // Matching case-exactly failed the build on them, which reads as the
+        // loader being broken rather than as a spelling rule.
+        let ext = ext.trim().trim_start_matches('.').to_ascii_lowercase();
         if ext.is_empty() {
             bail!("--loader expects an extension before the `=`, got {token:?}");
         }
-        // Rejected rather than silently mapped: `from_str_with_fallback` would
-        // hand back `Custom(_)`, which Rolldown fails on much later with a
-        // message that names neither the flag nor the extension.
         if name == "file" {
-            module_types.remove(ext);
-            if !file.iter().any(|e| e == ext) {
-                file.push(ext.to_string());
+            module_types.remove(&ext);
+            if !file.contains(&ext) {
+                file.push(ext);
             }
             continue;
+        }
+        // `from_known_str` ALSO accepts `asset`, `copy`, and `css`, none of which
+        // may reach Rolldown from this flag. Two of them build clean and produce
+        // an artifact that dies on first run: `copy` leaves a literal
+        // `import p from "./x.png"` in the chunk (valid JavaScript, so the
+        // emitted-chunk gate passes it) which throws
+        // ERR_UNKNOWN_FILE_EXTENSION, and `asset` yields the chunk-relative path
+        // that this module's `file` loader exists to avoid. `css` merely errors,
+        // but from inside Rolldown rather than from the flag the user typed.
+        if matches!(name, "asset" | "copy" | "css") {
+            bail!(
+                "--loader {token:?}: {name:?} is not a loader nub supports\n\
+                 \x20\x20For a file that should ship beside the executable and be opened by \
+                 path, use: --loader .{ext}=file"
+            );
         }
         let module_type = ModuleType::from_known_str(name).map_err(|_| {
             anyhow::anyhow!(
@@ -120,8 +136,8 @@ pub fn plan(raw: &[String]) -> Result<Loaders> {
                  \x20\x20Available: file, text, json, base64, dataurl, binary, empty, js, jsx, ts, tsx"
             )
         })?;
-        file.retain(|e| e != ext);
-        module_types.insert(ext.to_string(), module_type);
+        file.retain(|e| *e != ext);
+        module_types.insert(ext, module_type);
     }
 
     file.sort();
@@ -197,6 +213,7 @@ impl FilePlugin {
     /// `.tar.gz=text` had claimed — the loser being decided by hook order rather
     /// than by specificity.
     fn claims(&self, id: &str) -> bool {
+        let id = id.to_ascii_lowercase();
         id.match_indices('.')
             .find_map(|(i, _)| self.by_ext.get(&id[i + 1..]))
             .copied()
@@ -279,23 +296,25 @@ impl Plugin for FilePlugin {
                 .map_err(|e| anyhow::anyhow!("reading the imported asset {id}: {e}"))?;
             let name = asset_name(Path::new(&id), &bytes);
             let code = file_module(&name);
-            if let Ok(mut collected) = self.collected.lock() {
-                collected.insert(name, bytes);
-            }
+            // A silent drop here would ship a chunk naming a file that is not in
+            // the payload — a runtime ENOENT with nothing to attribute it to.
+            self.collected
+                .lock()
+                .map_err(|_| {
+                    anyhow::anyhow!("the asset collector was poisoned by an earlier panic")
+                })?
+                .insert(name, bytes);
             Ok(Some(HookLoadOutput {
                 code: code.into(),
                 module_type: Some(ModuleType::Js),
                 // The emitted module observes nothing, so it must not anchor
                 // anything that would otherwise be shaken out.
                 //
-                // Payload bloat is handled a step EARLIER and not by this flag:
-                // under tree-shaking Rolldown elides an import whose bindings
-                // all go unused before it ever loads the module, so this hook
-                // does not run and the bytes are never collected. Verified by
-                // making an imported-but-unused asset unreadable — the build
-                // still succeeds, which it could not if `load` had fired.
-                // (`--no-treeshake` therefore does ship such an asset, which is
-                // exactly what disabling tree-shaking asks for.)
+                // This does NOT keep unused assets out of the payload — this
+                // hook runs during graph construction, before anything is
+                // shaken, so the bytes are already collected by then. Dropping
+                // the ones no chunk ends up naming is a separate pass over the
+                // emitted output; see `retain_referenced` in `compile::bundle`.
                 side_effects: Some(HookSideEffects::False),
                 ..Default::default()
             }))
@@ -377,6 +396,41 @@ mod tests {
         let p = FilePlugin::new(&plan(&[]).expect("valid"));
         assert!(p.claims("/home/user.v2/app/icon.png"));
         assert!(!p.claims("/home/user.v2/app/main.ts"));
+    }
+
+    // `from_known_str` accepts these, and two of them BUILD CLEAN and produce an
+    // artifact that dies on first run — `copy` leaves a literal `import p from
+    // "./x.png"` (valid JavaScript, so the emitted-chunk gate passes it), and
+    // `asset` yields the chunk-relative path the file loader exists to avoid.
+    #[test]
+    fn the_rolldown_loaders_that_would_ship_a_broken_binary_are_refused() {
+        for bad in ["asset", "copy", "css"] {
+            let err = plan(&[format!(".png={bad}")])
+                .err()
+                .unwrap_or_else(|| panic!("--loader .png={bad} must be refused"));
+            let msg = format!("{err:#}");
+            assert!(msg.contains(bad), "the error must name the value: {msg}");
+            assert!(
+                msg.contains("--loader .png=file"),
+                "and point at what to use instead: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn extensions_match_case_insensitively() {
+        let p = FilePlugin::new(&plan(&[]).expect("valid"));
+        assert!(
+            p.claims("/proj/PHOTO.PNG"),
+            "a screenshot named .PNG is routine"
+        );
+        assert!(p.claims("/proj/photo.png"));
+
+        let upper = plan(&[".HTML=file".into()]).expect("valid");
+        assert!(
+            upper.file.iter().any(|e| e == "html"),
+            "a flag spelled in caps must map the same extension"
+        );
     }
 
     #[test]

--- a/crates/nub-cli/src/compile/loaders.rs
+++ b/crates/nub-cli/src/compile/loaders.rs
@@ -100,11 +100,9 @@ pub fn plan(raw: &[String]) -> Result<Loaders> {
                  \x20\x20For example: --loader .html=file --loader .md=text"
             )
         })?;
-        // Lowercased because a filesystem hands back whatever case the file was
-        // created with, and `.PNG`/`.JPG` are routine on macOS and Windows.
-        // Matching case-exactly failed the build on them, which reads as the
-        // loader being broken rather than as a spelling rule.
-        let ext = ext.trim().trim_start_matches('.').to_ascii_lowercase();
+        // Kept EXACTLY as written, case included — see `FilePlugin::claims` for
+        // why matching is case-sensitive on both sides.
+        let ext = ext.trim().trim_start_matches('.').to_string();
         if ext.is_empty() {
             bail!("--loader expects an extension before the `=`, got {token:?}");
         }
@@ -212,8 +210,19 @@ impl FilePlugin {
     /// `file` set would let a broad `.gz=file` steal a file that a more specific
     /// `.tar.gz=text` had claimed — the loser being decided by hook order rather
     /// than by specificity.
+    ///
+    /// CASE-SENSITIVE, DELIBERATELY, and it must stay that way. Lowercasing here
+    /// is tempting — `.PNG` and `.JPG` are ordinary on macOS and Windows — but it
+    /// can only ever fix nub's half. Rolldown looks its own `module_types` up
+    /// with an exact-case `get`, and the text family goes through THAT, so
+    /// lowercasing only here bought `PHOTO.PNG` at the cost of making `PROMPT.MD`
+    /// fail the build: one convenience, two rules, and the difference invisible
+    /// until it bites. Routing the text family through this plugin instead would
+    /// not close it either, since `HookLoadOutput.code` is a string and the
+    /// byte-oriented loaders (`base64`, `binary`, `dataurl`) need bytes. One rule
+    /// for both families is worth more than a convenience that holds in one;
+    /// an uppercase extension is spelled `--loader .PNG=file`.
     fn claims(&self, id: &str) -> bool {
-        let id = id.to_ascii_lowercase();
         id.match_indices('.')
             .find_map(|(i, _)| self.by_ext.get(&id[i + 1..]))
             .copied()
@@ -418,18 +427,20 @@ mod tests {
     }
 
     #[test]
-    fn extensions_match_case_insensitively() {
-        let p = FilePlugin::new(&plan(&[]).expect("valid"));
+    fn extension_matching_is_case_sensitive_in_both_families() {
+        let d = FilePlugin::new(&plan(&[]).expect("valid"));
+        assert!(d.claims("/proj/photo.png"));
         assert!(
-            p.claims("/proj/PHOTO.PNG"),
-            "a screenshot named .PNG is routine"
+            !d.claims("/proj/PHOTO.PNG"),
+            "a lowercase default must not claim an uppercase extension — Rolldown's \
+             own lookup is exact-case, so claiming it here would make the file \
+             family case-insensitive while the text family stayed exact"
         );
-        assert!(p.claims("/proj/photo.png"));
 
-        let upper = plan(&[".HTML=file".into()]).expect("valid");
+        let upper = plan(&[".PNG=file".into()]).expect("valid");
         assert!(
-            upper.file.iter().any(|e| e == "html"),
-            "a flag spelled in caps must map the same extension"
+            FilePlugin::new(&upper).claims("/proj/PHOTO.PNG"),
+            "naming the extension as written is how an uppercase one is mapped"
         );
     }
 

--- a/crates/nub-cli/src/compile/loaders.rs
+++ b/crates/nub-cli/src/compile/loaders.rs
@@ -147,14 +147,23 @@ pub struct FileAsset {
 /// the invariant this loader rests on, and [`crate::compile::bundle`] asserts it.
 #[derive(Debug, Default)]
 pub struct FilePlugin {
-    exts: Vec<String>,
+    /// Every mapped extension → whether the `file` loader owns it. Both families
+    /// are present so [`FilePlugin::claims`] can resolve specificity across them;
+    /// see its doc comment.
+    by_ext: BTreeMap<String, bool>,
     collected: Mutex<BTreeMap<String, Vec<u8>>>,
 }
 
 impl FilePlugin {
     pub fn new(loaders: &Loaders) -> Self {
+        let mut by_ext: BTreeMap<String, bool> = loaders
+            .module_types
+            .keys()
+            .map(|ext| (ext.clone(), false))
+            .collect();
+        by_ext.extend(loaders.file.iter().map(|ext| (ext.clone(), true)));
         Self {
-            exts: loaders.file.clone(),
+            by_ext,
             collected: Mutex::new(BTreeMap::new()),
         }
     }
@@ -172,11 +181,26 @@ impl FilePlugin {
             .collect()
     }
 
+    /// Whether the `file` loader owns `id`.
+    ///
+    /// MIRRORS ROLLDOWN'S OWN EXTENSION LOOKUP, and must keep doing so. Rolldown
+    /// matches the suffix after EVERY dot, left to right, taking the first hit —
+    /// so `x.tar.gz` tries `tar.gz` before `gz`, and the most specific mapping
+    /// wins. Matching only `Path::extension()` here (the last component) made the
+    /// two families disagree: `--loader .tar.gz=text` worked while
+    /// `--loader .tar.gz=file` silently did not claim the file, which then
+    /// reached the JS parser and failed the build.
+    ///
+    /// The lookup spans BOTH families rather than just this plugin's own, because
+    /// this hook runs BEFORE Rolldown consults `module_types`. Checking only the
+    /// `file` set would let a broad `.gz=file` steal a file that a more specific
+    /// `.tar.gz=text` had claimed — the loser being decided by hook order rather
+    /// than by specificity.
     fn claims(&self, id: &str) -> bool {
-        Path::new(id)
-            .extension()
-            .and_then(|e| e.to_str())
-            .is_some_and(|ext| self.exts.iter().any(|e| e == ext))
+        id.match_indices('.')
+            .find_map(|(i, _)| self.by_ext.get(&id[i + 1..]))
+            .copied()
+            .unwrap_or(false)
     }
 }
 
@@ -318,6 +342,41 @@ mod tests {
             "the text default must yield, or Rolldown would load it as text \
              and nub's file loader would never see it"
         );
+    }
+
+    // Rolldown matches the suffix after EVERY dot, so a multi-dot mapping has to
+    // as well. Matching only the last component made `--loader .tar.gz=file`
+    // silently not claim the file (which then failed in the JS parser) while
+    // `--loader .tar.gz=text` worked — the same flag behaving differently
+    // depending on which loader family the value named.
+    #[test]
+    fn a_multi_dot_extension_is_claimed_the_way_rolldown_matches_it() {
+        let p = FilePlugin::new(&plan(&[".tar.gz=file".into()]).expect("valid"));
+        assert!(p.claims("/proj/bundle.tar.gz"));
+        assert!(!p.claims("/proj/notes.gz"), "only .tar.gz was mapped");
+    }
+
+    // The `file` hook runs BEFORE Rolldown consults its extension map, so
+    // without a cross-family lookup a broad `.gz=file` would steal a file that a
+    // more specific `.tar.gz=text` had claimed — specificity decided by hook
+    // order instead of by the mapping.
+    #[test]
+    fn the_more_specific_mapping_wins_across_loader_families() {
+        let loaders = plan(&[".gz=file".into(), ".tar.gz=text".into()]).expect("valid");
+        let p = FilePlugin::new(&loaders);
+        assert!(
+            !p.claims("/proj/bundle.tar.gz"),
+            "the text mapping is more specific and must win"
+        );
+        assert!(p.claims("/proj/blob.gz"), "the broad mapping still applies");
+    }
+
+    // A path component containing a dot must not be read as an extension.
+    #[test]
+    fn a_dot_in_a_directory_name_does_not_decide_the_loader() {
+        let p = FilePlugin::new(&plan(&[]).expect("valid"));
+        assert!(p.claims("/home/user.v2/app/icon.png"));
+        assert!(!p.claims("/home/user.v2/app/main.ts"));
     }
 
     #[test]

--- a/crates/nub-cli/src/compile/loaders.rs
+++ b/crates/nub-cli/src/compile/loaders.rs
@@ -1,0 +1,381 @@
+//! Asset loaders — what a non-JavaScript import evaluates to.
+//!
+//! Two families, split by who implements them:
+//!
+//! - **Source-shaped** (`text`, `json`, `base64`, `dataurl`, `binary`, `empty`)
+//!   are Rolldown's own `module_types`, handed straight through. Rolldown does
+//!   the read, the BOM strip, the JS-string escaping, and the lazy
+//!   `export default`, and gets tree-shaking right — reimplementing any of that
+//!   here would be strictly worse.
+//! - **`file`** is nub's, because Rolldown's built-in equivalent
+//!   (`ModuleType::Asset`) yields a path RELATIVE TO THE CHUNK. Relative is
+//!   correct for esbuild, whose output sits in a directory the app already
+//!   knows; it is wrong here. A compiled artifact runs from a content-hashed
+//!   cache directory that the user never cd's into, so `readFileSync("./x.wasm")`
+//!   — resolved against `process.cwd()` — reads from wherever the binary
+//!   happened to be launched. That fails everywhere except the one directory the
+//!   developer tested from, which is the worst available failure mode. nub
+//!   therefore emits an ABSOLUTE path computed at runtime from `import.meta.url`
+//!   (Bun's `type: "file"` semantics), so the value works from any cwd.
+//!
+//! IMPORT ATTRIBUTES ARE INERT, AND THAT IS WHY THIS IS AN EXTENSION MAP.
+//! Rolldown 1.2.0 parses `with { type: "…" }` into an `import_attribute_map`
+//! that is only ever used to re-print attributes on external imports — no hook
+//! sees it (`HookResolveIdArgs` has no attributes field, and `load`'s
+//! `asserted_module_type` is set by `new URL()` and nothing else). `with { type:
+//! "json" }` "works" today purely because `.json` is in Rolldown's default
+//! extension map. So the extension decides the loader, and an attribute is
+//! accepted-and-ignored — which means the standards-track spelling starts
+//! working the moment its extension is mapped, and never contradicts it.
+//!
+//! The default map is deliberately short: an extension earns a `file` default
+//! only if it CANNOT be JavaScript, so mapping it converts a guaranteed build
+//! failure into working behavior and can regress nothing. Ambiguous extensions
+//! (`.css`, `.html`) are left to Rolldown and to `--loader`.
+
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Mutex;
+
+use anyhow::{Result, bail};
+use rolldown::plugin::{
+    HookLoadArgs, HookLoadOutput, HookLoadReturn, HookUsage, Plugin, SharedLoadPluginContext,
+};
+use rolldown_common::ModuleType;
+use rolldown_common::side_effects::HookSideEffects;
+use rolldown_utils::url::clean_url;
+use sha2::{Digest, Sha256};
+
+/// Extensions nub maps beyond Rolldown's defaults (which already cover `.js`,
+/// `.ts`, `.json`, `.txt`, `.css`, …).
+///
+/// `.md` is the whole text half: prompt/description files are the common shape
+/// in the tooling nub compiles, and `.txt` already worked only because Rolldown
+/// happens to default it.
+const DEFAULT_TEXT: &[&str] = &["md"];
+
+/// Binary extensions that get `file`. Each is a format no JavaScript parser can
+/// read, so the import fails the build today.
+const DEFAULT_FILE: &[&str] = &[
+    "wasm", // instantiated from the path
+    "mp3", "wav", "ogg", "flac", "mp4", "webm", // media
+    "png", "jpg", "jpeg", "gif", "webp", "avif", "ico", // images
+    "woff", "woff2", "ttf", "otf", // fonts
+    "pdf", "zip", "bin", "dat", // opaque payloads
+];
+
+/// The resolved loader configuration for one build.
+#[derive(Debug, Default)]
+pub struct Loaders {
+    /// Handed to Rolldown as `module_types`.
+    pub module_types: BTreeMap<String, ModuleType>,
+    /// Extensions nub's own `file` loader claims. Deliberately NOT in
+    /// `module_types`: routing them to `ModuleType::Asset` would hand them to
+    /// Rolldown's built-in plugin and produce the chunk-relative path this
+    /// module exists to avoid.
+    pub file: Vec<String>,
+}
+
+/// Build the loader map: nub's defaults, then `--loader EXT=TYPE` over the top.
+///
+/// A user entry wins over a default in BOTH directions — `--loader .wasm=binary`
+/// moves `.wasm` out of `file` and into Rolldown's inlining loader — so the flag
+/// is a real override rather than an append.
+pub fn plan(raw: &[String]) -> Result<Loaders> {
+    let mut module_types = BTreeMap::new();
+    let mut file: Vec<String> = Vec::new();
+
+    for ext in DEFAULT_TEXT {
+        module_types.insert((*ext).to_string(), ModuleType::Text);
+    }
+    for ext in DEFAULT_FILE {
+        file.push((*ext).to_string());
+    }
+
+    for token in raw {
+        let (ext, name) = token.split_once('=').ok_or_else(|| {
+            anyhow::anyhow!(
+                "--loader expects EXT=TYPE, got {token:?}\n\
+                 \x20\x20For example: --loader .html=file --loader .md=text"
+            )
+        })?;
+        let ext = ext.trim().trim_start_matches('.');
+        if ext.is_empty() {
+            bail!("--loader expects an extension before the `=`, got {token:?}");
+        }
+        // Rejected rather than silently mapped: `from_str_with_fallback` would
+        // hand back `Custom(_)`, which Rolldown fails on much later with a
+        // message that names neither the flag nor the extension.
+        if name == "file" {
+            module_types.remove(ext);
+            if !file.iter().any(|e| e == ext) {
+                file.push(ext.to_string());
+            }
+            continue;
+        }
+        let module_type = ModuleType::from_known_str(name).map_err(|_| {
+            anyhow::anyhow!(
+                "--loader {token:?}: unknown loader {name:?}\n\
+                 \x20\x20Available: file, text, json, base64, dataurl, binary, empty, js, jsx, ts, tsx"
+            )
+        })?;
+        file.retain(|e| e != ext);
+        module_types.insert(ext.to_string(), module_type);
+    }
+
+    file.sort();
+    file.dedup();
+    Ok(Loaders { module_types, file })
+}
+
+// ---- the `file` loader --------------------------------------------------------
+
+/// One emitted asset: the payload name it takes, and its bytes.
+pub struct FileAsset {
+    pub name: String,
+    pub bytes: Vec<u8>,
+}
+
+/// Rolldown plugin implementing `file`: emit the bytes as a sibling of the
+/// chunks, and evaluate the import to that sibling's ABSOLUTE path at runtime.
+///
+/// The path is computed rather than baked because the build machine's directory
+/// layout has nothing to do with the deploy machine's. `import.meta.url` is the
+/// only base that is right on both, and it works from ANY chunk because every
+/// chunk and every emitted asset land in one flat directory — that flatness is
+/// the invariant this loader rests on, and [`crate::compile::bundle`] asserts it.
+#[derive(Debug, Default)]
+pub struct FilePlugin {
+    exts: Vec<String>,
+    collected: Mutex<BTreeMap<String, Vec<u8>>>,
+}
+
+impl FilePlugin {
+    pub fn new(loaders: &Loaders) -> Self {
+        Self {
+            exts: loaders.file.clone(),
+            collected: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Every asset this build emitted, in a deterministic order — `app_sha256`
+    /// hashes the payload in order, so a nondeterministic one would re-key the
+    /// extraction dir on every compile of identical inputs.
+    pub fn take(&self) -> Vec<FileAsset> {
+        self.collected
+            .lock()
+            .map(|mut g| std::mem::take(&mut *g))
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(name, bytes)| FileAsset { name, bytes })
+            .collect()
+    }
+
+    fn claims(&self, id: &str) -> bool {
+        Path::new(id)
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|ext| self.exts.iter().any(|e| e == ext))
+    }
+}
+
+/// The payload name for an asset: its stem, a content hash, its extension.
+///
+/// Content-hashed, not path-hashed, so two imports of the same bytes dedupe to
+/// one payload entry while two different files that merely share a basename
+/// (`icons/logo.png` and `brand/logo.png`) cannot collide.
+fn asset_name(source: &Path, bytes: &[u8]) -> String {
+    let stem: String = source
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let stem = if stem.is_empty() {
+        "asset".to_string()
+    } else {
+        stem
+    };
+    let hash = format!("{:x}", Sha256::digest(bytes));
+    match source.extension().and_then(|e| e.to_str()) {
+        Some(ext) => format!("{stem}-{}.{ext}", &hash[..8]),
+        None => format!("{stem}-{}", &hash[..8]),
+    }
+}
+
+/// The module a `file` import evaluates to.
+///
+/// `fileURLToPath`, not `new URL(...).pathname`: the latter leaves an import
+/// percent-encoded (a space becomes `%20`) and on Windows yields `/C:/…`, so
+/// every `fs` call against it fails on exactly the paths that are hardest to
+/// debug.
+fn file_module(name: &str) -> String {
+    // `./` is explicit rather than incidental: a bare relative reference whose
+    // first component contained a colon would parse as a URL SCHEME, and the
+    // prefix removes that class of surprise entirely.
+    format!(
+        "import {{ fileURLToPath as __nubFileURLToPath }} from \"node:url\";\n\
+         export default __nubFileURLToPath(new URL({}, import.meta.url));\n",
+        serde_json::to_string(&format!("./{name}")).expect("a file name serializes")
+    )
+}
+
+impl Plugin for FilePlugin {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("nub:file-loader")
+    }
+
+    fn register_hook_usage(&self) -> HookUsage {
+        HookUsage::Load
+    }
+
+    fn load(
+        &self,
+        _ctx: SharedLoadPluginContext,
+        args: &HookLoadArgs<'_>,
+    ) -> impl std::future::Future<Output = HookLoadReturn> + Send {
+        // Rolldown does not strip a `?query` before handing an id to `load`, and
+        // a query is legal in a specifier, so the extension test and the read
+        // must both run against the cleaned path.
+        let id = clean_url(args.id).to_string();
+        let claimed = self.claims(&id);
+        async move {
+            if !claimed {
+                return Ok(None);
+            }
+            let bytes = std::fs::read(&id)
+                .map_err(|e| anyhow::anyhow!("reading the imported asset {id}: {e}"))?;
+            let name = asset_name(Path::new(&id), &bytes);
+            let code = file_module(&name);
+            if let Ok(mut collected) = self.collected.lock() {
+                collected.insert(name, bytes);
+            }
+            Ok(Some(HookLoadOutput {
+                code: code.into(),
+                module_type: Some(ModuleType::Js),
+                // Nothing in the emitted module observes anything, so an import
+                // whose binding goes unused should take the asset out of the
+                // payload with it rather than bloating every artifact.
+                side_effects: Some(HookSideEffects::False),
+                ..Default::default()
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_cover_text_and_binary_without_claiming_ambiguous_extensions() {
+        let l = plan(&[]).expect("defaults are valid");
+        assert_eq!(l.module_types.get("md"), Some(&ModuleType::Text));
+        assert!(l.file.iter().any(|e| e == "wasm"));
+        assert!(l.file.iter().any(|e| e == "png"));
+        // Rolldown has real handling for these; claiming them would regress it.
+        assert!(!l.file.iter().any(|e| e == "css"));
+        assert!(!l.file.iter().any(|e| e == "html"));
+        assert!(!l.file.iter().any(|e| e == "js"));
+        assert!(!l.module_types.contains_key("css"));
+    }
+
+    // The flag has to move an extension BETWEEN families, not just add to one —
+    // otherwise `--loader .wasm=binary` would leave `.wasm` claimed by `file`
+    // and the user's override would silently do nothing.
+    #[test]
+    fn a_user_loader_overrides_a_default_in_both_directions() {
+        let to_binary = plan(&[".wasm=binary".into()]).expect("valid");
+        assert!(
+            !to_binary.file.iter().any(|e| e == "wasm"),
+            "the file default must yield"
+        );
+        assert_eq!(
+            to_binary.module_types.get("wasm"),
+            Some(&ModuleType::Binary)
+        );
+
+        let to_file = plan(&[".md=file".into()]).expect("valid");
+        assert!(to_file.file.iter().any(|e| e == "md"));
+        assert!(
+            !to_file.module_types.contains_key("md"),
+            "the text default must yield, or Rolldown would load it as text \
+             and nub's file loader would never see it"
+        );
+    }
+
+    #[test]
+    fn an_extension_may_be_spelled_with_or_without_its_dot() {
+        let dotted = plan(&[".html=file".into()]).expect("valid");
+        let bare = plan(&["html=file".into()]).expect("valid");
+        assert!(dotted.file.iter().any(|e| e == "html") && bare.file.iter().any(|e| e == "html"));
+    }
+
+    #[test]
+    fn a_malformed_loader_names_the_flag_and_what_is_available() {
+        let err = plan(&["md".into()]).expect_err("no = must be rejected");
+        assert!(format!("{err:#}").contains("EXT=TYPE"), "{err:#}");
+
+        let err = plan(&[".md=markdown".into()]).expect_err("unknown loader");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("markdown"), "must name the bad value: {msg}");
+        assert!(msg.contains("text"), "must list what IS available: {msg}");
+
+        assert!(plan(&["=file".into()]).is_err(), "an empty extension");
+    }
+
+    // A shared basename is the collision this naming exists to prevent, and
+    // identical bytes are the dedup it exists to get for free.
+    #[test]
+    fn asset_names_separate_by_content_and_collapse_on_it() {
+        let a = asset_name(Path::new("/p/icons/logo.png"), b"AAA");
+        let b = asset_name(Path::new("/p/brand/logo.png"), b"BBB");
+        let c = asset_name(Path::new("/other/logo.png"), b"AAA");
+        assert_ne!(a, b, "same basename, different bytes must not collide");
+        assert_eq!(a, c, "identical bytes must dedupe to one payload entry");
+        assert!(a.starts_with("logo-") && a.ends_with(".png"), "{a}");
+    }
+
+    #[test]
+    fn an_asset_name_is_always_a_plain_relative_filename() {
+        // The payload name is checked against `is_safe_relative_name` at build
+        // AND extract time; a stem carrying a separator would fail there, far
+        // from the cause. Sanitizing here keeps it a single component.
+        let n = asset_name(Path::new("/p/we ird/../na/me?x.bin"), b"x");
+        assert!(
+            nub_core::compile::is_safe_relative_name(&n),
+            "{n} must be a safe single-component name"
+        );
+        assert!(!n.contains('/') && !n.contains('?'), "{n}");
+    }
+
+    // The emitted module is what every `file` import evaluates to, so its two
+    // load-bearing properties are worth pinning: an absolute path (not the
+    // chunk-relative one Rolldown's built-in would give), and a base of
+    // `import.meta.url` rather than cwd.
+    #[test]
+    fn the_file_module_resolves_against_the_module_not_the_cwd() {
+        let code = file_module("logo-a1b2c3d4.png");
+        assert!(code.contains("import.meta.url"), "{code}");
+        assert!(code.contains("fileURLToPath"), "{code}");
+        assert!(code.contains("\"./logo-a1b2c3d4.png\"") || code.contains("\"logo-a1b2c3d4.png\""));
+        assert!(!code.contains("process.cwd"), "{code}");
+    }
+
+    #[test]
+    fn a_file_name_needing_escapes_stays_valid_javascript() {
+        let code = file_module("a\"b.png");
+        assert!(
+            code.contains("\\\""),
+            "the name must be JSON-escaped: {code}"
+        );
+    }
+}

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -32,6 +32,7 @@ mod assets;
 pub mod bundle;
 mod external;
 mod inject;
+mod loaders;
 
 pub use bundle::{BundleOptions, SourcemapMode};
 
@@ -315,6 +316,7 @@ fn assemble_app(
     let mut files: AppFiles = bundled
         .files
         .iter()
+        .chain(&bundled.assets)
         .map(|f| (layout.bundle_path(&f.name), f.bytes.clone()))
         .collect();
 
@@ -323,8 +325,8 @@ fn assemble_app(
         // pointed at — always a mistake, and silent until the binary runs.
         if files.iter().any(|(name, _)| *name == asset.rel) {
             bail!(
-                "--include would overwrite compiled output: {} is also a bundle chunk. \
-                 Rename the file or drop it from --include.",
+                "--include would overwrite compiled output: {} is also a bundle chunk \
+                 or a loader-emitted asset. Rename the file or drop it from --include.",
                 asset.rel
             );
         }
@@ -838,6 +840,7 @@ mod tests {
                 conditions: Vec::new(),
                 external: Vec::new(),
                 tsconfig: None,
+                loaders: Vec::new(),
             },
         }
     }

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -966,6 +966,7 @@ mod tests {
                 bytes: b"export {}".to_vec(),
             }],
             detached_maps: Vec::new(),
+            assets: Vec::new(),
         };
         let layout = assets::Layout {
             entry_prefix: String::new(),

--- a/site/content/docs/compile.mdx
+++ b/site/content/docs/compile.mdx
@@ -206,6 +206,42 @@ nub compile app.ts --include=data --exclude=data/fixtures --exclude='**/*.tmp'
 
 An `--exclude` that matches nothing is ignored rather than an error, so it can outlive the files it was written for. That also means a mistyped one prunes nothing — check what shipped if a path was meant to stay out.
 
+## Importing an asset
+
+Importing a file that isn't JavaScript gives you either its contents or its path, depending on the extension:
+
+```ts
+import prompt from "./prompt.md";     // the text, as a string
+import model from "./model.wasm";     // an absolute path to the file
+```
+
+The extension decides which:
+
+| Extension | Import evaluates to |
+| --- | --- |
+| `.txt`, `.md` | The file's contents, as a string |
+| `.json` | The parsed value |
+| `.wasm`, `.png`, `.mp3`, `.woff2`, `.bin`, and other binary formats | An absolute path to the file |
+
+A binary asset ships inside the executable and is written out beside the compiled entry, so the path points at a real file that every filesystem API works on:
+
+```ts
+import wasm from "./model.wasm";
+
+const { instance } = await WebAssembly.instantiate(readFileSync(wasm));
+```
+
+The path is absolute and computed when the executable runs, so it holds wherever the binary is started from — no joining against `__dirname` first.
+
+Import attributes are accepted and ignored, since the extension already decides. Both of these load the same text:
+
+```ts
+import prompt from "./prompt.md";
+import prompt from "./prompt.md" with { type: "text" };
+```
+
+An asset that nothing uses is left out of the executable, so an unused import costs nothing.
+
 ## Asset paths resolve from the entry
 
 Compiling bundles every module into one file at the entry's location, so in the compiled app `import.meta.url` and `__dirname` always point at the entry's directory — including in code that lived in a subdirectory beforehand. Write asset paths as the entry would see them:
@@ -343,6 +379,28 @@ Resolve one specifier as another, repeatable:
 ```bash
 nub compile app.ts --alias lodash=lodash-es --alias '@/=./src/'
 ```
+
+### `--loader`
+
+Choose what importing an extension evaluates to, overriding the defaults. Repeatable:
+
+```bash
+nub compile app.ts --loader .html=file --loader .sql=text
+```
+
+Available loaders:
+
+```
+file      embeds the file and yields an absolute path to it
+text      the file's contents, as a string
+json      the parsed value
+base64    the bytes, base64-encoded into the bundle
+dataurl   the bytes, as a data: URL
+binary    the bytes, as a Uint8Array
+empty     nothing, and the file is not read
+```
+
+Reach for it when an extension nub doesn't map is a real asset — a web build's `.html` and `.css` files, a `.sql` schema — or to move one the other way, as `--loader .wasm=binary` does to inline a module's bytes instead of writing it out.
 
 ### `--conditions`
 

--- a/site/content/docs/compile.mdx
+++ b/site/content/docs/compile.mdx
@@ -402,6 +402,8 @@ empty     nothing, and the file is not read
 
 Reach for it when an extension nub doesn't map is a real asset — a web build's `.html` and `.css` files, a `.sql` schema — or to move one the other way, as `--loader .wasm=binary` does to inline a module's bytes instead of writing it out.
 
+Extensions match exactly, case included, so a file named `PHOTO.PNG` needs `--loader .PNG=file`.
+
 ### `--conditions`
 
 Add `exports` conditions to resolution. They join the defaults (`default`, `node`) rather than replacing them:


### PR DESCRIPTION
Importing a non-JavaScript file either failed the build or silently yielded `undefined`. Two loaders close that:

- **text** — `.md` joins Rolldown's built-in `.txt`; the import evaluates to the file's contents.
- **file** — `.wasm`, images, fonts and other binary formats ship inside the executable, and the import evaluates to an **absolute** path valid from any cwd.

Rolldown's own asset loader yields a chunk-relative path, which resolves against the launch directory — correct only where it was tested. Hence nub's own.

`--loader EXT=TYPE` overrides the defaults in either direction.

Also fixes an `Output::Asset` arm that dropped every non-map asset.

Verified on real compiled binaries, run from `/` with the source tree deleted.
