### PR TITLE
sandbox(win): stream a confined spawn's stdio, and give it a real IPC channel

### DIFF
--- a/.github/workflows/win-jail-repairs-probe.yml
+++ b/.github/workflows/win-jail-repairs-probe.yml
@@ -162,10 +162,12 @@ jobs:
             need_pass "$p"
           done
 
-          # The env-block ceiling is a HARD one and the payload sits inside it by ~8.7k characters:
-          # a CreateProcessW environment block holds 32767 in total, and the stamped NODE_OPTIONS is
-          # 23995 of that. `tiny` carries a flag-sized value and `full` the real one, so a launch
-          # failure caused by SIZE separates itself from anything the shim does.
+          # The env-block ceiling is a HARD one and the margin is thinner than the payload alone
+          # suggests: a CreateProcessW environment block holds 32767 characters IN TOTAL, the
+          # stamped NODE_OPTIONS is 23995 of them, and the whole block measured 27557 on this runner
+          # — about 5.2k spare, which PATH and npm_config_* have to fit inside. `tiny` carries a
+          # flag-sized value and `full` the real one, so a launch failure caused by SIZE separates
+          # itself from anything the shim does.
           echo "---- NODE_OPTIONS delivery size ----"
           for p in node-options-tiny-launches \
                    node-options-full-launches; do

--- a/.github/workflows/win-jail-repairs-probe.yml
+++ b/.github/workflows/win-jail-repairs-probe.yml
@@ -6,8 +6,16 @@
 # WHAT IS MEASURED. Repair 1 makes every ancestor of a granted path reachable, so an absolute
 # `require()` no longer dies on `EPERM: lstat 'C:\'` — by writing a non-inherited traverse ACE
 # where the user can, and requesting the capability SIDs already on those DACLs where it
-# cannot. Repair 2 stamps a NODE_OPTIONS preload that rewrites piped stdio into scratch files,
-# so a confined `child_process` spawn returns instead of spinning in libuv's retry loop.
+# cannot. Repair 2 stamps a NODE_OPTIONS preload that creates each pipe ITSELF in the
+# AppContainer-private namespace (`\\.\pipe\LOCAL\…`) and hands the child an already-connected end
+# as a raw fd, so a confined `child_process` spawn STREAMS instead of spinning in libuv's retry
+# loop — and `fork()` gets a real channel over that same namespace rather than failing fast.
+#
+# THE TWO ARMS THAT NEED A REAL LOWBOX TOKEN, and cannot be measured anywhere else: whether
+# `fs.openSync` on a `LOCAL\` pipe name is permitted (the fd handed to the child), and whether a
+# CONFINED DESCENDANT can create a second private pipe of its own (`shim-fork-nested`). Everything
+# about how faithfully the shim reproduces `child_process` is measured cross-platform by
+# `stdio_shim_semantics`; only the namespace question lives here.
 #
 # THE CONTROLS. `NUB_SANDBOX_WIN_NO_ANCESTOR_REPAIR` disables repair 1 for one arm of the same
 # run, on the same fixture, so the repaired arm has something to differ from; the unshimmed
@@ -23,7 +31,7 @@ on:
   push:
     # Path-filtered so a change to a SIBLING probe does not spend ~25 minutes of Windows runner
     # on this one. Shared capacity: every push here costs the full matrix.
-    branches: [sandbox/win-jail-caps]
+    branches: [sandbox/win-jail-caps, sandbox/win-stdio-stream]
     paths:
       - 'crates/nub-sandbox/**'
       - '.github/workflows/win-jail-repairs-probe.yml'
@@ -154,12 +162,23 @@ jobs:
             need_pass "$p"
           done
 
+          # The env-block ceiling is a HARD one and the payload sits inside it by ~8.7k characters:
+          # a CreateProcessW environment block holds 32767 in total, and the stamped NODE_OPTIONS is
+          # 23995 of that. `tiny` carries a flag-sized value and `full` the real one, so a launch
+          # failure caused by SIZE separates itself from anything the shim does.
+          echo "---- NODE_OPTIONS delivery size ----"
+          for p in node-options-tiny-launches \
+                   node-options-full-launches; do
+            need_pass "$p"
+          done
+
           echo "---- stdio shim ----"
           for p in shim-execfile-async-returns \
                    shim-execfilesync-returns \
                    shim-spawnsync-returns \
                    shim-spawn-stream-returns \
-                   shim-fork-fails-fast \
+                   shim-fork-roundtrip \
+                   shim-fork-nested \
                    unshimmed-piped-hangs; do
             need_pass "$p"
           done

--- a/crates/nub-cli/src/pm_engine/build_jail.rs
+++ b/crates/nub-cli/src/pm_engine/build_jail.rs
@@ -134,8 +134,9 @@ impl aube_util::LifecycleSandbox for NubBuildJail {
         // WINDOWS: deliver the `child_process` stdio shim. A piped spawn under the
         // AppContainer does not fail, it SPINS — libuv retries the refused named pipe
         // forever inside `uv_spawn`, before any timeout can arm — and every `node-gyp`
-        // configure pipes. Rationale and the residual it leaves (`fork`/IPC, which no file
-        // can emulate) are on `nub_sandbox::windows_build_jail_node_options`.
+        // configure pipes. Rationale, and the residuals it still leaves (handle passing and
+        // `serialization: 'advanced'`, which no userland stream can carry), are on
+        // `nub_sandbox::windows_build_jail_node_options`.
         //
         // UNCONDITIONAL, like `NODE_COMPAT` above: it OVERWRITES any ambient value, which is
         // also the ONLY thing that keeps the env allowlist's `NODE_OPTIONS` entry from

--- a/crates/nub-sandbox/src/backend/windows_stdio_shim.js
+++ b/crates/nub-sandbox/src/backend/windows_stdio_shim.js
@@ -1,75 +1,114 @@
-// Windows build jail: give a confined Node a working `child_process` with piped stdio.
+// Windows build jail: give a confined Node a working `child_process` — streaming piped stdio AND
+// an IPC channel — without touching libuv.
 //
-// WHY THIS EXISTS. libuv creates a NAMED PIPE per piped stdio stream, and the global NPFS
-// namespace (`\\.\pipe\…`) is closed to a LowBox token — every shape is refused, in every
-// grant configuration, and no capability the policy surface can reach changes it. The
-// AppContainer-private namespace (`\\.\pipe\LOCAL\…`) IS open, but libuv does not spell its
-// names that way. `uv__pipe_server` treats the refusal as a NAME COLLISION and retries with a
-// fresh name forever (`if (err != ERROR_PIPE_BUSY && err != ERROR_ACCESS_DENIED) goto error;`),
-// inside `uv_spawn`, before any timer arms — so a confined piped spawn does not fail, it SPINS.
-// Measured: cpu_ms 14906 of 15059 wall.
+// THE DEFECT. libuv names every stdio/IPC pipe in the GLOBAL NPFS namespace
+// (`uv__unique_pipe_name` -> `\\?\pipe\uv\%llu-%lu`, deps/uv/src/win/pipe.c:109), which a LowBox
+// token is refused — every shape, in every grant configuration, and no capability the policy
+// surface can reach changes it. `uv__pipe_server` reads `ERROR_ACCESS_DENIED` as a NAME COLLISION
+// and retries with a fresh name forever (`if (err != ERROR_PIPE_BUSY && err != ERROR_ACCESS_DENIED)
+// goto error;`), inside `uv_spawn`, before any timer arms — so a confined piped spawn does not
+// fail, it SPINS. Measured: cpu_ms 14906 of 15059 wall. The AppContainer-PRIVATE namespace
+// (`\\.\pipe\LOCAL\…`) IS creatable under the same jail (measured on Server 2025 and Win 11 arm64,
+// CI runs 30516750145 / 30517115980); libuv simply never spells a name there.
 //
-// WHAT IT DOES. `stdio: [0, fd, fd]` against ordinary FILES is permitted under the same jail,
-// so every 'pipe' slot is rewritten to a scratch file and the bytes are handed back through
-// stream objects the caller cannot tell apart for the buffered case. `exec`, `execFile`,
-// `execSync`, `execFileSync` and `spawnSync` buffer to completion anyway, so for them this is
-// exact. A raw `spawn()` whose caller streams incrementally gets all of its output at child
-// exit instead of as it is produced — the one behavioural difference, and the reason this is
-// scoped to the jail rather than shipped to every Node nub runs.
+// SO THE PIPE IS CREATED HERE, IN THAT NAMESPACE, AND THE CHILD IS HANDED AN ALREADY-CONNECTED END.
+// A `net` server binds a `LOCAL\` name, this process connects to it, and that connected end goes
+// into `options.stdio` as a raw fd — libuv's `UV_INHERIT_FD`, which duplicates a handle it never
+// had to name (deps/uv/src/win/process-stdio.c:254). The parent reads the accepted end, so output
+// arrives AS IT IS PRODUCED and `maxBuffer` applies again. An `'ipc'` slot is removed outright and
+// the channel re-implemented over the same private namespace as newline-delimited JSON — the
+// framing Node's own `json` mode uses, which is what `fork` defaults to.
 //
-// WHAT IT CANNOT DO. An IPC channel is a duplex pipe; a file cannot emulate one. `fork()` and
-// an explicit `'ipc'` slot therefore FAIL FAST here with a diagnostic naming the opt-out,
-// which is strictly better than the unkillable spin they would otherwise become. `maxBuffer`
-// also stops applying — a file has no backpressure — so a runaway child fills the disk rather
-// than tripping `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`.
+// WHY THE CHILD'S END IS AN fd AND NOT A STREAM. `UV_INHERIT_STREAM` also works under the jail
+// (measured, `spawn-wrap-local=OK streamed="wrapmarker" eof=yes`), but it reads
+// `((uv_pipe_t*) stream)->handle`, and on Windows `uv_pipe_connect2` parks the HANDLE on the
+// connect REQ — only `uv__process_pipe_connect_req` moves it onto the handle, a loop turn later.
+// `ChildProcess.prototype.spawn` is SYNCHRONOUS, so a stream connected in the same tick still reads
+// INVALID_HANDLE_VALUE there and the spawn fails `ERROR_NOT_SUPPORTED`. An fd sidesteps the whole
+// question: Windows gets one from `fs.openSync`, whose `CreateFileW` connects inline, and POSIX
+// from `net.connect`, where `connect(2)` on a listening unix socket completes inline. Only that one
+// primitive is platform-split; everything downstream is shared, so the force seam measures it all.
 //
-// SEAMS. `execFile`/`exec` call child_process's MODULE-LOCAL `spawn`, so patching the exported
-// one would miss them; the single shared seam underneath all of them is
-// `ChildProcess.prototype.spawn`. The sync family bottoms out in a module-local `spawnSync`
-// instead, so `execSync`/`execFileSync` are re-expressed on the patched export — their error
-// shaping (`inheritStderr`, `checkExecSyncError`) is reproduced from lib/child_process.js.
+// WHY NODE'S OWN IPC IS INEXPRESSIBLE. `setupChannel` (lib/internal/child_process.js) must be
+// handed a CONNECTED `Pipe(PipeConstants.IPC)`. It is module-internal, the `Pipe(IPC)` it wants is
+// a local of `ChildProcess.prototype.spawn`, and the one route for adopting an existing handle —
+// `Pipe.prototype.open` — is refused for IPC because `uv_pipe_open` asserts the handle is
+// OVERLAPPED and `fs__open` never sets `FILE_FLAG_OVERLAPPED`. A `NODE_CHANNEL_FD` handoff
+// therefore has no userland expression, which is why the channel is reimplemented, not reused.
+//
+// WHAT IS STILL REFUSED, DELIBERATELY. Handle passing (`child.send(msg, socket)`) needs
+// `uv_write2`/`SCM_RIGHTS`, which no userland stream carries, and `serialization: 'advanced'` rides
+// libuv's IPC frames. Both throw `ERR_NUB_SANDBOX_NO_IPC` naming the per-package opt-out: a clear,
+// typed error beats an unkillable spin, and beats silently misbehaving.
+//
+// `spawnSync` KEEPS THE FILE-BACKED PATH, AND MUST. `ParseStdioOption` has no `'wrap'` case
+// (`UNREACHABLE()`), and a synchronously-blocked loop cannot drain a pipe, so the sync family still
+// rewrites each `'pipe'` slot to a scratch FILE. `execSync`, `execFileSync` and `spawnSync` buffer
+// to completion anyway, so for them that is exact. It does need a writable directory — which is
+// why ONLY the sync family probes for one now. The async path needs no filesystem grant at all,
+// which matters in a jail whose whole purpose is confining writes, and is why the file path
+// survives here only as the fallback for a namespace that refuses.
+//
+// SEAMS. `execFile`/`exec` call child_process's MODULE-LOCAL `spawn`, so patching the exported one
+// would miss them; the single shared seam underneath all of them is `ChildProcess.prototype.spawn`.
+// ONE override resolves the IPC slot and the piped slots TOGETHER — deliberately, because two
+// stacked overrides would have an install order, and the wrong order would silently restore the
+// refusal this file exists to remove. The sync family bottoms out in a module-local `spawnSync`
+// instead, so `execSync`/`execFileSync` are re-expressed on the patched export; their error shaping
+// (`inheritStderr`, `checkExecSyncError`) is reproduced from lib/child_process.js.
 import cp from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { Readable, Writable } from "node:stream";
+import { PassThrough, Readable, Writable } from "node:stream";
 
-// The force seam is what lets `stdio_shim_semantics` run on EVERY platform. What it repairs is
-// a Windows fact, but how faithfully it reproduces `child_process` — buffered output, the
-// deferred `close`, error shaping — is not, and a Windows-only regression test would leave the
-// part most likely to break unmeasured on the machines people develop on. Inert without the
-// preload: setting it loads nothing.
 const SENTINEL = "__nubJailStdioShim";
-const active = process.platform === "win32" || !!process.env.__NUB_JAIL_STDIO_SHIM_FORCE;
+const CHANNEL_ENV = "__NUB_JAIL_IPC";
+const FORCE_ENV = "__NUB_JAIL_STDIO_SHIM_FORCE";
+const WIN = process.platform === "win32";
+const FORCE = process.env[FORCE_ENV] || "";
+const SELF_URL = import.meta.url;
+
+const IPC_HELP =
+  "To run this package's build scripts unsandboxed, add to your package.json: " +
+  '"dependenciesMeta": { "<package>": { "sandbox": false } }';
+
+const refusal = (what) => {
+  const e = new Error(
+    `${what} is not available inside nub's Windows build sandbox. ${IPC_HELP}`,
+  );
+  e.code = "ERR_NUB_SANDBOX_NO_IPC";
+  return e;
+};
+
+let addrSeq = 0;
+
+// The force seam is what lets `stdio_shim_semantics` run on EVERY platform. What it repairs is a
+// Windows fact, but how faithfully it reproduces `child_process` — incremental delivery, the
+// deferred `close`, `maxBuffer`, the channel's own semantics, error shaping — is not, and a
+// Windows-only regression test would leave the part most likely to break unmeasured on the machines
+// people develop on. Inert without the preload: setting it loads nothing.
+const active = WIN || !!FORCE;
 if (active && !globalThis[SENTINEL]) {
   globalThis[SENTINEL] = true;
   install();
+  // Awaited for the reason Node's own `_forkChild` runs during bootstrap: a package whose first
+  // line calls `process.send()` must not race the socket.
+  const inherited = process.env[CHANNEL_ENV];
+  if (inherited) await installChildEnd(inherited);
 }
 
 function install() {
-  // Every scratch file must land somewhere the jail granted WRITE. Neither candidate can be
-  // assumed — the temp dir is preferred but is not the jail's write anchor and is often
-  // ungranted, and the cwd is the anchor but a script may have moved off it — so writability
-  // is PROBED. With neither writable there is no repair to make, and leaving child_process
-  // untouched beats half-patching it.
-  const dir = writableScratchDir();
-  if (dir === null) return;
+  // Only the SYNC family needs a file now, so this probe no longer gates the whole shim: a jail
+  // with no writable directory anywhere still gets working async stdio and a working channel.
+  // Neither candidate can be assumed — the temp dir is preferred but is not the jail's write
+  // anchor and is often ungranted, and the cwd is the anchor but a script may have moved off it.
+  const scratchDir = writableScratchDir();
 
   let seq = 0;
   const scratch = (tag) =>
-    path.join(dir, `.nub-jail-${process.pid}-${seq++}-${tag}.tmp`);
-
-  const IPC_HELP =
-    "nub's Windows build sandbox cannot provide a child_process IPC channel: Windows " +
-    "refuses named pipes to a sandboxed (AppContainer) process, and Node's IPC channel " +
-    "requires one. To run this package's build scripts unsandboxed, add to your " +
-    'package.json: "dependenciesMeta": { "<package>": { "sandbox": false } }';
-
-  const ipcError = (api) => {
-    const e = new Error(`${api}: ${IPC_HELP}`);
-    e.code = "ERR_NUB_SANDBOX_NO_IPC";
-    return e;
-  };
+    path.join(scratchDir, `.nub-jail-${process.pid}-${seq++}-${tag}.tmp`);
 
   const isPipe = (slot) =>
     slot === undefined ||
@@ -84,97 +123,210 @@ function install() {
   const origSpawn = cp.ChildProcess.prototype.spawn;
   cp.ChildProcess.prototype.spawn = function (options) {
     const stdio = asArray(options && options.stdio);
-    if (stdio.includes("ipc")) throw ipcError("spawn");
-    if (!stdio.some(isPipe)) return origSpawn.call(this, options);
+    const ipcAt = stdio.indexOf("ipc");
+    const piped = stdio.some(isPipe);
+    if (ipcAt === -1 && !piped) return origSpawn.call(this, options);
 
-    const fds = [];
-    const captures = [null, null, null];
-    let stdinPiped = false;
-    for (let i = 0; i < stdio.length && i < 3; i++) {
-      if (!isPipe(stdio[i])) continue;
-      const file = scratch(`a${i}`);
-      if (i === 0) {
-        fs.writeFileSync(file, "");
-        const fd = fs.openSync(file, "r");
-        fds.push({ fd, file });
-        stdio[0] = fd;
-        stdinPiped = true;
-      } else {
-        const fd = fs.openSync(file, "w");
-        fds.push({ fd, file });
-        stdio[i] = fd;
-        captures[i] = file;
-      }
-    }
-    // A pipe past index 2 is an extra channel with no file analogue (it has no stream on
-    // the child either) — refuse rather than silently drop it.
-    for (let i = 3; i < stdio.length; i++) {
-      if (isPipe(stdio[i])) throw ipcError("spawn");
-    }
+    // Resolved FIRST, and in this same override — see SEAMS. A SECOND 'ipc' slot is deliberately
+    // left in place so Node still raises its own `ERR_IPC_ONE_PIPE`.
+    const channel = ipcAt === -1 ? null : openChannel(options, stdio, ipcAt);
+    const slots = piped ? (openStreamedSlots(stdio) ?? openScratchSlots(stdio)) : null;
+    if (piped && slots === null) throw refusal("piped stdio");
+
+    stampChildEnv(options, channel && channel.address);
     options.stdio = stdio;
 
-    const err = origSpawn.call(this, options);
-    attach(this, captures, fds, stdinPiped);
+    let err;
+    try {
+      err = origSpawn.call(this, options);
+    } catch (thrown) {
+      if (channel) channel.abort();
+      if (slots) slots.abort();
+      throw thrown;
+    }
+    // A spawn that never started still gets its streams — real Node exposes them too — but no
+    // close accounting, which is Node's `pid !== 0` condition and is what keeps `onexit`'s own
+    // `maybeClose` sufficient on the `error` path.
+    if (slots) slots.attach(this);
+    if (channel) {
+      if (err) channel.abort();
+      else channel.attach(this);
+    }
     return err;
   };
 
-  /// Replace the null streams an fd-stdio spawn produces with ones fed from the scratch
-  /// files at child exit, and hold `close` back until they have drained. `_closesNeeded`
-  /// is Node's own bookkeeping (`maybeClose`), so raising it is what stops the base
-  /// implementation emitting `close` before a single byte has been delivered.
-  function attach(child, captures, fds, stdinPiped) {
-    const streams = [null, null, null];
-    for (const i of [1, 2]) {
-      if (captures[i] === null) continue;
-      streams[i] = new Readable({ read() {} });
-      child._closesNeeded++;
+  /// A channel over the container-private namespace, replacing the `'ipc'` slot outright.
+  function openChannel(options, stdio, at) {
+    if (options.serialization === "advanced") {
+      throw refusal("serialization: 'advanced'");
     }
-    if (streams[1]) child.stdout = streams[1];
-    if (streams[2]) child.stderr = streams[2];
-    if (stdinPiped) {
-      // A write here cannot reach the child — its stdin was opened on an already-EOF file
-      // before it started. Accepting and discarding keeps `child.stdin.end()` from throwing
-      // on a null; a caller genuinely conversing over stdin is the documented residual.
-      child.stdin = new Writable({
-        write(_chunk, _enc, done) {
-          done();
-        },
-      });
-    }
-    child.stdio = [child.stdin || null, child.stdout || null, child.stderr || null];
+    // An 'ipc' slot below fd 3 would need `UV_IGNORE` on a real stdio fd, which opens
+    // `\Device\Null` — refused on Server images under the same jail. Nothing in the ecosystem does
+    // it; refusing beats trading one blocker for another.
+    if (at < 3) throw refusal("an 'ipc' stdio slot below fd 3");
 
-    // `error` as well as `exit`: a spawn that fails outright (a negative exit code, e.g. the
-    // image was not found) emits `error` INSTEAD of `exit`, and a caller waiting on `close`
-    // would then wait forever — the failure mode this whole shim exists to remove.
-    let flushed = false;
-    const flush = () => {
-      if (flushed) return;
-      flushed = true;
+    const address = newAddress("ipc");
+    const server = net.createServer({ pauseOnConnect: false });
+    server.unref();
+    // Bind happens synchronously inside `listen()` — only the 'listening' EVENT is deferred — so
+    // the address exists by the time the child is launched.
+    server.listen(address);
+    // `UV_IGNORE` above fd 2 is a no-op in libuv: the slot is left INVALID_HANDLE_VALUE and no
+    // device is opened (deps/uv/src/win/process-stdio.c:210). So this removes the channel without
+    // substituting anything, which is what keeps `uv_spawn` off `uv__pipe_server` entirely.
+    stdio[at] = "ignore";
+
+    // Closed the instant the one expected connection lands, and again on teardown: a
+    // `disconnect()` before the child ever connects would otherwise leave a listening pipe behind
+    // for the life of the process, and a jail run spawns hundreds of children.
+    const close = () => {
+      try {
+        server.close();
+      } catch {}
+    };
+    return {
+      address,
+      abort: close,
+      attach(child) {
+        attachChannel(
+          child,
+          (bind) =>
+            server.once("connection", (socket) => {
+              close();
+              bind(socket);
+            }),
+          close,
+        );
+      },
+    };
+  }
+
+  /// One connected pipe per piped slot. `null` when the private namespace is unusable, so the
+  /// caller can fall back to the scratch-file rewrite rather than lose stdio altogether.
+  function openStreamedSlots(stdio) {
+    const opened = [];
+    try {
+      for (let i = 0; i < stdio.length; i++) {
+        if (!isPipe(stdio[i])) continue;
+        const address = newAddress("io");
+        const server = net.createServer({ pauseOnConnect: true });
+        server.unref();
+        const accepted = new Promise((resolve, reject) => {
+          server.once("connection", resolve);
+          server.once("error", reject);
+        });
+        // The connection is OURS and is established before the child starts, so this settles on
+        // the next loop turn whatever the child does — but it has to be marked handled now, or an
+        // abort before `attach` surfaces as an unhandled rejection.
+        accepted.catch(() => {});
+        server.listen(address);
+        const end = openChildEnd(address);
+        opened.push({ slot: i, server, accepted, fd: end.fd, release: end.release });
+        stdio[i] = end.fd;
+      }
+    } catch {
+      for (const p of opened) {
+        p.release();
+        try {
+          p.server.close();
+        } catch {}
+      }
+      return null;
+    }
+    return streamedPlan(opened);
+  }
+
+  function streamedPlan(opened) {
+    const closeServer = (p) => {
+      try {
+        p.server.close();
+      } catch {}
+    };
+    return {
+      abort() {
+        for (const p of opened) {
+          p.release();
+          closeServer(p);
+        }
+      },
+      attach(child) {
+        const streams = [];
+        for (const p of opened) {
+          const stream = new PassThrough();
+          streams[p.slot] = stream;
+          // Node's own accounting, mirrored exactly: stdin is never counted, and a spawn that
+          // never started counts nothing (lib/internal/child_process.js).
+          const counted = p.slot > 0 && child.pid !== 0;
+          if (counted) child._closesNeeded++;
+          p.accepted.then(
+            (socket) => {
+              closeServer(p);
+              if (p.slot === 0) stream.pipe(socket);
+              else socket.pipe(stream);
+              // Accounting rides the SOCKET, not the PassThrough: real pipes emit `close` whether
+              // or not the caller ever read them, and gating on a PassThrough nobody drains would
+              // hang the child's own completion instead.
+              if (counted) socket.once("close", () => bumpClose(child));
+            },
+            () => {
+              closeServer(p);
+              stream.end();
+              if (counted) bumpClose(child);
+            },
+          );
+        }
+        // The parent's copy of each child-end handle must go, or EOF never arrives on the reading
+        // end. The duplicate the child holds is independent (`uv__duplicate_fd`) and was made
+        // synchronously inside `_handle.spawn`, so releasing now is safe — and a tick earlier than
+        // waiting for 'spawn' would be.
+        for (const p of opened) p.release();
+        publishStreams(child, streams);
+      },
+    };
+  }
+
+  /// The pre-streaming path, behaviour unchanged: every piped slot becomes a scratch FILE and the
+  /// bytes are handed back at child exit. Reachable now only when the private namespace refuses,
+  /// and the only path `spawnSync` can use at all.
+  function openScratchSlots(stdio) {
+    if (scratchDir === null) return null;
+    // A pipe past index 2 is an extra channel with no file analogue — refuse rather than silently
+    // drop it. The streamed path above has no such limit.
+    for (let i = 3; i < stdio.length; i++) {
+      if (isPipe(stdio[i])) throw refusal("a piped stdio slot above fd 2");
+    }
+    const fds = [];
+    const captures = [];
+    let stdinPiped = false;
+    try {
+      for (let i = 0; i < stdio.length && i < 3; i++) {
+        if (!isPipe(stdio[i])) continue;
+        const file = scratch(`a${i}`);
+        if (i === 0) {
+          fs.writeFileSync(file, "");
+          const fd = fs.openSync(file, "r");
+          fds.push({ fd, file });
+          stdio[0] = fd;
+          stdinPiped = true;
+        } else {
+          const fd = fs.openSync(file, "w");
+          fds.push({ fd, file });
+          stdio[i] = fd;
+          captures[i] = file;
+        }
+      }
+    } catch {
+      return null;
+    }
+    return scratchPlan(captures, fds, stdinPiped);
+  }
+
+  function scratchPlan(captures, fds, stdinPiped) {
+    const discard = () => {
       for (const { fd } of fds) {
         try {
           fs.closeSync(fd);
         } catch {}
-      }
-      for (const i of [1, 2]) {
-        const stream = streams[i];
-        if (!stream) continue;
-        let buf;
-        try {
-          buf = fs.readFileSync(captures[i]);
-        } catch {
-          buf = Buffer.alloc(0);
-        }
-        stream.on("end", () => {
-          child._closesGot++;
-          if (child._closesGot === child._closesNeeded) {
-            child.emit("close", child.exitCode, child.signalCode);
-          }
-        });
-        if (buf.length > 0) stream.push(buf);
-        stream.push(null);
-        // `end` only fires on a stream someone is reading, and `close` is gated on `end`.
-        // A caller that never reads must not be able to hang the child's own completion.
-        if (!stream.readableFlowing) stream.resume();
       }
       for (const { file } of fds) {
         try {
@@ -182,8 +334,65 @@ function install() {
         } catch {}
       }
     };
-    child.once("exit", flush);
-    child.once("error", flush);
+    return {
+      abort: discard,
+      attach(child) {
+        const streams = [];
+        for (const i of [1, 2]) {
+          if (captures[i] === undefined) continue;
+          streams[i] = new Readable({ read() {} });
+          if (child.pid !== 0) child._closesNeeded++;
+        }
+        if (stdinPiped) {
+          // A write here cannot reach the child — its stdin was opened on an already-EOF file
+          // before it started. Accepting and discarding keeps `child.stdin.end()` from throwing on
+          // a null; a caller genuinely conversing over stdin is the residual the streamed path
+          // above exists to remove.
+          streams[0] = new Writable({
+            write(_chunk, _enc, done) {
+              done();
+            },
+          });
+        }
+        publishStreams(child, streams);
+
+        // `error` as well as `exit`: a spawn that fails outright emits `error` INSTEAD of `exit`,
+        // and a caller waiting on `close` would then wait forever.
+        let flushed = false;
+        const flush = () => {
+          if (flushed) return;
+          flushed = true;
+          for (const { fd } of fds) {
+            try {
+              fs.closeSync(fd);
+            } catch {}
+          }
+          for (const i of [1, 2]) {
+            const stream = streams[i];
+            if (!stream) continue;
+            let buf;
+            try {
+              buf = fs.readFileSync(captures[i]);
+            } catch {
+              buf = Buffer.alloc(0);
+            }
+            if (child.pid !== 0) stream.on("end", () => bumpClose(child));
+            if (buf.length > 0) stream.push(buf);
+            stream.push(null);
+            // `end` only fires on a stream someone is reading, and `close` is gated on `end`. A
+            // caller that never reads must not be able to hang the child's own completion.
+            if (!stream.readableFlowing) stream.resume();
+          }
+          for (const { file } of fds) {
+            try {
+              fs.unlinkSync(file);
+            } catch {}
+          }
+        };
+        child.once("exit", flush);
+        child.once("error", flush);
+      },
+    };
   }
 
   // ── the sync seam ─────────────────────────────────────────────────────────────────
@@ -191,11 +400,14 @@ function install() {
   cp.spawnSync = function (file, argsOrOptions, maybeOptions) {
     const [args, given] = splitArgs(argsOrOptions, maybeOptions);
     const stdio = asArray(given && given.stdio);
-    if (stdio.includes("ipc")) throw ipcError("spawnSync");
+    if (stdio.includes("ipc")) throw refusal("a synchronous IPC channel");
     if (!stdio.some(isPipe)) return origSpawnSync(file, args, given);
+    // There is no streamed path to fall back to here, so without a writable directory there is no
+    // repair to make — and a typed refusal beats returning the caller to the spin.
+    if (scratchDir === null) throw refusal("synchronous piped stdio");
 
     for (let i = 3; i < stdio.length; i++) {
-      if (isPipe(stdio[i])) throw ipcError("spawnSync");
+      if (isPipe(stdio[i])) throw refusal("a piped stdio slot above fd 2");
     }
 
     const options = Object.assign({}, given);
@@ -282,11 +494,266 @@ function install() {
     if (error) throw error;
     return result.stdout;
   };
+}
 
-  // ── what has no file analogue ─────────────────────────────────────────────────────
-  cp.fork = function () {
-    throw ipcError("fork");
+/// Windows: the AppContainer-private namespace, the whole point of this file. Elsewhere a unix
+/// socket, so the fidelity half is regression-tested where people develop — the namespace is a
+/// Windows fact, the stream and channel semantics are not.
+function newAddress(kind) {
+  const tag = `nub-${kind}-${process.pid}-${addrSeq++}-${Math.random().toString(36).slice(2, 8)}`;
+  return WIN ? `\\\\.\\pipe\\LOCAL\\${tag}` : path.join(os.tmpdir(), `${tag}.sock`);
+}
+
+/// The child's end of an already-bound address, obtained SYNCHRONOUSLY — the header explains why
+/// that is the binding constraint and why the two platforms reach it differently.
+function openChildEnd(address) {
+  if (WIN) {
+    // `r+` is the mapping that yields a named-pipe CLIENT open: with no O_CREAT/O_TRUNC, libuv's
+    // `fs__open` picks `OPEN_EXISTING` with `FILE_GENERIC_READ | FILE_GENERIC_WRITE`
+    // (deps/uv/src/win/fs.c), and `toNamespacedPath` leaves a `\\.\` path alone so the name
+    // survives Node's own path handling.
+    const fd = fs.openSync(address, "r+");
+    return {
+      fd,
+      release() {
+        try {
+          fs.closeSync(fd);
+        } catch {}
+      },
+    };
+  }
+  const socket = net.connect(address);
+  const handle = socket._handle;
+  if (!handle || typeof handle.fd !== "number" || handle.fd < 0) {
+    socket.destroy();
+    throw new Error("the connected child end exposed no fd");
+  }
+  return { fd: handle.fd, release: () => socket.destroy() };
+}
+
+/// Node's `maybeClose`, which is module-internal. `_closesNeeded`/`_closesGot` are Node's own
+/// bookkeeping, so driving them by hand is what stops `close` landing before the output it is
+/// meant to have delivered.
+function bumpClose(child) {
+  child._closesGot++;
+  if (child._closesGot === child._closesNeeded) {
+    child.emit("close", child.exitCode, child.signalCode);
+  }
+}
+
+/// Mirrors the tail of Node's own `ChildProcess.prototype.spawn`: the three named properties plus
+/// the positional `stdio` array, leaving every slot Node already resolved untouched.
+function publishStreams(child, streams) {
+  const combined = Array.isArray(child.stdio) ? child.stdio.slice() : [];
+  while (combined.length < Math.max(3, streams.length)) combined.push(null);
+  for (let i = 0; i < streams.length; i++) {
+    if (streams[i]) combined[i] = streams[i];
+  }
+  child.stdio = combined;
+  child.stdin = combined[0] || null;
+  child.stdout = combined[1] || null;
+  child.stderr = combined[2] || null;
+}
+
+/// The channel address, and — when the caller rebuilt `env` or emptied `execArgv` — the preload
+/// chain the child would otherwise lose.
+///
+/// PRESERVATION, NOT CONSTRUCTION. In production this shim is one `--import` term on the
+/// `NODE_OPTIONS` nub stamps (`build_jail_node_options`), alongside the per-package egress gate,
+/// and that env var is also how BOTH reach every descendant. So the PARENT'S OWN value is the
+/// source and `import.meta.url` only the last resort: re-deriving from this module alone would
+/// silently drop the gate from every grandchild — a working `fork` that disarms the network
+/// confinement underneath it. When the inherited value already carries this module, the pairs are
+/// left exactly as they were.
+function stampChildEnv(options, address) {
+  const envPairs = Array.isArray(options.envPairs)
+    ? options.envPairs
+    : (options.envPairs = []);
+  const inherited = envPairs.filter((p) => p.startsWith("NODE_OPTIONS=")).pop();
+  const wanted = childNodeOptions(inherited);
+  for (let i = envPairs.length - 1; i >= 0; i--) {
+    // A stale address is dropped even for a non-IPC spawn, so a grandchild cannot attach to its
+    // parent's channel through an `env` object captured earlier.
+    if (envPairs[i].startsWith(`${CHANNEL_ENV}=`)) envPairs.splice(i, 1);
+    else if (wanted !== undefined && envPairs[i].startsWith("NODE_OPTIONS=")) {
+      envPairs.splice(i, 1);
+    }
+  }
+  if (address) envPairs.push(`${CHANNEL_ENV}=${address}`);
+  if (wanted !== undefined) {
+    envPairs.push(`NODE_OPTIONS=${wanted}`);
+    // The force seam's half of the same preservation. On Windows the preload is live because the
+    // child is on Windows, so this adds nothing; off Windows the sentinel is the ONLY thing that
+    // makes it live, and a caller who rebuilt `env` dropped it — which would leave the test suite
+    // measuring an inert preload while reporting on a repaired one.
+    if (FORCE && !envPairs.some((p) => p.startsWith(`${FORCE_ENV}=`))) {
+      envPairs.push(`${FORCE_ENV}=${FORCE}`);
+    }
+  }
+}
+
+/// `undefined` means "leave the inherited pairs exactly alone" — the common case, and the one where
+/// doing nothing is strictly safest.
+function childNodeOptions(inheritedPair) {
+  const prior =
+    inheritedPair === undefined ? "" : inheritedPair.slice("NODE_OPTIONS=".length);
+  if (prior.includes(SELF_URL)) return undefined;
+  const fromParent = process.env.NODE_OPTIONS || "";
+  if (fromParent.includes(SELF_URL)) return `${prior} ${fromParent}`.trim();
+  return `${prior} --import ${SELF_URL}`.trim();
+}
+
+// ── the channel, shared by both ends ─────────────────────────────────────────────────
+// Both ends run the identical protocol, so `send`/`'message'`/`disconnect` are defined once and
+// bound onto `process` in the child and onto the ChildProcess in the parent. `socket` may arrive
+// later than the first `send`, which is why writes queue.
+function attachChannel(emitter, getSocket, onTeardown) {
+  let socket = null;
+  let pending = [];
+  let closed = false;
+  let refs = 0;
+
+  const control = {
+    ref() {
+      refs++;
+      if (socket) socket.ref();
+    },
+    unref() {
+      refs--;
+      if (socket) socket.unref();
+    },
   };
+
+  const onLine = (line) => {
+    if (line.length === 0) return;
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return; // A partial line at close is not a message; Node's parser drops it too.
+    }
+    // `cmd: 'NODE_…'` is Node's internal namespace (`isInternal`), never delivered as 'message'.
+    // Nothing here emits one; the guard exists so a real Node peer on the other end cannot leak
+    // internals into user code.
+    if (
+      message &&
+      typeof message === "object" &&
+      typeof message.cmd === "string" &&
+      message.cmd.startsWith("NODE_")
+    ) {
+      emitter.emit("internalMessage", message);
+      return;
+    }
+    emitter.emit("message", message);
+  };
+
+  // Deferred, because Node's is: `child.disconnect()` on the line after `fork()` must still reach a
+  // 'disconnect' listener registered on the line after THAT. A synchronous emit loses it, and the
+  // loss is silent.
+  const teardown = () => {
+    if (closed) return;
+    closed = true;
+    emitter.connected = false;
+    emitter.channel = null;
+    pending = [];
+    if (onTeardown) onTeardown();
+    process.nextTick(() => emitter.emit("disconnect"));
+  };
+
+  const bind = (s) => {
+    socket = s;
+    socket.setEncoding("utf8");
+    if (refs < 0) socket.unref();
+    let buf = "";
+    socket.on("data", (chunk) => {
+      buf += chunk;
+      let nl;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        onLine(line);
+      }
+    });
+    socket.on("close", teardown);
+    socket.on("error", teardown);
+    for (const [line, cb] of pending) socket.write(line, cb);
+    pending = [];
+  };
+
+  emitter.channel = control;
+  emitter.connected = true;
+
+  emitter.send = function send(message, sendHandle, options, callback) {
+    if (typeof sendHandle === "function") {
+      callback = sendHandle;
+      sendHandle = undefined;
+    } else if (typeof options === "function") {
+      callback = options;
+      options = undefined;
+    }
+    if (sendHandle != null) throw refusal("child_process handle passing");
+    // Node reports a closed channel through the 'error' event (or the callback), NOT by throwing —
+    // `target.send`, lib/internal/child_process.js. Throwing instead turns a recoverable send into
+    // an exception at a call site written to expect neither.
+    if (closed) {
+      const ex = new Error("Channel closed");
+      ex.code = "ERR_IPC_CHANNEL_CLOSED";
+      if (typeof callback === "function") process.nextTick(callback, ex);
+      else process.nextTick(() => emitter.emit("error", ex));
+      return false;
+    }
+    if (message === undefined) {
+      const e = new TypeError('The "message" argument must be specified');
+      e.code = "ERR_MISSING_ARGS";
+      throw e;
+    }
+    const t = typeof message;
+    if (t !== "string" && t !== "object" && t !== "number" && t !== "boolean") {
+      const e = new TypeError(
+        'The "message" argument must be of type string, object, number, or boolean',
+      );
+      e.code = "ERR_INVALID_ARG_TYPE";
+      throw e;
+    }
+    const line = JSON.stringify(message) + "\n";
+    if (socket) socket.write(line, callback);
+    else pending.push([line, callback]);
+    return true;
+  };
+
+  emitter.disconnect = function disconnect() {
+    if (closed) return;
+    if (socket) {
+      emitter.connected = false;
+      socket.end();
+    } else {
+      teardown();
+    }
+  };
+
+  getSocket(bind);
+  return control;
+}
+
+/// The child half. The address is deleted from `process.env` exactly as Node deletes
+/// `NODE_CHANNEL_FD`, so a grandchild does not attach to its parent's channel.
+async function installChildEnd(address) {
+  delete process.env[CHANNEL_ENV];
+  const socket = await new Promise((resolve, reject) => {
+    const s = net.connect(address);
+    s.once("connect", () => resolve(s));
+    s.once("error", reject);
+  });
+  const control = attachChannel(process, (bind) => bind(socket));
+  // Node keeps the channel unref'd until something listens, so an IPC child with no 'message'
+  // listener still exits on its own (lib/child_process.js).
+  socket.unref();
+  process.on("newListener", (name) => {
+    if (name === "message" || name === "disconnect") control.ref();
+  });
+  process.on("removeListener", (name) => {
+    if (name === "message" || name === "disconnect") control.unref();
+  });
 }
 
 /// `(args, options)`, `(options)` and `(args)` all reach the same parameter slot.

--- a/crates/nub-sandbox/src/backend/windows_stdio_shim.js
+++ b/crates/nub-sandbox/src/backend/windows_stdio_shim.js
@@ -104,7 +104,11 @@ function install() {
   // with no writable directory anywhere still gets working async stdio and a working channel.
   // Neither candidate can be assumed — the temp dir is preferred but is not the jail's write
   // anchor and is often ungranted, and the cwd is the anchor but a script may have moved off it.
-  const scratchDir = writableScratchDir();
+  //
+  // The seam forces the no-writable-directory answer, because the property worth pinning — that
+  // the async path has no scratch precondition — cannot be staged with real permissions off
+  // Windows, where the address IS a filesystem path.
+  const scratchDir = process.env.__NUB_JAIL_NO_SCRATCH ? null : writableScratchDir();
 
   let seq = 0;
   const scratch = (tag) =>
@@ -263,6 +267,12 @@ function install() {
               closeServer(p);
               if (p.slot === 0) stream.pipe(socket);
               else socket.pipe(stream);
+              // In real Node the exposed stream IS the socket, so destroying it closes the pipe and
+              // settles the close accounting. Here they are two objects, and keeping that identity
+              // is load-bearing: `execFile`'s maxBuffer path calls `child.stdout.destroy()`, and if
+              // that left the socket open the count would never complete and the CALLBACK WOULD
+              // NEVER FIRE — silently, exit 0, which is what the file-backed path does today.
+              stream.once("close", () => socket.destroy());
               // Accounting rides the SOCKET, not the PassThrough: real pipes emit `close` whether
               // or not the caller ever read them, and gating on a PassThrough nobody drains would
               // hang the child's own completion instead.
@@ -630,7 +640,8 @@ function attachChannel(emitter, getSocket, onTeardown) {
     try {
       message = JSON.parse(line);
     } catch {
-      return; // A partial line at close is not a message; Node's parser drops it too.
+      // A partial line at close is not a message; Node's parser drops it too.
+      return;
     }
     // `cmd: 'NODE_…'` is Node's internal namespace (`isInternal`), never delivered as 'message'.
     // Nothing here emits one; the guard exists so a real Node peer on the other end cannot leak

--- a/crates/nub-sandbox/src/compiler/defaults.rs
+++ b/crates/nub-sandbox/src/compiler/defaults.rs
@@ -659,7 +659,10 @@ pub fn build_jail_stdio_preload_js() -> String {
     strip_js_comments(WINDOWS_STDIO_SHIM)
 }
 
-/// The `--import` term that delivers the stdio shim, encoded as the jail delivers it.
+/// The `--import` term that delivers the stdio shim, encoded as the jail delivers it. Built off
+/// Windows too, so the encoding and the env-block budget are gated on every platform's `cargo test`
+/// rather than only where the stamp is used.
+#[cfg(any(windows, test))]
 fn stdio_shim_import_term() -> String {
     format!(
         "--import data:text/javascript,{}",
@@ -696,6 +699,7 @@ pub fn windows_build_jail_node_options() -> String {
 /// Percent-encode everything outside the RFC 3986 unreserved set. Deliberately maximal:
 /// `NODE_OPTIONS` is split on whitespace and re-parsed by Node's own option reader, so an
 /// under-encoded payload does not corrupt a URL, it silently truncates the preload.
+#[cfg(any(windows, test))]
 fn percent_encode_strict(src: &str) -> String {
     let mut out = String::with_capacity(src.len() * 3);
     for byte in src.bytes() {

--- a/crates/nub-sandbox/src/compiler/defaults.rs
+++ b/crates/nub-sandbox/src/compiler/defaults.rs
@@ -630,8 +630,42 @@ pub fn windows_native_realpath_shim_node_options() -> String {
 /// The JS the Windows build jail preloads into every confined Node. Kept as a FILE rather
 /// than a Rust string so it stays readable, greppable and lintable; the delivery encoding is
 /// [`windows_build_jail_node_options`]'s job.
-#[cfg(windows)]
 const WINDOWS_STDIO_SHIM: &str = include_str!("../backend/windows_stdio_shim.js");
+
+/// Drop whole-line comments and indentation before the payload is encoded.
+///
+/// THIS IS A HARD BUDGET, NOT A TIDY-UP. A `CreateProcessW` environment block is capped at 32767
+/// CHARACTERS *in total*, and percent-encoding costs three characters for every byte outside the
+/// unreserved set — so the shim's own prose is charged at roughly 3x and the source, shipped raw,
+/// does not fit in the block AT ALL, let alone alongside `PATH` and the `npm_config_*` family.
+/// Stripping is what lets the file stay densely commented (which is where its provenance lives)
+/// while the delivered payload stays affordable. `stdio_shim_payload_fits_the_env_block` pins the
+/// margin so an innocent-looking edit cannot quietly break every jailed launch.
+///
+/// WHOLE LINES ONLY, deliberately: a partial-line stripper would have to know whether `//` sits
+/// inside a string, a regex or a template literal. Trimming and dropping entire lines is correct
+/// for any content EXCEPT a template literal spanning lines, of which the shim has none — every
+/// backtick in it opens and closes on one line, and the suite would catch a regression anyway.
+fn strip_js_comments(src: &str) -> String {
+    src.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The JS actually delivered to a confined Node.
+pub fn build_jail_stdio_preload_js() -> String {
+    strip_js_comments(WINDOWS_STDIO_SHIM)
+}
+
+/// The `--import` term that delivers the stdio shim, encoded as the jail delivers it.
+fn stdio_shim_import_term() -> String {
+    format!(
+        "--import data:text/javascript,{}",
+        percent_encode_strict(&strip_js_comments(WINDOWS_STDIO_SHIM))
+    )
+}
 
 /// The `NODE_OPTIONS` the Windows build jail STAMPS over any ambient value, delivering the
 /// `child_process` stdio shim ([`WINDOWS_STDIO_SHIM`]).
@@ -656,16 +690,12 @@ const WINDOWS_STDIO_SHIM: &str = include_str!("../backend/windows_stdio_shim.js"
 /// turn a missing repair into a broken install.
 #[cfg(windows)]
 pub fn windows_build_jail_node_options() -> String {
-    format!(
-        "--import data:text/javascript,{}",
-        percent_encode_strict(WINDOWS_STDIO_SHIM)
-    )
+    stdio_shim_import_term()
 }
 
 /// Percent-encode everything outside the RFC 3986 unreserved set. Deliberately maximal:
 /// `NODE_OPTIONS` is split on whitespace and re-parsed by Node's own option reader, so an
 /// under-encoded payload does not corrupt a URL, it silently truncates the preload.
-#[cfg(windows)]
 fn percent_encode_strict(src: &str) -> String {
     let mut out = String::with_capacity(src.len() * 3);
     for byte in src.bytes() {
@@ -952,20 +982,51 @@ mod tests {
     /// malformed URL that Node rejects — it produces a TRUNCATED preload that silently loads
     /// half a shim, or an option fragment Node aborts on. Both are quiet, so the encoding is
     /// asserted rather than eyeballed.
-    #[cfg(windows)]
+    /// Runs everywhere, because the encoding is not a Windows fact — only the DECISION to stamp is.
     #[test]
     fn the_stamped_node_options_is_a_single_whitespace_free_token() {
-        let stamped = windows_build_jail_node_options();
+        let stamped = stdio_shim_import_term();
+        #[cfg(windows)]
+        assert_eq!(stamped, windows_build_jail_node_options());
         let (flag, url) = stamped.split_once(' ').expect("flag then payload");
         assert_eq!(flag, "--import");
         assert!(
             !url.chars().any(char::is_whitespace),
-            "the data: URL must survive NODE_OPTIONS' whitespace split: {url}"
+            "the data: URL must survive NODE_OPTIONS' whitespace split"
         );
         assert!(url.starts_with("data:text/javascript,"));
         // The whole payload must arrive, not merely its opening — an identifier from the
         // shim's tail is what makes a truncation visible.
         assert!(url.contains(&percent_encode_strict("writableScratchDir")));
+    }
+
+    /// A `CreateProcessW` environment block is capped at 32767 CHARACTERS IN TOTAL, and this one
+    /// value is the largest thing in it by an order of magnitude. Left unstripped the shim does not
+    /// fit at all (measured: 56215 characters, ~1.7x the whole block), and every jailed launch on
+    /// Windows would fail for a reason that looks nothing like its cause.
+    ///
+    /// The ceiling here is what remains for `PATH` and the `npm_config_*` family that a real
+    /// install also has to carry, so it is deliberately well below 32767 rather than at it. If a
+    /// future edit trips this, shrink the payload — do not raise the number without re-measuring a
+    /// real install's block on Windows.
+    #[test]
+    fn stdio_shim_payload_fits_the_env_block() {
+        const BUDGET: usize = 26_000;
+        let stamped = stdio_shim_import_term();
+        assert!(
+            stamped.len() <= BUDGET,
+            "the stamped NODE_OPTIONS is {} chars, over the {BUDGET} budget; a CreateProcessW \
+             env block holds 32767 in total and must still fit PATH and npm_config_*",
+            stamped.len()
+        );
+        // Stripping must remove PROSE and nothing else: an identifier from the shim's tail proves
+        // the code survived, and the comment marker proves the prose did not.
+        let payload = strip_js_comments(WINDOWS_STDIO_SHIM);
+        assert!(payload.contains("writableScratchDir"));
+        assert!(
+            !payload.lines().any(|line| line.starts_with("//")),
+            "whole-line comments must be gone from the delivered payload"
+        );
     }
 
     #[test]

--- a/crates/nub-sandbox/src/compiler/mod.rs
+++ b/crates/nub-sandbox/src/compiler/mod.rs
@@ -19,6 +19,10 @@ mod preset;
 mod resolve;
 mod reuse;
 
+/// Exposed on EVERY platform, unlike the stamp itself, so `stdio_shim_semantics` drives the
+/// payload that actually ships rather than the source file it is derived from — comment-stripping
+/// is part of the delivery, so testing the unstripped file would leave it unmeasured.
+pub use defaults::build_jail_stdio_preload_js;
 #[cfg(windows)]
 pub use defaults::{
     windows_build_jail_node_options, windows_native_realpath_shim_node_options,

--- a/crates/nub-sandbox/src/lib.rs
+++ b/crates/nub-sandbox/src/lib.rs
@@ -140,7 +140,7 @@ pub mod windows_admin {
 }
 pub use compiler::{
     CommandRunner, CompileCtx, CompileError, CompileWarning, DOWNLOAD_HOSTS, ScopeCapabilities,
-    compile, compile_build_jail, compile_with_warnings,
+    build_jail_stdio_preload_js, compile, compile_build_jail, compile_with_warnings,
 };
 #[cfg(windows)]
 pub use compiler::{

--- a/crates/nub-sandbox/tests/stdio_shim_semantics.rs
+++ b/crates/nub-sandbox/tests/stdio_shim_semantics.rs
@@ -1,58 +1,40 @@
 //! The Windows build jail's `child_process` shim must be indistinguishable from the real thing
 //! for everything a lifecycle script does.
 //!
-//! WHY THIS RUNS EVERYWHERE. What the shim repairs is a Windows fact — the global NPFS
-//! namespace is closed to a LowBox token, so libuv's named-pipe stdio spins forever inside
-//! `uv_spawn`. How faithfully it reproduces `child_process` is NOT a Windows fact: it is
-//! ordinary JS about buffering, `close` ordering and error shaping, and it is the half most
-//! likely to regress. Behind a Windows-only probe it would go unmeasured on the machines
-//! people develop on, so the shim carries a force seam and this test drives it directly.
+//! WHY THIS RUNS EVERYWHERE. What the shim repairs is a Windows fact — the global NPFS namespace
+//! is closed to a LowBox token, so libuv's named-pipe stdio spins forever inside `uv_spawn`. How
+//! faithfully it reproduces `child_process` is NOT a Windows fact: it is ordinary JS about
+//! streaming, `close` ordering, `maxBuffer`, channel semantics and error shaping, and it is the
+//! half most likely to regress. Behind a Windows-only probe it would go unmeasured on the machines
+//! people develop on, so the shim carries a force seam and these tests drive it directly.
 //!
-//! THE ONE THAT IS EASY TO GET WRONG. A raw `spawn()` reads its bytes out of a scratch file at
-//! child EXIT, which means the shim has to hold `close` back until the streams it synthesised
-//! have drained — Node's own `_closesNeeded` bookkeeping, raised by hand. Get it wrong and the
-//! consumer's `close` handler runs before a single `data` event, so it observes empty output
-//! and exit code 0: a SILENT wrong answer, which is the failure mode this whole jail refuses to
-//! ship. `spawn` is therefore asserted on its bytes, not merely on completing.
+//! MOST OF THIS FILE IS A DIFFERENTIAL, deliberately: every case with an unshimmed equivalent is
+//! run TWICE from one driver, once preloaded and once not, and the two transcripts must match
+//! verbatim. A case that only passes in the shimmed arm proves nothing — it could be asserting the
+//! shim's own bug back to itself. Only the DELIBERATE divergences (the two typed refusals, and the
+//! sync family's scratch-file requirement) assert against a fixed expectation, and each names why
+//! no differential is possible.
 //!
-//! Each test drives ONE Node process that exercises its group and prints one `key=value` line
-//! per behaviour, so a failure names the behaviour rather than an exit status.
+//! THE TWO THAT ARE EASY TO GET WRONG, both of which the shipped file-backed version got wrong: a
+//! consumer's `close` handler must not run before the `data` it is meant to have delivered, and
+//! `execFile`'s `maxBuffer` path calls `child.stdout.destroy()` — which, if it does not settle the
+//! close accounting, loses the CALLBACK ENTIRELY, silently, exit 0. Both are asserted on observed
+//! bytes and an observed callback, never on a process merely completing.
 
 use std::path::PathBuf;
 use std::process::Command;
 
-const SHIM: &str = include_str!("../src/backend/windows_stdio_shim.js");
-
-/// Run `driver` (ESM) with the shim preloaded, and return its stdout.
-///
-/// `None` when there is no `node` to drive — the crate's other suites do not require one, and
-/// a hard failure here would make `cargo test` depend on the developer's PATH.
-fn run_under_shim(driver: &str) -> Option<String> {
-    let node = which_node()?;
-    let dir = tempfile::tempdir().expect("tempdir");
-    let shim = dir.path().join("shim.mjs");
-    let script = dir.path().join("driver.mjs");
-    std::fs::write(&shim, SHIM).expect("write shim");
-    std::fs::write(&script, driver).expect("write driver");
-
-    let out = Command::new(&node)
-        .env("__NUB_JAIL_STDIO_SHIM_FORCE", "1")
-        // The child spawns its own children; without this they would run unshimmed and the
-        // test would measure stock `child_process` while reporting on the shim.
-        .env("NODE_PATH", "")
-        .arg("--import")
-        .arg(&shim)
-        .arg(&script)
-        .output()
-        .expect("run the driver");
-    assert!(
-        out.status.success(),
-        "driver failed ({}):\n{}",
-        out.status,
-        String::from_utf8_lossy(&out.stderr)
-    );
-    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+/// The DELIVERED payload, not the source file: the jail ships the shim comment-stripped, because
+/// percent-encoding charges ~3x per punctuation byte and the raw source does not fit in a
+/// `CreateProcessW` environment block at all. Driving the source instead would leave the strip —
+/// a real transformation on the shipping path — entirely unmeasured.
+fn shim_js() -> String {
+    nub_sandbox::build_jail_stdio_preload_js()
 }
+
+/// A second `--import` term standing in for the per-package egress gate, which production stamps
+/// onto the same `NODE_OPTIONS`. Its only job is to be DETECTABLE two processes down.
+const MARKER: &str = "globalThis.__nubTestPreloadMarker = true;\n";
 
 fn which_node() -> Option<PathBuf> {
     let exe = if cfg!(windows) { "node.exe" } else { "node" };
@@ -61,20 +43,121 @@ fn which_node() -> Option<PathBuf> {
         .find(|candidate| candidate.is_file())
 }
 
+/// Everything outside the RFC 3986 unreserved set, so the payload survives `NODE_OPTIONS`'
+/// whitespace split. Mirrors `percent_encode_strict` in `compiler/defaults.rs`, which is private —
+/// the point here is to deliver the preload the way the jail does, not to re-test the encoder.
+fn data_url(js: &str) -> String {
+    let mut out = String::from("data:text/javascript,");
+    for byte in js.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            out.push(byte as char);
+        } else {
+            out.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    out
+}
+
+/// Run `driver` (ESM) and return its stdout.
+///
+/// `preload` is the `NODE_OPTIONS` chain, delivered as `data:` URLs exactly the way the build jail
+/// delivers it — which is also what makes `import.meta.url` inside the shim byte-identical to the
+/// term naming it, the identity its `NODE_OPTIONS` preservation turns on. An empty chain is the
+/// unshimmed control arm.
+///
+/// `None` when there is no `node` to drive: the crate's other suites do not require one, and a hard
+/// failure here would make `cargo test` depend on the developer's PATH.
+fn run(driver: &str, preload: &[&str], extra_env: &[(&str, &str)]) -> Option<String> {
+    let node = which_node()?;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("driver.mjs");
+    std::fs::write(&script, driver).expect("write driver");
+
+    let mut cmd = Command::new(&node);
+    if preload.is_empty() {
+        cmd.env("NODE_OPTIONS", "");
+        cmd.env_remove("__NUB_JAIL_STDIO_SHIM_FORCE");
+    } else {
+        let chain = preload
+            .iter()
+            .map(|js| format!("--import {}", data_url(js)))
+            .collect::<Vec<_>>()
+            .join(" ");
+        cmd.env("NODE_OPTIONS", chain);
+        cmd.env("__NUB_JAIL_STDIO_SHIM_FORCE", "1");
+    }
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
+    let out = cmd.arg(&script).output().expect("run the driver");
+    assert!(
+        out.status.success(),
+        "driver failed ({}) with {} preload term(s):\n{}",
+        out.status,
+        preload.len(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+fn shimmed(driver: &str) -> Option<String> {
+    run(driver, &[&shim_js()], &[])
+}
+
+/// The `> `-prefixed observations, which are the only lines a differential compares. Anything
+/// nondeterministic — a pid, a path, a raw duration — must never reach one.
+fn marks(out: &str) -> Vec<String> {
+    out.lines()
+        .filter(|line| line.starts_with("> "))
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Run one driver both ways and require the transcripts to agree. Returns the shared transcript so
+/// the caller can also assert what it actually said — agreeing on nothing is not a pass.
+fn differential(driver: &str) -> Option<Vec<String>> {
+    let plain = marks(&run(driver, &[], &[])?);
+    let with_shim = marks(&shimmed(driver)?);
+    assert_eq!(
+        plain, with_shim,
+        "the shimmed transcript must match unshimmed `child_process` verbatim"
+    );
+    assert!(!plain.is_empty(), "the driver printed no observations");
+    Some(plain)
+}
+
+fn no_node() -> bool {
+    if which_node().is_none() {
+        eprintln!("no node on PATH — skipping");
+        return true;
+    }
+    false
+}
+
+fn require(out: &[String], expected: &str) {
+    assert!(
+        out.iter().any(|line| line == expected),
+        "missing `{expected}` in:\n{out:#?}"
+    );
+}
+
 #[test]
-fn the_shim_returns_every_child_process_familys_output() {
+fn every_child_process_family_returns_its_output() {
+    if no_node() {
+        return;
+    }
     let driver = r#"
 import cp from "node:child_process";
 const node = process.execPath;
-const say = (k, v) => console.log(`${k}=${JSON.stringify(v)}`);
+const say = (k, v) => console.log(`> ${k}=${JSON.stringify(v)}`);
 const echo = (text) => [node, ["-e", `process.stdout.write(${JSON.stringify(text)})`]];
 
 const [f, a] = echo("async");
 cp.execFile(f, a, (error, stdout) => {
   say("execFile", error ? `ERR ${error.message}` : stdout);
 
-  // A raw spawn, consumed as a stream: the assertion that the deferred `close` lands AFTER
-  // the data it is meant to have delivered.
+  // A raw spawn consumed as a stream: the assertion that the deferred `close` lands AFTER the
+  // data it is meant to have delivered.
   const [sf, sa] = echo("streamed");
   const child = cp.spawn(sf, sa);
   let seen = "";
@@ -88,30 +171,248 @@ cp.execFile(f, a, (error, stdout) => {
   });
 });
 "#;
-    let Some(out) = run_under_shim(driver) else {
-        eprintln!("no node on PATH — skipping");
+    let Some(out) = differential(driver) else {
         return;
     };
-    for expected in [
-        r#"execFile="async""#,
-        r#"spawn="streamed/0""#,
-        r#"execFileSync="sync""#,
-        r#"spawnSync="sync""#,
-        r#"execSync="shelled""#,
-    ] {
-        assert!(out.contains(expected), "missing {expected} in:\n{out}");
+    require(&out, r#"> execFile="async""#);
+    require(&out, r#"> spawn="streamed/0""#);
+    require(&out, r#"> execFileSync="sync""#);
+    require(&out, r#"> spawnSync="sync""#);
+    require(&out, r#"> execSync="shelled""#);
+}
+
+#[test]
+fn spawn_delivers_output_as_it_is_produced() {
+    if no_node() {
+        return;
     }
+    // The property the file-backed rewrite CANNOT have: it reads the scratch file at child exit, so
+    // both writes land together. Bucketed rather than timed, because the assertion has to survive a
+    // contended host — the child's own 700ms sleep is the only interval measured, and contention can
+    // only widen it.
+    let driver = r#"
+import cp from "node:child_process";
+const child = cp.spawn(process.execPath, ["-e",
+  `process.stdout.write("first\\n"); setTimeout(() => { process.stdout.write("second\\n"); process.exit(0); }, 700);`]);
+const at = [];
+const t0 = Date.now();
+child.stdout.on("data", (d) => {
+  for (const _ of String(d).split("\n").filter(Boolean)) at.push(Date.now() - t0);
+});
+child.on("close", () => {
+  const gap = at.length === 2 ? at[1] - at[0] : -1;
+  console.log(`> chunks=${at.length}`);
+  console.log(`> delivery=${gap > 300 ? "as-produced" : "all-at-exit"}`);
+});
+"#;
+    let Some(out) = differential(driver) else {
+        return;
+    };
+    require(&out, "> chunks=2");
+    require(&out, "> delivery=as-produced");
+}
+
+#[test]
+fn maxbuffer_applies_and_the_callback_still_fires() {
+    if no_node() {
+        return;
+    }
+    // A file has no backpressure, so under the file-backed path the child ran to completion — and
+    // worse, `execFile`'s maxBuffer handler calls `child.stdout.destroy()`, which stranded the close
+    // accounting and lost the callback outright (measured: no output at all, exit 0). Every field
+    // asserted here is load-independent: an error code, a kill flag, and a size BUCKET.
+    let driver = r#"
+import cp from "node:child_process";
+// Bounded, so even a regression terminates instead of filling a disk.
+const src = `let n = 0; const t = setInterval(() => { process.stdout.write("z".repeat(4096)); if (++n >= 400) clearInterval(t); }, 10);`;
+const child = cp.execFile(process.execPath, ["-e", src], { maxBuffer: 8192 }, (error, stdout) => {
+  console.log(`> code=${error && error.code}`);
+  console.log(`> child-killed=${child.killed}`);
+  console.log(`> captured=${String(stdout).length <= 65536 ? "bounded" : "unbounded"}`);
+});
+"#;
+    let Some(out) = differential(driver) else {
+        return;
+    };
+    require(&out, "> code=ERR_CHILD_PROCESS_STDIO_MAXBUFFER");
+    require(&out, "> child-killed=true");
+    require(&out, "> captured=bounded");
+}
+
+#[test]
+fn the_channel_is_indistinguishable_from_forks_own() {
+    if no_node() {
+        return;
+    }
+    // `fork` used to throw here: a file cannot emulate a duplex pipe. It now rides a channel over
+    // the same container-private namespace, so every observable below has an unshimmed twin and the
+    // differential IS the assertion. Nested on purpose — the fix has to survive its own recursion,
+    // which means a second private pipe created from inside an already-confined descendant.
+    let driver = r#"
+import cp from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nub-chan-"));
+const write = (name, src) => { const p = path.join(dir, name); fs.writeFileSync(p, src); return p; };
+
+const echoer = write("echo.cjs",
+  "process.on('message', (m) => { if (m.q === 'bye') process.disconnect(); else process.send({ a: m.n, connected: process.connected }); });");
+const relay = write("relay.cjs",
+  `const cp = require('node:child_process');
+   const g = cp.fork(${JSON.stringify(path.join(dir, "echo.cjs"))}, [], { stdio: 'inherit' });
+   g.on('message', (m) => { process.send({ viaGrandchild: m.a }); g.kill(); });
+   process.on('message', (m) => g.send({ n: m.n }));`);
+const burstee = write("burst.cjs",
+  `const seen = [];
+   process.on('message', (m) => { if (m.i !== undefined) seen.push(m.i); else process.send({ ordered: seen.join(',') }); });`);
+const chatty = write("chatty.cjs",
+  "process.stdout.write('piped-too'); process.on('message', () => process.send({ both: true }));");
+
+const child = cp.fork(echoer, [], { stdio: "inherit" });
+console.log(`> connected=${child.connected} channel=${child.channel ? "present" : "absent"}`);
+console.log(`> send=${child.send({ n: 41 })}`);
+child.on("message", (m) => {
+  console.log(`> message=${JSON.stringify(m)}`);
+  child.send({ q: "bye" });
+});
+child.on("disconnect", () => console.log(`> disconnected connected=${child.connected}`));
+child.on("exit", (code) => {
+  console.log(`> exit=${code}`);
+
+  const nested = cp.fork(relay, [], { stdio: "inherit" });
+  nested.on("message", (m) => { console.log(`> nested=${JSON.stringify(m)}`); nested.kill(); });
+  nested.send({ n: 7 });
+  nested.on("exit", () => {
+    const burst = cp.fork(burstee, [], { stdio: "inherit" });
+    for (let i = 0; i < 200; i++) burst.send({ i });
+    burst.send({ done: 1 });
+    burst.on("message", (m) => {
+      const want = Array.from({ length: 200 }, (_, i) => i).join(",");
+      console.log(`> burst-ordered=${m.ordered === want}`);
+      burst.kill();
+
+      // A SILENT `fork`: three piped slots AND an 'ipc' slot resolved by one call (`fork` itself
+      // defaults to inheriting 0/1/2). This is where the two halves of the override interact, so it
+      // is the arm a stacked-override ordering bug breaks — the refusal would fire before the
+      // streaming ever ran.
+      const both = cp.fork(chatty, [], { silent: true });
+      let piped = "";
+      both.stdout.on("data", (d) => (piped += d));
+      both.send({ go: 1 });
+      both.on("message", (m) => {
+        console.log(`> piped-and-ipc=${JSON.stringify(m)}/${JSON.stringify(piped)}`);
+        both.kill();
+        fs.rmSync(dir, { recursive: true, force: true });
+      });
+    });
+  });
+});
+"#;
+    let Some(out) = differential(driver) else {
+        return;
+    };
+    require(&out, "> connected=true channel=present");
+    require(&out, "> send=true");
+    require(&out, r#"> message={"a":41,"connected":true}"#);
+    require(&out, "> disconnected connected=false");
+    require(&out, r#"> nested={"viaGrandchild":7}"#);
+    require(&out, "> burst-ordered=true");
+    require(&out, r#"> piped-and-ipc={"both":true}/"piped-too""#);
+}
+
+#[test]
+fn a_descendant_keeps_the_whole_preload_chain() {
+    if no_node() {
+        return;
+    }
+    // THE SECURITY-SHAPED ONE. Production puts this shim and the per-package egress gate on ONE
+    // `NODE_OPTIONS`, which is also how both reach every descendant. A `fork` that rebuilt `env`
+    // strips it, so the shim re-synthesises it — and it must re-synthesise the PARENT'S OWN value
+    // rather than re-derive from `import.meta.url`, or the gate silently vanishes from every
+    // grandchild while the channel keeps working. MARKER stands in for the gate: a grandchild that
+    // reports a channel but NO marker is exactly the regression this pins.
+    let driver = r#"
+import cp from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nub-chain-"));
+const leaf = path.join(dir, "leaf.cjs");
+fs.writeFileSync(leaf, "process.send({ marker: !!globalThis.__nubTestPreloadMarker, send: typeof process.send });");
+const mid = path.join(dir, "mid.cjs");
+fs.writeFileSync(mid,
+  `const cp = require('node:child_process');
+   const g = cp.fork(${JSON.stringify(leaf)}, [], { stdio: 'inherit', env: { PATH: process.env.PATH }, execArgv: [] });
+   g.on('message', (m) => { process.send({ depth: 2, ...m }); g.kill(); });`);
+
+// Both hostile shapes at once, at every level: a rebuilt env AND an emptied execArgv.
+const child = cp.fork(mid, [], { stdio: "inherit", env: { PATH: process.env.PATH }, execArgv: [] });
+child.on("message", (m) => {
+  console.log(`> grandchild=${JSON.stringify(m)}`);
+  child.kill();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+"#;
+    let Some(out) = run(driver, &[&shim_js(), MARKER], &[]) else {
+        return;
+    };
+    require(
+        &marks(&out),
+        r#"> grandchild={"depth":2,"marker":true,"send":"function"}"#,
+    );
+}
+
+#[test]
+fn only_the_sync_family_needs_a_writable_directory() {
+    if no_node() {
+        return;
+    }
+    // The async path's scratch-file precondition is GONE — it needs no filesystem grant at all,
+    // which matters in a jail whose purpose is confining writes. `spawnSync` cannot follow:
+    // `ParseStdioOption` has no `'wrap'` case and a blocked loop cannot drain a pipe, so it still
+    // needs a file, and now refuses in a typed, actionable way instead of returning to the spin.
+    // Driven through the seam rather than with real permissions because off Windows the address IS
+    // a filesystem path, so a read-only temp dir would break the streamed path for an unrelated
+    // reason and the test would measure nothing.
+    let driver = r#"
+import cp from "node:child_process";
+const node = process.execPath;
+const child = cp.spawn(node, ["-e", "process.stdout.write('streamed-without-a-directory')"]);
+let seen = "";
+child.stdout.on("data", (c) => (seen += c));
+child.on("close", (code) => {
+  console.log(`> async=${JSON.stringify(seen)}/${code}`);
+  try {
+    cp.spawnSync(node, ["-e", "0"], { encoding: "utf8" });
+    console.log("> sync=did-not-refuse");
+  } catch (error) {
+    console.log(`> sync=${error.code}/${error.message.includes("dependenciesMeta")}`);
+  }
+});
+"#;
+    let Some(out) = run(driver, &[&shim_js()], &[("__NUB_JAIL_NO_SCRATCH", "1")]) else {
+        return;
+    };
+    let seen = marks(&out);
+    require(&seen, r#"> async="streamed-without-a-directory"/0"#);
+    require(&seen, "> sync=ERR_NUB_SANDBOX_NO_IPC/true");
 }
 
 #[test]
 fn the_shim_reports_failure_the_way_child_process_does() {
+    if no_node() {
+        return;
+    }
     let driver = r#"
 import cp from "node:child_process";
 const node = process.execPath;
-const say = (k, v) => console.log(`${k}=${JSON.stringify(v)}`);
+const say = (k, v) => console.log(`> ${k}=${JSON.stringify(v)}`);
 
-// A non-zero exit must still throw, carrying the status AND the stderr the caller needs to
-// see why — reading it back out of a scratch file is exactly where that could be lost.
+// A non-zero exit must still throw, carrying the status AND the stderr the caller needs to see
+// why — reading it back out of a scratch file is exactly where that could be lost.
 try {
   cp.execFileSync(node, ["-e", "process.stderr.write('boom'); process.exit(3)"], { stdio: ["pipe", "pipe", "pipe"] });
   say("nonzero", "did not throw");
@@ -119,31 +420,67 @@ try {
   say("nonzero", `${error.status}/${String(error.stderr)}`);
 }
 
-// No file can emulate a duplex IPC channel, so this must refuse IMMEDIATELY rather than
-// become the unkillable spin the shim exists to remove.
-try {
-  cp.fork("unreachable.js");
-  say("fork", "did not throw");
-} catch (error) {
-  say("fork", `${error.code}/${error.message.includes("dependenciesMeta")}`);
-}
-
-// A spawn that fails outright emits `error` INSTEAD of `exit`; a caller waiting on `close`
-// must still be woken.
+// A spawn that fails outright emits `error` INSTEAD of `exit`; a caller waiting on `close` must
+// still be woken.
 const bad = cp.spawn("nub-no-such-binary-9c1f", []);
 let sawError = false;
 bad.on("error", () => (sawError = true));
 bad.on("close", () => say("failed-spawn", `${sawError}/closed`));
 setTimeout(() => { say("failed-spawn", "never closed"); process.exit(1); }, 5000).unref();
 "#;
-    let Some(out) = run_under_shim(driver) else {
-        eprintln!("no node on PATH — skipping");
+    let Some(out) = differential(driver) else {
         return;
     };
-    assert!(out.contains(r#"nonzero="3/boom""#), "in:\n{out}");
-    assert!(
-        out.contains(r#"fork="ERR_NUB_SANDBOX_NO_IPC/true""#),
-        "the refusal must name the per-package opt-out, in:\n{out}"
-    );
-    assert!(out.contains(r#"failed-spawn="true/closed""#), "in:\n{out}");
+    require(&out, r#"> nonzero="3/boom""#);
+    require(&out, r#"> failed-spawn="true/closed""#);
+}
+
+#[test]
+fn the_two_deliberate_refusals_stay_fast_and_typed() {
+    if no_node() {
+        return;
+    }
+    // No differential is possible: unshimmed `child_process` SUPPORTS both of these, so agreeing
+    // with it is precisely what the shim cannot do. Handle passing needs `uv_write2`/`SCM_RIGHTS`,
+    // which no userland stream carries, and `serialization: 'advanced'` rides libuv's own IPC
+    // frames. The contract is that each fails immediately and namefully — the exercise is pointless
+    // if it trades a hang for a hang.
+    let driver = r#"
+import cp from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nub-refuse-"));
+const idle = path.join(dir, "idle.cjs");
+fs.writeFileSync(idle, "setTimeout(() => {}, 200);");
+
+try {
+  cp.fork(idle, [], { stdio: "inherit", serialization: "advanced" });
+  console.log("> advanced=accepted");
+} catch (error) {
+  console.log(`> advanced=${error.code}/${error.message.includes("dependenciesMeta")}`);
+}
+
+const child = cp.fork(idle, [], { stdio: "inherit" });
+const server = net.createServer();
+server.listen(0, () => {
+  try {
+    child.send({ s: 1 }, server);
+    console.log("> handle=accepted");
+  } catch (error) {
+    console.log(`> handle=${error.code}/${error.message.includes("dependenciesMeta")}`);
+  }
+  server.close();
+  child.kill();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+"#;
+    let Some(out) = shimmed(driver) else {
+        return;
+    };
+    let seen = marks(&out);
+    require(&seen, "> advanced=ERR_NUB_SANDBOX_NO_IPC/true");
+    require(&seen, "> handle=ERR_NUB_SANDBOX_NO_IPC/true");
 }

--- a/crates/nub-sandbox/tests/windows_jail_repairs.rs
+++ b/crates/nub-sandbox/tests/windows_jail_repairs.rs
@@ -26,15 +26,16 @@
 //! NPFS namespace, which is closed to a LowBox token, and `uv__pipe_server` treats the refusal
 //! as a name collision and retries forever inside `uv_spawn` — so a confined piped spawn does
 //! not fail, it SPINS (measured: cpu_ms 14906 of 15059 wall). `windows_build_jail_node_options()`
-//! returns a `NODE_OPTIONS` carrying an `--import data:` preload that rewrites every `'pipe'`
-//! slot into a scratch FILE and hands the bytes back through stream objects. The five shapes a
-//! real lifecycle script uses are measured through it, plus `fork()`, which has no file
-//! analogue and must fail FAST rather than become an unkillable spin.
+//! returns a `NODE_OPTIONS` carrying an `--import data:` preload that creates the pipe ITSELF in
+//! the AppContainer-private namespace (`\\.\pipe\LOCAL\…`, which the same jail permits) and hands
+//! the child an already-connected end as a raw fd. The five shapes a real lifecycle script uses
+//! are measured through it, plus `fork()`, whose channel rides the same private namespace.
 //!
-//! `shim-spawn-stream-returns` is the one that can find a NEW bug rather than confirm an old
-//! fix: a raw `spawn()` gets its bytes at child exit, which means the shim has to hold `close`
-//! back until the synthesised streams have drained (`_closesNeeded`). If `close` fires first the
-//! marker comes back empty, and that is a real defect, reported as measured.
+//! `shim-spawn-stream-returns` is the one that can find a NEW bug rather than confirm an old fix:
+//! the shim has to hold `close` back until the streams it published have drained
+//! (`_closesNeeded`), and it drives that bookkeeping by hand because Node's own `maybeClose` does
+//! not count a slot the caller supplied. If `close` fires first the marker comes back empty, and
+//! that is a real defect, reported as measured.
 //!
 //! EVERY VERDICT IS A MARKER THE CHILD WROTE. Nothing is read off a status the harness reports
 //! about itself, and every path a child touches is baked into the JS as an absolute LITERAL —
@@ -1336,14 +1337,19 @@ child.on("close", (code) => fs.writeFileSync(M, "CLOSED code=" + code + " out=" 
             );
         }
 
-        fork_fails_fast(fails, &f, &shimmed, node, &dir);
+        fork_round_trips(fails, &f, &shimmed, node, &dir);
         unshimmed_control(fails, &f, &unshimmed, node, &dir);
     }
 
-    /// An IPC channel is a duplex pipe and a file cannot emulate one, so `fork()` must throw
-    /// SYNCHRONOUSLY with a diagnostic naming the opt-out. A hang here is a FAIL: the whole
-    /// point of failing fast is that it is strictly better than the unkillable spin.
-    fn fork_fails_fast(
+    /// `fork()` USED to throw here, because a scratch file cannot emulate a duplex pipe. It now
+    /// rides a channel over `\\.\pipe\LOCAL\…`, the AppContainer-private namespace, so the arm
+    /// asserts a real round trip — and NESTED, because the repair has to survive its own recursion:
+    /// the grandchild is forked BY a forked child, so a second private pipe must be creatable from
+    /// inside an already-confined descendant and the preload must reach two levels down.
+    ///
+    /// A hang is still a FAIL. That was the original point of failing fast, and it does not stop
+    /// being the bar just because the operation now succeeds.
+    fn fork_round_trips(
         fails: &mut u32,
         f: &Fixture,
         policy: &SandboxPolicy,
@@ -1351,35 +1357,70 @@ child.on("close", (code) => fs.writeFileSync(M, "CLOSED code=" + code + " out=" 
         dir: &Path,
     ) {
         let marker = dir.join("fork.marker");
-        let target = dir.join("fork-target.js");
-        std::fs::write(&target, "process.exit(0);\n").unwrap();
+        let leaf = dir.join("fork-leaf.js");
+        std::fs::write(
+            &leaf,
+            "process.on('message', (m) => process.send({ pong: m.ping, connected: process.connected }));\n",
+        )
+        .unwrap();
+        let relay = dir.join("fork-relay.js");
+        std::fs::write(
+            &relay,
+            format!(
+                "const cp = require('child_process');\n\
+                 const g = cp.fork({leaf});\n\
+                 g.on('message', (m) => {{ process.send({{ relayed: m.pong }}); g.kill(); }});\n\
+                 process.on('message', (m) => g.send({{ ping: m.ping }}));\n",
+                leaf = js_literal(&leaf),
+            ),
+        )
+        .unwrap();
         let _ = std::fs::remove_file(&marker);
         let body = format!(
             r#"const fs = require("fs"), cp = require("child_process");
 const M = {marker};
 fs.writeFileSync(M, "start");
+const done = (s) => {{ fs.writeFileSync(M, s); process.exit(0); }};
+const guard = setTimeout(() => done("HUNG no reply within 20s"), 20000);
 try {{
-  cp.fork({target});
-  fs.writeFileSync(M, "NO-THROW");
+  const direct = cp.fork({leaf});
+  direct.on("message", (m) => {{
+    direct.kill();
+    const nested = cp.fork({relay});
+    nested.on("message", (n) => {{
+      clearTimeout(guard);
+      nested.kill();
+      done("OK direct=" + JSON.stringify(m) + " nested=" + JSON.stringify(n));
+    }});
+    nested.send({{ ping: "p2" }});
+  }});
+  direct.send({{ ping: "p1" }});
 }} catch (e) {{
-  fs.writeFileSync(M, "THREW code=" + (e.code || "") + " msg=" + String(e.message));
+  clearTimeout(guard);
+  done("THREW code=" + (e.code || "") + " msg=" + String(e.message));
 }}
 "#,
             marker = js_literal(&marker),
-            target = js_literal(&target),
+            leaf = js_literal(&leaf),
+            relay = js_literal(&relay),
         );
         println!("  ---- shim shape fork ----");
-        let run = node_arm(f, policy, "fork", node, dir, 30, &body);
+        let run = node_arm(f, policy, "fork", node, dir, 40, &body);
         let inner = std::fs::read_to_string(&marker).unwrap_or_else(|_| "<no marker>".into());
         println!("  fact:fork-inner={inner}");
-        let _ = run.code;
         report(
             fails,
-            "shim-fork-fails-fast",
-            inner.contains("ERR_NUB_SANDBOX_NO_IPC")
-                && inner.contains("dependenciesMeta")
+            "shim-fork-roundtrip",
+            inner.contains(r#""pong":"p1""#)
+                && inner.contains(r#""connected":true"#)
                 && run.outer.starts_with("EXITED"),
             &format!("inner={inner} outer={}", run.outer),
+        );
+        report(
+            fails,
+            "shim-fork-nested",
+            inner.contains(r#""relayed":"p2""#),
+            &format!("inner={inner}"),
         );
     }
 

--- a/vendor/aube/crates/aube-linker/src/materialize.rs
+++ b/vendor/aube/crates/aube-linker/src/materialize.rs
@@ -845,7 +845,10 @@ impl Linker {
             // symlink still serves. Four of the five call sites are warm
             // short-circuits that previously could not fail at all.
             if let Err(e) = self.materialize_nested_dep(pkg_nm_dir, dep_name, dep_pkg, stats) {
-                warn!("could not nest optional dep {dep_name} inside {}: {e}", pkg.name);
+                warn!(
+                    "could not nest optional dep {dep_name} inside {}: {e}",
+                    pkg.name
+                );
             }
         }
         Ok(())

--- a/vendor/aube/crates/aube-linker/src/patches.rs
+++ b/vendor/aube/crates/aube-linker/src/patches.rs
@@ -467,9 +467,7 @@ fn evaluate_hunk(
     }
     let mut context_index = base as usize;
     // `fileLines.length - contextIndex < original.length` → null.
-    if file_lines.len() < context_index
-        || file_lines.len() - context_index < hunk.original_length
-    {
+    if file_lines.len() < context_index || file_lines.len() - context_index < hunk.original_length {
         return None;
     }
 
@@ -532,7 +530,9 @@ fn apply_hunks(base_image: &str, hunks: &[Hunk]) -> Result<String, String> {
                 -fuzzing_offset - 1
             };
             if fuzzing_offset.abs() > 20 {
-                return Err(format!("could not apply hunk {i} (offset drift > 20 lines)"));
+                return Err(format!(
+                    "could not apply hunk {i} (offset drift > 20 lines)"
+                ));
             }
         };
         all_mods.push(mods);
@@ -551,7 +551,9 @@ fn apply_hunks(base_image: &str, hunks: &[Hunk]) -> Result<String, String> {
                 } => {
                     let at = (*index as isize + diff_offset) as usize;
                     let end = (at + num_to_delete).min(file_lines.len());
-                    let removed: Vec<String> = file_lines.splice(at..end, lines_to_insert.iter().cloned()).collect();
+                    let removed: Vec<String> = file_lines
+                        .splice(at..end, lines_to_insert.iter().cloned())
+                        .collect();
                     diff_offset += lines_to_insert.len() as isize - removed.len() as isize;
                 }
                 Modification::Pop => {
@@ -1191,7 +1193,8 @@ mod tests {
         // no-trailing-newline EOF. With the newline-agnostic line array
         // this round-trips for free — the marker is informational here.
         let original = "a\nb\nlast";
-        let body = "--- a/x\n+++ b/x\n@@ -1,3 +1,3 @@\n a\n-b\n+B\n last\n\\ No newline at end of file\n";
+        let body =
+            "--- a/x\n+++ b/x\n@@ -1,3 +1,3 @@\n a\n-b\n+B\n last\n\\ No newline at end of file\n";
         assert_eq!(apply_body(original, body).unwrap(), "a\nB\nlast");
     }
 
@@ -1237,7 +1240,10 @@ mod tests {
         // comparing; the old diffy byte-exact match rejected. We match.
         let original = "alpha   \nbeta\ngamma\n"; // "alpha" has trailing spaces
         let body = "--- a/x\n+++ b/x\n@@ -1,3 +1,3 @@\n alpha\n-beta\n+BETA\n gamma\n";
-        assert_eq!(apply_body(original, body).unwrap(), "alpha   \nBETA\ngamma\n");
+        assert_eq!(
+            apply_body(original, body).unwrap(),
+            "alpha   \nBETA\ngamma\n"
+        );
     }
 
     #[test]
@@ -1300,8 +1306,12 @@ mod tests {
     #[test]
     fn happy_path_simple_edit_byte_identical() {
         let original = "module.exports = 'old';\n";
-        let body = "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-module.exports = 'old';\n+module.exports = 'new';\n";
-        assert_eq!(apply_body(original, body).unwrap(), "module.exports = 'new';\n");
+        let body =
+            "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-module.exports = 'old';\n+module.exports = 'new';\n";
+        assert_eq!(
+            apply_body(original, body).unwrap(),
+            "module.exports = 'new';\n"
+        );
     }
 
     #[test]
@@ -1310,7 +1320,10 @@ mod tests {
         let body = "--- a/x\n+++ b/x\n\
                     @@ -1,3 +1,3 @@\n 1\n-2\n+TWO\n 3\n\
                     @@ -6,3 +6,3 @@\n 6\n-7\n+SEVEN\n 8\n";
-        assert_eq!(apply_body(original, body).unwrap(), "1\nTWO\n3\n4\n5\n6\nSEVEN\n8\n");
+        assert_eq!(
+            apply_body(original, body).unwrap(),
+            "1\nTWO\n3\n4\n5\n6\nSEVEN\n8\n"
+        );
     }
 
     #[test]

--- a/vendor/aube/crates/aube-lockfile/src/npm/mod.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/mod.rs
@@ -24,8 +24,8 @@ pub(crate) use layout::{
     build_hoist_tree, canonical_key_from_dep_path, child_canonical_key, dep_path_tail,
     dep_value_as_version, segments_to_install_path,
 };
-pub(crate) use source::local_git_source_from_resolved;
 pub use read::parse;
+pub(crate) use source::local_git_source_from_resolved;
 pub use write::write;
 
 #[cfg(test)]

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -2544,15 +2544,27 @@ fn test_write_emits_workspace_members_on_fresh_resolve() {
     // Member importer entries carry name/version + their own deps.
     assert_eq!(packages["packages/pkg-a"]["name"], "@dedup/pkg-a");
     assert_eq!(packages["packages/pkg-a"]["version"], "1.0.0");
-    assert_eq!(packages["packages/pkg-a"]["dependencies"]["lodash"], "^3.10.1");
+    assert_eq!(
+        packages["packages/pkg-a"]["dependencies"]["lodash"],
+        "^3.10.1"
+    );
     assert_eq!(packages["packages/pkg-b"]["name"], "@dedup/pkg-b");
-    assert_eq!(packages["packages/pkg-b"]["dependencies"]["lodash"], "^4.17.0");
+    assert_eq!(
+        packages["packages/pkg-b"]["dependencies"]["lodash"],
+        "^4.17.0"
+    );
 
     // Root node_modules symlink record for each member.
     assert_eq!(packages["node_modules/@dedup/pkg-a"]["link"], true);
-    assert_eq!(packages["node_modules/@dedup/pkg-a"]["resolved"], "packages/pkg-a");
+    assert_eq!(
+        packages["node_modules/@dedup/pkg-a"]["resolved"],
+        "packages/pkg-a"
+    );
     assert_eq!(packages["node_modules/@dedup/pkg-b"]["link"], true);
-    assert_eq!(packages["node_modules/@dedup/pkg-b"]["resolved"], "packages/pkg-b");
+    assert_eq!(
+        packages["node_modules/@dedup/pkg-b"]["resolved"],
+        "packages/pkg-b"
+    );
 
     // Both deduped child versions land as nested package entries under
     // their owning member — npm ci rejects the lockfile if either is
@@ -2659,7 +2671,10 @@ fn test_roundtrip_preserves_npm_verbatim_meta_fields() {
     // `hasShrinkwrap` bools sort after `integrity` and before
     // `dependencies` (the only object key). Assert relative placement so
     // a future reorder can't silently produce churn vs npm.
-    let pos = |needle: &str| body.find(needle).unwrap_or_else(|| panic!("missing {needle}\n{body}"));
+    let pos = |needle: &str| {
+        body.find(needle)
+            .unwrap_or_else(|| panic!("missing {needle}\n{body}"))
+    };
     assert!(pos("\"bundleDependencies\"") < pos("\"deprecated\""));
     assert!(pos("\"deprecated\"") < pos("\"hasInstallScript\""));
     assert!(pos("\"hasInstallScript\"") < pos("\"hasShrinkwrap\""));
@@ -2671,7 +2686,10 @@ fn test_roundtrip_preserves_npm_verbatim_meta_fields() {
     let addon2 = &reparsed.packages["native-addon@1.0.0"];
     assert!(addon2.has_install_script);
     assert!(addon2.has_shrinkwrap);
-    assert_eq!(addon2.deprecated.as_deref(), Some("use native-addon@2 instead"));
+    assert_eq!(
+        addon2.deprecated.as_deref(),
+        Some("use native-addon@2 instead")
+    );
     assert_eq!(addon2.bundled_dependencies, vec!["inner".to_string()]);
     assert!(reparsed.packages["inner@2.0.0"].in_bundle);
 }
@@ -2762,7 +2780,9 @@ fn legacy_v1_package_lock_lifts_to_graph() {
     assert_eq!(is_odd.version, "3.0.1");
     assert_eq!(
         is_odd.integrity.as_deref(),
-        Some("sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==")
+        Some(
+            "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA=="
+        )
     );
     assert_eq!(
         is_odd.tarball_url.as_deref(),
@@ -2778,7 +2798,9 @@ fn legacy_v1_package_lock_lifts_to_graph() {
     let is_number = &graph.packages["is-number@6.0.0"];
     assert_eq!(
         is_number.integrity.as_deref(),
-        Some("sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==")
+        Some(
+            "sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg=="
+        )
     );
 
     // Direct deps come from the manifest, NOT the lockfile (v1 has no
@@ -3002,7 +3024,10 @@ fn legacy_v1_nested_dedupe_hoisting() {
         Some("2.0.0")
     );
 
-    let mut root: Vec<&str> = graph.importers["."].iter().map(|d| d.name.as_str()).collect();
+    let mut root: Vec<&str> = graph.importers["."]
+        .iter()
+        .map(|d| d.name.as_str())
+        .collect();
     root.sort_unstable();
     assert_eq!(root, vec!["a", "b"]);
 }

--- a/vendor/aube/crates/aube-lockfile/src/npm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/write.rs
@@ -340,10 +340,9 @@ pub fn write(
         .filter(|p| p.as_str() != ".")
         .filter(|p| workspace_package_for_importer(graph, p).is_none())
         .map(|p| {
-            let m = aube_manifest::PackageJson::from_path(
-                &project_dir.join(p).join("package.json"),
-            )
-            .unwrap_or_default();
+            let m =
+                aube_manifest::PackageJson::from_path(&project_dir.join(p).join("package.json"))
+                    .unwrap_or_default();
             (p.as_str(), m)
         })
         .collect();

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
@@ -1949,8 +1949,7 @@ fn patched_dependency_roundtrips_through_real_pnpm() {
     // Captured from `corepack pnpm@10.15.1 install` on the patched-deps
     // fixture — the exact bytes real pnpm wrote.
     const HASH: &str = "dcac38e61b21e4c1fbc036fbd04c2c57fc5aca4d595709258e1654cf8529c5c1";
-    const EXPECTED_BLOCK: &str =
-        "patchedDependencies:\n  is-odd@3.0.1:\n    hash: dcac38e61b21e4c1fbc036fbd04c2c57fc5aca4d595709258e1654cf8529c5c1\n    path: patches/is-odd@3.0.1.patch";
+    const EXPECTED_BLOCK: &str = "patchedDependencies:\n  is-odd@3.0.1:\n    hash: dcac38e61b21e4c1fbc036fbd04c2c57fc5aca4d595709258e1654cf8529c5c1\n    path: patches/is-odd@3.0.1.patch";
 
     let dir = tempfile::tempdir().unwrap();
     let lockfile_path = dir.path().join("pnpm-lock.yaml");
@@ -3235,10 +3234,7 @@ snapshots:
     // is read for its hash only, and the path map stays empty.
     assert!(graph.patched_dependencies.is_empty());
     assert_eq!(
-        graph
-            .patched_dependency_hashes
-            .get("is-odd@3.0.1")
-            .unwrap(),
+        graph.patched_dependency_hashes.get("is-odd@3.0.1").unwrap(),
         "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
     );
     assert_eq!(
@@ -5024,7 +5020,9 @@ fn npm_to_pnpm_conversion_omits_phantom_member_links_on_empty_root() {
     let manifest = PackageJson {
         name: Some("wsroot".to_string()),
         version: Some("1.0.0".to_string()),
-        workspaces: Some(aube_manifest::Workspaces::Array(vec!["packages/*".to_string()])),
+        workspaces: Some(aube_manifest::Workspaces::Array(vec![
+            "packages/*".to_string(),
+        ])),
         ..PackageJson::default()
     };
 

--- a/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/unsupported_source.rs
@@ -142,10 +142,7 @@ fn classic_git_protocol_dep_resolves() {
         .find(|p| p.name == "foo")
         .expect("foo must be in the graph");
     assert!(
-        matches!(
-            &pkg.local_source,
-            Some(aube_lockfile::LocalSource::Git(_))
-        ),
+        matches!(&pkg.local_source, Some(aube_lockfile::LocalSource::Git(_))),
         "expected git LocalSource, got {:?}",
         pkg.local_source
     );

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -1820,8 +1820,10 @@ async fn primer_dist_tag_pick_refetches_when_registry_repointed_latest() {
     // served (the bug).
     let mut full = make_packument(&name, &[&primer_latest, &live_latest], &live_latest);
     full.modified = Some("2024-01-01T00:00:00.000Z".to_string());
-    full.time
-        .insert(primer_latest.clone(), "2024-01-01T00:00:00.000Z".to_string());
+    full.time.insert(
+        primer_latest.clone(),
+        "2024-01-01T00:00:00.000Z".to_string(),
+    );
     full.time
         .insert(live_latest.clone(), "2024-01-02T00:00:00.000Z".to_string());
     let full_body = serde_json::to_vec(&full).unwrap();
@@ -1868,7 +1870,9 @@ async fn primer_dist_tag_pick_refetches_when_registry_repointed_latest() {
         .with_packument_cache(base.join("packuments"))
         .with_force_metadata_primer(true);
     let mut manifest = PackageJson::default();
-    manifest.dependencies.insert(name.clone(), "latest".to_string());
+    manifest
+        .dependencies
+        .insert(name.clone(), "latest".to_string());
 
     let graph = resolver
         .resolve(&manifest, None)
@@ -5292,12 +5296,30 @@ fn colonless_dist_tag_still_resolves_after_scheme_guard() {
     packument
         .dist_tags
         .insert("nightly".to_string(), "1.0.0".to_string());
-    let result =
-        pick_version(&packument, "nightly", None, false, None, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "nightly",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.0.0");
 
-    let result =
-        pick_version(&packument, "latest", None, false, None, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "latest",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "2.0.0");
 }
 

--- a/vendor/aube/crates/aube-store/src/lib.rs
+++ b/vendor/aube/crates/aube-store/src/lib.rs
@@ -286,7 +286,8 @@ impl Store {
     ///
     /// [`virtual_store_subdir`]: aube_util::Embedder::virtual_store_subdir
     pub fn virtual_store_dir(&self) -> PathBuf {
-        self.cache_dir.join(aube_util::embedder().virtual_store_subdir)
+        self.cache_dir
+            .join(aube_util::embedder().virtual_store_subdir)
     }
 
     /// Root of the per-package *extracted-tree* tier, a sibling of the

--- a/vendor/aube/crates/aube/src/commands/add/manifest.rs
+++ b/vendor/aube/crates/aube/src/commands/add/manifest.rs
@@ -652,7 +652,9 @@ pub(super) async fn update_manifest_for_add(
     let catalog_target = if catalog_upserts.is_empty() {
         None
     } else {
-        Some(crate::commands::catalogs::resolve_catalog_write_target(cwd)?)
+        Some(crate::commands::catalogs::resolve_catalog_write_target(
+            cwd,
+        )?)
     };
 
     // Write the updated package.json. Under `--no-save` callers still

--- a/vendor/aube/crates/aube/src/commands/catalogs.rs
+++ b/vendor/aube/crates/aube/src/commands/catalogs.rs
@@ -331,7 +331,10 @@ pub(crate) fn resolve_catalog_write_target(cwd: &Path) -> miette::Result<Catalog
     // key. Reject up front so the pre-flight fails before any manifest
     // mutation rather than half-way through.
     let manifest = crate::commands::load_manifest(&manifest_path)?;
-    if matches!(manifest.workspaces, Some(aube_manifest::Workspaces::String(_))) {
+    if matches!(
+        manifest.workspaces,
+        Some(aube_manifest::Workspaces::String(_))
+    ) {
         return Err(miette::miette!(
             "cannot save to a catalog: package.json#workspaces is a bare string; \
              convert it to an array or object form to hold a `workspaces.catalog`"
@@ -740,7 +743,10 @@ catalog:
     #[test]
     fn manifest_upsert_adds_default_catalog_preserving_packages() {
         let dir = tempfile::tempdir().unwrap();
-        let path = write_pkg(dir.path(), r#"{"name":"root","workspaces":{"packages":["apps/*"]}}"#);
+        let path = write_pkg(
+            dir.path(),
+            r#"{"name":"root","workspaces":{"packages":["apps/*"]}}"#,
+        );
         upsert_catalog_entries_in_manifest(&path, &[upsert("default", "@types/node", "^26.1.0")])
             .unwrap();
         let v: serde_json::Value =
@@ -785,6 +791,9 @@ catalog:
             .unwrap();
         let v: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(v["workspaces"]["catalogs"]["types"]["@types/node"], "^26.1.0");
+        assert_eq!(
+            v["workspaces"]["catalogs"]["types"]["@types/node"],
+            "^26.1.0"
+        );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/config/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/config/mod.rs
@@ -119,8 +119,8 @@ pub(crate) use aube_config::{
     load_user_entries as load_user_aube_config_entries,
 };
 pub(crate) use get_cmd::GetArgs;
-pub use set_cmd::set_project_scalar_to_workspace_yaml;
 pub(crate) use set_cmd::SetArgs;
+pub use set_cmd::set_project_scalar_to_workspace_yaml;
 
 impl Location {
     pub(super) fn path(self) -> miette::Result<PathBuf> {

--- a/vendor/aube/crates/aube/src/commands/dedupe.rs
+++ b/vendor/aube/crates/aube/src/commands/dedupe.rs
@@ -143,9 +143,7 @@ fn diff_graphs(
     existing: Option<&aube_lockfile::LockfileGraph>,
     new: &aube_lockfile::LockfileGraph,
 ) -> (Vec<String>, Vec<String>) {
-    fn serialized_keys(
-        pkgs: &BTreeMap<String, aube_lockfile::LockedPackage>,
-    ) -> BTreeSet<&String> {
+    fn serialized_keys(pkgs: &BTreeMap<String, aube_lockfile::LockedPackage>) -> BTreeSet<&String> {
         use aube_lockfile::LocalSource;
         pkgs.iter()
             .filter(|(_, pkg)| {

--- a/vendor/aube/crates/aube/src/commands/exec.rs
+++ b/vendor/aube/crates/aube/src/commands/exec.rs
@@ -377,15 +377,7 @@ pub(crate) async fn exec_bin_terminal(
     args: &[String],
     shell_mode: bool,
 ) -> miette::Result<Option<i32>> {
-    exec_bin_terminal_with_env(
-        cwd,
-        bin_path,
-        bin,
-        args,
-        shell_mode,
-        &Default::default(),
-    )
-    .await
+    exec_bin_terminal_with_env(cwd, bin_path, bin, args, shell_mode, &Default::default()).await
 }
 
 pub(crate) async fn exec_bin_terminal_with_env(

--- a/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
+++ b/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
@@ -369,8 +369,7 @@ pub(crate) fn link_all_bins(input: LinkAllBinsInput<'_>) -> miette::Result<()> {
             // Workspace member's own `bin` (discussion #228). `manifests`
             // was parsed once upstream and keys by importer relpath. See
             // the root self-bin call site for why this forces a POSIX shim.
-            if let Some((_, member_manifest)) =
-                manifests.iter().find(|(p, _)| p == importer_path)
+            if let Some((_, member_manifest)) = manifests.iter().find(|(p, _)| p == importer_path)
                 && let Some(bin) = member_manifest.extra.get("bin")
             {
                 let self_shim_opts = aube_linker::BinShimOptions {

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -1381,8 +1381,14 @@ mod tests {
     fn embedder_owned_lifecycle_sandbox_suppresses_aubes_jail() {
         // Standalone aube (flag false): `jailBuilds`/`paranoid` engage aube's own jail
         // exactly as before — byte-for-byte default behavior.
-        assert!(jail_enabled(false, true, false), "jailBuilds engages the jail");
-        assert!(jail_enabled(false, false, true), "paranoid engages the jail");
+        assert!(
+            jail_enabled(false, true, false),
+            "jailBuilds engages the jail"
+        );
+        assert!(
+            jail_enabled(false, false, true),
+            "paranoid engages the jail"
+        );
         assert!(!jail_enabled(false, false, false), "neither set → no jail");
         // Embedder-owned confinement (flag true, nub): aube's jail NEVER engages, even
         // when a user (or a compat project's .npmrc) sets jailBuilds/paranoid — the

--- a/vendor/aube/crates/aube/src/commands/install/resolve.rs
+++ b/vendor/aube/crates/aube/src/commands/install/resolve.rs
@@ -190,8 +190,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         } else {
             None
         };
-    let fresh = !(force_resolve
-        || revalidate_release_policy && matches!(mode, FrozenMode::Prefer))
+    let fresh = !(force_resolve || revalidate_release_policy && matches!(mode, FrozenMode::Prefer))
         && matches!(
             parsed,
             Ok((g, k))
@@ -458,7 +457,10 @@ pub(super) struct SelectLockfileInput<'a> {
 /// packageExtensions drift, gated on the embedder posture. Returns `Fresh`
 /// when the embedder doesn't enforce the checksum (standalone aube), so the
 /// check is a nub-only layer that never fires on aube's default path.
-fn package_extensions_drift(graph: &LockfileGraph, effective_checksum: Option<&str>) -> DriftStatus {
+fn package_extensions_drift(
+    graph: &LockfileGraph,
+    effective_checksum: Option<&str>,
+) -> DriftStatus {
     if aube_util::engine_context().enforce_package_extensions_checksum {
         graph.check_package_extensions_drift(effective_checksum)
     } else {

--- a/vendor/aube/crates/aube/src/patches.rs
+++ b/vendor/aube/crates/aube/src/patches.rs
@@ -308,7 +308,11 @@ pub fn upsert_patched_dependency(cwd: &Path, key: &str, rel_patch_path: &str) ->
             // Standalone aube (reads pnpm config): nest under `pnpm` so real
             // pnpm accepts the lockfile. An embedder that ignores pnpm config:
             // write the un-branded top-level field it actually reads.
-            let namespace = if reads_branded_pnpm { Some("pnpm") } else { None };
+            let namespace = if reads_branded_pnpm {
+                Some("pnpm")
+            } else {
+                None
+            };
             upsert_manifest_patched_dependency(cwd, key, rel_patch_path, namespace)
                 .wrap_err("failed to write package.json")?;
             return Ok(cwd.join("package.json"));

--- a/vendor/aube/crates/aube/src/progress/ci.rs
+++ b/vendor/aube/crates/aube/src/progress/ci.rs
@@ -225,54 +225,54 @@ impl CiState {
         let spawned = thread::Builder::new()
             .name("aube-ci-heartbeat".into())
             .spawn(move || {
-            let state = thread_state;
-            loop {
-                let guard = state.wake_lock.lock().unwrap();
-                // Re-check `done` *before* sleeping. `stop()` sets `done`
-                // and then `notify_all()`s without holding `wake_lock`, so
-                // a notification that races with the tick body would
-                // otherwise be lost and the thread would sleep a full
-                // `CI_HEARTBEAT_INTERVAL` before noticing shutdown.
-                if state.done.load(Ordering::Relaxed) {
-                    break;
+                let state = thread_state;
+                loop {
+                    let guard = state.wake_lock.lock().unwrap();
+                    // Re-check `done` *before* sleeping. `stop()` sets `done`
+                    // and then `notify_all()`s without holding `wake_lock`, so
+                    // a notification that races with the tick body would
+                    // otherwise be lost and the thread would sleep a full
+                    // `CI_HEARTBEAT_INTERVAL` before noticing shutdown.
+                    if state.done.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let (guard, _timeout) = state
+                        .wake
+                        .wait_timeout(guard, CI_HEARTBEAT_INTERVAL)
+                        .unwrap();
+                    drop(guard);
+                    if state.done.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let snap = state.snapshot();
+                    // Don't make noise until an install is actually underway.
+                    // Until then there's nothing to bar-graph and no reason to
+                    // print anything — a no-op install should remain
+                    // completely silent.
+                    if snap.resolved == 0 || snap.phase == 0 {
+                        continue;
+                    }
+                    let line = Self::render(snap);
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let mut last = state.last_printed.lock().unwrap();
+                    if *last == line {
+                        // Same rendered line as before — stay quiet.
+                        continue;
+                    }
+                    *last = line.clone();
+                    drop(last);
+                    // First time we actually print, emit the unframed
+                    // `aube VERSION by jdx.dev` header above the bar so
+                    // the CI log shows the aube banner. Only printed
+                    // once per install — `shown` flips true here.
+                    if !state.shown.swap(true, Ordering::Relaxed) {
+                        let _ = writeln!(std::io::stderr(), "{}", Self::render_header());
+                    }
+                    let _ = writeln!(std::io::stderr(), "{line}");
                 }
-                let (guard, _timeout) = state
-                    .wake
-                    .wait_timeout(guard, CI_HEARTBEAT_INTERVAL)
-                    .unwrap();
-                drop(guard);
-                if state.done.load(Ordering::Relaxed) {
-                    break;
-                }
-                let snap = state.snapshot();
-                // Don't make noise until an install is actually underway.
-                // Until then there's nothing to bar-graph and no reason to
-                // print anything — a no-op install should remain
-                // completely silent.
-                if snap.resolved == 0 || snap.phase == 0 {
-                    continue;
-                }
-                let line = Self::render(snap);
-                if line.is_empty() {
-                    continue;
-                }
-                let mut last = state.last_printed.lock().unwrap();
-                if *last == line {
-                    // Same rendered line as before — stay quiet.
-                    continue;
-                }
-                *last = line.clone();
-                drop(last);
-                // First time we actually print, emit the unframed
-                // `aube VERSION by jdx.dev` header above the bar so
-                // the CI log shows the aube banner. Only printed
-                // once per install — `shown` flips true here.
-                if !state.shown.swap(true, Ordering::Relaxed) {
-                    let _ = writeln!(std::io::stderr(), "{}", Self::render_header());
-                }
-                let _ = writeln!(std::io::stderr(), "{line}");
-            }
-        });
+            });
         // On spawn failure (e.g. EAGAIN under thread/PID exhaustion) leave the
         // handle `None` — the install proceeds without the cosmetic ticker.
         *state.heartbeat.lock().unwrap() = spawned.ok();

--- a/vendor/aube/crates/aube/tests/e2e.rs
+++ b/vendor/aube/crates/aube/tests/e2e.rs
@@ -284,7 +284,10 @@ fn approve_builds_surfaces_and_runs_a_local_source_dep() {
     // `virtual_store_subdir` (the shared global store, which `file:` deps
     // never enter), never by the `aube_dir_entry_name` that
     // `materialized_pkg_dir` reconstructs.
-    sbx.cmd().args(["approve-builds", "--all"]).assert().success();
+    sbx.cmd()
+        .args(["approve-builds", "--all"])
+        .assert()
+        .success();
     assert!(
         marker_exists_under(&node_modules, "BUILT_527_MARKER"),
         "approve-builds must run a local-source dep's build in the same invocation"


### PR DESCRIPTION
A confined piped `spawn` used to spin forever, so the shipped shim rewrote every `'pipe'` slot to a scratch file and handed the bytes back at child exit. That fixed the hang and cost three things: incremental delivery, `maxBuffer`, and `fork()` — which failed fast because a file cannot emulate a duplex pipe.

Both are now real. The pipe is created here, in the AppContainer-private namespace the same jail permits (`\\.\pipe\LOCAL\…`), and the child is handed an already-connected end as a raw fd — libuv's `UV_INHERIT_FD`, which duplicates a handle it never had to name. The parent reads the accepted end. An `'ipc'` slot is removed before `uv_spawn` can name a global pipe, and the channel is re-implemented over the same namespace as newline-delimited JSON, the framing Node's own `json` mode uses.

Both live in the ONE `ChildProcess.prototype.spawn` override the shim already had. Two stacked overrides would have an install order, and the wrong order would silently restore the refusal.

## Measured

Same driver, three arms. Node 20.19.0 / 22.15.0 / 22.23.1 / 26.5.0.

| | shipped shim | this branch | real Node |
|---|---|---|---|
| two writes 700ms apart | both at exit, gap 0ms | gap 902ms | gap 902ms |
| `maxBuffer` on a runaway child | callback never fires, exit 0 | `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`, child killed | same |
| `fork()` round trip | `ERR_NUB_SANDBOX_NO_IPC` | `{"pong":"p1","connected":true}` | same |
| nested `fork()` two levels down | — | `{"relayed":"p2"}` | same |
| async spawn with no writable directory | no repair installed | streams | n/a |

The `maxBuffer` row is a defect this found rather than a property it adds: `execFile`'s maxBuffer path calls `child.stdout.destroy()`, which under the file-backed path stranded the close accounting and lost the callback entirely — silently, exit 0.

## The payload had to shrink

The shim's source percent-encodes to 56215 characters. A `CreateProcessW` environment block holds 32767 in total, so shipping it raw would have failed every jailed launch on Windows for a reason that looks nothing like its cause. Whole-line comments and indentation are dropped before encoding, bringing the delivered `NODE_OPTIONS` to 23995 characters against the 22111 the previous shim already used. A unit test pins the budget, and the semantics suite drives the delivered payload rather than the source so the strip is measured on the shipping path.

The margin is thinner than the payload alone suggests. The probe reports `env-block-chars=27557` for the whole block, so about 5.2k characters are spare for `PATH` and the `npm_config_*` family. `node-options-full-launches` gates it on a real runner.

## Scope

`spawnSync` keeps the file-backed path and must: `ParseStdioOption` has no `'wrap'` case and a synchronously-blocked loop cannot drain a pipe. That path is now also the fallback for a namespace that refuses, and it is the only thing that still needs a writable directory — the async path needs no filesystem grant at all.

Handle passing and `serialization: 'advanced'` still throw `ERR_NUB_SANDBOX_NO_IPC` naming the per-package opt-out. Neither can ride a userland stream.

`NODE_OPTIONS` re-synthesis preserves the parent's own value rather than re-deriving from `import.meta.url`, because in production that variable carries the egress gate as well as this shim, and re-deriving would drop the gate from every grandchild while the channel kept working. `a_descendant_keeps_the_whole_preload_chain` pins it with a second preload standing in for the gate, forked twice through a rebuilt `env` and an emptied `execArgv`.

## Verification

- `stdio_shim_semantics`: 8 tests, differential — every case with an unshimmed twin runs both ways and the transcripts must match verbatim. Against the shipped shim 6 of the 8 fail; the 2 that pass are the behaviours that were already correct.
- `cargo test -p nub-sandbox` green (181 lib + all integration), `cargo clippy --all-targets --all-features` clean, `cargo fmt --check` clean.
- Real AppContainer, `windows_jail_repairs` on windows-latest — [run 30528704494](https://github.com/nubjs/nub/actions/runs/30528704494), green:

```
prop:shim-spawn-stream-returns=PASS  inner=CLOSED code=0 out=pong
prop:shim-fork-roundtrip=PASS  inner=OK direct={"pong":"p1","connected":true} nested={"relayed":"p2"}
prop:shim-fork-nested=PASS   prop:node-options-full-launches=PASS  ok:written
prop:unshimmed-piped-hangs=PASS  outer=HUNG killed_after_ms=15051 cpu_ms=14984
```

  The last line is the control: with the stamp withheld the same spawn still spins, cpu 14984 of 15051 wall, so the shim is what changed the outcome. `shim-fork-nested` is the one that could only be measured here — a confined descendant creating a second private pipe of its own.

  That run is on `sandbox/win-stdio-stream-verify`, this branch's commits cherry-picked onto `sandbox/win-ace-kernel`. On this PR's own base the probe aborts in the ancestor-repair arm before reaching any stdio arm, and it does so identically at the unmodified base commit ([run 30502067382](https://github.com/nubjs/nub/actions/runs/30502067382) at `96f8de366f`, where the old `shim-fork-fails-fast` is also never measured) — pre-existing, fixed by `SetKernelObjectSecurity` on `win-ace-kernel`.

Base is `sandbox/win-stdio-stream-base`, a ref at the shared ancestor of the six in-flight sandbox branches, so the diff here is only this change. `crates/nub-sandbox` is not on `main` yet.
