### PR TITLE
pm: run Windows dependency lifecycle scripts through bundled busybox sh

### DIFF
--- a/.github/workflows/busybox-lifecycle-probe.yml
+++ b/.github/workflows/busybox-lifecycle-probe.yml
@@ -1,0 +1,57 @@
+# Branch-scoped Windows probe (see .claude/skills/ci-adhoc-test) — NO PR needed.
+# Pushing to the busybox-lifecycle-shell branch runs this on a real
+# windows-latest runner. It builds one nub and drives the same dependency
+# postinstall fixtures twice, with `busybox.exe` staged next to nub.exe and
+# without it — the sidecar's presence is the only variable, and its absence
+# reproduces the pre-change cmd.exe behavior exactly.
+name: busybox-lifecycle-probe
+on:
+  push:
+    branches: [busybox-lifecycle-shell]
+    paths:
+      - 'tests/busybox-lifecycle-probe/**'
+      - '.github/workflows/busybox-lifecycle-probe.yml'
+      - 'crates/nub-cli/src/pm_engine/mod.rs'
+      - 'crates/nub-cli/src/cli.rs'
+      - 'vendor/aube/crates/aube-scripts/**'
+      - 'vendor/aube/crates/aube-util/src/engine_context.rs'
+      - 'vendor/busybox-w32/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: busybox dependency lifecycle (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: busybox-lifecycle-probe
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: 24
+          cache: 'npm'
+      # Root deps + the nub-native addon, mirroring ci.yml's Windows test leg —
+      # the install path resolves the augmentation preload through them.
+      - run: npm ci
+      - name: Build nub-native addon
+        shell: bash
+        run: |
+          (cd crates/nub-native && cargo build)
+          mkdir -p runtime/addons
+          cp target/debug/nub_native.dll runtime/addons/nub-native.node
+      - name: Build nub
+        run: cargo build -p nub-cli
+      # The probe stages and un-stages target/debug/busybox.exe itself, so it is
+      # deliberately NOT copied here.
+      - name: Probe dependency lifecycle shell (differential)
+        shell: bash
+        run: |
+          node tests/busybox-lifecycle-probe/run-probe.mjs \
+            target/debug/nub.exe "$RUNNER_TEMP/bblp" vendor/busybox-w32/busybox64.exe

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3797,8 +3797,11 @@ enum StreamMode {
     Prefixed,
 }
 
-/// Resolve the bundled busybox-w32 POSIX-`sh` sidecar that backs `nub run` script
-/// bodies on Windows. The win32 package lays `busybox.exe` beside `nub.exe` in the
+/// Resolve the bundled busybox-w32 POSIX-`sh` sidecar that backs every script
+/// body nub runs on Windows — `nub run` here, and dependency lifecycle scripts
+/// through the engine-context default `pm_engine` installs
+/// (`apply_lifecycle_script_shell`). The win32 package lays `busybox.exe`
+/// beside `nub.exe` in the
 /// package's `bin/` dir, so it resolves relative to the running executable
 /// (canonicalized, matching `current_nub_binary`). `__NUB_BUSYBOX_EXE` overrides
 /// the location — an internal test/CI seam that lets the Rust suite and the
@@ -3808,7 +3811,7 @@ enum StreamMode {
 /// fallback — that would resurrect the non-POSIX script semantics busybox replaces.
 /// Only reached on Windows (the `cfg!(windows)` default arm); cross-platform std so
 /// it compiles everywhere.
-fn resolve_bundled_busybox() -> Result<String> {
+pub(crate) fn resolve_bundled_busybox() -> Result<String> {
     let to_utf8 = |p: PathBuf| -> Result<String> {
         p.to_str()
             .map(str::to_string)
@@ -3913,6 +3916,9 @@ fn build_script_command(
     // can confine it (an in-process interpreter could do neither). This replaces
     // the former implicit `cmd.exe` default. busybox is a multi-call binary, so
     // its `sh` applet name precedes `-c`; every other shell here takes plain `-c`.
+    // The engine's dependency-lifecycle spawn resolves the same sidecar the same
+    // way (`pm_engine::apply_lifecycle_script_shell`), so one POSIX script body
+    // behaves identically whether `nub run` or a `postinstall` runs it.
     let custom_shell = script_shell_override
         .map(str::to_string)
         .or_else(|| nub_core::workspace::scripts::script_shell(&project.root));

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3800,9 +3800,8 @@ enum StreamMode {
 /// Resolve the bundled busybox-w32 POSIX-`sh` sidecar that backs every script
 /// body nub runs on Windows — `nub run` here, and dependency lifecycle scripts
 /// through the engine-context default `pm_engine` installs
-/// (`apply_lifecycle_script_shell`). The win32 package lays `busybox.exe`
-/// beside `nub.exe` in the
-/// package's `bin/` dir, so it resolves relative to the running executable
+/// (`apply_lifecycle_script_shell`). The win32 package lays `busybox.exe` beside
+/// `nub.exe` in the package's `bin/` dir, so it resolves relative to the running executable
 /// (canonicalized, matching `current_nub_binary`). `__NUB_BUSYBOX_EXE` overrides
 /// the location — an internal test/CI seam that lets the Rust suite and the
 /// branch-scoped Windows probe supply a busybox without the release-packaging step;

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -845,6 +845,7 @@ fn engine_session_inner(
     // compiled against ambient Node instead of the project's. Default-empty
     // overlay when augmentation can't engage ⇒ behavior preserved.
     apply_lifecycle_augmentation(&cwd);
+    apply_lifecycle_script_shell();
     Ok(EngineSession {
         detected,
         runtime: build_runtime()?,
@@ -1466,6 +1467,64 @@ fn apply_lifecycle_augmentation(cwd: &Path) {
         c.runtime_node_dir = runtime_node_dir;
         c.runtime_node_bin = runtime_node_bin;
     });
+}
+
+/// Replace the engine's Windows default lifecycle shell with nub's bundled
+/// busybox-w32 `sh`, so a dependency's `postinstall` gets the same POSIX shell
+/// `nub run` already uses (`crate::cli::resolve_bundled_busybox`) instead of
+/// `cmd.exe`. No-op on Unix, where the engine default is already `sh`.
+///
+/// Three reasons:
+///
+/// 1. ONE SHELL. `nub run` already defaults to busybox on Windows, so leaving
+///    the lifecycle path on `cmd.exe` meant one POSIX script body behaved
+///    differently depending on which nub surface ran it. This removes a
+///    divergence rather than creating one.
+/// 2. NO COMPATIBILITY COST, AND TWO FIXES. A sweep of the 344 widely-used
+///    packages that run install scripts found ZERO of 363 script bodies using
+///    cmd-only syntax (no `%VAR%`, `%~dp0`, `if exist`, `copy`/`del`/`rd`,
+///    `>nul`, `call`, `set VAR=`, caret escapes, `.cmd`/`.bat` invocation) —
+///    `sh` parses all 363. Two (`detox-recorder`, `svf-lib`) invoke `./*.sh`
+///    and only work under `sh`.
+/// 3. ROBUSTNESS UNDER THE SANDBOX. Confined in an AppContainer with no
+///    ancestor repair at all, busybox's `cd`, globbing, redirection, reads and
+///    whole spawn battery are byte-identical to unconfined. `cmd.exe` instead
+///    depends on the sandbox's ancestor repair (`nub-sandbox`'s traverse ACEs
+///    plus the capability SIDs it harvests off each ancestor's DACL) to report
+///    the filesystem correctly — and that repair is best-effort BY DESIGN: a
+///    refused ACE write is skipped rather than fatal, and an ancestor whose
+///    DACL names no harvestable capability yields nothing to request. A shell
+///    that needs no repair cannot be degraded by one that partially failed.
+///
+/// A user's explicit `script-shell` still wins — aube consults this only when
+/// that is unset. A missing sidecar (a broken install; `nub run` is equally
+/// dead in that state) warns and leaves the engine on `cmd.exe` rather than
+/// failing read-only verbs like `nub list` that never spawn a script.
+fn apply_lifecycle_script_shell() {
+    if !cfg!(windows) {
+        return;
+    }
+    match crate::cli::resolve_bundled_busybox() {
+        Ok(busybox) => aube_util::update_engine_context(|c| {
+            c.default_script_shell = Some(busybox_script_shell(&busybox));
+        }),
+        Err(err) => tracing::warn!(
+            "{err:#}\ndependency lifecycle scripts will run under cmd.exe, which does not \
+             support POSIX script bodies"
+        ),
+    }
+}
+
+/// busybox is a multi-call binary: it dispatches on `argv[0]`, or on a leading
+/// applet name. Spawned as `busybox.exe` the applet name must LEAD, so a bare
+/// `-c` would not select `sh` at all. Split out of the Windows-gated caller so
+/// the form is pinned by a test on every platform — dropping `"sh"` breaks only
+/// Windows, where no other test in this suite would see it.
+fn busybox_script_shell(busybox: &str) -> aube_util::ScriptShell {
+    aube_util::ScriptShell {
+        program: PathBuf::from(busybox),
+        args: vec!["sh".to_string(), "-c".to_string()],
+    }
 }
 
 /// `--dir` / `-C` (and the global `--cwd`, which dispatch applies earlier):
@@ -4139,6 +4198,19 @@ mod tests {
             "a member install builds the workspace's one shared tree, so anchoring \
              Node discovery anywhere but the root keys the ABI caches to a Node the \
              install state never saw"
+        );
+    }
+
+    #[test]
+    fn busybox_lifecycle_shell_leads_with_the_sh_applet_name() {
+        let spec = busybox_script_shell(r"C:\nub\bin\busybox.exe");
+        assert_eq!(spec.program, PathBuf::from(r"C:\nub\bin\busybox.exe"));
+        assert_eq!(
+            spec.args,
+            ["sh", "-c"],
+            "busybox dispatches on argv[0] or a leading applet name, so spawned as \
+             `busybox.exe` it needs `sh` before `-c` — `busybox.exe -c <body>` runs \
+             no shell. This test exists because that mistake is invisible off Windows."
         );
     }
 }

--- a/crates/nub-cli/tests/pm_augment.rs
+++ b/crates/nub-cli/tests/pm_augment.rs
@@ -71,7 +71,7 @@ fn install_runs_lifecycle_scripts_under_runtime_augmentation() {
         .map(|stem| format!("{stem}.cjs"))
         .unwrap_or_default();
 
-    let dir = fixture();
+    let dir = fixture(POSTINSTALL_PROBE);
     let (stdout, stderr, code) = run(&nub, &dir, &["install"]);
     assert_eq!(
         code, 0,
@@ -109,9 +109,50 @@ fn install_runs_lifecycle_scripts_under_runtime_augmentation() {
     );
 }
 
-/// A nub-identity project with a root postinstall probe, an empty lock, no
+/// A POSIX-only `postinstall`: braced parameter expansion with a default, and
+/// the `test` utility. `cmd.exe` leaves `${…}` literal (quotes included) and has
+/// no `test`, so under cmd this writes different bytes AND exits non-zero.
+const POSIX_SHELL_PROBE: &str =
+    "echo \"MARK=${SHELL_PROBE:-posix}\" > shell.txt && test -d . && echo dirok >> shell.txt";
+
+/// Lifecycle scripts run under a POSIX `sh` on every platform: the system
+/// `/bin/sh` on Unix, and on Windows the bundled busybox-w32 `sh` the engine
+/// takes from `EngineContext::default_script_shell` — NOT `cmd.exe`, which the
+/// engine defaulted to before. The body is the assertion: cmd.exe cannot run it,
+/// so a regression here fails the install rather than passing quietly.
+///
+/// Root and dependency hooks share aube's one `spawn_shell_with_settings`, so
+/// this pins the shell selection for both. The dependency path end-to-end (and
+/// the cmd.exe-vs-busybox differential, which needs a real Windows runner) is
+/// `tests/busybox-lifecycle-probe/`.
+#[test]
+fn install_runs_lifecycle_scripts_under_a_posix_shell() {
+    let nub = nub_binary();
+    let dir = fixture(POSIX_SHELL_PROBE);
+    let (stdout, stderr, code) = run(&nub, &dir, &["install"]);
+    assert_eq!(
+        code, 0,
+        "install failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let marker = std::fs::read_to_string(dir.join("shell.txt")).unwrap_or_else(|_| {
+        panic!(
+            "the root postinstall wrote no shell.txt — the lifecycle script did not run at all.\
+             \nstdout: {stdout}\nstderr: {stderr}"
+        )
+    });
+    assert_eq!(
+        marker.replace("\r\n", "\n"),
+        "MARK=posix\ndirok\n",
+        "the lifecycle shell did not expand `${{SHELL_PROBE:-posix}}` or run `test -d .`, so it \
+         is not a POSIX sh. On Windows that means the bundled busybox sidecar was not used and \
+         the engine fell back to cmd.exe.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+/// A nub-identity project with the given root `postinstall`, an empty lock, no
 /// dependencies, and a dead-port registry (offline).
-fn fixture() -> PathBuf {
+fn fixture(postinstall: &str) -> PathBuf {
     use std::sync::atomic::{AtomicU64, Ordering};
     static N: AtomicU64 = AtomicU64::new(0);
     let dir = std::env::temp_dir().join(format!(
@@ -125,7 +166,7 @@ fn fixture() -> PathBuf {
     std::fs::write(dir.join("nub.lock"), EMPTY_LOCK).unwrap();
     let pkg = format!(
         r#"{{"name":"app","version":"1.0.0","packageManager":"nub@0.0.1","scripts":{{"postinstall":{}}}}}"#,
-        serde_json::to_string(POSTINSTALL_PROBE).unwrap()
+        serde_json::to_string(postinstall).unwrap()
     );
     std::fs::write(dir.join("package.json"), pkg).unwrap();
     dir

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -408,6 +408,10 @@ Approval takes effect immediately: `nub approve-builds` records the decision and
 
 Which manifest field grants permission tracks the inferred incumbent: pnpm projects use `pnpm.onlyBuiltDependencies` / `pnpm.allowBuilds`, Bun projects use `trustedDependencies`, and the neutral `allowBuilds` field plus `nub approve-builds` apply in any project. An explicit denial (`allowBuilds: { pkg: false }`, `neverBuiltDependencies`) always wins. A package that wants to build but isn't allowed is skipped, with `WARN_NUB_IGNORED_BUILD_SCRIPTS` naming it and `nub approve-builds` as the remedy.
 
+### The build-script shell
+
+An approved package's build script runs in a POSIX `sh` — the same shell `nub run` gives your own scripts, so a dependency's `postinstall` behaves identically on macOS, Linux, and Windows, including one that invokes a shipped `./configure.sh`. Windows uses the small bundled shell rather than `cmd.exe`; see [the script shell](/docs/runner/run#the-script-shell) for the contract and [`script-shell`](/docs/runner/run#--script-shell) to pin a different one.
+
 ### Cooling window
 
 A registry-resolved version must be older than `minimumReleaseAge` — 24 hours by default — before Nub will install it. The window is what keeps a compromised publish out of your tree during the hours between it going up and being caught.

--- a/tests/busybox-lifecycle-probe/README.md
+++ b/tests/busybox-lifecycle-probe/README.md
@@ -1,0 +1,62 @@
+# busybox-lifecycle-probe — the dependency lifecycle shell, on real Windows
+
+A throwaway, branch-scoped CI probe (see `.claude/skills/ci-adhoc-test`). No PR is
+needed: pushing to the `busybox-lifecycle-shell` branch runs
+`.github/workflows/busybox-lifecycle-probe.yml` on a real `windows-latest` runner.
+
+Sibling of `tests/busybox-run-probe/`, which covers the same shell swap for
+`nub run`. This one covers the engine's **dependency lifecycle** path
+(`preinstall`/`install`/`postinstall`), which used to hardcode `cmd.exe`.
+
+## The differential
+
+One `nub.exe`, each case installed twice, and the only variable is whether the
+`busybox.exe` sidecar sits next to the binary:
+
+| arm | sidecar | shell the engine resolves |
+| --- | --- | --- |
+| `cmd` | absent | `cmd.exe /d /s /c` — `apply_lifecycle_script_shell` warns and leaves the platform default, byte-identical to the pre-change behavior |
+| `busybox` | staged as the win32 package lays it out | `busybox.exe sh -c` |
+
+Every case body is POSIX and is chosen to fail under `cmd.exe`, and the probe
+asserts the split in **both** directions: the `busybox` arm must produce the
+POSIX result, and the `cmd` arm must **not**. A case that passes in both arms is
+not a discriminator and is reported as a failure.
+
+| case | body | asserts |
+| --- | --- | --- |
+| `param_expansion_and_test` | `echo "MARK=${LIFECYCLE_PROBE:-posix}" > out.txt && test -d . && …` | braced expansion with a default, plus the `test` utility |
+| `invokes_shipped_sh_script` | `./scripts/build.sh` | the shape that makes this a fix: `detox-recorder` and `svf-lib` invoke a shipped shell script and fail under `cmd.exe` today |
+| `glob_loop_and_redirect` | `for f in src/*.txt; do cat $f >> out.txt; done` | shell-side glob expansion, loop, append redirect |
+
+## Three things the harness has to get right
+
+Each was a real bug caught while building it, and each produced a control that
+"confirmed" the wrong answer:
+
+1. **One fixture and one install per case.** A lifecycle failure aborts the
+   `JoinSet` driving the parallel pass, which kills sibling scripts mid-write —
+   that truncated one case's marker and suppressed another's entirely.
+2. **`side-effects-cache=false` in every fixture.** The cache is on by default and
+   keys on `(name, version, engine, input hash)`, which is identical across the
+   two arms because the shell is not part of the key. With it on, the second arm
+   hardlinks the first arm's built tree back and never runs the script.
+3. **A distinct package name per case.** With one shared name the
+   content-addressed store served the first case's built package directory to all
+   of them, so all three reported the first case's marker.
+
+The probe also guards its own setup: it asserts `approve-builds --all` actually
+approved the build in each arm, because an unapproved build produces no marker in
+either arm and the split would then read as "cmd failed" for the wrong reason.
+
+## Reproducing locally
+
+The runner is cross-platform, but the control arm is meaningful only on Windows —
+`apply_lifecycle_script_shell` is Windows-gated, so elsewhere both arms run
+`/bin/sh` and the control checks report `SKIP`. A Unix run is still a useful
+harness smoke test: it proves the fixtures, the approve step, and every POSIX
+body are correct.
+
+```sh
+node tests/busybox-lifecycle-probe/run-probe.mjs target/fast/nub /tmp/bblp vendor/busybox-w32/busybox64.exe
+```

--- a/tests/busybox-lifecycle-probe/run-probe.mjs
+++ b/tests/busybox-lifecycle-probe/run-probe.mjs
@@ -1,0 +1,210 @@
+// Branch-scoped Windows probe for the shell that runs DEPENDENCY LIFECYCLE
+// scripts (`preinstall`/`install`/`postinstall`), which the engine used to
+// hardcode to cmd.exe while `nub run` already defaulted to the bundled
+// busybox-w32 `sh`. Sibling of tests/busybox-run-probe/, which covers `nub run`.
+//
+// This is a DIFFERENTIAL, not a green check: one nub binary runs each case
+// twice and the ONLY variable is whether `busybox.exe` sits next to `nub.exe`.
+//
+//   arm `cmd`     — sidecar absent. `apply_lifecycle_script_shell` warns and
+//                   leaves the engine on `cmd.exe /d /s /c`, byte-identical to
+//                   the pre-change behavior. This is the control.
+//   arm `busybox` — sidecar staged as the win32 package lays it out, so the
+//                   engine resolves it and spawns `busybox.exe sh -c <body>`.
+//
+// Each body is POSIX and chosen to FAIL under cmd.exe, so the control arm must
+// go red. A case that passes in both arms is not a discriminator and proves
+// nothing, so the probe asserts the split in BOTH directions.
+//
+// Each case gets its OWN fixture and its own install. Sharing one fixture is
+// wrong: a lifecycle failure aborts the JoinSet driving the parallel pass,
+// which kills sibling scripts mid-write — that silently truncated one case's
+// marker and suppressed another's entirely.
+//
+// Usage: node run-probe.mjs <path-to-nub.exe> <work-dir> <path-to-busybox.exe>
+// Exit 0 iff every case shows the expected cmd-fails / busybox-passes split.
+
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  copyFileSync,
+  existsSync,
+  chmodSync,
+} from "node:fs";
+import { join, resolve, dirname } from "node:path";
+
+const nubBin = resolve(process.argv[2] ?? "");
+const workRoot = resolve(process.argv[3] ?? "work");
+const busyboxSrc = resolve(process.argv[4] ?? "");
+if (!process.argv[2] || !process.argv[4]) {
+  process.stderr.write("usage: run-probe.mjs <nub.exe> <work-dir> <busybox.exe>\n");
+  process.exit(2);
+}
+// The sidecar nub resolves at run time is `busybox.exe` beside the binary.
+// Staging and un-staging THIS path is the probe's single independent variable.
+const sidecar = join(dirname(nubBin), `busybox${process.platform === "win32" ? ".exe" : ""}`);
+
+// `want` is what the body must leave in `<pkg>/out.txt` under a POSIX shell.
+// `exec` files get the exec bit (meaningless on Windows, required on Unix).
+const cases = [
+  {
+    // Braced parameter expansion with a default, plus the `test` utility cmd
+    // has no equivalent for. cmd leaves `${…}` literal and errors on `test`.
+    id: "param_expansion_and_test",
+    script: 'echo "MARK=${LIFECYCLE_PROBE:-posix}" > out.txt && test -d . && echo dirok >> out.txt',
+    files: {},
+    want: "MARK=posix\ndirok",
+  },
+  {
+    // The shape that makes this a FIX rather than a swap: real packages
+    // (`detox-recorder`, `svf-lib`) invoke a shipped shell script from their
+    // postinstall, which cmd.exe cannot execute at all.
+    id: "invokes_shipped_sh_script",
+    script: "./scripts/build.sh",
+    files: { "scripts/build.sh": "#!/bin/sh\nprintf 'SH_RAN\\n' > out.txt\n" },
+    exec: ["scripts/build.sh"],
+    want: "SH_RAN",
+  },
+  {
+    // Glob expansion + append redirection inside a loop — the shell, not the
+    // applet, has to expand the pattern.
+    id: "glob_loop_and_redirect",
+    script: "for f in src/*.txt; do cat $f >> out.txt; done",
+    files: { "src/a.txt": "A\n", "src/b.txt": "B\n" },
+    want: "A\nB",
+  },
+];
+
+// Every case gets a DISTINCT package name. Also load-bearing, and also a
+// broken-control bug this probe already hit: with one shared name the
+// content-addressed store served the first case's built package directory to
+// all of them, so all three reported the first case's marker and the control
+// "confirmed" the wrong thing three times.
+const pkgName = (c) => `probedep-${c.id.replace(/_/g, "-")}`;
+
+function writeFixture(dir, c) {
+  rmSync(dir, { recursive: true, force: true });
+  const pkg = pkgName(c);
+  const pkgDir = join(dir, pkg);
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(
+    join(pkgDir, "package.json"),
+    JSON.stringify({ name: pkg, version: "1.0.0", scripts: { postinstall: c.script } }, null, 2),
+  );
+  for (const [rel, body] of Object.entries(c.files)) {
+    const p = join(pkgDir, rel);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, body);
+  }
+  for (const rel of c.exec ?? []) chmodSync(join(pkgDir, rel), 0o755);
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify(
+      {
+        name: "lifecycle-shell-probe",
+        version: "0.0.0",
+        private: true,
+        dependencies: { [pkg]: `file:./${pkg}` },
+      },
+      null,
+      2,
+    ),
+  );
+  // LOAD-BEARING for the differential, not hygiene. The side-effects cache is
+  // on by default and keys on `(name, version, engine, input hash)` — which is
+  // IDENTICAL across the two arms, since only the shell differs and the shell
+  // is not part of the key. With it on, whichever arm ran second would hardlink
+  // the first arm's built tree back and skip the script entirely, so the
+  // control would "confirm" whatever the first arm did.
+  writeFileSync(join(dir, ".npmrc"), "side-effects-cache=false\n");
+}
+
+function nub(cwd, args) {
+  const r = spawnSync(nubBin, args, { cwd, encoding: "utf8", timeout: 300000 });
+  return { out: (r.stdout ?? "") + (r.stderr ?? ""), code: r.status, flag: r.error?.code };
+}
+
+// Install once to surface the ignored build, approve it, then run the MEASURED
+// install. `approve-builds --all` writes the allowlist key itself, so the probe
+// never hardcodes a `file:` spec spelling that could normalize per platform.
+function runCase(c, arm, withBusybox) {
+  rmSync(sidecar, { force: true });
+  if (withBusybox) copyFileSync(busyboxSrc, sidecar);
+  const dir = join(workRoot, arm, c.id);
+  writeFixture(dir, c);
+  nub(dir, ["install", "--offline"]);
+  const approve = nub(dir, ["approve-builds", "--all"]);
+  const measured = nub(dir, ["install", "--offline"]);
+  const out = join(dir, "node_modules", pkgName(c), "out.txt");
+  return {
+    approve,
+    measured,
+    marker: existsSync(out) ? readFileSync(out, "utf8").replace(/\r\n/g, "\n").trim() : null,
+  };
+}
+
+// The control arm only means anything on Windows: `apply_lifecycle_script_shell`
+// is gated to Windows, so off it BOTH arms run the platform `/bin/sh` and the
+// "cmd" arm is not a cmd arm at all. A Unix run is therefore a harness smoke
+// test — it proves the fixtures, the approve step, and every POSIX body are
+// right — and the control checks report SKIP rather than a misleading pass.
+const isWindows = process.platform === "win32";
+
+let failures = 0;
+function check(id, pass, detail) {
+  if (!pass) failures++;
+  process.stdout.write(`RESULT|${id}|${pass ? "PASS" : "FAIL"}|${detail}\n`);
+}
+function checkControl(id, pass, detail) {
+  if (!isWindows) {
+    process.stdout.write(`RESULT|${id}|SKIP|not Windows: both arms run /bin/sh\n`);
+    return;
+  }
+  check(id, pass, detail);
+}
+
+for (const c of cases) {
+  const cmd = runCase(c, "cmd", false);
+  const bb = runCase(c, "busybox", true);
+  process.stdout.write(
+    `ARM|${c.id}|cmd:exit=${cmd.measured.code},marker=${JSON.stringify(cmd.marker)}` +
+      `|busybox:exit=${bb.measured.code},marker=${JSON.stringify(bb.marker)}\n`,
+  );
+
+  // Guard the control itself: if approve never ran the build stays ignored, so
+  // BOTH arms would produce no marker and the split would read as "cmd failed"
+  // for a reason that has nothing to do with the shell.
+  for (const [arm, r] of [
+    ["cmd", cmd],
+    ["busybox", bb],
+  ]) {
+    check(
+      `${c.id}_${arm}_build_approved`,
+      /Approved 1 package/.test(r.approve.out),
+      JSON.stringify(r.approve.out.trim().slice(0, 200)),
+    );
+  }
+
+  check(
+    `${c.id}_busybox_install_succeeds`,
+    bb.measured.code === 0,
+    JSON.stringify(bb.measured.out.slice(-400)),
+  );
+  check(
+    `${c.id}_busybox_marker_is_posix_result`,
+    bb.marker === c.want,
+    `want=${JSON.stringify(c.want)} got=${JSON.stringify(bb.marker)}`,
+  );
+  checkControl(
+    `${c.id}_cmd_arm_differs`,
+    cmd.measured.code !== 0 || cmd.marker !== c.want,
+    `the control must NOT reproduce the POSIX result, else this case is not a ` +
+      `discriminator: exit=${cmd.measured.code} marker=${JSON.stringify(cmd.marker)}`,
+  );
+}
+
+process.stdout.write(`\nSUMMARY|${failures === 0 ? "PASS" : `${failures} FAILED`}\n`);
+process.exit(failures === 0 ? 0 : 1);

--- a/vendor/aube/crates/aube-scripts/src/lib.rs
+++ b/vendor/aube/crates/aube-scripts/src/lib.rs
@@ -537,9 +537,10 @@ fn spawn_jailed_shell(
 ///
 /// The dialect follows the RESOLVED shell, not the target platform: on Windows
 /// an embedder can replace the default with a POSIX shell, and cmd-quoting an
-/// arg a POSIX shell then reparses corrupts it — `%` doubles to `%%`, and
-/// `"$X"` / `"`cmd`"` become live expansions instead of the literal the user
-/// typed. Both dialects are compiled on every platform so each stays testable.
+/// arg a POSIX shell then reparses corrupts it — `%` doubles to `%%`, while a
+/// `$var` or a backtick command substitution stays live inside the double
+/// quotes cmd-quoting emits instead of arriving as the literal the user typed.
+/// Both dialects are compiled on every platform so each stays testable.
 pub fn shell_quote_arg(arg: &str) -> String {
     shell_quote_arg_with_settings(arg, &script_settings())
 }

--- a/vendor/aube/crates/aube-scripts/src/lib.rs
+++ b/vendor/aube/crates/aube-scripts/src/lib.rs
@@ -36,6 +36,12 @@ use std::path::{Path, PathBuf};
 pub struct ScriptSettings {
     pub node_options: Option<String>,
     pub script_shell: Option<PathBuf>,
+    /// Embedder-supplied replacement for the PLATFORM DEFAULT shell, consulted
+    /// only when [`Self::script_shell`] is unset (an explicit user
+    /// `script-shell` always wins). Copied verbatim from
+    /// [`aube_util::EngineContext::default_script_shell`]; `None` keeps aube's
+    /// own default (`sh -c`, or `cmd.exe /d /s /c` on Windows).
+    pub default_shell: Option<aube_util::ScriptShell>,
     pub unsafe_perm: Option<bool>,
     pub shell_emulator: bool,
     /// Directory of the project's resolved Node runtime, prepended to
@@ -296,9 +302,54 @@ pub fn prepend_paths(bin_dirs: &[PathBuf]) -> std::ffi::OsString {
     std::env::join_paths(entries).unwrap_or(path)
 }
 
+/// How a script body is handed to its shell. Resolved from
+/// [`ScriptSettings`] by [`resolve_shell`], which is the single source of truth
+/// the spawn AND [`shell_quote_arg`] both read — quoting the body for one
+/// dialect and parsing it with another is a silent-wrong-command bug, so the
+/// two are derived from one place rather than each deciding by `cfg`.
+enum ShellInvocation {
+    /// `<program> <args…> <body>`, the body a single argv element. `args` is
+    /// `["-c"]` for a plain shell and `["sh", "-c"]` for a multi-call binary
+    /// that dispatches on an applet name (busybox).
+    Args { program: PathBuf, args: Vec<String> },
+    /// `cmd.exe /d /s /c "<body>"`, built with `raw_arg` — see
+    /// [`spawn_shell`].
+    #[cfg(windows)]
+    CmdRaw,
+}
+
+/// Precedence: the user's explicit `script-shell` → an embedder's replacement
+/// default ([`ScriptSettings::default_shell`]) → aube's platform default.
+fn resolve_shell(settings: &ScriptSettings) -> ShellInvocation {
+    if let Some(shell) = settings.script_shell.as_deref() {
+        return ShellInvocation::Args {
+            program: shell.to_path_buf(),
+            args: vec!["-c".to_string()],
+        };
+    }
+    if let Some(spec) = &settings.default_shell {
+        return ShellInvocation::Args {
+            program: spec.program.clone(),
+            args: spec.args.clone(),
+        };
+    }
+    #[cfg(windows)]
+    {
+        ShellInvocation::CmdRaw
+    }
+    #[cfg(not(windows))]
+    {
+        ShellInvocation::Args {
+            program: PathBuf::from("sh"),
+            args: vec!["-c".to_string()],
+        }
+    }
+}
+
 /// Spawn a shell command line. On Unix we go through `sh -c`, on
 /// Windows through `cmd.exe /d /s /c` — matching what npm passes in
-/// `@npmcli/run-script`.
+/// `@npmcli/run-script` — unless an embedder supplied a replacement default
+/// ([`ScriptSettings::default_shell`]) or the user set `script-shell`.
 ///
 /// On Windows, the script command line is appended with
 /// [`std::os::windows::process::CommandExt::raw_arg`] instead of
@@ -323,35 +374,22 @@ fn spawn_shell_with_settings(
     script_cmd: &str,
     settings: &ScriptSettings,
 ) -> tokio::process::Command {
-    #[cfg(unix)]
-    let mut cmd = {
-        let mut cmd = tokio::process::Command::new(
-            settings
-                .script_shell
-                .as_deref()
-                .unwrap_or_else(|| Path::new("sh")),
-        );
-        cmd.arg("-c").arg(script_cmd);
-        cmd
-    };
-    #[cfg(windows)]
-    let mut cmd = {
-        let mut cmd = tokio::process::Command::new(
-            settings
-                .script_shell
-                .as_deref()
-                .unwrap_or_else(|| Path::new("cmd.exe")),
-        );
-        if settings.script_shell.is_some() {
-            cmd.arg("-c").arg(script_cmd);
-        } else {
+    let mut cmd = match resolve_shell(settings) {
+        ShellInvocation::Args { program, args } => {
+            let mut cmd = tokio::process::Command::new(program);
+            cmd.args(args).arg(script_cmd);
+            cmd
+        }
+        #[cfg(windows)]
+        ShellInvocation::CmdRaw => {
+            let mut cmd = tokio::process::Command::new("cmd.exe");
             // `/d` skips AutoRun, `/s` flips the quote-stripping rule
             // so only the *outer* `"..."` pair is removed, `/c` runs
             // the command and exits. Build the raw argv tail manually
             // so cmd.exe sees the original script bytes.
             cmd.raw_arg("/d /s /c \"").raw_arg(script_cmd).raw_arg("\"");
+            cmd
         }
-        cmd
     };
     apply_script_settings_env(&mut cmd, settings);
     // Aborting the `JoinSet` that drives the parallel lifecycle pass
@@ -425,17 +463,16 @@ fn spawn_jailed_shell(
     jail: &ScriptJail,
     home: &Path,
 ) -> tokio::process::Command {
-    let shell = settings
-        .script_shell
-        .as_deref()
-        .unwrap_or_else(|| Path::new("sh"));
+    // Same shell resolution as the unjailed path, just re-hosted under
+    // `sandbox-exec` — `CmdRaw` is unreachable here (macOS-only fn).
+    let ShellInvocation::Args { program, args } = resolve_shell(settings);
     let profile = jail_profile(jail, home);
     let mut cmd = tokio::process::Command::new("sandbox-exec");
     cmd.arg("-p")
         .arg(profile)
         .arg("--")
-        .arg(shell)
-        .arg("-c")
+        .arg(program)
+        .args(args)
         .arg(script_cmd);
     apply_script_settings_env(&mut cmd, settings);
     // Matches the unjailed path — see `spawn_shell_with_settings`.
@@ -497,68 +534,97 @@ fn spawn_jailed_shell(
 /// interior " and backslash per CommandLineToArgvW. Full cmd.exe
 /// metachar caret-escaping is a rabbit hole, so this is best-effort,
 /// works for the common cases, matches what node's shell-quote does.
+///
+/// The dialect follows the RESOLVED shell, not the target platform: on Windows
+/// an embedder can replace the default with a POSIX shell, and cmd-quoting an
+/// arg a POSIX shell then reparses corrupts it — `%` doubles to `%%`, and
+/// `"$X"` / `"`cmd`"` become live expansions instead of the literal the user
+/// typed. Both dialects are compiled on every platform so each stays testable.
 pub fn shell_quote_arg(arg: &str) -> String {
-    #[cfg(unix)]
-    {
-        let mut out = String::with_capacity(arg.len() + 2);
-        out.push('\'');
-        for ch in arg.chars() {
-            if ch == '\'' {
-                out.push_str("'\\''");
-            } else {
+    shell_quote_arg_with_settings(arg, &script_settings())
+}
+
+fn shell_quote_arg_with_settings(arg: &str, settings: &ScriptSettings) -> String {
+    match resolve_shell(settings) {
+        ShellInvocation::Args { ref program, .. } if !is_cmd_program(program) => quote_posix(arg),
+        _ => quote_cmd(arg),
+    }
+}
+
+/// Does this program name invoke `cmd.exe`? Mirrors npm's
+/// `/(?:^|\\)cmd(?:\.exe)?$/i`, so a user `script-shell` of `bash` selects
+/// POSIX quoting while an explicit `cmd` still selects cmd quoting. Splits on
+/// both separators by hand rather than using `Path::file_name`, which does not
+/// treat `\` as one off Windows — a Windows path reaching this on any host
+/// (a settings snapshot in a test, a cross-platform fixture) must still resolve
+/// to its last component.
+fn is_cmd_program(program: &Path) -> bool {
+    let Some(path) = program.to_str() else {
+        return false;
+    };
+    let name = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    name.eq_ignore_ascii_case("cmd") || name.eq_ignore_ascii_case("cmd.exe")
+}
+
+fn quote_posix(arg: &str) -> String {
+    let mut out = String::with_capacity(arg.len() + 2);
+    out.push('\'');
+    for ch in arg.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+fn quote_cmd(arg: &str) -> String {
+    let mut out = String::with_capacity(arg.len() + 2);
+    out.push('"');
+    let mut backslashes: usize = 0;
+    for ch in arg.chars() {
+        match ch {
+            '\\' => backslashes += 1,
+            '"' => {
+                for _ in 0..backslashes * 2 + 1 {
+                    out.push('\\');
+                }
+                out.push('"');
+                backslashes = 0;
+            }
+            // cmd.exe expands %VAR% even inside double quotes.
+            // Outer `/s /c "..."` only strips the outermost
+            // quote pair, the shell still runs env expansion
+            // on the body. Argument like `%COMSPEC%` would
+            // otherwise get replaced with the shell path
+            // before the child saw it. Double the percent so
+            // cmd passes a literal `%` through. Full
+            // caret-escaping of `^ & | < > ( )` is a deeper
+            // rabbit hole, this handles the common injection
+            // vector.
+            '%' => {
+                for _ in 0..backslashes {
+                    out.push('\\');
+                }
+                backslashes = 0;
+                out.push_str("%%");
+            }
+            _ => {
+                for _ in 0..backslashes {
+                    out.push('\\');
+                }
+                backslashes = 0;
                 out.push(ch);
             }
         }
-        out.push('\'');
-        out
     }
-    #[cfg(windows)]
-    {
-        let mut out = String::with_capacity(arg.len() + 2);
-        out.push('"');
-        let mut backslashes: usize = 0;
-        for ch in arg.chars() {
-            match ch {
-                '\\' => backslashes += 1,
-                '"' => {
-                    for _ in 0..backslashes * 2 + 1 {
-                        out.push('\\');
-                    }
-                    out.push('"');
-                    backslashes = 0;
-                }
-                // cmd.exe expands %VAR% even inside double quotes.
-                // Outer `/s /c "..."` only strips the outermost
-                // quote pair, the shell still runs env expansion
-                // on the body. Argument like `%COMSPEC%` would
-                // otherwise get replaced with the shell path
-                // before the child saw it. Double the percent so
-                // cmd passes a literal `%` through. Full
-                // caret-escaping of `^ & | < > ( )` is a deeper
-                // rabbit hole, this handles the common injection
-                // vector.
-                '%' => {
-                    for _ in 0..backslashes {
-                        out.push('\\');
-                    }
-                    backslashes = 0;
-                    out.push_str("%%");
-                }
-                _ => {
-                    for _ in 0..backslashes {
-                        out.push('\\');
-                    }
-                    backslashes = 0;
-                    out.push(ch);
-                }
-            }
-        }
-        for _ in 0..backslashes * 2 {
-            out.push('\\');
-        }
-        out.push('"');
-        out
+    for _ in 0..backslashes * 2 {
+        out.push('\\');
     }
+    out.push('"');
+    out
 }
 
 /// Translate child ExitStatus to a parent exit code.
@@ -2087,6 +2153,134 @@ mod windows_job_object_tests {
         assert!(
             reaped,
             "grandchild pid {pid} survived parent abort — job object did not kill the tree"
+        );
+    }
+}
+
+#[cfg(test)]
+mod shell_resolution_tests {
+    use super::*;
+
+    fn busybox() -> aube_util::ScriptShell {
+        aube_util::ScriptShell {
+            program: PathBuf::from(r"C:\nub\busybox.exe"),
+            args: vec!["sh".to_string(), "-c".to_string()],
+        }
+    }
+
+    fn invocation(settings: &ScriptSettings) -> (String, Vec<String>) {
+        match resolve_shell(settings) {
+            ShellInvocation::Args { program, args } => {
+                (program.to_string_lossy().into_owned(), args)
+            }
+            #[cfg(windows)]
+            ShellInvocation::CmdRaw => ("cmd.exe".to_string(), vec!["/d /s /c".to_string()]),
+        }
+    }
+
+    /// The embedder default replaces the PLATFORM default and carries its own
+    /// leading args, so a multi-call binary gets its applet name — `busybox.exe
+    /// -c <body>` is not a valid invocation and would fail to select `sh`.
+    #[test]
+    fn embedder_default_supplies_program_and_applet_args() {
+        let settings = ScriptSettings {
+            default_shell: Some(busybox()),
+            ..Default::default()
+        };
+        assert_eq!(
+            invocation(&settings),
+            (
+                r"C:\nub\busybox.exe".to_string(),
+                vec!["sh".to_string(), "-c".to_string()]
+            )
+        );
+    }
+
+    /// A user's `script-shell` outranks the embedder default — the embedder
+    /// replaces what aube would have picked, never what the user asked for.
+    #[test]
+    fn user_script_shell_outranks_the_embedder_default() {
+        let settings = ScriptSettings {
+            script_shell: Some(PathBuf::from("/bin/dash")),
+            default_shell: Some(busybox()),
+            ..Default::default()
+        };
+        assert_eq!(
+            invocation(&settings),
+            ("/bin/dash".to_string(), vec!["-c".to_string()])
+        );
+    }
+
+    /// Default-empty settings keep aube's own platform default, so standalone
+    /// aube is unaffected by the seam existing.
+    #[test]
+    fn unset_settings_keep_the_platform_default() {
+        let (program, args) = invocation(&ScriptSettings::default());
+        if cfg!(windows) {
+            assert_eq!(
+                (program.as_str(), args[0].as_str()),
+                ("cmd.exe", "/d /s /c")
+            );
+        } else {
+            assert_eq!((program.as_str(), args[0].as_str()), ("sh", "-c"));
+        }
+    }
+
+    /// The leading-args form has to survive an actual spawn, not just
+    /// `resolve_shell`. `/usr/bin/env` is a stand-in for busybox with the same
+    /// shape — a program that takes a command name and then `-c` — so dropping
+    /// or reordering `args` fails here the same way `busybox.exe -c <body>`
+    /// fails on Windows, the one platform this suite cannot run.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn embedder_default_leading_args_survive_a_real_spawn() {
+        let settings = ScriptSettings {
+            default_shell: Some(aube_util::ScriptShell {
+                program: PathBuf::from("/usr/bin/env"),
+                args: vec!["sh".to_string(), "-c".to_string()],
+            }),
+            ..Default::default()
+        };
+        let out = spawn_shell_with_settings("echo \"ok=${X:-1}\"", &settings)
+            .output()
+            .await
+            .expect("the composed shell must be spawnable");
+        assert!(
+            out.status.success(),
+            "spawn failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout).trim(),
+            "ok=1",
+            "the body must reach a POSIX shell as one argv element, through the \
+             embedder's leading args"
+        );
+    }
+
+    /// Arg quoting must follow the RESOLVED shell, not the platform. Under a
+    /// POSIX default on Windows, cmd rules would corrupt the arg: `%` doubles
+    /// and `$`/backtick stay live inside the double quotes cmd-quoting emits.
+    #[test]
+    fn quoting_follows_the_resolved_shell_not_the_platform() {
+        let posix = ScriptSettings {
+            default_shell: Some(busybox()),
+            ..Default::default()
+        };
+        assert_eq!(
+            shell_quote_arg_with_settings("50%$HOME`id`", &posix),
+            "'50%$HOME`id`'",
+            "a POSIX shell needs single quotes; cmd rules would emit %% and leave $/` live"
+        );
+
+        let cmd = ScriptSettings {
+            script_shell: Some(PathBuf::from(r"C:\Windows\System32\cmd.exe")),
+            ..Default::default()
+        };
+        assert_eq!(
+            shell_quote_arg_with_settings("50%", &cmd),
+            r#""50%%""#,
+            "an explicit cmd.exe still gets cmd's percent-doubling"
         );
     }
 }

--- a/vendor/aube/crates/aube-util/src/engine_context.rs
+++ b/vendor/aube/crates/aube-util/src/engine_context.rs
@@ -358,6 +358,28 @@ pub struct EngineContext {
     /// kinds that carry no checksum (npm/yarn/bun): stored and computed both
     /// resolve to `None`, so the check is a no-op.
     pub enforce_package_extensions_checksum: bool,
+
+    /// Replacement DEFAULT shell for every lifecycle-script spawn, used only
+    /// when the user configured no `script-shell` (which still wins). `None`
+    /// (default) keeps aube's platform default — `sh -c` on Unix, `cmd.exe
+    /// /d /s /c` on Windows.
+    ///
+    /// Exists for the Windows default specifically: an embedder that runs the
+    /// same POSIX script bodies through its own surfaces wants ONE shell, and
+    /// a POSIX shell is the more robust choice under an OS sandbox because it
+    /// needs no filesystem-ancestor repair to behave correctly. aube itself
+    /// takes no position — it consumes whatever the embedder resolved.
+    pub default_script_shell: Option<ScriptShell>,
+}
+
+/// A shell invocation: the program plus the leading args that precede the
+/// script body. Two args are needed because a multi-call binary dispatches on
+/// an applet name — busybox is spawned as `busybox.exe sh -c <body>`, where a
+/// plain shell takes `<shell> -c <body>`.
+#[derive(Clone, Debug)]
+pub struct ScriptShell {
+    pub program: PathBuf,
+    pub args: Vec<String>,
 }
 
 impl Default for EngineContext {
@@ -388,6 +410,7 @@ impl Default for EngineContext {
             named_registries_enabled: false,
             embedder_package_extensions: None,
             enforce_package_extensions_checksum: false,
+            default_script_shell: None,
         }
     }
 }

--- a/vendor/aube/crates/aube-util/src/lib.rs
+++ b/vendor/aube/crates/aube-util/src/lib.rs
@@ -35,7 +35,7 @@ pub use identity::{
 // Convenience re-exports for the runtime embedder seam (the per-invocation
 // counterpart to `Embedder`).
 pub use engine_context::{
-    EngineContext, engine_context, set_engine_context, update_engine_context,
+    EngineContext, ScriptShell, engine_context, set_engine_context, update_engine_context,
 };
 pub mod path;
 pub mod pkg;

--- a/vendor/aube/crates/aube/src/commands/script_settings.rs
+++ b/vendor/aube/crates/aube/src/commands/script_settings.rs
@@ -40,16 +40,18 @@ pub(crate) fn configure_script_settings(
         .or_else(|| https_proxy.clone());
     let no_proxy = aube_settings::resolved::no_proxy(ctx).and_then(non_empty_string);
     // Source the embedder-owned overlay from the engine context: an embedder
-    // (e.g. nub) populates `env_overlay` / `path_prepends` on the context, and
-    // this settings pass copies them into `ScriptSettings` for the spawn path
-    // to apply. Reading from the context (not a prior `ScriptSettings`
-    // snapshot) means this pass can't wipe them no matter when it runs. The
-    // `.npmrc`/workspace-derived fields above are the only ones this function
-    // owns. Default-empty on the context ⇒ behavior-preserving.
+    // (e.g. nub) populates `env_overlay` / `path_prepends` /
+    // `default_script_shell` on the context, and this settings pass copies them
+    // into `ScriptSettings` for the spawn path to apply. Reading from the
+    // context (not a prior `ScriptSettings` snapshot) means this pass can't
+    // wipe them no matter when it runs. The `.npmrc`/workspace-derived fields
+    // above are the only ones this function owns. Default-empty on the context
+    // ⇒ behavior-preserving.
     let overlay = aube_util::engine_context();
     aube_scripts::set_script_settings(aube_scripts::ScriptSettings {
         node_options,
         script_shell,
+        default_shell: overlay.default_script_shell,
         unsafe_perm,
         shell_emulator,
         node_bin_dir: runtime.as_ref().and_then(|r| r.bin_dir.clone()),


### PR DESCRIPTION
Dependency lifecycle scripts (`preinstall` / `install` / `postinstall`) ran through `cmd.exe` on Windows, while `nub run` already defaulted to the bundled busybox-w32 `sh`. One POSIX script body therefore behaved differently depending on which Nub surface ran it. This moves the lifecycle path onto the same shell.

## Why

- **One shell.** Only aube's lifecycle spawn still hardcoded `cmd.exe`; `nub run` has defaulted to busybox since it landed. This removes a divergence rather than creating one.
- **No compatibility cost.** A sweep of the 344 widely-used packages that run install scripts found zero of 363 script bodies using cmd-only syntax — no `%VAR%`, `%~dp0`, `if exist`, `copy`/`del`/`rd`, `>nul`, `call`, `set VAR=`, caret escapes, or `.cmd`/`.bat` invocation. POSIX `sh` parses all 363. 144 use forward-slash paths and 6 chain with `&&`.
- **It fixes two packages.** `detox-recorder` and `svf-lib` invoke a shipped `./*.sh` from their postinstall, which `cmd.exe` cannot execute.
- **Fewer moving parts under the sandbox.** Confined in an AppContainer with no filesystem-ancestor repair at all, busybox's `cd`, globbing, redirection, reads, and whole spawn battery are byte-identical to unconfined. `cmd.exe` depends on the sandbox's ancestor repair to report the filesystem correctly, and that repair is best-effort by design — a refused ACE write is skipped rather than fatal, and an ancestor whose DACL names no harvestable capability yields nothing to request.

## Mechanism

A new embedder seam, `EngineContext::default_script_shell`, copied into `ScriptSettings::default_shell` by the settings pass and read by the spawn **only when the user set no `script-shell`**. Precedence is user `script-shell` → embedder default → platform default, so `None` reproduces aube's own behavior exactly.

Nub fills it on Windows with `busybox.exe sh -c`. The applet name has to lead: busybox is a multi-call binary that dispatches on `argv[0]` or a leading applet name, so `busybox.exe -c <body>` selects no shell at all. This is the same form `nub run` passes, and both now resolve the sidecar through the same `resolve_bundled_busybox`. A missing sidecar warns and leaves the engine on `cmd.exe` rather than failing read-only verbs like `nub list` that never spawn a script.

## The quoting audit

Shell selection was duplicated across the spawn and `shell_quote_arg`, which picked its dialect by `cfg(windows)`. Replacing the Windows default with a POSIX shell would have cmd-quoted args that a POSIX shell then reparses: `%` doubles to `%%`, and `$X` / backticks stay live inside the double quotes cmd-quoting emits. Both now derive from one `resolve_shell`, and the dialect follows the resolved program rather than the target platform.

The mismatch was not reachable under Nub today — every live caller passes empty args (`dlx --shell-mode` joins raw, `clean`/`purge` delegate with `&[]`, and aube's own `run`/`exec` are not registered verbs) — but it was one argument away from a silently-wrong command.

## Verification

The Windows differential is `tests/busybox-lifecycle-probe/` — a branch-scoped workflow, no PR needed. One binary installs each case twice and the only variable is whether the `busybox.exe` sidecar is present; its absence reproduces the pre-change `cmd.exe` path exactly. From [run 30527237372](https://github.com/nubjs/nub/actions/runs/30527237372) on `windows-latest`:

| case | control (no sidecar → `cmd.exe`) | with sidecar (`busybox sh -c`) |
| --- | --- | --- |
| `echo "MARK=${LIFECYCLE_PROBE:-posix}" > out.txt && test -d . && …` | **exit 0**, wrote `"MARK=${LIFECYCLE_PROBE:-posix}"  \ndirok` | exit 0, `MARK=posix\ndirok` |
| `./scripts/build.sh` | exit 1, no marker, `'.' is not recognized as an internal or external command` | exit 0, `SH_RAN` |
| `for f in src/*.txt; do cat $f >> out.txt; done` | exit 1, no marker, `f was unexpected at this time.` | exit 0, `A\nB` |

The first row is the one worth noting: `cmd.exe` exited **0** while writing the wrong bytes.

Three broken controls were found and fixed while building that probe, each of which had made a control agree with the expected answer for the wrong reason:

- A shared fixture let one case's lifecycle failure abort the `JoinSet` driving the parallel pass, killing sibling scripts mid-write — one marker came back truncated and another never appeared.
- The side-effects cache is on by default and keys on `(name, version, engine, input hash)`; the shell is not in the key, so the second arm hardlinked the first arm's built tree back and never ran the script.
- A shared package name let the content-addressed store serve one case's built directory to all three, so every case reported the first case's marker.

The probe now also asserts its own setup (`approve-builds` actually approved the build in each arm) and requires the split in **both** directions, so a case that behaves identically under both shells is reported as a failure rather than a pass.

Promoted into the committed suite:

- `install_runs_lifecycle_scripts_under_a_posix_shell` (`crates/nub-cli/tests/pm_augment.rs`) — a root postinstall whose body is POSIX-only, so a regression fails the install instead of passing quietly. Runs on every platform; on Windows CI it is the regression guard.
- `embedder_default_leading_args_survive_a_real_spawn` (`aube-scripts`) — spawns through the `<program> <applet> -c <body>` form using `/usr/bin/env` as a same-shaped stand-in, so the form is exercised on a platform this suite can run. Negative control: replacing `spec.args` with `vec!["-c"]` fails this test and the structural one, and leaves the other three green.
- `busybox_lifecycle_shell_leads_with_the_sh_applet_name` (`pm_engine`) — pins the applet form, a Windows-only breakage no other test here would see.

Gates, all from the worktree:

```
cargo fmt --check                                                  clean (nub + the four aube files)
cargo clippy --all-targets --all-features --profile fast -- -D warnings   clean
cargo test                                                         green, full nub suite
cargo test (vendor/aube)                                           green, full aube suite
```

Four `integration.rs` transpile tests failed on the first run and were **not** related to this change — the worktree had no root `node_modules`, so `@oxc-project/runtime` was unresolvable. Confirmed by running `npm ci` and re-running: 213 passed, 0 failed.

## Not verified

- Whether `cmd.exe`'s AppContainer behavior is repaired by the sandbox's production ancestor grant. That is being re-measured separately and this change does not depend on the answer.
- The win32-arm64 sidecar, `busybox64a.exe`. The probe runs on `windows-latest`, which is x64, so the arm64 sidecar is exercised only by the release matrix.

