### PR TITLE
sandbox(win): write the ancestor traverse ace with SetKernelObjectSecurity

### DIFF
--- a/.github/workflows/win-jail-repairs-probe.yml
+++ b/.github/workflows/win-jail-repairs-probe.yml
@@ -17,13 +17,19 @@
 #
 # The icacls dump is a FACT, not a gate: it names the capability SIDs on `C:\` and `C:\Users`
 # that the backend harvests, which is what makes the ancestors reachable without elevation.
+#
+# THE COST GROUP. Repair 1's ace is written per lifecycle SPAWN, and the propagating writer it
+# used to go through wedged a 20-minute step and stalled three runs of this probe. It now writes
+# through `SetKernelObjectSecurity`. `ace-cost-named-writer-scales-with-tree` is that group's
+# control — a run where the propagating writer did NOT slow down on the populated tree measured
+# nothing, so it is gated as a PASS alongside the kernel cells rather than reported as a fact.
 name: win-jail-repairs-probe
 
 on:
   push:
     # Path-filtered so a change to a SIBLING probe does not spend ~25 minutes of Windows runner
     # on this one. Shared capacity: every push here costs the full matrix.
-    branches: [sandbox/win-jail-caps]
+    branches: [sandbox/win-jail-caps, sandbox/win-ace-kernel]
     paths:
       - 'crates/nub-sandbox/**'
       - '.github/workflows/win-jail-repairs-probe.yml'
@@ -139,6 +145,33 @@ jobs:
             grep -E "prop:$p=" probe.log || true
           done
           done
+
+          echo "---- what the ancestor ace costs (the SetKernelObjectSecurity claim) ----"
+          # The named-writer cell is the control: if the propagating writer did NOT slow down on
+          # the populated tree, the walk never reproduced here and the kernel numbers are noise.
+          for p in ace-cost-named-writer-scales-with-tree \
+                   ace-cost-kernel-writer-flat-in-tree-size \
+                   ace-cost-kernel-beats-named-on-populated-tree \
+                   ace-cost-real-temp-under-a-second \
+                   ace-lands-with-exact-traverse-mask \
+                   ace-carries-no-inheritance-flags \
+                   ace-absent-on-child-directory \
+                   ace-revoke-removes-it \
+                   ace-preserves-dacl-control-bits; do
+            need_pass "$p"
+          done
+          need "  fact:ace-cost-us "
+
+          echo "---- the already-AppContainer-readable skip ----"
+          for p in aap-skip-declines-a-protected-fixture-root \
+                   aap-skip-sees-the-seeded-grant \
+                   aap-skip-child-still-reads-the-tool \
+                   aap-skip-leaves-the-preexisting-ace-alone; do
+            need_pass "$p"
+          done
+          # Whether the machine's own %ProgramFiles% publishes read to AppContainers is a FACT,
+          # not a gate: the skip is an optimisation and a machine without it simply pays.
+          grep -E 'fact:aap-readable-' probe.log || { echo "MISS the AAP-readability facts"; fail=1; }
 
           echo "---- ancestor reachability ----"
           for p in repair-on-lstat-c-root-permitted \

--- a/crates/nub-sandbox/LIMITATIONS.md
+++ b/crates/nub-sandbox/LIMITATIONS.md
@@ -482,13 +482,24 @@ OPENABLE under an ORDINARY `%TEMP%`/profile tree with no `C:\`-owned store (VM-v
   because the runner was ELEVATED and could write the DACLs on `C:\` and `C:\Users` directly.
   A standard non-elevated user can write neither, so the reachability of those two roots off an
   elevated machine remains an open question.
-- **The ancestor ACE write is not yet affordable (OPEN).** Any DACL write on a large shared
-  ancestor propagates inheritance across its subtree, and `%TEMP%` is on the chain. Measured on
-  windows-latest the write stalls for minutes with a duration that varies run to run, which is
-  what keeps the piped-stdio measurements from running at all. `SetKernelObjectSecurity` is the
-  non-propagating primitive this wants; until then the repair works and costs too much per
-  lifecycle spawn to turn on. **Secondary to the blocker below** — cost only matters for a
+- **The ancestor ACE write is affordable now: 630 µs on the runner's own `%TEMP%`, where it used
+  to stall for minutes.** Any DACL write through `Set*SecurityInfo` runs advapi32's inheritance
+  propagation over the object's existing subtree before returning, and `%TEMP%` is on the chain,
+  so the write took minutes with a duration that varied run to run — which is what kept the
+  piped-stdio measurements from running at all. `SetKernelObjectSecurity` goes straight to
+  `NtSetSecurityObject`, where there is no propagation pass. Measured against the writer it
+  replaced on the same path with the same trustee in the same run (`ace-cost` in
+  `tests/windows_jail_repairs.rs`, run 30528232196): 131 µs versus 534,378 µs on a 4,000-entry
+  tree, and a re-grant with the ace already present costs the same as a fresh one — a descriptor
+  write, not a tree walk. **Still secondary to the blocker below** — cost only matters for a
   mechanism that is available, and above the user profile this one is not.
+- **A leaf grant still propagates, because it is inheritable by design — so it is SKIPPED where
+  the target already publishes it.** `%ProgramFiles%` carries `ALL APPLICATION PACKAGES:
+  ReadAndExecute` inheritably (`aap-readable-programfiles=true`, with `nodejs` the measured
+  outlier), so an all-users python or node needs no ace at all; per-user layouts such as the
+  runner's `hostedtoolcache` carry none and still pay. Narrowing the grant instead is not
+  available: a narrow python grant fails `0xc0000135 STATUS_DLL_NOT_FOUND` because
+  `python3.dll`, `python312.dll` and `vcruntime140*.dll` sit in the install root beside the exe.
 
 - **BLOCKER: `C:\` and `C:\Users` are unreachable to an unprivileged AppContainer, on every image
   measured.** Surveyed read-only across three runner images, each labelled, `Get-Acl` only:

--- a/crates/nub-sandbox/src/backend/mod.rs
+++ b/crates/nub-sandbox/src/backend/mod.rs
@@ -122,7 +122,10 @@ pub fn earliest_bootstrap() -> std::io::Result<RuntimeCapability> {
 mod windows;
 #[cfg(target_os = "windows")]
 #[doc(hidden)]
-pub use windows::{windows_ancestor_capability_sids, windows_capability_fallbacks};
+pub use windows::{
+    windows_ancestor_capability_sids, windows_capability_fallbacks, windows_leaf_grant_redundant,
+    windows_object_traverse_ace,
+};
 
 // The Windows dedicated-account + WFP backend (agent-sandbox). Same cfg as `windows` so its
 // OS-agnostic plan derivation and mode-selection are unit-tested on the macOS dev host.

--- a/crates/nub-sandbox/src/backend/windows.rs
+++ b/crates/nub-sandbox/src/backend/windows.rs
@@ -856,6 +856,29 @@ pub fn windows_capability_fallbacks() -> u64 {
     launch::CAPABILITY_FALLBACKS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Place (`grant`) or remove the ancestor repair's non-inherited traverse ace on `dir` for
+/// `sddl`, so the probe can TIME the real writer against its own copy of the propagating one —
+/// same trustee, same path, same run. Nothing else attributes a cost difference to the primitive
+/// rather than to the machine, and the cost is the entire claim.
+#[cfg(target_os = "windows")]
+#[doc(hidden)]
+pub fn windows_object_traverse_ace(
+    dir: &std::path::Path,
+    sddl: &str,
+    grant: bool,
+) -> std::io::Result<()> {
+    launch::object_traverse_ace(dir, sddl, grant)
+}
+
+/// Whether `dir` already publishes read+execute to every AppContainer inheritably, i.e. whether
+/// a leaf read grant on it is a no-op. Which paths do is a property of the MACHINE's default
+/// ACLs, so the probe reports it rather than asserting it.
+#[cfg(target_os = "windows")]
+#[doc(hidden)]
+pub fn windows_leaf_grant_redundant(dir: &std::path::Path) -> bool {
+    launch::leaf_read_grant_redundant(dir)
+}
+
 // ── the FFI launcher ────────────────────────────────────────────────────────────
 
 #[cfg(target_os = "windows")]
@@ -1039,6 +1062,130 @@ pub(super) mod launch {
         Ok(())
     }
 
+    /// The FILE-object form of the generic rights the leaf grants are expressed in. Windows
+    /// applies this mapping itself when it evaluates an ace, and an effective-rights query
+    /// reports the RESULT — so a comparison against a generic mask has to map first or every
+    /// answer comes back "not granted". Bits that are already specific (`DELETE`) pass through.
+    fn file_specific_rights(generic: u32) -> u32 {
+        const FILE_GENERIC_READ: u32 = 0x0012_0089;
+        const FILE_GENERIC_WRITE: u32 = 0x0012_0116;
+        const FILE_GENERIC_EXECUTE: u32 = 0x0012_00a0;
+        let mut out = generic & !(GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE);
+        if generic & GENERIC_READ != 0 {
+            out |= FILE_GENERIC_READ;
+        }
+        if generic & GENERIC_WRITE != 0 {
+            out |= FILE_GENERIC_WRITE;
+        }
+        if generic & GENERIC_EXECUTE != 0 {
+            out |= FILE_GENERIC_EXECUTE;
+        }
+        out
+    }
+
+    /// Whether `path` ALREADY grants every right in `access` to AppContainers generally, through
+    /// an INHERITABLE ace — i.e. whether the ace [`grant_leaf_ace`] is about to write would
+    /// change nothing.
+    ///
+    /// This is worth a DACL read because the WRITE is the expensive half. An inheritable grant
+    /// legitimately propagates through the subtree, and a populated toolchain tree makes that
+    /// cost real: measured on windows-latest, granting the runner's `hostedtoolcache` python took
+    /// ~1000 ms against 3 ms on an empty directory, and a re-grant with the ace already present
+    /// cost the same as a fresh one — the signature of a tree walk, not a descriptor write.
+    /// Narrowing the grant is not an alternative: `Lib\` at 6,412 entries IS the tree, and a
+    /// narrow grant fails `0xc0000135 STATUS_DLL_NOT_FOUND` because `python3.dll`,
+    /// `python312.dll` and `vcruntime140*.dll` sit in the install ROOT beside the exe.
+    ///
+    /// It applies broadly, not just to python: `%ProgramFiles%` carries
+    /// `ALL APPLICATION PACKAGES: ReadAndExecute` inheritably on both Windows images (43 of the
+    /// 44 `C:\Program Files` children; `nodejs` is the known outlier), so an all-users python,
+    /// node, or Visual Studio install needs no grant at all. Only per-user layouts pay, which is
+    /// why `hostedtoolcache` — carrying none — is the one that measured.
+    ///
+    /// INHERITABLE is required rather than incidental: the ace being skipped covers the whole
+    /// subtree, so a this-directory-only AAP ace does not substitute for it. Same distinction
+    /// `verify_clean_root` draws above, for the same reason. Any failure to read the DACL answers
+    /// "no" and the grant is written — the skip is an optimisation and must never be the reason a
+    /// package cannot start.
+    ///
+    /// No conflict with `verify_clean_root`'s refusal to launch under an AAP-readable root: that
+    /// governs the working root's own chain, this governs granted paths OUTSIDE it. A toolchain
+    /// the OS already publishes to every AppContainer is not access nub is adding.
+    fn already_granted_to_appcontainers(path: &Path, access: u32) -> bool {
+        let sid_text = to_wide(ALL_APPLICATION_PACKAGES_SID);
+        let mut aap_sid: PSID = std::ptr::null_mut();
+        if unsafe { ConvertStringSidToSidW(sid_text.as_ptr(), &mut aap_sid) } == 0 {
+            return false;
+        }
+        let _sid = LocalFreeGuard(aap_sid.cast());
+
+        let wpath = to_wide_path(path);
+        let mut dacl: *mut ACL = std::ptr::null_mut();
+        let mut sd: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+        let rc = unsafe {
+            GetNamedSecurityInfoW(
+                wpath.as_ptr(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut dacl,
+                std::ptr::null_mut(),
+                &mut sd,
+            )
+        };
+        if rc != 0 {
+            return false;
+        }
+        let _sd = LocalFreeGuard(sd);
+        if dacl.is_null() || !has_inheritable_ace(dacl, aap_sid) {
+            return false;
+        }
+
+        let trustee = TRUSTEE_W {
+            pMultipleTrustee: std::ptr::null_mut(),
+            MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_USER,
+            ptstrName: aap_sid.cast(),
+        };
+        let mut rights = 0u32;
+        if unsafe { GetEffectiveRightsFromAclW(dacl, &trustee, &mut rights) } != 0 {
+            return false;
+        }
+        let needed = file_specific_rights(access);
+        rights & needed == needed
+    }
+
+    /// Install one leaf allow-ace, reporting whether an ace was actually written.
+    ///
+    /// The return value is the ONLY thing the teardown list is driven from, which is what keeps
+    /// grant and revoke symmetric BY CONSTRUCTION: a skipped path is never recorded, so the
+    /// teardown cannot strip an ace this launch did not create. Two independent conditionals
+    /// would make that a coincidence instead of a property — and stripping
+    /// `ALL APPLICATION PACKAGES` off `%ProgramFiles%\nodejs` would be a lasting change to the
+    /// user's own machine.
+    fn grant_leaf_ace(path: &Path, sid: PSID, access: u32) -> io::Result<bool> {
+        if already_granted_to_appcontainers(path, access) {
+            return Ok(false);
+        }
+        set_ace(path, sid, access, GRANT_ACCESS, true).map(|()| true)
+    }
+
+    /// See [`super::windows_object_traverse_ace`].
+    #[doc(hidden)]
+    pub(super) fn object_traverse_ace(dir: &Path, sddl: &str, grant: bool) -> io::Result<()> {
+        let sid = CapSid::new(sddl)?;
+        let mode = if grant { GRANT_ACCESS } else { REVOKE_ACCESS };
+        set_ace_on_object(dir, sid.0, TRAVERSE_MASK, mode)
+    }
+
+    /// See [`super::windows_leaf_grant_redundant`].
+    #[doc(hidden)]
+    pub(super) fn leaf_read_grant_redundant(dir: &Path) -> bool {
+        already_granted_to_appcontainers(dir, GENERIC_READ | GENERIC_EXECUTE)
+    }
+
     /// Each granted path's STRICT ancestors, deduped and ordered shallowest-first. These are
     /// the directories Node's `realpathSync` opens as targets on its way to a granted leaf. A
     /// grant that is itself an ancestor of another grant is included, and simply takes the
@@ -1157,25 +1304,41 @@ pub(super) mod launch {
     ///
     /// `FILE_FLAG_BACKUP_SEMANTICS` is what lets `CreateFileW` open a DIRECTORY at all.
     ///
-    /// STILL NOT ENOUGH, measured — do not read the paragraph above as settled. Run
-    /// 30493913027's watchdog pinned the remaining stall to the FIRST launch that writes these
-    /// aces, and the only WRITE in that window is this function (`verify_clean_root` and
-    /// `harvest_capability_sids` merely read DACLs). For file objects `SetSecurityInfo` still
-    /// propagates inheritance to existing children, so trading the named writer for the
-    /// handle-based one narrowed nothing: the chain includes `%TEMP%`, which on a CI runner is
-    /// enormous, and the walk takes minutes and varies from run to run. The genuinely
-    /// non-propagating primitive is `SetKernelObjectSecurity`, which wants a hand-built
-    /// descriptor (`InitializeSecurityDescriptor` + `SetSecurityDescriptorDacl`) instead of
-    /// `SetEntriesInAclW`'s convenience — that is the next move, and nothing else about the
-    /// repair changes with it.
+    /// `SetSecurityInfo` WAS NOT ENOUGH EITHER, and that is why the writer below is the kernel
+    /// one. Both `Set*SecurityInfo` entry points run advapi32's user-mode inheritance
+    /// propagation before they return, so swapping the named writer for the handle-based one
+    /// narrowed nothing: run 30493913027's watchdog pinned the remaining stall to the FIRST
+    /// launch that writes these aces, and the only WRITE in that window is this function
+    /// (`verify_clean_root` and `harvest_capability_sids` merely read DACLs). The chain includes
+    /// `%TEMP%`, which on a CI runner is enormous, so the walk took minutes and varied run to
+    /// run. `SetKernelObjectSecurity` goes straight to `NtSetSecurityObject`: it writes the
+    /// object's own descriptor and there is no propagation pass to skip. Measured on
+    /// windows-latest, the `ace-cost` group of `tests/windows_jail_repairs.rs`, same trustee and
+    /// same path in the same run — see that group's own comment for the numbers.
+    ///
+    /// The price is that it wants a whole SECURITY_DESCRIPTOR rather than a bare ACL, hence the
+    /// hand-built one below. `SetEntriesInAclW` still does the MERGE — it only assembles an ACL
+    /// in memory and propagates nothing; the cost was never there.
+    ///
+    /// SE_DACL_AUTO_INHERITED and SE_DACL_PROTECTED are carried across DELIBERATELY. A
+    /// hand-built descriptor starts with a zero control word, and writing that back would clear
+    /// both bits on a directory nub does not own — changing how the user's own ACL edits later
+    /// propagate through their profile or temp dir. This repair is only ever allowed to add and
+    /// remove one traverse ace.
     fn set_ace_on_object(path: &Path, sid: PSID, access: u32, mode: i32) -> io::Result<()> {
-        use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SetSecurityInfo};
+        use windows_sys::Win32::Security::Authorization::GetSecurityInfo;
+        use windows_sys::Win32::Security::{
+            InitializeSecurityDescriptor, SE_DACL_AUTO_INHERITED, SECURITY_DESCRIPTOR,
+            SetKernelObjectSecurity, SetSecurityDescriptorControl, SetSecurityDescriptorDacl,
+        };
         use windows_sys::Win32::Storage::FileSystem::{
             CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_DELETE, FILE_SHARE_READ,
             FILE_SHARE_WRITE, OPEN_EXISTING,
         };
         const READ_CONTROL: u32 = 0x0002_0000;
         const WRITE_DAC: u32 = 0x0004_0000;
+        const SECURITY_DESCRIPTOR_REVISION: u32 = 1;
+        const CARRIED_CONTROL: u16 = SE_DACL_AUTO_INHERITED | SE_DACL_PROTECTED;
 
         let _lock: MutexGuard<'_, ()> = ACL_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let wpath = to_wide_path(path);
@@ -1215,6 +1378,12 @@ pub(super) mod launch {
         }
         let _sd = LocalFreeGuard(sd);
 
+        let mut control = 0u16;
+        let mut revision = 0u32;
+        if unsafe { GetSecurityDescriptorControl(sd, &mut control, &mut revision) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
         let mut ea: EXPLICIT_ACCESS_W = unsafe { std::mem::zeroed() };
         ea.grfAccessPermissions = access;
         ea.grfAccessMode = mode;
@@ -1226,25 +1395,29 @@ pub(super) mod launch {
             TrusteeType: TRUSTEE_IS_USER,
             ptstrName: sid.cast(),
         };
+        // Merges into the aces already there, INHERITED_ACE flags intact, so the descriptor
+        // written below differs from the one read above by exactly this one ace.
         let mut new_dacl: *mut ACL = std::ptr::null_mut();
         let rc = unsafe { SetEntriesInAclW(1, &ea, old_dacl, &mut new_dacl) };
         if rc != 0 {
             return Err(io::Error::from_raw_os_error(rc as i32));
         }
         let _new = LocalFreeGuard(new_dacl.cast());
-        let rc = unsafe {
-            SetSecurityInfo(
-                handle,
-                SE_FILE_OBJECT,
-                DACL_SECURITY_INFORMATION,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-                new_dacl,
-                std::ptr::null_mut(),
-            )
-        };
-        if rc != 0 {
-            return Err(io::Error::from_raw_os_error(rc as i32));
+
+        let mut fresh: SECURITY_DESCRIPTOR = unsafe { std::mem::zeroed() };
+        let psd: PSECURITY_DESCRIPTOR = std::ptr::from_mut(&mut fresh).cast();
+        // SAFETY: `fresh` is a stack SECURITY_DESCRIPTOR that does not move; `new_dacl` outlives
+        // the write (`_new` drops after it). The absolute form is what SetKernelObjectSecurity
+        // documents for this pattern.
+        unsafe {
+            if InitializeSecurityDescriptor(psd, SECURITY_DESCRIPTOR_REVISION) == 0
+                || SetSecurityDescriptorDacl(psd, 1, new_dacl, 0) == 0
+                || SetSecurityDescriptorControl(psd, CARRIED_CONTROL, control & CARRIED_CONTROL)
+                    == 0
+                || SetKernelObjectSecurity(handle, DACL_SECURITY_INFORMATION, psd) == 0
+            {
+                return Err(io::Error::last_os_error());
+            }
         }
         Ok(())
     }
@@ -1499,50 +1672,37 @@ pub(super) mod launch {
             //    read/write grants are INHERITABLE (cover the subtree). Ancestors are
             //    handled separately, in step 2b. A REVOKE_ACCESS teardown on the unique SID
             //    removes exactly our ACEs from every path, whatever the access mask.
+            //
+            //    Both kinds run through ONE loop so the teardown list is populated from a
+            //    single decision — see [`grant_leaf_ace`], which may report that the path
+            //    already grants AppContainers what we were about to add.
             let mut _aces = AceGuard {
                 paths: Vec::new(),
                 objects: Vec::new(),
                 sid: sid_copy,
             };
-            for dir in &self.read_grants {
-                set_ace(
-                    dir,
-                    ac_sid,
-                    GENERIC_READ | GENERIC_EXECUTE,
-                    GRANT_ACCESS,
-                    true,
-                )
-                .map_err(|error| {
+            let leaves = self
+                .read_grants
+                .iter()
+                .map(|d| ("read", d, GENERIC_READ | GENERIC_EXECUTE))
+                .chain(self.write_grants.iter().map(|d| {
+                    (
+                        "write",
+                        d,
+                        GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE | DELETE,
+                    )
+                }));
+            for (kind, dir, access) in leaves {
+                let installed = grant_leaf_ace(dir, ac_sid, access).map_err(|error| {
                     io::Error::new(
                         error.kind(),
                         format!(
-                            "sandbox: installing read grant ACE on {} failed: {error}",
+                            "sandbox: installing {kind} grant ACE on {} failed: {error}",
                             dir.display()
                         ),
                     )
                 })?;
-                if !_aces.paths.contains(dir) {
-                    _aces.paths.push(dir.clone());
-                }
-            }
-            for dir in &self.write_grants {
-                set_ace(
-                    dir,
-                    ac_sid,
-                    GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE | DELETE,
-                    GRANT_ACCESS,
-                    true,
-                )
-                .map_err(|error| {
-                    io::Error::new(
-                        error.kind(),
-                        format!(
-                            "sandbox: installing write grant ACE on {} failed: {error}",
-                            dir.display()
-                        ),
-                    )
-                })?;
-                if !_aces.paths.contains(dir) {
+                if installed && !_aces.paths.contains(dir) {
                     _aces.paths.push(dir.clone());
                 }
             }

--- a/crates/nub-sandbox/src/lib.rs
+++ b/crates/nub-sandbox/src/lib.rs
@@ -114,7 +114,10 @@ pub use backend::{
 };
 #[cfg(target_os = "windows")]
 #[doc(hidden)]
-pub use backend::{windows_ancestor_capability_sids, windows_capability_fallbacks};
+pub use backend::{
+    windows_ancestor_capability_sids, windows_capability_fallbacks, windows_leaf_grant_redundant,
+    windows_object_traverse_ace,
+};
 
 /// The Linux enforcement suites' skip gate, resolving Bubblewrap candidates the way
 /// production does. Test support, not an embedder API.

--- a/crates/nub-sandbox/tests/windows_jail_repairs.rs
+++ b/crates/nub-sandbox/tests/windows_jail_repairs.rs
@@ -716,6 +716,544 @@ mod win {
         out
     }
 
+    // ── group 0: what the ancestor ace COSTS ─────────────────────────────────────────
+    //
+    // The ancestor repair is what makes the Windows jail work unprivileged, and its cost is
+    // per lifecycle SPAWN, so a slow writer is not a wart — it is what wedged a 20-minute CI
+    // step and stalled three runs of this very probe. `backend/windows.rs` now writes the
+    // traverse ace with `SetKernelObjectSecurity`, which goes straight to
+    // `NtSetSecurityObject` and has no user-mode inheritance-propagation pass. This group is
+    // the measurement of that claim, and it is a TIMING claim, so it needs a differential.
+    //
+    // THE CONTROL IS LOCAL, DELIBERATELY. `named_propagating_ace` below is a copy of the
+    // writer the backend used to call. It lives here rather than in the product because a
+    // second writer reachable from `apply` would be dead weight the moment this lands — and
+    // because the comparison it enables is only worth anything run on the SAME path with the
+    // SAME trustee in the SAME run. One variable: which primitive writes the descriptor.
+    //
+    // THE TREE IS SYNTHETIC, ALSO DELIBERATELY. `%TEMP%` on a hosted runner is enormous but
+    // its size is unknown and varies run to run, so it cannot be the empty-directory control's
+    // counterpart. Two sibling directories under one fixture root — identical DACL, identical
+    // volume, differing only in descendant count — can. `%TEMP%` is still measured, with the
+    // kernel writer only: it is the path that actually stalled, and the propagating writer on
+    // it is unbounded by construction.
+    //
+    // WHAT THIS GROUP DOES NOT MEASURE, because a sibling group already does: whether the ace
+    // reaches the confined child, and whether it stops at the directory object. Both now run
+    // through this writer, so `repair-on-lstat-chain-permitted` is the effect proof and
+    // `repair-on-ancestor-sibling-read-refused` is the scope proof. What is asserted HERE is
+    // the DACL-level shape (present, non-inherited, exact mask, absent on a child) and that
+    // the descriptor's control bits survive a grant/revoke round trip — the hand-built
+    // descriptor starts with a zero control word, so carrying those bits is a property of the
+    // new code with nothing else watching it.
+
+    /// Descendants under the populated arm. Sized against python's `Lib\` at 6,412 entries —
+    /// the tree that measured ~1000 ms — so the propagating writer has something real to walk.
+    const POPULATED_ENTRIES: usize = 4000;
+
+    mod ace {
+        use std::io;
+        use std::path::Path;
+        use windows_sys::Win32::Foundation::{
+            CloseHandle, HANDLE, INVALID_HANDLE_VALUE, LocalFree,
+        };
+        use windows_sys::Win32::Security::Authorization::{
+            ConvertSidToStringSidW, ConvertStringSidToSidW, EXPLICIT_ACCESS_W, GRANT_ACCESS,
+            GetNamedSecurityInfoW, GetSecurityInfo, NO_MULTIPLE_TRUSTEE, REVOKE_ACCESS,
+            SE_FILE_OBJECT, SetEntriesInAclW, SetSecurityInfo, TRUSTEE_IS_SID, TRUSTEE_IS_USER,
+            TRUSTEE_W,
+        };
+        use windows_sys::Win32::Security::Isolation::{
+            CreateAppContainerProfile, DeleteAppContainerProfile,
+        };
+        use windows_sys::Win32::Security::{
+            ACCESS_ALLOWED_ACE, ACE_HEADER, ACL, CONTAINER_INHERIT_ACE, DACL_SECURITY_INFORMATION,
+            EqualSid, GetAce, GetSecurityDescriptorControl, OBJECT_INHERIT_ACE,
+            PSECURITY_DESCRIPTOR, PSID,
+        };
+        use windows_sys::Win32::Storage::FileSystem::{
+            CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_DELETE, FILE_SHARE_READ,
+            FILE_SHARE_WRITE, OPEN_EXISTING,
+        };
+
+        /// Byte-identical to the backend's `TRAVERSE_MASK`, so the two writers are asked for
+        /// the same thing and a cost difference cannot be a mask difference.
+        pub const TRAVERSE_MASK: u32 = 0x0010_00a1;
+        pub const INHERIT_FLAGS: u32 = CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE;
+        const NO_INHERITANCE: u32 = 0x0;
+        const READ_CONTROL: u32 = 0x0002_0000;
+        const WRITE_DAC: u32 = 0x0004_0000;
+
+        fn wide(s: &str) -> Vec<u16> {
+            s.encode_utf16().chain(std::iter::once(0)).collect()
+        }
+        fn wide_path(p: &Path) -> Vec<u16> {
+            wide(&p.to_string_lossy())
+        }
+
+        /// An ephemeral AppContainer identity, used purely as a trustee. Unique per run and
+        /// deleted on drop, so an ace this probe fails to remove names a SID that no longer
+        /// resolves rather than a real principal.
+        pub struct Trustee {
+            name: Vec<u16>,
+            pub sddl: String,
+        }
+        impl Trustee {
+            pub fn new() -> io::Result<Self> {
+                let nonce = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos();
+                let name = wide(&format!("nub_acecost_{}_{nonce:x}", std::process::id()));
+                let mut sid: PSID = std::ptr::null_mut();
+                let hr = unsafe {
+                    CreateAppContainerProfile(
+                        name.as_ptr(),
+                        name.as_ptr(),
+                        name.as_ptr(),
+                        std::ptr::null(),
+                        0,
+                        &mut sid,
+                    )
+                };
+                if hr != 0 {
+                    return Err(io::Error::other(format!(
+                        "CreateAppContainerProfile failed hr=0x{hr:08x}"
+                    )));
+                }
+                let mut out: *mut u16 = std::ptr::null_mut();
+                let ok = unsafe { ConvertSidToStringSidW(sid, std::ptr::from_mut(&mut out)) };
+                unsafe { LocalFree(sid.cast()) };
+                if ok == 0 {
+                    let e = io::Error::last_os_error();
+                    unsafe { DeleteAppContainerProfile(name.as_ptr()) };
+                    return Err(e);
+                }
+                let mut len = 0usize;
+                while unsafe { *out.add(len) } != 0 {
+                    len += 1;
+                }
+                let sddl =
+                    String::from_utf16_lossy(unsafe { std::slice::from_raw_parts(out, len) });
+                unsafe { LocalFree(out.cast()) };
+                Ok(Trustee { name, sddl })
+            }
+        }
+        impl Drop for Trustee {
+            fn drop(&mut self) {
+                unsafe { DeleteAppContainerProfile(self.name.as_ptr()) };
+            }
+        }
+
+        struct Sid(PSID);
+        impl Sid {
+            fn new(sddl: &str) -> io::Result<Self> {
+                let w = wide(sddl);
+                let mut sid: PSID = std::ptr::null_mut();
+                if unsafe { ConvertStringSidToSidW(w.as_ptr(), &mut sid) } == 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                Ok(Sid(sid))
+            }
+        }
+        impl Drop for Sid {
+            fn drop(&mut self) {
+                unsafe { LocalFree(self.0.cast()) };
+            }
+        }
+
+        struct Handle(HANDLE);
+        impl Drop for Handle {
+            fn drop(&mut self) {
+                unsafe { CloseHandle(self.0) };
+            }
+        }
+
+        /// THE CONTROL WRITER: what `backend/windows.rs` called before this change. Identical
+        /// handle, identical merged DACL, identical non-inherited traverse ace — the only
+        /// difference is that `SetSecurityInfo` runs advapi32's inheritance propagation over
+        /// the directory's existing children before it returns.
+        pub fn named_propagating_ace(dir: &Path, sddl: &str, grant: bool) -> io::Result<()> {
+            let sid = Sid::new(sddl)?;
+            let wpath = wide_path(dir);
+            let handle = unsafe {
+                CreateFileW(
+                    wpath.as_ptr(),
+                    READ_CONTROL | WRITE_DAC,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    std::ptr::null(),
+                    OPEN_EXISTING,
+                    FILE_FLAG_BACKUP_SEMANTICS,
+                    std::ptr::null_mut(),
+                )
+            };
+            if handle == INVALID_HANDLE_VALUE {
+                return Err(io::Error::last_os_error());
+            }
+            let _h = Handle(handle);
+
+            let mut old: *mut ACL = std::ptr::null_mut();
+            let mut sd: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+            let rc = unsafe {
+                GetSecurityInfo(
+                    handle,
+                    SE_FILE_OBJECT,
+                    DACL_SECURITY_INFORMATION,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    &mut old,
+                    std::ptr::null_mut(),
+                    &mut sd,
+                )
+            };
+            if rc != 0 {
+                return Err(io::Error::from_raw_os_error(rc as i32));
+            }
+            let mut ea: EXPLICIT_ACCESS_W = unsafe { std::mem::zeroed() };
+            ea.grfAccessPermissions = TRAVERSE_MASK;
+            ea.grfAccessMode = if grant { GRANT_ACCESS } else { REVOKE_ACCESS };
+            ea.grfInheritance = NO_INHERITANCE;
+            ea.Trustee = TRUSTEE_W {
+                pMultipleTrustee: std::ptr::null_mut(),
+                MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+                TrusteeForm: TRUSTEE_IS_SID,
+                TrusteeType: TRUSTEE_IS_USER,
+                ptstrName: sid.0.cast(),
+            };
+            let mut new: *mut ACL = std::ptr::null_mut();
+            let rc = unsafe { SetEntriesInAclW(1, &ea, old, &mut new) };
+            unsafe { LocalFree(sd.cast()) };
+            if rc != 0 {
+                return Err(io::Error::from_raw_os_error(rc as i32));
+            }
+            let rc = unsafe {
+                SetSecurityInfo(
+                    handle,
+                    SE_FILE_OBJECT,
+                    DACL_SECURITY_INFORMATION,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    new,
+                    std::ptr::null_mut(),
+                )
+            };
+            unsafe { LocalFree(new.cast()) };
+            if rc != 0 {
+                return Err(io::Error::from_raw_os_error(rc as i32));
+            }
+            Ok(())
+        }
+
+        /// `(access_mask, ace_flags)` of every ace on `dir` naming `sddl`. Empty ⇒ no ace.
+        pub fn aces_for(dir: &Path, sddl: &str) -> io::Result<Vec<(u32, u32)>> {
+            let sid = Sid::new(sddl)?;
+            let (dacl, sd) = read_dacl(dir)?;
+            let mut out = Vec::new();
+            if !dacl.is_null() {
+                unsafe {
+                    for i in 0..(*dacl).AceCount as u32 {
+                        let mut ace: *mut std::ffi::c_void = std::ptr::null_mut();
+                        if GetAce(dacl, i, &mut ace) == 0 {
+                            continue;
+                        }
+                        let allow = ace.cast::<ACCESS_ALLOWED_ACE>();
+                        let ace_sid: PSID = std::ptr::addr_of!((*allow).SidStart).cast_mut().cast();
+                        if EqualSid(ace_sid, sid.0) != 0 {
+                            out.push((
+                                (*allow).Mask,
+                                u32::from((*ace.cast::<ACE_HEADER>()).AceFlags),
+                            ));
+                        }
+                    }
+                }
+            }
+            unsafe { LocalFree(sd.cast()) };
+            Ok(out)
+        }
+
+        /// The DACL's control word — `SE_DACL_AUTO_INHERITED` / `SE_DACL_PROTECTED` live here,
+        /// and a hand-built descriptor that dropped them would show up as a change across a
+        /// grant/revoke round trip.
+        pub fn control(dir: &Path) -> io::Result<u16> {
+            let (_dacl, sd) = read_dacl(dir)?;
+            let mut control = 0u16;
+            let mut revision = 0u32;
+            let ok = unsafe { GetSecurityDescriptorControl(sd, &mut control, &mut revision) };
+            unsafe { LocalFree(sd.cast()) };
+            if ok == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(control)
+        }
+
+        fn read_dacl(dir: &Path) -> io::Result<(*mut ACL, PSECURITY_DESCRIPTOR)> {
+            let wpath = wide_path(dir);
+            let mut dacl: *mut ACL = std::ptr::null_mut();
+            let mut sd: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+            let rc = unsafe {
+                GetNamedSecurityInfoW(
+                    wpath.as_ptr(),
+                    SE_FILE_OBJECT,
+                    DACL_SECURITY_INFORMATION,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    &mut dacl,
+                    std::ptr::null_mut(),
+                    &mut sd,
+                )
+            };
+            if rc != 0 {
+                return Err(io::Error::from_raw_os_error(rc as i32));
+            }
+            Ok((dacl, sd))
+        }
+    }
+
+    /// Grant then revoke with the PRODUCT's writer, returning both durations in microseconds.
+    /// Only the grant is compared: the grant is what a lifecycle spawn pays before the child
+    /// starts, and it is where the stall was.
+    fn time_kernel(dir: &Path, sddl: &str) -> (u128, u128) {
+        let t0 = std::time::Instant::now();
+        nub_sandbox::windows_object_traverse_ace(dir, sddl, true).expect("kernel grant");
+        let grant = t0.elapsed().as_micros();
+        let t1 = std::time::Instant::now();
+        nub_sandbox::windows_object_traverse_ace(dir, sddl, false).expect("kernel revoke");
+        (grant, t1.elapsed().as_micros())
+    }
+
+    fn time_named(dir: &Path, sddl: &str) -> (u128, u128) {
+        let t0 = std::time::Instant::now();
+        ace::named_propagating_ace(dir, sddl, true).expect("named grant");
+        let grant = t0.elapsed().as_micros();
+        let t1 = std::time::Instant::now();
+        ace::named_propagating_ace(dir, sddl, false).expect("named revoke");
+        (grant, t1.elapsed().as_micros())
+    }
+
+    fn ace_cost(fails: &mut u32) {
+        let f = Fixture::new("cost");
+        let trustee = match ace::Trustee::new() {
+            Ok(t) => t,
+            Err(e) => {
+                report(fails, "ace-cost-trustee-minted", false, &format!("{e}"));
+                return;
+            }
+        };
+        println!("  fact:ace-cost-trustee={}", trustee.sddl);
+
+        let empty = f.root.join("tree-empty");
+        let full = f.root.join("tree-full");
+        std::fs::create_dir_all(&empty).unwrap();
+        std::fs::create_dir_all(&full).unwrap();
+        // Spread across subdirectories: the propagation pass walks the whole subtree, and a
+        // flat directory understates a real toolchain layout.
+        for i in 0..POPULATED_ENTRIES {
+            if i % 200 == 0 {
+                std::fs::create_dir_all(full.join(format!("d{}", i / 200))).unwrap();
+            }
+            std::fs::write(full.join(format!("d{}/f{i}.bin", i / 200)), b"x").unwrap();
+        }
+        println!("  fact:ace-cost-populated-entries={POPULATED_ENTRIES}");
+
+        let control_before = ace::control(&full).expect("read control");
+        let (k_empty, k_empty_rev) = time_kernel(&empty, &trustee.sddl);
+        let (k_full, k_full_rev) = time_kernel(&full, &trustee.sddl);
+        let (n_empty, n_empty_rev) = time_named(&empty, &trustee.sddl);
+        let (n_full, n_full_rev) = time_named(&full, &trustee.sddl);
+        let control_after = ace::control(&full).expect("read control");
+        println!(
+            "  fact:ace-cost-us kernel-empty={k_empty} kernel-full={k_full} \
+             named-empty={n_empty} named-full={n_full}"
+        );
+        println!(
+            "  fact:ace-revoke-us kernel-empty={k_empty_rev} kernel-full={k_full_rev} \
+             named-empty={n_empty_rev} named-full={n_full_rev}"
+        );
+
+        // THE CONTROL. If the propagating writer did NOT get materially slower on the
+        // populated tree, the tree walk never reproduced on this machine and every comparison
+        // below is measuring noise — the one outcome that must not read as a pass.
+        report(
+            fails,
+            "ace-cost-named-writer-scales-with-tree",
+            n_full > n_empty.saturating_mul(3).max(n_empty + 5_000),
+            &format!(
+                "named: {n_empty}us empty -> {n_full}us at {POPULATED_ENTRIES} entries \
+                 (THE CONTROL: without this the kernel numbers prove nothing)"
+            ),
+        );
+        // The claim: the kernel writer's cost is a descriptor write, so tree size does not
+        // enter into it. Floored generously — building 4000 entries leaves cache state, and the
+        // runner is shared.
+        report(
+            fails,
+            "ace-cost-kernel-writer-flat-in-tree-size",
+            k_full < k_empty.saturating_mul(3).max(k_empty + 20_000),
+            &format!("kernel: {k_empty}us empty -> {k_full}us at {POPULATED_ENTRIES} entries"),
+        );
+        report(
+            fails,
+            "ace-cost-kernel-beats-named-on-populated-tree",
+            k_full < n_full,
+            &format!("kernel={k_full}us named={n_full}us on the same directory"),
+        );
+
+        // A re-grant with the ace already present. A tree walk costs the same either way (the
+        // signature measured on python's tree); a descriptor write is the same tiny cost.
+        nub_sandbox::windows_object_traverse_ace(&full, &trustee.sddl, true).expect("pre-grant");
+        let t = std::time::Instant::now();
+        nub_sandbox::windows_object_traverse_ace(&full, &trustee.sddl, true).expect("re-grant");
+        let regrant = t.elapsed().as_micros();
+        let landed = ace::aces_for(&full, &trustee.sddl).expect("read aces");
+        let child_aces = ace::aces_for(&full.join("d0"), &trustee.sddl).expect("read child aces");
+        nub_sandbox::windows_object_traverse_ace(&full, &trustee.sddl, false).expect("revoke");
+        let after_revoke = ace::aces_for(&full, &trustee.sddl).expect("read aces");
+        println!("  fact:ace-regrant-us={regrant}");
+
+        // EFFECT, not just a call that returned: the ace is on the DACL carrying exactly the
+        // traverse mask. `repair-on-lstat-chain-permitted` in the next group is the same fact
+        // seen from inside the jail.
+        report(
+            fails,
+            "ace-lands-with-exact-traverse-mask",
+            landed.len() == 1 && landed[0].0 == ace::TRAVERSE_MASK,
+            &format!(
+                "aces={landed:?} expected one at 0x{:08x}",
+                ace::TRAVERSE_MASK
+            ),
+        );
+        // SCOPE, and it is a security property: a non-inherited ace grants the directory
+        // OBJECT. An inheritable one would silently turn every ancestor into a readable
+        // subtree.
+        report(
+            fails,
+            "ace-carries-no-inheritance-flags",
+            landed.len() == 1 && landed[0].1 & ace::INHERIT_FLAGS == 0,
+            &format!("flags=0x{:02x}", landed.first().map_or(0, |a| a.1)),
+        );
+        report(
+            fails,
+            "ace-absent-on-child-directory",
+            child_aces.is_empty(),
+            &format!("child aces={child_aces:?} (the grant must stop at the object)"),
+        );
+        report(
+            fails,
+            "ace-revoke-removes-it",
+            after_revoke.is_empty(),
+            &format!("aces after revoke={after_revoke:?}"),
+        );
+        // The hand-built descriptor starts with a zero control word. Clearing
+        // SE_DACL_AUTO_INHERITED or SE_DACL_PROTECTED on a directory nub does not own would be
+        // a lasting change to the user's machine, so the bits are carried across explicitly.
+        report(
+            fails,
+            "ace-preserves-dacl-control-bits",
+            control_before == control_after,
+            &format!("control 0x{control_before:04x} -> 0x{control_after:04x}"),
+        );
+
+        // %TEMP% is the path that actually stalled, and it is on every fixture's ancestor
+        // chain. Kernel writer only: the propagating writer here is unbounded by construction,
+        // which is exactly why three runs of this probe lost their answer.
+        let tmp = std::env::temp_dir();
+        let (t_grant, t_revoke) = time_kernel(&tmp, &trustee.sddl);
+        println!("  fact:ace-cost-real-temp-us grant={t_grant} revoke={t_revoke}");
+        report(
+            fails,
+            "ace-cost-real-temp-under-a-second",
+            t_grant < 1_000_000,
+            &format!("{t_grant}us on {} (was minutes)", tmp.display()),
+        );
+
+        // The AAP skip. Which paths already publish read+execute to every AppContainer is a
+        // property of the MACHINE's default ACLs, so the %ProgramFiles% cells are FACTS; the
+        // fixture cell is the assertion, because a protected user-only root must never look
+        // already-granted or the skip would drop a grant the jail needs.
+        let pf = std::env::var("ProgramFiles").ok();
+        for (label, dir) in [
+            ("programfiles", pf.clone()),
+            ("programfiles-nodejs", pf.map(|p| format!("{p}\\nodejs"))),
+        ] {
+            match dir {
+                Some(d) if Path::new(&d).exists() => println!(
+                    "  fact:aap-readable-{label}={}",
+                    nub_sandbox::windows_leaf_grant_redundant(Path::new(&d))
+                ),
+                _ => println!("  fact:aap-readable-{label}=absent"),
+            }
+        }
+        report(
+            fails,
+            "aap-skip-declines-a-protected-fixture-root",
+            !nub_sandbox::windows_leaf_grant_redundant(&full),
+            "a user-only protected tree must still get its grant",
+        );
+    }
+
+    /// The teardown half of the AAP skip: a pre-existing inheritable
+    /// `ALL APPLICATION PACKAGES` ace must SURVIVE a launch that granted the path, because the
+    /// launch skipped writing one and therefore has nothing to revoke. Getting this wrong would
+    /// strip an ace off the user's own `%ProgramFiles%` tree, so it is asserted end to end
+    /// through `apply` rather than reasoned about from the skip's return value.
+    fn aap_skip_teardown(fails: &mut u32, node: &Path) {
+        let f = Fixture::new("aap");
+        let shared = f.root.join("shared-tool");
+        std::fs::create_dir_all(&shared).unwrap();
+        std::fs::write(shared.join("tool.txt"), b"shared").unwrap();
+        let seeded = std::process::Command::new("icacls")
+            .arg(&shared)
+            .args(["/grant", "*S-1-15-2-1:(OI)(CI)(RX)"])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !seeded {
+            report(
+                fails,
+                "aap-skip-fixture-seeded",
+                false,
+                "icacls could not place the ALL APPLICATION PACKAGES ace",
+            );
+            return;
+        }
+        report(
+            fails,
+            "aap-skip-sees-the-seeded-grant",
+            nub_sandbox::windows_leaf_grant_redundant(&shared),
+            "the seeded inheritable AAP ace must make the grant redundant",
+        );
+
+        let policy = jail_shaped(&f, vec![read_rule(node), read_rule(&shared)], &[]);
+        let run = fsprobe(
+            &f,
+            &policy,
+            "aap",
+            &[(
+                "toolread".to_string(),
+                "read",
+                shared.join("tool.txt").to_string_lossy().into_owned(),
+            )],
+        );
+        report(
+            fails,
+            "aap-skip-child-still-reads-the-tool",
+            line(&run, "toolread").starts_with("ok:"),
+            &line(&run, "toolread"),
+        );
+        let survivors = ace::aces_for(&shared, "S-1-15-2-1").expect("read aces");
+        report(
+            fails,
+            "aap-skip-leaves-the-preexisting-ace-alone",
+            survivors
+                .iter()
+                .any(|(_, flags)| flags & ace::INHERIT_FLAGS != 0),
+            &format!(
+                "AAP aces after teardown={survivors:?} \
+                 (the jail must not strip one it did not create)"
+            ),
+        );
+    }
+
     // ── group 1: ancestor reachability, both directions ──────────────────────────────
 
     /// ONE fixture, ONE variable. The unrepaired arm runs first and must reproduce the defect;
@@ -1462,12 +2000,17 @@ try {{
             let _ = std::io::stdout().flush();
         };
 
-        // require_shapes FIRST, deliberately. It is the blast-radius measurement, it writes no
-        // ancestor ace at all (every cell is repair-OFF), and it therefore cannot trigger the
-        // DACL-propagation stall that has taken the later groups down. Ordering a group that
-        // cannot stall behind one that can is how three runs lost the answer they were for.
+        // The CHEAP, CANNOT-STALL groups come first, deliberately: ordering a group that cannot
+        // stall behind one that can is how three runs lost the answer they were for.
+        // `require_shapes` is the blast-radius measurement and writes no ancestor ace at all
+        // (every cell is repair-OFF). `ace_cost` bounds itself — its propagating-writer control
+        // runs on a synthetic 4000-entry tree, never on `%TEMP%` — and it is the group that says
+        // whether the stall is gone, so it must not sit behind anything that could reproduce it.
         step("token_privileges");
         token_privileges(&mut fails);
+
+        step("ace_cost");
+        ace_cost(&mut fails);
 
         // The shipping configuration. A second arm under `--preserve-symlinks` was measured here
         // and has been REMOVED: the flag is off the table, because a hoisted layout still symlinks
@@ -1479,6 +2022,9 @@ try {{
 
         step("ancestor_repair");
         ancestor_repair(&mut fails, node.as_path());
+
+        step("aap_skip_teardown");
+        aap_skip_teardown(&mut fails, node.as_path());
 
         step("stdio_shim");
         stdio_shim(&mut fails, node.as_path());


### PR DESCRIPTION
The ancestor repair writes a traverse ace on every ancestor of a granted path, once per lifecycle spawn. It went through `SetSecurityInfo`, which runs advapi32's inheritance-propagation pass before returning — so the write walked the directory's existing subtree, and the chain includes `%TEMP%`. That is what wedged a 20-minute CI step and what killed the last two runs of this probe: both died on the first repair-ON launch, `watchdog-stalled-at=run_jailed mode=fsprobe`, exit 97, with no group after `ancestor_repair` ever running.

`SetKernelObjectSecurity` goes straight to `NtSetSecurityObject`: it writes the object's own descriptor and there is no propagation pass to skip. It wants a whole descriptor rather than a bare ACL, so the descriptor is hand-built (`InitializeSecurityDescriptor` + `SetSecurityDescriptorDacl`). `SetEntriesInAclW` still does the merge — it only assembles an ACL in memory and never propagated anything. `SE_DACL_AUTO_INHERITED` and `SE_DACL_PROTECTED` are carried across so a fresh descriptor cannot clear them on a directory nub does not own.

Second change, same root cause on the other side. A leaf grant is inheritable by design, so it must propagate — the lever there is not to write it when the target already publishes it. Measured: `%ProgramFiles%` carries `ALL APPLICATION PACKAGES: ReadAndExecute` inheritably, so an all-users python or node needs no ace at all; only per-user layouts pay. The teardown list is driven from `grant_leaf_ace`'s single return value, so a skipped path is never recorded and the revoke cannot strip an ace the launch did not create.

## Measured, windows-latest, run 30528232196

Same trustee, same path, same run. The propagating writer is kept as a local control in the probe rather than in the product.

| grant on | new (`SetKernelObjectSecurity`) | old (`SetSecurityInfo`), control |
|---|---|---|
| empty directory | 209 µs | 370 µs |
| 4,000-entry tree | **131 µs** | **534,378 µs** |
| re-grant, ace already present | 140 µs | — |
| real `%TEMP%` on the runner | **630 µs** | previously minutes |

The control reproduced: the old writer went 370 µs → 534 ms with tree size, a 1,444× blow-up. The new one is flat, and a re-grant costs the same as a fresh one, which is a descriptor write rather than a tree walk.

Effect and scope, asserted rather than assumed — the ace lands carrying exactly `0x001000a1` with flags `0x00`, is absent on a child directory, is gone after revoke, and the DACL control word is `0x8404` before and after. Seen from inside the jail, `repair-on-lstat-chain-permitted` and `repair-on-node-absolute-require-resolves` pass while `repair-on-ancestor-sibling-read-refused` and `-listing-refused` still refuse, so the grant reaches the confined child and stops at the directory object.

For the skip: `aap-readable-programfiles=true`, `aap-readable-programfiles-nodejs=false` (the known outlier), a protected user-only tree is correctly declined, and a seeded inheritable AAP ace survives a launch that granted the path.

This is the workflow's first green run. Four `shape-plain-*-unrepaired` cells are FAIL, byte-identical to both baseline runs — they are the repair-OFF blast-radius measurement and are un-gated by design.

## Base

Branched off `sandbox/win-jail-bin`, the newest tip carrying both the ancestor repair and the probe harnesses. `set_ace_on_object` is byte-identical across all seven branches that have it, so this applies to any of them.
