### PR TITLE
compile: embed new URL assets, refuse case-only payload collisions

### DIFF
--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -492,9 +492,8 @@ impl Plugin for NewUrlAssets {
             };
             let mut named = Vec::with_capacity(edits.len());
             for edit in edits {
-                let bytes = std::fs::read(&edit.source).map_err(|e| {
-                    anyhow!("reading {} for new URL(): {e}", edit.source.display())
-                })?;
+                let bytes = std::fs::read(&edit.source)
+                    .map_err(|e| anyhow!("reading {} for new URL(): {e}", edit.source.display()))?;
                 let name = self.collected.add(&edit.source, bytes)?;
                 named.push((edit, name));
             }
@@ -646,9 +645,9 @@ fn binds_url(program: &Program<'_>) -> bool {
     use oxc_ast::ast::{BindingPattern, Statement};
 
     program.body.iter().any(|stmt| match stmt {
-        Statement::VariableDeclaration(d) => d.declarations.iter().any(|decl| {
-            matches!(&decl.id, BindingPattern::BindingIdentifier(id) if id.name == "URL")
-        }),
+        Statement::VariableDeclaration(d) => d.declarations.iter().any(
+            |decl| matches!(&decl.id, BindingPattern::BindingIdentifier(id) if id.name == "URL"),
+        ),
         Statement::ClassDeclaration(c) => c.id.as_ref().is_some_and(|id| id.name == "URL"),
         Statement::FunctionDeclaration(f) => f.id.as_ref().is_some_and(|id| id.name == "URL"),
         _ => false,
@@ -1617,8 +1616,7 @@ mod tests {
     fn fixture_dir(tag: &str) -> PathBuf {
         static N: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
         let seq = N.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let dir =
-            std::env::temp_dir().join(format!("nub-{tag}-{}-{seq}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("nub-{tag}-{}-{seq}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -339,7 +339,13 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
 /// `file` loader in `load`, [`NewUrlAssets`] in `transform` — which is before
 /// anything is tree-shaken. So a reference whose result goes unused still
 /// collects its bytes, and without this pass a stray `import splash from
-/// "./splash.mp4"` would embed the file in every artifact forever. (This is entry-language-dependent and therefore easy to
+/// "./splash.mp4"` would embed the file in every artifact forever.
+///
+/// It prunes what the SHAKER left, so how much it recovers differs by path. The
+/// `file` loader marks its synthesized module side-effect-free, so an unused
+/// import is shaken and its asset dropped. A `new URL(…)` is a constructor call
+/// Rolldown cannot prove pure, so an unused binding in a REACHED module keeps its
+/// bytes; only an unreachable module drops them. (This is entry-language-dependent and therefore easy to
 /// miss: a `.ts` entry never reaches the hook at all, because the TypeScript
 /// transform elides an unused import as possibly-type-only, while the identical
 /// `.js` entry does. The payload should not depend on which one you wrote.)
@@ -611,7 +617,7 @@ fn scan_new_urls(id: &str, source: &str) -> Vec<NewUrlEdit> {
             if has_url_scheme(spec) {
                 return None;
             }
-            let path = self.dir.join(spec);
+            let path = self.dir.join(percent_decode(spec)?);
             path.is_file().then_some(path)
         }
     }
@@ -635,23 +641,88 @@ fn is_import_meta_url(expr: &Expression<'_>) -> bool {
             if meta.meta.name == "import" && meta.property.name == "meta")
 }
 
-/// Does this module define its own `URL` at the top level?
+/// Does this module declare its own top-level `URL`?
 ///
 /// A module that does is not talking about the global constructor, so rewriting
-/// its argument could change what the program means. Value declarations only:
-/// an `import { URL } from "node:url"` binds the SAME constructor, and skipping
-/// those would silently exclude a perfectly ordinary way to write this.
+/// its argument could change what the program means. Two deliberate boundaries:
+///
+/// - **Value declarations only.** An `import { URL } from "node:url"` binds the
+///   SAME constructor, so treating it as a shadow would silently exclude a
+///   perfectly ordinary way to write this.
+/// - **Top level only.** A `URL` bound in an inner scope — a function parameter,
+///   a block-scoped class — is NOT seen, and such a module IS rewritten. Catching
+///   it needs real scope analysis, which does not earn an `oxc_semantic`
+///   dependency for a name nothing legitimately rebinds.
+///
+/// The `export` wrappers are unwrapped rather than skipped: without that the
+/// guard turned on whether the shadow happened to be exported, honoring
+/// `class URL {}` while rewriting `export class URL {}` three characters later.
 fn binds_url(program: &Program<'_>) -> bool {
-    use oxc_ast::ast::{BindingPattern, Statement};
+    use oxc_ast::ast::{BindingPattern, Declaration, ExportDefaultDeclarationKind, Statement};
+
+    fn declares_url(decl: &Declaration<'_>) -> bool {
+        match decl {
+            Declaration::VariableDeclaration(d) => d.declarations.iter().any(
+                |d| matches!(&d.id, BindingPattern::BindingIdentifier(id) if id.name == "URL"),
+            ),
+            Declaration::ClassDeclaration(c) => c.id.as_ref().is_some_and(|id| id.name == "URL"),
+            Declaration::FunctionDeclaration(f) => f.id.as_ref().is_some_and(|id| id.name == "URL"),
+            _ => false,
+        }
+    }
 
     program.body.iter().any(|stmt| match stmt {
-        Statement::VariableDeclaration(d) => d.declarations.iter().any(
-            |decl| matches!(&decl.id, BindingPattern::BindingIdentifier(id) if id.name == "URL"),
-        ),
-        Statement::ClassDeclaration(c) => c.id.as_ref().is_some_and(|id| id.name == "URL"),
-        Statement::FunctionDeclaration(f) => f.id.as_ref().is_some_and(|id| id.name == "URL"),
-        _ => false,
+        Statement::ExportNamedDeclaration(e) => e.declaration.as_ref().is_some_and(declares_url),
+        Statement::ExportDefaultDeclaration(e) => match &e.declaration {
+            ExportDefaultDeclarationKind::ClassDeclaration(c) => {
+                c.id.as_ref().is_some_and(|id| id.name == "URL")
+            }
+            ExportDefaultDeclarationKind::FunctionDeclaration(f) => {
+                f.id.as_ref().is_some_and(|id| id.name == "URL")
+            }
+            _ => false,
+        },
+        other => other.as_declaration().is_some_and(declares_url),
     })
+}
+
+/// Resolve a URL specifier's `%XX` escapes into the path bytes the RUNTIME will
+/// open, or `None` when the result is not a usable path.
+///
+/// Skipping this does not merely miss a file — it opens the WRONG one. The
+/// specifier is URL text, so `./my%20file.bin` names `my file.bin`; joining the
+/// raw string instead looks for a literal `my%20file.bin`, which usually does not
+/// exist (so every filename containing a space silently stopped being embeddable)
+/// and, when it does, embeds a different file than the program reads, with
+/// nothing failing at build time.
+///
+/// An invalid escape is left verbatim, matching the WHATWG URL parser. Bytes that
+/// do not reassemble into UTF-8 yield `None` rather than a lossy path.
+fn percent_decode(spec: &str) -> Option<String> {
+    if !spec.contains('%') {
+        return Some(spec.to_string());
+    }
+    let raw = spec.as_bytes();
+    let mut out = Vec::with_capacity(raw.len());
+    let mut i = 0;
+    while i < raw.len() {
+        let hex = (i + 2 < raw.len())
+            .then(|| std::str::from_utf8(&raw[i + 1..i + 3]).ok())
+            .flatten()
+            .filter(|_| raw[i] == b'%')
+            .and_then(|h| u8::from_str_radix(h, 16).ok());
+        match hex {
+            Some(byte) => {
+                out.push(byte);
+                i += 3;
+            }
+            None => {
+                out.push(raw[i]);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8(out).ok()
 }
 
 /// An RFC 3986 `scheme:` — ALPHA then alphanumerics/`+-.` — which makes a
@@ -1691,9 +1762,22 @@ mod tests {
                  \x20\x20new URL('/data.json', import.meta.url),\n\
                  ];\n",
             ),
+            // A module's own URL is not the global one. The `export` spelling is
+            // listed because missing it made the guard depend on whether the
+            // shadow happened to be exported.
             (
                 "shadowed",
                 "class URL { constructor(a, b) { this.a = a; this.b = b; } }\n\
+                 globalThis.OUT = new URL('./data.json', import.meta.url);\n",
+            ),
+            (
+                "shadowed-export",
+                "export class URL { constructor(a, b) { this.a = a; } }\n\
+                 globalThis.OUT = new URL('./data.json', import.meta.url);\n",
+            ),
+            (
+                "shadowed-export-const",
+                "export const URL = class { constructor(a, b) { this.a = a; } };\n\
                  globalThis.OUT = new URL('./data.json', import.meta.url);\n",
             ),
         ] {
@@ -1742,6 +1826,47 @@ mod tests {
         assert_eq!(res.assets.len(), 1, "the nested sibling must ship");
         assert_eq!(res.assets[0].bytes, b"NESTEDBYTES");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // A specifier is URL text, so its escapes have to be resolved before it names
+    // a path. Skipping that does not merely miss the file — with both spellings on
+    // disk it embeds the OTHER one, and the compiled binary then reads bytes the
+    // same source reads differently under plain Node.
+    #[test]
+    fn a_percent_escaped_specifier_names_the_file_the_runtime_would_open() {
+        let dir = fixture_dir("newurl-pct");
+        std::fs::write(dir.join("my file.bin"), b"DECODED").unwrap();
+        std::fs::write(dir.join("my%20file.bin"), b"LITERAL").unwrap();
+        std::fs::write(
+            dir.join("entry.ts"),
+            b"globalThis.OUT = new URL('./my%20file.bin', import.meta.url);\n",
+        )
+        .unwrap();
+
+        let mut o = opts();
+        o.minify = false;
+        let res = bundle(&dir.join("entry.ts"), &o).expect("compiles");
+        assert_eq!(res.assets.len(), 1, "the referenced file must ship");
+        assert_eq!(
+            res.assets[0].bytes, b"DECODED",
+            "%20 is a space, so the space-named file is the one the URL resolves to"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn percent_decoding_follows_the_url_parser() {
+        assert_eq!(percent_decode("./a.bin").as_deref(), Some("./a.bin"));
+        assert_eq!(
+            percent_decode("./my%20f.bin").as_deref(),
+            Some("./my f.bin")
+        );
+        assert_eq!(percent_decode("./%C3%A9.bin").as_deref(), Some("./é.bin"));
+        // An invalid or truncated escape is left verbatim, as the URL parser does.
+        assert_eq!(percent_decode("./100%.bin").as_deref(), Some("./100%.bin"));
+        assert_eq!(percent_decode("./a%zz.bin").as_deref(), Some("./a%zz.bin"));
+        // Bytes that are not UTF-8 have no path spelling to resolve to.
+        assert_eq!(percent_decode("./%FF.bin"), None);
     }
 
     // The invariant behind `map: HookTransformOutputMap::Null` — the transform

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -35,18 +35,21 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result, anyhow, bail};
+use oxc_ast::ast::{Expression, NewExpression, Program};
 use rolldown::plugin::__inner::SharedPluginable;
 use rolldown::plugin::{
-    HookTransformArgs, HookTransformReturn, HookUsage, Plugin, SharedTransformPluginContext,
+    HookTransformArgs, HookTransformOutput, HookTransformOutputMap, HookTransformReturn, HookUsage,
+    Plugin, SharedTransformPluginContext,
 };
 use rolldown::{BundlerBuilder, BundlerOptions, InputItem};
 use rolldown_common::bundler_options::{BundlerTransformOptions, Either, JsxOptions};
 use rolldown_common::{
-    InnerOptions, IsExternal, Output, OutputFormat, Platform, RawMinifyOptions, ResolveOptions,
-    SourceMapType, StrOrBytes, TreeshakeOptions, TsConfig,
+    InnerOptions, IsExternal, ModuleType, Output, OutputFormat, Platform, RawMinifyOptions,
+    ResolveOptions, SourceMapType, StrOrBytes, TreeshakeOptions, TsConfig,
 };
 use rolldown_error::{BuildDiagnostic, DiagnosticOptions, EventKind};
 use rolldown_utils::indexmap::FxIndexMap;
+use rolldown_utils::url::clean_url;
 
 use super::loaders;
 
@@ -117,10 +120,10 @@ pub struct BundleResult {
     pub files: Vec<BundledFile>,
     /// `--sourcemap=external` maps: emitted, unreferenced, not shipped.
     pub detached_maps: Vec<BundledFile>,
-    /// Loader-emitted assets — in practice the `file` loader's payload, since
-    /// nothing else in nub's configuration makes Rolldown emit a non-map asset.
-    /// Kept APART from [`Self::files`] because those are re-parsed as JavaScript
-    /// by [`reject_invalid_chunks`], which a `.wasm` would rightly fail.
+    /// Files embedded beside the chunks: the `file` loader's payload and the
+    /// targets of [`NewUrlAssets`]. Kept APART from [`Self::files`] because those
+    /// are re-parsed as JavaScript by [`reject_invalid_chunks`], which a `.wasm`
+    /// would rightly fail.
     pub assets: Vec<BundledFile>,
 }
 
@@ -192,11 +195,22 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
         ..Default::default()
     };
 
-    let scan = std::sync::Arc::new(DynamicImportScan::default());
-    let files_plugin = std::sync::Arc::new(loaders::FilePlugin::new(&loader_plan));
+    let scan = Arc::new(DynamicImportScan::default());
+    // One collector behind both emitting plugins, so a file reached by an
+    // `import` AND by a `new URL(…)` ships once.
+    let collected = Arc::new(loaders::Assets::default());
+    let files_plugin = Arc::new(loaders::FilePlugin::new(
+        &loader_plan,
+        Arc::clone(&collected),
+    ));
+    let new_urls = Arc::new(NewUrlAssets {
+        collected: Arc::clone(&collected),
+        files: Arc::clone(&files_plugin),
+    });
     let plugins: Vec<SharedPluginable> = vec![
-        std::sync::Arc::clone(&scan) as SharedPluginable,
-        std::sync::Arc::clone(&files_plugin) as SharedPluginable,
+        Arc::clone(&scan) as SharedPluginable,
+        Arc::clone(&files_plugin) as SharedPluginable,
+        Arc::clone(&new_urls) as SharedPluginable,
     ];
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -233,7 +247,7 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
     let mut entry = None;
     let mut files = Vec::new();
     let mut maps = Vec::new();
-    let mut assets: Vec<BundledFile> = files_plugin
+    let mut assets: Vec<BundledFile> = collected
         .take()
         .into_iter()
         .map(|a| BundledFile {
@@ -267,16 +281,16 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
                 // is not in the payload — a runtime ENOENT with nothing failing
                 // at build time.
                 //
-                // Nothing reaches this branch today: nub's `file` loader collects
-                // its own bytes, and Rolldown's asset path is gated on
+                // Nothing reaches this branch today: both of nub's asset paths —
+                // the `file` loader and [`NewUrlAssets`] — collect their own
+                // bytes, and Rolldown's own asset path is gated on
                 // `experimental.resolve_new_url_to_asset`, which defaults off and
-                // nub never sets — so a `new URL(…, import.meta.url)` is left as
-                // a literal and emits nothing. This is kept as the correct
-                // handling rather than a silent drop, so enabling that flag (or
-                // any future emitting plugin) cannot quietly produce a broken
-                // artifact. `--include` never routes through here at all — it
-                // embeds bytes straight from disk, which is what makes it
-                // verbatim.
+                // nub never sets (see [`NewUrlAssets`] for why it is not the
+                // mechanism used). This is kept as the correct handling rather
+                // than a silent drop, so enabling that flag — or any future
+                // emitting plugin — cannot quietly produce a broken artifact.
+                // `--include` never routes through here at all: it embeds bytes
+                // straight from disk, which is what makes it verbatim.
                 if a.filename.ends_with(".map") {
                     maps.push(file);
                 } else {
@@ -321,11 +335,11 @@ pub fn bundle(entry_abs: &Path, opts: &BundleOptions) -> Result<BundleResult> {
 
 /// Drop assets that no emitted chunk names.
 ///
-/// The `file` loader reads and records an asset in its `load` hook, which runs
-/// while the graph is being built — before anything is tree-shaken. So an import
-/// whose binding goes unused still collects its bytes, and without this pass a
-/// stray `import splash from "./splash.mp4"` would embed the file in every
-/// artifact forever. (This is entry-language-dependent and therefore easy to
+/// Both asset paths record their bytes while the graph is being built — the
+/// `file` loader in `load`, [`NewUrlAssets`] in `transform` — which is before
+/// anything is tree-shaken. So a reference whose result goes unused still
+/// collects its bytes, and without this pass a stray `import splash from
+/// "./splash.mp4"` would embed the file in every artifact forever. (This is entry-language-dependent and therefore easy to
 /// miss: a `.ts` entry never reaches the hook at all, because the TypeScript
 /// transform elides an unused import as possibly-type-only, while the identical
 /// `.js` entry does. The payload should not depend on which one you wrote.)
@@ -346,16 +360,17 @@ fn retain_referenced(chunks: &[BundledFile], assets: &mut Vec<BundledFile>) {
     assets.retain(|asset| code.iter().any(|c| c.contains(&asset.name)));
 }
 
-/// Assert the flat-output invariant the `file` loader rests on.
+/// Assert the flat-output invariant both asset paths rest on.
 ///
-/// A `file` import evaluates to `new URL("./<name>", import.meta.url)`, resolved
-/// against whichever CHUNK the importing module was bundled into. That is only
-/// the asset's location while every chunk and every nub-emitted asset sit in one
-/// directory. Rolldown's defaults do put them there, but `chunkFileNames` is
-/// configurable and a future flag could nest them — at which point every `file`
-/// import would silently resolve to a path that does not exist, on the deploy
-/// machine, with no build-time signal. Checking is a string scan; the failure it
-/// prevents is a shipped-broken binary.
+/// A `file` import and a rewritten [`NewUrlAssets`] reference both evaluate to
+/// `new URL("./<name>", import.meta.url)`, resolved against whichever CHUNK the
+/// referencing module was bundled into. That is only the asset's location while
+/// every chunk and every nub-emitted asset sit in one directory. Rolldown's
+/// defaults do put them there, but `chunkFileNames` is configurable and a future
+/// flag could nest them — at which point every asset reference would silently
+/// resolve to a path that does not exist, on the deploy machine, with no
+/// build-time signal. Checking is a string scan; the failure it prevents is a
+/// shipped-broken binary.
 ///
 /// Rolldown's OWN assets are exempt: it rewrites those references itself
 /// (`compute_relative_path`), so a nested `assets/x-HASH.png` stays correct.
@@ -391,6 +406,284 @@ fn absolutize(path: &Path) -> PathBuf {
         return path.to_path_buf();
     }
     std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+}
+
+// ---- `new URL(…, import.meta.url)` asset embedding -----------------------------
+
+/// Embeds the file a `new URL("./x", import.meta.url)` names, and repoints the
+/// URL at the embedded copy.
+///
+/// This is the idiomatic ESM way to reach a file sitting beside your module, and
+/// it was the one asset form that compiled CLEAN and then died: the artifact
+/// carried no copy of `x`, and the source tree the URL pointed at is not on the
+/// machine the binary ships to, so the first read was an ENOENT with no
+/// build-time signal at all. Embedding makes it work; there is nothing for the
+/// user to opt into.
+///
+/// THE REWRITE IS NUB'S RATHER THAN ROLLDOWN'S, deliberately. Rolldown has
+/// `experimental.resolve_new_url_to_asset`, but it routes the referenced file
+/// through the module graph as `ModuleType::Asset` — where nub's own extension
+/// map and `file` loader already claim it, so a `new URL("./logo.png", …)` would
+/// be loaded as JavaScript by one and emitted as an asset by the other — and it
+/// names what it emits under Rolldown's `assetFileNames`, a second layout and a
+/// second naming scheme beside the flat content-hashed one everything else here
+/// depends on. Emitting from nub keeps ONE collector, one naming rule, one
+/// reachability pass ([`retain_referenced`]), and the same `import.meta.url` base
+/// that makes the path correct from any cwd.
+///
+/// WHAT IS OUT OF SCOPE, AND WHY IT IS SILENT. Only a statically analyzable
+/// specifier can be embedded, so `new URL(name, import.meta.url)` is left exactly
+/// as written — no rewrite and no build error. Failing it would be wrong twice
+/// over: the same expression is how a program names a file it intends to WRITE,
+/// and a computed URL is routinely on a branch the artifact never takes. The same
+/// reasoning covers a specifier resolving to nothing on the build machine.
+#[derive(Debug)]
+struct NewUrlAssets {
+    collected: Arc<loaders::Assets>,
+    /// The `file` loader, consulted only to skip the modules IT synthesized: the
+    /// module it emits is itself a `new URL(…, import.meta.url)`, so rescanning
+    /// one would re-resolve an already-hashed asset name against the original
+    /// file's directory.
+    files: Arc<loaders::FilePlugin>,
+}
+
+/// One `new URL(<literal>, import.meta.url)` whose file this build can embed.
+#[derive(Debug, Clone)]
+struct NewUrlEdit {
+    /// Byte range of the FIRST argument within the module's own source.
+    start: usize,
+    end: usize,
+    /// The file on the build machine the URL names.
+    source: PathBuf,
+}
+
+impl Plugin for NewUrlAssets {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("nub:new-url-assets")
+    }
+
+    fn register_hook_usage(&self) -> HookUsage {
+        HookUsage::Transform
+    }
+
+    fn transform(
+        &self,
+        _ctx: SharedTransformPluginContext,
+        args: &HookTransformArgs<'_>,
+    ) -> impl std::future::Future<Output = HookTransformReturn> + Send {
+        // Real JavaScript sources only. A `text`/`json` module's "code" IS the
+        // file's content, so parsing markdown as JavaScript and rewriting what
+        // happened to look like a URL inside it would corrupt the user's data.
+        let scannable = matches!(
+            args.module_type,
+            ModuleType::Js | ModuleType::Jsx | ModuleType::Ts | ModuleType::Tsx
+        ) && !self.files.claims(clean_url(args.id));
+        let edits = if scannable {
+            scan_new_urls(args.id, args.code)
+        } else {
+            Vec::new()
+        };
+        // Cloned only when there is an edit to make — this hook runs on every
+        // module in the graph, and almost none of them have one.
+        let source = (!edits.is_empty()).then(|| args.code.to_string());
+        async move {
+            let Some(source) = source else {
+                return Ok(None);
+            };
+            let mut named = Vec::with_capacity(edits.len());
+            for edit in edits {
+                let bytes = std::fs::read(&edit.source).map_err(|e| {
+                    anyhow!("reading {} for new URL(): {e}", edit.source.display())
+                })?;
+                let name = self.collected.add(&edit.source, bytes)?;
+                named.push((edit, name));
+            }
+            Ok(Some(HookTransformOutput {
+                code: Some(rewrite_new_urls(&source, &named)),
+                // NOT `Omitted`, which means "this transform broke the map":
+                // Rolldown answers that by dropping the module's mapping entirely
+                // and warning on every build. `Null` says the transform does not
+                // move positions — true here, since only a string literal's
+                // CONTENT changes and every line still starts where it did, so the
+                // codegen map still lands on the right line.
+                map: HookTransformOutputMap::Null,
+                ..Default::default()
+            }))
+        }
+    }
+}
+
+/// Splice each embedded asset's name in over the specifier it replaces.
+///
+/// LINE-PRESERVING, which is what makes the `Null` sourcemap honest: only a
+/// string literal's CONTENT changes, and a no-substitution template literal that
+/// spanned lines gives those newlines back as ordinary whitespace between
+/// `new URL`'s arguments.
+fn rewrite_new_urls(source: &str, edits: &[(NewUrlEdit, String)]) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut last = 0usize;
+    for (edit, name) in edits {
+        out.push_str(&source[last..edit.start]);
+        out.push_str(
+            &serde_json::to_string(&format!("./{name}")).expect("an asset name serializes"),
+        );
+        out.extend(std::iter::repeat_n(
+            '\n',
+            source[edit.start..edit.end].matches('\n').count(),
+        ));
+        last = edit.end;
+    }
+    out.push_str(&source[last..]);
+    out
+}
+
+/// Every embeddable `new URL(<literal>, import.meta.url)` in `source`, in source
+/// order — [`rewrite_new_urls`] splices in one forward pass. A parse failure
+/// yields nothing: the bundler's own parse error is the better diagnostic, and
+/// this pass must never be the thing that fails a build.
+fn scan_new_urls(id: &str, source: &str) -> Vec<NewUrlEdit> {
+    use oxc_allocator::Allocator;
+    use oxc_ast_visit::{Visit, walk};
+    use oxc_parser::Parser;
+    use oxc_span::{GetSpan, SourceType};
+
+    let Some(dir) = Path::new(clean_url(id)).parent().map(Path::to_path_buf) else {
+        return Vec::new();
+    };
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(id).unwrap_or_else(|_| SourceType::mjs());
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if parsed.panicked || binds_url(&parsed.program) {
+        return Vec::new();
+    }
+
+    struct Visitor {
+        dir: PathBuf,
+        found: Vec<NewUrlEdit>,
+    }
+
+    impl<'a> Visit<'a> for Visitor {
+        fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
+            if let Some(edit) = self.embeddable(it) {
+                self.found.push(edit);
+            }
+            walk::walk_new_expression(self, it);
+        }
+    }
+
+    impl Visitor {
+        fn embeddable(&self, expr: &NewExpression<'_>) -> Option<NewUrlEdit> {
+            let Expression::Identifier(callee) = &expr.callee else {
+                return None;
+            };
+            if callee.name != "URL" {
+                return None;
+            }
+            if !is_import_meta_url(expr.arguments.get(1)?.as_expression()?) {
+                return None;
+            }
+            let arg = expr.arguments.first()?.as_expression()?;
+            let source = self.embed_target(&static_specifier(arg)?)?;
+            let span = arg.span();
+            Some(NewUrlEdit {
+                start: span.start as usize,
+                end: span.end as usize,
+                source,
+            })
+        }
+
+        /// The file on the build machine a specifier names, if this build can
+        /// embed it.
+        ///
+        /// Deliberately narrow, and every exclusion leaves TODAY'S behavior in
+        /// place rather than failing. A specifier carrying a SCHEME is already an
+        /// absolute URL (`data:`, `https:`, and — the one that bites — a Windows
+        /// `C:\…`), so it does not describe a file beside the module; a leading
+        /// separator resolves against the URL's root, which is the deploy
+        /// machine's, not the build machine's; and `?`/`#` make the tail a query
+        /// or fragment rather than part of the path. What is left is resolved
+        /// against the importing module's own directory, exactly as the runtime
+        /// would, and must EXIST as a file — a specifier naming something that is
+        /// not there yet is a path the program WRITES, not one it ships.
+        fn embed_target(&self, spec: &str) -> Option<PathBuf> {
+            if spec.is_empty() || spec.starts_with(['/', '\\']) || spec.contains(['?', '#']) {
+                return None;
+            }
+            if has_url_scheme(spec) {
+                return None;
+            }
+            let path = self.dir.join(spec);
+            path.is_file().then_some(path)
+        }
+    }
+
+    let mut visitor = Visitor {
+        dir,
+        found: Vec::new(),
+    };
+    visitor.visit_program(&parsed.program);
+    visitor.found.sort_by_key(|e| e.start);
+    visitor.found
+}
+
+/// `import.meta.url`, exactly — the only base whose resolution nub can predict.
+fn is_import_meta_url(expr: &Expression<'_>) -> bool {
+    let Expression::StaticMemberExpression(member) = expr else {
+        return false;
+    };
+    member.property.name == "url"
+        && matches!(&member.object, Expression::MetaProperty(meta)
+            if meta.meta.name == "import" && meta.property.name == "meta")
+}
+
+/// Does this module define its own `URL` at the top level?
+///
+/// A module that does is not talking about the global constructor, so rewriting
+/// its argument could change what the program means. Value declarations only:
+/// an `import { URL } from "node:url"` binds the SAME constructor, and skipping
+/// those would silently exclude a perfectly ordinary way to write this.
+fn binds_url(program: &Program<'_>) -> bool {
+    use oxc_ast::ast::{BindingPattern, Statement};
+
+    program.body.iter().any(|stmt| match stmt {
+        Statement::VariableDeclaration(d) => d.declarations.iter().any(|decl| {
+            matches!(&decl.id, BindingPattern::BindingIdentifier(id) if id.name == "URL")
+        }),
+        Statement::ClassDeclaration(c) => c.id.as_ref().is_some_and(|id| id.name == "URL"),
+        Statement::FunctionDeclaration(f) => f.id.as_ref().is_some_and(|id| id.name == "URL"),
+        _ => false,
+    })
+}
+
+/// An RFC 3986 `scheme:` — ALPHA then alphanumerics/`+-.` — which makes a
+/// specifier an absolute URL rather than a reference resolved against the base.
+fn has_url_scheme(spec: &str) -> bool {
+    let mut chars = spec.chars();
+    if !chars.next().is_some_and(|c| c.is_ascii_alphabetic()) {
+        return false;
+    }
+    for c in chars {
+        if c == ':' {
+            return true;
+        }
+        if !(c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.')) {
+            return false;
+        }
+    }
+    false
+}
+
+/// A template literal with no interpolation is as static as a string literal —
+/// Rolldown resolves both, so both are analyzable here.
+fn static_specifier(expr: &Expression<'_>) -> Option<String> {
+    match expr {
+        Expression::StringLiteral(s) => Some(s.value.to_string()),
+        Expression::TemplateLiteral(t) if t.expressions.is_empty() => t
+            .quasis
+            .first()
+            .map(|q| q.value.cooked.as_ref().unwrap_or(&q.value.raw).to_string()),
+        _ => None,
+    }
 }
 
 // ---- jsx --------------------------------------------------------------------
@@ -722,7 +1015,7 @@ fn scan_unresolvable(id: &str, source: &str) -> Vec<DynamicSite> {
 
         fn visit_expression(&mut self, expr: &Expression<'a>) {
             if let Expression::ImportExpression(imp) = expr
-                && !is_static_specifier(&imp.source)
+                && static_specifier(&imp.source).is_none()
             {
                 self.found.push((SiteKind::Dynamic, imp.span));
             }
@@ -741,23 +1034,6 @@ fn scan_unresolvable(id: &str, source: &str) -> Vec<DynamicSite> {
         params.items.iter().any(
             |p| matches!(&p.pattern, BindingPattern::BindingIdentifier(id) if id.name == "require"),
         )
-    }
-
-    /// A template literal with no interpolation is as static as a string
-    /// literal — Rolldown resolves both.
-    fn static_specifier(expr: &Expression<'_>) -> Option<String> {
-        match expr {
-            Expression::StringLiteral(s) => Some(s.value.to_string()),
-            Expression::TemplateLiteral(t) if t.expressions.is_empty() => t
-                .quasis
-                .first()
-                .map(|q| q.value.cooked.as_ref().unwrap_or(&q.value.raw).to_string()),
-            _ => None,
-        }
-    }
-
-    fn is_static_specifier(expr: &Expression<'_>) -> bool {
-        static_specifier(expr).is_some()
     }
 
     let source_type = SourceType::from_path(id).unwrap_or_else(|_| SourceType::mjs());
@@ -1334,6 +1610,165 @@ mod tests {
             );
             let _ = std::fs::remove_dir_all(&dir);
         }
+    }
+
+    /// A fixture dir unique to this call, so parallel test threads never share a
+    /// path (the bundler keys diagnostics on it, and asset names on content).
+    fn fixture_dir(tag: &str) -> PathBuf {
+        static N: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = N.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("nub-{tag}-{}-{seq}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    // The whole contract of the `new URL` rewrite, against a REAL bundle: the
+    // referenced file's bytes ship, the chunk names the embedded copy instead of
+    // the source-tree path, and the base stays `import.meta.url` — which is what
+    // makes the compiled binary read the right file from any cwd. Until this
+    // existed the same source compiled clean and threw ENOENT on first run.
+    #[test]
+    fn a_new_url_beside_a_module_ships_its_bytes_and_keeps_the_module_relative_base() {
+        let dir = fixture_dir("newurl");
+        std::fs::write(dir.join("data.json"), br#"{"k":"NEWURLBYTES"}"#).unwrap();
+        std::fs::write(
+            dir.join("entry.ts"),
+            b"import { readFileSync } from 'node:fs';\n\
+              globalThis.OUT = readFileSync(new URL('./data.json', import.meta.url), 'utf8');\n",
+        )
+        .unwrap();
+
+        let mut o = opts();
+        o.minify = false;
+        let res = bundle(&dir.join("entry.ts"), &o).expect("a new URL asset must compile");
+
+        assert_eq!(res.assets.len(), 1, "the referenced file must ship");
+        assert_eq!(res.assets[0].bytes, br#"{"k":"NEWURLBYTES"}"#);
+        assert!(
+            !res.assets[0].name.contains('/'),
+            "the asset must be a flat sibling of the chunks: {}",
+            res.assets[0].name
+        );
+        let code = String::from_utf8(res.files[0].bytes.clone()).unwrap();
+        assert!(
+            code.contains(&res.assets[0].name),
+            "the chunk must name the embedded copy, got:\n{code}"
+        );
+        assert!(
+            !code.contains("\"./data.json\"") && !code.contains("'./data.json'"),
+            "the source-tree path must not survive — it does not exist where the \
+             binary runs, got:\n{code}"
+        );
+        assert!(
+            code.contains("import.meta.url"),
+            "the base must stay module-relative, not cwd-relative, got:\n{code}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The honest scope of the fix, and the control for the test above. A computed
+    // URL cannot be embedded, and must NOT become a new build failure: the same
+    // expression is how a program names a file it will WRITE, and a specifier
+    // pointing at nothing on the build machine is that same case spelled
+    // statically. Both still compile, and neither ships bytes.
+    #[test]
+    fn a_url_this_build_cannot_follow_still_compiles_and_ships_nothing() {
+        for (tag, src) in [
+            (
+                "computed",
+                "const name = globalThis.PICK;\n\
+                 globalThis.OUT = new URL(name, import.meta.url);\n",
+            ),
+            (
+                "absent",
+                "globalThis.OUT = new URL('./written-at-runtime.log', import.meta.url);\n",
+            ),
+            (
+                "scheme",
+                "globalThis.OUT = [\n\
+                 \x20\x20new URL('https://example.com/x.json', import.meta.url),\n\
+                 \x20\x20new URL('data:text/plain,hi', import.meta.url),\n\
+                 \x20\x20new URL('/data.json', import.meta.url),\n\
+                 ];\n",
+            ),
+            (
+                "shadowed",
+                "class URL { constructor(a, b) { this.a = a; this.b = b; } }\n\
+                 globalThis.OUT = new URL('./data.json', import.meta.url);\n",
+            ),
+        ] {
+            let dir = fixture_dir(&format!("newurl-{tag}"));
+            // Present on disk for every case, so "nothing shipped" can only be the
+            // rule under test and never a missing fixture.
+            std::fs::write(dir.join("data.json"), b"{}").unwrap();
+            std::fs::write(dir.join("entry.ts"), src).unwrap();
+
+            let mut o = opts();
+            o.minify = false;
+            let res = bundle(&dir.join("entry.ts"), &o)
+                .unwrap_or_else(|e| panic!("{tag} must still compile, got: {e:#}"));
+            assert!(
+                res.assets.is_empty(),
+                "{tag} must ship no asset, got {:?}",
+                res.assets.iter().map(|a| &a.name).collect::<Vec<_>>()
+            );
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+
+    // Resolution is PER MODULE, not per entry: a dependency in a subdirectory
+    // names its own sibling, and after bundling both modules share one chunk at
+    // the app root. Getting this wrong resolves against the entry's directory and
+    // silently embeds the wrong file — or none.
+    #[test]
+    fn a_new_url_in_a_nested_module_resolves_against_that_module() {
+        let dir = fixture_dir("newurl-nested");
+        std::fs::create_dir_all(dir.join("lib")).unwrap();
+        std::fs::write(dir.join("lib/table.bin"), b"NESTEDBYTES").unwrap();
+        std::fs::write(
+            dir.join("lib/load.ts"),
+            b"export const at = new URL('./table.bin', import.meta.url);\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("entry.ts"),
+            b"import { at } from './lib/load.ts';\nglobalThis.OUT = at;\n",
+        )
+        .unwrap();
+
+        let mut o = opts();
+        o.minify = false;
+        let res = bundle(&dir.join("entry.ts"), &o).expect("compiles");
+        assert_eq!(res.assets.len(), 1, "the nested sibling must ship");
+        assert_eq!(res.assets[0].bytes, b"NESTEDBYTES");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The invariant behind `map: HookTransformOutputMap::Null` — the transform
+    // does not move positions, so every line must still begin where it did. A
+    // no-substitution template literal is the one specifier form that can span
+    // lines, so its newlines have to come back.
+    #[test]
+    fn the_rewrite_preserves_the_sources_line_structure() {
+        let source = "const a = new URL(`./one\n.json`, import.meta.url);\nconst b = 2;\n";
+        let edits = vec![(
+            NewUrlEdit {
+                start: source.find('`').unwrap(),
+                end: source.rfind('`').unwrap() + 1,
+                source: PathBuf::from("/p/one\n.json"),
+            },
+            "one-a1b2c3d4.json".to_string(),
+        )];
+        let out = rewrite_new_urls(source, &edits);
+        assert_eq!(
+            out.matches('\n').count(),
+            source.matches('\n').count(),
+            "line count must survive the splice, got:\n{out}"
+        );
+        assert!(out.contains("\"./one-a1b2c3d4.json\""), "{out}");
+        assert!(out.ends_with("const b = 2;\n"), "{out}");
     }
 
     #[test]

--- a/crates/nub-cli/src/compile/loaders.rs
+++ b/crates/nub-cli/src/compile/loaders.rs
@@ -310,6 +310,14 @@ fn loader_name(ty: &ModuleType) -> &'static str {
 /// Content-hashed, not path-hashed, so two imports of the same bytes dedupe to
 /// one payload entry while two different files that merely share a basename
 /// (`icons/logo.png` and `brand/logo.png`) cannot collide.
+///
+/// LOWERCASED, so a generated name can never collide with another one on a
+/// filesystem that folds case. `a/Logo.bin` and `b/logo.bin` otherwise yield two
+/// payload names differing only in case: identical bytes, one file on Windows or
+/// on default APFS, and the build fails a collision check the user cannot act on
+/// because neither name is one they wrote. Folding here makes the pair dedupe to
+/// a single entry — correct, since a shared content hash means shared bytes —
+/// while different content still separates on the hash.
 fn asset_name(source: &Path, bytes: &[u8]) -> String {
     let stem: String = source
         .file_stem()
@@ -318,7 +326,7 @@ fn asset_name(source: &Path, bytes: &[u8]) -> String {
         .chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
+                c.to_ascii_lowercase()
             } else {
                 '-'
             }
@@ -331,7 +339,7 @@ fn asset_name(source: &Path, bytes: &[u8]) -> String {
     };
     let hash = format!("{:x}", Sha256::digest(bytes));
     match source.extension().and_then(|e| e.to_str()) {
-        Some(ext) => format!("{stem}-{}.{ext}", &hash[..8]),
+        Some(ext) => format!("{stem}-{}.{}", &hash[..8], ext.to_lowercase()),
         None => format!("{stem}-{}", &hash[..8]),
     }
 }
@@ -595,6 +603,25 @@ mod tests {
         assert_ne!(a, b, "same basename, different bytes must not collide");
         assert_eq!(a, c, "identical bytes must dedupe to one payload entry");
         assert!(a.starts_with("logo-") && a.ends_with(".png"), "{a}");
+    }
+
+    // A generated name must be safe on a filesystem that folds case, or two
+    // assets nub named itself can collide — and the collision error would tell
+    // the user to rename a file they never wrote.
+    #[test]
+    fn generated_names_cannot_differ_only_in_case() {
+        let upper = asset_name(Path::new("/p/a/Logo.BIN"), b"SAME");
+        let lower = asset_name(Path::new("/p/b/logo.bin"), b"SAME");
+        assert_eq!(
+            upper, lower,
+            "identical bytes must collapse to one entry rather than to a case-variant pair"
+        );
+        assert_eq!(upper, upper.to_lowercase(), "{upper} must be lowercase");
+        assert_ne!(
+            asset_name(Path::new("/p/a/Logo.bin"), b"ONE"),
+            asset_name(Path::new("/p/b/logo.bin"), b"TWO"),
+            "different bytes must still separate on the hash"
+        );
     }
 
     #[test]

--- a/crates/nub-cli/src/compile/loaders.rs
+++ b/crates/nub-cli/src/compile/loaders.rs
@@ -36,7 +36,7 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, bail};
 use rolldown::plugin::{
@@ -154,6 +154,43 @@ pub struct FileAsset {
     pub bytes: Vec<u8>,
 }
 
+/// The assets one build collected, keyed by the payload name each takes.
+///
+/// SHARED by every path that embeds a file — this module's `file` loader and the
+/// `new URL(…, import.meta.url)` rewrite in [`crate::compile::bundle`] — so one
+/// file reached both ways dedupes to a single payload entry instead of shipping
+/// twice, and both paths inherit the same naming and the same flat layout.
+#[derive(Debug, Default)]
+pub struct Assets(Mutex<BTreeMap<String, Vec<u8>>>);
+
+impl Assets {
+    /// Record `bytes` under the payload name `source` earns, and return that name
+    /// for the emitting code to reference.
+    pub fn add(&self, source: &Path, bytes: Vec<u8>) -> Result<String> {
+        let name = asset_name(source, &bytes);
+        // A silent drop here would ship a chunk naming a file that is not in the
+        // payload — a runtime ENOENT with nothing to attribute it to.
+        self.0
+            .lock()
+            .map_err(|_| anyhow::anyhow!("the asset collector was poisoned by an earlier panic"))?
+            .insert(name.clone(), bytes);
+        Ok(name)
+    }
+
+    /// Every asset this build emitted, in a deterministic order — `app_sha256`
+    /// hashes the payload in order, so a nondeterministic one would re-key the
+    /// extraction dir on every compile of identical inputs.
+    pub fn take(&self) -> Vec<FileAsset> {
+        self.0
+            .lock()
+            .map(|mut g| std::mem::take(&mut *g))
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(name, bytes)| FileAsset { name, bytes })
+            .collect()
+    }
+}
+
 /// Rolldown plugin implementing `file`: emit the bytes as a sibling of the
 /// chunks, and evaluate the import to that sibling's ABSOLUTE path at runtime.
 ///
@@ -169,14 +206,14 @@ pub struct FilePlugin {
     /// its doc comment. The loader's NAME is kept, not just which family it is
     /// in, so [`FilePlugin::case_mismatch`] can suggest the flag verbatim.
     by_ext: BTreeMap<String, &'static str>,
-    collected: Mutex<BTreeMap<String, Vec<u8>>>,
+    collected: Arc<Assets>,
     /// Hints for imports whose extension is mapped only in another case. Kept
     /// here rather than raised from the hook — see the `load` implementation.
     case_hints: Mutex<std::collections::BTreeSet<String>>,
 }
 
 impl FilePlugin {
-    pub fn new(loaders: &Loaders) -> Self {
+    pub fn new(loaders: &Loaders, collected: Arc<Assets>) -> Self {
         let mut by_ext: BTreeMap<String, &'static str> = loaders
             .module_types
             .iter()
@@ -185,7 +222,7 @@ impl FilePlugin {
         by_ext.extend(loaders.file.iter().map(|ext| (ext.clone(), "file")));
         Self {
             by_ext,
-            collected: Mutex::new(BTreeMap::new()),
+            collected,
             case_hints: Mutex::new(std::collections::BTreeSet::new()),
         }
     }
@@ -197,19 +234,6 @@ impl FilePlugin {
             .lock()
             .map(|h| h.iter().cloned().collect())
             .unwrap_or_default()
-    }
-
-    /// Every asset this build emitted, in a deterministic order — `app_sha256`
-    /// hashes the payload in order, so a nondeterministic one would re-key the
-    /// extraction dir on every compile of identical inputs.
-    pub fn take(&self) -> Vec<FileAsset> {
-        self.collected
-            .lock()
-            .map(|mut g| std::mem::take(&mut *g))
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(name, bytes)| FileAsset { name, bytes })
-            .collect()
     }
 
     /// Whether the `file` loader owns `id`.
@@ -239,7 +263,7 @@ impl FilePlugin {
     /// byte-oriented loaders (`base64`, `binary`, `dataurl`) need bytes. One rule
     /// for both families is worth more than a convenience that holds in one;
     /// an uppercase extension is spelled `--loader .PNG=file`.
-    fn claims(&self, id: &str) -> bool {
+    pub fn claims(&self, id: &str) -> bool {
         id.match_indices('.')
             .find_map(|(i, _)| self.by_ext.get(&id[i + 1..]))
             .is_some_and(|loader| *loader == "file")
@@ -378,16 +402,7 @@ impl Plugin for FilePlugin {
             }
             let bytes = std::fs::read(&id)
                 .map_err(|e| anyhow::anyhow!("reading the imported asset {id}: {e}"))?;
-            let name = asset_name(Path::new(&id), &bytes);
-            let code = file_module(&name);
-            // A silent drop here would ship a chunk naming a file that is not in
-            // the payload — a runtime ENOENT with nothing to attribute it to.
-            self.collected
-                .lock()
-                .map_err(|_| {
-                    anyhow::anyhow!("the asset collector was poisoned by an earlier panic")
-                })?
-                .insert(name, bytes);
+            let code = file_module(&self.collected.add(Path::new(&id), bytes)?);
             Ok(Some(HookLoadOutput {
                 code: code.into(),
                 module_type: Some(ModuleType::Js),
@@ -454,7 +469,7 @@ mod tests {
     // depending on which loader family the value named.
     #[test]
     fn a_multi_dot_extension_is_claimed_the_way_rolldown_matches_it() {
-        let p = FilePlugin::new(&plan(&[".tar.gz=file".into()]).expect("valid"));
+        let p = FilePlugin::new(&plan(&[".tar.gz=file".into()]).expect("valid"), Arc::default());
         assert!(p.claims("/proj/bundle.tar.gz"));
         assert!(!p.claims("/proj/notes.gz"), "only .tar.gz was mapped");
     }
@@ -466,7 +481,7 @@ mod tests {
     #[test]
     fn the_more_specific_mapping_wins_across_loader_families() {
         let loaders = plan(&[".gz=file".into(), ".tar.gz=text".into()]).expect("valid");
-        let p = FilePlugin::new(&loaders);
+        let p = FilePlugin::new(&loaders, Arc::default());
         assert!(
             !p.claims("/proj/bundle.tar.gz"),
             "the text mapping is more specific and must win"
@@ -477,7 +492,7 @@ mod tests {
     // A path component containing a dot must not be read as an extension.
     #[test]
     fn a_dot_in_a_directory_name_does_not_decide_the_loader() {
-        let p = FilePlugin::new(&plan(&[]).expect("valid"));
+        let p = FilePlugin::new(&plan(&[]).expect("valid"), Arc::default());
         assert!(p.claims("/home/user.v2/app/icon.png"));
         assert!(!p.claims("/home/user.v2/app/main.ts"));
     }
@@ -508,7 +523,7 @@ mod tests {
     // the mapped extension is in.
     #[test]
     fn a_case_mismatched_extension_names_the_flag_that_fixes_it() {
-        let p = FilePlugin::new(&plan(&[]).expect("valid"));
+        let p = FilePlugin::new(&plan(&[]).expect("valid"), Arc::default());
         assert_eq!(p.case_mismatch("/proj/PHOTO.PNG"), Some(("png", "file")));
         assert_eq!(p.case_mismatch("/proj/PROMPT.MD"), Some(("md", "text")));
         assert_eq!(
@@ -531,7 +546,7 @@ mod tests {
 
     #[test]
     fn extension_matching_is_case_sensitive_in_both_families() {
-        let d = FilePlugin::new(&plan(&[]).expect("valid"));
+        let d = FilePlugin::new(&plan(&[]).expect("valid"), Arc::default());
         assert!(d.claims("/proj/photo.png"));
         assert!(
             !d.claims("/proj/PHOTO.PNG"),
@@ -542,7 +557,7 @@ mod tests {
 
         let upper = plan(&[".PNG=file".into()]).expect("valid");
         assert!(
-            FilePlugin::new(&upper).claims("/proj/PHOTO.PNG"),
+            FilePlugin::new(&upper, Arc::default()).claims("/proj/PHOTO.PNG"),
             "naming the extension as written is how an uppercase one is mapped"
         );
     }

--- a/crates/nub-cli/src/compile/loaders.rs
+++ b/crates/nub-cli/src/compile/loaders.rs
@@ -469,7 +469,10 @@ mod tests {
     // depending on which loader family the value named.
     #[test]
     fn a_multi_dot_extension_is_claimed_the_way_rolldown_matches_it() {
-        let p = FilePlugin::new(&plan(&[".tar.gz=file".into()]).expect("valid"), Arc::default());
+        let p = FilePlugin::new(
+            &plan(&[".tar.gz=file".into()]).expect("valid"),
+            Arc::default(),
+        );
         assert!(p.claims("/proj/bundle.tar.gz"));
         assert!(!p.claims("/proj/notes.gz"), "only .tar.gz was mapped");
     }

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -320,16 +320,13 @@ fn assemble_app(
         .map(|f| (layout.bundle_path(&f.name), f.bytes.clone()))
         .collect();
 
+    let embedded: std::collections::HashSet<String> = bundled
+        .assets
+        .iter()
+        .map(|f| layout.bundle_path(&f.name))
+        .chain(layout.assets.iter().map(|a| a.rel.clone()))
+        .collect();
     for asset in &layout.assets {
-        // Overwriting a chunk would replace compiled code with whatever the user
-        // pointed at — always a mistake, and silent until the binary runs.
-        if files.iter().any(|(name, _)| *name == asset.rel) {
-            bail!(
-                "--include would overwrite compiled output: {} is also a bundle chunk \
-                 or a loader-emitted asset. Rename the file or drop it from --include.",
-                asset.rel
-            );
-        }
         let bytes = fs::read(&asset.source)
             .with_context(|| format!("reading {}", asset.source.display()))?;
         files.push((asset.rel.clone(), bytes));
@@ -355,6 +352,8 @@ fn assemble_app(
         }
         None => files.push((pkg, br#"{"type":"module"}"#.to_vec())),
     }
+
+    reject_colliding_names(&files, &embedded, target)?;
 
     // The launcher refuses any payload name that could escape its extraction dir.
     // Names are partly user-derived since `--include`, so check the SAME predicate
@@ -384,6 +383,62 @@ fn assemble_app(
         }
     }
     Ok(files)
+}
+
+/// Refuse two payload entries the target's filesystem cannot keep apart.
+///
+/// The launcher writes entries in payload order, so a later one with the same
+/// name silently REPLACES an earlier one — and on a case-insensitive filesystem
+/// "the same name" includes a case variant. `--include Main.js` alongside an
+/// emitted chunk `main.js` therefore ships a binary whose compiled code has been
+/// overwritten by the asset, with nothing failing at build time. Same class as
+/// the trailing dot/space that Win32 strips (see `is_safe_windows_component` in
+/// nub-core), one level up: there the NAME is unusable, here the PAIR is.
+///
+/// Case folding is applied only where the TARGET folds, never the host — Win32
+/// always, and macOS because APFS is formatted case-insensitive by default. On
+/// Linux the two names are genuinely two files, so nothing is rejected and no
+/// working build is broken.
+fn reject_colliding_names(
+    files: &AppFiles,
+    embedded: &std::collections::HashSet<String>,
+    target: &TargetPlatform,
+) -> Result<()> {
+    let folds = matches!(target.os, TargetOs::Win32 | TargetOs::Darwin);
+    let mut seen: std::collections::HashMap<String, &str> =
+        std::collections::HashMap::with_capacity(files.len());
+    for (name, _) in files {
+        let key = if folds { name.to_lowercase() } else { name.clone() };
+        let Some(prev) = seen.insert(key, name.as_str()) else {
+            continue;
+        };
+        // Which side is the user's file is the whole fix: the other side is a
+        // chunk or the generated manifest, and neither has a spelling to change.
+        let describe = |n: &str| {
+            if embedded.contains(n) {
+                "an embedded file"
+            } else {
+                "compiled output"
+            }
+        };
+        let why = if prev == name {
+            String::new()
+        } else {
+            format!(
+                "\n\x20\x20The names differ only in case, and {}'s filesystem does not \
+                 distinguish them.",
+                target.triple()
+            )
+        };
+        bail!(
+            "two files would collide in the compiled binary: {prev:?} ({}) and {name:?} ({}), \
+             so one would overwrite the other where it is extracted.{why}\n\
+             \x20\x20Rename one of them, or drop it from --include.",
+            describe(prev),
+            describe(name)
+        );
+    }
+    Ok(())
 }
 
 /// `--sourcemap=external` maps land BESIDE the executable, deliberately outside
@@ -986,6 +1041,83 @@ mod tests {
         let linux = TargetPlatform::parse("linux-x64").unwrap();
         assemble_app(&bundled, &layout, &linux)
             .expect("a backslash name is one legal component on a Unix target");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// A one-chunk bundle plus one `--include`d file named `rel`, which is the
+    /// whole setup both collision tests need.
+    fn app_with_included(dir: &Path, rel: &str) -> (bundle::BundleResult, assets::Layout) {
+        let source = dir.join("included");
+        fs::write(&source, b"asset").unwrap();
+        (
+            bundle::BundleResult {
+                entry: "main.js".into(),
+                files: vec![bundle::BundledFile {
+                    name: "main.js".into(),
+                    bytes: b"export {}".to_vec(),
+                }],
+                detached_maps: Vec::new(),
+                assets: Vec::new(),
+            },
+            assets::Layout {
+                entry_prefix: String::new(),
+                assets: vec![assets::Asset {
+                    source,
+                    rel: rel.to_string(),
+                }],
+            },
+        )
+    }
+
+    /// A case-only collision is invisible on the build host and destroys the
+    /// binary on a machine whose filesystem folds: the asset lands ON the chunk at
+    /// extraction and the compiled code is simply gone. Refused where the TARGET
+    /// folds — Win32 always, macOS because APFS defaults to case-insensitive —
+    /// and allowed on Linux, where the two names really are two files.
+    #[test]
+    fn a_case_only_collision_is_refused_exactly_where_the_target_folds() {
+        let dir = fresh_dir("casefold");
+        let (bundled, layout) = app_with_included(&dir, "Main.js");
+
+        for triple in ["win32-x64", "darwin-arm64"] {
+            let target = TargetPlatform::parse(triple).unwrap();
+            let Err(err) = assemble_app(&bundled, &layout, &target) else {
+                panic!("{triple} folds case and must refuse the pair");
+            };
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("\"Main.js\"") && msg.contains("\"main.js\""),
+                "{triple}: both colliding paths must be named: {msg}"
+            );
+            assert!(
+                msg.contains("an embedded file") && msg.contains("compiled output"),
+                "{triple}: the message must say which side is the asset: {msg}"
+            );
+            assert!(
+                msg.contains(triple),
+                "{triple}: the target whose filesystem folds must be named: {msg}"
+            );
+        }
+
+        let linux = TargetPlatform::parse("linux-x64").unwrap();
+        assemble_app(&bundled, &layout, &linux)
+            .expect("Main.js and main.js are two distinct files on Linux");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The exact-name case predates the fold-aware one and must survive it: an
+    /// `--include` whose name IS a chunk's replaces compiled code on every target.
+    #[test]
+    fn an_include_that_shadows_a_chunk_is_refused_on_every_target() {
+        let dir = fresh_dir("exactdup");
+        let (bundled, layout) = app_with_included(&dir, "main.js");
+        for triple in ["linux-x64", "win32-x64", "darwin-arm64"] {
+            let target = TargetPlatform::parse(triple).unwrap();
+            let Err(err) = assemble_app(&bundled, &layout, &target) else {
+                panic!("{triple} must refuse an exact duplicate");
+            };
+            assert!(format!("{err:#}").contains("collide"), "{triple}: {err:#}");
+        }
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -108,9 +108,12 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
     let mut entry_name = layout.bundle_path(&bundled.entry);
     let mut app_files = assemble_app(&bundled, &layout, &target)?;
     if !opts.bundle.external.is_empty() {
-        // These land AFTER assemble_app's payload-name gate. Safe because both are
-        // fixed constants legal on every target — a shim name derived from user
-        // input would have to move the gate here.
+        // These land AFTER assemble_app's payload-name and collision gates. Safe
+        // for the NAME gate because both are fixed constants legal on every
+        // target; a shim name derived from user input would have to move it here.
+        // The COLLISION gate is a weaker story: `external::shim` refuses a bundle
+        // file of the same name, but only exact-case, so an `--include` differing
+        // from a shim name in case alone still overwrites on a folding target.
         let shim = external::shim(&app_files, &entry_name, &opts.bundle.external)?;
         entry_name = shim.entry;
         app_files.extend(shim.files);
@@ -320,16 +323,17 @@ fn assemble_app(
         .map(|f| (layout.bundle_path(&f.name), f.bytes.clone()))
         .collect();
 
-    let embedded: std::collections::HashSet<String> = bundled
-        .assets
-        .iter()
-        .map(|f| layout.bundle_path(&f.name))
-        .chain(layout.assets.iter().map(|a| a.rel.clone()))
-        .collect();
+    // Tracked POSITIONALLY, not by looking a name up in a set: in a collision the
+    // two sides share a name, so a name-keyed lookup labels both of them the same
+    // and the message loses the one thing that makes it actionable — which side is
+    // the file the user can rename.
+    let mut origins: Vec<Origin> = vec![Origin::Compiled; bundled.files.len()];
+    origins.resize(files.len(), Origin::Generated);
     for asset in &layout.assets {
         let bytes = fs::read(&asset.source)
             .with_context(|| format!("reading {}", asset.source.display()))?;
         files.push((asset.rel.clone(), bytes));
+        origins.push(Origin::Included);
     }
 
     let pkg = layout.bundle_path("package.json");
@@ -350,10 +354,13 @@ fn assemble_app(
                 );
             }
         }
-        None => files.push((pkg, br#"{"type":"module"}"#.to_vec())),
+        None => {
+            files.push((pkg, br#"{"type":"module"}"#.to_vec()));
+            origins.push(Origin::Manifest);
+        }
     }
 
-    reject_colliding_names(&files, &embedded, target)?;
+    reject_colliding_names(&files, &origins, target)?;
 
     // The launcher refuses any payload name that could escape its extraction dir.
     // Names are partly user-derived since `--include`, so check the SAME predicate
@@ -385,6 +392,31 @@ fn assemble_app(
     Ok(files)
 }
 
+/// Where a payload entry came from. Carried alongside the names so a collision
+/// can say which of the two the user is able to change.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Origin {
+    /// A bundle chunk, or a source map shipped with one.
+    Compiled,
+    /// Bytes the bundler embedded for a `file` import or a `new URL(…)`.
+    Generated,
+    /// A file the user named with `--include`.
+    Included,
+    /// The `package.json` nub synthesizes when the app ships none.
+    Manifest,
+}
+
+impl Origin {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Compiled => "compiled output",
+            Self::Generated => "an embedded asset",
+            Self::Included => "an --included file",
+            Self::Manifest => "the generated package.json",
+        }
+    }
+}
+
 /// Refuse two payload entries the target's filesystem cannot keep apart.
 ///
 /// The launcher writes entries in payload order, so a later one with the same
@@ -399,32 +431,29 @@ fn assemble_app(
 /// always, and macOS because APFS is formatted case-insensitive by default. On
 /// Linux the two names are genuinely two files, so nothing is rejected and no
 /// working build is broken.
+///
+/// Nub's OWN generated names cannot reach here as a fold-collision: `asset_name`
+/// lowercases them, so a case-variant pair either dedupes (same bytes) or
+/// separates on the content hash. Every collision this reports therefore has a
+/// name the user wrote on at least one side.
 fn reject_colliding_names(
     files: &AppFiles,
-    embedded: &std::collections::HashSet<String>,
+    origins: &[Origin],
     target: &TargetPlatform,
 ) -> Result<()> {
     let folds = matches!(target.os, TargetOs::Win32 | TargetOs::Darwin);
-    let mut seen: std::collections::HashMap<String, &str> =
+    let mut seen: std::collections::HashMap<String, usize> =
         std::collections::HashMap::with_capacity(files.len());
-    for (name, _) in files {
+    for (i, (name, _)) in files.iter().enumerate() {
         let key = if folds {
             name.to_lowercase()
         } else {
             name.clone()
         };
-        let Some(prev) = seen.insert(key, name.as_str()) else {
+        let Some(first) = seen.insert(key, i) else {
             continue;
         };
-        // Which side is the user's file is the whole fix: the other side is a
-        // chunk or the generated manifest, and neither has a spelling to change.
-        let describe = |n: &str| {
-            if embedded.contains(n) {
-                "an embedded file"
-            } else {
-                "compiled output"
-            }
-        };
+        let (prev, prev_origin) = (&files[first].0, origins[first]);
         let why = if prev == name {
             String::new()
         } else {
@@ -434,12 +463,19 @@ fn reject_colliding_names(
                 target.triple()
             )
         };
+        // Only an --include has a spelling the user chose; a chunk name follows the
+        // entry's, so pointing at --include when neither side is one would send
+        // them to a flag they never passed.
+        let fix = if [prev_origin, origins[i]].contains(&Origin::Included) {
+            "\x20\x20Rename the file, or drop it from --include."
+        } else {
+            "\x20\x20Rename the source file one of them is named after."
+        };
         bail!(
             "two files would collide in the compiled binary: {prev:?} ({}) and {name:?} ({}), \
-             so one would overwrite the other where it is extracted.{why}\n\
-             \x20\x20Rename one of them, or drop it from --include.",
-            describe(prev),
-            describe(name)
+             so one would overwrite the other where it is extracted.{why}\n{fix}",
+            prev_origin.label(),
+            origins[i].label()
         );
     }
     Ok(())
@@ -1094,7 +1130,7 @@ mod tests {
                 "{triple}: both colliding paths must be named: {msg}"
             );
             assert!(
-                msg.contains("an embedded file") && msg.contains("compiled output"),
+                msg.contains("an --included file") && msg.contains("compiled output"),
                 "{triple}: the message must say which side is the asset: {msg}"
             );
             assert!(
@@ -1120,7 +1156,14 @@ mod tests {
             let Err(err) = assemble_app(&bundled, &layout, &target) else {
                 panic!("{triple} must refuse an exact duplicate");
             };
-            assert!(format!("{err:#}").contains("collide"), "{triple}: {err:#}");
+            // Both sides share the name here, so a name-keyed lookup would label
+            // them identically and lose the only fact that makes the message
+            // actionable — which of the two the user can rename.
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("compiled output") && msg.contains("an --included file"),
+                "{triple}: each side must be named by where it came from: {msg}"
+            );
         }
         let _ = fs::remove_dir_all(&dir);
     }

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -408,7 +408,11 @@ fn reject_colliding_names(
     let mut seen: std::collections::HashMap<String, &str> =
         std::collections::HashMap::with_capacity(files.len());
     for (name, _) in files {
-        let key = if folds { name.to_lowercase() } else { name.clone() };
+        let key = if folds {
+            name.to_lowercase()
+        } else {
+            name.clone()
+        };
         let Some(prev) = seen.insert(key, name.as_str()) else {
             continue;
         };

--- a/site/content/docs/compile.mdx
+++ b/site/content/docs/compile.mdx
@@ -175,8 +175,8 @@ Embedded files are extracted beside the compiled entry, keeping the layout they 
 
 ```ts
 // src/index.ts, compiled with the command above
-const instructions = readFileSync(join(__dirname, "instructions.md"), "utf8");
-const icons = createReadStream(join(__dirname, "..", "assets", "icons.xml"));
+const instructions = readFileSync(join(import.meta.dirname, "instructions.md"), "utf8");
+const icons = createReadStream(join(import.meta.dirname, "..", "assets", "icons.xml"));
 ```
 
 Because they are real files, every filesystem API works on them — `readFile`, `createReadStream`, `stat`, `readdir`, and a native addon opening the path itself.
@@ -240,7 +240,7 @@ import wasm from "./model.wasm";
 const { instance } = await WebAssembly.instantiate(readFileSync(wasm));
 ```
 
-The path is absolute and computed when the executable runs, so it holds wherever the binary is started from — no joining against `__dirname` first.
+The path is absolute and computed when the executable runs, so it holds wherever the binary is started from — no joining against a base directory first.
 
 Import attributes are accepted and ignored, since the extension already decides. Both of these load the same text:
 
@@ -265,21 +265,21 @@ The specifier is resolved per module, so a helper in a subdirectory names its ow
 Only a literal specifier can be embedded, since the file has to be known while the binary is being built. Anything else is left exactly as written:
 
 ```ts
-new URL("./table.bin", import.meta.url)   // embedded
-new URL(`./${locale}.json`, import.meta.url)   // computed — left alone
-new URL("./cache.db", import.meta.url)    // no such file at build time — left alone
+new URL("./table.bin", import.meta.url)         // embedded
+new URL(`./${locale}.json`, import.meta.url)    // computed — left alone
+new URL("./cache.db", import.meta.url)          // no such file yet — left alone
 ```
 
 The last two are also how a program names a file it *writes*, so neither is an error. Embed the files a computed URL might reach with `--include`, and reach them by a path the entry can see (below).
 
 ## Asset paths resolve from the entry
 
-Compiling bundles every module into one file at the entry's location, so any path a module computes at runtime from `__dirname` or `import.meta.url` resolves against the entry's directory — including in code that lived in a subdirectory beforehand. Write those paths as the entry would see them:
+Compiling bundles every module into one file at the entry's location, so any path a module computes at runtime from `import.meta.dirname` or `import.meta.url` resolves against the entry's directory — including in code that lived in a subdirectory beforehand. Write those paths as the entry would see them:
 
 ```ts
 // Entry src/index.ts, helper src/shapes/lib.ts, asset at assets/icons.xml.
-join(__dirname, "..", "assets", "icons.xml")        // from the entry — works either way
-join(__dirname, "..", "..", "assets", "icons.xml")  // from the helper — breaks once compiled
+join(import.meta.dirname, "..", "assets", "icons.xml")        // from the entry — works either way
+join(import.meta.dirname, "..", "..", "assets", "icons.xml")  // from the helper — breaks once compiled
 ```
 
 The helper's path is right until it is bundled into the entry, one directory up. Computing asset paths in the entry, or from a single exported base directory, keeps both forms working.

--- a/site/content/docs/compile.mdx
+++ b/site/content/docs/compile.mdx
@@ -175,7 +175,7 @@ Embedded files are extracted beside the compiled entry, keeping the layout they 
 
 ```ts
 // src/index.ts, compiled with the command above
-const instructions = readFileSync(new URL("./instructions.md", import.meta.url), "utf8");
+const instructions = readFileSync(join(__dirname, "instructions.md"), "utf8");
 const icons = createReadStream(join(__dirname, "..", "assets", "icons.xml"));
 ```
 
@@ -195,6 +195,15 @@ Error: --include "data/missing.json" matched no files (the path does not exist)
 ```
 
 Embedded bytes are stored as they are, not compressed, so the executable grows by roughly the size of what you embed.
+
+An embedded file that would land on top of compiled output is refused. On a target whose filesystem ignores case — Windows, and macOS by default — that includes a name matching only in case:
+
+```console
+$ nub compile main.ts --include=Main.js
+Error: two files would collide in the compiled binary: "main.js" (compiled output) and "Main.js" (an embedded file), so one would overwrite the other where it is extracted.
+  The names differ only in case, and darwin-arm64's filesystem does not distinguish them.
+  Rename one of them, or drop it from --include.
+```
 
 ## `--exclude`
 
@@ -242,9 +251,30 @@ import prompt from "./prompt.md" with { type: "text" };
 
 An asset that nothing uses is left out of the executable, so an unused import costs nothing.
 
+## Naming a file with a URL
+
+Writing a `new URL()` against `import.meta.url` — the ordinary ESM way to name a file sitting beside your module — embeds that file. You do not need `--include` for it:
+
+```ts
+// src/shapes/lib.ts, with table.bin beside it on disk
+const table = readFileSync(new URL("./table.bin", import.meta.url));
+```
+
+The specifier is resolved per module, so a helper in a subdirectory names its own siblings and keeps working once it is bundled into the entry.
+
+Only a literal specifier can be embedded, since the file has to be known while the binary is being built. Anything else is left exactly as written:
+
+```ts
+new URL("./table.bin", import.meta.url)   // embedded
+new URL(`./${locale}.json`, import.meta.url)   // computed — left alone
+new URL("./cache.db", import.meta.url)    // no such file at build time — left alone
+```
+
+The last two are also how a program names a file it *writes*, so neither is an error. Embed the files a computed URL might reach with `--include`, and reach them by a path the entry can see (below).
+
 ## Asset paths resolve from the entry
 
-Compiling bundles every module into one file at the entry's location, so in the compiled app `import.meta.url` and `__dirname` always point at the entry's directory — including in code that lived in a subdirectory beforehand. Write asset paths as the entry would see them:
+Compiling bundles every module into one file at the entry's location, so any path a module computes at runtime from `__dirname` or `import.meta.url` resolves against the entry's directory — including in code that lived in a subdirectory beforehand. Write those paths as the entry would see them:
 
 ```ts
 // Entry src/index.ts, helper src/shapes/lib.ts, asset at assets/icons.xml.


### PR DESCRIPTION
Two silent-failure fixes for `nub compile`.

**A file named by `new URL("./x", import.meta.url)` is now embedded.** That form compiled clean and died with ENOENT. A transform plugin repoints a static specifier at an auto-embedded copy, reusing the `file` loader's collector, flat layout, and `import.meta.url` base. Anything computed, scheme-carrying, absolute, or not yet on disk is left as written.

**Case-only payload collisions are refused.** An `--include Main.js` beside chunk `main.js` built clean, then overwrote compiled code at extraction wherever the filesystem folds. Now target-aware: win32/darwin reject, linux allows.

Verified against a merge-base build with real executables.
