### PR TITLE
site: add Cloudflare and Vercel deployment pages

### DIFF
--- a/site/content/docs/deployment/cloudflare.mdx
+++ b/site/content/docs/deployment/cloudflare.mdx
@@ -1,0 +1,60 @@
+---
+title: Cloudflare
+description: Nub is preinstalled in the Cloudflare Workers Builds image, so package scripts that call it run with no setup step. Pages uses the devDependency pattern instead.
+---
+
+Cloudflare's Workers Builds image has preinstalled Nub since July 30, 2026. Package scripts that shell out to `nub` or `nubx` run unchanged:
+
+```json
+{
+  "scripts": {
+    "build": "nub run i18n:compile && nubx vite build"
+  }
+}
+```
+
+There's no setup step to add and no devDependency to carry — the binary is on PATH the way `pnpm` and `bun` already are ([tracking issue](https://github.com/cloudflare/pages-build-image/issues/13)).
+
+## Workers Builds
+
+Nub augments the Node the image provisions rather than bringing its own. Cloudflare's [build image](https://developers.cloudflare.com/workers/ci-cd/builds/build-image/) ships Node 22.23.2 and 24.18.0 and defaults to 24.18.0, so builds land on Nub's fast tier without configuration.
+
+Both tools read the same version files, so a pin moves them together:
+
+- `package.json` → `devEngines.runtime`
+- `.node-version`
+- `.nvmrc`
+- `package.json` → `engines.node`
+
+Set one and the build Node matches the version Nub resolves at runtime.
+
+<Callout type="warn">
+  Cloudflare's support for `.tool-versions` is limited, and an entry it cannot resolve fails the build. Prefer `.node-version` or `.nvmrc` on Workers Builds.
+</Callout>
+
+## Pages
+
+The change landed in the Workers Builds image, not the Pages one. A Pages build still reports:
+
+```console
+sh: nub: not found
+```
+
+Add `@nubjs/nub` as a devDependency there and call it from your scripts:
+
+```json
+{
+  "devDependencies": {
+    "@nubjs/nub": "^0.6.0"
+  },
+  "scripts": {
+    "build": "nubx vite build"
+  }
+}
+```
+
+The package declares `bin: { nub, nubx }`, so the install Cloudflare runs links both onto `node_modules/.bin` and your scripts resolve them. See [Hosted builds](/docs/deployment#hosted-builds) for the full pattern.
+
+## Version pinning
+
+The image carries one Nub version and moves it on Cloudflare's own cadence. To hold a project to a specific version instead, add `@nubjs/nub` as a devDependency as above — the same pattern Pages needs, and it works identically on Workers Builds.

--- a/site/content/docs/deployment/index.mdx
+++ b/site/content/docs/deployment/index.mdx
@@ -6,7 +6,9 @@ description: Getting the Nub CLI into a deploy or build environment — the GitH
 A Nub project needs the `nub` CLI present wherever it builds. How you get it there depends on whether the environment gives you a setup step:
 
 - **You control a setup step** — a CI workflow or a Dockerfile. Install Nub explicitly: the [GitHub Action](/docs/deployment/github-action) on GitHub Actions, or the [Docker](/docs/deployment/docker) images in a container.
-- **A hosted builder runs the install for you** — Cloudflare Workers Builds, Netlify, some Vercel setups. There's no seam to add a setup step, so Nub rides in as a devDependency.
+- **You control the install command** — [Vercel](/docs/deployment/vercel) lets you replace it, so one line installs Nub before the build runs.
+- **A hosted builder runs the install for you** — Netlify, Cloudflare Pages. There's no seam to add a setup step, so Nub rides in as a devDependency.
+- **The builder ships Nub already** — [Cloudflare Workers Builds](/docs/deployment/cloudflare) preinstalls it, so scripts that call it need nothing.
 
 ## Hosted builds
 
@@ -21,7 +23,7 @@ Add `@nubjs/nub` as a devDependency and call it from your scripts:
 ```json
 {
   "devDependencies": {
-    "@nubjs/nub": "^0.1.0"
+    "@nubjs/nub": "^0.6.0"
   },
   "scripts": {
     "build": "nubx vite build"
@@ -45,6 +47,8 @@ The builder still provisions Node from your version pin — set it so the build 
 - **GitHub Actions** — the [GitHub Action](/docs/deployment/github-action). It installs Nub, eagerly provisions the pinned Node, and fronts it on PATH.
 - **A Dockerfile you control** — the [Docker](/docs/deployment/docker) images, or one line to layer Nub onto your own `node` base.
 - **A hosted builder with no setup step** — the devDependency pattern above.
+- **Cloudflare** — [Workers Builds and Pages](/docs/deployment/cloudflare) differ; Workers Builds needs no setup.
+- **Vercel** — [an install-command override](/docs/deployment/vercel), or the devDependency pattern.
 
 ## Version managers
 

--- a/site/content/docs/deployment/meta.json
+++ b/site/content/docs/deployment/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Deployment",
   "defaultOpen": false,
-  "pages": ["index", "github-action", "docker"]
+  "pages": ["index", "github-action", "docker", "cloudflare", "vercel"]
 }

--- a/site/content/docs/deployment/vercel.mdx
+++ b/site/content/docs/deployment/vercel.mdx
@@ -1,0 +1,91 @@
+---
+title: Vercel
+description: Vercel ships no preinstalled Nub, but the install command is yours to replace — so one line puts the CLI on PATH for the rest of the build. The devDependency pattern works too.
+---
+
+import { Steps, Step } from 'fumadocs-ui/components/steps';
+
+[Vercel](https://vercel.com) doesn't ship Nub in its build image, but it lets you replace the install command — which is all it takes.
+
+<Steps>
+
+<Step>
+
+### Point the install command at Nub
+
+Add both commands to `vercel.json`. The installer fetches a static binary, then Nub installs the dependencies and runs the build:
+
+```json title="vercel.json"
+{
+  "installCommand": "curl -fsSL https://nubjs.com/install.sh | bash && export PATH=$HOME/.nub/bin:$PATH && nub install",
+  "buildCommand": "export PATH=$HOME/.nub/bin:$PATH && nub run build"
+}
+```
+
+<Callout type="warn" title="Export PATH — don't call the binary by path">
+  The installer writes to `$HOME/.nub/bin`, and calling `$HOME/.nub/bin/nub` directly looks equivalent but leaves Nub off PATH for everything it then starts. A script like `"build": "nub run i18n:compile && nubx vite build"` fails with `nub: command not found`. Because the install and build commands run as separate shells, the export belongs in both.
+</Callout>
+
+</Step>
+
+<Step>
+
+### Deploy
+
+Connect the repository from the Vercel dashboard, or push a deployment from the CLI:
+
+```bash
+nubx vercel deploy
+```
+
+</Step>
+
+<Step>
+
+### Verify Nub ran the build
+
+The build log names the version it installed and the Node it picked up:
+
+```console
+Installed nub v0.6.0 (with nubx) to /vercel/.nub/bin/nub
+nub 0.6.0 · ✓ Already up to date (2 packages)
+$ nub run build
+» node v24.15.0 (from PATH)
+Build Completed in /vercel/output [3s]
+```
+
+The Node line is the thing to check. Nub augments the Node the build machine already provisioned rather than downloading one, which is why adding it costs seconds.
+
+</Step>
+
+</Steps>
+
+## The devDependency alternative
+
+Overriding the install command isn't required. Adding the CLI as a devDependency also works and leaves `vercel.json` empty:
+
+```json
+{
+  "devDependencies": {
+    "@nubjs/nub": "^0.6.0"
+  },
+  "scripts": {
+    "build": "nubx vite build"
+  }
+}
+```
+
+Vercel's auto-detected install links `nub` and `nubx` onto `node_modules/.bin`, and your scripts resolve them. Reach for it when you'd rather pin the version in the manifest than in build settings; see [Hosted builds](/docs/deployment#hosted-builds) for the full pattern.
+
+<Callout>
+  Excluding development dependencies from the install drops the CLI along with them. Override the install command instead when a project builds without devDependencies.
+</Callout>
+
+## Node version
+
+Vercel selects the Node version and Nub adopts it, so pin it on Vercel's side:
+
+- Project Settings → Node.js Version
+- `package.json` → `engines.node`
+
+Nub reads `engines.node` too, so that spelling keeps both in agreement from one place.


### PR DESCRIPTION
Two pages under Deployment, plus index routing.

**Cloudflare** — nub landed in the Workers Builds image 2026-07-30 (cloudflare/pages-build-image#13). The image already ships Node 22.23.2/24.18.0, so only the binary is new. Pages is not covered.

Not independently verified: Cloudflare's docs and changelog don't mention nub, and there is no public image to inspect. Probe at colinhacks/nub-cf-probe answers it from a build log. Hold until green.

**Vercel** — verified across three deployments. Calling the binary by absolute path half-works: nub runs but is off PATH, so a script calling nub or nubx fails. Both commands export PATH.

devDependency example: ^0.1.0 to ^0.6.0.

Refs #473
