### PR TITLE
fix(resolver): tolerate a non-integer dist.unpackedSize

### DIFF
--- a/vendor/aube/crates/aube-registry/src/lib.rs
+++ b/vendor/aube/crates/aube-registry/src/lib.rs
@@ -444,7 +444,11 @@ pub struct Dist {
     /// on most modern packuments, absent on older ones — used as the
     /// best-effort install-size estimate that the progress bar shows
     /// as `4.2 MB / ~13.8 MB`. Decimal MB to match every other PM.
-    #[serde(default, rename = "unpackedSize")]
+    #[serde(
+        default,
+        rename = "unpackedSize",
+        deserialize_with = "unpacked_size_tolerant"
+    )]
     pub unpacked_size: Option<u64>,
     /// Sigstore attestations block. The trust-policy check reads
     /// `dist.attestations.provenance` as rank-1 trust evidence when
@@ -459,6 +463,76 @@ pub struct Dist {
 pub struct Attestations {
     #[serde(default)]
     pub provenance: Option<serde_json::Value>,
+}
+
+/// Deserialize `dist.unpackedSize` tolerant to any non-integer shape,
+/// dropping to `None` rather than failing the packument parse.
+///
+/// The field is a cosmetic hint — it only feeds the progress bar's
+/// `4.2 MB / ~13.8 MB` estimate — so a strict `Option<u64>` traded a
+/// wrong pixel for a dead install: one odd value anywhere in the
+/// packument aborted the whole resolve with `ERR_AUBE_REGISTRY_ERROR:
+/// invalid type: map, expected u64`, and because packument fetches run
+/// concurrently the message named whichever fetch lost the race rather
+/// than the package actually at fault.
+///
+/// This was the last strict field left in a struct whose every other
+/// tolerant deserializer already exists for the reasons
+/// [`non_string_tolerant_map`] documents (proxy mirrors that rewrite
+/// `dist` sub-fields, ancient publishes that serialized a structured
+/// value where a scalar belongs). Measured against pnpm on a registry
+/// serving `"unpackedSize": {...}`: pnpm resolves the packument and
+/// installs; aube was alone in failing.
+fn unpacked_size_tolerant<'de, D>(de: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct V;
+
+    impl<'de> Visitor<'de> for V {
+        type Value = Option<u64>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a byte count or any other JSON value")
+        }
+
+        fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+            Ok(Some(v))
+        }
+
+        // serde_json hands non-negative integers to `visit_u64`, so this
+        // only fires for a negative size (meaningless — drop it) or for a
+        // deserializer that signs its integers differently.
+        fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+            Ok(u64::try_from(v).ok())
+        }
+
+        fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D2: Deserializer<'de>>(self, d: D2) -> Result<Self::Value, D2::Error> {
+            d.deserialize_any(self)
+        }
+
+        fn visit_bool<E: serde::de::Error>(self, _: bool) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_f64<E: serde::de::Error>(self, _: f64) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        visit_seq_to!('de, None);
+        visit_map_to!('de, None);
+        visit_strings_to!('de, None);
+    }
+
+    de.deserialize_any(V)
 }
 
 fn deprecated_string<'de, D>(de: D) -> Result<Option<String>, D::Error>

--- a/vendor/aube/crates/aube-registry/src/lib.rs
+++ b/vendor/aube/crates/aube-registry/src/lib.rs
@@ -438,6 +438,13 @@ pub struct NpmUser {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Dist {
     pub tarball: String,
+    /// Strict on purpose, unlike `unpacked_size` below. A malformed
+    /// `integrity`/`shasum` aborts the packument parse rather than
+    /// degrading to `None`, because `None` here means "install this
+    /// tarball with no verification" — a mirror that can rewrite the
+    /// field is exactly the one whose bytes must not be trusted
+    /// unchecked. Failing loud on an off-spec value is the intended
+    /// outcome; do not make these tolerant without deciding that.
     pub integrity: Option<String>,
     pub shasum: Option<String>,
     /// Unpacked tarball size in bytes (`dist.unpackedSize`). Present
@@ -476,13 +483,16 @@ pub struct Attestations {
 /// concurrently the message named whichever fetch lost the race rather
 /// than the package actually at fault.
 ///
-/// This was the last strict field left in a struct whose every other
-/// tolerant deserializer already exists for the reasons
-/// [`non_string_tolerant_map`] documents (proxy mirrors that rewrite
-/// `dist` sub-fields, ancient publishes that serialized a structured
-/// value where a scalar belongs). Measured against pnpm on a registry
-/// serving `"unpackedSize": {...}`: pnpm resolves the packument and
-/// installs; aube was alone in failing.
+/// The tolerance exists for the reasons [`non_string_tolerant_map`]
+/// documents (proxy mirrors that rewrite `dist` sub-fields, ancient
+/// publishes that serialized a structured value where a scalar
+/// belongs). Measured against pnpm on a registry serving
+/// `"unpackedSize": {...}`: pnpm resolves the packument and installs;
+/// aube was alone in failing.
+///
+/// Deliberately NOT extended to the rest of [`Dist`] — see the
+/// strictness note on `integrity`. This field is safe to drop because
+/// nothing but a progress-bar estimate reads it.
 fn unpacked_size_tolerant<'de, D>(de: D) -> Result<Option<u64>, D::Error>
 where
     D: Deserializer<'de>,

--- a/vendor/aube/crates/aube-registry/tests/tolerant_deserializers.rs
+++ b/vendor/aube/crates/aube-registry/tests/tolerant_deserializers.rs
@@ -149,6 +149,13 @@ fn arb_obj_or_null() -> impl Strategy<Value = Value> {
     ]
 }
 
+/// `dist.unpackedSize` keeps a non-negative integer byte count and
+/// drops every other shape — including the object that used to abort a
+/// whole install with `invalid type: map, expected u64`.
+fn ref_unpacked_size(v: &Value) -> Option<u64> {
+    v.as_u64()
+}
+
 // === Plumbing: wrap an arbitrary value into a minimal Packument /
 // VersionMetadata JSON and parse it through the production path. ===
 
@@ -165,6 +172,15 @@ fn parse_version_with(field: &str, value: &Value) -> VersionMetadata {
     m.insert("version".into(), Value::String("1.0.0".into()));
     m.insert(field.into(), value.clone());
     serde_json::from_value(Value::Object(m)).expect("version parses")
+}
+
+/// `dist` is the one tolerant field nested a level down, so it needs
+/// its own wrapper rather than `parse_version_with`.
+fn parse_dist_with(field: &str, value: &Value) -> VersionMetadata {
+    let mut dist = serde_json::Map::new();
+    dist.insert("tarball".into(), Value::String("https://x/t.tgz".into()));
+    dist.insert(field.into(), value.clone());
+    parse_version_with("dist", &Value::Object(dist))
 }
 
 // === Properties ===
@@ -233,6 +249,13 @@ proptest! {
     fn bin_matches_reference(v in arb_json()) {
         let parsed = parse_version_with("bin", &v);
         prop_assert_eq!(parsed.bin, ref_bin_map(&v));
+    }
+
+    #[test]
+    fn unpacked_size_matches_reference(v in arb_json()) {
+        let parsed = parse_dist_with("unpackedSize", &v);
+        let actual = parsed.dist.as_ref().and_then(|d| d.unpacked_size);
+        prop_assert_eq!(actual, ref_unpacked_size(&v));
     }
 
     #[test]


### PR DESCRIPTION
A registry serving `"unpackedSize": {...}` aborted the whole install with `ERR_NUB_REGISTRY_ERROR: invalid type: map, expected u64`. Packument fetches run concurrently, so the name in the message is whichever fetch lost the race — it reads as a different random package each run.

`unpacked_size` only feeds the progress bar's size estimate, so strictness cost a dead install for a wrong pixel. Now parsed through a tolerant visitor: integers kept, every other shape dropped to `None`. `integrity`/`shasum` stay strict on purpose; a note at the field records why.

Against a local registry serving that shape: v0.6.0 dies at the parse; this branch and pnpm 10 both resolve and reach the tarball fetch.