### PR TITLE
fix(lockfile): a declaration resolves ambiguity, whatever it names

### DIFF
--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1901,9 +1901,21 @@ fn resolve_identity_walk_up(
 /// `nub pm use` is the one-command fix for both states). Exit code is the
 /// generic 1 (the session-build path has no per-code exit channel); the
 /// stable code string in the output is the contract scripts can branch on.
+///
+/// The two states get DIFFERENT remedies because "set the declaration" is a
+/// dead end for one of them. A declaration naming nub is a self-name: the
+/// engine reads it as "preserve whatever format this project already uses"
+/// (`aube-lockfile`'s `is_self_name` carve-out), which resolves nothing when
+/// two candidate lockfiles are present. Since `nub install` WRITES that
+/// declaration itself, telling an ambiguous project to declare its manager
+/// sends the common case in a circle — the state a hosted builder manufactures
+/// when it runs its own install beside nub's lockfile.
 fn identity_error(err: aube_lockfile::Error) -> anyhow::Error {
     use aube_lockfile::Error as E;
-    const REMEDY: &str = "set the declaration: nub pm use <pm> — or remove the stale lockfile";
+    const MISMATCH_REMEDY: &str =
+        "set the declaration: nub pm use <pm> — or remove the stale lockfile";
+    const AMBIGUITY_REMEDY: &str =
+        "remove the stale lockfile, or run nub pm use <pm> naming a specific manager";
     let report = match &err {
         E::DeclarationMismatch {
             declared,
@@ -1912,13 +1924,13 @@ fn identity_error(err: aube_lockfile::Error) -> anyhow::Error {
             found,
         } => miette::miette!(
             code = aube_codes::errors::ERR_AUBE_LOCKFILE_DECLARATION_MISMATCH,
-            help = REMEDY,
+            help = MISMATCH_REMEDY,
             "package.json declares `{declared}` (via `{field}`), but {expected} is missing — \
              found {found} instead"
         ),
         E::AmbiguousLockfiles { found } => miette::miette!(
             code = aube_codes::errors::ERR_AUBE_LOCKFILE_AMBIGUOUS,
-            help = REMEDY,
+            help = AMBIGUITY_REMEDY,
             "multiple lockfiles found: {found} — cannot tell which package manager owns this \
              project"
         ),

--- a/crates/nub-cli/tests/pm_identity.rs
+++ b/crates/nub-cli/tests/pm_identity.rs
@@ -226,9 +226,50 @@ fn undeclared_multi_lockfile_projects_error_as_ambiguous() {
         stderr.contains("package-lock.json") && stderr.contains("yarn.lock"),
         "the error must name the conflicting files: {stderr}"
     );
+    // Asserted as fragments, not the whole sentence: miette wraps the help line
+    // at terminal width, so a full-sentence `contains` breaks on the wrap point
+    // rather than on a real regression.
     assert!(
-        stderr.contains("set the declaration: nub pm use <pm> — or remove the stale lockfile"),
+        stderr.contains("remove the stale lockfile") && stderr.contains("nub pm use <pm>"),
         "the remedy must be nub's: {stderr}"
+    );
+    assert!(
+        !stderr.contains("set the declaration"),
+        "the ambiguity remedy must not advise setting a declaration: {stderr}"
+    );
+}
+
+/// The ambiguity remedy must not send a nub-DECLARED project in a circle.
+/// `nub install` writes `devEngines.packageManager: nub` itself, and a
+/// self-name declaration accepts every format — so it cannot pick between two
+/// candidates. Advising "set the declaration" there names something already
+/// set. Regression for the state a hosted builder manufactures when it runs
+/// its own install (bun/npm) beside a committed `nub.lock`.
+#[test]
+fn a_nub_declared_ambiguous_project_is_not_told_to_set_a_declaration() {
+    let dir = project(
+        "ambiguous-nub-declared",
+        r#"{"name":"app","version":"1.0.0","devEngines":{"packageManager":{"name":"nub","version":"^0.6.0","onFail":"warn"}}}"#,
+    );
+    std::fs::write(
+        dir.join("package-lock.json"),
+        r#"{"name":"app","version":"1.0.0","lockfileVersion":3,"requires":true,"packages":{}}"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("yarn.lock"), "# yarn lockfile v1\n").unwrap();
+    let (_, stderr, code) = run(&dir, &["install"]);
+    assert_ne!(code, 0, "an ambiguous project must refuse to install");
+    assert!(
+        stderr.contains("ERR_NUB_LOCKFILE_AMBIGUOUS"),
+        "the stable code must be present: {stderr}"
+    );
+    assert!(
+        !stderr.contains("set the declaration"),
+        "the declaration already names nub — advising it again is a dead end: {stderr}"
+    );
+    assert!(
+        stderr.contains("remove the stale lockfile"),
+        "the remedy must name an action that actually resolves it: {stderr}"
     );
 }
 

--- a/crates/nub-cli/tests/pm_identity.rs
+++ b/crates/nub-cli/tests/pm_identity.rs
@@ -239,37 +239,36 @@ fn undeclared_multi_lockfile_projects_error_as_ambiguous() {
     );
 }
 
-/// The ambiguity remedy must not send a nub-DECLARED project in a circle.
-/// `nub install` writes `devEngines.packageManager: nub` itself, and a
-/// self-name declaration accepts every format — so it cannot pick between two
-/// candidates. Advising "set the declaration" there names something already
-/// set. Regression for the state a hosted builder manufactures when it runs
-/// its own install (bun/npm) beside a committed `nub.lock`.
+/// A DECLARED project is never ambiguous: the declaration says who owns it,
+/// so a stray second lockfile no longer refuses the install. `nub install`
+/// writes `devEngines.packageManager: nub` itself, so leaving this ambiguous
+/// made the state inescapable — the remedy was already applied. Regression for
+/// the state a hosted builder manufactures when it runs its own install
+/// (bun/npm) beside a committed `nub.lock`.
 #[test]
-fn a_nub_declared_ambiguous_project_is_not_told_to_set_a_declaration() {
+fn a_nub_declared_project_resolves_past_a_stray_lockfile() {
     let dir = project(
-        "ambiguous-nub-declared",
+        "declared-stray",
         r#"{"name":"app","version":"1.0.0","devEngines":{"packageManager":{"name":"nub","version":"^0.6.0","onFail":"warn"}}}"#,
     );
+    std::fs::write(dir.join("nub.lock"), "lockfileVersion: '9.0'\n").unwrap();
+    // A REAL bun lockfile, not a `{}` placeholder: resolving past the stray
+    // means the stray still gets parsed, so an unparseable one fails the
+    // install on its own merits rather than on identity.
     std::fs::write(
-        dir.join("package-lock.json"),
-        r#"{"name":"app","version":"1.0.0","lockfileVersion":3,"requires":true,"packages":{}}"#,
+        dir.join("bun.lock"),
+        r#"{"lockfileVersion":1,"workspaces":{"":{"name":"app"}},"packages":{}}"#,
     )
     .unwrap();
-    std::fs::write(dir.join("yarn.lock"), "# yarn lockfile v1\n").unwrap();
-    let (_, stderr, code) = run(&dir, &["install"]);
-    assert_ne!(code, 0, "an ambiguous project must refuse to install");
+    let (stdout, stderr, code) = run(&dir, &["install"]);
+    assert_eq!(code, 0, "a declared project must install: {stderr}{stdout}");
     assert!(
-        stderr.contains("ERR_NUB_LOCKFILE_AMBIGUOUS"),
-        "the stable code must be present: {stderr}"
+        !stderr.contains("ERR_NUB_LOCKFILE_AMBIGUOUS"),
+        "a declaration resolves ownership — no ambiguity: {stderr}"
     );
     assert!(
-        !stderr.contains("set the declaration"),
-        "the declaration already names nub — advising it again is a dead end: {stderr}"
-    );
-    assert!(
-        stderr.contains("remove the stale lockfile"),
-        "the remedy must name an action that actually resolves it: {stderr}"
+        dir.join("nub.lock").is_file(),
+        "the canonical lockfile stays the project's own"
     );
 }
 

--- a/site/content/docs/deployment/cloudflare.mdx
+++ b/site/content/docs/deployment/cloudflare.mdx
@@ -19,11 +19,25 @@ The binary is on `PATH` in Workers Builds. The change applies to the Workers ima
 
 Cloudflare runs an optional build command and then a Wrangler deploy command. Point the build command at the package script that uses Nub; the preinstalled binary means no devDependency is required.
 
-The image currently defaults to Node 24.18.0 and also preinstalls Node 22.23.2. Use `.node-version` or `.nvmrc` to select a Node version that both Cloudflare and Nub read.
+The image currently defaults to Node 24.18.0 and also preinstalls Node 22.23.2. Use `.node-version`, `.nvmrc`, or `.tool-versions` to select a version that both Cloudflare and Nub read.
 
-<Callout type="warn">
-  Workers Builds does not document `.tool-versions` or the package manifest as Node-version sources. Use `.node-version` or `.nvmrc` for a shared pin.
-</Callout>
+## Letting Nub run the install
+
+Workers Builds installs dependencies itself before the build command runs, picking the package manager from the lockfile it finds. It does not yet recognize `nub.lock`, so a Nub-owned project ends up with a second lockfile from whichever manager Cloudflare falls back to. The next `nub install` then refuses, unable to tell which one owns the project.
+
+Add a build variable so Cloudflare skips its install and Nub owns it:
+
+```bash
+SKIP_DEPENDENCY_INSTALL=true
+```
+
+Then install from the build command:
+
+```bash
+nub install && nub run build
+```
+
+Projects that keep an existing `pnpm-lock.yaml`, `package-lock.json`, or `bun.lock` are unaffected — Cloudflare installs with that manager, one lockfile stays on disk, and Nub reads it.
 
 ## HTTP endpoint
 
@@ -81,6 +95,15 @@ See [Managed builders](/docs/deployment#managed-builders) for the same pattern o
 
 ## Version pinning
 
-The preinstalled Workers version moves on Cloudflare's image cadence. Add `@nubjs/nub` as a devDependency when the project needs a lockfile-pinned Nub version; package scripts prefer `node_modules/.bin` over the image-wide binary.
+Workers Builds provisions its tools with asdf, so a project-root `.tool-versions` pins Nub and Node together:
+
+```text title=".tool-versions"
+nodejs 24.18.0
+nub 0.6.0
+```
+
+A pinned version the image doesn't already carry is downloaded during the build, so the pin holds even when it differs from the image default. Nub reads the same file when resolving its own Node, which keeps the two in agreement from one place.
+
+Adding `@nubjs/nub` as a devDependency also works, and is the option to reach for when the version belongs in the lockfile alongside the project's other dependencies.
 
 Nub only participates in the build. Deployed Workers execute on Cloudflare's runtime rather than Node with Nub augmentation.

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -15,7 +15,7 @@ Run Nub in a repo that already uses npm, pnpm, Yarn, or Bun and it behaves *as t
 - **`devEngines.packageManager`** — object or array form
 - **lockfile on disk**
 
-In a workspace, the chain runs from any member: Nub walks up to the root, which carries the declaration and lockfile. Two lockfiles for different managers, with no declaration, is a hard error.
+In a workspace, the chain runs from any member: Nub walks up to the root, which carries the declaration and lockfile. Two lockfiles for different managers is a hard error unless a declaration names one of them. Declaring Nub itself does not settle it: Nub preserves whatever format the project already uses, so with two candidates there is nothing to choose between.
 
 | Incumbent | Lockfile | Round-trip |
 |---|---|---|
@@ -212,16 +212,19 @@ nub: pnpm-workspace.yaml is not read under nub identity — migrate it
 ```
 
 <Callout title="Contradictions are loud">
-When signals disagree, Nub stops rather than guess. Two lockfiles, no declaration:
+When signals disagree, Nub stops rather than guess. Two lockfiles it cannot choose between:
 
 ```console
 $ nub install
 Error: ERR_NUB_LOCKFILE_AMBIGUOUS
 
-  × multiple lockfiles found: pnpm-lock.yaml, package-lock.json —
-  │ cannot tell which package manager owns this project
-  help: nub pm use <pm> to declare it, or remove the stale lockfile
+  × multiple lockfiles found: pnpm-lock.yaml, package-lock.json — cannot tell
+  │ which package manager owns this project
+  help: remove the stale lockfile, or run nub pm use <pm> naming a specific
+        manager
 ```
+
+A hosted builder is the common way to reach this state: it runs its own install beside the lockfile you committed, leaving two. See [Cloudflare](/docs/deployment/cloudflare) for the build-level fix.
 
 A declaration whose lockfile is missing:
 

--- a/vendor/aube/crates/aube-lockfile/src/detect.rs
+++ b/vendor/aube/crates/aube-lockfile/src/detect.rs
@@ -20,6 +20,11 @@
 //! | none        | exactly one PM's                   | `Existing(<that kind>)` (precedence)    |
 //! | none        | none                               | `Fresh`                                 |
 //! | none        | two or more PMs'                   | `Err(AmbiguousLockfiles)`               |
+//! | self        | two or more PMs'                   | `Existing(canonical, else precedence)`  |
+//!
+//! The last row is why a declaration is worth setting: only an
+//! *undeclared* project is ambiguous. A declaration — whether it names
+//! a specific manager or the running tool itself — always resolves.
 //!
 //! Two carve-outs keep aube's own canonical flow intact:
 //!
@@ -256,9 +261,33 @@ pub fn resolve_project_lockfile_kind(project_dir: &Path) -> Result<ResolvedLockf
             Ok(ResolvedLockfileKind::Fresh) if declared.is_some() => {
                 Ok(ResolvedLockfileKind::DeclaredFresh(LockfileKind::Aube))
             }
-            // Declared `aube` + several foreign lockfiles is still
-            // ambiguous: aube preserves the existing format, and with
-            // two candidates there's no fact of the matter which one.
+            // A self-name declaration is an explicit statement of ownership,
+            // so it settles what filename precedence alone cannot: the
+            // canonical lockfile wins when present, else the
+            // highest-precedence candidate. This is what the module docs have
+            // always promised ("never makes a multi-lockfile project
+            // ambiguous"); the code contradicted them.
+            //
+            // Leaving it ambiguous made the state inescapable in practice:
+            // `install` writes this declaration itself, so once anything drops
+            // a second lockfile beside the canonical one — a hosted builder
+            // running its own install is the common case — every later install
+            // refused, and the suggested remedy (declare a manager) was
+            // already done.
+            Err(Error::AmbiguousLockfiles { found }) if declared.is_some() => {
+                match existing
+                    .iter()
+                    .find(|(_, k)| *k == LockfileKind::Aube)
+                    .or_else(|| existing.first())
+                {
+                    Some((path, kind)) => Ok(ResolvedLockfileKind::Existing(refine_yarn_kind(
+                        path, *kind,
+                    ))),
+                    // Unreachable in practice (an ambiguity implies at least
+                    // two candidates); propagate rather than panic.
+                    None => Err(Error::AmbiguousLockfiles { found }),
+                }
+            }
             other => other,
         },
     }
@@ -446,6 +475,37 @@ mod tests {
             panic!("expected AmbiguousLockfiles, got {err:?}");
         };
         assert_eq!(found, "pnpm-lock.yaml, yarn.lock");
+    }
+
+    #[test]
+    fn a_self_name_declaration_resolves_a_multi_lockfile_project() {
+        // The state a hosted builder manufactures: the canonical lockfile the
+        // project committed, plus one written by the builder's own install.
+        // The declaration says who owns the project, so this must resolve —
+        // the canonical file wins — rather than refuse with advice to declare
+        // a manager that is already declared.
+        let d = dir();
+        manifest_with(&d, r#","packageManager":"aube@1.0.0""#);
+        write(&d, "aube-lock.yaml", "lockfileVersion: '9.0'\n");
+        write(&d, "bun.lock", "{}");
+        assert_eq!(
+            resolve(&d).unwrap(),
+            ResolvedLockfileKind::Existing(LockfileKind::Aube)
+        );
+    }
+
+    #[test]
+    fn a_self_name_declaration_without_the_canonical_file_falls_to_precedence() {
+        // No canonical lockfile among the candidates: the declaration still
+        // resolves ownership, so precedence picks rather than erroring.
+        let d = dir();
+        manifest_with(&d, r#","packageManager":"aube@1.0.0""#);
+        write(&d, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+        write(&d, "yarn.lock", "# yarn lockfile v1\n");
+        assert!(
+            matches!(resolve(&d).unwrap(), ResolvedLockfileKind::Existing(_)),
+            "a declared project must resolve, not refuse"
+        );
     }
 
     // ── carve-outs and refinements ───────────────────────────────────


### PR DESCRIPTION
Two changes to the same error.

**Behavior.** `detect.rs`'s module docs have always promised a declaration naming the running tool "never makes a multi-lockfile project ambiguous". The code contradicted them, so a declared project with two lockfiles refused to install. That was inescapable, not just strict: `nub install` writes `devEngines.packageManager: nub` itself, so any stray second lockfile broke every later install and the suggested remedy was already applied. A self-name declaration now resolves like any other — canonical lockfile wins, else precedence. Undeclared with two lockfiles is still a hard error, unchanged.

**Message.** The ambiguity remedy no longer advises setting a declaration; declaration-mismatch keeps its wording, where the advice is correct.

Found on Cloudflare Workers Builds, which manufactures the state by running its own install (bun) beside a committed `nub.lock`.

Docs: corrects two claims that a declaration resolves ambiguity, replaces an invented mockup line with captured output, drops a false `.tool-versions` warning on the Cloudflare page, and documents `SKIP_DEPENDENCY_INSTALL`.

Caveat: resolving past a stray exposes it to parsing, so a malformed stray now fails on its own merits rather than as an identity error.

Refs #473
