### PR TITLE
fix(registry): attribute packument decode failures; three more cosmetic fields stop aborting installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "sha2 0.11.0",
  "sonic-rs",
  "thiserror 2.0.18",
@@ -4157,6 +4158,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/vendor/aube/Cargo.lock
+++ b/vendor/aube/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "sha2 0.11.0",
  "sonic-rs",
  "tar",
@@ -4040,6 +4041,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/vendor/aube/Cargo.toml
+++ b/vendor/aube/Cargo.toml
@@ -72,6 +72,7 @@ yamlpatch = "1.25"
 yamlpath = ">=1.25, <1.28"
 serde_yaml = "0.9"
 sonic-rs = "0.5"
+serde_path_to_error = "0.1"
 toml = "1.1"
 rkyv = "0.8"
 

--- a/vendor/aube/crates/aube-codes/src/errors.rs
+++ b/vendor/aube/crates/aube-codes/src/errors.rs
@@ -44,6 +44,7 @@ pub const ERR_AUBE_ACCESS_ENTITY_NOT_FOUND: &str = "ERR_AUBE_ACCESS_ENTITY_NOT_F
 pub const ERR_AUBE_VERSION_NOT_FOUND: &str = "ERR_AUBE_VERSION_NOT_FOUND";
 pub const ERR_AUBE_UNAUTHORIZED: &str = "ERR_AUBE_UNAUTHORIZED";
 pub const ERR_AUBE_FORBIDDEN: &str = "ERR_AUBE_FORBIDDEN";
+pub const ERR_AUBE_METADATA_DECODE: &str = "ERR_AUBE_METADATA_DECODE";
 pub const ERR_AUBE_OFFLINE: &str = "ERR_AUBE_OFFLINE";
 pub const ERR_AUBE_INVALID_PACKAGE_NAME: &str = "ERR_AUBE_INVALID_PACKAGE_NAME";
 pub const ERR_AUBE_REGISTRY_WRITE_REJECTED: &str = "ERR_AUBE_REGISTRY_WRITE_REJECTED";
@@ -338,6 +339,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::REGISTRY_NETWORK,
         description: "Registry returned 401 — missing or invalid auth. Run `aube login`.",
         exit_code: Some(42),
+    },
+    CodeMeta {
+        name: ERR_AUBE_METADATA_DECODE,
+        category: category::REGISTRY_NETWORK,
+        description: "A registry response body failed to decode. Carries the package it belongs to and an excerpt of the payload around the offending field.",
+        exit_code: None,
     },
     CodeMeta {
         name: ERR_AUBE_FORBIDDEN,

--- a/vendor/aube/crates/aube-registry/Cargo.toml
+++ b/vendor/aube/crates/aube-registry/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 sonic-rs = { workspace = true }
+serde_path_to_error = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/vendor/aube/crates/aube-registry/src/client/endpoints.rs
+++ b/vendor/aube/crates/aube-registry/src/client/endpoints.rs
@@ -155,7 +155,7 @@ impl RegistryClient {
             self.fetch_policy.packument_max_bytes,
             "version-metadata",
         )?;
-        parse_full_response(resp).await
+        parse_full_response(resp, &format!("version metadata {name}@{version}")).await
     }
 
     /// Fetch the *full* (non-corgi) packument as raw JSON, bypassing the

--- a/vendor/aube/crates/aube-registry/src/client/packument.rs
+++ b/vendor/aube/crates/aube-registry/src/client/packument.rs
@@ -10,16 +10,27 @@ use std::path::{Path, PathBuf};
 /// `serde_json::from_value` sibling of `parse_full_response`'s error
 /// mapping, for the paths that already hold a parsed `Value`.
 ///
-/// `near` is empty here on purpose: `from_value` reports no byte offset
-/// (it walks an in-memory tree, so there is no input to quote), and
-/// re-serializing a multi-megabyte packument just to excerpt it would
-/// cost more than the diagnostic is worth. The package attribution —
-/// the part that made this class of failure unreadable — still lands.
+/// These paths have no byte offset to quote — `from_value` walks an
+/// in-memory tree, so there is no input text — which is why they carry
+/// a JSON path (`versions.1.0.0.dist.unpackedSize`) as their locator
+/// of a payload excerpt. Both answer the same question the raw serde
+/// message can't: WHICH field. Reaching for the path rather than
+/// re-serializing the tree matters because these are the
+/// full-packument paths (`minimumReleaseAge`, time-based resolution,
+/// `trustPolicy=no-downgrade`), where the document routinely runs to
+/// megabytes.
 fn decode_value(value: serde_json::Value, name: &str) -> Result<Packument, Error> {
-    serde_json::from_value(value).map_err(|e| Error::Decode {
-        context: format!("packument {name}"),
-        near: String::new(),
-        message: e.to_string(),
+    serde_path_to_error::deserialize(value).map_err(|e| {
+        let path = e.path().to_string();
+        Error::Decode {
+            context: format!("packument {name}"),
+            locator: if path.is_empty() || path == "." {
+                String::new()
+            } else {
+                format!("at {path}")
+            },
+            message: e.into_inner().to_string(),
+        }
     })
 }
 

--- a/vendor/aube/crates/aube-registry/src/client/packument.rs
+++ b/vendor/aube/crates/aube-registry/src/client/packument.rs
@@ -252,7 +252,7 @@ impl RegistryClient {
                     let max_age_secs = parse_cache_control_max_age(&resp);
                     let resp = resp.error_for_status()?;
                     check_body_cap(&resp, self.fetch_policy.packument_max_bytes, &label)?;
-                    match parse_full_response::<serde_json::Value>(resp).await {
+                    match parse_full_response::<serde_json::Value>(resp, &label).await {
                         Ok(packument) => {
                             if let Err(e) = write_cached_full_packument(
                                 &cache_path,
@@ -490,7 +490,7 @@ impl RegistryClient {
                     let max_age_secs = parse_cache_control_max_age(&resp);
                     let resp = resp.error_for_status()?;
                     check_body_cap(&resp, self.fetch_policy.packument_max_bytes, &label)?;
-                    match parse_full_response::<serde_json::Value>(resp).await {
+                    match parse_full_response::<serde_json::Value>(resp, &label).await {
                         Ok(value) => {
                             if let Err(e) = write_cached_full_packument(
                                 &cache_path,
@@ -640,7 +640,7 @@ impl RegistryClient {
                     .with_meta_fn(|| format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(name)));
                     let resp = resp.error_for_status()?;
                     check_body_cap(&resp, self.fetch_policy.packument_max_bytes, &label)?;
-                    match parse_full_response::<Packument>(resp).await {
+                    match parse_full_response::<Packument>(resp, &label).await {
                         Ok(packument) => {
                             drop(_diag_parse);
                             self.maybe_record_slow_metadata(&label, started);
@@ -852,7 +852,7 @@ impl RegistryClient {
 
                     let resp = resp.error_for_status()?;
                     check_body_cap(&resp, self.fetch_policy.packument_max_bytes, &label)?;
-                    match parse_full_response::<Packument>(resp).await {
+                    match parse_full_response::<Packument>(resp, &label).await {
                         Ok(packument) => {
                             let to_cache = CachedPackument {
                                 etag,

--- a/vendor/aube/crates/aube-registry/src/client/packument.rs
+++ b/vendor/aube/crates/aube-registry/src/client/packument.rs
@@ -7,6 +7,22 @@ use super::{
 use crate::{Error, NetworkMode, Packument};
 use std::path::{Path, PathBuf};
 
+/// `serde_json::from_value` sibling of `parse_full_response`'s error
+/// mapping, for the paths that already hold a parsed `Value`.
+///
+/// `near` is empty here on purpose: `from_value` reports no byte offset
+/// (it walks an in-memory tree, so there is no input to quote), and
+/// re-serializing a multi-megabyte packument just to excerpt it would
+/// cost more than the diagnostic is worth. The package attribution —
+/// the part that made this class of failure unreadable — still lands.
+fn decode_value(value: serde_json::Value, name: &str) -> Result<Packument, Error> {
+    serde_json::from_value(value).map_err(|e| Error::Decode {
+        context: format!("packument {name}"),
+        near: String::new(),
+        message: e.to_string(),
+    })
+}
+
 impl RegistryClient {
     pub fn cached_packument_lookup(&self, name: &str, cache_dir: &Path) -> CachedPackumentLookup {
         let registry_url = self.registry_url_for(name);
@@ -344,8 +360,7 @@ impl RegistryClient {
         // is amortized across the network round-trip so it doesn't
         // show up in steady-state resolves.
         let value = self.fetch_packument_full_cached(name, cache_dir).await?;
-        let packument: Packument = serde_json::from_value(value)
-            .map_err(|e| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))?;
+        let packument: Packument = decode_value(value, name)?;
         Ok(packument)
     }
 
@@ -360,8 +375,7 @@ impl RegistryClient {
     /// silently disables the age gate at the pick site.
     pub async fn fetch_packument_with_time(&self, name: &str) -> Result<Packument, Error> {
         let value = self.fetch_packument_json_fresh(name).await?;
-        let packument: Packument = serde_json::from_value(value)
-            .map_err(|e| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))?;
+        let packument: Packument = decode_value(value, name)?;
         Ok(packument)
     }
 
@@ -506,13 +520,7 @@ impl RegistryClient {
                                     cache_path.display()
                                 );
                             }
-                            let packument: Packument =
-                                serde_json::from_value(value).map_err(|e| {
-                                    Error::Io(std::io::Error::new(
-                                        std::io::ErrorKind::InvalidData,
-                                        e,
-                                    ))
-                                })?;
+                            let packument: Packument = decode_value(value, name)?;
                             self.maybe_record_slow_metadata(&label, started);
                             return Ok(packument);
                         }

--- a/vendor/aube/crates/aube-registry/src/client/parse.rs
+++ b/vendor/aube/crates/aube-registry/src/client/parse.rs
@@ -1,6 +1,53 @@
 use crate::Error;
 
-pub(super) async fn parse_full_response<T>(resp: reqwest::Response) -> Result<T, Error>
+/// Bytes of surrounding payload to quote on either side of a decode
+/// failure. Wide enough to carry the offending key and its value,
+/// narrow enough that a 50 MB packument can't turn one error into a
+/// screenful.
+const EXCERPT_RADIUS: usize = 60;
+
+/// Quote the payload around `offset` so a decode failure names the
+/// field it actually tripped on. serde's message says only what the
+/// shape was and what was wanted (`invalid type: map, expected u64`)
+/// — with 300 packages in flight and no key in that text, the reader
+/// has no way to tell WHICH field of WHICH package was malformed.
+fn excerpt(bytes: &[u8], offset: usize) -> String {
+    let start = offset.saturating_sub(EXCERPT_RADIUS);
+    let end = offset.saturating_add(EXCERPT_RADIUS).min(bytes.len());
+    if start >= end {
+        return String::new();
+    }
+    let window = String::from_utf8_lossy(&bytes[start..end]);
+    // Packument JSON is single-line in practice, but a mirror may pretty-print
+    // it; collapse so the excerpt stays one line inside the error.
+    let flattened = window
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect::<String>();
+    format!(
+        "{}{flattened}{}",
+        if start == 0 { "" } else { "…" },
+        if end == bytes.len() { "" } else { "…" }
+    )
+}
+
+/// Read a response body and decode it, attributing any failure to
+/// `context` (e.g. `"packument for lodash"`).
+///
+/// `context` exists because packument fetches run concurrently: the
+/// resolver surfaces whichever decode failed first, so an unattributed
+/// message gets blamed on an unrelated package and reads as a different
+/// random package on every run.
+///
+/// Every failure reaching here came off the WIRE, never off disk — all
+/// four cached-packument readers in `client/cache.rs` return `Option`
+/// and swallow a parse error into a refetch, so a corrupt cache entry
+/// cannot surface as a decode error. Callers may state that in
+/// `context` without qualification.
+pub(super) async fn parse_full_response<T>(
+    resp: reqwest::Response,
+    context: &str,
+) -> Result<T, Error>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -22,8 +69,11 @@ where
     // and only collapsed into the same `Error::Io(InvalidData)` for
     // the user, so we keep the single-parser shape.
     let parse_t0 = std::time::Instant::now();
-    let result = sonic_rs::from_slice::<T>(&bytes)
-        .map_err(|e| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)));
+    let result = sonic_rs::from_slice::<T>(&bytes).map_err(|e| Error::Decode {
+        context: context.to_string(),
+        near: excerpt(&bytes, e.offset()),
+        message: e.to_string(),
+    });
     aube_util::diag::event_lazy(
         aube_util::diag::Category::Registry,
         "json_parse_sonic_rs",
@@ -31,4 +81,44 @@ where
         || format!(r#"{{"bytes":{}}}"#, body_size),
     );
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::excerpt;
+
+    #[test]
+    fn excerpt_quotes_the_field_around_the_failure_offset() {
+        let body = br#"{"name":"pkg","versions":{"1.0.0":{"dist":{"unpackedSize":{"bytes":1}}}}}"#;
+        let offset = body
+            .windows(14)
+            .position(|w| w == b"\"unpackedSize\"")
+            .expect("fixture contains the key");
+        let quoted = excerpt(body, offset);
+        assert!(
+            quoted.contains("\"unpackedSize\""),
+            "excerpt must name the offending field, got: {quoted}"
+        );
+    }
+
+    #[test]
+    fn excerpt_is_single_line_and_bounded_for_a_large_pretty_printed_body() {
+        let mut body = b"{\n  \"a\": 1,\n".to_vec();
+        body.extend(std::iter::repeat_n(b' ', 10_000));
+        body.extend_from_slice(b"\"unpackedSize\": {}\n}");
+        let offset = body.len() - 20;
+        let quoted = excerpt(&body, offset);
+        assert!(!quoted.contains('\n'), "excerpt must stay on one line");
+        // Two radii of payload plus the two ellipsis marks.
+        assert!(
+            quoted.chars().count() <= 60 * 2 + 2,
+            "excerpt must stay bounded, got {} chars",
+            quoted.chars().count()
+        );
+    }
+
+    #[test]
+    fn excerpt_of_an_offset_past_the_body_is_empty_rather_than_panicking() {
+        assert_eq!(excerpt(b"{}", 9_999), "");
+    }
 }

--- a/vendor/aube/crates/aube-registry/src/client/parse.rs
+++ b/vendor/aube/crates/aube-registry/src/client/parse.rs
@@ -25,7 +25,7 @@ fn excerpt(bytes: &[u8], offset: usize) -> String {
         .map(|c| if c.is_control() { ' ' } else { c })
         .collect::<String>();
     format!(
-        "{}{flattened}{}",
+        "near: {}{flattened}{}",
         if start == 0 { "" } else { "…" },
         if end == bytes.len() { "" } else { "…" }
     )
@@ -71,7 +71,7 @@ where
     let parse_t0 = std::time::Instant::now();
     let result = sonic_rs::from_slice::<T>(&bytes).map_err(|e| Error::Decode {
         context: context.to_string(),
-        near: excerpt(&bytes, e.offset()),
+        locator: excerpt(&bytes, e.offset()),
         message: e.to_string(),
     });
     aube_util::diag::event_lazy(

--- a/vendor/aube/crates/aube-registry/src/lib.rs
+++ b/vendor/aube/crates/aube-registry/src/lib.rs
@@ -1087,6 +1087,41 @@ mod tests {
         serde_json::from_str(json).unwrap()
     }
 
+    /// The whole point of `Error::Decode` is that the rendered string
+    /// carries the package and the offending field. Pin the rendering,
+    /// not just the fields — the excerpt reaches the user through a
+    /// `#[error(...)]` format call that a field-level test would miss.
+    #[test]
+    fn decode_error_renders_the_package_and_the_offending_field() {
+        let rendered = Error::Decode {
+            context: "packument @img/colour".to_string(),
+            near: r#"…"shasum":"0000","unpackedSize":{"bytes":1}},"depend…"#.to_string(),
+            message: "invalid type: map, expected u64".to_string(),
+        }
+        .to_string();
+        assert_eq!(
+            rendered,
+            r#"failed to decode packument @img/colour: invalid type: map, expected u64 — near: …"shasum":"0000","unpackedSize":{"bytes":1}},"depend…"#
+        );
+    }
+
+    /// The `from_value` decode paths have no byte offset to quote, so
+    /// they pass an empty excerpt; it must vanish rather than leave a
+    /// dangling ` — near: ` clause.
+    #[test]
+    fn decode_error_omits_the_excerpt_clause_when_there_is_none() {
+        let rendered = Error::Decode {
+            context: "packument lodash".to_string(),
+            near: String::new(),
+            message: "invalid type: map, expected a string".to_string(),
+        }
+        .to_string();
+        assert_eq!(
+            rendered,
+            "failed to decode packument lodash: invalid type: map, expected a string"
+        );
+    }
+
     /// A registry URL carrying both `user:pass@` userinfo and a
     /// `?token=` query param must never appear UNREDACTED in a surfaced
     /// HTTP error — reqwest's raw Display leaks both, so `Error::Http`'s

--- a/vendor/aube/crates/aube-registry/src/lib.rs
+++ b/vendor/aube/crates/aube-registry/src/lib.rs
@@ -208,7 +208,7 @@ pub enum NetworkMode {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Packument {
     pub name: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "tolerant_string")]
     pub modified: Option<String>,
     #[serde(default)]
     pub versions: BTreeMap<String, VersionMetadata>,
@@ -313,7 +313,7 @@ pub struct VersionMetadata {
     /// tarball-level re-parse.
     #[serde(default, rename = "bin", deserialize_with = "bin_map")]
     pub bin: BTreeMap<String, String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "tolerant_bool")]
     pub has_install_script: bool,
     /// Deprecation message from the registry, if this version is deprecated.
     #[serde(default, deserialize_with = "deprecated_string")]
@@ -383,7 +383,7 @@ struct VersionMetadataRaw {
     funding_url: Option<String>,
     #[serde(default, rename = "bin", deserialize_with = "bin_map")]
     bin: BTreeMap<String, String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "tolerant_bool")]
     has_install_script: bool,
     #[serde(default, deserialize_with = "deprecated_string")]
     deprecated: Option<String>,
@@ -420,10 +420,48 @@ impl From<VersionMetadataRaw> for VersionMetadata {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, Default)]
 pub struct PeerDepMeta {
-    #[serde(default)]
     pub optional: bool,
+}
+
+/// Hand-rolled so a malformed `peerDependenciesMeta` entry degrades
+/// instead of failing the packument. Covers both shapes a mirror can
+/// produce: the whole entry being a non-object (`{"react": 1}`) and
+/// `optional` itself being off-spec (`{"react": {"optional": {}}}`).
+/// Either way the entry reads as `optional: false`, which is what a
+/// missing entry already means — so an unparseable value degrades to
+/// the stricter reading (peer required) rather than silently relaxing
+/// a peer requirement.
+impl<'de> Deserialize<'de> for PeerDepMeta {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = PeerDepMeta;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a peerDependenciesMeta entry or any other JSON value")
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, mut access: A) -> Result<Self::Value, A::Error> {
+                let mut optional = false;
+                while let Some(key) = access.next_key::<String>()? {
+                    if key == "optional" {
+                        let MaybeBool(b) = access.next_value()?;
+                        optional = b;
+                    } else {
+                        let _: IgnoredAny = access.next_value()?;
+                    }
+                }
+                Ok(PeerDepMeta { optional })
+            }
+
+            visit_primitives_to!('de, PeerDepMeta::default());
+            visit_seq_to!('de, PeerDepMeta::default());
+            visit_strings_to!('de, PeerDepMeta::default());
+        }
+        de.deserialize_any(V)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -543,6 +581,82 @@ where
     }
 
     de.deserialize_any(V)
+}
+
+/// `true`/`false` when the registry sends a bool, `false` for every
+/// other shape. Backs `hasInstallScript` and `peerDependenciesMeta`'s
+/// `optional`, neither of which is worth failing an install over:
+/// `hasInstallScript` only feeds npm-lockfile round-trip fidelity and
+/// `nub query` (whether a script actually runs is decided from the
+/// installed package's own manifest), and `optional: false` is the
+/// same reading a missing entry already gets.
+struct MaybeBool(bool);
+
+impl<'de> Deserialize<'de> for MaybeBool {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = MaybeBool;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a boolean or any other JSON value")
+            }
+
+            fn visit_bool<E: serde::de::Error>(self, b: bool) -> Result<MaybeBool, E> {
+                Ok(MaybeBool(b))
+            }
+
+            fn visit_unit<E: serde::de::Error>(self) -> Result<MaybeBool, E> {
+                Ok(MaybeBool(false))
+            }
+
+            fn visit_none<E: serde::de::Error>(self) -> Result<MaybeBool, E> {
+                Ok(MaybeBool(false))
+            }
+
+            fn visit_some<D2: Deserializer<'de>>(self, d: D2) -> Result<MaybeBool, D2::Error> {
+                d.deserialize_any(self)
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, _: i64) -> Result<MaybeBool, E> {
+                Ok(MaybeBool(false))
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, _: u64) -> Result<MaybeBool, E> {
+                Ok(MaybeBool(false))
+            }
+
+            fn visit_f64<E: serde::de::Error>(self, _: f64) -> Result<MaybeBool, E> {
+                Ok(MaybeBool(false))
+            }
+
+            visit_seq_to!('de, MaybeBool(false));
+            visit_map_to!('de, MaybeBool(false));
+            visit_strings_to!('de, MaybeBool(false));
+        }
+        de.deserialize_any(V)
+    }
+}
+
+fn tolerant_bool<'de, D>(de: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let MaybeBool(b) = MaybeBool::deserialize(de)?;
+    Ok(b)
+}
+
+/// A string when the registry sends one, `None` for every other shape.
+/// Backs the packument's top-level `modified`, whose only reader is the
+/// publish-age fallback in `aube-resolver`'s `semver_util` — and that
+/// reader treats `None` as "no publish time known", the conservative
+/// side of the age gate.
+fn tolerant_string<'de, D>(de: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let MaybeString(maybe) = MaybeString::deserialize(de)?;
+    Ok(maybe)
 }
 
 fn deprecated_string<'de, D>(de: D) -> Result<Option<String>, D::Error>
@@ -875,6 +989,21 @@ pub enum Error {
     Forbidden { body: String },
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+    /// A registry response body that didn't decode. Split out of
+    /// [`Error::Io`], which it used to be: the failure rendered as
+    /// `I/O error: invalid type: map, expected u64`, which reads as a
+    /// socket problem, names no package and no field. Packument fetches
+    /// run concurrently, so the resolver then attributed it to whichever
+    /// fetch surfaced first and the same bug appeared to move between
+    /// packages run to run. `context` and `near` are what make it
+    /// readable in one pass.
+    #[error("failed to decode {context}: {message}{}", render_near(.near))]
+    #[diagnostic(code(ERR_AUBE_METADATA_DECODE))]
+    Decode {
+        context: String,
+        near: String,
+        message: String,
+    },
     #[error("registry rejected write: HTTP {status}: {body}")]
     #[diagnostic(code(ERR_AUBE_REGISTRY_WRITE_REJECTED))]
     RegistryWrite { status: u16, body: String },
@@ -900,6 +1029,17 @@ pub enum Error {
 /// so credentials never reach an error message or log; the redacted host
 /// is preserved for debuggability. Errors with no attached URL render
 /// unchanged (reqwest's Display emits no URL in that case).
+/// Render the payload excerpt clause of [`Error::Decode`], or nothing
+/// when the body was too short to quote. Kept out of the `#[error]`
+/// format string so an empty excerpt doesn't leave a dangling ` near ""`.
+fn render_near(near: &str) -> String {
+    if near.is_empty() {
+        String::new()
+    } else {
+        format!(" — near: {near}")
+    }
+}
+
 fn redact_http_error(e: &reqwest::Error) -> String {
     match e.url() {
         Some(url) => {

--- a/vendor/aube/crates/aube-registry/src/lib.rs
+++ b/vendor/aube/crates/aube-registry/src/lib.rs
@@ -997,11 +997,16 @@ pub enum Error {
     /// fetch surfaced first and the same bug appeared to move between
     /// packages run to run. `context` and `near` are what make it
     /// readable in one pass.
-    #[error("failed to decode {context}: {message}{}", render_near(.near))]
+    #[error("failed to decode {context}: {message}{}", render_locator(.locator))]
     #[diagnostic(code(ERR_AUBE_METADATA_DECODE))]
     Decode {
         context: String,
-        near: String,
+        /// Rendered locator for the offending field — a payload excerpt
+        /// (`near: …"unpackedSize":{…`) on the byte-oriented sonic-rs
+        /// decode, a JSON path (`at versions.1.0.0.dist.unpackedSize`)
+        /// on the `from_value` paths, which have no input text to quote.
+        /// Empty when neither is available.
+        locator: String,
         message: String,
     },
     #[error("registry rejected write: HTTP {status}: {body}")]
@@ -1029,14 +1034,15 @@ pub enum Error {
 /// so credentials never reach an error message or log; the redacted host
 /// is preserved for debuggability. Errors with no attached URL render
 /// unchanged (reqwest's Display emits no URL in that case).
-/// Render the payload excerpt clause of [`Error::Decode`], or nothing
-/// when the body was too short to quote. Kept out of the `#[error]`
-/// format string so an empty excerpt doesn't leave a dangling ` near ""`.
-fn render_near(near: &str) -> String {
-    if near.is_empty() {
+/// Render the locator clause of [`Error::Decode`], or nothing when the
+/// decode gave us neither an excerpt nor a path. Kept out of the
+/// `#[error]` format string so an absent locator doesn't leave a
+/// dangling ` — `.
+fn render_locator(locator: &str) -> String {
+    if locator.is_empty() {
         String::new()
     } else {
-        format!(" — near: {near}")
+        format!(" — {locator}")
     }
 }
 
@@ -1095,7 +1101,7 @@ mod tests {
     fn decode_error_renders_the_package_and_the_offending_field() {
         let rendered = Error::Decode {
             context: "packument @img/colour".to_string(),
-            near: r#"…"shasum":"0000","unpackedSize":{"bytes":1}},"depend…"#.to_string(),
+            locator: r#"near: …"shasum":"0000","unpackedSize":{"bytes":1}},"depend…"#.to_string(),
             message: "invalid type: map, expected u64".to_string(),
         }
         .to_string();
@@ -1112,7 +1118,7 @@ mod tests {
     fn decode_error_omits_the_excerpt_clause_when_there_is_none() {
         let rendered = Error::Decode {
             context: "packument lodash".to_string(),
-            near: String::new(),
+            locator: String::new(),
             message: "invalid type: map, expected a string".to_string(),
         }
         .to_string();

--- a/vendor/aube/crates/aube-registry/tests/tolerant_deserializers.rs
+++ b/vendor/aube/crates/aube-registry/tests/tolerant_deserializers.rs
@@ -156,6 +156,18 @@ fn ref_unpacked_size(v: &Value) -> Option<u64> {
     v.as_u64()
 }
 
+/// `modified` keeps a string and drops every other shape.
+fn ref_modified(v: &Value) -> Option<String> {
+    v.as_str().map(str::to_owned)
+}
+
+/// `hasInstallScript` and `peerDependenciesMeta.<x>.optional` keep a
+/// real boolean and read as `false` for every other shape — the same
+/// reading a missing key already gets.
+fn ref_tolerant_bool(v: &Value) -> bool {
+    v.as_bool().unwrap_or(false)
+}
+
 // === Plumbing: wrap an arbitrary value into a minimal Packument /
 // VersionMetadata JSON and parse it through the production path. ===
 
@@ -181,6 +193,14 @@ fn parse_dist_with(field: &str, value: &Value) -> VersionMetadata {
     dist.insert("tarball".into(), Value::String("https://x/t.tgz".into()));
     dist.insert(field.into(), value.clone());
     parse_version_with("dist", &Value::Object(dist))
+}
+
+/// `peerDependenciesMeta` nests a level down, and both levels can be
+/// off-spec: the entry itself, or its `optional` field.
+fn parse_peer_meta_entry(entry: &Value) -> VersionMetadata {
+    let mut meta = serde_json::Map::new();
+    meta.insert("react".into(), entry.clone());
+    parse_version_with("peerDependenciesMeta", &Value::Object(meta))
 }
 
 // === Properties ===
@@ -256,6 +276,36 @@ proptest! {
         let parsed = parse_dist_with("unpackedSize", &v);
         let actual = parsed.dist.as_ref().and_then(|d| d.unpacked_size);
         prop_assert_eq!(actual, ref_unpacked_size(&v));
+    }
+
+    #[test]
+    fn modified_matches_reference(v in arb_json()) {
+        let parsed = parse_packument_with("modified", &v);
+        prop_assert_eq!(parsed.modified, ref_modified(&v));
+    }
+
+    #[test]
+    fn has_install_script_matches_reference(v in arb_json()) {
+        let parsed = parse_version_with("hasInstallScript", &v);
+        prop_assert_eq!(parsed.has_install_script, ref_tolerant_bool(&v));
+    }
+
+    /// An off-spec `optional` degrades to `false` — the stricter
+    /// reading (peer required), never a silently relaxed requirement.
+    #[test]
+    fn peer_dep_meta_optional_matches_reference(v in arb_json()) {
+        let parsed = parse_peer_meta_entry(&serde_json::json!({ "optional": v.clone() }));
+        let actual = parsed.peer_dependencies_meta.get("react").map(|m| m.optional);
+        prop_assert_eq!(actual, Some(ref_tolerant_bool(&v)));
+    }
+
+    /// The whole entry being off-spec is the other shape a mirror
+    /// produces; it must not abort the packument either.
+    #[test]
+    fn peer_dep_meta_tolerates_a_non_object_entry(v in arb_json()) {
+        let parsed = parse_peer_meta_entry(&v);
+        let expected = v.get("optional").is_some_and(ref_tolerant_bool);
+        prop_assert_eq!(parsed.peer_dependencies_meta["react"].optional, expected);
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #646 — review the top commit only.

**Decode errors name what failed.** `I/O error: invalid type: map, expected u64` named no package and no field, and packument fetches are concurrent, so it got blamed on whichever fetch surfaced first. Now:

```
failed to decode packument @img/colour: invalid type: map, expected u64
  — near: …"shasum":"0000…","unpackedSize":{"bytes":1}},"depend…
```

The excerpt supplies the field name; serde's message never carries the key.

**`modified`, `peerDependenciesMeta.optional`, `hasInstallScript`** each still aborted a whole install; each now degrades to the conservative reading. `integrity`/`shasum` stay strict.