### PR TITLE
fix(runtime): a .cjs preload must not outrun nub's hooks or run twice

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3067,24 +3067,14 @@ pub(crate) fn runtime_node_options(
         if preload.is_empty() || preload.contains('\0') {
             bail!("nub.jsonc `preload` entries must be non-empty paths or module specifiers");
         }
-        let path = Path::new(preload);
-        let is_cjs = path
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .is_some_and(|extension| extension.eq_ignore_ascii_case("cjs"));
-        let value = if path.is_absolute() && !is_cjs {
-            nub_core::node::spawn::path_to_file_url(preload)
-        } else {
-            preload.clone()
-        };
-        options.push(
-            nub_core::node::spawn::PreloadInjection {
-                flag: if is_cjs { "--require" } else { "--import" },
-                value,
-            }
-            .node_options_token(),
-        );
     }
+    // The whole list at once: whether a `.cjs` entry can keep `--require` depends on
+    // whether any SIBLING entry drags in the ESM loader. See user_preload_injections.
+    options.extend(
+        nub_core::node::spawn::user_preload_injections(&runtime.preload, &node.version)
+            .iter()
+            .map(|injection| injection.node_options_token()),
+    );
 
     if let Some(tsconfig) = runtime.tsconfig.as_deref()
         && !Path::new(tsconfig).is_file()

--- a/crates/nub-cli/src/project_config.rs
+++ b/crates/nub-cli/src/project_config.rs
@@ -1926,9 +1926,22 @@ mod tests {
             values.iter().map(|value| (*value).to_string()).collect()
         }
 
-        let schema: Value =
-            serde_json::from_str(include_str!("../../../site/public/schema/latest.json"))
-                .expect("the published nub.json schema must be valid JSON");
+        // Read at RUNTIME, not via include_str!. The schema is a PUBLISHED site
+        // artifact, and the site withdraws it whenever the config reference is
+        // hidden pending ship (3539b65db1) — a compile-time include turns that
+        // ordinary content decision into a build failure for the whole crate's test
+        // target. Absent schema means there is nothing published to be out of step
+        // with, so skip; the assertions return with the file.
+        let published = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../site/public/schema/latest.json"
+        );
+        let Ok(source) = std::fs::read_to_string(published) else {
+            eprintln!("skipping: {published} is not published right now");
+            return;
+        };
+        let schema: Value = serde_json::from_str(&source)
+            .expect("the published nub.json schema must be valid JSON");
         assert_eq!(keys(&schema, "/properties"), expected(ROOT_KEYS));
         assert_eq!(
             keys(&schema, "/properties/install/properties"),

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -707,3 +707,53 @@ fn module_enabler_flags_make_ffi_vfs_stream_iter_importable() {
         "all three enabler modules must load once nub injects their flags: stdout={stdout:?}"
     );
 }
+
+/// A `.cjs` entry in `nub.jsonc` `preload` must behave identically on both tiers:
+/// it runs exactly ONCE, and only after nub's hooks are live.
+///
+/// It regressed on the compat tier because a `.cjs` preload was injected as
+/// `--require`, and Node (a) runs every `--require` preload before any `--import`
+/// preload whatever the token order — and `--import` is how nub's own compat
+/// preload arrives — and (b) re-runs `--require` preloads inside the
+/// `module.register()` loader worker the compat tier always spawns. So the user's
+/// preload beat nub's hooks into the process AND ran a second time in the worker
+/// realm. See `user_preload_injection` in nub-core's spawn module.
+///
+/// The fixture's preload `require()`s a TypeScript sibling, so "hooks not yet
+/// installed" surfaces as a hard SyntaxError instead of a silent difference.
+#[test]
+fn cjs_preload_runs_once_after_hooks_on_both_tiers() {
+    // 22.13.0 is the compat-tier representative (the regression), 22.15.0 the
+    // first fast-tier version (the control that was always correct).
+    for want in [(22, 13, 0), (22, 15, 0)] {
+        let (maj, min, pat) = want;
+        let Some((stdout, stderr, code)) = run_nub_against_node(want, "cjs-preload", "main.js")
+        else {
+            eprintln!(
+                "skipping: Node {maj}.{min}.{pat} not installed \
+                 (set TEST_NODE_BIN_{maj}_{min}_{pat} or nvm install)"
+            );
+            continue;
+        };
+
+        assert_eq!(
+            code, 0,
+            "Node {maj}.{min}.{pat}: a .cjs preload must run without aborting: stderr={stderr}"
+        );
+        assert_eq!(
+            stdout.matches("preload:").count(),
+            1,
+            "Node {maj}.{min}.{pat}: a .cjs preload must run exactly once \
+             (a second line means the loader worker re-ran it): stdout={stdout:?}"
+        );
+        assert!(
+            stdout.contains("preload:hooked:marked"),
+            "Node {maj}.{min}.{pat}: the preload must see nub's hooks and version marker \
+             already installed: stdout={stdout:?}"
+        );
+        assert!(
+            stdout.find("preload:") < stdout.find("main:done"),
+            "Node {maj}.{min}.{pat}: the preload must run before the entry: stdout={stdout:?}"
+        );
+    }
+}

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -2714,6 +2714,32 @@ fn strip_verbatim(path: &str, windows: bool) -> String {
     path.to_string()
 }
 
+/// Whether a preload spec names an absolute path rather than a bare module
+/// specifier, deciding whether it needs the `file://` spelling.
+///
+/// Pure over `windows`, for the same reason [`to_file_url`] is: `Path::is_absolute`
+/// answers for the HOST, so a fixture like `/proj/pre.cjs` reads absolute on Unix
+/// and NOT absolute on Windows (there it is rooted but not drive-qualified). Mixing
+/// that into an otherwise-`windows`-parameterized function makes the pair disagree
+/// on a Windows host and silently emit a bare `--import=/proj/pre.cjs`. Matches
+/// `Path::is_absolute` on each platform for the paths that actually reach here.
+fn is_absolute_path(spec: &str, windows: bool) -> bool {
+    if !windows {
+        return spec.starts_with('/');
+    }
+    // UNC (`\\server\share`, `//server/share`) and the verbatim `\\?\C:\…` form
+    // both lead with a doubled separator; everything else must be drive-qualified
+    // (`C:\a`, `C:/a`). A lone leading slash is rooted-but-relative on Windows.
+    if spec.starts_with(r"\\") || spec.starts_with("//") {
+        return true;
+    }
+    let bytes = spec.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+}
+
 /// Convert a filesystem path to a `file://` URL Node's loader accepts on every
 /// platform. On Windows a path is `C:\a\b` (or a canonicalized `\\?\C:\a\b`); a
 /// naive `format!("file://{path}")` yields `file://C:\a\b`, which Node's
@@ -2924,7 +2950,7 @@ fn user_preload_injection_for(
         // as an import from the cwd. Only a real path needs the file:// spelling,
         // which is what stops a Windows `C:\…` from parsing its drive as the URL
         // authority (ERR_INVALID_FILE_URL_PATH).
-        value: if path.is_absolute() {
+        value: if is_absolute_path(spec, windows) {
             to_file_url(spec, windows)
         } else {
             spec.to_string()
@@ -5394,6 +5420,38 @@ mod tests {
                 "Node {version}: a bare specifier must not be mangled into a file:// URL"
             );
         }
+    }
+
+    /// Whether a spec needs the file:// spelling is decided from the `windows`
+    /// parameter, never the host — so both spellings are exercised wherever the
+    /// suite runs. Deciding it with `Path::is_absolute` instead passed everywhere
+    /// locally and failed all three POSIX-fixture cases above on the Windows CI leg,
+    /// where `/proj/pre.cjs` is rooted but not drive-qualified: the injection fell
+    /// through to the bare-specifier branch and emitted `--import=/proj/pre.cjs`.
+    #[test]
+    fn file_url_worthiness_is_decided_by_the_windows_flag_not_the_host() {
+        assert!(is_absolute_path("/proj/pre.cjs", false));
+        assert!(!is_absolute_path("telemetry-pkg", false));
+
+        // Rooted but not drive-qualified — Windows agrees this is not absolute.
+        assert!(!is_absolute_path("/proj/pre.cjs", true));
+        assert!(is_absolute_path(r"C:\proj\pre.cjs", true));
+        assert!(is_absolute_path("C:/proj/pre.cjs", true));
+        assert!(is_absolute_path(r"\\server\share\pre.cjs", true));
+        assert!(is_absolute_path(r"\\?\C:\proj\pre.cjs", true));
+        assert!(!is_absolute_path("telemetry-pkg", true));
+        assert!(!is_absolute_path("C:", true));
+
+        // End to end: a Windows drive path reaches Node as a drive-qualified URL,
+        // not as `file://C:\…` (whose drive would parse as the URL authority).
+        let specs = vec![r"C:\proj\pre.mjs".to_string()];
+        let win = user_preload_injections_for(&specs, &NodeVersion::new(20, 11, 0), true);
+        assert_eq!(
+            win.iter()
+                .map(|injection| injection.node_options_token())
+                .collect::<Vec<_>>(),
+            ["--import=file:///C:/proj/pre.mjs"]
+        );
     }
 
     #[test]

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -2736,11 +2736,6 @@ fn to_file_url(path: &str, windows: bool) -> String {
     }
 }
 
-/// Convert an absolute native path to the file URL spelling Node expects.
-pub fn path_to_file_url(path: &str) -> String {
-    to_file_url(path, cfg!(windows))
-}
-
 /// How nub injects its preload, chosen BY TIER. The fast tier (Node 22.15+) loads a
 /// CommonJS preload via `--require`; the compat tier (18.19–22.14) loads the ESM
 /// preload via `--import`. The channel choice is load-bearing: an `--import` ESM
@@ -2837,6 +2832,104 @@ pub fn preload_injection(
     version: &super::version::NodeVersion,
 ) -> PreloadInjection {
     preload_injection_for(preload_mjs, version, cfg!(windows))
+}
+
+/// How a USER preload (`nub.jsonc` `preload`) reaches Node — chosen by tier so it
+/// always lands AFTER nub's own preload and runs exactly once.
+///
+/// Two upstream Node facts drive this, both measured against plain `node` with no
+/// nub in the picture (18.19.0 through 26.5.0):
+///
+/// 1. Node runs EVERY `--require` preload before ANY `--import` preload, whatever
+///    order the tokens appear in on argv or in NODE_OPTIONS.
+/// 2. Every `module.register()` loader worker RE-RUNS the `--require` preloads in
+///    its own realm. The worker reads the immutable per-process option store, so
+///    scrubbing `process.env.NODE_OPTIONS` or `process.execArgv` before the
+///    `register()` call does NOT suppress it — there is no JS-side workaround.
+///    `--import` preloads are skipped in loader workers, which is why nub's own
+///    compat preload does not recurse.
+///
+/// On the COMPAT tier nub is itself an `--import` ([`preload_injection_for`]) and
+/// always registers a loader worker (`runtime/preload.mjs`), so a `.cjs` user
+/// preload injected as `--require` would run BEFORE nub's hooks are installed and
+/// run TWICE. Injecting it as `--import` fixes both at once.
+///
+/// So a `.cjs` preload may keep `--require` only when NOTHING in this invocation
+/// pulls in the ESM loader: nub's own preload is a `--require` (fast tier) AND no
+/// sibling entry in the list rides `--import`. A sibling `--import` is enough on its
+/// own, because it makes the runtime auto-select the async loader-worker tier
+/// (`shouldAutoAsyncTierAtPreload`) — measured: `["./b.mjs", "./a.cjs"]` on Node
+/// 22.15 ran `a.cjs` twice, ahead of `b.mjs`. Rerouting the `.cjs` in that case
+/// costs nothing, since the sibling has already forced eager ESM-loader init.
+///
+/// Where no sibling forces it, `--require` is retained deliberately: routing a CJS
+/// preload through `--import` would itself force that eager init and break the
+/// synchronous `Module.runMain` semantics of the user's ENTRY (the R1 cluster
+/// documented on [`PreloadInjection`]).
+///
+/// Takes the whole list because the decision is a property of the list, not of one
+/// entry. Order is preserved, which is the user-visible contract.
+pub fn user_preload_injections(
+    specs: &[String],
+    version: &super::version::NodeVersion,
+) -> Vec<PreloadInjection> {
+    user_preload_injections_for(specs, version, cfg!(windows))
+}
+
+fn user_preload_injections_for(
+    specs: &[String],
+    version: &super::version::NodeVersion,
+    windows: bool,
+) -> Vec<PreloadInjection> {
+    // Nub's own preload is `--import` below 22.15; above it, any non-CJS entry in
+    // the user's own list drags the ESM loader in just the same.
+    let esm_loader_forced =
+        !version.supports_augmentation() || specs.iter().any(|spec| !is_cjs_preload(spec));
+    specs
+        .iter()
+        .map(|spec| user_preload_injection_for(spec, esm_loader_forced, windows))
+        .collect()
+}
+
+fn is_cjs_preload(spec: &str) -> bool {
+    Path::new(spec)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("cjs"))
+}
+
+fn user_preload_injection_for(
+    spec: &str,
+    esm_loader_forced: bool,
+    windows: bool,
+) -> PreloadInjection {
+    let path = Path::new(spec);
+    // Only the exact lowercase `.cjs` can be rerouted. Node's ESM loader maps
+    // extensions case-SENSITIVELY and aborts on one it does not know
+    // (ERR_UNKNOWN_FILE_EXTENSION), while `require` falls back to loading an
+    // unrecognized extension as JS — so an oddly-cased `.CJS` stays on `--require`
+    // everywhere, keeping exactly the behavior it already had rather than trading a
+    // preload-ordering bug for a hard startup crash.
+    let reroutable = path.extension().and_then(|e| e.to_str()) == Some("cjs");
+    if is_cjs_preload(spec) && !(esm_loader_forced && reroutable) {
+        // `--require` does NOT accept a file:// URL, so the raw path goes through.
+        return PreloadInjection {
+            flag: "--require",
+            value: spec.to_string(),
+        };
+    }
+    PreloadInjection {
+        flag: "--import",
+        // A bare specifier (`my-preload`, `@scope/pkg`) stays bare — Node resolves it
+        // as an import from the cwd. Only a real path needs the file:// spelling,
+        // which is what stops a Windows `C:\…` from parsing its drive as the URL
+        // authority (ERR_INVALID_FILE_URL_PATH).
+        value: if path.is_absolute() {
+            to_file_url(spec, windows)
+        } else {
+            spec.to_string()
+        },
+    }
 }
 
 /// NODE_PATH value that makes nub's vendored runtime deps resolvable to a
@@ -5209,6 +5302,98 @@ mod tests {
         // The 22.14.x boundary stays on the compat (import) channel.
         let boundary = preload_injection_for(mjs, &NodeVersion::new(22, 14, 99), false);
         assert_eq!(boundary.flag, "--import");
+    }
+
+    fn tokens(specs: &[&str], version: &NodeVersion) -> Vec<String> {
+        let owned: Vec<String> = specs.iter().map(|s| (*s).to_string()).collect();
+        user_preload_injections_for(&owned, version, false)
+            .iter()
+            .map(|injection| injection.node_options_token())
+            .collect()
+    }
+
+    /// A lone `.cjs` USER preload rides `--require` only where nothing else pulls in
+    /// the ESM loader. On the compat tier nub's own preload is an `--import`, so the
+    /// user's must be one too: Node runs every `--require` before any `--import`
+    /// regardless of token order (a `--require` would beat nub's hooks into the
+    /// process), and re-runs `--require` preloads inside the `module.register()`
+    /// loader worker the compat tier always spawns (so it would also run twice).
+    #[test]
+    fn lone_cjs_preload_rides_import_on_compat_tier_require_on_fast_tier() {
+        assert_eq!(
+            tokens(&["/proj/pre.cjs"], &NodeVersion::new(22, 15, 0)),
+            ["--require=/proj/pre.cjs"]
+        );
+
+        for version in [
+            NodeVersion::new(22, 14, 99),
+            NodeVersion::new(20, 11, 0),
+            NodeVersion::new(18, 19, 0),
+        ] {
+            assert_eq!(
+                tokens(&["/proj/pre.cjs"], &version),
+                ["--import=file:///proj/pre.cjs"],
+                "Node {version}: a .cjs user preload must not ride --require on the compat tier"
+            );
+        }
+    }
+
+    /// A sibling `--import` entry forces the runtime onto its async loader-worker
+    /// tier even on the fast tier, so a `.cjs` alongside one has the same
+    /// runs-early-and-twice problem and is rerouted too. Rerouting is free here: the
+    /// sibling has already forced eager ESM-loader init, so the R1 entry semantics
+    /// that `--require` protects are gone either way. Declared order is preserved.
+    #[test]
+    fn cjs_preload_is_rerouted_when_a_sibling_entry_forces_the_esm_loader() {
+        assert_eq!(
+            tokens(
+                &["/proj/b.mjs", "/proj/a.cjs"],
+                &NodeVersion::new(22, 15, 0)
+            ),
+            ["--import=file:///proj/b.mjs", "--import=file:///proj/a.cjs"]
+        );
+        // No sibling `--import`: every entry keeps the sync `--require` channel.
+        assert_eq!(
+            tokens(
+                &["/proj/a.cjs", "/proj/c.cjs"],
+                &NodeVersion::new(22, 15, 0)
+            ),
+            ["--require=/proj/a.cjs", "--require=/proj/c.cjs"]
+        );
+    }
+
+    /// An oddly-cased `.CJS` keeps `--require` even where the ESM loader is forced.
+    /// Node's ESM loader would abort the process with ERR_UNKNOWN_FILE_EXTENSION on
+    /// it, whereas `require` loads an unrecognized extension as JS — so rerouting
+    /// would trade a preload-ordering bug for a hard startup crash.
+    #[test]
+    fn oddly_cased_cjs_preload_is_not_rerouted_onto_import() {
+        for version in [NodeVersion::new(20, 11, 0), NodeVersion::new(24, 0, 0)] {
+            assert_eq!(
+                tokens(&["/proj/pre.CJS"], &version),
+                ["--require=/proj/pre.CJS"],
+                "Node {version}: .CJS must stay on --require (the ESM loader has no \
+                 case-insensitive or unknown-extension fallback)"
+            );
+        }
+    }
+
+    /// Non-`.cjs` preloads are `--import` on BOTH tiers, and only a real path gets
+    /// the file:// spelling — a bare specifier stays bare so Node resolves it as an
+    /// ordinary import from the cwd.
+    #[test]
+    fn user_preload_import_form_is_tier_independent_and_spares_bare_specifiers() {
+        for version in [NodeVersion::new(24, 0, 0), NodeVersion::new(20, 11, 0)] {
+            assert_eq!(
+                tokens(&["/proj/pre.mjs"], &version),
+                ["--import=file:///proj/pre.mjs"]
+            );
+            assert_eq!(
+                tokens(&["telemetry-pkg"], &version),
+                ["--import=telemetry-pkg"],
+                "Node {version}: a bare specifier must not be mangled into a file:// URL"
+            );
+        }
     }
 
     #[test]

--- a/tests/fixtures/cjs-preload/main.js
+++ b/tests/fixtures/cjs-preload/main.js
@@ -1,0 +1,1 @@
+console.log("main:done");

--- a/tests/fixtures/cjs-preload/nub.jsonc
+++ b/tests/fixtures/cjs-preload/nub.jsonc
@@ -1,0 +1,5 @@
+{
+  // A `.cjs` preload is the case that regressed: it must run AFTER nub's hooks
+  // are installed, and exactly once.
+  "preload": ["./pre.cjs"]
+}

--- a/tests/fixtures/cjs-preload/package.json
+++ b/tests/fixtures/cjs-preload/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "cjs-preload-fixture",
+  "private": true
+}

--- a/tests/fixtures/cjs-preload/pre.cjs
+++ b/tests/fixtures/cjs-preload/pre.cjs
@@ -1,0 +1,5 @@
+// Requiring a TypeScript sibling is the proof that nub's hooks are already live:
+// the annotation only strips through the load hook nub installs in its own
+// preload. One line per execution, so a duplicate run is visible in the output.
+const { tag } = require("./probe.ts");
+console.log(`preload:${tag}:${process.versions.nub ? "marked" : "unmarked"}`);

--- a/tests/fixtures/cjs-preload/probe.ts
+++ b/tests/fixtures/cjs-preload/probe.ts
@@ -1,0 +1,5 @@
+// CJS module syntax deliberately: `require()` of an ESM `.ts` is a documented
+// compat-tier limitation (ERR_REQUIRE_ESM on 22.12-22.14), which would mask the
+// ordering signal this fixture exists to measure.
+const tag: string = "hooked";
+module.exports = { tag };


### PR DESCRIPTION
A `.cjs` entry in the nub.jsonc `preload` array ran before Nub's hooks were installed, and ran twice, on the compat tier (Node 18.19–22.14). Found while verifying something unrelated; no issue filed.

A preload that `require()`s a TypeScript file did not merely misbehave — it aborted the process on the unstripped annotation:

```
SyntaxError: Missing initializer in const declaration
    at Object.<anonymous> (/tmp/fixture/pre.cjs:4:17)
```

## Why

Preloads were injected by extension: `.cjs` → `--require`, everything else → `--import`. Two upstream Node behaviors make that wrong wherever Nub's own preload is an `--import`. Both were measured against plain `node` with no Nub involved, on 18.19.0 through 26.5.0:

1. Node runs **every** `--require` preload before **any** `--import` preload, whatever order the tokens appear in. Nub's compat preload is an `--import`, so a user `--require` always won the race and ran before the hooks existed.
2. Every `module.register()` loader worker **re-runs** the `--require` preloads in its own realm, and the compat tier always registers one. So the preload also ran twice — four times when user code spawned a worker of its own. The worker reads the immutable per-process option store, so scrubbing `process.env.NODE_OPTIONS` or `process.execArgv` before the `register()` call does not suppress it.

## The change

A `.cjs` preload keeps `--require` only when nothing in the invocation pulls in the ESM loader: Nub's own preload is a `--require` (fast tier) **and** no sibling entry rides `--import`. Otherwise it rides `--import`, which is ordered after Nub's token and is skipped in loader workers.

The sibling clause matters on the fast tier too. Given `["./b.mjs", "./a.cjs"]`, Node 22.15 ran `a.cjs` twice and ahead of `b.mjs`, because the `.mjs` makes the runtime auto-select the async loader-worker tier. Rerouting costs nothing there — the sibling has already forced eager ESM-loader init.

Where nothing forces it, `--require` is retained deliberately: routing a CJS preload through `--import` would itself force that init and break the synchronous `Module.runMain` semantics of the user's entry (the R1 cluster).

An oddly-cased `.CJS` stays on `--require` everywhere. Node's ESM loader maps extensions case-sensitively with no unknown-extension fallback, while `require()` loads an unrecognized extension as JS, so rerouting it would trade a preload-ordering bug for an `ERR_UNKNOWN_FILE_EXTENSION` startup crash.

## Verification

Driven end-to-end on 18.19.0, 18.20.4, 20.19.0, 22.13.0, 22.14.0, 22.15.0, 24.17.0 and 26.5.0 — one run, hooks live, declared order preserved, on both the file-run and `nub run` paths. A falsification sweep against a merge-base build also covered worker realms, a throwing preload (exit status and entry suppression unchanged), `require.cache` and `Module.prototype.require` patching, bare specifiers, and `--node` compat mode.

Two behavior notes, both accepted:

- An oddly-cased `.CJS` on the compat tier keeps the original early-and-twice bug, because rerouting it would crash. Uppercase `.MJS` was already broken the same way before this change, so uppercase-extension preloads are a pre-existing family worth its own fix.
- A rerouted `.cjs` preload sees `module.parent` as `undefined` rather than an object. The property is deprecated (DEP0144), and the fast tier is unchanged.

Coverage: five unit tests on the injection policy in `nub-core`, and a `version_tiers` integration test over a new `tests/fixtures/cjs-preload` fixture, run against both a compat-tier and a fast-tier Node.

## Third commit: a Windows-only defect the first CI run caught

The first run was red on `Test (windows-latest, node 24)` and `embed-runtime verify (windows-latest)`. The new injection function takes a `windows` parameter for purity but decided whether a spec needed the `file://` spelling with `Path::is_absolute()`, which answers for the host — so the POSIX fixture `/proj/pre.cjs`, rooted but not drive-qualified on Windows, fell through to the bare-specifier branch and emitted `--import=/proj/pre.cjs`.

Replaced with a pure `is_absolute_path(spec, windows)` beside `strip_verbatim` and `to_file_url`, matching the "pure over `windows` so both branches test on any host" pattern those already document.

Production behavior was never affected on either platform: preload entries are resolved to a platform-native absolute path before reaching this code, and the two predicates agree on those. The defect was test purity, and the coverage gap under it — nothing exercised the Windows spelling, so it was invisible from a Mac. The added test asserts the `windows: true` branch on any host, and was checked to fail against the old predicate with `--import=C:\proj\pre.mjs`.

## The first commit is unrelated

`cargo clippy --all-targets` and `cargo test` fail on `main` right now, before this branch touches anything:

```
error: couldn't read crates/nub-cli/src/../../../site/public/schema/latest.json
```

3539b65db1 withdrew that published schema to hide the nub.jsonc config reference until it ships, but a test still embedded it with `include_str!`, turning a content decision into a compile error for the whole nub-cli test target. Every CI run on main since has been cancelled, so nothing caught it. The test now reads the file at runtime and skips when it is unpublished, keeping its assertions — verified to still fail on a schema drifted from the parser's key set — whenever the file is present.
