### PR TITLE
fix(core): never trust a config-cache entry read inside the file's own mtime tick

### DIFF
--- a/crates/nub-core/src/config_cache.rs
+++ b/crates/nub-core/src/config_cache.rs
@@ -15,17 +15,24 @@
 //! call-ordering analysis: a cache validated on mtime can never serve a value
 //! older than the file on disk.
 //!
-//! That argument only closes once the RACY window is handled: mtime resolution
-//! is the platform clock's, not the filesystem's, and on Windows that clock
-//! ticks coarsely enough that a rewrite microseconds after the cached read can
-//! report the very same mtime. `size` catches such a rewrite only when the
-//! length also changed — a same-length edit (`pnpm@10.0.0` → `pnpm@11.0.0`, a
-//! patch bump inside a `packageManager` pin) is invisible to both fields. So
-//! entries also carry the instant they were cached and are trusted only once
-//! the file's mtime is strictly OLDER than that instant. This is git's
-//! "racily clean" rule: a stamp taken in the same tick as the observation
-//! cannot prove the file did not change afterwards, so it is never trusted on
-//! its own. See [`Entry::cached_at`].
+//! That argument only closes once the RACY window is handled. File mtimes are
+//! quantized to the platform's timer tick — measured at 0.39-1.4 ms on Windows
+//! Server 2022/NTFS — so a rewrite landing in the same tick as the cached read
+//! reports the very same mtime. `size` catches that only when the length also
+//! changed, and a same-length edit (`pnpm@10.0.0` → `pnpm@11.0.0`, a patch bump
+//! inside a `packageManager` pin) is invisible to both fields. Entries therefore
+//! also carry the instant they were cached, and are trusted only once a full
+//! [`MTIME_GRANULARITY_SLOP`] separates the file's mtime from it — proof the
+//! mtime's tick had already closed, so no later write can reuse that value.
+//!
+//! The slop is the whole trick, and leaving it out makes the check a no-op:
+//! `SystemTime::now()` is PRECISE (`GetSystemTimePreciseAsFileTime` on Windows,
+//! nanoseconds elsewhere) while the mtime it is compared against is QUANTIZED,
+//! so for any just-written file `mtime <= now()` holds by construction. Measured:
+//! a bare `mtime < cached_at` rejected 0 of 2000 trials on both macOS and
+//! Windows. Git avoids the trap by comparing an entry's mtime against the index
+//! FILE's mtime — two values from the same quantized domain. Comparing a precise
+//! clock against a quantized timestamp needs the slop to mean anything.
 //!
 //! Cache MISS semantics match an uncached read exactly: a missing/unreadable
 //! file, or a file whose mtime is unavailable, is never cached (the closure
@@ -34,7 +41,21 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock, RwLock};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
+
+/// How far a file's mtime must precede the read that cached it before the
+/// `(mtime, size)` stamp is trusted to detect a later rewrite. Must exceed the
+/// platform's mtime quantum, since two writes inside one quantum report the same
+/// mtime.
+///
+/// Two seconds covers every quantum nub can land on with margin: 0.39-1.4 ms
+/// measured on Windows Server 2022/NTFS, up to the 15.6 ms Windows timer tick
+/// when no process has raised the timer resolution, and FAT32's 2 s. Sized
+/// generously because the cost is close to zero — config nub reads is seconds to
+/// days old, so it clears the slop and still hits. Only a file written within two
+/// seconds of the read goes uncached, and the fallback there is exactly the
+/// uncached read this cache replaced.
+const MTIME_GRANULARITY_SLOP: Duration = Duration::from_secs(2);
 
 /// A path-keyed cache whose entries are invalidated when the underlying file's
 /// freshness stamp — its `(mtime, size)` pair — changes. Stores `Arc<V>` so a
@@ -63,20 +84,15 @@ struct Entry<V> {
     /// serves the value only if the file still reports this exact stamp.
     stamp: Stamp,
     /// The instant sampled just BEFORE the value was read, and the reason a
-    /// same-mtime same-size rewrite cannot be served stale: an entry is trusted
-    /// only while `stamp.mtime < cached_at`, i.e. the file was already at least
-    /// one clock tick old when it was read. A file written during or after that
-    /// read reports `mtime >= cached_at` and is re-read on every lookup — the
-    /// coarse-clock case can no longer masquerade as unchanged.
+    /// same-mtime same-size rewrite cannot be served stale. An entry is trusted
+    /// only once `cached_at - stamp.mtime >= MTIME_GRANULARITY_SLOP`, which
+    /// proves the mtime's quantum had already closed when the read happened, so
+    /// every later write necessarily lands in a later quantum and reports a
+    /// different mtime. A file still inside its own quantum is re-read on every
+    /// lookup instead.
     ///
     /// Sampled before rather than after the read so the read-then-stat window is
     /// covered too: a write landing mid-read also lands at-or-after this instant.
-    ///
-    /// Cost is confined to exactly the files this protects. Config already on
-    /// disk when the process started — every real `.npmrc` / `package.json` /
-    /// `.yarnrc.yml`, and the whole reason the cache exists — has an mtime well
-    /// below `cached_at` and still hits. Only a file nub itself just wrote, or
-    /// one written within the tick before it read, goes uncached.
     cached_at: SystemTime,
     value: Arc<V>,
 }
@@ -146,8 +162,19 @@ impl<V> MtimeCache<V> {
     fn lookup_fresh(&self, path: &Path, stamp: Stamp) -> Option<Arc<V>> {
         let guard = self.map().read().expect("MtimeCache lock poisoned");
         let entry = guard.get(path)?;
-        (entry.stamp == stamp && stamp.mtime < entry.cached_at).then(|| Arc::clone(&entry.value))
+        (entry.stamp == stamp && mtime_quantum_closed(stamp.mtime, entry.cached_at))
+            .then(|| Arc::clone(&entry.value))
     }
+}
+
+/// Whether `mtime`'s quantum had provably closed by `cached_at`, i.e. whether the
+/// `(mtime, size)` stamp can be trusted to notice a rewrite that happened after
+/// the caching read. A backwards clock step yields `Err` here and reads as "not
+/// closed", which is the safe direction.
+pub(crate) fn mtime_quantum_closed(mtime: SystemTime, cached_at: SystemTime) -> bool {
+    cached_at
+        .duration_since(mtime)
+        .is_ok_and(|elapsed| elapsed >= MTIME_GRANULARITY_SLOP)
 }
 
 /// The file's freshness stamp `(mtime, size)`, or `None` when it can't be
@@ -187,20 +214,6 @@ mod tests {
         std::fs::metadata(path).unwrap().modified().unwrap()
     }
 
-    /// Rewrite `path` with `contents`, busy-rewriting until the file's reported
-    /// mtime advances past `prev` — so the test forces a genuine mtime change
-    /// regardless of the filesystem's mtime granularity, without a fixed sleep
-    /// or a `filetime` dev-dep. Bounded to avoid hanging.
-    fn write_until_mtime_advances(path: &Path, contents: &str, prev: SystemTime) {
-        for _ in 0..10_000 {
-            std::fs::write(path, contents).unwrap();
-            if mtime_of(path) > prev {
-                return;
-            }
-        }
-        panic!("filesystem mtime did not advance after repeated writes");
-    }
-
     fn set_mtime(path: &Path, mtime: SystemTime) {
         std::fs::File::options()
             .write(true)
@@ -210,18 +223,14 @@ mod tests {
             .unwrap();
     }
 
-    /// Spin until the clock has passed `path`'s mtime, so a subsequent
-    /// `get_or_read` caches an entry that is trusted rather than racy-distrusted
-    /// (see `Entry::cached_at`). Costs at most one clock tick.
-    fn settle(path: &Path) {
-        let mtime = mtime_of(path);
-        for _ in 0..1_000_000 {
-            if SystemTime::now() > mtime {
-                return;
-            }
-            std::hint::spin_loop();
-        }
-        panic!("clock did not advance past the file's mtime");
+    /// Backdate `path` by `secs`, well clear of [`MTIME_GRANULARITY_SLOP`], making
+    /// it cacheable — the state every real on-disk config file is already in.
+    /// Tests asserting a cache HIT need this, since a file written moments ago is
+    /// deliberately never trusted. Callers that age the same path twice pass
+    /// DIFFERENT offsets, so the two mtimes differ by construction rather than by
+    /// however much wall-clock drifted between the calls.
+    fn age(path: &Path, secs: u64) {
+        set_mtime(path, SystemTime::now() - Duration::from_secs(secs));
     }
 
     #[test]
@@ -229,8 +238,8 @@ mod tests {
         let dir = tmpdir("hit");
         let path = dir.join("f.txt");
         std::fs::write(&path, "v1").unwrap();
-        // Only a file that predates the read is cacheable at all.
-        settle(&path);
+        // Only a file whose mtime quantum has closed is cacheable at all.
+        age(&path, 60);
 
         let cache: MtimeCache<String> = MtimeCache::new();
         let reads = AtomicUsize::new(0);
@@ -258,39 +267,40 @@ mod tests {
         let dir = tmpdir("inval");
         let path = dir.join("f.txt");
         std::fs::write(&path, "v1").unwrap();
+        age(&path, 60);
 
         let cache: MtimeCache<String> = MtimeCache::new();
         let read = || std::fs::read_to_string(&path).ok();
 
         let a = cache.get_or_read(&path, read).unwrap();
         assert_eq!(&*a, "v1");
-        let cached_mtime = mtime_of(&path);
 
         // Mutate the file (same byte length, so this exercises the MTIME half of
-        // the stamp specifically) and force a later mtime so the cache must miss
-        // and re-read — the same protection a mid-command engine write gets.
-        write_until_mtime_advances(&path, "v2", cached_mtime);
+        // the stamp specifically) and age it again, so it stays cacheable and the
+        // MISS is attributable to the changed mtime rather than to the slop.
+        std::fs::write(&path, "v2").unwrap();
+        age(&path, 30);
 
         let b = cache.get_or_read(&path, read).unwrap();
         assert_eq!(&*b, "v2", "a changed mtime must yield the fresh contents");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// A file still inside its own mtime tick when it is read must never be
-    /// cached, because a rewrite moments later can report a byte-identical
+    /// A file still inside its own mtime quantum when it is read must never be
+    /// cached, because a rewrite moments later reports a byte-identical
     /// `(mtime, size)` and would otherwise be served stale. That is exactly the
     /// `pnpm@10.0.0` → `pnpm@11.0.0` manifest rewrite (32 bytes either way) that
-    /// flaked on Windows CI, where two writes separated only by a read collide
-    /// on mtime the majority of the time.
+    /// flaked on Windows CI, where two writes separated only by a read collide on
+    /// mtime the majority of the time.
     ///
-    /// Reproducing it needs the collision forced rather than raced: on an
-    /// ns-resolution filesystem the two writes essentially never share an mtime.
-    /// Pinning both stamps to an instant the reader's clock has not yet passed
-    /// models what a coarse clock hands out — the write lands at or after the
-    /// reader's own `now()`, since both quantize to the same tick — and makes
-    /// the case deterministic on every platform.
+    /// The collision is pinned rather than raced, because an ns-resolution
+    /// filesystem essentially never produces it on its own. Both versions are
+    /// pinned to `now()` — where a real coarse-clock write lands, and the value
+    /// that makes this reproduce identically on every platform. Pinning to a
+    /// FUTURE instant would not: no clock hands one out, and a test built that way
+    /// passes against a guard that does nothing.
     #[test]
-    fn rewrite_inside_the_cached_mtime_tick_is_never_served_stale() {
+    fn rewrite_inside_the_cached_mtime_quantum_is_never_served_stale() {
         let dir = tmpdir("racy");
         let path = dir.join("f.txt");
 
@@ -301,17 +311,17 @@ mod tests {
             ("pnpm@10.0.0", "pnpm@11.0.0"), // same length — the flake's shape
             ("longer-contents", "short"),   // length also changes
         ] {
-            let unpassed = SystemTime::now() + std::time::Duration::from_millis(50);
+            let collided = SystemTime::now();
 
             std::fs::write(&path, first).unwrap();
-            set_mtime(&path, unpassed);
+            set_mtime(&path, collided);
             assert_eq!(&*cache.get_or_read(&path, read).unwrap(), first);
 
             std::fs::write(&path, second).unwrap();
-            set_mtime(&path, unpassed);
+            set_mtime(&path, collided);
             assert_eq!(
                 mtime_of(&path),
-                unpassed,
+                collided,
                 "the two versions must be indistinguishable by stamp for this to test anything"
             );
 

--- a/crates/nub-core/src/config_cache.rs
+++ b/crates/nub-core/src/config_cache.rs
@@ -15,6 +15,18 @@
 //! call-ordering analysis: a cache validated on mtime can never serve a value
 //! older than the file on disk.
 //!
+//! That argument only closes once the RACY window is handled: mtime resolution
+//! is the platform clock's, not the filesystem's, and on Windows that clock
+//! ticks coarsely enough that a rewrite microseconds after the cached read can
+//! report the very same mtime. `size` catches such a rewrite only when the
+//! length also changed — a same-length edit (`pnpm@10.0.0` → `pnpm@11.0.0`, a
+//! patch bump inside a `packageManager` pin) is invisible to both fields. So
+//! entries also carry the instant they were cached and are trusted only once
+//! the file's mtime is strictly OLDER than that instant. This is git's
+//! "racily clean" rule: a stamp taken in the same tick as the observation
+//! cannot prove the file did not change afterwards, so it is never trusted on
+//! its own. See [`Entry::cached_at`].
+//!
 //! Cache MISS semantics match an uncached read exactly: a missing/unreadable
 //! file, or a file whose mtime is unavailable, is never cached (the closure
 //! re-runs every time), so behavior is byte-for-byte identical to the
@@ -37,11 +49,9 @@ pub struct MtimeCache<V> {
 /// The cheap two-field freshness signal compared on every lookup. Both fields
 /// come from one `stat`. `size` is belt-and-suspenders alongside `mtime`: a
 /// rewrite that lands within the same mtime tick but changes the file length
-/// (common on coarse-resolution filesystems, and in tests that rewrite-then-
-/// reread the same path) still invalidates. A same-mtime, same-size content
-/// edit is not distinguished — that case does not arise in nub's one-command-
-/// per-process flow (the only mutator runs after all config reads), and the
-/// cache is per-process, so there is no cross-run staleness to chase.
+/// still invalidates on length alone. A same-mtime, same-size content edit is
+/// not distinguished by these two fields at all — [`Entry::cached_at`] is what
+/// covers that case.
 #[derive(PartialEq, Eq, Clone, Copy)]
 struct Stamp {
     mtime: SystemTime,
@@ -52,6 +62,22 @@ struct Entry<V> {
     /// The freshness stamp observed when this value was cached. A later lookup
     /// serves the value only if the file still reports this exact stamp.
     stamp: Stamp,
+    /// The instant sampled just BEFORE the value was read, and the reason a
+    /// same-mtime same-size rewrite cannot be served stale: an entry is trusted
+    /// only while `stamp.mtime < cached_at`, i.e. the file was already at least
+    /// one clock tick old when it was read. A file written during or after that
+    /// read reports `mtime >= cached_at` and is re-read on every lookup — the
+    /// coarse-clock case can no longer masquerade as unchanged.
+    ///
+    /// Sampled before rather than after the read so the read-then-stat window is
+    /// covered too: a write landing mid-read also lands at-or-after this instant.
+    ///
+    /// Cost is confined to exactly the files this protects. Config already on
+    /// disk when the process started — every real `.npmrc` / `package.json` /
+    /// `.yarnrc.yml`, and the whole reason the cache exists — has an mtime well
+    /// below `cached_at` and still hits. Only a file nub itself just wrote, or
+    /// one written within the tick before it read, goes uncached.
+    cached_at: SystemTime,
     value: Arc<V>,
 }
 
@@ -94,13 +120,13 @@ impl<V> MtimeCache<V> {
         {
             return Some(hit);
         }
+        // Sampled before the read so a write landing mid-read is also caught —
+        // see `Entry::cached_at`.
+        let cached_at = SystemTime::now();
         let value = Arc::new(read()?);
         // Only cache when we can observe a stamp to validate against. The common
         // case (the file exists, so `read` succeeded) has one; re-stat to pin
-        // the value to the version we just read. A read-then-mutate race within
-        // the same command is impossible (the only mutator is the engine call
-        // that runs after all config reads), but the post-read re-stat keeps the
-        // cached stamp honest regardless.
+        // the value to the version we just read.
         if let Some(stamp) = current_stamp(path) {
             self.map()
                 .write()
@@ -109,6 +135,7 @@ impl<V> MtimeCache<V> {
                     path.to_path_buf(),
                     Entry {
                         stamp,
+                        cached_at,
                         value: Arc::clone(&value),
                     },
                 );
@@ -119,7 +146,7 @@ impl<V> MtimeCache<V> {
     fn lookup_fresh(&self, path: &Path, stamp: Stamp) -> Option<Arc<V>> {
         let guard = self.map().read().expect("MtimeCache lock poisoned");
         let entry = guard.get(path)?;
-        (entry.stamp == stamp).then(|| Arc::clone(&entry.value))
+        (entry.stamp == stamp && stamp.mtime < entry.cached_at).then(|| Arc::clone(&entry.value))
     }
 }
 
@@ -174,11 +201,36 @@ mod tests {
         panic!("filesystem mtime did not advance after repeated writes");
     }
 
+    fn set_mtime(path: &Path, mtime: SystemTime) {
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(mtime)
+            .unwrap();
+    }
+
+    /// Spin until the clock has passed `path`'s mtime, so a subsequent
+    /// `get_or_read` caches an entry that is trusted rather than racy-distrusted
+    /// (see `Entry::cached_at`). Costs at most one clock tick.
+    fn settle(path: &Path) {
+        let mtime = mtime_of(path);
+        for _ in 0..1_000_000 {
+            if SystemTime::now() > mtime {
+                return;
+            }
+            std::hint::spin_loop();
+        }
+        panic!("clock did not advance past the file's mtime");
+    }
+
     #[test]
     fn second_read_of_unchanged_file_is_a_cache_hit() {
         let dir = tmpdir("hit");
         let path = dir.join("f.txt");
         std::fs::write(&path, "v1").unwrap();
+        // Only a file that predates the read is cacheable at all.
+        settle(&path);
 
         let cache: MtimeCache<String> = MtimeCache::new();
         let reads = AtomicUsize::new(0);
@@ -224,29 +276,50 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// A rewrite that lands within the SAME mtime tick but changes the file
-    /// length must still invalidate — the `size` half of the stamp. This is the
-    /// rapid rewrite-then-reread pattern some config tests use, and without the
-    /// size field it served a stale value on coarse-mtime filesystems. The loop
-    /// hammers the rewrite to make a same-tick collision likely; the assertion
-    /// must hold whether or not the tick actually collided.
+    /// A file still inside its own mtime tick when it is read must never be
+    /// cached, because a rewrite moments later can report a byte-identical
+    /// `(mtime, size)` and would otherwise be served stale. That is exactly the
+    /// `pnpm@10.0.0` → `pnpm@11.0.0` manifest rewrite (32 bytes either way) that
+    /// flaked on Windows CI, where two writes separated only by a read collide
+    /// on mtime the majority of the time.
+    ///
+    /// Reproducing it needs the collision forced rather than raced: on an
+    /// ns-resolution filesystem the two writes essentially never share an mtime.
+    /// Pinning both stamps to an instant the reader's clock has not yet passed
+    /// models what a coarse clock hands out — the write lands at or after the
+    /// reader's own `now()`, since both quantize to the same tick — and makes
+    /// the case deterministic on every platform.
     #[test]
-    fn same_mtime_different_size_invalidates() {
-        let dir = tmpdir("size");
+    fn rewrite_inside_the_cached_mtime_tick_is_never_served_stale() {
+        let dir = tmpdir("racy");
         let path = dir.join("f.txt");
 
         let cache: MtimeCache<String> = MtimeCache::new();
         let read = || std::fs::read_to_string(&path).ok();
 
-        for _ in 0..200 {
-            std::fs::write(&path, "longer-contents").unwrap();
-            let long = cache.get_or_read(&path, read).unwrap();
-            assert_eq!(&*long, "longer-contents");
-            // Different length — a same-mtime-tick collision here must NOT serve
-            // the stale "longer-contents".
-            std::fs::write(&path, "short").unwrap();
-            let short = cache.get_or_read(&path, read).unwrap();
-            assert_eq!(&*short, "short", "size change must invalidate the cache");
+        for (first, second) in [
+            ("pnpm@10.0.0", "pnpm@11.0.0"), // same length — the flake's shape
+            ("longer-contents", "short"),   // length also changes
+        ] {
+            let unpassed = SystemTime::now() + std::time::Duration::from_millis(50);
+
+            std::fs::write(&path, first).unwrap();
+            set_mtime(&path, unpassed);
+            assert_eq!(&*cache.get_or_read(&path, read).unwrap(), first);
+
+            std::fs::write(&path, second).unwrap();
+            set_mtime(&path, unpassed);
+            assert_eq!(
+                mtime_of(&path),
+                unpassed,
+                "the two versions must be indistinguishable by stamp for this to test anything"
+            );
+
+            assert_eq!(
+                &*cache.get_or_read(&path, read).unwrap(),
+                second,
+                "a rewrite sharing the cached mtime must not serve {first:?}"
+            );
         }
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/nub-core/src/workspace/detect.rs
+++ b/crates/nub-core/src/workspace/detect.rs
@@ -37,8 +37,8 @@ pub struct Project {
 /// can rewrite `package.json` mid-command (`nub install`/`add`/`pm use`) and an
 /// install can create or remove a `pnpm-lock.yaml`/`pnpm-workspace.yaml`; any
 /// such change flips a stamp, so the next lookup misses and the walk re-runs.
-/// A same-length rewrite landing inside the walk's own clock tick flips no stamp
-/// at all, which is what [`Entry::cached_at`] exists to catch.
+/// A same-length rewrite landing inside the manifest's own mtime quantum flips no
+/// stamp at all, which is what [`Entry::cached_at`] exists to catch.
 ///
 /// The stamp captures `package.json` *content* only at the resolved project (and
 /// workspace) root — not the *presence* of a `package.json` newly appearing at a
@@ -225,12 +225,12 @@ struct Entry {
     /// rewrite, or a pnpm-named file appearing/disappearing at a consulted dir)
     /// misses.
     stamp: FreshnessStamp,
-    /// The instant sampled before the walk ran, closing the same racy window
-    /// [`crate::config_cache::Entry::cached_at`] documents: a manifest rewritten
-    /// within one clock tick of the walk can report an unchanged `(mtime, size)`,
-    /// so an entry is trusted only while every stamped manifest is strictly
-    /// older than this. The `pnpm_presence` half needs no such guard — presence
-    /// is exact and carries no timestamp.
+    /// The instant sampled before the walk ran, closing the same racy window the
+    /// `config_cache` module doc explains: a manifest rewritten within one mtime
+    /// quantum of the walk reports an unchanged `(mtime, size)`, so an entry is
+    /// trusted only once every stamped manifest clears the granularity slop (see
+    /// [`crate::config_cache::mtime_quantum_closed`]). The `pnpm_presence` half
+    /// needs no such guard — presence is exact and carries no timestamp.
     ///
     /// This memo caches the parsed manifest the walk read, so without the guard
     /// a stale `Project` would flow into `pm::resolve::root_manifest` even when
@@ -268,7 +268,8 @@ impl ProjectCache {
         let entry = guard.get(key)?;
         let manifests_fresh = entry.stamp.manifests.iter().all(|(path, stamp)| {
             let (mtime, _size) = stamp;
-            stamp_of(path).as_ref() == Some(stamp) && *mtime < entry.cached_at
+            stamp_of(path).as_ref() == Some(stamp)
+                && crate::config_cache::mtime_quantum_closed(*mtime, entry.cached_at)
         });
         let pnpm_fresh = entry
             .stamp
@@ -320,11 +321,11 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("package.json"), r#"{"name":"root"}"#).unwrap();
         std::fs::write(dir.join("pnpm-workspace.yaml"), "packages:\n  - 'pkgs/*'\n").unwrap();
-        // A manifest is only cacheable once the clock has passed its mtime (see
-        // `Entry::cached_at`), which every real on-disk manifest already is. The
-        // memo tests below count walks, so the fixture has to start settled or
+        // A manifest is only cacheable once its mtime quantum has closed (see
+        // `Entry::cached_at`), which every real on-disk manifest already satisfies.
+        // The memo tests below count walks, so the fixture has to start aged or
         // every lookup would be a racy-distrusted miss.
-        settle(&dir.join("package.json"));
+        age(&dir.join("package.json"), 60);
         dir
     }
 
@@ -337,16 +338,14 @@ mod tests {
             .unwrap();
     }
 
-    /// Spin until the clock has passed `path`'s mtime. Costs at most one tick.
-    fn settle(path: &Path) {
-        let mtime = mtime_of(path);
-        for _ in 0..1_000_000 {
-            if SystemTime::now() > mtime {
-                return;
-            }
-            std::hint::spin_loop();
-        }
-        panic!("clock did not advance past the file's mtime");
+    /// Backdate `path` by `secs`, clear of the granularity slop, so it is
+    /// cacheable. Callers aging one path twice pass different offsets so the two
+    /// mtimes differ by construction.
+    fn age(path: &Path, secs: u64) {
+        set_mtime(
+            path,
+            SystemTime::now() - std::time::Duration::from_secs(secs),
+        );
     }
 
     // pnpm-workspace.yaml brand hard gate (AGENTS.md): `detect_project` may treat
@@ -380,21 +379,6 @@ mod tests {
 
     fn mtime_of(path: &Path) -> SystemTime {
         std::fs::metadata(path).unwrap().modified().unwrap()
-    }
-
-    /// Rewrite `path` with `contents`, busy-rewriting until the reported mtime
-    /// advances past `prev` so the test forces a real mtime change regardless of
-    /// the filesystem's granularity, without a fixed sleep or a `filetime`
-    /// dev-dep (matching `config_cache`'s test convention). Bounded so a stuck
-    /// filesystem fails loudly rather than hanging.
-    fn write_until_mtime_advances(path: &Path, contents: &str, prev: SystemTime) {
-        for _ in 0..10_000 {
-            std::fs::write(path, contents).unwrap();
-            if mtime_of(path) > prev {
-                return;
-            }
-        }
-        panic!("filesystem mtime did not advance after repeated writes");
     }
 
     /// How many uncached walks have run for exactly `cwd` so far. Scoping the
@@ -445,29 +429,30 @@ mod tests {
     /// `pm::resolve::root_manifest` even when the manifest cache itself misses —
     /// which is how a `pnpm@10.0.0` → `pnpm@11.0.0` rewrite (32 bytes either
     /// way) served the pre-write pin and flaked `pnpm_v11_surface` on Windows.
-    /// A manifest the clock has not yet passed must therefore never be cached.
-    /// Pinning the mtime models the coarse-clock case deterministically; see
-    /// `config_cache`'s counterpart test for why racing it does not reproduce.
+    /// A manifest still inside its own mtime quantum must therefore never be
+    /// cached. Both versions are pinned to `now()` — where a real coarse-clock
+    /// write lands — which reproduces the collision on every platform; see
+    /// `config_cache`'s counterpart test for why racing it does not.
     #[test]
-    fn manifest_rewritten_inside_its_mtime_tick_is_never_served_stale() {
+    fn manifest_rewritten_inside_its_mtime_quantum_is_never_served_stale() {
         let dir = fixture("memo-racy");
         std::fs::remove_file(dir.join("pnpm-workspace.yaml")).unwrap();
         let cwd = std::fs::canonicalize(&dir).unwrap();
         let pkg = cwd.join("package.json");
-        let unpassed = SystemTime::now() + std::time::Duration::from_millis(50);
+        let collided = SystemTime::now();
 
         std::fs::write(&pkg, r#"{"packageManager":"pnpm@10.0.0"}"#).unwrap();
-        set_mtime(&pkg, unpassed);
+        set_mtime(&pkg, collided);
         let first = detect_project(&cwd).expect("root detected");
         assert_eq!(first.manifest.get("packageManager").unwrap(), "pnpm@10.0.0");
 
         // Same byte length, and the stamp is pinned identical — neither half of
         // `(mtime, size)` can tell the two versions apart.
         std::fs::write(&pkg, r#"{"packageManager":"pnpm@11.0.0"}"#).unwrap();
-        set_mtime(&pkg, unpassed);
+        set_mtime(&pkg, collided);
         assert_eq!(
             mtime_of(&pkg),
-            unpassed,
+            collided,
             "the two versions must be indistinguishable by stamp for this to test anything"
         );
 
@@ -494,12 +479,13 @@ mod tests {
             1,
             "the first detect is a cache miss → one walk"
         );
-        let cached_mtime = mtime_of(&pkg);
-
         // The in-process PM engine rewriting package.json mid-command bumps the
         // mtime; the next lookup must miss and the walk must re-run with the new
-        // content — the same protection ROOT_MANIFEST_CACHE gets.
-        write_until_mtime_advances(&pkg, r#"{"name":"renamed"}"#, cached_mtime);
+        // content — the same protection ROOT_MANIFEST_CACHE gets. Aged to a
+        // different offset than the fixture's, so the miss is attributable to the
+        // changed mtime rather than to the granularity slop.
+        std::fs::write(&pkg, r#"{"name":"renamed"}"#).unwrap();
+        age(&pkg, 30);
         let second = detect_project(&cwd).expect("root detected");
 
         assert_eq!(

--- a/crates/nub-core/src/workspace/detect.rs
+++ b/crates/nub-core/src/workspace/detect.rs
@@ -37,6 +37,8 @@ pub struct Project {
 /// can rewrite `package.json` mid-command (`nub install`/`add`/`pm use`) and an
 /// install can create or remove a `pnpm-lock.yaml`/`pnpm-workspace.yaml`; any
 /// such change flips a stamp, so the next lookup misses and the walk re-runs.
+/// A same-length rewrite landing inside the walk's own clock tick flips no stamp
+/// at all, which is what [`Entry::cached_at`] exists to catch.
 ///
 /// The stamp captures `package.json` *content* only at the resolved project (and
 /// workspace) root — not the *presence* of a `package.json` newly appearing at a
@@ -62,6 +64,9 @@ pub fn detect_project(cwd: &Path) -> Option<Project> {
         return Some((*hit).clone());
     }
 
+    // Sampled before the walk reads anything, so a manifest written during or
+    // after it is never trusted on an unchanged stamp — see `Entry::cached_at`.
+    let cached_at = SystemTime::now();
     let (project, walked_dirs) = detect_project_walk(cwd)?;
     // Validate the cached value against the FULL input surface the walk read: the
     // project-root manifest, the workspace-root manifest when distinct, plus the
@@ -69,7 +74,7 @@ pub fn detect_project(cwd: &Path) -> Option<Project> {
     // to any of them invalidates the entry on the next lookup.
     let stamps = freshness_stamps(&project, &walked_dirs);
     let value = Arc::new(project);
-    cache().insert(key, stamps, Arc::clone(&value));
+    cache().insert(key, stamps, cached_at, Arc::clone(&value));
     Some((*value).clone())
 }
 
@@ -220,6 +225,17 @@ struct Entry {
     /// rewrite, or a pnpm-named file appearing/disappearing at a consulted dir)
     /// misses.
     stamp: FreshnessStamp,
+    /// The instant sampled before the walk ran, closing the same racy window
+    /// [`crate::config_cache::Entry::cached_at`] documents: a manifest rewritten
+    /// within one clock tick of the walk can report an unchanged `(mtime, size)`,
+    /// so an entry is trusted only while every stamped manifest is strictly
+    /// older than this. The `pnpm_presence` half needs no such guard — presence
+    /// is exact and carries no timestamp.
+    ///
+    /// This memo caches the parsed manifest the walk read, so without the guard
+    /// a stale `Project` would flow into `pm::resolve::root_manifest` even when
+    /// the manifest cache itself missed.
+    cached_at: SystemTime,
     project: Arc<Project>,
 }
 
@@ -250,11 +266,10 @@ impl ProjectCache {
     fn lookup_fresh(&self, key: &Path) -> Option<Arc<Project>> {
         let guard = self.map().read().expect("ProjectCache lock poisoned");
         let entry = guard.get(key)?;
-        let manifests_fresh = entry
-            .stamp
-            .manifests
-            .iter()
-            .all(|(path, stamp)| stamp_of(path).as_ref() == Some(stamp));
+        let manifests_fresh = entry.stamp.manifests.iter().all(|(path, stamp)| {
+            let (mtime, _size) = stamp;
+            stamp_of(path).as_ref() == Some(stamp) && *mtime < entry.cached_at
+        });
         let pnpm_fresh = entry
             .stamp
             .pnpm_presence
@@ -263,11 +278,24 @@ impl ProjectCache {
         (manifests_fresh && pnpm_fresh).then(|| Arc::clone(&entry.project))
     }
 
-    fn insert(&self, key: PathBuf, stamp: FreshnessStamp, project: Arc<Project>) {
+    fn insert(
+        &self,
+        key: PathBuf,
+        stamp: FreshnessStamp,
+        cached_at: SystemTime,
+        project: Arc<Project>,
+    ) {
         self.map()
             .write()
             .expect("ProjectCache lock poisoned")
-            .insert(key, Entry { stamp, project });
+            .insert(
+                key,
+                Entry {
+                    stamp,
+                    cached_at,
+                    project,
+                },
+            );
     }
 }
 
@@ -292,7 +320,33 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("package.json"), r#"{"name":"root"}"#).unwrap();
         std::fs::write(dir.join("pnpm-workspace.yaml"), "packages:\n  - 'pkgs/*'\n").unwrap();
+        // A manifest is only cacheable once the clock has passed its mtime (see
+        // `Entry::cached_at`), which every real on-disk manifest already is. The
+        // memo tests below count walks, so the fixture has to start settled or
+        // every lookup would be a racy-distrusted miss.
+        settle(&dir.join("package.json"));
         dir
+    }
+
+    fn set_mtime(path: &Path, mtime: SystemTime) {
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(mtime)
+            .unwrap();
+    }
+
+    /// Spin until the clock has passed `path`'s mtime. Costs at most one tick.
+    fn settle(path: &Path) {
+        let mtime = mtime_of(path);
+        for _ in 0..1_000_000 {
+            if SystemTime::now() > mtime {
+                return;
+            }
+            std::hint::spin_loop();
+        }
+        panic!("clock did not advance past the file's mtime");
     }
 
     // pnpm-workspace.yaml brand hard gate (AGENTS.md): `detect_project` may treat
@@ -384,6 +438,45 @@ mod tests {
         assert_eq!(c.root, d.root);
         assert_eq!(a.workspace_root, d.workspace_root);
         assert_eq!(a.manifest, d.manifest);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The memo caches the PARSED manifest, so a stale `Project` reaches
+    /// `pm::resolve::root_manifest` even when the manifest cache itself misses —
+    /// which is how a `pnpm@10.0.0` → `pnpm@11.0.0` rewrite (32 bytes either
+    /// way) served the pre-write pin and flaked `pnpm_v11_surface` on Windows.
+    /// A manifest the clock has not yet passed must therefore never be cached.
+    /// Pinning the mtime models the coarse-clock case deterministically; see
+    /// `config_cache`'s counterpart test for why racing it does not reproduce.
+    #[test]
+    fn manifest_rewritten_inside_its_mtime_tick_is_never_served_stale() {
+        let dir = fixture("memo-racy");
+        std::fs::remove_file(dir.join("pnpm-workspace.yaml")).unwrap();
+        let cwd = std::fs::canonicalize(&dir).unwrap();
+        let pkg = cwd.join("package.json");
+        let unpassed = SystemTime::now() + std::time::Duration::from_millis(50);
+
+        std::fs::write(&pkg, r#"{"packageManager":"pnpm@10.0.0"}"#).unwrap();
+        set_mtime(&pkg, unpassed);
+        let first = detect_project(&cwd).expect("root detected");
+        assert_eq!(first.manifest.get("packageManager").unwrap(), "pnpm@10.0.0");
+
+        // Same byte length, and the stamp is pinned identical — neither half of
+        // `(mtime, size)` can tell the two versions apart.
+        std::fs::write(&pkg, r#"{"packageManager":"pnpm@11.0.0"}"#).unwrap();
+        set_mtime(&pkg, unpassed);
+        assert_eq!(
+            mtime_of(&pkg),
+            unpassed,
+            "the two versions must be indistinguishable by stamp for this to test anything"
+        );
+
+        let second = detect_project(&cwd).expect("root detected");
+        assert_eq!(
+            second.manifest.get("packageManager").unwrap(),
+            "pnpm@11.0.0",
+            "a manifest rewrite sharing the cached mtime must not serve the stale pin"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/vendor/aube/crates/aube-util/src/cache.rs
+++ b/vendor/aube/crates/aube-util/src/cache.rs
@@ -191,10 +191,15 @@ impl FreshnessSnapshot {
     /// Returns `Ok(true)` when the snapshot's `(mtime, size)` pair
     /// still matches OR, on mismatch, the BLAKE3 hash of the file
     /// equals the recorded hash. Trusts the cheap mtime+size pair as
-    /// "fresh, no hash needed" — on filesystems with coarse mtime
-    /// resolution (FAT32) a same-second in-place overwrite to the
-    /// same byte length could slip past, but every other file
-    /// system reports nanosecond mtime so the trust is sound. Hash
+    /// "fresh, no hash needed", which leaves one residual: a same-size
+    /// in-place overwrite that reports an unchanged mtime. This is NOT
+    /// confined to FAT32's whole seconds, as this comment previously
+    /// claimed — mtime resolution is the platform CLOCK's, and Windows
+    /// quantizes it to the timer tick (measured 0.39-1.4 ms on Server
+    /// 2022/NTFS, with two same-size writes separated only by a read
+    /// colliding in ~62% of 6000 trials). The residual is therefore
+    /// reachable on Windows whenever a writer rewrites a file to the
+    /// same length within a tick of the snapshot. Hash
     /// fallback runs only when mtime or size differs.
     pub fn is_fresh(&self, path: &Path) -> io::Result<bool> {
         let meta = std::fs::metadata(path)?;


### PR DESCRIPTION
Fixes the Windows-only flake in `pnpm_v11_surfaces_need_a_declared_v11_incumbent`, which reds CI on `main`.

`MtimeCache` and the `detect_project` memo validate entries on a `(mtime, size)` stamp. File mtimes are quantized to the platform timer tick (0.39-1.4 ms measured on Windows Server 2022/NTFS), so two same-size writes separated only by a read collide on mtime 62-84% of the time and the stale value is served. The test rewrites `pnpm@10.0.0` to `pnpm@11.0.0` — 32 bytes either way.

Both caches now require a two-second granularity slop between a file's mtime and the read that cached it, proving the mtime's quantum had closed. Measured: 0/2000 just-written files trusted, 2000/2000 aged files still hit.

The second commit corrects the first, which was a no-op.
