### PR TITLE
feat(dist): ship one binary per platform package, carry the verb in __NUB_ARGV0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -708,13 +708,16 @@ jobs:
           MATRIX_PLATFORM: ${{ matrix.platform }}
         run: |
           # The runtime is EMBEDDED in the binary (staged + built above), so the
-          # platform package ships ONLY bin/ — no runtime/ sidecar. Both verbs are
-          # real binary copies (nub picks its verb from the argv[0] basename).
+          # platform package ships ONLY bin/ — no runtime/ sidecar. And ONE binary,
+          # not two: the launcher passes the verb in `__NUB_ARGV0` rather than relying
+          # on a separately-named `nubx` file (npm/nub/bin/launch.js,
+          # Argv0::capture_argv0_override). This is what keeps every platform package
+          # under cnpm/npmmirror's 80 MiB sync cap, and it halves the release archive
+          # too — the archive is tarred from THIS directory further down.
           PKG="npm/nub-$MATRIX_PLATFORM"
           mkdir -p "$PKG/bin"
           if [[ "$MATRIX_PLATFORM" == win32-* ]]; then
             cp "target/$MATRIX_TARGET/release/nub.exe" "$PKG/bin/nub.exe"
-            cp "target/$MATRIX_TARGET/release/nub.exe" "$PKG/bin/nubx.exe"
             # Bundle the arch-appropriate busybox-w32 POSIX-sh sidecar next to
             # nub.exe (nub's Windows script shell — see vendor/busybox-w32/README.md
             # and crates/nub-cli/src/cli.rs resolve_bundled_busybox). Verify the
@@ -729,8 +732,7 @@ jobs:
             cp "$SRC" "$PKG/bin/busybox.exe"
           else
             cp "target/$MATRIX_TARGET/release/nub" "$PKG/bin/nub"
-            cp "target/$MATRIX_TARGET/release/nub" "$PKG/bin/nubx"
-            chmod +x "$PKG/bin/nub" "$PKG/bin/nubx"
+            chmod +x "$PKG/bin/nub"
           fi
 
       - name: Upload platform package
@@ -767,7 +769,7 @@ jobs:
           BIN="nub-linux-x64/bin/nub"
           # The upload→download artifact round-trip strips the +x mode bit (binaries
           # arrive at 0644), so re-apply it before exec.
-          chmod +x "$BIN" nub-linux-x64/bin/nubx
+          chmod +x "$BIN"
           # The load-bearing assertion: if the binary links a glibc newer than
           # bookworm's 2.36, this exec fails with "GLIBC_2.xx not found" and the
           # job goes red — exactly the floor regression test-install can't see.
@@ -1076,7 +1078,7 @@ jobs:
               # runs the binary directly, so a 0644 archive breaks every self-upgrade
               # ("command not found" after upgrade). Ship 0755 in the archive so both
               # the curl|sh installer and `nub upgrade` get an executable binary.
-              chmod +x "$PKG/bin/nub" "$PKG/bin/nubx"
+              chmod +x "$PKG/bin/nub"
               archive="nub-$platform.tar.gz"
               tar -czf "release-archives/$archive" -C "$PKG" bin runtime
             fi
@@ -1325,7 +1327,7 @@ jobs:
               archive="nub-$platform.zip"
               (cd "$PKG" && zip -qr "$GITHUB_WORKSPACE/release-archives/$archive" bin runtime)
             else
-              chmod +x "$PKG/bin/nub" "$PKG/bin/nubx"
+              chmod +x "$PKG/bin/nub"
               archive="nub-$platform.tar.gz"
               tar -czf "release-archives/$archive" -C "$PKG" bin runtime
             fi

--- a/.github/workflows/verb-dispatch.yml
+++ b/.github/workflows/verb-dispatch.yml
@@ -132,6 +132,17 @@ jobs:
           [ "${{ matrix.os }}" = "windows-latest" ] && BIN="target/release/nub.exe"
           node tests/verb-dispatch/win-e2e.mjs "$BIN" npm/nub /tmp/launch-old.js
 
+      # What each launcher mechanism is actually WORTH, measured before any of them is
+      # engineered. The headline question: npm's cmd-shim emits a DIRECT invocation in
+      # all three shims for a SHEBANG-LESS bin target (cmd-shim/lib/index.js:42), which
+      # would remove the ~58 ms Node boot Windows pays on every call today.
+      - name: Launcher latency variants
+        shell: bash
+        run: |
+          BIN="target/release/nub"
+          [ "${{ matrix.os }}" = "windows-latest" ] && BIN="target/release/nub.exe"
+          node tests/verb-dispatch/win-latency-variants.mjs "$BIN"
+
       # Keep the binary retrievable so a VM run can reuse it without another build.
       - name: Stage artifact
         shell: bash

--- a/.github/workflows/verb-dispatch.yml
+++ b/.github/workflows/verb-dispatch.yml
@@ -1,0 +1,84 @@
+name: Verb dispatch (one-binary platform package)
+
+# Proves `nub` and `nubx` both dispatch correctly now that the platform packages ship
+# ONE binary and the verb travels in `__NUB_ARGV0` instead of a second, byte-identical
+# 45 MB copy named `nubx`.
+#
+# Why this needs REAL builds on TWO operating systems rather than the fake-native
+# harness in tests/launcher/ — the two platforms take different paths and only one of
+# them was previously covered at all:
+#
+#   Linux    first call goes through Node, which heals the on-PATH entry into an sh
+#            trampoline; every later call is sh -> exec and the trampoline is the only
+#            carrier of the verb. Also the dash leg: `exec -a` is unavailable there,
+#            which is the whole reason the verb moved into an env var.
+#   Windows  the heal is a NO-OP, so every call goes through the Node launcher and the
+#            verb rides on `opts.env`. Nothing exercised this before: until this change
+#            Windows got a correctly-named `nubx.exe` and needed no verb plumbing, and
+#            launcher.yml excludes Windows for exactly that (now stale) reason.
+#
+# Branch-scoped: no PR required, no interference with the shared runner pool on main.
+
+on:
+  push:
+    branches: [dedup-platform-binary]
+    paths:
+      - crates/nub-cli/**
+      - npm/nub/**
+      - tests/verb-dispatch/**
+      - .github/workflows/verb-dispatch.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: verb dispatch · ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4
+        with:
+          node-version: 22
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
+        with:
+          key: verb-dispatch-${{ matrix.os }}
+
+      # `fast` (not `release`): the probe asserts DISPATCH, which is independent of
+      # optimization level, and release's thin-LTO would roughly triple the job for
+      # nothing. Feature set is the default — `embed-runtime` changes the binary's size,
+      # not which verb it selects.
+      - name: Build nub
+        run: cargo build -p nub-cli --profile fast
+
+      - name: Verb dispatch probe
+        shell: bash
+        run: |
+          BIN="target/fast/nub"
+          [ "${{ matrix.os }}" = "windows-latest" ] && BIN="target/fast/nub.exe"
+          test -f "$BIN" || { echo "::error::no binary at $BIN"; ls -R target/fast | head -40; exit 1; }
+          node tests/verb-dispatch/probe.mjs "$BIN"
+
+      # Size is the whole point of the change: assert the packaged bin/ actually halved
+      # and would clear cnpm/npmmirror's 83,886,080-byte unpacked cap.
+      - name: Packaged size
+        shell: bash
+        run: |
+          BIN="target/fast/nub"; EXT=""
+          [ "${{ matrix.os }}" = "windows-latest" ] && { BIN="target/fast/nub.exe"; EXT=".exe"; }
+          mkdir -p pkgprobe/bin && cp "$BIN" "pkgprobe/bin/nub$EXT"
+          one=$(wc -c < "pkgprobe/bin/nub$EXT")
+          echo "one binary : $one bytes"
+          echo "two (today): $((one * 2)) bytes"
+          echo "cnpm cap   : 83886080 bytes"
+          echo "NOTE: a fast-profile binary is larger than the shipped release build;"
+          echo "      this reports the RATIO, not the published size."

--- a/.github/workflows/verb-dispatch.yml
+++ b/.github/workflows/verb-dispatch.yml
@@ -71,6 +71,7 @@ jobs:
           node tests/verb-dispatch/probe.mjs "$BIN"
 
       # Size is the whole point of the change: assert the packaged bin/ actually halved
+      # (see the release-artifact job below for the binary the VM timing run uses)
       # and would clear cnpm/npmmirror's 83,886,080-byte unpacked cap.
       - name: Packaged size
         shell: bash
@@ -84,3 +85,33 @@ jobs:
           echo "cnpm cap   : 83886080 bytes"
           echo "NOTE: a fast-profile binary is larger than the shipped release build;"
           echo "      this reports the RATIO, not the published size."
+
+  # A REAL MSVC release binary for the Windows VM timing run. Provisioning the VS C++
+  # workload + cmake + an -msvc rustup host on a VM costs far more than one CI dispatch,
+  # and a windows-gnu cross-compile is not the same artifact. Release (not `fast`)
+  # because the timing question is about the SHIPPED binary — fast carries debuginfo and
+  # is roughly 3x the size, which moves image-load time.
+  release-artifact:
+    name: windows release binary (for VM timing)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          key: verb-dispatch-release-windows
+      - name: Build release
+        run: cargo build -p nub-cli --release
+      - name: Stage the platform package + launcher
+        shell: bash
+        run: |
+          mkdir -p out/platform/bin out/launcher
+          cp target/release/nub.exe out/platform/bin/nub.exe
+          cp -r npm/nub/. out/launcher/
+          ls -l out/platform/bin
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: win-release-verbdispatch
+          path: out
+          retention-days: 5

--- a/.github/workflows/verb-dispatch.yml
+++ b/.github/workflows/verb-dispatch.yml
@@ -91,27 +91,58 @@ jobs:
   # and a windows-gnu cross-compile is not the same artifact. Release (not `fast`)
   # because the timing question is about the SHIPPED binary — fast carries debuginfo and
   # is roughly 3x the size, which moves image-load time.
-  release-artifact:
-    name: windows release binary (for VM timing)
-    runs-on: windows-latest
+  release-e2e:
+    name: release e2e + timing · ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: 22
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
-          key: verb-dispatch-release-windows
+          key: verb-dispatch-release-${{ matrix.os }}
+
+      # RELEASE, not `fast`: the question is about the shipped binary. A fast build
+      # carries debuginfo at roughly 3x the size, which moves image-load time and would
+      # make the absolute numbers meaningless.
       - name: Build release
         run: cargo build -p nub-cli --release
-      - name: Stage the platform package + launcher
+
+      # The A/B baseline. Holding the BINARY fixed and swapping only launch.js is what
+      # isolates the launcher change; two different builds would confound it with codegen.
+      - name: Fetch the pre-change launch.js
+        shell: bash
+        run: |
+          git fetch --depth=1 origin main
+          git show origin/main:npm/nub/bin/launch.js > /tmp/launch-old.js
+          wc -l /tmp/launch-old.js
+
+      - name: Real global install + dispatch + A/B timing
+        shell: bash
+        run: |
+          BIN="target/release/nub"
+          [ "${{ matrix.os }}" = "windows-latest" ] && BIN="target/release/nub.exe"
+          node tests/verb-dispatch/win-e2e.mjs "$BIN" npm/nub /tmp/launch-old.js
+
+      # Keep the binary retrievable so a VM run can reuse it without another build.
+      - name: Stage artifact
         shell: bash
         run: |
           mkdir -p out/platform/bin out/launcher
-          cp target/release/nub.exe out/platform/bin/nub.exe
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then cp target/release/nub.exe out/platform/bin/; \
+          else cp target/release/nub out/platform/bin/; fi
           cp -r npm/nub/. out/launcher/
           ls -l out/platform/bin
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: win-release-verbdispatch
+          name: release-verbdispatch-${{ matrix.os }}
           path: out
           retention-days: 5

--- a/.github/workflows/verb-dispatch.yml
+++ b/.github/workflows/verb-dispatch.yml
@@ -45,11 +45,13 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: 22
-      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           key: verb-dispatch-${{ matrix.os }}
 

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -569,8 +569,53 @@ pub enum Argv0 {
     PmShim(nub_core::pm::shim::ShimName),
 }
 
+/// The verb the launcher told us to be, captured out of `__NUB_ARGV0` once at
+/// startup and then erased from the environment (see [`capture_argv0_override`]).
+static ARGV0_OVERRIDE: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+
+/// Read `__NUB_ARGV0` into [`ARGV0_OVERRIDE`] and REMOVE it from the environment.
+///
+/// The platform packages ship ONE binary. `nub` and `nubx` are the same file, and
+/// the verb normally comes from argv[0]'s basename — but the launcher's healed sh
+/// trampoline `exec`s that file by its real path, and POSIX `sh` has no portable way
+/// to set argv[0] (`exec -a` is a bash/zsh-ism; dash, which is `/bin/sh` on Debian
+/// and Ubuntu, rejects it). So the launcher passes the verb in this variable instead.
+/// argv[0] remains the fallback and still carries every direct invocation — the
+/// installer's `~/.nub/bin/nubx` symlink, `nub pm shim` hardlinks, `nubx-dev`.
+///
+/// ERASING IT IS LOAD-BEARING, not hygiene: nub spawns Node, and a script under that
+/// Node may invoke `nub` again. An inherited `__NUB_ARGV0=nubx` would silently put
+/// that grandchild in exec mode. Removing it here means the variable survives exactly
+/// one process — the one the launcher aimed it at.
+///
+/// Captured into a `OnceLock` rather than re-read, because `Argv0::detect` runs more
+/// than once per process (invocation-boundary normalization, then dispatch) and the
+/// value is gone from the environment after this call.
+///
+/// # Safety
+///
+/// Mutates the process environment, which is sound only while nub is single-threaded.
+/// `main` calls this through [`normalize_invocation_environment`] as its first action.
+pub unsafe fn capture_argv0_override() {
+    ARGV0_OVERRIDE.get_or_init(|| {
+        let verb = env::var("__NUB_ARGV0").ok().filter(|v| !v.is_empty());
+        if verb.is_some() {
+            // SAFETY: upheld by this function's caller — no other thread exists yet.
+            unsafe { env::remove_var("__NUB_ARGV0") };
+        }
+        verb
+    });
+}
+
 impl Argv0 {
     pub fn detect() -> Self {
+        // The launcher-supplied verb wins over argv[0]: on the healed fast path the
+        // binary is exec'd by its real name (`bin/nub`) for BOTH verbs, so argv[0]
+        // cannot distinguish them. Absent the override — every direct invocation —
+        // argv[0]'s basename is still the signal.
+        if let Some(verb) = ARGV0_OVERRIDE.get().and_then(Option::as_deref) {
+            return Self::classify(verb);
+        }
         let argv0 = env::args_os().next().unwrap_or_default();
         let basename = PathBuf::from(&argv0)
             .file_stem()
@@ -608,6 +653,16 @@ impl Argv0 {
 /// environment back. A hidden internal re-entry belongs to its parent and is
 /// exempt for the same reason `node` is.
 pub fn normalize_invocation_environment() {
+    // UNCONDITIONALLY FIRST, before the early returns below: this both establishes the
+    // verb every later `Argv0::detect()` sees and erases `__NUB_ARGV0` so no child
+    // inherits it. Gating it behind the returns would leak the variable into the whole
+    // `node`-shim and internal-reentry subtree, and would leave the OnceLock unset on
+    // exactly the paths that re-enter nub.
+    //
+    // SAFETY: `main` calls this as its first action, before logging, config
+    // initialization, or any thread-capable subsystem. No other thread exists yet.
+    unsafe { capture_argv0_override() };
+
     let internal_reentry = env::args_os().nth(1).is_some_and(|arg| {
         (cfg!(unix) && arg == "__pdeath-watch") || arg == "__node-gyp-bootstrap"
     });
@@ -6851,7 +6906,9 @@ fn perform_selfowned_upgrade(
     swap_dir(install_dir, "bin", &new_bin)?;
     let _ = std::fs::remove_dir_all(install_dir.join("runtime"));
 
-    // The release tarball ships `bin/nub` (and `bin/nubx`) at mode 0644 — the
+    // The release tarball ships `bin/nub` — one binary; there is no `bin/nubx` any
+    // more, and `install.sh` / this upgrade path both create that alias themselves as
+    // a symlink. It arrives at mode 0644 — the
     // upload-artifact → download-artifact round-trip in CI strips the executable
     // bit, so the published archive is non-executable. install.sh heals fresh
     // installs with its own `chmod +x`; the self-owned upgrade path must do the

--- a/npm/build-local.sh
+++ b/npm/build-local.sh
@@ -34,13 +34,14 @@ cp -RL "$REPO_ROOT/node_modules/@petamoriken/float16" "$REPO_ROOT/runtime/node_m
 # 2. Build the release binary with the runtime embedded.
 cargo build --release -p nub-cli --features embed-runtime
 
-# 3. Copy ONLY the binary — under BOTH names (nub, nubx). The verb is the binary's
-#    own argv[0] basename, so nubx must be a real second copy. No runtime/ sidecar.
+# 3. Copy ONLY the binary, under ONE name. No runtime/ sidecar, and no second `nubx`
+#    copy: the launcher passes the verb in `__NUB_ARGV0` (npm/nub/bin/launch.js), so
+#    nubx no longer needs a separately-named file. Halves the package.
 rm -rf "$PKG_DIR/runtime"
 mkdir -p "$PKG_DIR/bin"
+rm -f "$PKG_DIR/bin/nubx"
 cp "$REPO_ROOT/target/release/nub" "$PKG_DIR/bin/nub"
-cp "$REPO_ROOT/target/release/nub" "$PKG_DIR/bin/nubx"
-chmod +x "$PKG_DIR/bin/nub" "$PKG_DIR/bin/nubx"
+chmod +x "$PKG_DIR/bin/nub"
 
 echo ""
 echo "✓ Platform package ready: $PKG_DIR ($(du -sh "$PKG_DIR" | cut -f1))"

--- a/npm/nub/bin/launch.js
+++ b/npm/nub/bin/launch.js
@@ -25,9 +25,18 @@
 // polyglot 0/600. So the heal needs no lock: it is best-effort, atomic (write temp +
 // rename), verify-before-clobber, and a no-op on Windows.
 //
-// The native binary selects its verb from argv[0]'s basename (nub vs nubx); the
-// healed trampoline exec's bin/<verb> in the platform package (which ships both
-// names), so no argv0 override is needed past the heal.
+// VERB SELECTION. The platform package ships ONE binary, `bin/nub` — shipping a
+// byte-identical second copy under the name `nubx` doubled every platform package
+// (77-99 MiB) and put them over cnpm/npmmirror's 80 MiB sync cap, breaking installs
+// behind that mirror. So the verb travels in `__NUB_ARGV0`, which BOTH dispatch paths
+// set: the healed sh trampoline as a prefix assignment, and the Node spawn below via
+// `opts.env`. The Rust side reads it, then erases it so it survives exactly one
+// process (Argv0::capture_argv0_override in crates/nub-cli/src/cli.rs).
+//
+// argv[0]'s basename remains the FALLBACK, and still carries every direct invocation:
+// the curl installer's `~/.nub/bin/nubx` symlink, `nub pm shim` hardlinks, `nubx-dev`.
+// It cannot serve the healed path because POSIX `sh` has no portable argv[0] override
+// (`exec -a` is a bash/zsh-ism; dash — `/bin/sh` on Debian and Ubuntu — rejects it).
 const { spawn } = require("child_process");
 const os = require("os");
 const fs = require("fs");
@@ -44,7 +53,11 @@ function resolveBinary(verb) {
   try {
     return require.resolve(`${pkg}/bin/${verb}${ext}`);
   } catch {
-    // bin/nubx may be absent on an older platform package; fall back to bin/nub.
+    // Expected for `nubx` on any current platform package — only `bin/nub` ships now,
+    // and the verb rides in `__NUB_ARGV0` (see the header). The `<verb>` probe above
+    // is kept so a NEWER launcher still works against an OLDER platform package that
+    // does carry `bin/nubx`: a PM can pin the two to mismatched versions, and picking
+    // the verb-named file there costs nothing and stays correct.
     try {
       return require.resolve(`${pkg}/bin/nub${ext}`);
     } catch {
@@ -157,10 +170,19 @@ function healPathEntry(verb, nativePath) {
     // fallback (spawn native) instead of choking on sh-as-JS. So the heal is race-free
     // on symlink-to-node-shim PMs (npm/bun/yarn) too, the guarantee pnpm gets for free.
     // Measured: pure-sh heal ~6%/200 concurrent first-call failures; polyglot 0/600.
+    //
+    // Both branches carry the verb in `__NUB_ARGV0`. The platform package ships ONE
+    // binary, so `nativeReal` is `bin/nub` for BOTH verbs and its basename can no
+    // longer distinguish them — and POSIX `sh` cannot set argv[0] portably (`exec -a`
+    // is a bash/zsh-ism; dash, i.e. `/bin/sh` on Debian and Ubuntu, rejects it). The
+    // Rust side reads this var, then erases it so it survives exactly one process
+    // (Argv0::capture_argv0_override). Without it the healed `nubx` entry silently
+    // runs `nub` — exit 0, wrong command, which is why this is not optional.
+    const envAssign = `__NUB_ARGV0=${shq(verb)} `;
     const content =
       `#!/bin/sh\n` +
-      `":" //# nub launcher; exec ${shq(nativeReal)} "$@"\n` +
-      `var r=require("child_process").spawnSync(${JSON.stringify(nativeReal)},process.argv.slice(2),{stdio:"inherit"});process.exit(r.status==null?1:r.status)\n`;
+      `":" //# nub launcher; ${envAssign}exec ${shq(nativeReal)} "$@"\n` +
+      `var r=require("child_process").spawnSync(${JSON.stringify(nativeReal)},process.argv.slice(2),{stdio:"inherit",env:Object.assign({},process.env,{__NUB_ARGV0:${JSON.stringify(verb)}})});process.exit(r.status==null?1:r.status)\n`;
 
     for (const dir of (process.env.PATH || "").split(path.delimiter)) {
       if (!dir) continue;
@@ -200,9 +222,13 @@ module.exports = function launch(argv0Name) {
   const binPath = ensureExecutable(resolved, verb);
   // Self-heal the PATH entry on first POSIX call so later calls skip Node entirely.
   healPathEntry(verb, binPath);
-  // This call still runs through Node; spawn the native binary. argv0 basename of
-  // binPath is the verb (bin/nub or bin/nubx), so the Rust CLI dispatches correctly
-  // without an argv0 override. We use async `spawn` (not `spawnSync`) ONLY so this
+  // This call still runs through Node; spawn the native binary. The platform package
+  // ships ONE binary, so binPath's basename is `nub` for both verbs and cannot carry
+  // the mode — `__NUB_ARGV0` does, below. We set `argv0` too, but the env var is the
+  // load-bearing one: Node documents argv0 as affecting only the process TITLE on
+  // Windows, and Windows is precisely where this path runs on EVERY call (the heal is
+  // POSIX-only). The env var makes the two platforms agree instead of resting on
+  // per-OS argv0 semantics. We use async `spawn` (not `spawnSync`) ONLY so this
   // Node launcher can forward terminating signals to the native child: `spawnSync`
   // blocks the event loop, so a SIGTERM (docker stop on a `nub run` entrypoint whose
   // first-ever call hasn't been healed to the sh trampoline yet) would terminate
@@ -211,7 +237,10 @@ module.exports = function launch(argv0Name) {
   // status. (Subsequent calls skip Node entirely via the healed trampoline's `exec`,
   // where signals reach the binary directly.)
   const opts = { stdio: "inherit", windowsHide: true };
-  if (argv0Name) opts.argv0 = argv0Name; // belt-and-suspenders for the bin/nub fallback path
+  if (argv0Name) {
+    opts.argv0 = argv0Name;
+    opts.env = Object.assign({}, process.env, { __NUB_ARGV0: argv0Name });
+  }
   const child = spawn(binPath, process.argv.slice(2), opts);
   let forwarding = true;
   const forward = (sig) => {

--- a/npm/nub/postinstall.js
+++ b/npm/nub/postinstall.js
@@ -24,8 +24,8 @@ function platformPkg() {
 // npm normalizes file modes on extract: a file referenced by a package's `bin`
 // field lands 0o755, everything else 0o644. The platform packages
 // (`@nubjs/nub-<platform>`) deliberately declare NO `bin` field — they're carriers
-// selected by npm's os/cpu filters — so their `bin/nub` / `bin/nubx` extract 0o644
-// (no +x). Something must add it back.
+// selected by npm's os/cpu filters — so their `bin/nub` extracts 0o644 (no +x).
+// Something must add it back.
 //
 // `bin/launch.js` also chmods at runtime, but that runs as the END user and chmod
 // only succeeds for the file's OWNER. The canonical container/CI pattern installs
@@ -46,7 +46,10 @@ function chmodExecutable(pkg) {
     try {
       binPath = require.resolve(`${pkg}/bin/${verb}${ext}`);
     } catch {
-      continue; // an older platform package may not ship bin/nubx.
+      // `nubx` is expected to miss: current platform packages ship only `bin/nub`
+      // and the verb rides in `__NUB_ARGV0`. Still probed so a newer launcher paired
+      // with an older platform package chmods that package's `bin/nubx` too.
+      continue;
     }
     try {
       // Preserve read/write bits, add execute for user/group/other (umask-free —

--- a/tests/launcher/Dockerfile.non-owner
+++ b/tests/launcher/Dockerfile.non-owner
@@ -13,9 +13,12 @@ FROM node:22-slim
 #    The fake native is mode 0o644 and root-owned; postinstall is NOT run.
 WORKDIR /opt/nub
 COPY fixture/ /opt/nub/
+# The launcher package keeps BOTH stubs (they are `bin`-field entries and npm chmods
+# them on install); the platform package now ships ONE binary, so there is no
+# nub-host/bin/nubx to mode.
 RUN chmod +x /opt/nub/node_modules/@nubjs/nub/bin/nub /opt/nub/node_modules/@nubjs/nub/bin/nubx \
  && (chmod +x /opt/nub/bin/nub /opt/nub/bin/nubx 2>/dev/null || true) \
- && chmod 0644 /opt/nub/node_modules/@nubjs/nub-host/bin/nub /opt/nub/node_modules/@nubjs/nub-host/bin/nubx \
+ && chmod 0644 /opt/nub/node_modules/@nubjs/nub-host/bin/nub \
  && chown -R root:root /opt/nub
 
 # 2. Drop to a non-root user (the `USER app` half of the canonical pattern).

--- a/tests/launcher/make-fixture.sh
+++ b/tests/launcher/make-fixture.sh
@@ -55,19 +55,24 @@ node -e '
 FAKE_SRC="$DEST/.fake-native"
 cat > "$FAKE_SRC" <<'F'
 #!/bin/sh
-case "${0##*/}" in
+verb="${__NUB_ARGV0:-${0##*/}}"
+case "$verb" in
   nubx*) echo "nubx-mode $*";;
   *)     echo "nub 9.9.9-ci $*";;
 esac
 F
+# ONE binary, matching the real platform package. The `__NUB_ARGV0`-before-argv[0]
+# precedence above mirrors Argv0::detect / capture_argv0_override, and the order is
+# load-bearing: on the healed fast path argv[0] is `nub` for BOTH verbs, so only the
+# env var separates them. A fixture that consulted argv[0] first would go green while
+# the real binary silently ran the wrong verb.
 cp "$FAKE_SRC" "$HOSTPKG/bin/nub"
-cp "$FAKE_SRC" "$HOSTPKG/bin/nubx"
 rm -f "$FAKE_SRC"
 # Land the fake native 0o644 (NO +x) — exactly how npm extracts a non-`bin`-field
 # file. ensureExecutable() must recover this at runtime (chmod in place, or stage a
 # copy when not owner). The heal/ensure code is what we're testing, so we do NOT
 # pre-chmod it here.
-chmod 0644 "$HOSTPKG/bin/nub" "$HOSTPKG/bin/nubx"
+chmod 0644 "$HOSTPKG/bin/nub"
 printf '{"name":"@nubjs/nub-host","version":"9.9.9","files":["bin"]}\n' \
   > "$HOSTPKG/package.json"
 

--- a/tests/launcher/run-launcher-matrix.sh
+++ b/tests/launcher/run-launcher-matrix.sh
@@ -79,12 +79,26 @@ run_block() {
   case "$pn" in *9.9.9-ci*) ok "healed entry runs via node too (polyglot) ($style)";;
     *) no "polyglot-as-node ($style): $pn";; esac
 
-  # nubx-verb: nubx keeps its verb through the heal.
+  # nubx-verb: nubx keeps its verb through the heal, off ONE shipped binary.
+  # The platform package has no bin/nubx any more, so the healed entry must exec
+  # bin/nub and carry the verb in __NUB_ARGV0. Assert the trampoline's SHAPE...
   : > "$dest/node.log"
   local ox; ox=$(R "$BIN/nubx" foo)
-  case "$ox" in *nubx-mode*) ok "nubx verb dispatch ($style)";; *) no "nubx verb ($style): $ox";; esac
-  case "$(cat "$BIN/nubx")" in *nub-host/bin/nubx\'*) ok "nubx healed -> bin/nubx ($style)";;
-    *) no "nubx not healed ($style)";; esac
+  case "$ox" in *nubx-mode*) ok "nubx verb dispatch, first call ($style)";; *) no "nubx verb ($style): $ox";; esac
+  case "$(cat "$BIN/nubx")" in
+    *__NUB_ARGV0=\'nubx\'*nub-host/bin/nub\'*) ok "nubx healed -> bin/nub + __NUB_ARGV0 ($style)";;
+    *) no "nubx heal shape wrong ($style): $(sed -n 2p "$BIN/nubx")";;
+  esac
+  # ...and then that it still dispatches as nubx THROUGH that healed path. This second
+  # call is the one that regressed when the duplicate was simply deleted: the first
+  # call succeeds via the node fallback either way, and only call 2 exposes a
+  # trampoline that lost the verb (exit 0, silently running `nub`).
+  : > "$dest/node.log"
+  local ox2; ox2=$(R "$BIN/nubx" foo)
+  case "$ox2" in *nubx-mode*) ok "nubx verb survives the heal, second call ($style)";;
+    *) no "nubx verb LOST post-heal ($style): $ox2";; esac
+  if [ -s "$dest/node.log" ]; then no "node spawned post-heal for nubx ($style)"
+  else ok "zero node post-heal for nubx ($style)"; fi
 
   # ensure-chmod: the fake native lands 0o644 (no +x). Because the FIRST call already
   # ran successfully above, ensureExecutable must have recovered it. We own the file

--- a/tests/verb-dispatch/probe.mjs
+++ b/tests/verb-dispatch/probe.mjs
@@ -17,6 +17,10 @@
 //     change Windows got a correctly-named `nubx.exe` and needed no verb plumbing.
 //
 // Usage: node tests/verb-dispatch/probe.mjs <path-to-built-nub-binary>
+//
+// Reproduce the CI condition locally with `CI=true node tests/verb-dispatch/probe.mjs …`.
+// nub gates registry fetches on CI, so a bare local run does NOT exercise the same paths —
+// a probe bug here passed on macOS and failed on the runner for exactly that reason.
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
@@ -150,8 +154,15 @@ fs.writeFileSync(script, 'console.log("CHILD:" + String(process.env.__NUB_ARGV0)
 // (it does on Windows; on macOS it only warns). We are asserting what the CHILD SAW,
 // not nub's exit status — so use spawnSync, which does not throw, and read the output
 // either way. An execFileSync here failed the Windows leg on the warning alone.
+// Deliberately `nub`, not `nubx`. The property under test is that the variable is
+// REMOVED from the environment at startup, which capture_argv0_override does for any
+// non-empty value — so the value is irrelevant to the assertion. Setting `nubx` here
+// instead puts the PARENT in exec mode, which treats the script path as a tool to fetch
+// and refuses under CI ("refusing to download … in CI"), failing the Windows leg for a
+// reason that has nothing to do with env hygiene. It passed on macOS only because CI
+// was unset there.
 const res = spawnSync(path.join(hostPkg, "bin", `nub${exe}`), [script], {
-  encoding: "utf8", env: { ...process.env, __NUB_ARGV0: "nubx" },
+  encoding: "utf8", env: { ...process.env, __NUB_ARGV0: "nub" },
 });
 const seen = `${res.stdout ?? ""}${res.stderr ?? ""}`;
 if (seen.includes("CHILD:undefined")) ok("__NUB_ARGV0 erased before any child sees it");

--- a/tests/verb-dispatch/probe.mjs
+++ b/tests/verb-dispatch/probe.mjs
@@ -1,0 +1,158 @@
+// Verb-dispatch probe: prove `nub` and `nubx` both dispatch correctly when the
+// platform package ships ONE binary.
+//
+// The platform packages used to ship two byte-identical copies of the 45 MB binary,
+// purely so the Rust CLI could read its verb off argv[0]'s basename. That doubled every
+// package past cnpm/npmmirror's 80 MiB sync cap. The verb now travels in `__NUB_ARGV0`
+// (npm/nub/bin/launch.js sets it on both dispatch paths; Argv0::capture_argv0_override
+// reads it and erases it).
+//
+// Runs on Linux and Windows because the two exercise DIFFERENT paths and only one of
+// them is covered elsewhere:
+//   - POSIX: first call goes through Node, which then heals the on-PATH entry into an
+//     sh trampoline; every later call is sh -> exec, and the trampoline is the only
+//     thing carrying the verb. tests/launcher/ covers this with a fake native.
+//   - Windows: the heal is a no-op, so EVERY call goes through the Node launcher and
+//     the verb rides on `opts.env`. Nothing covered this before, because before this
+//     change Windows got a correctly-named `nubx.exe` and needed no verb plumbing.
+//
+// Usage: node tests/verb-dispatch/probe.mjs <path-to-built-nub-binary>
+
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const nativeSrc = path.resolve(process.argv[2] ?? "");
+const isWin = process.platform === "win32";
+const exe = isWin ? ".exe" : "";
+
+let pass = 0;
+const failures = [];
+const ok = (m) => { console.log(`  ok: ${m}`); pass++; };
+const no = (m) => { console.log(`  FAIL: ${m}`); failures.push(m); };
+
+if (!fs.existsSync(nativeSrc)) {
+  console.error(`probe: no binary at ${nativeSrc}`);
+  process.exit(2);
+}
+
+// ── fixture: a real node_modules tree with a ONE-BINARY platform package ──────────
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "nub-verb-"));
+const launcher = path.join(root, "node_modules", "@nubjs", "nub");
+const hostPkg = path.join(root, "node_modules", "@nubjs", "nub-host");
+fs.mkdirSync(path.join(launcher, "bin"), { recursive: true });
+fs.mkdirSync(path.join(hostPkg, "bin"), { recursive: true });
+
+for (const f of ["nub", "nubx", "launch.js"]) {
+  const dest = path.join(launcher, "bin", f);
+  fs.copyFileSync(path.join(repo, "npm", "nub", "bin", f), dest);
+  // npm sets 0o755 on every `bin`-field entry at install time regardless of the mode in
+  // the tarball, so a fixture built by raw copy has to do the same or it is not modelling
+  // a real install. (Worth knowing: `bin/nubx` is committed 0o644 while `bin/nub` is
+  // 0o755, so without this the nubx stub is simply not executable and spawn returns
+  // empty output with no error — which is exactly how this bit the probe first time.)
+  if (!isWin) fs.chmodSync(dest, 0o755);
+}
+// Map every platform to the fake host package so resolveBinary finds our binary.
+fs.writeFileSync(
+  path.join(launcher, "platform.js"),
+  'module.exports={platformPackage(){return{key:"host",pkg:"@nubjs/nub-host"};}};\n',
+);
+fs.writeFileSync(
+  path.join(launcher, "package.json"),
+  JSON.stringify({ name: "@nubjs/nub", version: "9.9.9", optionalDependencies: { "@nubjs/nub-host": "9.9.9" } }),
+);
+fs.writeFileSync(
+  path.join(hostPkg, "package.json"),
+  JSON.stringify({ name: "@nubjs/nub-host", version: "9.9.9", files: ["bin"] }),
+);
+
+// THE change under test: one binary, named `nub`, for both verbs.
+fs.copyFileSync(nativeSrc, path.join(hostPkg, "bin", `nub${exe}`));
+if (!isWin) fs.chmodSync(path.join(hostPkg, "bin", "nub"), 0o755);
+
+const shipped = fs.readdirSync(path.join(hostPkg, "bin"));
+shipped.length === 1 && shipped[0] === `nub${exe}`
+  ? ok(`platform package ships exactly one binary (${shipped[0]})`)
+  : no(`platform package should ship only nub${exe}, has: ${shipped.join(", ")}`);
+
+// ── helpers ───────────────────────────────────────────────────────────────────────
+const NUBX_MARK = "Run a tool from";       // nubx --help
+const NUB_MARK = "all-in-one";             // nub --help
+
+// Merge both streams and fold the exit status into the label. A silent failure here
+// (non-executable stub, missing binary) otherwise reads as an empty string, which says
+// nothing about why — the first run of this probe reported `??()` for a plain EACCES.
+function verbOf(res) {
+  const out = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+  if (out.includes(NUBX_MARK)) return "nubx";
+  if (out.includes(NUB_MARK)) return "nub";
+  const why = res.error ? res.error.message : `exit=${res.status}`;
+  return `??(${why}: ${out.replace(/\s+/g, " ").trim().slice(0, 80) || "<no output>"})`;
+}
+
+const runNode = (stub, env = {}) =>
+  spawnSync(process.execPath, [path.join(launcher, "bin", stub), "--help"], {
+    encoding: "utf8", env: { ...process.env, ...env },
+  });
+
+// ── 1. the Node launcher path — Windows takes this on EVERY call ─────────────────
+console.log(`== node launcher path (${process.platform}) ==`);
+for (const [stub, want] of [["nub", "nub"], ["nubx", "nubx"]]) {
+  const got = verbOf(runNode(stub));
+  got === want ? ok(`node bin/${stub} -> ${want} mode`) : no(`node bin/${stub} -> ${got}, want ${want}`);
+}
+
+// ── 2. the healed fast path — POSIX only (heal is a no-op on Windows) ────────────
+// Regression guard: deleting the duplicate WITHOUT teaching the trampoline the verb
+// leaves call 1 correct (the node path falls back to bin/nub and sets argv0) and call 2
+// silently running `nub`. Both calls are asserted for exactly that reason.
+if (!isWin) {
+  console.log("== healed fast path (posix) ==");
+  const binDir = path.join(root, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  for (const v of ["nub", "nubx"]) fs.symlinkSync(path.join(launcher, "bin", v), path.join(binDir, v));
+  const env = { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH}` };
+  const call = (v) => spawnSync(path.join(binDir, v), ["--help"], { encoding: "utf8", env });
+
+  for (const v of ["nub", "nubx"]) {
+    const first = verbOf(call(v));
+    first === v ? ok(`${v} call 1 -> ${v} mode`) : no(`${v} call 1 -> ${first}`);
+
+    const healed = fs.readFileSync(path.join(binDir, v), "utf8");
+    healed.startsWith("#!/bin/sh")
+      ? ok(`${v} entry healed to sh trampoline`)
+      : no(`${v} entry not healed: ${healed.slice(0, 40)}`);
+    // nub needs no assignment (it is the default); nubx must carry one.
+    if (v === "nubx") {
+      healed.includes("__NUB_ARGV0='nubx'")
+        ? ok("nubx trampoline carries __NUB_ARGV0")
+        : no(`nubx trampoline missing __NUB_ARGV0: ${healed.split("\n")[1]?.slice(0, 90)}`);
+    }
+
+    const second = verbOf(call(v));
+    second === v
+      ? ok(`${v} call 2 (through the trampoline) -> ${v} mode`)
+      : no(`${v} call 2 -> ${second}, want ${v} — the trampoline lost the verb`);
+  }
+}
+
+// ── 3. the variable must not survive into a child ────────────────────────────────
+// nub spawns Node, and a script under it may re-enter nub. An inherited __NUB_ARGV0
+// would silently put that grandchild in exec mode.
+console.log("== env hygiene ==");
+const script = path.join(root, "probe-env.js");
+fs.writeFileSync(script, 'console.log("CHILD:" + String(process.env.__NUB_ARGV0));\n');
+const child = execFileSync(path.join(hostPkg, "bin", `nub${exe}`), [script], {
+  encoding: "utf8", env: { ...process.env, __NUB_ARGV0: "nubx" },
+}).trim();
+child.includes("CHILD:undefined")
+  ? ok("__NUB_ARGV0 erased before any child sees it")
+  : no(`__NUB_ARGV0 leaked to child: ${child}`);
+
+fs.rmSync(root, { recursive: true, force: true });
+console.log(`\nRESULT: ${pass} ok, ${failures.length} failed`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/tests/verb-dispatch/probe.mjs
+++ b/tests/verb-dispatch/probe.mjs
@@ -18,7 +18,7 @@
 //
 // Usage: node tests/verb-dispatch/probe.mjs <path-to-built-nub-binary>
 
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -146,12 +146,17 @@ if (!isWin) {
 console.log("== env hygiene ==");
 const script = path.join(root, "probe-env.js");
 fs.writeFileSync(script, 'console.log("CHILD:" + String(process.env.__NUB_ARGV0));\n');
-const child = execFileSync(path.join(hostPkg, "bin", `nub${exe}`), [script], {
+// A bare temp dir has no dependencies, so `nub <script>` warns and can exit non-zero
+// (it does on Windows; on macOS it only warns). We are asserting what the CHILD SAW,
+// not nub's exit status — so use spawnSync, which does not throw, and read the output
+// either way. An execFileSync here failed the Windows leg on the warning alone.
+const res = spawnSync(path.join(hostPkg, "bin", `nub${exe}`), [script], {
   encoding: "utf8", env: { ...process.env, __NUB_ARGV0: "nubx" },
-}).trim();
-child.includes("CHILD:undefined")
-  ? ok("__NUB_ARGV0 erased before any child sees it")
-  : no(`__NUB_ARGV0 leaked to child: ${child}`);
+});
+const seen = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+if (seen.includes("CHILD:undefined")) ok("__NUB_ARGV0 erased before any child sees it");
+else if (seen.includes("CHILD:nubx")) no("__NUB_ARGV0 LEAKED to child — erasure is not working");
+else no(`env-hygiene child never reported (exit=${res.status}): ${seen.replace(/\s+/g, " ").trim().slice(0, 160)}`);
 
 fs.rmSync(root, { recursive: true, force: true });
 console.log(`\nRESULT: ${pass} ok, ${failures.length} failed`);

--- a/tests/verb-dispatch/win-e2e.mjs
+++ b/tests/verb-dispatch/win-e2e.mjs
@@ -1,0 +1,189 @@
+// Windows end-to-end + A/B timing for the one-binary change.
+//
+// The dispatch probe (probe.mjs) hand-assembles a node_modules tree and calls
+// `node bin/nubx` directly. That leaves two things unproven on Windows, which is where
+// this harness comes in:
+//
+//   1. A REAL `npm install -g`. Production Windows is
+//      cmd.exe -> nub.cmd -> node bin/nub -> spawn nub.exe, and probe.mjs only covers
+//      the last two hops. npm's own .cmd/.ps1 shim generation and PATH resolution were
+//      never exercised.
+//   2. SPEED. The change adds an env-var assignment and, for nubx, spawns bin/nub.exe
+//      rather than bin/nubx.exe. Both should be free. "Should" is not a measurement.
+//
+// The A/B holds the BINARY FIXED and swaps only launch.js, so the only variable is the
+// launcher change. Comparing two different builds would confound it with codegen noise.
+//
+// Usage: node tests/verb-dispatch/win-e2e.mjs <release-nub.exe> <launcher-dir> <old-launch.js>
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const [nativeSrc, launcherSrc, oldLaunchJs] = process.argv.slice(2).map((p) => path.resolve(p));
+const isWin = process.platform === "win32";
+const exe = isWin ? ".exe" : "";
+const N = Number(process.env.VERB_TIMING_N || 40);
+const WARMUP = 5;
+
+let pass = 0;
+const failures = [];
+const ok = (m) => { console.log(`  ok: ${m}`); pass++; };
+const no = (m) => { console.log(`  FAIL: ${m}`); failures.push(m); };
+
+// ── a REAL global install ─────────────────────────────────────────────────────────
+// Build the two packages on disk and `npm install -g` the root, letting npm resolve the
+// platform package as a real optionalDependency and generate its own shims.
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "nub-wine2e-"));
+const prefix = path.join(root, "prefix");
+const platDir = path.join(root, "platform");
+const rootDir = path.join(root, "rootpkg");
+fs.mkdirSync(path.join(platDir, "bin"), { recursive: true });
+fs.mkdirSync(prefix, { recursive: true });
+fs.cpSync(launcherSrc, rootDir, { recursive: true });
+
+// ONE binary. The platform package declares no `bin` field — it is a carrier, exactly
+// like the published @nubjs/nub-<platform> packages.
+fs.copyFileSync(nativeSrc, path.join(platDir, "bin", `nub${exe}`));
+const platName = `@nubjs/nub-e2e-${process.platform}-${process.arch}`;
+fs.writeFileSync(path.join(platDir, "package.json"), JSON.stringify({
+  name: platName, version: "9.9.9", files: ["bin"],
+}));
+// Point the launcher's platform resolver at our fake platform package.
+fs.writeFileSync(path.join(rootDir, "platform.js"),
+  `module.exports={platformPackage(){return{key:"e2e",pkg:${JSON.stringify(platName)}};}};\n`);
+const rootPkg = JSON.parse(fs.readFileSync(path.join(rootDir, "package.json"), "utf8"));
+rootPkg.version = "9.9.9";
+// No optionalDependencies. A `file:` optional dep is NOT installed into a global prefix,
+// and leaving it declared makes npm's failed attempt shadow the manual placement below —
+// resolution then fails even though the package is on disk. (Measured: identical trees
+// resolve or don't purely on whether this field is present.) The package is placed by
+// hand a few lines down, in the layout npm's os/cpu hoisting produces for real.
+delete rootPkg.optionalDependencies;
+delete rootPkg.scripts; // postinstall is not what we are testing; the launcher must stand alone
+fs.writeFileSync(path.join(rootDir, "package.json"), JSON.stringify(rootPkg));
+
+// spawnSync cannot execute npm.cmd on Windows (ENOENT bare / EINVAL on .cmd since
+// CVE-2024-27980). Run npm's bundled CLI through node instead.
+const npmCli = path.join(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+const npmCliPath = fs.existsSync(npmCli)
+  ? npmCli
+  : path.join(path.dirname(process.execPath), "..", "lib", "node_modules", "npm", "bin", "npm-cli.js");
+
+// PACK FIRST, then install the tarball. `npm install -g <dir>` SYMLINKS the directory
+// (measured: `nub -> ../../../../rootpkg`), so the launcher's realpath becomes the source
+// tree and module resolution walks up from THERE — it never sees the platform package in
+// the global node_modules, and every dispatch fails with "package is not installed".
+// A tarball is copied, which is what a registry install does, and packing also honours
+// the `files` field so we ship what a publish would.
+const pack = spawnSync(process.execPath, [npmCliPath, "pack", rootDir, "--pack-destination", root], {
+  encoding: "utf8",
+});
+const tgz = (pack.stdout ?? "").trim().split(/\r?\n/).filter((l) => l.endsWith(".tgz")).pop();
+if (pack.status !== 0 || !tgz) {
+  console.log(pack.stdout, pack.stderr);
+  no(`npm pack failed (exit ${pack.status})`);
+}
+const install = spawnSync(process.execPath, [
+  npmCliPath, "install", "-g", path.join(root, tgz ?? ""), "--prefix", prefix, "--no-audit", "--no-fund",
+], { encoding: "utf8" });
+if (install.status !== 0) {
+  console.log(install.stdout, install.stderr);
+  no(`npm install -g failed (exit ${install.status})`);
+} else {
+  ok("npm install -g (from a packed tarball) completed");
+}
+
+// Place the platform package as a SIBLING in the global node_modules — the layout a real
+// `npm i -g @nubjs/nub` produces, since npm hoists the os/cpu-selected optionalDependency
+// there. npm will not resolve a `file:` optional dep into a global install, and faking the
+// registry's os/cpu filtering is not what this harness is for: the chain under test is
+// generated shim -> node bin/nub -> spawn nub.exe, not npm's platform SELECTION.
+const globalNm = isWin
+  ? path.join(prefix, "node_modules")
+  : path.join(prefix, "lib", "node_modules");
+fs.cpSync(platDir, path.join(globalNm, ...platName.split("/")), { recursive: true });
+fs.existsSync(path.join(globalNm, ...platName.split("/"), "bin", `nub${exe}`))
+  ? ok("platform package placed in the global node_modules (one binary)")
+  : no("could not place the platform package");
+
+const binHome = isWin ? prefix : path.join(prefix, "bin");
+const listing = fs.existsSync(binHome) ? fs.readdirSync(binHome) : [];
+console.log(`  (generated shims: ${listing.filter((f) => /^nubx?(\.|$)/.test(f)).join(", ") || "none"})`);
+
+// ── dispatch through npm's OWN shims, on PATH ─────────────────────────────────────
+const NUBX_MARK = "Run a tool from";
+const NUB_MARK = "all-in-one";
+const env = { ...process.env, PATH: `${binHome}${path.delimiter}${process.env.PATH}` };
+// `shell: true` is how a human's cmd.exe resolves `nub` -> nub.cmd; direct spawn of a
+// .cmd is refused by Node. This is the real production hop we could not reach before.
+const viaShim = (verb) => {
+  const r = spawnSync(`${verb} --help`, { shell: true, encoding: "utf8", env, cwd: root });
+  return `${r.stdout ?? ""}${r.stderr ?? ""}`;
+};
+for (const [verb, mark, label] of [["nub", NUB_MARK, "nub"], ["nubx", NUBX_MARK, "nubx"]]) {
+  const out = viaShim(verb);
+  if (out.includes(mark)) { ok(`${verb} via npm's generated shim on PATH -> ${label} mode`); continue; }
+  no(`${verb} via shim -> wrong: ${out.replace(/\s+/g, " ").trim().slice(0, 120)}`);
+  // Report the tree rather than leaving the reader to guess which layer broke — this
+  // harness has three candidate failure points (shim generation, platform placement,
+  // module resolution) and the error text alone does not distinguish them.
+  const installedRoot = path.join(globalNm, "@nubjs", "nub");
+  console.log(`     globalNm      : ${globalNm} (exists=${fs.existsSync(globalNm)})`);
+  console.log(`     @nubjs/*      : ${fs.existsSync(path.join(globalNm, "@nubjs")) ? fs.readdirSync(path.join(globalNm, "@nubjs")).join(", ") : "MISSING"}`);
+  console.log(`     platform.js   : ${fs.existsSync(path.join(installedRoot, "platform.js")) ? fs.readFileSync(path.join(installedRoot, "platform.js"), "utf8").trim().slice(0, 90) : "MISSING"}`);
+  try {
+    const { createRequire } = await import("node:module");
+    const req = createRequire(path.join(installedRoot, "bin", "launch.js"));
+    console.log(`     resolve()     : ${req.resolve(`${platName}/bin/nub${exe}`)}`);
+  } catch (e) { console.log(`     resolve()     : FAILED ${e.code}`); }
+}
+
+// ── A/B timing: same binary, only launch.js differs ───────────────────────────────
+const launchJs = path.join(binHome, "node_modules", "@nubjs", "nub", "bin", "launch.js");
+const launchJsAlt = fs.existsSync(launchJs)
+  ? launchJs
+  : path.join(prefix, "lib", "node_modules", "@nubjs", "nub", "bin", "launch.js");
+const installedLaunch = fs.existsSync(launchJs) ? launchJs : launchJsAlt;
+
+function median(xs) { const s = [...xs].sort((a, b) => a - b); return s[Math.floor(s.length / 2)]; }
+function iqr(xs) { const s = [...xs].sort((a, b) => a - b); return s[Math.floor(s.length * 0.75)] - s[Math.floor(s.length * 0.25)]; }
+function timeIt(verb) {
+  const samples = [];
+  for (let i = 0; i < N + WARMUP; i++) {
+    const t = process.hrtime.bigint();
+    spawnSync(`${verb} --version`, { shell: true, encoding: "utf8", env, cwd: root });
+    const ms = Number(process.hrtime.bigint() - t) / 1e6;
+    if (i >= WARMUP) samples.push(ms);
+  }
+  return { med: median(samples), iqr: iqr(samples) };
+}
+
+console.log("== A/B timing (same binary, launch.js is the only variable) ==");
+if (!fs.existsSync(installedLaunch)) {
+  no(`cannot A/B: no installed launch.js under ${prefix}`);
+} else {
+  const newJs = fs.readFileSync(installedLaunch, "utf8");
+  const results = {};
+  for (const [arm, body] of [["new", newJs], ["old", fs.readFileSync(oldLaunchJs, "utf8")]]) {
+    fs.writeFileSync(installedLaunch, body);
+    for (const verb of ["nub", "nubx"]) results[`${arm}/${verb}`] = timeIt(verb);
+  }
+  fs.writeFileSync(installedLaunch, newJs); // leave the tree in the state under test
+  for (const k of Object.keys(results)) {
+    console.log(`  ${k.padEnd(10)} median ${results[k].med.toFixed(1)} ms (IQR ${results[k].iqr.toFixed(1)})`);
+  }
+  // The old launcher cannot dispatch nubx off a one-binary package, so old/nubx is a
+  // WRONG-ANSWER timing, not a comparable arm — nub is the honest comparison.
+  const dNub = results["new/nub"].med - results["old/nub"].med;
+  console.log(`  delta (nub, new - old): ${dNub >= 0 ? "+" : ""}${dNub.toFixed(1)} ms`);
+  const budget = Math.max(5, results["old/nub"].med * 0.10);
+  Math.abs(dNub) <= budget
+    ? ok(`launcher change costs nothing measurable on nub (|${dNub.toFixed(1)}| <= ${budget.toFixed(1)} ms)`)
+    : no(`launcher change moved nub by ${dNub.toFixed(1)} ms (budget ${budget.toFixed(1)})`);
+}
+
+try { fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }); } catch {}
+console.log(`\nRESULT: ${pass} ok, ${failures.length} failed`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/tests/verb-dispatch/win-latency-variants.mjs
+++ b/tests/verb-dispatch/win-latency-variants.mjs
@@ -1,0 +1,145 @@
+// Windows launcher-latency variants — measure the CEILING of each mechanism before
+// engineering any of them.
+//
+// Today a Windows `nub` call costs ~94 ms. Measured breakdown from run 30680335776:
+//   cmd /c rem              10.22 ms   shell floor
+//   native no-op exe         6.11 ms   process-creation floor
+//   nub.exe --version        19.19 ms  our binary, direct, no shim
+//   node -e ""               57.98 ms  the Node hop
+//
+// So ~58 of the ~94 ms is a Node boot we pay because our `bin` target starts with
+// `#!/usr/bin/env node`. npm's cmd-shim branches on exactly that
+// (cmd-shim/lib/index.js:42 "check if the bin is a #! of some sort. If not ... just
+// call it directly") and, for a SHEBANG-LESS target, emits a direct invocation in ALL
+// THREE shims — .cmd, .ps1 and the extensionless sh — with no `node` and nothing to
+// delete. This harness measures what that is actually worth.
+//
+// Variant B deliberately ships the REAL binary as the bin target. That is not
+// shippable (a cross-platform package cannot carry a 45 MB Windows exe) — it is here to
+// measure the mechanism's CEILING. If B lands near 29 ms the approach is worth building
+// a tiny native launcher for; if it lands near 90 ms the idea is dead and we stop.
+//
+// Usage: node tests/verb-dispatch/win-latency-variants.mjs <nub.exe>
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const nativeSrc = path.resolve(process.argv[2] ?? "");
+const isWin = process.platform === "win32";
+const exe = isWin ? ".exe" : "";
+const N = Number(process.env.VERB_TIMING_N || 40);
+const WARMUP = 5;
+
+if (!fs.existsSync(nativeSrc)) { console.error(`no binary at ${nativeSrc}`); process.exit(2); }
+
+const npmCli = (() => {
+  const a = path.join(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+  return fs.existsSync(a) ? a
+    : path.join(path.dirname(process.execPath), "..", "lib", "node_modules", "npm", "bin", "npm-cli.js");
+})();
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "nub-winvar-"));
+const median = (xs) => [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+const iqr = (xs) => { const s = [...xs].sort((a, b) => a - b);
+  return s[Math.floor(s.length * 0.75)] - s[Math.floor(s.length * 0.25)]; };
+
+// Build one global install whose root package's `bin` points at `binRel`, then time
+// `nub --version` through whatever npm generated, resolved off PATH.
+function variant(label, { binRel, seedBin, extraBinDirFile }) {
+  const dir = path.join(root, label);
+  const pkg = path.join(dir, "pkg");
+  const prefix = path.join(dir, "prefix");
+  fs.mkdirSync(path.join(pkg, "bin"), { recursive: true });
+  fs.mkdirSync(prefix, { recursive: true });
+  seedBin(path.join(pkg, "bin"));
+  fs.writeFileSync(path.join(pkg, "package.json"), JSON.stringify({
+    name: "nub-winvar", version: "9.9.9", bin: { nub: binRel },
+  }));
+
+  // Pack then install: `npm install -g <dir>` SYMLINKS, which changes realpath-relative
+  // resolution and is not what a registry install does.
+  const pack = spawnSync(process.execPath, [npmCli, "pack", pkg, "--pack-destination", dir], { encoding: "utf8" });
+  const tgz = (pack.stdout ?? "").trim().split(/\r?\n/).filter((l) => l.endsWith(".tgz")).pop();
+  const inst = spawnSync(process.execPath, [
+    npmCli, "install", "-g", path.join(dir, tgz ?? ""), "--prefix", prefix, "--no-audit", "--no-fund",
+  ], { encoding: "utf8" });
+  if (inst.status !== 0) return { label, error: `install failed: ${(inst.stderr ?? "").slice(0, 160)}` };
+
+  const binHome = isWin ? prefix : path.join(prefix, "bin");
+  if (extraBinDirFile) extraBinDirFile(binHome);
+  const shims = fs.existsSync(binHome) ? fs.readdirSync(binHome).filter((f) => /^nub(\.|$)/.test(f)) : [];
+
+  const env = { ...process.env, PATH: `${binHome}${path.delimiter}${process.env.PATH}` };
+  const samples = [];
+  let out = "";
+  for (let i = 0; i < N + WARMUP; i++) {
+    const t = process.hrtime.bigint();
+    const r = spawnSync("nub --version", { shell: true, encoding: "utf8", env, cwd: dir });
+    const ms = Number(process.hrtime.bigint() - t) / 1e6;
+    if (i === 0) out = `${r.stdout ?? ""}${r.stderr ?? ""}`;
+    if (i >= WARMUP) samples.push(ms);
+  }
+  return { label, med: median(samples), iqr: iqr(samples), shims, works: /\d+\.\d+\.\d+/.test(out), out };
+}
+
+const rows = [];
+
+// A — TODAY. bin target is a #!/usr/bin/env node script that spawns the native binary.
+rows.push(variant("A-node-shebang", {
+  binRel: "bin/nub",
+  seedBin(binDir) {
+    fs.copyFileSync(nativeSrc, path.join(binDir, `native${exe}`));
+    fs.writeFileSync(path.join(binDir, "nub"),
+      '#!/usr/bin/env node\n' +
+      'const {spawnSync}=require("child_process");const path=require("path");\n' +
+      `const r=spawnSync(path.join(__dirname,"native${exe}"),process.argv.slice(2),{stdio:"inherit"});\n` +
+      'process.exit(r.status==null?1:r.status);\n');
+  },
+}));
+
+// B — SHEBANG-LESS bin target. The real binary stands in for a tiny native launcher, to
+// measure the ceiling of npm's direct-shim path.
+rows.push(variant("B-shebangless-bin", {
+  binRel: `bin/nub${exe}`,
+  seedBin(binDir) { fs.copyFileSync(nativeSrc, path.join(binDir, `nub${exe}`)); },
+}));
+
+// C — B plus a real nub.exe IN the bin dir, so PATHEXT resolves .exe ahead of .cmd and
+// even the one cmd.exe hop disappears.
+rows.push(variant("C-exe-on-PATH", {
+  binRel: `bin/nub${exe}`,
+  seedBin(binDir) { fs.copyFileSync(nativeSrc, path.join(binDir, `nub${exe}`)); },
+  extraBinDirFile(binHome) {
+    if (!isWin) return;
+    try { fs.linkSync(path.join(binHome, "node_modules", "nub-winvar", "bin", "nub.exe"), path.join(binHome, "nub.exe")); }
+    catch { try { fs.copyFileSync(nativeSrc, path.join(binHome, "nub.exe")); } catch {} }
+  },
+}));
+
+// D — the floor: the binary by absolute path, no shim, no shell resolution.
+{
+  const direct = path.join(root, `direct${exe}`);
+  fs.copyFileSync(nativeSrc, direct);
+  if (!isWin) fs.chmodSync(direct, 0o755);
+  const samples = [];
+  for (let i = 0; i < N + WARMUP; i++) {
+    const t = process.hrtime.bigint();
+    spawnSync(direct, ["--version"], { encoding: "utf8" });
+    const ms = Number(process.hrtime.bigint() - t) / 1e6;
+    if (i >= WARMUP) samples.push(ms);
+  }
+  rows.push({ label: "D-direct-exec", med: median(samples), iqr: iqr(samples), shims: ["(none)"], works: true });
+}
+
+console.log(`\n== Windows launcher-latency variants (${process.platform}, N=${N}) ==`);
+for (const r of rows) {
+  if (r.error) { console.log(`  ${r.label.padEnd(20)} ERROR ${r.error}`); continue; }
+  console.log(`  ${r.label.padEnd(20)} ${r.med.toFixed(1).padStart(6)} ms (IQR ${r.iqr.toFixed(1)})  works=${r.works}  shims: ${r.shims.join(", ")}`);
+}
+const a = rows.find((r) => r.label.startsWith("A"))?.med;
+for (const r of rows.slice(1)) {
+  if (r.med && a) console.log(`  ${r.label} vs today: ${(a / r.med).toFixed(1)}x faster (-${(a - r.med).toFixed(1)} ms)`);
+}
+try { fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }); } catch {}


### PR DESCRIPTION
Platform packages shipped `bin/nub` and `bin/nubx` byte-identical at 45 MB so the CLI could read its verb off argv[0]. Six of eight exceeded cnpm/npmmirror's 80 MiB cap, so that mirror is pinned at 0.0.31 and installs behind it fail. Now 90.3 → ~45 MiB; release archive 49.0 → ~24.5 MB.

The second name cannot ship: `npm pack` drops symlinks, hardlinks are mangled on install, `exec -a` is a bashism dash rejects.

Deleting the duplicate alone fails silently — call 2 runs `nub`, exit 0. So the trampoline and the Node spawn both set the var; the latter is what makes Windows work. argv[0] stays the fallback; the var is erased at startup.

Verified on ubuntu + windows.