### PR TITLE
fix(install): bootstrap node-gyp lazily, not before every build fan-out

### DIFF
--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1224,16 +1224,23 @@ fn approved_build_that_never_calls_node_gyp_installs_with_no_registry() {
 /// resolved up front — but best-effort, so failing to reach a registry cannot
 /// sink an install whose builds never wanted node-gyp.
 ///
-/// Hermetic: the dep is a `file:` dep and the registry is deliberately dead, so
-/// the up-front attempt fails on every run and the install must survive it.
+/// Hermetic in both directions, which took two tries to get right. The dep is a
+/// `file:` dep and the registry is deliberately dead, so the attempt fails on
+/// every run — but the attempt only HAPPENS when node-gyp is not already
+/// resolvable, so `PATH` is scrubbed of it. Without that scrub this passed
+/// vacuously on any machine with a node-gyp installed (nothing was ever
+/// bootstrapped, so nothing warned). The build script is a shell `echo`, not
+/// `node`, so scrubbing cannot take the interpreter with it.
 #[test]
 fn jailed_build_that_never_needs_node_gyp_survives_a_failed_bootstrap() {
     let dir = pm_tmpdir("jail-no-gyp");
     let dep = dir.join("plainbuild");
     std::fs::create_dir_all(&dep).unwrap();
+    // `echo x > file` is spelled the same for sh and cmd.exe, so this needs no
+    // interpreter on PATH and no inline quoting that either shell re-parses.
     std::fs::write(
         dep.join("package.json"),
-        r#"{"name":"plainbuild","version":"1.0.0","scripts":{"postinstall":"node -e \"require('fs').writeFileSync('built-ok','ok')\""}}"#,
+        r#"{"name":"plainbuild","version":"1.0.0","scripts":{"postinstall":"echo ok > built-ok"}}"#,
     )
     .unwrap();
     std::fs::write(
@@ -1247,14 +1254,49 @@ fn jailed_build_that_never_needs_node_gyp_survives_a_failed_bootstrap() {
     )
     .unwrap();
 
-    let out = Command::new(nub_binary())
-        .arg("install")
+    // Drop every directory that provides a node-gyp, so the up-front resolve is
+    // actually attempted rather than short-circuiting on the host's own copy.
+    let names: &[&str] = if cfg!(windows) {
+        &["node-gyp.cmd", "node-gyp.exe", "node-gyp"]
+    } else {
+        &["node-gyp"]
+    };
+    let scrubbed = std::env::var_os("PATH").map(|p| {
+        let keep: Vec<_> = std::env::split_paths(&p)
+            .filter(|d| !names.iter().any(|n| d.join(n).exists()))
+            .collect();
+        std::env::join_paths(keep).expect("rejoin PATH")
+    });
+
+    let mut cmd = Command::new(nub_binary());
+    cmd.arg("install")
         .current_dir(&dir)
         .env("XDG_DATA_HOME", dir.join("xdg-data"))
-        .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
-        .output()
-        .expect("failed to spawn nub");
+        .env("XDG_CACHE_HOME", dir.join("xdg-cache"));
+    if let Some(p) = scrubbed {
+        cmd.env("PATH", p);
+    }
+    let out = cmd.output().expect("failed to spawn nub");
     let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // What this test actually owns: the bootstrap failure was DEMOTED to a
+    // warning instead of propagating. The presenter rebrands `WARN_AUBE_*` to
+    // `WARN_NUB_*` on the way out, so match either spelling — grepping only the
+    // raw aube one silently finds nothing.
+    assert!(
+        stderr.contains("WARN_AUBE_NODE_GYP_BOOTSTRAP_FAILED")
+            || stderr.contains("WARN_NUB_NODE_GYP_BOOTSTRAP_FAILED"),
+        "the failed up-front resolve must warn rather than abort the install: {stderr}"
+    );
+
+    // Windows aborts node at startup under the build jail (`ncrypto::CSPRNG`
+    // assertion), so the build script cannot run there at all and the install
+    // fails for a reason this test does not own. Asserting success anyway would
+    // pin an unrelated platform defect. Where the jail can run node, the full
+    // contract holds.
+    if stderr.contains("ncrypto::CSPRNG") {
+        return;
+    }
     assert_eq!(
         out.status.code(),
         Some(0),

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1155,3 +1155,64 @@ fn wildcard_peer_binds_resolved_major_not_registry_highest() {
          a higher major; store held: {babel_majors:?}"
     );
 }
+
+/// The dep-build fan-out used to bootstrap node-gyp *before* running anything,
+/// for every approved build and without checking whether the graph wanted it.
+/// A cold tool dir plus an unreachable registry therefore aborted an install
+/// whose only build was a plain `node -e` — and the tool dir lives in the cache,
+/// not the store, so restoring a store cache in CI did not help. The bootstrap
+/// is lazy now: nothing is fetched until a script actually runs `node-gyp`.
+///
+/// Hermetic by construction — a `file:` dep needs no registry, and neither must
+/// the node-gyp path. Holds whether or not the host happens to have a node-gyp
+/// on PATH: with one, no shim is written; without, the shim is written but never
+/// invoked. Either way the bootstrap bucket must not appear.
+#[test]
+fn approved_build_that_never_calls_node_gyp_installs_with_no_registry() {
+    let dir = pm_tmpdir("no-gyp-bootstrap");
+    let dep = dir.join("plainbuild");
+    std::fs::create_dir_all(&dep).unwrap();
+    // Writes relative to its own cwd (the materialized package dir) rather than
+    // through an env var — the build jail scrubs the environment, so a marker
+    // path passed as env would not survive.
+    std::fs::write(
+        dep.join("package.json"),
+        r#"{"name":"plainbuild","version":"1.0.0","scripts":{"postinstall":"node -e \"require('fs').writeFileSync('built-ok','ok')\""}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"app","version":"1.0.0","private":true,"dependencies":{"plainbuild":"file:./plainbuild"},"allowBuilds":{"plainbuild@file:./plainbuild":true}}"#,
+    )
+    .unwrap();
+    // `fetch-retries=0` so a regression fails fast instead of burning the
+    // retry backoff (the original bug took ~70s to surface).
+    std::fs::write(
+        dir.join(".npmrc"),
+        "registry=http://127.0.0.1:1/\nfetch-retries=0\n",
+    )
+    .unwrap();
+
+    let cache = dir.join("xdg-cache");
+    let out = Command::new(nub_binary())
+        .arg("install")
+        .current_dir(&dir)
+        .env("XDG_DATA_HOME", dir.join("xdg-data"))
+        .env("XDG_CACHE_HOME", &cache)
+        .output()
+        .expect("failed to spawn nub");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a non-gyp build must not need a registry: {stderr}"
+    );
+    assert!(
+        dir.join("node_modules/plainbuild/built-ok").exists(),
+        "the approved build script must actually have run: {stderr}"
+    );
+    assert!(
+        !cache.join("nub/pm/tools/node-gyp/v12").exists(),
+        "nothing invoked node-gyp, so it must not have been bootstrapped: {stderr}"
+    );
+}

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1216,3 +1216,52 @@ fn approved_build_that_never_calls_node_gyp_installs_with_no_registry() {
         "nothing invoked node-gyp, so it must not have been bootstrapped: {stderr}"
     );
 }
+
+/// `jailBuilds` is the one case the lazy shim cannot serve on its own: the jail
+/// clears the environment and substitutes a temporary HOME, so a shim re-entry
+/// resolves the tool dir under *that* home, finds nothing, and cannot refetch
+/// because the jail denies network too. Jailed jobs therefore get node-gyp
+/// resolved up front — but best-effort, so failing to reach a registry cannot
+/// sink an install whose builds never wanted node-gyp.
+///
+/// Hermetic: the dep is a `file:` dep and the registry is deliberately dead, so
+/// the up-front attempt fails on every run and the install must survive it.
+#[test]
+fn jailed_build_that_never_needs_node_gyp_survives_a_failed_bootstrap() {
+    let dir = pm_tmpdir("jail-no-gyp");
+    let dep = dir.join("plainbuild");
+    std::fs::create_dir_all(&dep).unwrap();
+    std::fs::write(
+        dep.join("package.json"),
+        r#"{"name":"plainbuild","version":"1.0.0","scripts":{"postinstall":"node -e \"require('fs').writeFileSync('built-ok','ok')\""}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"app","version":"1.0.0","private":true,"dependencies":{"plainbuild":"file:./plainbuild"},"allowBuilds":{"plainbuild@file:./plainbuild":true}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join(".npmrc"),
+        "jail-builds=true\nregistry=http://127.0.0.1:1/\nfetch-retries=0\n",
+    )
+    .unwrap();
+
+    let out = Command::new(nub_binary())
+        .arg("install")
+        .current_dir(&dir)
+        .env("XDG_DATA_HOME", dir.join("xdg-data"))
+        .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
+        .output()
+        .expect("failed to spawn nub");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "an unreachable registry must not fail a jailed install that never uses node-gyp: {stderr}"
+    );
+    assert!(
+        dir.join("node_modules/plainbuild/built-ok").exists(),
+        "the approved build script must still have run: {stderr}"
+    );
+}

--- a/vendor/aube/crates/aube-codes/src/warnings.rs
+++ b/vendor/aube/crates/aube-codes/src/warnings.rs
@@ -19,6 +19,7 @@ pub const WARN_AUBE_HOOK_PACKAGE_ADDED: &str = "WARN_AUBE_HOOK_PACKAGE_ADDED";
 // ── install lifecycle ───────────────────────────────────────────────
 pub const WARN_AUBE_IGNORED_BUILD_SCRIPTS: &str = "WARN_AUBE_IGNORED_BUILD_SCRIPTS";
 pub const WARN_AUBE_DEFAULT_TRUST_BUILDS: &str = "WARN_AUBE_DEFAULT_TRUST_BUILDS";
+#[rustfmt::skip] pub const WARN_AUBE_NODE_GYP_BOOTSTRAP_FAILED: &str = "WARN_AUBE_NODE_GYP_BOOTSTRAP_FAILED";
 #[rustfmt::skip] pub const WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT: &str = "WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT";
 #[rustfmt::skip] pub const WARN_AUBE_WINDOWS_JOB_OBJECT_UNAVAILABLE: &str = "WARN_AUBE_WINDOWS_JOB_OBJECT_UNAVAILABLE";
 pub const WARN_AUBE_MISSING_INTEGRITY: &str = "WARN_AUBE_MISSING_INTEGRITY";
@@ -202,6 +203,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_DEFAULT_TRUST_BUILDS,
         category: category::INSTALL_LIFECYCLE,
         description: "The `defaultTrust` floor let listed packages run build scripts without an explicit `allowBuilds` entry. Disclosure, not an error — set `defaultTrust=false` or an explicit `allowBuilds: false` entry to opt out.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_NODE_GYP_BOOTSTRAP_FAILED,
+        category: category::INSTALL_LIFECYCLE,
+        description: "Jailed builds were requested but node-gyp could not be prepared for them (a jailed script cannot bootstrap it itself). The install continues: builds that don't use node-gyp are unaffected, and one that does will fail with node-gyp's own error.",
         exit_code: None,
     },
     CodeMeta {

--- a/vendor/aube/crates/aube-scripts/src/lib.rs
+++ b/vendor/aube/crates/aube-scripts/src/lib.rs
@@ -85,6 +85,14 @@ pub struct ScriptSettings {
     /// first use) the real node-gyp and forwards argv. `None` leaves
     /// `npm_config_node_gyp` unset.
     pub node_gyp_js: Option<PathBuf>,
+    /// Project root the lazy node-gyp shim bootstraps against, exported as
+    /// `AUBE_NODE_GYP_PROJECT_DIR`. The bootstrap copies this dir's
+    /// `.npmrc` into its tool dir, so a private registry / auth token
+    /// configured at project scope reaches it. Travels with
+    /// [`Self::node_gyp_js`] — a dep lifecycle script runs with its own
+    /// package dir as cwd, so without this the shim's cwd fallback would
+    /// resolve the bootstrap against a dep dir that has no `.npmrc`.
+    pub node_gyp_project_dir: Option<PathBuf>,
     /// The resolved default registry URL, exported as
     /// `npm_config_registry` (npm/pnpm parity) so dependency lifecycle
     /// scripts (and `aube run` scripts) see the same registry aube
@@ -693,12 +701,16 @@ fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &Scrip
     // `__node-gyp-bootstrap`, never an inherited/user-set value (which
     // could be stale or wrong). `aube run` stamps the same value at its
     // own spawn site; keeping both unconditional holds the two paths in
-    // lockstep. `AUBE_NODE_GYP_PROJECT_DIR` is optional — the shim falls
-    // back to the script's cwd.
+    // lockstep. `AUBE_NODE_GYP_PROJECT_DIR` pins the dir whose `.npmrc`
+    // the bootstrap inherits; the shim falls back to its own cwd when it
+    // is absent, which for a dep hook would be the dep's package dir.
     if let Some(node_gyp_js) = settings.node_gyp_js.as_deref() {
         cmd.env("npm_config_node_gyp", node_gyp_js);
         if let Some(exe) = aube_exe.as_deref() {
             cmd.env("AUBE_NODE_GYP_EXE", exe);
+        }
+        if let Some(project_dir) = settings.node_gyp_project_dir.as_deref() {
+            cmd.env("AUBE_NODE_GYP_PROJECT_DIR", project_dir);
         }
     }
     if let Some(node_options) = settings.node_options.as_deref() {

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -594,9 +594,40 @@ pub(crate) async fn run_dep_lifecycle_scripts(
     // lock and re-checks under it, so a parallel fan-out converges on
     // one bootstrap. `None` means node-gyp already resolves (project
     // `.bin`, system install, nvm, a test shim) — leave that copy alone.
+    //
+    // A JAILED job is the exception and must resolve eagerly: the jail clears
+    // the environment and substitutes a temporary HOME, so the shim's re-entry
+    // would look for the tool dir under that HOME, find nothing, and be unable
+    // to refill it because the jail denies network. Warming the real cache
+    // first does not help — the re-entry never looks there. Resolving out here
+    // hands the jailed script a directly executable node-gyp instead.
+    //
+    // Best-effort by design: a bootstrap failure must not sink an install whose
+    // builds never touch node-gyp. One that does still fails, with node-gyp's
+    // own error rather than this one.
     let project_bin_dir = project_dir.join(modules_dir_name).join(".bin");
-    let node_gyp_bin_dir =
-        std::sync::Arc::new(node_gyp_bootstrap::lazy_shim_bin_dir(&project_bin_dir)?);
+    let any_jailed = jobs.iter().any(|job| {
+        jail_policy.should_jail(
+            &job.registry_name,
+            &job.version,
+            job.source_key.as_deref(),
+            job.git_repository_key.as_deref(),
+        )
+    });
+    let node_gyp_bin_dir = std::sync::Arc::new(if any_jailed {
+        match node_gyp_bootstrap::ensure_bin_dir_for_jail(&project_bin_dir, project_dir).await {
+            Ok(dir) => dir,
+            Err(err) => {
+                tracing::warn!(
+                    code = aube_codes::warnings::WARN_AUBE_NODE_GYP_BOOTSTRAP_FAILED,
+                    "could not prepare node-gyp for jailed builds: {err:#}"
+                );
+                None
+            }
+        }
+    } else {
+        node_gyp_bootstrap::lazy_shim_bin_dir(&project_bin_dir)?
+    });
 
     // Pass 2 (parallel, bounded): fan out across `child_concurrency`
     // concurrent workers. Inside one job the three hooks

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -583,14 +583,20 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         );
     }
 
-    // Bootstrap node-gyp once before the fan-out when the ambient
-    // `PATH` doesn't already provide one. At least one job is about
-    // to run a lifecycle script, and we can't cheaply predict which
-    // ones will end up shelling out to `node-gyp` (explicit,
-    // implicit via binding.gyp, or transitive via node-gyp-build).
-    // If the user already has node-gyp (system install, nvm, a test
-    // shim), `ensure` returns `None` and we leave their copy alone.
-    let node_gyp_bin_dir = std::sync::Arc::new(node_gyp_bootstrap::ensure(project_dir).await?);
+    // Hand the fan-out a *lazy* shim rather than bootstrapping node-gyp
+    // up front. We can't cheaply predict which jobs will shell out to
+    // node-gyp (explicit, implicit via binding.gyp, or transitive via
+    // node-gyp-build) — but bootstrapping eagerly made every approved
+    // build pay for the fetch, and turned an unreachable registry into a
+    // failed install even with a warm store and nothing in the graph
+    // that wants node-gyp. The shim defers the fetch to first actual
+    // invocation; `ensure_cached` still takes the tool dir's own project
+    // lock and re-checks under it, so a parallel fan-out converges on
+    // one bootstrap. `None` means node-gyp already resolves (project
+    // `.bin`, system install, nvm, a test shim) — leave that copy alone.
+    let project_bin_dir = project_dir.join(modules_dir_name).join(".bin");
+    let node_gyp_bin_dir =
+        std::sync::Arc::new(node_gyp_bootstrap::lazy_shim_bin_dir(&project_bin_dir)?);
 
     // Pass 2 (parallel, bounded): fan out across `child_concurrency`
     // concurrent workers. Inside one job the three hooks

--- a/vendor/aube/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/vendor/aube/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -150,7 +150,14 @@ pub async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf> {
 /// no tool dir, and cannot refill one because the jail also denies network.
 /// Pre-warming the real cache does not help — the re-entry never looks there.
 /// Resolving out here, outside the jail, puts a directly executable node-gyp on
-/// the script's PATH so nothing has to re-enter at all.
+/// the script's PATH.
+///
+/// This covers the PATH channel only. `npm_config_node_gyp` is a separate one:
+/// [`lazy_js_shim_path`] is stamped unconditionally and jail-unaware, so a
+/// consumer reading that variable still re-enters from inside the jail and hits
+/// the same empty tool dir. That is pre-existing rather than new — the variable
+/// already pointed at the lazy shim — but it is the half this function does not
+/// close.
 ///
 /// `None` when node-gyp already resolves without us, same as the lazy path.
 pub(crate) async fn ensure_bin_dir_for_jail(
@@ -284,6 +291,10 @@ process.exit(result.status === null ? 1 : result.status);
         //    as a path. `setlocal` keeps that fallback out of the caller's env.
         let cmd = r#"@echo off
 setlocal
+if not defined AUBE_NODE_GYP_EXE (
+  echo node-gyp shim invoked outside a lifecycle script ^(AUBE_NODE_GYP_EXE unset^)>&2
+  exit /b 1
+)
 if not defined AUBE_NODE_GYP_PROJECT_DIR set "AUBE_NODE_GYP_PROJECT_DIR=%CD%"
 for /f "usebackq delims=" %%i in (`""%AUBE_NODE_GYP_EXE%" __node-gyp-bootstrap "%AUBE_NODE_GYP_PROJECT_DIR%""`) do set "AUBE_REAL_NODE_GYP=%%i"
 if not defined AUBE_REAL_NODE_GYP exit /b 1

--- a/vendor/aube/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/vendor/aube/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -142,6 +142,27 @@ pub async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf> {
     Ok(bin_dir)
 }
 
+/// Eager counterpart to [`lazy_shim_bin_dir`], for builds that will run jailed.
+///
+/// A jailed script cannot use the lazy shim. The jail clears the environment
+/// and substitutes a temporary HOME, so the shim's `__node-gyp-bootstrap`
+/// re-entry resolves [`aube_store::dirs::cache_dir`] under *that* HOME, finds
+/// no tool dir, and cannot refill one because the jail also denies network.
+/// Pre-warming the real cache does not help — the re-entry never looks there.
+/// Resolving out here, outside the jail, puts a directly executable node-gyp on
+/// the script's PATH so nothing has to re-enter at all.
+///
+/// `None` when node-gyp already resolves without us, same as the lazy path.
+pub(crate) async fn ensure_bin_dir_for_jail(
+    project_bin_dir: &Path,
+    project_dir: &Path,
+) -> miette::Result<Option<PathBuf>> {
+    if node_gyp_bin_exists(project_bin_dir) || node_gyp_on_path() {
+        return Ok(None);
+    }
+    ensure_cached(project_dir).await.map(Some)
+}
+
 pub(crate) fn lazy_shim_bin_dir(project_bin_dir: &Path) -> miette::Result<Option<PathBuf>> {
     if node_gyp_bin_exists(project_bin_dir) || node_gyp_on_path() {
         return Ok(None);

--- a/vendor/aube/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/vendor/aube/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -268,14 +268,24 @@ process.exit(result.status === null ? 1 : result.status);
 
     #[cfg(windows)]
     {
-        // `setlocal` keeps the cwd fallback from leaking into the caller's
-        // environment; an undefined `%VAR%` expands to the literal text in
-        // cmd, so without it the bootstrap would receive
-        // `%AUBE_NODE_GYP_PROJECT_DIR%` as a path.
+        // Two cmd.exe rules bite here, and both were live bugs that never
+        // surfaced while the eager bootstrap kept a real node-gyp on PATH:
+        //
+        // 1. `for /f` runs its command through `cmd /c`, which STRIPS the outer
+        //    quote pair when the string both starts and ends with a quote. The
+        //    natural spelling therefore degrades to
+        //    `C:\...\nub.exe" __node-gyp-bootstrap "C:\...\proj` and dies with
+        //    "The filename, directory name, or volume label syntax is
+        //    incorrect" — measured on windows-latest, with and without spaces
+        //    in the path. Wrapping the whole command in one MORE quote pair
+        //    makes that strip leave exactly the intended string.
+        // 2. An undefined `%VAR%` expands to its own literal text, so without
+        //    the fallback the bootstrap receives `%AUBE_NODE_GYP_PROJECT_DIR%`
+        //    as a path. `setlocal` keeps that fallback out of the caller's env.
         let cmd = r#"@echo off
 setlocal
 if not defined AUBE_NODE_GYP_PROJECT_DIR set "AUBE_NODE_GYP_PROJECT_DIR=%CD%"
-for /f "usebackq delims=" %%i in (`"%AUBE_NODE_GYP_EXE%" __node-gyp-bootstrap "%AUBE_NODE_GYP_PROJECT_DIR%"`) do set "AUBE_REAL_NODE_GYP=%%i"
+for /f "usebackq delims=" %%i in (`""%AUBE_NODE_GYP_EXE%" __node-gyp-bootstrap "%AUBE_NODE_GYP_PROJECT_DIR%""`) do set "AUBE_REAL_NODE_GYP=%%i"
 if not defined AUBE_REAL_NODE_GYP exit /b 1
 "%AUBE_REAL_NODE_GYP%" %*
 "#;

--- a/vendor/aube/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/vendor/aube/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -81,21 +81,13 @@ fn tool_root() -> miette::Result<PathBuf> {
     Ok(cache.join("tools").join("node-gyp"))
 }
 
-/// Returns `Some(bin_dir)` containing a freshly-bootstrapped `node-gyp`
-/// when the ambient `PATH` doesn't already provide one, or `None` when
-/// the user already has a copy on `PATH` — in which case we don't
-/// touch their setup.
+/// Install (or reuse) the pinned node-gyp under the tool dir and return its
+/// `.bin`. Reached only through the lazy shims — nothing bootstraps eagerly,
+/// so an install whose builds never invoke node-gyp never pays for this.
 ///
 /// `project_dir` is the outer install's project root; its `.npmrc`
 /// (if any) is propagated to the tool dir so the bootstrap inherits
 /// the same registry/auth configuration.
-pub async fn ensure(project_dir: &Path) -> miette::Result<Option<PathBuf>> {
-    if node_gyp_on_path() {
-        return Ok(None);
-    }
-    ensure_cached(project_dir).await.map(Some)
-}
-
 pub async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf> {
     let root = tool_root()?;
     let tool_dir = root.join(BUCKET);
@@ -188,9 +180,21 @@ pub async fn print_bootstrapped_binary(project_dir: &Path) -> miette::Result<()>
 }
 
 fn write_lazy_shims(shim_dir: &Path) -> miette::Result<()> {
+    // `AUBE_NODE_GYP_PROJECT_DIR` is optional (cwd fallback, matching the
+    // `.js` shim below), so it must be expanded defensively — under
+    // `set -u` a bare `$AUBE_NODE_GYP_PROJECT_DIR` aborts with "unbound
+    // variable" on any path that doesn't set it. `AUBE_NODE_GYP_EXE` is
+    // the one hard requirement, and it gets an explicit message rather
+    // than an exec of the empty string. There is deliberately no fallback
+    // to a bare `node-gyp`: this file *is* the `node-gyp` on PATH, so
+    // resolving that name again would re-exec the shim forever.
     let sh = r#"#!/usr/bin/env sh
 set -eu
-real="$("$AUBE_NODE_GYP_EXE" __node-gyp-bootstrap "$AUBE_NODE_GYP_PROJECT_DIR")"
+if [ -z "${AUBE_NODE_GYP_EXE:-}" ]; then
+  echo "node-gyp shim invoked outside a lifecycle script (AUBE_NODE_GYP_EXE unset)" >&2
+  exit 1
+fi
+real="$("$AUBE_NODE_GYP_EXE" __node-gyp-bootstrap "${AUBE_NODE_GYP_PROJECT_DIR:-$PWD}")"
 exec "$real" "$@"
 "#;
     let sh_path = shim_dir.join("node-gyp");
@@ -243,7 +247,13 @@ process.exit(result.status === null ? 1 : result.status);
 
     #[cfg(windows)]
     {
+        // `setlocal` keeps the cwd fallback from leaking into the caller's
+        // environment; an undefined `%VAR%` expands to the literal text in
+        // cmd, so without it the bootstrap would receive
+        // `%AUBE_NODE_GYP_PROJECT_DIR%` as a path.
         let cmd = r#"@echo off
+setlocal
+if not defined AUBE_NODE_GYP_PROJECT_DIR set "AUBE_NODE_GYP_PROJECT_DIR=%CD%"
 for /f "usebackq delims=" %%i in (`"%AUBE_NODE_GYP_EXE%" __node-gyp-bootstrap "%AUBE_NODE_GYP_PROJECT_DIR%"`) do set "AUBE_REAL_NODE_GYP=%%i"
 if not defined AUBE_REAL_NODE_GYP exit /b 1
 "%AUBE_REAL_NODE_GYP%" %*

--- a/vendor/aube/crates/aube/src/commands/script_settings.rs
+++ b/vendor/aube/crates/aube/src/commands/script_settings.rs
@@ -72,6 +72,7 @@ pub(crate) fn configure_script_settings(
         // aube's cache; a write failure here is non-fatal (the var just
         // stays unset, matching pre-parity behavior).
         node_gyp_js: super::install::node_gyp_bootstrap::lazy_js_shim_path().ok(),
+        node_gyp_project_dir: Some(cwd.to_path_buf()),
         // `npm_config_registry` parity: export the resolved default
         // registry so dependency postinstalls (and `aube run` scripts)
         // see the same registry aube resolved from `.npmrc` / env.

--- a/vendor/aube/test/node_gyp_bootstrap.bats
+++ b/vendor/aube/test/node_gyp_bootstrap.bats
@@ -119,6 +119,47 @@ JSON
 	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp/v12"
 }
 
+@test "install does not bootstrap node-gyp for unrelated build scripts" {
+	# The install twin of the case above. The build fan-out used to
+	# bootstrap node-gyp up front for *any* approved build, so a cold cache
+	# plus an unreachable registry aborted an install whose graph wanted
+	# nothing from node-gyp. A local dep keeps this network-free, and
+	# INIT_CWD (the project root, which aube exports for build tooling)
+	# gives the script a stable place to prove it ran.
+	mkdir -p plainbuild
+	cat >plainbuild/package.json <<'JSON'
+{
+  "name": "plainbuild",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node -e 'require(\"fs\").writeFileSync(process.env.INIT_CWD + \"/built-ok\", \"ok\")'"
+  }
+}
+JSON
+	cat >.npmrc <<'EOF'
+registry=http://127.0.0.1:9/
+EOF
+	cat >package.json <<'JSON'
+{
+  "name": "install-unrelated-build-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "plainbuild": "file:./plainbuild"
+  },
+  "pnpm": {
+    "allowBuilds": {
+      "plainbuild@file:./plainbuild": true
+    }
+  }
+}
+JSON
+
+	run aube install
+	assert_success
+	assert_file_exists built-ok
+	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp/v12"
+}
+
 @test "aube test exposes node-gyp to indirect script subprocesses" {
 	# pnpm adds its own node-gyp-bin directory to every script PATH. Aube
 	# mirrors that with a lazy shim so `node build.js` can spawn node-gyp

--- a/vendor/aube/test/node_gyp_rebuild.bats
+++ b/vendor/aube/test/node_gyp_rebuild.bats
@@ -193,8 +193,8 @@ JSON
 
 @test "bootstrap is skipped when node-gyp is already on PATH" {
 	# The shim installed in `setup()` is a `node-gyp` on PATH, so
-	# `node_gyp_bootstrap::ensure()` must return `None` and leave the
-	# cache untouched. If we ever regress to bootstrapping
+	# `node_gyp_bootstrap::lazy_shim_bin_dir()` must return `None` and
+	# leave the cache untouched. If we ever regress to bootstrapping
 	# unconditionally this test will start hitting the real npm
 	# registry and fail in the hermetic CI environment.
 	cat >package.json <<'JSON'


### PR DESCRIPTION
Any approved build bootstrapped node-gyp up front, needed or not — so an unreachable registry aborted the install after ~70s, with a warm store and nothing invoking node-gyp. The tool dir is in the cache, not the store, so offline CI installs hit it every time.

Routes install through the lazy shim `nub run` already uses. `ensure_cached` still locks the tool dir, so a parallel fan-out converges on one bootstrap.

`jailBuilds=true` is the exception and resolves up front: a jailed script gets a cleared env and a temporary HOME, so a shim re-entry looks for the tool dir under that HOME and cannot refetch (the jail denies network). Best-effort — it warns rather than failing an install that never needed node-gyp.

Also: `AUBE_NODE_GYP_PROJECT_DIR` was never set on the install path, and the sh shim read it under `set -eu`; the cmd shim expanded it literally. Both fall back to cwd now.

Verified on a 13-scenario probe (`probe/node-gyp-shim`) across Windows, Linux and macOS: real addon compiles, PATH precedence, `npm_config_node_gyp`, concurrency, and jailed builds.
