### PR TITLE
fix(aube): resolve workspace:<path> specifiers, and say where a patch hunk failed

### DIFF
--- a/vendor/aube/crates/aube-linker/src/patches.rs
+++ b/vendor/aube/crates/aube-linker/src/patches.rs
@@ -535,8 +535,17 @@ fn apply_hunks(base_image: &str, hunks: &[Hunk]) -> Result<String, String> {
                 -fuzzing_offset - 1
             };
             if fuzzing_offset.abs() > 20 {
+                // Refusing is deliberate — see this function's doc comment. The
+                // message says WHERE, because the actionable fact is that the
+                // patch was cut against a different release of the package: bun
+                // applies some of these where pnpm (and so nub) will not, so a
+                // patch that works under bun can arrive here already stale.
                 return Err(format!(
-                    "could not apply hunk {i} (offset drift > 20 lines)"
+                    "could not apply hunk {} at line {} (searched 20 lines either way for its context \
+                     and found none).\n\x20\x20The file does not match what the patch was cut \
+                     against — regenerate it against this version.",
+                    i + 1,
+                    hunk.original_start
                 ));
             }
         };
@@ -1275,8 +1284,12 @@ mod tests {
         let body = "--- a/x\n+++ b/x\n@@ -1,3 +1,3 @@\n anchor\n-target\n+TARGET\n tail\n";
         let err = apply_body(&original, body).unwrap_err();
         assert!(
-            err.contains("offset drift"),
-            "expected an offset-drift rejection, got: {err}"
+            err.contains("could not apply hunk 1 at line 1"),
+            "the rejection must say which hunk and where it looked: {err}"
+        );
+        assert!(
+            err.contains("regenerate it"),
+            "and what to do about it, since the patch is simply stale: {err}"
         );
     }
 

--- a/vendor/aube/crates/aube-lockfile/src/bun/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/read.rs
@@ -60,6 +60,16 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         })
         .collect();
     workspace_scopes.sort_by_key(|(name, _)| std::cmp::Reverse(name.len()));
+    // Member directories, verbatim. `classify_bun_ident` needs this to
+    // tell `workspace:<dir>` from `workspace:<selector>` — the tail of
+    // a top-level member carries no separator, so its shape alone is
+    // indistinguishable from a selector.
+    let workspace_dirs: BTreeSet<&str> = raw
+        .workspaces
+        .keys()
+        .filter(|ws_path| !ws_path.is_empty())
+        .map(String::as_str)
+        .collect();
 
     // First pass: parse (name, version) for each entry. bun.lock keys look
     // like the package name ("foo") for the hoisted version, or a nested
@@ -103,6 +113,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             &raw_name,
             &raw_version,
             entry.integrity.as_deref(),
+            &workspace_dirs,
         )?;
         // A protocol-shaped tail that fell through the classifier means a
         // source this reader can't resolve. Withhold the entry so the edge

--- a/vendor/aube/crates/aube-lockfile/src/bun/source.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/source.rs
@@ -1,6 +1,6 @@
 use crate::{Error, GitSource, LocalSource, RemoteTarballSource};
 use aube_util::path::normalize_lexical;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path};
 
 /// Extract the alias name bun uses as the hoist key. bun's `packages`
@@ -33,11 +33,16 @@ pub(super) fn bun_key_to_alias_name(key: &str) -> String {
 /// The alias name wins as `LockedPackage.name` whenever it differs
 /// from the ident's name (npm-alias case). `alias_of` records the
 /// registry-side name only then.
+///
+/// `workspace_dirs` is the lockfile's own `workspaces` map keyed by
+/// member directory — the authoritative answer to "is this
+/// `workspace:` tail a directory?", which no lexical test can give.
 pub(super) fn classify_bun_ident(
     alias_name: &str,
     raw_name: &str,
     raw_version: &str,
     integrity: Option<&str>,
+    workspace_dirs: &BTreeSet<&str>,
 ) -> Result<(String, String, Option<LocalSource>, Option<String>), Error> {
     // npm-alias tail: bun writes the registry identity into the ident,
     // so the raw name is the real registry name and the alias key is
@@ -55,13 +60,20 @@ pub(super) fn classify_bun_ident(
         // `workspace:*` / `workspace:^` / `workspace:~` are version-
         // range selectors, not directory paths — a `PathBuf::from("*")`
         // would silently become `{project_root}/*` under any caller
-        // that does `project_root.join(link.path())`. Bun's `packages`
-        // entries for workspace members use root-relative paths like
-        // `workspace:packages/lib`, so keep slash-bearing tails as paths.
-        // Otherwise fall back to `.` so range selectors point at the
-        // workspace root and the caller resolves the actual location
-        // from the graph's workspace map.
-        let is_path = rel.starts_with('.') || rel.starts_with('/') || rel.contains('/');
+        // that does `project_root.join(link.path())`. A selector falls
+        // back to `.` so it points at the workspace root and the caller
+        // resolves the actual location from the graph's workspace map;
+        // a directory tail is kept verbatim.
+        //
+        // Ask the lockfile's own `workspaces` map first — a member at a
+        // TOP-LEVEL directory has no separator in its tail
+        // (`workspace:plugin`), so the lexical shape alone reads it as a
+        // selector and links the member to the workspace ROOT, an
+        // install that exits 0 having resolved the wrong package.
+        let is_path = workspace_dirs.contains(rel)
+            || rel.starts_with('.')
+            || rel.starts_with('/')
+            || rel.contains('/');
         let path_buf = std::path::PathBuf::from(if rel.is_empty() || !is_path { "." } else { rel });
         return Ok((
             name,

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -2311,6 +2311,16 @@ impl<'a> ResolveDriver<'a> {
             // local version is. pnpm's "don't pin me, just track
             // local" sigils.
             Some("" | "*" | "^" | "~") => true,
+            // `workspace:<path>` names the member by DIRECTORY, not by
+            // version — bun writes exactly this in its lockfile
+            // (`@scope/plugin@workspace:packages/plugin`), and reading
+            // the tail as a semver range makes every such entry
+            // unsatisfiable: measured on opencode, where a registry
+            // package depending on a workspace member failed with
+            // `no version of @opencode-ai/plugin matches range
+            // \`workspace:packages/plugin\``. A path identifies the
+            // member outright, so it binds like the `*` sigil.
+            Some(rest) if is_workspace_path(rest) => true,
             // workspace:<range> must still satisfy the local version.
             Some(rest) => version_satisfies(ws_version, rest),
             // `link:`/`portal:` whose name is a workspace member is a
@@ -2640,6 +2650,15 @@ fn attach_integrity_to_git_source(local: &mut LocalSource, integrity: Option<&st
     }
 }
 
+/// Whether a `workspace:` tail names a directory rather than a version range.
+///
+/// Same discriminator the bun lockfile reader uses (`bun/source.rs`): a semver
+/// range never contains a path separator, and the sigils (`*`, `^`, `~`, ``)
+/// are handled before this is reached.
+fn is_workspace_path(rest: &str) -> bool {
+    rest.starts_with('.') || rest.starts_with('/') || rest.contains('/')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2768,5 +2787,31 @@ mod tests {
     #[test]
     fn named_registry_plain_range_is_not_a_named_spec() {
         assert_eq!(parse_named_registry_spec("^1.2.3", "foo", &known()), None);
+    }
+
+    /// bun records a workspace member's resolution as
+    /// `<name>@workspace:<dir>`, so the tail is a DIRECTORY. Read as a semver
+    /// range it satisfies nothing, and every dependency on that member becomes
+    /// unresolvable — measured on opencode, where a registry package depending
+    /// on a workspace member failed the whole install.
+    #[test]
+    fn a_workspace_tail_that_is_a_path_is_not_a_version_range() {
+        for path in [
+            "packages/plugin",
+            "packages/console/app",
+            "./packages/plugin",
+            "/abs/packages/plugin",
+        ] {
+            assert!(
+                is_workspace_path(path),
+                "{path} names a directory, not a version"
+            );
+        }
+        for range in ["1.2.3", "^1.0.0", "~2", ">=1 <2", "1.x"] {
+            assert!(
+                !is_workspace_path(range),
+                "{range} is a version range and must still be checked against the member"
+            );
+        }
     }
 }

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -28,8 +28,8 @@ use crate::package_ext::{
     apply_package_extensions, apply_package_extensions_to_deps, pick_override_spec,
 };
 use crate::semver_util::{
-    AgeGateCause, PickResult, Regime, classify_regime, pick_version, range_resolves_via_dist_tag,
-    version_satisfies,
+    AgeGateCause, PickResult, Regime, classify_regime, is_semver_range, pick_version,
+    range_resolves_via_dist_tag, version_satisfies,
 };
 use crate::{
     Error, ExoticSubdepDetails, FxHashMap, FxHashSet, ResolutionMode, ResolveTask, ResolvedPackage,
@@ -2311,16 +2311,22 @@ impl<'a> ResolveDriver<'a> {
             // local version is. pnpm's "don't pin me, just track
             // local" sigils.
             Some("" | "*" | "^" | "~") => true,
-            // `workspace:<path>` names the member by DIRECTORY, not by
-            // version — bun writes exactly this in its lockfile
-            // (`@scope/plugin@workspace:packages/plugin`), and reading
-            // the tail as a semver range makes every such entry
-            // unsatisfiable: measured on opencode, where a registry
-            // package depending on a workspace member failed with
-            // `no version of @opencode-ai/plugin matches range
-            // \`workspace:packages/plugin\``. A path identifies the
-            // member outright, so it binds like the `*` sigil.
-            Some(rest) if is_workspace_path(rest) => true,
+            // A tail that does not parse as a range is a LOCATOR, not a
+            // version — bun and yarn name the member by DIRECTORY
+            // (`@scope/plugin@workspace:packages/plugin`, or
+            // `workspace:plugin` for a top-level member). Read as a
+            // range it satisfies nothing: measured on opencode, where a
+            // registry package depending on a workspace member failed
+            // with `no version of @opencode-ai/plugin matches range
+            // \`workspace:packages/plugin\``. We are only here because
+            // the name already matched a member and `workspace:` never
+            // means "go to the registry", so a locator binds outright.
+            //
+            // The discriminator must be the PARSE, not the string's
+            // shape: a lexical path test (leading `.`, leading `/`,
+            // contains `/`) misses a single-segment member directory,
+            // which both real bun and real pnpm resolve.
+            Some(rest) if !is_semver_range(rest) => true,
             // workspace:<range> must still satisfy the local version.
             Some(rest) => version_satisfies(ws_version, rest),
             // `link:`/`portal:` whose name is a workspace member is a
@@ -2650,15 +2656,6 @@ fn attach_integrity_to_git_source(local: &mut LocalSource, integrity: Option<&st
     }
 }
 
-/// Whether a `workspace:` tail names a directory rather than a version range.
-///
-/// Same discriminator the bun lockfile reader uses (`bun/source.rs`): a semver
-/// range never contains a path separator, and the sigils (`*`, `^`, `~`, ``)
-/// are handled before this is reached.
-fn is_workspace_path(rest: &str) -> bool {
-    rest.starts_with('.') || rest.starts_with('/') || rest.contains('/')
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2794,6 +2791,10 @@ mod tests {
     /// range it satisfies nothing, and every dependency on that member becomes
     /// unresolvable — measured on opencode, where a registry package depending
     /// on a workspace member failed the whole install.
+    ///
+    /// `plugin` is the case a lexical path test (leading `.`, leading `/`,
+    /// contains `/`) gets wrong: a member at a top-level directory has no
+    /// separator in its tail, yet real bun and real pnpm both resolve it.
     #[test]
     fn a_workspace_tail_that_is_a_path_is_not_a_version_range() {
         for path in [
@@ -2801,15 +2802,17 @@ mod tests {
             "packages/console/app",
             "./packages/plugin",
             "/abs/packages/plugin",
+            "plugin",
+            "ms",
         ] {
             assert!(
-                is_workspace_path(path),
+                !is_semver_range(path),
                 "{path} names a directory, not a version"
             );
         }
-        for range in ["1.2.3", "^1.0.0", "~2", ">=1 <2", "1.x"] {
+        for range in ["1.2.3", "^1.0.0", "~2", ">=1 <2", "1.x", "*", ""] {
             assert!(
-                !is_workspace_path(range),
+                is_semver_range(range),
                 "{range} is a version range and must still be checked against the member"
             );
         }

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -612,6 +612,18 @@ pub(crate) fn version_satisfies(version: &str, range_str: &str) -> bool {
     })
 }
 
+/// Whether `range_str` parses as a semver range at all.
+///
+/// Distinct from [`version_satisfies`], which folds "does not parse"
+/// and "parses but does not match" into one `false`. Callers that must
+/// tell a RANGE from some other kind of tail — a `workspace:` locator
+/// naming a member directory, say — need the two apart. Shares the
+/// parse cache, so asking is as cheap as matching.
+#[inline]
+pub(crate) fn is_semver_range(range_str: &str) -> bool {
+    with_cached_range(normalize_range(range_str), |r| r.is_some())
+}
+
 /// npm / pnpm / yarn all treat an empty or whitespace-only version
 /// range as equivalent to `"*"` (match any). `node_semver` rejects it
 /// with `No valid ranges could be parsed`. Normalize here so the

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -5208,6 +5208,56 @@ async fn workspace_link_transitive_from_registry_parent_is_not_blocked_as_exotic
     );
 }
 
+// bun and yarn name a workspace member by DIRECTORY (`workspace:<dir>`).
+// A member at a TOP-LEVEL directory yields a tail with no separator, so a
+// lexical path test reads it as a version range, finds it satisfies
+// nothing, and sends the whole thing to the registry — which 404s. The
+// registry client here points at a dead port with no packument cached, so
+// any fall-through to the registry fails the resolve outright.
+#[tokio::test]
+async fn workspace_member_named_by_a_top_level_directory_binds_to_the_member() {
+    let client = Arc::new(aube_registry::client::RegistryClient::new(
+        "http://127.0.0.1:0",
+    ));
+    let mut resolver = Resolver::new(client);
+
+    let mut root = PackageJson::default();
+    root.dependencies
+        .insert("@eval/plugin".to_string(), "workspace:plugin".to_string());
+    let member = PackageJson {
+        name: Some("@eval/plugin".to_string()),
+        version: Some("0.3.0".to_string()),
+        ..Default::default()
+    };
+
+    let mut workspace_packages = std::collections::HashMap::new();
+    workspace_packages.insert("@eval/plugin".to_string(), "0.3.0".to_string());
+
+    let graph = resolver
+        .resolve_workspace(
+            &[
+                (".".to_string(), root),
+                ("plugin".to_string(), member),
+            ],
+            None,
+            &workspace_packages,
+        )
+        .await
+        .expect("a workspace: tail naming a top-level member directory must not go to the registry");
+
+    let dep = graph
+        .importers
+        .get(".")
+        .expect("root importer")
+        .iter()
+        .find(|dep| dep.name == "@eval/plugin")
+        .expect("@eval/plugin must be a direct dep of the root");
+    assert_eq!(
+        dep.dep_path, "@eval/plugin@0.3.0",
+        "it must bind to the local member, not a registry version"
+    );
+}
+
 // A fresh resolve must stash the packument's `deprecated` reason on the
 // LockedPackage (via `extra_meta`) so the pnpm/aube lockfile writer can
 // emit pnpm's `deprecated:` field. Without this the reason is dropped


### PR DESCRIPTION
Two package-manager fixes found while porting a bun-authored workspace. Unrelated to each other beyond where they surfaced, so one commit each.

**`workspace:<path>` was compared as a version range.** bun writes a dependency as `<name>@workspace:packages/plugin`, where the tail is the member's directory. nub compared that tail against the member's version as if it were semver, so `nub install` failed on any bun-authored workspace:

```
no version of @opencode-ai/plugin matches range 'workspace:packages/plugin'
```

`try_workspace_link` now treats a tail that looks like a path — leading `.`, leading `/`, or containing `/` — as a directory reference, alongside the existing empty/`*`/`^`/`~` forms. A tail that is a real range is still compared as one.

**A failed patch hunk named neither where it looked nor what to do.** It now reports the hunk index, the line it searched from, that it searched 20 lines either way, and that the patch needs regenerating against this version. The ±20 tolerance is unchanged — it matches pnpm.

Both were found on `compile-spike` while porting opencode; neither has anything to do with `nub compile`, so they are extracted here rather than waiting on #536. Refs #536.

Tests: 303 `aube-resolver`, 165 `aube-linker`, green on top of main; new test `a_workspace_tail_that_is_a_path_is_not_a_version_range`. `cargo fmt --check` and `clippy --all-targets -D warnings` green.