### PR TITLE
fix(preload): fold inherited NODE_OPTIONS preloads into the chainer

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3172,36 +3172,103 @@ fn prepare_preload_chain(
     let Some(root) = runtime.preload_root.clone() else {
         return Ok(None);
     };
-    if runtime.preload.is_empty() {
+    // Preload entries reaching nub through an INHERITED NODE_OPTIONS are folded into
+    // the same chainers as the config's, so the child ends up with at most one
+    // `--require` and one `--import` no matter how many arrive. Without this an
+    // ambient `--require` (what every APM injector sets) adds a second token, and a
+    // consumer that keys NODE_OPTIONS by flag name drops one of them — which, since
+    // nub appends the inherited value last, was nub's own preload.
+    let inherited = std::env::var("NODE_OPTIONS").unwrap_or_default();
+    let (_, inherited_requires, inherited_imports) =
+        nub_core::node::spawn::split_inherited_preloads(&inherited);
+    if runtime.preload.is_empty() && inherited_requires.is_empty() && inherited_imports.is_empty() {
         return Ok(None);
     }
-    let esm = !node.version.supports_augmentation()
+
+    // Which channel the CONFIG entries ride. Unchanged from the per-entry router it
+    // replaced: a `.cjs`-only list keeps `--require`'s synchronous entry semantics,
+    // anything else needs the async channel (and the compat tier is always async).
+    let config_is_esm = !node.version.supports_augmentation()
         || runtime.preload.iter().any(|spec| {
             !std::path::Path::new(spec)
                 .extension()
                 .is_some_and(|e| e.eq_ignore_ascii_case("cjs"))
         });
 
-    let dir = root.join("node_modules").join(".nub");
-    std::fs::create_dir_all(&dir)
-        .with_context(|| format!("could not create the preload chainer dir {}", dir.display()))?;
-    let path = dir.join(if esm {
-        "preload-chain.mjs"
+    // Config entries first, then inherited — which reproduces the ordering nub had
+    // before the fold in every measured combination, because Node's phase rule
+    // (every `--require` before any `--import`) still separates the two channels.
+    let mut cjs: Vec<String> = Vec::new();
+    let mut esm: Vec<String> = Vec::new();
+    if config_is_esm {
+        esm.extend(runtime.preload.iter().cloned());
     } else {
-        "preload-chain.cjs"
-    });
+        cjs.extend(runtime.preload.iter().cloned());
+    }
+    // Inherited `--require` values ride the CJS chain only on the fast tier, where
+    // nub's own preload carries it and no loader worker exists. On the compat tier
+    // nub registers a `module.register` loader worker, and Node RE-RUNS every
+    // `--require` preload inside that worker's realm — so a `--require` token there
+    // would run the entry twice. The original per-entry router made the same trade
+    // for config `.cjs` entries: moving them to the async channel costs ordering
+    // (they land in the import phase) and buys running exactly once.
+    if node.version.supports_augmentation() {
+        cjs.extend(inherited_requires);
+    } else {
+        esm.extend(inherited_requires);
+    }
+    esm.extend(inherited_imports);
+
+    let dir = root.join("node_modules").join(".nub");
+    if !cjs.is_empty() || !esm.is_empty() {
+        std::fs::create_dir_all(&dir).with_context(|| {
+            format!("could not create the preload chainer dir {}", dir.display())
+        })?;
+    }
+    let cjs_path = write_preload_chain(&dir, false, &cjs)?;
+    let esm_path = write_preload_chain(&dir, true, &esm)?;
+
+    // nub's own preload carries whichever chainer matches its channel, so that one
+    // costs no token at all; the other gets the single token of its name.
+    let (carried, tokened) = if node.version.supports_augmentation() {
+        (cjs_path, esm_path.map(|p| ("--import", p)))
+    } else {
+        // Compat tier: everything is on the ESM chain (see the routing above), which
+        // nub's own `--import` preload carries — so no extra token at all.
+        debug_assert!(cjs_path.is_none());
+        (esm_path, None)
+    };
+    runtime.preload_chain = carried;
+    Ok(
+        tokened.map(|(flag, path)| nub_core::node::spawn::PreloadInjection {
+            flag,
+            value: if flag == "--import" {
+                nub_core::node::spawn::file_url_for(&path.to_string_lossy())
+            } else {
+                path.to_string_lossy().into_owned()
+            },
+        }),
+    )
+}
+
+/// Write one chainer, or `Ok(None)` when it would be empty.
+///
+/// Entries are emitted as literal statements in order. A bare specifier stays bare so
+/// Node resolves it; an absolute path on the ESM side becomes a `file://` URL, because
+/// Windows rejects a raw `C:\...` as an ESM specifier (ERR_UNSUPPORTED_ESM_URL_SCHEME)
+/// where POSIX would have tolerated it.
+fn write_preload_chain(dir: &Path, esm: bool, entries: &[String]) -> Result<Option<PathBuf>> {
+    if entries.is_empty() {
+        return Ok(None);
+    }
     let mut body = String::from(
-        "// Generated by nub from `nub.jsonc` `preload`. Regenerated every run; do not edit.\n\
-         // One module instead of one NODE_OPTIONS token per entry — see vercel/next.js#96582.\n",
+        "// Generated by nub from `nub.jsonc` `preload` and any inherited NODE_OPTIONS\n\
+         // preload flags. Regenerated every run; do not edit. One module instead of one\n\
+         // token per entry — see vercel/next.js#96582.\n",
     );
     let resolver = bare_preload_resolver(esm);
-    for spec in &runtime.preload {
+    for spec in entries {
         let spec = resolve_bare_preload(&resolver, spec);
-        // An ESM specifier that is an absolute PATH must be a file:// URL. POSIX
-        // tolerates a bare `/abs/path`, but Windows rejects `C:\...` outright with
-        // ERR_UNSUPPORTED_ESM_URL_SCHEME ("Received protocol 'c:'"), so convert on
-        // both platforms rather than branch. `require` takes the raw path, and a
-        // BARE specifier must stay bare on either channel so Node resolves it.
         let spec = if esm && Path::new(&spec).is_absolute() {
             nub_core::node::spawn::file_url_for(&spec)
         } else {
@@ -3211,32 +3278,29 @@ fn prepare_preload_chain(
         // is what makes a Windows path or a quote in a specifier safe to embed.
         let literal = serde_json::to_string(&spec)?;
         if esm {
-            body.push_str(&format!("import {literal};\n"));
+            // `await import(...)`, not a static `import` — Node awaits each `--import`
+            // entry before starting the next, but STATIC imports of sibling modules
+            // may interleave, so an entry with top-level await would let a later one
+            // land first. Sequential dynamic import reproduces the token ordering.
+            body.push_str(&format!("await import({literal});\n"));
         } else {
             body.push_str(&format!("require({literal});\n"));
         }
     }
+    let name = if esm {
+        "preload-chain.mjs"
+    } else {
+        "preload-chain.cjs"
+    };
+    let path = dir.join(name);
     // Write via a sibling temp file so a concurrent nub in the same project can never
     // observe a half-written chainer.
-    let tmp = dir.join(format!("preload-chain.{}.tmp", std::process::id()));
+    let tmp = dir.join(format!("{name}.{}.tmp", std::process::id()));
     std::fs::write(&tmp, body)
         .with_context(|| format!("could not write the preload chainer {}", tmp.display()))?;
     std::fs::rename(&tmp, &path)
         .with_context(|| format!("could not install the preload chainer {}", path.display()))?;
-
-    if esm && node.version.supports_augmentation() {
-        // Fast tier: nub's own preload is a `--require` and cannot await, so the
-        // chainer needs its own `--import`. One of each flag name — Next-safe.
-        runtime.preload_chain = None;
-        Ok(Some(nub_core::node::spawn::PreloadInjection {
-            flag: "--import",
-            value: nub_core::node::spawn::file_url_for(&path.to_string_lossy()),
-        }))
-    } else {
-        // nub's own preload loads it, so no second token exists at all.
-        runtime.preload_chain = Some(path);
-        Ok(None)
-    }
+    Ok(Some(path))
 }
 
 /// A resolver for BARE `nub.jsonc` `preload` entries, with the condition set the
@@ -3274,7 +3338,11 @@ fn bare_preload_resolver(esm: bool) -> oxc_resolver::Resolver {
 /// unresolvable bare entry is passed through untouched so Node emits its own
 /// `ERR_MODULE_NOT_FOUND` naming the specifier the user actually wrote.
 fn resolve_bare_preload(resolver: &oxc_resolver::Resolver, spec: &str) -> String {
-    if Path::new(spec).is_absolute() || spec.starts_with('.') {
+    // Only an ABSOLUTE spec is already anchored. A relative one still needs the CWD:
+    // config entries arrive pre-absolutized, but an entry folded out of an inherited
+    // NODE_OPTIONS does not, and `./x.mjs` left verbatim would resolve against the
+    // CHAINER's directory instead of the CWD Node would have used.
+    if Path::new(spec).is_absolute() {
         return spec.to_string();
     }
     // No readable cwd: leave the entry alone and let Node raise its own error.

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3188,7 +3188,15 @@ fn prepare_preload_chain(
     // Which channel the CONFIG entries ride. Unchanged from the per-entry router it
     // replaced: a `.cjs`-only list keeps `--require`'s synchronous entry semantics,
     // anything else needs the async channel (and the compat tier is always async).
+    // Folding an inherited `--import` makes nub force the async loader-worker tier on
+    // the broken-compose band (see the folded-import marker in spawn.rs) — and Node
+    // RE-RUNS every `--require` preload inside that worker's realm. So whenever a
+    // loader worker is coming, everything rides the ESM chain, which loader workers
+    // skip. Same rule the compat tier already needs, for the same reason.
+    let async_tier_coming = !inherited_imports.is_empty()
+        && nub_core::node::spawn::force_async_tier_env(&node.version, ["--import"]).is_some();
     let config_is_esm = !node.version.supports_augmentation()
+        || async_tier_coming
         || runtime.preload.iter().any(|spec| {
             !std::path::Path::new(spec)
                 .extension()
@@ -3212,7 +3220,7 @@ fn prepare_preload_chain(
     // would run the entry twice. The original per-entry router made the same trade
     // for config `.cjs` entries: moving them to the async channel costs ordering
     // (they land in the import phase) and buys running exactly once.
-    if node.version.supports_augmentation() {
+    if node.version.supports_augmentation() && !async_tier_coming {
         cjs.extend(inherited_requires);
     } else {
         esm.extend(inherited_requires);

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3168,6 +3168,7 @@ fn is_node_option_token(value: &str) -> bool {
 fn prepare_preload_chain(
     runtime: &mut crate::project_config::RuntimeConfig,
     node: &nub_core::node::discovery::ResolvedNode,
+    fold: FoldInherited,
 ) -> Result<Option<nub_core::node::spawn::PreloadInjection>> {
     let Some(root) = runtime.preload_root.clone() else {
         return Ok(None);
@@ -3178,7 +3179,10 @@ fn prepare_preload_chain(
     // ambient `--require` (what every APM injector sets) adds a second token, and a
     // consumer that keys NODE_OPTIONS by flag name drops one of them — which, since
     // nub appends the inherited value last, was nub's own preload.
-    let inherited = std::env::var("NODE_OPTIONS").unwrap_or_default();
+    let inherited = match fold {
+        FoldInherited::Yes => std::env::var("NODE_OPTIONS").unwrap_or_default(),
+        FoldInherited::No => String::new(),
+    };
     let (_, inherited_requires, inherited_imports) =
         nub_core::node::spawn::split_inherited_preloads(&inherited);
     if runtime.preload.is_empty() && inherited_requires.is_empty() && inherited_imports.is_empty() {
@@ -3403,6 +3407,27 @@ pub(crate) fn runtime_node_options(
     runtime: &mut crate::project_config::RuntimeConfig,
     node: &nub_core::node::discovery::ResolvedNode,
 ) -> Result<Vec<String>> {
+    runtime_node_options_with(runtime, node, FoldInherited::Yes)
+}
+
+/// Whether inherited `NODE_OPTIONS` preloads may be folded into nub's chainer.
+///
+/// `No` for the watch path: `node --watch` runs a supervisor that is deliberately
+/// preload-free, and the chainer is only loaded by nub's own preload — so folding
+/// there would move the user's ambient preload out of the supervisor entirely. A
+/// user setting `NODE_OPTIONS=--require=<agent>` expects it in EVERY Node process,
+/// the supervisor included, so those entries stay on the inherited value verbatim.
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum FoldInherited {
+    Yes,
+    No,
+}
+
+pub(crate) fn runtime_node_options_with(
+    runtime: &mut crate::project_config::RuntimeConfig,
+    node: &nub_core::node::discovery::ResolvedNode,
+    fold: FoldInherited,
+) -> Result<Vec<String>> {
     let accepted = nub_core::node::discovery::accepted_env_flags(node.path.as_std_path());
     let mut options = Vec::new();
 
@@ -3425,7 +3450,7 @@ pub(crate) fn runtime_node_options(
     }
     // ONE synthesized chainer instead of a token per entry — see prepare_preload_chain
     // for why (vercel/next.js#96582) and where the chainer has to live.
-    if let Some(injection) = prepare_preload_chain(runtime, node)? {
+    if let Some(injection) = prepare_preload_chain(runtime, node, fold)? {
         options.push(injection.node_options_token());
     }
 
@@ -5824,7 +5849,7 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
         let status = nub_core::node::spawn::status_forwarding_signals(&mut cmd)?;
         return Ok(nub_core::node::spawn::exit_code_from_status(&status));
     }
-    let runtime_node_options = runtime_node_options(&mut runtime, &node)?;
+    let runtime_node_options = runtime_node_options_with(&mut runtime, &node, FoldInherited::No)?;
     let runtime_v8_flags = runtime_v8_flags(&runtime)?;
     let runtime_json = runtime_config_json(&runtime)?;
 

--- a/crates/nub-cli/src/project_config.rs
+++ b/crates/nub-cli/src/project_config.rs
@@ -724,9 +724,10 @@ impl EffectiveConfig {
             })
             .collect::<Vec<String>>();
         // Anchor the chainer to the same root the entries resolved against, so a
-        // bare entry resolves through THAT project's node_modules.
-        let preload_root =
-            (!preload.is_empty()).then(|| self.source_root(ConfigKey::Preload).to_path_buf());
+        // bare entry resolves through THAT project's node_modules. Set even with no
+        // `preload` entries: an INHERITED NODE_OPTIONS can carry preload flags of its
+        // own that nub folds into the same chainers, and those need a directory too.
+        let preload_root = Some(self.source_root(ConfigKey::Preload).to_path_buf());
 
         let env_file = match values.env_file.as_ref().unwrap_or(&EnvFileSetting::Default) {
             EnvFileSetting::Default => RuntimeEnvFile::Default,

--- a/crates/nub-cli/tests/project_runtime_config.rs
+++ b/crates/nub-cli/tests/project_runtime_config.rs
@@ -1226,3 +1226,80 @@ fn a_bare_preload_entry_resolves_from_the_cwd_like_node_does() {
         "the root copy must not shadow the member's: {stdout}"
     );
 }
+
+/// Preload flags arriving through an INHERITED `NODE_OPTIONS` are folded into nub's
+/// chainers rather than forwarded as extra tokens.
+///
+/// Without the fold, an ambient `--require` (what every APM injector sets) lands as a
+/// second token of a name nub already emits. A consumer that keys `NODE_OPTIONS` by
+/// flag name then keeps one — and since nub appends the inherited value last, the one
+/// it dropped was nub's own preload, taking the whole augmentation layer with it.
+///
+/// Both preloads must still RUN, and in the same order as before the fold.
+#[test]
+fn inherited_node_options_preloads_fold_into_the_chainer() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"fold","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    std::fs::write(root.join("nub.jsonc"), "{ \"preload\": [\"./cfg.cjs\"] }\n").unwrap();
+    let log = root.join("order.log");
+    for (file, marker) in [("cfg.cjs", "CFG"), ("amb.cjs", "AMB")] {
+        std::fs::write(
+            root.join(file),
+            format!(
+                "require(\"node:fs\").appendFileSync(process.env.FOLD_LOG, {:?});",
+                format!("{marker}\n")
+            ),
+        )
+        .unwrap();
+    }
+    std::fs::write(
+        root.join("app.js"),
+        "require(\"node:fs\").appendFileSync(process.env.FOLD_LOG, \"ENTRY\\n\");\n\
+         console.log(process.env.NODE_OPTIONS ?? \"\");",
+    )
+    .unwrap();
+
+    let mut command = Command::new(nub_binary());
+    command
+        .current_dir(root)
+        .arg("app.js")
+        .env("FOLD_LOG", &log)
+        .env(
+            "NODE_OPTIONS",
+            format!("--require {}", root.join("amb.cjs").display()),
+        )
+        .stdin(Stdio::null());
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "nub app.js failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let options = String::from_utf8_lossy(&output.stdout);
+    let requires = options.matches("--require").count();
+    let imports = options.matches("--import").count();
+    assert!(
+        requires <= 1 && imports <= 1,
+        "an inherited preload must be folded, not forwarded as a second token; \
+         got {requires} --require and {imports} --import: {options}"
+    );
+    let normalized = options.replace('\\', "/");
+    assert!(
+        normalized.contains("runtime/preload."),
+        "nub's own preload token must survive the fold: {options}"
+    );
+
+    let order = std::fs::read_to_string(&log).unwrap_or_default();
+    let order: Vec<&str> = order.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        order,
+        vec!["CFG", "AMB", "ENTRY"],
+        "both preloads must run, config before inherited, both before the entry"
+    );
+}

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -995,9 +995,24 @@ pub fn spawn_node(config: &SpawnConfig<'_>) -> Result<SpawnResult> {
         // loader (tsx/ts-node/--import) on a Node whose sync/async hook composition
         // is broken — the sync fast tier would otherwise crash with
         // ERR_METHOD_NOT_IMPLEMENTED (see force_async_tier_env / node_hook_compose_broken).
+        // An inherited `--import` is FOLDED into nub's chainer below, which removes it
+        // from NODE_OPTIONS — and with it the signal both this scan and the runtime's
+        // own intrinsic check read. A folded import can still register a loader (an
+        // `--import tsx` is exactly that), so stand in a synthetic token for it and
+        // keep the conservative "any such flag on the band takes the async tier"
+        // policy. Without this nub stays on the sync fast tier and a real tsx loader
+        // crashes on the resolveSync stub (nub#460).
+        let folded_import_marker: &[&str] = match node_options.as_deref() {
+            Some(value) if !split_inherited_preloads(value).2.is_empty() => &["--import"],
+            _ => &[],
+        };
         if let Some((k, val)) = force_async_tier_env(
             &config.node.version,
-            config.user_args.iter().map(String::as_str),
+            config
+                .user_args
+                .iter()
+                .map(String::as_str)
+                .chain(folded_import_marker.iter().copied()),
         ) {
             cmd.env(k, val);
         }

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -1233,6 +1233,10 @@ pub fn spawn_node(config: &SpawnConfig<'_>) -> Result<SpawnResult> {
             // can't parse (e.g. --experimental-webstorage on Node <22.4) aborts it
             // with exit 9 ("not allowed in NODE_OPTIONS"). See
             // flags::strip_unsupported_node_options.
+            // Preload flags were folded into nub's chainers by the caller
+            // (prepare_preload_chain), so forward only what is left — otherwise they
+            // ride as a second token of a name nub already emits.
+            let (existing, _, _) = split_inherited_preloads(&existing);
             let stripped = flags::strip_unsupported_node_options(&existing, &config.node.version);
             if !stripped.is_empty() {
                 node_opts_parts.push(stripped);
@@ -1989,6 +1993,8 @@ pub fn compute_augmentation_env(
         // before appending (mirror of the direct-spawn site above) — a gated flag
         // the child Node can't parse otherwise aborts it with exit 9. See
         // flags::strip_unsupported_node_options.
+        // Same fold as the main spawn path — see split_inherited_preloads.
+        let (existing, _, _) = split_inherited_preloads(&existing);
         let stripped = flags::strip_unsupported_node_options(&existing, &node_version);
         if !stripped.is_empty() {
             node_opts_parts.push(stripped);
@@ -2906,6 +2912,92 @@ pub fn node_options_token(value: &str) -> String {
 /// nub.jsonc (npm's `node-options` npmrc field) must hand `compute_augmentation_env`
 /// one element PER FLAG: it re-quotes every element individually, so pushing
 /// `--a --b` as a single element would emit the one broken token `"--a --b"`.
+/// Preload entries carried by an INHERITED `NODE_OPTIONS`, split out so nub can fold
+/// them into its own chainers instead of letting them ride as extra tokens.
+///
+/// Returns `(passthrough, requires, imports)` — the flags to forward unchanged, and
+/// the values of any `--require` / `--import` entries.
+///
+/// Why only those two names: a consumer that re-parses `NODE_OPTIONS` keys it by flag
+/// NAME and keeps one value per key (Next.js does — vercel/next.js#96582), so a token
+/// only collides with nub's own if it shares a name. nub emits exactly `--require`
+/// and `--import`.
+///
+/// Deliberately NOT folded:
+/// - `--loader` / `--experimental-loader` — nub emits neither, so they cannot collide,
+///   and folding one into an `import` would silently drop its hook registration. A
+///   loader is not an import.
+/// - Yarn PnP (`.pnp.cjs`, `.pnp.loader.mjs`) — PnP's resolver has to install before
+///   nub's preload, and the chainers run after it.
+///
+/// Safe against re-entrancy by construction: the caller only rebuilds `NODE_OPTIONS`
+/// when NOT re-entrant, so the inherited value cannot already carry nub's own token.
+pub fn split_inherited_preloads(value: &str) -> (String, Vec<String>, Vec<String>) {
+    // Left in place rather than folded. PnP's resolver must install before nub's
+    // preload, and nub's OWN tokens must stay exactly where they are: a NESTED nub
+    // inherits them, and folding them into the new chainer would re-run nub's preload
+    // from inside itself and break the re-entrancy detection that keys on that token.
+    fn keep_in_place(value: &str) -> bool {
+        let v = value.trim_matches('"').replace('\\', "/");
+        v.ends_with(".pnp.cjs")
+            || v.ends_with(".pnp.loader.mjs")
+            || v.contains("/runtime/preload.")
+            || v.contains("/.nub/preload-chain.")
+    }
+
+    let tokens = split_node_options(value);
+    let mut passthrough: Vec<String> = Vec::new();
+    let mut requires: Vec<String> = Vec::new();
+    let mut imports: Vec<String> = Vec::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = &tokens[index];
+        // Both spellings: `--require=<v>` and `--require <v>`.
+        let split = token
+            .split_once('=')
+            .map(|(flag, value)| (flag, Some(value.to_string())))
+            .unwrap_or((token.as_str(), None));
+        let (flag, inline) = split;
+        let had_inline = inline.is_some();
+        let sink = match flag {
+            "--require" | "-r" => Some(&mut requires),
+            "--import" => Some(&mut imports),
+            _ => None,
+        };
+        match (sink, inline) {
+            (Some(sink), Some(value)) if !keep_in_place(&value) => sink.push(value),
+            (Some(sink), None)
+                if index + 1 < tokens.len() && !keep_in_place(&tokens[index + 1]) =>
+            {
+                sink.push(tokens[index + 1].clone());
+                index += 1;
+            }
+            // A PnP token, or a value-less trailing flag: forward verbatim, taking the
+            // separated value with it so the pair stays intact.
+            _ => {
+                passthrough.push(token.clone());
+                if !had_inline
+                    && matches!(flag, "--require" | "-r" | "--import")
+                    && index + 1 < tokens.len()
+                {
+                    index += 1;
+                    passthrough.push(tokens[index].clone());
+                }
+            }
+        }
+        index += 1;
+    }
+    (
+        passthrough
+            .iter()
+            .map(|token| node_options_token(token))
+            .collect::<Vec<_>>()
+            .join(" "),
+        requires,
+        imports,
+    )
+}
+
 pub fn split_node_options(value: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut in_string = false;
@@ -3426,6 +3518,52 @@ mod tests {
             r#""--conditions=a\"b""#
         );
         assert_eq!(node_options_token(""), r#""""#);
+    }
+
+    #[test]
+    fn split_inherited_preloads_folds_only_the_names_nub_emits() {
+        let (rest, req, imp) = split_inherited_preloads(
+            "--enable-source-maps --require /a.cjs --import /b.mjs --title=x",
+        );
+        assert_eq!(req, vec!["/a.cjs"]);
+        assert_eq!(imp, vec!["/b.mjs"]);
+        assert_eq!(rest, "--enable-source-maps --title=x");
+
+        // Both spellings, and several of one name (the shape that collides).
+        let (rest, req, imp) =
+            split_inherited_preloads("--require=/a.cjs --require /b.cjs --import=/c.mjs");
+        assert_eq!(req, vec!["/a.cjs", "/b.cjs"]);
+        assert_eq!(imp, vec!["/c.mjs"]);
+        assert!(rest.is_empty(), "everything foldable was folded: {rest:?}");
+
+        // A loader is NOT an import: folding it would drop its hook registration.
+        let (rest, req, imp) =
+            split_inherited_preloads("--loader /l.mjs --experimental-loader=/m.mjs");
+        assert!(req.is_empty() && imp.is_empty());
+        assert_eq!(rest, "--loader /l.mjs --experimental-loader=/m.mjs");
+
+        // Yarn PnP must keep its position ahead of nub's preload.
+        let (rest, req, _) = split_inherited_preloads("--require /proj/.pnp.cjs --require /a.cjs");
+        assert_eq!(req, vec!["/a.cjs"], "only the non-PnP entry folds");
+        assert_eq!(rest, "--require /proj/.pnp.cjs");
+
+        // nub's OWN tokens stay put: a nested nub inherits them, and folding them
+        // would re-run nub's preload from inside itself and defeat re-entrancy
+        // detection, which keys on that exact token.
+        let (rest, req, imp) = split_inherited_preloads(
+            "--require=/nub/runtime/preload.cjs --import=/p/node_modules/.nub/preload-chain.mjs --require /a.cjs",
+        );
+        assert_eq!(req, vec!["/a.cjs"]);
+        assert!(imp.is_empty());
+        assert!(
+            rest.contains("runtime/preload.cjs") && rest.contains("preload-chain.mjs"),
+            "nub's own tokens must be forwarded verbatim: {rest}"
+        );
+
+        // A value with a space survives the round-trip through the tokenizer.
+        let (rest, req, _) = split_inherited_preloads(r#"--require "/a b/c.cjs" --title=t"#);
+        assert_eq!(req, vec!["/a b/c.cjs"]);
+        assert_eq!(rest, "--title=t");
     }
 
     #[test]

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -258,11 +258,22 @@ function nodeHookComposeBroken() {
 // Both must be scanned. nub's own fast-tier injection is `--require` (never `--import`/
 // `--loader`) on this band, and its compat-tier `--import preload.mjs` lives below 22.15
 // (outside the broken band this gates on), so any such flag here is FOREIGN.
+// nub's OWN preload chainer is not a foreign loader. It rides `--import` like one, so
+// a plain regex over NODE_OPTIONS matches it and nub forces ITSELF onto the async
+// tier — which spawns a loader worker, and Node re-runs every `--require` preload in
+// that worker's realm, so the CJS chain runs twice. Recognise and skip it.
+const NUB_CHAIN_MARKER = /[\\/]\.nub[\\/]preload-chain\./;
+
 function foreignAsyncLoaderFlagPresent() {
   if (cliAsyncLoaderPresent()) return true; // execArgv channel
   const opts = process.env.NODE_OPTIONS;
   if (typeof opts !== "string" || opts === "") return false;
-  return /(?:^|\s)--(?:experimental-)?(?:import|loader)(?:=|\s|$)/.test(opts);
+  const re = /(?:^|\s)--(?:experimental-)?(?:import|loader)(?:=|\s)("[^"]*"|\S*)/g;
+  for (const match of opts.matchAll(re)) {
+    const value = (match[1] || "").replace(/^"|"$/g, "");
+    if (!NUB_CHAIN_MARKER.test(value)) return true;
+  }
+  return false;
 }
 
 // Should nub auto-select its async loader-worker tier at PRELOAD time because a foreign

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -204,6 +204,13 @@ if (!requireEsmDisabled && !forceAsyncTier) {
   // user's compile-cache re-enable is independent of require(esm).
   common.installTemporalLazyGlobal(__require);
   common.reenableUserCompileCache();
+
+  // ── User preloads (`nub.jsonc` `preload` + folded NODE_OPTIONS entries) ──
+  // Also loaded on THIS tier. The chainer is carried by nub's own preload on both
+  // tiers, so skipping it here silently dropped every entry whenever the async tier
+  // was selected — which an inherited `--import` triggers on the broken-compose band
+  // (22.15–24.11) via shouldAutoAsyncTierAtPreload.
+  common.requireUserPreloadChain();
 }
 
 // ── Lazy ESM-side-effect polyfills (R7) ─────────────────────────────


### PR DESCRIPTION
Follow-up to #673, which bounded nub's own preload tokens to one per flag name. A preload arriving through an **inherited** `NODE_OPTIONS` still added another.

## The bug

A consumer that re-parses `NODE_OPTIONS` keys it by flag name and keeps one value per key. nub appends the inherited value last, so the token that got dropped was nub's own preload — and with it the whole augmentation layer.

That inherited `--require` is what every APM injector sets (`NODE_OPTIONS="--require dd-trace/init"` is the Datadog and OpenTelemetry k8s shape), so a Next.js app under nub with an agent attached lost its augmentation silently.

Measured on a real `next build` with an ambient `--require` plus a `nub.jsonc` preload, counting processes each preload reached and how many kept nub's augmentation:

| | ambient preload | config preload | nub-augmented |
|---|---|---|---|
| before | 8 procs | 8 procs | **3 of 8** |
| after | 8 procs | 8 procs | **8 of 8** |

## What changed

Inherited `--require` / `--import` values are folded into the same chainers as the config's, and stripped from the forwarded value — so the child sees at most one of each name however many arrive.

Only those two names are folded, because they are the only ones nub emits and therefore the only ones that can collide. Left in place:

- `--loader` / `--experimental-loader` — folding one into an `import` would drop its hook registration. A loader is not an import.
- Yarn PnP — its resolver has to install before nub's preload.
- **nub's own tokens** — a nested nub inherits them, and folding them would defeat the re-entrancy detection that keys on exactly that token.

## Four bugs surfaced while building it

Each was caught by the sweep rather than by reading the code, and each is worth knowing:

1. **A `--require` token re-runs inside the loader worker.** Node re-runs every `--require` preload in a `module.register` worker's realm, which the compat tier always has. Inherited requires ride the ESM chain there instead — the same trade the original per-entry router made for config `.cjs` entries: costs ordering, buys running exactly once.
2. **Static `import` breaks ordering under top-level await.** Node awaits each `--import` token before starting the next, but static sibling imports may interleave, so an entry with TLA let a later one land first. The chainer now emits sequential `await import(...)`.
3. **Entries were silently dropped on the async tier.** The chain was only loaded in `preload.cjs`'s fast-tier branch, so whenever the async tier was selected every entry vanished.
4. **nub forced itself onto the async tier.** `foreignAsyncLoaderFlagPresent()` matched any `--import` in `NODE_OPTIONS` — including nub's own chainer — so nub spawned a loader worker against itself and, via (1), double-ran the CJS chain. This was the root cause of the whole cluster; fixing it took the sweep from 153 failures to 29.

Separately, inherited **relative** entries now resolve from the CWD. Only an absolute spec is already anchored; config entries arrive pre-absolutized, but an inherited `./x.mjs` left verbatim resolved against the chainer's directory. Caught by the existing `import_cjs_require_cache` suite.

## Verification

- **1020-cell sweep, 991 passing.** 3 Node versions (22.14 compat, 22.15 fast floor, 26.5) × `{CJS, type: module}` × 17 preload combinations × `{.js, .mjs}` entry × 5 inherited shapes (none / require / import / both / loader). Each cell asserts every entry ran exactly once, in declared order, before the entry, with at most one `--require` and one `--import`.
- The 29 remaining failures are all the inherited-`--loader` shape and **reproduce identically on `main`** (`ERR_INVALID_RETURN_PROPERTY_VALUE`, config preload double-runs) — pre-existing, untouched here.
- **Ordering preserved exactly.** All five combinations measured against `main` before the change produce byte-identical order after it.
- The new regression test was confirmed to fail without the fold ("got 2 `--require` and 0 `--import`").
- Full `cargo test -p nub-cli`: 38 suites green. The 3 `verify_deps` failures are the known pre-existing ones that reproduce on the merge base. `nub-core` spawn 53/53. `clippy --all-targets --all-features` and `fmt --check` clean.
