### PR TITLE
fix(install): host-filter the prewarm graph under the isolated layout too

### DIFF
--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1307,3 +1307,56 @@ fn jailed_build_that_never_needs_node_gyp_survives_a_failed_bootstrap() {
         "the approved build script must still have run: {stderr}"
     );
 }
+
+/// A cold CI install must link only the optional platform variants it actually
+/// materializes. The resolver widens the graph with every platform's optional
+/// native dep so the committed lockfile stays portable, and the virtual-store
+/// prewarm writes one symlink per optional edge — so a prewarm running on the
+/// unfiltered graph leaves a DANGLING link for every variant the host filter
+/// drops (25 of esbuild's 26 `@esbuild/*`). CI is what auto-selects the
+/// isolated layout that prewarm feeds, so this is the shape CI shipped. The
+/// lockfile-reuse path filters before the prewarm and was never affected.
+#[test]
+#[ignore = "network: installs esbuild from the npm registry"]
+fn ci_install_links_only_the_optional_platform_variants_it_materializes() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("optional-platform-links");
+    // esbuild ships 26 platform-specific optional deps, exactly one of which is
+    // installable on any given host — the widest cheap fixture for this.
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"opt","private":true,"dependencies":{"esbuild":"0.25.10"}}"#,
+    )
+    .unwrap();
+    let (_out, err, code) = run_install_ci(&dir, &["install"]);
+    assert_eq!(code, 0, "cold CI install must succeed: {err}");
+
+    let nested = dir.join("node_modules/.store/esbuild@0.25.10/node_modules/@esbuild");
+    let entries: Vec<_> = std::fs::read_dir(&nested)
+        .unwrap_or_else(|e| panic!("no nested @esbuild dir at {}: {e}: {err}", nested.display()))
+        .map(|e| e.unwrap().path())
+        .collect();
+
+    // Positive control: without this the dangling assertion below passes
+    // vacuously on an empty or absent directory.
+    assert!(
+        !entries.is_empty(),
+        "the host's own @esbuild variant must be linked: {err}"
+    );
+
+    // `Path::exists` follows symlinks, so a link whose target was never
+    // materialized reads as absent — which is exactly the defect.
+    let dangling: Vec<_> = entries
+        .iter()
+        .filter(|p| !p.exists())
+        .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        dangling.is_empty(),
+        "every linked @esbuild variant must be materialized; {} dangling: {dangling:?}",
+        dangling.len()
+    );
+}

--- a/vendor/aube/crates/aube/src/commands/install/materialize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/materialize.rs
@@ -26,11 +26,12 @@ pub(super) struct GvsPrewarmInputs {
     /// instead materialized a SECOND store next to the configured one.
     pub virtual_store_dir: std::path::PathBuf,
     /// Host platform + `ignoredOptionalDependencies`, applied to the
-    /// prewarm's graph clone (GVS path only) via
-    /// [`aube_resolver::platform::filter_graph`] so it hashes and
-    /// materializes the SAME host-only graph the link phase will. See
-    /// the filter call in [`run_gvs_prewarm_materializer`] for why a
-    /// graph mismatch here splits a shared-store singleton.
+    /// prewarm's graph clone under BOTH layouts via
+    /// [`aube_resolver::platform::filter_graph`], so the prewarm
+    /// materializes the SAME host-only graph the link phase will (and,
+    /// under GVS, hashes it the same too). See the filter call in
+    /// [`run_gvs_prewarm_materializer`] for the two distinct failures a
+    /// graph mismatch here causes.
     pub supported_architectures: aube_resolver::SupportedArchitectures,
     pub ignored_optional_dependencies: std::collections::BTreeSet<String>,
 }
@@ -135,6 +136,51 @@ pub(super) async fn run_gvs_prewarm_materializer(
         .as_deref()
         .map(aube_lockfile::graph_hash::engine_name_default);
 
+    // Host-filter the prewarm's graph to exactly what the link phase will
+    // materialize, BEFORE either layout's materializer runs. The resolver
+    // widens the graph with every common platform's optional native dep so the
+    // committed lockfile stays portable; the link phase then runs
+    // `filter_graph` back to host-only. A prewarm left on the WIDENED graph
+    // diverges from link in a different way per layout, which is why the filter
+    // belongs above the split rather than in the GVS arm:
+    //
+    // - Per-project (`.aube/`): the materializer writes one
+    //   `<dep_path>/node_modules/<name>` symlink per optional edge, but only
+    //   the filtered variants are ever materialized — so every dropped variant
+    //   becomes a DANGLING link (25 of esbuild's 26 `@esbuild/*` on a cold
+    //   install). Nothing prunes them later: the link phase's existence-gated
+    //   step 1 accepts the prewarm's directory as already cached. This layout
+    //   is what a set `CI` auto-selects, so it is the shape CI ships.
+    // - GVS: any package whose subtree holds a platform-specific optional (all
+    //   of a native-touching tree — parcel, next, anything pulling
+    //   lmdb/@swc/@parcel/watcher) recursively hashes differently here than at
+    //   link, and the two phases materialize the SAME dep_path at two
+    //   byte-identical global store dirs. The existence-gated link step then
+    //   never rewires over the prewarm cohort, so one consumer resolves the
+    //   prewarm copy and another the link copy of a would-be singleton — for
+    //   parcel that is two `@parcel/core` instances, two module-scoped
+    //   serializer registries, and a `DataCloneError` at worker-farm startup.
+    //
+    // filter_graph is the hash-affecting transform between prewarm-spawn and
+    // link for a public-registry tree: the intervening lockfile-metadata
+    // mutations (pnpm-config checksums, `optional`/transitivePeerDeps stamping)
+    // don't feed the node hash. `apply_computed_integrities` also feeds it
+    // (integrity is folded into `full_pkg_id`), but only for a package that
+    // resolved WITHOUT integrity — a no-op for registry packages whose
+    // packument carries the SRI at resolve time (all of Parcel's tree).
+    // Integrity-less-at-resolve nodes are the git/tarball deps the prewarm
+    // already defers via `content_affected`. So filtering here makes the two
+    // phases agree and the link phase's reuse fast-path re-engages.
+    let graph = {
+        let mut host_graph = (*graph).clone();
+        aube_resolver::platform::filter_graph(
+            &mut host_graph,
+            &supported_architectures,
+            &ignored_optional_dependencies,
+        );
+        std::sync::Arc::new(host_graph)
+    };
+
     // Build a probe linker without graph_hashes to check GVS mode
     // first. compute_graph_hashes_with_patches walks every package
     // BLAKE3-style, expensive on huge graphs. Skip it when GVS is
@@ -161,41 +207,6 @@ pub(super) async fn run_gvs_prewarm_materializer(
         return run_aube_dir_materializer(probe, graph, cwd, link_concurrency, materialize_rx)
             .await;
     }
-
-    // Host-filter the prewarm's graph to exactly what the link phase
-    // hashes. The resolver widens the graph with every common platform's
-    // optional native deps so the committed lockfile is portable; the
-    // link phase then runs `filter_graph` to host-only before hashing.
-    // Prewarm ran with the WIDENED graph, so any package whose subtree
-    // contains a platform-specific optional (all of a native-touching
-    // tree — parcel, next, anything pulling lmdb/@swc/@parcel/watcher)
-    // recursively hashes differently here than at link, and the two
-    // phases materialize the SAME dep_path at two byte-identical global
-    // store dirs. The existence-gated link step then never rewires over
-    // the prewarm cohort, so one consumer resolves the prewarm copy and
-    // another the link copy of a would-be singleton — for parcel that is
-    // two `@parcel/core` instances, two module-scoped serializer
-    // registries, and a `DataCloneError` at worker-farm startup.
-    // filter_graph is the hash-affecting transform between prewarm-spawn
-    // and link for a public-registry tree: the intervening lockfile-metadata
-    // mutations (pnpm-config checksums, `optional`/transitivePeerDeps
-    // stamping) don't feed the node hash. `apply_computed_integrities` also
-    // feeds it (integrity is folded into `full_pkg_id`), but only for a
-    // package that resolved WITHOUT integrity — a no-op for registry
-    // packages whose packument carries the SRI at resolve time (all of
-    // Parcel's tree). Integrity-less-at-resolve nodes are the git/tarball
-    // deps the prewarm already defers via `content_affected`. So filtering
-    // here makes the two phases agree on this path and the link phase's
-    // reuse fast-path re-engages.
-    let graph = {
-        let mut host_graph = (*graph).clone();
-        aube_resolver::platform::filter_graph(
-            &mut host_graph,
-            &supported_architectures,
-            &ignored_optional_dependencies,
-        );
-        std::sync::Arc::new(host_graph)
-    };
 
     // Hash compute walks every package BLAKE3-style. spawn_blocking
     // pushes it off the tokio worker so the canonical_to_contextualized


### PR DESCRIPTION
The virtual-store prewarm host-filtered its graph clone only on the global-virtual-store path. The isolated path returned early with the widened graph, writing one nested symlink per declared optional edge while only the filtered variants were ever materialized — 25 of esbuild's 26 `@esbuild/*` left dangling on a cold install. A set `CI` auto-selects that layout, so it is the shape CI shipped. The lockfile-reuse path was unaffected.

Hoisting the filter above the layout split makes both paths materialize the same host-only graph. Honored variant sets are unchanged.

Verified on macOS with `CI=1`: 26 nested / 25 dangling to 1 / 0 plain, and 26 / 22 to 4 / 0 with `supportedArchitectures`. The GVS and lockfile-reuse paths are unchanged, and the regression test fails without the fix.

Refs #677
