### PR TITLE
fix(resolver): fall back to the newest mature release when the age gate blocks latest

### DIFF
--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -516,7 +516,7 @@ $ nub add some-tool
 + some-tool@2.3.0  latest 2.4.0   # ✓ 2.4.0 is still inside the window
 ```
 
-The fallback stops at whatever the publisher currently tags `latest`. A higher version that was published and then untagged is a release they withdrew, so Nub never falls back to one.
+The fallback stops at whatever the publisher currently tags `latest`. A higher version that was published and then untagged is a release they withdrew, so Nub never falls back to one. And when `latest` points at a prerelease, a blocked release fails outright rather than falling back — the stable release below it belongs to a line the publisher has moved off, and the flags below are the way through.
 
 Two flags adjust the window for a single command, so getting past a block never means editing config:
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -509,7 +509,16 @@ Which manifest field grants permission tracks the inferred incumbent: pnpm proje
 
 A registry-resolved version must be older than `minimumReleaseAge` — 24 hours by default — before Nub will install it. The window is what keeps a compromised publish out of your tree during the hours between it going up and being caught.
 
-Two flags adjust it for a single command, so getting past a block never means editing config:
+Asking for a package without naming a version resolves to the newest release that clears the window, so a fresh publish blocks that release rather than the whole command:
+
+```console
+$ nub add some-tool
++ some-tool@2.3.0  latest 2.4.0   # ✓ 2.4.0 is still inside the window
+```
+
+The fallback stops at whatever the publisher currently tags `latest`. A higher version that was published and then untagged is a release they withdrew, so Nub never falls back to one.
+
+Two flags adjust the window for a single command, so getting past a block never means editing config:
 
 ```console
 $ nub add some-tool

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -516,7 +516,7 @@ $ nub add some-tool
 + some-tool@2.3.0  latest 2.4.0   # ✓ 2.4.0 is still inside the window
 ```
 
-The fallback stops at whatever the publisher currently tags `latest`. A higher version that was published and then untagged is a release they withdrew, so Nub never falls back to one. And when `latest` points at a prerelease, a blocked release fails outright rather than falling back — the stable release below it belongs to a line the publisher has moved off, and the flags below are the way through.
+The fallback stops at whatever the publisher currently tags `latest`. A higher version that was published and then untagged is a release they withdrew, so Nub never falls back to one. A prerelease `latest` fails outright for the same reason — the stable release below it belongs to a line the publisher has moved off.
 
 Two flags adjust the window for a single command, so getting past a block never means editing config:
 

--- a/site/content/docs/runner/dlx.mdx
+++ b/site/content/docs/runner/dlx.mdx
@@ -47,6 +47,18 @@ A fetched package's `preinstall`/`install`/`postinstall` scripts stay skipped â€
 
 A fetch runs through Nub's normal install resolver, so the `minimumReleaseAge` cooling window applies: a resolved version must be older than the window (default 24 hours) before it's used. See [the cooling window](/docs/install#cooling-window) for the full posture, including what happens when a registry serves no publish dates.
 
+A tool published within the window runs at its newest release that clears it, and the substitution is reported â€” the scratch project is deleted when the tool exits, so this is the only record of which version ran:
+
+```console
+$ nubx some-tool
++ some-tool@2.3.0  latest 2.4.0
+
+warn: the latest some-tool release (2.4.0) is younger than minimumReleaseAge; using 2.3.0 instead
+help: to take the newest release anyway: `--minimum-release-age=0`, or `--minimum-release-age-exclude=some-tool`
+```
+
+Naming a version instead (`nubx some-tool@2.4.0`) is a request for that exact release, so a blocked one fails rather than falling back.
+
 ## Configuration
 
 The global [`nub.jsonc`](/docs/config) carries a [`dlx`](/docs/config#dlx) block. Whether a tool may be pulled from the registry is a decision about your machine, so a project file cannot set it:

--- a/site/content/docs/runner/dlx.mdx
+++ b/site/content/docs/runner/dlx.mdx
@@ -47,7 +47,7 @@ A fetched package's `preinstall`/`install`/`postinstall` scripts stay skipped �
 
 A fetch runs through Nub's normal install resolver, so the `minimumReleaseAge` cooling window applies: a resolved version must be older than the window (default 24 hours) before it's used. See [the cooling window](/docs/install#cooling-window) for the full posture, including what happens when a registry serves no publish dates.
 
-A tool published within the window runs at its newest release that clears it, and the substitution is reported — the scratch project is deleted when the tool exits, so this is the only record of which version ran:
+When the latest release is still inside the window, the tool runs at the newest release that clears it, and the substitution is reported — the scratch project is deleted when the tool exits, so this is the only record of which version ran:
 
 ```console
 $ nubx some-tool

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -1114,6 +1114,33 @@ impl<'a> ResolveDriver<'a> {
         // for the same reason.
         let mut picked_owned = picked_ref.clone();
         let picked_publish_time = packument.time.get(&picked_ref.version).cloned();
+
+        // Gate-steered `latest` (#681). `pick_version` widens a `latest` the
+        // cutoff blocks to `<=dist-tags.latest`, so a pick below the tag is
+        // the newest release that cleared the window. Surface it: `dlx`
+        // deletes its scratch project, so this is the only trace that the
+        // tool which ran is not the one the user asked for.
+        //
+        // Keyed on `minimum_release_age` being configured at all, NOT on
+        // `age_gate_cutoff` — that field is deliberately `None` in strict
+        // mode (it exists to spot loose-mode immature fallbacks, which strict
+        // mode never produces), and strict is exactly the posture that made
+        // this a hard failure in the first place. Time-based resolution is
+        // excluded for a different reason: it rewrites the whole graph to a
+        // date by design and needs no per-package note.
+        //
+        // Root deps only. The notice answers "which version of the thing I
+        // asked for am I getting"; a transitive dep that happens to declare a
+        // `latest` range is the resolver doing its job and not something the
+        // caller named.
+        if self.resolver.minimum_release_age.is_some()
+            && task.is_root
+            && task.range == "latest"
+            && let Some(latest) = packument.dist_tags.get("latest")
+            && latest != &picked_ref.version
+        {
+            aube_util::record_age_gate_downgrade(task.registry_name(), &picked_ref.version, latest);
+        }
         // Skip the readPackage hook entirely for a `(name, version)`
         // pair we've already fully processed via a prior task. The
         // mutated dep maps only drive the transitive enqueue below,

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -58,13 +58,14 @@ impl<'a> PickResult<'a> {
 /// `minimum_release_age` to get today's ungated pick (dist-tag preference,
 /// then highest satisfying).
 ///
-/// A gated `latest` range is normalized to `*` here, at the API boundary,
-/// so no caller can reintroduce the bypass: [`pick_version`]'s internal
-/// dist-tag fallback turns `latest` into the tagged version's exact range,
-/// whose lenient fallback would admit a fresh publish — the very thing the
-/// gate exists to block. `*` keeps the dist-tag preference for a mature
-/// `latest`, steers a gated one to the newest version clearing the cutoff,
-/// and (unlike the tag) still resolves when `dist-tags.latest` is missing.
+/// A gated `latest` is steered to the newest version clearing the cutoff by
+/// [`pick_version`] itself, so `add` and full resolution get that behavior
+/// from one place. `add` used to normalize the range to `*` here at the API
+/// boundary instead; the widening moved down into `pick_version` (#681) both
+/// so the install path gets it — `dlx` synthesizes a literal `latest` range
+/// and had no fallback at all — and because `pick_version` bounds the
+/// fallback at the tagged version, where `*` could reach a HIGHER major the
+/// publisher had already untagged.
 pub fn pick_version_for_add<'a>(
     packument: &'a Packument,
     registry_name: &str,
@@ -72,11 +73,6 @@ pub fn pick_version_for_add<'a>(
     minimum_release_age: Option<&crate::MinimumReleaseAge>,
 ) -> PickResult<'a> {
     let cutoff = minimum_release_age.and_then(|m| m.cutoff());
-    let range = if range == "latest" && cutoff.is_some() {
-        "*"
-    } else {
-        range
-    };
     let strict = minimum_release_age.is_some_and(|m| m.strict);
     let exclude = minimum_release_age.map(|m| &m.exclude);
     let is_age_exempt = |ver: &str, parsed: Option<&node_semver::Version>| {
@@ -225,6 +221,25 @@ pub(crate) fn pick_version<'a>(
     strict: bool,
     is_age_exempt: impl Fn(&str, Option<&node_semver::Version>) -> bool,
 ) -> PickResult<'a> {
+    let passes_effective_cutoff = |ver: &str, effective: Option<&str>| {
+        version_clears_cutoff(packument, ver, effective, strict)
+    };
+
+    // A version's effective cutoff: exempt versions answer to the
+    // time-based wall (`exempt_cutoff`) only; everyone else answers to
+    // the merged `cutoff`.
+    let classify_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> AgeVerdict {
+        let effective = if is_age_exempt(ver, parsed) {
+            exempt_cutoff
+        } else {
+            cutoff
+        };
+        classify_version_age(packument, ver, effective, strict)
+    };
+    let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
+        matches!(classify_cutoff(ver, parsed), AgeVerdict::Clears)
+    };
+
     // Handle dist-tag references. If the requested range is a tag
     // name and the packument has that tag, use the tagged version
     // as the effective range. Special case `latest`: some registries
@@ -260,30 +275,60 @@ pub(crate) fn pick_version<'a>(
             } else {
                 return PickResult::NoMatch;
             };
+            // A `latest` the cutoff blocks widens from the tagged version's
+            // exact range to everything at or below it, so the scan below can
+            // reach the newest release that *does* clear the cutoff (#681).
+            // Without this the tag narrows to a one-version range and the two
+            // modes fail in opposite directions: strict errors out with a
+            // mature release sitting right there, and lenient re-picks the
+            // very publish the gate blocked — it is the only candidate, so
+            // `fallback_lowest` is it — which is a silent bypass.
+            //
+            // pnpm 11 reaches the same outcome by a different route:
+            // `filterPkgMetadataByPublishDate` strips too-new versions from the
+            // packument and REPOPULATES each dist-tag to the highest surviving
+            // version before the tag lookup runs
+            // (`resolving/registry/pkg-metadata-filter/src/index.ts`). Two
+            // deliberate divergences from it:
+            //
+            // - **Bounded at the tagged version.** pnpm's repopulation scans
+            //   every surviving version for `latest`, so it can land ABOVE the
+            //   tag. `latest` is a pointer the publisher can move backwards —
+            //   ship 3.0.0, find it broken, tag a fresh 2.9.1 as `latest` — and
+            //   there the unbounded scan answers with the 3.0.0 they retracted.
+            //   `<=` keeps the fallback on the line they currently bless.
+            // - **`latest` only.** pnpm repopulates every tag, constrained to
+            //   the same major and the same prerelease-ness so a channel cannot
+            //   leak into a stable release. Expressing that pair of constraints
+            //   as a semver range is awkward (a prerelease tag needs a range
+            //   that admits prereleases at all), and the reported case is the
+            //   unversioned request, which is always `latest`. A blocked
+            //   `foo@next` still fails.
+            //
+            // The other two conditions are load-bearing:
+            //
+            // - A tag that CLEARS the cutoff keeps the exact pin, so the
+            //   `locked` and dist-tag-preference branches below still see the
+            //   one-version range they always did. Widening unconditionally
+            //   would let a lockfile pin far below `latest` satisfy the range
+            //   and freeze the dep there.
+            // - `pick_lowest` (`resolution-mode=time-based`) is excluded: it
+            //   deliberately takes the FLOOR of the range, so a widened
+            //   `latest` would resolve to the oldest release ever published.
+            let effective_range = if range_str == "latest"
+                && !pick_lowest
+                && cutoff.is_some()
+                && !passes_cutoff(&effective_range, None)
+            {
+                format!("<={effective_range}")
+            } else {
+                effective_range
+            };
             match node_semver::Range::parse(normalize_range(&effective_range)) {
                 Ok(r) => r,
                 Err(_) => return PickResult::NoMatch,
             }
         }
-    };
-
-    let passes_effective_cutoff = |ver: &str, effective: Option<&str>| {
-        version_clears_cutoff(packument, ver, effective, strict)
-    };
-
-    // A version's effective cutoff: exempt versions answer to the
-    // time-based wall (`exempt_cutoff`) only; everyone else answers to
-    // the merged `cutoff`.
-    let classify_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> AgeVerdict {
-        let effective = if is_age_exempt(ver, parsed) {
-            exempt_cutoff
-        } else {
-            cutoff
-        };
-        classify_version_age(packument, ver, effective, strict)
-    };
-    let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
-        matches!(classify_cutoff(ver, parsed), AgeVerdict::Clears)
     };
 
     // Prefer locked version if it satisfies and clears the cutoff.

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -297,16 +297,21 @@ pub(crate) fn pick_version<'a>(
             //   ship 3.0.0, find it broken, tag a fresh 2.9.1 as `latest` — and
             //   there the unbounded scan answers with the 3.0.0 they retracted.
             //   `<=` keeps the fallback on the line they currently bless.
-            // - **`latest` only.** pnpm repopulates every tag, constrained to
-            //   the same major and the same prerelease-ness so a channel cannot
-            //   leak into a stable release. Expressing that pair of constraints
-            //   as a semver range is awkward (a prerelease tag needs a range
-            //   that admits prereleases at all), and the reported case is the
-            //   unversioned request, which is always `latest`. A blocked
-            //   `foo@next` still fails.
+            // - **`latest` only, and only when it points at a stable release.**
+            //   pnpm repopulates every tag, constrained to the same major and
+            //   the same prerelease-ness so a channel cannot leak into a stable
+            //   release. Expressing that pair of constraints as a semver range
+            //   is awkward, and the reported case is the unversioned request,
+            //   which is always `latest`. A blocked `foo@next` still fails.
             //
-            // The other two conditions are load-bearing:
+            // The remaining conditions are load-bearing:
             //
+            // - A `latest` that points at a PRERELEASE is a channel pointer
+            //   too, and `<=` leaks straight through it: `<=3.0.0-beta.2`
+            //   admits a stable `2.9.0`, because npm's prerelease rule only
+            //   constrains prerelease CANDIDATES. That drops a full major onto
+            //   a line the publisher has moved off, so only a provably-stable
+            //   tag widens.
             // - A tag that CLEARS the cutoff keeps the exact pin, so the
             //   `locked` and dist-tag-preference branches below still see the
             //   one-version range they always did. Widening unconditionally
@@ -319,6 +324,8 @@ pub(crate) fn pick_version<'a>(
                 && !pick_lowest
                 && cutoff.is_some()
                 && !passes_cutoff(&effective_range, None)
+                && node_semver::Version::parse(&effective_range)
+                    .is_ok_and(|v| v.pre_release.is_empty())
             {
                 format!("<={effective_range}")
             } else {

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -5901,15 +5901,135 @@ fn pick_version_for_add_without_gate_keeps_latest_preference() {
 }
 
 #[test]
-fn pick_version_for_add_normalizes_gated_latest_range() {
-    // `latest` passed verbatim under an active gate must be normalized at
-    // the API boundary — pick_version's internal dist-tag fallback would
-    // otherwise turn it into the tagged version's exact range, whose
-    // lenient fallback admits the fresh publish.
+fn pick_version_for_add_steers_a_gated_latest_range() {
+    // `latest` passed verbatim under an active gate must not resolve to the
+    // fresh publish: pick_version's dist-tag fallback turns it into a range
+    // bounded at the tagged version, whose newest mature member wins.
     let packument = make_timed_packument("foo", &["1.0.0"], &["1.1.0"], "1.1.0");
     let gate = mra(1440, false, &[]);
     let result = pick_version_for_add(&packument, "foo", "latest", Some(&gate)).unwrap();
     assert_eq!(result.version, "1.0.0");
+}
+
+/// Every test below shares one wall-clock-free cutoff: `make_timed_packument`
+/// dates mature versions 2020 and fresh ones 2099, so this sits between them.
+const GATE_CUTOFF: &str = "2050-01-01T00:00:00.000Z";
+
+/// `pick_version` under an active release-age cutoff with the defaults the
+/// age-gate cases share: no lockfile pin, highest-first, no exemptions, and no
+/// time-based wall.
+fn pick_gated<'a>(packument: &'a Packument, range: &str, strict: bool) -> PickResult<'a> {
+    pick_version(
+        packument,
+        range,
+        None,
+        false,
+        Some(GATE_CUTOFF),
+        None,
+        strict,
+        |_, _| false,
+    )
+}
+
+/// The reported case (#681): `nubx <tool>` synthesizes a `latest` range, and a
+/// blocked `dist-tags.latest` used to narrow to a one-version range with no
+/// older candidate left — so strict mode failed outright with a mature release
+/// sitting right below the tag.
+#[test]
+fn pick_version_gated_latest_falls_back_to_newest_mature() {
+    let packument = make_timed_packument("skills", &["1.5.20", "1.5.21"], &["1.5.22"], "1.5.22");
+    assert_eq!(
+        pick_gated(&packument, "latest", true).unwrap().version,
+        "1.5.21"
+    );
+}
+
+/// The fallback stops at the tagged version. A publisher who ships 3.0.0,
+/// finds it broken and re-points `latest` at 2.0.0 has withdrawn 3.0.0 — an
+/// unbounded fallback would hand the gated user exactly the release the tag
+/// move retracted.
+#[test]
+fn pick_version_gated_latest_fallback_is_bounded_by_the_tag() {
+    let packument = make_timed_packument("foo", &["1.0.0", "3.0.0"], &["2.0.0"], "2.0.0");
+    assert_eq!(
+        pick_gated(&packument, "latest", true).unwrap().version,
+        "1.0.0"
+    );
+}
+
+/// The same narrowing broke lenient mode in the opposite direction: the
+/// blocked publish was the only version in range, so the lowest-satisfying
+/// fallback re-picked it and the gate was bypassed rather than enforced.
+#[test]
+fn pick_version_gated_latest_lenient_no_longer_readmits_the_blocked_publish() {
+    let packument = make_timed_packument("foo", &["1.0.0"], &["1.1.0"], "1.1.0");
+    assert_eq!(
+        pick_gated(&packument, "latest", false).unwrap().version,
+        "1.0.0"
+    );
+}
+
+/// A `latest` that CLEARS the cutoff keeps the exact-pin narrowing, so a
+/// lockfile entry far below the tag cannot satisfy the range and freeze the
+/// dependency there. This is why the widening is conditional on the tag
+/// actually being blocked rather than on the cutoff merely being active.
+#[test]
+fn pick_version_mature_latest_keeps_the_exact_tag_pin() {
+    let packument = make_timed_packument("foo", &["1.0.0", "1.5.0"], &[], "1.5.0");
+    let result = pick_version(
+        &packument,
+        "latest",
+        Some("1.0.0"),
+        false,
+        Some(GATE_CUTOFF),
+        None,
+        true,
+        |_, _| false,
+    );
+    assert_eq!(result.unwrap().version, "1.5.0");
+}
+
+/// Only `latest` widens. A channel tag names a specific release line, so
+/// falling back past it would answer `foo@beta` with a stable 1.9.0.
+#[test]
+fn pick_version_gated_channel_tag_does_not_fall_back_across_channels() {
+    let mut packument = make_timed_packument("foo", &["1.9.0"], &["2.0.0-beta.3"], "1.9.0");
+    packument
+        .dist_tags
+        .insert("beta".to_string(), "2.0.0-beta.3".to_string());
+    assert!(matches!(
+        pick_gated(&packument, "beta", true),
+        PickResult::AgeGated(AgeGateCause::TooNew)
+    ));
+}
+
+/// Time-based resolution takes the FLOOR of the range, so widening a blocked
+/// `latest` there would resolve to the oldest release ever published.
+#[test]
+fn pick_version_gated_latest_does_not_widen_in_lowest_first_mode() {
+    let packument = make_timed_packument("foo", &["1.0.0", "1.5.0"], &["2.0.0"], "2.0.0");
+    let result = pick_version(
+        &packument,
+        "latest",
+        None,
+        true,
+        Some(GATE_CUTOFF),
+        None,
+        true,
+        |_, _| false,
+    );
+    assert!(matches!(result, PickResult::AgeGated(AgeGateCause::TooNew)));
+}
+
+/// The gate still refuses when the fallback finds nothing: a package whose
+/// every release is inside the window has no mature version to offer.
+#[test]
+fn pick_version_gated_latest_still_refuses_when_nothing_is_mature() {
+    let packument = make_timed_packument("foo", &[], &["1.0.0", "1.1.0"], "1.1.0");
+    assert!(matches!(
+        pick_gated(&packument, "latest", true),
+        PickResult::AgeGated(AgeGateCause::TooNew)
+    ));
 }
 
 #[test]

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -6003,6 +6003,22 @@ fn pick_version_gated_channel_tag_does_not_fall_back_across_channels() {
     ));
 }
 
+/// A `latest` pointing at a PRERELEASE is a channel pointer too, and widening
+/// it crosses exactly the boundary the named-tag case refuses: `<=3.0.0-beta.2`
+/// admits a stable `2.9.0`, because npm's prerelease rule only constrains
+/// prerelease CANDIDATES. Falling back there drops a full major onto a line the
+/// publisher has moved off — and on the `add` path it would be silent, since
+/// the install summary suppresses its `latest` badge for a prerelease tag
+/// (`direct_dep_info::is_prerelease`).
+#[test]
+fn pick_version_gated_prerelease_latest_does_not_fall_back_to_a_stable_release() {
+    let packument = make_timed_packument("foo", &["2.9.0"], &["3.0.0-beta.2"], "3.0.0-beta.2");
+    assert!(matches!(
+        pick_gated(&packument, "latest", true),
+        PickResult::AgeGated(AgeGateCause::TooNew)
+    ));
+}
+
 /// Time-based resolution takes the FLOOR of the range, so widening a blocked
 /// `latest` there would resolve to the oldest release ever published.
 #[test]
@@ -6039,6 +6055,102 @@ fn pick_version_for_add_gated_latest_survives_missing_dist_tag() {
     let gate = mra(1440, false, &[]);
     let result = pick_version_for_add(&packument, "foo", "latest", Some(&gate)).unwrap();
     assert_eq!(result.version, "1.0.0");
+}
+
+/// The fallback and its notice, through a real resolve rather than a direct
+/// `pick_version` call — the half of #681 the unit tests above cannot reach.
+///
+/// Covers the driver's four-clause record condition, which is the piece that
+/// fails silently: keyed on the wrong field it records nothing, and a sink that
+/// never fires is indistinguishable from one that works until someone runs the
+/// command by hand. (It was keyed on `age_gate_cutoff` at first, which is
+/// deliberately `None` in strict mode — nub's posture — so the notice never
+/// appeared.)
+///
+/// The sink is process-global, so the assertion filters to this fixture's own
+/// name: another test recording concurrently must not turn this red. Nothing
+/// else in this crate arms or drains it.
+#[tokio::test]
+async fn resolve_records_a_gate_steered_latest_downgrade() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    const NAME: &str = "gate-downgrade-fixture";
+    let packument = make_timed_packument(NAME, &["1.0.0"], &["1.1.0"], "1.1.0");
+    let body = serde_json::to_vec(&packument).unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            let body = body.clone();
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 2048];
+                let _ = socket.read(&mut buf).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.write_all(&body).await;
+            });
+        }
+    });
+
+    let base = std::env::temp_dir().join(format!(
+        "aube-resolver-gate-downgrade-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let cache_dir = base.join("packuments");
+    let full_cache_dir = base.join("packuments-full");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::create_dir_all(&full_cache_dir).unwrap();
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    // Strict is nub's pin, and the posture that used to make this a hard
+    // ERR_AUBE_NO_MATURE_MATCHING_VERSION instead of a fallback.
+    let mut resolver = Resolver::new(client)
+        .with_packument_cache(cache_dir)
+        .with_packument_full_cache(full_cache_dir)
+        .with_minimum_release_age(Some(MinimumReleaseAge {
+            minutes: 60,
+            strict: true,
+            ..Default::default()
+        }));
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert(NAME.to_string(), "latest".to_string());
+
+    aube_util::arm_age_gate_downgrade_collection();
+    let resolved = resolver.resolve(&manifest, None).await;
+    let downgrades = aube_util::take_age_gate_downgrades();
+    server.abort();
+    let _ = std::fs::remove_dir_all(base);
+
+    let graph = resolved.unwrap_or_else(|e| {
+        panic!("a blocked `latest` with a mature release below it must resolve, got: {e}")
+    });
+    assert!(
+        graph_has_package(&graph, NAME, "1.0.0"),
+        "resolve must fall back to the mature 1.0.0, not the gated `latest` 1.1.0"
+    );
+
+    let ours: Vec<_> = downgrades.iter().filter(|d| d.name == NAME).collect();
+    assert_eq!(
+        ours.len(),
+        1,
+        "exactly one downgrade should be recorded for {NAME}; got {downgrades:?}"
+    );
+    assert_eq!(
+        (ours[0].picked.as_str(), ours[0].blocked.as_str()),
+        ("1.0.0", "1.1.0")
+    );
 }
 
 fn assert_protocol_hijack_blocked(spec: &str) {

--- a/vendor/aube/crates/aube-util/src/age_gate.rs
+++ b/vendor/aube/crates/aube-util/src/age_gate.rs
@@ -1,23 +1,76 @@
-//! Process-global sink for age-gated (immature) fallback version picks.
+//! Process-global sinks for the two ways `minimumReleaseAge` moves a version
+//! pick off the one the range would otherwise have produced.
 //!
-//! With `minimumReleaseAge` set in loose mode (the default), the resolver falls
-//! back to the lowest satisfying version when every candidate is younger than
-//! the cutoff. pnpm does the same, then auto-persists that package to
-//! `minimumReleaseAgeExclude` so a later verify-lockfile pass accepts the pin.
-//! The resolver here does the fallback but assigns it no policy; an embedder
-//! that wants pnpm's auto-persist ARMS this sink before a resolve, DRAINS it
-//! after, and writes the exclude entry in whatever config surface its identity
-//! model dictates.
+//! **Immature fallback picks.** With `minimumReleaseAge` set in loose mode (the
+//! default), the resolver falls back to the lowest satisfying version when every
+//! candidate is younger than the cutoff. pnpm does the same, then auto-persists
+//! that package to `minimumReleaseAgeExclude` so a later verify-lockfile pass
+//! accepts the pin. The resolver here does the fallback but assigns it no
+//! policy; an embedder that wants pnpm's auto-persist ARMS that sink before a
+//! resolve, DRAINS it after, and writes the exclude entry in whatever config
+//! surface its identity model dictates.
 //!
-//! Disarmed by default: standalone aube never arms it, records nothing, and its
-//! behavior is unchanged. The record check is a single relaxed atomic load,
-//! reached only on an actual immature pick.
+//! **Gate downgrades.** The opposite direction: a `latest` request the cutoff
+//! blocked, answered with the newest release that clears it instead (#681).
+//! Nothing to persist here — the pick is mature and correct — but the caller ran
+//! an older tool than it asked for and deserves to be told, which matters most
+//! for `dlx`, whose scratch project is deleted before it could be inspected.
+//!
+//! Both are disarmed by default: standalone aube arms nothing, records nothing,
+//! and its behavior is unchanged. Each record check is a single atomic load,
+//! reached only on an actual off-range pick.
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 static ARMED: AtomicBool = AtomicBool::new(false);
 static PICKS: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
+
+static DOWNGRADES_ARMED: AtomicBool = AtomicBool::new(false);
+static DOWNGRADES: Mutex<Vec<AgeGateDowngrade>> = Mutex::new(Vec::new());
+
+/// A `latest` pick the release-age gate steered downward: `picked` is the
+/// newest release clearing the cutoff, `blocked` the `dist-tags.latest` that
+/// did not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgeGateDowngrade {
+    pub name: String,
+    pub picked: String,
+    pub blocked: String,
+}
+
+/// Arm gate-downgrade collection for the next resolve, clearing any prior
+/// entries.
+pub fn arm_age_gate_downgrade_collection() {
+    if let Ok(mut d) = DOWNGRADES.lock() {
+        d.clear();
+    }
+    DOWNGRADES_ARMED.store(true, Ordering::Release);
+}
+
+/// Record a `latest` request the cutoff steered to an older mature release.
+/// No-op unless armed.
+pub fn record_age_gate_downgrade(name: &str, picked: &str, blocked: &str) {
+    if !DOWNGRADES_ARMED.load(Ordering::Acquire) {
+        return;
+    }
+    if let Ok(mut d) = DOWNGRADES.lock() {
+        d.push(AgeGateDowngrade {
+            name: name.to_string(),
+            picked: picked.to_string(),
+            blocked: blocked.to_string(),
+        });
+    }
+}
+
+/// Disarm and drain every recorded downgrade, in record order.
+pub fn take_age_gate_downgrades() -> Vec<AgeGateDowngrade> {
+    DOWNGRADES_ARMED.store(false, Ordering::Release);
+    match DOWNGRADES.lock() {
+        Ok(mut d) => std::mem::take(&mut *d),
+        Err(_) => Vec::new(),
+    }
+}
 
 /// Arm collection for the next resolve, clearing any prior picks. The embedder
 /// calls this before an install/add/update resolve it wants to auto-persist.

--- a/vendor/aube/crates/aube-util/src/lib.rs
+++ b/vendor/aube/crates/aube-util/src/lib.rs
@@ -13,10 +13,11 @@ pub mod env;
 // reference `aube_util::DiagConfig` instead of `aube_util::diag::DiagConfig`.
 pub use diag::{DiagConfig, Slot, Span, jstr};
 
-// Convenience re-exports for the age-gate fallback sink (the embedder seam the
-// resolver records immature loose-mode picks into).
+// Convenience re-exports for the age-gate sinks (the embedder seam the resolver
+// records immature loose-mode picks, and gate-steered `latest` downgrades, into).
 pub use age_gate::{
-    arm_age_gated_fallback_pick_collection, record_age_gated_fallback_pick,
+    AgeGateDowngrade, arm_age_gate_downgrade_collection, arm_age_gated_fallback_pick_collection,
+    record_age_gate_downgrade, record_age_gated_fallback_pick, take_age_gate_downgrades,
     take_age_gated_fallback_picks,
 };
 pub mod fs;

--- a/vendor/aube/crates/aube/src/commands/add/manifest.rs
+++ b/vendor/aube/crates/aube/src/commands/add/manifest.rs
@@ -436,10 +436,12 @@ pub(super) async fn update_manifest_for_add(
         // Resolve non-`latest` dist-tags to their tagged version: like
         // exact pins, they're a deliberate user override (strict mode
         // still refuses a gated one below). `latest` passes through
-        // verbatim — `pick_version_for_add` normalizes it at the API
-        // boundary, steering a gated `latest` to the newest version
-        // clearing the minimumReleaseAge cutoff while keeping the plain
-        // dist-tag preference for a mature one.
+        // verbatim so `pick_version` can widen it (#681): a gated
+        // `latest` steers to the newest release clearing the
+        // minimumReleaseAge cutoff at or below the tag, and a mature one
+        // keeps the plain dist-tag preference. A `latest` pointing at a
+        // prerelease is refused rather than widened, like any other
+        // channel tag.
         let effective_range = if spec.range == "latest" {
             spec.range.clone()
         } else if let Some(tagged_version) = packument.dist_tags.get(&spec.range) {

--- a/vendor/aube/crates/aube/src/commands/dlx.rs
+++ b/vendor/aube/crates/aube/src/commands/dlx.rs
@@ -237,9 +237,18 @@ pub async fn run_in(
         let _cwd_guard = CwdGuard::switch_to(&project_dir)?;
         let mut opts = dlx_install_options(&allow_build);
         opts.project_dir = Some(project_dir.clone());
+        // A dlx request usually carries no version, so its synthesized range is
+        // the `latest` tag. When `minimumReleaseAge` blocks that tag the
+        // resolver now falls back to the newest release clearing the window
+        // (#681) — arm the sink so the substitution can be reported below.
+        aube_util::arm_age_gate_downgrade_collection();
         let install_result = super::install::run(opts).await;
+        // Drained unconditionally, before the `?`, so a failed install cannot
+        // leak entries into a later in-process command.
+        let downgrades = aube_util::take_age_gate_downgrades();
         let prev = _cwd_guard.original.clone();
         install_result.wrap_err("dlx install failed")?;
+        report_age_gate_downgrades(&downgrades);
         prev
         // _cwd_guard drops here, restoring cwd.
     };
@@ -326,6 +335,47 @@ pub async fn run_in(
         return Ok(Some(aube_scripts::exit_code_from_status(status)));
     }
     Ok(None)
+}
+
+/// The notice for a `latest` request `minimumReleaseAge` steered to an older
+/// release: one line per package, then a single line carrying the remedies.
+///
+/// Unlike an install, dlx leaves nothing behind to inspect — the scratch
+/// project is deleted the moment the tool exits, and the exclude auto-persist
+/// deliberately does not run for a throwaway project — so this notice is the
+/// only place a user can learn that the tool they ran is not the one they
+/// asked for.
+fn age_gate_downgrade_lines(downgrades: &[aube_util::AgeGateDowngrade]) -> Vec<String> {
+    if downgrades.is_empty() {
+        return Vec::new();
+    }
+    let mut lines: Vec<String> = downgrades
+        .iter()
+        .map(|d| {
+            format!(
+                "warn: the latest {} release ({}) is younger than minimumReleaseAge; using {} instead",
+                d.name, d.blocked, d.picked
+            )
+        })
+        .collect();
+    let exempt = downgrades
+        .iter()
+        .map(|d| format!("--minimum-release-age-exclude={}", d.name))
+        .collect::<Vec<_>>()
+        .join(" ");
+    lines.push(format!(
+        "help: to take the newest release anyway: `--minimum-release-age=0`, or `{exempt}`"
+    ));
+    lines
+}
+
+/// Print [`age_gate_downgrade_lines`] before the fetched tool runs — a non-zero
+/// child exit propagates straight out of this command, so a notice emitted
+/// afterwards would be lost exactly when something went wrong.
+fn report_age_gate_downgrades(downgrades: &[aube_util::AgeGateDowngrade]) {
+    for line in age_gate_downgrade_lines(downgrades) {
+        crate::progress::safe_eprintln(&line);
+    }
 }
 
 fn dlx_manifest(install_specs: &[String], allow_build: &[String]) -> serde_json::Value {
@@ -937,6 +987,56 @@ mod tests {
         let (name, value) = synthesize_dlx_dep("git+https://host/u/r.git#v1");
         assert_eq!(name, "r");
         assert_eq!(value, "git+https://host/u/r.git#v1");
+    }
+
+    fn downgrade(name: &str, picked: &str, blocked: &str) -> aube_util::AgeGateDowngrade {
+        aube_util::AgeGateDowngrade {
+            name: name.to_string(),
+            picked: picked.to_string(),
+            blocked: blocked.to_string(),
+        }
+    }
+
+    /// Nothing steered means nothing printed — the common case must stay silent.
+    #[test]
+    fn age_gate_downgrade_lines_are_empty_without_a_downgrade() {
+        assert!(age_gate_downgrade_lines(&[]).is_empty());
+    }
+
+    /// The reported case (#681). Both versions have to appear: which release
+    /// the window blocked, and which one is actually about to run.
+    #[test]
+    fn age_gate_downgrade_lines_name_both_versions_and_the_remedies() {
+        let lines = age_gate_downgrade_lines(&[downgrade("skills", "1.5.21", "1.5.22")]);
+        assert_eq!(
+            lines,
+            vec![
+                "warn: the latest skills release (1.5.22) is younger than minimumReleaseAge; \
+                 using 1.5.21 instead"
+                    .to_string(),
+                "help: to take the newest release anyway: `--minimum-release-age=0`, or \
+                 `--minimum-release-age-exclude=skills`"
+                    .to_string(),
+            ]
+        );
+    }
+
+    /// A `-p`-multi-package dlx gets a line per package but one remedy line,
+    /// and the exclude flag repeats rather than comma-joining — the settings
+    /// reader takes the LAST matching CLI entry, so a comma list would be one
+    /// entry it never splits.
+    #[test]
+    fn age_gate_downgrade_lines_repeat_the_exclude_flag_per_package() {
+        let lines = age_gate_downgrade_lines(&[
+            downgrade("a", "1.0.0", "1.1.0"),
+            downgrade("b", "2.0.0", "2.1.0"),
+        ]);
+        assert_eq!(lines.len(), 3, "two warnings and one help line: {lines:?}");
+        assert_eq!(
+            lines[2],
+            "help: to take the newest release anyway: `--minimum-release-age=0`, or \
+             `--minimum-release-age-exclude=a --minimum-release-age-exclude=b`"
+        );
     }
 
     #[test]


### PR DESCRIPTION
A request with no version synthesizes a `latest` range, which resolved to the tagged version's exact range — one candidate, so a `minimumReleaseAge` window covering it had nothing older to fall back to. A blocked `latest` now widens to `<=<tagged>`. Lenient mode had the mirror bug: the lone candidate got re-picked, bypassing the gate.

Bounded at the tag, and `latest` only. pnpm 11 repopulates every tag unbounded, which can hand back a retracted release. Rationale in the commit message.

Verified on the real registry: a merge-base build reproduces the error; this branch runs cowsay@1.5.0 with a notice. 10 new tests, each confirmed red for the right reason.

Closes #681
