### PR TITLE
feat(install): --os / --cpu / --libc for per-invocation platform selection

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -2218,6 +2218,13 @@ fn value_consuming_flags(subcommand: &str) -> &'static [&'static str] {
             "--cwd",
             "--minimum-release-age",
             "--minimum-release-age-exclude",
+            // Platform selection is value-taking too, and the sibling list in
+            // `install_to_add_args` needed the same three. `nubx --os linux -p
+            // left-pad pad` would otherwise split at `linux`, pushing `-p
+            // left-pad` into the forwarded suffix instead of binding it.
+            "--os",
+            "--cpu",
+            "--libc",
         ],
         "watch" => &["--cwd"],
         _ => &[],
@@ -12899,6 +12906,34 @@ mod tests {
         );
         assert_eq!(bin, "tanstack", "the positional is the bin to run");
         assert_eq!(args, vec!["--help".to_string()], "post-bin args forward");
+    }
+
+    /// `value_consuming_flags("nubx")` and `install_to_add_args`'s `VALUE_FLAGS`
+    /// are two hand-maintained lists carrying the same contract, so a flag added
+    /// to one is easy to forget in the other. The miss is silent in the worst
+    /// way here: `nubx --os linux cowsay` alone comes out right, and only a
+    /// SECOND nubx-owned flag after the value exposes the bad split.
+    #[test]
+    fn nubx_platform_flag_values_do_not_steal_the_positional() {
+        for flag in ["--os", "--cpu", "--libc"] {
+            let Command::Nubx {
+                package, bin, args, ..
+            } = parse_nubx(&[flag, "linux", "-p", "left-pad", "pad", "--wrap"])
+            else {
+                unreachable!()
+            };
+            assert_eq!(
+                package,
+                vec!["left-pad".to_string()],
+                "{flag}'s value must not be read as the bin, which leaves -p to forward"
+            );
+            assert_eq!(bin, "pad", "the positional is still the bin: {flag}");
+            assert_eq!(
+                args,
+                vec!["--wrap".to_string()],
+                "only post-bin args forward: {flag}"
+            );
+        }
     }
 
     #[test]

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -999,6 +999,12 @@ pub enum Command {
         #[command(flatten)]
         age_gate: crate::pm_engine::AgeGateFlags,
 
+        /// Which platforms' optional dependencies to install
+        /// (`--os`/`--cpu`/`--libc`), overriding host detection for this
+        /// run only. Mirrors pnpm's flags of the same names.
+        #[command(flatten)]
+        platform: crate::pm_engine::PlatformFlags,
+
         /// Remaining arguments forwarded to the binary.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -1172,6 +1178,12 @@ pub enum Command {
 
         #[command(flatten)]
         age_gate: crate::pm_engine::AgeGateFlags,
+
+        /// Which platforms' optional dependencies to install
+        /// (`--os`/`--cpu`/`--libc`), overriding host detection for this
+        /// run only. Mirrors pnpm's flags of the same names.
+        #[command(flatten)]
+        platform: crate::pm_engine::PlatformFlags,
     },
 
     /// Clean install for CI: delete node_modules, install strictly from the
@@ -1219,6 +1231,12 @@ pub enum Command {
 
         #[command(flatten)]
         age_gate: crate::pm_engine::AgeGateFlags,
+
+        /// Which platforms' optional dependencies to install
+        /// (`--os`/`--cpu`/`--libc`), overriding host detection for this
+        /// run only. Mirrors pnpm's flags of the same names.
+        #[command(flatten)]
+        platform: crate::pm_engine::PlatformFlags,
     },
 }
 
@@ -1450,6 +1468,13 @@ fn install_to_add_args(rest: &[String]) -> Option<Vec<String>> {
             // read `0` as a package and route the whole command to `add`.
             "--minimum-release-age",
             "--minimum-release-age-exclude",
+            // Platform selection, same shape: `nub install --os linux` would
+            // otherwise read `linux` as a package spec and route the whole
+            // command to `add`. The `--os=linux` form never had the problem,
+            // which is what makes omitting these easy to ship unnoticed.
+            "--os",
+            "--cpu",
+            "--libc",
         ];
         let mut i = 0;
         while i < body.len() {
@@ -2569,6 +2594,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             ignore_existing,
             no_check,
             age_gate,
+            platform,
             mut args,
         }) => {
             args.extend(suffix);
@@ -2579,6 +2605,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             // bag is inert on the local-bin path, so publish unconditionally
             // rather than duplicating the call into each branch.
             age_gate.apply();
+            platform.apply();
             filter.extend(workspace);
             let recursive = recursive || parallel || include_workspace_root;
             let workspace_run = recursive || !filter.is_empty() || parallel;
@@ -2693,8 +2720,10 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             include_workspace_root,
             output,
             age_gate,
+            platform,
         }) => {
             age_gate.apply();
+            platform.apply();
             crate::pm_engine::run_install(crate::pm_engine::InstallFlags {
                 frozen_lockfile,
                 no_frozen_lockfile,
@@ -2732,8 +2761,10 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             include_workspace_root,
             output,
             age_gate,
+            platform,
         }) => {
             age_gate.apply();
+            platform.apply();
             crate::pm_engine::run_ci(crate::pm_engine::CiFlags {
                 ignore_scripts,
                 no_optional,
@@ -10743,6 +10774,21 @@ mod tests {
             install_to_add_args(&args(&["install", "--loglevel", "silent", "react"])),
             Some(args(&["add", "--loglevel", "silent", "react"])),
             "--loglevel silent with a package routes to add, value is not mis-forwarded"
+        );
+        // Platform selection, same shape again. Only the SPACE form can
+        // misroute — `--os=linux` carries its value inside the token — so a
+        // test that checks just the `=` spelling proves nothing here.
+        for flag in ["--os", "--cpu", "--libc"] {
+            assert_eq!(
+                install_to_add_args(&args(&["install", flag, "linux"])),
+                None,
+                "nub install {flag} linux stays on the native install path"
+            );
+        }
+        assert_eq!(
+            install_to_add_args(&args(&["install", "--os", "linux", "react"])),
+            Some(args(&["add", "--os", "linux", "react"])),
+            "--os linux with a package routes to add, the os value is not mis-forwarded"
         );
     }
 

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1757,6 +1757,7 @@ mod tests {
         let actual = dlx_separate_value_flags();
         let expected = [
             "--cd",
+            "--cpu",
             "--dir",
             "--fetch-retries",
             "--fetch-retry-factor",
@@ -1765,9 +1766,11 @@ mod tests {
             "--fetch-timeout",
             "--filter",
             "--filter-prod",
+            "--libc",
             "--loglevel",
             "--minimum-release-age",
             "--minimum-release-age-exclude",
+            "--os",
             "--package",
             "--prefix",
             "--registry",

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -255,6 +255,17 @@ struct EngineGlobals {
     /// this struct.
     #[command(flatten)]
     age_gate: super::min_release_age::AgeGateFlags,
+
+    /// Per-invocation platform selection (`--os`/`--cpu`/`--libc`) — the same
+    /// three flags pnpm carries on `install`/`add`/`dlx`.
+    ///
+    /// Rides `EngineGlobals` for the reason `age_gate` does: the verbs that
+    /// consult it are exactly the ones that resolve (`add`, `update`,
+    /// `dedupe`, `import`, and `dlx`/`create` through their transient
+    /// install), and threading a second args group per-verb costs more than an
+    /// inert `--help` line on the rest.
+    #[command(flatten)]
+    platform: super::platform_flags::PlatformFlags,
 }
 
 impl EngineGlobals {
@@ -300,10 +311,11 @@ fn parse_verb<A: ClapArgs>(typed: &str, args: &[String]) -> Result<ParsedVerb<A>
     match verb_command::<A>(typed).try_get_matches_from(argv) {
         Ok(matches) => {
             let globals = EngineGlobals::from_arg_matches(&matches)?;
-            // Publish before the verb runs: the engine reads the age gate
-            // through process-global settings accessors, not through anything
-            // threaded into the verb's own args.
+            // Publish before the verb runs: the engine reads the age gate and
+            // the platform selection through process-global state, not through
+            // anything threaded into the verb's own args.
             globals.age_gate.apply();
+            globals.platform.apply();
             Ok(ParsedVerb::Run(globals, A::from_arg_matches(&matches)?))
         }
         Err(err) => {

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -62,6 +62,7 @@ pub mod log;
 pub mod min_release_age;
 pub mod output;
 pub mod phantom_closure;
+pub mod platform_flags;
 pub mod present;
 pub mod publish_family;
 mod resource_limits;
@@ -76,6 +77,7 @@ pub use install_family::{
 };
 pub use min_release_age::AgeGateFlags;
 pub use output::OutputFlags;
+pub use platform_flags::PlatformFlags;
 
 use std::path::{Path, PathBuf};
 

--- a/crates/nub-cli/src/pm_engine/platform_flags.rs
+++ b/crates/nub-cli/src/pm_engine/platform_flags.rs
@@ -1,0 +1,254 @@
+//! Per-invocation platform selection: `--os`, `--cpu`, `--libc`.
+//!
+//! These pick which platform-specific optional dependencies an install
+//! materializes — the capability pnpm exposes as the `supportedArchitectures`
+//! config object. Nub reads that config for compatibility, but the flags are
+//! the surface it documents, because the capability is an OVERRIDE of platform
+//! detection for one command rather than a durable property of a project. pnpm
+//! ships the same three flag names on `install`/`add`/`dlx`, so this is a
+//! parity gap being closed, not a Nub-only spelling.
+//!
+//! Two deliberate departures from pnpm, both additive — no configuration that
+//! works under pnpm changes meaning:
+//!
+//! - `*` selects every value on its axis. Under pnpm `*`, `any`, `!name`, and
+//!   an empty list each install ZERO platform packages and print nothing,
+//!   which is the feature's sharpest edge: four of the spellings a user
+//!   reaches for first fail silently.
+//! - An unrecognized value warns. That is what turns the remaining silent-zero
+//!   spellings into something a user can see.
+//!
+//! Nothing here is ever written back to a config file. A flagged install
+//! leaves `.npmrc`, `package.json`, and `pnpm-workspace.yaml` untouched, which
+//! is also what pnpm, npm, and Bun all do with their equivalents.
+
+use aube_util::CliSupportedArchitectures;
+
+/// Values that name no platform but that a user plausibly types, mapped to
+/// what to suggest instead. `any` is Bun's spelling of the wildcard and pnpm
+/// accepts it on the PACKAGE side, so it is the single most likely miss.
+const WILDCARD_LOOKALIKES: &[&str] = &["any", "all", "every", "*.*"];
+
+/// Platform values npm and Node actually emit, per axis. Used only to decide
+/// whether to WARN — an unknown value is still passed through, so a platform
+/// newer than this binary works without an upgrade.
+const KNOWN_OS: &[&str] = &[
+    "aix",
+    "android",
+    "darwin",
+    "freebsd",
+    "linux",
+    "netbsd",
+    "openbsd",
+    "openharmony",
+    "sunos",
+    "win32",
+];
+const KNOWN_CPU: &[&str] = &[
+    "arm", "arm64", "ia32", "loong64", "mips64el", "ppc64", "riscv64", "s390x", "x64",
+];
+const KNOWN_LIBC: &[&str] = &["glibc", "musl"];
+
+// (Plain `//`, not rustdoc: a `///` comment on a clap `Args` struct becomes the
+// augmented command's `--help` about-text and clobbers the verb's own — the
+// same hazard `AgeGateFlags` documents, which leaked onto `nub add --help`.)
+#[derive(Debug, Default, Clone, clap::Args)]
+pub struct PlatformFlags {
+    /// Operating system(s) to install optional dependencies for. Repeatable or
+    /// comma-separated. Use `current` for this machine's own, `*` for every
+    /// one. REPLACES any configured `supportedArchitectures.os`.
+    #[arg(long, value_name = "OS", value_delimiter = ',')]
+    pub os: Vec<String>,
+
+    /// CPU architecture(s) to install optional dependencies for. Repeatable or
+    /// comma-separated. Use `current` for this machine's own, `*` for every
+    /// one. REPLACES any configured `supportedArchitectures.cpu`.
+    #[arg(long, value_name = "CPU", value_delimiter = ',')]
+    pub cpu: Vec<String>,
+
+    /// C library/libraries to install optional dependencies for (`glibc`,
+    /// `musl`). Only consulted on Linux — no other platform's packages declare
+    /// one. REPLACES any configured `supportedArchitectures.libc`.
+    #[arg(long, value_name = "LIBC", value_delimiter = ',')]
+    pub libc: Vec<String>,
+}
+
+impl PlatformFlags {
+    /// Whether any axis was named on the command line.
+    pub fn is_empty(&self) -> bool {
+        self.os.is_empty() && self.cpu.is_empty() && self.libc.is_empty()
+    }
+
+    /// The per-axis override, with an empty axis meaning "not named" rather
+    /// than "select nothing". Clap cannot distinguish `--os` absent from
+    /// `--os` given no values, and the latter is a usage error it already
+    /// rejects, so an empty vec here is unambiguously absence.
+    fn override_set(&self) -> CliSupportedArchitectures {
+        let axis = |v: &Vec<String>| (!v.is_empty()).then(|| v.clone());
+        CliSupportedArchitectures {
+            os: axis(&self.os),
+            cpu: axis(&self.cpu),
+            libc: axis(&self.libc),
+        }
+    }
+
+    /// Warnings for values that will select nothing. Returns the lines to
+    /// print; the caller owns rendering so this stays testable.
+    ///
+    /// The check is a membership test against the known values rather than a
+    /// prediction about the actual dependency graph: a value that names no
+    /// platform can never match a package, whatever the project depends on. A
+    /// value that IS a platform but happens to match no package in this
+    /// particular tree is not a mistake and stays silent.
+    fn warnings(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        let mut check = |axis: &str, values: &[String], known: &[&str]| {
+            for v in values {
+                if v == "current" || v == "*" || known.contains(&v.as_str()) {
+                    continue;
+                }
+                let hint = if WILDCARD_LOOKALIKES.contains(&v.as_str()) {
+                    " — use `*` to select every one".to_string()
+                } else if let Some(negated) = v.strip_prefix('!') {
+                    format!(
+                        " — negation isn't supported here; list the {axis} values you want instead of excluding `{negated}`"
+                    )
+                } else {
+                    format!(" — known values are {}", known.join(", "))
+                };
+                out.push(format!(
+                    "nub: `--{axis} {v}` matches no platform, so no optional dependency will be selected for it{hint}."
+                ));
+            }
+        };
+        check("os", &self.os, KNOWN_OS);
+        check("cpu", &self.cpu, KNOWN_CPU);
+        check("libc", &self.libc, KNOWN_LIBC);
+        out
+    }
+
+    /// Publish the flags into the engine context and warn about values that
+    /// select nothing. One call covers the whole run: every platform-filter
+    /// site reads back through
+    /// `commands::install::settings::effective_supported_architectures`, so
+    /// nothing needs the value threaded down to it.
+    pub fn apply(&self) {
+        if self.is_empty() {
+            return;
+        }
+        for line in self.warnings() {
+            if super::scope_warning_uses_dim() {
+                eprintln!("\x1b[2m{line}\x1b[0m");
+            } else {
+                eprintln!("{line}");
+            }
+        }
+        let set = self.override_set();
+        aube_util::update_engine_context(move |c| c.cli_supported_architectures = set.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flags(os: &[&str], cpu: &[&str], libc: &[&str]) -> PlatformFlags {
+        let own = |v: &[&str]| v.iter().map(|s| s.to_string()).collect();
+        PlatformFlags {
+            os: own(os),
+            cpu: own(cpu),
+            libc: own(libc),
+        }
+    }
+
+    #[test]
+    fn an_unnamed_axis_stays_none_so_config_survives() {
+        let set = flags(&["linux"], &[], &[]).override_set();
+        assert_eq!(set.os.as_deref(), Some(["linux".to_string()].as_slice()));
+        assert!(
+            set.cpu.is_none(),
+            "naming --os must not clear a configured cpu axis"
+        );
+        assert!(set.libc.is_none(), "naming --os must not clear libc");
+    }
+
+    #[test]
+    fn current_and_wildcard_pass_through_without_warning() {
+        let f = flags(&["current", "*"], &["current", "x64"], &["musl"]);
+        assert!(
+            f.warnings().is_empty(),
+            "current/* are the documented spellings: {:?}",
+            f.warnings()
+        );
+    }
+
+    /// The `*` wildcard is Nub's addition — pnpm installs zero packages for it
+    /// — so it needs a guard, and the resolver mechanism it rides lives in
+    /// `vendor/aube`, where a test would never run under Nub's own gates. Drive
+    /// the public entry point from this side instead.
+    #[test]
+    fn wildcard_accepts_a_package_for_a_platform_that_is_not_the_host() {
+        let sel = |os: &[&str], cpu: &[&str]| aube_resolver::SupportedArchitectures {
+            os: os.iter().map(|s| s.to_string()).collect(),
+            cpu: cpu.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        let pkg_os = vec!["win32".to_string()];
+        let pkg_cpu = vec!["ia32".to_string()];
+
+        assert!(
+            aube_resolver::platform::is_supported(&pkg_os, &pkg_cpu, &[], &sel(&["*"], &["*"])),
+            "`*` on both axes must accept every platform variant"
+        );
+        assert!(
+            aube_resolver::platform::is_supported(&pkg_os, &pkg_cpu, &[], &sel(&["win32"], &["*"])),
+            "`*` on one axis must not constrain the other"
+        );
+        // The negative control: without the wildcard the same package is
+        // rejected, so the assertions above are testing the wildcard and not
+        // some blanket accept-everything path.
+        assert!(
+            !aube_resolver::platform::is_supported(
+                &pkg_os,
+                &pkg_cpu,
+                &[],
+                &sel(&["linux"], &["x64"])
+            ),
+            "a non-matching selection must still reject"
+        );
+    }
+
+    #[test]
+    fn wildcard_lookalikes_are_pointed_at_the_real_wildcard() {
+        let w = flags(&["any"], &[], &[]).warnings();
+        assert_eq!(w.len(), 1, "one bad value, one warning: {w:?}");
+        assert!(
+            w[0].contains("use `*`"),
+            "the fix for `any` is the real wildcard: {}",
+            w[0]
+        );
+    }
+
+    #[test]
+    fn negation_is_named_as_unsupported_rather_than_ignored() {
+        let w = flags(&["!win32"], &[], &[]).warnings();
+        assert_eq!(w.len(), 1, "{w:?}");
+        assert!(
+            w[0].contains("negation isn't supported"),
+            "a `!` value silently selects nothing under pnpm; say so: {}",
+            w[0]
+        );
+    }
+
+    #[test]
+    fn a_real_platform_never_warns_even_when_the_tree_has_no_such_package() {
+        // The check is "does this name a platform", not "does this tree
+        // contain one" — a cross-build for a platform you have no native dep
+        // for is legitimate and must stay quiet.
+        assert!(
+            flags(&["win32"], &["arm64"], &["glibc"])
+                .warnings()
+                .is_empty()
+        );
+    }
+}

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1307,3 +1307,50 @@ fn jailed_build_that_never_needs_node_gyp_survives_a_failed_bootstrap() {
         "the approved build script must still have run: {stderr}"
     );
 }
+
+/// `--os`/`--cpu` select which platform-specific optional deps get installed,
+/// overriding host detection for the run. The assertion is host-independent by
+/// construction: it names platforms explicitly and never mentions the host, so
+/// it reads the same on every CI leg.
+///
+/// The override is per AXIS — naming `--os` must leave a configured `cpu`
+/// alone. That is the behavior pnpm pins too, and it is the one a union
+/// implementation would silently get wrong (it would install darwin AND linux
+/// here instead of linux only).
+#[test]
+#[ignore = "network: installs esbuild from the npm registry"]
+fn platform_flags_override_the_named_axis_and_leave_the_others_configured() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("platform-flags");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"pf","private":true,"packageManager":"pnpm@10.15.1",
+            "dependencies":{"esbuild":"0.25.10"},
+            "pnpm":{"supportedArchitectures":{"os":["darwin"],"cpu":["arm64","x64"]}}}"#,
+    )
+    .unwrap();
+    let (_out, err, code) = run_install(&dir, &["install", "--os", "linux"]);
+    assert_eq!(code, 0, "flagged install must succeed: {err}");
+
+    let mut got: Vec<String> = std::fs::read_dir(dir.join("node_modules/.store"))
+        .unwrap_or_else(|e| panic!("no virtual store: {e}: {err}"))
+        .filter_map(|e| {
+            let name = e.unwrap().file_name().to_string_lossy().to_string();
+            name.strip_prefix("@esbuild+")
+                .and_then(|rest| rest.split('@').next())
+                .map(str::to_string)
+        })
+        .collect();
+    got.sort();
+
+    // `os` came from the flag and replaced `darwin`; `cpu` was never named, so
+    // both configured values survive. A union would also install darwin-*.
+    assert_eq!(
+        got,
+        vec!["linux-arm64".to_string(), "linux-x64".to_string()],
+        "--os must replace the configured os and leave cpu alone: {err}"
+    );
+}

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1354,3 +1354,76 @@ fn platform_flags_override_the_named_axis_and_leave_the_others_configured() {
         "--os must replace the configured os and leave cpu alone: {err}"
     );
 }
+
+/// A platform selection has to invalidate the install-freshness fast path in
+/// BOTH directions. The selection changes which prebuilt is correct, exactly as
+/// swapping machines does, but the host bytes are identical across a flagged
+/// and a bare run — so a flagged install on an already-installed tree reported
+/// "up to date" and fetched nothing, and dropping the flags again left the
+/// foreign tree in place. Neither is visible from a fresh-fixture test, which
+/// is why this one installs twice.
+#[test]
+#[ignore = "network: installs esbuild from the npm registry"]
+fn changing_the_platform_selection_re_materializes_an_already_installed_tree() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("platform-rematerialize");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"pr","private":true,"packageManager":"pnpm@10.15.1",
+            "dependencies":{"esbuild":"0.25.10"}}"#,
+    )
+    .unwrap();
+
+    // Whichever variant the host earns. Named rather than assumed, so the
+    // assertions below stay true on every CI leg.
+    let (_o, err, code) = run_install(&dir, &["install"]);
+    assert_eq!(code, 0, "baseline install must succeed: {err}");
+    let host_variants = linked_esbuild_variants(&dir);
+    assert_eq!(
+        host_variants.len(),
+        1,
+        "a plain install links exactly the host's variant, got {host_variants:?}: {err}"
+    );
+
+    // win32/x64 is never the host on any leg we run, so this is a real change.
+    let (_o, err, code) = run_install(&dir, &["install", "--os", "win32", "--cpu", "x64"]);
+    assert_eq!(
+        code, 0,
+        "flagged install over a warm tree must succeed: {err}"
+    );
+    assert_eq!(
+        linked_esbuild_variants(&dir),
+        vec!["win32-x64".to_string()],
+        "the warm tree must be re-materialized for the named platform: {err}"
+    );
+
+    // ...and back. The state a flagged install writes must not read as
+    // up-to-date for a bare one.
+    let (_o, err, code) = run_install(&dir, &["install"]);
+    assert_eq!(
+        code, 0,
+        "install after dropping the flags must succeed: {err}"
+    );
+    assert_eq!(
+        linked_esbuild_variants(&dir),
+        host_variants,
+        "dropping the flags must restore the host's own variant: {err}"
+    );
+}
+
+/// The `@esbuild/*` variants actually linked under the `esbuild` package —
+/// resolvable ones only, so a dangling link never counts as present.
+fn linked_esbuild_variants(dir: &Path) -> Vec<String> {
+    let nested = dir.join("node_modules/.store/esbuild@0.25.10/node_modules/@esbuild");
+    let mut out: Vec<String> = std::fs::read_dir(&nested)
+        .unwrap_or_else(|e| panic!("no nested @esbuild dir at {}: {e}", nested.display()))
+        .map(|e| e.unwrap().path())
+        .filter(|p| p.exists())
+        .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+    out.sort();
+    out
+}

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -343,7 +343,26 @@ The accepted flags are pnpm's spellings:
 --reporter <name>     # default, append-only, silent
 --silent, -s          # alias for --reporter=silent
 --loglevel <level>    # debug, info, warn, error, silent
+--os <os>             # which platforms' optional deps to install
+--cpu <arch>
+--libc <libc>
 ```
+
+Packages like `esbuild` and `rollup` ship one prebuilt binary per platform as optional dependencies, and an install picks only the one matching the machine it runs on. Pass `--os`, `--cpu`, or `--libc` to pick a different one — when building a Linux container image from a Mac, say:
+
+```bash
+nub install --os linux --cpu x64
+```
+
+Each flag is repeatable, takes a comma-separated list, and accepts `current` for the running machine and `*` for every value. Naming one axis leaves the others alone:
+
+```bash
+nub install --os linux                  # Linux binaries, host CPU
+nub install --os current,linux          # this machine's platform, and Linux
+nub install --os '*' --cpu '*'          # every platform variant
+```
+
+These apply to one invocation and are never written to a config file. They also override `supportedArchitectures` from `.npmrc`, `pnpm-workspace.yaml`, or the `pnpm` object in `package.json` — Nub reads that setting for pnpm compatibility, and a flag replaces only the axis it names. A value that names no platform warns rather than silently installing nothing.
 
 To quiet the progress output, pass `--silent` (or `-s`, or `--reporter=silent`): nothing reaches stderr but a fatal error, matching `pnpm install --silent`. The `--reporter=append-only` form drops the live progress display while keeping the dependency summary, and `--loglevel error` hides warnings without touching the rest. These spellings apply to every install-family command, and work either after the command (`nub install --silent`) or before it (`nub --silent install`).
 

--- a/site/content/docs/install/pnpm.mdx
+++ b/site/content/docs/install/pnpm.mdx
@@ -41,6 +41,7 @@ Nub mirrors pnpm most closely: the CLI surface, the isolated `node_modules` layo
     { feature: <><code>pnpm.overrides</code></>, status: 'yes' },
     { feature: <><code>pnpm.packageExtensions</code></>, status: 'yes' },
     { feature: <><code>pnpm.patchedDependencies</code></>, status: 'yes' },
+    { feature: <><code>pnpm.supportedArchitectures</code></>, status: 'yes', note: 'Also settable per-invocation with --os / --cpu / --libc.' },
     { feature: <><code>resolutions</code></>, status: 'yes' },
     { feature: <><code>onlyBuiltDependencies</code> / <code>neverBuiltDependencies</code></>, status: 'yes' },
     { feature: <><code>packageManager</code> / <code>engines</code></>, status: 'yes' },
@@ -104,6 +105,7 @@ When pnpm is the incumbent, Nub honors pnpm's configuration surface:
 - `pnpm.packageExtensions` — extra dependency/peer metadata merged onto resolved packages, hashed into the lockfile's `packageExtensionsChecksum`.
 - `pnpm.patchedDependencies` — patch files applied to dependency contents during linking, wired to `nub patch` / `patch-commit` / `patch-remove`.
 - `pnpm.onlyBuiltDependencies` / `pnpm.neverBuiltDependencies` / `pnpm.allowBuilds` — feed Nub's lifecycle-script policy.
+- `pnpm.supportedArchitectures` — which platforms' optional dependencies get installed. Also readable from `.npmrc` and `pnpm-workspace.yaml`, and overridable per axis for one run with [`--os` / `--cpu` / `--libc`](/docs/install#nub-install).
 - `.pnpmfile.cjs` / `.pnpmfile.mjs` — the `readPackage`, `preResolution`, and `afterAllResolved` hooks run. Dependency-map edits from `readPackage` apply; package-map edits from `afterAllResolved` apply. New importers/packages, identity rewrites, `updateConfig` hooks, and config-dependency pnpmfiles are not supported.
 
 ```yaml

--- a/vendor/aube/crates/aube-resolver/src/platform.rs
+++ b/vendor/aube/crates/aube-resolver/src/platform.rs
@@ -169,8 +169,15 @@ fn detect_linux_libc() -> &'static str {
 /// Apply npm's `os`/`cpu`/`libc` rules to a single (pkg_field, host)
 /// pair. An empty pkg array is unconstrained; negations reject; at
 /// least one positive entry means one must match.
+///
+/// `host` is the value being selected FOR — the host's own triple, or an
+/// entry the caller configured. The literal `*` there accepts any package
+/// value on this axis, which is what `--os='*'` selects. pnpm has no such
+/// spelling (it silently installs nothing), so this is additive: no config
+/// that works under pnpm changes meaning, and the shape users reach for
+/// first now does what it looks like.
 fn field_matches(pkg_field: &[String], host: &str) -> bool {
-    if pkg_field.is_empty() {
+    if pkg_field.is_empty() || host == "*" {
         return true;
     }
     let mut has_positive = false;

--- a/vendor/aube/crates/aube-util/src/engine_context.rs
+++ b/vendor/aube/crates/aube-util/src/engine_context.rs
@@ -29,6 +29,28 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::sync::{OnceLock, RwLock};
 
+/// Command-line platform selection, one entry per axis.
+///
+/// `None` means the axis was not named on the command line and keeps whatever
+/// the config sources resolved. `Some(list)` REPLACES that axis outright —
+/// naming `--os` does not disturb `--cpu`. A list may carry `current` (the
+/// host's own value) and `*` (accept any value on this axis); both are
+/// interpreted downstream by `aube_resolver::platform`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CliSupportedArchitectures {
+    pub os: Option<Vec<String>>,
+    pub cpu: Option<Vec<String>>,
+    pub libc: Option<Vec<String>>,
+}
+
+impl CliSupportedArchitectures {
+    /// Whether any axis was named. Call sites use this to skip the override
+    /// entirely rather than reasoning about three `None`s.
+    pub fn is_empty(&self) -> bool {
+        self.os.is_none() && self.cpu.is_none() && self.libc.is_none()
+    }
+}
+
 /// Per-invocation values an embedder computes and hands to aube.
 ///
 /// Every field defaults to aube's upstream behavior, so an unset context is
@@ -242,6 +264,20 @@ pub struct EngineContext {
     /// and global sources. Empty by default, preserving standalone behavior.
     pub project_config_settings: Vec<(String, String)>,
 
+    /// Per-axis platform selection supplied on the command line
+    /// (`--os` / `--cpu` / `--libc`). An axis set here REPLACES whatever the
+    /// config sources resolved for that axis; an axis left `None` keeps the
+    /// config value. This is an override rather than another source in the
+    /// union because the two answer different questions: the config homes say
+    /// what a project supports, the flags say what THIS invocation should
+    /// fetch — and a union can only ever widen. Never written back to a config
+    /// file; a flagged install leaves the project's files untouched. Reaches
+    /// every filter site through
+    /// `commands::install::settings::effective_supported_architectures`, which
+    /// is the single funnel they all share. Default-empty preserves standalone
+    /// behavior.
+    pub cli_supported_architectures: CliSupportedArchitectures,
+
     /// PATH entries prepended (in order, ahead of the existing PATH) to every
     /// lifecycle spawn. An embedder places a runtime shim dir first so a bare
     /// `node` in a build script resolves to the augmented runtime. Default
@@ -398,6 +434,7 @@ impl Default for EngineContext {
             synthetic_user_npmrc_entries: Vec::new(),
             synthetic_project_npmrc_entries: Vec::new(),
             project_config_settings: Vec::new(),
+            cli_supported_architectures: CliSupportedArchitectures::default(),
             path_prepends: Vec::new(),
             env_overlay: Vec::new(),
             runtime_node_dir: None,

--- a/vendor/aube/crates/aube-util/src/lib.rs
+++ b/vendor/aube/crates/aube-util/src/lib.rs
@@ -35,7 +35,8 @@ pub use identity::{
 // Convenience re-exports for the runtime embedder seam (the per-invocation
 // counterpart to `Embedder`).
 pub use engine_context::{
-    EngineContext, engine_context, set_engine_context, update_engine_context,
+    CliSupportedArchitectures, EngineContext, engine_context, set_engine_context,
+    update_engine_context,
 };
 pub mod path;
 pub mod pkg;

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -558,6 +558,16 @@ pub(crate) fn effective_package_extensions(
 /// `packageExtensions`. Unioning (rather than overriding) matches how the
 /// manifest and workspace-yaml sources already combine, and keeps the
 /// arch set additive across every config home.
+///
+/// Command-line `--os`/`--cpu`/`--libc`
+/// ([`aube_util::CliSupportedArchitectures`]) are applied LAST and per axis,
+/// REPLACING the unioned config value for each axis named rather than adding
+/// to it. Union is right between config homes, which all answer "what does
+/// this project support"; the flags answer "what should this invocation
+/// fetch", and a union could only ever widen — so `--os=linux` on a project
+/// whose config says `darwin` has to mean linux, not both. Every filter site
+/// routes through this function, so the override lands on the resolver, the
+/// streaming-fetch gate, and `filter_graph` alike.
 pub(crate) fn effective_supported_architectures(
     manifest: &aube_manifest::PackageJson,
     ws_config: &aube_manifest::workspace::WorkspaceConfig,
@@ -582,6 +592,17 @@ pub(crate) fn effective_supported_architectures(
     extend_field(&mut os, "os");
     extend_field(&mut cpu, "cpu");
     extend_field(&mut libc, "libc");
+
+    let cli = aube_util::engine_context().cli_supported_architectures;
+    if let Some(v) = cli.os {
+        os = v;
+    }
+    if let Some(v) = cli.cpu {
+        cpu = v;
+    }
+    if let Some(v) = cli.libc {
+        libc = v;
+    }
     (os, cpu, libc)
 }
 
@@ -972,8 +993,12 @@ pub(crate) fn configure_resolver(
     let resolve_peers_from_workspace_root_opt = resolve_peers_from_workspace_root(settings_ctx);
     let registry_supports_time_field = resolve_registry_supports_time_field(settings_ctx);
     let force_metadata_primer = resolve_force_metadata_primer(settings_ctx);
+    // The full funnel, not the manifest-only reader: this is a filter input
+    // like every other site, so an `.npmrc`-sourced object and a `--os`/`--cpu`
+    // /`--libc` flag have to reach it too. Only the non-portable-lockfile arm
+    // below consumes it — the portable kinds take `accept_all` instead.
     let (sup_os, sup_cpu, sup_libc) =
-        aube_manifest::effective_supported_architectures(manifest, workspace_config);
+        effective_supported_architectures(manifest, workspace_config, settings_ctx);
     // pnpm-lock.yaml, aube-lock.yaml, bun.lock, package-lock.json, and
     // npm-shrinkwrap.json are committed, cross-platform artifacts that
     // carry per-package os/cpu metadata.

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -1636,6 +1636,38 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     // returns empty string, harmless but stable.
     hasher.update(aube_resolver::platform::host_triple().2.as_bytes());
     hasher.update(b"\0");
+    // Command-line platform selection (`--os`/`--cpu`/`--libc`), which decides
+    // the same thing the host block above does — which prebuilts are correct —
+    // but from argv rather than from the machine. The host bytes are IDENTICAL
+    // across a flagged and a bare run, so without this a flagged install on a
+    // warm tree short-circuits as up-to-date and fetches nothing, and dropping
+    // the flags again leaves the foreign tree in place. Both directions have to
+    // re-materialize, which is why the selection is hashed rather than merely
+    // recorded. The config-sourced spelling of the same setting is already
+    // covered: the `pnpm` manifest key rides `INSTALL_SHAPE_FIELDS`, and
+    // `pnpm-workspace.yaml` / `.npmrc` are byte-hashed above — this closes the
+    // one path that was invisible.
+    //
+    // An axis nobody named contributes NOTHING, so an unflagged run in a
+    // process that never parsed the flags (`ensure_installed`, `verify_deps`)
+    // hashes exactly as it did before this existed.
+    hasher.update(b"archsel=");
+    let selection = aube_util::engine_context().cli_supported_architectures;
+    for (axis, values) in [
+        ("os", &selection.os),
+        ("cpu", &selection.cpu),
+        ("libc", &selection.libc),
+    ] {
+        let Some(values) = values else { continue };
+        hasher.update(axis.as_bytes());
+        hasher.update(b"=");
+        for v in values {
+            hasher.update(v.as_bytes());
+            hasher.update(b"\x1f");
+        }
+        hasher.update(b"\x1e");
+    }
+    hasher.update(b"\0");
     // Patches dir. patch-commit and patch-remove touch patches in
     // `<project>/patches/` and `.aube-patches.json`. Old fast path
     // did not hash either. User edits a patch file, next install


### PR DESCRIPTION
Selecting which platform-specific optional dependencies get installed was reachable only through pnpm's `supportedArchitectures` config object. That surface is an override of platform detection dressed as a project property: it is normally wanted for one command, it silently persists once committed, and a `nub.lock` project has no manifest home for it.

pnpm already ships `--os`/`--cpu`/`--libc` on install/add/dlx, so this closes a parity gap rather than inventing a spelling. Repeatable, comma-separated, accepts `current` and `*`, overrides config per axis, never persisted.

Two additions over pnpm, affecting only input pnpm rejects: `*` selects every value on an axis (pnpm installs zero for `*`, `any`, `!name`, and `[]`, silently), and a value naming no platform warns.

Verified against pnpm 10.15.1 on the same fixtures: `--os=linux --cpu=x64` gives an identical result; `--os linux` against config `{os:[darwin],cpu:[arm64,x64]}` yields linux-arm64 + linux-x64, confirming per-axis override; config-only behavior is unchanged.

Refs #677
