### PR TITLE
fix(sandbox): copy instead of hardlink for Windows-jailed installs

### DIFF
--- a/vendor/aube/crates/aube-linker/src/lib.rs
+++ b/vendor/aube/crates/aube-linker/src/lib.rs
@@ -311,7 +311,7 @@ pub struct Linker {
 }
 
 /// Strategy for linking files from the store to node_modules.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LinkStrategy {
     /// Copy-on-write (APFS clonefile, btrfs reflink). Selected only by
     /// explicit `packageImportMethod = clone` / `clone-or-copy`, whose

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -3,7 +3,7 @@ use miette::{Context, IntoDiagnostic, miette};
 use super::bin_linking::materialized_pkg_dir;
 use super::node_gyp_bootstrap;
 use super::side_effects_cache::{
-    Confinement, SideEffectsCacheConfig, SideEffectsCacheEntry, SideEffectsCacheRestore,
+    Confinement, CopyMode, SideEffectsCacheConfig, SideEffectsCacheEntry, SideEffectsCacheRestore,
 };
 
 /// Run a root-package lifecycle hook, announcing it to the user if defined
@@ -299,6 +299,61 @@ fn resolve_jail_grant_path(project_dir: &std::path::Path, raw: &str) -> std::pat
     }
 }
 
+/// On Windows, a confined lifecycle script cannot read a HARD-LINKED file, so
+/// the embedder's build jail forces per-file copy.
+///
+/// Windows attaches the security descriptor to the file OBJECT, not to the
+/// directory entry, so a store file hardlinked into the install keeps the
+/// descriptor it was created with under the content-addressed store. MEASURED on
+/// `windows-latest` (build-jail-corpus run 31126235717): the denied `install.js`
+/// carried `SYSTEM`/`Administrators`/`<user>` full control and NOT ONE ace marked
+/// `(I)`, while `fsutil hardlink list` named four entries for that single object,
+/// two of them inside the CAS. A descriptor that never auto-inherited is one
+/// advapi32's inheritance-propagation pass also skips, so the jail's inheritable
+/// grant lands on every sibling the linker CREATED and never on the linked one.
+/// Node starts, enters its own ESM loader, and dies at `getSourceSync` with
+/// `EPERM` — which is why win32 produced no corpus records at all.
+///
+/// COPY IS THE ONLY FIX THAT DOES NOT WIDEN THE SHARED STORE. The alternative —
+/// acing the file object — rewrites the descriptor EVERY other name for it sees,
+/// including the machine-global CAS entry every project on the machine hardlinks
+/// from; for a private registry that is source disclosure between packages. A
+/// copied file is created fresh inside the granted directory, which restores the
+/// create-then-inherit invariant the whole Windows grant path is built around
+/// (`nub_sandbox`'s `windows_publish_appcontainer_read`: grant the EMPTY
+/// directory, then populate it).
+///
+/// It overrides an explicit `packageImportMethod=hardlink` deliberately: that
+/// combination does not install at all here, so honoring the setting would only
+/// choose which way to break.
+///
+/// Pure, so the rule is unit-testable off Windows — same reason [`jail_enabled`]
+/// is.
+fn jail_forces_copy(
+    strategy: aube_linker::LinkStrategy,
+    windows: bool,
+    embedder_confines: bool,
+) -> aube_linker::LinkStrategy {
+    if windows && embedder_confines {
+        aube_linker::LinkStrategy::Copy
+    } else {
+        strategy
+    }
+}
+
+/// Whether the embedder's lifecycle sandbox will confine anything in this
+/// install, asked with no package identity because the strategy is resolved once
+/// for the whole link phase. Mirrors [`dep_confinement`]'s gate; aube's own
+/// `ScriptJail` is not consulted because it spawns into a `bwrap`/Seatbelt
+/// namespace rather than an AppContainer, and neither carries per-file ACLs.
+fn embedder_confines_any(project_dir: &std::path::Path) -> bool {
+    aube_util::embedder().embedder_owns_lifecycle_sandbox
+        && aube_util::engine_context()
+            .lifecycle_sandbox
+            .as_ref()
+            .is_some_and(|hook| hook.would_confine(None, None, project_dir))
+}
+
 /// Resolve the link strategy (reflink / hardlink / copy) from CLI
 /// override, `.npmrc` / `pnpm-workspace.yaml`, or filesystem detection.
 /// Shared by the prewarm-GVS materializer (which needs the strategy
@@ -427,7 +482,11 @@ pub(super) fn resolve_link_strategy(
             }
         }
     };
-    Ok(strategy)
+    Ok(jail_forces_copy(
+        strategy,
+        cfg!(windows),
+        embedder_confines_any(cwd),
+    ))
 }
 
 /// Walk every linked dependency, check its `package.json` for
@@ -774,6 +833,16 @@ pub(crate) async fn run_dep_lifecycle_scripts(
     let project_dir = project_dir.to_path_buf();
     let modules_dir_name = modules_dir_name.to_string();
     let should_restore_side_effects_cache = side_effects_cache.should_restore();
+    // THE SECOND SITE OF THE SAME WINDOWS DEFECT [`jail_forces_copy`] covers for the linker:
+    // a restored tree hardlinked out of the cache carries the CACHE entry's security
+    // descriptor, which the jail's inheritable grant on the package dir never reaches — so a
+    // LATER package's confined script cannot read a dependency that was restored rather than
+    // built. Restoring by copy costs the bytes and keeps the tree private to this install.
+    let restore_mode = if cfg!(windows) && embedder_confines_any(&project_dir) {
+        CopyMode::Copy
+    } else {
+        CopyMode::HardlinkOrCopy
+    };
     let should_save_side_effects_cache = side_effects_cache.should_save();
     let overwrite_side_effects_cache = side_effects_cache.overwrite_existing();
     let jail_policy = std::sync::Arc::new((*jail_policy).clone());
@@ -797,7 +866,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             {
                 let package_dir = job.package_dir.clone();
                 let restore_result = tokio::task::spawn_blocking(move || {
-                    cache_entry.restore_if_available(&package_dir)
+                    cache_entry.restore_if_available(&package_dir, restore_mode)
                 })
                 .await
                 .map_err(|e| {
@@ -1599,6 +1668,27 @@ mod tests {
         assert!(!jail_enabled(true, true, false));
         assert!(!jail_enabled(true, false, true));
         assert!(!jail_enabled(true, false, false));
+    }
+
+    #[test]
+    fn the_windows_build_jail_forces_copy_over_every_linking_strategy() {
+        use aube_linker::LinkStrategy::{Copy, Hardlink, Reflink, ReflinkAuto};
+        // The defect: a hardlink into the jail keeps the CAS file object's descriptor, so
+        // the confined script cannot read its own entry point. Reflink is downgraded for
+        // the same reason — `ReflinkAuto` falls back to `hard_link` on a filesystem that
+        // refuses the clone, which is exactly NTFS.
+        for probed in [Hardlink, ReflinkAuto, Reflink, Copy] {
+            assert_eq!(
+                jail_forces_copy(probed, true, true),
+                Copy,
+                "windows + a confining embedder must copy, whatever {probed:?} was probed"
+            );
+        }
+        // Neither half alone changes anything: the other platforms' jails carry no per-file
+        // ACLs, and an unconfined Windows install keeps the hardlink fast path.
+        assert_eq!(jail_forces_copy(Hardlink, false, true), Hardlink);
+        assert_eq!(jail_forces_copy(Hardlink, true, false), Hardlink);
+        assert_eq!(jail_forces_copy(ReflinkAuto, false, false), ReflinkAuto);
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/vendor/aube/crates/aube/src/commands/install/side_effects_cache.rs
@@ -170,9 +170,13 @@ impl SideEffectsCacheEntry {
         })
     }
 
+    /// `mode` is the caller's, not this type's: a hardlinked restore shares the cache
+    /// entry's inode, which a Windows build jail cannot read through (see
+    /// `lifecycle::jail_forces_copy`), so the confinement-aware caller picks.
     pub(super) fn restore_if_available(
         &self,
         package_dir: &std::path::Path,
+        mode: CopyMode,
     ) -> miette::Result<SideEffectsCacheRestore> {
         if self.marker_matches(package_dir) && self.path.is_dir() {
             tracing::debug!(
@@ -184,7 +188,7 @@ impl SideEffectsCacheEntry {
         if !self.path.is_dir() {
             return Ok(SideEffectsCacheRestore::Miss);
         }
-        copy_dir(&self.path, package_dir, CopyMode::HardlinkOrCopy).wrap_err_with(|| {
+        copy_dir(&self.path, package_dir, mode).wrap_err_with(|| {
             format!(
                 "failed to restore side effects cache from {}",
                 self.path.display()
@@ -679,7 +683,9 @@ mod tests {
         confined.save(&pkg, false).unwrap();
         assert!(
             matches!(
-                unconfined.restore_if_available(&pkg).unwrap(),
+                unconfined
+                    .restore_if_available(&pkg, CopyMode::HardlinkOrCopy)
+                    .unwrap(),
                 SideEffectsCacheRestore::Miss
             ),
             "the opt-out must miss the jail-built entry and rebuild"
@@ -771,7 +777,7 @@ mod tests {
         assert!(
             matches!(
                 entry(&root, &pkg, Some("26.5.0"))
-                    .restore_if_available(&pkg)
+                    .restore_if_available(&pkg, CopyMode::HardlinkOrCopy)
                     .unwrap(),
                 SideEffectsCacheRestore::AlreadyApplied
             ),
@@ -781,7 +787,9 @@ mod tests {
         let node22 = entry(&root, &pkg, Some("22.15.0"));
         assert!(
             matches!(
-                node22.restore_if_available(&pkg).unwrap(),
+                node22
+                    .restore_if_available(&pkg, CopyMode::HardlinkOrCopy)
+                    .unwrap(),
                 SideEffectsCacheRestore::Miss
             ),
             "another engine's marker must not stand in for this engine's missing entry"
@@ -794,7 +802,7 @@ mod tests {
         assert!(
             matches!(
                 entry(&root, &pkg, Some("26.5.0"))
-                    .restore_if_available(&pkg)
+                    .restore_if_available(&pkg, CopyMode::HardlinkOrCopy)
                     .unwrap(),
                 SideEffectsCacheRestore::Restored
             ),
@@ -819,7 +827,9 @@ mod tests {
         );
         assert!(
             matches!(
-                reread.restore_if_available(&pkg).unwrap(),
+                reread
+                    .restore_if_available(&pkg, CopyMode::HardlinkOrCopy)
+                    .unwrap(),
                 SideEffectsCacheRestore::Restored
             ),
             "an engineless marker must degrade to a restore, never to a skip"
@@ -827,7 +837,7 @@ mod tests {
         assert!(
             matches!(
                 entry(&root, &pkg, Some("26.5.0"))
-                    .restore_if_available(&pkg)
+                    .restore_if_available(&pkg, CopyMode::HardlinkOrCopy)
                     .unwrap(),
                 SideEffectsCacheRestore::AlreadyApplied
             ),


### PR DESCRIPTION
The Windows build jail refused every confined install script, which is why win32 has produced no corpus records. Node started, entered its own ESM loader, and died at `getSourceSync` with `EPERM` reading the package's own `install.js`.

**Mechanism.** Windows attaches the security descriptor to the file OBJECT, not the directory entry, so a store file hardlinked into the install keeps the descriptor it was created with under the CAS. MEASURED on `windows-latest` (build-jail-corpus run 31126235717): the denied file carried `SYSTEM`/`Administrators`/`<user>` full control with not one ace marked `(I)`, while `fsutil hardlink list` named four entries for that one object, two of them in the CAS. A descriptor that never auto-inherited is one advapi32's propagation pass also skips, so the jail's inheritable grant lands on every sibling the linker created and never on the linked one.

**Fix.** On Windows, when the embedder's lifecycle sandbox will confine, resolve `LinkStrategy::Copy`, and restore the side-effects cache by copy under the same condition — the second site of the same defect. A copied file is created inside the granted directory, which restores the create-then-inherit invariant the Windows grant path is built around.

**Rejected: acing the file object.** It rewrites the descriptor every OTHER name for that object sees, including the machine-global CAS entry every project on the machine hardlinks from. For a private registry that is source disclosure between packages.

**Cost.** Any Windows install that runs a lifecycle script loses CAS dedupe for that install. Narrowing it to the scripts' read closure needs the dep graph at link time and is not attempted here.

**Verification.** Red-then-green on the new unit test (inverting `jail_forces_copy` fails it). Root `clippy --all-targets --all-features`, `fmt --check`, and `cargo test -p nub-sandbox` green. The real proof is on Windows: build-jail-corpus run 31127907595 builds this branch and measures three arms, with a jail-OFF control that must still show a link count above one.

**Two corrections to the record:**
1. `win-acl-probe` step 0 self-invalidated — MSYS turned `icacls /grant` into `C:/Program Files/Git/grant`, so the hardlink-inheritance premise was never measured.
2. `win-acl-probe` restores a cached `nub.exe` under a prefix key, so re-running it cannot measure a new commit. The new `win-jail-copy-verify` workflow keys on the resolved SHA and builds on a miss.

**Side defect, not fixed here:** `set_ace` (`windows.rs:2381`) feeds the DACL it read — inherited aces included — back through `SetEntriesInAclW`, converting them to explicit aces on every granted path. That residue is visible on `C:\jail\a2` in the run above.

Refs the Windows build-jail bring-up.