### PR TITLE
runtime: refuse an explicit env file when Varlock owns the environment

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -5905,6 +5905,12 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
                 .as_ref()
                 .map(|p| nub_core::workspace::env::discover_env_files(&p.root))
                 .unwrap_or_default(),
+            // Gated for the same reason as the run path's `Sources` arm, and
+            // reachable the same way: an explicit source alongside a hand-over is
+            // refused up front, so arriving here owned means this watcher is itself
+            // running INSIDE the loader — where the flag that would have suppressed
+            // these paths did not survive the spawn but the config snapshot did.
+            RuntimeEnvFile::Sources(_) if env_owner_suppresses => Vec::new(),
             RuntimeEnvFile::Sources(paths) => paths.clone(),
             RuntimeEnvFile::Default | RuntimeEnvFile::Disabled => Vec::new(),
         }
@@ -6030,6 +6036,7 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
                 .as_ref()
                 .map(|p| nub_core::workspace::env::load_env_files_raw_warning(&p.root))
                 .unwrap_or_default(),
+            RuntimeEnvFile::Sources(_) if env_owner_suppresses => HashMap::new(),
             RuntimeEnvFile::Sources(paths) => load_runtime_env_sources_raw(paths)?,
             RuntimeEnvFile::Default | RuntimeEnvFile::Disabled => HashMap::new(),
         }

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3669,7 +3669,21 @@ fn runtime_child_env(
 /// `--prod` install, a partial `node_modules`), and running anyway would hand the
 /// program an environment it never asked for: no defaults, no validation, no
 /// providers, and for a schema-only project with no committed `.env`, nothing.
-fn check_schema_usable(env_owner: Option<&crate::env_owner::EnvOwner>) -> Result<()> {
+fn check_schema_usable(
+    env_owner: Option<&crate::env_owner::EnvOwner>,
+    runtime: &crate::project_config::RuntimeConfig,
+) -> Result<()> {
+    // Gated on `spawn_target`, not `suppresses_env_files`: the conflict is with the
+    // process that is about to HAND OVER. A nested nub already inside the loader
+    // also suppresses, but the user's flags do not live there — the outer
+    // invocation is where they were typed, and it has already refused.
+    if env_owner
+        .and_then(crate::env_owner::EnvOwner::spawn_target)
+        .is_some()
+        && let Some(source) = explicit_env_file_source(runtime)
+    {
+        bail!(crate::env_owner::explicit_env_file_conflict(source));
+    }
     let Some(problem) = env_owner.and_then(crate::env_owner::EnvOwner::schema_problem) else {
         return Ok(());
     };
@@ -3678,6 +3692,27 @@ fn check_schema_usable(env_owner: Option<&crate::env_owner::EnvOwner>) -> Result
     }
     warn_once(&format!("nub: {}", problem.message()));
     Ok(())
+}
+
+/// The explicit env-file instruction in play, named as the user spelled it.
+///
+/// Only LOAD instructions count. `--no-env-file` and `envFile: false` ask nub to
+/// load nothing, which is what standing down for an external owner already does, so
+/// neither contradicts a hand-over.
+fn explicit_env_file_source(
+    runtime: &crate::project_config::RuntimeConfig,
+) -> Option<&'static str> {
+    if no_env_file() {
+        return None;
+    }
+    if env_file_flag_present() {
+        return Some("`--env-file`");
+    }
+    matches!(
+        &runtime.env_file,
+        crate::project_config::RuntimeEnvFile::Sources(_)
+    )
+    .then_some("`envFile` in nub.jsonc")
 }
 
 /// Emit a startup notice at most once per process. Several launchers can resolve
@@ -3766,8 +3801,8 @@ fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path, exec_ua: bool
             })
         })
         .flatten();
+    check_schema_usable(env_owner.as_ref(), &runtime)?;
     let mut env_vars = runtime_child_env(&runtime, project_root, compat_mode, env_owner.as_ref())?;
-    check_schema_usable(env_owner.as_ref())?;
     if let Some((_, schema_dir)) = env_owner
         .as_ref()
         .and_then(crate::env_owner::EnvOwner::spawn_target)
@@ -4872,7 +4907,7 @@ fn build_script_command(
     let env_owner = (!compat_mode)
         .then(|| crate::env_owner::detect(&project.root, project.workspace_root.as_deref()))
         .flatten();
-    check_schema_usable(env_owner.as_ref())?;
+    check_schema_usable(env_owner.as_ref(), &runtime)?;
     let runtime_node_options = if compat_mode {
         Vec::new()
     } else {
@@ -5831,6 +5866,7 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
                 .and_then(|p| crate::env_owner::detect(&p.root, p.workspace_root.as_deref()))
         })
         .flatten();
+    check_schema_usable(env_owner.as_ref(), &runtime)?;
     let env_owner_suppresses = env_owner
         .as_ref()
         .is_some_and(crate::env_owner::EnvOwner::suppresses_env_files);

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3620,9 +3620,10 @@ fn runtime_child_env(
     if no_env_file() {
         return Ok(HashMap::new());
     }
-    // An external loader owning env displaces nub's DEFAULT discovery only. An
-    // explicit `envFile` in nub.jsonc, like an explicit `--env-file`, is a
-    // deliberate instruction and still wins.
+    // An external loader owning env displaces every source, not just the default
+    // cascade: an explicit `--env-file` or `envFile` alongside a hand-over is
+    // refused up front, and anything that still reaches here owned came from the
+    // inherited config snapshot inside the loader, where refusing is too late.
     let owner = env_owner.filter(|owner| owner.suppresses_env_files());
     let base = if compat_mode {
         HashMap::new()
@@ -3636,7 +3637,16 @@ fn runtime_child_env(
                     .map(nub_core::workspace::env::load_env_files)
                     .unwrap_or_default(),
             },
-            RuntimeEnvFile::Sources(paths) => load_runtime_env_sources(paths)?,
+            // Consults `owner` for the same reason the arm above does, and this is
+            // the arm that MUST: the outer process refuses an explicit source
+            // alongside a hand-over, so the only way to arrive here owned is from
+            // INSIDE the loader — where `--no-env-file` did not survive the spawn
+            // but the config snapshot did, leaving these paths to load with nothing
+            // left to suppress them.
+            RuntimeEnvFile::Sources(paths) => match owner {
+                Some(_) => HashMap::new(),
+                None => load_runtime_env_sources(paths)?,
+            },
             RuntimeEnvFile::Default | RuntimeEnvFile::Disabled => HashMap::new(),
         }
     };
@@ -3656,19 +3666,23 @@ fn runtime_child_env(
     Ok(result)
 }
 
-/// Warn once when a project carries an `@env-spec` schema that nothing can read.
+/// Every env-owner diagnostic nub raises, in the order they can fire.
 ///
-/// This is nub's ONLY env-owner diagnostic. When the loader IS installed nub says
-/// nothing at all: it stands down, puts the loader in front of Node, and the
-/// loader owns everything from there — including its own errors.
-/// Report an `@env-spec` schema nub cannot act on — fatally when the project
-/// asked for the loader and it is missing.
+/// 1. A CONFLICT — the project both hands the environment over and names files for
+///    nub to load. Refused, because whichever nub picked, the other would vanish
+///    with nothing printed to say so.
+/// 2. A schema nub cannot act on — fatal when the project declared the loader and
+///    it will not resolve, a warning when it never declared one at all.
 ///
 /// Falling back to `.env*` is right for a project that never declared the loader
 /// and wrong for one that did. In the second case the tree is broken (a pruned
 /// `--prod` install, a partial `node_modules`), and running anyway would hand the
 /// program an environment it never asked for: no defaults, no validation, no
 /// providers, and for a schema-only project with no committed `.env`, nothing.
+///
+/// When the loader IS installed and nothing conflicts, nub says nothing at all: it
+/// stands down, puts the loader in front of Node, and the loader owns everything
+/// from there — including its own errors.
 fn check_schema_usable(
     env_owner: Option<&crate::env_owner::EnvOwner>,
     runtime: &crate::project_config::RuntimeConfig,
@@ -3706,7 +3720,18 @@ fn explicit_env_file_source(
         return None;
     }
     if env_file_flag_present() {
-        return Some("`--env-file`");
+        // Both spellings set the same presence flag, so recover which one the user
+        // actually typed from the recorded flavors — naming a flag they never used
+        // sends them looking for it. Mixed spellings name the plain form, which is
+        // the one that errors on a missing file and so the stronger instruction.
+        let if_exists_only = ENV_FILE_PATHS.get().is_some_and(|paths| {
+            !paths.is_empty() && paths.iter().all(|(_, if_exists)| *if_exists)
+        });
+        return Some(if if_exists_only {
+            "`--env-file-if-exists`"
+        } else {
+            "`--env-file`"
+        });
     }
     matches!(
         &runtime.env_file,

--- a/crates/nub-cli/src/env_owner.rs
+++ b/crates/nub-cli/src/env_owner.rs
@@ -87,6 +87,24 @@ impl SchemaProblem {
     }
 }
 
+/// The error for an explicit env-file instruction alongside an external owner.
+///
+/// Both are deliberate and they contradict: one asks nub to load a file set, the
+/// other says the loader owns the environment end to end. Letting either win
+/// silently drops half of what the project asked for, and the dropped half is
+/// invisible — nothing prints which files did or did not arrive. So nub refuses and
+/// names both sides.
+///
+/// `--no-env-file` is deliberately NOT one of these. It asks nub to load nothing,
+/// which is what standing down already does; only a LOAD instruction contradicts
+/// the hand-over.
+pub(crate) fn explicit_env_file_conflict(source: &str) -> String {
+    format!(
+        "{source} conflicts with {SCHEMA_FILE} — {LOADER_PACKAGE} owns the environment.\n\
+         Use one or the other."
+    )
+}
+
 /// A project whose environment belongs to an external loader.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct EnvOwner {

--- a/crates/nub-cli/tests/env_owner.rs
+++ b/crates/nub-cli/tests/env_owner.rs
@@ -557,11 +557,33 @@ fn a_foreign_env_schema_is_left_alone_silently() {
     );
 }
 
+/// Run without asserting success — for the cases whose point IS the exit code.
+#[cfg(unix)]
+fn try_run(dir: &Path, args: &[&str]) -> (bool, String, String) {
+    let node_dir = which_node_dir();
+    let output = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .env("PATH", &node_dir)
+        .env_remove("APP_ENV")
+        .env_remove("NODE_ENV")
+        .env_remove("NODE_OPTIONS")
+        .output()
+        .expect("spawn nub");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
 #[cfg(unix)]
 #[test]
-fn an_explicit_env_file_setting_overrides_the_stand_down() {
-    // Explicit beats inferred: a user who spells out `envFile` has asked for those
-    // files regardless of what a schema implies.
+fn an_explicit_env_file_alongside_the_loader_is_refused() {
+    // Two deliberate instructions that contradict: load THESE files, and the loader
+    // owns the environment. Whichever nub picked, the other would vanish silently —
+    // nothing prints which files did or did not arrive. So it refuses and names
+    // both. Previously the explicit setting simply won, which is the silent half.
     let dir = project(&[
         (".env.schema", "# ---\nA=1\n"),
         ("custom.env", "FROM_DOTENV=explicit\n"),
@@ -569,11 +591,58 @@ fn an_explicit_env_file_setting_overrides_the_stand_down() {
     ]);
     let tally = dir.path().join("tally");
     install_stub_loader(dir.path(), &tally);
-    let run = run(dir.path());
+
+    let (ok, stdout, stderr) = try_run(dir.path(), &["probe.mjs"]);
+    assert!(!ok, "the contradiction must not run; stdout: {stdout}");
+    assert!(
+        stderr.contains("envFile") && stderr.contains("varlock"),
+        "the error must name BOTH sides, so the user knows which two things collided; \
+         stderr: {stderr}"
+    );
+    assert!(
+        !tally.exists(),
+        "and must refuse BEFORE spawning the loader"
+    );
+
+    // Same collision from the command line, which is the likelier way to hit it.
+    let (ok, _, stderr) = try_run(dir.path(), &["--env-file=custom.env", "probe.mjs"]);
+    assert!(!ok, "an explicit --env-file must be refused too");
+    assert!(
+        stderr.contains("--env-file"),
+        "the error must name the flag the user actually typed, not the config field; \
+         stderr: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn an_explicit_env_file_is_fine_without_a_loader() {
+    // The control for the test above: same flag, no schema. Without this, that test
+    // would pass just as well if `--env-file` were broken outright.
+    let dir = project(&[("custom.env", "FROM_DOTENV=explicit\n")]);
+    let run = run_args(dir.path(), &["--env-file=custom.env", "probe.mjs"]);
     assert_eq!(
         run.var("FROM_DOTENV").as_deref(),
         Some("explicit"),
-        "an explicit envFile must still load. stderr: {}",
+        "with no loader in play an explicit env file must still load. stderr: {}",
+        run.stderr
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn loading_nothing_does_not_conflict_with_the_loader() {
+    // `--no-env-file` asks nub to load nothing, which is exactly what standing down
+    // for the loader already does. Only a LOAD instruction contradicts a hand-over,
+    // so this must still run — and still run THROUGH the loader.
+    let dir = project(&[(".env.schema", "# ---\nA=1\n")]);
+    let tally = dir.path().join("tally");
+    install_stub_loader(dir.path(), &tally);
+    let run = run_args(dir.path(), &["--no-env-file", "probe.mjs"]);
+    assert_eq!(
+        run.var("FROM_LOADER").as_deref(),
+        Some("yes"),
+        "--no-env-file must not disturb the hand-over. stderr: {}",
         run.stderr
     );
 }

--- a/crates/nub-cli/tests/env_owner.rs
+++ b/crates/nub-cli/tests/env_owner.rs
@@ -631,6 +631,60 @@ fn an_explicit_env_file_is_fine_without_a_loader() {
 
 #[cfg(unix)]
 #[test]
+fn no_env_file_does_not_smuggle_config_sources_past_the_loader() {
+    // The one path the outer refusal cannot cover. `--no-env-file` is classified as
+    // a non-conflict, so nub hands over — but the flag does not survive the spawn
+    // while the config snapshot does, so the nested nub inside the loader used to
+    // load `envFile` sources with nothing left to suppress them. Asking for LESS
+    // loading produced MORE than the default, silently.
+    let dir = project(&[
+        (".env.schema", "# ---\nA=1\n"),
+        ("custom.env", "FROM_DOTENV=smuggled\n"),
+        ("nub.jsonc", r#"{ "envFile": ["custom.env"] }"#),
+    ]);
+    let tally = dir.path().join("tally");
+    install_stub_loader(dir.path(), &tally);
+    let run = run_args(dir.path(), &["--no-env-file", "probe.mjs"]);
+    assert_eq!(
+        run.var("FROM_DOTENV"),
+        None,
+        "an explicit envFile source must not reach the child once the loader owns \
+         the environment, from any process. stderr: {}",
+        run.stderr
+    );
+    assert_eq!(
+        run.var("FROM_LOADER").as_deref(),
+        Some("yes"),
+        "and the hand-over must still have happened. stderr: {}",
+        run.stderr
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn the_conflict_names_the_if_exists_flag_when_that_is_what_was_typed() {
+    // Both spellings set one presence flag, so the message used to say `--env-file`
+    // to a user who typed `--env-file-if-exists` — sending them to look for a flag
+    // that is not in their command.
+    let dir = project(&[
+        (".env.schema", "# ---\nA=1\n"),
+        ("custom.env", "FROM_DOTENV=explicit\n"),
+    ]);
+    let tally = dir.path().join("tally");
+    install_stub_loader(dir.path(), &tally);
+    let (ok, _, stderr) = try_run(
+        dir.path(),
+        &["--env-file-if-exists=custom.env", "probe.mjs"],
+    );
+    assert!(!ok, "the conflict must be refused for either spelling");
+    assert!(
+        stderr.contains("--env-file-if-exists"),
+        "the error must name the spelling the user typed; stderr: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn loading_nothing_does_not_conflict_with_the_loader() {
     // `--no-env-file` asks nub to load nothing, which is exactly what standing down
     // for the loader already does. Only a LOAD instruction contradicts a hand-over,

--- a/crates/nub-cli/tests/env_owner.rs
+++ b/crates/nub-cli/tests/env_owner.rs
@@ -271,6 +271,51 @@ fn nub_watch_also_puts_the_loader_in_front_of_node() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn a_watcher_inside_the_loader_does_not_load_config_sources() {
+    // `run_watch` builds its own env instead of going through `runtime_child_env`,
+    // so gating that function's `Sources` arm left this copy of the same hole open.
+    // Reachable because the wrap marker is INHERITED: any `nub watch` started by a
+    // program already running behind the loader arrives here owned, and used to
+    // load `envFile` sources the outer refusal had no chance to see.
+    let dir = project(&[
+        (".env.schema", "# ---\nA=1\n"),
+        ("custom.env", "FROM_DOTENV=smuggled\n"),
+        ("nub.jsonc", r#"{ "envFile": ["custom.env"] }"#),
+    ]);
+    let root = std::fs::canonicalize(dir.path()).expect("canonicalize");
+
+    let mut child = Command::new(nub_binary())
+        .args(["watch", "probe.mjs"])
+        .current_dir(dir.path())
+        .env("PATH", which_node_dir())
+        .env("__NUB_ENV_OWNER_WRAPPED", &root)
+        .env_remove("NODE_OPTIONS")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn nub watch");
+
+    let stdout = child.stdout.take().expect("piped stdout");
+    let first_line = std::thread::spawn(move || {
+        use std::io::BufRead;
+        std::io::BufReader::new(stdout)
+            .lines()
+            .map_while(Result::ok)
+            .find(|line| line.contains("FROM_DOTENV"))
+    });
+    let line = wait_for(first_line, std::time::Duration::from_secs(60));
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let line = line.expect("nub watch printed no probe output within 60s");
+    assert!(
+        line.contains(r#""FROM_DOTENV":null"#),
+        "a watcher behind the loader must not load explicit envFile sources; got: {line}"
+    );
+}
+
 /// Join a reader thread with a deadline, so a hung watcher fails the test rather
 /// than the suite.
 #[cfg(unix)]

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -285,6 +285,8 @@ Paths expand `${VAR}` and `$VAR` against the environment, which a config file ne
 APP_ENV=staging nub app.ts   # reads .env.staging
 ```
 
+Naming files here while [Varlock](/docs/runtime/varlock) owns the environment is a contradiction, and Nub refuses rather than picking a winner. Setting `false` is fine — it asks Nub to load nothing, which is what handing over already does.
+
 ### `loader`
 
 Teach Nub an extension it does not already know, by mapping it onto a loader it has.

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -98,6 +98,14 @@ A missing file is an error. To load a file only when it is present and skip sile
 nub --env-file-if-exists=.env.local server.ts
 ```
 
+Naming a file while [Varlock](/docs/runtime/varlock) owns the environment is a contradiction, so Nub refuses rather than picking a winner:
+
+```console
+$ nub --env-file=.env.ci server.ts
+Error: `--env-file` conflicts with .env.schema — varlock owns the environment.
+Use one or the other.
+```
+
 ## Loading nothing
 
 Pass `--no-env-file` to load zero env files: the automatic `.env*` discovery is suppressed and any `--env-file` or `--env-file-if-exists` is ignored. Everything else Nub does — TypeScript, JSX, the module hooks — stays on. Reach for it when the environment is already managed elsewhere (CI, a secret manager, `direnv`) and you want Nub to keep its hands off.

--- a/site/content/docs/runtime/varlock.mdx
+++ b/site/content/docs/runtime/varlock.mdx
@@ -3,14 +3,9 @@ title: Varlock
 description: First-party Varlock support — a project carrying an env-spec schema hands environment loading over entirely, so validation, providers, secret redaction, and type generation all happen on Varlock's own terms.
 ---
 
-Nub has first-party support for [Varlock](https://varlock.dev). Add it to a project and Nub stops loading `.env*` files, handing your environment to Varlock instead — no wrapper command, no import in your source, no configuration.
+Nub has first-party support for [Varlock](https://varlock.dev). 
 
-```bash
-nub add -D varlock    # then write a .env.schema
-nub server.ts         # validated, with secrets redacted
-```
-
-An `@env-spec` schema declares your variables with types, validation, and which of them are secret, using comments as the schema language:
+Varlock is an environment loading and validation tool that lets you specify a declarative schema file for your environment: `.env.schema`. This file determines what environment files get loaded and validate individual variables.
 
 ```env-spec title=".env.schema"
 # @defaultSensitive=false
@@ -30,75 +25,18 @@ DATABASE_URL=
 STRIPE_SECRET_KEY=
 ```
 
-The schema holds no secrets, so it is safe to commit — and safe to hand to an agent.
+When Nub detects `.env.schema`, it *disables its own [environment loading](/docs/runtime/env)* and defers to Varlock for all file and script running. 
 
-## Handoff
-
-Nub does not resolve the schema, inject its values, or redact anything. It puts Varlock in front of Node and steps out of the way:
-
-```bash
-varlock run --path <the schema's directory> -- node server.ts
+```sh
+nub index.ts
+nub run dev
 ```
 
-That indirection is the point. A schema is a graph, not a file list: it picks its own environment selector with `@currentEnv`, pulls values from providers, and can resolve differently depending on what you pass it. Only Varlock knows how to resolve it, so Nub does not try, and there is no second interpretation to drift out of sync.
-
-Everything Varlock does on its own works unchanged, because it is running as itself:
-
-```bash
-APP_ENV=production nub server.ts   # or whatever selector your schema declares
-```
-
-Type generation, providers, validation, secret redaction — whatever your schema asks for happens, on Varlock's own terms. Nub adds nothing and takes nothing away.
-
-<Callout title="Watch mode">
-Varlock resolves once at `nub watch` startup and Node's `--watch` supervisor re-execs your program inside it, so values are fixed for the life of the watcher. Nub's own `.env*` files are re-read on every restart; Varlock's are not. Restart the watcher to pick up a changed value.
+<Callout title="Monorepos">
+If you're in a monorepo sub-package, Nub checks the package root for `.env.schema` first, then the workspace root.
 </Callout>
 
-## Redaction
+Nub uses the version of Varlock installed on your computer! It does not vendor Varlock. It checks your local project first for a locally installed version, then falls back to global `PATH` resolution.
 
-Anything marked `@sensitive` is masked on its way out, so a stray log line cannot leak a key:
 
-```ts title="server.ts"
-console.log(`connecting with ${process.env.STRIPE_SECRET_KEY}`);
-```
-
-```console
-$ nub server.ts | tee run.log
-connecting with sk▒▒▒▒▒
-```
-
-Varlock redacts a stream it is **piping** — `console` methods, raw `process.stdout.write`, and anything a subprocess prints. Attached to an interactive terminal it passes output through untouched, so the same line printed at a prompt is not masked. That is Varlock's behavior either way; running under Nub neither adds redaction nor removes it.
-
-## Detection
-
-Three things have to be true before Nub hands over.
-
-- A `.env.schema` in the project root, or in the workspace root above it
-- The file is actually `@env-spec` — a `# ---` divider or a `# @decorator` line
-- Varlock resolves, from `node_modules/.bin` up to the workspace root, then `PATH`
-
-The middle condition exists because the filename is contested. [dotenv-extended](https://www.npmjs.com/package/dotenv-extended) has used `.env.schema` for its own incompatible format since 2016, so Nub recognizes the name without claiming it: a schema written for another tool never routes your run through Varlock.
-
-## Monorepos
-
-Nub looks for the schema in your project root, then the workspace root, and points Varlock at whichever it finds. A workspace member with no schema of its own uses the one at the root, and a member that ships its own uses that instead.
-
-```bash
-cd pkgs/web && nub dev.ts   # resolves the schema at the workspace root
-```
-
-This is also what makes running from a subdirectory work. Varlock on its own takes its entry point from the current directory, so `cd src && varlock run -- node app.js` reports no `.env` files found; Nub passes the directory it found the schema in.
-
-## Conflicts
-
-Naming an env file explicitly while Varlock owns the environment is a contradiction, so Nub refuses rather than picking a winner:
-
-```console
-$ nub --env-file=.env.ci server.ts
-Error: `--env-file` conflicts with .env.schema — varlock owns the environment.
-Use one or the other.
-```
-
-The same holds for an [`envFile`](/docs/config#envfile) in `nub.jsonc`. Either instruction on its own is fine — together, whichever lost would be invisible, since nothing prints which files did and did not arrive.
-
-To turn the handoff off along with the rest of Nub's augmentation, use `--node` or `NODE_COMPAT=1`.
+Read the [Varlock docs](https://varlock.dev) for complete information.

--- a/site/content/docs/runtime/varlock.mdx
+++ b/site/content/docs/runtime/varlock.mdx
@@ -71,7 +71,7 @@ Varlock redacts a stream it is **piping** — `console` methods, raw `process.st
 
 ## Detection
 
-Three things have to be true. Miss any one of them and Nub keeps loading `.env*` exactly as it always has.
+Three things have to be true before Nub hands over.
 
 - A `.env.schema` in the project root, or in the workspace root above it
 - The file is actually `@env-spec` — a `# ---` divider or a `# @decorator` line

--- a/site/content/docs/runtime/varlock.mdx
+++ b/site/content/docs/runtime/varlock.mdx
@@ -1,11 +1,11 @@
 ---
 title: Varlock
-description: First-party Varlock support — a project carrying an env-spec schema hands environment loading over entirely, so validation, providers, secret redaction, and type generation all happen on Varlock's own terms.
+description: First-party Varlock support — a project carrying an env-spec schema turns off Nub's own environment loading and defers to Varlock, using whichever Varlock the project or your PATH provides.
 ---
 
-Nub has first-party support for [Varlock](https://varlock.dev). 
+Nub has first-party support for [Varlock](https://varlock.dev).
 
-Varlock is an environment loading and validation tool that lets you specify a declarative schema file for your environment: `.env.schema`. This file determines what environment files get loaded and validate individual variables.
+Varlock is an environment loading and validation tool that lets you specify a declarative schema file for your environment: `.env.schema`. The schema determines which environment files get loaded, and validates individual variables.
 
 ```env-spec title=".env.schema"
 # @defaultSensitive=false
@@ -25,7 +25,7 @@ DATABASE_URL=
 STRIPE_SECRET_KEY=
 ```
 
-When Nub detects `.env.schema`, it *disables its own [environment loading](/docs/runtime/env)* and defers to Varlock for all file and script running. 
+When Nub detects `.env.schema`, it *disables its own [environment loading](/docs/runtime/env)* and defers to Varlock for all file and script running.
 
 ```sh
 nub index.ts
@@ -37,6 +37,5 @@ If you're in a monorepo sub-package, Nub checks the package root for `.env.schem
 </Callout>
 
 Nub uses the version of Varlock installed on your computer! It does not vendor Varlock. It checks your local project first for a locally installed version, then falls back to global `PATH` resolution.
-
 
 Read the [Varlock docs](https://varlock.dev) for complete information.

--- a/site/content/docs/runtime/varlock.mdx
+++ b/site/content/docs/runtime/varlock.mdx
@@ -1,6 +1,6 @@
 ---
 title: Varlock
-description: First-party Varlock support — a project carrying an env-spec schema hands environment loading over entirely, so validation, providers, secret redaction, and type generation all happen on Varlock's own terms, in monorepos and from subdirectories included.
+description: First-party Varlock support — a project carrying an env-spec schema hands environment loading over entirely, so validation, providers, secret redaction, and type generation all happen on Varlock's own terms.
 ---
 
 Nub has first-party support for [Varlock](https://varlock.dev). Add it to a project and Nub stops loading `.env*` files, handing your environment to Varlock instead — no wrapper command, no import in your source, no configuration.
@@ -10,19 +10,29 @@ nub add -D varlock    # then write a .env.schema
 nub server.ts         # validated, with secrets redacted
 ```
 
-An `@env-spec` schema — conventionally `.env.schema` — declares your variables with types and validation, using comments as the schema language:
+An `@env-spec` schema declares your variables with types, validation, and which of them are secret, using comments as the schema language:
 
-```ini title=".env.schema"
+```env-spec title=".env.schema"
+# @defaultSensitive=false
+# @generateTypes(lang="ts", path="env.d.ts")
+# ---
+
 # @required @type=port
 PORT=3000
 
+# @required @type=enum(development, staging, production)
+APP_ENV=development
+
+# @required @sensitive @type=url
+DATABASE_URL=
+
 # @required @sensitive @type=string(startsWith=sk-)
-API_KEY=
+STRIPE_SECRET_KEY=
 ```
 
-The schema holds no secrets, so it is safe to commit. At runtime you get coercion, validation, and redaction on anything marked `@sensitive`.
+The schema holds no secrets, so it is safe to commit — and safe to hand to an agent.
 
-## How the handoff works
+## Handoff
 
 Nub does not resolve the schema, inject its values, or redact anything. It puts Varlock in front of Node and steps out of the way:
 
@@ -40,7 +50,26 @@ APP_ENV=production nub server.ts   # or whatever selector your schema declares
 
 Type generation, providers, validation, secret redaction — whatever your schema asks for happens, on Varlock's own terms. Nub adds nothing and takes nothing away.
 
-## When Nub hands over
+<Callout title="Watch mode">
+Varlock resolves once at `nub watch` startup and Node's `--watch` supervisor re-execs your program inside it, so values are fixed for the life of the watcher. Nub's own `.env*` files are re-read on every restart; Varlock's are not. Restart the watcher to pick up a changed value.
+</Callout>
+
+## Redaction
+
+Anything marked `@sensitive` is masked on its way out, so a stray log line cannot leak a key:
+
+```ts title="server.ts"
+console.log(`connecting with ${process.env.STRIPE_SECRET_KEY}`);
+```
+
+```console
+$ nub server.ts | tee run.log
+connecting with sk▒▒▒▒▒
+```
+
+Varlock redacts a stream it is **piping** — `console` methods, raw `process.stdout.write`, and anything a subprocess prints. Attached to an interactive terminal it passes output through untouched, so the same line printed at a prompt is not masked. That is Varlock's behavior either way; running under Nub neither adds redaction nor removes it.
+
+## Detection
 
 Three things have to be true. Miss any one of them and Nub keeps loading `.env*` exactly as it always has.
 
@@ -48,9 +77,9 @@ Three things have to be true. Miss any one of them and Nub keeps loading `.env*`
 - The file is actually `@env-spec` — a `# ---` divider or a `# @decorator` line
 - Varlock resolves, from `node_modules/.bin` up to the workspace root, then `PATH`
 
-The middle condition exists because the filename is contested. [dotenv-extended](https://www.npmjs.com/package/dotenv-extended) has used `.env.schema` for its own incompatible format since 2016, so Nub recognizes the name without claiming it: a schema written for another tool never routes your run through Varlock, and never draws a warning either.
+The middle condition exists because the filename is contested. [dotenv-extended](https://www.npmjs.com/package/dotenv-extended) has used `.env.schema` for its own incompatible format since 2016, so Nub recognizes the name without claiming it: a schema written for another tool never routes your run through Varlock.
 
-## Monorepos and subdirectories
+## Monorepos
 
 Nub looks for the schema in your project root, then the workspace root, and points Varlock at whichever it finds. A workspace member with no schema of its own uses the one at the root, and a member that ships its own uses that instead.
 
@@ -60,37 +89,16 @@ cd pkgs/web && nub dev.ts   # resolves the schema at the workspace root
 
 This is also what makes running from a subdirectory work. Varlock on its own takes its entry point from the current directory, so `cd src && varlock run -- node app.js` reports no `.env` files found; Nub passes the directory it found the schema in.
 
-## Redaction
+## Conflicts
 
-Varlock redacts a stream it is **piping** — `console` methods, raw `process.stdout.write`, and anything a subprocess prints. Attached to an interactive terminal it passes output through untouched, so a secret you print at a prompt is not redacted. That is Varlock's behavior either way; running under Nub neither adds redaction nor removes it.
+Naming an env file explicitly while Varlock owns the environment is a contradiction, so Nub refuses rather than picking a winner:
 
-## Keeping Nub's own loading
-
-The handoff displaces automatic `.env*` discovery only. Naming a file explicitly is a deliberate instruction, and it still wins:
-
-```bash
-nub --env-file=.env.ci server.ts   # loads .env.ci; Varlock does not run
+```console
+$ nub --env-file=.env.ci server.ts
+Error: `--env-file` conflicts with .env.schema — varlock owns the environment.
+Use one or the other.
 ```
 
-The same holds for an [`envFile`](/docs/config#envfile) in `nub.jsonc`. To turn the handoff off along with the rest of Nub's augmentation, use `--node` or `NODE_COMPAT=1`.
+The same holds for an [`envFile`](/docs/config#envfile) in `nub.jsonc`. Either instruction on its own is fine — together, whichever lost would be invisible, since nothing prints which files did and did not arrive.
 
-## When Varlock is not installed
-
-What Nub does depends on whether your project asked for Varlock, because the two cases mean different things.
-
-| Your `package.json` | What Nub does |
-|---|---|
-| Declares `varlock` | Fails, and tells you to run `nub install` |
-| Does not declare it | Loads `.env*` as usual, and warns once |
-
-A declared dependency that will not resolve means a broken tree — a pruned `--prod` install, a partial `node_modules`. Falling back to `.env*` there would hand your program an environment it never asked for: no defaults, no validation, no providers, and for a schema-only project with no committed `.env`, nothing at all. Nub refuses instead. With nothing declared, the project may simply not know the file means anything to Nub, so Nub keeps going and says so.
-
-## Watch mode
-
-Under `nub watch`, Varlock resolves once at watcher startup and Node's `--watch` supervisor re-execs your program inside it. Values are therefore fixed for the life of the watcher, where Nub's own `.env*` files are re-read on every restart. Editing a value means restarting the watcher.
-
-## Dependency install scripts
-
-A dependency's `postinstall` or build script does not get your schema. It runs with its own package directory as the working directory, so Nub anchors on that package's `package.json` and never looks as far up as your project root — the same reason those scripts do not see your `.env*` files either.
-
-Your own scripts are unaffected: `nub run build` runs at the project root, so the schema applies normally.
+To turn the handoff off along with the rest of Nub's augmentation, use `--node` or `NODE_COMPAT=1`.

--- a/site/source.config.ts
+++ b/site/source.config.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { rehypeCodeDefaultOptions } from 'fumadocs-core/mdx-plugins';
 import { transformerConsole } from './src/lib/shiki-console';
 import { transformerDiff } from './src/lib/shiki-diff';
+import { envSpecLang } from './src/lib/shiki-env-spec';
 import { remarkNodeVersion } from './src/lib/remark-node-version';
 import { remarkGithubAlerts } from './src/lib/remark-github-alerts';
 
@@ -57,6 +58,9 @@ export default defineConfig({
     // prompt, bright commands, dimmed output. See `src/lib/shiki-console.ts`.
     rehypeCodeOptions: {
       themes: { light: 'vesper', dark: 'vesper' },
+      // `langs` PRELOADS grammars; it does not restrict the bundled set, which
+      // stays lazily available. Only non-bundled languages need to be listed.
+      langs: [envSpecLang],
       // Keep fumadocs' default notation transformers (highlight/diff/focus/word)
       // and append the console terminal-look transformer.
       transformers: [

--- a/site/src/lib/env-spec.tmLanguage.json
+++ b/site/src/lib/env-spec.tmLanguage.json
@@ -1,0 +1,930 @@
+{
+  "scopeName": "source.env-spec",
+  "patterns": [
+    {
+      "comment": "Comment line - divider",
+      "match": "^\\s?(#)\\s?([-=~#]{3,})\\s*$",
+      "name": "comment.line.env-spec",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.comment"
+        }
+      }
+    },
+    {
+      "comment": "Comment line - divider w/ text",
+      "match": "^\\s?(#)\\s?([-=~#]{3,}.*)$",
+      "name": "comment.line.env-spec",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.comment"
+        },
+        "2": {
+          "name": "markup.bold.env-spec"
+        }
+      }
+    },
+    {
+      "comment": "Comment line - w/ decorators",
+      "begin": "^\\s?(#)\\s?(?=@)",
+      "end": "(\\s*#.*)?$",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment comment.line.env-spec"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "comment": "additional post comment",
+          "name": "comment.line.env-spec"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#decorator"
+        }
+      ]
+    },
+    {
+      "comment": "Comment line - no decorators",
+      "begin": "^\\s?(#)\\s?",
+      "end": "$",
+      "name": "comment.line.env-spec",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comment-markup"
+        }
+      ]
+    },
+
+    {
+      "comment": "ENV entry - 3x double quote",
+      "begin": "^\\s?(export\\s)?([a-zA-Z_]+[a-zA-Z0-9._-]*)\\s?(\\=)\\s?(\"\"\")",
+      "end": "(\"\"\")(.*)$",
+      "beginCaptures": {
+        "1": {
+          "patterns": [{ "include": "#export-item-prefix" }]
+        },
+        "2": {
+          "patterns": [{ "include": "#env-item-name" }]
+        },
+        "3": {
+          "name": "keyword.operator.assignment.env-spec"
+        },
+        "4": {
+          "name": "punctuation.definition.string.begin"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end"
+        },
+        "2": {
+          "name": "invalid",
+          "patterns": [{ "include": "#post-value-comment" }]
+        }
+      },
+      "contentName": "string.quoted.triple.env-spec",
+      "patterns": [
+        { "include": "#escape-characters" },
+        { "include": "#expansion" }
+      ]
+    },
+    {
+      "comment": "ENV entry - 3x backtick",
+      "begin": "^\\s?(export\\s)?([a-zA-Z_]+[a-zA-Z0-9._-]*)\\s?(\\=)\\s?(```)",
+      "end": "(```)(.*)$",
+      "beginCaptures": {
+        "1": {
+          "patterns": [{ "include": "#export-item-prefix" }]
+        },
+        "2": {
+          "patterns": [{ "include": "#env-item-name" }]
+        },
+        "3": {
+          "name": "keyword.operator.assignment.env-spec"
+        },
+        "4": {
+          "name": "punctuation.definition.string.begin"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end"
+        },
+        "2": {
+          "name": "invalid",
+          "patterns": [{ "include": "#post-value-comment" }]
+        }
+      },
+      "contentName": "string.quoted.triple.env-spec",
+      "patterns": [
+        { "include": "#escape-characters" },
+        { "include": "#expansion" }
+      ]
+    },
+    {
+      "comment": "ENV entry - single quote",
+      "begin": "^\\s?(export\\s)?([a-zA-Z_]+[a-zA-Z0-9._-]*)\\s?(\\=)\\s?(')",
+      "end": "(')(.*)$",
+      "beginCaptures": {
+        "1": {
+          "patterns": [{ "include": "#export-item-prefix" }]
+        },
+        "2": {
+          "patterns": [{ "include": "#env-item-name" }]
+        },
+        "3": {
+          "name": "keyword.operator.assignment.env-spec"
+        },
+        "4": {
+          "name": "punctuation.definition.string.begin"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end"
+        },
+        "2": {
+          "name": "invalid",
+          "patterns": [{ "include": "#post-value-comment" }]
+        }
+      },
+      "contentName": "string.quoted.single.env-spec",
+      "patterns": [{ "include": "#escape-characters" }]
+    },
+    {
+      "comment": "ENV entry - double quote",
+      "begin": "^\\s?(export\\s)?([a-zA-Z_]+[a-zA-Z0-9._-]*)\\s?(\\=)\\s?(\")",
+      "end": "(\")(.*)$",
+      "beginCaptures": {
+        "1": {
+          "patterns": [{ "include": "#export-item-prefix" }]
+        },
+        "2": {
+          "patterns": [{ "include": "#env-item-name" }]
+        },
+        "3": {
+          "name": "keyword.operator.assignment.env-spec"
+        },
+        "4": {
+          "name": "punctuation.definition.string.begin"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end"
+        },
+        "2": {
+          "name": "invalid",
+          "patterns": [{ "include": "#post-value-comment" }]
+        }
+      },
+      "contentName": "string.quoted.double.env-spec",
+      "patterns": [
+        { "include": "#escape-characters" },
+        { "include": "#expansion" }
+      ]
+    },
+    {
+      "comment": "ENV entry - backtick",
+      "begin": "^\\s?(export\\s)?([a-zA-Z_]+[a-zA-Z0-9._-]*)\\s?(\\=)\\s?(`)",
+      "end": "\n|(`)(.*)$",
+      "beginCaptures": {
+        "1": {
+          "patterns": [{ "include": "#export-item-prefix" }]
+        },
+        "2": {
+          "patterns": [{ "include": "#env-item-name" }]
+        },
+        "3": {
+          "name": "keyword.operator.assignment.env-spec"
+        },
+        "4": {
+          "name": "punctuation.definition.string.begin"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end"
+        },
+        "2": {
+          "name": "invalid",
+          "patterns": [{ "include": "#post-value-comment" }]
+        }
+      },
+      "contentName": "string.quoted.other.env-spec",
+      "patterns": [
+        { "include": "#escape-characters" },
+        { "include": "#expansion" }
+      ]
+    },
+
+    {
+      "comment": "ENV entry - unquoted (single line)",
+      "begin": "^\\s?(export\\s)?([a-zA-Z_]+[a-zA-Z0-9._-]*)\\s?(\\=)\\s*",
+      "end": "(\\s?#.*)?$",
+      "beginCaptures": {
+        "1": {
+          "patterns": [{ "include": "#export-item-prefix" }]
+        },
+        "2": {
+          "patterns": [{ "include": "#env-item-name" }]
+        },
+        "3": {
+          "name": "keyword.operator.assignment.env-spec"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "comment.line.env-spec",
+          "patterns": [{ "include": "#post-value-comment" }]
+        }
+      },
+      "patterns": [
+        { "include": "#bracket-literal-inline" },
+        { "include": "#literal-value" },
+        { "include": "#env-item-value-fn-call" },
+        { "include": "#expansion" },
+        {
+          "comment": "item value unquoted string",
+          "match": "([^#$]+)",
+          "name": "string.unquoted.env-spec",
+          "captures": {
+            "1": {
+              "patterns": [{ "include": "#escape-characters" }]
+            }
+          }
+        },
+        {
+          "comment": "extra $",
+          "match": "\\$",
+          "name": "string.unquoted.env-spec"
+        }
+      ]
+    },
+    {
+      "comment": "Closing paren on its own line (multi-line fn call)",
+      "match": "^\\s*(\\))\\s*$",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.parameters.end.env-spec"
+        }
+      },
+      "name": "meta.function-call.env-spec"
+    },
+    {
+      "comment": "Multi-line function call continuation (for item values)",
+      "begin": "^(\\s+)(?!#)",
+      "end": "$",
+      "name": "meta.function-call.env-spec",
+      "patterns": [
+        {
+          "comment": "comment inside a multi-line item-value fn call / literal",
+          "match": "#.*$",
+          "name": "comment.line.env-spec"
+        },
+        { "include": "#bracket-literal-item" },
+        { "include": "#literal-value" },
+        { "include": "#quoted-value" },
+        { "include": "#key-value-pair-item" },
+        { "include": "#env-item-value-fn-call" },
+        { "include": "#expansion" },
+        { "include": "#unquoted-string-within-fn-call" },
+        {
+          "comment": "extra $",
+          "match": "\\$",
+          "name": "string.unquoted.env-spec"
+        },
+        {
+          "match": "\\s*,\\s*",
+          "name": "punctuation.separator.comma.env-spec"
+        },
+        {
+          "match": "\\)",
+          "name": "punctuation.definition.parameters.end.env-spec"
+        }
+      ]
+    },
+    {
+      "comment": "invalid line",
+      "match": ".*",
+      "name": "invalid"
+    }
+  ],
+
+  "repository": {
+    "env-item-name": {
+      "comment": "env item name",
+      "match": ".*",
+      "name": "entity.name.tag.env-spec"
+    },
+    "export-item-prefix": {
+      "comment": "export item prefix",
+      "match": ".*",
+      "name": "markup.italic.env-spec keyword.control.export.env-spec"
+    },
+
+    "post-value-comment": {
+      "comment": "Post-value comment",
+      "begin": "(#)\\s?",
+      "end": "(\\s*#.*)?$",
+      "name": "comment.line.env-spec",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "comment": "additional post comment",
+          "name": "comment.line.env-spec"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#decorator"
+        },
+        {
+          "include": "#comment-markup"
+        }
+      ]
+    },
+    "comment-markup": {
+      "comment": "Comment markup",
+      "patterns": [
+        {
+          "match": "__.+__",
+          "name": "markup.italic.env-spec"
+        },
+        {
+          "match": "(?<= )_[^_]+_(?= |\\n)",
+          "name": "markup.italic.env-spec"
+        },
+        {
+          "match": "\\*\\*.+\\*\\*",
+          "name": "markup.bold.env-spec"
+        },
+        {
+          "match": "\\*.+\\*",
+          "name": "markup.bold.env-spec"
+        }
+      ]
+    },
+
+    "literal-value": {
+      "patterns": [
+        { "include": "#literal-value--boolean" },
+        { "include": "#literal-value--undefined" },
+
+        { "include": "#literal-value--numeric" }
+      ],
+      "repository": {
+        "literal-value--boolean": {
+          "comment": "Boolean item value",
+          "match": "(true|false)",
+          "name": "constant.language.boolean.env-spec"
+        },
+        "literal-value--undefined": {
+          "comment": "Undefined item value",
+          "match": "(undefined)",
+          "name": "constant.language.undefined.env-spec"
+        },
+        "literal-value--numeric": {
+          "comment": "Numeric item value",
+          "match": "[0-9]+(\\.[0-9]+)?(?=[\n ,)\\]}])",
+          "name": "constant.numeric.env-spec"
+        }
+      }
+    },
+
+    "bracket-literal": {
+      "comment": "DECORATOR-context object/array literal — multi-line, where each continuation line is prefixed by the comment-block `#`. Uses the structural-`#`-aware contents. Only reachable from decorator rules.",
+      "patterns": [
+        { "include": "#bracket-literal--object" },
+        { "include": "#bracket-literal--array" }
+      ]
+    },
+    "bracket-literal-item": {
+      "comment": "ITEM-context object/array literal — multi-line, used inside fn() calls in item values. Continuation lines are NOT `#`-prefixed, so a column-0 `#` is a real comment (no structural marker).",
+      "patterns": [
+        { "include": "#bracket-literal--object-item" },
+        { "include": "#bracket-literal--array-item" }
+      ]
+    },
+    "bracket-literal-inline": {
+      "comment": "Single-line object/array literal for bare item values (`KEY=[...]` / `KEY={...}`). Bare multi-line literals are not valid @env-spec — they require a fn() wrapper — so these close at the newline to avoid swallowing subsequent lines when a bracket is left unclosed.",
+      "patterns": [
+        { "include": "#bracket-literal--object-inline" },
+        { "include": "#bracket-literal--array-inline" }
+      ]
+    },
+    "bracket-literal--object": {
+      "comment": "Object literal { key=value, ... } (decorator context)",
+      "begin": "(\\{)",
+      "end": "(\\})",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.dictionary.begin.env-spec" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.dictionary.end.env-spec" }
+      },
+      "name": "meta.structure.dictionary.env-spec",
+      "patterns": [{ "include": "#bracket-literal--contents" }]
+    },
+    "bracket-literal--array": {
+      "comment": "Array literal [ value, ... ] (decorator context)",
+      "begin": "(\\[)",
+      "end": "(\\])",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.array.begin.env-spec" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.array.end.env-spec" }
+      },
+      "name": "meta.structure.array.env-spec",
+      "patterns": [{ "include": "#bracket-literal--contents" }]
+    },
+    "bracket-literal--object-item": {
+      "comment": "Object literal { key=value, ... } (item context — plain, non-`#`-prefixed lines)",
+      "begin": "(\\{)",
+      "end": "(\\})",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.dictionary.begin.env-spec" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.dictionary.end.env-spec" }
+      },
+      "name": "meta.structure.dictionary.env-spec",
+      "patterns": [{ "include": "#bracket-literal--contents-item" }]
+    },
+    "bracket-literal--array-item": {
+      "comment": "Array literal [ value, ... ] (item context — plain, non-`#`-prefixed lines)",
+      "begin": "(\\[)",
+      "end": "(\\])",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.array.begin.env-spec" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.array.end.env-spec" }
+      },
+      "name": "meta.structure.array.env-spec",
+      "patterns": [{ "include": "#bracket-literal--contents-item" }]
+    },
+    "bracket-literal--object-inline": {
+      "comment": "Single-line object literal — closes at `}` or end of line",
+      "begin": "(\\{)",
+      "end": "(\\})|(?=\\n)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.dictionary.begin.env-spec" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.dictionary.end.env-spec" }
+      },
+      "name": "meta.structure.dictionary.env-spec",
+      "patterns": [{ "include": "#bracket-literal--contents-item" }]
+    },
+    "bracket-literal--array-inline": {
+      "comment": "Single-line array literal — closes at `]` or end of line",
+      "begin": "(\\[)",
+      "end": "(\\])|(?=\\n)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.array.begin.env-spec" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.array.end.env-spec" }
+      },
+      "name": "meta.structure.array.env-spec",
+      "patterns": [{ "include": "#bracket-literal--contents-item" }]
+    },
+    "bracket-literal--contents": {
+      "comment": "Inner patterns for DECORATOR-context object/array literals. The structural `#` marker strips the comment-block prefix on each continuation line so the rest is parsed as literal content; nests the decorator-context literal/key-value-pair variants.",
+      "patterns": [
+        {
+          "comment": "structural # continuation marker (decorator context): strips the comment-block `#` prefix; indented item-value comments are handled by #bracket-literal--contents-item instead",
+          "match": "^\\s?#\\s*",
+          "name": "comment.line.env-spec punctuation.definition.comment"
+        },
+        {
+          "comment": "comment inside a literal (commented-out entry or trailing note)",
+          "match": "#.*$",
+          "name": "comment.line.env-spec"
+        },
+        { "include": "#bracket-literal" },
+        { "include": "#key-value-pair" },
+        { "include": "#env-item-value-fn-call" },
+        { "include": "#quoted-value" },
+        { "include": "#expansion" },
+        { "include": "#literal-value" },
+        { "include": "#unquoted-string-within-literal" },
+        {
+          "comment": "extra $",
+          "match": "\\$",
+          "name": "string.unquoted.env-spec"
+        },
+        {
+          "comment": "literal element separator",
+          "match": "\\s*,\\s*",
+          "name": "punctuation.separator.comma.env-spec"
+        }
+      ]
+    },
+    "bracket-literal--contents-item": {
+      "comment": "Inner patterns for ITEM-context object/array literals (inside fn() calls / bare values). No structural `#` marker — continuation lines are not comment-prefixed, so any `#` (column-0 or indented) is a full comment. Nests the item-context literal/key-value-pair variants.",
+      "patterns": [
+        {
+          "comment": "comment inside a literal — commented-out entry, full-line note (column-0 or indented), or trailing note",
+          "match": "#.*$",
+          "name": "comment.line.env-spec"
+        },
+        { "include": "#bracket-literal-item" },
+        { "include": "#key-value-pair-item" },
+        { "include": "#env-item-value-fn-call" },
+        { "include": "#quoted-value" },
+        { "include": "#expansion" },
+        { "include": "#literal-value" },
+        { "include": "#unquoted-string-within-literal" },
+        {
+          "comment": "extra $",
+          "match": "\\$",
+          "name": "string.unquoted.env-spec"
+        },
+        {
+          "comment": "literal element separator",
+          "match": "\\s*,\\s*",
+          "name": "punctuation.separator.comma.env-spec"
+        }
+      ]
+    },
+
+    "unquoted-string-within-literal": {
+      "comment": "unquoted value within a {}/[] literal (stops at , ) } ] and whitespace)",
+      "match": "([^ \n,)$\\]}]+)",
+      "name": "string.unquoted.env-spec",
+      "captures": {
+        "1": {
+          "patterns": [{ "include": "#escape-characters" }]
+        }
+      }
+    },
+
+    "quoted-value": {
+      "patterns": [
+        { "include": "#quoted-value--single" },
+        { "include": "#quoted-value--double" },
+        { "include": "#quoted-value--backtick" }
+      ],
+      "repository": {
+        "quoted-value--double": {
+          "comment": "Double quoted String",
+          "begin": "(\")",
+          "end": "(\")",
+          "beginCaptures": {
+            "1": { "name": "punctuation.definition.string.begin" }
+          },
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.string.end" }
+          },
+          "patterns": [
+            { "include": "#escape-characters" },
+            { "include": "#expansion" }
+          ],
+          "name": "string.quoted.double.env-spec"
+        },
+        "quoted-value--backtick": {
+          "comment": "Backtick quoted string",
+          "begin": "(`)",
+          "end": "(`)",
+          "beginCaptures": {
+            "1": { "name": "punctuation.definition.string.begin" }
+          },
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.string.end" }
+          },
+          "patterns": [
+            { "include": "#escape-characters" },
+            { "include": "#expansion" }
+          ],
+          "name": "string.quoted.backtick.env-spec"
+        },
+        "quoted-value--single": {
+          "comment": "Single quoted string",
+          "begin": "(')",
+          "end": "(')",
+          "beginCaptures": {
+            "1": { "name": "punctuation.definition.string.begin" }
+          },
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.string.end" }
+          },
+          "patterns": [{ "include": "#escape-characters" }],
+          "name": "string.quoted.single.env-spec"
+        }
+      }
+    },
+
+    "expansion": {
+      "patterns": [
+        { "include": "#expansion--ref-bracketed" },
+        { "include": "#expansion--ref-simple" },
+        { "include": "#expansion--exec" }
+      ],
+      "repository": {
+        "expansion--ref-bracketed": {
+          "comment": "Ref expansion (with brackets)",
+          "begin": "\\$\\{",
+          "end": "\\}",
+          "name": "punctuation.section.interpolation.env-spec",
+          "contentName": "variable.function.env-spec"
+        },
+        "expansion--ref-simple": {
+          "comment": "Ref expansion (no brackets)",
+          "match": "\\$([a-zA-Z_]+[a-zA-Z0-9_]*)",
+          "name": "variable.function.env-spec"
+        },
+        "expansion--exec": {
+          "comment": "Exec expansion",
+          "begin": "\\$\\(",
+          "end": "\\)",
+          "name": "punctuation.section.interpolation.env-spec",
+          "contentName": "variable.function.env-spec"
+        }
+      }
+    },
+
+    "escape-characters": {
+      "comment": "Escape characters",
+      "match": "\\\\[nrtfb\"'`\\\\]|\\\\u[0123456789ABCDEF]{4}",
+      "name": "constant.character.escape.env-spec"
+    },
+
+    "decorator": {
+      "comment": "Decorator",
+      "name": "meta.annotation.decorator.env-spec",
+      "patterns": [
+        { "include": "#decorator--bare" },
+        { "include": "#decorator--fn-call" },
+        { "include": "#decorator--with-value" }
+      ],
+      "repository": {
+        "decorator--bare": {
+          "match": "(@[a-zA-Z][a-zA-Z0-9]+)(?=[\n #])",
+          "captures": {
+            "1": {
+              "patterns": [{ "include": "#decorator--name" }]
+            }
+          }
+        },
+        "decorator--fn-call": {
+          "begin": "(@[a-zA-Z][a-zA-Z0-9]+)(\\()",
+          "end": "(\\))",
+          "name": "meta.function-call.env-spec",
+          "contentName": "variable.parameters.env-spec",
+          "beginCaptures": {
+            "1": {
+              "patterns": [{ "include": "#decorator--name" }]
+            },
+            "2": {
+              "name": "punctuation.section.parens.begin.env-spec"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.parens.end.env-spec"
+            }
+          },
+          "patterns": [
+            {
+              "comment": "comment continuation for multi-line decorator fn call",
+              "match": "^\\s*#\\s*",
+              "name": "comment.line.env-spec punctuation.definition.comment"
+            },
+            {
+              "comment": "comment inside a multi-line decorator fn call (commented-out arg or trailing note)",
+              "match": "#.*$",
+              "name": "comment.line.env-spec"
+            },
+            { "include": "#bracket-literal" },
+            { "include": "#literal-value" },
+            { "include": "#quoted-value" },
+            { "include": "#key-value-pair" },
+            { "include": "#decorator-fn-call-value" },
+            { "include": "#expansion" },
+            { "include": "#unquoted-string-within-fn-call" },
+            {
+              "comment": "extra $",
+              "match": "\\$",
+              "name": "string.unquoted.env-spec"
+            },
+            {
+              "comment": "decorator fn arg separator",
+              "match": "\\s*,\\s*",
+              "name": "punctuation.separator.comma.env-spec"
+            }
+          ]
+        },
+        "decorator--with-value": {
+          "begin": "(@[a-zA-Z][a-zA-Z0-9]+)(=)?",
+          "end": "(?=[\n #)])",
+          "beginCaptures": {
+            "1": {
+              "patterns": [{ "include": "#decorator--name" }]
+            },
+            "2": {
+              "name": "keyword.operator.assignment.env-spec"
+            }
+          },
+          "patterns": [
+            { "include": "#literal-value" },
+            { "include": "#quoted-value" },
+            { "include": "#decorator-fn-call-value" },
+            { "include": "#bracket-literal" },
+            {
+              "comment": "unquoted decorator value",
+              "match": "([^ \n#]+)",
+              "name": "string.unquoted.env-spec",
+              "captures": {
+                "1": {
+                  "patterns": [{ "include": "#escape-characters" }]
+                }
+              }
+            }
+          ]
+        },
+        "decorator--name": {
+          "match": "(@)([a-zA-Z][a-zA-Z0-9]+)",
+          "name": "variable.annotation.env-spec",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.annotation.env-spec"
+            }
+          }
+        }
+
+      }
+
+    },
+    "decorator-fn-call-value": {
+      "comment": "Decorator function call value",
+      "begin": "([a-zA-Z][a-zA-Z0-9]+)(\\()",
+      "end": "(\\))",
+      "name": "meta.function-call.env-spec variable.function.env-spec",
+      "contentName": "variable.parameters.env-spec",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.function.env-spec"
+        },
+        "2": {
+          "name": "punctuation.section.parens.begin.env-spec"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parens.end.env-spec"
+        }
+      },
+      "patterns": [
+        {
+          "comment": "comment continuation for multi-line decorator fn call",
+          "match": "^\\s*#\\s*",
+          "name": "comment.line.env-spec punctuation.definition.comment"
+        },
+        {
+          "comment": "comment inside a multi-line decorator fn call (commented-out arg or trailing note)",
+          "match": "#.*$",
+          "name": "comment.line.env-spec"
+        },
+        { "include": "#bracket-literal" },
+        { "include": "#literal-value" },
+        { "include": "#quoted-value" },
+        { "include": "#key-value-pair" },
+        { "include": "#expansion" },
+        { "include": "#unquoted-string-within-fn-call" },
+        {
+          "comment": "extra $",
+          "match": "\\$",
+          "name": "string.unquoted.env-spec"
+        },
+        {
+          "comment": "decorator fn arg separator",
+          "match": "\\s*,\\s*",
+          "name": "punctuation.separator.comma.env-spec"
+        }
+      ]
+    },
+
+    "unquoted-string-within-fn-call": {
+      "comment": "unquoted string value within fn call",
+      "match": "([^ \n,)$]+)",
+      "name": "string.unquoted.env-spec",
+      "captures": {
+        "1": {
+          "patterns": [{ "include": "#escape-characters" }]
+        }
+      }
+    },
+
+    "key-value-pair": {
+      "comment": "key=value pair (decorator context) — a nested literal value spans `#`-prefixed lines",
+      "begin": "([a-zA-Z][a-zA-Z0-9]+)(=)",
+      "end": "(?=[,\n#)\\]}])",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.other.attribute-name.env-spec"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.env-spec"
+        }
+      },
+      "patterns": [
+        { "include": "#bracket-literal" },
+        { "include": "#env-item-value-fn-call" },
+        { "include": "#literal-value" },
+        { "include": "#quoted-value" },
+        { "include": "#expansion" },
+        { "include": "#unquoted-string-within-fn-call" },
+        {
+          "comment": "extra $",
+          "match": "\\$",
+          "name": "string.unquoted.env-spec"
+        }
+      ]
+    },
+    "key-value-pair-item": {
+      "comment": "key=value pair (item context) — same as #key-value-pair but nests the item-context literal variant so column-0 comments inside a nested literal are treated as comments",
+      "begin": "([a-zA-Z][a-zA-Z0-9]+)(=)",
+      "end": "(?=[,\n#)\\]}])",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.other.attribute-name.env-spec"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.env-spec"
+        }
+      },
+      "patterns": [
+        { "include": "#bracket-literal-item" },
+        { "include": "#env-item-value-fn-call" },
+        { "include": "#literal-value" },
+        { "include": "#quoted-value" },
+        { "include": "#expansion" },
+        { "include": "#unquoted-string-within-fn-call" },
+        {
+          "comment": "extra $",
+          "match": "\\$",
+          "name": "string.unquoted.env-spec"
+        }
+      ]
+    },
+
+    "env-item-value-fn-call": {
+      "comment": "env item value fn call",
+      "begin": "([a-zA-Z][a-zA-Z0-9]+)(\\()",
+      "end": "(\\))|$",
+      "beginCaptures": {
+        "1": {
+          "comment": "env item value function name",
+          "name": "variable.function.env-spec"
+        },
+        "2": {
+          "name": "punctuation.definition.parameters.begin.env-spec"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.parameters.end.env-spec"
+        }
+      },
+      "name": "meta.function-call.env-spec",
+      "patterns": [
+        { "include": "#env-item-value-fn-call-arg" },
+        {
+          "match": "\\s*,\\s*",
+          "name": "punctuation.separator.comma.env-spec"
+        }
+      ]
+    },
+    "env-item-value-fn-call-arg": {
+      "comment": "env item value fn call arg (item context)",
+      "patterns": [
+        { "include": "#bracket-literal-item" },
+        { "include": "#literal-value" },
+        { "include": "#key-value-pair-item" },
+        { "include": "#env-item-value-fn-call" },
+        { "include": "#expansion" },
+        { "include": "#quoted-value" },
+        { "include": "#unquoted-string-within-fn-call" },
+        {
+          "comment": "extra $",
+          "match": "\\$",
+          "name": "string.unquoted.env-spec"
+        }
+      ]
+    }
+  }
+}

--- a/site/src/lib/shiki-env-spec.ts
+++ b/site/src/lib/shiki-env-spec.ts
@@ -1,0 +1,22 @@
+import type { LanguageRegistration } from '@shikijs/types';
+import grammar from './env-spec.tmLanguage.json';
+
+/* Syntax highlighting for `@env-spec` — the schema format Varlock reads out of a
+   `.env.schema`. Shiki bundles no grammar for it, so a ```env-spec fence would
+   otherwise render as unhighlighted plain text, which is a poor showing on the page
+   whose whole subject is that format.
+
+   The grammar is Varlock's own, vendored verbatim from their VSCode extension
+   (`dmno-dev/varlock`, packages/vscode-plugin/language/env-spec.tmLanguage.json @
+   6283b725, MIT © DMNO Inc.). Vendored rather than depended on because the npm
+   package is a VSCode extension, not a library — installing it would pull an
+   editor plugin in to read one JSON file. Re-copy that file to update.
+
+   `scopeName` and `patterns` come from the grammar as published; `name` is what a
+   fence's info string matches, and shiki requires it on a LanguageRegistration
+   where a TextMate grammar does not carry one. */
+export const envSpecLang = {
+  ...grammar,
+  name: 'env-spec',
+  aliases: ['envspec'],
+} as unknown as LanguageRegistration;


### PR DESCRIPTION
An explicit `--env-file` or `envFile` alongside a Varlock schema is two contradicting instructions. The explicit one used to win silently, dropping the loader's half with no diagnostic. Now it errors, naming both sides. `--no-env-file` and `envFile: false` are not conflicts — they load nothing, which standing down already does.

Runs on all three surfaces; `nub watch` never called `check_schema_usable` at all.

Verified against real varlock 1.16.0: both conflict forms exit 1, both no-load forms run redacted, `--env-file` still works with the schema removed. Tests, clippy and fmt clean.

Docs: rewrites the Varlock page; adds `@env-spec` highlighting.