### PR TITLE
env: decide .env.schema ownership by loader resolution, and refuse when it is missing

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3656,48 +3656,25 @@ fn runtime_child_env(
     Ok(result)
 }
 
-/// Warn once when a project carries an `@env-spec` schema that nothing can read.
+/// Refuse to run when a project carries a `.env.schema` that nothing can read.
 ///
-/// This is nub's ONLY env-owner diagnostic. When the loader IS installed nub says
-/// nothing at all: it stands down, puts the loader in front of Node, and the
-/// loader owns everything from there — including its own errors.
-/// Report an `@env-spec` schema nub cannot act on — fatally when the project
-/// asked for the loader and it is missing.
+/// This is nub's ONLY env-owner diagnostic, and it is always fatal. When the
+/// loader IS installed nub says nothing at all: it stands down, puts the loader in
+/// front of Node, and the loader owns everything from there — including its own
+/// errors.
 ///
-/// Falling back to `.env*` is right for a project that never declared the loader
-/// and wrong for one that did. In the second case the tree is broken (a pruned
-/// `--prod` install, a partial `node_modules`), and running anyway would hand the
-/// program an environment it never asked for: no defaults, no validation, no
-/// providers, and for a schema-only project with no committed `.env`, nothing.
+/// Falling back to `.env*` was the old behavior here and it is the wrong answer,
+/// not a softer one. A schema the project has not disclaimed (by declaring a rival
+/// claimant of the filename) says the environment is schema-resolved; running on
+/// nub's own cascade instead gives the program no defaults, no validation, no
+/// providers, and for a schema-only project with no committed `.env`, nothing at
+/// all — silently. Only the file run and `nub run` are gated, so `nub install` and
+/// `nub add` still work to fix it.
 fn check_schema_usable(env_owner: Option<&crate::env_owner::EnvOwner>) -> Result<()> {
     let Some(problem) = env_owner.and_then(crate::env_owner::EnvOwner::schema_problem) else {
         return Ok(());
     };
-    if problem.is_fatal() {
-        bail!(problem.message());
-    }
-    warn_once(&format!("nub: {}", problem.message()));
-    Ok(())
-}
-
-/// Emit a startup notice at most once per process. Several launchers can resolve
-/// the same project in one run, and a repeated warning reads as a loop.
-///
-/// Gated on `--silent`, NOT on `SHOW_WARNINGS`: that flag is the `--verbose`
-/// opt-in and defaults off, so gating here would hide the notice from nearly
-/// everyone. These notices exist to explain why an environment the user expected
-/// was not applied — invisible by default is the one thing they must not be.
-fn warn_once(message: &str) {
-    static WARNED: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
-    if SILENT.load(Ordering::Relaxed) {
-        return;
-    }
-    let mut seen = WARNED.lock().unwrap_or_else(|err| err.into_inner());
-    if seen.iter().any(|prior| prior == message) {
-        return;
-    }
-    seen.push(message.to_string());
-    eprintln!("{message}");
+    bail!(problem.message());
 }
 
 fn run_file(args: &[String]) -> Result<i32> {

--- a/crates/nub-cli/src/env_owner.rs
+++ b/crates/nub-cli/src/env_owner.rs
@@ -1,7 +1,7 @@
 //! Handing the environment to an external owner.
 //!
-//! When a project carries an `@env-spec` schema and its loader is installed, nub
-//! does not load `.env*` at all. It spawns the loader in FRONT of Node —
+//! When a project carries a `.env.schema` and its loader resolves, nub does not
+//! load `.env*` at all. It spawns the loader in FRONT of Node —
 //! `<loader> run -- <node> …` — and the loader owns the environment end to end:
 //! resolution, validation, and redaction of the child's output.
 //!
@@ -130,27 +130,33 @@ impl EnvOwner {
 
     /// Whether this `.env.schema` is one nub should act on at all.
     ///
-    /// Two gates, because the filename is CONTESTED and acting on the name alone
-    /// is wrong in both directions:
+    /// One gate: no other tool that claims this filename may be a declared
+    /// dependency. The file's CONTENTS are deliberately never read.
     ///
-    /// 1. the file must actually look like `@env-spec`, and
-    /// 2. no other tool that claims this filename may be a declared dependency.
+    /// nub used to sniff for `@env-spec`'s own syntax — a `# ---` divider or a
+    /// `# @decorator` line — and infer ownership from that. It put nub in the
+    /// business of guessing at a format it does not parse, on evidence weak in
+    /// both directions: a decorator-free `@env-spec` schema reads as foreign, and
+    /// a `# ---` comment in anyone's file reads as ours. Declared intent replaces
+    /// it. What decides is whether the loader RESOLVES — something the project
+    /// did, by installing it or listing it — and not something nub inferred from
+    /// bytes it cannot interpret.
     ///
     /// This governs the STAND-DOWN as well as the diagnostic, and that pairing is
-    /// the point. Gating only the warning left the worse half live: a
+    /// the point. Gating only the warning leaves the worse half live: a
     /// `dotenv-extended` schema in a project where any varlock happened to be
     /// reachable would suppress nub's own cascade and route the whole run through
     /// `varlock run` against a schema written for a different format — silently,
-    /// since the warning was the thing being suppressed.
+    /// since the warning is the thing being suppressed.
     fn is_ours(&self) -> bool {
-        self.schema_looks_like_env_spec() && !self.rival_schema_tool_declared()
+        !self.rival_schema_tool_declared()
     }
 
     /// What is wrong with this schema, if anything — see [`SchemaProblem`].
     ///
-    /// Warning on the filename alone told `dotenv-extended` projects their schema
-    /// "was not applied" while that tool was applying it correctly, and
-    /// recommended a package they had never asked for.
+    /// Silent for a project that declares a rival tool: telling it the schema "was
+    /// not applied" is false while that tool is applying it correctly, and
+    /// recommends a package it never asked for.
     pub(crate) fn schema_problem(&self) -> Option<SchemaProblem> {
         if self.wrapped || self.cli.is_some() || !self.is_ours() {
             return None;
@@ -182,12 +188,16 @@ impl EnvOwner {
 
     /// Whether a package that also claims `.env.schema` is declared here.
     ///
+    /// The sole carve-out, so it carries the whole weight of the contested
+    /// filename: with the contents never read, a declared rival is the one signal
+    /// nub has that this file belongs to something else.
+    ///
     /// Deliberately a list of ONE. The bar is a package popular enough that its
-    /// users meeting this warning is likely — `dotenv-extended` (~44k weekly
-    /// downloads) has defaulted to this filename for its own incompatible format
-    /// since 2016, which is the whole reason the filename is contested. Adding
-    /// long-tail names would trade a real diagnostic for silence in projects that
-    /// genuinely want the schema applied.
+    /// users meeting this is likely — `dotenv-extended` (~44k weekly downloads)
+    /// has defaulted to this filename for its own incompatible format since 2016,
+    /// which is the whole reason the filename is contested. Adding long-tail names
+    /// would trade a real diagnostic for silence in projects that genuinely want
+    /// the schema applied.
     fn rival_schema_tool_declared(&self) -> bool {
         const RIVAL_PACKAGES: [&str; 1] = ["dotenv-extended"];
 
@@ -201,24 +211,6 @@ impl EnvOwner {
             .iter()
             .filter_map(|field| manifest.get(field).and_then(serde_json::Value::as_object))
             .any(|deps| RIVAL_PACKAGES.iter().any(|rival| deps.contains_key(*rival)))
-    }
-
-    /// Whether the schema carries `@env-spec`'s own syntax: a `# ---` header
-    /// divider or a `# @decorator` line.
-    ///
-    /// A deliberately shallow sniff, not a parse — nub never interprets the
-    /// schema, and this only decides whether a diagnostic is honest. A false
-    /// negative costs a hint; a false positive is what it exists to prevent.
-    fn schema_looks_like_env_spec(&self) -> bool {
-        let Ok(text) = std::fs::read_to_string(self.root.join(SCHEMA_FILE)) else {
-            return false;
-        };
-        text.lines().take(200).any(|line| {
-            line.trim_start()
-                .strip_prefix('#')
-                .map(str::trim_start)
-                .is_some_and(|rest| rest.starts_with("---") || rest.starts_with('@'))
-        })
     }
 }
 
@@ -248,9 +240,8 @@ pub(crate) fn detect(project_root: &Path, workspace_root: Option<&Path>) -> Opti
         cli: None,
         wrapped,
     };
-    // Read the file before deciding anything. `is_ours` is what separates an
-    // `@env-spec` schema from another tool's file of the same name, and it gates
-    // the hand-over, not just the diagnostic.
+    // `is_ours` gates the hand-over, not just the diagnostic: a project that
+    // declares a rival claimant of this filename gets neither.
     if !wrapped && owner.is_ours() {
         owner.cli = find_loader_cli(project_root, workspace_root);
     }
@@ -436,19 +427,49 @@ mod tests {
     }
 
     #[test]
-    fn a_foreign_env_schema_is_left_alone_silently() {
+    fn a_declared_rival_tool_keeps_its_own_schema() {
         // dotenv-extended has defaulted to this filename since 2016, for an
-        // incompatible format: bare `NAME=` lines, values still in `.env`.
-        let dir = project(&[(".env.schema", "# Server\nPORT=\nAPI_URL=\n")]);
+        // incompatible format: bare `NAME=` lines, values still in `.env`. Its
+        // presence in the manifest is the one signal that this file is not ours —
+        // the contents are never consulted, so nothing else can say so.
+        let dir = project(&[
+            (
+                "package.json",
+                r#"{"name":"f","devDependencies":{"dotenv-extended":"^2.9.0"}}"#,
+            ),
+            (".env.schema", "# Server\nPORT=\nAPI_URL=\n"),
+            (&format!("node_modules/.bin/{}", bin_name()), "#!/bin/sh\n"),
+        ]);
         let owner = with_path(None, || detect(dir.path(), None)).expect("file present");
+        assert_eq!(
+            owner.cli(),
+            None,
+            "a declared rival must block the hand-over even with the loader installed"
+        );
         assert!(
             !owner.suppresses_env_files(),
-            "a foreign schema must not disturb nub's own loading"
+            "a rival's schema must not disturb nub's own loading"
         );
         assert_eq!(
             owner.schema_problem(),
             None,
             "nub must not name another tool at a project that never asked for it"
+        );
+    }
+
+    #[test]
+    fn the_schema_contents_are_never_inspected() {
+        // A schema with no `@env-spec` syntax in it at all. nub used to read the
+        // file and infer ownership from a `# ---` divider or a `# @decorator`
+        // line; what decides now is that the loader RESOLVES.
+        let dir = project(&[
+            (".env.schema", "PORT=\nAPI_URL=\n"),
+            (&format!("node_modules/.bin/{}", bin_name()), "#!/bin/sh\n"),
+        ]);
+        let owner = with_path(None, || detect(dir.path(), None)).expect("schema present");
+        assert!(
+            owner.cli().is_some(),
+            "an installed loader owns the schema whatever the file's syntax looks like"
         );
     }
 

--- a/crates/nub-cli/src/env_owner.rs
+++ b/crates/nub-cli/src/env_owner.rs
@@ -51,24 +51,28 @@ const LOADER_PACKAGE: &str = "varlock";
 /// Internal `__NUB_*` plumbing, not a user knob.
 pub(crate) const WRAPPED_ENV: &str = "__NUB_ENV_OWNER_WRAPPED";
 
-/// An `@env-spec` schema nub cannot act on, and why.
+/// A schema nub cannot act on, and why. Always fatal.
 ///
-/// The two cases get opposite treatment because the project's INTENT differs.
+/// A `.env.schema` this project has not disclaimed is a statement that the
+/// environment is schema-resolved. Running anyway would hand the program an
+/// environment it never asked for — no defaults, no validation, no providers, and
+/// for a schema-only project with no committed `.env`, nothing at all — and it
+/// would do it silently, which is the failure mode worth refusing. Falling back
+/// to `.env*` is not a lesser version of what was asked for; it is a different
+/// answer wearing the same shape.
+///
+/// The two cases differ only in the fix to recommend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SchemaProblem {
-    /// The manifest asks for the loader and it is not resolvable — a broken
-    /// install (a pruned `--prod` tree, a partial `node_modules`). Falling back to
-    /// `.env*` here would run the project with an environment it never asked for:
-    /// no defaults, no validation, no providers, and for a schema-only project
-    /// with no committed `.env`, nothing at all. Refuse instead.
+    /// The manifest asks for the loader and it is not resolvable — a broken tree
+    /// (a pruned `--prod` install, a partial `node_modules`). An install fixes it.
     LoaderDeclaredButMissing,
-    /// A schema with no loader declared anywhere. The project may not know the
-    /// file means anything to nub, so nub keeps loading `.env*` and says so.
+    /// A schema with no loader declared anywhere and none on `PATH`. The project
+    /// needs to add one.
     LoaderNotDeclared,
 }
 
 impl SchemaProblem {
-    /// The message, and whether it is fatal.
     pub(crate) fn message(self) -> String {
         match self {
             Self::LoaderDeclaredButMissing => format!(
@@ -76,14 +80,10 @@ impl SchemaProblem {
                  installed. Run `nub install`."
             ),
             Self::LoaderNotDeclared => format!(
-                "{SCHEMA_FILE} needs {LOADER_PACKAGE}, which isn't installed; loaded .env files \
-                 instead. Run `nub add -D {LOADER_PACKAGE}`."
+                "{SCHEMA_FILE} needs {LOADER_PACKAGE}, which isn't installed. Run \
+                 `nub add -D {LOADER_PACKAGE}`."
             ),
         }
-    }
-
-    pub(crate) fn is_fatal(self) -> bool {
-        matches!(self, Self::LoaderDeclaredButMissing)
     }
 }
 
@@ -116,10 +116,11 @@ impl EnvOwner {
 
     /// Whether nub should stand down from its own `.env*` cascade.
     ///
-    /// False when the loader is absent, and deliberately so. A schema file with
-    /// nothing to read it is not evidence that anything owns this project — the
-    /// filename is shared with other tools — and standing down there would leave
-    /// the process with no environment at all. nub keeps loading instead.
+    /// False when the loader is absent — but with a schema present that state no
+    /// longer reaches a running program, because [`SchemaProblem`] is fatal. The
+    /// one case that survives is a project declaring a rival claimant of the
+    /// filename, which nub is not entitled to interpret and whose `.env*` it must
+    /// therefore keep loading.
     pub(crate) fn suppresses_env_files(&self) -> bool {
         // True in BOTH owned states. `cli` is Some when this process will put the
         // loader in front of Node; it is None-but-wrapped when a parent nub
@@ -410,19 +411,14 @@ mod tests {
     }
 
     #[test]
-    fn a_schema_without_the_loader_keeps_nub_loading() {
+    fn a_schema_with_no_loader_anywhere_is_reported() {
         let dir = project(&[(".env.schema", "# ---\nA=1\n")]);
         let owner = with_path(None, || detect(dir.path(), None)).expect("schema present");
-        assert!(
-            !owner.suppresses_env_files(),
-            "with nothing to read the schema, standing down would leave the child \
-             with no environment at all"
-        );
         assert_eq!(
             owner.schema_problem(),
             Some(SchemaProblem::LoaderNotDeclared),
-            "an @env-spec schema with no loader DECLARED must say so, and must not \
-             be fatal — the project may not know the file means anything to nub"
+            "a schema with nothing to read it must be reported — the CLI refuses \
+             the run rather than falling back to its own cascade"
         );
     }
 

--- a/crates/nub-cli/tests/env_owner.rs
+++ b/crates/nub-cli/tests/env_owner.rs
@@ -442,8 +442,9 @@ fn a_schema_without_the_loader_keeps_loading_and_warns() {
 fn a_project_using_a_rival_schema_tool_is_not_warned_at() {
     // `dotenv-extended` claims this filename too. A project that declares it has
     // a tool applying its schema already, so telling it the schema "was not
-    // applied" is false, and recommending another package is noise. The file
-    // sniff cannot settle this one: the schema here IS @env-spec shaped.
+    // applied" is false, and recommending another package is noise. Its manifest
+    // is the only thing that can say so — nub never reads the schema itself, so
+    // the file here is deliberately @env-spec shaped.
     let dir = project(&[
         (
             "package.json",
@@ -469,13 +470,17 @@ fn a_project_using_a_rival_schema_tool_is_not_warned_at() {
 
 #[cfg(unix)]
 #[test]
-fn a_foreign_schema_does_not_hand_over_even_when_the_loader_is_installed() {
-    // The format sniff used to gate only the DIAGNOSTIC. That left the worse half
-    // live: a `dotenv-extended` schema in a project where any varlock happened to
-    // be reachable made nub suppress its own cascade and route the whole run
-    // through `varlock run` against a schema written for another format —
-    // silently, because the warning was the thing being suppressed.
+fn a_declared_rival_tool_blocks_the_hand_over_even_with_the_loader_installed() {
+    // The carve-out gates the HAND-OVER, not just the diagnostic. Gating only the
+    // warning leaves the worse half live: a `dotenv-extended` project where any
+    // varlock happens to be reachable would have nub suppress its own cascade and
+    // route the whole run through `varlock run` against a schema written for
+    // another format — silently, since the warning is what is being suppressed.
     let dir = project(&[
+        (
+            "package.json",
+            r#"{"name":"f","version":"1.0.0","devDependencies":{"dotenv-extended":"^2.9.0"}}"#,
+        ),
         (".env", "FROM_DOTENV=yes\n"),
         (".env.schema", "# Server\nPORT=\nAPI_URL=\n"),
     ]);
@@ -486,7 +491,7 @@ fn a_foreign_schema_does_not_hand_over_even_when_the_loader_is_installed() {
     assert_eq!(
         run.var("FROM_LOADER"),
         None,
-        "a foreign schema must not put the loader in front of Node. stderr: {}",
+        "a declared rival must not put the loader in front of Node. stderr: {}",
         run.stderr
     );
     assert!(!tally.exists(), "and must not invoke the loader at all");
@@ -529,30 +534,6 @@ fn a_different_project_inside_the_wrap_still_wraps_its_own() {
         Some("yes"),
         "a different project's wrap must not suppress this project's own. \
          stderr: {}",
-        run.stderr
-    );
-}
-
-#[test]
-fn a_foreign_env_schema_is_left_alone_silently() {
-    // `.env.schema` is not this format's name — dotenv-extended has defaulted to
-    // it since 2016 for an incompatible format. Warning on the filename told those
-    // projects their schema "was not applied" while another tool was applying it.
-    let dir = project(&[
-        (".env", "FROM_DOTENV=yes\n"),
-        (".env.schema", "# Server\nPORT=\nAPI_URL=\n"),
-    ]);
-    let run = run(dir.path());
-    assert_eq!(
-        run.var("FROM_DOTENV").as_deref(),
-        Some("yes"),
-        "a foreign schema must not disturb nub's own loading. stderr: {}",
-        run.stderr
-    );
-    assert!(
-        !run.stderr.contains("varlock"),
-        "nub must not name another tool at a project that never asked for it; \
-         stderr was: {}",
         run.stderr
     );
 }

--- a/crates/nub-cli/tests/env_owner.rs
+++ b/crates/nub-cli/tests/env_owner.rs
@@ -415,26 +415,40 @@ fn a_declared_but_missing_loader_is_fatal() {
 }
 
 #[test]
-fn a_schema_without_the_loader_keeps_loading_and_warns() {
-    // A schema with nothing to read it is not evidence that anything owns this
-    // project, so standing down would leave the child with no environment at all.
+fn a_schema_without_any_loader_is_fatal() {
+    // Falling back to `.env*` is a DIFFERENT answer, not a softer one: no defaults,
+    // no validation, no providers. A schema the project has not disclaimed says the
+    // environment is schema-resolved, so nub refuses rather than running the
+    // program on an environment it never asked for.
     let dir = project(&[
         (".env", "FROM_DOTENV=yes\n"),
         (".env.schema", "# ---\nA=1\n"),
     ]);
-    let run = run(dir.path());
-    assert_eq!(
-        run.var("FROM_DOTENV").as_deref(),
-        Some("yes"),
-        "with no loader installed nub must keep loading. stderr: {}",
-        run.stderr
+    let node_dir = which_node_dir();
+    let output = Command::new(nub_binary())
+        .arg("probe.mjs")
+        .current_dir(dir.path())
+        .env("PATH", &node_dir)
+        .env_remove("NODE_OPTIONS")
+        .output()
+        .expect("spawn nub");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "an unreadable schema must not run the program; exit was {:?}",
+        output.status.code()
     );
     assert!(
-        run.stderr.contains("nub add -D varlock"),
-        "the user must be told the schema was not applied, and how to fix it — \
-         as a DEV dependency, which is what the loader's own docs prescribe; \
-         stderr was: {}",
-        run.stderr
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "the program must not have run at all; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        stderr.contains("nub add -D varlock"),
+        "the fix for a schema with no loader declared anywhere is an add — as a \
+         DEV dependency, which is what the loader's own docs prescribe; \
+         stderr: {stderr}"
     );
 }
 

--- a/site/content/docs/runtime/varlock.mdx
+++ b/site/content/docs/runtime/varlock.mdx
@@ -42,14 +42,18 @@ Type generation, providers, validation, secret redaction — whatever your schem
 
 ## When Nub hands over
 
-Two things have to be true. Miss either and Nub keeps loading `.env*` exactly as it always has.
+A `.env.schema` in the project root — or in the workspace root above it — hands the environment to Varlock, resolved from `node_modules/.bin` up to the workspace root and then `PATH`. Nub never reads the schema itself.
 
-- A `.env.schema` in the project root, or in the workspace root above it
-- Varlock resolves, from `node_modules/.bin` up to the workspace root, then `PATH`
+**A schema Varlock cannot be found for is an error, not a fallback.**
 
-Nub never reads the schema. Whether Varlock resolves is the whole test.
+```console
+$ nub server.ts
+.env.schema needs varlock, which isn't installed. Run `nub add -D varlock`.
+```
 
-One carve-out, because the filename is contested. [dotenv-extended](https://www.npmjs.com/package/dotenv-extended) has used `.env.schema` for its own incompatible format since 2016, so a project that declares it as a dependency is left alone: Nub keeps loading `.env*`, and never mentions Varlock.
+Loading `.env*` instead would be a different answer wearing the same shape — no defaults, no validation, no providers, and for a schema-only project, nothing at all. Only running code is gated, so `nub install` and `nub add` still work to fix it.
+
+One carve-out, because the filename is contested. [dotenv-extended](https://www.npmjs.com/package/dotenv-extended) has used `.env.schema` for its own incompatible format since 2016, so a project that declares it as a dependency is left alone entirely: Nub keeps loading `.env*`, and never mentions Varlock.
 
 ## Monorepos and subdirectories
 

--- a/site/content/docs/runtime/varlock.mdx
+++ b/site/content/docs/runtime/varlock.mdx
@@ -42,13 +42,14 @@ Type generation, providers, validation, secret redaction — whatever your schem
 
 ## When Nub hands over
 
-Three things have to be true. Miss any one of them and Nub keeps loading `.env*` exactly as it always has.
+Two things have to be true. Miss either and Nub keeps loading `.env*` exactly as it always has.
 
 - A `.env.schema` in the project root, or in the workspace root above it
-- The file is actually `@env-spec` — a `# ---` divider or a `# @decorator` line
 - Varlock resolves, from `node_modules/.bin` up to the workspace root, then `PATH`
 
-The middle condition exists because the filename is contested. [dotenv-extended](https://www.npmjs.com/package/dotenv-extended) has used `.env.schema` for its own incompatible format since 2016, so Nub recognizes the name without claiming it: a schema written for another tool never routes your run through Varlock, and never draws a warning either.
+Nub never reads the schema. Whether Varlock resolves is the whole test.
+
+One carve-out, because the filename is contested. [dotenv-extended](https://www.npmjs.com/package/dotenv-extended) has used `.env.schema` for its own incompatible format since 2016, so a project that declares it as a dependency is left alone: Nub keeps loading `.env*`, and never mentions Varlock.
 
 ## Monorepos and subdirectories
 

--- a/site/content/docs/runtime/varlock.mdx
+++ b/site/content/docs/runtime/varlock.mdx
@@ -48,7 +48,7 @@ A `.env.schema` in the project root — or in the workspace root above it — ha
 
 ```console
 $ nub server.ts
-.env.schema needs varlock, which isn't installed. Run `nub add -D varlock`.
+Error: .env.schema needs varlock, which isn't installed. Run `nub add -D varlock`.
 ```
 
 Loading `.env*` instead would be a different answer wearing the same shape — no defaults, no validation, no providers, and for a schema-only project, nothing at all. Only running code is gated, so `nub install` and `nub add` still work to fix it.


### PR DESCRIPTION
Removes the `@env-spec` syntax sniff: Nub gated the hand-over on a `# ---` or `# @decorator` line, guessing at a format it does not parse. Whether varlock resolves is now the whole test. A declared `dotenv-extended` is the sole carve-out, and blocks the hand-over rather than only the warning.

Makes an unreadable schema fatal. It previously fell back to `.env*` — a different answer, not a softer one, and silent. Both `SchemaProblem` variants bail; `is_fatal` and the unused `warn_once` are gone. Only the file run and `nub run` are gated, so `nub install` still works.