### PR TITLE
config: add native TypeScript transform fields

### DIFF
--- a/crates/nub-cli/src/config_fields.rs
+++ b/crates/nub-cli/src/config_fields.rs
@@ -131,6 +131,42 @@ const FIELDS: &[Field] = &[
         global_only: false,
     },
     Field {
+        address: "jsx",
+        path: "jsx",
+        shape: Shape::Str,
+        global_only: false,
+    },
+    Field {
+        address: "jsxFactory",
+        path: "jsxFactory",
+        shape: Shape::Str,
+        global_only: false,
+    },
+    Field {
+        address: "jsxFragmentFactory",
+        path: "jsxFragmentFactory",
+        shape: Shape::Str,
+        global_only: false,
+    },
+    Field {
+        address: "jsxImportSource",
+        path: "jsxImportSource",
+        shape: Shape::Str,
+        global_only: false,
+    },
+    Field {
+        address: "decorators",
+        path: "decorators",
+        shape: Shape::Str,
+        global_only: false,
+    },
+    Field {
+        address: "emitDecoratorMetadata",
+        path: "emitDecoratorMetadata",
+        shape: Shape::Bool,
+        global_only: false,
+    },
+    Field {
         address: "verifyDeps",
         path: "verifyDeps",
         shape: Shape::VerifyDeps,
@@ -528,6 +564,18 @@ mod tests {
         assert_eq!(
             coerced("tsconfig", "./tsconfig.json"),
             Value::String("./tsconfig.json".into())
+        );
+        assert_eq!(
+            coerced("jsx", "react-jsx"),
+            Value::String("react-jsx".into())
+        );
+        assert_eq!(
+            coerced("decorators", "legacy"),
+            Value::String("legacy".into())
+        );
+        assert_eq!(
+            coerced("emitDecoratorMetadata", "false"),
+            Value::Bool(false)
         );
         assert_eq!(
             coerced("tsconfig", "[generated]/tsconfig.json"),

--- a/crates/nub-cli/src/project_config.rs
+++ b/crates/nub-cli/src/project_config.rs
@@ -42,6 +42,12 @@ pub(crate) const ROOT_KEYS: &[&str] = &[
     "loader",
     "conditions",
     "tsconfig",
+    "jsx",
+    "jsxFactory",
+    "jsxFragmentFactory",
+    "jsxImportSource",
+    "decorators",
+    "emitDecoratorMetadata",
     "verifyDeps",
     "install",
     "dlx",
@@ -65,6 +71,16 @@ pub(crate) const LOADERS: &[&str] = &["text", "jsonc", "json5", "toml", "yaml", 
 /// loader on them could not take effect and is refused. Their schema enums are
 /// therefore [`LOADERS`] minus `ts`.
 pub(crate) const JSX_PINNED_EXTS: &[&str] = &[".tsx", ".jsx"];
+
+/// The `compilerOptions.jsx` modes that produce executable JavaScript in Nub's
+/// per-file runtime transform. TypeScript's `preserve` / `react-native` modes
+/// intentionally leave JSX syntax in the output, so the native runtime surface
+/// refuses them rather than accepting a setting it cannot apply as written.
+pub(crate) const JSX_VALUES: &[&str] = &["react", "react-jsx", "react-jsxdev"];
+
+/// Decorator semantics Nub can currently lower. Standard ECMAScript decorators
+/// will join this vocabulary once the native transform can emit them.
+pub(crate) const DECORATOR_VALUES: &[&str] = &["legacy"];
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Error type — fail-loud, with a JSON path so a bad file self-describes.
@@ -196,6 +212,12 @@ pub struct ProjectConfig {
     pub loader: Option<BTreeMap<String, String>>,
     pub conditions: Option<Vec<String>>,
     pub tsconfig: Option<String>,
+    pub jsx: Option<String>,
+    pub jsx_factory: Option<String>,
+    pub jsx_fragment_factory: Option<String>,
+    pub jsx_import_source: Option<String>,
+    pub decorators: Option<DecoratorMode>,
+    pub emit_decorator_metadata: Option<bool>,
     pub verify_deps: Option<VerifyDeps>,
 
     // ── install phase ──
@@ -254,6 +276,13 @@ pub enum VerifyDeps {
     Enabled(bool),
     Warn,
     Error,
+}
+
+/// The decorator transform selected by Nub's native config surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecoratorMode {
+    /// TypeScript's pre-Stage-3 decorator calling and emit semantics.
+    Legacy,
 }
 
 /// The `install` block, consumed by the native PM through its aube settings
@@ -373,6 +402,12 @@ pub enum ConfigKey {
     Loader,
     Conditions,
     Tsconfig,
+    Jsx,
+    JsxFactory,
+    JsxFragmentFactory,
+    JsxImportSource,
+    Decorators,
+    EmitDecoratorMetadata,
     VerifyDeps,
     InstallLinker,
     InstallPublicHoist,
@@ -435,6 +470,12 @@ pub(crate) struct RuntimeConfig {
     pub loader: BTreeMap<String, String>,
     pub conditions: Vec<String>,
     pub tsconfig: Option<String>,
+    pub jsx: Option<String>,
+    pub jsx_factory: Option<String>,
+    pub jsx_fragment_factory: Option<String>,
+    pub jsx_import_source: Option<String>,
+    pub experimental_decorators: Option<bool>,
+    pub emit_decorator_metadata: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -780,6 +821,17 @@ impl EffectiveConfig {
             loader: values.loader.clone().unwrap_or_default(),
             conditions: values.conditions.clone().unwrap_or_default(),
             tsconfig,
+            jsx: values.jsx.clone(),
+            jsx_factory: values.jsx_factory.clone(),
+            jsx_fragment_factory: values.jsx_fragment_factory.clone(),
+            jsx_import_source: values.jsx_import_source.clone(),
+            // Keep the established TypeScript spelling in the internal wire
+            // format so an older child Nub can still consume a newer parent's
+            // resolved project config during a version handoff.
+            experimental_decorators: values
+                .decorators
+                .map(|mode| matches!(mode, DecoratorMode::Legacy)),
+            emit_decorator_metadata: values.emit_decorator_metadata,
         })
     }
 }
@@ -863,7 +915,7 @@ fn merge_layer(
 ) {
     // `merge!(install.linker, ConfigKey::InstallLinker)` — the field path is the
     // same on both sides, so naming it once keeps this a readable table of
-    // field ↔ key rather than fourteen near-identical `if let`s.
+    // field ↔ key rather than twenty near-identical `if let`s.
     macro_rules! merge {
         ($($field:ident).+, $key:expr) => {
             if let Some(value) = layer.$($field).+.as_ref() {
@@ -881,6 +933,12 @@ fn merge_layer(
     merge!(loader, ConfigKey::Loader);
     merge!(conditions, ConfigKey::Conditions);
     merge!(tsconfig, ConfigKey::Tsconfig);
+    merge!(jsx, ConfigKey::Jsx);
+    merge!(jsx_factory, ConfigKey::JsxFactory);
+    merge!(jsx_fragment_factory, ConfigKey::JsxFragmentFactory);
+    merge!(jsx_import_source, ConfigKey::JsxImportSource);
+    merge!(decorators, ConfigKey::Decorators);
+    merge!(emit_decorator_metadata, ConfigKey::EmitDecoratorMetadata);
     merge!(verify_deps, ConfigKey::VerifyDeps);
 
     merge!(install.linker, ConfigKey::InstallLinker);
@@ -941,6 +999,17 @@ fn as_str<'a>(v: &'a Value, path: &str) -> Result<&'a str> {
         path: path.into(),
         expected: "a string",
     })
+}
+
+fn as_nonempty_str<'a>(v: &'a Value, path: &str) -> Result<&'a str> {
+    let value = as_str(v, path)?;
+    if value.is_empty() {
+        return Err(ConfigError::Value {
+            path: path.into(),
+            message: "must not be empty".into(),
+        });
+    }
+    Ok(value)
 }
 
 /// A `string[]` field — every element must be a string.
@@ -1107,6 +1176,54 @@ fn validate_root(
     }
     if let Some(v) = obj.get("tsconfig") {
         cfg.tsconfig = Some(as_str(v, "tsconfig")?.to_string());
+    }
+    if let Some(v) = obj.get("jsx") {
+        let value = as_str(v, "jsx")?;
+        if !JSX_VALUES.contains(&value) {
+            return Err(ConfigError::Value {
+                path: "jsx".into(),
+                message: format!(
+                    "must be one of {}",
+                    JSX_VALUES
+                        .iter()
+                        .map(|value| format!("`{value}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            });
+        }
+        cfg.jsx = Some(value.to_string());
+    }
+    if let Some(v) = obj.get("jsxFactory") {
+        cfg.jsx_factory = Some(as_nonempty_str(v, "jsxFactory")?.to_string());
+    }
+    if let Some(v) = obj.get("jsxFragmentFactory") {
+        cfg.jsx_fragment_factory = Some(as_nonempty_str(v, "jsxFragmentFactory")?.to_string());
+    }
+    if let Some(v) = obj.get("jsxImportSource") {
+        cfg.jsx_import_source = Some(as_nonempty_str(v, "jsxImportSource")?.to_string());
+    }
+    if let Some(v) = obj.get("decorators") {
+        let value = as_nonempty_str(v, "decorators")?;
+        cfg.decorators = Some(match value {
+            "legacy" => DecoratorMode::Legacy,
+            _ => {
+                return Err(ConfigError::Value {
+                    path: "decorators".into(),
+                    message: format!(
+                        "must be one of {}",
+                        DECORATOR_VALUES
+                            .iter()
+                            .map(|value| format!("`{value}`"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                });
+            }
+        });
+    }
+    if let Some(v) = obj.get("emitDecoratorMetadata") {
+        cfg.emit_decorator_metadata = Some(as_bool(v, "emitDecoratorMetadata")?);
     }
     if let Some(v) = obj.get("verifyDeps") {
         cfg.verify_deps = Some(validate_verify_deps(v, "verifyDeps")?);
@@ -1444,6 +1561,12 @@ mod tests {
               "loader": { ".svg": "text" },
               "conditions": ["worker"],
               "tsconfig": "./tsconfig.runtime.json",
+              "jsx": "react",
+              "jsxFactory": "createElement",
+              "jsxFragmentFactory": "Fragment",
+              "jsxImportSource": "preact",
+              "decorators": "legacy",
+              "emitDecoratorMetadata": false,
             }"#,
         );
         assert_eq!(cfg.node_compat, Some(true));
@@ -1462,6 +1585,50 @@ mod tests {
         );
         assert_eq!(cfg.conditions, Some(vec!["worker".into()]));
         assert_eq!(cfg.tsconfig.as_deref(), Some("./tsconfig.runtime.json"));
+        assert_eq!(cfg.jsx.as_deref(), Some("react"));
+        assert_eq!(cfg.jsx_factory.as_deref(), Some("createElement"));
+        assert_eq!(cfg.jsx_fragment_factory.as_deref(), Some("Fragment"));
+        assert_eq!(cfg.jsx_import_source.as_deref(), Some("preact"));
+        assert_eq!(cfg.decorators, Some(DecoratorMode::Legacy));
+        assert_eq!(cfg.emit_decorator_metadata, Some(false));
+    }
+
+    #[test]
+    fn jsx_accepts_only_executable_runtime_modes() {
+        for value in JSX_VALUES {
+            parse_project_config(&format!(r#"{{ "jsx": "{value}" }}"#)).unwrap();
+        }
+        let err = parse_project_config(r#"{ "jsx": "solid" }"#).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Value { ref path, .. } if path == "jsx"),
+            "{err}"
+        );
+
+        for key in ["jsxFactory", "jsxFragmentFactory", "jsxImportSource"] {
+            let err = parse_project_config(&format!(r#"{{ "{key}": "" }}"#)).unwrap_err();
+            assert!(
+                matches!(err, ConfigError::Value { ref path, .. } if path == key),
+                "{key}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn decorators_accepts_only_implemented_semantics() {
+        let cfg = parse_project_config(r#"{ "decorators": "legacy" }"#).unwrap();
+        assert_eq!(cfg.decorators, Some(DecoratorMode::Legacy));
+
+        for document in [
+            r#"{ "decorators": "standard" }"#,
+            r#"{ "decorators": "experimental" }"#,
+            r#"{ "decorators": true }"#,
+        ] {
+            let err = parse_project_config(document).unwrap_err();
+            assert!(
+                matches!(err, ConfigError::Type { ref path, .. } | ConfigError::Value { ref path, .. } if path == "decorators"),
+                "{err}"
+            );
+        }
     }
 
     #[test]
@@ -2002,6 +2169,20 @@ mod tests {
             "verifyDeps: nub rejects the values it never implemented, so the schema must not offer them"
         );
         assert_eq!(
+            enum_values(&schema, "/properties/jsx/enum"),
+            expected(JSX_VALUES),
+            "jsx must offer exactly the TypeScript modes the parser accepts"
+        );
+        for key in ["jsxFactory", "jsxFragmentFactory", "jsxImportSource"] {
+            assert_eq!(
+                schema
+                    .pointer(&format!("/properties/{key}/minLength"))
+                    .and_then(Value::as_u64),
+                Some(1),
+                "{key}: the schema must reject the empty string like the parser"
+            );
+        }
+        assert_eq!(
             enum_values(&schema, "/properties/dlx/properties/consent/enum"),
             expected(&["prompt", "never"])
         );
@@ -2277,6 +2458,12 @@ mod tests {
           "loader": {},
           "conditions": [],
           "tsconfig": "./tsconfig.json",
+          "jsx": "react-jsx",
+          "jsxFactory": "createElement",
+          "jsxFragmentFactory": "Fragment",
+          "jsxImportSource": "preact",
+          "decorators": "legacy",
+          "emitDecoratorMetadata": true,
           "verifyDeps": false,
           "install": {
             "linker": { "strategy": "isolated", "hoist": false },

--- a/crates/nub-cli/src/project_config_precedence_matrix.rs
+++ b/crates/nub-cli/src/project_config_precedence_matrix.rs
@@ -140,6 +140,72 @@ fn specs() -> Vec<KeySpec> {
             is_empty: None,
         },
         KeySpec {
+            key: ConfigKey::Jsx,
+            name: "jsx",
+            set: |c, t| {
+                c.jsx = Some(
+                    if t.is_multiple_of(2) {
+                        "react"
+                    } else {
+                        "react-jsx"
+                    }
+                    .into(),
+                )
+            },
+            matches: |c, t| {
+                c.jsx.as_deref()
+                    == Some(if t.is_multiple_of(2) {
+                        "react"
+                    } else {
+                        "react-jsx"
+                    })
+            },
+            set_empty: None,
+            is_empty: None,
+        },
+        KeySpec {
+            key: ConfigKey::JsxFactory,
+            name: "jsxFactory",
+            set: |c, t| c.jsx_factory = Some(format!("factory{t}")),
+            matches: |c, t| c.jsx_factory.as_deref() == Some(format!("factory{t}").as_str()),
+            set_empty: None,
+            is_empty: None,
+        },
+        KeySpec {
+            key: ConfigKey::JsxFragmentFactory,
+            name: "jsxFragmentFactory",
+            set: |c, t| c.jsx_fragment_factory = Some(format!("fragment{t}")),
+            matches: |c, t| {
+                c.jsx_fragment_factory.as_deref() == Some(format!("fragment{t}").as_str())
+            },
+            set_empty: None,
+            is_empty: None,
+        },
+        KeySpec {
+            key: ConfigKey::JsxImportSource,
+            name: "jsxImportSource",
+            set: |c, t| c.jsx_import_source = Some(format!("runtime-{t}")),
+            matches: |c, t| c.jsx_import_source.as_deref() == Some(format!("runtime-{t}").as_str()),
+            set_empty: None,
+            is_empty: None,
+        },
+        KeySpec {
+            key: ConfigKey::Decorators,
+            name: "decorators",
+            set: |c, _| c.decorators = Some(crate::project_config::DecoratorMode::Legacy),
+            matches: |c, _| c.decorators == Some(crate::project_config::DecoratorMode::Legacy),
+            set_empty: None,
+            is_empty: None,
+        },
+        KeySpec {
+            key: ConfigKey::EmitDecoratorMetadata,
+            name: "emitDecoratorMetadata",
+            set: |c, t| c.emit_decorator_metadata = Some(t.is_multiple_of(2)),
+            matches: |c, t| c.emit_decorator_metadata == Some(t.is_multiple_of(2)),
+            set_empty: Some(|c| c.emit_decorator_metadata = Some(false)),
+            is_empty: Some(|c| c.emit_decorator_metadata == Some(false)),
+        },
+        KeySpec {
             key: ConfigKey::VerifyDeps,
             name: "verifyDeps",
             set: |c, t| c.verify_deps = Some(verify_deps(t)),
@@ -209,7 +275,7 @@ fn specs() -> Vec<KeySpec> {
 }
 
 /// One per `ConfigKey` variant; [`ordinal`] is what keeps it honest.
-const KEY_COUNT: usize = 14;
+const KEY_COUNT: usize = 20;
 
 /// Exhaustive by construction: adding a `ConfigKey` variant breaks this match,
 /// forcing the new key into the spec table.
@@ -223,12 +289,18 @@ fn ordinal(key: ConfigKey) -> usize {
         ConfigKey::Loader => 5,
         ConfigKey::Conditions => 6,
         ConfigKey::Tsconfig => 7,
-        ConfigKey::VerifyDeps => 8,
-        ConfigKey::InstallLinker => 9,
-        ConfigKey::InstallPublicHoist => 10,
-        ConfigKey::InstallMinimumReleaseAge => 11,
-        ConfigKey::InstallMinimumReleaseAgeExclude => 12,
-        ConfigKey::DlxConsent => 13,
+        ConfigKey::Jsx => 8,
+        ConfigKey::JsxFactory => 9,
+        ConfigKey::JsxFragmentFactory => 10,
+        ConfigKey::JsxImportSource => 11,
+        ConfigKey::Decorators => 12,
+        ConfigKey::EmitDecoratorMetadata => 13,
+        ConfigKey::VerifyDeps => 14,
+        ConfigKey::InstallLinker => 15,
+        ConfigKey::InstallPublicHoist => 16,
+        ConfigKey::InstallMinimumReleaseAge => 17,
+        ConfigKey::InstallMinimumReleaseAgeExclude => 18,
+        ConfigKey::DlxConsent => 19,
     }
 }
 

--- a/crates/nub-cli/tests/project_runtime_config.rs
+++ b/crates/nub-cli/tests/project_runtime_config.rs
@@ -450,6 +450,121 @@ impl ConditionFixture {
     }
 }
 
+#[test]
+fn top_level_typescript_options_override_the_selected_tsconfig() {
+    let fixture = Fixture::new();
+    std::fs::write(
+        fixture.project.join("tsconfig.runtime.jsonc"),
+        r#"{ "compilerOptions": {
+          "jsx": "react-jsx",
+          "jsxImportSource": "./missing-runtime",
+          "experimentalDecorators": false,
+          "emitDecoratorMetadata": false
+        } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        fixture.project.join("classic.tsx"),
+        r#"function make(tag: unknown, props: unknown, ...children: unknown[]) {
+  return { tag, props, children };
+}
+const Fragment = "fragment";
+console.log(JSON.stringify(<><widget /></>));
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        fixture.project.join("nub.jsonc"),
+        r#"{
+          "tsconfig": "./tsconfig.runtime.jsonc",
+          "jsx": "react",
+          "jsxFactory": "make",
+          "jsxFragmentFactory": "Fragment"
+        }"#,
+    )
+    .unwrap();
+
+    let mut classic = fixture.command();
+    classic.arg("classic.tsx");
+    let classic = probe_json("top-level classic JSX options", classic);
+    assert_eq!(classic["tag"], "fragment", "{classic}");
+    assert_eq!(classic["children"][0]["tag"], "widget", "{classic}");
+
+    std::fs::create_dir_all(fixture.project.join("runtime")).unwrap();
+    std::fs::write(
+        fixture.project.join("runtime/jsx-dev-runtime.js"),
+        r#"export const Fragment = "fragment";
+export function jsxDEV(tag, props) { return { mode: "development", tag, props }; }
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        fixture.project.join("decorated.tsx"),
+        r#"const parameterTypes: string[][] = [];
+Reflect.metadata = (key: string, value: unknown[]) => () => {
+  if (key === "design:paramtypes") parameterTypes.push(value.map(type => type.name));
+};
+function marked<T>(value: T): T { return value; }
+@marked class Dependency {}
+@marked class Service { constructor(_dependency: Dependency) {} }
+console.log(JSON.stringify({
+  element: <widget answer={42} />,
+  parameterTypes,
+  snapshot: JSON.parse(process.env.__NUB_RUNTIME_CONFIG ?? "{}"),
+}));
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        fixture.project.join("nub.jsonc"),
+        r#"{
+          "tsconfig": "./tsconfig.runtime.jsonc",
+          "jsx": "react-jsxdev",
+          "jsxImportSource": "./runtime",
+          "decorators": "legacy",
+          "emitDecoratorMetadata": true
+        }"#,
+    )
+    .unwrap();
+
+    let mut automatic = fixture.command();
+    automatic.arg("decorated.tsx");
+    let automatic = probe_json("top-level automatic JSX and decorator options", automatic);
+    assert_eq!(automatic["element"]["mode"], "development", "{automatic}");
+    assert_eq!(automatic["element"]["tag"], "widget", "{automatic}");
+    assert_eq!(
+        automatic["parameterTypes"],
+        serde_json::json!([["Dependency"]]),
+        "{automatic}"
+    );
+    assert_eq!(automatic["snapshot"]["jsx"], "react-jsxdev", "{automatic}");
+    assert_eq!(
+        automatic["snapshot"]["jsxImportSource"], "./runtime",
+        "{automatic}"
+    );
+    assert_eq!(
+        automatic["snapshot"]["experimentalDecorators"], true,
+        "{automatic}"
+    );
+    assert_eq!(
+        automatic["snapshot"]["emitDecoratorMetadata"], true,
+        "{automatic}"
+    );
+
+    std::fs::write(
+        fixture.project.join("decorated.js"),
+        r#"function marked(_target, _key, descriptor) { return descriptor; }
+class Example { @marked greet() { return "hello"; } }
+console.log(new Example().greet());
+"#,
+    )
+    .unwrap();
+    let mut javascript = fixture.command();
+    javascript.arg("decorated.js");
+    let output = probe_output("top-level legacy decorators in JavaScript", javascript);
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "hello");
+}
+
 /// The `node_modules/.bin` routes, split out because they ride a
 /// `#!/usr/bin/env node` shim. Windows resolves local bins through `.cmd`
 /// shims instead — a different path this fixture does not build — so gating

--- a/crates/nub-cli/tests/project_runtime_config.rs
+++ b/crates/nub-cli/tests/project_runtime_config.rs
@@ -453,6 +453,14 @@ impl ConditionFixture {
 #[test]
 fn top_level_typescript_options_override_the_selected_tsconfig() {
     let fixture = Fixture::new();
+    // Keep the entry files in ESM format so this config-surface test does not
+    // conflate decorator behavior with the documented compat-tier limitation
+    // for CommonJS entries that need external transform helpers.
+    std::fs::write(
+        fixture.project.join("package.json"),
+        r#"{ "type": "module" }"#,
+    )
+    .unwrap();
     std::fs::write(
         fixture.project.join("tsconfig.runtime.jsonc"),
         r#"{ "compilerOptions": {
@@ -499,17 +507,9 @@ export function jsxDEV(tag, props) { return { mode: "development", tag, props };
     )
     .unwrap();
     std::fs::write(
-        fixture.project.join("decorated.tsx"),
-        r#"const parameterTypes: string[][] = [];
-Reflect.metadata = (key: string, value: unknown[]) => () => {
-  if (key === "design:paramtypes") parameterTypes.push(value.map(type => type.name));
-};
-function marked<T>(value: T): T { return value; }
-@marked class Dependency {}
-@marked class Service { constructor(_dependency: Dependency) {} }
-console.log(JSON.stringify({
+        fixture.project.join("automatic.tsx"),
+        r#"console.log(JSON.stringify({
   element: <widget answer={42} />,
-  parameterTypes,
   snapshot: JSON.parse(process.env.__NUB_RUNTIME_CONFIG ?? "{}"),
 }));
 "#,
@@ -528,15 +528,10 @@ console.log(JSON.stringify({
     .unwrap();
 
     let mut automatic = fixture.command();
-    automatic.arg("decorated.tsx");
+    automatic.arg("automatic.tsx");
     let automatic = probe_json("top-level automatic JSX and decorator options", automatic);
     assert_eq!(automatic["element"]["mode"], "development", "{automatic}");
     assert_eq!(automatic["element"]["tag"], "widget", "{automatic}");
-    assert_eq!(
-        automatic["parameterTypes"],
-        serde_json::json!([["Dependency"]]),
-        "{automatic}"
-    );
     assert_eq!(automatic["snapshot"]["jsx"], "react-jsxdev", "{automatic}");
     assert_eq!(
         automatic["snapshot"]["jsxImportSource"], "./runtime",
@@ -550,6 +545,24 @@ console.log(JSON.stringify({
         automatic["snapshot"]["emitDecoratorMetadata"], true,
         "{automatic}"
     );
+
+    std::fs::write(
+        fixture.project.join("decorated.ts"),
+        r#"const parameterTypes: string[][] = [];
+Reflect.metadata = (key: string, value: unknown[]) => () => {
+  if (key === "design:paramtypes") parameterTypes.push(value.map(type => type.name));
+};
+function marked<T>(value: T): T { return value; }
+@marked class Dependency {}
+@marked class Service { constructor(_dependency: Dependency) {} }
+console.log(JSON.stringify(parameterTypes));
+"#,
+    )
+    .unwrap();
+    let mut typescript = fixture.command();
+    typescript.arg("decorated.ts");
+    let typescript = probe_json("top-level legacy decorators and metadata", typescript);
+    assert_eq!(typescript, serde_json::json!([["Dependency"]]));
 
     std::fs::write(
         fixture.project.join("decorated.js"),

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -2240,8 +2240,9 @@ const NEUTRALIZE_LOCALSTORAGE_ENV: &str = "__NUB_NEUTRALIZE_LOCALSTORAGE";
 /// the same preload via NODE_OPTIONS) and they advertise the marker too.
 const VERSION_ENV: &str = "__NUB_VERSION";
 
-/// Carries the resolved `nub.jsonc` snapshot (`preload`, `loader`, `tsconfig`)
-/// to the runtime as JSON. Resolved ONCE by the Rust frontend after the final
+/// Carries the resolved `nub.jsonc` runtime snapshot (preloads, loaders,
+/// TypeScript transforms, and the selected tsconfig) to the runtime as JSON.
+/// Resolved ONCE by the Rust frontend after the final
 /// cwd is known and transported unchanged through nested shim launches, so every
 /// process in a run transpiles against the same config. Internal plumbing, not a
 /// user knob — and denylisted from `.env` sources, since a repo-supplied value

--- a/crates/nub-core/src/workspace/env.rs
+++ b/crates/nub-core/src/workspace/env.rs
@@ -26,8 +26,8 @@ const ENV_FILE_MAX_BYTES: u64 = 16 * 1024 * 1024;
 /// - `NODE_EXTRA_CA_CERTS` — adds a trusted CA to the process.
 /// - `NODE_REPL_EXTERNAL_MODULE` — auto-loads a module at start-up.
 /// - `__NUB_RUNTIME_CONFIG` — nub's own resolved `nub.jsonc` snapshot, handed to
-///   the child as JSON. It carries `preload`, `loader`, and `tsconfig`, so a
-///   `.env` that sets it would rewrite the code nub transpiles. The watch path
+///   the child as JSON. It carries runtime loaders and TypeScript transforms,
+///   so a `.env` that sets it would rewrite the code nub transpiles. The watch path
 ///   in particular applies its injected `.env` values AFTER stamping this var,
 ///   so without the denylist a repo-supplied `.env` wins.
 /// - `__NUB_COMPAT_*` / `__NUB_AUGMENTED_*` — the parent-captured ambient

--- a/nub.jsonc
+++ b/nub.jsonc
@@ -1,4 +1,0 @@
-﻿{
-  // hello
-  "nodeCompat": true
-}

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -157,6 +157,23 @@ let runtimeConfig = {};
 try { runtimeConfig = JSON.parse(process.env.__NUB_RUNTIME_CONFIG || "{}"); } catch {}
 const RUNTIME_LOADER = runtimeConfig.loader || {};
 const RUNTIME_TSCONFIG = runtimeConfig.tsconfig || undefined;
+// Transform-only TypeScript options may live directly in `nub.jsonc`. They
+// override the selected/nearest tsconfig because the project runtime config is
+// the more specific source for what Nub executes; `baseUrl`/`paths` stay in the
+// tsconfig reader, where editors and the resolver share them.
+const RUNTIME_COMPILER_OPTIONS = {};
+for (const key of [
+  "jsx",
+  "jsxFactory",
+  "jsxFragmentFactory",
+  "jsxImportSource",
+  "experimentalDecorators",
+  "emitDecoratorMetadata",
+]) {
+  if (runtimeConfig[key] !== null && runtimeConfig[key] !== undefined) {
+    RUNTIME_COMPILER_OPTIONS[key] = runtimeConfig[key];
+  }
+}
 
 // NOTE: the transpile-cache version component is no longer read here. nub's
 // version is baked into the native addon at compile time (`env!("CARGO_PKG_VERSION")`
@@ -258,9 +275,13 @@ export function getTsconfigForDir(dir) {
   const result = nubNative
     ? nubNative.loadTsconfig(dir, RUNTIME_TSCONFIG)
     : { path: null, compilerOptions: null, tsconfigHash: "" };
-  tsconfigCache.set(dir, result);
-  if (result.path) _reportDep?.(result.path);
-  return result;
+  const compilerOptions = Object.keys(RUNTIME_COMPILER_OPTIONS).length > 0
+    ? { ...(result.compilerOptions || {}), ...RUNTIME_COMPILER_OPTIONS }
+    : result.compilerOptions;
+  const resolved = { ...result, compilerOptions };
+  tsconfigCache.set(dir, resolved);
+  if (resolved.path) _reportDep?.(resolved.path);
+  return resolved;
 }
 
 // The NEAREST package.json's `type` decides the format of ambiguous extensions
@@ -585,7 +606,8 @@ function stage3DecoratorError(filePath) {
     `This is an upstream limitation in oxc (oxc-project/oxc#9170).\n` +
     `  in ${filePath}\n\n` +
     `Workarounds:\n` +
-    `  1. Set "experimentalDecorators": true in tsconfig.json to use legacy decorators\n` +
+    `  1. Set "decorators": "legacy" in nub.jsonc, or set\n` +
+    `     "experimentalDecorators": true in tsconfig.json\n` +
     `     (the shape NestJS / TypeORM / class-validator are written against).\n` +
     `  2. Wait for Stage 3 decorator support in oxc; tracked upstream at\n` +
     `     https://github.com/oxc-project/oxc/issues/9170.\n\n` +
@@ -713,6 +735,7 @@ export function loadTranspile(url, ext) {
   if (lang === "tsx" || lang === "jsx") {
     opts.jsx = {
       runtime: co?.jsx === "react" ? "classic" : "automatic",
+      development: co?.jsx === "react-jsxdev",
       importSource: co?.jsxImportSource || "react",
     };
     if (co?.jsxFactory) opts.jsx.pragma = co.jsxFactory;
@@ -741,7 +764,11 @@ export function loadTranspile(url, ext) {
   const formatByte = format === "commonjs" ? "c" : "m";
   // The RAW configured loader, not `lang`: a non-TS/JSX loader (`text`, `json5`)
   // changes the output without changing `lang`, so the key must see it.
-  const runtimeHash = JSON.stringify({ loader: RUNTIME_LOADER[ext] || null, tsconfig: RUNTIME_TSCONFIG || null });
+  const runtimeHash = JSON.stringify({
+    loader: RUNTIME_LOADER[ext] || null,
+    tsconfig: RUNTIME_TSCONFIG || null,
+    compilerOptions: RUNTIME_COMPILER_OPTIONS,
+  });
   const result = nubNative.transformCached(
     filePath, source, opts, ext, `${tsconfigHash || ""}\0${runtimeHash}`, pkgType || "", formatByte, getCacheDir() ?? undefined,
   );

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -18,9 +18,15 @@ Put `nub.jsonc` at the project root. Every field it takes, with its full value s
 
   // text | jsonc | json5 | toml | yaml | ts | tsx | jsx
   "loader": { ".graphql": "text" },
-  "conditions": ["development"],           // additional; matched before "default"
-  "tsconfig": "./tsconfig.runtime.json",   // JSX, decorators, paths, conditions — not type checking
   "verifyDeps": "warn",                    // warn | error | true | false
+  "tsconfig": "./tsconfig.runtime.json",   // paths, conditions, transform defaults; no type checking
+  "conditions": ["development"],           // additional; matched before "default"
+  "jsx": "react-jsx",                      // react | react-jsx | react-jsxdev
+  "jsxImportSource": "preact",             // automatic runtime package
+  "jsxFactory": "createElement",            // classic runtime factory
+  "jsxFragmentFactory": "Fragment",         // classic runtime fragment factory
+  "decorators": "legacy",                  // legacy TypeScript decorator semantics
+  "emitDecoratorMetadata": true,            // design-type metadata for legacy decorators
 
   // ── installs — Nub-identity projects only ──
   "install": {
@@ -272,7 +278,62 @@ jsx
 
 An entry may also point an extension Nub already knows at something else — `".ts": "text"` imports TypeScript sources as strings, and `".ts": "tsx"` turns JSX on for them. One pairing is rejected: `ts` on `.tsx` or `.jsx`. Those extensions are always parsed as JSX, so the entry could not take effect, and Nub reports it rather than accepting a setting that does nothing.
 
+### `verifyDeps`
+
+Warn when installed dependencies may be stale.
+
+```jsonc title="nub.jsonc"
+{
+  // ...
+  "verifyDeps": "warn"
+}
+```
+
+Stop instead of running.
+
+```jsonc title="nub.jsonc"
+{
+  // ...
+  "verifyDeps": "error"
+}
+```
+
+Skip the check.
+
+```jsonc title="nub.jsonc"
+{
+  // ...
+  "verifyDeps": false
+}
+```
+
+Nub rejects pnpm's `"install"` and `"prompt"` values, which it does not implement.
+
+### `tsconfig`
+
+Choose the TypeScript configuration Nub's runtime reads. Nub uses it for [path mapping](https://www.typescriptlang.org/tsconfig/#paths), [custom conditions](#conditions), and as the fallback source for JSX and decorator settings — not for type checking. Top-level JSX and decorator fields in `nub.jsonc` override their `compilerOptions` counterparts.
+
+```jsonc title="nub.jsonc"
+{
+  // ...
+  "tsconfig": "./tsconfig.runtime.json"
+}
+```
+
+```jsonc title="tsconfig.runtime.json"
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
 ### `conditions`
+
+<Callout title="Note">`conditions` is also supported as `compilerOptions.customConditions` in `tsconfig.json`. Prefer the TypeScript config in TypeScript projects.</Callout>
 
 Add **additional** package export conditions. Nub passes each entry to Node as `--conditions` (same as `-C` on the command line). Node always keeps its built-in conditions (`node`, `import`, `require`, `default`); your names are extra, and on an `exports` map they are matched before `default`.
 
@@ -310,58 +371,57 @@ Nub also applies the [`customConditions`](https://www.typescriptlang.org/tsconfi
 
 TypeScript uses them to resolve types, and Nub passes them to Node as well — so the file the type checker followed is the file that runs. A condition declared in the base config a package `extends` counts.
 
-### `tsconfig`
+### `jsx`
 
-Choose the TypeScript configuration Nub's runtime reads. Nub uses it for the options that affect execution — JSX, decorators, [path mapping](https://www.typescriptlang.org/tsconfig/#paths), and [custom conditions](#conditions) — not for type checking.
+<Callout title="Note">`jsx`, `jsxImportSource`, `jsxFactory`, and `jsxFragmentFactory` are also supported in `tsconfig.json`. Prefer the TypeScript config in TypeScript projects.</Callout>
 
-```jsonc title="nub.jsonc"
-{
-  // ...
-  "tsconfig": "./tsconfig.runtime.json"
-}
-```
-
-```jsonc title="tsconfig.runtime.json"
-{
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  }
-}
-```
-
-### `verifyDeps`
-
-Warn when installed dependencies may be stale.
+Configure JSX without adding a TypeScript config. The accepted modes all emit JavaScript that Nub can execute directly: `react`, `react-jsx`, and `react-jsxdev`.
 
 ```jsonc title="nub.jsonc"
 {
   // ...
-  "verifyDeps": "warn"
+  "jsx": "react-jsx",
+  "jsxImportSource": "preact"
 }
 ```
 
-Stop instead of running.
+The automatic runtime uses `jsxImportSource` as its package. The classic runtime uses `jsxFactory` as its element function and `jsxFragmentFactory` as its fragment value.
 
 ```jsonc title="nub.jsonc"
 {
   // ...
-  "verifyDeps": "error"
+  "jsx": "react",
+  "jsxFactory": "h",
+  "jsxFragmentFactory": "Fragment"
 }
 ```
 
-Skip the check.
+### `decorators`
+
+<Callout title="Note">Legacy decorators are also configured with `compilerOptions.experimentalDecorators` in `tsconfig.json`. Prefer the TypeScript config in TypeScript projects.</Callout>
+
+Enable TypeScript's legacy decorator transform.
 
 ```jsonc title="nub.jsonc"
 {
   // ...
-  "verifyDeps": false
+  "decorators": "legacy"
 }
 ```
 
-Nub rejects pnpm's `"install"` and `"prompt"` values, which it does not implement.
+### `emitDecoratorMetadata`
+
+<Callout title="Note">`emitDecoratorMetadata` is also supported in `tsconfig.json`. Prefer the TypeScript config in TypeScript projects.</Callout>
+
+Emit the design-type metadata used by decorator-based dependency injection and ORM libraries. This setting takes effect with legacy decorators enabled.
+
+```jsonc title="nub.jsonc"
+{
+  // ...
+  "decorators": "legacy",
+  "emitDecoratorMetadata": true
+}
+```
 
 ## `install`
 

--- a/site/content/docs/runtime/decorators.mdx
+++ b/site/content/docs/runtime/decorators.mdx
@@ -3,14 +3,12 @@ title: Decorators
 description: How Nub runs legacy TypeScript decorators and their emitted design-type metadata on stock Node — the form the NestJS, TypeORM, and Angular dependency-injection ecosystem is written against.
 ---
 
-Set `experimentalDecorators: true` in your `tsconfig.json` and decorated classes run with no build step. This is the legacy decorator form the DI / ORM ecosystem (NestJS, TypeORM, Angular) is written against.
+Set the decorator mode to `legacy` in `nub.jsonc` and decorated classes run with no build step. This is the legacy decorator form the DI / ORM ecosystem (NestJS, TypeORM, Angular) is written against.
 
-```json
+```jsonc title="nub.jsonc"
 {
-  "compilerOptions": {
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
-  }
+  "decorators": "legacy",
+  "emitDecoratorMetadata": true
 }
 ```
 
@@ -25,10 +23,12 @@ class Account {
 }
 ```
 
+Nub also reads `compilerOptions.experimentalDecorators` and `compilerOptions.emitDecoratorMetadata` from the selected or nearest `tsconfig.json`. Top-level Nub fields override their TypeScript equivalents when both are present.
+
 ## `emitDecoratorMetadata`
 
 When `emitDecoratorMetadata` is also set, Nub emits the `Reflect.metadata(...)` calls that DI containers read for constructor-parameter type inference. The emitted code references `Reflect.metadata`, so install and import `reflect-metadata` yourself, exactly as on plain TypeScript — Nub does not auto-inject it.
 
 ## Stage 3 decorators
 
-Stage 3 decorators (TypeScript 5's default when neither flag is set) are not supported: that transform is an [upstream gap in oxc](https://github.com/oxc-project/oxc/issues/9170), so Nub rejects Stage-3-shaped decorator syntax with a diagnostic pointing you at `experimentalDecorators: true`.
+Stage 3 decorators (TypeScript 5's default when no legacy mode is selected) are not supported: that transform is an [upstream gap in oxc](https://github.com/oxc-project/oxc/issues/9170), so Nub rejects Stage-3-shaped decorator syntax with a diagnostic pointing you at `decorators: "legacy"`.

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -60,7 +60,7 @@ In brief:
 
 - **[TypeScript](/docs/runtime/typescript)** — the whole TypeScript surface runs directly, including non-erasable syntax (`enum`, `namespace`, parameter properties). Types are stripped, not checked.
 - **[JSX](/docs/runtime/jsx)** — `.jsx` and `.tsx` files run with the modern automatic runtime by default, configured through `tsconfig.json` or a per-file `@jsxImportSource` pragma.
-- **[Decorators](/docs/runtime/decorators)** — legacy decorators run with no build step under `experimentalDecorators`, including `emitDecoratorMetadata` for the DI / ORM ecosystem.
+- **[Decorators](/docs/runtime/decorators)** — legacy decorators run with no build step, including emitted design-type metadata for the DI / ORM ecosystem.
 - **[Resolution](/docs/runtime/resolution)** — extensionless imports, `.js → .ts` rewriting, and `tsconfig.json` path aliases resolve at runtime, the way `tsc` and your editor resolve them.
 - **[Environment variables](/docs/runtime/env)** — `.env*` files load into the environment before Node starts, with `${VAR}` expansion. No `dotenv`, no `--env-file`.
 - **[Varlock](/docs/runtime/varlock)** — a project with an `@env-spec` schema hands its environment to Varlock instead, with no wrapper command and no import in your source.

--- a/site/content/docs/runtime/jsx.mdx
+++ b/site/content/docs/runtime/jsx.mdx
@@ -9,9 +9,30 @@ Files ending in `.jsx` and `.tsx` execute through the same load hook. JSX is rec
 nub render.tsx
 ```
 
-## `compilerOptions.jsx`
+## `nub.jsonc`
 
-Configure the JSX runtime through `tsconfig.json`, the way the rest of your toolchain already does. These `compilerOptions` are honored:
+Configure the runtime directly in the project file. The field names match TypeScript's compiler options, and the `jsx` field accepts the three modes that emit executable JavaScript: `react`, `react-jsx`, and `react-jsxdev`.
+
+```jsonc title="nub.jsonc"
+{
+  "jsx": "react-jsx",
+  "jsxImportSource": "preact"
+}
+```
+
+The classic runtime also accepts `jsxFactory` and `jsxFragmentFactory`.
+
+```jsonc title="nub.jsonc"
+{
+  "jsx": "react",
+  "jsxFactory": "h",
+  "jsxFragmentFactory": "Fragment"
+}
+```
+
+## `tsconfig.json`
+
+Nub still reads the same settings from `compilerOptions` when they are absent from `nub.jsonc`, so the runtime can share configuration with the rest of the toolchain. Top-level Nub fields win when both files set the same option.
 
 - **`jsx`** — the runtime mode. One of:
 

--- a/site/content/docs/runtime/typescript.mdx
+++ b/site/content/docs/runtime/typescript.mdx
@@ -18,7 +18,7 @@ Nub does not type-check — types are stripped for execution. Keep `tsc --noEmit
 
 ## Choosing a tsconfig
 
-Nub reads the nearest `tsconfig.json` for the settings that affect execution — JSX, decorators, and the [resolution](/docs/runtime/resolution) layer. Name a different file in a [nub.jsonc](/docs/config#tsconfig) when the config your editor uses is not the one the runtime should read.
+Nub reads the nearest `tsconfig.json` for the [resolution](/docs/runtime/resolution) layer and transform defaults. Set JSX and decorator options directly in [nub.jsonc](/docs/config#jsx), or name a different TypeScript config when the runtime should not use the one your editor finds.
 
 ```jsonc title="nub.jsonc"
 {
@@ -56,7 +56,7 @@ import fs = require("node:fs");
 
 You opt into the syntax by writing it; Nub makes it run.
 
-JSX and decorators each have their own page: see [JSX](/docs/runtime/jsx) for the `.jsx` / `.tsx` runtime and tsconfig configuration, and [Decorators](/docs/runtime/decorators) for the legacy `experimentalDecorators` form and `emitDecoratorMetadata`.
+JSX and decorators each have their own page: see [JSX](/docs/runtime/jsx) for the `.jsx` / `.tsx` runtime and tsconfig configuration, and [Decorators](/docs/runtime/decorators) for the legacy decorator mode and emitted design-type metadata.
 
 ## Plain JavaScript
 

--- a/site/content/docs/watch.mdx
+++ b/site/content/docs/watch.mdx
@@ -17,7 +17,7 @@ nub watch src/server.ts
 
 TypeScript, JSX, `.env*` loading, `tsconfig.json` paths — everything `nub <file>` gives you is active here too, because `nub watch` runs the same augmented Node underneath.
 
-A project [`nub.jsonc`](/docs/config) applies the same way: its runtime settings — `preload`, `envFile`, `loader`, `conditions`, `tsconfig` — are in force on every restart.
+A project [`nub.jsonc`](/docs/config) applies the same way: preloads, environment files, loaders, conditions, TypeScript transforms, and the selected tsconfig are in force on every restart.
 
 A `--watch` placed after a script name is forwarded *to the script* like any other argument — `nub run test --watch` runs your test tool's own watch mode, it does not invoke Nub's watcher. See [`nub run` → Forward arguments](/docs/runner/run#forward-arguments).
 

--- a/site/public/schema/latest.json
+++ b/site/public/schema/latest.json
@@ -84,6 +84,39 @@
       "type": "string",
       "description": "Path to the tsconfig used by Nub's runtime."
     },
+    "jsx": {
+      "enum": [
+        "react",
+        "react-jsx",
+        "react-jsxdev"
+      ],
+      "description": "JSX runtime mode. Overrides compilerOptions.jsx from the selected tsconfig."
+    },
+    "jsxFactory": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Classic JSX factory. Overrides compilerOptions.jsxFactory from the selected tsconfig."
+    },
+    "jsxFragmentFactory": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Classic JSX fragment factory. Overrides compilerOptions.jsxFragmentFactory from the selected tsconfig."
+    },
+    "jsxImportSource": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Automatic JSX runtime package. Overrides compilerOptions.jsxImportSource from the selected tsconfig."
+    },
+    "decorators": {
+      "enum": [
+        "legacy"
+      ],
+      "description": "Decorator semantics to transform. Legacy maps to compilerOptions.experimentalDecorators."
+    },
+    "emitDecoratorMetadata": {
+      "type": "boolean",
+      "description": "Emit design-type metadata for legacy decorators. Requires decorators to be legacy."
+    },
     "verifyDeps": {
       "oneOf": [
         {


### PR DESCRIPTION
## Summary

- add first-party JSX transform fields to `nub.jsonc`
- add `decorators: "legacy"` as the native equivalent of TypeScript's legacy decorator option
- document every TypeScript-compatible field with a short note recommending `tsconfig.json` for TypeScript projects
- carry native transform settings through precedence, runtime snapshots, cache identity, schema, config commands, and end-to-end coverage
- remove the stray root `nub.jsonc` that forced repository tests into Node compatibility mode

## Verification

- `make verify`
- `cargo test -p nub-cli --test project_runtime_config`
- `site: nub run typecheck`
- `site: nub run build`
