### PR TITLE
run(windows): carry the bundled POSIX shell with the relocated nub.exe

### DIFF
--- a/.github/workflows/busybox-run-probe.yml
+++ b/.github/workflows/busybox-run-probe.yml
@@ -1,9 +1,13 @@
 # Branch-scoped Windows probe (see .claude/skills/ci-adhoc-test) — NO PR needed.
 # Pushing to the busybox-shell branch runs this on a real windows-latest runner.
-# It builds a real nub, stages busybox.exe next to nub.exe exactly as the win32
-# package lays it out, and drives the integrated `nub run` (production sidecar
-# resolution, /tmp glue, .bin shim resolution, --script-shell override) — the
-# acceptance test for the bundled busybox script shell that macOS/Linux cannot run.
+# It builds a real nub and drives the integrated `nub run` (sidecar resolution, /tmp
+# glue, .bin shim resolution, --script-shell override) — the acceptance test for the
+# bundled busybox script shell that macOS/Linux cannot run.
+#
+# It covers BOTH layouts the binary can find its shell in: `busybox.exe` beside
+# nub.exe (how the win32 package ships), and `nub-sh/busybox.exe` beside a nub.exe the
+# npm launcher relocated into npm's global bin dir (#687), plus a negative control
+# proving a shell-less layout really does fail.
 name: busybox-run-probe
 on:
   push:
@@ -13,6 +17,10 @@ on:
       - '.github/workflows/busybox-run-probe.yml'
       - 'crates/nub-cli/src/cli.rs'
       - 'vendor/busybox-w32/**'
+      # The launcher decides WHERE nub.exe ends up, and the shell is resolved relative
+      # to it — so a launcher change can break `nub run` without touching cli.rs. That
+      # is exactly how #687 shipped.
+      - 'npm/nub/**'
   workflow_dispatch:
 
 permissions:

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4890,8 +4890,11 @@ fn resolve_bundled_busybox() -> Result<String> {
         .parent()
         .ok_or_else(|| anyhow::anyhow!("nub binary has no parent directory"))?;
     let [beside, staged] = busybox_candidates(dir);
-    if let Some(found) = [&beside, &staged].into_iter().find(|p| p.is_file()) {
-        return to_utf8(found.clone());
+    if beside.is_file() {
+        return to_utf8(beside);
+    }
+    if staged.is_file() {
+        return to_utf8(staged);
     }
     bail!(
         "nub's bundled POSIX shell (busybox.exe) was not found next to the nub \

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4839,13 +4839,31 @@ enum StreamMode {
     Prefixed,
 }
 
+/// The nub-owned subdirectory the npm launcher carries the bundled shell into when it
+/// relocates `nub.exe`. Must match `SHELL_SUBDIR` in `npm/nub/bin/launch.js`.
+const NUB_SHELL_SUBDIR: &str = "nub-sh";
+
 /// Resolve the bundled busybox-w32 POSIX-`sh` sidecar that backs `nub run` script
-/// bodies on Windows. The win32 package lays `busybox.exe` beside `nub.exe` in the
-/// package's `bin/` dir, so it resolves relative to the running executable
-/// (canonicalized, matching `current_nub_binary`). `__NUB_BUSYBOX_EXE` overrides
-/// the location — an internal test/CI seam that lets the Rust suite and the
-/// branch-scoped Windows probe supply a busybox without the release-packaging step;
-/// it is NOT a documented user knob (`--script-shell` is the user-facing override).
+/// bodies on Windows. `__NUB_BUSYBOX_EXE` overrides the location — an internal
+/// test/CI seam that lets the Rust suite and the branch-scoped Windows probe supply a
+/// busybox without the release-packaging step; it is NOT a documented user knob
+/// (`--script-shell` is the user-facing override).
+///
+/// Otherwise it resolves relative to the running executable (canonicalized, matching
+/// `current_nub_binary`), checking TWO layouts in order:
+///
+///   * `<exe dir>/busybox.exe` — how the win32 npm package, the release `.zip` behind
+///     `install.ps1`, and `nub upgrade`'s self-owned `~/.nub/bin` all lay it out.
+///   * `<exe dir>/nub-sh/busybox.exe` — where the npm launcher stages it after
+///     hardlinking `nub.exe` into npm's global bin dir for the PATHEXT fast path
+///     (`healWindowsBinDir`). That directory is on PATH, so the shell goes in a
+///     subdirectory rather than beside the binary: a bare `busybox.exe` on PATH would
+///     shadow a busybox the user installed themselves.
+///
+/// The second layout is what #687 needed. 0.7.0 began relocating the binary and this
+/// resolution had no way to follow it, so every `nub run` on a Windows npm install
+/// failed from the second invocation onward.
+///
 /// A missing sidecar is a clean error, never a panic and never a silent cmd.exe
 /// fallback — that would resurrect the non-POSIX script semantics busybox replaces.
 /// Only reached on Windows (the `cfg!(windows)` default arm); cross-platform std so
@@ -4871,16 +4889,27 @@ fn resolve_bundled_busybox() -> Result<String> {
     let dir = exe
         .parent()
         .ok_or_else(|| anyhow::anyhow!("nub binary has no parent directory"))?;
-    let busybox = dir.join("busybox.exe");
-    if !busybox.is_file() {
-        bail!(
-            "nub's bundled POSIX shell (busybox.exe) was not found next to the nub \
-             executable at {}. Reinstall nub, or set `script-shell` in .npmrc to a \
-             POSIX shell on PATH.",
-            busybox.display()
-        );
+    let [beside, staged] = busybox_candidates(dir);
+    if let Some(found) = [&beside, &staged].into_iter().find(|p| p.is_file()) {
+        return to_utf8(found.clone());
     }
-    to_utf8(busybox)
+    bail!(
+        "nub's bundled POSIX shell (busybox.exe) was not found next to the nub \
+         executable — looked at {} and {}. Reinstall nub, or set `script-shell` in \
+         .npmrc to a POSIX shell on PATH.",
+        beside.display(),
+        staged.display()
+    );
+}
+
+/// The two busybox layouts, in resolution order, for an executable directory.
+/// Split out from [`resolve_bundled_busybox`] so the ORDER is unit-testable without
+/// having to relocate the test binary's own `current_exe()`.
+fn busybox_candidates(dir: &Path) -> [PathBuf; 2] {
+    [
+        dir.join("busybox.exe"),
+        dir.join(NUB_SHELL_SUBDIR).join("busybox.exe"),
+    ]
 }
 
 /// Build the shell `Command` for a package script with Nub's augmentation
@@ -12580,6 +12609,52 @@ mod tests {
         assert!(
             v.ends_with("v8-compile-cache"),
             "the cache dir is nub-owned, got {v}"
+        );
+    }
+
+    #[test]
+    fn busybox_resolves_beside_the_binary_before_the_relocated_shell_dir() {
+        // #687: 0.7.0 began hardlinking nub.exe into npm's global bin dir, away from
+        // the `busybox.exe` this resolution had always assumed was its sibling, and
+        // every `nub run` on a Windows npm install broke. The launcher now carries the
+        // shell into a `nub-sh/` subdir beside the relocated binary, so BOTH layouts
+        // must resolve — and the sibling must win, because that is the untouched
+        // packaged layout (win32 package, install.ps1's .zip, `nub upgrade`'s
+        // ~/.nub/bin) and a stale staged copy must never shadow it.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let beside = root.join("busybox.exe");
+        let staged = root.join(NUB_SHELL_SUBDIR).join("busybox.exe");
+
+        assert_eq!(
+            busybox_candidates(root),
+            [beside.clone(), staged.clone()],
+            "the sibling sidecar must be probed before the relocated nub-sh/ copy"
+        );
+
+        // Neither present: the caller bails. Asserting on the candidate list rather
+        // than resolve_bundled_busybox() because that reads the TEST binary's
+        // current_exe(), which no fixture can relocate.
+        assert!(
+            !busybox_candidates(root).iter().any(|p| p.is_file()),
+            "an empty dir must offer no resolvable candidate"
+        );
+
+        // Only the relocated copy: found. This is the case that was broken.
+        std::fs::create_dir_all(staged.parent().unwrap()).expect("mkdir nub-sh");
+        std::fs::write(&staged, b"stub").expect("write staged busybox");
+        assert_eq!(
+            busybox_candidates(root).into_iter().find(|p| p.is_file()),
+            Some(staged.clone()),
+            "a binary relocated away from its sidecar must resolve nub-sh/busybox.exe"
+        );
+
+        // Both present: the sibling wins.
+        std::fs::write(&beside, b"stub").expect("write sibling busybox");
+        assert_eq!(
+            busybox_candidates(root).into_iter().find(|p| p.is_file()),
+            Some(beside),
+            "the packaged sibling layout must take precedence over the staged copy"
         );
     }
 

--- a/npm/nub/bin/launch.js
+++ b/npm/nub/bin/launch.js
@@ -218,7 +218,58 @@ function cmdShimLeadsToUs(dir, verb, ourReal) {
   return false;
 }
 
-// WINDOWS: put a real `<verb>.exe` next to npm's shims and CHANGE NOTHING ELSE.
+// Place `src` at `dest` as a hardlink, idempotently. Extracted from the .exe path so
+// the shell sidecar below gets identical staleness + fallback semantics.
+//
+// Idempotent, and correct across an upgrade: `npm i -g` extracts a NEW binary at a
+// new inode, so an existing file from a previous version is stale and must be
+// re-linked. Comparing ino+dev is exact for a hardlink; the size fallback covers
+// the copy path, where ino necessarily differs.
+function stageWindowsLink(srcPath, srcStat, dest) {
+  try {
+    const cur = fs.statSync(dest);
+    if ((cur.ino && cur.ino === srcStat.ino && cur.dev === srcStat.dev) || cur.size === srcStat.size) return;
+    fs.rmSync(dest, { force: true });
+  } catch {}
+  try {
+    fs.linkSync(srcPath, dest);
+  } catch {
+    // EXDEV (prefix on a different volume from the store) or a filesystem without
+    // hardlinks: fall back to a copy. Costs the file's size on disk once, which is
+    // why it is the fallback and not the default.
+    try { fs.copyFileSync(srcPath, dest); } catch {}
+  }
+}
+
+// The nub-owned subdirectory the bundled POSIX shell is carried into. Must match
+// NUB_SHELL_SUBDIR in crates/nub-cli/src/cli.rs (resolve_bundled_busybox).
+const SHELL_SUBDIR = "nub-sh";
+
+// Carry the bundled POSIX shell along with the .exe we just linked.
+//
+// `nub run` executes script bodies through the bundled busybox-w32 `sh`, and the
+// binary resolves it RELATIVE TO ITSELF (cli.rs resolve_bundled_busybox). The win32
+// package lays `busybox.exe` beside `bin/nub.exe`, so that holds — until the .exe is
+// hardlinked into npm's global bin dir, whose parent has no sidecar, and every
+// `nub run` then dies "bundled POSIX shell (busybox.exe) was not found" (#687).
+//
+// It goes in a SUBDIRECTORY, not beside the .exe, because `dir` is by construction a
+// directory on the user's PATH: a bare `busybox.exe` there would shadow a busybox the
+// user installed themselves, which is the same shadowing hazard cmdShimLeadsToUs
+// exists to prevent — and worse here, since the name is not even ours. A subdirectory
+// is not searched by PATH, so it is invisible to command resolution.
+//
+// A missing source is not an error: a NEWER launcher can run against an OLDER platform
+// package that predates the bundled shell (<0.6.0), and those installs never had one.
+function stageWindowsShell(pkgBinDir, dir) {
+  const from = path.join(pkgBinDir, "busybox.exe");
+  let st; try { st = fs.statSync(from); } catch { return; }
+  const into = path.join(dir, SHELL_SUBDIR);
+  try { fs.mkdirSync(into, { recursive: true }); } catch { return; }
+  stageWindowsLink(from, st, path.join(into, "busybox.exe"));
+}
+
+// WINDOWS: put a real `<verb>.exe` next to npm's shims, plus the shell it needs.
 //
 // The heal below is POSIX-only because there is no shebang or symlink fast path on
 // Windows — every call goes cmd.exe -> nub.cmd -> node -> spawn nub.exe, and the node
@@ -226,15 +277,19 @@ function cmdShimLeadsToUs(dir, verb, ourReal) {
 // of `nub.cmd` by PATHEXT, so cmd.exe reaches the binary directly. Measured on
 // windows-latest, N=40: 95.6 -> 35.8 ms.
 //
-// DELIBERATELY ADD-ONLY. npm's `.ps1` and extensionless shims are left exactly as
-// generated: we are not the first package to start editing files npm owns (checked —
-// esbuild, bun and @pnpm/exe all modify only files inside their OWN package and never
-// touch the global bin dir). The cost is that PowerShell and every sh-family shell keep
-// preferring those shims and see no improvement — including nub's OWN Windows script
-// shell, the bundled busybox (cli.rs `resolve_bundled_busybox`), measured 170.3 -> 169.0
-// ms, i.e. nothing. `nub run` therefore does not benefit. That trade was made explicitly.
+// ADD-ONLY WITH RESPECT TO FILES NPM OWNS. npm's `.ps1` and extensionless shims are
+// left exactly as generated: we are not the first package to start editing files npm
+// owns (checked — esbuild, bun and @pnpm/exe all modify only files inside their OWN
+// package and never touch the global bin dir). The cost is that PowerShell and every
+// sh-family shell keep preferring those shims and see no improvement — including nub's
+// OWN Windows script shell, the bundled busybox (cli.rs `resolve_bundled_busybox`),
+// measured 170.3 -> 169.0 ms, i.e. nothing. `nub run` therefore does not benefit on
+// SPEED. It does depend on this function for CORRECTNESS: relocating the .exe moves
+// the binary away from the sidecar it resolves relative to itself, which is what
+// stageWindowsShell repairs (#687). Reading that trade as "nub run is unaffected"
+// is how the regression shipped.
 //
-// TWO RESIDUES THIS SHAPE OWNS, both from the `.exe` being a file npm does not track:
+// THREE RESIDUES THIS SHAPE OWNS, all from writing files npm does not track:
 //
 //   UNINSTALL. `npm uninstall -g @nubjs/nub` removes only the shims npm generated;
 //   cmd-shim never created `<verb>.exe` and npm has run no uninstall lifecycle script
@@ -242,14 +297,15 @@ function cmdShimLeadsToUs(dir, verb, ourReal) {
 //   answering `nub` from cmd.exe after the user believes nub is gone — and on the
 //   hardlink path the surviving link also keeps the binary's bytes on disk. This is a
 //   real user-visible residue, not merely wasted space; do not describe it as "npm's
-//   uninstall is unaffected".
+//   uninstall is unaffected". The `nub-sh/` shell dir survives the same way, but it is
+//   NOT on PATH, so it wastes space without answering any command.
 //
 //   UPGRADE. Once the `.exe` wins PATHEXT, cmd.exe never dispatches through npm's `.cmd`
 //   again, so THIS FUNCTION NEVER RUNS AGAIN for the users it serves and its currency
-//   check below cannot fire for them. `postinstall.js` (dropStaleWindowsExe) removes the
-//   file on every install so the next call re-heals against the new binary — but that
-//   only runs when lifecycle scripts do, so an `--ignore-scripts` upgrade still leaves
-//   cmd.exe executing the previous version silently.
+//   check below cannot fire for them. `postinstall.js` (dropStaleWindowsExe) removes both
+//   the file and `nub-sh/` on every install so the next call re-heals against the new
+//   binary — but that only runs when lifecycle scripts do, so an `--ignore-scripts`
+//   upgrade still leaves cmd.exe executing the previous version silently.
 //
 // Best-effort and silent, like every other heal step: any failure leaves a working
 // (slower) install rather than a broken one.
@@ -264,24 +320,11 @@ function healWindowsBinDir(verb, nativePath) {
     for (const dir of (process.env.PATH || "").split(path.delimiter)) {
       if (!dir) continue;
       if (!cmdShimLeadsToUs(dir, verb, ourReal)) continue;
-      const dest = path.join(dir, `${verb}.exe`);
-      // Idempotent, and correct across an upgrade: `npm i -g` extracts a NEW binary at a
-      // new inode, so an existing .exe from a previous version is stale and must be
-      // re-linked. Comparing ino+dev is exact for a hardlink; the size fallback covers
-      // the copy path, where ino necessarily differs.
-      try {
-        const cur = fs.statSync(dest);
-        if ((cur.ino && cur.ino === src.ino && cur.dev === src.dev) || cur.size === src.size) return;
-        fs.rmSync(dest, { force: true });
-      } catch {}
-      try {
-        fs.linkSync(nativeReal, dest);
-      } catch {
-        // EXDEV (prefix on a different volume from the store) or a filesystem without
-        // hardlinks: fall back to a copy. Costs the binary's size on disk once, which is
-        // why it is the fallback and not the default.
-        try { fs.copyFileSync(nativeReal, dest); } catch {}
-      }
+      stageWindowsLink(nativeReal, src, path.join(dir, `${verb}.exe`));
+      // Unconditional, NOT gated on the .exe having been (re)linked above: the
+      // 0.7.0-0.7.2 installs this fixes already carry a current .exe, so a shell
+      // staged only alongside a fresh link would never reach them.
+      stageWindowsShell(path.dirname(nativeReal), dir);
       break; // the first PATH entry that dispatches to us is the one that matters
     }
   } catch {}

--- a/npm/nub/postinstall.js
+++ b/npm/nub/postinstall.js
@@ -199,6 +199,12 @@ function dropStaleWindowsExe() {
       // delete — there is a real unrelated `nub@1.0.0` on npm.
       if (!fs.existsSync(path.join(dir, `${verb}.cmd`))) continue;
       try { fs.rmSync(path.join(dir, `${verb}.exe`), { force: true }); } catch {}
+      // The bundled POSIX shell the launcher carried in beside that `.exe`
+      // (healWindowsBinDir -> `nub-sh/busybox.exe`). Same staleness argument as the
+      // binary: the new package ships a new busybox inode, and the heal only re-stages
+      // once the `.exe` is gone. Removing the whole nub-owned dir keeps the two in
+      // lockstep — a fresh shell can never outlive the binary it was staged for.
+      try { fs.rmSync(path.join(dir, "nub-sh"), { recursive: true, force: true }); } catch {}
     }
   }
 }

--- a/npm/nub/postinstall.js
+++ b/npm/nub/postinstall.js
@@ -200,10 +200,12 @@ function dropStaleWindowsExe() {
       if (!fs.existsSync(path.join(dir, `${verb}.cmd`))) continue;
       try { fs.rmSync(path.join(dir, `${verb}.exe`), { force: true }); } catch {}
       // The bundled POSIX shell the launcher carried in beside that `.exe`
-      // (healWindowsBinDir -> `nub-sh/busybox.exe`). Same staleness argument as the
-      // binary: the new package ships a new busybox inode, and the heal only re-stages
-      // once the `.exe` is gone. Removing the whole nub-owned dir keeps the two in
-      // lockstep — a fresh shell can never outlive the binary it was staged for.
+      // (healWindowsBinDir -> `nub-sh/busybox.exe`). The heal re-stages this
+      // unconditionally, so unlike the `.exe` it is not stranded by being left here —
+      // but its currency check falls back to comparing SIZE when the inode differs,
+      // and a busybox that changed while keeping its size would be kept forever.
+      // Dropping the nub-owned dir at install time closes that, and costs one hardlink
+      // on the next call.
       try { fs.rmSync(path.join(dir, "nub-sh"), { recursive: true, force: true }); } catch {}
     }
   }

--- a/nub.jsonc
+++ b/nub.jsonc
@@ -1,4 +1,0 @@
-﻿{
-  // hello
-  "nodeCompat": true
-}

--- a/tests/busybox-run-probe/README.md
+++ b/tests/busybox-run-probe/README.md
@@ -17,7 +17,28 @@ end-to-end, not a standalone shell.
 shell to bundle — by driving each shell standalone. This probe is the acceptance
 test for the choice that won (busybox), through the integrated CLI.
 
-Cases (`node run-probe.mjs`), each `nub run <script>`:
+### Both shell layouts, plus a negative control
+
+The binary resolves its shell relative to itself, and there are two places that
+shell legitimately lives. The full case matrix runs against each:
+
+| layout | shape | who produces it |
+| --- | --- | --- |
+| `sidecar` | `busybox.exe` beside `nub.exe` | the win32 npm package, the release `.zip` behind `install.ps1`, `nub upgrade`'s `~/.nub/bin` |
+| `relocated` | `nub-sh/busybox.exe`, **no** sibling | the npm launcher, after hardlinking `nub.exe` into npm's global bin dir for the PATHEXT fast path (`healWindowsBinDir`) |
+
+The `relocated` layout is [#687](https://github.com/nubjs/nub/issues/687): 0.7.0
+started relocating the binary and the resolution could not follow, so every
+`nub run` on a Windows npm install failed from the second invocation onward. The
+sidecar-only probe passed throughout — it never built the shape that breaks.
+
+`no_busybox_anywhere_fails_cleanly` is the negative control, and it is what makes
+the other two rows mean anything: a `nub.exe` with neither candidate present must
+fail with the shell-resolution error. Without it, a binary that found a shell by
+some unintended third route would show all-green while the resolution under test
+did nothing.
+
+Cases (`node run-probe.mjs`), each `nub run <script>`, run once per layout:
 
 | case | body | asserts |
 | --- | --- | --- |
@@ -42,4 +63,6 @@ node tests/busybox-run-probe/run-probe.mjs "$(command -v nub)" /tmp/bbrp
 ```
 
 On Windows the workflow builds `nub`, copies `vendor/busybox-w32/busybox64.exe` to
-`busybox.exe` beside it, and runs the probe against that binary.
+`busybox.exe` beside it, and runs the probe against that binary. Staging that
+sidecar is a precondition — the probe derives the `relocated` layout's copy from it
+and exits 2 with a setup error if it is missing.

--- a/tests/busybox-run-probe/run-probe.mjs
+++ b/tests/busybox-run-probe/run-probe.mjs
@@ -11,8 +11,8 @@
 // Exit 0 iff every case passes; prints one greppable RESULT line per case.
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, rmSync, chmodSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { mkdirSync, writeFileSync, rmSync, chmodSync, copyFileSync, existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
 
 const nubBin = resolve(process.argv[2] ?? "");
 const workRoot = resolve(process.argv[3] ?? "work");
@@ -109,8 +109,8 @@ writeFileSync(
 writeFileSync(join(fixture, "probe.ts"), 'const n: number = 7;\nconsole.log("TS_OK=" + n);\n');
 
 // ── run each case through the integrated `nub run` ───────────────────────────
-function run(extraArgs, script) {
-  const r = spawnSync(nubBin, ["run", ...extraArgs, script], {
+function run(exe, extraArgs, script) {
+  const r = spawnSync(exe, ["run", ...extraArgs, script], {
     cwd: fixture,
     encoding: "utf8",
     timeout: 60000,
@@ -156,16 +156,70 @@ const cases = [
 ];
 
 let failures = 0;
-for (const c of cases) {
-  const { out, code, flag } = run(c.args, c.script);
-  const pass = flag === undefined && c.ok(out);
-  if (!pass) failures++;
-  const first = out.split(/\r?\n/).find((l) => l.trim()) ?? "";
-  process.stdout.write(
-    `RESULT|${c.id}|exit=${code}|${flag ? `flag=${flag}|` : ""}${pass ? "PASS" : "FAIL"}|${JSON.stringify(first.slice(0, 160))}\n`,
-  );
-  if (!pass) process.stdout.write(`  FULL|${c.id}|${JSON.stringify(out.slice(0, 800))}\n`);
+let total = 0;
+
+function runMatrix(exe, layout) {
+  process.stdout.write(`\n--- layout=${layout} exe=${exe}\n`);
+  for (const c of cases) {
+    const { out, code, flag } = run(exe, c.args, c.script);
+    const pass = flag === undefined && c.ok(out);
+    total++;
+    if (!pass) failures++;
+    const first = out.split(/\r?\n/).find((l) => l.trim()) ?? "";
+    process.stdout.write(
+      `RESULT|${layout}|${c.id}|exit=${code}|${flag ? `flag=${flag}|` : ""}${pass ? "PASS" : "FAIL"}|${JSON.stringify(first.slice(0, 160))}\n`,
+    );
+    if (!pass) process.stdout.write(`  FULL|${c.id}|${JSON.stringify(out.slice(0, 800))}\n`);
+  }
 }
 
-process.stdout.write(`\nSUMMARY|${cases.length - failures}/${cases.length} passed\n`);
+function check(id, cond, detail) {
+  total++;
+  if (!cond) failures++;
+  process.stdout.write(`RESULT|${id}|${cond ? "PASS" : "FAIL"}|${JSON.stringify(String(detail).slice(0, 300))}\n`);
+}
+
+// (1) SIDECAR layout — busybox.exe beside nub.exe, how the win32 package, the release
+// .zip behind install.ps1, and `nub upgrade`'s ~/.nub/bin all lay it out.
+runMatrix(nubBin, "sidecar");
+
+// (2) RELOCATED layout — the #687 shape. The npm launcher hardlinks nub.exe into npm's
+// global bin dir for the PATHEXT fast path, which has no sibling busybox; the shell is
+// carried into a nub-owned `nub-sh/` subdir instead (launch.js healWindowsBinDir, and
+// cli.rs resolve_bundled_busybox's second candidate). Reproduce that exactly: the exe
+// alone in a fresh dir, the shell ONLY under nub-sh/.
+//
+// The busybox source is the sidecar beside the real binary — the layout the caller
+// staged for (1) — so this needs no second copy of the vendored blob.
+const relocated = join(workRoot, "relocated");
+rmSync(relocated, { recursive: true, force: true });
+mkdirSync(join(relocated, "nub-sh"), { recursive: true });
+const relocatedExe = join(relocated, "nub.exe");
+copyFileSync(nubBin, relocatedExe);
+copyFileSync(join(dirname(nubBin), "busybox.exe"), join(relocated, "nub-sh", "busybox.exe"));
+check(
+  "relocated_layout_has_no_sibling_busybox",
+  !existsSync(join(relocated, "busybox.exe")),
+  "the relocated dir must NOT have a sibling busybox, or this proves nothing",
+);
+runMatrix(relocatedExe, "relocated");
+
+// (3) NEGATIVE CONTROL. Without it (1) and (2) are unfalsifiable: if the binary ever
+// found a busybox some third way (one on PATH, a stale absolute default), every case
+// above would pass while the resolution under test did nothing. A nub.exe with NEITHER
+// candidate present must fail, and must fail with the specific shell-resolution error
+// rather than some unrelated non-zero exit.
+const bare = join(workRoot, "bare");
+rmSync(bare, { recursive: true, force: true });
+mkdirSync(bare, { recursive: true });
+const bareExe = join(bare, "nub.exe");
+copyFileSync(nubBin, bareExe);
+const neg = run(bareExe, [], "braced");
+check(
+  "no_busybox_anywhere_fails_cleanly",
+  neg.code !== 0 && /bundled POSIX shell/.test(neg.out),
+  `exit=${neg.code} out=${neg.out.slice(0, 200)}`,
+);
+
+process.stdout.write(`\nSUMMARY|${total - failures}/${total} passed\n`);
 process.exit(failures === 0 ? 0 : 1);

--- a/tests/busybox-run-probe/run-probe.mjs
+++ b/tests/busybox-run-probe/run-probe.mjs
@@ -21,6 +21,15 @@ if (!process.argv[2]) {
   process.stderr.write("usage: run-probe.mjs <nub.exe> <work-dir> [git-bash.exe]\n");
   process.exit(2);
 }
+// The caller stages busybox.exe beside nub.exe (the production sidecar layout). The
+// relocated-layout case below sources its copy from there, so a missing one is a
+// harness setup error, not a nub defect — say so rather than throwing mid-run or
+// reporting a wall of failures that look like the binary's fault.
+const sidecarSrc = join(dirname(nubBin), "busybox.exe");
+if (!existsSync(sidecarSrc)) {
+  process.stderr.write(`setup error: no busybox.exe beside ${nubBin} — stage it first\n`);
+  process.exit(2);
+}
 
 // ── fixture: package.json scripts + a real npm-style node_modules/.bin ────────
 const fixture = join(workRoot, "fixture");
@@ -196,7 +205,7 @@ rmSync(relocated, { recursive: true, force: true });
 mkdirSync(join(relocated, "nub-sh"), { recursive: true });
 const relocatedExe = join(relocated, "nub.exe");
 copyFileSync(nubBin, relocatedExe);
-copyFileSync(join(dirname(nubBin), "busybox.exe"), join(relocated, "nub-sh", "busybox.exe"));
+copyFileSync(sidecarSrc, join(relocated, "nub-sh", "busybox.exe"));
 check(
   "relocated_layout_has_no_sibling_busybox",
   !existsSync(join(relocated, "busybox.exe")),

--- a/tests/verb-dispatch/win-e2e.mjs
+++ b/tests/verb-dispatch/win-e2e.mjs
@@ -46,6 +46,12 @@ fs.cpSync(launcherSrc, rootDir, { recursive: true });
 // ONE binary. The platform package declares no `bin` field — it is a carrier, exactly
 // like the published @nubjs/nub-<platform> packages.
 fs.copyFileSync(nativeSrc, path.join(platDir, "bin", `nub${exe}`));
+// The bundled POSIX shell the real win32 package lays beside its binary. A STUB, not a
+// real busybox: this harness asserts the launcher CARRIES the shell when it relocates
+// the .exe (#687), which is a file-placement contract. That the shell actually runs
+// script bodies is tests/busybox-run-probe/'s job, against a real one.
+const BUSYBOX_STUB = "busybox-stub-bytes\n";
+if (isWin) fs.writeFileSync(path.join(platDir, "bin", "busybox.exe"), BUSYBOX_STUB);
 const platName = `@nubjs/nub-e2e-${process.platform}-${process.arch}`;
 fs.writeFileSync(path.join(platDir, "package.json"), JSON.stringify({
   name: platName, version: "9.9.9", files: ["bin"],
@@ -170,6 +176,28 @@ if (isWin) {
       ? ok(`npm's ${f} left untouched (add-only)`)
       : no(`npm's ${f} was REMOVED — the heal must be add-only`);
   }
+
+  // #687: THE SHELL MUST TRAVEL WITH THE BINARY. `nub run` resolves its bundled busybox
+  // relative to the running executable, so relocating nub.exe here — and nothing else —
+  // left every `nub run` on a Windows npm install unable to find a shell from the second
+  // invocation onward. This directory pairing IS the contract; assert it, because the
+  // regression was invisible to every check above (all of them only ran `--version`,
+  // which never touches the script shell).
+  const stagedShell = path.join(binHome, "nub-sh", "busybox.exe");
+  if (fs.existsSync(stagedShell)) {
+    ok("first call staged nub-sh/busybox.exe beside the relocated nub.exe");
+    fs.readFileSync(stagedShell, "utf8") === BUSYBOX_STUB
+      ? ok("the staged shell is the platform package's own busybox")
+      : no("the staged shell does not match the platform package's busybox");
+  } else {
+    no("first call did not stage nub-sh/busybox.exe — `nub run` would fail (#687)");
+  }
+  // And it must NOT land beside the .exe: binHome is on PATH, so a bare `busybox.exe`
+  // here would shadow a busybox the user installed themselves. The subdirectory is what
+  // keeps the fix from creating a second, quieter problem.
+  fs.existsSync(path.join(binHome, "busybox.exe"))
+    ? no("busybox.exe was placed directly on PATH — it must go in the nub-sh/ subdir")
+    : ok("no bare busybox.exe on PATH (cannot shadow a user's own)");
 }
 
 // ── A/B timing: same binary, only launch.js differs ───────────────────────────────


### PR DESCRIPTION
`nub run` resolves its bundled busybox `sh` relative to the running executable. 0.7.0 (#671) began hardlinking `nub.exe` into npm's global bin dir, away from that sidecar, so on Windows npm installs every `nub run` after the first failed with "bundled POSIX shell (busybox.exe) was not found".

The launcher now carries `busybox.exe` into a `nub-sh/` subdir beside the relocated binary, and the resolution accepts that layout. A subdir, not a sibling: the target dir is on PATH, where a bare `busybox.exe` would shadow the user's own.

Tests: candidate-order unit test; the Windows probe runs its matrix against both layouts plus a negative control.

Also removes a stray root `nub.jsonc` (`nodeCompat: true`) that reached main in 7ae35e252b and has had the whole Test matrix red since eeb66d86e0. Removing it: 219 passed / 0 failed.

Closes #687