### PR TITLE
fix: bound unbounded retention in the run supervisor, blob URLs, and the caches

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -5359,7 +5359,7 @@ fn run_single_script_prefixed(
         if let Some(pre_cmd) =
             nub_core::workspace::scripts::resolve_script(&project.manifest, &pre_name)
         {
-            let (code, _) = spawn_script_prefixed(
+            let code = spawn_script_prefixed(
                 &pre_cmd,
                 project,
                 compat_mode,
@@ -5376,7 +5376,7 @@ fn run_single_script_prefixed(
         }
     }
 
-    let (code, _) = spawn_script_prefixed(
+    let code = spawn_script_prefixed(
         cmd,
         project,
         compat_mode,
@@ -5397,7 +5397,7 @@ fn run_single_script_prefixed(
         if let Some(post_cmd) =
             nub_core::workspace::scripts::resolve_script(&project.manifest, &post_name)
         {
-            let (post_code, _) = spawn_script_prefixed(
+            let post_code = spawn_script_prefixed(
                 &post_cmd,
                 project,
                 compat_mode,
@@ -5439,7 +5439,8 @@ struct DrainPolicy {
 }
 
 impl DrainPolicy {
-    /// Emit one raw line per this policy, returning the prefixed form to collect.
+    /// Emit one raw line per this policy, returning the prefixed form to collect —
+    /// `None` whenever nothing downstream will read it back.
     fn emit(&self, line: &str) -> Option<String> {
         if self.ndjson {
             let level = if self.is_stderr { "error" } else { "info" };
@@ -5453,24 +5454,87 @@ impl DrainPolicy {
             } else {
                 println!("{prefixed}");
             }
+            // STREAMING: the line has already reached the user's terminal and
+            // nothing reads it back, so retaining a copy is pure growth. The
+            // collected `Vec` lives for the child's whole life, which for a
+            // script that never exits — `nub run -r dev`, the standard monorepo
+            // workflow — means the supervisor grows 1:1 with child output until
+            // it is killed or OOMs. Collect ONLY for the aggregate flush, the
+            // one consumer that genuinely replays these lines.
+            return None;
         }
         Some(prefixed)
     }
 
     /// Drain `stream` to EOF on the CURRENT thread, returning the collected lines.
+    /// Aggregate mode holds at most [`AGGREGATE_MAX_HELD_BYTES`] before flushing
+    /// early, so a child that never exits cannot grow this without bound.
     fn run<R: std::io::Read>(&self, stream: R) -> Vec<String> {
+        self.run_capped(stream, AGGREGATE_MAX_HELD_BYTES)
+    }
+
+    /// `run` with an explicit hold ceiling, so a test can exercise the early
+    /// flush without pushing the shipped 8 MiB through the harness's capture.
+    fn run_capped<R: std::io::Read>(&self, stream: R, max_held: usize) -> Vec<String> {
         use std::io::BufRead as _;
         let mut lines = Vec::new();
+        let mut held = 0usize;
         for line in std::io::BufReader::new(stream)
             .lines()
             .map_while(Result::ok)
         {
             if let Some(prefixed) = self.emit(&line) {
+                held += prefixed.len() + 1;
                 lines.push(prefixed);
+                if held >= max_held {
+                    flush_aggregated(&mut lines, self.is_stderr);
+                    held = 0;
+                }
             }
         }
         lines
     }
+}
+
+/// Ceiling on the output one stream holds for the deferred aggregate flush.
+///
+/// Aggregate mode buffers a child's whole output so each package prints as ONE
+/// contiguous block — which quietly assumes the script COMPLETES. It does not
+/// only apply to `--aggregate-output`: a non-TTY stdout selects it too (see the
+/// `aggregate` binding in the workspace run path), so `nub run -r dev` in CI, or
+/// piped to a file, takes this path with a dev server that never exits. The
+/// buffer then grew for the life of the run — measured at 46 → 555 MB in 80 s.
+///
+/// Past the cap the held lines are flushed early and buffering resumes. An
+/// ordinary script still prints as one block; only a runaway producer is split
+/// into several, and no output is dropped. That is the right trade against a
+/// supervisor that OOMs after long enough.
+const AGGREGATE_MAX_HELD_BYTES: usize = 8 * 1024 * 1024;
+
+/// Write buffered aggregate lines and clear the buffer, under the shared flush
+/// lock so concurrent workers never tear each other's output.
+fn flush_aggregated(lines: &mut Vec<String>, is_stderr: bool) {
+    use std::io::Write as _;
+    if lines.is_empty() {
+        return;
+    }
+    let _guard = AGGREGATE_FLUSH_LOCK.lock();
+    if is_stderr {
+        let stderr = std::io::stderr();
+        let mut se = stderr.lock();
+        for line in lines.iter() {
+            let _ = writeln!(se, "{line}");
+        }
+        let _ = se.flush();
+    } else {
+        let stdout = std::io::stdout();
+        let mut so = stdout.lock();
+        for line in lines.iter() {
+            let _ = writeln!(so, "{line}");
+        }
+        let _ = so.flush();
+    }
+    lines.clear();
 }
 
 /// Both of a script child's output pipes plus their per-stream policies, drained
@@ -5776,7 +5840,7 @@ fn spawn_script_prefixed(
     color_idx: usize,
     exec: &ScriptExecOpts,
     aggregate: bool,
-) -> Result<(i32, String)> {
+) -> Result<i32> {
     use std::io::Write;
 
     let (mut command, display_cmd) = build_script_command(
@@ -5823,7 +5887,6 @@ fn spawn_script_prefixed(
     // the wait below, dropped (disarmed) on return.
     #[cfg(unix)]
     let _reaper = nub_core::node::spawn::spawn_group_reaper(child.id());
-    let mut output_buf = String::new();
 
     let stdout = child.stdout.take();
     let stderr = child.stderr.take();
@@ -5894,12 +5957,7 @@ fn spawn_script_prefixed(
         let _ = se.flush();
     }
 
-    for line in &out_lines {
-        output_buf.push_str(line);
-        output_buf.push('\n');
-    }
-
-    Ok((exit_code, output_buf))
+    Ok(exit_code)
 }
 
 /// The per-package label that leads each prefixed output line: the member's
@@ -10258,6 +10316,71 @@ mod tests {
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
         Cli::try_parse_from(args)
+    }
+
+    // A streaming drain must retain NOTHING. The collected `Vec` lives as long as
+    // the child, so for a script that never exits (`nub run -r dev`) anything kept
+    // here grows the supervisor 1:1 with child output until it OOMs — while in
+    // streaming mode the line has already gone to the terminal and nothing ever
+    // reads the copy back. Only the aggregate flush genuinely replays these lines.
+    #[test]
+    fn drain_retains_lines_only_for_the_aggregate_flush() {
+        let policy = |aggregate: bool| DrainPolicy {
+            ndjson: false,
+            aggregate,
+            is_stderr: false,
+            prefix: "pkg | ".to_string(),
+            name: "pkg".to_string(),
+            script: "dev".to_string(),
+        };
+
+        let streamed = policy(false).run(&b"one\ntwo\nthree\n"[..]);
+        assert!(
+            streamed.is_empty(),
+            "streaming drain retained {} line(s); it must retain none",
+            streamed.len(),
+        );
+
+        let aggregated = policy(true).run(&b"one\ntwo\n"[..]);
+        assert_eq!(
+            aggregated,
+            vec!["pkg | one".to_string(), "pkg | two".to_string()],
+            "aggregate drain must keep every line, prefixed, for the deferred flush",
+        );
+    }
+
+    // Aggregate mode buffers so each package prints as one block, which assumes
+    // the script exits. A non-TTY stdout selects aggregate too, so `nub run -r dev`
+    // in CI took this path with a server that never exits and the buffer grew for
+    // the life of the run. Past the ceiling it must flush early and keep going.
+    #[test]
+    fn aggregate_drain_flushes_early_instead_of_growing_without_bound() {
+        let policy = DrainPolicy {
+            ndjson: false,
+            aggregate: true,
+            is_stderr: false,
+            prefix: String::new(),
+            name: "pkg".to_string(),
+            script: "dev".to_string(),
+        };
+
+        const CAP: usize = 2 * 1024;
+        // ~16 KiB of input — eight times the ceiling, small enough that the early
+        // flushes this deliberately triggers stay out of the suite's output.
+        let mut input = Vec::new();
+        for _ in 0..200 {
+            input.extend_from_slice(&b"z".repeat(79));
+            input.push(b'\n');
+        }
+        let total = input.len();
+
+        let held = policy.run_capped(&input[..], CAP);
+        let held_bytes: usize = held.iter().map(|l| l.len() + 1).sum();
+        assert!(
+            held_bytes < CAP,
+            "drain held {held_bytes} B of {total} B after the early flush; \
+             it must stay under the {CAP} B ceiling",
+        );
     }
 
     // `--env-file` opts the run out of eager `.env*` auto-discovery: with the flag

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -6765,10 +6765,26 @@ fn transpile_cache_eviction_evicts_oldest_over_cap() {
     // runtime/cache-evict.mjs and sweeps a temp dir with a small cap), so it
     // verifies LRU-by-mtime eviction, the low-water target, and that the
     // `.sweep` sentinel + `*.tmp` files are skipped — without the 512 MiB
-    // shipped cap making it untestable.
+    // shipped cap making it untestable. It covers both shapes: the flat
+    // transpile dir and nub's own nested V8 compile-cache dir, whose version
+    // subdirectories are pruned once eviction empties them.
     let (stdout, stderr, code) = run_nub("cache-evict", "sweep-test.mjs");
     assert_eq!(code, 0, "stderr: {stderr}");
     assert!(stdout.contains("EVICT-OK"), "eviction behavior: {stdout}");
+}
+
+#[test]
+fn data_url_with_extension_shaped_tail_imports() {
+    // A `data:` URL's payload is inline, so a trailing `//x.ts` is SOURCE, not a
+    // filename. Deriving an extension from it routed the load hooks into the
+    // transpile/data branches, where `fileURLToPath` threw ERR_INVALID_URL_SCHEME
+    // on a module plain Node imports without complaint.
+    let (stdout, stderr, code) = run_nub("data-url", "extension-tail.mjs");
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(
+        stdout.contains("DATA-URL-OK"),
+        "data: URL dispatch: {stdout}"
+    );
 }
 
 // ── `nub run` full flag set (run.md) ────────────────────────────────────────

--- a/crates/nub-tsconfig/src/lib.rs
+++ b/crates/nub-tsconfig/src/lib.rs
@@ -127,6 +127,22 @@ fn cache() -> &'static Mutex<HashMap<String, Arc<Loaded>>> {
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Entry ceiling for the memo above. A directory-keyed memo is unbounded BY
+/// CONSTRUCTION, and this one lives in the addon — i.e. inside the user's own
+/// long-lived Node process, not the one-shot CLI. A process that materializes
+/// directories at RUNTIME (codegen, a dev server's generated routes, per-case
+/// temp dirs) therefore adds an entry per directory forever; each holds the
+/// merged `compilerOptions` plus the compiled `paths` matcher, measured at
+/// ~2.6 KB against an ordinary tsconfig, so 100k directories cost ~250 MB.
+///
+/// Clearing wholesale instead of evicting an LRU is deliberate: this is a PURE
+/// memo, so a miss costs only a re-read, and a real project re-warms the handful
+/// of directories it actually imports from within the next few resolves. An LRU
+/// would buy a better hit rate on a pathological key stream in exchange for
+/// per-lookup bookkeeping on the hot path, which is the wrong trade for a cache
+/// whose realistic working set is far below the cap.
+const CACHE_MAX_ENTRIES: usize = 8192;
+
 /// Parse + resolve the project's tsconfig: `explicit` when the project names
 /// one, else the nearest found walking up from `dir`. Memoized per pair.
 /// Returns null-ish fields when there is none.
@@ -168,10 +184,11 @@ fn load_for_dir(dir: &str, explicit: Option<&str>) -> Arc<Loaded> {
         return hit.clone();
     }
     let loaded = Arc::new(build_loaded(dir, explicit));
-    cache()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .insert(key, loaded.clone());
+    let mut entries = cache().lock().unwrap_or_else(|e| e.into_inner());
+    if entries.len() >= CACHE_MAX_ENTRIES {
+        entries.clear();
+    }
+    entries.insert(key, loaded.clone());
     loaded
 }
 
@@ -1254,6 +1271,26 @@ mod tests {
 
     fn read(dir: &tempfile::TempDir) -> Vec<String> {
         custom_conditions(&dir.path().to_string_lossy(), None)
+    }
+
+    /// The memo is keyed by DIRECTORY, so it is unbounded by construction — and it
+    /// lives in the addon, inside the user's own long-lived process. A program that
+    /// materializes directories at runtime (codegen, generated routes, per-case temp
+    /// dirs) would otherwise add an entry per directory forever. Drive past the cap
+    /// with distinct keys and assert the map never exceeds it.
+    #[test]
+    fn directory_memo_stays_bounded() {
+        for i in 0..(super::CACHE_MAX_ENTRIES + 64) {
+            // Directories that do not exist still memoize the "no tsconfig here"
+            // answer, which is exactly the entry that used to accumulate.
+            super::load_tsconfig(&format!("/nonexistent/nub-cap-probe/{i}"), None);
+        }
+        let len = super::cache().lock().unwrap().len();
+        assert!(
+            len <= super::CACHE_MAX_ENTRIES,
+            "tsconfig memo grew to {len} entries, past the {} cap",
+            super::CACHE_MAX_ENTRIES,
+        );
     }
 
     /// The layout that motivates the feature: leaf configs `extends` a shared base

--- a/runtime/cache-evict.mjs
+++ b/runtime/cache-evict.mjs
@@ -9,7 +9,7 @@
 // the read-only fast path; oldest-written is the right, cheap proxy for a cache
 // whose entries are written once per source version.
 
-import { readdirSync, statSync, unlinkSync } from "node:fs";
+import { readdirSync, rmdirSync, statSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
 // A valid cache entry is a 64-char lowercase-hex sha256 (see cacheKey in
@@ -18,11 +18,22 @@ import { join } from "node:path";
 // evicted.
 const ENTRY_RE = /^[0-9a-f]{64}$/;
 
+// What one entry actually costs the filesystem. `stat.size` is the LOGICAL
+// length, but the disk hands out whole blocks, and this cache is mostly small
+// files — measured on a real 32k-entry cache: 45% of entries sat under one 4 KiB
+// block, so 492.6 MB of logical bytes occupied 571.0 MB of disk, and a nominal
+// 512 MiB cap silently permitted ~594 MB. `blocks` is POSIX (512-byte units);
+// Windows does not report it, so fall back to the logical size there.
+function diskBytes(s) {
+  return typeof s.blocks === "number" && s.blocks > 0 ? s.blocks * 512 : s.size;
+}
+
 /**
  * Evict oldest entries from `dir` until total entry bytes ≤ `lowWater`, if they
- * exceed `maxBytes`. Returns `{ scanned, deleted, freed }`. Best-effort: a stat
- * or unlink that fails (concurrent reader/evictor, Windows open handle) is
- * skipped, and the next sweep retries. Never throws.
+ * exceed `maxBytes`. Sizes are the entries' real on-disk footprint, so the cap
+ * bounds what the user's disk actually loses. Returns `{ scanned, deleted, freed }`.
+ * Best-effort: a stat or unlink that fails (concurrent reader/evictor, Windows
+ * open handle) is skipped, and the next sweep retries. Never throws.
  */
 export function sweepCache(dir, maxBytes, lowWater = Math.floor(maxBytes * 0.75)) {
   let names;
@@ -39,8 +50,9 @@ export function sweepCache(dir, maxBytes, lowWater = Math.floor(maxBytes * 0.75)
     const path = join(dir, name);
     const s = statSync(path, { throwIfNoEntry: false });
     if (!s || !s.isFile()) continue;
-    entries.push({ path, size: s.size, mtime: s.mtimeMs });
-    total += s.size;
+    const size = diskBytes(s);
+    entries.push({ path, size, mtime: s.mtimeMs });
+    total += size;
   }
 
   if (total <= maxBytes) {
@@ -65,5 +77,78 @@ export function sweepCache(dir, maxBytes, lowWater = Math.floor(maxBytes * 0.75)
       // entries; the loop is bounded by `entries`, so it still terminates.
     }
   }
+  return { scanned: entries.length, deleted, freed };
+}
+
+/**
+ * Evict from nub's OWN default V8 compile-cache dir. The layout there is Node's,
+ * not ours — `<dir>/<version>-<arch>-<hash>-<uid>/<entry>` — so this walks one
+ * level down, treats every regular file as an entry (V8 picks the names; there
+ * is no pattern of ours to match), and prunes a version directory once eviction
+ * has emptied it. Those version directories are the quiet half of the problem:
+ * one accumulates per Node build ever run under nub and nothing removed it, so a
+ * working machine had 96 of them totalling 6.9 GB across ~594k files.
+ *
+ * Deleting a live entry is safe: a missing or unreadable code-cache entry only
+ * makes V8 recompile that module. Same oldest-first, delete-to-`lowWater` policy
+ * and the same never-throws contract as `sweepCache`.
+ */
+export function sweepCompileCache(dir, maxBytes, lowWater = Math.floor(maxBytes * 0.75)) {
+  let versionDirs;
+  try {
+    versionDirs = readdirSync(dir, { withFileTypes: true }).filter((d) => d.isDirectory());
+  } catch {
+    return { scanned: 0, deleted: 0, freed: 0 };
+  }
+
+  const entries = [];
+  let total = 0;
+  for (const vd of versionDirs) {
+    const vpath = join(dir, vd.name);
+    let names;
+    try {
+      names = readdirSync(vpath);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      const path = join(vpath, name);
+      const s = statSync(path, { throwIfNoEntry: false });
+      if (!s || !s.isFile()) continue;
+      const size = diskBytes(s);
+      entries.push({ path, size, mtime: s.mtimeMs });
+      total += size;
+    }
+  }
+
+  if (total <= maxBytes) {
+    return { scanned: entries.length, deleted: 0, freed: 0 };
+  }
+
+  entries.sort((a, b) => a.mtime - b.mtime);
+  let deleted = 0;
+  let freed = 0;
+  for (const e of entries) {
+    if (total <= lowWater) break;
+    try {
+      unlinkSync(e.path);
+      total -= e.size;
+      freed += e.size;
+      deleted++;
+    } catch {
+      // Concurrent sweep or an open handle (Windows): skip, retried next sweep.
+    }
+  }
+
+  // `rmdir` refuses a non-empty directory, so this can only ever remove one the
+  // eviction above actually emptied — never a version dir still holding entries.
+  for (const vd of versionDirs) {
+    try {
+      rmdirSync(join(dir, vd.name));
+    } catch {
+      // Still populated, or in use by a concurrent run.
+    }
+  }
+
   return { scanned: entries.length, deleted, freed };
 }

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -115,18 +115,6 @@ if (!requireEsmDisabled && !forceAsyncTier) {
   // ── Watch-mode dependency reporting + hooks ───────────────────────
   const watchReporting = common.installWatchReporting(core);
 
-  // Best-effort bounded-cache eviction (main thread only; the core guards on it).
-  // DEFERRED to setImmediate: maybeSweepCache probes `worker_threads.isMainThread`
-  // and dynamic-imports cache-evict.mjs, which would otherwise pull worker_threads
-  // (and its streams/worker-io transitive set) into the BOOTSTRAP module-load list
-  // on every startup — a cold-start regression (test-bootstrap-modules snapshots
-  // process.moduleLoadList at user code's first line). Running it one turn later
-  // keeps those out of the bootstrap snapshot while preserving the once-a-day sweep.
-  // unref so a purely-synchronous program still exits promptly without waiting on it.
-  setImmediate(() => {
-    try { core.maybeSweepCache(); } catch {}
-  }).unref();
-
   // ── Pre-load clobbered polyfill packages BEFORE hooks register ────
   // Packages in the core's CLOBBER_MAP can't be imported after hooks register (the
   // resolve hook returns a synthetic module instead of the real package), so
@@ -211,6 +199,28 @@ if (!requireEsmDisabled && !forceAsyncTier) {
   // was selected — which an inherited `--import` triggers on the broken-compose band
   // (22.15–24.11) via shouldAutoAsyncTierAtPreload.
   common.requireUserPreloadChain();
+}
+
+// ── Bounded-cache eviction (BOTH branches above) ────────────────────
+// Main thread only; the core guards on that too. Deferred one turn so the
+// dynamic import of cache-evict.mjs and maybeSweepCache's `worker_threads`
+// probe stay out of the BOOTSTRAP module-load list, which test-bootstrap-modules
+// snapshots at user code's first line.
+//
+// SCHEDULED ONLY WHEN A SWEEP IS DUE, and then ref'd. It used to be armed
+// unconditionally and `.unref()`'d, so a purely SYNCHRONOUS program — the common
+// `nub script.ts` — exited before the callback could run: for a user whose runs
+// are all synchronous the cache was never swept at all and grew without bound.
+// `sweepDue()` is one statSync with no mkdir and no worker_threads, so the
+// overwhelmingly common not-due path now schedules NOTHING (strictly cheaper
+// than before), and on the once-a-day run that IS due the process waits for the
+// eviction it asked for. Placed after the tier branches so the async-loader tier
+// sweeps too — it never did; `core` is null there only when require(esm) is off,
+// which is exactly when there is no core to ask.
+if (core && core.sweepDue()) {
+  setImmediate(() => {
+    try { core.maybeSweepCache(); } catch {}
+  });
 }
 
 // ── Lazy ESM-side-effect polyfills (R7) ─────────────────────────────

--- a/runtime/preload.mjs
+++ b/runtime/preload.mjs
@@ -152,6 +152,18 @@ common.installTemporalLazyGlobal(__require);
 // NODE_COMPILE_CACHE. See reenableUserCompileCache for the full rationale.
 common.reenableUserCompileCache();
 
+// ── Bounded-cache eviction ──────────────────────────────────────────
+// This tier never swept at all, so a user pinned below Node 22.15 grew both the
+// transpile cache and nub's own V8 compile-cache dir forever. Same shape as the
+// fast tier (preload.cjs): probe cheaply, and schedule the deferred sweep only
+// on the once-a-day run where one is actually due. Main thread only — the core
+// guards on that itself.
+if (core.sweepDue()) {
+  setImmediate(() => {
+    try { core.maybeSweepCache(); } catch {}
+  });
+}
+
 // ── User preloads (`nub.jsonc` `preload`) ───────────────────────────
 // LAST, so the user's entries observe a fully-augmented realm — hooks installed,
 // polyfills in place. Awaited, so a top-level `await` inside an entry settles before

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -316,6 +316,16 @@ export function getPackageType(dir) {
 
 // ── Filesystem helpers ──────────────────────────────────────────────
 export function extname(url) {
+  // A `data:` URL carries its payload INLINE, so anything extension-shaped at
+  // the end belongs to the source text, not to a filename — a trailing `//x.ts`
+  // comment, a sourceMappingURL, a path inside a string literal. Reading an
+  // extension off one sent both load hooks into the transpile/data branches,
+  // whose `fileURLToPath` then threw ERR_INVALID_URL_SCHEME on a module plain
+  // Node imports without complaint. Scoped to `data:` deliberately: the only
+  // other schemes these hooks see are `file:` (which does have an extension)
+  // and `node:` (which has no dot), and a broader "any scheme" test would have
+  // to distinguish a real scheme from a Windows drive letter.
+  if (url.startsWith("data:")) return "";
   const path = url.includes("?") ? url.slice(0, url.indexOf("?")) : url;
   const dot = path.lastIndexOf(".");
   return dot === -1 ? "" : path.slice(dot);
@@ -648,14 +658,21 @@ const CACHE_DISABLED =
 // "not yet computed".
 let cacheDir = null;
 let cacheDirResolved = false;
+// nub's cache ROOT (`<cache>/nub`), computed WITHOUT creating anything, so the
+// sweep-due probe and the compile-cache check can name a directory without a
+// mkdir side effect on every startup.
+function cacheRoot() {
+  const base = process.env.XDG_CACHE_HOME || (process.env.HOME ? join(process.env.HOME, ".cache") : null);
+  return base ? join(base, "nub") : null;
+}
 function getCacheDir() {
   if (cacheDirResolved) return cacheDir;
   cacheDirResolved = true;
   if (CACHE_DISABLED) return cacheDir;
   __ensureBuiltins();
-  const base = process.env.XDG_CACHE_HOME || (process.env.HOME ? join(process.env.HOME, ".cache") : null);
-  if (base) {
-    cacheDir = join(base, "nub", "transpile");
+  const root = cacheRoot();
+  if (root) {
+    cacheDir = join(root, "transpile");
     try { mkdirSync(cacheDir, { recursive: true }); } catch { cacheDir = null; }
   }
   return cacheDir;
@@ -664,6 +681,28 @@ function getCacheDir() {
 // ── Bounded-cache maintenance ───────────────────────────────────────
 const CACHE_MAX_BYTES = 512 * 1024 * 1024; // 512 MiB — bounds runaway growth, not normal use
 const SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000; // ≤ one sweep per day
+
+// Is a sweep DUE right now? Deliberately cheap and side-effect-free: one
+// `statSync` against a path built without `mkdir`, loading no module the preload
+// has not already loaded. The caller uses this to decide whether to schedule the
+// sweep AT ALL, which is what lets the scheduled work be ref'd instead of
+// unref'd — see preload.cjs for why that mattered.
+//
+// It deliberately does NOT test for the main thread. The tempting cheap test —
+// "is worker_threads in `process.moduleLoadList`?" — is simply WRONG here:
+// nub's own preload already pulls worker_threads in on the MAIN thread
+// (verified), so it reports every run as a worker and nothing ever sweeps.
+// `maybeSweepCache` asks `isMainThread` authoritatively, so the worst a worker
+// thread costs is one statSync and a scheduled immediate that no-ops.
+export function sweepDue() {
+  if (CACHE_DISABLED) return false;
+  __ensureBuiltins();
+  const root = cacheRoot();
+  if (!root) return false;
+  const s = statSync(join(root, "transpile", ".sweep"), { throwIfNoEntry: false });
+  return !s || Date.now() - s.mtimeMs >= SWEEP_INTERVAL_MS;
+}
+
 export function maybeSweepCache() {
   __ensureBuiltins();
   const dir = getCacheDir();
@@ -682,8 +721,22 @@ export function maybeSweepCache() {
   } catch {
     return;
   }
+  // nub's OWN default V8 compile-cache dir gets the same daily treatment. The
+  // Rust spawn layer creates it and points NODE_COMPILE_CACHE at it for every
+  // augmented run (spawn.rs `default_compile_cache_dir`), it gains an entry per
+  // distinct module path plus a whole subdirectory per Node build, and nothing
+  // ever removed any of it — 6.9 GB across ~594k files after ~12 days on a
+  // working machine. Swept ONLY when NODE_COMPILE_CACHE is exactly nub's own
+  // dir: a dir the USER chose is theirs, and nub must not evict from it.
+  const root = cacheRoot();
+  const ownCompileCache = root ? join(root, "v8-compile-cache") : null;
+  const compileDir =
+    ownCompileCache && process.env.NODE_COMPILE_CACHE === ownCompileCache ? ownCompileCache : null;
   import("./cache-evict.mjs")
-    .then((m) => m.sweepCache(dir, CACHE_MAX_BYTES))
+    .then((m) => {
+      m.sweepCache(dir, CACHE_MAX_BYTES);
+      if (compileDir) m.sweepCompileCache(compileDir, CACHE_MAX_BYTES);
+    })
     .catch(() => {});
 }
 

--- a/runtime/worker-blob-url.cjs
+++ b/runtime/worker-blob-url.cjs
@@ -10,28 +10,63 @@
 // main-thread preload can install the wrap EAGERLY: it must be live before user
 // code calls createObjectURL, whereas worker-polyfill.mjs (which pulls
 // worker_threads + the whole streams/worker-io builtin set) is loaded LAZILY on
-// first `new Worker` to protect cold start. The Worker class imports THIS module to
-// read `blobUrlSources`. Touches only URL / Blob / Buffer — all already-realized
+// first `new Worker` to protect cold start. The Worker class calls THIS module's
+// `blobUrlSource()`. Touches only URL / Blob / Buffer — all already-realized
 // core globals — so requiring it adds nothing to the main-thread bootstrap set.
+//
+// WHAT IS RETAINED, AND WHY IT IS THE MINIMUM. This wrap is installed on EVERY
+// nub run, and the overwhelming majority of object URLs never back a Worker at
+// all (a download link, an image preview, a CSV export). Node cannot read a
+// Blob's bytes synchronously, so supporting `new Worker(blobUrl)` at all means
+// capturing SOMETHING when the Blob is built. Three properties keep that honest:
+//
+//   * it is a COMPACT COPY, not the caller's parts. Holding the parts pinned
+//     whatever they referenced — `new Blob([big.subarray(0, 32)])` kept the
+//     whole 256 KB backing buffer alive for 32 bytes of content, measured at
+//     504 MB retained for 2000 such Blobs where plain Node held 2 MB.
+//   * it lives OFF the V8 heap, as a Buffer. The previous decoded-string form
+//     put a second full copy of every blob on the JS heap — measured at +43 MB
+//     against plain Node's +1 MB for 20k object URLs — where it counts against
+//     `--max-old-space-size` and can OOM a process Node would not. Decoding to
+//     text is deferred to `blobUrlSource()`, which only `new Worker` reaches.
+//   * it is CAPPED. A blob: worker entry is a script; past the cap nothing is
+//     kept, and `new Worker` reports the URL as unknown rather than silently
+//     retaining tens of megabytes per object URL to serve a case that does not
+//     occur in practice.
 
-// blob: URL → source text. Shared with worker-polyfill.mjs's Worker constructor.
+// blob: URL → the Blob's UTF-8 source bytes (a Buffer, off the V8 heap).
+// Read via blobUrlSource(); cleared by revokeObjectURL.
 const blobUrlSources = new Map();
-// Blob construction parts, remembered so createObjectURL can assemble source sync.
+// Per-Blob captured source bytes, so createObjectURL can assemble the entry
+// synchronously and a nested Blob part can be resolved.
 const blobParts = new WeakMap();
 
-function decode(parts) {
-  let src = "";
+// Generous ceiling on what is worth capturing: far above any real inline worker
+// script, far below the media/data blobs this must not duplicate.
+const MAX_CAPTURE_BYTES = 4 * 1024 * 1024;
+
+// Encode a Blob's construction parts into ONE compact Buffer, or null when the
+// content exceeds MAX_CAPTURE_BYTES (or a nested Blob was itself uncaptured).
+// `Buffer.concat` allocates a fresh exactly-sized buffer, which is also what
+// detaches the result from any larger backing store the caller passed a view of.
+function encodeParts(parts) {
+  const chunks = [];
+  let total = 0;
   for (const p of parts ?? []) {
-    if (typeof p === "string") src += p;
-    else if (typeof Buffer !== "undefined" && Buffer.isBuffer(p)) src += p.toString("utf8");
-    else if (ArrayBuffer.isView(p)) src += Buffer.from(p.buffer, p.byteOffset, p.byteLength).toString("utf8");
-    else if (p instanceof ArrayBuffer) src += Buffer.from(p).toString("utf8");
+    let chunk;
+    if (typeof p === "string") chunk = Buffer.from(p, "utf8");
+    else if (typeof Buffer !== "undefined" && Buffer.isBuffer(p)) chunk = p;
+    else if (ArrayBuffer.isView(p)) chunk = Buffer.from(p.buffer, p.byteOffset, p.byteLength);
+    else if (p instanceof ArrayBuffer) chunk = Buffer.from(p);
     else if (typeof p === "object" && p && typeof p.size === "number") {
-      const nested = blobParts.get(p); // a nested Blob made via our wrapper
-      if (nested) src += decode(nested);
-    }
+      chunk = blobParts.get(p); // a nested Blob made via our wrapper
+      if (chunk === undefined) return null; // nested blob was over the cap
+    } else continue;
+    total += chunk.length;
+    if (total > MAX_CAPTURE_BYTES) return null;
+    chunks.push(chunk);
   }
-  return src;
+  return Buffer.concat(chunks, total);
 }
 
 // Wrap URL.createObjectURL/revokeObjectURL and Proxy Blob to remember parts.
@@ -79,7 +114,18 @@ function installBlobUrlSupport() {
         // forwards to NativeBlob.prototype — so a direct Blob is byte-identical to a
         // native one (same brand, passes instanceof + undici's webidl check).
         const inst = Reflect.construct(target, args, newTarget);
-        if (args[0] != null) blobParts.set(inst, args[0]);
+        if (args[0] != null) {
+          // Capture a compact copy NOW — the only moment the bytes are readable
+          // synchronously. `encodeParts` returns null past the cap, and a Blob
+          // with no entry simply is not usable as a worker entry. Never let our
+          // accounting fail a Blob construction that vanilla Node would allow.
+          try {
+            const bytes = encodeParts(args[0]);
+            if (bytes !== null) blobParts.set(inst, bytes);
+          } catch {
+            /* exotic parts: no capture, so no blob: worker from this Blob */
+          }
+        }
         return inst;
       },
     });
@@ -99,8 +145,11 @@ function installBlobUrlSupport() {
     typeof URL.revokeObjectURL === "function" ? URL.revokeObjectURL.bind(URL) : null;
   const wrappedCreate = function createObjectURL(obj) {
     const url = nativeCreate(obj);
-    const parts = blobParts.get(obj);
-    if (parts) blobUrlSources.set(url, decode(parts));
+    // Point the URL at the compact bytes captured at construction — never at the
+    // Blob itself, which would keep our own WeakMap entry (and so the caller's
+    // parts) reachable for as long as the URL lives.
+    const bytes = blobParts.get(obj);
+    if (bytes !== undefined) blobUrlSources.set(url, bytes);
     return url;
   };
   Object.defineProperty(wrappedCreate, INSTALLED, { value: true });
@@ -113,4 +162,14 @@ function installBlobUrlSupport() {
   }
 }
 
-module.exports = { blobUrlSources, installBlobUrlSupport };
+// The source text behind a `blob:` worker entry, decoded ON DEMAND — the only
+// caller is worker-polyfill.mjs's Worker constructor, so an object URL that
+// never becomes a Worker is never decoded at all. `undefined` when the URL was
+// not minted through our wrap, was revoked, or held content past the capture
+// cap; the constructor turns that into its "not a known object URL" TypeError.
+function blobUrlSource(url) {
+  const bytes = blobUrlSources.get(url);
+  return bytes === undefined ? undefined : bytes.toString("utf8");
+}
+
+module.exports = { blobUrlSources, blobUrlSource, installBlobUrlSupport };

--- a/runtime/worker-polyfill.mjs
+++ b/runtime/worker-polyfill.mjs
@@ -90,8 +90,8 @@ export function installWorkerPolyfill() {
   // blob: worker source registry, shared with the eager main-thread preload that
   // wraps URL.createObjectURL (worker-blob-url.cjs). Loaded via createRequire so
   // both this lazily-loaded ESM module and the eager CJS preload reference the SAME
-  // module instance (Node dedupes by resolved path) — i.e. the SAME blobUrlSources.
-  const { blobUrlSources, installBlobUrlSupport } = (
+  // module instance (Node dedupes by resolved path) — i.e. the SAME registry.
+  const { blobUrlSource, installBlobUrlSupport } = (
     typeof process.getBuiltinModule === "function"
       ? __getBuiltin("node:module").createRequire(import.meta.url)
       : _bootstrapCreateRequire(import.meta.url)
@@ -182,12 +182,15 @@ export function installWorkerPolyfill() {
           // A `blob:` worker (WHATWG inline mechanism). Node cannot open a blob:
           // URL as a worker entry, and the Blob's bytes are only readable
           // ASYNCHRONOUSLY (Blob.text/arrayBuffer) while this constructor is sync.
-          // We close that gap by snapshotting the source SYNCHRONOUSLY at
+          // We close that gap by capturing the Blob SYNCHRONOUSLY at
           // `URL.createObjectURL(blob)` time (see installBlobUrlSupport) into a
           // module-scope registry keyed by URL, then spawn the source as a `data:`
           // URL — a real module load (a proper worker entry that receives nub's
           // preload, so `self`/`postMessage` are present) on every supported tier.
-          const source = blobUrlSources.get(asUrlString);
+          // The UTF-8 decode happens HERE rather than at createObjectURL time, so
+          // the object URLs that never become a Worker — nearly all of them — pay
+          // nothing for this feature.
+          const source = blobUrlSource(asUrlString);
           if (source === undefined) {
             throw new TypeError(
               `Worker constructor: blob URL '${asUrlString}' is not a known object URL`

--- a/site/content/docs/runtime/workers.mdx
+++ b/site/content/docs/runtime/workers.mdx
@@ -58,6 +58,8 @@ new Worker("data:text/javascript," + encodeURIComponent(src));
 new Worker(URL.createObjectURL(new Blob([src], { type: "text/javascript" })));
 ```
 
+A Blob's bytes are only readable asynchronously, so Nub captures them when the Blob is constructed — which caps a `blob:` worker source at 4 MB. Past that the URL is rejected as a worker entry; use a file or `data:` URL instead.
+
 For a raw source string, pass `{ eval: true }` — Node's inline form, covered under [Node worker_threads compatibility](#node-worker_threads-compatibility).
 
 The second argument is a `WorkerOptions` object:

--- a/tests/fixtures/cache-evict/sweep-test.mjs
+++ b/tests/fixtures/cache-evict/sweep-test.mjs
@@ -1,16 +1,36 @@
-// Exercises the transpile-cache eviction (A16) directly, with a controllable
-// small cap so eviction actually triggers (the shipped cap is 512 MiB). Run by
-// `nub` in an integration test; prints EVICT-OK on success.
-import { sweepCache } from "../../../runtime/cache-evict.mjs";
-import { mkdtempSync, writeFileSync, readdirSync, utimesSync, existsSync } from "node:fs";
+// Exercises the transpile-cache eviction (A16) and nub's own V8 compile-cache
+// eviction directly, with a controllable small cap so eviction actually triggers
+// (the shipped cap is 512 MiB). Run by `nub` in an integration test; prints
+// EVICT-OK on success.
+import { sweepCache, sweepCompileCache } from "../../../runtime/cache-evict.mjs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+  utimesSync,
+  existsSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-const dir = mkdtempSync(join(tmpdir(), "nub-evict-"));
 const hex = (i) => i.toString().padStart(64, "0"); // 64-char all-hex key name
 const SIZE = 100;
 
-// 10 entries (1000 bytes total); index 0 is oldest (smallest mtime).
+// The sweep bounds REAL disk footprint, not logical length, so a 100-byte entry
+// costs a whole allocation block (4 KiB on APFS/ext4). Derive the caps from what
+// one entry actually occupies here, so the arithmetic below holds on any
+// filesystem — and on Windows, where `blocks` is unreported and the sweep falls
+// back to the logical size.
+const unitOf = (p) => {
+  const s = statSync(p);
+  return typeof s.blocks === "number" && s.blocks > 0 ? s.blocks * 512 : s.size;
+};
+
+// ── transpile cache: flat dir, 64-hex entry names ───────────────────
+const dir = mkdtempSync(join(tmpdir(), "nub-evict-"));
+// 10 entries; index 0 is oldest (smallest mtime).
 for (let i = 0; i < 10; i++) {
   const p = join(dir, hex(i));
   writeFileSync(p, "x".repeat(SIZE));
@@ -20,24 +40,55 @@ for (let i = 0; i < 10; i++) {
 writeFileSync(join(dir, ".sweep"), "");
 writeFileSync(join(dir, hex(0) + ".999.0.tmp"), "y".repeat(SIZE));
 
-// cap 500, low-water 300 → evict oldest until ≤ 300: delete 7, keep newest 3.
-const res = sweepCache(dir, 500, 300);
+const unit = unitOf(join(dir, hex(0)));
+// 10 units total; cap 5 units, low-water 3 → evict oldest until ≤ 3: delete 7,
+// keep the newest 3.
+const res = sweepCache(dir, unit * 5, unit * 3);
 
 const survivors = readdirSync(dir)
   .filter((n) => /^[0-9a-f]{64}$/.test(n))
   .sort();
 const expected = [hex(7), hex(8), hex(9)].sort();
 
-const ok =
+const flatOk =
   res.deleted === 7 &&
   survivors.length === 3 &&
   JSON.stringify(survivors) === JSON.stringify(expected) &&
   existsSync(join(dir, ".sweep")) &&
   existsSync(join(dir, hex(0) + ".999.0.tmp")) &&
-  sweepCache(dir, 500, 300).deleted === 0; // under cap now → no-op
+  sweepCache(dir, unit * 5, unit * 3).deleted === 0; // under cap now → no-op
+
+// ── V8 compile cache: Node's nested <version>/<entry> layout ────────
+// Entry names are V8's (8-hex), and a whole subdirectory accumulates per Node
+// build — so the sweep walks one level and prunes a version dir it empties.
+const cdir = mkdtempSync(join(tmpdir(), "nub-ccevict-"));
+const older = join(cdir, "v20.19.0-arm64-abcd1234-501");
+const newer = join(cdir, "v26.5.0-arm64-abcd1234-501");
+mkdirSync(older);
+mkdirSync(newer);
+for (let i = 0; i < 5; i++) {
+  const a = join(older, `a${i}0000`);
+  writeFileSync(a, "x".repeat(SIZE));
+  utimesSync(a, 1000 + i, 1000 + i); // oldest cohort
+  const b = join(newer, `b${i}0000`);
+  writeFileSync(b, "x".repeat(SIZE));
+  utimesSync(b, 2000 + i, 2000 + i); // newest cohort
+}
+
+// 10 units across two dirs; cap 5, low-water 3 → delete 7: all 5 of the older
+// version (emptying and pruning its directory) plus the 2 oldest of the newer.
+const cres = sweepCompileCache(cdir, unit * 5, unit * 3);
+const nestedOk =
+  cres.deleted === 7 &&
+  !existsSync(older) && // emptied → pruned
+  existsSync(newer) &&
+  readdirSync(newer).length === 3 &&
+  sweepCompileCache(cdir, unit * 5, unit * 3).deleted === 0; // under cap → no-op
 
 console.log(
-  ok
+  flatOk && nestedOk
     ? "EVICT-OK"
-    : `EVICT-FAIL deleted=${res.deleted} survivors=${JSON.stringify(survivors)}`,
+    : `EVICT-FAIL flat=${flatOk} deleted=${res.deleted} survivors=${JSON.stringify(survivors)} ` +
+        `nested=${nestedOk} cdeleted=${cres.deleted} olderPruned=${!existsSync(older)} ` +
+        `newerLeft=${existsSync(newer) ? readdirSync(newer).length : "gone"}`,
 );

--- a/tests/fixtures/data-url/extension-tail.mjs
+++ b/tests/fixtures/data-url/extension-tail.mjs
@@ -1,0 +1,29 @@
+// A `data:` URL carries its payload INLINE, so the URL string can end in
+// something extension-shaped that belongs to the SOURCE, not to a filename — a
+// trailing comment, a `sourceMappingURL`, a path inside a string literal.
+// Reading an extension off the whole URL sent nub's load hooks into the
+// transpile/data branches, whose `fileURLToPath` then threw
+// ERR_INVALID_URL_SCHEME on a module plain Node imports without complaint.
+//
+// Prints DATA-URL-OK when every tail loads and evaluates.
+const tails = [".ts", ".tsx", ".jsx", ".mjs", ".cjs", ".yaml", ".json5", ".txt"];
+const failures = [];
+
+for (const tail of tails) {
+  try {
+    const mod = await import(`data:text/javascript,export default 1//x${tail}`);
+    if (mod.default !== 1) failures.push(`${tail}: value=${mod.default}`);
+  } catch (err) {
+    failures.push(`${tail}: ${err.code ?? err.name}`);
+  }
+}
+
+// A plain data: URL with no extension-shaped tail must keep working too.
+try {
+  const plain = await import("data:text/javascript,export default 2");
+  if (plain.default !== 2) failures.push(`plain: value=${plain.default}`);
+} catch (err) {
+  failures.push(`plain: ${err.code ?? err.name}`);
+}
+
+console.log(failures.length === 0 ? "DATA-URL-OK" : `DATA-URL-FAIL ${failures.join(", ")}`);


### PR DESCRIPTION
Seven memory/disk defects, each reproduced and re-measured against plain Node.

| Defect | Before | After |
| --- | --- | --- |
| `run -r` retained every output line | 45→325 MB/50s | flat 15 MB |
| Non-TTY buffered the whole run | climbing | flat 29 MB |
| Object URLs kept a decoded heap copy | +43 MB/20k | +5.6 MB |
| Blobs pinned source buffers | 504 MB ext | 4 MB |
| Sweep never ran for sync runs | never | 527→383 MB |
| Compile-cache dir never evicted | 6.9 GB | swept daily |
| tsconfig memo unbounded | unbounded | 8192 cap |

Also fixes `data:` URLs with an extension-shaped tail throwing ERR_INVALID_URL_SCHEME.

Gates clean, 220/220 integration, bootstrap module list byte-identical.

A `blob:` worker source over 4 MB is no longer accepted; documented.
