### PR TITLE
fix(upgrade): strip the Windows verbatim path prefix, and skip a no-op upgrade

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -441,6 +441,16 @@ fn strip_windows_verbatim_prefix(path: &str) -> String {
     }
 }
 
+/// A path spelled for a HUMAN to read. `current_nub_binary` canonicalizes, and
+/// Windows canonicalization returns the extended-length `\\?\C:\…` form, so any
+/// path derived from it lands in output with a prefix no user typed and no shell
+/// echoes back (#704). Strip it at the print site only: the `PathBuf` itself
+/// stays verbatim so filesystem operations keep the `MAX_PATH` exemption a deep
+/// install dir depends on.
+fn display_path(path: &Path) -> String {
+    strip_windows_verbatim_prefix(&path.to_string_lossy())
+}
+
 /// The keys the watch guard strips from a forwarded env file's values.
 ///
 /// The runtime-control denylist is unconditional. `NODE_ENV` joins it only when
@@ -1065,7 +1075,7 @@ pub enum Command {
         #[arg(long)]
         dry_run: bool,
 
-        /// Skip confirmation prompt.
+        /// Accepted for scripted use; `nub upgrade` never prompts.
         #[arg(long, short)]
         yes: bool,
     },
@@ -4949,8 +4959,8 @@ fn resolve_bundled_busybox() -> Result<String> {
         "nub's bundled POSIX shell (busybox.exe) was not found next to the nub \
          executable — looked at {} and {}. Reinstall nub, or set `script-shell` in \
          .npmrc to a POSIX shell on PATH.",
-        beside.display(),
-        staged.display()
+        display_path(&beside),
+        display_path(&staged)
     );
 }
 
@@ -7203,7 +7213,7 @@ fn run_upgrade(
     _yes: bool,
 ) -> Result<i32> {
     let nub_binary = nub_core::node::spawn::current_nub_binary()?;
-    let bin_str = nub_binary.to_string_lossy().into_owned();
+    let bin_str = display_path(&nub_binary);
     let channel = detect_channel(&nub_binary);
     let release_channel =
         choose_release_channel(canary, stable, version.is_some(), is_canary_build());
@@ -7253,7 +7263,7 @@ fn run_upgrade(
                 };
                 println!(
                     "would upgrade to {channel_word} via self-owned ({})",
-                    install_dir.display()
+                    display_path(install_dir)
                 );
                 match platform_target() {
                     Some(plat) => {
@@ -7280,13 +7290,17 @@ fn run_upgrade(
                                 if resolved.is_err() && target == "latest" {
                                     println!("  (could not resolve `latest`; showing literal)");
                                 }
+                                if stable_upgrade_is_current(ver, env!("CARGO_PKG_VERSION"), target)
+                                {
+                                    println!("  (already on v{ver}; a real run would do nothing)");
+                                }
                                 format!("v{ver}")
                             }
                         };
                         println!("  platform: {plat}");
                         println!("  archive:  {}", archive_url_for_tag(&tag, plat));
                         println!("  sha256:   {}", checksum_url_for_tag(&tag, plat));
-                        println!("  install:  {}", install_dir.display());
+                        println!("  install:  {}", display_path(install_dir));
                     }
                     None => println!(
                         "  (no published archive for this platform: {}/{})",
@@ -7483,6 +7497,22 @@ fn resolve_version(spec: &str) -> Result<String> {
     Ok(tag.trim_start_matches('v').to_string())
 }
 
+/// Whether a resolved stable release is the one already running, so the upgrade
+/// can report "already on the latest" instead of re-downloading identical bytes
+/// (#664). Generalizes the arm the canary channel has always had.
+///
+/// Two cases deliberately do NOT short-circuit, because in both the versions
+/// matching does not mean the install is what the user asked for:
+///
+/// - An explicit `--version X` is a re-install request. Matching the running
+///   version is exactly when a user repairs a damaged install, so honor it.
+/// - A canary build carries the version it was cut from, so a canary at
+///   `0.7.4-canary.…` can resolve `latest` to a stable `0.7.4` it is NOT
+///   running. `--stable` off a canary is a channel switch and must download.
+fn stable_upgrade_is_current(resolved: &str, running: &str, version_spec: &str) -> bool {
+    version_spec == "latest" && !running.contains("-canary.") && resolved == running
+}
+
 /// Download + SHA-256-verify + atomic-swap a release archive into a self-owned
 /// `~/.nub` install. Mirrors install.sh's layout exactly: the archive contains
 /// `bin/` + `runtime/`, extracted into `<install_dir>` after replacing the prior
@@ -7520,6 +7550,13 @@ fn perform_selfowned_upgrade(
     let (tag, label) = match release_channel {
         ReleaseChannel::Stable => {
             let version = resolve_version(version_spec)?;
+            if stable_upgrade_is_current(&version, env!("CARGO_PKG_VERSION"), version_spec) {
+                // The resolve above is the same API call the download path
+                // needed anyway, so the check costs nothing and saves the whole
+                // archive fetch in the no-op case.
+                println!("already on the latest release (v{version})");
+                return Ok(());
+            }
             (format!("v{version}"), format!("v{version}"))
         }
         ReleaseChannel::Canary => match resolve_canary_version() {
@@ -7541,7 +7578,13 @@ fn perform_selfowned_upgrade(
     let url = archive_url_for_tag(&tag, target);
     let sha_url = checksum_url_for_tag(&tag, target);
 
-    println!("upgrading to {label} ({target})");
+    // Name the version being left as well as the one arriving: an upgrade that
+    // prints only its destination gives no way to tell a real move from a
+    // re-install (#664).
+    println!(
+        "upgrading from v{} to {label} ({target})",
+        env!("CARGO_PKG_VERSION")
+    );
 
     // Stage downloads + extraction in a sibling temp dir on the same filesystem
     // as the install so the final swap is a same-filesystem rename (atomic).
@@ -7631,7 +7674,7 @@ fn perform_selfowned_upgrade(
         }
     }
 
-    println!("installed {label} to {}", install_dir.display());
+    println!("installed {label} to {}", display_path(install_dir));
     Ok(())
 }
 
@@ -7659,7 +7702,7 @@ fn perform_selfowned_upgrade(
 fn swap_bin_files_windows(install_dir: &Path, staged_bin: &Path) -> Result<()> {
     let bin_dir = install_dir.join("bin");
     std::fs::create_dir_all(&bin_dir)
-        .with_context(|| format!("could not create {}", bin_dir.display()))?;
+        .with_context(|| format!("could not create {}", display_path(&bin_dir)))?;
     let nub = bin_dir.join("nub.exe");
     let nub_old = bin_dir.join("nub.exe.old");
     let nubx = bin_dir.join("nubx.exe");
@@ -7677,14 +7720,15 @@ fn swap_bin_files_windows(install_dir: &Path, staged_bin: &Path) -> Result<()> {
                 "nub upgrade: could not move the running {} aside. If a stale \
                  nub.exe.old is held open by another running nub process, close \
                  it and retry; the install has not been modified.",
-                nub.display()
+                display_path(&nub)
             )
         })?;
     }
     if let Err(e) = std::fs::rename(staged_bin.join("nub.exe"), &nub) {
         // Roll the old binary back so the install keeps working.
         let _ = std::fs::rename(&nub_old, &nub);
-        return Err(e).with_context(|| format!("nub upgrade: could not install {}", nub.display()));
+        return Err(e)
+            .with_context(|| format!("nub upgrade: could not install {}", display_path(&nub)));
     }
 
     // nubx refresh is BEST-EFFORT per the resilience contract: `nub` is already
@@ -7697,7 +7741,7 @@ fn swap_bin_files_windows(install_dir: &Path, staged_bin: &Path) -> Result<()> {
         eprintln!(
             "nub upgrade: warning: could not refresh the nubx alias at {} ({e}); \
              `nub` is upgraded and usable. Re-run the installer to restore nubx.",
-            nubx.display()
+            display_path(&nubx)
         );
     }
 
@@ -7721,7 +7765,7 @@ fn swap_bin_files_windows(install_dir: &Path, staged_bin: &Path) -> Result<()> {
                 "nub upgrade: warning: could not install the bundled shell at {} ({e}); \
                  `nub` is upgraded and usable, but `nub run` may fail until you re-run \
                  the installer.",
-                busybox.display()
+                display_path(&busybox)
             );
         }
     }
@@ -8744,7 +8788,7 @@ fn run_pm(args: &[String]) -> Result<i32> {
             if resolve::project_pm_identity(&cwd).is_some_and(|id| id.name == "nub") {
                 let exe = nub_core::node::spawn::current_nub_binary()
                     .unwrap_or_else(|_| PathBuf::from("nub"));
-                println!("{}", exe.display());
+                println!("{}", display_path(&exe));
                 std::io::stdout().flush().ok();
                 // Name the field the nub identity actually resolved from — the
                 // virgin/bare-`use` path pins via `devEngines.packageManager`
@@ -10634,6 +10678,24 @@ mod tests {
         );
     }
 
+    // #704: the upgrade path derives its install dir from the canonicalized
+    // binary, so on Windows every path it prints arrives carrying `\\?\`.
+    // `display_path` is the single place that spelling is dropped, and only for
+    // display — the PathBuf the swap operates on keeps the verbatim form.
+    #[test]
+    fn display_path_drops_the_windows_verbatim_prefix_a_user_never_typed() {
+        assert_eq!(
+            display_path(Path::new(r"\\?\C:\Users\u\.nub")),
+            r"C:\Users\u\.nub"
+        );
+        assert_eq!(
+            display_path(Path::new(r"\\?\UNC\server\share\.nub")),
+            r"\\server\share\.nub"
+        );
+        // POSIX paths, and an already-ordinary Windows path, pass through whole.
+        assert_eq!(display_path(Path::new("/home/u/.nub")), "/home/u/.nub");
+    }
+
     #[cfg(windows)]
     #[test]
     fn windows_long_watch_path_keeps_existing_file_and_cwd_in_one_spelling() {
@@ -11457,6 +11519,29 @@ mod tests {
             detect_channel(Path::new("/some/random/place/nub")),
             UpgradeChannel::Unknown
         );
+    }
+
+    // #664: `nub upgrade` on an up-to-date install must report that instead of
+    // re-downloading the archive it is already running. The two non-short-circuit
+    // cases are the point of the test — each is a request the version match does
+    // not actually satisfy.
+    #[test]
+    fn stable_upgrade_skips_the_download_only_for_an_unpinned_matching_stable() {
+        assert!(stable_upgrade_is_current("0.7.4", "0.7.4", "latest"));
+        assert!(!stable_upgrade_is_current("0.7.5", "0.7.4", "latest"));
+
+        // An explicit `--version` is a re-install request — matching the running
+        // version is exactly when a user repairs a damaged install.
+        assert!(!stable_upgrade_is_current("0.7.4", "0.7.4", "0.7.4"));
+
+        // A canary carries the version it was cut from, so `--stable` off a
+        // canary can resolve to a stable release it is NOT running. Downloading
+        // is what performs the channel switch.
+        assert!(!stable_upgrade_is_current(
+            "0.7.4",
+            "0.7.4-canary.20260809.1",
+            "latest"
+        ));
     }
 
     // Receipt-based self-owned detection: a relocated NUB_INSTALL_DIR (not named

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -368,7 +368,7 @@ That installs the Rust binary (via the usual `@<scope>/<platform-arch>` npm dist
 npm install -g @nubjs/nub@latest
 ```
 
-Same as installing — match how you installed: `brew update && brew upgrade nub` for a Homebrew install, otherwise re-run your installer. Nub and Node version independently: Nub resolves the Node your project pins (`.node-version` / `.nvmrc` / `engines.node`) and provisions it if it's missing, falling back to the `node` on your `PATH` only when nothing is pinned. So upgrading Nub does not change your project's Node version, and upgrading Node does not change your Nub version.
+Same as installing — match how you installed: `brew update && brew upgrade nub` for a Homebrew install, otherwise re-run your installer. On a script install, `nub upgrade` resolves the published release before it downloads anything: when nothing is newer it prints `already on the latest release` and stops. Pass `--version` to reinstall the version you are already running. Nub and Node version independently: Nub resolves the Node your project pins (`.node-version` / `.nvmrc` / `engines.node`) and provisions it if it's missing, falling back to the `node` on your `PATH` only when nothing is pinned. So upgrading Nub does not change your project's Node version, and upgrading Node does not change your Nub version.
 
 ## Is there a curl install script?
 


### PR DESCRIPTION
`current_nub_binary` canonicalizes, and Windows canonicalization returns `\\?\C:\…`, so every path `nub upgrade` printed carried that prefix. A new `display_path` strips it at the print sites only; the `PathBuf` used for the swap keeps the `MAX_PATH` exemption.

The stable self-owned channel now stops with `already on the latest release (vX)` instead of re-downloading. An explicit `--version` still reinstalls, and `--stable` off a canary still downloads.

`--yes` advertised a prompt that never existed; the help text now matches.

Closes #704
Closes #664