### PR TITLE
fix(install): only revalidate release policy when the age gate moved

### DIFF
--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1198,9 +1198,11 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     // yaml_prefer_frozen: None — see KNOWN APPROXIMATIONS in the module doc.
     let mut opts = args.into_options(global_frozen, None, cli_flags, super::env_snapshot());
     // The settings hash makes release-policy drift miss the no-op warm path.
-    // Once there is real install work, validate the existing lockfile picks by
-    // re-resolving under the effective age gate. Explicit frozen modes remain
-    // lockfile-as-truth inside the engine.
+    // Once there is real install work, opt into revalidating the existing
+    // lockfile picks under the effective age gate. The engine only re-resolves
+    // when the age policy itself actually moved since the last install — an
+    // ordinary catalog or overrides edit keeps normal prefer-frozen reuse.
+    // Explicit frozen modes remain lockfile-as-truth inside the engine.
     opts.revalidate_release_policy = true;
     // yarn `enableScripts: false` — honor the security opt-out by forcing a
     // block-all-builds policy that overrides even nub's curated default-trust floor.

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -1091,11 +1091,19 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // this install has already missed the unchanged-tree fast path. Prefer mode
     // then takes a fresh-metadata resolver path; explicit Frozen remains
     // lockfile-as-truth.
+    // `release_policy_settings_drift` is derived from `settings_hash`, which
+    // also covers the raw workspace yaml — so it fires on any catalog,
+    // overrides, or packageExtensions edit. Those cannot change the age gate,
+    // and revalidation discards the lockfile (below), which re-resolves the
+    // whole graph to newest-in-range. Narrow it to real age-policy drift: a
+    // pick that was already admitted under an unchanged gate only ever gets
+    // older, so it stays admissible and needs no revalidation.
     let revalidate_release_policy = release_policy_settings_drift
         && opts
             .minimum_release_age_override
             .unwrap_or_else(|| aube_settings::resolved::minimum_release_age(&settings_ctx))
-            > 0;
+            > 0
+        && crate::state::release_policy_changed_since_last_run(&cwd, &opts.cli_flags);
     // Resolver reuse can accept a locked package without fetching its publish
     // time, which would bypass the age gate we are here to revalidate. Match
     // `--force` for this one path by withholding the existing-graph hint.

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -103,8 +103,11 @@ pub struct InstallState {
     /// touching the age gate. Only a real age-policy change can
     /// invalidate lockfile picks that were already admitted under it,
     /// and that is the one question release-policy revalidation asks.
-    /// Empty on fresh state or an install predating this field, which
-    /// revalidates once and then records the hash.
+    /// Empty on fresh state or an install predating this field. That
+    /// reads as "previous policy unknown", which does NOT revalidate —
+    /// see [`release_policy_changed_since_last_run`] for why the two
+    /// directions carry very different costs. The next install records
+    /// the hash, and a genuine change is caught from then on.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub release_policy_hash: String,
     /// Per-package content fingerprints from the last install,
@@ -903,18 +906,26 @@ pub fn read_state_dep_build_policy_hash(project_dir: &Path) -> Option<String> {
 }
 
 /// Whether the resolved minimum-release-age policy differs from the one the
-/// last install recorded. `true` when state is missing or predates
-/// `release_policy_hash`, so an unknown policy still revalidates once and
-/// records the hash for next time.
+/// last install recorded.
+///
+/// An unknown previous policy — state missing, or written before
+/// `release_policy_hash` existed — answers `false`. Revalidation discards the
+/// lockfile and re-picks every range at newest, so the two directions are not
+/// symmetric: guessing "changed" costs every upgrading user one whole-graph
+/// re-resolve on their next settings edit, while guessing "unchanged" only
+/// defers a gate re-check. That exposure is bounded — a locked pick was
+/// admitted under some earlier gate and has only aged since, so the sole miss
+/// is a pick younger than a gate that was raised while we had no record, and
+/// the next real policy change re-checks it. Fail toward the lockfile.
 pub(crate) fn release_policy_changed_since_last_run(
     project_dir: &Path,
     cli_flags: &[(String, String)],
 ) -> bool {
     let Some(state) = read_state(&state_dir(project_dir)) else {
-        return true;
+        return false;
     };
     if state.release_policy_hash.is_empty() {
-        return true;
+        return false;
     }
     state.release_policy_hash != hash_release_policy(project_dir, cli_flags)
 }
@@ -2735,10 +2746,10 @@ mod tests {
         let workspace = dir.join("pnpm-workspace.yaml");
         std::fs::write(&workspace, "minimumReleaseAge: 4320\n").unwrap();
 
-        // Nothing recorded yet, so nothing has been validated.
+        // Nothing recorded yet, so there is no evidence the gate moved.
         assert!(
-            release_policy_changed_since_last_run(&dir, &[]),
-            "missing state must revalidate"
+            !release_policy_changed_since_last_run(&dir, &[]),
+            "missing state must not revalidate"
         );
 
         let graph = aube_lockfile::LockfileGraph::default();
@@ -2798,8 +2809,11 @@ mod tests {
             "a raised age gate must revalidate"
         );
 
-        // A state file predating the field (empty hash) is treated as unknown
-        // and revalidates once rather than silently trusting it.
+        // A state file predating the field (empty hash) is unknown, not changed.
+        // This is the upgrade hop: every nub before this field wrote state
+        // without it, so answering "changed" here would hand each upgrading
+        // user one full re-resolve on their next settings edit — the very
+        // symptom this PR exists to remove.
         write(&dir);
         let mut state = read_state(&state_dir(&dir)).expect("state should read back");
         assert!(
@@ -2813,8 +2827,21 @@ mod tests {
         )
         .unwrap();
         assert!(
+            !release_policy_changed_since_last_run(&dir, &[]),
+            "state predating release_policy_hash must not revalidate"
+        );
+
+        // The unknown-is-not-changed default must not swallow a real change:
+        // once a hash is on record, raising the gate still revalidates.
+        write(&dir);
+        std::fs::write(
+            &workspace,
+            "minimumReleaseAge: 20160\ncatalog:\n  left-pad: 1.0.0\n",
+        )
+        .unwrap();
+        assert!(
             release_policy_changed_since_last_run(&dir, &[]),
-            "state predating release_policy_hash must revalidate"
+            "a raised age gate must still revalidate once a hash is recorded"
         );
     }
 }

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -1797,10 +1797,12 @@ fn empty_blake3_hash() -> &'static str {
 mod tests {
     use super::{
         InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
-        collect_package_json_hashes_from_manifests, empty_blake3_hash, fresh_state_file, hash_file,
-        hash_release_age_settings, hash_release_policy, hash_settings, install_state_file,
-        member_lockfiles_stale, new_workspace_member, read_or_migrate_fresh_state,
-        relative_path_or_original, remove_state, verify_install_layout,
+        WriteStateInput, WriteStateLayout, collect_package_json_hashes_from_manifests,
+        empty_blake3_hash, fresh_state_file, hash_file, hash_release_age_settings,
+        hash_release_policy, hash_settings, install_state_file, member_lockfiles_stale,
+        new_workspace_member, read_or_migrate_fresh_state, read_state, relative_path_or_original,
+        release_policy_changed_since_last_run, remove_state, state_dir, verify_install_layout,
+        write_state,
     };
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -2718,6 +2720,101 @@ mod tests {
             policy_before,
             hash_release_policy(&dir, &[]),
             "changing the age gate must read as age-policy drift"
+        );
+    }
+
+    #[test]
+    fn recorded_release_policy_hash_round_trips_through_write_state() {
+        // The narrowing only works if the hash `write_state` records is the one
+        // `release_policy_changed_since_last_run` later compares against. If
+        // those two ever stop agreeing, the checker returns `true` forever and
+        // revalidation silently reverts to firing on every settings change —
+        // which the hash-only test above would not catch.
+        let dir = temp_project_dir("release-policy-round-trip");
+        std::fs::write(dir.join("package.json"), r#"{"name":"x"}"#).unwrap();
+        let workspace = dir.join("pnpm-workspace.yaml");
+        std::fs::write(&workspace, "minimumReleaseAge: 4320\n").unwrap();
+
+        // Nothing recorded yet, so nothing has been validated.
+        assert!(
+            release_policy_changed_since_last_run(&dir, &[]),
+            "missing state must revalidate"
+        );
+
+        let graph = aube_lockfile::LockfileGraph::default();
+        let aube_dir = dir.join("node_modules/.aube");
+        std::fs::create_dir_all(&aube_dir).unwrap();
+        let write = |dir: &Path| {
+            write_state(
+                dir,
+                WriteStateInput {
+                    section_filtered: false,
+                    package_json_hashes: BTreeMap::new(),
+                    cli_flags: &[],
+                    package_content_hashes: BTreeMap::new(),
+                    graph_lthash: String::new(),
+                    package_subtree_hashes: BTreeMap::new(),
+                    dep_build_policy_hash: String::new(),
+                    layout: WriteStateLayout {
+                        graph: &graph,
+                        node_linker: aube_linker::NodeLinker::Isolated,
+                        modules_dir_name: "node_modules",
+                        aube_dir: &aube_dir,
+                        virtual_store_dir_max_length: 120,
+                        placements: None,
+                    },
+                    unreviewed_builds: Vec::new(),
+                },
+            )
+            .expect("state should write");
+        };
+        write(&dir);
+
+        assert!(
+            !release_policy_changed_since_last_run(&dir, &[]),
+            "an unchanged age gate must not revalidate"
+        );
+
+        // The bug this PR fixes: a catalog edit moves `settings_hash` but is not
+        // an age-policy change, so it must not force revalidation.
+        std::fs::write(
+            &workspace,
+            "minimumReleaseAge: 4320\ncatalog:\n  left-pad: 1.0.0\n",
+        )
+        .unwrap();
+        assert!(
+            !release_policy_changed_since_last_run(&dir, &[]),
+            "a catalog edit must not revalidate"
+        );
+
+        // A tightened gate still must.
+        std::fs::write(
+            &workspace,
+            "minimumReleaseAge: 10080\ncatalog:\n  left-pad: 1.0.0\n",
+        )
+        .unwrap();
+        assert!(
+            release_policy_changed_since_last_run(&dir, &[]),
+            "a raised age gate must revalidate"
+        );
+
+        // A state file predating the field (empty hash) is treated as unknown
+        // and revalidates once rather than silently trusting it.
+        write(&dir);
+        let mut state = read_state(&state_dir(&dir)).expect("state should read back");
+        assert!(
+            !state.release_policy_hash.is_empty(),
+            "write_state must record the policy hash"
+        );
+        state.release_policy_hash = String::new();
+        std::fs::write(
+            install_state_file(&state_dir(&dir)),
+            serde_json::to_string(&state).expect("state should serialize"),
+        )
+        .unwrap();
+        assert!(
+            release_policy_changed_since_last_run(&dir, &[]),
+            "state predating release_policy_hash must revalidate"
         );
     }
 }

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -96,6 +96,17 @@ pub struct InstallState {
     /// full eligible build scan.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub dep_build_policy_hash: String,
+    /// Resolved minimum-release-age policy. Separate from
+    /// `settings_hash` for the same reason as `dep_build_policy_hash`:
+    /// `settings_hash` mixes in the raw workspace yaml, so an ordinary
+    /// catalog / overrides / packageExtensions edit moves it without
+    /// touching the age gate. Only a real age-policy change can
+    /// invalidate lockfile picks that were already admitted under it,
+    /// and that is the one question release-policy revalidation asks.
+    /// Empty on fresh state or an install predating this field, which
+    /// revalidates once and then records the hash.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub release_policy_hash: String,
     /// Per-package content fingerprints from the last install,
     /// keyed by dep_path. Drives delta installs. Next install diffs
     /// these against the new lockfile's hashes and only re-fetches
@@ -716,6 +727,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     let (lockfile_hash, lockfile_snapshot_name) =
         snapshot_active_lockfile(project_dir, &state_path)?;
     let settings_hash = hash_settings(project_dir, cli_flags);
+    let release_policy_hash = hash_release_policy(project_dir, cli_flags);
     let install_layout = InstallLayoutState::from_graph(
         project_dir,
         layout.graph,
@@ -777,6 +789,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         section_filtered,
         settings_hash,
         dep_build_policy_hash,
+        release_policy_hash,
         package_content_hashes,
         graph_lthash,
         package_subtree_hashes,
@@ -887,6 +900,23 @@ pub fn read_state_dep_build_policy_hash(project_dir: &Path) -> Option<String> {
         return None;
     }
     Some(state.dep_build_policy_hash)
+}
+
+/// Whether the resolved minimum-release-age policy differs from the one the
+/// last install recorded. `true` when state is missing or predates
+/// `release_policy_hash`, so an unknown policy still revalidates once and
+/// records the hash for next time.
+pub(crate) fn release_policy_changed_since_last_run(
+    project_dir: &Path,
+    cli_flags: &[(String, String)],
+) -> bool {
+    let Some(state) = read_state(&state_dir(project_dir)) else {
+        return true;
+    };
+    if state.release_policy_hash.is_empty() {
+        return true;
+    }
+    state.release_policy_hash != hash_release_policy(project_dir, cli_flags)
 }
 
 /// Read the node-linker layout the last install materialized, if
@@ -1704,6 +1734,24 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     format!("blake3:{}", hasher.finalize().to_hex())
 }
 
+/// Fingerprint *only* the resolved minimum-release-age policy.
+///
+/// `hash_settings` also mixes in the raw workspace-yaml bytes, so it moves on
+/// every catalog / overrides / packageExtensions edit. That makes it far too
+/// broad to stand in for "did the age gate change?", which is the only drift
+/// that can invalidate lockfile picks already admitted under the gate.
+/// Resolved values only, so a no-op edit collapses to the same hash.
+fn hash_release_policy(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
+    let files = crate::commands::FileSources::load(project_dir);
+    let (_ws_config, raw_workspace) =
+        aube_manifest::workspace::load_both(project_dir).unwrap_or_default();
+    let env = aube_settings::values::capture_env();
+    let ctx = files.ctx(&raw_workspace, &env, cli_flags);
+    let mut hasher = blake3::Hasher::new();
+    hash_release_age_settings(&mut hasher, &ctx);
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
 fn hash_release_age_settings(hasher: &mut blake3::Hasher, ctx: &aube_settings::ResolveCtx<'_>) {
     let minimum_release_age = aube_settings::resolved::minimum_release_age(ctx);
     hasher.update(format!("minimum_release_age={minimum_release_age}\0").as_bytes());
@@ -1750,9 +1798,9 @@ mod tests {
     use super::{
         InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
         collect_package_json_hashes_from_manifests, empty_blake3_hash, fresh_state_file, hash_file,
-        hash_release_age_settings, hash_settings, install_state_file, member_lockfiles_stale,
-        new_workspace_member, read_or_migrate_fresh_state, relative_path_or_original, remove_state,
-        verify_install_layout,
+        hash_release_age_settings, hash_release_policy, hash_settings, install_state_file,
+        member_lockfiles_stale, new_workspace_member, read_or_migrate_fresh_state,
+        relative_path_or_original, remove_state, verify_install_layout,
     };
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -1783,6 +1831,7 @@ mod tests {
             section_filtered: false,
             settings_hash: String::new(),
             dep_build_policy_hash: String::new(),
+            release_policy_hash: String::new(),
             package_content_hashes: BTreeMap::new(),
             graph_lthash: String::new(),
             package_subtree_hashes: BTreeMap::new(),
@@ -2038,6 +2087,7 @@ mod tests {
             section_filtered: false,
             settings_hash: "blake3:settings".to_string(),
             dep_build_policy_hash: "blake3:dep-build-policy".to_string(),
+            release_policy_hash: "blake3:release-policy".to_string(),
             package_content_hashes: BTreeMap::from([(
                 "is-odd@3.0.1".to_string(),
                 "blake3:content".to_string(),
@@ -2095,6 +2145,7 @@ mod tests {
             section_filtered: false,
             settings_hash: String::new(),
             dep_build_policy_hash: String::new(),
+            release_policy_hash: String::new(),
             package_content_hashes: BTreeMap::new(),
             graph_lthash: String::new(),
             package_subtree_hashes: BTreeMap::new(),
@@ -2328,6 +2379,7 @@ mod tests {
             section_filtered: false,
             settings_hash: String::new(),
             dep_build_policy_hash: String::new(),
+            release_policy_hash: String::new(),
             package_content_hashes: BTreeMap::new(),
             graph_lthash: String::new(),
             package_subtree_hashes: BTreeMap::new(),
@@ -2619,6 +2671,53 @@ mod tests {
                 ("minimumReleaseAgeStrict", "true")
             ]),
             "changing strictness must invalidate"
+        );
+    }
+
+    #[test]
+    fn catalog_edit_moves_settings_hash_but_not_release_policy_hash() {
+        // Release-policy revalidation discards the lockfile and re-resolves the
+        // whole graph to newest-in-range, so it has to key off the age gate
+        // alone. `settings_hash` also covers the raw workspace yaml — which is
+        // where catalogs live — so using it as the trigger re-resolves
+        // everything on an ordinary dependency bump.
+        let dir = temp_project_dir("release-policy-vs-catalog");
+        std::fs::write(dir.join("package.json"), r#"{"name":"x"}"#).unwrap();
+        let workspace = dir.join("pnpm-workspace.yaml");
+        std::fs::write(
+            &workspace,
+            "minimumReleaseAge: 4320\ncatalog:\n  left-pad: 1.0.0\n",
+        )
+        .unwrap();
+
+        let settings_before = hash_settings(&dir, &[]);
+        let policy_before = hash_release_policy(&dir, &[]);
+
+        std::fs::write(
+            &workspace,
+            "minimumReleaseAge: 4320\ncatalog:\n  left-pad: 1.1.0\n",
+        )
+        .unwrap();
+        assert_ne!(
+            settings_before,
+            hash_settings(&dir, &[]),
+            "a catalog bump must still bust the broad settings hash"
+        );
+        assert_eq!(
+            policy_before,
+            hash_release_policy(&dir, &[]),
+            "a catalog bump must not read as age-policy drift"
+        );
+
+        std::fs::write(
+            &workspace,
+            "minimumReleaseAge: 10080\ncatalog:\n  left-pad: 1.1.0\n",
+        )
+        .unwrap();
+        assert_ne!(
+            policy_before,
+            hash_release_policy(&dir, &[]),
+            "changing the age gate must read as age-policy drift"
         );
     }
 }

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -909,14 +909,31 @@ pub fn read_state_dep_build_policy_hash(project_dir: &Path) -> Option<String> {
 /// last install recorded.
 ///
 /// An unknown previous policy — state missing, or written before
-/// `release_policy_hash` existed — answers `false`. Revalidation discards the
-/// lockfile and re-picks every range at newest, so the two directions are not
-/// symmetric: guessing "changed" costs every upgrading user one whole-graph
-/// re-resolve on their next settings edit, while guessing "unchanged" only
-/// defers a gate re-check. That exposure is bounded — a locked pick was
-/// admitted under some earlier gate and has only aged since, so the sole miss
-/// is a pick younger than a gate that was raised while we had no record, and
-/// the next real policy change re-checks it. Fail toward the lockfile.
+/// `release_policy_hash` existed — answers `false`.
+///
+/// State the cost plainly, because it is real: on a project's first install
+/// that does actual work after upgrading past this field, a RAISED age gate is
+/// NOT applied to the versions already in the lockfile, and that same install
+/// records the new hash, so the raise is never retried. Picks sitting between
+/// the old and the new cutoff are kept, and leave the window by aging out
+/// rather than by any check. `--force` re-resolves under the current gate and
+/// is how to apply a raise retroactively. An empty hash cannot establish what
+/// gate, if any, the existing picks once cleared — a lockfile written by
+/// another package manager never saw this gate at all — so no safety argument
+/// is available from the picks themselves.
+///
+/// It is accepted because the alternative is worse and certain. Answering
+/// "changed" here fires on the upgrade hop for EVERY project, whatever moved
+/// its settings — a comment in `.npmrc`, a catalog entry, a different Node
+/// major — and revalidation discards the lockfile and re-picks every range at
+/// newest. That is the reported defect this narrowing exists to remove, and it
+/// would survive one full install per project. A deferred gate re-check is
+/// recoverable with one flag; a whole-graph version bump landed in someone's
+/// lockfile is not.
+///
+/// The two arms differ in reachability, not in answer: `read_state` returning
+/// `None` is already unreachable from the only caller, because
+/// `install_settings_changed_since_last_run` answers `false` on missing state.
 pub(crate) fn release_policy_changed_since_last_run(
     project_dir: &Path,
     cli_flags: &[(String, String)],
@@ -2829,6 +2846,22 @@ mod tests {
         assert!(
             !release_policy_changed_since_last_run(&dir, &[]),
             "state predating release_policy_hash must not revalidate"
+        );
+
+        // The DOCUMENTED COST, pinned so it cannot be flipped back without
+        // reading why: on that same upgrade-hop install a RAISED gate is not
+        // applied either, because an empty hash carries no policy to compare
+        // against. `--force` is the retroactive path. If this assertion ever
+        // fails, the upgrade hop has started re-resolving every project's whole
+        // graph again — the defect this narrowing removes.
+        std::fs::write(
+            &workspace,
+            "minimumReleaseAge: 43200\ncatalog:\n  left-pad: 1.0.0\n",
+        )
+        .unwrap();
+        assert!(
+            !release_policy_changed_since_last_run(&dir, &[]),
+            "an unknown previous policy must not revalidate even when the gate is raised"
         );
 
         // The unknown-is-not-changed default must not swallow a real change:


### PR DESCRIPTION
Root cause and fix for #709.

Closes #709.

## The bug

With `minimumReleaseAge` set, `nub install` throws away the lockfile and re-picks every dependency to the newest version in range.

Why: `nub install` asks the engine to re-check the age gate against the locked versions. The engine decides whether that check is needed by comparing `settings_hash` — which includes the raw `pnpm-workspace.yaml` bytes, where `catalog` lives. So editing a catalog entry looks like an age-gate change. And the "check" is done by resolving as if there were no lockfile.

That also explains the frozen/prefer-frozen split in #709: `ci.rs` turns the check off, so frozen never takes that branch.

One repo, `minimumReleaseAge: 4320`, three catalog edits:

| | changed lines in `pnpm-lock.yaml` |
| --- | --- |
| before | 14,492 |
| after | 6 |

The flag doesn't exist in v0.6.0 and does in v0.7.0, matching #709.

## The fix

Compare a hash of just the age settings, not the whole settings hash. Follows the existing `dep_build_policy_hash` next to it, same reason, and reuses the existing `hash_release_age_settings`.

Safe because a locked version only gets older — if it passed this gate before, it still does. Newly resolved versions are still gated as usual; this only stops discarding a lockfile that was already checked under the same settings.

## Two limits

A tightened gate is not always applied to versions already in the lockfile.

The first case is an unknown previous policy. State written before this PR's `release_policy_hash` field carries no policy to compare against, which is every project on its first install after upgrading. That install reuses the lockfile and records the new hash, so a gate raised in that window is never applied to existing picks — they leave it by aging out. Running with `--force` re-resolves under the current gate. The alternative was worse: answering "changed" there fires on the upgrade hop for every project whatever moved its settings, and re-picks every range at newest, which is the defect this PR removes.

The second is that `write_state` records the hash on any install, including `nub ci`, which never calls the resolver. So CI can record a tightened gate without checking anything. Pre-existing — `hash_settings` already included the same bytes — but my first draft claimed more than that, so I'm stating it straight. Can close it separately if you want (only record the hash when the run actually resolved).

## Checks

903 tests pass, clippy clean, `cargo fmt`.

Two tests, both mutation-checked so I know they bite:
- catalog edit moves `settings_hash` but not the age hash; an age-gate change moves both.
- the recorded hash round-trips through the real `write_state`, plus missing state and old state files with no hash.

## Not covered

Only the `nub install` path. The report also saw standalone aube 1.38.0 do this, but that is not the same defect: `revalidate_release_policy` does not exist upstream at all (zero occurrences in aube 1.38.0), and upstream assigns the resolver's existing-graph hint unconditionally, so it has no path that discards a lockfile over release-age policy. Checked against source rather than behaviour, so a different standalone symptom is not ruled out — but this mechanism is nub-only, and nothing about it is left unfixed here.

Not a regular contributor here, so say the word if a stored hash is the wrong shape. The narrowing is the point, not the mechanism.

