### PR TITLE
fix(config): write nub.jsonc at the workspace root

### DIFF
--- a/crates/nub-cli/src/config_fields.rs
+++ b/crates/nub-cli/src/config_fields.rs
@@ -32,6 +32,7 @@
 use std::path::{Path, PathBuf};
 
 use jsonc_parser::cst::CstInputValue;
+use nub_core::workspace::detect::detect_project;
 use serde_json::{Map, Value};
 
 use crate::project_config::{self, ConfigError};
@@ -327,12 +328,23 @@ fn write_target(field: &Field, scope: Scope) -> anyhow::Result<PathBuf> {
 }
 
 /// The project file a write lands in: the one discovery would read, else a new
-/// file at the project root so a `set` from a subdirectory does not create a
-/// second `nub.jsonc` that shadows nothing.
+/// file at the workspace root when the project is a member, else at the project
+/// root — so a `set` or an `init` from a subdirectory does not create a second
+/// `nub.jsonc` that shadows nothing.
+///
+/// A workspace materializes ONE tree under ONE resolved engine, so its settings
+/// belong to the root rather than to whichever member happened to be the cwd —
+/// the same anchor [`crate::install_engine::anchor`] keys an install's tree at.
+/// Going through [`detect_project`] rather than a second walk keeps the
+/// pnpm-incumbency gate on `pnpm-workspace.yaml` in one place. A member that
+/// wants its own config still gets one: discovery above takes the nearest file.
 pub(crate) fn project_file() -> PathBuf {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     if let Some(found) = project_config::discover_project_config(&cwd) {
         return found;
+    }
+    if let Some(workspace_root) = detect_project(&cwd).and_then(|p| p.workspace_root) {
+        return workspace_root.join(project_config::FILE_NAME);
     }
     for dir in cwd.ancestors() {
         if dir.join("package.json").is_file() {

--- a/crates/nub-cli/src/config_fields.rs
+++ b/crates/nub-cli/src/config_fields.rs
@@ -338,6 +338,14 @@ fn write_target(field: &Field, scope: Scope) -> anyhow::Result<PathBuf> {
 /// Going through [`detect_project`] rather than a second walk keeps the
 /// pnpm-incumbency gate on `pnpm-workspace.yaml` in one place. A member that
 /// wants its own config still gets one: discovery above takes the nearest file.
+///
+/// Membership is deliberately NOT glob-checked against the workspace patterns,
+/// so a nested package the patterns exclude (`examples/*`, a fixture dir) also
+/// resolves to the root. That is the point rather than a gap: absent a local
+/// file, discovery already READS the root config from such a directory, so
+/// anchoring the write there edits the file that governs it. Matching globs
+/// instead would have a `set` mint a local file that SHADOWS the root for that
+/// subtree — the surprise this function exists to avoid.
 pub(crate) fn project_file() -> PathBuf {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     if let Some(found) = project_config::discover_project_config(&cwd) {

--- a/crates/nub-cli/tests/pm_publish_store_config.rs
+++ b/crates/nub-cli/tests/pm_publish_store_config.rs
@@ -261,15 +261,12 @@ fn config_init_from_a_subdirectory_targets_the_project_file() {
     assert_eq!(std::fs::read(&project_file).unwrap(), before);
 }
 
-/// A workspace member is not its own config scope. One workspace materializes
-/// one tree under one engine, so `init` from a member anchors at the workspace
-/// root instead of dropping a `nub.jsonc` in every package — and `set` resolves
-/// the same file, so the two cannot disagree about where the config lives.
-#[test]
-fn config_init_from_a_workspace_member_targets_the_workspace_root() {
-    const WORKSPACE_ROOT: &str =
-        r#"{"name":"ws-root","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#;
-    let ctx = Ctx::new("config-init-workspace", WORKSPACE_ROOT);
+/// A workspace root holding one member at `packages/app`, both with manifests.
+fn workspace(tag: &str) -> (Ctx, PathBuf) {
+    let ctx = Ctx::new(
+        tag,
+        r#"{"name":"ws-root","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#,
+    );
     let member = ctx.project.join("packages/app");
     std::fs::create_dir_all(&member).unwrap();
     std::fs::write(
@@ -277,8 +274,17 @@ fn config_init_from_a_workspace_member_targets_the_workspace_root() {
         r#"{"name":"app","version":"1.0.0"}"#,
     )
     .unwrap();
+    (ctx, member)
+}
+
+/// A workspace member is not its own config scope. One workspace materializes
+/// one tree under one engine, so `init` from a member anchors at the workspace
+/// root instead of dropping a `nub.jsonc` in every package — and `set` resolves
+/// the same file, so the two cannot disagree about where the config lives.
+#[test]
+fn config_init_from_a_workspace_member_targets_the_workspace_root() {
+    let (ctx, member) = workspace("config-init-workspace");
     let root_file = ctx.project.join("nub.jsonc");
-    let member_file = member.join("nub.jsonc");
 
     let (stdout, stderr, code) = ctx.run_in(&member, &["config", "init"]);
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
@@ -291,19 +297,29 @@ fn config_init_from_a_workspace_member_targets_the_workspace_root() {
         "no file at the workspace root: {stdout}"
     );
     assert!(
-        !member_file.exists(),
+        !member.join("nub.jsonc").exists(),
         "init created a second config in the member: {stdout}"
     );
+}
+
+/// The write path resolves the same root. Deliberately a FRESH workspace with no
+/// `init` first: the template comments out every project field, so `"nodeCompat":
+/// true` appears in an initialized file whether or not the write landed, and the
+/// assertion would hold on the template alone.
+#[test]
+fn config_set_from_a_workspace_member_writes_the_workspace_root() {
+    let (ctx, member) = workspace("config-set-workspace");
+    let root_file = ctx.project.join("nub.jsonc");
 
     let (_, stderr, code) = ctx.run_in(&member, &["config", "set", "nodeCompat", "true"]);
     assert_eq!(code, 0, "stderr: {stderr}");
     let body = read(&root_file);
     assert!(
         body.contains("\"nodeCompat\": true"),
-        "a member `set` must edit the workspace-root file: {body}"
+        "a member `set` must write the workspace-root file: {body}"
     );
     assert!(
-        !member_file.exists(),
+        !member.join("nub.jsonc").exists(),
         "a member `set` forked a second config"
     );
 }

--- a/crates/nub-cli/tests/pm_publish_store_config.rs
+++ b/crates/nub-cli/tests/pm_publish_store_config.rs
@@ -322,6 +322,22 @@ fn config_set_from_a_workspace_member_writes_the_workspace_root() {
         !member.join("nub.jsonc").exists(),
         "a member `set` forked a second config"
     );
+
+    // Deliberate, and it reads like a gap: a nested package the workspace
+    // patterns EXCLUDE resolves to the root as well, because absent a local
+    // file that is already the config a run there reads. Minting one here
+    // instead would shadow the root for this subtree.
+    let excluded = ctx.project.join("examples/demo");
+    std::fs::create_dir_all(&excluded).unwrap();
+    std::fs::write(excluded.join("package.json"), r#"{"name":"demo"}"#).unwrap();
+    let (_, stderr, code) = ctx.run_in(&excluded, &["config", "set", "tsconfig", "./t.json"]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(
+        !excluded.join("nub.jsonc").exists(),
+        "an excluded package must not shadow the workspace config"
+    );
+    let body = read(&root_file);
+    assert!(body.contains("./t.json"), "write missed the root: {body}");
 }
 
 /// Both public global spellings create the user template and add the

--- a/crates/nub-cli/tests/pm_publish_store_config.rs
+++ b/crates/nub-cli/tests/pm_publish_store_config.rs
@@ -261,6 +261,53 @@ fn config_init_from_a_subdirectory_targets_the_project_file() {
     assert_eq!(std::fs::read(&project_file).unwrap(), before);
 }
 
+/// A workspace member is not its own config scope. One workspace materializes
+/// one tree under one engine, so `init` from a member anchors at the workspace
+/// root instead of dropping a `nub.jsonc` in every package — and `set` resolves
+/// the same file, so the two cannot disagree about where the config lives.
+#[test]
+fn config_init_from_a_workspace_member_targets_the_workspace_root() {
+    const WORKSPACE_ROOT: &str =
+        r#"{"name":"ws-root","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#;
+    let ctx = Ctx::new("config-init-workspace", WORKSPACE_ROOT);
+    let member = ctx.project.join("packages/app");
+    std::fs::create_dir_all(&member).unwrap();
+    std::fs::write(
+        member.join("package.json"),
+        r#"{"name":"app","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    let root_file = ctx.project.join("nub.jsonc");
+    let member_file = member.join("nub.jsonc");
+
+    let (stdout, stderr, code) = ctx.run_in(&member, &["config", "init"]);
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        stdout.contains(&root_file.display().to_string()),
+        "init must report the workspace-root path: {stdout}"
+    );
+    assert!(
+        root_file.is_file(),
+        "no file at the workspace root: {stdout}"
+    );
+    assert!(
+        !member_file.exists(),
+        "init created a second config in the member: {stdout}"
+    );
+
+    let (_, stderr, code) = ctx.run_in(&member, &["config", "set", "nodeCompat", "true"]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let body = read(&root_file);
+    assert!(
+        body.contains("\"nodeCompat\": true"),
+        "a member `set` must edit the workspace-root file: {body}"
+    );
+    assert!(
+        !member_file.exists(),
+        "a member `set` forked a second config"
+    );
+}
+
 /// Both public global spellings create the user template and add the
 /// global-only consent example without enabling it.
 #[test]

--- a/crates/nub-cli/tests/pm_publish_store_config.rs
+++ b/crates/nub-cli/tests/pm_publish_store_config.rs
@@ -322,21 +322,31 @@ fn config_set_from_a_workspace_member_writes_the_workspace_root() {
         !member.join("nub.jsonc").exists(),
         "a member `set` forked a second config"
     );
+}
 
-    // Deliberate, and it reads like a gap: a nested package the workspace
-    // patterns EXCLUDE resolves to the root as well, because absent a local
-    // file that is already the config a run there reads. Minting one here
-    // instead would shadow the root for this subtree.
+/// Deliberate, and it reads like a gap: `detect_project` never glob-matches the
+/// cwd against the workspace patterns, so a nested package the patterns EXCLUDE
+/// anchors at the root too. That is the point — absent a local file the root
+/// config is already what a run there READS, so the write edits the file that
+/// governs it, where minting a local one would shadow the root for that subtree.
+///
+/// Nothing writes before this, deliberately: once a root `nub.jsonc` exists,
+/// plain up-tree discovery resolves it and the workspace rung this pins is never
+/// consulted.
+#[test]
+fn config_set_from_an_excluded_nested_package_writes_the_workspace_root() {
+    let (ctx, _member) = workspace("config-set-excluded");
     let excluded = ctx.project.join("examples/demo");
     std::fs::create_dir_all(&excluded).unwrap();
     std::fs::write(excluded.join("package.json"), r#"{"name":"demo"}"#).unwrap();
+
     let (_, stderr, code) = ctx.run_in(&excluded, &["config", "set", "tsconfig", "./t.json"]);
     assert_eq!(code, 0, "stderr: {stderr}");
     assert!(
         !excluded.join("nub.jsonc").exists(),
         "an excluded package must not shadow the workspace config"
     );
-    let body = read(&root_file);
+    let body = read(&ctx.project.join("nub.jsonc"));
     assert!(body.contains("./t.json"), "write missed the root: {body}");
 }
 

--- a/crates/nub-cli/tests/verify_deps.rs
+++ b/crates/nub-cli/tests/verify_deps.rs
@@ -68,6 +68,13 @@ fn run(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
         // check outright — which any suite launched from inside a nub-run
         // script inherits, silently turning `an_inherited_checked_marker_…`
         // into a test that cannot fail.
+        //
+        // `resolve_policy`'s last rung, the user `~/.npmrc`, stays ambient on
+        // Windows and only there: it resolves through `dirs_next::home_dir()`,
+        // which is `SHGetKnownFolderPath` on that platform and reads no
+        // environment variable at all. The `XDG_CONFIG_HOME` redirect above is
+        // cross-platform — `config_dir()` checks it ahead of every platform
+        // branch.
         .env("HOME", &home)
         .env("XDG_CONFIG_HOME", home.join(".config"))
         .env_remove(CHECKED_MARKER);

--- a/crates/nub-cli/tests/verify_deps.rs
+++ b/crates/nub-cli/tests/verify_deps.rs
@@ -72,7 +72,7 @@ fn run(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
         // `resolve_policy`'s last rung, the user `~/.npmrc`, stays ambient on
         // Windows and only there: it resolves through `dirs_next::home_dir()`,
         // which is `SHGetKnownFolderPath` on that platform and reads no
-        // environment variable at all. The `XDG_CONFIG_HOME` redirect above is
+        // environment variable at all. The `XDG_CONFIG_HOME` redirect below is
         // cross-platform — `config_dir()` checks it ahead of every platform
         // branch.
         .env("HOME", &home)

--- a/crates/nub-cli/tests/verify_deps.rs
+++ b/crates/nub-cli/tests/verify_deps.rs
@@ -56,10 +56,21 @@ struct Output {
 
 fn run(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
     let mut cmd = Command::new(nub_binary());
+    let home = tmp("home");
     cmd.args(args)
         .current_dir(dir)
         .env("XDG_DATA_HOME", tmp("xdg-data"))
-        .env("XDG_CACHE_HOME", tmp("xdg-cache"));
+        .env("XDG_CACHE_HOME", tmp("xdg-cache"))
+        // Both of these decide the gate BEFORE the fixture gets a say, so a
+        // suite that inherits them asserts the dev box rather than the tree
+        // under test. `verifyDeps` in the user's global `nub.jsonc` outranks
+        // every project source in `resolve_policy`, and the marker skips the
+        // check outright — which any suite launched from inside a nub-run
+        // script inherits, silently turning `an_inherited_checked_marker_…`
+        // into a test that cannot fail.
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env_remove(CHECKED_MARKER);
     for (k, v) in envs {
         cmd.env(k, v);
     }
@@ -72,6 +83,10 @@ fn run(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
 }
 
 const STALE: &str = "out of date";
+
+/// The internal re-entry sentinel (`verify_deps::CHECKED_MARKER`), which a
+/// binary-level test can't import.
+const CHECKED_MARKER: &str = "__NUB_DEPS_CHECKED";
 
 #[test]
 fn fresh_clone_warns_but_still_runs_the_script() {
@@ -353,7 +368,7 @@ fn an_inherited_checked_marker_skips_the_gate() {
         &d.join("package.json"),
         r#"{"name":"m","version":"1.0.0","scripts":{"build":"echo OK"},"devDependencies":{"typescript":"^5.0.0"}}"#,
     );
-    let out = run(&d, &["run", "build"], &[("__NUB_DEPS_CHECKED", "1")]);
+    let out = run(&d, &["run", "build"], &[(CHECKED_MARKER, "1")]);
     assert!(
         !out.stderr.contains(STALE),
         "an inherited __NUB_DEPS_CHECKED must skip the check: {}",

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -3,7 +3,7 @@ title: Config reference
 description: The project file that configures Nub's runtime, dependency installs, and temporary package runs.
 ---
 
-Put `nub.jsonc` at the project root. Every project field it takes, with its full value set:
+Put `nub.jsonc` at the project root — the workspace root in a monorepo. Every project field it takes, with its full value set:
 
 ```jsonc title="nub.jsonc" full
 {
@@ -617,7 +617,7 @@ Explicit `nub dlx` runs still work because the command itself supplies consent.
 
 ## `nub config`
 
-Create a commented project file with every supported project field. Only the schema URL is active.
+Create a commented project file with every supported project field. Only the schema URL is active. Run it from anywhere in a workspace and the file lands at the workspace root, which every member reads.
 
 ```bash
 nub config init


### PR DESCRIPTION
`nub config init` from a workspace member created `packages/app/nub.jsonc`. It now anchors at the workspace root.

The change is in `project_file()`, the resolver behind `init`, `set`, `get --local` and `delete`, so those cannot disagree about where the config lives. An existing file still wins by up-tree discovery. The root comes from `detect_project`, keeping the pnpm-incumbency gate on `pnpm-workspace.yaml` in one place.

Also isolates `HOME`/`XDG_CONFIG_HOME` and `__NUB_DEPS_CHECKED` in the `verify_deps` tests: three failed on a dev box, and `an_inherited_checked_marker_skips_the_gate` could not fail.