### PR TITLE
pm: allow deep peer-context convergence

### DIFF
--- a/vendor/aube/.rules
+++ b/vendor/aube/.rules
@@ -47,7 +47,7 @@ pipeline:
 subsystems:
   catalogs: catalog: protocol, root pnpm-workspace.yaml catalog + named catalogs (evens, etc.), resolver rewrites to resolved spec
   workspace_protocol: workspace:*, workspace:^, workspace:~ resolve to local workspace package via aube-workspace
-  peer_context: aube-resolver/src/peer_context.rs, fixed-point loop (max 16 iterations) computes nested peer suffixes for dep_path hashes
+  peer_context: aube-resolver/src/peer_context.rs, graph-bounded fixed-point loop computes nested peer suffixes for dep_path hashes
   overrides: aube-resolver/src/override_rule.rs, pnpm.overrides / overrides map rewrites versions during resolve
   patches: aube patch / patch-commit / patch-remove, diffs applied at materialize time, sidecar .aube-patches.json
   frozen_fast_path: install/frozen.rs, short-circuits install when state + lockfile + install-shape settings match

--- a/vendor/aube/crates/aube-codes/src/errors.rs
+++ b/vendor/aube/crates/aube-codes/src/errors.rs
@@ -257,7 +257,7 @@ pub const ALL: &[CodeMeta] = &[
     CodeMeta {
         name: ERR_AUBE_PEER_CONTEXT_NOT_CONVERGED,
         category: category::RESOLVER,
-        description: "Peer-context fixed-point loop hit `MAX_ITERATIONS=16` without converging — usually mutually-recursive peers.",
+        description: "Peer-context resolution repeated a graph state or exhausted its graph-sized convergence bound.",
         exit_code: Some(27),
     },
     CodeMeta {

--- a/vendor/aube/crates/aube-resolver/src/error.rs
+++ b/vendor/aube/crates/aube-resolver/src/error.rs
@@ -47,7 +47,7 @@ pub enum Error {
     )]
     TrustCheckMissingTime(Box<MissingTimeDetails>),
     #[error(
-        "peer-context fixed-point did not converge after {0} iterations. mutually recursive peers, lockfile would be incomplete"
+        "peer-context fixed-point did not converge after {0} iterations; lockfile would be incomplete"
     )]
     PeerContextDivergence(usize),
 }

--- a/vendor/aube/crates/aube-resolver/src/peer_context.rs
+++ b/vendor/aube/crates/aube-resolver/src/peer_context.rs
@@ -373,7 +373,6 @@ pub fn apply_peer_contexts(
     canonical: LockfileGraph,
     options: &PeerContextOptions,
 ) -> Result<LockfileGraph, crate::Error> {
-    const MAX_ITERATIONS: usize = 16;
     let mut current = canonical;
     let mut converged = false;
     // Hash both keys and dependency tails. A peer-context iteration can
@@ -395,13 +394,21 @@ pub fn apply_peer_contexts(
         }
         aube_util::hash::ordered_seq_hash(tokens.iter().copied())
     };
+    // A pass can expose at most one additional nested peer layer. An
+    // acyclic dependency path cannot contain more canonical packages
+    // than the graph, and one final pass is needed to observe that the
+    // graph stopped changing. Keep a small floor for tiny cyclic graphs.
+    let max_iterations = current.packages.len().saturating_add(1).max(16);
+
     // Carry the post-iteration hash forward as the next iteration's
-    // pre-hash. Saves one full graph walk per iteration (the loop runs
-    // up to 16 times; each `graph_hash` allocates a Vec<&str> sized
-    // to `pkgs * 3 + deps * 2` tokens — ~25k entries on a 1000-pkg
-    // graph). One hash per iter instead of two.
+    // pre-hash. Saves one full graph walk per iteration; each
+    // `graph_hash` allocates a Vec<&str> sized to
+    // `pkgs * 3 + deps * 2` tokens — ~25k entries on a 1000-package
+    // graph. One hash per iteration instead of two.
     let mut before = graph_hash(&current);
-    for i in 0..MAX_ITERATIONS {
+    let mut seen = FxHashSet::default();
+    seen.insert(before);
+    for iteration in 0..max_iterations {
         let after_once = apply_peer_contexts_once(current, options);
         let next = if options.dedupe_peer_dependents {
             dedupe_peer_variants(after_once)
@@ -410,10 +417,22 @@ pub fn apply_peer_contexts(
         };
         let after = graph_hash(&next);
         if before == after {
-            tracing::debug!("peer-context pass converged after {i} iteration(s)");
+            tracing::debug!(
+                "peer-context pass converged after {} iteration(s)",
+                iteration + 1
+            );
             current = next;
             converged = true;
             break;
+        }
+        if !seen.insert(after) {
+            let completed = iteration + 1;
+            tracing::error!(
+                code = aube_codes::errors::ERR_AUBE_PEER_CONTEXT_NOT_CONVERGED,
+                iterations = completed,
+                "peer-context repeated a graph state after {completed} iteration(s)"
+            );
+            return Err(crate::Error::PeerContextDivergence(completed));
         }
         current = next;
         before = after;
@@ -423,10 +442,10 @@ pub fn apply_peer_contexts(
         // broken node_modules. Now fatal.
         tracing::error!(
             code = aube_codes::errors::ERR_AUBE_PEER_CONTEXT_NOT_CONVERGED,
-            max_iterations = MAX_ITERATIONS,
-            "peer-context hit MAX_ITERATIONS={MAX_ITERATIONS} without convergence"
+            max_iterations,
+            "peer-context exhausted its graph-sized convergence bound of {max_iterations} iteration(s)"
         );
-        return Err(crate::Error::PeerContextDivergence(MAX_ITERATIONS));
+        return Err(crate::Error::PeerContextDivergence(max_iterations));
     }
     // Propagate each package's peer-suffix segments up through its
     // non-peer-declaring ancestors so a parent that pulls in a peer-

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -3192,6 +3192,48 @@ fn apply_peer_contexts_produces_nested_peer_suffixes() {
     }
 }
 
+#[test]
+fn apply_peer_contexts_converges_for_peer_chains_deeper_than_sixteen() {
+    const PACKAGE_COUNT: usize = 18;
+    let mut packages = BTreeMap::new();
+    for index in 0..PACKAGE_COUNT {
+        let name = format!("peer-{index:02}");
+        let package = if index + 1 == PACKAGE_COUNT {
+            mk_locked(&name, "1.0.0", &[], &[])
+        } else {
+            let child = format!("peer-{:02}", index + 1);
+            mk_locked(&name, "1.0.0", &[(&child, "1.0.0")], &[(&child, "^1")])
+        };
+        packages.insert(package.dep_path.clone(), package);
+    }
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "peer-00".to_string(),
+            dep_path: "peer-00@1.0.0".to_string(),
+            dep_type: DepType::Production,
+            specifier: Some("^1".to_string()),
+        }],
+    );
+
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+    let out = apply_peer_contexts(graph, &PeerContextOptions::default())
+        .expect("an acyclic peer chain must converge regardless of its depth");
+
+    let expected = (0..PACKAGE_COUNT - 1).rev().fold(
+        format!("peer-{:02}@1.0.0", PACKAGE_COUNT - 1),
+        |nested, index| format!("peer-{index:02}@1.0.0({nested})"),
+    );
+    assert_eq!(out.importers["."][0].dep_path, expected);
+    assert!(out.packages.contains_key(&expected));
+}
+
 // Repro for the johnpyp/aube-vite-peer-variant case: a workspace
 // importer pins a peer version that DOESN'T satisfy a sibling's
 // declared peer range, while the workspace ROOT pins a satisfying
@@ -5235,15 +5277,14 @@ async fn workspace_member_named_by_a_top_level_directory_binds_to_the_member() {
 
     let graph = resolver
         .resolve_workspace(
-            &[
-                (".".to_string(), root),
-                ("plugin".to_string(), member),
-            ],
+            &[(".".to_string(), root), ("plugin".to_string(), member)],
             None,
             &workspace_packages,
         )
         .await
-        .expect("a workspace: tail naming a top-level member directory must not go to the registry");
+        .expect(
+            "a workspace: tail naming a top-level member directory must not go to the registry",
+        );
 
     let dep = graph
         .importers

--- a/vendor/aube/docs/error-codes.data.json
+++ b/vendor/aube/docs/error-codes.data.json
@@ -99,7 +99,7 @@
     {
       "name": "ERR_AUBE_PEER_CONTEXT_NOT_CONVERGED",
       "category": "Resolver",
-      "description": "Peer-context fixed-point loop hit `MAX_ITERATIONS=16` without converging — usually mutually-recursive peers.",
+      "description": "Peer-context resolution repeated a graph state or exhausted its graph-sized convergence bound.",
       "exit_code": 27
     },
     {

--- a/vendor/aube/test/pnpm_install_misc.bats
+++ b/vendor/aube/test/pnpm_install_misc.bats
@@ -295,7 +295,7 @@ JSON
 	# reproduces the cycle (two workspace packages peer-depending on each
 	# other) to keep the test hermetic. The regression guard is the
 	# resolver actually terminating — bounded by the fixed-point loop in
-	# aube-resolver/src/peer_context.rs (max 16 iterations).
+	# aube-resolver/src/peer_context.rs (bounded by graph size).
 	mkdir -p packages/a packages/b
 	cat >pnpm-workspace.yaml <<'YAML'
 packages:


### PR DESCRIPTION
## Summary

- Size the peer-context convergence bound from the resolved package graph.
- Stop early when a graph state repeats.
- Cover dependency chains that require more than 16 passes.

## Verification

- `cargo fmt --all --check`
- `(cd vendor/aube && cargo test -p aube-resolver)`
- `(cd vendor/aube && cargo clippy -p aube-resolver --all-targets --all-features -- -D warnings)`
- `cargo clippy --all-targets --all-features --profile fast -- -D warnings`
- `tests/brand-lint/check-env-reads.sh`
- `tests/brand-lint/check-path-literals.sh`
- `@aws-amplify/cli@7.6.9` completes `nub install --ignore-scripts` after 21 peer-context passes.