### PR TITLE
fix(pm): resolve workspace aliases and relative-path workspace specs

### DIFF
--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1480,3 +1480,161 @@ fn linked_esbuild_variants(dir: &Path) -> Vec<String> {
     out.sort();
     out
 }
+
+/// Build a workspace whose consumer `app` declares `deps`, alongside members
+/// `lib` (name `lib`, 1.0.0, bin `lib-cli`), `@acme/scoped` (2.0.0) and
+/// `shadow` (9.9.9). Each member's `main` returns its own name, so a test can
+/// assert WHICH package answered rather than that something did.
+fn workspace_alias_fixture(tag: &str, deps: &str) -> PathBuf {
+    let dir = pm_tmpdir(tag);
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{ "name": "root", "private": true, "workspaces": ["packages/*"] }"#,
+    )
+    .unwrap();
+    for (member, name, version) in [
+        ("lib", "lib", "1.0.0"),
+        ("scoped", "@acme/scoped", "2.0.0"),
+        ("shadow", "shadow", "9.9.9"),
+    ] {
+        let mdir = dir.join("packages").join(member);
+        std::fs::create_dir_all(&mdir).unwrap();
+        let bin = if member == "lib" {
+            r#", "bin": { "lib-cli": "cli.js" }"#
+        } else {
+            ""
+        };
+        std::fs::write(
+            mdir.join("package.json"),
+            format!(r#"{{ "name": "{name}", "version": "{version}", "main": "index.js"{bin} }}"#),
+        )
+        .unwrap();
+        std::fs::write(mdir.join("index.js"), format!("module.exports = '{name}';")).unwrap();
+        std::fs::write(mdir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
+    }
+    let app = dir.join("packages/app");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::write(
+        app.join("package.json"),
+        format!(r#"{{ "name": "app", "version": "1.0.0", "dependencies": {{ {deps} }} }}"#),
+    )
+    .unwrap();
+    dir
+}
+
+/// What `require(spec)` returns from `packages/app`, or the node error.
+fn require_from_app(dir: &Path, spec: &str) -> String {
+    let out = Command::new("node")
+        .args(["-e", &format!("process.stdout.write(require({spec:?}))")])
+        .current_dir(dir.join("packages/app"))
+        .output()
+        .expect("failed to spawn node");
+    if out.status.success() {
+        String::from_utf8_lossy(&out.stdout).to_string()
+    } else {
+        format!("<require failed: {}>", String::from_utf8_lossy(&out.stderr))
+    }
+}
+
+/// `workspace:<member>@<range>` aliases a workspace package under a different
+/// dependency key, and `workspace:<relative-path>` addresses one by directory.
+/// Both are documented pnpm spec forms (nubjs/nub#713) that resolve against the
+/// workspace, never the registry.
+///
+/// The `shadow` case is the one that matters most: the dependency key names a
+/// member too, and the ALIAS TARGET has to win. Real pnpm 10 resolves it to
+/// `lib`; before the fix nub silently linked `shadow` to itself, returned the
+/// wrong package with exit 0, and wrote that wrong answer to the lockfile.
+#[test]
+fn workspace_alias_resolves_the_target_member_not_the_dependency_key() {
+    let dir = workspace_alias_fixture(
+        "ws-alias",
+        r#""lib-alias": "workspace:lib@*",
+           "pinned": "workspace:lib@^1.0.0",
+           "s-alias": "workspace:@acme/scoped@*",
+           "by-path": "workspace:../lib",
+           "shadow": "workspace:lib@*""#,
+    );
+
+    let (stdout, stderr, code) = run_install(&dir, &["install"]);
+    assert_eq!(code, 0, "install must succeed: {stdout}{stderr}");
+
+    for (key, want) in [
+        ("lib-alias", "lib"),
+        ("pinned", "lib"),
+        ("s-alias", "@acme/scoped"),
+        ("by-path", "lib"),
+        ("shadow", "lib"),
+    ] {
+        assert_eq!(
+            require_from_app(&dir, key),
+            want,
+            "`require({key:?})` must load the aliased member `{want}`"
+        );
+    }
+
+    // pnpm records both the plain and the aliased form as `link:<rel>` while
+    // keeping the `workspace:` text as the specifier. Matching that shape is
+    // what keeps the lockfile readable by pnpm.
+    let lock = std::fs::read_to_string(dir.join("nub.lock")).unwrap();
+    for needle in [
+        "specifier: workspace:lib@*",
+        "specifier: workspace:@acme/scoped@*",
+        "specifier: workspace:../lib",
+        "version: link:../lib",
+        "version: link:../scoped",
+    ] {
+        assert!(
+            lock.contains(needle),
+            "nub.lock must contain `{needle}`, got:\n{lock}"
+        );
+    }
+
+    // An aliased member's bins reach the consumer's `.bin/` like any other
+    // workspace dep's — the alias is a rename, not a downgrade.
+    let bin = dir.join("packages/app/node_modules/.bin/lib-cli");
+    assert!(
+        bin.exists(),
+        "`lib-cli` must be shimmed into packages/app/node_modules/.bin, found: {:?}",
+        std::fs::read_dir(dir.join("packages/app/node_modules/.bin"))
+            .map(|d| d.map(|e| e.unwrap().file_name()).collect::<Vec<_>>())
+            .unwrap_or_default()
+    );
+}
+
+/// `workspace:` only ever resolves against the workspace, so a spec naming a
+/// package that is not a member is a hard error — never a silent fall-through
+/// to the registry, which used to report the confusing
+/// `no version of <key> matches range \`workspace:*\``.
+#[test]
+fn workspace_spec_naming_a_non_member_fails_without_reaching_the_registry() {
+    for (deps, expect_code, expect_text) in [
+        // The alias form: the message must name the TARGET, not the key.
+        (
+            r#""lib-alias": "workspace:nosuchpkg@*""#,
+            "ERR_NUB_WORKSPACE_PKG_NOT_FOUND",
+            "nosuchpkg",
+        ),
+        // The plain form, where the key itself is not a member.
+        (
+            r#""ms": "workspace:*""#,
+            "ERR_NUB_WORKSPACE_PKG_NOT_FOUND",
+            "ms",
+        ),
+        // An aliased range the local copy cannot satisfy.
+        (
+            r#""lib-alias": "workspace:lib@^2.0.0""#,
+            "ERR_NUB_NO_MATCHING_VERSION",
+            "^2.0.0",
+        ),
+    ] {
+        let dir = workspace_alias_fixture("ws-alias-err", deps);
+        let (stdout, stderr, code) = run_install(&dir, &["install"]);
+        let all = format!("{stdout}{stderr}");
+        assert_ne!(code, 0, "`{deps}` must fail the install, got 0:\n{all}");
+        assert!(
+            all.contains(expect_code) && all.contains(expect_text),
+            "`{deps}` must fail with {expect_code} mentioning `{expect_text}`, got:\n{all}"
+        );
+    }
+}

--- a/vendor/aube/crates/aube-codes/src/errors.rs
+++ b/vendor/aube/crates/aube-codes/src/errors.rs
@@ -86,6 +86,7 @@ pub const ERR_AUBE_SCRIPT_NON_ZERO_EXIT: &str = "ERR_AUBE_SCRIPT_NON_ZERO_EXIT";
 
 // ── workspace / filter ──────────────────────────────────────────────
 pub const ERR_AUBE_WORKSPACE_PARSE: &str = "ERR_AUBE_WORKSPACE_PARSE";
+#[rustfmt::skip] pub const ERR_AUBE_WORKSPACE_PKG_NOT_FOUND: &str = "ERR_AUBE_WORKSPACE_PKG_NOT_FOUND";
 pub const ERR_AUBE_FILTER_EMPTY: &str = "ERR_AUBE_FILTER_EMPTY";
 pub const ERR_AUBE_FILTER_GIT_IO: &str = "ERR_AUBE_FILTER_GIT_IO";
 pub const ERR_AUBE_FILTER_GIT_FAILED: &str = "ERR_AUBE_FILTER_GIT_FAILED";
@@ -514,6 +515,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::MANIFEST_WORKSPACE,
         description: "An `aube-workspace.yaml` / `pnpm-workspace.yaml` was structurally invalid.",
         exit_code: Some(71),
+    },
+    CodeMeta {
+        name: ERR_AUBE_WORKSPACE_PKG_NOT_FOUND,
+        category: category::MANIFEST_WORKSPACE,
+        description: "A `workspace:` dependency named a package that is not a member of this workspace.",
+        exit_code: None,
     },
     CodeMeta {
         name: ERR_AUBE_MANIFEST_YAML_PARSE,

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -324,6 +324,42 @@ pub fn dep_type_label(dt: DepType) -> &'static str {
     }
 }
 
+/// Render a project-root-relative directory as a `link:` target
+/// relative to the consuming importer, the way pnpm writes importer
+/// `version:` values (`packages/app` → `packages/core` renders as
+/// `../core`; the root importer keeps `packages/core` as-is). Pure
+/// lexical computation over `/`-separated components — both inputs are
+/// normalized root-relative paths, so no filesystem access is needed.
+///
+/// Shared by the pnpm writer and the resolver's `workspace:` alias
+/// rewrite, which has to synthesize the same importer-relative target
+/// the writer would later render.
+pub fn link_from_importer(importer_path: &str, target_posix: &str) -> String {
+    if importer_path == "." {
+        return target_posix.to_string();
+    }
+    let from: Vec<&str> = importer_path
+        .split('/')
+        .filter(|c| !c.is_empty() && *c != ".")
+        .collect();
+    let to: Vec<&str> = target_posix
+        .split('/')
+        .filter(|c| !c.is_empty() && *c != ".")
+        .collect();
+    let common = from
+        .iter()
+        .zip(to.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let mut parts: Vec<&str> = vec![".."; from.len() - common];
+    parts.extend(&to[common..]);
+    if parts.is_empty() {
+        ".".to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
 /// A lockfile entry whose dependency source the reader can't resolve,
 /// recorded by a format reader's classifier under the `strict_unsupported_source`
 /// embedder profile instead of silently dropping it (yarn-berry) or

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
@@ -3,7 +3,7 @@ use super::dep_path::{
     version_to_dep_path,
 };
 use super::format::reformat_for_pnpm_parity;
-use crate::{DepType, Error, LocalSource, LockfileGraph};
+use crate::{DepType, Error, LocalSource, LockfileGraph, link_from_importer};
 use aube_manifest::PackageJson;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -959,38 +959,6 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
     // atomic_write_lockfile for full rationale.
     crate::atomic_write_lockfile(path, yaml.as_bytes())?;
     Ok(())
-}
-
-/// Render a project-root-relative directory as a `link:` target
-/// relative to the consuming importer, the way pnpm writes importer
-/// `version:` values (`packages/app` → `packages/core` renders as
-/// `../core`; the root importer keeps `packages/core` as-is). Pure
-/// lexical computation over `/`-separated components — both inputs are
-/// normalized root-relative paths, so no filesystem access is needed.
-fn link_from_importer(importer_path: &str, target_posix: &str) -> String {
-    if importer_path == "." {
-        return target_posix.to_string();
-    }
-    let from: Vec<&str> = importer_path
-        .split('/')
-        .filter(|c| !c.is_empty() && *c != ".")
-        .collect();
-    let to: Vec<&str> = target_posix
-        .split('/')
-        .filter(|c| !c.is_empty() && *c != ".")
-        .collect();
-    let common = from
-        .iter()
-        .zip(to.iter())
-        .take_while(|(a, b)| a == b)
-        .count();
-    let mut parts: Vec<&str> = vec![".."; from.len() - common];
-    parts.extend(&to[common..]);
-    if parts.is_empty() {
-        ".".to_string()
-    } else {
-        parts.join("/")
-    }
 }
 
 fn registry_tarball_url_is_not_derivable(

--- a/vendor/aube/crates/aube-resolver/src/error.rs
+++ b/vendor/aube/crates/aube-resolver/src/error.rs
@@ -47,9 +47,50 @@ pub enum Error {
     )]
     TrustCheckMissingTime(Box<MissingTimeDetails>),
     #[error(
+        "in {}: `\"{}\": \"{}\"` names workspace package `{}`, which is not in this workspace",
+        .0.importer, .0.dep_name, .0.spec, .0.target
+    )]
+    WorkspacePkgNotFound(Box<WorkspacePkgNotFoundDetails>),
+    #[error(
+        "in {}: `\"{}\": \"{}\"` wants `{}` at `{}`, but this workspace has {}@{}",
+        .0.importer, .0.dep_name, .0.spec, .0.target, .0.range, .0.target, .0.local_version
+    )]
+    WorkspaceVersionMismatch(Box<WorkspaceVersionMismatchDetails>),
+    #[error(
         "peer-context fixed-point did not converge after {0} iterations; lockfile would be incomplete"
     )]
     PeerContextDivergence(usize),
+}
+
+/// Context attached to a `WorkspacePkgNotFound` error.
+///
+/// `dep_name` is the key as written in the manifest and `target` is the
+/// member the spec asks for. They differ only for the alias form
+/// (`"card": "workspace:components-card@*"`), and keeping both is what
+/// lets the message point at the name the user actually has to fix.
+#[derive(Debug)]
+pub struct WorkspacePkgNotFoundDetails {
+    pub dep_name: String,
+    pub spec: String,
+    pub target: String,
+    pub importer: String,
+    /// Every member name in the workspace, for a did-you-mean list.
+    /// The formatter caps the rendered list; empty means the workspace
+    /// has no members at all.
+    pub known: Vec<String>,
+}
+
+/// Context attached to a `WorkspaceVersionMismatch` error — an aliased
+/// `workspace:<target>@<range>` whose range the local copy of `target`
+/// does not satisfy.
+#[derive(Debug)]
+pub struct WorkspaceVersionMismatchDetails {
+    pub dep_name: String,
+    pub spec: String,
+    pub target: String,
+    pub range: String,
+    pub local_version: String,
+    pub importer: String,
 }
 
 /// Context attached to a `NoMatch` error so the miette `help()` output can
@@ -165,6 +206,8 @@ impl miette::Diagnostic for Error {
             Self::BlockedExoticSubdep(_) => ERR_AUBE_BLOCKED_EXOTIC_SUBDEP,
             Self::TrustDowngrade(_) => ERR_AUBE_TRUST_DOWNGRADE,
             Self::TrustCheckMissingTime(_) => ERR_AUBE_TRUST_MISSING_TIME,
+            Self::WorkspacePkgNotFound(_) => ERR_AUBE_WORKSPACE_PKG_NOT_FOUND,
+            Self::WorkspaceVersionMismatch(_) => ERR_AUBE_NO_MATCHING_VERSION,
             Self::PeerContextDivergence(_) => ERR_AUBE_PEER_CONTEXT_NOT_CONVERGED,
         }))
     }
@@ -180,9 +223,50 @@ impl miette::Diagnostic for Error {
             Self::BlockedExoticSubdep(d) => Some(Box::new(format_exotic_subdep_help(d))),
             Self::TrustDowngrade(d) => Some(Box::new(format_trust_downgrade_help(d))),
             Self::TrustCheckMissingTime(d) => Some(Box::new(format_trust_missing_time_help(d))),
+            Self::WorkspacePkgNotFound(d) => Some(Box::new(format_workspace_pkg_not_found_help(d))),
+            Self::WorkspaceVersionMismatch(d) => Some(Box::new(format!(
+                "the `workspace:` protocol only resolves against this workspace, so this does \
+                 not fall back to the registry. Either widen the range (`workspace:{target}@*` \
+                 tracks whatever the local copy is) or bump `{target}` to a version that \
+                 satisfies `{range}`",
+                target = d.target,
+                range = d.range,
+            ))),
             Self::PeerContextDivergence(_) => None,
         }
     }
+}
+
+fn format_workspace_pkg_not_found_help(d: &WorkspacePkgNotFoundDetails) -> String {
+    let mut help = if d.dep_name == d.target {
+        format!(
+            "the `workspace:` protocol only resolves against this workspace's own packages, \
+             so `{}` never falls back to the registry",
+            d.target
+        )
+    } else {
+        // The alias form. Naming both halves matters: the key is what
+        // lands in `node_modules/`, the target is what has to exist.
+        format!(
+            "`workspace:{target}@<range>` aliases the local package `{target}` under the name \
+             `{key}`. `{key}` is the directory name you get in `node_modules/`; `{target}` is \
+             the `name` field some package in this workspace must declare",
+            target = d.target,
+            key = d.dep_name,
+        )
+    };
+    if d.known.is_empty() {
+        help.push_str(". This workspace has no packages");
+        return help;
+    }
+    // A big monorepo would bury the message under its own member list.
+    const SHOWN: usize = 10;
+    help.push_str(". Packages in this workspace: ");
+    help.push_str(&d.known[..d.known.len().min(SHOWN)].join(", "));
+    if d.known.len() > SHOWN {
+        help.push_str(&format!(" (+{} more)", d.known.len() - SHOWN));
+    }
+    help
 }
 
 fn format_trust_downgrade_help(d: &TrustDowngradeDetails) -> String {

--- a/vendor/aube/crates/aube-resolver/src/lib.rs
+++ b/vendor/aube/crates/aube-resolver/src/lib.rs
@@ -19,10 +19,12 @@ mod resolve;
 mod semver_util;
 mod trust;
 mod types;
+mod workspace_spec;
 
 pub use direct_dep_info::DirectDepInfo;
 pub use error::{
     AgeGateDetails, CatalogDetails, Error, ExoticSubdepDetails, NoMatchDetails, UndatedDetails,
+    WorkspacePkgNotFoundDetails, WorkspaceVersionMismatchDetails,
 };
 pub use local_source::resolve_exec_script_path;
 pub use package_ext::is_deprecation_allowed;

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -28,16 +28,19 @@ use crate::package_ext::{
     apply_package_extensions, apply_package_extensions_to_deps, pick_override_spec,
 };
 use crate::semver_util::{
-    AgeGateCause, PickResult, Regime, classify_regime, is_semver_range, pick_version,
-    range_resolves_via_dist_tag, version_satisfies,
+    AgeGateCause, PickResult, Regime, classify_regime, pick_version, range_resolves_via_dist_tag,
+    version_satisfies,
 };
+use crate::workspace_spec::workspace_range_binds;
 use crate::{
     Error, ExoticSubdepDetails, FxHashMap, FxHashSet, ResolutionMode, ResolveTask, ResolvedPackage,
-    Resolver, error, is_deprecation_allowed, is_supported,
+    Resolver, WorkspacePkgNotFoundDetails, WorkspaceVersionMismatchDetails, error,
+    is_deprecation_allowed, is_supported,
 };
 use aube_lockfile::{DepType, DirectDep, LocalSource, LockedPackage, LockfileGraph};
 use aube_manifest::PackageJson;
 use aube_util::adaptive::{AdaptiveLimit, PersistentState};
+use aube_util::pkg::{WorkspaceSpec, parse_workspace_spec};
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -135,6 +138,12 @@ pub(crate) struct ResolveDriver<'a> {
     resolver: &'a mut Resolver,
     existing: Option<&'a LockfileGraph>,
     workspace_packages: &'a HashMap<String, String>,
+    /// Workspace member name → its importer path (`packages/card`).
+    /// `workspace_packages` carries versions only, and the `workspace:`
+    /// alias rewrite needs the DIRECTORY to synthesize a `link:` target.
+    /// Derived from the same `manifests` slice the importer seed walks,
+    /// so the two can never disagree about the member set.
+    workspace_member_importers: BTreeMap<String, String>,
 
     /// Borrowed set of names present in the existing lockfile. Used as
     /// a prefetch gate so packuments that will hit the lockfile-reuse
@@ -277,6 +286,15 @@ impl<'a> ResolveDriver<'a> {
                 (importer_path.clone(), names)
             })
             .collect();
+        // A member's importer path IS its directory, so the `workspace:`
+        // alias rewrite reads its `link:` targets straight off here. A
+        // manifest with no `name` cannot be aliased and is skipped.
+        let workspace_member_importers: BTreeMap<String, String> = manifests
+            .iter()
+            .filter_map(|(importer_path, manifest)| {
+                Some((manifest.name.clone()?, importer_path.clone()))
+            })
+            .collect();
         // ISO-8601 UTC cutoff string. npm's registry `time` map uses
         // `Z`-suffixed UTC timestamps throughout, which sort
         // lexicographically — so a raw `String` doubles as a
@@ -350,6 +368,7 @@ impl<'a> ResolveDriver<'a> {
             resolver,
             existing,
             workspace_packages,
+            workspace_member_importers,
             existing_names,
             locked_index,
             importer_declared_dep_names,
@@ -635,12 +654,28 @@ impl<'a> ResolveDriver<'a> {
             return Ok(());
         }
 
+        // `workspace:<member>@<range>` / `workspace:<relative-path>` name
+        // a member the dependency key does not, so they have to be bound
+        // before the non-registry dispatch and before the key→member
+        // lookup below.
+        self.rewrite_workspace_alias(&mut task)?;
+
         if is_non_registry_specifier(&task.range) {
             return self.handle_local_source_task(task).await;
         }
 
         if self.try_workspace_link(&task) {
             return Ok(());
+        }
+
+        // `workspace:` never means "go to the registry". Reaching here
+        // with the protocol still on the range means no member carries
+        // this name, so say that instead of letting a literal
+        // `workspace:*` hit the registry as if it were a version range.
+        if task.range.starts_with("workspace:") && !self.workspace_packages.contains_key(&task.name)
+        {
+            let name = task.name.clone();
+            return Err(self.workspace_pkg_not_found(&task, &name));
         }
 
         if self.try_sibling_dedupe(&task) {
@@ -2317,6 +2352,98 @@ impl<'a> ResolveDriver<'a> {
         }
     }
 
+    /// Bind a `workspace:` spec that names a member the dependency KEY
+    /// does not: the alias form (`"card": "workspace:components-card@*"`)
+    /// and the relative-path form (`"card": "workspace:../card"`), both
+    /// documented by pnpm and both an error here before this ran.
+    ///
+    /// The rewrite target is `link:`, and that is faithful rather than a
+    /// shortcut: pnpm records the plain form, the alias form and the path
+    /// form all three as `version: link:../card` in the importer entry,
+    /// so this produces exactly the graph the lockfile writer would have
+    /// to synthesize anyway. `original_specifier` is captured at task
+    /// construction, so the importer's `specifier:` still reads back the
+    /// `workspace:` text the user wrote.
+    ///
+    /// Runs BEFORE the key→member lookup in `try_workspace_link`, because
+    /// the alias target outranks a key that also happens to name a member
+    /// — real pnpm resolves `"pkg3": "workspace:pkg2@*"` to pkg2 even
+    /// when a member named pkg3 exists.
+    ///
+    /// Importer-declared deps only (`is_root`, which covers every member's
+    /// own manifest, not just the root's). A `workspace:` spec inside a
+    /// fetched package is a publish bug — pnpm rewrites the protocol away
+    /// on publish — and the path it would produce has no importer to
+    /// anchor against, so those keep failing the way they already did.
+    fn rewrite_workspace_alias(&self, task: &mut ResolveTask) -> Result<(), Error> {
+        if !task.is_root {
+            return Ok(());
+        }
+        let (target, range) = match parse_workspace_spec(&task.range) {
+            // A path addresses a directory, not a name. Hand it straight
+            // to the local-source resolver, which anchors a root-declared
+            // `link:` at the importer — the same anchor pnpm uses.
+            Some(WorkspaceSpec::Path(path)) => {
+                task.range = format!("link:{path}");
+                return Ok(());
+            }
+            Some(WorkspaceSpec::Alias { name, range }) => (name, range),
+            // The plain form. `try_workspace_link` owns it.
+            Some(WorkspaceSpec::Range(_)) | None => return Ok(()),
+        };
+        let Some(ws_version) = self.workspace_packages.get(target) else {
+            return Err(self.workspace_pkg_not_found(task, target));
+        };
+        if !workspace_range_binds(ws_version, range) {
+            return Err(Error::WorkspaceVersionMismatch(Box::new(
+                WorkspaceVersionMismatchDetails {
+                    dep_name: task.name.clone(),
+                    spec: task
+                        .original_specifier
+                        .clone()
+                        .unwrap_or_else(|| task.range.clone()),
+                    target: target.to_string(),
+                    range: range.to_string(),
+                    local_version: ws_version.clone(),
+                    importer: task.importer.clone(),
+                },
+            )));
+        }
+        // A member is an importer, so its directory IS its importer path.
+        // Missing would mean `workspace_packages` and `manifests`
+        // disagreed about the member set, which the caller builds from
+        // one source.
+        let Some(member_importer) = self.workspace_member_importers.get(target) else {
+            return Err(self.workspace_pkg_not_found(task, target));
+        };
+        let rel = aube_lockfile::link_from_importer(&task.importer, member_importer);
+        tracing::trace!(
+            "workspace alias: {} {} -> link:{}",
+            task.name,
+            task.range,
+            rel
+        );
+        task.range = format!("link:{rel}");
+        Ok(())
+    }
+
+    /// Build the "names a package this workspace does not have" error,
+    /// carrying the member list so the message can name what IS here.
+    fn workspace_pkg_not_found(&self, task: &ResolveTask, target: &str) -> Error {
+        let mut known: Vec<String> = self.workspace_packages.keys().cloned().collect();
+        known.sort();
+        Error::WorkspacePkgNotFound(Box::new(WorkspacePkgNotFoundDetails {
+            dep_name: task.name.clone(),
+            spec: task
+                .original_specifier
+                .clone()
+                .unwrap_or_else(|| task.range.clone()),
+            target: target.to_string(),
+            importer: task.importer.clone(),
+            known,
+        }))
+    }
+
     /// Try to resolve `task` against the workspace.
     ///
     /// Three cases link rather than going to the registry: an explicit
@@ -2334,28 +2461,16 @@ impl<'a> ResolveDriver<'a> {
             return false;
         };
         let matches = match task.range.strip_prefix("workspace:") {
-            // workspace:*, workspace:^, workspace:~ bind to whatever
-            // local version is. pnpm's "don't pin me, just track
-            // local" sigils.
-            Some("" | "*" | "^" | "~") => true,
-            // A tail that does not parse as a range is a LOCATOR, not a
-            // version — bun and yarn name the member by DIRECTORY
-            // (`@scope/plugin@workspace:packages/plugin`, or
-            // `workspace:plugin` for a top-level member). Read as a
-            // range it satisfies nothing: measured on opencode, where a
-            // registry package depending on a workspace member failed
-            // with `no version of @opencode-ai/plugin matches range
-            // \`workspace:packages/plugin\``. We are only here because
-            // the name already matched a member and `workspace:` never
-            // means "go to the registry", so a locator binds outright.
+            // The range part carries pnpm's sigils, an ordinary semver
+            // range, or a bun/yarn member DIRECTORY. `workspace_range_binds`
+            // owns all three so the plain form here and the alias form in
+            // `rewrite_workspace_alias` cannot drift.
             //
-            // The discriminator must be the PARSE, not the string's
-            // shape: a lexical path test (leading `.`, leading `/`,
-            // contains `/`) misses a single-segment member directory,
-            // which both real bun and real pnpm resolve.
-            Some(rest) if !is_semver_range(rest) => true,
-            // workspace:<range> must still satisfy the local version.
-            Some(rest) => version_satisfies(ws_version, rest),
+            // An aliased tail (`workspace:pkg2@*`) never reaches this arm:
+            // `rewrite_workspace_alias` runs first and has already turned
+            // it into a `link:`, which is what lets the alias target
+            // outrank a dependency key that happens to name a member too.
+            Some(rest) => workspace_range_binds(ws_version, rest),
             // `link:`/`portal:` whose name is a workspace member is a
             // workspace link, not an untrusted exotic dep. pnpm records
             // a peer satisfied by a workspace member this way (e.g.
@@ -2686,6 +2801,7 @@ fn attach_integrity_to_git_source(local: &mut LocalSource, integrity: Option<&st
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::semver_util::is_semver_range;
     use aube_lockfile::GitSource;
 
     #[test]

--- a/vendor/aube/crates/aube-resolver/src/workspace_spec.rs
+++ b/vendor/aube/crates/aube-resolver/src/workspace_spec.rs
@@ -1,0 +1,47 @@
+//! Range semantics for the `workspace:` protocol.
+//!
+//! The grammar itself — how a tail splits into an alias, a path, or a
+//! range — lives in [`aube_util::pkg::parse_workspace_spec`], because the
+//! lockfile readers need the same split and cannot depend on this crate.
+//! What stays here is the half that needs the resolver's semver cache.
+
+use crate::semver_util::{is_semver_range, version_satisfies};
+
+/// Whether the RANGE part of a `workspace:` tail binds to a member
+/// sitting at `ws_version`.
+///
+/// Shared by the plain form (`workspace:^1`) and the alias form
+/// (`workspace:pkg@^1`) so the two cannot drift apart. Note the
+/// unparseable-range arm: it exists because a tail that is not a range is
+/// a member DIRECTORY under bun/Yarn-v1 (`workspace:packages/x`), and
+/// read as a range it would satisfy nothing. We only ever reach here once
+/// a member has been identified, and `workspace:` never means "go to the
+/// registry", so a locator binds outright.
+pub(crate) fn workspace_range_binds(ws_version: &str, range: &str) -> bool {
+    match range {
+        // `*`/`^`/`~`/empty are pnpm's "don't pin me, just track local"
+        // sigils.
+        "" | "*" | "^" | "~" => true,
+        r if !is_semver_range(r) => true,
+        r => version_satisfies(ws_version, r),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn range_binds_follows_the_sigils_then_semver() {
+        for sigil in ["", "*", "^", "~"] {
+            assert!(
+                workspace_range_binds("0.0.0-0", sigil),
+                "`{sigil}` must bind to any local version"
+            );
+        }
+        assert!(workspace_range_binds("1.2.3", "^1.0.0"));
+        assert!(!workspace_range_binds("1.2.3", "^2.0.0"));
+        // A directory locator is not a range and binds outright.
+        assert!(workspace_range_binds("1.2.3", "packages/plugin"));
+    }
+}

--- a/vendor/aube/crates/aube-util/src/pkg.rs
+++ b/vendor/aube/crates/aube-util/src/pkg.rs
@@ -22,6 +22,79 @@ pub fn is_link_spec(spec: &str) -> bool {
     spec.starts_with("link:")
 }
 
+/// A `workspace:` specifier, classified by which member it names and
+/// how. See [`parse_workspace_spec`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum WorkspaceSpec<'a> {
+    /// `workspace:<name>@<range>` — binds to the member `name`, which is
+    /// independent of the dependency key. This is the alias form.
+    Alias { name: &'a str, range: &'a str },
+    /// `workspace:.<path>` / `workspace:..<path>` — binds to whatever
+    /// package sits at that importer-relative directory.
+    Path(&'a str),
+    /// `workspace:<range>` — binds to the member the dependency key
+    /// names. The plain, overwhelmingly common form.
+    Range(&'a str),
+}
+
+/// Classify a `workspace:` specifier. `None` when `spec` does not carry
+/// the protocol at all.
+///
+/// The tail after `workspace:` is one of three things, and telling them
+/// apart is the whole job. pnpm settles it with a single regex plus one
+/// escape hatch, and we mirror both so a manifest that installs there
+/// installs here:
+///
+/// ```text
+/// /^workspace:(?:(?<alias>[^._/][^@]*)@)?(?<version>.*)$/   spec-parser/src/index.ts
+/// if (bareSpecifier.startsWith('workspace:.')) return null   npm-resolver/src/index.ts
+/// ```
+///
+/// Three consequences worth stating, because each is a case that looks
+/// like another:
+///
+/// * The `@` is REQUIRED to name a member. `workspace:pkg2` is a
+///   *version* (the `pkg2` dist-tag), not an alias for member `pkg2` —
+///   real pnpm rejects it with `no package named "<key>" is present in
+///   the workspace` when the KEY is not a member.
+/// * A leading `.` is the entire path test. `workspace:packages/pkg2` is
+///   NOT a path; pnpm calls it `Invalid workspace: spec`. Bun and Yarn
+///   v1 do read a bare directory as a locator, so the resolver keeps
+///   accepting that shape when the dependency key already names the
+///   member — this parser just does not classify it as a path.
+/// * A scoped target survives because `@` is not in the excluded set:
+///   `workspace:@acme/x@*` splits at the SECOND `@`.
+pub fn parse_workspace_spec(spec: &str) -> Option<WorkspaceSpec<'_>> {
+    let tail = spec.strip_prefix("workspace:")?;
+    if tail.starts_with('.') {
+        return Some(WorkspaceSpec::Path(tail));
+    }
+    // The alias part is `[^._/][^@]*` followed by `@`, so the split point
+    // is the first `@` at index >= 1 — never index 0, which is what keeps
+    // a scoped `@acme/x@*` splitting at its second `@`.
+    if let Some(first) = tail.chars().next()
+        && !matches!(first, '.' | '_' | '/')
+        && let Some(rel) = tail[first.len_utf8()..].find('@')
+    {
+        let at = first.len_utf8() + rel;
+        return Some(WorkspaceSpec::Alias {
+            name: &tail[..at],
+            range: &tail[at + 1..],
+        });
+    }
+    Some(WorkspaceSpec::Range(tail))
+}
+
+/// The member a `workspace:` spec names, when it names one that the
+/// dependency key does not. `None` for the plain and path forms, whose
+/// member comes from the key or the directory instead.
+pub fn workspace_alias_target(spec: &str) -> Option<&str> {
+    match parse_workspace_spec(spec) {
+        Some(WorkspaceSpec::Alias { name, .. }) => Some(name),
+        _ => None,
+    }
+}
+
 pub fn split_name_spec(input: &str) -> (&str, Option<&str>) {
     if let Some(rest) = input.strip_prefix('@') {
         if let Some(slash) = rest.find('/') {
@@ -51,6 +124,54 @@ mod tests {
         assert!(is_catalog_spec("catalog:"));
         assert!(is_catalog_spec("catalog:default"));
         assert!(!is_catalog_spec("cat:foo"));
+    }
+
+    fn alias(name: &'static str, range: &'static str) -> WorkspaceSpec<'static> {
+        WorkspaceSpec::Alias { name, range }
+    }
+
+    #[test]
+    fn classifies_every_workspace_tail_shape() {
+        let cases: &[(&str, WorkspaceSpec<'_>)] = &[
+            // The alias form needs the `@`; the split is the FIRST `@`
+            // at index >= 1.
+            ("workspace:pkg2@*", alias("pkg2", "*")),
+            ("workspace:pkg2@^1.0.0", alias("pkg2", "^1.0.0")),
+            ("workspace:@acme/x@*", alias("@acme/x", "*")),
+            ("workspace:pkg2@", alias("pkg2", "")),
+            // No `@` means the tail is a version, even when it looks like
+            // a package name — the case real pnpm rejects when the key is
+            // not a member.
+            ("workspace:pkg2", WorkspaceSpec::Range("pkg2")),
+            (
+                "workspace:packages/pkg2",
+                WorkspaceSpec::Range("packages/pkg2"),
+            ),
+            ("workspace:*", WorkspaceSpec::Range("*")),
+            ("workspace:^", WorkspaceSpec::Range("^")),
+            ("workspace:", WorkspaceSpec::Range("")),
+            ("workspace:^2.0.0", WorkspaceSpec::Range("^2.0.0")),
+            // A leading `.` is the whole path test.
+            ("workspace:../pkg2", WorkspaceSpec::Path("../pkg2")),
+            ("workspace:./pkg2", WorkspaceSpec::Path("./pkg2")),
+            // The excluded first-character set cannot open an alias.
+            ("workspace:_priv@1", WorkspaceSpec::Range("_priv@1")),
+            ("workspace:/abs@1", WorkspaceSpec::Range("/abs@1")),
+        ];
+        for (spec, want) in cases {
+            assert_eq!(
+                parse_workspace_spec(spec).as_ref(),
+                Some(want),
+                "{spec} classified wrongly"
+            );
+        }
+        assert!(
+            parse_workspace_spec("^1.0.0").is_none(),
+            "a spec without the protocol prefix is not a workspace spec"
+        );
+        assert_eq!(workspace_alias_target("workspace:pkg2@*"), Some("pkg2"));
+        assert_eq!(workspace_alias_target("workspace:*"), None);
+        assert_eq!(workspace_alias_target("workspace:../pkg2"), None);
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/deploy/rewrite.rs
+++ b/vendor/aube/crates/aube/src/commands/deploy/rewrite.rs
@@ -40,8 +40,29 @@ pub(super) struct DeployRoot<'a> {
 /// the exact version; `^`/`~` keep their operator; any other suffix is
 /// already a valid range and used verbatim. Used only for peer-dep
 /// rewrites — regular deps go through bundling and become `file:` refs.
+///
+/// The aliased form (`workspace:<target>@<range>`) resolves its RANGE
+/// part the same way and then re-emits the target as an `npm:` alias,
+/// which is the shape pnpm's own publish rewrite produces. Reading the
+/// whole tail as a range instead would emit `target@range`, a string no
+/// semver parser accepts — real pnpm ships exactly that corruption for
+/// peers today, so this deliberately does not copy it.
 fn resolve_workspace_spec(spec: &str, concrete_version: &str) -> String {
+    if let Some(aube_util::pkg::WorkspaceSpec::Alias { name, range }) =
+        aube_util::pkg::parse_workspace_spec(spec)
+    {
+        return format!(
+            "npm:{name}@{}",
+            resolve_range_suffix(range, concrete_version)
+        );
+    }
     let suffix = spec.strip_prefix("workspace:").unwrap_or(spec);
+    resolve_range_suffix(suffix, concrete_version)
+}
+
+/// The sigil-or-range half of a `workspace:` tail, pinned against the
+/// sibling's actual version.
+fn resolve_range_suffix(suffix: &str, concrete_version: &str) -> String {
     match suffix {
         "" | "*" => concrete_version.to_string(),
         "^" => format!("^{concrete_version}"),
@@ -192,9 +213,16 @@ pub(super) fn rewrite_local_refs(
                 raw_spec
             };
             if aube_util::pkg::is_workspace_spec(spec) {
-                let Some((sibling_dir, sibling_version)) = ws_index.get(name) else {
+                // `workspace:<target>@<range>` aliases a member under a
+                // different key, so the sibling to bundle is the TARGET.
+                // The manifest key stays the alias, which is exactly what
+                // the deploy target needs: the key is the directory name
+                // in `node_modules/`, the value points at the bundled copy.
+                let sibling_name =
+                    aube_util::pkg::workspace_alias_target(spec).unwrap_or(name.as_str());
+                let Some((sibling_dir, sibling_version)) = ws_index.get(sibling_name) else {
                     return Err(miette!(
-                        "{}: {} declares `{name}: {spec}` but no workspace package named {name:?} was found",
+                        "{}: {} declares `{name}: {spec}` but no workspace package named {sibling_name:?} was found",
                         aube_util::cmd("deploy"),
                         manifest_path.display()
                     ));
@@ -472,7 +500,9 @@ mod tests {
                     "@test/lib":"workspace:*",
                     "@test/lib-caret":"workspace:^",
                     "@test/lib-tilde":"workspace:~",
-                    "@test/lib-literal":"workspace:^2.0.0"
+                    "@test/lib-literal":"workspace:^2.0.0",
+                    "lib-alias":"workspace:@test/lib@*",
+                    "lib-alias-pinned":"workspace:@test/lib@^1.0.0"
                 }
             }"#,
         )
@@ -513,6 +543,12 @@ mod tests {
         assert_eq!(peers["@test/lib-caret"], "^1.2.3");
         assert_eq!(peers["@test/lib-tilde"], "~1.2.3");
         assert_eq!(peers["@test/lib-literal"], "^2.0.0");
+        // The aliased form keeps the alias as the KEY and re-points the
+        // value at the target via `npm:`, the shape pnpm's publish
+        // rewrite emits. Folding the whole tail into the range instead
+        // would write `@test/lib@*`, which no semver parser accepts.
+        assert_eq!(peers["lib-alias"], "npm:@test/lib@1.2.3");
+        assert_eq!(peers["lib-alias-pinned"], "npm:@test/lib@^1.0.0");
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
+++ b/vendor/aube/crates/aube/src/commands/install/bin_linking.rs
@@ -296,7 +296,9 @@ pub(super) fn link_bins(
 
     for dep in graph.root_deps() {
         if let Some(ws_dir) = ws_dirs.and_then(|m| m.get(&dep.name)) {
-            link_bins_for_workspace_dep(ws_cache, &bin_dir, ws_dir, &dep.name, shim_opts)?;
+            link_bins_from_dir(ws_cache, &bin_dir, ws_dir, &dep.name, shim_opts)?;
+        } else if let Some(dir) = symlinked_dep_dir(graph, &dep.dep_path, project_dir) {
+            link_bins_from_dir(ws_cache, &bin_dir, &dir, &dep.name, shim_opts)?;
         } else {
             link_bins_for_dep(
                 cache,
@@ -465,10 +467,18 @@ pub(crate) fn link_all_bins(input: LinkAllBinsInput<'_>) -> miette::Result<()> {
             std::fs::create_dir_all(&bin_dir).into_diagnostic()?;
             for dep in deps {
                 if let Some(ws_dir) = ws_dirs.get(&dep.name) {
-                    link_bins_for_workspace_dep(
+                    link_bins_from_dir(
                         &mut ws_pkg_json_cache,
                         &bin_dir,
                         ws_dir,
+                        &dep.name,
+                        shim_opts,
+                    )?;
+                } else if let Some(dir) = symlinked_dep_dir(graph_for_link, &dep.dep_path, cwd) {
+                    link_bins_from_dir(
+                        &mut ws_pkg_json_cache,
+                        &bin_dir,
+                        &dir,
                         &dep.name,
                         shim_opts,
                     )?;
@@ -526,55 +536,76 @@ pub(crate) fn link_all_bins(input: LinkAllBinsInput<'_>) -> miette::Result<()> {
     Ok(())
 }
 
-/// Link bins declared by a `workspace:` dep into the importer's
-/// `.bin/`. Workspace deps don't get a `.aube/<dep_path>/` materialization
-/// (the linker symlinks them straight into the importer's `node_modules/`),
-/// so `link_bins_for_dep` finds nothing on disk and silently skips. Read
-/// the workspace package's own `package.json` and shim each bin entry,
-/// matching pnpm's behavior of exposing workspace bins to dependent
-/// packages' npm scripts.
+/// Link bins declared by a dep that lives at a directory on disk rather
+/// than in the virtual store — a `workspace:` sibling, or a `link:` /
+/// `portal:` target. The linker symlinks all of these straight into the
+/// importer's `node_modules/` and never materializes a
+/// `.aube/<dep_path>/`, so `link_bins_for_dep` looks up a path that does
+/// not exist and silently shims nothing. Read the package's own
+/// `package.json` from `pkg_dir` instead and shim each bin entry, which
+/// is what pnpm does for every one of these kinds.
 ///
 /// `cache` deduplicates the read+parse across importers — without it,
 /// a popular tooling package consumed by N workspace members gets its
 /// `package.json` read N times during a single install.
-pub(super) fn link_bins_for_workspace_dep(
+pub(super) fn link_bins_from_dir(
     cache: &mut WsPkgJsonCache,
     bin_dir: &Path,
-    ws_dir: &Path,
+    pkg_dir: &Path,
     name: &str,
     shim_opts: aube_linker::BinShimOptions,
 ) -> miette::Result<()> {
-    let pkg_json = if let Some(cached) = cache.get(ws_dir) {
+    let pkg_json = if let Some(cached) = cache.get(pkg_dir) {
         cached.clone()
     } else {
-        let pkg_json_path = ws_dir.join("package.json");
+        let pkg_json_path = pkg_dir.join("package.json");
         let parsed = match std::fs::read_to_string(&pkg_json_path) {
             Ok(content) => Some(
                 aube_manifest::parse_json::<serde_json::Value>(&pkg_json_path, content)
                     .map_err(miette::Report::new)
                     .wrap_err_with(|| {
-                        format!("failed to parse package.json for workspace dep {name}")
+                        format!("failed to parse package.json for local dep {name}")
                     })?,
             ),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
             Err(e) => {
                 return Err(miette!(
-                    "failed to read package.json for workspace dep {name} at {}: {e}",
+                    "failed to read package.json for local dep {name} at {}: {e}",
                     pkg_json_path.display()
                 ));
             }
         };
-        cache.insert(ws_dir.to_path_buf(), parsed.clone());
+        cache.insert(pkg_dir.to_path_buf(), parsed.clone());
         parsed
     };
     if let Some(pkg_json) = pkg_json {
         if let Some(bin) = pkg_json.get("bin") {
-            link_bin_entries(bin_dir, ws_dir, Some(name), bin, shim_opts)?;
+            link_bin_entries(bin_dir, pkg_dir, Some(name), bin, shim_opts)?;
         } else if let Some(dir_bin) = pkg_json.get("directories").and_then(|d| d.get("bin")) {
-            link_dir_bins(bin_dir, ws_dir, dir_bin, shim_opts)?;
+            link_dir_bins(bin_dir, pkg_dir, dir_bin, shim_opts)?;
         }
     }
     Ok(())
+}
+
+/// On-disk root of a dep the linker SYMLINKED rather than materialized
+/// into the virtual store, i.e. `link:` and `portal:`. `file:<dir>` is
+/// deliberately absent: that kind is hardlink-copied into
+/// `.aube/<dep_path>/`, so `materialized_pkg_dir` already finds it and
+/// its bins work today.
+///
+/// Paths on `LocalSource` are stored relative to the project root.
+fn symlinked_dep_dir(
+    graph: &aube_lockfile::LockfileGraph,
+    dep_path: &str,
+    root_dir: &Path,
+) -> Option<PathBuf> {
+    match graph.packages.get(dep_path)?.local_source.as_ref()? {
+        aube_lockfile::LocalSource::Link(p) | aube_lockfile::LocalSource::Portal(p) => {
+            Some(root_dir.join(p))
+        }
+        _ => None,
+    }
 }
 
 /// Gate + run the per-dep `.bin` linking pass.


### PR DESCRIPTION
`"card": "workspace:card-impl@*"` and `"card": "workspace:../card"` name a member the dependency key does not. Both failed with `package not found`. When the key also named a different member, the locator branch bound to that one — exit 0, wrong package linked and locked.

Parses the tail with pnpm's grammar (an alias needs `@`; a leading `.` is a path) and binds the target before the key lookup.

Also fixed: `link:`/`portal:` deps never got their bins shimmed; a `workspace:` spec binding no member now errors instead of hitting the registry.

Verified against pnpm 10.15.1. New tests confirmed RED before the fix.

Closes #713