### PR TITLE
fix(registry): bound and surface a stalled packument fetch

### DIFF
--- a/tests/registry-stall/README.md
+++ b/tests/registry-stall/README.md
@@ -2,14 +2,16 @@
 
 This directory is the working system for nub's behavior when a registry accepts a connection and then goes quiet. It exists because the defect class here is invisible to unit tests: a stalled stream is not an error, so nothing fails, nothing logs, and the resolver simply blocks at 0% CPU until some bound expires. The bug that motivated it ([#715](https://github.com/nubjs/nub/issues/715)) presented as "`nub install` hangs forever" and was really a 970-second wait — a distinction only wall-clock can make.
 
-`wiki/` carries no decision record for this; the mechanism is documented in `crates/aube-registry/src/client/retry_policy.rs` and the `fetchStallTimeout` entry in `settings.toml`. This README documents the *loop*.
+`wiki/` carries no decision record for this; the mechanism is documented in `vendor/aube/crates/aube-registry/src/client/retry_policy.rs` and the `fetchStallTimeout` entry in `vendor/aube/crates/aube-settings/settings.toml`. This README documents the *loop*.
 
 ## The loop
 
 1. Build a binary: `scripts/rust-build.sh build -p nub-cli --profile fast`.
 2. Run the matrix: `tests/registry-stall/run-stall-matrix.sh "$(scripts/rust-build.sh --print-target)/fast/nub"`.
 
-It takes about three minutes, needs no network, and exits non-zero on the first case outside its window.
+It takes about three minutes, needs no network, runs all five cases, and exits non-zero if any of them missed its window. It is deliberately not fail-fast: which bounds moved *together* is what localises a regression, and that is only visible if every case runs.
+
+Each case runs with the ambient `npm_config_*` / `AUBE_*` / `NUB_*` environment stripped, because `env` outranks the project `.npmrc` in the settings precedence chain — without that, a developer who exports `npm_config_registry` would silently measure something other than what the case claims.
 
 **Pass the binary path explicitly.** The build wrapper writes to a content-hashed bucket that moves whenever a depended-on crate (`vendor/aube`, `nub-core`) changes, so a stale artifact can sit at the obvious path looking valid. That is not hypothetical — it happened while this harness was being written, and a stale binary reports a confusing out-of-window failure rather than an error. The script warns when the binary has no `fetchStallTimeout` symbol.
 

--- a/tests/registry-stall/README.md
+++ b/tests/registry-stall/README.md
@@ -1,0 +1,47 @@
+# Registry-stall harness — how the fetch timeout bounds are iterated on
+
+This directory is the working system for nub's behavior when a registry accepts a connection and then goes quiet. It exists because the defect class here is invisible to unit tests: a stalled stream is not an error, so nothing fails, nothing logs, and the resolver simply blocks at 0% CPU until some bound expires. The bug that motivated it ([#715](https://github.com/nubjs/nub/issues/715)) presented as "`nub install` hangs forever" and was really a 970-second wait — a distinction only wall-clock can make.
+
+`wiki/` carries no decision record for this; the mechanism is documented in `crates/aube-registry/src/client/retry_policy.rs` and the `fetchStallTimeout` entry in `settings.toml`. This README documents the *loop*.
+
+## The loop
+
+1. Build a binary: `scripts/rust-build.sh build -p nub-cli --profile fast`.
+2. Run the matrix: `tests/registry-stall/run-stall-matrix.sh "$(scripts/rust-build.sh --print-target)/fast/nub"`.
+
+It takes about three minutes, needs no network, and exits non-zero on the first case outside its window.
+
+**Pass the binary path explicitly.** The build wrapper writes to a content-hashed bucket that moves whenever a depended-on crate (`vendor/aube`, `nub-core`) changes, so a stale artifact can sit at the obvious path looking valid. That is not hypothetical — it happened while this harness was being written, and a stale binary reports a confusing out-of-window failure rather than an error. The script warns when the binary has no `fetchStallTimeout` symbol.
+
+## Why elapsed time is the assertion
+
+Every case pins a *different* bound, so the number is the test. A bound that silently stops being read does not throw — it falls back to another bound and the wait changes. That is exactly how two defects shipped in the original fix: the setting declared a CLI flag that did not exist, and its only env alias was one the nub profile disables, so the knob had no env route at all. Both were invisible to `cargo test` and to code review, and both show up here as a case landing in the wrong window.
+
+| Case | Pins | Fails if |
+| --- | --- | --- |
+| `default-60s` | `fetchStallTimeout` default (60s) fires on a silent connection | the idle bound is gone; falls back to the 300s `fetchTimeout` |
+| `npmrc-5s` | the `.npmrc` key reaches the client | settings plumbing breaks between `settings.toml` and `FetchPolicy` |
+| `env-20s` | `npm_config_fetch_stall_timeout` reaches the client | the env route is dropped, or only an `AUBE_*` alias is declared (inert under nub, whose `env_prefix` is `None`) |
+| `disabled-falls-back` | `0` disables the idle bound and `fetchTimeout` alone applies | `0` is treated as a real value, or the disable path stops falling back |
+| `warn-disabled` | `fetchWarnTimeoutMs=0` silences the in-flight line without moving the bound | the "still waiting" ticker ignores the documented disable |
+
+The last one guards a real regression: the first implementation of the ticker turned `fetchWarnTimeoutMs=0` into *one warning every 10 seconds*, the exact inverse of what the setting documents.
+
+## The two stall shapes
+
+`stall-registry.mjs` serves both, because they exercise different bounds and only one of them is reachable with a mock HTTP server.
+
+- `--mode blackhole` accepts the connection and never writes a byte. No response head ever arrives, so only a bound on the head wait ends it. This is what the matrix uses.
+- `--mode proxy --stall-at N` forwards everything to the real registry except the Nth response, which gets its real headers and ~4 KB of real body and then stops forever. This is the shape [#715](https://github.com/nubjs/nub/issues/715)'s reporter hit, and it is how you reproduce the original symptom against a real dependency graph:
+
+  ```sh
+  node tests/registry-stall/stall-registry.mjs --port 4998 --mode proxy --stall-at 800
+  # then, in a workspace with registry=http://127.0.0.1:4998/ in .npmrc:
+  nub install --lockfile-only
+  ```
+
+  Watch the resolver go to 0% CPU and the progress bar freeze, which is what the reporter saw. It surfaces elsewhere as `error decoding response body`, and confirming those are the same underlying condition is what this mode is for.
+
+## What this cannot test
+
+`reqwest`'s read timeout resets on every delivered frame, so a large-but-progressing response is never cut off. Neither mode here proves that: the blackhole delivers nothing, and the proxy stalls permanently rather than dribbling. A genuine test of the per-frame reset needs a server that spaces body frames on a timer, which neither `wiremock` (used by the Rust unit tests) nor this proxy does. The positive control for it is a real cold resolve of a workspace pulling a multi-megabyte packument — `@remotion/google-fonts` is ~11.7 MB and is the one to watch.

--- a/tests/registry-stall/run-stall-matrix.sh
+++ b/tests/registry-stall/run-stall-matrix.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Drives a real nub binary against a registry that never answers, and asserts
+# on how long each configuration takes to give up. Elapsed time IS the
+# assertion here: every case pins a different bound, so a bound that silently
+# stops being read shows up as the wrong number rather than as a pass.
+#
+# Usage: run-stall-matrix.sh [path-to-nub] [port]
+#
+# Exits non-zero on the first case whose elapsed time misses its window.
+set -uo pipefail
+
+NUB="${1:-target/fast/nub}"
+PORT="${2:-4999}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/nub-stall-matrix.XXXXXX")"
+SERVER_PID=""
+FAILURES=0
+
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+if [ ! -x "$NUB" ]; then
+  echo "no nub binary at $NUB — build one first:" >&2
+  echo "  scripts/rust-build.sh build -p nub-cli --profile fast" >&2
+  echo "  then pass \"\$(scripts/rust-build.sh --print-target)/fast/nub\"" >&2
+  exit 2
+fi
+
+# A binary that predates the stall bound is the failure mode this harness is
+# most likely to hit in practice, because the wrapper's target dir is a
+# content-hashed bucket that moves when a depended-on crate changes — so a
+# stale artifact can sit at the expected path looking perfectly valid. It would
+# not error; it would take ~300s on the first case and report a confusing
+# out-of-window failure. Name it up front instead.
+# `grep -c` rather than `grep -q`: under `pipefail`, a `-q` grep exits on the
+# first match and SIGPIPEs `strings`, which fails the whole pipeline and makes
+# this warn on a perfectly good binary. `-c` consumes all input; `|| true`
+# absorbs grep's exit 1 when there is genuinely no match.
+STALL_SYMBOLS=$(strings "$NUB" 2>/dev/null | grep -c fetchStallTimeout || true)
+if [ "${STALL_SYMBOLS:-0}" -eq 0 ]; then
+  echo "warning: $NUB has no fetchStallTimeout — it predates the stall bound." >&2
+  echo "         Expect the first case to take ~300s (the old fetchTimeout) and fail." >&2
+  echo "         Rebuild and re-check which artifact you are pointing at." >&2
+fi
+
+node "$HERE/stall-registry.mjs" --port "$PORT" --mode blackhole > "$WORK/server.log" 2>&1 &
+SERVER_PID=$!
+sleep 1
+
+# name | npmrc body | env prefix | low bound (s) | high bound (s) | expected "still waiting" lines
+run_case() {
+  local name="$1" npmrc="$2" envs="$3" lo="$4" hi="$5" want_lines="$6"
+  local dir="$WORK/$name"
+  mkdir -p "$dir"
+  echo '{"name":"stall-case","private":true,"dependencies":{"react":"^19.0.0"}}' > "$dir/package.json"
+  { echo "registry=http://127.0.0.1:$PORT/"; printf '%b\n' "$npmrc"; } > "$dir/.npmrc"
+
+  local start elapsed rc lines
+  start=$(date +%s)
+  ( cd "$dir" && env XDG_CACHE_HOME="$dir/cache" $envs timeout 700 "$NUB" install --lockfile-only ) \
+    > "$dir/out.log" 2>&1
+  rc=$?
+  elapsed=$(( $(date +%s) - start ))
+  lines=$(tr '\r' '\n' < "$dir/out.log" | grep -c "still waiting on")
+
+  local verdict="ok"
+  if [ "$elapsed" -lt "$lo" ] || [ "$elapsed" -gt "$hi" ]; then
+    verdict="FAIL (wanted ${lo}-${hi}s)"
+    FAILURES=$((FAILURES + 1))
+  elif [ "$rc" -eq 0 ]; then
+    verdict="FAIL (expected a non-zero exit; a stalled registry must not succeed)"
+    FAILURES=$((FAILURES + 1))
+  elif [ "$want_lines" = "some" ] && [ "$lines" -eq 0 ]; then
+    verdict="FAIL (expected 'still waiting' output)"
+    FAILURES=$((FAILURES + 1))
+  elif [ "$want_lines" = "none" ] && [ "$lines" -ne 0 ]; then
+    verdict="FAIL (expected silence, got $lines lines)"
+    FAILURES=$((FAILURES + 1))
+  fi
+  printf '%-22s elapsed=%-5s rc=%-3s waiting-lines=%-3s %s\n' \
+    "$name" "${elapsed}s" "$rc" "$lines" "$verdict"
+}
+
+echo "nub: $NUB"
+echo
+
+# The default idle bound. Without fetchStallTimeout this took the whole
+# 300s fetchTimeout, which is what made #715 look like a permanent hang.
+run_case "default-60s"        "fetch-retries=0"                                        "" 55  90  some
+# Proves the .npmrc key reaches the client. Only a changed elapsed shows that.
+run_case "npmrc-5s"           "fetch-retries=0\nfetch-stall-timeout=5000"               "" 3   25  none
+# Same, via env. The AUBE_* spelling is inert under nub (env_prefix is None),
+# so npm_config_* is the only env route and this is what guards it.
+run_case "env-20s"            "fetch-retries=0"     "npm_config_fetch_stall_timeout=20000" 17  40  some
+# 0 must DISABLE the idle bound and fall back to fetchTimeout alone.
+run_case "disabled-falls-back" "fetch-retries=0\nfetch-stall-timeout=0\nfetch-timeout=30000" "" 27 55 some
+# fetchWarnTimeoutMs=0 is documented as disabling the warning; it must silence
+# the in-flight line too, without touching the bound.
+run_case "warn-disabled"      "fetch-retries=0\nfetch-warn-timeout-ms=0"                "" 55  90  none
+
+echo
+if [ "$FAILURES" -ne 0 ]; then
+  echo "$FAILURES case(s) failed"
+  exit 1
+fi
+echo "all cases passed"

--- a/tests/registry-stall/run-stall-matrix.sh
+++ b/tests/registry-stall/run-stall-matrix.sh
@@ -82,12 +82,12 @@ run_case() {
     esac
   done < <(env)
 
-  # An array rather than a word-split scalar. Not because an empty `$envs`
-  # would produce a stray argument — unquoted, it expands to zero words, and
-  # only the *quoted* spelling has that hazard. The reason is the opposite
-  # end: unquoted, the content is subject to globbing and IFS splitting, so an
-  # assignment whose value ever contained a space or a glob character would be
-  # silently mangled. The array says exactly how many arguments there are.
+  # An array rather than an unquoted scalar. The difference is pathname
+  # expansion, and only that: `read -r -a` splits on IFS exactly as unquoted
+  # expansion does, so neither form survives a value containing a space. What
+  # unquoted expansion additionally does is glob — with a file named `FOO=x`
+  # present, `set -- FOO=*` yields `FOO=x` while `read -r -a` keeps the
+  # literal. Measured under bash, which is what runs this file.
   local -a case_env=()
   [ -n "$envs" ] && read -r -a case_env <<< "$envs"
 

--- a/tests/registry-stall/run-stall-matrix.sh
+++ b/tests/registry-stall/run-stall-matrix.sh
@@ -6,7 +6,9 @@
 #
 # Usage: run-stall-matrix.sh [path-to-nub] [port]
 #
-# Exits non-zero on the first case whose elapsed time misses its window.
+# Runs all five cases and exits non-zero if any of them missed its window.
+# Deliberately not fail-fast: the whole matrix is about three minutes, and
+# seeing which bounds moved together is what tells you where a regression is.
 set -uo pipefail
 
 NUB="${1:-target/fast/nub}"
@@ -58,10 +60,31 @@ run_case() {
   echo '{"name":"stall-case","private":true,"dependencies":{"react":"^19.0.0"}}' > "$dir/package.json"
   { echo "registry=http://127.0.0.1:$PORT/"; printf '%b\n' "$npmrc"; } > "$dir/.npmrc"
 
+  # Scrub the ambient settings env. `env` outranks `project_npmrc` in the
+  # precedence chain (aube-settings/src/values.rs), so a developer who happens
+  # to export npm_config_registry or npm_config_fetch_stall_timeout would have
+  # it silently beat the fixture's .npmrc and the case would measure something
+  # other than what it claims. Each case's own env is applied after the -u
+  # flags, so it still wins.
+  local -a scrub=()
+  local key
+  while IFS='=' read -r key _; do
+    case "$key" in
+      npm_config_*|NPM_CONFIG_*|pnpm_config_*|PNPM_CONFIG_*|AUBE_*|NUB_*)
+        scrub+=(-u "$key") ;;
+    esac
+  done < <(env)
+
+  # An array, not a bare word-split string: the case env is sometimes empty,
+  # and an unquoted empty scalar would hand `env` a stray "" argument.
+  local -a case_env=()
+  [ -n "$envs" ] && read -r -a case_env <<< "$envs"
+
   local start elapsed rc lines
   start=$(date +%s)
-  ( cd "$dir" && env XDG_CACHE_HOME="$dir/cache" $envs timeout 700 "$NUB" install --lockfile-only ) \
-    > "$dir/out.log" 2>&1
+  ( cd "$dir" && env ${scrub[@]+"${scrub[@]}"} XDG_CACHE_HOME="$dir/cache" \
+      ${case_env[@]+"${case_env[@]}"} timeout 700 "$NUB" install --lockfile-only ) \
+      > "$dir/out.log" 2>&1
   rc=$?
   elapsed=$(( $(date +%s) - start ))
   lines=$(tr '\r' '\n' < "$dir/out.log" | grep -c "still waiting on")
@@ -91,7 +114,7 @@ echo
 # 300s fetchTimeout, which is what made #715 look like a permanent hang.
 run_case "default-60s"        "fetch-retries=0"                                        "" 55  90  some
 # Proves the .npmrc key reaches the client. Only a changed elapsed shows that.
-run_case "npmrc-5s"           "fetch-retries=0\nfetch-stall-timeout=5000"               "" 3   25  none
+run_case "npmrc-5s"           "fetch-retries=0\nfetch-stall-timeout=5000"               "" 3   15  none
 # Same, via env. The AUBE_* spelling is inert under nub (env_prefix is None),
 # so npm_config_* is the only env route and this is what guards it.
 run_case "env-20s"            "fetch-retries=0"     "npm_config_fetch_stall_timeout=20000" 17  40  some

--- a/tests/registry-stall/run-stall-matrix.sh
+++ b/tests/registry-stall/run-stall-matrix.sh
@@ -72,11 +72,22 @@ run_case() {
     case "$key" in
       npm_config_*|NPM_CONFIG_*|pnpm_config_*|PNPM_CONFIG_*|AUBE_*|NUB_*)
         scrub+=(-u "$key") ;;
+      # The proxy family too: `NpmConfig` fills http_proxy from HTTPS_PROXY,
+      # then HTTP_PROXY, then PROXY whenever the npmrc layer left it unset
+      # (config/apply.rs), and the fixture npmrc deliberately sets none of
+      # them. On a machine behind a corporate proxy every case would then be
+      # routed away from the 127.0.0.1 stall server it is supposed to measure.
+      HTTPS_PROXY|https_proxy|HTTP_PROXY|http_proxy|PROXY|proxy|NO_PROXY|no_proxy)
+        scrub+=(-u "$key") ;;
     esac
   done < <(env)
 
-  # An array, not a bare word-split string: the case env is sometimes empty,
-  # and an unquoted empty scalar would hand `env` a stray "" argument.
+  # An array rather than a word-split scalar. Not because an empty `$envs`
+  # would produce a stray argument — unquoted, it expands to zero words, and
+  # only the *quoted* spelling has that hazard. The reason is the opposite
+  # end: unquoted, the content is subject to globbing and IFS splitting, so an
+  # assignment whose value ever contained a space or a glob character would be
+  # silently mangled. The array says exactly how many arguments there are.
   local -a case_env=()
   [ -n "$envs" ] && read -r -a case_env <<< "$envs"
 

--- a/tests/registry-stall/stall-registry.mjs
+++ b/tests/registry-stall/stall-registry.mjs
@@ -1,0 +1,96 @@
+// A registry that stalls on purpose, in the two shapes that actually break nub.
+//
+//   --mode blackhole
+//       Accepts the TCP connection, reads the request, and never writes a byte
+//       back. This is the "connection accepted, then silence" case: no response
+//       head ever arrives, so only a bound on the *head* wait can end it.
+//
+//   --mode proxy --stall-at N
+//       Forwards every request to the real registry, except the Nth, where it
+//       sends the real status and headers plus ~4 KB of the real body and then
+//       stops forever without closing. This is the "stream dies mid-body" case,
+//       which is what issue #715's reporter was hitting; it surfaces elsewhere
+//       as `error decoding response body`.
+//
+// Both keep the socket open, which is the point: a closed socket produces a
+// prompt error on its own and proves nothing about nub's own timeouts.
+import http from "node:http";
+import https from "node:https";
+import net from "node:net";
+
+const args = process.argv.slice(2);
+const arg = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i === -1 ? fallback : args[i + 1];
+};
+
+const port = Number(arg("port", 4999));
+const mode = arg("mode", "blackhole");
+const stallAt = Number(arg("stall-at", 800));
+const upstream = arg("upstream", "registry.npmjs.org");
+
+const stamp = () => new Date().toISOString();
+
+if (mode === "blackhole") {
+  net
+    .createServer((sock) => {
+      console.log(`${stamp()} ACCEPTED ${sock.remoteAddress}:${sock.remotePort}`);
+      sock.on("data", (d) =>
+        console.log(`${stamp()} REQ ${d.toString("utf8").split("\r\n")[0]}`),
+      );
+      sock.on("close", () => console.log(`${stamp()} CLOSED (client gave up)`));
+      sock.on("error", (e) => console.log(`${stamp()} ERR ${e.code}`));
+      // Deliberately never respond.
+    })
+    .listen(port, "127.0.0.1", () =>
+      console.log(`blackhole registry on 127.0.0.1:${port}`),
+    );
+} else if (mode === "proxy") {
+  let seen = 0;
+  // Holds the stalled response objects so nothing is garbage collected and the
+  // socket stays open for the whole run.
+  const held = [];
+  http
+    .createServer((req, res) => {
+      const n = ++seen;
+      const headers = { ...req.headers, host: upstream };
+      const preq = https.request(
+        { host: upstream, path: req.url, method: req.method, headers },
+        (pres) => {
+          res.writeHead(pres.statusCode, pres.headers);
+          if (n !== stallAt) {
+            pres.pipe(res);
+            return;
+          }
+          console.log(`${stamp()} STALLING request #${n} ${req.url}`);
+          let sent = 0;
+          pres.on("data", (chunk) => {
+            if (sent < 4096) {
+              res.write(chunk);
+              sent += chunk.length;
+            } else {
+              pres.pause(); // never deliver the rest, never end the response
+            }
+          });
+          held.push({ req, res, pres });
+        },
+      );
+      preq.on("error", () => {
+        try {
+          res.writeHead(502);
+          res.end();
+        } catch {
+          // client already gone
+        }
+      });
+      req.pipe(preq);
+    })
+    .listen(port, "127.0.0.1", () =>
+      console.log(
+        `stall proxy on 127.0.0.1:${port} -> ${upstream}, stalling request #${stallAt}`,
+      ),
+    );
+} else {
+  console.error(`unknown --mode ${mode} (expected "blackhole" or "proxy")`);
+  process.exit(2);
+}

--- a/vendor/aube/crates/aube-registry/src/client.rs
+++ b/vendor/aube/crates/aube-registry/src/client.rs
@@ -14,6 +14,7 @@ mod npm_verbs;
 mod packument;
 mod parse;
 mod request;
+mod retry_policy;
 mod tarball;
 
 #[cfg(test)]

--- a/vendor/aube/crates/aube-registry/src/client/http.rs
+++ b/vendor/aube/crates/aube-registry/src/client/http.rs
@@ -173,8 +173,14 @@ fn build_http_client_inner(
         // `fetchTimeout` — applied to the whole response (headers +
         // body) via reqwest's single-knob timeout. pnpm / npm expose
         // this as `fetch-timeout` in `.npmrc`; the default matches
-        // npm's 60s. Without this override reqwest would use its
+        // npm's 5 minutes. Without this override reqwest would use its
         // built-in 30s default, which is tighter than pnpm's.
+        //
+        // This is a WHOLE-REQUEST budget, which is why it cannot be the
+        // only bound: a connection that is accepted and then goes silent
+        // burns all 5 minutes before anything fails, and the resolver
+        // blocks on it at 0% CPU the entire time. `fetchStallTimeout`
+        // below is the idle bound that actually catches that case.
         .timeout(std::time::Duration::from_millis(fetch_policy.timeout_ms))
         // Bigger connection pool so concurrent fetches don't queue on a small set of conns.
         // HTTP/2 (when negotiated via ALPN, which npm registry supports) multiplexes many
@@ -182,6 +188,17 @@ fn build_http_client_inner(
         .pool_max_idle_per_host(pool_max_idle)
         .pool_idle_timeout(std::time::Duration::from_secs(90))
         .tcp_nodelay(true);
+    // `fetchStallTimeout` — idle bound. reqwest restarts this clock on
+    // every delivered frame, so a slow-but-progressing 12 MB packument
+    // is never cut off; only a stream that goes quiet trips it. It also
+    // gates the wait for the response head, so a socket that is accepted
+    // and never answered fails here rather than at `fetchTimeout`.
+    // `0` opts out and leaves `fetchTimeout` as the sole bound.
+    if fetch_policy.stall_timeout_ms > 0 {
+        builder = builder.read_timeout(std::time::Duration::from_millis(
+            fetch_policy.stall_timeout_ms,
+        ));
+    }
     if !for_tarball {
         builder = builder
             .http2_keep_alive_interval(std::time::Duration::from_secs(30))

--- a/vendor/aube/crates/aube-registry/src/client/packument.rs
+++ b/vendor/aube/crates/aube-registry/src/client/packument.rs
@@ -1,5 +1,6 @@
 use super::body::{check_body_cap, is_retriable_status, retry_after_from};
 use super::cache::*;
+use super::retry_policy::{self, RetryCause, RetryPolicy};
 use super::{
     PACKUMENT_ACCEPT, PACKUMENT_FULL_ACCEPT, RegistryClient, force_full_packument,
     parse_full_response,
@@ -201,7 +202,12 @@ impl RegistryClient {
         // a caching bug.
         let cached_ref = cached.as_ref();
         let label = format!("packument {name}");
-        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        // Marks this fetch as in flight for the whole retry loop, so the
+        // "still waiting" ticker can name it while the user is blocked
+        // on it. Dropped on every exit path with the loop's scope.
+        let _in_flight = crate::slow_metadata::begin(&label, self.fetch_policy.warn_timeout_ms);
+        let mut retry = RetryPolicy::new(&self.fetch_policy, &label);
+        let max_attempts = retry.max_attempts();
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
             match {
@@ -232,16 +238,14 @@ impl RegistryClient {
             .await
             {
                 Ok(resp) if is_retriable_status(resp.status()) && !is_last => {
+                    let status = resp.status().as_u16();
                     let wait = retry_after_from(&resp)
                         .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        max_attempts,
-                        backoff_ms = wait.as_millis() as u64,
-                        status = resp.status().as_u16(),
-                        label,
-                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
-                        "retrying HTTP request after transient failure",
+                    retry.warn_retry(
+                        RetryCause::Status,
+                        &format_args!("HTTP {status}"),
+                        attempt,
+                        wait,
                     );
                     drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
@@ -299,16 +303,12 @@ impl RegistryClient {
                             return Ok(packument);
                         }
                         Err(err) if !is_last => {
-                            let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
-                            tracing::warn!(
-                                    attempt = attempt + 1,
-                                    max_attempts,
-                                    backoff_ms = wait.as_millis() as u64,
-                                    error = %err,
-                                    label,
-                                    code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_BODY_DECODE,
-                            "retrying HTTP request after response body decode error",
-                                );
+                            let is_timeout = retry_policy::is_timeout_body_error(&err);
+                            let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
+                                retry.warn_giving_up(RetryCause::BodyDecode, &err);
+                                return Err(err);
+                            };
+                            retry.warn_retry(RetryCause::BodyDecode, &err, attempt, wait);
                             drop(sf_guard.take());
                             tokio::time::sleep(wait).await;
                         }
@@ -316,16 +316,12 @@ impl RegistryClient {
                     }
                 }
                 Err(err) if !is_last => {
-                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        max_attempts,
-                        backoff_ms = wait.as_millis() as u64,
-                        error = %err,
-                        label,
-                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSPORT,
-                        "retrying HTTP request after transport error",
-                    );
+                    let is_timeout = retry_policy::is_timeout_error(&err);
+                    let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
+                        retry.warn_giving_up(RetryCause::Transport, &err);
+                        return Err(err.into());
+                    };
+                    retry.warn_retry(RetryCause::Transport, &err, attempt, wait);
                     drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
                 }
@@ -438,7 +434,11 @@ impl RegistryClient {
 
         let label = format!("packument {name}");
         let started = std::time::Instant::now();
-        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        // See `fetch_packument_full_cached` for why the in-flight guard
+        // wraps the whole retry loop rather than a single attempt.
+        let _in_flight = crate::slow_metadata::begin(&label, self.fetch_policy.warn_timeout_ms);
+        let mut retry = RetryPolicy::new(&self.fetch_policy, &label);
+        let max_attempts = retry.max_attempts();
 
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
@@ -458,16 +458,14 @@ impl RegistryClient {
             .await
             {
                 Ok(resp) if is_retriable_status(resp.status()) && !is_last => {
+                    let status = resp.status().as_u16();
                     let wait = retry_after_from(&resp)
                         .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        max_attempts,
-                        backoff_ms = wait.as_millis() as u64,
-                        status = resp.status().as_u16(),
-                        label,
-                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
-                        "retrying HTTP request after transient failure",
+                    retry.warn_retry(
+                        RetryCause::Status,
+                        &format_args!("HTTP {status}"),
+                        attempt,
+                        wait,
                     );
                     drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
@@ -536,16 +534,12 @@ impl RegistryClient {
                             return Ok(packument);
                         }
                         Err(err) if !is_last => {
-                            let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
-                            tracing::warn!(
-                                    attempt = attempt + 1,
-                                    max_attempts,
-                                    backoff_ms = wait.as_millis() as u64,
-                                    error = %err,
-                                    label,
-                                    code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_BODY_DECODE,
-                            "retrying HTTP request after response body decode error",
-                                );
+                            let is_timeout = retry_policy::is_timeout_body_error(&err);
+                            let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
+                                retry.warn_giving_up(RetryCause::BodyDecode, &err);
+                                return Err(err);
+                            };
+                            retry.warn_retry(RetryCause::BodyDecode, &err, attempt, wait);
                             drop(sf_guard.take());
                             tokio::time::sleep(wait).await;
                         }
@@ -553,16 +547,12 @@ impl RegistryClient {
                     }
                 }
                 Err(err) if !is_last => {
-                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        max_attempts,
-                        backoff_ms = wait.as_millis() as u64,
-                        error = %err,
-                        label,
-                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSPORT,
-                        "retrying HTTP request after transport error",
-                    );
+                    let is_timeout = retry_policy::is_timeout_error(&err);
+                    let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
+                        retry.warn_giving_up(RetryCause::Transport, &err);
+                        return Err(err.into());
+                    };
+                    retry.warn_retry(RetryCause::Transport, &err, attempt, wait);
                     drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
                 }
@@ -582,7 +572,11 @@ impl RegistryClient {
         let _diag_full =
             aube_util::diag::Span::new(aube_util::diag::Category::Registry, "fetch_packument")
                 .with_meta_fn(|| format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(name)));
-        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        // See `fetch_packument_full_cached` for why the in-flight guard
+        // wraps the whole retry loop rather than a single attempt.
+        let _in_flight = crate::slow_metadata::begin(&label, self.fetch_policy.warn_timeout_ms);
+        let mut retry = RetryPolicy::new(&self.fetch_policy, &label);
+        let max_attempts = retry.max_attempts();
         let started = std::time::Instant::now();
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
@@ -622,16 +616,14 @@ impl RegistryClient {
             .await
             {
                 Ok(resp) if is_retriable_status(resp.status()) && !is_last => {
+                    let status = resp.status().as_u16();
                     let wait = retry_after_from(&resp)
                         .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        max_attempts,
-                        backoff_ms = wait.as_millis() as u64,
-                        status = resp.status().as_u16(),
-                        label,
-                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
-                        "retrying HTTP request after transient failure",
+                    retry.warn_retry(
+                        RetryCause::Status,
+                        &format_args!("HTTP {status}"),
+                        attempt,
+                        wait,
                     );
                     tokio::time::sleep(wait).await;
                 }
@@ -666,32 +658,24 @@ impl RegistryClient {
                             return Ok(packument);
                         }
                         Err(err) if !is_last => {
-                            let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
-                            tracing::warn!(
-                                    attempt = attempt + 1,
-                                    max_attempts,
-                                    backoff_ms = wait.as_millis() as u64,
-                                    error = %err,
-                                    label,
-                                    code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_BODY_DECODE,
-                            "retrying HTTP request after response body decode error",
-                                );
+                            let is_timeout = retry_policy::is_timeout_body_error(&err);
+                            let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
+                                retry.warn_giving_up(RetryCause::BodyDecode, &err);
+                                return Err(err);
+                            };
+                            retry.warn_retry(RetryCause::BodyDecode, &err, attempt, wait);
                             tokio::time::sleep(wait).await;
                         }
                         Err(err) => return Err(err),
                     }
                 }
                 Err(err) if !is_last => {
-                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        max_attempts,
-                        backoff_ms = wait.as_millis() as u64,
-                        error = %err,
-                        label,
-                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSPORT,
-                        "retrying HTTP request after transport error",
-                    );
+                    let is_timeout = retry_policy::is_timeout_error(&err);
+                    let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
+                        retry.warn_giving_up(RetryCause::Transport, &err);
+                        return Err(err.into());
+                    };
+                    retry.warn_retry(RetryCause::Transport, &err, attempt, wait);
                     tokio::time::sleep(wait).await;
                 }
                 Err(err) => return Err(err.into()),
@@ -794,7 +778,12 @@ impl RegistryClient {
         // without silently stripping cache hints.
         let cached_ref = cached.as_ref();
         let label = format!("packument {name}");
-        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        // Marks this fetch as in flight for the whole retry loop, so the
+        // "still waiting" ticker can name it while the user is blocked
+        // on it. Dropped on every exit path with the loop's scope.
+        let _in_flight = crate::slow_metadata::begin(&label, self.fetch_policy.warn_timeout_ms);
+        let mut retry = RetryPolicy::new(&self.fetch_policy, &label);
+        let max_attempts = retry.max_attempts();
         let started = std::time::Instant::now();
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
@@ -825,16 +814,14 @@ impl RegistryClient {
             .await
             {
                 Ok(resp) if is_retriable_status(resp.status()) && !is_last => {
+                    let status = resp.status().as_u16();
                     let wait = retry_after_from(&resp)
                         .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        max_attempts,
-                        backoff_ms = wait.as_millis() as u64,
-                        status = resp.status().as_u16(),
-                        label,
-                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
-                        "retrying HTTP request after transient failure",
+                    retry.warn_retry(
+                        RetryCause::Status,
+                        &format_args!("HTTP {status}"),
+                        attempt,
+                        wait,
                     );
                     drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
@@ -891,16 +878,12 @@ impl RegistryClient {
                             return Ok(packument);
                         }
                         Err(err) if !is_last => {
-                            let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
-                            tracing::warn!(
-                                    attempt = attempt + 1,
-                                    max_attempts,
-                                    backoff_ms = wait.as_millis() as u64,
-                                    error = %err,
-                                    label,
-                                    code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_BODY_DECODE,
-                            "retrying HTTP request after response body decode error",
-                                );
+                            let is_timeout = retry_policy::is_timeout_body_error(&err);
+                            let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
+                                retry.warn_giving_up(RetryCause::BodyDecode, &err);
+                                return Err(err);
+                            };
+                            retry.warn_retry(RetryCause::BodyDecode, &err, attempt, wait);
                             drop(sf_guard.take());
                             tokio::time::sleep(wait).await;
                         }
@@ -908,16 +891,12 @@ impl RegistryClient {
                     }
                 }
                 Err(err) if !is_last => {
-                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        max_attempts,
-                        backoff_ms = wait.as_millis() as u64,
-                        error = %err,
-                        label,
-                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSPORT,
-                        "retrying HTTP request after transport error",
-                    );
+                    let is_timeout = retry_policy::is_timeout_error(&err);
+                    let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
+                        retry.warn_giving_up(RetryCause::Transport, &err);
+                        return Err(err.into());
+                    };
+                    retry.warn_retry(RetryCause::Transport, &err, attempt, wait);
                     drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
                 }

--- a/vendor/aube/crates/aube-registry/src/client/packument.rs
+++ b/vendor/aube/crates/aube-registry/src/client/packument.rs
@@ -242,7 +242,7 @@ impl RegistryClient {
                     let wait = retry_after_from(&resp)
                         .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
                     retry.warn_retry(
-                        RetryCause::Status,
+                        RetryCause::Status(status),
                         &format_args!("HTTP {status}"),
                         attempt,
                         wait,
@@ -305,7 +305,11 @@ impl RegistryClient {
                         Err(err) if !is_last => {
                             let is_timeout = retry_policy::is_timeout_body_error(&err);
                             let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
-                                retry.warn_giving_up(RetryCause::BodyDecode, &err);
+                                retry.warn_giving_up(
+                                    RetryCause::BodyDecode,
+                                    &err,
+                                    started.elapsed(),
+                                );
                                 return Err(err);
                             };
                             retry.warn_retry(RetryCause::BodyDecode, &err, attempt, wait);
@@ -318,7 +322,7 @@ impl RegistryClient {
                 Err(err) if !is_last => {
                     let is_timeout = retry_policy::is_timeout_error(&err);
                     let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
-                        retry.warn_giving_up(RetryCause::Transport, &err);
+                        retry.warn_giving_up(RetryCause::Transport, &err, started.elapsed());
                         return Err(err.into());
                     };
                     retry.warn_retry(RetryCause::Transport, &err, attempt, wait);
@@ -462,7 +466,7 @@ impl RegistryClient {
                     let wait = retry_after_from(&resp)
                         .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
                     retry.warn_retry(
-                        RetryCause::Status,
+                        RetryCause::Status(status),
                         &format_args!("HTTP {status}"),
                         attempt,
                         wait,
@@ -536,7 +540,11 @@ impl RegistryClient {
                         Err(err) if !is_last => {
                             let is_timeout = retry_policy::is_timeout_body_error(&err);
                             let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
-                                retry.warn_giving_up(RetryCause::BodyDecode, &err);
+                                retry.warn_giving_up(
+                                    RetryCause::BodyDecode,
+                                    &err,
+                                    started.elapsed(),
+                                );
                                 return Err(err);
                             };
                             retry.warn_retry(RetryCause::BodyDecode, &err, attempt, wait);
@@ -549,7 +557,7 @@ impl RegistryClient {
                 Err(err) if !is_last => {
                     let is_timeout = retry_policy::is_timeout_error(&err);
                     let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
-                        retry.warn_giving_up(RetryCause::Transport, &err);
+                        retry.warn_giving_up(RetryCause::Transport, &err, started.elapsed());
                         return Err(err.into());
                     };
                     retry.warn_retry(RetryCause::Transport, &err, attempt, wait);
@@ -620,7 +628,7 @@ impl RegistryClient {
                     let wait = retry_after_from(&resp)
                         .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
                     retry.warn_retry(
-                        RetryCause::Status,
+                        RetryCause::Status(status),
                         &format_args!("HTTP {status}"),
                         attempt,
                         wait,
@@ -660,7 +668,11 @@ impl RegistryClient {
                         Err(err) if !is_last => {
                             let is_timeout = retry_policy::is_timeout_body_error(&err);
                             let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
-                                retry.warn_giving_up(RetryCause::BodyDecode, &err);
+                                retry.warn_giving_up(
+                                    RetryCause::BodyDecode,
+                                    &err,
+                                    started.elapsed(),
+                                );
                                 return Err(err);
                             };
                             retry.warn_retry(RetryCause::BodyDecode, &err, attempt, wait);
@@ -672,7 +684,7 @@ impl RegistryClient {
                 Err(err) if !is_last => {
                     let is_timeout = retry_policy::is_timeout_error(&err);
                     let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
-                        retry.warn_giving_up(RetryCause::Transport, &err);
+                        retry.warn_giving_up(RetryCause::Transport, &err, started.elapsed());
                         return Err(err.into());
                     };
                     retry.warn_retry(RetryCause::Transport, &err, attempt, wait);
@@ -818,7 +830,7 @@ impl RegistryClient {
                     let wait = retry_after_from(&resp)
                         .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
                     retry.warn_retry(
-                        RetryCause::Status,
+                        RetryCause::Status(status),
                         &format_args!("HTTP {status}"),
                         attempt,
                         wait,
@@ -880,7 +892,11 @@ impl RegistryClient {
                         Err(err) if !is_last => {
                             let is_timeout = retry_policy::is_timeout_body_error(&err);
                             let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
-                                retry.warn_giving_up(RetryCause::BodyDecode, &err);
+                                retry.warn_giving_up(
+                                    RetryCause::BodyDecode,
+                                    &err,
+                                    started.elapsed(),
+                                );
                                 return Err(err);
                             };
                             retry.warn_retry(RetryCause::BodyDecode, &err, attempt, wait);
@@ -893,7 +909,7 @@ impl RegistryClient {
                 Err(err) if !is_last => {
                     let is_timeout = retry_policy::is_timeout_error(&err);
                     let Some(wait) = retry.next_backoff(is_timeout, attempt) else {
-                        retry.warn_giving_up(RetryCause::Transport, &err);
+                        retry.warn_giving_up(RetryCause::Transport, &err, started.elapsed());
                         return Err(err.into());
                     };
                     retry.warn_retry(RetryCause::Transport, &err, attempt, wait);

--- a/vendor/aube/crates/aube-registry/src/client/retry_policy.rs
+++ b/vendor/aube/crates/aube-registry/src/client/retry_policy.rs
@@ -94,6 +94,14 @@ impl<'a> RetryPolicy<'a> {
     /// to the caller — either the budget is spent or the failure is
     /// timeout-shaped and has already cost more wall-clock than another
     /// attempt is worth.
+    ///
+    /// The retriable-STATUS arms deliberately do not call this. A 5xx or
+    /// 429 is not timeout-shaped, so the only question is whether the
+    /// budget is spent — which those arms already answer in their match
+    /// guard (`&& !is_last`). Routing them through here would add an
+    /// `else` branch that can never be taken. They still share
+    /// [`Self::warn_retry`], which is where the wording and the
+    /// structured fields have to stay identical.
     pub(super) fn next_backoff(&mut self, is_timeout: bool, attempt: u32) -> Option<Duration> {
         if attempt + 1 >= self.max_attempts() {
             return None;

--- a/vendor/aube/crates/aube-registry/src/client/retry_policy.rs
+++ b/vendor/aube/crates/aube-registry/src/client/retry_policy.rs
@@ -36,10 +36,13 @@ pub(super) enum RetryCause {
     Transport,
     /// The response arrived but its body could not be read or decoded.
     BodyDecode,
-    /// The registry answered with a retriable status (5xx, 429). The
-    /// status itself is carried in the `err` argument to
-    /// [`RetryPolicy::warn_retry`] so it reaches the user-visible line.
-    Status,
+    /// The registry answered with a retriable status (5xx, 429). Carries
+    /// the code so [`RetryPolicy::warn_retry`] can keep emitting the
+    /// structured `status` field the tarball paths in `request.rs` and
+    /// `tarball.rs` emit. Dropping it here would have reintroduced,
+    /// between packument and tarball retries, exactly the per-call-site
+    /// divergence this module exists to prevent.
+    Status(u16),
 }
 
 impl RetryCause {
@@ -47,7 +50,7 @@ impl RetryCause {
         match self {
             Self::Transport => aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSPORT,
             Self::BodyDecode => aube_codes::warnings::WARN_AUBE_HTTP_RETRY_BODY_DECODE,
-            Self::Status => aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
+            Self::Status(_) => aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
         }
     }
 
@@ -55,7 +58,7 @@ impl RetryCause {
         match self {
             Self::Transport => "connection failed or timed out",
             Self::BodyDecode => "response body could not be read",
-            Self::Status => "registry returned a temporary error",
+            Self::Status(_) => "registry returned a temporary error",
         }
     }
 }
@@ -123,20 +126,40 @@ impl<'a> RetryPolicy<'a> {
         attempt: u32,
         wait: Duration,
     ) {
-        tracing::warn!(
-            attempt = attempt + 1,
-            max_attempts = self.max_attempts(),
-            backoff_ms = wait.as_millis() as u64,
-            error = %err,
-            label = self.label,
-            code = cause.code(),
-            "{}: {} — retrying in {}s (attempt {} of {})",
-            self.label,
-            cause.what_happened(),
-            wait.as_secs().max(1),
-            attempt + 2,
-            self.max_attempts(),
-        );
+        // Two arms rather than an `Option` field: the status paths in
+        // `request.rs` / `tarball.rs` emit a bare `status = <u16>`, and
+        // matching that exactly is the whole point of centralising here.
+        match cause {
+            RetryCause::Status(status) => tracing::warn!(
+                attempt = attempt + 1,
+                max_attempts = self.max_attempts(),
+                backoff_ms = wait.as_millis() as u64,
+                status,
+                error = %err,
+                label = self.label,
+                code = cause.code(),
+                "{}: {} — retrying in {}s (attempt {} of {})",
+                self.label,
+                cause.what_happened(),
+                wait.as_secs().max(1),
+                attempt + 2,
+                self.max_attempts(),
+            ),
+            _ => tracing::warn!(
+                attempt = attempt + 1,
+                max_attempts = self.max_attempts(),
+                backoff_ms = wait.as_millis() as u64,
+                error = %err,
+                label = self.label,
+                code = cause.code(),
+                "{}: {} — retrying in {}s (attempt {} of {})",
+                self.label,
+                cause.what_happened(),
+                wait.as_secs().max(1),
+                attempt + 2,
+                self.max_attempts(),
+            ),
+        }
     }
 
     /// Emit the warning for a stop that the retry *count* does not
@@ -149,16 +172,29 @@ impl<'a> RetryPolicy<'a> {
     /// and is owed the reason. The error itself still propagates and is
     /// rendered by the caller, so this says *why we stopped*, not what
     /// broke.
-    pub(super) fn warn_giving_up(&self, cause: RetryCause, err: &dyn std::fmt::Display) {
+    /// `elapsed` is the request's own measured wall-clock. It must be
+    /// measured, not derived from `fetchTimeout`: a timeout error can now
+    /// come from either bound, and `reqwest`'s `is_timeout` cannot tell
+    /// them apart — so reporting the `fetchTimeout` value would claim
+    /// 300s for a request that actually spent 60s on the stall bound.
+    /// That is the line this issue's reporter sees, so its one number
+    /// has to be true.
+    pub(super) fn warn_giving_up(
+        &self,
+        cause: RetryCause,
+        err: &dyn std::fmt::Display,
+        elapsed: Duration,
+    ) {
         tracing::warn!(
             error = %err,
             label = self.label,
+            elapsed_ms = elapsed.as_millis() as u64,
             code = cause.code(),
-            "{}: {} — not retrying, a timed-out request has already cost the full fetchTimeout \
-             ({}s); raise fetchStallTimeout or fetchTimeout if this registry is just slow",
+            "{}: {} — not retrying, this request has already spent {}s; raise fetchStallTimeout \
+             or fetchTimeout if the registry is simply slow",
             self.label,
             cause.what_happened(),
-            self.policy.timeout_ms / 1000,
+            elapsed.as_secs().max(1),
         );
     }
 }

--- a/vendor/aube/crates/aube-registry/src/client/retry_policy.rs
+++ b/vendor/aube/crates/aube-registry/src/client/retry_policy.rs
@@ -172,13 +172,14 @@ impl<'a> RetryPolicy<'a> {
     /// and is owed the reason. The error itself still propagates and is
     /// rendered by the caller, so this says *why we stopped*, not what
     /// broke.
-    /// `elapsed` is the request's own measured wall-clock. It must be
-    /// measured, not derived from `fetchTimeout`: a timeout error can now
-    /// come from either bound, and `reqwest`'s `is_timeout` cannot tell
-    /// them apart — so reporting the `fetchTimeout` value would claim
-    /// 300s for a request that actually spent 60s on the stall bound.
-    /// That is the line this issue's reporter sees, so its one number
-    /// has to be true.
+    ///
+    /// The `elapsed` argument is the request's own measured wall-clock,
+    /// and it has to be measured rather than derived from `fetchTimeout`.
+    /// A timeout error can now come from either bound, and reqwest's
+    /// `is_timeout` cannot tell them apart, so reporting the
+    /// `fetchTimeout` value would claim 300s for a request that actually
+    /// spent 60s on the stall bound. This is the line the reporter of
+    /// the originating issue sees, so its one number has to be true.
     pub(super) fn warn_giving_up(
         &self,
         cause: RetryCause,

--- a/vendor/aube/crates/aube-registry/src/client/retry_policy.rs
+++ b/vendor/aube/crates/aube-registry/src/client/retry_policy.rs
@@ -98,10 +98,12 @@ impl<'a> RetryPolicy<'a> {
     /// The retriable-STATUS arms deliberately do not call this. A 5xx or
     /// 429 is not timeout-shaped, so the only question is whether the
     /// budget is spent — which those arms already answer in their match
-    /// guard (`&& !is_last`). Routing them through here would add an
-    /// `else` branch that can never be taken. They still share
-    /// [`Self::warn_retry`], which is where the wording and the
-    /// structured fields have to stay identical.
+    /// guard (`&& !is_last`). They also prefer the registry's own
+    /// `Retry-After` header over a computed backoff, which this method
+    /// cannot express, so routing them through here would both add an
+    /// `else` branch that can never be taken and drop that header. They
+    /// still share [`Self::warn_retry`], which is where the wording and
+    /// the structured fields have to stay identical.
     pub(super) fn next_backoff(&mut self, is_timeout: bool, attempt: u32) -> Option<Duration> {
         if attempt + 1 >= self.max_attempts() {
             return None;

--- a/vendor/aube/crates/aube-registry/src/client/retry_policy.rs
+++ b/vendor/aube/crates/aube-registry/src/client/retry_policy.rs
@@ -1,0 +1,177 @@
+//! One retry policy for every registry request.
+//!
+//! The packument fetchers, the revalidation path and the tarball
+//! fetchers all handle a *successful* response differently — 304
+//! revalidation, cache writes, streaming SHA-512, typed vs. untyped
+//! parse — so their loop bodies legitimately differ. What must *not*
+//! differ is the retry decision: how long to back off, what to log,
+//! and how much of the attempt budget a timeout is allowed to spend.
+//!
+//! That decision did drift. [`TIMEOUT_RETRY_CAP`] was introduced to stop
+//! a stalled transfer costing the full attempt budget, and it reached
+//! the two tarball helpers in `request.rs` but never reached the four
+//! copied loops in `packument.rs`. The result was that one stalled
+//! packument cost `3 x fetchTimeout` (measured: 970 s with the default
+//! 5-minute timeout) while the equivalent tarball stall cost two
+//! attempts. The resolver blocks on packument fetches, so the path that
+//! kept the unbounded policy was the one where a stall is most visible
+//! to the user — it presents as an install that hangs at 0% CPU.
+//!
+//! Centralising the decision here is what stops it drifting again: a
+//! new caller gets the cap, the backoff and the user-facing wording by
+//! construction rather than by remembering to copy them.
+
+use super::body::TIMEOUT_RETRY_CAP;
+use crate::Error;
+use crate::config::FetchPolicy;
+use std::time::Duration;
+
+/// Why a request is being retried. Selects the warning code and the
+/// wording, so the four call sites cannot describe the same event
+/// differently.
+#[derive(Clone, Copy)]
+pub(super) enum RetryCause {
+    /// `send()` itself failed: connection refused, TLS failure, DNS,
+    /// or the request exceeded `fetchTimeout` / `fetchStallTimeout`.
+    Transport,
+    /// The response arrived but its body could not be read or decoded.
+    BodyDecode,
+    /// The registry answered with a retriable status (5xx, 429). The
+    /// status itself is carried in the `err` argument to
+    /// [`RetryPolicy::warn_retry`] so it reaches the user-visible line.
+    Status,
+}
+
+impl RetryCause {
+    fn code(self) -> &'static str {
+        match self {
+            Self::Transport => aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSPORT,
+            Self::BodyDecode => aube_codes::warnings::WARN_AUBE_HTTP_RETRY_BODY_DECODE,
+            Self::Status => aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
+        }
+    }
+
+    fn what_happened(self) -> &'static str {
+        match self {
+            Self::Transport => "connection failed or timed out",
+            Self::BodyDecode => "response body could not be read",
+            Self::Status => "registry returned a temporary error",
+        }
+    }
+}
+
+/// Shared retry driver. Construct one per logical request, then ask it
+/// what to do after each failed attempt.
+pub(super) struct RetryPolicy<'a> {
+    policy: &'a FetchPolicy,
+    label: &'a str,
+    /// Timeout-shaped failures consumed so far. Counted separately from
+    /// the attempt index so a 503 on attempt 1 never eats the timeout
+    /// budget — the two failure modes cost very different wall-clock.
+    timeout_retries: u32,
+}
+
+impl<'a> RetryPolicy<'a> {
+    pub(super) fn new(policy: &'a FetchPolicy, label: &'a str) -> Self {
+        Self {
+            policy,
+            label,
+            timeout_retries: 0,
+        }
+    }
+
+    pub(super) fn max_attempts(&self) -> u32 {
+        self.policy.retries.saturating_add(1)
+    }
+
+    /// Decide what to do after attempt `attempt` (0-indexed) failed.
+    ///
+    /// `Some(wait)` means sleep that long and try again; the warning has
+    /// already been emitted. `None` means give up and surface the error
+    /// to the caller — either the budget is spent or the failure is
+    /// timeout-shaped and has already cost more wall-clock than another
+    /// attempt is worth.
+    pub(super) fn next_backoff(&mut self, is_timeout: bool, attempt: u32) -> Option<Duration> {
+        if attempt + 1 >= self.max_attempts() {
+            return None;
+        }
+        // A timeout has already burned a full `fetchTimeout`. Retrying
+        // it repeatedly multiplies a hang the user is already staring
+        // at, so it gets a tighter budget than the retry count implies.
+        if is_timeout {
+            if self.timeout_retries >= TIMEOUT_RETRY_CAP {
+                return None;
+            }
+            self.timeout_retries += 1;
+        }
+        Some(self.policy.backoff_for_attempt(attempt + 1))
+    }
+
+    /// Emit the user-facing retry warning. Kept separate from the
+    /// decision so a caller can drop a single-flight guard between the
+    /// two without holding it across the log call.
+    ///
+    /// The message names the package, says what went wrong in plain
+    /// words, and says what happens next. A user watching an install
+    /// stall needs all three: without the package name they cannot tell
+    /// which dependency is at fault, and without the wait they cannot
+    /// tell whether the tool is still working or wedged.
+    pub(super) fn warn_retry(
+        &self,
+        cause: RetryCause,
+        err: &dyn std::fmt::Display,
+        attempt: u32,
+        wait: Duration,
+    ) {
+        tracing::warn!(
+            attempt = attempt + 1,
+            max_attempts = self.max_attempts(),
+            backoff_ms = wait.as_millis() as u64,
+            error = %err,
+            label = self.label,
+            code = cause.code(),
+            "{}: {} — retrying in {}s (attempt {} of {})",
+            self.label,
+            cause.what_happened(),
+            wait.as_secs().max(1),
+            attempt + 2,
+            self.max_attempts(),
+        );
+    }
+
+    /// Emit the warning for a stop that the retry *count* does not
+    /// explain. Every call site guards on `!is_last`, so reaching here
+    /// means [`Self::next_backoff`] refused for the other reason: the
+    /// failure was timeout-shaped and the timeout budget is spent.
+    ///
+    /// Worth its own line because the arithmetic is otherwise baffling
+    /// from outside — the user set `fetchRetries=5`, saw two attempts,
+    /// and is owed the reason. The error itself still propagates and is
+    /// rendered by the caller, so this says *why we stopped*, not what
+    /// broke.
+    pub(super) fn warn_giving_up(&self, cause: RetryCause, err: &dyn std::fmt::Display) {
+        tracing::warn!(
+            error = %err,
+            label = self.label,
+            code = cause.code(),
+            "{}: {} — not retrying, a timed-out request has already cost the full fetchTimeout \
+             ({}s); raise fetchStallTimeout or fetchTimeout if this registry is just slow",
+            self.label,
+            cause.what_happened(),
+            self.policy.timeout_ms / 1000,
+        );
+    }
+}
+
+/// Whether a `reqwest` error is timeout-shaped. Both `fetchTimeout` and
+/// `fetchStallTimeout` surface through this, and reqwest reports them as
+/// a request-kind error whose *source* is its `TimedOut` marker, so the
+/// check has to walk the source chain — which `is_timeout` does.
+pub(super) fn is_timeout_error(err: &reqwest::Error) -> bool {
+    err.is_timeout()
+}
+
+/// Same question for an already-wrapped [`Error`].
+pub(super) fn is_timeout_body_error(err: &Error) -> bool {
+    matches!(err, Error::Http(e) if e.is_timeout())
+}

--- a/vendor/aube/crates/aube-registry/src/client/retry_tests.rs
+++ b/vendor/aube/crates/aube-registry/src/client/retry_tests.rs
@@ -1129,14 +1129,18 @@ async fn packument_stall_timeout_trips_well_before_fetch_timeout() {
 }
 
 #[tokio::test]
-async fn packument_stall_timeout_does_not_abort_a_slow_but_progressing_response() {
-    // The positive control for the test above. An idle timeout must not
-    // become a throughput cap: a large packument that keeps delivering
-    // bytes has to survive even when the total transfer runs longer
-    // than `fetchStallTimeout`. reqwest resets the read clock on every
-    // frame, and this asserts we rely on that rather than on a total
-    // budget. Without it, "stalls now fail fast" could ship alongside
-    // "big packuments now fail too" and both tests would still pass.
+async fn packument_under_the_stall_bound_is_not_aborted() {
+    // The positive control for the test above: a response slower than
+    // nothing, but inside the bound, must still succeed. Without it,
+    // "stalls now fail fast" could ship alongside "everything now fails"
+    // and the stall test would not notice.
+    //
+    // Scope, deliberately stated: `set_delay` withholds the whole
+    // response until the head, so the body lands as a single frame.
+    // This pins "a 300ms wait under a 2s bound is not aborted" and
+    // nothing more — it does NOT exercise reqwest's per-frame clock
+    // reset, because wiremock cannot space body frames. A real test of
+    // the reset needs a raw TCP or hyper stub that dribbles bytes.
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/demo"))

--- a/vendor/aube/crates/aube-registry/src/client/retry_tests.rs
+++ b/vendor/aube/crates/aube-registry/src/client/retry_tests.rs
@@ -1044,3 +1044,121 @@ async fn scoped_packument_request_is_url_encoded() {
         "corgi Accept header must include JSON and */* fallbacks",
     );
 }
+
+#[tokio::test]
+async fn packument_timeout_retries_at_most_once_even_with_high_retry_budget() {
+    // The metadata twin of
+    // `tarball_headers_timeout_retries_at_most_once_even_with_high_retry_budget`.
+    // The cap reached the tarball helpers and never reached the four
+    // copied packument loops, so a stalled packument spent the whole
+    // attempt budget: 3 x `fetchTimeout` = 970s measured with the
+    // shipped defaults, during which the resolver sat at 0% CPU with
+    // nothing on screen. `retries: 5` would be 6 attempts uncapped.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/demo"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(make_packument_json())
+                .set_delay(std::time::Duration::from_secs(30)),
+        )
+        .mount(&server)
+        .await;
+
+    let policy = FetchPolicy {
+        timeout_ms: 150,
+        // Isolate the whole-request timeout: this test is about the
+        // retry budget, not about which bound trips first.
+        stall_timeout_ms: 0,
+        retries: 5,
+        retry_factor: 1,
+        retry_min_timeout_ms: 1,
+        retry_max_timeout_ms: 1,
+        ..FetchPolicy::default()
+    };
+    let client = client_with(&server, policy);
+    client
+        .fetch_packument("demo")
+        .await
+        .expect_err("a response that never arrives must surface an error");
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(
+        requests.len(),
+        2,
+        "a timeout must cost 1 attempt + 1 retry regardless of fetchRetries, got {} attempts",
+        requests.len(),
+    );
+}
+
+#[tokio::test]
+async fn packument_stall_timeout_trips_well_before_fetch_timeout() {
+    // `fetchTimeout` is a whole-request budget, so on its own it lets a
+    // silent connection hold the resolver for the full 5 minutes.
+    // `fetchStallTimeout` is the idle bound that catches it. Here the
+    // whole-request budget is 60s and the idle bound is 200ms; the call
+    // must come back on the idle bound.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/demo"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(make_packument_json())
+                .set_delay(std::time::Duration::from_secs(30)),
+        )
+        .mount(&server)
+        .await;
+
+    let policy = FetchPolicy {
+        timeout_ms: 60_000,
+        stall_timeout_ms: 200,
+        retries: 0,
+        ..FetchPolicy::default()
+    };
+    let client = client_with(&server, policy);
+    let started = std::time::Instant::now();
+    client
+        .fetch_packument("demo")
+        .await
+        .expect_err("a stalled response must fail on the idle bound");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(10),
+        "stall timeout must bound the wait, but the call took {elapsed:?} against a 60s fetchTimeout",
+    );
+}
+
+#[tokio::test]
+async fn packument_stall_timeout_does_not_abort_a_slow_but_progressing_response() {
+    // The positive control for the test above. An idle timeout must not
+    // become a throughput cap: a large packument that keeps delivering
+    // bytes has to survive even when the total transfer runs longer
+    // than `fetchStallTimeout`. reqwest resets the read clock on every
+    // frame, and this asserts we rely on that rather than on a total
+    // budget. Without it, "stalls now fail fast" could ship alongside
+    // "big packuments now fail too" and both tests would still pass.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/demo"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(make_packument_json())
+                // Delay is under the stall bound, so the response is
+                // slow but never idle for longer than the bound allows.
+                .set_delay(std::time::Duration::from_millis(300)),
+        )
+        .mount(&server)
+        .await;
+
+    let policy = FetchPolicy {
+        timeout_ms: 60_000,
+        stall_timeout_ms: 2_000,
+        retries: 0,
+        ..FetchPolicy::default()
+    };
+    let client = client_with(&server, policy);
+    client
+        .fetch_packument("demo")
+        .await
+        .expect("a slow but progressing response must not be cut off");
+}

--- a/vendor/aube/crates/aube-registry/src/config/fetch.rs
+++ b/vendor/aube/crates/aube-registry/src/config/fetch.rs
@@ -14,6 +14,16 @@ pub struct FetchPolicy {
     /// `reqwest::ClientBuilder::timeout` so it covers the whole
     /// response (headers + body).
     pub timeout_ms: u64,
+    /// `fetchStallTimeout` — idle timeout. Applied via
+    /// `reqwest::ClientBuilder::read_timeout`, which resets on every
+    /// delivered chunk, so it bounds a *silent* connection without
+    /// capping a large-but-progressing transfer. Covers the wait for
+    /// response headers too. `0` disables it.
+    ///
+    /// This is the bound that matters for a stalled stream:
+    /// [`Self::timeout_ms`] is a whole-request budget, so without an
+    /// idle timeout a stall burns the entire budget before failing.
+    pub stall_timeout_ms: u64,
     /// `fetchRetries` — number of *additional* attempts on transient
     /// failure. `retries = 2` means up to 3 total attempts, matching
     /// pnpm / `make-fetch-happen`.
@@ -54,6 +64,7 @@ impl Default for FetchPolicy {
     fn default() -> Self {
         Self {
             timeout_ms: 300_000,
+            stall_timeout_ms: 60_000,
             retries: 2,
             retry_factor: 10,
             retry_min_timeout_ms: 10_000,
@@ -76,6 +87,7 @@ impl FetchPolicy {
     pub fn from_ctx(ctx: &aube_settings::ResolveCtx<'_>) -> Self {
         Self {
             timeout_ms: aube_settings::resolved::fetch_timeout(ctx),
+            stall_timeout_ms: aube_settings::resolved::fetch_stall_timeout(ctx),
             retries: clamp_u32(aube_settings::resolved::fetch_retries(ctx)),
             retry_factor: clamp_u32(aube_settings::resolved::fetch_retry_factor(ctx)),
             retry_min_timeout_ms: aube_settings::resolved::fetch_retry_mintimeout(ctx),

--- a/vendor/aube/crates/aube-registry/src/config/tests.rs
+++ b/vendor/aube/crates/aube-registry/src/config/tests.rs
@@ -2970,10 +2970,15 @@ fn fetch_policy_default_matches_settings_toml_declared_defaults() {
     // `FetchPolicy::from_ctx` still get the same behavior.
     let p = FetchPolicy::default();
     assert_eq!(p.timeout_ms, 300_000);
+    assert_eq!(p.stall_timeout_ms, 60_000);
     assert_eq!(p.retries, 2);
     assert_eq!(p.retry_factor, 10);
     assert_eq!(p.retry_min_timeout_ms, 10_000);
     assert_eq!(p.retry_max_timeout_ms, 60_000);
+    assert!(
+        p.stall_timeout_ms < p.timeout_ms,
+        "the idle bound must trip before the whole-request budget, or it can never fire",
+    );
 }
 
 #[test]

--- a/vendor/aube/crates/aube-registry/src/slow_metadata.rs
+++ b/vendor/aube/crates/aube-registry/src/slow_metadata.rs
@@ -32,8 +32,9 @@
 //! a usable escape hatch; if structured per-package telemetry is ever
 //! needed, ndjson is the right vehicle.
 
+use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Window during which slow-fetch events are coalesced into one group.
 /// Long enough that bursts (~18 events within a few seconds) emit a
@@ -72,11 +73,169 @@ struct State {
     /// can name the threshold without the timer task re-reading
     /// settings. Invariant across a single install run.
     threshold_ms: u64,
+    /// Metadata requests that are in flight *right now*, keyed by a
+    /// monotonic id, holding the label and the instant the request
+    /// started.
+    ///
+    /// This is what makes a stall visible. Everything else in this
+    /// module is post-hoc: [`record`] runs only after a request has
+    /// returned, so a request that never returns produced no output at
+    /// all. A stalled packument therefore showed the user nothing —
+    /// frozen progress bar, 0% CPU, silence — until `fetchTimeout`
+    /// expired minutes later. The pending set lets the ticker below
+    /// report the wait *while it is happening*.
+    pending: HashMap<u64, (String, Instant)>,
+    next_id: u64,
+    /// Whether the pending-request ticker is running. It stops itself
+    /// once `pending` drains, so an install with no slow fetches pays
+    /// nothing after its first metadata request completes.
+    ticker_armed: bool,
 }
 
 fn state() -> &'static Mutex<State> {
     static STATE: OnceLock<Mutex<State>> = OnceLock::new();
     STATE.get_or_init(|| Mutex::new(State::default()))
+}
+
+/// How often the pending-request ticker wakes. Also the spacing between
+/// "still waiting" lines, so a 60s stall produces about five of them —
+/// enough to show the elapsed time climbing, few enough not to bury the
+/// rest of the install output.
+const PENDING_TICK: Duration = Duration::from_secs(10);
+
+/// Fallback threshold when no `fetchWarnTimeoutMs` has been seen yet.
+/// Matches the setting's own default.
+const DEFAULT_THRESHOLD_MS: u64 = 10_000;
+
+/// Guard marking one metadata request as in flight. Drop it when the
+/// request finishes, succeeds or fails; [`begin`] returns it and the
+/// pending set is what the ticker reports from.
+#[must_use = "the request stays marked in-flight until this guard drops"]
+pub struct InFlight {
+    id: u64,
+}
+
+impl Drop for InFlight {
+    fn drop(&mut self) {
+        if let Ok(mut g) = state().lock() {
+            g.pending.remove(&self.id);
+        }
+    }
+}
+
+/// Mark `label` as in flight and make sure the ticker is running.
+///
+/// Pair this with the existing [`record`] call, which reports the same
+/// request once it has *finished*. The two answer different questions:
+/// `record` says "that was slow", `begin` is what lets nub say "this is
+/// still going" while the user is waiting on it.
+pub fn begin(label: &str, threshold_ms: u64) -> InFlight {
+    let id = {
+        let Ok(mut g) = state().lock() else {
+            return InFlight { id: u64::MAX };
+        };
+        let id = g.next_id;
+        g.next_id = g.next_id.wrapping_add(1);
+        g.pending.insert(id, (label.to_string(), Instant::now()));
+        if threshold_ms > 0 {
+            g.threshold_ms = threshold_ms;
+        }
+        id
+    };
+    arm_pending_ticker();
+    InFlight { id }
+}
+
+/// Start the ticker if it is not already running. Mirrors
+/// [`try_arm_flush_timer`]: a missing tokio runtime leaves the flag
+/// clear so the next [`begin`] retries the spawn.
+fn arm_pending_ticker() {
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+        return;
+    };
+    {
+        let Ok(mut g) = state().lock() else {
+            return;
+        };
+        if g.ticker_armed {
+            return;
+        }
+        g.ticker_armed = true;
+    }
+    handle.spawn(async move {
+        loop {
+            tokio::time::sleep(PENDING_TICK).await;
+            if !report_pending_once() {
+                break;
+            }
+        }
+        if let Ok(mut g) = state().lock() {
+            g.ticker_armed = false;
+        }
+    });
+}
+
+/// What the ticker found on one pass. `None` from [`pending_report`]
+/// means nothing is in flight at all, which is the ticker's stop
+/// condition; `over_threshold` being `None` means requests are in
+/// flight but none has waited long enough to be worth a line yet.
+struct PendingReport {
+    over_threshold: Option<(usize, String, Duration)>,
+}
+
+/// Pure half of [`report_pending_once`], split out so the selection
+/// logic — which requests count, and which one is named — is testable
+/// without a tokio runtime or a tracing subscriber.
+fn pending_report(now: Instant) -> Option<PendingReport> {
+    let g = state().lock().ok()?;
+    if g.pending.is_empty() {
+        return None;
+    }
+    let threshold = Duration::from_millis(if g.threshold_ms == 0 {
+        DEFAULT_THRESHOLD_MS
+    } else {
+        g.threshold_ms
+    });
+    let mut over = 0usize;
+    let mut longest_label = String::new();
+    let mut longest_wait = Duration::ZERO;
+    for (label, started) in g.pending.values() {
+        let waited = now.saturating_duration_since(*started);
+        if waited >= threshold {
+            over += 1;
+        }
+        if waited > longest_wait {
+            longest_wait = waited;
+            longest_label = label.clone();
+        }
+    }
+    Some(PendingReport {
+        over_threshold: (over > 0).then_some((over, longest_label, longest_wait)),
+    })
+}
+
+/// Emit one "still waiting" line if any in-flight request has been
+/// waiting longer than the threshold. Returns `false` once nothing is
+/// pending, which stops the ticker.
+fn report_pending_once() -> bool {
+    let Some(outcome) = pending_report(Instant::now()) else {
+        return false;
+    };
+    let PendingReport { over_threshold } = outcome;
+    let Some((count, label, waited)) = over_threshold else {
+        // Nothing over the threshold yet, but requests are still in
+        // flight — keep ticking.
+        return true;
+    };
+    // Names the package and the elapsed wait so a stalled install is
+    // legible while it is stalled, instead of only in hindsight.
+    tracing::warn!(
+        code = aube_codes::warnings::WARN_AUBE_SLOW_METADATA,
+        "still waiting on {count} registry metadata request{} (longest: {label}, {}s)",
+        if count == 1 { "" } else { "s" },
+        waited.as_secs(),
+    );
+    true
 }
 
 /// Record that `label` took `elapsed_ms` and exceeded `threshold_ms`
@@ -206,11 +365,36 @@ mod tests {
     use super::*;
 
     /// Process-global state plus parallel test execution means two
-    /// tests touching the accumulator can race. Serialize the whole
-    /// module under one test entry point so the cases run
-    /// deterministically.
+    /// tests touching the accumulator can race. Every test in this
+    /// module holds this lock for its duration, so the cases run
+    /// deterministically no matter how cargo schedules them.
+    ///
+    /// (Previously there was a single test and the comment said to keep
+    /// it that way. A lock is the cheaper constraint: it lets the
+    /// pending-request cases live in their own test without re-opening
+    /// the race.)
+    ///
+    /// Deliberately tokio's mutex, not `std`'s: these tests await, and a
+    /// `std` guard held across an await point is what
+    /// `clippy::await_holding_lock` exists to reject.
+    static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// Clear every field so a test starts from a known state
+    /// regardless of what ran before it.
+    fn reset_state() {
+        let mut g = state().lock().unwrap();
+        g.records.clear();
+        g.timer_armed = false;
+        g.generation = 0;
+        g.threshold_ms = 0;
+        g.pending.clear();
+        g.next_id = 0;
+        g.ticker_armed = false;
+    }
+
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn debounced_grouping_lifecycle() {
+        let _serial = TEST_LOCK.lock().await;
         // Reset state in case another test ran first.
         {
             let mut g = state().lock().unwrap();
@@ -297,6 +481,66 @@ mod tests {
         assert!(
             state().lock().unwrap().records.is_empty(),
             "new window's timer must drain its own records",
+        );
+    }
+
+    /// The in-flight side: what the user sees *while* a fetch is stuck.
+    /// Before this existed, a request that never returned produced no
+    /// output at all, because everything else here reports on requests
+    /// that have already finished.
+    #[tokio::test(flavor = "current_thread")]
+    async fn pending_report_names_the_longest_waiting_request() {
+        let _serial = TEST_LOCK.lock().await;
+        reset_state();
+
+        // Nothing in flight: the ticker's stop condition.
+        assert!(
+            pending_report(Instant::now()).is_none(),
+            "an empty pending set must stop the ticker",
+        );
+
+        let quick = begin("packument fast-pkg", 10_000);
+        let stuck = begin("packument stuck-pkg", 10_000);
+        let now = Instant::now();
+
+        // Both are young, so there is nothing worth telling the user
+        // yet — but the ticker must keep running.
+        let report = pending_report(now).expect("requests are in flight");
+        assert!(
+            report.over_threshold.is_none(),
+            "a request under the threshold must not produce a line",
+        );
+
+        // Age only the stuck one past the threshold.
+        {
+            let mut g = state().lock().unwrap();
+            let started = g
+                .pending
+                .values_mut()
+                .find(|(label, _)| label == "packument stuck-pkg")
+                .map(|(_, started)| started)
+                .expect("stuck request is registered");
+            *started = now - Duration::from_secs(45);
+        }
+
+        let report = pending_report(now).expect("requests are in flight");
+        let (count, label, waited) = report
+            .over_threshold
+            .expect("a request past the threshold must produce a line");
+        assert_eq!(count, 1, "only the aged request is over the threshold");
+        assert_eq!(
+            label, "packument stuck-pkg",
+            "the line must name the package the user is actually blocked on",
+        );
+        assert_eq!(waited.as_secs(), 45, "the line must report the real wait");
+
+        // Dropping the guards clears the set, which is what stops the
+        // ticker once an install recovers.
+        drop(quick);
+        drop(stuck);
+        assert!(
+            pending_report(Instant::now()).is_none(),
+            "dropping every guard must stop the ticker",
         );
     }
 }

--- a/vendor/aube/crates/aube-registry/src/slow_metadata.rs
+++ b/vendor/aube/crates/aube-registry/src/slow_metadata.rs
@@ -193,9 +193,11 @@ struct PendingReport {
     over_threshold: Option<(usize, String, Duration)>,
 }
 
-/// Pure half of [`report_pending_once`], split out so the selection
-/// logic — which requests count, and which one is named — is testable
-/// without a tokio runtime or a tracing subscriber.
+/// Selection half of [`report_pending_once`]: decides which requests
+/// count and which one gets named, split out so that logic is testable
+/// without a tokio runtime or a tracing subscriber. It is not pure — it
+/// owns one state write, described next, which is why the split is here
+/// and not at the lock boundary.
 ///
 /// Returning `None` also CLEARS `ticker_armed`, under the same lock that
 /// observed the empty set. That atomicity is load-bearing: with the two

--- a/vendor/aube/crates/aube-registry/src/slow_metadata.rs
+++ b/vendor/aube/crates/aube-registry/src/slow_metadata.rs
@@ -103,22 +103,24 @@ fn state() -> &'static Mutex<State> {
 /// rest of the install output.
 const PENDING_TICK: Duration = Duration::from_secs(10);
 
-/// Fallback threshold when no `fetchWarnTimeoutMs` has been seen yet.
-/// Matches the setting's own default.
-const DEFAULT_THRESHOLD_MS: u64 = 10_000;
-
 /// Guard marking one metadata request as in flight. Drop it when the
 /// request finishes, succeeds or fails; [`begin`] returns it and the
 /// pending set is what the ticker reports from.
+///
+/// `id` is `None` when `fetchWarnTimeoutMs` is `0`: the guard is inert
+/// and nothing was registered, so the disabled setting costs nothing.
 #[must_use = "the request stays marked in-flight until this guard drops"]
 pub struct InFlight {
-    id: u64,
+    id: Option<u64>,
 }
 
 impl Drop for InFlight {
     fn drop(&mut self) {
+        let Some(id) = self.id else {
+            return;
+        };
         if let Ok(mut g) = state().lock() {
-            g.pending.remove(&self.id);
+            g.pending.remove(&id);
         }
     }
 }
@@ -129,21 +131,29 @@ impl Drop for InFlight {
 /// request once it has *finished*. The two answer different questions:
 /// `record` says "that was slow", `begin` is what lets nub say "this is
 /// still going" while the user is waiting on it.
+///
+/// `threshold_ms == 0` is `fetchWarnTimeoutMs`'s documented "disable the
+/// warning entirely", and it disables this line too. Gating at the
+/// boundary rather than at the emit site is what makes that airtight: a
+/// ticker can then never be running without having seen a real
+/// threshold, so there is no default to fall back to and no way for the
+/// disabled setting to produce a line every 10s.
 pub fn begin(label: &str, threshold_ms: u64) -> InFlight {
+    if threshold_ms == 0 {
+        return InFlight { id: None };
+    }
     let id = {
         let Ok(mut g) = state().lock() else {
-            return InFlight { id: u64::MAX };
+            return InFlight { id: None };
         };
         let id = g.next_id;
         g.next_id = g.next_id.wrapping_add(1);
         g.pending.insert(id, (label.to_string(), Instant::now()));
-        if threshold_ms > 0 {
-            g.threshold_ms = threshold_ms;
-        }
+        g.threshold_ms = threshold_ms;
         id
     };
     arm_pending_ticker();
-    InFlight { id }
+    InFlight { id: Some(id) }
 }
 
 /// Start the ticker if it is not already running. Mirrors
@@ -163,14 +173,14 @@ fn arm_pending_ticker() {
         g.ticker_armed = true;
     }
     handle.spawn(async move {
-        loop {
+        // The stop decision and the `ticker_armed` clear happen together
+        // inside `report_pending_once`, under one lock. Splitting them
+        // would let a `begin` land in between, see the flag still set,
+        // skip the spawn, and then be left pending with no ticker — a
+        // stall reported by nobody, which is the exact failure this
+        // module exists to remove.
+        while report_pending_once() {
             tokio::time::sleep(PENDING_TICK).await;
-            if !report_pending_once() {
-                break;
-            }
-        }
-        if let Ok(mut g) = state().lock() {
-            g.ticker_armed = false;
         }
     });
 }
@@ -186,16 +196,22 @@ struct PendingReport {
 /// Pure half of [`report_pending_once`], split out so the selection
 /// logic — which requests count, and which one is named — is testable
 /// without a tokio runtime or a tracing subscriber.
+///
+/// Returning `None` also CLEARS `ticker_armed`, under the same lock that
+/// observed the empty set. That atomicity is load-bearing: with the two
+/// split, a `begin` could insert between them, see the flag still set,
+/// decline to spawn, and be left with no ticker watching it. Same shape
+/// as [`drain_window_if_current`], which already pairs its decision and
+/// its flag write this way.
 fn pending_report(now: Instant) -> Option<PendingReport> {
-    let g = state().lock().ok()?;
+    let mut g = state().lock().ok()?;
     if g.pending.is_empty() {
+        g.ticker_armed = false;
         return None;
     }
-    let threshold = Duration::from_millis(if g.threshold_ms == 0 {
-        DEFAULT_THRESHOLD_MS
-    } else {
-        g.threshold_ms
-    });
+    // `begin` refuses to register anything when the threshold is 0, so a
+    // non-empty pending set implies a real threshold was recorded.
+    let threshold = Duration::from_millis(g.threshold_ms);
     let mut over = 0usize;
     let mut longest_label = String::new();
     let mut longest_wait = Duration::ZERO;
@@ -216,7 +232,7 @@ fn pending_report(now: Instant) -> Option<PendingReport> {
 
 /// Emit one "still waiting" line if any in-flight request has been
 /// waiting longer than the threshold. Returns `false` once nothing is
-/// pending, which stops the ticker.
+/// pending, having cleared `ticker_armed` in the same critical section.
 fn report_pending_once() -> bool {
     let Some(outcome) = pending_report(Instant::now()) else {
         return false;
@@ -541,6 +557,55 @@ mod tests {
         assert!(
             pending_report(Instant::now()).is_none(),
             "dropping every guard must stop the ticker",
+        );
+    }
+
+    /// `fetchWarnTimeoutMs = 0` is documented as disabling the warning
+    /// entirely. It has to disable the in-flight line too — otherwise
+    /// turning the warning off would turn on a line every 10s, which is
+    /// the opposite of what the setting says.
+    #[tokio::test(flavor = "current_thread")]
+    async fn zero_threshold_registers_nothing() {
+        let _serial = TEST_LOCK.lock().await;
+        reset_state();
+
+        let disabled = begin("packument whatever", 0);
+        assert!(
+            state().lock().unwrap().pending.is_empty(),
+            "a disabled threshold must not register an in-flight request",
+        );
+        assert!(
+            !state().lock().unwrap().ticker_armed,
+            "a disabled threshold must not arm the ticker",
+        );
+        assert!(
+            pending_report(Instant::now()).is_none(),
+            "a disabled threshold must produce no report",
+        );
+        drop(disabled);
+    }
+
+    /// The ticker's stop condition and its `ticker_armed` clear must
+    /// happen together. Split across two lock acquisitions, a `begin`
+    /// landing between them would see the flag still set, skip the
+    /// spawn, and be left with nothing watching it.
+    #[tokio::test(flavor = "current_thread")]
+    async fn emptying_the_pending_set_clears_the_armed_flag() {
+        let _serial = TEST_LOCK.lock().await;
+        reset_state();
+        state().lock().unwrap().ticker_armed = true;
+
+        let guard = begin("packument solo", 10_000);
+        assert!(state().lock().unwrap().ticker_armed);
+        drop(guard);
+
+        assert!(
+            pending_report(Instant::now()).is_none(),
+            "an empty pending set stops the ticker",
+        );
+        assert!(
+            !state().lock().unwrap().ticker_armed,
+            "the same critical section that saw the empty set must clear the flag",
         );
     }
 }

--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -1952,10 +1952,9 @@ Applies to the wait for response headers as well as to the body, so a
 connection that is accepted and then never answered fails here too. Set
 to `0` to disable and rely on `fetchTimeout` alone.
 """
-sources.cli = ["fetch-stall-timeout"]
 sources.env = ["AUBE_FETCH_STALL_TIMEOUT"]
 sources.npmrc = ["fetch-stall-timeout", "fetchStallTimeout"]
-examples = ["aube install --fetch-stall-timeout=15000"]
+examples = []
 
 [fetchWarnTimeoutMs]
 description = "Warn if a metadata request exceeds this threshold (ms)."

--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -1936,6 +1936,27 @@ sources.npmrc = ["fetch-timeout", "fetchTimeout"]
 examples = ["aube add lodash --fetch-timeout=60000"]
 npmShared = true
 
+[fetchStallTimeout]
+description = "Fail a request that delivers no data for this long (ms)."
+type = "int"
+default = "60000"
+docs = """
+Idle timeout, applied via `reqwest`'s `.read_timeout()`. The clock
+resets on every chunk the registry delivers, so a large-but-progressing
+response is never cut off; only a connection that goes *silent* trips
+it. This is the bound that matters in practice, because `fetchTimeout`
+is a whole-request budget and a stalled stream burns all 5 minutes of
+it before anything fails.
+
+Applies to the wait for response headers as well as to the body, so a
+connection that is accepted and then never answered fails here too. Set
+to `0` to disable and rely on `fetchTimeout` alone.
+"""
+sources.cli = ["fetch-stall-timeout"]
+sources.env = ["AUBE_FETCH_STALL_TIMEOUT"]
+sources.npmrc = ["fetch-stall-timeout", "fetchStallTimeout"]
+examples = ["aube install --fetch-stall-timeout=15000"]
+
 [fetchWarnTimeoutMs]
 description = "Warn if a metadata request exceeds this threshold (ms)."
 type = "int"

--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -1952,7 +1952,7 @@ Applies to the wait for response headers as well as to the body, so a
 connection that is accepted and then never answered fails here too. Set
 to `0` to disable and rely on `fetchTimeout` alone.
 """
-sources.env = ["AUBE_FETCH_STALL_TIMEOUT"]
+sources.env = ["npm_config_fetch_stall_timeout", "NPM_CONFIG_FETCH_STALL_TIMEOUT", "AUBE_FETCH_STALL_TIMEOUT"]
 sources.npmrc = ["fetch-stall-timeout", "fetchStallTimeout"]
 examples = []
 


### PR DESCRIPTION
Closes #715

An install froze mid-resolve at 0% CPU with no output when a registry connection was accepted and then went silent. Three defects on the packument path, measured against a registry that accepts a connection and never answers.

## Nothing bounded a stalled stream

The `fetchTimeout` setting is a whole-request budget, and there was no idle bound, so a silent stream burned all 5 minutes of it before anything failed. Adds `fetchStallTimeout` (default 60000, `0` disables), applied via reqwest's `read_timeout`. That clock resets on every delivered frame, so a large-but-progressing packument is never cut off, and it also gates the wait for response headers — a socket that is accepted and never answered fails on it too.

## The timeout cap never reached the packument path

`TIMEOUT_RETRY_CAP` was applied in the two tarball helpers in `request.rs` and in none of the four copied retry loops in `packument.rs`, so a stalled packument spent the whole attempt budget.

| | before | after |
|---|---|---|
| attempts against a silent registry | 3 × 300s | 60s + 1 retry |
| wall-clock before an error | 970s | ~130s |

All twelve retry arms now route through a new `retry_policy` module, so the cap, the backoff and the wording cannot drift per call site again.

## A stall produced no output

The `slow_metadata::record` call runs only after a request returns, so a request that never returned printed nothing at all. In-flight metadata requests are now tracked, and a ticker reports them every 10s:

```
WARN still waiting on 9 registry metadata requests (longest: packument @prisma/client, 40s)
WARN packument playwright: response body could not be read — retrying in 10s (attempt 2 of 3)
```

## Verification

- 296 `aube-registry` tests pass. Three new ones cover the retry cap, the idle bound, and a positive control that a slow-but-progressing response is not cut off.
- Reverting the timeout classification makes the cap test fail with 6 attempts, which is the pre-fix behavior.
- clippy `--all-targets --all-features -D warnings` and `cargo fmt --check` pass in both workspaces.
- Driven end-to-end against the reporter's repro tree through a proxy that stalls a packument mid-body.

Also corrects a comment claiming the `fetchTimeout` default matches npm's 60s; it is 300000.
