### PR TITLE
fix(pm): tolerate optional-only build failures

### DIFF
--- a/vendor/aube/crates/aube-codes/src/warnings.rs
+++ b/vendor/aube/crates/aube-codes/src/warnings.rs
@@ -19,6 +19,7 @@ pub const WARN_AUBE_HOOK_PACKAGE_ADDED: &str = "WARN_AUBE_HOOK_PACKAGE_ADDED";
 // ── install lifecycle ───────────────────────────────────────────────
 pub const WARN_AUBE_IGNORED_BUILD_SCRIPTS: &str = "WARN_AUBE_IGNORED_BUILD_SCRIPTS";
 pub const WARN_AUBE_DEFAULT_TRUST_BUILDS: &str = "WARN_AUBE_DEFAULT_TRUST_BUILDS";
+pub const WARN_AUBE_OPTIONAL_BUILD_FAILED: &str = "WARN_AUBE_OPTIONAL_BUILD_FAILED";
 #[rustfmt::skip] pub const WARN_AUBE_NODE_GYP_BOOTSTRAP_FAILED: &str = "WARN_AUBE_NODE_GYP_BOOTSTRAP_FAILED";
 #[rustfmt::skip] pub const WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT: &str = "WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT";
 #[rustfmt::skip] pub const WARN_AUBE_WINDOWS_JOB_OBJECT_UNAVAILABLE: &str = "WARN_AUBE_WINDOWS_JOB_OBJECT_UNAVAILABLE";
@@ -203,6 +204,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_DEFAULT_TRUST_BUILDS,
         category: category::INSTALL_LIFECYCLE,
         description: "The `defaultTrust` floor let listed packages run build scripts without an explicit `allowBuilds` entry. Disclosure, not an error — set `defaultTrust=false` or an explicit `allowBuilds: false` entry to opt out.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_OPTIONAL_BUILD_FAILED,
+        category: category::INSTALL_LIFECYCLE,
+        description: "An optional-only dependency's permitted lifecycle script failed. The failure is reported, but the install continues because no required dependency path needs that package.",
         exit_code: None,
     },
     CodeMeta {

--- a/vendor/aube/crates/aube-resolver/src/platform.rs
+++ b/vendor/aube/crates/aube-resolver/src/platform.rs
@@ -374,6 +374,21 @@ pub fn filter_graph(
 /// package required even when other paths to it are optional, matching
 /// pnpm.
 pub fn mark_optional_packages(graph: &mut aube_lockfile::LockfileGraph) {
+    let optional = optional_only_packages(graph);
+    for (dep_path, pkg) in graph.packages.iter_mut() {
+        pkg.optional = optional.contains(dep_path);
+    }
+}
+
+/// Return the packages reachable only through optional dependency edges.
+///
+/// This derives optionality from the graph instead of
+/// [`aube_lockfile::LockedPackage::optional`]. The stamped field is available
+/// on pnpm lockfiles and freshly resolved graphs, but frozen npm, Bun, and Yarn
+/// installs still need the same lifecycle semantics.
+pub fn optional_only_packages(
+    graph: &aube_lockfile::LockfileGraph,
+) -> aube_util::collections::FxSet<String> {
     use crate::FxHashSet;
     use aube_lockfile::DepType;
 
@@ -410,9 +425,12 @@ pub fn mark_optional_packages(graph: &mut aube_lockfile::LockfileGraph) {
             }
         }
     }
-    for (dep_path, pkg) in graph.packages.iter_mut() {
-        pkg.optional = !required.contains(dep_path);
-    }
+    graph
+        .packages
+        .keys()
+        .filter(|dep_path| !required.contains(*dep_path))
+        .cloned()
+        .collect()
 }
 
 /// Populate each package's `transitive_peer_dependencies` the way pnpm
@@ -748,6 +766,35 @@ mod tests {
         assert!(is_opt("native-linux@1.0.0"));
         // Direct optional importer dep with no required path → optional.
         assert!(is_opt("opt-root@1.0.0"));
+    }
+
+    #[test]
+    fn optional_only_packages_uses_edges_when_flags_are_unset() {
+        use aube_lockfile::DepType;
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.importers.insert(
+            ".".to_string(),
+            vec![
+                dep("host", DepType::Production),
+                dep("also-required", DepType::Production),
+            ],
+        );
+        graph.packages.extend([
+            pkg("host", &["native", "dual"], &["native", "dual"]),
+            pkg("also-required", &["dual"], &[]),
+            pkg("native", &["native-child"], &[]),
+            pkg("native-child", &[], &[]),
+            pkg("dual", &[], &[]),
+        ]);
+        assert!(graph.packages.values().all(|pkg| !pkg.optional));
+
+        let optional = optional_only_packages(&graph);
+
+        assert!(optional.contains("native@1.0.0"));
+        assert!(optional.contains("native-child@1.0.0"));
+        assert!(!optional.contains("dual@1.0.0"));
+        assert!(!optional.contains("host@1.0.0"));
+        assert!(!optional.contains("also-required@1.0.0"));
     }
 
     fn pkg_with_peers(

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -430,6 +430,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         package_dir: std::path::PathBuf,
         manifest: aube_manifest::PackageJson,
         cache_entry: Option<SideEffectsCacheEntry>,
+        dep_path: String,
     }
 
     let mut jobs: Vec<BuildJob> = Vec::new();
@@ -559,12 +560,19 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             package_dir,
             manifest: dep_manifest,
             cache_entry,
+            dep_path: dep_path.clone(),
         });
     }
 
     if jobs.is_empty() {
         return Ok(0);
     }
+
+    // Derive this from graph edges rather than `LockedPackage::optional`.
+    // Frozen installs from npm, Bun, and Yarn lockfiles do not consistently
+    // stamp that pnpm snapshot field, but their graph still carries the
+    // optional edges needed to make the same decision.
+    let optional_only = aube_resolver::platform::optional_only_packages(graph);
 
     // Name what the floor let through — the floor must never be a
     // silent allow path. One line, not per-package, so big graphs
@@ -659,6 +667,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         let modules_dir_name = modules_dir_name.clone();
         let node_gyp_bin_dir = node_gyp_bin_dir.clone();
         let jail_policy = jail_policy.clone();
+        let job_optional = optional_only.contains(&job.dep_path);
         let task = crate::dep_chain::scope_current(async move {
             let _permit = sem.acquire().await.unwrap();
             if should_restore_side_effects_cache && let Some(cache_entry) = job.cache_entry.clone()
@@ -729,7 +738,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             let _jail_home_cleanup = jail.as_ref().map(aube_scripts::ScriptJailHomeCleanup::new);
             let mut ran_here = 0usize;
             for hook in aube_scripts::DEP_LIFECYCLE_HOOKS {
-                let did_run = aube_scripts::run_dep_hook(
+                let did_run = match aube_scripts::run_dep_hook(
                     &job.package_dir,
                     &project_dir,
                     &modules_dir_name,
@@ -739,15 +748,27 @@ pub(crate) async fn run_dep_lifecycle_scripts(
                     jail.as_ref(),
                 )
                 .await
-                .map_err(|e| {
-                    miette!(
-                        "lifecycle script {} failed for {}@{}: {}",
-                        hook.script_name(),
-                        job.name,
-                        job.version,
-                        e
-                    )
-                })?;
+                {
+                    Ok(did_run) => did_run,
+                    Err(error) if job_optional => {
+                        tracing::warn!(
+                            code = aube_codes::warnings::WARN_AUBE_OPTIONAL_BUILD_FAILED,
+                            package = %format!("{}@{}", job.name, job.version),
+                            hook = hook.script_name(),
+                            "optional dependency build failed; continuing install: {error}"
+                        );
+                        return Ok(ran_here);
+                    }
+                    Err(error) => {
+                        return Err(miette!(
+                            "lifecycle script {} failed for {}@{}: {}",
+                            hook.script_name(),
+                            job.name,
+                            job.version,
+                            error
+                        ));
+                    }
+                };
                 if did_run {
                     tracing::debug!(
                         "ran {} for {}@{}",

--- a/vendor/aube/crates/aube/tests/e2e.rs
+++ b/vendor/aube/crates/aube/tests/e2e.rs
@@ -251,6 +251,135 @@ fn run_failing_pre_script_short_circuits_with_its_code() {
 }
 
 #[test]
+fn approve_builds_tolerates_an_optional_dependency_build_failure() {
+    let _guard = e2e_lock();
+    let sbx = Sandbox::new();
+    sbx.write_file(
+        "required-dep/package.json",
+        r#"{
+            "name": "required-build",
+            "version": "1.0.0",
+            "scripts": { "install": "node -e \"require('fs').writeFileSync('REQUIRED_BUILT_MARKER','ok')\"" }
+        }"#,
+    );
+    sbx.write_file(
+        "optional-dep/package.json",
+        r#"{
+            "name": "optional-failing-build",
+            "version": "1.0.0",
+            "scripts": { "install": "node -e \"process.exit(19)\"" }
+        }"#,
+    );
+    sbx.write_manifest(
+        r#"{
+            "name": "e2e-optional-build-failure",
+            "version": "0.0.0",
+            "dependencies": { "required-build": "file:./required-dep" },
+            "optionalDependencies": { "optional-failing-build": "file:./optional-dep" }
+        }"#,
+    );
+
+    sbx.cmd()
+        .arg("install")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains(
+            "optional-failing-build@file:./optional-dep",
+        ));
+
+    sbx.cmd()
+        .args(["approve-builds", "--all"])
+        .assert()
+        .success()
+        .stderr(predicates::str::contains(
+            aube_codes::warnings::WARN_AUBE_OPTIONAL_BUILD_FAILED,
+        ));
+    assert!(
+        marker_exists_under(&sbx.project.join("node_modules"), "REQUIRED_BUILT_MARKER"),
+        "a required sibling's build must complete after an optional build fails"
+    );
+
+    sbx.cmd()
+        .arg("ignored-builds")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("No ignored builds"));
+}
+
+#[test]
+fn install_fails_when_the_same_build_is_required() {
+    let _guard = e2e_lock();
+    let sbx = Sandbox::new();
+    sbx.write_file(
+        "required-dep/package.json",
+        r#"{
+            "name": "required-failing-build",
+            "version": "1.0.0",
+            "scripts": { "install": "node -e \"process.exit(19)\"" }
+        }"#,
+    );
+    sbx.write_manifest(
+        r#"{
+            "name": "e2e-required-build-failure",
+            "version": "0.0.0",
+            "dependencies": { "required-failing-build": "file:./required-dep" }
+        }"#,
+    );
+
+    sbx.cmd()
+        .args(["install", "--dangerously-allow-all-builds"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "lifecycle script install failed for required-failing-build@1.0.0",
+        ))
+        .stderr(
+            predicates::str::contains(aube_codes::warnings::WARN_AUBE_OPTIONAL_BUILD_FAILED).not(),
+        );
+}
+
+#[test]
+fn install_fails_when_an_optional_dependency_also_has_a_required_path() {
+    let _guard = e2e_lock();
+    let sbx = Sandbox::new();
+    sbx.write_file(
+        "required-parent/package.json",
+        r#"{
+            "name": "required-parent",
+            "version": "1.0.0",
+            "dependencies": { "dual-path-build": "file:../dual-path" }
+        }"#,
+    );
+    sbx.write_file(
+        "dual-path/package.json",
+        r#"{
+            "name": "dual-path-build",
+            "version": "1.0.0",
+            "scripts": { "install": "node -e \"process.exit(19)\"" }
+        }"#,
+    );
+    sbx.write_manifest(
+        r#"{
+            "name": "e2e-dual-path-build-failure",
+            "version": "0.0.0",
+            "dependencies": { "required-parent": "file:./required-parent" },
+            "optionalDependencies": { "dual-path-build": "file:./dual-path" }
+        }"#,
+    );
+
+    sbx.cmd()
+        .args(["install", "--dangerously-allow-all-builds"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "lifecycle script install failed for dual-path-build@1.0.0",
+        ))
+        .stderr(
+            predicates::str::contains(aube_codes::warnings::WARN_AUBE_OPTIONAL_BUILD_FAILED).not(),
+        );
+}
+
+#[test]
 fn approve_builds_surfaces_and_runs_a_local_source_dep() {
     // Regression for the `file:`-dep approve-builds dead-end: install
     // warns about a local-source dependency's build script, but


### PR DESCRIPTION
## Summary

- Continue an install when an approved lifecycle script fails for a package reachable only through optional dependency edges.
- Derive optionality from the dependency graph so frozen npm, Bun, and Yarn lockfiles behave the same as fresh resolutions.
- Keep failures fatal when the package has any required path, and report skipped builds through `WARN_NUB_OPTIONAL_BUILD_FAILED`.

## Verification

- `XDG_CONFIG_HOME=$(mktemp -d) make verify`
- `cd vendor/aube && cargo test -p aube --test e2e`
- Built `target/fast/nub` and verified both optional-only and required sibling builds in a clean fixture.
- Installed and approved `@bahmutov/add-typescript-to-cypress@2.1.2` in a clean hoisted consumer fixture; the published postinstall created both Cypress plugin files.
