### PR TITLE
fix(pm): order dependency lifecycle builds

### DIFF
--- a/vendor/aube/crates/aube-settings/settings.toml
+++ b/vendor/aube/crates/aube-settings/settings.toml
@@ -2366,7 +2366,10 @@ type = "int"
 default = "5"
 docs = """
 Caps how many dependency lifecycle scripts run in parallel during the
-post-link `allowBuilds` phase. Inside a single package the
+post-link `allowBuilds` phase. Builds run in children-first dependency
+phases — a package's build waits for the builds it depends on — so the
+cap applies within one phase rather than across the whole graph.
+Inside a single package the
 `preinstall` / `install` / `postinstall` hooks still run sequentially
 — pnpm's execution model is "at most N packages building in
 parallel," not "at most N scripts running." Defaults to 5, matching

--- a/vendor/aube/crates/aube/src/commands/install/delta.rs
+++ b/vendor/aube/crates/aube/src/commands/install/delta.rs
@@ -397,6 +397,114 @@ fn tarjan_scc(graph: &LockfileGraph) -> Vec<Vec<String>> {
     out
 }
 
+/// Group selected dependency builds into children-first phases.
+///
+/// The graph walk includes non-building packages only when they connect two
+/// selected builds: if `parent -> bridge -> child` and only parent/child have
+/// lifecycle scripts, child still has to finish before parent starts. An
+/// unrelated non-building child does not delay its parent. Strongly connected
+/// components collapse dependency cycles into one phase, matching pnpm's
+/// graph sequencer rather than deadlocking on a cycle.
+///
+/// Every member of `selected` that is a key of `graph.packages` appears in
+/// exactly one returned phase — `lifecycle`'s per-job phase lookup is an
+/// `expect` on that. A phase carrying no selected build is dropped rather than
+/// emitted empty, so an index into the result is a position in this sequence,
+/// not a graph depth.
+pub(super) fn dependency_build_phases(
+    graph: &LockfileGraph,
+    selected: &BTreeSet<String>,
+) -> Vec<Vec<String>> {
+    let mut components = tarjan_scc(graph);
+    for members in &mut components {
+        members.sort();
+    }
+
+    let mut component_by_path = BTreeMap::new();
+    for (index, members) in components.iter().enumerate() {
+        for dep_path in members {
+            component_by_path.insert(dep_path.as_str(), index);
+        }
+    }
+
+    // Edges point parent -> child. A component becomes ready only after all
+    // child components have drained, so Kahn's algorithm emits leaves first.
+    let mut children = vec![BTreeSet::new(); components.len()];
+    let mut parents = vec![BTreeSet::new(); components.len()];
+    for (dep_path, package) in &graph.packages {
+        let Some(&parent) = component_by_path.get(dep_path.as_str()) else {
+            continue;
+        };
+        for (child_name, child_tail) in &package.dependencies {
+            let Some(child_path) = aube_lockfile::resolve_dep_edge(child_name, child_tail, |key| {
+                graph.packages.contains_key(key)
+            }) else {
+                continue;
+            };
+            let Some(&child) = component_by_path.get(child_path.as_str()) else {
+                continue;
+            };
+            if parent != child && children[parent].insert(child) {
+                parents[child].insert(parent);
+            }
+        }
+    }
+
+    // pnpm sequences only packages that build and the ancestors connecting
+    // them. Starting at selected components and walking toward parents gives
+    // that same projection without letting unrelated graph depth serialize
+    // independent builds.
+    let mut relevant = BTreeSet::new();
+    let mut pending: Vec<usize> = selected
+        .iter()
+        .filter_map(|dep_path| component_by_path.get(dep_path.as_str()).copied())
+        .collect();
+    while let Some(component) = pending.pop() {
+        if relevant.insert(component) {
+            pending.extend(parents[component].iter().copied());
+        }
+    }
+
+    let mut remaining_children: Vec<usize> = children
+        .iter()
+        .map(|component_children| {
+            component_children
+                .iter()
+                .filter(|child| relevant.contains(child))
+                .count()
+        })
+        .collect();
+    let mut ready: BTreeSet<usize> = relevant
+        .iter()
+        .copied()
+        .filter(|index| remaining_children[*index] == 0)
+        .collect();
+    let mut phases = Vec::new();
+    while !ready.is_empty() {
+        let current = std::mem::take(&mut ready);
+        let mut selected_here = Vec::new();
+        for component in current {
+            selected_here.extend(
+                components[component]
+                    .iter()
+                    .filter(|dep_path| selected.contains(*dep_path))
+                    .cloned(),
+            );
+            for &parent in &parents[component] {
+                remaining_children[parent] -= 1;
+                if remaining_children[parent] == 0 {
+                    ready.insert(parent);
+                }
+            }
+        }
+        selected_here.sort();
+        if !selected_here.is_empty() {
+            phases.push(selected_here);
+        }
+    }
+    phases
+}
+
 fn dfs_post(start: usize, edges: &[BTreeSet<usize>], seen: &mut [bool], order: &mut Vec<usize>) {
     if seen[start] {
         return;
@@ -1044,5 +1152,54 @@ mod tests {
         let hashes = csh(&g);
         assert_eq!(hashes.len(), 2);
         assert_eq!(hashes["a@1"], hashes["b@1"]);
+    }
+
+    #[test]
+    fn build_phases_wait_through_non_building_intermediaries() {
+        let graph = graph_of(&[
+            pkg_with_deps("parent", "1", &[("bridge", "1"), ("unused", "1")]),
+            pkg_with_deps("bridge", "1", &[("child", "1")]),
+            pkg("child", "1"),
+            pkg("unused", "1"),
+            pkg("independent", "1"),
+        ]);
+        let selected = [
+            "parent@1".to_string(),
+            "child@1".to_string(),
+            "independent@1".to_string(),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(
+            dependency_build_phases(&graph, &selected),
+            vec![
+                vec!["child@1".to_string(), "independent@1".to_string()],
+                vec!["parent@1".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn build_phases_keep_independent_jobs_parallel_and_cycles_live() {
+        let graph = graph_of(&[
+            pkg_with_deps("parent", "1", &[("left", "1"), ("right", "1")]),
+            pkg_with_deps("left", "1", &[("right", "1")]),
+            pkg_with_deps("right", "1", &[("left", "1")]),
+            pkg("independent", "1"),
+        ]);
+        let selected = graph.packages.keys().cloned().collect();
+
+        assert_eq!(
+            dependency_build_phases(&graph, &selected),
+            vec![
+                vec![
+                    "independent@1".to_string(),
+                    "left@1".to_string(),
+                    "right@1".to_string(),
+                ],
+                vec!["parent@1".to_string()],
+            ]
+        );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -465,9 +465,12 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         package_dir: std::path::PathBuf,
         manifest: aube_manifest::PackageJson,
         cache_entry: Option<SideEffectsCacheEntry>,
-        /// Graph key, kept so the optional-only classification below resolves
-        /// per job without re-walking the graph.
+        /// Graph key, kept so the optional-only classification and the
+        /// build-phase assignment below resolve per job without re-walking
+        /// the graph.
         dep_path: String,
+        /// Children-first build phase, filled in once every job is known.
+        phase: usize,
     }
 
     let mut jobs: Vec<BuildJob> = Vec::new();
@@ -634,6 +637,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             manifest: dep_manifest,
             cache_entry,
             dep_path: dep_path.clone(),
+            phase: 0,
         });
     }
 
@@ -654,6 +658,20 @@ pub(crate) async fn run_dep_lifecycle_scripts(
     // this silently inert on a frozen install off an npm/bun/yarn lockfile.
     // A package with even one fully-required path stays required.
     let optional_only = aube_resolver::platform::optional_only_packages(graph);
+
+    let selected: std::collections::BTreeSet<String> =
+        jobs.iter().map(|job| job.dep_path.clone()).collect();
+    let phases = super::delta::dependency_build_phases(graph, &selected);
+    let phase_by_path: std::collections::BTreeMap<&str, usize> = phases
+        .iter()
+        .enumerate()
+        .flat_map(|(phase, paths)| paths.iter().map(move |path| (path.as_str(), phase)))
+        .collect();
+    for job in &mut jobs {
+        job.phase = *phase_by_path
+            .get(job.dep_path.as_str())
+            .expect("every selected lifecycle job must have a build phase");
+    }
 
     // Name what the floor let through — the floor must never be a
     // silent allow path. One line, not per-package, so big graphs
@@ -718,12 +736,16 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         node_gyp_bootstrap::lazy_shim_bin_dir(&project_bin_dir)?
     });
 
-    // Pass 2 (parallel, bounded): fan out across `child_concurrency`
-    // concurrent workers. Inside one job the three hooks
-    // (preinstall → install → postinstall) still run sequentially —
-    // pnpm's execution model is "at most N packages building in
-    // parallel," not "at most N scripts running," so hook ordering
-    // within a single package is preserved.
+    // Pass 2 (dependency-ordered, parallel within each phase): all jobs are
+    // registered up front so the existing first-error cancellation stays
+    // intact, but a job does not start until every EARLIER phase has fully
+    // drained, which is what puts a dependency's build ahead of its consumer's.
+    // Jobs within one phase stay bounded by `child_concurrency`, and inside one
+    // job the three hooks (preinstall → install → postinstall) still run
+    // sequentially — pnpm's execution model is "at most N packages building in
+    // parallel," not "at most N scripts running." pnpm sequences the same way:
+    // `buildSequence` chunks the build subgraph and `runGroups` runs one chunk
+    // at a time under `childConcurrency`.
     //
     // Cancellation on first failure uses `JoinSet`, which aborts every
     // outstanding task when it's dropped. A plain `Vec<JoinHandle>`
@@ -735,6 +757,34 @@ pub(crate) async fn run_dep_lifecycle_scripts(
     // waiting for the longest-running one to finish.
     let concurrency = child_concurrency.max(1);
     let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency));
+    let (phase_tx, phase_rx) = tokio::sync::watch::channel(0usize);
+    let phase_remaining = std::sync::Arc::new(
+        phases
+            .iter()
+            .map(|phase| std::sync::atomic::AtomicUsize::new(phase.len()))
+            .collect::<Vec<_>>(),
+    );
+    // The gate has to open on EVERY exit path a job can take, which is why
+    // this is a drop guard rather than a decrement at the end of the task
+    // body. An optional-only package whose build fails is tolerated by the
+    // drain loop below, so a success-only decrement would leave that phase's
+    // counter above zero and every later phase parked on the watch channel
+    // forever — a hang, not a failure. The early returns from a
+    // side-effects-cache hit and the `?` on every fallible step are the same
+    // shape. A phase-k guard only comes into existence once the gate has
+    // already reached k, so the sends stay monotonic.
+    struct PhaseGuard {
+        remaining: std::sync::Arc<Vec<std::sync::atomic::AtomicUsize>>,
+        tx: tokio::sync::watch::Sender<usize>,
+        phase: usize,
+    }
+    impl Drop for PhaseGuard {
+        fn drop(&mut self) {
+            if self.remaining[self.phase].fetch_sub(1, std::sync::atomic::Ordering::AcqRel) == 1 {
+                let _ = self.tx.send(self.phase + 1);
+            }
+        }
+    }
     let project_dir = project_dir.to_path_buf();
     let modules_dir_name = modules_dir_name.to_string();
     let should_restore_side_effects_cache = side_effects_cache.should_restore();
@@ -754,7 +804,23 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         let jail_policy = jail_policy.clone();
         let job_optional = optional_only.contains(&job.dep_path);
         let job_spec = format!("{}@{}", job.name, job.version);
+        let phase_tx = phase_tx.clone();
+        let mut phase_rx = phase_rx.clone();
+        let phase_remaining = phase_remaining.clone();
         let task = crate::dep_chain::scope_current(async move {
+            // The task owns a `phase_tx` clone until the guard below takes it,
+            // so `changed()` can never see every sender dropped and the error
+            // arm is unreachable. Keep it that way: an error here returns
+            // BEFORE the guard exists, and for an optional-only package the
+            // drain loop tolerates that — which would park every later phase.
+            while *phase_rx.borrow_and_update() < job.phase {
+                phase_rx.changed().await.into_diagnostic()?;
+            }
+            let _phase_guard = PhaseGuard {
+                remaining: phase_remaining,
+                tx: phase_tx,
+                phase: job.phase,
+            };
             let _permit = sem.acquire().await.unwrap();
             if should_restore_side_effects_cache && let Some(cache_entry) = job.cache_entry.clone()
             {

--- a/vendor/aube/crates/aube/tests/e2e.rs
+++ b/vendor/aube/crates/aube/tests/e2e.rs
@@ -416,6 +416,60 @@ fn approve_builds_surfaces_and_runs_a_local_source_dep() {
         .stdout(predicates::str::contains("No ignored builds"));
 }
 
+#[test]
+fn dependency_build_finishes_before_its_consumers_build_starts() {
+    let _guard = e2e_lock();
+    let sbx = Sandbox::new();
+
+    sbx.write_file(
+        "child/package.json",
+        r#"{
+            "name": "build-child",
+            "version": "1.0.0",
+            "scripts": {
+                "postinstall": "node -e \"setTimeout(() => require('fs').writeFileSync('READY', 'ok'), 300)\""
+            }
+        }"#,
+    );
+    sbx.write_file(
+        "parent/package.json",
+        r#"{
+            "name": "build-parent",
+            "version": "1.0.0",
+            "dependencies": { "build-child": "file:../child" },
+            "scripts": {
+                "postinstall": "node -e \"const fs=require('fs'), p=require('path').join(require('path').dirname(require.resolve('build-child/package.json')), 'READY'); if (!fs.existsSync(p)) process.exit(17); fs.writeFileSync('PARENT_READY', 'ok')\""
+            }
+        }"#,
+    );
+    sbx.write_manifest(
+        r#"{
+            "name": "dependency-build-order-e2e",
+            "version": "1.0.0",
+            "dependencies": { "build-parent": "file:./parent" }
+        }"#,
+    );
+
+    sbx.cmd()
+        .args(["install", "--dangerously-allow-all-builds"])
+        .assert()
+        .success();
+    let node_modules = sbx.project.join("node_modules");
+    assert!(
+        marker_exists_under(&node_modules, "READY"),
+        "build-child's postinstall never wrote READY under {}",
+        node_modules.display()
+    );
+    // The parent's postinstall exits 17 when READY is missing, so reaching
+    // PARENT_READY is the ordering assertion: without phases the parent starts
+    // while the child is still inside its 300ms timer and the install fails.
+    assert!(
+        marker_exists_under(&node_modules, "PARENT_READY"),
+        "build-parent's postinstall never wrote PARENT_READY under {}",
+        node_modules.display()
+    );
+}
+
 // --- optional-dependency build failures are non-fatal ---------------------
 //
 // A package reachable only through `optionalDependencies` is one the project

--- a/vendor/aube/docs/settings/index.md
+++ b/vendor/aube/docs/settings/index.md
@@ -2272,7 +2272,10 @@ Maximum number of concurrent script-executing child processes.
 - Workspace YAML keys: `childConcurrency`
 
 Caps how many dependency lifecycle scripts run in parallel during the
-post-link `allowBuilds` phase. Inside a single package the
+post-link `allowBuilds` phase. Builds run in children-first dependency
+phases — a package's build waits for the builds it depends on — so the
+cap applies within one phase rather than across the whole graph.
+Inside a single package the
 `preinstall` / `install` / `postinstall` hooks still run sequentially
 — pnpm's execution model is "at most N packages building in
 parallel," not "at most N scripts running." Defaults to 5, matching


### PR DESCRIPTION
## Summary

- run dependency lifecycle scripts in children-first graph phases
- preserve bounded parallelism for independent packages and collapse dependency cycles
- cover ordering through non-building graph nodes and an end-to-end parent/child build

## Verification

- `make verify`
- fresh `spectron@17.0.0` install with an isolated Nub store and Electron cache
- control regression fails on `main` when the parent starts before its child finishes
