### PR TITLE
fix(pm): apply the disk-materialize eject in workspace projects too

### DIFF
--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -92,7 +92,9 @@ fn eject_disabled(raw: Option<&str>) -> bool {
 /// members are injected inside the expand hook, past aube's `disk_materialize_packages`
 /// settings fold, so folding the list token here is what invalidates a warm tree on
 /// the initial ship AND on any future list edit (else the stale symlinked shape is
-/// accepted and #457 stays unfixed on existing installs).
+/// accepted and #457 stays unfixed on existing installs). It also folds
+/// [`GVS_EJECT_ALGO_VERSION`], which covers the third way a warm tree goes stale:
+/// the plan is unchanged but the LINKER writes it differently (nub#711).
 ///
 /// The token still branches on [`enabled`] SOLELY for the internal A/B seam: when
 /// an agent flips [`INTERNAL_EJECT_DISABLE_VAR`] the token changes, so a warm tree
@@ -107,7 +109,7 @@ pub(crate) fn settings_fingerprint() -> String {
 fn settings_token(enabled: bool) -> String {
     if enabled {
         format!(
-            "phantom_scanner={PHANTOM_SCANNER_VERSION};project_context={}",
+            "phantom_scanner={PHANTOM_SCANNER_VERSION};project_context={};gvs_eject_algo={GVS_EJECT_ALGO_VERSION}",
             crate::pm_engine::phantom_closure::project_context_eject_token()
         )
     } else {
@@ -308,6 +310,25 @@ pub(crate) fn phantom_cache_dir() -> Option<PathBuf> {
 /// is structural, nothing else to remember.
 pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 4;
 
+/// Version of what the linker's GVS-populate pass WRITES TO DISK for a given eject
+/// set — bumped when the same plan produces a different on-disk shape.
+///
+/// Distinct from [`PHANTOM_SCANNER_VERSION`] (which plan is computed) and from
+/// aube's `disk_materialize_packages` fold (which NAMES are in the seed): both of
+/// those are unchanged when only the EXECUTOR changes, so neither invalidates.
+/// nub#711 is the case in point — `link_workspace` never consulted the eject set,
+/// so every workspace install produced an all-symlinks tree. Fixing the linker
+/// moves no hash: the lockfile, the manifest, the settings and the seed are all
+/// identical, so `try_install_fast_path` reports "Already up to date" and the
+/// broken layout survives the upgrade. Only the users who filed the bug have such
+/// a tree, so without this salt the fix reaches nobody until unrelated churn
+/// (a lockfile edit, `--force`) happens to bust the state.
+///
+/// Same shape and same remedy as aube's `hoisted_layout_algo` salt, which exists
+/// because a hoisted-layout algorithm change likewise left the graph hash
+/// identical. Bump on any future change to what that pass materializes.
+pub(crate) const GVS_EJECT_ALGO_VERSION: u32 = 1;
+
 /// THE single source of truth for a phantom sidecar's location: the versioned
 /// subdir `<phantom_cache_dir>/s<PHANTOM_SCANNER_VERSION>/<fingerprint>.json`.
 /// Both halves derive their path HERE — the extract-time PRODUCER
@@ -342,18 +363,19 @@ mod tests {
         );
     }
 
-    /// The user (enabled) token folds the scanner version AND the curated-eject list
-    /// token, so a scanner bump or a #457 list edit invalidates a warm tree and forces
-    /// a re-scan/relink; the dead on/off toggle is gone. The disabled token (reachable
-    /// only via the internal A/B seam) is version-free and distinct, so flipping the
-    /// seam still re-links to the pure-symlink shape. Pins both against a future
-    /// refactor.
+    /// The user (enabled) token folds the scanner version, the curated-eject list
+    /// token AND the GVS-eject algorithm version, so a scanner bump, a #457 list edit,
+    /// or a change to what the linker MATERIALIZES (nub#711) each invalidates a warm
+    /// tree and forces a re-scan/relink; the dead on/off toggle is gone. The disabled
+    /// token (reachable only via the internal A/B seam) is version-free and distinct,
+    /// so flipping the seam still re-links to the pure-symlink shape. Pins both
+    /// against a future refactor.
     #[test]
     fn enabled_token_folds_version_disabled_seam_token_is_distinct() {
         assert_eq!(
             settings_token(true),
             format!(
-                "phantom_scanner={PHANTOM_SCANNER_VERSION};project_context={}",
+                "phantom_scanner={PHANTOM_SCANNER_VERSION};project_context={};gvs_eject_algo={GVS_EJECT_ALGO_VERSION}",
                 crate::pm_engine::phantom_closure::project_context_eject_token()
             )
         );

--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -327,6 +327,19 @@ pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 4;
 /// Same shape and same remedy as aube's `hoisted_layout_algo` salt, which exists
 /// because a hoisted-layout algorithm change likewise left the graph hash
 /// identical. Bump on any future change to what that pass materializes.
+///
+/// COST of a bump, measured rather than assumed: the dependency side is cheap —
+/// no refetch, no rebuild, no side-effects-cache bust, no lockfile churn, since
+/// those all stay gated on content-hash deltas. But root lifecycle hooks are
+/// gated only on the fast path being missed, so `preinstall` and
+/// `install`/`postinstall`/`prepare` re-run ONCE PER IMPORTER on the first
+/// install after a bump — meaningful in a workspace whose members drive builds
+/// from `prepare`. Accepted here: the alternative is leaving every already-installed
+/// workspace on the broken layout, and `PHANTOM_SCANNER_VERSION` bumps already
+/// carry the same cost. Narrowing the salt to "only when the eject closure is
+/// non-empty" is NOT available — the closure needs the resolved graph, and this
+/// hash is computed before resolution. The auto-install path (`nub run`) does not
+/// pay it at all: it passes no CLI flags, which skips the settings-hash check.
 pub(crate) const GVS_EJECT_ALGO_VERSION: u32 = 1;
 
 /// THE single source of truth for a phantom sidecar's location: the versioned

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -1302,7 +1302,11 @@ impl Linker {
     /// resolved one workspace member (nub#711). Legacy-vite (nub#315) was NOT
     /// affected — it rides `project_local_dep_paths`, which the `project_local`
     /// branch below already honored in both loops. Sharing the body is what keeps
-    /// that class of divergence from recurring.
+    /// that class of divergence from recurring. A change to WHAT this pass
+    /// materializes must ALSO bump `GVS_EJECT_ALGO_VERSION` in nub's
+    /// `crates/nub-cli/src/dynamic_phantom.rs`: nothing here enforces that, and
+    /// without the bump an existing install state reads as current, so the new
+    /// shape is never written to a tree that already exists.
     #[allow(clippy::too_many_arguments)]
     fn gvs_populate_entry(
         &self,

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -323,259 +323,16 @@ impl Linker {
                     step1_prep
                         .par_iter()
                         .map(|&(dep_path, pkg, ref entry_name, ref subdir)| {
-                            let dep_path = dep_path.as_str();
-                            let mut local_stats = LinkStats::default();
-                            let local_aube_entry = aube_dir.join(entry_name);
-                            let global_entry = self.virtual_store.join(subdir);
-                            let project_local = self.project_local_dep_paths.contains(dep_path);
-
-                            // Disk-materialize: this package must be a real
-                            // project-local directory (not a shared-store
-                            // symlink) so its realpath stays inside the project
-                            // and Node's upward node_modules walk from inside it
-                            // reaches a consumer-installed, undeclared backend at
-                            // the project root (the subpath-adapter phantom
-                            // class). Materializes exactly as the per-project
-                            // (GVS-off) branch does — the local `.aube/<entry>`
-                            // name is dep_path-keyed regardless of GVS, so the
-                            // top-level and sibling symlinks resolve unchanged.
-                            // Only registry packages reach here — source deps
-                            // (git/tarball/file/link) were filtered from
-                            // `step1_prep` above and keep the shared-store path;
-                            // the curated disk-materialize list is registry-only,
-                            // so that gap is unreachable in practice. A
-                            // prior GVS install or the fetch prewarm may have left
-                            // a symlink here; replace it. An existing real
-                            // directory is reused as cached. Neither
-                            // `file_type().is_symlink()` nor a `read_link` error
-                            // kind classifies that correctly on both platforms —
-                            // `aube_util::fs::is_real_dir` carries the split.
-                            if self.disk_materialize_matches(&pkg.name) {
-                                // Orphan-safety invariant: disk-materialize gives X
-                                // a real project-local dir so X's OWN undeclared
-                                // consumer-provided import resolves via the project
-                                // root — but every STORE-RESIDENT dependent of X
-                                // still reaches X through a sibling symlink into the
-                                // shared store at `virtual_store_subdir(X)` (==
-                                // `subdir`). The project-local dir alone does NOT
-                                // satisfy those siblings, and X's store copy is NOT
-                                // guaranteed to exist at THIS `subdir`: the fetch
-                                // prewarm materializes X under its own subtree hash,
-                                // which can differ from the link-phase `subdir` a
-                                // dependent's sibling points at (they diverge
-                                // whenever the link phase folds a fingerprint the
-                                // prewarm didn't). A non-disk-materialized install
-                                // would still WRITE X's store copy at `subdir` here
-                                // (the normal branch below), keeping every dependent
-                                // resolvable; the pre-fix disk-materialize branch
-                                // skipped that write, dangling the sibling — the
-                                // `@storybook/builder-webpack5` ← `react-webpack5`
-                                // regression. So ALWAYS keep X's store copy at
-                                // `subdir` IN ADDITION to the project-local dir. The
-                                // store copy is reflinked/CoW and is exactly what a
-                                // non-disk-materialized install writes, so this only
-                                // RESTORES it — it is not a second full byte copy.
-                                let store_pkg_dir = self
-                                    .virtual_store
-                                    .join(subdir)
-                                    .join("node_modules")
-                                    .join(&pkg.name);
-                                let local_is_real_dir =
-                                    aube_util::fs::is_real_dir(&local_aube_entry);
-                                if store_pkg_dir.exists() && local_is_real_dir {
-                                    // Both placements already correct.
-                                    local_stats.packages_cached += 1;
-                                    return Ok(local_stats);
-                                }
-                                let owned_index;
-                                let index = match package_indices.get(dep_path) {
-                                    Some(idx) => idx,
-                                    None => {
-                                        owned_index = self
-                                            .store
-                                            .load_index(
-                                                pkg.registry_name(),
-                                                &pkg.version,
-                                                self.index_read_key(pkg),
-                                            )
-                                            .ok_or_else(|| {
-                                                Error::MissingPackageIndex(dep_path.to_string())
-                                            })?;
-                                        &owned_index
-                                    }
-                                };
-                                // Keep the shared-store copy at the exact `subdir`
-                                // every dependent's sibling targets. Idempotent (a
-                                // cache hit when already placed there). Stats land in
-                                // a throwaway sink so this belt-and-suspenders write
-                                // does not double-count the package — the
-                                // project-local `materialize_into` below is the one
-                                // that counts, matching a normal single-placement
-                                // install's package tally.
-                                let mut store_stats = LinkStats::default();
-                                self.ensure_in_virtual_store_with_subdir(
-                                    dep_path,
-                                    subdir,
-                                    graph,
-                                    pkg,
-                                    index,
-                                    &mut store_stats,
-                                    nested_link_targets.as_ref(),
-                                )?;
-                                if local_is_real_dir {
-                                    // Project-local dir was already correct; only the
-                                    // store copy needed (re)placing, done above.
-                                    local_stats.packages_cached += 1;
-                                    // The call above already stripped the shared-store
-                                    // copy. This ejected project-local one is what
-                                    // resolution actually reaches, and the index is
-                                    // still in hand here, so strip it too rather than
-                                    // leave the two halves of one branch inconsistent.
-                                    crate::quarantine::strip_cached_entry(
-                                        &local_aube_entry,
-                                        &pkg.name,
-                                        index,
-                                    );
-                                    return Ok(local_stats);
-                                }
-                                // Drop a stale shared-store symlink/junction left by
-                                // a prior GVS install or the fetch prewarm before
-                                // materializing the real project-local dir.
-                                //
-                                // The removal must be checked, not best-effort:
-                                // `ensure_in_aube_dir` opens with an `exists()` gate,
-                                // and `exists()` FOLLOWS a symlink. A surviving link
-                                // whose target is live would read as "already
-                                // materialized" and silently skip the ejection — the
-                                // package would stay a store symlink, which is exactly
-                                // what disk-materialize exists to prevent. Fail loudly
-                                // instead.
-                                if std::fs::read_link(&local_aube_entry).is_ok() {
-                                    try_remove_entry(&local_aube_entry);
-                                    if std::fs::symlink_metadata(&local_aube_entry).is_ok() {
-                                        return Err(Error::Io(
-                                            local_aube_entry.clone(),
-                                            std::io::Error::other(
-                                                "failed to remove stale shared-store link before \
-                                                 disk-materializing the package",
-                                            ),
-                                        ));
-                                    }
-                                }
-                                // Undeclared imports this ejected package makes are
-                                // resolved by the collective project-local hidden
-                                // hoist tree (built in `link_hidden_hoist` over the
-                                // whole ejected set) — its realpath is project-local,
-                                // so Node's upward walk from inside it reaches
-                                // `.aube/node_modules/`. So materialize the copy with
-                                // its own edges; no per-importer sibling injection.
-                                // Staged (see the note in step 1) so a partial
-                                // failure leaves no entry to be mistaken for a
-                                // complete one.
-                                self.ensure_in_aube_dir(
-                                    &aube_dir,
-                                    dep_path,
-                                    graph,
-                                    pkg,
-                                    index,
-                                    &mut local_stats,
-                                    nested_link_targets.as_ref(),
-                                )?;
-                                return Ok(local_stats);
-                            }
-
-                            // Single readlink classifies the entry into one of
-                            // three states and drives the whole per-package
-                            // decision tree below. Avoids the double-check
-                            // (`read_link` then `exists`) the previous version
-                            // did and eliminates the unconditional
-                            // `remove_dir`/`remove_file` pair on cold installs,
-                            // which strace showed as ~1.4k ENOENT syscalls per
-                            // install on the medium fixture.
-                            let state = if project_local {
-                                classify_local_entry_state(&local_aube_entry)
-                            } else {
-                                classify_entry_state(&local_aube_entry, &global_entry)
-                            };
-
-                            if matches!(state, EntryState::Fresh) {
-                                local_stats.packages_cached += 1;
-                                return Ok(local_stats);
-                            }
-
-                            // Symlink is stale or missing — need the package
-                            // index to (re)materialize. The install driver
-                            // omits `package_indices` entries for packages on
-                            // the fast path; load from the store on demand if
-                            // this one slipped through. This keeps the
-                            // fast-path safe against graph-hash changes that
-                            // invalidate the symlink target (patches, engine
-                            // bumps, `allowBuilds` flips).
-                            let owned_index;
-                            let index = match package_indices.get(dep_path) {
-                                Some(idx) => idx,
-                                None => {
-                                    owned_index = self
-                                        .store
-                                        .load_index(
-                                            pkg.registry_name(),
-                                            &pkg.version,
-                                            self.index_read_key(pkg),
-                                        )
-                                        .ok_or_else(|| {
-                                            Error::MissingPackageIndex(dep_path.to_string())
-                                        })?;
-                                    &owned_index
-                                }
-                            };
-                            if project_local {
-                                if !matches!(state, EntryState::Missing) {
-                                    try_remove_entry(&local_aube_entry);
-                                }
-                                self.materialize_into(
-                                    &aube_dir,
-                                    &aube_dir,
-                                    dep_path,
-                                    graph,
-                                    pkg,
-                                    index,
-                                    &mut local_stats,
-                                    false,
-                                    nested_link_targets.as_ref(),
-                                )?;
-                                return Ok(local_stats);
-                            }
-
-                            self.ensure_in_virtual_store_with_subdir(
+                            self.gvs_populate_entry(
+                                &aube_dir,
                                 dep_path,
+                                pkg,
+                                entry_name,
                                 subdir,
                                 graph,
-                                pkg,
-                                index,
-                                &mut local_stats,
+                                package_indices,
                                 nested_link_targets.as_ref(),
-                            )?;
-
-                            // Only pay the removal syscalls when there is
-                            // something to remove. `Stale` covers more than a
-                            // wrong-target link: a POPULATED real directory
-                            // lands here whenever a package leaves the
-                            // disk-materialize eject set, or a per-project tree
-                            // was only partly converted to the shared store. A
-                            // non-recursive `remove_dir` cannot clear that, and
-                            // the swallowed error then resurfaces as EEXIST /
-                            // os-183 from the junction/symlink creation below.
-                            // `try_remove_entry` clears dir, symlink, junction,
-                            // and dangling-link shapes alike — the same call
-                            // the git/tarball sibling path already uses.
-                            if matches!(state, EntryState::Stale) {
-                                try_remove_entry(&local_aube_entry);
-                            }
-                            // Parent dirs were pre-created above the
-                            // par_iter; no per-package `mkdirp` here.
-                            sys::create_dir_link(&global_entry, &local_aube_entry)
-                                .map_err(|e| Error::Io(local_aube_entry.clone(), e))?;
-                            Ok(local_stats)
+                            )
                         })
                         .collect()
                 });
@@ -1117,83 +874,16 @@ impl Linker {
                     step1_prep
                         .par_iter()
                         .map(|&(dep_path, pkg, ref entry_name, ref subdir)| {
-                            let dep_path = dep_path.as_str();
-                            let mut local_stats = LinkStats::default();
-                            let local_aube_entry = aube_dir.join(entry_name);
-                            let global_entry = self.virtual_store.join(subdir);
-                            let project_local = self.project_local_dep_paths.contains(dep_path);
-
-                            let state = if project_local {
-                                classify_local_entry_state(&local_aube_entry)
-                            } else {
-                                classify_entry_state(&local_aube_entry, &global_entry)
-                            };
-
-                            if matches!(state, EntryState::Fresh) {
-                                local_stats.packages_cached += 1;
-                                return Ok(local_stats);
-                            }
-
-                            let owned_index;
-                            let index = match package_indices.get(dep_path) {
-                                Some(idx) => idx,
-                                None => {
-                                    owned_index = self
-                                        .store
-                                        .load_index(
-                                            pkg.registry_name(),
-                                            &pkg.version,
-                                            self.index_read_key(pkg),
-                                        )
-                                        .ok_or_else(|| {
-                                            Error::MissingPackageIndex(dep_path.to_string())
-                                        })?;
-                                    &owned_index
-                                }
-                            };
-                            if project_local {
-                                if !matches!(state, EntryState::Missing) {
-                                    try_remove_entry(&local_aube_entry);
-                                }
-                                self.materialize_into(
-                                    &aube_dir,
-                                    &aube_dir,
-                                    dep_path,
-                                    graph,
-                                    pkg,
-                                    index,
-                                    &mut local_stats,
-                                    false,
-                                    nested_link_targets.as_ref(),
-                                )?;
-                                return Ok(local_stats);
-                            }
-
-                            self.ensure_in_virtual_store_with_subdir(
+                            self.gvs_populate_entry(
+                                &aube_dir,
                                 dep_path,
+                                pkg,
+                                entry_name,
                                 subdir,
                                 graph,
-                                pkg,
-                                index,
-                                &mut local_stats,
+                                package_indices,
                                 nested_link_targets.as_ref(),
-                            )?;
-
-                            // Same `Stale` shapes as `link_all`'s step 1, and
-                            // the same reason a non-recursive `remove_dir`
-                            // cannot clear them — see the comment there. This
-                            // arm is the workspace twin of that code and was
-                            // left on the old removal, so a workspace wedged
-                            // permanently on os-183 where a single-package
-                            // project self-healed.
-                            if matches!(state, EntryState::Stale) {
-                                try_remove_entry(&local_aube_entry);
-                            }
-                            // Parent dirs were pre-created above the
-                            // par_iter; no per-package `mkdirp` here.
-                            sys::create_dir_link(&global_entry, &local_aube_entry)
-                                .map_err(|e| Error::Io(local_aube_entry.clone(), e))?;
-                            Ok(local_stats)
+                            )
                         })
                         .collect()
                 });
@@ -1600,6 +1290,281 @@ impl Linker {
             );
         }
         Ok(stats)
+    }
+
+    /// One registry package's GVS-populate decision: eject it project-local when
+    /// it is on the disk-materialize list, else keep the shared-store copy and
+    /// point `.aube/<entry>` at it. Extracted so `link_all` (single-package) and
+    /// `link_workspace` share ONE body. They previously carried hand-mirrored
+    /// copies and the disk-materialize branch was only ever added to `link_all`,
+    /// so every eject — type-phantom (nub#450/#452), undeclared-phantom,
+    /// project-context (nub#457), legacy-vite — silently did nothing the moment a
+    /// project resolved one workspace member (nub#711). Sharing the body is what
+    /// keeps that class of divergence from recurring.
+    #[allow(clippy::too_many_arguments)]
+    fn gvs_populate_entry(
+        &self,
+        aube_dir: &Path,
+        dep_path: &str,
+        pkg: &LockedPackage,
+        entry_name: &str,
+        subdir: &str,
+        graph: &LockfileGraph,
+        package_indices: &BTreeMap<String, PackageIndex>,
+        nested_link_targets: Option<&BTreeMap<String, PathBuf>>,
+    ) -> Result<LinkStats, Error> {
+        let mut local_stats = LinkStats::default();
+        let local_aube_entry = aube_dir.join(entry_name);
+        let global_entry = self.virtual_store.join(subdir);
+        let project_local = self.project_local_dep_paths.contains(dep_path);
+
+        // Disk-materialize: this package must be a real
+        // project-local directory (not a shared-store
+        // symlink) so its realpath stays inside the project
+        // and Node's upward node_modules walk from inside it
+        // reaches a consumer-installed, undeclared backend at
+        // the project root (the subpath-adapter phantom
+        // class). Materializes exactly as the per-project
+        // (GVS-off) branch does — the local `.aube/<entry>`
+        // name is dep_path-keyed regardless of GVS, so the
+        // top-level and sibling symlinks resolve unchanged.
+        // Only registry packages reach here — source deps
+        // (git/tarball/file/link) were filtered from
+        // `step1_prep` above and keep the shared-store path;
+        // the curated disk-materialize list is registry-only,
+        // so that gap is unreachable in practice. A
+        // prior GVS install or the fetch prewarm may have left
+        // a symlink here; replace it. An existing real
+        // directory is reused as cached. Neither
+        // `file_type().is_symlink()` nor a `read_link` error
+        // kind classifies that correctly on both platforms —
+        // `aube_util::fs::is_real_dir` carries the split.
+        if self.disk_materialize_matches(&pkg.name) {
+            // Orphan-safety invariant: disk-materialize gives X
+            // a real project-local dir so X's OWN undeclared
+            // consumer-provided import resolves via the project
+            // root — but every STORE-RESIDENT dependent of X
+            // still reaches X through a sibling symlink into the
+            // shared store at `virtual_store_subdir(X)` (==
+            // `subdir`). The project-local dir alone does NOT
+            // satisfy those siblings, and X's store copy is NOT
+            // guaranteed to exist at THIS `subdir`: the fetch
+            // prewarm materializes X under its own subtree hash,
+            // which can differ from the link-phase `subdir` a
+            // dependent's sibling points at (they diverge
+            // whenever the link phase folds a fingerprint the
+            // prewarm didn't). A non-disk-materialized install
+            // would still WRITE X's store copy at `subdir` here
+            // (the normal branch below), keeping every dependent
+            // resolvable; the pre-fix disk-materialize branch
+            // skipped that write, dangling the sibling — the
+            // `@storybook/builder-webpack5` ← `react-webpack5`
+            // regression. So ALWAYS keep X's store copy at
+            // `subdir` IN ADDITION to the project-local dir. The
+            // store copy is reflinked/CoW and is exactly what a
+            // non-disk-materialized install writes, so this only
+            // RESTORES it — it is not a second full byte copy.
+            let store_pkg_dir = self
+                .virtual_store
+                .join(subdir)
+                .join("node_modules")
+                .join(&pkg.name);
+            let local_is_real_dir =
+                aube_util::fs::is_real_dir(&local_aube_entry);
+            if store_pkg_dir.exists() && local_is_real_dir {
+                // Both placements already correct.
+                local_stats.packages_cached += 1;
+                return Ok(local_stats);
+            }
+            let owned_index;
+            let index = match package_indices.get(dep_path) {
+                Some(idx) => idx,
+                None => {
+                    owned_index = self
+                        .store
+                        .load_index(
+                            pkg.registry_name(),
+                            &pkg.version,
+                            self.index_read_key(pkg),
+                        )
+                        .ok_or_else(|| {
+                            Error::MissingPackageIndex(dep_path.to_string())
+                        })?;
+                    &owned_index
+                }
+            };
+            // Keep the shared-store copy at the exact `subdir`
+            // every dependent's sibling targets. Idempotent (a
+            // cache hit when already placed there). Stats land in
+            // a throwaway sink so this belt-and-suspenders write
+            // does not double-count the package — the
+            // project-local `materialize_into` below is the one
+            // that counts, matching a normal single-placement
+            // install's package tally.
+            let mut store_stats = LinkStats::default();
+            self.ensure_in_virtual_store_with_subdir(
+                dep_path,
+                subdir,
+                graph,
+                pkg,
+                index,
+                &mut store_stats,
+                nested_link_targets,
+            )?;
+            if local_is_real_dir {
+                // Project-local dir was already correct; only the
+                // store copy needed (re)placing, done above.
+                local_stats.packages_cached += 1;
+                // The call above already stripped the shared-store
+                // copy. This ejected project-local one is what
+                // resolution actually reaches, and the index is
+                // still in hand here, so strip it too rather than
+                // leave the two halves of one branch inconsistent.
+                crate::quarantine::strip_cached_entry(
+                    &local_aube_entry,
+                    &pkg.name,
+                    index,
+                );
+                return Ok(local_stats);
+            }
+            // Drop a stale shared-store symlink/junction left by
+            // a prior GVS install or the fetch prewarm before
+            // materializing the real project-local dir.
+            //
+            // The removal must be checked, not best-effort:
+            // `ensure_in_aube_dir` opens with an `exists()` gate,
+            // and `exists()` FOLLOWS a symlink. A surviving link
+            // whose target is live would read as "already
+            // materialized" and silently skip the ejection — the
+            // package would stay a store symlink, which is exactly
+            // what disk-materialize exists to prevent. Fail loudly
+            // instead.
+            if std::fs::read_link(&local_aube_entry).is_ok() {
+                try_remove_entry(&local_aube_entry);
+                if std::fs::symlink_metadata(&local_aube_entry).is_ok() {
+                    return Err(Error::Io(
+                        local_aube_entry.clone(),
+                        std::io::Error::other(
+                            "failed to remove stale shared-store link before \
+                             disk-materializing the package",
+                        ),
+                    ));
+                }
+            }
+            // Undeclared imports this ejected package makes are
+            // resolved by the collective project-local hidden
+            // hoist tree (built in `link_hidden_hoist` over the
+            // whole ejected set) — its realpath is project-local,
+            // so Node's upward walk from inside it reaches
+            // `.aube/node_modules/`. So materialize the copy with
+            // its own edges; no per-importer sibling injection.
+            // Staged (see the note in step 1) so a partial
+            // failure leaves no entry to be mistaken for a
+            // complete one.
+            self.ensure_in_aube_dir(
+                aube_dir,
+                dep_path,
+                graph,
+                pkg,
+                index,
+                &mut local_stats,
+                nested_link_targets,
+            )?;
+            return Ok(local_stats);
+        }
+
+        // Single readlink classifies the entry into one of
+        // three states and drives the whole per-package
+        // decision tree below. Avoids the double-check
+        // (`read_link` then `exists`) the previous version
+        // did and eliminates the unconditional
+        // `remove_dir`/`remove_file` pair on cold installs,
+        // which strace showed as ~1.4k ENOENT syscalls per
+        // install on the medium fixture.
+        let state = if project_local {
+            classify_local_entry_state(&local_aube_entry)
+        } else {
+            classify_entry_state(&local_aube_entry, &global_entry)
+        };
+
+        if matches!(state, EntryState::Fresh) {
+            local_stats.packages_cached += 1;
+            return Ok(local_stats);
+        }
+
+        // Symlink is stale or missing — need the package
+        // index to (re)materialize. The install driver
+        // omits `package_indices` entries for packages on
+        // the fast path; load from the store on demand if
+        // this one slipped through. This keeps the
+        // fast-path safe against graph-hash changes that
+        // invalidate the symlink target (patches, engine
+        // bumps, `allowBuilds` flips).
+        let owned_index;
+        let index = match package_indices.get(dep_path) {
+            Some(idx) => idx,
+            None => {
+                owned_index = self
+                    .store
+                    .load_index(
+                        pkg.registry_name(),
+                        &pkg.version,
+                        self.index_read_key(pkg),
+                    )
+                    .ok_or_else(|| {
+                        Error::MissingPackageIndex(dep_path.to_string())
+                    })?;
+                &owned_index
+            }
+        };
+        if project_local {
+            if !matches!(state, EntryState::Missing) {
+                try_remove_entry(&local_aube_entry);
+            }
+            self.materialize_into(
+                aube_dir,
+                aube_dir,
+                dep_path,
+                graph,
+                pkg,
+                index,
+                &mut local_stats,
+                false,
+                nested_link_targets,
+            )?;
+            return Ok(local_stats);
+        }
+
+        self.ensure_in_virtual_store_with_subdir(
+            dep_path,
+            subdir,
+            graph,
+            pkg,
+            index,
+            &mut local_stats,
+            nested_link_targets,
+        )?;
+
+        // Only pay the removal syscalls when there is
+        // something to remove. `Stale` covers more than a
+        // wrong-target link: a POPULATED real directory
+        // lands here whenever a package leaves the
+        // disk-materialize eject set, or a per-project tree
+        // was only partly converted to the shared store. A
+        // non-recursive `remove_dir` cannot clear that, and
+        // the swallowed error then resurfaces as EEXIST /
+        // os-183 from the junction/symlink creation below.
+        // `try_remove_entry` clears dir, symlink, junction,
+        // and dangling-link shapes alike — the same call
+        // the git/tarball sibling path already uses.
+        if matches!(state, EntryState::Stale) {
+            try_remove_entry(&local_aube_entry);
+        }
+        // Parent dirs were pre-created above the
+        // par_iter; no per-package `mkdirp` here.
+        sys::create_dir_link(&global_entry, &local_aube_entry)
+            .map_err(|e| Error::Io(local_aube_entry.clone(), e))?;
+        Ok(local_stats)
     }
 
     /// Populate (or sweep) the project-local hidden modules directory at

--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -1297,10 +1297,12 @@ impl Linker {
     /// point `.aube/<entry>` at it. Extracted so `link_all` (single-package) and
     /// `link_workspace` share ONE body. They previously carried hand-mirrored
     /// copies and the disk-materialize branch was only ever added to `link_all`,
-    /// so every eject — type-phantom (nub#450/#452), undeclared-phantom,
-    /// project-context (nub#457), legacy-vite — silently did nothing the moment a
-    /// project resolved one workspace member (nub#711). Sharing the body is what
-    /// keeps that class of divergence from recurring.
+    /// so the type-phantom (nub#450/#452), undeclared-phantom and
+    /// project-context (nub#457) ejects silently did nothing the moment a project
+    /// resolved one workspace member (nub#711). Legacy-vite (nub#315) was NOT
+    /// affected — it rides `project_local_dep_paths`, which the `project_local`
+    /// branch below already honored in both loops. Sharing the body is what keeps
+    /// that class of divergence from recurring.
     #[allow(clippy::too_many_arguments)]
     fn gvs_populate_entry(
         &self,
@@ -1369,8 +1371,7 @@ impl Linker {
                 .join(subdir)
                 .join("node_modules")
                 .join(&pkg.name);
-            let local_is_real_dir =
-                aube_util::fs::is_real_dir(&local_aube_entry);
+            let local_is_real_dir = aube_util::fs::is_real_dir(&local_aube_entry);
             if store_pkg_dir.exists() && local_is_real_dir {
                 // Both placements already correct.
                 local_stats.packages_cached += 1;
@@ -1382,14 +1383,8 @@ impl Linker {
                 None => {
                     owned_index = self
                         .store
-                        .load_index(
-                            pkg.registry_name(),
-                            &pkg.version,
-                            self.index_read_key(pkg),
-                        )
-                        .ok_or_else(|| {
-                            Error::MissingPackageIndex(dep_path.to_string())
-                        })?;
+                        .load_index(pkg.registry_name(), &pkg.version, self.index_read_key(pkg))
+                        .ok_or_else(|| Error::MissingPackageIndex(dep_path.to_string()))?;
                     &owned_index
                 }
             };
@@ -1420,11 +1415,7 @@ impl Linker {
                 // resolution actually reaches, and the index is
                 // still in hand here, so strip it too rather than
                 // leave the two halves of one branch inconsistent.
-                crate::quarantine::strip_cached_entry(
-                    &local_aube_entry,
-                    &pkg.name,
-                    index,
-                );
+                crate::quarantine::strip_cached_entry(&local_aube_entry, &pkg.name, index);
                 return Ok(local_stats);
             }
             // Drop a stale shared-store symlink/junction left by
@@ -1506,14 +1497,8 @@ impl Linker {
             None => {
                 owned_index = self
                     .store
-                    .load_index(
-                        pkg.registry_name(),
-                        &pkg.version,
-                        self.index_read_key(pkg),
-                    )
-                    .ok_or_else(|| {
-                        Error::MissingPackageIndex(dep_path.to_string())
-                    })?;
+                    .load_index(pkg.registry_name(), &pkg.version, self.index_read_key(pkg))
+                    .ok_or_else(|| Error::MissingPackageIndex(dep_path.to_string()))?;
                 &owned_index
             }
         };

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -536,10 +536,11 @@ fn disk_materialize_makes_only_listed_package_a_real_dir_under_gvs() {
 // near-duplicate step-1 GVS-populate loops, so a fix landing in one silently
 // skipped the other. nub#566/#576 was the `EntryState::Stale` arm; nub#711 is
 // the disk-materialize branch, which existed ONLY in `link_all` — so resolving
-// a single workspace member disabled every eject class at once (type-phantom
-// nub#450/#452, undeclared-phantom, project-context nub#457, legacy-vite
-// nub#315). Both loops now share one `gvs_populate_entry` body; this test is
-// what holds the workspace half to it.
+// a single workspace member disabled the disk-materialize eject classes at once
+// (type-phantom nub#450/#452, undeclared-phantom, project-context nub#457).
+// Legacy-vite (nub#315) rides `project_local_dep_paths`, which the workspace
+// loop already honored. Both loops now share one `gvs_populate_entry` body;
+// this test is what holds the workspace half to it.
 #[test]
 fn disk_materialize_ejects_under_gvs_in_a_workspace_too() {
     let dir = tempfile::tempdir().unwrap();

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -531,6 +531,65 @@ fn disk_materialize_makes_only_listed_package_a_real_dir_under_gvs() {
     );
 }
 
+// The workspace twin of the test above, and the second time this exact
+// duplication has cost a release: `link_all` and `link_workspace` carried
+// near-duplicate step-1 GVS-populate loops, so a fix landing in one silently
+// skipped the other. nub#566/#576 was the `EntryState::Stale` arm; nub#711 is
+// the disk-materialize branch, which existed ONLY in `link_all` — so resolving
+// a single workspace member disabled every eject class at once (type-phantom
+// nub#450/#452, undeclared-phantom, project-context nub#457, legacy-vite
+// nub#315). Both loops now share one `gvs_populate_entry` body; this test is
+// what holds the workspace half to it.
+#[test]
+fn disk_materialize_ejects_under_gvs_in_a_workspace_too() {
+    let dir = tempfile::tempdir().unwrap();
+    let root_dir = dir.path().join("workspace");
+    std::fs::create_dir_all(&root_dir).unwrap();
+
+    let (store, indices) = setup_store_with_files(dir.path());
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
+        .with_hoist(false)
+        .with_disk_materialize(&["foo".to_string()]);
+
+    // One resolved member is the whole trigger: `has_workspace` flips true, the
+    // install routes to `link_workspace`, and pre-fix the eject stopped happening.
+    let mut graph = make_graph();
+    let root_deps = graph.importers.get(".").cloned().unwrap_or_default();
+    graph.importers.insert("packages/a".to_string(), root_deps);
+
+    linker
+        .link_workspace(&root_dir, &graph, &indices, &BTreeMap::new())
+        .unwrap();
+
+    // foo is on the list: a real project-local dir, so its realpath stays inside
+    // the project and TypeScript's/Node's upward walk re-enters it.
+    let aube_foo = root_dir.join("node_modules/.aube/foo@1.0.0");
+    assert!(
+        !aube_foo
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "disk-materialized foo must be a real dir in a workspace too, not a global-store symlink"
+    );
+    assert_eq!(
+        std::fs::read_to_string(aube_foo.join("node_modules/foo/index.js")).unwrap(),
+        "module.exports = 'foo';"
+    );
+
+    // The bound still holds: an unlisted package stays symlinked, so the eject
+    // is per-package and GVS sharing survives for everything else.
+    assert!(
+        root_dir
+            .join("node_modules/.aube/bar@2.0.0")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "an unlisted package must stay a global-virtual-store symlink"
+    );
+}
+
 #[test]
 fn disk_materialize_keeps_store_copy_so_store_resident_dependents_dont_orphan() {
     // Orphan-safety regression (the shipped @storybook/builder-webpack5 ←


### PR DESCRIPTION
## Problem

Resolving a single workspace member disabled every disk-materialize eject. A project with one member — even an empty one — kept every registry package symlinked into the machine-global store, so no package realpath returned to the project and each eject class silently stopped working:

- **Type-phantom (#450, #452)** — `@react-pdf/renderer`'s `.d.ts` imports `react`, the project's `@types/react` sits only at the top level, and TypeScript's upward walk from the store never re-enters the project. `TS2786`/`TS2607`, or `TS7006` on the TanStack shape.
- **Undeclared-phantom** — `@hookform/resolvers` and similar keep 404ing their undeclared target.
- **Project-context (#457)** — `simple-git-hooks` and the other host-project mutators run detached from any project again.

Legacy-vite (#315, #318) was unaffected: it rides `project_local_dep_paths`, a separate channel the workspace path already honored.

Reproduced on `main` with one fixture varied only by workspace shape:

| Fixture | Ejected | `tsc` |
|---|---|---|
| No workspace | 4 | 0 errors |
| `workspaces` glob matching no member | 4 | 0 errors |
| Same glob plus one empty member | 0 | `TS2786` |
| `pnpm-workspace.yaml` plus one member, pnpm incumbent | 0 | `TS2786` |

## Cause

The install routes on `has_workspace`, which is true as soon as one member resolves. That picks `link_workspace` over `link_all`, and only `link_all` consulted the eject set — its GVS populate pass had the `disk_materialize_matches` branch, and the workspace twin never got one. The install digest still printed the eject because it records the plan, not what the linker ran.

The two passes were otherwise identical line for line, and this is the second bug that duplication has shipped: #566/#576 was the `EntryState::Stale` arm landing in `link_all` alone, which wedged Windows workspaces on os-183.

## Fix

Both passes now call one `Linker::gvs_populate_entry`, so a branch can no longer reach one and miss the other. Sharing the body rather than mirroring it a second time is the point of the change.

## Reaching the projects that already broke

The linker change alone reaches nobody who hit this. Their tree carries a current install state, and nothing about the fix moves the hash — lockfile, manifest, resolved settings and the disk-materialize seed are all identical, since only which code path consults the seed changed. So the first install after upgrading short-circuits on the warm fast path, reports "Already up to date", and the all-symlinks layout survives. Installing a workspace fixture with a pre-fix binary and then running a post-fix one confirmed it: nothing ejected, `TS2786` still there. Layout verification does not catch it either, because it checks entry existence and package identity, never entry type.

So a `GVS_EJECT_ALGO_VERSION` is folded into the settings fingerprint, the seam already carrying the scanner version and the #457 curated-eject token for this same class of staleness, and the shape aube's `hoisted_layout_algo` salt already uses. It is deliberately not gated on a non-empty `diskMaterializePackages`: that setting is almost always empty here because the eject set arrives through the expand hook, so gating there would skip the salt in exactly the broken cases.

The cost is one full install on the first run after upgrading, and that is more than a relink. The dependency side is cheap — no refetch, no rebuild, no side-effects-cache bust and no lockfile churn, all of which stay gated on content-hash deltas. Root lifecycle hooks are not: they gate only on the fast path being missed, so `preinstall` and `install`/`postinstall`/`prepare` re-run once per importer, which is worth knowing for a workspace whose members build from `prepare`. That is accepted rather than overlooked — the alternative is leaving every already-installed workspace on the broken layout, and scanner-version bumps already carry the same cost. Narrowing the salt to fire only when the eject closure is non-empty is not available, because the closure needs the resolved graph and this hash is computed before resolution. The auto-install path behind `nub run` does not pay it at all, since it skips the settings-hash check.

Measured on the upgrade path: pre-fix install ejects 0 and fails `TS2786`, the post-fix binary relinks to 9 ejected and 0 errors, and a third run reports "Already up to date" — so the salt fires once and settles.

## Validation

- Unit — a workspace twin of the existing `link_all` eject test, asserting the listed package becomes a real project-local dir while an unlisted one stays a shared-store symlink. It fails on the pre-fix linker. The fingerprint test pins the new algorithm fold.
- End to end, real `nub install` — all four fixtures above eject and type-check, across both the neutral `workspaces` field and the pnpm-incumbent path; `simple-git-hooks` and `@hookform/resolvers` eject in a workspace again; `vite` is unchanged.
- Cost — on a five-member React/eslint/vitest workspace, 21 of 245 packages eject, inside the existing bounded-subtree guard and matching what the same dependency set already ejects without a workspace.

Fixes #711
