### PR TITLE
cli: parse a help flag after the verb in the pm and node groups

### DIFF
--- a/crates/nub-cli/src/agent/mod.rs
+++ b/crates/nub-cli/src/agent/mod.rs
@@ -51,8 +51,11 @@ const INDEX_SLUG: &str = "/docs";
 
 /// Entry point for `nub agent …`, dispatched from `dispatch_subcommand`.
 pub fn run(args: &[String]) -> Result<i32> {
+    // Same guard as the other two non-forwarding groups: a help flag counts after
+    // the verb too, so `nub agent docs --help` prints usage instead of failing on
+    // an unexpected argument, and `nub agent skill --help` stops dumping the skill.
     let verb = args.first().map(String::as_str);
-    if matches!(verb, None | Some("help") | Some("--help") | Some("-h")) {
+    if verb.is_none() || crate::cli::group_help_requested(args) {
         print_usage();
         return Ok(0);
     }
@@ -269,6 +272,26 @@ mod tests {
         assert_eq!(run(&[]).unwrap(), 0);
         assert_eq!(run(&["help".into()]).unwrap(), 0);
         assert_eq!(run(&["--help".into()]).unwrap(), 0);
+    }
+
+    #[test]
+    fn a_help_flag_after_the_verb_is_not_an_unexpected_argument() {
+        // The #653 shape in the third non-forwarding group: `nub agent docs --help`
+        // failed with "unexpected argument '--help'" before the shared guard, so the
+        // exit code alone catches that regression.
+        //
+        // `skill` is deliberately not asserted here. It returned 0 either way — it
+        // dumped the whole skill markdown and ignored the flag — so an exit-code
+        // assertion on it could never fail. The flag-anywhere semantics it now
+        // depends on are asserted directly in
+        // `cli::tests::group_help_is_recognized_after_the_verb`.
+        for flag in ["--help", "-h"] {
+            assert_eq!(
+                run(&["docs".into(), flag.into()]).unwrap(),
+                0,
+                "`nub agent docs {flag}` must print usage, not error"
+            );
+        }
     }
 
     #[test]

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -8510,20 +8510,24 @@ fn is_help_routable(word: &str) -> bool {
         || crate::pm_engine::lookup_verb(word).is_some()
 }
 
-/// True when a non-forwarding command group (`nub pm`, `nub node`) was asked for
-/// its help. A help FLAG counts ANYWHERE in the group's argv, not just at argv[0]:
-/// the top-level scan stops matching nub's own flags once a subcommand is seen
-/// (the three-position rule, so `nub run build --watch` reaches the script), which
-/// is right for the forwarding commands but leaves these groups to parse their own
-/// help. Without the flag-anywhere rule the sub-verbs take no arguments, so the
-/// flag is silently dropped and the verb RUNS — `nub pm shim --help` installs the
-/// shims and `nub pm unshim --help` removes them, both editing shell startup files
-/// a user was only asking about (#653). Safe as a blanket scan because neither
-/// group forwards argv to a child: their only argument consumers take a package-
-/// manager name or a version, and no help flag is valid there.
-fn group_help_requested(args: &[String]) -> bool {
-    args.first().is_some_and(|a| a == "help")
-        || args.iter().any(|a| a == "--help" || a == "-h")
+/// True when a non-forwarding command group was asked for its help. The three
+/// are `nub pm`, `nub node` and `nub agent` — the groups that bypass clap for a
+/// manual sub-verb match, so each has to recognize its own help.
+///
+/// A help FLAG counts ANYWHERE in the group's argv, not just at argv[0]: the
+/// top-level scan stops matching nub's own flags once a subcommand is seen (the
+/// three-position rule, so `nub run build --watch` reaches the script), which is
+/// right for the forwarding commands but leaves these groups to parse their own
+/// help. Without the flag-anywhere rule the sub-verbs never read past argv[0], so
+/// the flag is silently dropped and the verb RUNS — `nub pm shim --help` installs
+/// the shims and `nub pm unshim --help` removes them, both editing shell startup
+/// files a user was only asking about (#653).
+///
+/// Safe as a blanket scan because no group forwards argv to a child process:
+/// their only argument consumers take a package-manager name, a version, or a
+/// `/docs/...` slug, and no help flag is a valid value for any of them.
+pub(crate) fn group_help_requested(args: &[String]) -> bool {
+    args.first().is_some_and(|a| a == "help") || args.iter().any(|a| a == "--help" || a == "-h")
 }
 
 /// The help router. `command = None` prints the top-level page (`-h` curated,
@@ -8885,7 +8889,8 @@ fn run_node(args: &[String]) -> Result<i32> {
          \x20 shim                     make `node` on PATH resolve through nub (re-run after `nub upgrade`)\n\
          \x20 unshim                   remove the `node` shim and its PATH block";
 
-    // `nub node --help`/`-h`/`help`: short usage listing the verbs.
+    // A help request — `help` at argv[0], or `--help`/`-h` at any position,
+    // including after the verb: the short usage listing the verbs.
     let verb = args.first().map(String::as_str);
     if group_help_requested(args) {
         println!("{NODE_HELP}");
@@ -12588,6 +12593,9 @@ mod tests {
             &["unshim", "--help"][..],
             &["unshim", "-h"][..],
             &["install", "22.13.0", "--help"][..],
+            // `nub agent` is the third group on this guard.
+            &["docs", "--help"][..],
+            &["skill", "-h"][..],
         ] {
             assert!(
                 group_help_requested(&argv(args)),
@@ -12605,6 +12613,7 @@ mod tests {
             &["use", "pnpm"][..],
             &["cache", "clear"][..],
             &["install", "22.13.0"][..],
+            &["docs", "--page", "/docs/runtime/jsx"][..],
         ] {
             assert!(
                 !group_help_requested(&argv(args)),

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -8510,6 +8510,22 @@ fn is_help_routable(word: &str) -> bool {
         || crate::pm_engine::lookup_verb(word).is_some()
 }
 
+/// True when a non-forwarding command group (`nub pm`, `nub node`) was asked for
+/// its help. A help FLAG counts ANYWHERE in the group's argv, not just at argv[0]:
+/// the top-level scan stops matching nub's own flags once a subcommand is seen
+/// (the three-position rule, so `nub run build --watch` reaches the script), which
+/// is right for the forwarding commands but leaves these groups to parse their own
+/// help. Without the flag-anywhere rule the sub-verbs take no arguments, so the
+/// flag is silently dropped and the verb RUNS — `nub pm shim --help` installs the
+/// shims and `nub pm unshim --help` removes them, both editing shell startup files
+/// a user was only asking about (#653). Safe as a blanket scan because neither
+/// group forwards argv to a child: their only argument consumers take a package-
+/// manager name or a version, and no help flag is valid there.
+fn group_help_requested(args: &[String]) -> bool {
+    args.first().is_some_and(|a| a == "help")
+        || args.iter().any(|a| a == "--help" || a == "-h")
+}
+
 /// The help router. `command = None` prints the top-level page (`-h` curated,
 /// `--help` verbose); a command routes to its own help, consistently across the
 /// `nub <cmd> -h`, `nub help <cmd>`, and leaf forms. Engine verbs dispatch their
@@ -8871,7 +8887,7 @@ fn run_node(args: &[String]) -> Result<i32> {
 
     // `nub node --help`/`-h`/`help`: short usage listing the verbs.
     let verb = args.first().map(String::as_str);
-    if matches!(verb, Some("--help") | Some("-h") | Some("help")) {
+    if group_help_requested(args) {
         println!("{NODE_HELP}");
         return Ok(0);
     }
@@ -9120,7 +9136,7 @@ fn run_pm(args: &[String]) -> Result<i32> {
     let cwd = env::current_dir()?;
 
     let verb = args.first().map(String::as_str);
-    if matches!(verb, None | Some("help") | Some("--help") | Some("-h")) {
+    if verb.is_none() || group_help_requested(args) {
         println!(
             "nub pm — manage the project's package manager\n\n\
              Usage: nub pm <command>\n\n\
@@ -12551,6 +12567,51 @@ mod tests {
         }
         // Unknown words fall through to the top-level page rather than erroring.
         assert!(!is_help_routable("definitely-not-a-command"));
+    }
+
+    #[test]
+    fn group_help_is_recognized_after_the_verb() {
+        // #653: `nub pm shim --help` installed the shims and edited the user's
+        // shell profiles, because the group's help guard only ever looked at
+        // argv[0]. The flag has to count at ANY position — the top-level scan
+        // hands it through untouched once `pm`/`node` is seen.
+        //
+        // Asserted on the predicate rather than by calling `run_pm`, on purpose:
+        // a test that drove the real verb would install shims into the test
+        // runner's own HOME the moment this regressed, and the suite has no
+        // HOME-isolation helper.
+        let argv = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+
+        for args in [
+            &["shim", "--help"][..],
+            &["shim", "-h"][..],
+            &["unshim", "--help"][..],
+            &["unshim", "-h"][..],
+            &["install", "22.13.0", "--help"][..],
+        ] {
+            assert!(
+                group_help_requested(&argv(args)),
+                "`{}` is a help request, not a command to run",
+                args.join(" ")
+            );
+        }
+        // The pre-existing argv[0] forms keep working.
+        for args in [&["--help"][..], &["-h"][..], &["help"][..]] {
+            assert!(group_help_requested(&argv(args)));
+        }
+        // A real verb with a real argument is untouched — no help flag, no match.
+        for args in [
+            &["shim"][..],
+            &["use", "pnpm"][..],
+            &["cache", "clear"][..],
+            &["install", "22.13.0"][..],
+        ] {
+            assert!(
+                !group_help_requested(&argv(args)),
+                "`{}` must still run",
+                args.join(" ")
+            );
+        }
     }
 
     #[test]

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -8518,10 +8518,14 @@ fn is_help_routable(word: &str) -> bool {
 /// top-level scan stops matching nub's own flags once a subcommand is seen (the
 /// three-position rule, so `nub run build --watch` reaches the script), which is
 /// right for the forwarding commands but leaves these groups to parse their own
-/// help. Without the flag-anywhere rule the sub-verbs never read past argv[0], so
-/// the flag is silently dropped and the verb RUNS — `nub pm shim --help` installs
-/// the shims and `nub pm unshim --help` removes them, both editing shell startup
-/// files a user was only asking about (#653).
+/// help. Without the flag-anywhere rule each group's help GUARD inspected argv[0]
+/// alone, and past it the flag met whatever the verb does with its arguments — so
+/// the same defect surfaced three ways. A verb taking no arguments ignored the
+/// flag and RAN: `nub pm shim --help` installs the shims and `nub pm unshim
+/// --help` removes them, both editing shell startup files a user was only asking
+/// about (#653). A verb taking a value consumed it as a bad one (`no published
+/// Node version matches "--help"`). And `nub agent docs` rejected it outright
+/// (`unexpected argument '--help'`).
 ///
 /// Safe as a blanket scan because no group forwards argv to a child process:
 /// their only argument consumers take a package-manager name, a version, or a


### PR DESCRIPTION
Every `nub pm` and `nub node` sub-verb ignored `--help`/`-h` and ran the verb. `nub pm shim --help` installed six shims and added a PATH block to every shell startup file; `nub pm unshim --help` removed them. The two `nub node` shim verbs behaved the same way.

The top-level scan stops matching nub's own flags once a subcommand is seen, so `nub run build --watch` reaches the script. Both groups bypass clap and guarded help on argv[0] only, so past it the flag was dropped.

Both now recognize a help flag at any position. Neither forwards argv to a child, and their argument consumers take a package-manager name or a version, so no help flag was valid there.

Closes #653