### PR TITLE
site: refresh the v0.7 schema snapshot after the Varlock enum landed

### DIFF
--- a/site/public/schema/v0.7.json
+++ b/site/public/schema/v0.7.json
@@ -311,7 +311,11 @@
           "type": "boolean"
         },
         {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "varlock"
+          ],
+          "description": "Hand the environment to Varlock. A file path goes in an array."
         },
         {
           "$ref": "#/$defs/stringArray"


### PR DESCRIPTION
`979f8fbb67` (#735) added the `varlock` enum value and its description to `latest.json` without refreshing the pinned v0.7 snapshot. `make version-check` has failed on `main` ever since, which red-lights the `Verify version consistency` gate and blocks the release workflow.

Refreshes `site/public/schema/v0.7.json` from `latest.json`, preserving the snapshot's own `$id` — the same fallout `f58f09f849` cleaned up after the transform fields landed.

Verified: `make version-check` exits 0 with this change and 2 without it, reproducing the gate's exact message.