### PR TITLE
ci: gate version consistency on pull requests, not just releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1288,6 +1288,23 @@ jobs:
           persist-credentials: false
       - run: node scripts/check-oxc-lockstep.mjs
 
+  # `make version-check` also runs in release.yml's verify job, but that fires on
+  # `v*` tags and on pushes to main — i.e. always AFTER the offending merge. #735
+  # edited site/public/schema/latest.json without refreshing its pinned snapshot,
+  # merged green, and surfaced only on main, where it blocked every release until
+  # #751. This job is what makes that fail on its own pull request instead. Same
+  # shape as oxc-lockstep above: one Make target that shells a single node -e, no
+  # toolchain and no path filter, because the drift it catches spans package.json,
+  # Cargo.toml, runtime/version.mjs and the published schema snapshots at once.
+  version-consistency:
+    name: Version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+      - run: make version-check
+
   # Make THIS job (`CI gate`) the sole required status check in branch protection.
   # A docs-only PR → Rust matrix skipped → this gate green → mergeable. A Rust PR
   # → matrix runs → this gate reflects it. The merge gate is never weakened: a
@@ -1295,7 +1312,7 @@ jobs:
   ci-gate:
     name: CI gate
     if: always()
-    needs: [matrix-plan, check, clippy, embed-runtime, windows-embed-roundtrip, test, pnp, fmt, types-fixtures, docs-links, site-build, oxc-lockstep]
+    needs: [matrix-plan, check, clippy, embed-runtime, windows-embed-roundtrip, test, pnp, fmt, types-fixtures, docs-links, site-build, oxc-lockstep, version-consistency]
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required job failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1299,6 +1299,8 @@ jobs:
   version-consistency:
     name: Version consistency
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:


### PR DESCRIPTION
`make version-check` runs in exactly one place — `release.yml`'s verify job — which fires on `v*` tags and on pushes to main, i.e. always after the offending merge. So #735 edited `site/public/schema/latest.json` without refreshing its pinned snapshot, merged green, and surfaced only on main, where it blocked every release until #751.

Adds a `Version consistency` job and wires it into the `CI gate` aggregate, in the same shape as `oxc lockstep`: checkout plus one Make target that shells a single `node -e`. No toolchain to install, no path filter to keep in sync — the drift it catches spans `package.json`, `Cargo.toml`, `runtime/version.mjs` and the published schema snapshots at once.

Verified: the command exits 2 on current main, catching the live drift, and 0 with #751 applied. `actionlint` clean.

## Merge #751 first

A `pull_request` checkout resolves `refs/pull/N/merge` — base merged with head — so this gate evaluates against current `main`, which fails `make version-check` today. Landing this before #751 would turn `CI gate` red on every other open PR until the snapshot is refreshed. #751 itself stays mergeable, since its own merge ref carries the fix.

This PR's own `Version consistency` job is red for that same reason, which is the gate catching the bug it exists for. No rebase is needed once #751 lands — the merge ref already reflects `main`, so re-running the checks is enough.

Refs #751