### PR TITLE
fix(pm): resolve a member-scoped update in the workspace-root frame

### DIFF
--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1670,6 +1670,60 @@ fn member_scoped_update_keeps_workspace_local_deps_anchored_at_the_root() {
     }
 }
 
+/// The alias rewrite needs the workspace's members in EVERY frame, not just
+/// the workspace-root one a shared-lockfile member resolves in.
+///
+/// Both configurations here keep the resolve at the `"."` importer, so an
+/// earlier cut of the #721 fix — which supplied the member map only when it
+/// switched frames — left the reported `ERR_NUB_WORKSPACE_PKG_NOT_FOUND`
+/// reproducing in exactly these two, while closing the issue.
+#[test]
+fn workspace_alias_resolves_for_updates_that_stay_in_the_dot_frame() {
+    // A member whose graph does NOT merge into a shared root lockfile:
+    // it writes its own, so it resolves at `.` anchored on itself, and
+    // the alias target has to come out `../lib` rather than `packages/lib`.
+    let dir = workspace_alias_fixture("ws-alias-unshared", r#""lib-alias": "workspace:lib@*""#);
+    std::fs::write(dir.join(".npmrc"), "shared-workspace-lockfile=false\n").unwrap();
+
+    let (stdout, stderr, code) = run_install(&dir, &["install"]);
+    assert_eq!(code, 0, "install must succeed: {stdout}{stderr}");
+    let (stdout, stderr, code) = run_install(&dir.join("packages/app"), &["up"]);
+    assert_eq!(
+        code, 0,
+        "`up` in a member with its own lockfile must resolve the alias: {stdout}{stderr}"
+    );
+    assert_eq!(
+        require_from_app(&dir, "lib-alias"),
+        "lib",
+        "the aliased member must still load after an unshared-lockfile `up`"
+    );
+
+    // An alias declared in the workspace ROOT's own manifest. `up` at the
+    // root is already the `.` frame, so nothing switches — but the root
+    // still needs the member map to find `lib`.
+    let root_dir = workspace_alias_fixture("ws-alias-rootdep", r#""x": "workspace:lib@*""#);
+    let root_manifest = root_dir.join("package.json");
+    std::fs::write(
+        &root_manifest,
+        r#"{ "name": "root", "private": true, "workspaces": ["packages/*"],
+             "dependencies": { "lib-at-root": "workspace:lib@*" } }"#,
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run_install(&root_dir, &["install"]);
+    assert_eq!(code, 0, "install must succeed: {stdout}{stderr}");
+    let (stdout, stderr, code) = run_install(&root_dir, &["up"]);
+    assert_eq!(
+        code, 0,
+        "`up` at the workspace root must resolve an alias the root declares: {stdout}{stderr}"
+    );
+    let lock = std::fs::read_to_string(root_dir.join("nub.lock")).unwrap();
+    assert!(
+        lock.contains("version: link:packages/lib"),
+        "the root's own alias must link to the member directory, got:\n{lock}"
+    );
+}
+
 /// `workspace:` only ever resolves against the workspace, so a spec naming a
 /// package that is not a member is a hard error — never a silent fall-through
 /// to the registry, which used to report the confusing

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1602,6 +1602,74 @@ fn workspace_alias_resolves_the_target_member_not_the_dependency_key() {
     );
 }
 
+/// `nub up` run INSIDE a workspace member must leave every workspace-local
+/// dependency resolving exactly where the root install left it.
+///
+/// A member-scoped update merges its graph into the workspace-root lockfile,
+/// so it has to resolve in the workspace-root frame. Anchored at the member
+/// instead (nubjs/nub#721) it broke two ways at once, one loud and one silent:
+///
+///   - `workspace:lib@*` — the alias rewrite looks the target member's
+///     directory up among the manifests it was handed, and a member-scoped
+///     resolve is handed only its own, so every sibling was missing and the
+///     update died with `ERR_NUB_WORKSPACE_PKG_NOT_FOUND` while the error
+///     itself listed the member as present.
+///   - `link:../lib` — `LocalSource` paths are stored relative to the
+///     resolver's project root, so a member anchor made them member-relative
+///     and the lockfile writer rebased them a SECOND time against the
+///     root-relative importer key. `link:../lib` was written `link:../../../lib`
+///     and the symlink pointed clean out of the workspace, with exit 0.
+///
+/// Asserting on the post-`up` lockfile AND on `require` catches both: the
+/// version strings pin the anchoring, `require` proves the tree on disk still
+/// resolves rather than dangling.
+#[test]
+fn member_scoped_update_keeps_workspace_local_deps_anchored_at_the_root() {
+    let dir = workspace_alias_fixture(
+        "ws-alias-up",
+        r#""lib-alias": "workspace:lib@*",
+           "by-path": "workspace:../lib",
+           "linked": "link:../lib""#,
+    );
+
+    let (stdout, stderr, code) = run_install(&dir, &["install"]);
+    assert_eq!(code, 0, "install must succeed: {stdout}{stderr}");
+
+    // The update runs from the member, which is the whole point.
+    let app = dir.join("packages/app");
+    let (stdout, stderr, code) = run_install(&app, &["up"]);
+    assert_eq!(
+        code, 0,
+        "`nub up` inside packages/app must succeed: {stdout}{stderr}"
+    );
+
+    let lock = std::fs::read_to_string(dir.join("nub.lock")).unwrap();
+    for needle in [
+        "specifier: workspace:lib@*",
+        "specifier: workspace:../lib",
+        "specifier: link:../lib",
+        "version: link:../lib",
+    ] {
+        assert!(
+            lock.contains(needle),
+            "after a member-scoped `up`, nub.lock must still contain `{needle}`, got:\n{lock}"
+        );
+    }
+    assert!(
+        !lock.contains("link:../../"),
+        "a `link:` target must stay anchored at the workspace root — an extra `../` \
+         walks out of the workspace entirely, got:\n{lock}"
+    );
+
+    for key in ["lib-alias", "by-path", "linked"] {
+        assert_eq!(
+            require_from_app(&dir, key),
+            "lib",
+            "after a member-scoped `up`, `require({key:?})` must still load `lib`"
+        );
+    }
+}
+
 /// `workspace:` only ever resolves against the workspace, so a spec naming a
 /// package that is not a member is a hard error — never a silent fall-through
 /// to the registry, which used to report the confusing

--- a/vendor/aube/crates/aube-resolver/src/builder.rs
+++ b/vendor/aube/crates/aube-resolver/src/builder.rs
@@ -38,6 +38,7 @@ impl Resolver {
             ignored_optional_dependencies: BTreeSet::new(),
             resolution_mode: ResolutionMode::Highest,
             project_root: PathBuf::from("."),
+            workspace_member_importers: BTreeMap::new(),
             ignore_scripts: false,
             minimum_release_age: None,
             catalogs: BTreeMap::new(),
@@ -85,6 +86,7 @@ impl Resolver {
                 ignored_optional_dependencies: BTreeSet::new(),
                 resolution_mode: ResolutionMode::Highest,
                 project_root: PathBuf::from("."),
+                workspace_member_importers: BTreeMap::new(),
                 ignore_scripts: false,
                 minimum_release_age: None,
                 catalogs: BTreeMap::new(),
@@ -293,6 +295,19 @@ impl Resolver {
     /// local package's transitive deps.
     pub fn with_project_root(mut self, project_root: PathBuf) -> Self {
         self.project_root = project_root;
+        self
+    }
+
+    /// Seed the workspace member `name` → importer-path map for a
+    /// caller that resolves only a subset of the workspace's
+    /// manifests, so a `workspace:<name>@<range>` alias can still find
+    /// a member the `manifests` slice omits. Paths are relative to the
+    /// project root, matching the importer keys.
+    pub fn with_workspace_member_importers(
+        mut self,
+        workspace_member_importers: BTreeMap<String, String>,
+    ) -> Self {
+        self.workspace_member_importers = workspace_member_importers;
         self
     }
 

--- a/vendor/aube/crates/aube-resolver/src/lib.rs
+++ b/vendor/aube/crates/aube-resolver/src/lib.rs
@@ -156,6 +156,16 @@ pub struct Resolver {
     /// target directory. Defaults to the current working directory;
     /// callers set it via `with_project_root`.
     project_root: PathBuf,
+    /// Workspace member `name` → importer path, for a caller that
+    /// resolves a SUBSET of the workspace's manifests. The driver
+    /// otherwise derives this map from the `manifests` slice, which is
+    /// only complete when the caller passes every member — true for
+    /// install, false for an `update` scoped to one member. Without it
+    /// a `workspace:<name>@<range>` alias naming some *other* member
+    /// cannot find that member's directory. Manifest-derived entries
+    /// are overlaid on top, so a caller passing the full set is
+    /// unaffected.
+    workspace_member_importers: BTreeMap<String, String>,
     /// When true, resolver-time `exec:` generators are blocked the
     /// same way fetch-time execution is blocked.
     ignore_scripts: bool,

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -289,12 +289,18 @@ impl<'a> ResolveDriver<'a> {
         // A member's importer path IS its directory, so the `workspace:`
         // alias rewrite reads its `link:` targets straight off here. A
         // manifest with no `name` cannot be aliased and is skipped.
-        let workspace_member_importers: BTreeMap<String, String> = manifests
-            .iter()
-            .filter_map(|(importer_path, manifest)| {
-                Some((manifest.name.clone()?, importer_path.clone()))
-            })
-            .collect();
+        //
+        // Seeded from the resolver first: a caller resolving a SUBSET of
+        // the workspace (`update` scoped to one member) supplies the
+        // members its `manifests` slice omits, without which an alias
+        // naming a sibling would find nothing. The manifests overlay it,
+        // so whenever the caller passes the full set — install — the map
+        // is exactly what it was before.
+        let mut workspace_member_importers: BTreeMap<String, String> =
+            resolver.workspace_member_importers.clone();
+        workspace_member_importers.extend(manifests.iter().filter_map(
+            |(importer_path, manifest)| Some((manifest.name.clone()?, importer_path.clone())),
+        ));
         // ISO-8601 UTC cutoff string. npm's registry `time` map uses
         // `Z`-suffixed UTC timestamps throughout, which sort
         // lexicographically — so a raw `String` doubles as a

--- a/vendor/aube/crates/aube/src/commands/update.rs
+++ b/vendor/aube/crates/aube/src/commands/update.rs
@@ -735,13 +735,57 @@ pub async fn run(
             Some((h, f)) => (Some(h), f),
             None => (None, Vec::new()),
         };
-    let workspace_package_versions = workspace_package_versions(&cwd)?;
+    let (workspace_package_versions, workspace_member_importers) = workspace_members(&cwd)?;
     let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs)?;
     if let Some(host) = read_package_host {
         resolver = resolver
             .with_read_package_hook(Box::new(host) as Box<dyn aube_resolver::ReadPackageHook>);
     }
-    let resolver_manifests = [(".".to_string(), resolver_manifest)];
+    // A member-scoped update MERGES its graph into the workspace-root
+    // lockfile, so it has to resolve in the workspace-root frame — the
+    // same frame install uses. Two things break when it resolves
+    // anchored at the member instead, both because the transplant at
+    // `merge_update_graph_into_workspace_lockfile` moves entries between
+    // frames without translating them:
+    //
+    //   - `LocalSource` paths are stored relative to the resolver's
+    //     project root (see its doc comment). Anchored at the member
+    //     they come out member-relative, and the writer then rebases
+    //     them a SECOND time against the root-relative importer key —
+    //     `link:../pkg2` declared in `packages/pkg1` was written as
+    //     `link:../../../pkg2`, a symlink pointing clean out of the
+    //     workspace, with exit 0.
+    //   - the `workspace:<name>@<range>` alias rewrite needs the target
+    //     member's directory, and a member-scoped resolve passes only
+    //     its own manifest, so every sibling was missing
+    //     (nubjs/nub#721). `workspace_member_importers` supplies them.
+    //
+    // The condition mirrors `write_update_lockfile`'s exactly: only a
+    // member whose graph lands in the shared root lockfile switches
+    // frames. A member carrying its OWN lockfile still resolves and
+    // writes at `.`, so its `existing` (keyed `.`) keeps matching.
+    // The root and the importer key move together or not at all: a
+    // project root the importer path isn't relative to would anchor
+    // `link:` targets at the wrong directory, which is the very bug
+    // above. So the frame is one value, derived once.
+    let shared_workspace_frame = match crate::dirs::find_workspace_root(&cwd) {
+        Some(ws) if ws.as_path() != cwd.as_path() && resolve_shared_workspace_lockfile(&ws)? => {
+            super::workspace_importer_path(&ws, &cwd)
+                .ok()
+                .map(|importer| (ws, importer))
+        }
+        _ => None,
+    };
+    let resolve_importer = match shared_workspace_frame {
+        Some((workspace_root, importer)) => {
+            resolver = resolver
+                .with_project_root(workspace_root)
+                .with_workspace_member_importers(workspace_member_importers);
+            importer
+        }
+        None => ".".to_string(),
+    };
+    let resolver_manifests = [(resolve_importer.clone(), resolver_manifest)];
     let mut graph = resolver
         .resolve_workspace(
             &resolver_manifests,
@@ -761,9 +805,13 @@ pub async fn run(
         BTreeMap::new();
     for target in &catalog_targets {
         let real_name = resolve_real_name(&target.manifest_key);
-        let Some(resolved) = lookup_pkg(&graph, &["."], &target.manifest_key, &real_name)
-            .map(|pkg| pkg.version.clone())
-        else {
+        let Some(resolved) = lookup_pkg(
+            &graph,
+            &[resolve_importer.as_str()],
+            &target.manifest_key,
+            &real_name,
+        )
+        .map(|pkg| pkg.version.clone()) else {
             continue;
         };
         let persisted_range = if no_save {
@@ -803,10 +851,10 @@ pub async fn run(
     // `pkg.alias_of == Some("real")`, so the version-lookup match has to
     // accept either the manifest key (the alias) or the real name —
     // matching only on `real_name` would miss aliased entries.
-    // The freshly resolved `graph` was built from `resolver_manifests = [(".", ...)]`,
-    // so its only importer key is "." regardless of the cwd's path under
-    // any workspace root.
-    let new_importers: Vec<&str> = vec!["."];
+    // The freshly resolved `graph` carries exactly one importer, keyed by
+    // whichever frame the resolve ran in — the member's own importer path
+    // when the graph merges into a shared workspace lockfile, else ".".
+    let new_importers: Vec<&str> = vec![resolve_importer.as_str()];
     for manifest_key in &manifest_keys_to_update {
         let real_name = resolve_real_name(manifest_key);
 
@@ -938,6 +986,7 @@ pub async fn run(
         &cwd,
         &graph,
         &manifest,
+        &resolve_importer,
         args.ignore_pnpmfile,
         absolute_cli_pnpmfile(&cwd, args.pnpmfile.as_deref()).as_deref(),
     )
@@ -1079,19 +1128,32 @@ fn select_global_updates(
     Ok(by_hash.into_values().collect())
 }
 
-fn workspace_package_versions(cwd: &std::path::Path) -> miette::Result<HashMap<String, String>> {
+/// Every workspace member, as `name` → version and `name` → importer
+/// path (relative to the workspace root, matching the lockfile's
+/// importer keys).
+///
+/// One walk produces both because they must agree: the resolver checks
+/// a `workspace:` target against the version map, then reads its
+/// directory out of the importer map, and a target present in one but
+/// not the other reports as "not in this workspace" while the error
+/// itself lists it (nubjs/nub#721).
+fn workspace_members(
+    cwd: &std::path::Path,
+) -> miette::Result<(HashMap<String, String>, BTreeMap<String, String>)> {
     let workspace_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
     let workspace_packages = aube_workspace::find_workspace_packages(&workspace_root)
         .into_diagnostic()
         .wrap_err("failed to discover workspace packages")?;
     let mut versions = HashMap::new();
+    let mut importers = BTreeMap::new();
     // Include the root package itself as a workspace target so
     // sub-packages can use `workspace:*` to depend on it.
     match aube_manifest::PackageJson::from_path(&workspace_root.join("package.json")) {
         Ok(root) => {
             if let Some(name) = root.name {
                 let version = root.version.unwrap_or_else(|| "0.0.0".to_string());
-                versions.insert(name, version);
+                versions.insert(name.clone(), version);
+                importers.insert(name, ".".to_string());
             }
         }
         // Yaml-only workspaces may not have a root package.json;
@@ -1107,7 +1169,10 @@ fn workspace_package_versions(cwd: &std::path::Path) -> miette::Result<HashMap<S
             .wrap_err_with(|| format!("failed to read {}/package.json", pkg_dir.display()))?;
         if let Some(name) = pkg_manifest.name {
             let version = pkg_manifest.version.unwrap_or_else(|| "0.0.0".to_string());
-            versions.insert(name, version);
+            versions.insert(name.clone(), version);
+            if let Ok(importer) = super::workspace_importer_path(&workspace_root, &pkg_dir) {
+                importers.insert(name, importer);
+            }
         } else {
             tracing::warn!(
                 code = aube_codes::warnings::WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME,
@@ -1116,7 +1181,7 @@ fn workspace_package_versions(cwd: &std::path::Path) -> miette::Result<HashMap<S
             );
         }
     }
-    Ok(versions)
+    Ok((versions, importers))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1721,6 +1786,9 @@ async fn merge_filtered_update_lockfile(
         root_manifest,
         root_graph,
         pkg_graph,
+        // Parsed back off the package's OWN lockfile, which is a
+        // standalone project lockfile — its sole importer is ".".
+        ".",
         ignore_pnpmfile,
         cli_pnpmfile,
     )
@@ -1754,6 +1822,7 @@ async fn write_update_lockfile(
     cwd: &std::path::Path,
     graph: &aube_lockfile::LockfileGraph,
     manifest: &aube_manifest::PackageJson,
+    source_importer: &str,
     ignore_pnpmfile: bool,
     cli_pnpmfile: Option<&std::path::Path>,
 ) -> miette::Result<()> {
@@ -1774,6 +1843,7 @@ async fn write_update_lockfile(
         &root_manifest,
         root_graph,
         graph.clone(),
+        source_importer,
         ignore_pnpmfile,
         cli_pnpmfile,
     )
@@ -1786,17 +1856,25 @@ async fn merge_update_graph_into_workspace_lockfile(
     root_manifest: &aube_manifest::PackageJson,
     mut root_graph: aube_lockfile::LockfileGraph,
     mut pkg_graph: aube_lockfile::LockfileGraph,
+    source_importer: &str,
     ignore_pnpmfile: bool,
     cli_pnpmfile: Option<&std::path::Path>,
 ) -> miette::Result<()> {
     let importer_path = super::workspace_importer_path(workspace_root, pkg_dir)?;
-    let pkg_deps = pkg_graph.importers.remove(".").ok_or_else(|| {
+    // `source_importer` is the key the member's graph carries, which
+    // depends on the frame it was produced in: the member's own importer
+    // path for an in-memory graph resolved in the workspace-root frame,
+    // "." for one parsed back off a per-package lockfile on disk. Both
+    // land under `importer_path` here.
+    let pkg_deps = pkg_graph.importers.remove(source_importer).ok_or_else(|| {
         miette!(
-            "workspace update for {} resolved without a root importer",
+            "workspace update for {} resolved without a `{source_importer}` importer",
             pkg_dir.display()
         )
     })?;
-    let pkg_skipped_optional = pkg_graph.skipped_optional_dependencies.remove(".");
+    let pkg_skipped_optional = pkg_graph
+        .skipped_optional_dependencies
+        .remove(source_importer);
 
     root_graph.importers.insert(importer_path.clone(), pkg_deps);
     if let Some(skipped) = pkg_skipped_optional {
@@ -1808,7 +1886,7 @@ async fn merge_update_graph_into_workspace_lockfile(
             .skipped_optional_dependencies
             .remove(&importer_path);
     }
-    if let Some(extra) = pkg_graph.workspace_extra_fields.remove(".") {
+    if let Some(extra) = pkg_graph.workspace_extra_fields.remove(source_importer) {
         root_graph
             .workspace_extra_fields
             .insert(importer_path, extra);
@@ -2333,10 +2411,52 @@ mod tests {
         )
         .unwrap();
 
-        let versions = workspace_package_versions(root).unwrap();
+        let versions = workspace_members(root).unwrap().0;
         assert_eq!(versions.get("@my/root").unwrap(), "2.0.0");
         assert_eq!(versions.get("@my/lib").unwrap(), "1.0.0");
         assert_eq!(versions.len(), 2);
+    }
+
+    /// The importer map has to cover exactly the members the version map
+    /// does — a target in one but not the other is what made a
+    /// member-scoped `up` report a sibling as "not in this workspace"
+    /// while listing it as present (nubjs/nub#721). Paths are relative to
+    /// the workspace root, matching the lockfile's importer keys.
+    #[test]
+    fn workspace_members_maps_every_member_to_its_importer_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("package.json"),
+            br#"{"name": "@my/root", "version": "2.0.0"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("pnpm-workspace.yaml"),
+            b"packages:\n  - packages/*\n",
+        )
+        .unwrap();
+        for member in ["lib", "app"] {
+            std::fs::create_dir_all(root.join("packages").join(member)).unwrap();
+            std::fs::write(
+                root.join("packages").join(member).join("package.json"),
+                format!(r#"{{"name": "@my/{member}", "version": "1.0.0"}}"#),
+            )
+            .unwrap();
+        }
+
+        let (versions, importers) = workspace_members(root).unwrap();
+        assert_eq!(importers.get("@my/root").unwrap(), ".");
+        assert_eq!(importers.get("@my/lib").unwrap(), "packages/lib");
+        assert_eq!(importers.get("@my/app").unwrap(), "packages/app");
+        let mut named: Vec<&String> = versions.keys().collect();
+        named.sort();
+        let mut mapped: Vec<&String> = importers.keys().collect();
+        mapped.sort();
+        assert_eq!(
+            named, mapped,
+            "every member with a version must also have an importer path"
+        );
     }
 
     #[test]
@@ -2356,7 +2476,7 @@ mod tests {
         )
         .unwrap();
 
-        let versions = workspace_package_versions(root).unwrap();
+        let versions = workspace_members(root).unwrap().0;
         assert_eq!(versions.get("@my/root").unwrap(), "0.0.0");
         assert_eq!(versions.get("@my/lib").unwrap(), "1.0.0");
     }
@@ -2378,7 +2498,7 @@ mod tests {
         )
         .unwrap();
 
-        let versions = workspace_package_versions(root).unwrap();
+        let versions = workspace_members(root).unwrap().0;
         assert_eq!(versions.len(), 1);
         assert_eq!(versions.get("@my/lib").unwrap(), "1.0.0");
         assert!(!versions.contains_key("@my/root"));
@@ -2402,7 +2522,7 @@ mod tests {
         )
         .unwrap();
 
-        let versions = workspace_package_versions(root).unwrap();
+        let versions = workspace_members(root).unwrap().0;
         assert_eq!(versions.get("@my/root").unwrap(), "3.0.0");
         assert_eq!(versions.get("@my/docs").unwrap(), "1.0.0");
     }

--- a/vendor/aube/crates/aube/src/commands/update.rs
+++ b/vendor/aube/crates/aube/src/commands/update.rs
@@ -735,56 +735,68 @@ pub async fn run(
             Some((h, f)) => (Some(h), f),
             None => (None, Vec::new()),
         };
-    let (workspace_package_versions, workspace_member_importers) = workspace_members(&cwd)?;
+    let (workspace_package_versions, workspace_member_dirs) = workspace_members(&cwd)?;
     let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs)?;
     if let Some(host) = read_package_host {
         resolver = resolver
             .with_read_package_hook(Box::new(host) as Box<dyn aube_resolver::ReadPackageHook>);
     }
-    // A member-scoped update MERGES its graph into the workspace-root
-    // lockfile, so it has to resolve in the workspace-root frame — the
-    // same frame install uses. Two things break when it resolves
-    // anchored at the member instead, both because the transplant at
-    // `merge_update_graph_into_workspace_lockfile` moves entries between
-    // frames without translating them:
+    // An update resolves ONE importer, so the resolver's own view of the
+    // workspace has to be supplied rather than derived from that single
+    // manifest. Two independent things follow, and conflating them is
+    // what left nubjs/nub#721 half-fixed:
     //
-    //   - `LocalSource` paths are stored relative to the resolver's
-    //     project root (see its doc comment). Anchored at the member
-    //     they come out member-relative, and the writer then rebases
-    //     them a SECOND time against the root-relative importer key —
-    //     `link:../pkg2` declared in `packages/pkg1` was written as
+    //   - WHICH FRAME the resolve runs in is conditional. A member whose
+    //     graph MERGES into the shared root lockfile must resolve in the
+    //     workspace-root frame, because `LocalSource` paths are stored
+    //     relative to the resolver's project root (see its doc comment)
+    //     and the transplant at `merge_update_graph_into_workspace_lockfile`
+    //     moves entries between frames without translating them. Anchored
+    //     at the member they come out member-relative and the writer
+    //     rebases them a SECOND time against the root-relative importer
+    //     key: `link:../pkg2` declared in `packages/pkg1` was written
     //     `link:../../../pkg2`, a symlink pointing clean out of the
-    //     workspace, with exit 0.
-    //   - the `workspace:<name>@<range>` alias rewrite needs the target
-    //     member's directory, and a member-scoped resolve passes only
-    //     its own manifest, so every sibling was missing
-    //     (nubjs/nub#721). `workspace_member_importers` supplies them.
+    //     workspace, with exit 0. A member carrying its OWN lockfile
+    //     writes at `.` and so must resolve at `.`, keeping its
+    //     `existing` (also keyed `.`) matching.
+    //   - The MEMBER MAP is needed unconditionally. The
+    //     `workspace:<name>@<range>` alias rewrite has to find the target
+    //     member's directory whatever frame we are in, and no frame
+    //     supplies it, because the manifests slice only ever holds the
+    //     one importer being updated. Gating the map on the frame left
+    //     the reported error reproducing in the two configurations that
+    //     stay at `.`: a member under `shared-workspace-lockfile=false`,
+    //     and an alias declared in the workspace ROOT's own manifest.
     //
-    // The condition mirrors `write_update_lockfile`'s exactly: only a
-    // member whose graph lands in the shared root lockfile switches
-    // frames. A member carrying its OWN lockfile still resolves and
-    // writes at `.`, so its `existing` (keyed `.`) keeps matching.
-    // The root and the importer key move together or not at all: a
-    // project root the importer path isn't relative to would anchor
-    // `link:` targets at the wrong directory, which is the very bug
-    // above. So the frame is one value, derived once.
+    // So: derive the frame, then express the member map in it. The paths
+    // must share the frame's base or the alias would link to the wrong
+    // directory — from a non-shared member the target is `../pkg2`, from
+    // the workspace root it is `packages/pkg2`.
     let shared_workspace_frame = match crate::dirs::find_workspace_root(&cwd) {
         Some(ws) if ws.as_path() != cwd.as_path() && resolve_shared_workspace_lockfile(&ws)? => {
-            super::workspace_importer_path(&ws, &cwd)
-                .ok()
-                .map(|importer| (ws, importer))
+            // `?`, not `.ok()`: the write side runs this same computation
+            // with `?` after `package.json` has already been rewritten, so
+            // swallowing a failure here only defers the abort to a point
+            // where the manifest is updated and no lockfile was written.
+            let importer = super::workspace_importer_path(&ws, &cwd)?;
+            Some((ws, importer))
         }
         _ => None,
     };
-    let resolve_importer = match shared_workspace_frame {
-        Some((workspace_root, importer)) => {
-            resolver = resolver
-                .with_project_root(workspace_root)
-                .with_workspace_member_importers(workspace_member_importers);
-            importer
-        }
-        None => ".".to_string(),
+    let (resolve_root, resolve_importer) = match shared_workspace_frame {
+        Some((workspace_root, importer)) => (workspace_root, importer),
+        None => (cwd.clone(), ".".to_string()),
     };
+    let mut workspace_member_importers = BTreeMap::new();
+    for (name, dir) in &workspace_member_dirs {
+        workspace_member_importers.insert(
+            name.clone(),
+            super::workspace_importer_path(&resolve_root, dir)?,
+        );
+    }
+    resolver = resolver
+        .with_project_root(resolve_root)
+        .with_workspace_member_importers(workspace_member_importers);
     let resolver_manifests = [(resolve_importer.clone(), resolver_manifest)];
     let mut graph = resolver
         .resolve_workspace(
@@ -1128,24 +1140,31 @@ fn select_global_updates(
     Ok(by_hash.into_values().collect())
 }
 
-/// Every workspace member, as `name` → version and `name` → importer
-/// path (relative to the workspace root, matching the lockfile's
-/// importer keys).
+/// Every workspace member, as `name` → version and `name` → its
+/// directory.
 ///
-/// One walk produces both because they must agree: the resolver checks
-/// a `workspace:` target against the version map, then reads its
-/// directory out of the importer map, and a target present in one but
-/// not the other reports as "not in this workspace" while the error
-/// itself lists it (nubjs/nub#721).
+/// One walk fills both, and both are written in the same breath, so
+/// they cannot disagree: the resolver checks a `workspace:` target
+/// against the version map and then reads its directory out of the
+/// other, and a target present in one but not the other reports as
+/// "not in this workspace" while the error itself lists it
+/// (nubjs/nub#721).
+///
+/// Directories rather than importer paths because the caller has to
+/// express them relative to whichever project root its resolve runs
+/// in, which this function cannot know.
 fn workspace_members(
     cwd: &std::path::Path,
-) -> miette::Result<(HashMap<String, String>, BTreeMap<String, String>)> {
+) -> miette::Result<(
+    HashMap<String, String>,
+    BTreeMap<String, std::path::PathBuf>,
+)> {
     let workspace_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
     let workspace_packages = aube_workspace::find_workspace_packages(&workspace_root)
         .into_diagnostic()
         .wrap_err("failed to discover workspace packages")?;
     let mut versions = HashMap::new();
-    let mut importers = BTreeMap::new();
+    let mut dirs = BTreeMap::new();
     // Include the root package itself as a workspace target so
     // sub-packages can use `workspace:*` to depend on it.
     match aube_manifest::PackageJson::from_path(&workspace_root.join("package.json")) {
@@ -1153,7 +1172,7 @@ fn workspace_members(
             if let Some(name) = root.name {
                 let version = root.version.unwrap_or_else(|| "0.0.0".to_string());
                 versions.insert(name.clone(), version);
-                importers.insert(name, ".".to_string());
+                dirs.insert(name, workspace_root.clone());
             }
         }
         // Yaml-only workspaces may not have a root package.json;
@@ -1170,9 +1189,7 @@ fn workspace_members(
         if let Some(name) = pkg_manifest.name {
             let version = pkg_manifest.version.unwrap_or_else(|| "0.0.0".to_string());
             versions.insert(name.clone(), version);
-            if let Ok(importer) = super::workspace_importer_path(&workspace_root, &pkg_dir) {
-                importers.insert(name, importer);
-            }
+            dirs.insert(name, pkg_dir);
         } else {
             tracing::warn!(
                 code = aube_codes::warnings::WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME,
@@ -1181,7 +1198,7 @@ fn workspace_members(
             );
         }
     }
-    Ok((versions, importers))
+    Ok((versions, dirs))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2417,13 +2434,19 @@ mod tests {
         assert_eq!(versions.len(), 2);
     }
 
-    /// The importer map has to cover exactly the members the version map
+    /// The directory map has to cover exactly the members the version map
     /// does — a target in one but not the other is what made a
     /// member-scoped `up` report a sibling as "not in this workspace"
-    /// while listing it as present (nubjs/nub#721). Paths are relative to
-    /// the workspace root, matching the lockfile's importer keys.
+    /// while listing it as present (nubjs/nub#721).
+    ///
+    /// The second half pins the property the caller depends on: a
+    /// directory expressed against the resolve's project root yields that
+    /// frame's importer key, and the answer DIFFERS per frame — from the
+    /// workspace root `@my/lib` is `packages/lib`, from a sibling member
+    /// it is `../lib`. Gating the map on one frame is what left #721
+    /// reproducing under `shared-workspace-lockfile=false`.
     #[test]
-    fn workspace_members_maps_every_member_to_its_importer_path() {
+    fn workspace_members_maps_every_member_to_its_directory() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         std::fs::write(
@@ -2445,17 +2468,30 @@ mod tests {
             .unwrap();
         }
 
-        let (versions, importers) = workspace_members(root).unwrap();
-        assert_eq!(importers.get("@my/root").unwrap(), ".");
-        assert_eq!(importers.get("@my/lib").unwrap(), "packages/lib");
-        assert_eq!(importers.get("@my/app").unwrap(), "packages/app");
+        let (versions, dirs) = workspace_members(root).unwrap();
         let mut named: Vec<&String> = versions.keys().collect();
         named.sort();
-        let mut mapped: Vec<&String> = importers.keys().collect();
+        let mut mapped: Vec<&String> = dirs.keys().collect();
         mapped.sort();
         assert_eq!(
             named, mapped,
-            "every member with a version must also have an importer path"
+            "every member with a version must also have a directory"
+        );
+
+        // Resolving from the workspace root — what a shared-lockfile
+        // member-scoped update uses.
+        let from_root =
+            |name: &str| crate::commands::workspace_importer_path(root, &dirs[name]).unwrap();
+        assert_eq!(from_root("@my/root"), ".");
+        assert_eq!(from_root("@my/lib"), "packages/lib");
+
+        // Resolving from a member — what an update under
+        // `shared-workspace-lockfile=false` uses. Same map, different
+        // frame, so the alias target has to come out `../lib`.
+        let app = root.join("packages/app");
+        assert_eq!(
+            crate::commands::workspace_importer_path(&app, &dirs["@my/lib"]).unwrap(),
+            "../lib"
         );
     }
 


### PR DESCRIPTION
`nub up` inside a workspace member resolved anchored at the member, then merged into the workspace-root lockfile without translating frames.

Two defects. `workspace:<name>@<range>` failed with ERR_NUB_WORKSPACE_PKG_NOT_FOUND: the alias map held only the member's own manifest. `link:../pkg2` in `packages/pkg1` was rewritten to `link:../../../pkg2` — dangling, exit 0. The second needs no alias and reproduces on 0.7.4.

Fix: resolve in the workspace-root frame when the graph merges into the shared root lockfile. A member with its own lockfile still resolves at `.`.

Verified on pnpm-lock.yaml, nub.lock and bun.lock, against pnpm 10.15.1. New test confirmed red on both assertions.

Closes #721