### PR TITLE
ci: make the embed fixtures able to detect a missing vendored runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,20 +452,36 @@ jobs:
           if (-not (Test-Path $nub)) { throw "nub.exe not found at $nub" }
 
           # Isolated work dir (no package.json/.nvmrc) so nub uses the PATH Node and
-          # no project pin interferes. `enum` is NON-ERASABLE, and that is the whole
-          # point: Node has stripped type ANNOTATIONS natively since 23.6, so a
-          # types-only fixture executes on plain Node and proves nothing about nub —
-          # measured, this job printed its success marker even in a run where
-          # extraction had failed outright. Node rejects `enum`, so only a real
+          # no project pin interferes. The fixture carries two constructs because they
+          # fail on different halves of the blob.
+          #
+          # `enum` is NON-ERASABLE: Node has stripped type ANNOTATIONS natively since
+          # 23.6, so a types-only fixture executes on plain Node and proves nothing
+          # about nub — measured, this job printed its success marker even in a run
+          # where extraction had failed outright. Node rejects `enum`, so only a real
           # extract -> dlopen -> transpile can execute this file.
+          #
+          # `enum` alone is still blind to the vendored node_modules, because oxc
+          # inlines it and it pulls no helper. The legacy DECORATOR is what covers
+          # them: its transpiled output requires `@oxc-project/runtime/helpers/
+          # decorateMetadata`, and an extracted tree has no parent node_modules to
+          # resolve that through — only its own (`vendored_node_path`,
+          # crates/nub-core/src/node/spawn.rs). Measured against a locally built
+          # embed-runtime binary staged with an EMPTY runtime/node_modules: the
+          # enum-only fixture exits 0 and prints the success marker, this one exits 1
+          # with MODULE_NOT_FOUND. That gap is the shape a packager's smoke test
+          # misses. Legacy decorators down-level on every Node version, so this does
+          # not drift with whatever Node the runner ships.
           $work = Join-Path $env:RUNNER_TEMP "fixture"
           if (Test-Path $work) { Remove-Item -Recurse -Force $work }
           New-Item -ItemType Directory -Force -Path $work | Out-Null
+          '{"compilerOptions":{"experimentalDecorators":true,"emitDecoratorMetadata":true}}' | Set-Content -Encoding utf8 (Join-Path $work "tsconfig.json")
           $fixture = Join-Path $work "embed.ts"
           @'
           enum Answer { Value = 42 }
-          const greeting: string = "embed-roundtrip-ok";
-          console.log(`${greeting}-${Answer.Value}`);
+          function tag(_t: any, _k: string, d: PropertyDescriptor) { return d; }
+          class Probe { @tag greet(): string { return "embed-roundtrip-ok"; } }
+          console.log(`${new Probe().greet()}-${Answer.Value}`);
           '@ | Set-Content -Encoding utf8 $fixture
 
           # --- First run: must extract runtime + dlopen addon + transpile + execute ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,8 +470,15 @@ jobs:
           # embed-runtime binary staged with an EMPTY runtime/node_modules: the
           # enum-only fixture exits 0 and prints the success marker, this one exits 1
           # with MODULE_NOT_FOUND. That gap is the shape a packager's smoke test
-          # misses. Legacy decorators down-level on every Node version, so this does
-          # not drift with whatever Node the runner ships.
+          # misses.
+          #
+          # This stays a CommonJS entry (no package.json) because the step above pins
+          # Node 24. Down-levelling a legacy decorator is version-independent, but
+          # RESOLVING its helper from a CJS entry is not — that shape is unsupported
+          # below require(esm) (Node <20.19 / 22.0-22.11), which is why the repo's own
+          # `legacy_decorators_require_experimental_flag` skips it
+          # (crates/nub-cli/tests/integration.rs). The pin is what keeps this clear of
+          # that floor. release.yml's gate pins no Node, so it uses an ESM entry instead.
           $work = Join-Path $env:RUNNER_TEMP "fixture"
           if (Test-Path $work) { Remove-Item -Recurse -Force $work }
           New-Item -ItemType Directory -Force -Path $work | Out-Null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1090,11 +1090,21 @@ jobs:
       # smoke.sh, which installs from npm — i.e. it runs AFTER publish, past the
       # irreversible step.
       #
-      # A legacy decorator is the version-INDEPENDENT detector. oxc down-levels it on
-      # every Node, so its helper require must resolve through the extracted tree's own
-      # node_modules. A Temporal/URLPattern/Float16Array probe cannot do this job: those
-      # are native on a modern runner Node, so they answer "function" on a binary whose
-      # polyfills never loaded.
+      # A legacy decorator is the detector, and a Temporal/URLPattern/Float16Array probe
+      # cannot do this job: those are native on a modern runner Node, so they answer
+      # "function" on a binary whose polyfills never loaded. oxc down-levels a legacy
+      # decorator on every Node version, so its helper import must resolve through the
+      # extracted tree's own node_modules.
+      #
+      # The fixture is an ESM entry (`{"type":"module"}`) deliberately. Down-levelling is
+      # version-independent, but RESOLVING the helper from a CommonJS entry is not: a CJS
+      # entry whose transpiled output `require()`s an external helper is unsupported below
+      # require(esm) (Node <20.19 / 22.0-22.11), which is why the repo's own
+      # `legacy_decorators_require_experimental_flag` skips that shape
+      # (crates/nub-cli/tests/integration.rs). This job pins no Node and inherits whatever
+      # each runner image ships, so an ESM entry keeps the gate off that floor by
+      # construction instead of depending on image versions. The fixture has no imports,
+      # so the package.json changes nothing else.
       - name: Assert the packaged binary resolves a vendored transpile helper
         shell: bash
         run: |
@@ -1103,6 +1113,7 @@ jobs:
           WORK="$RUNNER_TEMP/nub-helper-smoke-${{ matrix.platform }}"
           rm -rf "$WORK"
           mkdir -p "$WORK"
+          printf '%s\n' '{"type":"module"}' > "$WORK/package.json"
           printf '%s\n' '{"compilerOptions":{"experimentalDecorators":true,"emitDecoratorMetadata":true}}' > "$WORK/tsconfig.json"
           printf '%s\n' \
             'function tag(_t: any, _k: string, d: PropertyDescriptor) { return d; }' \
@@ -1111,7 +1122,7 @@ jobs:
             > "$WORK/helper.ts"
           if ! OUT="$(cd "$WORK" && "$BIN" helper.ts 2>&1)"; then
             echo "$OUT"
-            echo "::error::${{ matrix.platform }} binary cannot run a file needing a transpile helper — its embedded runtime is missing the vendored node_modules. Refusing to publish."
+            echo "::error::${{ matrix.platform }} binary could not run a file that needs a transpile helper — see the output above. The usual cause is an embedded runtime missing its vendored node_modules; a transpile failure or an unusable runner Node lands here too. Refusing to publish."
             exit 1
           fi
           case "$OUT" in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1083,6 +1083,48 @@ jobs:
             echo "✓ ${{ matrix.platform }} binary runs and reports version '$REPORTED' (non-publishing dispatch)"
           fi
 
+      # A binary whose embedded runtime is missing its vendored node_modules passes
+      # `--version` above AND the compile fixture below, because that fixture is plain
+      # JS and never transpiles. It fails only on a file needing a transpile HELPER.
+      # Before this step the earliest check that could see it was .github/scripts/
+      # smoke.sh, which installs from npm — i.e. it runs AFTER publish, past the
+      # irreversible step.
+      #
+      # A legacy decorator is the version-INDEPENDENT detector. oxc down-levels it on
+      # every Node, so its helper require must resolve through the extracted tree's own
+      # node_modules. A Temporal/URLPattern/Float16Array probe cannot do this job: those
+      # are native on a modern runner Node, so they answer "function" on a binary whose
+      # polyfills never loaded.
+      - name: Assert the packaged binary resolves a vendored transpile helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN="$PWD/nub-pkg/${{ matrix.bin }}"
+          WORK="$RUNNER_TEMP/nub-helper-smoke-${{ matrix.platform }}"
+          rm -rf "$WORK"
+          mkdir -p "$WORK"
+          printf '%s\n' '{"compilerOptions":{"experimentalDecorators":true,"emitDecoratorMetadata":true}}' > "$WORK/tsconfig.json"
+          printf '%s\n' \
+            'function tag(_t: any, _k: string, d: PropertyDescriptor) { return d; }' \
+            'class Probe { @tag greet(): string { return "helper-ok"; } }' \
+            'console.log(new Probe().greet());' \
+            > "$WORK/helper.ts"
+          if ! OUT="$(cd "$WORK" && "$BIN" helper.ts 2>&1)"; then
+            echo "$OUT"
+            echo "::error::${{ matrix.platform }} binary cannot run a file needing a transpile helper — its embedded runtime is missing the vendored node_modules. Refusing to publish."
+            exit 1
+          fi
+          case "$OUT" in
+            *helper-ok*)
+              echo "✓ ${{ matrix.platform }} resolves @oxc-project/runtime from the embedded runtime"
+              ;;
+            *)
+              echo "$OUT"
+              echo "::error::${{ matrix.platform }} decorator smoke printed unexpected output"
+              exit 1
+              ;;
+          esac
+
       - name: Compile and run packaged default + --smol artifacts
         shell: bash
         env:


### PR DESCRIPTION
oxc inlines `enum`, so the round-trip fixture never touched the vendored `node_modules` in the blob. Two `embed-runtime` binaries differing only in whether `runtime/node_modules` was staged:

| Fixture | Complete | Empty |
| --- | --- | --- |
| `enum` only | exit 0 | exit 0 |
| plain `.js` compile | exit 0 | exit 0 |
| legacy decorator | exit 0 | exit 1, `Cannot find module '@oxc-project/runtime/helpers/decorateMetadata'` |

The pre-publish gate gets the same check, because `smoke.sh`'s decorator case installs from npm and so runs only after publish.

Down-levelling a decorator is version-independent; resolving its helper from a CJS entry is not, below require(esm). The unpinned release gate therefore uses an ESM entry; `ci.yml`'s fixture stays CJS because that job pins Node 24. `macos-embed-roundtrip` builds incomplete deliberately and is untouched.