### PR TITLE
docs: point the node-shim fresh install at the tap

### DIFF
--- a/site/content/docs/node.mdx
+++ b/site/content/docs/node.mdx
@@ -175,7 +175,7 @@ With no pin the explainer reads `» resolved from node on PATH`. Bare `nub node`
 
 ## `nub node shim`
 
-Make `node` itself resolve through Nub, so a machine with no Node installed can run `node` at all. This is the fresh-install story: `brew install nub` (or the curl script), `nub node shim`, and now a bare `node file.js` works — Nub resolves the right version, provisions it if it's missing, and runs it.
+Make `node` itself resolve through Nub, so a machine with no Node installed can run `node` at all. This is the fresh-install story: `brew install nubjs/tap/nub` (or the curl script), `nub node shim`, and now a bare `node file.js` works — Nub resolves the right version, provisions it if it's missing, and runs it.
 
 ```console
 $ nub node shim


### PR DESCRIPTION
`brew install nub` resolves nothing today — Nub is not in Homebrew's core tap, so the command errors. This is the `nub node shim` fresh-install story, aimed at a reader whose machine has no Node, which makes it the worst place for an install command that fails.

Every other install surface already says `nubjs/tap/nub`. This one was missed when `nub node shim` landed in #297.

`tsc --noEmit` exits 0.