### PR TITLE
chore(make): add fix target for clippy autofix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ else
   CARGO_FLAGS = --profile $(PROFILE)
 endif
 
-.PHONY: build addon addon-fast install-dev uninstall-dev qos-global build-status build-slots-off build-slots-on target-gc test-target-gc test test-build-slots verify test-node-matrix bench clean npm-build npm-publish npm-publish-dry
+.PHONY: build addon addon-fast install-dev uninstall-dev qos-global build-status build-slots-off build-slots-on target-gc test-target-gc test test-build-slots verify fix test-node-matrix bench clean npm-build npm-publish npm-publish-dry
 
 build: addon
 	$(CARGO) build $(CARGO_FLAGS)
@@ -170,6 +170,24 @@ verify:
 	tests/brand-lint/check-path-literals.sh
 	@tests/target-gc/run.sh
 	NUB_SHARED_TARGET="$(CURDIR)/target" "$(RUST_BUILD)" test
+
+# Apply clippy's machine-applicable autofixes across the root workspace AND the
+# nub-native workspace (the separate one `verify` lints from inside the crate).
+# Run on a dirty tree is intended (--allow-dirty --allow-staged); review the
+# diff before committing.
+fix:
+	@# `--all-features` activates `embed-runtime`, whose build.rs reads
+	@# runtime/addons/nub-native.node for integrity hashing and panics when
+	@# it is absent (it is gitignored, built by `make addon` / staged in CI).
+	@# Stage a placeholder — the same trick CI's lint job uses — so `make fix`
+	@# works on a fresh tree without a full addon build. clippy --fix never
+	@# runs the binary, so the placeholder is never loaded. The root lint
+	@# grants incomplete runtime staging just as `verify` and CI do.
+	@mkdir -p runtime/addons
+	@test -s runtime/addons/nub-native.node || printf 'placeholder-addon' > runtime/addons/nub-native.node
+	@set -e; \
+	NUB_ALLOW_INCOMPLETE_RUNTIME=1 NUB_SHARED_TARGET="$(CURDIR)/target" "$(RUST_BUILD)" clippy --fix --workspace --all-targets --all-features --profile fast --allow-dirty --allow-staged -- -D warnings; \
+	(cd crates/nub-native && NUB_SHARED_TARGET="$(CURDIR)/target" "$(RUST_BUILD)" clippy --fix --all-features --profile fast --allow-dirty --allow-staged -- -D warnings)
 
 # Run the integration suite across a Node version matrix (18.19 floor → 22.15
 # fast-path floor) — the local mirror of ci.yml's `test` job. Locates or

--- a/external-tools.json
+++ b/external-tools.json
@@ -5,7 +5,6 @@
       "version": "11.24.0",
       "packageManager": "pnpm",
       "repository": "github:pnpm/pnpm",
-      "release": "asset",
       "notes": [
         "Latest soaked pnpm — CI downloads + SRI-verifies (sha512) the pinned asset",
         "darwin-x64 has no SEA asset upstream; its pin is the npm registry tarball"
@@ -43,7 +42,8 @@
           "asset": "pnpm-win32-x64.zip",
           "integrity": "sha512-ScYF853vPjdyJQeysSV7QXDo9YY+rnJoAblMrJK+6fzF1NXDhHCPLytpLnpxsbVDXP3iicAHyM5MhBKxbSMeaw=="
         }
-      }
+      },
+      "origin": "gh-asset"
     },
     "npm": {
       "notes": [
@@ -53,13 +53,13 @@
       "description": "npm — pinned, SRI-verified registry tarball; installed without self-update",
       "repository": "npm:npm",
       "version": "12.0.2",
-      "integrity": "sha512-uIXokLlBj6FpNUTQX1PmT5pz7BlIN9QlixX+zdaSNHsd0qUXsbDLr50xzY6Sw7cJVr0uzHKDOle0swmPW/p5Qw=="
+      "integrity": "sha512-uIXokLlBj6FpNUTQX1PmT5pz7BlIN9QlixX+zdaSNHsd0qUXsbDLr50xzY6Sw7cJVr0uzHKDOle0swmPW/p5Qw==",
+      "origin": "npm"
     },
     "sfw-free": {
       "description": "Socket Firewall (free tier) — malware gate on dep installs.",
       "version": "1.15.1",
       "repository": "github:SocketDev/sfw-free",
-      "release": "asset",
       "binaryName": "sfw",
       "notes": [
         "Used when SOCKET_SECURITY_KEY is not set",
@@ -99,13 +99,13 @@
           "asset": "sfw-free-windows-arm64.exe",
           "integrity": "sha512-Js7zoNMFf/iUjFb30vyAs6ffSg7CXMVHuwrPUWIKh5qjAKVtDDTOdaLuUzf/KQSj8XdFfFIImrNyB1vkwce49w=="
         }
-      }
+      },
+      "origin": "gh-asset"
     },
     "sfw-enterprise": {
       "description": "Socket Firewall (enterprise tier) — selected when SOCKET_SECURITY_KEY is set.",
       "version": "1.15.1",
       "repository": "github:SocketDev/firewall-release",
-      "release": "asset",
       "binaryName": "sfw",
       "notes": [
         "Used when SOCKET_SECURITY_KEY is set (the one env var every Socket product reads)",
@@ -145,13 +145,13 @@
           "asset": "sfw-windows-arm64.exe",
           "integrity": "sha512-IVQ7FWCGT1ivaA13G2Gcau28eyjtjEorLrgSrjeZGaQQzrB9b+1yQ9V/oplk0JFBLOA116P4kUvZunP/rxRkrw=="
         }
-      }
+      },
+      "origin": "gh-asset"
     },
     "zizmor": {
       "description": "GitHub Actions security linter — audits .github/ for workflow-injection / credential-leak patterns.",
       "version": "1.29.0",
       "repository": "github:zizmorcore/zizmor",
-      "release": "asset",
       "notes": [
         "Required: CI (blocks merges on medium+ findings)",
         "Installed by the setup-and-install composite; SRI-verified (sha512) per platform"
@@ -177,19 +177,21 @@
           "asset": "zizmor-x86_64-pc-windows-msvc.zip",
           "integrity": "sha512-r6YP+e2GsOklaxEf9JHrixkeR0NNkVAaMGcvwLxkt1JlYJpxFizH/LzhcsMmPSrLkELf6LNB2JL8hpDa5dBAww=="
         }
-      }
+      },
+      "origin": "gh-asset"
     },
     "agentshield": {
       "description": "Claude AI config security scanner (prompt injection, secrets)",
       "purl": "pkg:npm/ecc-agentshield@1.4.0",
-      "integrity": "sha512-R98OO1Ujyk2lezDLb+iQmMhF6FwTJCHajy3G4FCB6x7wkSTqR9f8+eAelC5KDzYDsGSbc0sOZvjXOOPRBtMpDg=="
+      "integrity": "sha512-R98OO1Ujyk2lezDLb+iQmMhF6FwTJCHajy3G4FCB6x7wkSTqR9f8+eAelC5KDzYDsGSbc0sOZvjXOOPRBtMpDg==",
+      "origin": "npm"
     },
     "skillspector": {
       "description": "NVIDIA's third-party-skill security scanner (LangGraph-based; YARA + AST + OSV.dev CVE lookups + optional LLM analysis). No PyPI release / no GH tags upstream — pinned to a git SHA on main + installed via a locked uv project (pyproject.toml + uv.lock, `uv sync --locked`; the fleet uv pin + exclude-newer make it reproducible). Sibling to AgentShield: AgentShield audits the operator's .claude/ config; SkillSpector audits untrusted upstream skills before install.",
-      "release": "uv-project",
       "repository": "github:NVIDIA/skillspector",
       "version": "2eb84478",
-      "versionDate": "2026-05-18"
+      "versionDate": "2026-05-18",
+      "origin": "manager"
     }
   }
 }

--- a/scripts/soak/external-tools.mts
+++ b/scripts/soak/external-tools.mts
@@ -63,7 +63,8 @@ interface ToolPin {
   description?: string
   version?: string
   repository?: string
-  release?: string
+  origin?: string
+  manager?: string
   binaryName?: string
   purl?: string
   integrity?: string
@@ -124,7 +125,7 @@ export function checkPins(tools: Record<string, ToolPin>): string[] {
       ...(pin.integrity ? [pin.integrity] : []),
       ...Object.values(pin.platforms ?? {}).map(p => p.integrity),
     ]
-    if (pin.release === 'asset' && integrities.length === 0) {
+    if (pin.origin === 'gh-asset' && integrities.length === 0) {
       out.push(`${name}: release asset without any integrity pin`)
     }
     for (const sri of integrities) {
@@ -549,7 +550,7 @@ export async function installTool(name: string, tools: Record<string, ToolPin>):
   if (!pin) {
     throw new Error(`unknown tool ${name} (see external-tools.json)`)
   }
-  if (pin.release === 'asset') {
+  if (pin.origin === 'gh-asset') {
     await installAssetTool(name, pin)
     return
   }
@@ -570,15 +571,28 @@ export async function installTool(name: string, tools: Record<string, ToolPin>):
     await installNpmTarball(name, pin.repository.slice('npm:'.length), pin.version!, pin.integrity!)
     return
   }
-  if (pin.release === 'uv-project') {
-    // Git-SHA-pinned python project; not auto-installed (needs uv).
+  if (pin.origin === 'npm') {
+    // npm registry tarball named only by `origin`. Pins that carry a `purl`
+    // or an `npm:` repository are already claimed by the branches above, so
+    // the package name here is always the tool name.
+    const pkg = name
+    if (!pin.version || !pin.integrity) {
+      throw new Error(`${name}: npm pin missing version or integrity`)
+    }
+    await installNpmTarball(name, pkg, pin.version, pin.integrity)
+    return
+  }
+  if (pin.origin === 'manager') {
+    // Git-SHA-pinned python project installed via an external package
+    // manager (uv); not auto-installed here.
     const repo = pin.repository!.replace(/^github:/, '')
+    const mgr = pin.manager ?? 'uv'
     console.log(
-      `[external-tools] ${name} is a uv project — run: uvx --from git+https://github.com/${repo}@${pin.version} ${name}`,
+      `[external-tools] ${name} is a ${mgr} project — run: uvx --from git+https://github.com/${repo}@${pin.version} ${name}`,
     )
     return
   }
-  throw new Error(`${name}: no installable shape (release=${pin.release ?? 'none'})`)
+  throw new Error(`${name}: no installable shape (origin=${pin.origin ?? 'none'})`)
 }
 
 /**

--- a/scripts/soak/external-tools.test.mts
+++ b/scripts/soak/external-tools.test.mts
@@ -32,7 +32,7 @@ test('the repo external-tools.json passes checkPins', () => {
 test('checkPins flags missing pins, bad SRIs, and asset entries with no integrity', () => {
   assert.equal(checkPins({ a: {} }).length, 1)
   assert.equal(checkPins({ a: { version: '1.0.0', integrity: 'sha256-abc' } }).length, 1)
-  assert.equal(checkPins({ a: { version: '1.0.0', release: 'asset' } }).length, 1)
+  assert.equal(checkPins({ a: { version: '1.0.0', origin: 'gh-asset' } }).length, 1)
 })
 
 // A key `platformKey()` cannot produce is a DEAD pin: the tool silently has
@@ -334,7 +334,7 @@ test('installTool rejects unknown tools, foreign purls, and shapeless pins', asy
   )
   await assert.rejects(installTool('y', { y: { version: '1.0.0' } }), /no installable shape/)
   await assert.rejects(
-    installTool('z', { z: { release: 'asset', version: '1.0.0', platforms: {} } }),
+    installTool('z', { z: { origin: 'gh-asset', version: '1.0.0', platforms: {} } }),
     /no pinned asset for/,
   )
 })
@@ -354,10 +354,10 @@ test('installTool resolves the sfw flavor from SOCKET_SECURITY_KEY', async t => 
   )
 })
 
-test('installTool prints the uvx line for uv-project pins without installing', async () => {
+test('installTool prints the uvx line for manager pins without installing', async () => {
   const tools = JSON.parse(readFileSync(EXTERNAL_TOOLS_JSON, 'utf8')).tools
-  const uv = Object.keys(tools).find(name => tools[name].release === 'uv-project')
-  assert.ok(uv, 'the manifest is expected to pin at least one uv project')
+  const uv = Object.keys(tools).find(name => tools[name].origin === 'manager')
+  assert.ok(uv, 'the manifest is expected to pin at least one manager project')
   await installTool(uv!, tools)
 })
 


### PR DESCRIPTION
Adds `make fix` to apply Clippy autofixes through the repository build wrapper in the root and native-addon workspaces. It permits dirty and staged files, stages an addon placeholder when needed, permits incomplete runtime staging for the root lint, and stops if either workspace fails.

Normalizes external-tool dispatch to the `origin` field while preserving current versions, integrity pins, and Windows/musl platform keys. No `cargo-fixit` installation is required.

Validation: 18 external-tool tests passed, one skipped; pin validation, make invocation, and stop-on-failure checks passed. Rebased onto `64065d15` as one commit.
