### PR TITLE
fix(resolver): emit the popular-names corpus for source builds too

### DIFF
--- a/vendor/aube/crates/aube-resolver/build.rs
+++ b/vendor/aube/crates/aube-resolver/build.rs
@@ -191,9 +191,66 @@ fn generate(manifest_dir: &Path, source: &Path, top: usize) -> bool {
         return false;
     }
 
+    generate_popular_names(workspace, manifest_dir);
+
     compress_json_primer(&json, source);
     let _ = std::fs::remove_file(json);
     true
+}
+
+/// Emit the download-ranked popular-names corpus alongside a primer we just
+/// built from source. Best-effort by design: see the failure note below.
+///
+/// Release builds ship this file in the primer artifact, so they never reach
+/// `generate()` at all. Every SOURCE build does — homebrew-core, the Nix flake,
+/// Fedora, AUR — and without the file `write_popular_names_blob` falls back to
+/// primer-derived names and leaves `AUBE_POPULAR_NAMES_RANKED` unset. That does
+/// not merely degrade the similar-name gate in `aube add`, it turns it OFF:
+/// the fallback list is alphabetical, so "absent from the corpus" stops meaning
+/// "nobody installs this" and the gate declines to run rather than report an
+/// alphabetical position as a popularity rank. A source-built binary therefore
+/// accepts a typosquat that a release binary refuses.
+///
+/// Three deliberate properties, each of which is what keeps this from being a
+/// regression risk:
+///
+/// 1. It runs only AFTER the primer command succeeded. An offline or
+///    network-blocked build has already failed that fetch and returned, so it
+///    never pays for this call.
+/// 2. Its failure is swallowed. The outcome is exactly the prior behaviour — no
+///    corpus, gate declines to run — so this cannot turn a working build into a
+///    broken one, and cannot degrade the primer it was called after.
+/// 3. It fetches from the same host the primer path already requires
+///    (`raw.githubusercontent.com`), so it introduces no new network dependency.
+///
+/// `--popular-names-only` makes the script write the corpus and exit before any
+/// packument work, so the cost is a single request.
+fn generate_popular_names(workspace: &Path, manifest_dir: &Path) {
+    // Honour the override rather than writing a file main() will not read.
+    if std::env::var_os("AUBE_POPULAR_NAMES_PATH").is_some() {
+        return;
+    }
+    let dest = manifest_dir.join("data").join(format!(
+        "popular-top{POPULAR_NAMES_TOP}-v{POPULAR_NAMES_FORMAT}.json"
+    ));
+    if dest.is_file() {
+        return;
+    }
+    let ok = Command::new("node")
+        .arg(workspace.join("scripts/generate-primer.mjs"))
+        .arg("--popular-names-only")
+        .arg("--popular-names-out")
+        .arg(&dest)
+        .status()
+        .is_ok_and(|s| s.success());
+    if !ok {
+        let _ = std::fs::remove_file(&dest);
+        println!(
+            "cargo:warning=could not generate the popular package-name corpus; the similar-name \
+             check in `aube add` stays disabled in this build (resolution and installs are \
+             unaffected)"
+        );
+    }
 }
 
 fn compress_json_primer(json: &Path, source: &Path) {


### PR DESCRIPTION
Release builds generate `data/popular-top100000-v1.json` before compiling, so they never reach `generate()`. Every source build does — homebrew-core, Nix, Fedora, AUR — and without it `AUBE_POPULAR_NAMES_RANKED` stays unset, so `nub add`'s similar-name check declines to run.

`nub add expresss`:

| Binary | Result |
| --- | --- |
| release | `SIMILAR_PACKAGE_NAME`, rank #258 |
| source, before | `LOW_DOWNLOAD_PACKAGE` — check never ran |
| source, after | `SIMILAR_PACKAGE_NAME`, rank #258 |

Best-effort, after the primer succeeds: offline builds return before reaching it, failure is swallowed, and the host is one the primer already needs.