### PR TITLE
lockfile: treat an empty importer as drift, not as a specifier-less format

### DIFF
--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1638,3 +1638,59 @@ fn workspace_spec_naming_a_non_member_fails_without_reaching_the_registry() {
         );
     }
 }
+
+/// A lockfile that records the root importer with ZERO direct deps while
+/// `package.json` declares one must read as drift, in every format
+/// (nubjs/nub#657). Two shapes reach it: a `package-lock.json` whose root
+/// entry declares a dep with no matching `node_modules/<name>` package node,
+/// and a `pnpm-lock.yaml` written as `importers: { .: {} }`. Both used to
+/// satisfy the drift check's `all(specifier.is_none())` guard vacuously, so
+/// `nub ci` exited 0 having linked nothing and printed "Already up to date" —
+/// a green CI run with an empty `node_modules`. `npm ci` rejects the same
+/// input with `EUSAGE`, `pnpm install --frozen-lockfile` with
+/// `ERR_PNPM_OUTDATED_LOCKFILE`.
+///
+/// No network: the frozen drift check runs before any resolution, so the
+/// rejection is reached without touching a registry.
+#[test]
+fn ci_rejects_lockfile_whose_root_importer_is_empty() {
+    for (tag, lockfile, body) in [
+        (
+            "npm-no-package-node",
+            "package-lock.json",
+            r#"{"name":"empty-importer","version":"1.0.0","lockfileVersion":3,"requires":true,
+                "packages":{"":{"name":"empty-importer","version":"1.0.0",
+                "dependencies":{"is-odd":"3.0.1"}}}}"#,
+        ),
+        (
+            "pnpm-empty-importer",
+            "pnpm-lock.yaml",
+            "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n",
+        ),
+    ] {
+        let dir = pm_tmpdir(tag);
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"empty-importer","version":"1.0.0","dependencies":{"is-odd":"3.0.1"}}"#,
+        )
+        .unwrap();
+        std::fs::write(dir.join(lockfile), body).unwrap();
+
+        let (out, err, code) = run_install(&dir, &["ci"]);
+        assert_ne!(
+            code, 0,
+            "{tag}: `nub ci` must reject a lockfile that resolves none of the \
+             manifest's deps, not report success: {out}\n{err}"
+        );
+        // Pin the failure to the drift path so it cannot pass on an unrelated
+        // network or store error.
+        assert!(
+            err.contains("ERR_NUB_OUTDATED_LOCKFILE"),
+            "{tag}: the rejection must be the outdated-lockfile error: {err}"
+        );
+        assert!(
+            !dir.join("node_modules").join("is-odd").exists(),
+            "{tag}: nothing may be linked when the frozen install is rejected"
+        );
+    }
+}

--- a/vendor/aube/crates/aube-lockfile/src/drift.rs
+++ b/vendor/aube/crates/aube-lockfile/src/drift.rs
@@ -513,18 +513,21 @@ impl LockfileGraph {
             .unwrap_or(&[]);
 
         // Skip the check entirely if the importer's recorded deps carry no
-        // specifier (a non-pnpm lockfile format that doesn't record them).
-        // Guard on the importer actually being present in the lockfile: a
-        // brand-new workspace member absent from it has an empty
-        // `importer_deps`, for which `all(specifier.is_none())` is vacuously
-        // true — skipping here would wrongly report the new member Fresh and
-        // its declared deps would never resolve (nubjs/nub#441). Falling
-        // through instead makes each manifest dep read as added against the
-        // empty locked specs (Stale), while a depless new member still reads
-        // Fresh (nothing to add — matches a `workspace:*` link with no deps).
-        if self.importers.contains_key(importer_path)
-            && importer_deps.iter().all(|d| d.specifier.is_none())
-        {
+        // specifier (a non-pnpm lockfile format that doesn't record them —
+        // yarn berry is the one that reaches here). Guard on the importer
+        // having at least one dep: `all(specifier.is_none())` is vacuously
+        // true for an empty list, so an importer that recorded *nothing*
+        // would skip the check and report Fresh no matter what the manifest
+        // declares. That covers two distinct holes — a brand-new workspace
+        // member absent from the lockfile (nubjs/nub#441) and a lockfile
+        // whose importer parsed to zero direct deps while the manifest
+        // declares some (nubjs/nub#657: a package-lock.json missing the
+        // `node_modules/<name>` package node, or a pnpm-lock.yaml with an
+        // empty `importers: { .: {} }`). Falling through instead makes each
+        // manifest dep read as added against the empty locked specs (Stale),
+        // while a depless importer still reads Fresh (nothing to add —
+        // matches a `workspace:*` link with no deps).
+        if !importer_deps.is_empty() && importer_deps.iter().all(|d| d.specifier.is_none()) {
             return DriftStatus::Fresh;
         }
         let lockfile_specs: BTreeMap<&str, &str> = importer_deps
@@ -1455,6 +1458,45 @@ mod drift_tests {
                 &BTreeMap::new(),
                 true,
             ),
+            DriftStatus::Fresh
+        );
+    }
+
+    #[test]
+    fn stale_when_root_importer_is_empty_but_manifest_declares_deps() {
+        // nubjs/nub#657. A lockfile that records the root importer with zero
+        // direct deps — a package-lock.json whose root entry declares a dep
+        // with no matching `node_modules/<name>` package node, or a
+        // pnpm-lock.yaml written as `importers: { .: {} }` — used to satisfy
+        // `all(specifier.is_none())` vacuously and report Fresh, so
+        // `nub install` linked nothing and printed "Already up to date" while
+        // `nub ci` exited 0 with an empty tree. Both npm and pnpm treat this
+        // as drift.
+        let graph = LockfileGraph {
+            importers: {
+                let mut m = BTreeMap::new();
+                m.insert(".".to_string(), Vec::<DirectDep>::new());
+                m
+            },
+            packages: BTreeMap::new(),
+            ..Default::default()
+        };
+        assert_eq!(
+            graph.check_drift(
+                &make_manifest(&[("is-odd", "3.0.1")]),
+                &BTreeMap::new(),
+                &[],
+                &BTreeMap::new(),
+            ),
+            DriftStatus::Stale {
+                reason: "manifest adds is-odd@3.0.1".to_string()
+            }
+        );
+        // An empty importer against a depless manifest is still Fresh —
+        // there is nothing to add, so this must not force a re-resolve on
+        // every install of a dependency-free project.
+        assert_eq!(
+            graph.check_drift(&make_manifest(&[]), &BTreeMap::new(), &[], &BTreeMap::new(),),
             DriftStatus::Fresh
         );
     }


### PR DESCRIPTION
The importer drift check skipped itself when every recorded direct dep carried no specifier — how a yarn berry lockfile parses. That is vacuously true on an empty list, so an importer recording nothing skipped too and reported Fresh whatever package.json declared: `nub install` linked nothing and printed "Already up to date", `nub ci` exited 0 with an empty tree.

Requiring one recorded dep before the skip closes it for every format; a depless importer still reads Fresh.

Closes #657

Verified: four lockfile shapes now install, `nub ci` exits 16 with ERR_NUB_OUTDATED_LOCKFILE, warm and depless projects unchanged. 563 + 12 tests pass; reverting the guard turns the new test red.
