### PR TITLE
fix(phantom-scan): exclude type-surface-only imports from runtime targets

### DIFF
--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -343,7 +343,7 @@ pub(crate) fn phantom_cache_dir() -> Option<PathBuf> {
 /// after upgrade; harmless and expected (the whole point is to pick up the better
 /// verdict). Just bump the number when the scanner logic changes — the coupling
 /// is structural, nothing else to remember.
-pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 5;
+pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 6;
 
 /// Version of what the linker's GVS-populate pass WRITES TO DISK for a given eject
 /// set — bumped when the same plan produces a different on-disk shape.

--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -22,6 +22,10 @@ pub enum Verdict {
     /// Undeclared but only ever loaded under a try/catch — a soft/optional load,
     /// not a hard break.
     SoftPhantom,
+    /// Undeclared and reachable only from the declaration-file type surface.
+    /// Excluded from runtime compatibility targets even without a declared
+    /// `@types` twin; declared type fallbacks retain `Declared` instead.
+    TypeOnly,
     /// Declared as an OPTIONAL peer (`peerDependenciesMeta.<x>.optional`). NOT a
     /// phantom — the pick-your-plugin pattern. Tracked so the report can show how
     /// much a naive scan over-counts.
@@ -135,7 +139,15 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
             // `types_package_for`.
             let types_only =
                 agg.from_types && !agg.from_main && !agg.from_subpath && !agg.from_deep_path;
-            let verdict = verdict_for(manifest, &package, agg.all_soft, deep_path_only, types_only);
+            let base = verdict_for(manifest, &package, agg.all_soft, deep_path_only, types_only);
+            // Type-only references need no runtime package, even without a declared
+            // @types twin. A legacy deep-path reference still needs the runtime.
+            let verdict =
+                if types_only && matches!(base, Verdict::HardPhantom | Verdict::SoftPhantom) {
+                    Verdict::TypeOnly
+                } else {
+                    base
+                };
             Finding {
                 package,
                 verdict,
@@ -185,7 +197,7 @@ fn verdict_for(
     // downstream, so a `.d.ts` leaning on a dev-only types package really does
     // break for the consumer. Measured over the sampled false positives: 13
     // declare the types package in `dependencies`, 2 as a peer, and 2 dev-only
-    // (correctly still phantoms).
+    // (classified separately as TypeOnly).
     if types_only && {
         let t = types_package_for(package);
         manifest.deps.contains(&t)
@@ -319,14 +331,14 @@ mod tests {
         );
 
         // But a DEV-only types package does not: it is not installed downstream,
-        // so the consumer's type-check really does break.
+        // so it stays TypeOnly rather than Declared. Neither is a runtime target.
         let dev =
             Manifest::parse(br#"{"name":"p","devDependencies":{"@types/geojson":"*"}}"#).unwrap();
         let f = classify(&dev, &[type_ref("geojson", "geojson")]);
         assert_eq!(
             f[0].verdict,
-            Verdict::HardPhantom,
-            "a devDependency types package is not resolvable for a consumer"
+            Verdict::TypeOnly,
+            "a devDependency types package does not create a runtime requirement"
         );
 
         // THE CONTROL. A runtime reference is NOT satisfied by a types package —
@@ -348,10 +360,10 @@ mod tests {
             "a runtime occurrence is not satisfied by @types/geojson"
         );
 
-        // And with no types package declared it stays a phantom.
+        // With no types package declared, it still needs no runtime package.
         let bare = Manifest::parse(br#"{"name":"p"}"#).unwrap();
         let f = classify(&bare, &[type_ref("geojson", "geojson")]);
-        assert_eq!(f[0].verdict, Verdict::HardPhantom);
+        assert_eq!(f[0].verdict, Verdict::TypeOnly);
     }
 
     #[test]
@@ -417,6 +429,79 @@ mod tests {
         let f = classify(&m, &[deep("ava"), also_main]);
         assert_eq!(f[0].verdict, Verdict::HardPhantom);
         assert!(!f[0].is_deep_path_only());
+    }
+
+    #[test]
+    fn declared_type_surface_and_runtime_phantom_stay_distinct() {
+        // The current classifier recognizes a declared @types twin. Both
+        // Declared and TypeOnly stay out of runtime targets; runtime imports
+        // still require the actual package.
+        let m =
+            Manifest::parse(br#"{"name":"eslint","dependencies":{"@types/estree":"*"}}"#).unwrap();
+        let estree = Reference {
+            package: "estree".into(),
+            raw: "estree".into(),
+            soft: false,
+            from_main: false,
+            from_subpath: false,
+            from_types: true,
+            from_deep_path: false,
+        };
+        let ghost = Reference {
+            package: "ghost".into(),
+            raw: "ghost".into(),
+            soft: false,
+            from_main: true,
+            from_subpath: false,
+            from_types: false,
+            from_deep_path: false,
+        };
+        let f = classify(&m, &[estree, ghost]);
+        let estree_v = f.iter().find(|x| x.package == "estree").unwrap();
+        let ghost_v = f.iter().find(|x| x.package == "ghost").unwrap();
+        assert_eq!(estree_v.verdict, Verdict::Declared);
+        assert_eq!(ghost_v.verdict, Verdict::HardPhantom);
+    }
+
+    #[test]
+    fn type_surface_only_needs_no_types_twin_at_all() {
+        // pnpm#14128: `@typescript-eslint/types`'s only reference to `typescript`
+        // is `import type { Program } from 'typescript'` in a `.d.ts` file.
+        // Gating TypeOnly on a declared `@types/typescript` twin flagged this a
+        // HardPhantom, because typescript ships its own types — there is no
+        // separate `@types/typescript` package to find. A type-surface-only
+        // reference must be TypeOnly regardless of where (or whether) a types
+        // twin is declared, since it needs nothing at runtime either way.
+        let m = Manifest::parse(br#"{"name":"@typescript-eslint/types"}"#).unwrap();
+        let typescript = Reference {
+            package: "typescript".into(),
+            raw: "typescript".into(),
+            soft: false,
+            from_main: false,
+            from_subpath: false,
+            from_types: true,
+            from_deep_path: false,
+        };
+        let f = classify(&m, &[typescript]);
+        let v = f.iter().find(|x| x.package == "typescript").unwrap();
+        assert_eq!(v.verdict, Verdict::TypeOnly);
+
+        let mut deep_runtime = Reference {
+            package: "typescript".into(),
+            raw: "typescript".into(),
+            soft: false,
+            from_main: false,
+            from_subpath: false,
+            from_types: true,
+            from_deep_path: true,
+        };
+        assert_eq!(
+            classify(&m, &[deep_runtime.clone()])[0].verdict,
+            Verdict::HardPhantom
+        );
+        deep_runtime.from_deep_path = false;
+        deep_runtime.soft = true;
+        assert_eq!(classify(&m, &[deep_runtime])[0].verdict, Verdict::TypeOnly);
     }
 
     #[test]

--- a/crates/nub-phantom-scan/src/lib.rs
+++ b/crates/nub-phantom-scan/src/lib.rs
@@ -314,10 +314,24 @@ mod tests {
             "react (runtime-only, in widgets.js) must NOT leak into type_coupled_peers: {:?}",
             r.type_coupled_peers
         );
-        // The real widgets.d.ts WAS walked: its undeclared type import surfaced.
+        // `the-backend` is an undeclared, UNSATISFIED (no `@types/the-backend`)
+        // type-only import — TypeOnly per pnpm#14128, never a compat/eject target.
+        // Proving widgets.d.ts was genuinely walked needs the raw reference, not
+        // `r.targets` (which correctly excludes it now).
+        let manifest =
+            super::manifest::Manifest::parse(&fs::read(root.join("package.json")).unwrap())
+                .unwrap();
+        let walk = super::graph::walk(&root, &manifest.entry_points);
         assert!(
-            r.targets.iter().any(|t| t.name == "the-backend"),
+            walk.references
+                .iter()
+                .any(|r| r.package == "the-backend" && r.from_types && !r.from_main),
             "widgets.d.ts should be walked from the type surface: {:?}",
+            walk.references
+        );
+        assert!(
+            r.targets.iter().all(|t| t.name != "the-backend"),
+            "an unsatisfied type-only import must stay TypeOnly, never a compat target: {:?}",
             r.targets
         );
         assert_eq!(scan_index(&index_of(&root)).unwrap(), r);

--- a/crates/nub-phantom/src/lib.rs
+++ b/crates/nub-phantom/src/lib.rs
@@ -72,14 +72,17 @@ impl PackageReport {
     /// What a NAIVE detector would flag: every undeclared reference, NOT excluding
     /// optional peers or soft loads. Lets the report quantify the over-count the
     /// real classifier avoids. (Builtins/self/declared are excluded even naively;
-    /// the over-count is optional-peers + soft-phantoms counted as phantoms.)
+    /// the over-count includes optional peers, soft loads, and type-only imports.)
     pub fn naive_phantom_count(&self) -> usize {
         self.findings
             .iter()
             .filter(|f| {
                 matches!(
                     f.verdict,
-                    Verdict::HardPhantom | Verdict::SoftPhantom | Verdict::DeclaredOptionalPeer
+                    Verdict::HardPhantom
+                        | Verdict::SoftPhantom
+                        | Verdict::DeclaredOptionalPeer
+                        | Verdict::TypeOnly
                 )
             })
             .count()

--- a/crates/nub-phantom/src/main.rs
+++ b/crates/nub-phantom/src/main.rs
@@ -388,6 +388,7 @@ fn print_report_human(r: &PackageReport) {
         let tag = match f.verdict {
             Verdict::HardPhantom => "PHANTOM  ",
             Verdict::SoftPhantom => "soft     ",
+            Verdict::TypeOnly => "type-only",
             Verdict::DeclaredOptionalPeer => "opt-peer ",
             Verdict::DeclaredPeer => "peer     ",
             Verdict::Declared => "ok       ",

--- a/wiki/design/design.md
+++ b/wiki/design/design.md
@@ -5,3 +5,4 @@ Mechanism documents: how Nub is put together and what a change should be designe
 - [[architecture]] — Nub as an augmenter of the user's installed Node, and the Node-published surfaces every augmentation reaches the process through
 - [[compat-mode-tests]] — the four behaviors `--node` and `NODE_COMPAT` guarantee, each mapped to the test that proves it
 - [[compiled-executables]] — how `nub compile` assembles a single executable that runs with no Node and no `node_modules` on the target machine
+- [[phantom-scanning]] — phantom scanning

--- a/wiki/design/phantom-scanning.md
+++ b/wiki/design/phantom-scanning.md
@@ -1,0 +1,7 @@
+# Phantom scanning
+
+The scanner excludes type-surface-only imports from runtime compatibility targets. References reached from a runtime entry point or a legacy deep path still require a runtime package.
+
+The classifier keeps declared dependencies, peers, and declared type-package fallbacks in their existing categories. Remaining hard or soft phantom references reachable only from declarations become `TypeOnly`, regardless of whether an `@types` twin exists.
+
+Classification lives in [[crates/nub-phantom-scan/src/classify.rs#classify]]. Scanner changes bump [[crates/nub-cli/src/dynamic_phantom.rs#PHANTOM_SCANNER_VERSION]] so cached scans and warm install state are recomputed.


### PR DESCRIPTION
Excludes declaration-file-only phantom references from runtime compatibility targets, even when no `@types` twin is declared. Runtime and legacy deep-path imports still require the actual package; declared dependencies, peers, and declared type fallbacks retain their existing classifications.

Bumps the scanner cache version, handles `TypeOnly` in the evaluation CLI, and includes type-only findings in its naive overcount. This prevents type-only imports such as `typescript` from becoming runtime install requirements.

Validation: 53 scanner/core tests passed; the excluded evaluation workspace compiled with all targets; formatting and knowledge-graph checks passed. Rebased onto `64065d15` as one commit.

Related: pnpm/pnpm#13981 and pnpm/pnpm#14128.
