### PR TITLE
release: stage an owning package.json for the compile smoke gate's addon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1181,7 +1181,9 @@ jobs:
           # A loose `.node` beside the entry is `Island::Colocated`, whose owning
           # manifest is the APPLICATION's — so the fixture needs one or the addon
           # plugin fails with "no owning package.json in any parent directory".
-          # `type: module` because every fixture below is ESM.
+          # `type: module` so the ESM fixtures keep their format once a manifest
+          # exists; `windows-long-replace.js` has no ESM syntax and is the one
+          # fixture this reclassifies, which its bare `console.log` tolerates.
           printf '%s\n' '{"name":"nub-release-compile-fixture","version":"0.0.0","private":true,"type":"module"}' > "$MANIFEST"
           printf '%s\n' 'export const dependency = "bundled-dependency";' > "$DEPENDENCY"
           printf '%s\n' 'included-asset' > "$INCLUDED"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1162,6 +1162,7 @@ jobs:
           FOREIGN_CWD="$WORKDIR/foreign-cwd"
           mkdir -p "$SOURCE_DIR" "$OUTPUT_DIR" "$FOREIGN_CWD"
           FIXTURE="$SOURCE_DIR/release-compile.js"
+          MANIFEST="$SOURCE_DIR/package.json"
           DEPENDENCY="$SOURCE_DIR/dependency.js"
           INCLUDED="$SOURCE_DIR/included.txt"
           NATIVE_ADDON="$SOURCE_DIR/compile-native.node"
@@ -1177,6 +1178,11 @@ jobs:
           LICENSE_CACHE="$WORKDIR/licenses-cache"
           EMPTY_PATH="$WORKDIR/no-host-node"
           mkdir -p "$COMPILE_CACHE" "$RUNTIME_CACHE" "$SMOL_RUNTIME_CACHE" "$EMPTY_PATH"
+          # A loose `.node` beside the entry is `Island::Colocated`, whose owning
+          # manifest is the APPLICATION's — so the fixture needs one or the addon
+          # plugin fails with "no owning package.json in any parent directory".
+          # `type: module` because every fixture below is ESM.
+          printf '%s\n' '{"name":"nub-release-compile-fixture","version":"0.0.0","private":true,"type":"module"}' > "$MANIFEST"
           printf '%s\n' 'export const dependency = "bundled-dependency";' > "$DEPENDENCY"
           printf '%s\n' 'included-asset' > "$INCLUDED"
           test -f nub-pkg/test/compile-native.node \

--- a/crates/nub-cli/src/compile/native_layout.rs
+++ b/crates/nub-cli/src/compile/native_layout.rs
@@ -1143,4 +1143,37 @@ mod tests {
         }));
         let _ = fs::remove_dir_all(root);
     }
+
+    /// The release pre-publish gate compiles a loose `.node` sitting beside its
+    /// entry, so the manifest above it is the application's own. That manifest is
+    /// REQUIRED — the gate staged its fixture without one and failed every
+    /// platform leg on "no owning package.json in any parent directory".
+    #[test]
+    fn a_loose_addon_needs_an_application_manifest_above_it() {
+        let root = fixture("colocated-app");
+        package(
+            &root,
+            r#"{"name":"app","version":"0.0.0","private":true,"type":"module"}"#,
+            &[("addon.node", b"\0")],
+        );
+        let seed = Seed::discover(&root.join("addon.node")).unwrap();
+        assert!(
+            matches!(seed.island, Island::Colocated),
+            "an app manifest outside any install tree is the colocated island, got {:?}",
+            seed.island
+        );
+
+        // Without it the addon has no owner at all, which is the gate's shape.
+        let bare = fixture("colocated-bare");
+        fs::write(bare.join("addon.node"), b"\0").unwrap();
+        let err = Seed::discover(&bare.join("addon.node"))
+            .expect_err("a loose addon with no manifest above it must not resolve")
+            .to_string();
+        assert!(
+            err.contains("no owning package.json"),
+            "the error must name the missing manifest, got: {err}"
+        );
+        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(bare);
+    }
 }


### PR DESCRIPTION
The pre-publish smoke gate stages its fixture in a bare temp dir, so the loose `compile-native.node` has no `package.json` in any parent. That is `Island::Colocated`, whose owning manifest is the application's own, so every platform leg failed with "no owning package.json in any parent directory".

The gate has never passed on main — when it runs it fails, and the green Release runs skipped it. It gates `publish-npm`, `stable-immutable-release` and `canary-immutable-release`, so canary publishing stopped when it broke (last canary: `0.7.5-canary.20260814.317`) and a release tag would not reach publish.

`type: module` because every fixture in the step is ESM.

Test pins both directions: with an app manifest the addon resolves as colocated, without one it names the missing manifest. Runs in CI via the existing `--features compile` leg.
