### PR TITLE
linker: claim hidden-hoist names shallowest-first, matching pnpm's depth ordering

### DIFF
--- a/vendor/aube/crates/aube-linker/src/link.rs
+++ b/vendor/aube/crates/aube-linker/src/link.rs
@@ -1595,8 +1595,11 @@ impl Linker {
         //     shared store, so its walk ascends the store, never the project — it
         //     can NEVER consume this tree. So the ejected subset gets pnpm's
         //     blanket phantom tolerance while the symlinked majority is untouched.
-        // Standalone aube always has an empty `disk_materialize`, so this branch
-        // is unreachable there and the pass stays byte-for-byte unchanged.
+        // Standalone aube always has an empty `disk_materialize`, so this BRANCH
+        // is unreachable there. It still reaches `link_hidden_hoist_at` below,
+        // whose name selection shares `collect_hidden_hoist_packages` — so the
+        // shallowest-first claim order applies to standalone aube too, and only
+        // this collective-tree branch is exclusive to the eject path.
         if self.use_global_virtual_store && !self.disk_materialize.is_empty() {
             let packages = self.collect_hidden_hoist_packages(graph, &|_| true);
             self.write_hidden_hoist_entries(aube_dir, aube_dir, &packages, false, true)?;
@@ -1644,11 +1647,23 @@ impl Linker {
     }
 
     /// Select the non-local graph packages to symlink into a hidden hoist tree,
-    /// deduplicated by name with root direct dependencies reserving their name
-    /// before the deterministic transitive sweep — pnpm's undeclared-import
-    /// version choice when the app and a transitive dep bring different versions
-    /// of the same name. `select` is the per-name gate: `hoist_matches` for the
-    /// pattern-driven GVS-off tree, `|_| true` for the blanket collective tree.
+    /// deduplicated by name — pnpm's undeclared-import version choice when the
+    /// app and a transitive dep bring different versions of the same name.
+    /// `select` is the per-name gate: `hoist_matches` for the pattern-driven
+    /// GVS-off tree, `|_| true` for the blanket collective tree.
+    ///
+    /// Claim order mirrors pnpm's hoist sort ("by depth and then
+    /// alphabetically"): root direct dependencies reserve their name first, then
+    /// the SHALLOWEST copy of each remaining name wins, dep_path breaking a tie.
+    /// Sweeping `graph.packages` instead claims in dep_path order, which tracks
+    /// nothing about the graph — `1.0.0` beats `2.0.0` while `10.0.0` beats
+    /// `9.0.0`. Shallowest-wins reproduces what a hoisted npm install leaves at
+    /// top level, which is the resolution a phantom-importing author relied on.
+    ///
+    /// Divergence from pnpm: pnpm ranks a candidate by its PARENT's depth and
+    /// ties on the parent's node id; this ranks by the candidate's own depth and
+    /// ties on its own dep_path. Root priority is NOT a divergence — pnpm
+    /// pre-reserves the root importer's aliases the same way.
     fn collect_hidden_hoist_packages<'g>(
         &self,
         graph: &'g LockfileGraph,
@@ -1670,12 +1685,25 @@ impl Linker {
                 packages.push((direct.dep_path.as_str(), pkg));
             }
         }
-        for (dep_path, pkg) in &graph.packages {
-            if pkg.local_source.is_some() || !select(&pkg.name) {
-                continue;
-            }
+
+        let depths = graph.dependency_depths();
+        let mut candidates: Vec<(&'g str, &'g LockedPackage)> = graph
+            .packages
+            .iter()
+            .filter(|(_, pkg)| pkg.local_source.is_none() && select(&pkg.name))
+            .map(|(dep_path, pkg)| (dep_path.as_str(), pkg))
+            .collect();
+        // Unreachable sorts last rather than being dropped: it is still a real
+        // package in the graph, and a name nothing else claims should get its
+        // alias rather than none at all.
+        candidates.sort_by(|(a, _), (b, _)| {
+            let a_depth = depths.get(a).copied().unwrap_or(usize::MAX);
+            let b_depth = depths.get(b).copied().unwrap_or(usize::MAX);
+            a_depth.cmp(&b_depth).then_with(|| a.cmp(b))
+        });
+        for (dep_path, pkg) in candidates {
             if claimed.insert(pkg.name.as_str()) {
-                packages.push((dep_path.as_str(), pkg));
+                packages.push((dep_path, pkg));
             }
         }
         packages
@@ -1717,6 +1745,12 @@ impl Linker {
                 .join(source_subdir)
                 .join("node_modules")
                 .join(&pkg.name);
+            // Known divergence, pre-existing: the name was already claimed in
+            // `collect_hidden_hoist_packages`, so a package that never
+            // materialized (a skipped optional dep) leaves it with no alias
+            // instead of yielding to the next candidate. pnpm skips BEFORE
+            // claiming. Fixing it means statting the store from the currently
+            // pure collect pass — a separate change, not bundled with ordering.
             if !source_dir.exists() {
                 continue;
             }

--- a/vendor/aube/crates/aube-linker/src/tests.rs
+++ b/vendor/aube/crates/aube-linker/src/tests.rs
@@ -1589,7 +1589,18 @@ fn test_hidden_hoist_prefers_root_direct_dep_over_transitive_version() {
         ..Default::default()
     };
 
-    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true);
+    // Reaching the collective tree takes BOTH of these, and each one alone
+    // leaves the test asserting nothing. Without `with_hoist(false)`, `link_all`
+    // returns `self.without_global_virtual_store().link_all(..)` and the GVS
+    // path is never entered. Without a non-empty disk-materialize set, the
+    // collective branch is skipped and `link_hidden_hoist_at` returns early on
+    // `!self.hoist`, so no tree is built at all — see
+    // `no_collective_hidden_hoist_when_ejected_set_empty_under_gvs`, which
+    // asserts exactly that. Ejecting the resolver is also what this test's own
+    // "realpaths project-local" assertion requires.
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
+        .with_hoist(false)
+        .with_disk_materialize(&["@hookform/resolvers".to_string()]);
     linker.link_all(&project_dir, &graph, &indices).unwrap();
 
     let resolver_real =
@@ -1613,6 +1624,147 @@ fn test_hidden_hoist_prefers_root_direct_dep_over_transitive_version() {
             .symlink_metadata()
             .is_err(),
         "global virtual store must not expose an unversioned zod alias"
+    );
+}
+
+#[test]
+fn test_hidden_hoist_claims_by_depth_then_dep_path() {
+    // Both keys of the comparator, in one graph. Neither contested name has a
+    // root-direct-dep copy, so pass 1 decides neither.
+    //
+    // DEPTH: `shallow` brings ms@2.1.2 at depth 1; `deep` → `mid` brings
+    // ms@2.0.0 at depth 2. Claiming in dep_path order instead picks ms@2.0.0,
+    // since "ms@2.0.0" sorts first while being the deeper copy — the inversion
+    // this guards.
+    //
+    // TIE: `tie@1.0.0` and `tie@2.0.0` are both depth 1, so dep_path decides
+    // and the lower version wins. That is not a preference for old versions —
+    // it is the tie-break being deterministic.
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let store = Store::at(dir.path().join("store/files"));
+    let mut indices = BTreeMap::new();
+    for (dep_path, manifest, body) in [
+        (
+            "shallow@1.0.0",
+            r#"{"name":"shallow","version":"1.0.0"}"#,
+            "module.exports = 'shallow';",
+        ),
+        (
+            "deep@1.0.0",
+            r#"{"name":"deep","version":"1.0.0"}"#,
+            "module.exports = 'deep';",
+        ),
+        (
+            "mid@1.0.0",
+            r#"{"name":"mid","version":"1.0.0"}"#,
+            "module.exports = 'mid';",
+        ),
+        (
+            "ms@2.1.2",
+            r#"{"name":"ms","version":"2.1.2"}"#,
+            "module.exports = 'ms-2.1.2';",
+        ),
+        (
+            "ms@2.0.0",
+            r#"{"name":"ms","version":"2.0.0"}"#,
+            "module.exports = 'ms-2.0.0';",
+        ),
+        (
+            "tie@1.0.0",
+            r#"{"name":"tie","version":"1.0.0"}"#,
+            "module.exports = 'tie-1.0.0';",
+        ),
+        (
+            "tie@2.0.0",
+            r#"{"name":"tie","version":"2.0.0"}"#,
+            "module.exports = 'tie-2.0.0';",
+        ),
+    ] {
+        indices.insert(dep_path.to_string(), package_index(&store, manifest, body));
+    }
+
+    let mut packages = BTreeMap::new();
+    for (dep_path, name, version, deps) in [
+        (
+            "shallow@1.0.0",
+            "shallow",
+            "1.0.0",
+            vec![("ms", "2.1.2"), ("tie", "1.0.0")],
+        ),
+        (
+            "deep@1.0.0",
+            "deep",
+            "1.0.0",
+            vec![("mid", "1.0.0"), ("tie", "2.0.0")],
+        ),
+        ("mid@1.0.0", "mid", "1.0.0", vec![("ms", "2.0.0")]),
+        ("ms@2.1.2", "ms", "2.1.2", vec![]),
+        ("ms@2.0.0", "ms", "2.0.0", vec![]),
+        ("tie@1.0.0", "tie", "1.0.0", vec![]),
+        ("tie@2.0.0", "tie", "2.0.0", vec![]),
+    ] {
+        packages.insert(
+            dep_path.to_string(),
+            LockedPackage {
+                name: name.to_string(),
+                version: version.to_string(),
+                dep_path: dep_path.to_string(),
+                dependencies: deps
+                    .into_iter()
+                    .map(|(n, t)| (n.to_string(), t.to_string()))
+                    .collect(),
+                ..Default::default()
+            },
+        );
+    }
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        ["shallow@1.0.0", "deep@1.0.0"]
+            .into_iter()
+            .map(|dep_path| DirectDep {
+                name: dep_path.split('@').next().unwrap().to_string(),
+                dep_path: dep_path.to_string(),
+                dep_type: DepType::Production,
+                specifier: None,
+            })
+            .collect(),
+    );
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+
+    // Both settings are required to build the collective tree — see the note in
+    // `test_hidden_hoist_prefers_root_direct_dep_over_transitive_version`. The
+    // ejected package only has to make the set non-empty; this test asserts on
+    // the tree's contents, not on resolution through it.
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
+        .with_hoist(false)
+        .with_disk_materialize(&["deep".to_string()]);
+    linker.link_all(&project_dir, &graph, &indices).unwrap();
+
+    let hidden_ms = project_dir.join("node_modules/.aube/node_modules/ms");
+    assert!(
+        hidden_ms.symlink_metadata().unwrap().is_symlink(),
+        "the hidden hoist tree must carry an `ms` alias"
+    );
+    assert_eq!(
+        std::fs::read_to_string(hidden_ms.join("index.js")).unwrap(),
+        "module.exports = 'ms-2.1.2';",
+        "the shallower ms@2.1.2 must win the alias over the deeper ms@2.0.0"
+    );
+
+    let hidden_tie = project_dir.join("node_modules/.aube/node_modules/tie");
+    assert_eq!(
+        std::fs::read_to_string(hidden_tie.join("index.js")).unwrap(),
+        "module.exports = 'tie-1.0.0';",
+        "at equal depth the lower dep_path must win, deterministically"
     );
 }
 

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -1035,6 +1035,7 @@ impl LockfileGraph {
     /// First-write-wins over a FIFO queue, so a cycle terminates (each dep_path
     /// is enqueued at most once) and the recorded depth is the shortest one.
     pub fn dependency_depths(&self) -> std::collections::HashMap<&str, usize> {
+        use std::collections::hash_map::Entry;
         use std::collections::{HashMap, VecDeque};
 
         let mut depths: HashMap<&str, usize> = HashMap::new();
@@ -1044,7 +1045,8 @@ impl LockfileGraph {
                 let Some((key, _)) = self.packages.get_key_value(&direct.dep_path) else {
                     continue;
                 };
-                if depths.insert(key.as_str(), 0).is_none() {
+                if let Entry::Vacant(slot) = depths.entry(key.as_str()) {
+                    slot.insert(0);
                     queue.push_back(key.as_str());
                 }
             }
@@ -1065,7 +1067,14 @@ impl LockfileGraph {
                 let Some((key, _)) = self.packages.get_key_value(&child_key) else {
                     continue;
                 };
-                if depths.insert(key.as_str(), depth + 1).is_none() {
+                // Vacant-only, never a bare `insert`: `insert` OVERWRITES and
+                // returns the old value, so `if insert(..).is_none()` guards the
+                // queue push while still letting a later, deeper visit clobber
+                // the recorded depth — last-write-wins, the inverse of what this
+                // returns. A cycle makes it observable: a seed re-reached around
+                // the loop lands at the cycle length instead of 0.
+                if let Entry::Vacant(slot) = depths.entry(key.as_str()) {
+                    slot.insert(depth + 1);
                     queue.push_back(key.as_str());
                 }
             }

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -1035,16 +1035,18 @@ impl LockfileGraph {
     /// First-write-wins over a FIFO queue, so a cycle terminates (each dep_path
     /// is enqueued at most once) and the recorded depth is the shortest one.
     ///
-    /// Walks `optional_dependencies` as well as `dependencies`, even though this
-    /// struct documents active optional edges as MIRRORED into `dependencies`.
-    /// That invariant is not upheld by every reader — `yarn/berry.rs` assigns the
-    /// two maps from separate sources with no merge — and a consumer that ranks
-    /// by depth cannot absorb the difference the way a closure walk can: an
-    /// optional-only-reachable package would be absent, rank as infinitely deep,
-    /// and lose every name contest to arbitrarily deeper packages. Widening the
-    /// walk cannot over-reach, because an edge still has to resolve to a real
-    /// `packages` entry to be followed at all. The readers are the actual bug;
-    /// `transitive_closure` and `importer_closure` share it.
+    /// Walks `optional_dependencies` as well as `dependencies`. This struct
+    /// documents active optional edges as mirrored into `dependencies`, and
+    /// `yarn/berry.rs` does not uphold that — it assigns the two maps from
+    /// separate sources with no merge.
+    ///
+    /// DEFENSIVE, not a live fix. Every route to the linker runs
+    /// `platform::filter_graph` first, and its GC walk follows `dependencies`
+    /// from the same seeds through the same edge predicate, then retains only
+    /// what it reached. So on a berry graph an optional-only-reachable package
+    /// is deleted from `packages` upstream rather than arriving here without a
+    /// depth — the chain cannot add a key on any real install. It keeps this
+    /// function honest for a caller that runs before that GC.
     pub fn dependency_depths(&self) -> std::collections::HashMap<&str, usize> {
         use std::collections::hash_map::Entry;
         use std::collections::{HashMap, VecDeque};
@@ -1560,11 +1562,10 @@ mod graph_traversal_tests {
 
     #[test]
     fn an_optional_only_edge_still_yields_a_depth() {
-        // `LockedPackage` documents active optional edges as mirrored into
-        // `dependencies`, but `yarn/berry.rs` assigns the two maps separately.
-        // Walking `dependencies` alone would leave `native@1.0.0` absent, and
-        // absent ranks as infinitely deep — so it would lose the `native` name
-        // to any copy with a real depth, however much deeper.
+        // Guards this function's contract in isolation, NOT a berry install
+        // scenario: `platform::filter_graph` would have GC'd an
+        // optional-only-reachable package before any real caller got here, so
+        // this graph shape is hand-built on purpose.
         let mut g = with_importer(
             graph(&[("host@1.0.0", &[]), ("native@1.0.0", &[])]),
             ".",

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -1034,6 +1034,17 @@ impl LockfileGraph {
     ///
     /// First-write-wins over a FIFO queue, so a cycle terminates (each dep_path
     /// is enqueued at most once) and the recorded depth is the shortest one.
+    ///
+    /// Walks `optional_dependencies` as well as `dependencies`, even though this
+    /// struct documents active optional edges as MIRRORED into `dependencies`.
+    /// That invariant is not upheld by every reader — `yarn/berry.rs` assigns the
+    /// two maps from separate sources with no merge — and a consumer that ranks
+    /// by depth cannot absorb the difference the way a closure walk can: an
+    /// optional-only-reachable package would be absent, rank as infinitely deep,
+    /// and lose every name contest to arbitrarily deeper packages. Widening the
+    /// walk cannot over-reach, because an edge still has to resolve to a real
+    /// `packages` entry to be followed at all. The readers are the actual bug;
+    /// `transitive_closure` and `importer_closure` share it.
     pub fn dependency_depths(&self) -> std::collections::HashMap<&str, usize> {
         use std::collections::hash_map::Entry;
         use std::collections::{HashMap, VecDeque};
@@ -1056,7 +1067,11 @@ impl LockfileGraph {
             let Some(pkg) = self.packages.get(dep_path) else {
                 continue;
             };
-            for (child_name, child_tail) in &pkg.dependencies {
+            for (child_name, child_tail) in pkg
+                .dependencies
+                .iter()
+                .chain(pkg.optional_dependencies.iter())
+            {
                 // Same edge reconstruction `importer_closure` uses, so a yarn
                 // full-dep_path edge maps to the real child key.
                 let Some(child_key) =
@@ -1541,6 +1556,33 @@ mod graph_traversal_tests {
         assert_eq!(depths.get("a@1.0.0"), Some(&0));
         assert_eq!(depths.get("b@1.0.0"), Some(&1));
         assert_eq!(depths.get("c@1.0.0"), Some(&2));
+    }
+
+    #[test]
+    fn an_optional_only_edge_still_yields_a_depth() {
+        // `LockedPackage` documents active optional edges as mirrored into
+        // `dependencies`, but `yarn/berry.rs` assigns the two maps separately.
+        // Walking `dependencies` alone would leave `native@1.0.0` absent, and
+        // absent ranks as infinitely deep — so it would lose the `native` name
+        // to any copy with a real depth, however much deeper.
+        let mut g = with_importer(
+            graph(&[("host@1.0.0", &[]), ("native@1.0.0", &[])]),
+            ".",
+            &["host@1.0.0"],
+        );
+        g.packages
+            .get_mut("host@1.0.0")
+            .unwrap()
+            .optional_dependencies
+            .insert("native".to_string(), "1.0.0".to_string());
+
+        let depths = g.dependency_depths();
+        assert_eq!(depths.get("host@1.0.0"), Some(&0));
+        assert_eq!(
+            depths.get("native@1.0.0"),
+            Some(&1),
+            "an active optional edge is a real edge and must carry a depth"
+        );
     }
 
     #[test]

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -1022,6 +1022,57 @@ impl LockfileGraph {
         closure
     }
 
+    /// BFS distance from the importers' direct dependencies to every reachable
+    /// package, keyed by dep_path. A direct dep is depth 0; a package absent
+    /// from the result is unreachable.
+    ///
+    /// Seeded from EVERY importer, not just the root. `root_deps` reads only
+    /// `importers["."]`, so in a workspace a member's direct dependency would be
+    /// unreachable here and sort as if infinitely deep — the opposite of what
+    /// hidden-hoist name selection wants, since that dependency is exactly the
+    /// copy the member's own code resolves.
+    ///
+    /// First-write-wins over a FIFO queue, so a cycle terminates (each dep_path
+    /// is enqueued at most once) and the recorded depth is the shortest one.
+    pub fn dependency_depths(&self) -> std::collections::HashMap<&str, usize> {
+        use std::collections::{HashMap, VecDeque};
+
+        let mut depths: HashMap<&str, usize> = HashMap::new();
+        let mut queue: VecDeque<&str> = VecDeque::new();
+        for deps in self.importers.values() {
+            for direct in deps {
+                let Some((key, _)) = self.packages.get_key_value(&direct.dep_path) else {
+                    continue;
+                };
+                if depths.insert(key.as_str(), 0).is_none() {
+                    queue.push_back(key.as_str());
+                }
+            }
+        }
+        while let Some(dep_path) = queue.pop_front() {
+            let depth = depths[dep_path];
+            let Some(pkg) = self.packages.get(dep_path) else {
+                continue;
+            };
+            for (child_name, child_tail) in &pkg.dependencies {
+                // Same edge reconstruction `importer_closure` uses, so a yarn
+                // full-dep_path edge maps to the real child key.
+                let Some(child_key) =
+                    resolve_dep_edge(child_name, child_tail, |k| self.packages.contains_key(k))
+                else {
+                    continue;
+                };
+                let Some((key, _)) = self.packages.get_key_value(&child_key) else {
+                    continue;
+                };
+                if depths.insert(key.as_str(), depth + 1).is_none() {
+                    queue.push_back(key.as_str());
+                }
+            }
+        }
+        depths
+    }
+
     /// Clone only the `packages` entries whose keys are in `reachable`.
     /// Paired with `transitive_closure` to produce the pruned
     /// `LockfileGraph.packages` for `filter_deps` / `subset_to_importer`.
@@ -1260,7 +1311,7 @@ impl LockfileGraph {
 }
 
 #[cfg(test)]
-mod importer_closure_tests {
+mod graph_traversal_tests {
     use super::*;
 
     /// Build a graph from `(dep_path, [(child_name, child_tail)])` edges. The
@@ -1396,5 +1447,104 @@ mod importer_closure_tests {
                 .map(String::from)
                 .into()
         );
+    }
+
+    /// Attach direct dependencies to `importer_id`, so a graph can carry a
+    /// workspace member's own entry point and not just the root's.
+    fn with_importer(mut g: LockfileGraph, importer_id: &str, deps: &[&str]) -> LockfileGraph {
+        g.importers.insert(
+            importer_id.to_string(),
+            deps.iter()
+                .map(|dep_path| DirectDep {
+                    name: dep_path_name(dep_path).to_string(),
+                    dep_path: (*dep_path).to_string(),
+                    dep_type: DepType::Production,
+                    specifier: None,
+                })
+                .collect(),
+        );
+        g
+    }
+
+    #[test]
+    fn depth_is_the_shortest_path_from_a_direct_dep() {
+        // shallow@1 → ms@2.1.2 (depth 1); deep@1 → mid@1 → ms@2.0.0 (depth 2).
+        let g = with_importer(
+            graph(&[
+                ("shallow@1.0.0", &[("ms", "2.1.2")]),
+                ("deep@1.0.0", &[("mid", "1.0.0")]),
+                ("mid@1.0.0", &[("ms", "2.0.0")]),
+                ("ms@2.1.2", &[]),
+                ("ms@2.0.0", &[]),
+            ]),
+            ".",
+            &["shallow@1.0.0", "deep@1.0.0"],
+        );
+        let depths = g.dependency_depths();
+        assert_eq!(depths.get("shallow@1.0.0"), Some(&0));
+        assert_eq!(depths.get("deep@1.0.0"), Some(&0));
+        assert_eq!(depths.get("mid@1.0.0"), Some(&1));
+        assert_eq!(
+            depths.get("ms@2.1.2"),
+            Some(&1),
+            "the copy under a root direct dep is the shallow one"
+        );
+        assert_eq!(depths.get("ms@2.0.0"), Some(&2));
+    }
+
+    #[test]
+    fn a_workspace_members_direct_dep_is_depth_zero() {
+        // The regression this guards: seeding from `root_deps()` alone leaves a
+        // member's direct dependency unreachable, so hidden-hoist name selection
+        // would rank it BELOW every transitive the root can reach — the opposite
+        // of what the member's own code resolves.
+        let g = with_importer(
+            with_importer(
+                graph(&[
+                    ("express@4.18.2", &[("debug", "2.6.9")]),
+                    ("debug@2.6.9", &[]),
+                    ("debug@4.3.4", &[]),
+                ]),
+                ".",
+                &["express@4.18.2"],
+            ),
+            "packages/a",
+            &["debug@4.3.4"],
+        );
+        let depths = g.dependency_depths();
+        assert_eq!(depths.get("debug@4.3.4"), Some(&0));
+        assert_eq!(depths.get("debug@2.6.9"), Some(&1));
+    }
+
+    #[test]
+    fn a_dependency_cycle_terminates_and_keeps_the_shortest_depth() {
+        // a → b → c → a. Without first-write-wins this never settles.
+        let g = with_importer(
+            graph(&[
+                ("a@1.0.0", &[("b", "1.0.0")]),
+                ("b@1.0.0", &[("c", "1.0.0")]),
+                ("c@1.0.0", &[("a", "1.0.0")]),
+            ]),
+            ".",
+            &["a@1.0.0"],
+        );
+        let depths = g.dependency_depths();
+        assert_eq!(depths.get("a@1.0.0"), Some(&0));
+        assert_eq!(depths.get("b@1.0.0"), Some(&1));
+        assert_eq!(depths.get("c@1.0.0"), Some(&2));
+    }
+
+    #[test]
+    fn a_package_no_importer_reaches_is_absent() {
+        // Absent rather than present-with-a-number: the hidden-hoist sort maps
+        // absence to "infinitely deep" so it loses every name contest it enters.
+        let g = with_importer(
+            graph(&[("reachable@1.0.0", &[]), ("orphan@1.0.0", &[])]),
+            ".",
+            &["reachable@1.0.0"],
+        );
+        let depths = g.dependency_depths();
+        assert_eq!(depths.get("reachable@1.0.0"), Some(&0));
+        assert_eq!(depths.get("orphan@1.0.0"), None);
     }
 }

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -1550,6 +1550,22 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     if matches!(node_linker, aube_settings::resolved::NodeLinker::Hoisted) {
         hasher.update(b"hoisted_layout_algo=2\0");
     }
+    // Hidden-hoist name-selection version. The tree at
+    // `<virtual-store>/node_modules/` now claims each name shallowest-first
+    // (pnpm's hoist sort) instead of in dep_path order, so which VERSION of a
+    // name an undeclared import resolves to can move. Nothing else in this hash
+    // sees that: the graph, the settings and the direct entries are all
+    // identical across the change, and `verify_install_layout` only lstats the
+    // top-level entries — it never inspects the tree. Without this salt a warm
+    // `node_modules` keeps the old tree and a phantom import resolves
+    // differently warm vs. fresh from one lockfile. Bump on any future
+    // hidden-hoist selection change. Gated ON the isolated linker, which is the
+    // only one that builds this tree — the hoisted linker returns from
+    // `link_all` before `link_hidden_hoist`. Stated positively so a future
+    // third linker has to opt in rather than inherit the salt by default.
+    if matches!(node_linker, aube_settings::resolved::NodeLinker::Isolated) {
+        hasher.update(b"hidden_hoist_algo=1\0");
+    }
     let dedupe_direct_deps = aube_settings::resolved::dedupe_direct_deps(&ctx);
     hasher.update(format!("dedupe_direct_deps={dedupe_direct_deps}\0").as_bytes());
     let symlink = aube_settings::resolved::symlink(&ctx);


### PR DESCRIPTION
Hidden-hoist alias claims were made by iterating `graph.packages`, keyed by dep_path — lexicographic, tracking nothing about the graph (`1.0.0` beat `2.0.0`; `10.0.0` beat `9.0.0`). Now root direct deps claim first, then shallowest wins, dep_path breaking ties.

The depth tier matches pnpm; the tie-break does not. pnpm sorts parents and walks their children, so its effective key is the parent's `(depth, node id)` — two same-depth parents bringing different versions resolve differently there than here.

- `dependency_depths` seeds from every importer; `root_deps()` reads only `importers["."]`, leaving a member's direct dep unreachable.
- It walks optional edges too: `LockedPackage` documents active optionals as mirrored into `dependencies`, but `yarn/berry.rs` does not merge them. The readers are the underlying bug; that is a separate change.
- Adds a `hidden_hoist_algo` settings-hash salt; without it the change is inert on warm trees. One-time relink.

Claim order also changes for the GVS-off tree; intended.
