### PR TITLE
fix(tsconfig): refuse the run when the project's tsconfig cannot be read

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3950,6 +3950,36 @@ fn tsconfig_reported_env() -> Option<(String, String)> {
     (!reported.is_empty()).then(|| (nub_tsconfig::REPORTED_ENV.to_string(), reported.join("\n")))
 }
 
+/// Directory of the entry file for a `nub <file>` run, resolved against `cwd`.
+///
+/// The first non-flag argument is the entry; anything else (a bare `--flag`) leaves
+/// this `None` and the CWD-anchored check stands alone.
+fn entry_file_dir(args: &[String], cwd: &Path) -> Option<PathBuf> {
+    let entry = args.iter().find(|a| !a.starts_with('-'))?;
+    let joined = cwd.join(entry);
+    joined.parent().map(Path::to_path_buf)
+}
+
+/// Refuse the run when the tsconfig governing `dir` will not parse.
+///
+/// The diagnostics themselves are already on stderr by the time this reads them
+/// (`nub_tsconfig` writes each one once per config path), so this adds the verdict
+/// and the way out rather than repeating the detail.
+fn ensure_tsconfig_parses(dir: &str, explicit: Option<&str>) -> Result<()> {
+    if nub_tsconfig::diagnostics(dir, explicit).is_empty() {
+        return Ok(());
+    }
+    // `--node` is named as the way past this, but NOT as a way to keep the program
+    // working: compat mode turns off every config-derived behavior, so a project
+    // that needed `paths` fails there too, just further downstream. Say what it
+    // costs, or the suggestion sends the reader somewhere worse than where they are.
+    bail!(
+        "the project's tsconfig.json could not be read in full (see above).\n\
+         Fix the config, or use --node to run without Nub's TypeScript features, \
+         path aliases included."
+    );
+}
+
 pub(crate) fn runtime_node_options(
     runtime: &mut crate::project_config::RuntimeConfig,
     node: &nub_core::node::discovery::ResolvedNode,
@@ -4008,6 +4038,16 @@ pub(crate) fn runtime_node_options_with(
     // `extends`. Skipped entirely in compat mode by the caller, like every other
     // config-derived flag.
     if let Ok(cwd) = std::env::current_dir() {
+        // A tsconfig that will not parse is FATAL, not a warning (#731). Reporting it
+        // and carrying on still runs the program under options its author never
+        // wrote — the same silent-wrong-answer the issue reported, only quieter — and
+        // `tsc` likewise exits rather than guessing at the missing half. Nothing is
+        // salvageable enough to be worth guessing: `extends` is how a project factors
+        // out `strict`, `target` and `paths`, so the base is usually where the load
+        // lives. `--node` / `NODE_COMPAT` skip this whole function, so the escape
+        // hatch for a config nub cannot read is the one that already turns off every
+        // other config-derived behavior.
+        ensure_tsconfig_parses(&cwd.to_string_lossy(), runtime.tsconfig.as_deref())?;
         for condition in
             nub_tsconfig::custom_conditions(&cwd.to_string_lossy(), runtime.tsconfig.as_deref())
         {
@@ -4396,6 +4436,15 @@ fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path, exec_ua: bool
         (Vec::new(), Vec::new())
     } else {
         let options = runtime_node_options(&mut runtime, &node)?;
+        // `runtime_node_options` anchors its own check at the CWD, which is the config
+        // `nub.jsonc` and a bare preload specifier resolve against. The ENTRY can sit
+        // under a different one — `nub sub/main.ts` from the parent — and that is the
+        // config the addon will actually transform against, so it gets the same
+        // refusal. Without this, the identical project fails from inside `sub/` and
+        // merely warned from above it.
+        if let Some(entry_dir) = entry_file_dir(args, cwd) {
+            ensure_tsconfig_parses(&entry_dir.to_string_lossy(), runtime.tsconfig.as_deref())?;
+        }
         let v8_flags = runtime_v8_flags(&runtime)?;
         env_vars.insert(
             crate::project_config::RUNTIME_CONFIG_ENV.to_string(),

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1477,6 +1477,29 @@ fn legacy_decorators_require_experimental_flag() {
     );
 }
 
+#[test]
+fn an_unreadable_tsconfig_stops_the_run() {
+    // #731 reported that an `extends` target nub could not resolve was dropped in
+    // silence, taking `paths`, decorator flags and `customConditions` with it. The
+    // first fix reported it and carried on; that still ran the program under options
+    // its author never wrote, so it is fatal now — `tsc` (TS5083) likewise exits
+    // rather than guessing at the missing half.
+    //
+    // Asserts the DIAGNOSTIC, not just the exit code: a non-zero exit is what the
+    // old behavior produced too, by failing to resolve the alias further downstream
+    // with an error that never mentioned the config.
+    let (_stdout, stderr, code) = run_nub("tsconfig-broken-extends", "main.ts");
+    assert_ne!(code, 0, "a tsconfig that will not parse must stop the run");
+    assert!(
+        stderr.contains("does-not-exist.json"),
+        "the failure must name the file it could not read: {stderr}"
+    );
+    assert!(
+        stderr.contains("--node"),
+        "the failure must name the way past it: {stderr}"
+    );
+}
+
 // ── Project-source plain JS (.js/.mjs/.cjs) transpile ───────────────
 // nub transpiles PROJECT plain JS through the same pipeline as `.ts`, so
 // transformable syntax (`using`/`await using`, `v`-flag RegExp, decorators) lowers

--- a/crates/nub-tsconfig/src/lib.rs
+++ b/crates/nub-tsconfig/src/lib.rs
@@ -275,11 +275,10 @@ fn build_loaded(dir: &str, explicit: Option<&str>) -> Loaded {
         Err(e) => {
             // The config's OWN body is unreadable, so there is nothing to keep —
             // unlike a failed `extends`, which leaves this file's options intact
-            // (see `inner_parse`). Still not fatal to the run: the transpiler falls
-            // back to defaults. What changed in #731 is that the reason now travels
-            // out of here instead of being dropped, because a silent fallback is
-            // indistinguishable from having no tsconfig at all.
-            diagnostics.push(format!("{e} No compilerOptions were applied."));
+            // (see `inner_parse`). The reason travels out with the empty result so
+            // the CLI can refuse the run; a silent fallback to defaults here is
+            // indistinguishable from having no tsconfig at all (#731).
+            diagnostics.push(e);
             report_diagnostics(&config_path, &diagnostics);
             return Loaded {
                 path: Some(slash(&config_path)),
@@ -570,23 +569,23 @@ fn inner_parse(
         }
         // arrays processed in reverse (later entries win).
         //
-        // A base that will not resolve is RECORDED AND SKIPPED, not propagated
-        // (#731). get-tsconfig throws here and so did this port, which meant one
-        // missing `extends` target discarded the whole file — `paths`, decorator
-        // flags and `customConditions` alike — leaving nub indistinguishable from
-        // "no tsconfig". `tsc` (TS5083) and bun both keep the options the file
-        // itself declares, and this now matches them. A deliberate divergence from
-        // the mirrored package, in the same spirit as the PnP gap noted up top.
+        // A base that will not resolve is RECORDED AND SKIPPED here, not propagated
+        // (#731). get-tsconfig throws, which meant one missing `extends` target
+        // discarded the whole file — `paths`, decorator flags and `customConditions`
+        // alike — leaving nub indistinguishable from "no tsconfig".
         //
-        // Circularity lands here too, and is likewise skipped rather than fatal;
-        // `stack` is what actually stops the recursion, and tsc also reports and
-        // carries on.
+        // Skipping is NOT the whole answer, because a run that proceeds on half a
+        // config is wrong in the same quiet way. The recorded diagnostic is what the
+        // CLI refuses to run on, so the salvage below only ever governs a config the
+        // CLI never saw — a dependency's own tsconfig, reached mid-resolve by the
+        // addon, where aborting the process is not available. Keeping what the file
+        // declares is the better answer there, and matches `tsc` (TS5083) and bun.
+        //
+        // Circularity lands here too; `stack` is what actually stops the recursion.
         for entry in list.into_iter().rev() {
             match resolve_extends(&entry, &dir, &mut stack.to_vec(), diags) {
                 Ok(base) => config = merge_extends(base, config),
-                Err(e) => diags.push(format!(
-                    "{config_path}: {e} Skipped it; the options set in this file still apply."
-                )),
+                Err(e) => diags.push(format!("{config_path}: {e}")),
             }
         }
     }
@@ -1518,8 +1517,8 @@ mod tests {
             "expected exactly one diagnostic, got {reported:?}",
         );
         assert!(
-            reported[0].contains("absent.json") && reported[0].contains("still apply"),
-            "diagnostic should name the missing target and what survived; got {:?}",
+            reported[0].contains("absent.json") && reported[0].contains("tsconfig.json"),
+            "diagnostic should name both the config and the target it could not read; got {:?}",
             reported[0],
         );
     }
@@ -1533,8 +1532,8 @@ mod tests {
         assert!(read(&dir).is_empty());
         let reported = diags(&dir);
         assert!(
-            reported.len() == 1 && reported[0].contains("No compilerOptions were applied"),
-            "expected one diagnostic naming the consequence; got {reported:?}",
+            reported.len() == 1 && reported[0].contains("tsconfig.json"),
+            "expected one diagnostic naming the unparseable config; got {reported:?}",
         );
     }
 

--- a/site/content/docs/runtime/typescript.mdx
+++ b/site/content/docs/runtime/typescript.mdx
@@ -36,13 +36,16 @@ Nub reads the nearest `tsconfig.json` for the [resolution](/docs/runtime/resolut
 }
 ```
 
-When a config names an `extends` target that cannot be resolved, Nub reports it and still applies the options that config sets itself — the same as `tsc`. Only the unreadable base is skipped, so path aliases and decorator flags declared alongside it keep working.
+A config Nub cannot read in full stops the run. Since `extends` is where a project usually keeps `strict`, `target` and its path aliases, continuing would run your code under options you never wrote.
 
 ```console
 $ nub main.ts
-Nub: /app/tsconfig.json: File './base.json' not found. Skipped it; the options set in this file still apply.
-alias-resolved
+Nub: /app/tsconfig.json: File './base.json' not found.
+Error: the project's tsconfig.json could not be read in full (see above).
+Fix the config, or use --node to run without Nub's TypeScript features, path aliases included.
 ```
+
+Compat mode turns off every config-derived behavior, so `--node` gets past the error but does not restore what the config was setting up. Fixing the config is the way to keep path aliases and decorator flags working.
 
 <Callout>
 Read the [full docs](https://www.typescriptlang.org/tsconfig/) for `tsconfig.json` on typescriptlang.org.

--- a/tests/fixtures/tsconfig-broken-extends/main.ts
+++ b/tests/fixtures/tsconfig-broken-extends/main.ts
@@ -1,0 +1,2 @@
+import { thing } from "@/util";
+console.log(thing);

--- a/tests/fixtures/tsconfig-broken-extends/tsconfig.json
+++ b/tests/fixtures/tsconfig-broken-extends/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./does-not-exist.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["./*"] }
+  }
+}

--- a/tests/fixtures/tsconfig-broken-extends/util.ts
+++ b/tests/fixtures/tsconfig-broken-extends/util.ts
@@ -1,0 +1,1 @@
+export const thing = "alias-resolved";


### PR DESCRIPTION
Follow-up to #768, which reported an unreadable tsconfig and carried on. Continuing still runs the program under options its author never wrote — `extends` is where a project factors out `strict`, `target` and its path aliases — so this refuses the run instead, as `tsc` (TS5083) does.

```console
$ nub main.ts
Nub: /app/tsconfig.json: File './base.json' not found.
Error: the project's tsconfig.json could not be read in full (see above).
Fix the config, or use --node to run without Nub's TypeScript features, path aliases included.
```

Two anchors: the CWD, and the entry file's own directory, so `nub sub/main.ts` from the parent answers the same as that project run from inside `sub/`.

The salvage from #768 stays and now only governs a config the CLI never saw — a dependency's own tsconfig reached mid-resolve by the addon, where aborting is not available.

Refs #731
