### PR TITLE
lockfile: resolve a read against the declared package manager, not filename precedence

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/detect.rs
+++ b/vendor/aube/crates/aube-lockfile/src/detect.rs
@@ -177,7 +177,7 @@ fn declared_lockfile_kind(name: &str) -> Option<LockfileKind> {
 /// The PM family a lockfile kind belongs to, for the ambiguity check.
 /// Kinds owned by the same tool (npm's shrinkwrap + package-lock,
 /// yarn classic + berry) never make a project ambiguous together.
-fn family(kind: LockfileKind) -> &'static str {
+pub(crate) fn family(kind: LockfileKind) -> &'static str {
     match kind {
         LockfileKind::Aube => "aube",
         LockfileKind::Pnpm => "pnpm",

--- a/vendor/aube/crates/aube-lockfile/src/io.rs
+++ b/vendor/aube/crates/aube-lockfile/src/io.rs
@@ -498,7 +498,7 @@ pub fn parse_lockfile_with_kind_and_options(
     options: ParseOptions,
 ) -> Result<(LockfileGraph, LockfileKind), Error> {
     reject_bun_binary(project_dir)?;
-    for (path, kind) in lockfile_candidates(project_dir, /*include_aube=*/ true) {
+    for (path, kind) in read_candidates(project_dir, /*include_aube=*/ true) {
         if !path.exists() {
             continue;
         }
@@ -520,7 +520,7 @@ pub fn parse_for_import(
     manifest: &aube_manifest::PackageJson,
 ) -> Result<(LockfileGraph, LockfileKind), Error> {
     reject_bun_binary(project_dir)?;
-    for (path, kind) in lockfile_candidates(project_dir, /*include_aube=*/ false) {
+    for (path, kind) in read_candidates(project_dir, /*include_aube=*/ false) {
         if !path.exists() {
             continue;
         }
@@ -529,6 +529,36 @@ pub fn parse_for_import(
         return Ok((graph, kind));
     }
     Err(Error::NotFound(project_dir.to_path_buf()))
+}
+
+/// [`lockfile_candidates`] reordered so the lockfile the project's declaration
+/// resolves to leads, with raw filename precedence breaking every remaining tie.
+///
+/// A read and a write must land on the SAME file. The write path asks
+/// [`crate::resolve_project_lockfile_kind`], which honors
+/// `packageManager`/`devEngines`; filename precedence cannot see either. So a
+/// declared-npm project carrying a stray `bun.lock` resolved against bun's
+/// graph and wrote it back out as `package-lock.json`, dropping the `resolved`,
+/// `license` and `engines` that bun's format cannot carry.
+///
+/// Reorder rather than filter: when the declaration contradicts the disk, or
+/// several tools' lockfiles coexist undeclared, detection errors and the read
+/// falls back to today's precedence, leaving the write path to raise that error
+/// as it already does.
+///
+/// Order by FAMILY, not exact kind — [`crate::resolve_project_lockfile_kind`]
+/// applies [`refine_yarn_kind`], so it answers `YarnBerry` where this list says
+/// `Yarn`. The sort is stable, so npm's shrinkwrap-first precedence survives.
+fn read_candidates(project_dir: &Path, include_aube: bool) -> Vec<(PathBuf, LockfileKind)> {
+    let mut candidates = lockfile_candidates(project_dir, include_aube);
+    if let Some(resolved) = crate::detect::resolve_project_lockfile_kind(project_dir)
+        .ok()
+        .and_then(|r| r.kind())
+    {
+        let want = crate::detect::family(resolved);
+        candidates.sort_by_key(|(_, kind)| crate::detect::family(*kind) != want);
+    }
+    candidates
 }
 
 /// If only `bun.lockb` is present (without a text `bun.lock`), surface an

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -3210,3 +3210,30 @@ fn test_write_npm_root_entry_mirrors_manifest_metadata() {
         "root entry key order drifted from npm's:\n{written}"
     );
 }
+
+/// npm strips the leading `./` off every bin path — and strips it repeatedly,
+/// so `././d.js` lands as `d.js`. Leaving the prefix on churns the lockfile
+/// against npm's own output on every alternating install. Expectations
+/// captured from npm 11.17 on this exact `bin` map.
+#[test]
+fn test_write_npm_root_bin_paths_shed_leading_dot_slash() {
+    let manifest: aube_manifest::PackageJson = serde_json::from_str(
+        r#"{
+            "name": "binforms",
+            "version": "1.0.0",
+            "bin": { "a": "./a.js", "b": "b.js", "c": "./nested/c.js", "d": "././d.js" }
+        }"#,
+    )
+    .unwrap();
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    write(tmp.path(), &LockfileGraph::default(), &manifest).unwrap();
+    let root: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(tmp.path()).unwrap()).unwrap();
+
+    assert_eq!(
+        root["packages"][""]["bin"],
+        serde_json::json!({ "a": "a.js", "b": "b.js", "c": "nested/c.js", "d": "d.js" }),
+        "only the leading ./ segments are shed; the rest of the path is kept"
+    );
+}

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -3167,3 +3167,46 @@ fn legacy_flat_hoisted_transitive_flagged_as_unreferenced() {
         "a recorded `requires` edge means nothing is orphaned"
     );
 }
+
+/// npm copies the root project's own `license`, `bin` and `engines` into the
+/// `""` importer entry, normalizing an object `license` to its `type` and a
+/// string `bin` to `{ <name-without-scope>: <path> }`. Expectations captured
+/// from npm 11.17 on the same manifest.
+#[test]
+fn test_write_npm_root_entry_mirrors_manifest_metadata() {
+    let manifest: aube_manifest::PackageJson = serde_json::from_str(
+        r#"{
+            "name": "@scope/fx",
+            "version": "1.2.3",
+            "license": { "type": "MIT" },
+            "bin": "cli.js",
+            "engines": { "node": ">=22.15.0" }
+        }"#,
+    )
+    .unwrap();
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    write(tmp.path(), &LockfileGraph::default(), &manifest).unwrap();
+    let written = std::fs::read_to_string(tmp.path()).unwrap();
+
+    let root: serde_json::Value = serde_json::from_str(&written).unwrap();
+    let root = &root["packages"][""];
+    assert_eq!(
+        root["license"], "MIT",
+        "object license collapses to its type"
+    );
+    assert_eq!(
+        root["bin"],
+        serde_json::json!({ "fx": "cli.js" }),
+        "string bin expands under the scope-stripped package name"
+    );
+    assert_eq!(root["engines"], serde_json::json!({ "node": ">=22.15.0" }));
+
+    // npm orders package-entry keys non-objects-then-objects, so `license`
+    // lands before `bin` and `engines`. Byte-parity with npm depends on it.
+    let key_at = |key: &str| written.find(key).unwrap_or_else(|| panic!("missing {key}"));
+    assert!(
+        key_at("\"license\"") < key_at("\"bin\"") && key_at("\"bin\"") < key_at("\"engines\""),
+        "root entry key order drifted from npm's:\n{written}"
+    );
+}

--- a/vendor/aube/crates/aube-lockfile/src/npm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/write.rs
@@ -194,6 +194,49 @@ impl Serialize for WriteNpmPackage<'_> {
     }
 }
 
+/// The root project's `license` and `bin`, normalized the way npm normalizes
+/// them into the root importer entry (verified against npm 11.17): an object
+/// `license` collapses to its `type`, and a string `bin` expands to
+/// `{ <name-without-scope>: <path> }`.
+///
+/// Both are read out of [`aube_manifest::PackageJson::extra`], the flattened
+/// catch-all, rather than promoted to typed fields — nothing else in aube
+/// consumes them, and a typed field would change how a manifest re-serializes.
+/// `engines` is already typed, so the caller reads it directly.
+///
+/// Only the ROOT importer gets this. A workspace member's entry is built from
+/// whichever of the link package or an on-disk manifest is available, and the
+/// manifest is absent on exactly the path that matters here (a graph read back
+/// from an npm lockfile), so there is nothing to mirror.
+fn root_manifest_metadata(
+    manifest: &aube_manifest::PackageJson,
+) -> (Option<&str>, BTreeMap<&str, &str>) {
+    let license = manifest.extra.get("license").and_then(|v| match v {
+        serde_json::Value::String(s) => Some(s.as_str()),
+        serde_json::Value::Object(o) => o.get("type").and_then(|t| t.as_str()),
+        _ => None,
+    });
+
+    let mut bin: BTreeMap<&str, &str> = BTreeMap::new();
+    match manifest.extra.get("bin") {
+        Some(serde_json::Value::Object(entries)) => {
+            for (target, path) in entries {
+                if let Some(path) = path.as_str() {
+                    bin.insert(target.as_str(), path);
+                }
+            }
+        }
+        Some(serde_json::Value::String(path)) => {
+            if let Some(name) = manifest.name.as_deref() {
+                bin.insert(name.rsplit('/').next().unwrap_or(name), path.as_str());
+            }
+        }
+        _ => {}
+    }
+
+    (license, bin)
+}
+
 /// npm emits `funding: {"url": "…"}` verbatim, one key, on every
 /// package entry that declared funding. We only carry the URL on
 /// `LockedPackage`, so this wrapper slots it back into the expected
@@ -294,16 +337,27 @@ pub fn write(
 
     let mut packages: BTreeMap<String, WriteNpmPackage> = BTreeMap::new();
 
-    // Root importer entry — mirrors the manifest's dep fields.
+    // Root importer entry — mirrors the manifest's dep fields, plus the
+    // `license`/`bin`/`engines` npm copies across from the project's own
+    // `package.json`. Omitting the latter three silently dropped them from a
+    // hand-written `package-lock.json` on the first rewrite.
+    let (root_license, root_bin) = root_manifest_metadata(manifest);
     packages.insert(
         root_key.to_string(),
         WriteNpmPackage {
             name: manifest.name.as_deref(),
             version: manifest.version.as_deref(),
+            license: root_license,
             dependencies: borrow_map(&manifest.dependencies),
             dev_dependencies: borrow_map(&manifest.dev_dependencies),
             optional_dependencies: borrow_map(&manifest.optional_dependencies),
             peer_dependencies: borrow_map(&manifest.peer_dependencies),
+            bin: root_bin,
+            engines: manifest
+                .engines
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect(),
             ..Default::default()
         },
     );

--- a/vendor/aube/crates/aube-lockfile/src/npm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/write.rs
@@ -196,8 +196,10 @@ impl Serialize for WriteNpmPackage<'_> {
 
 /// The root project's `license` and `bin`, normalized the way npm normalizes
 /// them into the root importer entry (verified against npm 11.17): an object
-/// `license` collapses to its `type`, and a string `bin` expands to
-/// `{ <name-without-scope>: <path> }`.
+/// `license` collapses to its `type`, a string `bin` expands to
+/// `{ <name-without-scope>: <path> }`, and every bin path sheds its leading
+/// `./` segments — npm writes `"./a.js"` and `"././d.js"` alike as `d.js`,
+/// so leaving them on churns the lockfile against npm's own output.
 ///
 /// Both are read out of [`aube_manifest::PackageJson::extra`], the flattened
 /// catch-all, rather than promoted to typed fields — nothing else in aube
@@ -217,18 +219,30 @@ fn root_manifest_metadata(
         _ => None,
     });
 
+    // Repeated rather than single: npm collapses `././d.js` all the way to
+    // `d.js`. Prefix-stripping keeps the result a borrow of the manifest.
+    fn strip_dot_slash(mut path: &str) -> &str {
+        while let Some(rest) = path.strip_prefix("./") {
+            path = rest;
+        }
+        path
+    }
+
     let mut bin: BTreeMap<&str, &str> = BTreeMap::new();
     match manifest.extra.get("bin") {
         Some(serde_json::Value::Object(entries)) => {
             for (target, path) in entries {
                 if let Some(path) = path.as_str() {
-                    bin.insert(target.as_str(), path);
+                    bin.insert(target.as_str(), strip_dot_slash(path));
                 }
             }
         }
         Some(serde_json::Value::String(path)) => {
             if let Some(name) = manifest.name.as_deref() {
-                bin.insert(name.rsplit('/').next().unwrap_or(name), path.as_str());
+                bin.insert(
+                    name.rsplit('/').next().unwrap_or(name),
+                    strip_dot_slash(path.as_str()),
+                );
             }
         }
         _ => {}

--- a/vendor/aube/crates/aube-lockfile/tests/declared_lockfile_read_source.rs
+++ b/vendor/aube/crates/aube-lockfile/tests/declared_lockfile_read_source.rs
@@ -1,0 +1,113 @@
+//! A `packageManager` declaration decides which lockfile a READ resolves
+//! against, not only which one a write targets.
+//!
+//! `package-lock.json` sorts LAST in filename precedence, so a stray `bun.lock`
+//! used to win the read while `write_lockfile_preserving_existing` still
+//! resolved npm. An install then serialized bun's thinner graph back out as
+//! `package-lock.json`, silently dropping the `resolved`, `license` and
+//! `engines` that bun's format cannot carry.
+
+use aube_lockfile::{
+    LockfileKind, ResolvedLockfileKind, parse_lockfile_with_kind, resolve_project_lockfile_kind,
+};
+use std::path::Path;
+
+const LODASH_20_INTEGRITY: &str = "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==";
+const LODASH_21_INTEGRITY: &str = "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==";
+
+/// The two lockfiles deliberately disagree on lodash's version, so which one
+/// the read picked is visible in the returned graph rather than inferred.
+fn fixture(dir: &Path, package_manager: &str) -> aube_manifest::PackageJson {
+    let manifest_json = format!(
+        r#"{{"name":"fx","version":"1.0.0","packageManager":"{package_manager}",
+            "dependencies":{{"lodash":"^4.17.0"}}}}"#
+    );
+    std::fs::write(dir.join("package.json"), &manifest_json).unwrap();
+
+    std::fs::write(
+        dir.join("package-lock.json"),
+        format!(
+            r#"{{"name":"fx","version":"1.0.0","lockfileVersion":3,"requires":true,"packages":{{
+                "":{{"name":"fx","version":"1.0.0","dependencies":{{"lodash":"^4.17.0"}}}},
+                "node_modules/lodash":{{
+                    "version":"4.17.20",
+                    "resolved":"https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                    "integrity":"{LODASH_20_INTEGRITY}",
+                    "license":"MIT"}}}}}}"#
+        ),
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.join("bun.lock"),
+        format!(
+            r#"{{"lockfileVersion":1,
+                "workspaces":{{"":{{"name":"fx","dependencies":{{"lodash":"^4.17.0"}},}},}},
+                "packages":{{"lodash":["lodash@4.17.21","",{{}},"{LODASH_21_INTEGRITY}"],}}}}"#
+        ),
+    )
+    .unwrap();
+
+    serde_json::from_str(&manifest_json).unwrap()
+}
+
+#[test]
+fn declared_npm_reads_package_lock_over_a_higher_precedence_bun_lockfile() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = fixture(dir.path(), "npm@11.0.0");
+
+    let (graph, kind) = parse_lockfile_with_kind(dir.path(), &manifest).unwrap();
+    assert_eq!(
+        kind,
+        LockfileKind::Npm,
+        "declared npm must read package-lock.json, not the bun.lock that outranks it in filename precedence"
+    );
+    assert_eq!(
+        resolve_project_lockfile_kind(dir.path()).unwrap(),
+        ResolvedLockfileKind::Existing(LockfileKind::Npm),
+        "the write path resolves npm, so a read landing anywhere else rewrites one format's graph into the other's file"
+    );
+
+    let lodash = graph
+        .packages
+        .values()
+        .find(|p| p.name == "lodash")
+        .expect("lodash missing from the parsed graph");
+    assert_eq!(
+        lodash.version, "4.17.20",
+        "read the npm lockfile's pin; bun.lock pins 4.17.21"
+    );
+    assert_eq!(
+        lodash.license.as_deref(),
+        Some("MIT"),
+        "npm-only metadata that bun's format cannot carry must survive the read"
+    );
+    assert_eq!(
+        lodash.tarball_url.as_deref(),
+        Some("https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz"),
+        "npm-only metadata that bun's format cannot carry must survive the read"
+    );
+}
+
+#[test]
+fn declared_bun_still_reads_bun_lock_over_a_coexisting_package_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = fixture(dir.path(), "bun@1.2.0");
+
+    let (graph, kind) = parse_lockfile_with_kind(dir.path(), &manifest).unwrap();
+    assert_eq!(
+        kind,
+        LockfileKind::Bun,
+        "the declaration decides in both directions — this is not an npm-always rule"
+    );
+
+    let lodash = graph
+        .packages
+        .values()
+        .find(|p| p.name == "lodash")
+        .expect("lodash missing from the parsed graph");
+    assert_eq!(
+        lodash.version, "4.17.21",
+        "read bun.lock's pin; package-lock.json pins 4.17.20"
+    );
+}


### PR DESCRIPTION
## The defect

In a project declaring npm, a `bun.lock` sitting beside `package-lock.json` made `nub install` rewrite `package-lock.json` without the `resolved`, `license` and `engines` of exactly the entries `bun.lock` also names. It also installed bun's pins rather than the project's own. Remove the `bun.lock` and the same fixture round-tripped byte-for-byte.

```sh
mkdir /tmp/repro && cd /tmp/repro
cp <nub-repo>/{package.json,package-lock.json,bun.lock} .
cp package-lock.json /tmp/before.json
nub install
diff -u /tmp/before.json package-lock.json   # 6 entries lose resolved/license/engines
```

The same shape reproduces with a stray `pnpm-lock.yaml` or `yarn.lock`, and with `npm-shrinkwrap.json`.

## Root cause

Reads and writes were resolving different files. The write path asks the declaration-aware `resolve_project_lockfile_kind`, which honors `packageManager` and `devEngines`. The read path walked candidates in raw filename precedence — `pnpm > bun > yarn > npm-shrinkwrap > npm` — and took the first that existed. Since `package-lock.json` sorts last, the stray file won the read while npm still won the write, so bun's thinner graph was serialized into npm's file.

Confirmed with `RUST_LOG=debug`: the install logged `peer-context pass (lockfile=Bun)` before, `lockfile=Npm` after. Nothing merged the two lockfiles — the npm one was never read.

The read candidates are now ordered so the declaration's family leads. Reordering rather than filtering keeps this from inventing a failure mode: when a declaration contradicts the disk, or several tools' lockfiles coexist undeclared, detection errors and the read falls back to the old precedence, leaving the write path to raise the error it already raised.

## Second defect, independent of any foreign lockfile

The npm writer's root importer entry mirrored only the manifest's dependency fields. Real npm also copies `license`, `bin` and `engines` there, so a genuine rewrite dropped all three even with no stray lockfile present. Both npm normalizations are reproduced: an object `license` collapses to its `type`, a string `bin` expands to `{ <name-without-scope>: <path> }`. Scoped to the root importer — a workspace member's entry has no manifest available on the path that matters.

## The signal-exit hoist: intended, left alone

The same rewrite moved `node_modules/write-file-atomic/node_modules/signal-exit` to `node_modules/signal-exit`. Differential on the same fixture:

| tool and state | placement |
| --- | --- |
| npm, existing lockfile kept | `node_modules/write-file-atomic/node_modules/signal-exit` |
| npm, no lockfile (fresh resolve) | `node_modules/signal-exit` |
| nub, genuine write | `node_modules/signal-exit` |

The npm writer recomputes the layout from the flat graph on every write and places each package in the shallowest legal slot. Only one version of `signal-exit` is demanded in the tree and the root slot is free, so the hoist is what npm itself produces on a fresh resolve. npm differs only in that its tree build is incremental and preserves an existing valid placement.

## Verification

- Reported reproduction: read resolves `Npm`, `package-lock.json` byte-identical.
- Genuine write (`nub add is-odd@3.0.1`) with `bun.lock` present: zero `resolved`/`license`/`engines` lost, against 17 fields before.
- Fresh project carrying `license`, `bin` and `engines`: nub's `package-lock.json` byte-identical to npm 11.17's.
- A 13-case declaration-by-lockfile matrix run against the merge-base build and this one: only the declared-with-stray cases changed; ambiguity and declaration-mismatch errors are untouched.
- Both new tests confirmed red with their fix reverted.
- Root clippy `--all-targets --all-features`, `cargo fmt --check`, root `cargo test` (59 binaries), and `cargo test --workspace` in `vendor/aube` (56 binaries) all pass.
