### PR TITLE
runtime: pass non-file URLs through the load hook untouched

### DIFF
--- a/crates/nub-cli/tests/loader_nonfile_urls.rs
+++ b/crates/nub-cli/tests/loader_nonfile_urls.rs
@@ -1,0 +1,100 @@
+//! A URL whose scheme is not `file:` is not nub's to claim.
+//!
+//! Both load hooks dispatch on the URL's extension, and every branch that dispatch
+//! reaches reads the module's bytes off disk through `fileURLToPath`. A non-`file:`
+//! URL that merely ENDED in a plain-JS extension entered those branches anyway, and
+//! the conversion threw `ERR_INVALID_URL_SCHEME` — nub's TypeError standing in for
+//! whatever Node was about to do. Two user-visible faces, one per test below:
+//! Node's own `ERR_UNSUPPORTED_ESM_URL_SCHEME` was masked, and every
+//! custom-protocol ESM loader died on a URL plain Node serves fine.
+//!
+//! Fix: `extname` (`runtime/transform-core.mjs`) reports an extension only for a
+//! `file:` URL, so every other scheme falls through to the next hook untouched.
+//! The gate is in the core, which is why one edit covers both tiers — the fast
+//! tier's sync `module.registerHooks` hook (`runtime/preload-common.cjs`) and the
+//! compat tier's async loader worker (`runtime/preload-async-hooks.mjs`) share it.
+//!
+//! These spawn the real `nub` binary against whatever `node` is first on PATH, and
+//! skip when none is usable — a local + CI signal, not a build-time dependency.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/
+    path.push("nub");
+    path
+}
+
+fn fixture_dir() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    PathBuf::from(manifest).join("../../tests/fixtures/loader-nonfile-urls")
+}
+
+fn node_on_path() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Run `nub <file>` in the fixture dir. Returns `(stdout, stderr, exit_code)`.
+fn run_nub(file: &str) -> (String, String, i32) {
+    let dir = fixture_dir();
+    let output = Command::new(nub_binary())
+        .arg(dir.join(file))
+        .current_dir(&dir)
+        .output()
+        .expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+/// `import()` of an unsupported scheme must reject with Node's own
+/// `ERR_UNSUPPORTED_ESM_URL_SCHEME`. Asserting the exact code is the point: the
+/// import failed either way, but nub replaced the diagnosis with a TypeError about
+/// `fileURLToPath`, so user code branching on `err.code` saw the wrong error.
+#[test]
+fn unsupported_scheme_keeps_nodes_own_error_code() {
+    if !node_on_path() {
+        eprintln!("skipping unsupported-scheme: no usable node on PATH");
+        return;
+    }
+    let (stdout, stderr, code) = run_nub("unsupported-scheme.mjs");
+    assert_eq!(
+        code, 0,
+        "the fixture handles its own rejection; stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("CODE ERR_UNSUPPORTED_ESM_URL_SCHEME"),
+        "import('http://…/foo.js') must reject with Node's own code, not nub's \
+         ERR_INVALID_URL_SCHEME; stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+/// A `module.register` loader serving its own protocol must work under nub exactly
+/// as it does on plain Node. This is the higher-impact face: it covers every
+/// virtual-module and http-style loader, none of which nub could run.
+#[test]
+fn custom_scheme_loader_serves_its_own_protocol() {
+    if !node_on_path() {
+        eprintln!("skipping custom-scheme loader: no usable node on PATH");
+        return;
+    }
+    let (stdout, stderr, code) = run_nub("custom-scheme-entry.mjs");
+    assert_eq!(
+        code, 0,
+        "a custom-protocol ESM loader must run under nub; stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("LOADED served-by-custom-loader"),
+        "nub's load hook must defer `custom://virtual/index.js` to the user's \
+         loader instead of claiming it on the `.js` suffix; \
+         stdout={stdout:?} stderr={stderr:?}"
+    );
+}

--- a/crates/nub-cli/tests/loader_nonfile_urls.rs
+++ b/crates/nub-cli/tests/loader_nonfile_urls.rs
@@ -98,3 +98,25 @@ fn custom_scheme_loader_serves_its_own_protocol() {
          stdout={stdout:?} stderr={stderr:?}"
     );
 }
+
+/// A `data:` URL imported with `{ type: "text" }` keeps Node's own text answer on
+/// a native-import-text Node. Gating the whole import-text branch on `file:` sent
+/// it into the unknown-data-URL-format trap instead (`ERR_UNKNOWN_MODULE_FORMAT`);
+/// only the disk-reading polyfill leg needs the scheme gate. The fixture prints
+/// SKIP on Nodes without the feature, so the assertion accepts either outcome.
+#[test]
+fn data_url_text_import_keeps_nodes_answer() {
+    if !node_on_path() {
+        eprintln!("SKIP: no usable node on PATH");
+        return;
+    }
+    let (stdout, stderr, code) = run_nub("data-url-text-import.mjs");
+    assert_eq!(
+        code, 0,
+        "expected exit 0, got {code}\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("TEXT hello text") || stdout.contains("SKIP"),
+        "expected Node's text answer (or SKIP on an old Node), got\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -29,7 +29,7 @@
 import "./floor-builtin.mjs";
 import {
   TRANSPILE_EXTS, PLAIN_JS_EXTS, dataExtsFor,
-  extname, resolveSpec, loadTranspile, maybeTranspilePlainJs, loadData, loadTextImport, isDependency,
+  extname, isFileUrl, resolveSpec, loadTranspile, maybeTranspilePlainJs, loadData, loadTextImport, isDependency,
 } from "./transform-core.mjs";
 import { createRequire, isBuiltin } from "node:module";
 import { existsSync } from "node:fs";
@@ -92,7 +92,10 @@ export async function load(url, context, nextLoad) {
   // fast-tier hook (preload-common.cjs) this ALWAYS polyfills, with no native
   // fall-through gate: native import-text is Node 26.5+, but the compat tier tops out
   // at Node 22.14, so a native-capable Node never reaches this loader worker.
-  if (context?.importAttributes?.type === "text") return loadTextImport(url);
+  // `isFileUrl` because this branch precedes extension dispatch and so is not covered
+  // by `extname`'s scheme gate; the polyfill reads the bytes off disk. Mirrors the
+  // fast-tier hook.
+  if (context?.importAttributes?.type === "text" && isFileUrl(url)) return loadTextImport(url);
   const ext = extname(url);
   // node_modules deps are NEVER transpiled (the byte-parity boundary). This guard is
   // make-or-break now that TRANSPILE_EXTS includes `.js`/`.mjs`/`.cjs`: without it,

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -646,7 +646,11 @@ function makeHooks(core, watchReporting) {
     // 22.14, below every flag-bearing release, so native import-text is never reachable
     // there.
     // (Node 18.20+ parses the `with` syntax; the 18.19.x floor cannot.)
-    if (context?.importAttributes?.type === "text") {
+    // `isFileUrl` because this branch precedes extension dispatch and so is not
+    // covered by `extname`'s scheme gate: the polyfill reads the bytes off disk, so
+    // a `custom://x` carrying the attribute falls through to `nextLoad` below along
+    // with every other non-`file:` URL and gets Node's own answer.
+    if (context?.importAttributes?.type === "text" && core.isFileUrl(url)) {
       return NATIVE_IMPORT_TEXT ? nextLoad(url, context) : core.loadTextImport(url);
     }
 

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -646,11 +646,15 @@ function makeHooks(core, watchReporting) {
     // 22.14, below every flag-bearing release, so native import-text is never reachable
     // there.
     // (Node 18.20+ parses the `with` syntax; the 18.19.x floor cannot.)
-    // `isFileUrl` because this branch precedes extension dispatch and so is not
-    // covered by `extname`'s scheme gate: the polyfill reads the bytes off disk, so
-    // a `custom://x` carrying the attribute falls through to `nextLoad` below along
-    // with every other non-`file:` URL and gets Node's own answer.
-    if (context?.importAttributes?.type === "text" && core.isFileUrl(url)) {
+    // The scheme gate applies only to the POLYFILL leg: this branch precedes
+    // extension dispatch, so `extname`'s gate does not cover it, and the polyfill
+    // reads the bytes off disk — only a `file:` URL has bytes there. The native
+    // leg needs no scheme restriction: it hands the URL straight back to the
+    // chain, and gating it would drop `data:text/plain` + `type: "text"` into
+    // the unknown-data-URL-format trap below instead of Node's own text answer.
+    // A non-`file:` URL on the polyfill tier falls through to `nextLoad` with
+    // every other unclaimed URL.
+    if (context?.importAttributes?.type === "text" && (NATIVE_IMPORT_TEXT || core.isFileUrl(url))) {
       return NATIVE_IMPORT_TEXT ? nextLoad(url, context) : core.loadTextImport(url);
     }
 

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -315,17 +315,28 @@ export function getPackageType(dir) {
 }
 
 // ── Filesystem helpers ──────────────────────────────────────────────
+// Is this a URL whose bytes nub may read off disk? Every branch of either load
+// hook that claims a module ends in `fileURLToPath` + `readFileSync`, so `file:`
+// is the whole answer. A load hook sees whatever scheme resolution produced:
+// `node:`, `data:`, and — because a user `module.register` loader may serve any
+// protocol it likes — `custom://x.js`, `byop://1/index.mjs`, an http-loader's
+// `https://…/x.js`. None of those are nub's to claim.
+export function isFileUrl(url) {
+  return typeof url === "string" && url.startsWith("file:");
+}
+
 export function extname(url) {
-  // A `data:` URL carries its payload INLINE, so anything extension-shaped at
-  // the end belongs to the source text, not to a filename — a trailing `//x.ts`
-  // comment, a sourceMappingURL, a path inside a string literal. Reading an
-  // extension off one sent both load hooks into the transpile/data branches,
-  // whose `fileURLToPath` then threw ERR_INVALID_URL_SCHEME on a module plain
-  // Node imports without complaint. Scoped to `data:` deliberately: the only
-  // other schemes these hooks see are `file:` (which does have an extension)
-  // and `node:` (which has no dot), and a broader "any scheme" test would have
-  // to distinguish a real scheme from a Windows drive letter.
-  if (url.startsWith("data:")) return "";
+  // Report an extension ONLY for a `file:` URL: the extension is what dispatches
+  // both load hooks into their transpile/data branches, and a non-`file:` URL that
+  // merely ENDS in something extension-shaped used to enter them anyway, where the
+  // unguarded `fileURLToPath` threw ERR_INVALID_URL_SCHEME — masking Node's own
+  // ERR_UNSUPPORTED_ESM_URL_SCHEME and killing every custom-protocol ESM loader
+  // that plain Node runs fine. `data:` was the first face of this (its payload is
+  // INLINE, so a trailing `//x.ts` comment or a sourceMappingURL reads as an
+  // extension); testing for `file:` positively covers it and every other scheme at
+  // once, and — unlike a "does this look like a scheme" test — cannot mistake a
+  // Windows drive letter for one.
+  if (!isFileUrl(url)) return "";
   const path = url.includes("?") ? url.slice(0, url.indexOf("?")) : url;
   const dot = path.lastIndexOf(".");
   return dot === -1 ? "" : path.slice(dot);

--- a/tests/fixtures/loader-nonfile-urls/custom-scheme-entry.mjs
+++ b/tests/fixtures/loader-nonfile-urls/custom-scheme-entry.mjs
@@ -1,0 +1,6 @@
+import { register } from "node:module";
+
+register("./custom-scheme-loader.mjs", import.meta.url);
+
+const mod = await import("custom://virtual/index.js");
+console.log("LOADED", mod.default);

--- a/tests/fixtures/loader-nonfile-urls/custom-scheme-loader.mjs
+++ b/tests/fixtures/loader-nonfile-urls/custom-scheme-loader.mjs
@@ -1,0 +1,14 @@
+// The smallest virtual-module loader: it serves `custom:` itself and defers
+// everything else. `index.js` gives the served URL a plain-JS extension, which is
+// what makes nub's extension-keyed load branches consider claiming it.
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith("custom:")) return { url: specifier, shortCircuit: true };
+  return nextResolve(specifier, context);
+}
+
+export async function load(url, context, nextLoad) {
+  if (url.startsWith("custom:")) {
+    return { format: "module", source: 'export default "served-by-custom-loader";\n', shortCircuit: true };
+  }
+  return nextLoad(url, context);
+}

--- a/tests/fixtures/loader-nonfile-urls/data-url-text-import.mjs
+++ b/tests/fixtures/loader-nonfile-urls/data-url-text-import.mjs
@@ -1,0 +1,14 @@
+// A data: URL carrying `with { type: "text" }` must get Node's own text
+// strategy on a native-import-text Node — not nub's unknown-data-URL trap.
+// On a Node without the feature, report SKIP and exit 0.
+let supported = false;
+try {
+  supported = process.allowedNodeEnvironmentFlags.has("--experimental-import-text") ||
+    process.versions.node.split(".").map(Number)[0] >= 25;
+} catch {}
+if (!supported) {
+  console.log("SKIP no import-text on this Node");
+} else {
+  const { default: text } = await import("data:text/plain,hello%20text", { with: { type: "text" } });
+  console.log("TEXT " + text);
+}

--- a/tests/fixtures/loader-nonfile-urls/unsupported-scheme.mjs
+++ b/tests/fixtures/loader-nonfile-urls/unsupported-scheme.mjs
@@ -1,0 +1,8 @@
+// Node rejects an unsupported ESM URL scheme with ERR_UNSUPPORTED_ESM_URL_SCHEME.
+// `.js` is deliberate: it is what used to route the URL into nub's transpile branch.
+try {
+  await import("http://example.com/foo.js");
+  console.log("CODE none");
+} catch (err) {
+  console.log("CODE", err.code);
+}


### PR DESCRIPTION
nub’s load hooks dispatch on the URL extension, and every branch they reach calls `fileURLToPath`. A non-`file:` URL ending in a plain-JS extension entered those branches and threw `ERR_INVALID_URL_SCHEME` — masking Node’s `ERR_UNSUPPORTED_ESM_URL_SCHEME` and breaking every custom-protocol ESM loader plain Node serves.

An extension is now reported only for a `file:` URL. The gate sits in `transform-core`, shared by both tiers.

Three corpus tests go 1 → 0 under nub on Node 26.7: `test-esm-dynamic-import.js`, `test-esm-loader-default-resolver.mjs`, `test-esm-loader-http-imports.mjs`. Both new tests were confirmed red before the fix.