### PR TITLE
tests: make recursive clones skip the node-suite submodule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -502,7 +502,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Init node-suite submodule (shallow)
-        run: git submodule update --init --depth 1 tests/node-suite
+        run: git submodule update --init --checkout --depth 1 tests/node-suite
         shell: bash
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,15 +495,13 @@ jobs:
       #
       # The heavyweight Node-suite compat corpus is intentionally NOT in this
       # publish gate: it reproducibly exhausts the GitHub runner at parallel
-      # fan-out (regressed during the 2026-06 repo move; tracked separately). It
-      # still runs in ci.yml as its own must-pass signal, just not in the publish
-      # critical path.
+      # fan-out (regressed during the 2026-06 repo move; tracked separately), and
+      # its CI job was removed on 2026-06-03 (see ci.yml). Its two tests are
+      # #[ignore]d, so a plain `cargo test` never reads tests/node-suite and the
+      # submodule is left unpopulated here.
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           persist-credentials: false
-      - name: Init node-suite submodule (shallow)
-        run: git submodule update --init --checkout --depth 1 tests/node-suite
-        shell: bash
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
         with:
           toolchain: 1.95.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,7 +478,7 @@ jobs:
           if-no-files-found: error
 
   test:
-    name: Test gate (cargo test + compat suite)
+    name: Test gate (cargo test)
     needs: verify
     # Tag + dispatch only. Canary runs skip this gate: ci.yml runs the same
     # suite on the same commit, and the canary contract is "newest main, built

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tests/node-suite"]
 	path = tests/node-suite
 	url = https://github.com/nodejs/node.git
+	update = none

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,7 @@
 [submodule "tests/node-suite"]
 	path = tests/node-suite
 	url = https://github.com/nodejs/node.git
+	# `none` keeps recursive clones (Vercel's site build among them) from
+	# fetching all of nodejs/node — ~49k files it then deletes. The consumers
+	# that need the corpus pass `--checkout`, which overrides this.
 	update = none

--- a/crates/nub-cli/tests/node_compat.rs
+++ b/crates/nub-cli/tests/node_compat.rs
@@ -163,7 +163,7 @@ fn load_config() -> Vec<TestEntry> {
 /// that. Run the corpus explicitly:
 ///   cargo test -p nub-cli --test node_compat -- --ignored --nocapture
 /// or via tests/run-node-compat.sh / the CI `compat` job. Requires the
-/// tests/node-suite submodule (`git submodule update --init --depth 1
+/// tests/node-suite submodule (`git submodule update --init --checkout --depth 1
 /// tests/node-suite`).
 #[test]
 #[ignore = "heavyweight Node-suite compat corpus — run via `cargo test -p nub-cli --test node_compat -- --ignored` or the CI compat job (needs the tests/node-suite submodule)"]
@@ -172,12 +172,12 @@ fn node_compat_suite() {
     // Fail LOUDLY when the suite is absent. A silent `return;` here let a
     // missing submodule read as a green test — the compat gate would "pass"
     // having checked nothing. CI initializes tests/node-suite (a registered
-    // submodule); locally, run `git submodule update --init --depth 1
+    // submodule); locally, run `git submodule update --init --checkout --depth 1
     // tests/node-suite`. A missing suite is a setup error, never a pass.
     assert!(
         suite.exists(),
         "Node compat suite missing at {suite:?}. The compat gate cannot run. \
-         Initialize the submodule: `git submodule update --init --depth 1 tests/node-suite`. \
+         Initialize the submodule: `git submodule update --init --checkout --depth 1 tests/node-suite`. \
          (Refusing to skip silently — a vacuous pass would hide real compat regressions.)"
     );
 

--- a/crates/nub-cli/tests/node_compat.rs
+++ b/crates/nub-cli/tests/node_compat.rs
@@ -162,18 +162,19 @@ fn load_config() -> Vec<TestEntry> {
 /// test` therefore runs only the fast unit + integration path; the gates ride on
 /// that. Run the corpus explicitly:
 ///   cargo test -p nub-cli --test node_compat -- --ignored --nocapture
-/// or via tests/run-node-compat.sh / the CI `compat` job. Requires the
+/// or via tests/run-node-compat.sh. Requires the
 /// tests/node-suite submodule (`git submodule update --init --checkout --depth 1
 /// tests/node-suite`).
 #[test]
-#[ignore = "heavyweight Node-suite compat corpus — run via `cargo test -p nub-cli --test node_compat -- --ignored` or the CI compat job (needs the tests/node-suite submodule)"]
+#[ignore = "heavyweight Node-suite compat corpus — run via `cargo test -p nub-cli --test node_compat -- --ignored` (needs the tests/node-suite submodule)"]
 fn node_compat_suite() {
     let suite = suite_dir();
     // Fail LOUDLY when the suite is absent. A silent `return;` here let a
     // missing submodule read as a green test — the compat gate would "pass"
-    // having checked nothing. CI initializes tests/node-suite (a registered
-    // submodule); locally, run `git submodule update --init --checkout --depth 1
-    // tests/node-suite`. A missing suite is a setup error, never a pass.
+    // having checked nothing. Nothing in CI populates tests/node-suite (its
+    // corpus job was removed 2026-06-03); run `git submodule update --init
+    // --checkout --depth 1 tests/node-suite` first. A missing suite is a setup
+    // error, never a pass.
     assert!(
         suite.exists(),
         "Node compat suite missing at {suite:?}. The compat gate cannot run. \

--- a/crates/nub-cli/tests/resolution_compat.rs
+++ b/crates/nub-cli/tests/resolution_compat.rs
@@ -125,15 +125,15 @@ const KNOWN_DIVERGENCES: &[(&str, &str)] = &[];
 /// [`node_compat_suite`], this is a CI-scale gate, not a unit test, so it is
 /// `#[ignore]` and excluded from the default `cargo test`. Run it explicitly:
 ///   cargo test -p nub-cli --test resolution_compat -- --ignored --nocapture
-/// or via the CI `compat` job. Requires the tests/node-suite submodule.
+/// Requires the tests/node-suite submodule.
 #[test]
-#[ignore = "resolution-parity corpus (double-spawns the node-suite subset) — run via `cargo test -p nub-cli --test resolution_compat -- --ignored` or the CI compat job"]
+#[ignore = "resolution-parity corpus (double-spawns the node-suite subset) — run via `cargo test -p nub-cli --test resolution_compat -- --ignored`"]
 fn resolution_parity() {
     let suite = suite_dir();
     // Fail LOUDLY when the suite is absent — a silent `return;` let a missing
-    // submodule masquerade as a passing resolution gate. CI initializes the
-    // tests/node-suite submodule; locally run
-    // `git submodule update --init --checkout --depth 1 tests/node-suite`.
+    // submodule masquerade as a passing resolution gate. Nothing in CI populates
+    // tests/node-suite; run
+    // `git submodule update --init --checkout --depth 1 tests/node-suite` first.
     assert!(
         suite.exists(),
         "resolution_compat: suite missing at {suite:?}. The resolution-parity gate cannot run. \
@@ -404,10 +404,10 @@ fn async_module_register_loader_sync_resolve_does_not_crash() {
 /// Heavy end-to-end twin of the fast guard above: a real, minimal Next 16 + Tailwind v4
 /// Turbopack build — the in-the-wild manifestation. `#[ignore]`d because it scaffolds an
 /// app, runs `nub install`, and runs a full `next build`; run via
-/// `cargo test … -- --ignored` or the CI compat job. Like the fast guard, this is only
+/// `cargo test … -- --ignored`. Like the fast guard, this is only
 /// meaningful on an AFFECTED Node version.
 #[test]
-#[ignore = "heavy e2e: scaffolds a Next 16 + Tailwind v4 app, installs deps, and runs `next build` (Turbopack). Run via `cargo test -p nub-cli --test resolution_compat -- --ignored` or the CI compat job."]
+#[ignore = "heavy e2e: scaffolds a Next 16 + Tailwind v4 app, installs deps, and runs `next build` (Turbopack). Run via `cargo test -p nub-cli --test resolution_compat -- --ignored`."]
 fn next_turbopack_tailwind_build_does_not_crash() {
     use std::fs;
 

--- a/crates/nub-cli/tests/resolution_compat.rs
+++ b/crates/nub-cli/tests/resolution_compat.rs
@@ -133,11 +133,11 @@ fn resolution_parity() {
     // Fail LOUDLY when the suite is absent — a silent `return;` let a missing
     // submodule masquerade as a passing resolution gate. CI initializes the
     // tests/node-suite submodule; locally run
-    // `git submodule update --init --depth 1 tests/node-suite`.
+    // `git submodule update --init --checkout --depth 1 tests/node-suite`.
     assert!(
         suite.exists(),
         "resolution_compat: suite missing at {suite:?}. The resolution-parity gate cannot run. \
-         Initialize the submodule: `git submodule update --init --depth 1 tests/node-suite`. \
+         Initialize the submodule: `git submodule update --init --checkout --depth 1 tests/node-suite`. \
          (Refusing to skip silently — a vacuous pass would hide resolver divergences.)"
     );
     let nub = nub_binary();

--- a/tests/run-node-compat.sh
+++ b/tests/run-node-compat.sh
@@ -18,7 +18,7 @@ FILTER="${2:-}"
 
 if [ ! -d "$SUITE_DIR" ]; then
   echo "Error: Node test suite not found at $SUITE_DIR"
-  echo "Run: git submodule update --init --depth 1"
+  echo "Run: git submodule update --init --checkout --depth 1"
   exit 1
 fi
 

--- a/wiki/research/node-test-suite-leverage.md
+++ b/wiki/research/node-test-suite-leverage.md
@@ -98,6 +98,8 @@ The blob fetch is one commit's worth (~50 MB), not the full history (~6 GB), so 
 
 Submodule path: `tests/node-suite/`. Pin to current Node LTS (24); bump on each LTS minor by re-pointing the submodule at the new tag.
 
+**Recursive clones skip it (2026-08-24).** `.gitmodules` sets `update = none`, so `git clone --recurse-submodules` and a bare `git submodule update --init` leave `tests/node-suite/` empty; the consumers that need the corpus pass `--checkout` (`git submodule update --init --checkout --depth 1 tests/node-suite`), which overrides the setting. The trigger was the site: Vercel recursively clones every submodule it can reach over HTTPS, so each `site/` deploy fetched all of `nodejs/node` (48,844 files) only to delete it under `.vercelignore` — one clone took 32 minutes and another hung for 46 and failed the deployment.
+
 **Previously recommended (superseded):** Nub-controlled mirror at `nubjs/node-test-mirror` holding only a `test/`-only snapshot, refreshed by a CI job (`git clone nodejs/node && cp -R node/test ./test && commit`). Rejected because the `--depth 1` shallow submodule reaches the same size budget with no second-repo overhead.
 
 ### 5.2 Allowlist (`tests/node-suite-config.jsonc`)
@@ -181,3 +183,4 @@ Every revision to this document, with the date and what changed.
 - 2026-05-26 — **REVERSAL on §5.1 (vendoring):** swap the recommended Nub-controlled mirror (`nubjs/node-test-mirror`) for a shallow `--depth 1` git submodule of `nodejs/node` directly. A `--depth 1` clone is ~50 MB (one commit's worth of blobs) rather than the full ~6 GB history, so the original size objection that drove the mirror-repo recommendation no longer applies. Prior conclusion preserved in §5.1 under "Previously recommended (superseded)." Also retargeted the cross-references onto the current implementation plan.
 - 2026-08-20 — Delinked the `node-test-viewer.deno.dev` citations after that host began 404ing.
 - 2026-08-21 — Relinked them: the viewer moved to `node-test-viewer.deno.deno.net` (verified live, serving per-module results). Corrected the viewer's last-push date to 2026-05-14.
+- 2026-08-24 — §5.1: the submodule is now `update = none` in `.gitmodules` so recursive clones (Vercel site builds) skip it; corpus consumers pass `--checkout`.


### PR DESCRIPTION
Vercel clones every HTTPS-reachable submodule before a site build, so each deploy fetched all of nodejs/node (48,844 files) and then deleted it under .vercelignore. Clones on recent preview deploys took 1.5 to 32 minutes, and one hung for 46 minutes and failed the deployment.

- `.gitmodules` sets `update = none`, so recursive clones and a bare `git submodule update --init` skip `tests/node-suite`. A probe deploy on this branch cloned in 3.2s and removed 1,272 ignored files instead of 50,104.
- The consumers that need the corpus pass `--checkout`, which overrides the setting: the release workflow's gate, the two Rust corpus gates' hints, and `tests/run-node-compat.sh`.