### PR TITLE
runtime: forward caller arguments through the revokeObjectURL wrap

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -4419,6 +4419,27 @@ fn worker_blob_wrapping_preserves_file_instanceof_blob() {
 }
 
 #[test]
+fn worker_blob_url_revoke_forwards_caller_arity() {
+    // Regression: the revokeObjectURL wrap called the native function with a fixed
+    // arity of one, so `URL.revokeObjectURL()` passed `undefined` through instead of
+    // reaching Node's zero-arg ERR_MISSING_ARGS check — nub returned silently where
+    // vanilla Node throws.
+    let (stdout, stderr, code) = run_nub("worker", "blob-url-revoke-arity.ts");
+    assert_eq!(
+        code, 0,
+        "revoke-arity fixture should run: {stderr}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("revoke-no-args:ERR_MISSING_ARGS"),
+        "URL.revokeObjectURL() with no arguments must throw ERR_MISSING_ARGS as on plain Node: {stdout}"
+    );
+    assert!(
+        stdout.contains("revoke-one-arg:ok"),
+        "the ordinary one-argument revoke must still succeed: {stdout}"
+    );
+}
+
+#[test]
 fn worker_error_event_carries_source_location() {
     // WHATWG ErrorEvent must carry filename/lineno/colno from where the error was
     // raised. nub fills these from the worker error's stack (they were hardcoded

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -4429,9 +4429,17 @@ fn worker_blob_url_revoke_forwards_caller_arity() {
         code, 0,
         "revoke-arity fixture should run: {stderr}\n{stdout}"
     );
+    // Node's own zero-arg guard landed in v20.12.0; on the 18.19 floor and the
+    // 20.11 compat leg plain Node returns silently, so forwarding real arity
+    // must return silently there too.
+    let expected = if node_at_least((20, 12, 0)) {
+        "revoke-no-args:ERR_MISSING_ARGS"
+    } else {
+        "revoke-no-args:no-throw"
+    };
     assert!(
-        stdout.contains("revoke-no-args:ERR_MISSING_ARGS"),
-        "URL.revokeObjectURL() with no arguments must throw ERR_MISSING_ARGS as on plain Node: {stdout}"
+        stdout.contains(expected),
+        "URL.revokeObjectURL() with no arguments must match plain Node ({expected}): {stdout}"
     );
     assert!(
         stdout.contains("revoke-one-arg:ok"),

--- a/runtime/worker-blob-url.cjs
+++ b/runtime/worker-blob-url.cjs
@@ -157,7 +157,9 @@ function installBlobUrlSupport() {
   if (nativeRevoke) {
     URL.revokeObjectURL = function revokeObjectURL(url) {
       blobUrlSources.delete(url);
-      return nativeRevoke(url);
+      // Forward the caller's real arguments rather than a fixed arity of one, so a
+      // zero-arg call still reaches Node's own ERR_MISSING_ARGS check.
+      return nativeRevoke(...arguments);
     };
   }
 }

--- a/tests/fixtures/worker/blob-url-revoke-arity.ts
+++ b/tests/fixtures/worker/blob-url-revoke-arity.ts
@@ -1,0 +1,15 @@
+// Regression: nub wraps URL.revokeObjectURL to drop its captured blob source.
+// The wrapper used to call the native function with a fixed arity of one, so a
+// zero-arg call passed `undefined` through and Node's own ERR_MISSING_ARGS
+// check never fired — nub silently returned where vanilla Node throws.
+try {
+  (URL.revokeObjectURL as () => void)();
+  console.log("revoke-no-args:no-throw");
+} catch (e) {
+  console.log("revoke-no-args:" + (e as { code?: string }).code);
+}
+
+// The ordinary one-arg path must still revoke.
+const url = URL.createObjectURL(new Blob(["hello"]));
+URL.revokeObjectURL(url);
+console.log("revoke-one-arg:ok");


### PR DESCRIPTION
`URL.revokeObjectURL()` with no arguments returned silently under nub; Node throws `ERR_MISSING_ARGS`. The blob-URL wrap called the saved native function with a fixed arity of one, so the zero-arg call passed `undefined` through. It now spreads the caller's arguments.

The `createObjectURL` wrap has the same fixed arity but no divergence: Node throws `ERR_INVALID_ARG_TYPE` for both zero args and explicit `undefined`, and ignores extras. Left as is.

New fixture plus integration test, verified RED before the fix. Upstream `test/parallel/test-url-revokeobjecturl.js` (v26.7.0) goes from exit 1 to exit 0.