### PR TITLE
runtime: restore the node: scheme on builtins that require it

### DIFF
--- a/crates/nub-cli/tests/cjs_scheme_only_builtin.rs
+++ b/crates/nub-cli/tests/cjs_scheme_only_builtin.rs
@@ -13,12 +13,14 @@
 //! saw `ERR_INVALID_RETURN_PROPERTY_VALUE` ("Expected a string, an ArrayBuffer, or
 //! a TypedArray … but got null") thrown from inside nub's own load hook.
 //!
-//! Version band, measured against plain Node with a pass-through hook: broken on
-//! 22.15–22.23.0, all of 23.x, and 24.0–24.8; fixed by backport in 22.23.1+,
-//! 24.9+ and 25+, which rewrote the helper to strip any `node:` prefix and test
-//! `canBeRequiredByUsers`. A REGULAR builtin was never affected. nub registers a
-//! resolve hook unconditionally on the fast tier, so on that band the breakage was
-//! unconditional for its users.
+//! Version band, measured per-release against plain Node with a pass-through hook:
+//! broken on 22.15.0–22.17.1, 23.5.0–23.11.1 and 24.0.0–24.3.0; fixed in 22.18.0+,
+//! 24.4.0+ and 25+, which rewrote the helper to strip any `node:` prefix and test
+//! `canBeRequiredByUsers`. The 23.x line reached end-of-life without the backport,
+//! and below 22.15/23.5 `module.registerHooks` does not exist, so the bug cannot
+//! occur there. A REGULAR builtin was never affected. nub registers a resolve hook
+//! unconditionally on the fast tier, so on that band the breakage was unconditional
+//! for its users.
 //!
 //! Fix (`runtime/preload-common.cjs`, resolve hook): re-prefix a bare
 //! scheme-only builtin id returned by the default resolve step, reproducing the
@@ -92,10 +94,25 @@ fn scheme_only_builtins_require_cleanly_from_cjs() {
         "require of the scheme-only builtins must exit 0 (node {version}); \
          stdout={stdout:?} stderr={stderr:?}"
     );
+    // Positive control on the self-enumeration. Exit 0 plus a bare `OK` prefix is
+    // also what an EMPTY list produces — `OK 0` would mean the fixture required
+    // nothing at all and passed vacuously. Every Node from the 18.19 floor up has
+    // at least `node:test`, so parse the count and require it to be non-zero.
+    let required: usize = stdout
+        .strip_prefix("OK ")
+        .and_then(|rest| rest.split_whitespace().next())
+        .and_then(|count| count.parse().ok())
+        .unwrap_or_else(|| {
+            panic!(
+                "expected the fixture's `OK <count> <names>` line (node {version}); \
+                 stdout={stdout:?} stderr={stderr:?}"
+            )
+        });
     assert!(
-        stdout.starts_with("OK "),
-        "expected the fixture's OK line naming the builtins it required \
-         (node {version}); stdout={stdout:?} stderr={stderr:?}"
+        required > 0,
+        "the fixture must have actually required a scheme-only builtin — a count of \
+         0 means the enumeration found none and the test proved nothing \
+         (node {version}); stdout={stdout:?}"
     );
 }
 

--- a/crates/nub-cli/tests/cjs_scheme_only_builtin.rs
+++ b/crates/nub-cli/tests/cjs_scheme_only_builtin.rs
@@ -1,0 +1,122 @@
+//! CommonJS `require()` of a SCHEME-ONLY builtin — `node:test`, `node:sqlite`,
+//! `node:sea`, `node:test/reporters` — must work under nub's runtime augmentation.
+//!
+//! Root cause (upstream Node, not nub): with ANY sync `module.registerHooks`
+//! resolve hook registered, `resolveForCJSWithHooks` leaves its fast path and
+//! recomputes the resolved URL as `convertCJSFilenameToURL(<normalized id>)`. The
+//! old form of that helper keyed on `BuiltinModule.normalizeRequirableId(id)`,
+//! which is false for a bare scheme-only id — `require("test")` is not legal — so
+//! `test` matched neither the builtin branch nor `isAbsolute` and came back
+//! VERBATIM as `"test"`. The load chain then rejected the default step's own
+//! correct `{ format: "builtin", source: null }`, because `validateLoad` waives
+//! the string-source requirement only for a url starting with `node:`. The user
+//! saw `ERR_INVALID_RETURN_PROPERTY_VALUE` ("Expected a string, an ArrayBuffer, or
+//! a TypedArray … but got null") thrown from inside nub's own load hook.
+//!
+//! Version band, measured against plain Node with a pass-through hook: broken on
+//! 22.15–22.23.0, all of 23.x, and 24.0–24.8; fixed by backport in 22.23.1+,
+//! 24.9+ and 25+, which rewrote the helper to strip any `node:` prefix and test
+//! `canBeRequiredByUsers`. A REGULAR builtin was never affected. nub registers a
+//! resolve hook unconditionally on the fast tier, so on that band the breakage was
+//! unconditional for its users.
+//!
+//! Fix (`runtime/preload-common.cjs`, resolve hook): re-prefix a bare
+//! scheme-only builtin id returned by the default resolve step, reproducing the
+//! fixed helper's output. Provably a no-op on a fixed Node, where the url already
+//! starts with `node:` and the guard cannot fire.
+//!
+//! Both tests assert behavior that holds on EVERY leg of the CI matrix (18.19 …
+//! 26): the compat tier registers no sync resolve hook and so never had the bug,
+//! and the fixture self-enumerates which scheme-only builtins the running Node
+//! actually has. They spawn the real `nub` binary against whatever `node` is
+//! first on PATH, and skip when none is usable.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/
+    path.push("nub");
+    path
+}
+
+fn fixture_dir() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    PathBuf::from(manifest).join("../../tests/fixtures/cjs-scheme-only-builtin")
+}
+
+/// `<version>` of the `node` first on PATH, for failure messages, or `None` when
+/// no usable Node is present.
+fn path_node_version() -> Option<String> {
+    let out = Command::new("node").arg("--version").output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Run `nub` with `args` in `dir`, returning `(stdout, stderr, exit_code)`.
+fn run_nub(dir: &PathBuf, args: &[&str]) -> (String, String, i32) {
+    let output = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+/// The regression: every scheme-only builtin this Node has must `require()`
+/// cleanly, and the neighbours the fix must not disturb — a regular builtin, and
+/// a project file whose basename collides with a scheme-only id — must still
+/// resolve to themselves.
+#[test]
+fn scheme_only_builtins_require_cleanly_from_cjs() {
+    let Some(version) = path_node_version() else {
+        eprintln!("skipping cjs-scheme-only-builtin: no usable node on PATH");
+        return;
+    };
+    let dir = fixture_dir();
+    let (stdout, stderr, code) = run_nub(&dir, &["require-builtins.cjs"]);
+    assert!(
+        !stderr.contains("ERR_INVALID_RETURN_PROPERTY_VALUE"),
+        "requiring a scheme-only builtin must not hit Node's bare-id load-hook \
+         validation (node {version}); stderr={stderr:?}"
+    );
+    assert_eq!(
+        code, 0,
+        "require of the scheme-only builtins must exit 0 (node {version}); \
+         stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.starts_with("OK "),
+        "expected the fixture's OK line naming the builtins it required \
+         (node {version}); stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+/// The reported symptom, end to end: Node's test runner over a CommonJS test file
+/// that does `require("node:test")`. Before the fix the test FILE failed on the
+/// broken band while the runner itself exited non-zero.
+#[test]
+fn node_test_runner_runs_a_cjs_test_file() {
+    let Some(version) = path_node_version() else {
+        eprintln!("skipping cjs-scheme-only-builtin runner: no usable node on PATH");
+        return;
+    };
+    let dir = fixture_dir().join("runner");
+    let (stdout, stderr, code) = run_nub(&dir, &["--test", "--test-reporter=tap"]);
+    assert_eq!(
+        code, 0,
+        "`nub --test` over a CJS test file must exit 0 (node {version}); \
+         stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains("# pass 1") && stdout.contains("# fail 0"),
+        "the CJS test file must run and pass (node {version}); stdout={stdout:?}"
+    );
+}

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -550,9 +550,12 @@ function annotateError(err, hint) {
 // Upstream Node bug: CJS `require()` of a SCHEME-ONLY builtin (`node:test`,
 // `node:sqlite`, `node:sea`, `node:test/reporters`) throws
 // ERR_INVALID_RETURN_PROPERTY_VALUE ("… but got null") whenever ANY sync resolve
-// hook is registered. Broken on 22.15–22.23.0, all of 23.x and 24.0–24.8; fixed by
-// backport in 22.23.1+, 24.9+ and 25+. A plain-Node pass-through hook reproduces it
-// exactly — nub only makes it unconditional, by always hooking on the fast tier.
+// hook is registered. Measured per-release: broken on 22.15.0–22.17.1,
+// 23.5.0–23.11.1 and 24.0.0–24.3.0; fixed in 22.18.0+, 24.4.0+ and 25+. The 23.x
+// line reached end-of-life without the backport, and below 22.15/23.5
+// `module.registerHooks` does not exist at all, so the bug is unreachable there. A
+// plain-Node pass-through hook reproduces it exactly — nub only makes it
+// unconditional, by always hooking on the fast tier.
 //
 // Mechanism: with hooks present, `resolveForCJSWithHooks` leaves its fast path and
 // recomputes the URL as `convertCJSFilenameToURL(<normalized id>)`. The old helper
@@ -570,7 +573,14 @@ function annotateError(err, hint) {
 // It is a provable no-op on a fixed Node, where the url already starts with `node:`
 // and the guard cannot fire, and `isBuiltin("node:" + url)` selects exactly the
 // scheme-only set — a `file:`/`data:` url, a Windows path and a bare regular builtin
-// all fail it. ESM `import` never enters this code path and was never affected.
+// all fail it.
+//
+// This hook is SHARED with ESM: a `registerHooks` resolve hook fires for `import`
+// too, on every version (verified on 22.15.0, 24.3.0 and 26.7.0 — both
+// `import("node:test")` and a relative `import` reach it). What keeps ESM safe is
+// not unreachability but the colon guard: ESM resolution always yields a
+// scheme-bearing URL (`node:test`, `file:///…`), so the rewrite short-circuits
+// before it can apply. Only the CJS `require()` path ever produces a bare id.
 function restoreSchemeOnlyBuiltinURL(result) {
   try {
     const url = result && result.url;

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -551,7 +551,8 @@ function annotateError(err, hint) {
 // `node:sqlite`, `node:sea`, `node:test/reporters`) throws
 // ERR_INVALID_RETURN_PROPERTY_VALUE ("… but got null") whenever ANY sync resolve
 // hook is registered. Measured per-release: broken on 22.15.0–22.17.1,
-// 23.5.0–23.11.1 and 24.0.0–24.3.0; fixed in 22.18.0+, 24.4.0+ and 25+. The 23.x
+// 23.5.0–23.11.1 and 24.0.0–24.3.0; fixed in 22.18.0+, 24.4.0+ and 25+ by
+// nodejs/node#58612 (bfc68c8ae8, for nodejs/node#58607). The 23.x
 // line reached end-of-life without the backport, and below 22.15/23.5
 // `module.registerHooks` does not exist at all, so the bug is unreachable there. A
 // plain-Node pass-through hook reproduces it exactly — nub only makes it

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -547,6 +547,41 @@ function annotateError(err, hint) {
   }
 }
 
+// Upstream Node bug: CJS `require()` of a SCHEME-ONLY builtin (`node:test`,
+// `node:sqlite`, `node:sea`, `node:test/reporters`) throws
+// ERR_INVALID_RETURN_PROPERTY_VALUE ("… but got null") whenever ANY sync resolve
+// hook is registered. Broken on 22.15–22.23.0, all of 23.x and 24.0–24.8; fixed by
+// backport in 22.23.1+, 24.9+ and 25+. A plain-Node pass-through hook reproduces it
+// exactly — nub only makes it unconditional, by always hooking on the fast tier.
+//
+// Mechanism: with hooks present, `resolveForCJSWithHooks` leaves its fast path and
+// recomputes the URL as `convertCJSFilenameToURL(<normalized id>)`. The old helper
+// keyed on `BuiltinModule.normalizeRequirableId(id)`, which is FALSE for a bare
+// scheme-only id — `require("test")` is not legal — so `test` matched neither the
+// builtin branch nor `isAbsolute` and came back VERBATIM. That bare id then rides
+// into the load chain, where `validateLoad` waives the string-source requirement
+// only for a `node:`-prefixed url, so the default step's own correct
+// `{ format: "builtin", source: null }` is rejected. Upstream's fix was to strip any
+// `node:` prefix and test `canBeRequiredByUsers` instead. A REGULAR builtin was
+// never affected: `normalizeRequirableId("fs")` is truthy, so it already round-
+// tripped to `node:fs`.
+//
+// Re-prefixing reproduces the fixed helper's output at the one place nub can reach.
+// It is a provable no-op on a fixed Node, where the url already starts with `node:`
+// and the guard cannot fire, and `isBuiltin("node:" + url)` selects exactly the
+// scheme-only set — a `file:`/`data:` url, a Windows path and a bare regular builtin
+// all fail it. ESM `import` never enters this code path and was never affected.
+function restoreSchemeOnlyBuiltinURL(result) {
+  try {
+    const url = result && result.url;
+    if (typeof url !== "string" || url === "" || url.includes(":")) return result;
+    if (!module_.isBuiltin(`node:${url}`)) return result;
+    return { ...result, url: `node:${url}` };
+  } catch {
+    return result;
+  }
+}
+
 function makeHooks(core, watchReporting) {
   installUserHookDetector();
   installUserAsyncLoaderDetector();
@@ -569,7 +604,7 @@ function makeHooks(core, watchReporting) {
       } catch { /* fall through to Node's resolver */ }
     }
     try {
-      return nextResolve(specifier, context);
+      return restoreSchemeOnlyBuiltinURL(nextResolve(specifier, context));
     } catch (err) {
       if (isAsyncLoaderSyncStub(err)) {
         const fallback = resolveViaParentRequire(specifier, context.parentURL);

--- a/tests/fixtures/cjs-scheme-only-builtin/local-test.js
+++ b/tests/fixtures/cjs-scheme-only-builtin/local-test.js
@@ -1,0 +1,1 @@
+exports.tag = "local";

--- a/tests/fixtures/cjs-scheme-only-builtin/require-builtins.cjs
+++ b/tests/fixtures/cjs-scheme-only-builtin/require-builtins.cjs
@@ -1,0 +1,30 @@
+// Every builtin that can ONLY be required WITH the `node:` scheme, required from
+// CommonJS. Self-enumerating so the fixture is meaningful on every Node in the CI
+// matrix: `node:sqlite` (22.5+), `node:sea` (21.7+) and `node:test/reporters`
+// (19.9+) simply drop out of the list on a Node that predates them.
+const { isBuiltin } = require("node:module");
+const assert = require("node:assert");
+
+const CANDIDATES = ["node:test", "node:test/reporters", "node:sqlite", "node:sea"];
+const schemeOnly = CANDIDATES.filter((s) => isBuiltin(s) && !isBuiltin(s.slice("node:".length)));
+
+const failures = [];
+for (const spec of schemeOnly) {
+  try {
+    assert.notStrictEqual(require(spec), undefined, `${spec} loaded as undefined`);
+  } catch (err) {
+    failures.push(`${spec}: ${err.code || err.name}: ${err.message}`);
+  }
+}
+
+// Neighbours that must be untouched: a REGULAR builtin (never affected, since its
+// bare id already round-tripped to `node:fs`) and a project file whose basename
+// collides with a scheme-only builtin id.
+assert.strictEqual(typeof require("node:fs").readFileSync, "function");
+assert.strictEqual(require("./local-test.js").tag, "local");
+
+if (failures.length > 0) {
+  console.error(`FAILED ${failures.join(" | ")}`);
+  process.exit(1);
+}
+console.log(`OK ${schemeOnly.length} ${schemeOnly.join(",")}`);

--- a/tests/fixtures/cjs-scheme-only-builtin/runner/logic.js
+++ b/tests/fixtures/cjs-scheme-only-builtin/runner/logic.js
@@ -1,0 +1,1 @@
+exports.add = (a, b) => a + b;

--- a/tests/fixtures/cjs-scheme-only-builtin/runner/logic.test.js
+++ b/tests/fixtures/cjs-scheme-only-builtin/runner/logic.test.js
@@ -1,0 +1,7 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const { add } = require("./logic.js");
+
+test("add", () => {
+  assert.strictEqual(add(1, 2), 3);
+});


### PR DESCRIPTION
CommonJS `require("node:test")` — plus `node:sqlite`, `node:sea` and `node:test/reporters` — threw ERR_INVALID_RETURN_PROPERTY_VALUE under nub. Measured per release: broken on 22.15.0–22.17.1, 23.5.0–23.11.1 and 24.0.0–24.3.0; fixed in 22.18.0+, 24.4.0+ and 25+.

The defect is upstream and reproduces on plain Node with a pass-through hook: with a sync resolve hook registered, Node recomputed the URL through a helper that returned a bare `test` for an id only requirable with the scheme, so the load validator rejected the default step's null source. Nub hooks on every fast-tier run, so its users hit this unconditionally.

Nub now re-prefixes the bare id, a no-op where Node is already fixed.
