### PR TITLE
lockfile: drop non-optional peerDependenciesMeta entries from the pnpm writer

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/tests.rs
@@ -5270,3 +5270,79 @@ snapshots:
         Some("is-odd")
     );
 }
+
+// pnpm's resolver drops a `peerDependenciesMeta` entry that is not
+// `optional: true` (`peerDependenciesWithoutOwn`), so its lockfile type is
+// `{ optional: true }` and pnpm 12's reader models `optional` as a required
+// field. Emitting the non-optional entry as an empty mapping — the real case
+// is vitest declaring `vite: { optional: false }` — makes pnpm 12 reject the
+// whole file with ERR_PNPM_BROKEN_LOCKFILE.
+#[test]
+fn write_omits_non_optional_peer_dependencies_meta_entries() {
+    let yaml = r#"lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      peer-host:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+
+  peer-host@1.0.0:
+    resolution: {integrity: sha512-peer}
+    peerDependencies:
+      jsdom: '*'
+      vite: ^7.0.0
+    peerDependenciesMeta:
+      jsdom:
+        optional: true
+      vite: {}
+
+snapshots:
+
+  peer-host@1.0.0: {}
+"#;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(&path, yaml).unwrap();
+    let graph = parse(&path).unwrap();
+
+    // The reader stays lenient so a lockfile already carrying the broken
+    // shape still loads; the writer is what normalizes it.
+    let pkg = graph.packages.get("peer-host@1.0.0").unwrap();
+    assert!(pkg.peer_dependencies_meta["jsdom"].optional);
+    assert!(!pkg.peer_dependencies_meta["vite"].optional);
+
+    let manifest = PackageJson {
+        name: Some("peer-meta".to_string()),
+        version: Some("1.0.0".to_string()),
+        dependencies: [("peer-host".to_string(), "1.0.0".to_string())]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    let out = dir.path().join("out.yaml");
+    write(&out, &graph, &manifest).unwrap();
+    let written = std::fs::read_to_string(&out).unwrap();
+
+    assert!(
+        !written.contains("vite: {}"),
+        "an empty peerDependenciesMeta mapping is rejected by pnpm 12:\n{written}"
+    );
+    assert!(
+        written.contains("      jsdom:\n        optional: true\n"),
+        "the optional peer must keep its entry:\n{written}"
+    );
+    assert!(
+        !written.contains("      vite:\n"),
+        "the non-optional peer must be dropped from peerDependenciesMeta:\n{written}"
+    );
+    // Dropping the meta entry must not drop the declared peer range.
+    assert!(
+        written.contains("      vite: ^7.0.0\n"),
+        "peerDependencies must still carry the non-optional peer:\n{written}"
+    );
+}

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
@@ -445,22 +445,25 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
             let deps = pkg.peer_dependencies_with_meta_defaults();
             if deps.is_empty() { None } else { Some(deps) }
         };
-        let peer_meta = if pkg.peer_dependencies_meta.is_empty() {
+        // Only `optional: true` peers are recorded. pnpm's resolver
+        // drops a non-optional `peerDependenciesMeta` entry outright
+        // (`peerDependenciesWithoutOwn` skips `peerMeta.optional !== true`),
+        // so its lockfile type is `{ optional: true }` and every entry
+        // carries the field. pnpm 12's reader models that as a required
+        // `bool` and fails the whole file with ERR_PNPM_BROKEN_LOCKFILE
+        // on an empty mapping, which is what emitting the non-optional
+        // entries with the false flag skipped used to produce (real case:
+        // vitest declaring `vite: { optional: false }`).
+        let peer_meta: BTreeMap<String, WritablePeerDepMeta> = pkg
+            .peer_dependencies_meta
+            .iter()
+            .filter(|(_, v)| v.optional)
+            .map(|(k, _)| (k.clone(), WritablePeerDepMeta { optional: true }))
+            .collect();
+        let peer_meta = if peer_meta.is_empty() {
             None
         } else {
-            Some(
-                pkg.peer_dependencies_meta
-                    .iter()
-                    .map(|(k, v)| {
-                        (
-                            k.clone(),
-                            WritablePeerDepMeta {
-                                optional: v.optional,
-                            },
-                        )
-                    })
-                    .collect(),
-            )
+            Some(peer_meta)
         };
         // Always render the path through `path_posix()` so the
         // lockfile uses forward slashes regardless of the host OS —
@@ -1215,11 +1218,9 @@ struct WritableRuntimeTarget {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WritablePeerDepMeta {
-    // pnpm v9 omits `optional: false` entirely; only the truthy form
-    // shows up in real-world lockfiles. Skip the default so we stay
-    // byte-identical for the rare case where a packument explicitly
-    // marks a peer as non-optional.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    // Always `true` — the writer filters non-optional peers out of the
+    // map rather than emitting them with the field skipped, because an
+    // empty mapping is not a valid `peerDependenciesMeta` value.
     optional: bool,
 }
 


### PR DESCRIPTION
pnpm 12's lockfile reader requires `optional` on every `peerDependenciesMeta` entry. Nub wrote an empty mapping for a peer declared `optional: false` (`vitest` does this for `vite`), so `pnpm@12 install --frozen-lockfile` failed with `ERR_PNPM_BROKEN_LOCKFILE`; pnpm 10 accepted the file. pnpm drops those entries and records only `optional: true`; the writer now does the same. Writer test added in `aube-lockfile`.

Verified on a `vitest@4.1.11` fixture: this build's lockfile passes `pnpm@12.0.0 install --frozen-lockfile --offline`; the shipped 0.7.4 binary's fails.