### PR TITLE
build: self-pruning GC for build residue (buckets + worktree targets)

### DIFF
--- a/.claude/skills/disk-reduction/SKILL.md
+++ b/.claude/skills/disk-reduction/SKILL.md
@@ -7,6 +7,8 @@ description: Reclaim disk on the maintainer's Mac when the volume is full or fil
 
 The dev Mac has a 1.8 TiB data volume that fills with Rust build output. Measured 2026-08-14: the volume hit **340 MiB free** — every agent tool call failed `ENOSPC` before it could run — and a sweep took it to **189 GiB** without deleting one line of source.
 
+**Most of this now prunes itself.** `scripts/target-gc.sh` runs hourly from every `rust-build.sh` build: orphaned buckets go after a day, anything idle 14 days goes, and a low-disk pressure pass (under 100 GiB free) collects idle state aggressively while sparing the newest. `make target-gc` shows what it would take right now. The manual sweeps below remain the tool for IMMEDIATE reclaim — the collector never touches a dir written within 2h, never the newest rlib seed, never `nub-dev`'s bucket — and for the families it does not scan (merged worktree checkouts).
+
 **Judge every reclaim by `df`, never `du`.** `scripts/rust-build.sh` CoW-clones buckets with `cp -c`, so APFS bills the same physical blocks to every referencing path. Summed `du` sizes overstate what you get back — measured, a set of buckets `du` called 135 G returned 73 GiB of `df`. A `du -sh` over `~/.cache/nub` also takes minutes; `df` is instant.
 
 ```sh
@@ -48,7 +50,7 @@ python3 .claude/skills/disk-reduction/scripts/clean-shared-buckets.py --apply
 - **Only a NON-diverged worktree resolves to a bucket at all.** The moment a branch touches a depended-on crate, `rust-build.sh` sends it to a private `$root/target` instead — so most feature branches reference no bucket, and a bucket's referrers are only ever the worktrees sitting at some exact content state.
 - **`main` advancing moves the key.** Every merge that touches `vendor/aube`, a non-leaf crate, or `runtime/` strands the previous bucket.
 
-`rust-build.sh` has its own GC, but it only retires a bucket after **14 days** of untouched mtime, so a fortnight of churn accumulates first. On 2026-08-14, 13 of 15 buckets proved orphaned — 12 in the first pass, holding ~135 G by `du` and returning 73 GiB of `df`, plus a 15 G bucket that orphaned the moment its last worktree was removed. Re-run the audit after removing any worktree.
+`scripts/target-gc.sh` (run hourly by `rust-build.sh`) retires an orphaned bucket after **a day** and anything idle after 14; before it existed, the only GC was a 14-day mtime sweep, so a fortnight of churn accumulated first. On 2026-08-14, 13 of 15 buckets proved orphaned — 12 in the first pass, holding ~135 G by `du` and returning 73 GiB of `df`, plus a 15 G bucket that orphaned the moment its last worktree was removed. Re-run the audit after removing any worktree.
 
 **What the script never deletes:**
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1382,10 +1382,31 @@ jobs:
   # A docs-only PR → Rust matrix skipped → this gate green → mergeable. A Rust PR
   # → matrix runs → this gate reflects it. The merge gate is never weakened: a
   # real failure still fails here.
+  target-gc:
+    name: Target-dir collector
+    needs: matrix-plan
+    # Path-gated on BOTH groups, like the other scripts gates: the collector is
+    # scripts/**, its harness tests/**. Ubuntu and macOS because the script must
+    # keep speaking both the BSD and GNU stat/date/find dialects.
+    if: needs.matrix-plan.outputs.run_rust == 'true' || needs.matrix-plan.outputs.run_scripts == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+      - run: tests/target-gc/run.sh
+
   ci-gate:
     name: CI gate
     if: always()
-    needs: [matrix-plan, check, clippy, embed-runtime, windows-embed-roundtrip, test, pnp, fmt, types-fixtures, docs-links, site-build, oxc-lockstep, version-consistency]
+    needs: [matrix-plan, check, clippy, embed-runtime, windows-embed-roundtrip, test, pnp, fmt, types-fixtures, docs-links, site-build, oxc-lockstep, version-consistency, target-gc]
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required job failed

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ else
   CARGO_FLAGS = --profile $(PROFILE)
 endif
 
-.PHONY: build addon addon-fast install-dev uninstall-dev qos-global build-status test verify test-node-matrix bench clean npm-build npm-publish npm-publish-dry
+.PHONY: build addon addon-fast install-dev uninstall-dev qos-global build-status target-gc test-target-gc test verify test-node-matrix bench clean npm-build npm-publish npm-publish-dry
 
 build: addon
 	$(CARGO) build $(CARGO_FLAGS)
@@ -100,6 +100,14 @@ qos-global:
 build-status:
 	@scripts/build-status.sh
 
+# What the self-pruning collector would reclaim right now (it runs for real,
+# hourly, from rust-build.sh; scripts/target-gc.sh has the policy).
+target-gc:
+	@scripts/target-gc.sh --dry-run
+
+test-target-gc:
+	@tests/target-gc/run.sh
+
 uninstall-dev:
 	rm -f $(BIN_DIR)/nub-dev $(BIN_DIR)/nubx-dev
 	@echo "Removed nub-dev and nubx-dev from $(BIN_DIR)"
@@ -133,6 +141,7 @@ verify:
 	(cd crates/nub-native && NUB_SHARED_TARGET="$(CURDIR)/target" "$(RUST_BUILD)" clippy --all-features --profile fast -- -D warnings)
 	tests/brand-lint/check-env-reads.sh
 	tests/brand-lint/check-path-literals.sh
+	@tests/target-gc/run.sh
 	NUB_SHARED_TARGET="$(CURDIR)/target" "$(RUST_BUILD)" test
 
 # Run the integration suite across a Node version matrix (18.19 floor → 22.15

--- a/scripts/rust-build.sh
+++ b/scripts/rust-build.sh
@@ -248,17 +248,18 @@ mkdir -p "$target"
 # the GC window and is collected mid-build — a failed build, not a cold one.
 touch "$target" 2>/dev/null || true
 
-# Stale-mtime sweep; the `touch` above is the liveness signal. Exact names rather
-# than a prefix glob so an unrelated sibling (a hand-made `shared-target.bak`)
-# can't be caught, while the bare legacy dir still is — which is what lets the
-# migration retire itself. Second pass: abandoned claims from a killed clone,
-# bucket-side only; a claim in a worktree root is retired by `seed_from`.
-_base=$(basename "$shared")
-find "$(dirname "$shared")" -maxdepth 1 -type d \
-  \( -name "$_base" -o -name "$_base-*" \) -mtime +14 \
-  -exec rm -rf {} + 2>/dev/null || true
-find "$(dirname "$shared")" -maxdepth 1 -type d -name "$_base*.seeding" -mmin +120 \
-  -exec rm -rf {} + 2>/dev/null || true
+# SELF-PRUNING. scripts/target-gc.sh owns the policy — orphaned buckets after
+# a day, anything untouched 14 days, low-disk pressure collection, abandoned
+# .seeding claims — and it replaces the inline 14-day sweep that used to live
+# here. At most hourly (the stamp), in the foreground so nothing outlives this
+# process, and fail-open: a failing collector never blocks the build. The
+# `touch` above is the liveness signal that keeps this dir out of its reach.
+_gcstamp="$HOME/.cache/nub/target-gc.stamp"
+if [ -f "$root/scripts/target-gc.sh" ] \
+  && [ -z "$(find "$_gcstamp" -mmin -60 2>/dev/null)" ]; then
+  touch "$_gcstamp" 2>/dev/null || true
+  NUB_GC_KEEP="$target" sh "$root/scripts/target-gc.sh" || true
+fi
 
 # CONTENTION CONTROL. Many agent worktrees build concurrently, and every cargo
 # assumes it owns the machine — ~20 parallel builds drove the 10-core dev host to

--- a/scripts/target-gc.sh
+++ b/scripts/target-gc.sh
@@ -34,8 +34,9 @@
 #     signal for a build in flight (a wrapper `touch` marks the top level at
 #     every build start, and artifacts landing keep the profile dirs fresh);
 #   - the newest rlib-bearing bucket (the seed every isolated worktree clones);
-#   - the bucket the installed nub-dev symlink resolves into (deleting it
-#     breaks the dev binary with no error until it is run).
+#   - the directory the installed nub-dev symlink resolves into — a shared
+#     bucket or an isolated worktree's target/ alike (deleting it breaks the
+#     dev binary with no error until it is run).
 #
 # Deletion is tomb-based: `mv` aside, then rm -rf. A build racing the
 # collector into the same directory then recreates it fresh via mkdir -p and
@@ -57,6 +58,15 @@
 set -u
 
 [ "${NUB_TARGET_GC:-1}" = "0" ] && exit 0
+
+# An inherited NUB_SHARED_TARGET would poison every resolution probe below:
+# the wrapper honours it verbatim, so all N worktrees would print one
+# identical path, no real bucket would land in the resolved set, and — the
+# set being non-empty — the empty-set valve would not fire, classifying every
+# live bucket an orphan. make verify/fmt/addon all export it, and the hourly
+# hook runs inside exactly those builds. Unset covers this process AND the
+# child probes.
+unset NUB_SHARED_TARGET
 
 dry=""
 [ "${1:-}" = "--dry-run" ] && dry=1
@@ -85,6 +95,17 @@ trap 'rm -rf "$lock" 2>/dev/null' EXIT
 
 say() { printf 'target-gc: %s\n' "$*" >&2; }
 
+# Every path is compared as a string, so every path that exists is reduced to
+# its one physical spelling first — a symlinked component anywhere (macOS's
+# /var -> /private/var, a symlinked $HOME) would otherwise make the keep and
+# resolved sets silently miss the candidates they name. A path that does not
+# exist yet (a bucket --print-target names but nothing created) passes through
+# raw: it cannot be a deletion candidate, so a mismatch there is harmless.
+# shellcheck disable=SC1007  # CDPATH= is a deliberate empty assignment for this one command
+canon() { CDPATH= cd -P -- "$1" 2>/dev/null && pwd -P || printf '%s\n' "$1"; }
+cache=$(canon "$cache")
+shared="$cache/shared-target"
+
 nl='
 '
 
@@ -93,16 +114,19 @@ nl='
 # whole-line (each entry sits between newlines), so /a/b never shields /x/a/b.
 keep=$nl
 old_ifs=$IFS; IFS=:
-for _k in ${NUB_GC_KEEP:-}; do [ -n "$_k" ] && keep="$keep$_k$nl"; done
+for _k in ${NUB_GC_KEEP:-}; do [ -n "$_k" ] && keep="$keep$(canon "$_k")$nl"; done
 IFS=$old_ifs
 
-# The bucket nub-dev resolves into: the symlink points at <bucket>/fast/nub.
+# The directory nub-dev resolves into: the symlink points at <dir>/fast/nub,
+# where <dir> is a shared bucket OR an isolated worktree's target/ — whichever
+# --print-target answered when make install-dev last ran. Both shapes are
+# collectible, so both are kept; no path filter, because narrowing this to the
+# cache root once left the isolated shape unprotected.
 for _dev in nub-dev nubx-dev; do
   _bin=$(command -v "$_dev" 2>/dev/null) || continue
   _dst=$(readlink "$_bin" 2>/dev/null) || continue
-  case $_dst in
-    "$shared"*) keep="$keep${_dst%/*/*}$nl" ;;
-  esac
+  _dir=${_dst%/*/*}
+  [ -n "$_dir" ] && [ -d "$_dir" ] && keep="$keep$(canon "$_dir")$nl"
 done
 
 # The newest rlib-bearing bucket — the seed every isolated worktree clones.
@@ -125,7 +149,7 @@ while read -r _root; do
   [ -n "$_root" ] && [ -d "$_root" ] || continue
   if [ -f "$_root/scripts/rust-build.sh" ]; then
     _t=$(cd "$_root" 2>/dev/null && sh scripts/rust-build.sh --print-target 2>/dev/null) || _t=""
-    [ -n "$_t" ] && resolved="$resolved$_t$nl"
+    [ -n "$_t" ] && resolved="$resolved$(canon "$_t")$nl"
   fi
 done <<ROOTS
 $roots

--- a/scripts/target-gc.sh
+++ b/scripts/target-gc.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env sh
+# target-gc — self-pruning for nub's Rust build residue.
+#
+# The two families that fill the disk (measured 2026-08-14: 101 GiB + 87 GiB
+# on a volume down to 340 MiB free) are worktree-private target/ dirs and
+# orphaned content-keyed shared buckets under ~/.cache/nub. Both used to wait
+# for a human to run the audit scripts; this collector runs from rust-build.sh
+# after target resolution, at most hourly, so the residue prunes itself the
+# way mbx (mr boxington) prunes its managed target directories: abandoned
+# state is collected unconditionally, idle state by age, and a low-disk
+# pressure pass collects harder while sparing the directory most recently
+# built in — deleting that one cannot hold the total down, because the next
+# build recreates it.
+#
+# WHAT IT COLLECTS, AND WHEN:
+#   - a BUCKET (shared-target-<key>) no live worktree resolves to, untouched
+#     for NUB_GC_ORPHAN_HOURS (24): the key moved with trunk, nothing can join
+#     it again. Resolution is asked of each worktree's OWN rust-build.sh
+#     --print-target — a pure read — so there is no duplicated key computation
+#     to drift, which is the failure the manual sweep's positive control
+#     exists to catch.
+#   - any bucket or live worktree's target/ untouched for NUB_GC_AGE_DAYS
+#     (14): the incumbent age rule, unchanged.
+#   - under PRESSURE (free space below NUB_GC_FREE_MIN_GIB, default 100):
+#     orphan buckets at any age, and idle directories beyond
+#     NUB_GC_PRESSURE_HOURS (24) oldest-first — sparing the newest non-orphan
+#     that would otherwise go, so an all-idle fleet is never wiped at once.
+#   - .seeding claims abandoned for 2h, and tombs a killed collector left.
+#
+# WHAT IT NEVER COLLECTS:
+#   - anything in NUB_GC_KEEP (colon-separated; the calling build passes its
+#     own CARGO_TARGET_DIR);
+#   - anything whose top three levels saw a write in the last 2h — the in-use
+#     signal for a build in flight (a wrapper `touch` marks the top level at
+#     every build start, and artifacts landing keep the profile dirs fresh);
+#   - the newest rlib-bearing bucket (the seed every isolated worktree clones);
+#   - the bucket the installed nub-dev symlink resolves into (deleting it
+#     breaks the dev binary with no error until it is run).
+#
+# Deletion is tomb-based: `mv` aside, then rm -rf. A build racing the
+# collector into the same directory then recreates it fresh via mkdir -p and
+# pays a seeded rebuild — never reads a half-deleted tree. That is the same
+# accepted race the bucket sweep always had, narrowed from the width of an
+# rm -rf to the width of a rename.
+#
+# Fail-open everywhere: any read or delete that fails skips that entry; a
+# collector that cannot take the lock exits 0 silently. NUB_TARGET_GC=0
+# disables collection entirely.
+#
+#   scripts/target-gc.sh             # collect (rust-build.sh calls this hourly)
+#   scripts/target-gc.sh --dry-run   # print what would be collected, delete nothing
+#
+# Tunables: NUB_GC_ORPHAN_HOURS (24), NUB_GC_AGE_DAYS (14, 0 disables the age
+# rule), NUB_GC_FREE_MIN_GIB (100, 0 disables the pressure pass),
+# NUB_GC_PRESSURE_HOURS (24), NUB_GC_KEEP, NUB_GC_CACHE_ROOT (test override),
+# NUB_TARGET_GC=0.
+set -u
+
+[ "${NUB_TARGET_GC:-1}" = "0" ] && exit 0
+
+dry=""
+[ "${1:-}" = "--dry-run" ] && dry=1
+
+cache=${NUB_GC_CACHE_ROOT:-$HOME/.cache/nub}
+shared="$cache/shared-target"
+orphan_hours=${NUB_GC_ORPHAN_HOURS:-24}
+age_days=${NUB_GC_AGE_DAYS:-14}
+free_min=${NUB_GC_FREE_MIN_GIB:-100}
+pressure_hours=${NUB_GC_PRESSURE_HOURS:-24}
+# A non-numeric tunable would turn every comparison below into a shell error;
+# fall back to the default instead (the governor's rule).
+[ "$orphan_hours" -ge 0 ] 2>/dev/null || orphan_hours=24
+[ "$age_days" -ge 0 ] 2>/dev/null || age_days=14
+[ "$free_min" -ge 0 ] 2>/dev/null || free_min=100
+[ "$pressure_hours" -ge 1 ] 2>/dev/null || pressure_hours=24
+
+# One collector at a time; a lock older than 30 min belonged to a killed one.
+lock="$cache/target-gc.lock"
+if [ -d "$lock" ] && [ -z "$(find "$lock" -maxdepth 0 -mmin -30 2>/dev/null)" ]; then
+  rm -rf "$lock" 2>/dev/null
+fi
+mkdir -p "$cache" 2>/dev/null || exit 0
+mkdir "$lock" 2>/dev/null || exit 0
+trap 'rm -rf "$lock" 2>/dev/null' EXIT
+
+say() { printf 'target-gc: %s\n' "$*" >&2; }
+
+nl='
+'
+
+# ── The protect set ─────────────────────────────────────────────────────────
+# keep: newline-delimited absolute paths that survive every pass. Matched
+# whole-line (each entry sits between newlines), so /a/b never shields /x/a/b.
+keep=$nl
+old_ifs=$IFS; IFS=:
+for _k in ${NUB_GC_KEEP:-}; do [ -n "$_k" ] && keep="$keep$_k$nl"; done
+IFS=$old_ifs
+
+# The bucket nub-dev resolves into: the symlink points at <bucket>/fast/nub.
+for _dev in nub-dev nubx-dev; do
+  _bin=$(command -v "$_dev" 2>/dev/null) || continue
+  _dst=$(readlink "$_bin" 2>/dev/null) || continue
+  case $_dst in
+    "$shared"*) keep="$keep${_dst%/*/*}$nl" ;;
+  esac
+done
+
+# The newest rlib-bearing bucket — the seed every isolated worktree clones.
+# shellcheck disable=SC2010,SC2012  # names are ours and contain no newlines
+for _b in $(ls -dt "$shared"-* 2>/dev/null | grep -v '\.seeding$' | grep -v '\.gc\.'); do
+  if [ -n "$(find "$_b" -name '*.rlib' -print -quit 2>/dev/null)" ]; then
+    keep="$keep$_b$nl"
+    break
+  fi
+done
+
+# Live worktrees, and the target dir each one would build into today. Asking
+# each checkout's own wrapper keeps this collector free of any second copy of
+# the content-key computation. A worktree whose wrapper predates --print-target
+# or fails contributes nothing — its bucket is then only protected by age and
+# the in-use probe, which is the fail-open direction (one reseed, not a wedge).
+roots=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{sub(/^worktree /, ""); print}' | head -40)
+resolved=$nl
+while read -r _root; do
+  [ -n "$_root" ] && [ -d "$_root" ] || continue
+  if [ -f "$_root/scripts/rust-build.sh" ]; then
+    _t=$(cd "$_root" 2>/dev/null && sh scripts/rust-build.sh --print-target 2>/dev/null) || _t=""
+    [ -n "$_t" ] && resolved="$resolved$_t$nl"
+  fi
+done <<ROOTS
+$roots
+ROOTS
+
+kept()     { case "$keep"     in *"$nl$1$nl"*) return 0 ;; esac; return 1; }
+# With no worktree resolutions at all — not a git repo, or every wrapper failed
+# — orphanhood is unknowable, so resolves() answers "yes" for every bucket and
+# the orphan rule disables itself. Age, keep and in-use still apply.
+resolves() {
+  [ "$resolved" = "$nl" ] && return 0
+  case "$resolved" in *"$nl$1$nl"*) return 0 ;; esac; return 1
+}
+# A write anywhere in the top three levels within 2h means a build may be in
+# flight (top-level touch at build start; artifacts keep profile dirs fresh).
+in_use() { [ -n "$(find "$1" -maxdepth 3 -mmin -120 -print -quit 2>/dev/null)" ]; }
+
+collect() {
+  if [ -n "$dry" ]; then
+    say "would collect $1 ($2)"
+    return 0
+  fi
+  _tomb="$1.gc.$$"
+  if mv "$1" "$_tomb" 2>/dev/null; then
+    rm -rf "$_tomb" 2>/dev/null
+    say "collected $1 ($2)"
+  fi
+}
+
+# ── Pressure detection ──────────────────────────────────────────────────────
+pressure=""
+if [ "${NUB_GC_PRESSURE:-}" = "1" ]; then
+  pressure=1
+elif [ "$free_min" -gt 0 ]; then
+  _avail=$(df -Pk "$cache" 2>/dev/null | awk 'NR==2{print $4}')
+  if [ "$_avail" -ge 0 ] 2>/dev/null && [ "$_avail" -lt $((free_min * 1024 * 1024)) ]; then
+    pressure=1
+    say "pressure: $((_avail / 1024 / 1024)) GiB free, floor ${free_min} GiB — collecting idle state"
+  fi
+fi
+
+# ── Housekeeping: abandoned seeding claims and tombs ────────────────────────
+[ -z "$dry" ] && find "$(dirname "$shared")" -maxdepth 1 -type d -name "$(basename "$shared")*.seeding" \
+  -mmin +120 -exec rm -rf {} + 2>/dev/null
+[ -z "$dry" ] && find "$(dirname "$shared")" -maxdepth 1 -type d -name "$(basename "$shared")*.gc.*" \
+  -mmin +120 -exec rm -rf {} + 2>/dev/null
+
+# ── Candidate scan ──────────────────────────────────────────────────────────
+# Buckets (plus the bare legacy dir), then each live worktree's real target/.
+# One candidate per line: "<epoch-mtime> <kind> <path>". Sorting survivors by
+# mtime lets the pressure pass go oldest-first and spare the newest.
+stat_mtime() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0; }
+
+candidates=""
+for _b in "$shared" "$shared"-*; do
+  [ -d "$_b" ] || continue
+  case $_b in *.seeding | *.gc.*) continue ;; esac
+  candidates="$candidates$(stat_mtime "$_b") bucket $_b$nl"
+done
+while read -r _root; do
+  [ -n "$_root" ] || continue
+  _t="$_root/target"
+  [ -d "$_t" ] && [ ! -L "$_t" ] || continue
+  candidates="$candidates$(stat_mtime "$_t") target $_t$nl"
+done <<ROOTS
+$roots
+ROOTS
+
+now=$(date +%s 2>/dev/null) || now=""
+[ "$now" -ge 1 ] 2>/dev/null || exit 0
+
+# ── Normal pass ─────────────────────────────────────────────────────────────
+survivors=""
+while read -r _m _kind _path; do
+  [ -n "$_path" ] || continue
+  [ "$_m" -ge 1 ] 2>/dev/null || continue
+  _h=$(( (now - _m) / 3600 ))
+  kept "$_path" && continue
+  in_use "$_path" && continue
+  if [ "$age_days" -gt 0 ] && [ "$_h" -ge $((age_days * 24)) ]; then
+    collect "$_path" "untouched ${age_days}d"
+  elif [ "$_kind" = bucket ] && ! resolves "$_path" && [ "$_h" -ge "$orphan_hours" ]; then
+    collect "$_path" "orphaned bucket, ${_h}h old"
+  else
+    survivors="$survivors$_m $_kind $_path$nl"
+  fi
+done <<CANDIDATES
+$candidates
+CANDIDATES
+
+# ── Pressure pass ───────────────────────────────────────────────────────────
+# Oldest-first over what the normal pass left. Orphan buckets go at any age.
+# Everything else goes once idle past NUB_GC_PRESSURE_HOURS — resolved buckets
+# included, since a rebuild recovers them — EXCEPT the newest directory that
+# would otherwise be collected: when the whole fleet has sat idle (a weekend),
+# that spare is what keeps pressure from wiping every warm dir at once, and
+# it never goes to an orphan (which is being deleted regardless, so the
+# protection would be spent on nothing — mbx's rule).
+if [ -n "$pressure" ] && [ -n "$survivors" ]; then
+  sorted=$(printf '%s' "$survivors" | sort -n)
+  spare=""
+  while read -r _m _kind _path; do
+    [ -n "$_path" ] || continue
+    [ "$_m" -ge 1 ] 2>/dev/null || continue
+    _h=$(( (now - _m) / 3600 ))
+    if [ "$_h" -ge "$pressure_hours" ] \
+      && { [ "$_kind" = target ] || resolves "$_path"; }; then spare=$_path; fi
+  done <<SORTED
+$sorted
+SORTED
+  while read -r _m _kind _path; do
+    [ -n "$_path" ] || continue
+    [ "$_path" = "$spare" ] && continue
+    _h=$(( (now - _m) / 3600 ))
+    if [ "$_kind" = bucket ] && ! resolves "$_path"; then
+      collect "$_path" "pressure: orphaned bucket"
+    elif [ "$_h" -ge "$pressure_hours" ]; then
+      collect "$_path" "pressure: idle ${_h}h"
+    fi
+  done <<SORTED
+$sorted
+SORTED
+fi
+
+exit 0

--- a/tests/target-gc/run.sh
+++ b/tests/target-gc/run.sh
@@ -119,6 +119,34 @@ if run pressure; then
   check "a recently touched referenced bucket is untouched by pressure" '[ -d "$T/cache/shared-target-live" ]'
 fi
 
+if run envleak; then
+  echo "envleak: an inherited NUB_SHARED_TARGET must not poison orphan detection"
+  reset
+  # Stubs that model the real wrapper's env sensitivity: an inherited
+  # NUB_SHARED_TARGET is echoed verbatim, exactly as --print-target honours it.
+  for _w in wt1 wt2; do
+    printf '#!/bin/sh\n[ -n "${NUB_SHARED_TARGET:-}" ] && { echo "$NUB_SHARED_TARGET"; exit 0; }\necho "%s"\n' \
+      "$T/cache/shared-target-live" > "$T/$_w/scripts/rust-build.sh"
+  done
+  plant "$T/cache/shared-target-live" "$(ago_h 30)"
+  (cd "$T/repo" && NUB_GC_CACHE_ROOT="$T/cache" NUB_GC_FREE_MIN_GIB=0 \
+    NUB_SHARED_TARGET="$T/bogus" sh "$GC" 2>/dev/null)
+  check "the live bucket survives a poisoned caller environment" '[ -d "$T/cache/shared-target-live" ]'
+fi
+
+if run devkeep; then
+  echo "devkeep: the dir nub-dev resolves into is kept, isolated worktree targets included"
+  reset
+  plant "$T/wt1/target" "$(ago_d 15)"
+  # command -v refuses a dangling symlink, so the fake binary must exist — and
+  # carry the old stamp, or the in-use probe would mask what this pins.
+  printf '#!/bin/sh\n' > "$T/wt1/target/fast/nub" && chmod +x "$T/wt1/target/fast/nub"
+  find "$T/wt1/target" -exec touch -t "$(ago_d 15)" {} + 2>/dev/null
+  mkdir -p "$T/bin" && ln -sf "$T/wt1/target/fast/nub" "$T/bin/nub-dev"
+  (cd "$T/repo" && PATH="$T/bin:$PATH" NUB_GC_CACHE_ROOT="$T/cache" NUB_GC_FREE_MIN_GIB=0 sh "$GC" 2>/dev/null)
+  check "the 15d-idle target nub-dev points into survives" '[ -d "$T/wt1/target" ]'
+fi
+
 if run noroots; then
   echo "noroots: with no worktree resolutions the orphan rule disables itself"
   reset

--- a/tests/target-gc/run.sh
+++ b/tests/target-gc/run.sh
@@ -44,7 +44,8 @@ plant() { # path stamp [rlib]
 reset() {
   rm -rf "$T/cache" "$T/repo" "$T/wt1" "$T/wt2"
   mkdir -p "$T/cache"
-  git init -q "$T/repo" && (cd "$T/repo" && git commit -q --allow-empty -m x \
+  git init -q "$T/repo" && (cd "$T/repo" \
+    && git -c user.email=gc@test -c user.name=gc commit -q --allow-empty -m x \
     && git worktree add -q --detach "$T/wt1" && git worktree add -q --detach "$T/wt2") || exit 1
   for _w in wt1 wt2; do
     mkdir -p "$T/$_w/scripts"

--- a/tests/target-gc/run.sh
+++ b/tests/target-gc/run.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+# Drives scripts/target-gc.sh against a fake cache root and fake git worktrees,
+# so every collection rule can be asserted in seconds without touching the
+# machine's real ~/.cache/nub. Ages are planted with touch -t; worktree
+# resolution goes through a stub scripts/rust-build.sh in each fake worktree,
+# exactly the interface the real collector uses.
+#
+#   tests/target-gc/run.sh            # all scenarios, ~10s
+#   tests/target-gc/run.sh orphan age # a subset
+#
+# shellcheck disable=SC2016  # check() exprs are eval'd later; single quotes are the point
+set -u
+
+here=$(cd "$(dirname "$0")" && pwd)
+GC="$here/../../scripts/target-gc.sh"
+T=$(mktemp -d "${TMPDIR:-/tmp}/target-gc-test.XXXXXX") || exit 1
+trap 'rm -rf "$T"' EXIT
+
+fails=0
+check() {
+  if eval "$2" 2>/dev/null; then echo "  ok   $1"; else echo "  FAIL $1"; fails=$((fails + 1)); fi
+}
+want=" $* "
+run() { [ "$want" = "  " ] || case $want in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+
+# touch -t stamps: N hours / days in the past, both date dialects.
+ago_h() { date -v-"$1"H +%Y%m%d%H%M 2>/dev/null || date -d "$1 hours ago" +%Y%m%d%H%M; }
+ago_d() { date -v-"$1"d +%Y%m%d%H%M 2>/dev/null || date -d "$1 days ago" +%Y%m%d%H%M; }
+
+# A bucket/target whose top level AND contents carry the given stamp — the
+# in-use probe reads three levels deep, so a fresh inner file would pin it.
+# `find -exec touch` stamps only what exists; a bare `touch -t list...` would
+# CREATE any missing name, silently planting an rlib in every bucket.
+plant() { # path stamp [rlib]
+  mkdir -p "$1/fast"
+  : > "$1/fast/artifact"
+  [ "${3:-}" = rlib ] && : > "$1/fast/libx.rlib"
+  find "$1" -exec touch -t "$2" {} + 2>/dev/null
+}
+
+# One fake repo with two worktrees, both of whose stub wrappers resolve to the
+# `live` bucket, so the collector sees one referenced bucket and two real
+# checkouts whose target/ dirs it may scan. Recreated per scenario.
+reset() {
+  rm -rf "$T/cache" "$T/repo" "$T/wt1" "$T/wt2"
+  mkdir -p "$T/cache"
+  git init -q "$T/repo" && (cd "$T/repo" && git commit -q --allow-empty -m x \
+    && git worktree add -q --detach "$T/wt1" && git worktree add -q --detach "$T/wt2") || exit 1
+  for _w in wt1 wt2; do
+    mkdir -p "$T/$_w/scripts"
+    printf '#!/bin/sh\necho "%s"\n' "$T/cache/shared-target-live" > "$T/$_w/scripts/rust-build.sh"
+  done
+}
+gc() { (cd "$T/repo" && NUB_GC_CACHE_ROOT="$T/cache" NUB_GC_FREE_MIN_GIB=0 sh "$GC" "$@" 2>"$T/gc.err"); }
+
+if run orphan; then
+  echo "orphan: an unreferenced bucket is collected after a day; a referenced one is kept"
+  reset
+  plant "$T/cache/shared-target-live" "$(ago_h 30)"
+  plant "$T/cache/shared-target-dead" "$(ago_h 30)"
+  plant "$T/cache/shared-target-young" "$(ago_h 3)"
+  gc
+  check "the 30h unreferenced bucket is gone" '[ ! -d "$T/cache/shared-target-dead" ]'
+  check "the bucket a worktree resolves to survives" '[ -d "$T/cache/shared-target-live" ]'
+  check "a 3h unreferenced bucket survives (under NUB_GC_ORPHAN_HOURS)" '[ -d "$T/cache/shared-target-young" ]'
+fi
+
+if run seed; then
+  echo "seed: the newest rlib-bearing bucket survives even as an orphan"
+  reset
+  plant "$T/cache/shared-target-seed" "$(ago_h 30)" rlib
+  gc
+  check "the rlib seed bucket survives" '[ -d "$T/cache/shared-target-seed" ]'
+fi
+
+if run inuse; then
+  echo "inuse: a fresh write inside pins a bucket whose top level looks old"
+  reset
+  plant "$T/cache/shared-target-busy" "$(ago_h 30)"
+  : > "$T/cache/shared-target-busy/fast/fresh"
+  gc
+  check "the bucket with a fresh inner write survives" '[ -d "$T/cache/shared-target-busy" ]'
+fi
+
+if run age; then
+  echo "age: a worktree target idle 14 days is collected; a fresh one is kept"
+  reset
+  plant "$T/wt1/target" "$(ago_d 15)"
+  gc
+  check "the 15d-idle worktree target is gone" '[ ! -d "$T/wt1/target" ]'
+  reset
+  plant "$T/wt1/target" "$(ago_d 3)"
+  gc
+  check "a 3d-idle worktree target survives" '[ -d "$T/wt1/target" ]'
+fi
+
+if run keep; then
+  echo "keep: NUB_GC_KEEP shields a directory from every pass"
+  reset
+  plant "$T/cache/shared-target-dead" "$(ago_h 30)"
+  (cd "$T/repo" && NUB_GC_CACHE_ROOT="$T/cache" NUB_GC_FREE_MIN_GIB=0 \
+    NUB_GC_KEEP="$T/cache/shared-target-dead" sh "$GC" 2>/dev/null)
+  check "the kept orphan survives" '[ -d "$T/cache/shared-target-dead" ]'
+fi
+
+if run pressure; then
+  echo "pressure: orphans go at any age, idle dirs oldest-first, the newest non-orphan is spared"
+  reset
+  plant "$T/cache/shared-target-live" "$(ago_h 3)"
+  plant "$T/cache/shared-target-young" "$(ago_h 3)"
+  plant "$T/wt1/target" "$(ago_h 40)"
+  plant "$T/wt2/target" "$(ago_h 26)"
+  (cd "$T/repo" && NUB_GC_CACHE_ROOT="$T/cache" NUB_GC_FREE_MIN_GIB=0 \
+    NUB_GC_PRESSURE=1 sh "$GC" 2>/dev/null)
+  check "a young orphan bucket is collected under pressure (never spared)" '[ ! -d "$T/cache/shared-target-young" ]'
+  check "the oldest idle worktree target is collected under pressure" '[ ! -d "$T/wt1/target" ]'
+  check "the newest at-risk non-orphan is spared" '[ -d "$T/wt2/target" ]'
+  check "a recently touched referenced bucket is untouched by pressure" '[ -d "$T/cache/shared-target-live" ]'
+fi
+
+if run noroots; then
+  echo "noroots: with no worktree resolutions the orphan rule disables itself"
+  reset
+  plant "$T/cache/shared-target-dead" "$(ago_h 30)"
+  mkdir -p "$T/nowhere"
+  (cd "$T/nowhere" && NUB_GC_CACHE_ROOT="$T/cache" NUB_GC_FREE_MIN_GIB=0 sh "$GC" 2>/dev/null)
+  check "an unreferenced bucket survives when references are unknowable" '[ -d "$T/cache/shared-target-dead" ]'
+fi
+
+if run dryrun; then
+  echo "dryrun: --dry-run reports and deletes nothing"
+  reset
+  plant "$T/cache/shared-target-dead" "$(ago_h 30)"
+  gc --dry-run
+  check "the candidate is reported" 'grep -q "would collect .*shared-target-dead" "$T/gc.err"'
+  check "nothing was deleted" '[ -d "$T/cache/shared-target-dead" ]'
+fi
+
+if run off; then
+  echo "off: NUB_TARGET_GC=0 disables collection"
+  reset
+  plant "$T/cache/shared-target-dead" "$(ago_h 30)"
+  (cd "$T/repo" && NUB_GC_CACHE_ROOT="$T/cache" NUB_TARGET_GC=0 sh "$GC" 2>/dev/null)
+  check "the orphan survives with collection off" '[ -d "$T/cache/shared-target-dead" ]'
+fi
+
+if run lock; then
+  echo "lock: a live sibling collector wins; a stale lock is taken over"
+  reset
+  plant "$T/cache/shared-target-dead" "$(ago_h 30)"
+  mkdir -p "$T/cache/target-gc.lock"
+  gc
+  check "a fresh lock blocks collection" '[ -d "$T/cache/shared-target-dead" ]'
+  touch -t "$(ago_h 1)" "$T/cache/target-gc.lock"
+  gc
+  check "a stale lock is taken over and collection proceeds" '[ ! -d "$T/cache/shared-target-dead" ]'
+  check "the lock is released afterwards" '[ ! -d "$T/cache/target-gc.lock" ]'
+fi
+
+echo
+if [ "$fails" = 0 ]; then echo "target-gc: all scenarios passed"; else echo "target-gc: $fails assertion(s) FAILED"; exit 1; fi


### PR DESCRIPTION
`scripts/target-gc.sh`, run at most hourly from `rust-build.sh`: collects buckets no live worktree resolves to after 24h (orphanhood via each worktree's own `--print-target`), anything idle 14 days, and — under 100 GiB free — idle state oldest-first, sparing the newest at-risk dir. Never touches the calling build's dir, anything written within 2h, the newest rlib seed, or `nub-dev`'s bucket; deletes by rename-then-remove.

`make target-gc` prints a dry-run audit. 10-scenario harness (ubuntu + macOS), each protection mutation-checked red; the live-host dry run matched the manual audit's orphaned/referenced verdicts exactly.