### PR TITLE
outdated/update: never offer a version below the installed one

### DIFF
--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -554,6 +554,8 @@ All dependencies up to date.
 
 A project whose only pending upgrade sits inside the window has nothing to act on, so the command exits 0 and a CI check that runs it passes.
 
+The fallback never walks back past what is installed. A window set wider than a dependency's own age would otherwise leave the newest admitted release older than the installed one, and the report would name a downgrade as the version to move to. There is no upgrade in that case, so `Latest` reports the installed version and the command exits 0.
+
 Two flags adjust the window for a single command, so getting past a block never means editing config:
 
 ```console

--- a/vendor/aube/crates/aube/src/commands/outdated.rs
+++ b/vendor/aube/crates/aube/src/commands/outdated.rs
@@ -132,7 +132,7 @@ struct Row {
 /// settings accessor `install`/`add` use rather than standing up a
 /// [`aube_resolver::Resolver`] it would never resolve with. `None` means no
 /// window is in effect and every pick below stays on today's ungated path.
-fn age_gate_for(cwd: &Path) -> Option<aube_resolver::MinimumReleaseAge> {
+pub(super) fn age_gate_for(cwd: &Path) -> Option<aube_resolver::MinimumReleaseAge> {
     let files = super::FileSources::load(cwd);
     let raw_workspace = aube_manifest::workspace::load_raw(cwd).unwrap_or_default();
     let ctx = files.ctx(&raw_workspace, aube_settings::values::process_env(), &[]);

--- a/vendor/aube/crates/aube/src/commands/outdated.rs
+++ b/vendor/aube/crates/aube/src/commands/outdated.rs
@@ -199,7 +199,11 @@ pub(super) fn latest_pick(
         // known to normalize a local dep to a parseable `0.0.0`.
         return Some(picked);
     };
-    Some(if new < cur { current.to_string() } else { picked })
+    Some(if new < cur {
+        current.to_string()
+    } else {
+        picked
+    })
 }
 
 /// The version a column should show: what an install would actually land on.
@@ -230,7 +234,7 @@ pub(super) fn latest_pick(
 /// `wanted` caller warns instead — and only that one, since only the manifest
 /// range predicts plain `update` — on stderr beside the existing
 /// packument-fetch warning; stdout stays data.
-fn gated_pick(
+pub(super) fn gated_pick(
     packument: &Packument,
     registry_name: &str,
     range: &str,
@@ -1174,7 +1178,10 @@ mod age_gate_tests {
                 .as_deref(),
             Some("2.0.1")
         );
-        assert_eq!(latest_pick(&p, "pkg", None, "2.0.0").as_deref(), Some("2.0.1"));
+        assert_eq!(
+            latest_pick(&p, "pkg", None, "2.0.0").as_deref(),
+            Some("2.0.1")
+        );
     }
 
     #[test]
@@ -1189,7 +1196,10 @@ mod age_gate_tests {
                 .as_deref(),
             Some("2.0.0")
         );
-        assert_eq!(latest_pick(&p, "pkg", Some(&g), "2.0.0").as_deref(), Some("2.0.0"));
+        assert_eq!(
+            latest_pick(&p, "pkg", Some(&g), "2.0.0").as_deref(),
+            Some("2.0.0")
+        );
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/outdated.rs
+++ b/vendor/aube/crates/aube/src/commands/outdated.rs
@@ -154,6 +154,7 @@ fn latest_pick(
     packument: &Packument,
     registry_name: &str,
     gate: Option<&aube_resolver::MinimumReleaseAge>,
+    current: &str,
 ) -> Option<String> {
     let tagged = packument.dist_tags.get("latest").cloned();
     tagged.as_ref()?;
@@ -163,7 +164,33 @@ fn latest_pick(
     // The undeterminable flag is deliberately dropped: it describes the
     // `latest` tag's own candidate set, which no message keys on. See the
     // warning's rationale in `collect_rows`.
-    gated_pick(packument, registry_name, "latest", gate, tagged).0
+    let picked = gated_pick(packument, registry_name, "latest", gate, tagged).0?;
+
+    // Never offer a DOWNGRADE. That same widening walks DOWNWARD looking for a
+    // release old enough to clear the window, so a window wider than the
+    // installed version's own age lands below `current` — and the column then
+    // advertises an older version as the one to move to, counts as drift, and
+    // pins the exit code at 1 with nothing installable. That is the dead end
+    // #722 was about, reached by a different route.
+    //
+    // A pick at or below `current` reports `current` instead of dropping to
+    // unknown: there genuinely is no upgrade, and saying so is both truer and
+    // what lets the command exit 0.
+    //
+    // Accepted cost: a publisher who ROLLS BACK the tag — ships 3.0.0, retracts
+    // it, re-tags 2.9.1 — no longer surfaces here to someone already on 3.0.0.
+    // That signal was never dependable in this column, since it appears only
+    // when the installed version happens to sit above the tag, and a retraction
+    // reaches the user through deprecation metadata instead.
+    let (Ok(new), Ok(cur)) = (
+        node_semver::Version::parse(&picked),
+        node_semver::Version::parse(current),
+    ) else {
+        // Either side unparseable (a git/file resolution) means the two are not
+        // ordered at all, so leave the pick alone rather than guess a direction.
+        return Some(picked);
+    };
+    Some(if new < cur { current.to_string() } else { picked })
 }
 
 /// The version a column should show: what an install would actually land on.
@@ -643,7 +670,7 @@ async fn collect_rows(
         // `latest` dist-tag (common on private registries) doesn't get
         // silently flagged as outdated. Drift detection treats an
         // unknown latest the same as "matches current".
-        let latest = latest_pick(packument, &registry_name, gate);
+        let latest = latest_pick(packument, &registry_name, gate, &current);
 
         // Wanted = highest version in the packument that still satisfies the
         // manifest range. Fall back to `current` when the range is unparseable
@@ -1138,7 +1165,7 @@ mod age_gate_tests {
                 .as_deref(),
             Some("2.0.1")
         );
-        assert_eq!(latest_pick(&p, "pkg", None).as_deref(), Some("2.0.1"));
+        assert_eq!(latest_pick(&p, "pkg", None, "2.0.0").as_deref(), Some("2.0.1"));
     }
 
     #[test]
@@ -1153,7 +1180,7 @@ mod age_gate_tests {
                 .as_deref(),
             Some("2.0.0")
         );
-        assert_eq!(latest_pick(&p, "pkg", Some(&g)).as_deref(), Some("2.0.0"));
+        assert_eq!(latest_pick(&p, "pkg", Some(&g), "2.0.0").as_deref(), Some("2.0.0"));
     }
 
     #[test]
@@ -1210,8 +1237,8 @@ mod age_gate_tests {
             "time": { "2.0.0": "2020-01-01T00:00:00.000Z" },
         }))
         .unwrap();
-        assert_eq!(latest_pick(&p, "pkg", Some(&gate(true))), None);
-        assert_eq!(latest_pick(&p, "pkg", None), None);
+        assert_eq!(latest_pick(&p, "pkg", Some(&gate(true)), "1.0.0"), None);
+        assert_eq!(latest_pick(&p, "pkg", None, "1.0.0"), None);
         // Guard the mechanism, so a resolver change cannot quietly reintroduce
         // the synthesis the call-site guard exists to stop.
         assert!(
@@ -1276,7 +1303,7 @@ mod age_gate_tests {
         .unwrap();
         let g = gate(true);
         assert_eq!(
-            latest_pick(&p, "pkg", Some(&g)),
+            latest_pick(&p, "pkg", Some(&g), "3.0.0"),
             None,
             "the `latest` column genuinely admits nothing here"
         );
@@ -1295,6 +1322,50 @@ mod age_gate_tests {
         assert!(
             !undated,
             "so the warning must NOT fire — `nub update` succeeds on this package"
+        );
+    }
+
+    /// The `Latest` column must never point BACKWARDS.
+    ///
+    /// A window wider than the installed version's own age sends the widened
+    /// `<=dist-tags.latest` scan down PAST `current` to the newest release old
+    /// enough to clear. Reporting that advertises a DOWNGRADE, counts as drift,
+    /// and holds the exit code at 1 with nothing installable — #722's dead end
+    /// reached by another route.
+    #[test]
+    fn a_window_wider_than_the_installed_version_offers_no_downgrade() {
+        let p: Packument = serde_json::from_value(serde_json::json!({
+            "name": "pkg",
+            "dist-tags": { "latest": "2.0.0" },
+            "versions": {
+                "1.0.0": { "name": "pkg", "version": "1.0.0" },
+                "2.0.0": { "name": "pkg", "version": "2.0.0" },
+            },
+            // 2.0.0 is what is installed, and it is too new for the window;
+            // 1.0.0 is the newest release the window does admit.
+            "time": {
+                "1.0.0": "2020-01-01T00:00:00.000Z",
+                "2.0.0": "2099-01-01T00:00:00.000Z",
+            },
+        }))
+        .unwrap();
+        let g = gate(true);
+        // Guard the premise: without the clamp the column would say 1.0.0, so
+        // this case genuinely exercises the backwards pick rather than a refusal.
+        assert!(matches!(
+            aube_resolver::pick_version_for_add(&p, "pkg", "latest", Some(&g)),
+            aube_resolver::PickResult::Found(m) if m.version == "1.0.0"
+        ));
+        assert_eq!(
+            latest_pick(&p, "pkg", Some(&g), "2.0.0").as_deref(),
+            Some("2.0.0"),
+            "the newest admitted release is OLDER than what is installed, so \
+             there is no upgrade and the column reports current"
+        );
+        let r = row("2.0.0", "2.0.0", Some("2.0.0"));
+        assert!(
+            !has_drift(std::slice::from_ref(&r)),
+            "and with no upgrade on offer the command must exit 0"
         );
     }
 }

--- a/vendor/aube/crates/aube/src/commands/outdated.rs
+++ b/vendor/aube/crates/aube/src/commands/outdated.rs
@@ -191,10 +191,12 @@ fn latest_pick(
         node_semver::Version::parse(current),
     ) else {
         // Either side unparseable means the two are not ordered at all, so leave
-        // the pick alone rather than guess a direction. Reached via `current`,
-        // which is the `(missing)` sentinel when the dep is absent from the
-        // graph — NOT via a git/`file:`/`link:` dep, which the lockfile reader
-        // gives a parseable `0.0.0` (`aube-lockfile/src/pnpm/read.rs`).
+        // the pick alone rather than guess a direction. Two known ways `current`
+        // gets there: the `(missing)` sentinel for a dep absent from the graph,
+        // and a git dep read from an npm v1 lockfile, whose `version` the legacy
+        // lifter carries through verbatim (`aube-lockfile/src/npm/read.rs`).
+        // Not exhaustive — nub reads six lockfile formats and only pnpm's is
+        // known to normalize a local dep to a parseable `0.0.0`.
         return Some(picked);
     };
     Some(if new < cur { current.to_string() } else { picked })

--- a/vendor/aube/crates/aube/src/commands/outdated.rs
+++ b/vendor/aube/crates/aube/src/commands/outdated.rs
@@ -150,7 +150,7 @@ pub(super) fn age_gate_for(cwd: &Path) -> Option<aube_resolver::MinimumReleaseAg
 /// consults a dist-tag — so passing an absent tag through would SYNTHESIZE one
 /// and start flipping the exit code for registries that publish no `latest`.
 /// Nub pins the window on for every project, so that would be the default path.
-fn latest_pick(
+pub(super) fn latest_pick(
     packument: &Packument,
     registry_name: &str,
     gate: Option<&aube_resolver::MinimumReleaseAge>,

--- a/vendor/aube/crates/aube/src/commands/outdated.rs
+++ b/vendor/aube/crates/aube/src/commands/outdated.rs
@@ -170,8 +170,12 @@ fn latest_pick(
     // release old enough to clear the window, so a window wider than the
     // installed version's own age lands below `current` — and the column then
     // advertises an older version as the one to move to, counts as drift, and
-    // pins the exit code at 1 with nothing installable. That is the dead end
-    // #722 was about, reached by a different route.
+    // pins the exit code at 1 with nothing worth installing on offer. That is
+    // the dead end #722 was about, reached by a different route.
+    //
+    // "worth installing" rather than "installable": the lower release IS
+    // reachable — `update --latest` passes the literal `latest` range through
+    // the same widening (`update.rs:634`) and resolves to it.
     //
     // A pick at or below `current` reports `current` instead of dropping to
     // unknown: there genuinely is no upgrade, and saying so is both truer and
@@ -186,8 +190,11 @@ fn latest_pick(
         node_semver::Version::parse(&picked),
         node_semver::Version::parse(current),
     ) else {
-        // Either side unparseable (a git/file resolution) means the two are not
-        // ordered at all, so leave the pick alone rather than guess a direction.
+        // Either side unparseable means the two are not ordered at all, so leave
+        // the pick alone rather than guess a direction. Reached via `current`,
+        // which is the `(missing)` sentinel when the dep is absent from the
+        // graph — NOT via a git/`file:`/`link:` dep, which the lockfile reader
+        // gives a parseable `0.0.0` (`aube-lockfile/src/pnpm/read.rs`).
         return Some(picked);
     };
     Some(if new < cur { current.to_string() } else { picked })

--- a/vendor/aube/crates/aube/src/commands/outdated.rs
+++ b/vendor/aube/crates/aube/src/commands/outdated.rs
@@ -256,6 +256,23 @@ pub(super) fn gated_pick(
     }
 }
 
+/// Announce that a package's registry served no publish times at all, so the
+/// window can admit no version of it and an install hard-errors.
+///
+/// Shared with the interactive pickers, which drop a cell on the same verdict.
+/// Dropping it silently would leave those commands reporting no work on a
+/// package every install refuses — #722's report-versus-installer disagreement,
+/// one surface over — so each caller that discards an `Undeterminable` says so
+/// here instead. Stderr, so stdout stays data.
+pub(super) fn warn_undatable(registry_name: &str) {
+    eprintln!(
+        "warn: {registry_name} has no registry publish times, so \
+         minimumReleaseAge cannot admit any version; \
+         `{}` will fail for it",
+        aube_util::cmd("update")
+    );
+}
+
 /// Serialize `DepType` using pnpm's `package.json` field names so
 /// `outdated --json` is a drop-in match for `pnpm outdated --json`.
 fn serialize_dep_type<S: serde::Serializer>(dt: &DepType, s: S) -> Result<S::Ok, S::Error> {
@@ -718,12 +735,7 @@ async fn collect_rows(
         // `latest` tag reaches that state routinely, and folding it in here
         // told the user an update would fail on a package where it succeeds.
         if wanted_undated && warned.insert(registry_name.clone()) {
-            eprintln!(
-                "warn: {registry_name} has no registry publish times, so \
-                 minimumReleaseAge cannot admit any version; \
-                 `{}` will fail for it",
-                aube_util::cmd("update")
-            );
+            warn_undatable(&registry_name);
         }
 
         let latest_known = latest.is_some();
@@ -1199,6 +1211,43 @@ mod age_gate_tests {
         assert_eq!(
             latest_pick(&p, "pkg", Some(&g), "2.0.0").as_deref(),
             Some("2.0.0")
+        );
+    }
+
+    /// A dist-tag SPECIFIER is gated like any other range.
+    ///
+    /// `"pkg": "beta"` in a manifest does not parse as a range, so the pickers
+    /// keep a dist-tag lookup as the fallback for it. That fallback is the raw
+    /// tag, and it has to stay INSIDE this call: applied to the result instead,
+    /// it hands back the exact version the window just declined, and the
+    /// picker's own screen cannot catch it — that screen compares against the
+    /// installed version, not against the policy.
+    #[test]
+    fn a_dist_tag_specifier_is_gated_and_the_raw_tag_does_not_come_back() {
+        let p: Packument = serde_json::from_value(serde_json::json!({
+            "name": "pkg",
+            "dist-tags": { "latest": "2.0.0", "beta": "2.0.1" },
+            "versions": {
+                "2.0.0": { "name": "pkg", "version": "2.0.0" },
+                "2.0.1": { "name": "pkg", "version": "2.0.1" },
+            },
+            "time": {
+                "2.0.0": "2020-01-01T00:00:00.000Z",
+                "2.0.1": "2099-01-01T00:00:00.000Z",
+            },
+        }))
+        .expect("test packument parses");
+        // Guard the premise: only `latest` widens to `<=<tag>`, so a `beta`
+        // the window blocks refuses outright rather than scanning down to
+        // 2.0.0. Without that this case would be testing the widening.
+        assert!(matches!(
+            aube_resolver::pick_version_for_add(&p, "pkg", "beta", Some(&gate(true))),
+            aube_resolver::PickResult::AgeGated(_)
+        ));
+        assert_eq!(
+            gated_pick(&p, "pkg", "beta", Some(&gate(true)), Some("2.0.1".into())).0,
+            None,
+            "the tag fallback is what the window declined, so it must not survive it"
         );
     }
 

--- a/vendor/aube/crates/aube/src/commands/update.rs
+++ b/vendor/aube/crates/aube/src/commands/update.rs
@@ -430,8 +430,7 @@ pub async fn run(
     // <pkg>@latest` reach the same widened range and downgrade identically, so
     // scoping the guard to whole-project `--latest` left two of the three
     // latest-targeting paths unprotected.
-    let preserve_pin: BTreeSet<String> = if (latest || !explicit_specs.is_empty()) && !rich_picker
-    {
+    let preserve_pin: BTreeSet<String> = if (latest || !explicit_specs.is_empty()) && !rich_picker {
         let client = std::sync::Arc::new(super::make_client(&cwd));
         // The release-age window is checked against per-version publish times,
         // which the abbreviated packument does not carry — so a project with a
@@ -528,7 +527,10 @@ pub async fn run(
                 let gated_below = want_time
                     && age_gate.as_ref().is_some_and(|g| {
                         match aube_resolver::pick_version_for_add(
-                            &packument, &real_name, "latest", Some(g),
+                            &packument,
+                            &real_name,
+                            "latest",
+                            Some(g),
                         ) {
                             aube_resolver::PickResult::Found(m) => {
                                 node_semver::Version::parse(&m.version).is_ok_and(|picked| {
@@ -1347,6 +1349,7 @@ async fn pick_update_interactively(
     }
 
     let packuments = fetch_packuments(&registry_keys, specifiers, cwd).await?;
+    let gate = super::outdated::age_gate_for(cwd);
 
     let mut picker = demand::MultiSelect::new("Choose which dependencies to update")
         .description("Space to toggle, Enter to confirm")
@@ -1364,8 +1367,28 @@ async fn pick_update_interactively(
         let current = existing
             .and_then(|g| lookup_pkg(g, existing_importers, key, &real_name))
             .map(|p| p.version.as_str());
-        let registry_latest = packument.dist_tags.get("latest").map(String::as_str);
-        let wanted = super::wanted_version(packument, spec).or_else(|| current.map(str::to_owned));
+        // Same floor as the rich picker: offer what an install would land on,
+        // not the raw tag, so a release-age window cannot present a cell that
+        // resolves BELOW the installed version once selected. A dep with no
+        // current version has nothing to floor against, and the empty string
+        // fails to parse as semver, so the pick passes through unclamped.
+        let gated_latest = super::outdated::latest_pick(
+            packument,
+            &real_name,
+            gate.as_ref(),
+            current.unwrap_or_default(),
+        );
+        let registry_latest = gated_latest.as_deref();
+        // Gated for the same reason as the rich picker's in-range cell above.
+        let wanted = super::outdated::gated_pick(
+            packument,
+            &real_name,
+            spec,
+            gate.as_ref(),
+            super::wanted_version(packument, spec),
+        )
+        .0
+        .or_else(|| current.map(str::to_owned));
         // `--latest` rewrites past the manifest range, so the picker
         // shows the dist-tag latest as the target. Without `--latest`
         // we only refresh inside the range, so target = wanted.
@@ -1531,8 +1554,21 @@ async fn pick_update_rich(
             .or_else(|| specifiers.get(key.as_str()))
             .map(String::as_str)
             .unwrap_or("");
-        let wanted = super::wanted_version(packument, spec)
-            .or_else(|| packument.dist_tags.get(spec).cloned());
+        // The in-range cell is gated for the same reason the `latest` cell is,
+        // and skipping it leaves a bypass rather than a cosmetic gap: when the
+        // gated `latest` is filtered out, `build_row` falls back to THIS value
+        // for the latest cell, and selecting a latest cell that duplicates the
+        // range cell is classified `in_range` — which resolves the raw manifest
+        // range and can land below `current`.
+        let wanted = super::outdated::gated_pick(
+            packument,
+            &real_name,
+            spec,
+            gate.as_ref(),
+            super::wanted_version(packument, spec),
+        )
+        .0
+        .or_else(|| packument.dist_tags.get(spec).cloned());
         // The `latest` cell offers what an install would actually land on, not
         // the raw dist-tag. `build_row` drops a cell at-or-below `current`, but
         // it can only do that against the version it is GIVEN — handed the raw
@@ -1540,7 +1576,8 @@ async fn pick_update_rich(
         // whose gated pick sits below `current` then installs a downgrade once
         // the cell is selected. Same floor as the report's column and the
         // non-interactive guard above.
-        let gated_latest = super::outdated::latest_pick(packument, &real_name, gate.as_ref(), &current);
+        let gated_latest =
+            super::outdated::latest_pick(packument, &real_name, gate.as_ref(), &current);
         let registry_latest = gated_latest.as_deref();
         // The displayed spec is always the MANIFEST's (the dim annotation
         // answers "what does package.json say today"), even when an

--- a/vendor/aube/crates/aube/src/commands/update.rs
+++ b/vendor/aube/crates/aube/src/commands/update.rs
@@ -1355,6 +1355,7 @@ async fn pick_update_interactively(
         .description("Space to toggle, Enter to confirm")
         .filterable(true);
     let mut shown = 0usize;
+    let mut warned = std::collections::HashSet::new();
     for key in &registry_keys {
         let spec = specifiers
             .get(key.as_str())
@@ -1380,15 +1381,22 @@ async fn pick_update_interactively(
         );
         let registry_latest = gated_latest.as_deref();
         // Gated for the same reason as the rich picker's in-range cell above.
-        let wanted = super::outdated::gated_pick(
+        // The fallback is the `ungated` argument rather than an `or_else` on
+        // the result: a refusal must stay refused, and an `or_else` outside
+        // would hand the cell back the very value the window declined.
+        let (wanted, wanted_undated) = super::outdated::gated_pick(
             packument,
             &real_name,
             spec,
             gate.as_ref(),
-            super::wanted_version(packument, spec),
-        )
-        .0
-        .or_else(|| current.map(str::to_owned));
+            super::wanted_version(packument, spec).or_else(|| current.map(str::to_owned)),
+        );
+        // The registry dated nothing in range, so no version is installable and
+        // the cell is gone. Say so rather than let the package drop out of the
+        // list looking current — same warning, same reason, as the report.
+        if wanted_undated && warned.insert(real_name.clone()) {
+            super::outdated::warn_undatable(&real_name);
+        }
         // `--latest` rewrites past the manifest range, so the picker
         // shows the dist-tag latest as the target. Without `--latest`
         // we only refresh inside the range, so target = wanted.
@@ -1531,6 +1539,7 @@ async fn pick_update_rich(
     let packuments = fetch_packuments(&registry_keys, specifiers, cwd).await?;
     let gate = super::outdated::age_gate_for(cwd);
     let mut rows = Vec::new();
+    let mut warned = std::collections::HashSet::new();
     for key in &registry_keys {
         let Some(packument) = packuments.get(key.as_str()) else {
             continue;
@@ -1560,15 +1569,27 @@ async fn pick_update_rich(
         // for the latest cell, and selecting a latest cell that duplicates the
         // range cell is classified `in_range` — which resolves the raw manifest
         // range and can land below `current`.
-        let wanted = super::outdated::gated_pick(
+        //
+        // The dist-tag fallback for a tag spec is the `ungated` argument, not
+        // an `or_else` on the result. Outside, it would hand back the RAW tag
+        // the window had just declined — the one input `build_row` cannot
+        // screen, since it screens against `current` rather than against the
+        // policy.
+        let (wanted, wanted_undated) = super::outdated::gated_pick(
             packument,
             &real_name,
             spec,
             gate.as_ref(),
-            super::wanted_version(packument, spec),
-        )
-        .0
-        .or_else(|| packument.dist_tags.get(spec).cloned());
+            super::wanted_version(packument, spec)
+                .or_else(|| packument.dist_tags.get(spec).cloned()),
+        );
+        // No version of this package is installable at all, so both cells go
+        // and the row disappears. The report warns rather than print `All
+        // dependencies up to date.` over a project every install refuses; the
+        // picker owes the same, for the same reason.
+        if wanted_undated && warned.insert(real_name.clone()) {
+            super::outdated::warn_undatable(&real_name);
+        }
         // The `latest` cell offers what an install would actually land on, not
         // the raw dist-tag. `build_row` drops a cell at-or-below `current`, but
         // it can only do that against the version it is GIVEN — handed the raw

--- a/vendor/aube/crates/aube/src/commands/update.rs
+++ b/vendor/aube/crates/aube/src/commands/update.rs
@@ -117,6 +117,28 @@ pub struct UpdateArgs {
     pub virtual_store: crate::cli_args::VirtualStoreArgs,
 }
 
+/// Whether an update must KEEP the version already pinned, rather than move to
+/// `candidate`.
+///
+/// Both `--latest` downgrade guards reduce to this one comparison; only the
+/// candidate differs. Against the registry's `latest` dist-tag it preserves a
+/// prerelease pin the publisher has moved below. Against the release-age
+/// window's own `latest` pick it preserves an installed version the window
+/// would otherwise walk backwards from (#722) — that pick comes from a range
+/// widened to `<=<tag>` and scanned DOWNWARD, so it can land below what is
+/// installed.
+///
+/// Either pin outranking the candidate is enough: the manifest may carry an
+/// exact pin, the lockfile a resolved version, and neither is authoritative
+/// over the other for this purpose.
+fn pin_outranks(
+    manifest_pin: Option<&node_semver::Version>,
+    locked_pin: Option<&node_semver::Version>,
+    candidate: &node_semver::Version,
+) -> bool {
+    manifest_pin.is_some_and(|v| v > candidate) || locked_pin.is_some_and(|v| v > candidate)
+}
+
 pub async fn run(
     args: UpdateArgs,
     mut filter: aube_workspace::selector::EffectiveFilter,
@@ -403,8 +425,20 @@ pub async fn run(
     // cell at-or-below `current`), so a "latest" pick can never name a
     // preserve-pin key and the pre-fetch here would be a redundant network
     // round.
-    let preserve_pin: BTreeSet<String> = if latest && update_all && !rich_picker {
+    //
+    // NOT gated on `update_all`: `update <pkg> --latest` and `update
+    // <pkg>@latest` reach the same widened range and downgrade identically, so
+    // scoping the guard to whole-project `--latest` left two of the three
+    // latest-targeting paths unprotected.
+    let preserve_pin: BTreeSet<String> = if (latest || !explicit_specs.is_empty()) && !rich_picker
+    {
         let client = std::sync::Arc::new(super::make_client(&cwd));
+        // The release-age window is checked against per-version publish times,
+        // which the abbreviated packument does not carry — so a project with a
+        // window in effect needs the full document here, exactly as `outdated`
+        // does. `None` means no window and the age arm below is skipped.
+        let age_gate = super::outdated::age_gate_for(&cwd);
+        let full_cache_dir = super::packument_full_cache_dir_for_cwd(&cwd);
         let mut handles = Vec::new();
         for key in &manifest_keys_to_update {
             let original = all_specifiers.get(key).map(String::as_str).unwrap_or("");
@@ -424,8 +458,16 @@ pub async fn run(
             if manifest_pin.is_none() && locked_pin.is_none() {
                 continue;
             }
+            // Only a `latest`-derived target gets the age floor. An explicit
+            // `<pkg>@<version>` is a deliberate pin the user typed — downgrade
+            // included — and must still be honored.
+            let targets_latest = explicit_specs
+                .get(key)
+                .map_or(latest, |spec| spec == "latest");
             let key_owned = key.clone();
             let client = client.clone();
+            let age_gate = age_gate.clone();
+            let full_cache_dir = full_cache_dir.clone();
             handles.push(tokio::spawn(async move {
                 // A fetch failure here would silently fall through to the
                 // rewrite path and downgrade the prerelease pin — exactly
@@ -434,7 +476,15 @@ pub async fn run(
                 // transient registry failure that broke the guard, then
                 // continue with the resolver path (which has its own
                 // retry/cache semantics and may still succeed).
-                let packument = match client.fetch_packument(&real_name).await {
+                let want_time = age_gate.is_some() && targets_latest;
+                let fetched = if want_time {
+                    client
+                        .fetch_packument_with_time_cached(&real_name, &full_cache_dir)
+                        .await
+                } else {
+                    client.fetch_packument(&real_name).await
+                };
+                let packument = match fetched {
                     Ok(p) => p,
                     Err(e) => {
                         tracing::warn!(
@@ -453,9 +503,39 @@ pub async fn run(
                     );
                     return None;
                 };
-                let above_latest = manifest_pin.as_ref().is_some_and(|v| v > &parsed_latest)
-                    || locked_pin.as_ref().is_some_and(|v| v > &parsed_latest);
-                above_latest.then_some(key_owned)
+                let above_latest =
+                    pin_outranks(manifest_pin.as_ref(), locked_pin.as_ref(), &parsed_latest);
+
+                // A blocked `latest` tag widens to `<=<tag>` and the scan walks
+                // DOWNWARD for a release old enough to clear the window (#681).
+                // With a window wider than the installed version's own age that
+                // lands BELOW it, and the rewrite path would then install the
+                // downgrade — silently, and rewriting package.json with it.
+                // Preserve the pin instead, matching what the interactive picker
+                // already does per-cell (`update_picker::build_row` drops a
+                // `latest` cell at-or-below `current`) and what the report now
+                // shows (`outdated::latest_pick`).
+                let gated_below = want_time
+                    && age_gate.as_ref().is_some_and(|g| {
+                        match aube_resolver::pick_version_for_add(
+                            &packument, &real_name, "latest", Some(g),
+                        ) {
+                            aube_resolver::PickResult::Found(m) => {
+                                node_semver::Version::parse(&m.version).is_ok_and(|picked| {
+                                    pin_outranks(
+                                        manifest_pin.as_ref(),
+                                        locked_pin.as_ref(),
+                                        &picked,
+                                    )
+                                })
+                            }
+                            // A refusal installs nothing, so there is no
+                            // downgrade to guard against here.
+                            _ => false,
+                        }
+                    });
+
+                (above_latest || gated_below).then_some(key_owned)
             }));
         }
         let mut set = BTreeSet::new();
@@ -2643,6 +2723,48 @@ mod tests {
             assert!(
                 reject_unsupported_pkg_specs(&[bad.to_string()]).is_err(),
                 "{bad} should be rejected"
+            );
+        }
+    }
+    /// The `--latest` downgrade guard (#722).
+    ///
+    /// A release-age window wider than the installed version's own age drives
+    /// the gated `latest` pick BELOW what is installed, because the widened
+    /// `<=<tag>` range is scanned downward for something old enough to clear.
+    /// Preserving the pin is what stops `update --latest` installing that.
+    mod pin_outranks_tests {
+        use super::super::pin_outranks;
+
+        fn v(s: &str) -> node_semver::Version {
+            node_semver::Version::parse(s).expect("test version parses")
+        }
+
+        #[test]
+        fn a_candidate_below_either_pin_preserves_it() {
+            // Manifest pin alone.
+            assert!(pin_outranks(Some(&v("2.5.7")), None, &v("2.5.5")));
+            // Locked version alone — the #722 shape, where the manifest holds a
+            // range rather than an exact pin.
+            assert!(pin_outranks(None, Some(&v("2.5.7")), &v("2.5.5")));
+        }
+
+        #[test]
+        fn a_candidate_at_or_above_both_pins_is_taken() {
+            assert!(
+                !pin_outranks(Some(&v("2.5.7")), Some(&v("2.5.7")), &v("2.5.11")),
+                "a genuine upgrade must not be preserved away"
+            );
+            assert!(
+                !pin_outranks(Some(&v("2.5.7")), Some(&v("2.5.7")), &v("2.5.7")),
+                "equal is not a downgrade, so there is nothing to guard"
+            );
+        }
+
+        #[test]
+        fn no_pin_at_all_never_preserves() {
+            assert!(
+                !pin_outranks(None, None, &v("0.0.1")),
+                "nothing is installed to protect, so any candidate stands"
             );
         }
     }

--- a/vendor/aube/crates/aube/src/commands/update.rs
+++ b/vendor/aube/crates/aube/src/commands/update.rs
@@ -458,12 +458,22 @@ pub async fn run(
             if manifest_pin.is_none() && locked_pin.is_none() {
                 continue;
             }
-            // Only a `latest`-derived target gets the age floor. An explicit
-            // `<pkg>@<version>` is a deliberate pin the user typed — downgrade
-            // included — and must still be honored.
+            // Only a `latest`-derived target belongs in this guard at all. An
+            // explicit `<pkg>@<version>` is a deliberate pin the user typed —
+            // downgrade included — and must resolve as typed.
+            //
+            // This SKIPS the key rather than just gating the age arm: both
+            // guards here are latest-derived, so letting an explicit target
+            // reach the prerelease arm would preserve the pin and silently
+            // ignore the version asked for. Broadening the outer condition to
+            // cover `<pkg>@latest` is what first exposed a key with an
+            // explicit spec to this block.
             let targets_latest = explicit_specs
                 .get(key)
                 .map_or(latest, |spec| spec == "latest");
+            if !targets_latest {
+                continue;
+            }
             let key_owned = key.clone();
             let client = client.clone();
             let age_gate = age_gate.clone();
@@ -476,7 +486,7 @@ pub async fn run(
                 // transient registry failure that broke the guard, then
                 // continue with the resolver path (which has its own
                 // retry/cache semantics and may still succeed).
-                let want_time = age_gate.is_some() && targets_latest;
+                let want_time = age_gate.is_some();
                 let fetched = if want_time {
                     client
                         .fetch_packument_with_time_cached(&real_name, &full_cache_dir)
@@ -1409,14 +1419,27 @@ async fn fetch_packuments(
 ) -> miette::Result<HashMap<String, aube_registry::Packument>> {
     let client = std::sync::Arc::new(super::make_client(cwd));
     let cache_dir = super::packument_cache_dir();
+    // A release-age window is checked against per-version publish times, which
+    // the abbreviated packument does not carry. Callers that gate a pick off
+    // these documents need the full one, same as `outdated`; without it a
+    // gated pick here silently degrades to the ungated answer.
+    let needs_time = super::outdated::age_gate_for(cwd).is_some();
+    let full_cache_dir = super::packument_full_cache_dir_for_cwd(cwd);
     let mut set = tokio::task::JoinSet::new();
     for key in registry_keys {
         let real_name = real_name_from_spec(key, specifiers.get(key.as_str()));
         let key_owned = (*key).clone();
         let client = client.clone();
         let cache_dir = cache_dir.clone();
+        let full_cache_dir = full_cache_dir.clone();
         set.spawn(async move {
-            let result = client.fetch_packument_cached(&real_name, &cache_dir).await;
+            let result = if needs_time {
+                client
+                    .fetch_packument_with_time_cached(&real_name, &full_cache_dir)
+                    .await
+            } else {
+                client.fetch_packument_cached(&real_name, &cache_dir).await
+            };
             (key_owned, result)
         });
     }
@@ -1483,6 +1506,7 @@ async fn pick_update_rich(
     }
 
     let packuments = fetch_packuments(&registry_keys, specifiers, cwd).await?;
+    let gate = super::outdated::age_gate_for(cwd);
     let mut rows = Vec::new();
     for key in &registry_keys {
         let Some(packument) = packuments.get(key.as_str()) else {
@@ -1509,7 +1533,15 @@ async fn pick_update_rich(
             .unwrap_or("");
         let wanted = super::wanted_version(packument, spec)
             .or_else(|| packument.dist_tags.get(spec).cloned());
-        let registry_latest = packument.dist_tags.get("latest").map(String::as_str);
+        // The `latest` cell offers what an install would actually land on, not
+        // the raw dist-tag. `build_row` drops a cell at-or-below `current`, but
+        // it can only do that against the version it is GIVEN — handed the raw
+        // tag it screens a version the resolver will never pick, and a window
+        // whose gated pick sits below `current` then installs a downgrade once
+        // the cell is selected. Same floor as the report's column and the
+        // non-interactive guard above.
+        let gated_latest = super::outdated::latest_pick(packument, &real_name, gate.as_ref(), &current);
+        let registry_latest = gated_latest.as_deref();
         // The displayed spec is always the MANIFEST's (the dim annotation
         // answers "what does package.json say today"), even when an
         // explicit CLI spec drives the targets.


### PR DESCRIPTION
A blocked `latest` tag widens to `<=<tag>` and the scan walks downward for a release old enough to clear the window (#681). A window wider than the installed version's own age lands below it.

`outdated` named that older release as the version to move to — drift, exit 1, no upgrade available. `update --latest` went further and installed it, rewriting `package.json`, on all three latest-targeting paths.

Both now floor at the installed version. `preserve_pin` was gated on `update_all` and compared against the raw ungated dist-tag, so it missed every case. An explicit `<pkg>@<version>` is still honored as typed.

Both interactive pickers take the same floor. They screened the raw dist-tag, and dropping a gated `latest` fell back to the in-range cell, which resolved the raw manifest range — so each cell now comes from the same picker the report uses. Those two paths need a TTY and are covered by unit test rather than end to end.

Verified across four non-interactive paths plus controls for a deliberate pin, a narrower window, and the gate off.

Refs #722