### PR TITLE
ci: probe the Windows node-24 worker test on current main (not for merge)

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -4385,6 +4385,7 @@ fn worker_error_listener_capture_identity_not_a_false_fatality() {
 
 #[test]
 fn worker_without_inbound_listener_exits_naturally() {
+    // CI probe (#825): re-running this test on a stable matrix off main's tip.
     // Regression (worker-polyfill delegation — worker-polyfill.md §4): the worker
     // scope once held a persistent `parentPort.on("message")` forwarder, keeping
     // every worker's event loop alive — a pure `node:worker_threads` worker that


### PR DESCRIPTION
Empty commit on main's tip to get a stable full-matrix run: main's run 33447462117 failed `worker_without_inbound_listener_exits_naturally` (worker-hung) on windows-latest/node 24, and every rerun since was cancelled by the next push to main. #812's own head passed the same leg. Green here = flake; red = regression in today's landings.