### PR TITLE
compile: find the strip tool by its Windows spelling

### DIFF
--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -1899,28 +1899,17 @@ impl Drop for FileGuard {
     }
 }
 
-/// Returns the file that was actually found, not the name that was searched for.
-/// Spawning the matched path is what keeps the tool this probe proved exists and
-/// the tool that later runs the same one — resolving the name a second time at
-/// spawn could pick a different PATH entry or a different PATHEXT extension.
+/// The first of `names` on PATH, as the matched path — which is what gets spawned,
+/// so discovery and execution cannot disagree.
 ///
-/// The extension is why this exists at all: on Windows the strippers ship as
-/// `llvm-strip.exe`, so the old bare `dir.join("llvm-strip")` matched nothing,
-/// every candidate list missed, and `prepare_node_bytes` took its unstripped
-/// early return on every compile run on a Windows host.
+/// Thin on purpose: the lookup lives in nub-core because the launcher needs the
+/// same one, and because nub-core's tests run on every OS leg while the
+/// compile-feature tests run only on Ubuntu. The rule it carries is that on
+/// Windows the strippers are on disk as `llvm-strip.exe`, so a bare
+/// `dir.join("llvm-strip")` matched nothing and `prepare_node_bytes` took its
+/// unstripped early return on every compile run on a Windows host.
 fn which_first(names: &[&str]) -> Option<PathBuf> {
-    let path = std::env::var_os("PATH")?;
-    for name in names {
-        for dir in std::env::split_paths(&path) {
-            if let Some(found) = nub_core::command_candidates(&dir, name)
-                .into_iter()
-                .find(|p| p.is_file())
-            {
-                return Some(found);
-            }
-        }
-    }
-    None
+    nub_core::find_on_path(names)
 }
 
 fn run_ok(program: impl AsRef<std::ffi::OsStr>, args: &[&std::ffi::OsStr]) -> bool {
@@ -1984,39 +1973,6 @@ mod tests {
         let _ = fs::remove_dir_all(&d);
         fs::create_dir_all(&d).unwrap();
         d
-    }
-
-    /// The strip probe finds a tool spelled the way the host actually ships it —
-    /// `llvm-strip.exe` on Windows, `llvm-strip` elsewhere — and hands back the
-    /// file it found, so the tool proved to exist is the tool that runs. Missing
-    /// it is not a hard failure but a silent one: `prepare_node_bytes` warns and
-    /// embeds the Node unstripped, costing every artifact built on that host
-    /// ~4 MB.
-    #[test]
-    fn the_strip_probe_finds_the_hosts_own_spelling() {
-        let dir = fresh_dir("which-first");
-        let spelled = if cfg!(windows) {
-            "llvm-strip.exe"
-        } else {
-            "llvm-strip"
-        };
-        fs::write(dir.join(spelled), b"").unwrap();
-
-        let found = nub_core::command_candidates(&dir, "llvm-strip")
-            .into_iter()
-            .find(|p| p.is_file())
-            .expect("a bare `llvm-strip` must match the host's own spelling on disk");
-        assert_eq!(
-            found,
-            dir.join(spelled),
-            "the probe must hand back the file it matched, since that is what gets spawned"
-        );
-        assert!(
-            !nub_core::command_candidates(&dir, "definitely-not-a-stripper")
-                .into_iter()
-                .any(|p| p.is_file()),
-            "the probe matched a tool that is not present"
-        );
     }
 
     /// Only the two path-length codes may divert the probe to a copy. The

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -1899,16 +1899,40 @@ impl Drop for FileGuard {
     }
 }
 
+/// Returns the bare name, which is what `Command::new` wants: the spawn does its
+/// own `PATH` search, so only this existence probe has to know about extensions.
+/// It has to know on Windows, where the tools ship as `llvm-strip.exe` and a bare
+/// `dir.join("llvm-strip")` matches nothing — every candidate list missed, and
+/// `prepare_node_bytes` took its unstripped early return on every Windows-host
+/// compile.
 fn which_first(names: &[&str]) -> Option<String> {
     let path = std::env::var_os("PATH")?;
     for name in names {
         for dir in std::env::split_paths(&path) {
-            if dir.join(name).is_file() {
+            if command_candidates(&dir, name).iter().any(|p| p.is_file()) {
                 return Some(name.to_string());
             }
         }
     }
     None
+}
+
+#[cfg(windows)]
+fn command_candidates(dir: &Path, name: &str) -> Vec<PathBuf> {
+    if Path::new(name).extension().is_some() {
+        return vec![dir.join(name)];
+    }
+    let extensions = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".into());
+    extensions
+        .split(';')
+        .filter(|extension| !extension.is_empty())
+        .map(|extension| dir.join(format!("{name}{extension}")))
+        .collect()
+}
+
+#[cfg(not(windows))]
+fn command_candidates(dir: &Path, name: &str) -> Vec<PathBuf> {
+    vec![dir.join(name)]
 }
 
 fn run_ok(program: &str, args: &[&std::ffi::OsStr]) -> bool {
@@ -1972,6 +1996,35 @@ mod tests {
         let _ = fs::remove_dir_all(&d);
         fs::create_dir_all(&d).unwrap();
         d
+    }
+
+    /// The strip probe finds a tool spelled the way the host actually ships it —
+    /// `llvm-strip.exe` on Windows, `llvm-strip` elsewhere. Missing it is not a
+    /// hard failure but a silent one: `prepare_node_bytes` warns and embeds the
+    /// Node unstripped, costing every artifact built on that host ~4 MB.
+    #[test]
+    fn the_strip_probe_finds_the_hosts_own_spelling() {
+        let dir = fresh_dir("which-first");
+        let name = if cfg!(windows) {
+            "llvm-strip.exe"
+        } else {
+            "llvm-strip"
+        };
+        fs::write(dir.join(name), b"").unwrap();
+
+        assert!(
+            command_candidates(&dir, "llvm-strip")
+                .iter()
+                .any(|p| p.is_file()),
+            "no candidate for `llvm-strip` matched {name}; candidates were {:?}",
+            command_candidates(&dir, "llvm-strip")
+        );
+        assert!(
+            !command_candidates(&dir, "definitely-not-a-stripper")
+                .iter()
+                .any(|p| p.is_file()),
+            "the probe matched a tool that is not present"
+        );
     }
 
     /// Only the two path-length codes may divert the probe to a copy. The

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -1899,43 +1899,31 @@ impl Drop for FileGuard {
     }
 }
 
-/// Returns the bare name, which is what `Command::new` wants: the spawn does its
-/// own `PATH` search, so only this existence probe has to know about extensions.
-/// It has to know on Windows, where the tools ship as `llvm-strip.exe` and a bare
-/// `dir.join("llvm-strip")` matches nothing — every candidate list missed, and
-/// `prepare_node_bytes` took its unstripped early return on every Windows-host
-/// compile.
-fn which_first(names: &[&str]) -> Option<String> {
+/// Returns the file that was actually found, not the name that was searched for.
+/// Spawning the matched path is what keeps the tool this probe proved exists and
+/// the tool that later runs the same one — resolving the name a second time at
+/// spawn could pick a different PATH entry or a different PATHEXT extension.
+///
+/// The extension is why this exists at all: on Windows the strippers ship as
+/// `llvm-strip.exe`, so the old bare `dir.join("llvm-strip")` matched nothing,
+/// every candidate list missed, and `prepare_node_bytes` took its unstripped
+/// early return on every compile run on a Windows host.
+fn which_first(names: &[&str]) -> Option<PathBuf> {
     let path = std::env::var_os("PATH")?;
     for name in names {
         for dir in std::env::split_paths(&path) {
-            if command_candidates(&dir, name).iter().any(|p| p.is_file()) {
-                return Some(name.to_string());
+            if let Some(found) = nub_core::command_candidates(&dir, name)
+                .into_iter()
+                .find(|p| p.is_file())
+            {
+                return Some(found);
             }
         }
     }
     None
 }
 
-#[cfg(windows)]
-fn command_candidates(dir: &Path, name: &str) -> Vec<PathBuf> {
-    if Path::new(name).extension().is_some() {
-        return vec![dir.join(name)];
-    }
-    let extensions = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".into());
-    extensions
-        .split(';')
-        .filter(|extension| !extension.is_empty())
-        .map(|extension| dir.join(format!("{name}{extension}")))
-        .collect()
-}
-
-#[cfg(not(windows))]
-fn command_candidates(dir: &Path, name: &str) -> Vec<PathBuf> {
-    vec![dir.join(name)]
-}
-
-fn run_ok(program: &str, args: &[&std::ffi::OsStr]) -> bool {
+fn run_ok(program: impl AsRef<std::ffi::OsStr>, args: &[&std::ffi::OsStr]) -> bool {
     std::process::Command::new(program)
         .args(args)
         .stdout(std::process::Stdio::null())
@@ -1999,29 +1987,33 @@ mod tests {
     }
 
     /// The strip probe finds a tool spelled the way the host actually ships it —
-    /// `llvm-strip.exe` on Windows, `llvm-strip` elsewhere. Missing it is not a
-    /// hard failure but a silent one: `prepare_node_bytes` warns and embeds the
-    /// Node unstripped, costing every artifact built on that host ~4 MB.
+    /// `llvm-strip.exe` on Windows, `llvm-strip` elsewhere — and hands back the
+    /// file it found, so the tool proved to exist is the tool that runs. Missing
+    /// it is not a hard failure but a silent one: `prepare_node_bytes` warns and
+    /// embeds the Node unstripped, costing every artifact built on that host
+    /// ~4 MB.
     #[test]
     fn the_strip_probe_finds_the_hosts_own_spelling() {
         let dir = fresh_dir("which-first");
-        let name = if cfg!(windows) {
+        let spelled = if cfg!(windows) {
             "llvm-strip.exe"
         } else {
             "llvm-strip"
         };
-        fs::write(dir.join(name), b"").unwrap();
+        fs::write(dir.join(spelled), b"").unwrap();
 
-        assert!(
-            command_candidates(&dir, "llvm-strip")
-                .iter()
-                .any(|p| p.is_file()),
-            "no candidate for `llvm-strip` matched {name}; candidates were {:?}",
-            command_candidates(&dir, "llvm-strip")
+        let found = nub_core::command_candidates(&dir, "llvm-strip")
+            .into_iter()
+            .find(|p| p.is_file())
+            .expect("a bare `llvm-strip` must match the host's own spelling on disk");
+        assert_eq!(
+            found,
+            dir.join(spelled),
+            "the probe must hand back the file it matched, since that is what gets spawned"
         );
         assert!(
-            !command_candidates(&dir, "definitely-not-a-stripper")
-                .iter()
+            !nub_core::command_candidates(&dir, "definitely-not-a-stripper")
+                .into_iter()
                 .any(|p| p.is_file()),
             "the probe matched a tool that is not present"
         );

--- a/crates/nub-core/src/lib.rs
+++ b/crates/nub-core/src/lib.rs
@@ -23,6 +23,34 @@ pub mod workspace;
 /// handful of sites that build a PATH by concatenation.
 pub const PATH_LIST_SEPARATOR: &str = if cfg!(windows) { ";" } else { ":" };
 
+/// The filenames a bare command name can take inside one PATH directory. On
+/// Windows a tool is spelled with an extension on disk — `llvm-strip.exe` — so a
+/// probe for `dir.join(name)` there matches nothing and its caller silently
+/// concludes the tool is absent. Every such probe goes through here so the
+/// PATHEXT rule is written once: the launcher's Node discovery and the
+/// compiler's strip lookup previously carried separate copies of it.
+///
+/// A name that already carries an extension is taken as spelled.
+#[cfg(windows)]
+pub fn command_candidates(dir: &std::path::Path, name: &str) -> Vec<std::path::PathBuf> {
+    if std::path::Path::new(name).extension().is_some() {
+        return vec![dir.join(name)];
+    }
+    let extensions = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".into());
+    extensions
+        .split(';')
+        .filter(|extension| !extension.is_empty())
+        .map(|extension| dir.join(format!("{name}{extension}")))
+        .collect()
+}
+
+/// See the Windows counterpart. Elsewhere a command is spelled on disk exactly as
+/// it is invoked, so there is one candidate.
+#[cfg(not(windows))]
+pub fn command_candidates(dir: &std::path::Path, name: &str) -> Vec<std::path::PathBuf> {
+    vec![dir.join(name)]
+}
+
 /// Strip a leading UTF-8 BOM (U+FEFF, bytes `EF BB BF`) so `serde_json` accepts
 /// the document. Windows PowerShell 5.1 / .NET `Encoding.UTF8` and many Windows
 /// editors write `package.json` with a BOM; npm/pnpm tolerate it, `serde_json`

--- a/crates/nub-core/src/lib.rs
+++ b/crates/nub-core/src/lib.rs
@@ -133,6 +133,33 @@ mod tests {
         path
     }
 
+    /// Asserts the probe resolved to `expected`, ignoring extension case.
+    ///
+    /// The candidate is built from the PATHEXT entry, and Windows spells that
+    /// `.EXE` while the file on disk is `llvm-strip.exe`. Both name the same file
+    /// on a case-insensitive filesystem and both spawn, so requiring byte
+    /// equality would be asserting an incidental property of PATHEXT rather than
+    /// the contract, which is that the probe finds the right FILE and hands back
+    /// something runnable. A probe that finds nothing still fails this.
+    fn assert_resolved(found: Option<PathBuf>, expected: &std::path::Path) {
+        let found = found.unwrap_or_else(|| {
+            panic!(
+                "expected the probe to resolve {}, got None",
+                expected.display()
+            )
+        });
+        assert!(
+            found.is_file(),
+            "the probe returned {}, which is not a file",
+            found.display()
+        );
+        assert_eq!(
+            found.to_string_lossy().to_lowercase(),
+            expected.to_string_lossy().to_lowercase(),
+            "the probe resolved to the wrong file"
+        );
+    }
+
     fn scratch(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
             "nub-core-path-{tag}-{}-{:?}",
@@ -161,11 +188,7 @@ mod tests {
         let expected = put_tool(&dir, spelled);
 
         let path = std::env::join_paths([&dir]).unwrap();
-        assert_eq!(
-            find_on_path_in(Some(&path), &["llvm-strip"]).as_ref(),
-            Some(&expected),
-            "a bare name must find the host's own spelling, and hand back that file"
-        );
+        assert_resolved(find_on_path_in(Some(&path), &["llvm-strip"]), &expected);
         assert_eq!(
             find_on_path_in(Some(&path), &["definitely-not-a-stripper"]),
             None,
@@ -191,10 +214,10 @@ mod tests {
         );
 
         let path = std::env::join_paths([&first, &second]).unwrap();
-        assert_eq!(
-            find_on_path_in(Some(&path), &["llvm-strip", "strip"]).as_ref(),
-            Some(&preferred),
-            "search is name-major: the preferred tool wins from a later PATH entry"
+        // Name-major: the preferred tool wins from a later PATH entry.
+        assert_resolved(
+            find_on_path_in(Some(&path), &["llvm-strip", "strip"]),
+            &preferred,
         );
     }
 

--- a/crates/nub-core/src/lib.rs
+++ b/crates/nub-core/src/lib.rs
@@ -30,16 +30,22 @@ pub const PATH_LIST_SEPARATOR: &str = if cfg!(windows) { ";" } else { ":" };
 /// PATHEXT rule is written once: the launcher's Node discovery and the
 /// compiler's strip lookup previously carried separate copies of it.
 ///
-/// A name that already carries an extension is taken as spelled.
+/// Only the extensions `CreateProcessW` can launch as an image are offered, which
+/// is narrower than PATHEXT. A `.BAT`/`.CMD` needs `cmd.exe` to interpret it, so
+/// admitting one would hand a caller a path it cannot spawn — the launcher's
+/// discovery states the same rule for its own reason: a candidate that would fail
+/// at spawn must lose to the next one rather than be selected. A name that already
+/// carries an extension is taken as spelled, and it is the caller's business
+/// whether that spelling runs.
 #[cfg(windows)]
 pub fn command_candidates(dir: &std::path::Path, name: &str) -> Vec<std::path::PathBuf> {
     if std::path::Path::new(name).extension().is_some() {
         return vec![dir.join(name)];
     }
-    let extensions = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".into());
-    extensions
+    let configured = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE".into());
+    configured
         .split(';')
-        .filter(|extension| !extension.is_empty())
+        .filter(|extension| matches!(extension.to_ascii_uppercase().as_str(), ".EXE" | ".COM"))
         .map(|extension| dir.join(format!("{name}{extension}")))
         .collect()
 }
@@ -49,6 +55,53 @@ pub fn command_candidates(dir: &std::path::Path, name: &str) -> Vec<std::path::P
 #[cfg(not(windows))]
 pub fn command_candidates(dir: &std::path::Path, name: &str) -> Vec<std::path::PathBuf> {
     vec![dir.join(name)]
+}
+
+/// Whether a candidate is a file this process could actually execute. On Unix a
+/// present-but-non-executable file is not a usable tool, and letting it win would
+/// turn a clean "not found" into a spawn failure further along.
+fn is_executable_file(path: &std::path::Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+    }
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
+}
+
+/// The first of `names` that resolves to an executable file on `path`, as the
+/// matched PATH ITSELF. Returning the path rather than the name is what keeps
+/// discovery and execution aligned: resolving the name a second time at spawn can
+/// land on a different PATH entry or a different extension than the one just
+/// proved to exist.
+///
+/// Search is name-major — every directory is tried for the first name before the
+/// second is considered — so an earlier name is a genuine preference rather than
+/// a tie broken by PATH order.
+pub fn find_on_path_in(
+    path: Option<&std::ffi::OsStr>,
+    names: &[&str],
+) -> Option<std::path::PathBuf> {
+    let path = path?;
+    for name in names {
+        for dir in std::env::split_paths(path) {
+            if let Some(found) = command_candidates(&dir, name)
+                .into_iter()
+                .find(|candidate| is_executable_file(candidate))
+            {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// [`find_on_path_in`] against this process's own `PATH`.
+pub fn find_on_path(names: &[&str]) -> Option<std::path::PathBuf> {
+    find_on_path_in(std::env::var_os("PATH").as_deref(), names)
 }
 
 /// Strip a leading UTF-8 BOM (U+FEFF, bytes `EF BB BF`) so `serde_json` accepts
@@ -64,7 +117,123 @@ pub fn strip_utf8_bom(s: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{PATH_LIST_SEPARATOR, strip_utf8_bom};
+    use super::{PATH_LIST_SEPARATOR, find_on_path_in, strip_utf8_bom};
+    use std::path::PathBuf;
+
+    /// Writes `name` into `dir` and makes it executable, so it is a candidate the
+    /// probe is allowed to return rather than a file that only looks like one.
+    fn put_tool(dir: &std::path::Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, b"").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        path
+    }
+
+    fn scratch(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "nub-core-path-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// The regression this guards: probing for a bare `llvm-strip` on Windows,
+    /// where the tool is on disk as `llvm-strip.exe`. A probe that only tries the
+    /// bare spelling finds nothing, and `nub compile`'s caller then embeds an
+    /// unstripped Node — quietly, and about 4 MB heavier — on every Windows host.
+    /// Driving the real entry point is the point: asserting on candidate
+    /// generation alone stays green against the bare-`join` implementation.
+    #[test]
+    fn a_bare_name_resolves_to_the_hosts_own_spelling() {
+        let dir = scratch("spelling");
+        let spelled = if cfg!(windows) {
+            "llvm-strip.exe"
+        } else {
+            "llvm-strip"
+        };
+        let expected = put_tool(&dir, spelled);
+
+        let path = std::env::join_paths([&dir]).unwrap();
+        assert_eq!(
+            find_on_path_in(Some(&path), &["llvm-strip"]).as_ref(),
+            Some(&expected),
+            "a bare name must find the host's own spelling, and hand back that file"
+        );
+        assert_eq!(
+            find_on_path_in(Some(&path), &["definitely-not-a-stripper"]),
+            None,
+            "a tool that is absent must not resolve"
+        );
+    }
+
+    /// An earlier name wins even when a later one sits in an earlier PATH entry,
+    /// because `llvm-strip` is preferred over `strip` for reasons PATH order knows
+    /// nothing about (it is the only one that handles a foreign object format).
+    #[test]
+    fn an_earlier_name_outranks_path_order() {
+        let first = scratch("pref-first");
+        let second = scratch("pref-second");
+        put_tool(&first, if cfg!(windows) { "strip.exe" } else { "strip" });
+        let preferred = put_tool(
+            &second,
+            if cfg!(windows) {
+                "llvm-strip.exe"
+            } else {
+                "llvm-strip"
+            },
+        );
+
+        let path = std::env::join_paths([&first, &second]).unwrap();
+        assert_eq!(
+            find_on_path_in(Some(&path), &["llvm-strip", "strip"]).as_ref(),
+            Some(&preferred),
+            "search is name-major: the preferred tool wins from a later PATH entry"
+        );
+    }
+
+    /// A file that is present but carries no execute bit is not a usable tool.
+    /// Accepting it would turn a clean "not found" — which callers handle, by
+    /// falling back or naming the missing tool — into a spawn failure further
+    /// along, where the cause is much harder to read.
+    #[cfg(unix)]
+    #[test]
+    fn a_file_without_the_execute_bit_does_not_resolve() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = scratch("nonexec");
+        let path = dir.join("llvm-strip");
+        std::fs::write(&path, b"").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let joined = std::env::join_paths([&dir]).unwrap();
+        assert_eq!(
+            find_on_path_in(Some(&joined), &["llvm-strip"]),
+            None,
+            "a non-executable file must not satisfy a probe whose result gets spawned"
+        );
+    }
+
+    /// A batch file is not an image `CreateProcessW` can launch, so offering one
+    /// would hand back a path that cannot be spawned. Unix has no such split, and
+    /// there the file is simply not named `.bat`.
+    #[cfg(windows)]
+    #[test]
+    fn a_batch_file_is_not_offered_as_a_spawnable_tool() {
+        let dir = scratch("batch");
+        put_tool(&dir, "llvm-strip.bat");
+        let path = std::env::join_paths([&dir]).unwrap();
+        assert_eq!(
+            find_on_path_in(Some(&path), &["llvm-strip"]),
+            None,
+            "a .bat needs cmd.exe, so it must not satisfy a probe whose result gets spawned"
+        );
+    }
 
     #[test]
     fn strip_utf8_bom_removes_only_a_leading_bom() {

--- a/crates/nub-core/src/lib.rs
+++ b/crates/nub-core/src/lib.rs
@@ -30,22 +30,35 @@ pub const PATH_LIST_SEPARATOR: &str = if cfg!(windows) { ";" } else { ":" };
 /// PATHEXT rule is written once: the launcher's Node discovery and the
 /// compiler's strip lookup previously carried separate copies of it.
 ///
-/// Only the extensions `CreateProcessW` can launch as an image are offered, which
-/// is narrower than PATHEXT. A `.BAT`/`.CMD` needs `cmd.exe` to interpret it, so
-/// admitting one would hand a caller a path it cannot spawn — the launcher's
-/// discovery states the same rule for its own reason: a candidate that would fail
-/// at spawn must lose to the next one rather than be selected. A name that already
-/// carries an extension is taken as spelled, and it is the caller's business
-/// whether that spelling runs.
+/// Offered candidates are the PATHEXT entries `Command` can actually start, which
+/// is narrower than PATHEXT itself but wider than the executable image formats.
+/// A `.BAT`/`.CMD` counts: std detects that suffix on an explicit path and
+/// substitutes `cmd.exe` to interpret it (`sys::process::windows`), so a batch
+/// wrapper on PATH — a common shape for `curl` — is a tool the caller can run.
+/// A `.PS1` or `.VBS` is not, and offering one would hand back a path that fails
+/// at spawn, which the callers' shared rule forbids: a candidate that cannot run
+/// must lose to the next one rather than be selected.
+///
+/// This narrowing is only sound because callers receive the matched PATH and
+/// spawn THAT. Resolving the bare name again at spawn would find only `.exe`,
+/// which is what makes the distinction load-bearing rather than academic.
+///
+/// A name that already carries an extension is taken as spelled, and whether that
+/// spelling runs is the caller's business.
 #[cfg(windows)]
 pub fn command_candidates(dir: &std::path::Path, name: &str) -> Vec<std::path::PathBuf> {
     if std::path::Path::new(name).extension().is_some() {
         return vec![dir.join(name)];
     }
-    let configured = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE".into());
+    let configured = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".into());
     configured
         .split(';')
-        .filter(|extension| matches!(extension.to_ascii_uppercase().as_str(), ".EXE" | ".COM"))
+        .filter(|extension| {
+            matches!(
+                extension.to_ascii_uppercase().as_str(),
+                ".EXE" | ".COM" | ".BAT" | ".CMD"
+            )
+        })
         .map(|extension| dir.join(format!("{name}{extension}")))
         .collect()
 }
@@ -242,19 +255,35 @@ mod tests {
         );
     }
 
-    /// A batch file is not an image `CreateProcessW` can launch, so offering one
-    /// would hand back a path that cannot be spawned. Unix has no such split, and
-    /// there the file is simply not named `.bat`.
+    /// A batch wrapper on PATH is a real tool: std substitutes `cmd.exe` for an
+    /// explicit `.bat`/`.cmd` path, so the launcher can run one and has always
+    /// been able to — that is how a PATH-provided `curl` often arrives. Dropping
+    /// these would narrow discovery that already works.
     #[cfg(windows)]
     #[test]
-    fn a_batch_file_is_not_offered_as_a_spawnable_tool() {
+    fn a_batch_wrapper_resolves_because_std_can_run_one() {
         let dir = scratch("batch");
-        put_tool(&dir, "llvm-strip.bat");
+        let wrapper = put_tool(&dir, "curl.bat");
+        let path = std::env::join_paths([&dir]).unwrap();
+        assert_resolved(find_on_path_in(Some(&path), &["curl"]), &wrapper);
+    }
+
+    /// A script PATHEXT lists but nothing can start directly must not be offered:
+    /// `CreateProcessW` cannot launch it and std substitutes a shell only for
+    /// `.bat`/`.cmd`, so returning one would trade a clean "not found" for a spawn
+    /// failure. `.VBS` is the case to pick because Windows ships it in the default
+    /// PATHEXT — dropping the filter really does start offering it, which is what
+    /// keeps this test able to fail.
+    #[cfg(windows)]
+    #[test]
+    fn a_script_std_cannot_start_is_not_offered_as_a_tool() {
+        let dir = scratch("vbs");
+        put_tool(&dir, "curl.vbs");
         let path = std::env::join_paths([&dir]).unwrap();
         assert_eq!(
-            find_on_path_in(Some(&path), &["llvm-strip"]),
+            find_on_path_in(Some(&path), &["curl"]),
             None,
-            "a .bat needs cmd.exe, so it must not satisfy a probe whose result gets spawned"
+            "a .vbs cannot be started directly, so it must not satisfy the probe"
         );
     }
 

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -1697,33 +1697,13 @@ fn which_on_path(name: &str) -> Option<PathBuf> {
 fn which_in_path(path: Option<&std::ffi::OsStr>, name: &str) -> Option<PathBuf> {
     let path = path?;
     for dir in std::env::split_paths(path) {
-        for candidate in command_candidates(&dir, name) {
+        for candidate in nub_core::command_candidates(&dir, name) {
             if is_executable_file(&candidate) {
                 return Some(candidate);
             }
         }
     }
     None
-}
-
-#[cfg(windows)]
-fn command_candidates(dir: &Path, name: &str) -> Vec<PathBuf> {
-    let candidate = dir.join(name);
-    if Path::new(name).extension().is_some() {
-        return vec![candidate];
-    }
-
-    let extensions = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".into());
-    extensions
-        .split(';')
-        .filter(|extension| !extension.is_empty())
-        .map(|extension| dir.join(format!("{name}{extension}")))
-        .collect()
-}
-
-#[cfg(not(windows))]
-fn command_candidates(dir: &Path, name: &str) -> Vec<PathBuf> {
-    vec![dir.join(name)]
 }
 
 /// Provision `version` for the host from nodejs.org. The launcher keeps TLS out

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -1695,15 +1695,7 @@ fn which_on_path(name: &str) -> Option<PathBuf> {
 }
 
 fn which_in_path(path: Option<&std::ffi::OsStr>, name: &str) -> Option<PathBuf> {
-    let path = path?;
-    for dir in std::env::split_paths(path) {
-        for candidate in nub_core::command_candidates(&dir, name) {
-            if is_executable_file(&candidate) {
-                return Some(candidate);
-            }
-        }
-    }
-    None
+    nub_core::find_on_path_in(path, &[name])
 }
 
 /// Provision `version` for the host from nodejs.org. The launcher keeps TLS out


### PR DESCRIPTION
The strip probe looked for a tool with `dir.join(name).is_file()`. On Windows the strippers ship as `llvm-strip.exe`, which that never matches, so both candidate lists missed and the compiler took its unstripped early return on every compile run on a Windows host. It fails quietly: a `note:` on stderr, and an artifact roughly 4 MB larger than it should be.

The probe is now PATHEXT-aware, mirroring the helper the launcher already carries for the same reason. It still returns the bare name, since `Command::new` does its own PATH search and only the existence check was wrong.

Found during a production-readiness review of the compile feature, not from a report.

Gates are green on macOS and behavior there is unchanged. The added test can only go red on Windows, so the Windows leg is what actually exercises this.
