### PR TITLE
compile: close the shim-capability gap at both ends, and gate it on every host

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,13 @@ tests/fixtures/import-text-named/*  text eol=lf
 # provisioning ever widens.
 tests/fixtures/data-loaders-require/*       text eol=lf
 tests/fixtures/loader-redirect-both-ways/*  text eol=lf
+
+# Same trap, third form: the compile-augmentation harness reads `*.flags` as
+# ARGV and `*.differs` as a reason string, so a CRLF checkout appends `\r` to a
+# flag's value. On Windows that turned `--sourcemap=inline` into
+# `error: invalid value 'inline' for '--sourcemap[=<MODE>]'` — a message naming a
+# value that IS in the allowed list, because the `\r` making it invalid does not
+# print. It surfaced the moment the erasability gate started running on every
+# native host rather than Linux alone. `**` rather than `*` because the `.d`
+# companion directories nest, and their sources feed the same byte comparisons.
+tests/compile-augmentation/fixtures/**  text eol=lf

--- a/.github/workflows/compile-native.yml
+++ b/.github/workflows/compile-native.yml
@@ -174,32 +174,44 @@ jobs:
       # reference run and the artifact are all the same build. That control is what
       # makes a green row mean something, and the harness prints how many rows were
       # discriminating so a run that quietly stops proving anything is visible.
+      #
+      # Every host, not just Linux. The class this catches — an augmentation the
+      # runtime makes and the compiler does not — is not Linux-specific, so gating
+      # it on one OS left the other three unguarded against exactly the failure
+      # the step exists to find. The harness needed one portability fix to get
+      # here: `--out` is taken verbatim, so it now names the target's exe suffix
+      # rather than asking for an extensionless `./bin` on Windows. The other two
+      # Unix-looking things in it are already portable — the provisioned-Node
+      # lookup falls back to `command -v node`, and XDG_CACHE_HOME outranks the
+      # platform cache roots on every OS (`nub-launcher/src/cache.rs`).
       - name: Compiled artifacts keep Nub's augmentations
-        if: runner.os == 'Linux'
         shell: bash
         run: |
           set -euo pipefail
           nub="$GITHUB_WORKSPACE/target/release/nub"
+          launcher="$GITHUB_WORKSPACE/crates/nub-launcher/target/release/nub-launcher"
+          if [[ "$RUNNER_OS" == Windows ]]; then nub+='.exe'; launcher+='.exe'; fi
           test -f "$nub"
+          test -f "$launcher"
           version="$(node --version)"
-          NUB="$nub" \
-          __NUB_LAUNCHER_TEMPLATE="$GITHUB_WORKSPACE/crates/nub-launcher/target/release/nub-launcher" \
+          NUB="$nub" __NUB_LAUNCHER_TEMPLATE="$launcher" \
             tests/compile-augmentation/run.sh "${version#v}"
       # The other shipping shape, and a whole code path the default never touches:
       # --smol carries no Node blob and finds one at run time, so it computes the
       # injected flag set against a version the build never saw. That is the
       # reason the flag policy is what it is, so it should not be the untested one.
       - name: Compiled artifacts keep Nub's augmentations (--smol)
-        if: runner.os == 'Linux'
         shell: bash
         run: |
           set -euo pipefail
           nub="$GITHUB_WORKSPACE/target/release/nub"
+          launcher="$GITHUB_WORKSPACE/crates/nub-launcher/target/release/nub-launcher"
+          if [[ "$RUNNER_OS" == Windows ]]; then nub+='.exe'; launcher+='.exe'; fi
           test -f "$nub"
+          test -f "$launcher"
           version="$(node --version)"
           COMPILE_FLAGS=--smol \
-          NUB="$nub" \
-          __NUB_LAUNCHER_TEMPLATE="$GITHUB_WORKSPACE/crates/nub-launcher/target/release/nub-launcher" \
+          NUB="$nub" __NUB_LAUNCHER_TEMPLATE="$launcher" \
             tests/compile-augmentation/run.sh "${version#v}"
       - name: Upload native-island failure logs
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -170,10 +170,16 @@ tests/bench/RESULTS.md
 # local-only design corpus (symlink to external dir) — never tracked
 internal
 
-# The repo root is npm-only — a root pnpm-lock.yaml (beside a workspace
-# yaml) would mark the root as a workspace for nub and re-trigger the
-# engines-redirect the soak surfaces were moved to tools/ to avoid.
+# The repo root is nub-identity — `nub.lock` is the tracked lockfile and
+# devEngines.packageManager names nub — so every other PM's root lockfile is
+# residue. A root pnpm-lock.yaml (beside a workspace yaml) additionally marks
+# the root as a workspace for nub and re-triggers the engines-redirect the soak
+# surfaces were moved to tools/ to avoid.
 /pnpm-lock.yaml
+# npm leaves this behind whenever anyone runs `npm install` here to populate
+# node_modules, which the compile test suites need. Neither tracked nor ignored
+# left it one `git add` away from a commit, and it got into one.
+/package-lock.json
 
 # Maintainer-local frizz worker norms (names private orchestration tooling). The tool
 # was renamed fray→frizz and only the old name was listed, so FRIZZ.md sat untracked and

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -8907,7 +8907,7 @@ nub {v} — the all-in-one Node.js toolkit
   watch <file>                run a file and restart on changes
   nubx <pkg>                  fetch and run a package binary
   init                        scaffold a new project
-
+{compileverb}
 {runtime}
   -                           read script from stdin
   --                          end of nub options; the rest is the script's argv
@@ -8972,6 +8972,7 @@ nub {v} — the all-in-one Node.js toolkit
         v = v,
         usage = help_bold("Usage:"),
         headline = help_bold("Headline commands:"),
+        compileverb = COMPILE_HELP_LINE,
         runtime = help_bold("Runtime options (passed through to Node):"),
         pm = help_bold("Package manager commands:"),
         toolchain = help_bold("Manage the toolchain:"),
@@ -8980,6 +8981,23 @@ nub {v} — the all-in-one Node.js toolkit
         )
     )
 }
+
+/// The `compile` entry for the two help surfaces, or nothing when the verb is not
+/// in this build. Release binaries pass `--features compile`, so users see it; a
+/// feature-off dev build must not advertise a verb it would reject. Each surface
+/// gets its own spelling because their indentation and grouping differ, and the
+/// verbose one carries its section heading so the heading disappears with it
+/// rather than leaving an empty group.
+#[cfg(feature = "compile")]
+const COMPILE_HELP_LINE: &str = "  compile <file>              build a standalone executable\n";
+#[cfg(not(feature = "compile"))]
+const COMPILE_HELP_LINE: &str = "";
+
+#[cfg(feature = "compile")]
+const COMPILE_HELP_SECTION: &str =
+    "  Build:\n    compile                  build a file into a standalone executable\n\n";
+#[cfg(not(feature = "compile"))]
+const COMPILE_HELP_SECTION: &str = "";
 
 /// `nub --help` — the verbose reference: nub's command surface plus a fuller
 /// Node runtime flag and environment-variable reference. The power-user / agent
@@ -9030,7 +9048,7 @@ nub {v} — the all-in-one Node.js toolkit
     publish / pack / version / dist-tag
     login / logout / whoami / owner / token
 
-  Manage the toolchain:
+{compileverb}  Manage the toolchain:
     node                     manage Node versions (install / ls / uninstall / pin)
     pm                       manage the project's package manager
     upgrade                  upgrade nub itself
@@ -9115,6 +9133,7 @@ nub {v} — the all-in-one Node.js toolkit
         v = v,
         usage = help_bold("Usage:"),
         commands = help_bold("Commands:"),
+        compileverb = COMPILE_HELP_SECTION,
         nubopts = help_bold("Nub options:"),
         noderun = help_bold("Common Node runtime flags (passed through to Node):"),
         nodeenv = help_bold("Common environment variables:"),

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -412,7 +412,9 @@ fn bundle_inner(
             .with_options(options)
             .with_plugins(plugins)
             .build()
-            .map_err(|e| anyhow!("rolldown init:\n{}", render_diagnostics(&e)))?;
+            // Not "rolldown init" — a bad `--define` key lands here, and the
+            // vendored bundler's name is not a thing the user can act on.
+            .map_err(|e| anyhow!("preparing the bundler:\n{}", render_diagnostics(&e)))?;
         bundler
             .generate()
             .await
@@ -4774,6 +4776,169 @@ mod tests {
             native_target: None,
             target_node: None,
         }
+    }
+
+    /// Whether the bundle emits `value` as a string literal. Quote-agnostic on
+    /// purpose: the source may write `'x'` and the emitted chunk `"x"`, and which
+    /// quote the bundler chose is never what these tests are asserting.
+    fn emits_literal(code: &str, value: &str) -> bool {
+        code.contains(&format!("\"{value}\"")) || code.contains(&format!("'{value}'"))
+    }
+
+    /// Bundle an entry that imports a package, with that package laid out under a
+    /// real `node_modules` so resolution — `exports` conditions included — runs for
+    /// real rather than through a stub.
+    fn bundle_with_package(
+        entry_src: &str,
+        pkg_name: &str,
+        pkg_json: &str,
+        files: &[(&str, &str)],
+        o: &BundleOptions,
+    ) -> String {
+        static N: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = N.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("nub-bundle-pkg-{}-{seq}", std::process::id()));
+        let pkg = dir.join("node_modules").join(pkg_name);
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("package.json"), pkg_json).unwrap();
+        for (name, body) in files {
+            std::fs::write(pkg.join(name), body).unwrap();
+        }
+        // The project's own manifest, without which the entry has no package
+        // boundary and the dependency resolves to nothing — verified against the
+        // real binary, which resolves the same fixture correctly once it is here.
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{ "name": "fixture", "type": "module" }"#,
+        )
+        .unwrap();
+        std::fs::write(dir.join("entry.ts"), entry_src).unwrap();
+        let res = bundle(&dir.join("entry.ts"), o).expect("bundle succeeds");
+        // Every chunk, not just the entry: a package's code routinely lands in a
+        // split chunk, and which chunk it lands in is not what these tests are about.
+        let code = emitted_chunk_code(&res);
+        let _ = std::fs::remove_dir_all(&dir);
+        code
+    }
+
+    /// `--conditions` claims to ADD to the default condition set rather than
+    /// replace it, which is a claim about the vendored resolver's behavior, not
+    /// nub's. Nothing pinned it, so a resolver bump could silently turn an
+    /// additive flag into a replacing one and quietly change which `exports`
+    /// branch every compiled binary resolves.
+    ///
+    /// Both halves are asserted deliberately: the custom branch is selected when
+    /// asked for, and `import` still resolves when it is — the second is what
+    /// catches "replaced" masquerading as "added".
+    #[test]
+    fn a_custom_condition_is_added_to_the_defaults_not_substituted_for_them() {
+        const PKG: &str = r#"{
+            "name": "conditional",
+            "exports": {
+                ".": { "custom": "./custom.js", "import": "./import.js" },
+                "./plain": { "import": "./plain.js" }
+            }
+        }"#;
+        const FILES: &[(&str, &str)] = &[
+            ("custom.js", "export const WHICH = 'custom';\n"),
+            ("import.js", "export const WHICH = 'import';\n"),
+            ("plain.js", "export const PLAIN = 'plain';\n"),
+        ];
+        const SRC: &str = "import { WHICH } from 'conditional';\n\
+                           import { PLAIN } from 'conditional/plain';\n\
+                           globalThis.OUT = WHICH + PLAIN;\n";
+
+        let mut with = opts();
+        with.minify = false;
+        with.conditions = vec!["custom".to_string()];
+        let selected = bundle_with_package(SRC, "conditional", PKG, FILES, &with);
+        assert!(
+            emits_literal(&selected, "custom"),
+            "--conditions custom must select the custom branch; got:\n{selected}"
+        );
+        assert!(
+            emits_literal(&selected, "plain"),
+            "the default `import` condition must still resolve — a custom condition \
+             ADDS to the defaults, and a subpath with no custom branch proves it was \
+             not substituted for them; got:\n{selected}"
+        );
+
+        // Control: without the flag the same package resolves the other way, so
+        // the assertion above is about the flag and not about the fixture.
+        let mut without = opts();
+        without.minify = false;
+        let default = bundle_with_package(SRC, "conditional", PKG, FILES, &without);
+        assert!(
+            emits_literal(&default, "import"),
+            "without --conditions the import branch must win; got:\n{default}"
+        );
+    }
+
+    /// `--sourcemap-exclude-sources` exists so a shipped map does not carry the
+    /// program's own source text. Nothing asserted it, and the flag is exactly the
+    /// kind that can silently no-op.
+    #[test]
+    fn excluding_sources_drops_the_original_text_from_the_map() {
+        const SRC: &str = "export const MARKER_FROM_SOURCE = 41 + 1;\n\
+                           globalThis.OUT = MARKER_FROM_SOURCE;\n";
+
+        let mut included = opts();
+        included.minify = false;
+        included.sourcemap = SourcemapMode::Inline;
+        included.sources_content = true;
+        let with_sources = bundle_fixture(SRC, &included);
+
+        let mut excluded = opts();
+        excluded.minify = false;
+        excluded.sourcemap = SourcemapMode::Inline;
+        excluded.sources_content = false;
+        let without_sources = bundle_fixture(SRC, &excluded);
+
+        // The map rides as a base64 data URL, so decode rather than string-matching
+        // the emitted code — the marker appears in the CODE either way.
+        let decode_map = |code: &str| -> String {
+            use base64::Engine as _;
+            let tail = code
+                .rsplit("base64,")
+                .next()
+                .expect("an inline sourcemap comment");
+            let b64 = tail.trim();
+            String::from_utf8(
+                base64::engine::general_purpose::STANDARD
+                    .decode(b64)
+                    .expect("the inline map must be valid base64"),
+            )
+            .expect("the decoded map must be UTF-8")
+        };
+
+        let kept = decode_map(&with_sources);
+        assert!(
+            kept.contains("MARKER_FROM_SOURCE"),
+            "the control must carry the original text, or this test proves nothing"
+        );
+        let dropped = decode_map(&without_sources);
+        assert!(
+            !dropped.contains("sourcesContent") || !dropped.contains("MARKER_FROM_SOURCE"),
+            "excluding sources must leave the authored text out of the map; got:\n{dropped}"
+        );
+    }
+
+    /// `--alias` was covered only by its `a=b` parser. Nothing asserted that an
+    /// alias actually redirects a resolution, which is the whole flag.
+    #[test]
+    fn an_alias_redirects_the_resolution_to_the_named_package() {
+        const PKG: &str = r#"{ "name": "replacement", "exports": "./index.js" }"#;
+        const FILES: &[(&str, &str)] = &[("index.js", "export const WHO = 'replacement';\n")];
+        const SRC: &str = "import { WHO } from 'original';\nglobalThis.OUT = WHO;\n";
+
+        let mut aliased = opts();
+        aliased.minify = false;
+        aliased.alias = vec!["original=replacement".to_string()];
+        let code = bundle_with_package(SRC, "replacement", PKG, FILES, &aliased);
+        assert!(
+            emits_literal(&code, "replacement"),
+            "the alias must redirect `original` to `replacement`; got:\n{code}"
+        );
     }
 
     fn emitted_entry_code(result: &BundleResult) -> String {

--- a/crates/nub-cli/src/compile/external.rs
+++ b/crates/nub-cli/src/compile/external.rs
@@ -91,17 +91,18 @@ const HOOK: &str = "__nub_external.mjs";
 /// 23.5.0. The build succeeded and the ARTIFACT died at startup on `registerHooks is
 /// not a function`. A bare `--target 23` floors at 23.0.0, landing in that band.
 ///
-/// KNOWN GAP, deliberate: this gate sees a FLOOR, not the pin's whole acceptance set.
-/// A `--smol` pin slips through iff its resolved floor lands in 22.15.0..23.0.0 AND
-/// the manifest carries nothing narrower than that floor — narrower being only an
-/// `Exact` target (`smol_requires_exact_target`) or a floor-bearing `Range` that
-/// `range_minimum_is` carries (and a carried `">=22.15"` still admits the band).
-/// `SmolTarget::matches` then falls back to `candidate >= floor` and accepts a 23.2
-/// at launch. Illustrative shapes, not a closed list: `--target ">=22.15"`,
-/// `--target 22.15`, `--target lts/jod`, `--target "<23"`. Closing the class needs
-/// the gate to see the whole acceptance set rather than its floor, which is a
-/// different change; an exact three-part target, a bare major, and a `23.x` range
-/// all floor inside the band and are caught.
+/// This gate sees a FLOOR, not the pin's whole acceptance set, so it cannot be the
+/// only check under `--smol`: a pin whose floor lands in 22.15.0..23.0.0 passes here
+/// and the launcher would still accept a 23.2 that satisfies `candidate >= floor`.
+/// Illustrative shapes, not a closed list: `--target ">=22.15"`, `--target 22.15`,
+/// `--target lts/jod`, `--target "<23"`.
+///
+/// That class is closed at the other end rather than here. `Manifest::requires_augmentation`
+/// records that the payload NEEDS the API, and `SmolTarget::matches` applies
+/// `supports_augmentation` to the candidate it actually discovered — judging the
+/// runtime in hand instead of predicting it from a bound. This gate remains worth
+/// keeping because it fails the BUILD, which is where a target the author chose
+/// wrong should be reported, and it does so before the ~100 MB download.
 pub fn check_node_support(version: &NodeVersion, source: &str, plan: &ShimPlan<'_>) -> Result<()> {
     if !plan.needed() || version.supports_augmentation() {
         return Ok(());

--- a/crates/nub-cli/src/compile/inject.rs
+++ b/crates/nub-cli/src/compile/inject.rs
@@ -509,6 +509,7 @@ mod tests {
             provision_version: String::new(),
             smol_exact_target: false,
             smol_version_range: String::new(),
+            requires_augmentation: false,
             triple: "linux-x64".into(),
             node_sha256: String::new(),
             node_blake3: String::new(),

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -245,7 +245,9 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         let newest =
             version_management::resolve_pin_for_platform(&pin, os, arch, musl, &cache_root)
                 .ok()
-                .filter(|newest| *newest != floor);
+                .filter(|newest| {
+                    provision_preference_is_usable(newest, &floor, shim_plan.needed())
+                });
         eprintln!(
             "Using Node.js {} (resolved from {source}; {}{})",
             non_exact_spec(&pin, &raw).unwrap_or_else(|| floor.to_string()),
@@ -683,6 +685,29 @@ fn smol_version_range(pin: &VersionPin, gate: &NodeVersion) -> String {
         }
         _ => String::new(),
     }
+}
+
+/// Is `newest` worth recording as the version to DOWNLOAD when discovery finds
+/// nothing? Two ways it is not.
+///
+/// Equal to the floor, and the preference says nothing the launcher does not
+/// already know. Or — the case this exists for — newer than the floor, satisfying
+/// the pin, and still unable to run the payload: `--target ">=22.15 <23.5"`
+/// resolves to 23.4, which sorts above the floor and matches the range yet
+/// predates `registerHooks` on the 23.x line. Recording it produced a binary that
+/// built clean and then bailed on the user's machine, which is the same class the
+/// launcher's discovery check closes, reached through the other door.
+///
+/// Refusing is safe rather than merely conservative: no preference means the
+/// launcher provisions the FLOOR, and `check_node_support` has already failed the
+/// build if a shim-bearing floor lacks the API. So whenever `shim_needed` holds
+/// here, the floor is known to run the payload.
+fn provision_preference_is_usable(
+    newest: &NodeVersion,
+    floor: &NodeVersion,
+    shim_needed: bool,
+) -> bool {
+    newest != floor && (!shim_needed || newest.supports_augmentation())
 }
 
 /// The runtime contract printed beside the original target. Kept in step with
@@ -2663,6 +2688,41 @@ mod tests {
         assert_eq!(non_exact_spec(&range, ">=20"), Some(">=20".to_string()));
         let major = version_management::parse_target_spec("24").unwrap();
         assert_eq!(non_exact_spec(&major, "24"), Some("24".to_string()));
+    }
+
+    /// The build end of the same rule the launcher enforces on discovery: a version
+    /// can be newer than the floor, satisfy the pin, and still be unable to run the
+    /// payload. `--target ">=22.15 <23.5"` is the shape that resolves to one.
+    #[test]
+    fn a_provision_preference_that_cannot_run_the_shim_is_dropped() {
+        let floor = NodeVersion::new(22, 15, 0);
+        let in_band = NodeVersion::new(23, 4, 0);
+        let above_band = NodeVersion::new(23, 5, 0);
+        let same_line = NodeVersion::new(22, 20, 0);
+
+        assert!(
+            !provision_preference_is_usable(&in_band, &floor, true),
+            "23.4 predates registerHooks on the 23.x line, so provisioning it would \
+             hand the launcher a Node it must then refuse"
+        );
+        // The control that keeps this from being a blanket 23.x ban: without a shim
+        // the payload does not need the API, so 23.4 is a perfectly good download.
+        assert!(
+            provision_preference_is_usable(&in_band, &floor, false),
+            "a payload with no shim has no claim on registerHooks"
+        );
+        assert!(
+            provision_preference_is_usable(&above_band, &floor, true),
+            "23.5 is where the 23.x line gained registerHooks"
+        );
+        assert!(
+            provision_preference_is_usable(&same_line, &floor, true),
+            "a newer version on the floor's own line stays preferred"
+        );
+        assert!(
+            !provision_preference_is_usable(&floor, &floor, true),
+            "a preference equal to the floor tells the launcher nothing new"
+        );
     }
 
     #[test]

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -303,6 +303,9 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         } else {
             String::new()
         },
+        // Only smol discovers its runtime, so only smol can be handed one that
+        // cannot run the shim; embed carries an exact Node already gated above.
+        requires_augmentation: opts.smol && shim_plan.needed(),
         triple: target.triple(),
         node_sha256: node.sha256,
         node_blake3: node.blake3,
@@ -2547,6 +2550,7 @@ mod tests {
             provision_version: String::new(),
             smol_exact_target: false,
             smol_version_range: String::new(),
+            requires_augmentation: false,
             triple: "darwin-arm64".into(),
             node_sha256: "node".into(),
             node_blake3: String::new(),

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -224,9 +224,14 @@ fn run_compiled_artifact_with_timeout(artifact: &Path, cwd: &Path) -> std::proce
     run_compiled_artifact_command_with_timeout(cmd, std::time::Duration::from_secs(10))
 }
 
+/// Covers the TEST HARNESS, not a compiled artifact: nothing here is compiled.
+/// `run_compiled_artifact_command_with_timeout` is what every artifact e2e runs
+/// through, so a deadlock in its stdio drain would hang those tests rather than
+/// fail them. Driving it with a plain `node -e` writing 1 MB to each stream is
+/// the cheapest way to prove it drains concurrently.
 #[cfg(feature = "compile")]
 #[test]
-fn large_compiled_artifact_output_does_not_block_process_exit() {
+fn artifact_runner_drains_large_output_without_deadlock() {
     let runtime = compile_test_runtime();
     let mut command = Command::new(runtime.node_exec_path);
     command.args([
@@ -240,9 +245,12 @@ fn large_compiled_artifact_output_does_not_block_process_exit() {
     assert_eq!(output.stderr.len(), 1_000_000);
 }
 
+/// Also the harness, not an artifact. On Windows a grandchild inheriting stdio
+/// keeps the pipe open after the child exits, so a naive read-to-end never
+/// returns; the timeout has to fire on the CHILD rather than on end-of-stream.
 #[cfg(all(feature = "compile", windows))]
 #[test]
-fn timeout_returns_after_a_descendant_inherits_stdio() {
+fn artifact_runner_timeout_survives_a_descendant_holding_stdio() {
     let runtime = compile_test_runtime();
     let mut command = Command::new(runtime.node_exec_path);
     command.args([

--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -284,6 +284,76 @@ setInterval(() => {}, 1000);"#,
 /// `__toCommonJS(namespace)` operand. The call then returned `undefined` with no
 /// error. A block body or any surrounding expression escapes the misread, so this
 /// fixture must keep the concise form to discriminate.
+/// The payload must TELL the launcher it needs `module.registerHooks`, because the
+/// launcher's refusal of an incapable Node keys on that manifest field and nothing
+/// else. The wiring is one expression in `compile::run`, and until this existed it
+/// could be replaced with a literal `false` — deleting the whole fix — with every
+/// other test still green.
+///
+/// Both directions are asserted, and the second is what makes the first mean
+/// something: a field hardwired `true` would satisfy the shim case and fail the
+/// plain one, so neither constant passes.
+///
+/// `--external` rather than `--allow-dynamic-import`, so the two compiles differ
+/// in exactly one thing. `--external`'s requirement applies unconditionally, while
+/// `--allow-dynamic-import` only installs the shim when a computed `import()`
+/// actually survives into the bundle — so testing it needs a different ENTRY too,
+/// and a two-variable comparison would not isolate the flag.
+#[cfg(feature = "compile")]
+#[test]
+fn a_smol_payload_records_whether_it_needs_the_register_hooks_shim() {
+    let runtime = compile_test_runtime();
+    let work = unique_test_cache();
+    let cache = work.join("cache");
+    let entry = work.join("app.mjs");
+    std::fs::create_dir_all(&work).expect("create the work dir");
+    std::fs::write(&entry, "console.log('ok');\n").expect("write entry");
+
+    // Read off the artifact rather than a return value: the manifest is what the
+    // launcher on a user's machine actually parses, so that is the surface worth
+    // pinning. It is stored as uncompressed JSON inside the payload.
+    let compile = |extra: &[&str], name: &str| -> String {
+        let artifact = work.join(format!("{name}{}", std::env::consts::EXE_SUFFIX));
+        let output = Command::new(nub_binary())
+            .args([
+                "compile",
+                "--smol",
+                "--target",
+                &runtime.node_target,
+                "--out",
+            ])
+            .arg(&artifact)
+            .arg(&entry)
+            .args(extra)
+            .current_dir(&work)
+            .env("XDG_CACHE_HOME", &cache)
+            .env("__NUB_LAUNCHER_TEMPLATE", &runtime.launcher)
+            .output()
+            .expect("spawn nub compile");
+        assert!(
+            output.status.success(),
+            "compile {extra:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let bytes = std::fs::read(&artifact).expect("read the compiled artifact");
+        String::from_utf8_lossy(&bytes).into_owned()
+    };
+
+    let shimmed = compile(&["--external", "some-pkg"], "shimmed");
+    assert!(
+        shimmed.contains(r#""requires_augmentation":true"#),
+        "--external installs the registerHooks shim, so the manifest must demand it; \
+         without that the launcher accepts a Node that cannot run the payload"
+    );
+
+    let plain = compile(&[], "plain");
+    assert!(
+        plain.contains(r#""requires_augmentation":false"#),
+        "a smol build with no shim must not demand registerHooks — doing so would refuse \
+         every 18.19-22.14 Node the compat tier still supports"
+    );
+}
+
 #[cfg(feature = "compile")]
 #[test]
 fn compile_resolves_commonjs_requires_of_esm() {

--- a/crates/nub-core/src/compile.rs
+++ b/crates/nub-core/src/compile.rs
@@ -122,8 +122,10 @@ pub struct Manifest {
     /// candidate it actually found, which closes the class rather than the shapes
     /// the floor happens to catch.
     ///
-    /// Absent in legacy manifests, where `false` preserves their behavior exactly:
-    /// they carry no shim the old launcher knew how to install.
+    /// Absent in legacy manifests, where `false` reproduces their behavior exactly
+    /// — not because they carry no shim (a legacy `--smol --external` payload
+    /// carries one; that IS the bug) but because no launcher that read them ever
+    /// applied this check. `false` is what they were already doing.
     #[serde(default)]
     pub requires_augmentation: bool,
     /// The target triple this binary was compiled for (e.g. `darwin-arm64`).

--- a/crates/nub-core/src/compile.rs
+++ b/crates/nub-core/src/compile.rs
@@ -110,6 +110,22 @@ pub struct Manifest {
     /// fails closed.
     #[serde(default)]
     pub smol_version_range: String,
+    /// Whether the payload installs a `module.registerHooks` shim, which a
+    /// discovered Node must therefore provide. Set for a `--smol` build carrying
+    /// `--external` or `--allow-dynamic-import`.
+    ///
+    /// The build-time gate cannot stand in for this. It sees the pin's FLOOR, and
+    /// a floor in 22.15.0..23.0.0 admits the 23.0–23.4 band, which sorts above the
+    /// floor but predates `registerHooks` on the 23.x line — so `--target ">=22.15"`
+    /// passed the build and the artifact died at launch on `registerHooks is not a
+    /// function`. Recording the REQUIREMENT lets the launcher apply it to the
+    /// candidate it actually found, which closes the class rather than the shapes
+    /// the floor happens to catch.
+    ///
+    /// Absent in legacy manifests, where `false` preserves their behavior exactly:
+    /// they carry no shim the old launcher knew how to install.
+    #[serde(default)]
+    pub requires_augmentation: bool,
     /// The target triple this binary was compiled for (e.g. `darwin-arm64`).
     pub triple: String,
     /// Content hash (hex) of the DECOMPRESSED embedded Node — the cache key for
@@ -809,6 +825,7 @@ mod tests {
             provision_version: String::new(),
             smol_exact_target: false,
             smol_version_range: String::new(),
+            requires_augmentation: false,
             triple: "darwin-arm64".into(),
             node_sha256: "abc123".into(),
             node_blake3: String::new(),
@@ -836,6 +853,7 @@ mod tests {
             provision_version: String::new(),
             smol_exact_target: false,
             smol_version_range: String::new(),
+            requires_augmentation: false,
             triple: "darwin-arm64".into(),
             node_sha256: "abc123".into(),
             node_blake3: String::new(),
@@ -881,6 +899,7 @@ mod tests {
             provision_version: String::new(),
             smol_exact_target: false,
             smol_version_range: ">=24 <25".into(),
+            requires_augmentation: false,
             triple: "darwin-arm64".into(),
             node_sha256: String::new(),
             node_blake3: String::new(),

--- a/crates/nub-core/src/compile.rs
+++ b/crates/nub-core/src/compile.rs
@@ -81,7 +81,8 @@ pub struct Manifest {
     /// version satisfying [`Self::smol_version_range`].
     pub node_version: String,
     /// What `smol` DOWNLOADS when discovery finds nothing: the newest release
-    /// satisfying the compiled pin, resolved at compile time.
+    /// satisfying the compiled pin that can also RUN this payload, resolved at
+    /// compile time.
     ///
     /// Deliberately NOT an acceptance bound — discovery uses the explicit exact,
     /// range, or floor policy stored beside it. This exists because
@@ -90,6 +91,13 @@ pub struct Manifest {
     /// major plainly asks for the newest in that line. Resolved here rather than
     /// in the launcher to keep version lookup out of a component that is
     /// deliberately minimal.
+    ///
+    /// The capability qualifier is load-bearing, not decorative. The newest
+    /// satisfying release is not always one that can run the payload, so when
+    /// [`Self::requires_augmentation`] is set and that release lacks the API, this
+    /// field is left EMPTY and the launcher provisions the floor — which the build
+    /// gate has already proven capable. Recording it anyway produced a binary that
+    /// built clean and then refused its own download on the user's machine.
     ///
     /// Empty for embed, where `node_version` is already exact, and in legacy
     /// manifests, where the launcher falls back to the floor.

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -34,13 +34,19 @@ const ALWAYS_INJECT: &[&str] = &["--enable-source-maps"];
 /// documented as 26.2-only.
 ///
 /// Fixed on Node `main` by b5d37cd4 (nodejs/node#63215, 2026-08-20) in
-/// `lib/internal/errors/error_source.js`, which is in NO release yet (latest is
-/// v26.7.0, 2026-08-05). 26.8.0 is therefore the first release that can carry
-/// the fix, so the band is closed there — a **stopgap pending that release**.
-/// RE-VERIFY when 26.8.0 ships, and move the boundary up if it does not carry
-/// the fix:
+/// `lib/internal/errors/error_source.js`, and the band was predicted to close at
+/// 26.8.0 as the first release that could carry it.
+///
+/// RE-VERIFIED 2026-09-01, now that the release exists — the boundary below is
+/// measured rather than predicted, so this is no longer a stopgap. Running
 /// `node --enable-source-maps -e 'try{require("assert").ok(false)}catch(e){console.log(e.constructor.name)}'`
-/// must print `AssertionError`, not `TypeError`.
+/// on real binaries gives `TypeError` on 26.7.0 and `AssertionError` on 26.8.1.
+///
+/// The artifact published as v26.8.0 also gives `AssertionError`, with one caveat
+/// worth stating rather than rounding off: that build self-reports
+/// `v26.8.0-alpha.0.0.0`, which sorts BELOW `26.8.0` and so lands inside the band
+/// this constant withholds on. So the clean measurement is 26.7.0 broken / 26.8.1
+/// fixed, and 26.8.0 is bounded by the fix landing upstream before it was cut.
 ///
 /// The trade-off is unchanged: withholding costs only stack-trace remapping (a
 /// cosmetic loss), while injecting corrupts the TYPE of a thrown AssertionError,

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -1288,6 +1288,19 @@ impl SmolTarget {
         }
     }
 
+    /// The VERSION half alone. Split out so a caller can tell the two rejection
+    /// reasons apart: a candidate this accepts and `matches` rejects was refused
+    /// on capability, which is the one a user cannot read off the version number.
+    fn version_policy_admits(&self, candidate: &NodeVersion) -> bool {
+        if let Some(range) = &self.range {
+            candidate.satisfies(range)
+        } else if self.exact {
+            candidate == &self.floor
+        } else {
+            candidate >= &self.floor
+        }
+    }
+
     /// Version policy AND capability. The two are separate questions and the
     /// version one cannot answer the capability one: 23.0–23.4 sorts above a
     /// 22.15 floor and satisfies a `>=22.15` range, yet predates `registerHooks`
@@ -1297,13 +1310,7 @@ impl SmolTarget {
         if self.requires_augmentation && !candidate.supports_augmentation() {
             return false;
         }
-        if let Some(range) = &self.range {
-            candidate.satisfies(range)
-        } else if self.exact {
-            candidate == &self.floor
-        } else {
-            candidate >= &self.floor
-        }
+        self.version_policy_admits(candidate)
     }
 }
 
@@ -1553,7 +1560,25 @@ fn version_manager_dirs() -> Vec<NodeDir> {
 
 /// Does a discovered `candidate` satisfy this smol payload's version policy?
 /// Kept as one predicate so managed-layout scans and PATH discovery cannot drift.
+///
+/// A CAPABILITY refusal is reported, once; an ordinary version miss stays quiet.
+/// The asymmetry is the point: a user can read "needs >= 26, found 22" off the
+/// numbers, but 23.4 looks strictly newer than a 22.15 floor and is refused
+/// anyway, so silence there reads as a ~50 MB download for no reason at all.
 fn smol_candidate_matches(candidate: &NodeVersion, target: &SmolTarget) -> bool {
+    if target.requires_augmentation
+        && !candidate.supports_augmentation()
+        && target.version_policy_admits(candidate)
+    {
+        static REPORTED: std::sync::Once = std::sync::Once::new();
+        REPORTED.call_once(|| {
+            eprintln!(
+                "nub: found Node {candidate}, but this program needs module.registerHooks, \
+                 which arrived in {} — looking for another",
+                candidate.fast_tier_floor_for_line()
+            );
+        });
+    }
     target.matches(candidate)
 }
 
@@ -4148,6 +4173,35 @@ mod tests {
         assert!(
             smol_candidate_matches(&in_band, &plain),
             "a payload with no shim has no reason to reject 23.2"
+        );
+    }
+
+    /// The capability term has to arrive from the MANIFEST, not from a hand-built
+    /// `SmolTarget`. Every other test of this rule constructs the target directly,
+    /// so `requires_augmentation: m.requires_augmentation` in `smol_target` could
+    /// be replaced with a literal `false` — deleting the fix on the reading side —
+    /// and stay green. This is the test that goes red for that.
+    #[test]
+    fn the_shim_requirement_reaches_the_target_from_the_manifest() {
+        let mut manifest = test_manifest();
+        manifest.shape = Shape::Smol;
+        manifest.node_version = "22.15.0".to_string();
+        manifest.requires_augmentation = true;
+        let target = smol_target(&manifest).unwrap();
+        assert!(
+            !target.matches(&NodeVersion::new(23, 2, 0)),
+            "23.2 clears the 22.15 floor but predates registerHooks on the 23.x line, \
+             so a payload that says it needs the API must not accept it"
+        );
+
+        // Same manifest, one field flipped: without it 23.2 is a fine runtime, which
+        // is what proves the refusal above came from the field and not the floor.
+        manifest.requires_augmentation = false;
+        assert!(
+            smol_target(&manifest)
+                .unwrap()
+                .matches(&NodeVersion::new(23, 2, 0)),
+            "a payload with no shim has no claim on registerHooks"
         );
     }
 

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -1204,8 +1204,10 @@ fn alpine_package_for(lib: &str) -> String {
 /// version-manager layouts → PATH → shell-out provision. Legacy payloads accept
 /// any Node at or above their target; new payloads enforce exact targets and
 /// explicit ranges. Provisioning prefers `provision_version` — the newest release
-/// the COMPILER resolved for the pin — and falls back to the manifest version when
-/// the payload names none. Acceptance is unaffected either way.
+/// the COMPILER resolved for the pin AND judged able to run the payload — and
+/// falls back to the manifest version when the payload names none, which covers a
+/// legacy manifest and one whose newest match could not run its shim alike.
+/// Acceptance is unaffected either way.
 fn acquire_smol_node(
     m: &Manifest,
     base: &Path,
@@ -1243,9 +1245,11 @@ fn acquire_smol_node(
     }
 
     // 3. Provision via shell-out. Prefer the version the COMPILER resolved as the
-    // newest satisfying the pin: the target's floor may be the oldest release this
-    // binary tolerates — `--target 26` landing on 26.0.0. Legacy manifests name no
-    // preference and still get the floor.
+    // newest satisfying the pin THAT CAN RUN THIS PAYLOAD: the target's floor may
+    // be the oldest release this binary tolerates — `--target 26` landing on
+    // 26.0.0. Two payloads name no preference and get the floor instead: a legacy
+    // manifest, and one whose newest match lacked the API its shim needs, where
+    // the floor is the capability the build gate already proved.
     let fetch = smol_provision_version(m).unwrap_or_else(|| target.floor.clone());
     if !target.matches(&fetch) {
         bail!("compiled provision version {fetch} does not satisfy its runtime target");

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -1272,6 +1272,9 @@ struct SmolTarget {
     floor: NodeVersion,
     exact: bool,
     range: Option<VersionPin>,
+    /// The payload installs a `module.registerHooks` shim, so a candidate that
+    /// lacks the API cannot run it whatever the version policy says.
+    requires_augmentation: bool,
 }
 
 impl SmolTarget {
@@ -1281,10 +1284,19 @@ impl SmolTarget {
             floor,
             exact,
             range: None,
+            requires_augmentation: false,
         }
     }
 
+    /// Version policy AND capability. The two are separate questions and the
+    /// version one cannot answer the capability one: 23.0–23.4 sorts above a
+    /// 22.15 floor and satisfies a `>=22.15` range, yet predates `registerHooks`
+    /// on the 23.x line. Accepting such a candidate produced a binary that built
+    /// clean and threw `registerHooks is not a function` on the user's machine.
     fn matches(&self, candidate: &NodeVersion) -> bool {
+        if self.requires_augmentation && !candidate.supports_augmentation() {
+            return false;
+        }
         if let Some(range) = &self.range {
             candidate.satisfies(range)
         } else if self.exact {
@@ -1326,6 +1338,7 @@ fn smol_target(m: &Manifest) -> Result<SmolTarget> {
         floor,
         exact: m.smol_exact_target,
         range,
+        requires_augmentation: m.requires_augmentation,
     })
 }
 
@@ -2940,6 +2953,7 @@ mod tests {
             provision_version: String::new(),
             smol_exact_target: false,
             smol_version_range: String::new(),
+            requires_augmentation: false,
             triple: "darwin-arm64".to_string(),
             node_sha256: format!("{:x}", Sha256::digest(b"node")),
             node_blake3: String::new(),
@@ -4076,6 +4090,7 @@ mod tests {
             floor: NodeVersion::new(22, 0, 0),
             exact: false,
             range: Some(parse_target_spec(">=22 <23").unwrap()),
+            requires_augmentation: false,
         };
         assert!(smol_candidate_matches(&NodeVersion::new(22, 23, 1), &range));
         assert!(!smol_candidate_matches(&NodeVersion::new(21, 7, 3), &range));
@@ -4084,6 +4099,55 @@ mod tests {
         assert!(
             select_path_node((PathBuf::from("node"), NodeVersion::new(26, 5, 0)), &range).is_none(),
             "PATH must apply the range ceiling too"
+        );
+    }
+
+    /// A payload carrying a `registerHooks` shim must refuse a discovered Node that
+    /// lacks the API, whatever the version policy says about it.
+    ///
+    /// 23.0–23.4 is the band that makes this more than bookkeeping: it sorts above a
+    /// 22.15 floor and satisfies a `>=22.15` range, so every version-shaped check
+    /// admits it, and `registerHooks` did not reach the 23.x line until 23.5. A
+    /// `--smol --external` artifact built against a 22.15 floor therefore shipped
+    /// clean and threw `registerHooks is not a function` on a box running 23.2.
+    #[test]
+    fn a_shim_bearing_smol_artifact_refuses_a_node_without_register_hooks() {
+        let floor = NodeVersion::new(22, 15, 0);
+        let in_band = NodeVersion::new(23, 2, 0);
+        let above_band = NodeVersion::new(23, 5, 0);
+
+        let shimmed = SmolTarget {
+            floor: floor.clone(),
+            exact: false,
+            range: None,
+            requires_augmentation: true,
+        };
+        assert!(
+            !smol_candidate_matches(&in_band, &shimmed),
+            "23.2 clears the 22.15 floor but predates registerHooks, so the shim cannot run"
+        );
+        assert!(
+            smol_candidate_matches(&above_band, &shimmed),
+            "23.5 has the API and must still be accepted"
+        );
+        assert!(smol_candidate_matches(&floor, &shimmed));
+
+        // A carried range admits the same band, so the capability term has to
+        // survive the range arm rather than only the floor arm.
+        let shimmed_range = SmolTarget {
+            floor: floor.clone(),
+            exact: false,
+            range: Some(parse_target_spec(">=22.15").unwrap()),
+            requires_augmentation: true,
+        };
+        assert!(!smol_candidate_matches(&in_band, &shimmed_range));
+
+        // Without a shim the band is perfectly runnable and must not be refused —
+        // this is what keeps the fix from becoming a blanket 23.x ban.
+        let plain = SmolTarget::legacy(floor, false);
+        assert!(
+            smol_candidate_matches(&in_band, &plain),
+            "a payload with no shim has no reason to reject 23.2"
         );
     }
 
@@ -4450,6 +4514,7 @@ mod tests {
             floor: NodeVersion::new(22, 0, 0),
             exact: false,
             range: Some(parse_target_spec(">=22 <23").unwrap()),
+            requires_augmentation: false,
         };
         assert_eq!(
             best_node_in_policy_probed(&NodeDir::plain(plain.clone()), &bounded, "darwin-arm64")

--- a/tests/compile-augmentation/run.sh
+++ b/tests/compile-augmentation/run.sh
@@ -33,6 +33,14 @@ NODE_VERSION="${1:-26.5.0}"
 WORK="${WORK:-${TMPDIR:-/tmp}/nub-compile-augmentation}"
 read -r -a EXTRA_COMPILE_FLAGS <<< "${COMPILE_FLAGS:-}"
 
+# `--out` is taken VERBATIM — the target's exe suffix is only applied when the
+# name is defaulted from the entry — so asking for `./bin` on Windows produces an
+# extensionless file, and whether that runs then depends on the shell rather than
+# on nub. Naming the suffix here keeps the harness saying what it means.
+EXE=""
+case "$(uname -s)" in MINGW* | MSYS* | CYGWIN*) EXE=.exe ;; esac
+ARTIFACT="bin$EXE"
+
 rm -rf "$WORK"; mkdir -p "$WORK"; cd "$WORK" || exit 1
 printf '%s\n' "$NODE_VERSION" > .node-version
 npm init -y >/dev/null 2>&1
@@ -97,15 +105,15 @@ for fixture in "${fixtures[@]}"; do
 
   built=1
   if "$NUB" compile "$entry" ${compile_flags[@]+"${compile_flags[@]}"} \
-       ${EXTRA_COMPILE_FLAGS[@]+"${EXTRA_COMPILE_FLAGS[@]}"} --out ./bin >./build.log 2>&1; then
+       ${EXTRA_COMPILE_FLAGS[@]+"${EXTRA_COMPILE_FLAGS[@]}"} --out "./$ARTIFACT" >./build.log 2>&1; then
     rm -rf ./cache
-    got_out="$(cd "${TMPDIR:-/tmp}" && XDG_CACHE_HOME="$WORK/cache" "$WORK/bin" 2>&1)"; got_rc=$?
+    got_out="$(cd "${TMPDIR:-/tmp}" && XDG_CACHE_HOME="$WORK/cache" "$WORK/$ARTIFACT" 2>&1)"; got_rc=$?
     got="$(printf '%s' "$got_out" | tail -1) rc=$got_rc"
   else
     built=0
     got="<build failed: $(grep -m1 -iE 'error' ./build.log | cut -c1-60)>"
   fi
-  rm -f ./bin
+  rm -f "./$ARTIFACT"
 
   # A few augmentations are SUPPOSED to disappear when compiled — .env loading
   # above all, because a baked program's configuration must not depend on the

--- a/tests/compile-augmentation/run.sh
+++ b/tests/compile-augmentation/run.sh
@@ -112,6 +112,16 @@ for fixture in "${fixtures[@]}"; do
   else
     built=0
     got="<build failed: $(grep -m1 -iE 'error' ./build.log | cut -c1-60)>"
+    # The table cell is 60 characters, which names a build failure without ever
+    # explaining one. On a platform the author cannot reproduce on, that cell is
+    # the ONLY evidence that exists — a `--sourcemap=inline` build failed this way
+    # on Windows arm64 and the run said `error: in ` and nothing more. Dump the
+    # log so a red CI leg carries its own diagnosis.
+    {
+      echo "--- $name: compile failed, full build log ---"
+      cat ./build.log
+      echo "--- end $name ---"
+    } >&2
   fi
   rm -f "./$ARTIFACT"
 

--- a/wiki/commands/compile-architecture.md
+++ b/wiki/commands/compile-architecture.md
@@ -35,7 +35,7 @@ A range qualifies when its lower bound is representable and floor resolution ret
 
 The split is not cosmetic. The bundle is stripped against the resolved gate, so a form whose gate is not the range's minimum must not have its range enforced — the artifact would otherwise accept a Node whose polyfills it already removed. Two cases miss: an upper-only range, whose gate falls back to the newest matching release, and a range whose minimum is published but carries no artifact for the target, where the gate lands above it. [[crates/nub-core/src/version_management/mod.rs#range_minimum_is]] is the single predicate both sides read.
 
-When no installed Node qualifies, the launcher provisions the newest matching release resolved at compile time.
+When no installed Node qualifies, the launcher provisions the newest matching release resolved at compile time — provided that release can run the payload. A bundle carrying a `module.registerHooks` shim needs a Node that has the API, and version order does not imply it: 23.0 through 23.4 sort above a 22.15 floor and satisfy a range built on it, yet predate `registerHooks` on the 23.x line. Where the newest match fails that test the compiler records no preference at all, and the launcher provisions the floor, which the build already gated on the same capability.
 
 ## Anatomy of a compiled binary
 


### PR DESCRIPTION
A production-readiness pass over `nub compile`. One real defect class, closed at both ends, plus the test and CI coverage that was missing around it.

## The defect

A `--smol` build that carries `--external` or `--allow-dynamic-import` installs a `module.registerHooks` shim, so the Node it runs on must provide that API. The build-time gate only saw the pin's **floor**, and a floor in `22.15.0..23.0.0` admits the 23.0–23.4 band — which sorts above the floor and satisfies the range, yet predates `registerHooks` on the 23.x line. `--target ">=22.15"` built clean and the artifact died on the user's machine with `registerHooks is not a function`.

It is closed at both ends, because a version bound cannot answer a capability question:

- **Discovery** — the manifest now records that the payload *needs* the API, and `SmolTarget::matches` applies `supports_augmentation` to the candidate actually found, rather than predicting it from a bound.
- **Provisioning** — the same artifact could still bake a provisioning preference with the same defect: `--target ">=22.15 <23.5"` resolves its newest satisfying release to 23.4. `provision_preference_is_usable` drops it at build time. Falling back is safe rather than merely conservative — `check_node_support` has already failed the build when a shim-bearing floor lacks the API, so no preference means the launcher provisions a floor known to run the payload.

The build gate stays, because it fails the *build*, which is where a wrongly-chosen target should be reported and before the ~100 MB download.

## Also here

- A discovered Node refused on capability now says so once, naming the version that gained the API on its own line. It was silent, so a user with a modern-looking Node saw an unexplained download.
- **The erasability harness runs on every native host**, not Linux alone — macOS and both Windows legs. It is the only gate that catches an augmentation the runtime makes and the compiler does not, and that class is not Linux-specific. One portability fix was needed: `--out` is taken verbatim, so it now names the target's exe suffix instead of asking for an extensionless `./bin`.
- `compile` now appears in both help surfaces, feature-gated so a feature-off dev build still advertises nothing it would reject.
- Three bundler tests for flags that had no coverage (`--conditions`, `--sourcemap-exclude-sources`, `--alias`), a brand leak fixed in a user-facing bundler error, and two misleading test names corrected — both cover the harness, not a compiled artifact.
- `--enable-source-maps` withholding on Node 26: the comment asked for a re-verification once 26.8.0 shipped. It has, so I ran it. `TypeError` on 26.7.0, `AssertionError` on 26.8.1 — the predicted boundary holds and the constant is unchanged. The artifact published as v26.8.0 also gives `AssertionError`, but it self-reports `v26.8.0-alpha.0.0.0`, which sorts *below* `26.8.0` and so lands inside the withheld band; the comment now states that rather than rounding it off.
- `package-lock.json` is ignored. `npm install` creates one whenever anyone populates `node_modules` for the compile suites, and being neither tracked nor ignored left it one `git add` from a commit.

## Verification

Every new test was mutation-tested: the fix reverted, the test confirmed **red**, the fix restored. That covers the producing side (`provision_preference_is_usable`), the reading side (the `smol_target` wiring), and the manifest field end-to-end from a produced artifact in both directions.

Local gates green: root `clippy --all-targets --all-features`, `fmt --check` in all three workspaces, launcher `clippy --all-targets` plus 74/74, nub-cli 785 unit tests. The augmentation harness runs **13 ok / 0 failed** on macOS at Node 24, the version this workflow pins.

**Reviewing this needs one flag.** A plain local `nub compile` silently injects a *cached release* launcher rather than your build (`compile/launcher.rs`), so a fix can look absent when it is present. Pass `__NUB_LAUNCHER_TEMPLATE=crates/nub-launcher/target/release/nub-launcher`.

## Known, not changed — two things this pass found and deliberately left

`tests/compile-augmentation/a-sourcemap` fails on Node 26.0–26.7, and that is correct: `source_maps_safe` deliberately withholds `--enable-source-maps` across that band for nodejs/node#63169, and a compiled artifact is a minified bundle so it needs the map that `nub <file>` does not. CI pins Node 24, where the row is green. Teaching the fixture about the withholding band would duplicate that policy, so what the row should assert is left as a call to make.

`compile_artifact_process_bootstrap_topology` fails on a Node 26.4+ host over `--js-defer-import-eval`, which #770 auto-unflags from that version. Its CI gate (`ci.yml`, "Compile artifact process topology") is pinned to `matrix.node == '24'`, so nub's newest supported major is unverified for compiled-artifact process topology and CI never sees the mismatch. Raising the gate to 26 turns the leg red until the Worker-vs-root execArgv difference is resolved, which is flag-injection territory rather than compile-capability, so it is reported rather than folded in here.
