### PR TITLE
fix(config): inject the Windows local-app-data root into pnpm's config-dir resolver

### DIFF
--- a/vendor/aube/crates/aube-registry/src/config.rs
+++ b/vendor/aube/crates/aube-registry/src/config.rs
@@ -29,7 +29,7 @@ use env::npm_config_env_entries_from;
 use load::{
     GlobalNpmrcPaths, expand_userconfig_path, load_npmrc_entries_tagged_with_globals,
     load_npmrc_entries_tagged_with_home, load_npmrc_entries_with_home, resolve_global_npmrc_paths,
-    userconfig_override_from_env,
+    test_local_app_data, test_pnpm_global_auth_ini_path, userconfig_override_from_env,
 };
 #[cfg(test)]
 use npmrc::{parse_npmrc, parse_npmrc_untrusted, substitute_env};

--- a/vendor/aube/crates/aube-registry/src/config/load.rs
+++ b/vendor/aube/crates/aube-registry/src/config/load.rs
@@ -126,6 +126,7 @@ impl NpmConfig {
         // Feed tagged entries so `apply_tagged` can reject
         // high-privilege settings sourced from untrusted locations.
         let xdg = aube_util::env::xdg_config_home();
+        let local_app_data = aube_util::env::local_app_data();
         let home = home_dir();
         // `NPM_CONFIG_USERCONFIG` / `npm_config_userconfig` move the
         // user-level `.npmrc` off the default `$HOME/.npmrc`. npm and
@@ -142,6 +143,7 @@ impl NpmConfig {
         let tagged = load_npmrc_entries_tagged_with_globals(
             home.as_deref(),
             xdg.as_deref(),
+            local_app_data.as_deref(),
             project_dir,
             user_rc_override.as_deref(),
             &global_paths,
@@ -201,6 +203,7 @@ pub fn load_npmrc_entries_split(project_dir: &Path) -> SplitNpmrcEntries {
         return hit.clone();
     }
     let xdg = aube_util::env::xdg_config_home();
+    let local_app_data = aube_util::env::local_app_data();
     let home = home_dir();
     let user_rc_override =
         userconfig_env_value().and_then(|raw| expand_userconfig_path(&raw, home.as_deref()));
@@ -208,6 +211,7 @@ pub fn load_npmrc_entries_split(project_dir: &Path) -> SplitNpmrcEntries {
     let tagged = load_npmrc_entries_tagged_with_globals(
         home.as_deref(),
         xdg.as_deref(),
+        local_app_data.as_deref(),
         project_dir,
         user_rc_override.as_deref(),
         &global_paths,
@@ -271,6 +275,7 @@ pub struct SplitNpmrcEntries {
 /// project files that can block or be attacker-controlled.
 pub fn load_user_npmrc_entries(project_dir: &Path) -> Vec<(String, String)> {
     let xdg = aube_util::env::xdg_config_home();
+    let local_app_data = aube_util::env::local_app_data();
     let home = home_dir();
     let user_rc_override =
         userconfig_env_value().and_then(|raw| expand_userconfig_path(&raw, home.as_deref()));
@@ -278,6 +283,7 @@ pub fn load_user_npmrc_entries(project_dir: &Path) -> Vec<(String, String)> {
     let mut tagged = load_user_npmrc_entries_tagged(
         home.as_deref(),
         xdg.as_deref(),
+        local_app_data.as_deref(),
         project_dir,
         user_rc_override.as_deref(),
         &global_paths,
@@ -353,6 +359,7 @@ pub fn load_npmrc_entries(project_dir: &Path) -> Vec<(String, String)> {
     // explicit override so tests don't inherit the developer's real
     // `XDG_CONFIG_HOME` and pick up whatever auth tokens live there.
     let xdg = aube_util::env::xdg_config_home();
+    let local_app_data = aube_util::env::local_app_data();
     let home = home_dir();
     // `*_CONFIG_USERCONFIG` relocates the user-level `.npmrc` (XDG
     // layouts, `~/.config/npm/npmrc`, etc.). Read directly rather than
@@ -367,6 +374,7 @@ pub fn load_npmrc_entries(project_dir: &Path) -> Vec<(String, String)> {
     let tagged = load_npmrc_entries_tagged_with_globals(
         home.as_deref(),
         xdg.as_deref(),
+        local_app_data.as_deref(),
         project_dir,
         user_rc_override.as_deref(),
         &global_paths,
@@ -472,6 +480,10 @@ pub(super) fn load_npmrc_entries_tagged_with_home(
     load_npmrc_entries_tagged_with_globals(
         home,
         xdg_config_home,
+        // Derived, not a parameter: isolation is the whole point of this
+        // shim, so no fixture should be able to forget to pass it and
+        // silently read the developer's real `%LOCALAPPDATA%` (nub#605).
+        home.map(test_local_app_data).as_deref(),
         project_dir,
         user_rc_override,
         &GlobalNpmrcPaths::default(),
@@ -489,6 +501,7 @@ pub(super) fn load_npmrc_entries_tagged_with_home(
 pub(super) fn load_npmrc_entries_tagged_with_globals(
     home: Option<&Path>,
     xdg_config_home: Option<&Path>,
+    local_app_data: Option<&Path>,
     project_dir: &Path,
     user_rc_override: Option<&Path>,
     global_paths: &GlobalNpmrcPaths,
@@ -552,7 +565,7 @@ pub(super) fn load_npmrc_entries_tagged_with_globals(
     if let Some(home) = home
         && pnpm_auth_ini_enabled()
     {
-        let auth_ini = pnpm_global_auth_ini_path(home, xdg_config_home);
+        let auth_ini = pnpm_global_auth_ini_path(home, xdg_config_home, local_app_data);
         if auth_ini.exists()
             && let Ok(entries) = parse_npmrc(&auth_ini)
         {
@@ -603,6 +616,7 @@ pub(super) fn load_npmrc_entries_tagged_with_globals(
 fn load_user_npmrc_entries_tagged(
     home: Option<&Path>,
     xdg_config_home: Option<&Path>,
+    local_app_data: Option<&Path>,
     project_dir: &Path,
     user_rc_override: Option<&Path>,
     global_paths: &GlobalNpmrcPaths,
@@ -647,7 +661,7 @@ fn load_user_npmrc_entries_tagged(
     if let Some(home) = home
         && pnpm_auth_ini_enabled()
     {
-        let auth_ini = pnpm_global_auth_ini_path(home, xdg_config_home);
+        let auth_ini = pnpm_global_auth_ini_path(home, xdg_config_home, local_app_data);
         if auth_ini.exists()
             && let Ok(entries) = parse_npmrc(&auth_ini)
         {
@@ -998,17 +1012,46 @@ fn resolve_global_npmrc_paths_from_std_env() -> GlobalNpmrcPaths {
 /// [`load_npmrc_entries`]; tests inject an override or `None`) the file
 /// lives at `<xdg>/pnpm/auth.ini` on every OS; otherwise it follows the
 /// platform default — macOS `~/Library/Preferences/pnpm`, Windows
-/// `%LOCALAPPDATA%\pnpm\config`, Linux `~/.config/pnpm`. A flat
+/// `<local_app_data>\pnpm\config`, Linux `~/.config/pnpm`. A flat
 /// `~/.config/pnpm` is correct only on Linux, so the previous
 /// home-joined fallback read the wrong location on a stock macOS or
 /// Windows box and silently missed the user's `auth.ini` there.
-fn pnpm_global_auth_ini_path(home: &Path, xdg_config_home: Option<&Path>) -> PathBuf {
-    let config_dir = aube_util::env::pnpm_config_dir_with(Some(home), xdg_config_home)
-        // `home` is always `Some` at every call site (guarded by
-        // `if let Some(home) = home`), so the helper only returns `None`
-        // when both home and XDG are absent — impossible here. Keep a
-        // defined fallback rather than unwrap so a future caller change
-        // can't panic.
-        .unwrap_or_else(|| home.join(".config").join("pnpm"));
+///
+/// `local_app_data` is the Windows root, injected for the same reason
+/// `home` is: production reads `%LOCALAPPDATA%`, tests pin a tempdir. It
+/// is inert on every other platform.
+fn pnpm_global_auth_ini_path(
+    home: &Path,
+    xdg_config_home: Option<&Path>,
+    local_app_data: Option<&Path>,
+) -> PathBuf {
+    let config_dir =
+        aube_util::env::pnpm_config_dir_with(Some(home), xdg_config_home, local_app_data)
+            // `home` is always `Some` at every call site (guarded by
+            // `if let Some(home) = home`), so the helper only returns `None`
+            // when both home and XDG are absent — impossible here. Keep a
+            // defined fallback rather than unwrap so a future caller change
+            // can't panic.
+            .unwrap_or_else(|| home.join(".config").join("pnpm"));
     config_dir.join("auth.ini")
+}
+
+/// The `%LOCALAPPDATA%`-equivalent root the `*_with_home` test loaders
+/// pin under an injected tempdir home. A real Windows profile puts it at
+/// `<home>\AppData\Local`, so mirroring that keeps the Windows branch of
+/// [`aube_util::env::pnpm_config_dir_with`] genuinely under test instead
+/// of routing every fixture to the `~/.config` fallback a `None` would
+/// select — while staying inside the tempdir.
+#[cfg(test)]
+pub(super) fn test_local_app_data(home: &Path) -> PathBuf {
+    home.join("AppData").join("Local")
+}
+
+/// The `auth.ini` path the `*_with_home` test loaders read for a given
+/// tempdir `$HOME` and no XDG override. Fixture writers compose their
+/// path through this rather than by hand, so the write and the read can
+/// never drift apart on a platform nobody ran the suite on (nub#605).
+#[cfg(test)]
+pub(super) fn test_pnpm_global_auth_ini_path(home: &Path) -> PathBuf {
+    pnpm_global_auth_ini_path(home, None, Some(&test_local_app_data(home)))
 }

--- a/vendor/aube/crates/aube-registry/src/config/load.rs
+++ b/vendor/aube/crates/aube-registry/src/config/load.rs
@@ -562,19 +562,16 @@ pub(super) fn load_npmrc_entries_tagged_with_globals(
     {
         out.extend(entries.into_iter().map(|(k, v)| (NpmrcSource::User, k, v)));
     }
-    if let Some(home) = home
-        && pnpm_auth_ini_enabled()
+    if pnpm_auth_ini_enabled()
+        && let Some(auth_ini) = pnpm_global_auth_ini_path(home, xdg_config_home, local_app_data)
+        && auth_ini.exists()
+        && let Ok(entries) = parse_npmrc(&auth_ini)
     {
-        let auth_ini = pnpm_global_auth_ini_path(home, xdg_config_home, local_app_data);
-        if auth_ini.exists()
-            && let Ok(entries) = parse_npmrc(&auth_ini)
-        {
-            out.extend(
-                entries
-                    .into_iter()
-                    .map(|(k, v)| (NpmrcSource::PnpmAuth, k, v)),
-            );
-        }
+        out.extend(
+            entries
+                .into_iter()
+                .map(|(k, v)| (NpmrcSource::PnpmAuth, k, v)),
+        );
     }
     if let Some((auth_path, auth_source)) = resolve_npmrc_auth_file_tagged(home, project_dir, &out)
         && !auth_source.is_project_controlled()
@@ -658,19 +655,16 @@ fn load_user_npmrc_entries_tagged(
     {
         out.extend(entries.into_iter().map(|(k, v)| (NpmrcSource::User, k, v)));
     }
-    if let Some(home) = home
-        && pnpm_auth_ini_enabled()
+    if pnpm_auth_ini_enabled()
+        && let Some(auth_ini) = pnpm_global_auth_ini_path(home, xdg_config_home, local_app_data)
+        && auth_ini.exists()
+        && let Ok(entries) = parse_npmrc(&auth_ini)
     {
-        let auth_ini = pnpm_global_auth_ini_path(home, xdg_config_home, local_app_data);
-        if auth_ini.exists()
-            && let Ok(entries) = parse_npmrc(&auth_ini)
-        {
-            out.extend(
-                entries
-                    .into_iter()
-                    .map(|(k, v)| (NpmrcSource::PnpmAuth, k, v)),
-            );
-        }
+        out.extend(
+            entries
+                .into_iter()
+                .map(|(k, v)| (NpmrcSource::PnpmAuth, k, v)),
+        );
     }
     if let Some((auth_path, _auth_source)) = resolve_npmrc_auth_file_tagged(home, project_dir, &out)
         && auth_path.exists()
@@ -1020,20 +1014,19 @@ fn resolve_global_npmrc_paths_from_std_env() -> GlobalNpmrcPaths {
 /// `local_app_data` is the Windows root, injected for the same reason
 /// `home` is: production reads `%LOCALAPPDATA%`, tests pin a tempdir. It
 /// is inert on every other platform.
+///
+/// `None` means no config dir resolves at all — no XDG root, no home, and
+/// (on Windows) no local-app-data root — so there is no `auth.ini` to
+/// read. Guarding on the config dir rather than on `home` is what keeps
+/// this matching pnpm, whose Windows branch reads `%LOCALAPPDATA%`
+/// without consulting a home directory at all.
 fn pnpm_global_auth_ini_path(
-    home: &Path,
+    home: Option<&Path>,
     xdg_config_home: Option<&Path>,
     local_app_data: Option<&Path>,
-) -> PathBuf {
-    let config_dir =
-        aube_util::env::pnpm_config_dir_with(Some(home), xdg_config_home, local_app_data)
-            // `home` is always `Some` at every call site (guarded by
-            // `if let Some(home) = home`), so the helper only returns `None`
-            // when both home and XDG are absent — impossible here. Keep a
-            // defined fallback rather than unwrap so a future caller change
-            // can't panic.
-            .unwrap_or_else(|| home.join(".config").join("pnpm"));
-    config_dir.join("auth.ini")
+) -> Option<PathBuf> {
+    aube_util::env::pnpm_config_dir_with(home, xdg_config_home, local_app_data)
+        .map(|dir| dir.join("auth.ini"))
 }
 
 /// The `%LOCALAPPDATA%`-equivalent root the `*_with_home` test loaders
@@ -1053,5 +1046,6 @@ pub(super) fn test_local_app_data(home: &Path) -> PathBuf {
 /// never drift apart on a platform nobody ran the suite on (nub#605).
 #[cfg(test)]
 pub(super) fn test_pnpm_global_auth_ini_path(home: &Path) -> PathBuf {
-    pnpm_global_auth_ini_path(home, None, Some(&test_local_app_data(home)))
+    pnpm_global_auth_ini_path(Some(home), None, Some(&test_local_app_data(home)))
+        .expect("a home is given, so every platform branch resolves")
 }

--- a/vendor/aube/crates/aube-registry/src/config/tests.rs
+++ b/vendor/aube/crates/aube-registry/src/config/tests.rs
@@ -1392,6 +1392,7 @@ fn npmrc_cascade_orders_builtin_global_user_project() {
     let tagged = load_npmrc_entries_tagged_with_globals(
         Some(home.path()),
         None,
+        Some(&test_local_app_data(home.path())),
         project.path(),
         None,
         &globals,
@@ -1471,6 +1472,7 @@ fn global_npmrc_may_set_token_helper_project_may_not() {
     config.apply_tagged(load_npmrc_entries_tagged_with_globals(
         Some(home.path()),
         None,
+        Some(&test_local_app_data(home.path())),
         project.path(),
         None,
         &globals,
@@ -2504,17 +2506,42 @@ fn test_load_npmrc_entries_orders_user_before_project() {
     );
 }
 
-// Windows-quarantined: these three build their `auth.ini` fixture at
-// `pnpm_config_dir_with(Some(tmp_home), None)`, and that helper DISCARDS the
-// injected home on Windows — it returns the real `%LOCALAPPDATA%\pnpm\config`
-// (`aube_util::env::pnpm_config_dir_with`). So the fixture escapes its tempdir
-// into the actual user profile, where it both contaminates every sibling test
-// that resolves a token and would clobber a real developer's pnpm credentials.
-// The XDG short-circuit in that helper is hermetic on every platform, but these
-// tests deliberately exercise the per-OS branch, so the fix is to make that
-// branch injectable rather than to reroute the tests. Tracked in nub#605.
+// The cross-platform guard for nub#605. The Windows branch of pnpm's
+// config-dir resolver used to read `%LOCALAPPDATA%` env-direct, so an
+// injected tempdir home was discarded there and the `auth.ini` path landed
+// in the developer's real user profile: every fixture write clobbered their
+// pnpm credentials, and every sibling test that resolved a token then read
+// the leftover. Assert the containment rather than the escape, so this fails
+// on the platform that regresses instead of on the one that runs it.
 #[test]
-#[cfg_attr(windows, ignore = "escapes its tempdir on Windows; nub#605")]
+fn pnpm_auth_ini_path_stays_inside_the_injected_home() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let auth_ini = test_pnpm_global_auth_ini_path(home_dir.path());
+    assert!(
+        auth_ini.starts_with(home_dir.path()),
+        "auth.ini escaped its tempdir: {} is not under {}",
+        auth_ini.display(),
+        home_dir.path().display()
+    );
+    if cfg!(windows) {
+        assert_eq!(
+            auth_ini,
+            test_local_app_data(home_dir.path())
+                .join("pnpm")
+                .join("config")
+                .join("auth.ini"),
+            "the Windows branch must resolve against the injected local-app-data root"
+        );
+    }
+}
+
+// These three exercise pnpm's per-OS config-dir branch (no XDG override), so
+// they build the fixture through `test_pnpm_global_auth_ini_path` — the same
+// resolver the loader reads, pinned to the tempdir home on every platform
+// including Windows. Composing the path by hand is what let the fixture escape
+// into the real `%LOCALAPPDATA%\pnpm\config` and overwrite a developer's pnpm
+// credentials (nub#605).
+#[test]
 fn pnpm_global_auth_ini_loads_and_overrides_user_rc() {
     // `~/.config/pnpm/auth.ini` is pnpm's out-of-band credential
     // file. Aube needs to read it so users who stash tokens there
@@ -2533,10 +2560,8 @@ fn pnpm_global_auth_ini_loads_and_overrides_user_rc() {
     .unwrap();
     // Place auth.ini at pnpm's per-OS config dir (no XDG override), not a
     // flat `~/.config/pnpm` — the latter is correct only on Linux, so the
-    // file must land where `pnpm_config_dir_with` resolves on the test host.
-    let auth_ini = aube_util::env::pnpm_config_dir_with(Some(home_dir.path()), None)
-        .unwrap()
-        .join("auth.ini");
+    // file must land where the loader itself resolves it on the test host.
+    let auth_ini = test_pnpm_global_auth_ini_path(home_dir.path());
     std::fs::create_dir_all(auth_ini.parent().unwrap()).unwrap();
     std::fs::write(
         &auth_ini,
@@ -2598,7 +2623,6 @@ fn pnpm_global_auth_ini_honors_xdg_config_home_override() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "escapes its tempdir on Windows; nub#605")]
 fn pnpm_global_auth_ini_loses_to_project_npmrc() {
     // Project `.npmrc` pins still win — per-repo configuration is
     // the most specific layer, and a user's global auth.ini
@@ -2607,9 +2631,7 @@ fn pnpm_global_auth_ini_loses_to_project_npmrc() {
     let home_dir = tempfile::tempdir().unwrap();
     let proj_dir = tempfile::tempdir().unwrap();
 
-    let auth_ini = aube_util::env::pnpm_config_dir_with(Some(home_dir.path()), None)
-        .unwrap()
-        .join("auth.ini");
+    let auth_ini = test_pnpm_global_auth_ini_path(home_dir.path());
     std::fs::create_dir_all(auth_ini.parent().unwrap()).unwrap();
     std::fs::write(
         &auth_ini,
@@ -2632,7 +2654,6 @@ fn pnpm_global_auth_ini_loses_to_project_npmrc() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "escapes its tempdir on Windows; nub#605")]
 fn pnpm_global_auth_ini_not_read_when_gate_disabled() {
     // The pnpm-NAMED GLOBAL `~/.config/pnpm/auth.ini` is gated by the
     // GLOBAL-scope `read_pnpm_global_config` posture — NOT the project-scope
@@ -2654,9 +2675,7 @@ fn pnpm_global_auth_ini_not_read_when_gate_disabled() {
     .unwrap();
     // Per-OS config dir (no XDG override), so the fixture matches where
     // `pnpm_global_auth_ini_path` looks on the test host.
-    let auth_ini = aube_util::env::pnpm_config_dir_with(Some(home_dir.path()), None)
-        .unwrap()
-        .join("auth.ini");
+    let auth_ini = test_pnpm_global_auth_ini_path(home_dir.path());
     std::fs::create_dir_all(auth_ini.parent().unwrap()).unwrap();
     std::fs::write(
         &auth_ini,

--- a/vendor/aube/crates/aube-registry/src/config/tests.rs
+++ b/vendor/aube/crates/aube-registry/src/config/tests.rs
@@ -2622,6 +2622,30 @@ fn pnpm_global_auth_ini_honors_xdg_config_home_override() {
     );
 }
 
+// pnpm resolves its config dir from `XDG_CONFIG_HOME` (and, on Windows, from
+// `%LOCALAPPDATA%`) without ever calling `os.homedir()`, so a machine with no
+// home still has a global `auth.ini`. Guarding the read on the presence of a
+// home instead of on the resolved config dir made nub skip the user's real
+// credentials there.
+#[test]
+fn pnpm_global_auth_ini_is_read_without_a_home_when_xdg_resolves() {
+    let _gate = AUTH_INI_GATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let xdg_dir = tempfile::tempdir().unwrap();
+    let proj_dir = tempfile::tempdir().unwrap();
+
+    let auth_ini = xdg_dir.path().join("pnpm/auth.ini");
+    std::fs::create_dir_all(auth_ini.parent().unwrap()).unwrap();
+    std::fs::write(&auth_ini, "//registry.example.com/:_authToken=xdg-token\n").unwrap();
+
+    let entries = load_npmrc_entries_with_home(None, Some(xdg_dir.path()), proj_dir.path(), None);
+    let mut cfg = NpmConfig::default();
+    cfg.apply(entries);
+    assert_eq!(
+        cfg.auth_token_for("https://registry.example.com/"),
+        Some("xdg-token"),
+    );
+}
+
 #[test]
 fn pnpm_global_auth_ini_loses_to_project_npmrc() {
     // Project `.npmrc` pins still win — per-repo configuration is

--- a/vendor/aube/crates/aube-util/src/env.rs
+++ b/vendor/aube/crates/aube-util/src/env.rs
@@ -272,6 +272,13 @@ pub fn local_app_data() -> Option<PathBuf> {
 /// 4. Windows → `%LOCALAPPDATA%\pnpm\config` when `LOCALAPPDATA` is set,
 ///    else `~/.config/pnpm`.
 ///
+/// A home directory is required only by the branches that join against it.
+/// pnpm calls `os.homedir()` inside each of those branches rather than up
+/// front, so its XDG and `LOCALAPPDATA` cases resolve on a machine with no
+/// home at all; this mirrors that. Checking home first instead would make
+/// nub miss the user's real global config and `auth.ini` on a Windows box
+/// where neither `HOME` nor `USERPROFILE` is set.
+///
 /// This is the directory that holds pnpm's global `config.yaml` (pnpm
 /// v11) and its global `auth.ini`. The platform branches matter: a flat
 /// `~/.config/pnpm` is correct only on Linux — on a stock macOS or
@@ -298,17 +305,16 @@ pub fn pnpm_config_dir_with(
     if let Some(xdg) = xdg_config_home {
         return Some(xdg.join("pnpm"));
     }
-    let home = home?;
     if cfg!(target_os = "macos") {
-        return Some(home.join("Library").join("Preferences").join("pnpm"));
+        return Some(home?.join("Library").join("Preferences").join("pnpm"));
     }
     if cfg!(windows) {
         if let Some(local) = local_app_data {
             return Some(local.join("pnpm").join("config"));
         }
-        return Some(home.join(".config").join("pnpm"));
+        return Some(home?.join(".config").join("pnpm"));
     }
-    Some(home.join(".config").join("pnpm"))
+    Some(home?.join(".config").join("pnpm"))
 }
 
 /// [`pnpm_config_dir_with`] using the process `$HOME` /
@@ -343,6 +349,11 @@ mod pnpm_config_dir_tests {
             ),
             Some(xdg.join("pnpm")),
             "an explicit XDG_CONFIG_HOME points the config dir at <xdg>/pnpm regardless of OS"
+        );
+        assert_eq!(
+            pnpm_config_dir_with(None, Some(xdg), None),
+            Some(xdg.join("pnpm")),
+            "pnpm's XDG branch never calls os.homedir(), so it resolves without a home"
         );
     }
 
@@ -395,14 +406,21 @@ mod pnpm_config_dir_tests {
         assert_eq!(pnpm_config_dir_with(Some(home), None, None), Some(expected));
     }
 
+    // pnpm's `getConfigDir` reads `LOCALAPPDATA` and returns before it ever
+    // reaches an `os.homedir()` call, so on Windows that root alone resolves
+    // the config dir — verified against `config/reader/src/dirs.ts` and the
+    // `getConfigDir()` case in its own `dirs.test.ts`. Every other platform
+    // joins against home, so the argument is inert there.
     #[test]
-    fn none_when_no_home_and_no_xdg() {
+    fn local_app_data_alone_resolves_the_config_dir_on_windows() {
+        let local = Path::new("/local/app/data");
+        let expected = cfg!(windows).then(|| local.join("pnpm").join("config"));
+        assert_eq!(pnpm_config_dir_with(None, None, Some(local)), expected);
+    }
+
+    #[test]
+    fn none_when_no_root_can_be_determined() {
         assert_eq!(pnpm_config_dir_with(None, None, None), None);
-        assert_eq!(
-            pnpm_config_dir_with(None, None, Some(Path::new("/local/app/data"))),
-            None,
-            "a local-app-data root alone is not a config dir — pnpm needs a home or an XDG root"
-        );
     }
 }
 

--- a/vendor/aube/crates/aube-util/src/env.rs
+++ b/vendor/aube/crates/aube-util/src/env.rs
@@ -281,15 +281,19 @@ pub fn local_app_data() -> Option<PathBuf> {
 /// Returns `None` only when neither an XDG override nor a home directory
 /// can be determined — callers then have no global config dir to read.
 ///
-/// `home` and `xdg_config_home` are injected (not read from the
-/// environment here) so tests can pin a tempdir without mutating
-/// process-wide env; production callers pass [`home_dir`] /
-/// [`xdg_config_home`]. Only `LOCALAPPDATA` is read env-direct — it has
-/// no per-call override site today and a defined non-env fallback
-/// (`~/.config/pnpm`).
+/// Every root this reads is injected — `home`, `xdg_config_home` and
+/// `local_app_data` — so a test can pin a tempdir without mutating
+/// process-wide env, on every platform. Production callers pass
+/// [`home_dir`] / [`xdg_config_home`] / [`local_app_data`]; the
+/// production composition is [`pnpm_config_dir`]. `local_app_data` used
+/// to be read env-direct inside the Windows branch, which silently
+/// discarded an injected `home` there: a fixture built at the returned
+/// path escaped its tempdir into the developer's real user profile and
+/// overwrote their pnpm credentials (nub#605).
 pub fn pnpm_config_dir_with(
     home: Option<&std::path::Path>,
     xdg_config_home: Option<&std::path::Path>,
+    local_app_data: Option<&std::path::Path>,
 ) -> Option<PathBuf> {
     if let Some(xdg) = xdg_config_home {
         return Some(xdg.join("pnpm"));
@@ -299,7 +303,7 @@ pub fn pnpm_config_dir_with(
         return Some(home.join("Library").join("Preferences").join("pnpm"));
     }
     if cfg!(windows) {
-        if let Some(local) = local_app_data() {
+        if let Some(local) = local_app_data {
             return Some(local.join("pnpm").join("config"));
         }
         return Some(home.join(".config").join("pnpm"));
@@ -308,11 +312,15 @@ pub fn pnpm_config_dir_with(
 }
 
 /// [`pnpm_config_dir_with`] using the process `$HOME` /
-/// `$XDG_CONFIG_HOME` (via [`home_dir`] / [`xdg_config_home`]).
-/// Production entry point; tests prefer the `_with` form to stay
-/// hermetic.
+/// `$XDG_CONFIG_HOME` / `%LOCALAPPDATA%` (via [`home_dir`] /
+/// [`xdg_config_home`] / [`local_app_data`]). Production entry point;
+/// tests prefer the `_with` form to stay hermetic.
 pub fn pnpm_config_dir() -> Option<PathBuf> {
-    pnpm_config_dir_with(home_dir().as_deref(), xdg_config_home().as_deref())
+    pnpm_config_dir_with(
+        home_dir().as_deref(),
+        xdg_config_home().as_deref(),
+        local_app_data().as_deref(),
+    )
 }
 
 #[cfg(test)]
@@ -320,17 +328,19 @@ mod pnpm_config_dir_tests {
     use super::*;
     use std::path::Path;
 
-    // These tests assert the *non-XDG* platform branch, so they must run
-    // with `XDG_CONFIG_HOME` unset. The suite runs serially
-    // (RUST_TEST_THREADS=1), and no other test in this crate sets
-    // `XDG_CONFIG_HOME`, so reading it env-direct is safe here. Guard
-    // anyway: if a developer's shell exports it, skip the platform-branch
-    // assertion rather than fail spuriously.
+    // Every root the resolver consults is a parameter, so these assert the
+    // platform branches exactly and read no environment variable — a
+    // developer who exports `XDG_CONFIG_HOME` or `LOCALAPPDATA` cannot
+    // perturb them.
     #[test]
     fn xdg_override_wins_on_every_platform() {
         let xdg = Path::new("/custom/xdg");
         assert_eq!(
-            pnpm_config_dir_with(Some(Path::new("/home/tester")), Some(xdg)),
+            pnpm_config_dir_with(
+                Some(Path::new("/home/tester")),
+                Some(xdg),
+                Some(Path::new("/local/app/data"))
+            ),
             Some(xdg.join("pnpm")),
             "an explicit XDG_CONFIG_HOME points the config dir at <xdg>/pnpm regardless of OS"
         );
@@ -339,24 +349,60 @@ mod pnpm_config_dir_tests {
     #[test]
     fn resolves_per_os_config_dir_without_xdg() {
         let home = Path::new("/home/tester");
-        let got = pnpm_config_dir_with(Some(home), None).expect("home given");
+        let local = Path::new("/local/app/data");
+        let got = pnpm_config_dir_with(Some(home), None, Some(local)).expect("home given");
         let expected = if cfg!(target_os = "macos") {
             home.join("Library").join("Preferences").join("pnpm")
         } else if cfg!(windows) {
-            // On a Windows test host LOCALAPPDATA is normally set; accept
-            // either the LOCALAPPDATA-rooted path or the `~/.config`
-            // fallback so the assertion holds regardless.
-            let local = local_app_data().map(|l| l.join("pnpm").join("config"));
-            local.unwrap_or_else(|| home.join(".config").join("pnpm"))
+            local.join("pnpm").join("config")
         } else {
             home.join(".config").join("pnpm")
         };
         assert_eq!(got, expected);
     }
 
+    // The injected local-app-data root is what the Windows branch uses, so
+    // an injected one must displace whatever `%LOCALAPPDATA%` says. This is
+    // the regression guard for nub#605: the branch used to read the env var
+    // itself, so a tempdir-pinned fixture landed in the real user profile.
+    #[test]
+    #[cfg(windows)]
+    fn windows_branch_uses_the_injected_local_app_data_not_the_env() {
+        let home = Path::new(r"C:\Users\tester");
+        let injected = Path::new(r"C:\fixture\AppData\Local");
+        assert_eq!(
+            pnpm_config_dir_with(Some(home), None, Some(injected)),
+            Some(injected.join("pnpm").join("config"))
+        );
+        assert_ne!(
+            pnpm_config_dir_with(Some(home), None, Some(injected)),
+            local_app_data().map(|l| l.join("pnpm").join("config")),
+            "a real %LOCALAPPDATA% must not win over the injected root"
+        );
+    }
+
+    // Windows with no local-app-data root falls back to the home-joined
+    // `~/.config/pnpm`, matching pnpm's own behavior when the variable is
+    // unset. On the other platforms the argument is inert.
+    #[test]
+    fn falls_back_to_home_config_when_local_app_data_is_absent() {
+        let home = Path::new("/home/tester");
+        let expected = if cfg!(target_os = "macos") {
+            home.join("Library").join("Preferences").join("pnpm")
+        } else {
+            home.join(".config").join("pnpm")
+        };
+        assert_eq!(pnpm_config_dir_with(Some(home), None, None), Some(expected));
+    }
+
     #[test]
     fn none_when_no_home_and_no_xdg() {
-        assert_eq!(pnpm_config_dir_with(None, None), None);
+        assert_eq!(pnpm_config_dir_with(None, None, None), None);
+        assert_eq!(
+            pnpm_config_dir_with(None, None, Some(Path::new("/local/app/data"))),
+            None,
+            "a local-app-data root alone is not a config dir — pnpm needs a home or an XDG root"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #605

The Windows branch of `pnpm_config_dir_with` read `%LOCALAPPDATA%` env-direct and discarded the injected home, so tempdir-pinned auth.ini fixtures landed in the real user profile and overwrote the developer's pnpm credentials.

The root is now a third parameter. Production passes `local_app_data()`, so the resolved location is unchanged; the test loaders derive `<home>/AppData/Local`. Closes the `load_isolated` read leak and retires the Windows quarantine on three tests.

Forcing the branch on macOS: with the fix, 140 config tests pass and a seeded token survives; with the env-direct read restored, five fail.