### PR TITLE
config: only write a key that something reads back

### DIFF
--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -249,26 +249,135 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
     // token is constant-on and folds the scanner version, so a scanner-logic bump
     // invalidates a warm tree and re-links; standalone aube's `None` skips the fold.
     extra_settings_fingerprint: Some(crate::dynamic_phantom::settings_fingerprint),
-    // `aubeNoAutoInstall` skips the engine's own pre-run staleness check, which
-    // lives in `commands::auto_install::ensure_installed` — reached only from the
-    // engine's `run` / `exec` / `restart`. None of those is an `ENGINE_VERB`: nub
-    // runs scripts through its own frontend and gates freshness in
-    // `crate::verify_deps`, so the engine's gate never executes and the setting
-    // decides nothing here. Before this entry `nub config set aubeNoAutoInstall
-    // true` wrote that key into the user's `.npmrc` and `nub config list --all`
-    // advertised it — nub putting the ENGINE's brand in a user's config for a
-    // value nub never reads.
+    // Every engine setting whose ONLY reader sits on a code path nub does not
+    // route. A listed name is absent from `meta::find`/`meta::all`, so `config
+    // set` refuses it in both scopes, `config list --all` stops advertising it,
+    // and the generated accessor falls through to the default — which is what it
+    // already resolved to, since nothing here reads the setting.
     //
-    // Deliberately the ONLY entry. `verifyDepsBeforeRun` and
-    // `optimisticRepeatInstall` are read by that same dead gate, but their names
-    // are neutral and pnpm-shared, and nub honors `verify-deps-before-run` on its
-    // own path — hiding them would break the pnpm surface to fix nothing.
-    unsupported_settings: &[(
-        "aubeNoAutoInstall",
-        "nub does not auto-install before a run. Use `verifyDeps` in nub.jsonc, or \
-         `verify-deps-before-run` in .npmrc, to choose what happens when dependencies \
-         are stale.",
-    )],
+    // The entry bar is exactly that: NOTHING reads it back. A setting nub reads
+    // on its own surface stays off this list even when the ENGINE's reader is
+    // dead (`verifyDepsBeforeRun` — `crate::verify_deps` resolves it from
+    // `.npmrc` / the workspace yaml itself), and so does one npm reads from
+    // `.npmrc` even though nub does not (`color`, `loglevel`): the npm-shared
+    // route exists for cross-tool visibility, so those writes have a consumer.
+    // Each advice line has to name a replacement that accepts the same VALUE, not
+    // just the same concept.
+    //
+    // Reachability is decided against `ENGINE_VERBS`. The engine's own
+    // `cli_main`, `run`/`exec`/`restart`, `auto_install`, `update_check`,
+    // `npm_fallback`, self-version switching and node-runtime provisioning are
+    // all unrouted, and `deploy` is a nub stub — so a reader that only lives
+    // there decides nothing.
+    unsupported_settings: &[
+        // `commands::auto_install::ensure_installed`, reached only from the
+        // engine's `run`/`exec`/`restart`. nub runs scripts through its own
+        // frontend and gates freshness in `crate::verify_deps`. Before this
+        // entry `nub config set aubeNoAutoInstall true` wrote the ENGINE's brand
+        // into a user's `.npmrc` for a value nub never reads.
+        (
+            "aubeNoAutoInstall",
+            "nub does not auto-install before a run. Use `verifyDeps` in nub.jsonc, or \
+             `verify-deps-before-run` in .npmrc, to choose what happens when dependencies \
+             are stale.",
+        ),
+        // Same dead gate: the flag that lets that auto-install skip a repeat.
+        (
+            "optimisticRepeatInstall",
+            "nub does not auto-install before a run, so there is no repeat install to skip. \
+             Use `verifyDeps` in nub.jsonc, or `verify-deps-before-run` in .npmrc, to choose \
+             what happens when dependencies are stale.",
+        ),
+        // `commands::run`, the engine's script runner. nub runs scripts through
+        // its own frontend (`cli::run_single_script`), which runs `pre`/`post`
+        // unconditionally — the DECIDED behavior, not an oversight: the run docs
+        // promise `npm run` semantics for the hooks and name `--ignore-scripts`
+        // as the way to skip them. So the key can never decide anything here,
+        // and the advice repeats the documented escape hatch.
+        (
+            "enablePrePostScripts",
+            "nub always runs `pre`/`post` scripts for a named script, like npm. \
+             Pass `--ignore-scripts` to `nub run` to skip the whole lifecycle.",
+        ),
+        // `update_check::check_and_notify`, reached from the engine's own CLI
+        // dispatcher and `doctor`. nub's self-update is `nub upgrade`
+        // (`self_update_enabled: false`), which never runs during another verb.
+        (
+            "updateNotifier",
+            "nub does not check for its own updates while running a command. Run `nub upgrade` \
+             when you want a new version.",
+        ),
+        // `runtime::RuntimeSettings::from_ctx`. `resolve_context` returns the
+        // PATH fallback before consuming any of them under
+        // `runtime_switching: false` — nub owns Node provisioning.
+        (
+            "runtimeInstaller",
+            "nub provisions Node itself rather than delegating to another installer. \
+             Manage versions with `nub node install` and `nub node pin`.",
+        ),
+        (
+            "runtimeOnFail",
+            "nub provisions Node itself and installs a missing pin on demand. \
+             Manage versions with `nub node install` and `nub node pin`.",
+        ),
+        (
+            "nodeDownloadMirrors",
+            "nub provisions Node itself and does not read the engine's download mirrors. \
+             Install the version another way and `nub node pin` it.",
+        ),
+        // `startup::StartupSettings` / `package_manager_guard_mode`, built by
+        // the engine's own CLI dispatcher and by self-version switching. nub
+        // resolves the `packageManager` pin in `nub_core::pm::resolve`.
+        (
+            "packageManagerStrict",
+            "nub does not enforce another package manager's pin. `nub pm pin` records the \
+             project's manager, and `nub pm which` reports the one in force.",
+        ),
+        (
+            "packageManagerStrictVersion",
+            "nub does not enforce another package manager's pinned version. `nub pm pin` \
+             records the project's manager.",
+        ),
+        (
+            "managePackageManagerVersions",
+            "nub does not download or switch package-manager versions. `nub pm pin` records \
+             the project's manager, and `nub upgrade` updates nub itself.",
+        ),
+        // `commands::npm_fallback`, the engine's shell-out dispatcher for verbs
+        // it has no implementation of. Every verb nub routes runs in-process.
+        (
+            "npmPath",
+            "nub never shells out to npm; every package-manager verb runs in-process.",
+        ),
+        // `commands::deploy`, which `install_family` refuses as a stub.
+        (
+            "deployAllFiles",
+            "nub does not implement `deploy`. For now: pnpm deploy.",
+        ),
+        // Read by the engine's own CLI dispatcher to pick an output stream. nub
+        // owns its output routing.
+        (
+            "useStderr",
+            "nub chooses its own output streams. Redirect the command's stdout or stderr \
+             in your shell instead.",
+        ),
+        // Parity no-ops in the engine ITSELF, not just under nub: accepted and
+        // wired to nothing. Both carry the standing note in settings.toml that
+        // the flag comes off once a caller starts gating on them.
+        ("useBetaCli", "nub has no beta-gated commands."),
+        (
+            "ignoreCompatibilityDb",
+            "nub ships no package-compatibility database, so there is nothing to disable.",
+        ),
+        // `install::FrozenMode::default_for_env` asks `aube_util::env::is_ci()`,
+        // which reads the `CI` ENVIRONMENT VARIABLE. No reader consults the
+        // config key, so an `.npmrc` `ci=` line has never decided anything.
+        (
+            "ci",
+            "nub detects CI from the `CI` environment variable, not from config. Set `CI=1`, \
+             or pass `--frozen-lockfile` / `--no-frozen-lockfile` to pin the install mode.",
+        ),
+    ],
 };
 
 /// Register [`NUB`] as the active embedder profile. Idempotent (the engine's
@@ -313,8 +422,11 @@ const _: () = {
     assert!(!NUB.warm_trust_revalidate);
     assert!(matches!(NUB.trust_policy_ignore_after_default, Some(20160)));
     assert!(NUB.extra_settings_fingerprint.is_some());
-    assert!(matches!(NUB.unsupported_settings, [(n, a)]
-        if matches!(n.as_bytes(), b"aubeNoAutoInstall") && !a.is_empty()));
+    // Non-empty (the pattern implies it) and still led by the entry the list was
+    // introduced for. Every name's realness and advice is checked at test time by
+    // `every_unsupported_setting_names_a_real_one`, which needs the settings table.
+    assert!(matches!(NUB.unsupported_settings, [(n, _), ..]
+        if matches!(n.as_bytes(), b"aubeNoAutoInstall")));
 };
 
 #[cfg(test)]

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -119,10 +119,12 @@
 //!   edit parent is on-disk temp state, never printed.
 //!
 //! KNOWN APPROXIMATIONS (install/ci, from slice 2):
-//! - `preferFrozenLockfile` from `.npmrc` / workspace yaml is not consulted
-//!   when defaulting the frozen mode (aube's `FileSources` is crate-private
-//!   at the pinned API); without a CLI flag the mode falls back to aube's
-//!   env-aware default (CI ⇒ frozen, else prefer-frozen).
+//! - (resolved) `preferFrozenLockfile` from `.npmrc` / workspace yaml is now
+//!   consulted when defaulting the frozen mode, through the fork's
+//!   `install::resolve_prefer_frozen_lockfile` seam (`FileSources` is still
+//!   crate-private; the seam builds the `ResolveCtx` engine-side). An unset
+//!   project still falls back to aube's env-aware default (CI ⇒ frozen, else
+//!   prefer-frozen), so only a project that sets the key changes behavior.
 //! - (resolved) The yarn gate now maps aube's frozen-drift failure by its
 //!   stable `ERR_AUBE_OUTDATED_LOCKFILE` diagnostic code; the old message
 //!   substring backstop is gone.
@@ -1282,8 +1284,15 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     let global_frozen = args.lockfile.frozen_override();
     let cli_flags = args.to_cli_flag_bag(global_frozen, args.virtual_store.flags());
 
-    // yaml_prefer_frozen: None — see KNOWN APPROXIMATIONS in the module doc.
-    let mut opts = args.into_options(global_frozen, None, cli_flags, super::env_snapshot());
+    // `preferFrozenLockfile` from the project's own config. Consulted only when
+    // no CLI override was given, and `None` — no source sets it — is the same
+    // env-aware default this used to pass unconditionally.
+    let mut opts = args.into_options(
+        global_frozen,
+        aube::commands::install::resolve_prefer_frozen_lockfile(),
+        cli_flags,
+        super::env_snapshot(),
+    );
     // The settings hash makes release-policy drift miss the no-op warm path.
     // Once there is real install work, opt into revalidating the existing
     // lockfile picks under the effective age gate. The engine only re-resolves

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1284,12 +1284,19 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     let global_frozen = args.lockfile.frozen_override();
     let cli_flags = args.to_cli_flag_bag(global_frozen, args.virtual_store.flags());
 
-    // `preferFrozenLockfile` from the project's own config. Consulted only when
-    // no CLI override was given, and `None` — no source sets it — is the same
-    // env-aware default this used to pass unconditionally.
+    // `preferFrozenLockfile` from the project's own config, and `None` — no
+    // source sets it — is the same env-aware default this used to pass
+    // unconditionally. Resolved lazily because the resolution is real file I/O
+    // (`FileSources::load` plus the workspace yaml) and `from_override` ignores
+    // the value outright once a CLI override exists — which is the common CI
+    // shape, where `--frozen-lockfile` is passed on every run.
+    let prefer_frozen = global_frozen
+        .is_none()
+        .then(aube::commands::install::resolve_prefer_frozen_lockfile)
+        .flatten();
     let mut opts = args.into_options(
         global_frozen,
-        aube::commands::install::resolve_prefer_frozen_lockfile(),
+        prefer_frozen,
         cli_flags,
         super::env_snapshot(),
     );

--- a/crates/nub-cli/src/pm_engine/store_config_family.rs
+++ b/crates/nub-cli/src/pm_engine/store_config_family.rs
@@ -839,6 +839,18 @@ mod npmrc_first {
             // `.npmrc` about the setting just written. `.npmrc` is
             // where the paired `keep_layout` allowlist reads them back from.
             Some(meta) if meta.layout => SetRoute::ProjectNpmrc,
+            // A known scalar with NO `.npmrc` alias cannot be read back out of
+            // the file this route writes: `write_plan` falls back to the key
+            // verbatim, so the line lands, `config set` reports success, and
+            // every reader looks somewhere else — the same silent no-op an
+            // unsupported setting used to produce. Refused rather than declared
+            // unsupported, because the surfaces these DO have (a CLI flag, the
+            // workspace yaml under a pnpm incumbent) keep working and must keep
+            // reading. Only the `.npmrc` route is decided here; the yaml route's
+            // own `.npmrc` fallback re-asks in [`set_project_npmrc`].
+            Some(meta) if !scalar_to_yaml && meta.npmrc_keys.is_empty() => {
+                SetRoute::Refuse(no_npmrc_home_error(meta))
+            }
             // Known scalar (including canonical dotted names like
             // `peerDependencyRules.allowedVersions`).
             Some(_) => scalar_route,
@@ -881,6 +893,9 @@ mod npmrc_first {
     /// so a stale `auto-install-peers=` line can't shadow a fresh
     /// `autoInstallPeers=` write (the engine reads them last-write-wins).
     pub(super) fn set_project_npmrc(key: &str, value: &str) -> Result<i32> {
+        if let Some(err) = no_npmrc_home_refusal(key) {
+            return Err(err);
+        }
         let path = project_root().join(".npmrc");
         let (sweep, write_key) = write_plan(key);
         npmrc_set(&path, &sweep, &write_key, value)?;
@@ -897,6 +912,9 @@ mod npmrc_first {
     /// read-coherent. (Auth/registry keys take the engine's own user-`.npmrc`
     /// writer instead — see the `set` dispatch.)
     pub(super) fn set_user_npmrc(key: &str, value: &str) -> Result<i32> {
+        if let Some(err) = no_npmrc_home_refusal(key) {
+            return Err(err);
+        }
         let Some(home) = home_dir() else {
             return Err(anyhow!(
                 "nub config set --global: could not locate the home directory\n\
@@ -1064,6 +1082,56 @@ mod npmrc_first {
         ))
     }
 
+    /// The refusal for a key naming a real setting that has NO `.npmrc` alias,
+    /// `None` for every other key — including an unknown one, which is free-form
+    /// and legitimately lands in `.npmrc` verbatim.
+    ///
+    /// The choke point every `.npmrc` write asks, so the yaml route's own
+    /// fallback and the global writer are covered as well as
+    /// [`classify_set`]'s direct route.
+    pub(super) fn no_npmrc_home_refusal(key: &str) -> Option<anyhow::Error> {
+        setting_for_key(key)
+            .filter(|meta| meta.npmrc_keys.is_empty())
+            .map(no_npmrc_home_error)
+    }
+
+    /// Name the surfaces that DO read the setting. Both settings in this class
+    /// today (`pnpmfilePath`, `globalPnpmfile`) carry a CLI flag, and only
+    /// `pnpmfilePath` also has a workspace-yaml key.
+    ///
+    /// An `AUBE_*` variable is never offered: `env_prefix: None` means nub does
+    /// not read the engine's env family, so naming one would replace a dead
+    /// write with a dead export. That leaves both of these with real advice; a
+    /// future setting sourced ONLY from `AUBE_*` would fall to the last line,
+    /// which is the honest answer rather than a wrong pointer.
+    fn no_npmrc_home_error(meta: &SettingMeta) -> anyhow::Error {
+        let mut homes: Vec<String> = Vec::new();
+        if let Some(flag) = meta.cli_flags.first() {
+            let flag = flag.trim_start_matches('-');
+            homes.push(format!("pass `--{flag} <value>` on the command line"));
+        }
+        if !meta.workspace_yaml_keys.is_empty() {
+            homes.push(format!(
+                "set `{}:` in pnpm-workspace.yaml under a pnpm project",
+                meta.workspace_yaml_keys[0]
+            ));
+        }
+        if let Some(var) = meta.env_vars.iter().find(|v| !v.starts_with("AUBE_")) {
+            homes.push(format!("export `{var}`"));
+        }
+        let advice = if homes.is_empty() {
+            "it has no config-file home at all".to_string()
+        } else {
+            homes.join(", or ")
+        };
+        anyhow!(
+            "nub config set {}: `{}` is not readable from .npmrc, so writing it there would do nothing\n\
+             \x20\x20{advice}",
+            meta.name,
+            meta.name
+        )
+    }
+
     fn map_setting_error(name: &str) -> anyhow::Error {
         anyhow!(
             "nub config set {name}: `{name}` is a workspace map setting and can't be set as a single value\n\
@@ -1206,6 +1274,50 @@ mod npmrc_first {
                 ),
                 "control: a non-layout scalar still follows the pnpm-v11 scalar home"
             );
+        }
+
+        /// A real setting with NO `.npmrc` alias is refused on the `.npmrc`
+        /// route and still allowed on the yaml one.
+        ///
+        /// Both halves matter and they pull opposite ways. `write_plan` falls
+        /// back to the key verbatim, so without the refusal the line lands and
+        /// nothing reads it; but `pnpmfilePath` DOES have a workspace-yaml key,
+        /// which a pnpm-v11 incumbent reads back — so a blanket refusal would
+        /// take away the one home that works. The invariant is per-ROUTE, not
+        /// per-setting. `autoInstallPeers` is the control: an ordinary scalar
+        /// with an `.npmrc` alias is untouched on both routes.
+        #[test]
+        fn a_setting_with_no_npmrc_alias_is_refused_on_the_npmrc_route() {
+            for key in ["pnpmfilePath", "globalPnpmfile"] {
+                assert!(
+                    matches!(classify_set(key, false), SetRoute::Refuse(_)),
+                    "{key} has no .npmrc alias and must not be written there"
+                );
+            }
+            assert!(
+                matches!(
+                    classify_set("pnpmfilePath", true),
+                    SetRoute::ProjectWorkspaceYaml
+                ),
+                "pnpmfilePath has a workspace-yaml key a pnpm-v11 incumbent reads back"
+            );
+            for scalar_to_yaml in [true, false] {
+                assert!(
+                    no_npmrc_home_refusal("autoInstallPeers").is_none(),
+                    "control: a setting with an .npmrc alias is never refused for lacking one"
+                );
+                assert!(
+                    !matches!(
+                        classify_set("autoInstallPeers", scalar_to_yaml),
+                        SetRoute::Refuse(_)
+                    ),
+                    "control: the ordinary scalar route is untouched (scalar_to_yaml={scalar_to_yaml})"
+                );
+            }
+            // An UNKNOWN key names no setting, so it is free-form config and
+            // still legal in `.npmrc`. Guarding by "has no alias" rather than by
+            // "is a known setting" would have refused every custom key.
+            assert!(no_npmrc_home_refusal("some-custom-key").is_none());
         }
 
         #[test]

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -436,6 +436,9 @@ pub(crate) fn plan_migration(source: &Map<String, Value>) -> Result<YamlMigratio
     }
 
     for (key, value) in source {
+        // Looked up once, ahead of the match, because a match GUARD cannot bind
+        // what it tests and the arm needs the same meta to reach the advice.
+        let unsupported = aube_settings::meta::unsupported_for_key(key);
         match key.as_str() {
             // structural / resolution-bearing → package.json
             "packages" => m.packages = Some(value.clone()),
@@ -493,8 +496,8 @@ pub(crate) fn plan_migration(source: &Map<String, Value>) -> Result<YamlMigratio
             // one of these would move a value out of a file pnpm read into a
             // file nothing reads, and report it as migrated. The profile's own
             // advice line is the note, so the drop names the replacement.
-            _ if aube_settings::meta::unsupported_for_key(key).is_some() => {
-                let note = aube_settings::meta::unsupported_for_key(key)
+            _ if unsupported.is_some() => {
+                let note = unsupported
                     .and_then(|meta| aube_settings::meta::unsupported_advice(meta.name))
                     .unwrap_or_default();
                 m.dropped.push(format!("{key} — {note}"));

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -45,6 +45,11 @@ use super::use_align::{self, AlignPlan, NUB_LEGACY_LOCKFILE, NUB_LOCKFILE};
 /// at build time, so the kebab line always parses). Objects and lists are
 /// emitted as JSON values — the engine's npmrc readers parse both
 /// (`object_setting_from_npmrc`, `parse_string_list`).
+///
+/// This is the HOME table, not the consumed set: an entry nub's embedder profile
+/// declares unsupported is warn-dropped by the earlier profile arm and never
+/// reaches this one. Entries deliberately stay listed so a setting that later
+/// becomes consumed resumes migrating without a second edit here.
 const NPMRC_KEYS: &[&str] = &[
     // data-shaped keys whose only engine-readable post-yaml home is .npmrc
     // (Bun-names addendum: no manifest-commons squatting)
@@ -479,6 +484,18 @@ pub(crate) fn plan_migration(source: &Map<String, Value>) -> Result<YamlMigratio
                     .iter()
                     .find(|(k, _)| k == key)
                     .map(|(_, n)| *n)
+                    .unwrap_or_default();
+                m.dropped.push(format!("{key} — {note}"));
+            }
+            // A setting nub's embedder profile declares it does not consume.
+            // Asked BEFORE [`NPMRC_KEYS`] and derived from the profile rather
+            // than a second hand-kept list, so the two cannot drift: migrating
+            // one of these would move a value out of a file pnpm read into a
+            // file nothing reads, and report it as migrated. The profile's own
+            // advice line is the note, so the drop names the replacement.
+            _ if aube_settings::meta::unsupported_for_key(key).is_some() => {
+                let note = aube_settings::meta::unsupported_for_key(key)
+                    .and_then(|meta| aube_settings::meta::unsupported_advice(meta.name))
                     .unwrap_or_default();
                 m.dropped.push(format!("{key} — {note}"));
             }

--- a/crates/nub-cli/tests/pm_config_defaults.rs
+++ b/crates/nub-cli/tests/pm_config_defaults.rs
@@ -184,18 +184,48 @@ fn the_listing_never_names_the_engine() {
     );
 }
 
+/// Every setting nub's embedder profile declares it does not consume, with a
+/// substring the refusal has to name so the user has somewhere to go.
+///
+/// One row per REASON the setting is inert under nub, not per setting name —
+/// the shared machinery is the same for all of them, and a row that only
+/// re-exercises it is the test bloat AGENTS.md warns about. What each row does
+/// buy is the advice check: an entry whose advice pointed at something that does
+/// not exist would still refuse, and refuse looking correct.
+const NOT_CONSUMED: &[(&str, &str)] = &[
+    // The engine's pre-run auto-install gate (nub runs scripts itself).
+    ("aubeNoAutoInstall", "verify"),
+    ("optimisticRepeatInstall", "verify"),
+    // Its script runner (nub's own frontend always runs pre/post).
+    ("enablePrePostScripts", "--ignore-scripts"),
+    // Its self-update notifier (`self_update_enabled: false`).
+    ("updateNotifier", "nub upgrade"),
+    // Its Node provisioning (`runtime_switching: false`).
+    ("runtimeInstaller", "nub node install"),
+    // Its package-manager-version guard, built only by its own CLI dispatcher.
+    ("managePackageManagerVersions", "nub pm pin"),
+    // Its npm shell-out dispatcher (every nub verb runs in-process).
+    ("npmPath", "in-process"),
+    // A verb nub stubs out.
+    ("deployAllFiles", "deploy"),
+    // A parity no-op in the engine itself, wired to nothing.
+    ("useBetaCli", "beta-gated"),
+    // Read as the `CI` environment variable, never as a config key.
+    ("ci", "CI"),
+];
+
 /// `config set` refuses a setting nub does not consume, and writes nothing.
 ///
 /// Refusing is the load-bearing half. Making the setting absent from the table
 /// is not enough on its own: an unrecognized key is legal config, so the write
-/// would fall through to the free-form path and land verbatim — nub putting the
-/// engine's brand into the user's own `.npmrc` for a value nub never reads.
+/// would fall through to the free-form path and land verbatim — nub reporting a
+/// successful write of a value nothing will ever read back.
 #[test]
 fn config_set_refuses_a_setting_nub_does_not_consume() {
-    // Both spellings, and both SCOPES. `--global` matters on its own: it takes
-    // a different branch that never reaches the project write router, so a
-    // guard on the router alone left it writing straight to `~/.npmrc`.
-    for key in ["aubeNoAutoInstall", "aube-no-auto-install"] {
+    // Both SCOPES for every row. `--global` matters on its own: it takes a
+    // different branch that never reaches the project write router, so a guard
+    // on the router alone left it writing straight to `~/.npmrc`.
+    for (key, advice) in NOT_CONSUMED {
         for scope in [&[][..], &["--global"][..]] {
             let mut argv = vec!["set", key, "true"];
             argv.extend_from_slice(scope);
@@ -205,11 +235,76 @@ fn config_set_refuses_a_setting_nub_does_not_consume() {
                 "`config set {key} {scope:?}` must fail: {stdout}{stderr}"
             );
             assert!(
-                stderr.contains("verifyDeps") || stderr.contains("verify-deps-before-run"),
-                "the refusal must name what to use instead: {stderr}"
+                stderr.contains(advice),
+                "the refusal for {key} must name what to use instead ({advice}): {stderr}"
             );
             // Neither scope's file may appear. The fixture pins HOME, so the
             // global target is inside it and a stray write is visible here.
+            assert!(
+                !project.join(".npmrc").exists(),
+                "`config set {key} {scope:?}` wrote a project .npmrc it had refused"
+            );
+            let home = project.parent().unwrap().join("home").join(".npmrc");
+            assert!(
+                !home.exists(),
+                "`config set {key} {scope:?}` wrote a user .npmrc it had refused"
+            );
+        }
+    }
+    // The alias surface too: the profile hangs its advice on the canonical name,
+    // and the lookup has to reach it from an `.npmrc` spelling as well.
+    let (_, stderr, code, _) = config(&["set", "aube-no-auto-install", "true"]);
+    assert_ne!(code, 0, "the kebab alias must refuse too: {stderr}");
+    assert!(stderr.contains("verify"), "{stderr}");
+}
+
+/// A setting nub does not consume is absent from `config list --all` too.
+///
+/// The write guard and the listing are separate code paths off one declaration,
+/// and only the listing answers "what can I set here?". Advertising a row that
+/// `set` then refuses is a worse surface than either failure alone.
+#[test]
+fn the_listing_never_offers_a_setting_nub_does_not_consume() {
+    let listing = list_all("not-consumed");
+    for (key, _) in NOT_CONSUMED {
+        let named = format!("{key}=");
+        assert!(
+            !listing.lines().any(|line| line.starts_with(&named)),
+            "`config list --all` still offers {key}:\n{listing}"
+        );
+    }
+    // Positive control, same shape as the brand row above: the listing really
+    // was populated, so every absence is a sweep rather than an empty read.
+    assert!(
+        listing.lines().count() > 50,
+        "expected a full `--all` listing, got:\n{listing}"
+    );
+}
+
+/// `config set` refuses a real setting that has no `.npmrc` home.
+///
+/// A distinct hole from the one above: these ARE consumed — just never from
+/// `.npmrc`, which has no key for them. The writer's alias plan falls back to
+/// the key verbatim, so the line landed, `config set` reported success, and
+/// every reader looked at the command line or the workspace yaml instead.
+#[test]
+fn config_set_refuses_a_setting_npmrc_cannot_hold() {
+    for (key, advice) in [
+        ("pnpmfilePath", "--pnpmfile"),
+        ("globalPnpmfile", "--global-pnpmfile"),
+    ] {
+        for scope in [&[][..], &["--global"][..]] {
+            let mut argv = vec!["set", key, "./hooks.cjs"];
+            argv.extend_from_slice(scope);
+            let (stdout, stderr, code, project) = config(&argv);
+            assert_ne!(
+                code, 0,
+                "`config set {key} {scope:?}` must fail: {stdout}{stderr}"
+            );
+            assert!(
+                stderr.contains(advice),
+                "the refusal for {key} must name a surface that is read ({advice}): {stderr}"
+            );
             assert!(
                 !project.join(".npmrc").exists(),
                 "`config set {key} {scope:?}` wrote a project .npmrc it had refused"

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -718,7 +718,7 @@ nub config get --local nodeCompat   # project file only
 nub config get preload --json       # ["./setup.ts","tsx/esm"]
 ```
 
-A key that is not a field of this file reads and writes `.npmrc`, so the value stays visible to npm, Yarn, and pnpm. Under a pnpm 11 project it writes `pnpm-workspace.yaml` instead, because that is the only file pnpm 11 reads a setting back from.
+A key that is not a field of this file reads and writes `.npmrc`, so the value stays visible to npm, Yarn, and pnpm. Nub picks whichever file will read the key back, so under a pnpm 11 project the settings pnpm moved out of `.npmrc` are written to `pnpm-workspace.yaml` instead. Registry and auth keys stay in `.npmrc` on every project.
 
 Nub refuses a key it would never read back rather than writing a line nothing consults, and names the surface that works instead. Two kinds hit this: a setting only the underlying engine's own CLI acts on, and a setting `.npmrc` has no spelling for.
 

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -718,4 +718,14 @@ nub config get --local nodeCompat   # project file only
 nub config get preload --json       # ["./setup.ts","tsx/esm"]
 ```
 
-A key that is not a field of this file reads and writes `.npmrc`.
+A key that is not a field of this file reads and writes `.npmrc`, so the value stays visible to npm, Yarn, and pnpm. Under a pnpm 11 project it writes `pnpm-workspace.yaml` instead, because that is the only file pnpm 11 reads a setting back from.
+
+Nub refuses a key it would never read back rather than writing a line nothing consults, and names the surface that works instead. Two kinds hit this: a setting only the underlying engine's own CLI acts on, and a setting `.npmrc` has no spelling for.
+
+```text
+$ nub config set updateNotifier false
+Error: nub config set updateNotifier: `updateNotifier` is not a nub setting
+  nub does not check for its own updates while running a command. Run `nub upgrade` when you want a new version.
+```
+
+Those keys are absent from `nub config list --all` too, so the listing and the write agree on what this project can set.

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -160,6 +160,33 @@ pub fn set_pre_summary_hook(hook: PreSummaryHook) {
     let _ = PRE_SUMMARY_HOOK.set(hook);
 }
 
+/// Resolve `preferFrozenLockfile` for the current project, the way the engine's
+/// own CLI does before [`InstallArgs::into_options`].
+///
+/// The embedder seam for a host that builds `InstallOptions` itself: the
+/// resolution needs a `ResolveCtx`, which needs `commands::FileSources`, and
+/// that is crate-private — so an embedder had no way to reach this setting and
+/// passed `None`, silently defaulting every project to the env-aware mode
+/// whatever its config said. Returns `None` when no source sets the setting,
+/// which is [`FrozenMode::from_override`]'s "fall back to the default" input, so
+/// an unset project resolves exactly as before.
+///
+/// Resolves from the WORKSPACE root when there is one, matching the engine's own
+/// call site: the workspace yaml lives there rather than in the member. A tree
+/// with no root at all reads from the cwd instead of failing — a config lookup
+/// must never be what ends a command.
+pub fn resolve_prefer_frozen_lockfile() -> Option<bool> {
+    let cwd = match crate::dirs::workspace_or_project_root() {
+        Ok(root) => root,
+        Err(_) => std::env::current_dir().ok()?,
+    };
+    let files = super::FileSources::load(&cwd);
+    let raw_ws = aube_manifest::workspace::load_raw(&cwd).unwrap_or_default();
+    let env = aube_settings::values::capture_env();
+    let ctx = files.ctx(&raw_ws, &env, &[]);
+    aube_settings::resolved::prefer_frozen_lockfile(&ctx)
+}
+
 pub(crate) fn emit_pre_summary(cwd: &std::path::Path, uses_shared_store: bool, is_noop: bool) {
     if let Some(hook) = PRE_SUMMARY_HOOK.get() {
         hook(PreSummary {


### PR DESCRIPTION
Refs #626
Refs #745

`nub config set` wrote every setting it accepted, including keys no reader under nub consults.

- 15 settings whose only reader is a code path nub does not route join the embedder's `unsupported_settings`, each refused with advice naming a replacement.
- `pnpmfilePath` / `globalPnpmfile` have no `.npmrc` spelling, so the writer's fallback wrote the key verbatim. Refused per route, leaving the workspace-yaml home intact.
- `preferFrozenLockfile` is honored instead: the install family passed a constant `None`. An unset project resolves as before.
- `nub pm use nub` warn-drops an unsupported setting rather than migrating it.

This is the ignored-key half of #626. Routing supported settings to `nub.jsonc`, and the nine duplicate homes, are untouched, so the issue stays open.
