### PR TITLE
spawn: stop folding nub's own preload into the preload chainer

### DIFF
--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -3154,6 +3154,41 @@ pub fn node_options_token(value: &str) -> String {
     }
 }
 
+/// Whether a `--require` / `--import` value names one of NUB'S OWN preload entry
+/// points — the runtime preload, or a synthesized preload chainer — rather than a
+/// user's. `value` must already be slash-normalized; a `file://` prefix is
+/// irrelevant because only the last two path components are read.
+///
+/// Recognized by SHAPE, deliberately, because the recognizer has to hold for a nub of
+/// any version whose token this process inherited, and because the directory the
+/// preload lives in is not one path but two:
+///
+/// - `<...>/runtime/preload.{mjs,cjs}` — the in-repo sidecar an `embed-runtime`-off
+///   dev build resolves to.
+/// - `<cache>/runtime-<version>-<hash8>/preload.{mjs,cjs}` — the extracted runtime
+///   cache every SHIPPED build resolves to (`runtime_cache::CACHE_KEY`).
+///
+/// A substring test for the first spelling alone silently misses every released
+/// binary, which is exactly how nub's own `--import` came to be folded into the
+/// chainer that nub's preload then imports: on the compat tier that is an ESM cycle
+/// through a top-level await, so the child hangs and Node exits 13 with no output
+/// (#746). CJS cycles resolve to a partial export instead of deadlocking, which is
+/// why the fast tier survived the same fold and hid the bug.
+fn is_nub_preload_entry(value: &str) -> bool {
+    let Some((parent, file)) = value.rsplit_once('/') else {
+        return false;
+    };
+    match file {
+        "preload.mjs" | "preload.cjs" => {
+            let dir = parent.rsplit('/').next().unwrap_or_default();
+            dir == "runtime" || dir.starts_with("runtime-")
+        }
+        // The chainer nub synthesizes into `<preload root>/node_modules/.nub/`.
+        "preload-chain.mjs" | "preload-chain.cjs" => parent.ends_with("/.nub"),
+        _ => false,
+    }
+}
+
 /// Split a NODE_OPTIONS-shaped string into individual flag tokens — the inverse of
 /// [`node_options_token`], mirroring Node's own `ParseNodeOptionsEnvVar`
 /// (.repos/node/src/node_options.cc): split on whitespace EXCEPT inside a
@@ -3180,9 +3215,9 @@ pub fn node_options_token(value: &str) -> String {
 ///   loader is not an import.
 /// - Yarn PnP (`.pnp.cjs`, `.pnp.loader.mjs`) — PnP's resolver has to install before
 ///   nub's preload, and the chainers run after it.
-///
-/// Safe against re-entrancy by construction: the caller only rebuilds `NODE_OPTIONS`
-/// when NOT re-entrant, so the inherited value cannot already carry nub's own token.
+/// - nub's own preload and chainer ([`is_nub_preload_entry`]) — the chainer is rebuilt
+///   on every spawn, re-entrant ones included, so an inherited nub token really does
+///   reach here and folding it would make nub's preload load itself.
 pub fn split_inherited_preloads(value: &str) -> (String, Vec<String>, Vec<String>) {
     // Left in place rather than folded. PnP's resolver must install before nub's
     // preload, and nub's OWN tokens must stay exactly where they are: a NESTED nub
@@ -3190,10 +3225,7 @@ pub fn split_inherited_preloads(value: &str) -> (String, Vec<String>, Vec<String
     // from inside itself and break the re-entrancy detection that keys on that token.
     fn keep_in_place(value: &str) -> bool {
         let v = value.trim_matches('"').replace('\\', "/");
-        v.ends_with(".pnp.cjs")
-            || v.ends_with(".pnp.loader.mjs")
-            || v.contains("/runtime/preload.")
-            || v.contains("/.nub/preload-chain.")
+        v.ends_with(".pnp.cjs") || v.ends_with(".pnp.loader.mjs") || is_nub_preload_entry(&v)
     }
 
     let tokens = split_node_options(value);
@@ -3444,8 +3476,10 @@ fn vendored_node_path(preload: Option<&str>) -> Option<OsString> {
 
 /// Find the preload entry script relative to the Nub binary.
 ///
-/// In development: `<repo>/runtime/preload.mjs`
-/// In distribution: `<nub-install-dir>/runtime/preload.mjs`
+/// In development (`embed-runtime` off): `<repo>/runtime/preload.mjs`
+/// In distribution: `<cache>/runtime-<version>-<hash8>/preload.mjs` — the extracted
+/// runtime cache, NOT a `runtime/` directory beside the binary. Anything matching
+/// this path by shape has to accept both spellings ([`is_nub_preload_entry`]).
 pub fn find_public_preload(nub_binary: &Path) -> Option<String> {
     find_preload(nub_binary)
 }
@@ -3815,6 +3849,61 @@ mod tests {
         let (rest, req, _) = split_inherited_preloads(r#"--require "/a b/c.cjs" --title=t"#);
         assert_eq!(req, vec!["/a b/c.cjs"]);
         assert_eq!(rest, "--title=t");
+    }
+
+    /// A SHIPPED nub resolves its preload out of the extracted runtime cache
+    /// (`runtime-<version>-<hash8>/`), never a plain `runtime/` sidecar — so the
+    /// recognizer has to hold for that spelling too. It did not, and folding nub's
+    /// own compat-tier `--import` into the chainer that nub's preload then imports
+    /// made an ESM cycle through a top-level await: exit 13, no output, on every
+    /// nested `node` a script ran under Node < 22.15 (#746). Every fixture in the
+    /// suite used the dev sidecar path, so the whole gate was dead in release.
+    #[test]
+    fn nub_preload_is_recognized_in_the_shipped_runtime_cache_layout() {
+        for own in [
+            "/home/u/.cache/nub/runtime-0.8.2-e6384feb/preload.mjs",
+            "/home/u/.cache/nub/runtime-0.8.2-e6384feb/preload.cjs",
+            "/opt/nub/runtime/preload.mjs",
+            "/p/node_modules/.nub/preload-chain.mjs",
+            "C:/Users/u/AppData/Local/nub/runtime-0.8.2-e6384feb/preload.cjs",
+        ] {
+            let (rest, req, imp) = split_inherited_preloads(&format!(
+                "--import=file://{own} --require={own} --require /a.cjs"
+            ));
+            assert_eq!(req, vec!["/a.cjs"], "only the user entry folds: {own}");
+            assert!(imp.is_empty(), "nub's own import must not fold: {own}");
+            assert_eq!(
+                rest.matches("preload").count(),
+                2,
+                "both nub tokens forwarded verbatim for {own}: {rest}"
+            );
+        }
+
+        // A user file that merely shares the name is still theirs to fold — the
+        // gate is the runtime/chainer directory, not the basename (A26).
+        let (_, req, _) = split_inherited_preloads("--require=/my/app/preload.cjs");
+        assert_eq!(req, vec!["/my/app/preload.cjs"]);
+    }
+
+    /// The recognizer and [`find_preload`] must agree on THIS build's layout,
+    /// whichever one it is. Binds the two together so a future move of the runtime
+    /// cache cannot silently re-open #746 under the feature set that ships.
+    #[test]
+    fn nub_recognizes_the_preload_it_actually_injects() {
+        let exe = std::env::current_exe().expect("test binary path");
+        match find_preload(&exe) {
+            Some(preload) => assert!(
+                is_nub_preload_entry(&preload.replace('\\', "/")),
+                "nub must recognize its own preload as un-foldable: {preload}"
+            ),
+            // Nothing resolvable means nothing is injected either, so there is no
+            // token to recognize — but a feature-on build carries the blob and must
+            // always extract one.
+            #[cfg(feature = "embed-runtime")]
+            None => panic!("an embed-runtime build must resolve its own preload"),
+            #[cfg(not(feature = "embed-runtime"))]
+            None => {}
+        }
     }
 
     #[test]

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -3174,19 +3174,48 @@ pub fn node_options_token(value: &str) -> String {
 /// through a top-level await, so the child hangs and Node exits 13 with no output
 /// (#746). CJS cycles resolve to a partial export instead of deadlocking, which is
 /// why the fast tier survived the same fold and hid the bug.
+///
+/// The cache spelling is matched against the FULL key grammar rather than a
+/// `runtime-` prefix, because over-claiming here is its own bug: a user entry wrongly
+/// held out of the chainer keeps its own `NODE_OPTIONS` token, and on the compat tier
+/// that token is a `--require` Node re-runs inside the loader worker — the double
+/// execution the chainer's compat-tier routing exists to prevent. A package directory
+/// named `runtime-hooks` is enough to trip a prefix test.
 fn is_nub_preload_entry(value: &str) -> bool {
     let Some((parent, file)) = value.rsplit_once('/') else {
         return false;
     };
     match file {
         "preload.mjs" | "preload.cjs" => {
-            let dir = parent.rsplit('/').next().unwrap_or_default();
-            dir == "runtime" || dir.starts_with("runtime-")
+            is_nub_runtime_dir(parent.rsplit('/').next().unwrap_or_default())
         }
         // The chainer nub synthesizes into `<preload root>/node_modules/.nub/`.
         "preload-chain.mjs" | "preload-chain.cjs" => parent.ends_with("/.nub"),
         _ => false,
     }
+}
+
+/// The directory name a nub preload sits in: the dev sidecar's plain `runtime`, or a
+/// shipped `runtime-<version>-<blobhash8>` cache key (`crates/nub-core/build.rs`,
+/// where `blobhash8` is the first four bytes of the blob's SHA-256 rendered as
+/// lowercase hex). The version is not validated — it is `CARGO_PKG_VERSION` and may
+/// carry a prerelease suffix with its own dashes — so the hex suffix is what carries
+/// the discrimination.
+fn is_nub_runtime_dir(dir: &str) -> bool {
+    if dir == "runtime" {
+        return true;
+    }
+    let Some(rest) = dir.strip_prefix("runtime-") else {
+        return false;
+    };
+    let Some((version, hash8)) = rest.rsplit_once('-') else {
+        return false;
+    };
+    !version.is_empty()
+        && hash8.len() == 8
+        && hash8
+            .bytes()
+            .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
 }
 
 /// Split a NODE_OPTIONS-shaped string into individual flag tokens — the inverse of
@@ -3895,10 +3924,24 @@ mod tests {
             );
         }
 
-        // A user file that merely shares the name is still theirs to fold — the
-        // gate is the runtime/chainer directory, not the basename (A26).
-        let (_, req, _) = split_inherited_preloads("--require=/my/app/preload.cjs");
-        assert_eq!(req, vec!["/my/app/preload.cjs"]);
+        // Over-claiming is its own bug, so the negative half matters as much: a user
+        // entry wrongly held back keeps its own token, and on the compat tier that
+        // `--require` is re-run inside the loader worker. A shared basename is not
+        // enough (A26), and neither is a `runtime-` prefix without the cache key's
+        // 8-hex blob suffix — `runtime-hooks` is an ordinary package name.
+        for theirs in [
+            "/my/app/preload.cjs",
+            "/app/runtime-hooks/preload.cjs",
+            "/n/node_modules/@scope/runtime-hooks/preload.mjs",
+            "/app/runtime-/preload.mjs",
+            "/app/runtime-0.8.2-E6384FEB/preload.mjs",
+            "/app/runtime-0.8.2-e6384fe/preload.mjs",
+            "/app/.nub/preload.mjs",
+        ] {
+            let (rest, req, _) = split_inherited_preloads(&format!("--require={theirs}"));
+            assert_eq!(req, vec![theirs], "a user entry must fold: {theirs}");
+            assert!(rest.is_empty(), "nothing left behind for {theirs}: {rest}");
+        }
     }
 
     /// The recognizer and [`find_preload`] must agree on THIS build's layout,

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -3860,15 +3860,31 @@ mod tests {
     /// suite used the dev sidecar path, so the whole gate was dead in release.
     #[test]
     fn nub_preload_is_recognized_in_the_shipped_runtime_cache_layout() {
-        for own in [
-            "/home/u/.cache/nub/runtime-0.8.2-e6384feb/preload.mjs",
-            "/home/u/.cache/nub/runtime-0.8.2-e6384feb/preload.cjs",
-            "/opt/nub/runtime/preload.mjs",
-            "/p/node_modules/.nub/preload-chain.mjs",
-            "C:/Users/u/AppData/Local/nub/runtime-0.8.2-e6384feb/preload.cjs",
+        // Each path is spelled the way its platform spells it, and the `--import`
+        // URL comes from `to_file_url` rather than a hand-built `file://` prefix, so
+        // every token here is one nub can really emit. A hand-built URL got the
+        // Windows drive form wrong (`file://C:/…`, whose `C:` parses as the URL
+        // authority and which Node rejects) — and a fixture that is not the real
+        // shape is precisely what let this bug through in the first place.
+        for (own, windows) in [
+            (
+                "/home/u/.cache/nub/runtime-0.8.2-e6384feb/preload.mjs",
+                false,
+            ),
+            (
+                "/home/u/.cache/nub/runtime-0.8.2-e6384feb/preload.cjs",
+                false,
+            ),
+            ("/opt/nub/runtime/preload.mjs", false),
+            ("/p/node_modules/.nub/preload-chain.mjs", false),
+            (
+                r"C:\Users\u\AppData\Local\nub\runtime-0.8.2-e6384feb\preload.cjs",
+                true,
+            ),
         ] {
+            let url = to_file_url(own, windows);
             let (rest, req, imp) = split_inherited_preloads(&format!(
-                "--import=file://{own} --require={own} --require /a.cjs"
+                "--import={url} --require={own} --require /a.cjs"
             ));
             assert_eq!(req, vec!["/a.cjs"], "only the user entry folds: {own}");
             assert!(imp.is_empty(), "nub's own import must not fold: {own}");


### PR DESCRIPTION
Nub recognized its own preload token in an inherited `NODE_OPTIONS` by a substring matching only the dev layout. A shipped binary resolves its preload from the runtime cache, so nub folded its own token into the chainer its own preload loads. On the compat tier that is an ESM cycle through a top-level await: Node exits 13 silently, killing every nested `node` a script runs. The fast tier rides `--require`, where a CJS cycle returns a partial export — which hid it.

Now recognized by shape: `preload.{mjs,cjs}` under `runtime` or `runtime-*`, plus the chainer under `.nub/`.

On Node 20, `nub i` with `sqlite3@5.1.7` exits 13 on the merge base and installs here.

Closes #746
