### PR TITLE
install: retry dependency builds a previous install could not run

### DIFF
--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1816,3 +1816,137 @@ fn ci_rejects_lockfile_whose_root_importer_is_empty() {
         );
     }
 }
+
+/// A dependency build the previous install could not run leaves the tree
+/// incomplete, so the next install must not report it up to date
+/// (nubjs/nub#764). Before the fix nothing recorded that a build was owed:
+/// `check_needs_install` compared only inputs describing what the tree was
+/// built FROM, found them all unchanged, printed "Already up to date" and
+/// exited 0 — permanently, on every later install, with no way out but
+/// `--force` or deleting `node_modules`.
+///
+/// The assertion is the install's own verdict rather than the build's output,
+/// and that is not a shortcut. Three earlier drafts asserted on a marker file
+/// and each answered the wrong question. A marker written inside the dependency
+/// is part of a `file:` package's content, so deleting it to set up the retry
+/// changes the very input the install compares — and the side-effects cache
+/// restores it whether the script re-ran or not. A marker written outside the
+/// dependency never survives the build jail, which scrubs the environment and
+/// confines writes. The verdict has neither problem: it is exactly what the
+/// issue reports and exactly what the fix changes.
+///
+/// This lives nub-side rather than in aube's own e2e suite because the warm
+/// short-circuit is not reachable there at all — measured: under aube's
+/// defaults a `file:` dependency takes the full path on every install, with or
+/// without a build script, so only a dependency-free project ever goes warm.
+#[test]
+fn an_owed_dependency_build_stops_the_next_install_reporting_up_to_date() {
+    let dir = pm_tmpdir("owed-build-retry");
+    let dep = dir.join("plainbuild");
+    std::fs::create_dir_all(&dep).unwrap();
+    std::fs::write(
+        dep.join("package.json"),
+        r#"{"name":"plainbuild","version":"1.0.0","scripts":{"postinstall":"node -e \"process.exit(0)\""}}"#,
+    )
+    .unwrap();
+    // The approval is keyed by SOURCE (`name@file:./path`), not bare name — a
+    // bare-name entry never authorizes a source-backed build.
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"app","version":"1.0.0","private":true,"dependencies":{"plainbuild":"file:./plainbuild"},"allowBuilds":{"plainbuild@file:./plainbuild":true}}"#,
+    )
+    .unwrap();
+    // Dead registry + no retries: the fixture is entirely local, so any
+    // network attempt is a regression and must fail fast rather than hang.
+    std::fs::write(
+        dir.join(".npmrc"),
+        "registry=http://127.0.0.1:1/\nfetch-retries=0\n",
+    )
+    .unwrap();
+
+    // Run an install and report whether it took the warm short-circuit.
+    let up_to_date = || -> bool {
+        let out = Command::new(nub_binary())
+            .arg("install")
+            .current_dir(&dir)
+            .env("XDG_DATA_HOME", dir.join("xdg-data"))
+            .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
+            .output()
+            .expect("failed to spawn nub");
+        let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "install failed unexpectedly\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        format!("{stdout}{stderr}").contains("Already up to date")
+    };
+
+    assert!(!up_to_date(), "the first install has work to do");
+
+    // CONTROL. Without it every "not up to date" below would also pass on a
+    // fixture that simply never reaches the warm path — which is precisely how
+    // three earlier drafts of this test managed to prove nothing.
+    assert!(
+        up_to_date(),
+        "control: a settled tree must take the warm path, or the assertions below are vacuous"
+    );
+
+    let state_dir = dir.join("node_modules/.store/.nub-state");
+    assert!(
+        state_dir.is_dir(),
+        "expected install state at {}",
+        state_dir.display()
+    );
+
+    // Record a build as owed, exactly as an install that could not run one
+    // does. `None` strips the field entirely: state written before it existed,
+    // which is the shape a tree already sealed in the wild carries.
+    let strand = |deferred: Option<&str>| {
+        let mut touched = 0;
+        for name in ["state.json", "fresh.json"] {
+            let path = state_dir.join(name);
+            let Ok(raw) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let mut doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+            match deferred {
+                Some(key) => doc["deferred_dep_builds"] = serde_json::json!([key]),
+                None => {
+                    doc.as_object_mut().unwrap().remove("deferred_dep_builds");
+                }
+            }
+            std::fs::write(&path, serde_json::to_string(&doc).unwrap()).unwrap();
+            touched += 1;
+        }
+        assert!(
+            touched > 0,
+            "no install state found at {}",
+            state_dir.display()
+        );
+    };
+
+    strand(Some("plainbuild@file:./plainbuild"));
+    assert!(
+        !up_to_date(),
+        "an install that recorded an owed build must re-run the pipeline rather than report \
+         the tree up to date — that verdict is the seal this issue is about"
+    );
+    assert!(
+        up_to_date(),
+        "and the retry must clear the record: an owed build costs one install, not a full \
+         install forever"
+    );
+
+    strand(None);
+    assert!(
+        !up_to_date(),
+        "install state predating the field cannot say what it deferred, so it must re-check \
+         once rather than read as nothing owed — that is what heals an already-sealed tree"
+    );
+    assert!(
+        up_to_date(),
+        "and that migration must be one-time: the re-check writes the field, so it cannot repeat"
+    );
+}

--- a/vendor/aube/crates/aube-codes/src/warnings.rs
+++ b/vendor/aube/crates/aube-codes/src/warnings.rs
@@ -19,6 +19,7 @@ pub const WARN_AUBE_HOOK_PACKAGE_ADDED: &str = "WARN_AUBE_HOOK_PACKAGE_ADDED";
 // ── install lifecycle ───────────────────────────────────────────────
 pub const WARN_AUBE_IGNORED_BUILD_SCRIPTS: &str = "WARN_AUBE_IGNORED_BUILD_SCRIPTS";
 pub const WARN_AUBE_DEFAULT_TRUST_BUILDS: &str = "WARN_AUBE_DEFAULT_TRUST_BUILDS";
+#[rustfmt::skip] pub const WARN_AUBE_BUILD_NOT_ATTEMPTED: &str = "WARN_AUBE_BUILD_NOT_ATTEMPTED";
 #[rustfmt::skip] pub const WARN_AUBE_OPTIONAL_BUILD_FAILED: &str = "WARN_AUBE_OPTIONAL_BUILD_FAILED";
 #[rustfmt::skip] pub const WARN_AUBE_NODE_GYP_BOOTSTRAP_FAILED: &str = "WARN_AUBE_NODE_GYP_BOOTSTRAP_FAILED";
 #[rustfmt::skip] pub const WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT: &str = "WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT";
@@ -209,6 +210,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_DEFAULT_TRUST_BUILDS,
         category: category::INSTALL_LIFECYCLE,
         description: "The `defaultTrust` floor let listed packages run build scripts without an explicit `allowBuilds` entry. Disclosure, not an error — set `defaultTrust=false` or an explicit `allowBuilds: false` entry to opt out.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_BUILD_NOT_ATTEMPTED,
+        category: category::INSTALL_LIFECYCLE,
+        description: "A dependency the build policy allows could not have its build scripts attempted, because its directory in the virtual store was not on disk when the lifecycle phase ran. The install records this so the next one retries instead of reporting the tree up to date; `aube install --force` rebuilds immediately.",
         exit_code: None,
     },
     CodeMeta {

--- a/vendor/aube/crates/aube/src/commands/install/default_trust.rs
+++ b/vendor/aube/crates/aube/src/commands/install/default_trust.rs
@@ -188,10 +188,40 @@ impl DefaultTrustFloor {
         pkg: &aube_lockfile::LockedPackage,
         times: &BTreeMap<String, String>,
     ) -> bool {
+        self.has_advisory_vetting() && self.trusts_ignoring_vetting(pkg, times)
+    }
+
+    /// This install lacked advisory vetting, and that alone is why the
+    /// floor did not trust the package — every other gate (enabled,
+    /// registry provenance, the allowlist, the cooling window) holds.
+    ///
+    /// Vetting is the floor's one *run-scoped* input: it turns on the
+    /// OSV gate reaching the network, or on the graph being inherited
+    /// from an already-vetted lockfile. Two otherwise-identical runs can
+    /// therefore disagree, and the run that says no leaves an allowed
+    /// build unrun. The install records these so the freshness predicate
+    /// can retry them instead of sealing the tree (nubjs/nub#764) — the
+    /// config-derived gates are excluded on purpose, because a package
+    /// the config denies is denied stably and re-running the full
+    /// install could never change the answer.
+    pub(crate) fn deferred_by_missing_vetting(
+        &self,
+        pkg: &aube_lockfile::LockedPackage,
+        times: &BTreeMap<String, String>,
+    ) -> bool {
+        !self.has_advisory_vetting() && self.trusts_ignoring_vetting(pkg, times)
+    }
+
+    /// [`Self::trusts`] with the advisory-vetting gate assumed to hold.
+    fn trusts_ignoring_vetting(
+        &self,
+        pkg: &aube_lockfile::LockedPackage,
+        times: &BTreeMap<String, String>,
+    ) -> bool {
         let Some(cutoff) = self.age_cutoff.as_deref() else {
             return false;
         };
-        if !self.enabled || !self.has_advisory_vetting() {
+        if !self.enabled {
             return false;
         }
         // Registry-resolved only. `local_source` covers file / link /
@@ -435,6 +465,53 @@ mod tests {
         assert!(
             !active_floor().trusts(&aliased, &times),
             "trust must key off the registry name, not the in-tree alias"
+        );
+    }
+
+    /// A run with no advisory vetting skips the whole dep-script phase,
+    /// so a package the floor would otherwise have built goes unbuilt —
+    /// and before nubjs/nub#764 nothing recorded that, which sealed the
+    /// tree. Only the vetting gate may produce a deferral: every other
+    /// gate is config-derived, so a package it denies is denied stably
+    /// and re-running the install could not change the answer.
+    #[test]
+    fn missing_vetting_defers_a_build_that_every_other_gate_allows() {
+        let pkg = listed_pkg();
+        let times = times_published_minutes_ago(&pkg, 10 * 1440);
+
+        let mut no_vetting = active_floor();
+        no_vetting.osv_gate_active = false;
+        assert!(
+            no_vetting.deferred_by_missing_vetting(&pkg, &times),
+            "vetting is the only gate that failed, so this build is owed a retry"
+        );
+
+        assert!(
+            !active_floor().deferred_by_missing_vetting(&pkg, &times),
+            "a run that DID build the package owes nothing"
+        );
+        assert!(
+            !DefaultTrustFloor::disabled().deferred_by_missing_vetting(&pkg, &times),
+            "defaultTrust=false is a stable config denial, not a deferral"
+        );
+
+        // Config-derived denials stay out of the deferred set even when
+        // vetting is also missing — otherwise every install would bust
+        // the warm path for a package that can never become allowed.
+        let mut unlisted = listed_pkg();
+        unlisted.name = "not-on-the-trust-list".into();
+        assert!(
+            !no_vetting.deferred_by_missing_vetting(&unlisted, &times),
+            "a package off the allowlist is denied stably"
+        );
+        let young = times_published_minutes_ago(&pkg, 60);
+        assert!(
+            !no_vetting.deferred_by_missing_vetting(&pkg, &young),
+            "a version inside the cooling window is denied by config, not by the run"
+        );
+        assert!(
+            !no_vetting.deferred_by_missing_vetting(&pkg, &BTreeMap::new()),
+            "an unknown publish time fails closed rather than deferring forever"
         );
     }
 

--- a/vendor/aube/crates/aube/src/commands/install/default_trust.rs
+++ b/vendor/aube/crates/aube/src/commands/install/default_trust.rs
@@ -38,17 +38,19 @@
 //! - **cooling window** — the resolved version's recorded publish time
 //!   (the lockfile-graph `time:` data the resolver records in-memory
 //!   whenever `minimumReleaseAge` is active) is older than the
-//!   `minimumReleaseAge` window. Unknown publish time fails closed *on a
-//!   fresh resolve* — a missing time there means the package never
-//!   cleared resolution-time vetting. On a **frozen** install
-//!   (`lockfile_vetted`) an unknown time instead *waives* the window:
-//!   since #892 (commit `2b61eaa`) the lockfile no longer persists
-//!   `time:` data under non-time-based resolution, so a frozen reinstall
-//!   legitimately has no times, and the cooling window — a
-//!   resolution-time defense against pulling a brand-new version — has
-//!   nothing to defend against when the install pulls nothing new. A
-//!   known-but-too-young time still denies even when frozen; only the
-//!   *absence* is waived, and only when `lockfile_vetted`. The other
+//!   `minimumReleaseAge` window. Unknown publish time fails closed for
+//!   a **new** pick — a missing time there means the package never
+//!   cleared resolution-time vetting. For a pick **inherited** from the
+//!   prior lockfile at the same version an unknown time instead
+//!   *waives* the window: since #892 (commit `2b61eaa`) the lockfile no
+//!   longer persists `time:` data under non-time-based resolution, so
+//!   an inherited pick legitimately has no time, and the cooling window
+//!   — a resolution-time defense against pulling a brand-new version —
+//!   has nothing to defend against for a pick that pulls nothing new. A
+//!   known-but-too-young time still denies; only the *absence* is
+//!   waived, and only for an inherited pick. This is decided
+//!   per-package ([`InheritedPicks`]), so one new pick does not revoke
+//!   the waiver for the rest of the graph. The other
 //!   gates (registry provenance, advisory vetting, the allowlist) still
 //!   apply. `minimumReleaseAge = 0` disables the floor entirely — it
 //!   consults the cooling defense, it never substitutes for it.
@@ -58,7 +60,61 @@
 //! explicitly named packages.
 
 use aube_scripts::AllowDecision;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
+
+/// Which of this install's resolved picks were already in the prior
+/// lockfile at the same version.
+///
+/// The cooling window's unknown-publish-time arm waives the window for
+/// an inherited pick, because such a pick pulls nothing new and the
+/// window is a resolution-time defense against pulling something new
+/// (module docs above). **That question is per-package.** An `aube add`
+/// re-resolve produces one graph holding both kinds at once — the added
+/// package is new, every unrelated package is reproduced unchanged —
+/// and the whole-graph `lockfile_vetted` boolean cannot tell them
+/// apart. Answering it with that boolean made adding any dependency
+/// un-trust every *other* package's build scripts, so `aube install`
+/// and `aube add` disagreed about the same package in the same tree
+/// under the same config (nubjs/nub#764).
+#[derive(Debug, Clone)]
+pub(crate) enum InheritedPicks {
+    /// The graph came straight from the lockfile, so every pick is
+    /// inherited: frozen install, `aube ci`, a teammate clone.
+    All,
+    /// The resolver ran. Canonical `name@version` keys that were in the
+    /// prior lockfile; anything else in the graph is a new pick. Empty
+    /// when there was no prior lockfile to inherit from.
+    FromPriorLockfile(HashSet<String>),
+}
+
+impl InheritedPicks {
+    /// Canonical keys of every registry-resolved package in the prior
+    /// lockfile. Deliberately mirrors `lockfile_has_new_picks` — same
+    /// `(registry_name, version)` identity, same `local_source.is_none()`
+    /// filter — so the two never disagree about what counts as new.
+    pub(crate) fn from_prior(prior: Option<&aube_lockfile::LockfileGraph>) -> Self {
+        Self::FromPriorLockfile(
+            prior
+                .map(|g| {
+                    g.packages
+                        .values()
+                        .filter(|p| p.local_source.is_none())
+                        .map(|p| format!("{}@{}", p.registry_name(), p.version))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        )
+    }
+
+    /// `canonical` is the `name@version` spelling the caller already
+    /// built for the publish-time lookup.
+    fn contains(&self, canonical: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::FromPriorLockfile(keys) => keys.contains(canonical),
+        }
+    }
+}
 
 /// Resolved floor state for one install. Construct via
 /// [`DefaultTrustFloor::from_settings`] after the post-resolve OSV
@@ -80,6 +136,13 @@ pub(crate) struct DefaultTrustFloor {
     /// inherited trust is bounded to what the lockfile actually
     /// evidences.
     lockfile_vetted: bool,
+    /// Per-package counterpart to `lockfile_vetted`, consulted by the
+    /// cooling window's unknown-publish-time arm and nothing else. See
+    /// [`InheritedPicks`] for why that arm cannot use the boolean above:
+    /// the advisory gate `lockfile_vetted` feeds really is whole-graph,
+    /// the cooling window really is not, and one field was answering
+    /// both.
+    inherited: InheritedPicks,
     /// ISO-8601 UTC cutoff derived from `minimumReleaseAge`: publish
     /// times lexicographically `<=` this string satisfy the window.
     /// `None` when the window is disabled — which disables the floor.
@@ -92,6 +155,7 @@ impl DefaultTrustFloor {
             enabled: false,
             osv_gate_active: false,
             lockfile_vetted: false,
+            inherited: InheritedPicks::FromPriorLockfile(HashSet::new()),
             age_cutoff: None,
         }
     }
@@ -102,6 +166,7 @@ impl DefaultTrustFloor {
             enabled: true,
             osv_gate_active: true,
             lockfile_vetted: false,
+            inherited: InheritedPicks::FromPriorLockfile(HashSet::new()),
             age_cutoff: Some(age_cutoff.to_string()),
         }
     }
@@ -114,6 +179,7 @@ impl DefaultTrustFloor {
         mra_cli_minutes: Option<u64>,
         osv_gate_active: bool,
         lockfile_vetted: bool,
+        inherited: InheritedPicks,
     ) -> Self {
         let enabled = aube_settings::resolved::default_trust(ctx);
         if !enabled {
@@ -130,6 +196,7 @@ impl DefaultTrustFloor {
             enabled,
             osv_gate_active,
             lockfile_vetted,
+            inherited,
             age_cutoff,
         }
     }
@@ -146,6 +213,15 @@ impl DefaultTrustFloor {
     /// the delta build path must fall back to the full eligible scan
     /// so packages that just became trusted are not skipped merely
     /// because their package bytes are unchanged.
+    ///
+    /// `inherited` is deliberately NOT folded in. It is a per-run graph
+    /// fact, not a posture: the set grows on every `add`, so folding it
+    /// would churn this hash and force a full eligible scan on every
+    /// install that touches the manifest. The one transition it can
+    /// cause — a package denied for being too young, then waived once it
+    /// is inherited — is already carried by
+    /// `select_previously_unreviewed_now_allowed`, which reselects
+    /// packages that were unreviewed last time and are allowed now.
     pub(crate) fn fingerprint(&self) -> String {
         let mut hasher = blake3::Hasher::new();
         hasher.update(b"default-trust-floor-v1");
@@ -247,23 +323,30 @@ impl DefaultTrustFloor {
         match published {
             // Known publish time: enforce the window on every install.
             Some(t) => t.as_str() <= cutoff,
-            // Unknown publish time. On a FRESH resolve the resolver
-            // records `time:` data in-memory whenever `minimumReleaseAge`
-            // is active, so a missing time means the package never cleared
-            // resolution-time vetting — fail closed. On a FROZEN install
-            // (`lockfile_vetted`) the graph is inherited from a lockfile
-            // whose versions were already pinned and vetted when it was
-            // written; the cooling window is a *resolution-time* defense
-            // (don't pull a brand-new version), and a frozen install pulls
-            // nothing new. Since `2b61eaa` the lockfile no longer persists
-            // `time:` data under non-time-based resolution (upstream #892),
-            // so `times` is legitimately empty on a frozen reinstall — and
-            // re-applying the age gate against that absence would wrongly
-            // deny build scripts that ran for whoever locked the file. The
-            // other gates (registry provenance, advisory vetting via
-            // `lockfile_vetted`, the allowlist) all still applied above, so
-            // waiving *only* the cooling window here keeps the floor sound.
-            None => self.lockfile_vetted,
+            // Unknown publish time. For a NEW pick the resolver records
+            // `time:` data in-memory whenever `minimumReleaseAge` is
+            // active, so a missing time means the package never cleared
+            // resolution-time vetting — fail closed. For an INHERITED
+            // pick the version was already pinned and vetted when the
+            // lockfile was written; the cooling window is a
+            // *resolution-time* defense (don't pull a brand-new
+            // version), and an inherited pick pulls nothing new. Since
+            // `2b61eaa` the lockfile no longer persists `time:` data
+            // under non-time-based resolution (upstream #892), so
+            // `times` is legitimately empty for such picks — and
+            // re-applying the age gate against that absence would
+            // wrongly deny build scripts that ran for whoever locked the
+            // file. The other gates (registry provenance, advisory
+            // vetting, the allowlist) all still applied above, so
+            // waiving *only* the cooling window here keeps the floor
+            // sound.
+            //
+            // Per-package rather than the whole-graph `lockfile_vetted`:
+            // see [`InheritedPicks`]. Reading the boolean here meant one
+            // new pick anywhere in the graph revoked the waiver for
+            // every unrelated inherited package, which is why `aube add`
+            // un-trusted packages a plain `aube install` trusts.
+            None => self.inherited.contains(&canonical),
         }
     }
 }
@@ -333,6 +416,7 @@ mod tests {
             enabled: true,
             osv_gate_active: true,
             lockfile_vetted: false,
+            inherited: InheritedPicks::FromPriorLockfile(HashSet::new()),
             age_cutoff: aube_resolver::MinimumReleaseAge {
                 minutes: 1440,
                 ..Default::default()
@@ -350,6 +434,21 @@ mod tests {
         DefaultTrustFloor {
             osv_gate_active: false,
             lockfile_vetted: true,
+            inherited: InheritedPicks::All,
+            ..active_floor()
+        }
+    }
+
+    /// The `aube add` shape: the resolver ran and produced new picks, so
+    /// this install's advisory coverage comes from the live OSV gate
+    /// (`osv_gate_active = true`, `lockfile_vetted = false`) — while
+    /// every package listed in `inherited` was reproduced from the prior
+    /// lockfile unchanged.
+    fn add_floor(inherited: &[&str]) -> DefaultTrustFloor {
+        DefaultTrustFloor {
+            inherited: InheritedPicks::FromPriorLockfile(
+                inherited.iter().map(|s| s.to_string()).collect(),
+            ),
             ..active_floor()
         }
     }
@@ -592,8 +691,55 @@ mod tests {
         );
         assert!(
             !active_floor().trusts(&pkg, &BTreeMap::new()),
-            "a fresh resolve with no recorded publish time must still fail closed — \
-             the waiver is gated on lockfile_vetted"
+            "a NEW pick with no recorded publish time must still fail closed — \
+             the waiver is gated on the pick being inherited"
+        );
+    }
+
+    /// `aube add <something-else>` must not un-trust an unrelated
+    /// package that was already in the lockfile and already built
+    /// (nubjs/nub#764).
+    ///
+    /// The add re-resolves, so `lockfile_vetted` goes false for the
+    /// whole graph — but the graph is a MIXTURE: only the added package
+    /// is new. Reading that one boolean in the cooling window's
+    /// unknown-time arm revoked the waiver for every inherited package
+    /// too, so the same tree, config and package flipped from trusted to
+    /// unreviewed on `add` and back on the next `install`.
+    ///
+    /// Nothing here loosens the floor: the package this admits was
+    /// already built by the install that locked it, its version is
+    /// unchanged, and this install's live OSV gate covers it. The
+    /// widening is against the *previous behavior*, not against the
+    /// documented posture — which is what makes it the bug.
+    #[test]
+    fn adding_a_dependency_does_not_untrust_the_packages_already_locked() {
+        let pkg = listed_pkg();
+        let inherited_key = format!("{}@{}", pkg.name, pkg.version);
+        // Post-#892 the reproduced pick carries no publish time.
+        let no_times = BTreeMap::new();
+
+        assert!(
+            add_floor(&[&inherited_key]).trusts(&pkg, &no_times),
+            "a pick reproduced unchanged from the lockfile keeps its waiver when an \
+             unrelated package is added"
+        );
+        assert!(
+            !add_floor(&[]).trusts(&pkg, &no_times),
+            "the package being ADDED is a new pick with no publish time, so it still \
+             fails closed — the waiver did not become unconditional"
+        );
+        assert!(
+            !add_floor(&[&inherited_key]).trusts(&pkg, &times_published_minutes_ago(&pkg, 60)),
+            "a KNOWN too-young publish time still denies an inherited pick: only the \
+             absence of a time is waived"
+        );
+        // The deferral marker exists for builds a run could not attempt.
+        // An inherited pick that this run trusts was attempted, so it
+        // owes nothing — otherwise every `add` would strand a retry.
+        assert!(
+            !add_floor(&[&inherited_key]).deferred_by_missing_vetting(&pkg, &no_times),
+            "a package this run trusted and built is not owed a retry"
         );
     }
 

--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -831,4 +831,140 @@ mod tests {
 
         assert_eq!(selected, BTreeSet::from(["esbuild@1.0.0".to_string()]));
     }
+
+    /// The SELECTION half of the nubjs/nub#764 fix, guarded directly — and it
+    /// needs its own test because nothing else reaches it. Busting freshness
+    /// only restarts the pipeline; this bail is what gets the owed package
+    /// another attempt.
+    ///
+    /// That gap was measured, not assumed. Deleting the bail and re-running
+    /// everything else left the two state-layer unit tests green AND the
+    /// binary-level integration test green, because freshness still busts, the
+    /// delta still narrows, the build is still dropped, and the tree still
+    /// settles on the install after. A regression here would have shipped
+    /// silently — which is the exact shape of the defect the bail fixes.
+    #[test]
+    fn lifecycle_delta_widens_when_a_dependency_build_is_owed() {
+        const HASH: &str = "policy-hash-under-test";
+        let dir = std::env::temp_dir().join(format!("aube-delta-owed-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let aube_dir = dir.join("node_modules/.aube");
+        std::fs::create_dir_all(&aube_dir).unwrap();
+        std::fs::write(dir.join("package.json"), r#"{"name":"x"}"#).unwrap();
+
+        // A real package, and NON-EMPTY hash maps: both
+        // `read_state_package_content_hashes` and
+        // `read_state_subtree_hashes` return `None` for an empty map, which
+        // would make the filter bail through `?` before ever reaching the
+        // branch under test — the control below is what caught that.
+        let mut graph = LockfileGraph::default();
+        let pkg = LockedPackage {
+            name: "dep".into(),
+            version: "1.0.0".into(),
+            dep_path: "dep@1.0.0".into(),
+            integrity: Some("sha512-dep".into()),
+            ..Default::default()
+        };
+        graph.packages.insert(pkg.dep_path.clone(), pkg);
+        let recorded =
+            BTreeMap::from([("dep@1.0.0".to_string(), "recorded-content-hash".to_string())]);
+
+        state::write_state(
+            &dir,
+            state::WriteStateInput {
+                section_filtered: false,
+                package_json_hashes: BTreeMap::new(),
+                cli_flags: &[],
+                package_content_hashes: recorded.clone(),
+                graph_lthash: String::new(),
+                package_subtree_hashes: recorded.clone(),
+                dep_build_policy_hash: HASH.to_string(),
+                layout: state::WriteStateLayout {
+                    graph: &graph,
+                    node_linker: aube_linker::NodeLinker::Isolated,
+                    modules_dir_name: "node_modules",
+                    aube_dir: &aube_dir,
+                    virtual_store_dir_max_length: 120,
+                    placements: None,
+                },
+                unreviewed_builds: Vec::new(),
+                deferred_dep_builds: Vec::new(),
+            },
+        )
+        .expect("state should write");
+
+        // The state directory is named for the embedder, so find it rather
+        // than hard-coding a spelling this test does not own.
+        let state_dir = std::fs::read_dir(dir.join("node_modules"))
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.ends_with("-state"))
+            })
+            .expect("install state directory");
+
+        // Rewrite the recorded deferral in place, as an install that could not
+        // run a build does. `None` strips the field entirely: the shape of
+        // state written before it existed.
+        let set_deferred = |owed: Option<&str>| {
+            let mut touched = 0;
+            for name in ["state.json", "fresh.json"] {
+                let path = state_dir.join(name);
+                let Ok(raw) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                let mut doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+                match owed {
+                    Some(key) => doc["deferred_dep_builds"] = serde_json::json!([key]),
+                    None => {
+                        doc.as_object_mut().unwrap().remove("deferred_dep_builds");
+                    }
+                }
+                std::fs::write(&path, serde_json::to_string(&doc).unwrap()).unwrap();
+                touched += 1;
+            }
+            assert!(touched > 0, "no state files at {}", state_dir.display());
+        };
+
+        let run = || {
+            lifecycle_delta_filter(
+                &dir,
+                &graph,
+                &BTreeMap::new(),
+                &policy(),
+                &super::super::default_trust::DefaultTrustFloor::disabled(),
+                HASH,
+                false,
+            )
+        };
+
+        // CONTROL. A filter that returned `None` unconditionally would satisfy
+        // both assertions below while narrowing nothing, ever.
+        assert!(
+            run().is_some(),
+            "control: with nothing owed the delta may narrow to changed packages, or the \
+             assertions below cannot tell widening from a filter that never narrows"
+        );
+
+        set_deferred(Some("dep@1.0.0"));
+        assert!(
+            run().is_none(),
+            "an owed build must force the full eligible scan: its bytes are unchanged so it is \
+             not `touched`, and it was policy-ALLOWED so the previously-unreviewed pass does not \
+             reach it either — a narrowed delta drops it and the state write then re-seals the tree"
+        );
+
+        set_deferred(None);
+        assert!(
+            run().is_none(),
+            "state predating the field cannot say what it deferred, so the migration must widen \
+             here as well as at the freshness check — narrowing on an unknown drops a build \
+             stranded by the old behavior and records the tree as clean"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -264,7 +264,8 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             default_trust_floor,
             virtual_store_dir_max_length,
             placements_ref,
-        )?;
+        )?
+        .unreviewed;
         if !unreviewed.is_empty() {
             return Err(miette!(
                 "dependencies with build scripts must be reviewed before install:\n{}\nhelp: add the package(s) to `allowBuilds` with `true`/`false`, or set `strictDepBuilds=false`",
@@ -309,6 +310,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
     //     resolutions land at distinct paths.
     // The `defaultTrust` floor can allow builds even when the policy
     // itself has no allow rules, so it keeps the phase alive too.
+    let mut builds_not_attempted: Vec<String> = Vec::new();
     if super::default_trust::dep_build_scripts_may_run(
         ignore_scripts,
         build_policy.has_any_allow_rule(),
@@ -329,7 +331,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
                 }
             })
             .unwrap_or(SideEffectsCacheConfig::Disabled);
-        let ran = run_dep_lifecycle_scripts(
+        let outcome = run_dep_lifecycle_scripts(
             cwd,
             modules_dir_name,
             aube_dir,
@@ -345,6 +347,11 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             None,
         )
         .await?;
+        let ran = outcome.ran;
+        // An allowed build the phase could not attempt leaves the tree
+        // incomplete. Carried to the state write so the next install
+        // retries it rather than short-circuiting on a sealed tree.
+        builds_not_attempted = outcome.unbuilt;
         if ran > 0 {
             tracing::debug!("allowBuilds: ran {ran} dep lifecycle script(s)");
         }
@@ -422,8 +429,10 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
     // the post-install warning emission below. The walk does a stat per
     // package, so collapsing two callers into one cuts the linker-tail
     // cost on large graphs roughly in half.
-    let unreviewed_builds = if !ignore_scripts && !strict_dep_builds_setting && !virtual_store_only
-    {
+    // The same walk also separates out the builds this run deferred for
+    // a reason it invented rather than one the config decided — see
+    // `UnreviewedScan::deferred`.
+    let scan = if !ignore_scripts && !strict_dep_builds_setting && !virtual_store_only {
         unreviewed_dep_builds(
             aube_dir,
             graph_for_link,
@@ -433,8 +442,18 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             placements_ref,
         )?
     } else {
-        Vec::new()
+        super::lifecycle::UnreviewedScan::default()
     };
+    let unreviewed_builds = scan.unreviewed;
+    // Both halves say the same thing to the freshness predicate: a
+    // build this tree is supposed to carry is not in it, for a reason
+    // another install might not hit. `--ignore-scripts` contributes
+    // nothing — it writes an empty `dep_build_policy_hash`, which busts
+    // the warm path on its own.
+    let mut deferred_dep_builds = scan.deferred;
+    deferred_dep_builds.append(&mut builds_not_attempted);
+    deferred_dep_builds.sort();
+    deferred_dep_builds.dedup();
 
     if !virtual_store_only && !filtered_install {
         let phase_start = std::time::Instant::now();
@@ -584,6 +603,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
                     placements: placements_ref,
                 },
                 unreviewed_builds: unreviewed_builds_for_state,
+                deferred_dep_builds,
             },
         )
         .into_diagnostic()

--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -113,6 +113,24 @@ fn lifecycle_delta_filter(
         tracing::debug!("delta: dep build policy changed; running full eligible build scan");
         return None;
     }
+    // A build the last install could not run is owed one, and the delta
+    // is the wrong instrument for finding it: the package's bytes did
+    // not change, so it is not `touched`, and it was policy-ALLOWED, so
+    // `select_previously_unreviewed_now_allowed` does not reach it
+    // either. It would be dropped at the `selected_dep_paths` guard
+    // before the runner could retry it, and the state write would then
+    // clear the marker and re-seal the tree. Busting freshness only
+    // gets the pipeline running again; this is what makes the retry
+    // actually happen (nubjs/nub#764).
+    //
+    // A full scan rather than adding these to `selected`: the state
+    // records spec keys and the filter is keyed by dep_path, and a
+    // deferral is rare enough that widening the scan costs nothing
+    // worth the mapping.
+    if !state::read_state_deferred_dep_builds(cwd).is_empty() {
+        tracing::debug!("delta: a dependency build is owed; running full eligible build scan");
+        return None;
+    }
     let prior_leaf_hashes = state::read_state_package_content_hashes(cwd)?;
     let prior_subtree_hashes = state::read_state_subtree_hashes(cwd)?;
     let (current_leaf_hashes, current_subtree_hashes) =

--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -127,9 +127,23 @@ fn lifecycle_delta_filter(
     // records spec keys and the filter is keyed by dep_path, and a
     // deferral is rare enough that widening the scan costs nothing
     // worth the mapping.
-    if !state::read_state_deferred_dep_builds(cwd).is_empty() {
-        tracing::debug!("delta: a dependency build is owed; running full eligible build scan");
-        return None;
+    match state::read_state_deferred_dep_builds(cwd) {
+        Some(owed) if owed.is_empty() => {}
+        Some(_) => {
+            tracing::debug!("delta: a dependency build is owed; running full eligible build scan");
+            return None;
+        }
+        // State predating the field cannot say what it deferred, so the
+        // migration has to assume the worst here as well as in the
+        // freshness check. Narrowing on an unknown would drop a build
+        // stranded by the old behavior and then write `Some([])` over
+        // it, sealing the tree on the one install that could heal it.
+        None => {
+            tracing::debug!(
+                "delta: install state predates build-completion tracking; running full eligible build scan"
+            );
+            return None;
+        }
     }
     let prior_leaf_hashes = state::read_state_package_content_hashes(cwd)?;
     let prior_subtree_hashes = state::read_state_subtree_hashes(cwd)?;

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -376,6 +376,19 @@ pub(super) fn resolve_link_strategy(
     Ok(strategy)
 }
 
+/// What [`run_dep_lifecycle_scripts`] did.
+#[derive(Debug, Default)]
+pub(crate) struct DepLifecycleOutcome {
+    /// Lifecycle scripts actually executed.
+    pub ran: usize,
+    /// Spec keys of packages the policy ALLOWED to build whose build
+    /// could not be attempted, because the materialized directory or
+    /// its `package.json` was not on disk when the phase ran. Both are
+    /// environmental, not policy decisions, so the install must not
+    /// treat the resulting tree as complete (nubjs/nub#764).
+    pub unbuilt: Vec<String>,
+}
+
 /// Walk every linked dependency, check its `package.json` for
 /// lifecycle scripts, and run the ones the policy allows. Runs
 /// `preinstall` → `install` → `postinstall` per package in that order;
@@ -414,7 +427,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
     // gates which ones actually run. Match is by `pkg.name`, matching
     // pnpm's `pnpm rebuild <name>`.
     selected_names: Option<&std::collections::HashSet<String>>,
-) -> miette::Result<usize> {
+) -> miette::Result<DepLifecycleOutcome> {
     // Pass 1 (serial, cheap): walk the graph, keep only the packages
     // the policy allows AND that actually define at least one dep
     // lifecycle hook in their on-disk `package.json`. Filtering up front
@@ -437,6 +450,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
 
     let mut jobs: Vec<BuildJob> = Vec::new();
     let mut floor_trusted: Vec<String> = Vec::new();
+    let mut unbuilt: Vec<String> = Vec::new();
     for (dep_path, pkg) in &graph.packages {
         if let Some(selected) = selected_dep_paths
             && !selected.contains(dep_path)
@@ -492,11 +506,23 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             placements,
         );
         if !package_dir.exists() {
-            tracing::debug!(
-                "allowBuilds: skipping {} — {} not on disk",
+            // An ALLOWED build that cannot even be attempted. Nothing
+            // downstream would otherwise say so — no job means no
+            // `run_script` span, and the package is not unreviewed, so
+            // the ignored-builds warning skips it too. Left at `debug`
+            // this exited 0 with a materialized-but-unbuilt tree
+            // (nubjs/nub#764). `unbuilt` also carries it into the
+            // install state so the next install retries rather than
+            // reporting the tree up to date.
+            tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_BUILD_NOT_ATTEMPTED,
+                package = pkg.name.as_str(),
+                path = %package_dir.display(),
+                "build scripts for {} did not run: {} is not on disk",
                 pkg.name,
                 package_dir.display()
             );
+            unbuilt.push(pkg.source_approval_key().unwrap_or_else(|| pkg.spec_key()));
             continue;
         }
         // Read the dep's `package.json` directly from its materialized
@@ -567,7 +593,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
     }
 
     if jobs.is_empty() {
-        return Ok(0);
+        return Ok(DepLifecycleOutcome { ran: 0, unbuilt });
     }
 
     // A package reachable ONLY through `optionalDependencies` is one the
@@ -874,7 +900,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             Err(error) => return Err(error),
         }
     }
-    Ok(ran)
+    Ok(DepLifecycleOutcome { ran, unbuilt })
 }
 
 /// Persist a freshly imported package index under the store key(s) a
@@ -1375,6 +1401,22 @@ pub(in crate::commands::install) struct UnreviewedBuild {
     pub suspicions: Vec<aube_scripts::Suspicion>,
 }
 
+/// What one pass over the linked graph found in the way of dependency
+/// builds that did not run.
+#[derive(Debug, Default)]
+pub(in crate::commands::install) struct UnreviewedScan {
+    /// Packages with build scripts that no layer allowed. These are
+    /// denied *stably* — the user is warned, and leaving them unbuilt
+    /// is the correct steady state until they approve.
+    pub unreviewed: Vec<UnreviewedBuild>,
+    /// The subset of `unreviewed` that missed for a reason this run
+    /// invented rather than one the config decided — see
+    /// [`super::default_trust::DefaultTrustFloor::deferred_by_missing_vetting`].
+    /// Persisted so the next install retries them instead of reporting
+    /// a tree with an unrun build as up to date (nubjs/nub#764).
+    pub deferred: Vec<String>,
+}
+
 pub(super) fn unreviewed_dep_builds(
     aube_dir: &std::path::Path,
     graph: &aube_lockfile::LockfileGraph,
@@ -1382,8 +1424,9 @@ pub(super) fn unreviewed_dep_builds(
     floor: &super::default_trust::DefaultTrustFloor,
     virtual_store_dir_max_length: usize,
     placements: Option<&aube_linker::HoistedPlacements>,
-) -> miette::Result<Vec<UnreviewedBuild>> {
+) -> miette::Result<UnreviewedScan> {
     let mut unreviewed = Vec::new();
+    let mut deferred = Vec::new();
     for (dep_path, pkg) in &graph.packages {
         // A package the `defaultTrust` floor vouches for is not
         // unreviewed — its scripts ran. Same decision seam as
@@ -1429,15 +1472,24 @@ pub(super) fn unreviewed_dep_builds(
                 )
             })?;
         if aube_scripts::has_dep_lifecycle_work(&package_dir, &dep_manifest) {
+            let spec_key = pkg.source_approval_key().unwrap_or_else(|| pkg.spec_key());
+            if floor.deferred_by_missing_vetting(pkg, &graph.times) {
+                deferred.push(spec_key.clone());
+            }
             unreviewed.push(UnreviewedBuild {
-                spec_key: pkg.source_approval_key().unwrap_or_else(|| pkg.spec_key()),
+                spec_key,
                 suspicions: aube_scripts::sniff_lifecycle(&dep_manifest),
             });
         }
     }
     unreviewed.sort_by(|a, b| a.spec_key.cmp(&b.spec_key));
     unreviewed.dedup_by(|a, b| a.spec_key == b.spec_key);
-    Ok(unreviewed)
+    deferred.sort();
+    deferred.dedup();
+    Ok(UnreviewedScan {
+        unreviewed,
+        deferred,
+    })
 }
 
 #[cfg(test)]

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -1430,6 +1430,10 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // allowlist without a per-install OSV run — see
     // `wiki/commands/pm/supply-chain-posture.md` Decision 2.
     let lockfile_vetted;
+    // Per-package counterpart to `lockfile_vetted`, for the floor's
+    // cooling-window waiver. The boolean above is a whole-graph fact and
+    // the waiver is not — see `default_trust::InheritedPicks`.
+    let inherited_picks;
     // The cold-install lockfile write runs on a `spawn_blocking` task so it
     // overlaps `filter_graph` + the link phase (see
     // `lockfile_write_overlap`). The handle escapes the resolve match arm
@@ -1573,6 +1577,8 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             // `defaultTrust` floor inherits it rather than requiring a
             // (correctly skipped) per-install OSV run.
             lockfile_vetted = true;
+            // Nothing was re-resolved, so every pick is inherited.
+            inherited_picks = default_trust::InheritedPicks::All;
 
             // Check index cache, fetch missing tarballs. Tarball client
             // is lazy because eager construction costs ~20ms even when
@@ -2424,6 +2430,12 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             let prior_lockfile = lockfile_pre_parse.as_ref().map(|(g, _)| g);
             let fresh_resolution =
                 super::add_supply_chain::lockfile_has_new_picks(&cwd, prior_lockfile, &graph);
+            // Computed here, while `prior_lockfile` is still borrowed.
+            // `fresh_resolution` collapses this to one bit for the
+            // advisory gate; the cooling-window waiver needs the
+            // per-package answer, because an `aube add` graph is a
+            // mixture and the bit says only that a mixture exists.
+            inherited_picks = default_trust::InheritedPicks::from_prior(prior_lockfile);
             let osv_settings = resolve_osv_routing_settings(&cwd);
             // Fire the OSV gate as a concurrent task that overlaps the
             // tail of the in-flight tarball downloads (`fetch_handle`,
@@ -3065,6 +3077,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         opts.minimum_release_age_override,
         osv_gate_active,
         lockfile_vetted,
+        inherited_picks,
     );
     let link::LinkPhaseOutput {
         stats,

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -712,12 +712,18 @@ fn member_lockfiles_stale(project_dir: &Path, state: &FreshnessState) -> Option<
 /// [`InstallState::deferred_dep_builds`] for what qualifies.
 ///
 /// The `None` arm is the one-time migration for state written before
-/// the field existed. Such a state cannot say whether a build was
-/// deferred, and a tree sealed by the pre-fix behavior is exactly the
-/// one we want to heal — but only bother when the state also recorded
-/// unreviewed builds, since a project with none never had a skipped
-/// dependency build to strand. The full install that follows writes
-/// the field, so this fires at most once per project.
+/// the field existed. Such a state cannot say what it deferred, and a
+/// tree sealed by the pre-fix behavior is exactly the one to heal, so
+/// it re-checks once unconditionally.
+///
+/// Deliberately NOT narrowed to "only when unreviewed builds were
+/// recorded". The seal this migration exists for includes a
+/// policy-ALLOWED package whose materialized directory was missing when
+/// the lifecycle phase ran: allowed means it was never unreviewed, so
+/// that state carries an empty unreviewed list and the narrow form
+/// would leave exactly the trees it was written to rescue sealed
+/// forever. The cost is one full install per project on upgrade, and
+/// that install writes the field, so it never repeats.
 fn deferred_dep_builds_stale(state: &FreshnessState) -> Option<String> {
     match state.deferred_dep_builds.as_deref() {
         Some([]) => None,
@@ -725,7 +731,6 @@ fn deferred_dep_builds_stale(state: &FreshnessState) -> Option<String> {
             "a dependency build did not run on the last install ({}); retrying",
             preview_list(deferred)
         )),
-        None if state.unreviewed_builds.is_empty() => None,
         None => Some(
             "install state predates dependency-build completion tracking; re-checking builds"
                 .into(),
@@ -1094,6 +1099,16 @@ pub fn link_completed_cleanly(project_dir: &Path) -> bool {
 pub fn read_state_unreviewed_builds(project_dir: &Path) -> Vec<String> {
     read_or_migrate_fresh_state(&state_dir(project_dir))
         .map(|s| s.unreviewed_builds)
+        .unwrap_or_default()
+}
+
+/// Spec keys the last install recorded as owed a build. See
+/// [`InstallState::deferred_dep_builds`]. Legacy state with no field
+/// reads as empty here — the freshness predicate handles that case, and
+/// by the time anything asks this the install is already running.
+pub fn read_state_deferred_dep_builds(project_dir: &Path) -> Vec<String> {
+    read_or_migrate_fresh_state(&state_dir(project_dir))
+        .and_then(|s| s.deferred_dep_builds)
         .unwrap_or_default()
 }
 
@@ -2310,6 +2325,50 @@ mod tests {
         );
     }
 
+    /// The retry depends on this list surviving into the freshness
+    /// sidecar: `lifecycle_delta_filter` reads it back to force a full
+    /// eligible scan, and a field left out of `FreshnessState` would
+    /// read as empty there — the delta would then drop the owed package
+    /// and the next state write would clear the marker, re-sealing the
+    /// tree while every other test still passed.
+    #[test]
+    fn deferred_dep_builds_roundtrip_reaches_the_delta_filter() {
+        use super::read_state_deferred_dep_builds;
+        let project_dir = temp_project_dir("deferred-builds-rt");
+        let state_path = project_dir.join("node_modules/.aube-state");
+        std::fs::create_dir_all(&state_path).expect("state dir should write");
+        let state = InstallState {
+            lockfile_hash: "blake3:lock".to_string(),
+            lockfile_snapshot_name: None,
+            member_lockfile_hashes: BTreeMap::new(),
+            member_lockfile_meta: BTreeMap::new(),
+            package_json_hashes: BTreeMap::new(),
+            package_json_meta: BTreeMap::new(),
+            local_directory_hashes: Some(BTreeMap::new()),
+            aube_version: env!("CARGO_PKG_VERSION").to_string(),
+            section_filtered: false,
+            settings_hash: String::new(),
+            dep_build_policy_hash: String::new(),
+            release_policy_hash: String::new(),
+            package_content_hashes: BTreeMap::new(),
+            graph_lthash: String::new(),
+            package_subtree_hashes: BTreeMap::new(),
+            package_json_shape_digests: BTreeMap::new(),
+            layout: None,
+            unreviewed_builds: Vec::new(),
+            deferred_dep_builds: Some(vec!["esbuild@0.24.0".to_string()]),
+        };
+        let json = serde_json::to_string(&state).expect("state should serialize");
+        std::fs::write(install_state_file(&state_path), json).expect("state should write");
+        // First read migrates the fresh sidecar; the second reads it back.
+        let _ = read_state_deferred_dep_builds(&project_dir);
+        assert_eq!(
+            read_state_deferred_dep_builds(&project_dir),
+            vec!["esbuild@0.24.0".to_string()],
+            "the owed build must survive into the sidecar the delta filter reads"
+        );
+    }
+
     #[test]
     fn unreviewed_builds_default_when_field_missing_in_state() {
         use super::read_state_unreviewed_builds;
@@ -3051,10 +3110,15 @@ mod tests {
             deferred_dep_builds_stale(&state(None, vec!["esbuild@0.24.0".to_string()])).is_some(),
             "state predating the field may be hiding a stranded build, so re-check once"
         );
-        assert_eq!(
-            deferred_dep_builds_stale(&state(None, Vec::new())),
-            None,
-            "legacy state with no unreviewed builds never had one to strand"
+        // The seal this migration exists for includes an ALLOWED package
+        // whose directory was missing when the lifecycle phase ran.
+        // Allowed means never unreviewed, so that state's unreviewed list
+        // is empty — narrowing the migration to a non-empty list would
+        // leave exactly those trees sealed forever.
+        assert!(
+            deferred_dep_builds_stale(&state(None, Vec::new())).is_some(),
+            "legacy state must re-check even with no unreviewed builds: an allowed build that \
+             was never attempted leaves the unreviewed list empty"
         );
     }
 

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -147,6 +147,28 @@ pub struct InstallState {
     /// `--ignore-scripts` / `strictDepBuilds=true` / `virtualStoreOnly`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub unreviewed_builds: Vec<String>,
+    /// Spec keys of dependency builds the last install *wanted* to run
+    /// and could not, for a reason that run invented rather than one
+    /// the config decided: the `defaultTrust` floor's advisory-vetting
+    /// gate not covering the install, or an allowed package's
+    /// materialized directory not being on disk when the lifecycle
+    /// phase ran.
+    ///
+    /// Distinct from `unreviewed_builds`, which is a *stable* denial —
+    /// re-running the install could never change it, so sealing on it
+    /// is correct. These can differ between two otherwise-identical
+    /// runs, so a tree carrying them is incomplete rather than
+    /// finished, and `check_needs_install` must not report it up to
+    /// date (nubjs/nub#764).
+    ///
+    /// `None` means the state predates the field. Treated as "unknown,
+    /// so re-check" when the state also records unreviewed builds; a
+    /// single install turns it into `Some`, so the migration costs one
+    /// full install per project and never repeats. Deliberately NOT
+    /// `skip_serializing_if` empty — an empty vec must serialize, or
+    /// every clean install would read back as legacy-unknown.
+    #[serde(default)]
+    pub deferred_dep_builds: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -186,6 +208,11 @@ struct FreshnessState {
     layout: Option<InstallLayoutState>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     unreviewed_builds: Vec<String>,
+    /// See [`InstallState::deferred_dep_builds`]. Mirrored into the
+    /// freshness sidecar because the warm-path check reads only this
+    /// struct.
+    #[serde(default)]
+    deferred_dep_builds: Option<Vec<String>>,
 }
 
 /// `(size, mtime)` snapshot used by `R1` mtime fast path. mtime is
@@ -252,6 +279,7 @@ impl From<&InstallState> for FreshnessState {
             package_json_shape_digests: state.package_json_shape_digests.clone(),
             layout: state.layout.clone(),
             unreviewed_builds: state.unreviewed_builds.clone(),
+            deferred_dep_builds: state.deferred_dep_builds.clone(),
         }
     }
 }
@@ -443,6 +471,23 @@ fn check_needs_install_compute(
             "previous install omitted dependency sections; auto-installing full graph".into(),
         );
     }
+
+    // Every other input here describes what the tree was built FROM.
+    // None of them says whether the last install's dependency lifecycle
+    // phase finished, so a tree with an allowed-but-unrun build looked
+    // identical to a complete one and no later install could heal it —
+    // it reported "Already up to date" and exited 0 forever
+    // (nubjs/nub#764). The install records what it could not build; a
+    // miss here re-runs the pipeline, which is what gets those builds
+    // another attempt.
+    //
+    // Only builds deferred for a RUN-SCOPED reason land in the list.
+    // A package the config stably denies stays out, so the ordinary
+    // unreviewed-builds steady state still takes the warm path.
+    if let Some(reason) = deferred_dep_builds_stale(&state) {
+        return Some(reason);
+    }
+
     if state.dep_build_policy_hash.is_empty() {
         return Some("dependency build policy state is missing".into());
     }
@@ -663,6 +708,45 @@ fn member_lockfiles_stale(project_dir: &Path, state: &FreshnessState) -> Option<
 /// `package_json_hashes` is new. Returns `Some(reason)` on the first new
 /// member, `None` when every current member was already recorded.
 /// Non-workspace projects enumerate to nothing and no-op.
+/// Whether the last install left a dependency build owed. See
+/// [`InstallState::deferred_dep_builds`] for what qualifies.
+///
+/// The `None` arm is the one-time migration for state written before
+/// the field existed. Such a state cannot say whether a build was
+/// deferred, and a tree sealed by the pre-fix behavior is exactly the
+/// one we want to heal — but only bother when the state also recorded
+/// unreviewed builds, since a project with none never had a skipped
+/// dependency build to strand. The full install that follows writes
+/// the field, so this fires at most once per project.
+fn deferred_dep_builds_stale(state: &FreshnessState) -> Option<String> {
+    match state.deferred_dep_builds.as_deref() {
+        Some([]) => None,
+        Some(deferred) => Some(format!(
+            "a dependency build did not run on the last install ({}); retrying",
+            preview_list(deferred)
+        )),
+        None if state.unreviewed_builds.is_empty() => None,
+        None => Some(
+            "install state predates dependency-build completion tracking; re-checking builds"
+                .into(),
+        ),
+    }
+}
+
+/// Comma-joined preview of a spec-key list, capped so a napi-rs-style
+/// tree of per-platform packages cannot splat into one unreadable line.
+fn preview_list(items: &[String]) -> String {
+    const MAX_INLINE: usize = 3;
+    if items.len() <= MAX_INLINE {
+        return items.join(", ");
+    }
+    format!(
+        "{}, and {} more",
+        items[..MAX_INLINE].join(", "),
+        items.len() - MAX_INLINE
+    )
+}
+
 fn new_workspace_member(project_dir: &Path, state: &FreshnessState) -> Option<String> {
     let members = aube_workspace::find_workspace_packages(project_dir).unwrap_or_default();
     for member_dir in &members {
@@ -710,6 +794,11 @@ pub struct WriteStateInput<'a> {
     pub dep_build_policy_hash: String,
     pub layout: WriteStateLayout<'a>,
     pub unreviewed_builds: Vec<String>,
+    /// See [`InstallState::deferred_dep_builds`]. Always `Some` on the
+    /// write side — an empty vec is the positive statement "nothing was
+    /// owed", which is what distinguishes a fresh clean install from
+    /// state written before the field existed.
+    pub deferred_dep_builds: Vec<String>,
 }
 
 pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(), std::io::Error> {
@@ -723,6 +812,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         dep_build_policy_hash,
         layout,
         unreviewed_builds,
+        deferred_dep_builds,
     } = input;
 
     let state_path = state_dir(project_dir);
@@ -799,6 +889,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         package_json_shape_digests,
         layout: Some(install_layout),
         unreviewed_builds,
+        deferred_dep_builds: Some(deferred_dep_builds),
     };
 
     let fresh_state = FreshnessState::from(&state);
@@ -1842,11 +1933,11 @@ mod tests {
     use super::{
         InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
         WriteStateInput, WriteStateLayout, collect_package_json_hashes_from_manifests,
-        empty_blake3_hash, fresh_state_file, hash_file, hash_release_age_settings,
-        hash_release_policy, hash_settings, install_state_file, member_lockfiles_stale,
-        new_workspace_member, read_or_migrate_fresh_state, read_state, relative_path_or_original,
-        release_policy_changed_since_last_run, remove_state, state_dir, verify_install_layout,
-        write_state,
+        deferred_dep_builds_stale, empty_blake3_hash, fresh_state_file, hash_file,
+        hash_release_age_settings, hash_release_policy, hash_settings, install_state_file,
+        member_lockfiles_stale, new_workspace_member, preview_list, read_or_migrate_fresh_state,
+        read_state, relative_path_or_original, release_policy_changed_since_last_run, remove_state,
+        state_dir, verify_install_layout, write_state,
     };
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -1899,6 +1990,7 @@ mod tests {
                 )]),
             }),
             unreviewed_builds: Vec::new(),
+            deferred_dep_builds: Some(Vec::new()),
         };
 
         assert_eq!(
@@ -2150,6 +2242,7 @@ mod tests {
                 packages: BTreeMap::new(),
             }),
             unreviewed_builds: Vec::new(),
+            deferred_dep_builds: Some(Vec::new()),
         };
         let json = serde_json::to_string(&state).expect("state should serialize");
         std::fs::write(install_state_file(&state_path), json).expect("state should write");
@@ -2201,6 +2294,7 @@ mod tests {
                 "esbuild@0.21.5".to_string(),
                 "better-sqlite3@11.5.0".to_string(),
             ],
+            deferred_dep_builds: Some(Vec::new()),
         };
         let json = serde_json::to_string(&state).expect("state should serialize");
         std::fs::write(install_state_file(&state_path), json).expect("state should write");
@@ -2432,6 +2526,7 @@ mod tests {
             package_json_shape_digests: shapes,
             layout: None,
             unreviewed_builds: Vec::new(),
+            deferred_dep_builds: Some(Vec::new()),
         };
         let reformatted = r#"{
   "name": "x",
@@ -2494,6 +2589,7 @@ mod tests {
             package_json_shape_digests: BTreeMap::new(),
             layout: None,
             unreviewed_builds: Vec::new(),
+            deferred_dep_builds: Some(Vec::new()),
         };
 
         // Every recorded member matches what is on disk → fresh.
@@ -2571,6 +2667,7 @@ mod tests {
             package_json_shape_digests: BTreeMap::new(),
             layout: None,
             unreviewed_builds: Vec::new(),
+            deferred_dep_builds: Some(Vec::new()),
         };
 
         // Every current member was recorded → fresh.
@@ -2627,6 +2724,7 @@ mod tests {
             package_json_shape_digests: BTreeMap::new(),
             layout: None,
             unreviewed_builds: Vec::new(),
+            deferred_dep_builds: Some(Vec::new()),
         };
 
         // Root + apps/server both recorded → fresh (no churn on the root).
@@ -2808,6 +2906,7 @@ mod tests {
                         placements: None,
                     },
                     unreviewed_builds: Vec::new(),
+                    deferred_dep_builds: Vec::new(),
                 },
             )
             .expect("state should write");
@@ -2892,5 +2991,80 @@ mod tests {
             release_policy_changed_since_last_run(&dir, &[]),
             "a raised age gate must still revalidate once a hash is recorded"
         );
+    }
+
+    /// Builds the last install could not run leave the tree incomplete,
+    /// so the warm path must not report it up to date (nubjs/nub#764).
+    /// The three arms are the whole contract: nothing owed takes the
+    /// warm path, an owed build busts it, and state written before the
+    /// field existed busts once so an already-sealed tree can heal.
+    #[test]
+    fn deferred_dep_builds_decide_the_warm_path() {
+        fn state(deferred: Option<Vec<String>>, unreviewed: Vec<String>) -> super::FreshnessState {
+            super::FreshnessState {
+                lockfile_hash: String::new(),
+                lockfile_snapshot_name: None,
+                member_lockfile_hashes: BTreeMap::new(),
+                member_lockfile_meta: BTreeMap::new(),
+                package_json_hashes: BTreeMap::new(),
+                package_json_meta: BTreeMap::new(),
+                local_directory_hashes: Some(BTreeMap::new()),
+                section_filtered: false,
+                settings_hash: String::new(),
+                dep_build_policy_hash: String::new(),
+                package_json_shape_digests: BTreeMap::new(),
+                layout: None,
+                unreviewed_builds: unreviewed,
+                deferred_dep_builds: deferred,
+            }
+        }
+
+        assert_eq!(
+            deferred_dep_builds_stale(&state(Some(Vec::new()), Vec::new())),
+            None,
+            "a clean install owes no builds and must take the warm path"
+        );
+
+        // A package denied by config is denied stably: re-running the
+        // install could never change the answer, so sealing on it is
+        // correct and the warm path must survive it.
+        assert_eq!(
+            deferred_dep_builds_stale(&state(
+                Some(Vec::new()),
+                vec!["some-unapproved-pkg@1.0.0".to_string()]
+            )),
+            None,
+            "an ordinary pending approval must not force a reinstall every time"
+        );
+
+        let reason = deferred_dep_builds_stale(&state(
+            Some(vec!["esbuild@0.24.0".to_string()]),
+            vec!["esbuild@0.24.0".to_string()],
+        ))
+        .expect("an owed build must bust the warm path");
+        assert!(
+            reason.contains("esbuild@0.24.0"),
+            "the reason must name the package so the miss is diagnosable, got: {reason}"
+        );
+
+        assert!(
+            deferred_dep_builds_stale(&state(None, vec!["esbuild@0.24.0".to_string()])).is_some(),
+            "state predating the field may be hiding a stranded build, so re-check once"
+        );
+        assert_eq!(
+            deferred_dep_builds_stale(&state(None, Vec::new())),
+            None,
+            "legacy state with no unreviewed builds never had one to strand"
+        );
+    }
+
+    /// The list is a diagnostic, so a napi-rs-style tree of per-platform
+    /// packages must not splat its whole graph into one line.
+    #[test]
+    fn preview_list_caps_the_inline_names() {
+        let one = ["a@1".to_string()];
+        assert_eq!(preview_list(&one), "a@1");
+        let many: Vec<String> = (0..6).map(|i| format!("p{i}@1")).collect();
+        assert_eq!(preview_list(&many), "p0@1, p1@1, p2@1, and 3 more");
     }
 }

--- a/vendor/aube/crates/aube/src/state.rs
+++ b/vendor/aube/crates/aube/src/state.rs
@@ -1102,14 +1102,18 @@ pub fn read_state_unreviewed_builds(project_dir: &Path) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Spec keys the last install recorded as owed a build. See
-/// [`InstallState::deferred_dep_builds`]. Legacy state with no field
-/// reads as empty here — the freshness predicate handles that case, and
-/// by the time anything asks this the install is already running.
-pub fn read_state_deferred_dep_builds(project_dir: &Path) -> Vec<String> {
-    read_or_migrate_fresh_state(&state_dir(project_dir))
-        .and_then(|s| s.deferred_dep_builds)
-        .unwrap_or_default()
+/// Spec keys the last install recorded as owed a build, or `None` when
+/// the state cannot say — no state file, or state predating the field.
+/// See [`InstallState::deferred_dep_builds`].
+///
+/// `None` MUST stay distinct from `Some([])`. Flattening the two turns
+/// the one-time migration into a no-op exactly where it matters: legacy
+/// state busts freshness, but the lifecycle delta would then still
+/// narrow to changed packages, drop the stranded build, and write
+/// `Some([])` — recording the tree as clean on the very install meant
+/// to heal it.
+pub fn read_state_deferred_dep_builds(project_dir: &Path) -> Option<Vec<String>> {
+    read_or_migrate_fresh_state(&state_dir(project_dir))?.deferred_dep_builds
 }
 
 /// Remove the install state directory. Missing state is not an error.
@@ -2364,8 +2368,34 @@ mod tests {
         let _ = read_state_deferred_dep_builds(&project_dir);
         assert_eq!(
             read_state_deferred_dep_builds(&project_dir),
-            vec!["esbuild@0.24.0".to_string()],
+            Some(vec!["esbuild@0.24.0".to_string()]),
             "the owed build must survive into the sidecar the delta filter reads"
+        );
+    }
+
+    /// The delta filter distinguishes three states, and collapsing the
+    /// first two makes the migration a no-op: state predating the field
+    /// (`None`, must force a full scan) is NOT the same as an install
+    /// that positively recorded nothing owed (`Some([])`, may narrow).
+    #[test]
+    fn legacy_state_reads_as_unknown_not_as_nothing_owed() {
+        use super::read_state_deferred_dep_builds;
+        let project_dir = temp_project_dir("deferred-builds-legacy");
+        let state_path = project_dir.join("node_modules/.aube-state");
+        std::fs::create_dir_all(&state_path).expect("state dir should write");
+        let legacy_json = r#"{
+            "lockfile_hash": "blake3:lock",
+            "package_json_hashes": {},
+            "aube_version": "0.0.0"
+        }"#;
+        std::fs::write(install_state_file(&state_path), legacy_json).expect("state should write");
+
+        let _ = read_state_deferred_dep_builds(&project_dir);
+        assert_eq!(
+            read_state_deferred_dep_builds(&project_dir),
+            None,
+            "pre-field state must read as unknown, or the lifecycle delta narrows and re-seals \
+             the stranded tree the migration exists to heal"
         );
     }
 


### PR DESCRIPTION
The install freshness check recorded nothing about whether the previous install's dependency lifecycle phase completed. Every input it compares describes what the tree was built *from* — the lockfile, the manifests, the layout, the settings — so a materialized `node_modules` whose build scripts never ran was indistinguishable from a complete one. No later install could heal it: each reported `Already up to date` and exited 0.

## Reproduction

macOS, isolated store, same package and defaults throughout. The only variable is install history.

```console
$ npm_config_advisory_check=off nub install     # advisory gate unreachable this run
WARN ignored build scripts for 1 package(s): esbuild@0.24.0
$ nub install                                   # defaults; should build esbuild
nub 0.8.2 · ✓ Already up to date
$ file node_modules/esbuild/bin/esbuild
node_modules/esbuild/bin/esbuild: a /usr/bin/env node script text executable
```

A fresh directory with the identical second command builds it (`WARN defaultTrust: running build scripts for esbuild@0.24.0`, and the bin becomes a Mach-O binary). `nub install --force` heals a sealed tree; nothing else does.

## Mechanism

The `defaultTrust` floor, which nub turns on by default, requires advisory vetting: an OSV `MAL-*` gate that covered this install, or a graph inherited from an already-vetted lockfile. That input is **run-scoped**, so two otherwise-identical installs can disagree, and the one that says no skips the whole dependency-lifecycle phase while still writing state. One install that could not reach the advisory gate therefore sealed the tree permanently.

`dep_build_policy_hash` does fold the floor's posture, but `check_needs_install` only tests it for emptiness; the real comparison lives in `lifecycle_delta_filter`, which a short-circuited install never reaches. Comparing that hash in the freshness check is not available as a fix — `check_needs_install_compute` receives only the project dir and the CLI flags, so with no graph and no OSV result there is no current hash to compare against.

## The fix

Record the builds an install wanted to run and could not, and treat a non-empty set as a warm-path miss.

`DefaultTrustFloor::deferred_by_missing_vetting` reports a package that every gate *but* vetting allows. Packages the config denies stay out: that denial is stable, re-running could never change it, so the ordinary pending-approval steady state keeps taking the warm path and does not turn into a full install on every run.

An allowed package whose materialized directory was not on disk when the phase ran was dropped with a `debug!` line, and nothing else spoke for it — no job means no `run_script` span, and it is not unreviewed, so the ignored-builds warning skipped it too. It now warns under `WARN_NUB_BUILD_NOT_ATTEMPTED` and joins the same retry set.

State written before the field existed cannot say what it deferred, so it re-checks once when it also recorded unreviewed builds. That heals trees already sealed by the old behavior; the following install writes the field and the migration never repeats.

## Verification

Built binary against real fixtures, four arms, all passing:

| arm | expectation | result |
| --- | --- | --- |
| sealed tree, plain install | retries the build | esbuild native |
| control, fresh dir | builds | esbuild native |
| sealed tree, third install | warm path returns once nothing is owed | `Already up to date` |
| control, repeat install | warm path unaffected | `Already up to date` |

The causal chain is confirmed on the state file rather than inferred: the sealing install writes `deferred_dep_builds: ["esbuild@0.24.0"]`, the next install's debug miss reason is `a dependency build did not run on the last install (esbuild@0.24.0); retrying`, the floor then builds it, and the field clears to `[]`.

The anti-regression case that the design turns on: after `nub add`, the state records `unreviewed_builds: ["esbuild@0.24.0"]` with `deferred_dep_builds: []`, and installs stay warm.

`clippy -p aube --all-targets` is clean. The `aube` `e2e` target does not build from the root workspace — its dev-dependencies are unavailable there, which is pre-existing and unrelated to this change; `aube-parity` runs those tests from `vendor/aube`.

## Separately found, not addressed here

A routine `nub add` flips the floor off for already-built packages, producing a spurious `WARN_NUB_IGNORED_BUILD_SCRIPTS`. The cooling window fails closed for lockfile-inherited packages that carry no publish time, because `lockfile_vetted` is false whenever *any* package in the graph was newly picked. This is the behavior the issue thread recorded as unexplained. It is cosmetic today and this change does not regress on it, but the fix means widening when the default-trust floor fires, which is a security-posture decision rather than a bug fix.

Closes #764
