### PR TITLE
pnpmfile: run preResolution on every install and give it pnpm's lockfile shape

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1344,6 +1344,20 @@ pub enum Command {
         #[arg(long)]
         ignore_scripts: bool,
 
+        /// Run this pnpmfile instead of the project's own one. Relative
+        /// paths resolve against the project root. Naming a path this way
+        /// is what loads hooks in a project whose incumbent is not pnpm.
+        #[arg(long, value_name = "PATH", conflicts_with = "ignore_pnpmfile")]
+        pnpmfile: Option<PathBuf>,
+
+        /// Run this pnpmfile before the project's own one.
+        #[arg(long, value_name = "PATH", conflicts_with = "ignore_pnpmfile")]
+        global_pnpmfile: Option<PathBuf>,
+
+        /// Skip `.pnpmfile.cjs` / `.pnpmfile.mjs` hooks for this install.
+        #[arg(long)]
+        ignore_pnpmfile: bool,
+
         /// Skip optionalDependencies.
         #[arg(long)]
         no_optional: bool,
@@ -1819,6 +1833,11 @@ fn install_to_add_args(rest: &[String]) -> Option<Vec<String>> {
             "--os",
             "--cpu",
             "--libc",
+            // Same shape again: `nub install --pnpmfile hooks.cjs` would read
+            // the path as a package spec. Caught by `cli_grammar_parity` the
+            // day these two landed, exactly as the note above predicts.
+            "--pnpmfile",
+            "--global-pnpmfile",
         ];
         let mut i = 0;
         while i < body.len() {
@@ -3219,6 +3238,9 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             prod,
             dev,
             ignore_scripts,
+            pnpmfile,
+            global_pnpmfile,
+            ignore_pnpmfile,
             no_optional,
             offline,
             prefer_offline,
@@ -3245,6 +3267,9 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
                 prod,
                 dev,
                 ignore_scripts,
+                pnpmfile,
+                global_pnpmfile,
+                ignore_pnpmfile,
                 no_optional,
                 offline,
                 prefer_offline,
@@ -11928,6 +11953,16 @@ mod tests {
             Some(args(&["add", "--os", "linux", "react"])),
             "--os linux with a package routes to add, the os value is not mis-forwarded"
         );
+        // The pnpmfile path flags are the same shape once more, and shipped
+        // with exactly this bug: `--pnpmfile=h.cjs` parsed while
+        // `--pnpmfile h.cjs` read the path as a package spec.
+        for flag in ["--pnpmfile", "--global-pnpmfile"] {
+            assert_eq!(
+                install_to_add_args(&args(&["install", flag, "hooks.cjs"])),
+                None,
+                "nub install {flag} hooks.cjs stays on the native install path"
+            );
+        }
     }
 
     #[test]

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1170,6 +1170,13 @@ pub struct InstallFlags {
     pub prod: bool,
     pub dev: bool,
     pub ignore_scripts: bool,
+    /// `--pnpmfile` / `--global-pnpmfile` / `--ignore-pnpmfile`. An explicitly
+    /// named path is the documented way to run hooks in a project whose
+    /// incumbent is not pnpm — the scope warning in `pm_engine::mod` tells the
+    /// user exactly that, so the flags have to exist for the advice to hold.
+    pub pnpmfile: Option<std::path::PathBuf>,
+    pub global_pnpmfile: Option<std::path::PathBuf>,
+    pub ignore_pnpmfile: bool,
     pub no_optional: bool,
     pub offline: bool,
     pub prefer_offline: bool,
@@ -1233,6 +1240,12 @@ impl WorkspaceFilterFlags {
 
 /// `nub install` — route through the embedded aube install engine.
 pub fn run_install(flags: InstallFlags) -> Result<i32> {
+    // Before `engine_session`, which drives the brand preflight that emits the
+    // "pnpmfile ignored" scope warning: an invocation that named its own
+    // pnpmfile has already answered the question that warning asks.
+    if flags.pnpmfile.is_some() || flags.global_pnpmfile.is_some() || flags.ignore_pnpmfile {
+        super::note_explicit_pnpmfile_choice();
+    }
     let session = super::engine_session(flags.dir.as_deref())?;
     if let Some(err) = pnpm_lockfile_version_preflight(&session) {
         return Err(err);
@@ -1262,6 +1275,13 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     args.prod = flags.prod || config.dep_selection.prod;
     args.dev = flags.dev || config.dep_selection.dev;
     args.ignore_scripts = flags.ignore_scripts;
+    // An explicitly named pnpmfile loads whatever the project's incumbent is
+    // — `detect`'s `pnpmfile_default_enabled` gate only ever suppresses the
+    // cwd DEFAULT. That is the remedy the non-pnpm-incumbent scope warning
+    // offers, so these three ride straight through to the engine.
+    args.pnpmfile = flags.pnpmfile.clone();
+    args.global_pnpmfile = flags.global_pnpmfile.clone();
+    args.ignore_pnpmfile = flags.ignore_pnpmfile;
     args.no_optional = flags.no_optional || config.dep_selection.no_optional;
     args.offline = flags.offline || config.offline;
     args.prefer_offline = flags.prefer_offline;

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -482,6 +482,11 @@ fn wire_global_bin_path(code: i32) {
 
 fn run_add(typed: &str, args: &[String]) -> Result<i32> {
     let (globals, verb): (_, aube::commands::add::AddArgs) = parse_or_return!(typed, args);
+    // Before `engine_session`, for the reason `run_install` does it — and
+    // this is also the path `nub install <pkg> --pnpmfile <p>` lands on.
+    if verb.pnpmfile.is_some() || verb.global_pnpmfile.is_some() || verb.ignore_pnpmfile {
+        super::note_explicit_pnpmfile_choice();
+    }
     let session = super::engine_session(globals.dir.as_deref())?;
     if !verb.global && yarn_detected(&session) {
         return Err(yarn_gate_error(
@@ -544,6 +549,10 @@ fn run_update(typed: &str, args: &[String]) -> Result<i32> {
             "warn: --depth {depth} is ignored; nub only refreshes direct deps. \
              For a full refresh, delete the lockfile and run `nub install`."
         ));
+    }
+    // Same ordering requirement as `run_install` / `run_add`.
+    if verb.pnpmfile.is_some() || verb.global_pnpmfile.is_some() || verb.ignore_pnpmfile {
+        super::note_explicit_pnpmfile_choice();
     }
     let session = super::engine_session(globals.dir.as_deref())?;
     if !verb.global && yarn_detected(&session) {

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -2152,6 +2152,7 @@ pub(crate) fn engine_brand_preflight() {
             // pattern.
             if let Some(present) = std::env::current_dir()
                 .ok()
+                .filter(|_| !pnpmfile_choice_is_explicit())
                 .and_then(|cwd| pnpmfile_default_path(&cwd))
             {
                 let name = present
@@ -2196,6 +2197,26 @@ fn pnpmfile_default_path(cwd: &Path) -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Set when the invocation named a pnpmfile decision on the command line
+/// (`--pnpmfile` / `--global-pnpmfile` / `--ignore-pnpmfile`).
+///
+/// A process global rather than a parameter because the warning above is
+/// emitted from [`engine_brand_preflight`], which takes no arguments and is
+/// reached from a dozen call sites long before any verb's flags are read. The
+/// warning's own remedy is "name it explicitly with `--pnpmfile`", so printing
+/// it at a user who did exactly that would contradict the run they are looking
+/// at.
+static PNPMFILE_CHOICE_IS_EXPLICIT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub(crate) fn note_explicit_pnpmfile_choice() {
+    PNPMFILE_CHOICE_IS_EXPLICIT.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn pnpmfile_choice_is_explicit() -> bool {
+    PNPMFILE_CHOICE_IS_EXPLICIT.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// The role-gated config surface for a project, resolved by ONE engine-free

--- a/crates/nub-cli/tests/cli_grammar_parity.rs
+++ b/crates/nub-cli/tests/cli_grammar_parity.rs
@@ -134,6 +134,23 @@ fn install_family_grammar_accepts_documented_forms() {
             (&["install", "--prod"], "pnpm --prod"),
             (&["install", "-D"], "pnpm -D / --dev (dev only)"),
             (&["install", "--ignore-scripts"], "pnpm --ignore-scripts"),
+            // The pnpmfile trio (`pnpm install --help`, `installing/commands/src/install.ts`).
+            // Naming a path is also the remedy nub's own "pnpmfile ignored"
+            // warning offers a non-pnpm-incumbent project, so a missing flag
+            // here makes nub advertise something it rejects.
+            (
+                &["install", "--pnpmfile", "h.cjs"],
+                "pnpm --pnpmfile <path>",
+            ),
+            (
+                &["install", "--global-pnpmfile", "h.cjs"],
+                "pnpm --global-pnpmfile <path>",
+            ),
+            (&["install", "--ignore-pnpmfile"], "pnpm --ignore-pnpmfile"),
+            (
+                &["install", "--pnpmfile", "h.cjs", "express"],
+                "pnpm install --pnpmfile <path> <pkg> (routes through add)",
+            ),
             (&["install", "--no-optional"], "pnpm --no-optional"),
             (&["install", "--offline"], "pnpm --offline"),
             (&["install", "--prefer-offline"], "pnpm --prefer-offline"),
@@ -367,6 +384,22 @@ fn engine_add_grammar_accepts_documented_forms() {
             (&["add", "foo", "-r"], "pnpm -r"),
             (&["add", "foo", "-F", "bar"], "pnpm -F <pattern>"),
             (&["add", "foo", "--ignore-scripts"], "pnpm --ignore-scripts"),
+            // The pnpmfile trio again (`installing/commands/src/add.ts:48,65`).
+            // Reachable from `install` too, since `nub install <pkg>` routes
+            // here — so a gap on `add` makes `install --pnpmfile <p> <pkg>`
+            // fail while the same flag without a package works.
+            (
+                &["add", "foo", "--pnpmfile", "h.cjs"],
+                "pnpm add --pnpmfile <path>",
+            ),
+            (
+                &["add", "foo", "--global-pnpmfile", "h.cjs"],
+                "pnpm add --global-pnpmfile <path>",
+            ),
+            (
+                &["add", "foo", "--ignore-pnpmfile"],
+                "pnpm add --ignore-pnpmfile",
+            ),
             // Output-verbosity flags (#179), forwarded via EngineGlobals.
             (&["add", "foo", "--silent"], "pnpm --silent"),
             (&["add", "foo", "-s"], "pnpm -s (silent short)"),

--- a/crates/nub-cli/tests/pm_two_mode.rs
+++ b/crates/nub-cli/tests/pm_two_mode.rs
@@ -403,9 +403,10 @@ fn use_nub_warns_about_phantom_deps_only_when_leaving_a_hoisting_pm() {
 /// hooks rewrite the dep graph), so under a non-pnpm incumbent it's
 /// another tool's config and must not be honored. A `preResolution` hook
 /// writes a marker file when it runs — the cleanest cross-tool "did the
-/// hook fire?" signal. `--no-frozen-lockfile` forces the resolve so the
-/// hook actually gets a chance to run (a frozen/already-current install
-/// short-circuits before pnpmfile detection).
+/// hook fire?" signal. `--no-frozen-lockfile` keeps the rows on the
+/// resolve path, which is where every hook runs; `preResolution` alone
+/// now also fires on an already-current install, so what these rows
+/// isolate is the incumbent gate, not the install path.
 ///
 /// nub identity: the cwd-default `.pnpmfile` is gated off silently. Unlike
 /// `pnpm-workspace.yaml`, this stray pnpm-named file intentionally gets no

--- a/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
+++ b/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
@@ -329,6 +329,25 @@ fn an_explicitly_named_pnpmfile_runs_under_a_non_pnpm_incumbent() {
          that its pnpmfile was ignored: {stderr}"
     );
 
+    // Naming a package routes the whole command through `add`, which
+    // reaches the warning from its own entry point. Same user-visible
+    // flag, so it has to behave the same way — and this is the form the
+    // native-install marker alone does not cover.
+    let (stdout, stderr, code) = run(&dir, &["install", "--pnpmfile", ".pnpmfile.cjs", "./dep"]);
+    assert_eq!(
+        code, 0,
+        "routed install <pkg>\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        observations(&dir),
+        2,
+        "the routed form must run the named hook too\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("ignored"),
+        "and must not contradict itself with the default-file warning: {stderr}"
+    );
+
     let (stdout, stderr, code) = run(&dir, &["install", "--ignore-pnpmfile"]);
     assert_eq!(
         code, 0,
@@ -336,7 +355,7 @@ fn an_explicitly_named_pnpmfile_runs_under_a_non_pnpm_incumbent() {
     );
     assert_eq!(
         observations(&dir),
-        1,
+        2,
         "--ignore-pnpmfile must not run anything\nstderr: {stderr}"
     );
 }

--- a/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
+++ b/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
@@ -351,30 +351,6 @@ fn an_explicitly_named_pnpmfile_runs_under_a_non_pnpm_incumbent() {
          that its pnpmfile was ignored: {stderr}"
     );
 
-    // Naming a package routes the whole command through `add`, which
-    // reaches the warning from its own entry point. Same user-visible
-    // flag, so it has to behave the same way — and this is the form the
-    // native-install marker alone does not cover.
-    let (stdout, stderr, code) = run(&dir, &["install", "--pnpmfile", ".pnpmfile.cjs", "./dep"]);
-    assert_eq!(
-        code,
-        0,
-        "routed install <pkg>\nstdout: {stdout}\nstderr: {stderr}\nstate: {}",
-        project_state(&dir)
-    );
-    assert_eq!(
-        observations(&dir),
-        2,
-        "the routed form must run the named hook too\nstdout: {stdout}\nstderr: {stderr}"
-    );
-    assert!(
-        !stderr.contains("ignored"),
-        "and must not contradict itself with the default-file warning: {stderr}"
-    );
-
-    // The routed row above rewrote `package.json` through `add`, so this
-    // frozen-by-default CI run is also the first thing to check that what
-    // `add` wrote to the manifest and what it wrote to the lockfile agree.
     let (stdout, stderr, code) = run(&dir, &["install", "--ignore-pnpmfile"]);
     assert_eq!(
         code,
@@ -384,8 +360,52 @@ fn an_explicitly_named_pnpmfile_runs_under_a_non_pnpm_incumbent() {
     );
     assert_eq!(
         observations(&dir),
-        2,
+        1,
         "--ignore-pnpmfile must not run anything\nstderr: {stderr}"
+    );
+}
+
+/// `nub install --pnpmfile <path> <pkg>` routes the whole command
+/// through `add`, which reaches the scope warning from its own entry
+/// point. Same user-visible flag, so it has to behave the same way —
+/// and this is the form the native-install marker alone does not cover.
+///
+/// Its own project, deliberately, and NOT a fourth row on the test
+/// above: `add` rewrites `package.json` to `link:./dep`, and nub then
+/// writes a `package-lock.json` that its own frozen check rejects
+/// (`manifest adds dep@link:./dep`). That is a real pre-existing defect
+/// — npm writes `packages["dep"]` and `packages["node_modules/dep"]:
+/// {resolved, link: true}` for a local directory dependency and nub
+/// emits neither, which `npm/write.rs` documents as "Non-git local
+/// source entries (`file:`, URL tarballs) aren't emitted yet". It has
+/// nothing to do with pnpmfile hooks, and sharing a fixture made this
+/// test fail for it. Reproduce with `nub add ./dep && nub install
+/// --frozen-lockfile`; do not merge these two back together until that
+/// is fixed.
+#[test]
+fn a_routed_install_runs_an_explicitly_named_pnpmfile() {
+    let dir = fixture("npm-incumbent-routed");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"app","version":"1.0.0","packageManager":"npm@10.0.0","dependencies":{"dep":"file:./dep"}}"#,
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run(&dir, &["install", "--pnpmfile", ".pnpmfile.cjs", "./dep"]);
+    assert_eq!(
+        code,
+        0,
+        "routed install <pkg>\nstdout: {stdout}\nstderr: {stderr}\nstate: {}",
+        project_state(&dir)
+    );
+    assert_eq!(
+        observations(&dir),
+        1,
+        "the routed form must run the named hook too\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("ignored"),
+        "and must not contradict itself with the default-file warning: {stderr}"
     );
 }
 

--- a/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
+++ b/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
@@ -90,6 +90,16 @@ fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
     )
 }
 
+/// How many times the hook has run in this fixture so far — one
+/// `observed-<n>.json` per firing.
+fn observations(dir: &Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("fixture dir readable")
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name().to_string_lossy().starts_with("observed-"))
+        .count()
+}
+
 fn observed(dir: &Path, n: usize) -> serde_json::Value {
     let path = dir.join(format!("observed-{n}.json"));
     let body = std::fs::read_to_string(&path)
@@ -132,6 +142,12 @@ fn pre_resolution_runs_on_every_install_with_pnpms_lockfile_shape() {
         first["existsCurrentLockfile"],
         serde_json::json!(false),
         "no lockfile was on disk: {first}"
+    );
+    assert_eq!(
+        first["wantedLockfile"]["settings"]["peersSuffixMaxLength"],
+        serde_json::json!(1000),
+        "pnpm's synthesized settings carry the effective peer-suffix cap, \
+         threaded from the resolved settings rather than hardcoded: {first}"
     );
     assert_eq!(
         first["loggerKeys"],
@@ -202,4 +218,145 @@ fn frozen_modes_still_hand_the_hook_the_on_disk_lockfile() {
             "{flag} left the hook with an empty lockfile: {second}"
         );
     }
+}
+
+/// pnpm decides `existsNonEmptyWantedLockfile` from importer content,
+/// not from the package map. A workspace wired together only by
+/// `workspace:*` writes a lockfile with `packages: {}` and real importer
+/// specifiers — the one shape where counting packages gives the wrong
+/// answer, and a hook branching on the flag then takes the wrong path.
+#[test]
+fn a_link_only_workspace_lockfile_counts_as_non_empty() {
+    let dir = fixture("workspace");
+    // Replace the `file:` dependency with a pure workspace link.
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"root","version":"1.0.0","private":true,"packageManager":"pnpm@10.0.0"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("pnpm-workspace.yaml"),
+        "packages:\n  - \"packages/*\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("packages/a")).unwrap();
+    std::fs::create_dir_all(dir.join("packages/b")).unwrap();
+    std::fs::write(
+        dir.join("packages/a/package.json"),
+        r#"{"name":"a","version":"1.0.0","dependencies":{"b":"workspace:*"}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("packages/b/package.json"),
+        r#"{"name":"b","version":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run(&dir, &["install"]);
+    assert_eq!(code, 0, "seed install\nstdout: {stdout}\nstderr: {stderr}");
+    let (stdout, stderr, code) = run(&dir, &["install"]);
+    assert_eq!(
+        code, 0,
+        "second install\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let second = observed(&dir, 2);
+    assert_eq!(
+        second["wantedLockfile"]["packages"],
+        serde_json::json!({}),
+        "a link-only workspace resolves to no package rows — that is the \
+         precondition this test needs: {second}"
+    );
+    assert_eq!(
+        second["wantedLockfile"]["importers"]["packages/a"]["specifiers"]["b"],
+        serde_json::json!("workspace:*"),
+        "…while the importer carries a real specifier: {second}"
+    );
+    assert_eq!(
+        second["existsNonEmptyWantedLockfile"],
+        serde_json::json!(true),
+        "pnpm's isEmptyLockfile reads importers, so this lockfile is \
+         non-empty despite having no packages: {second}"
+    );
+}
+
+/// Under a non-pnpm incumbent nub suppresses the cwd-default pnpmfile
+/// and prints a warning whose remedy is "name it explicitly with
+/// `--pnpmfile`". That remedy has to work: the flag must parse, and the
+/// named file must run the hook the default would have run.
+#[test]
+fn an_explicitly_named_pnpmfile_runs_under_a_non_pnpm_incumbent() {
+    let dir = fixture("npm-incumbent");
+    // Make npm the incumbent, which gates the cwd-default `.pnpmfile.cjs` off.
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"app","version":"1.0.0","packageManager":"npm@10.0.0","dependencies":{"dep":"file:./dep"}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("package-lock.json"),
+        r#"{"lockfileVersion":3,"name":"app","version":"1.0.0","packages":{}}"#,
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run(&dir, &["install"]);
+    assert_eq!(
+        code, 0,
+        "default install\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        observations(&dir),
+        0,
+        "the cwd-default pnpmfile is another tool's config under an npm \
+         incumbent and must stay gated off\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("--pnpmfile"),
+        "the warning is what points the user at the flag: {stderr}"
+    );
+
+    let (stdout, stderr, code) = run(&dir, &["install", "--pnpmfile", ".pnpmfile.cjs"]);
+    assert_eq!(code, 0, "--pnpmfile\nstdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(
+        observations(&dir),
+        1,
+        "naming the path explicitly is the documented remedy, so it has to \
+         run the hook\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("ignored"),
+        "the run that took the warning's own advice must not be told again \
+         that its pnpmfile was ignored: {stderr}"
+    );
+
+    let (stdout, stderr, code) = run(&dir, &["install", "--ignore-pnpmfile"]);
+    assert_eq!(
+        code, 0,
+        "--ignore-pnpmfile\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        observations(&dir),
+        1,
+        "--ignore-pnpmfile must not run anything\nstderr: {stderr}"
+    );
+}
+
+/// `update` resolves itself and then chains an install to materialize
+/// the result. That is one install operation — one `mutateModules` call
+/// in pnpm's terms — so the hook fires once, not once per stage.
+#[test]
+fn update_fires_the_hook_once_not_once_per_stage() {
+    let dir = fixture("update");
+    let (stdout, stderr, code) = run(&dir, &["install"]);
+    assert_eq!(code, 0, "seed install\nstdout: {stdout}\nstderr: {stderr}");
+    let before = observations(&dir);
+
+    let (stdout, stderr, code) = run(&dir, &["update"]);
+    assert_eq!(code, 0, "update\nstdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(
+        observations(&dir) - before,
+        1,
+        "update ran the hook more than once — its own resolve and the \
+         install it chains must not each fire it\nstdout: {stdout}\nstderr: {stderr}"
+    );
 }

--- a/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
+++ b/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
@@ -90,6 +90,29 @@ fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
     )
 }
 
+/// The manifest and whatever lockfile the run left behind, for an
+/// assertion message to carry.
+///
+/// A bare `left: 16, right: 0` on a lockfile-freshness failure says
+/// nothing about WHICH of the two files drifted, and these rows mutate
+/// the fixture as they go — the routed row rewrites `package.json`
+/// through `add`. It is also the only view of that state on a platform
+/// where a failure reproduces and the dev host does not.
+fn project_state(dir: &Path) -> String {
+    let mut out = String::new();
+    for name in [
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "nub.lock",
+    ] {
+        if let Ok(body) = std::fs::read_to_string(dir.join(name)) {
+            out.push_str(&format!("\n--- {name} ---\n{body}"));
+        }
+    }
+    out
+}
+
 /// How many times the hook has run in this fixture so far — one
 /// `observed-<n>.json` per firing.
 fn observations(dir: &Path) -> usize {
@@ -334,8 +357,10 @@ fn an_explicitly_named_pnpmfile_runs_under_a_non_pnpm_incumbent() {
     // native-install marker alone does not cover.
     let (stdout, stderr, code) = run(&dir, &["install", "--pnpmfile", ".pnpmfile.cjs", "./dep"]);
     assert_eq!(
-        code, 0,
-        "routed install <pkg>\nstdout: {stdout}\nstderr: {stderr}"
+        code,
+        0,
+        "routed install <pkg>\nstdout: {stdout}\nstderr: {stderr}\nstate: {}",
+        project_state(&dir)
     );
     assert_eq!(
         observations(&dir),
@@ -347,10 +372,15 @@ fn an_explicitly_named_pnpmfile_runs_under_a_non_pnpm_incumbent() {
         "and must not contradict itself with the default-file warning: {stderr}"
     );
 
+    // The routed row above rewrote `package.json` through `add`, so this
+    // frozen-by-default CI run is also the first thing to check that what
+    // `add` wrote to the manifest and what it wrote to the lockfile agree.
     let (stdout, stderr, code) = run(&dir, &["install", "--ignore-pnpmfile"]);
     assert_eq!(
-        code, 0,
-        "--ignore-pnpmfile\nstdout: {stdout}\nstderr: {stderr}"
+        code,
+        0,
+        "--ignore-pnpmfile\nstdout: {stdout}\nstderr: {stderr}\nstate: {}",
+        project_state(&dir)
     );
     assert_eq!(
         observations(&dir),

--- a/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
+++ b/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
@@ -287,15 +287,14 @@ fn a_link_only_workspace_lockfile_counts_as_non_empty() {
 #[test]
 fn an_explicitly_named_pnpmfile_runs_under_a_non_pnpm_incumbent() {
     let dir = fixture("npm-incumbent");
-    // Make npm the incumbent, which gates the cwd-default `.pnpmfile.cjs` off.
+    // `packageManager` alone makes npm the incumbent, which gates the
+    // cwd-default `.pnpmfile.cjs` off. Deliberately NO `package-lock.json`:
+    // seeding an empty one against a manifest that declares a dependency is
+    // lockfile drift, and CI defaults to frozen, so the fixture failed there
+    // with ERR_NUB_OUTDATED_LOCKFILE while passing on a dev machine.
     std::fs::write(
         dir.join("package.json"),
         r#"{"name":"app","version":"1.0.0","packageManager":"npm@10.0.0","dependencies":{"dep":"file:./dep"}}"#,
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("package-lock.json"),
-        r#"{"lockfileVersion":3,"name":"app","version":"1.0.0","packages":{}}"#,
     )
     .unwrap();
 

--- a/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
+++ b/crates/nub-cli/tests/pnpmfile_pre_resolution.rs
@@ -1,0 +1,205 @@
+//! The `preResolution` pnpmfile hook, against pnpm's contract.
+//!
+//! pnpm calls the hook on EVERY install — before it decides whether the
+//! lockfile is up to date — and hands it the in-memory `LockfileObject`:
+//! never `null`, `packages[key].resolution` readable, importer
+//! specifiers split out into their own map. A `console.log` in the hook
+//! body reaches the terminal, and the second argument is a
+//! `{info, warn}` logger rather than `{log}`.
+//!
+//! Every row is OFFLINE: the only dependency is a sibling directory
+//! (`file:`), and the project points its registry at a dead port so an
+//! accidental fetch fails loudly instead of passing quietly.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/
+    path.push("nub");
+    path
+}
+
+/// A pnpm-incumbent project whose one dependency is the local `dep/`
+/// directory, plus a pnpmfile that records the whole `preResolution`
+/// context to `observed-<n>.json` and prints a marker on stdout.
+fn fixture(tag: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nub-preresolution-{tag}-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("dep")).unwrap();
+    std::fs::write(dir.join(".npmrc"), "registry=http://127.0.0.1:1/\n").unwrap();
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"app","version":"1.0.0","packageManager":"pnpm@10.0.0","dependencies":{"dep":"file:./dep"}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("dep/package.json"),
+        r#"{"name":"dep","version":"2.3.4"}"#,
+    )
+    .unwrap();
+    // Numbering the output file is what makes "did it run a second
+    // time?" observable — a single overwritten file cannot tell a
+    // second run from a first.
+    std::fs::write(
+        dir.join(".pnpmfile.cjs"),
+        r#"
+module.exports = {
+  hooks: {
+    preResolution(ctx, logger) {
+      const fs = require('fs');
+      const seen = fs.readdirSync('.').filter((f) => f.startsWith('observed-')).length;
+      fs.writeFileSync('observed-' + (seen + 1) + '.json', JSON.stringify({
+        wantedLockfile: ctx.wantedLockfile,
+        currentLockfile: ctx.currentLockfile,
+        existsCurrentLockfile: ctx.existsCurrentLockfile,
+        existsNonEmptyWantedLockfile: ctx.existsNonEmptyWantedLockfile,
+        loggerKeys: logger == null ? [] : Object.keys(logger).sort(),
+      }, null, 2));
+      console.log('PRERESOLUTION_MARKER');
+    },
+  },
+};
+"#,
+    )
+    .unwrap();
+    dir
+}
+
+fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(nub_binary())
+        .args(args)
+        .current_dir(dir)
+        .env("NUB_SELF_SHIM", "0")
+        .env("XDG_DATA_HOME", dir.join("xdg-data"))
+        .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
+        .output()
+        .expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+fn observed(dir: &Path, n: usize) -> serde_json::Value {
+    let path = dir.join(format!("observed-{n}.json"));
+    let body = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("preResolution run {n} left no {}: {e}", path.display()));
+    serde_json::from_str(&body).expect("hook wrote valid JSON")
+}
+
+/// The whole contract in one project, because the interesting part is
+/// the *sequence*: what the hook sees with no lockfile, that it runs
+/// again once the lockfile is current, and what it sees then.
+#[test]
+fn pre_resolution_runs_on_every_install_with_pnpms_lockfile_shape() {
+    let dir = fixture("contract");
+
+    let (stdout, stderr, code) = run(&dir, &["install"]);
+    assert_eq!(code, 0, "first install\nstdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        stdout.contains("PRERESOLUTION_MARKER"),
+        "a console.log in the hook body belongs on stdout, as it does under pnpm; \
+         nub used to swallow it because the shim owned the child's stdout.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let first = observed(&dir, 1);
+    assert!(
+        first["wantedLockfile"].is_object(),
+        "with no lockfile pnpm passes an empty OBJECT, never null: {first}"
+    );
+    assert!(
+        first["wantedLockfile"].get("packages").is_none(),
+        "pnpm's synthesized empty lockfile has no `packages` key at all — \
+         hooks guard on `if (!lockfile.packages) return`: {first}"
+    );
+    assert_eq!(
+        first["wantedLockfile"]["importers"]["."]["specifiers"],
+        serde_json::json!({}),
+        "every importer carries a specifiers map, empty or not: {first}"
+    );
+    assert_eq!(
+        first["existsCurrentLockfile"],
+        serde_json::json!(false),
+        "no lockfile was on disk: {first}"
+    );
+    assert_eq!(
+        first["loggerKeys"],
+        serde_json::json!(["info", "log", "warn"]),
+        "pnpm's preResolution logger is {{info, warn}}; `log` is aube's own \
+         spelling, kept so pnpmfiles written against aube keep working: {first}"
+    );
+
+    // The regression the issue reported: a second install has an
+    // up-to-date lockfile, takes the reuse path, and used to skip the
+    // hook entirely.
+    let (stdout, stderr, code) = run(&dir, &["install"]);
+    assert_eq!(
+        code, 0,
+        "second install\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let second = observed(&dir, 2);
+
+    let packages = second["wantedLockfile"]["packages"]
+        .as_object()
+        .unwrap_or_else(|| panic!("second run must see the written lockfile: {second}"));
+    let (key, entry) = packages
+        .iter()
+        .find(|(k, _)| k.starts_with("dep@"))
+        .unwrap_or_else(|| panic!("the local dependency must appear in packages: {second}"));
+    assert!(
+        entry.get("resolution").is_some(),
+        "packages[{key}].resolution is what a hook rewriting resolutions reads; \
+         nub's old projection had no such field: {entry}"
+    );
+    assert_eq!(
+        second["wantedLockfile"]["importers"]["."]["specifiers"]["dep"],
+        serde_json::json!("file:./dep"),
+        "the importer's inline {{specifier, version}} pair splits into a \
+         specifiers map, the way pnpm's reader leaves it: {second}"
+    );
+    assert_eq!(
+        second["existsNonEmptyWantedLockfile"],
+        serde_json::json!(true),
+        "a lockfile with packages is non-empty: {second}"
+    );
+    assert_eq!(
+        second["currentLockfile"], second["wantedLockfile"],
+        "aube keeps no separate installed-state lockfile, so the two sides \
+         are the same object at preResolution time: {second}"
+    );
+}
+
+/// `--frozen-lockfile` and `--no-frozen-lockfile` both withhold the
+/// parsed lockfile from the resolver, for reasons that have nothing to
+/// do with the hook. `wantedLockfile` is the file on disk, so neither
+/// flag may empty it out.
+#[test]
+fn frozen_modes_still_hand_the_hook_the_on_disk_lockfile() {
+    for flag in ["--frozen-lockfile", "--no-frozen-lockfile"] {
+        let dir = fixture("frozen");
+        let (stdout, stderr, code) = run(&dir, &["install"]);
+        assert_eq!(code, 0, "seed install\nstdout: {stdout}\nstderr: {stderr}");
+
+        let (stdout, stderr, code) = run(&dir, &["install", flag]);
+        assert_eq!(code, 0, "{flag}\nstdout: {stdout}\nstderr: {stderr}");
+        let second = observed(&dir, 2);
+        let packages = second["wantedLockfile"]["packages"]
+            .as_object()
+            .unwrap_or_else(|| panic!("{flag} must still show the lockfile: {second}"));
+        assert!(
+            packages.keys().any(|k| k.starts_with("dep@")),
+            "{flag} left the hook with an empty lockfile: {second}"
+        );
+    }
+}

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -294,6 +294,9 @@ The accepted flags are pnpm's spellings:
 --prod, -P            # production install
 --dev, -D
 --ignore-scripts
+--pnpmfile <path>     # run this one instead of the project's
+--global-pnpmfile <path>
+--ignore-pnpmfile
 --no-optional
 --offline / --prefer-offline
 --lockfile-only

--- a/site/content/docs/install/pnpm.mdx
+++ b/site/content/docs/install/pnpm.mdx
@@ -106,7 +106,7 @@ When pnpm is the incumbent, Nub honors pnpm's own settings:
 - `pnpm.patchedDependencies` — patch files applied to dependency contents during linking, wired to `nub patch` / `patch-commit` / `patch-remove`.
 - `pnpm.onlyBuiltDependencies` / `pnpm.neverBuiltDependencies` / `pnpm.allowBuilds` — feed Nub's lifecycle-script policy.
 - `pnpm.supportedArchitectures` — which platforms' optional dependencies get installed. Also readable from `.npmrc` and `pnpm-workspace.yaml`, and overridable per axis for one run with [`--os` / `--cpu` / `--libc`](/docs/install#nub-install).
-- `.pnpmfile.cjs` / `.pnpmfile.mjs` — the `readPackage`, `preResolution`, and `afterAllResolved` hooks run. Dependency-map edits from `readPackage` apply; package-map edits from `afterAllResolved` apply. New importers/packages, identity rewrites, `updateConfig` hooks, and config-dependency pnpmfiles are not supported.
+- `.pnpmfile.cjs` / `.pnpmfile.mjs` — the `readPackage`, `preResolution`, and `afterAllResolved` hooks run. Dependency-map edits from `readPackage` apply; package-map edits from `afterAllResolved` apply. `preResolution` is read-only: it runs on every install and receives pnpm's lockfile object, but Nub runs it out of process, so edits it makes to that object are reported and discarded. New importers/packages, identity rewrites, `updateConfig` hooks, and config-dependency pnpmfiles are not supported.
 
 <Callout>
 Read the [full docs](https://pnpm.io/settings) on pnpm.io.

--- a/vendor/aube/crates/aube-codes/src/warnings.rs
+++ b/vendor/aube/crates/aube-codes/src/warnings.rs
@@ -15,6 +15,7 @@ pub const WARN_AUBE_HOOK_IMPORTER_MUTATED: &str = "WARN_AUBE_HOOK_IMPORTER_MUTAT
 pub const WARN_AUBE_HOOK_IMPORTER_ADDED: &str = "WARN_AUBE_HOOK_IMPORTER_ADDED";
 pub const WARN_AUBE_HOOK_IDENTITY_REWRITTEN: &str = "WARN_AUBE_HOOK_IDENTITY_REWRITTEN";
 pub const WARN_AUBE_HOOK_PACKAGE_ADDED: &str = "WARN_AUBE_HOOK_PACKAGE_ADDED";
+#[rustfmt::skip] pub const WARN_AUBE_HOOK_PRE_RESOLUTION_MUTATED: &str = "WARN_AUBE_HOOK_PRE_RESOLUTION_MUTATED";
 
 // ── install lifecycle ───────────────────────────────────────────────
 pub const WARN_AUBE_IGNORED_BUILD_SCRIPTS: &str = "WARN_AUBE_IGNORED_BUILD_SCRIPTS";
@@ -196,6 +197,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_HOOK_PACKAGE_ADDED,
         category: category::PNPMFILE_HOOKS,
         description: "A pnpmfile hook added a wholly-new package entry; aube ignored it.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_HOOK_PRE_RESOLUTION_MUTATED,
+        category: category::PNPMFILE_HOOKS,
+        description: "A pnpmfile `preResolution` hook edited the lockfile it was handed. pnpm runs the hook in-process, so such an edit reaches the resolver; aube runs it in a child and the edit is discarded. Move the change to `readPackage` or `afterAllResolved`.",
         exit_code: None,
     },
     // Install lifecycle

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/hook_view.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/hook_view.rs
@@ -59,7 +59,17 @@ pub fn lockfile_object(
 ///
 /// An empty `importer_ids` falls back to the root importer alone,
 /// which is what a caller with no workspace list to hand over means.
-pub fn empty_lockfile_object(importer_ids: &[String], settings: &LockfileSettings) -> Value {
+///
+/// `peers_suffix_max_length` is the effective resolver cap, passed in
+/// rather than read off [`LockfileSettings`] because it is not a
+/// round-tripped lockfile field: pnpm omits it from the file whenever it
+/// equals the 1000 default, so the READ path legitimately has no value
+/// for it, and only this synthesized object carries one.
+pub fn empty_lockfile_object(
+    importer_ids: &[String],
+    settings: &LockfileSettings,
+    peers_suffix_max_length: u64,
+) -> Value {
     let root = [".".to_string()];
     let importer_ids = if importer_ids.is_empty() {
         &root[..]
@@ -85,6 +95,10 @@ pub fn empty_lockfile_object(importer_ids: &[String], settings: &LockfileSetting
         "excludeLinksFromLockfile".to_string(),
         Value::Bool(settings.exclude_links_from_lockfile),
     );
+    settings_map.insert(
+        "peersSuffixMaxLength".to_string(),
+        Value::Number(peers_suffix_max_length.into()),
+    );
     Value::Object(Map::from_iter([
         (
             "lockfileVersion".to_string(),
@@ -93,6 +107,28 @@ pub fn empty_lockfile_object(importer_ids: &[String], settings: &LockfileSetting
         ("settings".to_string(), Value::Object(settings_map)),
         ("importers".to_string(), Value::Object(importers)),
     ]))
+}
+
+/// pnpm's `isEmptyLockfile`, applied to a projected object from either
+/// constructor above: a lockfile is empty when every importer has an
+/// empty `specifiers` AND an empty `dependencies` map.
+///
+/// The package map deliberately does not enter into it. A workspace
+/// wired together only by `workspace:*` links resolves to zero
+/// `packages:` rows while its importers carry real specifiers, and pnpm
+/// calls that lockfile non-empty.
+pub fn is_empty(lockfile: &Value) -> bool {
+    let Some(importers) = lockfile.get("importers").and_then(Value::as_object) else {
+        return true;
+    };
+    importers.values().all(|importer| {
+        ["specifiers", "dependencies"].iter().all(|key| {
+            importer
+                .get(key)
+                .and_then(Value::as_object)
+                .is_none_or(Map::is_empty)
+        })
+    })
 }
 
 /// Collapse the v9 `packages:`/`snapshots:` split the way pnpm's reader
@@ -227,6 +263,7 @@ mod tests {
                 auto_install_peers: true,
                 ..Default::default()
             },
+            1000,
         );
         let root = value.as_object().unwrap();
         assert!(
@@ -235,10 +272,50 @@ mod tests {
         );
         assert_eq!(root["lockfileVersion"], Value::String("9.0".into()));
         assert_eq!(root["settings"]["autoInstallPeers"], Value::Bool(true));
+        assert_eq!(
+            root["settings"]["peersSuffixMaxLength"],
+            Value::Number(1000.into()),
+            "pnpm's createLockfileObject stamps the effective cap; a hook \
+             reading it must not get undefined"
+        );
         assert_eq!(root["importers"]["."]["specifiers"], Value::Object(Map::new()));
         assert_eq!(
             root["importers"]["."]["dependencies"],
             Value::Object(Map::new())
+        );
+        assert!(is_empty(&value), "a synthesized lockfile is empty");
+    }
+
+    /// pnpm decides emptiness from importers alone. A workspace linked
+    /// together with `workspace:*` writes no `packages:` rows, so a
+    /// package-count test would call this lockfile empty and flip
+    /// `existsNonEmptyWantedLockfile` for every workspace on that shape.
+    #[test]
+    fn a_link_only_workspace_lockfile_is_not_empty() {
+        let mut graph = LockfileGraph::default();
+        graph.importers.insert(".".into(), Vec::new());
+        graph.importers.insert(
+            "packages/a".into(),
+            vec![crate::DirectDep {
+                name: "b".into(),
+                dep_path: "link:../b".into(),
+                dep_type: crate::DepType::Production,
+                specifier: Some("workspace:*".into()),
+            }],
+        );
+
+        let dir = std::env::temp_dir().join("aube-hook-view-link-only");
+        let value =
+            lockfile_object(&dir, &graph, &PackageJson::default()).expect("projection succeeds");
+
+        assert_eq!(
+            value["packages"],
+            Value::Object(Map::new()),
+            "a link-only graph resolves to no package rows at all"
+        );
+        assert!(
+            !is_empty(&value),
+            "…but its importer carries a real specifier, so pnpm calls it non-empty"
         );
     }
 

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/hook_view.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/hook_view.rs
@@ -1,0 +1,310 @@
+//! The lockfile shape pnpmfile hooks see.
+//!
+//! pnpm hands `preResolution` its **in-memory** `LockfileObject`, which
+//! is not the on-disk v9 file: `packages:` and `snapshots:` are merged
+//! into one map keyed by the snapshot's dep path, and each importer's
+//! inline `{specifier, version}` pairs are split back into a flat
+//! `dependencies` map plus a sibling `specifiers` map
+//! (`convertToLockfileObject` / `revertProjectSnapshot` in
+//! `@pnpm/lockfile.fs`). A hook written against pnpm reads
+//! `lockfile.packages[key].resolution` and
+//! `lockfile.importers['.'].specifiers`, so anything else is a shape it
+//! cannot use.
+//!
+//! Both constructors below produce that object. They go through the
+//! writer's own projection ([`super::write::build`]) rather than a
+//! second walk of the graph, so the hook sees the same dep-path
+//! translation, patch-hash suffixes and alias recovery that land in
+//! `pnpm-lock.yaml` — a hook that rewrites a resolution URL is looking
+//! at the URL the lockfile will actually carry.
+
+use aube_manifest::PackageJson;
+use serde_json::{Map, Value};
+
+use crate::{Error, LockfileGraph, LockfileSettings};
+
+/// pnpm's own `LOCKFILE_VERSION` for the v9 schema, mirrored here so the
+/// empty object below advertises the same version the writer stamps.
+const LOCKFILE_VERSION: &str = "9.0";
+
+/// Project `graph` onto the object pnpm passes a pnpmfile hook.
+///
+/// `lockfile_dir` is the project root: the view is always rendered with
+/// pnpm's native encodings (aliases included) because its only consumer
+/// is a pnpm-compatible hook, whatever lockfile format the project
+/// itself is on.
+pub fn lockfile_object(
+    lockfile_dir: &std::path::Path,
+    graph: &LockfileGraph,
+    manifest: &PackageJson,
+) -> Result<Value, Error> {
+    let writable = super::write::build(&lockfile_dir.join("pnpm-lock.yaml"), graph, manifest)?;
+    let mut value = serde_json::to_value(&writable)
+        .map_err(|e| Error::parse(lockfile_dir, format!("failed to project lockfile: {e}")))?;
+    let Some(root) = value.as_object_mut() else {
+        return Ok(value);
+    };
+    merge_snapshots_into_packages(root);
+    flatten_patched_dependencies(root);
+    revert_importers(root);
+    Ok(value)
+}
+
+/// The object pnpm synthesizes when there is no lockfile on disk
+/// (`createLockfileObject`): a version, the resolved settings, and one
+/// empty entry per importer. Deliberately carries **no** `packages`
+/// key — pnpm only sets that field when a lockfile was read, and a hook
+/// that guards on `if (!lockfile.packages) return` depends on the
+/// difference.
+///
+/// An empty `importer_ids` falls back to the root importer alone,
+/// which is what a caller with no workspace list to hand over means.
+pub fn empty_lockfile_object(importer_ids: &[String], settings: &LockfileSettings) -> Value {
+    let root = [".".to_string()];
+    let importer_ids = if importer_ids.is_empty() {
+        &root[..]
+    } else {
+        importer_ids
+    };
+    let mut importers = Map::new();
+    for id in importer_ids {
+        importers.insert(
+            id.clone(),
+            Value::Object(Map::from_iter([
+                ("dependencies".to_string(), Value::Object(Map::new())),
+                ("specifiers".to_string(), Value::Object(Map::new())),
+            ])),
+        );
+    }
+    let mut settings_map = Map::new();
+    settings_map.insert(
+        "autoInstallPeers".to_string(),
+        Value::Bool(settings.auto_install_peers),
+    );
+    settings_map.insert(
+        "excludeLinksFromLockfile".to_string(),
+        Value::Bool(settings.exclude_links_from_lockfile),
+    );
+    Value::Object(Map::from_iter([
+        (
+            "lockfileVersion".to_string(),
+            Value::String(LOCKFILE_VERSION.to_string()),
+        ),
+        ("settings".to_string(), Value::Object(settings_map)),
+        ("importers".to_string(), Value::Object(importers)),
+    ]))
+}
+
+/// Collapse the v9 `packages:`/`snapshots:` split the way pnpm's reader
+/// does: iterate the *snapshots*, key the merged entry by the snapshot's
+/// dep path (peer and patch suffixes intact), and let the `packages:`
+/// entry for the suffix-less id win on any field both carry. A
+/// `packages:` entry no snapshot references drops out, exactly as in
+/// pnpm.
+fn merge_snapshots_into_packages(root: &mut Map<String, Value>) {
+    let snapshots = match root.remove("snapshots") {
+        Some(Value::Object(m)) => m,
+        _ => Map::new(),
+    };
+    let packages = match root.remove("packages") {
+        Some(Value::Object(m)) => m,
+        _ => Map::new(),
+    };
+    let mut merged = Map::new();
+    for (dep_path, snapshot) in snapshots {
+        let mut entry = match snapshot {
+            Value::Object(m) => m,
+            other => {
+                merged.insert(dep_path, other);
+                continue;
+            }
+        };
+        if let Some(Value::Object(info)) = packages.get(remove_suffix(&dep_path)) {
+            for (key, value) in info {
+                entry.insert(key.clone(), value.clone());
+            }
+        }
+        merged.insert(dep_path, Value::Object(entry));
+    }
+    root.insert("packages".to_string(), Value::Object(merged));
+}
+
+/// pnpm's `migratePatchedDependencies`: the in-memory map is always
+/// `selector -> string`, where a v10 `{hash, path}` entry collapses to
+/// its hash and a bare path string passes through.
+fn flatten_patched_dependencies(root: &mut Map<String, Value>) {
+    let Some(Value::Object(patched)) = root.get_mut("patchedDependencies") else {
+        return;
+    };
+    for value in patched.values_mut() {
+        if let Value::Object(entry) = value {
+            let flattened = entry
+                .get("hash")
+                .or_else(|| entry.get("path"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            *value = flattened;
+        }
+    }
+}
+
+/// pnpm's `revertProjectSnapshot`: hoist every dependency block's
+/// inline `specifier` into one `specifiers` map on the importer and
+/// leave the block itself as a flat `name -> version` map. `specifiers`
+/// is always present, even when empty, because pnpm's reader always
+/// sets it.
+///
+/// `skippedOptionalDependencies` is left out on purpose: it is aube's
+/// own drift-detection record, and its `version` is the sentinel
+/// `0.0.0` rather than an installed version, so flattening it into
+/// pnpm's `name -> version` shape would state something untrue.
+fn revert_importers(root: &mut Map<String, Value>) {
+    const BLOCKS: [&str; 3] = ["dependencies", "devDependencies", "optionalDependencies"];
+    let Some(Value::Object(importers)) = root.get_mut("importers") else {
+        return;
+    };
+    for importer in importers.values_mut() {
+        let Value::Object(importer) = importer else {
+            continue;
+        };
+        importer.remove("skippedOptionalDependencies");
+        let mut specifiers = Map::new();
+        for block in BLOCKS {
+            let Some(Value::Object(deps)) = importer.get(block) else {
+                continue;
+            };
+            let mut flat = Map::new();
+            for (name, spec) in deps {
+                let Value::Object(spec) = spec else {
+                    continue;
+                };
+                if let Some(specifier) = spec.get("specifier") {
+                    specifiers.insert(name.clone(), specifier.clone());
+                }
+                flat.insert(
+                    name.clone(),
+                    spec.get("version").cloned().unwrap_or(Value::Null),
+                );
+            }
+            importer.insert(block.to_string(), Value::Object(flat));
+        }
+        importer.insert("specifiers".to_string(), Value::Object(specifiers));
+    }
+}
+
+/// pnpm's `removeSuffix`: a dep path's identity ends at the first
+/// top-level `(`, whether that opens a `(patch_hash=…)` marker or a
+/// peer-suffix segment.
+fn remove_suffix(dep_path: &str) -> &str {
+    match dep_path.find('(') {
+        Some(i) => &dep_path[..i],
+        None => dep_path,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remove_suffix_trims_peer_and_patch_segments() {
+        assert_eq!(remove_suffix("react-dom@18.2.0"), "react-dom@18.2.0");
+        assert_eq!(
+            remove_suffix("react-dom@18.2.0(react@18.2.0)"),
+            "react-dom@18.2.0"
+        );
+        assert_eq!(
+            remove_suffix("lodash@4.17.21(patch_hash=abc)"),
+            "lodash@4.17.21"
+        );
+    }
+
+    #[test]
+    fn empty_object_has_no_packages_key() {
+        let value = empty_lockfile_object(
+            &[".".to_string()],
+            &LockfileSettings {
+                auto_install_peers: true,
+                ..Default::default()
+            },
+        );
+        let root = value.as_object().unwrap();
+        assert!(
+            !root.contains_key("packages"),
+            "pnpm's createLockfileObject sets no packages key; hooks guard on that"
+        );
+        assert_eq!(root["lockfileVersion"], Value::String("9.0".into()));
+        assert_eq!(root["settings"]["autoInstallPeers"], Value::Bool(true));
+        assert_eq!(root["importers"]["."]["specifiers"], Value::Object(Map::new()));
+        assert_eq!(
+            root["importers"]["."]["dependencies"],
+            Value::Object(Map::new())
+        );
+    }
+
+    #[test]
+    fn packages_carry_resolution_and_snapshot_dependencies() {
+        let mut graph = LockfileGraph::default();
+        let mut pkg = crate::LockedPackage {
+            name: "is-obj".into(),
+            version: "3.0.0".into(),
+            integrity: Some("sha512-deadbeef".into()),
+            dep_path: "is-obj@3.0.0".into(),
+            ..Default::default()
+        };
+        pkg.dependencies.insert("tslib".into(), "2.6.2".into());
+        pkg.engines.insert("node".into(), ">=12".into());
+        graph.packages.insert("is-obj@3.0.0".into(), pkg);
+        graph.packages.insert(
+            "tslib@2.6.2".into(),
+            crate::LockedPackage {
+                name: "tslib".into(),
+                version: "2.6.2".into(),
+                integrity: Some("sha512-tslib".into()),
+                dep_path: "tslib@2.6.2".into(),
+                ..Default::default()
+            },
+        );
+        graph.importers.insert(
+            ".".into(),
+            vec![crate::DirectDep {
+                name: "is-obj".into(),
+                dep_path: "is-obj@3.0.0".into(),
+                dep_type: crate::DepType::Production,
+                specifier: Some("^3.0.0".into()),
+            }],
+        );
+
+        let dir = std::env::temp_dir().join("aube-hook-view-test");
+        let value =
+            lockfile_object(&dir, &graph, &PackageJson::default()).expect("projection succeeds");
+
+        let entry = &value["packages"]["is-obj@3.0.0"];
+        assert_eq!(
+            entry["resolution"]["integrity"],
+            Value::String("sha512-deadbeef".into()),
+            "a pnpm hook reads packages[key].resolution; it must be present"
+        );
+        assert_eq!(entry["engines"]["node"], Value::String(">=12".into()));
+        assert_eq!(
+            entry["dependencies"]["tslib"],
+            Value::String("2.6.2".into()),
+            "the snapshot's dependency map merges into the same entry"
+        );
+        assert!(
+            value.get("snapshots").is_none(),
+            "pnpm's in-memory object has no snapshots key"
+        );
+
+        let importer = &value["importers"]["."];
+        assert_eq!(
+            importer["dependencies"]["is-obj"],
+            Value::String("3.0.0".into()),
+            "the inline {{specifier, version}} pair must be flattened to the version"
+        );
+        assert_eq!(
+            importer["specifiers"]["is-obj"],
+            Value::String("^3.0.0".into())
+        );
+    }
+}

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/mod.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/mod.rs
@@ -1,6 +1,7 @@
 mod checksum;
 mod dep_path;
 mod format;
+pub mod hook_view;
 mod raw;
 mod read;
 mod subset;

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
@@ -65,6 +65,30 @@ mod tests {
 
 /// Write a LockfileGraph as pnpm-lock.yaml v9 format.
 pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Result<(), Error> {
+    let lockfile = build(path, graph, manifest)?;
+    let yaml = yaml_serde::to_string(&lockfile).map_err(|e| Error::parse(path, e.to_string()))?;
+    let yaml = reformat_for_pnpm_parity(&yaml);
+    // Atomic via tempfile + persist. Crash, Ctrl+C, or AV
+    // quarantine during the write used to leave the user with a
+    // truncated pnpm-lock.yaml on disk, next install failed to
+    // parse and the user thought their lockfile was gone. See
+    // atomic_write_lockfile for full rationale.
+    crate::atomic_write_lockfile(path, yaml.as_bytes())?;
+    Ok(())
+}
+
+/// Project a `LockfileGraph` onto pnpm's v9 lockfile schema without
+/// serializing it. Split out of [`write`] so the pnpmfile hook view
+/// ([`super::hook_view`]) hands hooks the exact same projection the
+/// writer puts on disk — dep-path translation, patch-hash suffixes,
+/// alias recovery and all — instead of a second, drifting one.
+/// `path` decides `pnpm-lock.yaml`-only behavior (native alias
+/// encoding) and roots the workspace-member manifest reads.
+pub(super) fn build(
+    path: &Path,
+    graph: &LockfileGraph,
+    manifest: &PackageJson,
+) -> Result<WritablePnpmLockfile, Error> {
     let native_pnpm_aliases = path
         .file_name()
         .and_then(|name| name.to_str())
@@ -953,15 +977,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         snapshots,
     };
 
-    let yaml = yaml_serde::to_string(&lockfile).map_err(|e| Error::parse(path, e.to_string()))?;
-    let yaml = reformat_for_pnpm_parity(&yaml);
-    // Atomic via tempfile + persist. Crash, Ctrl+C, or AV
-    // quarantine during the write used to leave the user with a
-    // truncated pnpm-lock.yaml on disk, next install failed to
-    // parse and the user thought their lockfile was gone. See
-    // atomic_write_lockfile for full rationale.
-    crate::atomic_write_lockfile(path, yaml.as_bytes())?;
-    Ok(())
+    Ok(lockfile)
 }
 
 fn registry_tarball_url_is_not_derivable(
@@ -1036,7 +1052,7 @@ fn pruned_time_entries(
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct WritablePnpmLockfile {
+pub(super) struct WritablePnpmLockfile {
     lockfile_version: String,
     settings: WritableSettings,
     /// pnpm v9 emits a top-level `catalogs:` map immediately after

--- a/vendor/aube/crates/aube/src/commands/add/filtered.rs
+++ b/vendor/aube/crates/aube/src/commands/add/filtered.rs
@@ -94,6 +94,10 @@ pub(super) async fn run(
         install_opts.osv_transitive_check = true;
         // `--lockfile-only`: write the lockfile + manifests, skip linking.
         install_opts.lockfile_only = args.lockfile_only;
+        // Same as the sibling path: the chained install owns the hooks.
+        install_opts.pnpmfile = args.pnpmfile.clone();
+        install_opts.global_pnpmfile = args.global_pnpmfile.clone();
+        install_opts.ignore_pnpmfile = args.ignore_pnpmfile;
         install::run_with_project_lock(install_opts, &lock).await?;
         Ok(())
     }

--- a/vendor/aube/crates/aube/src/commands/add/global.rs
+++ b/vendor/aube/crates/aube/src/commands/add/global.rs
@@ -7,6 +7,17 @@ pub(super) struct GlobalAddOptions {
     pub(super) allow_low_downloads: bool,
     pub(super) dangerously_allow_all_builds: bool,
     pub(super) deny_build: Vec<String>,
+    /// An explicitly named pnpmfile survives the hop into the throwaway
+    /// global install dir. Only the cwd-DEFAULT discovery is meaningless
+    /// there — a path the user named is a path the user meant, and pnpm
+    /// carries its install options onto the global add unchanged.
+    ///
+    /// Absolute by the time they arrive: `run_global_inner` chdirs, so a
+    /// relative path resolved after the hop would name a file inside the
+    /// temporary directory instead of one beside the user's project.
+    pub(super) pnpmfile: Option<std::path::PathBuf>,
+    pub(super) global_pnpmfile: Option<std::path::PathBuf>,
+    pub(super) ignore_pnpmfile: bool,
 }
 
 /// `aube add -g <pkg>...` — install into an isolated global install dir
@@ -129,6 +140,9 @@ async fn run_global_inner(
         allow_low_downloads,
         dangerously_allow_all_builds,
         deny_build,
+        pnpmfile,
+        global_pnpmfile,
+        ignore_pnpmfile,
     } = options;
 
     // Seed a minimal package.json so the resolver has a project to work
@@ -194,12 +208,12 @@ async fn run_global_inner(
         // lockfile-only global add makes no sense, so the synthetic
         // inner add never sets it.
         lockfile_only: false,
-        // The inner add runs inside the throwaway global install dir,
-        // where the caller's project pnpmfile is not on the path and no
-        // default one exists — so there are no hooks here to steer.
-        pnpmfile: None,
-        global_pnpmfile: None,
-        ignore_pnpmfile: false,
+        // Already absolutised against the caller's cwd (see
+        // `GlobalAddOptions`); the throwaway dir has no default pnpmfile
+        // of its own, so only an explicitly named one can apply here.
+        pnpmfile,
+        global_pnpmfile,
+        ignore_pnpmfile,
         workspace: false,
         save_catalog: false,
         save_catalog_name: None,

--- a/vendor/aube/crates/aube/src/commands/add/global.rs
+++ b/vendor/aube/crates/aube/src/commands/add/global.rs
@@ -194,6 +194,12 @@ async fn run_global_inner(
         // lockfile-only global add makes no sense, so the synthetic
         // inner add never sets it.
         lockfile_only: false,
+        // The inner add runs inside the throwaway global install dir,
+        // where the caller's project pnpmfile is not on the path and no
+        // default one exists — so there are no hooks here to steer.
+        pnpmfile: None,
+        global_pnpmfile: None,
+        ignore_pnpmfile: false,
         workspace: false,
         save_catalog: false,
         save_catalog_name: None,

--- a/vendor/aube/crates/aube/src/commands/add/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/add/mod.rs
@@ -448,6 +448,20 @@ pub async fn run(
     reject_conflicting_build_flags(&allow_build, &deny_build)?;
 
     if global {
+        // Resolve the pnpmfile paths against the CALLER's cwd before
+        // handing them over: the global path chdirs into a throwaway
+        // install dir, and a relative path resolved after that hop would
+        // name a file inside the temporary directory.
+        // A cwd this process cannot read is a failure the install itself
+        // would hit moments later, so leaving the path relative there is
+        // no worse and keeps this from being the error the user sees.
+        let caller_cwd = crate::dirs::cwd().ok();
+        let absolutise = |p: std::path::PathBuf| -> std::path::PathBuf {
+            match &caller_cwd {
+                Some(dir) if !p.is_absolute() => dir.join(p),
+                _ => p,
+            }
+        };
         return global::run_global(
             packages,
             global::GlobalAddOptions {
@@ -455,6 +469,9 @@ pub async fn run(
                 allow_low_downloads,
                 dangerously_allow_all_builds,
                 deny_build,
+                pnpmfile: pnpmfile.map(absolutise),
+                global_pnpmfile: global_pnpmfile.map(absolutise),
+                ignore_pnpmfile,
             },
             lockfile,
             network,

--- a/vendor/aube/crates/aube/src/commands/add/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/add/mod.rs
@@ -452,6 +452,18 @@ pub async fn run(
         // handing them over: the global path chdirs into a throwaway
         // install dir, and a relative path resolved after that hop would
         // name a file inside the temporary directory.
+        //
+        // A deliberate divergence, not an oversight. pnpm resolves every
+        // pnpmfile path against the project PREFIX — `pathAbsolute(path,
+        // prefix)` in 11, and measured identical on 10.15.1, where `pnpm
+        // -C proj install --pnpmfile hooks.cjs` fails with `pnpmfile at
+        // "proj/hooks.cjs" is not found` for a file sitting in the cwd.
+        // Copying that would make the flag dead here rather than
+        // compatible: pnpm's global prefix is a stable `$PNPM_HOME/global`
+        // a user can drop a file into, while ours is `<pkg_dir>/<pid>-<ts>`
+        // (`global.rs`), created and removed per invocation, so no
+        // relative path could ever resolve inside it.
+        //
         // A cwd this process cannot read is a failure the install itself
         // would hit moments later, so leaving the path relative there is
         // no worse and keeps this from being the error the user sees.

--- a/vendor/aube/crates/aube/src/commands/add/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/add/mod.rs
@@ -268,6 +268,17 @@ pub struct AddArgs {
         value_parser = parse_deny_build_value,
     )]
     pub deny_build: Vec<String>,
+    /// Add a global pnpmfile that runs before the local one.
+    ///
+    /// Mirrors pnpm's `--global-pnpmfile <path>`, which `pnpm add`
+    /// documents alongside `install`. `add` chains an install, and it is
+    /// that install which runs the hooks, so these three exist to steer
+    /// it rather than to do anything here.
+    #[arg(long, value_name = "PATH", conflicts_with = "ignore_pnpmfile")]
+    pub global_pnpmfile: Option<std::path::PathBuf>,
+    /// Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this add.
+    #[arg(long)]
+    pub ignore_pnpmfile: bool,
     /// Skip lifecycle scripts (no-op; aube already skips by default).
     #[arg(long, hide = true)]
     pub ignore_scripts: bool,
@@ -306,6 +317,13 @@ pub struct AddArgs {
     /// `package.json`. Mirrors `pnpm add --no-save-workspace-protocol`.
     #[arg(long, overrides_with = "save_workspace_protocol")]
     pub no_save_workspace_protocol: bool,
+    /// Run this pnpmfile instead of the project's own one.
+    ///
+    /// Mirrors pnpm's `--pnpmfile <path>`; relative paths resolve
+    /// against the project root. Like the two flags above it, this
+    /// steers the install `add` chains rather than acting here.
+    #[arg(long, value_name = "PATH", conflicts_with = "ignore_pnpmfile")]
+    pub pnpmfile: Option<std::path::PathBuf>,
     /// Save the new dependency into the workspace's default catalog.
     ///
     /// Writes `catalog:` into `package.json` and seeds/upserts the
@@ -399,6 +417,9 @@ pub async fn run(
         save_workspace_protocol,
         no_save_workspace_protocol,
         workspace,
+        global_pnpmfile,
+        ignore_pnpmfile,
+        pnpmfile,
         ignore_scripts: _,
         no_save,
         ignore_workspace_root_check,
@@ -607,6 +628,11 @@ pub async fn run(
     // `--lockfile-only`: the resolver still runs and the lockfile +
     // manifest are written, but the linker never touches `node_modules`.
     install_opts.lockfile_only = lockfile_only;
+    // The chained install is what actually runs the hooks, so `add`'s
+    // pnpmfile flags only mean anything once they land here.
+    install_opts.pnpmfile = pnpmfile;
+    install_opts.global_pnpmfile = global_pnpmfile;
+    install_opts.ignore_pnpmfile = ignore_pnpmfile;
     let pipeline_result: miette::Result<()> =
         install::run_with_project_lock(install_opts, &lock).await;
 

--- a/vendor/aube/crates/aube/src/commands/ci.rs
+++ b/vendor/aube/crates/aube/src/commands/ci.rs
@@ -74,6 +74,9 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         ignore_pnpmfile: false,
         pnpmfile: None,
         global_pnpmfile: None,
+        // `ci` is an install in its own right, not a stage chained after
+        // one — it runs the hook itself.
+        pre_resolution_hook_already_ran: false,
         ignore_scripts,
         dry_run: false,
         lockfile_only: false,

--- a/vendor/aube/crates/aube/src/commands/deploy/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/deploy/mod.rs
@@ -329,6 +329,9 @@ pub async fn run(
             ignore_pnpmfile: false,
             pnpmfile: None,
             global_pnpmfile: None,
+            // A fresh install into the deploy target, not a stage
+            // chained after one — it runs the hook itself.
+            pre_resolution_hook_already_ran: false,
             ignore_scripts: false,
             dry_run: false,
             lockfile_only: false,

--- a/vendor/aube/crates/aube/src/commands/install/args.rs
+++ b/vendor/aube/crates/aube/src/commands/install/args.rs
@@ -282,6 +282,7 @@ impl InstallArgs {
             ignore_pnpmfile: self.ignore_pnpmfile,
             pnpmfile: self.pnpmfile,
             global_pnpmfile: self.global_pnpmfile,
+            pre_resolution_hook_already_ran: false,
             ignore_scripts: self.ignore_scripts,
             dry_run: self.dry_run,
             lockfile_only: self.lockfile_only,
@@ -348,6 +349,14 @@ pub struct InstallOptions {
     /// *before* the local one, so org-wide rules can be layered under
     /// per-project hooks.
     pub global_pnpmfile: Option<std::path::PathBuf>,
+    /// Set by a command that already ran `preResolution` itself and is
+    /// now chaining an install to materialize what it resolved — today
+    /// only `aube update`. pnpm fires the hook once per install
+    /// operation (one `mutateModules` call), so without this a single
+    /// `update` would run the user's hook twice. Not a CLI flag: no
+    /// user invocation sets it, and an ordinary `aube install` leaves
+    /// it false and runs the hook itself.
+    pub pre_resolution_hook_already_ran: bool,
     /// `--ignore-scripts`: skip root lifecycle scripts (`preinstall`,
     /// `install`, `postinstall`, `prepare`) *and* every dependency's
     /// lifecycle scripts, regardless of `allowBuilds`.
@@ -486,6 +495,7 @@ impl InstallOptions {
             ignore_pnpmfile: false,
             pnpmfile: None,
             global_pnpmfile: None,
+            pre_resolution_hook_already_ran: false,
             ignore_scripts: false,
             dry_run: false,
             lockfile_only: false,

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -792,7 +792,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // — which `try_install_fast_path` calls a few lines down — already
     // does `load_both` AND reads the pnpmfile's bytes to fold them into
     // the settings hash. This reads the same warm files a second time.
-    let early_pnpmfile_paths = if opts.ignore_pnpmfile {
+    let early_pnpmfile_paths = if opts.ignore_pnpmfile || opts.pre_resolution_hook_already_ran {
         Vec::new()
     } else {
         let (ws, _) = aube_manifest::workspace::load_both(&cwd).unwrap_or_default();
@@ -1200,7 +1200,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         } else {
             None
         };
-        let pnpmfile_paths = if opts.ignore_pnpmfile {
+        let pnpmfile_paths = if opts.ignore_pnpmfile || opts.pre_resolution_hook_already_ran {
             Vec::new()
         } else {
             crate::pnpmfile::ordered_paths(

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -782,7 +782,39 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     if !opts.dry_run {
         apply_force_state_reset(&cwd, &opts)?;
     }
+    // The pnpmfiles this install will run, resolved once here because
+    // the `preResolution` gate below needs them before the settings
+    // context exists. Re-derived (not threaded) at the hook call site,
+    // which has the shared workspace config; both use the same
+    // `ordered_paths(global, local)` contract.
+    //
+    // The workspace load is not new I/O on the fast path: `hash_settings`
+    // — which `try_install_fast_path` calls a few lines down — already
+    // does `load_both` AND reads the pnpmfile's bytes to fold them into
+    // the settings hash. This reads the same warm files a second time.
+    let early_pnpmfile_paths = if opts.ignore_pnpmfile {
+        Vec::new()
+    } else {
+        let (ws, _) = aube_manifest::workspace::load_both(&cwd).unwrap_or_default();
+        crate::pnpmfile::ordered_paths(
+            crate::pnpmfile::detect_global(&cwd, opts.global_pnpmfile.as_deref()).as_deref(),
+            crate::pnpmfile::detect(&cwd, opts.pnpmfile.as_deref(), ws.pnpmfile_path.as_deref())
+                .as_deref(),
+        )
+    };
+    // pnpm calls `preResolution` on every install, before it decides
+    // whether the lockfile is up to date — the hook is how a pnpmfile
+    // observes (and logs) the lockfile it is about to resolve against.
+    // The warm fast path reads neither the manifest nor the lockfile,
+    // so it cannot hand the hook a truthful context; the only honest
+    // way to keep the contract is to decline the fast path when a hook
+    // is declared. Bounded to projects that opted into one — a pnpmfile
+    // without `preResolution`, and every project without a pnpmfile at
+    // all, keeps the fast path untouched.
+    let pre_resolution_hook_declared =
+        crate::pnpmfile::any_declares_hook(&early_pnpmfile_paths, "preResolution").await;
     if !opts.dry_run
+        && !pre_resolution_hook_declared
         && let Some(total) =
             try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))?
     {
@@ -1137,6 +1169,63 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     } else {
         lockfile_pre_parse.as_ref().map(|(g, _)| g)
     };
+
+    // `preResolution` runs here — once, on every install, before any
+    // branch on frozen mode or lockfile freshness, which is where pnpm
+    // calls it (`mutateModules` fires the hook before `tryFrozenInstall`).
+    // Every downstream path is covered from this one site: the
+    // `--lockfile-only` / `--dry-run` short-circuit below, the
+    // lockfile-reuse arm, and the cold resolve.
+    //
+    // The hook is handed the lockfile as it is ON DISK. `lockfile_pre_parse`
+    // is deliberately `None` under `--frozen-lockfile` and
+    // `--no-frozen-lockfile` — neither mode reuses locked picks — but
+    // `wantedLockfile` is the file, not the subset the resolver is willing
+    // to reuse, so parse for the hook when one is declared and nothing has
+    // been parsed yet. Under `lockfile=false` there is deliberately no
+    // lockfile to show, and pnpm passes an empty one there too.
+    {
+        let hook_lockfile = if pre_resolution_hook_declared
+            && lockfile_enabled
+            && lockfile_pre_parse.is_none()
+        {
+            parse_lockfile_dir_remapped_with_kind_and_options(
+                &lockfile_dir,
+                &lockfile_importer_key,
+                &manifest,
+                lockfile_parse_options,
+            )
+            .ok()
+            .map(|(g, _)| g)
+        } else {
+            None
+        };
+        let pnpmfile_paths = if opts.ignore_pnpmfile {
+            Vec::new()
+        } else {
+            crate::pnpmfile::ordered_paths(
+                crate::pnpmfile::detect_global(&cwd, opts.global_pnpmfile.as_deref()).as_deref(),
+                crate::pnpmfile::detect(
+                    &cwd,
+                    opts.pnpmfile.as_deref(),
+                    ws_config_shared.pnpmfile_path.as_deref(),
+                )
+                .as_deref(),
+            )
+        };
+        let importer_ids: Vec<String> = manifests.iter().map(|(path, _)| path.clone()).collect();
+        super::run_pnpmfile_pre_resolution(
+            &pnpmfile_paths,
+            &cwd,
+            lockfile_pre_parse
+                .as_ref()
+                .map(|(g, _)| g)
+                .or(hook_lockfile.as_ref()),
+            &manifest,
+            &importer_ids,
+        )
+        .await?;
+    }
 
     // The project's effective packageExtensions checksum, for the lockfile
     // drift check. Computed only under an enforcing embedder (nub); standalone
@@ -1800,8 +1889,9 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                     .as_deref(),
                 )
             };
-            super::run_pnpmfile_pre_resolution(&pnpmfile_paths, &cwd, existing_for_resolver)
-                .await?;
+            // `preResolution` already ran, up where every install path
+            // passes through it. Only the `readPackage` host is started
+            // here, because it belongs to the resolve that follows.
             control::check_cancelled()?;
             let (read_package_host, read_package_forwarders) =
                 match crate::pnpmfile::ReadPackageHostChain::spawn(&pnpmfile_paths, &cwd)

--- a/vendor/aube/crates/aube/src/commands/install/resolve.rs
+++ b/vendor/aube/crates/aube/src/commands/install/resolve.rs
@@ -256,8 +256,10 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
             crate::pnpmfile::detect(cwd, pnpmfile, ws_config.pnpmfile_path.as_deref()).as_deref(),
         )
     };
-    crate::commands::run_pnpmfile_pre_resolution(&pnpmfile_paths, cwd, existing_for_resolver)
-        .await?;
+    // `preResolution` already ran in `install::run_inner`, ahead of the
+    // `--lockfile-only` short-circuit that reaches this function — and
+    // ahead of the up-to-date early return above it, which used to skip
+    // the hook entirely.
     super::control::check_cancelled()?;
     let (read_package_host, read_package_forwarders) =
         match crate::pnpmfile::ReadPackageHostChain::spawn(&pnpmfile_paths, cwd)

--- a/vendor/aube/crates/aube/src/commands/settings_context.rs
+++ b/vendor/aube/crates/aube/src/commands/settings_context.rs
@@ -406,13 +406,21 @@ pub(crate) async fn run_pnpmfile_pre_resolution(
     // hook sees then are the ones pnpm stamps into its synthesized
     // empty lockfile. When a lockfile exists its own `settings:` header
     // is authoritative and this is never consulted.
-    let settings = if existing.is_some() {
-        aube_lockfile::LockfileSettings::default()
+    let (settings, peers_suffix_max_length) = if existing.is_some() {
+        // Unread on this arm: with a lockfile to project, the synthesized
+        // object these two feed is never built.
+        (aube_lockfile::LockfileSettings::default(), 0)
     } else {
-        with_settings_ctx(cwd, |ctx| aube_lockfile::LockfileSettings {
-            auto_install_peers: aube_settings::resolved::auto_install_peers(ctx),
-            exclude_links_from_lockfile: aube_settings::resolved::exclude_links_from_lockfile(ctx),
-            ..Default::default()
+        with_settings_ctx(cwd, |ctx| {
+            (
+                aube_lockfile::LockfileSettings {
+                    auto_install_peers: aube_settings::resolved::auto_install_peers(ctx),
+                    exclude_links_from_lockfile:
+                        aube_settings::resolved::exclude_links_from_lockfile(ctx),
+                    ..Default::default()
+                },
+                aube_settings::resolved::peers_suffix_max_length(ctx),
+            )
         })
     };
     let ctx =
@@ -423,6 +431,7 @@ pub(crate) async fn run_pnpmfile_pre_resolution(
             manifest,
             importer_ids,
             settings,
+            peers_suffix_max_length,
             registries,
         });
     crate::pnpmfile::run_pre_resolution_chain(paths, cwd, &ctx)

--- a/vendor/aube/crates/aube/src/commands/settings_context.rs
+++ b/vendor/aube/crates/aube/src/commands/settings_context.rs
@@ -379,6 +379,8 @@ pub(crate) async fn run_pnpmfile_pre_resolution(
     paths: &[std::path::PathBuf],
     cwd: &std::path::Path,
     existing: Option<&aube_lockfile::LockfileGraph>,
+    manifest: &aube_manifest::PackageJson,
+    importer_ids: &[String],
 ) -> miette::Result<()> {
     if paths.is_empty() {
         return Ok(());
@@ -400,12 +402,29 @@ pub(crate) async fn run_pnpmfile_pre_resolution(
         aube_store::dirs::store_dir()
             .and_then(|p| p.parent()?.parent().map(std::path::Path::to_path_buf))
     });
-    let ctx = crate::pnpmfile::PreResolutionContext::from_existing(
-        cwd,
-        store_dir.as_deref(),
-        existing,
-        registries,
-    );
+    // Only read when there is no lockfile to project — the settings a
+    // hook sees then are the ones pnpm stamps into its synthesized
+    // empty lockfile. When a lockfile exists its own `settings:` header
+    // is authoritative and this is never consulted.
+    let settings = if existing.is_some() {
+        aube_lockfile::LockfileSettings::default()
+    } else {
+        with_settings_ctx(cwd, |ctx| aube_lockfile::LockfileSettings {
+            auto_install_peers: aube_settings::resolved::auto_install_peers(ctx),
+            exclude_links_from_lockfile: aube_settings::resolved::exclude_links_from_lockfile(ctx),
+            ..Default::default()
+        })
+    };
+    let ctx =
+        crate::pnpmfile::PreResolutionContext::from_existing(crate::pnpmfile::PreResolutionInputs {
+            lockfile_dir: cwd,
+            store_dir: store_dir.as_deref(),
+            existing,
+            manifest,
+            importer_ids,
+            settings,
+            registries,
+        });
     crate::pnpmfile::run_pre_resolution_chain(paths, cwd, &ctx)
         .await
         .wrap_err("pnpmfile preResolution hook failed")

--- a/vendor/aube/crates/aube/src/commands/update.rs
+++ b/vendor/aube/crates/aube/src/commands/update.rs
@@ -1112,6 +1112,11 @@ pub async fn run(
     chained.ignore_pnpmfile = args.ignore_pnpmfile;
     chained.pnpmfile = args.pnpmfile.clone();
     chained.global_pnpmfile = args.global_pnpmfile.clone();
+    // `preResolution` already ran above, before this command's own
+    // resolve. pnpm fires it once per install operation, so letting the
+    // chained install fire it again would run the user's hook twice for
+    // one `aube update`.
+    chained.pre_resolution_hook_already_ran = true;
     // `aube update` is one of the canonical fresh-resolution
     // entry points — by design it pulls newer versions than the
     // lockfile pins. Route the post-resolve transitive set

--- a/vendor/aube/crates/aube/src/commands/update.rs
+++ b/vendor/aube/crates/aube/src/commands/update.rs
@@ -818,7 +818,12 @@ pub async fn run(
                 .as_deref(),
         )
     };
-    super::run_pnpmfile_pre_resolution(&pnpmfile_paths, &cwd, existing.as_ref()).await?;
+    // No importer list to hand over here — `update` resolves against
+    // the root manifest and the workspace members are only enumerated
+    // below. The ids are consulted only when there is no lockfile at
+    // all, where the empty slice means "the root importer".
+    super::run_pnpmfile_pre_resolution(&pnpmfile_paths, &cwd, existing.as_ref(), &manifest, &[])
+        .await?;
     let (read_package_host, read_package_forwarders) =
         match crate::pnpmfile::ReadPackageHostChain::spawn(&pnpmfile_paths, &cwd)
             .await

--- a/vendor/aube/crates/aube/src/pnpmfile.rs
+++ b/vendor/aube/crates/aube/src/pnpmfile.rs
@@ -653,6 +653,11 @@ pub struct PreResolutionInputs<'a> {
     /// Resolved lockfile settings, stamped into that empty lockfile the
     /// way pnpm's `createLockfileObject` does.
     pub settings: aube_lockfile::LockfileSettings,
+    /// Effective `peersSuffixMaxLength`. Part of the synthesized settings
+    /// but not of [`aube_lockfile::LockfileSettings`], because pnpm omits
+    /// it from the file at its 1000 default and so it is not a
+    /// round-tripped lockfile field.
+    pub peers_suffix_max_length: u64,
     pub registries: BTreeMap<String, String>,
 }
 
@@ -676,9 +681,16 @@ impl<'a> PreResolutionContext<'a> {
             manifest,
             importer_ids,
             settings,
+            peers_suffix_max_length,
             registries,
         } = inputs;
-        let empty = || aube_lockfile::pnpm::hook_view::empty_lockfile_object(importer_ids, &settings);
+        let empty = || {
+            aube_lockfile::pnpm::hook_view::empty_lockfile_object(
+                importer_ids,
+                &settings,
+                peers_suffix_max_length,
+            )
+        };
         let lockfile = match existing {
             Some(graph) => {
                 match aube_lockfile::pnpm::hook_view::lockfile_object(
@@ -698,7 +710,16 @@ impl<'a> PreResolutionContext<'a> {
             None => empty(),
         };
         let exists_current_lockfile = existing.is_some();
-        let exists_non_empty_wanted_lockfile = existing.is_some_and(|g| !g.packages.is_empty());
+        // pnpm's `existsWantedLockfile && !isEmptyLockfile(wanted)`, and
+        // `isEmptyLockfile` reads IMPORTERS, not packages — "every importer has
+        // an empty `specifiers` and an empty `dependencies`"
+        // (`lockfile/fs/src/write.ts`). A workspace whose only edges are
+        // `workspace:*` links writes no `packages:` rows at all and is still
+        // not empty, so deriving this from the package map flips the answer on
+        // exactly that shape. Reading it off the projected object also leaves
+        // one definition of empty rather than two that can drift.
+        let exists_non_empty_wanted_lockfile =
+            existing.is_some() && !aube_lockfile::pnpm::hook_view::is_empty(&lockfile);
         Self {
             lockfile_dir,
             store_dir,

--- a/vendor/aube/crates/aube/src/pnpmfile.rs
+++ b/vendor/aube/crates/aube/src/pnpmfile.rs
@@ -89,6 +89,14 @@ fn ndjson_reporter() -> bool {
 /// stack traces, hook-body diagnostics) never collides.
 const HOOK_LOG_SENTINEL: &str = "__AUBE_HOOK_LOG__ ";
 
+/// Sentinel our shims prepend to a chunk the hook wrote to its own
+/// stdout — a bare `console.log` in a pnpmfile body. Every shim owns
+/// the child's stdout as a machine-readable result channel, so a user
+/// write there would corrupt the protocol; [`STDOUT_CAPTURE_JS`]
+/// re-routes it through stderr under this tag and the parent replays
+/// it verbatim on its own stdout, which is where pnpm puts it.
+const HOOK_STDOUT_SENTINEL: &str = "__AUBE_HOOK_STDOUT__ ";
+
 /// Return the path to the project's pnpmfile if one exists.
 ///
 /// Override precedence is `cli > workspace_yaml > default`:
@@ -299,6 +307,33 @@ fn apply(wire: LockfileWire, graph: &mut LockfileGraph) {
     }
 }
 
+/// Preamble every shim runs before it loads the pnpmfile. Swaps
+/// `process.stdout.write` for one that tags the chunk and sends it down
+/// stderr, and stashes the real writer on `globalThis.__aubeRawStdout`
+/// for the shim's own protocol frames.
+///
+/// pnpm runs hooks inside its own process, so `console.log` in a
+/// pnpmfile reaches the user's terminal. Our shims run the hook in a
+/// child whose stdout carries the result (the round-tripped lockfile,
+/// the `readPackage` NDJSON responses, the hooks-gate bit), so before
+/// this the user's line was either swallowed or — worse, on the
+/// long-lived `readPackage` host — spliced into the response stream as
+/// an unparseable frame.
+///
+/// Installed ahead of `loadPnpmfile` so a `console.log` at module scope
+/// is captured too.
+const STDOUT_CAPTURE_JS: &str = r#"
+const __AUBE_STDOUT_SENTINEL = '__AUBE_HOOK_STDOUT__ ';
+globalThis.__aubeRawStdout = process.stdout.write.bind(process.stdout);
+process.stdout.write = function (chunk, encoding, callback) {
+  if (typeof encoding === 'function') { callback = encoding; encoding = undefined; }
+  const text = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+  const ok = process.stderr.write(__AUBE_STDOUT_SENTINEL + JSON.stringify(text) + '\n');
+  if (typeof callback === 'function') callback();
+  return ok;
+};
+"#;
+
 const LOAD_PNPMFILE_JS: &str = r#"
 const path = require('path');
 const { pathToFileURL } = require('url');
@@ -329,16 +364,24 @@ process.stdin.on('end', async () => {
     const fn = hooks[hookName];
     let result = input;
     if (typeof fn === 'function') {
-      const ctx = {
-        log: (...args) => {
-          const message = args.map((a) => typeof a === 'string' ? a : require('util').inspect(a)).join(' ');
-          process.stderr.write(SENTINEL + JSON.stringify({hook: hookName, message}) + '\n');
-        },
+      const emit = (...args) => {
+        const message = args.map((a) => typeof a === 'string' ? a : require('util').inspect(a)).join(' ');
+        process.stderr.write(SENTINEL + JSON.stringify({hook: hookName, message}) + '\n');
       };
+      // pnpm gives each hook a different second argument: `readPackage`
+      // and `afterAllResolved` get `{log}`, `preResolution` gets a
+      // `{info, warn}` logger and no `log` at all (`requireHooks.ts`
+      // `createReadPackageHookContext` vs `createPreResolutionHookLogger`).
+      // `log` stays on the preResolution object as well, because it has
+      // been aube's spelling since the hook landed and dropping it would
+      // break pnpmfiles written against aube for nothing.
+      const ctx = hookName === 'preResolution'
+        ? { info: emit, warn: emit, log: emit }
+        : { log: emit };
       const out = await fn(input, ctx);
       if (out && typeof out === 'object') result = out;
     }
-    process.stdout.write(JSON.stringify(result));
+    globalThis.__aubeRawStdout(JSON.stringify(result));
   } catch (err) {
     console.error('[pnpmfile] hook failed:', (err && err.stack) || err);
     process.exit(1);
@@ -351,7 +394,7 @@ process.stdin.on('end', async () => {
 /// one-shot hook only needs a `run_one_shot_hook(.., name, ..)` call —
 /// don't add a parallel shim.
 fn one_shot_hook_shim() -> String {
-    format!("{LOAD_PNPMFILE_JS}{SHIM}")
+    format!("{STDOUT_CAPTURE_JS}{LOAD_PNPMFILE_JS}{SHIM}")
 }
 
 /// Drain the child's stderr line-by-line. Lines tagged with
@@ -372,7 +415,9 @@ fn spawn_stderr_forwarder(
         let mut stdout = tokio::io::stdout();
         let mut stderr_w = tokio::io::stderr();
         while let Ok(Some(line)) = lines.next_line().await {
-            if let Some(rest) = line.strip_prefix(HOOK_LOG_SENTINEL) {
+            if let Some(rest) = line.strip_prefix(HOOK_STDOUT_SENTINEL) {
+                forward_hook_stdout(rest, &mut stdout, &mut stderr_w).await;
+            } else if let Some(rest) = line.strip_prefix(HOOK_LOG_SENTINEL) {
                 forward_hook_log(rest, &prefix, &from, &mut stdout, &mut stderr_w).await;
             } else {
                 let _ = stderr_w.write_all(line.as_bytes()).await;
@@ -386,6 +431,28 @@ fn spawn_stderr_forwarder(
 struct HookLogRecord {
     hook: String,
     message: String,
+}
+
+/// Replay one chunk the hook wrote to its own stdout. The payload is a
+/// JSON string holding the chunk verbatim, newlines included, so it is
+/// written through unchanged — this is a passthrough of the user's own
+/// output, not a log record we get to reformat. A payload we cannot
+/// decode falls back to stderr rather than being dropped.
+async fn forward_hook_stdout(
+    payload: &str,
+    stdout: &mut tokio::io::Stdout,
+    stderr_w: &mut tokio::io::Stderr,
+) {
+    match serde_json::from_str::<String>(payload) {
+        Ok(text) => {
+            let _ = stdout.write_all(text.as_bytes()).await;
+            let _ = stdout.flush().await;
+        }
+        Err(_) => {
+            let _ = stderr_w.write_all(payload.as_bytes()).await;
+            let _ = stderr_w.write_all(b"\n").await;
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -550,40 +617,93 @@ pub async fn run_after_all_resolved_chain(
 /// Snapshot passed to the `preResolution` hook before resolve starts.
 /// Mirrors pnpm's context shape (camelCase on the wire) so existing
 /// pnpmfiles can read the fields they expect.
+///
+/// The two lockfiles are pnpm's **in-memory** `LockfileObject`
+/// ([`aube_lockfile::pnpm::hook_view`]), never `null`: pnpm hands the
+/// hook an empty object when there is no lockfile on disk, and hooks
+/// written against it dereference `wantedLockfile.packages[key]
+/// .resolution` without a guard.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PreResolutionContext<'a> {
     pub lockfile_dir: &'a Path,
     pub store_dir: Option<&'a Path>,
-    pub current_lockfile: Option<LockfileWire>,
-    pub wanted_lockfile: Option<LockfileWire>,
+    pub current_lockfile: serde_json::Value,
+    pub wanted_lockfile: serde_json::Value,
     pub exists_current_lockfile: bool,
     pub exists_non_empty_wanted_lockfile: bool,
     pub registries: BTreeMap<String, String>,
 }
 
+/// Everything [`PreResolutionContext::from_existing`] needs that isn't
+/// already a field of the context. Grouped rather than passed
+/// positionally: seven arguments of which three are paths and two are
+/// borrowed slices is a signature that invites a silent swap.
+pub struct PreResolutionInputs<'a> {
+    pub lockfile_dir: &'a Path,
+    pub store_dir: Option<&'a Path>,
+    /// The on-disk lockfile graph, or `None` when there is none.
+    pub existing: Option<&'a LockfileGraph>,
+    /// Root manifest — the projection needs it for the same reason the
+    /// lockfile writer does (patched dependencies, alias recovery).
+    pub manifest: &'a aube_manifest::PackageJson,
+    /// Importer ids to seed the empty lockfile with when `existing` is
+    /// `None`. `["."]` for a single project.
+    pub importer_ids: &'a [String],
+    /// Resolved lockfile settings, stamped into that empty lockfile the
+    /// way pnpm's `createLockfileObject` does.
+    pub settings: aube_lockfile::LockfileSettings,
+    pub registries: BTreeMap<String, String>,
+}
+
 impl<'a> PreResolutionContext<'a> {
-    /// Build the snapshot for `lockfile_dir`. `existing` is the on-disk
-    /// lockfile graph (or `None` when there isn't one); both
-    /// `currentLockfile` and `wantedLockfile` are derived from it
-    /// because at preResolution time they're identical — pnpm only
-    /// diverges them after resolve has produced the wanted graph.
-    pub fn from_existing(
-        lockfile_dir: &'a Path,
-        store_dir: Option<&'a Path>,
-        existing: Option<&LockfileGraph>,
-        registries: BTreeMap<String, String>,
-    ) -> Self {
-        let wire = existing.map(to_wire);
+    /// Build the snapshot for `inputs.lockfile_dir`. Both
+    /// `currentLockfile` and `wantedLockfile` are derived from the
+    /// on-disk lockfile because at preResolution time they're identical
+    /// — pnpm only diverges them after resolve has produced the wanted
+    /// graph, and aube keeps no separate installed-state lockfile of
+    /// its own for the `current` side to come from.
+    ///
+    /// A projection failure is not fatal: the hook is an observation
+    /// point, and refusing the whole install because one lockfile entry
+    /// would not render is a worse outcome than handing the hook the
+    /// empty object. The error is logged.
+    pub fn from_existing(inputs: PreResolutionInputs<'a>) -> Self {
+        let PreResolutionInputs {
+            lockfile_dir,
+            store_dir,
+            existing,
+            manifest,
+            importer_ids,
+            settings,
+            registries,
+        } = inputs;
+        let empty = || aube_lockfile::pnpm::hook_view::empty_lockfile_object(importer_ids, &settings);
+        let lockfile = match existing {
+            Some(graph) => {
+                match aube_lockfile::pnpm::hook_view::lockfile_object(
+                    lockfile_dir,
+                    graph,
+                    manifest,
+                ) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        tracing::warn!(
+                            "[pnpmfile] could not project the lockfile for preResolution: {e}"
+                        );
+                        empty()
+                    }
+                }
+            }
+            None => empty(),
+        };
         let exists_current_lockfile = existing.is_some();
-        let exists_non_empty_wanted_lockfile = wire
-            .as_ref()
-            .is_some_and(|w| !w.importers.is_empty() || !w.packages.is_empty());
+        let exists_non_empty_wanted_lockfile = existing.is_some_and(|g| !g.packages.is_empty());
         Self {
             lockfile_dir,
             store_dir,
-            current_lockfile: wire.clone(),
-            wanted_lockfile: wire,
+            current_lockfile: lockfile.clone(),
+            wanted_lockfile: lockfile,
             exists_current_lockfile,
             exists_non_empty_wanted_lockfile,
             registries,
@@ -592,11 +712,20 @@ impl<'a> PreResolutionContext<'a> {
 }
 
 /// Run the `preResolution` hook before the resolver walks the graph.
-/// Fire-and-forget — the hook's return value is discarded by pnpm and
-/// by aube. Skips spawning `node` when the pnpmfile doesn't reference
-/// `preResolution` so a hook-less pnpmfile doesn't pay the per-install
-/// node-startup cost on every command. `prefix` is the project root
-/// used to enrich `ctx.log` records under `--reporter=ndjson`.
+/// The hook's declared return type is `Promise<void>`, so nothing comes
+/// back by design. Skips spawning `node` when the pnpmfile doesn't
+/// reference `preResolution` so a hook-less pnpmfile doesn't pay the
+/// per-install node-startup cost on every command. `prefix` is the
+/// project root used to enrich `ctx.log` records under
+/// `--reporter=ndjson`.
+///
+/// The one place the contract genuinely differs: pnpm runs the hook
+/// in-process against the live lockfile object, so a hook that *mutates*
+/// `ctx.wantedLockfile` in place changes what pnpm resolves. Aube runs it
+/// in a child, so that edit cannot cross back. Rather than let it no-op
+/// in silence — the worst kind of divergence, because the pnpmfile looks
+/// like it worked — the returned snapshot is compared against what was
+/// sent and any edit is reported.
 pub async fn run_pre_resolution(
     pnpmfile: &Path,
     prefix: &Path,
@@ -608,8 +737,34 @@ pub async fn run_pre_resolution(
     let input_json = serde_json::to_vec(ctx)
         .into_diagnostic()
         .wrap_err("failed to serialize preResolution context")?;
-    run_one_shot_hook(pnpmfile, prefix, "preResolution", &input_json).await?;
+    let stdout = run_one_shot_hook(pnpmfile, prefix, "preResolution", &input_json).await?;
+    warn_on_pre_resolution_mutation(pnpmfile, ctx, &stdout);
     Ok(())
+}
+
+/// Compare the context the hook handed back against the one it was
+/// given. A malformed or missing reply is not a mutation and is
+/// ignored — the hook already ran, and its exit status was checked.
+fn warn_on_pre_resolution_mutation(
+    pnpmfile: &Path,
+    sent: &PreResolutionContext<'_>,
+    stdout: &[u8],
+) {
+    let Ok(returned) = serde_json::from_slice::<serde_json::Value>(stdout) else {
+        return;
+    };
+    let Some(returned) = returned.get("wantedLockfile") else {
+        return;
+    };
+    if *returned != sent.wanted_lockfile {
+        tracing::warn!(
+            code = aube_codes::warnings::WARN_AUBE_HOOK_PRE_RESOLUTION_MUTATED,
+            "[pnpmfile] preResolution in {} edited the lockfile it was given; \
+             aube runs the hook out of process, so the edit is discarded. \
+             Use readPackage or afterAllResolved to change resolution.",
+            pnpmfile.display(),
+        );
+    }
 }
 
 /// Run `preResolution` for each pnpmfile in `paths` (global first,
@@ -679,10 +834,10 @@ async function main() {
         }
         result = out;
       }
-      process.stdout.write(JSON.stringify({ id, pkg: result }) + '\n');
+      globalThis.__aubeRawStdout(JSON.stringify({ id, pkg: result }) + '\n');
     } catch (err) {
       const msg = (err && err.stack) || String(err);
-      process.stdout.write(JSON.stringify({ id, error: String(msg) }) + '\n');
+      globalThis.__aubeRawStdout(JSON.stringify({ id, error: String(msg) }) + '\n');
     }
   }
 }
@@ -693,7 +848,7 @@ main().catch((err) => {
 "#;
 
 fn read_package_shim() -> String {
-    format!("{LOAD_PNPMFILE_JS}{READ_PACKAGE_SHIM}")
+    format!("{STDOUT_CAPTURE_JS}{LOAD_PNPMFILE_JS}{READ_PACKAGE_SHIM}")
 }
 
 /// Long-lived node child that answers `readPackage` calls one at a
@@ -960,13 +1115,30 @@ async fn has_hook(pnpmfile: &Path, name: &str) -> Result<bool> {
     Ok(contents.contains(name))
 }
 
+/// Whether any pnpmfile in `paths` mentions `name`. Same cheap
+/// text scan [`has_hook`] uses to decide whether spawning `node` is
+/// worth it — over-reporting (the name appears in a comment) costs one
+/// wasted child, under-reporting would silently skip a real hook.
+///
+/// An unreadable pnpmfile answers `false` here rather than erroring:
+/// this gate only decides whether to take a fast path, and the real
+/// hook run downstream is where a broken pnpmfile should surface.
+pub async fn any_declares_hook(paths: &[PathBuf], name: &str) -> bool {
+    for path in paths {
+        if has_hook(path, name).await.unwrap_or(false) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Node shim that loads the pnpmfile the way pnpm does and prints `1`
 /// when it exports a `hooks` object, `0` otherwise. Reuses the shared
 /// [`LOAD_PNPMFILE_JS`] loader so default-vs-named export resolution
 /// matches the hook-execution path exactly.
 const HOOKS_GATE_SHIM: &str = r#"
 loadPnpmfile(process.env.AUBE_PNPMFILE)
-  .then((mod) => { process.stdout.write(mod != null && mod.hooks != null ? '1' : '0'); })
+  .then((mod) => { globalThis.__aubeRawStdout(mod != null && mod.hooks != null ? '1' : '0'); })
   .catch((err) => {
     console.error('[pnpmfile] failed to load for checksum gate:', (err && err.stack) || err);
     process.exit(1);
@@ -988,7 +1160,7 @@ loadPnpmfile(process.env.AUBE_PNPMFILE)
 /// `module.exports = { hooks }`, `export default { hooks }`, and
 /// `export const hooks = …` all count, mirroring pnpm's resolution.
 pub async fn exports_hooks(pnpmfile: &Path) -> Result<bool> {
-    let shim = format!("{LOAD_PNPMFILE_JS}{HOOKS_GATE_SHIM}");
+    let shim = format!("{STDOUT_CAPTURE_JS}{LOAD_PNPMFILE_JS}{HOOKS_GATE_SHIM}");
     let output = tokio::process::Command::new(crate::runtime::internal_node_program())
         .arg("-e")
         .arg(shim)

--- a/vendor/aube/crates/aube/src/pnpmfile.rs
+++ b/vendor/aube/crates/aube/src/pnpmfile.rs
@@ -117,11 +117,19 @@ pub fn detect(
     cli_pnpmfile: Option<&Path>,
     workspace_pnpmfile_path: Option<&str>,
 ) -> Option<PathBuf> {
+    // Every path this returns is handed to a `node -e` shim that
+    // `require()`s it, and Node cannot dereference a Windows verbatim
+    // path: `path.resolve(r"\\?\C:\…")` mangles the prefix and the
+    // require dies with `EISDIR … lstat 'C:'`. `cwd` here is whatever
+    // the command resolved as its project root, which on some paths is
+    // already canonicalized (and so verbatim), so strip on the way out
+    // rather than trusting every producer.
+    let plain = aube_util::path::strip_verbatim_prefix;
     if let Some(rel) = cli_pnpmfile {
         let p = if rel.is_absolute() {
-            rel.to_path_buf()
+            plain(rel)
         } else {
-            cwd.join(rel)
+            plain(&cwd.join(rel))
         };
         if !p.is_file() {
             tracing::warn!(
@@ -134,7 +142,7 @@ pub fn detect(
         return Some(p);
     }
     if let Some(rel) = workspace_pnpmfile_path {
-        let p = cwd.join(rel);
+        let p = plain(&cwd.join(rel));
         if !p.is_file() {
             tracing::warn!(
                 code = aube_codes::warnings::WARN_AUBE_PNPMFILE_NOT_FOUND,
@@ -152,7 +160,7 @@ pub fn detect(
     if !pnpmfile_default_enabled() {
         return None;
     }
-    default_path(cwd)
+    default_path(cwd).map(|p| plain(&p))
 }
 
 /// Resolve `--global-pnpmfile <path>`. Unlike [`detect`], there is no
@@ -162,10 +170,11 @@ pub fn detect(
 /// is a hard miss with a warning, matching the local-pnpmfile shape.
 pub fn detect_global(cwd: &Path, cli_global: Option<&Path>) -> Option<PathBuf> {
     let rel = cli_global?;
+    // Non-verbatim for the same reason as [`detect`].
     let p = if rel.is_absolute() {
-        rel.to_path_buf()
+        aube_util::path::strip_verbatim_prefix(rel)
     } else {
-        cwd.join(rel)
+        aube_util::path::strip_verbatim_prefix(&cwd.join(rel))
     };
     if !p.is_file() {
         tracing::warn!(
@@ -1379,6 +1388,41 @@ mod tests {
     fn detect_global_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
         assert!(detect_global(dir.path(), Some(Path::new("nope.cjs"))).is_none());
+    }
+
+    /// Node cannot dereference a Windows verbatim path — the shim's
+    /// `path.resolve()` mangles the `\\?\` prefix and the `require`
+    /// dies with `EISDIR … lstat 'C:'`. A caller whose project root was
+    /// canonicalized hands one of these in, so both detectors have to
+    /// return the plain form whatever they were given.
+    #[cfg(windows)]
+    #[test]
+    fn detected_paths_are_never_windows_verbatim() {
+        // The default-file arm below reads the process-global gate that
+        // sibling tests flip, so take the same lock they do.
+        let _lock = default_gate_lock();
+        let _gate = DefaultGateGuard::set(true);
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(PNPMFILE_CJS_NAME), "").unwrap();
+        std::fs::write(dir.path().join("hooks.cjs"), "").unwrap();
+        // Strip before prepending: whether the temp dir arrives plain or
+        // already verbatim, this names the same directory rather than the
+        // unopenable `\\?\\\?\C:\…` a blind prefix would build.
+        let plain_dir = aube_util::path::strip_verbatim_prefix(dir.path());
+        let verbatim = PathBuf::from(format!(r"\\?\{}", plain_dir.display()));
+
+        for found in [
+            detect(&verbatim, None, None),
+            detect(&verbatim, Some(Path::new("hooks.cjs")), None),
+            detect_global(&verbatim, Some(Path::new("hooks.cjs"))),
+        ] {
+            let found = found.expect("the file exists under both spellings");
+            assert!(
+                !found.to_string_lossy().starts_with(r"\\?\"),
+                "a verbatim path reaches Node's require and fails there: {}",
+                found.display()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Four divergences from pnpm's `preResolution` contract, measured against pnpm 10.15.1 and 11.

- The hook only ran when the install re-resolved. pnpm fires it on every install, before any lockfile-freshness decision.
- `wantedLockfile` / `currentLockfile` were `null`. pnpm always passes an object, empty when there is no lockfile.
- The shape was the narrow `afterAllResolved` projection: no `resolution`, internal dep-path keys. It is now pnpm's in-memory `LockfileObject`, built by reusing the lockfile writer's projection.
- A `console.log` in a hook body was swallowed by the shim's result channel.

The second argument is now pnpm's `{info, warn}` logger, and an in-place lockfile edit warns rather than no-opping.

Closes #755