### PR TITLE
ci: accept the dependency-axis flags pnpm's ci inherits

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1414,6 +1414,14 @@ pub enum Command {
     /// Clean install for CI: delete node_modules, install strictly from the
     /// lockfile (drift or a missing lockfile is a hard error).
     Ci {
+        /// Skip devDependencies; install only production deps.
+        #[arg(short = 'P', long, visible_alias = "production")]
+        prod: bool,
+
+        /// Install only devDependencies.
+        #[arg(short = 'D', long, conflicts_with = "prod")]
+        dev: bool,
+
         /// Skip all lifecycle scripts (root and dependency).
         #[arg(long)]
         ignore_scripts: bool,
@@ -3264,6 +3272,8 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             })
         }
         Some(Command::Ci {
+            prod,
+            dev,
             ignore_scripts,
             no_optional,
             registry,
@@ -3280,6 +3290,8 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             age_gate.apply();
             platform.apply();
             crate::pm_engine::run_ci(crate::pm_engine::CiFlags {
+                prod,
+                dev,
                 ignore_scripts,
                 no_optional,
                 registry,

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1185,11 +1185,14 @@ pub struct InstallFlags {
     pub output: super::output::OutputFlags,
 }
 
-/// `nub ci` flags. `ci` is frozen + clean by definition, so only the script /
-/// optional-dep / registry knobs are configurable (mirrors `aube ci`'s
-/// `CiArgs`, whose flattened NetworkArgs carries `--registry` upstream).
+/// `nub ci` flags. `ci` is frozen + clean by definition, so the lockfile-mode
+/// knobs are fixed; the dep-axis / script / optional-dep / registry knobs stay
+/// configurable (mirrors `aube ci`'s `CiArgs`, whose flattened NetworkArgs
+/// carries `--registry` upstream).
 #[derive(Debug, Default)]
 pub struct CiFlags {
+    pub prod: bool,
+    pub dev: bool,
     pub ignore_scripts: bool,
     pub no_optional: bool,
     pub registry: Option<String>,
@@ -1534,8 +1537,8 @@ pub fn run_ci(flags: CiFlags) -> Result<i32> {
         // The explicit CLI flag always wins (OR'd in, never overridden) — same
         // contract as `run_install`.
         dep_selection: DepSelection::from_flags(
-            dep.prod,
-            dep.dev,
+            dep.prod || flags.prod,
+            dep.dev || flags.dev,
             dep.no_optional || flags.no_optional,
         ),
         ignore_scripts: flags.ignore_scripts,

--- a/crates/nub-cli/tests/cli_grammar_parity.rs
+++ b/crates/nub-cli/tests/cli_grammar_parity.rs
@@ -319,15 +319,24 @@ fn leading_global_flags_before_info_verb_reach_engine() {
     );
 }
 
-// `nub ci` — pnpm `ci` (clean-install). pnpm's `ci` documents NO production
-// control (it is exactly `clean` + `install --frozen-lockfile`), so the
-// pnpm-only surface is bare `ci` plus nub's workspace/script knobs.
+// `nub ci` — pnpm `ci` (clean-install). pnpm 11 implements `ci` as `clean` +
+// `install --frozen-lockfile` and re-exports install's whole option table
+// (`cliOptionsTypes`/`shorthands` in `pnpm/src/cmd/cleanInstall.ts`), so the
+// dep-axis flags come with it: `pnpm ci -P` skips devDependencies, `-D` keeps
+// only them. pnpm 10's `ci` is a stub that throws `ERR_PNPM_CI_NOT_IMPLEMENTED`
+// and takes no options at all, so its rejections carry no grammar signal — nub
+// tracks the pnpm 11 surface here.
 #[test]
 fn ci_grammar_accepts_documented_forms() {
     assert_all_accepted(
         "ci",
         &[
             (&["ci"], "pnpm ci (clean-install)"),
+            (&["ci", "--prod"], "pnpm ci --prod"),
+            (&["ci", "-P"], "pnpm ci -P"),
+            (&["ci", "--production"], "pnpm ci --production"),
+            (&["ci", "--dev"], "pnpm ci --dev"),
+            (&["ci", "-D"], "pnpm ci -D"),
             (&["ci", "--ignore-scripts"], "pnpm --ignore-scripts"),
             (&["ci", "--no-optional"], "pnpm --no-optional"),
             (&["ci", "-r"], "pnpm -r ci"),

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1371,21 +1371,29 @@ fn ci_install_links_only_the_optional_platform_variants_it_materializes() {
 /// Each leg asserts a presence beside its absence, so neither half can pass on
 /// an install that did nothing; the bare-`ci` leg is the control that both
 /// packages are installable from this lockfile at all.
+///
+/// Both dependencies are `file:` paths written by the test, so this runs
+/// offline and stays un-ignored — verified against a closed-port registry.
 #[test]
-#[ignore = "network: installs is-number + ms from the npm registry"]
 fn ci_dep_axis_flags_select_which_dependency_sets_link() {
-    if !registry_reachable() {
-        eprintln!("skipping: registry.npmjs.org unreachable");
-        return;
-    }
     let dir = pm_tmpdir("ci-dep-axis");
     let store = pm_tmpdir("ci-dep-axis-store");
     let cache = pm_tmpdir("ci-dep-axis-cache");
-    // Two zero-dependency packages, one per dep set, so a missing directory
-    // means the dep set was skipped and never a transitive-pruning artifact.
+    // One local package per dep set, each with no dependencies of its own, so
+    // a missing directory means the set was skipped and never a
+    // transitive-pruning artifact.
+    for name in ["prod-pkg", "dev-pkg"] {
+        let pkg = dir.join("vendored").join(name);
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(
+            pkg.join("package.json"),
+            format!(r#"{{"name":"{name}","version":"1.0.0"}}"#),
+        )
+        .unwrap();
+    }
     std::fs::write(
         dir.join("package.json"),
-        r#"{"name":"ci-dep-axis","private":true,"dependencies":{"is-number":"7.0.0"},"devDependencies":{"ms":"2.1.3"}}"#,
+        r#"{"name":"ci-dep-axis","private":true,"dependencies":{"prod-pkg":"file:./vendored/prod-pkg"},"devDependencies":{"dev-pkg":"file:./vendored/dev-pkg"}}"#,
     )
     .unwrap();
     let (err, code) = run_install_in_store(&dir, &store, &cache, &["install", "--lockfile-only"]);
@@ -1394,22 +1402,22 @@ fn ci_dep_axis_flags_select_which_dependency_sets_link() {
     let (err, code) = run_install_in_store(&dir, &store, &cache, &["ci", "-P"]);
     assert_eq!(code, 0, "`nub ci -P` must succeed: {err}");
     assert!(
-        dir.join("node_modules/is-number").exists(),
+        dir.join("node_modules/prod-pkg").exists(),
         "`ci -P` must still link dependencies: {err}"
     );
     assert!(
-        !dir.join("node_modules/ms").exists(),
+        !dir.join("node_modules/dev-pkg").exists(),
         "`ci -P` must omit devDependencies: {err}"
     );
 
     let (err, code) = run_install_in_store(&dir, &store, &cache, &["ci", "-D"]);
     assert_eq!(code, 0, "`nub ci -D` must succeed: {err}");
     assert!(
-        dir.join("node_modules/ms").exists(),
+        dir.join("node_modules/dev-pkg").exists(),
         "`ci -D` must link devDependencies: {err}"
     );
     assert!(
-        !dir.join("node_modules/is-number").exists(),
+        !dir.join("node_modules/prod-pkg").exists(),
         "`ci -D` must omit dependencies: {err}"
     );
 
@@ -1417,7 +1425,7 @@ fn ci_dep_axis_flags_select_which_dependency_sets_link() {
     let (err, code) = run_install_in_store(&dir, &store, &cache, &["ci"]);
     assert_eq!(code, 0, "bare `nub ci` must succeed: {err}");
     assert!(
-        dir.join("node_modules/is-number").exists() && dir.join("node_modules/ms").exists(),
+        dir.join("node_modules/prod-pkg").exists() && dir.join("node_modules/dev-pkg").exists(),
         "bare `ci` must link both dep sets: {err}"
     );
 }

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1361,6 +1361,67 @@ fn ci_install_links_only_the_optional_platform_variants_it_materializes() {
     );
 }
 
+/// `nub ci` carries the dep axis (#747). pnpm 11 builds `ci` out of `clean` +
+/// `install --frozen-lockfile` over install's whole option table, so `-P`/`-D`
+/// are pnpm's own `ci` surface rather than a nub extension. The payoff is the
+/// multi-stage Dockerfile: `ci` already forces a project-local virtual store so
+/// `node_modules` survives a `COPY --from`, and `-P` is what makes the copied
+/// tree production-only.
+///
+/// Each leg asserts a presence beside its absence, so neither half can pass on
+/// an install that did nothing; the bare-`ci` leg is the control that both
+/// packages are installable from this lockfile at all.
+#[test]
+#[ignore = "network: installs is-number + ms from the npm registry"]
+fn ci_dep_axis_flags_select_which_dependency_sets_link() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let dir = pm_tmpdir("ci-dep-axis");
+    let store = pm_tmpdir("ci-dep-axis-store");
+    let cache = pm_tmpdir("ci-dep-axis-cache");
+    // Two zero-dependency packages, one per dep set, so a missing directory
+    // means the dep set was skipped and never a transitive-pruning artifact.
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"ci-dep-axis","private":true,"dependencies":{"is-number":"7.0.0"},"devDependencies":{"ms":"2.1.3"}}"#,
+    )
+    .unwrap();
+    let (err, code) = run_install_in_store(&dir, &store, &cache, &["install", "--lockfile-only"]);
+    assert_eq!(code, 0, "lockfile seed must succeed: {err}");
+
+    let (err, code) = run_install_in_store(&dir, &store, &cache, &["ci", "-P"]);
+    assert_eq!(code, 0, "`nub ci -P` must succeed: {err}");
+    assert!(
+        dir.join("node_modules/is-number").exists(),
+        "`ci -P` must still link dependencies: {err}"
+    );
+    assert!(
+        !dir.join("node_modules/ms").exists(),
+        "`ci -P` must omit devDependencies: {err}"
+    );
+
+    let (err, code) = run_install_in_store(&dir, &store, &cache, &["ci", "-D"]);
+    assert_eq!(code, 0, "`nub ci -D` must succeed: {err}");
+    assert!(
+        dir.join("node_modules/ms").exists(),
+        "`ci -D` must link devDependencies: {err}"
+    );
+    assert!(
+        !dir.join("node_modules/is-number").exists(),
+        "`ci -D` must omit dependencies: {err}"
+    );
+
+    // `ci` deletes node_modules first, so this re-links from scratch.
+    let (err, code) = run_install_in_store(&dir, &store, &cache, &["ci"]);
+    assert_eq!(code, 0, "bare `nub ci` must succeed: {err}");
+    assert!(
+        dir.join("node_modules/is-number").exists() && dir.join("node_modules/ms").exists(),
+        "bare `ci` must link both dep sets: {err}"
+    );
+}
+
 /// `--os`/`--cpu` select which platform-specific optional deps get installed,
 /// overriding host detection for the run. The assertion is host-independent by
 /// construction: it names platforms explicitly and never mentions the host, so

--- a/site/content/docs/deployment/docker.mdx
+++ b/site/content/docs/deployment/docker.mdx
@@ -94,12 +94,15 @@ Change `package-lock.json` to the project's existing lockfile. Exclude `node_mod
 
 Install with `nub ci` in the build stage. It writes a self-contained `node_modules` — real files, project-local links — that survives a `COPY --from` into the final stage. A plain `nub install` shares packages through a machine-global store the final stage doesn't have, so the copied tree would point at files that aren't there.
 
+The tree the build stage installs carries `devDependencies` the final image never runs. Pass `--prod` (or `-P`) to relink it from the same lockfile with only `dependencies`, once the build no longer needs the rest:
+
 ```dockerfile title="Dockerfile"
 FROM ghcr.io/nubjs/nub:{{NUB_VERSION}} AS build
 COPY --chown=node:node package.json package-lock.json ./
 RUN nub ci
 COPY --chown=node:node . .
 RUN nub run build
+RUN nub ci --prod  # drop devDependencies from the tree the next stage copies
 
 FROM ghcr.io/nubjs/nub:{{NUB_VERSION}}
 COPY --from=build --chown=node:node /app/node_modules ./node_modules

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -285,6 +285,7 @@ nub install -P                   # --prod / --production
 nub install -D                   # dev only
 nub install --node-linker hoisted
 nub ci                           # clean install from the lockfile
+nub ci -P                        # clean install, no devDependencies
 ```
 
 The accepted flags are pnpm's spellings:


### PR DESCRIPTION
Closes #747

`nub ci` had no CLI channel for the production/dev split, so a Docker build stage could not produce a devDependency-free tree to `COPY --from`.

pnpm 11 builds `ci` as `clean` + `install --frozen-lockfile` and re-exports install's whole option table (`cliOptionsTypes`/`shorthands` in `pnpm/src/cmd/cleanInstall.ts`), so `-P`/`--prod`/`--production` and `-D`/`--dev` are part of its `ci` surface. The flags land on the `Ci` clap variant exactly as they do on `Install`, and OR into the `DepSelection` that `run_ci` already builds from config-derived signals.

Verified against pnpm 11.25.0 on one identical fixture (`is-number` as a dependency, `ms` as a devDependency):

```
pnpm ci     -> is-number ms       nub ci     -> is-number ms
pnpm ci -P  -> is-number          nub ci -P  -> is-number
pnpm ci -D  -> ms                 nub ci -D  -> ms
```

Workspace `ci -r -P` matches pnpm too, and the root `prepare` hook still runs under `--prod` in both tools.

pnpm 10 rejects both flags on `ci`, but that carries no grammar signal: its `ci` accepts no options at all because the handler is a stub that throws `ERR_PNPM_CI_NOT_IMPLEMENTED`. The comment above the grammar test recorded the opposite conclusion from that stub, so it is rewritten.
