### PR TITLE
launcher: pin the probe directory's mode instead of taking it from the umask

### DIFF
--- a/crates/nub-launcher/src/cache.rs
+++ b/crates/nub-launcher/src/cache.rs
@@ -308,6 +308,14 @@ pub fn read_node_version(node_bin: &Path, stamp: &str) -> Option<String> {
 
 /// Remember a probe verdict. Best effort: a cache that cannot be written is a
 /// slower launch, never a failed one, so every error here is discarded.
+///
+/// The probe directory is made by `create`, never `create_dir_all`, and the two
+/// are not interchangeable here: `create_dir_all` takes the directory's mode from
+/// the ambient umask, and [`read_node_version`] runs the same leaf gate that
+/// rejects any group- or other-writable directory. Under a umask of 002 that
+/// `create_dir_all` yields 0o775, so every write lands in a directory every read
+/// then refuses — the cache writes and never hits, silently, exactly the failure
+/// the parent-vs-leaf note on the read path already records once.
 pub fn write_node_version(node_bin: &Path, stamp: &str, version: &str) {
     for candidate in candidates() {
         let Some(base) = candidate.path else { continue };
@@ -315,7 +323,7 @@ pub fn write_node_version(node_bin: &Path, stamp: &str, version: &str) {
         let Some(parent) = path.parent() else {
             continue;
         };
-        if fs::create_dir_all(parent).is_err() {
+        if create(parent).is_err() {
             continue;
         }
         if fs::write(&path, format!("{stamp}\n{version}\n")).is_ok() {
@@ -1246,6 +1254,24 @@ mod tests {
             None,
             "verdicts are per binary path, never shared"
         );
+
+        // The DIRECTORY's mode is pinned, never inherited from the umask. The read
+        // path runs the leaf gate on it, so a `create_dir_all` under a umask of 002
+        // (0o775) would make every write unreadable — the cache writing and never
+        // hitting, on every machine with that umask, invisible from a 022 one.
+        // Asserted here rather than in a test of its own because this one already
+        // owns `__NUB_COMPILE_CACHE_DIR`, and a second writer of that process global
+        // would race it under the parallel runner.
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = probe_path(&base, &node).parent().unwrap().to_path_buf();
+            let mode = fs::metadata(&dir).unwrap().permissions().mode();
+            assert_eq!(
+                mode & 0o022,
+                0,
+                "the probe directory must not be group- or other-writable: {mode:o}"
+            );
+        }
 
         // A group-writable entry is somebody else's to edit, so it is not believed.
         {

--- a/crates/nub-launcher/src/cache.rs
+++ b/crates/nub-launcher/src/cache.rs
@@ -1262,14 +1262,20 @@ mod tests {
         // Asserted here rather than in a test of its own because this one already
         // owns `__NUB_COMPILE_CACHE_DIR`, and a second writer of that process global
         // would race it under the parallel runner.
+        //
+        // The assertion pins the EXACT mode rather than testing `& 0o022 == 0`, and
+        // that difference is the whole value of it: `create_dir_all` yields
+        // `0o777 & !umask`, so the weaker form holds at the 0o755 a 022 umask gives
+        // and stays green on CI — passing on the very environment that hid the bug.
+        // Only 0o700 discriminates, and it is umask-independent precisely because it
+        // has no group or other bits left for a umask to clear.
         {
             use std::os::unix::fs::PermissionsExt;
             let dir = probe_path(&base, &node).parent().unwrap().to_path_buf();
-            let mode = fs::metadata(&dir).unwrap().permissions().mode();
+            let mode = fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
             assert_eq!(
-                mode & 0o022,
-                0,
-                "the probe directory must not be group- or other-writable: {mode:o}"
+                mode, 0o700,
+                "the probe directory's mode must be pinned, not taken from the umask: {mode:o}"
             );
         }
 

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -2973,6 +2973,24 @@ mod tests {
         fs::canonicalize(dir).unwrap()
     }
 
+    /// Stage a fixture file the way the extraction path stages a real one — mode
+    /// pinned, never taken from the ambient umask.
+    ///
+    /// `cache_metadata_is_trusted` refuses a group- or other-writable file, and a
+    /// bare `fs::write` yields 0o664 under a umask of 002 against the 0o644 a 022
+    /// umask gives. A fixture written the bare way therefore passes on one machine
+    /// and fails on another for a reason that has nothing to do with what it tests.
+    /// Production never has the problem: it writes through `create_private_file`,
+    /// which pins 0o600 at open time and again afterwards.
+    fn write_staged_fixture(path: &Path, bytes: &[u8]) {
+        fs::write(path, bytes).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+    }
+
     fn test_manifest() -> Manifest {
         use sha2::{Digest, Sha256};
         Manifest {
@@ -4322,7 +4340,7 @@ mod tests {
         let base = fresh_cache_dir("node-size-check");
         let node = base.join("node");
         let bytes = b"#!/bin/sh\nprintf 'v26.5.0\\n'\n";
-        fs::write(&node, bytes).unwrap();
+        write_staged_fixture(&node, bytes);
 
         let mut manifest = test_view().manifest;
         // Digests that can never match, so any fallback to hashing fails BOTH halves
@@ -4336,13 +4354,13 @@ mod tests {
             "an intact extraction whose length matches the manifest must be accepted"
         );
 
-        fs::write(&node, &bytes[..bytes.len() - 1]).unwrap();
+        write_staged_fixture(&node, &bytes[..bytes.len() - 1]);
         assert!(
             !embedded_node_file_is_ready(&node, &manifest),
             "a truncated extraction must be rejected — this is the field failure the \
              size check replaced the per-launch digest to catch"
         );
-        fs::write(&node, bytes).unwrap();
+        write_staged_fixture(&node, bytes);
         manifest.node_size = 0;
         manifest.node_blake3 = blake3::hash(bytes).to_hex().to_string();
         assert!(
@@ -4368,15 +4386,18 @@ mod tests {
         let base = fresh_cache_dir("compile-cache-outside-app");
         let view = test_view();
         let app_dir = app_cache_dir(&base, &view.manifest);
-        fs::create_dir_all(&app_dir).unwrap();
+        // Staged through the production helper, not `create_dir_all`: the readiness
+        // check trusts a directory only while it is not group- or other-writable,
+        // and `create_dir_all` takes its mode from the umask (0o775 under 002).
+        create_staging_subdirs(&base, &app_dir).unwrap();
         for file in &view.app_files {
             let dest = app_dir.join(&file.name);
-            fs::create_dir_all(dest.parent().unwrap()).unwrap();
-            fs::write(&dest, file.bytes).unwrap();
+            create_staging_subdirs(&base, dest.parent().unwrap()).unwrap();
+            write_staged_fixture(&dest, file.bytes);
         }
         // The marker is an EMPTY regular file — `completion_marker_is_ready`
         // requires len == 0, so any content here would fail the control below.
-        fs::write(app_dir.join(CACHE_COMPLETE_MARKER), b"").unwrap();
+        write_staged_fixture(&app_dir.join(CACHE_COMPLETE_MARKER), b"");
         assert!(
             app_cache_is_ready(&view, &app_dir),
             "control: a freshly written extraction must be ready, or the assertion \


### PR DESCRIPTION
The probe directory was made with `create_dir_all`, whose mode comes from the umask, while the read path runs a gate that refuses a group- or other-writable directory. Under a umask of 002 every write landed where every read refused: the probe cache wrote and never hit, so each launch re-ran the Node version probe. This module's `create` exists for exactly this, and the write path was its only non-caller.

Two extraction tests failed for the neighbouring reason — fixtures inheriting `0o664`. Production pins `0o600` and is not exposed.

Invisible under a 022 umask, so CI never saw it. On a umask-002 builder the launcher suite goes from 72 passed / 3 failed to 75 passed.
