### PR TITLE
config: refuse an .npmrc write that nub.jsonc already answers

### DIFF
--- a/crates/nub-cli/src/pm_engine/duplicate_home.rs
+++ b/crates/nub-cli/src/pm_engine/duplicate_home.rs
@@ -137,7 +137,7 @@ pub(super) fn shadowed_error(key: &str, field: &str) -> anyhow::Error {
     anyhow!(
         "nub config set {key}: this project sets `{field}` in nub.jsonc, which outranks .npmrc, \
          so the value written here would never be read\n\
-         \x20\x20set `{field}` instead, or remove it from nub.jsonc to configure this from .npmrc"
+         \x20\x20run `nub config set {field} <value>` instead, or remove `{field}` from nub.jsonc"
     )
 }
 

--- a/crates/nub-cli/src/pm_engine/duplicate_home.rs
+++ b/crates/nub-cli/src/pm_engine/duplicate_home.rs
@@ -1,0 +1,194 @@
+//! Engine settings a `nub.jsonc` field ALSO supplies, and the refusal that
+//! keeps a write out of the file that loses.
+//!
+//! Twelve engine settings can be supplied by a `nub.jsonc` field. The lowering
+//! in [`super::lower_native_install_settings`] injects them at the engine's
+//! `project_config` tier, which outranks every file source — `project_npmrc`
+//! included — so once the owning field is set, an `.npmrc` line for the same
+//! setting is read by nothing. `nub config set` reports success, the file gains
+//! a line, and no resolve ever consults it: the same silent no-op
+//! [`super::store_config_family::npmrc_first`] refuses elsewhere, reached from
+//! the other side. There the key was never readable; here it is readable in
+//! general and answered by a different file in THIS project.
+//!
+//! So the refusal is conditional on what the project actually sets, not on the
+//! key alone. A project with no `install` block reads `.npmrc` `nodeLinker`
+//! exactly as before and must keep working — refusing the key outright would
+//! break a configuration that is correct today.
+//!
+//! **Why this refuses rather than rewriting the value into `nub.jsonc`.** A
+//! redirect was built and rejected. The two surfaces do not share a value
+//! grammar: `.npmrc` `minimumReleaseAge` is a bare integer in MINUTES while the
+//! field is a duration string that deliberately rejects a unit-less number (the
+//! days-vs-minutes trap in [`crate::project_config::parse_duration`]), `.npmrc`
+//! lists are comma-separated where the fields are JSON arrays, and pnpm's
+//! `install`/`prompt` verify-deps modes have no field spelling at all. Moving
+//! the write silently restates the user's value in another grammar, and it
+//! desynchronizes `get` from `set` unless `get` is rewritten to match — which
+//! would reintroduce, on the read side, exactly the divergence this module
+//! exists to remove. Naming the field the user should set has neither problem.
+
+use anyhow::anyhow;
+
+/// One engine setting a `nub.jsonc` field supplies.
+struct DuplicateHome {
+    /// The canonical engine setting name.
+    setting: &'static str,
+    /// The `nub.jsonc` address that outranks it, and the address the refusal
+    /// tells the user to set instead.
+    field: &'static str,
+}
+
+/// Every engine setting reachable from a `nub.jsonc` field, with the field that
+/// owns it. Derived from [`super::lower_native_install_settings`] and
+/// [`crate::verify_deps::resolve_policy`] — when either learns to supply
+/// another setting, it belongs here too, and
+/// `every_entry_names_a_real_setting_and_a_real_field` fails if a name here
+/// stops being real.
+const HOMES: &[DuplicateHome] = &[
+    // `install.linker` lowers to a whole layout group: the strategy, where the
+    // virtual store lives, and the hidden hoist tree that injected dependencies
+    // need.
+    DuplicateHome {
+        setting: "nodeLinker",
+        field: "install.linker",
+    },
+    DuplicateHome {
+        setting: "enableGlobalVirtualStore",
+        field: "install.linker",
+    },
+    DuplicateHome {
+        setting: "hoist",
+        field: "install.linker",
+    },
+    DuplicateHome {
+        setting: "hoistPattern",
+        field: "install.linker",
+    },
+    DuplicateHome {
+        setting: "disableGlobalVirtualStoreForPackages",
+        field: "install.linker",
+    },
+    DuplicateHome {
+        setting: "diskMaterializePackages",
+        field: "install.linker",
+    },
+    // Naming public-hoist patterns is always a narrowing, so the lowering also
+    // forces the blanket flag off — both belong to the one field.
+    DuplicateHome {
+        setting: "publicHoistPattern",
+        field: "install.publicHoist",
+    },
+    DuplicateHome {
+        setting: "shamefullyHoist",
+        field: "install.publicHoist",
+    },
+    // Release-age resolution. Admitted only under nub's own identity, which is
+    // why the caller gates these on `native_mode` before consulting the table.
+    DuplicateHome {
+        setting: "minimumReleaseAge",
+        field: "install.minimumReleaseAge",
+    },
+    DuplicateHome {
+        setting: "minimumReleaseAgeStrict",
+        field: "install.minimumReleaseAge",
+    },
+    DuplicateHome {
+        setting: "minimumReleaseAgeExclude",
+        field: "install.minimumReleaseAgeExclude",
+    },
+    // Read by `crate::verify_deps` rather than through the settings tier, but
+    // the ordering is the same: an explicitly-set field wins over `.npmrc`.
+    DuplicateHome {
+        setting: "verifyDepsBeforeRun",
+        field: "verifyDeps",
+    },
+];
+
+/// The `nub.jsonc` field that would SHADOW an `.npmrc` write of `key`, or
+/// `None` when nothing shadows it and the write is genuinely read back.
+///
+/// `supplied` is what the project's own `nub.jsonc` currently lowers to, so
+/// this follows the real injection rather than predicting it from the field
+/// names a second time. A key naming no setting, or a setting no field
+/// supplies, routes exactly as it did before.
+pub(super) fn shadowing_field(key: &str, supplied: &[String]) -> Option<&'static str> {
+    // Matched by canonical name FIRST, then by every alias spelling, so
+    // `hoist-pattern` resolves as well as `hoistPattern`. `find_unfiltered`
+    // alone matches the canonical name only, which silently made every aliased
+    // key unrecognized — and an unrecognized key is never refused, so the guard
+    // failed open rather than loudly.
+    let meta = aube_settings::meta::find_unfiltered(key).or_else(|| {
+        aube_settings::meta::all_unfiltered().iter().find(|meta| {
+            meta.npmrc_keys.contains(&key)
+                || meta.workspace_yaml_keys.contains(&key)
+                || meta.cli_flags.contains(&key)
+        })
+    })?;
+    let home = HOMES.iter().find(|home| home.setting == meta.name)?;
+    supplied
+        .iter()
+        .any(|name| name == home.setting)
+        .then_some(home.field)
+}
+
+/// The refusal for an `.npmrc` write this project's `nub.jsonc` already answers.
+pub(super) fn shadowed_error(key: &str, field: &str) -> anyhow::Error {
+    anyhow!(
+        "nub config set {key}: this project sets `{field}` in nub.jsonc, which outranks .npmrc, \
+         so the value written here would never be read\n\
+         \x20\x20set `{field}` instead, or remove it from nub.jsonc to configure this from .npmrc"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every setting named here is a real engine setting and every field a real
+    /// `nub.jsonc` address. A typo in either makes the entry inert — the
+    /// refusal never fires, and its advice names a command that does not work.
+    #[test]
+    fn every_entry_names_a_real_setting_and_a_real_field() {
+        for home in HOMES {
+            assert!(
+                aube_settings::meta::find_unfiltered(home.setting).is_some(),
+                "`{}` is not an engine setting",
+                home.setting
+            );
+            assert!(
+                crate::config_fields::field(home.field).is_some(),
+                "`{}` is not a nub.jsonc field",
+                home.field
+            );
+        }
+    }
+
+    /// The refusal is decided by what the project SUPPLIES, not by the key.
+    ///
+    /// Both directions matter and they pull opposite ways. A project that sets
+    /// the field must not be able to write a dead `.npmrc` line; a project that
+    /// does not set it reads `.npmrc` normally, and refusing there would break
+    /// a configuration that works today.
+    #[test]
+    fn shadowing_follows_what_the_project_supplies() {
+        let supplied = vec!["nodeLinker".to_string(), "hoistPattern".to_string()];
+        // An alias spelling resolves to the same setting as the canonical one.
+        assert_eq!(
+            shadowing_field("hoist-pattern", &supplied),
+            Some("install.linker")
+        );
+        assert_eq!(
+            shadowing_field("nodeLinker", &supplied),
+            Some("install.linker")
+        );
+        // Supplied by no field in this project, so the `.npmrc` write is read.
+        assert_eq!(shadowing_field("minimumReleaseAge", &supplied), None);
+        // Never a duplicate home at all.
+        assert_eq!(shadowing_field("autoInstallPeers", &supplied), None);
+        // An unknown key is free-form config and is not ours to refuse.
+        assert_eq!(shadowing_field("some-custom-key", &supplied), None);
+        // The ordinary project supplies nothing and nothing is refused.
+        assert_eq!(shadowing_field("nodeLinker", &[]), None);
+    }
+}

--- a/crates/nub-cli/src/pm_engine/duplicate_home.rs
+++ b/crates/nub-cli/src/pm_engine/duplicate_home.rs
@@ -133,9 +133,9 @@ pub(super) fn shadowing_field(key: &str, supplied: &[String]) -> Option<&'static
 }
 
 /// The refusal for an `.npmrc` write this project's `nub.jsonc` already answers.
-pub(super) fn shadowed_error(key: &str, field: &str) -> anyhow::Error {
+pub(super) fn shadowed_error(key: &str, field: &str, home: &str) -> anyhow::Error {
     anyhow!(
-        "nub config set {key}: this project sets `{field}` in nub.jsonc, which outranks .npmrc, \
+        "nub config set {key}: this project sets `{field}` in nub.jsonc, which outranks {home}, \
          so the value written here would never be read\n\
          \x20\x20run `nub config set {field} <value>` instead, or remove `{field}` from nub.jsonc"
     )

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1019,15 +1019,22 @@ fn native_pm_mode(detected: Option<&DetectedLockfile>, truly_fresh: bool, cwd: &
 /// project. Resolved from the same lowering the session uses, so the answer
 /// tracks the real injection instead of predicting it a second time.
 ///
-/// The embedder defaults are deliberately empty: they change the VALUES the
-/// lowering emits, never which settings it emits, and only the key set matters
-/// here.
+/// The embedder defaults are resolved for real rather than passed empty. They
+/// are not value-only: under `linker: global` an injected dependency puts
+/// `hoist=true` in the defaults, and that SUPPRESSES the
+/// `enableGlobalVirtualStore` push entirely. Passing `&[]` therefore invented a
+/// supplied setting the real session never injects, and refused an `.npmrc`
+/// write the install would have honored — a false refusal, which is the worst
+/// failure this guard has, since it breaks a configuration that works.
 pub(crate) fn project_supplied_settings(cwd: &Path) -> (Vec<String>, bool) {
     let detected = resolve_identity_walk_up(cwd, IdentityStrictness::Lenient).unwrap_or(None);
-    let native_mode = native_pm_mode(
+    let truly_fresh = is_truly_fresh_project(cwd, detected.as_ref());
+    let native_mode = native_pm_mode(detected.as_ref(), truly_fresh, cwd);
+    let defaults = nub_setting_defaults(
         detected.as_ref(),
-        is_truly_fresh_project(cwd, detected.as_ref()),
+        truly_fresh,
         cwd,
+        VirtualStoreLocality::Default,
     );
     // The config verbs dispatch through `lookup_verb` and RETURN before the
     // clap match that initializes the snapshot for ordinary routes, so on this
@@ -1049,7 +1056,9 @@ pub(crate) fn project_supplied_settings(cwd: &Path) -> (Vec<String>, bool) {
         return (Vec::new(), native_mode);
     };
     let mut supplied = Vec::new();
-    if let Ok(lowered) = lower_native_install_settings_for_mode(Some(&config.values.install), &[]) {
+    if let Ok(lowered) =
+        lower_native_install_settings_for_mode(Some(&config.values.install), &defaults)
+    {
         supplied.extend(lowered.layout.iter().map(|(key, _)| key.clone()));
         // Release-age settings reach the engine only under nub's own identity
         // (`scoped_install_settings`), so under an incumbent they shadow
@@ -1059,12 +1068,21 @@ pub(crate) fn project_supplied_settings(cwd: &Path) -> (Vec<String>, bool) {
         }
     }
     // `verifyDeps` is read by `crate::verify_deps` rather than through the
-    // settings tier, and only an EXPLICIT value outranks `.npmrc` there — a
-    // defaulted one leaves the file in charge.
+    // settings tier, and only an explicit value from a nub CONFIG FILE outranks
+    // `.npmrc` there. `sources` also carries the CLI and environment overlays,
+    // so testing "not defaulted" would let `NUB_VERIFY_DEPS` masquerade as a
+    // `nub.jsonc` field: the write meant for runs WITHOUT that variable would be
+    // refused, and the advice would name a field that still loses to the env.
     if config
         .sources
         .get(&crate::project_config::ConfigKey::VerifyDeps)
-        .is_some_and(|s| s.kind != crate::project_config::ConfigSourceKind::Defaults)
+        .is_some_and(|s| {
+            matches!(
+                s.kind,
+                crate::project_config::ConfigSourceKind::Project
+                    | crate::project_config::ConfigSourceKind::Global
+            )
+        })
     {
         supplied.push("verifyDepsBeforeRun".to_string());
     }

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -53,6 +53,7 @@
 
 mod bun_config;
 pub mod config_scope;
+mod duplicate_home;
 mod expo_compat;
 pub mod identity;
 pub mod info_family;
@@ -1006,6 +1007,64 @@ fn native_pm_mode(detected: Option<&DetectedLockfile>, truly_fresh: bool, cwd: &
     // already said so — a lone `packageManager: nub` declaration does not make
     // an otherwise-unresolved tree nub-identity.
     detected.is_some() && active_role(detected, cwd) == Some(config_scope::Role::Nub)
+}
+
+/// The engine settings this project's own `nub.jsonc` supplies, plus whether
+/// nub owns the project.
+///
+/// The config surface needs both to decide where a write belongs, and it runs
+/// OUTSIDE the engine session that normally computes them — `nub config` builds
+/// no install context, so `engine_context().project_config_settings` is empty
+/// on that path and reading it would report "nothing is shadowed" for every
+/// project. Resolved from the same lowering the session uses, so the answer
+/// tracks the real injection instead of predicting it a second time.
+///
+/// The embedder defaults are deliberately empty: they change the VALUES the
+/// lowering emits, never which settings it emits, and only the key set matters
+/// here.
+pub(crate) fn project_supplied_settings(cwd: &Path) -> (Vec<String>, bool) {
+    let detected = resolve_identity_walk_up(cwd, IdentityStrictness::Lenient).unwrap_or(None);
+    let native_mode = native_pm_mode(
+        detected.as_ref(),
+        is_truly_fresh_project(cwd, detected.as_ref()),
+        cwd,
+    );
+    // The config verbs dispatch through `lookup_verb` and RETURN before the
+    // clap match that initializes the snapshot for ordinary routes, so on this
+    // path `effective_config` is unset unless it is asked for here. Without
+    // this the whole check reported "nothing is shadowed" for every project —
+    // inert, and silently so, because failing to recognize a shadow just lets
+    // the write through.
+    //
+    // The error is swallowed rather than propagated: a malformed `nub.jsonc`
+    // means we cannot know what it supplies, and refusing every `config set`
+    // on the strength of an unparseable file would be a worse answer than the
+    // `.npmrc` write this project already gets today.
+    let _ = crate::cli::initialize_config_snapshot(false, false);
+    let Some(config) = crate::project_config::effective_config() else {
+        return (Vec::new(), native_mode);
+    };
+    let mut supplied = Vec::new();
+    if let Ok(lowered) = lower_native_install_settings_for_mode(Some(&config.values.install), &[]) {
+        supplied.extend(lowered.layout.iter().map(|(key, _)| key.clone()));
+        // Release-age settings reach the engine only under nub's own identity
+        // (`scoped_install_settings`), so under an incumbent they shadow
+        // nothing and the `.npmrc` value is the one that gets read.
+        if native_mode {
+            supplied.extend(lowered.resolution.iter().map(|(key, _)| key.clone()));
+        }
+    }
+    // `verifyDeps` is read by `crate::verify_deps` rather than through the
+    // settings tier, and only an EXPLICIT value outranks `.npmrc` there — a
+    // defaulted one leaves the file in charge.
+    if config
+        .sources
+        .get(&crate::project_config::ConfigKey::VerifyDeps)
+        .is_some_and(|s| s.kind != crate::project_config::ConfigSourceKind::Defaults)
+    {
+        supplied.push("verifyDepsBeforeRun".to_string());
+    }
+    (supplied, native_mode)
 }
 
 fn lower_native_install_settings(

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1036,11 +1036,15 @@ pub(crate) fn project_supplied_settings(cwd: &Path) -> (Vec<String>, bool) {
     // inert, and silently so, because failing to recognize a shadow just lets
     // the write through.
     //
-    // The error is swallowed rather than propagated: a malformed `nub.jsonc`
-    // means we cannot know what it supplies, and refusing every `config set`
-    // on the strength of an unparseable file would be a worse answer than the
-    // `.npmrc` write this project already gets today.
-    let _ = crate::cli::initialize_config_snapshot(false, false);
+    // A failure reports "supplies nothing" rather than propagating: a
+    // malformed `nub.jsonc` means we cannot know what it supplies, and refusing
+    // every `config set` on the strength of an unparseable file would be a
+    // worse answer than the `.npmrc` write this project already gets today.
+    // Returning here rather than falling through also keeps that promise when
+    // some earlier path in the same process already populated the snapshot.
+    if crate::cli::initialize_config_snapshot(false, false).is_err() {
+        return (Vec::new(), native_mode);
+    }
     let Some(config) = crate::project_config::effective_config() else {
         return (Vec::new(), native_mode);
     };

--- a/crates/nub-cli/src/pm_engine/store_config_family.rs
+++ b/crates/nub-cli/src/pm_engine/store_config_family.rs
@@ -637,7 +637,7 @@ fn dispatch_config(parsed: ConfigArgs) -> Result<i32> {
                 // answer is a refusal rather than a different destination: the
                 // two surfaces do not share a value grammar, and moving the
                 // write would desynchronize `get` from `set` (module doc on
-                // [`super::duplicate_home`]).
+                // the duplicate_home module docs).
                 let (supplied, _native) =
                     super::project_supplied_settings(&std::env::current_dir()?);
                 if let Some(field) = super::duplicate_home::shadowing_field(&set.key, &supplied) {

--- a/crates/nub-cli/src/pm_engine/store_config_family.rs
+++ b/crates/nub-cli/src/pm_engine/store_config_family.rs
@@ -632,6 +632,17 @@ fn dispatch_config(parsed: ConfigArgs) -> Result<i32> {
                 // scalars in the neutral project `.npmrc` (v9/v10 read them from
                 // there, and v11 still reads auth from there). Non-pnpm and
                 // nub-identity surfaces also keep `.npmrc` (read_branded off).
+                // `nub.jsonc` outranks `.npmrc` for the settings it supplies,
+                // so ask what THIS project sets before choosing a file. The
+                // answer is a refusal rather than a different destination: the
+                // two surfaces do not share a value grammar, and moving the
+                // write would desynchronize `get` from `set` (module doc on
+                // [`super::duplicate_home`]).
+                let (supplied, _native) =
+                    super::project_supplied_settings(&std::env::current_dir()?);
+                if let Some(field) = super::duplicate_home::shadowing_field(&set.key, &supplied) {
+                    return Err(super::duplicate_home::shadowed_error(&set.key, field));
+                }
                 let pnpm_incumbent = aube_util::engine_context().read_branded_pnpm_config;
                 let scalar_to_yaml = project_scalar_home(pnpm_incumbent)
                     == config_model::ScalarHome::PnpmWorkspaceYaml;

--- a/crates/nub-cli/src/pm_engine/store_config_family.rs
+++ b/crates/nub-cli/src/pm_engine/store_config_family.rs
@@ -632,21 +632,36 @@ fn dispatch_config(parsed: ConfigArgs) -> Result<i32> {
                 // scalars in the neutral project `.npmrc` (v9/v10 read them from
                 // there, and v11 still reads auth from there). Non-pnpm and
                 // nub-identity surfaces also keep `.npmrc` (read_branded off).
-                // `nub.jsonc` outranks `.npmrc` for the settings it supplies,
-                // so ask what THIS project sets before choosing a file. The
-                // answer is a refusal rather than a different destination: the
-                // two surfaces do not share a value grammar, and moving the
-                // write would desynchronize `get` from `set` (module doc on
-                // the duplicate_home module docs).
-                let (supplied, _native) =
-                    super::project_supplied_settings(&std::env::current_dir()?);
-                if let Some(field) = super::duplicate_home::shadowing_field(&set.key, &supplied) {
-                    return Err(super::duplicate_home::shadowed_error(&set.key, field));
-                }
                 let pnpm_incumbent = aube_util::engine_context().read_branded_pnpm_config;
                 let scalar_to_yaml = project_scalar_home(pnpm_incumbent)
                     == config_model::ScalarHome::PnpmWorkspaceYaml;
-                match npmrc_first::classify_set(&set.key, scalar_to_yaml) {
+                let route = npmrc_first::classify_set(&set.key, scalar_to_yaml);
+                // `nub.jsonc` outranks every file home for the settings it
+                // supplies, so a write of one is read by nothing. Asked AFTER
+                // the route is chosen, for two reasons: the refusal can name the
+                // file it actually blocked — a non-shared scalar under a pnpm 11
+                // incumbent was bound for `pnpm-workspace.yaml`, not `.npmrc` —
+                // and a key the engine handles, or already refuses, never pays
+                // for the project lookup at all.
+                //
+                // The answer is a refusal rather than a different destination:
+                // the two surfaces do not share a value grammar, and moving the
+                // write would desynchronize `get` from `set`. See the
+                // duplicate_home module docs.
+                let blocked_home = match &route {
+                    npmrc_first::SetRoute::ProjectWorkspaceYaml => Some("pnpm-workspace.yaml"),
+                    npmrc_first::SetRoute::ProjectNpmrc => Some(".npmrc"),
+                    npmrc_first::SetRoute::Engine | npmrc_first::SetRoute::Refuse(_) => None,
+                };
+                if let Some(home) = blocked_home {
+                    let (supplied, _native) =
+                        super::project_supplied_settings(&std::env::current_dir()?);
+                    if let Some(field) = super::duplicate_home::shadowing_field(&set.key, &supplied)
+                    {
+                        return Err(super::duplicate_home::shadowed_error(&set.key, field, home));
+                    }
+                }
+                match route {
                     npmrc_first::SetRoute::Engine => {} // fall through to delegate
                     npmrc_first::SetRoute::ProjectWorkspaceYaml => {
                         return npmrc_first::set_project_workspace_yaml(&set.key, &set.value);

--- a/crates/nub-cli/tests/pm_config_defaults.rs
+++ b/crates/nub-cli/tests/pm_config_defaults.rs
@@ -365,3 +365,44 @@ fn a_stale_key_from_an_older_nub_can_still_be_deleted() {
         "the delete took the neighbouring setting with it: {after:?}"
     );
 }
+
+/// A setting the project's own `nub.jsonc` supplies is refused on the `.npmrc`
+/// route — and the SAME key is written normally when it does not.
+///
+/// The control is the whole point. `nub.jsonc` outranks `.npmrc`, so once
+/// `install.linker` is set an `.npmrc` `nodeLinker` line is read by nothing and
+/// writing it is the silent no-op this suite exists to catch. But a project
+/// with no `install` block reads that line exactly as before, so a refusal
+/// keyed on the KEY rather than on the project would break a configuration that
+/// is correct today. Both halves are asserted against one key so the difference
+/// can only be the project.
+#[test]
+fn config_set_refuses_a_setting_nub_jsonc_already_supplies() {
+    let shadowed = fixture("shadowed");
+    std::fs::write(
+        shadowed.join("nub.jsonc"),
+        r#"{ "install": { "linker": "hoisted" } }"#,
+    )
+    .unwrap();
+    let (_out, err, code, _) = spawn_in(&shadowed, &["set", "nodeLinker", "isolated"]);
+    assert_ne!(code, 0, "`config set nodeLinker` must fail: {err}");
+    assert!(
+        err.contains("install.linker"),
+        "the refusal must name the field that wins: {err}"
+    );
+    assert!(
+        !shadowed.join(".npmrc").exists(),
+        "a refused write must leave no .npmrc behind"
+    );
+
+    // Control: same key, same command, no `install` block. The `.npmrc` value
+    // is what gets read here, so the write has to land.
+    let plain = fixture("unshadowed");
+    let (_out, err, code, _) = spawn_in(&plain, &["set", "nodeLinker", "isolated"]);
+    assert_eq!(code, 0, "`config set nodeLinker` must succeed here: {err}");
+    let written = std::fs::read_to_string(plain.join(".npmrc")).expect("the write must land");
+    assert!(
+        written.contains("isolated"),
+        "the .npmrc must carry the value: {written:?}"
+    );
+}

--- a/crates/nub-cli/tests/pm_config_defaults.rs
+++ b/crates/nub-cli/tests/pm_config_defaults.rs
@@ -442,3 +442,45 @@ fn an_env_overlay_does_not_count_as_a_nub_jsonc_field() {
         "the persistent write must still land"
     );
 }
+
+/// The shadow set is computed with the REAL embedder defaults, so an injected
+/// dependency changes which settings count as supplied.
+///
+/// Under `linker: global-virtual-store` the lowering pushes
+/// `enableGlobalVirtualStore` only when the defaults do NOT already carry
+/// `hoist=true`. An injected dependency puts it there, the push is suppressed,
+/// and the engine takes that setting from `.npmrc` after all — so refusing the
+/// write would reject configuration the install honors. Computing the set with
+/// empty defaults inverts exactly this one case, which is why the two halves
+/// differ only by `dependenciesMeta`.
+#[test]
+fn an_injected_dependency_changes_what_counts_as_supplied() {
+    let gvs = r#"{ "install": { "linker": "global-virtual-store" } }"#;
+
+    let injected = fixture("injected");
+    std::fs::write(
+        injected.join("package.json"),
+        r#"{"name":"app","version":"1.0.0","dependenciesMeta":{"dep":{"injected":true}}}"#,
+    )
+    .unwrap();
+    std::fs::write(injected.join("nub.jsonc"), gvs).unwrap();
+    let (_out, err, code, _) = spawn_in(&injected, &["set", "enableGlobalVirtualStore", "false"]);
+    assert_eq!(
+        code, 0,
+        "an injected dep suppresses the lowering's push, so .npmrc still answers: {err}"
+    );
+
+    // Control: identical but for `dependenciesMeta`. Here the lowering DOES
+    // push the setting, so the same write is genuinely unreadable.
+    let plain = fixture("not-injected");
+    std::fs::write(plain.join("nub.jsonc"), gvs).unwrap();
+    let (_out, err, code, _) = spawn_in(&plain, &["set", "enableGlobalVirtualStore", "false"]);
+    assert_ne!(
+        code, 0,
+        "without an injected dep this must be refused: {err}"
+    );
+    assert!(
+        err.contains("install.linker"),
+        "the refusal must name the field that wins: {err}"
+    );
+}

--- a/crates/nub-cli/tests/pm_config_defaults.rs
+++ b/crates/nub-cli/tests/pm_config_defaults.rs
@@ -406,3 +406,39 @@ fn config_set_refuses_a_setting_nub_jsonc_already_supplies() {
         "the .npmrc must carry the value: {written:?}"
     );
 }
+
+/// A transient overlay is not a `nub.jsonc` field, so it must not trigger the
+/// shadow refusal.
+///
+/// `effective_config().sources` records CLI and environment overlays alongside
+/// the two config files, so testing merely "not defaulted" classifies
+/// `NUB_VERIFY_DEPS` as a field this project sets. The write would then be
+/// refused — even though it is the persistent setting for every run WITHOUT
+/// that variable — and the advice would name a field that still loses to the
+/// environment. The refusal has to follow the FILES.
+#[test]
+fn an_env_overlay_does_not_count_as_a_nub_jsonc_field() {
+    let project = fixture("env-overlay");
+    let home = project.parent().unwrap().join("home");
+    let out = Command::new(nub_binary())
+        .args(["config", "set", "verifyDepsBeforeRun", "error"])
+        .current_dir(&project)
+        .env("NUB_SELF_SHIM", "0")
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("XDG_CONFIG_HOME", home.join("xdg-config"))
+        .env("XDG_DATA_HOME", home.join("xdg-data"))
+        .env("XDG_CACHE_HOME", home.join("xdg-cache"))
+        .env("NUB_VERIFY_DEPS", "error")
+        .output()
+        .expect("nub config set must run");
+    assert!(
+        out.status.success(),
+        "an env overlay must not be mistaken for a nub.jsonc field: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        project.join(".npmrc").exists(),
+        "the persistent write must still land"
+    );
+}

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -735,7 +735,7 @@ A field of this file also wins over the `.npmrc` spelling of the same setting. W
 ```text
 $ nub config set nodeLinker isolated
 Error: nub config set nodeLinker: this project sets `install.linker` in nub.jsonc, which outranks .npmrc, so the value written here would never be read
-  set `install.linker` instead, or remove it from nub.jsonc to configure this from .npmrc
+  run `nub config set install.linker <value>` instead, or remove `install.linker` from nub.jsonc
 ```
 
 This tracks what the project actually sets, not the key alone. `install.linker: "hoisted"` decides the linker and nothing else, so `hoist-pattern` still reads from `.npmrc`; giving `linker` a `hoist` list decides that too, and then it does not.

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -729,3 +729,13 @@ Error: nub config set updateNotifier: `updateNotifier` is not a nub setting
 ```
 
 Those keys are absent from `nub config list --all` too, so the listing and the write agree on what this project can set.
+
+A field of this file also wins over the `.npmrc` spelling of the same setting. When the project sets one, writing the other spelling is refused rather than left to look like it worked:
+
+```text
+$ nub config set nodeLinker isolated
+Error: nub config set nodeLinker: this project sets `install.linker` in nub.jsonc, which outranks .npmrc, so the value written here would never be read
+  set `install.linker` instead, or remove it from nub.jsonc to configure this from .npmrc
+```
+
+This tracks what the project actually sets, not the key alone. `install.linker: "hoisted"` decides the linker and nothing else, so `hoist-pattern` still reads from `.npmrc`; giving `linker` a `hoist` list decides that too, and then it does not.


### PR DESCRIPTION
Closes #626, stacked on #833.

A `nub.jsonc` install field lowers into engine settings at the `project_config` tier, which outranks project `.npmrc`. Once the field is set, an `.npmrc` line for the same setting is read by nothing — `config set` reported success and no resolve consulted the value. Measured in both directions against a real install.

This refuses that write and names the field to set instead. Keyed on what the project actually supplies, not on the key alone: `linker: "hoisted"` decides only the linker, so `hoist-pattern` still routes to `.npmrc` there.

Not a redirect — the two surfaces disagree on value grammar, and moving the write would desync `get` from `set`.

