### PR TITLE
npm lockfile: emit the link pair for a `link:` directory dependency

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -842,6 +842,95 @@ fn test_write_nests_a_conflicting_member_local_dep() {
     );
 }
 
+/// A root dep and a member-local dep sharing an ALIAS. The root one wins
+/// `node_modules/<alias>` and the member's link nests, exactly as with two
+/// local targets — but the occupant here is written by a LATER pass, so
+/// the partially-built `packages` map cannot see it.
+///
+/// That is what `root_claimed` exists for. Without it the link was written
+/// to root while the slot still looked free, the hoist pass overwrote it,
+/// and the member's link vanished from the lockfile entirely — leaving the
+/// member resolving to the registry package. Measured, npm 10, root
+/// `shared = npm:is-number@7.0.0` + member `shared = file:../../vendor/local`:
+///
+///     "node_modules/shared":              <the registry package>
+///     "packages/app/node_modules/shared": { resolved: "vendor/local", link: true }
+#[test]
+fn test_write_nests_a_member_local_dep_under_a_root_registry_alias() {
+    let local = LocalSource::Directory(PathBuf::from("vendor/local"));
+    let local_dp = local.dep_path("shared");
+    let mut graph = LockfileGraph::default();
+    graph.packages.insert(
+        local_dp.clone(),
+        LockedPackage {
+            name: "shared".to_string(),
+            version: "1.0.0".to_string(),
+            dep_path: local_dp.clone(),
+            local_source: Some(local),
+            ..Default::default()
+        },
+    );
+    graph.packages.insert(
+        "shared@7.0.0".to_string(),
+        LockedPackage {
+            name: "shared".to_string(),
+            version: "7.0.0".to_string(),
+            dep_path: "shared@7.0.0".to_string(),
+            ..Default::default()
+        },
+    );
+    graph.importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "shared".to_string(),
+            dep_path: "shared@7.0.0".to_string(),
+            dep_type: DepType::Production,
+            specifier: Some("^7.0.0".to_string()),
+        }],
+    );
+    graph.importers.insert(
+        "packages/app".to_string(),
+        vec![DirectDep {
+            name: "shared".to_string(),
+            dep_path: local_dp,
+            dep_type: DepType::Production,
+            specifier: Some("file:../../vendor/local".to_string()),
+        }],
+    );
+
+    let manifest = aube_manifest::PackageJson {
+        name: Some("root".to_string()),
+        version: Some("1.0.0".to_string()),
+        dependencies: [("shared".to_string(), "^7.0.0".to_string())]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("packages/app")).unwrap();
+    std::fs::write(
+        dir.path().join("packages/app/package.json"),
+        r#"{"name":"@w/app","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    let out = dir.path().join("package-lock.json");
+    write(&out, &graph, &manifest).unwrap();
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+    let packages = &doc["packages"];
+
+    assert_eq!(
+        packages["node_modules/shared"]["version"], "7.0.0",
+        "the root dep keeps the root alias, got {packages}"
+    );
+    assert_eq!(
+        packages["packages/app/node_modules/shared"]["resolved"], "vendor/local",
+        "the member's local link must survive the later hoist pass, nested \
+         under its own importer, got {packages}"
+    );
+}
+
 #[test]
 fn test_parse_file_resolved_without_link() {
     // npm writes `resolved: "file:..."` without `link: true` for

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -3744,6 +3744,70 @@ fn test_write_npm_root_entry_mirrors_manifest_metadata() {
     );
 }
 
+/// npm mirrors the root manifest's `workspaces` into `packages[""]` too, and
+/// copies it VERBATIM — so the key's BUCKET follows the value's runtime type,
+/// which is the only field in the entry that moves. `json-stringify-nice`
+/// sorts non-objects first, and a JSON array counts as a non-object, so the
+/// ordinary array form lands last among the scalars while bun's object form
+/// lands last among the objects. Both measured, npm 11.19.0, on these exact
+/// manifests:
+///
+///     array  → name, version, license, workspaces, dependencies
+///     object → name, version, license, dependencies, engines, workspaces
+///
+/// Omitting the field entirely was the only divergence left between nub's
+/// root entry and npm's, so a workspace project churned its lockfile on every
+/// alternating install.
+#[test]
+fn test_write_npm_root_entry_mirrors_workspaces_in_npms_key_order() {
+    let write_root = |manifest_json: &str| {
+        let manifest: aube_manifest::PackageJson = serde_json::from_str(manifest_json).unwrap();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write(tmp.path(), &LockfileGraph::default(), &manifest).unwrap();
+        std::fs::read_to_string(tmp.path()).unwrap()
+    };
+
+    let array = write_root(
+        r#"{
+            "name": "root", "version": "1.0.0", "license": "MIT",
+            "workspaces": ["packages/*"],
+            "dependencies": { "is-number": "7.0.0" }
+        }"#,
+    );
+    let doc: serde_json::Value = serde_json::from_str(&array).unwrap();
+    assert_eq!(
+        doc["packages"][""]["workspaces"],
+        serde_json::json!(["packages/*"]),
+        "the array form is copied through unchanged, got {array}"
+    );
+    let at = |hay: &str, key: &str| hay.find(key).unwrap_or_else(|| panic!("missing {key}"));
+    assert!(
+        at(&array, "\"license\"") < at(&array, "\"workspaces\"")
+            && at(&array, "\"workspaces\"") < at(&array, "\"dependencies\""),
+        "an array `workspaces` sorts with the scalars, before every object key:\n{array}"
+    );
+
+    // Bun's object form: same field, other bucket. npm accepts this manifest
+    // and writes the object back as authored — including NOT inventing a
+    // `nohoist` key, which is why the manifest type skips an empty one.
+    let object = write_root(
+        r#"{
+            "name": "root", "version": "1.0.0", "license": "MIT",
+            "workspaces": { "packages": ["packages/*"] },
+            "dependencies": { "is-number": "7.0.0" },
+            "engines": { "node": ">=18" }
+        }"#,
+    );
+    assert!(
+        !object.contains("nohoist"),
+        "an object form authored without `nohoist` must not grow one:\n{object}"
+    );
+    assert!(
+        at(&object, "\"engines\"") < at(&object, "\"workspaces\""),
+        "an object `workspaces` sorts with the objects, last:\n{object}"
+    );
+}
+
 /// npm strips the leading `./` off every bin path — and strips it repeatedly,
 /// so `././d.js` lands as `d.js`. Leaving the prefix on churns the lockfile
 /// against npm's own output on every alternating install. Expectations

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -706,6 +706,142 @@ fn test_write_leaves_workspace_member_links_to_the_workspace_pass() {
     assert_eq!(packages["node_modules/@w/a"]["link"], true);
 }
 
+/// A NON-root importer's local dep is keyed in the project-root frame,
+/// not the importer's. `LocalSource` paths arrive project-root-relative
+/// (`rebase_local`) and npm's keys are project-root-relative, so the two
+/// already agree — prepending the importer produced
+/// `packages/app/vendor/local-pkg`, a path matching nothing on disk,
+/// where npm 10 writes `vendor/local-pkg` (measured).
+#[test]
+fn test_write_keys_a_member_local_dep_in_the_project_root_frame() {
+    let local = LocalSource::Directory(PathBuf::from("vendor/local-pkg"));
+    let dep_path = local.dep_path("local-utils");
+    let mut graph = LockfileGraph::default();
+    graph.packages.insert(
+        dep_path.clone(),
+        LockedPackage {
+            name: "local-utils".to_string(),
+            version: "1.0.0".to_string(),
+            dep_path: dep_path.clone(),
+            local_source: Some(local),
+            ..Default::default()
+        },
+    );
+    graph.importers.insert(".".to_string(), vec![]);
+    graph.importers.insert(
+        "packages/app".to_string(),
+        vec![DirectDep {
+            name: "local-utils".to_string(),
+            dep_path,
+            dep_type: DepType::Production,
+            specifier: Some("file:../../vendor/local-pkg".to_string()),
+        }],
+    );
+
+    let manifest = aube_manifest::PackageJson {
+        name: Some("root".to_string()),
+        version: Some("1.0.0".to_string()),
+        ..Default::default()
+    };
+    // `write` recovers a member's identity from its `package.json` on
+    // disk, so the importer needs to exist for the member pass to run.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("packages/app")).unwrap();
+    std::fs::write(
+        dir.path().join("packages/app/package.json"),
+        r#"{"name":"@w/app","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    let out = dir.path().join("package-lock.json");
+    write(&out, &graph, &manifest).unwrap();
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+    let packages = &doc["packages"];
+
+    assert_eq!(packages["vendor/local-pkg"]["version"], "1.0.0");
+    assert!(
+        packages.get("packages/app/vendor/local-pkg").is_none(),
+        "the importer prefix must not be prepended to an already-root-relative \
+         path, got {packages}"
+    );
+    assert_eq!(
+        packages["node_modules/local-utils"]["resolved"],
+        "vendor/local-pkg"
+    );
+}
+
+/// Two members depending on the same NAME at different paths: npm hoists
+/// the first to the root and NESTS the conflicting one under the importer
+/// that wants it. Measured, npm 10 — `node_modules/shared` →
+/// `vendor/one`, `packages/b/node_modules/shared` → `vendor/two`.
+///
+/// Keying every link at the root made the last writer win, so the first
+/// member silently resolved to the other's package: no error, a wrong
+/// module. That is the failure this pins.
+#[test]
+fn test_write_nests_a_conflicting_member_local_dep() {
+    let one = LocalSource::Directory(PathBuf::from("vendor/one"));
+    let two = LocalSource::Directory(PathBuf::from("vendor/two"));
+    let (one_path, two_path) = (one.dep_path("shared"), two.dep_path("shared"));
+    let mut graph = LockfileGraph::default();
+    for (dp, src, ver) in [(&one_path, one, "1.0.0"), (&two_path, two, "2.0.0")] {
+        graph.packages.insert(
+            dp.clone(),
+            LockedPackage {
+                name: "shared".to_string(),
+                version: ver.to_string(),
+                dep_path: dp.clone(),
+                local_source: Some(src),
+                ..Default::default()
+            },
+        );
+    }
+    graph.importers.insert(".".to_string(), vec![]);
+    for (importer, dp, spec) in [
+        ("packages/a", &one_path, "file:../../vendor/one"),
+        ("packages/b", &two_path, "file:../../vendor/two"),
+    ] {
+        graph.importers.insert(
+            importer.to_string(),
+            vec![DirectDep {
+                name: "shared".to_string(),
+                dep_path: dp.clone(),
+                dep_type: DepType::Production,
+                specifier: Some(spec.to_string()),
+            }],
+        );
+    }
+
+    let manifest = aube_manifest::PackageJson {
+        name: Some("root".to_string()),
+        version: Some("1.0.0".to_string()),
+        ..Default::default()
+    };
+    let dir = tempfile::tempdir().unwrap();
+    for (d, n) in [("packages/a", "@w/a"), ("packages/b", "@w/b")] {
+        std::fs::create_dir_all(dir.path().join(d)).unwrap();
+        std::fs::write(
+            dir.path().join(d).join("package.json"),
+            format!(r#"{{"name":"{n}","version":"1.0.0"}}"#),
+        )
+        .unwrap();
+    }
+    let out = dir.path().join("package-lock.json");
+    write(&out, &graph, &manifest).unwrap();
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+    let packages = &doc["packages"];
+
+    assert_eq!(packages["node_modules/shared"]["resolved"], "vendor/one");
+    assert_eq!(
+        packages["packages/b/node_modules/shared"]["resolved"], "vendor/two",
+        "the conflicting target nests under its own importer rather than \
+         overwriting the root slot, got {packages}"
+    );
+}
+
 #[test]
 fn test_parse_file_resolved_without_link() {
     // npm writes `resolved: "file:..."` without `link: true` for

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -3806,6 +3806,32 @@ fn test_write_npm_root_entry_mirrors_workspaces_in_npms_key_order() {
         at(&object, "\"engines\"") < at(&object, "\"workspaces\""),
         "an object `workspaces` sorts with the objects, last:\n{object}"
     );
+
+    // The other half of verbatim: npm distinguishes a field that was never
+    // authored from one authored EMPTY, and keeps the empty one. Measured,
+    // npm 11.19.0 — `{"packages":[…],"nohoist":[]}` round-trips with the
+    // empty list intact, as do `catalog: {}` and `catalogs: {}`. Skipping
+    // them on emptiness reproduces the absent case and silently drops this
+    // one, which churns the key out of the lockfile on every alternating
+    // install; hence the presence-aware `Option`s on the manifest type.
+    let explicit_empties = write_root(
+        r#"{
+            "name": "root", "version": "1.0.0",
+            "workspaces": {
+                "packages": ["packages/*"],
+                "nohoist": [], "catalog": {}, "catalogs": {}
+            }
+        }"#,
+    );
+    let doc: serde_json::Value = serde_json::from_str(&explicit_empties).unwrap();
+    assert_eq!(
+        doc["packages"][""]["workspaces"],
+        serde_json::json!({
+            "packages": ["packages/*"],
+            "nohoist": [], "catalog": {}, "catalogs": {}
+        }),
+        "an authored-empty field is kept, not collapsed into absence, got {explicit_empties}"
+    );
 }
 
 /// npm strips the leading `./` off every bin path — and strips it repeatedly,

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -654,7 +654,7 @@ fn test_write_emits_link_dir_dep_as_link_pair() {
 /// Honest about what it does NOT prove: the emitter's workspace guard is
 /// belt-and-braces rather than load-bearing. `emit_file_dep_links` runs
 /// BEFORE the workspace pass, which rewrites the same two keys and so
-/// wins regardless — with the guard deleted, this test and all 546 others
+/// wins regardless — with the guard deleted, this test and all 579 others
 /// in the crate still pass (measured). The guard states which pass owns a
 /// member instead of leaving it to that ordering, and this test gives a
 /// future reordering something to fail against.
@@ -711,7 +711,7 @@ fn test_write_leaves_workspace_member_links_to_the_workspace_pass() {
 /// (`rebase_local`) and npm's keys are project-root-relative, so the two
 /// already agree — prepending the importer produced
 /// `packages/app/vendor/local-pkg`, a path matching nothing on disk,
-/// where npm 10 writes `vendor/local-pkg` (measured).
+/// where npm 11.19.0 writes `vendor/local-pkg` (measured).
 #[test]
 fn test_write_keys_a_member_local_dep_in_the_project_root_frame() {
     let local = LocalSource::Directory(PathBuf::from("vendor/local-pkg"));
@@ -773,7 +773,7 @@ fn test_write_keys_a_member_local_dep_in_the_project_root_frame() {
 
 /// Two members depending on the same NAME at different paths: npm hoists
 /// the first to the root and NESTS the conflicting one under the importer
-/// that wants it. Measured, npm 10 — `node_modules/shared` →
+/// that wants it. Measured, npm 11.19.0 — `node_modules/shared` →
 /// `vendor/one`, `packages/b/node_modules/shared` → `vendor/two`.
 ///
 /// Keying every link at the root made the last writer win, so the first
@@ -850,7 +850,7 @@ fn test_write_nests_a_conflicting_member_local_dep() {
 /// That is what `root_claimed` exists for. Without it the link was written
 /// to root while the slot still looked free, the hoist pass overwrote it,
 /// and the member's link vanished from the lockfile entirely — leaving the
-/// member resolving to the registry package. Measured, npm 10, root
+/// member resolving to the registry package. Measured, npm 11.19.0, root
 /// `shared = npm:is-number@7.0.0` + member `shared = file:../../vendor/local`:
 ///
 ///     "node_modules/shared":              <the registry package>
@@ -928,6 +928,196 @@ fn test_write_nests_a_member_local_dep_under_a_root_registry_alias() {
         packages["packages/app/node_modules/shared"]["resolved"], "vendor/local",
         "the member's local link must survive the later hoist pass, nested \
          under its own importer, got {packages}"
+    );
+}
+
+/// The root occupant reached the alias TRANSITIVELY — nothing in the root
+/// importer's own dependency list is named `shared`, but a dep of a dep
+/// hoists there.
+///
+/// Sibling of the test above and a distinct hole: predicting the root's
+/// occupants from the root importer's DIRECT deps missed every hoisted
+/// transitive, so the member's link went to root and the hoist pass
+/// erased it. The set is read off the hoist tree instead, which answers
+/// the question by construction. Measured, npm 11.19.0, root
+/// `fill-range@7.1.1` (which pulls `to-regex-range`) + member
+/// `to-regex-range = file:../../vendor/local`:
+///
+///     "node_modules/to-regex-range":              <the registry package>
+///     "packages/app/node_modules/to-regex-range": { resolved: "vendor/local", link: true }
+#[test]
+fn test_write_nests_a_member_local_dep_under_a_transitive_hoist() {
+    let local = LocalSource::Directory(PathBuf::from("vendor/local"));
+    let local_dp = local.dep_path("shared");
+    let mut graph = LockfileGraph::default();
+    graph.packages.insert(
+        local_dp.clone(),
+        LockedPackage {
+            name: "shared".to_string(),
+            version: "1.0.0".to_string(),
+            dep_path: local_dp.clone(),
+            local_source: Some(local),
+            ..Default::default()
+        },
+    );
+    // `outer` is the root's only direct dep; `shared@2.0.0` rides in
+    // underneath it and hoists to the root alongside it.
+    graph.packages.insert(
+        "outer@1.0.0".to_string(),
+        LockedPackage {
+            name: "outer".to_string(),
+            version: "1.0.0".to_string(),
+            dep_path: "outer@1.0.0".to_string(),
+            dependencies: [("shared".to_string(), "shared@2.0.0".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        },
+    );
+    graph.packages.insert(
+        "shared@2.0.0".to_string(),
+        LockedPackage {
+            name: "shared".to_string(),
+            version: "2.0.0".to_string(),
+            dep_path: "shared@2.0.0".to_string(),
+            ..Default::default()
+        },
+    );
+    graph.importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "outer".to_string(),
+            dep_path: "outer@1.0.0".to_string(),
+            dep_type: DepType::Production,
+            specifier: Some("^1.0.0".to_string()),
+        }],
+    );
+    graph.importers.insert(
+        "packages/app".to_string(),
+        vec![DirectDep {
+            name: "shared".to_string(),
+            dep_path: local_dp,
+            dep_type: DepType::Production,
+            specifier: Some("file:../../vendor/local".to_string()),
+        }],
+    );
+
+    let manifest = aube_manifest::PackageJson {
+        name: Some("root".to_string()),
+        version: Some("1.0.0".to_string()),
+        dependencies: [("outer".to_string(), "^1.0.0".to_string())]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("packages/app")).unwrap();
+    std::fs::write(
+        dir.path().join("packages/app/package.json"),
+        r#"{"name":"@w/app","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    let out = dir.path().join("package-lock.json");
+    write(&out, &graph, &manifest).unwrap();
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+    let packages = &doc["packages"];
+
+    assert_eq!(
+        packages["node_modules/shared"]["version"], "2.0.0",
+        "the hoisted transitive keeps the root alias, got {packages}"
+    );
+    assert_eq!(
+        packages["packages/app/node_modules/shared"]["resolved"], "vendor/local",
+        "a transitive hoist claims the root slot just as a direct dep does, \
+         so the member's link nests rather than being erased, got {packages}"
+    );
+}
+
+/// The root occupant is a workspace MEMBER's own name, on a graph that was
+/// freshly resolved rather than read back from a lockfile.
+///
+/// Third shape of the same collision, and the one that survived the first
+/// two fixes. A member is linked at `node_modules/<its name>`, so its name
+/// claims the root — but the roster was built from
+/// `workspace_package_for_importer`, which only answers on a graph READ
+/// from an npm lockfile (it looks for the synthesized `link: true`
+/// package). On a fresh resolve every member was invisible to it, so a
+/// sibling's local link took the root slot and the member pass erased it.
+/// The roster now falls back to the on-disk manifests, exactly as the
+/// member pass itself does.
+///
+/// Ordering matters to the reproduction: `packages/a` (the local dep) must
+/// serialize BEFORE `packages/z` (the name), or the member entry is
+/// already in the map and the plain occupancy check catches it.
+///
+/// Measured, npm 11.19.0, member `packages/z` named `shared` + member
+/// `packages/a` with `shared = file:../../vendor/local`:
+///
+///     "node_modules/shared":            { resolved: "packages/z",  link: true }
+///     "packages/a/node_modules/shared": { resolved: "vendor/local", link: true }
+#[test]
+fn test_write_nests_a_member_local_dep_under_a_sibling_member_name() {
+    let local = LocalSource::Directory(PathBuf::from("vendor/local"));
+    let local_dp = local.dep_path("shared");
+    let mut graph = LockfileGraph::default();
+    graph.packages.insert(
+        local_dp.clone(),
+        LockedPackage {
+            name: "shared".to_string(),
+            version: "1.0.0".to_string(),
+            dep_path: local_dp.clone(),
+            local_source: Some(local),
+            ..Default::default()
+        },
+    );
+    graph.importers.insert(".".to_string(), vec![]);
+    graph.importers.insert(
+        "packages/a".to_string(),
+        vec![DirectDep {
+            name: "shared".to_string(),
+            dep_path: local_dp,
+            dep_type: DepType::Production,
+            specifier: Some("file:../../vendor/local".to_string()),
+        }],
+    );
+    // No `LocalSource::Link` package for either member: this is what a
+    // fresh resolve from package.json looks like.
+    graph.importers.insert("packages/z".to_string(), vec![]);
+
+    let manifest = aube_manifest::PackageJson {
+        name: Some("root".to_string()),
+        version: Some("1.0.0".to_string()),
+        ..Default::default()
+    };
+    let dir = tempfile::tempdir().unwrap();
+    for (d, n, v) in [
+        ("packages/a", "@w/a", "1.0.0"),
+        ("packages/z", "shared", "2.0.0"),
+    ] {
+        std::fs::create_dir_all(dir.path().join(d)).unwrap();
+        std::fs::write(
+            dir.path().join(d).join("package.json"),
+            format!(r#"{{"name":"{n}","version":"{v}"}}"#),
+        )
+        .unwrap();
+    }
+    let out = dir.path().join("package-lock.json");
+    write(&out, &graph, &manifest).unwrap();
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+    let packages = &doc["packages"];
+
+    assert_eq!(
+        packages["node_modules/shared"]["resolved"], "packages/z",
+        "the member named `shared` keeps the root alias, got {packages}"
+    );
+    assert_eq!(
+        packages["packages/a/node_modules/shared"]["resolved"], "vendor/local",
+        "a member name claims the root slot even when only the on-disk \
+         manifest knows it, so the sibling's link nests, got {packages}"
     );
 }
 

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -588,6 +588,124 @@ fn test_write_emits_file_dir_dep_as_link_pair() {
     assert_eq!(packages["node_modules/local-utils"]["link"], true);
 }
 
+/// A `link:` dep to a plain directory gets the SAME pair. npm has no
+/// separate encoding for it — a `file:` directory dep is already written
+/// as a link record — so the two differ only inside aube, where `Link`
+/// skips the virtual store.
+///
+/// Emitting nothing (the prior behavior) did not merely lose bytes: the
+/// importer parsed back with zero direct deps, so nub's own freshness
+/// check read the manifest's dep as newly added and failed every later
+/// `--frozen-lockfile` with `manifest adds local-utils@link:./local-pkg`
+/// — on a project nub itself had just installed. Reproduce with
+/// `nub add ./dep && nub install --frozen-lockfile`.
+#[test]
+fn test_write_emits_link_dir_dep_as_link_pair() {
+    let local = LocalSource::Link(PathBuf::from("./local-pkg"));
+    let dep_path = local.dep_path("local-utils");
+    let mut graph = LockfileGraph::default();
+    graph.packages.insert(
+        dep_path.clone(),
+        LockedPackage {
+            name: "local-utils".to_string(),
+            version: "1.0.0".to_string(),
+            dep_path: dep_path.clone(),
+            local_source: Some(local),
+            ..Default::default()
+        },
+    );
+    graph.importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "local-utils".to_string(),
+            dep_path,
+            dep_type: DepType::Production,
+            specifier: Some("link:./local-pkg".to_string()),
+        }],
+    );
+
+    let manifest = aube_manifest::PackageJson {
+        name: Some("test".to_string()),
+        version: Some("1.0.0".to_string()),
+        dependencies: [("local-utils".to_string(), "link:./local-pkg".to_string())]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    let out = tempfile::NamedTempFile::new().unwrap();
+    write(out.path(), &graph, &manifest).unwrap();
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.path()).unwrap()).unwrap();
+    let packages = &doc["packages"];
+
+    assert_eq!(packages["local-pkg"]["version"], "1.0.0");
+    assert_eq!(
+        packages["node_modules/local-utils"]["resolved"],
+        "local-pkg"
+    );
+    assert_eq!(packages["node_modules/local-utils"]["link"], true);
+}
+
+/// A workspace MEMBER is also reached as a `link:` — its target is an
+/// importer — so widening the link emitter must not change what a member
+/// serializes to. This pins that shape.
+///
+/// Honest about what it does NOT prove: the emitter's workspace guard is
+/// belt-and-braces rather than load-bearing. `emit_file_dep_links` runs
+/// BEFORE the workspace pass, which rewrites the same two keys and so
+/// wins regardless — with the guard deleted, this test and all 546 others
+/// in the crate still pass (measured). The guard states which pass owns a
+/// member instead of leaving it to that ordering, and this test gives a
+/// future reordering something to fail against.
+#[test]
+fn test_write_leaves_workspace_member_links_to_the_workspace_pass() {
+    let local = LocalSource::Link(PathBuf::from("packages/a"));
+    let dep_path = local.dep_path("@w/a");
+    let mut graph = LockfileGraph::default();
+    graph.packages.insert(
+        dep_path.clone(),
+        LockedPackage {
+            name: "@w/a".to_string(),
+            version: "1.0.0".to_string(),
+            dep_path: dep_path.clone(),
+            local_source: Some(local),
+            ..Default::default()
+        },
+    );
+    graph.importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "@w/a".to_string(),
+            dep_path,
+            dep_type: DepType::Production,
+            specifier: Some("*".to_string()),
+        }],
+    );
+    graph.importers.insert("packages/a".to_string(), vec![]);
+
+    let manifest = aube_manifest::PackageJson {
+        name: Some("root".to_string()),
+        version: Some("1.0.0".to_string()),
+        dependencies: [("@w/a".to_string(), "*".to_string())]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    let out = tempfile::NamedTempFile::new().unwrap();
+    write(out.path(), &graph, &manifest).unwrap();
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.path()).unwrap()).unwrap();
+    let packages = &doc["packages"];
+
+    // The member keeps the workspace pass's spelling — keyed by importer
+    // path — rather than a second, competing entry from the link emitter.
+    assert_eq!(packages["packages/a"]["name"], "@w/a");
+    assert_eq!(packages["node_modules/@w/a"]["resolved"], "packages/a");
+    assert_eq!(packages["node_modules/@w/a"]["link"], true);
+}
+
 #[test]
 fn test_parse_file_resolved_without_link() {
     // npm writes `resolved: "file:..."` without `link: true` for

--- a/vendor/aube/crates/aube-lockfile/src/npm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/write.rs
@@ -386,25 +386,10 @@ pub fn write(
     // dropped entirely. `npm ci` then rejects the lockfile with
     // `Missing: <name>@<version> from lock file`. Emit the pair here.
     //
-    // Every name that will end up owning a root `node_modules/<name>`
-    // entry, gathered BEFORE anything is written: the root importer's own
-    // direct deps (which hoist there) and every workspace member (linked
-    // there by the member pass). A member's local link consults this to
-    // decide root-vs-nested, because the passes that claim those slots run
-    // after it and would otherwise overwrite the link silently.
-    let root_claimed: std::collections::BTreeSet<&str> = roots
-        .iter()
-        .map(|d| d.name.as_str())
-        .chain(
-            graph
-                .importers
-                .keys()
-                .filter(|p| p.as_str() != ".")
-                .filter_map(|p| workspace_package_for_importer(graph, p))
-                .map(|pkg| pkg.name.as_str()),
-        )
-        .collect();
-    emit_file_dep_links(graph, &roots, ".", &root_claimed, &mut packages);
+    // The root importer's own local deps always take the root slot, so
+    // they need no reservation set; the members' do, and theirs is built
+    // below once the member identities are known.
+    emit_file_dep_links(graph, &roots, ".", &Default::default(), &mut packages);
 
     // Resolve each workspace member's identity (name/version/peers).
     // A `LocalSource::Link` package exists only when the graph was
@@ -433,6 +418,52 @@ pub fn write(
             (p.as_str(), m)
         })
         .collect();
+
+    // Every name that will end up owning a root `node_modules/<name>`
+    // entry, gathered before the member loop writes anything: each
+    // top-level hoist placement, and each workspace member, which the
+    // loop links at the root. A member's local link consults this to
+    // decide root-vs-nested, because both of those passes serialize
+    // AFTER it and would otherwise overwrite the link — leaving the dep
+    // with orphaned metadata and no link node anywhere.
+    //
+    // Read off `placed` rather than recomputed from the root importer's
+    // direct deps: `placed` IS the hoist tree's own answer to what lands
+    // at the top level, so a TRANSITIVE that hoists there is covered by
+    // construction. Enumerating direct deps missed exactly those — root
+    // depending on `outer`, which pulls `shared@2`, alongside a member's
+    // `shared = file:../local`, silently dropped the member's link. The
+    // loop below grows `placed`, but only with `<importer>/node_modules/…`
+    // keys, so reading it here already sees the whole top level.
+    //
+    // Member names come from the same two sources the loop itself uses: a
+    // `LocalSource::Link` package when the graph was READ from a
+    // lockfile, and the on-disk manifest when it was freshly resolved.
+    // Consulting only the former missed every member on a fresh resolve,
+    // which is the common case.
+    let root_claimed: BTreeSet<String> = placed
+        .keys()
+        .filter_map(|install_path| install_path.strip_prefix("node_modules/"))
+        .filter(|name| !name.contains("/node_modules/"))
+        .map(str::to_string)
+        .chain(
+            graph
+                .importers
+                .keys()
+                .filter(|p| p.as_str() != ".")
+                .filter_map(|p| {
+                    workspace_package_for_importer(graph, p)
+                        .map(|pkg| pkg.name.as_str())
+                        .or_else(|| {
+                            member_manifests
+                                .get(p.as_str())
+                                .and_then(|m| m.name.as_deref())
+                        })
+                })
+                .map(str::to_string),
+        )
+        .collect();
+
     for (importer_path, importer_roots) in graph.importers.iter().filter(|(path, _)| *path != ".") {
         let linked = workspace_package_for_importer(graph, importer_path);
         let disk_manifest = member_manifests.get(importer_path.as_str());
@@ -783,7 +814,7 @@ fn emit_file_dep_links<'a>(
     graph: &'a LockfileGraph,
     roots: &[DirectDep],
     importer_path: &str,
-    root_claimed: &std::collections::BTreeSet<&str>,
+    root_claimed: &BTreeSet<String>,
     packages: &mut BTreeMap<String, WriteNpmPackage<'a>>,
 ) {
     for dep in roots {
@@ -814,7 +845,7 @@ fn emit_file_dep_links<'a>(
         // npm hoists the first target to the root and NESTS a conflicting
         // one under the importer that wants it, which is the only way the
         // format can express two members depending on the same NAME at
-        // different paths. Measured, npm 10, members `a`→`vendor/one` and
+        // different paths. Measured, npm 11.19.0, members `a`→`vendor/one` and
         // `b`→`vendor/two`:
         //
         //     "node_modules/shared":            { resolved: "vendor/one" }
@@ -832,8 +863,8 @@ fn emit_file_dep_links<'a>(
         // that — the link went to root while the slot looked free, the
         // later hoist pass overwrote it, and the member's link vanished
         // from the lockfile entirely rather than merely moving. Hence
-        // `root_claimed`, computed up front from every name that will own
-        // a root entry. Measured, npm 10:
+        // `root_claimed`, read off the hoist tree's own top level plus the
+        // member roster before either pass runs. Measured, npm 11.19.0:
         //
         //     "node_modules/shared":                 <the registry package>
         //     "packages/app/node_modules/shared":    { resolved: "vendor/local" }
@@ -876,7 +907,7 @@ fn emit_file_dep_links<'a>(
 /// result was a doubled prefix: a member `packages/app` declaring
 /// `file:../../vendor/local-pkg` was keyed `packages/app/vendor/local-pkg`,
 /// a path matching nothing on disk, where npm writes `vendor/local-pkg`
-/// (measured, npm 10). Root importers were unaffected, which is why it
+/// (measured, npm 11.19.0). Root importers were unaffected, which is why it
 /// went unnoticed.
 fn npm_file_dep_path(path_posix: &str) -> String {
     path_posix

--- a/vendor/aube/crates/aube-lockfile/src/npm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/write.rs
@@ -57,6 +57,15 @@ struct WriteNpmPackage<'a> {
     os: Vec<String>,
     cpu: Vec<String>,
     libc: Vec<String>,
+    /// Root importer only. npm mirrors the manifest's `workspaces` into
+    /// `packages[""]` and copies it VERBATIM rather than normalizing it,
+    /// so this borrows the parsed value instead of flattening to
+    /// `patterns()`: an array stays an array and bun's object form stays
+    /// an object, which is what npm writes back (measured, npm 11.19.0).
+    /// The third form aube parses, a bare `"workspaces": "packages/*"`,
+    /// has no npm spelling to match — npm rejects that manifest outright
+    /// (`npm install` exits 1), so nothing it produces can diverge.
+    workspaces: Option<&'a aube_manifest::Workspaces>,
     funding: Option<WriteNpmFunding<'a>>,
     link: bool,
     dev: bool,
@@ -159,6 +168,22 @@ impl Serialize for WriteNpmPackage<'_> {
         if !self.os.is_empty() {
             map.serialize_entry("os", &self.os)?;
         }
+        // `workspaces` is the one key whose BUCKET depends on its value,
+        // because `json-stringify-nice` sorts on the runtime type and npm
+        // copies this field through verbatim. The usual array form is a
+        // non-object, so it sorts here, last among the scalars after `os`
+        // — npm writes `name, version, license, workspaces, dependencies`.
+        // Bun's object form sorts with the object keys instead, last
+        // again: npm writes `… dependencies, engines, workspaces`. Both
+        // measured, npm 11.19.0. A bare string has no npm spelling to
+        // match (npm rejects that manifest), and is a non-object, so it
+        // rides with the array.
+        if let Some(
+            v @ (aube_manifest::Workspaces::Array(_) | aube_manifest::Workspaces::String(_)),
+        ) = self.workspaces
+        {
+            map.serialize_entry("workspaces", v)?;
+        }
 
         // --- object keys ---
         // preferred (swKeyOrder): dependencies
@@ -188,6 +213,11 @@ impl Serialize for WriteNpmPackage<'_> {
         }
         if !self.peer_dependencies_meta.is_empty() {
             map.serialize_entry("peerDependenciesMeta", &self.peer_dependencies_meta)?;
+        }
+        // The object half of the split described above — `workspaces`
+        // sorts alphabetically among the object keys, i.e. last.
+        if let Some(v @ aube_manifest::Workspaces::Object { .. }) = self.workspaces {
+            map.serialize_entry("workspaces", v)?;
         }
 
         map.end()
@@ -372,6 +402,7 @@ pub fn write(
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect(),
+            workspaces: manifest.workspaces.as_ref(),
             ..Default::default()
         },
     );

--- a/vendor/aube/crates/aube-lockfile/src/npm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/write.rs
@@ -385,7 +385,26 @@ pub fn write(
     // so the canonical-map lookup misses and the package would otherwise be
     // dropped entirely. `npm ci` then rejects the lockfile with
     // `Missing: <name>@<version> from lock file`. Emit the pair here.
-    emit_file_dep_links(graph, &roots, ".", &mut packages);
+    //
+    // Every name that will end up owning a root `node_modules/<name>`
+    // entry, gathered BEFORE anything is written: the root importer's own
+    // direct deps (which hoist there) and every workspace member (linked
+    // there by the member pass). A member's local link consults this to
+    // decide root-vs-nested, because the passes that claim those slots run
+    // after it and would otherwise overwrite the link silently.
+    let root_claimed: std::collections::BTreeSet<&str> = roots
+        .iter()
+        .map(|d| d.name.as_str())
+        .chain(
+            graph
+                .importers
+                .keys()
+                .filter(|p| p.as_str() != ".")
+                .filter_map(|p| workspace_package_for_importer(graph, p))
+                .map(|pkg| pkg.name.as_str()),
+        )
+        .collect();
+    emit_file_dep_links(graph, &roots, ".", &root_claimed, &mut packages);
 
     // Resolve each workspace member's identity (name/version/peers).
     // A `LocalSource::Link` package exists only when the graph was
@@ -465,7 +484,13 @@ pub fn write(
             },
         );
 
-        emit_file_dep_links(graph, importer_roots, importer_path, &mut packages);
+        emit_file_dep_links(
+            graph,
+            importer_roots,
+            importer_path,
+            &root_claimed,
+            &mut packages,
+        );
 
         let workspace_tree_roots = non_link_roots(graph, importer_roots);
         let workspace_tree = super::build_hoist_tree(&canonical, &workspace_tree_roots);
@@ -758,6 +783,7 @@ fn emit_file_dep_links<'a>(
     graph: &'a LockfileGraph,
     roots: &[DirectDep],
     importer_path: &str,
+    root_claimed: &std::collections::BTreeSet<&str>,
     packages: &mut BTreeMap<String, WriteNpmPackage<'a>>,
 ) {
     for dep in roots {
@@ -798,16 +824,29 @@ fn emit_file_dep_links<'a>(
         // writer win, so `a` silently resolved to `b`'s package — no error,
         // a wrong module. Take the root slot only if it is free or already
         // points at this exact target; otherwise nest.
+        //
+        // `packages` alone cannot answer that, because it is still being
+        // built: the hoist tree and the workspace pass both serialize AFTER
+        // this one and can claim the same root alias. A root registry dep
+        // aliased `shared` plus a member's `shared = file:…` hit exactly
+        // that — the link went to root while the slot looked free, the
+        // later hoist pass overwrote it, and the member's link vanished
+        // from the lockfile entirely rather than merely moving. Hence
+        // `root_claimed`, computed up front from every name that will own
+        // a root entry. Measured, npm 10:
+        //
+        //     "node_modules/shared":                 <the registry package>
+        //     "packages/app/node_modules/shared":    { resolved: "vendor/local" }
+        let is_root_importer = importer_path == "." || importer_path.is_empty();
         let root_key = format!("node_modules/{}", dep.name);
-        let key = match packages.get(&root_key) {
-            Some(existing) if existing.resolved.as_deref() != Some(resolved.as_str()) => {
-                if importer_path == "." || importer_path.is_empty() {
-                    root_key
-                } else {
-                    format!("{importer_path}/node_modules/{}", dep.name)
-                }
-            }
-            _ => root_key,
+        let taken_by_other = match packages.get(&root_key) {
+            Some(existing) => existing.resolved.as_deref() != Some(resolved.as_str()),
+            None => !is_root_importer && root_claimed.contains(dep.name.as_str()),
+        };
+        let key = if taken_by_other && !is_root_importer {
+            format!("{importer_path}/node_modules/{}", dep.name)
+        } else {
+            root_key
         };
         packages.insert(
             key,

--- a/vendor/aube/crates/aube-lockfile/src/npm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/write.rs
@@ -695,10 +695,10 @@ fn non_link_roots(graph: &LockfileGraph, roots: &[DirectDep]) -> Vec<DirectDep> 
     roots
         .iter()
         .filter(|dep| {
-            // `Link` deps are pure symlinks (no virtual-store node), and
-            // `Directory`/`Tarball` `file:` deps are emitted out of band by
-            // `emit_file_dep_links` as npm's `link: true` pair — neither
-            // belongs in the hoisted `name@version` tree.
+            // All three are emitted out of band by `emit_file_dep_links`
+            // as npm's `link: true` pair, and `Link` additionally has no
+            // virtual-store node at all — so none of them belongs in the
+            // hoisted `name@version` tree.
             !graph.packages.get(&dep.dep_path).is_some_and(|pkg| {
                 matches!(
                     pkg.local_source,
@@ -724,10 +724,36 @@ fn non_link_roots(graph: &LockfileGraph, roots: &[DirectDep]) -> Vec<DirectDep> 
 /// prefix and a leading `./`, but keeps `../` parent climbs), carries
 /// only `name`/`version`, and is what `npm ci` validates the root
 /// `dependencies` entry against. The second is the `node_modules/<name>`
-/// symlink record pointing back at that path. `LocalSource::Link`
-/// (`link:` deps and workspace members) is handled separately — npm
-/// links those too but the importer/workspace machinery already emits
-/// their pair, so this only covers `file:` directory and tarball deps.
+/// symlink record pointing back at that path.
+///
+/// `LocalSource::Link` gets the SAME pair, with one exception. npm has no
+/// separate encoding for `link:` — a `file:` directory dependency is
+/// already written as a link record — so the two only differ inside aube,
+/// where `Link` skips the virtual store. The exception is a workspace
+/// MEMBER, which is also a `Link` but whose pair the importer/workspace
+/// pass below owns. A member is exactly a link whose TARGET is an
+/// importer, so ask `graph.importers` directly.
+///
+/// That guard is belt-and-braces, not load-bearing, and the comment says
+/// so rather than implying a correctness dependency that does not exist:
+/// this function runs BEFORE the workspace pass, which rewrites the same
+/// two keys and wins on ordering alone — deleting the guard leaves the
+/// whole crate's tests green (measured). It is here to state which pass
+/// owns a member instead of resting that on pass order.
+///
+/// Not `workspace_package_for_importer`: that asks "is there a package
+/// linking AT this path", which a plain `link:` dep answers about
+/// ITSELF — it is the package linking at its own target — so using it
+/// here silently skips every dep this function exists to emit.
+///
+/// This function used to take `Directory`/`Tarball` only, on the stated
+/// grounds that "the importer/workspace machinery already emits their
+/// pair" for every `Link`. That is true of a workspace member and false
+/// of a `link:` to a plain directory, which has no importer entry at all
+/// — so nothing emitted it, `non_link_roots` also kept it out of the
+/// hoist tree, and it vanished from the lockfile. nub's own freshness
+/// check then read the importer as having zero direct deps and failed
+/// every later `--frozen-lockfile` with `manifest adds <name>@link:…`.
 fn emit_file_dep_links<'a>(
     graph: &'a LockfileGraph,
     roots: &[DirectDep],
@@ -739,9 +765,15 @@ fn emit_file_dep_links<'a>(
             continue;
         };
         let resolved = match &pkg.local_source {
-            Some(local @ (LocalSource::Directory(_) | LocalSource::Tarball(_))) => {
-                npm_file_dep_path(importer_path, &local.path_posix())
+            Some(LocalSource::Link(path))
+                if graph.importers.contains_key(&*path.to_string_lossy()) =>
+            {
+                continue;
             }
+            Some(
+                local
+                @ (LocalSource::Directory(_) | LocalSource::Tarball(_) | LocalSource::Link(_)),
+            ) => npm_file_dep_path(importer_path, &local.path_posix()),
             _ => continue,
         };
         packages.insert(

--- a/vendor/aube/crates/aube-lockfile/src/npm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/write.rs
@@ -773,7 +773,7 @@ fn emit_file_dep_links<'a>(
             Some(
                 local
                 @ (LocalSource::Directory(_) | LocalSource::Tarball(_) | LocalSource::Link(_)),
-            ) => npm_file_dep_path(importer_path, &local.path_posix()),
+            ) => npm_file_dep_path(&local.path_posix()),
             _ => continue,
         };
         packages.insert(
@@ -784,8 +784,33 @@ fn emit_file_dep_links<'a>(
                 ..Default::default()
             },
         );
+
+        // npm hoists the first target to the root and NESTS a conflicting
+        // one under the importer that wants it, which is the only way the
+        // format can express two members depending on the same NAME at
+        // different paths. Measured, npm 10, members `a`→`vendor/one` and
+        // `b`→`vendor/two`:
+        //
+        //     "node_modules/shared":            { resolved: "vendor/one" }
+        //     "packages/b/node_modules/shared": { resolved: "vendor/two" }
+        //
+        // Keying every link at the root unconditionally made the last
+        // writer win, so `a` silently resolved to `b`'s package — no error,
+        // a wrong module. Take the root slot only if it is free or already
+        // points at this exact target; otherwise nest.
+        let root_key = format!("node_modules/{}", dep.name);
+        let key = match packages.get(&root_key) {
+            Some(existing) if existing.resolved.as_deref() != Some(resolved.as_str()) => {
+                if importer_path == "." || importer_path.is_empty() {
+                    root_key
+                } else {
+                    format!("{importer_path}/node_modules/{}", dep.name)
+                }
+            }
+            _ => root_key,
+        };
         packages.insert(
-            format!("node_modules/{}", dep.name),
+            key,
             WriteNpmPackage {
                 resolved: Some(resolved),
                 link: true,
@@ -795,19 +820,30 @@ fn emit_file_dep_links<'a>(
     }
 }
 
-/// Render the lockfile path key for a `file:` dep's package entry the
-/// way npm does: drop a leading `./` (npm normalizes `file:./local-pkg`
-/// to `local-pkg`) but preserve `../` climbs verbatim
-/// (`file:../sib` → `../sib`). For a non-root importer the stored path is
-/// importer-relative, so re-anchor it to the project root the way npm's
-/// keys are project-relative.
-fn npm_file_dep_path(importer_path: &str, path_posix: &str) -> String {
-    let normalized = path_posix.strip_prefix("./").unwrap_or(path_posix);
-    if importer_path == "." || importer_path.is_empty() {
-        normalized.to_string()
-    } else {
-        format!("{importer_path}/{normalized}")
-    }
+/// Render the lockfile path key for a local dep's package entry the way
+/// npm does: drop a leading `./` (npm normalizes `file:./local-pkg` to
+/// `local-pkg`) but preserve `../` climbs verbatim (`file:../sib` →
+/// `../sib`).
+///
+/// The path arrives PROJECT-ROOT-relative whichever importer declared
+/// it — `aube_resolver::local_source::rebase_local` rewrites every
+/// variant that way precisely so downstream code can resolve it with one
+/// `project_root.join(rel)` — and npm's keys are project-root-relative
+/// too, so the two frames already agree and nothing needs re-anchoring.
+///
+/// This used to take an `importer_path` and prepend it, on the stated
+/// belief that "for a non-root importer the stored path is
+/// importer-relative". That belief contradicted `rebase_local`, and the
+/// result was a doubled prefix: a member `packages/app` declaring
+/// `file:../../vendor/local-pkg` was keyed `packages/app/vendor/local-pkg`,
+/// a path matching nothing on disk, where npm writes `vendor/local-pkg`
+/// (measured, npm 10). Root importers were unaffected, which is why it
+/// went unnoticed.
+fn npm_file_dep_path(path_posix: &str) -> String {
+    path_posix
+        .strip_prefix("./")
+        .unwrap_or(path_posix)
+        .to_string()
 }
 
 type DepSections<'a> = (

--- a/vendor/aube/crates/aube-manifest/src/lib.rs
+++ b/vendor/aube/crates/aube-manifest/src/lib.rs
@@ -303,24 +303,32 @@ pub enum Workspaces {
         // includes `packages`, so this doesn't lock out the catalog use
         // case.
         packages: Vec<String>,
-        // Skipped when empty so serializing this value back out
-        // reproduces what was read. npm copies a manifest's `workspaces`
-        // verbatim into `packages[""]` of `package-lock.json`, and an
-        // object form authored without `nohoist` comes back without it
-        // (measured, npm 11.19.0) — emitting `"nohoist": []` would be a
-        // key npm never wrote. An absent list and an empty one mean the
-        // same thing, so nothing is lost.
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        nohoist: Vec<String>,
+        // The three optional fields below are PRESENCE-AWARE — `Option`
+        // around an already-emptiable collection — because npm copies a
+        // manifest's `workspaces` verbatim into `packages[""]` of
+        // `package-lock.json` and so distinguishes a field that was never
+        // authored from one authored empty. Measured, npm 11.19.0:
+        // `{"packages":[…]}` comes back without `nohoist`, and
+        // `{"packages":[…],"nohoist":[]}` comes back WITH `"nohoist": []`.
+        //
+        // Collapsing the two (a bare `Vec` plus `skip_serializing_if`)
+        // reproduces the absent case and silently drops the empty one, so
+        // a project authoring `"nohoist": []` churned that key out of its
+        // lockfile on every alternating npm/nub install. `Option` is what
+        // makes the round-trip faithful in both directions; the accessors
+        // below still hand out an empty collection either way, so no
+        // caller has to care which it was.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        nohoist: Option<Vec<String>>,
         /// Bun-style default catalog nested under `workspaces.catalog`.
         /// Aube reads it in addition to `pnpm-workspace.yaml`'s `catalog:`
         /// so bun projects that migrated config into package.json keep
         /// working.
-        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-        catalog: BTreeMap<String, String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        catalog: Option<BTreeMap<String, String>>,
         /// Bun-style named catalogs nested under `workspaces.catalogs`.
-        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-        catalogs: BTreeMap<String, BTreeMap<String, String>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        catalogs: Option<BTreeMap<String, BTreeMap<String, String>>>,
     },
 }
 
@@ -339,7 +347,12 @@ impl Workspaces {
         static EMPTY: std::sync::OnceLock<BTreeMap<String, String>> = std::sync::OnceLock::new();
         match self {
             Workspaces::String(_) | Workspaces::Array(_) => EMPTY.get_or_init(BTreeMap::new),
-            Workspaces::Object { catalog, .. } => catalog,
+            // An authored-empty catalog and an absent one are the same
+            // thing to a caller; only the serializer needs to tell them
+            // apart, to copy npm's verbatim round-trip.
+            Workspaces::Object { catalog, .. } => catalog
+                .as_ref()
+                .unwrap_or_else(|| EMPTY.get_or_init(BTreeMap::new)),
         }
     }
 
@@ -349,7 +362,9 @@ impl Workspaces {
             std::sync::OnceLock::new();
         match self {
             Workspaces::String(_) | Workspaces::Array(_) => EMPTY.get_or_init(BTreeMap::new),
-            Workspaces::Object { catalogs, .. } => catalogs,
+            Workspaces::Object { catalogs, .. } => catalogs
+                .as_ref()
+                .unwrap_or_else(|| EMPTY.get_or_init(BTreeMap::new)),
         }
     }
 }

--- a/vendor/aube/crates/aube-manifest/src/lib.rs
+++ b/vendor/aube/crates/aube-manifest/src/lib.rs
@@ -303,7 +303,14 @@ pub enum Workspaces {
         // includes `packages`, so this doesn't lock out the catalog use
         // case.
         packages: Vec<String>,
-        #[serde(default)]
+        // Skipped when empty so serializing this value back out
+        // reproduces what was read. npm copies a manifest's `workspaces`
+        // verbatim into `packages[""]` of `package-lock.json`, and an
+        // object form authored without `nohoist` comes back without it
+        // (measured, npm 11.19.0) — emitting `"nohoist": []` would be a
+        // key npm never wrote. An absent list and an empty one mean the
+        // same thing, so nothing is lost.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         nohoist: Vec<String>,
         /// Bun-style default catalog nested under `workspaces.catalog`.
         /// Aube reads it in addition to `pnpm-workspace.yaml`'s `catalog:`


### PR DESCRIPTION
`nub add ./dep` writes `link:./dep`, and the npm lockfile writer recorded only the root importer entry. The freshness check reads a dep's specifier off the `node_modules/<name>` node, so the importer parsed back empty and frozen installs failed with `manifest adds dep@link:./dep`.

npm has no separate `link:` encoding — a `file:` dir dep is written as a link record — so `emit_file_dep_links` already built the right pair and skipped only that variant. The pnpm writer was fine.

Widen the match to `LocalSource::Link`, skipping links whose target is an importer so the workspace pass keeps members.

`file:`, workspace and `../` output unchanged. aube 3006, nub-cli 1090, clippy/fmt clean.

Refs #755.
