### PR TITLE
docs: de-slop pass over the docs site

### DIFF
--- a/site/content/blog/introducing-nub.mdx
+++ b/site/content/blog/introducing-nub.mdx
@@ -512,7 +512,7 @@ Remove Nub tomorrow and your code keeps working, unchanged.
 ## FAQ
 
 - [Is it faster than Node.js?](/docs/faq#is-it-faster-than-nodejs)
-- [Why not just use Node's built-in TypeScript support?](/docs/faq#why-not-just-use-nodes-built-in-typescript-support)
+- [Why not Node's built-in TypeScript support?](/docs/faq#why-not-nodes-built-in-typescript-support)
 - [Why hasn't anyone else done this?](/docs/faq#why-hasnt-anyone-else-done-this)
 - [Is Nub a replacement for Node?](/docs/faq#is-nub-a-replacement-for-node)
 - [What can I stop using once I install Nub?](/docs/faq#what-npm-packages-can-i-stop-using-once-i-install-nub)

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -74,7 +74,7 @@ The global file is read leniently, because it applies to every project on your m
 
 Four fields take paths: [`preload`](#preload), [`envFile`](#envfile), [`tsconfig`](#tsconfig), and [`nodeExecutable`](#nodeexecutable) in its path form. A relative path resolves against the directory of the file that set it — not your working directory.
 
-For a project `nub.jsonc` that is the directory the file sits in — in a monorepo, wherever the nearest one lives, which need not be the package you are running from. For the global file it is your config directory, which is where the rule starts to surprise people.
+For a project `nub.jsonc` that is the directory the file sits in — in a monorepo, wherever the nearest one lives, which need not be the package you are running from. For the global file it is your config directory.
 
 ```jsonc title="~/.config/nub/nub.jsonc"
 {
@@ -92,7 +92,7 @@ For a global path, write it absolute or lead with `~/`.
 }
 ```
 
-Project-relative paths belong in the project file; a global path cannot mean "each project's own directory".
+A global path cannot refer to each project's own directory; those paths go in the project file.
 
 ## JSON Schema
 
@@ -109,12 +109,12 @@ Schemas are served from `https://nubjs.com/schema/`:
 
 | URL | Role |
 | --- | --- |
-| [`latest.json`](https://nubjs.com/schema/latest.json) | Rolling — always matches the newest release; new fields show up in the schema as they ship |
-| `https://nubjs.com/schema/v0.7.json` | Pinned to the `0.7` minor series — use when you want the schema to stop drifting under a checkout |
+| [`latest.json`](https://nubjs.com/schema/latest.json) | Rolling — matches the newest release |
+| `https://nubjs.com/schema/v0.7.json` | Pinned to the `0.7` minor series |
 
 Each minor series gets one file (`v0.6.json`, `v0.7.json`, …). On every release bump Nub snapshots the rolling schema into that series' file; patch releases within `0.7.x` keep rewriting `v0.7.json` only when the published field surface changes. Older series stay published for long-lived branches. The [schema index](/schema) lists every file on disk.
 
-The `$schema` key is read by editors only, never by Nub.
+Only editors read the `$schema` key.
 
 ## Runtime
 

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -305,7 +305,7 @@ Paths expand `${VAR}` and `$VAR` against the environment, which a config file ne
 APP_ENV=staging nub app.ts   # reads .env and .env.staging
 ```
 
-Setting `envFile` takes precedence over [Varlock](/docs/runtime/varlock). A `.env.schema` file is a signal Nub infers ownership from; an `envFile` value is a project stating what it wants, so the value wins and Varlock stays out of the chain. The `--env-file` and `--no-env-file` flags do the same.
+Setting `envFile` takes precedence over [Varlock](/docs/runtime/varlock): a `.env.schema` is an inferred signal, and an explicit `envFile` value outranks it, so Varlock stays out of the chain. The `--env-file` and `--no-env-file` flags do the same.
 
 This holds at every scope, your global config included. A `.env.schema` decides the environment only when nothing else does, so setting `envFile` globally reaches into schema projects too.
 

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -62,19 +62,19 @@ Every setting resolves through the same chain, most specific first:
 - **Global `nub.jsonc`** — the same field, for personal defaults everywhere
 - **Built-in default**
 
-Both files take the same fields, except [`dlx`](#dlx), which is global-only. Run `nub config path` to print the global file Nub will actually read, resolved in this order:
+Both files take the same fields, except [`dlx`](#dlx), which is global-only. Run `nub config path` to print the global file Nub reads, resolved in this order:
 
 - `$XDG_CONFIG_HOME/nub/nub.jsonc` — when that variable is set
 - `~/.config/nub/nub.jsonc` — every platform, Windows included
 - `%APPDATA%\nub\nub.jsonc` — Windows service and `SYSTEM` accounts, whose profile lives under the system root
 
-The global file is read leniently, because it applies to every project on your machine: an unrecognized section is ignored, and a bad value skips the whole file rather than failing the command. Only the project file, which is checked in and shared, fails loud.
+The global file is read leniently, because it applies to every project on your machine: an unrecognized section is ignored, and a bad value skips the whole file rather than failing the command. Only the project file, which is checked in and shared, fails.
 
 ### Relative paths
 
 Four fields take paths: [`preload`](#preload), [`envFile`](#envfile), [`tsconfig`](#tsconfig), and [`nodeExecutable`](#nodeexecutable) in its path form. A relative path resolves against the directory of the file that set it — not your working directory.
 
-For a project `nub.jsonc` that is the directory the file sits in — in a monorepo, wherever the nearest one lives, which need not be the package you are running from. For the global file it is your config directory.
+For a project `nub.jsonc` that is the file's own directory — in a monorepo, wherever the nearest one is, which need not be the package you are running from. For the global file it is your config directory.
 
 ```jsonc title="~/.config/nub/nub.jsonc"
 {
@@ -221,7 +221,7 @@ Use plain Node behavior while keeping Nub's Node version selection.
 }
 ```
 
-This is the project-wide form of the `--node` escape hatch. Nub does not load its runtime hooks, environment files, preloads, custom loaders, or conditions.
+This is the project-wide form of the `--node` flag. Nub does not load its runtime hooks, environment files, preloads, custom loaders, or conditions.
 
 ### `nodeExecutable`
 
@@ -235,11 +235,11 @@ Name the Node binary to run, instead of letting Nub resolve a version.
 }
 ```
 
-The command runs through the platform shell (`sh -c`, or `cmd /C` on Windows) in your working directory, so a directory-aware tool answers for the project you are actually in — mise, asdf, fnm, Volta, or a wrapper script of your own. A non-zero exit stops the run and reports that tool's error, rather than falling back to a download.
+The command runs through the platform shell (`sh -c`, or `cmd /C` on Windows) in your working directory, so a directory-aware tool (mise, asdf, fnm, Volta, or a wrapper script) resolves the version for that directory. A non-zero exit stops the run and reports that tool's error, rather than falling back to a download.
 
-To ignore the project's pins and take whatever Node comes first on `PATH`, ask the shell for it — `"$(which node)"`, or `"$(where node)"` on Windows. Only the first line of output is read, so a tool that lists every match still names one binary.
+To ignore the project's pins and take the first Node on `PATH`, use `"$(which node)"`, or `"$(where node)"` on Windows. Only the first line of output is read, so a tool that lists every match still names one binary.
 
-A path works too, absolute or relative to the file:
+A path is also accepted, absolute or relative to the file:
 
 ```jsonc title="nub.jsonc"
 {
@@ -248,7 +248,7 @@ A path works too, absolute or relative to the file:
 }
 ```
 
-Either form bypasses the [pin sources](/docs/node#which-version-is-pinned), Nub's cache, and any download. The binary's version is still detected, so the [floor and tier selection](/docs/runtime#supported-versions-and-tiers) still apply, and Nub warns when that version contradicts a pin the project also declares. The `NODE_EXECUTABLE` environment variable is the per-shell form of the same setting and outranks this field.
+Either form bypasses the [pin sources](/docs/node#pin-sources), Nub's cache, and any download. The binary's version is still detected, so the [floor and tier selection](/docs/runtime#supported-versions-and-tiers) still apply, and Nub warns when that version contradicts a pin the project also declares. The `NODE_EXECUTABLE` environment variable is the per-shell form of the same setting and outranks this field.
 
 ### `envFile`
 
@@ -320,7 +320,7 @@ Hand the environment to Varlock explicitly with `"varlock"`. That is how a proje
 
 ### `loader`
 
-Teach Nub an extension it does not already know, by mapping it onto a loader it has.
+Map an extension Nub does not handle onto one of its loaders.
 
 ```jsonc title="nub.jsonc"
 {
@@ -348,7 +348,7 @@ tsx
 jsx
 ```
 
-An entry may also point an extension Nub already knows at something else — `".ts": "text"` imports TypeScript sources as strings, and `".ts": "tsx"` turns JSX on for them. One pairing is rejected: `ts` on `.tsx` or `.jsx`. Those extensions are always parsed as JSX, so the entry could not take effect.
+An entry may also point an extension Nub already handles at something else — `".ts": "text"` imports TypeScript sources as strings, and `".ts": "tsx"` turns JSX on for them. One pairing is rejected: `ts` on `.tsx` or `.jsx`. Those extensions are always parsed as JSX, so the entry could not take effect.
 
 ### `verifyDeps`
 
@@ -547,9 +547,9 @@ Two strategies take an extra key, written in the object form: `global-virtual-st
 }
 ```
 
-Ejected packages are written into the project as real directories instead of linked out of the shared store. Reach for it when a package resolves paths relative to its own location on disk, which native builds and self-extracting binaries tend to do.
+Ejected packages are written into the project as real directories instead of linked out of the shared store. Use it for a package that resolves paths relative to its own location on disk, as native builds and self-extracting binaries do.
 
-This list **adds to** the set Nub already ejects — the packages known to break when their real path sits outside the project. It cannot shrink that set, so `"eject": []` leaves the built-in list in force rather than turning ejection off.
+This list **adds to** the set Nub already ejects — the packages known to break when their real path is outside the project. It cannot shrink that set, so `"eject": []` leaves the built-in list in force rather than turning ejection off.
 
 Under `isolated`, `hoist` fills the hidden fallback tree that your dependencies reach when they import something they never declared. It takes `true`, `false`, or a list.
 
@@ -567,14 +567,14 @@ Under `isolated`, `hoist` fills the hidden fallback tree that your dependencies 
 
 Setting `false` is strict: an undeclared import fails instead of resolving. Setting `true` matches everything, which is pnpm's default.
 
-Writing a knob under the wrong strategy is an error, and the message names the strategy that takes it.
+Writing a key under the wrong strategy is an error, and the message names the strategy that takes it.
 
 ```text
 `install.linker.hoist` in nub.jsonc: not valid with `strategy: "global-virtual-store"` — it
 configures the "isolated" layout. Either switch to `strategy: "isolated"` or drop this key.
 ```
 
-The strategy `"pnp"` is reserved for future Plug'n'Play support. An install that names it is rejected until support lands.
+The strategy `"pnp"` is reserved for future Plug'n'Play support. An install that names it is rejected until support ships.
 
 ```text
 nub: `install.linker: "pnp"` is reserved and not supported yet [ERR_NUB_CONFIG_UNSUPPORTED]
@@ -608,7 +608,7 @@ A single `*` lifts everything, matching pnpm's `shamefully-hoist`. Every package
 }
 ```
 
-The field sits outside `linker` because it writes the project's own `node_modules`, which exists under every strategy.
+The field is outside `linker` because it writes the project's own `node_modules`, which exists under every strategy.
 
 ### `install.minimumReleaseAge`
 
@@ -682,11 +682,11 @@ Disable implicit registry fetches.
 }
 ```
 
-Explicit `nub dlx` runs still work because the command itself supplies consent.
+Explicit `nub dlx` runs are unaffected; the command itself supplies consent.
 
 ## `nub config`
 
-Create a commented project file with every supported project field. Only the schema URL is active. Run it from anywhere in a workspace and the file lands at the workspace root, which every member reads.
+Create a commented project file with every supported project field. Only the schema URL is active. Run it from anywhere in a workspace and the file is written at the workspace root, which every member reads.
 
 ```bash
 nub config init
@@ -747,7 +747,7 @@ nub config get preload --json       # ["./setup.ts","tsx/esm"]
 
 A key that is not a field of this file reads and writes `.npmrc`, so the value stays visible to npm, Yarn, and pnpm. Nub picks whichever file will read the key back, so under a pnpm 11 project the settings pnpm moved out of `.npmrc` are written to `pnpm-workspace.yaml` instead. Registry and auth keys stay in `.npmrc` on every project.
 
-Nub refuses a key it would never read back rather than writing a line nothing consults, and names the surface that works instead. Two kinds hit this: a setting only the underlying engine's own CLI acts on, and a setting `.npmrc` has no spelling for.
+Nub refuses a key it would never read back rather than writing a line nothing consults, and names the surface that works instead. Two kinds are refused: a setting only the underlying engine's own CLI acts on, and a setting `.npmrc` has no spelling for.
 
 ```text
 $ nub config set updateNotifier false
@@ -757,7 +757,7 @@ Error: nub config set updateNotifier: `updateNotifier` is not a nub setting
 
 Those keys are absent from `nub config list --all` too, so the listing and the write agree on what this project can set.
 
-A field of this file also wins over the `.npmrc` spelling of the same setting. When the project sets one, writing the other spelling is refused rather than left to look like it worked:
+A field of this file also wins over the `.npmrc` spelling of the same setting. When the project sets one, writing the other spelling is refused rather than written without effect:
 
 ```text
 $ nub config set nodeLinker isolated
@@ -765,4 +765,4 @@ Error: nub config set nodeLinker: this project sets `install.linker` in nub.json
   run `nub config set install.linker <value>` instead, or remove `install.linker` from nub.jsonc
 ```
 
-This tracks what the project actually sets, not the key alone. `install.linker: "hoisted"` decides the linker and nothing else, so `hoist-pattern` still reads from `.npmrc`; giving `linker` a `hoist` list decides that too, and then it does not.
+The rule follows what the project sets, not the key alone. `install.linker: "hoisted"` decides the linker and nothing else, so `hoist-pattern` still reads from `.npmrc`; giving `linker` a `hoist` list decides that too, and then it does not.

--- a/site/content/docs/config.mdx
+++ b/site/content/docs/config.mdx
@@ -83,7 +83,7 @@ For a project `nub.jsonc` that is the directory the file sits in — in a monore
 }
 ```
 
-Set a path globally and you almost certainly meant a fixed location, so write it absolute or lead with `~/`.
+For a global path, write it absolute or lead with `~/`.
 
 ```jsonc title="~/.config/nub/nub.jsonc"
 {
@@ -92,7 +92,7 @@ Set a path globally and you almost certainly meant a fixed location, so write it
 }
 ```
 
-There is no way to write a global path meaning "each project's own directory". Put project-relative paths in the project file.
+Project-relative paths belong in the project file; a global path cannot mean "each project's own directory".
 
 ## JSON Schema
 
@@ -114,7 +114,7 @@ Schemas are served from `https://nubjs.com/schema/`:
 
 Each minor series gets one file (`v0.6.json`, `v0.7.json`, …). On every release bump Nub snapshots the rolling schema into that series' file; patch releases within `0.7.x` keep rewriting `v0.7.json` only when the published field surface changes. Older series stay published for long-lived branches. The [schema index](/schema) lists every file on disk.
 
-Nub does not read `$schema` when it runs your code; the key is for editors only.
+The `$schema` key is read by editors only, never by Nub.
 
 ## Runtime
 

--- a/site/content/docs/deployment/cloudflare.mdx
+++ b/site/content/docs/deployment/cloudflare.mdx
@@ -110,7 +110,7 @@ nodejs 24.18.0
 nub {{NUB_VERSION}}
 ```
 
-A pinned version the image doesn't already carry is downloaded during the build, so the pin holds even when it differs from the image default. Nub reads the same file when resolving its own Node, which keeps the two in agreement from one place.
+A pinned version the image doesn't already carry is downloaded during the build, so the pin holds even when it differs from the image default. Nub reads the same file when resolving its own Node, so one file pins both.
 
 Adding `@nubjs/nub` as a devDependency also works, and is the option to reach for when the version belongs in the lockfile alongside the project's other dependencies.
 

--- a/site/content/docs/deployment/cloudflare.mdx
+++ b/site/content/docs/deployment/cloudflare.mdx
@@ -45,7 +45,7 @@ Projects that keep an existing `pnpm-lock.yaml`, `package-lock.json`, or `bun.lo
 
 ## HTTP endpoint
 
-Workers use Cloudflare's `fetch` handler rather than a Node HTTP server. A minimal aliveness endpoint looks like this:
+Workers use Cloudflare's `fetch` handler rather than a Node HTTP server. A minimal aliveness endpoint:
 
 ```ts title="src/index.ts"
 export default {
@@ -112,6 +112,6 @@ nub {{NUB_VERSION}}
 
 A pinned version the image doesn't already carry is downloaded during the build, so the pin holds even when it differs from the image default. Nub reads the same file when resolving its own Node, so one file pins both.
 
-Adding `@nubjs/nub` as a devDependency also works, and is the option to reach for when the version belongs in the lockfile alongside the project's other dependencies.
+Adding `@nubjs/nub` as a devDependency also works, and pins the version in the lockfile alongside the project's other dependencies.
 
 Nub only participates in the build. Deployed Workers execute on Cloudflare's runtime rather than Node with Nub augmentation.

--- a/site/content/docs/deployment/docker.mdx
+++ b/site/content/docs/deployment/docker.mdx
@@ -1,6 +1,6 @@
 ---
 title: Docker
-description: Official Nub Docker images, and how to add Nub to your own image. The images install Nub onto an official Node base, so Node is present and the runtime is augmented out of the box.
+description: Official Nub Docker images, and how to add Nub to your own image. The images install Nub onto an official Node base.
 ---
 
 Nub augments the Node already in your image — it is not a separate runtime. The official images start from an official `node` base and layer Nub on top, so `node`, `npm`, and `nub` are all present.

--- a/site/content/docs/deployment/docker.mdx
+++ b/site/content/docs/deployment/docker.mdx
@@ -15,7 +15,7 @@ COPY --chown=node:node . .
 CMD ["nub", "run", "start"]
 ```
 
-The image runs as the non-root `node` user, so copy your project in with `--chown=node:node` — a bare `COPY . .` lands root-owned files that `nub install` then can't write alongside.
+The image runs as the non-root `node` user, so copy your project in with `--chown=node:node` — a bare `COPY . .` creates root-owned files that `nub install` then cannot write alongside.
 
 Two variants, both on the current Node release line, digest-pinned and published for `linux/amd64` and `linux/arm64`:
 
@@ -30,7 +30,7 @@ Run a TypeScript file directly — the entrypoint passes any non-command argumen
 docker run --rm -v "$PWD:/app" ghcr.io/nubjs/nub script.ts
 ```
 
-Signals reach the runtime: `docker stop` delivers `SIGTERM` to `nub`, which forwards it to the Node process for a clean shutdown. The `node` user is uid 1000, so when you bind-mount a directory that `nub install` must write into, run with `--user "$(id -u)"` and the writes land with your host ownership.
+Signals reach the runtime: `docker stop` delivers `SIGTERM` to `nub`, which forwards it to the Node process for a clean shutdown. The `node` user is uid 1000, so when you bind-mount a directory that `nub install` must write into, run with `--user "$(id -u)"` and the writes carry your host ownership.
 
 ## Adding Nub to your own image
 

--- a/site/content/docs/deployment/github-action.mdx
+++ b/site/content/docs/deployment/github-action.mdx
@@ -94,7 +94,7 @@ Read a Node version from a file, then provision and front it on PATH. Accepts `.
 
 ### `cache`
 
-Caching is on by default — it auto-enables when the project looks installable, mirroring setup-node. The auto-detection triggers on a lockfile or a `package.json` that declares `packageManager` or `devEngines`. Set the input explicitly to override:
+Caching is on by default when the project has a lockfile or a `package.json` that declares `packageManager` or `devEngines`, mirroring setup-node. Set the input explicitly to override:
 
 ```yaml
 - uses: nubjs/setup-nub@v0
@@ -114,7 +114,7 @@ The cache key is derived from the project's lockfile and the Node pin, with the 
 
 ### `package-manager-cache`
 
-The disable knob for the automatic caching above. Set false to turn caching off without setting `cache`:
+Turns the automatic caching above off without setting `cache`:
 
 ```yaml
 - uses: nubjs/setup-nub@v0
@@ -194,7 +194,7 @@ Write `always-auth=true` into the `.npmrc` to authenticate on every registry req
 
 ### `token`
 
-Token for GitHub-API rate-limit relief when resolving Nub's version range (and Node downloads on GHES). Defaults to `github.token` on github.com — most workflows don't need to set this explicitly.
+Token for GitHub-API rate-limit relief when resolving Nub's version range (and Node downloads on GHES). Defaults to `github.token` on github.com.
 
 ## Outputs
 

--- a/site/content/docs/deployment/github-action.mdx
+++ b/site/content/docs/deployment/github-action.mdx
@@ -1,9 +1,9 @@
 ---
 title: GitHub Action
-description: A drop-in replacement for the official setup-node action. Swap one line in your workflow and Nub installs itself, provisions the project's pinned Node, and fronts it on PATH so every step keeps working unchanged.
+description: A drop-in replacement for the official setup-node action. Swap one line in your workflow and Nub installs itself, provisions the project's pinned Node, and fronts it on PATH.
 ---
 
-A drop-in for [`actions/setup-node`](https://github.com/actions/setup-node). Swap one line and your workflow keeps working:
+A drop-in for [`actions/setup-node`](https://github.com/actions/setup-node) — swap one line:
 
 ```diff
 steps:
@@ -29,7 +29,7 @@ Read the [full docs](https://github.com/actions/setup-node#readme) on github.com
 
 ## How it works
 
-The action installs the `nub` CLI, then eagerly provisions the project's pinned Node into Nub's cache during the setup step — downloaded and ready before any of your steps run, never lazily mid-build. The pin is resolved from the project's Node-version sources, in this order:
+The action installs the `nub` CLI, then provisions the project's pinned Node into Nub's cache during the setup step, before any of your steps run. The pin is resolved from the project's Node-version sources, in this order:
 
 1. `package.json#/devEngines/runtime`
 2. `.node-version`
@@ -40,8 +40,6 @@ The action installs the `nub` CLI, then eagerly provisions the project's pinned 
 That resolved Node's bin directory is added to the global PATH, so bare `node`/`npm`/`npx` and every subsequent step see the pinned version — the same PATH guarantee setup-node gives. With no pin declared, the eager step skips and Nub provisions at runtime.
 
 Because the pin lives in the repository, `actions/checkout` must run before this action.
-
-Every `actions/setup-node` input is accepted, so the swap is always mechanical.
 
 ## Inputs
 
@@ -60,7 +58,7 @@ Every `actions/setup-node` input is accepted, so the swap is always mechanical.
 | `always-auth` | `false` | Authenticate on every registry request. |
 | `token` | `github.token` | Token for GitHub-API rate-limit relief when resolving Nub's version range. |
 
-The setup-node inputs `check-latest`, `architecture`, `mirror`, and `mirror-token` are accepted and ignored — present so a swap never errors, with no effect. The `version` input is a deprecated alias for `nub-version` and emits a warning.
+The setup-node inputs `check-latest`, `architecture`, `mirror`, and `mirror-token` are accepted and ignored, so a swap never errors. The `version` input is a deprecated alias for `nub-version` and emits a warning.
 
 ### `nub-version`
 
@@ -188,7 +186,7 @@ Read the [full docs](https://docs.github.com/en/packages/working-with-a-github-p
 
 ### `scope`
 
-Scope for a scoped registry. Falls back to the repository owner for `npm.pkg.github.com`. The `.npmrc` written by `registry-url` follows the same contract as setup-node, so existing auth setups port over unchanged.
+Scope for a scoped registry. Falls back to the repository owner for `npm.pkg.github.com`. The `.npmrc` written by `registry-url` follows the same contract as setup-node.
 
 ### `always-auth`
 

--- a/site/content/docs/deployment/github-action.mdx
+++ b/site/content/docs/deployment/github-action.mdx
@@ -37,7 +37,7 @@ The action installs the `nub` CLI, then provisions the project's pinned Node int
 4. `.tool-versions` (the asdf/mise file's `nodejs` or `node` line)
 5. `package.json#/engines/node`
 
-That resolved Node's bin directory is added to the global PATH, so bare `node`/`npm`/`npx` and every subsequent step see the pinned version — the same PATH guarantee setup-node gives. With no pin declared, the eager step skips and Nub provisions at runtime.
+That resolved Node's bin directory is added to the global PATH, so bare `node`/`npm`/`npx` and every subsequent step see the pinned version. With no pin declared, the eager step skips and Nub provisions at runtime.
 
 Because the pin lives in the repository, `actions/checkout` must run before this action.
 
@@ -58,7 +58,7 @@ Because the pin lives in the repository, `actions/checkout` must run before this
 | `always-auth` | `false` | Authenticate on every registry request. |
 | `token` | `github.token` | Token for GitHub-API rate-limit relief when resolving Nub's version range. |
 
-The setup-node inputs `check-latest`, `architecture`, `mirror`, and `mirror-token` are accepted and ignored, so a swap never errors. The `version` input is a deprecated alias for `nub-version` and emits a warning.
+The setup-node inputs `check-latest`, `architecture`, `mirror`, and `mirror-token` are accepted and ignored. The `version` input is a deprecated alias for `nub-version` and emits a warning.
 
 ### `nub-version`
 

--- a/site/content/docs/deployment/index.mdx
+++ b/site/content/docs/deployment/index.mdx
@@ -108,6 +108,6 @@ Read the [full docs](https://docs.github.com/en/packages/working-with-a-github-p
 
 A managed builder selects Node, and Nub augments that version. Pin Node with the source the platform supports, normally `.node-version`, `.nvmrc`, or `package.json#engines.node`.
 
-A container carries its own Node version. Pin the Nub image tag and update it deliberately when you want a new Nub or Node release.
+A container carries its own Node version. Pin the Nub image tag and update it to move to a new Nub or Node release.
 
 Environments driven by `.tool-versions` can also provision the CLI through [mise](https://mise.jdx.dev): `mise use nub@latest` puts `nub` and `nubx` on `PATH`.

--- a/site/content/docs/deployment/vercel.mdx
+++ b/site/content/docs/deployment/vercel.mdx
@@ -5,7 +5,7 @@ description: Vercel ships no preinstalled Nub, but the install command is yours 
 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
 
-[Vercel](https://vercel.com) doesn't ship Nub in its build image, but it lets you replace the install command — which is all it takes.
+[Vercel](https://vercel.com) doesn't ship Nub in its build image, but it lets you replace the install command.
 
 <Steps>
 

--- a/site/content/docs/deployment/vercel.mdx
+++ b/site/content/docs/deployment/vercel.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vercel
-description: Vercel ships no preinstalled Nub, but the install command is yours to replace — so one line puts the CLI on PATH for the rest of the build. The devDependency pattern works too.
+description: Vercel ships no preinstalled Nub, but the install command is yours to replace — so one line puts the CLI on PATH for the rest of the build.
 ---
 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
@@ -117,7 +117,7 @@ Adding the CLI as a devDependency also works, and leaves `vercel.json` empty:
 }
 ```
 
-Vercel's auto-detected install links `nub` and `nubx` onto `node_modules/.bin`, and your scripts resolve them. Reach for it when you'd rather pin the version in the manifest than in build settings; see [Managed builders](/docs/deployment#managed-builders) for the full pattern.
+Vercel's auto-detected install links `nub` and `nubx` onto `node_modules/.bin`, and your scripts resolve them. Use it to pin the version in the manifest instead of build settings; see [Managed builders](/docs/deployment#managed-builders) for the full pattern.
 
 <Callout>
   Excluding development dependencies from the install drops the CLI along with them. Override the install command instead when a project builds without devDependencies.

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -168,7 +168,7 @@ For restart-on-change, yes: `nub watch script.ts` (or `nub --watch script.ts`) r
 
 ## What about `dotenv-cli`?
 
-Not needed. Nub loads your env files automatically — with the Vite/Bun-style precedence rules — and injects them into the process environment *before* Node starts:
+Nub loads your env files automatically — with the Vite/Bun-style precedence rules — and injects them into the process environment *before* Node starts:
 
 ```text
 .env.[mode].local
@@ -193,9 +193,9 @@ Nub is a Rust CLI. When you type `nub script.ts`, the Rust binary:
 2. Reads your nearest `package.json`, `tsconfig.json`, and `.env*` files.
 3. Spawns that Node with `--import` pointing at Nub's preload bundle and `NODE_OPTIONS` set to whatever experimental flags are needed for that Node version.
 4. The preload bundle calls `module.registerHooks()` to install Nub's load hook (TS / JSX / YAML / TOML / JSON5 / JSONC transpile-and-parse path, backed by an N-API binding to `oxc`), installs polyfills (`Temporal`, `URLPattern`, `WebSocket`, `Worker`, WinterTC gap globals) where Node is behind, and hands control to your script.
-5. Subprocesses inherit the same augmentation recursively — `node hello.js` from inside a script, the Node process Vite or Next.js spawns for a dev server, the worker pool your test runner spins up, `child_process.spawn("node", …)` from your own code.
+5. Subprocesses inherit the same augmentation recursively — a `node hello.js` from inside a script, or the worker pool your test runner spins up.
 
-Every step rides on a public Node extension surface — see [What Node features does it rely on?](#what-node-features-does-it-rely-on) for the full inventory.
+See [What Node features does it rely on?](#what-node-features-does-it-rely-on) for the extension surfaces each step uses.
 
 ## What Node features does it rely on?
 

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -160,11 +160,11 @@ Node 22.18+ runs `.ts` files by default, but only strips types. Anything beyond 
 - `tsconfig.json` `paths`, `baseUrl`, `jsx`, `experimentalDecorators`, `extends` → ignored ("intentionally unsupported," per the Node 26 docs)
 - Extensionless `.ts` imports → unresolved, and no source maps
 
-Nub transpiles each file through its native addon instead. If your codebase is `erasableSyntaxOnly`-clean, Node's built-in support is enough.
+Nub transpiles each file through its native addon instead.
 
 ## Does it replace `nodemon` / `tsx watch`?
 
-For restart-on-change, yes: `nub watch script.ts` (or `nub --watch script.ts`) restarts the process when anything in the resolved dependency graph (plus your `.env*` files and `tsconfig.json`) changes — no glob list to maintain. Full details: [Watch mode](/docs/watch).
+For restart-on-change, yes: `nub watch script.ts` (or `nub --watch script.ts`) restarts the process when anything in the resolved dependency graph (plus your `.env*` files and `tsconfig.json`) changes. Full details: [Watch mode](/docs/watch).
 
 ## What about `dotenv-cli`?
 
@@ -193,7 +193,7 @@ Nub is a Rust CLI. When you type `nub script.ts`, the Rust binary:
 2. Reads your nearest `package.json`, `tsconfig.json`, and `.env*` files.
 3. Spawns that Node with `--import` pointing at Nub's preload bundle and `NODE_OPTIONS` set to whatever experimental flags are needed for that Node version.
 4. The preload bundle calls `module.registerHooks()` to install Nub's load hook (TS / JSX / YAML / TOML / JSON5 / JSONC transpile-and-parse path, backed by an N-API binding to `oxc`), installs polyfills (`Temporal`, `URLPattern`, `WebSocket`, `Worker`, WinterTC gap globals) where Node is behind, and hands control to your script.
-5. Subprocesses inherit the same augmentation recursively — `node hello.js` from inside a script, the Node process Vite or Next.js spawns for a dev server, the worker pool your test runner spins up, `child_process.spawn("node", …)` from your own code, all augmented.
+5. Subprocesses inherit the same augmentation recursively — `node hello.js` from inside a script, the Node process Vite or Next.js spawns for a dev server, the worker pool your test runner spins up, `child_process.spawn("node", …)` from your own code.
 
 Every step rides on a public Node extension surface — see [What Node features does it rely on?](#what-node-features-does-it-rely-on) for the full inventory.
 

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -14,19 +14,19 @@ $ nub run dev              # run a package.json script
 $ nubx prisma generate     # run a CLI from node_modules/.bin
 ```
 
-It's a Rust CLI that runs on stock Node, provisioning the version your project pins or using whatever's on your `PATH` when nothing is pinned. It augments that Node through Node's own public extension surfaces: `module.registerHooks()`, `--import` preloads, `NODE_OPTIONS`, and N-API addons.
+It's a Rust CLI that runs on stock Node, provisioning the version your project pins or using the `node` on your `PATH` when nothing is pinned. It augments that Node through Node's own public extension surfaces: `module.registerHooks()`, `--import` preloads, `NODE_OPTIONS`, and N-API addons.
 
 ## Is it a new runtime?
 
-No. Nub runs *on* stock Node. There is no Nub runtime, no Nub JavaScript engine, no separate compatibility surface. When `nub index.ts` runs, what's actually executing is a stock `node` binary: Nub spawns it, registers a load hook for TypeScript / JSX / YAML / TOML, and preloads polyfills where Node is behind. See [How does it work under the hood?](#how-does-it-work-under-the-hood) for the mechanism-level answer.
+No. Nub runs *on* stock Node. There is no Nub runtime, no Nub JavaScript engine, no separate compatibility surface. When `nub index.ts` runs, the process is a stock `node` binary: Nub spawns it, registers a load hook for TypeScript / JSX / YAML / TOML, and preloads polyfills where Node lacks them. See [How does it work?](#how-does-it-work) for the mechanism.
 
 ## Is it a fork of Node?
 
-No. Nub does not patch Node source, ship a custom-built Node binary, or embed `libnode`. Every augmentation rides on Node's public extension surfaces.
+No. Nub does not patch Node source, ship a custom-built Node binary, or embed `libnode`. Every augmentation uses Node's public extension surfaces.
 
 ## Is Nub a replacement for Node?
 
-No — Nub *is* Node. Your code is transpiled and executed by the stock `node` binary; there's no Nub runtime to discover and nothing reimplemented. Nub is a layer of developer-experience defaults on top of Node, built entirely on Node's own extension surfaces.
+No. Your code is transpiled and executed by the stock `node` binary; there is no Nub runtime. Nub is a layer of developer-experience defaults built on Node's own extension surfaces.
 
 ## How is it different from plain `node`?
 
@@ -40,40 +40,40 @@ Running `nub <file>` is flag-for-flag compatible with `node <file>` — same arg
 - **Automatic polyfills** — `Temporal`, `URLPattern`, browser-shape `Worker`, WinterTC gap globals, version-detected and feature-gated
 - **Unflagged experimentals** — `EventSource`, `WebSocket`, `localStorage` / `sessionStorage`, `vm.Module`, `node:sqlite` — flags Node already ships but keeps gated, auto-injected in exact per-version bands where each is still behind `--experimental-*`
 
-For plain Node behavior, type `node` — the PATH shim is per-invocation, so shell `node` is always the user's real Node. For orchestration without runtime augmentation, the [`--node` flag](#whats-the---node-flag) on `nub run` and `nubx` strips the hook/preload/unflagging while keeping Nub's CLI work.
+For plain Node behavior, run `node` directly; Nub's per-invocation PATH shim only affects descendants of a `nub` call. For orchestration without runtime augmentation, the [`--node` flag](#whats-the---node-flag) on `nub run` and `nubx` strips the hook/preload/unflagging while keeping Nub's CLI work.
 
-## What's the elevator pitch?
+## What does it replace?
 
-If you've spent the last few years assembling a personal toolchain out of `tsx`, `dotenv-cli`, `nodemon`, `npx`, `pnpm run`, plus a handful of `tsconfig` loader shims — Nub replaces that pile with one binary that starts in milliseconds and doesn't ask you to change your runtime. **Keep Node. Replace the toolchain.**
+One binary replaces `tsx`, `dotenv-cli`, `nodemon`, `npx`, `pnpm run`, and the `tsconfig` loader shims around them, and runs on the Node you already have.
 
 ## Is it faster than Node.js?
 
-No — your code runs in Node itself, so once it's executing, V8 is V8. The CLI surface is much faster, because a native Rust binary skips the Node bootstrap `pnpm run` and `npx` pay just to do a script lookup:
+No. Your code runs in Node itself, so execution speed is Node's. The CLI surface is faster, because a native Rust binary skips the Node bootstrap that `pnpm run` and `npx` pay for a script lookup:
 
 - `nub run` is 24× faster than `pnpm run` on cold start.
 - `nubx` is 19× faster than `npx` on cold start.
 
-Transpile output lands in a content-addressed on-disk cache keyed on `(source content, Nub version, resolved tsconfig)`, so the first run transpiles and every run after pays roughly nothing.
+Transpile output lands in a content-addressed on-disk cache keyed on `(source content, Nub version, resolved tsconfig)`, so the first run transpiles and every later run reads the cache.
 
 ## Will my existing Node code work on Nub?
 
-Yes. The compatibility surface is Node's. If a package works on Node, it works on Nub — because what's actually running underneath is Node.
+Yes. The compatibility surface is Node's. If a package works on Node, it works on Nub.
 
 <Callout title="The contract">
-Code targeting Node runs on Nub byte-for-byte. If you hit a case where that's not true, it's a bug.
+Code targeting Node runs on Nub byte-for-byte. Any divergence is a bug.
 </Callout>
 
 ## What about CommonJS / `require()`?
 
-Works. CommonJS, `require()`, dynamic `require()`, `require.cache`, `module.exports`, the `node:` core modules in both ESM and CJS form — all of it works because all of it is just Node, running underneath. Nub's load hook covers TypeScript / JSX / YAML / TOML at the ESM and CJS entry points equivalently.
+Yes. CommonJS, `require()`, dynamic `require()`, `require.cache`, `module.exports`, and the `node:` core modules in both ESM and CJS form all run, because the process is stock Node. Nub's load hook covers TypeScript / JSX / YAML / TOML at the ESM and CJS entry points equivalently.
 
 ## What about native (N-API) addons?
 
-Works. Native addons compile against Node's N-API ABI, and Nub is running on a stock Node binary, so addons load as they do on plain Node. (Nub itself ships its `oxc` transpiler as an N-API addon; that path is the same path your `better-sqlite3` or `@napi-rs/canvas` uses.) Compiling one from source carries one upstream caveat under the default install layout — see [GYP-based native builds](/docs/install/virtual-store#gyp-based-native-builds).
+Yes. Native addons compile against Node's N-API ABI, and Nub is running on a stock Node binary, so addons load as they do on plain Node. (Nub itself ships its `oxc` transpiler as an N-API addon; that path is the same path your `better-sqlite3` or `@napi-rs/canvas` uses.) Compiling one from source carries one upstream caveat under the default install layout — see [GYP-based native builds](/docs/install/virtual-store#gyp-based-native-builds).
 
 ## Does it support all Node core modules?
 
-Yes. Every `node:` core module — `node:fs`, `node:http`, `node:test`, `node:worker_threads`, `node:sqlite`, `node:crypto`, all of them — works because they're provided by the stock Node binary, not by Nub.
+Yes. Every `node:` core module — `node:fs`, `node:http`, `node:test`, `node:worker_threads`, `node:sqlite`, `node:crypto` — is provided by the stock Node binary.
 
 ## What Node versions does it support?
 
@@ -81,7 +81,7 @@ Yes. Every `node:` core module — `node:fs`, `node:http`, `node:test`, `node:wo
 - **Compat mode** (the [`--node` flag](#whats-the---node-flag)) is best-effort on any Node version. Here Nub is a pure orchestrator (script resolution, workspace bin PATH, env var injection) and spawns plain Node without runtime augmentation.
 
 <Callout title="Below the floor">
-On Node older than 18.19, augmented commands emit a tagged error telling you to upgrade Node or use compat mode.
+On Node older than 18.19, augmented commands fail with an error naming the floor and compat mode.
 </Callout>
 
 ## Does it work on Linux / macOS / Windows?
@@ -101,7 +101,7 @@ The action installs the Nub CLI onto the runner, and from there Nub provisions t
 
 ## Does it replace my package manager?
 
-It can. The `nub install` command is a full package manager — pnpm's CLI surface, your project's lockfile — powered by the embedded aube engine. It detects the lockfile your project already has and writes the same format back, so nothing forces a migration: pnpm, npm, and Bun keep working side by side, and `nub pm use` provisions the original tool at its exact pinned version (corepack's job, without the PATH shims).
+It can. The `nub install` command is a full package manager — pnpm's CLI surface, your project's lockfile — powered by the embedded aube engine. It detects the lockfile your project already has and writes the same format back, and `nub pm use` provisions the original tool at its exact pinned version (corepack's job, without the PATH shims).
 
 | Lockfile | Behavior |
 | --- | --- |
@@ -118,12 +118,12 @@ Yes. Your lockfile stays in whatever format your package manager produces, and w
 - `nubx` reads `node_modules/.bin`.
 
 <Callout title="Yarn Berry Plug'n'Play">
-PnP has no `node_modules/.bin/` — just a runtime resolution table managed by Yarn's loader. Nub handles it anyway: the runtime detects a `.pnp.cjs` and runs the project through it, and `nubx` resolves PnP bins through `pnpapi` (the way `yarn exec` does). See [module resolution](/docs/runtime/resolution#yarn-plugnplay).
+PnP has no `node_modules/.bin/`, only a runtime resolution table managed by Yarn's loader. The runtime detects a `.pnp.cjs` and runs the project through it, and `nubx` resolves PnP bins through `pnpapi` (the way `yarn exec` does). See [module resolution](/docs/runtime/resolution#yarn-plugnplay).
 </Callout>
 
 ## Is it monorepo-friendly?
 
-Yes. Workspace topology comes from `package.json`'s `"workspaces"` field (`npm`, `yarn`) and `pnpm-workspace.yaml` (`pnpm`), with the `-r` / `--filter` semantics every workspace user already knows from `pnpm`:
+Yes. Workspace topology comes from `package.json`'s `"workspaces"` field (`npm`, `yarn`) and `pnpm-workspace.yaml` (`pnpm`), with pnpm's `-r` / `--filter` semantics:
 
 ```bash
 nub run -r build                        # all workspace packages
@@ -136,22 +136,22 @@ nub run --filter "@org/web..." build    # @org/web and its dependencies
 Read the [full docs](https://pnpm.io/filtering) on pnpm.io for the filter syntax.
 </Callout>
 
-Topological ordering, parallelism, and `--workspace-root` are honored. What Nub does not pay is the ~150 ms `pnpm` bootstrap, charged once per package: in a 30-package monorepo, `pnpm -r run build` pays it 30 times before any of your code runs.
+Topological ordering, parallelism, and `--workspace-root` are honored. Nub skips the ~150 ms `pnpm` bootstrap, which `pnpm -r run build` pays once per package.
 
 ## Does it replace `npx`?
 
 Yes — `nubx` is the equivalent, following the same local-first-then-registry model as `npx` and `pnpm dlx`:
 
 - **Local bin** — `nubx` walks up the directory tree checking `node_modules/.bin/` at each level (the standard resolution algorithm), in Rust, returning in single-digit milliseconds.
-- **Not installed** — `nubx` fetches the binary from the registry and runs it on the fly. Nub is a complete package manager, so it does the fetch itself rather than shelling out to a foreign PM.
+- **Not installed** — `nubx` fetches the binary from the registry and runs it. Nub is a complete package manager, so it does the fetch itself rather than shelling out to a foreign PM.
 
-The one behavioral difference from `npx` is that the fetch is not silent: the first fetch of a tool prompts, and CI fails closed unless you pass `-y`. See [the runner docs](/docs/runner#fetch-from-the-registry) for the consent model.
+The one behavioral difference from `npx` is that the fetch is not silent: the first fetch of a tool prompts, and CI fails closed unless you pass `-y`. See [the runner docs](/docs/runner#registry-fetches) for the consent model.
 
 ## Does it replace `tsx` / `ts-node`?
 
 Yes — `nub script.ts` runs TypeScript directly, with the full TS surface (not just type stripping), respecting your `tsconfig.json`, with inline source maps so stack traces point at your `.ts` source. Full details: [Runtime → TypeScript](/docs/runtime/typescript).
 
-## Why not just use Node's built-in TypeScript support?
+## Why not Node's built-in TypeScript support?
 
 Node 22.18+ runs `.ts` files by default, but only strips types. Anything beyond erasable annotations is rejected or ignored:
 
@@ -185,7 +185,7 @@ Under the test mode (`APP_ENV=test`), `.env.local` is skipped, following the Nex
 
 Full details: [Runtime → Environment variables](/docs/runtime/env).
 
-## How does it work under the hood?
+## How does it work?
 
 Nub is a Rust CLI. When you type `nub script.ts`, the Rust binary:
 
@@ -199,16 +199,16 @@ See [What Node features does it rely on?](#what-node-features-does-it-rely-on) f
 
 ## What Node features does it rely on?
 
-Every augmentation Nub applies is something you could wire up by hand on plain Node. The extension surface Node exposes for this work has grown substantially in the last three years, and the kit Nub composes from it is entirely public:
+Every augmentation Nub applies can be set up by hand on plain Node, through public surfaces:
 
 - **`module.registerHooks()`** (Node 22.15, April 2025) — synchronous loader hooks for the transpile-on-import path.
-- **`module.register()`** (Node 20.6, August 2023) — programmatic loader registration, no `--loader` CLI dance.
+- **`module.register()`** (Node 20.6, August 2023) — programmatic loader registration without the `--loader` flag.
 - **`--import` preload** (Node 19.0, October 2022, stable since 20.6) — run setup code before user `main`, ESM-aware. Used to install polyfills and set up the load hook.
-- **`--require` preload** (Node 1.6, 2012) — older CJS-style preload, still useful in pre-ESM corners.
+- **`--require` preload** (Node 1.6, 2012) — older CJS-style preload, for CJS-only setups.
 - **`NODE_OPTIONS` and V8 flag injection** — used to turn on `--experimental-*` flags Node already implements but keeps gated.
 - **N-API addons** (stable since Node 8.6, October 2017) — the ABI-stable native-addon contract. The `oxc` transpiler ships as a Node addon, called from inside the load hook.
 
-There is no patched Node binary, no vendored `libnode`, no separate runtime to discover.
+There is no patched Node binary, no vendored `libnode`, no separate runtime.
 
 ## Why hasn't anyone else done this?
 
@@ -234,7 +234,7 @@ These are not Nub-specific. They're the [Minimum Common Web API](https://min-com
 
 ## What npm packages can I stop using once I install Nub?
 
-Two buckets — and the first one isn't limited to npm packages. Nub replaces these directly:
+Two sets. Nub replaces these directly:
 
 ```text
 dotenv
@@ -305,19 +305,19 @@ Deno implements Node compatibility inside Deno. Nub runs on the actual Node bina
 
 ## How is it different from `node --run`?
 
-Node shipped a built-in script runner in 22.0 — `node --run` — and it's fast. But it's deliberately minimal, and the gaps are why projects still reach for `pnpm run`:
+Node shipped a built-in script runner in 22.0, `node --run`, and it is fast. It is deliberately minimal; three gaps keep projects on `pnpm run`:
 
 - No `pre` / `post` lifecycle hooks.
 - No workspaces — no recursive or filtered runs across a monorepo.
 - No `npm_*` environment variables (`npm_package_*`, `npm_config_*`, `npm_lifecycle_event`) that countless scripts read.
 
-The `nub run` command is just as fast in the [script-runner benchmark](https://github.com/nubjs/nub/tree/main/tests/bench/script-runner) and closes all three.
+The `nub run` command is as fast in the [script-runner benchmark](https://github.com/nubjs/nub/tree/main/tests/bench/script-runner) and closes all three.
 
 ## What if I want to stop using Nub?
 
-Your codebase keeps working on plain Node, unchanged. Nub adds no APIs to your code — no `nub` global, no `nub:*` import namespace, no `@nub/*` scope, no `"nub"` field in your `package.json`.
+Your codebase runs on plain Node unchanged. Nub adds no APIs to your code — no `nub` global, no `nub:*` import namespace, no `@nub/*` scope, no `"nub"` field in your `package.json`.
 
-If Nub disappeared tomorrow, the worst case is going back to whatever toolchain you had before:
+Removing Nub restores the previous toolchain's requirements:
 
 - TypeScript files need a separate compile step or a tsx-equivalent loader.
 - `.env` files need `dotenv-cli` or `import "dotenv/config"` again.
@@ -336,7 +336,7 @@ nubx --node prisma generate  # Nub's bin resolution, runtime augmentation off
 
 It strips every runtime augmentation for the spawned process — the transpile hook, `.env` loading, polyfills, unflagging, and the PATH shim — leaving byte-exact Node runtime behavior; full contract at [the runtime overview](/docs/runtime#--node).
 
-Useful when a script's `#!/usr/bin/env node` shebang chain expects real Node, when bisecting a Nub bug, or when CI wants byte-exact Node runtime behavior with Nub's `--filter` / workspace selection.
+Useful when a script's `#!/usr/bin/env node` shebang chain expects plain Node, when bisecting a Nub bug, or when CI needs byte-exact Node runtime behavior with Nub's `--filter` / workspace selection.
 
 ## Does Nub add anything to my `package.json`?
 
@@ -376,12 +376,12 @@ Same as installing — match how you installed: `brew update && brew upgrade nub
 
 ## Is there a curl install script?
 
-Yes. On macOS and Linux, `curl -fsSL https://nubjs.com/install.sh | bash`; on Windows, `powershell -c "irm https://nubjs.com/install.ps1 | iex"`. Both drop a native binary into `~/.nub` and put it on your `PATH`. The scripts verify the release archive against its SHA-256 sidecar before replacing an existing installation. This detects corrupt, truncated, stale-cache, or mismatched assets; it is not an independent authenticity guarantee because the archive and checksum share the same release origin. If you'd rather go through your package manager, `npm install -g @nubjs/nub` (or `pnpm add -g` / `yarn global add`) does the same thing, and on macOS and Linux `brew install nub` works too.
+Yes. On macOS and Linux, `curl -fsSL https://nubjs.com/install.sh | bash`; on Windows, `powershell -c "irm https://nubjs.com/install.ps1 | iex"`. Both place a native binary in `~/.nub` and put it on your `PATH`. The scripts verify the release archive against its SHA-256 sidecar before replacing an existing installation. This detects corrupt, truncated, stale-cache, or mismatched assets; it is not an independent authenticity guarantee because the archive and checksum share the same release origin. Alternatively, `npm install -g @nubjs/nub` (or `pnpm add -g` / `yarn global add`) does the same, as does `brew install nub` on macOS and Linux.
 
 Two environment variables customize the script, following the same convention as rustup and uv:
 
 - `NUB_INSTALL_DIR` — install somewhere other than `~/.nub`. `nub upgrade` still updates it in place.
-- `NUB_NO_MODIFY_PATH` — set it truthy (`1`/`yes`/`true`/`on`) to skip the shell-profile edit; the script prints the `PATH` line for you to add yourself.
+- `NUB_NO_MODIFY_PATH` — set it truthy (`1`/`yes`/`true`/`on`) to skip the shell-profile edit; the script prints the `PATH` line to add manually.
 
 Set them on the shell that runs the script — the right side of the pipe, not on `curl`:
 
@@ -413,20 +413,20 @@ npm install -g @nubjs/nub@canary
 
 An existing script install switches channels in place with `nub upgrade --canary`; `nub upgrade --stable` returns to the latest stable release. On a canary build, a plain `nub upgrade` stays on the canary channel. Canary versions are date-stamped — `nub --version` prints something like `v0.5.1-canary.20260724.117`.
 
-Canary is the bleeding edge: it may break, and each build replaces the last. Homebrew and winget carry only stable releases, so upgrading through them always lands on a release.
+Canary may break, and each build replaces the last. Homebrew and winget carry only stable releases.
 
 ## Does it have a dev server?
 
-No. Vite already owns this; `nub run dev` runs whatever your project's `dev` script is — faster, because the `nub run` wrapper costs less than the `pnpm run` wrapper, but the dev server itself is still Vite (or Next.js, or whatever you're running).
+No. `nub run dev` runs your project's `dev` script; the dev server itself is Vite, Next.js, or whatever that script starts.
 
 ## Does it have a test runner?
 
-No. Node's own `node:test` covers it — and `vitest` and `jest` if you prefer those. Nub runs whichever you've chosen. Workers spawned by your test runner inherit Nub's augmentation, so TypeScript test files run directly.
+No. Node's own `node:test`, `vitest`, and `jest` all run under Nub. Workers spawned by your test runner inherit Nub's augmentation, so TypeScript test files run directly.
 
 ## Does it have a bundler?
 
 No. Use the bundler your project already has (Vite / Rollup / Rolldown / esbuild / webpack / tsup); Nub's transpile path is for *execution*, not for shipping production artifacts.
 
-## What's the hot-reload story?
+## Does it hot-reload?
 
 Watch mode restarts the process when files change — the watch set is the resolved dependency graph plus your `.env*` files and `tsconfig.json`, so a TypeScript project needs no glob list. It does not preserve in-memory state or hot-swap modules in place. See [Watch mode](/docs/watch).

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -69,7 +69,7 @@ Works. CommonJS, `require()`, dynamic `require()`, `require.cache`, `module.expo
 
 ## What about native (N-API) addons?
 
-Works. Native addons compile against Node's N-API ABI, and Nub is running on a stock Node binary, so addons load exactly as they do on plain Node. (Nub itself ships its `oxc` transpiler as an N-API addon; that path is the same path your `better-sqlite3` or `@napi-rs/canvas` uses.) Compiling one from source carries one upstream caveat under the default install layout — see [GYP-based native builds](/docs/install/virtual-store#gyp-based-native-builds).
+Works. Native addons compile against Node's N-API ABI, and Nub is running on a stock Node binary, so addons load as they do on plain Node. (Nub itself ships its `oxc` transpiler as an N-API addon; that path is the same path your `better-sqlite3` or `@napi-rs/canvas` uses.) Compiling one from source carries one upstream caveat under the default install layout — see [GYP-based native builds](/docs/install/virtual-store#gyp-based-native-builds).
 
 ## Does it support all Node core modules?
 
@@ -153,14 +153,14 @@ Yes — `nub script.ts` runs TypeScript directly, with the full TS surface (not 
 
 ## Why not just use Node's built-in TypeScript support?
 
-Node 22.18+ runs `.ts` files by default, but it *strips* types rather than transpiling them — so anything beyond erasable annotations is on its own:
+Node 22.18+ runs `.ts` files by default, but only strips types. Anything beyond erasable annotations fails:
 
 - `enum`, `namespace`, and parameter properties → syntax errors (Node 26 even removed `--experimental-transform-types`, the flag that used to handle them)
 - JSX and `emitDecoratorMetadata` → unsupported
 - `tsconfig.json` `paths`, `baseUrl`, `jsx`, `experimentalDecorators`, `extends` → ignored ("intentionally unsupported," per the Node 26 docs)
 - Extensionless `.ts` imports → unresolved, and no source maps
 
-Nub transpiles each file through its native addon instead, so all of that works. If your codebase is `erasableSyntaxOnly`-clean, Node's built-in support is fine; if it isn't, you need a real transpile pipeline.
+Nub transpiles each file through its native addon instead. If your codebase is `erasableSyntaxOnly`-clean, Node's built-in support is enough.
 
 ## Does it replace `nodemon` / `tsx watch`?
 
@@ -180,7 +180,7 @@ Not needed. Nub loads your env files automatically — with the Vite/Bun-style p
 The `[mode]` slot comes from `APP_ENV` — not `NODE_ENV`. To load a specific file directly, pass `--env-file` (repeatable); its values arrive verbatim, as on Node. In the automatic `.env*` files, expansion of `${VAR}` and `$VAR` is supported, including nested references and cycle detection.
 
 <Callout title="Test mode">
-Under the test mode (`APP_ENV=test`), `.env.local` is skipped, following the Next.js convention — local secrets shouldn't leak into your test suite.
+Under the test mode (`APP_ENV=test`), `.env.local` is skipped, following the Next.js convention.
 </Callout>
 
 Full details: [Runtime → Environment variables](/docs/runtime/env).
@@ -340,7 +340,7 @@ Useful when a script's `#!/usr/bin/env node` shebang chain expects real Node, wh
 
 ## Does Nub add anything to my `package.json`?
 
-No. The fields Nub reads are the existing standard ones, exactly as Node, `npm`, `pnpm`, and `yarn` read them:
+No. The fields Nub reads are the existing standard ones, as Node, `npm`, `pnpm`, and `yarn` read them:
 
 ```text
 scripts

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -153,7 +153,7 @@ Yes — `nub script.ts` runs TypeScript directly, with the full TS surface (not 
 
 ## Why not just use Node's built-in TypeScript support?
 
-Node 22.18+ runs `.ts` files by default, but only strips types. Anything beyond erasable annotations fails:
+Node 22.18+ runs `.ts` files by default, but only strips types. Anything beyond erasable annotations is rejected or ignored:
 
 - `enum`, `namespace`, and parameter properties → syntax errors (Node 26 even removed `--experimental-transform-types`, the flag that used to handle them)
 - JSX and `emitDecoratorMetadata` → unsupported

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -112,7 +112,7 @@ It can. The `nub install` command is a full package manager — pnpm's CLI surfa
 
 ## Does it work with `pnpm` / `npm` / `yarn` / `bun`?
 
-Yes. All four keep working exactly as they do without Nub. Your lockfile stays in whatever format your package manager produces, and workspace topology (`pnpm-workspace.yaml`, `npm` workspaces, `yarn` workspaces) is honored by `nub run` and `nubx` directly. The sources of truth:
+Yes. Your lockfile stays in whatever format your package manager produces, and workspace topology (`pnpm-workspace.yaml`, `npm` workspaces, `yarn` workspaces) is honored by `nub run` and `nubx` directly. The sources of truth:
 
 - `nub run` reads `package.json` and its `"scripts"` field.
 - `nubx` reads `node_modules/.bin`.
@@ -301,17 +301,17 @@ Deno.env
 Deno.readTextFile
 ```
 
-Deno implements Node compatibility inside Deno. Nub runs on the actual Node binary you installed; if a package works on Node, it works on Nub, by construction.
+Deno implements Node compatibility inside Deno. Nub runs on the actual Node binary you installed; if a package works on Node, it works on Nub.
 
 ## How is it different from `node --run`?
 
-Node shipped a built-in script runner in 22.0 — `node --run` — and it's genuinely fast. But it's deliberately minimal, and the gaps are why projects still reach for `pnpm run`:
+Node shipped a built-in script runner in 22.0 — `node --run` — and it's fast. But it's deliberately minimal, and the gaps are why projects still reach for `pnpm run`:
 
 - No `pre` / `post` lifecycle hooks.
 - No workspaces — no recursive or filtered runs across a monorepo.
 - No `npm_*` environment variables (`npm_package_*`, `npm_config_*`, `npm_lifecycle_event`) that countless scripts read.
 
-The `nub run` command is just as fast in the [script-runner benchmark](https://github.com/nubjs/nub/tree/main/tests/bench/script-runner) and closes all three, so scripts written for `npm` or `pnpm` keep working unchanged.
+The `nub run` command is just as fast in the [script-runner benchmark](https://github.com/nubjs/nub/tree/main/tests/bench/script-runner) and closes all three.
 
 ## What if I want to stop using Nub?
 
@@ -421,12 +421,12 @@ No. Vite already owns this; `nub run dev` runs whatever your project's `dev` scr
 
 ## Does it have a test runner?
 
-No. Node's own `node:test` already owns this — and `vitest` and `jest` if you prefer those. Nub runs whichever you've chosen. Workers spawned by your test runner inherit Nub's augmentation, so TypeScript test files run directly.
+No. Node's own `node:test` covers it — and `vitest` and `jest` if you prefer those. Nub runs whichever you've chosen. Workers spawned by your test runner inherit Nub's augmentation, so TypeScript test files run directly.
 
 ## Does it have a bundler?
 
-No. The bundlers your project already uses (Vite / Rollup / Rolldown / esbuild / webpack / tsup) keep working. Nub's transpile path is for *execution*, not for shipping production artifacts.
+No. Use the bundler your project already has (Vite / Rollup / Rolldown / esbuild / webpack / tsup); Nub's transpile path is for *execution*, not for shipping production artifacts.
 
 ## What's the hot-reload story?
 
-Watch mode restarts the process when files change — the watch set is the resolved dependency graph plus your `.env*` files and `tsconfig.json`, so a TypeScript project needs no glob list. It does not preserve in-memory state or hot-swap modules in place; a restart is a restart. See [Watch mode](/docs/watch).
+Watch mode restarts the process when files change — the watch set is the resolved dependency graph plus your `.env*` files and `tsconfig.json`, so a TypeScript project needs no glob list. It does not preserve in-memory state or hot-swap modules in place. See [Watch mode](/docs/watch).

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -13,7 +13,7 @@ nub run dev              # run a package.json script
 nubx prisma generate     # run a CLI from node_modules/.bin
 ```
 
-Every augmentation rides on Node's own public extension surfaces, and the package manager reads and writes whatever lockfile your project already uses.
+Every augmentation uses Node's own public extension surfaces, and the package manager reads and writes whatever lockfile your project already uses.
 
 ## The toolkit
 
@@ -25,7 +25,7 @@ Every augmentation rides on Node's own public extension surfaces, and the packag
 - **A watcher** — restart on changes to your source, your `.env*` files, and your `tsconfig.json`, driven by the dependency graph. See [watch](/docs/watch).
 - **A GitHub Action** — swap `actions/setup-node` for `nubjs/setup-nub` to install Nub, warm the project's Node, and cache Nub's store in CI. See [GitHub Action](/docs/deployment/github-action).
 
-## What Nub replaces
+## Replaced tools
 
 | Nub | Instead of |
 |---|---|
@@ -49,7 +49,7 @@ Both `pnpm add -g @nubjs/nub` and `yarn global add @nubjs/nub` work too. That in
 brew install nub
 ```
 
-With [mise](https://mise.jdx.dev), `nub` and `nubx` both land on `PATH`:
+With [mise](https://mise.jdx.dev), `nub` and `nubx` are both put on `PATH`:
 
 ```bash
 mise use -g nub
@@ -76,7 +76,7 @@ Every code commit to `main` publishes a canary build for all platforms, versione
 npm install -g @nubjs/nub@canary
 ```
 
-The same binaries are attached to the rolling [canary release](https://github.com/nubjs/nub/releases/tag/canary) on GitHub. Canary tracks the newest commit and passes build and smoke checks only — expect rough edges, and pin back to `@nubjs/nub@latest` to return to the stable channel.
+The same binaries are attached to the rolling [canary release](https://github.com/nubjs/nub/releases/tag/canary) on GitHub. Canary tracks the newest commit and passes build and smoke checks only; pin back to `@nubjs/nub@latest` to return to the stable channel.
 
 ## Package management
 
@@ -90,11 +90,11 @@ nub update
 nub ci                   # frozen-lockfile install
 ```
 
-It's optional: keep running your existing package manager and reach for Nub for everything else. See [install](/docs/install) for lockfile fidelity per incumbent, and [pm](/docs/pm) for provisioning the exact package-manager version a project pins.
+The installer is optional: keep your existing package manager and use Nub for everything else. See [install](/docs/install) for lockfile fidelity per incumbent, and [pm](/docs/pm) for provisioning the exact package-manager version a project pins.
 
 ## Configuration
 
-Everything above works with no configuration. When you want to change a default, put a `nub.jsonc` at the project root:
+To change a default, put a `nub.jsonc` at the project root:
 
 ```jsonc title="nub.jsonc"
 {
@@ -117,6 +117,6 @@ Unknown keys and invalid values stop the command with an error. See [nub.jsonc](
 - **Node 18.19+** (Node 18 LTS) for augmented modes.
 - macOS (arm64, x64), Linux (x64, arm64), Windows (x64, arm64).
 
-## Where to next
+## Next steps
 
 - Quick answers: the [FAQ](/docs/faq).

--- a/site/content/docs/init.mdx
+++ b/site/content/docs/init.mdx
@@ -74,7 +74,7 @@ The tsconfig targets Node's own TypeScript semantics — `nodenext` resolution, 
 }
 ```
 
-The generated project is not locked to Nub: everything runs on plain Node too (the `devEngines` policy is `ignore` — a signal to read, not a rule to enforce), and swapping the start script to a plain `node` invocation is the only change a non-Nub user would make. Plain `node` runs the TypeScript entry on Node ≥22.18 (type stripping, unflagged in 23.6 and backported to 22.18); on older Node, scaffold with `--js` instead.
+The generated project is not locked to Nub: everything runs on plain Node too (the `devEngines` policy is `ignore`, so nothing enforces it), and swapping the start script to a plain `node` invocation is the only change a non-Nub user would make. Plain `node` runs the TypeScript entry on Node ≥22.18 (type stripping, unflagged in 23.6 and backported to 22.18); on older Node, scaffold with `--js` instead.
 
 ## Prompts
 

--- a/site/content/docs/init.mdx
+++ b/site/content/docs/init.mdx
@@ -24,14 +24,14 @@ Your project is ready!
 Try running `nub index.ts`
 ```
 
-The scaffold has zero runtime dependencies — the entry file runs right away:
+The scaffold has zero runtime dependencies:
 
 ```console
 $ nub index.ts
 Hello from Nub
 ```
 
-## What it writes
+## Generated files
 
 The manifest carries the same `packageManager` pin and `devEngines` range that [`nub pm pin`](/docs/pm#nub-pm-pin) writes, plus the dev dependencies:
 
@@ -78,7 +78,7 @@ The generated project is not locked to Nub: everything runs on plain Node too (t
 
 ## Prompts
 
-In a terminal, `nub init` asks three questions — project name, TypeScript or JavaScript, and whether to initialize git. Every prompt has a sensible default; `-y` skips them all. Outside a terminal (CI, piped stdin) the defaults apply automatically, so the command never hangs.
+In a terminal, `nub init` asks three questions — project name, TypeScript or JavaScript, and whether to initialize git. Each prompt has a default; `-y` accepts them all. Outside a terminal (CI, piped stdin) the defaults apply automatically.
 
 ## Flags
 
@@ -105,7 +105,7 @@ Passing `--force` overwrites the listed files. An existing `.git/` is never touc
 
 ## Templates
 
-Framework templates are not init's job — they belong to `nub create`. It resolves the ecosystem's `create-*` convention (`vue` → `create-vue`, `@scope/foo` → `@scope/create-foo`), fetches the scaffolder, and runs it. Scaffolders that detect the invoking package manager answer with Nub commands:
+Framework templates come from `nub create`. It resolves the ecosystem's `create-*` convention (`vue` → `create-vue`, `@scope/foo` → `@scope/create-foo`), fetches the scaffolder, and runs it. Scaffolders that detect the invoking package manager answer with Nub commands:
 
 ```console
 $ nub create vue my-app --default
@@ -123,7 +123,7 @@ Everything after the template name is passed through to the scaffolder, so each 
 Read the [full docs](https://pnpm.io/cli/create) for `pnpm create` on pnpm.io.
 </Callout>
 
-Passing a template to `init` points you the same way:
+Passing a template to `init` prints the same hint:
 
 ```console
 $ nub init vite

--- a/site/content/docs/install/bun.mdx
+++ b/site/content/docs/install/bun.mdx
@@ -109,7 +109,7 @@ dependencies:
 nub 0.0.44 · ✓ installed 2 packages in 35ms
 ```
 
-Nub's curated default-trust floor stays on but does nothing over a `bun.lock`: its cooling-window gate needs per-package publish times, which `bun.lock` does not carry, so it fails closed. Only `trustedDependencies` builds anything, matching Bun.
+Nub's curated default-trust floor is inert over a `bun.lock`: its cooling-window gate needs per-package publish times, which `bun.lock` does not carry, so it fails closed. Only `trustedDependencies` builds anything, matching Bun.
 
 ## `bunfig.toml`
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -12,7 +12,7 @@ nub update --latest       # move ranges to the newest release
 nub dedupe                # collapse duplicate versions
 ```
 
-The lockfile is `nub.lock`. Every field Nub reads to build the graph is one pnpm, npm, Yarn, or Bun already reads — Nub adds no config field of its own, so there is no new syntax here to learn. Running Nub inside a repo that already belongs to one of those tools works too: see [lockfile compatibility](#lockfile-compatibility).
+The lockfile is `nub.lock`. Every field Nub reads to build the graph is one pnpm, npm, Yarn, or Bun already reads — Nub adds no config field of its own. Running Nub inside a repo that already belongs to one of those tools works too: see [lockfile compatibility](#lockfile-compatibility).
 
 ## Layout
 
@@ -449,7 +449,7 @@ cowsay hello
 nub remove -g cowsay
 ```
 
-Two directories are involved, and they are deliberately separate:
+Two directories are involved:
 
 | | Default | Purpose |
 | --- | --- | --- |
@@ -546,7 +546,7 @@ $ nub add some-tool
 
 The fallback stops at whatever the publisher currently tags `latest`. A higher version that was published and then untagged is a release they withdrew, so Nub never falls back to one. A prerelease `latest` fails outright for the same reason — the stable release below it belongs to a line the publisher has moved off.
 
-The report follows the same rule, and just as quietly. Both version columns of `nub outdated` name what an install would land on, so a version inside the window is never offered:
+The report follows the same rule. Both version columns of `nub outdated` name what an install would land on, so a version inside the window is never offered:
 
 ```console
 $ nub outdated
@@ -577,7 +577,7 @@ $ nub add some-tool --minimum-release-age-exclude='@internal/*' --minimum-releas
 ```
 
 <Callout title="The window is enforced, not advisory">
-When nothing satisfying the range is old enough, the install fails — Nub never quietly takes a version that missed the cutoff, and no flag relaxes that. Setting the window to `0` turns it off outright, which is the honest way to say you don't want one.
+When nothing satisfying the range is old enough, the install fails — Nub never quietly takes a version that missed the cutoff, and no flag relaxes that. Setting the window to `0` turns it off outright.
 </Callout>
 
 Publish dates come from the registry's `time` metadata, so the gate is only as strong as what the registry serves. An age Nub cannot establish counts as a failure rather than a pass:
@@ -591,7 +591,7 @@ Publish dates come from the registry's `time` metadata, so the gate is only as s
 
 Registries that publish no dates at all — some private mirrors, older Verdaccio — hit the last row. The refusal is its own error, `ERR_NUB_RELEASE_AGE_MISSING_TIME`, rather than the too-new one.
 
-This is the one case where the report cannot stay quiet. Staying silent would leave `nub outdated` reporting no work to do on a project where every install refuses, so it names the package on stderr and leaves stdout as data:
+This is the one case where `nub outdated` warns: staying silent would report no work to do on a project where every install refuses. The warning goes to stderr, leaving stdout as data:
 
 ```console
 $ nub outdated
@@ -606,7 +606,7 @@ minimumReleaseAgeExclude=internal-pkg   # exempt one package (comma-separated)
 minimumReleaseAge=0                     # turn the window off
 ```
 
-Setting pnpm's `minimumReleaseAgeStrict=false` also gets past both, and Nub reads it for compatibility — but it makes an undateable version count as *clearing* the gate, which is a window you still appear to have and no longer enforce. Prefer `minimumReleaseAge=0`, which says the same thing plainly.
+Setting pnpm's `minimumReleaseAgeStrict=false` also gets past both, and Nub reads it for compatibility — but it makes an undateable version count as *clearing* the gate, which is a window you still appear to have and no longer enforce. Prefer `minimumReleaseAge=0`.
 
 ### Default-trust floor
 
@@ -977,7 +977,7 @@ Set layout with [`install.linker` and `install.publicHoist` in `nub.jsonc`](/doc
 
 Running `nub pm use nub` moves a project onto Nub's own surface: it aligns the manifest and lockfile, migrates pnpm workspace config into the neutral `package.json` fields, and writes `nub.lock`. A fresh `nub install` in a project with no declaration and no lockfile does the same thing implicitly.
 
-Either way Nub records itself with a non-locking range rather than an exact pin. Tools that read `devEngines` by name see the signal, and the caret is a floor, so upgrading Nub just works.
+Either way Nub records itself with a non-locking range rather than an exact pin. Tools that read `devEngines` by name see the signal, and the caret is a floor rather than a pin.
 
 ```json title="package.json"
 {
@@ -985,7 +985,7 @@ Either way Nub records itself with a non-locking range rather than an exact pin.
     "packageManager": {
       "name": "nub",
       "version": "^0.7.1",   // a floor, not a pin
-      "onFail": "ignore"     // a signal to read, not a rule to enforce
+      "onFail": "ignore"     // nothing enforces it
     }
   }
 }
@@ -1030,5 +1030,5 @@ Error: ERR_NUB_LOCKFILE_DECLARATION_MISMATCH
 In a Nub-owned project, `nub.lock` beside a foreign lockfile is the same ambiguity error.
 
 <Callout title="Inference vs the pinned PM">
-This inference picks the *install engine's* incumbent — the format Nub reads and writes. It is separate from the version `nub pm` provisions: the meta-manager resolves a *pin* (`.yarnrc.yml` `yarnPath` → `packageManager` → `devEngines`) to fetch and run an exact PM binary. Same signals, different questions: "which format do I install in?" versus "which PM binary do I run?".
+This inference picks the *install engine's* incumbent — the format Nub reads and writes. It is separate from the version `nub pm` provisions: the meta-manager resolves a *pin* (`.yarnrc.yml` `yarnPath` → `packageManager` → `devEngines`) to fetch and run an exact PM binary. The two answer different questions: which format to install in, and which PM binary to run.
 </Callout>

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -541,12 +541,12 @@ Asking for a package without naming a version resolves to the newest release tha
 
 ```console
 $ nub add some-tool
-+ some-tool@2.3.0  latest 2.4.0   # ✓ 2.4.0 is still inside the window
++ some-tool@2.3.0  latest 2.4.0   # 2.4.0 is still inside the window, so 2.3.0 installs
 ```
 
-The fallback stops at whatever the publisher currently tags `latest`; a version published and then untagged was withdrawn, and Nub never falls back to one. When `latest` is a prerelease the command fails outright, since the stable release below it belongs to a line the publisher has moved off.
+The fallback stops at whatever the publisher currently tags `latest`; a version published and then untagged was withdrawn. When `latest` is a prerelease the command fails outright, since the stable release below it belongs to a line the publisher has moved off.
 
-The report follows the same rule. Both version columns of `nub outdated` name what an install would land on, so a version inside the window is never offered:
+Both version columns of `nub outdated` follow the same rule: they name what an install would land on, so a version inside the window is never offered:
 
 ```console
 $ nub outdated
@@ -577,10 +577,10 @@ $ nub add some-tool --minimum-release-age-exclude='@internal/*' --minimum-releas
 ```
 
 <Callout title="The window is enforced, not advisory">
-When nothing satisfying the range is old enough, the install fails; Nub never quietly takes a version that missed the cutoff. Setting the window to `0` turns it off outright.
+When nothing satisfying the range is old enough, the install fails. Setting `minimumReleaseAge` to `0s` turns the window off entirely.
 </Callout>
 
-Publish dates come from the registry's `time` metadata. An age Nub cannot establish is a failure:
+Publish dates come from the registry's `time` metadata, and the outcome depends on what it supplies:
 
 | Registry metadata | Outcome |
 |---|---|

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -46,7 +46,7 @@ The `--node-linker` flag does the same for one command. The same two choices are
 }
 ```
 
-Both fields take an object form too — see [`install.linker`](/docs/config#installlinker) and [`install.publicHoist`](/docs/config#installpublichoist) for the strategies and their knobs. See [the flat opt-out](/docs/install/virtual-store#the-flat-opt-out) for choosing between the layouts.
+Both fields take an object form too — see [`install.linker`](/docs/config#installlinker) and [`install.publicHoist`](/docs/config#installpublichoist) for the strategies and their options. See [the flat opt-out](/docs/install/virtual-store#the-flat-opt-out) for choosing between the layouts.
 
 ## Resolution
 
@@ -109,7 +109,7 @@ Read the [full docs](https://pnpm.io/settings/dependency-resolution#packageexten
 
 ### `patchedDependencies`
 
-Apply a patch file to a package's contents, keyed by name and version. Running `nub patch <pkg>` writes both the patch and this entry for you. A key matching no installed package fails the install unless `allowUnusedPatches` downgrades it to a warning.
+Apply a patch file to a package's contents, keyed by name and version. Running `nub patch <pkg>` writes both the patch and this entry. A key matching no installed package fails the install unless `allowUnusedPatches` downgrades it to a warning.
 
 ```json title="package.json"
 {
@@ -165,7 +165,7 @@ Read the [full docs](https://pnpm.io/catalogs) on pnpm.io. The `catalog:` syntax
 
 ### `allowBuilds`
 
-Which dependencies may run install scripts — see [lifecycle scripts](#lifecycle-scripts) for the deny-by-default posture around it. A registry dependency is keyed by name, anything else by its full specifier, and an explicit `false` always wins.
+Which dependencies may run install scripts — see [lifecycle scripts](#lifecycle-scripts) for the deny-by-default rules around it. A registry dependency is keyed by name, anything else by its full specifier, and an explicit `false` always wins.
 
 ```json title="package.json"
 {
@@ -310,7 +310,7 @@ The accepted flags are pnpm's spellings:
 --libc <libc>
 ```
 
-Packages like `esbuild` and `rollup` ship one prebuilt binary per platform as optional dependencies, and an install picks only the one matching the machine it runs on. Pass `--os`, `--cpu`, or `--libc` to pick a different one — when building a Linux container image from a Mac, say:
+Packages like `esbuild` and `rollup` ship one prebuilt binary per platform as optional dependencies, and an install picks only the one matching the machine it runs on. Pass `--os`, `--cpu`, or `--libc` to pick a different one, for example when building a Linux container image from a Mac:
 
 ```bash
 nub install --os linux --cpu x64
@@ -417,7 +417,7 @@ nub import          # package-lock.json / yarn.lock / bun.lock → pnpm-lock.yam
 nub import --force  # overwrite an existing pnpm-lock.yaml
 ```
 
-The full registered verb set covers more:
+The full verb set:
 
 ```text
 why          outdated      list, ls
@@ -475,11 +475,11 @@ Linked 2 bins into /Users/you/.local/bin
   Restart your shell, or source that file, to pick it up.
 ```
 
-The block is written once, under a `# nub global bin` marker, for bash, zsh and fish. Installing again does not add a second copy, and pointing the directory somewhere new rewrites that line rather than stacking another. When no profile can be written, Nub prints the line for you to add by hand instead.
+The block is written once, under a `# nub global bin` marker, for bash, zsh and fish. Installing again does not add a second copy, and pointing the directory somewhere new rewrites that line rather than stacking another. When no profile can be written, Nub prints the line to add by hand.
 
 ### Name collisions
 
-The executable directory is shared, so a package may want a name something else already occupies. Nub links it only when it can show the existing entry is one of its own; otherwise it keeps your file and says what it skipped:
+The executable directory is shared, so a package's executable name may already be taken. Nub links it only when it can show the existing entry is one of its own; otherwise it keeps your file and says what it skipped:
 
 ```console
 $ nub add -g cowsay
@@ -490,7 +490,7 @@ The rest of the package's executables still link. Removing a global package like
 
 ## Lifecycle scripts
 
-Some dependencies run build steps on install — `preinstall`, `install`, and `postinstall` scripts declared in their own `package.json` (across pnpm, npm, and Bun). Nub ships a **deny-by-default** posture: it does not run them indiscriminately the way npm does. You control which packages build.
+Some dependencies run build steps on install — `preinstall`, `install`, and `postinstall` scripts declared in their own `package.json` (across pnpm, npm, and Bun). Nub denies them by default; you allow the packages that may build.
 
 ```bash
 nub approve-builds                # approve packages to build, then build them
@@ -513,7 +513,7 @@ The neutral `allowBuilds` field grants permission, and it keys on the package na
 }
 ```
 
-That field applies in any project, whoever owns it. A project owned by another package manager grants permission through its own field as well: pnpm projects use `pnpm.onlyBuiltDependencies` / `pnpm.allowBuilds`, and Bun projects use `trustedDependencies`. A package that wants to build but isn't allowed is skipped, with `WARN_NUB_IGNORED_BUILD_SCRIPTS` naming it and `nub approve-builds` as the remedy.
+That field applies in any project, whoever owns it. A project owned by another package manager grants permission through its own field as well: pnpm projects use `pnpm.onlyBuiltDependencies` / `pnpm.allowBuilds`, and Bun projects use `trustedDependencies`. A package with build scripts that is not allowed is skipped, with `WARN_NUB_IGNORED_BUILD_SCRIPTS` naming it and `nub approve-builds` as the remedy.
 
 ### When a build fails
 
@@ -546,7 +546,7 @@ $ nub add some-tool
 
 The fallback stops at whatever the publisher currently tags `latest`; a version published and then untagged was withdrawn. When `latest` is a prerelease the command fails outright, since the stable release below it belongs to a line the publisher has moved off.
 
-Both version columns of `nub outdated` follow the same rule: they name what an install would land on, so a version inside the window is never offered:
+Both version columns of `nub outdated` follow the same rule: they name what an install would select, so a version inside the window is never offered:
 
 ```console
 $ nub outdated
@@ -576,7 +576,7 @@ The exclude flag *replaces* the configured `minimumReleaseAgeExclude` for that r
 $ nub add some-tool --minimum-release-age-exclude='@internal/*' --minimum-release-age-exclude=some-tool
 ```
 
-<Callout title="The window is enforced, not advisory">
+<Callout title="Enforcement">
 When nothing satisfying the range is old enough, the install fails. Setting `minimumReleaseAge` to `0s` turns the window off entirely.
 </Callout>
 
@@ -589,7 +589,7 @@ Publish dates come from the registry's `time` metadata, and the outcome depends 
 | No per-version dates, document older than the window | Allowed — the document's own timestamp bounds every version in it |
 | No per-version dates, document newer than the window | Blocked |
 
-Registries that publish no dates at all — some private mirrors, older Verdaccio — hit the last row. The refusal is its own error, `ERR_NUB_RELEASE_AGE_MISSING_TIME`, rather than the too-new one.
+Registries that publish no dates at all — some private mirrors, older Verdaccio — fall under the last row. The refusal is its own error, `ERR_NUB_RELEASE_AGE_MISSING_TIME`, rather than the too-new one.
 
 This is the one case where `nub outdated` warns: staying silent would report no work to do on a project where every install refuses. The warning goes to stderr, leaving stdout as data:
 
@@ -599,14 +599,14 @@ warn: internal-pkg has no registry publish times, so minimumReleaseAge cannot ad
 All dependencies up to date.
 ```
 
-Two ways through:
+Two remedies:
 
 ```ini title=".npmrc"
 minimumReleaseAgeExclude=internal-pkg   # exempt one package (comma-separated)
 minimumReleaseAge=0                     # turn the window off
 ```
 
-Setting pnpm's `minimumReleaseAgeStrict=false` also gets past both, and Nub reads it for compatibility — but it makes an undateable version count as *clearing* the gate, which is a window you still appear to have and no longer enforce. Prefer `minimumReleaseAge=0`.
+Setting pnpm's `minimumReleaseAgeStrict=false` also gets past both, and Nub reads it for compatibility — but it makes an undateable version count as *clearing* the gate, so the window appears enforced but is not. Prefer `minimumReleaseAge=0`.
 
 ### Default-trust floor
 
@@ -630,7 +630,7 @@ dependencies:
 + esbuild@0.21.5
 ```
 
-When a gate fails, the floor steps aside rather than guess: the same package is skipped and disclosed, with `nub approve-builds` as the remedy. Tighten the cooling window past every published version and even a curated package fails closed:
+When a gate fails, the floor does not apply: the same package is skipped and disclosed, with `nub approve-builds` as the remedy. Tighten the cooling window past every published version and even a curated package fails closed:
 
 ```console
 # captured: nub 0.0.44, esbuild — minimumReleaseAge set past every release
@@ -642,11 +642,11 @@ dependencies:
 + esbuild@0.21.5
 ```
 
-A foreign lockfile that carries no publish-time data — notably an incumbent `bun.lock` — trips the same fail-closed path: the cooling gate has nothing to read, so the package is skipped (see the [Bun page](/docs/install/bun#trusteddependencies) for the captured A/B).
+A foreign lockfile that carries no publish-time data — notably an incumbent `bun.lock` — takes the same fail-closed path: the cooling gate has nothing to read, so the package is skipped (see the [Bun page](/docs/install/bun#trusteddependencies)).
 
 ### Advisory gate
 
-The OSV check queries `api.osv.dev` on a fresh resolve. A confirmed `MAL-*` hit is a **hard block** — the install aborts with `ERR_NUB_MALICIOUS_PACKAGE`, never a skip-and-warn. An osv.dev **outage** is treated differently: the check fails *open*, warning and proceeding so a network blip can't brick an offline install. To fail closed on outages too, set `advisoryCheck=required`.
+The OSV check queries `api.osv.dev` on a fresh resolve. A confirmed `MAL-*` hit is a **hard block** — the install aborts with `ERR_NUB_MALICIOUS_PACKAGE`, never a skip-and-warn. An osv.dev **outage** is treated differently: the check fails *open*, warning and proceeding, so an outage does not block an install. To fail closed on outages too, set `advisoryCheck=required`.
 
 Frozen reinstalls — `nub ci`, `--frozen-lockfile`, a teammate's clone — inherit the advisory vetting recorded when the lockfile was written and skip the per-install round-trip, but still enforce the cooling and provenance gates on every install.
 
@@ -666,7 +666,7 @@ The substitution stays inside the declared range and never crosses the refused v
 
 A lockfile names one exact version rather than a range, so there is nothing to walk. Any install that reuses an undrifted lockfile — `nub ci`, `--frozen-lockfile`, or a plain `nub install` — still aborts on a pin the check refuses, because only a fresh resolve has a range to substitute within. The remedy is `nub install --no-frozen-lockfile`.
 
-The comparison is by publish date, so a legitimate maintenance release on an older major — shipped after a newer major adopted provenance — can trip it. Nub exempts any version older than 14 days, so an aged, un-yanked backport resolves while a freshly published downgrade is still checked against the full history. Widen the window, clear a single package, or turn the check off in `.npmrc`:
+The comparison is by publish date, so a legitimate maintenance release on an older major — shipped after a newer major adopted provenance — can trigger it. Nub exempts any version older than 14 days, so an aged, un-yanked backport resolves while a freshly published downgrade is still checked against the full history. Widen the window, clear a single package, or turn the check off in `.npmrc`:
 
 ```ini title=".npmrc"
 trustPolicyIgnoreAfter=20160        # age exemption in minutes (default 14 days)
@@ -680,7 +680,7 @@ Regardless of the incumbent, Nub installs through a global content-addressed sto
 
 ### Global content store
 
-Package files are deduplicated by content hash in a global store at `$XDG_DATA_HOME/nub/store/v1/` (default `~/.local/share/nub/store/v1/`). Every install imports from it, so a given package version lands on disk once and is shared across projects.
+Package files are deduplicated by content hash in a global store at `$XDG_DATA_HOME/nub/store/v1/` (default `~/.local/share/nub/store/v1/`). Every install imports from it, so a given package version is on disk once and is shared across projects.
 
 ```console
 $ nub store path
@@ -700,7 +700,7 @@ $ nub store path
 /srv/nub-store/v1
 ```
 
-For a single invocation — a CI runner, a test sandbox, any run that must not touch or warm-hit the machine's real store — set the environment form instead:
+For a single invocation — a CI runner, a test sandbox, any run that must not touch the machine's real store — set the environment form instead:
 
 ```console
 $ npm_config_store_dir=/tmp/scratch-store nub install
@@ -731,14 +731,14 @@ npm_config_cache_dir=/mnt/fast/nub-cache nub install   # neutral — npm and pnp
 NUB_CACHE_DIR=/mnt/fast/nub-cache nub install          # Nub's own spelling, wins over the above
 ```
 
-Ask for the effective value rather than guessing which source won:
+Print the effective value:
 
 ```console
 $ npm_config_cache_dir=/mnt/fast/nub-cache nub config get cache-dir
 /mnt/fast/nub-cache
 ```
 
-Sharing a volume with `store-dir`, as the section above recommends, matters only while the shared virtual store is enabled: packages materialize into it by hardlink out of the content store, and a hardlink cannot cross filesystems, so a split degrades every install to a per-file copy — which Nub warns about. In CI the shared store is off by default, so the two can sit on different volumes there at no cost.
+Sharing a volume with `store-dir`, as the section above recommends, matters only while the shared virtual store is enabled: packages materialize into it by hardlink out of the content store, and a hardlink cannot cross filesystems, so a split degrades every install to a per-file copy — which Nub warns about. In CI the shared store is off by default, so the two can be on different volumes there.
 
 Some caches stay at the platform default whatever this is set to: the advisory database, the bootstrapped `node-gyp`, git clones, and the registry behind `nub link -g`.
 
@@ -756,7 +756,7 @@ The `--node-linker hoisted` flag does the same for a single command. When an und
 
 ### Shared vs per-project store
 
-Outside CI, the isolated virtual store is shared across projects: a package version materializes once per machine and every project links to that copy. It is fast and disk-cheap, but machine-local — the links reach outside the project, so a `node_modules` copied to another machine won't resolve.
+Outside CI, the isolated virtual store is shared across projects: a package version materializes once per machine and every project links to that copy. It is fast and uses little disk, but machine-local — the links reach outside the project, so a `node_modules` copied to another machine won't resolve.
 
 In CI, and under `nub ci`, each project gets its own self-contained virtual store instead — real directories and relative links, nothing shared. That tree survives a Docker `COPY --from` into a fresh image, where the shared store wouldn't exist. Force it for any install with one line in `.npmrc`:
 
@@ -764,7 +764,7 @@ In CI, and under `nub ci`, each project gets its own self-contained virtual stor
 enableGlobalVirtualStore=false
 ```
 
-Some packages and tools break when a dependency's real path sits outside the project. Nub detects those and steps around them on its own, so the rest of the tree keeps sharing:
+Some packages and tools break when a dependency's real path is outside the project. Nub detects those and ejects them, so the rest of the tree keeps sharing:
 
 | What breaks | Example | What Nub does |
 |---|---|---|
@@ -773,7 +773,7 @@ Some packages and tools break when a dependency's real path sits outside the pro
 | A bundler that resolves by real path | Next.js; Metro, in bare React Native and Expo before SDK 56 | Gives the project a self-contained store |
 | A dev server that gates real-path access by allow-list | Vite | Writes `node_modules/.modules.yaml`, which Vite reads — no `vite.config` change |
 
-Detection scans each package's published code rather than a curated list, so nothing needs maintaining. Add a bundler of your own in `.npmrc`:
+Detection scans each package's published code rather than a curated list. Add a bundler of your own in `.npmrc`:
 
 ```ini title=".npmrc"
 disableGlobalVirtualStoreForPackages=my-bundler   # comma-separated
@@ -810,7 +810,7 @@ nub install --prefer-offline  # try the cache first
 
 ## Lockfile compatibility
 
-Run Nub in a repo that already uses npm, pnpm, Yarn, or Bun and it behaves *as that package manager* — no migration, no new files, and no `nub.lock` dropped into a project it doesn't own. Nub infers the incumbent, then mirrors it: same lockfile format, same config files, same manifest fields. Inference walks one precedence chain:
+Run Nub in a repo that already uses npm, pnpm, Yarn, or Bun and it behaves *as that package manager* — no migration, no new files, and no `nub.lock` in a project it does not own. Nub infers the incumbent, then mirrors it: same lockfile format, same config files, same manifest fields. Inference walks one precedence chain:
 
 - **`packageManager`** — Corepack standard
 - **`devEngines.packageManager`** — object or array form
@@ -828,8 +828,8 @@ In a workspace, the chain runs from any member: Nub walks up to the root, which 
 
 A no-churn guard leaves a graph-equal lockfile untouched. The `bun.lockb` binary format is rejected — convert to text `bun.lock` first.
 
-<Callout title="You don't need to use Nub's package manager">
-The installer is optional. Keep running `npm`, `pnpm`, `yarn`, or `bun` as you do today, and reach for Nub for everything else — running files, scripts, and binaries.
+<Callout title="Optional">
+The installer is optional. Keep running `npm`, `pnpm`, `yarn`, or `bun` as you do today, and use Nub for everything else — running files, scripts, and binaries.
 </Callout>
 
 ### Config it reads
@@ -958,7 +958,7 @@ dependencies:
 + is-odd@3.0.1
 ```
 
-Declaring the same pin in both fields is the portable thing to do and stays silent, since the ignore changes nothing. Branded config from a *different* manager is never read: Nub in a pnpm project ignores Bun's `trustedDependencies`, and under its own identity it reads neither that nor `pnpm.overrides`, `pnpm-workspace.yaml`, `.pnpmfile.cjs`, `pnpm_config_*`, `.yarnrc.yml`, or `bunfig.toml`. To keep pnpm hooks or pnpm-named workspace config active, stay pnpm-owned or run `nub pm use pnpm`.
+Declaring the same pin in both fields is portable and stays silent, since the ignore changes nothing. Branded config from a *different* manager is never read: Nub in a pnpm project ignores Bun's `trustedDependencies`, and under its own identity it reads neither that nor `pnpm.overrides`, `pnpm-workspace.yaml`, `.pnpmfile.cjs`, `pnpm_config_*`, `.yarnrc.yml`, or `bunfig.toml`. To keep pnpm hooks or pnpm-named workspace config active, stay pnpm-owned or run `nub pm use pnpm`.
 
 ### Layout settings
 

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -535,7 +535,7 @@ The warning is emitted by the install that runs the build. A later install with 
 
 ### Cooling window
 
-A registry-resolved version must be older than `minimumReleaseAge` — 24 hours by default — before Nub will install it. The window covers the hours between a compromised publish going up and being caught.
+A registry-resolved version must be older than `minimumReleaseAge` — 24 hours by default — before Nub will install it.
 
 Asking for a package without naming a version resolves to the newest release that clears the window:
 
@@ -577,10 +577,10 @@ $ nub add some-tool --minimum-release-age-exclude='@internal/*' --minimum-releas
 ```
 
 <Callout title="The window is enforced, not advisory">
-When nothing satisfying the range is old enough, the install fails — Nub never quietly takes a version that missed the cutoff, and no flag relaxes that. Setting the window to `0` turns it off outright.
+When nothing satisfying the range is old enough, the install fails; Nub never quietly takes a version that missed the cutoff. Setting the window to `0` turns it off outright.
 </Callout>
 
-Publish dates come from the registry's `time` metadata, so the gate is only as strong as what the registry serves. An age Nub cannot establish counts as a failure rather than a pass:
+Publish dates come from the registry's `time` metadata. An age Nub cannot establish is a failure:
 
 | Registry metadata | Outcome |
 |---|---|

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -535,16 +535,16 @@ The warning is emitted by the install that runs the build. A later install with 
 
 ### Cooling window
 
-A registry-resolved version must be older than `minimumReleaseAge` — 24 hours by default — before Nub will install it. The window is what keeps a compromised publish out of your tree during the hours between it going up and being caught.
+A registry-resolved version must be older than `minimumReleaseAge` — 24 hours by default — before Nub will install it. The window covers the hours between a compromised publish going up and being caught.
 
-Asking for a package without naming a version resolves to the newest release that clears the window, so a fresh publish blocks that release rather than the whole command:
+Asking for a package without naming a version resolves to the newest release that clears the window:
 
 ```console
 $ nub add some-tool
 + some-tool@2.3.0  latest 2.4.0   # ✓ 2.4.0 is still inside the window
 ```
 
-The fallback stops at whatever the publisher currently tags `latest`. A higher version that was published and then untagged is a release they withdrew, so Nub never falls back to one. A prerelease `latest` fails outright for the same reason — the stable release below it belongs to a line the publisher has moved off.
+The fallback stops at whatever the publisher currently tags `latest`; a version published and then untagged was withdrawn, and Nub never falls back to one. When `latest` is a prerelease the command fails outright, since the stable release below it belongs to a line the publisher has moved off.
 
 The report follows the same rule. Both version columns of `nub outdated` name what an install would land on, so a version inside the window is never offered:
 
@@ -553,11 +553,11 @@ $ nub outdated
 All dependencies up to date.
 ```
 
-A project whose only pending upgrade sits inside the window has nothing to act on, so the command exits 0 and a CI check that runs it passes.
+With every pending upgrade inside the window, the command exits 0.
 
-The fallback never walks back past what is installed. A window set wider than a dependency's own age would otherwise leave the newest admitted release older than the installed one, and the report would name a downgrade as the version to move to. There is no upgrade in that case, so `Latest` reports the installed version and the command exits 0.
+The fallback never walks back past what is installed: when the window is wider than a dependency's own age, `Latest` reports the installed version and the command exits 0.
 
-Two flags adjust the window for a single command, so getting past a block never means editing config:
+Two flags adjust the window for a single command:
 
 ```console
 $ nub add some-tool
@@ -829,7 +829,7 @@ In a workspace, the chain runs from any member: Nub walks up to the root, which 
 A no-churn guard leaves a graph-equal lockfile untouched. The `bun.lockb` binary format is rejected — convert to text `bun.lock` first.
 
 <Callout title="You don't need to use Nub's package manager">
-The installer is optional. Keep running `npm`, `pnpm`, `yarn`, or `bun` exactly as you do today, and reach for Nub for everything else — running files, scripts, and binaries.
+The installer is optional. Keep running `npm`, `pnpm`, `yarn`, or `bun` as you do today, and reach for Nub for everything else — running files, scripts, and binaries.
 </Callout>
 
 ### Config it reads

--- a/site/content/docs/install/npm.mdx
+++ b/site/content/docs/install/npm.mdx
@@ -68,9 +68,9 @@ Read the [full docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-lock
 
 A no-op rewrite keeps the incoming `lockfileVersion` — a v2 lock stays v2. The first **mutating** operation (`nub add`, `nub remove`) rewrites it as v3 (npm's default since npm 9), so the version field is an expected diff. An `npm-shrinkwrap.json` is read and preserved as-is.
 
-Older formats are read too. A `lockfileVersion: 1` lock (npm 5/6) and a pre-2017 `npm-shrinkwrap.json` — a nested `dependencies` tree with no `lockfileVersion` field at all — both resolve and install: Nub lifts the legacy nested tree into the same install-path scheme it uses for v2/v3. Registry dependencies install fully. The first mutating operation (`nub add`, `nub remove`) rewrites the lock as v3, the same in-place upgrade npm 7+ performs.
+Older formats are read too. A `lockfileVersion: 1` lock (npm 5/6) and a pre-2017 `npm-shrinkwrap.json` — a nested `dependencies` tree with no `lockfileVersion` field at all — both resolve and install: Nub maps the legacy nested tree onto the same install-path scheme it uses for v2/v3. Registry dependencies install fully. The first mutating operation (`nub add`, `nub remove`) rewrites the lock as v3, the same in-place upgrade npm 7+ performs.
 
-Two legacy edges remain out of scope. Git and `file:` dependencies, which a v1 lock encodes in the `version` field rather than `resolved`, are not yet read. And a fully-hoisted pre-npm-5 shrinkwrap that records no `requires` edges cannot place every transitive — Nub installs what it can and warns about the rest (`WARN_NUB_LOCKFILE_LEGACY_INCOMPLETE_GRAPH`). For either, re-lock once under npm 7+, then `nub install`.
+Two legacy cases are not read. Git and `file:` dependencies, which a v1 lock encodes in the `version` field rather than `resolved`, are not yet read. And a fully-hoisted pre-npm-5 shrinkwrap that records no `requires` edges cannot place every transitive — Nub installs what it can and warns about the rest (`WARN_NUB_LOCKFILE_LEGACY_INCOMPLETE_GRAPH`). For either, re-lock once under npm 7+, then `nub install`.
 
 ## `.npmrc`
 

--- a/site/content/docs/install/pnpm.mdx
+++ b/site/content/docs/install/pnpm.mdx
@@ -160,7 +160,7 @@ $ nub install
   │ `hoisted`
 ```
 
-Lifecycle scripts for dependencies are skipped by default, exactly as pnpm 10 does. A package runs install scripts only when allowlisted via `pnpm.onlyBuiltDependencies` (or `pnpm.allowBuilds`), or when Nub's gated default-trust floor vouches for it (see [the default-trust floor](/docs/install#default-trust-floor)); `nub approve-builds` adds an entry and builds the approved packages in the same invocation. `pnpm.neverBuiltDependencies` is a denylist that wins over any allow and over the floor.
+Lifecycle scripts for dependencies are skipped by default, as pnpm 10 does. A package runs install scripts only when allowlisted via `pnpm.onlyBuiltDependencies` (or `pnpm.allowBuilds`), or when Nub's gated default-trust floor vouches for it (see [the default-trust floor](/docs/install#default-trust-floor)); `nub approve-builds` adds an entry and builds the approved packages in the same invocation. `pnpm.neverBuiltDependencies` is a denylist that wins over any allow and over the floor.
 
 ## Unsupported
 

--- a/site/content/docs/install/pnpm.mdx
+++ b/site/content/docs/install/pnpm.mdx
@@ -129,7 +129,7 @@ namedRegistries:
 
 Nub reads `overrides`, `packageExtensions`, and `patchedDependencies` from either home pnpm accepts: the `pnpm.*` namespace in `package.json`, or the matching key in `pnpm-workspace.yaml`. The pnpm resolver prefers `pnpm.overrides`; top-level `resolutions` is still honored (pnpm supports it for Yarn compatibility), but top-level `overrides` is npm and Bun's field and is ignored under pnpm.
 
-Adopting Nub into an existing pnpm repo leaves the project pnpm-owned, so all of this keeps working untouched. Switching it to Nub's own identity with `nub pm use nub` migrates the pins to the top-level `overrides` and `patchedDependencies` fields in `package.json`.
+Adopting Nub into an existing pnpm repo leaves the project pnpm-owned. Switching it to Nub's own identity with `nub pm use nub` migrates the pins to the top-level `overrides` and `patchedDependencies` fields in `package.json`.
 
 None of this is read under an npm, Yarn, or Bun incumbent, or in a Nub-identity project. Under those three incumbents, a stray `.pnpmfile.cjs` is ignored with a warning rather than applied silently:
 

--- a/site/content/docs/install/virtual-store.mdx
+++ b/site/content/docs/install/virtual-store.mdx
@@ -148,7 +148,7 @@ Holding 24 entries unreferenced for 30 days before removal.
 Install in any project that still needs them and they are kept.
 ```
 
-That delay is what makes the command safe to run on a store you have had for a while. A project only becomes visible to the prune once it has installed at least once, so on the day you upgrade every project you have not touched yet looks exactly like garbage. Without the hold, one install followed by one prune would delete the rest.
+That delay is what makes the command safe to run on a store you have had for a while. A project only becomes visible to the prune once it has installed at least once, so on the day you upgrade every project you have not touched yet looks like garbage. Without the hold, one install followed by one prune would delete the rest.
 
 With nothing registered at all, a prune skips the store entirely rather than treating an empty registry as an empty store:
 

--- a/site/content/docs/install/virtual-store.mdx
+++ b/site/content/docs/install/virtual-store.mdx
@@ -25,12 +25,12 @@ my-app/
     └── react  →  ~/.local/share/nub/store/…/react@19.2.0
 ```
 
-Two properties fall out of this layout:
+Two properties follow:
 
 - **Warm installs scale with package count, not file count.** Linking a project is O(packages) symlinks instead of O(files) hardlinks or copies.
-- **The store is a sealed world.** Node resolves a symlink to its real path before loading, so code loaded from the store resolves imports from inside its store entry — its declared dependencies and nothing else. An undeclared import fails at resolve time instead of working by accident.
+- **The store is sealed.** Node resolves a symlink to its real path before loading, so code loaded from the store resolves imports from inside its store entry — its declared dependencies and nothing else. An undeclared import fails at resolve time instead of working by accident.
 
-No other package manager ships this as its default. Bun shipped it for its isolated linker and reverted to opt-in three weeks later; pnpm keeps it behind the off-by-default `enableGlobalVirtualStore` flag. The blocker is the same in both trackers: widely-used packages import **phantom dependencies** — packages they never declare — and a sealed store breaks them. The deep dive on that history and the mechanism below is the blog post: [how we built a 5x faster package manager](/blog/unblocking-the-global-virtual-store).
+No other package manager ships this as its default. Bun shipped it for its isolated linker and reverted to opt-in three weeks later; pnpm keeps it behind the off-by-default `enableGlobalVirtualStore` flag. The blocker is the same in both trackers: widely-used packages import **phantom dependencies** — packages they never declare — and a sealed store breaks them. The history and the mechanism below are in the blog post: [how we built a 5x faster package manager](/blog/unblocking-the-global-virtual-store).
 
 ## Phantom detection and ejection
 
@@ -44,7 +44,7 @@ Detection and ejection are on for every install, with no configuration. Two tool
 
 ## Performance
 
-A warm install — store populated, frozen lockfile — is where the layout pays: relinking costs O(packages) while every other installer pays O(files), so the gap widens as trees get fatter.
+A warm install — store populated, frozen lockfile — is where the layout's advantage shows: relinking costs O(packages) while every other installer pays O(files), so the gap widens as trees grow.
 
 <Bench
   label="warm install · 1168 packages · Linux (ubuntu-latest)"
@@ -118,7 +118,7 @@ node-linker=hoisted
 enableGlobalVirtualStore=false
 ```
 
-The `enableGlobalVirtualStore=false` form keeps isolation and its phantom-dependency protection; it only relocates the store from the shared per-machine location to `node_modules/.store/` inside the project. That makes the tree self-contained — it survives a Docker `COPY --from` into a fresh image, where the shared store would not exist. Nub already does this automatically in CI and under `nub ci`, so you rarely set it by hand. See [store and disk layout](/docs/install#store-and-disk-layout) for the shared-versus-project-local store in full.
+The `enableGlobalVirtualStore=false` form keeps isolation and its phantom-dependency protection; it only relocates the store from the shared per-machine location to `node_modules/.store/` inside the project. That makes the tree self-contained — it survives a Docker `COPY --from` into a fresh image, where the shared store would not exist. Nub already does this automatically in CI and under `nub ci`. See [store and disk layout](/docs/install#store-and-disk-layout) for the shared-versus-project-local store in full.
 
 <Callout>
 Read the [full docs](https://pnpm.io/settings/node-modules#enableglobalvirtualstore) on pnpm.io.
@@ -139,7 +139,7 @@ Pruned 2 entries from the virtual store and 0 entries from the extracted-tree ti
 
 Nub records every project that installs against the shared store. A prune keeps the entries those projects still reach — directly, or through another entry's own dependencies — and removes the rest.
 
-A registered project that nub cannot find might be deleted, or might be on a disk that is not mounted, and those look identical. It stops counting as a store user and the prune says so, but everything else still gets collected. Whatever only that project reached becomes unreferenced and takes the usual 30-day hold, so plugging the disk back in before then keeps it.
+A registered project that nub cannot find might be deleted, or might be on a disk that is not mounted, and those look identical. It stops counting as a store user and the prune says so, but everything else still gets collected. Whatever only that project reached becomes unreferenced and takes the usual 30-day hold, so remounting the disk before then keeps it.
 
 Removal takes two passes. The first prune to find an entry unreferenced holds it and says so; only a prune that still finds it unreferenced 30 days later removes it. Installing in a project that needs the entry clears the hold.
 
@@ -148,7 +148,7 @@ Holding 24 entries unreferenced for 30 days before removal.
 Install in any project that still needs them and they are kept.
 ```
 
-That delay is what makes the command safe to run on a store you have had for a while. A project only becomes visible to the prune once it has installed at least once, so on the day you upgrade every project you have not touched yet looks like garbage. Without the hold, one install followed by one prune would delete the rest.
+That delay is what makes the command safe to run on a store you have had for a while. A project only becomes visible to the prune once it has installed at least once, so on the day you upgrade every project you have not touched yet looks unreferenced. Without the hold, one install followed by one prune would delete the rest.
 
 With nothing registered at all, a prune skips the store entirely rather than treating an empty registry as an empty store:
 
@@ -158,7 +158,7 @@ Run an install in each project you want kept, then prune again.
 ```
 
 <Callout>
-Any install registers a project, including one that reports no work to do. Opening each project you care about and running an install once is enough.
+Any install registers a project, including one that reports no work to do. Running an install once in each project registers it.
 </Callout>
 
 ## Project configuration
@@ -204,7 +204,7 @@ Under `global-virtual-store` that option is `eject`, which writes matching packa
 
 The two are not interchangeable: `hoist` fills a directory that only exists when the store is project-local, and a package linked out of a shared store never walks through the project on the way to it. Naming one under the other strategy is rejected.
 
-A related field, [`publicHoist`](/docs/config#installpublichoist), sits outside `linker` because it applies under every strategy — it puts packages in the project's own top-level `node_modules` for tools that resolve from the project root, like TypeScript looking for `@types/*`.
+A related field, [`publicHoist`](/docs/config#installpublichoist), is outside `linker` because it applies under every strategy — it puts packages in the project's own top-level `node_modules` for tools that resolve from the project root, like TypeScript looking for `@types/*`.
 
 ## GYP-based native builds
 
@@ -220,7 +220,7 @@ Some packages that compile native code with node-gyp fail to build under the iso
 }
 ```
 
-Every node-gyp run generates with `--depth=.` and writes into `build/`, and GYP joins its output paths against that depth. A dependency reference pointing outside the package directory — which any non-flat `node_modules` produces — then resolves one level short of its target. The build either dies with a Python `FileNotFoundError` naming a `.target.mk` path, or writes a duplicate tree next to the intended one.
+Every node-gyp run generates with `--depth=.` and writes into `build/`, and GYP joins its output paths against that depth. A dependency reference pointing outside the package directory — which any non-flat `node_modules` produces — then resolves one level short of its target. The build either fails with a Python `FileNotFoundError` naming a `.target.mk` path, or writes a duplicate tree next to the intended one.
 
 Install that project flat:
 

--- a/site/content/docs/install/virtual-store.mdx
+++ b/site/content/docs/install/virtual-store.mdx
@@ -61,7 +61,7 @@ A warm install — store populated, frozen lockfile — is where the layout pays
   ]}
 />
 
-The two Nub rows isolate the layout's contribution. With `--node-linker hoisted`, Nub links Bun's exact flat layout with the same per-file hardlink syscall — 1.3× faster than Bun on the same work. The default row is the same install with the one-symlink-per-package relink: 4.2× faster than Nub's own hoisted mode, 5.5× faster than Bun. On a thinner 313-package tree the default's lead over Bun is 1.7× — the advantage grows with the tree.
+The two Nub rows isolate the layout's contribution. With `--node-linker hoisted`, Nub links Bun's exact flat layout with the same per-file hardlink syscall — 1.3× faster than Bun on the same work. The default row is the same install with the one-symlink-per-package relink. On a thinner 313-package tree the default's lead over Bun is 1.7×.
 
 ## The flat opt-out
 

--- a/site/content/docs/install/yarn.mdx
+++ b/site/content/docs/install/yarn.mdx
@@ -1,6 +1,6 @@
 ---
 title: Yarn
-description: Yarn is supported read-only — Nub reads the Yarn lockfile (Classic v1 and Berry v2+) to install and run a project, but never writes it. Treat a Yarn project as something Nub consumes, not maintains.
+description: Yarn is supported read-only — Nub reads the Yarn lockfile (Classic v1 and Berry v2+) to install and run a project, but never writes it.
 ---
 
 Yarn is supported **read-only**. Install and run work; any command that would rewrite `yarn.lock` refuses before the engine touches anything:
@@ -154,7 +154,7 @@ Read the [full docs](https://yarnpkg.com/configuration/yarnrc#nodeLinker) on yar
 
 Plug'n'Play is the exception: it is refused, not ignored. A PnP project has no `node_modules` tree for Nub to install into, and Yarn Berry defaults to PnP when `nodeLinker` is absent, so both `nub install` and `nub ci` abort before mutation with `ERR_NUB_PNP_UNSUPPORTED`. Set `nodeLinker: node-modules` to install with Nub.
 
-**The Nub runtime fully supports Plug'n'Play.** If a project was *already* installed by Yarn in PnP mode, Nub can run it — `nub <file>`, `nub run`, and `nubx` honor `.pnp.cjs` across all supported Node versions. What Nub cannot do is *produce* a PnP install. So the supported workflow for a PnP project is: install with `yarn`, run with `nub`. See [Plug'n'Play resolution](/docs/runtime/resolution#yarn-plugnplay) for how Nub resolves a PnP project at runtime.
+**The Nub runtime runs Plug'n'Play projects.** If a project was *already* installed by Yarn in PnP mode, `nub <file>`, `nub run`, and `nubx` honor `.pnp.cjs`. What Nub cannot do is *produce* a PnP install, so the workflow for a PnP project is: install with `yarn`, run with `nub`. See [Plug'n'Play resolution](/docs/runtime/resolution#yarn-plugnplay) for how Nub resolves a PnP project at runtime.
 
 ## Gaps
 

--- a/site/content/docs/install/yarn.mdx
+++ b/site/content/docs/install/yarn.mdx
@@ -158,7 +158,7 @@ Plug'n'Play is the exception: it is refused, not ignored. A PnP project has no `
 
 ## Gaps
 
-Nub does not fully support these Yarn settings:
+Yarn settings with partial or no support:
 
 - Per-host `networkSettings` proxies — the proxy Nub applies is process-wide, not per registry host.
 - Layout settings — `nodeLinker`, `nmHoistingLimits`, `nmMode`, and `YARN_NODE_LINKER` have no effect. Set layout in `nub.jsonc` or `.npmrc` instead.

--- a/site/content/docs/loader.mdx
+++ b/site/content/docs/loader.mdx
@@ -49,7 +49,7 @@ node --require @nubjs/loader app.ts       # same, delivered as a CommonJS preloa
 node --import @nubjs/loader/esm app.ts    # ESM hooks only
 ```
 
-Module formats follow Node's own rules: a `.cts` file is CommonJS and a `.mts` file is an ES module. The loader transpiles types and syntax; it does not convert one format into the other, so a `.cts` file uses `module.exports`, exactly as it would under plain Node.
+Module formats follow Node's own rules: a `.cts` file is CommonJS and a `.mts` file is an ES module. The loader transpiles types and syntax; it does not convert one format into the other, so a `.cts` file uses `module.exports`, as it would under plain Node.
 
 ## Node support
 

--- a/site/content/docs/loader.mdx
+++ b/site/content/docs/loader.mdx
@@ -26,9 +26,9 @@ node --require @nubjs/loader app.ts            # CommonJS delivery
 }
 ```
 
-## What it adds
+## Features
 
-The loader arms the same resolve and transpile hooks the `nub` command uses, and nothing else — no polyfills, no globals, no `.env` loading:
+The loader registers the resolve and transpile hooks the `nub` command uses, without its polyfills, globals, or `.env` loading:
 
 - Full TypeScript — `enum`, `namespace`, parameter properties, `emitDecoratorMetadata` decorators — not just the erasable subset Node's built-in stripping accepts
 - JSX / TSX with the automatic runtime
@@ -59,4 +59,4 @@ Platform binaries ship as `optionalDependencies` (`@nubjs/loader-*`) for macOS, 
 
 ## The loader and the `nub` command
 
-Running `nub app.ts` gives you everything on this page plus [the rest of the runtime](/docs/runtime) — polyfilled web APIs, `.env` loading, Node version provisioning — with no flags. Reach for the loader when the `node` invocation itself is fixed; reach for `nub` everywhere else. The two share one transpiler and one resolver, so a file behaves the same under either.
+Running `nub app.ts` gives you everything on this page plus [the rest of the runtime](/docs/runtime) — polyfilled web APIs, `.env` loading, Node version provisioning — with no flags. Use the loader when the `node` invocation itself is fixed, and `nub` everywhere else. The two share one transpiler and one resolver, so a file behaves the same under either.

--- a/site/content/docs/node.mdx
+++ b/site/content/docs/node.mdx
@@ -169,7 +169,7 @@ With no pin the explainer reads `» resolved from node on PATH`. Bare `nub node`
 
 ## `nub node shim`
 
-Make `node` itself resolve through Nub, so a machine with no Node installed can run `node` at all. This is the fresh-install story: `brew install nub` (or the curl script), `nub node shim`, and now a bare `node file.js` works — Nub resolves the right version, provisions it if it's missing, and runs it.
+Make `node` itself resolve through Nub, so a machine with no Node installed can run `node` at all. On a fresh machine, `brew install nub` (or the curl script) followed by `nub node shim` is enough for a bare `node file.js` to run: Nub resolves and provisions the version.
 
 ```console
 $ nub node shim
@@ -179,9 +179,9 @@ node shim in /Users/you/.local/share/nub/node-shim (created)
   restart your shell, or run: source /Users/you/.zshrc
 ```
 
-The shimmed `node` runs stock Node, unchanged. It resolves and provisions the version — the [precedence above](#version-precedence) — but adds nothing else: no TypeScript, no injected globals, no automatic `.env`. So `node app.ts` type-strips exactly as stock Node does, while `nub app.ts` transpiles and runs it.
+The shimmed `node` runs stock Node, unchanged. It resolves and provisions the version (the [precedence above](#version-precedence)) and adds nothing else, so `node app.ts` type-strips as stock Node does while `nub app.ts` transpiles it.
 
-Like [`nub pm shim`](/docs/pm/pm-shim), it is opt-in and reversible. It installs a `node` link in `$XDG_DATA_HOME/nub/node-shim` — `~/.local/share/nub/node-shim` when that variable is unset — and adds that directory to your PATH; because that comes first, a Node you install later (`brew install node`) is shadowed until you unshim. Re-run `nub node shim` after `nub upgrade` to re-link.
+It installs a `node` link in `$XDG_DATA_HOME/nub/node-shim` — `~/.local/share/nub/node-shim` when that variable is unset — and adds that directory to your PATH; because that comes first, a Node you install later (`brew install node`) is shadowed until you unshim. Re-run `nub node shim` after `nub upgrade` to re-link.
 
 ```console
 $ nub node unshim
@@ -191,7 +191,7 @@ removed /Users/you/.local/share/nub/node-shim
 
 ## Mirrors and proxies
 
-Node downloads honor `HTTP(S)_PROXY` and `NO_PROXY`, and TLS-intercepting corporate CAs work out of the box through the system trust store. To fetch Node from an internal mirror instead of nodejs.org, set the standard env var or the `.npmrc` key pnpm uses — Nub reads both from a project or user-level file, with no Nub-specific config:
+Node downloads use `HTTP(S)_PROXY` / `NO_PROXY` and the system trust store. To fetch Node from an internal mirror instead of nodejs.org, set the standard env var or the `.npmrc` key pnpm uses — Nub reads both from a project or user-level file, with no Nub-specific config:
 
 ```ini title=".npmrc"
 node-mirror:release=https://artifactory.corp.example/node/

--- a/site/content/docs/node.mdx
+++ b/site/content/docs/node.mdx
@@ -3,11 +3,11 @@ title: Node manager
 description: Manage the Node versions Nub provisions — pin a version and it's fetched automatically, or drive the cache explicitly with the install, list, uninstall, and pin subcommands.
 ---
 
-Nub runs your code on stock Node and provisions the right version for you. Pin a version, run a file, and the matching Node is downloaded and cached without a second command. The `nub node` subcommands are for the steps you want to take deliberately: warming the cache before you run, listing what's installed, reclaiming disk, and recording a pin.
+Nub runs your code on stock Node and provisions the pinned version. Pin a version, run a file, and the matching Node is downloaded and cached without a second command. The `nub node` subcommands cover the explicit steps: warming the cache before a run, listing what is installed, reclaiming disk, and recording a pin.
 
 ## Automatic provisioning
 
-Drop a `.node-version` or `.nvmrc` in your project (or an `engines.node` range in `package.json`) and run `nub`. If that Node is already on your machine it's used as-is; if not, Nub downloads the matching stock build from nodejs.org — SHA-256 verified and cached under `~/.cache/nub/node` — then runs your code. Nub provisions the pinned version itself rather than handing off to `nvm`, `fnm`, or `mise`; with nothing pinned anywhere up the tree, it uses whatever `node` is already on your `PATH`.
+Add a `.node-version` or `.nvmrc` to your project (or an `engines.node` range in `package.json`) and run `nub`. If that Node is already on your machine it's used as-is; if not, Nub downloads the matching stock build from nodejs.org — SHA-256 verified and cached under `~/.cache/nub/node` — then runs your code. Nub provisions the pinned version itself rather than handing off to `nvm`, `fnm`, or `mise`; with nothing pinned anywhere up the tree, it uses whatever `node` is already on your `PATH`.
 
 ```console
 $ echo {{NODE_VERSION}} > .node-version
@@ -18,7 +18,7 @@ Installed in 8.0s
 # ...your script runs, on exactly the Node you pinned
 ```
 
-On a fresh machine with no Node at all — you installed Nub before anything else — a plain `nub file.ts` still runs. With no pin and no `node` on `PATH`, Nub provisions the latest release and runs your code on it, reusing the newest version already in its cache before downloading. Pin a version whenever you want a reproducible one (`nub node pin <version>`); until then, each run picks up the latest.
+On a fresh machine with no Node at all, a plain `nub file.ts` runs. With no pin and no `node` on `PATH`, Nub provisions the latest release, reusing the newest version already in its cache before downloading. Without a pin each run uses the latest release; `nub node pin <version>` makes it reproducible.
 
 ```console
 $ nub app.ts          # fresh machine: no pin, no Node on PATH
@@ -28,13 +28,11 @@ Installed in 5.1s
 # ...your script runs
 ```
 
-For the full provisioning story — the `~/.cache/nub` layout, the per-invocation shim — see [Running files → The Node version](/docs/runtime#node-version-resolution).
+For the `~/.cache/nub` layout and the per-invocation shim, see [Running files → The Node version](/docs/runtime#node-version-resolution).
 
 ## Version precedence
 
-Two questions decide which Node runs: *which version is pinned*, then *where that binary comes from*. Both are resolved in a fixed order.
-
-### Which version is pinned
+### Pin sources
 
 Nub walks up from your working directory to the nearest pin, highest precedence first:
 
@@ -57,7 +55,7 @@ Installed in 9.8s
 Hello world!
 ```
 
-Within a single directory, `.node-version` wins over `.nvmrc` (it's the tool-agnostic standard). Discovery walks **up** the directory tree to the nearest pin and **skips** pin files that live inside an installed dependency (under `node_modules`) — a dependency's own CI pin never drives your project. The `package.json` fields (`devEngines.runtime`, `engines.node`) are read from the **workspace root** manifest when one exists above you, else the nearest `package.json` — a monorepo pins its Node once at the root.
+Within a single directory, `.node-version` wins over `.nvmrc` (it's the tool-agnostic standard). Discovery walks **up** the directory tree to the nearest pin and **skips** pin files inside an installed dependency (under `node_modules`) — a dependency's own CI pin never drives your project. The `package.json` fields (`devEngines.runtime`, `engines.node`) are read from the **workspace root** manifest when one exists above you, else the nearest `package.json` — a monorepo pins its Node once at the root.
 
 Both fields take the `engines.node` grammar, so either can express a range or an exact version:
 
@@ -78,11 +76,11 @@ Dependency build scripts follow the same root anchor during an install, so every
 Read the [full docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) for the `devEngines` and `engines` fields on docs.npmjs.com.
 </Callout>
 
-### Where the binary comes from
+### Binary sources
 
 Once a version is pinned, Nub finds a binary for it in order:
 
-1. **`node` on `PATH`**, if its version satisfies the pin — so `fnm` / `Volta` / `mise` auto-switching just works.
+1. **`node` on `PATH`**, if its version satisfies the pin — so `fnm` / `Volta` / `mise` auto-switching is honored.
 2. **Nub's own download store** (`~/.cache/nub/node/<version>/`).
 3. **An `nvm`-installed version** (nvm scan).
 4. **Download the matching stock build from nodejs.org** — SHA-256 verified and cached — otherwise error.
@@ -91,7 +89,7 @@ The `PATH` walk **skips** `node_modules/.bin`, mirroring how pin discovery skips
 
 ## `nub node install`
 
-Provision a version into the cache *now*, instead of on the next `nub <file>`. The use cases are warming a CI cache in a setup step (the [GitHub Action](/docs/deployment/github-action) does this for you), or fetching a Node before you go offline.
+Provision a version into the cache *now*, instead of on the next `nub <file>`. Use it to warm a CI cache in a setup step (the [GitHub Action](/docs/deployment/github-action) does this) or to fetch a Node before going offline.
 
 ```bash
 nub node install {{NODE_MAJOR}}          # newest {{NODE_MAJOR}}.x
@@ -140,16 +138,16 @@ Like `ls`, this operates on Nub's cache only.
 
 ## `nub node pin`
 
-Write a `.node-version` for the project so every later `nub` in that tree uses it. This is the explicit form of creating the pin file by hand.
+Write a `.node-version` for the project so every later `nub` in that tree uses it.
 
 ```console
 $ nub node pin {{NODE_MAJOR}}
 pinned Node {{NODE_MAJOR}} → /path/to/project/.node-version
 ```
 
-A few deliberate behaviors:
+Placement and file choice:
 
-- **It pins the project, not the subdirectory.** Run from anywhere inside the project and the file lands at the project root — the nearest `package.json` directory — not in your current subfolder.
+- **It pins the project, not the subdirectory.** Run from anywhere inside the project and the file is written at the project root — the nearest `package.json` directory — not in your current subfolder.
 - **In a workspace, it pins the whole repo.** A Node version is a property of the repository, not one package, so in a monorepo the pin is written at the workspace root.
 - **It edits the pin file you already have.** If the project carries a `.nvmrc` but no `.node-version`, `pin` updates the `.nvmrc` in place.
 
@@ -157,7 +155,7 @@ Whatever spec you give is written verbatim — including an alias like `lts` —
 
 ## `nub node which`
 
-Resolve which Node runs here and where it lives. The binary path goes to stdout; a `» resolved from <source>` explainer goes to stderr, so it never pollutes a captured value.
+Print the Node that runs in the current directory. The binary path goes to stdout; a `» resolved from <source>` explainer goes to stderr, so a captured value is only the path.
 
 ```console
 $ nub node which

--- a/site/content/docs/node.mdx
+++ b/site/content/docs/node.mdx
@@ -191,7 +191,7 @@ removed /Users/you/.local/share/nub/node-shim
 
 ## Mirrors and proxies
 
-Node downloads use `HTTP(S)_PROXY` / `NO_PROXY` and the system trust store. To fetch Node from an internal mirror instead of nodejs.org, set the standard env var or the `.npmrc` key pnpm uses — Nub reads both from a project or user-level file, with no Nub-specific config:
+Node downloads use `HTTP(S)_PROXY` / `NO_PROXY` and the system trust store. To fetch Node from an internal mirror instead of nodejs.org, set the standard env var or the `.npmrc` key pnpm uses — Nub reads both from a project or user-level file:
 
 ```ini title=".npmrc"
 node-mirror:release=https://artifactory.corp.example/node/

--- a/site/content/docs/node.mdx
+++ b/site/content/docs/node.mdx
@@ -169,7 +169,7 @@ With no pin the explainer reads `» resolved from node on PATH`. Bare `nub node`
 
 ## `nub node shim`
 
-Make `node` itself resolve through Nub, so a machine with no Node installed can run `node` at all. On a fresh machine, `brew install nub` (or the curl script) followed by `nub node shim` is enough for a bare `node file.js` to run: Nub resolves and provisions the version.
+Make `node` itself resolve through Nub, so a machine with no Node installed can run `node` at all. On a fresh machine, `brew install nub` (or the curl script) followed by `nub node shim` is enough for a bare `node file.js` to run.
 
 ```console
 $ nub node shim
@@ -179,7 +179,7 @@ node shim in /Users/you/.local/share/nub/node-shim (created)
   restart your shell, or run: source /Users/you/.zshrc
 ```
 
-The shimmed `node` runs stock Node, unchanged. It resolves and provisions the version (the [precedence above](#version-precedence)) and adds nothing else, so `node app.ts` type-strips as stock Node does while `nub app.ts` transpiles it.
+The shimmed `node` resolves and provisions the version (the [precedence above](#version-precedence)) and adds nothing else: `node app.ts` type-strips as stock Node does, while `nub app.ts` transpiles it.
 
 It installs a `node` link in `$XDG_DATA_HOME/nub/node-shim` — `~/.local/share/nub/node-shim` when that variable is unset — and adds that directory to your PATH; because that comes first, a Node you install later (`brew install node`) is shadowed until you unshim. Re-run `nub node shim` after `nub upgrade` to re-link.
 

--- a/site/content/docs/node.mdx
+++ b/site/content/docs/node.mdx
@@ -165,15 +165,6 @@ $ nub node which
 » resolved from .node-version ({{NODE_VERSION}})
 ```
 
-The stdout/stderr split means `nub node which` composes in a shell — capture the path and the explainer stays out of the variable:
-
-```console
-$ NODE=$(nub node which)
-» resolved from .node-version ({{NODE_VERSION}})
-$ echo "$NODE"
-/Users/you/.nvm/versions/node/v{{NODE_VERSION}}/bin/node
-```
-
 With no pin the explainer reads `» resolved from node on PATH`. Bare `nub node` prints a status block instead — the version, path, and resolution source on separate lines.
 
 ## `nub node shim`

--- a/site/content/docs/plugins.mdx
+++ b/site/content/docs/plugins.mdx
@@ -26,7 +26,7 @@ The prefixed name is resolved in two places, in order:
 
 Only the prefixed `nub-<verb>` name is ever probed — never the bare verb.
 
-## Built-ins always win
+## Built-in precedence
 
 A plugin can never shadow a built-in verb. Native commands and package-manager verbs are matched before any plugin lookup, so `nub run`, `nub install`, `nub add`, and the rest always dispatch to Nub itself, even if a `nub-run` bin exists in `node_modules/.bin`. The fallthrough fires only for a verb Nub has no built-in for.
 
@@ -34,9 +34,9 @@ Script names take the same priority. A verb that names a script in the local `pa
 
 ## Writing a plugin
 
-A plugin is a runnable executable named `nub-<verb>` — a compiled JavaScript bin or a native binary, the same as any other `node_modules/.bin` entry or a `git`/`cargo` subcommand. There's no plugin-specific build target: author it in TypeScript and publish the compiled output, as you'd ship any other bin. Installed bins aren't transpiled, so the entry that actually runs has to be JavaScript or native.
+A plugin is a runnable executable named `nub-<verb>` — a compiled JavaScript bin or a native binary, the same as any other `node_modules/.bin` entry or a `git`/`cargo` subcommand. There's no plugin-specific build target: author it in TypeScript and publish the compiled output, as any other bin. Installed bins are not transpiled, so the entry that runs must be JavaScript or native.
 
-A JavaScript plugin runs under Nub's runtime augmentation, as `nub run` runs a script — the version-gated globals are present. A native executable just runs. The plugin's exit code is what Nub returns.
+A JavaScript plugin runs under Nub's runtime augmentation, as `nub run` runs a script — the version-gated globals are present. A native executable runs directly. The plugin's exit code is what Nub returns.
 
 ```js title="nub-changeset"
 #!/usr/bin/env node

--- a/site/content/docs/plugins.mdx
+++ b/site/content/docs/plugins.mdx
@@ -10,7 +10,7 @@ nub changeset publish      # runs nub-changeset publish
 nub release --tag beta     # runs nub-release --tag beta
 ```
 
-A plugin is a package that installs a `nub-<verb>` bin — there is no plugin manifest, no registration step, and no config field to declare it. Install it like any other dependency and the verb works.
+A plugin is a package that installs a `nub-<verb>` bin — there is no plugin manifest and no registration step. Install it like any other dependency and the verb works.
 
 ```bash
 nub add -D nub-changeset   # ships a nub-changeset bin

--- a/site/content/docs/plugins.mdx
+++ b/site/content/docs/plugins.mdx
@@ -34,9 +34,9 @@ Script names take the same priority. A verb that names a script in the local `pa
 
 ## Writing a plugin
 
-A plugin is a runnable executable named `nub-<verb>` — a compiled JavaScript bin or a native binary, the same as any other `node_modules/.bin` entry or a `git`/`cargo` subcommand. There's no plugin-specific build target: author it in TypeScript and publish the compiled output, exactly as you'd ship any other bin. Installed bins aren't transpiled, so the entry that actually runs has to be JavaScript or native.
+A plugin is a runnable executable named `nub-<verb>` — a compiled JavaScript bin or a native binary, the same as any other `node_modules/.bin` entry or a `git`/`cargo` subcommand. There's no plugin-specific build target: author it in TypeScript and publish the compiled output, as you'd ship any other bin. Installed bins aren't transpiled, so the entry that actually runs has to be JavaScript or native.
 
-A JavaScript plugin runs under Nub's runtime augmentation, exactly as `nub run` runs a script — the version-gated globals are present. A native executable just runs. The plugin's exit code is what Nub returns.
+A JavaScript plugin runs under Nub's runtime augmentation, as `nub run` runs a script — the version-gated globals are present. A native executable just runs. The plugin's exit code is what Nub returns.
 
 ```js title="nub-changeset"
 #!/usr/bin/env node

--- a/site/content/docs/pm/index.mdx
+++ b/site/content/docs/pm/index.mdx
@@ -65,12 +65,12 @@ using pnpm@11.5.3
 
 What it writes:
 
-- **`package.json#/packageManager`** — the exact version plus a `+sha512` hash from the verified tarball. What corepack, pnpm, and turbo execute; `use` is the only Nub command that writes it.
+- **`package.json#/packageManager`** — the exact version plus a `+sha512` hash from the verified tarball. This is the field corepack, pnpm, and turbo read; `use` is the only Nub command that writes it.
 - **`package.json#/devEngines/packageManager`** — `{ name, version: "^<exact>", onFail: "warn" }`, the range-and-policy form npm and pnpm enforce natively, written beside the exact pin so the two can't drift.
 - **The lockfile, in the new manager's format.** A lockfile in another format is *converted* — resolution state preserved — and the old file removed. One already in the target format is left untouched; with no lockfile, the next install creates it. The converted lockfile passes the active manager's frozen install (`pnpm install --frozen-lockfile`, etc.) byte-for-byte.
 
 <Callout title="Config is not migrated">
-Switching managers converts the lockfile, not your config. The `.npmrc`, any `pnpm.*` fields, `pnpm-workspace.yaml` settings, and other manager-specific config stay as they are — Nub does not translate them. Carry over whatever the new manager needs yourself.
+Switching managers converts the lockfile, not your config. The `.npmrc`, any `pnpm.*` fields, `pnpm-workspace.yaml` settings, and other manager-specific config stay as they are — Nub does not translate them. Migrate the new manager's config manually.
 </Callout>
 
 Whichever manager the project ends up on, [Nub's own installer](/docs/install) mirrors its supported resolution settings and respects its lockfile. The layout fields in [`nub.jsonc`](/docs/config#installlinker) apply in every project; the incumbent's branded layout settings do not.
@@ -82,7 +82,7 @@ Every file written or removed is named in the output; rerunning is a no-op. Four
 - **Running `use yarn` onto a Berry (2+) `yarn.lock`** — classic would downgrade the format; use `yarn set version`.
 - **Running `use yarn` on a graph using the `workspace:` protocol** — classic yarn can't express it.
 
-A converting `use yarn` is otherwise fine — Nub writes a classic `yarn.lock` directly. Running `use bun` writes the pin and lockfile but doesn't provision bun.
+Otherwise a converting `use yarn` writes a classic `yarn.lock` directly. Running `use bun` writes the pin and lockfile but doesn't provision bun.
 
 ### `nub pm pin`
 
@@ -100,7 +100,7 @@ pinned nub@0.2.10
   package.json: devEngines.packageManager = { name: "nub", version: "^0.2.10", onFail: "ignore" }
 ```
 
-It writes the two pin fields — the exact `packageManager` and the `devEngines.packageManager` caret beside it — and nothing else: no lockfile conversion, no config migration. That fuller switch onto Nub is [`nub pm use nub`](#nub-pm-use)'s job; pin is the lightweight lock, the package-manager analog of [Nub's Node pin](/docs/node).
+It writes the two pin fields — the exact `packageManager` and the `devEngines.packageManager` caret beside it — and nothing else: no lockfile conversion, no config migration. The full switch onto Nub is [`nub pm use nub`](#nub-pm-use); `pin` only records the version, the package-manager analog of [Nub's Node pin](/docs/node).
 
 The version must be exact — Nub is the binary you're running, not a registry package, so a range or dist-tag has nothing to resolve against.
 

--- a/site/content/docs/pm/index.mdx
+++ b/site/content/docs/pm/index.mdx
@@ -3,7 +3,7 @@ title: Package meta-manager
 description: Provision and run the package manager your project pins — corepack's job, in native Rust. The exact pnpm, npm, or yarn release is fetched, verified, cached, and run on the project's Node.
 ---
 
-Nub reads your project's package-manager pin, fetches that exact version from the npm registry — integrity-verified, cached under `~/.cache/nub/pm` — and runs it under the project's Node. No corepack, no `enable` step, no baked version table: a six-month-old Nub binary provisions today's pnpm.
+Nub reads your project's package-manager pin, fetches that exact version from the npm registry — integrity-verified, cached under `~/.cache/nub/pm` — and runs it under the project's Node. There is no corepack `enable` step and no baked version table, so a six-month-old Nub binary provisions today's pnpm.
 
 ```console
 $ nub pm which
@@ -168,7 +168,7 @@ registry=https://npm.corp.example
 //npm.corp.example/:_authToken=${CORP_NPM_TOKEN}
 ```
 
-Environment placeholders (`${VAR}`) in these values expand from your user `~/.npmrc` and `npm_config_*` — but not from a project `.npmrc` committed to the repo, which is read literally. A hostile `registry=` or auth line in a checked-out repo therefore can't interpolate a secret like `${NPM_TOKEN}` into a request to an attacker's host. On trusted CI where the project file genuinely needs expansion, set `PNPM_CONFIG_NPMRC_AUTH_FILE=.npmrc` to opt back in — it comes from the environment, so a repo can't set it for itself.
+Environment placeholders (`${VAR}`) in these values expand from your user `~/.npmrc` and `npm_config_*` — but not from a project `.npmrc` committed to the repo, which is read literally. A hostile `registry=` or auth line in a checked-out repo therefore can't interpolate a secret like `${NPM_TOKEN}` into a request to an attacker's host. On trusted CI where the project file needs expansion, set `PNPM_CONFIG_NPMRC_AUTH_FILE=.npmrc` to opt back in — it comes from the environment, so a repo can't set it for itself.
 
 To fetch package managers from a different registry than your dependencies, `COREPACK_NPM_REGISTRY` (+ `COREPACK_NPM_TOKEN`) overrides the PM-download registry — teams migrating off corepack keep their existing CI vars.
 

--- a/site/content/docs/pm/pm-shim.mdx
+++ b/site/content/docs/pm/pm-shim.mdx
@@ -1,13 +1,13 @@
 ---
 title: Corepack-style shims
-description: An opt-in for muscle memory. Install the shims and a bare pnpm, npm, or yarn command routes through Nub to the package manager your project pins, with no extra Node process in front.
+description: Optional shims for bare package-manager commands. Install them and a bare pnpm, npm, or yarn command routes through Nub to the package manager your project pins, with no extra Node process in front.
 ---
 
-Default Nub usage needs no shims: `nub install`, `nub add`, and `nub run` already provision and run the pinned package manager. The shims are for when you'd rather type the manager directly — bare `pnpm install`, `npm ci`, `yarn add` — and still have it go through Nub. One command turns that on.
+Default Nub usage needs no shims: `nub install`, `nub add`, and `nub run` already provision and run the pinned package manager. The shims are for typing the manager directly — bare `pnpm install`, `npm ci`, `yarn add` — and still routing through Nub. One command turns that on.
 
 <ShimDemo />
 
-After `nub pm shim`, bare `pnpm` resolves to a shim — a hardlink to the Nub binary. The shims live in `$XDG_DATA_HOME/nub/shims` when that variable is set, `%LOCALAPPDATA%\nub\shims` on Windows, and `~/.local/share/nub/shims` otherwise. On a cold cache, `pnpm --version` (or any pinned-PM command) provisions the pinned pnpm, then dispatches to it in-process under the project's Node. The dim `pnpm@9.5.0 (via nub shim)` line names the manager and version it ran; it prints on stderr on every dispatch, so it never pollutes piped stdout.
+After `nub pm shim`, bare `pnpm` resolves to a shim — a hardlink to the Nub binary. The shims live in `$XDG_DATA_HOME/nub/shims` when that variable is set, `%LOCALAPPDATA%\nub\shims` on Windows, and `~/.local/share/nub/shims` otherwise. On a cold cache, `pnpm --version` (or any pinned-PM command) provisions the pinned pnpm, then dispatches to it in-process under the project's Node. The dim `pnpm@9.5.0 (via nub shim)` line names the manager and version it ran; it prints on stderr on every dispatch, so piped stdout stays clean.
 
 To remove the shims, `nub pm unshim` deletes the shim directory and strips the PATH block, restoring the previous `pnpm`.
 
@@ -25,11 +25,11 @@ With a pin set, `nub install` already runs the right pnpm. The shims are the sep
 
 ## Per-invocation overhead
 
-A shim sits in front of every command, so what matters is the time it adds. A corepack-style shim is a Node script (`#!/usr/bin/env node`), so invoking it boots the Node interpreter to read your pin and load the manager before any install work begins. The Nub shim is a hardlink to the native binary: the process that resolves the pin and dispatches is the one already running — no extra interpreter in front of the package manager.
+A shim runs before every command, so its overhead matters. A corepack-style shim is a Node script (`#!/usr/bin/env node`), so invoking it boots the Node interpreter to read your pin and load the manager before any install work begins. The Nub shim is a hardlink to the native binary: the process that resolves the pin and dispatches is the one already running — no extra interpreter in front of the package manager.
 
 ## Strict by default
 
-In a pinned project, a shim refuses to run a *different* package manager — a competing lockfile and `node_modules` are exactly what you don't want. Bare `yarn add react` in a pnpm-pinned project exits nonzero and names what to run instead:
+In a pinned project, a shim refuses to run a *different* package manager — which would produce a competing lockfile and `node_modules`. Bare `yarn add react` in a pnpm-pinned project exits nonzero and names what to run instead:
 
 ```console
 $ yarn add react   # ❌ wrong package manager for this project
@@ -46,6 +46,6 @@ and node_modules.
 
 Runner commands fall through to the system tool whatever the pin — `npx`, `pnpx`, and the `init` / `create` / `dlx` / `exec` verbs — so `npm create vite` works in a pnpm project. A package manager spawned by a running install — a lifecycle script shelling out to a different one — also falls through, so an install you never typed directly isn't broken.
 
-## No manager on PATH
+## Missing system manager
 
 An unpinned invocation falls through to the system manager. When there is none — a fresh machine, a minimal container — the shim runs a dynamic default instead of failing: the version family the committed lockfile implies, or the registry `latest` when there is no lockfile. It announces the choice on stderr and writes no pin. The `latest` resolution is remembered for 24 hours, so repeat invocations dispatch with no registry round-trip, and when the registry is unreachable the last resolved version keeps working.

--- a/site/content/docs/runner/dlx.mdx
+++ b/site/content/docs/runner/dlx.mdx
@@ -49,7 +49,7 @@ A fetched package's `preinstall`/`install`/`postinstall` scripts are skipped —
 
 ## Cooling window
 
-A fetch runs through Nub's normal install resolver, so the `minimumReleaseAge` cooling window applies: a resolved version must be older than the window (default 24 hours) before it's used. See [the cooling window](/docs/install#cooling-window) for the full posture, including what happens when a registry serves no publish dates.
+A fetch runs through Nub's normal install resolver, so the `minimumReleaseAge` cooling window applies: a resolved version must be older than the window (default 24 hours) before it's used. See [the cooling window](/docs/install#cooling-window) for the full rules, including what happens when a registry serves no publish dates.
 
 When the latest release is still inside the window, the tool runs at the newest release that clears it, and the substitution is reported — the scratch project is deleted when the tool exits, so this is the only record of which version ran:
 
@@ -83,4 +83,4 @@ Setting it to `never` turns off [`nubx`](/docs/runner)'s implicit fallthrough fe
 - [Runner](/docs/runner) — `nubx`, which fetches only on a local miss, and prompts first.
 - [Local bin runner](/docs/runner/exec) — `nub exec`, for a tool that's already installed.
 - [Script runner](/docs/runner/run) — `nub run`, the `package.json` script runner.
-- [Package manager](/docs/pm) — installing dependencies for real, not just running them.
+- [Package manager](/docs/pm) — installing dependencies into a project.

--- a/site/content/docs/runner/dlx.mdx
+++ b/site/content/docs/runner/dlx.mdx
@@ -1,6 +1,6 @@
 ---
 title: Remote bin runner
-description: Fetch a package from the registry and run its bin, explicitly — the deliberate download gesture, with consent by invocation.
+description: Fetch a package from the registry and run its bin, explicitly — no prompt, because asking for the fetch is itself the consent.
 ---
 
 Fetch a package from the registry and run its bin:

--- a/site/content/docs/runner/exec.mdx
+++ b/site/content/docs/runner/exec.mdx
@@ -36,7 +36,7 @@ Read the [full docs](https://pnpm.io/cli/exec) for `pnpm exec` on pnpm.io.
 
 ## Pass arguments
 
-Everything after the bin name is forwarded to it untouched — there's no `--` separator to remember.
+Everything after the bin name is forwarded to it untouched — no `--` separator needed.
 
 ```bash
 nub exec eslint . --fix --max-warnings 0

--- a/site/content/docs/runner/exec.mdx
+++ b/site/content/docs/runner/exec.mdx
@@ -28,13 +28,13 @@ The walk-up happens in Rust, with no Node bootstrap in front of the tool — the
   source="https://github.com/nubjs/nub/tree/main/tests/bench/bin-runner"
 />
 
-Yarn Plug'n'Play projects work too: `nub exec` finds PnP-registered bins that tools walking only `node_modules/.bin` miss. See [module resolution](/docs/runtime/resolution#yarn-plugnplay).
+In a Yarn Plug'n'Play project, `nub exec` finds PnP-registered bins through `pnpapi`. See [module resolution](/docs/runtime/resolution#yarn-plugnplay).
 
 <Callout>
 Read the [full docs](https://pnpm.io/cli/exec) for `pnpm exec` on pnpm.io.
 </Callout>
 
-## Pass arguments
+## Arguments
 
 Everything after the bin name is forwarded to it untouched — no `--` separator needed.
 

--- a/site/content/docs/runner/index.mdx
+++ b/site/content/docs/runner/index.mdx
@@ -50,7 +50,7 @@ nubx -y cowsay "hi"
 
 ### `exec.implicitDlx`
 
-Answering **Never** turns the implicit fetch off for good. Nub records `exec.implicitDlx` in its global settings file (`~/.config/nub/nub.jsonc`), and from then on a local miss stops instead of offering a download. Explicit fetches are unaffected: [`nub dlx`](/docs/runner/dlx) and `nubx -y` keep working, because asking for them is itself the consent.
+Answering **Never** turns the implicit fetch off for good. Nub records `exec.implicitDlx` in its global settings file (`~/.config/nub/nub.jsonc`), and from then on a local miss stops instead of offering a download. Explicit fetches — [`nub dlx`](/docs/runner/dlx) and `nubx -y` — are unaffected, because asking for them is itself the consent.
 
 Restore the prompt at any time:
 
@@ -60,7 +60,7 @@ nub config set exec.implicitDlx prompt
 
 ## Pass arguments
 
-Everything after the tool name is forwarded to it untouched — there's no `--` separator to remember.
+Everything after the tool name is forwarded to it untouched — no `--` separator needed.
 
 ```bash
 nubx eslint . --fix --max-warnings 0

--- a/site/content/docs/runner/index.mdx
+++ b/site/content/docs/runner/index.mdx
@@ -11,11 +11,11 @@ nubx vitest run --coverage
 nubx cowsay "hi"           # not installed — offers to fetch it
 ```
 
-Resolution is local first. Nub walks the `node_modules/.bin` chain — the nearest `node_modules/.bin`, then up through parent directories to the workspace root — and execs the match directly, with no network and no Node process in the wrapper. Yarn Plug'n'Play projects work too: PnP-registered bins resolve through `pnpapi`, the way `yarn exec` does. See [module resolution](/docs/runtime/resolution#yarn-plugnplay).
+Resolution is local first. Nub walks the `node_modules/.bin` chain — the nearest `node_modules/.bin`, then up through parent directories to the workspace root — and execs the match directly, with no network and no Node process in the wrapper. In a Yarn Plug'n'Play project, PnP-registered bins resolve through `pnpapi`, the way `yarn exec` does. See [module resolution](/docs/runtime/resolution#yarn-plugnplay).
 
-Only a local miss reaches the registry — the shape `npx` has, with two differences. Dispatch happens in Rust rather than a Node bootstrap, so a local CLI starts in milliseconds instead of a couple hundred (see [the local bin runner](/docs/runner/exec) for the numbers), and a fetch is never silent.
+Only a local miss reaches the registry, as with `npx`, with two differences: dispatch happens in Rust rather than a Node bootstrap (see [the local bin runner](/docs/runner/exec) for timings), and a fetch is never silent.
 
-## Fetch from the registry
+## Registry fetches
 
 Where `npx` downloads without asking, `nubx` asks. The first fetch of a given tool prompts, runs it once you agree, and remembers the answer:
 
@@ -50,7 +50,7 @@ nubx -y cowsay "hi"
 
 ### `exec.implicitDlx`
 
-Answering **Never** turns the implicit fetch off for good. Nub records `exec.implicitDlx` in its global settings file (`~/.config/nub/nub.jsonc`), and from then on a local miss stops instead of offering a download. Explicit fetches — [`nub dlx`](/docs/runner/dlx) and `nubx -y` — are unaffected, because asking for them is itself the consent.
+Answering **Never** turns the implicit fetch off permanently. Nub records `exec.implicitDlx` in its global settings file (`~/.config/nub/nub.jsonc`), and from then on a local miss stops instead of offering a download. Explicit fetches — [`nub dlx`](/docs/runner/dlx) and `nubx -y` — are unaffected, because asking for them is itself the consent.
 
 Restore the prompt at any time:
 
@@ -58,7 +58,7 @@ Restore the prompt at any time:
 nub config set exec.implicitDlx prompt
 ```
 
-## Pass arguments
+## Arguments
 
 Everything after the tool name is forwarded to it untouched — no `--` separator needed.
 
@@ -69,7 +69,7 @@ nubx vitest run --coverage
 
 ## `--node`
 
-Pass `--node` to run the tool with runtime augmentation disabled — see [the runtime overview](/docs/runtime#--node) for the full contract. Resolution, the registry fetch, and `nubx`'s own machinery still run; only the augmentation is off.
+Pass `--node` to run the tool with runtime augmentation disabled — see [the runtime overview](/docs/runtime#--node) for the full contract. Resolution and the registry fetch still run; only the augmentation is off.
 
 ```bash
 nubx --node prisma generate

--- a/site/content/docs/runner/run.mdx
+++ b/site/content/docs/runner/run.mdx
@@ -3,7 +3,7 @@ title: Script runner
 description: A drop-in for pnpm run and npm run — every flag carries over with the same spelling and semantics, 24× faster on the cold path, with the full workspace and lifecycle-hook surface preserved.
 ---
 
-A drop-in for `pnpm run` and `npm run`, `nub run` carries every flag over with the same spelling and semantics, including the recursive and workspace-filter ones. Existing invocations work unchanged:
+A drop-in for `pnpm run` and `npm run`, `nub run` carries every flag over with the same spelling and semantics, including the recursive and workspace-filter ones:
 
 ```bash
 # resume an interrupted recursive run mid-graph
@@ -30,7 +30,7 @@ nub run dev
 nub run test
 ```
 
-Running a script is always `nub run <script>` — barewords like `nub dev` do not fall through to scripts. (If you type `nub build` and `build` is a real script, Nub's error tells you to type `nub run build`.) See [Running files](/docs/runtime) for how `nub <file>` works.
+Running a script is always `nub run <script>` — barewords like `nub dev` do not fall through to scripts. A `nub build` where `build` is a script fails with a hint to run `nub run build`. See [Running files](/docs/runtime) for how `nub <file>` works.
 
 Dispatch is handled in Rust with no Node bootstrap in the wrapper, so the runner adds only a few milliseconds before your script's first byte — faster than Node's own `node --run`:
 
@@ -47,7 +47,7 @@ Dispatch is handled in Rust with no Node bootstrap in the wrapper, so the runner
   source="https://github.com/nubjs/nub/tree/main/tests/bench/script-runner"
 />
 
-## Run several scripts at once
+## Multiple scripts
 
 A `/regex/` selector in place of a script name runs every script whose name matches, mirroring `pnpm run`. This is the in-package equivalent of `npm-run-all`'s `run-p` — without the extra dependency or the per-task PM re-spawn, since Nub spawns each script body directly.
 
@@ -64,7 +64,7 @@ nub run --workspace-concurrency 1 "/^build:/"
 
 The selector must be a slash-delimited regular expression literal (`/^build:/`); a plain `build:*` is treated as a literal script name, not a glob. Regex flags are not supported. An exact script name (no slashes) always runs that single script unchanged.
 
-Coming from `npm-run-all` / `npm-run-all2`:
+Equivalents for `npm-run-all` / `npm-run-all2`:
 
 | npm-run-all | Nub |
 |---|---|
@@ -78,7 +78,7 @@ Selecting an *arbitrary, unrelated* set of scripts (for example `build`, `lint`,
 Read the [full docs](https://pnpm.io/cli/run#running-multiple-scripts) for pnpm's regex selector on pnpm.io.
 </Callout>
 
-## Forward arguments
+## Argument forwarding
 
 Trailing arguments after the script name are passed straight through to the script. You do not need the `--` separator that `npm run` requires.
 
@@ -87,7 +87,7 @@ nub run test --watch          # forwards --watch to the test script
 nub run build --target=esnext # forwards --target=esnext
 ```
 
-This matches `bun run`. The explicit separator still works for muscle memory:
+This matches `bun run`. The explicit separator is also accepted:
 
 ```bash
 nub run test -- --watch       # identical result; the -- is optional
@@ -128,13 +128,13 @@ nub run --ignore-scripts build
 
 ## Dependency freshness
 
-Before a script runs, Nub checks the installed `node_modules` against your `package.json`. When a dependency is missing or its installed version has drifted out of the declared range — the usual "fresh clone, forgot to install" case — Nub warns and still runs, so a stale tree surfaces as a clear message instead of a raw `husky: command not found`:
+Before a script runs, Nub checks the installed `node_modules` against your `package.json`. When a dependency is missing or its installed version has drifted out of the declared range, Nub warns and still runs, so a stale tree surfaces as a clear message instead of a raw `husky: command not found`:
 
 ```
 nub: dependencies may be out of date (`chalk` is not installed). Run `nub install`.
 ```
 
-The check works whatever installed the tree — npm, pnpm, Yarn, Bun, or Nub itself. It errs toward silence: an ambiguous tree (Yarn PnP, an unparseable version, or a production-only install with devDependencies deliberately omitted) never warns.
+The check works whatever installed the tree — npm, pnpm, Yarn, Bun, or Nub itself. An ambiguous tree (Yarn PnP, an unparseable version, or a production-only install with devDependencies deliberately omitted) never warns.
 
 Set the behavior with the `verify-deps-before-run` key in `.npmrc`. The values are `warn` (the default — warn, then run), `error` (print the message and refuse to run), and `off` (skip the check):
 
@@ -158,15 +158,15 @@ nub run --no-check build
 NUB_VERIFY_DEPS=off nub run build
 ```
 
-Nub never installs on your behalf here — run `nub install` when you see the warning. pnpm's `install` and `prompt` values are read from `.npmrc` and treated as `warn`; in `nub.jsonc` they are rejected. The check also applies to `nub <file>`, `nub exec`, and `nubx`, and is skipped in [`--node` / compat mode](#--node) and inside an already-running script (so a script that spawns `node` doesn't re-check).
+Nub does not install here; run `nub install` when the warning appears. pnpm's `install` and `prompt` values are read from `.npmrc` and treated as `warn`; in `nub.jsonc` they are rejected. The check also applies to `nub <file>`, `nub exec`, and `nubx`, and is skipped in [`--node` / compat mode](#--node) and inside an already-running script (so a script that spawns `node` doesn't re-check).
 
-The one exception is a tree Nub installed for a different Node major than the one about to run it. Native addons are compiled against a specific Node ABI, so switching Node — bumping `.nvmrc` or `engines.node`, or moving between installed versions — leaves them unloadable, and the run would otherwise die with a raw `ERR_DLOPEN_FAILED … NODE_MODULE_VERSION` from deep inside a dependency. Nub records which engine built the tree, notices the mismatch, and reinstalls once before the run:
+The one exception is a tree Nub installed for a different Node major than the one about to run it. Native addons are compiled against a specific Node ABI, so switching Node — bumping `.nvmrc` or `engines.node`, or moving between installed versions — leaves them unloadable, and the run would otherwise fail with `ERR_DLOPEN_FAILED … NODE_MODULE_VERSION` inside a dependency. Nub records which engine built the tree, detects the mismatch, and reinstalls once before the run:
 
 ```
 nub: dependencies were installed for Node 22, this run uses Node 26. Reinstalling — native addons are built per Node major.
 ```
 
-Because Nub keeps a build per engine in its store, the reinstall is a fast re-link once you have run under that Node before; only an engine it has never built for pays a real rebuild. Setting `off` disables this repair along with the rest of the check.
+Because Nub keeps a build per engine in its store, the reinstall is a fast re-link once you have run under that Node before; only an engine it has never built for rebuilds. Setting `off` disables this repair along with the rest of the check.
 
 <Callout>
 Read the [full docs](https://pnpm.io/settings/build#verifydepsbeforerun) for pnpm's `verifyDepsBeforeRun` setting on pnpm.io.
@@ -174,13 +174,13 @@ Read the [full docs](https://pnpm.io/settings/build#verifydepsbeforerun) for pnp
 
 ## Undeclared dependencies
 
-Nub also flags a *phantom* dependency — a package your own source imports but never declares, that resolves today only because some dependency-of-a-dependency hoisted it into `node_modules`. It works under a flat npm or Yarn install and breaks the moment the tree is installed isolated, so Nub names the file and the fix before that happens:
+Nub also flags a *phantom* dependency — a package your own source imports but never declares, that resolves today only because some dependency-of-a-dependency hoisted it into `node_modules`. It works under a flat npm or Yarn install and breaks when the tree is installed isolated, so Nub names the file and the fix before that happens:
 
 ```
 nub: src/index.ts imports `ansi-styles`, which isn't in package.json. Run `nub add ansi-styles` (WARN_PHANTOM_DEP).
 ```
 
-The scan is conservative — it warns only on a package that is imported unguarded (a `try/catch` optional load is left alone), is absent from every dependency field, and is actually present in `node_modules`. It is warn-only and never changes the exit code.
+The scan is conservative — it warns only on a package that is imported unguarded (a `try/catch` optional load is left alone), is absent from every dependency field, and is present in `node_modules`. It is warn-only and never changes the exit code.
 
 Turn it off with the `phantom-check` key in `.npmrc`, or the `NUB_PHANTOM_CHECK` variable for one shell:
 
@@ -306,7 +306,7 @@ Read the [full docs](https://pnpm.io/filtering) for the filter grammar on pnpm.i
 
 ## `--parallel`, `--sequential`
 
-Across a workspace, Nub runs packages concurrently up to a cap (CPU count by default) while respecting topological order. Tune or override that.
+Across a workspace, Nub runs packages concurrently up to a cap (CPU count by default) while respecting topological order. Two flags adjust that.
 
 ```bash
 nub run -r --workspace-concurrency 4 build   # cap at 4 concurrent scripts
@@ -327,7 +327,7 @@ nub run -r --no-bail test     # run every package, report failures at the end
 
 ## `--resume-from`
 
-When a long topological run dies partway through, `--resume-from` skips the topological predecessors of a package so you restart where it broke instead of from the top.
+When a long topological run fails partway through, `--resume-from` skips the topological predecessors of a package to restart from the failing one.
 
 ```bash
 nub run -r --resume-from @org/api build
@@ -372,7 +372,7 @@ nub run --silent build
 
 ## `--color`
 
-Prefixing each line means piping the script's output, and a piped tool sees no terminal, so most of them switch their own color off. Ask for it back with `--color`, and the scripts keep their colors under prefixing:
+Prefixing each line means piping the script's output, and a piped tool sees no terminal, so most of them switch their own color off. Pass `--color` and the scripts keep their colors under prefixing:
 
 ```bash
 nub run -r --parallel --color=always dev  # scripts stay colored, prefixes too
@@ -386,7 +386,7 @@ NO_COLOR=1 nub run -r build      # off, whatever the terminal says
 FORCE_COLOR=1 nub run -r build   # on, even when the output is piped
 ```
 
-Setting both is contradictory, and the two variables disagree about which should win: Nub honors `NO_COLOR`, Node honors `FORCE_COLOR`. On a prefixed run Nub settles it for the scripts as well, so the labels and the lines they wrap can't end up disagreeing. A run that isn't prefixed passes both through untouched.
+Setting both is contradictory, and the two variables disagree about which should win: Nub honors `NO_COLOR`, Node honors `FORCE_COLOR`. On a prefixed run Nub applies its choice to the scripts as well, so the labels and the wrapped lines agree. A run that isn't prefixed passes both through untouched.
 
 ## `--node`
 
@@ -396,7 +396,7 @@ By default, the `nub` executable is aliased as `node` for the duration of a `nub
 nub run --node test
 ```
 
-What still happens under `--node`: script lookup, workspace walk-up, `--filter` evaluation, `npm_*` env injection, `node_modules/.bin` on `PATH`, and the `pre` / `post` lifecycle hooks. Reach for it when a script's `#!/usr/bin/env node` shebang chain expects plain Node, when bisecting a Nub bug, or when CI wants byte-exact Node runtime behavior with Nub's workspace selection.
+What still happens under `--node`: script lookup, workspace walk-up, `--filter` evaluation, `npm_*` env injection, `node_modules/.bin` on `PATH`, and the `pre` / `post` lifecycle hooks. Use it when a script's `#!/usr/bin/env node` shebang chain expects plain Node, when bisecting a Nub bug, or when CI needs byte-exact Node runtime behavior with Nub's workspace selection.
 
 ## Related
 

--- a/site/content/docs/runner/run.mdx
+++ b/site/content/docs/runner/run.mdx
@@ -190,7 +190,7 @@ phantom-check = off
 
 ## The `npm_*` environment
 
-Nub populates the child process with the full npm-compatible environment, so scripts and tooling that read `npm_*` variables behave exactly as they do under `npm run`. Locally installed CLIs are on `PATH` via the `node_modules/.bin` chain, so you can call them by bare name.
+Nub populates the child process with the full npm-compatible environment, so scripts and tooling that read `npm_*` variables behave as they do under `npm run`. Locally installed CLIs are on `PATH` via the `node_modules/.bin` chain, so you can call them by bare name.
 
 ```json title="package.json"
 {

--- a/site/content/docs/runtime/debugging.mdx
+++ b/site/content/docs/runtime/debugging.mdx
@@ -24,7 +24,7 @@ VS Code resolves `runtimeExecutable` against its own `PATH`. If it can't find `n
 
 ## Program arguments
 
-Pass your program's argv through `args`. Each entry lands on `process.argv`, exactly as it would after the file on the command line.
+Pass your program's argv through `args`. Each entry lands on `process.argv`, as it would after the file on the command line.
 
 ```json title=".vscode/launch.json"
 {

--- a/site/content/docs/runtime/debugging.mdx
+++ b/site/content/docs/runtime/debugging.mdx
@@ -3,7 +3,7 @@ title: Debugging
 description: Attach the VS Code debugger to a program run through Nub, with breakpoints and stepping working while augmentation is on.
 ---
 
-VS Code's Node debugger launches your program with its own `node`, which skips Nub entirely. Point it at the `nub` binary instead and Nub launches the file for you — the inspector comes up and the debugger attaches.
+VS Code's Node debugger launches your program with its own `node`, which skips Nub entirely. Point it at the `nub` binary instead: Nub launches the file, the inspector starts, and the debugger attaches.
 
 ```json title=".vscode/launch.json"
 {
@@ -16,7 +16,7 @@ VS Code's Node debugger launches your program with its own `node`, which skips N
 }
 ```
 
-Set a breakpoint and run the configuration; execution stops at it. VS Code injects `--inspect-brk` ahead of your file, and Nub forwards it to the Node child it spawns, so the inspector binds to the port VS Code chose and attaches. The first stop lands on the first line of your file, not inside Nub's internals.
+Set a breakpoint and run the configuration; execution stops at it. VS Code injects `--inspect-brk` ahead of your file, and Nub forwards it to the Node child it spawns, so the inspector binds to the port VS Code chose and attaches.
 
 <Callout title="If nub isn't found">
 VS Code resolves `runtimeExecutable` against its own `PATH`. If it can't find `nub`, set the field to the absolute path that `which nub` prints — for example `~/.nub/bin/nub`.
@@ -24,7 +24,7 @@ VS Code resolves `runtimeExecutable` against its own `PATH`. If it can't find `n
 
 ## Program arguments
 
-Pass your program's argv through `args`. Each entry lands on `process.argv`, as it would after the file on the command line.
+Pass your program's argv through `args`. Each entry appears on `process.argv`, as it would after the file on the command line.
 
 ```json title=".vscode/launch.json"
 {
@@ -40,7 +40,7 @@ Read the [full docs](https://code.visualstudio.com/docs/nodejs/nodejs-debugging)
 
 ## TypeScript
 
-Breakpoints in `.ts` source land on the right line. Nub transpiles TypeScript with an inline source map and injects `--enable-source-maps`, so the debugger maps the running code back to your original file — no build step and no `outFiles` configuration.
+Breakpoints in `.ts` source resolve to the source line. Nub transpiles TypeScript with an inline source map and injects `--enable-source-maps`, so the debugger maps the running code back to your original file.
 
 ## Running without augmentation
 

--- a/site/content/docs/runtime/debugging.mdx
+++ b/site/content/docs/runtime/debugging.mdx
@@ -3,7 +3,7 @@ title: Debugging
 description: Attach the VS Code debugger to a program run through Nub, with breakpoints and stepping working while augmentation is on.
 ---
 
-VS Code's Node debugger launches your program with its own `node`, which skips Nub entirely. Point it at the `nub` binary instead and Nub launches the file for you — the inspector comes up and the debugger attaches with no extra setup.
+VS Code's Node debugger launches your program with its own `node`, which skips Nub entirely. Point it at the `nub` binary instead and Nub launches the file for you — the inspector comes up and the debugger attaches.
 
 ```json title=".vscode/launch.json"
 {
@@ -44,7 +44,7 @@ Breakpoints in `.ts` source land on the right line. Nub transpiles TypeScript wi
 
 ## Running without augmentation
 
-To debug on plain Node — every augmentation off, the project's pinned version still used — add `--node` through `runtimeArgs`. It answers the differential question: does the bug still reproduce with none of Nub's runtime changes?
+To debug on plain Node — every augmentation off, the project's pinned version still used — add `--node` through `runtimeArgs`.
 
 ```json title=".vscode/launch.json"
 {

--- a/site/content/docs/runtime/decorators.mdx
+++ b/site/content/docs/runtime/decorators.mdx
@@ -31,7 +31,7 @@ Read the [full docs](https://www.typescriptlang.org/docs/handbook/decorators.htm
 
 ## Design-type metadata
 
-When `emitDecoratorMetadata` is also set, Nub emits the `Reflect.metadata(...)` calls that DI containers read for constructor-parameter type inference. The emitted code references `Reflect.metadata`, so install and import `reflect-metadata` yourself, exactly as on plain TypeScript.
+When `emitDecoratorMetadata` is also set, Nub emits the `Reflect.metadata(...)` calls that DI containers read for constructor-parameter type inference. The emitted code references `Reflect.metadata`, so install and import `reflect-metadata` yourself, as on plain TypeScript.
 
 ## Stage 3 decorators
 

--- a/site/content/docs/runtime/decorators.mdx
+++ b/site/content/docs/runtime/decorators.mdx
@@ -31,7 +31,7 @@ Read the [full docs](https://www.typescriptlang.org/docs/handbook/decorators.htm
 
 ## Design-type metadata
 
-When `emitDecoratorMetadata` is also set, Nub emits the `Reflect.metadata(...)` calls that DI containers read for constructor-parameter type inference. The emitted code references `Reflect.metadata`, so install and import `reflect-metadata` yourself, exactly as on plain TypeScript — Nub does not auto-inject it.
+When `emitDecoratorMetadata` is also set, Nub emits the `Reflect.metadata(...)` calls that DI containers read for constructor-parameter type inference. The emitted code references `Reflect.metadata`, so install and import `reflect-metadata` yourself, exactly as on plain TypeScript.
 
 ## Stage 3 decorators
 

--- a/site/content/docs/runtime/decorators.mdx
+++ b/site/content/docs/runtime/decorators.mdx
@@ -35,4 +35,4 @@ When `emitDecoratorMetadata` is also set, Nub emits the `Reflect.metadata(...)` 
 
 ## Stage 3 decorators
 
-Stage 3 decorators (TypeScript 5's default when no legacy mode is selected) are not supported: that transform is an [upstream gap in oxc](https://github.com/oxc-project/oxc/issues/9170), so Nub rejects Stage-3-shaped decorator syntax with a diagnostic pointing you at `decorators: "legacy"`.
+Stage 3 decorators (TypeScript 5's default when no legacy mode is selected) are not supported: that transform is an [upstream gap in oxc](https://github.com/oxc-project/oxc/issues/9170), so Nub rejects Stage-3-shaped decorator syntax with a diagnostic that names `decorators: "legacy"`.

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -10,7 +10,7 @@ nub server.ts   # .env* in the project root are loaded automatically
 ```
 
 <Callout title="Using Varlock?">
-Nub has first-party support for [Varlock](/docs/runtime/varlock). When a project carries a `.env.schema` and Varlock is installed, Nub's own environment loading switches off entirely and Varlock owns the environment — so the automatic `.env*` discovery on this page does not run. Naming files explicitly still works, and doing so takes Varlock out of the chain.
+Nub has first-party support for [Varlock](/docs/runtime/varlock). When a project carries a `.env.schema` and Varlock is installed, Nub's own environment loading switches off entirely and Varlock owns the environment — so the automatic `.env*` discovery on this page does not run. Naming a file explicitly takes Varlock out of the chain.
 </Callout>
 
 ## File precedence
@@ -22,7 +22,7 @@ Four filenames are loaded, highest priority first. The shell environment always 
 3. `.env.[mode]`
 4. `.env`
 
-The `[mode]` slots only exist when a mode is set; the example below resolves them under `production`. Among the `.env*` files, the first one to define a key wins (first-writer-wins); the shell env sits above all of them.
+The `[mode]` slots only exist when a mode is set; the example below resolves them under `production`. Among the `.env*` files, the first one to define a key wins.
 
 ```bash
 # reads .env.production.local, .env.local, .env.production, .env
@@ -39,7 +39,7 @@ APP_ENV=staging nub server.ts      # reads .env.staging*
 NODE_ENV=production nub server.ts  # APP_ENV unset → reads .env.production*
 ```
 
-The `APP_ENV` variable is a framework-neutral selector: it chooses which `.env` files load without also flipping `NODE_ENV`. It accepts any mode name, and it wins over `NODE_ENV` when both are set. To load a specific file rather than a mode, name it with `--env-file` (below).
+The `APP_ENV` variable is a framework-neutral selector: it chooses which `.env` files load without changing `NODE_ENV`. It accepts any mode name, and it wins over `NODE_ENV` when both are set. To load a specific file rather than a mode, name it with `--env-file` (below).
 
 A mode is only used to build filenames when it contains just letters, digits, `_`, `.`, and `-`. A value with a path separator (a stray `APP_ENV=../other`) is ignored — the `[mode]` files are skipped, `.env` and `.env.local` still load, and no error is raised.
 
@@ -53,9 +53,9 @@ NODE_ENV=staging nub server.ts     # not canonical → reads only .env, .env.loc
 APP_ENV=staging nub server.ts      # use APP_ENV for arbitrary modes
 ```
 
-The clamp exists because `NODE_ENV` is overloaded: many tools read it to switch between development and production behavior, so an unrecognized value silently flips them into development mode.
+The clamp exists because `NODE_ENV` is overloaded: many tools read it to switch between development and production behavior, so an unrecognized value puts them in development mode.
 
-Nub never *sets* `NODE_ENV`, and a `.env` file cannot change it. A `.env` file that assigns `NODE_ENV` has that one key ignored on load, and Nub warns. Otherwise a `.env` pinning `NODE_ENV=development` leaks into production tooling: `next build`, for one, then runs its prerender workers in development mode against production-compiled output.
+Nub never *sets* `NODE_ENV`, and a `.env` file cannot change it. A `.env` file that assigns `NODE_ENV` has that one key ignored on load, and Nub warns. Otherwise a `.env` that sets `NODE_ENV=development` reaches production tooling: `next build` then runs its prerender workers in development mode against production-compiled output.
 
 ## Test environment
 
@@ -126,11 +126,11 @@ Pass `--no-env-file` to load zero env files: the automatic `.env*` discovery is 
 nub --no-env-file --env-file=.env.ci server.ts
 ```
 
-It applies on every surface — a file run, `nub run`, `nubx`, and `nub watch` (where no `.env*` file is handed to the watched Node). For a persistent, whole-tree opt-out that also disables the rest of Nub's augmentation, use `--node` or `NODE_COMPAT=1` instead.
+It applies on every surface — a file run, `nub run`, `nubx`, and `nub watch` (where no `.env*` file is handed to the watched Node).
 
 ## Project configuration
 
-The same choices live in a [nub.jsonc](/docs/config#envfile) at the project root, so every run in the project makes them without a flag.
+The same settings go in a [nub.jsonc](/docs/config#envfile) at the project root and apply to every run.
 
 ```jsonc title="nub.jsonc"
 {

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -78,24 +78,24 @@ Escape a literal dollar sign with `\$` — a value like `PASSWORD=foo$bar` trunc
 
 ## Explicit files
 
-Passing `--env-file=<path>` disables the automatic `.env*` discovery entirely — only the named file loads. Nub reads it through the same parser as the automatic files, and the shell environment still wins over it — matching Bun.
+Passing `--env-file=<path>` disables the automatic `.env*` discovery entirely — only the named file loads. Nub reads it through the same parser as the automatic files, and the shell environment still wins over it.
 
 ```bash
-# only .env.ci loads; auto .env* discovery is skipped; shell env still wins
+# only .env.ci loads
 nub --env-file=.env.ci server.ts
 ```
 
-Values from these files arrive verbatim — no `${VAR}` expansion, matching Node's `--env-file`. The `\$` escape from the expansion section does not apply either: `PASSWORD="foo\$bar"` keeps its backslash, as on Node.
+Values from these files arrive verbatim — no `${VAR}` expansion, matching Node's `--env-file`. The `\$` escape from the expansion section does not apply either: `PASSWORD="foo\$bar"` keeps its backslash.
 
 ```bash title=".env.ci"
 # arrives as the literal string, dollar sign and all
 PASSWORD=foo$bar
 ```
 
-Pass `--env-file` more than once to load several files, in order. A later file overrides a key set by an earlier one — matching Node — and the shell environment still wins over all of them.
+Pass `--env-file` more than once to load several files, in order. A later file overrides a key set by an earlier one, and the shell environment still wins over all of them.
 
 ```bash
-# both load; .env.production wins any key it shares with .env
+# .env.production wins the keys it shares with .env
 nub --env-file=.env --env-file=.env.production server.ts
 ```
 
@@ -110,19 +110,19 @@ nub --env-file-if-exists=.env.local server.ts
 Read the [full docs](https://nodejs.org/api/cli.html#--env-filefile) for `--env-file` on nodejs.org.
 </Callout>
 
-Naming a file takes precedence over [Varlock](/docs/runtime/varlock). A `.env.schema` is a signal Nub infers ownership from; `--env-file` names the file outright, so Nub loads it and Varlock stays out of the chain.
+Naming a file takes precedence over [Varlock](/docs/runtime/varlock): Nub loads it and Varlock stays out of the chain.
 
 ```bash
-# loads .env.ci; the .env.schema hand-over does not happen
+# .env.ci loads; no Varlock hand-over
 nub --env-file=.env.ci server.ts
 ```
 
 ## Loading nothing
 
-Pass `--no-env-file` to load zero env files: the automatic `.env*` discovery is suppressed, any `--env-file` or `--env-file-if-exists` is ignored, and a [Varlock](/docs/runtime/varlock) hand-over does not happen either. Everything else Nub does — TypeScript, JSX, the module hooks — stays on. Reach for it when the environment is already managed elsewhere (CI, a secret manager, `direnv`) and you want Nub to keep its hands off.
+Pass `--no-env-file` to load zero env files: the automatic `.env*` discovery is suppressed, any `--env-file` or `--env-file-if-exists` is ignored, and a [Varlock](/docs/runtime/varlock) hand-over does not happen either. Everything else Nub does stays on. Reach for it when the environment is already managed elsewhere (CI, a secret manager, `direnv`).
 
 ```bash
-# no .env* auto-discovery, and the --env-file is ignored — the child sees neither
+# neither .env* discovery nor the named --env-file loads
 nub --no-env-file --env-file=.env.ci server.ts
 ```
 

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -3,7 +3,7 @@ title: Environment files
 description: Automatic environment-file loading — the file set, mode selection from APP_ENV or a clamped NODE_ENV fallback, precedence, variable expansion, the skip under the test environment, loading explicit files with --env-file, and disabling all loading with --no-env-file.
 ---
 
-Nub reads your `.env*` files and injects them into the environment before Node starts — no `dotenv` import, no `--env-file` flag. Loading happens from the nearest directory with a `package.json` (walking up from your cwd), matching Vite's single-directory model. Works on every Node version Nub supports (18.19+).
+Nub reads your `.env*` files and injects them into the environment before Node starts — no `dotenv` import, no `--env-file` flag. Loading happens from the nearest directory with a `package.json` (walking up from your cwd), matching Vite's single-directory model.
 
 ```bash
 nub server.ts   # .env* in the project root are loaded automatically
@@ -74,18 +74,18 @@ PORT=5432
 DATABASE_URL=postgres://${HOST}:${PORT}/app
 ```
 
-Escape a literal dollar sign with `\$`. Watch the classic footgun: a value like `PASSWORD=foo$bar` truncates to `foo` when `bar` is unset, since `$bar` expands to the empty string — quote and escape it as `PASSWORD="foo\$bar"`.
+Escape a literal dollar sign with `\$` — a value like `PASSWORD=foo$bar` truncates to `foo` when `bar` is unset, since `$bar` expands to the empty string. Quote and escape it as `PASSWORD="foo\$bar"`.
 
 ## Explicit files
 
-Passing `--env-file=<path>` disables the automatic `.env*` discovery entirely — only the named file loads. Nub reads it through the same parser as the automatic files, and the shell environment still wins over it. This matches Bun: ask for a file by name and Nub stops guessing which files you meant.
+Passing `--env-file=<path>` disables the automatic `.env*` discovery entirely — only the named file loads. Nub reads it through the same parser as the automatic files, and the shell environment still wins over it — matching Bun.
 
 ```bash
 # only .env.ci loads; auto .env* discovery is skipped; shell env still wins
 nub --env-file=.env.ci server.ts
 ```
 
-Values from these files arrive verbatim — no `${VAR}` expansion, matching Node's `--env-file`. A password holding a literal dollar sign survives intact, so `PASSWORD=foo$bar` stays `foo$bar` and needs no escaping. The `\$` escape from the expansion section does not apply here either: `PASSWORD="foo\$bar"` keeps its backslash, as it does on Node.
+Values from these files arrive verbatim — no `${VAR}` expansion, matching Node's `--env-file`. The `\$` escape from the expansion section does not apply either: `PASSWORD="foo\$bar"` keeps its backslash, as on Node.
 
 ```bash title=".env.ci"
 # arrives as the literal string, dollar sign and all

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -92,7 +92,7 @@ Values from these files arrive verbatim — no `${VAR}` expansion, matching Node
 PASSWORD=foo$bar
 ```
 
-Pass `--env-file` more than once to load several files, in order. A later file overrides a key set by an earlier one, and the shell environment still wins over all of them.
+Pass `--env-file` more than once to load several files, in order. A later file overrides a key set by an earlier one.
 
 ```bash
 # .env.production wins the keys it shares with .env
@@ -110,7 +110,7 @@ nub --env-file-if-exists=.env.local server.ts
 Read the [full docs](https://nodejs.org/api/cli.html#--env-filefile) for `--env-file` on nodejs.org.
 </Callout>
 
-Naming a file takes precedence over [Varlock](/docs/runtime/varlock): Nub loads it and Varlock stays out of the chain.
+Naming a file takes precedence over [Varlock](/docs/runtime/varlock).
 
 ```bash
 # .env.ci loads; no Varlock hand-over
@@ -148,7 +148,7 @@ false                    load nothing, like --no-env-file
 [".env", ".env.local"]   these files, in order; later files win
 ```
 
-A path always goes in an array, including a single one — `[".env.local"]`, never `".env.local"`. A bare string names a mode, and `"varlock"` is the only one.
+A path always goes in an array, including a single one (`[".env.local"]`). A bare string names a mode, and `"varlock"` is the only one.
 
 Paths resolve from the directory holding the file that supplied them — see [relative paths](/docs/config#relative-paths), which matters most when the file is your global config — and they expand `${VAR}` and `$VAR` against the environment, because a config file is never shell-expanded. A path of `".env.${APP_ENV}"` reads `.env.staging` under `APP_ENV=staging`.
 

--- a/site/content/docs/runtime/env.mdx
+++ b/site/content/docs/runtime/env.mdx
@@ -92,14 +92,14 @@ Values from these files arrive verbatim — no `${VAR}` expansion, matching Node
 PASSWORD=foo$bar
 ```
 
-Pass `--env-file` more than once to load several files, in order. A later file overrides a key set by an earlier one.
+Pass `--env-file` more than once to load several files, in order.
 
 ```bash
 # .env.production wins the keys it shares with .env
 nub --env-file=.env --env-file=.env.production server.ts
 ```
 
-A missing file is an error. To load a file only when it is present and skip silently otherwise, use `--env-file-if-exists` — the Node v22 variant. It behaves identically to `--env-file` in every other respect.
+A missing file is an error. To load a file only when it is present and skip silently otherwise, use `--env-file-if-exists` — the Node v22 variant.
 
 ```bash
 # loads .env.local if present; no error if it isn't
@@ -119,7 +119,7 @@ nub --env-file=.env.ci server.ts
 
 ## Loading nothing
 
-Pass `--no-env-file` to load zero env files: the automatic `.env*` discovery is suppressed, any `--env-file` or `--env-file-if-exists` is ignored, and a [Varlock](/docs/runtime/varlock) hand-over does not happen either. Everything else Nub does stays on. Reach for it when the environment is already managed elsewhere (CI, a secret manager, `direnv`).
+Pass `--no-env-file` to load zero env files: the automatic `.env*` discovery is suppressed, any `--env-file` or `--env-file-if-exists` is ignored, and a [Varlock](/docs/runtime/varlock) hand-over does not happen either.
 
 ```bash
 # neither .env* discovery nor the named --env-file loads

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -155,9 +155,7 @@ A command-line flag always wins over the file. See [nub.jsonc](/docs/config) for
 
 ## Compatibility mode
 
-Nub augments by default. Compatibility mode turns every augmentation off — the load hook, preloads, unflagging, and `.env` loading — and runs your code on plain Node, as `node <file>` would. It still runs the project's *pinned* Node; version provisioning stays on. (This is distinct from the compatibility *tier* in the [table above](#supported-versions-and-tiers), the startup path for Node lines without sync `registerHooks`, which only changes how augmentation is delivered.)
-
-The three forms below compose: any one of them forces compatibility mode.
+Compatibility mode turns every augmentation off — the load hook, preloads, unflagging, and `.env` loading — and runs your code on plain Node, as `node <file>` would. It still runs the project's *pinned* Node; version provisioning stays on. (This is distinct from the compatibility *tier* in the [table above](#supported-versions-and-tiers), the startup path for Node lines without sync `registerHooks`, which only changes how augmentation is delivered.)
 
 ### `--node`
 
@@ -170,7 +168,7 @@ node script.js           # your shell's Node, unaugmented, unprovisioned
 
 ### `NODE_COMPAT`
 
-Setting a truthy `NODE_COMPAT` (`1`, `true`, or `yes`, case-insensitive) is the project/tree-wide form of `--node`. It has the identical effect — zero augmentation, Node-version provisioning still on — but it's **persistent and inherited** by every descendant `node` / `nub` in the tree, so you don't repeat `--node` per invocation:
+Setting a truthy `NODE_COMPAT` (`1`, `true`, or `yes`, case-insensitive) is the tree-wide form of `--node`: the same effect, inherited by every descendant `node` / `nub` in the tree:
 
 ```bash
 export NODE_COMPAT=1     # every nub/node in this shell now runs vanilla
@@ -179,7 +177,7 @@ nub script.ts            # plain Node, still on the project's pinned version
 
 ### `nodeCompat`
 
-Setting `nodeCompat` in a [nub.jsonc](/docs/config#nodecompat) is the project-wide form: it applies to everyone working in the repository.
+Setting `nodeCompat` in a [nub.jsonc](/docs/config#nodecompat) is the project-wide form.
 
 ```jsonc title="nub.jsonc"
 {
@@ -192,7 +190,7 @@ None of the other `nub.jsonc` runtime fields apply once it is set.
 
 ## How it works
 
-Every augmentation goes through Node's own extension points; Nub ships no patched Node and no runtime of its own. It registers a `module.registerHooks()` load hook (an async `module.register()` loader-worker on the compatibility tier) for transpilation and resolution, and injects a small `--import` preload for the globals and `.env` loading. On the fast tier, transpilation runs through an embedded [oxc](https://oxc.rs) N-API addon.
+Nub registers a `module.registerHooks()` load hook (an async `module.register()` loader-worker on the compatibility tier) for transpilation and resolution, and injects a small `--import` preload for the globals and `.env` loading. On the fast tier, transpilation runs through an embedded [oxc](https://oxc.rs) N-API addon.
 
 <Callout>
 Read the [full docs](https://nodejs.org/api/module.html#moduleregisterhooksoptions) for module customization hooks on nodejs.org.

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -155,11 +155,11 @@ A command-line flag always wins over the file. See [nub.jsonc](/docs/config) for
 
 ## Compatibility mode
 
-Compatibility mode turns every augmentation off — the load hook, preloads, unflagging, and `.env` loading — and runs your code on plain Node, as `node <file>` would. It still runs the project's *pinned* Node; version provisioning stays on. (This is distinct from the compatibility *tier* in the [table above](#supported-versions-and-tiers), the startup path for Node lines without sync `registerHooks`, which only changes how augmentation is delivered.)
+Compatibility mode turns every augmentation off — the load hook, preloads, unflagging, and `.env` loading — and runs your code on plain Node. It still runs the project's *pinned* Node; version provisioning stays on. (This is distinct from the compatibility *tier* in the [table above](#supported-versions-and-tiers), the startup path for Node lines without sync `registerHooks`, which only changes how augmentation is delivered.)
 
 ### `--node`
 
-Pass `--node` to run a single invocation with zero augmentation. Your code runs on the project's *pinned* Node (from `.node-version` / `.nvmrc`, fetched if missing), vanilla.
+Pass `--node` to run a single invocation with zero augmentation. Your code runs on the project's *pinned* Node (from `.node-version` / `.nvmrc`, fetched if missing).
 
 ```bash
 nub --node script.js     # the project's pinned Node, vanilla
@@ -168,7 +168,7 @@ node script.js           # your shell's Node, unaugmented, unprovisioned
 
 ### `NODE_COMPAT`
 
-Setting a truthy `NODE_COMPAT` (`1`, `true`, or `yes`, case-insensitive) is the tree-wide form of `--node`: the same effect, inherited by every descendant `node` / `nub` in the tree:
+Setting a truthy `NODE_COMPAT` (`1`, `true`, or `yes`, case-insensitive) has the same effect as `--node` and is inherited by every descendant `node` / `nub` in the tree:
 
 ```bash
 export NODE_COMPAT=1     # every nub/node in this shell now runs vanilla
@@ -177,12 +177,12 @@ nub script.ts            # plain Node, still on the project's pinned version
 
 ### `nodeCompat`
 
-Setting `nodeCompat` in a [nub.jsonc](/docs/config#nodecompat) is the project-wide form.
+Setting `nodeCompat` in a [nub.jsonc](/docs/config#nodecompat) applies compatibility mode to every run in the project.
 
 ```jsonc title="nub.jsonc"
 {
   // ...
-  "nodeCompat": true  // plain Node, version pinning kept
+  "nodeCompat": true  // compatibility mode for every run
 }
 ```
 

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -49,7 +49,7 @@ Nub selects the tier from your Node version. The fast tier needs sync `module.re
 | 26.x | all 26.x | 26.0 | Fast (whole line) | ✓ **default** |
 
 <Callout title="Why a fast-tier Node is recommended">
-The compatibility tier routes module loading through an async `module.register()` loader-worker, which costs about **1.4× slower cold start** than the fast tier — a fixed **~80 ms** startup overhead plus **~90 µs per module**. There's **zero runtime cost**: execution speed is identical, and the penalty is module loading only. The fast tier (22.15+, sync `module.registerHooks()`) has none of it.
+The compatibility tier routes module loading through an async `module.register()` loader-worker: about **1.4× slower cold start** than the fast tier — a fixed **~80 ms** plus **~90 µs per module** — with no effect on execution speed. The fast tier (22.15+, sync `module.registerHooks()`) has none of it.
 </Callout>
 
 ## Augmentations
@@ -61,13 +61,13 @@ The compatibility tier routes module loading through an async `module.register()
 - **[Environment variables](/docs/runtime/env)** — `.env*` files load into the environment before Node starts, with `${VAR}` expansion. No `dotenv`, no `--env-file`.
 - **[Varlock](/docs/runtime/varlock)** — a project with an `@env-spec` schema hands its environment to Varlock instead, with no wrapper command and no import in your source.
 - **[Loaders](/docs/runtime/loaders)** — import `.yaml`, `.toml`, `.jsonc`, `.json5`, and `.txt` files directly as parsed values, with no npm parser.
-- **[Modern APIs](/docs/runtime/modern-apis)** — modern globals and built-ins (Temporal, URLPattern, WebSocket, EventSource, node:sqlite, and more) work out of the box, polyfilled or unflagged per Node-version band.
+- **[Modern APIs](/docs/runtime/modern-apis)** — modern globals and built-ins (Temporal, URLPattern, WebSocket, EventSource, node:sqlite, and more) are present, polyfilled or unflagged per Node-version band.
 - **[Workers](/docs/runtime/workers)** — the browser-shape `Worker` global runs your `.ts` entry points, wrapping `node:worker_threads`.
 - **[Web Storage](/docs/runtime/web-storage)** — `localStorage` / `sessionStorage` behavior and the opt-in that backs persistent storage.
 
 ## Modern APIs
 
-Modern globals — TC39, web-platform, and newer Node built-ins — work out of the box under Nub. Native implementations win; Nub fills a missing API or enables a version's experimental Node feature only where needed.
+Modern globals — TC39, web-platform, and newer Node built-ins — are available under Nub. Native implementations win; Nub fills a missing API or enables a version's experimental Node feature only where needed.
 
 ```ts
 const now = Temporal.Now.plainDateTimeISO();
@@ -161,7 +161,7 @@ There are three spellings: a per-invocation flag, a tree-wide env var, and a pro
 
 ### `--node`
 
-Pass `--node` to run a single invocation with zero augmentation. Your code runs on the project's *pinned* Node (from `.node-version` / `.nvmrc`, fetched if missing), vanilla — which makes it the tool for differential debugging: does this reproduce on plain Node, on the exact version this project pins? A bare `node script.js` can't answer that, because it runs your shell's Node, not the project's.
+Pass `--node` to run a single invocation with zero augmentation. Your code runs on the project's *pinned* Node (from `.node-version` / `.nvmrc`, fetched if missing), vanilla — useful for checking whether a behavior reproduces on plain Node, on the exact version the project pins.
 
 ```bash
 nub --node script.js     # the project's pinned Node, vanilla

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -155,13 +155,13 @@ A command-line flag always wins over the file. See [nub.jsonc](/docs/config) for
 
 ## Compatibility mode
 
-Nub augments by default. Compatibility mode turns **every** augmentation off — no load hook, no preload, no unflagging, no `.env` loading — and runs your code on plain Node, exactly as `node <file>` would. It still runs the project's *pinned* Node; version provisioning stays on. (This is distinct from the compatibility *tier* — the startup path for the Node lines without sync `registerHooks`, in the [table above](#supported-versions-and-tiers) — which is about how augmentation is delivered, not whether it runs.)
+Nub augments by default. Compatibility mode turns every augmentation off — the load hook, preloads, unflagging, and `.env` loading — and runs your code on plain Node, as `node <file>` would. It still runs the project's *pinned* Node; version provisioning stays on. (This is distinct from the compatibility *tier* in the [table above](#supported-versions-and-tiers), the startup path for Node lines without sync `registerHooks`, which only changes how augmentation is delivered.)
 
-There are three spellings: a per-invocation flag, a tree-wide env var, and a project field. They compose — any one of them forces compatibility mode.
+The three forms below compose: any one of them forces compatibility mode.
 
 ### `--node`
 
-Pass `--node` to run a single invocation with zero augmentation. Your code runs on the project's *pinned* Node (from `.node-version` / `.nvmrc`, fetched if missing), vanilla — useful for checking whether a behavior reproduces on plain Node, on the exact version the project pins.
+Pass `--node` to run a single invocation with zero augmentation. Your code runs on the project's *pinned* Node (from `.node-version` / `.nvmrc`, fetched if missing), vanilla.
 
 ```bash
 nub --node script.js     # the project's pinned Node, vanilla
@@ -179,7 +179,7 @@ nub script.ts            # plain Node, still on the project's pinned version
 
 ### `nodeCompat`
 
-Setting `nodeCompat` in a [nub.jsonc](/docs/config#nodecompat) is the project-wide form: everyone working in the repository gets plain Node without setting anything in their shell.
+Setting `nodeCompat` in a [nub.jsonc](/docs/config#nodecompat) is the project-wide form: it applies to everyone working in the repository.
 
 ```jsonc title="nub.jsonc"
 {
@@ -192,7 +192,7 @@ None of the other `nub.jsonc` runtime fields apply once it is set.
 
 ## How it works
 
-Every augmentation rides on Node's own extension points — Nub patches nothing and ships no runtime of its own. It registers a `module.registerHooks()` load hook (an async `module.register()` loader-worker on the compatibility tier) for transpilation and resolution, and injects a small `--import` preload for the globals and `.env` loading. On the fast tier, transpilation runs through an embedded [oxc](https://oxc.rs) N-API addon.
+Every augmentation goes through Node's own extension points; Nub ships no patched Node and no runtime of its own. It registers a `module.registerHooks()` load hook (an async `module.register()` loader-worker on the compatibility tier) for transpilation and resolution, and injects a small `--import` preload for the globals and `.env` loading. On the fast tier, transpilation runs through an embedded [oxc](https://oxc.rs) N-API addon.
 
 <Callout>
 Read the [full docs](https://nodejs.org/api/module.html#moduleregisterhooksoptions) for module customization hooks on nodejs.org.

--- a/site/content/docs/runtime/index.mdx
+++ b/site/content/docs/runtime/index.mdx
@@ -26,7 +26,7 @@ On top of stock Node, `nub <file>` adds a modern runtime:
 Nub is a drop-in for `node`: same argv shape, same flag set, and every flag reaches Node verbatim. Pass `--node` (or set `NODE_COMPAT=1`) to turn every augmentation off and run on plain Node.
 
 <Callout title="Supported Node versions">
-Nub runs your code on stock Node — it resolves which Node your project pins and fetches one if it's missing, but never ships a runtime of its own.
+Nub runs your code on stock Node: it resolves the Node your project pins and fetches it when missing.
 </Callout>
 
 ## Supported versions and tiers
@@ -34,9 +34,9 @@ Nub runs your code on stock Node — it resolves which Node your project pins an
 The hard floor is **Node 18.19** — below it no loader-hook API can carry Nub's augmentations, so Nub refuses to run. Above the floor, augmentation is delivered through one of two tiers:
 
 - **Fast tier** — sync `module.registerHooks()`, run in-thread via a `--require` CJS preload. No loader-worker, lower startup overhead.
-- **Compatibility tier** — async `module.register()`, run in a loader-worker thread via an `--import` ESM preload. Same augmentations, a little more startup cost.
+- **Compatibility tier** — async `module.register()`, run in a loader-worker thread via an `--import` ESM preload. Same augmentations, more startup cost.
 
-Nub selects the tier from your Node version. The fast tier needs sync `module.registerHooks()`, which Node added in v23.5.0 and backported to v22.15.0 — and never backported to the 20.x line. So the tier boundary lands differently per Node major:
+Nub selects the tier from your Node version. The fast tier needs sync `module.registerHooks()`, which Node added in v23.5.0 and backported to v22.15.0 — and never backported to the 20.x line. The tier boundary differs per Node major:
 
 | Node line | Minimum Nub supports | Fast-tier floor | Tier | Recommended |
 |---|---|---|---|---|
@@ -102,9 +102,9 @@ Hello world!
 
 A few details of the walk:
 
-- Discovery walks **up** the directory tree to the nearest pin, and **skips** pin files that live inside an installed dependency (under `node_modules`) — a dependency's own CI pin never drives your project.
+- Discovery walks **up** the directory tree to the nearest pin, and **skips** pin files inside an installed dependency (under `node_modules`) — a dependency's own CI pin never drives your project.
 - The `package.json` fields (`devEngines.runtime`, `engines.node`) are read from the **workspace root** manifest when one exists above you — a monorepo pins its Node once at the root.
-- Once a version is pinned, Nub finds a binary for it in order: the `node` on `PATH` (so `fnm` / `Volta` / `mise` auto-switching just works) → Nub's own download store (`~/.cache/nub/node/<version>/`) → an `nvm`-installed version → download the matching stock build from nodejs.org, SHA-256 verified and cached.
+- Once a version is pinned, Nub finds a binary for it in order: the `node` on `PATH` (so `fnm` / `Volta` / `mise` auto-switching is honored) → Nub's own download store (`~/.cache/nub/node/<version>/`) → an `nvm`-installed version → download the matching stock build from nodejs.org, SHA-256 verified and cached.
 
 For pinning, pre-installing, and the `nub node` subcommands, see [Managing Node versions](/docs/node).
 

--- a/site/content/docs/runtime/jsx.mdx
+++ b/site/content/docs/runtime/jsx.mdx
@@ -66,5 +66,3 @@ export default function Page() {
   return <h1>Hello</h1>;
 }
 ```
-
-The pragma is read from the file source itself; no tsconfig entry is needed for it to take effect.

--- a/site/content/docs/runtime/jsx.mdx
+++ b/site/content/docs/runtime/jsx.mdx
@@ -3,7 +3,7 @@ title: JSX
 description: How Nub runs JSX on stock Node — automatic-runtime defaults, tsconfig-driven configuration, and the per-file import-source pragma for mixing runtimes.
 ---
 
-Files ending in `.jsx` and `.tsx` execute through the same load hook. JSX is recognized in `.jsx` / `.tsx` only, never in plain `.js`. The defaults are the modern ones — automatic runtime, `react` as the import source — matching oxc-transformer, Vite's React plugins, Rolldown, and Bun, so a React project needs no setup.
+Files ending in `.jsx` and `.tsx` execute through the same load hook. JSX is recognized in `.jsx` / `.tsx` only, never in plain `.js`. The defaults are the modern ones — automatic runtime, `react` as the import source — matching oxc-transformer, Vite's React plugins, Rolldown, and Bun.
 
 ```bash
 nub render.tsx

--- a/site/content/docs/runtime/loaders.mdx
+++ b/site/content/docs/runtime/loaders.mdx
@@ -53,7 +53,7 @@ Any other value stops the command with an error.
 
 ## Default export
 
-A data module exposes a single default export — the parsed value, exactly like Node's own JSON modules. There are no named exports; destructure the default to pull out top-level keys.
+A data module exposes a single default export — the parsed value, like Node's own JSON modules. There are no named exports; destructure the default to pull out top-level keys.
 
 ```yaml title="config.yaml"
 host: localhost

--- a/site/content/docs/runtime/loaders.mdx
+++ b/site/content/docs/runtime/loaders.mdx
@@ -27,7 +27,7 @@ Loaders are keyed on file extension:
 - `.yaml` / `.yml`
 - `.txt` — loaded as a string, no parsing
 
-The `.json` extension is intentionally not in this set — it is Node-native (`resolveJsonModule`), so Nub leaves it to Node.
+The `.json` extension is not in this set: JSON modules are Node-native.
 
 ## Custom extensions
 
@@ -67,7 +67,7 @@ const { host, port } = config;      // "localhost", 5432
 
 The object formats are typed `Record<string, unknown>`, so destructured keys are `unknown` — narrow or cast them at the use site. A data file whose top-level value is an array or scalar imports as that value via the default; cast it, since the wildcard type assumes an object.
 
-## Import any file as text
+## Text imports
 
 Add the `with { type: "text" }` import attribute to read a file's raw contents as a string, whatever its extension.
 

--- a/site/content/docs/runtime/modern-apis.mdx
+++ b/site/content/docs/runtime/modern-apis.mdx
@@ -11,7 +11,7 @@ Nub's types package declares the keyed Promise combinators, `Temporal`, the brow
 
 ## How augmentation works
 
-Nub augments the stock Node binary through mechanisms Node itself provides. It does not patch Node, replace V8, or ship a fork.
+Nub augments the stock Node binary through mechanisms Node itself provides.
 
 - **JavaScript polyfills** run from Nub's preload and feature-detect each property before defining it. They fill missing globals and methods without replacing native or user-supplied implementations.
 - **Lazy globals** defer larger fallbacks until first use. On older Node versions, reading `Temporal` loads the fallback and replaces the getter with the resulting namespace.
@@ -19,11 +19,11 @@ Nub augments the stock Node binary through mechanisms Node itself provides. It d
 - **Experimental flags** expose APIs already built into a particular Node release. Nub derives flags from the exact Node version because passing an unknown flag would abort Node during startup.
 - **Loader hooks** add supported import formats through Node's module-loader API. They do not emulate native subsystems that are absent from the running Node.
 
-Native implementations always win. As Node adds an API, Nub's feature check steps aside and the native one takes over.
+Native implementations always win.
 
 Compatibility mode turns all of this off: `nub --node`, or `NODE_COMPAT=1`, runs the project's pinned Node with no polyfills, preload patches, loader hooks, or automatically enabled flags. See [the runtime overview](/docs/runtime#compatibility-mode).
 
-Availability below covers Nub's supported Node range, beginning with Node 18.19. A native-version note says when Nub steps aside.
+Availability below covers Nub's supported Node range, beginning with Node 18.19. Each entry names the Node version where the native implementation takes over.
 
 ## JavaScript APIs
 
@@ -366,7 +366,7 @@ try {
 
 ### `Math.sumPrecise()`
 
-The [`Math.sumPrecise()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sumPrecise) method reduces floating-point error and avoids overflow caused only by an unfortunate addition order.
+The [`Math.sumPrecise()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sumPrecise) method reduces floating-point error and avoids overflow caused by addition order.
 
 <Callout title="Delivery">
 Feature-detected JavaScript polyfill on every supported Node version. No Node release ships this method yet.
@@ -697,7 +697,7 @@ if (consented) {
 ```
 
 <Callout type="warn" title="The dynamic form aborts the process">
-Nub enables this V8 feature for every program on Node 26.4+, not only the ones that use it. So the dynamic counterpart, `import.defer(specifier)`, behaves differently than it does on bare Node: Node raises a catchable `SyntaxError`, while under Nub the same code dies on a V8 fatal error that no handler can catch. The underlying crash is a Node defect, but Nub is what exposes it. Use the static form.
+Nub enables this V8 feature for every program on Node 26.4+, not only the ones that use it. So the dynamic counterpart, `import.defer(specifier)`, behaves differently than it does on bare Node: Node raises a catchable `SyntaxError`, while under Nub the same code terminates with an uncatchable V8 fatal error. The crash is a Node defect that Nub's flag exposes. Use the static form.
 </Callout>
 
 ### Module syntax detection

--- a/site/content/docs/runtime/resolution.mdx
+++ b/site/content/docs/runtime/resolution.mdx
@@ -24,7 +24,7 @@ Nub reads your nearest `tsconfig.json` and applies its resolution settings at ru
 
 ### `paths`
 
-The `compilerOptions.paths` and `compilerOptions.baseUrl` mappings resolve `@/...`-style aliases with no extra tooling.
+The `compilerOptions.paths` and `compilerOptions.baseUrl` mappings resolve `@/...`-style aliases.
 
 ```json title="tsconfig.json"
 {
@@ -53,7 +53,7 @@ Path aliases work from any file, not just TypeScript ones — a `.js` file that 
 
 ### `baseUrl`
 
-With `baseUrl` set and no matching `paths` entry, a bare specifier resolves relative to the base directory. A `import "lib/config"` finds `baseUrl/lib/config.ts` on its own.
+With `baseUrl` set and no matching `paths` entry, a bare specifier resolves relative to the base directory.
 
 ```json title="tsconfig.json"
 { "compilerOptions": { "baseUrl": "." } }
@@ -73,7 +73,7 @@ Configs are read once per process. Edit your `tsconfig.json` and restart the pro
 
 ## Extensionless imports
 
-In TypeScript-family files, extensionless imports resolve the way `tsc` resolves them — `import "./foo"` finds `./foo.ts`. This is the conventional pattern most TypeScript codebases use.
+In TypeScript-family files, extensionless imports resolve the way `tsc` resolves them — `import "./foo"` finds `./foo.ts`.
 
 ```ts
 // from a .ts / .tsx / .mts / .cts file:
@@ -123,7 +123,7 @@ A subpath naming a directory resolves that directory's `index` file, the way a `
 import { parse } from "qs/lib";   // resolves qs/lib/index.js
 ```
 
-Only `index` is consulted. A directory's own `package.json` `main` is not read for a subpath — Node's `require` reads it, and deferring keeps both resolvers on the same answer. A trailing slash means what it says: `qs/lib/` is the directory, never a `qs/lib.js` beside it.
+Only `index` is consulted. A directory's own `package.json` `main` is not read for a subpath — Node's `require` reads it, and deferring keeps both resolvers on the same answer. A trailing slash names the directory: `qs/lib/` is the directory, never a `qs/lib.js` beside it.
 
 <Callout>A dependency that declares `exports` is never probed. Its map decides what is reachable, exactly as on Node, so a subpath it withholds stays an error.</Callout>
 
@@ -139,7 +139,7 @@ import { handler } from "./handler.js";
 import { createPrompt } from "@repo/lib/prompt.js";
 ```
 
-The literal extension always wins first: a real on-disk `./handler.js` is used as-is, and the swap only fires when the written extension points at a file that doesn't exist. The same rewrite covers `.jsx → .tsx`, `.mjs → .mts`, and `.cjs → .cts` — and likewise, a real `.cjs` beats a sibling `.cts`. This is the `tsc` emit convention.
+The swap only fires when the written extension points at a file that doesn't exist — a real on-disk `./handler.js` is used as-is. The same rewrite covers `.jsx → .tsx`, `.mjs → .mts`, and `.cjs → .cts`, and likewise a real `.cjs` beats a sibling `.cts`.
 
 ## What falls through to Node
 
@@ -180,7 +180,7 @@ Every resolution in the project matches against them, a bare-specifier [preload]
 
 ## Yarn Plug'n'Play
 
-A project Yarn installed in PnP mode just runs — Nub enables Plug'n'Play automatically, with no flag and no setup. Walking up from the working directory, Nub detects a `.pnp.cjs` at the project root and injects it ahead of its own preload (`--require .pnp.cjs` on the fast tier, the `NODE_OPTIONS` equivalent on the compat tier), so PnP's resolver patches install first and Nub's TypeScript resolution layers on top.
+Nub enables Plug'n'Play automatically, with no flag and no setup. Walking up from the working directory, it detects a `.pnp.cjs` at the project root and injects it ahead of its own preload (`--require .pnp.cjs` on the fast tier, the `NODE_OPTIONS` equivalent on the compat tier), so PnP's resolver patches install first and Nub's TypeScript resolution layers on top.
 
 ```bash
 nub index.ts        # .pnp.cjs is detected and loaded automatically
@@ -196,7 +196,7 @@ Both `require` and `import` resolve under PnP, by different paths:
 
 Nub doesn't register Yarn's `.pnp.loader.mjs` (its ESM resolver collides with the fast tier's `module.registerHooks`), so the same `pnpapi.resolveRequest` path serves both tiers.
 
-It works across the whole supported Node range (18.19+), on macOS, Linux, and Windows — including `import` of zip-stored packages and running a zip-stored binary through `nubx`. This is the runtime *running* a PnP project; Nub's installer does not itself produce a PnP install — that stays Yarn's job. Package `extends` chains resolve through the node_modules walk rather than the PnP API, which covers the npm and pnpm installs where that form appears.
+Zip-stored packages resolve too — `import` from a `.yarn/cache` zip, and `nubx` running a zip-stored binary. This is the runtime *running* a PnP project; producing the PnP install stays Yarn's job. Package `extends` chains resolve through the node_modules walk rather than the PnP API, which covers the npm and pnpm installs where that form appears.
 
 <Callout>
 Read the [full docs](https://yarnpkg.com/features/pnp) for Plug'n'Play on yarnpkg.com.

--- a/site/content/docs/runtime/resolution.mdx
+++ b/site/content/docs/runtime/resolution.mdx
@@ -93,7 +93,7 @@ The probe order is extension-aware — it depends on the parent file's extension
 
 A directory import honors the directory's `package.json` `"main"` before falling back to probing `index.<ext>` in that same parent-aware order. Only `"main"` is consulted — `exports` is never read for a directory-path import, matching Node, which honors `exports` only for package-name resolution.
 
-This probing is scoped to TypeScript-family parent files (`.ts` / `.tsx` / `.mts` / `.cts`) with a relative specifier. A plain `.js` file stays strict about relative extensions, exactly like vanilla Node. Subpaths into a dependency are covered below and follow a different rule.
+This probing is scoped to TypeScript-family parent files (`.ts` / `.tsx` / `.mts` / `.cts`) with a relative specifier. A plain `.js` file stays strict about relative extensions, like vanilla Node. Subpaths into a dependency are covered below and follow a different rule.
 
 ## Package subpaths
 
@@ -113,9 +113,9 @@ The order here is fixed, and unlike relative imports it does not vary with the i
 .js  .json  .ts  .tsx
 ```
 
-JavaScript sorts first because a published package's `.ts` is unshipped source that Nub does not transpile inside node_modules. A workspace package symlinked into node_modules ships no `.js` at all, so the same order still lands on its TypeScript.
+JavaScript sorts first because a published package's `.ts` is unshipped source that Nub does not transpile inside node_modules. A workspace package symlinked into node_modules ships no `.js`, so the order lands on its TypeScript.
 
-Because the rule is about the dependency's shape rather than the importer's, it is not scoped to TypeScript-family parents — a `.js` file in a `checkJs` project resolves these the same way.
+Subpath probing applies from any importing file, `.js` included.
 
 A subpath naming a directory resolves that directory's `index` file, the way a `require` of the same subpath already does:
 
@@ -123,9 +123,9 @@ A subpath naming a directory resolves that directory's `index` file, the way a `
 import { parse } from "qs/lib";   // resolves qs/lib/index.js
 ```
 
-Only `index` is consulted. A directory's own `package.json` `main` is not read for a subpath — Node's `require` reads it, and deferring keeps both resolvers on the same answer. A trailing slash names the directory: `qs/lib/` is the directory, never a `qs/lib.js` beside it.
+Nub's probe consults only `index`; a directory's own `package.json` `main` is left to Node's resolver, so `require` and `import` land on the same file.
 
-<Callout>A dependency that declares `exports` is never probed. Its map decides what is reachable, exactly as on Node, so a subpath it withholds stays an error.</Callout>
+<Callout>A dependency that declares `exports` is never probed. Its map decides what is reachable, as on Node, so a subpath it withholds stays an error.</Callout>
 
 ## .js → .ts resolution
 
@@ -143,7 +143,7 @@ The swap only fires when the written extension points at a file that doesn't exi
 
 ## What falls through to Node
 
-Nub resolves only the TypeScript-aware cases Node has no opinion on. Everything else is Node's job, handled by Node's own resolver unchanged:
+Nub resolves only the TypeScript-aware cases. Node's own resolver handles everything else, unchanged:
 
 - package names
 - `exports` / `imports` maps

--- a/site/content/docs/runtime/resolution.mdx
+++ b/site/content/docs/runtime/resolution.mdx
@@ -123,13 +123,13 @@ A subpath naming a directory resolves that directory's `index` file, the way a `
 import { parse } from "qs/lib";   // resolves qs/lib/index.js
 ```
 
-Nub's probe consults only `index`; a directory's own `package.json` `main` is left to Node's resolver, so `require` and `import` land on the same file.
+Nub's probe consults only `index`; a directory's own `package.json` `main` is left to Node's resolver.
 
-<Callout>A dependency that declares `exports` is never probed. Its map decides what is reachable, as on Node, so a subpath it withholds stays an error.</Callout>
+<Callout>A dependency that declares `exports` is never probed; its map alone decides what is reachable, as on Node.</Callout>
 
 ## .js → .ts resolution
 
-With `moduleResolution: "nodenext"`, `tsc` wants a `.js` extension even though the file on disk is `.ts`. Nub reverses that at runtime, so the same source runs before and after a build.
+With `moduleResolution: "nodenext"`, `tsc` wants a `.js` extension even though the file on disk is `.ts`. Nub reverses that at runtime.
 
 ```ts
 // resolves ./handler.ts when no ./handler.js exists
@@ -139,11 +139,11 @@ import { handler } from "./handler.js";
 import { createPrompt } from "@repo/lib/prompt.js";
 ```
 
-The swap only fires when the written extension points at a file that doesn't exist — a real on-disk `./handler.js` is used as-is. The same rewrite covers `.jsx → .tsx`, `.mjs → .mts`, and `.cjs → .cts`, and likewise a real `.cjs` beats a sibling `.cts`.
+The swap only fires when the written extension points at a file that doesn't exist. The same rewrite covers `.jsx → .tsx`, `.mjs → .mts`, and `.cjs → .cts`, and likewise a real `.cjs` beats a sibling `.cts`.
 
 ## What falls through to Node
 
-Nub resolves only the TypeScript-aware cases. Node's own resolver handles everything else, unchanged:
+Node's own resolver handles everything else, unchanged:
 
 - package names
 - `exports` / `imports` maps

--- a/site/content/docs/runtime/resolution.mdx
+++ b/site/content/docs/runtime/resolution.mdx
@@ -16,7 +16,7 @@ import { config } from "./config";
 import { handler } from "./handler.js";
 ```
 
-If your editor's Go-to-Definition works on an import and `tsc` accepts it, Nub resolves it the same way at runtime — no `tsconfig-paths` package, no build step. Nub owns exactly the cases Node has no opinion on: `tsconfig.json` path aliases, extensionless imports in TypeScript files, the `.js`→`.ts` emit-convention swap, and subpaths into dependencies that declare no `exports`. Everything else — package names, `exports` / `imports` maps, export conditions — falls through to Node unchanged.
+If your editor's Go-to-Definition works on an import and `tsc` accepts it, Nub resolves it the same way at runtime — no `tsconfig-paths` package, no build step. Nub handles only the cases Node does not define: `tsconfig.json` path aliases, extensionless imports in TypeScript files, the `.js`→`.ts` emit-convention swap, and subpaths into dependencies that declare no `exports`. Everything else — package names, `exports` / `imports` maps, export conditions — falls through to Node unchanged.
 
 ## `tsconfig.json`
 
@@ -69,7 +69,7 @@ A bare specifier with no `baseUrl`-relative file on disk falls through to Node's
 
 Nub walks up to the nearest `tsconfig.json` and follows `extends` chains, including array `extends` (later entries win) and package extends like `extends: "@tsconfig/node20/tsconfig.json"` resolved through node_modules. The TS 5.5 `${configDir}` template is interpolated against the consuming config's directory.
 
-Configs are read once per process. Edit your `tsconfig.json` and restart the process — or let [`nub watch`](/docs/watch) restart it for you.
+Configs are read once per process. Edit your `tsconfig.json` and restart the process, or run under [`nub watch`](/docs/watch), which restarts it.
 
 ## Extensionless imports
 
@@ -93,7 +93,7 @@ The probe order is extension-aware — it depends on the parent file's extension
 
 A directory import honors the directory's `package.json` `"main"` before falling back to probing `index.<ext>` in that same parent-aware order. Only `"main"` is consulted — `exports` is never read for a directory-path import, matching Node, which honors `exports` only for package-name resolution.
 
-This probing is scoped to TypeScript-family parent files (`.ts` / `.tsx` / `.mts` / `.cts`) with a relative specifier. A plain `.js` file stays strict about relative extensions, like vanilla Node. Subpaths into a dependency are covered below and follow a different rule.
+This probing is scoped to TypeScript-family parent files (`.ts` / `.tsx` / `.mts` / `.cts`) with a relative specifier. A plain `.js` file requires relative extensions, as under Node. Subpaths into a dependency are covered below and follow a different rule.
 
 ## Package subpaths
 
@@ -113,7 +113,7 @@ The order here is fixed, and unlike relative imports it does not vary with the i
 .js  .json  .ts  .tsx
 ```
 
-JavaScript sorts first because a published package's `.ts` is unshipped source that Nub does not transpile inside node_modules. A workspace package symlinked into node_modules ships no `.js`, so the order lands on its TypeScript.
+JavaScript sorts first because a published package's `.ts` is unshipped source that Nub does not transpile inside node_modules. A workspace package symlinked into node_modules ships no `.js`, so the probe reaches its TypeScript.
 
 Subpath probing applies from any importing file, `.js` included.
 
@@ -139,9 +139,9 @@ import { handler } from "./handler.js";
 import { createPrompt } from "@repo/lib/prompt.js";
 ```
 
-The swap only fires when the written extension points at a file that doesn't exist. The same rewrite covers `.jsx → .tsx`, `.mjs → .mts`, and `.cjs → .cts`, and likewise a real `.cjs` beats a sibling `.cts`.
+The swap only fires when the written extension points at a file that doesn't exist. The same rewrite covers `.jsx → .tsx`, `.mjs → .mts`, and `.cjs → .cts`, and likewise a real `.cjs` wins over a sibling `.cts`.
 
-## What falls through to Node
+## Node's resolver
 
 Node's own resolver handles everything else, unchanged:
 
@@ -196,7 +196,7 @@ Both `require` and `import` resolve under PnP, by different paths:
 
 Nub doesn't register Yarn's `.pnp.loader.mjs` (its ESM resolver collides with the fast tier's `module.registerHooks`), so the same `pnpapi.resolveRequest` path serves both tiers.
 
-Zip-stored packages resolve too — `import` from a `.yarn/cache` zip, and `nubx` running a zip-stored binary. This is the runtime *running* a PnP project; producing the PnP install stays Yarn's job. Package `extends` chains resolve through the node_modules walk rather than the PnP API, which covers the npm and pnpm installs where that form appears.
+Zip-stored packages resolve too — `import` from a `.yarn/cache` zip, and `nubx` running a zip-stored binary. This is the runtime *running* a PnP project; Nub does not produce a PnP install. Package `extends` chains resolve through the node_modules walk rather than the PnP API, which covers the npm and pnpm installs where that form appears.
 
 <Callout>
 Read the [full docs](https://yarnpkg.com/features/pnp) for Plug'n'Play on yarnpkg.com.

--- a/site/content/docs/runtime/resolution.mdx
+++ b/site/content/docs/runtime/resolution.mdx
@@ -129,7 +129,7 @@ Nub's probe consults only `index`; a directory's own `package.json` `main` is le
 
 ## .js → .ts resolution
 
-With `moduleResolution: "nodenext"`, `tsc` wants a `.js` extension even though the file on disk is `.ts`. Nub reverses that at runtime.
+With `moduleResolution: "nodenext"`, `tsc` requires a `.js` extension even though the file on disk is `.ts`, so Nub maps the written `.js` back to the `.ts` on disk.
 
 ```ts
 // resolves ./handler.ts when no ./handler.js exists
@@ -156,7 +156,7 @@ Read the [full docs](https://nodejs.org/api/packages.html) for package entry poi
 
 ## Adding export conditions
 
-Node does the condition matching, but you choose which conditions are active. Add your own in a [nub.jsonc](/docs/config#conditions) and every run in the project resolves against them.
+Add your own in a [nub.jsonc](/docs/config#conditions) and every run in the project resolves against them.
 
 ```jsonc title="nub.jsonc"
 {
@@ -180,7 +180,7 @@ Every resolution in the project matches against them, a bare-specifier [preload]
 
 ## Yarn Plug'n'Play
 
-Nub enables Plug'n'Play automatically, with no flag and no setup. Walking up from the working directory, it detects a `.pnp.cjs` at the project root and injects it ahead of its own preload (`--require .pnp.cjs` on the fast tier, the `NODE_OPTIONS` equivalent on the compat tier), so PnP's resolver patches install first and Nub's TypeScript resolution layers on top.
+Nub enables Plug'n'Play automatically. Walking up from the working directory, it detects a `.pnp.cjs` at the project root and injects it ahead of its own preload (`--require .pnp.cjs` on the fast tier, the `NODE_OPTIONS` equivalent on the compat tier), so PnP's resolver patches install first and Nub's TypeScript resolution layers on top.
 
 ```bash
 nub index.ts        # .pnp.cjs is detected and loaded automatically

--- a/site/content/docs/runtime/typescript.mdx
+++ b/site/content/docs/runtime/typescript.mdx
@@ -36,7 +36,7 @@ Nub reads the nearest `tsconfig.json` for the [resolution](/docs/runtime/resolut
 }
 ```
 
-A config Nub cannot read in full stops the run. Since `extends` is where a project usually keeps `strict`, `target` and its path aliases, continuing would run your code under options you never wrote.
+A config Nub cannot read in full stops the run.
 
 ```console
 $ nub main.ts
@@ -86,7 +86,7 @@ JSX in a `.js` file is out of scope — use `.jsx`. Nub parses `.js` as JavaScri
 
 ## Explicit resource management
 
-Explicit Resource Management — the `using` and `await using` declarations — runs on Nub's entire Node floor. Older Node (Node 22's V8) cannot parse `using` natively — it's a hard `SyntaxError` — so Nub's transpiler lowers it to the helper-based form before Node ever sees it.
+Explicit Resource Management — the `using` and `await using` declarations — runs on Nub's entire Node floor. Node 22's V8 cannot parse `using`, so Nub's transpiler lowers it to the helper-based form.
 
 ```ts
 class Handle {
@@ -107,7 +107,7 @@ disposed
 after scope
 ```
 
-The lowering targets `es2022` — the highest target that still rewrites `using` while leaving everything Node 22 already supports (top-level await, class fields, private methods) untouched. The disposal helper resolves through Nub's vendored runtime; you don't install anything.
+The lowering targets `es2022` — the highest target that still rewrites `using` while leaving everything Node 22 already supports (top-level await, class fields, private methods) untouched. The disposal helper resolves through Nub's vendored runtime.
 
 <Callout>
 Read the [full docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/using) for `using` on developer.mozilla.org.

--- a/site/content/docs/runtime/typescript.mdx
+++ b/site/content/docs/runtime/typescript.mdx
@@ -45,7 +45,7 @@ Error: the project's tsconfig.json could not be read in full (see above).
 Fix the config, or use --node to run without Nub's TypeScript features, path aliases included.
 ```
 
-Compat mode turns off every config-derived behavior, so `--node` gets past the error but does not restore what the config was setting up. Fixing the config is the way to keep path aliases and decorator flags working.
+Compat mode turns off every config-derived behavior, so `--node` gets past the error but loses what the config was setting up — path aliases and decorator flags included.
 
 <Callout>
 Read the [full docs](https://www.typescriptlang.org/tsconfig/) for `tsconfig.json` on typescriptlang.org.
@@ -80,7 +80,7 @@ using handle = openHandle();
 const letters = /\p{Letter}/v;
 ```
 
-A file with nothing to lower is handed to Node untouched — byte for byte, no reformatting and no source-map footer. Files inside `node_modules` are never transpiled; they load as the package shipped them, on every tier.
+A file with nothing to lower is handed to Node untouched — byte for byte, no reformatting and no source-map footer. Files inside `node_modules` are never transpiled, on any tier.
 
 JSX in a `.js` file is out of scope — use `.jsx`. Nub parses `.js` as JavaScript, not JSX, so a `<` is a comparison, not an element.
 
@@ -128,6 +128,6 @@ Error: kaboom
     at Object.<anonymous> (/path/to/app.ts:4:1)
 ```
 
-The stack frame reports `app.ts:2:8` — the line in your source, not the transpiled output. To turn it off, pass `--no-enable-source-maps`.
+To turn it off, pass `--no-enable-source-maps`.
 
 Source maps are injected on every supported Node version except **26.0 through 26.7**, where a Node regression ([nodejs/node#63169](https://github.com/nodejs/node/issues/63169)) makes a no-message `assert(false)` throw a `TypeError` instead of an `AssertionError` when source maps are on. Nub withholds the flag across that band, so stack traces are not remapped there. Every other version gets source maps: 18.19 through 25.x, and 26.8 onward, where the upstream fix ships.

--- a/site/content/docs/runtime/typescript.mdx
+++ b/site/content/docs/runtime/typescript.mdx
@@ -73,7 +73,7 @@ JSX and decorators each have their own page: see [JSX](/docs/runtime/jsx) for th
 
 ## Plain JavaScript
 
-Your project's plain JavaScript — `.js`, `.mjs`, and `.cjs` — goes through the same pipeline. Modern syntax that Nub's Node floor can't parse natively is lowered exactly as it is in a `.ts` file, so identical source behaves the same whatever extension it carries: `using` / `await using`, a `v`-flag (unicode-sets) RegExp like `/\p{Letter}/v`, and decorators all run.
+Your project's plain JavaScript — `.js`, `.mjs`, and `.cjs` — goes through the same pipeline. Modern syntax that Nub's Node floor can't parse natively is lowered as it is in a `.ts` file, so identical source behaves the same whatever extension it carries: `using` / `await using`, a `v`-flag (unicode-sets) RegExp like `/\p{Letter}/v`, and decorators all run.
 
 ```js title="app.js"
 using handle = openHandle();

--- a/site/content/docs/runtime/varlock.mdx
+++ b/site/content/docs/runtime/varlock.mdx
@@ -33,7 +33,7 @@ nub run dev
 ```
 
 <Callout title="Monorepos">
-Nub looks for `.env.schema` at the package you're running, then walks up to the workspace root. The nearest one wins, so a package that ships its own schema keeps it. Nub then hands that directory to Varlock and stays out of the way.
+Nub looks for `.env.schema` at the package you're running, then walks up to the workspace root. The nearest one wins, so a package that ships its own schema keeps it. Nub hands that directory to Varlock.
 </Callout>
 
 Nub does not vendor Varlock — it uses the copy already on your machine, checking the local project first and falling back to `PATH`. Finding neither is an error:
@@ -47,7 +47,7 @@ Only the commands that launch your code are gated this way. Installing still wor
 
 ## Overriding the hand-over
 
-A `.env.schema` file is a signal Nub infers ownership from. Setting [`envFile`](/docs/config#envfile) is a project stating what it wants, so `envFile` takes precedence and Varlock stays out of the chain.
+A `.env.schema` file is a signal Nub infers ownership from; an explicit [`envFile`](/docs/config#envfile) setting wins, and Varlock stays out of the chain.
 
 ```jsonc title="nub.jsonc"
 {
@@ -73,7 +73,7 @@ Setting `"envFile": "varlock"` goes the other way and selects Varlock. That is h
 }
 ```
 
-One exception to all of this. [dotenv-extended](https://www.npmjs.com/package/dotenv-extended) has used the `.env.schema` name for its own incompatible format since 2016, so a project declaring it as a dependency keeps Nub's own environment loading and never sees Varlock mentioned.
+The exception is [dotenv-extended](https://www.npmjs.com/package/dotenv-extended), which has used the `.env.schema` name for its own incompatible format since 2016 — a project declaring it as a dependency keeps Nub's own environment loading and never sees Varlock mentioned.
 
 <Callout>
 Read the [full docs](https://varlock.dev) for Varlock on varlock.dev.

--- a/site/content/docs/runtime/varlock.mdx
+++ b/site/content/docs/runtime/varlock.mdx
@@ -43,7 +43,7 @@ $ nub index.ts
 Error: .env.schema needs varlock, which isn't installed. Run `nub add -D varlock`.
 ```
 
-Only the commands that launch your code are gated this way. Installing still works, so `nub add -D varlock` fixes it in place.
+Only the commands that launch your code are gated; `nub add -D varlock` resolves it.
 
 ## Overriding the hand-over
 
@@ -65,7 +65,7 @@ The `--env-file` and `--no-env-file` flags do the same for a single run, and eit
 
 Precedence works at every scope, your global config included. A `.env.schema` decides the environment only when nothing else does, so a machine-wide `nub config set --global envFile false` reaches schema projects too.
 
-Setting `"envFile": "varlock"` goes the other way and selects Varlock. That is how one project keeps the hand-over when your global config turns environment files off.
+Setting `"envFile": "varlock"` selects Varlock explicitly. That is how one project keeps the hand-over when your global config turns environment files off.
 
 ```jsonc title="nub.jsonc"
 {

--- a/site/content/docs/runtime/web-storage.mdx
+++ b/site/content/docs/runtime/web-storage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Web Storage
-description: Session storage is in-memory and always available; persistent local storage turns on once you point it at a backing file.
+description: Session storage is in-memory, and persistent local storage turns on once you point it at a backing file. Both need Node 22.4 or newer.
 ---
 
 Node hides `sessionStorage` and `localStorage` behind `--experimental-webstorage` on the 22.4–24 band (native from 25); Nub injects that flag on exactly that band. Below Node 22.4 the flag does not exist and Web Storage is unavailable.

--- a/site/content/docs/runtime/web-storage.mdx
+++ b/site/content/docs/runtime/web-storage.mdx
@@ -11,7 +11,7 @@ Read the [full docs](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storag
 
 ## `sessionStorage`
 
-The `sessionStorage` global is in-memory and per-process: it is created fresh each run and discarded when the process exits, never touching disk.
+The `sessionStorage` global is in-memory and per-process: it is created fresh each run and discarded when the process exits.
 
 ```ts
 sessionStorage.setItem("step", "1");
@@ -34,8 +34,6 @@ localStorage.key(0);                  // "token"
 localStorage.removeItem("token");
 localStorage.clear();
 ```
-
-Values survive between runs:
 
 ```console
 $ nub --localstorage-file=./app.db write.ts

--- a/site/content/docs/runtime/web-storage.mdx
+++ b/site/content/docs/runtime/web-storage.mdx
@@ -44,6 +44,6 @@ abc123
 
 The `--localstorage-file` flag is also honored when set in `NODE_OPTIONS`.
 
-<Callout title="Your explicit webstorage flag wins">
+<Callout title="Explicit flags">
 If you pass `--experimental-webstorage` (or `--no-experimental-webstorage`) yourself, Nub respects it and injects nothing. The flag exists from Node 22.4.0, is required through 24.x, and is unflagged from 25.0.0 on.
 </Callout>

--- a/site/content/docs/runtime/web-storage.mdx
+++ b/site/content/docs/runtime/web-storage.mdx
@@ -1,9 +1,9 @@
 ---
 title: Web Storage
-description: Session storage works out of the box; persistent local storage turns on once you point it at a backing file.
+description: Session storage is in-memory and always available; persistent local storage turns on once you point it at a backing file.
 ---
 
-Web Storage works under Nub without a flag to remember. Node hides `sessionStorage` and `localStorage` behind `--experimental-webstorage` on the 22.4–24 band (native from 25), so Nub injects that flag for you on exactly that band — you never pass it. Below Node 22.4 the flag does not exist and Web Storage is unavailable.
+Node hides `sessionStorage` and `localStorage` behind `--experimental-webstorage` on the 22.4–24 band (native from 25); Nub injects that flag on exactly that band. Below Node 22.4 the flag does not exist and Web Storage is unavailable.
 
 <Callout>
 Read the [full docs](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API) for Web Storage on developer.mozilla.org.
@@ -11,7 +11,7 @@ Read the [full docs](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storag
 
 ## `sessionStorage`
 
-The `sessionStorage` global is in-memory and per-process: it is created fresh each run and discarded when the process exits, never touching disk. It works out of the box on Node 22.4+ — nothing to pass:
+The `sessionStorage` global is in-memory and per-process: it is created fresh each run and discarded when the process exits, never touching disk.
 
 ```ts
 sessionStorage.setItem("step", "1");
@@ -22,31 +22,9 @@ sessionStorage.removeItem("step");
 sessionStorage.clear();
 ```
 
-A short walkthrough of a multi-step flow within one run:
-
-```ts
-sessionStorage.setItem("cursor", "0");
-
-for (const page of pages) {
-  const seen = Number(sessionStorage.getItem("cursor"));
-  process(page, seen);
-  sessionStorage.setItem("cursor", String(seen + 1));
-}
-
-console.log(sessionStorage.getItem("cursor")); // pages.length
-```
-
-Captured from Nub on Node 22.15.0 (no flag, no file passed):
-
-```console
-$ nub session.ts
-1
-length 1
-```
-
 ## `localStorage`
 
-The `localStorage` global persists across runs, so it needs a file on disk to write to. Pass `--localstorage-file <path>` and Nub forwards it to Node verbatim. Until you do, `localStorage` is `undefined`, so `typeof localStorage === "undefined"` is a feature check. Name a backing file and the global comes alive:
+The `localStorage` global persists across runs, so it needs a file on disk to write to. Pass `--localstorage-file <path>` and Nub forwards it to Node verbatim; until then `localStorage` is `undefined`, so `typeof localStorage === "undefined"` is a feature check.
 
 ```ts
 localStorage.setItem("token", "abc123");
@@ -69,5 +47,5 @@ abc123
 The `--localstorage-file` flag is also honored when set in `NODE_OPTIONS`.
 
 <Callout title="Your explicit webstorage flag wins">
-If you pass `--experimental-webstorage` (or `--no-experimental-webstorage`) yourself, Nub respects it and injects nothing. The version band is encoded in `crates/nub-core/src/node/flags.rs`: the flag exists from Node 22.4.0, is required through 24.x, and is unflagged from 25.0.0 on.
+If you pass `--experimental-webstorage` (or `--no-experimental-webstorage`) yourself, Nub respects it and injects nothing. The flag exists from Node 22.4.0, is required through 24.x, and is unflagged from 25.0.0 on.
 </Callout>

--- a/site/content/docs/runtime/workers.mdx
+++ b/site/content/docs/runtime/workers.mdx
@@ -7,7 +7,7 @@ description: A browser-style Worker global on stock Node — its constructor, me
 The browser-shape `Worker` global is typed by Nub's own types package — `@types/node` declares only `node:worker_threads`. Install `@nubjs/types` as a devDependency alongside `@types/node` 26.
 </TypesSetup>
 
-Browsers expose a `Worker` global; Node ships only `node:worker_threads.Worker`, a different class with a different API. Nub closes the gap with a polyfill preloaded on every supported Node (18.19+), so the browser constructor and messaging shape work unchanged.
+Browsers expose a `Worker` global; Node ships only `node:worker_threads.Worker`, a different class with a different API. Nub preloads a polyfill on every supported Node (18.19+), so the browser constructor and messaging shape work.
 
 ```ts
 const worker = new Worker(import.meta.resolve("./worker.ts"), { type: "module" });
@@ -36,15 +36,15 @@ Read the [full docs](https://developer.mozilla.org/en-US/docs/Web/API/Worker) fo
 The constructor takes the WHATWG script-URL inputs — a file path or `URL` (including `file://`), a `data:` URL, or a `blob:` URL. For a path-based worker, default to `import.meta.resolve`:
 
 ```ts
-new Worker(import.meta.resolve("./worker.ts")); // module-relative, build-free, TypeScript and all
+new Worker(import.meta.resolve("./worker.ts")); // resolves relative to this module; a .ts entry is fine
 ```
 
 The `import.meta.resolve` call resolves a specifier against the current module — never `process.cwd()` — and returns its URL.
 
-Using a bundler? Vite, webpack, and esbuild trace the `new URL(...)` form — pulling the worker into its own chunk and rewriting its path — but they don't yet trace `import.meta.resolve`. Switch forms whenever a bundler is in the pipeline:
+Vite, webpack, and esbuild trace the `new URL(...)` form — pulling the worker into its own chunk and rewriting its path — but do not trace `import.meta.resolve`. Use that form when a bundler is in the pipeline:
 
 ```ts
-new Worker(new URL("./worker.ts", import.meta.url)); // bundler-traceable, and runtime-correct too
+new Worker(new URL("./worker.ts", import.meta.url)); // traced by bundlers; also correct at runtime
 ```
 
 A bare relative string resolves against `process.cwd()`, not the calling module — matching `node:worker_threads` and Bun. It works when the launch directory is fixed, but breaks for a nested file run from elsewhere:
@@ -150,7 +150,7 @@ worker.on("message", async (value) => {
 worker.postMessage(21);
 ```
 
-On the node channel, `message` listeners get the raw posted value and `error` listeners a bare `Error` — Node's shapes, not the `MessageEvent` / `ErrorEvent` the web channel keeps. Both channels live on one handle; reach for whichever fits the code.
+On the node channel, `message` listeners get the raw posted value and `error` listeners a bare `Error` — Node's shapes, not the `MessageEvent` / `ErrorEvent` the web channel keeps. Both channels are on one handle.
 
 <Callout>
 Read the [full docs](https://nodejs.org/api/worker_threads.html#class-worker) for `worker_threads` on nodejs.org.
@@ -158,7 +158,7 @@ Read the [full docs](https://nodejs.org/api/worker_threads.html#class-worker) fo
 
 ## TypeScript
 
-The main-thread `Worker` global and `WorkerOptions` are typed by `@nubjs/types` (a types-only devDependency). The declaration steps aside when `lib: ["dom"]` is in your `tsconfig.json` — the DOM's own `Worker` type wins there.
+The main-thread `Worker` global and `WorkerOptions` are typed by `@nubjs/types` (a types-only devDependency). The declaration yields when `lib: ["dom"]` is in your `tsconfig.json` — the DOM's own `Worker` type wins there.
 
 Inside a worker file the global scope is the dedicated-worker scope, not the main thread's — `self`, `postMessage`, and `onmessage` live there, and neither `@types/node` nor `@nubjs/types` declares them. Set `lib: ["webworker"]` for the full worker-scope types, or drop a one-line shim at the top of the worker for the common handlers:
 

--- a/site/content/docs/runtime/workers.mdx
+++ b/site/content/docs/runtime/workers.mdx
@@ -25,7 +25,7 @@ self.onmessage = (ev) => {
 };
 ```
 
-The worker entry is TypeScript for free — Nub transpiles it like any other file. A listening worker keeps the process alive, so the main thread calls `worker.terminate()` once it has its reply (or the worker can `self.close()` itself).
+The worker entry can be TypeScript — Nub transpiles it like any other file. A listening worker keeps the process alive, so the main thread calls `worker.terminate()` once it has its reply (or the worker can `self.close()` itself).
 
 <Callout>
 Read the [full docs](https://developer.mozilla.org/en-US/docs/Web/API/Worker) for `Worker` on developer.mozilla.org.
@@ -158,7 +158,7 @@ Read the [full docs](https://nodejs.org/api/worker_threads.html#class-worker) fo
 
 ## TypeScript
 
-The main-thread `Worker` global and `WorkerOptions` are typed by `@nubjs/types` (a types-only devDependency). The declaration steps aside when `lib: ["dom"]` is in your `tsconfig.json` — the DOM's own `Worker` type wins there — so the two never collide.
+The main-thread `Worker` global and `WorkerOptions` are typed by `@nubjs/types` (a types-only devDependency). The declaration steps aside when `lib: ["dom"]` is in your `tsconfig.json` — the DOM's own `Worker` type wins there.
 
 Inside a worker file the global scope is the dedicated-worker scope, not the main thread's — `self`, `postMessage`, and `onmessage` live there, and neither `@types/node` nor `@nubjs/types` declares them. Set `lib: ["webworker"]` for the full worker-scope types, or drop a one-line shim at the top of the worker for the common handlers:
 
@@ -182,7 +182,7 @@ Nub's `Worker` runs a vendored slice of [web-platform-tests](https://github.com/
 
 ## Divergences
 
-Nub's `Worker` carries the browser's shape. Two differences are worth knowing:
+Nub's `Worker` carries the browser's shape, with two divergences:
 
 - **No `SharedWorker`** — it needs a browser document and origin model with no server-side equivalent. Use a single worker with message passing.
 - **Workers are real threads** — each is an OS thread with its own V8 isolate and module graph, heavier than a browser worker. Pool them for hot paths instead of spawning one per task.

--- a/site/content/docs/watch.mdx
+++ b/site/content/docs/watch.mdx
@@ -1,6 +1,6 @@
 ---
 title: Watch mode
-description: Restart-on-change for files and scripts, driven by the resolved dependency graph plus your environment files, tsconfig, and package manifest — no glob hygiene required.
+description: Restart-on-change for files and scripts, driven by the resolved dependency graph plus your environment files, tsconfig, and package manifest — no glob list to maintain.
 ---
 
 Watch mode (`nub watch`) runs your entry point and restarts it whenever something it actually depends on changes.
@@ -52,15 +52,13 @@ This is why a plain `node --watch` silently goes stale on a tsconfig edit, and w
 
 ## What doesn't trigger a restart
 
-Because the watch set is the import graph rather than a directory glob, files that nothing in the run actually loads are simply not watched. A rebuild that emits `dist/foo.js` doesn't trigger a restart unless something in the run imported `dist/foo.js`.
+Because the watch set is the import graph rather than a directory glob, files that nothing in the run actually loads are not watched. A rebuild that emits `dist/foo.js` doesn't trigger a restart unless something in the run imported `dist/foo.js`.
 
 ```bash
 nub watch src/server.ts
 # editing dist/** or coverage/** does not restart —
 # they aren't in the loaded dependency graph
 ```
-
-There is no ignore list to maintain.
 
 ## Plain Node `--watch`
 

--- a/site/content/docs/watch.mdx
+++ b/site/content/docs/watch.mdx
@@ -41,23 +41,22 @@ Restarting 'src/server.ts'
 
 ## What triggers a restart
 
-The watch set is loader-instrumented, not glob-based: `nub watch` only watches files that were actually loaded as part of the run, plus a small set of off-graph files that invalidate the process when they change. Concretely, a restart fires on a change to:
+The watch set is loader-instrumented, not glob-based: `nub watch` only watches files that were actually loaded as part of the run, plus a small set of off-graph files that invalidate the process when they change. A restart fires on a change to:
 
 - Any file in the **resolved dependency graph** of the entry — including `.ts` / `.tsx` files transpiled in-memory through `module.registerHooks()` that Node never sees on disk.
 - Your **`.env*` files** — these are read once at boot and aren't in any import graph, so Nub reports them to the watcher explicitly. Files named with `--env-file` or `--env-file-if-exists` are watched the same way, and every restart re-reads them, so an edited value is live on the next run. Re-reading on restart needs Node 20.6 or newer, the version that introduced the underlying flag; below it the values are captured once at startup, and an edit applies only after you restart `nub watch` itself.
 - The **`tsconfig.json` extends chain** — editing a tsconfig (for example, changing a `paths` mapping) restarts the process even though tsconfig isn't imported by anything.
 - **`package.json`**.
 
-This is why a plain `node --watch` silently goes stale on a tsconfig edit, and why Nub reports those off-graph files over Node's internal `WATCH_REPORT_DEPENDENCIES` channel.
+Nub reports the off-graph files to Node's watcher over its `WATCH_REPORT_DEPENDENCIES` channel.
 
 ## What doesn't trigger a restart
 
-Because the watch set is the import graph rather than a directory glob, files that nothing in the run actually loads are not watched. A rebuild that emits `dist/foo.js` doesn't trigger a restart unless something in the run imported `dist/foo.js`.
+Files that nothing in the run loads are not watched. A rebuild that emits `dist/foo.js` doesn't trigger a restart unless something in the run imported `dist/foo.js`.
 
 ```bash
 nub watch src/server.ts
-# editing dist/** or coverage/** does not restart —
-# they aren't in the loaded dependency graph
+# editing dist/** or coverage/** does not restart
 ```
 
 ## Plain Node `--watch`
@@ -68,7 +67,7 @@ Nub's watch mode is not byte-for-byte Node — it adds the banner, the preserve-
 node --watch script.js
 ```
 
-Nub's PATH shim is per-invocation: it only affects descendants of an active `nub ...` call, so the `node` in your shell is always your real Node.
+Nub's PATH shim only affects descendants of an active `nub` call, so the `node` in your shell is your real Node.
 
 <Callout>
 Read the [full docs](https://nodejs.org/api/cli.html#--watch) for Node's `--watch` flag on nodejs.org.

--- a/site/content/docs/watch.mdx
+++ b/site/content/docs/watch.mdx
@@ -67,7 +67,7 @@ Nub's watch mode adds the banner, the preserve-output default, and the off-graph
 node --watch script.js
 ```
 
-Nub's PATH shim only affects descendants of an active `nub` call.
+Nub's per-invocation PATH shim only affects descendants of an active `nub` call. A `node` installed by [`nub node shim`](/docs/node#nub-node-shim) resolves the pinned version and adds nothing else, so `node --watch` stays vanilla there too.
 
 <Callout>
 Read the [full docs](https://nodejs.org/api/cli.html#--watch) for Node's `--watch` flag on nodejs.org.

--- a/site/content/docs/watch.mdx
+++ b/site/content/docs/watch.mdx
@@ -52,7 +52,7 @@ Nub reports the off-graph files to Node's watcher over its `WATCH_REPORT_DEPENDE
 
 ## What doesn't trigger a restart
 
-Files that nothing in the run loads are not watched. A rebuild that emits `dist/foo.js` doesn't trigger a restart unless something in the run imported `dist/foo.js`.
+A rebuild that emits `dist/foo.js` doesn't trigger a restart unless something in the run imported `dist/foo.js`.
 
 ```bash
 nub watch src/server.ts
@@ -61,7 +61,7 @@ nub watch src/server.ts
 
 ## Plain Node `--watch`
 
-Nub's watch mode is not byte-for-byte Node — it adds the banner, the preserve-output default, and the off-graph reporting. When you want vanilla Node `--watch` with no Nub-side glue at all, type `node --watch` directly in your shell.
+Nub's watch mode adds the banner, the preserve-output default, and the off-graph reporting on top of Node's. When you want vanilla Node `--watch` with no Nub-side glue at all, type `node --watch` directly in your shell.
 
 ```bash
 node --watch script.js

--- a/site/content/docs/watch.mdx
+++ b/site/content/docs/watch.mdx
@@ -3,13 +3,13 @@ title: Watch mode
 description: Restart-on-change for files and scripts, driven by the resolved dependency graph plus your environment files, tsconfig, and package manifest — no glob list to maintain.
 ---
 
-Watch mode (`nub watch`) runs your entry point and restarts it whenever something it actually depends on changes.
+Watch mode (`nub watch`) runs your entry point and restarts it whenever a file it depends on changes.
 
-The engine underneath is Node's own `--watch` (run with `--watch-preserve-output`), with Nub-side glue that reports the in-memory-transpiled dependency graph — plus the off-graph files that still invalidate a process — back to Node's watcher. There is no glob list to maintain.
+The engine underneath is Node's own `--watch` (run with `--watch-preserve-output`), with a Nub-side layer that reports the in-memory-transpiled dependency graph — plus the off-graph files that still invalidate a process — back to Node's watcher.
 
 For how `nub` runs files in the first place, see [Running files](/docs/runtime); for scripts, [Running scripts](/docs/runner/run).
 
-## Watch and restart a file
+## Watching a file
 
 The watcher takes a file, not a script name. Point `nub watch` at an entry file — the one your `dev` script runs, for example. It runs the file, then restarts the process on any change to the file or anything in its resolved import graph.
 
@@ -19,11 +19,11 @@ nub watch src/server.ts
 
 TypeScript, JSX, `.env*` loading, `tsconfig.json` paths — everything `nub <file>` gives you is active here too, because `nub watch` runs the same augmented Node underneath. A project [`nub.jsonc`](/docs/config) is in force on every restart: preloads, environment files, loaders, conditions, TypeScript transforms, and the selected tsconfig.
 
-A `--watch` placed after a script name is forwarded *to the script* like any other argument — `nub run test --watch` runs your test tool's own watch mode, it does not invoke Nub's watcher. See [`nub run` → Forward arguments](/docs/runner/run#forward-arguments).
+A `--watch` placed after a script name is forwarded *to the script* like any other argument — `nub run test --watch` runs your test tool's own watch mode, it does not invoke Nub's watcher. See [`nub run` → Forward arguments](/docs/runner/run#argument-forwarding).
 
 ## `--watch`
 
-Flag and subcommand are aliases: `nub --watch <file>` dispatches to the exact same code path as `nub watch <file>` — same defaults, same behavior. The flag form is there for `node --watch script.ts` muscle memory.
+Flag and subcommand are aliases: `nub --watch <file>` and `nub watch <file>` run the same code path. The flag form matches `node --watch script.ts`.
 
 ```bash
 nub --watch src/server.ts
@@ -39,9 +39,9 @@ Completed running 'src/server.ts'. Waiting for file changes before restarting...
 Restarting 'src/server.ts'
 ```
 
-## What triggers a restart
+## Watched files
 
-The watch set is loader-instrumented, not glob-based: `nub watch` only watches files that were actually loaded as part of the run, plus a small set of off-graph files that invalidate the process when they change. A restart fires on a change to:
+The watch set is loader-instrumented, not glob-based: `nub watch` only watches files loaded as part of the run, plus a small set of off-graph files that invalidate the process when they change. A restart fires on a change to:
 
 - Any file in the **resolved dependency graph** of the entry — including `.ts` / `.tsx` files transpiled in-memory through `module.registerHooks()` that Node never sees on disk.
 - Your **`.env*` files** — these are read once at boot and aren't in any import graph, so Nub reports them to the watcher explicitly. Files named with `--env-file` or `--env-file-if-exists` are watched the same way, and every restart re-reads them, so an edited value is live on the next run. Re-reading on restart needs Node 20.6 or newer, the version that introduced the underlying flag; below it the values are captured once at startup, and an edit applies only after you restart `nub watch` itself.
@@ -50,9 +50,7 @@ The watch set is loader-instrumented, not glob-based: `nub watch` only watches f
 
 Nub reports the off-graph files to Node's watcher over its `WATCH_REPORT_DEPENDENCIES` channel.
 
-## What doesn't trigger a restart
-
-A rebuild that emits `dist/foo.js` doesn't trigger a restart unless something in the run imported `dist/foo.js`.
+A rebuild that emits `dist/foo.js` does not trigger a restart unless something in the run imported `dist/foo.js`.
 
 ```bash
 nub watch src/server.ts
@@ -61,7 +59,7 @@ nub watch src/server.ts
 
 ## Plain Node `--watch`
 
-Nub's watch mode adds the banner, the preserve-output default, and the off-graph reporting on top of Node's. For vanilla `node --watch`, type it in your shell:
+Nub's watch mode adds the banner, the preserve-output default, and the off-graph reporting on top of Node's. For vanilla `node --watch`, run it directly:
 
 ```bash
 node --watch script.js

--- a/site/content/docs/watch.mdx
+++ b/site/content/docs/watch.mdx
@@ -61,13 +61,13 @@ nub watch src/server.ts
 
 ## Plain Node `--watch`
 
-Nub's watch mode adds the banner, the preserve-output default, and the off-graph reporting on top of Node's. When you want vanilla Node `--watch` with no Nub-side glue at all, type `node --watch` directly in your shell.
+Nub's watch mode adds the banner, the preserve-output default, and the off-graph reporting on top of Node's. For vanilla `node --watch`, type it in your shell:
 
 ```bash
 node --watch script.js
 ```
 
-Nub's PATH shim only affects descendants of an active `nub` call, so the `node` in your shell is your real Node.
+Nub's PATH shim only affects descendants of an active `nub` call.
 
 <Callout>
 Read the [full docs](https://nodejs.org/api/cli.html#--watch) for Node's `--watch` flag on nodejs.org.


### PR DESCRIPTION
Applies the Reads-as-AI catalogue from PROSE.md to all 41 pages under `site/content/docs/`: shaped closers, reassurance lines, example restatements, and the "exactly as X does" tail (14 pages) are deleted. No technical claim changes.

Verified with the lineup test against zod.dev / pnpm.io / Vite samples: three rounds, two fresh blind judges each; money bets on Nub excerpts fell 6/5 → 6/4 → 4/3.

Also fixes: a web-storage console capture matching neither snippet, a repo source path in user docs, a cooling-window callout contradicting `--minimum-release-age`, a ✓ on a rejected version, and a table lead-in contradicting its "Allowed" row.