### PR TITLE
build: dedupe dependencies and compact the registry primer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,20 +67,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1daa54020e05aa0b163ee10434fff35a0f18d28a1cafa142bd1290e1abe630e"
 dependencies = [
  "astral-reqwest-middleware",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -184,7 +175,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "thiserror 2.0.18",
  "tower-service",
@@ -253,7 +244,7 @@ dependencies = [
  "ci_info",
  "clap",
  "clap_usage",
- "clx 3.0.2",
+ "clx",
  "console",
  "demand",
  "diffy",
@@ -269,7 +260,7 @@ dependencies = [
  "pathdiff",
  "pluralizer",
  "rayon",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sha1 0.11.0",
@@ -282,7 +273,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "xx",
@@ -357,7 +348,6 @@ dependencies = [
  "miette",
  "serde",
  "serde_json",
- "serde_yaml",
  "sonic-rs",
  "thiserror 2.0.18",
  "yaml_serde",
@@ -379,7 +369,7 @@ dependencies = [
  "bytes",
  "miette",
  "node-semver",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -401,6 +391,7 @@ dependencies = [
  "aube-registry",
  "aube-store",
  "aube-util",
+ "base64",
  "flate2",
  "miette",
  "node-semver",
@@ -430,7 +421,7 @@ dependencies = [
  "flate2",
  "hex",
  "node-semver",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -468,7 +459,7 @@ dependencies = [
  "aube-codes",
  "aube-util",
  "serde",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "yaml_serde",
 ]
@@ -508,7 +499,7 @@ dependencies = [
  "foldhash 0.2.0",
  "libc",
  "reflink-copy",
- "reqwest 0.13.4",
+ "reqwest",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -802,39 +793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf 0.11.3",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf 0.11.3",
- "phf_codegen",
-]
-
-[[package]]
 name = "ci_info"
 version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,22 +880,6 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20daab9df9e49b0478215055d38362d5973043b7a4af836a58968760755e9a9f"
-dependencies = [
- "console",
- "nix 0.31.3",
- "serde",
- "serde_json",
- "strum",
- "tera 1.20.1",
- "thiserror 2.0.18",
- "unicode-width 0.2.2",
-]
-
-[[package]]
-name = "clx"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a65674abcd65c2846d6bfc4c9816ab9177b15277a18a78aa1691683ce63095"
@@ -947,7 +889,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "tera 2.1.0",
+ "tera",
  "thiserror 2.0.18",
  "unicode-width 0.2.2",
 ]
@@ -1346,12 +1288,6 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "diffy"
@@ -1847,17 +1783,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,15 +2021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,11 +2060,9 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2174,30 +2088,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2680,12 +2570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libmimalloc-sys"
 version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,12 +2937,13 @@ dependencies = [
  "base64",
  "blake3",
  "clap",
- "clx 2.1.0",
+ "clx",
  "console",
  "demand",
  "dirs-next",
  "dotenvy",
  "glob-match",
+ "hex",
  "jsonc-parser",
  "libc",
  "libsui",
@@ -3089,18 +2974,18 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml_ng",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "string_wizard",
  "tempfile",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "unicode-casefold",
  "unicode-normalization",
  "url",
  "windows-sys 0.61.2",
+ "yaml_serde",
  "zstd",
 ]
 
@@ -3117,18 +3002,19 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "glob-match",
+ "hex",
  "libc",
  "liblzma",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rustc-hash",
  "ruzstd",
  "same-file",
  "semver",
  "serde",
  "serde_json",
- "sha1 0.10.6",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "signal-hook 0.3.18",
  "tar",
  "thiserror 2.0.18",
@@ -3146,7 +3032,7 @@ dependencies = [
  "jsonc-parser",
  "nub-json-guard",
  "serde_json",
- "toml 0.8.23",
+ "toml",
  "yaml-rust2",
 ]
 
@@ -3460,7 +3346,7 @@ version = "0.140.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef089097e96b74388a8025a9247bdb12774b99f5971926d9dafbe84a78f9efb7"
 dependencies = [
- "phf 0.14.0",
+ "phf",
  "proc-macro2",
  "quote",
  "syn",
@@ -3672,7 +3558,7 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_span",
  "oxc_str",
- "phf 0.14.0",
+ "phf",
  "rustc-hash",
  "unicode-id-start",
 ]
@@ -3785,7 +3671,7 @@ dependencies = [
  "oxc_index",
  "oxc_span",
  "oxc_str",
- "phf 0.14.0",
+ "phf",
  "serde",
  "unicode-id-start",
 ]
@@ -3886,15 +3772,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3982,42 +3859,13 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
- "phf_shared 0.14.0",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -4027,7 +3875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
- "phf_shared 0.14.0",
+ "phf_shared",
 ]
 
 [[package]]
@@ -4036,20 +3884,11 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
- "phf_generator 0.14.0",
- "phf_shared 0.14.0",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -4363,22 +4202,11 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -4391,16 +4219,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4418,9 +4236,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -4559,47 +4374,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -4607,6 +4381,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -5022,7 +4797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61425ffb878ba8b6ab76953c2f0e8903509ef43b22983974a9ae7832881734c"
 dependencies = [
  "arcstr",
- "phf 0.14.0",
+ "phf",
  "rolldown_common",
  "rolldown_plugin",
  "rolldown_utils",
@@ -5167,7 +4942,6 @@ checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5396,15 +5170,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -5422,32 +5187,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
-name = "serde_yaml_ng"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5628,7 +5367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "823d3f43c29500feb1ccacec68552f8e2bcecd62ec99c5284570a623bcf0c921"
 dependencies = [
  "base64",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -5661,7 +5400,7 @@ dependencies = [
  "base64",
  "open",
  "rand 0.9.4",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -5679,7 +5418,7 @@ checksum = "9b97c5a866f849a9445ae657bef0caa2db053a82827e6dae3a2b3de9c15a6a1a"
 dependencies = [
  "base64",
  "hex",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -5743,7 +5482,7 @@ dependencies = [
  "hex",
  "jiff",
  "rand 0.9.4",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls-pki-types",
  "rustls-webpki",
  "sigstore-crypto",
@@ -5763,7 +5502,7 @@ dependencies = [
  "globset",
  "hex",
  "jiff",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5835,16 +5574,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "smallvec"
@@ -6117,28 +5846,6 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
-dependencies = [
- "chrono",
- "chrono-tz",
- "globwalk",
- "humansize",
- "lazy_static",
- "percent-encoding",
- "pest",
- "pest_derive",
- "rand 0.8.6",
- "regex",
- "serde",
- "serde_json",
- "slug",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "tera"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511f07fd91a70e92efbe4793d111aaa9035f8474dd157aaa1e31e7c27f5051da"
@@ -6341,38 +6048,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -6385,20 +6071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6406,12 +6078,6 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -6698,12 +6364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6745,7 +6405,7 @@ dependencies = [
  "serde",
  "shell-words",
  "strum",
- "tera 2.1.0",
+ "tera",
  "thiserror 2.0.18",
  "versions",
  "xx",
@@ -6993,15 +6653,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7487,15 +7138,6 @@ name = "winnow"
 version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,14 +65,14 @@ panic = "abort"
 # Size-optimize the COLD crates only. Whole-binary `opt-level = "z"` measured
 # −10.5 MB (48.6 → 38.1 MB, linux-x64, 2026-09-03) but de-optimizes the hot
 # paths, so the resolver, linker, lockfile, manifest, transpiler, JSON and TLS
-# crates keep `opt-level = 3` and only latency-irrelevant code takes "z": CLI
-# dispatch and command glue, arg parsing, prompts, templating, diagnostics, DNS
-# config, and the publish-provenance stack. Add a crate here only after
-# checking cargo-bloat shows it cold; never a crate on the install or startup
-# path.
+# crates keep `opt-level = 3` and only latency-irrelevant code takes "z": arg
+# parsing, prompts, templating, diagnostics, DNS config, and the
+# publish-provenance stack. `aube` (install orchestration) and `nub-cli`
+# (pm_engine glue, the phantom-closure walk) are NOT cold: with both at "z" a
+# warm resolve+link on the 84-dep bench fixture measured ~8% slower
+# (2.40 s → 2.59 s, same VM, interleaved runs). Add a crate here only after an
+# A/B on that fixture shows it costs nothing.
 [profile.release.package]
-aube = { opt-level = "z" }
-nub-cli = { opt-level = "z" }
 clap = { opt-level = "z" }
 clap_builder = { opt-level = "z" }
 clx = { opt-level = "z" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,51 +62,6 @@ codegen-units = 1
 strip = true
 panic = "abort"
 
-# Size-optimize the COLD crates only. Whole-binary `opt-level = "z"` measured
-# −10.5 MB (48.6 → 38.1 MB, linux-x64, 2026-09-03) but de-optimizes the hot
-# paths, so the resolver, linker, lockfile, manifest, transpiler, JSON and TLS
-# crates keep `opt-level = 3` and only latency-irrelevant code takes "z": arg
-# parsing, prompts, templating, diagnostics, DNS config, and the
-# publish-provenance stack. `aube` (install orchestration) and `nub-cli`
-# (pm_engine glue, the phantom-closure walk) are NOT cold: with both at "z" a
-# warm resolve+link on the 84-dep bench fixture measured ~8% slower
-# (2.40 s → 2.59 s, same VM, interleaved runs). Add a crate here only after an
-# A/B on that fixture shows it costs nothing.
-[profile.release.package]
-clap = { opt-level = "z" }
-clap_builder = { opt-level = "z" }
-clx = { opt-level = "z" }
-demand = { opt-level = "z" }
-tera = { opt-level = "z" }
-miette = { opt-level = "z" }
-regex = { opt-level = "z" }
-regex-automata = { opt-level = "z" }
-regex-syntax = { opt-level = "z" }
-aho-corasick = { opt-level = "z" }
-hickory-resolver = { opt-level = "z" }
-hickory-proto = { opt-level = "z" }
-hickory-net = { opt-level = "z" }
-toml = { opt-level = "z" }
-sigstore-sign = { opt-level = "z" }
-sigstore-oidc = { opt-level = "z" }
-sigstore-fulcio = { opt-level = "z" }
-sigstore-rekor = { opt-level = "z" }
-sigstore-tsa = { opt-level = "z" }
-sigstore-tuf = { opt-level = "z" }
-sigstore-bundle = { opt-level = "z" }
-sigstore-crypto = { opt-level = "z" }
-sigstore-merkle = { opt-level = "z" }
-sigstore-trust-root = { opt-level = "z" }
-sigstore-types = { opt-level = "z" }
-ambient-id = { opt-level = "z" }
-x509-cert = { opt-level = "z" }
-x509-tsp = { opt-level = "z" }
-cms = { opt-level = "z" }
-cmpv2 = { opt-level = "z" }
-crmf = { opt-level = "z" }
-der = { opt-level = "z" }
-spki = { opt-level = "z" }
-
 # Fast local-iteration profile for `nub-dev` / `make install-dev`. NOT a ship
 # profile — the release block above is untouched. Inherits `dev` (debug
 # assertions + overflow checks stay on), but drops everything the release build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,51 @@ codegen-units = 1
 strip = true
 panic = "abort"
 
+# Size-optimize the COLD crates only. Whole-binary `opt-level = "z"` measured
+# −10.5 MB (48.6 → 38.1 MB, linux-x64, 2026-09-03) but de-optimizes the hot
+# paths, so the resolver, linker, lockfile, manifest, transpiler, JSON and TLS
+# crates keep `opt-level = 3` and only latency-irrelevant code takes "z": CLI
+# dispatch and command glue, arg parsing, prompts, templating, diagnostics, DNS
+# config, and the publish-provenance stack. Add a crate here only after
+# checking cargo-bloat shows it cold; never a crate on the install or startup
+# path.
+[profile.release.package]
+aube = { opt-level = "z" }
+nub-cli = { opt-level = "z" }
+clap = { opt-level = "z" }
+clap_builder = { opt-level = "z" }
+clx = { opt-level = "z" }
+demand = { opt-level = "z" }
+tera = { opt-level = "z" }
+miette = { opt-level = "z" }
+regex = { opt-level = "z" }
+regex-automata = { opt-level = "z" }
+regex-syntax = { opt-level = "z" }
+aho-corasick = { opt-level = "z" }
+hickory-resolver = { opt-level = "z" }
+hickory-proto = { opt-level = "z" }
+hickory-net = { opt-level = "z" }
+toml = { opt-level = "z" }
+sigstore-sign = { opt-level = "z" }
+sigstore-oidc = { opt-level = "z" }
+sigstore-fulcio = { opt-level = "z" }
+sigstore-rekor = { opt-level = "z" }
+sigstore-tsa = { opt-level = "z" }
+sigstore-tuf = { opt-level = "z" }
+sigstore-bundle = { opt-level = "z" }
+sigstore-crypto = { opt-level = "z" }
+sigstore-merkle = { opt-level = "z" }
+sigstore-trust-root = { opt-level = "z" }
+sigstore-types = { opt-level = "z" }
+ambient-id = { opt-level = "z" }
+x509-cert = { opt-level = "z" }
+x509-tsp = { opt-level = "z" }
+cms = { opt-level = "z" }
+cmpv2 = { opt-level = "z" }
+crmf = { opt-level = "z" }
+der = { opt-level = "z" }
+spki = { opt-level = "z" }
+
 # Fast local-iteration profile for `nub-dev` / `make install-dev`. NOT a ship
 # profile — the release block above is untouched. Inherits `dev` (debug
 # assertions + overflow checks stay on), but drops everything the release build
@@ -139,7 +184,7 @@ oxc = { version = "=0.140.0", features = ["full"] }
 oxc_napi = "=0.140.0"
 oxc_sourcemap = { version = "=8.1.0", features = ["napi"] }
 rustc-hash = "2"
-toml = "0.8"
+toml = "1.1"
 # Interactive terminal primitive (raw-mode key reads, cursor control) for the
 # dlx consent radio in nubx_consent.rs. Already compiled in via `demand` (aube's
 # build-approval picker) → direct dep reuses the same crate (no new build).
@@ -147,7 +192,7 @@ console = "0.16"
 yaml-rust2 = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 # blake3 content hash for the transpile-cache key + integrity prefix (SIMD,
 # replaced SHA-256 on the warm path; schema v4).
 blake3 = "1"

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -235,9 +235,9 @@ semver = "1"
 node-semver = "2"
 pathdiff = { version = "0.2", optional = true }
 # pnpm-workspace.yaml read + regeneration for `nub pm use nub` / `use pnpm`
-# (pm_engine/use_nub.rs). serde_yaml is archived/unmaintained; serde_yaml_ng
-# is the maintained, API-compatible fork, aliased as `serde_yaml` so the
-# source paths are unchanged.
+# (pm_engine/use_nub.rs). serde_yaml is archived/unmaintained; yaml_serde is
+# the maintained, API-compatible fork vendor/aube already builds, aliased as
+# `serde_yaml` so the source paths are unchanged.
 serde_yaml = { package = "yaml_serde", version = "0.10" }
 sha2.workspace = true
 hex = "0.4"

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -203,7 +203,7 @@ clap.workspace = true
 # Same major as vendor/aube: `nubx -q` switches the engine's progress UI to
 # text mode via clx::progress::set_output, the same knob aube's own startup
 # flips for --silent (vendor/aube/crates/aube/src/startup.rs).
-clx = "2"
+clx = "3"
 # Same major as vendor/aube: `nub init`'s prompts (src/init.rs) use the same
 # clack-style prompt crate the engine already ships, so the dep graph carries
 # one copy and the prompt aesthetic matches the engine's own pickers.
@@ -238,8 +238,9 @@ pathdiff = { version = "0.2", optional = true }
 # (pm_engine/use_nub.rs). serde_yaml is archived/unmaintained; serde_yaml_ng
 # is the maintained, API-compatible fork, aliased as `serde_yaml` so the
 # source paths are unchanged.
-serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
+serde_yaml = { package = "yaml_serde", version = "0.10" }
 sha2.workspace = true
+hex = "0.4"
 # Records the embedded Node's optional BLAKE3 format-headroom field. The launcher
 # does not hash the extracted runtime on its current warm path.
 blake3 = "1"

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -1607,7 +1607,7 @@ impl CompilePreamble {
     /// on the source path and retains its current layout.
     fn worker_root(&self, source: &Path) -> Result<String> {
         let source = canonicalize_for_bundler(source);
-        let hash = format!("{:x}", Sha256::digest(source.to_string_lossy().as_bytes()));
+        let hash = hex::encode(Sha256::digest(source.to_string_lossy().as_bytes()));
         let id = format!("\0nub:compile-worker-{hash}");
         let mut roots = self
             .roots
@@ -2456,7 +2456,7 @@ fn worker_output_name(project_root: &Path, source: &Path, stem: &str) -> String 
         .unwrap_or_else(|| source.to_path_buf())
         .to_string_lossy()
         .replace('\\', "/");
-    let hash = format!("{:x}", Sha256::digest(logical.as_bytes()));
+    let hash = hex::encode(Sha256::digest(logical.as_bytes()));
     worker_output_name_with_hash(stem, &hash)
 }
 
@@ -3750,7 +3750,7 @@ impl ExternalImports {
             hash.update((part.len() as u64).to_le_bytes());
             hash.update(part.as_bytes());
         }
-        let id = format!("\0nub:compile-external:{:x}", hash.finalize());
+        let id = format!("\0nub:compile-external:{}", hex::encode(hash.finalize()));
         Some(ExternalImport {
             id,
             specifier: specifier.to_string(),

--- a/crates/nub-cli/src/compile/loaders.rs
+++ b/crates/nub-cli/src/compile/loaders.rs
@@ -408,7 +408,7 @@ fn asset_name(source: &Path, bytes: &[u8]) -> String {
     } else {
         stem
     };
-    let hash = format!("{:x}", Sha256::digest(bytes));
+    let hash = hex::encode(Sha256::digest(bytes));
     asset_name_with_hash(source, &stem, &hash)
 }
 

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -1963,7 +1963,7 @@ fn sha256_of_app(files: &[AppFile<Vec<u8>>]) -> String {
         h.update(&file.bytes);
         h.update([u8::from(file.executable)]);
     }
-    format!("{:x}", h.finalize())
+    hex::encode(h.finalize())
 }
 
 /// The source file's Unix mode, or `None` where the platform has none — see

--- a/crates/nub-cli/src/compile/native_layout.rs
+++ b/crates/nub-cli/src/compile/native_layout.rs
@@ -781,7 +781,7 @@ fn digest_files(files: &BTreeMap<String, Body>) -> String {
         hash.update(&body.bytes);
         hash.update([u8::from(body.executable)]);
     }
-    format!("{:x}", hash.finalize())
+    hex::encode(hash.finalize())
 }
 
 /// The source file's Unix mode, or `None` on a host that has none. Windows
@@ -800,7 +800,7 @@ fn source_mode(_metadata: &std::fs::Metadata) -> Option<u32> {
 }
 
 fn hex_sha256(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    hex::encode(Sha256::digest(bytes))
 }
 
 /// Island size for the build report, in the decimal units the rest of `compile`

--- a/crates/nub-cli/src/pm_engine/bun_config.rs
+++ b/crates/nub-cli/src/pm_engine/bun_config.rs
@@ -45,7 +45,8 @@ fn load_bunfig_file(path: &Path) -> Vec<(String, String)> {
 }
 
 fn parse_bunfig_file(path: &Path) -> Option<Value> {
-    std::fs::read_to_string(path).ok()?.parse::<Value>().ok()
+    let table = std::fs::read_to_string(path).ok()?.parse::<toml::Table>().ok()?;
+    Some(Value::Table(table))
 }
 
 /// Whether the project's `bunfig.toml` directs `node_modules` layout.
@@ -317,7 +318,7 @@ mod tests {
     use super::*;
 
     fn parsed(source: &str) -> Vec<(String, String)> {
-        let value = source.parse::<Value>().unwrap();
+        let value = Value::Table(source.parse::<toml::Table>().unwrap());
         entries_from_bunfig(&value)
     }
 

--- a/crates/nub-cli/src/pm_engine/bun_config.rs
+++ b/crates/nub-cli/src/pm_engine/bun_config.rs
@@ -45,7 +45,10 @@ fn load_bunfig_file(path: &Path) -> Vec<(String, String)> {
 }
 
 fn parse_bunfig_file(path: &Path) -> Option<Value> {
-    let table = std::fs::read_to_string(path).ok()?.parse::<toml::Table>().ok()?;
+    let table = std::fs::read_to_string(path)
+        .ok()?
+        .parse::<toml::Table>()
+        .ok()?;
     Some(Value::Table(table))
 }
 

--- a/crates/nub-cli/src/pm_engine/unsupported_config.rs
+++ b/crates/nub-cli/src/pm_engine/unsupported_config.rs
@@ -522,7 +522,7 @@ fn bunfig_install_bool(root: &Path, key: &str) -> Option<bool> {
     let mut value = None;
     for path in bunfig_paths(root) {
         if let Some(raw) = read_config_text(&path)
-            && let Ok(parsed) = raw.parse::<toml::Value>()
+            && let Ok(parsed) = raw.parse::<toml::Table>()
             && let Some(b) = parsed
                 .get("install")
                 .and_then(toml::Value::as_table)

--- a/crates/nub-core/Cargo.toml
+++ b/crates/nub-core/Cargo.toml
@@ -43,12 +43,12 @@ dirs-next = "2"
 dotenvy = "0.15"
 flate2 = { version = "1", default-features = false, features = ["zlib-ng"] }
 glob-match = "0.2"
+hex = "0.4"
 getrandom = "0.3"
 liblzma = { version = "0.4", features = ["static"] }
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
     "blocking",
-    "rustls-tls",
-    "rustls-tls-native-roots",
+    "rustls",
     "socks",
     "gzip",
 ] }
@@ -70,8 +70,8 @@ serde_json = { version = "1", features = ["preserve_order"] }
 # sha1 (ancient PM publishes carry only a sha1 dist.shasum) sits alongside sha2.
 # Pinned 0.10 to share `digest` 0.10 with sha2 — a single Digest trait, no second
 # major. sha512 is preferred; sha1 is the fail-closed fallback only.
-sha1 = "0.10"
-sha2 = "0.10"
+sha1 = "0.11"
+sha2 = "0.11"
 tar = "0.4"
 zip = { version = "8.6", default-features = false, features = ["deflate"] }
 thiserror = "2"
@@ -101,7 +101,7 @@ windows-sys = { version = "0.61", features = [
 [build-dependencies]
 tar = { version = "0.4", optional = true }
 zstd = { version = "0.13", optional = true }
-sha2 = { version = "0.10", optional = true }
+sha2 = { version = "0.11", optional = true }
 # Bakes the R2 per-entrypoint BLAKE3 digests (the runtime side decodes with the
 # `blake3` dep above). build-deps never reach the shipped binary.
 blake3 = { version = "1", optional = true }

--- a/crates/nub-core/src/version_management/mod.rs
+++ b/crates/nub-core/src/version_management/mod.rs
@@ -481,7 +481,7 @@ impl NodeLicenseAttestation {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    hex::encode(Sha256::digest(bytes))
 }
 
 fn is_sha256_hex(value: &str) -> bool {
@@ -1479,7 +1479,7 @@ mod tests {
             builder.into_inner().unwrap().finish().unwrap();
         }
         use sha2::{Digest, Sha256};
-        let sha = format!("{:x}", Sha256::digest(&bytes));
+        let sha = hex::encode(Sha256::digest(&bytes));
         (bytes, sha)
     }
 
@@ -1799,7 +1799,7 @@ mod tests {
         let mut corrupt = b"\xfd7zXZ\x00".to_vec();
         corrupt.extend(std::iter::repeat_n(0xAAu8, 4 << 20));
         use sha2::{Digest, Sha256};
-        let sha = format!("{:x}", Sha256::digest(&corrupt));
+        let sha = hex::encode(Sha256::digest(&corrupt));
         let (base, hits) = serve_dist(
             format!("{sha}  {name}.tar.xz\n"),
             format!("{name}.tar.xz"),

--- a/crates/nub-data-formats/Cargo.toml
+++ b/crates/nub-data-formats/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/nubjs/nub"
 # bytes — HashMap ordering would make two builds of one input differ.
 serde_json = { version = "1", features = ["preserve_order"] }
 yaml-rust2 = "0.9"
-toml = "0.8"
+toml = "1.1"
 json5 = "0.4"
 jsonc-parser = { version = "0.32.4", features = ["serde"] }
 nub-json-guard = { path = "../nub-json-guard" }

--- a/crates/nub-data-formats/src/lib.rs
+++ b/crates/nub-data-formats/src/lib.rs
@@ -73,7 +73,7 @@ pub fn parse_yaml(source: &str) -> Result<serde_json::Value, String> {
 
 /// Parse TOML source into a JSON value.
 pub fn parse_toml(source: &str) -> Result<serde_json::Value, String> {
-    let value: toml::Value = source
+    let value: toml::Table = source
         .parse()
         .map_err(|e| format!("TOML parse error: {e}"))?;
 

--- a/crates/nub-launcher/Cargo.lock
+++ b/crates/nub-launcher/Cargo.lock
@@ -72,6 +72,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -187,6 +219,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +244,12 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -263,13 +311,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -309,6 +377,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "equivalent"
@@ -371,6 +445,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -492,6 +572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +617,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,11 +655,9 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -729,6 +822,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,7 +934,7 @@ dependencies = [
  "indexmap",
  "libc",
  "object",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "windows",
  "zerocopy 0.7.35",
@@ -880,6 +1022,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "glob-match",
+ "hex",
  "libc",
  "liblzma",
  "regex",
@@ -890,7 +1033,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.11.0",
  "signal-hook",
  "tar",
  "thiserror 2.0.19",
@@ -909,7 +1052,7 @@ dependencies = [
  "libc",
  "libsui",
  "nub-core",
- "sha2",
+ "sha2 0.10.9",
  "zstd",
 ]
 
@@ -1027,6 +1170,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -1146,9 +1290,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -1167,11 +1311,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -1182,7 +1323,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1206,6 +1346,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,8 +1373,8 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1255,11 +1404,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1270,12 +1447,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1369,26 +1540,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "sha1"
-version = "0.10.7"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1399,7 +1558,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1433,6 +1603,22 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1759,6 +1945,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,10 +2054,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
+name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/crates/nub-native/Cargo.lock
+++ b/crates/nub-native/Cargo.lock
@@ -1360,11 +1360,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1476,44 +1476,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "typenum"
@@ -1577,12 +1575,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "yaml-rust2"

--- a/vendor/aube/Cargo.lock
+++ b/vendor/aube/Cargo.lock
@@ -384,7 +384,6 @@ dependencies = [
  "miette",
  "serde",
  "serde_json",
- "serde_yaml",
  "sonic-rs",
  "tempfile",
  "thiserror 2.0.19",
@@ -450,6 +449,7 @@ dependencies = [
  "aube-registry",
  "aube-store",
  "aube-util",
+ "base64",
  "criterion",
  "flate2",
  "miette",
@@ -4077,19 +4077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5207,12 +5194,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/vendor/aube/Cargo.toml
+++ b/vendor/aube/Cargo.toml
@@ -65,13 +65,10 @@ yaml_serde = "0.10.4"
 # aube to surgically rewrite user-authored workspace YAML files
 # (catalogs, allowBuilds, patchedDependencies) without stripping
 # comments — yaml_serde's round-trip would otherwise destroy them.
-# yamlpatch uses yaml_serde for patch payloads; serde_yaml remains only
-# for the manual block injector that works around nested Add formatting.
 yamlpatch = "1.25"
 # yamlpath 1.28 does not declare the Rust 1.97 requirement it inherits
 # from tree-sitter-iter 1.28, so resolver 3 cannot avoid it.
 yamlpath = ">=1.25, <1.28"
-serde_yaml = "0.9"
 sonic-rs = "0.5"
 serde_path_to_error = "0.1"
 toml = "1.1"

--- a/vendor/aube/crates/aube-manifest/Cargo.toml
+++ b/vendor/aube/crates/aube-manifest/Cargo.toml
@@ -20,7 +20,6 @@ sonic-rs = { workspace = true }
 yaml_serde = { workspace = true }
 yamlpatch = { workspace = true }
 yamlpath = { workspace = true }
-serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/vendor/aube/crates/aube-manifest/src/workspace/yaml_patch.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace/yaml_patch.rs
@@ -32,7 +32,7 @@ enum Edit {
     Add {
         route_keys: Vec<String>,
         key: String,
-        value: serde_yaml::Value,
+        value: yaml_serde::Value,
     },
 }
 
@@ -77,7 +77,7 @@ pub(super) fn apply_diff(
     // mapping. Sort outer-most first so a parent that only just
     // came into existence is queryable for its children. Within
     // the same depth, preserve insertion order.
-    let mut adds: Vec<(Vec<String>, String, serde_yaml::Value)> = edits
+    let mut adds: Vec<(Vec<String>, String, yaml_serde::Value)> = edits
         .into_iter()
         .filter_map(|e| match e {
             Edit::Add {
@@ -130,7 +130,7 @@ fn diff_into(
             None => out.push(Edit::Add {
                 route_keys: route.to_vec(),
                 key: key.to_string(),
-                value: to_serde_value(path, after_v)?,
+                value: after_v.clone(),
             }),
             Some(before_v) if before_v != after_v => {
                 if let (Some(bm), Some(am)) = (before_v.as_mapping(), after_v.as_mapping()) {
@@ -153,7 +153,7 @@ fn diff_into(
                     out.push(Edit::Add {
                         route_keys: route.to_vec(),
                         key: key.to_string(),
-                        value: to_serde_value(path, after_v)?,
+                        value: after_v.clone(),
                     });
                 } else {
                     out.push(Edit::Yp(Patch {
@@ -187,7 +187,7 @@ fn inject_entry(
     source: &str,
     route_keys: &[String],
     key: &str,
-    value: &serde_yaml::Value,
+    value: &yaml_serde::Value,
     path: &Path,
 ) -> Result<String, crate::Error> {
     if route_keys.is_empty() {
@@ -249,21 +249,21 @@ fn inject_entry(
 /// recursively; non-empty sequence values emit as block
 /// sequences with `- ` items at child indent; everything else
 /// is emitted as a scalar value after the colon.
-fn render_entry(key: &str, value: &serde_yaml::Value, indent: usize) -> String {
+fn render_entry(key: &str, value: &yaml_serde::Value, indent: usize) -> String {
     let pad = " ".repeat(indent);
     match value {
-        serde_yaml::Value::Mapping(m) if !m.is_empty() => {
+        yaml_serde::Value::Mapping(m) if !m.is_empty() => {
             let mut out = format!("{pad}{}:\n", scalar_key_str(key));
             for (k, v) in m {
                 let child_key = match k {
-                    serde_yaml::Value::String(s) => s.clone(),
+                    yaml_serde::Value::String(s) => s.clone(),
                     other => render_scalar(other),
                 };
                 out.push_str(&render_entry(&child_key, v, indent + INDENT_STEP));
             }
             out
         }
-        serde_yaml::Value::Sequence(seq) if !seq.is_empty() => {
+        yaml_serde::Value::Sequence(seq) if !seq.is_empty() => {
             // Block-sequence under a mapping key. Without an
             // explicit arm the catch-all below would feed the
             // sequence through `render_scalar`, which emits a
@@ -274,14 +274,14 @@ fn render_entry(key: &str, value: &serde_yaml::Value, indent: usize) -> String {
             for item in seq {
                 if matches!(
                     item,
-                    serde_yaml::Value::Mapping(_) | serde_yaml::Value::Sequence(_)
+                    yaml_serde::Value::Mapping(_) | yaml_serde::Value::Sequence(_)
                 ) {
                     // Nested mapping/sequence as a list item: defer
-                    // to serde_yaml for inner shape, then attach
+                    // to yaml_serde for inner shape, then attach
                     // the dash to the first emitted line and pad
                     // every continuation line so it stays inside
                     // the same item.
-                    let raw = serde_yaml::to_string(item).unwrap_or_default();
+                    let raw = yaml_serde::to_string(item).unwrap_or_default();
                     let mut first = true;
                     for line in raw.lines() {
                         if first {
@@ -308,25 +308,25 @@ fn render_entry(key: &str, value: &serde_yaml::Value, indent: usize) -> String {
     }
 }
 
-/// Re-serialize a single scalar through serde_yaml so YAML
+/// Re-serialize a single scalar through yaml_serde so YAML
 /// quoting (escapes, leading-special-char handling) matches what
 /// the rest of the file already uses. Trailing newlines from the
 /// emitter are stripped — the caller owns its own line break.
-fn render_scalar(value: &serde_yaml::Value) -> String {
-    let raw = serde_yaml::to_string(value).unwrap_or_default();
+fn render_scalar(value: &yaml_serde::Value) -> String {
+    let raw = yaml_serde::to_string(value).unwrap_or_default();
     raw.trim_end().to_string()
 }
 
 /// Render a mapping key for emission, quoting only when the YAML
-/// 1.2 plain-scalar grammar requires it. Defers to serde_yaml's
+/// 1.2 plain-scalar grammar requires it. Defers to yaml_serde's
 /// emitter so the rules stay in lockstep with the rest of the
 /// file: identifiers like `b@2.0.0` and `is-positive@3.1.0`
 /// round-trip unquoted (the `@` is reserved only at the *start*
 /// of a scalar), while keys that lead with a reserved indicator
 /// or contain flow/quote/comment characters get the canonical
-/// quoted form serde_yaml would have produced.
+/// quoted form yaml_serde would have produced.
 fn scalar_key_str(key: &str) -> String {
-    let raw = serde_yaml::to_string(&serde_yaml::Value::String(key.to_string()))
+    let raw = yaml_serde::to_string(&yaml_serde::Value::String(key.to_string()))
         .unwrap_or_else(|_| format!("{key}\n"));
     raw.trim_end().to_string()
 }
@@ -364,19 +364,6 @@ fn key_str<'a>(path: &Path, value: &'a Value) -> Result<&'a str, crate::Error> {
             format!("workspace yaml mapping key must be a string, got {other:?}"),
         )),
     }
-}
-
-/// Bridge `yaml_serde::Value` (our typed parse type) to
-/// `serde_yaml::Value` (the manual injector's render type).
-/// yaml_serde is
-/// the maintained fork of serde_yaml 0.9, so a YAML round-trip is
-/// lossless for every variant we use (scalars, sequences,
-/// mappings, tagged values). Errors on either side propagate
-/// instead of panicking — they're vanishingly rare but a
-/// workspace edit is a poor place to crash the process.
-fn to_serde_value(path: &Path, value: &Value) -> Result<serde_yaml::Value, crate::Error> {
-    let raw = yaml_serde::to_string(value).map_err(|e| yp_err(path, e.to_string()))?;
-    serde_yaml::from_str(&raw).map_err(|e| yp_err(path, e.to_string()))
 }
 
 fn yp_err(path: &Path, msg: String) -> crate::Error {

--- a/vendor/aube/crates/aube-resolver/Cargo.toml
+++ b/vendor/aube/crates/aube-resolver/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sonic-rs = { workspace = true }
 rkyv = { workspace = true }
+base64 = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
 zstd = { workspace = true }
@@ -56,6 +57,7 @@ required-features = ["bench"]
 
 [build-dependencies]
 rkyv = { workspace = true }
+base64 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 zstd = { workspace = true }

--- a/vendor/aube/crates/aube-resolver/build.rs
+++ b/vendor/aube/crates/aube-resolver/build.rs
@@ -21,6 +21,15 @@ const RELEASE_TOP: usize = 2000;
 // cleanly via `PickResult::NoMatch` in resolve.rs — one extra packument
 // fetch per long-tail version pick, typically old `react-is`, hoisted
 // `@typescript-eslint/*`, or stale `core-js@2.x` style versions.
+//
+// On top of the cap, `generate-primer.mjs` prunes versions older than 3
+// years unless they are the newest of their `major.minor` line or a dist-tag
+// target (`--prune-age-days`). Measured 2026-09-03 on the top-2000 primer:
+// 97,292 -> 58,806 versions, compressed 10.05 MB -> 6.35 MB, and a cold
+// resolve of the 84-dependency bench fixture (1,120 packuments) served the
+// same 862 from the primer with and without the prune — zero extra fetches.
+// The per-version SHA-512 is the primer's dominant byte cost and does not
+// compress, so version count, not compression level, is the size lever.
 const DEFAULT_VERSION_CAP: usize = 100;
 const FAST_COMPRESSION_LEVEL: i32 = 10;
 const RELEASE_CI_COMPRESSION_LEVEL: i32 = 19;

--- a/vendor/aube/crates/aube-resolver/build.rs
+++ b/vendor/aube/crates/aube-resolver/build.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[allow(dead_code)]
 mod primer_schema {
     include!("src/primer_schema.rs");
 }
@@ -29,7 +30,7 @@ const POPULAR_NAMES_FORMAT: u32 = 1;
 // in a layout-breaking way. The on-disk `primer-topN-vM-sK.rkyv.zst`
 // artifact is gitignored, so older `sK` files orphan harmlessly and
 // the new `sK+1` is regenerated on the next build.
-const PRIMER_DATA_SCHEMA: u32 = 2;
+const PRIMER_DATA_SCHEMA: u32 = 3;
 
 fn main() {
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());

--- a/vendor/aube/crates/aube-resolver/build.rs
+++ b/vendor/aube/crates/aube-resolver/build.rs
@@ -23,13 +23,15 @@ const RELEASE_TOP: usize = 2000;
 // `@typescript-eslint/*`, or stale `core-js@2.x` style versions.
 //
 // On top of the cap, `generate-primer.mjs` prunes versions older than 3
-// years unless they are the newest of their `major.minor` line or a dist-tag
-// target (`--prune-age-days`). Measured 2026-09-03 on the top-2000 primer:
-// 97,292 -> 58,806 versions, compressed 10.05 MB -> 6.35 MB, and a cold
-// resolve of the 84-dependency bench fixture (1,120 packuments) served the
-// same 862 from the primer with and without the prune — zero extra fetches.
-// The per-version SHA-512 is the primer's dominant byte cost and does not
-// compress, so version count, not compression level, is the size lever.
+// years unless they are the highest of their `major.minor` line or a dist-tag
+// target (`--prune-age-days`), and flags such a seed `sparse` so the resolver
+// refetches any pick a dropped version could outrank
+// (`semver_util::sparse_pick_needs_refetch`). Measured 2026-09-03 on the
+// top-2000 primer: 97,292 -> 58,806 versions, compressed 10.05 MB -> 6.35 MB,
+// and a cold resolve of the 84-dependency bench fixture (1,120 packuments)
+// served the same 862 from the primer with and without the prune — zero extra
+// fetches. The per-version SHA-512 is the primer's dominant byte cost and does
+// not compress, so version count, not compression level, is the size lever.
 const DEFAULT_VERSION_CAP: usize = 100;
 const FAST_COMPRESSION_LEVEL: i32 = 10;
 const RELEASE_CI_COMPRESSION_LEVEL: i32 = 19;
@@ -39,7 +41,7 @@ const POPULAR_NAMES_FORMAT: u32 = 1;
 // in a layout-breaking way. The on-disk `primer-topN-vM-sK.rkyv.zst`
 // artifact is gitignored, so older `sK` files orphan harmlessly and
 // the new `sK+1` is regenerated on the next build.
-const PRIMER_DATA_SCHEMA: u32 = 3;
+const PRIMER_DATA_SCHEMA: u32 = 4;
 
 fn main() {
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());

--- a/vendor/aube/crates/aube-resolver/src/primer.rs
+++ b/vendor/aube/crates/aube-resolver/src/primer.rs
@@ -120,7 +120,7 @@ impl PrimerDist {
                 .tarball
                 .clone()
                 .unwrap_or_else(|| deterministic_tarball_url(name, version)),
-            integrity: self.integrity.clone(),
+            integrity: self.integrity.as_ref().map(|i| i.to_sri()),
             shasum: None,
             unpacked_size: None,
             attestations: self.provenance.then(|| Attestations {

--- a/vendor/aube/crates/aube-resolver/src/primer_schema.rs
+++ b/vendor/aube/crates/aube-resolver/src/primer_schema.rs
@@ -91,7 +91,48 @@ pub(super) struct PrimerDist {
     #[serde(default, rename = "t")]
     pub(super) tarball: Option<String>,
     #[serde(default, rename = "i")]
-    pub(super) integrity: Option<String>,
+    pub(super) integrity: Option<PrimerIntegrity>,
     #[serde(default, rename = "a")]
     pub(super) provenance: bool,
+}
+
+/// An SRI integrity string, stored as the raw digest. This is the primer's
+/// single largest field — one `sha512-<base64>` per version, ~97k of them in
+/// the release primer — and a digest compresses no better than its own bytes,
+/// so the base64 text costs a third more for nothing. Re-encoded on read.
+#[derive(Archive, Clone, RkyvSerialize, RkyvDeserialize)]
+pub(super) enum PrimerIntegrity {
+    Sha512([u8; 64]),
+    /// Any other SRI form (the ~100 legacy `sha1-` publishes), verbatim.
+    Other(String),
+}
+
+impl PrimerIntegrity {
+    pub(super) fn from_sri(sri: String) -> Self {
+        use base64::Engine as _;
+        if let Some(b64) = sri.strip_prefix("sha512-")
+            && let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(b64)
+            && let Ok(digest) = <[u8; 64]>::try_from(bytes)
+        {
+            return Self::Sha512(digest);
+        }
+        Self::Other(sri)
+    }
+
+    pub(super) fn to_sri(&self) -> String {
+        use base64::Engine as _;
+        match self {
+            Self::Sha512(digest) => format!(
+                "sha512-{}",
+                base64::engine::general_purpose::STANDARD.encode(digest)
+            ),
+            Self::Other(sri) => sri.clone(),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for PrimerIntegrity {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        String::deserialize(deserializer).map(Self::from_sri)
+    }
 }

--- a/vendor/aube/crates/aube-resolver/src/primer_schema.rs
+++ b/vendor/aube/crates/aube-resolver/src/primer_schema.rs
@@ -6,6 +6,13 @@ pub(crate) struct Seed {
     pub(crate) etag: Option<String>,
     #[serde(default, rename = "lm")]
     pub(crate) last_modified: Option<String>,
+    /// `generate-primer.mjs` dropped at least one old version from this
+    /// seed (`--prune-age-days`), keeping the highest version of every
+    /// `major.minor` line and every dist-tag target. The resolver reads
+    /// this to refetch a pick that a dropped version could outrank
+    /// (`semver_util::sparse_pick_needs_refetch`).
+    #[serde(default, rename = "sp")]
+    pub(crate) sparse: bool,
     #[serde(rename = "p")]
     pub(super) packument: PrimerPackument,
 }

--- a/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/driver.rs
@@ -29,7 +29,7 @@ use crate::package_ext::{
 };
 use crate::semver_util::{
     AgeGateCause, PickResult, Regime, classify_regime, pick_version, range_resolves_via_dist_tag,
-    version_satisfies,
+    sparse_pick_needs_refetch, version_satisfies,
 };
 use crate::workspace_spec::workspace_range_binds;
 use crate::{
@@ -591,13 +591,18 @@ impl<'a> ResolveDriver<'a> {
     /// fail-open hazard). Returns `false` (accept the offline pick) for
     /// frozen picks whose history is settled. See the big comment on the
     /// matching arm in the pick loop for the full rationale.
+    #[allow(clippy::too_many_arguments)]
     fn primer_pick_needs_refetch(
         &self,
         packument: &aube_registry::Packument,
         picked_version: &str,
+        range_str: &str,
         cutoff_for_pkg: Option<&str>,
-        range_is_dist_tag: bool,
+        pick_lowest: bool,
+        locked_version: Option<&str>,
+        sparse_seed: bool,
     ) -> bool {
+        let range_is_dist_tag = range_resolves_via_dist_tag(packument, range_str);
         // A dist-tag (`latest`, `next`, a custom tag) is a MUTABLE pointer
         // the publisher can repoint between builds. The primer bakes the
         // tag's value at build time, and `classify_regime` — which keys
@@ -613,6 +618,21 @@ impl<'a> ResolveDriver<'a> {
         // fresh-resolve refetched, so the two diverged and `update`
         // downgraded). Refetch unconditionally so the tag is re-read live.
         if range_is_dist_tag {
+            return true;
+        }
+        // An age-pruned seed has holes in settled history, so the regime
+        // argument below ("a refetch could never surface a newer
+        // satisfying version") does not hold when the range could match
+        // a version the prune dropped above the pick.
+        if sparse_seed
+            && sparse_pick_needs_refetch(
+                packument,
+                picked_version,
+                range_str,
+                pick_lowest,
+                locked_version,
+            )
+        {
             return true;
         }
         match classify_regime(packument, picked_version) {
@@ -723,10 +743,10 @@ impl<'a> ResolveDriver<'a> {
         {
             self.ensure_fetch(&fetch_name);
             match self.fetcher.join_next().await {
-                Some(Ok(Ok((name, packument, from_primer)))) => {
+                Some(Ok(Ok((name, packument, primer_seed)))) => {
                     self.fetcher.release_in_flight(&name);
-                    if from_primer {
-                        self.fetcher.note_primer_seeded(name.clone());
+                    if let Some(seed) = primer_seed {
+                        self.fetcher.note_primer_seeded(name.clone(), seed);
                     }
                     self.resolver.cache.insert(name, packument);
                     self.packument_fetch_count += 1;
@@ -966,8 +986,11 @@ impl<'a> ResolveDriver<'a> {
                         && self.primer_pick_needs_refetch(
                             packument,
                             &meta.version,
+                            &task.range,
                             cutoff_for_pkg,
-                            range_resolves_via_dist_tag(packument, &task.range),
+                            pick_lowest,
+                            locked_version,
+                            self.fetcher.primer_seed_is_sparse(&registry_name),
                         ) =>
                 {
                     // Consume the seed flag (one refetch per package,

--- a/vendor/aube/crates/aube-resolver/src/resolve/fetch.rs
+++ b/vendor/aube/crates/aube-resolver/src/resolve/fetch.rs
@@ -1,4 +1,4 @@
-use crate::{Error, FxHashSet, Resolver};
+use crate::{Error, FxHashMap, FxHashSet, Resolver};
 use aube_registry::Packument;
 use aube_registry::client::RegistryClient;
 use aube_util::adaptive::AdaptiveLimit;
@@ -20,9 +20,9 @@ use tokio::task::JoinSet;
 /// keeping it compatible with the BFS loop's `&mut self.resolver.cache`
 /// access pattern.
 pub(super) struct FetchScheduler {
-    in_flight: JoinSet<Result<(String, Packument, bool), Error>>,
+    in_flight: JoinSet<Result<Fetched, Error>>,
     in_flight_names: FxHashSet<String>,
-    primer_seeded_names: FxHashSet<String>,
+    primer_seeded_names: FxHashMap<String, PrimerSeed>,
     sem: Arc<AdaptiveLimit>,
     client: Arc<RegistryClient>,
     cache_dir: Option<PathBuf>,
@@ -31,15 +31,28 @@ pub(super) struct FetchScheduler {
     needs_time: bool,
 }
 
-pub(super) type FetchOutcome =
-    Option<Result<Result<(String, Packument, bool), Error>, tokio::task::JoinError>>;
+/// What the fetch task knows about a packument it served from the primer.
+#[derive(Clone, Copy)]
+pub(super) struct PrimerSeed {
+    /// The seed was age-pruned (`Seed::sparse`): old versions that are
+    /// neither the highest of their `major.minor` line nor a dist-tag
+    /// target are missing, so a pick from it can sit below a version the
+    /// registry holds (`semver_util::sparse_pick_needs_refetch`).
+    pub(super) sparse: bool,
+}
+
+/// A landed packument: `(name, packument, primer_seed)`, the last `Some`
+/// when the bundled primer served it.
+pub(super) type Fetched = (String, Packument, Option<PrimerSeed>);
+
+pub(super) type FetchOutcome = Option<Result<Result<Fetched, Error>, tokio::task::JoinError>>;
 
 impl FetchScheduler {
     pub(super) fn new(resolver: &Resolver, sem: Arc<AdaptiveLimit>, needs_time: bool) -> Self {
         Self {
             in_flight: JoinSet::new(),
             in_flight_names: FxHashSet::default(),
-            primer_seeded_names: FxHashSet::default(),
+            primer_seeded_names: FxHashMap::default(),
             sem,
             client: resolver.client.clone(),
             cache_dir: resolver.packument_cache_dir.clone(),
@@ -98,13 +111,13 @@ impl FetchScheduler {
         self.in_flight_names.remove(name);
     }
 
-    pub(super) fn note_primer_seeded(&mut self, name: String) {
-        self.primer_seeded_names.insert(name);
+    pub(super) fn note_primer_seeded(&mut self, name: String, seed: PrimerSeed) {
+        self.primer_seeded_names.insert(name, seed);
     }
 
     /// Returns true if `name` was marked as primer-seeded, removing it.
     pub(super) fn take_primer_seeded(&mut self, name: &str) -> bool {
-        self.primer_seeded_names.remove(name)
+        self.primer_seeded_names.remove(name).is_some()
     }
 
     /// Non-consuming peek: is `name` currently flagged as primer-seeded?
@@ -112,7 +125,15 @@ impl FetchScheduler {
     /// before deciding whether to consume the flag and refetch (frozen
     /// picks are accepted as-is, so they must not eagerly clear it).
     pub(super) fn is_primer_seeded(&self, name: &str) -> bool {
-        self.primer_seeded_names.contains(name)
+        self.primer_seeded_names.contains_key(name)
+    }
+
+    /// Non-consuming peek: was `name` seeded from an age-pruned primer
+    /// entry? False for a dense seed and for a name not primer-seeded.
+    pub(super) fn primer_seed_is_sparse(&self, name: &str) -> bool {
+        self.primer_seeded_names
+            .get(name)
+            .is_some_and(|seed| seed.sparse)
     }
 
     pub(super) async fn drain(&mut self) {
@@ -145,12 +166,12 @@ struct FetchInputs {
 
 /// Body of the per-packument fetch task spawned by the resolver.
 ///
-/// Returns `(name, packument, from_primer)` — `from_primer` is true
+/// Returns `(name, packument, primer_seed)` — `primer_seed` is `Some`
 /// when the result came from the bundled metadata primer (only its
 /// capped slice of high-traffic histories), so the caller knows a
 /// range miss must trigger a live registry refetch before reporting
 /// `ERR_AUBE_NO_MATCHING_VERSION`.
-async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, bool), Error> {
+async fn fetch_one_packument(inputs: FetchInputs) -> Result<Fetched, Error> {
     let FetchInputs {
         name,
         client,
@@ -195,7 +216,7 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
             || format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(&name)),
         );
         permit.record_cancelled();
-        return Ok((name, packument, false));
+        return Ok((name, packument, None));
     }
     let use_metadata_primer = (force_metadata_primer
         || client.uses_default_npm_registry_for(&name))
@@ -246,7 +267,13 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
             || format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(&name)),
         );
         permit.record_cancelled();
-        return Ok((name, packument, true));
+        return Ok((
+            name,
+            packument,
+            Some(PrimerSeed {
+                sparse: seed.sparse,
+            }),
+        ));
     }
     let fetch_outcome = if needs_time {
         match full_cache_dir.as_ref() {
@@ -288,5 +315,5 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
         "packument_network_hit",
         || format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(&name)),
     );
-    Ok((name, packument, false))
+    Ok((name, packument, None))
 }

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -500,6 +500,99 @@ pub(crate) fn range_resolves_via_dist_tag(packument: &Packument, range_str: &str
     packument.dist_tags.contains_key(range_str) || range_str == "latest"
 }
 
+/// Could a version the primer's age prune DROPPED be what the full
+/// packument picks for `range_str`? `packument` is the sparse seed and
+/// `picked_version` what `pick_version` chose from it.
+///
+/// The prune (`scripts/generate-primer.mjs`, `--prune-age-days`) keeps the
+/// highest version of every `major.minor` line (prereleases on their own
+/// line) and every dist-tag target, and drops other old versions. So a
+/// dropped version lies below the highest held version of a line the
+/// seed still holds, and a `^x` / `~x.y` pick, which lands on a line's
+/// highest, has nothing dropped above it. A range with an explicit upper
+/// bound (`<4.17.21` against lodash: 4.17.20 dropped, 4.16.6 held) can,
+/// and refetches.
+///
+/// Conservative wherever the seed cannot prove the pick: `pick_lowest`
+/// (the floor of a range is exactly what was dropped) and a locked
+/// version the seed does not hold refetch outright, so does anything
+/// unparseable, and `Range::allows_any` overlaps bounds without npm's
+/// prerelease rule.
+pub(crate) fn sparse_pick_needs_refetch(
+    packument: &Packument,
+    picked_version: &str,
+    range_str: &str,
+    pick_lowest: bool,
+    locked: Option<&str>,
+) -> bool {
+    if pick_lowest || locked.is_some_and(|v| !packument.versions.contains_key(v)) {
+        return true;
+    }
+    let Ok(picked) = node_semver::Version::parse(picked_version) else {
+        return true;
+    };
+    // An exact pin the seed holds is the full packument's pick too.
+    if node_semver::Version::parse(range_str.trim().trim_start_matches(['=', 'v']))
+        .is_ok_and(|pinned| pinned == picked)
+    {
+        return false;
+    }
+    let Ok(range) = node_semver::Range::parse(normalize_range(range_str)) else {
+        return true;
+    };
+    // Highest held version per line, keyed `(major, minor, prerelease)`.
+    let mut lines: std::collections::BTreeMap<(u64, u64, bool), node_semver::Version> =
+        std::collections::BTreeMap::new();
+    for v in packument
+        .versions
+        .keys()
+        .filter_map(|v| node_semver::Version::parse(v).ok())
+    {
+        let slot = lines
+            .entry((v.major, v.minor, !v.pre_release.is_empty()))
+            .or_insert_with(|| v.clone());
+        if v > *slot {
+            *slot = v;
+        }
+    }
+    let picked_line = (picked.major, picked.minor, !picked.pre_release.is_empty());
+    for (&(major, minor, pre), highest) in &lines {
+        if *highest <= picked {
+            continue;
+        }
+        // Where a dropped version of this line could sit above the pick.
+        // `allows_any` compares bounds only, so a prerelease line is
+        // consulted just when the range names a prerelease of that
+        // `major.minor` — npm's rule for admitting one at all.
+        let gap = if (major, minor, pre) == picked_line {
+            format!(">{picked} <{highest}")
+        } else if pre {
+            if !range_names_prerelease_of(range_str, major, minor) {
+                continue;
+            }
+            format!(">={major}.{minor}.0-0 <{highest}")
+        } else if highest.patch == 0 {
+            continue;
+        } else {
+            format!(">={major}.{minor}.0 <{highest}")
+        };
+        match node_semver::Range::parse(&gap) {
+            Ok(gap) if range.allows_any(&gap) => return true,
+            Ok(_) => {}
+            Err(_) => return true,
+        }
+    }
+    false
+}
+
+fn range_names_prerelease_of(range_str: &str, major: u64, minor: u64) -> bool {
+    range_str
+        .split(|c: char| c.is_whitespace() || c == '|')
+        .map(|token| token.trim_start_matches(['<', '>', '=', '~', '^', 'v']))
+        .filter_map(|token| node_semver::Version::parse(token).ok())
+        .any(|v| !v.pre_release.is_empty() && v.major == major && v.minor == minor)
+}
+
 /// Walk the packument's versions and return the highest non
 /// prerelease version string. Used as the `latest` tag fallback
 /// when the registry response lacks `dist-tags.latest`. Some

--- a/vendor/aube/crates/aube-resolver/src/semver_util.rs
+++ b/vendor/aube/crates/aube-resolver/src/semver_util.rs
@@ -514,10 +514,11 @@ pub(crate) fn range_resolves_via_dist_tag(packument: &Packument, range_str: &str
 /// and refetches.
 ///
 /// Conservative wherever the seed cannot prove the pick: `pick_lowest`
-/// (the floor of a range is exactly what was dropped) and a locked
-/// version the seed does not hold refetch outright, so does anything
-/// unparseable, and `Range::allows_any` overlaps bounds without npm's
-/// prerelease rule.
+/// (the floor of a range is exactly what was dropped), a locked version
+/// the seed does not hold, and a deprecated pick (`outranks` prefers any
+/// live version, so a dropped live one anywhere in the range beats it)
+/// refetch outright, so does anything unparseable, and
+/// `Range::allows_any` overlaps bounds without npm's prerelease rule.
 pub(crate) fn sparse_pick_needs_refetch(
     packument: &Packument,
     picked_version: &str,
@@ -536,6 +537,13 @@ pub(crate) fn sparse_pick_needs_refetch(
         .is_ok_and(|pinned| pinned == picked)
     {
         return false;
+    }
+    if packument
+        .versions
+        .get(picked_version)
+        .is_some_and(|meta| meta.deprecated.is_some())
+    {
+        return true;
     }
     let Ok(range) = node_semver::Range::parse(normalize_range(range_str)) else {
         return true;

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -7443,6 +7443,18 @@ fn sparse_pick_refetches_only_when_a_dropped_version_could_outrank_it() {
     assert!(refetch("^1.2.0", "1.2.5", false, Some("1.2.3")));
     assert!(!refetch("^1.2.0", "1.2.5", false, Some("1.2.5")));
 
+    // A deprecated line end loses to a dropped live version below it
+    // (`outranks` prefers live over deprecated before comparing versions),
+    // so it is not authoritative even with nothing above it. An exact pin
+    // has no other candidate.
+    let mut seed = make_packument("baz", &["1.0.1"], "1.0.1");
+    seed.versions.get_mut("1.0.1").unwrap().deprecated = Some("use 2.x".to_string());
+    let refetch = |range: &str, picked: &str| {
+        crate::semver_util::sparse_pick_needs_refetch(&seed, picked, range, false, None)
+    };
+    assert!(refetch("^1.0.0", "1.0.1"));
+    assert!(!refetch("1.0.1", "1.0.1"));
+
     // Prereleases sit on their own line. A stable pick ignores a held
     // next-major beta unless the range names a prerelease of that line;
     // an exact prerelease pin the seed holds is final; a prerelease range

--- a/vendor/aube/crates/aube-resolver/src/tests.rs
+++ b/vendor/aube/crates/aube-resolver/src/tests.rs
@@ -7409,3 +7409,191 @@ async fn required_dep_with_no_matching_version_still_fails() {
         .expect_err("a required dep with no matching version must fail the resolve");
     assert!(matches!(err, Error::NoMatch(_)), "got {err:?}");
 }
+
+#[test]
+fn sparse_pick_refetches_only_when_a_dropped_version_could_outrank_it() {
+    // lodash after the age prune: 4.16.6 and 4.17.21 are the highest of
+    // their lines and stay, 4.17.0..4.17.20 are dropped. The full
+    // packument picks 4.17.20 for every range in the first group; the
+    // seed picked 4.16.6.
+    let seed = make_packument("lodash", &["3.10.1", "4.16.6", "4.17.21"], "4.17.21");
+    let refetch = |range: &str, picked: &str| {
+        crate::semver_util::sparse_pick_needs_refetch(&seed, picked, range, false, None)
+    };
+    assert!(refetch("<4.17.21", "4.16.6"));
+    assert!(refetch("4.10.0 - 4.17.20", "4.16.6"));
+    assert!(refetch(">=4.16.0 <4.17.5", "4.16.6"));
+    // A pick at the top of its line has nothing dropped above it.
+    assert!(!refetch("^4.0.0", "4.17.21"));
+    assert!(!refetch("*", "4.17.21"));
+    assert!(!refetch("~4.16.0", "4.16.6"));
+    assert!(!refetch("4.16.6", "4.16.6"));
+    assert!(!refetch("^3.0.0", "3.10.1"));
+
+    // A dist-tag target held below its line's highest: the versions
+    // between them may be dropped.
+    let seed = make_packument("foo", &["1.2.0", "1.2.5"], "1.2.0");
+    let refetch = |range: &str, picked: &str, lowest: bool, locked: Option<&str>| {
+        crate::semver_util::sparse_pick_needs_refetch(&seed, picked, range, lowest, locked)
+    };
+    assert!(refetch("<1.2.5", "1.2.0", false, None));
+    // The floor of a range, and a locked version the seed lacks, are
+    // exactly what the prune drops.
+    assert!(refetch("^1.2.0", "1.2.0", true, None));
+    assert!(refetch("^1.2.0", "1.2.5", false, Some("1.2.3")));
+    assert!(!refetch("^1.2.0", "1.2.5", false, Some("1.2.5")));
+
+    // Prereleases sit on their own line. A stable pick ignores a held
+    // next-major beta unless the range names a prerelease of that line;
+    // an exact prerelease pin the seed holds is final; a prerelease range
+    // below its line's highest may have lost a candidate to the prune.
+    let seed = make_packument(
+        "bar",
+        &["7.21.4-esm.4", "7.21.8", "8.0.0-beta.1", "8.0.0-beta.3"],
+        "7.21.8",
+    );
+    let refetch = |range: &str, picked: &str| {
+        crate::semver_util::sparse_pick_needs_refetch(&seed, picked, range, false, None)
+    };
+    assert!(!refetch("^7.21.0", "7.21.8"));
+    assert!(!refetch("=7.21.4-esm.4", "7.21.4-esm.4"));
+    assert!(refetch(">=8.0.0-beta.1 <8.0.0-beta.3", "8.0.0-beta.1"));
+    assert!(refetch("^7.21.0 || 8.0.0-beta.2", "7.21.8"));
+}
+
+/// A range whose best match the age prune dropped must not settle on the
+/// older version the seed still holds: the resolver refetches the full
+/// packument and picks from it. Uses the bundled primer, so it looks for
+/// a sparse seed with a stable line end `lower` and a higher line of the
+/// same major whose highest `upper` has a patch above 0 — then
+/// `<upper` resolves to `upper - 1 patch` on the registry and to `lower`
+/// on the seed. Skips honestly when the primer has no such entry.
+#[tokio::test]
+async fn primer_sparse_pick_refetches_when_a_dropped_version_outranks_it() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let Some((name, lower, dropped, upper)) = crate::primer::names().find_map(|name| {
+        let seed = crate::primer::get(name)?;
+        if !seed.sparse {
+            return None;
+        }
+        let pkt = seed.packument();
+        let mut stable: Vec<node_semver::Version> = pkt
+            .versions
+            .keys()
+            .filter_map(|v| node_semver::Version::parse(v).ok())
+            .filter(|v| v.pre_release.is_empty())
+            .collect();
+        stable.sort();
+        stable.iter().find_map(|lower| {
+            let line_end = !stable
+                .iter()
+                .any(|h| h > lower && h.major == lower.major && h.minor == lower.minor);
+            let meta = pkt.versions.get(&lower.to_string())?;
+            let standalone = meta.dependencies.is_empty()
+                && meta.optional_dependencies.is_empty()
+                && meta.peer_dependencies.is_empty();
+            if !line_end || !standalone {
+                return None;
+            }
+            let upper = stable.iter().find(|h| {
+                h.major == lower.major
+                    && h.minor > lower.minor
+                    && h.patch > 0
+                    && !stable
+                        .iter()
+                        .any(|o| o.major == h.major && o.minor == h.minor && o.patch == h.patch - 1)
+            })?;
+            let dropped = format!("{}.{}.{}", upper.major, upper.minor, upper.patch - 1);
+            Some((
+                name.to_string(),
+                lower.to_string(),
+                dropped,
+                upper.to_string(),
+            ))
+        })
+    }) else {
+        return;
+    };
+
+    fn spawn_counting_registry(
+        full_body: Vec<u8>,
+    ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let seen = hits.clone();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+        let registry = format!("http://{addr}/");
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                seen.fetch_add(1, Ordering::Relaxed);
+                let full_body = full_body.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0_u8; 8192];
+                    let _ = socket.read(&mut buf).await;
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                        full_body.len()
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.write_all(&full_body).await;
+                });
+            }
+        });
+        (registry, hits, server)
+    }
+
+    let full = make_packument(&name, &[&lower, &dropped, &upper], &upper);
+    let (registry, hits, server) = spawn_counting_registry(serde_json::to_vec(&full).unwrap());
+
+    let resolve = |range: String| {
+        let name = name.clone();
+        let registry = registry.clone();
+        async move {
+            let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+            let mut resolver = Resolver::new(client)
+                .with_force_metadata_primer(true)
+                .with_registry_supports_time_field(true);
+            let mut manifest = PackageJson::default();
+            manifest.dependencies.insert(name.clone(), range);
+            let graph = resolver.resolve(&manifest, None).await.expect("resolve");
+            graph
+                .packages
+                .values()
+                .find(|p| p.name == name)
+                .map(|p| p.version.clone())
+                .expect("package resolved")
+        }
+    };
+
+    // The seed alone would answer `lower`; the registry holds `dropped`.
+    let picked = resolve(format!("<{upper}")).await;
+    assert_eq!(
+        picked, dropped,
+        "{name}: sparse seed pick was served without a refetch"
+    );
+    assert_eq!(
+        hits.load(Ordering::Relaxed),
+        1,
+        "{name}: expected one live refetch"
+    );
+
+    // A tilde range lands on the line's highest, which the prune keeps:
+    // served from the seed, no registry traffic.
+    let line = node_semver::Version::parse(&lower).unwrap();
+    let picked = resolve(format!("~{}.{}.0", line.major, line.minor)).await;
+    assert_eq!(picked, lower, "{name}: tilde pick must come from the seed");
+    assert_eq!(
+        hits.load(Ordering::Relaxed),
+        1,
+        "{name}: tilde pick must not refetch"
+    );
+
+    server.abort();
+}

--- a/vendor/aube/scripts/generate-primer.mjs
+++ b/vendor/aube/scripts/generate-primer.mjs
@@ -23,6 +23,9 @@ const top = Number(args.get('top') ?? 2000)
 // documented in the build.rs comment.
 const versionsArg = args.get('versions') ?? '100'
 const versions = versionsArg === 'all' ? Infinity : Number(versionsArg)
+// Age prune on top of the count cap — see `selectVersions`. `none` disables.
+const pruneAgeArg = args.get('prune-age-days') ?? '1095'
+const pruneAgeDays = pruneAgeArg === 'none' ? Infinity : Number(pruneAgeArg)
 const out = resolve(args.get('out') ?? `crates/aube-resolver/data/primer-top${top}.json`)
 const namesFile = args.get('names')
 const namesUrl = args.get('names-url') ?? 'https://raw.githubusercontent.com/jdx/aube-primer-packages/main/data/packages.json'
@@ -35,6 +38,9 @@ const popularNamesUrl =
 if (!Number.isInteger(top) || top < 1) throw new Error('--top must be a positive integer')
 if (versions !== Infinity && (!Number.isInteger(versions) || versions < 1)) {
   throw new Error('--versions must be a positive integer or "all"')
+}
+if (pruneAgeDays !== Infinity && (!Number.isInteger(pruneAgeDays) || pruneAgeDays < 1)) {
+  throw new Error('--prune-age-days must be a positive integer or "none"')
 }
 if (popularNamesOnly && !popularNamesOut) {
   throw new Error('--popular-names-only requires --popular-names-out')
@@ -94,7 +100,7 @@ async function packumentSeed(name, keepVersions) {
     console.error(`  skipped: HTTP ${res.status}`)
     return null
   }
-  const selected = selectVersions(full, keepVersions)
+  const selected = selectVersions(full, keepVersions, pruneAgeDays)
   const packument = {
     n: full.name ?? name,
     m: full.modified,
@@ -112,14 +118,34 @@ async function packumentSeed(name, keepVersions) {
   }
 }
 
-function selectVersions(packument, keepVersions) {
+// The newest `keepVersions` by publish time, minus anything older than
+// `pruneAgeDays` that is neither the newest of its `major.minor` line nor a
+// dist-tag target. A fresh resolve takes the newest version a range admits, so
+// an old version only wins when its whole line is old — and both `^x` and
+// `~x.y` land on the newest of a line, which stays. A pinned old exact version
+// misses the primer and refetches its packument: correct, merely slower. The
+// per-version SHA-512 is the primer's dominant byte cost and does not
+// compress, so every pruned version is ~100 bytes off the shipped binary.
+function selectVersions(packument, keepVersions, pruneAgeDays) {
+  const time = packument.time ?? {}
   const versions = Object.keys(packument.versions ?? {})
-  const byTime = versions
-    .filter((v) => packument.time?.[v])
-    .sort((a, b) => packument.time[a].localeCompare(packument.time[b]))
+  const byTime = versions.filter((v) => time[v]).sort((a, b) => time[a].localeCompare(time[b]))
   const ordered = byTime.length ? byTime : versions
-  if (keepVersions === Infinity) return ordered
-  return ordered.slice(-keepVersions)
+  const kept = keepVersions === Infinity ? ordered : ordered.slice(-keepVersions)
+  if (pruneAgeDays === Infinity || !byTime.length) return kept
+  const cutoff = Date.now() - pruneAgeDays * 86_400_000
+  // Ascending publish order, so the last write per line is its newest.
+  const newestOfLine = new Map()
+  for (const v of ordered) newestOfLine.set(versionLine(v), v)
+  const pinned = new Set([...newestOfLine.values(), ...Object.values(packument['dist-tags'] ?? {})])
+  return kept.filter((v) => pinned.has(v) || Date.parse(time[v]) >= cutoff)
+}
+
+// `major.minor`, with prereleases on their own line so a newer `-beta` never
+// evicts the stable release a caret range actually resolves to.
+function versionLine(version) {
+  const m = /^(\d+)\.(\d+)\.\d+(-)?/.exec(version)
+  return m ? `${m[1]}.${m[2]}${m[3] ? '-pre' : ''}` : version
 }
 
 function trimDistTags(tags = {}, selected) {

--- a/vendor/aube/scripts/generate-primer.mjs
+++ b/vendor/aube/scripts/generate-primer.mjs
@@ -100,7 +100,7 @@ async function packumentSeed(name, keepVersions) {
     console.error(`  skipped: HTTP ${res.status}`)
     return null
   }
-  const selected = selectVersions(full, keepVersions, pruneAgeDays)
+  const { selected, sparse } = selectVersions(full, keepVersions, pruneAgeDays)
   const packument = {
     n: full.name ?? name,
     m: full.modified,
@@ -114,31 +114,40 @@ async function packumentSeed(name, keepVersions) {
   return {
     e: res.headers.get('etag'),
     lm: res.headers.get('last-modified'),
+    ...(sparse ? { sp: true } : {}),
     p: packument,
   }
 }
 
 // The newest `keepVersions` by publish time, minus anything older than
-// `pruneAgeDays` that is neither the newest of its `major.minor` line nor a
+// `pruneAgeDays` that is neither the highest of its `major.minor` line nor a
 // dist-tag target. A fresh resolve takes the newest version a range admits, so
 // an old version only wins when its whole line is old — and both `^x` and
-// `~x.y` land on the newest of a line, which stays. A pinned old exact version
-// misses the primer and refetches its packument: correct, merely slower. The
-// per-version SHA-512 is the primer's dominant byte cost and does not
-// compress, so every pruned version is ~100 bytes off the shipped binary.
+// `~x.y` land on the highest of a line, which stays. Every other shape can
+// land on a dropped version (`<4.17.21` against lodash: 4.17.20 is dropped,
+// 4.16.6 stays), so a pruned seed is flagged `sparse` and the resolver
+// refetches such picks (`semver_util::sparse_pick_needs_refetch`). That
+// contract is what the highest-of-line rule exists for: the highest held
+// version of a line must be the highest version of the line. The per-version
+// SHA-512 is the primer's dominant byte cost and does not compress, so every
+// pruned version is ~100 bytes off the shipped binary.
 function selectVersions(packument, keepVersions, pruneAgeDays) {
   const time = packument.time ?? {}
   const versions = Object.keys(packument.versions ?? {})
   const byTime = versions.filter((v) => time[v]).sort((a, b) => time[a].localeCompare(time[b]))
   const ordered = byTime.length ? byTime : versions
   const kept = keepVersions === Infinity ? ordered : ordered.slice(-keepVersions)
-  if (pruneAgeDays === Infinity || !byTime.length) return kept
+  if (pruneAgeDays === Infinity || !byTime.length) return { selected: kept, sparse: false }
   const cutoff = Date.now() - pruneAgeDays * 86_400_000
-  // Ascending publish order, so the last write per line is its newest.
-  const newestOfLine = new Map()
-  for (const v of ordered) newestOfLine.set(versionLine(v), v)
-  const pinned = new Set([...newestOfLine.values(), ...Object.values(packument['dist-tags'] ?? {})])
-  return kept.filter((v) => pinned.has(v) || Date.parse(time[v]) >= cutoff)
+  const highestOfLine = new Map()
+  for (const v of versions) {
+    const line = versionLine(v)
+    const cur = highestOfLine.get(line)
+    if (cur === undefined || compareVersions(v, cur) > 0) highestOfLine.set(line, v)
+  }
+  const pinned = new Set([...highestOfLine.values(), ...Object.values(packument['dist-tags'] ?? {})])
+  const selected = kept.filter((v) => pinned.has(v) || Date.parse(time[v]) >= cutoff)
+  return { selected, sparse: selected.length < kept.length }
 }
 
 // `major.minor`, with prereleases on their own line so a newer `-beta` never
@@ -146,6 +155,40 @@ function selectVersions(packument, keepVersions, pruneAgeDays) {
 function versionLine(version) {
   const m = /^(\d+)\.(\d+)\.\d+(-)?/.exec(version)
   return m ? `${m[1]}.${m[2]}${m[3] ? '-pre' : ''}` : version
+}
+
+// Semver precedence, enough to order versions within one line: numeric
+// core, then prerelease identifiers (numeric before alphanumeric, a shorter
+// prefix first). Only ever compares two versions of the same line.
+function compareVersions(a, b) {
+  const pa = parseVersion(a)
+  const pb = parseVersion(b)
+  if (pa === null || pb === null) return a.localeCompare(b)
+  for (let i = 0; i < 3; i++) if (pa.core[i] !== pb.core[i]) return pa.core[i] - pb.core[i]
+  if (!pa.pre.length || !pb.pre.length) return pb.pre.length - pa.pre.length
+  const n = Math.max(pa.pre.length, pb.pre.length)
+  for (let i = 0; i < n; i++) {
+    const x = pa.pre[i]
+    const y = pb.pre[i]
+    if (x === undefined) return -1
+    if (y === undefined) return 1
+    const nx = /^\d+$/.test(x)
+    const ny = /^\d+$/.test(y)
+    if (nx && ny) {
+      if (Number(x) !== Number(y)) return Number(x) - Number(y)
+    } else if (nx !== ny) {
+      return nx ? -1 : 1
+    } else if (x !== y) {
+      return x < y ? -1 : 1
+    }
+  }
+  return 0
+}
+
+function parseVersion(version) {
+  const m = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(version)
+  if (!m) return null
+  return { core: [Number(m[1]), Number(m[2]), Number(m[3])], pre: m[4] ? m[4].split('.') : [] }
 }
 
 function trimDistTags(tags = {}, selected) {


### PR DESCRIPTION
linux-x64 release binary (with `compile`, before the runtime blob): 58.6 MB → 52.6 MB stripped.

- One reqwest (0.13), one rustls provider (aws-lc-rs), sha2 0.11, toml 1.1, clx 3, two YAML stacks instead of four.
- toml 1.x: bunfig and data-format loaders parse a `Table`, not a `Value`.
- Primer: raw SHA-512 digests and a 3-year age prune keeping the highest of each `major.minor` line and every dist-tag target (schema s4): 97,292 → 58,806 versions, 10.05 MB → 6.35 MB, same 862/1,120 primer hits on the bench fixture.
- A pruned seed is flagged sparse, and the resolver refetches any pick a dropped version could outrank (`sparse_pick_needs_refetch`): `lodash@<4.17.21` resolves to 4.17.20 again instead of the held 4.16.6. Line-end picks (`^x`, `~x.y`) and held exact pins stay offline.
- Per-crate `opt-level = "z"` measured and rejected: −7.5 MB but +8.7% warm resolve+link; cold crates alone −0.25 MB.
