### PR TITLE
compile: gate the --smol probe cache once per pass

### DIFF
--- a/crates/nub-launcher/src/cache.rs
+++ b/crates/nub-launcher/src/cache.rs
@@ -271,7 +271,7 @@ const PROBE_DIR: &str = "smol-probe";
 ///
 /// The probe directory is made by `create`, never `create_dir_all`, and the two
 /// are not interchangeable here: `create_dir_all` takes the directory's mode from
-/// the ambient umask, and [`read_node_version`] runs the same leaf gate that
+/// the ambient umask, and [`ProbeStore::resolve`] runs the same leaf gate that
 /// rejects any group- or other-writable directory. Under a umask of 002 that
 /// `create_dir_all` yields 0o775, so every write lands in a directory every read
 /// then refuses — the cache writes and never hits, silently, exactly the failure

--- a/crates/nub-launcher/src/cache.rs
+++ b/crates/nub-launcher/src/cache.rs
@@ -266,46 +266,6 @@ fn resolve_from<T>(
 /// verdict then costs one launch on a mislabelled Node, not a safety property.
 const PROBE_DIR: &str = "smol-probe";
 
-/// A remembered probe verdict for `node_bin`, if one exists and still applies.
-///
-/// Returns `None` on any doubt — a missing, untrusted, malformed, or stale entry
-/// all mean "probe it again", which is always correct and merely slower.
-pub fn read_node_version(node_bin: &Path, stamp: &str) -> Option<String> {
-    for candidate in candidates() {
-        let Some(base) = candidate.path else { continue };
-        let path = probe_path(&base, node_bin);
-        // The namespace gate walks DIRECTORIES, so it is applied to the directory
-        // holding the entry; the entry itself is then checked directly. Handing it
-        // the file made every read miss, silently — the cache wrote and never hit.
-        let Some(parent) = path.parent() else {
-            continue;
-        };
-        if inspect_existing(parent).is_err() {
-            continue;
-        }
-        let Ok(metadata) = fs::symlink_metadata(&path) else {
-            continue;
-        };
-        // symlink_metadata, so a symlink planted at this name is rejected rather
-        // than followed to whatever it points at.
-        if !metadata.is_file() || !owner_only(&metadata) {
-            continue;
-        }
-        let Ok(body) = fs::read_to_string(&path) else {
-            continue;
-        };
-        // `<stamp>\n<version>`: the stamp must match the binary as it is NOW, or
-        // this entry describes a different file that happened to sit at this path.
-        let Some((recorded, version)) = body.split_once('\n') else {
-            continue;
-        };
-        if recorded == stamp {
-            return Some(version.trim().to_string());
-        }
-    }
-    None
-}
-
 /// Remember a probe verdict. Best effort: a cache that cannot be written is a
 /// slower launch, never a failed one, so every error here is discarded.
 ///
@@ -336,8 +296,89 @@ pub fn write_node_version(node_bin: &Path, stamp: &str, version: &str) {
 /// One file per probed binary, named by the hash of its path so an arbitrary
 /// filesystem path becomes a fixed-width name that cannot escape the directory.
 fn probe_path(base: &Path, node_bin: &Path) -> PathBuf {
-    let name = blake3::hash(node_bin.to_string_lossy().as_bytes()).to_hex();
-    base.join(PROBE_DIR).join(name.as_str())
+    base.join(PROBE_DIR).join(probe_entry_name(node_bin))
+}
+
+/// The entry filename for `node_bin`, independent of which cache root holds it.
+fn probe_entry_name(node_bin: &Path) -> String {
+    blake3::hash(node_bin.to_string_lossy().as_bytes())
+        .to_hex()
+        .to_string()
+}
+
+/// The probe directories one discovery pass may READ, gate-checked once.
+///
+/// The gate walks an ancestor chain — roughly six `symlink_metadata` calls per
+/// root — and the read path used to run it for every candidate root on every
+/// lookup. `--smol` discovery looks up once per installed Node, so a machine
+/// carrying 91 of them ran the walk ~720 times to read at most one small file:
+/// the walk, not the verdict, was the cost.
+///
+/// Its guarantee is per-pass exactly as [`resolve`]'s is — that function
+/// validates one root and threads it through the whole run rather than
+/// re-checking before each use — so this is resolved once and threaded the same
+/// way. Deliberately NOT a process-global memo: `candidates()` reads the
+/// environment, and a `OnceLock` over it would freeze whichever test happened to
+/// call first, which is the shared-mutable-state shape that makes a suite
+/// order-dependent.
+///
+/// ORDER and fall-through are unchanged — a root whose gate fails is dropped
+/// here instead of inside the loop, and a root holding no entry for a given Node
+/// still falls through to the next one.
+pub struct ProbeStore {
+    dirs: Vec<PathBuf>,
+}
+
+impl ProbeStore {
+    /// Gate-check every candidate probe directory, once.
+    pub fn resolve() -> Self {
+        Self {
+            dirs: candidates()
+                .into_iter()
+                .filter_map(|candidate| {
+                    let dir = candidate.path?.join(PROBE_DIR);
+                    // A directory that does not exist yet passes the gate, so a
+                    // pass that writes its first verdict can still read it back.
+                    inspect_existing(&dir).ok()?;
+                    Some(dir)
+                })
+                .collect(),
+        }
+    }
+
+    /// A remembered probe verdict for `node_bin`, if one exists and still applies.
+    ///
+    /// Returns `None` on any doubt — a missing, untrusted, malformed, or stale
+    /// entry all mean "probe it again", which is always correct and merely slower.
+    pub fn read_node_version(&self, node_bin: &Path, stamp: &str) -> Option<String> {
+        // One hash per lookup rather than one per candidate root: the entry name
+        // is a function of the Node path alone.
+        let name = probe_entry_name(node_bin);
+        for base in &self.dirs {
+            let path = base.join(&name);
+            let Ok(metadata) = fs::symlink_metadata(&path) else {
+                continue;
+            };
+            // symlink_metadata, so a symlink planted at this name is rejected
+            // rather than followed to whatever it points at.
+            if !metadata.is_file() || !owner_only(&metadata) {
+                continue;
+            }
+            let Ok(body) = fs::read_to_string(&path) else {
+                continue;
+            };
+            // `<stamp>\n<version>`: the stamp must match the binary as it is NOW,
+            // or this entry describes a different file that happened to sit at
+            // this path.
+            let Some((recorded, version)) = body.split_once('\n') else {
+                continue;
+            };
+            if recorded == stamp {
+                return Some(version.trim().to_string());
+            }
+        }
+        None
+    }
 }
 
 #[cfg(unix)]
@@ -1234,12 +1275,14 @@ mod tests {
 
         write_node_version(&node, "stamp-A", "26.5.0");
         assert_eq!(
-            read_node_version(&node, "stamp-A").as_deref(),
+            ProbeStore::resolve()
+                .read_node_version(&node, "stamp-A")
+                .as_deref(),
             Some("26.5.0"),
             "a verdict written for this stamp must come back"
         );
         assert_eq!(
-            read_node_version(&node, "stamp-B"),
+            ProbeStore::resolve().read_node_version(&node, "stamp-B"),
             None,
             "a DIFFERENT stamp means the binary changed — the old verdict must not \
              be reused, or a replaced Node inherits a version nobody verified"
@@ -1250,7 +1293,7 @@ mod tests {
         let other = base.join("other-node");
         fs::write(&other, b"#!/bin/sh\nexit 0\n").unwrap();
         assert_eq!(
-            read_node_version(&other, "stamp-A"),
+            ProbeStore::resolve().read_node_version(&other, "stamp-A"),
             None,
             "verdicts are per binary path, never shared"
         );
@@ -1285,7 +1328,7 @@ mod tests {
             let entry = probe_path(&base, &node);
             fs::set_permissions(&entry, fs::Permissions::from_mode(0o666)).unwrap();
             assert_eq!(
-                read_node_version(&node, "stamp-A"),
+                ProbeStore::resolve().read_node_version(&node, "stamp-A"),
                 None,
                 "a world-writable verdict must be refused"
             );

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -1244,6 +1244,7 @@ fn acquire_smol_node(
     external_smol: Option<(PathBuf, NodeVersion)>,
 ) -> Result<(PathBuf, NodeVersion, NodeOrigin)> {
     let target = smol_target(m)?;
+    let probes = cache::ProbeStore::resolve();
 
     // 1. nub's Node store, then every version manager's install root. nub's store
     //    is checked first (it is the one nub itself provisioned into), but WITHIN
@@ -1259,7 +1260,7 @@ fn acquire_smol_node(
             return Ok((path, ver, NodeOrigin::Discovered));
         }
         for (path, _) in candidates {
-            if let Some(actual) = probe_node_version(&path) {
+            if let Some(actual) = probe_node_version(&probes, &path) {
                 if smol_candidate_matches(&actual, &target) {
                     return Ok((path, actual, NodeOrigin::Discovered));
                 }
@@ -1419,11 +1420,17 @@ fn discover_external_smol_node(m: &Manifest) -> Result<Option<(PathBuf, NodeVers
         return Ok(trusted);
     }
     ranked.sort_by(|(_, left), (_, right)| right.cmp(left));
+    // Gate-checked once for the whole pass rather than once per candidate: this
+    // loop runs to the END of the ranked list whenever no external Node satisfies
+    // the payload (an exact `--target` the user has not installed is the ordinary
+    // way to hit that), so the per-lookup cost is multiplied by every Node on the
+    // machine.
+    let probes = cache::ProbeStore::resolve();
     let verified = ranked.into_iter().find_map(|(path, _)| {
-        let actual = probe_node_version(&path)?;
+        let actual = probe_node_version(&probes, &path)?;
         smol_candidate_matches(&actual, &target).then_some((path, actual))
     });
-    Ok(verified.or_else(|| probe_path_node(&target)))
+    Ok(verified.or_else(|| probe_path_node(&probes, &target)))
 }
 
 /// Node stores to READ, nearest first: the probed cache base, then the location
@@ -1697,9 +1704,12 @@ fn select_path_node(
 
 /// Resolve `node` on PATH to its path + version, or `None` if absent, unparseable,
 /// or unsuitable for this payload.
-fn probe_path_node(target: &SmolTarget) -> Option<(PathBuf, NodeVersion)> {
+fn probe_path_node(
+    probes: &cache::ProbeStore,
+    target: &SmolTarget,
+) -> Option<(PathBuf, NodeVersion)> {
     let path = which_on_path(node_exe_name())?;
-    let ver = probe_node_version(&path)?;
+    let ver = probe_node_version(probes, &path)?;
     select_path_node((path, ver), target)
 }
 
@@ -1715,10 +1725,10 @@ fn probe_path_node(target: &SmolTarget) -> Option<(PathBuf, NodeVersion)> {
 ///
 /// A stale or untrusted entry simply means another exec, so every failure path here
 /// is the slow answer rather than a wrong one.
-fn probe_node_version(path: &Path) -> Option<NodeVersion> {
+fn probe_node_version(probes: &cache::ProbeStore, path: &Path) -> Option<NodeVersion> {
     let stamp = node_binary_stamp(path);
     if let Some(stamp) = &stamp {
-        if let Some(version) = cache::read_node_version(path, stamp) {
+        if let Some(version) = probes.read_node_version(path, stamp) {
             if let Ok(parsed) = version.parse() {
                 phase_with(|| format!("  probe cache HIT: {}", path.display()));
                 return Some(parsed);
@@ -2983,7 +2993,7 @@ mod tests {
         let (owned, candidates) = best_node_in(dir, target, triple);
         owned.or_else(|| {
             candidates.into_iter().find_map(|(path, _)| {
-                let actual = probe_node_version(&path)?;
+                let actual = probe_node_version(&cache::ProbeStore::resolve(), &path)?;
                 smol_candidate_matches(&actual, target).then_some((path, actual))
             })
         })
@@ -4503,7 +4513,7 @@ mod tests {
         // And the control for the claim above: these fixtures really are unprobeable,
         // so the assertions cannot be passing because probing happens to succeed.
         assert!(
-            probe_node_version(&ranked[0].0).is_none(),
+            probe_node_version(&cache::ProbeStore::resolve(), &ranked[0].0).is_none(),
             "the fixture must be unprobeable, otherwise this test proves nothing"
         );
         let _ = fs::remove_dir_all(&base);


### PR DESCRIPTION
Warm-start work following #846, which landed the exec launcher and the sealed-graph flag skip. One cost is fixed here; the rest of what the investigation found is recorded below rather than changed.

## The namespace gate ran once per lookup

Reading one remembered `--smol` probe verdict walked the ancestor chain of every candidate cache root — roughly six `symlink_metadata` calls each — to read at most one small file. Discovery calls that once per installed Node, so on a host carrying 91 of them a warm start ran the walk about 720 times. The walk, rather than the verdict, was the cost.

The gate's guarantee is per-pass, exactly as `cache::resolve`'s is: that function validates one root and threads it through the whole run rather than re-checking before each use. The probe directories are now resolved once into a `ProbeStore` and threaded the same way, leaving each lookup a stat and a read. Order and fall-through are unchanged.

Not a process-global memo: `candidates()` reads the environment and this crate's own tests mutate `__NUB_COMPILE_CACHE_DIR`, so a `OnceLock` over it would freeze whichever test called first and make the suite order-dependent.

Warm `--smol` pre-spawn **10.92 → 8.10 ms** as a mean over ten interleaved pairs on one host, per lookup **40.3 → 25.9 us**. The embed shape does not probe and is untouched.

## Overlap with #830

The same investigation found duplicate version-manager roots — `NVM_DIR=$HOME/.nvm` colliding with the `~/.nvm` fallback, so all 91 Nodes were enumerated and probed twice. #830 already fixes exactly that as `dedupe_node_dirs`, so that half was dropped from this branch rather than landed twice. The two compose: #830 halves the number of lookups, this halves the cost of each.

One difference worth a look while #830 is open — its dedupe is lexical by design, so a manager reached through a symlinked spelling is still scanned twice. That is a deliberate call in its doc comment (a syscall per root to catch a shape no default layout produces) and is left alone here.

## Verification

- Launcher gates green: `clippy --all-targets -- -D warnings`, `fmt --check`, 75 tests, release build. `cargo metadata --locked` clean — no dependency change.
- Selection is unchanged: an artifact whose target is satisfied by an installed Node picks the same Node before and after (v26.7.0 either way), and `process.execPath` still reports the outer executable.
- Exercised `--smol` at exact, major and range targets. Exit code 42 propagates, SIGTERM gives 143, SIGINT reaches the handler and gives 130, stdout through `head` is clean.
- `new Worker(new URL('./w.mjs', import.meta.url))` and `child_process.fork(url, args)` match plain Node exactly.

## Two findings for the record

**The eight `--experimental-*` flags are free — do not spend a manifest field on them.** Emitting only the flags a bundle needs was on the table for this work. Measured on a real artifact at n=240, adding `--disable-warning=ExperimentalWarning`, the seven `--experimental-*` flags and `--enable-source-maps` to the child costs **+0.01 ms** of CPU. The positive control in the same run, `--js-defer-import-eval`, costs +6.04 ms, which independently confirms #846's figure and shows the instrument works. Those flags are Node-level rather than V8-level, so they do not forfeit the startup snapshot the way the V8 flag did. Recording a needed-flag set would add a payload field and a compile-time analysis, and carry a wrongly-dropped-flag breakage risk, to buy nothing.

**Where the remaining embed overhead sits.** Post-#846, over plain `node hello.js` at n=240: launcher image ~4.2 ms, launcher pre-spawn ~1.2 ms, the `--require` bootstrap ~2.0 ms, the emitted bundle ~4.0 ms, flags ~0.7 ms (noise). Artifact size is not a factor — pre-main cost is 4.15 ms for the 29.5 MB embed binary and 4.06 ms for the 0.9 MB smol one, so shrinking artifacts will not help warm start. The largest addressable item is the bundle: `runtime/polyfills.cjs` ships 47.7 KB minified into every artifact and installs DisposableStack, the Iterator surface, `RegExp.escape`, `Promise.try`, Set methods, `Array.fromAsync` and more, all native on Node 26 and all still parsed and run. The `nub:polyfill:<name>` region mechanism and `strip_native_polyfills` already exist but cover only the five npm-backed polyfills. Extending them needs a per-polyfill native-since floor and has to respect `--smol`'s floor target rather than the probed version, so it is left for a decision rather than taken here.

## The announcement post's startup chart

#826 charts warm startup at 58.1 ms for the embed shape and 60.5 ms for `--smol`. Both #846 and this change move the `--smol` number, and #846 moves the embed number, so that chart needs re-measuring before v0.9 ships. Not edited here.

Refs #846, #830, #826
