### PR TITLE
pm: fix npm workspace importer detection, and give afterAllResolved pnpm's lockfile shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "aube-manifest",
  "aube-settings",
  "aube-util",
+ "aube-workspace",
  "base64",
  "blake3",
  "glob",

--- a/vendor/aube/Cargo.lock
+++ b/vendor/aube/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "aube-manifest",
  "aube-settings",
  "aube-util",
+ "aube-workspace",
  "base64",
  "blake3",
  "criterion",

--- a/vendor/aube/crates/aube-codes/src/warnings.rs
+++ b/vendor/aube/crates/aube-codes/src/warnings.rs
@@ -194,7 +194,7 @@ pub const ALL: &[CodeMeta] = &[
     CodeMeta {
         name: WARN_AUBE_HOOK_IDENTITY_REWRITTEN,
         category: category::PNPMFILE_HOOKS,
-        description: "A pnpmfile hook rewrote a package's `(name, version)` identity; aube reverted the edit.",
+        description: "A pnpmfile hook edited a package field that is fixed by resolution (`resolution`, `engines`, identity); aube applies only `dependencies` and `peerDependencies` and reverted the rest.",
         exit_code: None,
     },
     CodeMeta {

--- a/vendor/aube/crates/aube-lockfile/Cargo.toml
+++ b/vendor/aube/crates/aube-lockfile/Cargo.toml
@@ -15,6 +15,12 @@ aube-codes = { workspace = true }
 aube-manifest = { workspace = true }
 aube-settings = { workspace = true }
 aube-util = { workspace = true }
+# For `matches_member_patterns`: the npm reader has to tell a workspace
+# member apart from a local directory dependency, and only the manifest's
+# `workspaces` patterns can say which is which. Sharing the walk's own
+# matcher keeps the two from drifting. aube-workspace does not depend on
+# aube-lockfile, so this edge is acyclic.
+aube-workspace = { workspace = true }
 base64 = { workspace = true }
 glob = { workspace = true }
 miette = { workspace = true }

--- a/vendor/aube/crates/aube-lockfile/src/npm/raw.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/raw.rs
@@ -98,6 +98,13 @@ pub(super) struct RawNpmPackage {
     pub(super) resolved: Option<String>,
     #[serde(default)]
     pub(super) link: bool,
+    /// Root importer only. npm mirrors the manifest's `workspaces` here,
+    /// which is what lets the reader tell a member apart from a local
+    /// directory dependency — the two are otherwise identical in shape.
+    /// Read as the parsed enum so the array, bun object, and string forms
+    /// all yield their patterns.
+    #[serde(default)]
+    pub(super) workspaces: Option<aube_manifest::Workspaces>,
     #[serde(default)]
     pub(super) dependencies: BTreeMap<String, String>,
     #[serde(default)]

--- a/vendor/aube/crates/aube-lockfile/src/npm/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/read.rs
@@ -425,8 +425,49 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
     // `packages/app`, ...) carries that package's own dependency sections.
     // Preserve those target paths as graph importers so install/link and a
     // later package-lock rewrite keep each workspace's node_modules tree.
+    //
+    // But only for targets that are actually MEMBERS. npm writes the very
+    // same pair for a local directory dependency — `vendor/local` gets a
+    // bare `name`/`version` entry plus a `link: true` record — so taking
+    // every link target registered phantom importers for paths outside the
+    // workspace. `drift` then compared them against the real member list
+    // and failed every `--frozen-lockfile` with `workspace importer
+    // vendor/local is in the lockfile but not in the workspace`, including
+    // against lockfiles npm itself had written.
+    //
+    // The shapes are identical in the lockfile — a root importer's own
+    // `file:./dep` also produces a root link record — so the manifest's
+    // `workspaces` patterns are the only thing that can decide. A
+    // non-member still becomes a proper local-source package via the link
+    // entry's own synthesis pass above; it just stops pretending to be an
+    // importer.
+    // The LOCKFILE's own copy comes first: npm mirrors `workspaces` into
+    // `packages[""]`, so a lockfile is self-describing and a caller that
+    // passes a bare manifest still gets the right answer. The manifest is
+    // the fallback for a lockfile written before that field was emitted.
+    //
+    // When NEITHER carries patterns, keep every link target, exactly as
+    // before. That is the conservative direction on purpose: dropping a
+    // real member costs it its importer entry and breaks its install,
+    // while keeping a stray one only reproduces the pre-existing
+    // behaviour. It is also the case for a workspace whose members are
+    // declared outside package.json (a `pnpm-workspace.yaml` project
+    // converted to npm format), where absence of patterns says nothing
+    // about whether members exist.
+    let member_patterns: Vec<String> = raw
+        .packages
+        .get("")
+        .and_then(|root| root.workspaces.as_ref())
+        .or(manifest.workspaces.as_ref())
+        .map(|w| w.patterns().to_vec())
+        .unwrap_or_default();
     for target in &link_targets {
         if target.is_empty() {
+            continue;
+        }
+        if !member_patterns.is_empty()
+            && !aube_workspace::matches_member_patterns(target, &member_patterns)
+        {
             continue;
         }
         let Some(package_entry) = raw.packages.get(target) else {

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -2419,6 +2419,80 @@ fn test_parse_npm_workspace_importers() {
     }));
 }
 
+/// A local directory dependency's target is NOT a workspace importer,
+/// even though npm records it with the same shape as one.
+///
+/// npm keys both a member (`packages/app`) and a `file:` target
+/// (`vendor/local`) as a bare path carrying `name`/`version`, and gives
+/// both a `link: true` record. Taking every link target as an importer
+/// registered `vendor/local` as a phantom workspace member, and the
+/// freshness check then rejected the lockfile — `workspace importer
+/// vendor/local is in the lockfile but not in the workspace` — on every
+/// `--frozen-lockfile`, INCLUDING against lockfiles npm itself wrote.
+///
+/// The root entry's own `workspaces` patterns are what separate them, so
+/// the fixture below is shaped exactly as npm writes it: a braced pattern
+/// and a negation, to pin that the reader shares the discovery walk's
+/// matching rather than doing something simpler.
+#[test]
+fn test_parse_npm_local_dep_target_is_not_a_workspace_importer() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+            "name": "root",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "root",
+                    "version": "1.0.0",
+                    "workspaces": ["packages/*", "tools/{a,b}", "!packages/skipped"]
+                },
+                "node_modules/@w/app": { "resolved": "packages/app", "link": true },
+                "node_modules/@w/tool": { "resolved": "tools/b", "link": true },
+                "node_modules/@w/skipped": { "resolved": "packages/skipped", "link": true },
+                "packages/app": {
+                    "name": "@w/app",
+                    "version": "1.0.0",
+                    "dependencies": { "shared": "file:../../vendor/local" }
+                },
+                "packages/skipped": { "name": "@w/skipped", "version": "1.0.0" },
+                "tools/b": { "name": "@w/tool", "version": "1.0.0" },
+                "vendor/local": { "name": "shared", "version": "1.0.0" },
+                "packages/app/node_modules/shared": {
+                    "resolved": "vendor/local",
+                    "link": true
+                }
+            }
+        }"#;
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let graph = parse(tmp.path()).unwrap();
+
+    assert!(
+        graph.importers.contains_key("packages/app"),
+        "a globbed member stays an importer, got {:?}",
+        graph.importers.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        graph.importers.contains_key("tools/b"),
+        "a BRACED member stays an importer -- excluding one breaks its \
+         install, which is the expensive direction, got {:?}",
+        graph.importers.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !graph.importers.contains_key("vendor/local"),
+        "a local dep target must not be registered as a workspace \
+         importer, got {:?}",
+        graph.importers.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !graph.importers.contains_key("packages/skipped"),
+        "a negated pattern excludes the member, matching the discovery \
+         walk, got {:?}",
+        graph.importers.keys().collect::<Vec<_>>()
+    );
+}
+
 #[test]
 fn test_parse_npm_workspace_importer_keeps_nested_conflicting_direct_dep() {
     let tmp = tempfile::NamedTempFile::new().unwrap();

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/hook_view.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/hook_view.rs
@@ -18,6 +18,8 @@
 //! `pnpm-lock.yaml` — a hook that rewrites a resolution URL is looking
 //! at the URL the lockfile will actually carry.
 
+use std::collections::BTreeMap;
+
 use aube_manifest::PackageJson;
 use serde_json::{Map, Value};
 
@@ -38,16 +40,39 @@ pub fn lockfile_object(
     graph: &LockfileGraph,
     manifest: &PackageJson,
 ) -> Result<Value, Error> {
-    let writable = super::write::build(&lockfile_dir.join("pnpm-lock.yaml"), graph, manifest)?;
-    let mut value = serde_json::to_value(&writable)
+    lockfile_object_with_keys(lockfile_dir, graph, manifest).map(|(value, _)| value)
+}
+
+/// [`lockfile_object`], plus the map from a projected `packages` key back
+/// to the graph `dep_path` it was derived from.
+///
+/// Only a hook whose result is applied BACK to the graph needs this, and
+/// `afterAllResolved` is that hook. It is handed pnpm's spelling of every
+/// key, so without the correspondence an edit to
+/// `packages["is-obj@https://codeload…/tar.gz/<sha>"]` cannot be matched
+/// against the graph's `is-obj@url+f5ca9b17a622e185`. A registry package
+/// spells the two identically, which is exactly why a map reconstructed
+/// by guesswork looks right until the first git or remote-tarball
+/// dependency arrives.
+///
+/// The keys are SNAPSHOT keys because that is what the merge below keys
+/// the projected `packages` map by; a `packages:` entry no snapshot
+/// references drops out of the view entirely and has nothing to map.
+pub fn lockfile_object_with_keys(
+    lockfile_dir: &std::path::Path,
+    graph: &LockfileGraph,
+    manifest: &PackageJson,
+) -> Result<(Value, BTreeMap<String, String>), Error> {
+    let built = super::write::build(&lockfile_dir.join("pnpm-lock.yaml"), graph, manifest)?;
+    let mut value = serde_json::to_value(&built.lockfile)
         .map_err(|e| Error::parse(lockfile_dir, format!("failed to project lockfile: {e}")))?;
     let Some(root) = value.as_object_mut() else {
-        return Ok(value);
+        return Ok((value, built.snapshot_keys));
     };
     merge_snapshots_into_packages(root);
     flatten_patched_dependencies(root);
     revert_importers(root);
-    Ok(value)
+    Ok((value, built.snapshot_keys))
 }
 
 /// The object pnpm synthesizes when there is no lockfile on disk
@@ -278,7 +303,10 @@ mod tests {
             "pnpm's createLockfileObject stamps the effective cap; a hook \
              reading it must not get undefined"
         );
-        assert_eq!(root["importers"]["."]["specifiers"], Value::Object(Map::new()));
+        assert_eq!(
+            root["importers"]["."]["specifiers"],
+            Value::Object(Map::new())
+        );
         assert_eq!(
             root["importers"]["."]["dependencies"],
             Value::Object(Map::new())

--- a/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/pnpm/write.rs
@@ -65,7 +65,7 @@ mod tests {
 
 /// Write a LockfileGraph as pnpm-lock.yaml v9 format.
 pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Result<(), Error> {
-    let lockfile = build(path, graph, manifest)?;
+    let Built { lockfile, .. } = build(path, graph, manifest)?;
     let yaml = yaml_serde::to_string(&lockfile).map_err(|e| Error::parse(path, e.to_string()))?;
     let yaml = reformat_for_pnpm_parity(&yaml);
     // Atomic via tempfile + persist. Crash, Ctrl+C, or AV
@@ -84,11 +84,29 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
 /// alias recovery and all — instead of a second, drifting one.
 /// `path` decides `pnpm-lock.yaml`-only behavior (native alias
 /// encoding) and roots the workspace-member manifest reads.
+/// [`build`]'s output: the projection, plus the key correspondence a
+/// pnpmfile hook round-trip needs.
+pub(super) struct Built {
+    pub lockfile: WritablePnpmLockfile,
+    /// `snapshots:` key -> the graph `dep_path` it was derived from.
+    ///
+    /// The two spellings diverge for anything that is not a plain
+    /// registry dep: pnpm keys on the resolved specifier
+    /// (`is-obj@https://codeload…/tar.gz/<sha>`) while the graph keys on
+    /// an FS-safe hashed dep_path (`is-obj@url+f5ca9b17a622e185`). A
+    /// hook is handed the pnpm spelling, so an edit it makes to
+    /// `packages[<pnpm key>]` cannot be applied back to the graph
+    /// without this map. Derived in the snapshot loop below, where both
+    /// spellings are in hand, rather than re-computed by a second copy
+    /// of the key rules that could drift from it.
+    pub snapshot_keys: BTreeMap<String, String>,
+}
+
 pub(super) fn build(
     path: &Path,
     graph: &LockfileGraph,
     manifest: &PackageJson,
-) -> Result<WritablePnpmLockfile, Error> {
+) -> Result<Built, Error> {
     let native_pnpm_aliases = path
         .file_name()
         .and_then(|name| name.to_str())
@@ -792,6 +810,7 @@ pub(super) fn build(
             .collect()
     };
     let mut snapshots = BTreeMap::new();
+    let mut snapshot_keys = BTreeMap::new();
     for (dep_path, pkg) in &graph.packages {
         // `link:` deps are omitted from snapshots (pnpm parity). `exec:`
         // is omitted for the same reason it is omitted from packages:
@@ -813,6 +832,7 @@ pub(super) fn build(
             }
         };
         key = decorate_patch_hash(&key, Some(pkg));
+        snapshot_keys.insert(key.clone(), dep_path.clone());
         let pkg_deps = rewrite_local_deps(pkg.dependencies.clone());
         let pkg_opt_deps = rewrite_local_deps(pkg.optional_dependencies.clone());
         snapshots.insert(
@@ -977,7 +997,10 @@ pub(super) fn build(
         snapshots,
     };
 
-    Ok(lockfile)
+    Ok(Built {
+        lockfile,
+        snapshot_keys,
+    })
 }
 
 fn registry_tarball_url_is_not_derivable(

--- a/vendor/aube/crates/aube-workspace/src/lib.rs
+++ b/vendor/aube/crates/aube-workspace/src/lib.rs
@@ -238,13 +238,18 @@ fn validate_workspace_pattern(
 /// entry and its install breaks — while an over-inclusive answer only
 /// reproduces the phantom-importer bug the caller is fixing.
 ///
-/// The two halves match with DIFFERENT options, because the walk does.
-/// It expands positives through `glob::glob` on the filesystem, where a
-/// `*` cannot span a directory boundary, but tests negatives with
-/// `Pattern::matches_path`, which by default lets one span freely. That
-/// asymmetry is the walk's, not an oversight here; copying it is what
-/// keeps the two answering alike.
+/// Positives and negatives match with DIFFERENT options, and positives
+/// with two different sets again depending on the pattern, because the
+/// walk does. That asymmetry is the walk's, not an oversight here;
+/// copying it is what keeps the two answering alike, and every attempt
+/// to tidy it into one uniform rule has desynchronised them.
+/// [`pattern_matches_path`] carries the breakdown.
 pub fn matches_member_patterns(path: &str, patterns: &[String]) -> bool {
+    // Both discovery branches skip `node_modules` outright, so no path
+    // under one is ever a member however well it matches.
+    if path.split('/').any(|component| component == "node_modules") {
+        return false;
+    }
     let mut matched = false;
     for raw in patterns {
         let (negated, pattern) = raw
@@ -283,60 +288,68 @@ pub fn matches_member_patterns(path: &str, patterns: &[String]) -> bool {
 
 /// One expanded (brace-free, sign-free) POSITIVE pattern against one path.
 ///
-/// Reproducing the walk lexically takes two corrections, both measured
-/// against `find_workspace_packages` on the same inputs, and getting
-/// either wrong desynchronises the two.
+/// **`expand_workspace_pattern` has TWO branches and they disagree, so
+/// this picks between them the same way it does — on whether the pattern
+/// contains `**`.** Treating positives as one uniform case is what made
+/// earlier versions of this wrong in both directions at once.
 ///
-/// **Separators.** The walk expands positives through `glob::glob` on the
-/// filesystem, which cannot let a `*` span a directory boundary. Matching
-/// a string with `Pattern::matches` can: it defaults
-/// `require_literal_separator` to false, so `packages/*` also matches
-/// `packages/app/vendor/local` — a nested local dependency, which is
-/// exactly the thing the caller is trying to exclude. Hence the strict
-/// option here.
+/// - No `**`: discovery joins the pattern onto a real directory and hands
+///   it to `glob::glob`, so a `*` cannot span a directory boundary, and
+///   the FILESYSTEM resolves the spelling — `./packages/*`, `packages/./*`
+///   and `packages/*/` all find `packages/app`. A lexical matcher gets no
+///   such help, so it normalises first.
+/// - With `**`: discovery walks `read_dir` and tests each path with
+///   `Pattern::matches_path`, whose default lets a `*` span freely, and it
+///   compiles the pattern VERBATIM. So `packages/*/leaf/**` really does
+///   reach `packages/a/b/leaf/x`, and normalising the spelling here would
+///   match paths discovery misses.
 ///
-/// **Spelling.** The walk joins the pattern onto a real directory, so the
-/// filesystem normalises `./packages/*` and `packages/*/` for it and both
-/// find `packages/app`. A string comparison gets no such help and matches
-/// NEITHER, which would drop a real member and break its install — the
-/// expensive direction. So normalise the spelling first.
+/// `case_sensitive` is spelled out rather than inherited from `Default`.
+/// `MatchOptions` DERIVES `Default`, which yields `case_sensitive: false`,
+/// while every discovery path uses `MatchOptions::new()`, which is `true`
+/// — the crate documents that mismatch on `new()` as a FIXME. Inheriting
+/// it made this matcher silently case-insensitive, so a differently-cased
+/// path stayed a phantom importer.
 ///
-/// The `**` companion below is a third divergence, already handled: the
-/// `glob` crate requires `**` to consume at least one component, while
-/// the micromatch semantics pnpm and npm use let it match zero, so
-/// `packages/**` names `packages` itself as well as its descendants.
+/// There is deliberately NO `/**`-stripped companion here, unlike the
+/// negation half. The walk builds one only for its negation matchers; its
+/// positive recursive branch has none, and `read_dir` never tests the walk
+/// root itself, so `packages/**` does not name `packages`. Adding one
+/// looked symmetric and over-matched.
 fn pattern_matches_path(pattern: &str, path: &str) -> bool {
-    // `**` is deliberately still allowed to cross separators — that is its
-    // whole purpose, and the strict option only constrains `*` and `?`.
+    let recursive = pattern.contains("**");
     let options = glob::MatchOptions {
-        require_literal_separator: true,
-        ..Default::default()
+        case_sensitive: true,
+        require_literal_separator: !recursive,
+        require_literal_leading_dot: false,
     };
-    let normalized = normalize_member_pattern(pattern);
-    let Ok(matcher) = glob::Pattern::new(normalized) else {
-        return false;
+    let normalized;
+    let effective = if recursive {
+        pattern
+    } else {
+        normalized = normalize_member_pattern(pattern);
+        normalized.as_str()
     };
-    if matcher.matches_with(path, options) {
-        return true;
-    }
-    normalized
-        .strip_suffix("/**")
-        .and_then(|self_form| glob::Pattern::new(self_form).ok())
-        .is_some_and(|m| m.matches_with(path, options))
+    glob::Pattern::new(effective).is_ok_and(|m| m.matches_with(path, options))
 }
 
 /// Render a workspace pattern in the same frame as a lockfile importer
-/// key: no leading `./`, no trailing `/`.
+/// key: no `.` components, no empty ones, no trailing slash.
 ///
-/// npm accepts and preserves both spellings, and the discovery walk never
-/// has to care because it hands the pattern to the filesystem. A lexical
-/// matcher does.
-fn normalize_member_pattern(pattern: &str) -> &str {
-    let mut p = pattern;
-    while let Some(rest) = p.strip_prefix("./") {
-        p = rest;
-    }
-    p.strip_suffix('/').unwrap_or(p)
+/// This is what the filesystem does for the non-recursive discovery
+/// branch when it joins the pattern onto a real directory, which is why
+/// `./packages/*`, `packages/./*` and `packages/*/` all find
+/// `packages/app` there. A lexical matcher has to do it explicitly.
+///
+/// Splitting on `/` is safe for glob metacharacters: a `.` is only dropped
+/// when it is a WHOLE component, never when it sits inside one, and `..`
+/// is preserved because parent-relative patterns (`../**`) are supported.
+fn normalize_member_pattern(pattern: &str) -> String {
+    pattern
+        .split('/')
+        .filter(|component| !component.is_empty() && *component != ".")
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 fn expand_braces(pattern: &str) -> Vec<String> {
@@ -579,7 +592,9 @@ mod tests {
             "packages",
             "packages/app",
             "packages/app/vendor/local",
+            "packages/app/node_modules/dep",
             "packages/skipped",
+            "packages/a/b/leaf/x",
         ];
         for sub in universe {
             write(
@@ -591,16 +606,18 @@ mod tests {
             );
         }
 
-        let cases: [(&[&str], &[&str]); 6] = [
+        let cases: [(&[&str], &[&str]); 10] = [
             // A single `*` must not span a directory boundary, or the
             // nested local dep is retained as a phantom importer.
             (&["packages/*"], &["packages/app", "packages/skipped"]),
-            // Two spellings npm accepts and preserves. The walk hands each
-            // to the filesystem, which normalises it; a lexical matcher
-            // gets no such help, so both matched NOTHING before the fix --
-            // dropping real members.
+            // Three spellings npm accepts and preserves. The non-recursive
+            // discovery branch joins the pattern onto a real directory, so
+            // the filesystem resolves every one of them; a lexical matcher
+            // gets no such help and matched NOTHING before it normalised
+            // -- dropping real members, the expensive direction.
             (&["./packages/*"], &["packages/app", "packages/skipped"]),
             (&["packages/*/"], &["packages/app", "packages/skipped"]),
+            (&["packages/./*"], &["packages/app", "packages/skipped"]),
             (&["packages/*", "!packages/skipped"], &["packages/app"]),
             // The walk does NOT normalise a negation's spelling, so this
             // one excludes nothing. Normalising it here would drop a real
@@ -614,6 +631,30 @@ mod tests {
             // component, so the walk compiles a companion matcher with the
             // trailing `/**` stripped, and so must this.
             (&["*", "!packages/**"], &[]),
+            // The RECURSIVE branch, which discovery selects on the pattern
+            // containing `**` and matches with `Pattern::matches_path` --
+            // whose default lets a `*` span separators. Forcing literal
+            // separators on EVERY positive dropped the nested member here.
+            (&["packages/*/leaf/**"], &["packages/a/b/leaf/x"]),
+            // That branch also compiles the pattern VERBATIM, so the `./`
+            // spelling finds nothing, even though the non-recursive branch
+            // above resolves it through the filesystem. Normalising both
+            // alike would match what discovery misses.
+            (&["./packages/**"], &[]),
+            // `packages` itself is NOT named by `packages/**`: discovery
+            // read_dirs FROM the pattern root, so it never tests the root,
+            // and `glob` needs `**` to consume a component. A positive
+            // `/**` companion mirroring the negation half over-matched it.
+            // `node_modules` is skipped outright by both branches.
+            (
+                &["packages/**"],
+                &[
+                    "packages/a/b/leaf/x",
+                    "packages/app",
+                    "packages/app/vendor/local",
+                    "packages/skipped",
+                ],
+            ),
         ];
 
         for (patterns, expected_walk) in cases {
@@ -648,6 +689,32 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Case is asserted LEXICALLY rather than through the walk, on
+    /// purpose: macOS ships a case-insensitive volume by default while CI
+    /// runs on Linux, so a filesystem fixture would make the walk's answer
+    /// a property of the volume rather than of the pattern language, and
+    /// the comparison would mean different things on the two.
+    ///
+    /// What is pinned here is the pattern language: every discovery path
+    /// matches through `MatchOptions::new()`, which is case-SENSITIVE.
+    /// `MatchOptions` also derives `Default`, whose `case_sensitive` is
+    /// `false` — the crate documents the mismatch as a FIXME — so a
+    /// `..Default::default()` here silently made matching insensitive and
+    /// kept a differently-cased path as a phantom importer.
+    #[test]
+    fn member_matching_is_case_sensitive() {
+        let patterns = vec!["packages/*".to_string()];
+        assert!(
+            matches_member_patterns("packages/app", &patterns),
+            "the exact spelling must match"
+        );
+        let shouty = vec!["PACKAGES/*".to_string()];
+        assert!(
+            !matches_member_patterns("packages/app", &shouty),
+            "a differently-cased pattern must not match, as `MatchOptions::new()` would not"
+        );
     }
 
     #[test]

--- a/vendor/aube/crates/aube-workspace/src/lib.rs
+++ b/vendor/aube/crates/aube-workspace/src/lib.rs
@@ -334,22 +334,36 @@ fn pattern_matches_path(pattern: &str, path: &str) -> bool {
 }
 
 /// Render a workspace pattern in the same frame as a lockfile importer
-/// key: no `.` components, no empty ones, no trailing slash.
+/// key: no `.` components, no empty ones, no trailing slash, and an
+/// in-root `normal/..` pair collapsed.
 ///
 /// This is what the filesystem does for the non-recursive discovery
 /// branch when it joins the pattern onto a real directory, which is why
 /// `./packages/*`, `packages/./*` and `packages/*/` all find
 /// `packages/app` there. A lexical matcher has to do it explicitly.
 ///
-/// Splitting on `/` is safe for glob metacharacters: a `.` is only dropped
-/// when it is a WHOLE component, never when it sits inside one, and `..`
-/// is preserved because parent-relative patterns (`../**`) are supported.
+/// Splitting on `/` is safe for glob metacharacters: `.` and `..` are only
+/// ever acted on as a WHOLE component, never inside one.
+///
+/// A LEADING `..` has nothing to pop and must survive. The two cases are
+/// genuinely different frames rather than two spellings of one: npm
+/// accepts `packages/../apps/*`, discovers `apps/a` and keys it `apps/a`,
+/// so failing to collapse that dropped a real importer — while `../**`
+/// deliberately reaches OUTSIDE the project, and the walk renders what it
+/// finds there as `../sibling`. Collapsing the first and preserving the
+/// second is what keeps both answers right.
 fn normalize_member_pattern(pattern: &str) -> String {
-    pattern
-        .split('/')
-        .filter(|component| !component.is_empty() && *component != ".")
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut components: Vec<&str> = Vec::new();
+    for component in pattern.split('/') {
+        match component {
+            "" | "." => {}
+            ".." if matches!(components.last(), Some(&last) if last != "..") => {
+                components.pop();
+            }
+            other => components.push(other),
+        }
+    }
+    components.join("/")
 }
 
 fn expand_braces(pattern: &str) -> Vec<String> {
@@ -714,6 +728,28 @@ mod tests {
         assert!(
             !matches_member_patterns("packages/app", &shouty),
             "a differently-cased pattern must not match, as `MatchOptions::new()` would not"
+        );
+    }
+
+    /// An in-root `normal/..` pair collapses; a leading `..` does not.
+    ///
+    /// Asserted lexically rather than through the walk because the two
+    /// render in different frames, which is the whole point. npm accepts
+    /// `packages/../apps/*`, discovers `apps/a` and keys it `apps/a` in
+    /// the lockfile, so the matcher has to answer for `apps/a` — whereas
+    /// the walk hands its caller an absolute path that `pathdiff` renders
+    /// back as `packages/../apps/a`. Comparing those two spellings would
+    /// be testing the rendering, not the membership question the npm
+    /// reader actually asks.
+    #[test]
+    fn in_root_parent_components_collapse_but_leading_ones_do_not() {
+        assert!(
+            matches_member_patterns("apps/a", &["packages/../apps/*".to_string()]),
+            "npm keys this member `apps/a`; not collapsing the `..` dropped a real importer"
+        );
+        assert!(
+            !matches_member_patterns("apps/a", &["../apps/*".to_string()]),
+            "a leading `..` points outside the project and must not collapse into `apps/*`"
         );
     }
 

--- a/vendor/aube/crates/aube-workspace/src/lib.rs
+++ b/vendor/aube/crates/aube-workspace/src/lib.rs
@@ -216,6 +216,69 @@ fn validate_workspace_pattern(
     Ok(())
 }
 
+/// Does `path` name a workspace member under `patterns`?
+///
+/// `path` is project-root-relative with `/` separators — the spelling an
+/// importer key already uses. Purely lexical: no filesystem access, so a
+/// caller holding only a lockfile and a manifest can ask the question.
+///
+/// This exists because a `package-lock.json` CANNOT answer it. npm keys
+/// both a workspace member (`packages/app`) and a local directory
+/// dependency (`vendor/local`) as a bare path carrying `name`/`version`,
+/// and either may hold a root `node_modules/<name>` link record — a root
+/// importer's own `file:./dep` is indistinguishable from a member by
+/// shape alone. The manifest's `workspaces` patterns are the only real
+/// source of truth, so the reader matches against them here rather than
+/// guessing from the lockfile.
+///
+/// Shares the discovery walk's semantics deliberately: braces expand
+/// first, a `!` prefix negates, and a match requires some positive
+/// pattern and no negative one. Getting that wrong in the exclusive
+/// direction is the expensive one — a real member judged a non-member
+/// loses its importer entry and its install breaks — so the `**`
+/// companion-matcher compensation below matters as much here as it does
+/// there.
+pub fn matches_member_patterns(path: &str, patterns: &[String]) -> bool {
+    let mut matched = false;
+    for raw in patterns {
+        let (negated, pattern) = raw
+            .strip_prefix('!')
+            .map_or((false, raw.as_str()), |p| (true, p));
+        for expanded in expand_braces(pattern) {
+            if !pattern_matches_path(&expanded, path) {
+                continue;
+            }
+            if negated {
+                // A later exclusion wins outright, matching the walk.
+                return false;
+            }
+            matched = true;
+        }
+    }
+    matched
+}
+
+/// One expanded (brace-free, sign-free) pattern against one path.
+///
+/// The `glob` crate requires `**` to consume at least one component,
+/// while the micromatch semantics pnpm and npm use let it match zero — so
+/// `packages/**` names the `packages` directory itself as well as its
+/// descendants. `expand_workspace_pattern` compensates with a companion
+/// matcher for the trailing `/**` form; do the same here so the two agree
+/// about which directories are members.
+fn pattern_matches_path(pattern: &str, path: &str) -> bool {
+    let Ok(matcher) = glob::Pattern::new(pattern) else {
+        return false;
+    };
+    if matcher.matches(path) {
+        return true;
+    }
+    pattern
+        .strip_suffix("/**")
+        .and_then(|self_form| glob::Pattern::new(self_form).ok())
+        .is_some_and(|m| m.matches(path))
+}
+
 fn expand_braces(pattern: &str) -> Vec<String> {
     let mut depth = 0;
     let mut open = None;

--- a/vendor/aube/crates/aube-workspace/src/lib.rs
+++ b/vendor/aube/crates/aube-workspace/src/lib.rs
@@ -231,13 +231,19 @@ fn validate_workspace_pattern(
 /// source of truth, so the reader matches against them here rather than
 /// guessing from the lockfile.
 ///
-/// Shares the discovery walk's semantics deliberately: braces expand
-/// first, a `!` prefix negates, and a match requires some positive
-/// pattern and no negative one. Getting that wrong in the exclusive
-/// direction is the expensive one — a real member judged a non-member
-/// loses its importer entry and its install breaks — so the `**`
-/// companion-matcher compensation below matters as much here as it does
-/// there.
+/// Reproduces the discovery walk's semantics: braces expand first, a `!`
+/// prefix negates, and a match needs some positive pattern and no
+/// negative one. Getting that wrong in the EXCLUSIVE direction is the
+/// expensive one — a real member judged a non-member loses its importer
+/// entry and its install breaks — while an over-inclusive answer only
+/// reproduces the phantom-importer bug the caller is fixing.
+///
+/// The two halves match with DIFFERENT options, because the walk does.
+/// It expands positives through `glob::glob` on the filesystem, where a
+/// `*` cannot span a directory boundary, but tests negatives with
+/// `Pattern::matches_path`, which by default lets one span freely. That
+/// asymmetry is the walk's, not an oversight here; copying it is what
+/// keeps the two answering alike.
 pub fn matches_member_patterns(path: &str, patterns: &[String]) -> bool {
     let mut matched = false;
     for raw in patterns {
@@ -245,38 +251,92 @@ pub fn matches_member_patterns(path: &str, patterns: &[String]) -> bool {
             .strip_prefix('!')
             .map_or((false, raw.as_str()), |p| (true, p));
         for expanded in expand_braces(pattern) {
-            if !pattern_matches_path(&expanded, path) {
-                continue;
-            }
             if negated {
-                // A later exclusion wins outright, matching the walk.
-                return false;
+                // Mirror the walk's negation matchers EXACTLY: the raw
+                // spelling, default match options, and the companion with a
+                // trailing `/**` stripped — the `glob` crate makes `**`
+                // consume at least one component, while the micromatch
+                // semantics pnpm uses let it match zero, so `!packages/**`
+                // has to exclude `packages` itself as well.
+                //
+                // Normalising the spelling here, as the positive half does,
+                // looks like the consistent choice and is a bug: it makes
+                // `!./packages/skipped` exclude a member the walk KEEPS,
+                // and over-exclusion is the direction that costs a real
+                // member its importer entry. Agreement with the walk is the
+                // whole contract, so a divergence that reads as an
+                // improvement is still a divergence.
+                let excluded = std::iter::once(expanded.as_str())
+                    .chain(expanded.strip_suffix("/**"))
+                    .any(|p| glob::Pattern::new(p).is_ok_and(|m| m.matches(path)));
+                if excluded {
+                    // A later exclusion wins outright, matching the walk.
+                    return false;
+                }
+            } else if pattern_matches_path(&expanded, path) {
+                matched = true;
             }
-            matched = true;
         }
     }
     matched
 }
 
-/// One expanded (brace-free, sign-free) pattern against one path.
+/// One expanded (brace-free, sign-free) POSITIVE pattern against one path.
 ///
-/// The `glob` crate requires `**` to consume at least one component,
-/// while the micromatch semantics pnpm and npm use let it match zero — so
-/// `packages/**` names the `packages` directory itself as well as its
-/// descendants. `expand_workspace_pattern` compensates with a companion
-/// matcher for the trailing `/**` form; do the same here so the two agree
-/// about which directories are members.
+/// Reproducing the walk lexically takes two corrections, both measured
+/// against `find_workspace_packages` on the same inputs, and getting
+/// either wrong desynchronises the two.
+///
+/// **Separators.** The walk expands positives through `glob::glob` on the
+/// filesystem, which cannot let a `*` span a directory boundary. Matching
+/// a string with `Pattern::matches` can: it defaults
+/// `require_literal_separator` to false, so `packages/*` also matches
+/// `packages/app/vendor/local` — a nested local dependency, which is
+/// exactly the thing the caller is trying to exclude. Hence the strict
+/// option here.
+///
+/// **Spelling.** The walk joins the pattern onto a real directory, so the
+/// filesystem normalises `./packages/*` and `packages/*/` for it and both
+/// find `packages/app`. A string comparison gets no such help and matches
+/// NEITHER, which would drop a real member and break its install — the
+/// expensive direction. So normalise the spelling first.
+///
+/// The `**` companion below is a third divergence, already handled: the
+/// `glob` crate requires `**` to consume at least one component, while
+/// the micromatch semantics pnpm and npm use let it match zero, so
+/// `packages/**` names `packages` itself as well as its descendants.
 fn pattern_matches_path(pattern: &str, path: &str) -> bool {
-    let Ok(matcher) = glob::Pattern::new(pattern) else {
+    // `**` is deliberately still allowed to cross separators — that is its
+    // whole purpose, and the strict option only constrains `*` and `?`.
+    let options = glob::MatchOptions {
+        require_literal_separator: true,
+        ..Default::default()
+    };
+    let normalized = normalize_member_pattern(pattern);
+    let Ok(matcher) = glob::Pattern::new(normalized) else {
         return false;
     };
-    if matcher.matches(path) {
+    if matcher.matches_with(path, options) {
         return true;
     }
-    pattern
+    normalized
         .strip_suffix("/**")
         .and_then(|self_form| glob::Pattern::new(self_form).ok())
-        .is_some_and(|m| m.matches(path))
+        .is_some_and(|m| m.matches_with(path, options))
+}
+
+/// Render a workspace pattern in the same frame as a lockfile importer
+/// key: no leading `./`, no trailing `/`.
+///
+/// npm accepts and preserves both spellings, and the discovery walk never
+/// has to care because it hands the pattern to the filesystem. A lexical
+/// matcher does.
+fn normalize_member_pattern(pattern: &str) -> &str {
+    let mut p = pattern;
+    while let Some(rest) = p.strip_prefix("./") {
+        p = rest;
+    }
+    p.strip_suffix('/').unwrap_or(p)
 }
 
 fn expand_braces(pattern: &str) -> Vec<String> {
@@ -497,6 +557,97 @@ mod tests {
             .into_iter()
             .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
             .collect()
+    }
+
+    /// `matches_member_patterns` must answer exactly what the walk finds,
+    /// so every case asks BOTH on the same inputs. The expected column
+    /// pins the WALK — a positive control proving the fixture is live and
+    /// the case is not passing vacuously — and the matcher is then checked
+    /// against the walk's answer rather than against a second hand-written
+    /// list the two could drift away from together.
+    ///
+    /// The tree carries the shapes that decide an npm lockfile importer: a
+    /// real member, a local directory dependency NESTED beneath it (npm
+    /// keys the two identically, which is the whole reason this function
+    /// exists), a second member for a negation to exclude, and a manifest
+    /// on `packages` itself, which is what makes the `**`-companion
+    /// matcher observable at all.
+    #[test]
+    fn member_matching_agrees_with_workspace_discovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let universe = [
+            "packages",
+            "packages/app",
+            "packages/app/vendor/local",
+            "packages/skipped",
+        ];
+        for sub in universe {
+            write(
+                &dir.path().join(sub).join("package.json"),
+                &format!(
+                    r#"{{"name":"{}","version":"1.0.0"}}"#,
+                    sub.replace('/', "-")
+                ),
+            );
+        }
+
+        let cases: [(&[&str], &[&str]); 6] = [
+            // A single `*` must not span a directory boundary, or the
+            // nested local dep is retained as a phantom importer.
+            (&["packages/*"], &["packages/app", "packages/skipped"]),
+            // Two spellings npm accepts and preserves. The walk hands each
+            // to the filesystem, which normalises it; a lexical matcher
+            // gets no such help, so both matched NOTHING before the fix --
+            // dropping real members.
+            (&["./packages/*"], &["packages/app", "packages/skipped"]),
+            (&["packages/*/"], &["packages/app", "packages/skipped"]),
+            (&["packages/*", "!packages/skipped"], &["packages/app"]),
+            // The walk does NOT normalise a negation's spelling, so this
+            // one excludes nothing. Normalising it here would drop a real
+            // member -- the expensive direction.
+            (
+                &["packages/*", "!./packages/skipped"],
+                &["packages/app", "packages/skipped"],
+            ),
+            // `!packages/**` excludes `packages` itself, not just its
+            // descendants: the `glob` crate needs `**` to consume a
+            // component, so the walk compiles a companion matcher with the
+            // trailing `/**` stripped, and so must this.
+            (&["*", "!packages/**"], &[]),
+        ];
+
+        for (patterns, expected_walk) in cases {
+            let quoted = patterns
+                .iter()
+                .map(|p| format!(r#""{p}""#))
+                .collect::<Vec<_>>()
+                .join(",");
+            write(
+                &dir.path().join("package.json"),
+                &format!(r#"{{"name":"r","version":"1.0.0","workspaces":[{quoted}]}}"#),
+            );
+            let walked: BTreeSet<String> = find_workspace_packages(dir.path())
+                .unwrap()
+                .iter()
+                .filter_map(|p| pathdiff::diff_paths(p, dir.path()))
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+                .collect();
+            assert_eq!(
+                walked,
+                expected_walk.iter().map(|s| s.to_string()).collect(),
+                "the walk itself must see {expected_walk:?} for {patterns:?}"
+            );
+
+            let owned: Vec<String> = patterns.iter().map(|p| p.to_string()).collect();
+            for candidate in universe {
+                assert_eq!(
+                    matches_member_patterns(candidate, &owned),
+                    walked.contains(candidate),
+                    "lexical matching disagreed with the walk for {patterns:?} \
+                     on {candidate}; the walk saw {walked:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -2494,8 +2494,13 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             // logs in the ndjson stream.
             drop(resolver);
             crate::pnpmfile::ReadPackageHostChain::drain_forwarders(read_package_forwarders).await;
-            crate::pnpmfile::run_after_all_resolved_chain(&pnpmfile_paths, &cwd, &mut graph)
-                .await?;
+            crate::pnpmfile::run_after_all_resolved_chain(
+                &pnpmfile_paths,
+                &cwd,
+                &manifest,
+                &mut graph,
+            )
+            .await?;
             // Record the project's patch configuration (manifest /
             // workspace-yaml `patchedDependencies` + sha256 of each
             // patch file) on the graph before anything downstream

--- a/vendor/aube/crates/aube/src/commands/install/resolve.rs
+++ b/vendor/aube/crates/aube/src/commands/install/resolve.rs
@@ -313,7 +313,8 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
     // resolve-time logs strictly ahead of post-resolve logs in the
     // ndjson stream.
     crate::pnpmfile::ReadPackageHostChain::drain_forwarders(read_package_forwarders).await;
-    crate::pnpmfile::run_after_all_resolved_chain(&pnpmfile_paths, cwd, &mut graph).await?;
+    crate::pnpmfile::run_after_all_resolved_chain(&pnpmfile_paths, cwd, manifest, &mut graph)
+        .await?;
     // Same patch-config recording as the main install branch — keeps
     // `--lockfile-only` output byte-identical to a full install's.
     crate::patches::record_patches_on_graph(cwd, &mut graph)?;

--- a/vendor/aube/crates/aube/src/commands/update.rs
+++ b/vendor/aube/crates/aube/src/commands/update.rs
@@ -908,7 +908,8 @@ pub async fn run(
     // Drain the readPackage stderr forwarders so resolve-time `ctx.log`
     // records flush to stdout before afterAllResolved emits its own.
     crate::pnpmfile::ReadPackageHostChain::drain_forwarders(read_package_forwarders).await;
-    crate::pnpmfile::run_after_all_resolved_chain(&pnpmfile_paths, &cwd, &mut graph).await?;
+    crate::pnpmfile::run_after_all_resolved_chain(&pnpmfile_paths, &cwd, &manifest, &mut graph)
+        .await?;
 
     let mut catalog_updates: BTreeMap<super::CatalogSource, Vec<super::catalogs::CatalogUpdate>> =
         BTreeMap::new();

--- a/vendor/aube/crates/aube/src/pnpmfile.rs
+++ b/vendor/aube/crates/aube/src/pnpmfile.rs
@@ -33,6 +33,7 @@ use aube_registry::VersionMetadata;
 use aube_resolver::ReadPackageHook;
 use miette::{IntoDiagnostic, Result, WrapErr, miette};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout};
 
@@ -202,117 +203,140 @@ pub fn ordered_paths(global: Option<&Path>, local: Option<&Path>) -> Vec<PathBuf
     paths
 }
 
-#[derive(Serialize, Deserialize, Default, Clone)]
-pub struct LockfileWire {
-    importers: BTreeMap<String, Vec<DirectDepWire>>,
-    packages: BTreeMap<String, PackageWire>,
+/// The object at `root[key]`, or an empty one, so the walks below stay
+/// flat for fields pnpm legitimately omits (a lockfile with no packages
+/// carries no `packages` key at all).
+fn json_object<'a>(root: &'a Value, key: &str) -> &'a serde_json::Map<String, Value> {
+    static EMPTY: std::sync::OnceLock<serde_json::Map<String, Value>> = std::sync::OnceLock::new();
+    root.get(key)
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| EMPTY.get_or_init(serde_json::Map::new))
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-struct DirectDepWire {
-    name: String,
-    version: String,
-}
-
-#[derive(Serialize, Deserialize, Clone, Default)]
-struct PackageWire {
-    name: String,
-    version: String,
-    #[serde(default)]
-    dependencies: BTreeMap<String, String>,
-    #[serde(default, rename = "peerDependencies")]
-    peer_dependencies: BTreeMap<String, String>,
-}
-
-fn to_wire(graph: &LockfileGraph) -> LockfileWire {
-    let importers = graph
-        .importers
+/// A `name -> string` block (`dependencies`, `peerDependencies`) off one
+/// package entry. A non-string value is dropped rather than guessed at:
+/// pnpm's own blocks are always strings, so anything else is a hook
+/// writing something the graph has no field to hold.
+fn string_block(entry: &Value, key: &str) -> BTreeMap<String, String> {
+    json_object(entry, key)
         .iter()
-        .map(|(path, deps)| {
-            let wire = deps
-                .iter()
-                .map(|d| DirectDepWire {
-                    name: d.name.clone(),
-                    version: d.dep_path.clone(),
-                })
-                .collect();
-            (path.clone(), wire)
-        })
-        .collect();
-    let packages = graph
-        .packages
-        .iter()
-        .map(|(key, pkg)| {
-            (
-                key.clone(),
-                PackageWire {
-                    name: pkg.name.clone(),
-                    version: pkg.version.clone(),
-                    dependencies: pkg.dependencies.clone(),
-                    peer_dependencies: pkg.peer_dependencies.clone(),
-                },
-            )
-        })
-        .collect();
-    LockfileWire {
-        importers,
-        packages,
+        .filter_map(|(name, value)| value.as_str().map(|s| (name.clone(), s.to_string())))
+        .collect()
+}
+
+/// Fold a hook's edits to one `name -> version` block into `current`.
+///
+/// `current` is in the GRAPH's spelling while `sent` and `returned` are
+/// both in pnpm's, so this applies the hook's DELTA rather than adopting
+/// the returned map wholesale: a value the hook left alone keeps the
+/// graph's spelling, one it changed or added is taken verbatim, and one it
+/// deleted is removed.
+///
+/// A name `current` holds that never appeared in the projection at all is
+/// left untouched, which is how an optional dependency survives — the
+/// writer strips those out of a snapshot's `dependencies` block while the
+/// graph keeps them in both, so adopting the returned map wholesale would
+/// silently delete every one of them.
+fn fold_block_edits(
+    current: &mut BTreeMap<String, String>,
+    sent: &BTreeMap<String, String>,
+    returned: &BTreeMap<String, String>,
+) {
+    for name in sent.keys() {
+        if !returned.contains_key(name) {
+            current.remove(name);
+        }
+    }
+    for (name, value) in returned {
+        if sent.get(name) != Some(value) {
+            current.insert(name.clone(), value.clone());
+        }
     }
 }
 
-fn apply(wire: LockfileWire, graph: &mut LockfileGraph) {
-    // Only packages[].dependencies and packages[].peerDependencies
-    // are honored. Mutations to importers or to a package's
-    // name/version are ignored because they would require re-running
-    // the resolver to stay consistent; warn about them so the
-    // pnpmfile author knows the edit was a no-op.
-    for (path, wire_deps) in &wire.importers {
-        if let Some(graph_deps) = graph.importers.get(path) {
-            let same = graph_deps.len() == wire_deps.len()
-                && graph_deps
-                    .iter()
-                    .zip(wire_deps.iter())
-                    .all(|(g, w)| g.name == w.name && g.dep_path == w.version);
-            if !same {
-                tracing::warn!(
-                    code = aube_codes::warnings::WARN_AUBE_HOOK_IMPORTER_MUTATED,
-                    "[pnpmfile] afterAllResolved mutated importers[{path}]; \
-                     aube ignores importer edits because they would require \
-                     re-running the resolver",
-                );
-            }
-        } else {
-            tracing::warn!(
+/// Apply an `afterAllResolved` result back onto the graph.
+///
+/// `sent` is the projection the hook was handed, `returned` is what it
+/// gave back, and `snapshot_keys` maps a projected `packages` key to the
+/// graph `dep_path` it came from.
+///
+/// Only `packages[].dependencies` and `packages[].peerDependencies` are
+/// honored. Everything else would need the resolver re-run to stay
+/// consistent, so it is warned about instead — pnpm writes whatever the
+/// hook returns, so an edit aube drops silently is one the author has no
+/// way to notice.
+fn apply_hook_result(
+    sent: &Value,
+    returned: &Value,
+    snapshot_keys: &BTreeMap<String, String>,
+    graph: &mut LockfileGraph,
+) {
+    let sent_importers = json_object(sent, "importers");
+    for (path, block) in json_object(returned, "importers") {
+        match sent_importers.get(path) {
+            Some(before) if before == block => {}
+            Some(_) => tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_HOOK_IMPORTER_MUTATED,
+                "[pnpmfile] afterAllResolved mutated importers[{path}]; \
+                 aube ignores importer edits because they would require \
+                 re-running the resolver",
+            ),
+            None => tracing::warn!(
                 code = aube_codes::warnings::WARN_AUBE_HOOK_IMPORTER_ADDED,
                 "[pnpmfile] afterAllResolved added importers[{path}]; \
                  aube ignores new importer entries",
-            );
+            ),
         }
     }
-    for (key, pkg) in wire.packages {
-        if let Some(locked) = graph.packages.get_mut(&key) {
-            if pkg.name != locked.name || pkg.version != locked.version {
-                tracing::warn!(
-                    code = aube_codes::warnings::WARN_AUBE_HOOK_IDENTITY_REWRITTEN,
-                    "[pnpmfile] afterAllResolved rewrote name/version for {key} \
-                     (to {}@{}); aube ignores identity edits on existing packages",
-                    pkg.name,
-                    pkg.version,
-                );
-            }
-            if locked.dependencies != pkg.dependencies {
-                locked.dependencies = pkg.dependencies;
-            }
-            if locked.peer_dependencies != pkg.peer_dependencies {
-                locked.peer_dependencies = pkg.peer_dependencies;
-            }
-        } else {
+
+    // Everything except the two blocks that can be applied. Compared as
+    // whole objects because pnpm's entry carries `resolution`, `engines`
+    // and friends, none of which the graph can take from a hook.
+    let ignored_fields = |value: &Value| {
+        let mut map = value.as_object().cloned().unwrap_or_default();
+        map.remove("dependencies");
+        map.remove("peerDependencies");
+        map
+    };
+
+    let sent_packages = json_object(sent, "packages");
+    for (view_key, entry) in json_object(returned, "packages") {
+        let Some(dep_path) = snapshot_keys.get(view_key) else {
             tracing::warn!(
                 code = aube_codes::warnings::WARN_AUBE_HOOK_PACKAGE_ADDED,
-                "[pnpmfile] afterAllResolved added a new package entry {key}; \
+                "[pnpmfile] afterAllResolved added a new package entry {view_key}; \
                  aube ignores newly-introduced packages from the hook",
             );
+            continue;
+        };
+        let Some(locked) = graph.packages.get_mut(dep_path) else {
+            continue;
+        };
+        let sent_entry = sent_packages.get(view_key);
+        if let Some(before) = sent_entry
+            && ignored_fields(before) != ignored_fields(entry)
+        {
+            tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_HOOK_IDENTITY_REWRITTEN,
+                "[pnpmfile] afterAllResolved edited a field of {view_key} that is \
+                 fixed by resolution (resolution, engines, identity); aube applies \
+                 only dependencies and peerDependencies",
+            );
         }
+        fold_block_edits(
+            &mut locked.dependencies,
+            &sent_entry
+                .map(|e| string_block(e, "dependencies"))
+                .unwrap_or_default(),
+            &string_block(entry, "dependencies"),
+        );
+        fold_block_edits(
+            &mut locked.peer_dependencies,
+            &sent_entry
+                .map(|e| string_block(e, "peerDependencies"))
+                .unwrap_or_default(),
+            &string_block(entry, "peerDependencies"),
+        );
     }
 }
 
@@ -588,20 +612,33 @@ async fn run_one_shot_hook(
 /// are applied in place. All other fields are round-tripped but
 /// ignored on the way back. `prefix` is the project root used to enrich
 /// `ctx.log` records under `--reporter=ndjson`.
+///
+/// The hook is handed pnpm's in-memory `LockfileObject`
+/// ([`aube_lockfile::pnpm::hook_view`]) — the same projection
+/// `preResolution` gets, and the one every pnpmfile in the wild is written
+/// against. It used to receive a narrow aube-shaped object instead
+/// (`{importers: {".": [{name, version}]}, packages: {k: {name, version,
+/// dependencies, peerDependencies}}}`), which has no `resolution`, no
+/// `engines`, no `specifiers`, and renders each importer as an ARRAY where
+/// pnpm's is an object. A hook doing `lockfile.packages[k].resolution
+/// .integrity` — the shape pnpm's own docs show — threw on it.
 pub async fn run_after_all_resolved(
     pnpmfile: &Path,
     prefix: &Path,
+    manifest: &aube_manifest::PackageJson,
     graph: &mut LockfileGraph,
 ) -> Result<()> {
-    let input = to_wire(graph);
-    let input_json = serde_json::to_vec(&input)
+    let (sent, snapshot_keys) =
+        aube_lockfile::pnpm::hook_view::lockfile_object_with_keys(prefix, graph, manifest)
+            .map_err(|e| miette!("failed to project the lockfile for afterAllResolved: {e}"))?;
+    let input_json = serde_json::to_vec(&sent)
         .into_diagnostic()
         .wrap_err("failed to serialize lockfile for pnpmfile hook")?;
     let stdout = run_one_shot_hook(pnpmfile, prefix, "afterAllResolved", &input_json).await?;
-    let wire: LockfileWire = serde_json::from_slice(&stdout)
+    let returned: Value = serde_json::from_slice(&stdout)
         .into_diagnostic()
         .wrap_err("pnpmfile hook returned invalid JSON from afterAllResolved")?;
-    apply(wire, graph);
+    apply_hook_result(&sent, &returned, &snapshot_keys, graph);
     Ok(())
 }
 
@@ -613,10 +650,11 @@ pub async fn run_after_all_resolved(
 pub async fn run_after_all_resolved_chain(
     paths: &[PathBuf],
     prefix: &Path,
+    manifest: &aube_manifest::PackageJson,
     graph: &mut LockfileGraph,
 ) -> Result<()> {
     for p in paths {
-        run_after_all_resolved(p, prefix, graph)
+        run_after_all_resolved(p, prefix, manifest, graph)
             .await
             .wrap_err_with(|| format!("pnpmfile afterAllResolved hook failed ({})", p.display()))?;
     }
@@ -702,11 +740,8 @@ impl<'a> PreResolutionContext<'a> {
         };
         let lockfile = match existing {
             Some(graph) => {
-                match aube_lockfile::pnpm::hook_view::lockfile_object(
-                    lockfile_dir,
-                    graph,
-                    manifest,
-                ) {
+                match aube_lockfile::pnpm::hook_view::lockfile_object(lockfile_dir, graph, manifest)
+                {
                     Ok(value) => value,
                     Err(e) => {
                         tracing::warn!(
@@ -1543,5 +1578,92 @@ mod tests {
         )
         .unwrap();
         assert!(exports_hooks(&p).await.unwrap());
+    }
+
+    fn block(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    /// The hook sees pnpm's spelling of a dependency value; the graph
+    /// stores its own. Anything the hook did not touch has to come back
+    /// carrying the GRAPH's spelling, or the round-trip rewrites every
+    /// non-registry dep into a form the linker cannot resolve.
+    #[test]
+    fn untouched_dependency_values_keep_the_graphs_spelling() {
+        let mut current = block(&[("is-obj", "is-obj@url+f5ca9b17a622e185")]);
+        let sent = block(&[("is-obj", "is-obj@https://codeload.example/tar.gz/abc")]);
+        fold_block_edits(&mut current, &sent, &sent.clone());
+        assert_eq!(
+            current,
+            block(&[("is-obj", "is-obj@url+f5ca9b17a622e185")]),
+            "a value the hook left alone must not be rewritten into pnpm's spelling"
+        );
+    }
+
+    /// An optional dependency is in the graph's `dependencies` map but is
+    /// stripped out of the projected snapshot block, so it never reaches
+    /// the hook. Adopting the returned map wholesale would delete it —
+    /// silently, and only for packages that have one.
+    #[test]
+    fn a_dependency_absent_from_the_projection_survives() {
+        let mut current = block(&[("left-pad", "1.0.0"), ("fsevents", "2.3.3")]);
+        let sent = block(&[("left-pad", "1.0.0")]);
+        fold_block_edits(&mut current, &sent, &sent.clone());
+        assert_eq!(
+            current,
+            block(&[("left-pad", "1.0.0"), ("fsevents", "2.3.3")]),
+            "an optional dep the projection never showed the hook must be left alone"
+        );
+    }
+
+    #[test]
+    fn hook_edits_are_applied_and_deletions_honored() {
+        let mut current = block(&[("left-pad", "1.0.0"), ("dropped", "1.0.0")]);
+        let sent = block(&[("left-pad", "1.0.0"), ("dropped", "1.0.0")]);
+        let returned = block(&[("left-pad", "2.0.0"), ("added", "3.0.0")]);
+        fold_block_edits(&mut current, &sent, &returned);
+        assert_eq!(
+            current,
+            block(&[("left-pad", "2.0.0"), ("added", "3.0.0")]),
+            "a changed value is taken verbatim, an added one inserted, a removed one dropped"
+        );
+    }
+
+    /// The hook is keyed by pnpm's dep path; the graph is keyed by its own
+    /// hashed one. Without the correspondence the edit lands nowhere and
+    /// is reported as a phantom "added package" instead.
+    #[test]
+    fn package_edits_map_back_through_the_snapshot_keys() {
+        let pnpm_key = "is-obj@https://codeload.example/tar.gz/abc";
+        let graph_key = "is-obj@url+f5ca9b17a622e185";
+
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.packages.insert(
+            graph_key.to_string(),
+            aube_lockfile::LockedPackage {
+                name: "is-obj".to_string(),
+                version: "2.0.0".to_string(),
+                dependencies: block(&[("left-pad", "1.0.0")]),
+                ..Default::default()
+            },
+        );
+
+        let sent = serde_json::json!({
+            "packages": { pnpm_key: { "dependencies": { "left-pad": "1.0.0" } } }
+        });
+        let returned = serde_json::json!({
+            "packages": { pnpm_key: { "dependencies": { "left-pad": "2.0.0" } } }
+        });
+        let keys = BTreeMap::from([(pnpm_key.to_string(), graph_key.to_string())]);
+
+        apply_hook_result(&sent, &returned, &keys, &mut graph);
+        assert_eq!(
+            graph.packages[graph_key].dependencies,
+            block(&[("left-pad", "2.0.0")]),
+            "the hook's edit under pnpm's key must reach the graph's own entry"
+        );
     }
 }


### PR DESCRIPTION
Two fixes in the npm/pnpmfile area, both surfaced while investigating #755.

**npm lockfile reader.** npm records a workspace member and a `file:` local directory dependency identically — a bare path key plus a `link: true` record — so the reader registered targets like `vendor/local` as workspace importers. The freshness check then rejected the lockfile with `workspace importer vendor/local is in the lockfile but not in the workspace`, failing every `--frozen-lockfile` for a workspace with an out-of-tree local dep, including against lockfiles npm itself wrote. Verified against a real npm 11.19.0 lockfile: exit 16 to exit 0.

Link targets are now matched against the workspace patterns, which is the only thing that can tell the two apart. That matcher has to agree with `find_workspace_packages`, and getting it wrong in the exclusive direction costs a real member its importer entry — so it now follows the discovery branch each pattern actually selects (`**` present or not), is explicitly case-sensitive, normalizes `./`, interior `.`, trailing `/` and an in-root `..`, and skips `node_modules`. A ten-case differential asks the walk and the matcher the same question so the two cannot drift.

**`afterAllResolved` hook shape.** `preResolution` was fixed to hand hooks pnpm's in-memory `LockfileObject`; `afterAllResolved` still got a narrow aube-shaped one, so a hook reading `lockfile.packages[k].resolution.integrity` threw. It round-trips, so the writer now also returns the snapshot-key to graph dep_path map, and edits apply as a delta — which is what stops optional dependencies being silently deleted. Measured on a builder VM: nub's projection now matches pnpm 10.15.1 field-for-field.

Refs #755