### PR TITLE
compile: drop a single-argument format! in the warn label

### DIFF
--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -819,7 +819,7 @@ fn warn_lines(headline: &str, body: &[&str], color: bool) -> Vec<String> {
     let label = if color {
         // Yellow, which is what an install already spends on the `latest X`
         // advisory — the CLI's existing "worth your attention, not an error".
-        format!("\x1b[33m\x1b[1mwarn\x1b[22m\x1b[39m")
+        "\x1b[33m\x1b[1mwarn\x1b[22m\x1b[39m".to_string()
     } else {
         "warn".to_string()
     };


### PR DESCRIPTION
`clippy::useless_format` is denied by `-D warnings`, so `main` has been red since #830 (`9b464fe00d`) and every open pull request inherits the failure — including this one, which is how it surfaced.

`crates/nub-cli/src/compile/mod.rs:822` builds a constant string, so Clippy's own suggestion applies verbatim: `.to_string()` in place of `format!`.

```
error: useless use of `format!`
822 |         format!("\x1b[33m\x1b[1mwarn\x1b[22m\x1b[39m")
    |         help: consider using `.to_string()`
    = note: `-D clippy::useless-format` implied by `-D warnings`
```

This branch previously carried a comment-only correction to the mechanism behind the `--js-defer-import-eval` startup cost. #856 already makes that correction independently and more completely — it fixes the launcher comment and both wiki pages as well — so that commit is dropped rather than left to conflict.

Refs #830