### PR TITLE
compile: add --hide-console for Windows GUI apps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,6 @@ tests/fixtures/loader-redirect-both-ways/*  text eol=lf
 # native host rather than Linux alone. `**` rather than `*` because the `.d`
 # companion directories nest, and their sources feed the same byte comparisons.
 tests/compile-augmentation/fixtures/**  text eol=lf
+# PowerShell 5.1 reads a BOM-less script in the ANSI codepage and is happiest with
+# CRLF; keep this probe byte-identical on every checkout.
+tests/compile-hide-console/*.ps1 text eol=crlf

--- a/.github/workflows/compile-native.yml
+++ b/.github/workflows/compile-native.yml
@@ -20,6 +20,7 @@ on:
       - 'tests/compile-augmentation/**'
       - 'tests/compile-corpus/**'
       - 'tests/compile-metadata/**'
+      - 'tests/compile-hide-console/**'
       - '.github/workflows/compile-native.yml'
   pull_request:
     branches: [main]
@@ -37,6 +38,7 @@ on:
       - 'tests/compile-augmentation/**'
       - 'tests/compile-corpus/**'
       - 'tests/compile-metadata/**'
+      - 'tests/compile-hide-console/**'
       - '.github/workflows/compile-native.yml'
   workflow_dispatch:
 
@@ -261,6 +263,23 @@ jobs:
           version="$(node --version)"
           NUB="$nub" __NUB_LAUNCHER_TEMPLATE="$launcher" \
             tests/compile-metadata/run.sh "${version#v}"
+      # Windows only, and the other half of the metadata step above: the subsystem
+      # is a PE field, and the launcher this job built is the host's. The unit
+      # tests already prove the byte survives the resource rewrite — what needs a
+      # real host is that a GUI-subsystem launcher, whose standard handles are no
+      # longer a console's, still spawns Node and still delivers its output.
+      - name: A hidden-console artifact runs with no console
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          nub="$GITHUB_WORKSPACE/target/release/nub.exe"
+          launcher="$GITHUB_WORKSPACE/crates/nub-launcher/target/release/nub-launcher.exe"
+          test -f "$nub"
+          test -f "$launcher"
+          version="$(node --version)"
+          NUB="$nub" __NUB_LAUNCHER_TEMPLATE="$launcher" \
+            tests/compile-hide-console/run.sh "${version#v}"
       - name: Upload native-island failure logs
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1179,6 +1179,14 @@ pub enum Command {
         )]
         metadata: Vec<String>,
 
+        /// Start a Windows executable without a console window, for a GUI app, a
+        /// tray icon, or a file-association handler. Launched from a terminal the
+        /// binary still writes to it; launched from Explorer it shows nothing.
+        /// Works when cross-compiling, and is refused for a non-Windows target
+        /// rather than ignored.
+        #[arg(long = "hide-console")]
+        hide_console: bool,
+
         /// Custom message the compiled binary shows on a terminal while it sets
         /// itself up on first run. Default: `Initializing...`.
         #[arg(long, value_name = "TEXT")]
@@ -3188,6 +3196,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             node_options,
             icon,
             metadata,
+            hide_console,
             no_keep_names,
             no_treeshake,
             ignore_annotations,
@@ -3213,6 +3222,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             node_options,
             icon,
             metadata,
+            hide_console,
             metafile: metafile.as_deref().map(PathBuf::from),
             bundle: crate::compile::BundleOptions {
                 minify: !no_minify,

--- a/crates/nub-cli/src/compile/inject.rs
+++ b/crates/nub-cli/src/compile/inject.rs
@@ -15,6 +15,7 @@
 //! not a re-read of whatever the writer happened to emit.
 
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -33,6 +34,7 @@ pub fn inject(
     payload: &[u8],
     icon: Option<&[u8]>,
     version_info: Option<&[u8]>,
+    hide_console: bool,
     out: &Path,
 ) -> Result<()> {
     let format = target.format();
@@ -80,10 +82,23 @@ pub fn inject(
             if let Some(version_info) = version_info {
                 pe = pe.set_version_info(version_info.to_vec());
             }
+            // Built into memory rather than straight into the file, because the
+            // subsystem flip has to land on the FINISHED image. libsui rebuilds
+            // the PE headers while it rewrites the resource directory, so a
+            // subsystem set on the template is discarded here along with the
+            // template's own resources — the same reason the icon and the version
+            // resource are set inside this builder chain instead of baked in.
+            let mut image = Vec::with_capacity(template.len() + payload.len());
             pe.write_resource(nub_core::compile::SECTION_NAME, payload.to_vec())
                 .map_err(|e| anyhow!("injecting the payload resource: {e:?}"))?
-                .build(&mut file)
-                .map_err(|e| anyhow!("building the executable: {e:?}"))
+                .build(&mut image)
+                .map_err(|e| anyhow!("building the executable: {e:?}"))?;
+            if hide_console {
+                set_pe_subsystem_gui(&mut image)
+                    .context("hiding the console window (--hide-console)")?;
+            }
+            file.write_all(&image)
+                .with_context(|| format!("writing {}", out.display()))
         }
     }
 }
@@ -503,8 +518,25 @@ fn pe_header_offset(image: &[u8]) -> Result<usize> {
 /// gets a console allocated for that child, so the launcher must also pass
 /// `CREATE_NO_WINDOW`. Bun and Deno need this half alone because each one IS the
 /// process it is hiding.
+/// The PE `Subsystem` field, read back the way Windows' loader reads it.
+///
+/// Exists for the same reason the version-resource scanner does: a cross-compiled
+/// Windows binary cannot be run on this host, so reading the field back out of the
+/// finished file is the only evidence the flip survived libsui's header rebuild.
+/// `None` when the image is not a placeable PE.
+pub fn pe_subsystem(image: &[u8]) -> Option<u16> {
+    let pe = pe_header_offset(image).ok()?;
+    match u16le(image, pe + 24) {
+        Some(0x20b) | Some(0x10b) => u16le(image, pe + 24 + 68),
+        _ => None,
+    }
+}
+
+/// `IMAGE_SUBSYSTEM_WINDOWS_GUI` — the value that stops Windows allocating a
+/// console for the process it starts from this image.
+pub const SUBSYSTEM_WINDOWS_GUI: u16 = 2;
+
 fn set_pe_subsystem_gui(image: &mut [u8]) -> Result<()> {
-    const IMAGE_SUBSYSTEM_WINDOWS_GUI: u16 = 2;
     let pe = pe_header_offset(image)?;
     let optional_header = pe + 24;
     // Checked rather than assumed: a ROM image (0x107) lays its optional header
@@ -519,7 +551,7 @@ fn set_pe_subsystem_gui(image: &mut [u8]) -> Result<()> {
     let slot = image
         .get_mut(at..at + 2)
         .context("truncated PE optional header")?;
-    slot.copy_from_slice(&IMAGE_SUBSYSTEM_WINDOWS_GUI.to_le_bytes());
+    slot.copy_from_slice(&SUBSYSTEM_WINDOWS_GUI.to_le_bytes());
     Ok(())
 }
 
@@ -654,7 +686,7 @@ mod tests {
         let target = TargetPlatform::parse(triple).unwrap();
         let out = tmp(&format!("artifact-{triple}"));
         let payload = payload("main.js");
-        inject(&target, template, &payload, None, None, &out).expect("inject");
+        inject(&target, template, &payload, None, None, false, &out).expect("inject");
 
         let produced = fs::read(&out).unwrap();
         assert_eq!(
@@ -727,6 +759,7 @@ mod tests {
             &payload("main.js"),
             Some(&fixtures::png()),
             Some(&info.encode().expect("the fixture encodes")),
+            false,
             &out,
         )
         .expect("inject");
@@ -747,6 +780,71 @@ mod tests {
             "the payload must still be findable once RT_VERSION joins the table"
         );
         let _ = fs::remove_file(&out);
+    }
+
+    /// The flip has to survive the write, which is the whole reason it is applied
+    /// to the finished image instead of the template.
+    ///
+    /// libsui rebuilds the PE headers while it rewrites the resource directory, so
+    /// a subsystem set on the way in is discarded — silently, leaving a binary that
+    /// passes every other check here and still flashes a console on the user's
+    /// machine. The CUI assertion on the same build with the flag off is the
+    /// control: without it this would pass against a fixture that was never
+    /// console-subsystem to begin with.
+    #[test]
+    fn the_hidden_console_subsystem_survives_the_resource_rewrite() {
+        let target = TargetPlatform::parse("win32-x64").unwrap();
+        assert_eq!(
+            pe_subsystem(&fixtures::pe()),
+            Some(3),
+            "the fixture must start as CUI, or this test cannot fail"
+        );
+
+        let hidden = tmp("artifact-hidden");
+        inject(
+            &target,
+            &fixtures::pe(),
+            &payload("main.js"),
+            None,
+            None,
+            true,
+            &hidden,
+        )
+        .expect("inject");
+        let produced = fs::read(&hidden).unwrap();
+        assert_eq!(
+            pe_subsystem(&produced),
+            Some(SUBSYSTEM_WINDOWS_GUI),
+            "--hide-console must leave the produced artifact GUI-subsystem"
+        );
+        // The payload is what the flip is written next to, and a wrong offset would
+        // corrupt the header the scan walks, so assert both in one breath.
+        assert!(
+            find_payload(ContainerFormat::Pe, &produced)
+                .unwrap()
+                .is_some(),
+            "the payload must still be findable once the subsystem is flipped"
+        );
+
+        let plain = tmp("artifact-shown");
+        inject(
+            &target,
+            &fixtures::pe(),
+            &payload("main.js"),
+            None,
+            None,
+            false,
+            &plain,
+        )
+        .expect("inject");
+        assert_eq!(
+            pe_subsystem(&fs::read(&plain).unwrap()),
+            Some(3),
+            "without the flag the artifact must stay a console application"
+        );
+
+        let _ = fs::remove_file(&hidden);
+        let _ = fs::remove_file(&plain);
     }
 
     /// The negative control for the scan above: without one it must report none
@@ -779,6 +877,7 @@ mod tests {
             &payload("main.js"),
             None,
             None,
+            false,
             &tmp("wrong"),
         )
         .unwrap_err();
@@ -809,6 +908,7 @@ mod tests {
             &payload("main.js"),
             None,
             None,
+            false,
             &tmp("badarch"),
         )
         .unwrap_err();
@@ -825,6 +925,7 @@ mod tests {
                 &payload("main.js"),
                 None,
                 None,
+                false,
                 &tmp("okarch")
             )
             .is_ok(),
@@ -843,6 +944,7 @@ mod tests {
             &payload("main.js"),
             None,
             None,
+            false,
             &tmp("unknownarch"),
         )
         .unwrap_err();

--- a/crates/nub-cli/src/compile/inject.rs
+++ b/crates/nub-cli/src/compile/inject.rs
@@ -661,6 +661,7 @@ mod tests {
             install_message: None,
             node_flags: Vec::new(),
             sealed_module_graph: false,
+            hide_console: false,
         };
         nub_core::compile::encode(
             &manifest,

--- a/crates/nub-cli/src/compile/inject.rs
+++ b/crates/nub-cli/src/compile/inject.rs
@@ -484,6 +484,45 @@ fn pe_header_offset(image: &[u8]) -> Result<usize> {
     Ok(pe)
 }
 
+/// Flip a PE's subsystem to GUI, so Windows opens no console beside the app.
+///
+/// `Subsystem` sits at optional-header offset 68 in BOTH PE32 and PE32+. The two
+/// layouts differ earlier — PE32 carries an extra `BaseOfData`, and an `ImageBase`
+/// four bytes narrower than PE32+'s — and those differences cancel exactly, so the
+/// field lands at the same offset either way and no magic-dependent arithmetic is
+/// needed. Deno computes it as `standard_fields_size + 68`, which is correct only
+/// because Deno ships 64-bit alone; on a PE32 image that expression points four
+/// bytes past the field, into `DllCharacteristics`. Worth not copying.
+///
+/// Applied to the FINISHED artifact rather than the template: libsui rebuilds the
+/// headers while rewriting the resource directory, so a flip made beforehand is
+/// discarded — the same reason the icon is set inside the builder chain.
+///
+/// This is only HALF of hiding the console. nub's launcher spawns Node as a
+/// child, and a GUI-subsystem parent starting a console-subsystem child still
+/// gets a console allocated for that child, so the launcher must also pass
+/// `CREATE_NO_WINDOW`. Bun and Deno need this half alone because each one IS the
+/// process it is hiding.
+fn set_pe_subsystem_gui(image: &mut [u8]) -> Result<()> {
+    const IMAGE_SUBSYSTEM_WINDOWS_GUI: u16 = 2;
+    let pe = pe_header_offset(image)?;
+    let optional_header = pe + 24;
+    // Checked rather than assumed: a ROM image (0x107) lays its optional header
+    // out differently, so writing at +68 would land in an unrelated field and
+    // produce a corrupt executable that still passes every other check here.
+    match u16le(image, optional_header) {
+        Some(0x20b) | Some(0x10b) => {}
+        Some(other) => bail!("unexpected PE optional-header magic {other:#x}"),
+        None => bail!("truncated PE optional header"),
+    }
+    let at = optional_header + 68;
+    let slot = image
+        .get_mut(at..at + 2)
+        .context("truncated PE optional header")?;
+    slot.copy_from_slice(&IMAGE_SUBSYSTEM_WINDOWS_GUI.to_le_bytes());
+    Ok(())
+}
+
 /// `(virtual_address, virtual_size, raw_offset, raw_size)` per section.
 fn pe_sections(image: &[u8], pe: usize) -> Result<Vec<(u32, u32, u32, u32)>> {
     let count = u16le(image, pe + 6).context("truncated COFF header")? as usize;
@@ -820,6 +859,48 @@ mod tests {
         assert!(msg.contains("unsupported or unreadable"), "{msg}");
         assert!(msg.contains("Mach-O (macOS)"), "{msg}");
         assert!(msg.contains("darwin-x64"), "{msg}");
+    }
+
+    /// The subsystem flip, asserted against the byte Windows actually reads.
+    ///
+    /// The fixture ships `3` (`WINDOWS_CUI`), so the starting state is a real
+    /// console executable rather than a zeroed field that would pass whatever this
+    /// wrote. The offset is the whole claim — a flip four bytes wide of it lands in
+    /// `DllCharacteristics` and silently changes ASLR or DEP instead — so the test
+    /// reads it back at `pe + 24 + 68` computed independently of the function, and
+    /// checks that its neighbours on both sides are untouched.
+    #[test]
+    fn the_subsystem_flip_writes_gui_at_the_offset_windows_reads() {
+        let mut image = fixtures::pe();
+        let opt = 0x80 + 24;
+        assert_eq!(
+            u16le(&image, opt + 68),
+            Some(3),
+            "fixture should start as a console executable, or this proves nothing"
+        );
+        let before = (u16le(&image, opt + 66), u16le(&image, opt + 70));
+
+        set_pe_subsystem_gui(&mut image).unwrap();
+
+        assert_eq!(u16le(&image, opt + 68), Some(2), "subsystem must be GUI");
+        assert_eq!(
+            (u16le(&image, opt + 66), u16le(&image, opt + 70)),
+            before,
+            "the write must not touch MinorSubsystemVersion or DllCharacteristics"
+        );
+    }
+
+    /// A magic this function does not understand must refuse rather than write.
+    ///
+    /// A ROM image lays the optional header out differently, so a blind write at
+    /// +68 would corrupt an unrelated field and still leave every structural check
+    /// in this module passing.
+    #[test]
+    fn the_subsystem_flip_refuses_an_optional_header_it_cannot_place() {
+        let mut rom = fixtures::pe();
+        rom[0x98..0x9a].copy_from_slice(&0x107u16.to_le_bytes());
+        let err = set_pe_subsystem_gui(&mut rom).unwrap_err();
+        assert!(format!("{err:#}").contains("0x107"), "{err:#}");
     }
 
     #[test]

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -3550,6 +3550,7 @@ mod tests {
             out: None,
             icon: None,
             metadata: Vec::new(),
+            hide_console: false,
             smol: false,
             target: None,
             platform: None,

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -84,6 +84,11 @@ pub struct CompileOptions {
     /// the nearest `package.json` supplies. Windows-only for the same reason as
     /// [`CompileOptions::icon`] — no other container format carries them.
     pub metadata: Vec<String>,
+    /// `--hide-console`: give the Windows executable the GUI subsystem, and tell
+    /// its launcher to spawn Node with no console. Windows-only for the same
+    /// reason as [`CompileOptions::icon`] — the subsystem is a PE header field,
+    /// and neither Mach-O nor ELF has anything corresponding to it.
+    pub hide_console: bool,
     /// `--metafile`: where to write the build report. `None` collects nothing.
     pub metafile: Option<PathBuf>,
     /// The bundler-flag surface, shared verbatim with `nub build`.
@@ -139,6 +144,7 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         &out_path,
         &target,
     )?;
+    reject_non_windows_hide_console(opts.hide_console, &target)?;
 
     // Resolved AND verified before any real work: a cross-compile whose launcher
     // template is missing, or is not that platform's executable, must fail in the
@@ -372,6 +378,10 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         // OUTSIDE the artifact stays out of the predicate on the
         // plain-Node-baseline argument in the Manifest field's doc comment.
         sealed_module_graph: !shim_plan.needed() && !carries_verbatim_files,
+        // The launcher's half of `--hide-console`. The PE subsystem flip below
+        // only stops Windows giving the LAUNCHER a console; this is what stops it
+        // giving one to the Node it spawns.
+        hide_console: opts.hide_console,
     };
     let payload = encode_with_license(&manifest, &app_files, &node.blob, &node.license);
 
@@ -387,13 +397,19 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         &payload,
         icon.as_deref(),
         version_info.as_deref(),
+        opts.hide_console,
         staged.path(),
     )
     .with_context(|| format!("writing {}", staged.path().display()))?;
     set_executable(staged.path())?;
     sync_file(staged.path())?;
     live.phase("verifying", "");
-    verify_artifact(staged.path(), &target, version_info.as_deref())?;
+    verify_artifact(
+        staged.path(),
+        &target,
+        version_info.as_deref(),
+        opts.hide_console,
+    )?;
     staged.publish(&out_path)?;
 
     // Detached maps are optional debugging companions rather than part of the
@@ -1058,6 +1074,29 @@ fn load_icon(icon: Option<&Path>, target: &TargetPlatform) -> Result<Option<Vec<
         );
     }
     Ok(Some(bytes))
+}
+
+/// Refuse `--hide-console` for a target whose format has no subsystem field.
+///
+/// Refused rather than ignored, matching `--icon` and `--metadata`: the whole
+/// point of the flag is that nothing is shown, so accepting it on a target that
+/// cannot honor it would be indistinguishable from it working right up until
+/// someone ran the binary.
+///
+/// The HOST is not checked, only the target. Everything the flag does is byte
+/// editing plus one payload field, so a hidden Windows binary cross-compiles
+/// from macOS or Linux exactly like an icon does.
+fn reject_non_windows_hide_console(hide_console: bool, target: &TargetPlatform) -> Result<()> {
+    if hide_console && target.format() != ContainerFormat::Pe {
+        bail!(
+            "--hide-console applies to Windows executables, and this build targets {}.\n\
+             \x20\x20A console window is a Windows concept: macOS and Linux start a program \
+             from a terminal that already exists, and neither Mach-O nor ELF carries anything \
+             that would suppress one.",
+            target.triple()
+        );
+    }
+    Ok(())
 }
 
 /// Build the Windows version resource — the fields Explorer's Details tab shows
@@ -2305,7 +2344,12 @@ fn node_runs(node: &Path) -> bool {
 ///    check can see. Cross-compiling SKIPS this, loudly: an artifact that passes
 ///    the scan but was never executed is a weaker guarantee, and the user should
 ///    know which one they got.
-fn verify_artifact(bin: &Path, target: &TargetPlatform, version_info: Option<&[u8]>) -> Result<()> {
+fn verify_artifact(
+    bin: &Path,
+    target: &TargetPlatform,
+    version_info: Option<&[u8]>,
+    hide_console: bool,
+) -> Result<()> {
     let bytes = fs::read(bin).with_context(|| format!("reading {}", bin.display()))?;
     let payload = inject::find_payload(target.format(), &bytes)
         .with_context(|| format!("scanning {} for its payload", bin.display()))?
@@ -2321,6 +2365,24 @@ fn verify_artifact(bin: &Path, target: &TargetPlatform, version_info: Option<&[u
     // Explorer showing nothing and no error anywhere. The concrete way to lose it
     // is the resource directory's ascending-id rule (see `set_version_info` in
     // vendor/libsui), which takes the icon down with it.
+    // Same argument as the version resource below, and the same failure shape: a
+    // Windows artifact built on macOS is never executed here, so reading the
+    // subsystem back is the only thing standing between a silently un-hidden
+    // binary and the user discovering it on the target machine.
+    if hide_console {
+        let subsystem = inject::pe_subsystem(&bytes).context(
+            "the produced executable's PE optional header is unreadable, so \
+             --hide-console cannot be confirmed",
+        )?;
+        if subsystem != inject::SUBSYSTEM_WINDOWS_GUI {
+            bail!(
+                "the produced executable's subsystem is {subsystem}, not \
+                 {} (GUI) — --hide-console did not take",
+                inject::SUBSYSTEM_WINDOWS_GUI
+            );
+        }
+    }
+
     if let Some(encoded) = version_info {
         let found = inject::find_version_resource(&bytes)
             .with_context(|| format!("scanning {} for its version resource", bin.display()))?
@@ -2869,7 +2931,6 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
-    /// The parent guard above passes when `--out` names a directory whose parent
     /// `--icon` is checked before anything expensive runs, and by CONTENT rather
     /// than by extension — a PNG saved under a `.ico` name is the ordinary mistake
     /// and would embed into a resource Windows silently declines to draw.
@@ -2903,6 +2964,38 @@ mod tests {
             "must name the target, got: {err}"
         );
         assert!(load_icon(None, &mac).unwrap().is_none());
+    }
+
+    /// `--hide-console` is refused on a target that cannot honor it, for the same
+    /// reason `--icon` is: the flag's whole promise is that nothing appears, so
+    /// accepting it and doing nothing looks identical to it working until someone
+    /// runs the binary. The HOST is deliberately not part of the gate — the flip
+    /// is byte editing, so a hidden Windows binary cross-compiles from anywhere.
+    #[test]
+    fn hide_console_is_refused_for_a_target_with_no_subsystem_field() {
+        let win = TargetPlatform {
+            os: TargetOs::Win32,
+            arch: TargetArch::X64,
+            musl: false,
+        };
+        let linux = TargetPlatform {
+            os: TargetOs::Linux,
+            arch: TargetArch::Arm64,
+            musl: false,
+        };
+
+        reject_non_windows_hide_console(true, &win).expect("a Windows target accepts the flag");
+        let err = reject_non_windows_hide_console(true, &linux)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("linux-arm64"),
+            "must name the target, got: {err}"
+        );
+        // The control: the gate must key on the FLAG, not on the target alone, or
+        // it would break every ordinary Linux build.
+        reject_non_windows_hide_console(false, &linux)
+            .expect("a Linux build without the flag is untouched");
     }
 
     /// The defaults are the feature: a Windows build with no version resource is
@@ -3007,6 +3100,7 @@ mod tests {
         );
     }
 
+    /// The parent guard above passes when `--out` names a directory whose parent
     /// exists, so the build used to run to completion and die on the rename with
     /// `Is a directory (os error 21)` over an internal staging path.
     #[test]
@@ -3511,6 +3605,7 @@ mod tests {
             install_message: None,
             node_flags: Vec::new(),
             sealed_module_graph: false,
+            hide_console: false,
         };
         let app = vec![AppFile::plain("main.js", b"app".to_vec())];
         let missing = nub_core::compile::encode_with_license(&manifest, &app, b"node", &[]);

--- a/crates/nub-core/Cargo.toml
+++ b/crates/nub-core/Cargo.toml
@@ -104,6 +104,8 @@ blake3 = { version = "1", optional = true }
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
+    # `GetConsoleWindow`, for `spawn::process_has_console`.
+    "Win32_System_Console",
 ] }
 
 # Build-time only (embed-runtime): tar + zstd-compress the staged runtime tree

--- a/crates/nub-core/src/compile.rs
+++ b/crates/nub-core/src/compile.rs
@@ -235,6 +235,21 @@ pub struct Manifest {
     /// (always inject) exactly.
     #[serde(default)]
     pub sealed_module_graph: bool,
+    /// Whether `--hide-console` built this artifact, which the launcher needs to
+    /// know at RUN time and cannot infer from the image it is running as.
+    ///
+    /// The subsystem flip alone does not hide anything here. Bun and Deno ARE the
+    /// process they hide, so a GUI subsystem is their whole fix; nub's launcher
+    /// SPAWNS Node, and Windows allocates a console for a console-subsystem child
+    /// whose parent has none — so the flash simply moves from the launcher to
+    /// Node. Closing that means passing `CREATE_NO_WINDOW` on the spawn, and the
+    /// launcher has no other way to tell a hidden build from an ordinary one:
+    /// nothing readable at run time distinguishes them, and reading its own PE
+    /// header back would be both slower and a layering inversion.
+    ///
+    /// Absent in legacy manifests, where `false` is exactly what they were doing.
+    #[serde(default)]
+    pub hide_console: bool,
 }
 
 /// One logical file in the payload. `B` is `Vec<u8>` on the writing side and
@@ -871,6 +886,7 @@ mod tests {
             install_message: None,
             node_flags: Vec::new(),
             sealed_module_graph: false,
+            hide_console: false,
         }
     }
 
@@ -902,6 +918,10 @@ mod tests {
             // encoding bug, so it would fix the build without covering the field.
             node_flags: vec!["--max-old-space-size=256".into(), "--no-warnings".into()],
             sealed_module_graph: false,
+            // True on purpose: `false` is this field's serde default, so a
+            // manifest carrying it would round-trip through an encoding bug that
+            // dropped the field entirely.
+            hide_console: true,
         };
         let app = vec![
             AppFile::plain("main.js", b"import './c.js'\n".to_vec()),
@@ -918,6 +938,10 @@ mod tests {
             view.manifest.node_flags,
             ["--max-old-space-size=256", "--no-warnings"],
             "flags baked into the binary must survive the round trip in order"
+        );
+        assert!(
+            view.manifest.hide_console,
+            "the hidden-console flag decides whether the launcher passes              CREATE_NO_WINDOW, so losing it in the payload un-hides the artifact"
         );
         assert_eq!(view.app_files.len(), 2);
         assert_eq!(view.app_files[0].name, "main.js");
@@ -948,6 +972,7 @@ mod tests {
             // Empty here, so the pair covers both ends of the field.
             node_flags: Vec::new(),
             sealed_module_graph: false,
+            hide_console: false,
         };
         let app = vec![AppFile::plain("main.js", b"console.log(1)".to_vec())];
         let blob = encode_with_license(&manifest, &app, &[], &[]);

--- a/crates/nub-core/src/node/spawn.rs
+++ b/crates/nub-core/src/node/spawn.rs
@@ -24,6 +24,26 @@ use super::discovery::ResolvedNode;
 use super::flags;
 use super::version::NodeVersion;
 
+/// Whether this process is attached to a console.
+///
+/// Only a compiled artifact built with `--hide-console` asks. Such a launcher
+/// carries the GUI subsystem, so Windows allocates it no console of its own — but
+/// a GUI process started FROM a console inherits that one, which is the difference
+/// between double-clicking the binary and running it from `cmd.exe`, and the
+/// difference decides whether suppressing the child's console loses the user's
+/// output or saves them a flashing window.
+///
+/// `GetConsoleWindow` is the question asked directly. Testing the standard handles
+/// instead answers a narrower one — `app.exe > out.txt` redirects stdout to a file
+/// while stderr stays on the console — and would suppress a console that is
+/// genuinely there.
+#[cfg(windows)]
+pub fn process_has_console() -> bool {
+    // SAFETY: no arguments, no out-params; returns the console's window handle or
+    // null, and is safe to call at any time from any thread.
+    !unsafe { windows_sys::Win32::System::Console::GetConsoleWindow() }.is_null()
+}
+
 #[cfg(windows)]
 #[derive(Debug)]
 struct FileHandle {

--- a/crates/nub-launcher/src/hidden.rs
+++ b/crates/nub-launcher/src/hidden.rs
@@ -4,8 +4,8 @@
 //! Deno's equivalent flags stop — they ARE the process they hide, so a subsystem
 //! bit is the whole fix. This launcher is not: it spawns Node, and Windows
 //! allocates a console for a console-subsystem child whose parent has none. Left
-//! alone, the flash simply moves from the launcher to Node, and a first run moves
-//! it again to `curl`, `icacls`, and the `node --version` probe.
+//! alone, the flash simply moves from the launcher to Node, and on a `--smol`
+//! first run to `curl`/`wget` and the `node --version` probe as well.
 //!
 //! So the suppression is process-wide rather than threaded through each call, and
 //! it is recorded ONCE from the payload manifest before anything spawns.
@@ -68,7 +68,9 @@ pub fn state() -> &'static str {
         }
     }
     #[cfg(not(windows))]
-    "not applicable off Windows"
+    {
+        "not applicable off Windows"
+    }
 }
 
 /// Start `cmd` without a console window, on a hidden launch. A no-op everywhere
@@ -77,8 +79,8 @@ pub fn apply(cmd: &mut std::process::Command) {
     #[cfg(windows)]
     if SUPPRESS.load(Ordering::Relaxed) {
         use std::os::windows::process::CommandExt;
-        /// `CREATE_NO_WINDOW`: run a console application with no console window,
-        /// and do not give it the parent's console either.
+        // `CREATE_NO_WINDOW`: run a console application with no console window, and
+        // do not hand it the parent's console either.
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         cmd.creation_flags(CREATE_NO_WINDOW);
     }

--- a/crates/nub-launcher/src/hidden.rs
+++ b/crates/nub-launcher/src/hidden.rs
@@ -1,0 +1,87 @@
+//! `--hide-console`: the launcher's half of hiding a Windows console.
+//!
+//! The compiler gives the artifact the GUI subsystem, which is where Bun's and
+//! Deno's equivalent flags stop — they ARE the process they hide, so a subsystem
+//! bit is the whole fix. This launcher is not: it spawns Node, and Windows
+//! allocates a console for a console-subsystem child whose parent has none. Left
+//! alone, the flash simply moves from the launcher to Node, and a first run moves
+//! it again to `curl`, `icacls`, and the `node --version` probe.
+//!
+//! So the suppression is process-wide rather than threaded through each call, and
+//! it is recorded ONCE from the payload manifest before anything spawns.
+//! `creation_flags` is the only channel — `Stdio` says nothing about consoles, and
+//! `CREATE_NO_WINDOW` is per-`CreateProcess`, so every site has to opt in.
+//!
+//! CONDITIONAL ON THERE BEING NO CONSOLE ALREADY, which is the part that keeps the
+//! flag usable. A GUI process started from `cmd.exe` inherits that console, and
+//! suppressing the child's would throw the user's own output away for no gain;
+//! started from Explorer there is no console to inherit and nothing to lose. Bun
+//! gets the same split for free by being one process, and this reproduces it.
+
+#[cfg(windows)]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(windows)]
+static SUPPRESS: AtomicBool = AtomicBool::new(false);
+
+/// Whether the payload asked to be hidden, kept apart from whether anything was
+/// actually suppressed. The two differ exactly when a console is already
+/// attached, and only that distinction can tell a CI runner that owns a console
+/// (where this feature has nothing to do) from a build that lost its flag
+/// somewhere between the compiler and the payload.
+#[cfg(windows)]
+static REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Record whether every child this launcher spawns must be console-free. Called
+/// once, from the payload manifest, before the first spawn.
+pub fn arm(hide_console: bool) {
+    #[cfg(windows)]
+    {
+        REQUESTED.store(hide_console, Ordering::Relaxed);
+        SUPPRESS.store(
+            hide_console && !nub_core::node::spawn::process_has_console(),
+            Ordering::Relaxed,
+        );
+    }
+    #[cfg(not(windows))]
+    let _ = hide_console;
+}
+
+/// What [`arm`] decided, for the timing trace.
+///
+/// A CI leg cannot see a window, so "no console appeared" is not observable there
+/// — only whether this launcher took the suppressing path. Without that the probe
+/// would pass identically on a runner that happens to own a console, where nothing
+/// is suppressed and every assertion still holds.
+pub fn state() -> &'static str {
+    #[cfg(windows)]
+    {
+        match (
+            REQUESTED.load(Ordering::Relaxed),
+            SUPPRESS.load(Ordering::Relaxed),
+        ) {
+            (_, true) => "suppressing child consoles",
+            // Not a defect, and the reason the two flags are tracked separately:
+            // this is the deliberate terminal case, where the user is watching.
+            (true, false) => "requested, but a console is already attached",
+            (false, false) => "off (not a hidden build)",
+        }
+    }
+    #[cfg(not(windows))]
+    "not applicable off Windows"
+}
+
+/// Start `cmd` without a console window, on a hidden launch. A no-op everywhere
+/// else, including every Unix host — the concept does not exist there.
+pub fn apply(cmd: &mut std::process::Command) {
+    #[cfg(windows)]
+    if SUPPRESS.load(Ordering::Relaxed) {
+        use std::os::windows::process::CommandExt;
+        /// `CREATE_NO_WINDOW`: run a console application with no console window,
+        /// and do not give it the parent's console either.
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(windows))]
+    let _ = cmd;
+}

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -22,6 +22,7 @@
 #![allow(clippy::collapsible_if)]
 
 mod cache;
+mod hidden;
 mod ui;
 
 use std::borrow::Cow;
@@ -166,6 +167,11 @@ fn run() -> i32 {
         }
     };
     phase("payload decoded");
+    // Before the first spawn of any kind: `--hide-console` has to cover the
+    // first-run helpers (`curl`, `icacls`, the `node --version` probe) as well as
+    // Node itself, and they run from several modules.
+    hidden::arm(view.manifest.hide_console);
+    phase_with(|| format!("hidden console: {}", hidden::state()));
 
     let launcher_path =
         match std::env::current_exe().context("resolving the compiled executable path") {
@@ -379,6 +385,11 @@ fn launch(view: &PayloadView<'_>, launcher_path: &Path) -> Result<ExitStatus> {
     cmd.stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit());
+    // Inheriting is still right under `--hide-console`: from Explorer the handles
+    // are already invalid and Node treats them as it treats any closed stream,
+    // while from a terminal they are the console the user is watching and the
+    // suppression below does not apply.
+    hidden::apply(&mut cmd);
 
     phase_with(|| {
         let args: Vec<String> = cmd
@@ -1171,7 +1182,10 @@ fn acquire_embedded_node(
 /// spawn "is not measurable". Both halves are false on macOS, and the sentence
 /// sent one investigation looking for a regression that was never here.
 fn explain_if_node_cannot_start(node_bin: &Path) -> Result<()> {
-    let Ok(out) = Command::new(node_bin).arg("--version").output() else {
+    let mut probe = Command::new(node_bin);
+    probe.arg("--version");
+    hidden::apply(&mut probe);
+    let Ok(out) = probe.output() else {
         // Could not run it at all — the caller's own spawn will produce a better
         // error than a guess from here.
         return Ok(());
@@ -1811,7 +1825,10 @@ fn node_binary_stamp(path: &Path) -> Option<String> {
 }
 
 fn probe_node_version_inner(path: &Path) -> Option<NodeVersion> {
-    let out = Command::new(path).arg("--version").output().ok()?;
+    let mut probe = Command::new(path);
+    probe.arg("--version");
+    hidden::apply(&mut probe);
+    let out = probe.output().ok()?;
     if !out.status.success() {
         return None;
     }
@@ -1962,6 +1979,7 @@ fn download_via_commands(
 
     if let Some(curl) = curl {
         let mut cmd = Command::new(curl);
+        hidden::apply(&mut cmd);
         cmd.args(["-fSL", "--retry", "2"]);
         if muted {
             cmd.arg("-s");
@@ -1974,6 +1992,7 @@ fn download_via_commands(
     }
     if let Some(wget) = wget {
         let mut cmd = Command::new(wget);
+        hidden::apply(&mut cmd);
         if muted {
             cmd.arg("-q");
         }
@@ -3141,6 +3160,7 @@ mod tests {
             install_message: None,
             node_flags: Vec::new(),
             sealed_module_graph: false,
+            hide_console: false,
         }
     }
 

--- a/tests/compile-hide-console/README.md
+++ b/tests/compile-hide-console/README.md
@@ -1,0 +1,40 @@
+# `nub compile --hide-console` — no console window on Windows
+
+A GUI app, a tray icon or a file-association handler cannot ship with a console window attached to it. The flag gives the executable the GUI subsystem and tells its launcher to spawn Node with `CREATE_NO_WINDOW`.
+
+## What this covers that the unit tests cannot
+
+`crates/nub-cli/src/compile/inject.rs` proves the subsystem byte survives libsui's header rebuild, with a console-subsystem control beside it. That is one byte in a file nothing ran.
+
+The half that follows from it only exists on a real Windows host. Flipping the subsystem makes the launcher a GUI process, so its standard handles are no longer a console's, and it goes on to spawn Node — plus, on a first run, `curl` and a version probe — with console creation suppressed. The artifact still has to run, exit with the program's status, and deliver output through a redirect.
+
+## "No window appeared" is not what this asserts
+
+A headless runner has no desktop to observe, so the absence of a window is not measurable there. What the harness measures instead is whether the launcher **took** the suppressing path, read out of the `__NUB_LAUNCHER_TIMING` trace.
+
+Without that arm the harness would pass identically on a runner that owns a console — where the launcher deliberately suppresses nothing, every other assertion still holds, and the feature was never exercised. That case is reported as INCONCLUSIVE rather than failed: inheriting a console is the correct behavior when the user is watching one, and it is not the harness's business to fail over.
+
+## The four arms
+
+| | |
+| --- | --- |
+| 1 | `--hide-console` leaves the artifact GUI-subsystem (`Subsystem` = 2). |
+| 2 | **Negative control.** Without the flag it stays a console application (`Subsystem` = 3). Otherwise arm 1 would pass against a template that was already GUI-subsystem before nub touched it. |
+| 3 | The hidden artifact runs, prints through a redirect, and exits with the program's own status. |
+| 4 | The launcher reports that it suppressed its children's consoles — or says plainly that it did not, and why. |
+
+The subsystem is read back by `read-subsystem.mjs`, which shares no code with nub. nub's own reader runs inside `verify_artifact` on every compile, so using it here would only prove it agrees with itself.
+
+## Running it
+
+CI runs it on the `win32-x64` and `win32-arm64` legs of `compile-native.yml`, which already build the launcher this needs. Locally on Windows:
+
+```sh
+NUB=target/release/nub.exe \
+  __NUB_LAUNCHER_TEMPLATE=crates/nub-launcher/target/release/nub-launcher.exe \
+  tests/compile-hide-console/run.sh 26
+```
+
+The subsystem is set by byte-editing rather than by calling Windows, so arms 1 and 2 also run from macOS or Linux with `COMPILE_PLATFORM=win32-x64`. That path cross-compiles and cannot execute the artifact, so arms 3 and 4 are skipped there.
+
+It builds with `--smol` so no Node is downloaded: the subsystem lives in the launcher's PE either way.

--- a/tests/compile-hide-console/README.md
+++ b/tests/compile-hide-console/README.md
@@ -23,7 +23,20 @@ Without that arm the harness would pass identically on a runner that owns a cons
 | 3 | The hidden artifact runs, prints through a redirect, and exits with the program's own status. |
 | 4 | The launcher reports that it suppressed its children's consoles — or says plainly that it did not, and why. |
 
+The arm that is missing from that list is the user-visible one, and it is missing on purpose — see below.
+
 The subsystem is read back by `read-subsystem.mjs`, which shares no code with nub. nub's own reader runs inside `verify_artifact` on every compile, so using it here would only prove it agrees with itself.
+
+## The claim itself needs a desktop
+
+`observe-console.ps1` asks the question directly: launch the artifact through ShellExecute — what a double-click in Explorer does — and count the console windows that appear, with a build made without the flag as the control.
+
+It is deliberately **not** wired into CI. A hosted runner has no interactive desktop, so a console window may be un-creatable there and every assertion would pass without meaning anything. The script detects that itself: if the control opens no console either, it reports inconclusive rather than claiming a pass. Run it on a real Windows desktop or the local Windows VM (`windows-vm-test`):
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File observe-console.ps1 `
+  -Hidden .\hidden.exe -Shown .\shown.exe
+```
 
 ## Running it
 

--- a/tests/compile-hide-console/README.md
+++ b/tests/compile-hide-console/README.md
@@ -31,6 +31,8 @@ The subsystem is read back by `read-subsystem.mjs`, which shares no code with nu
 
 `observe-console.ps1` asks the question directly: launch the artifact through ShellExecute — what a double-click in Explorer does — and count the console windows that appear, with a build made without the flag as the control.
 
+The fixture it needs must write a marker file and exit 7. Standard output has nowhere to go when there is no console, so a file is the only channel that can prove the program ran rather than dying on its own invalid handles — which is the failure this flag could plausibly introduce and nothing else here would catch.
+
 It is deliberately **not** wired into CI. A hosted runner has no interactive desktop, so a console window may be un-creatable there and every assertion would pass without meaning anything. The script detects that itself: if the control opens no console either, it reports inconclusive rather than claiming a pass. Run it on a real Windows desktop or the local Windows VM (`windows-vm-test`):
 
 ```powershell

--- a/tests/compile-hide-console/README.md
+++ b/tests/compile-hide-console/README.md
@@ -31,9 +31,19 @@ The subsystem is read back by `read-subsystem.mjs`, which shares no code with nu
 
 `observe-console.ps1` asks the question directly: launch the artifact through ShellExecute — what a double-click in Explorer does — and count the console windows that appear, with a build made without the flag as the control.
 
-The fixture it needs must write a marker file and exit 7. Standard output has nowhere to go when there is no console, so a file is the only channel that can prove the program ran rather than dying on its own invalid handles — which is the failure this flag could plausibly introduce and nothing else here would catch.
+The fixture it needs must write a marker file, stay alive past `-SettleMs`, then exit 7. Staying alive is not incidental: Windows destroys a console with its last attached process, so a program that exits immediately is counted after its console has already gone — which reads as "no console" for the control as much as for the hidden build, and makes the whole run inconclusive. Standard output has nowhere to go when there is no console, so a file is the only channel that can prove the program ran rather than dying on its own invalid handles — which is the failure this flag could plausibly introduce and nothing else here would catch.
 
-It is deliberately **not** wired into CI. A hosted runner has no interactive desktop, so a console window may be un-creatable there and every assertion would pass without meaning anything. The script detects that itself: if the control opens no console either, it reports inconclusive rather than claiming a pass. Run it on a real Windows desktop or the local Windows VM (`windows-vm-test`):
+### Counting console hosts instead does not work
+
+The obvious way to make this runnable anywhere is to count console-host processes rather than windows, since Windows starts a `conhost` in every window station including the non-interactive one. It was tried on Server 2022 and it does not discriminate: `CREATE_NO_WINDOW` does not stop a console being **allocated**, it allocates one with no window. Control and hidden both started exactly one new console host, while the launcher traces confirmed only the hidden build had passed the flag. An assertion on that count reports a failure against a launcher doing exactly what it was asked.
+
+So the window is the only signal, and a window needs a desktop.
+
+### Getting a desktop
+
+It is deliberately **not** wired into CI, and SSH is not enough either. A hosted runner has no interactive desktop, and an SSH session on Windows lands in session 0 — the services session — where nothing can draw. In both cases the control opens no window, every assertion below it passes vacuously, and the script says so: it reports inconclusive rather than claiming a pass, and prints the session id it found.
+
+Run it from a session that has a desktop — RDP into the machine, or use its own console. On a GCE Windows VM (`gcloud-vm`) that means connecting over RDP, not the SSH path the rest of this harness uses.
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File observe-console.ps1 `

--- a/tests/compile-hide-console/observe-console.ps1
+++ b/tests/compile-hide-console/observe-console.ps1
@@ -1,0 +1,94 @@
+# Does a console window actually appear? — the one question CI cannot answer.
+#
+# run.sh asserts everything measurable without a desktop: the subsystem byte, that
+# the artifact runs, and that the launcher took the suppressing path. None of that
+# is the user-visible claim. This script makes the claim directly, by launching the
+# artifact the way Explorer does and counting the console windows that appear.
+#
+# NOT wired into CI. A hosted runner has no interactive desktop, so a console
+# window may be un-creatable there and every assertion below would pass without
+# meaning anything — the exact false green the harness is built to avoid. Run it on
+# a real Windows desktop or the local Windows VM.
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File observe-console.ps1 `
+#     -Hidden .\hidden.exe -Shown .\shown.exe
+param(
+  [Parameter(Mandatory = $true)][string]$Hidden,
+  [Parameter(Mandatory = $true)][string]$Shown,
+  [int]$SettleMs = 1500
+)
+$ErrorActionPreference = 'Stop'
+
+Add-Type @'
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+public static class Win {
+  delegate bool EnumProc(IntPtr hWnd, IntPtr lParam);
+  [DllImport("user32.dll")] static extern bool EnumWindows(EnumProc cb, IntPtr p);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+  static extern int GetClassName(IntPtr hWnd, StringBuilder buf, int max);
+  [DllImport("user32.dll")] static extern bool IsWindowVisible(IntPtr hWnd);
+  // Every console window is one of these two classes: the classic conhost window
+  // and the Windows 11 / Windows Terminal one. Counted rather than matched by
+  // title, which a program can change.
+  public static List<IntPtr> Consoles() {
+    var found = new List<IntPtr>();
+    EnumWindows((h, p) => {
+      var sb = new StringBuilder(256);
+      if (GetClassName(h, sb, sb.Capacity) > 0) {
+        var cls = sb.ToString();
+        if ((cls == "ConsoleWindowClass" || cls == "PseudoConsoleWindow") && IsWindowVisible(h))
+          found.Add(h);
+      }
+      return true;
+    }, IntPtr.Zero);
+    return found;
+  }
+}
+'@
+
+function Measure-Launch([string]$exe, [string]$label) {
+  $before = [Win]::Consoles()
+  $hosts0 = @(Get-Process -Name conhost, OpenConsole -ErrorAction SilentlyContinue).Count
+  # ShellExecute, which is what a double-click in Explorer does — and unlike a
+  # direct spawn it hands the child no console of ours to inherit, so a
+  # console-subsystem program gets a brand new window.
+  $proc = Start-Process -FilePath $exe -PassThru
+  Start-Sleep -Milliseconds $SettleMs
+  $after = [Win]::Consoles()
+  $hosts1 = @(Get-Process -Name conhost, OpenConsole -ErrorAction SilentlyContinue).Count
+  try { if (-not $proc.HasExited) { $proc.Kill() } } catch { }
+  $new = @($after | Where-Object { $before -notcontains $_ }).Count
+  Write-Host ("  {0}: {1} new console window(s), conhost delta {2}" -f $label, $new, ($hosts1 - $hosts0))
+  return $new
+}
+
+$fail = 0
+
+# The control runs FIRST and on purpose. If an ordinary compiled binary shows no
+# console either, then this desktop cannot create one and the hidden result below
+# proves nothing — which is a different answer from "the feature works".
+Write-Host "== control: a binary built WITHOUT --hide-console =="
+$shownWindows = Measure-Launch $Shown 'shown.exe'
+if ($shownWindows -lt 1) {
+  Write-Host "  INCONCLUSIVE: no console appeared for the control either, so this"
+  Write-Host "                environment cannot show one and the arm below is vacuous."
+  Write-Host "RESULT: inconclusive on this host"
+  exit 0
+}
+Write-Host "  ok: the control opens a console, so this desktop can show one"
+
+Write-Host "== the claim: --hide-console opens none =="
+$hiddenWindows = Measure-Launch $Hidden 'hidden.exe'
+if ($hiddenWindows -eq 0) {
+  Write-Host "  ok: no console window appeared"
+} else {
+  Write-Host ("  FAIL: {0} console window(s) appeared" -f $hiddenWindows)
+  $fail = 1
+}
+
+Write-Host ""
+if ($fail -eq 0) { Write-Host "RESULT: all checks passed" } else { Write-Host "RESULT: $fail check(s) failed" }
+exit $fail

--- a/tests/compile-hide-console/observe-console.ps1
+++ b/tests/compile-hide-console/observe-console.ps1
@@ -58,16 +58,24 @@ public static class Win {
 }
 '@
 
-# Two independent signals, because each one is blind somewhere.
+# THE ASSERTION IS THE WINDOW, AND ONLY THE WINDOW.
 #
-# CONSOLE HOST COUNT is the primary. Windows starts one console host process per
-# console it allocates, and it does so in every window station - including the
-# non-interactive one an SSH session runs in, where window enumeration sees
-# nothing at all. This is the signal that survives being driven remotely.
+# Console-host COUNT looks like the more portable signal and is the wrong one:
+# CREATE_NO_WINDOW does not stop a console being ALLOCATED, it allocates one with
+# no window. So a correctly-hidden artifact starts a conhost exactly like an
+# ordinary one, and asserting on that count reports a failure against a launcher
+# doing precisely what it was asked. Measured on Server 2022: control and hidden
+# both showed one new console host, and the traces confirmed the hidden launcher
+# had passed CREATE_NO_WINDOW.
 #
-# WINDOW COUNT is the confirmation, and it is what literally answers "did
-# something appear on screen". It only means anything on an interactive desktop,
-# so it is reported rather than asserted on.
+# What separates them is whether that console has a visible window, which is only
+# observable from a session that HAS a desktop. An SSH session runs in session 0,
+# where the control reports no window either -- that is the inconclusive case, and
+# the control arm below is what detects it rather than reporting a false failure.
+# NOTE: never name a result variable $Hidden/$Shown. PowerShell variables are
+# case-insensitive, the parameters above are [string]-typed, and assigning an
+# object to one silently stringifies it -- so `.Hosts` reads as empty and the
+# arm misreports rather than erroring.
 function Measure-Launch([string]$exe, [string]$label) {
   $before = [Win]::Consoles()
   $hosts0 = @(Get-Process -Name conhost, OpenConsole -ErrorAction SilentlyContinue).Count
@@ -76,7 +84,14 @@ function Measure-Launch([string]$exe, [string]$label) {
   # program gets a brand new one.
   Remove-Item -Force -ErrorAction SilentlyContinue $script:Marker
   $proc = Start-Process -FilePath $exe -PassThru
+  # Sampled WHILE it runs. Sampling after exit measures nothing: Windows destroys a
+  # console with its last attached process, so a short-lived program shows a zero
+  # delta whether or not it ever had one. That mistake made the control look as
+  # console-free as the hidden build and turned the whole run inconclusive.
   Start-Sleep -Milliseconds $SettleMs
+  if ($proc.HasExited) {
+    Write-Host ("  WARNING: {0} exited before it was sampled; the fixture must outlive -SettleMs" -f $label)
+  }
   $after  = [Win]::Consoles()
   $hosts1 = @(Get-Process -Name conhost, OpenConsole -ErrorAction SilentlyContinue).Count
   # Let it finish rather than killing it. The exit code and the marker are the only
@@ -87,8 +102,8 @@ function Measure-Launch([string]$exe, [string]$label) {
   $ran = Test-Path $script:Marker
   $windows = @($after | Where-Object { $before -notcontains $_ }).Count
   $hosts = $hosts1 - $hosts0
-  Write-Host ("  {0}: {1} new console host(s), {2} new console window(s), exit {3}, marker {4}" `
-    -f $label, $hosts, $windows, $code, $ran)
+  Write-Host ("  {0}: {1} new console window(s), {2} new console host(s), exit {3}, marker {4}" `
+    -f $label, $windows, $hosts, $code, $ran)
   return [pscustomobject]@{ Hosts = $hosts; Windows = $windows; Code = $code; Ran = $ran }
 }
 
@@ -99,27 +114,33 @@ $script:Marker = $Marker
 # no console either, this host cannot show one and the hidden result below proves
 # nothing - which is a different answer from "the feature works".
 Write-Host "== control: a binary built WITHOUT --hide-console =="
-$control = Measure-Launch $Shown 'shown.exe'
-if (-not $control.Ran) {
+$controlResult = Measure-Launch $Shown 'shown.exe'
+if (-not $controlResult.Ran) {
   Write-Host "  FAIL: the control never wrote its marker, so the fixture is wrong and"
   Write-Host "        nothing below can be believed."
   Write-Host "RESULT: 1 check(s) failed"
   exit 1
 }
-if ($control.Hosts -lt 1) {
-  Write-Host "  INCONCLUSIVE: the control allocated no console either, so this host"
-  Write-Host "                cannot show one and the arm below would be vacuous."
+if ($controlResult.Windows -lt 1) {
+  Write-Host "  INCONCLUSIVE: the control opened no console WINDOW, so this host has no"
+  Write-Host "                interactive desktop and the arm below would be vacuous."
+  Write-Host ("                (session {0}; an SSH session runs in session 0, which has none)" -f (Get-Process -Id $PID).SessionId)
+  Write-Host "                Run this from a desktop session -- RDP, or the console itself."
   Write-Host "RESULT: inconclusive on this host"
   exit 0
 }
-Write-Host "  ok: the control allocates a console, so this host can"
+Write-Host "  ok: the control opens a console window, so this host can show one"
 
-Write-Host "== the claim: --hide-console allocates none =="
-$hidden = Measure-Launch $Hidden 'hidden.exe'
-if ($hidden.Hosts -eq 0) {
-  Write-Host "  ok: no console was allocated"
+Write-Host "== the claim: --hide-console opens no console WINDOW =="
+$hiddenResult = Measure-Launch $Hidden 'hidden.exe'
+if ($hiddenResult.Windows -eq 0) {
+  Write-Host "  ok: no console window appeared"
+  if ($hiddenResult.Hosts -gt 0) {
+    Write-Host "       (a console host still started, which is correct: CREATE_NO_WINDOW"
+    Write-Host "        allocates a console without a window rather than none at all)"
+  }
 } else {
-  Write-Host ("  FAIL: {0} console host(s) started, so a window would appear" -f $hidden.Hosts)
+  Write-Host ("  FAIL: {0} console window(s) appeared" -f $hiddenResult.Windows)
   $fail = 1
 }
 
@@ -127,10 +148,10 @@ if ($hidden.Hosts -eq 0) {
 # standard handles are invalid, and this is where a launcher that mishandles them
 # shows up: no marker, or a nonzero exit.
 Write-Host "== and it still runs, with no valid standard handles =="
-if ($hidden.Ran -and $hidden.Code -eq 7) {
+if ($hiddenResult.Ran -and $hiddenResult.Code -eq 7) {
   Write-Host "  ok: the program ran to completion and returned its own exit code"
 } else {
-  Write-Host ("  FAIL: marker {0}, exit {1} (expected marker True, exit 7)" -f $hidden.Ran, $hidden.Code)
+  Write-Host ("  FAIL: marker {0}, exit {1} (expected marker True, exit 7)" -f $hiddenResult.Ran, $hiddenResult.Code)
   $fail = 1
 }
 

--- a/tests/compile-hide-console/observe-console.ps1
+++ b/tests/compile-hide-console/observe-console.ps1
@@ -20,6 +20,10 @@
 param(
   [Parameter(Mandatory = $true)][string]$Hidden,
   [Parameter(Mandatory = $true)][string]$Shown,
+  # The fixture must write this file and then exit 7. Standard output has nowhere
+  # to go when there is no console, so a file is the only channel that proves the
+  # program actually ran rather than dying on its own invalid handles.
+  [string]$Marker = "$env:TEMP\nub-hidden-probe.txt",
   [int]$SettleMs = 2000
 )
 $ErrorActionPreference = 'Stop'
@@ -70,25 +74,39 @@ function Measure-Launch([string]$exe, [string]$label) {
   # ShellExecute, which is what a double-click in Explorer does. Unlike a direct
   # spawn it hands the child no console of ours to inherit, so a console-subsystem
   # program gets a brand new one.
+  Remove-Item -Force -ErrorAction SilentlyContinue $script:Marker
   $proc = Start-Process -FilePath $exe -PassThru
   Start-Sleep -Milliseconds $SettleMs
   $after  = [Win]::Consoles()
   $hosts1 = @(Get-Process -Name conhost, OpenConsole -ErrorAction SilentlyContinue).Count
-  try { if (-not $proc.HasExited) { $proc.Kill() } } catch { }
+  # Let it finish rather than killing it. The exit code and the marker are the only
+  # evidence that a GUI-subsystem launcher, whose standard handles are invalid,
+  # actually ran the program instead of dying on them.
+  $exited = $proc.WaitForExit(20000)
+  $code = if ($exited) { $proc.ExitCode } else { try { $proc.Kill() } catch { }; 'TIMEOUT' }
+  $ran = Test-Path $script:Marker
   $windows = @($after | Where-Object { $before -notcontains $_ }).Count
   $hosts = $hosts1 - $hosts0
-  Write-Host ("  {0}: {1} new console host(s), {2} new console window(s)" -f $label, $hosts, $windows)
-  return $hosts
+  Write-Host ("  {0}: {1} new console host(s), {2} new console window(s), exit {3}, marker {4}" `
+    -f $label, $hosts, $windows, $code, $ran)
+  return [pscustomobject]@{ Hosts = $hosts; Windows = $windows; Code = $code; Ran = $ran }
 }
 
 $fail = 0
+$script:Marker = $Marker
 
 # The control runs FIRST and on purpose. If an ordinary compiled binary allocates
 # no console either, this host cannot show one and the hidden result below proves
 # nothing - which is a different answer from "the feature works".
 Write-Host "== control: a binary built WITHOUT --hide-console =="
-$shownHosts = Measure-Launch $Shown 'shown.exe'
-if ($shownHosts -lt 1) {
+$control = Measure-Launch $Shown 'shown.exe'
+if (-not $control.Ran) {
+  Write-Host "  FAIL: the control never wrote its marker, so the fixture is wrong and"
+  Write-Host "        nothing below can be believed."
+  Write-Host "RESULT: 1 check(s) failed"
+  exit 1
+}
+if ($control.Hosts -lt 1) {
   Write-Host "  INCONCLUSIVE: the control allocated no console either, so this host"
   Write-Host "                cannot show one and the arm below would be vacuous."
   Write-Host "RESULT: inconclusive on this host"
@@ -97,11 +115,22 @@ if ($shownHosts -lt 1) {
 Write-Host "  ok: the control allocates a console, so this host can"
 
 Write-Host "== the claim: --hide-console allocates none =="
-$hiddenHosts = Measure-Launch $Hidden 'hidden.exe'
-if ($hiddenHosts -eq 0) {
+$hidden = Measure-Launch $Hidden 'hidden.exe'
+if ($hidden.Hosts -eq 0) {
   Write-Host "  ok: no console was allocated"
 } else {
-  Write-Host ("  FAIL: {0} console host(s) started, so a window would appear" -f $hiddenHosts)
+  Write-Host ("  FAIL: {0} console host(s) started, so a window would appear" -f $hidden.Hosts)
+  $fail = 1
+}
+
+# Hiding a console the program needed is not a success. With no console its
+# standard handles are invalid, and this is where a launcher that mishandles them
+# shows up: no marker, or a nonzero exit.
+Write-Host "== and it still runs, with no valid standard handles =="
+if ($hidden.Ran -and $hidden.Code -eq 7) {
+  Write-Host "  ok: the program ran to completion and returned its own exit code"
+} else {
+  Write-Host ("  FAIL: marker {0}, exit {1} (expected marker True, exit 7)" -f $hidden.Ran, $hidden.Code)
   $fail = 1
 }
 

--- a/tests/compile-hide-console/observe-console.ps1
+++ b/tests/compile-hide-console/observe-console.ps1
@@ -1,21 +1,26 @@
-# Does a console window actually appear? — the one question CI cannot answer.
+# Does a console actually appear? - the one question CI cannot answer.
+#
+# ASCII ONLY, deliberately. PowerShell 5.1 reads a BOM-less script in the ANSI
+# codepage, so a single em-dash in a comment fails the whole file with "The string
+# is missing the terminator", pointing at the last line rather than the offending
+# one. Keep every character in this file plain ASCII.
 #
 # run.sh asserts everything measurable without a desktop: the subsystem byte, that
 # the artifact runs, and that the launcher took the suppressing path. None of that
 # is the user-visible claim. This script makes the claim directly, by launching the
-# artifact the way Explorer does and counting the console windows that appear.
+# artifact the way Explorer does and watching for a console being allocated.
 #
-# NOT wired into CI. A hosted runner has no interactive desktop, so a console
-# window may be un-creatable there and every assertion below would pass without
-# meaning anything — the exact false green the harness is built to avoid. Run it on
-# a real Windows desktop or the local Windows VM.
+# NOT wired into CI. A hosted runner may not be able to allocate a console at all,
+# in which case every assertion below passes without meaning anything - the exact
+# false green this harness exists to avoid. The control arm detects that and says
+# so instead of reporting a pass.
 #
 #   powershell -NoProfile -ExecutionPolicy Bypass -File observe-console.ps1 `
 #     -Hidden .\hidden.exe -Shown .\shown.exe
 param(
   [Parameter(Mandatory = $true)][string]$Hidden,
   [Parameter(Mandatory = $true)][string]$Shown,
-  [int]$SettleMs = 1500
+  [int]$SettleMs = 2000
 )
 $ErrorActionPreference = 'Stop'
 
@@ -31,7 +36,7 @@ public static class Win {
   static extern int GetClassName(IntPtr hWnd, StringBuilder buf, int max);
   [DllImport("user32.dll")] static extern bool IsWindowVisible(IntPtr hWnd);
   // Every console window is one of these two classes: the classic conhost window
-  // and the Windows 11 / Windows Terminal one. Counted rather than matched by
+  // and the Windows 11 / Windows Terminal one. Counted by class rather than by
   // title, which a program can change.
   public static List<IntPtr> Consoles() {
     var found = new List<IntPtr>();
@@ -49,43 +54,54 @@ public static class Win {
 }
 '@
 
+# Two independent signals, because each one is blind somewhere.
+#
+# CONSOLE HOST COUNT is the primary. Windows starts one console host process per
+# console it allocates, and it does so in every window station - including the
+# non-interactive one an SSH session runs in, where window enumeration sees
+# nothing at all. This is the signal that survives being driven remotely.
+#
+# WINDOW COUNT is the confirmation, and it is what literally answers "did
+# something appear on screen". It only means anything on an interactive desktop,
+# so it is reported rather than asserted on.
 function Measure-Launch([string]$exe, [string]$label) {
   $before = [Win]::Consoles()
   $hosts0 = @(Get-Process -Name conhost, OpenConsole -ErrorAction SilentlyContinue).Count
-  # ShellExecute, which is what a double-click in Explorer does — and unlike a
-  # direct spawn it hands the child no console of ours to inherit, so a
-  # console-subsystem program gets a brand new window.
+  # ShellExecute, which is what a double-click in Explorer does. Unlike a direct
+  # spawn it hands the child no console of ours to inherit, so a console-subsystem
+  # program gets a brand new one.
   $proc = Start-Process -FilePath $exe -PassThru
   Start-Sleep -Milliseconds $SettleMs
-  $after = [Win]::Consoles()
+  $after  = [Win]::Consoles()
   $hosts1 = @(Get-Process -Name conhost, OpenConsole -ErrorAction SilentlyContinue).Count
   try { if (-not $proc.HasExited) { $proc.Kill() } } catch { }
-  $new = @($after | Where-Object { $before -notcontains $_ }).Count
-  Write-Host ("  {0}: {1} new console window(s), conhost delta {2}" -f $label, $new, ($hosts1 - $hosts0))
-  return $new
+  $windows = @($after | Where-Object { $before -notcontains $_ }).Count
+  $hosts = $hosts1 - $hosts0
+  Write-Host ("  {0}: {1} new console host(s), {2} new console window(s)" -f $label, $hosts, $windows)
+  return $hosts
 }
 
 $fail = 0
 
-# The control runs FIRST and on purpose. If an ordinary compiled binary shows no
-# console either, then this desktop cannot create one and the hidden result below
-# proves nothing — which is a different answer from "the feature works".
+# The control runs FIRST and on purpose. If an ordinary compiled binary allocates
+# no console either, this host cannot show one and the hidden result below proves
+# nothing - which is a different answer from "the feature works".
 Write-Host "== control: a binary built WITHOUT --hide-console =="
-$shownWindows = Measure-Launch $Shown 'shown.exe'
-if ($shownWindows -lt 1) {
-  Write-Host "  INCONCLUSIVE: no console appeared for the control either, so this"
-  Write-Host "                environment cannot show one and the arm below is vacuous."
+$shownHosts = Measure-Launch $Shown 'shown.exe'
+if ($shownHosts -lt 1) {
+  Write-Host "  INCONCLUSIVE: the control allocated no console either, so this host"
+  Write-Host "                cannot show one and the arm below would be vacuous."
   Write-Host "RESULT: inconclusive on this host"
   exit 0
 }
-Write-Host "  ok: the control opens a console, so this desktop can show one"
+Write-Host "  ok: the control allocates a console, so this host can"
 
-Write-Host "== the claim: --hide-console opens none =="
-$hiddenWindows = Measure-Launch $Hidden 'hidden.exe'
-if ($hiddenWindows -eq 0) {
-  Write-Host "  ok: no console window appeared"
+Write-Host "== the claim: --hide-console allocates none =="
+$hiddenHosts = Measure-Launch $Hidden 'hidden.exe'
+if ($hiddenHosts -eq 0) {
+  Write-Host "  ok: no console was allocated"
 } else {
-  Write-Host ("  FAIL: {0} console window(s) appeared" -f $hiddenWindows)
+  Write-Host ("  FAIL: {0} console host(s) started, so a window would appear" -f $hiddenHosts)
   $fail = 1
 }
 

--- a/tests/compile-hide-console/read-subsystem.mjs
+++ b/tests/compile-hide-console/read-subsystem.mjs
@@ -1,0 +1,24 @@
+// The PE `Subsystem` field, read independently of nub.
+//
+// nub's own reader runs inside `verify_artifact` on every compile, so using it
+// here would only prove it agrees with itself. This walks the header the way
+// Windows' loader does: e_lfanew at 0x3c, the COFF header, then the optional
+// header, whose `Subsystem` sits at offset 68 in BOTH PE32 and PE32+ — PE32's
+// extra BaseOfData and its narrower ImageBase cancel out.
+//
+// Prints `2` for a GUI image, `3` for a console one, or `none` when the file is
+// not a placeable PE.
+import { readFileSync } from "node:fs";
+
+const image = readFileSync(process.argv[2]);
+const pe = image.readUInt32LE(0x3c);
+if (image.toString("latin1", pe, pe + 4) !== "PE\0\0") {
+  console.log("none");
+  process.exit(0);
+}
+const magic = image.readUInt16LE(pe + 24);
+if (magic !== 0x10b && magic !== 0x20b) {
+  console.log("none");
+  process.exit(0);
+}
+console.log(String(image.readUInt16LE(pe + 24 + 68)));

--- a/tests/compile-hide-console/run.sh
+++ b/tests/compile-hide-console/run.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# `nub compile --hide-console` end to end, on a real Windows runner.
+#
+# The unit tests prove the subsystem byte survives libsui's header rebuild. What
+# they cannot reach is the half that follows from it: the launcher becomes a GUI
+# process, so its standard handles are no longer a console's, and it goes on to
+# spawn Node with CREATE_NO_WINDOW. That artifact has to still run, still exit
+# with the program's status, and still deliver output through a redirect.
+#
+# "No window appeared" is NOT what this asserts — a headless runner has no desktop
+# to observe. What it asserts instead is that the launcher TOOK the suppressing
+# path, read out of the timing trace, so a green run cannot come from a runner
+# where nothing was suppressed and every other check passed anyway.
+#
+# Usage: NUB=<nub.exe> __NUB_LAUNCHER_TEMPLATE=<launcher.exe> run.sh <node-version>
+set -euo pipefail
+
+NUB="${NUB:?set NUB to the built nub}"
+NODE_TARGET="${1:?usage: run.sh <node-version>}"
+READER="$(cd "$(dirname "$0")" && pwd)/read-subsystem.mjs"
+
+work="$(mktemp -d)"
+cd "$work"
+echo "fixture: $work"
+
+echo '{ "name": "hidden-app", "version": "1.0.0" }' > package.json
+cat > app.ts <<'TS'
+process.stdout.write(`ran ${process.argv.length >= 2 ? "ok" : "odd"}\n`);
+process.exit(7);
+TS
+
+fail=0
+inconclusive=0
+check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; else echo "  FAIL: $1 — expected [$2], got [$3]"; fail=$((fail+1)); fi; }
+
+# --smol so no Node blob is downloaded: the subsystem lives in the launcher's PE
+# either way. COMPILE_PLATFORM is a development escape hatch, not something CI
+# sets — the flip is byte editing, so the header arms of this harness can be
+# exercised from macOS or Linux before it is pushed. The RUN arms cannot.
+compile() {
+  "$NUB" compile app.ts --smol --target "$NODE_TARGET" --out "$1" \
+    ${COMPILE_PLATFORM:+--platform "$COMPILE_PLATFORM"} "${@:2}" >/dev/null
+}
+
+echo "== 1. --hide-console gives the artifact the GUI subsystem =="
+compile hidden.exe --hide-console
+check "subsystem" "2" "$(node "$READER" hidden.exe)"
+
+# Without this the arm above proves nothing: it would pass just as well against a
+# launcher template that was GUI-subsystem before nub touched it.
+echo "== 2. NEGATIVE CONTROL: without the flag it stays a console application =="
+compile shown.exe
+check "subsystem" "3" "$(node "$READER" shown.exe)"
+
+if [ -n "${COMPILE_PLATFORM:-}" ]; then
+  echo
+  echo "COMPILE_PLATFORM set — skipping the run arms, which need a real Windows host"
+  echo "RESULT: $fail check(s) failed"
+  exit "$fail"
+fi
+
+# The half that only a real Windows host can answer. A GUI-subsystem process has
+# no console of its own, so if any of this were wrong the artifact would hang,
+# die, or print nothing — none of which the header check above can see.
+echo "== 3. the hidden artifact still runs, and its output survives a redirect =="
+set +e
+out="$(./hidden.exe 2>err.txt)"
+code=$?
+set -e
+check "stdout"    "ran ok" "$out"
+check "exit code" "7"      "$code"
+
+# The assertion that keeps arm 3 honest. On a runner that already owns a console
+# the launcher deliberately suppresses nothing, and arm 3 would pass without ever
+# exercising the CREATE_NO_WINDOW path this feature is made of.
+echo "== 4. the launcher took the suppressing path =="
+__NUB_LAUNCHER_TIMING=1 ./hidden.exe >/dev/null 2>trace.txt || true
+line="$(grep -o 'hidden console: .*' trace.txt || echo '@MISSING')"
+echo "  trace: $line"
+case "$line" in
+  *"suppressing child consoles"*)
+    echo "  ok: children were spawned with no console" ;;
+  # The deliberate terminal case. Not a defect and not this harness's business to
+  # fail over — but arms 1-3 then say nothing about CREATE_NO_WINDOW, so it is
+  # reported loudly rather than passed off as a green run.
+  *"a console is already attached"*)
+    echo "  INCONCLUSIVE: this runner owns a console, which the launcher inherits by"
+    echo "                design, so arms 1-3 did not exercise the suppression path."
+    inconclusive=1 ;;
+  *"off (not a hidden build)"*)
+    echo "  FAIL: the artifact was built with --hide-console and the launcher does not"
+    echo "        know it — the flag is not reaching the payload manifest."
+    fail=$((fail+1)) ;;
+  *)
+    echo "  FAIL: the launcher emitted no hidden-console phase at all"
+    fail=$((fail+1)) ;;
+esac
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "RESULT: $fail check(s) failed"
+elif [ "$inconclusive" -ne 0 ]; then
+  echo "RESULT: checks passed, but the suppression path was never taken on this host"
+else
+  echo "RESULT: all checks passed"
+fi
+exit "$fail"


### PR DESCRIPTION
Bun ships `--windows-hide-console` and Deno ships `--no-terminal`. Nub had neither the flag nor the mechanism, so anything with a GUI, a tray icon or a file-association handler could not ship on it.

## Why the subsystem flip is only half of it

Bun and Deno **are** the process they hide, so setting the PE subsystem to GUI is their entire fix. Nub's launcher spawns Node, and Windows allocates a console for a console-subsystem child whose parent has none — so the flip alone just moves the flash from the launcher to Node, and on a `--smol` first run to `curl`/`wget` and the version probe as well.

So the artifact carries the decision. `Manifest::hide_console` is `#[serde(default)]`, so older payloads still load, and the launcher passes `CREATE_NO_WINDOW` on every spawn it makes. That is process-wide state rather than a threaded argument because the spawn sites are spread across several call paths, and it is armed once from the payload before the first of them runs.

**Suppression is conditional on no console being attached already.** A GUI process started from `cmd.exe` inherits that console, and suppressing the child's would throw away output the user is watching; started from Explorer there is nothing to inherit. Bun gets that split for free by being one process; this reproduces it rather than picking a side.

## Where the flip is applied

To the finished image, not the template: libsui rebuilds the PE headers while rewriting the resource directory, so a subsystem set on the way in is discarded — the same reason the icon and version resource are set inside that builder chain. `verify_artifact` reads the field back, since a cross-compiled Windows binary is never executed on the build host.

`Subsystem` sits at optional-header offset 68 in both PE32 and PE32+, so the position is `pe + 24 + 68` with no magic-dependent arithmetic. Deno computes it as `standard_fields_size + 68`, which is correct only because it ships 64-bit alone; on PE32 that lands in `DllCharacteristics`.

## Verification

`tests/compile-hide-console/run.sh` runs on the Windows legs of `compile-native.yml`. It cannot see a window, so it asserts what a headless runner can: the subsystem byte with a console-subsystem control, that the artifact still runs and delivers output through a redirect, and — from the timing trace — that the launcher actually took the suppressing path, so a runner that owns a console reports itself inconclusive rather than passing for the wrong reason.

`observe-console.ps1` asks the question directly on a real desktop: launch through ShellExecute as Explorer does, count consoles allocated, with a non-hidden build as the control and a marker file proving the program ran despite its invalid standard handles. Deliberately not wired into CI, which has no interactive desktop.

Also repairs a doc comment #830 split across two tests in `compile/mod.rs`.

Refs #830
