### PR TITLE
compile: key the Node flag cache per binary instead of one flat map

### DIFF
--- a/crates/nub-core/Cargo.toml
+++ b/crates/nub-core/Cargo.toml
@@ -33,7 +33,7 @@ repository = "https://github.com/nubjs/nub"
 # it on via `nub-cli/embed-runtime`. The optional deps are pulled in ONLY here:
 # `ruzstd` (pure-Rust decode at runtime) ships in the binary; `zstd`/`tar`/`sha2`
 # (encode + key-hash at build time) are build-deps that never reach the binary.
-embed-runtime = ["dep:ruzstd", "dep:zstd", "dep:tar", "dep:sha2", "dep:blake3"]
+embed-runtime = ["dep:ruzstd", "dep:zstd", "dep:tar", "dep:sha2"]
 
 [dependencies]
 anyhow = "1"
@@ -98,7 +98,14 @@ ruzstd = { version = "0.8", optional = true }
 # win-arm64/musl), vs ~6 ms for BLAKE3's portable SIMD. BLAKE3 is collision/preimage
 # resistant — fully adequate for integrity — and builds identically on every target.
 # (`sha2` stays for the 32-bit cache KEY, which is not on the hot path.)
-blake3 = { version = "1", optional = true }
+#
+# NOT optional, though the R2 digest use above is `embed-runtime`-only: the
+# per-binary Node flag cache (`node::discovery`, `FLAG_ENTRY_DIR`) names its entry
+# files by hashing the binary's path, and that cache is read on every spawn in
+# every build. Unconditional costs the shipped artifacts nothing — nub-launcher
+# already depends on blake3 directly and nub-cli's release build turns
+# `embed-runtime` on — so only a feature-off dev build gains it.
+blake3 = "1"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/crates/nub-core/Cargo.toml
+++ b/crates/nub-core/Cargo.toml
@@ -33,7 +33,7 @@ repository = "https://github.com/nubjs/nub"
 # it on via `nub-cli/embed-runtime`. The optional deps are pulled in ONLY here:
 # `ruzstd` (pure-Rust decode at runtime) ships in the binary; `zstd`/`tar`/`sha2`
 # (encode + key-hash at build time) are build-deps that never reach the binary.
-embed-runtime = ["dep:ruzstd", "dep:zstd", "dep:tar", "dep:sha2"]
+embed-runtime = ["dep:ruzstd", "dep:zstd", "dep:tar", "dep:sha2", "dep:blake3"]
 
 [dependencies]
 anyhow = "1"
@@ -122,6 +122,21 @@ zstd = { version = "0.13", optional = true }
 sha2 = { version = "0.11", optional = true }
 # Bakes the R2 per-entrypoint BLAKE3 digests (the runtime side decodes with the
 # `blake3` dep above). build-deps never reach the shipped binary.
+#
+# STILL OPTIONAL, and `embed-runtime` must keep listing `dep:blake3` even though the
+# NORMAL dependency of the same name is now unconditional — this is the activator for
+# THIS one, and nothing else is. Dropping it from the feature list compiles a
+# build.rs whose `#[cfg(feature = "embed-runtime")]` half calls `blake3::hash` with
+# the crate unlinked: E0433 from the build script.
+#
+# NO GATE WE RUN CATCHES THAT, which is the part worth remembering. An optional
+# dependency no feature mentions still gets an IMPLICIT feature of its own name, and
+# `--all-features` turns it on — so `clippy --all-targets --all-features` and the
+# whole test suite stay green while the real build, which asks for the exact set
+# (`--features embed-runtime,compile`), breaks. It surfaced on CI's musl
+# native-islands leg and nowhere before it. Verify a change here with
+# `cargo tree -p nub-core -e build --features nub-core/embed-runtime`: blake3 present
+# with the feature, absent without, so a feature-off dev build still pays nothing.
 blake3 = { version = "1", optional = true }
 
 # Unix-only: terminating-signal forwarding to the child (SIGINT/SIGTERM/SIGHUP).

--- a/crates/nub-core/src/node/discovery.rs
+++ b/crates/nub-core/src/node/discovery.rs
@@ -1717,43 +1717,15 @@ pub fn accepts_argv_flag(node_path: &Path, flag: &str) -> Option<bool> {
 
 /// Read the cached argv-flag verdict for (binary, flag), honoring the mtime key.
 fn read_argv_flag_cache(node_path: &Path, flag: &str) -> Option<bool> {
-    let cache = cache_dir()?.join("node-argv-flags.json");
-    let content = fs::read_to_string(&cache).ok()?;
-    let data: serde_json::Value = serde_json::from_str(&content).ok()?;
-    let entry = data.get(node_path.to_string_lossy().as_ref())?;
-    if entry.get("mtime")?.as_u64()? != node_mtime_secs(node_path)? {
-        return None;
-    }
-    entry.get("flags")?.get(flag)?.as_bool()
+    read_flag_entry(node_path)?.argv.get(flag).copied()
 }
 
 /// Record the argv-flag verdict for (binary, flag). Best-effort: a failed write
 /// only costs a re-probe.
 fn write_argv_flag_cache(node_path: &Path, flag: &str, accepted: bool) {
-    let Some(dir) = cache_dir() else { return };
-    let Some(dir) = safe_cache_dir(dir) else {
-        return;
-    };
-    let cache = dir.join("node-argv-flags.json");
-
-    let mut data: serde_json::Value = fs::read_to_string(&cache)
-        .ok()
-        .and_then(|c| serde_json::from_str(&c).ok())
-        .unwrap_or_else(|| serde_json::json!({}));
-
-    let key = node_path.to_string_lossy().to_string();
-    let mtime = node_mtime_secs(node_path).unwrap_or(0);
-    // A stale entry (different mtime) is replaced wholesale rather than merged —
-    // the old verdicts describe a different binary.
-    if data[&key].get("mtime").and_then(|m| m.as_u64()) != Some(mtime) {
-        data[&key] = serde_json::json!({ "mtime": mtime, "flags": {} });
-    }
-    data[&key]["flags"][flag] = serde_json::json!(accepted);
-
-    let _ = fs::write(
-        &cache,
-        serde_json::to_string_pretty(&data).unwrap_or_default(),
-    );
+    update_flag_entry(node_path, |entry| {
+        entry.argv.insert(flag.to_string(), accepted);
+    });
 }
 
 /// mtime (seconds since epoch) of a Node binary, for cache-key freshness. `None`
@@ -1769,50 +1741,132 @@ fn node_mtime_secs(node_path: &Path) -> Option<u64> {
 }
 
 /// Read the cached `allowedNodeEnvironmentFlags` set for a binary, honoring the
-/// (path, mtime) key so a rebuilt/replaced Node at the same path re-probes. Kept in
-/// a sibling file to `node-discovery.json` so it never risks the version cache.
+/// (path, mtime) key so a rebuilt/replaced Node at the same path re-probes.
 fn read_env_flags_cache(node_path: &Path) -> Option<std::collections::BTreeSet<String>> {
-    let cache = cache_dir()?.join("node-env-flags.json");
-    let content = fs::read_to_string(&cache).ok()?;
-    let data: serde_json::Value = serde_json::from_str(&content).ok()?;
-    let key = node_path.to_string_lossy();
-    let entry = data.get(key.as_ref())?;
-    let cached_mtime = entry.get("mtime")?.as_u64()?;
-
-    if cached_mtime != node_mtime_secs(node_path)? {
-        return None;
-    }
-
-    let arr = entry.get("flags")?.as_array()?;
-    Some(
-        arr.iter()
-            .filter_map(|v| v.as_str().map(str::to_string))
-            .collect(),
-    )
+    let env = read_flag_entry(node_path)?.env?;
+    Some(env.into_iter().collect())
 }
 
 fn write_env_flags_cache(node_path: &Path, flags: &std::collections::BTreeSet<String>) {
-    let Some(dir) = cache_dir() else { return };
-    let Some(dir) = safe_cache_dir(dir) else {
+    update_flag_entry(node_path, |entry| {
+        entry.env = Some(flags.iter().cloned().collect());
+    });
+}
+
+/// Both probe verdicts for ONE Node binary: its `allowedNodeEnvironmentFlags` set
+/// and its per-flag argv verdicts. They share the (path, mtime) key and are read on
+/// the same spawn, so they share a file and a launch reads one.
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+struct NodeFlagEntry {
+    /// The binary this describes. Stored so a hashed-filename collision is a miss
+    /// (one re-probe) rather than another binary's verdicts.
+    path: String,
+    mtime: u64,
+    /// Absent until the env-flag probe has run; the argv probe writes the file first
+    /// whenever a `Mitigation::UnflagArgv` row applies to a Node nub did not install.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    env: Option<Vec<String>>,
+    #[serde(default)]
+    argv: std::collections::BTreeMap<String, bool>,
+}
+
+/// ONE FILE PER BINARY, not one shared map — the same shape, and for the same
+/// reason, as the launcher's `cache::ProbeStore`.
+///
+/// These verdicts used to live in two flat `{ "<path>": … }` maps
+/// (`node-env-flags.json`, `node-argv-flags.json`) that every read parsed WHOLE, via
+/// `serde_json::Value`, to pull a single key. The env-flag set is ~256 strings per
+/// binary, so the file grew ~9 KB for every Node the machine had ever seen and the
+/// parse grew with it — on a hot path taken by every compiled-artifact launch AND
+/// every non-compat `nub` spawn. Measured on linux-x64, warm, hello-world artifact:
+/// the pre-spawn flag window ran 0.08 ms at 1 entry, 0.45 at 10, 2.09 at 50 and
+/// 8.45 at 200 — 0.042 ms of pure parse per remembered Node, per launch, forever.
+/// For scale, the whole rest of the launcher's warm work is ~0.6 ms. Keyed per
+/// binary the read is one small file whatever else the machine has installed.
+///
+/// It also stops one bad entry from poisoning every other: a single malformed byte
+/// anywhere in a shared map made `from_str` fail for EVERY binary — a `node` spawn
+/// per launch, indefinitely — and the next write reset the map, discarding every
+/// other binary's verdicts.
+///
+/// The legacy files are left alone rather than deleted. They are inert (nothing
+/// reads them now) and leaving them keeps a downgrade working.
+const FLAG_ENTRY_DIR: &str = "node-flags";
+
+/// The entry filename for `node_path`: a hash, so an arbitrary filesystem path
+/// becomes a fixed-width name that cannot escape the directory. A collision costs
+/// one re-probe, never a wrong verdict — `read_flag_entry` compares the stored path.
+fn flag_entry_name(node_path: &Path) -> String {
+    blake3::hash(node_path.to_string_lossy().as_bytes())
+        .to_hex()
+        .to_string()
+}
+
+fn read_flag_entry(node_path: &Path) -> Option<NodeFlagEntry> {
+    read_flag_entry_in(&cache_dir()?, node_path)
+}
+
+/// `read_flag_entry` against an explicit cache root, so a test can drive it without
+/// mutating process-global environment (`XDG_CACHE_HOME`) — the seam
+/// `nub_store_node_in` established.
+fn read_flag_entry_in(cache_root: &Path, node_path: &Path) -> Option<NodeFlagEntry> {
+    let path = cache_root
+        .join(FLAG_ENTRY_DIR)
+        .join(flag_entry_name(node_path));
+    let entry: NodeFlagEntry = serde_json::from_str(&fs::read_to_string(&path).ok()?).ok()?;
+    // Any doubt means "probe it again", which is always correct and merely slower:
+    // a hash collision, or a binary rebuilt in place since the verdict was recorded.
+    if entry.path != node_path.to_string_lossy() || entry.mtime != node_mtime_secs(node_path)? {
+        return None;
+    }
+    Some(entry)
+}
+
+/// Read-modify-write one binary's entry. Best-effort throughout: a cache that
+/// cannot be written is a slower launch, never a failed one.
+fn update_flag_entry(node_path: &Path, mutate: impl FnOnce(&mut NodeFlagEntry)) {
+    let Some(cache_root) = cache_dir().and_then(safe_cache_dir) else {
         return;
     };
-    let cache = dir.join("node-env-flags.json");
+    update_flag_entry_in(&cache_root, node_path, mutate);
+}
 
-    let mut data: serde_json::Value = fs::read_to_string(&cache)
-        .ok()
-        .and_then(|c| serde_json::from_str(&c).ok())
-        .unwrap_or_else(|| serde_json::json!({}));
+/// `update_flag_entry` against an explicit cache root — the write half of the
+/// `read_flag_entry_in` seam.
+fn update_flag_entry_in(
+    cache_root: &Path,
+    node_path: &Path,
+    mutate: impl FnOnce(&mut NodeFlagEntry),
+) {
+    let dir = cache_root.join(FLAG_ENTRY_DIR);
+    if fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let Some(mtime) = node_mtime_secs(node_path) else {
+        return;
+    };
+    // A stale entry is replaced wholesale rather than merged — the old verdicts
+    // describe a different binary at the same path.
+    let mut entry = read_flag_entry_in(cache_root, node_path).unwrap_or_default();
+    entry.path = node_path.to_string_lossy().into_owned();
+    entry.mtime = mtime;
+    mutate(&mut entry);
 
-    let key = node_path.to_string_lossy().to_string();
-    data[key] = serde_json::json!({
-        "flags": flags.iter().collect::<Vec<_>>(),
-        "mtime": node_mtime_secs(node_path).unwrap_or(0),
-    });
-
-    let _ = fs::write(
-        &cache,
-        serde_json::to_string_pretty(&data).unwrap_or_default(),
-    );
+    let Ok(body) = serde_json::to_string(&entry) else {
+        return;
+    };
+    // Written through a temp file and renamed: the two probes write the same entry,
+    // so a concurrent reader must never see a half-written one. A torn read would
+    // only cost a re-probe, but rename is free here and removes the case.
+    let final_path = dir.join(flag_entry_name(node_path));
+    let staging = dir.join(format!(
+        "{}.{}.tmp",
+        flag_entry_name(node_path),
+        std::process::id()
+    ));
+    if fs::write(&staging, body).is_ok() && fs::rename(&staging, &final_path).is_err() {
+        let _ = fs::remove_file(&staging);
+    }
 }
 
 /// Scan the nvm install directory for a version matching the pin.
@@ -3012,5 +3066,97 @@ mod tests {
             }
             Err(e) => panic!("unexpected error: {e}"),
         }
+    }
+
+    /// The verdicts for one Node must be readable no matter what is on disk for
+    /// another. They used to share two flat `{ "<path>": … }` maps that every read
+    /// parsed WHOLE, which had two consequences this pins down: the parse was
+    /// O(every Node the machine had ever seen) on a path taken by every launch, and
+    /// one malformed entry made `from_str` fail for EVERY binary — a `node` spawn
+    /// per launch, indefinitely.
+    #[test]
+    fn a_damaged_entry_for_one_binary_does_not_hide_anothers_verdicts() {
+        let dir = unique_tmp("flagcache-isolation");
+        let cache = dir.join("cache");
+        let (mine, other) = (dir.join("node-a"), dir.join("node-b"));
+        std::fs::write(&mine, b"a").unwrap();
+        std::fs::write(&other, b"b").unwrap();
+
+        update_flag_entry_in(&cache, &mine, |e| {
+            e.env = Some(vec!["--experimental-vm-modules".to_string()]);
+        });
+        update_flag_entry_in(&cache, &other, |e| e.env = Some(vec![]));
+
+        // Corrupt the OTHER binary's entry, exactly as a truncated write would.
+        let damaged = cache.join(FLAG_ENTRY_DIR).join(flag_entry_name(&other));
+        std::fs::write(&damaged, b"{not json").unwrap();
+
+        assert_eq!(
+            read_flag_entry_in(&cache, &mine).and_then(|e| e.env),
+            Some(vec!["--experimental-vm-modules".to_string()]),
+            "a damaged entry for a different binary must not affect this one"
+        );
+        assert!(
+            read_flag_entry_in(&cache, &other).is_none(),
+            "the damaged entry itself must read as a miss, not as empty verdicts"
+        );
+    }
+
+    /// Both probes key on (path, mtime) and are read on the same spawn, so they
+    /// share one file — and a binary rebuilt in place invalidates both together.
+    #[test]
+    fn both_verdicts_share_one_entry_and_lapse_when_the_binary_changes() {
+        let dir = unique_tmp("flagcache-roundtrip");
+        let cache = dir.join("cache");
+        let node = dir.join("node");
+        std::fs::write(&node, b"v1").unwrap();
+
+        update_flag_entry_in(&cache, &node, |e| e.env = Some(vec!["--permission".into()]));
+        update_flag_entry_in(&cache, &node, |e| {
+            e.argv.insert("--js-defer-import-eval".into(), false);
+        });
+
+        let entry = read_flag_entry_in(&cache, &node).expect("both writes land in one entry");
+        assert_eq!(entry.env.as_deref(), Some(&["--permission".to_string()][..]));
+        assert_eq!(entry.argv.get("--js-defer-import-eval"), Some(&false));
+        assert_eq!(
+            std::fs::read_dir(cache.join(FLAG_ENTRY_DIR)).unwrap().count(),
+            1,
+            "one binary must occupy exactly one entry file"
+        );
+
+        // Move the mtime far enough that a whole-second key changes.
+        let later = std::time::SystemTime::now() + std::time::Duration::from_secs(5);
+        std::fs::write(&node, b"v2").unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&node)
+            .unwrap()
+            .set_modified(later)
+            .unwrap();
+        assert!(
+            read_flag_entry_in(&cache, &node).is_none(),
+            "a binary replaced at the same path must re-probe, not reuse the old verdicts"
+        );
+    }
+
+    /// The entry filename is a hash of the path, so the path is stored INSIDE and
+    /// compared on read: a collision costs one re-probe, never another binary's
+    /// verdicts.
+    #[test]
+    fn an_entry_recorded_for_a_different_path_is_a_miss() {
+        let dir = unique_tmp("flagcache-collision");
+        let cache = dir.join("cache");
+        let node = dir.join("node");
+        std::fs::write(&node, b"x").unwrap();
+        update_flag_entry_in(&cache, &node, |e| e.env = Some(vec![]));
+
+        let entry_path = cache.join(FLAG_ENTRY_DIR).join(flag_entry_name(&node));
+        let mut entry: NodeFlagEntry =
+            serde_json::from_str(&std::fs::read_to_string(&entry_path).unwrap()).unwrap();
+        entry.path = "/somewhere/else/bin/node".into();
+        std::fs::write(&entry_path, serde_json::to_string(&entry).unwrap()).unwrap();
+
+        assert!(read_flag_entry_in(&cache, &node).is_none());
     }
 }

--- a/crates/nub-launcher/Cargo.lock
+++ b/crates/nub-launcher/Cargo.lock
@@ -1005,6 +1005,7 @@ name = "nub-core"
 version = "0.8.3"
 dependencies = [
  "anyhow",
+ "blake3",
  "camino",
  "dirs-next",
  "dotenvy",

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -285,6 +285,7 @@ fn launch(view: &PayloadView<'_>, launcher_path: &Path) -> Result<ExitStatus> {
         NodeOrigin::Managed => None,
         NodeOrigin::Discovered => discovery::accepted_env_flags(&node_path),
     };
+    phase("  flags: accepted_env_flags");
     let mut inject = flags::compute_inject_flags(
         version.clone(),
         // The compiled entry is already the first positional argument to Node;
@@ -295,6 +296,7 @@ fn launch(view: &PayloadView<'_>, launcher_path: &Path) -> Result<ExitStatus> {
         false,
         accepted.as_ref(),
     );
+    phase("  flags: compute_inject_flags");
     // Compiled launchers need the closed 22.4–<25 experimental flag band for
     // sessionStorage. Their compile preamble can neutralize the flag's throwing
     // localStorage getter, but this launcher never synthesizes a storage file or
@@ -328,6 +330,7 @@ fn launch(view: &PayloadView<'_>, launcher_path: &Path) -> Result<ExitStatus> {
         flags::argv_inject_flags(argv_probe_path, &version, &[])
     };
     inject.extend(argv_only.iter().copied());
+    phase("  flags: argv_inject_flags");
 
     let mut cmd = Command::new(node_path.as_os_str());
     // Node runs CommonJS preloads before ESM `--import` hooks, including ones
@@ -1420,7 +1423,9 @@ fn discover_external_smol_node(m: &Manifest) -> Result<Option<(PathBuf, NodeVers
     let target = smol_target(m)?;
     let mut trusted: Option<(PathBuf, NodeVersion)> = None;
     let mut ranked: Vec<(PathBuf, NodeVersion)> = Vec::new();
-    for dir in version_manager_dirs() {
+    let roots = version_manager_dirs();
+    phase_with(|| format!("  smol: {} version-manager root(s)", roots.len()));
+    for dir in roots {
         let (owned, candidates) = best_node_in(&dir, &target, &m.triple);
         if let Some(found) = owned {
             if trusted.as_ref().is_none_or(|(_, cur)| found.1 > *cur) {
@@ -1434,12 +1439,14 @@ fn discover_external_smol_node(m: &Manifest) -> Result<Option<(PathBuf, NodeVers
         return Ok(trusted);
     }
     ranked.sort_by(|(_, left), (_, right)| right.cmp(left));
+    phase_with(|| format!("  smol: {} candidate(s) scanned + ranked", ranked.len()));
     // Gate-checked once for the whole pass rather than once per candidate: this
     // loop runs to the END of the ranked list whenever no external Node satisfies
     // the payload (an exact `--target` the user has not installed is the ordinary
     // way to hit that), so the per-lookup cost is multiplied by every Node on the
     // machine.
     let probes = cache::ProbeStore::resolve();
+    phase("  smol: probe store resolved");
     let verified = ranked.into_iter().find_map(|(path, _)| {
         let actual = probe_node_version(&probes, &path)?;
         smol_candidate_matches(&actual, &target).then_some((path, actual))
@@ -1761,15 +1768,24 @@ fn probe_path_node(
     select_path_node((path, ver), target)
 }
 
-/// Counts probe execs for `__NUB_LAUNCHER_TIMING`. Each one is a full `node`
-/// process spawn (~28 ms), so the count is the whole story for smol start-up.
 /// The version of the Node at `path`, from a remembered verdict when one applies
-/// and an exec otherwise.
+/// and an exec otherwise. Logs which of the two happened under
+/// `__NUB_LAUNCHER_TIMING`; an exec is a full `node` process spawn (~28 ms), so on a
+/// COLD probe cache the exec count is the whole story for smol start-up.
 ///
-/// The exec is why `--smol` starts slower than the embed shape: `--smol` discovers
-/// a Node it did not install, so it runs it once per launch to learn what it really
-/// is. That is a full process spawn and it accounts for the whole warm gap between
-/// the two shapes. Embed needs none of this — it knows its Node by content hash.
+/// It is not the story on a WARM one, and this comment used to say it was — that the
+/// exec "accounts for the whole warm gap between the two shapes". A warm launch takes
+/// the cache-hit branch above and execs nothing, so it cannot. Measured on linux-x64,
+/// hello-world artifact, min of 25 interleaved runs, one Node on PATH and no version
+/// manager installed: the launcher's own pre-spawn work is 0.56 ms for embed against
+/// 0.66 ms for smol, and the 0.10 ms between them is ~0.05 ms of
+/// `discover_external_smol_node` (the version-manager root scan plus
+/// `cache::ProbeStore::resolve`, both of which embed skips entirely), ~0.03 ms reading
+/// this verdict back off disk, and ~0.06 ms extra in `discovery::accepted_env_flags`,
+/// because a DISCOVERED Node is probe-gated where a managed one is trusted from its
+/// version. The first two grow with how many Nodes the machine has — ~0.011 ms per
+/// installed version, since every candidate is stat'd (and, on Linux, ELF-checked)
+/// before the ranked list is probed.
 ///
 /// A stale or untrusted entry simply means another exec, so every failure path here
 /// is the slow answer rather than a wrong one.
@@ -2564,15 +2580,16 @@ fn cleanup_launcher_orphans(base: &Path, manifest: &Manifest) {
     cleanup_orphan_entries(base, None, ORPHAN_STAGE_MAX_AGE, |name| {
         launcher_stage_name(name, ".compile-app.") || launcher_stage_name(name, ".compile-node.")
     });
-    for parent in [
-        base.join("compile-app"),
-        base.join("compile-node"),
-        base.join("node"),
-    ] {
+    for parent in [base.join("compile-app"), base.join("compile-node")] {
         cleanup_orphan_entries(&parent, None, ORPHAN_STAGE_MAX_AGE, launcher_stale_name);
     }
+    // The node store's two grammars share ONE pass. Every `cleanup_orphan_entries`
+    // call costs a `cache::revalidate` ancestor walk plus a `read_dir` before it can
+    // reject a single name, and this runs on every launch including a fully warm one
+    // — so scanning the same directory twice to apply two predicates was pure
+    // duplicate syscalls. Same entries removed, same ages, half the walks.
     cleanup_orphan_entries(&base.join("node"), None, ORPHAN_STAGE_MAX_AGE, |name| {
-        launcher_stage_name(name, ".smol.")
+        launcher_stale_name(name) || launcher_stage_name(name, ".smol.")
     });
 
     // Published trees this run does not use. `current` is what keeps a

--- a/tests/windows/compile-cache-release.ps1
+++ b/tests/windows/compile-cache-release.ps1
@@ -106,13 +106,13 @@ function Assert-NoRuntimeWriteThrough {
     # The property under test is that the RUNTIME CACHE refuses an unsafe candidate
     # -- ensure_safe_base returns None and extraction falls through. Assert that by
     # the absence of an extracted `runtime-*` tree, NOT by the absence of the `nub`
-    # directory: nub's node-discovery / node-env-flags / transpile / v8-compile-cache
+    # directory: nub's node-discovery / node-flags / transpile / v8-compile-cache
     # caches create that directory unconditionally through a plain create_dir_all,
     # with no DACL validation of their own, so it exists either way and testing for
     # it can never pass. Measured on windows-latest against a real release build --
     # under a rejected Everyone-Modify ancestor the `nub` dir held exactly
-    # transpile/, v8-compile-cache/, node-discovery.json and node-env-flags.json,
-    # runtime-* count 0, while the runtime itself landed in the fallback root.
+    # transpile/, v8-compile-cache/, node-discovery.json and the per-binary flag
+    # cache, runtime-* count 0, while the runtime itself landed in the fallback root.
     #
     # That those other caches write into an unsafe directory at all is a real but
     # SEPARATE gap, tracked as a follow-up; it is not what this gate covers.


### PR DESCRIPTION
Warm-start work on the compiled artifact's launcher, and on the `nub` spawn path it shares.

## The premise moved before the work started

Every figure in the brief for this came from released v0.8.2, which spawned Node and waited. `e3de38c4e9` replaced that with `exec` on Unix. Re-measured on `main` first — linux-x64, hello-world artifact, warm, min of 25 interleaved runs, clean cache, one Node on PATH, no version manager installed:

| | v0.8.2 (darwin, contended host) | `main` (linux-x64) |
|---|---|---|
| embed — launcher's own pre-spawn work | 2.09 ms | **0.56 ms** |
| smol — launcher's own pre-spawn work | 6.80 ms | **0.66 ms** |

End to end: `node -e 0` 27.8 ms, embed 33.8 ms, smol 36.5 ms. The launcher's own work is ~2% of the artifact's start; most of the rest of the gap is Node itself starting from a different binary.

So there were no fixed milliseconds left to remove. Both leads turned out to be **unbounded per-Node terms**.

## What the phase split found

Six finer `__NUB_LAUNCHER_TIMING` phases put `cache revalidated → about to spawn node` almost entirely inside one call, `discovery::accepted_env_flags` — 0.07 ms of 0.09 on smol, with `compute_inject_flags` and `argv_inject_flags` ~0.01 each. Sweeping the flat map's entry count:

| entries in `node-env-flags.json` | file size | flag window |
|---|---|---|
| 1 | 8.9 KB | 0.08 ms |
| 10 | 89 KB | 0.45 ms |
| 50 | 447 KB | 2.09 ms |
| 200 | 1.79 MB | 8.45 ms |

Dead linear: **0.042 ms of `serde_json::Value` parse per remembered Node, per launch**, against ~0.6 ms for the entire rest of the launcher's warm work. At 46 entries — one real developer machine — that is ~1.9 ms, which matches the brief's unattributed figure exactly.

The second lead, the `--smol` version-manager scan, is the same shape and 3.7x shallower: 0.09 ms at 0 installs, 0.17 at 1, 0.28 at 10, 0.73 at 50 → **~0.011 ms per installed Node**.

## What this changes

**One entry file per binary** under `node-flags/`, replacing the two flat `{ "<path>": … }` maps. Both verdicts share the `(path, mtime)` key and are read on the same spawn, so they share a file and a launch reads one — the same shape, for the same reason, as the launcher's own `cache::ProbeStore`. Not launcher-only: `accepted_env_flags` is on `node::spawn`'s path and two `cli.rs` sites, so every non-compat `nub run` / `nub <file>` / `nubx` paid this too.

It also stops one bad entry poisoning every other. A single malformed byte in a shared map made `from_str` fail for **every** binary — a `node` spawn per launch, indefinitely — and the next write reset the map, discarding every other binary's verdicts. Three tests pin the per-binary keying, the shared invalidation, and the collision guard.

`blake3` becomes a non-optional `nub-core` dependency, since it names the entry files. That costs the shipped artifacts nothing — `nub-launcher` already depends on it directly and `nub-cli`'s release build turns `embed-runtime` on — so only a feature-off dev build gains it. `crates/nub-launcher/Cargo.lock` moves with it.

**One orphan-sweep pass over the node store instead of two.** That GC runs on every launch including a fully warm one, and each `cleanup_orphan_entries` call costs a `cache::revalidate` ancestor walk plus a `read_dir` before it can reject a single name. Same entries removed, same ages, half the walks.

**The `probe_node_version` doc comment is corrected.** It claimed the version exec "accounts for the whole warm gap between the two shapes"; a warm launch takes the cache-hit branch and execs nothing, so it cannot. Replaced with the measured split.

## Measured and deliberately left alone

- **The `--smol` rescan.** ~0.011 ms per installed Node, redone every launch with nothing remembering which Node won. A fix means new persisted state with its own invalidation rules — worth its own change and review, and it is the smaller of the two terms.
- **The orphan GC's remaining ~0.06 ms.** Gating it on cold launches would remove it, since garbage is only produced by a launch that extracts — but a warm-forever artifact would then stop reclaiming another payload's 30-day-old tree. A real behaviour change for ~9% of a 0.6 ms budget.
- **`app_cache_is_ready`, ~0.29 ms — the largest single fixed cost, ~45% of a warm launch.** It zstd-decompresses every app payload file and byte-compares it against the on-disk copy, so it is O(bundle size) per start; hello-world hides that. Whether it can be cheapened is a cache-trust question rather than a perf one.

## Verification

`clippy --all-targets --all-features` (all four legs, including `nub-launcher`) and the full `cargo test` are green on a remote builder; the three new tests run and pass.

The direct proof is sweep 1 re-run against the fix. The pre-spawn flag window, same host, same script, same min-of-25 interleaved method:

| sibling entries | before — one flat map | after — one file per binary |
|---|---|---|
| 1 | 0.08 ms | **0.05 ms** |
| 10 | 0.45 ms | **0.05 ms** |
| 50 | 2.09 ms | **0.05 ms** |
| 200 | 8.45 ms | **0.05 ms** |

Flat, and the launcher's whole warm path holds at 0.66 ms at every entry count — the per-Node term is gone rather than reduced. The version-manager sweep is unchanged, as expected, since this does not touch that scan.

One piece of fallout not fixed here, because this branch is under a no-docs constraint: `wiki/research/node-experimental-flag-lifecycle.md:40` still names `~/.cache/nub/node-env-flags.json` as where the verdict is cached. One-line follow-up.
