### PR TITLE
pm: rename the neutral build allowlist to allowScripts

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -10294,7 +10294,7 @@ fn run_pm_use(name: &str, spec: &str, cwd: &Path) -> Result<i32> {
 
     // `use pnpm` regenerates pnpm-workspace.yaml from the nub-mode package.json
     // homes (workspaces + catalogs, top-level overrides/patchedDependencies/
-    // allowBuilds/auditConfig) — the exact reverse of `use nub`'s migration.
+    // allowScripts/auditConfig) — the exact reverse of `use nub`'s migration.
     // No-op on a project that never carried them.
     if name == "pnpm" {
         for line in crate::pm_engine::use_nub::regenerate_workspace_yaml(&root)? {

--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -43,7 +43,7 @@
 ///   The shared `pnpm-workspace.yaml` compat surface is gated separately on the
 ///   `EngineContext` (`read_branded_pnpm_config`), per the role.
 /// - `manifest_namespace` = `""` — nub reads its config from the manifest
-///   ROOT (top-level `workspaces`/`overrides`/`allowBuilds`), not a branded
+///   ROOT (top-level `workspaces`/`overrides`/`allowScripts`), not a branded
 ///   `"nub"` object.
 /// - `env_prefix` = `None` — nub exposes NONE of aube's internal debug /
 ///   perf-bisect toggle family (`AUBE_DISABLE_*`, `AUBE_CAS_*`, `AUBE_INTERNAL_*`,

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1363,6 +1363,16 @@ fn apply_config_scope(
     });
 
     if noise == ConfigScopeNoise::Warn {
+        // Renamed-field hard-error. The build allowlist moved from a top-level
+        // `allowBuilds` map to `allowScripts`, the field npm 12 gates its own
+        // install scripts on. Proceeding would silently drop every approval AND
+        // every explicit `false` denial the old map records — a security-
+        // relevant miss in the permissive direction for the denials — so refuse
+        // instead. Role-independent: the top-level map is nub's own key, read on
+        // every surface, and no other PM reads it either.
+        if manifest.has_legacy_root_allow_builds() {
+            return Err(legacy_allow_builds_error());
+        }
         // Catalog hard-error: a role that doesn't honor `catalog:` specifiers
         // (npm/yarn/bun, pnpm<9) must mirror the real PM and refuse, rather
         // than silently mis-resolve. nub-branded, role-named.
@@ -1491,6 +1501,19 @@ fn first_catalog_in_dep_maps(manifest: &aube_manifest::PackageJson) -> Option<St
 
 /// Hard error mirroring the active PM's refusal of a `catalog:` specifier —
 /// nub-branded, role-named, with the remedy.
+/// The refusal for a project still carrying the pre-cutover top-level
+/// `allowBuilds` map. Names the mechanical fix, because that is the whole
+/// migration: the key is renamed and the entries are unchanged.
+fn legacy_allow_builds_error() -> anyhow::Error {
+    anyhow::anyhow!(
+        "nub: package.json sets a top-level `allowBuilds` map — that field was renamed to \
+         `allowScripts`, which is also the field npm reads. Rename the key in package.json; \
+         the entries are unchanged. (`pnpm.allowBuilds` and a `pnpm-workspace.yaml` \
+         `allowBuilds:` block are pnpm's own surface and still read as-is.) \
+         [ERR_NUB_ALLOW_BUILDS_RENAMED]"
+    )
+}
+
 fn catalog_unsupported_error(role: config_scope::Role, spec: &str) -> anyhow::Error {
     let pm = role.display();
     anyhow::anyhow!(

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -1130,8 +1130,16 @@ pub(crate) fn regenerate_workspace_yaml(root: &Path) -> Result<Vec<String>> {
     // The nub-mode home is the neutral top-level `allowScripts`; pnpm's home
     // for the same map is `allowBuilds`, so this one entry is renamed on the
     // way out rather than moved verbatim.
+    //
+    // The pre-cutover root key is accepted here too. This command never builds
+    // an install session, so the `ERR_NUB_ALLOW_BUILDS_RENAMED` refusal cannot
+    // reach it — a project that predates the rename would otherwise switch to
+    // pnpm with its whole build policy stranded at a root key pnpm does not
+    // read. Migrating it out is strictly better than refusing, because pnpm's
+    // destination key is the legacy spelling anyway.
     let allow_builds = manifest
         .get(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY)
+        .or_else(|| manifest.get(aube_manifest::LEGACY_ROOT_ALLOW_BUILDS_KEY))
         .cloned();
     let audit_config = manifest.get("auditConfig").cloned();
 
@@ -1174,6 +1182,10 @@ pub(crate) fn regenerate_workspace_yaml(root: &Path) -> Result<Vec<String>> {
             "overrides",
             "patchedDependencies",
             aube_manifest::ROOT_ALLOW_SCRIPTS_KEY,
+            // Cleared alongside the current spelling: whichever of the two the
+            // project carried was just written into the yaml above, so leaving
+            // it here would strand a duplicate nothing reads.
+            aube_manifest::LEGACY_ROOT_ALLOW_BUILDS_KEY,
             "auditConfig",
         ] {
             obj.remove(key);
@@ -1460,6 +1472,51 @@ mod tests {
 
         // Idempotent rerun: nothing left to move.
         assert!(regenerate_workspace_yaml(dir.path()).unwrap().is_empty());
+    }
+
+    /// A project that predates the `allowBuilds` → `allowScripts` rename can
+    /// reach `nub pm use pnpm` directly: that command builds no install
+    /// session, so the rename refusal never runs. The legacy map must still
+    /// migrate, or the switch strands the whole build policy at a root key
+    /// pnpm does not read.
+    #[test]
+    fn regenerate_migrates_a_pre_cutover_allow_builds_map() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            serde_json::to_string_pretty(&json!({
+                "name": "app",
+                "packageManager": "nub@0.1.0",
+                "allowBuilds": { "esbuild": true, "fsevents": false }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let lines = regenerate_workspace_yaml(dir.path()).unwrap();
+        assert!(
+            !lines.is_empty(),
+            "the legacy map must be migrated, not skipped"
+        );
+
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            &std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(yaml["allowBuilds"]["esbuild"], true);
+        assert_eq!(
+            yaml["allowBuilds"]["fsevents"], false,
+            "a denial must survive the switch — losing it runs a script the project refused"
+        );
+
+        let manifest: Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("package.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            manifest.get("allowBuilds").is_none(),
+            "the legacy key must not be left behind as a duplicate"
+        );
     }
 
     #[test]

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -1097,6 +1097,32 @@ fn remove_strays(paths: &[std::path::PathBuf], why: &str) -> Result<()> {
     Ok(())
 }
 
+/// Fold the two manifest-root build-allowlist spellings into the single map
+/// pnpm reads, with an explicit `false` beating any allow — the same deny-wins
+/// rule the engine applies when one package is named by several sources.
+///
+/// Both arguments are passed because a manifest can legitimately carry both: the
+/// rename refusal only guards paths that build an install session, and `nub pm
+/// use pnpm` is not one. Order is irrelevant to the result; a denial in either
+/// map survives.
+///
+/// `None` when neither name holds an object, which is what keeps a manifest with
+/// nothing to migrate on the idempotent-rerun path.
+fn merge_root_allow_maps(legacy: Option<&Value>, current: Option<&Value>) -> Option<Value> {
+    let mut out: Option<Map<String, Value>> = None;
+    for map in [legacy, current].into_iter().flatten() {
+        let Some(map) = map.as_object() else { continue };
+        let acc = out.get_or_insert_with(Map::new);
+        for (key, value) in map {
+            if acc.get(key) == Some(&Value::Bool(false)) {
+                continue;
+            }
+            acc.insert(key.clone(), value.clone());
+        }
+    }
+    out.map(Value::Object)
+}
+
 /// The yaml-regeneration half of `nub pm use pnpm` — the exact reverse of
 /// [`run_use_nub`]'s migration: collect the nub-mode homes out of
 /// `package.json` (`workspaces` membership + catalogs, top-level `overrides`
@@ -1131,16 +1157,18 @@ pub(crate) fn regenerate_workspace_yaml(root: &Path) -> Result<Vec<String>> {
     // for the same map is `allowBuilds`, so this one entry is renamed on the
     // way out rather than moved verbatim.
     //
-    // The pre-cutover root key is accepted here too. This command never builds
-    // an install session, so the `ERR_NUB_ALLOW_BUILDS_RENAMED` refusal cannot
-    // reach it — a project that predates the rename would otherwise switch to
-    // pnpm with its whole build policy stranded at a root key pnpm does not
-    // read. Migrating it out is strictly better than refusing, because pnpm's
-    // destination key is the legacy spelling anyway.
-    let allow_builds = manifest
-        .get(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY)
-        .or_else(|| manifest.get(aube_manifest::LEGACY_ROOT_ALLOW_BUILDS_KEY))
-        .cloned();
+    // The pre-cutover root key is read here too, and MERGED rather than chosen
+    // between. This command never builds an install session, so the
+    // `ERR_NUB_ALLOW_BUILDS_RENAMED` refusal cannot reach it — a project that
+    // predates the rename, or that is part-way through it and carries both
+    // spellings, would otherwise switch to pnpm with its build policy stranded
+    // at a root key pnpm does not read. Taking one map wholesale would drop the
+    // other's entries silently, and the entry that matters is a `false`: losing
+    // a denial runs a script the project refused.
+    let allow_builds = merge_root_allow_maps(
+        manifest.get(aube_manifest::LEGACY_ROOT_ALLOW_BUILDS_KEY),
+        manifest.get(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY),
+    );
     let audit_config = manifest.get("auditConfig").cloned();
 
     if packages.is_none()
@@ -1182,9 +1210,9 @@ pub(crate) fn regenerate_workspace_yaml(root: &Path) -> Result<Vec<String>> {
             "overrides",
             "patchedDependencies",
             aube_manifest::ROOT_ALLOW_SCRIPTS_KEY,
-            // Cleared alongside the current spelling: whichever of the two the
-            // project carried was just written into the yaml above, so leaving
-            // it here would strand a duplicate nothing reads.
+            // Cleared alongside the current spelling. Both were folded into the
+            // one map written above, so removing only one would strand a
+            // duplicate nothing reads.
             aube_manifest::LEGACY_ROOT_ALLOW_BUILDS_KEY,
             "auditConfig",
         ] {
@@ -1517,6 +1545,59 @@ mod tests {
             manifest.get("allowBuilds").is_none(),
             "the legacy key must not be left behind as a duplicate"
         );
+    }
+
+    /// A manifest can carry both spellings — the rename refusal guards only the
+    /// paths that build an install session, and this is not one. Choosing one
+    /// map wholesale would drop the other's entries, and the entry that matters
+    /// is the denial: `fsevents: false` in the stale map against `true` in the
+    /// new one has to reach pnpm as `false`, or the switch runs a script the
+    /// project refused.
+    #[test]
+    fn regenerate_folds_both_allow_spellings_with_the_denial_winning() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            serde_json::to_string_pretty(&json!({
+                "name": "app",
+                "packageManager": "nub@0.1.0",
+                "allowScripts": { "esbuild": true, "fsevents": true, "sharp": true },
+                "allowBuilds": { "fsevents": false, "canvas": false, "sharp": true }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        regenerate_workspace_yaml(dir.path()).unwrap();
+
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            &std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            yaml["allowBuilds"]["fsevents"], false,
+            "a denial in the stale map must beat an allow in the new one"
+        );
+        assert_eq!(
+            yaml["allowBuilds"]["esbuild"], true,
+            "an entry only the new map carries must survive"
+        );
+        assert_eq!(
+            yaml["allowBuilds"]["canvas"], false,
+            "an entry only the stale map carries must survive"
+        );
+        assert_eq!(yaml["allowBuilds"]["sharp"], true);
+
+        let manifest: Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("package.json")).unwrap(),
+        )
+        .unwrap();
+        for key in ["allowScripts", "allowBuilds"] {
+            assert!(
+                manifest.get(key).is_none(),
+                "{key} must not be left behind once folded into the yaml"
+            );
+        }
     }
 
     #[test]

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -15,7 +15,7 @@
 //! - resolution-bearing keys → `package.json` under ecosystem-standard
 //!   top-level names (`workspaces` incl. the object form,
 //!   `workspaces.catalog(s)`, `overrides`, `patchedDependencies`, the
-//!   three-state `allowBuilds` map, `auditConfig`);
+//!   three-state `allowScripts` map, `auditConfig`);
 //! - settings → `.npmrc` (the same vocabulary, kebab spellings — one engine
 //!   reads both homes, so this is a mechanical move, not a translation);
 //! - engine-unsupported keys → warn-drop naming each (the three repo-wide
@@ -377,10 +377,10 @@ pub(crate) struct YamlMigration {
     /// and package.json live in the same directory, so relative patch paths
     /// stay correct).
     pub patched_dependencies: Option<Map<String, Value>>,
-    /// Top-level three-state `allowBuilds` map. Folds the legacy trio:
-    /// `onlyBuiltDependencies` → `true`, `neverBuiltDependencies` /
-    /// `ignoredBuiltDependencies` → `false` (asked-and-answered, not
-    /// security denial). Explicit `allowBuilds` entries win the fold.
+    /// Entries for the top-level three-state `allowScripts` map. Folds the
+    /// legacy trio: `onlyBuiltDependencies` → `true`, `neverBuiltDependencies`
+    /// / `ignoredBuiltDependencies` → `false` (asked-and-answered, not
+    /// security denial). Explicit pnpm `allowBuilds` entries win the fold.
     pub allow_builds: Option<Map<String, Value>>,
     /// Top-level `auditConfig` (aube's existing extension home).
     pub audit_config: Option<Value>,
@@ -601,9 +601,10 @@ pub(crate) fn write_nub_identity_fields(
 /// - `workspaces` membership + catalogs: the yaml was authoritative under
 ///   pnpm (it shadows `package.json#workspaces`), so yaml values overwrite —
 ///   any differing pre-existing value is named in the returned notes.
-/// - `overrides` / `patchedDependencies` / `allowBuilds` / `auditConfig`:
+/// - `overrides` / `patchedDependencies` / `allowScripts` / `auditConfig`:
 ///   per-key insert; an existing top-level entry wins (the engine's merge
-///   already ranked top-level above the yaml), conflicts named.
+///   already ranked top-level above the yaml), conflicts named. pnpm's
+///   `allowBuilds` map lands under the neutral `allowScripts` name.
 /// - `pnpm` namespace: removed (migrated through the same table by the
 ///   caller; unread under nub identity).
 ///
@@ -668,7 +669,7 @@ pub(crate) fn apply_manifest_edits(
     for (key, entries) in [
         ("overrides", &m.overrides),
         ("patchedDependencies", &m.patched_dependencies),
-        ("allowBuilds", &m.allow_builds),
+        (aube_manifest::ROOT_ALLOW_SCRIPTS_KEY, &m.allow_builds),
     ] {
         let Some(entries) = entries else { continue };
         let target = obj.entry(key).or_insert_with(|| Value::Object(Map::new()));
@@ -938,7 +939,10 @@ pub(crate) fn run_use_nub(root: &Path, exact_pin: Option<&str>) -> Result<i32> {
             "patchedDependencies",
             migration.patched_dependencies.is_some(),
         ),
-        ("allowBuilds", migration.allow_builds.is_some()),
+        (
+            aube_manifest::ROOT_ALLOW_SCRIPTS_KEY,
+            migration.allow_builds.is_some(),
+        ),
         ("auditConfig", migration.audit_config.is_some()),
     ] {
         if present {
@@ -1096,8 +1100,10 @@ fn remove_strays(paths: &[std::path::PathBuf], why: &str) -> Result<()> {
 /// The yaml-regeneration half of `nub pm use pnpm` — the exact reverse of
 /// [`run_use_nub`]'s migration: collect the nub-mode homes out of
 /// `package.json` (`workspaces` membership + catalogs, top-level `overrides`
-/// / `patchedDependencies` / `allowBuilds` / `auditConfig`), write them into
-/// `pnpm-workspace.yaml` (merging into an existing yaml, package.json values
+/// / `patchedDependencies` / `allowScripts` / `auditConfig`), write them into
+/// `pnpm-workspace.yaml` under pnpm's own key names (`allowScripts` →
+/// `allowBuilds`; the rest keep their spelling), merging into an existing yaml
+/// with package.json values
 /// winning — they were the live config under nub), and remove the migrated
 /// keys from `package.json`. Settings already in `.npmrc` stay there — pnpm
 /// reads them too. Returns the summary lines; empty when there was nothing
@@ -1121,7 +1127,12 @@ pub(crate) fn regenerate_workspace_yaml(root: &Path) -> Result<Vec<String>> {
     };
     let overrides = manifest.get("overrides").cloned();
     let patched = manifest.get("patchedDependencies").cloned();
-    let allow_builds = manifest.get("allowBuilds").cloned();
+    // The nub-mode home is the neutral top-level `allowScripts`; pnpm's home
+    // for the same map is `allowBuilds`, so this one entry is renamed on the
+    // way out rather than moved verbatim.
+    let allow_builds = manifest
+        .get(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY)
+        .cloned();
     let audit_config = manifest.get("auditConfig").cloned();
 
     if packages.is_none()
@@ -1162,7 +1173,7 @@ pub(crate) fn regenerate_workspace_yaml(root: &Path) -> Result<Vec<String>> {
             "workspaces",
             "overrides",
             "patchedDependencies",
-            "allowBuilds",
+            aube_manifest::ROOT_ALLOW_SCRIPTS_KEY,
             "auditConfig",
         ] {
             obj.remove(key);
@@ -1416,7 +1427,7 @@ mod tests {
                 "packageManager": "nub@0.1.0",
                 "workspaces": { "packages": ["packages/*"], "catalog": { "react": "^18.0.0" } },
                 "overrides": { "lodash": "4.17.21" },
-                "allowBuilds": { "esbuild": true, "fsevents": false }
+                "allowScripts": { "esbuild": true, "fsevents": false }
             }))
             .unwrap(),
         )
@@ -1432,13 +1443,15 @@ mod tests {
         assert_eq!(yaml["packages"][0], "packages/*");
         assert_eq!(yaml["catalog"]["react"], "^18.0.0");
         assert_eq!(yaml["overrides"]["lodash"], "4.17.21");
+        // The map is renamed on the way out: nub's neutral `allowScripts`
+        // lands under pnpm's own `allowBuilds` key in the yaml.
         assert_eq!(yaml["allowBuilds"]["esbuild"], true);
 
         let manifest: Value = serde_json::from_str(
             &std::fs::read_to_string(dir.path().join("package.json")).unwrap(),
         )
         .unwrap();
-        for key in ["workspaces", "overrides", "allowBuilds"] {
+        for key in ["workspaces", "overrides", "allowScripts"] {
             assert!(
                 manifest.get(key).is_none(),
                 "{key} must move back into the yaml"

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -1167,6 +1167,47 @@ fn wildcard_peer_binds_resolved_major_not_registry_highest() {
 /// the node-gyp path. Holds whether or not the host happens to have a node-gyp
 /// on PATH: with one, no shim is written; without, the shim is written but never
 /// invoked. Either way the bootstrap bucket must not appear.
+/// The build allowlist moved from a top-level `allowBuilds` map to
+/// `allowScripts` (npm 12's own field). Honoring neither would silently drop
+/// the old map's explicit `false` denials, so the stale key is a hard refusal
+/// naming the rename. The paired positive control is the test below, which
+/// runs a build off an `allowScripts` entry.
+#[test]
+fn a_stale_top_level_allow_builds_map_is_refused_with_the_rename() {
+    let dir = pm_tmpdir("legacy-allow-builds");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"app","version":"1.0.0","private":true,"allowBuilds":{"esbuild":false}}"#,
+    )
+    .unwrap();
+
+    let out = Command::new(nub_binary())
+        .arg("install")
+        .current_dir(&dir)
+        .env("XDG_DATA_HOME", dir.join("xdg-data"))
+        .env("XDG_CACHE_HOME", dir.join("xdg-cache"))
+        .output()
+        .expect("failed to spawn nub");
+    let output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "a stale allowBuilds map must fail the install: {output}"
+    );
+    assert!(
+        output.contains("ERR_NUB_ALLOW_BUILDS_RENAMED"),
+        "the refusal must carry its code: {output}"
+    );
+    assert!(
+        output.contains("allowScripts"),
+        "the refusal must name the field to rename to: {output}"
+    );
+}
+
 #[test]
 fn approved_build_that_never_calls_node_gyp_installs_with_no_registry() {
     let dir = pm_tmpdir("no-gyp-bootstrap");
@@ -1182,7 +1223,7 @@ fn approved_build_that_never_calls_node_gyp_installs_with_no_registry() {
     .unwrap();
     std::fs::write(
         dir.join("package.json"),
-        r#"{"name":"app","version":"1.0.0","private":true,"dependencies":{"plainbuild":"file:./plainbuild"},"allowBuilds":{"plainbuild@file:./plainbuild":true}}"#,
+        r#"{"name":"app","version":"1.0.0","private":true,"dependencies":{"plainbuild":"file:./plainbuild"},"allowScripts":{"plainbuild@file:./plainbuild":true}}"#,
     )
     .unwrap();
     // `fetch-retries=0` so a regression fails fast instead of burning the
@@ -1245,7 +1286,7 @@ fn jailed_build_that_never_needs_node_gyp_survives_a_failed_bootstrap() {
     .unwrap();
     std::fs::write(
         dir.join("package.json"),
-        r#"{"name":"app","version":"1.0.0","private":true,"dependencies":{"plainbuild":"file:./plainbuild"},"allowBuilds":{"plainbuild@file:./plainbuild":true}}"#,
+        r#"{"name":"app","version":"1.0.0","private":true,"dependencies":{"plainbuild":"file:./plainbuild"},"allowScripts":{"plainbuild@file:./plainbuild":true}}"#,
     )
     .unwrap();
     std::fs::write(
@@ -1922,7 +1963,7 @@ fn an_owed_dependency_build_stops_the_next_install_reporting_up_to_date() {
     // bare-name entry never authorizes a source-backed build.
     std::fs::write(
         dir.join("package.json"),
-        r#"{"name":"app","version":"1.0.0","private":true,"dependencies":{"plainbuild":"file:./plainbuild"},"allowBuilds":{"plainbuild@file:./plainbuild":true}}"#,
+        r#"{"name":"app","version":"1.0.0","private":true,"dependencies":{"plainbuild":"file:./plainbuild"},"allowScripts":{"plainbuild@file:./plainbuild":true}}"#,
     )
     .unwrap();
     // Dead registry + no retries: the fixture is entirely local, so any

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -165,7 +165,7 @@ Read the [full docs](https://pnpm.io/catalogs) on pnpm.io. The `catalog:` syntax
 
 ### `allowScripts`
 
-Which dependencies may run install scripts — see [lifecycle scripts](#lifecycle-scripts) for the deny-by-default rules around it. A registry dependency is keyed by name, anything else by its full specifier, and an explicit `false` always wins.
+Which dependencies may run install scripts — see [lifecycle scripts](#lifecycle-scripts) for the deny-by-default rules around it. A registry dependency is keyed by name, anything else by its full specifier, and an explicit `false` beats any allow in the map.
 
 ```json title="package.json"
 {
@@ -511,7 +511,7 @@ The neutral `allowScripts` field grants permission, and it keys on the package n
   "allowScripts": {
     "esbuild": true,                        // a registry dependency, by name
     "buildy@file:./buildy-1.0.0.tgz": true, // anything else, by full specifier
-    "sharp": false                          // an explicit denial always wins
+    "sharp": false                          // a denial beats any allow in the map
   }
 }
 ```

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -163,13 +163,13 @@ Name a version once and let every member reference it, so a bump is a one-line e
 Read the [full docs](https://pnpm.io/catalogs) on pnpm.io. The `catalog:` syntax matches pnpm's; the definitions live here rather than in `pnpm-workspace.yaml`.
 </Callout>
 
-### `allowBuilds`
+### `allowScripts`
 
 Which dependencies may run install scripts — see [lifecycle scripts](#lifecycle-scripts) for the deny-by-default rules around it. A registry dependency is keyed by name, anything else by its full specifier, and an explicit `false` always wins.
 
 ```json title="package.json"
 {
-  "allowBuilds": {
+  "allowScripts": {
     "esbuild": true,
     "sharp": false
   }
@@ -177,7 +177,7 @@ Which dependencies may run install scripts — see [lifecycle scripts](#lifecycl
 ```
 
 <Callout>
-Read the [full docs](https://pnpm.io/settings/build#allowbuilds) on pnpm.io.
+npm 12 gates its own install scripts on this same field, so one map covers both tools. Read npm's [approve-scripts docs](https://docs.npmjs.com/cli/v12/commands/npm-approve-scripts).
 </Callout>
 
 ### `dependenciesMeta`
@@ -504,11 +504,11 @@ nub install --ignore-scripts      # skip dependency build scripts this install
 
 Approval takes effect immediately: `nub approve-builds` records the decision and runs the just-approved packages' build scripts in the same invocation, matching pnpm — no follow-up `nub install` or `nub rebuild` needed.
 
-The neutral `allowBuilds` field grants permission, and it keys on the package name for a registry dependency or the full specifier for anything else:
+The neutral `allowScripts` field grants permission, and it keys on the package name for a registry dependency or the full specifier for anything else:
 
 ```json title="package.json"
 {
-  "allowBuilds": {
+  "allowScripts": {
     "esbuild": true,                        // a registry dependency, by name
     "buildy@file:./buildy-1.0.0.tgz": true, // anything else, by full specifier
     "sharp": false                          // an explicit denial always wins
@@ -516,14 +516,14 @@ The neutral `allowBuilds` field grants permission, and it keys on the package na
 }
 ```
 
-That field applies in any project, whoever owns it. A project owned by another package manager grants permission through its own field as well: pnpm projects use `pnpm.onlyBuiltDependencies` / `pnpm.allowBuilds`, and Bun projects use `trustedDependencies`. A package with build scripts that is not allowed is skipped, with `WARN_NUB_IGNORED_BUILD_SCRIPTS` naming it and `nub approve-builds` as the remedy.
+That field applies in any project, whoever owns it, and npm 12 reads the same map for the same purpose — approve a package once and both tools honor it. A project owned by another package manager grants permission through its own field as well: pnpm projects use `pnpm.onlyBuiltDependencies` / `pnpm.allowBuilds`, and Bun projects use `trustedDependencies`. A package with build scripts that is not allowed is skipped, with `WARN_NUB_IGNORED_BUILD_SCRIPTS` naming it and `nub approve-builds` as the remedy.
 
 ### When a build fails
 
 A failed build fails the install. The one exception is a package reachable only through `optionalDependencies`, which the project has declared it can work without: that failure is reported and the install continues, matching npm and pnpm.
 
 ```console
-# captured: nub 0.7.5, optfail@1.0.0 whose postinstall exits 3, allowBuilds entry present
+# captured: nub 0.7.5, optfail@1.0.0 whose postinstall exits 3, allowScripts entry present
 $ nub install
 WARN optfail@1.0.0 is an optional dependency and failed to build; continuing
      without it: lifecycle script postinstall failed for optfail@1.0.0: script
@@ -626,7 +626,7 @@ Explicit decisions outrank the floor in both directions: a package you approve b
 A fresh resolve, or a lockfile Nub itself wrote (which carries the `time:` block), gives the floor everything it needs, so curated packages like `esbuild` build automatically:
 
 ```console
-# captured: nub 0.0.44, pnpm-incumbent, esbuild@0.21.5 — no allowBuilds entry
+# captured: nub 0.0.44, pnpm-incumbent, esbuild@0.21.5 — no allowScripts entry
 $ nub install
 WARN defaultTrust: running build scripts for esbuild@0.21.5   # ✓ all three gates passed
 dependencies:

--- a/site/src/app/(home)/page.tsx
+++ b/site/src/app/(home)/page.tsx
@@ -1038,13 +1038,15 @@ const RULES = [
    `packageExtensions` row has no pm_engine dialect-scoping (no per-PM conflict);
    the nub=yes cell is grounded in the embedded aube engine, which honors a
    top-level `packageExtensions` natively (vendor/aube/crates/aube-manifest/src/lib.rs
-   `package_extensions()` → resolver package_ext.rs). Same for `allowBuilds` — a real
-   pnpm field (pnpm-workspace.yaml; pnpm/core/types/src/package.ts) that aube reads via
-   its pnpm-compat settings family; bun honors none of it (only `trustedDependencies`).
+   `package_extensions()` → resolver package_ext.rs). Same for `allowScripts` — a real
+   npm field (top-level package.json, npm 12; RFC npm/rfcs#868) that the engine reads at
+   the manifest root (vendor/aube/crates/aube-manifest/src/lib.rs ROOT_ALLOW_SCRIPTS_KEY).
+   pnpm=no because pnpm's own map is `allowBuilds` in pnpm-workspace.yaml, which nub
+   still reads under a pnpm incumbent — a different field, so a different row's claim.
    Both bun=no cells verified: zero refs in bun source + docs.
    `trustedDependencies` is nub=no on purpose: `honors_trusted_dependencies` returns
    true for Role::Bun ALONE (config_scope.rs, asserted for every other role), so under
-   its own identity nub reads the neutral `allowBuilds` and ignores bun's branded field.
+   its own identity nub reads the neutral `allowScripts` and ignores bun's branded field.
    `catalog:` is yarn=yes for berry — `role_honors_catalog` honors Role::Yarn at major>=2
    (pm_engine/mod.rs); only a `1.x` pin refuses. Version-gated cells show the modern
    line's truth, same as npm=yes for `overrides` (which npm gained in 8.3). Legend:
@@ -1076,8 +1078,8 @@ const PM_MATRIX: { field: ReactNode; cells: Record<(typeof PM_COLUMNS)[number], 
     cells: { npm: 'no', pnpm: 'yes', yarn: 'yes', bun: 'no', nub: 'yes' },
   },
   {
-    field: <><Mono>allowBuilds</Mono></>,
-    cells: { npm: 'no', pnpm: 'yes', yarn: 'no', bun: 'no', nub: 'yes' },
+    field: <><Mono>allowScripts</Mono></>,
+    cells: { npm: 'yes', pnpm: 'no', yarn: 'no', bun: 'no', nub: 'yes' },
   },
   {
     field: <><Mono>trustedDependencies</Mono></>,

--- a/vendor/aube/crates/aube-codes/src/errors.rs
+++ b/vendor/aube/crates/aube-codes/src/errors.rs
@@ -446,19 +446,19 @@ pub const ALL: &[CodeMeta] = &[
     CodeMeta {
         name: ERR_AUBE_BUILD_POLICY_UNSUPPORTED_VALUE,
         category: category::SCRIPTS,
-        description: "An entry in `allowBuilds` had a value that wasn't `true`/`false`.",
+        description: "An entry in the build allowlist had a value that wasn't `true`/`false`.",
         exit_code: None,
     },
     CodeMeta {
         name: ERR_AUBE_BUILD_POLICY_INVALID_VERSION_UNION,
         category: category::SCRIPTS,
-        description: "An `allowBuilds` pattern's version union was unparseable.",
+        description: "A build-allowlist pattern's version union was unparseable.",
         exit_code: None,
     },
     CodeMeta {
         name: ERR_AUBE_BUILD_POLICY_WILDCARD_WITH_VERSION,
         category: category::SCRIPTS,
-        description: "An `allowBuilds` pattern combined a wildcard name with a version union.",
+        description: "A build-allowlist pattern combined a wildcard name with a version union.",
         exit_code: None,
     },
     // Linker

--- a/vendor/aube/crates/aube-codes/src/warnings.rs
+++ b/vendor/aube/crates/aube-codes/src/warnings.rs
@@ -213,13 +213,13 @@ pub const ALL: &[CodeMeta] = &[
     CodeMeta {
         name: WARN_AUBE_IGNORED_BUILD_SCRIPTS,
         category: category::INSTALL_LIFECYCLE,
-        description: "Dep had `preinstall`/`install`/`postinstall` scripts but isn't on the `allowBuilds` allowlist. Run `aube approve-builds`.",
+        description: "Dep had `preinstall`/`install`/`postinstall` scripts but isn't on the build allowlist. Run `aube approve-builds`.",
         exit_code: None,
     },
     CodeMeta {
         name: WARN_AUBE_DEFAULT_TRUST_BUILDS,
         category: category::INSTALL_LIFECYCLE,
-        description: "The `defaultTrust` floor let listed packages run build scripts without an explicit `allowBuilds` entry. Disclosure, not an error — set `defaultTrust=false` or an explicit `allowBuilds: false` entry to opt out.",
+        description: "The `defaultTrust` floor let listed packages run build scripts without an explicit build-allowlist entry. Disclosure, not an error — set `defaultTrust=false` or an explicit `false` allowlist entry to opt out.",
         exit_code: None,
     },
     CodeMeta {
@@ -243,7 +243,7 @@ pub const ALL: &[CodeMeta] = &[
     CodeMeta {
         name: WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT,
         category: category::INSTALL_LIFECYCLE,
-        description: "A dependency's lifecycle script matched a dangerous-shape heuristic (curl|sh, eval+atob, credential-file read, secret-env exfil, exfil endpoint, bare-IP HTTP). Advisory only; the `allowBuilds` allowlist still gates execution. Inspect the script before approving the build.",
+        description: "A dependency's lifecycle script matched a dangerous-shape heuristic (curl|sh, eval+atob, credential-file read, secret-env exfil, exfil endpoint, bare-IP HTTP). Advisory only; the build allowlist still gates execution. Inspect the script before approving the build.",
         exit_code: None,
     },
     CodeMeta {

--- a/vendor/aube/crates/aube-manifest/src/lib.rs
+++ b/vendor/aube/crates/aube-manifest/src/lib.rs
@@ -114,6 +114,33 @@ pub struct UpdateConfig {
     pub ignore_dependencies: Vec<String>,
 }
 
+/// The manifest-ROOT (un-branded) key holding the lifecycle-script allowlist,
+/// for embedders whose `manifest_namespace` is empty. npm 12 reads the same
+/// top-level `allowScripts` map out of `package.json` (RFC npm/rfcs#868), with
+/// the same `name`/`name@version` → `true`/`false` shape and the same
+/// deny-wins fold, so sharing the field means one allowlist per project rather
+/// than two competing maps in one file. The pnpm-branded `pnpm.allowBuilds`
+/// map keeps its own spelling — that surface belongs to pnpm.
+pub const ROOT_ALLOW_SCRIPTS_KEY: &str = "allowScripts";
+
+/// The pre-cutover manifest-root spelling of [`ROOT_ALLOW_SCRIPTS_KEY`]. No
+/// package manager reads a top-level `allowBuilds` — pnpm reads it from
+/// `pnpm-workspace.yaml` or `package.json#pnpm`, npm reads `allowScripts`, bun
+/// reads `trustedDependencies` — so a project still carrying it is refused
+/// with a rename remedy rather than silently losing its whole build policy.
+pub const LEGACY_ROOT_ALLOW_BUILDS_KEY: &str = "allowBuilds";
+
+/// The allowlist field name to NAME in user-facing text on the active surface:
+/// the neutral root key for a manifest-root embedder, pnpm's spelling
+/// otherwise.
+pub fn allow_scripts_field_name() -> &'static str {
+    if aube_util::embedder().manifest_namespace.is_empty() {
+        ROOT_ALLOW_SCRIPTS_KEY
+    } else {
+        LEGACY_ROOT_ALLOW_BUILDS_KEY
+    }
+}
+
 /// Parsed `package.json`.
 ///
 /// Deserializes via [`PackageJsonRaw`] (`#[serde(from = ...)]`) so a
@@ -468,14 +495,16 @@ impl PackageJson {
     /// Extract the `pnpm.allowBuilds` / `aube.allowBuilds` object from
     /// the raw `package.json` payload, if present. For embedders whose native
     /// manifest config lives at root (`manifest_namespace == ""`), the
-    /// top-level `allowBuilds` map is *always* read — it is the embedder's own
-    /// un-branded key (not a foreign brand's surface), so it is honored on
-    /// every config surface (nub identity, npm/bun/yarn compat, pnpm/fresh),
-    /// not only the root-native one. This is what makes `approve-builds`
-    /// effective under an npm/bun/yarn incumbent: the approval it writes at the
-    /// top level is read back here regardless of incumbent. Standalone aube
-    /// keeps a non-empty `manifest_namespace`, so this branch never fires for
-    /// it — its behavior is unchanged. Returns a map keyed by the raw
+    /// top-level [`ROOT_ALLOW_SCRIPTS_KEY`] map is *always* read — it is the
+    /// embedder's own un-branded key (not a foreign brand's surface), so it is
+    /// honored on every config surface (nub identity, npm/bun/yarn compat,
+    /// pnpm/fresh), not only the root-native one. This is what makes
+    /// `approve-builds` effective under an npm/bun/yarn incumbent: the approval
+    /// it writes at the top level is read back here regardless of incumbent —
+    /// and under an npm incumbent it is the very field npm 12 itself gates on,
+    /// so one map serves both tools. Standalone aube keeps a non-empty
+    /// `manifest_namespace`, so this branch never fires for it — its behavior
+    /// is unchanged. Returns a map keyed by the raw
     /// pattern string (e.g. `"esbuild"`, `"@swc/core@1.3.0"`) with `bool`
     /// values preserved as `bool` and any other shape captured verbatim so the
     /// caller can warn about it. The tool's own namespace/root surface wins
@@ -493,13 +522,30 @@ impl PackageJson {
             }
         }
         if aube_util::embedder().manifest_namespace.is_empty()
-            && let Some(map) = self.extra.get("allowBuilds").and_then(|v| v.as_object())
+            && let Some(map) = self
+                .extra
+                .get(ROOT_ALLOW_SCRIPTS_KEY)
+                .and_then(|v| v.as_object())
         {
             for (k, v) in map {
                 out.insert(k.clone(), AllowBuildRaw::from_json(v));
             }
         }
         out
+    }
+
+    /// Whether this manifest still carries the pre-cutover top-level
+    /// [`LEGACY_ROOT_ALLOW_BUILDS_KEY`] map. Only meaningful for a
+    /// manifest-root embedder — for a namespaced tool the same top-level key
+    /// was never read, so it is somebody else's field and not ours to refuse.
+    /// The caller turns a hit into a hard error: silently ignoring the map
+    /// would drop every approval AND every explicit denial it records.
+    pub fn has_legacy_root_allow_builds(&self) -> bool {
+        aube_util::embedder().manifest_namespace.is_empty()
+            && self
+                .extra
+                .get(LEGACY_ROOT_ALLOW_BUILDS_KEY)
+                .is_some_and(serde_json::Value::is_object)
     }
 
     /// Extract `pnpm.onlyBuiltDependencies` / `aube.onlyBuiltDependencies`

--- a/vendor/aube/crates/aube-manifest/src/lib.rs
+++ b/vendor/aube/crates/aube-manifest/src/lib.rs
@@ -116,11 +116,22 @@ pub struct UpdateConfig {
 
 /// The manifest-ROOT (un-branded) key holding the lifecycle-script allowlist,
 /// for embedders whose `manifest_namespace` is empty. npm 12 reads the same
-/// top-level `allowScripts` map out of `package.json` (RFC npm/rfcs#868), with
-/// the same `name`/`name@version` → `true`/`false` shape and the same
-/// deny-wins fold, so sharing the field means one allowlist per project rather
-/// than two competing maps in one file. The pnpm-branded `pnpm.allowBuilds`
-/// map keeps its own spelling — that surface belongs to pnpm.
+/// top-level `allowScripts` map out of `package.json` (RFC npm/rfcs#868), so
+/// sharing the field means one allowlist per project rather than two competing
+/// maps in one file. The pnpm-branded `pnpm.allowBuilds` map keeps its own
+/// spelling — that surface belongs to pnpm.
+///
+/// REGISTRY keys are interchangeable with npm's: a bare `name` and a pinned
+/// `name@version` mean the same thing to both tools, and both fold with
+/// `false` winning. NON-REGISTRY keys are NOT yet interchangeable, and this is
+/// a known gap rather than a claim: npm writes a source-ONLY key for a file,
+/// tarball or Git dependency (`file:../local`, `github:owner/repo#sha` — see
+/// its `lib/utils/allow-scripts-writer.js`), whereas the engine builds a
+/// name-qualified one (`pkg@file:../local`, see
+/// `aube_lockfile::…::source_approval_key`). An npm-authored approval for a
+/// non-registry package therefore reads as unreviewed here. Closing that means
+/// deciding whether a bare source key may grant whatever package occupies that
+/// source, which is a security call, not a parsing one.
 pub const ROOT_ALLOW_SCRIPTS_KEY: &str = "allowScripts";
 
 /// The pre-cutover manifest-root spelling of [`ROOT_ALLOW_SCRIPTS_KEY`]. No

--- a/vendor/aube/crates/aube-manifest/src/workspace/mutations.rs
+++ b/vendor/aube/crates/aube-manifest/src/workspace/mutations.rs
@@ -23,10 +23,12 @@ use std::path::{Path, PathBuf};
 ///
 /// Manifest-root embedder routing: an embedder whose `manifest_namespace`
 /// is `""` writes the setting at the *top level* of `package.json` via
-/// [`edit_setting_map`]. The read side honors that top-level (neutral,
-/// un-branded) key on *every* surface, so under nub identity AND under an
-/// npm/bun/yarn incumbent (`read_branded_pnpm_config` off) the approval takes
-/// effect — `approve-builds` heals on those surfaces.
+/// [`edit_setting_map`], under [`crate::ROOT_ALLOW_SCRIPTS_KEY`]. The read side
+/// honors that top-level (neutral, un-branded) key on *every* surface, so under
+/// nub identity AND under an npm/bun/yarn incumbent (`read_branded_pnpm_config`
+/// off) the approval takes effect — `approve-builds` heals on those surfaces.
+/// Under an npm incumbent it heals npm as well, since npm 12 gates its own
+/// install scripts on that same top-level map.
 ///
 /// The one surface where a bare top-level write is NOT the right target is the
 /// embedder's *pnpm-compat* surface (`read_branded_pnpm_config` on): there the
@@ -62,7 +64,7 @@ pub fn set_allow_builds(
             Ok(project_dir.join("package.json"))
         }
         ConfigWriteTarget::PackageJson => {
-            edit_setting_map(project_dir, "allowBuilds", |map| {
+            edit_setting_map(project_dir, crate::allow_scripts_field_name(), |map| {
                 for name in names {
                     map.insert(name.clone(), serde_json::Value::Bool(allow));
                 }

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -148,7 +148,9 @@ fn root_embedder_writes_map_settings_at_manifest_root() {
     );
     // Never nested under the foreign `pnpm` brand.
     assert!(
-        obj.get("pnpm").and_then(|p| p.get("allowScripts")).is_none(),
+        obj.get("pnpm")
+            .and_then(|p| p.get("allowScripts"))
+            .is_none(),
         "must never nest the setting under the pnpm namespace, got: {obj:#?}"
     );
 }

--- a/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
+++ b/vendor/aube/crates/aube-manifest/tests/root_namespace_write.rs
@@ -1,5 +1,5 @@
 //! An embedder whose `manifest_namespace` is `""` ("manifest root") writes
-//! map settings (`allowBuilds`, `patchedDependencies`, …) as **top-level**
+//! map settings (`allowScripts`, `patchedDependencies`, …) as **top-level**
 //! `package.json` keys — never nested under a namespace object, and never
 //! under a foreign brand's key (`pnpm`).
 //!
@@ -113,15 +113,15 @@ fn root_embedder_writes_map_settings_at_manifest_root() {
 
     let tmp = tempfile::tempdir().unwrap();
     // Pre-existing `pnpm` object present (the case that must NOT divert the
-    // write into `pnpm`), plus a prior root-level `allowBuilds` entry that
+    // write into `pnpm`), plus a prior root-level `allowScripts` entry that
     // must survive the merge.
     std::fs::write(
         tmp.path().join("package.json"),
-        "{\n  \"name\": \"x\",\n  \"pnpm\": {},\n  \"allowBuilds\": { \"old\": true }\n}\n",
+        "{\n  \"name\": \"x\",\n  \"pnpm\": {},\n  \"allowScripts\": { \"old\": true }\n}\n",
     )
     .unwrap();
 
-    edit_setting_map(tmp.path(), "allowBuilds", |m| {
+    edit_setting_map(tmp.path(), "allowScripts", |m| {
         m.insert("esbuild".to_string(), serde_json::Value::Bool(true));
     })
     .unwrap();
@@ -131,13 +131,13 @@ fn root_embedder_writes_map_settings_at_manifest_root() {
 
     // Lands at the manifest ROOT as a top-level map key.
     assert_eq!(
-        obj["allowBuilds"]["esbuild"],
+        obj["allowScripts"]["esbuild"],
         serde_json::Value::Bool(true),
-        "new entry must land at top-level allowBuilds, got: {obj:#?}"
+        "new entry must land at top-level allowScripts, got: {obj:#?}"
     );
     // The pre-existing root-level entry round-trips via the merge.
     assert_eq!(
-        obj["allowBuilds"]["old"],
+        obj["allowScripts"]["old"],
         serde_json::Value::Bool(true),
         "existing root-level entry must survive the write"
     );
@@ -148,13 +148,13 @@ fn root_embedder_writes_map_settings_at_manifest_root() {
     );
     // Never nested under the foreign `pnpm` brand.
     assert!(
-        obj.get("pnpm").and_then(|p| p.get("allowBuilds")).is_none(),
+        obj.get("pnpm").and_then(|p| p.get("allowScripts")).is_none(),
         "must never nest the setting under the pnpm namespace, got: {obj:#?}"
     );
 }
 
 #[test]
-fn root_embedder_reads_neutral_top_level_allow_builds_on_every_surface() {
+fn root_embedder_reads_neutral_top_level_allow_scripts_on_every_surface() {
     let _surface = SurfaceGuard::acquire();
     aube_util::set_embedder(&ROOT_TOOL);
 
@@ -162,7 +162,7 @@ fn root_embedder_reads_neutral_top_level_allow_builds_on_every_surface() {
         std::path::Path::new("package.json"),
         r#"{
             "name": "x",
-            "allowBuilds": {
+            "allowScripts": {
                 "esbuild": true,
                 "sharp": false
             },
@@ -177,7 +177,7 @@ fn root_embedder_reads_neutral_top_level_allow_builds_on_every_surface() {
     .unwrap();
 
     // A non-pnpm incumbent under a manifest-root embedder: the pnpm namespace
-    // is gated off, but the top-level `allowBuilds` is the embedder's own
+    // is gated off, but the top-level `allowScripts` is the embedder's own
     // un-branded key and is read on EVERY surface — so `approve-builds` heals
     // here (the npm/bun/yarn incumbent case). The pnpm-branded `left-pad` entry
     // is NOT read on this surface.
@@ -216,7 +216,7 @@ fn root_embedder_reads_neutral_top_level_allow_builds_on_every_surface() {
         Some(AllowBuildRaw::Bool(true))
     ));
 
-    // NubIdentity-style mode gates pnpm off and reads root `allowBuilds` as the
+    // NubIdentity-style mode gates pnpm off and reads root `allowScripts` as the
     // native config surface produced by `pm use nub`.
     aube_util::update_engine_context(|ctx| {
         ctx.read_branded_pnpm_config = false;
@@ -272,8 +272,8 @@ fn set_allow_builds_writes_pnpm_only_built_deps_on_pnpm_surface_no_yaml() {
     // Nested under `pnpm.onlyBuiltDependencies`, not the unread top-level key.
     let manifest = read_manifest(tmp.path());
     assert!(
-        manifest.get("allowBuilds").is_none(),
-        "must not write an unread top-level allowBuilds key, got: {manifest:#?}"
+        manifest.get("allowScripts").is_none(),
+        "must not write an unread top-level allowScripts key, got: {manifest:#?}"
     );
     assert_eq!(
         manifest["pnpm"]["onlyBuiltDependencies"],
@@ -377,9 +377,11 @@ fn set_allow_builds_writes_pnpm_allow_builds_map_for_denial_no_yaml() {
 
 /// `approve-builds` HEALS on the NonPnpmCompat (npm/bun/yarn incumbent)
 /// surface: with both gates off, `set_allow_builds` writes the top-level
-/// `package.json#allowBuilds` key, and the read side now consults that neutral,
+/// `package.json#allowScripts` key, and the read side now consults that neutral,
 /// un-branded key on every surface — so the approval takes effect and the next
 /// install runs the script. (Previously a documented no-op; the gap is closed.)
+/// Under an npm incumbent it is also npm 12's own field, so one approval serves
+/// both tools.
 #[test]
 fn set_allow_builds_heals_on_non_pnpm_compat_surface() {
     let _surface = SurfaceGuard::acquire();
@@ -408,7 +410,7 @@ fn set_allow_builds_heals_on_non_pnpm_compat_surface() {
     // The approval is written at the top level…
     let manifest = read_manifest(tmp.path());
     assert_eq!(
-        manifest["allowBuilds"]["core-js"],
+        manifest["allowScripts"]["core-js"],
         serde_json::Value::Bool(true)
     );
     // …and the read side on this surface now honors it: the approval takes
@@ -458,8 +460,8 @@ fn set_allow_builds_writes_root_key_under_nub_identity() {
     );
     let manifest = read_manifest(tmp.path());
     assert_eq!(
-        manifest["allowBuilds"]["core-js"],
+        manifest["allowScripts"]["core-js"],
         serde_json::Value::Bool(true),
-        "approval must land in the top-level allowBuilds the nub-identity reader consults"
+        "approval must land in the top-level allowScripts the nub-identity reader consults"
     );
 }

--- a/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
+++ b/vendor/aube/crates/aube-scripts/tests/root_namespace_allow_builds.rs
@@ -1,8 +1,9 @@
-//! Manifest-root embedders such as nub write `allowBuilds` at package.json
+//! Manifest-root embedders such as nub write `allowScripts` at package.json
 //! root after migration and on the npm/bun/yarn-compat `approve-builds` heal
-//! path. The top-level `allowBuilds` is the embedder's own un-branded key, so
-//! the lifecycle build policy consumes it on every surface — while the
-//! pnpm-branded `pnpm.allowBuilds` is read only when the pnpm surface is active.
+//! path. The top-level `allowScripts` is the embedder's own un-branded key —
+//! and the field npm 12 gates its own install scripts on — so the lifecycle
+//! build policy consumes it on every surface, while the pnpm-branded
+//! `pnpm.allowBuilds` is read only when the pnpm surface is active.
 
 use aube_manifest::PackageJson;
 use aube_scripts::{AllowDecision, BuildPolicy};
@@ -59,13 +60,13 @@ fn build_decision(manifest: &PackageJson, name: &str, version: &str) -> AllowDec
 }
 
 #[test]
-fn root_allow_builds_feeds_build_policy_on_every_surface() {
+fn root_allow_scripts_feeds_build_policy_on_every_surface() {
     aube_util::set_embedder(&ROOT_TOOL);
     let manifest = PackageJson::parse(
         std::path::Path::new("package.json"),
         r#"{
             "name": "x",
-            "allowBuilds": {
+            "allowScripts": {
                 "esbuild": true,
                 "sharp": false
             },

--- a/vendor/aube/crates/aube-util/src/hash.rs
+++ b/vendor/aube/crates/aube-util/src/hash.rs
@@ -246,7 +246,7 @@ pub const INSTALL_SHAPE_FIELDS: &[&str] = &[
     // invalidate the install — without this, an approval written to the
     // neutral field left the warm fast path reporting "up to date" and
     // the script never ran.
-    "allowBuilds",
+    "allowScripts",
     "bundleDependencies",
     "bundledDependencies",
     "catalog",
@@ -452,14 +452,14 @@ mod tests {
     }
 
     #[test]
-    fn manifest_digest_reacts_to_allow_builds_change() {
-        // The neutral `allowBuilds` review map gates which dep build scripts
+    fn manifest_digest_reacts_to_allow_scripts_change() {
+        // The neutral `allowScripts` review map gates which dep build scripts
         // run, so an approval must invalidate the install (a stale digest let
         // the warm fast path skip newly-approved scripts).
         let a: serde_json::Value =
             serde_json::from_str(r#"{"dependencies":{"esbuild":"0.20.2"}}"#).unwrap();
         let b: serde_json::Value = serde_json::from_str(
-            r#"{"dependencies":{"esbuild":"0.20.2"},"allowBuilds":{"esbuild":true}}"#,
+            r#"{"dependencies":{"esbuild":"0.20.2"},"allowScripts":{"esbuild":true}}"#,
         )
         .unwrap();
         assert_ne!(

--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -300,12 +300,13 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         .unreviewed;
         if !unreviewed.is_empty() {
             return Err(miette!(
-                "dependencies with build scripts must be reviewed before install:\n{}\nhelp: add the package(s) to `allowBuilds` with `true`/`false`, or set `strictDepBuilds=false`",
+                "dependencies with build scripts must be reviewed before install:\n{}\nhelp: add the package(s) to `{}` with `true`/`false`, or set `strictDepBuilds=false`",
                 unreviewed
                     .into_iter()
                     .map(|b| format!("  - {}", b.spec_key))
                     .collect::<Vec<_>>()
-                    .join("\n")
+                    .join("\n"),
+                aube_manifest::allow_scripts_field_name(),
             ));
         }
     }

--- a/vendor/aube/crates/aube/src/commands/remove.rs
+++ b/vendor/aube/crates/aube/src/commands/remove.rs
@@ -314,15 +314,7 @@ fn prune_sidecar_entries_json(obj: &mut serde_json::Map<String, serde_json::Valu
         }
     }
 
-    // The manifest-root build allowlist is a map keyed by package name, so a
-    // removed dep must lose its entry here too — otherwise the grant outlives
-    // the dependency and silently re-applies if the name comes back.
-    let top_keys: [&str; 3] = [
-        "overrides",
-        "resolutions",
-        aube_manifest::ROOT_ALLOW_SCRIPTS_KEY,
-    ];
-    for top_key in top_keys {
+    for top_key in ["overrides", "resolutions"] {
         let remove_top = if let Some(top) = obj.get_mut(top_key).and_then(|v| v.as_object_mut()) {
             top.shift_remove(name);
             top.is_empty()
@@ -333,6 +325,40 @@ fn prune_sidecar_entries_json(obj: &mut serde_json::Map<String, serde_json::Valu
             obj.shift_remove(top_key);
         }
     }
+
+    // The manifest-root build allowlist is keyed by package name OR by a
+    // pinned `name@<spec>` form, so a removed dep must lose every key that
+    // targets it — otherwise the grant outlives the dependency and silently
+    // re-applies when that version comes back. npm's `approve-scripts` writes
+    // the pinned form by DEFAULT, so an exact-name removal would miss the
+    // common case entirely.
+    let remove_allow = if let Some(top) = obj
+        .get_mut(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY)
+        .and_then(|v| v.as_object_mut())
+    {
+        top.retain(|key, _| !allow_key_targets(key, name));
+        top.is_empty()
+    } else {
+        false
+    };
+    if remove_allow {
+        obj.shift_remove(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY);
+    }
+}
+
+/// Whether a build-allowlist key targets the package `name`: either the bare
+/// name, or any `name@<spec>` pin (`pkg@1.2.3`, `pkg@1 || 2`, `pkg@file:./x`,
+/// `pkg@git+https://…`).
+///
+/// Anchored on the `@` separator rather than a bare prefix test, which is what
+/// keeps `is-odd` from matching `is-odd-2`, and splitting from the LEFT rather
+/// than the right, which is what keeps a scoped bare name (`@scope/pkg`, whose
+/// only `@` is its first character) from being read as a pin.
+fn allow_key_targets(key: &str, name: &str) -> bool {
+    key == name
+        || key
+            .strip_prefix(name)
+            .is_some_and(|rest| rest.starts_with('@'))
 }
 
 /// Prune aube/pnpm sidecar metadata entries that reference `name`.
@@ -420,17 +446,16 @@ fn prune_sidecar_entries(manifest: &mut aube_manifest::PackageJson, name: &str) 
         }
     }
     // The manifest-root build allowlist, for the same reason as above: a grant
-    // must not outlive the dependency it was written for.
+    // must not outlive the dependency it was written for. Pinned `name@<spec>`
+    // keys count — npm writes those by default.
     if let Some(top) = manifest
         .extra
         .get_mut(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY)
         .and_then(|v| v.as_object_mut())
     {
-        top.remove(name);
+        top.retain(|key, _| !allow_key_targets(key, name));
         if top.is_empty() {
-            manifest
-                .extra
-                .remove(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY);
+            manifest.extra.remove(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY);
         }
     }
 }
@@ -438,6 +463,33 @@ fn prune_sidecar_entries(manifest: &mut aube_manifest::PackageJson, name: &str) 
 #[cfg(test)]
 mod tests {
     use serde_json::Value;
+
+    /// The allowlist key grammar, exercised on the shapes that actually occur.
+    /// The two rows that matter are the last two: a same-prefix sibling must
+    /// survive (`is-odd` never prunes `is-odd-2`), and a scoped bare name must
+    /// not be mistaken for a pin just because it contains an `@`.
+    #[test]
+    fn allow_key_matching_is_anchored_on_the_pin_separator() {
+        for (key, name, targets) in [
+            ("canvas", "canvas", true),
+            ("canvas@2.11.0", "canvas", true),
+            ("esbuild@0.19.0 || 0.20.0", "esbuild", true),
+            ("buildy@file:./buildy-1.0.0.tgz", "buildy", true),
+            ("pkg@git+https://example.com/pkg.git", "pkg", true),
+            ("@scope/pkg", "@scope/pkg", true),
+            ("@scope/pkg@1.0.0", "@scope/pkg", true),
+            ("is-odd-2", "is-odd", false),
+            ("is-odd-2@1.0.0", "is-odd", false),
+            ("@scope/pkg-2@1.0.0", "@scope/pkg", false),
+            ("other", "canvas", false),
+        ] {
+            assert_eq!(
+                super::allow_key_targets(key, name),
+                targets,
+                "key {key:?} vs name {name:?}"
+            );
+        }
+    }
 
     fn collect_section_order(raw: &str, section: &str) -> Vec<String> {
         let v: Value = serde_json::from_str(raw).unwrap();

--- a/vendor/aube/crates/aube/src/commands/remove.rs
+++ b/vendor/aube/crates/aube/src/commands/remove.rs
@@ -314,7 +314,15 @@ fn prune_sidecar_entries_json(obj: &mut serde_json::Map<String, serde_json::Valu
         }
     }
 
-    for top_key in ["overrides", "resolutions"] {
+    // The manifest-root build allowlist is a map keyed by package name, so a
+    // removed dep must lose its entry here too — otherwise the grant outlives
+    // the dependency and silently re-applies if the name comes back.
+    let top_keys: [&str; 3] = [
+        "overrides",
+        "resolutions",
+        aube_manifest::ROOT_ALLOW_SCRIPTS_KEY,
+    ];
+    for top_key in top_keys {
         let remove_top = if let Some(top) = obj.get_mut(top_key).and_then(|v| v.as_object_mut()) {
             top.shift_remove(name);
             top.is_empty()
@@ -330,7 +338,8 @@ fn prune_sidecar_entries_json(obj: &mut serde_json::Map<String, serde_json::Valu
 /// Prune aube/pnpm sidecar metadata entries that reference `name`.
 /// Covers pnpm.allowBuilds, pnpm.onlyBuiltDependencies,
 /// pnpm.neverBuiltDependencies, pnpm.overrides, aube.* mirrors,
-/// top-level overrides, yarn resolutions. Also removes the whole
+/// top-level overrides, yarn resolutions, and the manifest-root build
+/// allowlist. Also removes the whole
 /// namespace block if its last entry was the one we just dropped.
 /// Safe no-op if the manifest has none of these fields.
 fn prune_sidecar_entries(manifest: &mut aube_manifest::PackageJson, name: &str) {
@@ -408,6 +417,20 @@ fn prune_sidecar_entries(manifest: &mut aube_manifest::PackageJson, name: &str) 
         top.remove(name);
         if top.is_empty() {
             manifest.extra.remove("resolutions");
+        }
+    }
+    // The manifest-root build allowlist, for the same reason as above: a grant
+    // must not outlive the dependency it was written for.
+    if let Some(top) = manifest
+        .extra
+        .get_mut(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY)
+        .and_then(|v| v.as_object_mut())
+    {
+        top.remove(name);
+        if top.is_empty() {
+            manifest
+                .extra
+                .remove(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY);
         }
     }
 }

--- a/vendor/aube/docs/error-codes.data.json
+++ b/vendor/aube/docs/error-codes.data.json
@@ -279,19 +279,19 @@
     {
       "name": "ERR_AUBE_BUILD_POLICY_UNSUPPORTED_VALUE",
       "category": "Scripts / build",
-      "description": "An entry in `allowBuilds` had a value that wasn't `true`/`false`.",
+      "description": "An entry in the build allowlist had a value that wasn't `true`/`false`.",
       "exit_code": null
     },
     {
       "name": "ERR_AUBE_BUILD_POLICY_INVALID_VERSION_UNION",
       "category": "Scripts / build",
-      "description": "An `allowBuilds` pattern's version union was unparseable.",
+      "description": "A build-allowlist pattern's version union was unparseable.",
       "exit_code": null
     },
     {
       "name": "ERR_AUBE_BUILD_POLICY_WILDCARD_WITH_VERSION",
       "category": "Scripts / build",
-      "description": "An `allowBuilds` pattern combined a wildcard name with a version union.",
+      "description": "A build-allowlist pattern combined a wildcard name with a version union.",
       "exit_code": null
     },
     {
@@ -635,13 +635,13 @@
     {
       "name": "WARN_AUBE_IGNORED_BUILD_SCRIPTS",
       "category": "Install lifecycle",
-      "description": "Dep had `preinstall`/`install`/`postinstall` scripts but isn't on the `allowBuilds` allowlist. Run `aube approve-builds`.",
+      "description": "Dep had `preinstall`/`install`/`postinstall` scripts but isn't on the build allowlist. Run `aube approve-builds`.",
       "exit_code": null
     },
     {
       "name": "WARN_AUBE_DEFAULT_TRUST_BUILDS",
       "category": "Install lifecycle",
-      "description": "The `defaultTrust` floor let listed packages run build scripts without an explicit `allowBuilds` entry. Disclosure, not an error — set `defaultTrust=false` or an explicit `allowBuilds: false` entry to opt out.",
+      "description": "The `defaultTrust` floor let listed packages run build scripts without an explicit build-allowlist entry. Disclosure, not an error — set `defaultTrust=false` or an explicit `false` allowlist entry to opt out.",
       "exit_code": null
     },
     {
@@ -659,7 +659,7 @@
     {
       "name": "WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT",
       "category": "Install lifecycle",
-      "description": "A dependency's lifecycle script matched a dangerous-shape heuristic (curl|sh, eval+atob, credential-file read, secret-env exfil, exfil endpoint, bare-IP HTTP). Advisory only; the `allowBuilds` allowlist still gates execution. Inspect the script before approving the build.",
+      "description": "A dependency's lifecycle script matched a dangerous-shape heuristic (curl|sh, eval+atob, credential-file read, secret-env exfil, exfil endpoint, bare-IP HTTP). Advisory only; the build allowlist still gates execution. Inspect the script before approving the build.",
       "exit_code": null
     },
     {


### PR DESCRIPTION
npm 12 gates install scripts on a top-level `allowScripts` map in package.json (RFC npm/rfcs#868) — the same slot Nub wrote `allowBuilds` to, same shape, same deny-wins fold. Nub's neutral field becomes `allowScripts` on read and write, so one map serves both tools.

pnpm's `allowBuilds` (pnpm-workspace.yaml, `package.json#pnpm`) is unchanged; `nub pm use pnpm` renames the map back.

A stale top-level `allowBuilds` errors with `ERR_NUB_ALLOW_BUILDS_RENAMED` — ignoring it would drop its `false` denials as well as its approvals.

Also: `INSTALL_SHAPE_FIELDS` follows the key, so an approval still invalidates the install, and `nub remove` now prunes the root entry.

Breaking: rename the key.
