### PR TITLE
compile: add --icu to trim locales from the embedded Node

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -1105,6 +1105,21 @@ pub enum Command {
         #[arg(long = "no-minify")]
         no_minify: bool,
 
+        /// Languages to keep in the embedded Node's ICU data, comma-separated:
+        /// `--icu=en,de,fr`. Default is every locale, which formats exactly like
+        /// the user's own `node`. Written `--icu=<LOCALES>`; bare `--icu` is
+        /// `full`. A region is accepted and narrows nothing (`en-US` keeps `en`),
+        /// and `root` is always retained. Dropped languages fall back silently,
+        /// so name every one the app formats for. No effect under `--smol`.
+        #[arg(
+            long,
+            value_name = "LOCALES",
+            num_args = 0..=1,
+            require_equals = true,
+            default_missing_value = "full"
+        )]
+        icu: Option<String>,
+
         /// Where the source map goes: `none` (default), `linked`, `inline`, or
         /// `external`. Written `--sourcemap=<MODE>`; bare `--sourcemap` is inline.
         #[arg(
@@ -3197,6 +3212,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             target,
             platform,
             no_minify,
+            icu,
             sourcemap,
             define,
             define_file,
@@ -3235,6 +3251,10 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
             icon,
             metadata,
             hide_console,
+            icu: match icu.as_deref() {
+                Some(value) => crate::compile::parse_icu_locales(value)?,
+                None => None,
+            },
             metafile: metafile.as_deref().map(PathBuf::from),
             bundle: crate::compile::BundleOptions {
                 minify: !no_minify,

--- a/crates/nub-cli/src/compile/icu.rs
+++ b/crates/nub-cli/src/compile/icu.rs
@@ -190,7 +190,7 @@ pub fn trim(bytes: &mut [u8], locales: &[String]) -> Result<TrimReport> {
     // corruption of exactly the kind this whole rewrite has to be trusted not to
     // produce. Not observed in any Node measured; checked because the cost of being
     // wrong is unbounded and the cost of the check is one pass.
-    if sizes.iter().any(|&size| size == 0) {
+    if sizes.contains(&0) {
         bail!("the ICU data package aliases two resources to one offset; refusing to rewrite it");
     }
 

--- a/crates/nub-cli/src/compile/icu.rs
+++ b/crates/nub-cli/src/compile/icu.rs
@@ -1,0 +1,468 @@
+//! Locale trimming for the embedded Node's linked-in ICU data.
+//!
+//! An official Node is built `--with-intl=full-icu`, so one linked-in ICU data
+//! package covering ~700 locales accounts for 31.6 MiB of a ~102 MiB stripped
+//! binary — 31.7% of the compressed blob a default-shape artifact ships. ICU
+//! reaches that package through a bare pointer (`U_ICUDATA_ENTRY_POINT`; a
+//! full-icu Node never calls `udata_setCommonData`, which is `#ifdef
+//! NODE_HAVE_SMALL_ICU`) and navigates it by its own table of contents. Nothing
+//! anywhere records its length. So a SMALLER valid package written at the same
+//! offset is served normally, and the zero padding behind it costs ~900 bytes
+//! once zstd has seen it.
+//!
+//! DELIBERATELY FORMAT-BLIND. The package announces itself with a two-byte magic
+//! plus a `CmnD` format tag, and that pair occurs exactly once per Node binary on
+//! all three container formats — measured on darwin-arm64 Mach-O, linux-x64 ELF
+//! and win32-x64 PE for 26.8.1, each yielding one header and an identical 4305-item
+//! TOC. So this needs no Mach-O/ELF/PE parser and no symbol table, which is what
+//! makes it work at all on ELF: `strip` removes the `.symtab` entry that would
+//! otherwise name the blob, and a PE never exports it in the first place.
+//!
+//! What a trim COSTS is locale output, not APIs. Only locale-shaped resources are
+//! dropped, so the charset converters, break iterators, normalization tables and
+//! every supplemental resource stay — `Intl.Segmenter`, `TextDecoder('shift_jis')`,
+//! `String.prototype.normalize` and time-zone arithmetic are unaffected. A locale
+//! that was dropped falls back through ICU's normal chain to `root`, silently,
+//! which is why this is opt-in and never a default.
+
+use anyhow::{Result, bail};
+
+/// ICU's `UDataInfo.dataFormat` for a common-data package, at header + 12.
+const COMMON_DATA_FORMAT: &[u8; 4] = b"CmnD";
+/// `DataHeader.magic1` / `magic2`, at header + 2 and + 3.
+const MAGIC: (u8, u8) = (0xDA, 0x27);
+/// Every item in the package is padded to this boundary, and the rebuilt package
+/// reproduces that rather than packing tight — ICU memory-maps items in place and
+/// several formats assume their own alignment.
+const ITEM_ALIGN: usize = 16;
+
+/// What a trim did, for the build report.
+pub struct TrimReport {
+    /// Package size before, in bytes.
+    pub before: usize,
+    /// Package size after, in bytes.
+    pub after: usize,
+    /// Items retained.
+    pub kept: usize,
+    /// Items the original package held.
+    pub total: usize,
+}
+
+impl TrimReport {
+    /// Bytes the trim freed inside the binary. They do not shrink the file — the
+    /// package is overwritten in place and zero-padded — but zstd removes almost
+    /// all of them from the artifact.
+    pub fn freed(&self) -> usize {
+        self.before - self.after
+    }
+}
+
+/// The one ICU common-data package in `bytes`.
+///
+/// Scans for the magic rather than a symbol. Every resource INSIDE the package
+/// carries the same two-byte magic, so the `CmnD` format tag is what disambiguates
+/// — an inner resource declares `ResB`, `Cnv `, `Nrm2` and so on. Requiring exactly
+/// one match is the check that this stayed true for the Node in hand, rather than
+/// an assumption carried from the versions it was measured on.
+fn find_package(bytes: &[u8]) -> Result<usize> {
+    let mut found = None;
+    let mut at = 0;
+    while let Some(hit) = bytes[at..]
+        .windows(4)
+        .position(|w| w == COMMON_DATA_FORMAT)
+        .map(|p| at + p)
+    {
+        at = hit + 1;
+        let Some(header) = hit.checked_sub(12) else {
+            continue;
+        };
+        if bytes[header + 2] != MAGIC.0 || bytes[header + 3] != MAGIC.1 {
+            continue;
+        }
+        if found.replace(header).is_some() {
+            bail!("this Node carries more than one ICU data package; refusing to guess which one");
+        }
+    }
+    let Some(header) = found else {
+        bail!("no ICU data package found in this Node — it may be a small-icu build");
+    };
+
+    // isBigEndian / charsetFamily, at header + 8 and + 9. Every Node target is
+    // little-endian ASCII; a package that is not was built by a toolchain whose
+    // layout this reader has never seen, so it declines rather than corrupting it.
+    if bytes[header + 8] != 0 || bytes[header + 9] != 0 {
+        bail!("the ICU data package is not little-endian ASCII; refusing to rewrite it");
+    }
+    Ok(header)
+}
+
+fn u16_at(b: &[u8], at: usize) -> usize {
+    u16::from_le_bytes([b[at], b[at + 1]]) as usize
+}
+
+fn u32_at(b: &[u8], at: usize) -> usize {
+    u32::from_le_bytes([b[at], b[at + 1], b[at + 2], b[at + 3]]) as usize
+}
+
+/// ICU structural resources whose names collide with the locale-id shape below.
+///
+/// `res_index` is the whole list and it is not academic: a three-letter first
+/// segment plus a lowercase second one is indistinguishable from a language plus a
+/// variant subtag (`ca_ES_valencia`), so the shape test alone classifies each
+/// tree's locale index as a droppable locale. A prototype that dropped them
+/// produced a package that formats but reports `supportedLocalesOf` as empty.
+const STRUCTURAL: &[&str] = &["res_index"];
+
+/// Does this item name a locale, as opposed to supplemental data?
+///
+/// ICU locale ids are a language subtag of two or three lowercase letters plus
+/// optional `_`-joined script/region/variant subtags. Every other resource in the
+/// package fails that shape — `supplementalData`, `zoneinfo64`, `likelySubtags`,
+/// `pool`, `nfkc`, `uemoji`, and the converter and break-iterator files — except
+/// the [`STRUCTURAL`] names, which are excluded by hand. Getting this wrong in the
+/// permissive direction only keeps a file that could have gone, which costs bytes
+/// and never correctness.
+fn is_locale(stem: &str) -> bool {
+    if STRUCTURAL.contains(&stem) {
+        return false;
+    }
+    let mut parts = stem.split('_');
+    let Some(language) = parts.next() else {
+        return false;
+    };
+    if !(2..=3).contains(&language.len()) || !language.bytes().all(|c| c.is_ascii_lowercase()) {
+        return false;
+    }
+    parts.all(|p| !p.is_empty() && p.bytes().all(|c| c.is_ascii_alphanumeric()))
+}
+
+/// The language subtag a locale-shaped stem belongs to, which is what `--icu`
+/// matches on: asking for `zh` keeps `zh_Hans_CN`, and asking for `en` keeps
+/// `en_GB`, because a caller naming a language wants that language to work.
+fn language_of(stem: &str) -> &str {
+    stem.split('_').next().unwrap_or(stem)
+}
+
+/// Rewrite the ICU package in `bytes` to hold only `locales` (plus `root` and every
+/// non-locale resource), zero-filling what it vacates.
+///
+/// `bytes` keeps its length: the package is overwritten in place because it is
+/// referenced by absolute address, and everything after it in the binary must stay
+/// where it is.
+pub fn trim(bytes: &mut [u8], locales: &[String]) -> Result<TrimReport> {
+    let header = find_package(bytes)?;
+    let toc = header + u16_at(bytes, header);
+    let count = u32_at(bytes, toc);
+    if count == 0 {
+        bail!("the ICU data package has an empty table of contents");
+    }
+
+    // (name, data offset), both relative to the TOC. The TOC is sorted by name and
+    // the data is laid out in that same order, which is what makes an item's length
+    // readable as the distance to the next one.
+    let entry = |i: usize| -> (String, usize) {
+        let at = toc + 4 + 8 * i;
+        let name_at = toc + u32_at(bytes, at);
+        let end = bytes[name_at..]
+            .iter()
+            .position(|&c| c == 0)
+            .map(|p| name_at + p)
+            .unwrap_or(name_at);
+        (
+            String::from_utf8_lossy(&bytes[name_at..end]).into_owned(),
+            u32_at(bytes, at + 4),
+        )
+    };
+    let mut items: Vec<(String, usize)> = (0..count).map(entry).collect();
+    items.sort_by_key(|(_, offset)| *offset);
+
+    // The final item's length is the one thing the format does not state, so the
+    // rewrite stops at its start: it is never retained, and the bytes it occupies
+    // are left untouched rather than zeroed. That forfeits the alphabetically last
+    // resource of ~4300 (`zu_ZA.res` on 26.x) and a few dozen bytes of padding, and
+    // buys a reader that needs no per-format length parser.
+    let end = toc + items[count - 1].1;
+    let sizes: Vec<usize> = (0..count - 1)
+        .map(|i| items[i + 1].1 - items[i].1)
+        .collect();
+    // Two entries sharing one offset would make the earlier of them zero-length, and
+    // the rewrite would emit it as an empty resource instead of refusing — silent
+    // corruption of exactly the kind this whole rewrite has to be trusted not to
+    // produce. Not observed in any Node measured; checked because the cost of being
+    // wrong is unbounded and the cost of the check is one pass.
+    if sizes.iter().any(|&size| size == 0) {
+        bail!("the ICU data package aliases two resources to one offset; refusing to rewrite it");
+    }
+
+    let wanted = |name: &str| -> bool {
+        let rel = name.split_once('/').map_or(name, |(_, r)| r);
+        let base = rel.rsplit('/').next().unwrap_or(rel);
+        let stem = base.rsplit_once('.').map_or(base, |(s, _)| s);
+        if !is_locale(stem) {
+            return true;
+        }
+        stem == "root" || locales.iter().any(|l| l == language_of(stem))
+    };
+
+    // Rebuilt in NAME order, which the TOC requires — ICU binary-searches it.
+    let mut kept: Vec<(String, usize, usize)> = items[..count - 1]
+        .iter()
+        .zip(&sizes)
+        .filter(|((name, _), _)| wanted(name))
+        .map(|((name, offset), size)| (name.clone(), *offset, *size))
+        .collect();
+    kept.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let names_len: usize = kept.iter().map(|(n, _, _)| n.len() + 1).sum();
+    let mut cursor = 4 + 8 * kept.len();
+    let name_offsets: Vec<usize> = kept
+        .iter()
+        .map(|(n, _, _)| {
+            let at = cursor;
+            cursor += n.len() + 1;
+            at
+        })
+        .collect();
+    let data_start = cursor.div_ceil(ITEM_ALIGN) * ITEM_ALIGN;
+
+    let mut body = Vec::with_capacity(data_start + names_len);
+    body.extend_from_slice(&(kept.len() as u32).to_le_bytes());
+    let mut at = data_start;
+    let data_offsets: Vec<usize> = kept
+        .iter()
+        .map(|(_, _, size)| {
+            let start = at;
+            at += size.div_ceil(ITEM_ALIGN) * ITEM_ALIGN;
+            start
+        })
+        .collect();
+    for (name_at, data_at) in name_offsets.iter().zip(&data_offsets) {
+        body.extend_from_slice(&(*name_at as u32).to_le_bytes());
+        body.extend_from_slice(&(*data_at as u32).to_le_bytes());
+    }
+    for (name, _, _) in &kept {
+        body.extend_from_slice(name.as_bytes());
+        body.push(0);
+    }
+    body.resize(data_start, 0);
+    for (_, offset, size) in &kept {
+        let from = toc + offset;
+        body.extend_from_slice(&bytes[from..from + size]);
+        body.resize(body.len().div_ceil(ITEM_ALIGN) * ITEM_ALIGN, 0);
+    }
+
+    let before = end - header;
+    let after = (toc - header) + body.len();
+    if after > before {
+        bail!("the trimmed ICU package is larger than the one it replaces");
+    }
+    bytes[toc..toc + body.len()].copy_from_slice(&body);
+    bytes[toc + body.len()..end].fill(0);
+
+    Ok(TrimReport {
+        before,
+        after,
+        kept: kept.len(),
+        total: count,
+    })
+}
+
+/// Parse an `--icu` value into the locales to retain.
+///
+/// `full` is the spelling for "change nothing" and is what a bare `--icu` supplies,
+/// so the flag has an explicit form for the default as well as the trim.
+pub fn parse_locales(value: &str) -> Result<Option<Vec<String>>> {
+    if value.eq_ignore_ascii_case("full") {
+        return Ok(None);
+    }
+    let mut out = Vec::new();
+    for part in value.split(',') {
+        let locale = part.trim();
+        if locale.is_empty() {
+            bail!("--icu: empty locale in {value:?}");
+        }
+        // Matched against a language subtag, so this is the whole grammar the flag
+        // accepts. A region is fine to write (`--icu=en-US`) and narrows nothing.
+        let language = locale.split(['-', '_']).next().unwrap_or(locale);
+        if !is_locale(&language.to_ascii_lowercase()) {
+            bail!("--icu: {locale:?} is not a locale");
+        }
+        let language = language.to_ascii_lowercase();
+        if !out.contains(&language) {
+            out.push(language);
+        }
+    }
+    if out.is_empty() {
+        bail!("--icu: no locales given");
+    }
+    Ok(Some(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locale_shape_separates_locales_from_supplemental_data() {
+        for locale in ["en", "de", "root", "zh_Hans_CN", "en_GB", "haw", "sr_Latn"] {
+            assert!(is_locale(locale), "{locale} is a locale id");
+        }
+        for other in [
+            "supplementalData",
+            "zoneinfo64",
+            "likelySubtags",
+            "res_index",
+            "pool",
+            "nfkc",
+            "uemoji",
+            "cnvalias",
+            "metaZones",
+        ] {
+            assert!(!is_locale(other), "{other} is supplemental, not a locale");
+        }
+    }
+
+    #[test]
+    fn a_language_keeps_its_regional_variants() {
+        assert_eq!(language_of("zh_Hans_CN"), "zh");
+        assert_eq!(language_of("en"), "en");
+    }
+
+    #[test]
+    fn full_is_the_spelling_for_no_trim() {
+        assert!(parse_locales("full").unwrap().is_none());
+        assert!(parse_locales("FULL").unwrap().is_none());
+    }
+
+    #[test]
+    fn a_locale_list_normalizes_to_language_subtags() {
+        assert_eq!(
+            parse_locales("en,de-DE,fr_FR,EN").unwrap().unwrap(),
+            vec!["en", "de", "fr"]
+        );
+    }
+
+    #[test]
+    fn a_malformed_locale_list_is_rejected() {
+        for bad in ["", "en,,de", "english", "e", "12"] {
+            assert!(parse_locales(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    /// The rewriter against a synthetic package with the real layout: a header, a
+    /// name-sorted TOC, a name pool, and 16-byte-aligned items.
+    #[test]
+    fn a_trim_keeps_supplemental_data_and_the_named_languages() {
+        let names = [
+            "icudt78l/de.res",
+            "icudt78l/en.res",
+            "icudt78l/fr.res",
+            "icudt78l/root.res",
+            "icudt78l/supplementalData.res",
+            "icudt78l/zz_ZZ.res",
+        ];
+        let mut package = build_package(&names);
+        let original = package.len();
+        // Padded exactly the way a real binary embeds it, so the rewrite has room.
+        package.resize(original * 2, 0xAB);
+
+        let report = trim(&mut package, &["en".to_string()]).unwrap();
+
+        // `zz_ZZ` is last by offset and is therefore outside the rewrite by design.
+        assert_eq!(report.total, names.len());
+        assert_eq!(
+            kept_names(&package),
+            [
+                "icudt78l/en.res",
+                "icudt78l/root.res",
+                "icudt78l/supplementalData.res"
+            ]
+        );
+        assert!(report.after < report.before, "the package must shrink");
+        assert!(report.freed() > 0);
+    }
+
+    #[test]
+    fn a_trim_matches_a_language_across_its_regional_variants() {
+        let names = [
+            "icudt78l/en.res",
+            "icudt78l/root.res",
+            "icudt78l/zh.res",
+            "icudt78l/zh_Hans_CN.res",
+            "icudt78l/zz_ZZ.res",
+        ];
+        let mut package = build_package(&names);
+        package.resize(package.len() * 2, 0);
+        trim(&mut package, &["zh".to_string()]).unwrap();
+        assert_eq!(
+            kept_names(&package),
+            [
+                "icudt78l/root.res",
+                "icudt78l/zh.res",
+                "icudt78l/zh_Hans_CN.res"
+            ]
+        );
+    }
+
+    #[test]
+    fn a_binary_with_no_icu_package_is_refused() {
+        let mut not_node = vec![0u8; 4096];
+        assert!(trim(&mut not_node, &["en".to_string()]).is_err());
+    }
+
+    const HEADER_LEN: usize = 32;
+
+    /// A minimal but structurally faithful common-data package.
+    fn build_package(names: &[&str]) -> Vec<u8> {
+        let mut header = vec![0u8; HEADER_LEN];
+        header[0..2].copy_from_slice(&(HEADER_LEN as u16).to_le_bytes());
+        header[2] = MAGIC.0;
+        header[3] = MAGIC.1;
+        header[12..16].copy_from_slice(COMMON_DATA_FORMAT);
+
+        let mut cursor = 4 + 8 * names.len();
+        let name_offsets: Vec<usize> = names
+            .iter()
+            .map(|n| {
+                let at = cursor;
+                cursor += n.len() + 1;
+                at
+            })
+            .collect();
+        let data_start = cursor.div_ceil(ITEM_ALIGN) * ITEM_ALIGN;
+
+        let mut body = Vec::new();
+        body.extend_from_slice(&(names.len() as u32).to_le_bytes());
+        for (i, _) in names.iter().enumerate() {
+            body.extend_from_slice(&(name_offsets[i] as u32).to_le_bytes());
+            body.extend_from_slice(&((data_start + i * ITEM_ALIGN) as u32).to_le_bytes());
+        }
+        for n in names {
+            body.extend_from_slice(n.as_bytes());
+            body.push(0);
+        }
+        body.resize(data_start, 0);
+        for i in 0..names.len() {
+            body.extend_from_slice(&[i as u8 + 1; ITEM_ALIGN]);
+        }
+        header.extend_from_slice(&body);
+        header
+    }
+
+    fn kept_names(package: &[u8]) -> Vec<String> {
+        let header = find_package(package).unwrap();
+        let toc = header + u16_at(package, header);
+        let count = u32_at(package, toc);
+        (0..count)
+            .map(|i| {
+                let name_at = toc + u32_at(package, toc + 4 + 8 * i);
+                let end = package[name_at..]
+                    .iter()
+                    .position(|&c| c == 0)
+                    .map(|p| name_at + p)
+                    .unwrap();
+                String::from_utf8_lossy(&package[name_at..end]).into_owned()
+            })
+            .collect()
+    }
+}

--- a/crates/nub-cli/src/compile/icu.rs
+++ b/crates/nub-cli/src/compile/icu.rs
@@ -37,24 +37,16 @@ const MAGIC: (u8, u8) = (0xDA, 0x27);
 const ITEM_ALIGN: usize = 16;
 
 /// What a trim did, for the build report.
+///
+/// Counts only. The bytes freed inside the binary are not carried, because the
+/// figure a caller would want — how much smaller the artifact gets — is decided by
+/// zstd afterwards, and the raw number is about four times larger. Reporting it
+/// promised a saving the build does not deliver.
 pub struct TrimReport {
-    /// Package size before, in bytes.
-    pub before: usize,
-    /// Package size after, in bytes.
-    pub after: usize,
     /// Items retained.
     pub kept: usize,
     /// Items the original package held.
     pub total: usize,
-}
-
-impl TrimReport {
-    /// Bytes the trim freed inside the binary. They do not shrink the file — the
-    /// package is overwritten in place and zero-padded — but zstd removes almost
-    /// all of them from the artifact.
-    pub fn freed(&self) -> usize {
-        self.before - self.after
-    }
 }
 
 /// The one ICU common-data package in `bytes`.
@@ -251,17 +243,16 @@ pub fn trim(bytes: &mut [u8], locales: &[String]) -> Result<TrimReport> {
         body.resize(body.len().div_ceil(ITEM_ALIGN) * ITEM_ALIGN, 0);
     }
 
-    let before = end - header;
-    let after = (toc - header) + body.len();
-    if after > before {
+    // Dropping items can only shrink the package, so this cannot fire on any input
+    // the filter above produces. It is here because the alternative to failing is
+    // writing past `end` into whatever the linker put next.
+    if (toc - header) + body.len() > end - header {
         bail!("the trimmed ICU package is larger than the one it replaces");
     }
     bytes[toc..toc + body.len()].copy_from_slice(&body);
     bytes[toc + body.len()..end].fill(0);
 
     Ok(TrimReport {
-        before,
-        after,
         kept: kept.len(),
         total: count,
     })
@@ -302,12 +293,18 @@ pub fn parse_locales(value: &str) -> Result<Option<Vec<String>>> {
 mod tests {
     use super::*;
 
+    /// `root` is deliberately absent from the locale list below. Its four letters
+    /// fail the language-subtag length bound, so it is classified as supplemental
+    /// and retained by that path — and `wanted` names it explicitly as well, so
+    /// widening the bound later could not start dropping it. Both trim tests assert
+    /// `root.res` survives, which is the property that actually matters.
     #[test]
     fn locale_shape_separates_locales_from_supplemental_data() {
-        for locale in ["en", "de", "root", "zh_Hans_CN", "en_GB", "haw", "sr_Latn"] {
+        for locale in ["en", "de", "zh_Hans_CN", "en_GB", "haw", "sr_Latn"] {
             assert!(is_locale(locale), "{locale} is a locale id");
         }
         for other in [
+            "root",
             "supplementalData",
             "zoneinfo64",
             "likelySubtags",
@@ -378,8 +375,7 @@ mod tests {
                 "icudt78l/supplementalData.res"
             ]
         );
-        assert!(report.after < report.before, "the package must shrink");
-        assert!(report.freed() > 0);
+        assert!(report.kept < report.total, "the package must shrink");
     }
 
     #[test]

--- a/crates/nub-cli/src/compile/inject.rs
+++ b/crates/nub-cli/src/compile/inject.rs
@@ -655,6 +655,7 @@ mod tests {
             node_sha256: String::new(),
             node_blake3: String::new(),
             node_size: 0,
+            node_icu: String::new(),
             app_compressed: false,
             app_sha256: "aa".into(),
             minify: true,

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -35,6 +35,7 @@ mod assets;
 pub mod bundle;
 mod closure;
 mod external;
+mod icu;
 mod inject;
 mod launcher;
 mod loaders;
@@ -45,6 +46,7 @@ mod unbundlable;
 mod version_info;
 
 pub use bundle::{BundleOptions, SourcemapMode};
+pub use icu::parse_locales as parse_icu_locales;
 
 /// Shown while a first run unpacks the embedded Node (or provisions one under
 /// `--smol`). Deliberately generic: the launcher has no app name of its own, and
@@ -75,6 +77,11 @@ pub struct CompileOptions {
     /// `--node-options`: NODE_OPTIONS-style strings the compiled binary starts its
     /// Node with, applied before whatever the end user sets at run time.
     pub node_options: Vec<String>,
+    /// `--icu=<locales>`: the languages to keep in the embedded Node's ICU data.
+    /// `None` — no flag, or a bare `--icu`, or `--icu=full` — keeps all ~700, which
+    /// is the only setting that formats identically to the user's own `node`.
+    /// Ignored under `--smol`, which embeds no Node to trim.
+    pub icu: Option<Vec<String>>,
     /// `--icon`: a Windows `.ico` to show on the executable. Windows-only because
     /// it is the only target whose format carries the icon in the file itself —
     /// macOS reads one from the surrounding `.app` bundle and Linux from a
@@ -113,6 +120,17 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
     let entry_path = Path::new(&opts.entry);
     if !entry_path.is_file() {
         bail!("entry file not found: {}", opts.entry);
+    }
+
+    // Refused rather than ignored, matching `--icon` and `--metadata`: `--smol`
+    // embeds no Node, so there is no ICU data to trim and the artifact would run on
+    // whatever the host supplies. Accepting the flag would report a saving the
+    // build never made.
+    if opts.smol && opts.icu.is_some() {
+        bail!(
+            "--icu trims the ICU data out of the EMBEDDED Node, and --smol embeds none.\n\
+             \x20\x20A --smol artifact uses whichever Node it finds or provisions at startup."
+        );
     }
 
     // Read here for the same reason the entry is stat'd here: a mistyped path is
@@ -306,7 +324,7 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         let exact =
             version_management::resolve_pin_for_platform(&pin, os, arch, musl, &cache_root)?;
         external::check_node_support(&exact, &source, &shim_plan)?;
-        let node = build_node_blob(&exact, &target, &cache_root, &source)?;
+        let node = build_node_blob(&exact, &target, &cache_root, &source, opts.icu.as_deref())?;
         let summary = RuntimeSummary {
             fact: format!("Node {exact}, embedded"),
             provenance: source.to_string(),
@@ -363,6 +381,7 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         node_sha256: node.sha256,
         node_blake3: node.blake3,
         node_size: node.size,
+        node_icu: node.icu,
         app_compressed: true,
         app_sha256: app_sha,
         minify: opts.bundle.minify,
@@ -1891,6 +1910,9 @@ struct EmbeddedNode {
     size: u64,
     /// zstd-19 compressed Node LICENSE.
     license: Vec<u8>,
+    /// The locales `--icu` kept, comma-joined, or empty for an untrimmed Node.
+    /// Reaches the manifest, where it gates the launcher's official-Node dedup.
+    icu: String,
 }
 
 fn build_node_blob(
@@ -1898,6 +1920,7 @@ fn build_node_blob(
     target: &TargetPlatform,
     cache_root: &Path,
     resolved_from: &str,
+    icu: Option<&[String]>,
 ) -> Result<EmbeddedNode> {
     let (os, arch, musl) = dist_platform(target);
     // Provisioning prints the `Using Node.js <v> (resolved from <source>)` line +
@@ -1919,7 +1942,7 @@ fn build_node_blob(
         );
     }
 
-    let bytes = prepare_node_bytes(&node_bin, target)?;
+    let bytes = prepare_node_bytes(&node_bin, target, icu)?;
     let sha = crate::cli::sha256_hex(&bytes);
     // Retained as manifest format headroom; `sha` stays the cache key. Both are
     // over the same decompressed bytes.
@@ -1961,6 +1984,7 @@ fn build_node_blob(
         blake3: b3,
         size: bytes.len() as u64,
         license,
+        icu: icu.map(|l| l.join(",")).unwrap_or_default(),
     })
 }
 
@@ -2005,12 +2029,27 @@ fn node_binary_in(version_dir: &Path, target: &TargetPlatform) -> PathBuf {
 ///   binary cannot be run, so the check degrades to "is it still a well-formed
 ///   image of the expected format". Execution alone is NOT sufficient — see
 ///   `retains_node_api_exports`.
-fn prepare_node_bytes(node_bin: &Path, target: &TargetPlatform) -> Result<Vec<u8>> {
+fn prepare_node_bytes(
+    node_bin: &Path,
+    target: &TargetPlatform,
+    icu: Option<&[String]>,
+) -> Result<Vec<u8>> {
     let original = fs::read(node_bin).with_context(|| format!("reading {}", node_bin.display()))?;
     let format = target.format();
 
+    // Every fallback below ships the ORIGINAL Node, which is correct but larger.
+    // That trade is fine for a strip nobody asked for and wrong for an explicit
+    // `--icu`: silently shipping ~700 locales when the caller asked for two is the
+    // build lying about what it produced. So a requested trim turns each fallback
+    // into an error instead.
     let needs_resign = format == ContainerFormat::MachO;
     if needs_resign && which_first(&["codesign"]).is_none() {
+        if icu.is_some() {
+            bail!(
+                "--icu needs codesign on PATH: trimming rewrites the Node binary, and macOS will \
+                 not launch one whose signature no longer matches"
+            );
+        }
         warn(
             "no codesign on PATH, so the embedded Node is not stripped",
             &["A stripped macOS Node could not be re-signed, and an unsigned one cannot launch."],
@@ -2026,7 +2065,11 @@ fn prepare_node_bytes(node_bin: &Path, target: &TargetPlatform) -> Result<Vec<u8
     } else {
         &["llvm-strip"]
     };
-    let Some(strip) = which_first(candidates) else {
+    // Optional, because an ICU trim is worth staging for on its own: a cross-format
+    // target needs llvm-strip specifically, so a Mac compiling for Windows routinely
+    // has no usable stripper and must still be able to honour `--icu`.
+    let strip = which_first(candidates);
+    if strip.is_none() && icu.is_none() {
         warn(
             &format!(
                 "no {} on PATH, so the embedded Node is not stripped",
@@ -2035,11 +2078,29 @@ fn prepare_node_bytes(node_bin: &Path, target: &TargetPlatform) -> Result<Vec<u8
             &["The artifact is larger than it needs to be; installing the tool shrinks it."],
         );
         return Ok(original);
+    }
+
+    // The trim lands on the STAGED copy, never on `original`, so every fallback path
+    // below still has pristine bytes to return.
+    let staged = match icu {
+        Some(locales) => {
+            let mut bytes = original.clone();
+            let report = icu::trim(&mut bytes, locales)?;
+            note(&format!(
+                "Trimmed ICU to {} ({} of {} resources, −{:.0} MB before compression)",
+                locales.join(", "),
+                report.kept,
+                report.total,
+                report.freed() as f64 / 1_000_000.0
+            ));
+            bytes
+        }
+        None => original.clone(),
     };
 
     let tmp = std::env::temp_dir().join(format!("nub-compile-node-{}", std::process::id()));
     let _ = fs::remove_file(&tmp);
-    fs::write(&tmp, &original).with_context(|| format!("staging Node at {}", tmp.display()))?;
+    fs::write(&tmp, &staged).with_context(|| format!("staging Node at {}", tmp.display()))?;
     // fs::write lands 0644; the post-strip `--version` verification must be able to
     // EXEC the staged binary, so restore the executable bit before strip/verify.
     set_executable(&tmp)?;
@@ -2066,9 +2127,16 @@ fn prepare_node_bytes(node_bin: &Path, target: &TargetPlatform) -> Result<Vec<u8
         && fs::metadata(&entitlements).is_ok_and(|m| m.len() > 0);
     let _ent_guard = FileGuard(entitlements.clone());
 
-    let mut argv: Vec<&std::ffi::OsStr> = strip_flags(format).iter().map(AsRef::as_ref).collect();
-    argv.push(tmp.as_os_str());
-    let mut ok = run_ok(&strip, &argv);
+    let mut ok = match &strip {
+        Some(strip) => {
+            let mut argv: Vec<&std::ffi::OsStr> =
+                strip_flags(format).iter().map(AsRef::as_ref).collect();
+            argv.push(tmp.as_os_str());
+            run_ok(strip, &argv)
+        }
+        // Nothing to strip with, but a trim still has to be signed and verified.
+        None => true,
+    };
     if ok && needs_resign {
         // `-i node` is load-bearing, not cosmetic. Without it `codesign` derives the
         // CodeDirectory identifier from the file's BASENAME, and this file is staged
@@ -2130,10 +2198,19 @@ fn prepare_node_bytes(node_bin: &Path, target: &TargetPlatform) -> Result<Vec<u8
         Some("the stripped Node failed verification")
     } else if !retains_node_api_exports(&original, &stripped) {
         Some("stripping dropped the Node-API exports that native addons resolve against")
+    } else if icu.is_some() && target.is_host() && !node_formats_dates(&tmp) {
+        // `node_runs` is a `--version` check, and a broken ICU package passes it:
+        // a package whose per-tree indexes no longer resolve boots fine and then
+        // FATAL-aborts inside the first `Intl.DateTimeFormat`. So a trim earns a
+        // probe that actually reaches ICU.
+        Some("the trimmed Node could not format a date through Intl")
     } else {
         None
     };
     if let Some(why) = reject {
+        if icu.is_some() {
+            bail!("--icu could not produce a working Node: {why}");
+        }
         // The same class as the two missing-tool warnings above: the artifact is
         // correct but larger than it should be, and the reader can act on why.
         warn(
@@ -2143,10 +2220,29 @@ fn prepare_node_bytes(node_bin: &Path, target: &TargetPlatform) -> Result<Vec<u8
         return Ok(original);
     }
 
-    if !needs_resign {
+    if !needs_resign && strip.is_some() {
         note("Stripped the embedded Node");
     }
     Ok(stripped)
+}
+
+/// Can this Node reach its ICU data and format through it?
+///
+/// Constructs an `Intl.DateTimeFormat` and a segmenter and formats with both, which
+/// is what separates a package that merely PARSES from one ICU can navigate. Host
+/// targets only, for the same reason `node_runs` is: a foreign binary cannot run
+/// here. A non-zero exit or a crash is a failure; the OUTPUT is deliberately not
+/// asserted on, because a trimmed Node is expected to answer in a fallback locale.
+fn node_formats_dates(node: &Path) -> bool {
+    run_ok(
+        node.to_string_lossy().as_ref(),
+        &[
+            "-e".as_ref(),
+            "new Intl.DateTimeFormat('en',{dateStyle:'full'}).format(0);\
+             [...new Intl.Segmenter('en',{granularity:'word'}).segment('a b')];"
+                .as_ref(),
+        ],
+    )
 }
 
 /// Flags this format's stripper needs to leave a usable Node behind.
@@ -3600,6 +3696,7 @@ mod tests {
             node_sha256: "node".into(),
             node_blake3: String::new(),
             node_size: 0,
+            node_icu: String::new(),
             app_compressed: false,
             app_sha256: "app".into(),
             minify: false,
@@ -3622,6 +3719,7 @@ mod tests {
             node_sha256: String::new(),
             node_blake3: String::new(),
             node_size: 0,
+            node_icu: String::new(),
             app_compressed: false,
             ..manifest
         };

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -2086,12 +2086,16 @@ fn prepare_node_bytes(
         Some(locales) => {
             let mut bytes = original.clone();
             let report = icu::trim(&mut bytes, locales)?;
+            // Resource counts, not the bytes freed. The rewrite vacates ~19 MB of a
+            // ~107 MB binary, but most of that is zeros by the time zstd sees it, so
+            // reporting the raw figure would promise an artifact four times smaller
+            // than the one this build is about to produce. The `output` row below
+            // states the size that actually ships.
             note(&format!(
-                "Trimmed ICU to {} ({} of {} resources, −{:.0} MB before compression)",
+                "Trimmed ICU to {} ({} of {} locale resources kept)",
                 locales.join(", "),
                 report.kept,
-                report.total,
-                report.freed() as f64 / 1_000_000.0
+                report.total
             ));
             bytes
         }

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -3647,6 +3647,7 @@ mod tests {
             icon: None,
             metadata: Vec::new(),
             hide_console: false,
+            icu: None,
             smol: false,
             target: None,
             platform: None,

--- a/crates/nub-core/src/compile.rs
+++ b/crates/nub-core/src/compile.rs
@@ -170,6 +170,18 @@ pub struct Manifest {
     /// the launcher falls back to the digest then, so old artifacts keep working.
     #[serde(default)]
     pub node_size: u64,
+    /// The locales `--icu` kept in the embedded Node, comma-joined. Empty means the
+    /// Node is the official one, untrimmed — which is the default, and what every
+    /// manifest written before this field existed describes.
+    ///
+    /// Load-bearing at RUNTIME, not just informational: it is what forbids the
+    /// launcher's official-Node dedup. That dedup rests on the embedded and the
+    /// provisioned Node running identically, which a trim falsifies — so without
+    /// this gate one artifact would format through full ICU on a machine that has
+    /// Node in nub's store and through the trimmed data on a machine that does not,
+    /// and the publisher would be unable to reproduce their own user's bug.
+    #[serde(default)]
+    pub node_icu: String,
     /// Whether each app file's bytes are individually zstd-compressed.
     ///
     /// Per FILE, not per region: this module is a pure container (see the header —
@@ -882,6 +894,7 @@ mod tests {
             node_sha256: "abc123".into(),
             node_blake3: String::new(),
             node_size: 0,
+            node_icu: String::new(),
             app_compressed: false,
             app_sha256: "def456".into(),
             minify: false,
@@ -912,6 +925,7 @@ mod tests {
             node_sha256: "abc123".into(),
             node_blake3: String::new(),
             node_size: 0,
+            node_icu: String::new(),
             app_compressed: false,
             app_sha256: "def456".into(),
             minify: true,
@@ -967,6 +981,7 @@ mod tests {
             node_sha256: String::new(),
             node_blake3: String::new(),
             node_size: 0,
+            node_icu: String::new(),
             app_compressed: false,
             app_sha256: "aa".into(),
             minify: false,

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -1499,6 +1499,14 @@ fn node_stores(base: &Path) -> Vec<NodeDir> {
 }
 
 fn official_node_for_manifest(base: &Path, manifest: &Manifest) -> Option<PathBuf> {
+    // The dedup's whole premise is that the embedded Node and an official one of
+    // the same version run identically — true of a strip, false of an `--icu` trim.
+    // Reusing a store Node here would make the artifact format through whichever
+    // ICU the MACHINE happened to have, so a trimmed payload never dedups: it is
+    // the one case where the embedded bytes are the point.
+    if !manifest.node_icu.is_empty() {
+        return None;
+    }
     node_stores(base).into_iter().find_map(|store| {
         cache::revalidate(&store.root).ok()?;
         let version_dir = store.root.join(&manifest.node_version);
@@ -3186,6 +3194,7 @@ mod tests {
             node_sha256: format!("{:x}", Sha256::digest(b"node")),
             node_blake3: String::new(),
             node_size: b"node".len() as u64,
+            node_icu: String::new(),
             app_compressed: false,
             app_sha256: "app-cache-key".to_string(),
             minify: false,
@@ -3903,6 +3912,39 @@ mod tests {
         assert!(
             !node_cache_dir(&base, &view.manifest).exists(),
             "the official store is the Node artifact; no extracted duplicate is needed"
+        );
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    /// An ICU-trimmed payload must extract its OWN Node even when an official one of
+    /// the same version is sitting in the store, ready and free.
+    ///
+    /// The dedup exists because a stripped Node and an official one run identically.
+    /// A trim breaks that, and the resulting bug is the nastiest shape available: the
+    /// artifact would format through full ICU on a developer's machine (which has
+    /// Node) and through English-only data on an end user's (which does not), so the
+    /// publisher could never reproduce the report. This is the assertion that stops
+    /// it, and it is exactly the previous test with one field set.
+    #[test]
+    fn a_trimmed_payload_refuses_an_official_store_node() {
+        let base = fresh_cache_dir("trimmed-refuses-official");
+        let mut view = test_view();
+        view.manifest.node_icu = "en".into();
+
+        let official = node_in_version_dir(&base.join("node").join(&view.manifest.node_version));
+        create_staging_subdirs(&base, official.parent().unwrap()).unwrap();
+        write_file(&official, b"official node").unwrap();
+        set_executable(&official).unwrap();
+        materialize_test_app(&view, &base);
+
+        assert!(
+            official_node_for_manifest(&base, &view.manifest).is_none(),
+            "a trimmed payload must never adopt the official Node — its ICU data is \
+             the whole reason it carries its own"
+        );
+        assert!(
+            verify_warm_cache(&view, &base).is_none(),
+            "and no warm verdict may rest on that official Node either"
         );
         let _ = fs::remove_dir_all(&base);
     }

--- a/wiki/commands/compile-architecture.md
+++ b/wiki/commands/compile-architecture.md
@@ -12,6 +12,8 @@ Normal Nub execution augments the user's Node through preloads, module hooks, an
 
 The runtime is still more than a bare script spawn. The launcher starts official, unpatched Node with a fixed internal CommonJS bootstrap as its first CLI argument, followed by version-appropriate flags and the extracted bundled entry. The bootstrap captures fixed-root builtin access before user hooks run, and the bundle's preamble restores the runtime globals the compiled program needs.
 
+"Unpatched" describes the default and the source, not an invariant of the byte stream: the build already strips the binary and re-signs it on macOS, and `--icu` additionally rewrites its ICU data package in place. Node's own code is never altered.
+
 The preamble is injected into the main root and each supported static worker root. It installs feature-detected polyfills, including the supported Web Storage surface for `sessionStorage`. That storage is process-local and does not add browser-origin sharing or unsupported Web Storage APIs.
 
 Static workers must use a file-backed `new Worker(new URL("./worker.js", import.meta.url))` shape through the global `Worker` or a named ESM import from `node:worker_threads`. Statically recognized data URLs, blob URLs, `{ eval: true }`, and CommonJS `require("node:worker_threads")` worker bindings are refused because the compiler cannot turn them into preamble-bearing roots.
@@ -24,6 +26,16 @@ The default shape embeds a Node; `--smol` does not, and finds one at startup ins
 | --- | --- | --- | --- |
 | default (embed) | ~26 MB | launcher + manifest + bundled JS + assets + a stripped, zstd-19 Node | inside the binary |
 | `--smol` | ~0.6 MB | launcher + manifest + bundled JS + assets | discovered locally, else provisioned |
+
+### Trimming ICU out of the embedded Node
+
+`--icu=en,de,fr` rewrites the embedded Node's ICU data package in place to hold only the named languages. The default keeps every locale, because a dropped one falls back silently rather than failing.
+
+An official Node is built `--with-intl=full-icu`, so one linked-in package covering ~700 locales accounts for 31.6 MiB of the ~102 MiB stripped binary and 31.7% of the compressed blob. The rewrite zero-fills what it vacates, and that padding survives zstd at under a kilobyte. Measured on Node 26 for darwin-arm64, English alone takes a hello-world artifact from 29.5 MB to 24.4 MB.
+
+Three properties make the rewrite safe to do after linking. ICU reaches the package through a bare pointer and navigates it by its own table of contents, so nothing records the length a smaller package would contradict. The package announces itself with a magic and a `CmnD` format tag that occur exactly once per binary in all three container formats, so locating it needs no symbol table — which matters because `strip` removes the ELF symbol that would otherwise name it. And only locale-shaped resources are dropped, so the charset converters, break iterators, normalization tables and supplemental resources all remain: no API changes behavior, and a dropped language falls back through ICU's normal chain to `root`.
+
+That fallback is silent, which is why the default keeps every locale and why the trim is never inferred. Two consequences follow the artifact. A trimmed payload never dedups against an official Node in Nub's store — the dedup assumes the embedded and provisioned binaries run identically, and a trim falsifies exactly that — and a trimmed macOS Node must be re-signed, so `--icu` requires `codesign` rather than degrading to an unsigned binary. Because a broken ICU package still answers `--version` before aborting at the first format call, a host-target trim is verified by formatting a date and segmenting a string, not by launching.
 
 The `--smol` launcher downloads through curl or wget, verifies the selected archive against `SHASUMS256.txt`, and extracts it through Nub core's capped archive reader. Unix hosts use the published `.tar.xz`; Windows hosts use the published `.zip`. The verified tree is staged and atomically published under the ordinary Node store before discovery can return it.
 


### PR DESCRIPTION
Adds an opt-in `--icu` flag to `nub compile` that trims unused locales out of the embedded Node's ICU data.

An official Node is built `--with-intl=full-icu`, so one linked-in ICU data package covering ~700 locales accounts for 31.6 MiB of the ~102 MiB stripped binary — 31.7% of the compressed blob a default-shape artifact ships. Naming the languages an app actually formats for reclaims most of it.

```
nub compile app.ts                # 29,456,306 B — every locale (unchanged default)
nub compile app.ts --icu=en       # 24,898,994 B — 1000 of 4305 ICU resources
nub compile app.ts --icu=en,de    # 24,898,994 B — 1027 of 4305
```

Measured end to end on Node 26.8.1 for darwin-arm64: **−4,557,312 bytes, or 15.5%**. The two trimmed artifacts match in total because their Node blobs differ by only 35 KB and the injection's alignment padding absorbs it; they are not identical, and they format differently.

Locale data is cheap once the full set is gone — twenty languages cost 4 MiB raw more than English alone — so the value list is where the saving sits rather than an on/off switch.

## Flag grammar

Written `--icu=<LOCALES>`; a bare `--icu` means `full`. The `require_equals` form is required, not stylistic — an optional-value flag beside a positional would otherwise consume the entry, and `nub compile --icu en,de app.ts` would fail with `unexpected argument`. This matches `--sourcemap` in the same subcommand.

Matching is on the language subtag, so `--icu=zh` retains `zh_Hans_CN` and `--icu=en-US` retains `en`. The `root` locale is always kept.

## How the rewrite works

ICU reaches its data package through a bare pointer and navigates it by its own table of contents, and nothing records the package's length. A smaller valid package written at the same offset is therefore served normally, and the zero padding behind it survives zstd at under a kilobyte.

Locating the package needs no Mach-O/ELF/PE parser and no symbol table: it announces itself with a two-byte magic plus a `CmnD` format tag, and that pair occurs exactly once per binary. Verified on Node 26.8.1 for darwin-arm64, linux-x64 and win32-x64 — one header each, identical 4305-item table of contents. The symbol-based alternative does not survive `strip` on ELF.

Only locale-shaped resources are dropped. The charset converters, break iterators, normalization tables and every supplemental resource stay, so no API changes behavior: `Intl.Segmenter`, `TextDecoder('shift_jis')`, `String.prototype.normalize` and time-zone arithmetic all work unchanged. A dropped language falls back through ICU's normal chain to `root`.

## Why the default is unchanged

That fallback is silent. `Intl.NumberFormat('de-DE').format(1234.5)` returns `1,234.5` on a trimmed build, with no error, and the publisher choosing the default is not the person who reads the wrong output. `vercel/pkg` shipped small-icu base binaries and collected years of exit-0-wrong-output reports ([#539](https://github.com/vercel/pkg/issues/539), [#1563](https://github.com/vercel/pkg/issues/1563), [#1731](https://github.com/vercel/pkg/issues/1731)). A build with no `--icu` keeps every locale and formats exactly like the user's own `node`.

## Three safety properties

**A trimmed payload never dedups against an official store Node.** The launcher's dedup rests on the embedded and provisioned binaries running identically, which a trim falsifies. Without the gate, one artifact would format through full ICU on a machine that has Node in nub's store and through trimmed data on a machine that does not — a difference the publisher could not reproduce locally. `a_trimmed_payload_refuses_an_official_store_node` covers it, and was confirmed to fail with the gate removed.

**A trim requires `codesign` on a Mach-O target**, rather than degrading to an unsigned binary macOS will not launch. Every other fallback in `prepare_node_bytes` ships the original Node, which is correct but larger; a requested trim turns each of those into an error instead, because silently shipping 700 locales when two were asked for is the build misreporting what it produced.

**A host-target trim is verified by formatting, not by launching.** A package whose per-tree indexes no longer resolve answers `--version` correctly and then aborts inside the first `Intl.DateTimeFormat`, so the existing `node_runs` probe cannot see it. `node_formats_dates` formats a date and segments a string instead.

Refused rather than ignored under `--smol`, which embeds no Node to trim, matching how `--icon` and `--metadata` handle a target that cannot carry them.

## Verification

- Unit tests over the locale-shape rule, the flag parser and the package rewrite against a synthetic package.
- The launcher regression test above, plus its negative control.
- End-to-end: one fixture compiled three ways against the same Node, run, and diffed, with an official Node deliberately left in the store so the dedup gate is under test.

| Probe | default | `--icu=en` | `--icu=en,de` |
| --- | --- | --- | --- |
| `Intl.NumberFormat('de-DE')` | `1.234,5` | `1,234.5` | `1.234,5` |
| `Intl.NumberFormat('fr-FR')` | `1 234,5` | `1,234.5` | `1,234.5` |
| `Intl.DateTimeFormat('de-DE')` | `Mittwoch, 31. Dezember 1969` | `Wednesday, December 31, 1969` | `Mittwoch, 31. Dezember 1969` |
| `Intl.ListFormat('de')` | `a, b und c` | `a, b, and c` | `a, b und c` |
| `resolvedOptions().locale` for `de-DE` | `de-DE` | `en-US` | `de-DE` |
| `Intl.Segmenter` word count | 3 | 3 | 3 |
| `TextDecoder('shift_jis')` | `あ` | `あ` | `あ` |
| `'i'.toLocaleUpperCase('tr')` | `İ` | `İ` | `İ` |
| time zone `Asia/Tokyo` | `9:00:00 AM GMT+9` | `9:00:00 AM GMT+9` | `9:00:00 AM GMT+9` |

German is correct under `--icu=en,de` and falls back under `--icu=en`; French falls back under both, since neither names it. Every API-level probe is unchanged across all three.
- Root and `nub-launcher` clippy at `--all-targets`, `cargo fmt`, and the test suite.
