### PR TITLE
compile: run a pure-JavaScript artifact straight from the executable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,6 +2926,7 @@ dependencies = [
  "aube-workspace",
  "base64",
  "blake3",
+ "brotli",
  "clap",
  "clx",
  "console",

--- a/crates/nub-cli/Cargo.toml
+++ b/crates/nub-cli/Cargo.toml
@@ -34,6 +34,7 @@ compile = [
     "dep:rolldown_utils",
     "dep:libsui",
     "dep:zstd",
+    "dep:brotli",
     "dep:oxc_allocator",
     "dep:oxc_ast",
     "dep:oxc_ast_visit",
@@ -94,6 +95,10 @@ libsui = { version = "0.16", optional = true }
 # zstd-19 compression of the embedded Node (encode side; the launcher decodes with
 # pure-Rust ruzstd).
 zstd = { version = "0.13", optional = true }
+# The inline (`no-extract`) payload's codec. Brotli rather than the zstd beside it
+# because the artifact's own JavaScript is what decompresses those bytes, and
+# `zlib.zstdDecompressSync` is absent on Node 23.5 and 23.6.
+brotli = { version = "8", optional = true }
 # `--include`/`--exclude` matching. Already in the tree at this version as a
 # nub-core dependency, so the compile feature adds no build cost — declared here
 # rather than reached through nub-core, which does not re-export it.

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -1616,13 +1616,6 @@ impl CompilePreamble {
         let source = std::fs::read_to_string(&prelude)
             .with_context(|| format!("reading the compile prelude at {}", prelude.display()))?;
         let source = strip_native_polyfills(&source, target_node);
-        let worker_blob = runtime_dir.join("worker-blob-url.cjs");
-        let worker_blob_bytes = std::fs::read(&worker_blob).with_context(|| {
-            format!(
-                "reading compile runtime support at {}",
-                worker_blob.display()
-            )
-        })?;
         // Two distinct names, deliberately: the runtime tree ships this as its own
         // source filename, while the payload publishes it under the `__nub_`-prefixed
         // fixed root name so it cannot collide with an application file. Reading by
@@ -1635,9 +1628,6 @@ impl CompilePreamble {
             )
         })?;
         let mut prelude = Self::from_source(entry, runtime_dir, source);
-        prelude
-            .support_files
-            .push(("worker-blob-url.cjs".to_string(), worker_blob_bytes));
         prelude.root_support_files.push((
             nub_core::compile::COMPILE_BOOTSTRAP_NAME.to_string(),
             bootstrap_bytes,
@@ -1782,6 +1772,18 @@ fn compile_runtime_dir() -> Result<PathBuf> {
         bail!("the embedded nub runtime failed integrity verification; refusing to compile")
     }
     Ok(runtime_dir)
+}
+
+/// Read one file out of the public runtime directory `nub compile` bundles from.
+///
+/// The same seam [`compile_runtime_dir`] establishes, exposed for compile stages
+/// that need a runtime file without going through the prelude plugin — the
+/// no-extract loader is the one caller. Going through this rather than a path of
+/// its own is what keeps a released binary reading its EXTRACTED embedded runtime
+/// instead of a Cargo checkout that is not there.
+pub fn compile_runtime_file(name: &str) -> Result<Vec<u8>> {
+    let path = compile_runtime_dir()?.join(name);
+    std::fs::read(&path).with_context(|| format!("reading compile runtime at {}", path.display()))
 }
 
 impl Plugin for CompilePreamble {

--- a/crates/nub-cli/src/compile/inject.rs
+++ b/crates/nub-cli/src/compile/inject.rs
@@ -663,6 +663,7 @@ mod tests {
             node_flags: Vec::new(),
             sealed_module_graph: false,
             hide_console: false,
+            inline_app: false,
         };
         nub_core::compile::encode(
             &manifest,

--- a/crates/nub-cli/src/compile/inline.rs
+++ b/crates/nub-cli/src/compile/inline.rs
@@ -1,0 +1,360 @@
+//! The no-extract payload shape: a compiled artifact that writes nothing.
+//!
+//! An ordinary compiled binary extracts its app files to `~/.cache/nub/compile-app/…`
+//! on first run, because Node has to be handed a `--require` preload and an entry
+//! by PATH. A payload that reduces to generated JavaScript needs neither: the
+//! launcher passes the bootstrap as `-e` and the bootstrap serves each chunk to
+//! `import()` as a `data:` URL read straight out of the executable. Nothing on the
+//! path to running such an artifact touches the filesystem, so it starts under a
+//! read-only `HOME` and `TMPDIR`, where today it refuses to start at all.
+//!
+//! Everything here runs AFTER bundling, on the emitted chunks. That is the design
+//! constraint, not an implementation detail: whether a payload qualifies is not
+//! knowable until the bundler has reported its worker roots, its native islands and
+//! its chunk graph, and a build that turns out not to qualify must not pay for a
+//! second bundle. So the bundler is configured identically either way and this
+//! module rewrites what came out — or declines, and the payload extracts exactly as
+//! it always has.
+
+use anyhow::{Context, Result, bail};
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::AppFiles;
+use super::bundle;
+
+/// The virtual directory every inline chunk reports as its own location, matching
+/// the string the runtime loader publishes. A `file:` URL rather than a private
+/// scheme because the bundled preamble calls `fileURLToPath(import.meta.url)`,
+/// which throws on a scheme it does not know. Bun publishes `/$bunfs/root` for the
+/// same reason.
+const VIRTUAL_ROOT: &str = "file:///$nub/";
+
+/// The specifier an inline chunk carries in place of a relative import of another
+/// chunk. The loader replaces it with that chunk's `data:` URL before importing.
+/// It stays a syntactically valid specifier so a payload the loader somehow failed
+/// to rewrite fails as a plain module-not-found rather than a parse error.
+const CHUNK_SPECIFIER_PREFIX: &str = "nub-inline:";
+
+/// The placeholder `compile-inline-loader.cjs` carries for the entry chunk's name.
+const ENTRY_PLACEHOLDER: &str = "__NUB_INLINE_ENTRY__";
+
+/// Node's `-e` publishes the CommonJS wrapper's five names as GLOBALS, so a
+/// compiled program's authored ESM would see `typeof require === "function"` where
+/// plain Node — and the extracted shape — give `undefined`. That is not cosmetic:
+/// `typeof require !== "undefined"` and `typeof module !== "undefined"` are the two
+/// most common CommonJS/ESM feature detections in published packages, and both
+/// would take the wrong branch.
+///
+/// It has to run from inside a MODULE rather than from the `-e` script, because
+/// Node re-publishes a lazy global `module` while it brings the ESM loader up — a
+/// delete before the first `import()` is undone. Every chunk carries it and the
+/// first one evaluated does the work; the rest are five failed lookups.
+///
+/// One line, so the source-map shift stays exactly one generated line.
+const EVAL_GLOBAL_CLEANUP: &str = "for(const k of[\"require\",\"module\",\"exports\",\"__filename\",\"__dirname\"])delete globalThis[k];";
+
+/// Why a payload cannot run inline. Reported in the build summary rather than as an
+/// error: each of these is a payload that works, just not without extracting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decline {
+    /// `--external`, a surviving computed `import()`, or a verbatim payload file —
+    /// exactly `Manifest::sealed_module_graph` being false. Each hands the real
+    /// module loader a path at run time, and an inline payload has no paths.
+    UnsealedGraph,
+    /// A statically traced `new Worker(...)`. Its chunk is loaded by URL from inside
+    /// the program rather than imported by another chunk, and `new Worker` does not
+    /// take a `data:` URL.
+    StaticWorker,
+    /// A payload file that is not a generated `.mjs` chunk — a `--sourcemap=linked`
+    /// map is the one that occurs in practice, and a linked map cannot be fetched
+    /// from a `data:` URL anyway.
+    NonChunkFile,
+    /// The chunks import each other in a cycle. Nesting one `data:` URL inside
+    /// another needs a topological order and a cycle has none. Rolldown's manual
+    /// CommonJS boundary makes this reachable rather than theoretical.
+    CyclicChunks,
+    /// The build asked for source maps. Measured on Node 26.7: `--enable-source-maps`
+    /// does not apply an inline map to a `data:` URL module at all — with or without
+    /// a `//# sourceURL` — so an inline artifact would report unmapped frames where
+    /// the extracted one reports `app.ts:1`. Extracting is what keeps the maps the
+    /// build was asked to produce, so a build that wants them gets exactly today's
+    /// behavior.
+    SourceMap,
+}
+
+impl Decline {
+    /// The clause the build summary prints after "extracts on first run because …".
+    pub fn reason(self) -> &'static str {
+        match self {
+            Self::UnsealedGraph => "it resolves modules at run time",
+            Self::StaticWorker => "it carries a worker chunk",
+            Self::NonChunkFile => "it carries a file that is not a compiled chunk",
+            Self::CyclicChunks => "its chunks import each other in a cycle",
+            Self::SourceMap => "it was built with source maps",
+        }
+    }
+}
+
+/// What the caller knows about the payload that this module cannot see for itself.
+pub struct Inputs<'a> {
+    /// `Manifest::sealed_module_graph`, computed by the caller.
+    pub sealed_module_graph: bool,
+    /// Statically traced worker roots, plus the public wrappers written for them.
+    pub worker_roots: usize,
+    pub worker_wrappers: usize,
+    /// Whether any source map was asked for.
+    pub sourcemap: bool,
+    /// The entry chunk's payload name.
+    pub entry: &'a str,
+}
+
+/// What [`rewrite`] decided. The files come back either way: a declined payload
+/// extracts exactly as it always has, so a decline is a report, not a failure.
+pub enum Rewritten {
+    Inline(AppFiles),
+    Extract(AppFiles, Decline),
+}
+
+/// Rewrite `files` for inline launch, or say why the payload has to extract.
+///
+/// On success every `.mjs` chunk has been given its virtual identity and had its
+/// cross-chunk specifiers replaced, and the bootstrap entry carries the loader that
+/// reads them back out of the executable. The caller compresses the result with
+/// brotli and sets `Manifest::inline_app`.
+pub fn rewrite(files: AppFiles, inputs: &Inputs<'_>) -> Result<Rewritten> {
+    match classify(&files, inputs)? {
+        Err(decline) => Ok(Rewritten::Extract(files, decline)),
+        Ok(chunk_names) => {
+            let loader = loader_source(inputs.entry)?;
+            let bootstrap_name = nub_core::compile::COMPILE_BOOTSTRAP_NAME;
+            let rewritten = files
+                .into_iter()
+                .map(|mut file| {
+                    if file.name == bootstrap_name {
+                        file.bytes.push(b'\n');
+                        file.bytes.extend_from_slice(loader.as_bytes());
+                        return Ok(file);
+                    }
+                    let source = String::from_utf8(std::mem::take(&mut file.bytes))
+                        .with_context(|| format!("reading the emitted chunk {}", file.name))?;
+                    file.bytes = rewrite_chunk(&source, &file.name, &chunk_names).into_bytes();
+                    Ok(file)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Rewritten::Inline(rewritten))
+        }
+    }
+}
+
+/// The eligibility half, kept separate so the borrow of `files` ends before the
+/// rewrite consumes it. Returns the chunk names on success.
+fn classify(files: &AppFiles, inputs: &Inputs<'_>) -> Result<Result<BTreeSet<String>, Decline>> {
+    if !inputs.sealed_module_graph {
+        return Ok(Err(Decline::UnsealedGraph));
+    }
+    if inputs.worker_roots != 0 || inputs.worker_wrappers != 0 {
+        return Ok(Err(Decline::StaticWorker));
+    }
+    if inputs.sourcemap {
+        return Ok(Err(Decline::SourceMap));
+    }
+    let bootstrap_name = nub_core::compile::COMPILE_BOOTSTRAP_NAME;
+    // Every file is the bootstrap or a chunk. `--include`s, emitted assets and
+    // native islands are already excluded by the sealed-graph check above; what this
+    // catches is the compiler's OWN non-chunk output, which today means a
+    // `--sourcemap=linked` map travelling beside the bundle.
+    if files
+        .iter()
+        .any(|file| file.name != bootstrap_name && !file.name.ends_with(".mjs"))
+    {
+        return Ok(Err(Decline::NonChunkFile));
+    }
+    let chunk_names: BTreeSet<String> = files
+        .iter()
+        .filter(|file| file.name.ends_with(".mjs"))
+        .map(|file| file.name.clone())
+        .collect();
+    if !chunk_names.contains(inputs.entry) {
+        bail!(
+            "the compiled entry {:?} is not among the emitted chunks",
+            inputs.entry
+        );
+    }
+
+    // The chunk graph, read the way the loader will read it: a chunk depends on
+    // another when it names it in a relative specifier. Textual on both sides on
+    // purpose — the loader has no bundler metadata, so a graph derived from anything
+    // else would not be the graph it walks.
+    let mut edges: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for file in files.iter().filter(|f| f.name.ends_with(".mjs")) {
+        let source = std::str::from_utf8(&file.bytes)
+            .with_context(|| format!("reading the emitted chunk {}", file.name))?;
+        let deps = chunk_names
+            .iter()
+            .map(String::as_str)
+            .filter(|dep| *dep != file.name && imports_chunk(source, dep))
+            .collect();
+        edges.insert(file.name.as_str(), deps);
+    }
+    if has_cycle(&edges) {
+        return Ok(Err(Decline::CyclicChunks));
+    }
+    Ok(Ok(chunk_names))
+}
+
+/// Every spelling Rolldown can emit for a sibling chunk's specifier.
+///
+/// Three, not one, and the third is the one that bites: a STATIC import's specifier
+/// must be a string literal, so it keeps its double quotes, but a DYNAMIC
+/// `import()` takes an expression and the minifier rewrites its argument to a
+/// template literal. A rewrite that only knew the double-quoted form left
+/// `import(`./lazy-BPasMaRY.mjs`)` untouched, and the artifact died at run time on
+/// `ERR_UNSUPPORTED_RESOLVE_REQUEST` — a relative specifier has nothing to resolve
+/// against inside a `data:` URL.
+fn relative_specifiers(name: &str) -> [String; 3] {
+    [
+        format!("\"./{name}\""),
+        format!("'./{name}'"),
+        format!("`./{name}`"),
+    ]
+}
+
+/// Whether `source` imports the chunk `name`, in any of those spellings.
+fn imports_chunk(source: &str, name: &str) -> bool {
+    relative_specifiers(name)
+        .iter()
+        .any(|spelling| source.contains(spelling))
+}
+
+/// Iterative three-colour depth-first search. Iterative rather than recursive
+/// because the graph is derived from user code, and a payload has a handful of
+/// chunks so nothing here is worth optimizing.
+fn has_cycle(edges: &BTreeMap<&str, Vec<&str>>) -> bool {
+    #[derive(Clone, Copy, PartialEq)]
+    enum Mark {
+        Open,
+        Done,
+    }
+    let mut marks: BTreeMap<&str, Mark> = BTreeMap::new();
+    for root in edges.keys().copied() {
+        if marks.contains_key(root) {
+            continue;
+        }
+        marks.insert(root, Mark::Open);
+        let mut stack = vec![(root, 0usize)];
+        while let Some((node, index)) = stack.pop() {
+            let deps = edges.get(node).map(Vec::as_slice).unwrap_or_default();
+            match deps.get(index).copied() {
+                Some(dep) => {
+                    stack.push((node, index + 1));
+                    match marks.get(dep) {
+                        Some(Mark::Open) => return true,
+                        Some(Mark::Done) => {}
+                        None => {
+                            marks.insert(dep, Mark::Open);
+                            stack.push((dep, 0));
+                        }
+                    }
+                }
+                None => {
+                    marks.insert(node, Mark::Done);
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Give one chunk its virtual identity and point its cross-chunk imports at the
+/// loader's placeholders.
+///
+/// The `import.meta.url` assignment is what keeps the rest of a compiled artifact
+/// working from a `data:` URL: the bundled CommonJS chunk builds its `require` with
+/// `createRequire(import.meta.url)`, and the `__filename`/`__dirname` globals
+/// spliced into CommonJS modules are derived from it. Left alone, all three would
+/// see the base64 blob — `createRequire` throws on one outright.
+///
+/// Prefixed as a WHOLE LINE, so every column in the chunk stays where the bundler
+/// put it. Prefixing without a newline would have been simpler and is wrong:
+/// minified output is one long line, so it would displace every column in the
+/// program — and the emitted line numbers are what a stack frame reports.
+fn rewrite_chunk(source: &str, name: &str, chunks: &BTreeSet<String>) -> String {
+    let mut out = String::with_capacity(source.len() + 256);
+    out.push_str(EVAL_GLOBAL_CLEANUP);
+    out.push_str("import.meta.url = \"");
+    out.push_str(VIRTUAL_ROOT);
+    out.push_str(name);
+    out.push_str("\";\n");
+    let mut code = source.to_string();
+    for dep in chunks.iter().filter(|dep| dep.as_str() != name) {
+        // Always DOUBLE-quoted on the way out, whatever it was on the way in, so the
+        // loader has one spelling to look for.
+        let placeholder = format!("\"{CHUNK_SPECIFIER_PREFIX}{dep}\"");
+        for spelling in relative_specifiers(dep) {
+            code = code.replace(&spelling, &placeholder);
+        }
+    }
+    out.push_str(&code);
+    out
+}
+
+/// The `-e` script's second half, with the entry chunk's name substituted in.
+fn loader_source(entry: &str) -> Result<String> {
+    let source = bundle::compile_runtime_file("compile-inline-loader.cjs")?;
+    let source = String::from_utf8(source).context("the compile inline loader is not utf-8")?;
+    // A payload name is validated against the target's path rules long before this,
+    // so it cannot carry a quote or a backslash — but it is substituted into a
+    // JavaScript string literal, so it is escaped rather than trusted.
+    let escaped = serde_json::to_string(entry).expect("a payload name serializes");
+    Ok(source.replace(&format!("\"{ENTRY_PLACEHOLDER}\""), &escaped))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chunks(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|n| (*n).to_string()).collect()
+    }
+
+    #[test]
+    fn a_chunk_keeps_every_line_below_the_prefixed_identity() {
+        let source = "import{a}from\"./dep-A1.mjs\";\nconsole.log(a);\n";
+        let out = rewrite_chunk(source, "main.mjs", &chunks(&["main.mjs", "dep-A1.mjs"]));
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(
+            lines[0].ends_with("import.meta.url = \"file:///$nub/main.mjs\";"),
+            "the identity assignment closes the single prefix line: {}",
+            lines[0]
+        );
+        assert!(
+            lines[0].starts_with("for(const k of["),
+            "and the `-e` global cleanup opens it"
+        );
+        assert_eq!(
+            lines[1], "import{a}from\"nub-inline:dep-A1.mjs\";",
+            "the cross-chunk specifier becomes the loader's placeholder"
+        );
+        assert_eq!(
+            lines[2], "console.log(a);",
+            "code below the imports is untouched, so a map shifted by one line still lands"
+        );
+    }
+
+    #[test]
+    fn a_chunk_cycle_declines_rather_than_producing_an_unbuildable_url() {
+        let mut cyclic: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+        cyclic.insert("a.mjs", vec!["b.mjs"]);
+        cyclic.insert("b.mjs", vec!["a.mjs"]);
+        assert!(has_cycle(&cyclic));
+
+        // The shape every ordinary build produces: the entry imports both the
+        // CommonJS chunk and the Rolldown runtime, and the CommonJS chunk imports the
+        // runtime too. That is a diamond, and a diamond must not read as a cycle.
+        let mut diamond: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+        diamond.insert("entry.mjs", vec!["cjs.mjs", "rt.mjs"]);
+        diamond.insert("cjs.mjs", vec!["rt.mjs"]);
+        diamond.insert("rt.mjs", vec![]);
+        assert!(!has_cycle(&diamond));
+    }
+}

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -37,6 +37,7 @@ mod closure;
 mod external;
 mod icu;
 mod inject;
+mod inline;
 mod launcher;
 mod loaders;
 mod metafile;
@@ -256,6 +257,35 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         entry_name = shim.entry;
         app_files.extend(shim.files);
     }
+    // Computed here rather than beside the manifest because the no-extract decision
+    // below needs it: only the VERBATIM payload sets can carry a file Node parses
+    // that the bundler did not — emitted asset copies, native-island contents, and
+    // `--include`s. Their PRESENCE is the predicate, not their extensions, since the
+    // CommonJS loader parses an exact-path `require()` of any unknown or absent
+    // extension with its `.js` handler, so no name-based allowlist can prove a
+    // shipped file is not runtime JavaScript.
+    let carries_verbatim_files =
+        bundled.assets.len() + bundled.native_files.len() + layout.assets.len() > 0;
+    let sealed_module_graph = !shim_plan.needed() && !carries_verbatim_files;
+
+    // Can this payload run WITHOUT being written to disk? `sealed_module_graph` is
+    // necessary and not sufficient: a statically traced worker chunk and a
+    // `--sourcemap=linked` map are both files the bundler itself parsed, so the
+    // graph is sealed with either present, and neither can be reached from a
+    // `data:` URL. See `compile::inline`.
+    let (app_files, inline_app, inline_decline) = match inline::rewrite(
+        app_files,
+        &inline::Inputs {
+            sealed_module_graph,
+            worker_roots: bundled.worker_roots.len(),
+            worker_wrappers: worker_wrappers.len(),
+            sourcemap: opts.bundle.sourcemap != bundle::SourcemapMode::None,
+            entry: &entry_name,
+        },
+    )? {
+        inline::Rewritten::Inline(files) => (files, true, None),
+        inline::Rewritten::Extract(files, why) => (files, false, Some(why)),
+    };
     let app_sha = sha256_of_app(&app_files);
     if !layout.assets.is_empty() {
         live.phase("embedding", &format!("{} files", layout.assets.len()));
@@ -339,19 +369,29 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
     // Node blob already uses, and it lets the launcher decode only the files it
     // actually extracts. Level 19 matches the Node blob; the app region is small
     // enough that the time is not noticeable next to the ~107 MB one.
-    // Computed before `app_files` is consumed below. Only the VERBATIM payload
-    // sets can carry a file Node parses that the bundler did not: emitted asset
-    // copies, native-island contents, and `--include`s. Their PRESENCE is the
-    // predicate, not their extensions — the CJS loader parses an exact-path
-    // `require()` of any unknown or absent extension with its `.js` handler, so
-    // no name-based allowlist can prove a shipped file is not runtime JS.
-    let carries_verbatim_files =
-        bundled.assets.len() + bundled.native_files.len() + layout.assets.len() > 0;
+    // An inline payload takes BROTLI instead, because the code that decompresses it
+    // is the artifact's own JavaScript: `zlib.zstdDecompressSync` is missing on Node
+    // 23.5 and 23.6 while brotli is on every supported version. Nothing in Rust ever
+    // decompresses these bytes, which is why the manifest's `app_compressed` — the
+    // launcher's per-file zstd flag — stays false for them.
     let app_files: Vec<_> = app_files
         .into_iter()
         .map(|file| {
-            let bytes = zstd::encode_all(&file.bytes[..], 19)
-                .with_context(|| format!("zstd-compressing {}", file.name))?;
+            let bytes = if inline_app {
+                // The bootstrap alone is stored VERBATIM. The launcher reads it out
+                // of the payload to build the `-e` argument, and it carries no
+                // decompressor for this codec by design — nub-launcher is a
+                // deliberately minimal binary. Storing ~13 KB raw is what buys that.
+                if file.name == nub_core::compile::COMPILE_BOOTSTRAP_NAME {
+                    file.bytes
+                } else {
+                    brotli_encode(&file.bytes)
+                        .with_context(|| format!("brotli-compressing {}", file.name))?
+                }
+            } else {
+                zstd::encode_all(&file.bytes[..], 19)
+                    .with_context(|| format!("zstd-compressing {}", file.name))?
+            };
             Ok::<_, anyhow::Error>(nub_core::compile::AppFile {
                 name: file.name,
                 bytes,
@@ -382,7 +422,7 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         node_blake3: node.blake3,
         node_size: node.size,
         node_icu: node.icu,
-        app_compressed: true,
+        app_compressed: !inline_app,
         app_sha256: app_sha,
         minify: opts.bundle.minify,
         install_message: Some(install_message(&opts)),
@@ -396,11 +436,12 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         // construction: the bundler parsed them. Computed require of a path
         // OUTSIDE the artifact stays out of the predicate on the
         // plain-Node-baseline argument in the Manifest field's doc comment.
-        sealed_module_graph: !shim_plan.needed() && !carries_verbatim_files,
+        sealed_module_graph,
         // The launcher's half of `--hide-console`. The PE subsystem flip below
         // only stops Windows giving the LAUNCHER a console; this is what stops it
         // giving one to the Node it spawns.
         hide_console: opts.hide_console,
+        inline_app,
     };
     let payload = encode_with_license(&manifest, &app_files, &node.blob, &node.license);
 
@@ -453,6 +494,7 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         app_bytes: app_files.iter().map(|f| f.bytes.len() as u64).sum(),
         shipped,
         deferred: bundled.dynamic_import_sites,
+        app_extracts: inline_decline,
         report: opts.metafile.clone(),
         elapsed: started.elapsed(),
     };
@@ -735,6 +777,23 @@ fn resolved_build_rows(
             ],
         ));
     }
+    // Always shown, because whether the binary needs a writable directory is the
+    // question a self-contained artifact exists to answer — and the reason is what
+    // makes the answer actionable when it is the wrong one.
+    rows.push((
+        "app",
+        match facts.app_extracts {
+            None => vec![
+                ("run from the executable".to_string(), Ink::Plain),
+                ("  nothing is written to disk".to_string(), Ink::Muted),
+            ],
+            Some(why) => vec![
+                ("extracted on first run".to_string(), Ink::Plain),
+                (format!("  {}", why.reason()), Ink::Muted),
+            ],
+        },
+    ));
+
     if let Some(report) = &facts.report {
         rows.push((
             "report",
@@ -948,6 +1007,9 @@ struct BuildFacts {
     shipped: Vec<(String, &'static str)>,
     /// Surviving computed `import()` sites, from `--allow-dynamic-import`.
     deferred: usize,
+    /// `None` when the app runs straight out of the executable; otherwise why it
+    /// has to be written to the cache on first run.
+    app_extracts: Option<inline::Decline>,
     /// Where `--metafile` wrote the build report, if it was asked for.
     report: Option<PathBuf>,
     elapsed: std::time::Duration,
@@ -2935,6 +2997,18 @@ fn run_ok(program: impl AsRef<std::ffi::OsStr>, args: &[&std::ffi::OsStr]) -> bo
 ///
 /// This is the extraction cache key, so the mode belongs in it: two artifacts
 /// whose files differ only in executability must not share one extracted tree.
+/// Brotli at the maximum quality, for an inline payload's chunks.
+///
+/// Quality 11 with a 24-bit window, matching what the zstd-19 it replaces is
+/// reaching for: this runs once per build on a few tens of kilobytes, and the bytes
+/// it produces are shipped to every user of the artifact.
+fn brotli_encode(bytes: &[u8]) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    let mut reader = brotli::CompressorReader::new(bytes, 4096, 11, 24);
+    std::io::copy(&mut reader, &mut out).context("brotli-compressing an inline payload chunk")?;
+    Ok(out)
+}
+
 fn sha256_of_app(files: &[AppFile<Vec<u8>>]) -> String {
     let mut h = Sha256::new();
     for file in files {
@@ -3709,6 +3783,7 @@ mod tests {
             node_flags: Vec::new(),
             sealed_module_graph: false,
             hide_console: false,
+            inline_app: false,
         };
         let app = vec![AppFile::plain("main.js", b"app".to_vec())];
         let missing = nub_core::compile::encode_with_license(&manifest, &app, b"node", &[]);

--- a/crates/nub-core/src/compile.rs
+++ b/crates/nub-core/src/compile.rs
@@ -40,6 +40,23 @@ pub const SECTION_NAME: &str = "__nubc";
 /// and must not vary with the entry's layout.
 pub const COMPILE_BOOTSTRAP_NAME: &str = "__nub_compile_bootstrap.cjs";
 
+/// The trailer that marks an inline (`no-extract`) payload, and the only thing in
+/// the container the compiled artifact's own JavaScript ever parses.
+///
+/// Written at the very END of the payload blob, so it is inside the injected
+/// section and therefore inside whatever the platform signs. The bootstrap reads a
+/// bounded window at the end of the executable, scans BACKWARDS for this magic, and
+/// takes the two little-endian `u64`s that follow it: the distance back from the
+/// magic's first byte to the app region's first byte, and the app region's length.
+///
+/// Sixteen bytes of non-ASCII so it cannot occur in the JavaScript or the manifest
+/// it sits behind, and searched from the end so the last match wins — the compiler
+/// writes exactly one, and nothing but the platform's signature follows it.
+pub const INLINE_LOCATOR_MAGIC: &[u8; 16] = b"\x00nub-inline-app\x00";
+
+/// Magic + `u64` back-distance + `u64` app-region length.
+pub const INLINE_LOCATOR_LEN: usize = 16 + 8 + 8;
+
 const MAGIC: &[u8; 4] = b"NUBC";
 const FORMAT_VERSION_V1: u8 = 1;
 const FORMAT_VERSION: u8 = 2;
@@ -264,6 +281,33 @@ pub struct Manifest {
     /// Absent in legacy manifests, where `false` is exactly what they were doing.
     #[serde(default)]
     pub hide_console: bool,
+    /// Whether this payload runs WITHOUT being extracted: the launcher hands Node
+    /// the compiled bootstrap through `-e` and the bootstrap serves every chunk
+    /// from the executable's own bytes as a `data:` URL, so nothing the app needs
+    /// is ever written to disk.
+    ///
+    /// Set only for a payload that reduces to generated JavaScript chunks and the
+    /// bootstrap — no `--external` shim, no verbatim file, no worker chunk, and an
+    /// acyclic chunk graph (see `nub compile`'s `inline_launch_plan`). A payload
+    /// that misses any of those extracts exactly as it always has.
+    ///
+    /// Two container conventions follow from it, and they are the reason this is a
+    /// manifest field rather than a launcher inference:
+    /// - the app-file bytes are BROTLI-compressed, not zstd, because the code that
+    ///   decompresses them is the JavaScript bootstrap and
+    ///   `zlib.zstdDecompressSync` is missing on 23.5/23.6 while brotli is on every
+    ///   supported Node. [`Self::app_compressed`] is therefore false: no Rust code
+    ///   decompresses an inline payload.
+    /// - the payload blob carries an [`INLINE_LOCATOR_MAGIC`] trailer, which is how
+    ///   the bootstrap finds the app region's FILE offset. The launcher cannot
+    ///   supply one: `find_section` returns a pointer into the MAPPED image on all
+    ///   three platforms (`getsectdata`, `dl_iterate_phdr`, `LockResource`), and no
+    ///   file offset exists anywhere on that path.
+    ///
+    /// Absent in legacy manifests, where `false` is what every existing artifact
+    /// already does.
+    #[serde(default)]
+    pub inline_app: bool,
 }
 
 /// One logical file in the payload. `B` is `Vec<u8>` on the writing side and
@@ -571,6 +615,18 @@ pub fn encode_with_license(
     out.extend_from_slice(&app_region);
     out.extend_from_slice(node_blob);
     out.extend_from_slice(node_license_blob);
+    // The inline locator, and only for an inline payload: it is what the compiled
+    // artifact's own `-e` bootstrap uses to find the app region's FILE offset,
+    // which nothing on the Rust side can tell it (see `Manifest::inline_app`).
+    // Written past the last declared region, which `decode` already tolerates, so
+    // a payload carrying it decodes byte-identically to one that does not.
+    if manifest.inline_app {
+        let app_start = HEADER_LEN_V2 + manifest_bytes.len();
+        let back = (out.len() - app_start) as u64;
+        out.extend_from_slice(INLINE_LOCATOR_MAGIC);
+        out.extend_from_slice(&back.to_le_bytes());
+        out.extend_from_slice(&(app_region.len() as u64).to_le_bytes());
+    }
     out
 }
 
@@ -902,6 +958,7 @@ mod tests {
             node_flags: Vec::new(),
             sealed_module_graph: false,
             hide_console: false,
+            inline_app: false,
         }
     }
 
@@ -938,6 +995,7 @@ mod tests {
             // manifest carrying it would round-trip through an encoding bug that
             // dropped the field entirely.
             hide_console: true,
+            inline_app: false,
         };
         let app = vec![
             AppFile::plain("main.js", b"import './c.js'\n".to_vec()),
@@ -990,6 +1048,7 @@ mod tests {
             node_flags: Vec::new(),
             sealed_module_graph: false,
             hide_console: false,
+            inline_app: false,
         };
         let app = vec![AppFile::plain("main.js", b"console.log(1)".to_vec())];
         let blob = encode_with_license(&manifest, &app, &[], &[]);

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -47,6 +47,11 @@ const INTERNAL_MODE_ENV: &str = "__NUB_COMPILED_LAUNCHER_MODE";
 /// Private process-identity channel. The launcher always overwrites this on the
 /// child Command, so an inherited value can never spoof the compiled executable.
 const COMPILED_EXEC_PATH_ENV: &str = "__NUB_COMPILED_EXEC_PATH";
+
+/// The flags an INLINE artifact would have had in `process.execArgv`, as a JSON
+/// array. `-e` puts the script itself there instead, and the compiled bootstrap
+/// consumes this and restores the real set before application code runs.
+const COMPILED_EXEC_ARGV_ENV: &str = "__NUB_COMPILED_EXEC_ARGV";
 /// Interrupted staging trees are never current after this age. The bounded
 /// cleanup is deliberately limited to the launcher's own temp prefixes.
 const ORPHAN_STAGE_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
@@ -202,80 +207,115 @@ fn launch(view: &PayloadView<'_>, launcher_path: &Path) -> Result<ExitStatus> {
         Shape::Smol => discover_external_smol_node(&view.manifest)?,
         Shape::Embed => None,
     };
-    let cache_use = cache_use_for(
-        &view.manifest.shape,
-        external_smol.is_some(),
-        view.has_executable_file(),
-    );
 
-    // Resolved ONCE and threaded through: every write this process makes lands
-    // under the one directory that was proven writable, and the probe (a mkdir
-    // plus a zero-byte file) is not repeated per payload. A candidate already
-    // holding this payload's artifacts skips the write half of that probe.
-    let resolved = cache::resolve(cache_use, &|dir: &Path| {
-        if external_smol.is_some() {
-            app_cache_is_ready(view, &app_cache_dir(dir, &view.manifest))
-                .then_some(CacheWarm::AppOnly)
-        } else {
-            verify_warm_cache(view, dir).map(CacheWarm::Managed)
-        }
-    })?;
-    phase("cache::resolve (incl. warm verify)");
-    let base = resolved.path;
-    cleanup_launcher_orphans(&base, &view.manifest);
-    phase("orphan cleanup");
-    let notice = FirstRun::new(view.manifest.install_message.as_deref());
-
-    let ((node_path, version, origin), app_dir) = match (external_smol, resolved.warm) {
-        (Some((node_path, version)), Some(CacheWarm::AppOnly)) => (
-            (node_path, version, NodeOrigin::Discovered),
-            app_cache_dir(&base, &view.manifest),
-        ),
-        (Some((node_path, version)), None) => (
-            (node_path, version, NodeOrigin::Discovered),
-            ensure_app(view, &base)?,
-        ),
-        (None, Some(CacheWarm::Managed(warm))) => {
-            phase("ARM: warm managed (fast path)");
-            let version = view
-                .manifest
-                .node_version
-                .parse()
-                .unwrap_or_else(|_| NodeVersion::new(22, 15, 0));
-            ((warm.node_path, version, NodeOrigin::Managed), warm.app_dir)
-        }
-        (None, None) => {
-            phase("ARM: COLD — acquire_node + ensure_app");
-            let n = acquire_node(view, &base, &notice, None)?;
-            phase("  acquire_node done");
-            let a = ensure_app(view, &base)?;
-            phase("  ensure_app done");
-            (n, a)
-        }
-        // The warm callback ties its variant to `external_smol`; retaining this
-        // arm makes a future callback refactor fail closed rather than executing
-        // a cache Node from a data-only cache.
-        _ => bail!("cache warm state did not match the selected Node source"),
+    // An INLINE payload materializes no app files at all — the bootstrap arrives as
+    // `-e` and every chunk is served to `import()` straight out of this executable
+    // — so a `--smol` build whose Node was already on the machine needs no writable
+    // directory, not even to probe for one. That is the case the mode exists for: a
+    // distroless image, a `noexec` mount, a read-only `HOME`, where resolving a
+    // cache is itself the failure. Every other combination still resolves one,
+    // because the Node has to be unpacked or provisioned into it.
+    let inline_discovered = match (view.manifest.inline_app, &external_smol) {
+        (true, Some(found)) => Some(found.clone()),
+        _ => None,
     };
-    // Resolution proves the whole cache namespace cannot be renamed by another
-    // principal. Repeat the read-only gate after extraction and immediately
-    // before handing its paths to Command so deployment-time ACL/mode changes
-    // cannot turn a validated cache into a cross-principal execution handoff.
-    phase("node + app resolved");
-    cache::revalidate(&base).context("revalidating the executable cache namespace")?;
-    phase("cache revalidated");
-    // Hand the terminal back BEFORE anything the app might print — the box lives
-    // on the alternate screen, so this restores the user's scrollback intact.
-    notice.finish();
+    let ((node_path, version, origin), base, app_dir) = match inline_discovered {
+        Some((node_path, node_version)) => {
+            phase("ARM: inline payload + discovered Node — no cache resolved");
+            // No first-run notice: nothing is being unpacked or downloaded. The
+            // notice exists to explain a multi-second silent startup, and this path
+            // has none.
+            (
+                (node_path, node_version, NodeOrigin::Discovered),
+                None,
+                None,
+            )
+        }
+        None => {
+            let cache_use = cache_use_for(
+                &view.manifest.shape,
+                external_smol.is_some(),
+                view.has_executable_file(),
+            );
+
+            // Resolved ONCE and threaded through: every write this process makes
+            // lands under the one directory that was proven writable, and the probe
+            // (a mkdir plus a zero-byte file) is not repeated per payload. A
+            // candidate already holding this payload's artifacts skips the write
+            // half of that probe.
+            let resolved = cache::resolve(cache_use, &|dir: &Path| {
+                if external_smol.is_some() {
+                    app_cache_is_ready(view, &app_cache_dir(dir, &view.manifest))
+                        .then_some(CacheWarm::AppOnly)
+                } else {
+                    verify_warm_cache(view, dir).map(CacheWarm::Managed)
+                }
+            })?;
+            phase("cache::resolve (incl. warm verify)");
+            let base = resolved.path;
+            cleanup_launcher_orphans(&base, &view.manifest);
+            phase("orphan cleanup");
+            let notice = FirstRun::new(view.manifest.install_message.as_deref());
+
+            let (node, app_dir) = match (external_smol, resolved.warm) {
+                (Some((node_path, version)), Some(CacheWarm::AppOnly)) => (
+                    (node_path, version, NodeOrigin::Discovered),
+                    Some(app_cache_dir(&base, &view.manifest)),
+                ),
+                (Some((node_path, version)), None) => (
+                    (node_path, version, NodeOrigin::Discovered),
+                    ensure_app_unless_inline(view, &base)?,
+                ),
+                (None, Some(CacheWarm::Managed(warm))) => {
+                    phase("ARM: warm managed (fast path)");
+                    let version = view
+                        .manifest
+                        .node_version
+                        .parse()
+                        .unwrap_or_else(|_| NodeVersion::new(22, 15, 0));
+                    (
+                        (warm.node_path, version, NodeOrigin::Managed),
+                        (!view.manifest.inline_app).then_some(warm.app_dir),
+                    )
+                }
+                (None, None) => {
+                    phase("ARM: COLD — acquire_node + ensure_app");
+                    let n = acquire_node(view, &base, &notice, None)?;
+                    phase("  acquire_node done");
+                    let a = ensure_app_unless_inline(view, &base)?;
+                    phase("  ensure_app done");
+                    (n, a)
+                }
+                // The warm callback ties its variant to `external_smol`; retaining
+                // this arm makes a future callback refactor fail closed rather than
+                // executing a cache Node from a data-only cache.
+                _ => bail!("cache warm state did not match the selected Node source"),
+            };
+            // Resolution proves the whole cache namespace cannot be renamed by
+            // another principal. Repeat the read-only gate after extraction and
+            // immediately before handing its paths to Command so deployment-time
+            // ACL/mode changes cannot turn a validated cache into a cross-principal
+            // execution handoff.
+            phase("node + app resolved");
+            cache::revalidate(&base).context("revalidating the executable cache namespace")?;
+            phase("cache revalidated");
+            // Hand the terminal back BEFORE anything the app might print — the box
+            // lives on the alternate screen, so this restores the user's scrollback
+            // intact.
+            notice.finish();
+            (node, Some(base), app_dir)
+        }
+    };
     // `cache::resolve` canonicalizes `app_dir`'s root, so these are absolute paths
     // to files already covered by the exact payload-cache verification. They are
     // the only two cache paths that leave Rust and become Node arguments, so the
     // verbatim spelling stops here (see `node_argument`).
-    let entry = node_argument(&app_dir.join(&view.manifest.entry), cfg!(windows));
-    let bootstrap = node_argument(
-        &app_dir.join(compile::COMPILE_BOOTSTRAP_NAME),
-        cfg!(windows),
-    );
+    let extracted = app_dir.as_ref().map(|dir| {
+        (
+            node_argument(&dir.join(&view.manifest.entry), cfg!(windows)),
+            node_argument(&dir.join(compile::COMPILE_BOOTSTRAP_NAME), cfg!(windows)),
+        )
+    });
 
     let user_args: Vec<String> = std::env::args().skip(1).collect();
     let node_options = std::env::var("NODE_OPTIONS").ok();
@@ -342,10 +382,12 @@ fn launch(view: &PayloadView<'_>, launcher_path: &Path) -> Result<ExitStatus> {
     phase("  flags: argv_inject_flags");
 
     let mut cmd = Command::new(node_path.as_os_str());
-    // Node runs CommonJS preloads before ESM `--import` hooks, including ones
-    // inherited through NODE_OPTIONS. Keep this absolute payload preload ahead
-    // of Nub's injected flags and the compiled entry on every supported Node.
-    cmd.arg(compiled_bootstrap_require_arg(&bootstrap));
+    if let Some((_, bootstrap)) = &extracted {
+        // Node runs CommonJS preloads before ESM `--import` hooks, including ones
+        // inherited through NODE_OPTIONS. Keep this absolute payload preload ahead
+        // of Nub's injected flags and the compiled entry on every supported Node.
+        cmd.arg(compiled_bootstrap_require_arg(bootstrap));
+    }
     // argv0 fidelity: process.argv0 / process.title report "node", matching
     // nub-core's spawn path. The compile preamble separately restores execPath
     // to this outer artifact.
@@ -354,8 +396,13 @@ fn launch(view: &PayloadView<'_>, launcher_path: &Path) -> Result<ExitStatus> {
         use std::os::unix::process::CommandExt;
         cmd.arg0("node");
     }
+    // The flags a compiled artifact was always going to run with, kept in one list
+    // so the inline shape can publish them: under `-e` Node fills `process.execArgv`
+    // with the script itself, and a program that forwards execArgv to a Worker would
+    // otherwise hand it a megabyte of JavaScript where a flag belongs.
+    let mut execargv: Vec<&str> = Vec::new();
     for flag in &inject {
-        cmd.arg(flag);
+        execargv.push(flag);
     }
     // `--node-flag`, baked in at compile time. AFTER nub's own injected flags,
     // because Node takes the last occurrence of a repeated flag — so a publisher
@@ -369,12 +416,32 @@ fn launch(view: &PayloadView<'_>, launcher_path: &Path) -> Result<ExitStatus> {
         if inject.iter().any(|injected| injected == flag) {
             continue;
         }
+        execargv.push(flag);
+    }
+    for flag in &execargv {
         cmd.arg(flag);
     }
-    cmd.arg(&entry);
-    cmd.args(&user_args);
+    match &extracted {
+        Some((entry, _)) => {
+            cmd.arg(entry);
+            cmd.args(&user_args);
+        }
+        None => {
+            // The inline shape: the bootstrap IS the script, and it imports the app
+            // out of this executable's own bytes. `--` is not optional — Node parses
+            // everything after `-e`'s value as its OWN options until it sees one, so
+            // a program argument that looks like a flag (`--port 3000`) aborts
+            // startup with `node: bad option`.
+            cmd.arg("-e").arg(inline_bootstrap_source(view)?);
+            cmd.arg("--");
+            cmd.args(&user_args);
+            cmd.env(COMPILED_EXEC_ARGV_ENV, serde_execargv(&execargv));
+        }
+    }
     configure_compiled_process_identity(&mut cmd, launcher_path);
-    configure_compiled_compile_cache(&mut cmd, &base, &view.manifest);
+    if let Some(base) = &base {
+        configure_compiled_compile_cache(&mut cmd, base, &view.manifest);
+    }
     if neutralize_localstorage {
         // The compile preamble consumes this internal signal before application
         // code runs, removing Node 22.4–24's throwing localStorage getter. A
@@ -446,20 +513,74 @@ fn launch(view: &PayloadView<'_>, launcher_path: &Path) -> Result<ExitStatus> {
         use std::os::unix::process::CommandExt;
         // Returns only on failure; success never comes back.
         let error = cmd.exec();
-        Err(node_spawn_error(&node_path, &base, error))
+        Err(node_spawn_error(&node_path, base.as_deref(), error))
     }
     // Windows has no exec(2): CreateProcess always makes a child, so the faithful
     // spawn — job-object grouping, signal relay, status forwarding — stays.
     #[cfg(not(unix))]
     {
         let status = spawn::status_forwarding_signals(&mut cmd)
-            .map_err(|error| node_spawn_error(&node_path, &base, error));
+            .map_err(|error| node_spawn_error(&node_path, base.as_deref(), error));
         phase("node exited");
         status
     }
 }
 
-fn node_spawn_error(node_path: &Path, base: &Path, error: std::io::Error) -> anyhow::Error {
+/// The `-e` script for an inline payload: the compiled bootstrap plus the loader
+/// `nub compile` appended to it, stored UNCOMPRESSED in the payload for exactly
+/// this reason — the launcher would otherwise need a brotli decoder, and it is a
+/// deliberately minimal binary. Roughly 13 KB, against a `getconf ARG_MAX` of 1 MB
+/// on macOS and Windows' 32,767-character command line.
+fn inline_bootstrap_source(view: &PayloadView<'_>) -> Result<String> {
+    let file = view
+        .app_files
+        .iter()
+        .find(|file| file.name == compile::COMPILE_BOOTSTRAP_NAME)
+        .context("this inline compiled payload carries no bootstrap")?;
+    String::from_utf8(file.bytes.to_vec()).context("the compiled bootstrap is not valid UTF-8")
+}
+
+/// The published `execArgv`, as JSON.
+///
+/// Hand-written rather than pulled through serde: the launcher carries no JSON
+/// dependency, the input is a flag list, and the only characters JSON requires
+/// escaping that a Node flag can contain are the quote and the backslash — both of
+/// which a flag `nub compile` accepted cannot hold, so this escapes them and stops.
+fn serde_execargv(flags: &[&str]) -> String {
+    let mut out = String::from("[");
+    for (i, flag) in flags.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('"');
+        for ch in flag.chars() {
+            match ch {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                c if (c as u32) < 0x20 => out.push(' '),
+                c => out.push(c),
+            }
+        }
+        out.push('"');
+    }
+    out.push(']');
+    out
+}
+
+/// Extraction, skipped entirely for an inline payload.
+///
+/// `None` means there is no app directory and never will be — the caller passes no
+/// entry path to Node and writes no compile cache beside it.
+fn ensure_app_unless_inline(view: &PayloadView<'_>, base: &Path) -> Result<Option<PathBuf>> {
+    if view.manifest.inline_app {
+        return Ok(None);
+    }
+    ensure_app(view, base).map(Some)
+}
+
+/// `base` is `None` for an inline payload that resolved no cache at all, where the
+/// Node came from the host and no cache path can be implicated in the failure.
+fn node_spawn_error(node_path: &Path, base: Option<&Path>, error: std::io::Error) -> anyhow::Error {
     #[cfg(not(unix))]
     let _ = base;
     // Checked first: this failure also presents as a plain OS error about a path
@@ -473,7 +594,10 @@ fn node_spawn_error(node_path: &Path, base: &Path, error: std::io::Error) -> any
     // error. Other Unix hosts use this exec-time fallback when no mount query is
     // available; Linux/macOS normally reject the mount during cache resolution.
     #[cfg(unix)]
-    if cache::exec_denied(&error) && node_path.starts_with(base) {
+    if let Some(base) = base
+        && cache::exec_denied(&error)
+        && node_path.starts_with(base)
+    {
         return anyhow!(cache::noexec_remedy(base));
     }
     anyhow::Error::new(error).context("spawning Node")
@@ -652,7 +776,12 @@ struct VerifiedWarmCache {
 fn verify_warm_cache(view: &PayloadView<'_>, dir: &Path) -> Option<VerifiedWarmCache> {
     let m = &view.manifest;
     let app_dir = app_cache_dir(dir, m);
-    if m.shape != Shape::Embed || !app_cache_is_ready(view, &app_dir) {
+    if m.shape != Shape::Embed {
+        return None;
+    }
+    // An inline payload has no app directory to verify — its chunks never leave the
+    // executable — so the embedded Node is the whole warm check.
+    if !m.inline_app && !app_cache_is_ready(view, &app_dir) {
         return None;
     }
 
@@ -3202,6 +3331,7 @@ mod tests {
             node_flags: Vec::new(),
             sealed_module_graph: false,
             hide_console: false,
+            inline_app: false,
         }
     }
 
@@ -3493,7 +3623,7 @@ mod tests {
         let base = Path::new("/tmp/nub-cache");
         let error = node_spawn_error(
             &base.join("compile-node/node"),
-            base,
+            Some(base),
             std::io::Error::from_raw_os_error(libc::EACCES),
         );
         assert!(format!("{error:#}").contains("mounted noexec"));

--- a/runtime/compile-bootstrap.cjs
+++ b/runtime/compile-bootstrap.cjs
@@ -3,7 +3,12 @@
 // plumbing, not a security boundary.
 const earlyRequire = require;
 const key = Symbol.for("nub.compile.bootstrap");
-const requireArg = `--require=${__filename}`;
+// `undefined` in the inline (no-extract) shape, where this whole script arrives as
+// Node's `-e` argument: there is no file, so `__filename` is Node's `[eval]`
+// placeholder and nothing can be required by path. Every consumer treats a missing
+// value as "do not prepend a preload", which is the truth there — a Worker started
+// from such an artifact runs without this bootstrap.
+const requireArg = __filename === "[eval]" ? undefined : `--require=${__filename}`;
 const descriptor = Object.getOwnPropertyDescriptor(process, key);
 const existing = descriptor?.value;
 let validExisting = false;
@@ -82,6 +87,9 @@ function installCompiledForkIdentity(childProcess, realNodeExecPath) {
     if (execArgv && !Array.isArray(execArgv)) return execArgv;
     const args = execArgv || process.execArgv;
     if (!Array.isArray(args)) return args;
+    // No bootstrap path to prepend in the inline shape; the rest of the identity
+    // fix-up below still applies, because it is `execPath` that a fork gets wrong.
+    if (requireArg === undefined) return args;
     return [requireArg, ...args.filter((arg) => arg !== requireArg)];
   };
 

--- a/runtime/compile-inline-loader.cjs
+++ b/runtime/compile-inline-loader.cjs
@@ -1,0 +1,176 @@
+// The second half of an inline (`no-extract`) compiled artifact's `-e` script.
+//
+// `nub compile` concatenates compile-bootstrap.cjs and this file, substitutes the
+// two `__NUB_INLINE_*__` placeholders, and stores the result as the payload's
+// bootstrap entry. The launcher decompresses it and hands it to Node as `-e`,
+// which is what removes the last reason a qualifying artifact needed a writable
+// directory: with no `--require` there is no file to require, and with the chunks
+// served as `data:` URLs there is no file to import.
+//
+// It runs as CommonJS, before any ESM in the process, with the bootstrap's frozen
+// builtin accessors already published — so every builtin here comes off that
+// record rather than a bare `require`, for the same reason the bootstrap uses it:
+// nothing the user can register has run yet, and keeping the one accessor means
+// there is one thing to audit.
+
+(() => {
+  const boot = process[Symbol.for("nub.compile.bootstrap")];
+  const fs = boot.getBuiltin("node:fs");
+  const zlib = boot.getBuiltin("node:zlib");
+
+  const ENTRY = "__NUB_INLINE_ENTRY__";
+  // The virtual root every chunk reports as its own location. `file:` rather than
+  // a private scheme because the bundled runtime calls `fileURLToPath` on
+  // `import.meta.url`, and a scheme it does not know throws. Bun publishes
+  // `/$bunfs/root` for the same reason.
+  const ROOT = "file:///$nub/";
+  // nub_core::compile::INLINE_LOCATOR_MAGIC.
+  const MAGIC = Buffer.from("006e75622d696e6c696e652d61707000", "hex");
+  // How much of the executable's tail to search before falling back to the whole
+  // file. The locator is the last byte of the payload, and only the platform's
+  // signature can follow it — a few hundred KB on macOS, nothing on Linux — so
+  // this window is met on the first read and the fallback is a safety net rather
+  // than a path anything is expected to take.
+  const TAIL_WINDOW = 4 * 1024 * 1024;
+
+  const selfPath = process.env.__NUB_COMPILED_EXEC_PATH;
+  if (typeof selfPath !== "string" || selfPath.length === 0) {
+    throw new Error("nub: the compiled executable's path was not published to its own process");
+  }
+
+  // Node's own argv under `-e` is [execPath, ...userArgs]: there is no script, so
+  // the first USER argument lands where every program expects its own path. Splice
+  // the artifact in, which is both the fix and an improvement on the extracted
+  // shape, where argv[1] leaked the cache directory.
+  process.argv.splice(1, 0, selfPath);
+
+  // `-e` puts the whole script into execArgv. The launcher publishes what the flags
+  // actually were, so a program that reads execArgv — or forwards it to a Worker,
+  // which is where a bogus entry becomes a crash — sees the real set.
+  const publishedExecArgv = process.env.__NUB_COMPILED_EXEC_ARGV;
+  if (typeof publishedExecArgv === "string") {
+    try {
+      const parsed = JSON.parse(publishedExecArgv);
+      if (Array.isArray(parsed) && parsed.every((a) => typeof a === "string")) {
+        process.execArgv = parsed;
+      }
+    } catch {
+      // A corrupt value leaves the `-e` spelling in place rather than throwing:
+      // it is cosmetic, and failing the launch over it would be worse.
+    }
+    delete process.env.__NUB_COMPILED_EXEC_ARGV;
+  }
+
+  const fd = fs.openSync(selfPath, "r");
+  let region;
+  try {
+    const size = fs.fstatSync(fd).size;
+    const read = (length, position) => {
+      const buf = Buffer.allocUnsafe(length);
+      let got = 0;
+      while (got < length) {
+        const n = fs.readSync(fd, buf, got, length - got, position + got);
+        if (n === 0) throw new Error("nub: the compiled executable ended early");
+        got += n;
+      }
+      return buf;
+    };
+
+    let windowStart = Math.max(0, size - TAIL_WINDOW);
+    let window = read(size - windowStart, windowStart);
+    let at = window.lastIndexOf(MAGIC);
+    if (at < 0 && windowStart > 0) {
+      windowStart = 0;
+      window = read(size, 0);
+      at = window.lastIndexOf(MAGIC);
+    }
+    if (at < 0) {
+      throw new Error("nub: this executable carries no inline compiled payload");
+    }
+    const locator = windowStart + at;
+    const back = Number(window.readBigUInt64LE(at + 16));
+    const length = Number(window.readBigUInt64LE(at + 24));
+    region = read(length, locator - back);
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  // The payload's V2 app region, which is the one container structure this file
+  // knows: [u32 files][u32 records][per file: u16 nameLen, name, u32 dataIndex]
+  // [per record: u64 len, bytes]. Bit 31 of dataIndex is the executable flag,
+  // which an inline payload never sets — it ships no verbatim file — and is
+  // masked off rather than asserted so the parse stays a pure reader.
+  let p = 0;
+  const u32 = () => {
+    const v = region.readUInt32LE(p);
+    p += 4;
+    return v;
+  };
+  const fileCount = u32();
+  const recordCount = u32();
+  const entries = [];
+  for (let i = 0; i < fileCount; i++) {
+    const nameLen = region.readUInt16LE(p);
+    p += 2;
+    const name = region.toString("utf8", p, p + nameLen);
+    p += nameLen;
+    entries.push([name, u32() & 0x7fffffff]);
+  }
+  const records = [];
+  for (let i = 0; i < recordCount; i++) {
+    const len = Number(region.readBigUInt64LE(p));
+    p += 8;
+    records.push(region.subarray(p, p + len));
+    p += len;
+  }
+
+  // Brotli, not zstd: this is the one decompressor that has to run in JavaScript,
+  // and `zlib.zstdDecompressSync` is absent on Node 23.5 and 23.6 while brotli is
+  // present on every version nub supports.
+  const sources = new Map();
+  for (const [name, index] of entries) {
+    if (name.endsWith(".mjs")) {
+      sources.set(name, zlib.brotliDecompressSync(records[index]).toString("utf8"));
+    }
+  }
+
+  // Each chunk becomes its own `data:` module, deepest first, with the
+  // placeholders `nub compile` left in place of the cross-chunk specifiers
+  // replaced by the URL of the chunk they named. Substitution rather than a
+  // resolve hook is the whole point: a `data:` URL has no base, so a relative
+  // specifier cannot resolve, and `module.registerHooks` would put a floor of
+  // Node 22.15/23.5 on a mode that otherwise has none.
+  const built = new Map();
+  const building = new Set();
+  const urlFor = (name) => {
+    const cached = built.get(name);
+    if (cached !== undefined) return cached;
+    if (building.has(name)) {
+      // The compiler proves the chunk graph acyclic before choosing this mode, so
+      // reaching here means the payload does not match the manifest that selected
+      // it. Fail loudly instead of recursing to a stack overflow.
+      throw new Error(`nub: the compiled payload has a cyclic chunk graph at ${name}`);
+    }
+    building.add(name);
+    let code = sources.get(name);
+    if (code === undefined) throw new Error(`nub: the compiled payload is missing ${name}`);
+    for (const [dep] of entries) {
+      const token = `"nub-inline:${dep}"`;
+      if (code.includes(token)) code = code.split(token).join(JSON.stringify(urlFor(dep)));
+    }
+    // Trailing, so it wins over anything the bundle already carries and so the
+    // chunk's own line numbering — which the compiler kept intact when it prefixed
+    // the `import.meta.url` assignment — is what stack frames report.
+    code += `\n//# sourceURL=${ROOT}${name}\n`;
+    const url = `data:text/javascript;base64,${Buffer.from(code, "utf8").toString("base64")}`;
+    built.set(name, url);
+    building.delete(name);
+    return url;
+  };
+
+  const entryUrl = urlFor(ENTRY);
+  // Not awaited, and deliberately not wrapped: an import failure must surface as
+  // the ordinary unhandled rejection Node prints for a failed ESM entry, with the
+  // `file:///$nub/…` frames the sourceURL above establishes.
+  import(entryUrl);
+})();

--- a/runtime/compile-preamble.mjs
+++ b/runtime/compile-preamble.mjs
@@ -90,8 +90,18 @@ import { installNavigatorLocks } from "./navigator-locks.mjs";
 import {
   installWorkerPolyfill,
   setBootstrapCreateRequire as setWorkerCreateRequire,
+  setBlobUrlModule,
   setCompiledBootstrapRequireArg,
 } from "./worker-polyfill.mjs";
+// Statically imported so it is BUNDLED rather than resolved beside the emitted
+// chunk. worker-polyfill reaches this module through
+// `createRequire(import.meta.url)("./worker-blob-url.cjs")` — correct for an
+// ordinary nub run, where the eager CommonJS preload must share the one registry
+// instance, but in a compiled artifact it is the only reason the payload has to
+// ship a sibling file at all. Importing it here keeps the whole preamble inside
+// the bundle, which is what lets a pure-JavaScript payload run straight from the
+// executable with nothing on disk.
+import { blobUrlSource, installBlobUrlSupport } from "./worker-blob-url.cjs";
 
 export function installCompilePreamble() {
   // Node 18/20 lack process.getBuiltinModule, so keep builtin lookup tied to the
@@ -100,6 +110,7 @@ export function installCompilePreamble() {
   setNavigatorCreateRequire(bootstrap.createRequire);
   // #endregion
   setWorkerCreateRequire(bootstrap.createRequire);
+  setBlobUrlModule({ blobUrlSource, installBlobUrlSupport });
   setCompiledBootstrapRequireArg(bootstrap.requireArg);
 
   installCompiledChildProcess();

--- a/runtime/worker-polyfill.mjs
+++ b/runtime/worker-polyfill.mjs
@@ -40,11 +40,20 @@
 let _bootstrapCreateRequire = null;
 // Compiled global Workers must carry their fixed-root bootstrap exactly once.
 let _compiledBootstrapRequireArg = null;
+// The blob-URL registry, supplied by an importer that already holds it. Set only
+// by the compile preamble: a compiled bundle has no sibling files to
+// `createRequire` (see the load below), and it is the ONE importer for which the
+// shared-instance argument does not apply, because nothing else in a compiled
+// artifact ever reaches worker-blob-url.cjs.
+let _blobUrlModule = null;
 export function setBootstrapCreateRequire(fn) {
   _bootstrapCreateRequire = fn;
 }
 export function setCompiledBootstrapRequireArg(requireArg) {
   _compiledBootstrapRequireArg = requireArg;
+}
+export function setBlobUrlModule(mod) {
+  _blobUrlModule = mod;
 }
 function __getBuiltin(id) {
   if (typeof process.getBuiltinModule === "function") return process.getBuiltinModule(id);
@@ -96,11 +105,13 @@ export function installWorkerPolyfill() {
   // wraps URL.createObjectURL (worker-blob-url.cjs). Loaded via createRequire so
   // both this lazily-loaded ESM module and the eager CJS preload reference the SAME
   // module instance (Node dedupes by resolved path) — i.e. the SAME registry.
-  const { blobUrlSource, installBlobUrlSupport } = (
-    typeof process.getBuiltinModule === "function"
-      ? __getBuiltin("node:module").createRequire(import.meta.url)
-      : _bootstrapCreateRequire(import.meta.url)
-  )("./worker-blob-url.cjs");
+  const { blobUrlSource, installBlobUrlSupport } =
+    _blobUrlModule ??
+    (
+      typeof process.getBuiltinModule === "function"
+        ? __getBuiltin("node:module").createRequire(import.meta.url)
+        : _bootstrapCreateRequire(import.meta.url)
+    )("./worker-blob-url.cjs");
 
   // Resolve a worker-error stack frame to {filename,lineno,colno} so the
   // ErrorEvent carries real source location, per WHATWG §10.2.6 (the spec
@@ -722,4 +733,16 @@ if (!isMainThread && parentPort) {
 // on-`require` contract the fast-tier call sites (preload.cjs, polyfills.cjs) rely on.
 // On the FLOOR (getBuiltinModule absent) this is skipped; the compat main-thread
 // preload calls setBootstrapCreateRequire(...) + installWorkerPolyfill() explicitly.
-if (typeof process.getBuiltinModule === "function") installWorkerPolyfill();
+//
+// Skipped inside a COMPILED artifact for the same reason as the floor: its preamble
+// hands this module the blob-URL registry through `setBlobUrlModule` — a compiled
+// bundle has no sibling file to `createRequire` — and a setter cannot run before an
+// auto-install at module eval. So the compile preamble owns the call, exactly as the
+// compat preload does. The bootstrap record is published before any ESM in the
+// process runs, which makes it a sound signal at module-eval time.
+if (
+  typeof process.getBuiltinModule === "function" &&
+  process[Symbol.for("nub.compile.bootstrap")] === undefined
+) {
+  installWorkerPolyfill();
+}


### PR DESCRIPTION
A compiled binary extracts its app files to `~/.cache/nub/compile-app/<hash>/` on first run, because Node has to be handed a `--require` preload and an entry by path. A payload that reduces to generated JavaScript needs neither: the launcher passes the bootstrap as `-e` and the bootstrap serves each chunk to `import()` as a `data:` URL read out of the executable's own bytes.

A `console.log("hello world")` artifact wrote 7 files before this change and writes zero after it, `embed` and `--smol` alike. A `--smol` build whose Node is already on the machine now resolves no cache directory at all, so it starts under a read-only `HOME`/`TMPDIR` where it previously refused with `nub: no writable, executable cache directory was found.`

## Qualification — is `sealed_module_graph` the right test?

Necessary, not sufficient. A statically traced worker chunk and a `--sourcemap=linked` map are both files the bundler itself parsed, so `sealed_module_graph` stays true with either present, and neither can be reached from a `data:` URL (`new Worker` does not take one; a linked map cannot be fetched from one). The operative predicate is `sealed_module_graph` AND no worker roots or wrappers AND no source map requested AND every payload file is the bootstrap or a generated `.mjs` chunk AND the chunk graph is acyclic. Anything else extracts exactly as it always has.

Automatic-only, no `--no-extract` flag: a flag promising "no extraction" would be misleading, because an `embed` artifact still unpacks its Node once and a `--smol` one still provisions when none is found. The build summary's new `app` row reports the state and the decline reason on every build.

## Three departures from the obvious shape

- The app region is located by a trailer, not by an offset the launcher passes. `libsui::find_section` returns a pointer into the mapped image on all three platforms (`getsectdata`, `dl_iterate_phdr`, `LockResource`), so no file offset exists on that path. `encode_with_license` appends a 32-byte locator past the container's last declared region, which `decode` already tolerates; the bootstrap scans a bounded tail window backwards for it.
- Inline chunks are brotli, not the zstd beside them. The decompressor is the artifact's own JavaScript, and `zlib.zstdDecompressSync` is absent on Node 23.5 and 23.6 while brotli is on every supported Node. The bootstrap file alone is stored verbatim, so the launcher needs no decoder.
- The chunk set is unchanged and the chunks are linked at run time. Collapsing to one chunk would put `function require(id)` at module scope in an authored-ESM chunk and break `typeof require !== "undefined"` detection, which three existing `bundle.rs` tests assert against. Each chunk becomes its own `data:` URL instead, with cross-chunk specifiers rewritten at build time to `"nub-inline:<name>"` placeholders the loader substitutes — so a payload that does not qualify costs no second bundle.

Two `-e` behaviours the bootstrap undoes, both measured on 26.7.0: Node publishes the CommonJS wrapper's five names as globals, and it puts the whole script into `process.execArgv`. Each chunk deletes the globals from module scope (a delete from the `-e` script itself is undone, because Node republishes a lazy `module` accessor while bringing the ESM loader up), and the launcher publishes the real flag list in `__NUB_COMPILED_EXEC_ARGV`. `--` before the user arguments is mandatory: `node -e "…" --port 3000` otherwise dies with `node: bad option: --port`.

The compile preamble now bundles `worker-blob-url.cjs` instead of resolving it beside the emitted chunks. That was the last support file forced onto disk, and removing it drops a file from every compile build, extracting or not.

## Verification

A 21-fixture differential sweep, each fixture compiled and run under both this branch and a build of the merge-base `9b464fe00d`, on macOS arm64: 47 checks pass, 2 fail on the harness's own path filter (the `sourcemap` fixture's `at …` frames carry a per-build cache-hash directory the filter only strips at line start; both arms print the identical mapped `app.ts:1` header).

Covered: CJS/ESM feature detection against plain `node`, dynamic `import()`, `--external`, `--include`d assets, static and blob workers, TypeScript, JSON imports, `child_process.fork`, baked node flags, both source-map modes, minified and unminified, the `embed` shape, the polyfill-stripping targets 22.15/24.19/26.7, the tier matrix 18.20.8 through 26.7.0 including the zstd-absent 23.5/23.6 band, and the read-only `HOME` case. Every non-qualifying fixture declines to extraction and matches the merge-base.

Two fixes fall out of the shape: `process.argv[1]` is the artifact's own path rather than the leaked `~/.cache/nub/compile-app/<hash>/entry.mjs`, and `process.execPath === process.argv[1]` is true where it was false.

## Known, not introduced here

A blob-URL worker (`new Worker(URL.createObjectURL(blob))`) inside a compiled artifact fails with `ReferenceError: self is not defined` on both arms — an `{eval:true}` worker never receives the bundled preamble, so the worker-side scope is never installed. Pre-existing and independent of this change.
