### PR TITLE
ci: publish the macOS release binary the PR round-trip already builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -771,16 +771,25 @@ jobs:
           node-version: "24"
       - run: npm install --no-audit --no-fund --loglevel=error
       # Stage the vendored helpers into runtime/ so the embedded blob can transpile
-      # anything, not just the erasable-syntax fixture below. `jsbi` is transitive
-      # (via @js-temporal/polyfill) and arrives hoisted at the node_modules root.
-      # Mirrors the Windows twin, which uses `nub install` because its --smol gate
-      # needs a lockfile-exact tree; a plain npm install is enough here.
+      # anything, not just the erasable-syntax fixture below. The list is exactly the
+      # one nub-core/build.rs enforces once NUB_ALLOW_INCOMPLETE_RUNTIME is gone, and
+      # the copies match the two sibling staging steps in this file.
+      #
+      # `jsbi` is TRANSITIVE (via @js-temporal/polyfill) yet copied from the root,
+      # which holds only because npm hoists it there as a real directory — verified by
+      # running this package.json through `npm install` rather than assumed. Under an
+      # isolated layout it sits in the store with no root entry, so a future installer
+      # swap here breaks this line before it breaks anything else. The Windows twin
+      # pins `--node-linker hoisted` for the same reason.
       - name: Stage runtime dependencies
         shell: bash
         run: |
           set -euo pipefail
           rm -rf runtime/node_modules
-          mkdir -p runtime/node_modules/@js-temporal runtime/node_modules/@oxc-project runtime/node_modules/@petamoriken
+          mkdir -p \
+            runtime/node_modules/@js-temporal \
+            runtime/node_modules/@oxc-project \
+            runtime/node_modules/@petamoriken
           cp -R node_modules/@js-temporal/polyfill runtime/node_modules/@js-temporal/
           cp -R node_modules/@oxc-project/runtime runtime/node_modules/@oxc-project/
           cp -R node_modules/@petamoriken/float16 runtime/node_modules/@petamoriken/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -921,20 +921,27 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           cp target/release/nub dist/nub
-          # arm64 macOS SIGKILLs an unsigned binary, and the signature does not survive
-          # the artifact zip round-trip either — hence the re-sign note below.
+          # arm64 macOS SIGKILLs an unsigned binary, so verify rather than let a
+          # developer discover it as what looks like a build bug.
           codesign --verify --verbose=1 dist/nub || codesign -s - dist/nub
           file dist/nub
           (cd dist && shasum -a 256 nub | tee SHA256SUMS)
           ./dist/nub --version
-          # A browser download also carries com.apple.quarantine, which Gatekeeper
-          # enforces before anything else. Both fixes are one line each, and finding
-          # that out the hard way reads exactly like a broken build.
+          # The one step a download really does need. A BROWSER download carries
+          # com.apple.quarantine, which Gatekeeper enforces before anything else, and
+          # an ad-hoc signature can never satisfy Gatekeeper — only notarization can.
+          # `gh run download` sets no quarantine, so that path needs nothing at all.
+          #
+          # The ad-hoc signature itself SURVIVES the artifact zip (measured on the
+          # pr867 artifact: `codesign -dv` reports adhoc, linker-signed, and the
+          # checksum matches), so re-signing is a fallback for a broken signature
+          # rather than a routine step. `spctl` rejecting the binary is expected and
+          # is not that: it assesses against notarization, which no dev build has.
           cat > dist/HOW-TO-RUN.txt <<'EOF'
           shasum -a 256 -c SHA256SUMS
           xattr -d com.apple.quarantine nub 2>/dev/null || true
-          codesign -s - nub
           chmod +x nub && ./nub --version
+          # if macOS kills it, the signature did not survive: codesign -s - nub
           EOF
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -749,10 +749,11 @@ jobs:
     permissions:
       contents: read
     # This leg now stages the vendored runtime like its Windows twin, so the binary it
-    # builds is COMPLETE rather than `enum`-only, and `NUB_ALLOW_INCOMPLETE_RUNTIME` is
-    # gone with it — AGENTS.md forbids that flag on any binary meant to be run, and this
-    # one is uploaded for people to run. Staging widens what the round-trip proves (the
-    # transpile path, not just extract/dlopen) at the cost of one `npm install`.
+    # builds is COMPLETE, and `NUB_ALLOW_INCOMPLETE_RUNTIME` is gone with it — AGENTS.md
+    # forbids that flag on any binary meant to be run, and this one is uploaded for
+    # people to run. Staging a tree is not the same as PROVING it resolves, so the
+    # round-trip fixture below carries the legacy-decorator detector rather than `enum`
+    # alone; `enum` inlines and would pass over an empty node_modules.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
@@ -833,14 +834,37 @@ jobs:
           work="$RUNNER_TEMP/fixture"
           rm -rf "$work"; mkdir -p "$work"
           fixture="$work/embed.ts"
-          # `enum` is NON-ERASABLE — see the Windows twin of this step. Node strips
-          # type ANNOTATIONS natively since 23.6, so a types-only fixture proves
-          # nothing about nub; Node rejects `enum`, so this file executes only if
-          # the extract -> dlopen -> transpile round-trip really happened.
+          # Two constructs, because they fail on different halves of the blob — the
+          # same pair the Windows twin carries, for the reasons documented there.
+          #
+          # `enum` is NON-ERASABLE: Node has stripped type ANNOTATIONS natively since
+          # 23.6, so a types-only fixture proves nothing about nub. Node rejects
+          # `enum`, so this file executes only if extract -> dlopen -> transpile
+          # really happened.
+          #
+          # `enum` alone is BLIND to the vendored node_modules, though — oxc inlines
+          # it and it pulls no helper. That is why this job could stage a runtime
+          # tree, upload a binary built from it, and never once prove the tree
+          # resolves. The legacy DECORATOR is the detector: its transpiled output
+          # requires `@oxc-project/runtime/helpers/decorateMetadata`, and an extracted
+          # tree has no parent node_modules to reach it through — only its own
+          # (`vendored_node_path`, crates/nub-core/src/node/spawn.rs). Measured by the
+          # Windows twin against a binary staged with an EMPTY runtime/node_modules:
+          # the enum-only fixture exits 0 and prints the success marker, this one
+          # exits 1 with MODULE_NOT_FOUND.
+          #
+          # CommonJS entry (no package.json) is deliberate and depends on the Node 24
+          # pin above: down-levelling a legacy decorator is version-independent, but
+          # RESOLVING its helper from a CJS entry is unsupported below require(esm)
+          # (Node <20.19 / 22.0-22.11).
+          cat > "$work/tsconfig.json" <<'EOF'
+          {"compilerOptions":{"experimentalDecorators":true,"emitDecoratorMetadata":true}}
+          EOF
           cat > "$fixture" <<'EOF'
           enum Answer { Value = 42 }
-          const greeting: string = "embed-roundtrip-ok";
-          console.log(`${greeting}-${Answer.Value}`);
+          function tag(_t: any, _k: string, d: PropertyDescriptor) { return d; }
+          class Probe { @tag greet(): string { return "embed-roundtrip-ok"; } }
+          console.log(`${new Probe().greet()}-${Answer.Value}`);
           EOF
 
           # --- First run: extract -> verify -> dlopen -> transpile -> execute ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -748,11 +748,11 @@ jobs:
     runs-on: macos-14
     permissions:
       contents: read
-    # Its fixture is `enum`-only, which needs no vendored helper, so this leg covers the
-    # extract/dlopen round-trip rather than the transpile path. Its Windows twin DOES
-    # stage node_modules (for the offline `--smol` compile gate) and so keeps the gate on.
-    env:
-      NUB_ALLOW_INCOMPLETE_RUNTIME: "1"
+    # This leg now stages the vendored runtime like its Windows twin, so the binary it
+    # builds is COMPLETE rather than `enum`-only, and `NUB_ALLOW_INCOMPLETE_RUNTIME` is
+    # gone with it — AGENTS.md forbids that flag on any binary meant to be run, and this
+    # one is uploaded for people to run. Staging widens what the round-trip proves (the
+    # transpile path, not just extract/dlopen) at the cost of one `npm install`.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
@@ -769,6 +769,36 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"
+      - run: npm install --no-audit --no-fund --loglevel=error
+      # Stage the vendored helpers into runtime/ so the embedded blob can transpile
+      # anything, not just the erasable-syntax fixture below. `jsbi` is transitive
+      # (via @js-temporal/polyfill) and arrives hoisted at the node_modules root.
+      # Mirrors the Windows twin, which uses `nub install` because its --smol gate
+      # needs a lockfile-exact tree; a plain npm install is enough here.
+      - name: Stage runtime dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf runtime/node_modules
+          mkdir -p runtime/node_modules/@js-temporal runtime/node_modules/@oxc-project runtime/node_modules/@petamoriken
+          cp -R node_modules/@js-temporal/polyfill runtime/node_modules/@js-temporal/
+          cp -R node_modules/@oxc-project/runtime runtime/node_modules/@oxc-project/
+          cp -R node_modules/@petamoriken/float16 runtime/node_modules/@petamoriken/
+          cp -R node_modules/jsbi node_modules/urlpattern-polyfill runtime/node_modules/
+      # Without the typosquat corpus, aube-resolver/build.rs ships an EMPTY primer and
+      # says so only in a cargo warning — the binary then falls back to network
+      # packument fetches at exit 0, which would silently turn any install benchmark
+      # run against this artifact into a measurement of the network. AUBE_REQUIRE_PRIMER
+      # on the build below turns that warning into a hard failure; this step supplies
+      # what it then demands. Same pair as mac-build.yml, and the reason is the same.
+      - name: Generate typosquat popularity corpus
+        run: |
+          set -euo pipefail
+          cd vendor/aube
+          node scripts/generate-primer.mjs \
+            --top 1 \
+            --out "$RUNNER_TEMP/primer-discard.json" \
+            --popular-names-out crates/aube-resolver/data/popular-top100000-v1.json
       - name: Build + stage release nub-native addon
         shell: bash
         run: |
@@ -777,6 +807,8 @@ jobs:
           mkdir -p runtime/addons
           cp target/release/libnub_native.dylib runtime/addons/nub-native.node
       - name: Build release nub (--features embed-runtime)
+        env:
+          AUBE_REQUIRE_PRIMER: "1"
         run: cargo build -p nub-cli --release --features embed-runtime
       - name: Round-trip — extract, verify, dlopen, execute, warm cache, R2 self-heal
         shell: bash
@@ -842,6 +874,42 @@ jobs:
           [ "$orig" = "$healed" ] || { echo "self-heal did not restore the dylib ($orig -> $healed)"; exit 1; }
           echo "R2 self-heal confirmed: tampered dylib detected, re-extracted, restored, still executed"
           echo "ROUND-TRIP OK (macOS): extract -> verify -> dlopen -> execute -> warm reuse -> R2"
+
+      # PUBLISH THE BINARY THIS JOB ALREADY BUILT. The release build above is the whole
+      # cost of a downloadable macOS dev build, and it is paid on every PR either way —
+      # so the artifact is worth seconds of upload rather than a second macOS job. One
+      # file, not two: --features embed-runtime carries the addon and the vendored
+      # runtime inside the binary, so this is standalone and needs no checkout to run.
+      # The round-trip step above tampers only with the EXTRACTED cache copy, so
+      # target/release/nub is untouched by the time it is staged here.
+      - name: Stage the downloadable binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp target/release/nub dist/nub
+          # arm64 macOS SIGKILLs an unsigned binary, and the signature does not survive
+          # the artifact zip round-trip either — hence the re-sign note below.
+          codesign --verify --verbose=1 dist/nub || codesign -s - dist/nub
+          file dist/nub
+          (cd dist && shasum -a 256 nub | tee SHA256SUMS)
+          ./dist/nub --version
+          # A browser download also carries com.apple.quarantine, which Gatekeeper
+          # enforces before anything else. Both fixes are one line each, and finding
+          # that out the hard way reads exactly like a broken build.
+          cat > dist/HOW-TO-RUN.txt <<'EOF'
+          shasum -a 256 -c SHA256SUMS
+          xattr -d com.apple.quarantine nub 2>/dev/null || true
+          codesign -s - nub
+          chmod +x nub && ./nub --version
+          EOF
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: nub-macos-arm64-pr${{ github.event.pull_request.number }}
+          path: dist/
+          retention-days: 7
+          if-no-files-found: error
 
   test:
     name: Test (${{ matrix.os }}, node ${{ matrix.node }})


### PR DESCRIPTION
`macos-embed-roundtrip` already runs a full release build of `nub-cli` and the addon on every PR, then discards the binary. Upload it instead, so a PR can be downloaded and run locally. `embed-runtime` carries the addon and runtime inside the binary, so the artifact is one standalone file.

Two fixes make it fit to run:

- The job never staged `runtime/node_modules` and set `NUB_ALLOW_INCOMPLETE_RUNTIME` to compensate. It now stages the vendored helpers as the Windows twin does, and the flag is gone. The round-trip covers the transpile path, not just extract/dlopen.
- Without the typosquat corpus, `aube-resolver`'s `build.rs` ships an empty primer and only warns, leaving a binary that falls back to network packument fetches at exit 0. The corpus is generated and `AUBE_REQUIRE_PRIMER` makes that a build failure.

`actionlint` is clean. The job is `pull_request`-gated, so this PR is what proves the build passes without the flag.

Linux legs build `dev`/`fast` only, so an artifact there would be a new build, not a reused one. Windows builds a release `nub.exe` per PR and could get the same treatment; not in this PR.