### PR TITLE
pm: drop the three nub-only root install fields

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -10294,8 +10294,9 @@ fn run_pm_use(name: &str, spec: &str, cwd: &Path) -> Result<i32> {
 
     // `use pnpm` regenerates pnpm-workspace.yaml from the nub-mode package.json
     // homes (workspaces + catalogs, top-level overrides/patchedDependencies/
-    // allowScripts/auditConfig) — the exact reverse of `use nub`'s migration.
-    // No-op on a project that never carried them.
+    // allowScripts) — the reverse of `use nub`'s migration, plus a legacy
+    // `auditConfig` a pre-drop conversion may have left behind. No-op on a
+    // project that never carried them.
     if name == "pnpm" {
         for line in crate::pm_engine::use_nub::regenerate_workspace_yaml(&root)? {
             println!("  {line}");

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1374,6 +1374,7 @@ fn apply_config_scope(
         if manifest.has_legacy_root_allow_builds() {
             return Err(legacy_allow_builds_error());
         }
+        warn_dropped_root_install_fields(&manifest);
         // Catalog hard-error: a role that doesn't honor `catalog:` specifiers
         // (npm/yarn/bun, pnpm<9) must mirror the real PM and refuse, rather
         // than silently mis-resolve. nub-branded, role-named.
@@ -1513,6 +1514,62 @@ fn legacy_allow_builds_error() -> anyhow::Error {
          `allowBuilds:` block are pnpm's own surface and still read as-is.) \
          [ERR_NUB_ALLOW_BUILDS_RENAMED]"
     )
+}
+
+/// Manifest-ROOT install keys nub used to read and no longer does, each with
+/// the surface that replaces it.
+///
+/// All three were nub-only. No package manager reads a top-level `auditConfig`,
+/// `allowUnusedPatches` or `allowNonAppliedPatches`: npm 12 ships
+/// `patchedDependencies` but makes its relax flag CLI-ONLY on purpose (ignored
+/// in `.npmrc` and env, rejected by `npm ci`, so it cannot become project
+/// policy) and has no audit-ignore mechanism at all; bun's is `bun audit
+/// --ignore <CVE>`; pnpm keeps both under `pnpm.*` or the workspace yaml, which
+/// nub still reads under a pnpm incumbent. So the root spellings were three
+/// un-namespaced `package.json` names held on the strength of nobody having
+/// claimed them yet — the position `allowBuilds` was in when npm 12 shipped
+/// `allowScripts` into the same slot.
+const DROPPED_ROOT_INSTALL_FIELDS: [(&str, &str); 3] = [
+    (
+        "auditConfig",
+        "pass `nub audit --ignore <id>`, which takes advisory numbers, GHSA ids and CVE ids",
+    ),
+    (
+        "allowUnusedPatches",
+        "remove the `patchedDependencies` entry that matches no installed package",
+    ),
+    (
+        "allowNonAppliedPatches",
+        "remove the `patchedDependencies` entry that matches no installed package",
+    ),
+];
+
+/// Tell a project still carrying one of those keys that it does nothing.
+///
+/// A warning rather than the hard error `allowBuilds` gets: both of these fail
+/// SAFE when unread — advisories the project had muted come back, and an
+/// unmatched patch fails an install that used to warn — where a dropped
+/// `allowBuilds: false` would RUN a script the project denied. Silence is still
+/// the wrong answer, because the key looks like it is doing something.
+///
+/// Says nothing about the branded `pnpm.*` spellings: those are pnpm's own
+/// surface, read under a pnpm incumbent exactly as before.
+fn warn_dropped_root_install_fields(manifest: &aube_manifest::PackageJson) {
+    let dim = scope_warning_uses_dim();
+    for (root, remedy) in DROPPED_ROOT_INSTALL_FIELDS {
+        if !manifest.extra.contains_key(root) {
+            continue;
+        }
+        let line = format!(
+            "nub: package.json sets a top-level `{root}` — no package manager reads that key \
+             there, and nub no longer does either. Instead, {remedy}."
+        );
+        if dim {
+            eprintln!("\x1b[2m{line}\x1b[0m");
+        } else {
+            eprintln!("{line}");
+        }
+    }
 }
 
 fn catalog_unsupported_error(role: config_scope::Role, spec: &str) -> anyhow::Error {

--- a/crates/nub-cli/src/pm_engine/use_nub.rs
+++ b/crates/nub-cli/src/pm_engine/use_nub.rs
@@ -15,7 +15,7 @@
 //! - resolution-bearing keys → `package.json` under ecosystem-standard
 //!   top-level names (`workspaces` incl. the object form,
 //!   `workspaces.catalog(s)`, `overrides`, `patchedDependencies`, the
-//!   three-state `allowScripts` map, `auditConfig`);
+//!   three-state `allowScripts` map);
 //! - settings → `.npmrc` (the same vocabulary, kebab spellings — one engine
 //!   reads both homes, so this is a mechanical move, not a translation);
 //! - engine-unsupported keys → warn-drop naming each (the three repo-wide
@@ -240,6 +240,14 @@ const ENGINE_UNSUPPORTED: &[(&str, &str)] = &[
         "allowUnusedPatches",
         "unreferenced patch files always error in the engine",
     ),
+    // Was migrated to a top-level `auditConfig` until nub stopped reading that
+    // key. Reporting it is the whole point: the alternative is a conversion
+    // that says it succeeded while the project's triaged advisories quietly
+    // come back on the next audit.
+    (
+        "auditConfig",
+        "nub has no persistent audit-ignore config — pass `nub audit --ignore <id>`, which takes advisory numbers, GHSA ids and CVE ids",
+    ),
     (
         "fetchingConcurrency",
         "use network-concurrency in .npmrc instead",
@@ -382,8 +390,6 @@ pub(crate) struct YamlMigration {
     /// / `ignoredBuiltDependencies` → `false` (asked-and-answered, not
     /// security denial). Explicit pnpm `allowBuilds` entries win the fold.
     pub allow_builds: Option<Map<String, Value>>,
-    /// Top-level `auditConfig` (aube's existing extension home).
-    pub audit_config: Option<Value>,
     /// `.npmrc` lines to append, as `(key, value)` (key already kebab).
     pub npmrc: Vec<(String, String)>,
     /// Engine-unsupported keys found, as `key — note` summary lines.
@@ -446,7 +452,6 @@ pub(crate) fn plan_migration(source: &Map<String, Value>) -> Result<YamlMigratio
             "catalogs" => m.catalogs = Some(value.clone()),
             "overrides" => m.overrides = value.as_object().cloned(),
             "patchedDependencies" => m.patched_dependencies = value.as_object().cloned(),
-            "auditConfig" => m.audit_config = Some(value.clone()),
             // handled by the folds above
             "allowBuilds"
             | "onlyBuiltDependencies"
@@ -601,7 +606,7 @@ pub(crate) fn write_nub_identity_fields(
 /// - `workspaces` membership + catalogs: the yaml was authoritative under
 ///   pnpm (it shadows `package.json#workspaces`), so yaml values overwrite —
 ///   any differing pre-existing value is named in the returned notes.
-/// - `overrides` / `patchedDependencies` / `allowScripts` / `auditConfig`:
+/// - `overrides` / `patchedDependencies` / `allowScripts`:
 ///   per-key insert; an existing top-level entry wins (the engine's merge
 ///   already ranked top-level above the yaml), conflicts named. pnpm's
 ///   `allowBuilds` map lands under the neutral `allowScripts` name.
@@ -693,14 +698,6 @@ pub(crate) fn apply_manifest_edits(
             }
         }
     }
-    if let Some(audit) = &m.audit_config
-        && obj.get("auditConfig").is_none_or(|prev| prev == audit)
-    {
-        obj.insert("auditConfig".into(), audit.clone());
-    } else if m.audit_config.is_some() {
-        notes.push("auditConfig: package.json already sets a differing value — kept".into());
-    }
-
     obj.remove("pnpm");
     notes
 }
@@ -943,7 +940,6 @@ pub(crate) fn run_use_nub(root: &Path, exact_pin: Option<&str>) -> Result<i32> {
             aube_manifest::ROOT_ALLOW_SCRIPTS_KEY,
             migration.allow_builds.is_some(),
         ),
-        ("auditConfig", migration.audit_config.is_some()),
     ] {
         if present {
             println!("  package.json: top-level {key} migrated");
@@ -1126,7 +1122,8 @@ fn merge_root_allow_maps(legacy: Option<&Value>, current: Option<&Value>) -> Opt
 /// The yaml-regeneration half of `nub pm use pnpm` — the exact reverse of
 /// [`run_use_nub`]'s migration: collect the nub-mode homes out of
 /// `package.json` (`workspaces` membership + catalogs, top-level `overrides`
-/// / `patchedDependencies` / `allowScripts` / `auditConfig`), write them into
+/// / `patchedDependencies` / `allowScripts`, plus a legacy `auditConfig` left
+/// by a pre-drop conversion), write them into
 /// `pnpm-workspace.yaml` under pnpm's own key names (`allowScripts` →
 /// `allowBuilds`; the rest keep their spelling), merging into an existing yaml
 /// with package.json values
@@ -1169,6 +1166,11 @@ pub(crate) fn regenerate_workspace_yaml(root: &Path) -> Result<Vec<String>> {
         manifest.get(aube_manifest::LEGACY_ROOT_ALLOW_BUILDS_KEY),
         manifest.get(aube_manifest::ROOT_ALLOW_SCRIPTS_KEY),
     );
+    // Rescue only. `nub pm use nub` no longer writes this key — nub has no
+    // persistent audit-ignore config — but a project converted before that
+    // change still carries one, doing nothing. Carrying it back to pnpm's own
+    // home is the one place it becomes live again, so the switch restores a
+    // policy rather than leaving it stranded at a name nothing reads.
     let audit_config = manifest.get("auditConfig").cloned();
 
     if packages.is_none()
@@ -1234,6 +1236,49 @@ mod tests {
 
     fn src(json: serde_json::Value) -> Map<String, Value> {
         json.as_object().cloned().unwrap()
+    }
+
+    /// `pnpm.auditConfig` has no destination under nub identity, so the
+    /// conversion must NAME it rather than write it somewhere nothing reads.
+    ///
+    /// It used to be migrated to a top-level `package.json` `auditConfig`.
+    /// Once nub stopped reading that key the same write became a silent policy
+    /// loss dressed as a successful migration — the project's triaged
+    /// advisories would come back on the next audit with nothing said. The
+    /// assertions are the two halves of "loud": it must not reach the manifest,
+    /// and the summary must carry the remedy.
+    #[test]
+    fn an_audit_config_is_reported_as_unsupported_rather_than_migrated() {
+        let m = plan_migration(&src(json!({
+            "auditConfig": { "ignoreGhsas": ["GHSA-xxxx-yyyy-zzzz"] }
+        })))
+        .unwrap();
+
+        let dropped = m.dropped.join("\n");
+        assert!(
+            dropped.contains("auditConfig"),
+            "the conversion must name the key it could not carry: {dropped:?}"
+        );
+        assert!(
+            dropped.contains("nub audit --ignore"),
+            "and must name what replaces it: {dropped:?}"
+        );
+        assert!(
+            !m.npmrc.iter().any(|(k, _)| k.contains("audit")),
+            "no invented `.npmrc` home either: {:?}",
+            m.npmrc
+        );
+
+        let mut manifest = Map::new();
+        let notes = apply_manifest_edits(&mut manifest, &m, None, "^0.8.0");
+        assert!(
+            manifest.get("auditConfig").is_none(),
+            "a key nub does not read must not be written to package.json: {manifest:?}"
+        );
+        assert!(
+            !notes.join("\n").contains("auditConfig"),
+            "and it must not be reported as moved: {notes:?}"
+        );
     }
 
     #[test]

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -2060,3 +2060,97 @@ fn an_owed_dependency_build_stops_the_next_install_reporting_up_to_date() {
         "and that migration must be one-time: the re-check writes the field, so it cannot repeat"
     );
 }
+
+/// The three manifest-ROOT install keys nub used to read, and no longer does.
+///
+/// No package manager reads a top-level `auditConfig`, `allowUnusedPatches` or
+/// `allowNonAppliedPatches` — npm 12 makes its own patch relax flag CLI-only on
+/// purpose and has no audit-ignore at all — so these were nub-only names held on
+/// an un-namespaced `package.json` key. Removing the read is the point of the
+/// change; the two halves asserted here are that the key no longer DOES
+/// anything, and that a project carrying it is told so rather than left to
+/// wonder why its install started failing.
+///
+/// Offline and dependency-free: the unused-patch check runs before any fetch,
+/// so this needs no registry.
+#[test]
+fn a_manifest_root_allow_unused_patches_no_longer_relaxes_the_patch_check() {
+    let dir = pm_tmpdir("root-allow-unused-patches");
+    std::fs::create_dir_all(dir.join("patches")).unwrap();
+    std::fs::write(dir.join("patches/ghost.patch"), "").unwrap();
+    let manifest = |extra: &str| {
+        std::fs::write(
+            dir.join("package.json"),
+            format!(
+                r#"{{"name":"probe","version":"1.0.0",
+                     "patchedDependencies":{{"ghost@1.0.0":"patches/ghost.patch"}}{extra}}}"#
+            ),
+        )
+        .unwrap();
+    };
+
+    // The control: with no allowance anywhere the install fails. Without it a
+    // read that still worked would be indistinguishable from one that never ran.
+    manifest("");
+    let (_, stderr, code) = run_install(&dir, &["install", "--offline"]);
+    assert_eq!(
+        code, 1,
+        "an unused patch key must fail the install: {stderr}"
+    );
+    assert!(
+        stderr.contains("ERR_NUB_UNUSED_PATCH"),
+        "expected the unused-patch refusal, got: {stderr}"
+    );
+
+    // The root key must not change that verdict, and must say why it did not.
+    manifest(r#","allowUnusedPatches":true"#);
+    let (_, stderr, code) = run_install(&dir, &["install", "--offline"]);
+    assert_eq!(
+        code, 1,
+        "a top-level allowUnusedPatches must no longer relax the check: {stderr}"
+    );
+    assert!(
+        stderr.contains("ERR_NUB_UNUSED_PATCH"),
+        "expected the unused-patch refusal, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("sets a top-level `allowUnusedPatches`"),
+        "a project carrying the dropped key must be told it does nothing, got: {stderr}"
+    );
+}
+
+/// The same notice for the other two, and silence for a manifest carrying none.
+/// One run per key rather than one manifest holding all three, so a notice that
+/// fired for the wrong key cannot hide behind its neighbours.
+#[test]
+fn the_other_dropped_root_install_keys_are_announced_and_only_when_present() {
+    for (key, value) in [
+        ("auditConfig", r#"{"ignoreGhsas":["GHSA-xxxx-yyyy-zzzz"]}"#),
+        ("allowNonAppliedPatches", "true"),
+    ] {
+        let dir = pm_tmpdir(&format!("dropped-{key}"));
+        std::fs::write(
+            dir.join("package.json"),
+            format!(r#"{{"name":"probe","version":"1.0.0","{key}":{value}}}"#),
+        )
+        .unwrap();
+        let (_, stderr, code) = run_install(&dir, &["install", "--offline"]);
+        assert_eq!(code, 0, "the notice must not fail the install: {stderr}");
+        assert!(
+            stderr.contains(&format!("sets a top-level `{key}`")),
+            "{key} must be announced, got: {stderr}"
+        );
+    }
+
+    let clean = pm_tmpdir("dropped-none");
+    std::fs::write(
+        clean.join("package.json"),
+        r#"{"name":"probe","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    let (_, stderr, _) = run_install(&clean, &["install", "--offline"]);
+    assert!(
+        !stderr.contains("sets a top-level"),
+        "a manifest carrying none of the keys must say nothing, got: {stderr}"
+    );
+}

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -109,19 +109,18 @@ Read the [full docs](https://pnpm.io/settings/dependency-resolution#packageexten
 
 ### `patchedDependencies`
 
-Apply a patch file to a package's contents, keyed by name and version. Running `nub patch <pkg>` writes both the patch and this entry. A key matching no installed package fails the install unless `allowUnusedPatches` downgrades it to a warning.
+Apply a patch file to a package's contents, keyed by name and version. Running `nub patch <pkg>` writes both the patch and this entry. A key matching no installed package fails the install, because the usual cause is a patch that silently stopped being applied.
 
 ```json title="package.json"
 {
   "patchedDependencies": {
     "is-odd@3.0.1": "patches/is-odd@3.0.1.patch"
-  },
-  "allowUnusedPatches": true
+  }
 }
 ```
 
 <Callout>
-Read the full docs on [patchedDependencies](https://pnpm.io/cli/patch#patcheddependencies) and [allowUnusedPatches](https://pnpm.io/cli/patch#allowunusedpatches) on pnpm.io.
+Read the [full docs](https://pnpm.io/cli/patch#patcheddependencies) on pnpm.io.
 </Callout>
 
 ### `workspaces`

--- a/vendor/aube/crates/aube-manifest/src/lib.rs
+++ b/vendor/aube/crates/aube-manifest/src/lib.rs
@@ -771,15 +771,26 @@ impl PackageJson {
     /// key that matched no installed package from a hard error to a
     /// warning.
     ///
-    /// Read from exactly the homes `patchedDependencies` itself uses, so
-    /// the setting always travels with the config it governs: the
-    /// branded `pnpm.*` object (only under a pnpm incumbent, per
-    /// `pnpm_aube_objects`), this tool's own namespace, and — for a
-    /// root-namespace embedder — the neutral top-level key, which is
-    /// what keeps a nub-identity project off another tool's brand.
-    /// Deliberately NOT an npmrc/env setting: pnpm 10 honors it only
-    /// here and in the workspace yaml (verified against 10.15.1), and
-    /// accepting it where pnpm doesn't would be its own divergence.
+    /// The MANIFEST half of the lookup, and only that: the branded
+    /// `pnpm.*` object (read solely under a pnpm incumbent, per
+    /// `pnpm_aube_objects`) and this tool's own namespace, which are
+    /// exactly the manifest homes `patchedDependencies` itself uses, so
+    /// the setting travels with the config it governs. pnpm 10 honors
+    /// the knob here and in the workspace yaml and nowhere else
+    /// (verified against 10.15.1); `patches.rs` reads the yaml and
+    /// prefers it over this reader, matching how `patchedDependencies`
+    /// itself merges.
+    ///
+    /// There is deliberately no manifest-ROOT read, and a manifest-root
+    /// embedder therefore has no persistent home for the knob at all.
+    /// That un-namespaced key was nub-only: no package manager reads a
+    /// top-level `allowUnusedPatches`, and npm 12 — which ships the
+    /// feature — makes its own `--allow-unused-patches` command-line
+    /// only on purpose, ignored in `.npmrc` and env and rejected by
+    /// `npm ci`, so it cannot become project policy anywhere. Squatting
+    /// an un-namespaced `package.json` name that only one tool honors
+    /// is what removing the read undoes.
+    ///
     /// `allowNonAppliedPatches` is pnpm's deprecated spelling, still
     /// accepted by pnpm 10; the current name wins when both appear.
     pub fn allow_unused_patches(&self) -> Option<bool> {
@@ -792,13 +803,12 @@ impl PackageJson {
                 }
             }
         }
-        if aube_util::embedder().manifest_namespace.is_empty() {
-            for key in KEYS {
-                if let Some(v) = self.extra.get(key).and_then(|v| v.as_bool()) {
-                    out = Some(v);
-                }
-            }
-        }
+        // No manifest-ROOT read, and no replacement home. The root key was
+        // nub-only — no package manager reads a top-level
+        // `allowUnusedPatches` or `allowNonAppliedPatches` — so nothing
+        // outside nub ever saw it. npm ships the feature and refuses to let it
+        // be project policy at all; the remedy for a key matching no installed
+        // package is to delete the key.
         out
     }
 

--- a/vendor/aube/crates/aube/src/commands/audit.rs
+++ b/vendor/aube/crates/aube/src/commands/audit.rs
@@ -443,10 +443,19 @@ fn configured_audit_ignores(
     if let Some(canonical) = canonical {
         out.extend(canonical);
     } else {
-        if let Some(config) = manifest
-            .extra
-            .get("auditConfig")
-            .and_then(|v| v.as_object())
+        // Manifest-ROOT `auditConfig` is read only by a NAMESPACED embedder.
+        // An un-namespaced top-level `auditConfig` is a name no package manager
+        // reads — npm has no audit-ignore mechanism at all, bun's is the CLI
+        // flag `bun audit --ignore <CVE>`, and pnpm's is a settings key whose
+        // workspace-yaml home is read below. So for a manifest-root embedder
+        // this block would honour a key only that embedder had ever written, at
+        // a `package.json` name the ecosystem is still free to claim.
+        // `--ignore` is the surface that stays.
+        if !aube_util::embedder().manifest_namespace.is_empty()
+            && let Some(config) = manifest
+                .extra
+                .get("auditConfig")
+                .and_then(|v| v.as_object())
         {
             for key in ["ignoreGhsas", "ignoreCves"] {
                 if let Some(values) = config.get(key).and_then(|v| v.as_array()) {


### PR DESCRIPTION
`auditConfig`, `allowUnusedPatches` and `allowNonAppliedPatches` were read from the `package.json` ROOT. No package manager reads any of the three there, so they were un-namespaced names held on the strength of nobody having claimed them yet — the position `allowBuilds` was in when npm 12 shipped `allowScripts` into the same slot (#863).

Checked against each tool's source rather than assumed:

| tool | `allowUnusedPatches` | audit ignore |
| --- | --- | --- |
| npm 12 | `--allow-unused-patches`, **CLI-only by design** — ignored in `.npmrc`/env, rejected by `npm ci` | none at all |
| pnpm 11 | `pnpm.*` / workspace yaml | `auditConfig.ignoreGhsas`, same homes |
| bun | — | `bun audit --ignore <CVE>` |
| yarn berry | — | `npmAuditExcludePackages` + `--exclude` |

npm's `lib/utils/cli-only-flag.js` is explicit: "Values from `.npmrc`, env, or defaults resolve to undefined, so the flag cannot be set as project policy." A nub-native config home for it would be the design npm rejected. And `nub audit --ignore <ID>` already exists — repeatable, matching advisory numbers, GHSA ids and CVE ids together — so a config key would be a second spelling of a flag we already ship.

So the reads go and nothing replaces them. pnpm compatibility is untouched: the branded `pnpm.*` spellings, the workspace-yaml homes and the `auditConfig.*` settings read exactly as before. Only the manifest-root surface goes.

A project still carrying one of the keys gets a warning naming what replaces it — not the hard error `allowBuilds` gets, because both fail safe when unread: advisories the project had muted come back, and an unmatched patch fails an install that used to warn.

Two integration tests guard it through the real binary, offline; the aube-side unit tests structurally cannot reach the removed branch. Both were falsified — restoring either half turns them red.


`nub pm use nub` migrated pnpm's `auditConfig` to the root key. With the read gone that write would report a successful conversion while silently dropping the project's triaged advisories, and the next install would warn about the file the conversion had just written. It now reports the key as unsupported and names `nub audit --ignore`, alongside the other engine-unsupported keys. `nub pm use pnpm` still reads a root `auditConfig`: a project converted before this change carries a dead one, and pnpm's own home is the single place it becomes live again.
