### PR TITLE
compile: sign darwin-x64 output with a deterministic identifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,6 +820,16 @@ jobs:
         env:
           AUBE_REQUIRE_PRIMER: "1"
         run: cargo build -p nub-cli --release --features embed-runtime
+      # The libsui signing-determinism test is `cfg(target_vendor = "apple")`, and the
+      # per-OS launcher step in the test job reaches macOS only on push:main and
+      # nightly. This is the one macOS leg every pull request runs, so a
+      # filename-dependent signature regresses here rather than on the next main run.
+      - name: libsui units (macOS, pull requests)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd crates/nub-launcher
+          cargo test --locked -p libsui --lib
       - name: Round-trip — extract, verify, dlopen, execute, warm cache, R2 self-heal
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1221,10 +1221,20 @@ jobs:
       # where the inherit-only-ACE defect lived: it made every Windows cache base
       # unusable, and no CI leg could see it. The launcher is already built above,
       # so covering the OS legs it actually targets costs one `cargo test`.
-      - name: nub-launcher cache chain (per-OS)
+      - name: nub-launcher cache chain + libsui units (per-OS)
         if: matrix.node == '24' && runner.os != 'Linux'
         shell: bash
-        run: cd crates/nub-launcher && cargo test --locked
+        run: |
+          set -euo pipefail
+          cd crates/nub-launcher
+          cargo test --locked
+          # vendor/libsui reaches every workspace as a path/patch dependency and is
+          # a MEMBER of none, so until now nothing anywhere ran its unit tests —
+          # `cargo test -p libsui` from the repo root fails outright. This
+          # workspace patches it in, so `-p` resolves here. `--lib` scopes it to
+          # the units: a crate-doc doctest reads a fixture file that does not
+          # exist and has always failed.
+          cargo test --locked -p libsui --lib
       # The default compile shape builds from the runtime extracted out of the
       # feature-on nub binary, so it cannot resolve these package imports from the
       # checkout's root node_modules. Copy the same locked pure-JS set release.yml

--- a/crates/nub-cli/src/compile/inject.rs
+++ b/crates/nub-cli/src/compile/inject.rs
@@ -24,10 +24,12 @@ use nub_core::compile::{ContainerFormat, TargetArch, TargetPlatform};
 /// Inject `payload` into a copy of `template`, writing the artifact to `out`.
 ///
 /// Signing policy is per format and lives here because it is inseparable from
-/// the write: Mach-O is ad-hoc signed by libsui's pure-Rust signer (arm64 refuses
-/// to execute an unsigned image, and Gatekeeper rejects an invalid one), while
-/// ELF and PE are never signed — an unsigned ELF is normal, and Authenticode is
-/// deliberately out of scope (an unsigned PE runs; SmartScreen may warn).
+/// the write: Mach-O is ad-hoc signed (arm64 refuses to execute an unsigned
+/// image, and Gatekeeper rejects an invalid one) — arm64 by libsui's pure-Rust
+/// signer, x86_64 by `codesign` on a staged temp file — while ELF and PE are
+/// never signed, an unsigned ELF being normal and Authenticode deliberately out
+/// of scope (an unsigned PE runs; SmartScreen may warn). Both Mach-O legs pin
+/// the same CodeDirectory identifier, so the artifact is byte-reproducible.
 pub fn inject(
     target: &TargetPlatform,
     template: &[u8],

--- a/vendor/libsui/apple_codesign.rs
+++ b/vendor/libsui/apple_codesign.rs
@@ -99,6 +99,13 @@ const SEC_CODE_SIGNATURE_HASH_SHA256: u8 = 2;
 
 const CS_EXECSEG_MAIN_BINARY: u64 = 0x1; // executable segment denotes main binary
 
+/// The CodeDirectory identifier every ad-hoc signature this crate produces
+/// carries, on both macOS architectures. A CONSTANT, because the identifier is
+/// part of the signed image: anything derived from the file name or the signing
+/// process makes two builds of one input differ. `crate::codesign_adhoc` passes
+/// it to `codesign -i` for the same reason.
+pub(crate) const ADHOC_IDENTIFIER: &str = "a.out";
+
 impl MachoSigner {
     pub fn new(obj: Vec<u8>) -> Result<Self, Error> {
         let header = Header64::read_from_prefix(&obj)
@@ -178,7 +185,9 @@ impl MachoSigner {
     pub fn sign<W: std::io::Write>(mut self, mut writer: W) -> Result<(), Error> {
         const PAGE_SIZE: usize = 1 << 12;
 
-        let id = b"a.out\0";
+        // CodeDirectory identifiers are NUL-terminated.
+        let id = format!("{ADHOC_IDENTIFIER}\0");
+        let id = id.as_bytes();
         let n_hashes = self.sig_off.div_ceil(PAGE_SIZE);
         let id_off = size_of::<CodeDirectory>();
         let hash_off = id_off + id.len();

--- a/vendor/libsui/lib.rs
+++ b/vendor/libsui/lib.rs
@@ -585,6 +585,56 @@ pub struct Macho {
 
 pub(crate) const SEGNAME: [u8; 16] = *b"__SUI\0\0\0\0\0\0\0\0\0\0\0";
 
+/// Ad-hoc sign `data` by staging it at `tmp_path` and handing that file to
+/// Apple's `codesign`, returning the signed bytes. This is the x86_64 leg of
+/// [`Macho::build_and_sign`]; arm64 is signed in-process instead.
+///
+/// `-i` is load-bearing, not cosmetic. Without it `codesign` derives the
+/// CodeDirectory identifier from the staged file's BASENAME, and that name
+/// carries the compiling process's PID — so two compiles of an unchanged tree
+/// produced artifacts differing in exactly the ASCII digits of that PID, and a
+/// reproducible build was impossible. `ADHOC_IDENTIFIER` is what the arm64
+/// signer writes, so both macOS legs now agree on one stable value.
+///
+/// A missing or failing `codesign` leaves `data` unsigned rather than failing
+/// the build: an unsigned x86_64 image still executes.
+#[cfg(target_vendor = "apple")]
+fn codesign_adhoc(data: &[u8], tmp_path: &std::path::Path) -> Result<Vec<u8>, Error> {
+    if let Some(parent) = tmp_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(tmp_path, data)?;
+
+    match std::process::Command::new("codesign")
+        .arg("-s")
+        .arg("-")
+        .arg("-i")
+        .arg(apple_codesign::ADHOC_IDENTIFIER)
+        .arg(tmp_path)
+        .output()
+    {
+        Ok(output) => {
+            if !output.status.success() {
+                eprintln!(
+                    "Warning: Failed to adhoc codesign binary: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // codesign not found, skip it
+        }
+        Err(e) => {
+            std::fs::remove_file(tmp_path).ok();
+            return Err(e.into());
+        }
+    }
+
+    let signed = std::fs::read(tmp_path)?;
+    std::fs::remove_file(tmp_path).ok();
+    Ok(signed)
+}
+
 impl Macho {
     pub fn from(obj: Vec<u8>) -> Result<Self, Error> {
         let header = Header64::read_from_prefix(&obj)
@@ -937,44 +987,11 @@ impl Macho {
             // For Intel binaries, build to a temporary file and run adhoc codesign
             #[cfg(target_vendor = "apple")]
             {
-                let tmp_dir = std::env::temp_dir();
-                std::fs::create_dir_all(&tmp_dir)?;
-                let tmp_path = tmp_dir.join(format!("sui_sign_{}", std::process::id()));
-
-                {
-                    let mut tmp_file = std::fs::File::create(&tmp_path)?;
-                    self.build(&mut tmp_file)?;
-                }
-
-                // Run adhoc codesign
-                match std::process::Command::new("codesign")
-                    .arg("-s")
-                    .arg("-")
-                    .arg(&tmp_path)
-                    .output()
-                {
-                    Ok(output) => {
-                        if !output.status.success() {
-                            eprintln!(
-                                "Warning: Failed to adhoc codesign binary: {}",
-                                String::from_utf8_lossy(&output.stderr)
-                            );
-                        }
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                        // codesign not found, skip it
-                    }
-                    Err(e) => {
-                        std::fs::remove_file(&tmp_path).ok();
-                        return Err(e.into());
-                    }
-                }
-
-                // Read the (possibly signed) binary and write to output
-                let signed_data = std::fs::read(&tmp_path)?;
-                writer.write_all(&signed_data)?;
-                std::fs::remove_file(&tmp_path).ok();
-
+                let mut data = Vec::new();
+                self.build(&mut data)?;
+                let tmp_path =
+                    std::env::temp_dir().join(format!("sui_sign_{}", std::process::id()));
+                writer.write_all(&codesign_adhoc(&data, &tmp_path)?)?;
                 Ok(())
             }
 
@@ -1762,6 +1779,46 @@ pub mod utils {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Two compiles of one tree stage the x86_64 image at `sui_sign_<pid>`, so the
+    // staged file's NAME is the only per-run input `codesign` sees. Signing
+    // identical bytes under two names must therefore yield identical bytes.
+    //
+    // The input is a signature-stripped copy of the test binary — an arm64 image
+    // on an arm64 host, which is fine: `codesign_adhoc` never parses what it
+    // signs, and the arch dispatch it serves lives in `build_and_sign`.
+    #[cfg(target_vendor = "apple")]
+    #[test]
+    fn adhoc_signature_is_independent_of_the_staged_file_name() {
+        let dir = std::env::temp_dir().join(format!("sui_sign_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let input = dir.join("input");
+        std::fs::copy(std::env::current_exe().unwrap(), &input).unwrap();
+        // `codesign` refuses to sign an already-signed image, and the production
+        // x86_64 path is handed one `Macho::from` has already stripped.
+        let stripped = std::process::Command::new("codesign")
+            .arg("--remove-signature")
+            .arg(&input)
+            .status()
+            .unwrap();
+        assert!(stripped.success(), "could not strip the test input");
+        let data = std::fs::read(&input).unwrap();
+
+        let a = codesign_adhoc(&data, &dir.join("sui_sign_11111")).unwrap();
+        let b = codesign_adhoc(&data, &dir.join("sui_sign_22222")).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        // Positive control: a failing or absent `codesign` returns the input
+        // untouched, and the equality below would then hold for the wrong reason.
+        // Compared with `assert!` rather than `assert_ne!`/`assert_eq!` so a
+        // failure does not dump two multi-megabyte images into the output.
+        assert!(a != data, "codesign did not sign the staged image");
+        assert!(
+            a == b,
+            "the ad-hoc signature depends on the staged file's name"
+        );
+    }
 
     // Build a minimal arm64 Mach-O containing __TEXT, __LINKEDIT, and the
     // dyld-1284.13 commands LC_FUNCTION_VARIANTS / LC_FUNCTION_VARIANT_FIXUPS,


### PR DESCRIPTION
`nub compile --platform darwin-x64` did not produce the same bytes twice. Seven of eight targets were reproducible; darwin-x64 differed by the ASCII digits of the compiling process's PID.

libsui's x86_64 signing leg stages the image at `$TMPDIR/sui_sign_<pid>` and shells out to `codesign`. Without `-i`, `codesign` derives the CodeDirectory identifier from the file's basename, so the PID landed in the signed image:

```
run 1  Identifier=sui_sign_30145-5555494407935bcff598383ca6638cdd9460491e
run 2  Identifier=sui_sign_31424-5555494407935bcff598383ca6638cdd9460491e
```

arm64 was unaffected — it is signed in-process by `apple_codesign::MachoSigner`, which writes a fixed `a.out`. That identifier is now a shared constant, passed to `codesign -i` for x86_64, matching what `prepare_node_bytes` already does with `-i node` for the embedded Node re-sign.

After, on the same fixture:

| target | run 1 | run 2 | identifier |
| --- | --- | --- | --- |
| darwin-x64 | `603006b87717db55` | `603006b87717db55` | `a.out` |
| darwin-arm64 | `5be5bae6db61ffa3` | `5be5bae6db61ffa3` | `a.out` |

`codesign --verify --strict` passes on all four artifacts, and the arm64 one runs.

## Test

The x86_64 signing moved into `codesign_adhoc`, which takes the staged path as a parameter so a test can vary it: signing one input under two names must yield one result. It fails without the fix.

libsui's unit tests ran from nowhere — it is a member of no workspace, so `cargo test -p libsui` fails at the repo root and `cd vendor/libsui && cargo test` fails too. The nub-launcher workspace patches it in as a path dependency, so `-p libsui --lib` resolves there; wired into that workspace's existing per-OS CI step, which also picks up the Mach-O section test added earlier.
