### PR TITLE
compile: point the addon-mismatch advice at nub install's platform flags

### DIFF
--- a/crates/nub-cli/src/compile/native.rs
+++ b/crates/nub-cli/src/compile/native.rs
@@ -1637,18 +1637,19 @@ enum Classification {
 /// the platform defines make resolution pick the TARGET's platform package
 /// whenever one is installed, so a mismatch means it genuinely is not there.
 fn check_target(bytes: &[u8], path: &Path, target: &TargetPlatform) -> Result<()> {
-    // Names WHERE supportedArchitectures works, because it does not work
-    // everywhere: the engine reads it from an incumbent pnpm or yarn's own
-    // config, so a project using neither has no equivalent setting and the
-    // advice was unactionable for exactly the reader most likely to hit this.
+    // Leads with Nub's own `--os` / `--cpu` / `--libc` install flags, which work
+    // in every project. `supportedArchitectures` is the persistent form of the
+    // same selection, but the engine reads it only from an incumbent pnpm or
+    // yarn's config, so it is the second suggestion rather than the first.
     let advice = "\x20\x20A native addon is machine code for one platform, and a compiled binary \
                   loads it\n\x20\x20from a real file at run time — there is no later step that \
                   could translate it. The\n\x20\x20install has to put the target's own platform \
                   package on disk before you compile.\n\
-                  \n\x20\x20If this project uses pnpm or yarn, set supportedArchitectures.os, \
-                  .cpu and .libc\n\x20\x20in its config and install again. Otherwise install on \
-                  the target platform itself —\n\x20\x20a container of that platform is the \
-                  usual way — or drop --platform to build for\n\x20\x20this machine.";
+                  \n\x20\x20Select it for one install with nub install --os <os> --cpu <cpu> \
+                  --libc <libc>, or set\n\x20\x20supportedArchitectures.os, .cpu and .libc in \
+                  the project config and install again.\n\x20\x20If no prebuilt exists for the \
+                  target, install on the target platform itself — a\n\x20\x20container is the \
+                  usual way — or drop --platform to build for this machine.";
     let found = match classify(bytes) {
         Some(Classification::Object(found)) => found,
         Some(Classification::UnsupportedMachine { os }) => bail!(

--- a/crates/nub-cli/src/compile/native.rs
+++ b/crates/nub-cli/src/compile/native.rs
@@ -1637,19 +1637,18 @@ enum Classification {
 /// the platform defines make resolution pick the TARGET's platform package
 /// whenever one is installed, so a mismatch means it genuinely is not there.
 fn check_target(bytes: &[u8], path: &Path, target: &TargetPlatform) -> Result<()> {
-    // Leads with Nub's own `--os` / `--cpu` / `--libc` install flags, which work
-    // in every project. `supportedArchitectures` is the persistent form of the
-    // same selection, but the engine reads it only from an incumbent pnpm or
-    // yarn's config, so it is the second suggestion rather than the first.
+    // Names only Nub's own `--os` / `--cpu` / `--libc` install flags, which work
+    // in every project. The persistent `supportedArchitectures` setting is not
+    // offered: the engine reads it only from an incumbent pnpm or yarn's config,
+    // so for a nub, npm or bun project it is advice that cannot be followed.
     let advice = "\x20\x20A native addon is machine code for one platform, and a compiled binary \
                   loads it\n\x20\x20from a real file at run time — there is no later step that \
                   could translate it. The\n\x20\x20install has to put the target's own platform \
                   package on disk before you compile.\n\
-                  \n\x20\x20Select it for one install with nub install --os <os> --cpu <cpu> \
-                  --libc <libc>, or set\n\x20\x20supportedArchitectures.os, .cpu and .libc in \
-                  the project config and install again.\n\x20\x20If no prebuilt exists for the \
-                  target, install on the target platform itself — a\n\x20\x20container is the \
-                  usual way — or drop --platform to build for this machine.";
+                  \n\x20\x20Select it with nub install --os <os> --cpu <cpu> --libc <libc>, then \
+                  compile again.\n\x20\x20If no prebuilt exists for the target, install on the \
+                  target platform itself — a\n\x20\x20container is the usual way — or drop \
+                  --platform to build for this machine.";
     let found = match classify(bytes) {
         Some(Classification::Object(found)) => found,
         Some(Classification::UnsupportedMachine { os }) => bail!(

--- a/crates/nub-cli/src/compile/native_layout.rs
+++ b/crates/nub-cli/src/compile/native_layout.rs
@@ -513,14 +513,13 @@ fn ensure_metadata_matches(
     )
 }
 
-/// Leads with Nub's own `--os` / `--cpu` / `--libc` install flags, which work in
-/// every project, for the same reason [`super::native`]'s `check_target` does:
-/// `supportedArchitectures` is the persistent form of the same selection, but
-/// the engine reads it only from an incumbent pnpm or yarn's config.
+/// Names only Nub's own `--os` / `--cpu` / `--libc` install flags, for the same
+/// reason [`super::native`]'s `check_target` does: the persistent
+/// `supportedArchitectures` setting is read only from an incumbent pnpm or
+/// yarn's config, so it is advice a nub, npm or bun project cannot follow.
 fn architecture_advice() -> &'static str {
     "\x20\x20Install a compatible optional package before compiling.\n\
-     \n\x20\x20Select it for one install with nub install --os <os> --cpu <cpu> --libc <libc>, or set\n\
-     \x20\x20supportedArchitectures.os, .cpu and .libc in the project config and install again.\n\
+     \n\x20\x20Select it with nub install --os <os> --cpu <cpu> --libc <libc>, then compile again.\n\
      \x20\x20If no prebuilt exists for the target, install on the target platform itself; a\n\
      \x20\x20container is the usual way."
 }

--- a/crates/nub-cli/src/compile/native_layout.rs
+++ b/crates/nub-cli/src/compile/native_layout.rs
@@ -513,16 +513,16 @@ fn ensure_metadata_matches(
     )
 }
 
-/// Names WHERE `supportedArchitectures` works, for the same reason
-/// [`super::native`]'s `check_target` does: the engine reads that setting from
-/// an incumbent pnpm or yarn's own config. Every project can still select the
-/// target for one install with Nub's neutral `--os` / `--cpu` / `--libc` flags.
+/// Leads with Nub's own `--os` / `--cpu` / `--libc` install flags, which work in
+/// every project, for the same reason [`super::native`]'s `check_target` does:
+/// `supportedArchitectures` is the persistent form of the same selection, but
+/// the engine reads it only from an incumbent pnpm or yarn's config.
 fn architecture_advice() -> &'static str {
     "\x20\x20Install a compatible optional package before compiling.\n\
-     \n\x20\x20If this project uses pnpm or yarn, set supportedArchitectures.os, .cpu and .libc\n\
-     \x20\x20in its config and install again. Otherwise ask for them on the install itself —\n\
-     \x20\x20nub install --os <os> --cpu <cpu> --libc <libc> — or, if no prebuilt exists,\n\
-     \x20\x20install on the target platform; a container is the usual way."
+     \n\x20\x20Select it for one install with nub install --os <os> --cpu <cpu> --libc <libc>, or set\n\
+     \x20\x20supportedArchitectures.os, .cpu and .libc in the project config and install again.\n\
+     \x20\x20If no prebuilt exists for the target, install on the target platform itself; a\n\
+     \x20\x20container is the usual way."
 }
 
 /// Resolve a declared edge to an installed, readable package.

--- a/tests/windows/compile-cache-release.ps1
+++ b/tests/windows/compile-cache-release.ps1
@@ -200,7 +200,7 @@ setInterval(() => {}, 1000);
 
     $nubRoot = Join-Path $cache 'nub'
     $runtimeDirs = @(Get-ChildItem -LiteralPath $nubRoot -Directory -Filter 'runtime-*')
-    # nub names the reason it declined a cache base on stderr ("… is not usable for
+    # Nub names the reason it declined a cache base on stderr ("… is not usable for
     # the runtime cache (<reason>)"); without it a relocation reads as a bare count.
     if ($runtimeDirs.Count -ne 1) { throw "expected exactly one extracted runtime, got $($runtimeDirs.Count); cold-run stderr: $($cold.Stderr)" }
     $runtime = $runtimeDirs[0].FullName

--- a/tests/windows/compile-cache-release.ps1
+++ b/tests/windows/compile-cache-release.ps1
@@ -200,7 +200,9 @@ setInterval(() => {}, 1000);
 
     $nubRoot = Join-Path $cache 'nub'
     $runtimeDirs = @(Get-ChildItem -LiteralPath $nubRoot -Directory -Filter 'runtime-*')
-    if ($runtimeDirs.Count -ne 1) { throw "expected exactly one extracted runtime, got $($runtimeDirs.Count)" }
+    # nub names the reason it declined a cache base on stderr ("… is not usable for
+    # the runtime cache (<reason>)"); without it a relocation reads as a bare count.
+    if ($runtimeDirs.Count -ne 1) { throw "expected exactly one extracted runtime, got $($runtimeDirs.Count); cold-run stderr: $($cold.Stderr)" }
     $runtime = $runtimeDirs[0].FullName
     $workerBlob = Join-Path $runtime 'worker-blob-url.cjs'
     $addon = Join-Path $runtime 'addons\nub-native.node'


### PR DESCRIPTION
The two cross-compile refusals for a native addon named only pnpm and yarn's `supportedArchitectures`. The advice now leads with `nub install --os <os> --cpu <cpu> --libc <libc>`, which works in every project, then the setting, then the target-platform fallback. Re-captured from the built binary against a `sharp` fixture.