### PR TITLE
ci: give two dead rust-cache keys a writer and path-gate the docs-only builds

### DIFF
--- a/.github/workflows/aube-parity.yml
+++ b/.github/workflows/aube-parity.yml
@@ -73,9 +73,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read — see the note in daily-driver.yml.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: vendor/aube
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run aube's own test suite
         working-directory: vendor/aube
         run: cargo test --workspace
@@ -112,9 +114,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read — see the note in daily-driver.yml.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: vendor/aube
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run aube's own test suite
         working-directory: vendor/aube
         run: cargo test --workspace
@@ -136,7 +140,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read — see the note in daily-driver.yml.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"
@@ -164,7 +171,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read — see the note in daily-driver.yml.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"
@@ -204,7 +214,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read — see the note in daily-driver.yml.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,11 +383,15 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
-      # Throwaway job: read-only cache (save-if: false) so it never churns the budget.
+      # `save-if: main`, NOT `save-if: false`. This key had no writer anywhere in the
+      # repo, so every run — PR and trunk alike — logged "No cache found." and paid a
+      # cold ~24 min release build of nub.exe before reaching the first gate. A
+      # read-only cache is only cheap when something else fills it; with no writer it
+      # is the most expensive setting available. Trunk fills it, PRs read it.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           shared-key: ci-win-embed-roundtrip
-          save-if: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             .
             crates/nub-native
@@ -742,9 +746,20 @@ jobs:
   # extract -> verify -> dlopen -> execute -> warm reuse -> R2 zero-false-positive +
   # self-heal. Non-blocking (NOT in ci-gate); the verify LOGIC is ci-gate-required via
   # the embed-runtime macos leg. Delete alongside windows-embed-roundtrip post-decision.
+  #
+  # It now runs on trunk as well as pull requests, for the cache below: the job builds a
+  # release binary from scratch, and a PR-only job can never populate a trunk-scoped
+  # cache, so it was cold on every single run. Trunk pays that cold build once per
+  # Rust-relevant push; every PR after it restores. It is also gated on `run_rust` — a
+  # docs- or site-only PR cannot change what this builds, yet before the gate this job
+  # was the ENTIRE wall time of such a PR's CI run (~17 min on a macos-14 runner, while
+  # every Rust job around it correctly skipped).
   macos-embed-roundtrip:
     name: macOS embed round-trip (TEMPORARY, PR #175)
-    if: github.event_name == 'pull_request'
+    needs: matrix-plan
+    if: >-
+      needs.matrix-plan.outputs.run_rust == 'true' &&
+      (github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
     runs-on: macos-14
     permissions:
       contents: read
@@ -763,7 +778,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           shared-key: ci-mac-embed-roundtrip
-          save-if: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             .
             crates/nub-native
@@ -919,8 +934,9 @@ jobs:
           echo "ROUND-TRIP OK (macOS): extract -> verify -> dlopen -> execute -> warm reuse -> R2"
 
       # PUBLISH THE BINARY THIS JOB ALREADY BUILT. The release build above is the whole
-      # cost of a downloadable macOS dev build, and it is paid on every PR either way —
-      # so the artifact is worth seconds of upload rather than a second macOS job. One
+      # cost of a downloadable macOS dev build, and it is paid by every run that reaches
+      # here either way (every Rust-relevant PR, plus trunk, which is what fills the
+      # cache) — so the artifact is worth seconds of upload rather than a second job. One
       # file, not two: --features embed-runtime carries the addon and the vendored
       # runtime inside the binary, so this is standalone and needs no checkout to run.
       # The round-trip step above tampers only with the EXTRACTED cache copy, so
@@ -956,7 +972,9 @@ jobs:
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: nub-macos-arm64-pr${{ github.event.pull_request.number }}
+          # The job also runs on trunk now, where pull_request.number is empty; name the
+          # trunk artifact by SHA so it is not a bare `-pr` suffix.
+          name: nub-macos-arm64-${{ github.event_name == 'pull_request' && format('pr{0}', github.event.pull_request.number) || format('main-{0}', github.sha) }}
           path: dist/
           retention-days: 7
           if-no-files-found: error

--- a/.github/workflows/daily-driver.yml
+++ b/.github/workflows/daily-driver.yml
@@ -55,7 +55,14 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read. A cache saved from a PR ref is visible only to
+      # that ONE pull request, yet it still counts against the repository-wide 10 GB
+      # budget — so unconditional saving here evicted the shared trunk caches that every
+      # other job restores from. Same reasoning in native-deps, lockfile-roundtrip,
+      # aube-parity and verb-dispatch.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5
         with:
           version: 10

--- a/.github/workflows/lockfile-roundtrip.yml
+++ b/.github/workflows/lockfile-roundtrip.yml
@@ -85,7 +85,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read — see the note in daily-driver.yml.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"
@@ -121,7 +124,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read — see the note in daily-driver.yml.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"
@@ -152,7 +158,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read — see the note in daily-driver.yml.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"
@@ -190,7 +199,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read — see the note in daily-driver.yml.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"

--- a/.github/workflows/native-deps.yml
+++ b/.github/workflows/native-deps.yml
@@ -57,7 +57,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      # Trunk writes, pull requests read — see the note in daily-driver.yml.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: "24"

--- a/.github/workflows/node-matrix.yml
+++ b/.github/workflows/node-matrix.yml
@@ -18,11 +18,28 @@ name: Node matrix
 #   - push:main + nightly: the FULL version matrix + both real-app builds.
 #   - concurrency group with cancel-in-progress so superseded runs free their slots.
 
+# The path filter is `paths-ignore`, not `paths`, and the direction is deliberate: a
+# `paths` allowlist fails CLOSED — a new Rust directory nobody remembered to add would
+# silently stop running this workflow — while `paths-ignore` fails toward RUNNING, and
+# GitHub skips the workflow only when EVERY changed file matches. The listed surfaces
+# cannot change what `Build nub (once)` compiles, and that build is otherwise ~4 min of
+# Rust on a docs-only pull request. The nightly cron ignores path filters entirely, so
+# the full matrix still runs daily regardless.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "wiki/**"
+      - "*.md"
+      - ".claude/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "wiki/**"
+      - "*.md"
+      - ".claude/**"
   schedule:
     # Nightly full matrix at 05:00 UTC (offset from the other nightlies: CI 06:00,
     # lockfile-roundtrip 07:00, pnpm-conformance 08:00).

--- a/.github/workflows/verb-dispatch.yml
+++ b/.github/workflows/verb-dispatch.yml
@@ -19,12 +19,26 @@ name: Verb dispatch (one-binary platform package)
 #            changes Windows got a correctly-named `nubx.exe` and needed no verb
 #            plumbing, and launcher.yml still excludes Windows for that stale reason.
 #
-# Runs on pull_request for the paths below, plus workflow_dispatch. It was branch-scoped
-# while this was an exploratory probe; a branch filter left on main would name a deleted
-# branch and silently never fire.
-
+# Runs on pull_request and push:main for the paths below, plus workflow_dispatch. It was
+# branch-scoped while this was an exploratory probe; a branch filter left on main would
+# name a deleted branch and silently never fire.
+#
+# The push:main leg exists for the Rust cache. GitHub scopes a cache to the ref that
+# wrote it, so a pull-request-only workflow can only ever write caches that one PR can
+# read — four ~500 MB copies per PR, charged against the repository-wide 10 GB budget
+# and evicting the shared trunk caches every other workflow restores from. Trunk writes
+# them once; every PR reads them.
 on:
   pull_request:
+    paths:
+      - crates/nub-cli/**
+      - npm/nub/**
+      - tests/verb-dispatch/**
+      - .github/workflows/verb-dispatch.yml
+  # Keep this list in step with the pull_request one above. GitHub Actions does not
+  # support YAML anchors, so the two are duplicated rather than shared.
+  push:
+    branches: [main]
     paths:
       - crates/nub-cli/**
       - npm/nub/**
@@ -57,6 +71,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           key: verb-dispatch-${{ matrix.os }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # `fast` (not `release`): the probe asserts DISPATCH, which is independent of
       # optimization level, and release's thin-LTO would roughly triple the job for
@@ -112,6 +127,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           key: verb-dispatch-release-${{ matrix.os }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # RELEASE, not `fast`: the question is about the shipped binary. A fast build
       # carries debuginfo at roughly 3x the size, which moves image-load time and would

--- a/.github/workflows/wpt-worker.yml
+++ b/.github/workflows/wpt-worker.yml
@@ -14,14 +14,28 @@ name: WPT Worker
 # tier), and the latest major.
 #
 # COST MODEL mirrors node-matrix.yml: build nub ONCE, reuse the bundle across every Node
-# leg (the Node version is a setup-node/PATH choice, not a rebuild). The runner is cheap
-# (subprocess-per-file, ~seconds), so every push/PR is fine.
+# leg (the Node version is a setup-node/PATH choice, not a rebuild). The runner legs are
+# cheap (subprocess-per-file, ~seconds); the one real cost is that single build, which is
+# what the path filter below keeps off changes that cannot affect it.
 
+# `paths-ignore` rather than a `paths` allowlist, for the fail-toward-running reason
+# spelled out in node-matrix.yml. `Build nub (WPT)` is ~13 min of Rust that a docs- or
+# site-only change cannot affect, and it was the longest job such a pull request ran.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "wiki/**"
+      - "*.md"
+      - ".claude/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "wiki/**"
+      - "*.md"
+      - ".claude/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
`ci-win-embed-roundtrip` and `ci-mac-embed-roundtrip` were `save-if: false` with no writer in the repo. Both logged `No cache found.` and cold-built a release binary: 24 and 12 min (runs 33890307588, 33888414113). Trunk now writes them.

Thirteen rust-cache steps set no `save-if`, saving from PR refs. Such a cache is readable only by that PR but counts against the 10 GB budget: 10.27 GB total, 4.57 GB on one PR ref. Now main-only; verb-dispatch gains push:main so it has a writer.

macos-embed-roundtrip, wpt-worker and node-matrix built Rust on docs-only PRs — 17, 13 and 4 min, the whole wall time of #826. Now gated on `run_rust` / `paths-ignore`.