### PR TITLE
ci: key concurrency groups on the event name so a push cannot cancel the nightly

### DIFF
--- a/.github/workflows/aube-parity.yml
+++ b/.github/workflows/aube-parity.yml
@@ -46,8 +46,12 @@ on:
     # the path filters above and exercise the full workflow.
     - cron: "30 6 * * *"
 
+# The event name is part of the group so a trunk push cannot cancel the nightly
+# schedule run. rust-cache saves in a post-step that a cancelled job never reaches,
+# and 34 of the last 39 push:main runs were cancelled by the next push — so the
+# nightly is the one run guaranteed to refresh every trunk-scoped cache key.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,12 @@ on:
 # No-scope default token; each job opts into the read scopes its steps use.
 permissions: {}
 
+# The event name is part of the group so a trunk push cannot cancel the nightly
+# schedule run. rust-cache saves in a post-step that a cancelled job never reaches,
+# and 34 of the last 39 push:main runs were cancelled by the next push — so the
+# nightly is the one run guaranteed to refresh every trunk-scoped cache key.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/lockfile-roundtrip.yml
+++ b/.github/workflows/lockfile-roundtrip.yml
@@ -57,8 +57,12 @@ on:
 
 permissions: {}
 
+# The event name is part of the group so a trunk push cannot cancel the nightly
+# schedule run. rust-cache saves in a post-step that a cancelled job never reaches,
+# and 34 of the last 39 push:main runs were cancelled by the next push — so the
+# nightly is the one run guaranteed to refresh every trunk-scoped cache key.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/node-matrix.yml
+++ b/.github/workflows/node-matrix.yml
@@ -48,8 +48,12 @@ on:
 
 permissions: {}
 
+# The event name is part of the group so a trunk push cannot cancel the nightly
+# schedule run. rust-cache saves in a post-step that a cancelled job never reaches,
+# and 34 of the last 39 push:main runs were cancelled by the next push — so the
+# nightly is the one run guaranteed to refresh every trunk-scoped cache key.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
rust-cache saves in a post-step that a cancelled job never reaches, and 34 of the last 39 push:main ci.yml runs were cancelled by the next push. With the event name in the concurrency group, the scheduled run is the one guaranteed to refresh every trunk-scoped cache key. Same change in aube-parity, lockfile-roundtrip and node-matrix, the other workflows with a Rust cache and a schedule. Follow-up to #876.