### PR TITLE
compile: skip eager builtin loads a payload never needs

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -51,3 +51,15 @@ symlink .fray
 # clobbering it for every sibling. A missing source is skipped, so a tree that
 # has never built the addon still creates worktrees fine.
 copy runtime/addons/nub-native.node
+
+# The vendored polyfill packages the compile preamble imports (urlpattern,
+# Temporal, Float16Array). Without them 49 compile bundle tests fail in a fresh
+# worktree with `Cannot find module 'urlpattern-polyfill/urlpattern'` — a
+# confusing failure that looks like a code defect. CI never hits it because a
+# Node 26 target strips those polyfill regions before they are resolved.
+# COPIED, not symlinked, and 5 MB: a symlink resolves into the SHARED tree, which
+# puts the packages outside the worktree's own runtime directory. The compile
+# preamble's builtin-usage scan classifies anything outside that directory as
+# APPLICATION code, so a symlink would make it read nub's own polyfills as app
+# usage and keep eager builtin loads no payload asked for.
+copy runtime/node_modules

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -1949,6 +1949,44 @@ fn strip_regions(source: &str, prefix: &str, drop: &[&str]) -> String {
     out
 }
 
+/// Can this module reach a builtin by a name the substring scan cannot read?
+///
+/// Compiled CommonJS deliberately PRESERVES a non-static `require(expr)` rather
+/// than failing the build (see [`Requires::classify_require`], which declines to
+/// flag them because every real instance measured was a guarded optional loader).
+/// That is correct for the bundler and fatal for a literal scan:
+/// `require(["child", "process"].join("_")).fork(...)` reaches the builtin naming
+/// neither marker, and stripping the fork identity patch there would let `fork()`
+/// silently re-run the artifact instead of real Node.
+///
+/// So a module that can compute a specifier counts as using EVERYTHING. The same
+/// applies to the indirect accessors, which take a specifier this scan never sees.
+/// A template literal counts as computed even when its body is constant — the
+/// distinction is not worth reading, and the cheap answer is the safe one.
+fn has_computed_module_access(code: &str) -> bool {
+    for accessor in ["createRequire", "getBuiltinModule", "process.binding"] {
+        if code.contains(accessor) {
+            return true;
+        }
+    }
+    for call in ["require(", "import("] {
+        let mut rest = code;
+        while let Some(at) = rest.find(call) {
+            rest = &rest[at + call.len()..];
+            // A specifier this scan CAN read starts with a plain quote once
+            // whitespace is skipped. Anything else — an identifier, a call, a
+            // concatenation, a template — is computed.
+            if !matches!(
+                rest.trim_start().as_bytes().first(),
+                Some(b'"') | Some(b'\'')
+            ) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Drop the bootstrap's eager builtin loads when the APP graph never names them.
 ///
 /// Loading `node:child_process` costs ~1.9 ms and `node:worker_threads` ~1.4 ms on
@@ -2060,6 +2098,14 @@ impl CompilePreamble {
         // on every payload and nothing is ever stripped. Its transitive imports are
         // real paths under the runtime tree and the second test covers those.
         if id.starts_with('\0') || Path::new(clean_url(id)).starts_with(&self.runtime_dir) {
+            return;
+        }
+        // A module that can COMPUTE a specifier defeats substring matching outright,
+        // so it counts as using everything. See [`has_computed_module_access`].
+        if has_computed_module_access(code) {
+            self.app_uses_child_process
+                .store(true, AtomicOrdering::Relaxed);
+            self.app_uses_worker.store(true, AtomicOrdering::Relaxed);
             return;
         }
         if code.contains("child_process") || code.contains("cluster") {
@@ -9904,6 +9950,59 @@ after
             uses(&app_worker),
             (false, true),
             "an application module naming Worker must keep only that load"
+        );
+    }
+
+    /// A module that can compute a specifier keeps every eager load.
+    ///
+    /// This is the hole a literal scan leaves: compiled CommonJS preserves a
+    /// non-static `require(expr)`, so `require(["child", "process"].join("_"))`
+    /// reaches the builtin naming neither marker. Stripping there would drop the
+    /// fork identity patch and let `fork()` re-run the artifact with no error
+    /// raised, which is the silent failure this whole scan is written around.
+    #[test]
+    fn a_computed_specifier_keeps_every_eager_load() {
+        for computed in [
+            r#"require(["child", "process"].join("_"))"#,
+            r#"const m = "fs"; require(m);"#,
+            r#"await import(specifier)"#,
+            r#"createRequire(import.meta.url)("child_process")"#,
+            r#"process.getBuiltinModule(name)"#,
+            "require(`fs`)", // a template is not read, and cheap-and-safe wins
+        ] {
+            assert!(
+                has_computed_module_access(computed),
+                "must be treated as computed: {computed}"
+            );
+        }
+
+        // The negative half is what keeps the optimisation alive at all: if every
+        // ordinary module read as computed, nothing would ever be stripped and the
+        // positive assertions above would still pass.
+        for literal in [
+            r#"import { readFile } from "node:fs/promises";"#,
+            r#"const fs = require("node:fs");"#,
+            r#"await import("./chunk.mjs")"#,
+            r#"console.log("plain");"#,
+        ] {
+            assert!(
+                !has_computed_module_access(literal),
+                "must stay readable: {literal}"
+            );
+        }
+
+        // And the whole point: a computed specifier forces BOTH loads, even though
+        // it names neither builtin.
+        let p = CompilePreamble::from_source(
+            Path::new("/app/entry.ts"),
+            PathBuf::from("/nub/runtime"),
+            String::new(),
+        );
+        p.note_app_builtin_usage("/app/entry.ts", r#"require(["child","process"].join("_"))"#);
+        assert!(
+            p.app_uses_child_process.load(AtomicOrdering::Relaxed)
+                && p.app_uses_worker.load(AtomicOrdering::Relaxed),
+            "an unreadable specifier must keep every eager load"
         );
     }
 

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -38,6 +38,7 @@ use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -707,14 +708,20 @@ fn bundle_inner(
         report.finish(&emitted, &modules, &edge_kinds, &external_imports)
     });
 
+    // Before `root_support_files` reads the decision: islands bypass `transform`,
+    // so this is the only place their usage can be folded in.
+    for file in &native_files {
+        prelude.note_island_usage(&file.bytes);
+    }
+
     Ok(BundleResult {
         entry,
         files,
         detached_maps,
         assets,
-        native_files,
         support_files: prelude.support_files().collect(),
         root_support_files: prelude.root_support_files().collect(),
+        native_files,
         dynamic_import_sites,
         native_addons,
         external_imports,
@@ -1853,6 +1860,12 @@ struct CompilePreamble {
     /// Runtime bootstrap extracted at the payload root rather than beside the
     /// content-addressed bundle layout. The launcher loads it before the entry.
     root_support_files: Vec<(String, Vec<u8>)>,
+    /// Whether an APP module — the graph minus nub's own runtime tree — names a
+    /// builtin the bootstrap would otherwise load eagerly. Written from `transform`,
+    /// which Rolldown drives concurrently, so these are atomics rather than a lock.
+    /// See [`strip_unused_bootstrap_regions`].
+    app_uses_child_process: AtomicBool,
+    app_uses_worker: AtomicBool,
 }
 
 /// Polyfills the compile preamble installs, and the first Node version that ships
@@ -1904,12 +1917,22 @@ fn strip_native_polyfills(source: &str, target: Option<(u64, u64, u64)>) -> Stri
     if native.is_empty() {
         return source.to_string();
     }
+    strip_regions(source, "// #region nub:polyfill:", &native)
+}
+
+/// Remove `<prefix><name>` … `// #endregion` blocks for every name in `drop`.
+///
+/// The region contract is the same wherever it is used and it lives across two
+/// files: each region must be independently removable and must leave valid syntax
+/// behind, so the source it guards is written to survive its own deletion. Regions
+/// do not nest — the first `// #endregion` closes the block.
+fn strip_regions(source: &str, prefix: &str, drop: &[&str]) -> String {
     let mut out = String::with_capacity(source.len());
     let mut skipping = false;
     for line in source.lines() {
         let trimmed = line.trim();
-        if let Some(name) = trimmed.strip_prefix("// #region nub:polyfill:") {
-            if native.contains(&name) {
+        if let Some(name) = trimmed.strip_prefix(prefix) {
+            if drop.contains(&name) {
                 skipping = true;
                 continue;
             }
@@ -1924,6 +1947,40 @@ fn strip_native_polyfills(source: &str, target: Option<(u64, u64, u64)>) -> Stri
         out.push('\n');
     }
     out
+}
+
+/// Drop the bootstrap's eager builtin loads when the APP graph never names them.
+///
+/// Loading `node:child_process` costs ~1.9 ms and `node:worker_threads` ~1.4 ms on
+/// every run of the artifact (measured on a quiet CI runner against interleaved
+/// duplicate baselines; 2.3 ms together, since they share a subgraph). A payload
+/// that touches neither pays that for nothing.
+///
+/// The scan behind `uses_*` covers the graph MINUS nub's own runtime tree, and that
+/// exclusion is what makes it work at all: the preamble bundles `worker-polyfill.mjs`
+/// (which declares `class Worker`) and `preload-common.cjs` (which names
+/// `child_process`), so a scan over the FINISHED chunks matches on every payload —
+/// verified against a bare `console.log("hello")`, which carries all four markers —
+/// and would strip nothing, ever.
+fn strip_unused_bootstrap_regions(
+    source: &[u8],
+    uses_child_process: bool,
+    uses_worker: bool,
+) -> Vec<u8> {
+    let Ok(text) = std::str::from_utf8(source) else {
+        return source.to_vec();
+    };
+    let mut drop: Vec<&str> = Vec::new();
+    if !uses_child_process {
+        drop.push("childprocess");
+    }
+    if !uses_worker {
+        drop.push("worker");
+    }
+    if drop.is_empty() {
+        return source.to_vec();
+    }
+    strip_regions(text, "// #region nub:compile:", &drop).into_bytes()
 }
 
 impl CompilePreamble {
@@ -1963,6 +2020,48 @@ impl CompilePreamble {
             ]))),
             support_files: Vec::new(),
             root_support_files: Vec::new(),
+            app_uses_child_process: AtomicBool::new(false),
+            app_uses_worker: AtomicBool::new(false),
+        }
+    }
+
+    /// Fold a native-addon island into the same decision.
+    ///
+    /// An island is a verbatim copy of a package directory rather than a bundled
+    /// module, so its files never reach [`Plugin::transform`] and the scan there
+    /// cannot see them. Island code runs in the artifact's own process, so an
+    /// island calling `fork` needs the identity fix-up exactly as application code
+    /// does. Scanned as raw bytes because an island carries binaries as well as
+    /// JavaScript; a stray match inside a `.node` only keeps a load.
+    fn note_island_usage(&self, bytes: &[u8]) {
+        let contains = |needle: &[u8]| bytes.windows(needle.len()).any(|w| w == needle);
+        if contains(b"child_process") || contains(b"cluster") {
+            self.app_uses_child_process
+                .store(true, AtomicOrdering::Relaxed);
+        }
+        if contains(b"worker_threads") || contains(b"Worker") {
+            self.app_uses_worker.store(true, AtomicOrdering::Relaxed);
+        }
+    }
+
+    /// Note that an application module names a builtin whose eager load in the
+    /// bootstrap cannot then be stripped.
+    ///
+    /// Substring matching over source text, deliberately. It over-detects — a
+    /// variable named `cluster` or a comment mentioning `Worker` is enough — and
+    /// that is the safe direction: a false positive keeps an eager load the payload
+    /// did not need and costs startup, whereas a false negative ships an artifact
+    /// whose `fork` is never identity-corrected, which is the failure that silently
+    /// bypassed the policy for every cluster worker before it was fixed.
+    fn note_app_builtin_usage(&self, id: &str, code: &str) {
+        if Path::new(clean_url(id)).starts_with(&self.runtime_dir) {
+            return;
+        }
+        if code.contains("child_process") || code.contains("cluster") {
+            self.app_uses_child_process.store(true, AtomicOrdering::Relaxed);
+        }
+        if code.contains("worker_threads") || code.contains("Worker") {
+            self.app_uses_worker.store(true, AtomicOrdering::Relaxed);
         }
     }
 
@@ -1977,13 +2076,23 @@ impl CompilePreamble {
         })
     }
 
+    /// Collected AFTER the graph is walked, which is what makes the strip possible:
+    /// the bootstrap is not bundled, so unlike the preamble it can still be rewritten
+    /// once every application module has been seen.
     fn root_support_files(&self) -> impl Iterator<Item = BundledFile> + '_ {
-        self.root_support_files
-            .iter()
-            .map(|(name, bytes)| BundledFile {
+        let uses_child_process = self.app_uses_child_process.load(AtomicOrdering::Relaxed);
+        let uses_worker = self.app_uses_worker.load(AtomicOrdering::Relaxed);
+        self.root_support_files.iter().map(move |(name, bytes)| {
+            let bytes = if name == nub_core::compile::COMPILE_BOOTSTRAP_NAME {
+                strip_unused_bootstrap_regions(bytes, uses_child_process, uses_worker)
+            } else {
+                bytes.clone()
+            };
+            BundledFile {
                 name: name.clone(),
-                bytes: bytes.clone(),
-            })
+                bytes,
+            }
+        })
     }
 
     /// Register `source` as a static worker root and return the virtual entry id
@@ -2266,6 +2375,7 @@ impl Plugin for CompilePreamble {
         _ctx: SharedTransformPluginContext,
         args: &HookTransformArgs<'_>,
     ) -> impl Future<Output = HookTransformReturn> + Send {
+        self.note_app_builtin_usage(args.id, args.code);
         let root = self.is_root_source(args.id);
         let rewritten = if root {
             let cjs = rewrite_entry_main_checks(clean_url(args.id), args.code);
@@ -9722,6 +9832,73 @@ after
         // Surrounding code always survives — otherwise the assertions above could
         // pass by the stripper eating the whole file.
         for out in [&n26, &n24, &n18] {
+            assert!(
+                out.contains("before") && out.contains("after"),
+                "the stripper must only remove its own regions"
+            );
+        }
+    }
+
+    /// The bootstrap keeps an eager builtin load exactly when the app graph names
+    /// it, and the two regions are independent.
+    ///
+    /// The KEPT direction is the one that matters. Dropping the `childprocess`
+    /// region when the payload does use `fork`/`cluster` produces an artifact whose
+    /// child processes silently re-run the executable itself — a wrong answer with
+    /// no error — so every uncertain case must land on "keep".
+    #[test]
+    fn the_bootstrap_keeps_a_builtin_load_the_app_graph_names() {
+        let src = b"\
+before
+let needsChildProcess = false;
+let needsWorker = false;
+// #region nub:compile:childprocess
+needsChildProcess = true;
+// #endregion
+// #region nub:compile:worker
+needsWorker = true;
+// #endregion
+after
+";
+        let text = |v: Vec<u8>| String::from_utf8(v).expect("stripper must emit UTF-8");
+
+        let neither = text(strip_unused_bootstrap_regions(src, false, false));
+        assert!(
+            !neither.contains("needsChildProcess = true")
+                && !neither.contains("needsWorker = true"),
+            "a payload naming neither builtin must carry neither eager load"
+        );
+
+        let both = text(strip_unused_bootstrap_regions(src, true, true));
+        assert_eq!(
+            both,
+            String::from_utf8(src.to_vec()).unwrap(),
+            "a payload naming both must be left exactly as written"
+        );
+
+        // Independence: stripping one region must not disturb the other.
+        let cp_only = text(strip_unused_bootstrap_regions(src, true, false));
+        assert!(
+            cp_only.contains("needsChildProcess = true")
+                && !cp_only.contains("needsWorker = true"),
+            "child_process usage alone must keep only that region"
+        );
+        let worker_only = text(strip_unused_bootstrap_regions(src, false, true));
+        assert!(
+            !worker_only.contains("needsChildProcess = true")
+                && worker_only.contains("needsWorker = true"),
+            "Worker usage alone must keep only that region"
+        );
+
+        // Every variant must still assign the flags and keep surrounding code, or
+        // the assertions above could pass by the stripper eating the whole file and
+        // leaving an undefined binding behind.
+        for out in [&neither, &both, &cp_only, &worker_only] {
+            assert!(
+                out.contains("let needsChildProcess = false")
+                    && out.contains("let needsWorker = false"),
+                "the `false` initializers are what make a region removable"
+            );
             assert!(
                 out.contains("before") && out.contains("after"),
                 "the stripper must only remove its own regions"

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -2063,7 +2063,8 @@ impl CompilePreamble {
             return;
         }
         if code.contains("child_process") || code.contains("cluster") {
-            self.app_uses_child_process.store(true, AtomicOrdering::Relaxed);
+            self.app_uses_child_process
+                .store(true, AtomicOrdering::Relaxed);
         }
         if code.contains("worker_threads") || code.contains("Worker") {
             self.app_uses_worker.store(true, AtomicOrdering::Relaxed);
@@ -9887,7 +9888,10 @@ after
         // The positive control. Without it the assertions above would pass just as
         // well against a scan that never records anything at all.
         let app = fresh();
-        app.note_app_builtin_usage("/app/entry.ts", "import { fork } from 'node:child_process';");
+        app.note_app_builtin_usage(
+            "/app/entry.ts",
+            "import { fork } from 'node:child_process';",
+        );
         assert_eq!(
             uses(&app),
             (true, false),
@@ -9943,8 +9947,7 @@ after
         // Independence: stripping one region must not disturb the other.
         let cp_only = text(strip_unused_bootstrap_regions(src, true, false));
         assert!(
-            cp_only.contains("needsChildProcess = true")
-                && !cp_only.contains("needsWorker = true"),
+            cp_only.contains("needsChildProcess = true") && !cp_only.contains("needsWorker = true"),
             "child_process usage alone must keep only that region"
         );
         let worker_only = text(strip_unused_bootstrap_regions(src, false, true));

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -1990,7 +1990,15 @@ fn argument_is_one_static_string(after_paren: &str) -> bool {
         match bytes.get(i) {
             // Unterminated within this slice — unreadable, so treat it as computed.
             None => return false,
-            Some(b'\\') => i += 2,
+            // An ESCAPE makes the literal's VALUE differ from its SPELLING, and the
+            // marker check that follows reads the spelling. A specifier written with
+            // `_` in place of the underscore is perfectly static and resolves
+            // the builtin at run time, while containing no contiguous marker — so
+            // accepting it would strip the fork patch for a payload that really
+            // forks. Decoding would be the precise answer; declining to read an
+            // escaped literal is the cheap one, and costs an eager load only on a
+            // spelling almost nobody writes.
+            Some(b'\\') => return false,
             Some(&c) if c == quote => break i + 1,
             _ => i += 1,
         }
@@ -10007,6 +10015,11 @@ after
             r#"require("child" + "_process")"#,
             r#"await import("node:" + name)"#,
             r#"require("fs".concat(""))"#,
+            // An ESCAPED literal is static, but its spelling is not the marker, so
+            // the substring scan that follows finds nothing in it. Both spellings
+            // resolve the builtin at run time.
+            r#"require("child\u005fprocess")"#,
+            r#"require("child\x5fprocess")"#,
         ] {
             assert!(
                 has_computed_module_access(computed),
@@ -10059,6 +10072,21 @@ after
             split.app_uses_child_process.load(AtomicOrdering::Relaxed)
                 && split.app_uses_worker.load(AtomicOrdering::Relaxed),
             "a quoted-prefix concatenation must keep every eager load"
+        );
+
+        // And for a literal whose SPELLING is not its value. This one is fully
+        // static, so the specifier reader would accept it, while the marker scan
+        // that follows reads the raw text and finds nothing.
+        let escaped = CompilePreamble::from_source(
+            Path::new("/app/entry.ts"),
+            PathBuf::from("/nub/runtime"),
+            String::new(),
+        );
+        escaped.note_app_builtin_usage("/app/entry.ts", r#"require("child\u005fprocess").fork(m)"#);
+        assert!(
+            escaped.app_uses_child_process.load(AtomicOrdering::Relaxed)
+                && escaped.app_uses_worker.load(AtomicOrdering::Relaxed),
+            "an escaped builtin spelling must keep every eager load"
         );
     }
 

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -2054,7 +2054,12 @@ impl CompilePreamble {
     /// whose `fork` is never identity-corrected, which is the failure that silently
     /// bypassed the policy for every cluster worker before it was fixed.
     fn note_app_builtin_usage(&self, id: &str, code: &str) {
-        if Path::new(clean_url(id)).starts_with(&self.runtime_dir) {
+        // A leading NUL is Rollup's plugin-only namespace, which here means one of
+        // this compiler's own virtual roots — and the PREAMBLE is served from one.
+        // Its source names every marker, so without this the scan sets both flags
+        // on every payload and nothing is ever stripped. Its transitive imports are
+        // real paths under the runtime tree and the second test covers those.
+        if id.starts_with('\0') || Path::new(clean_url(id)).starts_with(&self.runtime_dir) {
             return;
         }
         if code.contains("child_process") || code.contains("cluster") {
@@ -9837,6 +9842,65 @@ after
                 "the stripper must only remove its own regions"
             );
         }
+    }
+
+    /// The usage scan counts application modules and ignores the compiler's own.
+    ///
+    /// Written after shipping the inverse by accident: the preamble is served from
+    /// a virtual id rather than a path under the runtime tree, so excluding only
+    /// the runtime tree let the preamble's own source — which names every marker —
+    /// set both flags on every payload, and nothing was ever stripped. The failure
+    /// was silent, because over-detection only costs startup.
+    #[test]
+    fn the_builtin_scan_ignores_the_compilers_own_modules() {
+        let every_marker = "child_process cluster worker_threads Worker";
+        let fresh = || {
+            CompilePreamble::from_source(
+                Path::new("/app/entry.ts"),
+                PathBuf::from("/nub/runtime"),
+                String::new(),
+            )
+        };
+        let uses = |p: &CompilePreamble| {
+            (
+                p.app_uses_child_process.load(AtomicOrdering::Relaxed),
+                p.app_uses_worker.load(AtomicOrdering::Relaxed),
+            )
+        };
+
+        let virtual_root = fresh();
+        virtual_root.note_app_builtin_usage(COMPILE_PREAMBLE_ID, every_marker);
+        assert_eq!(
+            uses(&virtual_root),
+            (false, false),
+            "the preamble's own virtual module must not count as application usage"
+        );
+
+        let runtime_file = fresh();
+        runtime_file.note_app_builtin_usage("/nub/runtime/worker-polyfill.mjs", every_marker);
+        assert_eq!(
+            uses(&runtime_file),
+            (false, false),
+            "a file in nub's runtime tree must not count as application usage"
+        );
+
+        // The positive control. Without it the assertions above would pass just as
+        // well against a scan that never records anything at all.
+        let app = fresh();
+        app.note_app_builtin_usage("/app/entry.ts", "import { fork } from 'node:child_process';");
+        assert_eq!(
+            uses(&app),
+            (true, false),
+            "an application module naming child_process must keep only that load"
+        );
+
+        let app_worker = fresh();
+        app_worker.note_app_builtin_usage("/app/entry.ts", "const w = new Worker(url);");
+        assert_eq!(
+            uses(&app_worker),
+            (false, true),
+            "an application module naming Worker must keep only that load"
+        );
     }
 
     /// The bootstrap keeps an eager builtin load exactly when the app graph names

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -1963,6 +1963,44 @@ fn strip_regions(source: &str, prefix: &str, drop: &[&str]) -> String {
 /// applies to the indirect accessors, which take a specifier this scan never sees.
 /// A template literal counts as computed even when its body is constant — the
 /// distinction is not worth reading, and the cheap answer is the safe one.
+/// Is the text after a `require(` / `import(` a WHOLE static specifier?
+///
+/// Opening with a quote proves nothing: `require("child" + "_process")` starts
+/// like a literal, names no contiguous marker, and is preserved by the compiler as
+/// a real runtime load — so accepting it on its first byte strips the fork identity
+/// patch for a payload that genuinely forks. The specifier must therefore END the
+/// argument: the string closes, and the next thing is the call's own `)` or a
+/// second argument (`import(spec, options)`), never an operator.
+///
+/// An immediately-closing paren is accepted because `import()` takes no specifier
+/// at all and is a SyntaxError, so it can reach nothing. That case is worth
+/// spelling out: the sequence occurs in PROSE, and one zod comment reading "an
+/// inline `import()` of an ESM path" was enough to keep both eager loads for every
+/// artifact depending on zod.
+fn argument_is_one_static_string(after_paren: &str) -> bool {
+    let arg = after_paren.trim_start();
+    let bytes = arg.as_bytes();
+    let quote = match bytes.first() {
+        Some(b')') => return true,
+        Some(&q @ (b'"' | b'\'')) => q,
+        _ => return false,
+    };
+    let mut i = 1;
+    let close = loop {
+        match bytes.get(i) {
+            // Unterminated within this slice — unreadable, so treat it as computed.
+            None => return false,
+            Some(b'\\') => i += 2,
+            Some(&c) if c == quote => break i + 1,
+            _ => i += 1,
+        }
+    };
+    matches!(
+        arg[close..].trim_start().as_bytes().first(),
+        Some(b')') | Some(b',')
+    )
+}
+
 fn has_computed_module_access(code: &str) -> bool {
     for accessor in ["createRequire", "getBuiltinModule", "process.binding"] {
         if code.contains(accessor) {
@@ -1973,13 +2011,7 @@ fn has_computed_module_access(code: &str) -> bool {
         let mut rest = code;
         while let Some(at) = rest.find(call) {
             rest = &rest[at + call.len()..];
-            // A specifier this scan CAN read starts with a plain quote once
-            // whitespace is skipped. Anything else — an identifier, a call, a
-            // concatenation, a template — is computed.
-            if !matches!(
-                rest.trim_start().as_bytes().first(),
-                Some(b'"') | Some(b'\'')
-            ) {
+            if !argument_is_one_static_string(rest) {
                 return true;
             }
         }
@@ -9969,6 +10001,12 @@ after
             r#"createRequire(import.meta.url)("child_process")"#,
             r#"process.getBuiltinModule(name)"#,
             "require(`fs`)", // a template is not read, and cheap-and-safe wins
+            // A QUOTED PREFIX is not a static specifier. This one opens with a
+            // quote and names no contiguous marker, so reading only the first byte
+            // stripped the fork patch for a payload that really does fork.
+            r#"require("child" + "_process")"#,
+            r#"await import("node:" + name)"#,
+            r#"require("fs".concat(""))"#,
         ] {
             assert!(
                 has_computed_module_access(computed),
@@ -9984,6 +10022,10 @@ after
             r#"const fs = require("node:fs");"#,
             r#"await import("./chunk.mjs")"#,
             r#"console.log("plain");"#,
+            // Prose, not code. A zod comment shaped exactly like this kept both
+            // eager loads for every artifact depending on zod until empty parens
+            // were excluded — `import()` takes no specifier, so it reaches nothing.
+            "// emits an indexed access rather than an inline `import()` of a path",
         ] {
             assert!(
                 !has_computed_module_access(literal),
@@ -10003,6 +10045,20 @@ after
             p.app_uses_child_process.load(AtomicOrdering::Relaxed)
                 && p.app_uses_worker.load(AtomicOrdering::Relaxed),
             "an unreadable specifier must keep every eager load"
+        );
+
+        // The same, for a specifier that merely BEGINS like a literal. This is the
+        // shape that reached the builtin while both flags stayed false.
+        let split = CompilePreamble::from_source(
+            Path::new("/app/entry.ts"),
+            PathBuf::from("/nub/runtime"),
+            String::new(),
+        );
+        split.note_app_builtin_usage("/app/entry.ts", r#"require("child" + "_process").fork(m)"#);
+        assert!(
+            split.app_uses_child_process.load(AtomicOrdering::Relaxed)
+                && split.app_uses_worker.load(AtomicOrdering::Relaxed),
+            "a quoted-prefix concatenation must keep every eager load"
         );
     }
 

--- a/runtime/compile-bootstrap.cjs
+++ b/runtime/compile-bootstrap.cjs
@@ -9,6 +9,25 @@ const key = Symbol.for("nub.compile.bootstrap");
 // value as "do not prepend a preload", which is the truth there — a Worker started
 // from such an artifact runs without this bootstrap.
 const requireArg = __filename === "[eval]" ? undefined : `--require=${__filename}`;
+// Whether the payload's sealed graph reaches these builtins. Loading either costs
+// real startup time on EVERY run (measured on a quiet runner: child_process 1.9 ms,
+// worker_threads 1.4 ms, 2.3 ms together), and a payload that touches neither pays
+// it for nothing.
+//
+// The compiler removes a region only when its scan of the APP modules — the graph
+// minus nub's own runtime tree — found no mention of the marker at all. That scan
+// deliberately over-detects: keeping a region costs startup, whereas dropping one
+// that was needed disables the fork policy below. Each region is independently
+// removable and leaves the `false` initializer behind, so a removal cannot produce
+// a syntax error or an undefined binding.
+let needsChildProcess = false;
+let needsWorker = false;
+// #region nub:compile:childprocess
+needsChildProcess = true;
+// #endregion
+// #region nub:compile:worker
+needsWorker = true;
+// #endregion
 const descriptor = Object.getOwnPropertyDescriptor(process, key);
 const existing = descriptor?.value;
 let validExisting = false;
@@ -22,10 +41,12 @@ if (immutableDescriptor && existing !== null && typeof existing === "object") {
     const fields = Reflect.ownKeys(existing);
     validExisting =
       Object.isFrozen(existing) &&
-      fields.length === 3 &&
+      fields.length === 5 &&
       Object.hasOwn(existing, "createRequire") &&
       Object.hasOwn(existing, "getBuiltin") &&
       Object.hasOwn(existing, "requireArg") &&
+      Object.hasOwn(existing, "needsChildProcess") &&
+      Object.hasOwn(existing, "needsWorker") &&
       typeof existing.createRequire === "function" &&
       typeof existing.getBuiltin === "function" &&
       existing.requireArg === requireArg;
@@ -48,6 +69,12 @@ if (!validExisting) {
     createRequire: module_.createRequire,
     getBuiltin,
     requireArg,
+    // Published so the bundled preamble can skip its own eager loads of the same
+    // two builtins. The preamble is an INPUT to bundling, so it cannot be stripped
+    // against the finished graph the way this file is; reading the decision off
+    // the record is what lets one build-time scan drive both.
+    needsChildProcess,
+    needsWorker,
   });
 
   Object.defineProperty(process, key, {
@@ -57,7 +84,9 @@ if (!validExisting) {
     writable: false,
   });
 
-  installCompiledForkIdentity(getBuiltin("node:child_process"), process.execPath);
+  if (needsChildProcess) {
+    installCompiledForkIdentity(getBuiltin("node:child_process"), process.execPath);
+  }
 }
 
 // A compiled artifact publishes the outer executable as `process.execPath`, and

--- a/runtime/compile-preamble.mjs
+++ b/runtime/compile-preamble.mjs
@@ -150,7 +150,38 @@ export function installCompilePreamble() {
   // #region nub:polyfill:navigatorlocks
   installNavigatorLocks();
   // #endregion
-  if (bootstrap.needsWorker) installWorkerPolyfill();
+  if (bootstrap.needsWorker) {
+    installWorkerPolyfill();
+  } else {
+    // `globalThis.Worker` belongs to every compiled artifact's global surface, not
+    // only to artifacts whose source happens to spell it — computed access such as
+    // `globalThis["Work" + "er"]` must still find it. So the NAME goes on globalThis
+    // either way, and only the ~1.4 ms worker_threads load behind it is deferred.
+    // Global-surface parity is compared by own-property NAMES, which an accessor
+    // satisfies exactly.
+    //
+    // The getter removes itself BEFORE installing: `installWorkerPolyfill` opens by
+    // reading `typeof globalThis.Worker`, which would otherwise re-enter this getter
+    // forever. It then redefines the property as a data descriptor, so the accessor
+    // is replaced rather than shadowed.
+    Object.defineProperty(globalThis, "Worker", {
+      enumerable: false,
+      configurable: true,
+      get() {
+        delete globalThis.Worker;
+        installWorkerPolyfill();
+        return globalThis.Worker;
+      },
+      set(value) {
+        Object.defineProperty(globalThis, "Worker", {
+          value,
+          writable: true,
+          enumerable: false,
+          configurable: true,
+        });
+      },
+    });
+  }
   // #region nub:polyfill:temporal
   installTemporalGlobal({ Temporal, toTemporalInstant });
   // #endregion

--- a/runtime/compile-preamble.mjs
+++ b/runtime/compile-preamble.mjs
@@ -1,9 +1,17 @@
 // Runtime globals compiled artifacts need without Nub's loader or installed runtime.
 const bootstrap = process[Symbol.for("nub.compile.bootstrap")];
 const COMPILED_WORKER_STATE = "nub.compile.worker-state";
-const workerThreads = bootstrap.getBuiltin("node:worker_threads");
+// Loading node:worker_threads costs ~1.4 ms on every run of the artifact, so it is
+// skipped when the payload's sealed graph never reaches Worker or worker_threads.
+// The bootstrap made that call at build time — see its `nub:compile:worker` region
+// — and a null here means no Worker can exist in this process, so there is no
+// state to carry and nothing to publish.
+const workerThreads = bootstrap.needsWorker
+  ? bootstrap.getBuiltin("node:worker_threads")
+  : null;
 
 function readCompiledWorkerState() {
+  if (workerThreads === null) return null;
   let state;
   try {
     state = workerThreads.getEnvironmentData(COMPILED_WORKER_STATE);
@@ -46,7 +54,11 @@ if (
 ) {
   process.env.__NUB_NEUTRALIZE_LOCALSTORAGE = "1";
 }
-if (typeof compiledExecPath === "string" && compiledExecPath.length !== 0) {
+if (
+  workerThreads !== null &&
+  typeof compiledExecPath === "string" &&
+  compiledExecPath.length !== 0
+) {
   workerThreads.setEnvironmentData(COMPILED_WORKER_STATE, {
     compiledExecPath,
     neutralizeLocalStorage,
@@ -113,7 +125,12 @@ export function installCompilePreamble() {
   setBlobUrlModule({ blobUrlSource, installBlobUrlSupport });
   setCompiledBootstrapRequireArg(bootstrap.requireArg);
 
-  installCompiledChildProcess();
+  // Eagerly loads and patches node:child_process — the one place that cost is
+  // unavoidable when the payload uses it, because an ESM `import { spawn }`
+  // bypasses Module._load and so cannot be intercepted lazily. A payload whose
+  // sealed graph never names child_process or cluster skips it and the fork
+  // identity fix-up in the bootstrap together; neither has anything to correct.
+  if (bootstrap.needsChildProcess) installCompiledChildProcess();
   if (compiledExecPath !== undefined) {
     process.execPath = compiledExecPath;
     process.argv[0] = compiledExecPath;
@@ -133,7 +150,7 @@ export function installCompilePreamble() {
   // #region nub:polyfill:navigatorlocks
   installNavigatorLocks();
   // #endregion
-  installWorkerPolyfill();
+  if (bootstrap.needsWorker) installWorkerPolyfill();
   // #region nub:polyfill:temporal
   installTemporalGlobal({ Temporal, toTemporalInstant });
   // #endregion


### PR DESCRIPTION
Loading `node:child_process` costs ~1.9 ms and `node:worker_threads` ~1.4 ms on every run of a compiled artifact (~2.3 ms together — they share a subgraph, so the costs are not additive). Every artifact paid both, including a payload that reaches neither.

## Measured

End-to-end on a quiet CI runner, with duplicate baselines interleaved in the same `hyperfine` invocation. The instrument prints the artifact's strip state beside the timings, so the number is bound to the artifact it came from rather than assumed.

| | before | after |
| --- | --- | --- |
| bootstrap alone, over stock Node | +3.55 ms | **+1.92 ms** |
| the artifact, over stock Node | +11.58 ms | **+8.97 ms** |

A 2.61 ms improvement against a 0.90 ms error bar, and it agrees with the 2.29 ms the per-builtin measurements predicted for both loads together. The bootstrap's own 1.63 ms drop matches the `child_process` load within the bar, so the split is consistent too, not just the total.

The dev Mac cannot measure any of this: two identical commands there differ by ~1.4 ms over 500 runs, which is larger than most of the effects involved.

## Why both loads had to move together

`child_process` was loaded eagerly in two places — the bootstrap's fork-identity fix-up, and `installCompiledChildProcess` called from the preamble. Removing either alone saves nothing, because the other still pays the load. An ablation confirms it: dropping the preamble's call by itself saves 0.16 ms, inside the noise floor.

## How one build-time decision drives both

The bootstrap is not bundled. It rides `root_support_files` and is materialised into the bundle result after the chunks exist, so it can be rewritten against the finished module graph. The preamble cannot — it is an *input* to bundling — so it reads the decision off the bootstrap's frozen record instead. No second bundle pass.

The scan covers application modules only, excluding both nub's runtime tree and the compiler's own virtual modules. That exclusion is what makes it work at all: the preamble bundles `worker-polyfill.mjs` (which declares `class Worker`) and `preload-common.cjs` (which names `child_process`), so a bare `console.log("hello")` artifact contains every marker. A scan over emitted chunks would never strip anything.

Native addon islands are verbatim package copies that never reach the bundler, so they are folded into the same decision separately.

## What counts as unreadable

Keeping a region costs startup; dropping one that was needed disables the fork policy with no error raised, so every uncertain case keeps the load. A module counts as reaching everything when it names `createRequire`, `getBuiltinModule` or `process.binding`, or when a `require(`/`import(` argument is not one complete static string.

Opening with a quote is not enough on its own: `require("child" + "_process")` starts like a literal and names no contiguous marker, so accepting it on its first byte would strip the fork patch for a payload that genuinely forks. The string must close and be followed by the call's own `)` or a second argument.

Empty parens are the deliberate exception — `import()` takes no specifier and is a syntax error, so it reaches nothing. It is worth excluding because the sequence appears in prose: one comment in zod reading "an inline `import()` of an ESM path" was enough to keep both loads for every artifact depending on zod.

`globalThis.Worker` is exempt from gating entirely. It belongs to every compiled artifact's global surface regardless of what the source spells, and computed access such as `globalThis["Work" + "er"]` must still find it. Global-surface parity is compared by own-property name, which an accessor satisfies, so the name is always present and only the load behind it defers to first read. The getter deletes itself before installing, because `installWorkerPolyfill` opens by reading `typeof globalThis.Worker` and would otherwise re-enter forever.

## Verification

Each region is independently removable and leaves the `false` initializer behind, so a removal cannot produce a syntax error or an undefined binding.

End-to-end against built artifacts, reading the bootstrap out of the extracted app tree — not `strings` on the binary, which reports "stripped" for every extracted artifact because the payload is compressed inside the executable:

| payload | `child_process` region | `Worker` region | result |
| --- | --- | --- | --- |
| names neither | dropped | dropped | exit 0 |
| imports `child_process` | kept | dropped | exit 0 |
| uses `Worker` | dropped | kept | exit 0 |
| reaches the name only by computed access | dropped | dropped, accessor present | exit 0 |
| computed specifier | kept | kept | exit 0 |

Unit tests cover the stripper, the scan, and the specifier reader, each with a positive control — the negative assertions would otherwise pass equally against a scan that records nothing at all.

## Also here

`.worktreeinclude` now brings `runtime/node_modules` into a new worktree. Without it 49 compile bundle tests fail there with `Cannot find module 'urlpattern-polyfill/urlpattern'`, which reads as a code defect rather than a missing dependency. CI never sees it, because a Node 26 target strips those polyfill regions before anything resolves them.

## Not addressed

Emptying the preamble entirely saves 6.20 ms, while its three install calls together account for only ~1.9 ms. The rest is not reachable by call-gating, and a follow-up measurement has since located it more precisely than this branch could.

The preamble's whole statically imported graph evaluates in ~1.84 ms of child CPU, so it is not where the remainder sits. Two things carry it, and they split by platform. On Linux the payload term is ~7.1 ms, of which roughly 5.2 ms is beyond the preamble graph — the emitted chunks, the entry, and the loader work for four files rather than two. On macOS the launcher process itself costs several milliseconds that Linux does not pay.

A second bundle pass over the preamble's unused imports was the obvious next move and it is worth recording that it gains nothing: five readings across both platforms, every one inside its error bar. `worker-polyfill.mjs` and `worker-blob-url.cjs` are pure declarations, and dropping them changes `process.moduleLoadList` by zero entries. Evaluation cost tracks top-level work, not bytes — `polyfills.cjs` is 86 KB and evaluates in 0.31 ms because its top level is four statements.

Single-file emission is the largest remaining item.
