### PR TITLE
compile: split the output size by measured components

### DIFF
--- a/crates/nub-cli/src/compile/inject.rs
+++ b/crates/nub-cli/src/compile/inject.rs
@@ -15,7 +15,7 @@
 //! not a re-read of whatever the writer happened to emit.
 
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::Path;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -238,6 +238,42 @@ pub fn find_payload(format: ContainerFormat, image: &[u8]) -> Result<Option<&[u8
     }
 }
 
+/// How many bytes of `image` are its ad-hoc code signature — 0 for a format that
+/// carries none, and for a Mach-O that was never signed.
+///
+/// Reported as its own component of the output size rather than being left in a
+/// remainder, because it is neither launcher nor payload and it is not small: the
+/// CodeDirectory holds one SHA-256 per 4 KiB page, so it grows at ~0.78% of the
+/// file — 228 KB on a 29 MB embed build, against a launcher template of 851 KB.
+pub fn code_signature_size(format: ContainerFormat, image: &[u8]) -> u64 {
+    // ELF is never signed and Authenticode is out of scope; see `inject`.
+    match format {
+        ContainerFormat::MachO => macho_code_signature_size(image).unwrap_or(0),
+        ContainerFormat::Elf | ContainerFormat::Pe => 0,
+    }
+}
+
+/// The same measurement against a file on disk, reading only the Mach-O header
+/// and its load commands. The artifact is up to ~30 MB and the answer lives in
+/// its first few KB, so this deliberately does not `read` the whole image.
+pub fn code_signature_size_of(format: ContainerFormat, path: &Path) -> Result<u64> {
+    if format != ContainerFormat::MachO {
+        return Ok(0);
+    }
+    let mut file = fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    let mut header = [0u8; 32];
+    file.read_exact(&mut header)
+        .with_context(|| format!("reading the Mach-O header of {}", path.display()))?;
+    // `sizeofcmds` comes out of the file, so cap the allocation it sizes. A
+    // launcher template's load commands are ~4 KB; nothing legitimate is near 1 MB.
+    let sizeofcmds = (u32le(&header, 20).context("truncated Mach-O header")? as usize).min(1 << 20);
+    let mut prefix = vec![0u8; 32usize.saturating_add(sizeofcmds)];
+    prefix[..32].copy_from_slice(&header);
+    file.read_exact(&mut prefix[32..])
+        .with_context(|| format!("reading the load commands of {}", path.display()))?;
+    Ok(macho_code_signature_size(&prefix).unwrap_or(0))
+}
+
 /// Find the `VS_VERSIONINFO` resource in a produced PE, walking the same
 /// `RT_VERSION` → name 1 → language path `GetFileVersionInfo` takes.
 ///
@@ -316,6 +352,31 @@ fn slice_at(image: &[u8], offset: u64, size: u64) -> Result<&[u8]> {
 
 const MH_MAGIC_64: u32 = 0xfeed_facf;
 const LC_SEGMENT_64: u32 = 0x19;
+const LC_CODE_SIGNATURE: u32 = 0x1d;
+
+/// `datasize` of the `LC_CODE_SIGNATURE` load command, or `None` when the image
+/// is unparseable or unsigned. Never errors: a size split is a report, and a
+/// report must not fail a build that already produced a verified artifact.
+fn macho_code_signature_size(image: &[u8]) -> Option<u64> {
+    if u32le(image, 0) != Some(MH_MAGIC_64) {
+        return None;
+    }
+    let ncmds = u32le(image, 16)? as usize;
+    let mut cursor = 32usize; // sizeof(mach_header_64)
+    for _ in 0..ncmds {
+        let cmd = u32le(image, cursor)?;
+        let cmdsize = u32le(image, cursor + 4)? as usize;
+        if cmdsize == 0 {
+            return None;
+        }
+        // linkedit_data_command: cmd, cmdsize, dataoff, datasize.
+        if cmd == LC_CODE_SIGNATURE {
+            return u32le(image, cursor + 12).map(u64::from);
+        }
+        cursor = cursor.checked_add(cmdsize)?;
+    }
+    None
+}
 
 /// Walk `LC_SEGMENT_64` load commands for a section named `name`. libsui writes
 /// it under its own `__SUI` segment; matching on the SECTION name alone keeps the

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -527,8 +527,17 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         // bytes being split. `node.size` is the DECOMPRESSED length — the
         // launcher's warm-start check — so using it here would report a Node
         // component four times the space it takes in the file.
-        node_bytes: node.blob.len() as u64,
+        node_bytes: (node.blob.len() + node.license.len()) as u64,
         app_bytes: app_files.iter().map(|f| f.bytes.len() as u64).sum(),
+        // Injection re-signs the whole image, so the template's own ad-hoc
+        // signature never reaches the artifact and must come off its size.
+        launcher_bytes: (template.len() as u64)
+            .saturating_sub(inject::code_signature_size(target.format(), &template)),
+        // Measured off the published file rather than predicted: the signature's
+        // size is a function of the final image, which nothing before the write
+        // knows. A failure to read it back is not worth failing a verified build
+        // over — the component simply reports zero and lands in `overhead`.
+        signature_bytes: inject::code_signature_size_of(target.format(), &out_path).unwrap_or(0),
         shipped,
         deferred: bundled.dynamic_import_sites,
         app_extracts: inline_decline,
@@ -775,7 +784,7 @@ fn render_row(
     // `run` is the text accumulated since the ink last changed or the line last
     // broke; it is flushed through `paint` once. Painting each word as it lands
     // renders identically and is what shipped first — but it wraps every word in
-    // its own escape pair, so `(node 28.3 MB · app 24 KB · launcher 1.2 MB)`
+    // its own escape pair, so `(node 28.2 MB · app 57 KB · launcher 851 KB)`
     // leaves the terminal as eleven separate dim spans and roughly ten times the
     // bytes, which is what anyone piping the output to a file or a doc gets.
     let mut run = String::new();
@@ -1387,11 +1396,19 @@ impl Drop for LiveLine {
 struct BuildFacts {
     /// The finished file, from `metadata` on what was published.
     size: u64,
-    /// The COMPRESSED Node blob's contribution. Zero under `--smol`, which
-    /// embeds no runtime at all.
+    /// The embedded runtime's contribution: the COMPRESSED Node blob plus the
+    /// compressed `LICENSE` shipped beside it, which exists only because that
+    /// runtime does. Zero under `--smol`, which embeds no runtime at all.
     node_bytes: u64,
     /// The compressed app files' contribution.
     app_bytes: u64,
+    /// The launcher template's contribution, which is its file size MINUS its own
+    /// ad-hoc signature: injection re-signs the whole image, so the template's
+    /// signature is discarded rather than carried.
+    launcher_bytes: u64,
+    /// The finished artifact's ad-hoc code signature, measured off the file that
+    /// was written. Zero on ELF and PE, which nub never signs.
+    signature_bytes: u64,
     /// Everything that did not get sealed into the bundle, with the reason each
     /// one earned. Ordered as the build discovered them.
     shipped: Vec<(String, &'static str)>,
@@ -1410,24 +1427,36 @@ impl BuildFacts {
     ///
     /// This is the number someone shrinking a binary actually wants; the total on
     /// its own cannot tell them whether their code or the runtime is the problem.
-    /// The remainder is the launcher plus the container's own headers, which is
-    /// what is left once the two payload regions are accounted for — computed as
-    /// a difference rather than measured, so it can never disagree with the total.
+    /// Every component is therefore MEASURED, and only `overhead` is a remainder.
     ///
-    /// Empty when the parts do not add up to something worth splitting: a `--smol`
-    /// build with no assets is almost entirely launcher, and naming three
-    /// components of one small number is noise.
+    /// It used to be the other way round: `launcher` was `size - node - app`, so
+    /// it swallowed the ad-hoc code signature as well. That is not a rounding
+    /// error — the CodeDirectory carries one SHA-256 per 4 KiB page, so on a
+    /// 29 MB embed build a fixed 851 KB launcher was reported as 1.2 MB, and the
+    /// row said the launcher alone outweighed a whole `--smol` binary.
+    ///
+    /// `overhead` is what is left: the payload container's header, the manifest,
+    /// the per-file framing, and the alignment of the payload region to a 64 KiB
+    /// boundary. Structurally non-negative on Mach-O and ELF, where injection only
+    /// ever appends; `saturating_sub` covers PE, whose resource directory libsui
+    /// rebuilds rather than extends.
     fn size_split(&self) -> String {
-        let launcher = self
+        let overhead = self
             .size
             .saturating_sub(self.node_bytes)
-            .saturating_sub(self.app_bytes);
+            .saturating_sub(self.app_bytes)
+            .saturating_sub(self.launcher_bytes)
+            .saturating_sub(self.signature_bytes);
         let mut parts = Vec::new();
         if self.node_bytes > 0 {
             parts.push(format!("node {}", mb(self.node_bytes)));
         }
         parts.push(format!("app {}", mb(self.app_bytes)));
-        parts.push(format!("launcher {}", mb(launcher)));
+        parts.push(format!("launcher {}", mb(self.launcher_bytes)));
+        if self.signature_bytes > 0 {
+            parts.push(format!("signature {}", mb(self.signature_bytes)));
+        }
+        parts.push(format!("overhead {}", mb(overhead)));
         format!("  ({})", parts.join(" · "))
     }
 }
@@ -4560,9 +4589,15 @@ mod tests {
     /// A build with everything present, so the optional rows all appear at once.
     fn full_facts() -> BuildFacts {
         BuildFacts {
-            size: 29_473_842,
-            node_bytes: 25_100_000,
-            app_bytes: 2_500_000,
+            // Every size here is measured off a real darwin-arm64 embed build, so
+            // the components add up the way a reader's own build will: 851 KB of
+            // launcher template, a 228 KB signature that scales with the file, and
+            // 66 KB of container header, manifest and 64 KiB payload alignment.
+            size: 29_390_370,
+            node_bytes: 28_189_460,
+            app_bytes: 56_571,
+            launcher_bytes: 850_864,
+            signature_bytes: 227_954,
             shipped: vec![
                 ("@napi-rs/nice".to_string(), "native addon"),
                 ("sharp".to_string(), "--external"),
@@ -4600,7 +4635,9 @@ mod tests {
                 &host,
             )),
             vec![
-                "output=acme  29.5 MB  (node 25.1 MB · app 2.5 MB · launcher 1.9 MB)".to_string(),
+                "output=acme  29.4 MB  (node 28.2 MB · app 57 KB · launcher 851 KB · \
+                 signature 228 KB · overhead 66 KB)"
+                    .to_string(),
                 "runtime=Node 26.8.1, embedded  (package.json#engines.node)".to_string(),
                 // No aside: building for the host is the default, and a note on
                 // the default is paid for by every build and earned by none.
@@ -4610,6 +4647,39 @@ mod tests {
                 "app=extracted on first run  it resolves modules at run time".to_string(),
                 "report=report.json  esbuild schema".to_string(),
             ]
+        );
+    }
+
+    /// Every component of the split is measured; only `overhead` is a remainder.
+    ///
+    /// The regression this pins: `launcher` used to BE the remainder, so it
+    /// swallowed the ad-hoc code signature — which grows at one SHA-256 per 4 KiB
+    /// page — and reported a fixed 851 KB template as 1.2 MB on a 29 MB build.
+    #[test]
+    fn the_split_names_the_signature_apart_from_the_launcher() {
+        let signed = full_facts();
+        assert_eq!(
+            signed.size_split(),
+            "  (node 28.2 MB · app 57 KB · launcher 851 KB · signature 228 KB · overhead 66 KB)",
+        );
+        let components =
+            signed.node_bytes + signed.app_bytes + signed.launcher_bytes + signed.signature_bytes;
+        assert!(
+            components < signed.size,
+            "the measured components must leave a non-negative overhead: {components} vs {}",
+            signed.size
+        );
+
+        // ELF and PE are never signed, so there is no component to name and the
+        // bytes it would have covered do not exist rather than moving elsewhere.
+        let unsigned = BuildFacts {
+            size: signed.size - signed.signature_bytes,
+            signature_bytes: 0,
+            ..signed
+        };
+        assert_eq!(
+            unsigned.size_split(),
+            "  (node 28.2 MB · app 57 KB · launcher 851 KB · overhead 66 KB)",
         );
     }
 
@@ -4646,10 +4716,12 @@ mod tests {
     fn a_build_with_nothing_deferred_or_external_prints_no_row_for_it() {
         let host = TargetPlatform::host().unwrap();
         let bare = BuildFacts {
-            size: 4_400_000,
+            size: 3_433_512,
             // `--smol` embeds no runtime, so the split names only what is there.
             node_bytes: 0,
             app_bytes: 2_500_000,
+            launcher_bytes: 850_864,
+            signature_bytes: 26_744,
             shipped: Vec::new(),
             deferred: 0,
             app_extracts: None,
@@ -4667,7 +4739,9 @@ mod tests {
                 &host,
             )),
             vec![
-                "output=acme  4.4 MB  (app 2.5 MB · launcher 1.9 MB)".to_string(),
+                "output=acme  3.4 MB  (app 2.5 MB · launcher 851 KB · signature 27 KB · \
+                 overhead 56 KB)"
+                    .to_string(),
                 "runtime=Node >=22 <23, not embedded  (--target)".to_string(),
                 format!("platform={}", host.triple()),
                 "app=run from the executable  nothing is written to disk".to_string(),

--- a/wiki/commands/compile-architecture.md
+++ b/wiki/commands/compile-architecture.md
@@ -24,8 +24,10 @@ The default shape embeds a Node; `--smol` does not, and finds one at startup ins
 
 | Shape | Size | Contains | Node comes from |
 | --- | --- | --- | --- |
-| default (embed) | ~26 MB | launcher + manifest + bundled JS + assets + a stripped, zstd-19 Node | inside the binary |
-| `--smol` | ~0.6 MB | launcher + manifest + bundled JS + assets | discovered locally, else provisioned |
+| default (embed) | ~29 MB | launcher + manifest + bundled JS + assets + a stripped, zstd-19 Node | inside the binary |
+| `--smol` | ~1.0 MB | launcher + manifest + bundled JS + assets | discovered locally, else provisioned |
+
+Both figures are a hello-world artifact on Node 26 for darwin-arm64. Neither floor is the bundled program: a `--smol` artifact is 851 KB of launcher template before it carries a byte of application code, and an embed artifact is that plus the compressed runtime.
 
 ### Trimming ICU out of the embedded Node
 
@@ -57,7 +59,7 @@ Payload V3 carries the app files, the length each one extracts to, and — for t
 
 Injection is format-specific:
 
-- **Mach-O** uses a new section and is ad-hoc-signed by the pure-Rust injector. The signature supplies neither a Developer ID identity nor notarization.
+- **Mach-O** uses a new section and is ad-hoc-signed by the pure-Rust injector. The signature supplies neither a Developer ID identity nor notarization. It is also not a fixed cost: the CodeDirectory holds one SHA-256 per 4 KiB page, so it scales with the image at roughly 0.78% of it — 8 KB on a `--smol` artifact and 228 KB on a 29 MB embed one. The template's own signature is discarded, since the whole image is signed again after injection.
 - **ELF** uses `.note.sui` plus `.sui.phdrs` and remains unsigned.
 - **PE** uses a resource and remains unsigned. Authenticode signing is the distributor's responsibility.
 


### PR DESCRIPTION
The output row computed `launcher` as `size − node − app`, so the remainder also carried the code signature, the payload region’s 64 KiB alignment, the container header and manifest, and the Node LICENSE. A 29.4 MB embed build reported an 851 KB launcher template as `launcher 1.2 MB`.

Every component is measured now; only `overhead` is a remainder.

```
29.4 MB  (node 28.2 MB · app 57 KB · launcher 851 KB · signature 228 KB · overhead 66 KB)
990 KB   (app 103 KB · launcher 851 KB · signature 8 KB · overhead 28 KB)
```

Both sum to the file size exactly, checked against `otool -l`. The signature holds one SHA-256 per 4 KiB page, so it scales with the artifact; ELF and PE omit it.