### PR TITLE
compile: keep an unconditional module.exports assignment CommonJS

### DIFF
--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -3114,32 +3114,50 @@ fn preserve_dependency_esm_classification(path: &str, source: &str) -> Option<St
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::mjs());
     let parsed = Parser::new(&allocator, source, source_type).parse();
-    if parsed.panicked
-        || has_esm_syntax(&parsed.program)
-        || assigns_commonjs_exports_at_top_level(&parsed.program)
-    {
+    if parsed.panicked || has_esm_syntax(&parsed.program) {
         return None;
     }
     let semantic = oxc_semantic::SemanticBuilder::new()
         .build(&parsed.program)
         .semantic;
-    let misread = semantic
+    // The references Rolldown misreads as proof of CommonJS, and the only ones the
+    // marker is for. Collected as REFERENCE IDS rather than as a yes/no, so the
+    // exemption below can require the assignment to target one of THESE and not a
+    // local binding that merely shares the name.
+    let unresolved: Vec<_> = semantic
         .scoping()
         .root_unresolved_references()
         .iter()
-        .any(|(name, _)| matches!(name.as_str(), "module" | "exports"));
-    misread.then(|| format!("{source}\nexport {{}};\n"))
+        .filter(|(name, _)| matches!(name.as_str(), "module" | "exports"))
+        .flat_map(|(_, ids)| ids.iter().copied())
+        .collect();
+    if unresolved.is_empty() {
+        return None;
+    }
+    let assigns_the_global = top_level_member_assignment_roots(&parsed.program)
+        .into_iter()
+        .any(|ident| {
+            ident
+                .reference_id
+                .get()
+                .is_some_and(|id| unresolved.contains(&id))
+        });
+    (!assigns_the_global).then(|| format!("{source}\nexport {{}};\n"))
 }
 
-/// Whether the module assigns `module.exports` or `exports.<name>` as an
-/// unconditional top-level statement.
+/// The root identifier of every unconditional top-level `<root>.… = …` assignment.
 ///
-/// Such a module is CommonJS by construction, not an ES module that merely
-/// mentions the name: run as ESM the statement is a guaranteed `ReferenceError`
-/// the first time the module executes, so no working package ships one. What the
-/// marker above is really for is the GUARDED probe — `try { module.exports = … }
-/// catch {}`, and its `typeof module !== "undefined"` cousins — which Node does
-/// read as ESM and which stays marked.
+/// A module that assigns the GLOBAL `module.exports` or `exports.<name>` this way
+/// is CommonJS by construction, not an ES module that merely mentions the name:
+/// run as ESM the statement throws the first time the module executes, so no
+/// working package ships one. What the marker above is really for is the GUARDED
+/// probe — `try { module.exports = … } catch {}`, and its
+/// `typeof module !== "undefined"` cousins — which Node does read as ESM.
+///
+/// The roots come back as REFERENCES rather than names so the caller can insist on
+/// the unresolved one. A local `const module = {}` shadowing the global must not
+/// buy the exemption: such a module can still need the marker for a SEPARATE
+/// unresolved `module`/`exports` reference elsewhere in it.
 ///
 /// The distinction is load-bearing for the compiler's OWN generated modules.
 /// `native::addon_module` is CommonJS Nub wrote itself, but the id it is served
@@ -3148,31 +3166,33 @@ fn preserve_dependency_esm_classification(path: &str, source: &str) -> Option<St
 /// it turned Rolldown's CommonJS wrapper off, `module` was left unbound, and every
 /// artifact carrying a native addon died at startup with the `ReferenceError` Node
 /// reports as `ERR_AMBIGUOUS_MODULE_SYNTAX`.
-fn assigns_commonjs_exports_at_top_level(program: &Program<'_>) -> bool {
-    use oxc_ast::ast::{Expression, Statement};
+fn top_level_member_assignment_roots<'a>(
+    program: &'a Program<'a>,
+) -> Vec<&'a oxc_ast::ast::IdentifierReference<'a>> {
+    use oxc_ast::ast::{Expression, IdentifierReference, Statement};
 
-    fn root_object<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
+    fn root<'a>(expr: &'a Expression<'a>) -> Option<&'a IdentifierReference<'a>> {
         match expr {
-            Expression::Identifier(ident) => Some(ident.name.as_str()),
-            Expression::StaticMemberExpression(member) => root_object(&member.object),
-            Expression::ComputedMemberExpression(member) => root_object(&member.object),
+            Expression::Identifier(ident) => Some(ident),
+            Expression::StaticMemberExpression(member) => root(&member.object),
+            Expression::ComputedMemberExpression(member) => root(&member.object),
             _ => None,
         }
     }
 
-    program.body.iter().any(|stmt| {
-        let Statement::ExpressionStatement(stmt) = stmt else {
-            return false;
-        };
-        let Expression::AssignmentExpression(assign) = &stmt.expression else {
-            return false;
-        };
-        assign
-            .left
-            .as_member_expression()
-            .and_then(|member| root_object(member.object()))
-            .is_some_and(|name| matches!(name, "module" | "exports"))
-    })
+    program
+        .body
+        .iter()
+        .filter_map(|stmt| {
+            let Statement::ExpressionStatement(stmt) = stmt else {
+                return None;
+            };
+            let Expression::AssignmentExpression(assign) = &stmt.expression else {
+                return None;
+            };
+            root(assign.left.as_member_expression()?.object())
+        })
+        .collect()
 }
 
 /// The mirror image, for a root Node runs as CommonJS. Rolldown classifies a
@@ -7983,6 +8003,19 @@ mod tests {
             )
             .is_some(),
             "a guarded probe is the shape the marker exists for and keeps it"
+        );
+        // The exemption follows the SEMANTIC reference, not the spelling. Here
+        // `module` is a local binding, so the assignment says nothing about the
+        // format — and the module still needs the marker for its separate
+        // unresolved `exports`, which is the reference Rolldown would misread.
+        assert!(
+            preserve_dependency_esm_classification(
+                &dir.join("shadowed.mjs").to_string_lossy(),
+                "const module = {};\nmodule.exports = 1;\n\
+                 try { exports.answer } catch (e) { console.log(e.name); }\n"
+            )
+            .is_some(),
+            "a local `module` must not suppress a marker another unresolved reference needs"
         );
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -3114,7 +3114,10 @@ fn preserve_dependency_esm_classification(path: &str, source: &str) -> Option<St
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::mjs());
     let parsed = Parser::new(&allocator, source, source_type).parse();
-    if parsed.panicked || has_esm_syntax(&parsed.program) {
+    if parsed.panicked
+        || has_esm_syntax(&parsed.program)
+        || assigns_commonjs_exports_at_top_level(&parsed.program)
+    {
         return None;
     }
     let semantic = oxc_semantic::SemanticBuilder::new()
@@ -3126,6 +3129,50 @@ fn preserve_dependency_esm_classification(path: &str, source: &str) -> Option<St
         .iter()
         .any(|(name, _)| matches!(name.as_str(), "module" | "exports"));
     misread.then(|| format!("{source}\nexport {{}};\n"))
+}
+
+/// Whether the module assigns `module.exports` or `exports.<name>` as an
+/// unconditional top-level statement.
+///
+/// Such a module is CommonJS by construction, not an ES module that merely
+/// mentions the name: run as ESM the statement is a guaranteed `ReferenceError`
+/// the first time the module executes, so no working package ships one. What the
+/// marker above is really for is the GUARDED probe — `try { module.exports = … }
+/// catch {}`, and its `typeof module !== "undefined"` cousins — which Node does
+/// read as ESM and which stays marked.
+///
+/// The distinction is load-bearing for the compiler's OWN generated modules.
+/// `native::addon_module` is CommonJS Nub wrote itself, but the id it is served
+/// under is the `.node` file, whose owning manifest is the application's — so an
+/// app with `"type": "module"` made the shim look like an ESM dependency. Marking
+/// it turned Rolldown's CommonJS wrapper off, `module` was left unbound, and every
+/// artifact carrying a native addon died at startup with the `ReferenceError` Node
+/// reports as `ERR_AMBIGUOUS_MODULE_SYNTAX`.
+fn assigns_commonjs_exports_at_top_level(program: &Program<'_>) -> bool {
+    use oxc_ast::ast::{Expression, Statement};
+
+    fn root_object<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
+        match expr {
+            Expression::Identifier(ident) => Some(ident.name.as_str()),
+            Expression::StaticMemberExpression(member) => root_object(&member.object),
+            Expression::ComputedMemberExpression(member) => root_object(&member.object),
+            _ => None,
+        }
+    }
+
+    program.body.iter().any(|stmt| {
+        let Statement::ExpressionStatement(stmt) = stmt else {
+            return false;
+        };
+        let Expression::AssignmentExpression(assign) = &stmt.expression else {
+            return false;
+        };
+        assign
+            .left
+            .as_member_expression()
+            .and_then(|member| root_object(member.object()))
+            .is_some_and(|name| matches!(name, "module" | "exports"))
+    })
 }
 
 /// The mirror image, for a root Node runs as CommonJS. Rolldown classifies a
@@ -7901,6 +7948,41 @@ mod tests {
         assert!(
             preserve_dependency_esm_classification("\0nub:virtual", source).is_none(),
             "virtual modules are the compiler's own"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// A module that assigns `module.exports` outright is CommonJS whatever its
+    /// package says, so the marker leaves it alone. The generated native-addon
+    /// shim is exactly that shape and is served under the `.node` id, whose
+    /// owning manifest is the APPLICATION's — so an app declaring
+    /// `"type": "module"` used to make the shim look like an ESM dependency,
+    /// and marking it left `module` unbound in every artifact carrying an addon.
+    #[test]
+    fn a_top_level_module_exports_assignment_keeps_its_commonjs_reading() {
+        let dir = fixture_dir("addon-shim-classification");
+        std::fs::write(dir.join("package.json"), r#"{"type":"module"}"#).unwrap();
+        let addon = dir.join("watcher-a1b2c3d4.node");
+        let shim = crate::compile::native::addon_module("watcher-a1b2c3d4.node");
+        assert!(
+            preserve_dependency_esm_classification(&addon.to_string_lossy(), &shim).is_none(),
+            "the generated addon shim assigns module.exports and must stay CommonJS"
+        );
+        assert!(
+            preserve_dependency_esm_classification(
+                &dir.join("exports-member.mjs").to_string_lossy(),
+                "exports.answer = 42;\n"
+            )
+            .is_none(),
+            "assigning through `exports` is the same statement about the format"
+        );
+        assert!(
+            preserve_dependency_esm_classification(
+                &dir.join("probe.mjs").to_string_lossy(),
+                "try { module.exports = 1; } catch (e) { console.log(e.name); }\n"
+            )
+            .is_some(),
+            "a guarded probe is the shape the marker exists for and keeps it"
         );
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/crates/nub-cli/src/compile/native.rs
+++ b/crates/nub-cli/src/compile/native.rs
@@ -439,7 +439,7 @@ fn resolve_package_root(importer: &Path, specifier: &str) -> Option<PathBuf> {
     }
 }
 
-fn addon_module(name: &str) -> String {
+pub(super) fn addon_module(name: &str) -> String {
     format!(
         "const record = process[Symbol.for(\"nub.compile.bootstrap\")];\n\
          module.exports = record.createRequire(import.meta.url)({});\n",


### PR DESCRIPTION
A compiled artifact that carries a native addon, in a project whose `package.json` declares `"type": "module"`, fails at startup:

```
ReferenceError: Cannot determine intended module format because both require() and top-level await are present.
  code: 'ERR_AMBIGUOUS_MODULE_SYNTAX'
```

Nub generates the shim that loads an embedded addon (`native::addon_module`), and that shim assigns `module.exports`. It is served under the `.node` id, whose owning manifest is the *application's* — so a project declaring `"type": "module"` made Nub's own CommonJS module look like an ESM dependency to `preserve_dependency_esm_classification`, which appended `export {};` to keep the ESM reading. The marker turned off Rolldown's CommonJS wrapper, `module` was left unbound, and Node reports that `ReferenceError` under the ambiguous-syntax code.

The marker now skips a module that assigns `module.exports` or `exports.<name>` as an unconditional top-level statement. Such a module is CommonJS by construction: run as ESM the statement throws the first time the module executes, so no working package ships one. The shape the marker exists for is the guarded probe — `try { module.exports = … } catch {}` — which still gets it. `compile::closure` emits the same unconditional shape for a CommonJS chunk entry, so it is covered by the same rule.

Caught by the nightly release run, which failed the pre-publish smoke gate on all eight platforms.

## Verification

Three builds against the smoke gate's own fixture, on darwin-arm64 with a Node 22.23.2 target:

| build | result |
| --- | --- |
| 0.8.3 | runs, prints the expected line |
| `main` at `c005160854` | `ERR_AMBIGUOUS_MODULE_SYNTAX` |
| `main`, same fixture, manifest without `"type": "module"` | runs |

The third row is the control: one field differs, and it is the guard clause the marker turns on.

The new unit test calls the real shim generator rather than a copy of its output, so the two cannot drift apart. No pull-request gate covered this shape — `compile-native.yml`'s fixture has no `"type": "module"`, and its addon belongs to `sharp` rather than to the application, so the package-defaults-to-CommonJS guard short-circuits there.

Refs #884
