### PR TITLE
nub-phantom: walk legacy deep-path entry points for packages without an exports map

### DIFF
--- a/crates/nub-phantom-core/src/extract.rs
+++ b/crates/nub-phantom-core/src/extract.rs
@@ -21,9 +21,10 @@
 //! hardness), never toward a false phantom — safe for the never-false-flag bar.
 
 use oxc_allocator::Allocator;
+use oxc_ast::AstKind;
 use oxc_ast::ast::{
-    Argument, ConditionalExpression, Expression, IfStatement, ImportDeclarationSpecifier,
-    LogicalExpression, Statement, TryStatement,
+    Argument, BindingPattern, ConditionalExpression, Expression, FormalParameters, IfStatement,
+    ImportDeclarationSpecifier, LogicalExpression, Statement, TryStatement,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
@@ -98,6 +99,7 @@ fn parse_and_visit(source: &str, source_type: SourceType, capture_types: bool) -
         guard_depth: 0,
         out: Vec::new(),
         capture_types,
+        require_shadow_depth: 0,
     };
     v.visit_program(&ret.program);
     v.out
@@ -112,6 +114,17 @@ struct SpecVisitor {
     /// Retain type-only import/re-export specifiers. Set only for SFC script
     /// blocks, where a type-position phantom still breaks GVS resolution (nub#450).
     capture_types: bool,
+    /// Lexical nesting inside a function that takes a PARAMETER named `require`.
+    /// Nonzero means a `require(...)` here resolves against that parameter, not
+    /// Node — the browserify/UMD/webpack bundle shape
+    /// (`function(require,module,exports){…}` fed by an inlined module registry),
+    /// where the specifiers name the transitive graph the bundler already
+    /// inlined. Measured: over the top-1000 packages this one shape produced 11
+    /// of 14 speculative deep-path findings (object.assign's `dist/browser.js`
+    /// naming `es-errors`, `gopd`, `math-intrinsics`, …), none of which a
+    /// consumer must install. Parameters only, never a `const require =
+    /// createRequire(...)` binding — that one IS a real Node edge.
+    require_shadow_depth: u32,
 }
 
 impl SpecVisitor {
@@ -125,6 +138,18 @@ impl SpecVisitor {
 }
 
 impl<'a> Visit<'a> for SpecVisitor {
+    fn enter_node(&mut self, kind: AstKind<'a>) {
+        if shadows_require(&kind) {
+            self.require_shadow_depth += 1;
+        }
+    }
+
+    fn leave_node(&mut self, kind: AstKind<'a>) {
+        if shadows_require(&kind) {
+            self.require_shadow_depth -= 1;
+        }
+    }
+
     fn visit_try_statement(&mut self, it: &TryStatement<'a>) {
         // Everything lexically within a try — the try block, the catch handler,
         // and the finalizer — is a guarded region: the canonical optional-load
@@ -209,7 +234,9 @@ impl<'a> Visit<'a> for SpecVisitor {
             }
             // `require("x")` / `require.resolve("x")` / `createRequire(...)("x")`.
             Expression::CallExpression(call) => {
-                if let Some((spec, kind)) = require_call(call) {
+                if let Some((spec, kind)) = require_call(call)
+                    && !(self.require_shadow_depth > 0 && callee_is_bare_require(&call.callee))
+                {
                     self.record(spec, kind);
                 }
             }
@@ -363,6 +390,38 @@ fn require_call<'a>(call: &'a oxc_ast::ast::CallExpression<'a>) -> Option<(&'a s
     }
 }
 
+/// Whether `kind` is a function whose PARAMETER list binds the name `require`,
+/// which shadows Node's for the whole body.
+fn shadows_require(kind: &AstKind<'_>) -> bool {
+    match kind {
+        AstKind::Function(f) => params_bind_require(&f.params),
+        AstKind::ArrowFunctionExpression(f) => params_bind_require(&f.params),
+        _ => false,
+    }
+}
+
+/// A plain identifier parameter named `require`. Destructured and rest patterns
+/// are not checked: no bundler emits one, and a narrower rule cannot suppress a
+/// real edge.
+fn params_bind_require(params: &FormalParameters<'_>) -> bool {
+    params.items.iter().any(|p| {
+        matches!(&p.pattern, BindingPattern::BindingIdentifier(id) if id.name == "require")
+    })
+}
+
+/// Whether the call is rooted at the bare name `require` (`require(...)` or
+/// `require.resolve(...)`) — the forms a `require` parameter shadows. A
+/// `createRequire(...)(...)` callee is NOT rooted at that name and is unaffected.
+fn callee_is_bare_require(callee: &Expression<'_>) -> bool {
+    match callee {
+        Expression::Identifier(id) => id.name == "require",
+        Expression::StaticMemberExpression(m) => {
+            matches!(&m.object, Expression::Identifier(id) if id.name == "require")
+        }
+        _ => false,
+    }
+}
+
 /// True if `callee` names `createRequire` — bare (`createRequire(...)`) or a
 /// member (`module.createRequire(...)`). The receiver is not checked: only Node's
 /// `createRequire` uses this name, and the outer call's argument must still be a
@@ -397,6 +456,54 @@ mod tests {
             .into_iter()
             .map(|o| (o.spec, o.soft, o.kind))
             .collect()
+    }
+
+    #[test]
+    fn a_require_parameter_shadows_node_so_bundle_internals_are_not_edges() {
+        // The browserify/UMD bundle shape: each inlined module is a factory taking
+        // its own `require`, fed by the bundle's module registry. Those specifiers
+        // name the graph the bundler ALREADY inlined, so attributing them to the
+        // publishing package is a false phantom (measured on object.assign's
+        // `dist/browser.js`, which names 11 packages it does not need).
+        let got = specs(
+            r#"
+            (function(){})()({1:[function(require,module,exports){
+              var e = require('es-errors');
+              require.resolve('gopd');
+            },{}]},{},[1]);
+            const real = require('really-needed');
+            "#,
+        );
+        let names: Vec<_> = got.iter().map(|(s, _, _)| s.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["really-needed"],
+            "only the module-scope require is a Node edge: {names:?}"
+        );
+
+        // The shadow is lexical and ends with the function.
+        let after = specs("function f(require) { require('inner'); }\nrequire('outer');");
+        assert_eq!(
+            after.iter().map(|(s, _, _)| s.as_str()).collect::<Vec<_>>(),
+            vec!["outer"]
+        );
+
+        // An arrow parameter shadows identically.
+        let arrow = specs("const f = (require) => require('inner');");
+        assert!(arrow.is_empty(), "arrow parameter shadows too: {arrow:?}");
+
+        // A `const require = createRequire(...)` binding is NOT a parameter and
+        // stays a real edge — the common ESM interop shape.
+        let cr = specs(
+            "import { createRequire } from 'node:module';\n\
+             const require = createRequire(import.meta.url);\n\
+             const x = require('lodash');",
+        );
+        let names: Vec<_> = cr.iter().map(|(s, _, _)| s.as_str()).collect();
+        assert!(
+            names.contains(&"lodash"),
+            "createRequire-bound require is a real edge: {names:?}"
+        );
     }
 
     #[test]

--- a/crates/nub-phantom-core/src/extract.rs
+++ b/crates/nub-phantom-core/src/extract.rs
@@ -404,9 +404,9 @@ fn shadows_require(kind: &AstKind<'_>) -> bool {
 /// are not checked: no bundler emits one, and a narrower rule cannot suppress a
 /// real edge.
 fn params_bind_require(params: &FormalParameters<'_>) -> bool {
-    params.items.iter().any(|p| {
-        matches!(&p.pattern, BindingPattern::BindingIdentifier(id) if id.name == "require")
-    })
+    params.items.iter().any(
+        |p| matches!(&p.pattern, BindingPattern::BindingIdentifier(id) if id.name == "require"),
+    )
 }
 
 /// Whether the call is rooted at the bare name `require` (`require(...)` or

--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -60,8 +60,10 @@ pub struct Finding {
     /// the nub#450 peer-type class (its `@types/<peer>` must be project-local).
     pub(crate) from_types: bool,
     /// Reachable from a speculative legacy deep-path root — a published file no
-    /// declared surface references, in a package with no `exports` map.
-    pub from_deep_path: bool,
+    /// declared surface references, in a package with no `exports` map. Read
+    /// across the crate boundary through [`Finding::is_deep_path_only`], as the
+    /// other provenance bits are through [`Finding::is_subpath_adapter`].
+    pub(crate) from_deep_path: bool,
     /// Example raw specifiers (deduped) showing how it was referenced.
     pub specifiers: Vec<String>,
 }

--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -34,6 +34,15 @@ pub enum Verdict {
     Builtin,
     /// A self reference (the package's own name / subpath).
     SelfRef,
+    /// Undeclared as a runtime dep, but present in `devDependencies` AND reachable
+    /// only as a speculative legacy deep-path root. That combination describes a
+    /// build/test helper that shipped in the tarball: nothing on the published
+    /// surface reaches it, and the author's own manifest says the import is
+    /// dev-time. Reported as its own category rather than a phantom — the
+    /// deep-path class is speculative, so it does not get to override the author's
+    /// declaration. A devDep import reached from `main`/`bin`/`exports` is
+    /// unaffected and stays a phantom.
+    DevOnlyDeepPath,
 }
 
 /// One classified package reference.
@@ -50,6 +59,9 @@ pub struct Finding {
     /// Reachable from the `.d.ts` TYPE surface — a DECLARED PEER with this set is
     /// the nub#450 peer-type class (its `@types/<peer>` must be project-local).
     pub(crate) from_types: bool,
+    /// Reachable from a speculative legacy deep-path root — a published file no
+    /// declared surface references, in a package with no `exports` map.
+    pub from_deep_path: bool,
     /// Example raw specifiers (deduped) showing how it was referenced.
     pub specifiers: Vec<String>,
 }
@@ -61,6 +73,20 @@ impl Finding {
     /// backend it never declares (`@hookform/resolvers/zod` → `zod`).
     pub fn is_subpath_adapter(&self) -> bool {
         self.verdict == Verdict::HardPhantom && self.from_subpath && !self.from_main
+    }
+
+    /// The legacy deep-path class: a HARD phantom reached ONLY through a published
+    /// file that no declared surface references (`redux-persist/lib/integration/
+    /// react` → `react`). Node's legacy resolution makes it genuinely importable,
+    /// but nothing in the manifest says a consumer does — so it is real-but-
+    /// lower-confidence, and a downstream consumer should be able to weigh it
+    /// separately from a `main`-reachable phantom.
+    pub fn is_deep_path_only(&self) -> bool {
+        self.verdict == Verdict::HardPhantom
+            && self.from_deep_path
+            && !self.from_main
+            && !self.from_subpath
+            && !self.from_types
     }
 }
 
@@ -74,6 +100,7 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
         from_main: bool,
         from_subpath: bool,
         from_types: bool,
+        from_deep_path: bool,
         specs: Vec<String>,
     }
     let mut by_pkg: BTreeMap<String, Agg> = BTreeMap::new();
@@ -83,12 +110,14 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
             from_main: false,
             from_subpath: false,
             from_types: false,
+            from_deep_path: false,
             specs: Vec::new(),
         });
         e.all_soft &= r.soft;
         e.from_main |= r.from_main;
         e.from_subpath |= r.from_subpath;
         e.from_types |= r.from_types;
+        e.from_deep_path |= r.from_deep_path;
         if !e.specs.contains(&r.raw) {
             e.specs.push(r.raw.clone());
         }
@@ -97,7 +126,9 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
     by_pkg
         .into_iter()
         .map(|(package, agg)| {
-            let verdict = verdict_for(manifest, &package, agg.all_soft);
+            let deep_path_only =
+                agg.from_deep_path && !agg.from_main && !agg.from_subpath && !agg.from_types;
+            let verdict = verdict_for(manifest, &package, agg.all_soft, deep_path_only);
             Finding {
                 package,
                 verdict,
@@ -105,13 +136,19 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
                 from_main: agg.from_main,
                 from_subpath: agg.from_subpath,
                 from_types: agg.from_types,
+                from_deep_path: agg.from_deep_path,
                 specifiers: agg.specs,
             }
         })
         .collect()
 }
 
-fn verdict_for(manifest: &Manifest, package: &str, all_soft: bool) -> Verdict {
+fn verdict_for(
+    manifest: &Manifest,
+    package: &str,
+    all_soft: bool,
+    deep_path_only: bool,
+) -> Verdict {
     if is_self(manifest, package) {
         return Verdict::SelfRef;
     }
@@ -127,7 +164,13 @@ fn verdict_for(manifest: &Manifest, package: &str, all_soft: bool) -> Verdict {
     if manifest.required_peers.contains(package) {
         return Verdict::DeclaredPeer;
     }
-    // Undeclared.
+    // Undeclared. A speculative deep-path root importing one of the package's own
+    // devDependencies is the shipped-build-helper shape, not a consumer surface —
+    // the author declared the import dev-time and nothing published reaches the
+    // file, so a speculative root does not get to promote it to a phantom.
+    if deep_path_only && manifest.dev_deps.contains(package) {
+        return Verdict::DevOnlyDeepPath;
+    }
     if all_soft {
         Verdict::SoftPhantom
     } else {
@@ -157,6 +200,7 @@ mod tests {
                 from_main: true,
                 from_subpath: false,
                 from_types: false,
+                from_deep_path: false,
             })
             .collect()
     }
@@ -204,6 +248,42 @@ mod tests {
     }
 
     #[test]
+    fn deep_path_only_devdep_is_not_a_phantom_but_a_reached_one_is() {
+        // A speculative deep-path root importing one of the package's OWN
+        // devDependencies is a shipped build/test helper — the author declared the
+        // import dev-time and no published surface reaches the file, so the
+        // speculative root does not get to promote it to a phantom. The same
+        // devDep reached from `main` is unaffected and stays hard.
+        let m = Manifest::parse(br#"{"name":"pkg","devDependencies":{"ava":"1"}}"#).unwrap();
+        let deep = |pkg: &str| Reference {
+            package: pkg.to_string(),
+            raw: pkg.to_string(),
+            soft: false,
+            from_main: false,
+            from_subpath: false,
+            from_types: false,
+            from_deep_path: true,
+        };
+        let f = classify(&m, &[deep("ava"), deep("react")]);
+        let v = |name: &str| f.iter().find(|x| x.package == name).unwrap();
+        assert_eq!(v("ava").verdict, Verdict::DevOnlyDeepPath);
+        assert_eq!(
+            v("react").verdict,
+            Verdict::HardPhantom,
+            "an undeclared package reached only by deep path is still a phantom"
+        );
+        assert!(v("react").is_deep_path_only());
+        assert!(!v("ava").is_deep_path_only());
+
+        // Same devDep, reached from `main` as well → the guard does not apply.
+        let mut also_main = deep("ava");
+        also_main.from_main = true;
+        let f = classify(&m, &[deep("ava"), also_main]);
+        assert_eq!(f[0].verdict, Verdict::HardPhantom);
+        assert!(!f[0].is_deep_path_only());
+    }
+
+    #[test]
     fn subpath_only_hard_phantom_is_the_adapter_class() {
         let m = Manifest::parse(br#"{"name":"@hookform/resolvers"}"#).unwrap();
         // A hard phantom reached only from a subpath export is the adapter class;
@@ -215,6 +295,7 @@ mod tests {
             from_main: false,
             from_subpath: true,
             from_types: false,
+            from_deep_path: false,
         };
         let main_reached = Reference {
             package: "junk".into(),
@@ -223,6 +304,7 @@ mod tests {
             from_main: true,
             from_subpath: false,
             from_types: false,
+            from_deep_path: false,
         };
         let f = classify(&m, &[subpath_only, main_reached]);
         let zod = f.iter().find(|x| x.package == "zod").unwrap();

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -31,6 +31,14 @@ const FROM_SUBPATH: u8 = 0b010;
 /// this and NOT the runtime bits, so `@types/<peer>` reachability (nub#450) is
 /// separable from a runtime require of the same peer.
 const FROM_TYPES: u8 = 0b100;
+/// Provenance bit: reached ONLY as a speculative legacy deep-path root — a
+/// published JS file no `main`/`bin`/`exports` surface references, in a package
+/// with no `exports` map, which Node's legacy resolution nonetheless lets a
+/// consumer import as `<pkg>/<path/to/file>`. Seeded in a second phase AFTER the
+/// authoritative walk reaches its fixpoint, so this bit alone never lands on a
+/// file the published surface already reaches; a reference carrying it and no
+/// runtime bit is deep-path-only, which the classifier treats as lower-confidence.
+const FROM_DEEP_PATH: u8 = 0b1000;
 
 /// A bare-specifier reference collected from a reachable file.
 #[derive(Debug, Clone)]
@@ -52,6 +60,9 @@ pub struct Reference {
     /// this surface is the nub#450 peer-type class: its `@types/<peer>` must be
     /// project-local for the type-checker's realpath walk to reach it.
     pub(crate) from_types: bool,
+    /// Reachable from a speculative legacy deep-path root (see [`FROM_DEEP_PATH`]).
+    /// Set only when [`WalkOptions::deep_path_roots`] is on.
+    pub(crate) from_deep_path: bool,
 }
 
 /// Result of the reachable-module walk.
@@ -87,6 +98,24 @@ trait FileSource {
     fn read(&self, key: &Self::Key) -> Option<String>;
     /// The package-relative path for `key` — the parser's `SourceType` hint.
     fn rel_path(&self, key: &Self::Key) -> String;
+    /// Every published file that may seed the walk as a speculative legacy
+    /// deep-path root, filtered by [`crate::manifest::is_deep_path_candidate`].
+    /// Sorted, so the two backings enumerate in the same order.
+    fn deep_path_roots(&self) -> Vec<Self::Key>;
+}
+
+/// Knobs on the reachable-graph walk. The default is the AUTHORITATIVE walk —
+/// only what `main`/`bin`/`exports`/`types` reach — and is what the shipped
+/// disk-eject scan runs.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct WalkOptions {
+    /// Additionally seed every published JS file as a speculative entry point.
+    /// Sound ONLY for a package with NO `exports` map, where Node's legacy
+    /// resolution really does let a consumer import any published path; a package
+    /// WITH `exports` cannot be deep-imported at all, so seeding its unexported
+    /// internals would manufacture phantoms for code no consumer can load.
+    /// Callers gate this on [`crate::manifest::Manifest::has_exports`].
+    pub deep_path_roots: bool,
 }
 
 /// Walk from `entry_points`, following relative edges and collecting bare
@@ -98,7 +127,14 @@ trait FileSource {
 /// once (cached) and propagates provenance bits to fixpoint — a file re-reached
 /// with new bits is re-queued for propagation only, never re-parsed; (2) build
 /// references from the cache using each file's FINAL mask.
-fn walk_generic<S: FileSource>(source: &S, entry_points: &[Entry]) -> Walk {
+///
+/// With [`WalkOptions::deep_path_roots`] a THIRD step sits between them: once the
+/// authoritative walk has reached its fixpoint, every still-unreached published
+/// JS file is seeded as a speculative deep-path root and drained the same way.
+/// Running it second — rather than seeding everything at once — is what keeps
+/// `FROM_DEEP_PATH` off files the published surface already reaches, so
+/// "deep-path-only" stays an exact predicate rather than an approximation.
+fn walk_generic<S: FileSource>(source: &S, entry_points: &[Entry], opts: WalkOptions) -> Walk {
     let mut result = Walk::default();
     let mut parsed: BTreeMap<S::Key, Vec<Occurrence>> = BTreeMap::new();
     let mut flags: BTreeMap<S::Key, u8> = BTreeMap::new();
@@ -117,7 +153,46 @@ fn walk_generic<S: FileSource>(source: &S, entry_points: &[Entry]) -> Walk {
             }
         }
     }
+    drain(source, &mut result, &mut parsed, &mut flags, &mut queue);
 
+    if opts.deep_path_roots {
+        for key in source.deep_path_roots() {
+            if !flags.contains_key(&key) && add_flags(&mut flags, &key, FROM_DEEP_PATH) {
+                queue.push_back(key);
+            }
+        }
+        drain(source, &mut result, &mut parsed, &mut flags, &mut queue);
+    }
+
+    result.files_analyzed = parsed.len();
+    for (file, occs) in &parsed {
+        let fflags = *flags.get(file).unwrap_or(&0);
+        for occ in occs {
+            if let SpecKind::Bare(package) = specifier::classify(&occ.spec) {
+                result.references.push(Reference {
+                    package,
+                    raw: occ.spec.clone(),
+                    soft: occ.soft,
+                    from_main: fflags & FROM_MAIN != 0,
+                    from_subpath: fflags & FROM_SUBPATH != 0,
+                    from_types: fflags & FROM_TYPES != 0,
+                    from_deep_path: fflags & FROM_DEEP_PATH != 0,
+                });
+            }
+        }
+    }
+    result
+}
+
+/// BFS the queue to its fixpoint: parse each file once, follow its relative edges,
+/// and propagate provenance bits onward.
+fn drain<S: FileSource>(
+    source: &S,
+    result: &mut Walk,
+    parsed: &mut BTreeMap<S::Key, Vec<Occurrence>>,
+    flags: &mut BTreeMap<S::Key, u8>,
+    queue: &mut VecDeque<S::Key>,
+) {
     while let Some(file) = queue.pop_front() {
         let fflags = *flags.get(&file).unwrap_or(&0);
         // Parse once; a re-queue for provenance propagation reuses the cache.
@@ -145,34 +220,23 @@ fn walk_generic<S: FileSource>(source: &S, entry_points: &[Entry]) -> Walk {
         // `ImportsHash` (self) and `NonPackage` (URL/virtual/internal) are not
         // dependency edges; only `Bare` references are collected in phase 2.
         for t in targets {
-            if add_flags(&mut flags, &t, fflags) {
+            if add_flags(flags, &t, fflags) {
                 queue.push_back(t);
             }
         }
     }
-
-    result.files_analyzed = parsed.len();
-    for (file, occs) in &parsed {
-        let fflags = *flags.get(file).unwrap_or(&0);
-        for occ in occs {
-            if let SpecKind::Bare(package) = specifier::classify(&occ.spec) {
-                result.references.push(Reference {
-                    package,
-                    raw: occ.spec.clone(),
-                    soft: occ.soft,
-                    from_main: fflags & FROM_MAIN != 0,
-                    from_subpath: fflags & FROM_SUBPATH != 0,
-                    from_types: fflags & FROM_TYPES != 0,
-                });
-            }
-        }
-    }
-    result
 }
 
-/// Walk an already-extracted package tree rooted at `root`.
+/// Walk an already-extracted package tree rooted at `root` — the authoritative
+/// surface only.
 pub fn walk(root: &Path, entry_points: &[Entry]) -> Walk {
-    walk_generic(&FsSource { root }, entry_points)
+    walk_with(root, entry_points, WalkOptions::default())
+}
+
+/// [`walk`] with explicit [`WalkOptions`] — the entry the eval tool uses to turn
+/// on speculative deep-path roots for an `exports`-less package.
+pub fn walk_with(root: &Path, entry_points: &[Entry], opts: WalkOptions) -> Walk {
+    walk_generic(&FsSource { root }, entry_points, opts)
 }
 
 /// Walk a CAS-backed package: `files` are `(package-relative-path, absolute
@@ -183,8 +247,17 @@ pub fn walk(root: &Path, entry_points: &[Entry]) -> Walk {
 /// [`normalize_rel_join`] for the one accepted divergence on malformed
 /// (escape-and-re-enter-by-root-name) specifiers that never appear in practice.
 pub(crate) fn walk_index(files: &[(String, PathBuf)], entry_points: &[Entry]) -> Walk {
+    walk_index_with(files, entry_points, WalkOptions::default())
+}
+
+/// [`walk_index`] with explicit [`WalkOptions`].
+pub(crate) fn walk_index_with(
+    files: &[(String, PathBuf)],
+    entry_points: &[Entry],
+    opts: WalkOptions,
+) -> Walk {
     let map: BTreeMap<String, PathBuf> = files.iter().cloned().collect();
-    walk_generic(&IndexSource { files: map }, entry_points)
+    walk_generic(&IndexSource { files: map }, entry_points, opts)
 }
 
 /// OR `bit` into `key`'s provenance mask. Returns true if the mask GREW (new
@@ -279,6 +352,39 @@ impl FileSource for FsSource<'_> {
             .unwrap_or(key)
             .to_string_lossy()
             .into_owned()
+    }
+
+    fn deep_path_roots(&self) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+        collect_files(self.root, self.root, &mut out, 0);
+        out.sort();
+        out
+    }
+}
+
+/// Recursively list candidate deep-path roots under `dir`. Depth-bounded for the
+/// same reason the resolver is: a tarball is untrusted input.
+fn collect_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>, depth: u32) {
+    if depth > MAX_RESOLVE_DEPTH {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for e in entries.flatten() {
+        let path = e.path();
+        let Ok(ft) = e.file_type() else { continue };
+        // Symlinks are not followed: a tarball's symlink can point outside the
+        // package root, and the walk's stay-under-root invariant is the only thing
+        // keeping another package's code out of this package's findings.
+        if ft.is_dir() {
+            collect_files(root, &path, out, depth + 1);
+        } else if ft.is_file() {
+            let rel = path.strip_prefix(root).unwrap_or(&path).to_string_lossy();
+            if crate::manifest::is_deep_path_candidate(&rel.replace('\\', "/")) {
+                out.push(path);
+            }
+        }
     }
 }
 
@@ -420,6 +526,16 @@ impl FileSource for IndexSource {
     fn rel_path(&self, key: &String) -> String {
         key.clone()
     }
+
+    fn deep_path_roots(&self) -> Vec<String> {
+        // `files` is a BTreeMap, so the key iteration is already sorted — the same
+        // order `FsSource` produces after its explicit sort.
+        self.files
+            .keys()
+            .filter(|rel| crate::manifest::is_deep_path_candidate(rel))
+            .cloned()
+            .collect()
+    }
 }
 
 impl IndexSource {
@@ -523,7 +639,7 @@ fn normalize_rel_join(from_dir: &str, spec: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{walk, walk_index};
+    use super::{WalkOptions, walk, walk_index, walk_index_with, walk_with};
     use crate::manifest::{Entry, EntryKind};
     use std::fs;
     use std::path::PathBuf;
@@ -716,6 +832,105 @@ mod tests {
         assert!(a.iter().any(|p| p == "sub-dep"));
         assert!(a.iter().any(|p| p == "pkg-dep"));
         assert!(a.iter().any(|p| p == "root-dep"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn deep_path_roots_reach_an_unreferenced_published_file_only_when_enabled() {
+        // The redux-persist@6.0.0 shape: no `exports` map, `main: lib/index.js`,
+        // and a published `lib/integration/react.js` that `main` never references
+        // but consumers import as `<pkg>/lib/integration/react`. Its unguarded
+        // `require("react")` is invisible to the authoritative walk.
+        let root = scratch("deep-path");
+        fs::create_dir_all(root.join("lib/integration")).unwrap();
+        fs::create_dir_all(root.join("test")).unwrap();
+        fs::create_dir_all(root.join("examples")).unwrap();
+        fs::write(root.join("lib/index.js"), "require('declared-dep');").unwrap();
+        fs::write(
+            root.join("lib/integration/react.js"),
+            "var r = require('react');",
+        )
+        .unwrap();
+        // Non-surface directories and tooling configs ship in real tarballs and
+        // import devDependencies no consumer ever resolves.
+        fs::write(root.join("test/index.test.js"), "require('ava');").unwrap();
+        fs::write(root.join("examples/app.js"), "require('express');").unwrap();
+        fs::write(root.join("rollup.config.js"), "require('rollup-plugin-babel');").unwrap();
+        fs::write(root.join(".eslintrc.js"), "require('eslint-plugin-flowtype');").unwrap();
+
+        let eps = [main_entry("lib/index.js")];
+        let pkgs = |w: &super::Walk| -> Vec<String> {
+            let mut v: Vec<String> = w.references.iter().map(|r| r.package.clone()).collect();
+            v.sort();
+            v.dedup();
+            v
+        };
+
+        // Default (authoritative) walk: the deep-path file is unreachable.
+        assert_eq!(pkgs(&walk(&root, &eps)), vec!["declared-dep".to_string()]);
+
+        let opts = WalkOptions {
+            deep_path_roots: true,
+        };
+        let deep = walk_with(&root, &eps, opts);
+        assert_eq!(
+            pkgs(&deep),
+            vec!["declared-dep".to_string(), "react".to_string()],
+            "only the legitimate deep-path file is seeded; test/, examples/, \
+             rollup.config.js and .eslintrc.js are not"
+        );
+
+        // Provenance separates the speculative reference from the authoritative one.
+        let react = deep.references.iter().find(|r| r.package == "react").unwrap();
+        assert!(
+            react.from_deep_path && !react.from_main,
+            "react is deep-path-only: {react:?}"
+        );
+        let dep = deep
+            .references
+            .iter()
+            .find(|r| r.package == "declared-dep")
+            .unwrap();
+        assert!(
+            dep.from_main && !dep.from_deep_path,
+            "a file the published surface reaches keeps its authoritative provenance \
+             and gains no deep-path bit: {dep:?}"
+        );
+
+        // Both backings must agree, as they do for the authoritative walk.
+        let idx = walk_index_with(&index_of(&root), &eps, opts);
+        assert_eq!(pkgs(&idx), pkgs(&deep));
+        assert_eq!(idx.files_analyzed, deep.files_analyzed);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn deep_path_root_shares_provenance_with_a_file_the_main_graph_also_reaches() {
+        // A deep-path root that pulls in a module `main` already reaches must not
+        // downgrade that module: the shared file ends up with BOTH bits, so its
+        // references stay main-reachable and are classified exactly as before.
+        let root = scratch("deep-path-diamond");
+        fs::write(root.join("index.js"), "require('./shared');").unwrap();
+        fs::write(root.join("shared.js"), "require('shared-ghost');").unwrap();
+        fs::write(root.join("orphan.js"), "require('./shared');").unwrap();
+
+        let w = walk_with(
+            &root,
+            &[main_entry("index.js")],
+            WalkOptions {
+                deep_path_roots: true,
+            },
+        );
+        let shared = w
+            .references
+            .iter()
+            .find(|r| r.package == "shared-ghost")
+            .unwrap();
+        assert!(
+            shared.from_main,
+            "a main-reachable module keeps from_main even when a deep-path root \
+             also reaches it: {shared:?}"
+        );
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -855,8 +855,16 @@ mod tests {
         // import devDependencies no consumer ever resolves.
         fs::write(root.join("test/index.test.js"), "require('ava');").unwrap();
         fs::write(root.join("examples/app.js"), "require('express');").unwrap();
-        fs::write(root.join("rollup.config.js"), "require('rollup-plugin-babel');").unwrap();
-        fs::write(root.join(".eslintrc.js"), "require('eslint-plugin-flowtype');").unwrap();
+        fs::write(
+            root.join("rollup.config.js"),
+            "require('rollup-plugin-babel');",
+        )
+        .unwrap();
+        fs::write(
+            root.join(".eslintrc.js"),
+            "require('eslint-plugin-flowtype');",
+        )
+        .unwrap();
 
         let eps = [main_entry("lib/index.js")];
         let pkgs = |w: &super::Walk| -> Vec<String> {
@@ -881,7 +889,11 @@ mod tests {
         );
 
         // Provenance separates the speculative reference from the authoritative one.
-        let react = deep.references.iter().find(|r| r.package == "react").unwrap();
+        let react = deep
+            .references
+            .iter()
+            .find(|r| r.package == "react")
+            .unwrap();
         assert!(
             react.from_deep_path && !react.from_main,
             "react is deep-path-only: {react:?}"

--- a/crates/nub-phantom-scan/src/manifest.rs
+++ b/crates/nub-phantom-scan/src/manifest.rs
@@ -349,7 +349,7 @@ fn extension(path: &str) -> Option<&str> {
 /// is the load-bearing one: a bundled dep's own imports are the BUNDLED
 /// package's, and attributing them to the outer package is a false positive by
 /// construction.
-const NON_SURFACE_DIRS: [&str; 22] = [
+const NON_SURFACE_DIRS: [&str; 24] = [
     "node_modules",
     "test",
     "tests",
@@ -372,6 +372,8 @@ const NON_SURFACE_DIRS: [&str; 22] = [
     "script",
     "scripts",
     "coverage",
+    "doc",
+    "docs",
 ];
 
 /// File names that are a dev script by overwhelming convention, at any depth. A
@@ -416,6 +418,10 @@ pub(crate) fn is_deep_path_candidate(rel: &str) -> bool {
         let stem = lower.rsplit_once('.').map_or(lower.as_str(), |(s, _)| s);
         if stem.ends_with(".test")
             || stem.ends_with(".spec")
+            // `@aws-crypto/sha256-js` compiles `knownHashes.fixture.ts` into its
+            // published `build/`, where it imports an `@aws-sdk` package the
+            // manifest declares nowhere — a shipped test fixture, not a surface.
+            || stem.ends_with(".fixture")
             || stem.ends_with("-test")
             || stem.ends_with("_test")
             || stem.ends_with(".config")
@@ -463,7 +469,11 @@ mod tests {
         // `has_exports` is what decides whether legacy deep-path roots are sound:
         // an `exports` map is Node's encapsulation boundary, so an unexported file
         // genuinely cannot be imported and must never seed the walk.
-        assert!(!Manifest::parse(br#"{"name":"p","main":"lib/index.js"}"#).unwrap().has_exports);
+        assert!(
+            !Manifest::parse(br#"{"name":"p","main":"lib/index.js"}"#)
+                .unwrap()
+                .has_exports
+        );
         assert!(
             Manifest::parse(br#"{"name":"p","exports":{".":"./index.js"}}"#)
                 .unwrap()
@@ -504,6 +514,8 @@ mod tests {
             ".github/workflow.js",
             "lib/thing.test.js",
             "lib/thing.spec.js",
+            "build/knownHashes.fixture.js",
+            "docs/example.js",
             "lib/thing-test.js",
             "rollup.config.js",
             "karma.conf.js",

--- a/crates/nub-phantom-scan/src/manifest.rs
+++ b/crates/nub-phantom-scan/src/manifest.rs
@@ -26,6 +26,19 @@ pub struct Manifest {
     pub(crate) optional_peers: BTreeSet<String>,
     /// `bundledDependencies` / `bundleDependencies` — shipped inside the tarball.
     pub(crate) bundled: BTreeSet<String>,
+    /// `devDependencies`. NOT part of the declared surface — a consumer install
+    /// does not make them resolvable, so importing one from published code is a
+    /// phantom. Kept only to discriminate the SPECULATIVE deep-path class: a file
+    /// reachable by nothing but a deep path, importing a package the author did
+    /// declare as a devDep, is a shipped build/test helper rather than a public
+    /// surface (see [`crate::classify`]).
+    pub(crate) dev_deps: BTreeSet<String>,
+    /// Whether the manifest declares an `exports` map. An `exports` map is Node's
+    /// encapsulation boundary: it is the AUTHORITATIVE public surface, and a file
+    /// it does not name genuinely cannot be imported. Without one, Node's legacy
+    /// resolution lets a consumer `require('<pkg>/<any/published/file.js>')`, so
+    /// every published JS file is a potential entry point.
+    pub has_exports: bool,
     /// Published entry files (relative paths from the package root) — the roots
     /// of the reachable-module walk, each tagged by whether it is the main entry
     /// or a non-`.` `exports` subpath (the adapter surface).
@@ -86,7 +99,11 @@ impl Manifest {
             }
         }
 
+        collect_keys(&v, "devDependencies", &mut m.dev_deps);
         collect_bundled(&v, &mut m.bundled);
+        // `"exports": null` counts: it exports nothing, which is still an
+        // encapsulation boundary, not a legacy deep-path-open package.
+        m.has_exports = v.get("exports").is_some();
         m.entry_points = collect_entry_points(&v);
         Some(m)
     }
@@ -326,6 +343,99 @@ fn extension(path: &str) -> Option<&str> {
     file.rsplit_once('.').map(|(_, e)| e)
 }
 
+/// Directory names that ship in tarballs but are never a consumer's import
+/// target. Deep-path seeding is speculative — "Node COULD resolve this" — so it
+/// is bounded to the directories where a deep import is plausible. `node_modules`
+/// is the load-bearing one: a bundled dep's own imports are the BUNDLED
+/// package's, and attributing them to the outer package is a false positive by
+/// construction.
+const NON_SURFACE_DIRS: [&str; 22] = [
+    "node_modules",
+    "test",
+    "tests",
+    "__tests__",
+    "__test__",
+    "spec",
+    "__specs__",
+    "__mocks__",
+    "mocks",
+    "fixture",
+    "fixtures",
+    "__fixtures__",
+    "example",
+    "examples",
+    "demo",
+    "demos",
+    "benchmark",
+    "benchmarks",
+    "bench",
+    "script",
+    "scripts",
+    "coverage",
+];
+
+/// File names that are a dev script by overwhelming convention, at any depth. A
+/// narrower list than [`NON_SURFACE_DIRS`] on purpose: `mocks.js` or `fixtures.js`
+/// can plausibly be a real module, `bench.js` cannot.
+const DEV_SCRIPT_STEMS: [&str; 8] = [
+    "bench",
+    "benchmark",
+    "benchmarks",
+    "test",
+    "tests",
+    "spec",
+    "example",
+    "examples",
+];
+
+/// Whether a published file may SPECULATIVELY seed the walk as a legacy deep-path
+/// entry (`require('<pkg>/lib/integration/react')`), for a package with no
+/// `exports` map. Admits JS-like files only, outside the non-surface directories
+/// above, excluding dotfiles/dot-dirs (`.eslintrc.js`, `.github/`), `*.test.*` /
+/// `*.spec.*` siblings, and build-tool configs (`rollup.config.js`, `gulpfile.js`)
+/// — all of which ship routinely and import devDependencies no consumer ever
+/// resolves. `.d.ts` is excluded by `is_js_like`; the type surface has its own
+/// seeding.
+pub(crate) fn is_deep_path_candidate(rel: &str) -> bool {
+    if !is_js_like(rel) {
+        return false;
+    }
+    let mut segments = rel.split('/').peekable();
+    while let Some(seg) = segments.next() {
+        let lower = seg.to_ascii_lowercase();
+        if lower.starts_with('.') {
+            return false;
+        }
+        if segments.peek().is_some() {
+            if NON_SURFACE_DIRS.contains(&lower.as_str()) {
+                return false;
+            }
+            continue;
+        }
+        // Last segment: the file name.
+        let stem = lower.rsplit_once('.').map_or(lower.as_str(), |(s, _)| s);
+        if stem.ends_with(".test")
+            || stem.ends_with(".spec")
+            || stem.ends_with("-test")
+            || stem.ends_with("_test")
+            || stem.ends_with(".config")
+            || stem.ends_with(".conf")
+            || matches!(stem, "gulpfile" | "gruntfile" | "makefile")
+            // A file whose whole name is a dev-script convention, wherever it
+            // sits. asynckit ships a root `bench.js` requiring `async` and
+            // `benchmark` (neither declared, not even as devDeps) purely because
+            // it has no `files` whitelist — importable in principle, imported by
+            // nobody. Excluding one here can only lose a SPECULATIVE root: a file
+            // the published surface actually references is reached in the
+            // authoritative phase, before deep-path seeding runs.
+            || DEV_SCRIPT_STEMS.contains(&stem)
+        {
+            return false;
+        }
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::Manifest;
@@ -346,6 +456,65 @@ mod tests {
         assert!(m.required_peers.contains("react"));
         assert!(m.optional_peers.contains("zod")); // optional peer moved out of required
         assert!(!m.required_peers.contains("zod"));
+    }
+
+    #[test]
+    fn has_exports_gates_deep_path_seeding_and_candidates_exclude_non_surface_files() {
+        // `has_exports` is what decides whether legacy deep-path roots are sound:
+        // an `exports` map is Node's encapsulation boundary, so an unexported file
+        // genuinely cannot be imported and must never seed the walk.
+        assert!(!Manifest::parse(br#"{"name":"p","main":"lib/index.js"}"#).unwrap().has_exports);
+        assert!(
+            Manifest::parse(br#"{"name":"p","exports":{".":"./index.js"}}"#)
+                .unwrap()
+                .has_exports
+        );
+        assert!(
+            Manifest::parse(br#"{"name":"p","exports":null}"#)
+                .unwrap()
+                .has_exports,
+            "`exports: null` exports nothing — still an encapsulation boundary"
+        );
+
+        let cand = super::is_deep_path_candidate;
+        // The redux-persist@6.0.0 miss: a published file no entry references.
+        assert!(cand("lib/integration/react.js"));
+        assert!(cand("es/index.mjs") && cand("src/persistReducer.js"));
+        // A dev-script FILE name, wherever it sits — asynckit's root `bench.js`.
+        assert!(!cand("bench.js") && !cand("test.js") && !cand("example.js"));
+        // Non-surface directories that ship in real tarballs.
+        for p in [
+            "test/index.js",
+            "tests/a.js",
+            "__tests__/a.js",
+            "__mocks__/fs.js",
+            "example/app.js",
+            "examples/app.js",
+            "benchmark/run.js",
+            "bench/run.js",
+            "scripts/build.js",
+            "coverage/lcov.js",
+            "node_modules/dep/index.js",
+        ] {
+            assert!(!cand(p), "{p} must not seed the walk");
+        }
+        // Dotfiles/dot-dirs, test siblings, and build-tool configs.
+        for p in [
+            ".eslintrc.js",
+            ".github/workflow.js",
+            "lib/thing.test.js",
+            "lib/thing.spec.js",
+            "lib/thing-test.js",
+            "rollup.config.js",
+            "karma.conf.js",
+            "gulpfile.js",
+        ] {
+            assert!(!cand(p), "{p} must not seed the walk");
+        }
+        // A `.d.ts` has its own Types surface; non-JS carries no imports.
+        assert!(!cand("index.d.ts") && !cand("data.json") && !cand("README.md"));
+        // `config.js` is an ordinary module — only `<tool>.config.js` is excluded.
+        assert!(cand("lib/config.js"));
     }
 
     #[test]

--- a/crates/nub-phantom/src/lib.rs
+++ b/crates/nub-phantom/src/lib.rs
@@ -157,13 +157,15 @@ mod tests {
             root
         };
 
-        let legacy = build(
-            r#"{"name":"demo","main":"lib/index.js","devDependencies":{"ava":"1"}}"#,
-        );
+        let legacy =
+            build(r#"{"name":"demo","main":"lib/index.js","devDependencies":{"ava":"1"}}"#);
         let r = analyze_extracted(&legacy, "0.0.0").unwrap();
         let f = r.findings.iter().find(|f| f.package == "react").unwrap();
         assert_eq!(f.verdict, Verdict::HardPhantom);
-        assert!(f.is_deep_path_only(), "flagged as the deep-path class: {f:?}");
+        assert!(
+            f.is_deep_path_only(),
+            "flagged as the deep-path class: {f:?}"
+        );
         assert_eq!(r.deep_path_phantoms().count(), 1);
         assert!(
             !r.findings.iter().any(|f| f.package == "ava"),

--- a/crates/nub-phantom/src/lib.rs
+++ b/crates/nub-phantom/src/lib.rs
@@ -54,6 +54,15 @@ impl PackageReport {
             .filter(|f| f.verdict == Verdict::HardPhantom)
     }
 
+    /// Hard phantoms of the LEGACY DEEP-PATH class — reached only through a
+    /// published file no declared surface references, which Node's legacy
+    /// resolution still lets a consumer import (`redux-persist/lib/integration/
+    /// react` → `react`). Separable so a downstream consumer can weigh them
+    /// against `main`-reachable phantoms rather than merging the two.
+    pub fn deep_path_phantoms(&self) -> impl Iterator<Item = &Finding> {
+        self.findings.iter().filter(|f| f.is_deep_path_only())
+    }
+
     /// Hard phantoms of the subpath-adapter class (subpath-only) — the
     /// consumer-provided-backend pattern that breaks under GVS-default.
     pub fn subpath_adapter_phantoms(&self) -> impl Iterator<Item = &Finding> {
@@ -83,7 +92,18 @@ pub fn analyze_extracted(root: &Path, version: &str) -> Result<PackageReport, St
     let raw =
         std::fs::read(root.join("package.json")).map_err(|e| format!("read package.json: {e}"))?;
     let manifest = Manifest::parse(&raw).ok_or("unparseable package.json / no name")?;
-    let walk = graph::walk(root, &manifest.entry_points);
+    // An `exports` map is the authoritative public surface, so a package that has
+    // one is walked from it alone. Without one, Node's legacy resolution lets a
+    // consumer import ANY published file by deep path — `redux-persist` ships no
+    // `exports`, and its `lib/integration/react.js` (a documented import target)
+    // is reached by nothing from `main`, so its undeclared `require("react")` was
+    // invisible. The eval tool opts in; the shipped disk-eject scan does not (see
+    // `nub_phantom_scan::scan_extracted`), because these findings are speculative
+    // and the eject decision must not act on them unreviewed.
+    let opts = graph::WalkOptions {
+        deep_path_roots: !manifest.has_exports,
+    };
+    let walk = graph::walk_with(root, &manifest.entry_points, opts);
     let findings = classify::classify(&manifest, &walk.references);
     Ok(PackageReport {
         name: manifest.name,
@@ -105,6 +125,64 @@ mod tests {
     use super::analyze_extracted;
     use crate::classify::Verdict;
     use std::fs;
+
+    /// The legacy deep-path class, end to end and both ways round: a package with
+    /// NO `exports` map has every published file speculatively seeded (the
+    /// redux-persist@6.0.0 miss), while the SAME tree with an `exports` map keeps
+    /// its unexported internals out of the walk — `exports` is Node's encapsulation
+    /// boundary, so a file it does not name cannot be imported and must not
+    /// manufacture a phantom.
+    #[test]
+    fn deep_path_roots_apply_only_without_an_exports_map() {
+        let build = |manifest: &str| {
+            let root = std::env::temp_dir().join(format!(
+                "nub-phantom-deep-{}-{:x}",
+                std::process::id(),
+                manifest.len()
+            ));
+            let _ = fs::remove_dir_all(&root);
+            fs::create_dir_all(root.join("lib/integration")).unwrap();
+            fs::create_dir_all(root.join("test")).unwrap();
+            fs::write(root.join("package.json"), manifest).unwrap();
+            fs::write(root.join("lib/index.js"), "module.exports = {};").unwrap();
+            // Reachable only by `<pkg>/lib/integration/react` — a documented import
+            // target that `main` never references.
+            fs::write(
+                root.join("lib/integration/react.js"),
+                "var r = require('react');",
+            )
+            .unwrap();
+            // Ships in the tarball, imports a devDep: must stay invisible either way.
+            fs::write(root.join("test/index.js"), "require('ava');").unwrap();
+            root
+        };
+
+        let legacy = build(
+            r#"{"name":"demo","main":"lib/index.js","devDependencies":{"ava":"1"}}"#,
+        );
+        let r = analyze_extracted(&legacy, "0.0.0").unwrap();
+        let f = r.findings.iter().find(|f| f.package == "react").unwrap();
+        assert_eq!(f.verdict, Verdict::HardPhantom);
+        assert!(f.is_deep_path_only(), "flagged as the deep-path class: {f:?}");
+        assert_eq!(r.deep_path_phantoms().count(), 1);
+        assert!(
+            !r.findings.iter().any(|f| f.package == "ava"),
+            "test/ never seeds the walk: {:?}",
+            r.findings
+        );
+        let _ = fs::remove_dir_all(&legacy);
+
+        let encapsulated = build(
+            r#"{"name":"demo","exports":{".":"./lib/index.js"},"devDependencies":{"ava":"1"}}"#,
+        );
+        let r = analyze_extracted(&encapsulated, "0.0.0").unwrap();
+        assert!(
+            r.findings.is_empty(),
+            "an `exports` map bars deep imports — no speculative roots: {:?}",
+            r.findings
+        );
+        let _ = fs::remove_dir_all(&encapsulated);
+    }
 
     /// End-to-end over a hand-built package tree: exercises the whole pipeline —
     /// entry resolution, graph walk, extraction, and classification of every

--- a/crates/nub-phantom/src/main.rs
+++ b/crates/nub-phantom/src/main.rs
@@ -228,6 +228,12 @@ struct Offender {
     /// The subset of `hard_phantoms` that are the subpath-adapter class
     /// (consumer-provided backend, reached only via a `<pkg>/<adapter>` subpath).
     subpath_adapter_phantoms: Vec<Finding>,
+    /// The subset of `hard_phantoms` that are the legacy deep-path class — reached
+    /// only through a published file no declared surface references, importable
+    /// because the package ships no `exports` map. Lower confidence than the other
+    /// two classes: real per Node resolution, but speculative as to whether any
+    /// consumer takes that path.
+    deep_path_phantoms: Vec<Finding>,
 }
 
 #[derive(Debug, Serialize)]
@@ -249,8 +255,12 @@ struct Totals {
     packages_with_subpath_adapter: usize,
     /// Subpath-adapter phantom edges across the scan.
     subpath_adapter_edges: usize,
+    /// Packages exhibiting the legacy deep-path class.
+    packages_with_deep_path: usize,
+    /// Legacy deep-path phantom edges across the scan.
+    deep_path_edges: usize,
     /// The complement: hard phantoms reachable from the main graph (accidental
-    /// undeclared deps — "genuine junk", not the adapter class).
+    /// undeclared deps — "genuine junk", not the adapter or deep-path classes).
     main_graph_hard_edges: usize,
     /// How many findings a NAIVE detector (undeclared incl. optional peers + soft
     /// loads) would have flagged as phantoms across the scan…
@@ -272,11 +282,14 @@ fn aggregate(reports: &[PackageReport], failures: &[(String, String)]) -> ScanRe
     let mut soft = 0usize;
     let mut adapter_pkgs = 0usize;
     let mut adapter_edges = 0usize;
+    let mut deep_pkgs = 0usize;
+    let mut deep_edges = 0usize;
 
     for r in reports {
         naive += r.naive_phantom_count();
         let hard: Vec<Finding> = r.hard_phantoms().cloned().collect();
         let adapters: Vec<Finding> = r.subpath_adapter_phantoms().cloned().collect();
+        let deep: Vec<Finding> = r.deep_path_phantoms().cloned().collect();
         let soft_ph: Vec<Finding> = r
             .findings
             .iter()
@@ -291,6 +304,10 @@ fn aggregate(reports: &[PackageReport], failures: &[(String, String)]) -> ScanRe
         if !adapters.is_empty() {
             adapter_pkgs += 1;
         }
+        deep_edges += deep.len();
+        if !deep.is_empty() {
+            deep_pkgs += 1;
+        }
         for f in &hard {
             target_importers
                 .entry(f.package.clone())
@@ -304,6 +321,7 @@ fn aggregate(reports: &[PackageReport], failures: &[(String, String)]) -> ScanRe
                 hard_phantoms: hard,
                 soft_phantoms: soft_ph,
                 subpath_adapter_phantoms: adapters,
+                deep_path_phantoms: deep,
             });
         }
     }
@@ -351,7 +369,9 @@ fn aggregate(reports: &[PackageReport], failures: &[(String, String)]) -> ScanRe
             distinct_hard_phantom_targets: phantom_targets.len(),
             packages_with_subpath_adapter: adapter_pkgs,
             subpath_adapter_edges: adapter_edges,
-            main_graph_hard_edges: total_hard_edges - adapter_edges,
+            packages_with_deep_path: deep_pkgs,
+            deep_path_edges: deep_edges,
+            main_graph_hard_edges: total_hard_edges - adapter_edges - deep_edges,
             naive_phantom_flags: naive,
             real_hard_phantom_flags: real_hard,
             optional_peers_excluded: optional_peers,
@@ -373,13 +393,26 @@ fn print_report_human(r: &PackageReport) {
             Verdict::Declared => "ok       ",
             Verdict::Builtin => "builtin  ",
             Verdict::SelfRef => "self     ",
+            Verdict::DevOnlyDeepPath => "dev-deep ",
         };
         // Only surface the interesting verdicts by default.
         if matches!(
             f.verdict,
             Verdict::HardPhantom | Verdict::SoftPhantom | Verdict::DeclaredOptionalPeer
         ) {
-            println!("  {tag} {}  [{}]", f.package, f.specifiers.join(", "));
+            // A deep-path-only phantom is real per Node resolution but speculative
+            // as to whether a consumer takes that path — marked so a reader never
+            // has to infer the difference from the provenance bits.
+            let via = if f.is_deep_path_only() {
+                "  (deep-path only)"
+            } else {
+                ""
+            };
+            println!(
+                "  {tag} {}  [{}]{via}",
+                f.package,
+                f.specifiers.join(", ")
+            );
         }
     }
 }
@@ -409,6 +442,20 @@ fn print_scan_human(a: &ScanReport) {
         a.totals.subpath_adapter_edges,
         a.totals.main_graph_hard_edges
     );
+    println!(
+        "LEGACY DEEP-PATH CLASS (no exports map; lower confidence): {} packages, {} edges",
+        a.totals.packages_with_deep_path, a.totals.deep_path_edges
+    );
+
+    println!("\n-- legacy deep-path offenders (reachable only by deep import) --");
+    for o in a.offenders.iter().filter(|o| !o.deep_path_phantoms.is_empty()) {
+        let names: Vec<&str> = o
+            .deep_path_phantoms
+            .iter()
+            .map(|f| f.package.as_str())
+            .collect();
+        println!("  {}@{}  ->  {}", o.package, o.version, names.join(", "));
+    }
 
     println!("\n-- subpath-adapter offenders (consumer-provided backend, breaks under GVS) --");
     for o in a

--- a/crates/nub-phantom/src/main.rs
+++ b/crates/nub-phantom/src/main.rs
@@ -408,11 +408,7 @@ fn print_report_human(r: &PackageReport) {
             } else {
                 ""
             };
-            println!(
-                "  {tag} {}  [{}]{via}",
-                f.package,
-                f.specifiers.join(", ")
-            );
+            println!("  {tag} {}  [{}]{via}", f.package, f.specifiers.join(", "));
         }
     }
 }
@@ -448,7 +444,11 @@ fn print_scan_human(a: &ScanReport) {
     );
 
     println!("\n-- legacy deep-path offenders (reachable only by deep import) --");
-    for o in a.offenders.iter().filter(|o| !o.deep_path_phantoms.is_empty()) {
+    for o in a
+        .offenders
+        .iter()
+        .filter(|o| !o.deep_path_phantoms.is_empty())
+    {
         let names: Vec<&str> = o
             .deep_path_phantoms
             .iter()


### PR DESCRIPTION
A package with no `exports` map has no encapsulation boundary: Node resolves `<pkg>/<any/published/file>`. The walk seeded only `main`/`bin`/`exports`, so `redux-persist@6.0.0`'s `lib/integration/react.js` and its undeclared `require("react")` were never parsed.

Published JS files now seed the walk as speculative roots — only without an `exports` map, and tagged `from_deep_path`. Seeding is opt-in and the shipped disk-eject scan does not enable it.

A/B over the top 2000 packages: +4 hard edges, 0 removed. Two are documented deep imports (`memfs/lib/fsa-to-node`, `recast/parsers/acorn`) naming an undeclared package. An earlier build added 14; 11 were browserify bundles, whose inlined factories bind their own `require` parameter.

A parameter-bound `require` is no longer recorded as an edge. That guard is in the shared extractor, so it applies everywhere including the shipped scan, and it removes a pre-existing false positive on packages whose `main` is a bundle.
