### PR TITLE
fix: preserve CommonJS cache under standalone loader imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1204,6 +1204,9 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: echo "__NUB_BUSYBOX_EXE=$GITHUB_WORKSPACE/vendor/busybox-w32/busybox64.exe" >> "$GITHUB_ENV"
+      - name: Standalone loader package fixtures
+        if: matrix.os == 'ubuntu-latest' && matrix.node == '22.15'
+        run: tests/loader/run-matrix.sh
       - run: cargo test
       # `compile` is not a default feature, so the bare `cargo test` above never
       # builds `src/compile/**` — including the bundler's emitted-chunk validity

--- a/runtime/loader-entry.mjs
+++ b/runtime/loader-entry.mjs
@@ -87,13 +87,16 @@ function isOwnLoaderToken(value) {
 // delivery channel (execArgv or NODE_OPTIONS). Same two-channel scan as
 // preload-common's computeForeignAsyncLoaderFlagPresent, but value-aware so our
 // own token is excluded.
-function foreignAsyncLoaderPresent() {
+function foreignAsyncLoaderPresent(includeRequire = false) {
   const tokens = [];
+  const flags = ["--import", "--loader", "--experimental-loader", "--experimental_loader"];
+  if (includeRequire) flags.push("--require", "-r");
   const argv = Array.isArray(process.execArgv) ? process.execArgv : [];
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (typeof a !== "string") continue;
-    for (const flag of ["--import", "--loader", "--experimental-loader"]) {
+    if (includeRequire && a.startsWith("-r") && a.length > 2) tokens.push(a.slice(2));
+    for (const flag of flags) {
       if (a === flag) {
         if (typeof argv[i + 1] === "string") tokens.push(argv[i + 1]);
       } else if (a.startsWith(`${flag}=`)) {
@@ -103,7 +106,9 @@ function foreignAsyncLoaderPresent() {
   }
   const opts = process.env.NODE_OPTIONS;
   if (typeof opts === "string" && opts !== "") {
-    const re = /(?:^|\s)--(?:experimental-)?(?:import|loader)(?:=|\s)("[^"]*"|\S*)/g;
+    const re = includeRequire
+      ? /(?:^|\s)(?:--(?:(?:experimental[-_])?(?:import|loader)|require)(?:=|\s)|-r(?:\s|=)?)("[^"]*"|\S*)/g
+      : /(?:^|\s)--(?:experimental[-_])?(?:import|loader)(?:=|\s)("[^"]*"|\S*)/g;
     for (const match of opts.matchAll(re)) {
       tokens.push((match[1] || "").replace(/^"|"$/g, ""));
     }
@@ -159,8 +164,10 @@ export function arm({ esm = true, cjs = true } = {}) {
   if (wantEsm) {
     if (hasSyncHooks && !forceAsync) {
       // The standalone --import is our own loader, not a foreign async hook.
-      // Share that distinction with the import-of-CJS require.cache repair.
-      const { resolve, load } = common.makeHooks(core, watchReporting, foreignLoaderFlagPresent);
+      // Earlier --require preloads may have registered hooks before our detectors
+      // were installed. Decline the cache repair for them too, without assuming
+      // their hooks are async when choosing the composition tier above.
+      const { resolve, load } = common.makeHooks(core, watchReporting, foreignAsyncLoaderPresent(true));
       module_.registerHooks({ resolve, load });
       armed.esmMode = "sync";
     } else {

--- a/runtime/loader-entry.mjs
+++ b/runtime/loader-entry.mjs
@@ -153,11 +153,14 @@ export function arm({ esm = true, cjs = true } = {}) {
   // loader (tsx, ts-node, an OTel ESM attach) would crash resolution. Register
   // via the async path there instead so both loaders compose all-async — the same
   // tier decision the CLI preload makes, minus counting ourselves as foreign.
-  const forceAsync = common.nodeHookComposeBroken() && foreignAsyncLoaderPresent();
+  const foreignLoaderFlagPresent = foreignAsyncLoaderPresent();
+  const forceAsync = common.nodeHookComposeBroken() && foreignLoaderFlagPresent;
 
   if (wantEsm) {
     if (hasSyncHooks && !forceAsync) {
-      const { resolve, load } = common.makeHooks(core, watchReporting);
+      // The standalone --import is our own loader, not a foreign async hook.
+      // Share that distinction with the import-of-CJS require.cache repair.
+      const { resolve, load } = common.makeHooks(core, watchReporting, foreignLoaderFlagPresent);
       module_.registerHooks({ resolve, load });
       armed.esmMode = "sync";
     } else {

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -293,6 +293,7 @@ function cliAsyncLoaderPresent() {
         if (
           a === "--loader" || a.startsWith("--loader=") ||
           a === "--experimental-loader" || a.startsWith("--experimental-loader=") ||
+          a === "--experimental_loader" || a.startsWith("--experimental_loader=") ||
           a === "--import" || a.startsWith("--import=")
         ) { present = true; break; }
       }
@@ -370,7 +371,7 @@ function computeForeignAsyncLoaderFlagPresent() {
   if (cliAsyncLoaderPresent()) return true; // execArgv channel
   const opts = process.env.NODE_OPTIONS;
   if (typeof opts !== "string" || opts === "") return false;
-  const re = /(?:^|\s)--(?:experimental-)?(?:import|loader)(?:=|\s)("[^"]*"|\S*)/g;
+  const re = /(?:^|\s)--(?:experimental[-_])?(?:import|loader)(?:=|\s)("[^"]*"|\S*)/g;
   for (const match of opts.matchAll(re)) {
     const value = (match[1] || "").replace(/^"|"$/g, "");
     if (!NUB_CHAIN_MARKER.test(value)) return true;

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -316,9 +316,10 @@ function cliAsyncLoaderPresent() {
 // against a user async loader, and Node rejected the `commonjs-sync`+null-source pair
 // (#669). That helper also excludes nub's OWN preload chainer, which rides NODE_OPTIONS
 // as `--import`; a raw scan here would read it as a user loader and silently decline
-// the relabel for every chained project.
-function userAsyncLoaderActive() {
-  return __userAsyncLoaderRegistered || foreignAsyncLoaderFlagPresent();
+// the relabel for every chained project. The standalone loader supplies its
+// value-aware flag scan instead, excluding its own --import entrypoint too.
+function userAsyncLoaderActive(foreignLoaderFlagPresent) {
+  return __userAsyncLoaderRegistered || foreignLoaderFlagPresent;
 }
 
 // The Node band where the async `module.register` loader's `resolveSync`/`loadSync`
@@ -634,7 +635,7 @@ function restoreSchemeOnlyBuiltinURL(result) {
   }
 }
 
-function makeHooks(core, watchReporting) {
+function makeHooks(core, watchReporting, foreignLoaderFlagPresent = foreignAsyncLoaderFlagPresent()) {
   installUserHookDetector();
   installUserAsyncLoaderDetector();
 
@@ -894,7 +895,7 @@ function makeHooks(core, watchReporting) {
       typeof url === "string" && url.startsWith("file:") &&
       Array.isArray(context && context.conditions) &&
       context.conditions.includes("import") &&
-      !__userHooksRegistered && !userAsyncLoaderActive()
+      !__userHooksRegistered && !userAsyncLoaderActive(foreignLoaderFlagPresent)
     ) {
       return { ...r, format: "commonjs-sync" };
     }

--- a/tests/build-slots/run.sh
+++ b/tests/build-slots/run.sh
@@ -91,6 +91,14 @@ last() { awk -v n="$1" -v k="$2" 'NR==1{t0=$1} $2==n && $3==k {t=$1-t0} END{prin
 check() {
   if eval "$2" 2>/dev/null; then echo "  ok   $1"; else echo "  FAIL $1"; fails=$((fails + 1)); fi
 }
+await_setup() {
+  remaining=20
+  until eval "$2"; do
+    remaining=$((remaining - 1))
+    [ "$remaining" -gt 0 ] || { echo "  FAIL setup: $1"; exit 1; }
+    sleep 1
+  done
+}
 timeline() { awk 'NR==1{t0=$1} {printf "t+%ds %s %s; ", $1-t0, $2, $3}' "$T/log/events"; echo; }
 want=" $* "
 run() { [ "$want" = "  " ] || case $want in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
@@ -134,20 +142,31 @@ printf '%s A cargo-start\n' "\$(date +%s)" >> "$T/log/events"
 "$W" "$T/bin/rustc" A 5 2>>"$T/log/wrapper.err"
 printf '%s A cargo-end\n' "\$(date +%s)" >> "$T/log/events"
 IDLE
-  # C's cargo is launched FIRST (lowest pid) but compiles only from t+2; A
-  # compiles 1s at t+0 and idles 8s; B queues at t+1, D at t+5. B reclaims the
-  # slot at ~t+6 and holds it to ~t+12 (two 5s compiles in a pair), so A
-  # re-queues (t+9) while B still holds: at B's release the line is A (first
-  # queued t+0), C (t+2), D (t+5), and A must go first — unless a re-queue
-  # loses its place, in which case the tie falls to C's lower pid. C's compiles
+  cat > "$T/late.sh" <<LATE
+while [ ! -e "$T/release-c" ]; do sleep 1; done
+exec /bin/sh "$T/build.sh" C 3 1 6
+LATE
+  # C's cargo is launched FIRST (lowest pid) but queues only after B's ticket
+  # is in an earlier clock second. Sleeps alone can give B and C the same
+  # ticket time on a busy runner, letting C's lower pid win the tie. A
+  # compiles for 1s and idles for 8s. B reclaims the slot and holds it for two
+  # parallel 5s compiles, so A re-queues while B still holds. At B's release,
+  # A must precede C and D using its original ticket. C's lower pid prevents
+  # pid order alone from passing this check. C's compiles
   # are 6s under a 4s window: a holder whose compile OUTLASTS the window is
   # exactly the build a stale start-stamp would expose. Mutation-checked:
   # dropping the end-stamp lets A steal from C (the +15 bound); ignoring live
   # markers, or skipping _hold's pid check, lets D steal (the D-after-C
   # check). A 3s compile caught none of these.
-  NUB_BUILD_IDLE=4 build C 3 1 6 2 &
-  NUB_BUILD_IDLE=4 "$T/bin/cargo" "$T/idle.sh" & sleep 1
-  NUB_BUILD_IDLE=4 build B 2 2 5 & sleep 4
+  NUB_BUILD_IDLE=4 "$T/bin/cargo" "$T/late.sh" &
+  NUB_BUILD_IDLE=4 "$T/bin/cargo" "$T/idle.sh" &
+  await_setup "A began compiling" '[ -n "$(at A start)" ]'
+  NUB_BUILD_IDLE=4 "$T/bin/cargo" "$T/build.sh" B 2 2 5 & b=$!
+  await_setup "B received its first ticket" '[ -s "$T/sem/first/$b" ]'
+  b_ticket=$(head -n 1 "$T/sem/first/$b")
+  await_setup "B and C have distinct ticket times" '[ "$(date +%s)" -gt "$b_ticket" ]'
+  touch "$T/release-c"
+  sleep 4
   NUB_BUILD_IDLE=4 build D 1 1 1 & wait; timeline
   # Relational: B may start once A's first compile is 4s idle, plus polling
   # (observed +5..6). Without idle reclaim B waits for A's cargo to exit, ~30s.

--- a/tests/loader/README.md
+++ b/tests/loader/README.md
@@ -19,6 +19,7 @@ TSX=1 tests/loader/run-matrix.sh                        # differential: same fix
 | `using.ts` | `using` lowering — resolves the `@oxc-project/runtime` helpers from the package's real dependency |
 | `worker-main.ts` | a worker thread inheriting the preload and transpiling its own `.ts` entry |
 | `clobber.ts` | a real installed `@js-temporal/polyfill` must load, not the CLI's synthetic global re-export — covers the clear on both tiers |
+| `cache-main.ts` | imported CommonJS retains `require.cache`, `require.extensions` and `require.resolve.paths`, with the loader in argv or `NODE_OPTIONS` |
 
 The fixture project is `"type": "module"`, so `.ts` files with `import`/`export` are ES modules; `.cts` content must be CommonJS (`module.exports`) because the loader transpiles syntax without converting module formats.
 

--- a/tests/loader/README.md
+++ b/tests/loader/README.md
@@ -20,6 +20,8 @@ TSX=1 tests/loader/run-matrix.sh                        # differential: same fix
 | `worker-main.ts` | a worker thread inheriting the preload and transpiling its own `.ts` entry |
 | `clobber.ts` | a real installed `@js-temporal/polyfill` must load, not the CLI's synthetic global re-export — covers the clear on both tiers |
 | `cache-main.ts` | imported CommonJS retains `require.cache`, `require.extensions` and `require.resolve.paths`, with the loader in argv or `NODE_OPTIONS` |
+| `foreign-main.mjs` | synchronous resolve/load hooks registered by an earlier preload see the same imported-CommonJS call sequence as plain Node on that version |
+| `foreign-async-main.mjs` | native loader underscore aliases and earlier async preloads preserve Node's user-loader CommonJS handoff |
 
 The fixture project is `"type": "module"`, so `.ts` files with `import`/`export` are ES modules; `.cts` content must be CommonJS (`module.exports`) because the loader transpiles syntax without converting module formats.
 

--- a/tests/loader/fixtures/cache-main.ts
+++ b/tests/loader/fixtures/cache-main.ts
@@ -1,0 +1,6 @@
+import { strict as assert } from 'node:assert';
+import cache from './cache.cjs';
+
+assert.equal(cache, 'cjs-cache-ok');
+assert.equal((await import('./cache.cjs')).default, cache);
+console.log(cache);

--- a/tests/loader/fixtures/cache.cjs
+++ b/tests/loader/fixtures/cache.cjs
@@ -1,0 +1,6 @@
+const assert = require('node:assert/strict');
+
+assert.equal(require.cache[__filename], module);
+assert.equal(typeof require.extensions['.js'], 'function');
+assert.ok(Array.isArray(require.resolve.paths('not-installed')));
+module.exports = 'cjs-cache-ok';

--- a/tests/loader/fixtures/expected.txt
+++ b/tests/loader/fixtures/expected.txt
@@ -5,3 +5,4 @@ using.ts=in scope\ndisposed
 worker-main.ts=from worker: hello thread blue
 clobber.ts=number
 cache-main.ts=cjs-cache-ok
+foreign-async-main.mjs=foreign-loader-ok

--- a/tests/loader/fixtures/expected.txt
+++ b/tests/loader/fixtures/expected.txt
@@ -4,3 +4,4 @@ req.cts=cjs: 14 a
 using.ts=in scope\ndisposed
 worker-main.ts=from worker: hello thread blue
 clobber.ts=number
+cache-main.ts=cjs-cache-ok

--- a/tests/loader/fixtures/foreign-async-main.mjs
+++ b/tests/loader/fixtures/foreign-async-main.mjs
@@ -1,0 +1,6 @@
+import { strict as assert } from 'node:assert';
+import value from './foreign-target.cjs';
+
+assert.equal(value.value, 42);
+assert.equal(value.cacheType, 'undefined');
+console.log('foreign-loader-ok');

--- a/tests/loader/fixtures/foreign-async.cjs
+++ b/tests/loader/fixtures/foreign-async.cjs
@@ -1,0 +1,3 @@
+const { register } = require('node:module');
+const { pathToFileURL } = require('node:url');
+register('./foreign-hooks.mjs', pathToFileURL(__filename));

--- a/tests/loader/fixtures/foreign-hooks.mjs
+++ b/tests/loader/fixtures/foreign-hooks.mjs
@@ -1,0 +1,9 @@
+import { readFileSync } from 'node:fs';
+
+export async function load(url, context, nextLoad) {
+  const result = await nextLoad(url, context);
+  if (url.endsWith('/foreign-target.cjs')) {
+    return { format: 'commonjs', source: readFileSync(new URL(url)), shortCircuit: true };
+  }
+  return result;
+}

--- a/tests/loader/fixtures/foreign-main.mjs
+++ b/tests/loader/fixtures/foreign-main.mjs
@@ -1,0 +1,5 @@
+import { strict as assert } from 'node:assert';
+import value from './foreign-target.cjs';
+
+assert.equal(value.value, 42);
+console.log('foreign-loader-ok');

--- a/tests/loader/fixtures/foreign-sync.cjs
+++ b/tests/loader/fixtures/foreign-sync.cjs
@@ -1,0 +1,17 @@
+const { registerHooks } = require('node:module');
+const calls = [];
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.endsWith('/foreign-target.cjs')) {
+      calls.push({ kind: 'resolve', specifier, conditions: context.conditions });
+    }
+    return nextResolve(specifier, context);
+  },
+  load(url, context, nextLoad) {
+    if (url.endsWith('/foreign-target.cjs')) {
+      calls.push({ kind: 'load', url, conditions: context.conditions });
+    }
+    return nextLoad(url, context);
+  },
+});
+process.on('exit', () => console.log(JSON.stringify(calls)));

--- a/tests/loader/fixtures/foreign-target.cjs
+++ b/tests/loader/fixtures/foreign-target.cjs
@@ -1,0 +1,1 @@
+module.exports = { value: 42, cacheType: typeof require.cache };

--- a/tests/loader/run-matrix.sh
+++ b/tests/loader/run-matrix.sh
@@ -49,7 +49,16 @@ run_one() {  # <label> <argv...>
   local label="$1"; shift
   local fixture="${@: -1}"
   local want got status=0
-  want="$(grep "^${fixture}=" "$fixtures/expected.txt" | cut -d= -f2- | sed 's/\\n/\n/g')"
+  if [[ "$fixture" == "foreign-main.mjs" ]]; then
+    # Node majors differ in their native imported-CJS hook call sequence.
+    if ! want="$(cd "$work" && node --require ./foreign-sync.cjs "$fixture" 2>&1)"; then
+      echo "  FAIL plain Node sync-hook control: $want"
+      fail=1
+      return
+    fi
+  else
+    want="$(grep "^${fixture}=" "$fixtures/expected.txt" | cut -d= -f2- | sed 's/\\n/\n/g')"
+  fi
   got="$(cd "$work" && "$@" 2>&1)" || status=$?
   if [[ "$status" == 0 && "$got" == "$want" ]]; then
     printf "  ok   %-10s %s\n" "$label" "$fixture"
@@ -70,10 +79,19 @@ run_version() {
     run_one "--import" node --import "$pkg_name" "$f"
   done
   run_one "env-import" env NODE_OPTIONS="--import $pkg_name" node cache-main.ts
+  run_one "loader-alias" node --no-warnings --experimental_loader ./foreign-hooks.mjs --import "$pkg_name" foreign-async-main.mjs
+  run_one "env-alias" env NODE_OPTIONS="--experimental_loader=./foreign-hooks.mjs" node --no-warnings --import "$pkg_name" foreign-async-main.mjs
+  run_one "early-async" node --no-warnings --require ./foreign-async.cjs --import "$pkg_name" foreign-async-main.mjs
+  run_one "env-async" env NODE_OPTIONS="--require ./foreign-async.cjs" node --no-warnings --import "$pkg_name" foreign-async-main.mjs
+  if node -e 'process.exit(typeof require("node:module").registerHooks === "function" ? 0 : 1)'; then
+    run_one "early-sync" node --require ./foreign-sync.cjs --import "$pkg_name" foreign-main.mjs
+    run_one "env-sync" env NODE_OPTIONS="-r ./foreign-sync.cjs" node --import "$pkg_name" foreign-main.mjs
+  fi
   if supports_require; then
     for f in main.ts req.cts cache-main.ts; do
       run_one "--require" node --require "$pkg_name" "$f"
     done
+    run_one "own-preload" node --require "$pkg_name" --import "$pkg_name" cache-main.ts
   else
     echo "  skip --require (no require(esm) on this Node)"
   fi

--- a/tests/loader/run-matrix.sh
+++ b/tests/loader/run-matrix.sh
@@ -48,10 +48,10 @@ fail=0
 run_one() {  # <label> <argv...>
   local label="$1"; shift
   local fixture="${@: -1}"
-  local want got
+  local want got status=0
   want="$(grep "^${fixture}=" "$fixtures/expected.txt" | cut -d= -f2- | sed 's/\\n/\n/g')"
-  got="$(cd "$work" && "$@" 2>&1 || true)"
-  if [[ "$got" == "$want" ]]; then
+  got="$(cd "$work" && "$@" 2>&1)" || status=$?
+  if [[ "$status" == 0 && "$got" == "$want" ]]; then
     printf "  ok   %-10s %s\n" "$label" "$fixture"
   elif [[ "$label" == "tsx" ]]; then
     # The tsx column is the differential reference, not a gate: a tsx miss is a
@@ -66,11 +66,12 @@ run_one() {  # <label> <argv...>
 
 run_version() {
   echo "== node $(node --version)"
-  for f in main.ts paths.ts req.cts using.ts worker-main.ts clobber.ts; do
+  for f in main.ts paths.ts req.cts using.ts worker-main.ts clobber.ts cache-main.ts; do
     run_one "--import" node --import "$pkg_name" "$f"
   done
+  run_one "env-import" env NODE_OPTIONS="--import $pkg_name" node cache-main.ts
   if supports_require; then
-    for f in main.ts req.cts; do
+    for f in main.ts req.cts cache-main.ts; do
       run_one "--require" node --require "$pkg_name" "$f"
     done
   else

--- a/wiki/design/architecture.md
+++ b/wiki/design/architecture.md
@@ -56,7 +56,7 @@ The 23.x exclusion is not a special case, it is the tier definition applied corr
 
 Using `--require` on the fast tier is a correctness mechanism, not an optimization. An `--import` preload forces eager ESM loader initialization, which routes even a CommonJS entry point through the async module job and breaks `executionAsyncId`, sync exception origin, `require.main.id` and `module.parent`. Coverage and composition behavior of the hooks API is measured in [[research/registerhooks-coverage-matrix]].
 
-The standalone loader also accepts `--import @nubjs/loader`. Its own preload is excluded from foreign-loader detection, while additional loader flags and runtime hook registrations retain the composition guards. When it is the only loader, imported CommonJS dependencies retain their `require.cache`, `require.extensions` and `require.resolve.paths` APIs.
+The standalone loader also accepts `--import @nubjs/loader`. Its own preload is excluded from foreign-loader detection, while additional loader flags and runtime hook registrations retain the composition guards. Earlier foreign `--require` preloads conservatively disable the CommonJS cache repair because they may register hooks before detection starts. When it is the only loader, imported CommonJS dependencies retain their `require.cache`, `require.extensions` and `require.resolve.paths` APIs.
 
 ## TypeScript and resolution
 

--- a/wiki/design/architecture.md
+++ b/wiki/design/architecture.md
@@ -56,6 +56,8 @@ The 23.x exclusion is not a special case, it is the tier definition applied corr
 
 Using `--require` on the fast tier is a correctness mechanism, not an optimization. An `--import` preload forces eager ESM loader initialization, which routes even a CommonJS entry point through the async module job and breaks `executionAsyncId`, sync exception origin, `require.main.id` and `module.parent`. Coverage and composition behavior of the hooks API is measured in [[research/registerhooks-coverage-matrix]].
 
+The standalone loader also accepts `--import @nubjs/loader`. Its own preload is excluded from foreign-loader detection, while additional loader flags and runtime hook registrations retain the composition guards. When it is the only loader, imported CommonJS dependencies retain their `require.cache`, `require.extensions` and `require.resolve.paths` APIs.
+
 ## TypeScript and resolution
 
 Both ride the same hook pair, and both run in Rust behind a single call across the addon boundary.


### PR DESCRIPTION
Exclude the standalone loader’s own import from foreign-loader detection, preserving CommonJS cache APIs on Node 22.15.

Adds packed-loader regression coverage for argv and NODE_OPTIONS delivery, plus the existing fixture matrix in CI.

Verified remotely on Node 22.15 and 24.11.1 using matched JavaScript packages and the released 0.8.3 addon. The merge-base control fails the new import cases; the patch passes. CI rebuilds the addon.