### PR TITLE
compile: stop declining every source map from the containers that can carry one

### DIFF
--- a/crates/nub-cli/src/compile/inline.rs
+++ b/crates/nub-cli/src/compile/inline.rs
@@ -155,24 +155,33 @@ pub enum Decline {
     /// those are is per container and per mode, and the answer is measured rather
     /// than argued — the same throwing `app.ts`, compiled six ways on Node 26.8:
     ///
-    /// | `--sourcemap=` | `Mode::Sea` | `Mode::Inline` |
-    /// | --- | --- | --- |
-    /// | `inline` | `app.ts:2:13` | `app.mjs:3:10743` |
-    /// | `linked` | needs a file | needs a file |
-    /// | `external` | `app.mjs:2:10743` | `app.mjs:2:10743` |
+    /// | `--sourcemap=` | extracted (the control) | `Mode::Sea` | `Mode::Inline` |
+    /// | --- | --- | --- | --- |
+    /// | `inline` | `app.ts:2:13` | `app.ts:2:13` | `app.mjs:3:10743` |
+    /// | `linked` | `app.ts:2:13` | needs a file | needs a file |
+    /// | `external` | `app.mjs:2:10743` | `app.mjs:2:10743` | `app.mjs:3:10743` |
     ///
     /// `linked` ships a `.map` beside the chunks and names it in a
     /// `sourceMappingURL`, which neither container can resolve; it is caught by
     /// [`Decline::NonChunkFile`] too, and kept here only because this reason reads
-    /// better. `external` emits its map beside the EXECUTABLE and puts no reference
-    /// in the bundle, so its frames are unmapped in every shape including today's
-    /// extracted one — declining it bought a first-run write and nothing else.
+    /// better.
     ///
-    /// `inline` is the one that splits, and it is why this was worth measuring: the
-    /// single-executable container serves each module through a `registerHooks`
-    /// `load` hook, and V8 honours the `sourceMappingURL` it finds there; the
-    /// no-extract launcher hands its chunks over as `-e` plus `data:` URLs, and it
-    /// does not.
+    /// `Mode::Inline` declines EVERY map, and the reason is not that it cannot find
+    /// one — it is that no map made by the bundler still describes what that
+    /// container runs. [`rewrite_chunk`] edits each chunk AFTER bundling: it
+    /// prepends one generated line and rewrites cross-chunk specifiers in place,
+    /// which moves every line by one and moves columns on the lines it touches. The
+    /// map is made before that. The shift is visible in the table above — the same
+    /// frame is line 2 under a container that runs the bundler's bytes and line 3
+    /// under the one that rewrites them. An unresolvable map is a missing map, which
+    /// a reader notices; a map that resolves to the WRONG line is worse, because
+    /// nothing reports it. Composing `rewrite_chunk`'s edit into each map would
+    /// admit both `inline` and `external` here, and is what that would take.
+    ///
+    /// `Mode::Sea` rewrites nothing — it serves the emitted chunk verbatim through
+    /// a `registerHooks` `load` hook, where V8 honours the `sourceMappingURL` it
+    /// finds (`sea.rs`: "`EVAL_GLOBAL_CLEANUP` has no counterpart here"). So its
+    /// maps still describe its code, and only `linked` is out of reach.
     SourceMap,
     /// The payload names `child_process`, so the bootstrap installs its `fork()`
     /// identity fix-up — which sets the fork's executable to the Node the artifact
@@ -319,11 +328,12 @@ pub fn classify(
     if inputs.worker_roots != 0 || inputs.worker_wrappers != 0 {
         return Ok(Err(Decline::StaticWorker));
     }
-    // `Linked` in either container, and `Inline` in the one that cannot apply it.
-    // The other four cells are reachable; the table behind that is on
+    // `Linked` needs a file no container can reach. Everything else is a question
+    // of whether the map still describes the code: `Mode::Inline` rewrites its
+    // chunks after the map is made, so none of them does. See
     // [`Decline::SourceMap`].
     if matches!(inputs.sourcemap, bundle::SourcemapMode::Linked)
-        || (mode == Mode::Inline && matches!(inputs.sourcemap, bundle::SourcemapMode::Inline))
+        || (mode == Mode::Inline && !matches!(inputs.sourcemap, bundle::SourcemapMode::None))
     {
         return Ok(Err(Decline::SourceMap));
     }
@@ -823,9 +833,14 @@ mod tests {
     /// The two `Inline` cells are the whole point. The same mode is reachable from
     /// the single-executable container and not from the no-extract launcher, so a
     /// test that checked one of them would read as coverage whichever way the code
-    /// went. `External` is here because declining it was the cost with no benefit:
-    /// its map is never named by the bundle, so its frames are unmapped in every
-    /// shape, extracted ones included.
+    /// went.
+    ///
+    /// `External` pins the correction that a review caught: it looked admissible
+    /// everywhere, because its map is never named by the bundle and its frames come
+    /// back unmapped in every shape. But `Mode::Inline` publishes a DETACHED map
+    /// made before [`rewrite_chunk`] shifts the code it describes, so admitting it
+    /// there hands an error tracker a map that resolves to the wrong line and says
+    /// nothing about it.
     #[test]
     fn each_container_declines_only_the_source_maps_it_cannot_honour() {
         use bundle::SourcemapMode::{External, Inline as InlineMap, Linked, None as NoMap};
@@ -862,8 +877,9 @@ mod tests {
             (
                 External,
                 None,
-                None,
-                "an external map is never named by the bundle, so nothing resolves it at run time",
+                Some(Decline::SourceMap),
+                "an external map is published unchanged, so the container that rewrites its \
+                 chunks would describe them with a map made before the rewrite",
             ),
         ] {
             assert_eq!(

--- a/crates/nub-cli/src/compile/inline.rs
+++ b/crates/nub-cli/src/compile/inline.rs
@@ -151,12 +151,28 @@ pub enum Decline {
     /// summary would have claimed "nothing is written to disk" beside a 28 MB Node
     /// being unpacked.
     EmbeddedNode,
-    /// The build asked for source maps. Measured on Node 26.7: `--enable-source-maps`
-    /// does not apply an inline map to a `data:` URL module at all — with or without
-    /// a `//# sourceURL` — so an inline artifact would report unmapped frames where
-    /// the extracted one reports `app.ts:1`. Extracting is what keeps the maps the
-    /// build was asked to produce, so a build that wants them gets exactly today's
-    /// behavior.
+    /// The build asked for a source map this container cannot honour. Which maps
+    /// those are is per container and per mode, and the answer is measured rather
+    /// than argued — the same throwing `app.ts`, compiled six ways on Node 26.8:
+    ///
+    /// | `--sourcemap=` | `Mode::Sea` | `Mode::Inline` |
+    /// | --- | --- | --- |
+    /// | `inline` | `app.ts:2:13` | `app.mjs:3:10743` |
+    /// | `linked` | needs a file | needs a file |
+    /// | `external` | `app.mjs:2:10743` | `app.mjs:2:10743` |
+    ///
+    /// `linked` ships a `.map` beside the chunks and names it in a
+    /// `sourceMappingURL`, which neither container can resolve; it is caught by
+    /// [`Decline::NonChunkFile`] too, and kept here only because this reason reads
+    /// better. `external` emits its map beside the EXECUTABLE and puts no reference
+    /// in the bundle, so its frames are unmapped in every shape including today's
+    /// extracted one — declining it bought a first-run write and nothing else.
+    ///
+    /// `inline` is the one that splits, and it is why this was worth measuring: the
+    /// single-executable container serves each module through a `registerHooks`
+    /// `load` hook, and V8 honours the `sourceMappingURL` it finds there; the
+    /// no-extract launcher hands its chunks over as `-e` plus `data:` URLs, and it
+    /// does not.
     SourceMap,
     /// The payload names `child_process`, so the bootstrap installs its `fork()`
     /// identity fix-up — which sets the fork's executable to the Node the artifact
@@ -196,8 +212,10 @@ pub struct Inputs<'a> {
     /// Statically traced worker roots, plus the public wrappers written for them.
     pub worker_roots: usize,
     pub worker_wrappers: usize,
-    /// Whether any source map was asked for.
-    pub sourcemap: bool,
+    /// Which source map the build asked for. The MODE rather than a yes/no,
+    /// because the three differ in what has to be reachable at run time and only
+    /// one of them is out of reach here — see [`Decline::SourceMap`].
+    pub sourcemap: bundle::SourcemapMode,
     /// Whether the artifact carries a Node of its own — everything but `--smol`.
     pub embeds_node: bool,
     /// `BundleResult::app_computes_module_specifier`.
@@ -301,7 +319,12 @@ pub fn classify(
     if inputs.worker_roots != 0 || inputs.worker_wrappers != 0 {
         return Ok(Err(Decline::StaticWorker));
     }
-    if inputs.sourcemap {
+    // `Linked` in either container, and `Inline` in the one that cannot apply it.
+    // The other four cells are reachable; the table behind that is on
+    // [`Decline::SourceMap`].
+    if matches!(inputs.sourcemap, bundle::SourcemapMode::Linked)
+        || (mode == Mode::Inline && matches!(inputs.sourcemap, bundle::SourcemapMode::Inline))
+    {
         return Ok(Err(Decline::SourceMap));
     }
     // Cheap and last of the caller-supplied checks, so a payload that could never
@@ -751,7 +774,7 @@ mod tests {
             sealed_module_graph: true,
             worker_roots: 0,
             worker_wrappers: 0,
-            sourcemap: false,
+            sourcemap: bundle::SourcemapMode::None,
             embeds_node: false,
             computes_module_specifier: false,
             entry,
@@ -792,6 +815,68 @@ mod tests {
         classify(&files, &inputs, Mode::Sea)
             .expect("classification succeeds")
             .err()
+    }
+
+    /// Which source maps each container can honour — one cell per measured row of
+    /// the table on [`Decline::SourceMap`].
+    ///
+    /// The two `Inline` cells are the whole point. The same mode is reachable from
+    /// the single-executable container and not from the no-extract launcher, so a
+    /// test that checked one of them would read as coverage whichever way the code
+    /// went. `External` is here because declining it was the cost with no benefit:
+    /// its map is never named by the bundle, so its frames are unmapped in every
+    /// shape, extracted ones included.
+    #[test]
+    fn each_container_declines_only_the_source_maps_it_cannot_honour() {
+        use bundle::SourcemapMode::{External, Inline as InlineMap, Linked, None as NoMap};
+
+        let files = vec![
+            AppFile::plain(
+                nub_core::compile::COMPILE_BOOTSTRAP_NAME.to_string(),
+                b"// bootstrap\n".to_vec(),
+            ),
+            AppFile::plain("main.mjs".to_string(), b"console.log(1);\n".to_vec()),
+        ];
+        let decline = |map, mode| {
+            let mut inputs = sealed("main.mjs");
+            inputs.sourcemap = map;
+            classify(&files, &inputs, mode)
+                .expect("classification succeeds")
+                .err()
+        };
+
+        for (map, sea, inline, why) in [
+            (NoMap, None, None, "no map was asked for"),
+            (
+                InlineMap,
+                None,
+                Some(Decline::SourceMap),
+                "an inline map is honoured through the blob's load hook, and not from a `data:` URL",
+            ),
+            (
+                Linked,
+                Some(Decline::SourceMap),
+                Some(Decline::SourceMap),
+                "a linked map is a file neither container can reach",
+            ),
+            (
+                External,
+                None,
+                None,
+                "an external map is never named by the bundle, so nothing resolves it at run time",
+            ),
+        ] {
+            assert_eq!(
+                decline(map, Mode::Sea),
+                sea,
+                "{map:?} in a single-executable: {why}"
+            );
+            assert_eq!(
+                decline(map, Mode::Inline),
+                inline,
+                "{map:?} in a no-extract launcher: {why}"
+            );
+        }
     }
 
     /// A single-executable artifact's `process.execPath` is the artifact, and Node

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -323,7 +323,10 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         sealed_module_graph,
         worker_roots: bundled.worker_roots.len(),
         worker_wrappers: worker_wrappers.len(),
-        sourcemap: opts.bundle.sourcemap != bundle::SourcemapMode::None,
+        // The mode, not whether one was asked for: two of the three are reachable
+        // from a container that writes nothing, and one of those two only from the
+        // single-executable one.
+        sourcemap: opts.bundle.sourcemap,
         embeds_node: !opts.smol,
         computes_module_specifier: bundled.app_computes_module_specifier,
         entry: &entry_name,

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -3546,13 +3546,41 @@ fn atomic_replace(staged: &Path, destination: &Path) -> std::io::Result<()> {
     let staged = windows_verbatim_path(staged)?;
     let destination = windows_verbatim_path(destination)?;
     let flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
-    // SAFETY: both buffers are live, NUL-terminated UTF-16 paths. No destination
-    // is removed first, so an API failure leaves the previous artifact intact.
-    if unsafe { MoveFileExW(staged.as_ptr(), destination.as_ptr(), flags) } == 0 {
-        Err(std::io::Error::last_os_error())
-    } else {
-        Ok(())
+
+    // Windows releases an executable's image section ASYNCHRONOUSLY, so the move
+    // can lose a race with a process that has already exited. The build's own
+    // self-probe RUNS the staged artifact immediately before this call, and
+    // `Command::output` returning means the child was reaped — not that the
+    // section is gone. Measured on the win32-arm64 CI leg: `a-env-strict` failed
+    // with `The process cannot access the file because it is being used by another
+    // process. (os error 32)`, intermittently, while every other fixture in the
+    // same run published fine.
+    //
+    // A bounded retry is the fix rather than a workaround: there is no handle to
+    // wait on, because the holder is the kernel finishing with a process that no
+    // longer exists. Anti-malware scanning a freshly written binary produces the
+    // same code, and the same answer. ~1.3s total, which is invisible next to a
+    // build and far short of hanging a broken publish.
+    //
+    // The retry is deliberately NOT extended to other errors. A denied or missing
+    // path fails on the first attempt, where the message still describes what went
+    // wrong.
+    const SHARING_VIOLATION: i32 = 32;
+    let mut delay = std::time::Duration::from_millis(10);
+    for attempt in 0..8 {
+        // SAFETY: both buffers are live, NUL-terminated UTF-16 paths. No destination
+        // is removed first, so an API failure leaves the previous artifact intact.
+        if unsafe { MoveFileExW(staged.as_ptr(), destination.as_ptr(), flags) } != 0 {
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() != Some(SHARING_VIOLATION) || attempt == 7 {
+            return Err(error);
+        }
+        std::thread::sleep(delay);
+        delay *= 2;
     }
+    unreachable!("the loop returns on its last attempt")
 }
 
 #[cfg(windows)]

--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -323,9 +323,10 @@ pub fn run(mut opts: CompileOptions) -> Result<i32> {
         sealed_module_graph,
         worker_roots: bundled.worker_roots.len(),
         worker_wrappers: worker_wrappers.len(),
-        // The mode, not whether one was asked for: two of the three are reachable
-        // from a container that writes nothing, and one of those two only from the
-        // single-executable one.
+        // The mode, not whether one was asked for. The single-executable container
+        // carries an inline or a detached map; the no-extract launcher carries
+        // neither, because it rewrites its chunks after the map is made. Only
+        // `linked` is out of reach for both.
         sourcemap: opts.bundle.sourcemap,
         embeds_node: !opts.smol,
         computes_module_specifier: bundled.app_computes_module_specifier,


### PR DESCRIPTION
`Decline::SourceMap` fired on any source map, which is broader than the measurement behind it. Its comment records `--enable-source-maps` failing to apply an inline map to a `data:` URL module — and a `data:` URL is the no-extract launcher. The single-executable container serves each module through a `registerHooks` load hook, where V8 does honour the `sourceMappingURL` it finds.

Measured on Node 26.8, one throwing `app.ts`, frames as reported:

| `--sourcemap=` | extracted (control) | single-executable | no-extract launcher |
| --- | --- | --- | --- |
| `inline` | `app.ts:2:13` | `app.ts:2:13` | `app.mjs:3:10743` |
| `linked` | `app.ts:2:13` | needs a file | needs a file |
| `external` | `app.mjs:2:10743` | `app.mjs:2:10743` | `app.mjs:3:10743` |

The single-executable container gains two modes, `inline` and `external`. The no-extract launcher gains none: it declines every map, because `rewrite_chunk` edits its chunks after the map is made — one prepended line, plus in-place specifier rewrites — so no bundler-made map still describes what it runs. The line-3 cells above are that shift. An unresolvable map is a missing map, which a reader notices; a map that resolves to the wrong line is worse, because nothing reports it.

`Inputs::sourcemap` carries the mode rather than a bool. `linked` is also caught by `NonChunkFile`; it stays here because this reason reads better. Composing `rewrite_chunk`'s edit into each map would admit both modes for the no-extract launcher, and is recorded on `Decline::SourceMap` as what that would take.

Also carries an unrelated Windows fix (b37a8dde) that this branch's CI surfaced. The build's self-probe runs the staged artifact immediately before `MoveFileExW`, and Windows releases an executable's image section asynchronously, so the publish could lose the race with `ERROR_SHARING_VIOLATION`. It now retries on that code alone. `a-sourcemap` passed in the same run and win32-x64 passed on identical code, so the failure was not the source-map change.
