### PR TITLE
nub-phantom: do not report a package's own baseUrl imports as phantoms

### DIFF
--- a/crates/nub-cli/src/dynamic_phantom.rs
+++ b/crates/nub-cli/src/dynamic_phantom.rs
@@ -343,7 +343,7 @@ pub(crate) fn phantom_cache_dir() -> Option<PathBuf> {
 /// after upgrade; harmless and expected (the whole point is to pick up the better
 /// verdict). Just bump the number when the scanner logic changes — the coupling
 /// is structural, nothing else to remember.
-pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 4;
+pub(crate) const PHANTOM_SCANNER_VERSION: u32 = 5;
 
 /// Version of what the linker's GVS-populate pass WRITES TO DISK for a given eject
 /// set — bumped when the same plan produces a different on-disk shape.

--- a/crates/nub-phantom-core/src/extract.rs
+++ b/crates/nub-phantom-core/src/extract.rs
@@ -24,7 +24,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::AstKind;
 use oxc_ast::ast::{
     Argument, BindingPattern, ConditionalExpression, Expression, FormalParameters, IfStatement,
-    ImportDeclarationSpecifier, LogicalExpression, Statement, TryStatement,
+    ImportDeclarationSpecifier, LogicalExpression, Statement, TSImportType, TryStatement,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
@@ -244,6 +244,32 @@ impl<'a> Visit<'a> for SpecVisitor {
         }
         walk::walk_expression(self, it);
     }
+
+    /// A TYPE-position `import("x")` — `typeof import("typescript")`,
+    /// `import("pkg").Foo`. A distinct AST node from `Expression::ImportExpression`
+    /// (which is the value-position dynamic import), so visiting expressions never
+    /// reaches it, and every occurrence was invisible before this.
+    ///
+    /// This is the idiomatic way a `.d.ts` types a dependency it does not import at
+    /// runtime — an injected one above all, where the value arrives as a parameter:
+    /// `volar-service-typescript-twoslash-queries`' whole declaration surface is
+    /// `create(ts: typeof import("typescript"))`, against a manifest that declares
+    /// `typescript` nowhere. Yarn carries a hand-written rule for exactly that
+    /// package (yarnpkg/berry#7232) and this scan could not rediscover it. Measured
+    /// over a 59-package spread of the download ranking: 2 packages carry an
+    /// undeclared bare type-position import, ~3% of the corpus.
+    ///
+    /// Gated on `capture_types`, like `import type … from …` above it, so it
+    /// surfaces only on the `.d.ts`/SFC type surface and a plain `.ts` still drops
+    /// it — a devDep used purely for types is never promoted to a runtime phantom.
+    /// `source` is a `StringLiteral`, so unlike a dynamic import there is no
+    /// computed form to skip.
+    fn visit_ts_import_type(&mut self, it: &TSImportType<'a>) {
+        if self.capture_types {
+            self.record(&it.source.value, RefKind::StaticImport);
+        }
+        walk::walk_ts_import_type(self, it);
+    }
 }
 
 /// A named import declaration is a runtime (value) import unless every specifier
@@ -456,6 +482,48 @@ mod tests {
             .into_iter()
             .map(|o| (o.spec, o.soft, o.kind))
             .collect()
+    }
+
+    #[test]
+    fn a_type_position_import_on_the_declaration_surface_is_an_edge() {
+        // `typeof import("x")` is a TS type node, not an expression, so the
+        // expression visitor never reached it. It is how a `.d.ts` types an
+        // injected dependency the package never imports at runtime —
+        // `volar-service-typescript-twoslash-queries` declares `typescript`
+        // nowhere and its entire surface is `create(ts: typeof
+        // import("typescript"))`. Yarn hand-wrote a rule for that package
+        // (yarnpkg/berry#7232) precisely because a scan could not find it.
+        let dts: Vec<String> = extract(
+            "index.d.ts",
+            r#"
+            import type { Plugin } from '@volar/language-service';
+            export declare function create(ts: typeof import('typescript')): Plugin;
+            export declare const cfg: import('webpack').Configuration;
+            "#,
+        )
+        .into_iter()
+        .map(|o| o.spec)
+        .collect();
+        assert_eq!(
+            dts,
+            vec!["@volar/language-service", "typescript", "webpack"],
+            "the declaration surface must carry both the type import and the type-position import(): {dts:?}"
+        );
+
+        // THE CONTROL, and the reason this is gated on `capture_types`: a plain
+        // `.ts` still drops it. A package that only names a devDep in a type
+        // annotation must not be reported as needing it at runtime.
+        let ts: Vec<String> = extract(
+            "src/index.ts",
+            "export function f(ts: typeof import('typescript')) { return ts; }",
+        )
+        .into_iter()
+        .map(|o| o.spec)
+        .collect();
+        assert!(
+            ts.is_empty(),
+            "a type-position import in a runtime .ts stays erased: {ts:?}"
+        );
     }
 
     #[test]

--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -130,7 +130,12 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
         .map(|(package, agg)| {
             let deep_path_only =
                 agg.from_deep_path && !agg.from_main && !agg.from_subpath && !agg.from_types;
-            let verdict = verdict_for(manifest, &package, agg.all_soft, deep_path_only);
+            // Referenced ONLY from the type surface, so TypeScript's `@types`
+            // fallback applies and a runtime resolution never happens. See
+            // `types_package_for`.
+            let types_only =
+                agg.from_types && !agg.from_main && !agg.from_subpath && !agg.from_deep_path;
+            let verdict = verdict_for(manifest, &package, agg.all_soft, deep_path_only, types_only);
             Finding {
                 package,
                 verdict,
@@ -150,6 +155,7 @@ fn verdict_for(
     package: &str,
     all_soft: bool,
     deep_path_only: bool,
+    types_only: bool,
 ) -> Verdict {
     if is_self(manifest, package) {
         return Verdict::SelfRef;
@@ -158,6 +164,35 @@ fn verdict_for(
         return Verdict::Builtin;
     }
     if manifest.deps.contains(package) || manifest.bundled.contains(package) {
+        return Verdict::Declared;
+    }
+    // A reference that exists ONLY on the type surface resolves through
+    // TypeScript's `@types` fallback, so a declared `@types/<pkg>` satisfies it and
+    // there is nothing for a consumer to install. Measured over the top 10,000:
+    // 15 of 40 sampled type-surface findings were this, and the targets are the
+    // DefinitelyTyped-only names — `geojson` (112 findings), `hast`, `estree`,
+    // `mdast`, `unist`, `json-schema` — where no runtime package is even intended.
+    // `@turf/destination` declares `@types/geojson` and writes
+    // `import('geojson').Position`; calling that a phantom asks the consumer to
+    // install a package the author correctly did not depend on.
+    //
+    // Restricted to `types_only` deliberately: a RUNTIME `require('geojson')` is
+    // NOT satisfied by `@types/geojson`, so any occurrence off the type surface
+    // keeps the reference a phantom.
+    // Every set a CONSUMER install makes resolvable, which is the question this
+    // whole module asks. A peer counts: the consumer supplies it, so the types
+    // are there. `devDependencies` deliberately does not — it is not installed
+    // downstream, so a `.d.ts` leaning on a dev-only types package really does
+    // break for the consumer. Measured over the sampled false positives: 13
+    // declare the types package in `dependencies`, 2 as a peer, and 2 dev-only
+    // (correctly still phantoms).
+    if types_only && {
+        let t = types_package_for(package);
+        manifest.deps.contains(&t)
+            || manifest.bundled.contains(&t)
+            || manifest.required_peers.contains(&t)
+            || manifest.optional_peers.contains(&t)
+    } {
         return Verdict::Declared;
     }
     if manifest.optional_peers.contains(package) {
@@ -177,6 +212,20 @@ fn verdict_for(
         Verdict::SoftPhantom
     } else {
         Verdict::HardPhantom
+    }
+}
+
+/// The DefinitelyTyped package that supplies types for `package`.
+///
+/// Unscoped is a plain prefix (`geojson` → `@types/geojson`); a SCOPED name is
+/// flattened with a double underscore and the `@` dropped (`@babel/core` →
+/// `@types/babel__core`), which is DefinitelyTyped's own convention and the one
+/// TypeScript's resolver implements. Getting the scoped form wrong would silently
+/// leave every scoped type-only reference misclassified.
+fn types_package_for(package: &str) -> String {
+    match package.strip_prefix('@').and_then(|r| r.split_once('/')) {
+        Some((scope, name)) => format!("@types/{scope}__{name}"),
+        None => format!("@types/{package}"),
     }
 }
 
@@ -218,6 +267,83 @@ mod tests {
         .unwrap();
         let f = classify(&m, &refs(&[("zod", "zod", false)]));
         assert_eq!(f[0].verdict, Verdict::DeclaredOptionalPeer);
+    }
+
+    #[test]
+    fn a_declared_types_package_satisfies_a_type_only_reference() {
+        // `@turf/destination` declares `@types/geojson` and writes
+        // `import('geojson').Position` in its `.d.ts`. TypeScript resolves that
+        // through the `@types` fallback, so nothing is undeclared and no consumer
+        // install can help. This was 15 of 40 sampled type-surface findings.
+        let type_ref = |raw: &str, package: &str| Reference {
+            package: package.to_string(),
+            raw: raw.to_string(),
+            soft: false,
+            from_main: false,
+            from_subpath: false,
+            from_types: true,
+            from_deep_path: false,
+        };
+
+        let m = Manifest::parse(
+            br#"{"name":"@turf/destination","dependencies":{"@types/geojson":"^7946.0.8"}}"#,
+        )
+        .unwrap();
+        let f = classify(&m, &[type_ref("geojson", "geojson")]);
+        assert_eq!(
+            f[0].verdict,
+            Verdict::Declared,
+            "a declared @types/geojson satisfies a type-only geojson reference"
+        );
+
+        // The SCOPED convention flattens with a double underscore. Getting this
+        // wrong misclassifies every scoped type-only reference silently.
+        let scoped =
+            Manifest::parse(br#"{"name":"p","dependencies":{"@types/babel__core":"^7"}}"#).unwrap();
+        let f = classify(&scoped, &[type_ref("@babel/core", "@babel/core")]);
+        assert_eq!(f[0].verdict, Verdict::Declared, "@babel/core → @types/babel__core");
+
+        // A PEER types package counts too — the consumer supplies it. Two of the
+        // fifteen sampled false positives declared it this way.
+        let peer =
+            Manifest::parse(br#"{"name":"p","peerDependencies":{"@types/geojson":"*"}}"#).unwrap();
+        let f = classify(&peer, &[type_ref("geojson", "geojson")]);
+        assert_eq!(f[0].verdict, Verdict::Declared, "a peer @types/geojson satisfies it");
+
+        // But a DEV-only types package does not: it is not installed downstream,
+        // so the consumer's type-check really does break.
+        let dev =
+            Manifest::parse(br#"{"name":"p","devDependencies":{"@types/geojson":"*"}}"#).unwrap();
+        let f = classify(&dev, &[type_ref("geojson", "geojson")]);
+        assert_eq!(
+            f[0].verdict,
+            Verdict::HardPhantom,
+            "a devDependency types package is not resolvable for a consumer"
+        );
+
+        // THE CONTROL. A runtime reference is NOT satisfied by a types package —
+        // `require('geojson')` needs the real thing — so any occurrence off the
+        // type surface keeps the reference a phantom.
+        let runtime = Reference {
+            package: "geojson".to_string(),
+            raw: "geojson".to_string(),
+            soft: false,
+            from_main: true,
+            from_subpath: false,
+            from_types: false,
+            from_deep_path: false,
+        };
+        let f = classify(&m, &[type_ref("geojson", "geojson"), runtime]);
+        assert_eq!(
+            f[0].verdict,
+            Verdict::HardPhantom,
+            "a runtime occurrence is not satisfied by @types/geojson"
+        );
+
+        // And with no types package declared it stays a phantom.
+        let bare = Manifest::parse(br#"{"name":"p"}"#).unwrap();
+        let f = classify(&bare, &[type_ref("geojson", "geojson")]);
+        assert_eq!(f[0].verdict, Verdict::HardPhantom);
     }
 
     #[test]

--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -301,14 +301,22 @@ mod tests {
         let scoped =
             Manifest::parse(br#"{"name":"p","dependencies":{"@types/babel__core":"^7"}}"#).unwrap();
         let f = classify(&scoped, &[type_ref("@babel/core", "@babel/core")]);
-        assert_eq!(f[0].verdict, Verdict::Declared, "@babel/core → @types/babel__core");
+        assert_eq!(
+            f[0].verdict,
+            Verdict::Declared,
+            "@babel/core → @types/babel__core"
+        );
 
         // A PEER types package counts too — the consumer supplies it. Two of the
         // fifteen sampled false positives declared it this way.
         let peer =
             Manifest::parse(br#"{"name":"p","peerDependencies":{"@types/geojson":"*"}}"#).unwrap();
         let f = classify(&peer, &[type_ref("geojson", "geojson")]);
-        assert_eq!(f[0].verdict, Verdict::Declared, "a peer @types/geojson satisfies it");
+        assert_eq!(
+            f[0].verdict,
+            Verdict::Declared,
+            "a peer @types/geojson satisfies it"
+        );
 
         // But a DEV-only types package does not: it is not installed downstream,
         // so the consumer's type-check really does break.

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -441,6 +441,16 @@ fn config_roots(text: &str) -> Vec<String> {
             targets
                 .iter()
                 .filter_map(|t| t.as_str())
+                // ONLY a target containing `*` is a module root. TypeScript
+                // substitutes the captured segment into the `*` position, so
+                // `"*": ["src/*"]` maps `react` to `src/react` — a root. A target
+                // with no `*` is a CONSTANT: `"*": ["aliases"]` maps every
+                // specifier to `aliases` itself, so treating it as a root and
+                // probing `aliases/react` resolves a path TypeScript never
+                // consults. That direction is the dangerous one — it would
+                // silently drop a real `react` edge for any package that also
+                // ships `aliases/react.ts`.
+                .filter(|t| t.contains('*'))
                 .filter_map(|t| normalize_rel_join(&base, t.trim_end_matches(['*', '/']))),
         );
     }
@@ -1226,6 +1236,34 @@ mod tests {
             packages(&walk_index(&index_of(&root), &eps)),
             vec!["real-dep".to_string()]
         );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_constant_paths_target_is_not_a_module_root() {
+        // `"*": ["aliases"]` has no `*` in the TARGET, so TypeScript maps every
+        // bare specifier to `aliases` itself — it never looks at `aliases/react`.
+        // Treating the constant as a root would probe exactly that path and
+        // silently drop a real undeclared `react` for any package that also ships
+        // `aliases/react.ts`. A wildcard target is a root; a constant is not.
+        let root = scratch("self-ref-constant-paths");
+        fs::create_dir_all(root.join("aliases")).unwrap();
+        fs::write(
+            root.join("tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"*":["aliases"]}}}"#,
+        )
+        .unwrap();
+        fs::write(root.join("index.ts"), "import 'react';").unwrap();
+        fs::write(root.join("aliases/react.ts"), "").unwrap();
+
+        let eps = [main_entry("index.ts")];
+        let want = vec!["react".to_string()];
+        assert_eq!(
+            packages(&walk(&root, &eps)),
+            want,
+            "a constant paths target must not suppress a real react edge"
+        );
+        assert_eq!(packages(&walk_index(&index_of(&root), &eps)), want);
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -414,14 +414,27 @@ impl SelfTree {
 }
 
 /// Module roots a published `tsconfig.json` declares: `compilerOptions.baseUrl`,
-/// plus each `compilerOptions.paths["*"]` target with its trailing `*` stripped,
-/// resolved under `baseUrl`.
+/// plus each `compilerOptions.paths["*"]` target with a `*` in it, resolved under
+/// `baseUrl` with the trailing `*` stripped.
 ///
 /// Only the `"*"` key qualifies. A prefixed mapping like `"@app/*"` governs
 /// specifiers that start `@app/` and is not a general module root, so admitting
 /// its target would resolve unrelated bare specifiers against it. `extends` is
 /// not chased and a comment-bearing (JSONC) file simply yields nothing — both
 /// degrade to the ancestor roots, which is the conservative direction.
+///
+/// THE PACKAGE ROOT ITSELF IS NEVER A DECLARED ROOT, and that asymmetry is
+/// deliberate rather than an oversight. `baseUrl: "."` — and the absent case,
+/// which defaults to it — normalizes to the empty path and is dropped. Honoring
+/// it would probe the package root with `index_only` off, so ANY bare specifier
+/// matching a root-level file would be suppressed: a package shipping a root
+/// `lodash.js` alongside an undeclared `require('lodash')` would lose a real
+/// phantom, silently. TypeScript would indeed resolve that import to the local
+/// file, but tsc does NOT rewrite a `baseUrl`-resolved specifier at emit, so the
+/// published JavaScript still carries a bare `lodash` that Node resolves from
+/// `node_modules` — the dependency is real. Dropping the empty root costs only a
+/// missed SUPPRESSION (the reference stays reported), which is the safe
+/// direction and the never-false-flag bar this scanner is held to.
 fn config_roots(text: &str) -> Vec<String> {
     let Ok(v) = serde_json::from_str::<serde_json::Value>(text) else {
         return Vec::new();

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -14,7 +14,7 @@
 //! to reach the same file set — and produce the same references — as a post-link
 //! scan of the materialized tree.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -102,6 +102,14 @@ trait FileSource {
     /// deep-path root, filtered by [`crate::manifest::is_deep_path_candidate`].
     /// Sorted, so the two backings enumerate in the same order.
     fn deep_path_roots(&self) -> Vec<Self::Key>;
+    /// Every published file as a package-root-relative POSIX path — the tree the
+    /// self-reference check ([`SelfTree`]) resolves against. Unfiltered: a file
+    /// excluded from seeding is still evidence that a specifier names something
+    /// inside this package.
+    fn published_paths(&self) -> BTreeSet<String>;
+    /// Read a package-root-relative path that is not a resolution target
+    /// (`tsconfig.json`), bypassing the extension ladder.
+    fn read_rel(&self, rel: &str) -> Option<String>;
 }
 
 /// Knobs on the reachable-graph walk. The default is the AUTHORITATIVE walk —
@@ -165,10 +173,30 @@ fn walk_generic<S: FileSource>(source: &S, entry_points: &[Entry], opts: WalkOpt
     }
 
     result.files_analyzed = parsed.len();
+    let mut tree: Option<SelfTree> = None;
+    // Keyed by the module root the probe searches (the importing file's directory)
+    // rather than the file, so one scan answers every file beside it.
+    let mut self_ref: BTreeMap<(String, String), bool> = BTreeMap::new();
     for (file, occs) in &parsed {
         let fflags = *flags.get(file).unwrap_or(&0);
+        let rel = source.rel_path(file).replace('\\', "/");
+        let own_dir = parent_rel(&rel);
+        let ts_source = is_ts_source(&rel);
         for occ in occs {
             if let SpecKind::Bare(package) = specifier::classify(&occ.spec) {
+                // Indexing the tree costs a full directory walk, so a package that
+                // publishes no TypeScript never pays for it.
+                if ts_source {
+                    let tree = tree.get_or_insert_with(|| {
+                        SelfTree::new(source.published_paths(), source.read_rel("tsconfig.json"))
+                    });
+                    if *self_ref
+                        .entry((own_dir.to_string(), occ.spec.clone()))
+                        .or_insert_with(|| tree.resolves(own_dir, &occ.spec))
+                    {
+                        continue;
+                    }
+                }
                 result.references.push(Reference {
                     package,
                     raw: occ.spec.clone(),
@@ -270,6 +298,158 @@ fn add_flags<K: Ord + Clone>(flags: &mut BTreeMap<K, u8>, key: &K, bit: u8) -> b
     *entry != before
 }
 
+// --- Self-reference probe ------------------------------------------------------
+
+/// The self-reference probe runs only for a TypeScript source (declarations
+/// included). A `baseUrl` / `paths` import is a COMPILE-TIME construct that only
+/// a compiler or bundler resolves, so it appears in the `src/` a package ships
+/// beside its build output. Published JAVASCRIPT naming a bare specifier is a
+/// real module request Node resolves against `node_modules`, and reading one as
+/// internal erased four real edges over five thousand packages —
+/// `@azure/core-rest-pipeline` imports the real `react-native` from
+/// `dist/react-native/util/*.mjs`, beside its own `dist/react-native/`.
+fn is_ts_source(rel: &str) -> bool {
+    matches!(
+        crate::manifest::extension(rel),
+        Some("ts" | "tsx" | "mts" | "cts")
+    )
+}
+
+/// Extensions the self-reference probe appends. The runtime ladder plus
+/// DECLARATIONS: a `.d.ts` at the mapped path is the package describing its own
+/// module just as much as a `.ts` is, and some are declaration-only — pusher-js's
+/// `runtime` is a per-target webpack alias whose only file is
+/// `src/runtimes/runtime.d.ts`.
+const SELF_REF_EXTS: [&str; 11] = [
+    "js", "cjs", "mjs", "jsx", "ts", "tsx", "mts", "cts", "d.ts", "d.mts", "d.cts",
+];
+
+/// The package's own published tree, indexed to answer one question: does a
+/// bare-looking specifier name a module inside THIS package?
+///
+/// It usually does when the package publishes `baseUrl`-compiled TS/ESM source.
+/// `pusher-js` ships `src/` built with `baseUrl: "src"` and
+/// `paths: {"*": ["*", "runtimes/*"]}`, so its own files import each other as
+/// `core/utils/url_store` and `isomorphic/runtime`; `react-zoom-pan-pinch` ships
+/// `src/` importing `components` and `utils/ref.utils`. Those resolve against the
+/// source root at build time, never against `node_modules`, so recording them as
+/// dependencies invents packages that no install can satisfy.
+///
+/// Two rules keep the probe from erasing real findings, each paid for by a
+/// measured regression over the top five thousand packages:
+///
+/// 1. A candidate module root is an ANCESTOR of the importing file (a `baseUrl`
+///    contains the source that imports against it) or a root the package's own
+///    `tsconfig.json` declares — never an unrelated directory elsewhere in the
+///    tarball. `next` vendors its compiled dependencies under
+///    `dist/compiled/<pkg>/`, so a wider search read its undeclared
+///    `react-server-dom-webpack/client` as internal.
+/// 2. Under an ancestor root a SINGLE-SEGMENT specifier counts only when it
+///    resolves to a directory's `index`. A plain file match there is a name
+///    collision, since one segment is also exactly the shape of a package name:
+///    `@nx/js` re-exports `dist/typescript.js` and imports the real `typescript`;
+///    recast's `parsers/` holds one adapter per parser, so `parsers/babel.js`
+///    requires the real `babylon` beside its own `parsers/babylon.js`. A
+///    tsconfig-declared root is exempt — there the package itself has said which
+///    directory bare specifiers resolve against.
+struct SelfTree {
+    files: BTreeSet<String>,
+    /// Module roots the package's own `tsconfig.json` declares. Needed for a root
+    /// that is not an ancestor of the files using it: pusher-js maps `*` to both
+    /// `src/*` and `src/runtimes/*`, which is what makes the bare `runtime` its
+    /// `src/core/` files import an internal module.
+    config_roots: Vec<String>,
+}
+
+impl SelfTree {
+    fn new(files: BTreeSet<String>, tsconfig: Option<String>) -> Self {
+        let config_roots = tsconfig.as_deref().map(config_roots).unwrap_or_default();
+        Self {
+            files,
+            config_roots,
+        }
+    }
+
+    /// True if `spec`, written in a file sitting in `own_dir`, names a module in
+    /// this package.
+    fn resolves(&self, own_dir: &str, spec: &str) -> bool {
+        // A file inside a bundled dependency imports that dependency's modules,
+        // not this package's, and `node_modules` as a root would resolve any
+        // undeclared import to the bundled copy.
+        if own_dir.split('/').any(|s| s == "node_modules") {
+            return false;
+        }
+        let index_only = !spec.contains('/');
+        let mut dir = own_dir;
+        loop {
+            if self.probe(dir, spec, index_only) {
+                return true;
+            }
+            if dir.is_empty() {
+                break;
+            }
+            dir = dir.rsplit_once('/').map_or("", |(parent, _)| parent);
+        }
+        self.config_roots
+            .iter()
+            .any(|root| self.probe(root, spec, false))
+    }
+
+    /// Node-shaped candidates for `base/spec`: the literal path and each extension
+    /// appended (both suppressed by `index_only`), then the directory's `index`.
+    fn probe(&self, base: &str, spec: &str, index_only: bool) -> bool {
+        let joined = join_rel(base, spec);
+        if !index_only
+            && (self.files.contains(&joined)
+                || SELF_REF_EXTS
+                    .iter()
+                    .any(|ext| self.files.contains(&format!("{joined}.{ext}"))))
+        {
+            return true;
+        }
+        SELF_REF_EXTS
+            .iter()
+            .any(|ext| self.files.contains(&format!("{joined}/index.{ext}")))
+    }
+}
+
+/// Module roots a published `tsconfig.json` declares: `compilerOptions.baseUrl`,
+/// plus each `compilerOptions.paths["*"]` target with its trailing `*` stripped,
+/// resolved under `baseUrl`.
+///
+/// Only the `"*"` key qualifies. A prefixed mapping like `"@app/*"` governs
+/// specifiers that start `@app/` and is not a general module root, so admitting
+/// its target would resolve unrelated bare specifiers against it. `extends` is
+/// not chased and a comment-bearing (JSONC) file simply yields nothing — both
+/// degrade to the ancestor roots, which is the conservative direction.
+fn config_roots(text: &str) -> Vec<String> {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(text) else {
+        return Vec::new();
+    };
+    let opts = v.get("compilerOptions");
+    let field = |name| opts.and_then(|o: &serde_json::Value| o.get(name));
+    let base = field("baseUrl").and_then(|b| b.as_str()).unwrap_or(".");
+    let Some(base) = normalize_rel_join("", base) else {
+        return Vec::new();
+    };
+    let mut out = vec![base.clone()];
+    if let Some(targets) = field("paths")
+        .and_then(|p| p.get("*"))
+        .and_then(|t| t.as_array())
+    {
+        out.extend(
+            targets
+                .iter()
+                .filter_map(|t| t.as_str())
+                .filter_map(|t| normalize_rel_join(&base, t.trim_end_matches(['*', '/']))),
+        );
+    }
+    out.retain(|r| !r.is_empty());
+    out.sort();
+    out.dedup();
+    out
+}
+
 /// Bound on `main`-chasing recursion. A dir whose `package.json` `main` points
 /// back at itself (`"."`/`""`/`"./"`) or a mutual `main` cycle across dirs would
 /// otherwise recurse forever → a stack-overflow ABORT that kills the whole scan
@@ -355,37 +535,52 @@ impl FileSource for FsSource<'_> {
     }
 
     fn deep_path_roots(&self) -> Vec<PathBuf> {
-        let mut out = Vec::new();
-        collect_files(self.root, self.root, &mut out, 0);
+        let mut out: Vec<PathBuf> = collect_files(self.root)
+            .into_iter()
+            .filter(|rel| crate::manifest::is_deep_path_candidate(rel))
+            .map(|rel| self.root.join(rel))
+            .collect();
         out.sort();
         out
     }
+
+    fn published_paths(&self) -> BTreeSet<String> {
+        collect_files(self.root).into_iter().collect()
+    }
+
+    fn read_rel(&self, rel: &str) -> Option<String> {
+        fs::read_to_string(self.root.join(rel)).ok()
+    }
 }
 
-/// Recursively list candidate deep-path roots under `dir`. Depth-bounded for the
-/// same reason the resolver is: a tarball is untrusted input.
-fn collect_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>, depth: u32) {
-    if depth > MAX_RESOLVE_DEPTH {
-        return;
-    }
-    let Ok(entries) = fs::read_dir(dir) else {
-        return;
-    };
-    for e in entries.flatten() {
-        let path = e.path();
-        let Ok(ft) = e.file_type() else { continue };
-        // Symlinks are not followed: a tarball's symlink can point outside the
-        // package root, and the walk's stay-under-root invariant is the only thing
-        // keeping another package's code out of this package's findings.
-        if ft.is_dir() {
-            collect_files(root, &path, out, depth + 1);
-        } else if ft.is_file() {
-            let rel = path.strip_prefix(root).unwrap_or(&path).to_string_lossy();
-            if crate::manifest::is_deep_path_candidate(&rel.replace('\\', "/")) {
-                out.push(path);
+/// Recursively list every file under `root` as a package-relative POSIX path.
+fn collect_files(root: &Path) -> Vec<String> {
+    /// Depth-bounded for the same reason the resolver is: a tarball is untrusted
+    /// input.
+    fn rec(root: &Path, dir: &Path, out: &mut Vec<String>, depth: u32) {
+        if depth > MAX_RESOLVE_DEPTH {
+            return;
+        }
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        for e in entries.flatten() {
+            let path = e.path();
+            let Ok(ft) = e.file_type() else { continue };
+            // Symlinks are not followed: a tarball's symlink can point outside the
+            // package root, and the walk's stay-under-root invariant is the only
+            // thing keeping another package's code out of this package's findings.
+            if ft.is_dir() {
+                rec(root, &path, out, depth + 1);
+            } else if ft.is_file() {
+                let rel = path.strip_prefix(root).unwrap_or(&path).to_string_lossy();
+                out.push(rel.replace('\\', "/"));
             }
         }
     }
+    let mut out = Vec::new();
+    rec(root, root, &mut out, 0);
+    out
 }
 
 fn fs_resolve(
@@ -535,6 +730,14 @@ impl FileSource for IndexSource {
             .filter(|rel| crate::manifest::is_deep_path_candidate(rel))
             .cloned()
             .collect()
+    }
+
+    fn published_paths(&self) -> BTreeSet<String> {
+        self.files.keys().cloned().collect()
+    }
+
+    fn read_rel(&self, rel: &str) -> Option<String> {
+        fs::read_to_string(self.files.get(rel)?).ok()
     }
 }
 
@@ -977,6 +1180,174 @@ mod tests {
         b.sort();
         assert_eq!(a, b);
         assert_eq!(a, vec!["real".to_string()]);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Package names reached by a walk, sorted and deduped.
+    fn packages(w: &super::Walk) -> Vec<String> {
+        let mut v: Vec<String> = w.references.iter().map(|r| r.package.clone()).collect();
+        v.sort();
+        v.dedup();
+        v
+    }
+
+    #[test]
+    fn a_bare_specifier_resolving_inside_the_package_is_not_a_dependency() {
+        // The pusher-js / react-zoom-pan-pinch shape: published `baseUrl`-compiled
+        // source importing its own modules by bare-looking specifiers. `core/util`
+        // and `components` resolve under `src/`; `runtime` resolves only as a
+        // DECLARATION under the nested module root `src/runtimes` (pusher-js's
+        // webpack `resolve.modules` lists both `src` and `src/runtimes`).
+        let root = scratch("self-ref");
+        fs::create_dir_all(root.join("src/core")).unwrap();
+        fs::create_dir_all(root.join("src/components")).unwrap();
+        fs::create_dir_all(root.join("src/runtimes")).unwrap();
+        fs::write(root.join("src/index.ts"), "import './core/entry';").unwrap();
+        fs::write(
+            root.join("src/core/entry.ts"),
+            "import 'core/util'; import 'components'; import 'runtime'; import 'real-dep';",
+        )
+        .unwrap();
+        fs::write(root.join("src/core/util.ts"), "").unwrap();
+        fs::write(root.join("src/components/index.ts"), "").unwrap();
+        // `runtime` lives under a root that is NOT an ancestor of the importer, so
+        // only the shipped tsconfig makes it internal — and it is declaration-only.
+        fs::write(root.join("src/runtimes/runtime.d.ts"), "").unwrap();
+        fs::write(
+            root.join("tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":"src","paths":{"*":["*","runtimes/*"]}}}"#,
+        )
+        .unwrap();
+
+        let eps = [main_entry("src/index.ts")];
+        assert_eq!(packages(&walk(&root, &eps)), vec!["real-dep".to_string()]);
+        // Both backings must agree, as they do for every other resolution rule.
+        assert_eq!(
+            packages(&walk_index(&index_of(&root), &eps)),
+            vec!["real-dep".to_string()]
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn only_an_ancestor_or_a_declared_root_counts_as_a_module_root() {
+        // Two shapes that a wider search gets wrong. `next` vendors its compiled
+        // dependencies under `dist/compiled/<pkg>/`, which is neither an ancestor
+        // of `dist/server/` nor declared, so an undeclared `rsd/client` imported
+        // there stays a phantom. `redux-persist` publishes the same modules twice
+        // (`lib/` and `es/`), so one tree must not answer for the other — that is
+        // what keeps its real undeclared `react` visible (nub#891).
+        let root = scratch("self-ref-roots");
+        for d in [
+            "dist/server",
+            "dist/compiled/rsd",
+            "lib/integration",
+            "es/integration",
+        ] {
+            fs::create_dir_all(root.join(d)).unwrap();
+        }
+        fs::write(
+            root.join("dist/server/index.ts"),
+            "import './entry'; import 'rsd/client';",
+        )
+        .unwrap();
+        fs::write(root.join("dist/compiled/rsd/client.ts"), "").unwrap();
+        fs::write(root.join("lib/integration/gate.ts"), "import 'react';").unwrap();
+        fs::write(root.join("es/integration/react.ts"), "").unwrap();
+
+        let eps = [
+            main_entry("dist/server/index.ts"),
+            main_entry("lib/integration/gate.ts"),
+        ];
+        let want = vec!["react".to_string(), "rsd".to_string()];
+        assert_eq!(packages(&walk(&root, &eps)), want);
+        assert_eq!(packages(&walk_index(&index_of(&root), &eps)), want);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_file_sharing_a_package_name_is_not_a_module_root() {
+        // A single-segment specifier has exactly the shape of a package name, so a
+        // plain file match under an ancestor is a collision rather than a root:
+        // `@nx/js` re-exports `dist/typescript.js` and imports the real
+        // `typescript` from its `dist/src/utils/` declarations.
+        let root = scratch("self-ref-collision");
+        fs::create_dir_all(root.join("dist/src/utils")).unwrap();
+        fs::write(
+            root.join("dist/src/utils/ast.d.ts"),
+            "import type * as ts from 'typescript';",
+        )
+        .unwrap();
+        fs::write(root.join("dist/typescript.js"), "").unwrap();
+
+        let eps = [Entry {
+            path: "dist/src/utils/ast.d.ts".to_string(),
+            kind: EntryKind::Types,
+        }];
+        assert_eq!(packages(&walk(&root, &eps)), vec!["typescript".to_string()]);
+        assert_eq!(
+            packages(&walk_index(&index_of(&root), &eps)),
+            vec!["typescript".to_string()]
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn published_javascript_is_not_probed_for_self_references() {
+        // A `baseUrl` import is compile-time only, so the probe is for TypeScript
+        // sources. `@azure/core-rest-pipeline` imports the real `react-native`
+        // from `dist/react-native/util/*.mjs`, beside its own `dist/react-native/`
+        // — and recast's `parsers/babel.js` requires the real `babylon` beside its
+        // own `parsers/babylon.js`. Probing emitted JS erases both.
+        let root = scratch("self-ref-js");
+        for d in ["dist/react-native/util", "parsers"] {
+            fs::create_dir_all(root.join(d)).unwrap();
+        }
+        fs::write(
+            root.join("index.mjs"),
+            "import './dist/react-native/util/ua'; import './parsers/babel';",
+        )
+        .unwrap();
+        fs::write(
+            root.join("dist/react-native/util/ua.mjs"),
+            "import 'react-native';",
+        )
+        .unwrap();
+        fs::write(root.join("dist/react-native/index.mjs"), "").unwrap();
+        fs::write(root.join("parsers/babel.js"), "require('babylon');").unwrap();
+        fs::write(root.join("parsers/babylon.js"), "").unwrap();
+
+        let eps = [main_entry("index.mjs")];
+        let want = vec!["babylon".to_string(), "react-native".to_string()];
+        assert_eq!(packages(&walk(&root, &eps)), want);
+        assert_eq!(packages(&walk_index(&index_of(&root), &eps)), want);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_bundled_tree_is_not_a_module_root() {
+        // A file reached inside a shipped `node_modules/` must not have its own
+        // undeclared imports laundered by the bundled tree around it: `node_modules`
+        // as a module root resolves every bare specifier to a vendored copy.
+        // (`bundledDependencies` is honored later, by the classifier, from the
+        // manifest — not by path coincidence.)
+        let root = scratch("self-ref-bundled");
+        fs::create_dir_all(root.join("node_modules/dep/lib")).unwrap();
+        fs::create_dir_all(root.join("node_modules/lodash")).unwrap();
+        fs::write(root.join("index.ts"), "import './node_modules/dep/lib/x';").unwrap();
+        fs::write(
+            root.join("node_modules/dep/lib/x.ts"),
+            "import 'lodash/merge';",
+        )
+        .unwrap();
+        fs::write(root.join("node_modules/lodash/merge.ts"), "").unwrap();
+
+        let eps = [main_entry("index.ts")];
+        assert_eq!(packages(&walk(&root, &eps)), vec!["lodash".to_string()]);
+        assert_eq!(
+            packages(&walk_index(&index_of(&root), &eps)),
+            vec!["lodash".to_string()]
+        );
         let _ = fs::remove_dir_all(&root);
     }
 }

--- a/crates/nub-phantom-scan/src/manifest.rs
+++ b/crates/nub-phantom-scan/src/manifest.rs
@@ -338,7 +338,7 @@ pub(crate) fn is_sfc_like(path: &str) -> bool {
     matches!(extension(path), Some("astro" | "vue" | "svelte"))
 }
 
-fn extension(path: &str) -> Option<&str> {
+pub(crate) fn extension(path: &str) -> Option<&str> {
     let file = path.rsplit('/').next().unwrap_or(path);
     file.rsplit_once('.').map(|(_, e)| e)
 }


### PR DESCRIPTION
The detector reported six packages for `pusher-js` and five for `react-zoom-pan-pinch` that no install can satisfy. Both publish `baseUrl`-compiled TypeScript, so their own sources import each other by bare-looking specifiers — `core/utils/url_store`, `isomorphic/runtime`, `components`, `utils/ref.utils`. Those resolve against the source root at compile time, never against `node_modules`.

Deep-path seeding (#891) is what exposed them: a package with no `exports` map now seeds every published file as a walk root, so source that only a bundler resolves gets parsed.

Before recording a bare specifier the walk now probes the package's own published file set for it. Four rules keep the probe from erasing real findings. Each was added after an A/B over the 5000 most-downloaded packages showed it losing edges, and each has a test that fails when the rule is reverted.

| Rule | Regression it prevents |
| --- | --- |
| Probe TypeScript sources only | `@azure/core-rest-pipeline` and `@typespec/ts-http-runtime` import the real `react-native` from `dist/react-native/util/*.mjs`, beside their own `dist/react-native/`. A `baseUrl` import is compile-time only, so emitted JavaScript naming a bare specifier is a real module request. |
| A module root is an ancestor of the importing file, or a root the package's own `tsconfig.json` declares — never an unrelated directory | `next` vendors its compiled dependencies under `dist/compiled/<pkg>/`, which a wider search matched against its undeclared `react-server-dom-webpack/client`. |
| Under an ancestor root, a single-segment specifier counts only as a directory's `index` | One segment is exactly the shape of a package name. `@nx/js` re-exports `dist/typescript.js` and imports the real `typescript`; recast's `parsers/babel.js` requires the real `babylon` beside its own `parsers/babylon.js`. |
| A shipped `node_modules/` tree is not a module root | A bundled copy would answer for every undeclared import around it. |

A tsconfig-declared root is exempt from the single-segment rule, since there the package itself has said which directory bare specifiers resolve against. That is what makes pusher-js's declaration-only `runtime` internal.

## Measurements

A/B against a binary built at 248608c5ad, over the same fixed package lists.

| Slice | Hard edges | Removed | Added | Soft removed |
| --- | --- | --- | --- | --- |
| Top 2000 | 118 → 118 | 0 | 0 | 0 |
| 2001–5000 | 446 → 445 | 1 | 0 | 0 |
| Union of all 396 offender packages, plus the cases above | 576 → 566 | 10 | 0 | 0 |

The ten removals are the nine target-class edges (`pusher-js` × 4, `react-zoom-pan-pinch` × 5) and `node-readfiles -> src`, whose `lib/readfiles.d.ts` declares `module "src/consts"`. Nothing was added.

Still reported, and correctly: `swagger-ui-dist` keeps `lodash`, `react-syntax-highlighter`, `remarkable` and `swagger-client`; `redux-persist` keeps `react`; `object.assign` stays clean.

The probe runs for the shipped extract-time scan as well as the eval tool, since a self-reference is not a dependency on either path. Indexing costs a directory walk, so a package that publishes no TypeScript never pays for it.

Refs #891
