### PR TITLE
nub-phantom: two type-surface classification fixes

### DIFF
--- a/crates/nub-phantom-core/src/extract.rs
+++ b/crates/nub-phantom-core/src/extract.rs
@@ -24,7 +24,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::AstKind;
 use oxc_ast::ast::{
     Argument, BindingPattern, ConditionalExpression, Expression, FormalParameters, IfStatement,
-    ImportDeclarationSpecifier, LogicalExpression, Statement, TryStatement,
+    ImportDeclarationSpecifier, LogicalExpression, Statement, TSImportType, TryStatement,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
@@ -244,6 +244,32 @@ impl<'a> Visit<'a> for SpecVisitor {
         }
         walk::walk_expression(self, it);
     }
+
+    /// A TYPE-position `import("x")` — `typeof import("typescript")`,
+    /// `import("pkg").Foo`. A distinct AST node from `Expression::ImportExpression`
+    /// (which is the value-position dynamic import), so visiting expressions never
+    /// reaches it, and every occurrence was invisible before this.
+    ///
+    /// This is the idiomatic way a `.d.ts` types a dependency it does not import at
+    /// runtime — an injected one above all, where the value arrives as a parameter:
+    /// `volar-service-typescript-twoslash-queries`' whole declaration surface is
+    /// `create(ts: typeof import("typescript"))`, against a manifest that declares
+    /// `typescript` nowhere. Yarn carries a hand-written rule for exactly that
+    /// package (yarnpkg/berry#7232) and this scan could not rediscover it. Measured
+    /// over a 59-package spread of the download ranking: 2 packages carry an
+    /// undeclared bare type-position import, ~3% of the corpus.
+    ///
+    /// Gated on `capture_types`, like `import type … from …` above it, so it
+    /// surfaces only on the `.d.ts`/SFC type surface and a plain `.ts` still drops
+    /// it — a devDep used purely for types is never promoted to a runtime phantom.
+    /// `source` is a `StringLiteral`, so unlike a dynamic import there is no
+    /// computed form to skip.
+    fn visit_ts_import_type(&mut self, it: &TSImportType<'a>) {
+        if self.capture_types {
+            self.record(&it.source.value, RefKind::StaticImport);
+        }
+        walk::walk_ts_import_type(self, it);
+    }
 }
 
 /// A named import declaration is a runtime (value) import unless every specifier
@@ -456,6 +482,48 @@ mod tests {
             .into_iter()
             .map(|o| (o.spec, o.soft, o.kind))
             .collect()
+    }
+
+    #[test]
+    fn a_type_position_import_on_the_declaration_surface_is_an_edge() {
+        // `typeof import("x")` is a TS type node, not an expression, so the
+        // expression visitor never reached it. It is how a `.d.ts` types an
+        // injected dependency the package never imports at runtime —
+        // `volar-service-typescript-twoslash-queries` declares `typescript`
+        // nowhere and its entire surface is `create(ts: typeof
+        // import("typescript"))`. Yarn hand-wrote a rule for that package
+        // (yarnpkg/berry#7232) precisely because a scan could not find it.
+        let dts: Vec<String> = extract(
+            "index.d.ts",
+            r#"
+            import type { Plugin } from '@volar/language-service';
+            export declare function create(ts: typeof import('typescript')): Plugin;
+            export declare const cfg: import('webpack').Configuration;
+            "#,
+        )
+        .into_iter()
+        .map(|o| o.spec)
+        .collect();
+        assert_eq!(
+            dts,
+            vec!["@volar/language-service", "typescript", "webpack"],
+            "the declaration surface must carry both the type import and the type-position import(): {dts:?}"
+        );
+
+        // THE CONTROL, and the reason this is gated on `capture_types`: a plain
+        // `.ts` still drops it. A package that only names a devDep in a type
+        // annotation must not be reported as needing it at runtime.
+        let ts: Vec<String> = extract(
+            "src/index.ts",
+            "export function f(ts: typeof import('typescript')) { return ts; }",
+        )
+        .into_iter()
+        .map(|o| o.spec)
+        .collect();
+        assert!(
+            ts.is_empty(),
+            "a type-position import in a runtime .ts stays erased: {ts:?}"
+        );
     }
 
     #[test]

--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -130,7 +130,12 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
         .map(|(package, agg)| {
             let deep_path_only =
                 agg.from_deep_path && !agg.from_main && !agg.from_subpath && !agg.from_types;
-            let verdict = verdict_for(manifest, &package, agg.all_soft, deep_path_only);
+            // Referenced ONLY from the type surface, so TypeScript's `@types`
+            // fallback applies and a runtime resolution never happens. See
+            // `types_package_for`.
+            let types_only =
+                agg.from_types && !agg.from_main && !agg.from_subpath && !agg.from_deep_path;
+            let verdict = verdict_for(manifest, &package, agg.all_soft, deep_path_only, types_only);
             Finding {
                 package,
                 verdict,
@@ -150,6 +155,7 @@ fn verdict_for(
     package: &str,
     all_soft: bool,
     deep_path_only: bool,
+    types_only: bool,
 ) -> Verdict {
     if is_self(manifest, package) {
         return Verdict::SelfRef;
@@ -158,6 +164,35 @@ fn verdict_for(
         return Verdict::Builtin;
     }
     if manifest.deps.contains(package) || manifest.bundled.contains(package) {
+        return Verdict::Declared;
+    }
+    // A reference that exists ONLY on the type surface resolves through
+    // TypeScript's `@types` fallback, so a declared `@types/<pkg>` satisfies it and
+    // there is nothing for a consumer to install. Measured over the top 10,000:
+    // 15 of 40 sampled type-surface findings were this, and the targets are the
+    // DefinitelyTyped-only names — `geojson` (112 findings), `hast`, `estree`,
+    // `mdast`, `unist`, `json-schema` — where no runtime package is even intended.
+    // `@turf/destination` declares `@types/geojson` and writes
+    // `import('geojson').Position`; calling that a phantom asks the consumer to
+    // install a package the author correctly did not depend on.
+    //
+    // Restricted to `types_only` deliberately: a RUNTIME `require('geojson')` is
+    // NOT satisfied by `@types/geojson`, so any occurrence off the type surface
+    // keeps the reference a phantom.
+    // Every set a CONSUMER install makes resolvable, which is the question this
+    // whole module asks. A peer counts: the consumer supplies it, so the types
+    // are there. `devDependencies` deliberately does not — it is not installed
+    // downstream, so a `.d.ts` leaning on a dev-only types package really does
+    // break for the consumer. Measured over the sampled false positives: 13
+    // declare the types package in `dependencies`, 2 as a peer, and 2 dev-only
+    // (correctly still phantoms).
+    if types_only && {
+        let t = types_package_for(package);
+        manifest.deps.contains(&t)
+            || manifest.bundled.contains(&t)
+            || manifest.required_peers.contains(&t)
+            || manifest.optional_peers.contains(&t)
+    } {
         return Verdict::Declared;
     }
     if manifest.optional_peers.contains(package) {
@@ -177,6 +212,20 @@ fn verdict_for(
         Verdict::SoftPhantom
     } else {
         Verdict::HardPhantom
+    }
+}
+
+/// The DefinitelyTyped package that supplies types for `package`.
+///
+/// Unscoped is a plain prefix (`geojson` → `@types/geojson`); a SCOPED name is
+/// flattened with a double underscore and the `@` dropped (`@babel/core` →
+/// `@types/babel__core`), which is DefinitelyTyped's own convention and the one
+/// TypeScript's resolver implements. Getting the scoped form wrong would silently
+/// leave every scoped type-only reference misclassified.
+fn types_package_for(package: &str) -> String {
+    match package.strip_prefix('@').and_then(|r| r.split_once('/')) {
+        Some((scope, name)) => format!("@types/{scope}__{name}"),
+        None => format!("@types/{package}"),
     }
 }
 
@@ -218,6 +267,83 @@ mod tests {
         .unwrap();
         let f = classify(&m, &refs(&[("zod", "zod", false)]));
         assert_eq!(f[0].verdict, Verdict::DeclaredOptionalPeer);
+    }
+
+    #[test]
+    fn a_declared_types_package_satisfies_a_type_only_reference() {
+        // `@turf/destination` declares `@types/geojson` and writes
+        // `import('geojson').Position` in its `.d.ts`. TypeScript resolves that
+        // through the `@types` fallback, so nothing is undeclared and no consumer
+        // install can help. This was 15 of 40 sampled type-surface findings.
+        let type_ref = |raw: &str, package: &str| Reference {
+            package: package.to_string(),
+            raw: raw.to_string(),
+            soft: false,
+            from_main: false,
+            from_subpath: false,
+            from_types: true,
+            from_deep_path: false,
+        };
+
+        let m = Manifest::parse(
+            br#"{"name":"@turf/destination","dependencies":{"@types/geojson":"^7946.0.8"}}"#,
+        )
+        .unwrap();
+        let f = classify(&m, &[type_ref("geojson", "geojson")]);
+        assert_eq!(
+            f[0].verdict,
+            Verdict::Declared,
+            "a declared @types/geojson satisfies a type-only geojson reference"
+        );
+
+        // The SCOPED convention flattens with a double underscore. Getting this
+        // wrong misclassifies every scoped type-only reference silently.
+        let scoped =
+            Manifest::parse(br#"{"name":"p","dependencies":{"@types/babel__core":"^7"}}"#).unwrap();
+        let f = classify(&scoped, &[type_ref("@babel/core", "@babel/core")]);
+        assert_eq!(f[0].verdict, Verdict::Declared, "@babel/core → @types/babel__core");
+
+        // A PEER types package counts too — the consumer supplies it. Two of the
+        // fifteen sampled false positives declared it this way.
+        let peer =
+            Manifest::parse(br#"{"name":"p","peerDependencies":{"@types/geojson":"*"}}"#).unwrap();
+        let f = classify(&peer, &[type_ref("geojson", "geojson")]);
+        assert_eq!(f[0].verdict, Verdict::Declared, "a peer @types/geojson satisfies it");
+
+        // But a DEV-only types package does not: it is not installed downstream,
+        // so the consumer's type-check really does break.
+        let dev =
+            Manifest::parse(br#"{"name":"p","devDependencies":{"@types/geojson":"*"}}"#).unwrap();
+        let f = classify(&dev, &[type_ref("geojson", "geojson")]);
+        assert_eq!(
+            f[0].verdict,
+            Verdict::HardPhantom,
+            "a devDependency types package is not resolvable for a consumer"
+        );
+
+        // THE CONTROL. A runtime reference is NOT satisfied by a types package —
+        // `require('geojson')` needs the real thing — so any occurrence off the
+        // type surface keeps the reference a phantom.
+        let runtime = Reference {
+            package: "geojson".to_string(),
+            raw: "geojson".to_string(),
+            soft: false,
+            from_main: true,
+            from_subpath: false,
+            from_types: false,
+            from_deep_path: false,
+        };
+        let f = classify(&m, &[type_ref("geojson", "geojson"), runtime]);
+        assert_eq!(
+            f[0].verdict,
+            Verdict::HardPhantom,
+            "a runtime occurrence is not satisfied by @types/geojson"
+        );
+
+        // And with no types package declared it stays a phantom.
+        let bare = Manifest::parse(br#"{"name":"p"}"#).unwrap();
+        let f = classify(&bare, &[type_ref("geojson", "geojson")]);
+        assert_eq!(f[0].verdict, Verdict::HardPhantom);
     }
 
     #[test]


### PR DESCRIPTION
Two defects on the `.d.ts` type surface. They are one PR because the second manufactures instances of
the first, so it is not safe to land alone.

## 1. A declared `@types/<pkg>` never satisfied a type-only reference

`@turf/destination` declares `@types/geojson` and writes `import('geojson').Position` in its
declarations. TypeScript resolves that through the `@types` fallback, so nothing is undeclared — but
the classifier only ever checked the bare name, so it reported a phantom and asked consumers to
install a package the author correctly did not depend on.

The scan holds 971 type-surface findings. Sampling 40 across a deterministic spread of the ranking,
**15 are satisfied by a declared `@types/` counterpart** — 37.5%, so on the order of 360 of them. The
targets are exactly the DefinitelyTyped-only names, where no runtime package is even intended:

| target | findings | | target | findings |
| --- | --- | --- | --- | --- |
| `geojson` | 112 | | `estree` | 37 |
| `react` | 46 | | `mdast` | 19 |
| `hast` | 39 | | `json-schema` | 19 |

Verified individually: `@rollup/pluginutils` → `estree` declares `@types/estree`; `@lit/react` →
`react` declares `@types/react`; `@stoplight/spectral-formats` → `json-schema` declares
`@types/json-schema`.

Scoped names use DefinitelyTyped's flattening — `@babel/core` → `@types/babel__core` — which is easy
to get wrong and would silently misclassify every scoped case.

**Scope of the rule, and what it deliberately excludes.** It applies only when *every* occurrence is
on the type surface (`types_only`, the same shape as the existing `deep_path_only`): a runtime
`require('geojson')` is not satisfied by `@types/geojson`, and that is a test. It accepts the types
package from `dependencies`, `bundled`, or either peer set — a peer is supplied by the consumer — but
**not** `devDependencies`, which is not installed downstream, so a `.d.ts` leaning on a dev-only types
package really does break. Measured over the sampled false positives: 13 `dependencies`, 2 peer, 2
dev-only, the last correctly still phantoms.

## 2. A type-position `import()` was invisible

`typeof import("typescript")` and `import("pkg").Type` parse to `TSImportType`, a TypeScript **type**
node. The visitor handled `Expression::ImportExpression` — the value-position dynamic import, a
different node — so these were never read. `.d.ts` files already extract with `capture_types: true`,
so the surface was reachable; the gap was one unvisited node type.

`volar-service-typescript-twoslash-queries@0.0.71` shows it in two lines:

```ts
import type { Plugin } from '@volar/language-service';                    // found
export declare function create(ts: typeof import('typescript')): Plugin;  // missed
```

It declares `typescript` nowhere, and Yarn hand-wrote a rule for the whole Volar family
(yarnpkg/berry#7232) precisely because no scan finds these. This is compiler output rather than a
hand-written idiom: tsc emits the form whenever a generated declaration references a type from a
module with no top-level import.

Gated on `capture_types` like `import type … from …` beside it, so a plain `.ts` still drops it and a
devDependency named only in a type annotation is never promoted to a runtime phantom.
`TSImportType.source` is a `StringLiteral`, so unlike a dynamic import there is no computed form to
skip.

## Blast radius: this changes shipped nub, not only the scan

`nub-phantom-core` and `nub-phantom-scan` ship inside `nub-cli`, and `has_unguarded_phantom` is the
global-virtual-store eject decision (`pm_engine/phantom_closure.rs:518`). Net effect is **fewer**
ejections: fix 1 removes hard phantoms wholesale, fix 2 adds a small number back. Both directions are
correct — an undeclared type import genuinely cannot resolve from a store realpath (the nub#450
reasoning), and a `@types`-satisfied one genuinely can.

Downstream, the published extensions dataset loses roughly 360 entries. That is a correctness gain;
every removed entry was advice to install a package that was never needed.

## Verification

- `cargo test -p nub-phantom-core -p nub-phantom-scan` green.
- The type-position test **fails for the right reason** with its recording disabled: it sees only
  `["@volar/language-service"]`, missing `typescript` and `webpack`.
- Eight acceptance cases against a built binary, and the **same script against a pre-fix control
  binary**, which fails exactly the cases the change is meant to add. Running that control is what
  caught a false third finding I had claimed — `@react-native-community/cli-platform-apple` was
  already detected via an ordinary import.
- A 120-package binary-vs-binary differential, run twice. The first run is what surfaced defect 1:
  the only two edges fix 2 added were both false positives of that class. The second, with both fixes
  in, removes **8 edges across 7 packages and adds none** — `rollup` -> `estree`, `remark-rehype` ->
  `hast`/`mdast`, `@turf/bbox` -> `geojson`, `vega-expression` -> `estree`, `@types/d3-scale` ->
  `d3-time`, `@types/d3-transition` -> `d3-selection`, `@turf/line-chunk` -> `geojson`. Every one is a
  package that declares the `@types/` counterpart.
- A doc-comment `import('foo')` must not become an edge; it is a comment, so it produces no node.
  Asserted as a control, and the case a regex-based survey gets wrong.

## Checked and deliberately not included

`import x = require("pkg")` (`TSImportEqualsDeclaration`) is also unvisited, and unlike a type query
it compiles to a real `require`. It appears in **0 of 59** sampled packages, so it is not worth the
node. That matcher was validated against five known-answer cases before the zero was trusted.
