### PR TITLE
runtime: reuse inspected source for JavaScript lowering

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1819,6 +1819,13 @@ fn js_transpilation_smoke_guard() {
 }
 
 #[test]
+fn esm_source_reuse_preserves_loaded_bytes_and_module_identity() {
+    let (stdout, stderr, code) = run_nub("loader-source-reuse", "main.mjs");
+    assert_eq!(code, 0, "source reuse contract failed: {stdout}\n{stderr}");
+    assert!(stdout.contains("source-reuse:ok"), "{stdout}\n{stderr}");
+}
+
+#[test]
 fn project_js_using_down_levels() {
     // `using` is a SyntaxError on every supported Node's V8; this project `.js`
     // must be down-leveled (the transformableSyntax verdict flags it) and run, just

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -920,10 +920,10 @@ export function noteRuntimeV8FlagSource(result) {
 // from extension alone), so a CommonJS-syntax `.ts` is reported `commonjs` — the
 // fix that makes `require()` of a TS file work on the compat tier, where Node's
 // CJS translator loads it via this hook and keys on the returned format.
-export function loadTranspile(url, ext) {
+export function loadTranspile(url, ext, source) {
   __ensureBuiltins();
   const filePath = fileURLToPath(url);
-  const source = readFileSync(filePath, "utf8");
+  source ??= readFileSync(filePath, "utf8");
   const dir = dirname(filePath);
   // The transform-relevant compilerOptions slice + the byte-for-byte cache-key
   // component (`tsconfigHash`) both come from the native tsconfig reader.
@@ -1024,7 +1024,7 @@ export function loadTranspile(url, ext) {
 // sites (the byte-parity boundary). JSX-in-`.js` is out of scope for the syntax
 // gate (lang is "ts", which does not parse JSX); use `.jsx`, or say so explicitly
 // with a `loader` entry, which takes the unconditional path below instead.
-export function maybeTranspilePlainJs(url, ext) {
+export function maybeTranspilePlainJs(url, ext, source) {
   __ensureBuiltins();
   // An explicit `loader` entry pointing this extension at a code dialect moved it
   // into TRANSPILE_EXTS, which for every other member means "always compile". Only
@@ -1035,11 +1035,10 @@ export function maybeTranspilePlainJs(url, ext) {
   // while the ESM path transpiles the same file on both tiers. The registration
   // loop deliberately skips `.js`/`.cjs` because this wrapper owns them, so there
   // is nothing else downstream to catch it.
-  if (TRANSPILE_EXTS.has(ext)) return loadTranspile(url, ext);
+  if (TRANSPILE_EXTS.has(ext)) return loadTranspile(url, ext, source);
   const filePath = fileURLToPath(url);
-  let source;
   try {
-    source = readFileSync(filePath, "utf8");
+    source ??= readFileSync(filePath, "utf8");
   } catch {
     // Unreadable here → let Node's loader surface its own error.
     return null;
@@ -1050,10 +1049,10 @@ export function maybeTranspilePlainJs(url, ext) {
     return null; // no-op: Node's native loader handles it, byte-identical.
   }
   // Transformable: run the SAME pipeline as TS/JSX (target es2022 lowering, tsconfig,
-  // source maps, the Stage-3 decorator guard, format detection, cache). loadTranspile
-  // re-reads + re-parses, but only for the rare file that actually needs lowering.
+  // source maps, the Stage-3 decorator guard, format detection, cache), reusing
+  // the bytes already inspected by the gate.
   try {
-    return loadTranspile(url, ext);
+    return loadTranspile(url, ext, source);
   } catch (err) {
     // #225: a plain-JS file the transformable verdict flagged (a `using` decl or
     // `v`-flag RegExp somewhere) but whose transform oxc then REJECTS — V8 tolerates

--- a/tests/fixtures/loader-source-reuse/early-hook.cjs
+++ b/tests/fixtures/loader-source-reuse/early-hook.cjs
@@ -1,0 +1,6 @@
+require('node:module').registerHooks({
+  load(url, context, nextLoad) {
+    if (url.endsWith('/state.mjs')) throw new Error('early hook saw transformable source');
+    return nextLoad(url, context);
+  },
+});

--- a/tests/fixtures/loader-source-reuse/main.mjs
+++ b/tests/fixtures/loader-source-reuse/main.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import module, {createRequire} from 'node:module';
+import {spawnSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+import * as core from '../../../runtime/transform-core.mjs';
+
+core.setBootstrapCreateRequire(createRequire);
+const url = new URL('./absent.mjs', import.meta.url).href;
+const lowered = core.maybeTranspilePlainJs(url, '.mjs', 'using resource = null;');
+assert.equal(lowered.format, 'module');
+assert.match(lowered.source, /usingCtx/);
+assert.equal(core.maybeTranspilePlainJs(url, '.mjs', ''), null);
+assert.match(core.loadTranspile(url, '.mts', 'export const answer: number = 42;').source, /answer = 42/);
+
+if (typeof module.registerHooks === 'function') {
+  const hook = fileURLToPath(new URL('./early-hook.cjs', import.meta.url));
+  const child = spawnSync(process.execPath, ['--input-type=module', '-e',
+    'import {disposals} from "./state.mjs"; console.log(disposals);'], {
+    cwd: fileURLToPath(new URL('.', import.meta.url)),
+    env: {...process.env, NODE_OPTIONS: `--require=${JSON.stringify(hook)} ${process.env.NODE_OPTIONS || ''}`},
+    encoding: 'utf8',
+  });
+  assert.equal(child.status, 0, child.stderr);
+  assert.equal(child.stdout.trim(), '1');
+}
+
+// Separate native consumers must still share one module instance.
+const imported = await import('./state.mjs');
+assert.equal(imported.disposals, 1);
+try {
+  const required = createRequire(import.meta.url)('./state.mjs');
+  imported.increment();
+  assert.equal(required.value, 42);
+  assert.equal(required.Token, imported.Token);
+} catch (e) {
+  if (e.code !== 'ERR_REQUIRE_ESM') throw e;
+}
+console.log('source-reuse:ok');

--- a/tests/fixtures/loader-source-reuse/package.json
+++ b/tests/fixtures/loader-source-reuse/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests/fixtures/loader-source-reuse/state.mjs
+++ b/tests/fixtures/loader-source-reuse/state.mjs
@@ -1,0 +1,7 @@
+export class Token {}
+export let value = 41;
+export function increment() { value++; }
+export let disposals = 0;
+{
+  using resource = {[Symbol.dispose]() { disposals++; }};
+}

--- a/wiki/design/architecture.md
+++ b/wiki/design/architecture.md
@@ -64,6 +64,8 @@ The load hook handles type stripping, the non-erasable syntax other strippers re
 
 The resolve hook is additive only. It layers tsconfig path aliases, extensionless probing for TypeScript extensions, and Yarn Plug'n'Play reads on top of Node's own resolver, and returns nothing when it has no additive answer — at which point resolution falls straight through. There is no reimplementation of Node's resolution algorithm anywhere in Nub, which confines the risk to what Nub adds. That is validated by running Node's own resolution test subset twice, once in passthrough and once augmented, and asserting parity: [[research/resolution-conformance]].
 
+When JavaScript syntax inspection identifies a required transform, the transform reuses the inspected bytes instead of reading the file again. Loader execution order remains unchanged on both tiers.
+
 Background: [[research/tsgo-vs-oxc-for-transpile]], [[research/wasm-vs-napi-for-transpile]], [[research/emit-decorator-metadata]], [[research/tsconfig-paths]], [[research/ts-extension-precedence]].
 
 ## Composition


### PR DESCRIPTION
Reuse source already read by the JavaScript syntax gate when lowering is required. Loader execution order and cache keys remain unchanged.

Adds supplied-source, transformed module identity, and early-hook ordering coverage. Verified on Node 18.19, 22.15, 24.20, and 26.8; remote workspace tests, compile tests, and Clippy pass.