### PR TITLE
compile: retry the publish rename past the self-probe's Windows lock

### DIFF
--- a/crates/nub-cli/src/compile/mod.rs
+++ b/crates/nub-cli/src/compile/mod.rs
@@ -18,6 +18,7 @@
 use std::fs;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
 use nub_core::compile::{
@@ -3639,11 +3640,92 @@ fn same_filesystem(_a: &Path, _b: &Path) -> bool {
     true
 }
 
+/// How long the publish rename keeps re-trying a lock it expects to clear.
+///
+/// The window being waited out is Windows releasing the image section of a
+/// process that has already exited. Its length is NOT measured here — the
+/// failures it was drawn from are CI races that cannot be reproduced on demand —
+/// so the budget is set by what it costs to be wrong rather than by a reading.
+/// Too short and the build still fails; too long and a destination something
+/// really holds reports the error it always did, two seconds later. The second
+/// is much the cheaper mistake, and it is paid only on a path that was going to
+/// fail anyway.
+const PUBLISH_RETRY_BUDGET: Duration = Duration::from_secs(2);
+
+/// Whether a failed publish rename is the transient lock left behind by the
+/// self-probe, rather than a real refusal.
+///
+/// `verify_artifact` SPAWNS the staged executable, and the publish rename follows
+/// as soon as it exits. On Windows the loader can still hold that image's section
+/// object after the process is gone, so `MoveFileExW` reports
+/// `ERROR_SHARING_VIOLATION` (32) — or `ERROR_ACCESS_DENIED` (5) once the name is
+/// delete-pending — for a file nothing is really using. The lock is therefore
+/// self-inflicted and always clears; the same two codes are what
+/// `runtime_cache::classify_target_rename_failure` already keys on.
+///
+/// Observed twice in CI on the same day, on both Windows architectures and on
+/// different fixtures, with the artifact fully built and verified: the compile
+/// failed at the last step having done all of the work. Naming each build's
+/// output uniquely does NOT prevent it, because the handle is on the STAGED file
+/// that was just probed rather than on a name reused from an earlier build.
+///
+/// Windows-only on purpose. A POSIX rename does not consult the image of a
+/// running or recently-exited program at all, and the two codes mean unrelated
+/// things there (2 is ENOENT, 32 is EPIPE), so reading them as a lock off
+/// Windows would sleep on real failures. Everywhere else this answers false and
+/// the rename keeps its single attempt.
+fn publish_rename_is_transient(error: &std::io::Error) -> bool {
+    #[cfg(not(windows))]
+    let _ = error;
+    #[cfg(windows)]
+    if matches!(error.raw_os_error(), Some(5 | 32)) {
+        return true;
+    }
+    false
+}
+
 fn publish_staged_with<F>(staged: &Path, destination: &Path, rename: F) -> Result<()>
 where
-    F: FnOnce(&Path, &Path) -> std::io::Result<()>,
+    F: FnMut(&Path, &Path) -> std::io::Result<()>,
 {
-    rename(staged, destination).with_context(|| {
+    publish_staged_retrying(staged, destination, rename, publish_rename_is_transient)
+}
+
+/// The retry itself, with the "is this worth another go?" question passed in.
+///
+/// Taking the predicate is what makes the loop testable AT ALL: the compile unit
+/// tests run on one CI leg and it is Linux (`ci.yml`, `matrix.os ==
+/// 'ubuntu-latest'`), so a `#[cfg(windows)]` test of this would compile
+/// everywhere and execute nowhere. The platform knowledge stays in
+/// [`publish_rename_is_transient`], which is two lines and has nothing to get
+/// wrong; the termination and attempt behaviour is what a test needs to reach.
+fn publish_staged_retrying<F, P>(
+    staged: &Path,
+    destination: &Path,
+    mut rename: F,
+    transient: P,
+) -> Result<()>
+where
+    F: FnMut(&Path, &Path) -> std::io::Result<()>,
+    P: Fn(&std::io::Error) -> bool,
+{
+    let mut waited = Duration::ZERO;
+    let mut backoff = Duration::from_millis(5);
+    let error = loop {
+        match rename(staged, destination) {
+            Ok(()) => return Ok(()),
+            Err(error) if waited < PUBLISH_RETRY_BUDGET && transient(&error) => {
+                std::thread::sleep(backoff);
+                waited += backoff;
+                // Short at first because the wait is usually over in one hop, then
+                // capped so a destination held by something real is polled at a
+                // steady rate rather than slept on for most of the budget.
+                backoff = (backoff * 2).min(Duration::from_millis(100));
+            }
+            Err(error) => break error,
+        }
+    };
+    Err(error).with_context(|| {
         format!(
             "atomically replacing {} with staged output {}",
             destination.display(),
@@ -4154,14 +4236,110 @@ mod tests {
         let staged = StagedArtifact::new(&destination, "test").unwrap();
         fs::write(staged.path(), b"new-artifact").unwrap();
 
+        let mut attempts = 0;
         let error = publish_staged_with(staged.path(), &destination, |_staged, _destination| {
+            attempts += 1;
             Err(std::io::Error::other("injected late publish failure"))
         })
         .unwrap_err();
         assert!(format!("{error:#}").contains("late publish failure"));
         assert_eq!(fs::read(&destination).unwrap(), b"known-good");
+        // The retry below exists for ONE transient condition. A real refusal — a
+        // read-only directory, a staging file that vanished — must surface at once
+        // rather than be slept on for the budget.
+        assert_eq!(attempts, 1, "a failure that is not a lock is not retried");
         drop(staged);
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// `verify_artifact` spawns the staged executable, so Windows can still hold
+    /// its image section when the publish rename runs a moment later. Retrying is
+    /// what stops that from failing a build whose artifact is already written and
+    /// verified — seen twice in CI on one day, on both Windows architectures.
+    ///
+    /// The predicate is injected rather than left to default, so this runs on the
+    /// one leg the compile unit tests have. `publish_rename_is_transient` answers
+    /// false off Windows, which would otherwise make this assert nothing.
+    #[test]
+    fn the_publish_rename_waits_out_a_lock_that_clears() {
+        let dir = fresh_dir("publish-lock-clears");
+        let destination = dir.join("app");
+        let mut attempts = 0;
+        publish_staged_retrying(
+            &dir.join("staged"),
+            &destination,
+            |_staged, _destination| {
+                attempts += 1;
+                if attempts < 3 {
+                    // ERROR_SHARING_VIOLATION, exactly what MoveFileExW reported.
+                    Err(std::io::Error::from_raw_os_error(32))
+                } else {
+                    Ok(())
+                }
+            },
+            |_| true,
+        )
+        .expect("a lock that clears must not fail the publish");
+        assert_eq!(attempts, 3, "every attempt is a fresh rename");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// A destination something really is holding — the user running the previous
+    /// artifact — must still fail, with the message it always had. What this is
+    /// really guarding is that the loop TERMINATES: drop the budget or stop
+    /// accumulating the wait and it spins forever, which costs a CI timeout
+    /// rather than a red assertion.
+    #[test]
+    fn a_lock_that_never_clears_gives_up_and_reports_it() {
+        let dir = fresh_dir("publish-lock-persists");
+        let destination = dir.join("app");
+        let mut attempts = 0;
+        let error = publish_staged_retrying(
+            &dir.join("staged"),
+            &destination,
+            |_staged, _destination| {
+                attempts += 1;
+                Err(std::io::Error::from_raw_os_error(32))
+            },
+            |_| true,
+        )
+        .unwrap_err();
+        assert!(attempts > 1, "a lock is retried before it is believed");
+        assert!(format!("{error:#}").contains("atomically replacing"));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Only the two codes the self-probe's lock reports are worth waiting on. A
+    /// missing staging file or a read-only directory is a real refusal, and the
+    /// mapping is what keeps the loop above from sleeping on one.
+    #[test]
+    fn only_the_windows_lock_codes_are_treated_as_transient() {
+        assert!(!publish_rename_is_transient(&std::io::Error::other(
+            "not an OS error at all"
+        )));
+        // ERROR_FILE_NOT_FOUND. A staged file that vanished never comes back.
+        assert!(!publish_rename_is_transient(
+            &std::io::Error::from_raw_os_error(2)
+        ));
+        #[cfg(windows)]
+        {
+            // ERROR_ACCESS_DENIED once the name is delete-pending, and
+            // ERROR_SHARING_VIOLATION while the image section is still mapped.
+            assert!(publish_rename_is_transient(
+                &std::io::Error::from_raw_os_error(5)
+            ));
+            assert!(publish_rename_is_transient(
+                &std::io::Error::from_raw_os_error(32)
+            ));
+        }
+        #[cfg(not(windows))]
+        {
+            // Those codes mean unrelated things elsewhere (2 is ENOENT, 32 is
+            // EPIPE), so nothing off Windows may read them as a lock.
+            assert!(!publish_rename_is_transient(
+                &std::io::Error::from_raw_os_error(32)
+            ));
+        }
     }
 
     /// Staging must survive an output directory whose PARENT is a read-only


### PR DESCRIPTION
`nub compile` fails intermittently on Windows at its very last step, with the artifact already written, signed and verified:

```
error  atomically replacing ./bin-a-resolution.exe with staged output
       ...\.nub-compile-artifact-6948-0\bin-a-resolution.exe.tmp
       The process cannot access the file because it is being used by another process. (os error 32)
```

`verify_artifact` spawns the staged executable as a self-probe, and the publish rename runs as soon as it exits. Windows can still hold that image's section object after the process is gone, so `MoveFileExW` reports `ERROR_SHARING_VIOLATION` for a file nothing is really using. The lock is self-inflicted and clears on its own.

Seen twice on 2026-09-05 in `Compile native package islands`, on both Windows architectures and on different fixtures — [win32-arm64 on `a-decorators`](https://github.com/nubjs/nub/actions/runs/33992824346) and [win32-x64 on `a-resolution`](https://github.com/nubjs/nub/actions/runs/33993294485). Naming each build's output uniquely does not prevent it: the handle is on the staged file that was just probed, not on a name reused from an earlier build, and the second failure already had unique names.

The publish rename now retries `ERROR_SHARING_VIOLATION` and `ERROR_ACCESS_DENIED` for up to two seconds, backing off from 5 ms to a 100 ms cap. Those are the two codes `runtime_cache::classify_target_rename_failure` already reads as an in-use target. Every other failure is reported on the first attempt, exactly as before, and a destination something really holds still fails with the message it always had.

How long the lock lasts is not measured, and the comment says so: the failures are CI races that cannot be reproduced on demand. The budget is set by what it costs to be wrong in each direction rather than by a reading.

So the tests cover the loop, not the race. `ci.yml` runs the compile unit tests on `ubuntu-latest` alone, so a `#[cfg(windows)]` test would compile on every platform and execute on none. The retryable-or-not question is a parameter instead, which puts the loop on the leg that actually runs it:

- a lock that clears is retried until it does, and each attempt is a fresh rename
- a lock that never clears gives up and reports, which is what proves the loop terminates
- only the two Windows codes count as transient; a vanished staging file and a non-OS error do not

Locally: the compile unit suite at `900 passed; 0 failed; 0 filtered out`, `cargo fmt --check` clean, and CI's own `clippy --all-targets --all-features -- -D warnings` at zero warnings. A red control with the budget zeroed fails exactly the two retry tests, on different lines, and leaves the code-mapping test green.
