### PR TITLE
pm: apply the bundled compatibility database under nub

### DIFF
--- a/crates/nub-cli/src/pm_engine/identity.rs
+++ b/crates/nub-cli/src/pm_engine/identity.rs
@@ -353,14 +353,18 @@ pub(crate) const NUB: aube_util::Embedder = aube_util::Embedder {
             "nub chooses its own output streams. Redirect the command's stdout or stderr \
              in your shell instead.",
         ),
-        // Parity no-ops in the engine ITSELF, not just under nub: accepted and
-        // wired to nothing. Both carry the standing note in settings.toml that
-        // the flag comes off once a caller starts gating on them.
+        // A parity no-op in the engine ITSELF, not just under nub: accepted and
+        // wired to nothing. It carries the standing note in settings.toml that
+        // the flag comes off once a caller starts gating on it.
+        //
+        // `ignoreCompatibilityDb` USED to sit here beside it, on the grounds that
+        // nub shipped no compatibility database. It ships one now — the same
+        // vendored Yarn + pnpm catalogs pnpm merges into every install — so the
+        // setting has a real reader and must stay settable. Leaving it listed
+        // would strip it from `meta::find`, make `config set` refuse it, and
+        // fall the accessor through to the default: a database applied to every
+        // install with no way to turn it off.
         ("useBetaCli", "nub has no beta-gated commands."),
-        (
-            "ignoreCompatibilityDb",
-            "nub ships no package-compatibility database, so there is nothing to disable.",
-        ),
         // `install::FrozenMode::default_for_env` asks `aube_util::env::is_ci()`,
         // which reads the `CI` ENVIRONMENT VARIABLE. No reader consults the
         // config key, so an `.npmrc` `ci=` line has never decided anything.

--- a/crates/nub-cli/tests/package_extensions.rs
+++ b/crates/nub-cli/tests/package_extensions.rs
@@ -130,3 +130,54 @@ fn top_level_package_extensions_shapes_resolution_and_invalidates_freshness() {
          the edit must invalidate the install fast path so it re-resolves: {err2}"
     );
 }
+
+/// The bundled compatibility database repairs a real published package whose
+/// manifest is wrong, and `ignoreCompatibilityDb` turns it off.
+///
+/// This is pnpm's own bundled data — Yarn's `packageExtensions` database plus
+/// pnpm's additions — and pnpm merges it into every install. `reactcss@1.2.3`
+/// requires `react` and declares it nowhere, so the catalog entry
+/// `reactcss@* -> peerDependencies.react` is what makes `auto-install-peers`
+/// supply it. Until the engine's embedder gate came off, that catalog applied
+/// only to standalone aube, so this package installed under pnpm and threw
+/// `Cannot find module 'react'` under nub.
+///
+/// Both arms matter. The opt-out arm is the control: it proves the pass is the
+/// database doing work rather than `react` arriving by some other route, and it
+/// proves the setting is still reachable — an escape hatch that silently did
+/// nothing would leave no way to decline the repair.
+#[test]
+#[ignore = "network: resolves reactcss@1.2.3 and the react the compat database adds"]
+fn the_bundled_compatibility_database_repairs_a_published_phantom() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let manifest = r#"{"name":"compatdb","version":"1.0.0","dependencies":{"reactcss":"1.2.3"}}"#;
+    let store = pm_tmpdir("compatdb-store");
+    let cache = pm_tmpdir("compatdb-cache");
+
+    let on = pm_tmpdir("compatdb-on");
+    std::fs::write(on.join("package.json"), manifest).unwrap();
+    let (err_on, code_on) = run_install_in_store(&on, &store, &cache, &["install"]);
+    assert_eq!(code_on, 0, "install with the database failed: {err_on}");
+    assert!(
+        store_has(&on, "react"),
+        "the bundled database must add reactcss's undeclared react peer so it is \
+         installed: {err_on}"
+    );
+
+    let off = pm_tmpdir("compatdb-off");
+    std::fs::write(off.join("package.json"), manifest).unwrap();
+    std::fs::write(off.join(".npmrc"), "ignore-compatibility-db=true\n").unwrap();
+    let (err_off, code_off) = run_install_in_store(&off, &store, &cache, &["install"]);
+    assert_eq!(
+        code_off, 0,
+        "install with the database off failed: {err_off}"
+    );
+    assert!(
+        !store_has(&off, "react"),
+        "ignore-compatibility-db must decline the repair, leaving reactcss's \
+         undeclared import unresolved: {err_off}"
+    );
+}

--- a/vendor/aube/crates/aube/build.rs
+++ b/vendor/aube/crates/aube/build.rs
@@ -85,9 +85,7 @@ fn generate_bundled_package_extensions() {
     for (name, optional) in peer_meta {
         writeln!(generated, "    ({name:?}, {optional}),").unwrap();
     }
-    generated.push_str(
-        "];\nstatic STANDALONE_BUNDLED_PACKAGE_EXTENSIONS: &[BundledPackageExtension] = &[\n",
-    );
+    generated.push_str("];\nstatic VENDORED_COMPAT_EXTENSIONS: &[BundledPackageExtension] = &[\n");
     for extension in extensions {
         writeln!(
             generated,

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -498,13 +498,6 @@ pub(crate) fn resolve_force_metadata_primer(ctx: &aube_settings::ResolveCtx<'_>)
     aube_settings::resolved::force_metadata_primer(ctx)
 }
 
-fn is_standalone_aube(embedder: &aube_util::Embedder) -> bool {
-    // `AUBE` is a `const`, so references to it are not guaranteed to have a
-    // single stable address. The command-safe program name is the canonical
-    // value-level distinction between standalone aube and another embedder.
-    embedder.name == aube_util::identity::AUBE.name
-}
-
 pub(crate) fn resolve_dependency_policy(
     manifest: &aube_manifest::PackageJson,
     ctx: &aube_settings::ResolveCtx<'_>,
@@ -524,11 +517,21 @@ pub(crate) fn resolve_dependency_policy(
     // and abort `--frozen-lockfile` under `enforce_package_extensions_checksum`.
     let mut extensions = parse_package_extensions(package_extensions)?;
     if !aube_settings::resolved::ignore_compatibility_db(ctx) {
-        if is_standalone_aube(aube_util::embedder()) {
-            // Catalog order is significant when semver selectors overlap: the
-            // first matching extension wins per dependency key.
-            extensions.extend(standalone_bundled_package_extensions());
-        }
+        // The vendored ecosystem catalogs apply to EVERY embedder, not only
+        // standalone aube. They are pnpm's own bundled data — Yarn's
+        // `packageExtensions` database plus pnpm's three additions — and pnpm
+        // merges it into every install unless `ignoreCompatibilityDb` is set. An
+        // embedder that skipped it resolves a strictly smaller dependency graph
+        // than the tool it mirrors, which is a compatibility difference users
+        // hit as a missing module rather than as a warning: `reactcss@1.2.3`
+        // requires `react` and declares it nowhere, so it installs and runs
+        // under pnpm (the catalog adds the peer, and `auto-install-peers`
+        // supplies it) and fails with `Cannot find module 'react'` without the
+        // catalog.
+        //
+        // Catalog order is significant when semver selectors overlap: the first
+        // matching extension wins per dependency key.
+        extensions.extend(standalone_bundled_package_extensions());
         if let Some(bundled) = aube_util::engine_context().bundled_package_extensions {
             // Bundled extensions are embedder-supplied data, not user config.
             // A malformed entry should warn and be skipped, not abort the install
@@ -1512,13 +1515,23 @@ mod bundled_compat_tests {
     use super::*;
 
     #[test]
-    fn standalone_detection_uses_embedder_value_not_const_address() {
-        assert!(is_standalone_aube(&aube_util::identity::AUBE));
-        let embedded = aube_util::Embedder {
-            name: "embedded-aube",
-            ..aube_util::identity::AUBE
-        };
-        assert!(!is_standalone_aube(&embedded));
+    fn the_catalog_carries_the_rule_an_embedder_gate_used_to_withhold() {
+        // Until this gate came off, the vendored catalogs applied only when the
+        // embedder was standalone aube, so every embedder resolved a smaller
+        // graph than pnpm for the same project. `reactcss` is the cheapest
+        // demonstration: it requires `react` and declares it nowhere, so without
+        // this rule the peer is never added, `auto-install-peers` has nothing to
+        // install, and the package fails at require time with `Cannot find
+        // module 'react'` — under a tool whose whole claim is pnpm parity.
+        let extensions = standalone_bundled_package_extensions();
+        let reactcss = extensions
+            .iter()
+            .find(|extension| extension.selector == "reactcss@*")
+            .expect("the bundled catalog must carry reactcss@*");
+        assert_eq!(
+            reactcss.peer_dependencies["react"], "*",
+            "reactcss must gain react as a peer for auto-install-peers to supply it"
+        );
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/install/settings.rs
+++ b/vendor/aube/crates/aube/src/commands/install/settings.rs
@@ -531,7 +531,7 @@ pub(crate) fn resolve_dependency_policy(
         //
         // Catalog order is significant when semver selectors overlap: the first
         // matching extension wins per dependency key.
-        extensions.extend(standalone_bundled_package_extensions());
+        extensions.extend(vendored_compat_extensions());
         if let Some(bundled) = aube_util::engine_context().bundled_package_extensions {
             // Bundled extensions are embedder-supplied data, not user config.
             // A malformed entry should warn and be skipped, not abort the install
@@ -1008,8 +1008,8 @@ fn parse_bundled_package_extensions(
         .collect()
 }
 
-fn standalone_bundled_package_extensions() -> Vec<aube_resolver::PackageExtension> {
-    STANDALONE_BUNDLED_PACKAGE_EXTENSIONS
+fn vendored_compat_extensions() -> Vec<aube_resolver::PackageExtension> {
+    VENDORED_COMPAT_EXTENSIONS
         .iter()
         .map(|extension| aube_resolver::PackageExtension {
             selector: bundled_string(extension.selector).to_owned(),
@@ -1523,7 +1523,7 @@ mod bundled_compat_tests {
         // this rule the peer is never added, `auto-install-peers` has nothing to
         // install, and the package fails at require time with `Cannot find
         // module 'react'` — under a tool whose whole claim is pnpm parity.
-        let extensions = standalone_bundled_package_extensions();
+        let extensions = vendored_compat_extensions();
         let reactcss = extensions
             .iter()
             .find(|extension| extension.selector == "reactcss@*")
@@ -1536,7 +1536,7 @@ mod bundled_compat_tests {
 
     #[test]
     fn catalog_matches_curated_upstreams_and_preserves_order() {
-        let extensions = standalone_bundled_package_extensions();
+        let extensions = vendored_compat_extensions();
 
         assert_eq!(extensions.len(), 161);
         let extension = |selector: &str| {
@@ -1569,7 +1569,7 @@ mod bundled_compat_tests {
         // These are the bare runtime targets the reverted scanner rules
         // injected. Their `@types/*` counterparts are legitimate packages and
         // intentionally remain allowed in curated repairs.
-        let extensions = standalone_bundled_package_extensions();
+        let extensions = vendored_compat_extensions();
         for target in ["estree", "typescript", "react", "eslint"] {
             for extension in &extensions {
                 assert!(


### PR DESCRIPTION
The vendored Yarn + pnpm `packageExtensions` catalogs (161 entries) were gated on the embedder being standalone aube, so nub applied none. pnpm merges the same data into every install unless `ignoreCompatibilityDb` is set.

`reactcss@1.2.3` requires `react` and declares it nowhere:

| | `require("reactcss")` |
| --- | --- |
| `main` | `Cannot find module 'react'` |
| this branch | passes |
| + `ignore-compatibility-db=true` | fails |

`auto_install_peers` already defaults on, so the catalog is the whole fix.

`ignoreCompatibilityDb` leaves the inert-settings list, which had made `config set` refuse it. Without that, the repairs have no opt-out; row 3 checks it.