### PR TITLE
pm: withhold lockfile reuse when packageExtensions drift

### DIFF
--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -991,15 +991,31 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             .unwrap_or_else(|| aube_settings::resolved::minimum_release_age(&settings_ctx))
             > 0
         && crate::state::release_policy_changed_since_last_run(&cwd, &opts.cli_flags);
-    // Resolver reuse can accept a locked package without fetching its publish
-    // time, which would bypass the age gate we are here to revalidate. Match
-    // `--force` for this one path by withholding the existing-graph hint.
-    let existing_for_resolver: Option<&aube_lockfile::LockfileGraph> = if revalidate_release_policy
-    {
-        None
-    } else {
-        lockfile_pre_parse.as_ref().map(|(g, _)| g)
-    };
+    // The project's effective packageExtensions checksum, for the lockfile
+    // drift check. Computed only under an enforcing embedder (nub); standalone
+    // aube leaves it `None` and the drift check (gated on the same posture) is
+    // a no-op. Uses the same `effective_package_extensions` the stamp path
+    // does, so a fresh install and the drift check agree.
+    let effective_package_extensions_checksum =
+        if aube_util::engine_context().enforce_package_extensions_checksum {
+            aube_lockfile::pnpm::package_extensions_checksum(
+                &settings::effective_package_extensions(&manifest, &settings_ctx),
+            )
+        } else {
+            None
+        };
+    // Withhold the resolver's existing-graph hint when reuse would defeat the
+    // very thing this install is re-resolving for — an age gate being
+    // revalidated, or a packageExtensions edit whose effect only lands when a
+    // packument is fetched. Scoped to real drift, so a steady-state install
+    // keeps full reuse: a lockfile written WITH the extensions already carries
+    // the extended deps, and reusing those is correct.
+    let existing_for_resolver: Option<&aube_lockfile::LockfileGraph> = resolve::existing_graph_hint(
+        lockfile_pre_parse.as_ref(),
+        revalidate_release_policy,
+        aube_util::engine_context().enforce_package_extensions_checksum,
+        effective_package_extensions_checksum.as_deref(),
+    );
 
     // `preResolution` runs here — once, on every install, before any
     // branch on frozen mode or lockfile freshness, which is where pnpm
@@ -1055,20 +1071,6 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         )
         .await?;
     }
-
-    // The project's effective packageExtensions checksum, for the lockfile
-    // drift check. Computed only under an enforcing embedder (nub); standalone
-    // aube leaves it `None` and the drift check (gated on the same posture) is
-    // a no-op. Uses the same `effective_package_extensions` the stamp path
-    // does, so a fresh install and the drift check agree.
-    let effective_package_extensions_checksum =
-        if aube_util::engine_context().enforce_package_extensions_checksum {
-            aube_lockfile::pnpm::package_extensions_checksum(
-                &settings::effective_package_extensions(&manifest, &settings_ctx),
-            )
-        } else {
-            None
-        };
 
     // `--lockfile-only` short-circuit. Resolves (or reuses a fresh
     // lockfile), writes the new lockfile, and exits before any tarball

--- a/vendor/aube/crates/aube/src/commands/install/resolve.rs
+++ b/vendor/aube/crates/aube/src/commands/install/resolve.rs
@@ -469,6 +469,42 @@ fn package_extensions_drift(
     }
 }
 
+/// The existing-graph hint handed to the resolver, or `None` to withhold it.
+///
+/// Withholding matters because resolver reuse is not merely an optimization:
+/// it accepts a locked package WITHOUT fetching its packument, and the
+/// packument is the only place a `packageExtensions` entry is ever applied.
+/// Discarding the lockfile on drift is therefore only half a fix — the
+/// re-resolve would load the new extensions and still hand back the locked
+/// dependency set, so the edit would rewrite the lockfile's checksum and
+/// change nothing else.
+///
+/// Pure, with the embedder posture passed in rather than read from the
+/// process-global engine context, so the wiring this guards is unit-testable
+/// without mutating global state.
+pub(super) fn existing_graph_hint<'a>(
+    lockfile_pre_parse: Option<&'a (LockfileGraph, LockfileKind)>,
+    revalidate_release_policy: bool,
+    enforce_package_extensions_checksum: bool,
+    effective_package_extensions_checksum: Option<&str>,
+) -> Option<&'a LockfileGraph> {
+    // Reuse can also accept a locked package without fetching its publish
+    // time, which would bypass an age gate being revalidated.
+    if revalidate_release_policy {
+        return None;
+    }
+    let (graph, _) = lockfile_pre_parse?;
+    if enforce_package_extensions_checksum
+        && matches!(
+            graph.check_package_extensions_drift(effective_package_extensions_checksum),
+            DriftStatus::Stale { .. }
+        )
+    {
+        return None;
+    }
+    Some(graph)
+}
+
 pub(super) fn select_lockfile_result(
     input: SelectLockfileInput<'_>,
 ) -> miette::Result<Result<(LockfileGraph, LockfileKind), aube_lockfile::Error>> {
@@ -773,5 +809,67 @@ pub(super) fn lockfile_source_label(kind: LockfileKind) -> &'static str {
         LockfileKind::Npm => "package-lock.json",
         LockfileKind::NpmShrinkwrap => "npm-shrinkwrap.json",
         LockfileKind::Bun => "bun.lock",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph_with_checksum(checksum: Option<&str>) -> (LockfileGraph, LockfileKind) {
+        let graph = LockfileGraph {
+            package_extensions_checksum: checksum.map(str::to_string),
+            ..Default::default()
+        };
+        (graph, LockfileKind::Aube)
+    }
+
+    /// A packageExtensions edit must withhold the resolver's reuse hint.
+    ///
+    /// Discarding the lockfile is not enough on its own: reuse resolves a
+    /// locked package without fetching its packument, which is the only place
+    /// an extension is applied. Before this wiring existed the re-resolve
+    /// loaded the new extensions and still returned the locked dependency set,
+    /// so `nub install` reported `Already up to date` and installed nothing.
+    #[test]
+    fn a_package_extensions_edit_withholds_the_resolver_reuse_hint() {
+        let locked = graph_with_checksum(Some("sha256-written-with-the-old-extensions"));
+        assert!(
+            existing_graph_hint(Some(&locked), false, true, Some("sha256-edited")).is_none(),
+            "a drifted checksum must withhold the hint, or the edit resolves to nothing"
+        );
+        // Adding a first extension to a project that had none drifts too: the
+        // lockfile records no checksum and the effective one is now `Some`.
+        let never_extended = graph_with_checksum(None);
+        assert!(
+            existing_graph_hint(Some(&never_extended), false, true, Some("sha256-edited"))
+                .is_none(),
+            "a first extension must withhold the hint"
+        );
+    }
+
+    /// Reuse survives everything that is not drift — the hint is the warm
+    /// path, so withholding it on a steady-state install would re-fetch every
+    /// packument in the tree on every run.
+    #[test]
+    fn an_unchanged_project_keeps_the_resolver_reuse_hint() {
+        let matching = graph_with_checksum(Some("sha256-same"));
+        assert!(
+            existing_graph_hint(Some(&matching), false, true, Some("sha256-same")).is_some(),
+            "an unchanged checksum must keep the hint"
+        );
+        let no_extensions = graph_with_checksum(None);
+        assert!(
+            existing_graph_hint(Some(&no_extensions), false, true, None).is_some(),
+            "a project with no extensions at all must keep the hint"
+        );
+        // Standalone aube does not enforce the checksum, so the whole layer is
+        // a no-op there even against a graph that would otherwise read as
+        // drifted — its lockfile never carries the field to begin with.
+        let drifted = graph_with_checksum(Some("sha256-written"));
+        assert!(
+            existing_graph_hint(Some(&drifted), false, false, Some("sha256-edited")).is_some(),
+            "a non-enforcing embedder must be unaffected by this layer"
+        );
     }
 }


### PR DESCRIPTION
A `packageExtensions` edit discarded the lockfile as drift, but the same graph still went to the resolver as a reuse hint. Reuse resolves a locked package without fetching its packument, the only place an extension is applied, so the re-resolve loaded the new extensions and returned the locked deps unchanged: checksum rewritten, nothing installed.

Withholds the hint on drift, matching the release-age path above it. Steady-state installs keep full reuse.

`top_level_package_extensions_shapes_resolution_and_invalidates_freshness` covered this and was failing. It is `#[ignore]`d for network and no CI job passes `--ignored`, so the decision is now unit-tested offline, where aube-parity runs it.