### PR TITLE
pm: bundle the phantom-derived packageExtensions database

### DIFF
--- a/crates/nub-cli/assets/bundled-package-extensions.json
+++ b/crates/nub-cli/assets/bundled-package-extensions.json
@@ -1,0 +1,9775 @@
+{
+ "_source": "@nubjs/extensions",
+ "_version": "1.0.0",
+ "_generated": "2026-09-06",
+ "_refresh": "node scripts/sync-package-extensions.mjs",
+ "packageExtensions": {
+  "@acemir/cssom@*": {
+   "peerDependencies": {
+    "cssstyle": "*"
+   },
+   "peerDependenciesMeta": {
+    "cssstyle": {
+     "optional": true
+    }
+   }
+  },
+  "@algolia/autocomplete-core@*": {
+   "peerDependencies": {
+    "@algolia/client-search": "*"
+   },
+   "peerDependenciesMeta": {
+    "@algolia/client-search": {
+     "optional": true
+    }
+   }
+  },
+  "@amplitude/rrweb-snapshot@*": {
+   "peerDependencies": {
+    "@amplitude/rrweb-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@amplitude/rrweb-types": {
+     "optional": true
+    }
+   }
+  },
+  "@andersbakken/blessed@*": {
+   "peerDependencies": {
+    "blessed": "*"
+   },
+   "peerDependenciesMeta": {
+    "blessed": {
+     "optional": true
+    }
+   }
+  },
+  "@angular-devkit/build-angular@*": {
+   "peerDependencies": {
+    "zone.js": "*"
+   },
+   "peerDependenciesMeta": {
+    "zone.js": {
+     "optional": true
+    }
+   }
+  },
+  "@angular-eslint/bundled-angular-compiler@*": {
+   "peerDependencies": {
+    "@angular/compiler": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular/compiler": {
+     "optional": true
+    }
+   }
+  },
+  "@angular-eslint/template-parser@*": {
+   "peerDependencies": {
+    "@typescript-eslint/types": "*",
+    "@typescript-eslint/utils": "*"
+   },
+   "peerDependenciesMeta": {
+    "@typescript-eslint/types": {
+     "optional": true
+    },
+    "@typescript-eslint/utils": {
+     "optional": true
+    }
+   }
+  },
+  "@angular/cdk@*": {
+   "peerDependencies": {
+    "@angular-devkit/core": "*",
+    "@angular-devkit/schematics": "*",
+    "@schematics/angular": "*",
+    "selenium-webdriver": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular-devkit/core": {
+     "optional": true
+    },
+    "@angular-devkit/schematics": {
+     "optional": true
+    },
+    "@schematics/angular": {
+     "optional": true
+    },
+    "selenium-webdriver": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@angular/cli@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@angular/common@*": {
+   "peerDependencies": {
+    "@angular/upgrade": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular/upgrade": {
+     "optional": true
+    }
+   }
+  },
+  "@angular/language-service@*": {
+   "peerDependencies": {
+    "@angular/compiler": "*",
+    "@angular/compiler-cli": "*",
+    "@angular/core": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular/compiler": {
+     "optional": true
+    },
+    "@angular/compiler-cli": {
+     "optional": true
+    },
+    "@angular/core": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@angular/router@*": {
+   "peerDependencies": {
+    "@angular/upgrade": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular/upgrade": {
+     "optional": true
+    }
+   }
+  },
+  "@ant-design/react-slick@<=0.28.3": {
+   "peerDependencies": {
+    "react": ">=16.0.0"
+   }
+  },
+  "@anthropic-ai/sdk@*": {
+   "peerDependencies": {
+    "node-fetch": "*",
+    "undici": "*",
+    "undici-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "node-fetch": {
+     "optional": true
+    },
+    "undici": {
+     "optional": true
+    },
+    "undici-types": {
+     "optional": true
+    }
+   }
+  },
+  "@apollo/client@*": {
+   "peerDependencies": {
+    "relay-runtime": "*"
+   },
+   "peerDependenciesMeta": {
+    "relay-runtime": {
+     "optional": true
+    }
+   }
+  },
+  "@apollographql/apollo-tools@<=0.5.2": {
+   "peerDependencies": {
+    "graphql": "^14.2.1 || ^15.0.0"
+   }
+  },
+  "@appium/types@*": {
+   "peerDependencies": {
+    "express": "*",
+    "ws": "*"
+   },
+   "peerDependenciesMeta": {
+    "express": {
+     "optional": true
+    },
+    "ws": {
+     "optional": true
+    }
+   }
+  },
+  "@applitools/spec-driver-webdriver@*": {
+   "peerDependencies": {
+    "@applitools/test-utils": "*"
+   },
+   "peerDependenciesMeta": {
+    "@applitools/test-utils": {
+     "optional": true
+    }
+   }
+  },
+  "@ardatan/relay-compiler@*": {
+   "peerDependencies": {
+    "glob": "*"
+   },
+   "peerDependenciesMeta": {
+    "glob": {
+     "optional": true
+    }
+   }
+  },
+  "@astrojs/language-server@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@astrojs/markdown-remark@*": {
+   "peerDependencies": {
+    "hast": "*",
+    "mdast": "*",
+    "unist": "*"
+   },
+   "peerDependenciesMeta": {
+    "hast": {
+     "optional": true
+    },
+    "mdast": {
+     "optional": true
+    },
+    "unist": {
+     "optional": true
+    }
+   }
+  },
+  "@astrojs/react@*": {
+   "peerDependencies": {
+    "astro": "*"
+   },
+   "peerDependenciesMeta": {
+    "astro": {
+     "optional": true
+    }
+   }
+  },
+  "@astrojs/sitemap@*": {
+   "peerDependencies": {
+    "astro": "*"
+   },
+   "peerDependenciesMeta": {
+    "astro": {
+     "optional": true
+    }
+   }
+  },
+  "@astrojs/yaml2ts@*": {
+   "peerDependencies": {
+    "@volar/language-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@volar/language-core": {
+     "optional": true
+    }
+   }
+  },
+  "@asyncapi/react-component@<=1.0.0-next.39": {
+   "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+   }
+  },
+  "@auth/core@*": {
+   "peerDependencies": {
+    "@simplewebauthn/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@simplewebauthn/types": {
+     "optional": true
+    }
+   }
+  },
+  "@aws-amplify/analytics@*": {
+   "peerDependencies": {
+    "@aws-sdk/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@aws-sdk/types": {
+     "optional": true
+    }
+   }
+  },
+  "@aws-amplify/auth@*": {
+   "peerDependencies": {
+    "@aws-sdk/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@aws-sdk/types": {
+     "optional": true
+    }
+   }
+  },
+  "@aws-amplify/core@*": {
+   "peerDependencies": {
+    "@smithy/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@smithy/types": {
+     "optional": true
+    }
+   }
+  },
+  "@aws-lambda-powertools/logger@*": {
+   "peerDependencies": {
+    "aws-lambda": "*"
+   },
+   "peerDependenciesMeta": {
+    "aws-lambda": {
+     "optional": true
+    }
+   }
+  },
+  "@aws-sdk/eventstream-serde-node@*": {
+   "dependencies": {
+    "@smithy/eventstream-serde-node": "*"
+   }
+  },
+  "@aws-sdk/service-error-classification@*": {
+   "dependencies": {
+    "tslib": "*"
+   }
+  },
+  "@azure/core-rest-pipeline@*": {
+   "peerDependencies": {
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "@babel/helper-builder-react-jsx@*": {
+   "peerDependencies": {
+    "@babel/traverse": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/traverse": {
+     "optional": true
+    }
+   }
+  },
+  "@babel/node@*": {
+   "peerDependencies": {
+    "kexec": "*"
+   },
+   "peerDependenciesMeta": {
+    "kexec": {
+     "optional": true
+    }
+   }
+  },
+  "@babel/parser@*": {
+   "dependencies": {
+    "@babel/types": "^7.8.3"
+   }
+  },
+  "@base44/vite-plugin@*": {
+   "peerDependencies": {
+    "vite": "*"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "@cloudflare/vite-plugin@*": {
+   "peerDependencies": {
+    "@cloudflare/workers-utils": "*"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-utils": {
+     "optional": true
+    }
+   }
+  },
+  "@codemirror/lang-json@*": {
+   "peerDependencies": {
+    "@codemirror/lint": "*",
+    "@codemirror/view": "*"
+   },
+   "peerDependenciesMeta": {
+    "@codemirror/lint": {
+     "optional": true
+    },
+    "@codemirror/view": {
+     "optional": true
+    }
+   }
+  },
+  "@codemirror/lang-less@*": {
+   "peerDependencies": {
+    "@codemirror/autocomplete": "*"
+   },
+   "peerDependenciesMeta": {
+    "@codemirror/autocomplete": {
+     "optional": true
+    }
+   }
+  },
+  "@codemirror/lang-sass@*": {
+   "peerDependencies": {
+    "@codemirror/autocomplete": "*"
+   },
+   "peerDependenciesMeta": {
+    "@codemirror/autocomplete": {
+     "optional": true
+    }
+   }
+  },
+  "@cypress/snapshot@*": {
+   "dependencies": {
+    "debug": "^3.2.7"
+   }
+  },
+  "@dabh/diagnostics@*": {
+   "peerDependencies": {
+    "debug": "*"
+   },
+   "peerDependenciesMeta": {
+    "debug": {
+     "optional": true
+    }
+   }
+  },
+  "@datadog/datadog-ci-base@*": {
+   "peerDependencies": {
+    "@datadog/mobile-react-native": "*",
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "@datadog/mobile-react-native": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "@datadog/datadog-ci@*": {
+   "peerDependencies": {
+    "@datadog/mobile-react-native": "*",
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "@datadog/mobile-react-native": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "@datadog/flagging-core@*": {
+   "peerDependencies": {
+    "@openfeature/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@openfeature/core": {
+     "optional": true
+    }
+   }
+  },
+  "@datadog/sketches-js@*": {
+   "dependencies": {
+    "protobufjs": "*"
+   }
+  },
+  "@dataform/core@*": {
+   "peerDependencies": {
+    "long": "*",
+    "protobufjs": "*"
+   },
+   "peerDependenciesMeta": {
+    "long": {
+     "optional": true
+    },
+    "protobufjs": {
+     "optional": true
+    }
+   }
+  },
+  "@develar/schema-utils@*": {
+   "peerDependencies": {
+    "json-schema": "*"
+   },
+   "peerDependenciesMeta": {
+    "json-schema": {
+     "optional": true
+    }
+   }
+  },
+  "@docusaurus/babel@*": {
+   "peerDependencies": {
+    "@docusaurus/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@docusaurus/types": {
+     "optional": true
+    }
+   }
+  },
+  "@docusaurus/core@*": {
+   "peerDependencies": {
+    "@docusaurus/theme-common": "*"
+   },
+   "peerDependenciesMeta": {
+    "@docusaurus/theme-common": {
+     "optional": true
+    }
+   }
+  },
+  "@docusaurus/logger@*": {
+   "peerDependencies": {
+    "@docusaurus/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@docusaurus/types": {
+     "optional": true
+    }
+   }
+  },
+  "@docusaurus/responsive-loader@<1.5.0": {
+   "peerDependenciesMeta": {
+    "sharp": {
+     "optional": true
+    },
+    "jimp": {
+     "optional": true
+    }
+   }
+  },
+  "@edge-runtime/node-utils@*": {
+   "peerDependencies": {
+    "@edge-runtime/primitives": "*"
+   },
+   "peerDependenciesMeta": {
+    "@edge-runtime/primitives": {
+     "optional": true
+    }
+   }
+  },
+  "@edge-runtime/ponyfill@*": {
+   "dependencies": {
+    "@edge-runtime/primitives": "*"
+   }
+  },
+  "@electric-sql/pglite-tools@*": {
+   "peerDependencies": {
+    "ws": "*"
+   },
+   "peerDependenciesMeta": {
+    "ws": {
+     "optional": true
+    }
+   }
+  },
+  "@electric-sql/pglite@*": {
+   "peerDependencies": {
+    "ws": "*"
+   },
+   "peerDependenciesMeta": {
+    "ws": {
+     "optional": true
+    }
+   }
+  },
+  "@electron/asar@*": {
+   "peerDependencies": {
+    "original-fs": "*"
+   },
+   "peerDependenciesMeta": {
+    "original-fs": {
+     "optional": true
+    }
+   }
+  },
+  "@emnapi/core@*": {
+   "peerDependencies": {
+    "@emnapi/runtime": "*"
+   },
+   "peerDependenciesMeta": {
+    "@emnapi/runtime": {
+     "optional": true
+    }
+   }
+  },
+  "@emotion/utils@*": {
+   "peerDependencies": {
+    "@emotion/sheet": "*"
+   },
+   "peerDependenciesMeta": {
+    "@emotion/sheet": {
+     "optional": true
+    }
+   }
+  },
+  "@es-joy/jsdoccomment@*": {
+   "peerDependencies": {
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "@eslint-react/shared@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "@eslint/eslintrc@*": {
+   "peerDependencies": {
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "@ethereumjs/common@*": {
+   "peerDependencies": {
+    "@noble/curves": "*"
+   },
+   "peerDependenciesMeta": {
+    "@noble/curves": {
+     "optional": true
+    }
+   }
+  },
+  "@expo/dom-webview@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "@expo/image-utils@*": {
+   "peerDependencies": {
+    "sharp": "*",
+    "sharp-cli": "*"
+   },
+   "peerDependenciesMeta": {
+    "sharp": {
+     "optional": true
+    },
+    "sharp-cli": {
+     "optional": true
+    }
+   }
+  },
+  "@expo/log-box@*": {
+   "peerDependencies": {
+    "react-dom": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "@expo/metro-config@*": {
+   "peerDependencies": {
+    "babel-preset-expo": "*"
+   },
+   "peerDependenciesMeta": {
+    "babel-preset-expo": {
+     "optional": true
+    }
+   }
+  },
+  "@expo/server@*": {
+   "peerDependencies": {
+    "expo-router": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-router": {
+     "optional": true
+    }
+   }
+  },
+  "@fal-works/esbuild-plugin-global-externals@*": {
+   "peerDependencies": {
+    "esbuild": "*"
+   },
+   "peerDependenciesMeta": {
+    "esbuild": {
+     "optional": true
+    }
+   }
+  },
+  "@fastify/cookie@*": {
+   "peerDependencies": {
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "@fastify/cors@*": {
+   "peerDependencies": {
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "@fastify/formbody@*": {
+   "peerDependencies": {
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "@fastify/helmet@*": {
+   "peerDependencies": {
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "@fastify/multipart@*": {
+   "peerDependencies": {
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "@fastify/rate-limit@*": {
+   "peerDependencies": {
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "@fastify/static@*": {
+   "peerDependencies": {
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "@fastify/swagger-ui@*": {
+   "peerDependencies": {
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "@fastify/swagger@*": {
+   "peerDependencies": {
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "@fastify/type-provider-typebox@^4.0.0": {
+   "peerDependencies": {
+    "fastify": "^4.0.0"
+   }
+  },
+  "@fastify/type-provider-typebox@^5.0.0": {
+   "peerDependencies": {
+    "fastify": "^5.0.0"
+   }
+  },
+  "@firebase/ai@*": {
+   "peerDependencies": {
+    "@firebase/auth-interop-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@firebase/auth-interop-types": {
+     "optional": true
+    }
+   }
+  },
+  "@firebase/analytics-types@*": {
+   "peerDependencies": {
+    "@firebase/app-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@firebase/app-types": {
+     "optional": true
+    }
+   }
+  },
+  "@firebase/app-check-types@*": {
+   "peerDependencies": {
+    "@firebase/app-types": "*",
+    "@firebase/component": "*",
+    "@firebase/util": "*"
+   },
+   "peerDependenciesMeta": {
+    "@firebase/app-types": {
+     "optional": true
+    },
+    "@firebase/component": {
+     "optional": true
+    },
+    "@firebase/util": {
+     "optional": true
+    }
+   }
+  },
+  "@firebase/auth@*": {
+   "peerDependencies": {
+    "@firebase/app-check-interop-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@firebase/app-check-interop-types": {
+     "optional": true
+    }
+   }
+  },
+  "@firebase/data-connect@*": {
+   "peerDependencies": {
+    "@firebase/app-check-interop-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@firebase/app-check-interop-types": {
+     "optional": true
+    }
+   }
+  },
+  "@firebase/database-compat@*": {
+   "peerDependencies": {
+    "@firebase/app-check-interop-types": "*",
+    "@firebase/app-types": "*",
+    "@firebase/auth-interop-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@firebase/app-check-interop-types": {
+     "optional": true
+    },
+    "@firebase/app-types": {
+     "optional": true
+    },
+    "@firebase/auth-interop-types": {
+     "optional": true
+    }
+   }
+  },
+  "@firebase/database@*": {
+   "dependencies": {
+    "@firebase/app": "*"
+   }
+  },
+  "@firebase/firestore-compat@*": {
+   "peerDependencies": {
+    "@firebase/app-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@firebase/app-types": {
+     "optional": true
+    }
+   }
+  },
+  "@firebase/storage-compat@*": {
+   "peerDependencies": {
+    "@firebase/app-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@firebase/app-types": {
+     "optional": true
+    }
+   }
+  },
+  "@firebase/vertexai-preview@*": {
+   "peerDependencies": {
+    "@firebase/auth-interop-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@firebase/auth-interop-types": {
+     "optional": true
+    }
+   }
+  },
+  "@floating-ui/react@*": {
+   "peerDependencies": {
+    "use-isomorphic-layout-effect": "*"
+   },
+   "peerDependenciesMeta": {
+    "use-isomorphic-layout-effect": {
+     "optional": true
+    }
+   }
+  },
+  "@foliojs-fork/fontkit@*": {
+   "peerDependencies": {
+    "iconv-lite": "*"
+   },
+   "peerDependenciesMeta": {
+    "iconv-lite": {
+     "optional": true
+    }
+   }
+  },
+  "@foliojs-fork/restructure@*": {
+   "peerDependencies": {
+    "iconv-lite": "*"
+   },
+   "peerDependenciesMeta": {
+    "iconv-lite": {
+     "optional": true
+    }
+   }
+  },
+  "@formkit/auto-animate@*": {
+   "peerDependencies": {
+    "@angular/core": "*",
+    "@nuxt/kit": "*",
+    "@nuxt/schema": "*",
+    "preact": "*",
+    "react": "*",
+    "solid-js": "*",
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular/core": {
+     "optional": true
+    },
+    "@nuxt/kit": {
+     "optional": true
+    },
+    "@nuxt/schema": {
+     "optional": true
+    },
+    "preact": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "solid-js": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "@fortawesome/fontawesome-svg-core@*": {
+   "peerDependencies": {
+    "@babel/helper-module-imports": "*",
+    "babel-plugin-macros": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/helper-module-imports": {
+     "optional": true
+    },
+    "babel-plugin-macros": {
+     "optional": true
+    }
+   }
+  },
+  "@fullhuman/postcss-purgecss@3.1.3 || 3.1.3-alpha.0": {
+   "peerDependencies": {
+    "postcss": "^8.0.0"
+   }
+  },
+  "@globalart/ddd@*": {
+   "dependencies": {
+    "date-fns": "*"
+   }
+  },
+  "@globalart/nestcord@*": {
+   "peerDependencies": {
+    "discord-api-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "discord-api-types": {
+     "optional": true
+    }
+   }
+  },
+  "@globalart/nestjs-logger@*": {
+   "peerDependencies": {
+    "@opentelemetry/api": "*"
+   },
+   "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+     "optional": true
+    }
+   }
+  },
+  "@google-cloud/firestore@<=4.9.3": {
+   "dependencies": {
+    "protobufjs": "^6.8.6"
+   }
+  },
+  "@google/gemini-cli@*": {
+   "peerDependencies": {
+    "bufferutil": "*",
+    "utf-8-validate": "*"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "@gorhom/bottom-sheet@*": {
+   "peerDependencies": {
+    "@shopify/flash-list": "*"
+   },
+   "peerDependenciesMeta": {
+    "@shopify/flash-list": {
+     "optional": true
+    }
+   }
+  },
+  "@graphql-codegen/client-preset@*": {
+   "peerDependencies": {
+    "@babel/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/core": {
+     "optional": true
+    }
+   }
+  },
+  "@graphql-codegen/plugin-helpers@*": {
+   "peerDependencies": {
+    "@graphql-tools/apollo-engine-loader": "*"
+   },
+   "peerDependenciesMeta": {
+    "@graphql-tools/apollo-engine-loader": {
+     "optional": true
+    }
+   }
+  },
+  "@graphql-tools/graphql-tag-pluck@*": {
+   "peerDependencies": {
+    "@astrojs/compiler": "*",
+    "@vue/compiler-sfc": "*",
+    "astrojs-compiler-sync": "*",
+    "content-tag": "*",
+    "svelte2tsx": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@astrojs/compiler": {
+     "optional": true
+    },
+    "@vue/compiler-sfc": {
+     "optional": true
+    },
+    "astrojs-compiler-sync": {
+     "optional": true
+    },
+    "content-tag": {
+     "optional": true
+    },
+    "svelte2tsx": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@hapi/catbox-memory@*": {
+   "peerDependencies": {
+    "@hapi/catbox": "*"
+   },
+   "peerDependenciesMeta": {
+    "@hapi/catbox": {
+     "optional": true
+    }
+   }
+  },
+  "@hapi/hapi@*": {
+   "peerDependencies": {
+    "joi": "*"
+   },
+   "peerDependenciesMeta": {
+    "joi": {
+     "optional": true
+    }
+   }
+  },
+  "@headlessui/react@*": {
+   "peerDependencies": {
+    "@floating-ui/react-dom": "*"
+   },
+   "peerDependenciesMeta": {
+    "@floating-ui/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "@hey-api/openapi-ts@*": {
+   "peerDependencies": {
+    "@angular/common": "*",
+    "@angular/core": "*",
+    "axios": "*",
+    "ky": "*",
+    "nuxt": "*",
+    "ofetch": "*",
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular/common": {
+     "optional": true
+    },
+    "@angular/core": {
+     "optional": true
+    },
+    "axios": {
+     "optional": true
+    },
+    "ky": {
+     "optional": true
+    },
+    "nuxt": {
+     "optional": true
+    },
+    "ofetch": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "@jest/test-result@*": {
+   "peerDependencies": {
+    "jest-haste-map": "*",
+    "jest-resolve": "*"
+   },
+   "peerDependenciesMeta": {
+    "jest-haste-map": {
+     "optional": true
+    },
+    "jest-resolve": {
+     "optional": true
+    }
+   }
+  },
+  "@jest/test-sequencer@*": {
+   "peerDependencies": {
+    "@jest/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jest/types": {
+     "optional": true
+    }
+   }
+  },
+  "@jimp/bmp@*": {
+   "peerDependencies": {
+    "@jimp/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/core": {
+     "optional": true
+    }
+   }
+  },
+  "@jimp/gif@*": {
+   "peerDependencies": {
+    "@jimp/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/core": {
+     "optional": true
+    }
+   }
+  },
+  "@jimp/jpeg@*": {
+   "peerDependencies": {
+    "@jimp/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/core": {
+     "optional": true
+    }
+   }
+  },
+  "@jimp/plugin-blur@*": {
+   "peerDependencies": {
+    "@jimp/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/types": {
+     "optional": true
+    }
+   }
+  },
+  "@jimp/plugin-gaussian@*": {
+   "peerDependencies": {
+    "@jimp/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/core": {
+     "optional": true
+    }
+   }
+  },
+  "@jimp/plugin-invert@*": {
+   "peerDependencies": {
+    "@jimp/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/core": {
+     "optional": true
+    }
+   }
+  },
+  "@jimp/plugin-normalize@*": {
+   "peerDependencies": {
+    "@jimp/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/core": {
+     "optional": true
+    }
+   }
+  },
+  "@jimp/plugin-scale@*": {
+   "peerDependencies": {
+    "@jimp/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/core": {
+     "optional": true
+    }
+   }
+  },
+  "@jimp/png@*": {
+   "peerDependencies": {
+    "@jimp/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/core": {
+     "optional": true
+    }
+   }
+  },
+  "@jimp/tiff@*": {
+   "peerDependencies": {
+    "@jimp/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/core": {
+     "optional": true
+    }
+   }
+  },
+  "@jscpd/html-reporter@*": {
+   "peerDependencies": {
+    "@jscpd/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jscpd/core": {
+     "optional": true
+    }
+   },
+   "dependencies": {
+    "@jscpd/finder": "*"
+   }
+  },
+  "@lerna/create@*": {
+   "dependencies": {
+    "ci-info": "*"
+   },
+   "peerDependencies": {
+    "libnpmaccess": "*"
+   },
+   "peerDependenciesMeta": {
+    "libnpmaccess": {
+     "optional": true
+    }
+   }
+  },
+  "@lexical/react@*": {
+   "peerDependencies": {
+    "@preact/signals-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@preact/signals-core": {
+     "optional": true
+    }
+   }
+  },
+  "@lhci/cli@*": {
+   "peerDependencies": {
+    "@lhci/server": "*",
+    "puppeteer": "*",
+    "puppeteer-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@lhci/server": {
+     "optional": true
+    },
+    "puppeteer": {
+     "optional": true
+    },
+    "puppeteer-core": {
+     "optional": true
+    }
+   }
+  },
+  "@lit/react@*": {
+   "peerDependencies": {
+    "@lit/reactive-element": "*"
+   },
+   "peerDependenciesMeta": {
+    "@lit/reactive-element": {
+     "optional": true
+    }
+   }
+  },
+  "@mantine/hooks@*": {
+   "peerDependencies": {
+    "react-dom": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "@mapbox/node-pre-gyp@*": {
+   "peerDependencies": {
+    "node-gyp": "*",
+    "npm": "*"
+   },
+   "peerDependenciesMeta": {
+    "node-gyp": {
+     "optional": true
+    },
+    "npm": {
+     "optional": true
+    }
+   }
+  },
+  "@mariozechner/pi-ai@*": {
+   "peerDependencies": {
+    "@smithy/node-http-handler": "*"
+   },
+   "peerDependenciesMeta": {
+    "@smithy/node-http-handler": {
+     "optional": true
+    }
+   }
+  },
+  "@mastra/core@*": {
+   "peerDependencies": {
+    "@ast-grep/napi": "*",
+    "@hono/standard-validator": "*",
+    "@standard-community/standard-json": "*",
+    "@standard-community/standard-openapi": "*",
+    "@workflow/serde": "*",
+    "msw": "*",
+    "openapi-types": "*",
+    "undici": "*",
+    "vitest": "*"
+   },
+   "peerDependenciesMeta": {
+    "@ast-grep/napi": {
+     "optional": true
+    },
+    "@hono/standard-validator": {
+     "optional": true
+    },
+    "@standard-community/standard-json": {
+     "optional": true
+    },
+    "@standard-community/standard-openapi": {
+     "optional": true
+    },
+    "@workflow/serde": {
+     "optional": true
+    },
+    "msw": {
+     "optional": true
+    },
+    "openapi-types": {
+     "optional": true
+    },
+    "undici": {
+     "optional": true
+    },
+    "vitest": {
+     "optional": true
+    }
+   }
+  },
+  "@mastra/schema-compat@*": {
+   "peerDependencies": {
+    "ajv": "*",
+    "zod-to-json-schema": "*"
+   },
+   "peerDependenciesMeta": {
+    "ajv": {
+     "optional": true
+    },
+    "zod-to-json-schema": {
+     "optional": true
+    }
+   }
+  },
+  "@material-ui/lab@*": {
+   "peerDependencies": {
+    "@material-ui/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@material-ui/types": {
+     "optional": true
+    }
+   }
+  },
+  "@mdx-js/loader@*": {
+   "peerDependencies": {
+    "vfile": "*"
+   },
+   "peerDependenciesMeta": {
+    "vfile": {
+     "optional": true
+    }
+   }
+  },
+  "@mdx-js/mdx@*": {
+   "peerDependencies": {
+    "mdast": "*"
+   },
+   "peerDependenciesMeta": {
+    "mdast": {
+     "optional": true
+    }
+   }
+  },
+  "@mendable/firecrawl-js@*": {
+   "peerDependencies": {
+    "undici": "*"
+   },
+   "peerDependenciesMeta": {
+    "undici": {
+     "optional": true
+    }
+   }
+  },
+  "@middy/core@*": {
+   "peerDependencies": {
+    "aws-lambda": "*"
+   },
+   "peerDependenciesMeta": {
+    "aws-lambda": {
+     "optional": true
+    }
+   }
+  },
+  "@module-federation/data-prefetch@*": {
+   "peerDependencies": {
+    "@module-federation/webpack-type": "*"
+   },
+   "peerDependenciesMeta": {
+    "@module-federation/webpack-type": {
+     "optional": true
+    }
+   }
+  },
+  "@module-federation/managers@*": {
+   "peerDependencies": {
+    "webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "@module-federation/manifest@*": {
+   "peerDependencies": {
+    "webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "@module-federation/sdk@*": {
+   "peerDependencies": {
+    "webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "@module-federation/webpack-bundler-runtime@*": {
+   "peerDependencies": {
+    "@module-federation/runtime-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@module-federation/runtime-core": {
+     "optional": true
+    }
+   }
+  },
+  "@monaco-editor/loader@*": {
+   "peerDependencies": {
+    "monaco-editor": "*"
+   },
+   "peerDependenciesMeta": {
+    "monaco-editor": {
+     "optional": true
+    }
+   }
+  },
+  "@mswjs/cookies@*": {
+   "peerDependencies": {
+    "set-cookie-parser": "*"
+   },
+   "peerDependenciesMeta": {
+    "set-cookie-parser": {
+     "optional": true
+    }
+   }
+  },
+  "@mui/material@*": {
+   "peerDependencies": {
+    "@mui/styled-engine": "*"
+   },
+   "peerDependenciesMeta": {
+    "@mui/styled-engine": {
+     "optional": true
+    }
+   }
+  },
+  "@mux/mux-video@*": {
+   "peerDependencies": {
+    "mux-embed": "*"
+   },
+   "peerDependenciesMeta": {
+    "mux-embed": {
+     "optional": true
+    }
+   }
+  },
+  "@napi-rs/cli@*": {
+   "peerDependencies": {
+    "@oxc-node/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@oxc-node/core": {
+     "optional": true
+    }
+   }
+  },
+  "@ndelangen/get-tarball@*": {
+   "peerDependencies": {
+    "got": "*"
+   },
+   "peerDependenciesMeta": {
+    "got": {
+     "optional": true
+    }
+   }
+  },
+  "@neoconfetti/react@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "@nestjs/cache-manager@*": {
+   "peerDependencies": {
+    "cacheable": "*"
+   },
+   "peerDependenciesMeta": {
+    "cacheable": {
+     "optional": true
+    }
+   }
+  },
+  "@nestjs/core@*": {
+   "peerDependencies": {
+    "@standard-schema/spec": "*"
+   },
+   "peerDependenciesMeta": {
+    "@standard-schema/spec": {
+     "optional": true
+    }
+   }
+  },
+  "@nestjs/graphql@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nestjs/swagger@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@netlify/serverless-functions-api@*": {
+   "peerDependencies": {
+    "@netlify/cache": "*",
+    "@netlify/node-cookies": "*"
+   },
+   "peerDependenciesMeta": {
+    "@netlify/cache": {
+     "optional": true
+    },
+    "@netlify/node-cookies": {
+     "optional": true
+    }
+   }
+  },
+  "@newrelic/security-agent@*": {
+   "peerDependencies": {
+    "@aws-sdk/client-lambda": "*",
+    "@grpc/grpc-js": "*"
+   },
+   "peerDependenciesMeta": {
+    "@aws-sdk/client-lambda": {
+     "optional": true
+    },
+    "@grpc/grpc-js": {
+     "optional": true
+    }
+   }
+  },
+  "@next/bundle-analyzer@*": {
+   "peerDependencies": {
+    "next": "*"
+   },
+   "peerDependenciesMeta": {
+    "next": {
+     "optional": true
+    }
+   }
+  },
+  "@next/eslint-plugin-next@*": {
+   "peerDependencies": {
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "@ngx-translate/http-loader@*": {
+   "peerDependencies": {
+    "rxjs": "*"
+   },
+   "peerDependenciesMeta": {
+    "rxjs": {
+     "optional": true
+    }
+   }
+  },
+  "@nivo/line@*": {
+   "peerDependencies": {
+    "lodash": "*"
+   },
+   "peerDependenciesMeta": {
+    "lodash": {
+     "optional": true
+    }
+   }
+  },
+  "@npmcli/config@*": {
+   "peerDependencies": {
+    "node-gyp": "*"
+   },
+   "peerDependenciesMeta": {
+    "node-gyp": {
+     "optional": true
+    }
+   }
+  },
+  "@npmcli/metavuln-calculator@<2.0.0": {
+   "dependencies": {
+    "json-parse-even-better-errors": "^2.3.1"
+   }
+  },
+  "@nrwl/devkit@*": {
+   "dependencies": {
+    "tslib": "*"
+   }
+  },
+  "@nrwl/js@*": {
+   "dependencies": {
+    "tslib": "*"
+   }
+  },
+  "@nrwl/workspace@*": {
+   "dependencies": {
+    "tslib": "*"
+   }
+  },
+  "@nuxt/devtools-kit@*": {
+   "peerDependencies": {
+    "@nuxt/schema": "*",
+    "@vitejs/devtools-kit": "*",
+    "birpc": "*",
+    "error-stack-parser-es": "*",
+    "hookable": "*",
+    "nuxt": "*",
+    "ofetch": "*",
+    "shiki": "*",
+    "unimport": "*",
+    "unstorage": "*",
+    "vue": "*",
+    "vue-router": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nuxt/schema": {
+     "optional": true
+    },
+    "@vitejs/devtools-kit": {
+     "optional": true
+    },
+    "birpc": {
+     "optional": true
+    },
+    "error-stack-parser-es": {
+     "optional": true
+    },
+    "hookable": {
+     "optional": true
+    },
+    "nuxt": {
+     "optional": true
+    },
+    "ofetch": {
+     "optional": true
+    },
+    "shiki": {
+     "optional": true
+    },
+    "unimport": {
+     "optional": true
+    },
+    "unstorage": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    },
+    "vue-router": {
+     "optional": true
+    }
+   }
+  },
+  "@nuxt/devtools@*": {
+   "peerDependencies": {
+    "@nuxt/schema": "*",
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nuxt/schema": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "@nuxt/kit@*": {
+   "peerDependencies": {
+    "@nuxt/schema": "*",
+    "nitropack": "*",
+    "unimport": "*",
+    "vite": "*",
+    "webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nuxt/schema": {
+     "optional": true
+    },
+    "nitropack": {
+     "optional": true
+    },
+    "unimport": {
+     "optional": true
+    },
+    "vite": {
+     "optional": true
+    },
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "@nuxt/nitro-server@*": {
+   "peerDependencies": {
+    "@nuxt/schema": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nuxt/schema": {
+     "optional": true
+    }
+   }
+  },
+  "@nuxt/schema@*": {
+   "peerDependencies": {
+    "@unhead/vue": "*",
+    "@vitejs/plugin-vue": "*",
+    "@vitejs/plugin-vue-jsx": "*",
+    "@vue/compiler-core": "*",
+    "@vue/compiler-sfc": "*",
+    "@vue/language-core": "*",
+    "autoprefixer": "*",
+    "c12": "*",
+    "chokidar": "*",
+    "compatx": "*",
+    "css-minimizer-webpack-plugin": "*",
+    "cssnano": "*",
+    "esbuild": "*",
+    "esbuild-loader": "*",
+    "h3": "*",
+    "hookable": "*",
+    "ignore": "*",
+    "mini-css-extract-plugin": "*",
+    "nitropack": "*",
+    "ofetch": "*",
+    "oxc-transform": "*",
+    "postcss": "*",
+    "pug": "*",
+    "rollup-plugin-visualizer": "*",
+    "scule": "*",
+    "unctx": "*",
+    "unimport": "*",
+    "untyped": "*",
+    "vite": "*",
+    "vue": "*",
+    "vue-bundle-renderer": "*",
+    "vue-loader": "*",
+    "vue-router": "*",
+    "webpack": "*",
+    "webpack-bundle-analyzer": "*",
+    "webpack-dev-middleware": "*",
+    "webpack-hot-middleware": "*"
+   },
+   "peerDependenciesMeta": {
+    "@unhead/vue": {
+     "optional": true
+    },
+    "@vitejs/plugin-vue": {
+     "optional": true
+    },
+    "@vitejs/plugin-vue-jsx": {
+     "optional": true
+    },
+    "@vue/compiler-core": {
+     "optional": true
+    },
+    "@vue/compiler-sfc": {
+     "optional": true
+    },
+    "@vue/language-core": {
+     "optional": true
+    },
+    "autoprefixer": {
+     "optional": true
+    },
+    "c12": {
+     "optional": true
+    },
+    "chokidar": {
+     "optional": true
+    },
+    "compatx": {
+     "optional": true
+    },
+    "css-minimizer-webpack-plugin": {
+     "optional": true
+    },
+    "cssnano": {
+     "optional": true
+    },
+    "esbuild": {
+     "optional": true
+    },
+    "esbuild-loader": {
+     "optional": true
+    },
+    "h3": {
+     "optional": true
+    },
+    "hookable": {
+     "optional": true
+    },
+    "ignore": {
+     "optional": true
+    },
+    "mini-css-extract-plugin": {
+     "optional": true
+    },
+    "nitropack": {
+     "optional": true
+    },
+    "ofetch": {
+     "optional": true
+    },
+    "oxc-transform": {
+     "optional": true
+    },
+    "postcss": {
+     "optional": true
+    },
+    "pug": {
+     "optional": true
+    },
+    "rollup-plugin-visualizer": {
+     "optional": true
+    },
+    "scule": {
+     "optional": true
+    },
+    "unctx": {
+     "optional": true
+    },
+    "unimport": {
+     "optional": true
+    },
+    "untyped": {
+     "optional": true
+    },
+    "vite": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    },
+    "vue-bundle-renderer": {
+     "optional": true
+    },
+    "vue-loader": {
+     "optional": true
+    },
+    "vue-router": {
+     "optional": true
+    },
+    "webpack": {
+     "optional": true
+    },
+    "webpack-bundle-analyzer": {
+     "optional": true
+    },
+    "webpack-dev-middleware": {
+     "optional": true
+    },
+    "webpack-hot-middleware": {
+     "optional": true
+    }
+   }
+  },
+  "@nuxt/telemetry@*": {
+   "peerDependencies": {
+    "@nuxt/schema": "*",
+    "nitropack": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nuxt/schema": {
+     "optional": true
+    },
+    "nitropack": {
+     "optional": true
+    }
+   }
+  },
+  "@nuxt/vite-builder@*": {
+   "peerDependencies": {
+    "@babel/core": "*",
+    "@nuxt/schema": "*",
+    "unplugin": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/core": {
+     "optional": true
+    },
+    "@nuxt/schema": {
+     "optional": true
+    },
+    "unplugin": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/angular@*": {
+   "peerDependencies": {
+    "@angular-devkit/architect": "*",
+    "@nx/vitest": "*",
+    "@storybook/angular": "*",
+    "browserslist": "*",
+    "cypress": "*",
+    "karma": "*",
+    "typescript": "*",
+    "webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular-devkit/architect": {
+     "optional": true
+    },
+    "@nx/vitest": {
+     "optional": true
+    },
+    "@storybook/angular": {
+     "optional": true
+    },
+    "browserslist": {
+     "optional": true
+    },
+    "cypress": {
+     "optional": true
+    },
+    "karma": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    },
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/cypress@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/devkit@*": {
+   "peerDependencies": {
+    "@angular-devkit/architect": "*",
+    "@angular-devkit/schematics": "*",
+    "prettier": "*",
+    "rxjs": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular-devkit/architect": {
+     "optional": true
+    },
+    "@angular-devkit/schematics": {
+     "optional": true
+    },
+    "prettier": {
+     "optional": true
+    },
+    "rxjs": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/eslint-plugin@*": {
+   "dependencies": {
+    "@eslint/js": "*",
+    "eslint-plugin-import": "*"
+   },
+   "peerDependencies": {
+    "angular-eslint": "*",
+    "eslint-plugin-jsx-a11y": "*",
+    "eslint-plugin-react": "*",
+    "eslint-plugin-react-hooks": "*",
+    "typescript": "*",
+    "typescript-eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "angular-eslint": {
+     "optional": true
+    },
+    "eslint-plugin-jsx-a11y": {
+     "optional": true
+    },
+    "eslint-plugin-react": {
+     "optional": true
+    },
+    "eslint-plugin-react-hooks": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    },
+    "typescript-eslint": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/eslint@*": {
+   "peerDependencies": {
+    "@angular-devkit/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular-devkit/core": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/jest@*": {
+   "peerDependencies": {
+    "@jest/core": "*",
+    "@jest/types": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jest/core": {
+     "optional": true
+    },
+    "@jest/types": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/js@*": {
+   "peerDependencies": {
+    "@nx/eslint": "*",
+    "@nx/oxlint": "*",
+    "@nx/vitest": "*",
+    "core-js": "*",
+    "nx": "*",
+    "prettier": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nx/eslint": {
+     "optional": true
+    },
+    "@nx/oxlint": {
+     "optional": true
+    },
+    "@nx/vitest": {
+     "optional": true
+    },
+    "core-js": {
+     "optional": true
+    },
+    "nx": {
+     "optional": true
+    },
+    "prettier": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/linter@*": {
+   "dependencies": {
+    "tslib": "*"
+   }
+  },
+  "@nx/module-federation@*": {
+   "peerDependencies": {
+    "@angular-devkit/build-angular": "*",
+    "nx": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular-devkit/build-angular": {
+     "optional": true
+    },
+    "nx": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/node@*": {
+   "peerDependencies": {
+    "@nx/vitest": "*",
+    "@nx/webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nx/vitest": {
+     "optional": true
+    },
+    "@nx/webpack": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/plugin@*": {
+   "peerDependencies": {
+    "nx": "*"
+   },
+   "peerDependenciesMeta": {
+    "nx": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/react@*": {
+   "peerDependencies": {
+    "@nx/cypress": "*",
+    "@nx/rsbuild": "*",
+    "@nx/storybook": "*",
+    "@nx/vitest": "*",
+    "@nx/webpack": "*",
+    "@pmmmwh/react-refresh-webpack-plugin": "*",
+    "@rollup/plugin-url": "*",
+    "@svgr/rollup": "*",
+    "@swc/jest": "*",
+    "babel-jest": "*",
+    "babel-loader": "*",
+    "css-loader": "*",
+    "eslint": "*",
+    "less-loader": "*",
+    "react-refresh": "*",
+    "sass": "*",
+    "sass-loader": "*",
+    "style-loader": "*",
+    "swc-loader": "*",
+    "tsconfig-paths-webpack-plugin": "*",
+    "typescript": "*",
+    "webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nx/cypress": {
+     "optional": true
+    },
+    "@nx/rsbuild": {
+     "optional": true
+    },
+    "@nx/storybook": {
+     "optional": true
+    },
+    "@nx/vitest": {
+     "optional": true
+    },
+    "@nx/webpack": {
+     "optional": true
+    },
+    "@pmmmwh/react-refresh-webpack-plugin": {
+     "optional": true
+    },
+    "@rollup/plugin-url": {
+     "optional": true
+    },
+    "@svgr/rollup": {
+     "optional": true
+    },
+    "@swc/jest": {
+     "optional": true
+    },
+    "babel-jest": {
+     "optional": true
+    },
+    "babel-loader": {
+     "optional": true
+    },
+    "css-loader": {
+     "optional": true
+    },
+    "eslint": {
+     "optional": true
+    },
+    "less-loader": {
+     "optional": true
+    },
+    "react-refresh": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "sass-loader": {
+     "optional": true
+    },
+    "style-loader": {
+     "optional": true
+    },
+    "swc-loader": {
+     "optional": true
+    },
+    "tsconfig-paths-webpack-plugin": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    },
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/rollup@*": {
+   "peerDependencies": {
+    "@swc/core": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@swc/core": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/storybook@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/vite@*": {
+   "peerDependencies": {
+    "@nx/eslint": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nx/eslint": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/vitest@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/web@*": {
+   "peerDependencies": {
+    "@nx/vitest": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nx/vitest": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/webpack@*": {
+   "peerDependencies": {
+    "@swc/core": "*",
+    "swc-loader": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@swc/core": {
+     "optional": true
+    },
+    "swc-loader": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@nx/workspace@*": {
+   "peerDependencies": {
+    "@angular-devkit/schematics": "*",
+    "@nx/angular": "*",
+    "@nx/eslint": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular-devkit/schematics": {
+     "optional": true
+    },
+    "@nx/angular": {
+     "optional": true
+    },
+    "@nx/eslint": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@oclif/command@*": {
+   "peerDependencies": {
+    "chalk": "*",
+    "cli-ux": "*"
+   },
+   "peerDependenciesMeta": {
+    "chalk": {
+     "optional": true
+    },
+    "cli-ux": {
+     "optional": true
+    }
+   }
+  },
+  "@oclif/config@*": {
+   "peerDependencies": {
+    "fs-extra-debug": "*",
+    "lodash": "*",
+    "ts-node": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "fs-extra-debug": {
+     "optional": true
+    },
+    "lodash": {
+     "optional": true
+    },
+    "ts-node": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@oclif/core@*": {
+   "peerDependencies": {
+    "pnpapi": "*",
+    "ts-node": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "pnpapi": {
+     "optional": true
+    },
+    "ts-node": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@oclif/errors@*": {
+   "peerDependencies": {
+    "chalk": "*"
+   },
+   "peerDependenciesMeta": {
+    "chalk": {
+     "optional": true
+    }
+   }
+  },
+  "@octokit/auth-token@*": {
+   "peerDependencies": {
+    "@octokit/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@octokit/types": {
+     "optional": true
+    }
+   }
+  },
+  "@okta/okta-auth-js@*": {
+   "peerDependencies": {
+    "core-js": "*",
+    "fast-text-encoding": "*",
+    "webcrypto-shim": "*",
+    "whatwg-fetch": "*"
+   },
+   "peerDependenciesMeta": {
+    "core-js": {
+     "optional": true
+    },
+    "fast-text-encoding": {
+     "optional": true
+    },
+    "webcrypto-shim": {
+     "optional": true
+    },
+    "whatwg-fetch": {
+     "optional": true
+    }
+   }
+  },
+  "@opennextjs/cloudflare@*": {
+   "peerDependencies": {
+    "esbuild": "*"
+   },
+   "peerDependenciesMeta": {
+    "esbuild": {
+     "optional": true
+    }
+   }
+  },
+  "@openrouter/ai-sdk-provider@*": {
+   "peerDependencies": {
+    "@ai-sdk/provider": "*",
+    "@ai-sdk/provider-utils": "*"
+   },
+   "peerDependenciesMeta": {
+    "@ai-sdk/provider": {
+     "optional": true
+    },
+    "@ai-sdk/provider-utils": {
+     "optional": true
+    }
+   }
+  },
+  "@opensearch-project/opensearch@*": {
+   "peerDependencies": {
+    "@aws-sdk/credential-provider-node": "*",
+    "aws-sdk": "*"
+   },
+   "peerDependenciesMeta": {
+    "@aws-sdk/credential-provider-node": {
+     "optional": true
+    },
+    "aws-sdk": {
+     "optional": true
+    }
+   }
+  },
+  "@opentelemetry/instrumentation-winston@*": {
+   "peerDependencies": {
+    "@opentelemetry/winston-transport": "*"
+   },
+   "peerDependenciesMeta": {
+    "@opentelemetry/winston-transport": {
+     "optional": true
+    }
+   }
+  },
+  "@parcel/cache@*": {
+   "peerDependencies": {
+    "@parcel/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@parcel/types": {
+     "optional": true
+    }
+   }
+  },
+  "@parcel/node-resolver-core@>=2": {
+   "peerDependencies": {
+    "@parcel/core": "*"
+   }
+  },
+  "@parcel/profiler@*": {
+   "peerDependencies": {
+    "@parcel/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@parcel/types": {
+     "optional": true
+    }
+   }
+  },
+  "@parcel/resolver-default@>=2": {
+   "peerDependencies": {
+    "@parcel/core": "*"
+   }
+  },
+  "@parcel/transformer-image@<2.5.0": {
+   "peerDependencies": {
+    "@parcel/core": "*"
+   }
+  },
+  "@parcel/transformer-js@<2.5.0": {
+   "peerDependencies": {
+    "@parcel/core": "*"
+   }
+  },
+  "@parcel/workers@*": {
+   "peerDependencies": {
+    "@parcel/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@parcel/types": {
+     "optional": true
+    }
+   }
+  },
+  "@pinia/testing@*": {
+   "peerDependencies": {
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "@playwright/mcp@*": {
+   "peerDependencies": {
+    "@modelcontextprotocol/sdk": "*"
+   },
+   "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": {
+     "optional": true
+    }
+   }
+  },
+  "@playwright/test@<=1.14.1": {
+   "dependencies": {
+    "jest-matcher-utils": "^26.4.2"
+   }
+  },
+  "@pm2/agent@<1.0.4": {
+   "dependencies": {
+    "debug": "*"
+   }
+  },
+  "@pm2/blessed@*": {
+   "peerDependencies": {
+    "blessed": "*"
+   },
+   "peerDependenciesMeta": {
+    "blessed": {
+     "optional": true
+    }
+   }
+  },
+  "@pnpm/npm-conf@*": {
+   "peerDependencies": {
+    "npm": "*"
+   },
+   "peerDependenciesMeta": {
+    "npm": {
+     "optional": true
+    }
+   }
+  },
+  "@prisma/fetch-engine@*": {
+   "peerDependencies": {
+    "http-proxy-agent": "*",
+    "https-proxy-agent": "*"
+   },
+   "peerDependenciesMeta": {
+    "http-proxy-agent": {
+     "optional": true
+    },
+    "https-proxy-agent": {
+     "optional": true
+    }
+   }
+  },
+  "@prisma/generator@*": {
+   "peerDependencies": {
+    "@prisma/dmmf": "*"
+   },
+   "peerDependenciesMeta": {
+    "@prisma/dmmf": {
+     "optional": true
+    }
+   }
+  },
+  "@prisma/get-platform@*": {
+   "peerDependencies": {
+    "execa": "*",
+    "fs-jetpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "execa": {
+     "optional": true
+    },
+    "fs-jetpack": {
+     "optional": true
+    }
+   }
+  },
+  "@prisma/query-plan-executor@*": {
+   "peerDependencies": {
+    "pg-native": "*",
+    "temporal-spec": "*"
+   },
+   "peerDependenciesMeta": {
+    "pg-native": {
+     "optional": true
+    },
+    "temporal-spec": {
+     "optional": true
+    }
+   }
+  },
+  "@prisma/studio-core@*": {
+   "peerDependencies": {
+    "@electric-sql/pglite": "*",
+    "@emotion/is-prop-valid": "*",
+    "kysely": "*",
+    "mysql2": "*",
+    "nuqs": "*",
+    "postgres": "*",
+    "sql.js": "*"
+   },
+   "peerDependenciesMeta": {
+    "@electric-sql/pglite": {
+     "optional": true
+    },
+    "@emotion/is-prop-valid": {
+     "optional": true
+    },
+    "kysely": {
+     "optional": true
+    },
+    "mysql2": {
+     "optional": true
+    },
+    "nuqs": {
+     "optional": true
+    },
+    "postgres": {
+     "optional": true
+    },
+    "sql.js": {
+     "optional": true
+    }
+   }
+  },
+  "@promptbook/utils@*": {
+   "peerDependencies": {
+    "openai": "*",
+    "papaparse": "*"
+   },
+   "peerDependenciesMeta": {
+    "openai": {
+     "optional": true
+    },
+    "papaparse": {
+     "optional": true
+    }
+   }
+  },
+  "@pulumi/pulumi@*": {
+   "peerDependencies": {
+    "@microsoft/typescript-etw": "*"
+   },
+   "peerDependenciesMeta": {
+    "@microsoft/typescript-etw": {
+     "optional": true
+    }
+   }
+  },
+  "@react-email/tailwind@*": {
+   "peerDependencies": {
+    "css-tree": "*"
+   },
+   "peerDependenciesMeta": {
+    "css-tree": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-community/cli-clean@*": {
+   "peerDependencies": {
+    "@react-native-community/cli-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli-types": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-community/cli-config-apple@*": {
+   "peerDependencies": {
+    "@react-native-community/cli-types": "*",
+    "fs-extra": "*",
+    "ora": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli-types": {
+     "optional": true
+    },
+    "fs-extra": {
+     "optional": true
+    },
+    "ora": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-community/cli-config@*": {
+   "peerDependencies": {
+    "@react-native-community/cli-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli-types": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-community/cli-doctor@*": {
+   "peerDependencies": {
+    "@react-native-community/cli-types": "*",
+    "fs-extra": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli-types": {
+     "optional": true
+    },
+    "fs-extra": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-community/cli-hermes@*": {
+   "peerDependencies": {
+    "@react-native-community/cli-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli-types": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-community/cli-platform-android@*": {
+   "peerDependencies": {
+    "@react-native-community/cli-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli-types": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-community/cli-platform-apple@*": {
+   "peerDependencies": {
+    "@react-native-community/cli-types": "*",
+    "fs-extra": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli-types": {
+     "optional": true
+    },
+    "fs-extra": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-community/cli-platform-ios@*": {
+   "peerDependencies": {
+    "@react-native-community/cli-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli-types": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-community/cli@*": {
+   "peerDependencies": {
+    "@react-native-community/cli-config-apple": "*",
+    "@react-native-community/cli-platform-apple": "*",
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli-config-apple": {
+     "optional": true
+    },
+    "@react-native-community/cli-platform-apple": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-community/slider@*": {
+   "peerDependencies": {
+    "@babel/runtime": "*",
+    "react": "*",
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/runtime": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-firebase/app@*": {
+   "peerDependencies": {
+    "@expo/config-plugins": "*"
+   },
+   "peerDependenciesMeta": {
+    "@expo/config-plugins": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native-firebase/messaging@*": {
+   "peerDependencies": {
+    "@expo/config-plugins": "*",
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "@expo/config-plugins": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native/community-cli-plugin@*": {
+   "peerDependencies": {
+    "@react-native-community/cli-server-api": "*",
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli-server-api": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native/debugger-frontend@*": {
+   "peerDependencies": {
+    "debug": "*",
+    "puppeteer": "*"
+   },
+   "peerDependenciesMeta": {
+    "debug": {
+     "optional": true
+    },
+    "puppeteer": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native/debugger-shell@*": {
+   "peerDependencies": {
+    "electron": "*"
+   },
+   "peerDependenciesMeta": {
+    "electron": {
+     "optional": true
+    }
+   }
+  },
+  "@react-native/metro-config@*": {
+   "peerDependencies": {
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "@react-navigation/bottom-tabs@*": {
+   "peerDependencies": {
+    "@react-navigation/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-navigation/core": {
+     "optional": true
+    }
+   }
+  },
+  "@react-navigation/native-stack@*": {
+   "peerDependencies": {
+    "@react-navigation/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-navigation/core": {
+     "optional": true
+    }
+   }
+  },
+  "@react-navigation/native@*": {
+   "peerDependencies": {
+    "@react-navigation/routers": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-navigation/routers": {
+     "optional": true
+    }
+   }
+  },
+  "@react-navigation/stack@*": {
+   "peerDependencies": {
+    "@react-navigation/core": "*",
+    "@react-navigation/routers": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-navigation/core": {
+     "optional": true
+    },
+    "@react-navigation/routers": {
+     "optional": true
+    }
+   }
+  },
+  "@react-pdf/layout@*": {
+   "peerDependencies": {
+    "@react-pdf/font": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-pdf/font": {
+     "optional": true
+    }
+   }
+  },
+  "@react-pdf/render@*": {
+   "peerDependencies": {
+    "@react-pdf/layout": "*",
+    "pdfkit": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-pdf/layout": {
+     "optional": true
+    },
+    "pdfkit": {
+     "optional": true
+    }
+   }
+  },
+  "@react-pdf/textkit@*": {
+   "peerDependencies": {
+    "@react-pdf/font": "*",
+    "fontkit": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-pdf/font": {
+     "optional": true
+    },
+    "fontkit": {
+     "optional": true
+    }
+   }
+  },
+  "@react-router/dev@*": {
+   "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    },
+    "react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "@react-spring/types@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "@rebass/forms@*": {
+   "dependencies": {
+    "@styled-system/should-forward-prop": "^5.0.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.6"
+   }
+  },
+  "@redocly/config@*": {
+   "peerDependencies": {
+    "@markdoc/markdoc": "*",
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "@markdoc/markdoc": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "@redocly/openapi-core@*": {
+   "peerDependencies": {
+    "json-schema-to-ts": "*"
+   },
+   "peerDependenciesMeta": {
+    "json-schema-to-ts": {
+     "optional": true
+    }
+   }
+  },
+  "@redocly/respect-core@*": {
+   "peerDependencies": {
+    "json-schema-to-ts": "*"
+   },
+   "peerDependenciesMeta": {
+    "json-schema-to-ts": {
+     "optional": true
+    }
+   }
+  },
+  "@redux-saga/is@*": {
+   "peerDependencies": {
+    "redux": "*"
+   },
+   "peerDependenciesMeta": {
+    "redux": {
+     "optional": true
+    }
+   }
+  },
+  "@reown/appkit-controllers@*": {
+   "peerDependencies": {
+    "@walletconnect/types": "*",
+    "react": "*",
+    "vitest": "*",
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "@walletconnect/types": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "vitest": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "@reown/appkit@*": {
+   "peerDependencies": {
+    "@reown/appkit-siwe": "*",
+    "@walletconnect/types": "*",
+    "react": "*",
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "@reown/appkit-siwe": {
+     "optional": true
+    },
+    "@walletconnect/types": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "@resvg/resvg-js@*": {
+   "peerDependencies": {
+    "@resvg/resvg-js-freebsd-x64": "*"
+   },
+   "peerDependenciesMeta": {
+    "@resvg/resvg-js-freebsd-x64": {
+     "optional": true
+    }
+   }
+  },
+  "@rjsf/utils@*": {
+   "peerDependencies": {
+    "json-schema": "*"
+   },
+   "peerDependenciesMeta": {
+    "json-schema": {
+     "optional": true
+    }
+   }
+  },
+  "@rolldown/binding-wasm32-wasi@*": {
+   "peerDependencies": {
+    "@oxc-project/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@oxc-project/types": {
+     "optional": true
+    }
+   }
+  },
+  "@rsbuild/core@*": {
+   "peerDependencies": {
+    "tsx": "*",
+    "yaml": "*"
+   },
+   "peerDependenciesMeta": {
+    "tsx": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "@rushstack/eslint-patch@*": {
+   "peerDependencies": {
+    "@eslint/eslintrc": "*",
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "@eslint/eslintrc": {
+     "optional": true
+    },
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "@rushstack/rush-sdk@*": {
+   "peerDependencies": {
+    "@rushstack/stream-collator": "*",
+    "@rushstack/ts-command-line": "*"
+   },
+   "peerDependenciesMeta": {
+    "@rushstack/stream-collator": {
+     "optional": true
+    },
+    "@rushstack/ts-command-line": {
+     "optional": true
+    }
+   }
+  },
+  "@salesforce/sf-plugins-core@*": {
+   "peerDependencies": {
+    "sinon": "*"
+   },
+   "peerDependenciesMeta": {
+    "sinon": {
+     "optional": true
+    }
+   }
+  },
+  "@samverschueren/stream-to-observable@<0.3.1": {
+   "peerDependenciesMeta": {
+    "rxjs": {
+     "optional": true
+    },
+    "zenObservable": {
+     "optional": true
+    }
+   }
+  },
+  "@scalar/openapi-upgrader@*": {
+   "peerDependencies": {
+    "@scalar/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@scalar/types": {
+     "optional": true
+    }
+   }
+  },
+  "@scalar/types@*": {
+   "peerDependencies": {
+    "har-format": "*"
+   },
+   "peerDependenciesMeta": {
+    "har-format": {
+     "optional": true
+    }
+   }
+  },
+  "@secretlint/secretlint-rule-preset-recommend@*": {
+   "peerDependencies": {
+    "@secretlint/secretlint-rule-aws": "*",
+    "@secretlint/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@secretlint/secretlint-rule-aws": {
+     "optional": true
+    },
+    "@secretlint/types": {
+     "optional": true
+    }
+   }
+  },
+  "@sentry/babel-plugin-component-annotate@*": {
+   "peerDependencies": {
+    "@babel/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/core": {
+     "optional": true
+    }
+   }
+  },
+  "@sentry/electron@*": {
+   "peerDependencies": {
+    "electron": "*"
+   },
+   "peerDependenciesMeta": {
+    "electron": {
+     "optional": true
+    }
+   }
+  },
+  "@sentry/react-native@*": {
+   "peerDependencies": {
+    "@expo/config": "*",
+    "@expo/env": "*",
+    "@react-navigation/native": "*",
+    "dotenv": "*",
+    "expo-router": "*",
+    "expo-updates": "*",
+    "open": "*",
+    "promise": "*"
+   },
+   "peerDependenciesMeta": {
+    "@expo/config": {
+     "optional": true
+    },
+    "@expo/env": {
+     "optional": true
+    },
+    "@react-navigation/native": {
+     "optional": true
+    },
+    "dotenv": {
+     "optional": true
+    },
+    "expo-router": {
+     "optional": true
+    },
+    "expo-updates": {
+     "optional": true
+    },
+    "open": {
+     "optional": true
+    },
+    "promise": {
+     "optional": true
+    }
+   }
+  },
+  "@sentry/tracing@*": {
+   "peerDependencies": {
+    "@sentry/core": "*",
+    "@sentry/utils": "*"
+   },
+   "peerDependenciesMeta": {
+    "@sentry/core": {
+     "optional": true
+    },
+    "@sentry/utils": {
+     "optional": true
+    }
+   }
+  },
+  "@sentry/vercel-edge@*": {
+   "peerDependencies": {
+    "@opentelemetry/sdk-trace-base": "*"
+   },
+   "peerDependenciesMeta": {
+    "@opentelemetry/sdk-trace-base": {
+     "optional": true
+    }
+   }
+  },
+  "@serverless/dashboard-plugin@*": {
+   "peerDependencies": {
+    "bufferutil": "*",
+    "original-fs": "*",
+    "utf-8-validate": "*"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "original-fs": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "@serverless/event-mocks@*": {
+   "peerDependencies": {
+    "aws-lambda": "*"
+   },
+   "peerDependenciesMeta": {
+    "aws-lambda": {
+     "optional": true
+    }
+   }
+  },
+  "@shikijs/transformers@*": {
+   "peerDependencies": {
+    "hast": "*"
+   },
+   "peerDependenciesMeta": {
+    "hast": {
+     "optional": true
+    }
+   }
+  },
+  "@sigstore/sign@*": {
+   "peerDependencies": {
+    "@sigstore/rekor-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@sigstore/rekor-types": {
+     "optional": true
+    }
+   }
+  },
+  "@sigstore/tuf@*": {
+   "peerDependencies": {
+    "make-fetch-happen": "*"
+   },
+   "peerDependenciesMeta": {
+    "make-fetch-happen": {
+     "optional": true
+    }
+   }
+  },
+  "@slack/bolt@*": {
+   "peerDependencies": {
+    "express-serve-static-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "express-serve-static-core": {
+     "optional": true
+    }
+   }
+  },
+  "@solana/sysvars@*": {
+   "peerDependencies": {
+    "@solana/addresses": "*",
+    "@solana/rpc-api": "*",
+    "@solana/rpc-parsed-types": "*",
+    "@solana/rpc-spec": "*"
+   },
+   "peerDependenciesMeta": {
+    "@solana/addresses": {
+     "optional": true
+    },
+    "@solana/rpc-api": {
+     "optional": true
+    },
+    "@solana/rpc-parsed-types": {
+     "optional": true
+    },
+    "@solana/rpc-spec": {
+     "optional": true
+    }
+   }
+  },
+  "@standard-schema/utils@*": {
+   "peerDependencies": {
+    "@standard-schema/spec": "*"
+   },
+   "peerDependenciesMeta": {
+    "@standard-schema/spec": {
+     "optional": true
+    }
+   }
+  },
+  "@stencil/core@*": {
+   "peerDependencies": {
+    "@jest/core": "*",
+    "@jest/transform": "*",
+    "@jest/types": "*",
+    "jest": "*",
+    "jest-config": "*",
+    "jest-environment-node": "*",
+    "jest-runner": "*",
+    "yargs": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jest/core": {
+     "optional": true
+    },
+    "@jest/transform": {
+     "optional": true
+    },
+    "@jest/types": {
+     "optional": true
+    },
+    "jest": {
+     "optional": true
+    },
+    "jest-config": {
+     "optional": true
+    },
+    "jest-environment-node": {
+     "optional": true
+    },
+    "jest-runner": {
+     "optional": true
+    },
+    "yargs": {
+     "optional": true
+    }
+   }
+  },
+  "@stoplight/json-ref-readers@*": {
+   "peerDependencies": {
+    "urijs": "*"
+   },
+   "peerDependenciesMeta": {
+    "urijs": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/addon-a11y@*": {
+   "peerDependencies": {
+    "@storybook/icons": "*",
+    "react": "*",
+    "react-dom": "*"
+   },
+   "peerDependenciesMeta": {
+    "@storybook/icons": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/addon-designs@*": {
+   "peerDependencies": {
+    "@storybook/icons": "*"
+   },
+   "peerDependenciesMeta": {
+    "@storybook/icons": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/addon-interactions@*": {
+   "peerDependencies": {
+    "@storybook/icons": "*",
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "@storybook/icons": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/addon-onboarding@*": {
+   "peerDependencies": {
+    "@storybook/icons": "*",
+    "react": "*",
+    "react-dom": "*"
+   },
+   "peerDependenciesMeta": {
+    "@storybook/icons": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/addon-themes@*": {
+   "peerDependencies": {
+    "@storybook/icons": "*",
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "@storybook/icons": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/addon-vitest@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/builder-webpack5@*": {
+   "peerDependencies": {
+    "@storybook/global": "*"
+   },
+   "peerDependenciesMeta": {
+    "@storybook/global": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/core@*": {
+   "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    },
+    "react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/docs-mdx@*": {
+   "peerDependencies": {
+    "@babel/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/types": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/nextjs-vite@*": {
+   "peerDependencies": {
+    "sb-original": "*"
+   },
+   "peerDependenciesMeta": {
+    "sb-original": {
+     "optional": true
+    }
+   }
+  },
+  "@storybook/nextjs@*": {
+   "peerDependencies": {
+    "sb-original": "*"
+   },
+   "peerDependenciesMeta": {
+    "sb-original": {
+     "optional": true
+    }
+   }
+  },
+  "@stryker-mutator/core@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@stryker-mutator/instrumenter@*": {
+   "peerDependencies": {
+    "svelte": "*"
+   },
+   "peerDependenciesMeta": {
+    "svelte": {
+     "optional": true
+    }
+   }
+  },
+  "@svgr/babel-plugin-transform-svg-component@*": {
+   "peerDependencies": {
+    "@babel/template": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/template": {
+     "optional": true
+    }
+   }
+  },
+  "@svgr/core@*": {
+   "peerDependencies": {
+    "prettier": "*",
+    "svgo": "*"
+   },
+   "peerDependenciesMeta": {
+    "prettier": {
+     "optional": true
+    },
+    "svgo": {
+     "optional": true
+    }
+   }
+  },
+  "@svgr/hast-util-to-babel-ast@*": {
+   "peerDependencies": {
+    "svg-parser": "*"
+   },
+   "peerDependenciesMeta": {
+    "svg-parser": {
+     "optional": true
+    }
+   }
+  },
+  "@svgr/webpack@*": {
+   "peerDependencies": {
+    "webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "@swagger-api/apidom-ast@*": {
+   "peerDependencies": {
+    "ts-toolbelt": "*"
+   },
+   "peerDependenciesMeta": {
+    "ts-toolbelt": {
+     "optional": true
+    }
+   }
+  },
+  "@swagger-api/apidom-ns-arazzo-1@*": {
+   "peerDependencies": {
+    "@swagger-api/apidom-ns-json-schema-draft-4": "*",
+    "minim": "*"
+   },
+   "peerDependenciesMeta": {
+    "@swagger-api/apidom-ns-json-schema-draft-4": {
+     "optional": true
+    },
+    "minim": {
+     "optional": true
+    }
+   }
+  },
+  "@swagger-api/apidom-ns-asyncapi-2@*": {
+   "peerDependencies": {
+    "@swagger-api/apidom-ns-json-schema-draft-4": "*",
+    "minim": "*"
+   },
+   "peerDependenciesMeta": {
+    "@swagger-api/apidom-ns-json-schema-draft-4": {
+     "optional": true
+    },
+    "minim": {
+     "optional": true
+    }
+   }
+  },
+  "@swagger-api/apidom-ns-json-schema-draft-6@*": {
+   "peerDependencies": {
+    "minim": "*"
+   },
+   "peerDependenciesMeta": {
+    "minim": {
+     "optional": true
+    }
+   }
+  },
+  "@swagger-api/apidom-ns-json-schema-draft-7@*": {
+   "peerDependencies": {
+    "@swagger-api/apidom-ns-json-schema-draft-4": "*",
+    "minim": "*"
+   },
+   "peerDependenciesMeta": {
+    "@swagger-api/apidom-ns-json-schema-draft-4": {
+     "optional": true
+    },
+    "minim": {
+     "optional": true
+    }
+   }
+  },
+  "@swagger-api/apidom-ns-openapi-3-0@*": {
+   "peerDependencies": {
+    "minim": "*"
+   },
+   "peerDependenciesMeta": {
+    "minim": {
+     "optional": true
+    }
+   }
+  },
+  "@swagger-api/apidom-reference@*": {
+   "peerDependencies": {
+    "@swagger-api/apidom-ns-asyncapi-3": "*",
+    "minim": "*"
+   },
+   "peerDependenciesMeta": {
+    "@swagger-api/apidom-ns-asyncapi-3": {
+     "optional": true
+    },
+    "minim": {
+     "optional": true
+    }
+   }
+  },
+  "@swc/core@*": {
+   "peerDependencies": {
+    "@swc/core-android-arm-eabi": "*",
+    "@swc/core-android-arm64": "*",
+    "@swc/core-freebsd-x64": "*",
+    "@swc/wasm": "*"
+   },
+   "peerDependenciesMeta": {
+    "@swc/core-android-arm-eabi": {
+     "optional": true
+    },
+    "@swc/core-android-arm64": {
+     "optional": true
+    },
+    "@swc/core-freebsd-x64": {
+     "optional": true
+    },
+    "@swc/wasm": {
+     "optional": true
+    }
+   }
+  },
+  "@swc/jest@*": {
+   "peerDependencies": {
+    "@jest/transform": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jest/transform": {
+     "optional": true
+    }
+   }
+  },
+  "@tailwindcss/aspect-ratio@<0.2.1": {
+   "peerDependencies": {
+    "tailwindcss": "^2.0.2"
+   }
+  },
+  "@tailwindcss/line-clamp@<0.2.1": {
+   "peerDependencies": {
+    "tailwindcss": "^2.0.2"
+   }
+  },
+  "@tailwindcss/oxide@*": {
+   "peerDependencies": {
+    "@tailwindcss/oxide-android-arm-eabi": "*",
+    "@tailwindcss/oxide-win32-ia32-msvc": "*"
+   },
+   "peerDependenciesMeta": {
+    "@tailwindcss/oxide-android-arm-eabi": {
+     "optional": true
+    },
+    "@tailwindcss/oxide-win32-ia32-msvc": {
+     "optional": true
+    }
+   }
+  },
+  "@tanstack/devtools-event-client@*": {
+   "peerDependencies": {
+    "@tanstack/intent": "*"
+   },
+   "peerDependenciesMeta": {
+    "@tanstack/intent": {
+     "optional": true
+    }
+   }
+  },
+  "@tanstack/devtools@*": {
+   "peerDependencies": {
+    "@tanstack/intent": "*"
+   },
+   "peerDependenciesMeta": {
+    "@tanstack/intent": {
+     "optional": true
+    }
+   }
+  },
+  "@tanstack/query-devtools@*": {
+   "peerDependencies": {
+    "@kobalte/core": "*",
+    "@solid-primitives/keyed": "*",
+    "@solid-primitives/resize-observer": "*",
+    "@solid-primitives/storage": "*",
+    "@tanstack/match-sorter-utils": "*",
+    "@tanstack/query-core": "*",
+    "clsx": "*",
+    "goober": "*",
+    "solid-js": "*",
+    "solid-transition-group": "*",
+    "superjson": "*"
+   },
+   "peerDependenciesMeta": {
+    "@kobalte/core": {
+     "optional": true
+    },
+    "@solid-primitives/keyed": {
+     "optional": true
+    },
+    "@solid-primitives/resize-observer": {
+     "optional": true
+    },
+    "@solid-primitives/storage": {
+     "optional": true
+    },
+    "@tanstack/match-sorter-utils": {
+     "optional": true
+    },
+    "@tanstack/query-core": {
+     "optional": true
+    },
+    "clsx": {
+     "optional": true
+    },
+    "goober": {
+     "optional": true
+    },
+    "solid-js": {
+     "optional": true
+    },
+    "solid-transition-group": {
+     "optional": true
+    },
+    "superjson": {
+     "optional": true
+    }
+   }
+  },
+  "@tanstack/react-start-rsc@*": {
+   "peerDependencies": {
+    "vite": "*"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "@tanstack/router-devtools-core@*": {
+   "peerDependencies": {
+    "solid-js": "*"
+   },
+   "peerDependenciesMeta": {
+    "solid-js": {
+     "optional": true
+    }
+   }
+  },
+  "@tanstack/router-plugin@*": {
+   "peerDependencies": {
+    "@tanstack/virtual-file-routes": "*"
+   },
+   "peerDependenciesMeta": {
+    "@tanstack/virtual-file-routes": {
+     "optional": true
+    }
+   }
+  },
+  "@tanstack/router-utils@*": {
+   "peerDependencies": {
+    "vite": "*"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "@tanstack/start-server-core@*": {
+   "peerDependencies": {
+    "@standard-schema/spec": "*",
+    "cookie-es": "*"
+   },
+   "peerDependenciesMeta": {
+    "@standard-schema/spec": {
+     "optional": true
+    },
+    "cookie-es": {
+     "optional": true
+    }
+   }
+  },
+  "@temporalio/client@*": {
+   "peerDependencies": {
+    "protobufjs": "*"
+   },
+   "peerDependenciesMeta": {
+    "protobufjs": {
+     "optional": true
+    }
+   }
+  },
+  "@temporalio/workflow@*": {
+   "peerDependencies": {
+    "long": "*",
+    "source-map": "*"
+   },
+   "peerDependenciesMeta": {
+    "long": {
+     "optional": true
+    },
+    "source-map": {
+     "optional": true
+    }
+   }
+  },
+  "@testing-library/jest-dom@*": {
+   "peerDependencies": {
+    "@jest/globals": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jest/globals": {
+     "optional": true
+    }
+   }
+  },
+  "@tiptap/extension-list@*": {
+   "peerDependencies": {
+    "prosemirror-model": "*"
+   },
+   "peerDependenciesMeta": {
+    "prosemirror-model": {
+     "optional": true
+    }
+   }
+  },
+  "@tokenizer/inflate@*": {
+   "peerDependencies": {
+    "strtok3": "*"
+   },
+   "peerDependenciesMeta": {
+    "strtok3": {
+     "optional": true
+    }
+   }
+  },
+  "@trpc/server@*": {
+   "peerDependencies": {
+    "@tanstack/intent": "*",
+    "express": "*",
+    "next": "*",
+    "ws": "*"
+   },
+   "peerDependenciesMeta": {
+    "@tanstack/intent": {
+     "optional": true
+    },
+    "express": {
+     "optional": true
+    },
+    "next": {
+     "optional": true
+    },
+    "ws": {
+     "optional": true
+    }
+   }
+  },
+  "@ts-morph/common@*": {
+   "peerDependencies": {
+    "source-map-support": "*"
+   },
+   "peerDependenciesMeta": {
+    "source-map-support": {
+     "optional": true
+    }
+   }
+  },
+  "@turbo/gen@*": {
+   "peerDependencies": {
+    "kerberos": "*"
+   },
+   "peerDependenciesMeta": {
+    "kerberos": {
+     "optional": true
+    }
+   }
+  },
+  "@types/k6@*": {
+   "peerDependencies": {
+    "k6": "*"
+   },
+   "peerDependenciesMeta": {
+    "k6": {
+     "optional": true
+    }
+   }
+  },
+  "@types/mdx@*": {
+   "peerDependencies": {
+    "mdx": "*"
+   },
+   "peerDependenciesMeta": {
+    "mdx": {
+     "optional": true
+    }
+   }
+  },
+  "@types/react-syntax-highlighter@*": {
+   "peerDependencies": {
+    "react-syntax-highlighter": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-syntax-highlighter": {
+     "optional": true
+    }
+   }
+  },
+  "@typescript-eslint/types@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@typespec/ts-http-runtime@*": {
+   "peerDependencies": {
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "@uiw/codemirror-themes@*": {
+   "peerDependencies": {
+    "style-mod": "*"
+   },
+   "peerDependenciesMeta": {
+    "style-mod": {
+     "optional": true
+    }
+   }
+  },
+  "@unhead/schema@*": {
+   "peerDependencies": {
+    "unhead": "*"
+   },
+   "peerDependenciesMeta": {
+    "unhead": {
+     "optional": true
+    }
+   }
+  },
+  "@vercel/analytics@*": {
+   "peerDependencies": {
+    "@nuxt/kit": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nuxt/kit": {
+     "optional": true
+    }
+   }
+  },
+  "@vercel/go@*": {
+   "peerDependencies": {
+    "encoding": "*"
+   },
+   "peerDependenciesMeta": {
+    "encoding": {
+     "optional": true
+    }
+   }
+  },
+  "@vercel/otel@*": {
+   "peerDependencies": {
+    "@opentelemetry/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@opentelemetry/core": {
+     "optional": true
+    }
+   }
+  },
+  "@vercel/speed-insights@*": {
+   "peerDependencies": {
+    "@nuxt/kit": "*",
+    "@remix-run/react": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nuxt/kit": {
+     "optional": true
+    },
+    "@remix-run/react": {
+     "optional": true
+    }
+   }
+  },
+  "@vercel/static-build@*": {
+   "peerDependencies": {
+    "encoding": "*"
+   },
+   "peerDependenciesMeta": {
+    "encoding": {
+     "optional": true
+    }
+   }
+  },
+  "@verdaccio/config@*": {
+   "peerDependencies": {
+    "@verdaccio/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@verdaccio/types": {
+     "optional": true
+    }
+   }
+  },
+  "@verdaccio/core@*": {
+   "peerDependencies": {
+    "@verdaccio/types": "*",
+    "express": "*"
+   },
+   "peerDependenciesMeta": {
+    "@verdaccio/types": {
+     "optional": true
+    },
+    "express": {
+     "optional": true
+    }
+   }
+  },
+  "@verdaccio/file-locking@*": {
+   "peerDependencies": {
+    "@verdaccio/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@verdaccio/types": {
+     "optional": true
+    }
+   }
+  },
+  "@verdaccio/utils@*": {
+   "peerDependencies": {
+    "@verdaccio/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@verdaccio/types": {
+     "optional": true
+    }
+   }
+  },
+  "@videojs/http-streaming@*": {
+   "peerDependencies": {
+    "@xmldom/xmldom": "*"
+   },
+   "peerDependenciesMeta": {
+    "@xmldom/xmldom": {
+     "optional": true
+    }
+   }
+  },
+  "@vimeo/player@*": {
+   "peerDependencies": {
+    "timing-object": "*"
+   },
+   "peerDependenciesMeta": {
+    "timing-object": {
+     "optional": true
+    }
+   }
+  },
+  "@volar/language-server@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@volar/language-service@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@volar/typescript@*": {
+   "peerDependencies": {
+    "@volar/language-service": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@volar/language-service": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@vscode/emmet-helper@*": {
+   "peerDependencies": {
+    "vscode": "*"
+   },
+   "peerDependenciesMeta": {
+    "vscode": {
+     "optional": true
+    }
+   }
+  },
+  "@vue-macros/common@*": {
+   "peerDependencies": {
+    "@babel/types": "*",
+    "@vitejs/plugin-vue": "*",
+    "rollup": "*",
+    "vite": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/types": {
+     "optional": true
+    },
+    "@vitejs/plugin-vue": {
+     "optional": true
+    },
+    "rollup": {
+     "optional": true
+    },
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "@vue/cli-plugin-typescript@<=5.0.0-alpha.0": {
+   "dependencies": {
+    "babel-loader": "^8.1.0"
+   }
+  },
+  "@vue/cli-plugin-typescript@<=5.0.0-beta.0": {
+   "dependencies": {
+    "@babel/core": "^7.12.16"
+   },
+   "peerDependencies": {
+    "vue-template-compiler": "^2.0.0"
+   },
+   "peerDependenciesMeta": {
+    "vue-template-compiler": {
+     "optional": true
+    }
+   }
+  },
+  "@vue/compiler-core@*": {
+   "peerDependencies": {
+    "@babel/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/types": {
+     "optional": true
+    }
+   }
+  },
+  "@vue/compiler-sfc@*": {
+   "peerDependencies": {
+    "@babel/types": "*",
+    "arc-templates": "*",
+    "atpl": "*",
+    "babel-core": "*",
+    "bracket-template": "*",
+    "coffee-script": "*",
+    "dot": "*",
+    "dust": "*",
+    "dustjs-helpers": "*",
+    "dustjs-linkedin": "*",
+    "eco": "*",
+    "ect": "*",
+    "ejs": "*",
+    "haml-coffee": "*",
+    "hamlet": "*",
+    "hamljs": "*",
+    "handlebars": "*",
+    "hogan.js": "*",
+    "htmling": "*",
+    "jade": "*",
+    "jazz": "*",
+    "jqtpl": "*",
+    "just": "*",
+    "liquid-node": "*",
+    "liquor": "*",
+    "lodash": "*",
+    "marko": "*",
+    "mote": "*",
+    "mustache": "*",
+    "nunjucks": "*",
+    "plates": "*",
+    "pug": "*",
+    "qejs": "*",
+    "ractive": "*",
+    "razor-tmpl": "*",
+    "react": "*",
+    "react-dom": "*",
+    "slm": "*",
+    "squirrelly": "*",
+    "swig": "*",
+    "swig-templates": "*",
+    "teacup": "*",
+    "templayed": "*",
+    "then-jade": "*",
+    "then-pug": "*",
+    "tinyliquid": "*",
+    "toffee": "*",
+    "twig": "*",
+    "twing": "*",
+    "typescript": "*",
+    "underscore": "*",
+    "vash": "*",
+    "velocityjs": "*",
+    "walrus": "*",
+    "whiskers": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/types": {
+     "optional": true
+    },
+    "arc-templates": {
+     "optional": true
+    },
+    "atpl": {
+     "optional": true
+    },
+    "babel-core": {
+     "optional": true
+    },
+    "bracket-template": {
+     "optional": true
+    },
+    "coffee-script": {
+     "optional": true
+    },
+    "dot": {
+     "optional": true
+    },
+    "dust": {
+     "optional": true
+    },
+    "dustjs-helpers": {
+     "optional": true
+    },
+    "dustjs-linkedin": {
+     "optional": true
+    },
+    "eco": {
+     "optional": true
+    },
+    "ect": {
+     "optional": true
+    },
+    "ejs": {
+     "optional": true
+    },
+    "haml-coffee": {
+     "optional": true
+    },
+    "hamlet": {
+     "optional": true
+    },
+    "hamljs": {
+     "optional": true
+    },
+    "handlebars": {
+     "optional": true
+    },
+    "hogan.js": {
+     "optional": true
+    },
+    "htmling": {
+     "optional": true
+    },
+    "jade": {
+     "optional": true
+    },
+    "jazz": {
+     "optional": true
+    },
+    "jqtpl": {
+     "optional": true
+    },
+    "just": {
+     "optional": true
+    },
+    "liquid-node": {
+     "optional": true
+    },
+    "liquor": {
+     "optional": true
+    },
+    "lodash": {
+     "optional": true
+    },
+    "marko": {
+     "optional": true
+    },
+    "mote": {
+     "optional": true
+    },
+    "mustache": {
+     "optional": true
+    },
+    "nunjucks": {
+     "optional": true
+    },
+    "plates": {
+     "optional": true
+    },
+    "pug": {
+     "optional": true
+    },
+    "qejs": {
+     "optional": true
+    },
+    "ractive": {
+     "optional": true
+    },
+    "razor-tmpl": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "react-dom": {
+     "optional": true
+    },
+    "slm": {
+     "optional": true
+    },
+    "squirrelly": {
+     "optional": true
+    },
+    "swig": {
+     "optional": true
+    },
+    "swig-templates": {
+     "optional": true
+    },
+    "teacup": {
+     "optional": true
+    },
+    "templayed": {
+     "optional": true
+    },
+    "then-jade": {
+     "optional": true
+    },
+    "then-pug": {
+     "optional": true
+    },
+    "tinyliquid": {
+     "optional": true
+    },
+    "toffee": {
+     "optional": true
+    },
+    "twig": {
+     "optional": true
+    },
+    "twing": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    },
+    "underscore": {
+     "optional": true
+    },
+    "vash": {
+     "optional": true
+    },
+    "velocityjs": {
+     "optional": true
+    },
+    "walrus": {
+     "optional": true
+    },
+    "whiskers": {
+     "optional": true
+    }
+   }
+  },
+  "@vue/compiler-vue2@*": {
+   "peerDependencies": {
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "@vue/component-compiler-utils@*": {
+   "peerDependencies": {
+    "less": "*",
+    "sass": "*",
+    "stylus": "*"
+   },
+   "peerDependenciesMeta": {
+    "less": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "stylus": {
+     "optional": true
+    }
+   }
+  },
+  "@vue/devtools-kit@*": {
+   "peerDependencies": {
+    "vue": "*",
+    "vue-router": "*"
+   },
+   "peerDependenciesMeta": {
+    "vue": {
+     "optional": true
+    },
+    "vue-router": {
+     "optional": true
+    }
+   }
+  },
+  "@vue/eslint-config-typescript@<11.0.0": {
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@vue/language-core@*": {
+   "peerDependencies": {
+    "@vue/compiler-sfc": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@vue/compiler-sfc": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "@vue/reactivity-transform@*": {
+   "peerDependencies": {
+    "@babel/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/types": {
+     "optional": true
+    }
+   }
+  },
+  "@vuetify/cli-plugin-utils@<=0.0.4": {
+   "dependencies": {
+    "semver": "^6.3.0"
+   },
+   "peerDependenciesMeta": {
+    "sass-loader": {
+     "optional": true
+    }
+   }
+  },
+  "@walletconnect/utils@*": {
+   "peerDependencies": {
+    "@walletconnect/jsonrpc-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@walletconnect/jsonrpc-types": {
+     "optional": true
+    }
+   }
+  },
+  "@webassemblyjs/wast-parser@*": {
+   "dependencies": {
+    "@webassemblyjs/helper-numbers": "*"
+   }
+  },
+  "@webpack-cli/package-utils@<=1.0.1-alpha.4": {
+   "dependencies": {
+    "cross-spawn": "^7.0.3"
+   }
+  },
+  "@whiskeysockets/baileys@*": {
+   "dependencies": {
+    "long": "*"
+   }
+  },
+  "@xterm/addon-web-links@*": {
+   "peerDependencies": {
+    "@xterm/xterm": "*"
+   },
+   "peerDependenciesMeta": {
+    "@xterm/xterm": {
+     "optional": true
+    }
+   }
+  },
+  "ably@*": {
+   "peerDependencies": {
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "ag-grid-enterprise@*": {
+   "peerDependencies": {
+    "ag-charts-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "ag-charts-types": {
+     "optional": true
+    }
+   }
+  },
+  "algoliasearch-helper@*": {
+   "peerDependencies": {
+    "@algolia/client-search": "*",
+    "@algolia/recommend": "*"
+   },
+   "peerDependenciesMeta": {
+    "@algolia/client-search": {
+     "optional": true
+    },
+    "@algolia/recommend": {
+     "optional": true
+    }
+   }
+  },
+  "angular-eslint@*": {
+   "peerDependencies": {
+    "@eslint/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@eslint/core": {
+     "optional": true
+    }
+   }
+  },
+  "any-observable@<0.5.1": {
+   "peerDependenciesMeta": {
+    "rxjs": {
+     "optional": true
+    },
+    "zenObservable": {
+     "optional": true
+    }
+   }
+  },
+  "apollo-upload-client@<14": {
+   "peerDependencies": {
+    "graphql": "14 - 15"
+   }
+  },
+  "app-builder-lib@*": {
+   "peerDependencies": {
+    "@babel/core": "*",
+    "@babel/plugin-proposal-class-properties": "*",
+    "@babel/plugin-proposal-decorators": "*",
+    "@babel/plugin-proposal-do-expressions": "*",
+    "@babel/plugin-proposal-export-default-from": "*",
+    "@babel/plugin-proposal-export-namespace-from": "*",
+    "@babel/plugin-proposal-function-bind": "*",
+    "@babel/plugin-proposal-function-sent": "*",
+    "@babel/plugin-proposal-json-strings": "*",
+    "@babel/plugin-proposal-logical-assignment-operators": "*",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "*",
+    "@babel/plugin-proposal-numeric-separator": "*",
+    "@babel/plugin-proposal-optional-chaining": "*",
+    "@babel/plugin-proposal-pipeline-operator": "*",
+    "@babel/plugin-proposal-throw-expressions": "*",
+    "@babel/plugin-syntax-dynamic-import": "*",
+    "@babel/plugin-syntax-import-meta": "*",
+    "@babel/preset-env": "*",
+    "@babel/preset-react": "*",
+    "babel-core": "*",
+    "electron-webpack": "*",
+    "toml": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/core": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-class-properties": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-decorators": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-do-expressions": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-export-default-from": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-export-namespace-from": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-function-bind": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-function-sent": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-json-strings": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-logical-assignment-operators": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-numeric-separator": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-pipeline-operator": {
+     "optional": true
+    },
+    "@babel/plugin-proposal-throw-expressions": {
+     "optional": true
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+     "optional": true
+    },
+    "@babel/plugin-syntax-import-meta": {
+     "optional": true
+    },
+    "@babel/preset-env": {
+     "optional": true
+    },
+    "@babel/preset-react": {
+     "optional": true
+    },
+    "babel-core": {
+     "optional": true
+    },
+    "electron-webpack": {
+     "optional": true
+    },
+    "toml": {
+     "optional": true
+    }
+   }
+  },
+  "appium-chromedriver@*": {
+   "peerDependencies": {
+    "@appium/types": "*",
+    "express": "*"
+   },
+   "peerDependenciesMeta": {
+    "@appium/types": {
+     "optional": true
+    },
+    "express": {
+     "optional": true
+    }
+   }
+  },
+  "appium-ios-simulator@*": {
+   "peerDependencies": {
+    "@appium/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@appium/types": {
+     "optional": true
+    }
+   }
+  },
+  "applicationinsights@*": {
+   "peerDependencies": {
+    "@opentelemetry/instrumentation": "*"
+   },
+   "peerDependenciesMeta": {
+    "@opentelemetry/instrumentation": {
+     "optional": true
+    }
+   }
+  },
+  "ast-kit@*": {
+   "peerDependencies": {
+    "@babel/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/types": {
+     "optional": true
+    }
+   }
+  },
+  "ast-v8-to-istanbul@*": {
+   "peerDependencies": {
+    "istanbul-lib-coverage": "*"
+   },
+   "peerDependenciesMeta": {
+    "istanbul-lib-coverage": {
+     "optional": true
+    }
+   }
+  },
+  "astring@*": {
+   "peerDependencies": {
+    "source-map": "*"
+   },
+   "peerDependenciesMeta": {
+    "source-map": {
+     "optional": true
+    }
+   }
+  },
+  "astro@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "auth0@*": {
+   "peerDependencies": {
+    "undici-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "undici-types": {
+     "optional": true
+    }
+   }
+  },
+  "auto-relay@<=0.14.0": {
+   "peerDependencies": {
+    "reflect-metadata": "^0.1.13"
+   }
+  },
+  "aws-cdk@*": {
+   "peerDependencies": {
+    "@aws-cdk/cloud-assembly-api": "*"
+   },
+   "peerDependenciesMeta": {
+    "@aws-cdk/cloud-assembly-api": {
+     "optional": true
+    }
+   }
+  },
+  "aws-sdk-client-mock@*": {
+   "peerDependencies": {
+    "@smithy/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@smithy/types": {
+     "optional": true
+    }
+   }
+  },
+  "babel-plugin-graphql-tag@<=3.1.0": {
+   "peerDependencies": {
+    "graphql": "^14.0.0 || ^15.0.0"
+   }
+  },
+  "babel-plugin-jest-hoist@*": {
+   "peerDependencies": {
+    "@babel/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/types": {
+     "optional": true
+    }
+   }
+  },
+  "babel-plugin-react-compiler@*": {
+   "peerDependencies": {
+    "@babel/core": "*",
+    "@babel/traverse": "*",
+    "zod": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/core": {
+     "optional": true
+    },
+    "@babel/traverse": {
+     "optional": true
+    },
+    "zod": {
+     "optional": true
+    }
+   }
+  },
+  "babel-plugin-remove-graphql-queries@<3.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "babel-plugin-remove-graphql-queries@<=3.14.0-next.1": {
+   "dependencies": {
+    "gatsby-core-utils": "^2.8.0-next.1"
+   }
+  },
+  "babel-plugin-remove-graphql-queries@<=4.20.0-next.0": {
+   "dependencies": {
+    "@babel/types": "^7.15.4"
+   }
+  },
+  "babel-plugin-transform-typescript-metadata@<=0.3.2": {
+   "peerDependencies": {
+    "@babel/core": "^7",
+    "@babel/traverse": "^7"
+   },
+   "peerDependenciesMeta": {
+    "@babel/traverse": {
+     "optional": true
+    }
+   }
+  },
+  "babel-preset-expo@*": {
+   "peerDependencies": {
+    "@babel/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/core": {
+     "optional": true
+    }
+   }
+  },
+  "babel-preset-gatsby-package@<1.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "babel-preset-react-app@10.0.x <10.0.2": {
+   "dependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.16.7"
+   }
+  },
+  "backbone@*": {
+   "peerDependencies": {
+    "jquery": "*"
+   },
+   "peerDependenciesMeta": {
+    "jquery": {
+     "optional": true
+    }
+   }
+  },
+  "batch@*": {
+   "peerDependencies": {
+    "emitter": "*"
+   },
+   "peerDependenciesMeta": {
+    "emitter": {
+     "optional": true
+    }
+   }
+  },
+  "bin-links@<2.3.0": {
+   "dependencies": {
+    "mkdirp-infer-owner": "^1.0.2"
+   }
+  },
+  "broccoli-persistent-filter@*": {
+   "peerDependencies": {
+    "broccoli-node-api": "*"
+   },
+   "peerDependenciesMeta": {
+    "broccoli-node-api": {
+     "optional": true
+    }
+   }
+  },
+  "browser-sync-ui@*": {
+   "peerDependencies": {
+    "browser-sync": "*"
+   },
+   "peerDependenciesMeta": {
+    "browser-sync": {
+     "optional": true
+    }
+   }
+  },
+  "browser-sync@*": {
+   "peerDependencies": {
+    "localtunnel": "*"
+   },
+   "peerDependenciesMeta": {
+    "localtunnel": {
+     "optional": true
+    }
+   }
+  },
+  "bullmq@*": {
+   "peerDependencies": {
+    "@valkey/valkey-glide": "*"
+   },
+   "peerDependenciesMeta": {
+    "@valkey/valkey-glide": {
+     "optional": true
+    }
+   }
+  },
+  "cacheable-lookup@<4.1.2": {
+   "dependencies": {
+    "@types/keyv": "^3.1.1"
+   }
+  },
+  "clipanion-v3-codemod@<=0.2.0": {
+   "peerDependencies": {
+    "jscodeshift": "^0.11.0"
+   }
+  },
+  "cls-hooked@*": {
+   "peerDependencies": {
+    "stack-chain": "*"
+   },
+   "peerDependenciesMeta": {
+    "stack-chain": {
+     "optional": true
+    }
+   }
+  },
+  "coffeescript@*": {
+   "peerDependencies": {
+    "@babel/core": "*",
+    "babel-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/core": {
+     "optional": true
+    },
+    "babel-core": {
+     "optional": true
+    }
+   }
+  },
+  "connect-mongo@<5.0.0": {
+   "peerDependencies": {
+    "express-session": "^1.17.1"
+   }
+  },
+  "consolidate@*": {
+   "peerDependencies": {
+    "babel-core": "*",
+    "eta": "*"
+   },
+   "peerDependenciesMeta": {
+    "babel-core": {
+     "optional": true
+    },
+    "eta": {
+     "optional": true
+    }
+   }
+  },
+  "consolidate@<0.16.0": {
+   "peerDependencies": {
+    "mustache": "^3.0.0"
+   },
+   "peerDependenciesMeta": {
+    "mustache": {
+     "optional": true
+    }
+   }
+  },
+  "consolidate@<=0.16.0": {
+   "peerDependencies": {
+    "velocityjs": "^2.0.1",
+    "tinyliquid": "^0.2.34",
+    "liquid-node": "^3.0.1",
+    "jade": "^1.11.0",
+    "then-jade": "*",
+    "dust": "^0.3.0",
+    "dustjs-helpers": "^1.7.4",
+    "dustjs-linkedin": "^2.7.5",
+    "swig": "^1.4.2",
+    "swig-templates": "^2.0.3",
+    "razor-tmpl": "^1.3.1",
+    "atpl": ">=0.7.6",
+    "liquor": "^0.0.5",
+    "twig": "^1.15.2",
+    "ejs": "^3.1.5",
+    "eco": "^1.1.0-rc-3",
+    "jazz": "^0.0.18",
+    "jqtpl": "~1.1.0",
+    "hamljs": "^0.6.2",
+    "hamlet": "^0.3.3",
+    "whiskers": "^0.4.0",
+    "haml-coffee": "^1.14.1",
+    "hogan.js": "^3.0.2",
+    "templayed": ">=0.2.3",
+    "handlebars": "^4.7.6",
+    "underscore": "^1.11.0",
+    "lodash": "^4.17.20",
+    "pug": "^3.0.0",
+    "then-pug": "*",
+    "qejs": "^3.0.5",
+    "walrus": "^0.10.1",
+    "mustache": "^4.0.1",
+    "just": "^0.1.8",
+    "ect": "^0.5.9",
+    "mote": "^0.2.0",
+    "toffee": "^0.3.6",
+    "dot": "^1.1.3",
+    "bracket-template": "^1.1.5",
+    "ractive": "^1.3.12",
+    "nunjucks": "^3.2.2",
+    "htmling": "^0.0.8",
+    "babel-core": "^6.26.3",
+    "plates": "~0.4.11",
+    "react-dom": "^16.13.1",
+    "react": "^16.13.1",
+    "arc-templates": "^0.5.3",
+    "vash": "^0.13.0",
+    "slm": "^2.0.0",
+    "marko": "^3.14.4",
+    "teacup": "^2.0.0",
+    "coffee-script": "^1.12.7",
+    "squirrelly": "^5.1.0",
+    "twing": "^5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "velocityjs": {
+     "optional": true
+    },
+    "tinyliquid": {
+     "optional": true
+    },
+    "liquid-node": {
+     "optional": true
+    },
+    "jade": {
+     "optional": true
+    },
+    "then-jade": {
+     "optional": true
+    },
+    "dust": {
+     "optional": true
+    },
+    "dustjs-helpers": {
+     "optional": true
+    },
+    "dustjs-linkedin": {
+     "optional": true
+    },
+    "swig": {
+     "optional": true
+    },
+    "swig-templates": {
+     "optional": true
+    },
+    "razor-tmpl": {
+     "optional": true
+    },
+    "atpl": {
+     "optional": true
+    },
+    "liquor": {
+     "optional": true
+    },
+    "twig": {
+     "optional": true
+    },
+    "ejs": {
+     "optional": true
+    },
+    "eco": {
+     "optional": true
+    },
+    "jazz": {
+     "optional": true
+    },
+    "jqtpl": {
+     "optional": true
+    },
+    "hamljs": {
+     "optional": true
+    },
+    "hamlet": {
+     "optional": true
+    },
+    "whiskers": {
+     "optional": true
+    },
+    "haml-coffee": {
+     "optional": true
+    },
+    "hogan.js": {
+     "optional": true
+    },
+    "templayed": {
+     "optional": true
+    },
+    "handlebars": {
+     "optional": true
+    },
+    "underscore": {
+     "optional": true
+    },
+    "lodash": {
+     "optional": true
+    },
+    "pug": {
+     "optional": true
+    },
+    "then-pug": {
+     "optional": true
+    },
+    "qejs": {
+     "optional": true
+    },
+    "walrus": {
+     "optional": true
+    },
+    "mustache": {
+     "optional": true
+    },
+    "just": {
+     "optional": true
+    },
+    "ect": {
+     "optional": true
+    },
+    "mote": {
+     "optional": true
+    },
+    "toffee": {
+     "optional": true
+    },
+    "dot": {
+     "optional": true
+    },
+    "bracket-template": {
+     "optional": true
+    },
+    "ractive": {
+     "optional": true
+    },
+    "nunjucks": {
+     "optional": true
+    },
+    "htmling": {
+     "optional": true
+    },
+    "babel-core": {
+     "optional": true
+    },
+    "plates": {
+     "optional": true
+    },
+    "react-dom": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "arc-templates": {
+     "optional": true
+    },
+    "vash": {
+     "optional": true
+    },
+    "slm": {
+     "optional": true
+    },
+    "marko": {
+     "optional": true
+    },
+    "teacup": {
+     "optional": true
+    },
+    "coffee-script": {
+     "optional": true
+    },
+    "squirrelly": {
+     "optional": true
+    },
+    "twing": {
+     "optional": true
+    }
+   }
+  },
+  "contentful-sdk-core@*": {
+   "peerDependencies": {
+    "axios": "*"
+   },
+   "peerDependenciesMeta": {
+    "axios": {
+     "optional": true
+    }
+   }
+  },
+  "convex@*": {
+   "peerDependencies": {
+    "fsevents": "*",
+    "utf-8-validate": "*"
+   },
+   "peerDependenciesMeta": {
+    "fsevents": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "cordova-ios@<=6.3.0": {
+   "dependencies": {
+    "underscore": "^1.9.2"
+   }
+  },
+  "cordova-lib@<=10.0.1": {
+   "dependencies": {
+    "underscore": "^1.9.2"
+   }
+  },
+  "country-flag-icons@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "create-gatsby@<1.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "create-react-class@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "critters-webpack-plugin@<3.0.2": {
+   "peerDependenciesMeta": {
+    "html-webpack-plugin": {
+     "optional": true
+    }
+   }
+  },
+  "crossws@*": {
+   "peerDependencies": {
+    "@cloudflare/workers-types": "*",
+    "bun": "*"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    },
+    "bun": {
+     "optional": true
+    }
+   }
+  },
+  "cssnano-utils@*": {
+   "peerDependencies": {
+    "postcss-value-parser": "*"
+   },
+   "peerDependenciesMeta": {
+    "postcss-value-parser": {
+     "optional": true
+    }
+   }
+  },
+  "cypress@*": {
+   "peerDependencies": {
+    "@angular/common": "*",
+    "@angular/core": "*",
+    "@angular/platform-browser": "*",
+    "@vue/compiler-dom": "*",
+    "@vue/server-renderer": "*",
+    "react": "*",
+    "react-dom": "*",
+    "svelte": "*",
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular/common": {
+     "optional": true
+    },
+    "@angular/core": {
+     "optional": true
+    },
+    "@angular/platform-browser": {
+     "optional": true
+    },
+    "@vue/compiler-dom": {
+     "optional": true
+    },
+    "@vue/server-renderer": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "react-dom": {
+     "optional": true
+    },
+    "svelte": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "danger@*": {
+   "peerDependencies": {
+    "prettier": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "prettier": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "dd-trace@*": {
+   "peerDependencies": {
+    "@vitest/runner": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@vitest/runner": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "debug@<4.2.0": {
+   "peerDependenciesMeta": {
+    "supports-color": {
+     "optional": true
+    }
+   }
+  },
+  "dependency-cruiser@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "diagnostic-channel-publishers@*": {
+   "peerDependencies": {
+    "@azure/opentelemetry-instrumentation-azure-sdk": "*",
+    "@opentelemetry/api": "*",
+    "@opentelemetry/instrumentation": "*",
+    "@opentelemetry/sdk-trace-base": "*"
+   },
+   "peerDependenciesMeta": {
+    "@azure/opentelemetry-instrumentation-azure-sdk": {
+     "optional": true
+    },
+    "@opentelemetry/api": {
+     "optional": true
+    },
+    "@opentelemetry/instrumentation": {
+     "optional": true
+    },
+    "@opentelemetry/sdk-trace-base": {
+     "optional": true
+    }
+   }
+  },
+  "domino@*": {
+   "peerDependencies": {
+    "parserlib": "*"
+   },
+   "peerDependenciesMeta": {
+    "parserlib": {
+     "optional": true
+    }
+   }
+  },
+  "drizzle-kit@*": {
+   "peerDependencies": {
+    "@electric-sql/pglite": "*",
+    "@libsql/client": "*",
+    "@neondatabase/serverless": "*",
+    "@planetscale/database": "*",
+    "@vercel/postgres": "*",
+    "better-sqlite3": "*",
+    "drizzle-orm": "*",
+    "mysql2": "*",
+    "pg": "*",
+    "postgres": "*",
+    "zod": "*"
+   },
+   "peerDependenciesMeta": {
+    "@electric-sql/pglite": {
+     "optional": true
+    },
+    "@libsql/client": {
+     "optional": true
+    },
+    "@neondatabase/serverless": {
+     "optional": true
+    },
+    "@planetscale/database": {
+     "optional": true
+    },
+    "@vercel/postgres": {
+     "optional": true
+    },
+    "better-sqlite3": {
+     "optional": true
+    },
+    "drizzle-orm": {
+     "optional": true
+    },
+    "mysql2": {
+     "optional": true
+    },
+    "pg": {
+     "optional": true
+    },
+    "postgres": {
+     "optional": true
+    },
+    "zod": {
+     "optional": true
+    }
+   }
+  },
+  "drizzle-orm@*": {
+   "peerDependencies": {
+    "@miniflare/d1": "*",
+    "bun": "*",
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "@miniflare/d1": {
+     "optional": true
+    },
+    "bun": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "echarts-for-react@*": {
+   "dependencies": {
+    "tslib": "*"
+   }
+  },
+  "electron-log@*": {
+   "peerDependencies": {
+    "electron": "*"
+   },
+   "peerDependenciesMeta": {
+    "electron": {
+     "optional": true
+    }
+   }
+  },
+  "electron-updater@*": {
+   "peerDependencies": {
+    "electron": "*"
+   },
+   "peerDependenciesMeta": {
+    "electron": {
+     "optional": true
+    }
+   }
+  },
+  "elkjs@*": {
+   "peerDependencies": {
+    "web-worker": "*"
+   },
+   "peerDependenciesMeta": {
+    "web-worker": {
+     "optional": true
+    }
+   }
+  },
+  "elm-webpack-loader@*": {
+   "dependencies": {
+    "temp": "^0.9.4"
+   }
+  },
+  "emoji-mart@*": {
+   "peerDependencies": {
+    "components": "*"
+   },
+   "peerDependenciesMeta": {
+    "components": {
+     "optional": true
+    }
+   }
+  },
+  "es-abstract@*": {
+   "dependencies": {
+    "for-each": "*"
+   }
+  },
+  "esbuild-plugin-alias@*": {
+   "peerDependencies": {
+    "esbuild": "*"
+   },
+   "peerDependenciesMeta": {
+    "esbuild": {
+     "optional": true
+    }
+   }
+  },
+  "esbuild@*": {
+   "peerDependencies": {
+    "pnpapi": "*"
+   },
+   "peerDependenciesMeta": {
+    "pnpapi": {
+     "optional": true
+    }
+   }
+  },
+  "escodegen@*": {
+   "dependencies": {
+    "optionator": "*"
+   }
+  },
+  "eslint-config-next@*": {
+   "peerDependencies": {
+    "next": "*"
+   },
+   "peerDependenciesMeta": {
+    "next": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-config-react-app@*": {
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-flat-config-utils@*": {
+   "peerDependencies": {
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-import-context@*": {
+   "peerDependencies": {
+    "@typescript-eslint/utils": "*",
+    "type-fest": "*"
+   },
+   "peerDependenciesMeta": {
+    "@typescript-eslint/utils": {
+     "optional": true
+    },
+    "type-fest": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-import-resolver-vite@<2.0.1": {
+   "dependencies": {
+    "debug": "^4.3.4",
+    "resolve": "^1.22.8"
+   }
+  },
+  "eslint-module-utils@*": {
+   "peerDependenciesMeta": {
+    "eslint-import-resolver-node": {
+     "optional": true
+    },
+    "eslint-import-resolver-typescript": {
+     "optional": true
+    },
+    "eslint-import-resolver-webpack": {
+     "optional": true
+    },
+    "@typescript-eslint/parser": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-plugin-compat@*": {
+   "dependencies": {
+    "caniuse-lite": "*"
+   }
+  },
+  "eslint-plugin-import-x@*": {
+   "peerDependencies": {
+    "@typescript-eslint/scope-manager": "*"
+   },
+   "peerDependenciesMeta": {
+    "@typescript-eslint/scope-manager": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-plugin-import@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    },
+    "@typescript-eslint/parser": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-plugin-jsdoc@*": {
+   "peerDependencies": {
+    "@eslint/core": "*",
+    "@typescript-eslint/types": "*",
+    "jsdoc-type-pratt-parser": "*",
+    "json-schema": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@eslint/core": {
+     "optional": true
+    },
+    "@typescript-eslint/types": {
+     "optional": true
+    },
+    "jsdoc-type-pratt-parser": {
+     "optional": true
+    },
+    "json-schema": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-plugin-only-warn@*": {
+   "peerDependencies": {
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-plugin-perfectionist@*": {
+   "peerDependencies": {
+    "@typescript-eslint/types": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@typescript-eslint/types": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-plugin-regexp@*": {
+   "peerDependencies": {
+    "json-schema": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "json-schema": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-plugin-svelte@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-plugin-tsdoc@*": {
+   "peerDependencies": {
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "eslint-plugin-vue@*": {
+   "peerDependencies": {
+    "eslint-scope": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint-scope": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "esm@*": {
+   "peerDependencies": {
+    "internal": "*"
+   },
+   "peerDependenciesMeta": {
+    "internal": {
+     "optional": true
+    }
+   }
+  },
+  "esprima@*": {
+   "peerDependencies": {
+    "system": "*"
+   },
+   "peerDependenciesMeta": {
+    "system": {
+     "optional": true
+    }
+   }
+  },
+  "event-target-shim@*": {
+   "peerDependencies": {
+    "@babel/runtime": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/runtime": {
+     "optional": true
+    }
+   }
+  },
+  "expect-webdriverio@*": {
+   "peerDependencies": {
+    "@wdio/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@wdio/types": {
+     "optional": true
+    }
+   }
+  },
+  "expo-application@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-asset@*": {
+   "peerDependencies": {
+    "@react-native/assets-registry": "*",
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native/assets-registry": {
+     "optional": true
+    },
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-auth-session@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-blur@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-camera@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-clipboard@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-constants@*": {
+   "peerDependencies": {
+    "expo-manifests": "*",
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-manifests": {
+     "optional": true
+    },
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-crypto@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-dev-menu@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-device@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-document-picker@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-eas-client@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-file-system@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-font@*": {
+   "peerDependencies": {
+    "expo-asset": "*",
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-asset": {
+     "optional": true
+    },
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-haptics@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-image-manipulator@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-image-picker@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-image@*": {
+   "peerDependencies": {
+    "expo-app-metrics": "*",
+    "expo-modules-core": "*",
+    "expo-observe": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-app-metrics": {
+     "optional": true
+    },
+    "expo-modules-core": {
+     "optional": true
+    },
+    "expo-observe": {
+     "optional": true
+    }
+   }
+  },
+  "expo-keep-awake@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-linking@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-localization@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-location@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-notifications@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-router@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*",
+    "react-native-tab-view": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    },
+    "react-native-tab-view": {
+     "optional": true
+    }
+   }
+  },
+  "expo-secure-store@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-sharing@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-splash-screen@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-system-ui@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-updates@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-video@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "expo-web-browser@*": {
+   "peerDependencies": {
+    "expo-modules-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "expo-modules-core": {
+     "optional": true
+    }
+   }
+  },
+  "express-basic-auth@*": {
+   "peerDependencies": {
+    "express": "*"
+   },
+   "peerDependenciesMeta": {
+    "express": {
+     "optional": true
+    }
+   }
+  },
+  "express-jwt@*": {
+   "peerDependencies": {
+    "express": "*"
+   },
+   "peerDependenciesMeta": {
+    "express": {
+     "optional": true
+    }
+   }
+  },
+  "express-unless@*": {
+   "peerDependencies": {
+    "express": "*"
+   },
+   "peerDependenciesMeta": {
+    "express": {
+     "optional": true
+    }
+   }
+  },
+  "fabric@*": {
+   "peerDependencies": {
+    "westures": "*"
+   },
+   "peerDependenciesMeta": {
+    "westures": {
+     "optional": true
+    }
+   }
+  },
+  "fastify-plugin@*": {
+   "peerDependencies": {
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "fdir@<=5.2.0": {
+   "peerDependencies": {
+    "picomatch": "2.x"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    }
+   }
+  },
+  "fetch-nodeshim@*": {
+   "peerDependencies": {
+    "undici-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "undici-types": {
+     "optional": true
+    }
+   }
+  },
+  "firebase-tools@*": {
+   "peerDependencies": {
+    "astro": "*",
+    "firebase-functions": "*"
+   },
+   "peerDependenciesMeta": {
+    "astro": {
+     "optional": true
+    },
+    "firebase-functions": {
+     "optional": true
+    }
+   }
+  },
+  "focus-trap-react@^8.0.0": {
+   "dependencies": {
+    "tabbable": "^5.3.2"
+   }
+  },
+  "foreachasync@*": {
+   "peerDependencies": {
+    "bluebird": "*"
+   },
+   "peerDependenciesMeta": {
+    "bluebird": {
+     "optional": true
+    }
+   }
+  },
+  "fork-ts-checker-webpack-plugin@<=6.3.4": {
+   "peerDependencies": {
+    "eslint": ">= 6",
+    "typescript": ">= 2.7",
+    "webpack": ">= 4",
+    "vue-template-compiler": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint": {
+     "optional": true
+    },
+    "vue-template-compiler": {
+     "optional": true
+    }
+   }
+  },
+  "gatsby-admin@<0.24.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-cli@<3.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-core-utils@<2.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8",
+    "got": "8.3.2"
+   }
+  },
+  "gatsby-design-tokens@<3.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-legacy-polyfills@<1.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-benchmark-reporting@<1.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-favicon@*": {
+   "peerDependencies": {
+    "webpack": "*"
+   }
+  },
+  "gatsby-plugin-gatsby-cloud@<=3.1.0-next.0": {
+   "dependencies": {
+    "gatsby-core-utils": "^2.13.0-next.0"
+   }
+  },
+  "gatsby-plugin-gatsby-cloud@<=3.2.0-next.1": {
+   "peerDependencies": {
+    "webpack": "*"
+   }
+  },
+  "gatsby-plugin-graphql-config@<0.23.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-i18n@*": {
+   "dependencies": {
+    "ramda": "^0.24.1"
+   }
+  },
+  "gatsby-plugin-image@<1.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-mdx@<2.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-mdx@<3.1.0-next.1": {
+   "dependencies": {
+    "mkdirp": "^1.0.4"
+   }
+  },
+  "gatsby-plugin-mdx@^2": {
+   "peerDependencies": {
+    "gatsby": "^3.0.0-next"
+   }
+  },
+  "gatsby-plugin-netlify-cms@<5.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-netlify@3.13.0-next.1": {
+   "dependencies": {
+    "gatsby-core-utils": "^2.13.0-next.0"
+   }
+  },
+  "gatsby-plugin-no-sourcemaps@<3.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-page-creator@<3.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-page-creator@<=4.20.0-next.1": {
+   "dependencies": {
+    "fs-extra": "^10.1.0"
+   }
+  },
+  "gatsby-plugin-preact@<5.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-preload-fonts@<2.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-schema-snapshot@<2.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-sharp@<=4.6.0-next.3": {
+   "dependencies": {
+    "debug": "^4.3.1"
+   }
+  },
+  "gatsby-plugin-styletron@<6.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-subfont@<3.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-utils@<1.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-plugin-utils@<=3.14.0-next.1": {
+   "dependencies": {
+    "fastq": "^1.13.0"
+   },
+   "peerDependencies": {
+    "graphql": "^15.0.0"
+   }
+  },
+  "gatsby-react-router-scroll@<=5.6.0-next.0": {
+   "dependencies": {
+    "prop-types": "^15.7.2"
+   }
+  },
+  "gatsby-recipes@<0.25.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-remark-prismjs@<3.3.28": {
+   "dependencies": {
+    "lodash": "^4"
+   }
+  },
+  "gatsby-source-apiserver@*": {
+   "dependencies": {
+    "babel-polyfill": "^6.26.0"
+   }
+  },
+  "gatsby-source-shopify@<5.6.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-source-wikipedia@<3.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-transformer-screenshot@<3.14.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gatsby-worker@<0.5.0-next.1": {
+   "dependencies": {
+    "@babel/runtime": "^7.14.8"
+   }
+  },
+  "gaxios@*": {
+   "peerDependencies": {
+    "undici-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "undici-types": {
+     "optional": true
+    }
+   }
+  },
+  "git-node-fs@*": {
+   "peerDependencies": {
+    "js-git": "^0.7.8"
+   },
+   "peerDependenciesMeta": {
+    "js-git": {
+     "optional": true
+    }
+   }
+  },
+  "goober@*": {
+   "peerDependencies": {
+    "@babel/helper-module-imports": "*",
+    "babel-plugin-macros": "*",
+    "style-vendorizer": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/helper-module-imports": {
+     "optional": true
+    },
+    "babel-plugin-macros": {
+     "optional": true
+    },
+    "style-vendorizer": {
+     "optional": true
+    }
+   }
+  },
+  "got@<11": {
+   "dependencies": {
+    "@types/responselike": "^1.0.0",
+    "@types/keyv": "^3.1.1"
+   }
+  },
+  "gradient-string@*": {
+   "peerDependencies": {
+    "tinycolor2": "*"
+   },
+   "peerDependenciesMeta": {
+    "tinycolor2": {
+     "optional": true
+    }
+   }
+  },
+  "graphql-compose@>=9.0.10": {
+   "peerDependencies": {
+    "graphql": "^14.2.0 || ^15.0.0 || ^16.0.0"
+   }
+  },
+  "graphql-language-service@*": {
+   "peerDependencies": {
+    "graphql-config": "*",
+    "json-schema": "*"
+   },
+   "peerDependenciesMeta": {
+    "graphql-config": {
+     "optional": true
+    },
+    "json-schema": {
+     "optional": true
+    }
+   }
+  },
+  "graphql-ws@*": {
+   "peerDependencies": {
+    "bun": "*",
+    "fastify": "*"
+   },
+   "peerDependenciesMeta": {
+    "bun": {
+     "optional": true
+    },
+    "fastify": {
+     "optional": true
+    }
+   }
+  },
+  "grunt@*": {
+   "peerDependencies": {
+    "coffeescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "coffeescript": {
+     "optional": true
+    }
+   }
+  },
+  "hast-util-from-parse5@*": {
+   "peerDependencies": {
+    "parse5": "*"
+   },
+   "peerDependenciesMeta": {
+    "parse5": {
+     "optional": true
+    }
+   }
+  },
+  "hast-util-to-parse5@*": {
+   "peerDependencies": {
+    "parse5": "*"
+   },
+   "peerDependenciesMeta": {
+    "parse5": {
+     "optional": true
+    }
+   }
+  },
+  "htm@*": {
+   "peerDependencies": {
+    "preact": "*",
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "preact": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "html-element-map@*": {
+   "peerDependencies": {
+    "for-each": "*",
+    "function.prototype.name": "*",
+    "isarray": "*",
+    "object-inspect": "*",
+    "tape": "*"
+   },
+   "peerDependenciesMeta": {
+    "for-each": {
+     "optional": true
+    },
+    "function.prototype.name": {
+     "optional": true
+    },
+    "isarray": {
+     "optional": true
+    },
+    "object-inspect": {
+     "optional": true
+    },
+    "tape": {
+     "optional": true
+    }
+   }
+  },
+  "http-call@*": {
+   "peerDependencies": {
+    "chalk": "*"
+   },
+   "peerDependenciesMeta": {
+    "chalk": {
+     "optional": true
+    }
+   }
+  },
+  "http-link-dataloader@*": {
+   "peerDependencies": {
+    "graphql": "^0.13.1 || ^14.0.0"
+   }
+  },
+  "http-proxy-middleware@*": {
+   "peerDependencies": {
+    "@hono/node-server": "*",
+    "hono": "*"
+   },
+   "peerDependenciesMeta": {
+    "@hono/node-server": {
+     "optional": true
+    },
+    "hono": {
+     "optional": true
+    }
+   }
+  },
+  "i18next-browser-languagedetector@*": {
+   "peerDependencies": {
+    "i18next": "*"
+   },
+   "peerDependenciesMeta": {
+    "i18next": {
+     "optional": true
+    }
+   }
+  },
+  "i18next-fs-backend@*": {
+   "peerDependencies": {
+    "i18next": "*"
+   },
+   "peerDependenciesMeta": {
+    "i18next": {
+     "optional": true
+    }
+   }
+  },
+  "i18next-http-backend@*": {
+   "peerDependencies": {
+    "i18next": "*"
+   },
+   "peerDependenciesMeta": {
+    "i18next": {
+     "optional": true
+    }
+   }
+  },
+  "i18next-resources-to-backend@*": {
+   "peerDependencies": {
+    "i18next": "*"
+   },
+   "peerDependenciesMeta": {
+    "i18next": {
+     "optional": true
+    }
+   }
+  },
+  "ink-select-input@<4.1.0": {
+   "peerDependencies": {
+    "react": "^16.8.2"
+   }
+  },
+  "jake@*": {
+   "peerDependencies": {
+    "coffeescript": "*",
+    "livescript": "*",
+    "ts-node": "*"
+   },
+   "peerDependenciesMeta": {
+    "coffeescript": {
+     "optional": true
+    },
+    "livescript": {
+     "optional": true
+    },
+    "ts-node": {
+     "optional": true
+    }
+   }
+  },
+  "jest-canvas-mock@*": {
+   "peerDependencies": {
+    "canvas": "*"
+   },
+   "peerDependenciesMeta": {
+    "canvas": {
+     "optional": true
+    }
+   }
+  },
+  "jest-config@*": {
+   "peerDependencies": {
+    "jest-jasmine2": "*"
+   },
+   "peerDependenciesMeta": {
+    "jest-jasmine2": {
+     "optional": true
+    }
+   }
+  },
+  "jest-expo@*": {
+   "peerDependencies": {
+    "babel-preset-expo": "*",
+    "jest": "*"
+   },
+   "peerDependenciesMeta": {
+    "babel-preset-expo": {
+     "optional": true
+    },
+    "jest": {
+     "optional": true
+    }
+   }
+  },
+  "jest-mock-extended@*": {
+   "peerDependencies": {
+    "jest-mock": "*"
+   },
+   "peerDependenciesMeta": {
+    "jest-mock": {
+     "optional": true
+    }
+   }
+  },
+  "jest-playwright-preset@*": {
+   "peerDependencies": {
+    "@jest/types": "*",
+    "playwright": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jest/types": {
+     "optional": true
+    },
+    "playwright": {
+     "optional": true
+    }
+   }
+  },
+  "jest-preset-angular@*": {
+   "peerDependencies": {
+    "@jest/transform": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jest/transform": {
+     "optional": true
+    }
+   }
+  },
+  "jest-resolve-dependencies@*": {
+   "peerDependencies": {
+    "jest-haste-map": "*",
+    "jest-resolve": "*"
+   },
+   "peerDependenciesMeta": {
+    "jest-haste-map": {
+     "optional": true
+    },
+    "jest-resolve": {
+     "optional": true
+    }
+   }
+  },
+  "jest-runner@*": {
+   "peerDependencies": {
+    "jest-jasmine2": "*"
+   },
+   "peerDependenciesMeta": {
+    "jest-jasmine2": {
+     "optional": true
+    }
+   }
+  },
+  "jest-styled-components@*": {
+   "peerDependencies": {
+    "pretty-format": "*"
+   },
+   "peerDependenciesMeta": {
+    "pretty-format": {
+     "optional": true
+    }
+   }
+  },
+  "jest-validate@*": {
+   "peerDependencies": {
+    "yargs": "*"
+   },
+   "peerDependenciesMeta": {
+    "yargs": {
+     "optional": true
+    }
+   }
+  },
+  "jest-vue-preprocessor@*": {
+   "dependencies": {
+    "@babel/core": "7.8.7",
+    "@babel/template": "7.8.6"
+   },
+   "peerDependencies": {
+    "pug": "^2.0.4"
+   },
+   "peerDependenciesMeta": {
+    "pug": {
+     "optional": true
+    }
+   }
+  },
+  "jest@*": {
+   "peerDependencies": {
+    "jest-config": "*"
+   },
+   "peerDependenciesMeta": {
+    "jest-config": {
+     "optional": true
+    }
+   }
+  },
+  "jimp-compact@*": {
+   "peerDependencies": {
+    "@jimp/core": "*",
+    "@jimp/plugins": "*",
+    "@jimp/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jimp/core": {
+     "optional": true
+    },
+    "@jimp/plugins": {
+     "optional": true
+    },
+    "@jimp/types": {
+     "optional": true
+    }
+   }
+  },
+  "json-schema-to-typescript@*": {
+   "peerDependencies": {
+    "cli-color": "*",
+    "json-schema": "*"
+   },
+   "peerDependenciesMeta": {
+    "cli-color": {
+     "optional": true
+    },
+    "json-schema": {
+     "optional": true
+    }
+   }
+  },
+  "json-stream-stringify@*": {
+   "peerDependencies": {
+    "@babel/runtime": "*",
+    "core-js": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/runtime": {
+     "optional": true
+    },
+    "core-js": {
+     "optional": true
+    }
+   }
+  },
+  "jsonc-eslint-parser@*": {
+   "peerDependencies": {
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "jss-plugin-rule-value-function@<=10.1.1": {
+   "dependencies": {
+    "tiny-warning": "^1.0.2"
+   }
+  },
+  "karma@*": {
+   "peerDependencies": {
+    "LiveScript": "*",
+    "coffeescript": "*",
+    "ts-node": "*"
+   },
+   "peerDependenciesMeta": {
+    "LiveScript": {
+     "optional": true
+    },
+    "coffeescript": {
+     "optional": true
+    },
+    "ts-node": {
+     "optional": true
+    }
+   }
+  },
+  "knex@*": {
+   "peerDependencies": {
+    "oracledb": "*"
+   },
+   "peerDependenciesMeta": {
+    "oracledb": {
+     "optional": true
+    }
+   }
+  },
+  "knip@*": {
+   "peerDependencies": {
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "langium@*": {
+   "peerDependencies": {
+    "@chevrotain/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@chevrotain/types": {
+     "optional": true
+    }
+   }
+  },
+  "langsmith@*": {
+   "peerDependencies": {
+    "@jest/globals": "*",
+    "@jest/reporters": "*",
+    "@langchain/core": "*",
+    "@opentelemetry/context-async-hooks": "*",
+    "vitest": "*"
+   },
+   "peerDependenciesMeta": {
+    "@jest/globals": {
+     "optional": true
+    },
+    "@jest/reporters": {
+     "optional": true
+    },
+    "@langchain/core": {
+     "optional": true
+    },
+    "@opentelemetry/context-async-hooks": {
+     "optional": true
+    },
+    "vitest": {
+     "optional": true
+    }
+   }
+  },
+  "lerna@*": {
+   "peerDependencies": {
+    "chalk": "*"
+   },
+   "peerDependenciesMeta": {
+    "chalk": {
+     "optional": true
+    }
+   }
+  },
+  "less-loader@*": {
+   "peerDependencies": {
+    "schema-utils": "*"
+   },
+   "peerDependenciesMeta": {
+    "schema-utils": {
+     "optional": true
+    }
+   }
+  },
+  "lib0@*": {
+   "peerDependencies": {
+    "isomorphic-webcrypto": "*"
+   },
+   "peerDependenciesMeta": {
+    "isomorphic-webcrypto": {
+     "optional": true
+    }
+   }
+  },
+  "license-webpack-plugin@<2.3.18": {
+   "peerDependenciesMeta": {
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "lighthouse@*": {
+   "peerDependencies": {
+    "puppeteer": "*"
+   },
+   "peerDependenciesMeta": {
+    "puppeteer": {
+     "optional": true
+    }
+   }
+  },
+  "livekit-client@*": {
+   "peerDependencies": {
+    "@livekit/throws-transformer": "*"
+   },
+   "peerDependenciesMeta": {
+    "@livekit/throws-transformer": {
+     "optional": true
+    }
+   }
+  },
+  "loglevel-plugin-prefix@*": {
+   "peerDependencies": {
+    "loglevel": "*"
+   },
+   "peerDependenciesMeta": {
+    "loglevel": {
+     "optional": true
+    }
+   }
+  },
+  "lovable-tagger@*": {
+   "peerDependencies": {
+    "@tailwindcss/node": "*"
+   },
+   "peerDependenciesMeta": {
+    "@tailwindcss/node": {
+     "optional": true
+    }
+   }
+  },
+  "magic-regexp@*": {
+   "peerDependencies": {
+    "@nuxt/kit": "*"
+   },
+   "peerDependenciesMeta": {
+    "@nuxt/kit": {
+     "optional": true
+    }
+   }
+  },
+  "mailgun.js@*": {
+   "peerDependencies": {
+    "form-data": "*"
+   },
+   "peerDependenciesMeta": {
+    "form-data": {
+     "optional": true
+    }
+   }
+  },
+  "material-table@^2.0.0": {
+   "dependencies": {
+    "@babel/runtime": "^7.11.2"
+   }
+  },
+  "mdast-util-gfm-autolink-literal@*": {
+   "peerDependencies": {
+    "mdast-util-from-markdown": "*",
+    "mdast-util-to-markdown": "*"
+   },
+   "peerDependenciesMeta": {
+    "mdast-util-from-markdown": {
+     "optional": true
+    },
+    "mdast-util-to-markdown": {
+     "optional": true
+    }
+   }
+  },
+  "media-chrome@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "mermaid@*": {
+   "peerDependencies": {
+    "@iconify/types": "*",
+    "d3-selection": "*",
+    "type-fest": "*"
+   },
+   "peerDependenciesMeta": {
+    "@iconify/types": {
+     "optional": true
+    },
+    "d3-selection": {
+     "optional": true
+    },
+    "type-fest": {
+     "optional": true
+    }
+   }
+  },
+  "metro-babel-transformer@*": {
+   "peerDependencies": {
+    "@babel/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/types": {
+     "optional": true
+    }
+   }
+  },
+  "metro-config@*": {
+   "peerDependencies": {
+    "metro-babel-register": "*",
+    "metro-file-map": "*",
+    "metro-resolver": "*",
+    "metro-transform-worker": "*"
+   },
+   "peerDependenciesMeta": {
+    "metro-babel-register": {
+     "optional": true
+    },
+    "metro-file-map": {
+     "optional": true
+    },
+    "metro-resolver": {
+     "optional": true
+    },
+    "metro-transform-worker": {
+     "optional": true
+    }
+   }
+  },
+  "metro-core@*": {
+   "peerDependencies": {
+    "metro": "*",
+    "metro-file-map": "*"
+   },
+   "peerDependenciesMeta": {
+    "metro": {
+     "optional": true
+    },
+    "metro-file-map": {
+     "optional": true
+    }
+   }
+  },
+  "metro-file-map@*": {
+   "peerDependencies": {
+    "metro-config": "*"
+   },
+   "peerDependenciesMeta": {
+    "metro-config": {
+     "optional": true
+    }
+   }
+  },
+  "metro-minify-terser@*": {
+   "peerDependencies": {
+    "metro-transform-worker": "*"
+   },
+   "peerDependenciesMeta": {
+    "metro-transform-worker": {
+     "optional": true
+    }
+   }
+  },
+  "metro-resolver@*": {
+   "peerDependencies": {
+    "metro": "*"
+   },
+   "peerDependenciesMeta": {
+    "metro": {
+     "optional": true
+    }
+   }
+  },
+  "metro-source-map@*": {
+   "peerDependencies": {
+    "@babel/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/core": {
+     "optional": true
+    }
+   }
+  },
+  "metro-transform-plugins@*": {
+   "peerDependencies": {
+    "@babel/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/types": {
+     "optional": true
+    }
+   }
+  },
+  "metro@*": {
+   "peerDependencies": {
+    "metro-babel-register": "*"
+   },
+   "peerDependenciesMeta": {
+    "metro-babel-register": {
+     "optional": true
+    }
+   }
+  },
+  "micromark-util-events-to-acorn@*": {
+   "peerDependencies": {
+    "acorn": "*"
+   },
+   "peerDependenciesMeta": {
+    "acorn": {
+     "optional": true
+    }
+   }
+  },
+  "miniflare@*": {
+   "peerDependencies": {
+    "@cloudflare/config": "*",
+    "@cloudflare/workers-shared": "*",
+    "@cloudflare/workers-types": "*",
+    "@puppeteer/browsers": "*",
+    "zod": "*"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/config": {
+     "optional": true
+    },
+    "@cloudflare/workers-shared": {
+     "optional": true
+    },
+    "@cloudflare/workers-types": {
+     "optional": true
+    },
+    "@puppeteer/browsers": {
+     "optional": true
+    },
+    "zod": {
+     "optional": true
+    }
+   }
+  },
+  "minimist-options@*": {
+   "peerDependencies": {
+    "minimist": "*"
+   },
+   "peerDependenciesMeta": {
+    "minimist": {
+     "optional": true
+    }
+   }
+  },
+  "moment-duration-format@*": {
+   "peerDependencies": {
+    "moment": "*"
+   },
+   "peerDependenciesMeta": {
+    "moment": {
+     "optional": true
+    }
+   }
+  },
+  "monocart-coverage-reports@*": {
+   "peerDependencies": {
+    "bufferutil": "*",
+    "utf-8-validate": "*"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "motion@*": {
+   "peerDependencies": {
+    "motion-dom": "*"
+   },
+   "peerDependenciesMeta": {
+    "motion-dom": {
+     "optional": true
+    }
+   }
+  },
+  "mqtt@<4.2.7": {
+   "dependencies": {
+    "duplexify": "^4.1.1"
+   }
+  },
+  "mz@*": {
+   "peerDependencies": {
+    "graceful-fs": "*"
+   },
+   "peerDependenciesMeta": {
+    "graceful-fs": {
+     "optional": true
+    }
+   }
+  },
+  "nativewind@*": {
+   "peerDependencies": {
+    "react": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "natural@*": {
+   "peerDependencies": {
+    "webworker-threads": "*"
+   },
+   "peerDependenciesMeta": {
+    "webworker-threads": {
+     "optional": true
+    }
+   }
+  },
+  "nest-winston@*": {
+   "peerDependencies": {
+    "logform": "*"
+   },
+   "peerDependenciesMeta": {
+    "logform": {
+     "optional": true
+    }
+   }
+  },
+  "next-intl@*": {
+   "peerDependencies": {
+    "webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "next@*": {
+   "peerDependencies": {
+    "critters": "*",
+    "next-rspack": "*",
+    "private-next-instrumentation-client": "*",
+    "react-server-dom-turbopack": "*",
+    "react-server-dom-webpack": "*",
+    "server-only": "*"
+   },
+   "peerDependenciesMeta": {
+    "critters": {
+     "optional": true
+    },
+    "next-rspack": {
+     "optional": true
+    },
+    "private-next-instrumentation-client": {
+     "optional": true
+    },
+    "react-server-dom-turbopack": {
+     "optional": true
+    },
+    "react-server-dom-webpack": {
+     "optional": true
+    },
+    "server-only": {
+     "optional": true
+    }
+   }
+  },
+  "ng-packagr@*": {
+   "peerDependencies": {
+    "@angular/compiler": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular/compiler": {
+     "optional": true
+    }
+   }
+  },
+  "nitro@*": {
+   "dependencies": {
+    "croner": "*",
+    "scule": "*",
+    "ufo": "*",
+    "unctx": "*"
+   },
+   "peerDependencies": {
+    "defu": "*",
+    "destr": "*",
+    "get-port-please": "*",
+    "rendu": "*",
+    "source-map": "*",
+    "youch": "*",
+    "youch-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "defu": {
+     "optional": true
+    },
+    "destr": {
+     "optional": true
+    },
+    "get-port-please": {
+     "optional": true
+    },
+    "rendu": {
+     "optional": true
+    },
+    "source-map": {
+     "optional": true
+    },
+    "youch": {
+     "optional": true
+    },
+    "youch-core": {
+     "optional": true
+    }
+   }
+  },
+  "nitropack@*": {
+   "peerDependencies": {
+    "@cloudflare/workers-types": "*",
+    "@scalar/api-reference": "*",
+    "firebase-functions": "*"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    },
+    "@scalar/api-reference": {
+     "optional": true
+    },
+    "firebase-functions": {
+     "optional": true
+    }
+   }
+  },
+  "node-fetch-commonjs@*": {
+   "peerDependencies": {
+    "fetch-blob": "*",
+    "formdata-polyfill": "*"
+   },
+   "peerDependenciesMeta": {
+    "fetch-blob": {
+     "optional": true
+    },
+    "formdata-polyfill": {
+     "optional": true
+    }
+   }
+  },
+  "node-fetch-h2@*": {
+   "peerDependencies": {
+    "encoding": "*"
+   },
+   "peerDependenciesMeta": {
+    "encoding": {
+     "optional": true
+    }
+   }
+  },
+  "node-fetch-native@*": {
+   "peerDependencies": {
+    "undici": "*"
+   },
+   "peerDependenciesMeta": {
+    "undici": {
+     "optional": true
+    }
+   }
+  },
+  "node-gyp-build-optional-packages@*": {
+   "peerDependencies": {
+    "node-gyp": "*"
+   },
+   "peerDependenciesMeta": {
+    "node-gyp": {
+     "optional": true
+    }
+   }
+  },
+  "node-gyp-build@*": {
+   "peerDependencies": {
+    "node-gyp": "*"
+   },
+   "peerDependenciesMeta": {
+    "node-gyp": {
+     "optional": true
+    }
+   }
+  },
+  "node-llama-cpp@*": {
+   "peerDependencies": {
+    "electron": "*"
+   },
+   "peerDependenciesMeta": {
+    "electron": {
+     "optional": true
+    }
+   }
+  },
+  "node-pre-gyp@*": {
+   "peerDependencies": {
+    "node-gyp": "*",
+    "npm": "*",
+    "request": "*"
+   },
+   "peerDependenciesMeta": {
+    "node-gyp": {
+     "optional": true
+    },
+    "npm": {
+     "optional": true
+    },
+    "request": {
+     "optional": true
+    }
+   }
+  },
+  "notistack@^3.0.0": {
+   "dependencies": {
+    "csstype": "^3.0.10"
+   }
+  },
+  "nx@*": {
+   "peerDependencies": {
+    "@angular-devkit/build-angular": "*",
+    "@angular/build": "*",
+    "@angular/cli": "*",
+    "@nx/angular": "*",
+    "@nx/conformance": "*",
+    "@nx/js": "*",
+    "@nx/key": "*",
+    "@nx/powerpack-conformance": "*",
+    "@nx/powerpack-license": "*",
+    "nx-cloud": "*",
+    "oxfmt": "*",
+    "prettier": "*",
+    "ts-node": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "@angular-devkit/build-angular": {
+     "optional": true
+    },
+    "@angular/build": {
+     "optional": true
+    },
+    "@angular/cli": {
+     "optional": true
+    },
+    "@nx/angular": {
+     "optional": true
+    },
+    "@nx/conformance": {
+     "optional": true
+    },
+    "@nx/js": {
+     "optional": true
+    },
+    "@nx/key": {
+     "optional": true
+    },
+    "@nx/powerpack-conformance": {
+     "optional": true
+    },
+    "@nx/powerpack-license": {
+     "optional": true
+    },
+    "nx-cloud": {
+     "optional": true
+    },
+    "oxfmt": {
+     "optional": true
+    },
+    "prettier": {
+     "optional": true
+    },
+    "ts-node": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "object.hasown@*": {
+   "dependencies": {
+    "call-bind": "*"
+   }
+  },
+  "ofetch@*": {
+   "peerDependencies": {
+    "undici": "*"
+   },
+   "peerDependenciesMeta": {
+    "undici": {
+     "optional": true
+    }
+   }
+  },
+  "openclaw@*": {
+   "peerDependencies": {
+    "esbuild": "*"
+   },
+   "peerDependenciesMeta": {
+    "esbuild": {
+     "optional": true
+    }
+   }
+  },
+  "openid-client@*": {
+   "peerDependencies": {
+    "express": "*",
+    "passport": "*"
+   },
+   "peerDependenciesMeta": {
+    "express": {
+     "optional": true
+    },
+    "passport": {
+     "optional": true
+    }
+   }
+  },
+  "oxc-minify@*": {
+   "peerDependencies": {
+    "@oxc-minify/binding-wasm32-wasi": "*"
+   },
+   "peerDependenciesMeta": {
+    "@oxc-minify/binding-wasm32-wasi": {
+     "optional": true
+    }
+   }
+  },
+  "oxc-parser@*": {
+   "peerDependencies": {
+    "@oxc-parser/binding-wasm32-wasi": "*"
+   },
+   "peerDependenciesMeta": {
+    "@oxc-parser/binding-wasm32-wasi": {
+     "optional": true
+    }
+   }
+  },
+  "oxc-resolver@*": {
+   "peerDependencies": {
+    "@oxc-resolver/binding-win32-ia32-msvc": "*"
+   },
+   "peerDependenciesMeta": {
+    "@oxc-resolver/binding-win32-ia32-msvc": {
+     "optional": true
+    }
+   }
+  },
+  "oxc-transform@*": {
+   "peerDependencies": {
+    "@oxc-transform/binding-wasm32-wasi": "*"
+   },
+   "peerDependenciesMeta": {
+    "@oxc-transform/binding-wasm32-wasi": {
+     "optional": true
+    }
+   }
+  },
+  "package-json@*": {
+   "peerDependencies": {
+    "type-fest": "*"
+   },
+   "peerDependenciesMeta": {
+    "type-fest": {
+     "optional": true
+    }
+   }
+  },
+  "parcel@*": {
+   "peerDependenciesMeta": {
+    "@parcel/core": {
+     "optional": true
+    }
+   }
+  },
+  "pg-connection-string@*": {
+   "peerDependencies": {
+    "pg": "*"
+   },
+   "peerDependenciesMeta": {
+    "pg": {
+     "optional": true
+    }
+   }
+  },
+  "pino-pretty@*": {
+   "peerDependencies": {
+    "pino": "*"
+   },
+   "peerDependenciesMeta": {
+    "pino": {
+     "optional": true
+    }
+   }
+  },
+  "playwright-core@*": {
+   "peerDependencies": {
+    "bufferutil": "*",
+    "chromium-bidi": "*",
+    "electron": "*",
+    "kerberos": "*",
+    "utf-8-validate": "*",
+    "zod": "*"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "chromium-bidi": {
+     "optional": true
+    },
+    "electron": {
+     "optional": true
+    },
+    "kerberos": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    },
+    "zod": {
+     "optional": true
+    }
+   }
+  },
+  "pm2@*": {
+   "peerDependencies": {
+    "@opentelemetry/auto-instrumentations-node": "*",
+    "@opentelemetry/sdk-node": "*",
+    "ts-node": "*"
+   },
+   "peerDependenciesMeta": {
+    "@opentelemetry/auto-instrumentations-node": {
+     "optional": true
+    },
+    "@opentelemetry/sdk-node": {
+     "optional": true
+    },
+    "ts-node": {
+     "optional": true
+    }
+   }
+  },
+  "postcss-import@*": {
+   "peerDependencies": {
+    "sugarss": "*"
+   },
+   "peerDependenciesMeta": {
+    "sugarss": {
+     "optional": true
+    }
+   }
+  },
+  "postcss-syntax@*": {
+   "peerDependenciesMeta": {
+    "postcss-html": {
+     "optional": true
+    },
+    "postcss-jsx": {
+     "optional": true
+    },
+    "postcss-less": {
+     "optional": true
+    },
+    "postcss-markdown": {
+     "optional": true
+    },
+    "postcss-scss": {
+     "optional": true
+    }
+   }
+  },
+  "posthog-node@*": {
+   "peerDependencies": {
+    "express": "*"
+   },
+   "peerDependenciesMeta": {
+    "express": {
+     "optional": true
+    }
+   }
+  },
+  "posthtml-render@*": {
+   "peerDependencies": {
+    "posthtml-parser": "*"
+   },
+   "peerDependenciesMeta": {
+    "posthtml-parser": {
+     "optional": true
+    }
+   }
+  },
+  "prettier-eslint@*": {
+   "peerDependencies": {
+    "loglevel": "*"
+   },
+   "peerDependenciesMeta": {
+    "loglevel": {
+     "optional": true
+    }
+   }
+  },
+  "prettier-plugin-organize-imports@*": {
+   "peerDependencies": {
+    "@volar/typescript": "*",
+    "@vue/language-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@volar/typescript": {
+     "optional": true
+    },
+    "@vue/language-core": {
+     "optional": true
+    }
+   }
+  },
+  "promise-inflight@*": {
+   "peerDependencies": {
+    "bluebird": "*"
+   },
+   "peerDependenciesMeta": {
+    "bluebird": {
+     "optional": true
+    }
+   }
+  },
+  "properties-file@*": {
+   "peerDependencies": {
+    "bun": "*",
+    "esbuild": "*",
+    "rollup": "*"
+   },
+   "peerDependenciesMeta": {
+    "bun": {
+     "optional": true
+    },
+    "esbuild": {
+     "optional": true
+    },
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "prosemirror-changeset@*": {
+   "peerDependencies": {
+    "prosemirror-model": "*"
+   },
+   "peerDependenciesMeta": {
+    "prosemirror-model": {
+     "optional": true
+    }
+   }
+  },
+  "prosemirror-collab@*": {
+   "peerDependencies": {
+    "prosemirror-transform": "*"
+   },
+   "peerDependenciesMeta": {
+    "prosemirror-transform": {
+     "optional": true
+    }
+   }
+  },
+  "prosemirror-gapcursor@*": {
+   "peerDependencies": {
+    "prosemirror-transform": "*"
+   },
+   "peerDependenciesMeta": {
+    "prosemirror-transform": {
+     "optional": true
+    }
+   }
+  },
+  "prosemirror-inputrules@*": {
+   "peerDependencies": {
+    "prosemirror-model": "*"
+   },
+   "peerDependenciesMeta": {
+    "prosemirror-model": {
+     "optional": true
+    }
+   }
+  },
+  "prosemirror-keymap@*": {
+   "peerDependencies": {
+    "prosemirror-view": "*"
+   },
+   "peerDependenciesMeta": {
+    "prosemirror-view": {
+     "optional": true
+    }
+   }
+  },
+  "prosemirror-menu@*": {
+   "peerDependencies": {
+    "prosemirror-model": "*",
+    "prosemirror-view": "*"
+   },
+   "peerDependenciesMeta": {
+    "prosemirror-model": {
+     "optional": true
+    },
+    "prosemirror-view": {
+     "optional": true
+    }
+   }
+  },
+  "prosemirror-schema-list@*": {
+   "peerDependencies": {
+    "orderedmap": "*"
+   },
+   "peerDependenciesMeta": {
+    "orderedmap": {
+     "optional": true
+    }
+   }
+  },
+  "publint@*": {
+   "peerDependencies": {
+    "pnpapi": "*"
+   },
+   "peerDependenciesMeta": {
+    "pnpapi": {
+     "optional": true
+    }
+   }
+  },
+  "puppeteer-extra-plugin@*": {
+   "peerDependencies": {
+    "puppeteer": "*"
+   },
+   "peerDependenciesMeta": {
+    "puppeteer": {
+     "optional": true
+    }
+   }
+  },
+  "query-ast@<1.0.5": {
+   "dependencies": {
+    "lodash": "^4.17.21"
+   }
+  },
+  "rc-animate@<=3.1.1": {
+   "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
+   }
+  },
+  "rc-cascader@*": {
+   "peerDependencies": {
+    "@rc-component/trigger": "*"
+   },
+   "peerDependenciesMeta": {
+    "@rc-component/trigger": {
+     "optional": true
+    }
+   }
+  },
+  "react-bootstrap-table2-paginator@*": {
+   "dependencies": {
+    "classnames": "^2.2.6"
+   }
+  },
+  "react-color@<=2.19.0": {
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "react-content-loader@*": {
+   "peerDependencies": {
+    "react-native": "*",
+    "react-native-svg": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-native": {
+     "optional": true
+    },
+    "react-native-svg": {
+     "optional": true
+    }
+   }
+  },
+  "react-csv@*": {
+   "peerDependencies": {
+    "prop-types": "*",
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "prop-types": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "react-dev-utils@*": {
+   "peerDependencies": {
+    "typescript": ">=2.7",
+    "webpack": ">=4"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "react-devtools-inline@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "react-draggable@<=4.4.3": {
+   "peerDependencies": {
+    "react": ">= 16.3.0",
+    "react-dom": ">= 16.3.0"
+   }
+  },
+  "react-github-btn@<=1.3.0": {
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "react-i18next@*": {
+   "peerDependencies": {
+    "babel-plugin-macros": "*"
+   },
+   "peerDependenciesMeta": {
+    "babel-plugin-macros": {
+     "optional": true
+    }
+   }
+  },
+  "react-instantsearch-core@<=6.7.0": {
+   "peerDependencies": {
+    "algoliasearch": ">= 3.1 < 5"
+   }
+  },
+  "react-instantsearch-dom@<=6.7.0": {
+   "dependencies": {
+    "react-fast-compare": "^3.0.0"
+   }
+  },
+  "react-leaflet@*": {
+   "peerDependencies": {
+    "geojson": "*"
+   },
+   "peerDependenciesMeta": {
+    "geojson": {
+     "optional": true
+    }
+   }
+  },
+  "react-live@*": {
+   "peerDependencies": {
+    "react-dom": "*",
+    "react": "*"
+   }
+  },
+  "react-native-device-info@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "react-native-gesture-handler@*": {
+   "peerDependencies": {
+    "react-native-reanimated": "*",
+    "react-native-worklets": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-native-reanimated": {
+     "optional": true
+    },
+    "react-native-worklets": {
+     "optional": true
+    }
+   }
+  },
+  "react-native-permissions@*": {
+   "peerDependencies": {
+    "@expo/config-plugins": "*"
+   },
+   "peerDependenciesMeta": {
+    "@expo/config-plugins": {
+     "optional": true
+    }
+   }
+  },
+  "react-native-reanimated@*": {
+   "peerDependencies": {
+    "react-native-svg": "*",
+    "react-native-web": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-native-svg": {
+     "optional": true
+    },
+    "react-native-web": {
+     "optional": true
+    }
+   }
+  },
+  "react-native-share@*": {
+   "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "react-native-svg-transformer@*": {
+   "peerDependencies": {
+    "@expo/metro-config": "*",
+    "@react-native/metro-babel-transformer": "*",
+    "expo": "*",
+    "metro-react-native-babel-transformer": "*"
+   },
+   "peerDependenciesMeta": {
+    "@expo/metro-config": {
+     "optional": true
+    },
+    "@react-native/metro-babel-transformer": {
+     "optional": true
+    },
+    "expo": {
+     "optional": true
+    },
+    "metro-react-native-babel-transformer": {
+     "optional": true
+    }
+   }
+  },
+  "react-native-webview@*": {
+   "peerDependencies": {
+    "@babel/runtime": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/runtime": {
+     "optional": true
+    }
+   }
+  },
+  "react-native-worklets@*": {
+   "peerDependencies": {
+    "@babel/plugin-transform-react-jsx": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/plugin-transform-react-jsx": {
+     "optional": true
+    }
+   }
+  },
+  "react-native@*": {
+   "peerDependencies": {
+    "@react-native-community/cli": "*"
+   },
+   "peerDependenciesMeta": {
+    "@react-native-community/cli": {
+     "optional": true
+    }
+   }
+  },
+  "react-phone-number-input@*": {
+   "peerDependencies": {
+    "react-hook-form": "*",
+    "react-native": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-hook-form": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "react-portal@<4.2.2": {
+   "peerDependencies": {
+    "react-dom": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
+   }
+  },
+  "react-qr-code@*": {
+   "peerDependencies": {
+    "react-native-svg": "*"
+   },
+   "peerDependenciesMeta": {
+    "react-native-svg": {
+     "optional": true
+    }
+   }
+  },
+  "react-rnd@<10.3.7": {
+   "peerDependencies": {
+    "react": ">=16.3.0",
+    "react-dom": ">=16.3.0"
+   }
+  },
+  "react-scripts@*": {
+   "peerDependencies": {
+    "eslint": "*"
+   }
+  },
+  "react-scripts@<=4.0.1": {
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "reactcss@*": {
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "rebass@*": {
+   "peerDependencies": {
+    "react": "^16.8.6"
+   }
+  },
+  "recast@*": {
+   "peerDependencies": {
+    "babylon": "*"
+   },
+   "peerDependenciesMeta": {
+    "babylon": {
+     "optional": true
+    }
+   }
+  },
+  "recharts@*": {
+   "peerDependencies": {
+    "redux": "*"
+   },
+   "peerDependenciesMeta": {
+    "redux": {
+     "optional": true
+    }
+   }
+  },
+  "redlock@*": {
+   "peerDependencies": {
+    "ioredis": "*"
+   },
+   "peerDependenciesMeta": {
+    "ioredis": {
+     "optional": true
+    }
+   }
+  },
+  "redoc@*": {
+   "peerDependencies": {
+    "call-me-maybe": "*",
+    "fast-safe-stringify": "*",
+    "null": "*",
+    "yaml": "*"
+   },
+   "peerDependenciesMeta": {
+    "call-me-maybe": {
+     "optional": true
+    },
+    "fast-safe-stringify": {
+     "optional": true
+    },
+    "null": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "redux-persist@*": {
+   "peerDependencies": {
+    "react": ">=16"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "redux-thunk@<=2.3.0": {
+   "peerDependencies": {
+    "redux": "^4.0.0"
+   }
+  },
+  "rehype-harden@*": {
+   "peerDependencies": {
+    "hast": "*"
+   },
+   "peerDependenciesMeta": {
+    "hast": {
+     "optional": true
+    }
+   }
+  },
+  "rehype-parse@*": {
+   "peerDependencies": {
+    "vfile": "*"
+   },
+   "peerDependenciesMeta": {
+    "vfile": {
+     "optional": true
+    }
+   }
+  },
+  "rehype-prism-plus@*": {
+   "peerDependencies": {
+    "hast": "*",
+    "unified": "*"
+   },
+   "peerDependenciesMeta": {
+    "hast": {
+     "optional": true
+    },
+    "unified": {
+     "optional": true
+    }
+   }
+  },
+  "rehype-rewrite@*": {
+   "peerDependencies": {
+    "hast": "*"
+   },
+   "peerDependenciesMeta": {
+    "hast": {
+     "optional": true
+    }
+   }
+  },
+  "remark-mdx@*": {
+   "peerDependencies": {
+    "unified": "*"
+   },
+   "peerDependenciesMeta": {
+    "unified": {
+     "optional": true
+    }
+   }
+  },
+  "remark-parse@*": {
+   "peerDependencies": {
+    "vfile": "*"
+   },
+   "peerDependenciesMeta": {
+    "vfile": {
+     "optional": true
+    }
+   }
+  },
+  "remark-stringify@*": {
+   "peerDependencies": {
+    "vfile": "*"
+   },
+   "peerDependenciesMeta": {
+    "vfile": {
+     "optional": true
+    }
+   }
+  },
+  "remotion@*": {
+   "peerDependencies": {
+    "zod": "*"
+   },
+   "peerDependenciesMeta": {
+    "zod": {
+     "optional": true
+    }
+   }
+  },
+  "resend@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "resolve-package-path@*": {
+   "peerDependencies": {
+    "pnpapi": "*"
+   },
+   "peerDependenciesMeta": {
+    "pnpapi": {
+     "optional": true
+    }
+   }
+  },
+  "retry-request@*": {
+   "peerDependencies": {
+    "request": "*"
+   },
+   "peerDependenciesMeta": {
+    "request": {
+     "optional": true
+    }
+   }
+  },
+  "rolldown-plugin-dts@*": {
+   "peerDependencies": {
+    "@vue/language-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@vue/language-core": {
+     "optional": true
+    }
+   }
+  },
+  "rollup-plugin-copy@*": {
+   "peerDependencies": {
+    "rollup": "*"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "rollup-plugin-polyfill-node@<=0.8.0": {
+   "peerDependencies": {
+    "rollup": "^1.20.0 || ^2.0.0"
+   }
+  },
+  "rollup-plugin-postcss@*": {
+   "peerDependencies": {
+    "rollup": "*"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "rrdom@*": {
+   "peerDependencies": {
+    "@rrweb/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@rrweb/types": {
+     "optional": true
+    }
+   }
+  },
+  "rrweb-snapshot@*": {
+   "peerDependencies": {
+    "@rrweb/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@rrweb/types": {
+     "optional": true
+    }
+   }
+  },
+  "rss-parser@*": {
+   "peerDependencies": {
+    "xmlbuilder": "*"
+   },
+   "peerDependenciesMeta": {
+    "xmlbuilder": {
+     "optional": true
+    }
+   }
+  },
+  "rx@*": {
+   "peerDependencies": {
+    "rx-lite": "*",
+    "rx-lite-compat": "*"
+   },
+   "peerDependenciesMeta": {
+    "rx-lite": {
+     "optional": true
+    },
+    "rx-lite-compat": {
+     "optional": true
+    }
+   }
+  },
+  "sass-embedded@*": {
+   "peerDependencies": {
+    "sass": "*",
+    "source-map-js": "*"
+   },
+   "peerDependenciesMeta": {
+    "sass": {
+     "optional": true
+    },
+    "source-map-js": {
+     "optional": true
+    }
+   }
+  },
+  "sass-loader@*": {
+   "peerDependencies": {
+    "schema-utils": "*"
+   },
+   "peerDependenciesMeta": {
+    "schema-utils": {
+     "optional": true
+    }
+   }
+  },
+  "satori@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "scss-parser@<=1.0.5": {
+   "dependencies": {
+    "lodash": "^4.17.21"
+   }
+  },
+  "select2@*": {
+   "peerDependencies": {
+    "jquery": "*"
+   },
+   "peerDependenciesMeta": {
+    "jquery": {
+     "optional": true
+    }
+   }
+  },
+  "sequelize-cli@*": {
+   "peerDependencies": {
+    "sequelize": "*"
+   },
+   "peerDependenciesMeta": {
+    "sequelize": {
+     "optional": true
+    }
+   }
+  },
+  "sharp@*": {
+   "peerDependencies": {
+    "@img/sharp-libvips-dev": "*",
+    "@img/sharp-wasm32": "*"
+   },
+   "peerDependenciesMeta": {
+    "@img/sharp-libvips-dev": {
+     "optional": true
+    },
+    "@img/sharp-wasm32": {
+     "optional": true
+    }
+   }
+  },
+  "sigstore@*": {
+   "peerDependencies": {
+    "make-fetch-happen": "*"
+   },
+   "peerDependenciesMeta": {
+    "make-fetch-happen": {
+     "optional": true
+    }
+   }
+  },
+  "simple-bin-help@*": {
+   "peerDependencies": {
+    "npm": "*"
+   },
+   "peerDependenciesMeta": {
+    "npm": {
+     "optional": true
+    }
+   }
+  },
+  "skypack@<=0.3.2": {
+   "dependencies": {
+    "tar": "^6.1.0"
+   }
+  },
+  "snappy@*": {
+   "peerDependencies": {
+    "@napi-rs/snappy-wasm32-wasi": "*"
+   },
+   "peerDependenciesMeta": {
+    "@napi-rs/snappy-wasm32-wasi": {
+     "optional": true
+    }
+   }
+  },
+  "snowpack@<3.8.6": {
+   "dependencies": {
+    "magic-string": "^0.25.7"
+   }
+  },
+  "snowpack@>=3.3.0": {
+   "dependencies": {
+    "node-gyp": "^7.1.0"
+   }
+  },
+  "sodium@>=3": {
+   "dependencies": {
+    "node-gyp": "^3.8.0"
+   }
+  },
+  "stacktrace-gps@*": {
+   "peerDependencies": {
+    "vertx": "*"
+   },
+   "peerDependenciesMeta": {
+    "vertx": {
+     "optional": true
+    }
+   }
+  },
+  "storybook-addon-pseudo-states@*": {
+   "peerDependencies": {
+    "@storybook/icons": "*",
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "@storybook/icons": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "storybook@*": {
+   "peerDependencies": {
+    "@storybook/react": "*",
+    "react": "*",
+    "react-dom": "*",
+    "valibot": "*"
+   },
+   "peerDependenciesMeta": {
+    "@storybook/react": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "react-dom": {
+     "optional": true
+    },
+    "valibot": {
+     "optional": true
+    }
+   }
+  },
+  "streamdown@*": {
+   "peerDependencies": {
+    "hast": "*"
+   },
+   "peerDependenciesMeta": {
+    "hast": {
+     "optional": true
+    }
+   }
+  },
+  "string.prototype.codepointat@*": {
+   "dependencies": {
+    "define-properties": "*"
+   }
+  },
+  "stylus-loader@*": {
+   "peerDependencies": {
+    "schema-utils": "*"
+   },
+   "peerDependenciesMeta": {
+    "schema-utils": {
+     "optional": true
+    }
+   }
+  },
+  "svelte-check@*": {
+   "peerDependencies": {
+    "picomatch": "*",
+    "prettier-plugin-svelte": "*"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    },
+    "prettier-plugin-svelte": {
+     "optional": true
+    }
+   }
+  },
+  "svelte-eslint-parser@*": {
+   "peerDependencies": {
+    "@typescript-eslint/parser": "*",
+    "@typescript-eslint/types": "*",
+    "@typescript-eslint/visitor-keys": "*",
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "@typescript-eslint/parser": {
+     "optional": true
+    },
+    "@typescript-eslint/types": {
+     "optional": true
+    },
+    "@typescript-eslint/visitor-keys": {
+     "optional": true
+    },
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "swagger2openapi@*": {
+   "peerDependencies": {
+    "should": "*"
+   },
+   "peerDependenciesMeta": {
+    "should": {
+     "optional": true
+    }
+   }
+  },
+  "swc-loader@*": {
+   "peerDependencies": {
+    "loader-utils": "*"
+   },
+   "peerDependenciesMeta": {
+    "loader-utils": {
+     "optional": true
+    }
+   }
+  },
+  "swiper@*": {
+   "peerDependencies": {
+    "react": "*",
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "sylvester@*": {
+   "peerDependencies": {
+    "lapack": "*"
+   },
+   "peerDependenciesMeta": {
+    "lapack": {
+     "optional": true
+    }
+   }
+  },
+  "systeminformation@*": {
+   "peerDependencies": {
+    "macos-temperature-sensor": "*",
+    "osx-temperature-sensor": "*"
+   },
+   "peerDependenciesMeta": {
+    "macos-temperature-sensor": {
+     "optional": true
+    },
+    "osx-temperature-sensor": {
+     "optional": true
+    }
+   }
+  },
+  "terser@<=5.10.0": {
+   "dependencies": {
+    "acorn": "^8.5.0"
+   }
+  },
+  "testcafe-legacy-api@<=4.2.0": {
+   "dependencies": {
+    "testcafe-hammerhead": "^17.0.1",
+    "read-file-relative": "^1.2.0"
+   }
+  },
+  "testcafe@<=1.10.1": {
+   "dependencies": {
+    "@babel/plugin-transform-for-of": "^7.12.1",
+    "@babel/runtime": "^7.12.5"
+   }
+  },
+  "tmcp@*": {
+   "peerDependencies": {
+    "json-schema": "*"
+   },
+   "peerDependenciesMeta": {
+    "json-schema": {
+     "optional": true
+    }
+   }
+  },
+  "toml-eslint-parser@*": {
+   "peerDependencies": {
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "ts-node-dev@*": {
+   "peerDependencies": {
+    "pnpapi": "*"
+   },
+   "peerDependenciesMeta": {
+    "pnpapi": {
+     "optional": true
+    }
+   }
+  },
+  "tsconfig-paths-webpack-plugin@*": {
+   "peerDependencies": {
+    "webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "tuf-js@*": {
+   "peerDependencies": {
+    "retry": "*"
+   },
+   "peerDependenciesMeta": {
+    "retry": {
+     "optional": true
+    }
+   }
+  },
+  "typed-array-byte-length@*": {
+   "dependencies": {
+    "available-typed-arrays": "*"
+   }
+  },
+  "typed-array-byte-offset@*": {
+   "peerDependencies": {
+    "possible-typed-array-names": "*"
+   },
+   "peerDependenciesMeta": {
+    "possible-typed-array-names": {
+     "optional": true
+    }
+   }
+  },
+  "typedoc-plugin-markdown@*": {
+   "peerDependencies": {
+    "prettier": "*"
+   },
+   "peerDependenciesMeta": {
+    "prettier": {
+     "optional": true
+    }
+   }
+  },
+  "typescript-json-schema@*": {
+   "peerDependencies": {
+    "json-schema": "*"
+   },
+   "peerDependenciesMeta": {
+    "json-schema": {
+     "optional": true
+    }
+   }
+  },
+  "typescript-language-server@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   },
+   "dependencies": {
+    "vscode-jsonrpc": "^5.0.1",
+    "vscode-languageserver-protocol": "^3.15.0"
+   }
+  },
+  "uglify-to-browserify@*": {
+   "dependencies": {
+    "uglify-js": "*"
+   }
+  },
+  "unfetch@*": {
+   "peerDependencies": {
+    "node-fetch": "*"
+   },
+   "peerDependenciesMeta": {
+    "node-fetch": {
+     "optional": true
+    }
+   }
+  },
+  "unified-engine@*": {
+   "peerDependencies": {
+    "unified": "*"
+   },
+   "peerDependenciesMeta": {
+    "unified": {
+     "optional": true
+    }
+   }
+  },
+  "unified@<10": {
+   "dependencies": {
+    "@types/unist": "^2.0.0"
+   }
+  },
+  "union@*": {
+   "peerDependencies": {
+    "spdy": "*"
+   },
+   "peerDependenciesMeta": {
+    "spdy": {
+     "optional": true
+    }
+   }
+  },
+  "unplugin-vue-router@*": {
+   "peerDependencies": {
+    "@pinia/colada": "*",
+    "vite": "*",
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "@pinia/colada": {
+     "optional": true
+    },
+    "vite": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "unplugin-vue2-script-setup@<0.9.1": {
+   "peerDependencies": {
+    "@vue/composition-api": "^1.4.3",
+    "@vue/runtime-dom": "^3.2.26"
+   }
+  },
+  "unplugin@*": {
+   "peerDependencies": {
+    "@rsbuild/core": "*",
+    "bun": "*"
+   },
+   "peerDependenciesMeta": {
+    "@rsbuild/core": {
+     "optional": true
+    },
+    "bun": {
+     "optional": true
+    }
+   }
+  },
+  "untyped@*": {
+   "peerDependencies": {
+    "@babel/core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@babel/core": {
+     "optional": true
+    }
+   }
+  },
+  "unzipper@*": {
+   "peerDependencies": {
+    "@aws-sdk/client-s3": "*",
+    "readable-stream": "*"
+   },
+   "peerDependenciesMeta": {
+    "@aws-sdk/client-s3": {
+     "optional": true
+    },
+    "readable-stream": {
+     "optional": true
+    }
+   }
+  },
+  "urijs@*": {
+   "peerDependencies": {
+    "jquery": "*"
+   },
+   "peerDependenciesMeta": {
+    "jquery": {
+     "optional": true
+    }
+   }
+  },
+  "useragent@*": {
+   "peerDependencies": {
+    "request": "*",
+    "yamlparser": "*"
+   },
+   "peerDependenciesMeta": {
+    "request": {
+     "optional": true
+    },
+    "yamlparser": {
+     "optional": true
+    }
+   }
+  },
+  "useragent@^2.0.0": {
+   "dependencies": {
+    "request": "^2.88.0",
+    "yamlparser": "0.0.x",
+    "semver": "5.5.x"
+   }
+  },
+  "utif2@*": {
+   "peerDependencies": {
+    "node": "*"
+   },
+   "peerDependenciesMeta": {
+    "node": {
+     "optional": true
+    }
+   }
+  },
+  "verdaccio-htpasswd@*": {
+   "peerDependencies": {
+    "@verdaccio/types": "*"
+   },
+   "peerDependenciesMeta": {
+    "@verdaccio/types": {
+     "optional": true
+    }
+   }
+  },
+  "vite-plugin-full-reload@*": {
+   "peerDependencies": {
+    "vite": "*"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "vite-plugin-pwa@*": {
+   "peerDependencies": {
+    "preact": "*",
+    "react": "*",
+    "rollup": "*",
+    "solid-js": "*",
+    "svelte": "*",
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "preact": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    },
+    "rollup": {
+     "optional": true
+    },
+    "solid-js": {
+     "optional": true
+    },
+    "svelte": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "vite-plugin-svgr@*": {
+   "peerDependencies": {
+    "react": "*"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "vite-plugin-vue-devtools@>=7.4.3": {
+   "peerDependencies": {
+    "vue": "*"
+   }
+  },
+  "vite-plugin-vuetify@<=1.0.2": {
+   "peerDependencies": {
+    "vue": "^3.0.0"
+   }
+  },
+  "vite@*": {
+   "peerDependencies": {
+    "pnpapi": "*"
+   },
+   "peerDependenciesMeta": {
+    "pnpapi": {
+     "optional": true
+    }
+   }
+  },
+  "vitefu@*": {
+   "peerDependencies": {
+    "pnpapi": "*"
+   },
+   "peerDependenciesMeta": {
+    "pnpapi": {
+     "optional": true
+    }
+   }
+  },
+  "vitest@*": {
+   "peerDependencies": {
+    "@vitest/expect": "*",
+    "bufferutil": "*",
+    "utf-8-validate": "*"
+   },
+   "peerDependenciesMeta": {
+    "@vitest/expect": {
+     "optional": true
+    },
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "vm2@*": {
+   "peerDependencies": {
+    "coffee-script": "*",
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "coffee-script": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "volar-service-typescript-twoslash-queries@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "volar-service-typescript@*": {
+   "peerDependencies": {
+    "typescript": "*"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "vscode-languageclient@*": {
+   "peerDependencies": {
+    "vscode": "*"
+   },
+   "peerDependenciesMeta": {
+    "vscode": {
+     "optional": true
+    }
+   }
+  },
+  "vue-bundle-renderer@*": {
+   "peerDependencies": {
+    "vite": "*"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "vue-cli-plugin-vuetify@<=2.0.3": {
+   "dependencies": {
+    "semver": "^6.3.0"
+   },
+   "peerDependenciesMeta": {
+    "sass-loader": {
+     "optional": true
+    },
+    "vuetify-loader": {
+     "optional": true
+    }
+   }
+  },
+  "vue-cli-plugin-vuetify@<=2.0.4": {
+   "dependencies": {
+    "null-loader": "^3.0.0"
+   }
+  },
+  "vue-cli-plugin-vuetify@>=2.4.3": {
+   "peerDependencies": {
+    "vue": "*"
+   }
+  },
+  "vue-i18n@<9": {
+   "peerDependencies": {
+    "vue": "^2"
+   }
+  },
+  "vue-loader@<=16.3.3": {
+   "peerDependencies": {
+    "@vue/compiler-sfc": "^3.0.8",
+    "webpack": "^4.1.0 || ^5.0.0-0"
+   },
+   "peerDependenciesMeta": {
+    "@vue/compiler-sfc": {
+     "optional": true
+    }
+   }
+  },
+  "vue-loader@^16.7.0": {
+   "peerDependencies": {
+    "@vue/compiler-sfc": "^3.0.8",
+    "vue": "^3.2.13"
+   },
+   "peerDependenciesMeta": {
+    "@vue/compiler-sfc": {
+     "optional": true
+    },
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "vue-router@*": {
+   "peerDependencies": {
+    "@vue/language-core": "*"
+   },
+   "peerDependenciesMeta": {
+    "@vue/language-core": {
+     "optional": true
+    }
+   }
+  },
+  "vue-router@<4": {
+   "peerDependencies": {
+    "vue": "^2"
+   }
+  },
+  "vue-template-babel-compiler@<1.2.0": {
+   "peerDependencies": {
+    "vue-template-compiler": "^2.6.0"
+   }
+  },
+  "vue-template-compiler@*": {
+   "peerDependencies": {
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "vuedraggable@*": {
+   "peerDependencies": {
+    "vue": "*"
+   },
+   "peerDependenciesMeta": {
+    "vue": {
+     "optional": true
+    }
+   }
+  },
+  "vuetify@*": {
+   "peerDependencies": {
+    "@vue/reactivity": "*",
+    "vue-router": "*"
+   },
+   "peerDependenciesMeta": {
+    "@vue/reactivity": {
+     "optional": true
+    },
+    "vue-router": {
+     "optional": true
+    }
+   }
+  },
+  "webpack-dev-server@*": {
+   "peerDependencies": {
+    "qs": "*"
+   },
+   "peerDependenciesMeta": {
+    "qs": {
+     "optional": true
+    }
+   }
+  },
+  "webpack-dev-server@<3.10.2": {
+   "peerDependenciesMeta": {
+    "webpack-cli": {
+     "optional": true
+    }
+   }
+  },
+  "webpack-plugin-vuetify@<=2.0.1": {
+   "peerDependencies": {
+    "vue": "^3.2.6"
+   }
+  },
+  "webpack-virtual-modules@*": {
+   "peerDependencies": {
+    "webpack": "*"
+   },
+   "peerDependenciesMeta": {
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "webpack@<4.44.1": {
+   "peerDependenciesMeta": {
+    "webpack-cli": {
+     "optional": true
+    },
+    "webpack-command": {
+     "optional": true
+    }
+   }
+  },
+  "webpack@<5.0.0-beta.23": {
+   "peerDependenciesMeta": {
+    "webpack-cli": {
+     "optional": true
+    }
+   }
+  },
+  "winston-transport@<=4.4.0": {
+   "dependencies": {
+    "logform": "^2.2.0"
+   }
+  },
+  "workbox-build@*": {
+   "peerDependencies": {
+    "type-fest": "*"
+   },
+   "peerDependenciesMeta": {
+    "type-fest": {
+     "optional": true
+    }
+   }
+  },
+  "workbox-window@*": {
+   "peerDependencies": {
+    "trusted-types": "*"
+   },
+   "peerDependenciesMeta": {
+    "trusted-types": {
+     "optional": true
+    }
+   }
+  },
+  "workerd@*": {
+   "peerDependencies": {
+    "pnpapi": "*"
+   },
+   "peerDependenciesMeta": {
+    "pnpapi": {
+     "optional": true
+    }
+   }
+  },
+  "wrangler@*": {
+   "peerDependencies": {
+    "@cloudflare/workers-shared": "*",
+    "@cloudflare/workers-utils": "*",
+    "cloudflare": "*",
+    "devtools-protocol": "*",
+    "undici": "*",
+    "yargs": "*"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-shared": {
+     "optional": true
+    },
+    "@cloudflare/workers-utils": {
+     "optional": true
+    },
+    "cloudflare": {
+     "optional": true
+    },
+    "devtools-protocol": {
+     "optional": true
+    },
+    "undici": {
+     "optional": true
+    },
+    "yargs": {
+     "optional": true
+    }
+   }
+  },
+  "ws@<7.2.1": {
+   "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": "^5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "xo@*": {
+   "peerDependencies": {
+    "webpack": ">=1.11.0"
+   },
+   "peerDependenciesMeta": {
+    "webpack": {
+     "optional": true
+    }
+   }
+  },
+  "yaml-eslint-parser@*": {
+   "peerDependencies": {
+    "eslint": "*"
+   },
+   "peerDependenciesMeta": {
+    "eslint": {
+     "optional": true
+    }
+   }
+  },
+  "yaml-language-server@*": {
+   "dependencies": {
+    "vscode-languageserver-protocol": "*"
+   }
+  },
+  "yeoman-environment@*": {
+   "peerDependencies": {
+    "yeoman-generator": "*"
+   },
+   "peerDependenciesMeta": {
+    "yeoman-generator": {
+     "optional": true
+    }
+   }
+  },
+  "yjs@*": {
+   "peerDependencies": {
+    "y-protocols": "*"
+   },
+   "peerDependenciesMeta": {
+    "y-protocols": {
+     "optional": true
+    }
+   }
+  },
+  "zx@*": {
+   "peerDependencies": {
+    "fs-extra": "*"
+   },
+   "peerDependenciesMeta": {
+    "fs-extra": {
+     "optional": true
+    }
+   }
+  }
+ }
+}

--- a/crates/nub-cli/src/pm_engine/compat_db.rs
+++ b/crates/nub-cli/src/pm_engine/compat_db.rs
@@ -1,0 +1,133 @@
+//! The bundled `packageExtensions` compatibility database.
+//!
+//! A package whose published code imports something its own manifest never
+//! declares resolves under npm's flat `node_modules` — the upward directory walk
+//! finds a copy something else installed — and fails under an isolated layout.
+//! `packageExtensions` repairs the manifest at resolve time, and both pnpm and
+//! Yarn ship a curated database of such repairs.
+//!
+//! nub ships a LARGER one. The vendored engine already carries Yarn's 158
+//! entries plus pnpm's 3 additions, byte-faithful to upstream; this module adds
+//! the machine-derived database published as `@nubjs/extensions`, produced by
+//! running nub's own phantom detector over the 10,000 most-downloaded packages.
+//! It is a strict superset — a gate in that project fails the build if any Yarn
+//! rule is weakened — so the two layers agree wherever they overlap.
+//!
+//! **This diverges from pnpm deliberately.** For 25 packages the extra rules
+//! carry a hard `dependencies` edge, so `nub install` materializes a package
+//! `pnpm install` does not; the remaining ~629 are optional peers, which install
+//! nothing on their own and instead repair resolution under a strict layout
+//! (Yarn PnP with no fallback, pnpm with hoisting off). `ignoreCompatibilityDb`
+//! declines the whole thing, both layers together.
+//!
+//! # Why a snapshot rather than a fetch
+//!
+//! `nubjs/package-extensions` rebuilds daily and publishes whenever the rules
+//! move. Tracking that live would make resolution depend on a registry round
+//! trip and let the same nub build install different trees on different days.
+//! Vendoring pins one dataset per nub release and makes each refresh a
+//! reviewable commit — `node scripts/sync-package-extensions.mjs`.
+//!
+//! Refreshing is safe for existing projects: this feeds
+//! `EngineContext::bundled_package_extensions`, which is read only when
+//! resolving a package and never by the lockfile `packageExtensionsChecksum`,
+//! so a bump cannot drift a lockfile or abort a frozen install.
+
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+/// The vendored database, verbatim. Keys are sorted in the file so a refresh
+/// diffs as the rules that changed rather than as the scan's iteration order.
+const BUNDLED: &str = include_str!("../../assets/bundled-package-extensions.json");
+
+/// The bundled `selector -> extension body` map, parsed once.
+///
+/// Parsed once, on first use, rather than eagerly: the map is only ever built
+/// on a path that registers the engine context, so a command that never touches
+/// the package manager does not pay for it.
+pub(crate) fn bundled_package_extensions() -> &'static BTreeMap<String, serde_json::Value> {
+    static PARSED: OnceLock<BTreeMap<String, serde_json::Value>> = OnceLock::new();
+    PARSED.get_or_init(|| {
+        // The asset is vendored and gated by the test below, so a parse failure
+        // is a build-time mistake rather than anything a user can provoke.
+        // Degrade to no database rather than aborting an install over it: the
+        // engine's own Yarn/pnpm catalogs still apply, and a missing repair
+        // surfaces as the phantom it was hiding.
+        let Ok(doc) = serde_json::from_str::<serde_json::Value>(BUNDLED) else {
+            tracing::warn!("bundled packageExtensions database is not valid JSON; skipping it");
+            return BTreeMap::new();
+        };
+        doc.get("packageExtensions")
+            .and_then(|v| v.as_object())
+            .map(|map| map.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The asset parses, is non-trivial, and every body is an object keyed only
+    /// by the four fields both package managers apply.
+    ///
+    /// A malformed asset does not fail the build — the loader degrades to an
+    /// empty map on purpose — so without this the database could silently go
+    /// missing and every install would just quietly stop being repaired.
+    #[test]
+    fn the_bundled_database_loads_and_is_well_formed() {
+        let db = bundled_package_extensions();
+        assert!(
+            db.len() > 500,
+            "the bundled database should carry the published dataset, got {} entries",
+            db.len()
+        );
+        for (selector, body) in db {
+            let obj = body
+                .as_object()
+                .unwrap_or_else(|| panic!("{selector}: extension body is not an object"));
+            assert!(!obj.is_empty(), "{selector}: empty extension body");
+            for field in obj.keys() {
+                assert!(
+                    matches!(
+                        field.as_str(),
+                        "dependencies"
+                            | "optionalDependencies"
+                            | "peerDependencies"
+                            | "peerDependenciesMeta"
+                    ),
+                    "{selector}: unknown field `{field}` — the engine applies only the four \
+                     manifest fields, so anything else is silently ignored"
+                );
+            }
+        }
+    }
+
+    /// The database is a superset of the engine's vendored Yarn catalog, which
+    /// is the property that lets nub layer it underneath without weakening a
+    /// hand-curated rule. Spot-checked on the entry that motivated the layer.
+    #[test]
+    fn the_bundled_database_carries_the_curated_rules_it_extends() {
+        let db = bundled_package_extensions();
+        let reactcss = db
+            .get("reactcss@*")
+            .expect("the published dataset carries every Yarn rule, including reactcss@*");
+        assert_eq!(
+            reactcss
+                .pointer("/peerDependencies/react")
+                .and_then(|v| v.as_str()),
+            Some("*"),
+            "reactcss must keep the required react peer Yarn curated by hand"
+        );
+        // A rule Yarn does not have, and the reason for shipping the larger set:
+        // `@datadog/sketches-js` declares protobufjs only in devDependencies,
+        // while `dist/ddsketch/proto/compiled.js` requires `protobufjs/minimal`.
+        let sketches = db
+            .get("@datadog/sketches-js@*")
+            .expect("the published dataset carries rules Yarn's does not");
+        assert!(
+            sketches.pointer("/dependencies/protobufjs").is_some(),
+            "@datadog/sketches-js must gain protobufjs as a real dependency"
+        );
+    }
+}

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -52,6 +52,7 @@
 //! with honest per-verb messages in their family dispatchers.
 
 mod bun_config;
+mod compat_db;
 pub mod config_scope;
 mod duplicate_home;
 mod expo_compat;
@@ -2284,6 +2285,16 @@ pub(crate) fn engine_brand_preflight() {
         // carry no checksum (npm/yarn/bun locks), where stored and computed both
         // resolve to `None`. Standalone aube leaves the default `false`.
         c.enforce_package_extensions_checksum = true;
+        // The bundled compatibility database, on top of the vendored Yarn and
+        // pnpm catalogs the engine already applies. Lowest precedence and purely
+        // additive, so a curated upstream rule always wins on a key both carry —
+        // and since extensions merge per DEPENDENCY NAME rather than per
+        // selector, an entry this database extends beyond Yarn's still lands.
+        //
+        // Read only when resolving a package, never by the lockfile checksum, so
+        // refreshing the dataset cannot drift an existing lockfile. Gated with
+        // the vendored catalogs by the one `ignoreCompatibilityDb` escape hatch.
+        c.bundled_package_extensions = Some(compat_db::bundled_package_extensions().clone());
     });
     match surface {
         ConfigSurface::NubIdentity(dir) => {

--- a/crates/nub-cli/tests/package_extensions.rs
+++ b/crates/nub-cli/tests/package_extensions.rs
@@ -181,3 +181,57 @@ fn the_bundled_compatibility_database_repairs_a_published_phantom() {
          undeclared import unresolved: {err_off}"
     );
 }
+
+/// The bundled database repairs a phantom that Yarn's curated catalog does not
+/// cover, which is the whole reason nub ships the larger set.
+///
+/// `@datadog/sketches-js` declares `protobufjs` only in `devDependencies`, so a
+/// consumer never gets it, while `dist/ddsketch/proto/compiled.js` does
+/// `require('protobufjs/minimal')` — reachable through a subpath, which is why
+/// the package's own main entry loads fine and hides the break. Yarn's database
+/// has no entry for it; the machine-derived one adds `protobufjs` as a real
+/// dependency, so it is materialized.
+///
+/// A hard `dependencies` edge is deliberately what this asserts. Most of the
+/// bundled set is optional peers, which install nothing on their own and only
+/// repair a strict layout, so an optional-peer entry would not prove the
+/// database reached the resolver at all.
+#[test]
+#[ignore = "network: resolves @datadog/sketches-js and the protobufjs the database adds"]
+fn the_bundled_database_repairs_a_phantom_yarns_catalog_misses() {
+    if !registry_reachable() {
+        eprintln!("skipping: registry.npmjs.org unreachable");
+        return;
+    }
+    let manifest =
+        r#"{"name":"bundled","version":"1.0.0","dependencies":{"@datadog/sketches-js":"2.1.1"}}"#;
+    let store = pm_tmpdir("bundled-store");
+    let cache = pm_tmpdir("bundled-cache");
+
+    let on = pm_tmpdir("bundled-on");
+    std::fs::write(on.join("package.json"), manifest).unwrap();
+    let (err_on, code_on) = run_install_in_store(&on, &store, &cache, &["install"]);
+    assert_eq!(code_on, 0, "install with the database failed: {err_on}");
+    assert!(
+        store_has(&on, "protobufjs"),
+        "the bundled database must add the protobufjs that @datadog/sketches-js \
+         requires but declares only as a devDependency: {err_on}"
+    );
+
+    // The control. Without it a pass proves only that protobufjs arrived, not
+    // that this database is what put it there — and it re-checks that the one
+    // escape hatch covers the bundled layer, not just the vendored catalogs.
+    let off = pm_tmpdir("bundled-off");
+    std::fs::write(off.join("package.json"), manifest).unwrap();
+    std::fs::write(off.join(".npmrc"), "ignore-compatibility-db=true\n").unwrap();
+    let (err_off, code_off) = run_install_in_store(&off, &store, &cache, &["install"]);
+    assert_eq!(
+        code_off, 0,
+        "install with the database off failed: {err_off}"
+    );
+    assert!(
+        !store_has(&off, "protobufjs"),
+        "ignore-compatibility-db must decline the bundled database too, leaving \
+         the undeclared import unresolved: {err_off}"
+    );
+}

--- a/scripts/sync-package-extensions.mjs
+++ b/scripts/sync-package-extensions.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Refresh the bundled packageExtensions database from the published
+// `@nubjs/extensions` package.
+//
+// The database is a SNAPSHOT, deliberately. `nubjs/package-extensions` rebuilds
+// daily and publishes a patch whenever the rules move, so tracking it live would
+// make nub's resolution depend on a registry fetch and change what a given nub
+// build installs from one day to the next. Vendoring it means a nub release
+// pins one dataset, and refreshing it is a reviewable commit.
+//
+// Bundled extensions are the lowest-precedence layer and never feed the lockfile
+// `packageExtensionsChecksum`, so a refresh does not drift anyone's lockfile —
+// it only affects freshly-resolved packages.
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const ASSET = new URL('../crates/nub-cli/assets/bundled-package-extensions.json', import.meta.url);
+const spec = process.argv[2] ?? '@nubjs/extensions@latest';
+
+const dir = mkdtempSync(join(tmpdir(), 'nub-pkgext-'));
+execFileSync('npm', ['pack', spec, '--silent'], { cwd: dir, stdio: ['ignore', 'ignore', 'inherit'] });
+const tgz = execFileSync('sh', ['-c', 'ls *.tgz'], { cwd: dir, encoding: 'utf8' }).trim();
+execFileSync('tar', ['xzf', tgz], { cwd: dir });
+
+const pkg = JSON.parse(readFileSync(join(dir, 'package/package.json'), 'utf8'));
+const data = JSON.parse(readFileSync(join(dir, 'package/package-extensions.json'), 'utf8'));
+
+// Sorted, so a refresh diffs as the rules that actually changed. The harness
+// emits insertion order, which reshuffles whenever the scan order does.
+const rules = {};
+for (const k of Object.keys(data.packageExtensions).sort()) rules[k] = data.packageExtensions[k];
+
+const before = JSON.parse(readFileSync(ASSET, 'utf8')).packageExtensions;
+writeFileSync(
+  ASSET,
+  JSON.stringify(
+    {
+      _source: '@nubjs/extensions',
+      _version: pkg.version,
+      _generated: data.generated,
+      _refresh: 'node scripts/sync-package-extensions.mjs',
+      packageExtensions: rules,
+    },
+    null,
+    1,
+  ) + '\n',
+);
+
+const added = Object.keys(rules).filter((k) => !(k in before));
+const removed = Object.keys(before).filter((k) => !(k in rules));
+const changed = Object.keys(rules).filter(
+  (k) => k in before && JSON.stringify(before[k]) !== JSON.stringify(rules[k]),
+);
+console.log(`@nubjs/extensions@${pkg.version} (${data.generated}) -> ${Object.keys(rules).length} entries`);
+console.log(`  ${added.length} added, ${removed.length} removed, ${changed.length} changed`);
+for (const k of [...added.slice(0, 5), ...removed.slice(0, 5), ...changed.slice(0, 5)]) console.log(`    ${k}`);

--- a/site/content/docs/install/index.mdx
+++ b/site/content/docs/install/index.mdx
@@ -107,6 +107,15 @@ Patch a dependency's own manifest at resolve time, adding to its `dependencies`,
 Read the [full docs](https://pnpm.io/settings/dependency-resolution#packageextensions) on pnpm.io.
 </Callout>
 
+Nub applies a bundled database of these repairs, so most undeclared dependencies resolve with no configuration. It covers what Nub's phantom detector finds across the 10,000 most-downloaded packages on npm, and carries every rule from Yarn's curated database.
+
+```ini title=".npmrc"
+# resolve every manifest exactly as published, repairing nothing
+ignore-compatibility-db=true
+```
+
+The bundled database is larger than the one pnpm applies, so a dependency can resolve under Nub that pnpm leaves missing. It ships separately as [@nubjs/extensions](https://www.npmjs.com/package/@nubjs/extensions) for other tools to read.
+
 ### `patchedDependencies`
 
 Apply a patch file to a package's contents, keyed by name and version. Running `nub patch <pkg>` writes both the patch and this entry. A key matching no installed package fails the install, because the usual cause is a patch that silently stopped being applied.


### PR DESCRIPTION
Adds the database published as `@nubjs/extensions` — derived by running nub's phantom detector over the top 10,000 npm packages — on top of the vendored Yarn and pnpm catalogs. It is a verified superset of Yarn's.

Of the 654 entries Yarn lacks, 25 add a hard `dependencies` edge; the rest are optional peers that install nothing and only repair strict layouts. So it diverges from pnpm for 25 packages, deliberately.

Supplied via `EngineContext::bundled_package_extensions` rather than by editing the vendored catalogs: lowest precedence, and never read by the lockfile checksum, so a refresh cannot drift a lockfile. `ignoreCompatibilityDb` still declines everything.