### PR TITLE
nub-phantom-scan: record the file each phantom reference was found in

### DIFF
--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -144,7 +144,14 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
         if !e.specs.contains(&r.raw) {
             e.specs.push(r.raw.clone());
         }
-        e.files.insert(r.file.clone());
+        // Membership first, so a repeat reference from a file already recorded
+        // costs a lookup rather than a String clone that is then discarded.
+        // `classify` runs per package on the shipped install path (`scan_index`
+        // -> `reduce`), where a target referenced from one file forty times is
+        // ordinary, and nothing on that path ever reads `files`.
+        if !e.files.contains(r.file.as_str()) {
+            e.files.insert(r.file.clone());
+        }
     }
 
     by_pkg

--- a/crates/nub-phantom-scan/src/classify.rs
+++ b/crates/nub-phantom-scan/src/classify.rs
@@ -5,7 +5,7 @@
 //! try/catch). The classification then answers the one question that matters —
 //! is this reference covered by something a consumer install makes resolvable?
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 
@@ -66,7 +66,26 @@ pub struct Finding {
     pub(crate) from_deep_path: bool,
     /// Example raw specifiers (deduped) showing how it was referenced.
     pub specifiers: Vec<String>,
+    /// Example source files (deduped, sorted, capped at [`MAX_EXAMPLE_FILES`])
+    /// the reference was found in, package-root-relative.
+    ///
+    /// The provenance bits say which entry surface REACHES a reference; this
+    /// says where it physically lives, and the two answer different questions.
+    /// A deep-path-only finding is real-but-lower-confidence precisely because
+    /// the bit cannot distinguish a legacy entry point a consumer imports from
+    /// test or build scaffolding a package shipped by declaring no `files`, and
+    /// the path is what settles it.
+    pub files: Vec<String>,
+    /// How many distinct files reference the package, before the cap — so a
+    /// truncated [`Finding::files`] is visible as truncated rather than reading
+    /// as the whole set.
+    pub file_count: usize,
 }
+
+/// Cap on [`Finding::files`]. A package referenced from every file in a large
+/// tree would otherwise dominate the report; a handful of examples is what a
+/// reviewer reads, and `file_count` carries the rest.
+const MAX_EXAMPLE_FILES: usize = 8;
 
 impl Finding {
     /// The subpath-adapter class the GVS-default bug hinges on: a HARD phantom
@@ -104,6 +123,7 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
         from_types: bool,
         from_deep_path: bool,
         specs: Vec<String>,
+        files: BTreeSet<String>,
     }
     let mut by_pkg: BTreeMap<String, Agg> = BTreeMap::new();
     for r in references {
@@ -114,6 +134,7 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
             from_types: false,
             from_deep_path: false,
             specs: Vec::new(),
+            files: BTreeSet::new(),
         });
         e.all_soft &= r.soft;
         e.from_main |= r.from_main;
@@ -123,6 +144,7 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
         if !e.specs.contains(&r.raw) {
             e.specs.push(r.raw.clone());
         }
+        e.files.insert(r.file.clone());
     }
 
     by_pkg
@@ -145,6 +167,8 @@ pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
                 from_types: agg.from_types,
                 from_deep_path: agg.from_deep_path,
                 specifiers: agg.specs,
+                file_count: agg.files.len(),
+                files: agg.files.into_iter().take(MAX_EXAMPLE_FILES).collect(),
             }
         })
         .collect()
@@ -237,7 +261,7 @@ fn is_self(manifest: &Manifest, package: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{Verdict, classify};
+    use super::{MAX_EXAMPLE_FILES, Verdict, classify};
     use crate::graph::Reference;
     use crate::manifest::Manifest;
 
@@ -247,6 +271,7 @@ mod tests {
             .map(|(p, raw, soft)| Reference {
                 package: (*p).to_string(),
                 raw: (*raw).to_string(),
+                file: "index.js".to_string(),
                 soft: *soft,
                 from_main: true,
                 from_subpath: false,
@@ -278,6 +303,7 @@ mod tests {
         let type_ref = |raw: &str, package: &str| Reference {
             package: package.to_string(),
             raw: raw.to_string(),
+            file: "index.d.ts".to_string(),
             soft: false,
             from_main: false,
             from_subpath: false,
@@ -335,6 +361,7 @@ mod tests {
         let runtime = Reference {
             package: "geojson".to_string(),
             raw: "geojson".to_string(),
+            file: "index.js".to_string(),
             soft: false,
             from_main: true,
             from_subpath: false,
@@ -394,6 +421,7 @@ mod tests {
         let deep = |pkg: &str| Reference {
             package: pkg.to_string(),
             raw: pkg.to_string(),
+            file: format!("lib/integration/{pkg}.js"),
             soft: false,
             from_main: false,
             from_subpath: false,
@@ -427,6 +455,7 @@ mod tests {
         let subpath_only = Reference {
             package: "zod".into(),
             raw: "zod/v4/core".into(),
+            file: "zod.js".into(),
             soft: false,
             from_main: false,
             from_subpath: true,
@@ -436,6 +465,7 @@ mod tests {
         let main_reached = Reference {
             package: "junk".into(),
             raw: "junk".into(),
+            file: "index.js".into(),
             soft: false,
             from_main: true,
             from_subpath: false,
@@ -447,5 +477,55 @@ mod tests {
         let junk = f.iter().find(|x| x.package == "junk").unwrap();
         assert!(zod.is_subpath_adapter());
         assert!(!junk.is_subpath_adapter());
+    }
+
+    /// A finding carries the files it was found in, deduped and sorted, with the
+    /// pre-cap count beside them.
+    ///
+    /// This is what separates a deep-path root that is a real legacy entry point
+    /// from one that is scaffolding a package shipped by declaring no `files` —
+    /// a distinction the provenance bits cannot make, because both reach the
+    /// same `from_deep_path` verdict. Without the count a truncated list would
+    /// read as the complete set, and "every referencing file is scaffolding" is
+    /// exactly the claim a reviewer would then get wrong.
+    #[test]
+    fn a_finding_records_the_files_it_was_found_in() {
+        let m = Manifest::parse(br#"{"name":"pkg"}"#).unwrap();
+        let at = |file: &str| Reference {
+            package: "react".to_string(),
+            raw: "react".to_string(),
+            file: file.to_string(),
+            soft: false,
+            from_main: false,
+            from_subpath: false,
+            from_types: false,
+            from_deep_path: true,
+        };
+        // Two references from one file collapse; the order of arrival does not
+        // survive into the report.
+        let f = classify(
+            &m,
+            &[
+                at("integration/react.js"),
+                at("integration_tests_server/index.js"),
+                at("integration/react.js"),
+            ],
+        );
+        assert_eq!(f[0].file_count, 2, "distinct files, not occurrences");
+        assert_eq!(
+            f[0].files,
+            vec![
+                "integration/react.js".to_string(),
+                "integration_tests_server/index.js".to_string()
+            ]
+        );
+
+        // Past the cap the list truncates and the count keeps the truth.
+        let many: Vec<Reference> = (0..MAX_EXAMPLE_FILES + 5)
+            .map(|i| at(&format!("src/{i:02}.js")))
+            .collect();
+        let f = classify(&m, &many);
+        assert_eq!(f[0].files.len(), MAX_EXAMPLE_FILES);
+        assert_eq!(f[0].file_count, MAX_EXAMPLE_FILES + 5);
     }
 }

--- a/crates/nub-phantom-scan/src/graph.rs
+++ b/crates/nub-phantom-scan/src/graph.rs
@@ -47,6 +47,15 @@ pub struct Reference {
     pub(crate) package: String,
     /// The raw specifier (kept for the report — shows the exact subpath).
     pub(crate) raw: String,
+    /// The package-root-relative file the reference was found in.
+    ///
+    /// Provenance BITS say which entry surface reaches a reference; this says
+    /// where the reference physically is, which is a different question and the
+    /// one a reviewer asks first. It separates a deep-path root that is a real
+    /// legacy entry point (`integration/react.js`) from one that is test or
+    /// build scaffolding a package shipped because it declares no `files`
+    /// (`integration_tests_server/index.js`) — indistinguishable by bit.
+    pub(crate) file: String,
     /// Guarded (try/catch or a conditional branch) at every occurrence collapses
     /// to soft; a single unguarded occurrence makes the package hard.
     pub(crate) soft: bool,
@@ -200,6 +209,7 @@ fn walk_generic<S: FileSource>(source: &S, entry_points: &[Entry], opts: WalkOpt
                 result.references.push(Reference {
                     package,
                     raw: occ.spec.clone(),
+                    file: rel.clone(),
                     soft: occ.soft,
                     from_main: fflags & FROM_MAIN != 0,
                     from_subpath: fflags & FROM_SUBPATH != 0,


### PR DESCRIPTION
Every phantom finding now records the files it was found in, plus the pre-cap count.

The provenance bits say which entry surface *reaches* a reference; they cannot say where it lives. That gap made the deep-path class unauditable: `redux-persist/lib/integration/react` (a real legacy entry point) and `pusher-js/integration_tests_server/index.js` (a test server shipped because the package declares no `files`) reach the same verdict.

Auditing it without the path got it wrong. `swagger-ui-dist`'s 33 edges were written off as a bundled `dist` with every target inlined — true of `swagger-ui-bundle.js`, false of the two files flagged. `swagger-ui.js` externalizes them, the package declares only `@scarf/scarf`, and a clean install throws `MODULE_NOT_FOUND` on `require("swagger-ui-dist/swagger-ui.js")`.

This also supplies what `crates/nub-phantom`'s probe harness asks for in its own header: the file, so it can require an offending path directly rather than settling for whether a bare import breaks.

Verified end to end against three real packages; the new test goes red alone under a negative control.