### PR TITLE
probe: verify opt-in PR CI (temporary)

### DIFF
--- a/.ci-optin-probe.md
+++ b/.ci-optin-probe.md
@@ -1,0 +1,1 @@
+Temporary probe for the opt-in CI change. Deleted with the branch.


### PR DESCRIPTION
Throwaway probe confirming that opening a pull request starts no CI and that the `ci` label starts it. Closed and deleted as soon as the check lands.