### PR TITLE
pm: accept the npm lockfiles and projects that npm ci accepts

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4185,7 +4185,32 @@ pub(crate) fn runtime_node_options(
     runtime: &mut crate::project_config::RuntimeConfig,
     node: &nub_core::node::discovery::ResolvedNode,
 ) -> Result<Vec<String>> {
-    runtime_node_options_with(runtime, node, FoldInherited::Yes)
+    runtime_node_options_with(runtime, node, FoldInherited::Yes, TsconfigGate::Required)
+}
+
+/// The options a PM verb hands its lifecycle scripts. Same set as a run, except a
+/// tsconfig that will not read is tolerated: the install is what makes the
+/// `extends` target exist (ava's `"extends": "@sindresorhus/tsconfig"` is a
+/// devDependency), so refusing here left every fresh clone unable to install.
+pub(crate) fn lifecycle_node_options(
+    runtime: &mut crate::project_config::RuntimeConfig,
+    node: &nub_core::node::discovery::ResolvedNode,
+) -> Result<Vec<String>> {
+    runtime_node_options_with(runtime, node, FoldInherited::Yes, TsconfigGate::BestEffort)
+}
+
+/// What an unreadable tsconfig does to the run whose options are being built.
+///
+/// `Required` is every path that executes the user's program (#731: running under
+/// options the author never wrote is the silent wrong answer). `BestEffort` is the
+/// lifecycle-script path of the PM verbs, where the config's `extends` target is
+/// routinely a package the verb is about to install: the run proceeds without the
+/// config-derived conditions and without a report — nothing is guessed at, and the
+/// child that re-enters nub to run a TypeScript file still applies the gate itself.
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum TsconfigGate {
+    Required,
+    BestEffort,
 }
 
 /// Whether inherited `NODE_OPTIONS` preloads may be folded into nub's chainer.
@@ -4205,6 +4230,7 @@ pub(crate) fn runtime_node_options_with(
     runtime: &mut crate::project_config::RuntimeConfig,
     node: &nub_core::node::discovery::ResolvedNode,
     fold: FoldInherited,
+    tsconfig_gate: TsconfigGate,
 ) -> Result<Vec<String>> {
     let accepted = nub_core::node::discovery::accepted_env_flags(node.path.as_std_path());
     let mut options = Vec::new();
@@ -4252,6 +4278,8 @@ pub(crate) fn runtime_node_options_with(
     // `extends`. Skipped entirely in compat mode by the caller, like every other
     // config-derived flag.
     if let Ok(cwd) = std::env::current_dir() {
+        let cwd = cwd.to_string_lossy();
+        let explicit = runtime.tsconfig.as_deref();
         // A tsconfig that will not parse is FATAL, not a warning (#731). Reporting it
         // and carrying on still runs the program under options its author never
         // wrote — the same silent-wrong-answer the issue reported, only quieter — and
@@ -4260,11 +4288,22 @@ pub(crate) fn runtime_node_options_with(
         // out `strict`, `target` and `paths`, so the base is usually where the load
         // lives. `--node` / `NODE_COMPAT` skip this whole function, so the escape
         // hatch for a config nub cannot read is the one that already turns off every
-        // other config-derived behavior.
-        ensure_tsconfig_parses(&cwd.to_string_lossy(), runtime.tsconfig.as_deref())?;
-        for condition in
-            nub_tsconfig::custom_conditions(&cwd.to_string_lossy(), runtime.tsconfig.as_deref())
-        {
+        // other config-derived behavior. The lifecycle path (`BestEffort`) is the one
+        // exception, and it takes the same "guess at nothing" line: no conditions at
+        // all from a config it cannot read.
+        let conditions = match tsconfig_gate {
+            TsconfigGate::Required => {
+                ensure_tsconfig_parses(&cwd, explicit)?;
+                nub_tsconfig::custom_conditions(&cwd, explicit)
+            }
+            TsconfigGate::BestEffort
+                if nub_tsconfig::probe_diagnostics(&cwd, explicit).is_empty() =>
+            {
+                nub_tsconfig::custom_conditions(&cwd, explicit)
+            }
+            TsconfigGate::BestEffort => Vec::new(),
+        };
+        for condition in conditions {
             // A condition name with whitespace is a user error in THEIR tsconfig that
             // `tsc` itself tolerates, so it cannot be fatal here the way a bad
             // nub.jsonc entry is: skip it and leave the rest of the set intact.
@@ -6950,7 +6989,12 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
         let status = nub_core::node::spawn::status_forwarding_signals(&mut cmd)?;
         return Ok(nub_core::node::spawn::exit_code_from_status(&status));
     }
-    let runtime_node_options = runtime_node_options_with(&mut runtime, &node, FoldInherited::No)?;
+    let runtime_node_options = runtime_node_options_with(
+        &mut runtime,
+        &node,
+        FoldInherited::No,
+        TsconfigGate::Required,
+    )?;
     let runtime_v8_flags = runtime_v8_flags(&runtime)?;
     let runtime_json = runtime_config_json(&runtime)?;
 

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -1925,7 +1925,7 @@ fn apply_lifecycle_augmentation(cwd: &Path) -> Result<()> {
     };
     let node = discovered.unwrap_or_else(|_| nub_core::node::discovery::ResolvedNode::fallback());
     let mut runtime = crate::project_config::runtime_config()?;
-    let runtime_node_options = crate::cli::runtime_node_options(&mut runtime, &node)?;
+    let runtime_node_options = crate::cli::lifecycle_node_options(&mut runtime, &node)?;
     let runtime_json = crate::cli::runtime_config_json(&runtime)?;
     let pnp_ctx = nub_core::pnp::detect(cwd);
     let Some(mut aug) = nub_core::node::spawn::compute_augmentation_env(

--- a/crates/nub-cli/tests/install_engine.rs
+++ b/crates/nub-cli/tests/install_engine.rs
@@ -2151,3 +2151,35 @@ fn the_other_dropped_root_install_keys_are_announced_and_only_when_present() {
         "a manifest carrying none of the keys must say nothing, got: {stderr}"
     );
 }
+
+/// `nub install` in a project whose tsconfig `extends` a package that is not
+/// installed yet. The install is what makes that target exist (ava's
+/// `"extends": "@sindresorhus/tsconfig"` is a devDependency), so the run-path
+/// rule that an unreadable tsconfig is fatal (#731) cannot apply to the PM verbs
+/// — it left every fresh clone unable to install — and the config is not
+/// announced either: a warning about the user's own devDependency on every CI
+/// run is noise, not a finding.
+#[test]
+fn install_tolerates_a_tsconfig_whose_extends_target_is_not_installed_yet() {
+    let dir = pm_tmpdir("tsconfig-extends-uninstalled");
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"extends-uninstalled","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("tsconfig.json"),
+        r#"{"extends":"@sindresorhus/tsconfig","compilerOptions":{"strict":true}}"#,
+    )
+    .unwrap();
+
+    let (out, err, code) = run_install(&dir, &["install"]);
+    assert_eq!(
+        code, 0,
+        "an unreadable tsconfig must not stop an install: {out}\n{err}"
+    );
+    assert!(
+        !err.contains("tsconfig"),
+        "the install must not report the tsconfig it does not need: {err}"
+    );
+}

--- a/crates/nub-tsconfig/src/lib.rs
+++ b/crates/nub-tsconfig/src/lib.rs
@@ -190,6 +190,27 @@ pub fn diagnostics(dir: &str, explicit: Option<&str>) -> Vec<String> {
     load_for_dir(dir, explicit).diagnostics.clone()
 }
 
+/// [`diagnostics`] without the stderr report — for a caller that tolerates an
+/// unreadable config and does not want it announced. The PM verbs are the case:
+/// `nub install` is what puts a tsconfig's `extends` target into `node_modules`
+/// in the first place, so on a fresh clone the config legitimately cannot be read
+/// until the install has run, and the user would read a warning about their own
+/// devDependency on every CI run. The result is memoized like every other load,
+/// so a later loud call in the same process for the same directory stays quiet
+/// too — the PM process never reaches one.
+pub fn probe_diagnostics(dir: &str, explicit: Option<&str>) -> Vec<String> {
+    load_for_dir_with(dir, explicit, Report::No)
+        .diagnostics
+        .clone()
+}
+
+/// Whether a load writes its diagnostics to stderr ([`report_diagnostics`]).
+#[derive(Clone, Copy, PartialEq)]
+enum Report {
+    Yes,
+    No,
+}
+
 /// Config paths this process has already written a warning for. The CLI hands
 /// these to the child through [`REPORTED_ENV`] so the addon does not repeat them.
 pub fn reported_config_paths() -> Vec<String> {
@@ -240,13 +261,17 @@ fn report_diagnostics(config_path: &str, diags: &[String]) {
 /// Shared internal entry — returns the cached `Loaded` (with its matcher) so the
 /// resolver can reuse the same state without re-reading the FS.
 fn load_for_dir(dir: &str, explicit: Option<&str>) -> Arc<Loaded> {
+    load_for_dir_with(dir, explicit, Report::Yes)
+}
+
+fn load_for_dir_with(dir: &str, explicit: Option<&str>, report: Report) -> Arc<Loaded> {
     // NUL cannot occur in a path on any platform nub runs on, so it separates the
     // two halves of the key without a collision an ordinary path could produce.
     let key = format!("{dir}\0{}", explicit.unwrap_or_default());
     if let Some(hit) = cache().lock().unwrap_or_else(|e| e.into_inner()).get(&key) {
         return hit.clone();
     }
-    let loaded = Arc::new(build_loaded(dir, explicit));
+    let loaded = Arc::new(build_loaded(dir, explicit, report));
     let mut entries = cache().lock().unwrap_or_else(|e| e.into_inner());
     if entries.len() >= CACHE_MAX_ENTRIES {
         entries.clear();
@@ -255,7 +280,7 @@ fn load_for_dir(dir: &str, explicit: Option<&str>) -> Arc<Loaded> {
     loaded
 }
 
-fn build_loaded(dir: &str, explicit: Option<&str>) -> Loaded {
+fn build_loaded(dir: &str, explicit: Option<&str>, report: Report) -> Loaded {
     let Some(config_path) = explicit
         .map(str::to_string)
         .or_else(|| find_up(dir, "tsconfig.json"))
@@ -279,7 +304,9 @@ fn build_loaded(dir: &str, explicit: Option<&str>) -> Loaded {
             // the CLI can refuse the run; a silent fallback to defaults here is
             // indistinguishable from having no tsconfig at all (#731).
             diagnostics.push(e);
-            report_diagnostics(&config_path, &diagnostics);
+            if report == Report::Yes {
+                report_diagnostics(&config_path, &diagnostics);
+            }
             return Loaded {
                 path: Some(slash(&config_path)),
                 compiler_options: None,
@@ -290,7 +317,9 @@ fn build_loaded(dir: &str, explicit: Option<&str>) -> Loaded {
             };
         }
     };
-    report_diagnostics(&config_path, &diagnostics);
+    if report == Report::Yes {
+        report_diagnostics(&config_path, &diagnostics);
+    }
 
     let co = parsed
         .get("compilerOptions")

--- a/vendor/aube/crates/aube-lockfile/src/npm/layout.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/layout.rs
@@ -7,6 +7,15 @@ use super::raw::InstallPathInfo;
 /// `pkg_install_path` using npm's nested-resolution walk: look first inside
 /// the package's own `node_modules`, then walk up each ancestor's
 /// `node_modules`, finally falling back to the root `node_modules`.
+///
+/// A workspace member's target path (`test/installation`) walks its
+/// DIRECTORY ancestors, not just `node_modules` boundaries: Node's upward
+/// lookup from `test/installation/` checks `test/node_modules/` before the
+/// root, and npm places a dep there when `test` is itself a member with
+/// its own tree (puppeteer keeps `diff@9` at `test/node_modules/diff` for
+/// both `test` and `test/installation`). Jumping straight to the root
+/// missed it and made every frozen install of that lockfile read as
+/// `manifest adds diff@^9.0.0`.
 pub(super) fn resolve_nested(
     pkg_install_path: &str,
     dep_name: &str,
@@ -28,8 +37,13 @@ pub(super) fn resolve_nested(
         // Walk up one level: strip the trailing "/node_modules/<pkg>" segment.
         if let Some(idx) = base.rfind("/node_modules/") {
             base.truncate(idx);
+        } else if base.starts_with("node_modules/") {
+            // A top-level path like "node_modules/foo" — next step is root.
+            base.clear();
+        } else if let Some(idx) = base.rfind('/') {
+            // A member target directory: its parent directory is next.
+            base.truncate(idx);
         } else {
-            // We're at a top-level path like "node_modules/foo" — next step is root.
             base.clear();
         }
     }

--- a/vendor/aube/crates/aube-lockfile/src/npm/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/read.rs
@@ -137,12 +137,16 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
                     format!("linked package '{install_name}' points to missing target '{target}'"),
                 )
             })?;
-            let version = target_entry.version.clone().ok_or_else(|| {
-                Error::parse(
-                    path,
-                    format!("linked package '{install_name}' target '{target}' has no version"),
-                )
-            })?;
+            // npm writes no `version` on a local package whose manifest
+            // declares none (a test fixture linked as `file:test/fixture`
+            // is the common shape — mocha ships one). The resolver
+            // defaults such a package to `0.0.0` (`install::workspace`);
+            // mirror that so a read graph matches a fresh resolve instead
+            // of refusing a lockfile npm itself wrote.
+            let version = target_entry
+                .version
+                .clone()
+                .unwrap_or_else(|| "0.0.0".to_string());
             let local = LocalSource::Link(PathBuf::from(target));
             (
                 target_entry,
@@ -375,10 +379,23 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
     // frozen install rejects the lockfile with
     // `specifiers in the lockfile don't match package.json` — the same
     // way the non-root workspace importers below already thread it.
-    let push_direct =
+    //
+    // One row per name, first section wins, in the resolver's own
+    // priority (`dependencies` > `devDependencies` >
+    // `optionalDependencies`, `seed_direct_deps`). A manifest may list
+    // one package under two sections — promptfoo carries
+    // `@anthropic-ai/claude-agent-sdk` as both a dev and an optional dep,
+    // and npm mirrors both onto the root entry. Recording both rows made
+    // the section check read the optional row as
+    // `manifest section is devDependencies, lockfile section is
+    // optionalDependencies` and refuse every frozen install.
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut push_direct =
         |dep_name: &str, specifier: &str, dep_type: DepType, direct: &mut Vec<DirectDep>| {
             let root_path = format!("node_modules/{dep_name}");
-            if let Some(info) = install_path_info.get(&root_path) {
+            if let Some(info) = install_path_info.get(&root_path)
+                && seen.insert(info.name.clone())
+            {
                 direct.push(DirectDep {
                     name: info.name.clone(),
                     dep_path: info.dep_path.clone(),
@@ -395,6 +412,9 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
     }
     for (dep_name, specifier) in &root.optional_dependencies {
         push_direct(dep_name, specifier, DepType::Optional, &mut direct);
+    }
+    for (dep_name, specifier) in required_peers_not_declared(&root) {
+        push_direct(dep_name, specifier, DepType::Production, &mut direct);
     }
 
     // npm symlinks every workspace member (and any other top-level
@@ -502,6 +522,7 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
             continue;
         };
         let mut direct = Vec::new();
+        let mut seen: BTreeSet<String> = BTreeSet::new();
         for (dep_name, specifier, dep_type) in package_entry
             .dependencies
             .iter()
@@ -518,10 +539,15 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
                     .iter()
                     .map(|(name, spec)| (name, spec, DepType::Optional)),
             )
+            .chain(
+                required_peers_not_declared(package_entry)
+                    .map(|(name, spec)| (name, spec, DepType::Production)),
+            )
         {
             if let Some(target_install_path) =
                 crate::npm::layout::resolve_nested(target, dep_name, &install_path_info)
                 && let Some(info) = install_path_info.get(&target_install_path)
+                && seen.insert(info.name.clone())
             {
                 direct.push(DirectDep {
                     name: info.name.clone(),
@@ -534,6 +560,31 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
         graph.importers.insert(target.clone(), direct);
     }
     Ok(graph)
+}
+
+/// An importer's required peers that no dependency section already
+/// declares, as (name, range) — the ones npm 7+ auto-installs into an
+/// ancestor `node_modules/` and that aube's own resolver seeds onto the
+/// importer as a `Production` direct dep carrying the peer range
+/// (`auto_install_peers`). The reader has to surface them the same way:
+/// the freshness check compares the manifest's required peers against the
+/// importer's recorded specifiers, so leaving them out read every
+/// workspace member with a peer as `manifest adds <peer>@<range>` under
+/// `--frozen-lockfile` (apollo-server's `@apollo/cache-control-types`,
+/// socket.io's cluster adapter). An optional peer (`peerDependenciesMeta`)
+/// is never auto-installed, so it stays out.
+fn required_peers_not_declared(
+    entry: &RawNpmPackage,
+) -> impl Iterator<Item = (&String, &String)> + '_ {
+    entry.peer_dependencies.iter().filter(|(name, _)| {
+        !entry
+            .peer_dependencies_meta
+            .get(*name)
+            .is_some_and(|meta| meta.optional)
+            && !entry.dependencies.contains_key(*name)
+            && !entry.dev_dependencies.contains_key(*name)
+            && !entry.optional_dependencies.contains_key(*name)
+    })
 }
 
 /// Lift a pre-npm-7 nested-`dependencies` tree into the flat,

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -4126,7 +4126,7 @@ fn test_parse_npm_workspace_importer_records_required_peers() {
         .iter()
         .map(|d| (d.name.as_str(), d.specifier.as_deref().unwrap(), d.dep_type))
         .collect();
-    recorded.sort();
+    recorded.sort_by(|a, b| a.0.cmp(b.0));
     assert_eq!(
         recorded,
         vec![

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -4074,3 +4074,246 @@ fn test_write_npm_root_bin_paths_shed_leading_dot_slash() {
         "only the leading ./ segments are shed; the rest of the path is kept"
     );
 }
+
+/// A workspace member's required peer is recorded on its importer with
+/// the peer range as the specifier — the same shape the resolver seeds
+/// under `auto_install_peers`, and the one the freshness check compares
+/// the manifest's peers against. Two providers, both real: a hoisted
+/// registry copy at the root (apollo-server's `graphql`) and a root
+/// link to a sibling member (socket.io's `socket.io-adapter`). An
+/// optional peer stays out, and a peer the member also declares as a
+/// dependency is not recorded twice.
+#[test]
+fn test_parse_npm_workspace_importer_records_required_peers() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+            "name": "root",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "root",
+                    "version": "1.0.0",
+                    "workspaces": ["packages/*"]
+                },
+                "node_modules/@scope/adapter": { "resolved": "packages/adapter", "link": true },
+                "node_modules/@scope/plugin": { "resolved": "packages/plugin", "link": true },
+                "node_modules/graphql": { "version": "16.11.0" },
+                "node_modules/react": { "version": "19.2.0" },
+                "packages/adapter": { "version": "2.5.8" },
+                "packages/plugin": {
+                    "name": "@scope/plugin",
+                    "version": "0.3.0",
+                    "dependencies": { "react": "^19" },
+                    "peerDependencies": {
+                        "@scope/adapter": "~2.5.5",
+                        "graphql": "14.x || 15.x || 16.x",
+                        "react": ">=18",
+                        "vue": "^3"
+                    },
+                    "peerDependenciesMeta": { "vue": { "optional": true } }
+                }
+            }
+        }"#;
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let graph = parse(tmp.path()).unwrap();
+    let plugin = graph
+        .importers
+        .get("packages/plugin")
+        .expect("plugin importer");
+    let mut recorded: Vec<(&str, &str, DepType)> = plugin
+        .iter()
+        .map(|d| (d.name.as_str(), d.specifier.as_deref().unwrap(), d.dep_type))
+        .collect();
+    recorded.sort();
+    assert_eq!(
+        recorded,
+        vec![
+            ("@scope/adapter", "~2.5.5", DepType::Production),
+            ("graphql", "14.x || 15.x || 16.x", DepType::Production),
+            ("react", "^19", DepType::Production),
+        ],
+        "required peers ride the importer as Production deps with the peer range; \
+         the optional `vue` and a second `react` row do not"
+    );
+    let adapter = plugin.iter().find(|d| d.name == "@scope/adapter").unwrap();
+    assert!(
+        matches!(
+            graph.packages[&adapter.dep_path].local_source,
+            Some(LocalSource::Link(ref p)) if p == Path::new("packages/adapter")
+        ),
+        "a peer satisfied by a root link resolves to the linked member"
+    );
+}
+
+/// The root importer gets the same treatment: a required peer the root
+/// manifest does not also list as a dependency is recorded from
+/// `node_modules/<peer>`.
+#[test]
+fn test_parse_npm_root_importer_records_required_peer() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+            "name": "lib",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "lib",
+                    "version": "1.0.0",
+                    "peerDependencies": { "react": ">=18" }
+                },
+                "node_modules/react": { "version": "19.2.0", "peer": true }
+            }
+        }"#;
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let graph = parse(tmp.path()).unwrap();
+    let root = graph.importers.get(".").expect("root importer");
+    assert_eq!(root.len(), 1);
+    assert_eq!(root[0].name, "react");
+    assert_eq!(root[0].specifier.as_deref(), Some(">=18"));
+    assert_eq!(root[0].dep_type, DepType::Production);
+}
+
+/// A member nested inside another member resolves through the parent
+/// member's own `node_modules` before the root, the way Node's upward
+/// walk does from `test/installation/`. puppeteer's lockfile keeps
+/// `diff@9` at `test/node_modules/diff` for both `test` and
+/// `test/installation`; jumping from the member straight to the root
+/// found the wrong copy (or none) and the frozen check refused the file.
+#[test]
+fn test_parse_npm_nested_member_resolves_through_parent_members_node_modules() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+            "name": "root",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "root",
+                    "version": "1.0.0",
+                    "workspaces": ["test", "test/installation"]
+                },
+                "node_modules/@t/test": { "resolved": "test", "link": true },
+                "node_modules/@t/installation": { "resolved": "test/installation", "link": true },
+                "node_modules/diff": { "version": "7.0.0" },
+                "node_modules/glob": { "version": "13.0.6" },
+                "test": {
+                    "name": "@t/test",
+                    "version": "1.0.0",
+                    "dependencies": { "diff": "9.0.0" }
+                },
+                "test/node_modules/diff": { "version": "9.0.0" },
+                "test/installation": {
+                    "name": "@t/installation",
+                    "version": "1.0.0",
+                    "dependencies": { "diff": "^9.0.0" },
+                    "devDependencies": { "glob": "13.0.6" }
+                }
+            }
+        }"#;
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let graph = parse(tmp.path()).unwrap();
+    let installation = graph
+        .importers
+        .get("test/installation")
+        .expect("nested member importer");
+    let diff = installation.iter().find(|d| d.name == "diff").unwrap();
+    assert_eq!(
+        graph.packages[&diff.dep_path].version, "9.0.0",
+        "the parent member's copy wins over the root's"
+    );
+    let glob = installation.iter().find(|d| d.name == "glob").unwrap();
+    assert_eq!(
+        graph.packages[&glob.dep_path].version, "13.0.6",
+        "a dep absent from every ancestor still falls back to the root"
+    );
+}
+
+/// npm writes no `version` on a local package whose manifest has none.
+/// mocha links a test fixture that way (`file:test/compiler-fixtures/...`
+/// with a name-only package.json). The reader takes the resolver's own
+/// `0.0.0` default rather than refusing the lockfile.
+#[test]
+fn test_parse_npm_link_target_without_version() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+            "name": "mocha",
+            "version": "11.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "mocha",
+                    "version": "11.0.0",
+                    "devDependencies": { "@test/esm-only-loader": "./test/fixtures/esm-only-loader" }
+                },
+                "node_modules/@test/esm-only-loader": {
+                    "resolved": "test/fixtures/esm-only-loader",
+                    "link": true
+                },
+                "test/fixtures/esm-only-loader": { "name": "@test/esm-only-loader", "dev": true }
+            }
+        }"#;
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let graph = parse(tmp.path()).unwrap();
+    let root = graph.importers.get(".").expect("root importer");
+    assert_eq!(root.len(), 1);
+    assert_eq!(root[0].name, "@test/esm-only-loader");
+    assert_eq!(root[0].dep_type, DepType::Dev);
+    let pkg = &graph.packages[&root[0].dep_path];
+    assert_eq!(pkg.version, "0.0.0");
+    assert!(matches!(
+        pkg.local_source,
+        Some(LocalSource::Link(ref p)) if p == Path::new("test/fixtures/esm-only-loader")
+    ));
+}
+
+/// A package listed under two manifest sections is one importer row,
+/// classified by the resolver's section priority. promptfoo declares
+/// `@anthropic-ai/claude-agent-sdk` as both a dev and an optional dep;
+/// npm mirrors both onto the root entry, and a second `Optional` row
+/// tripped the section-drift check on every frozen install.
+#[test]
+fn test_parse_npm_dep_in_two_sections_is_one_importer_row() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+            "name": "root",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "root",
+                    "version": "1.0.0",
+                    "workspaces": ["packages/*"],
+                    "devDependencies": { "sdk": "0.3.250" },
+                    "optionalDependencies": { "sdk": "0.3.250" }
+                },
+                "node_modules/@scope/app": { "resolved": "packages/app", "link": true },
+                "node_modules/sdk": { "version": "0.3.250", "devOptional": true },
+                "packages/app": {
+                    "name": "@scope/app",
+                    "version": "1.0.0",
+                    "dependencies": { "sdk": "0.3.250" },
+                    "optionalDependencies": { "sdk": "0.3.250" }
+                }
+            }
+        }"#;
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let graph = parse(tmp.path()).unwrap();
+    let root: Vec<_> = graph.importers[&".".to_string()]
+        .iter()
+        .filter(|d| d.name == "sdk")
+        .collect();
+    assert_eq!(root.len(), 1, "one row for the root, not one per section");
+    assert_eq!(root[0].dep_type, DepType::Dev);
+    let app: Vec<_> = graph.importers["packages/app"]
+        .iter()
+        .filter(|d| d.name == "sdk")
+        .collect();
+    assert_eq!(app.len(), 1, "one row for the member, not one per section");
+    assert_eq!(app[0].dep_type, DepType::Production);
+}

--- a/vendor/aube/crates/aube-scripts/src/lib.rs
+++ b/vendor/aube/crates/aube-scripts/src/lib.rs
@@ -1532,14 +1532,15 @@ pub async fn run_root_hook(
 }
 
 /// Run a lifecycle hook of a WORKSPACE MEMBER. Spawns in `member_dir` with
-/// the member's own manifest, and puts every `<modules_dir>/.bin` from the
-/// member up to `workspace_root` on `PATH`, closest first — the walk npm's
-/// run-script does for a workspace script (`run_script` appends the root's
-/// own `.bin` after these). A member's script routinely reaches for a bin
-/// that only the root declares: puppeteer's `tools/eslint` runs `wireit`,
-/// a root devDependency, from its `prepare`. With only the member's own
-/// `.bin` on `PATH` that was a 127 on every install. For the root importer
-/// itself the chain is empty and this is [`run_root_hook`] plus `tool_dirs`.
+/// the member's own manifest, and puts the `<modules_dir>/.bin` of the
+/// member and of every ancestor directory on `PATH`, closest first — the
+/// walk npm's run-script does for any script (`set-path.js` goes all the way
+/// to the filesystem root, so a bin provided above the workspace root
+/// counts too). A member's script routinely reaches for a bin that only the
+/// root declares: puppeteer's `tools/eslint` runs `wireit`, a root
+/// devDependency, from its `prepare`. With only the member's own `.bin` on
+/// `PATH` that was a 127 on every install. `run_script` appends the root's
+/// own `.bin` after the chain; that duplicate is inert.
 ///
 /// `tool_dirs` go on `PATH` after the chain and before the root's `.bin`:
 /// the embedder's lazy `node-gyp` shim above all, which npm provides to
@@ -1561,7 +1562,7 @@ pub async fn run_member_hook(
     let Some(script_cmd) = manifest.scripts.get(name) else {
         return Ok(false);
     };
-    let chain = member_bin_chain(member_dir, workspace_root, modules_dir_name);
+    let chain = member_bin_chain(member_dir, modules_dir_name);
     let extra: Vec<&Path> = chain
         .iter()
         .map(PathBuf::as_path)
@@ -1581,27 +1582,16 @@ pub async fn run_member_hook(
     Ok(true)
 }
 
-/// The `.bin` directories a workspace member's script sees before the
-/// root's: `<dir>/<modules_dir>/.bin` for the member's directory and each
-/// ancestor below `workspace_root`, closest first. Mirrors npm, whose
-/// run-script walks every ancestor of the script's directory; a member
-/// outside the root (a `../sibling` importer) walks to the filesystem root
-/// the same way npm does.
-fn member_bin_chain(
-    member_dir: &Path,
-    workspace_root: &Path,
-    modules_dir_name: &str,
-) -> Vec<PathBuf> {
-    let mut chain = Vec::new();
-    let mut cursor = Some(member_dir);
-    while let Some(dir) = cursor {
-        if dir == workspace_root {
-            break;
-        }
-        chain.push(dir.join(modules_dir_name).join(".bin"));
-        cursor = dir.parent();
-    }
-    chain
+/// The `.bin` directories a workspace member's script sees:
+/// `<dir>/<modules_dir>/.bin` for the member's directory and every
+/// ancestor up to the filesystem root, closest first. Exactly npm's walk
+/// (`@npmcli/run-script` `set-path.js`), so a bin an enclosing project
+/// provides above the workspace root resolves here as it does there.
+fn member_bin_chain(member_dir: &Path, modules_dir_name: &str) -> Vec<PathBuf> {
+    member_dir
+        .ancestors()
+        .map(|dir| dir.join(modules_dir_name).join(".bin"))
+        .collect()
 }
 
 /// Run a named root-package script if it's defined. Used by commands
@@ -2725,21 +2715,18 @@ mod member_bin_chain_tests {
     use std::path::{Path, PathBuf};
 
     /// A nested member (`test/installation`) sees its own `.bin`, then its
-    /// parent member's, closest first; the root's is appended by `run_script`.
-    /// The root importer itself contributes nothing.
+    /// parent member's, then the root's, then anything above — closest
+    /// first, out to the filesystem root, as npm walks it.
     #[test]
-    fn member_bin_chain_walks_every_ancestor_below_the_root_closest_first() {
-        let root = Path::new("/p");
+    fn member_bin_chain_walks_every_ancestor_to_the_filesystem_root_closest_first() {
         assert_eq!(
-            member_bin_chain(Path::new("/p/test/installation"), root, "node_modules"),
+            member_bin_chain(Path::new("/p/test/installation"), "node_modules"),
             vec![
                 PathBuf::from("/p/test/installation/node_modules/.bin"),
                 PathBuf::from("/p/test/node_modules/.bin"),
+                PathBuf::from("/p/node_modules/.bin"),
+                PathBuf::from("/node_modules/.bin"),
             ]
-        );
-        assert_eq!(
-            member_bin_chain(root, root, "node_modules"),
-            Vec::<PathBuf>::new()
         );
     }
 }

--- a/vendor/aube/crates/aube-scripts/src/lib.rs
+++ b/vendor/aube/crates/aube-scripts/src/lib.rs
@@ -1531,6 +1531,68 @@ pub async fn run_root_hook(
     run_root_script_by_name(project_dir, modules_dir_name, manifest, hook.script_name()).await
 }
 
+/// Run a lifecycle hook of a WORKSPACE MEMBER. Spawns in `member_dir` with
+/// the member's own manifest, and puts every `<modules_dir>/.bin` from the
+/// member up to `workspace_root` on `PATH`, closest first — the walk npm's
+/// run-script does for a workspace script (`run_script` appends the root's
+/// own `.bin` after these). A member's script routinely reaches for a bin
+/// that only the root declares: puppeteer's `tools/eslint` runs `wireit`,
+/// a root devDependency, from its `prepare`. With only the member's own
+/// `.bin` on `PATH` that was a 127 on every install. For the root importer
+/// itself the chain is empty and this is [`run_root_hook`].
+///
+/// Returns `Ok(false)` if the script isn't defined. The caller gates on
+/// `--ignore-scripts`.
+pub async fn run_member_hook(
+    member_dir: &Path,
+    workspace_root: &Path,
+    modules_dir_name: &str,
+    manifest: &PackageJson,
+    hook: LifecycleHook,
+) -> Result<bool, Error> {
+    let name = hook.script_name();
+    let Some(script_cmd) = manifest.scripts.get(name) else {
+        return Ok(false);
+    };
+    let chain = member_bin_chain(member_dir, workspace_root, modules_dir_name);
+    let extra: Vec<&Path> = chain.iter().map(PathBuf::as_path).collect();
+    run_script(
+        member_dir,
+        workspace_root,
+        modules_dir_name,
+        manifest,
+        name,
+        script_cmd,
+        &extra,
+        None,
+    )
+    .await?;
+    Ok(true)
+}
+
+/// The `.bin` directories a workspace member's script sees before the
+/// root's: `<dir>/<modules_dir>/.bin` for the member's directory and each
+/// ancestor below `workspace_root`, closest first. Mirrors npm, whose
+/// run-script walks every ancestor of the script's directory; a member
+/// outside the root (a `../sibling` importer) walks to the filesystem root
+/// the same way npm does.
+fn member_bin_chain(
+    member_dir: &Path,
+    workspace_root: &Path,
+    modules_dir_name: &str,
+) -> Vec<PathBuf> {
+    let mut chain = Vec::new();
+    let mut cursor = Some(member_dir);
+    while let Some(dir) = cursor {
+        if dir == workspace_root {
+            break;
+        }
+        chain.push(dir.join(modules_dir_name).join(".bin"));
+        cursor = dir.parent();
+    }
+    chain
+}
+
 /// Run a named root-package script if it's defined. Used by commands
 /// (pack, publish, version) that need to run lifecycle hooks outside
 /// the install-focused [`LifecycleHook`] enum. Returns `Ok(false)` if
@@ -2643,6 +2705,31 @@ mod break_cas_hardlinks_tests {
             std::path::Path::new("real.txt")
         );
         let _ = std::fs::remove_dir_all(&root);
+    }
+}
+
+#[cfg(test)]
+mod member_bin_chain_tests {
+    use super::member_bin_chain;
+    use std::path::{Path, PathBuf};
+
+    /// A nested member (`test/installation`) sees its own `.bin`, then its
+    /// parent member's, closest first; the root's is appended by `run_script`.
+    /// The root importer itself contributes nothing.
+    #[test]
+    fn member_bin_chain_walks_every_ancestor_below_the_root_closest_first() {
+        let root = Path::new("/p");
+        assert_eq!(
+            member_bin_chain(Path::new("/p/test/installation"), root, "node_modules"),
+            vec![
+                PathBuf::from("/p/test/installation/node_modules/.bin"),
+                PathBuf::from("/p/test/node_modules/.bin"),
+            ]
+        );
+        assert_eq!(
+            member_bin_chain(root, root, "node_modules"),
+            Vec::<PathBuf>::new()
+        );
     }
 }
 

--- a/vendor/aube/crates/aube-scripts/src/lib.rs
+++ b/vendor/aube/crates/aube-scripts/src/lib.rs
@@ -1539,7 +1539,13 @@ pub async fn run_root_hook(
 /// that only the root declares: puppeteer's `tools/eslint` runs `wireit`,
 /// a root devDependency, from its `prepare`. With only the member's own
 /// `.bin` on `PATH` that was a 127 on every install. For the root importer
-/// itself the chain is empty and this is [`run_root_hook`].
+/// itself the chain is empty and this is [`run_root_hook`] plus `tool_dirs`.
+///
+/// `tool_dirs` go on `PATH` after the chain and before the root's `.bin`:
+/// the embedder's lazy `node-gyp` shim above all, which npm provides to
+/// every lifecycle script from its own bundled copy (`node-gyp-bin`). A
+/// root `preinstall` that runs `node-gyp install` (theia) runs before any
+/// dependency exists, so nothing but such a shim can satisfy it.
 ///
 /// Returns `Ok(false)` if the script isn't defined. The caller gates on
 /// `--ignore-scripts`.
@@ -1549,13 +1555,18 @@ pub async fn run_member_hook(
     modules_dir_name: &str,
     manifest: &PackageJson,
     hook: LifecycleHook,
+    tool_dirs: &[&Path],
 ) -> Result<bool, Error> {
     let name = hook.script_name();
     let Some(script_cmd) = manifest.scripts.get(name) else {
         return Ok(false);
     };
     let chain = member_bin_chain(member_dir, workspace_root, modules_dir_name);
-    let extra: Vec<&Path> = chain.iter().map(PathBuf::as_path).collect();
+    let extra: Vec<&Path> = chain
+        .iter()
+        .map(PathBuf::as_path)
+        .chain(tool_dirs.iter().copied())
+        .collect();
     run_script(
         member_dir,
         workspace_root,

--- a/vendor/aube/crates/aube-store/src/integrity.rs
+++ b/vendor/aube/crates/aube-store/src/integrity.rs
@@ -369,7 +369,10 @@ pub fn validate_pkg_content(
 /// directory by integrity prefix. Returns `None` if the input isn't a
 /// well-formed SRI integrity string.
 pub fn integrity_to_hex(integrity: &str) -> Option<String> {
-    let (_, b64) = parse_sri(integrity)?;
+    // The first digest of the strongest algorithm names the entry; the
+    // verifiers accept any of them, but a cache path needs one answer.
+    let (_, digests) = parse_sri(integrity)?;
+    let b64 = digests.first()?;
     use base64::Engine;
     let bytes = base64::engine::general_purpose::STANDARD.decode(b64).ok()?;
     Some(hex::encode(bytes))

--- a/vendor/aube/crates/aube-store/src/integrity.rs
+++ b/vendor/aube/crates/aube-store/src/integrity.rs
@@ -39,21 +39,26 @@ impl IntegrityAlgo {
     }
 }
 
-/// Pick the hash to check from an SRI string. The value may carry
-/// several space-separated hashes — the W3C SRI grammar allows it and
-/// npm writes it: a package-lock.json entry can read
-/// `"integrity": "sha1-… sha512-…"` (Kong/grpc-reflection-js pins
+/// The digests to check from an SRI string: every candidate carrying the
+/// strongest algorithm the store supports, with any `?option` suffix
+/// stripped. The value may carry several space-separated hashes — the W3C
+/// SRI grammar allows it and npm writes it: a package-lock.json entry can
+/// read `"integrity": "sha1-… sha512-…"` (Kong/grpc-reflection-js pins
 /// `@types/minimist@1.2.0` that way, and a git dependency's nested
 /// `prepare` install feeds that lockfile straight here). ssri's rule is
-/// to verify against the strongest algorithm the client supports, so
-/// take that one; `SRI_PREFIXES` is already ordered strongest first.
-/// Reading the whole value as one token made every such entry an
-/// `integrity mismatch`.
-fn parse_sri(expected: &str) -> Option<(IntegrityAlgo, &str)> {
+/// to verify against the strongest algorithm the client supports and to
+/// accept when ANY digest of that algorithm matches, so every candidate
+/// of the chosen algorithm comes back; `SRI_PREFIXES` is already ordered
+/// strongest first. Reading the whole value as one token made every such
+/// entry an `integrity mismatch`.
+fn parse_sri(expected: &str) -> Option<(IntegrityAlgo, Vec<&str>)> {
     SRI_PREFIXES.iter().find_map(|(prefix, algo)| {
-        expected
+        let digests: Vec<&str> = expected
             .split_ascii_whitespace()
-            .find_map(|token| token.strip_prefix(prefix).map(|rest| (*algo, rest)))
+            .filter_map(|token| token.strip_prefix(prefix))
+            .map(|rest| rest.split('?').next().unwrap_or(rest))
+            .collect();
+        (!digests.is_empty()).then_some((*algo, digests))
     })
 }
 
@@ -145,7 +150,7 @@ pub fn validate_version(version: &str) -> bool {
 /// — the set npm and pnpm accept in `dist.integrity`. Returns `Ok(())`
 /// on match, `Err(Error::Integrity)` on mismatch or unknown algorithm.
 pub fn verify_integrity(data: &[u8], expected: &str) -> Result<(), Error> {
-    let Some((algo, expected_b64)) = parse_sri(expected) else {
+    let Some((algo, expected_digests)) = parse_sri(expected) else {
         return Err(Error::Integrity(format!(
             "unsupported integrity format (expected sha1/sha256/sha384/sha512-...): {expected}"
         )));
@@ -185,11 +190,13 @@ pub fn verify_integrity(data: &[u8], expected: &str) -> Result<(), Error> {
 
     use base64::Engine;
     let engine = base64::engine::general_purpose::STANDARD;
-    let mut expected_digest = [0u8; 64];
-    let matched = engine
-        .decode_slice(expected_b64, &mut expected_digest)
-        .map(|n| n == actual_len && expected_digest[..n] == actual[..])
-        .unwrap_or(false);
+    let matched = expected_digests.iter().any(|expected_b64| {
+        let mut expected_digest = [0u8; 64];
+        engine
+            .decode_slice(expected_b64, &mut expected_digest)
+            .map(|n| n == actual_len && expected_digest[..n] == actual[..])
+            .unwrap_or(false)
+    });
     if matched {
         Ok(())
     } else {
@@ -237,7 +244,7 @@ pub fn sha512_integrity_from_digest(digest: &[u8; 64]) -> String {
 /// re-hashes with the right algo. Returns `Err` on parse failure
 /// or SHA-512 mismatch.
 pub fn verify_precomputed_sha512(actual: &[u8; 64], expected: &str) -> Result<bool, Error> {
-    let Some((algo, expected_b64)) = parse_sri(expected) else {
+    let Some((algo, expected_digests)) = parse_sri(expected) else {
         return Err(Error::Integrity(format!(
             "unsupported integrity format (expected sha1/sha256/sha384/sha512-...): {expected}"
         )));
@@ -247,28 +254,29 @@ pub fn verify_precomputed_sha512(actual: &[u8; 64], expected: &str) -> Result<bo
     }
     use base64::Engine;
     let engine = base64::engine::general_purpose::STANDARD;
-    let mut expected_digest = [0u8; 64];
-    let decoded_len = match engine.decode_slice(expected_b64, &mut expected_digest) {
-        Ok(n) => n,
-        Err(e) => {
+    for expected_b64 in expected_digests {
+        let mut expected_digest = [0u8; 64];
+        let decoded_len = match engine.decode_slice(expected_b64, &mut expected_digest) {
+            Ok(n) => n,
+            Err(e) => {
+                return Err(Error::Integrity(format!(
+                    "integrity field has malformed base64: {expected} ({e})"
+                )));
+            }
+        };
+        if decoded_len != 64 {
             return Err(Error::Integrity(format!(
-                "integrity field has malformed base64: {expected} ({e})"
+                "integrity field decoded to {decoded_len} bytes, expected 64 for sha512: {expected}"
             )));
         }
-    };
-    if decoded_len != 64 {
-        return Err(Error::Integrity(format!(
-            "integrity field decoded to {decoded_len} bytes, expected 64 for sha512: {expected}"
-        )));
+        if expected_digest[..decoded_len] == actual[..] {
+            return Ok(true);
+        }
     }
-    if expected_digest[..decoded_len] == actual[..] {
-        Ok(true)
-    } else {
-        let actual_b64 = engine.encode(actual);
-        Err(Error::Integrity(format!(
-            "integrity mismatch: expected {expected}, got sha512-{actual_b64}",
-        )))
-    }
+    let actual_b64 = engine.encode(actual);
+    Err(Error::Integrity(format!(
+        "integrity mismatch: expected {expected}, got sha512-{actual_b64}",
+    )))
 }
 
 /// Cross-check that an extracted tarball's `package.json` reports the
@@ -415,13 +423,29 @@ mod tests {
         // beside a right sha1 is a mismatch, not a pass on the weak one.
         let wrong = sha512_integrity(b"other");
         assert!(verify_integrity(data, &format!("{sha1} {wrong}")).is_err());
-        // The streaming path sees the same value.
+        // Several digests of the strongest algorithm: any match accepts,
+        // whichever position the right one sits in — ssri's rule.
+        assert!(verify_integrity(data, &format!("{wrong} {sha512}")).is_ok());
+        assert!(verify_integrity(data, &format!("{sha512} {wrong}")).is_ok());
+        assert!(verify_integrity(data, &format!("{wrong} {wrong}")).is_err());
+        // An SRI option suffix (`?name=value`) is not part of the digest.
+        assert!(verify_integrity(data, &format!("{sha512}?foo=bar")).is_ok());
+        assert!(verify_integrity(data, &format!("{sha1} {sha512}?x")).is_ok());
+        // The streaming path sees the same values.
         let mut digest = [0u8; 64];
         digest.copy_from_slice(&Sha512::digest(data));
-        assert_eq!(
-            verify_precomputed_sha512(&digest, &format!("{sha1} {sha512}")).unwrap(),
-            true
-        );
+        for value in [
+            format!("{sha1} {sha512}"),
+            format!("{wrong} {sha512}"),
+            format!("{sha512}?foo=bar"),
+        ] {
+            assert!(
+                verify_precomputed_sha512(&digest, &value).unwrap(),
+                "{value}"
+            );
+        }
+        assert!(verify_precomputed_sha512(&digest, &format!("{wrong} {wrong}")).is_err());
+        assert!(!verify_precomputed_sha512(&digest, &sha1).unwrap());
     }
 
     #[test]

--- a/vendor/aube/crates/aube-store/src/integrity.rs
+++ b/vendor/aube/crates/aube-store/src/integrity.rs
@@ -39,10 +39,22 @@ impl IntegrityAlgo {
     }
 }
 
+/// Pick the hash to check from an SRI string. The value may carry
+/// several space-separated hashes — the W3C SRI grammar allows it and
+/// npm writes it: a package-lock.json entry can read
+/// `"integrity": "sha1-… sha512-…"` (Kong/grpc-reflection-js pins
+/// `@types/minimist@1.2.0` that way, and a git dependency's nested
+/// `prepare` install feeds that lockfile straight here). ssri's rule is
+/// to verify against the strongest algorithm the client supports, so
+/// take that one; `SRI_PREFIXES` is already ordered strongest first.
+/// Reading the whole value as one token made every such entry an
+/// `integrity mismatch`.
 fn parse_sri(expected: &str) -> Option<(IntegrityAlgo, &str)> {
-    SRI_PREFIXES
-        .iter()
-        .find_map(|(prefix, algo)| expected.strip_prefix(prefix).map(|rest| (*algo, rest)))
+    SRI_PREFIXES.iter().find_map(|(prefix, algo)| {
+        expected
+            .split_ascii_whitespace()
+            .find_map(|token| token.strip_prefix(prefix).map(|rest| (*algo, rest)))
+    })
 }
 
 /// Validate a package name and return the `safe_name` form used as a
@@ -382,6 +394,35 @@ pub fn shasum_to_sri(shasum: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A multi-hash SRI value verifies against its strongest supported
+    /// hash, whichever position it sits in, and a legacy-only value
+    /// still verifies. npm's own lockfiles carry the `sha1-… sha512-…`
+    /// shape.
+    #[test]
+    fn multi_hash_sri_verifies_the_strongest_hash() {
+        let data = b"hello world";
+        let sha512 = sha512_integrity(data);
+        use base64::Engine;
+        let sha1 = format!(
+            "sha1-{}",
+            base64::engine::general_purpose::STANDARD.encode(Sha1::digest(data))
+        );
+        assert!(verify_integrity(data, &format!("{sha1} {sha512}")).is_ok());
+        assert!(verify_integrity(data, &format!("{sha512} {sha1}")).is_ok());
+        assert!(verify_integrity(data, &sha1).is_ok());
+        // The strongest hash is the one that counts: a wrong sha512
+        // beside a right sha1 is a mismatch, not a pass on the weak one.
+        let wrong = sha512_integrity(b"other");
+        assert!(verify_integrity(data, &format!("{sha1} {wrong}")).is_err());
+        // The streaming path sees the same value.
+        let mut digest = [0u8; 64];
+        digest.copy_from_slice(&Sha512::digest(data));
+        assert_eq!(
+            verify_precomputed_sha512(&digest, &format!("{sha1} {sha512}")).unwrap(),
+            true
+        );
+    }
 
     #[test]
     fn shasum_to_sri_matches_npm_classic_encoding() {

--- a/vendor/aube/crates/aube-store/src/integrity.rs
+++ b/vendor/aube/crates/aube-store/src/integrity.rs
@@ -254,29 +254,35 @@ pub fn verify_precomputed_sha512(actual: &[u8; 64], expected: &str) -> Result<bo
     }
     use base64::Engine;
     let engine = base64::engine::general_purpose::STANDARD;
+    // A candidate that does not decode to a sha512 digest cannot match; it
+    // is skipped rather than fatal so a valid sibling digest still counts
+    // (the buffered path treats it the same way). Its reason is kept for
+    // the error when nothing matches.
+    let mut malformed = None;
     for expected_b64 in expected_digests {
         let mut expected_digest = [0u8; 64];
-        let decoded_len = match engine.decode_slice(expected_b64, &mut expected_digest) {
-            Ok(n) => n,
-            Err(e) => {
-                return Err(Error::Integrity(format!(
-                    "integrity field has malformed base64: {expected} ({e})"
-                )));
+        match engine.decode_slice(expected_b64, &mut expected_digest) {
+            Ok(64) => {
+                if expected_digest[..] == actual[..] {
+                    return Ok(true);
+                }
             }
-        };
-        if decoded_len != 64 {
-            return Err(Error::Integrity(format!(
-                "integrity field decoded to {decoded_len} bytes, expected 64 for sha512: {expected}"
-            )));
-        }
-        if expected_digest[..decoded_len] == actual[..] {
-            return Ok(true);
+            Ok(decoded_len) => {
+                malformed.get_or_insert(format!(
+                    "integrity field decoded to {decoded_len} bytes, expected 64 for sha512: {expected}"
+                ));
+            }
+            Err(e) => {
+                malformed.get_or_insert(format!(
+                    "integrity field has malformed base64: {expected} ({e})"
+                ));
+            }
         }
     }
     let actual_b64 = engine.encode(actual);
-    Err(Error::Integrity(format!(
-        "integrity mismatch: expected {expected}, got sha512-{actual_b64}",
-    )))
+    Err(Error::Integrity(malformed.unwrap_or_else(|| {
+        format!("integrity mismatch: expected {expected}, got sha512-{actual_b64}")
+    })))
 }
 
 /// Cross-check that an extracted tarball's `package.json` reports the
@@ -449,6 +455,11 @@ mod tests {
         }
         assert!(verify_precomputed_sha512(&digest, &format!("{wrong} {wrong}")).is_err());
         assert!(!verify_precomputed_sha512(&digest, &sha1).unwrap());
+        // A candidate that is not a digest at all does not veto a valid
+        // sibling on either path, and is the error when nothing matches.
+        assert!(verify_integrity(data, &format!("sha512-!!! {sha512}")).is_ok());
+        assert!(verify_precomputed_sha512(&digest, &format!("sha512-!!! {sha512}")).unwrap());
+        assert!(verify_precomputed_sha512(&digest, "sha512-!!!").is_err());
     }
 
     #[test]

--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -4,7 +4,7 @@ use super::bin_linking::{
 };
 use super::dep_selection::DepSelection;
 use super::lifecycle::{
-    JailBuildPolicy, run_dep_lifecycle_scripts, run_root_lifecycle, unreviewed_dep_builds,
+    JailBuildPolicy, run_dep_lifecycle_scripts, run_importer_lifecycle, unreviewed_dep_builds,
 };
 use super::side_effects_cache::{
     SideEffectsCacheConfig, SideEffectsCacheLocation, side_effects_cache_root,
@@ -455,7 +455,15 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
                 aube_scripts::LifecycleHook::PostInstall,
                 aube_scripts::LifecycleHook::Prepare,
             ] {
-                run_root_lifecycle(&project_dir, modules_dir_name, importer_manifest, hook).await?;
+                run_importer_lifecycle(
+                    cwd,
+                    &project_dir,
+                    importer_path,
+                    modules_dir_name,
+                    importer_manifest,
+                    hook,
+                )
+                .await?;
             }
         }
         phase_timings.record("root_lifecycle", phase_start.elapsed());

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -6,23 +6,14 @@ use super::side_effects_cache::{
     SideEffectsCacheConfig, SideEffectsCacheEntry, SideEffectsCacheRestore,
 };
 
-/// Run a root-package lifecycle hook, announcing it to the user if defined
-/// and turning aube_scripts::Error into a miette::Report with context.
-/// Silent when the hook isn't defined in package.json.
-pub(super) async fn run_root_lifecycle(
-    project_dir: &std::path::Path,
-    modules_dir_name: &str,
-    manifest: &aube_manifest::PackageJson,
-    hook: aube_scripts::LifecycleHook,
-) -> miette::Result<()> {
-    run_root_lifecycle_script(project_dir, modules_dir_name, manifest, hook.script_name()).await
-}
-
-/// Run a post-link lifecycle hook of one importer — the root or a workspace
-/// member — with the member's `.bin` chain up to the workspace root on
-/// `PATH` (see [`aube_scripts::run_member_hook`]). Silent when the hook
-/// isn't defined; the failure names the importer, since "root" was what a
-/// member's failing `prepare` used to be reported as.
+/// Run a lifecycle hook of one importer — the root or a workspace member —
+/// with the member's `.bin` chain up to the workspace root on `PATH`, plus
+/// the lazy `node-gyp` shim when neither the project nor the ambient `PATH`
+/// has one (see [`aube_scripts::run_member_hook`]; the shim is the same one
+/// dependency builds get, and stays out of the way when a real node-gyp
+/// resolves). Silent when the hook isn't defined; the failure names the
+/// importer, since "root" was what a member's failing `prepare` used to be
+/// reported as.
 pub(super) async fn run_importer_lifecycle(
     workspace_root: &std::path::Path,
     importer_dir: &std::path::Path,
@@ -41,12 +32,16 @@ pub(super) async fn run_importer_lifecycle(
         importer_path
     };
     tracing::debug!("Running {label} {script_name} script...");
+    let project_bin_dir = workspace_root.join(modules_dir_name).join(".bin");
+    let node_gyp_bin_dir = node_gyp_bootstrap::lazy_shim_bin_dir(&project_bin_dir)?;
+    let tool_dirs: Vec<&std::path::Path> = node_gyp_bin_dir.iter().map(|d| d.as_path()).collect();
     aube_scripts::run_member_hook(
         importer_dir,
         workspace_root,
         modules_dir_name,
         manifest,
         hook,
+        &tool_dirs,
     )
     .await
     .map_err(|e| miette!("{label} {script_name} script failed: {e}"))?;

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -18,6 +18,41 @@ pub(super) async fn run_root_lifecycle(
     run_root_lifecycle_script(project_dir, modules_dir_name, manifest, hook.script_name()).await
 }
 
+/// Run a post-link lifecycle hook of one importer — the root or a workspace
+/// member — with the member's `.bin` chain up to the workspace root on
+/// `PATH` (see [`aube_scripts::run_member_hook`]). Silent when the hook
+/// isn't defined; the failure names the importer, since "root" was what a
+/// member's failing `prepare` used to be reported as.
+pub(super) async fn run_importer_lifecycle(
+    workspace_root: &std::path::Path,
+    importer_dir: &std::path::Path,
+    importer_path: &str,
+    modules_dir_name: &str,
+    manifest: &aube_manifest::PackageJson,
+    hook: aube_scripts::LifecycleHook,
+) -> miette::Result<()> {
+    let script_name = hook.script_name();
+    if !manifest.scripts.contains_key(script_name) {
+        return Ok(());
+    }
+    let label = if importer_path == "." {
+        "root"
+    } else {
+        importer_path
+    };
+    tracing::debug!("Running {label} {script_name} script...");
+    aube_scripts::run_member_hook(
+        importer_dir,
+        workspace_root,
+        modules_dir_name,
+        manifest,
+        hook,
+    )
+    .await
+    .map_err(|e| miette!("{label} {script_name} script failed: {e}"))?;
+    Ok(())
+}
+
 /// Run a named root-package lifecycle script.
 ///
 /// Most install hooks use [`aube_scripts::LifecycleHook`], but pnpm's

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -64,8 +64,8 @@ pub(crate) use lifecycle::{
     run_dep_lifecycle_scripts,
 };
 use lifecycle::{
-    resolve_link_strategy, run_import_on_blocking, run_root_lifecycle, run_root_lifecycle_script,
-    validate_required_scripts,
+    resolve_link_strategy, run_import_on_blocking, run_importer_lifecycle,
+    run_root_lifecycle_script, validate_required_scripts,
 };
 
 pub(crate) fn resolve_active_lockfile_dir(
@@ -887,8 +887,10 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         let phase_start = std::time::Instant::now();
         for (importer_path, importer_manifest) in &lifecycle_manifests {
             let project_dir = importer_project_dir(&cwd, importer_path);
-            run_root_lifecycle(
+            run_importer_lifecycle(
+                &cwd,
                 &project_dir,
+                importer_path,
                 &modules_dir_name,
                 importer_manifest,
                 aube_scripts::LifecycleHook::PreInstall,


### PR DESCRIPTION
Eight refusals of npm-written lockfiles and projects, found by frozen-installing the most popular npm-using repos on GitHub. All are green under `npm ci` in the repos' own CI.

- A workspace member's required peer was not recorded on its importer, so the freshness check read every member with a peer as `manifest adds <peer>@<range>` (apollo-server, socket.io). The reader now records required peers the way the resolver seeds them under `auto_install_peers`.
- A member nested inside another member (`test/installation`) never looked in the parent member's own `node_modules`, jumping straight to the root (puppeteer). `resolve_nested` walks directory ancestors for a member target.
- A link target with no `version` failed to parse; npm writes none for a name-only local package (mocha, lerna, lit). The reader takes the resolver's own `0.0.0` default.
- A package listed under two manifest sections produced two importer rows and tripped the section check (promptfoo, theia). One row per name, first section wins.
- A space-separated multi-hash SRI value (`sha1-… sha512-…`) was read as one token and failed integrity verification (a git dependency's nested `prepare` install in insomnia). `parse_sri` picks the strongest supported algorithm and accepts any of its digests, with `?option` suffixes ignored, as ssri does.
- A workspace member's `install`/`postinstall`/`prepare` ran with only the member's own `node_modules/.bin` on PATH, so a bin that only the root declares was a 127 (puppeteer's `tools/eslint` runs `wireit` from its `prepare`), reported as `root prepare script failed`. `run_member_hook` walks every ancestor `.bin` out to the filesystem root, as npm's run-script does, and the failure names the member.
- A root `preinstall` that runs `node-gyp install` (theia) found no node-gyp on PATH, which npm provides to every lifecycle script from its bundled copy. Importer hooks now get the same lazy node-gyp shim dependency builds already got; it stays out of the way when a project or system node-gyp resolves.
- `nub install` refused to start when the project's tsconfig extends a package the install is about to provide (ava). The PM verbs build their lifecycle options with a best-effort tsconfig gate; runs that execute user code keep the fatal gate from #731.

Each fix has a test beside the code (`aube-lockfile` npm reader, `aube-store` integrity, `aube-scripts` bin chain, `nub-cli` `install_engine`). Verified on a builder VM: the reader tests go red on the merge-base reader, and `nub install --frozen-lockfile` now succeeds on the real lockfiles of mocha, socket.io, apollo-server, promptfoo, lerna, lit, theia, puppeteer and ava.
