### PR TITLE
runtime: let a user hook layered above nub's keep ownership of its files

### DIFF
--- a/crates/nub-cli/tests/integration.rs
+++ b/crates/nub-cli/tests/integration.rs
@@ -1956,6 +1956,19 @@ fn esm_source_reuse_preserves_loaded_bytes_and_module_identity() {
 }
 
 #[test]
+fn user_hooks_layered_above_nubs_keep_ownership_of_their_files() {
+    // tsx under `nub run` is the case in the wild. The fixture's hooks model it
+    // on whichever tier this Node runs: an outer load hook keys on the
+    // `responseURL` nub's transpiled result carries; an outer resolve hook that
+    // assigns a `.ts` file a bare `commonjs` format gets the raw source back to
+    // transform itself; and a `require.extensions` handler installed before nub's
+    // compat-tier preload stays in charge of its extension.
+    let (stdout, stderr, code) = run_nub("loader-outer-hook", "main.mjs");
+    assert_eq!(code, 0, "outer-hook contract failed: {stdout}\n{stderr}");
+    assert!(stdout.contains("outer-hook:ok"), "{stdout}\n{stderr}");
+}
+
+#[test]
 fn project_js_using_down_levels() {
     // `using` is a SyntaxError on every supported Node's V8; this project `.js`
     // must be down-leveled (the transformableSyntax verdict flags it) and run, just

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -30,7 +30,7 @@ import "./floor-builtin.mjs";
 import {
   TRANSPILE_EXTS, PLAIN_JS_EXTS, CLOBBER_MAP, dataExtsFor,
   extname, isFileUrl, resolveSpec, loadTranspile, maybeTranspilePlainJs, loadData, loadTextImport, isDependency,
-  noteRuntimeV8FlagSource,
+  noteRuntimeV8FlagSource, outerHookOwnsFormat,
 } from "./transform-core.mjs";
 import { createRequire, isBuiltin } from "node:module";
 import { existsSync } from "node:fs";
@@ -114,6 +114,11 @@ async function loadInner(url, context, nextLoad) {
   // fast-tier hook.
   if (context?.importAttributes?.type === "text" && isFileUrl(url)) return loadTextImport(url);
   const ext = extname(url);
+  // A user loader above nub's assigned this TypeScript file a bare module format
+  // and will transform it itself from the raw source (tsx's pattern; see
+  // `outerHookOwnsFormat`). This tier has no registration counter like the fast
+  // tier's and needs none: nothing but such a hook produces the bare form here.
+  if (outerHookOwnsFormat(context?.format, ext) && !isDependency(url)) return nextLoad(url, context);
   // node_modules deps are NEVER transpiled (the byte-parity boundary). This guard is
   // make-or-break now that TRANSPILE_EXTS includes `.js`/`.mjs`/`.cjs`: without it,
   // the compat tier would route every dependency `.js` through oxc. (loadTranspile's

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -231,6 +231,10 @@ function installWatchReporting(core) {
 // `type` (transpile — there is no user hook to do it, and Node's strip-only mode
 // can't handle enums/namespaces). See makeHooks().load.
 let __userHooksRegistered = false;
+// Narrower: a user registration that brought a `load` hook, so it can transform
+// what nub hands back. A resolve-only user hook that labels a `.ts` file with a
+// bare `commonjs`/`module` still relies on nub as the transformer.
+let __userLoadHookRegistered = false;
 function installUserHookDetector() {
   if (typeof module_.registerHooks !== "function") return;
   const orig = module_.registerHooks;
@@ -238,7 +242,10 @@ function installUserHookDetector() {
   let seen = 0;
   const wrapped = function (...args) {
     // Call #1 is nub's own preload registration; #2+ are user hooks.
-    if (seen >= 1) __userHooksRegistered = true;
+    if (seen >= 1) {
+      __userHooksRegistered = true;
+      if (args[0] && typeof args[0].load === "function") __userLoadHookRegistered = true;
+    }
     seen += 1;
     return orig.apply(this, args);
   };
@@ -698,8 +705,8 @@ function makeHooks(core, watchReporting, foreignLoaderFlagPresent = foreignAsync
       const source = readFileSync(path);
       const pkgType = core.getPackageType(dirname(path));
       const format = core.moduleFormatFor(ext, pkgType, path, source.toString("utf8"));
-      if (format === "commonjs") return { format: "commonjs", source: null, shortCircuit: true };
-      return { format, source, shortCircuit: true };
+      if (format === "commonjs") return { format: "commonjs", source: null, responseURL: url, shortCircuit: true };
+      return { format, source, responseURL: url, shortCircuit: true };
     } catch {
       return null;
     }
@@ -773,7 +780,22 @@ function makeHooks(core, watchReporting, foreignLoaderFlagPresent = foreignAsync
     // user's outer hook, which does the real ESM->CJS conversion, matching Node.
     // Native 'module-typescript'/'commonjs-typescript' formats still fall through to
     // nub's transpile below, so normal augmentation is unchanged.
-    if (__userHooksRegistered && context && context.format === "typescript") {
+    //
+    // tsx 4.2x writes the bare `commonjs`/`module` form instead of 'typescript'
+    // (`outerHookOwnsFormat`), and the hook that wrote it must also be able to
+    // transform what it gets back: a user registration WITH a load hook
+    // (`__userLoadHookRegistered`), or a loader registered through
+    // `module.register` (`userAsyncLoaderActive`), which the registerHooks counter
+    // cannot see and which nub has no way to inspect. A resolve-only user hook
+    // that labels a `.ts` file keeps nub as its transformer. The 'typescript'
+    // branch keeps its own narrower gate: a non-transpiling async loader (a
+    // telemetry `--import`) must not turn a bare 'typescript' from Node's own
+    // CJS loader into a step-aside.
+    if (context && (
+      (__userHooksRegistered && context.format === "typescript") ||
+      ((__userLoadHookRegistered || userAsyncLoaderActive(foreignLoaderFlagPresent)) &&
+        core.outerHookOwnsFormat(context.format, ext) && !core.isDependency(url))
+    )) {
       return nextLoad(url, context);
     }
 
@@ -1027,10 +1049,36 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   // missing. An explicit `require("dep/x/sub.cjs")` is unaffected either way — an
   // exact path is found by stat, without consulting the extension list at all.
   const NUB_ADDED_EXTS = [".ts", ".cts", ".mts", ".tsx", ".jsx", ".cjs"];
+  // A `require.extensions` handler that is ALREADY registered for one of these
+  // when this runs belongs to a transpiler the user chose, and it stays in charge
+  // of that extension: nub's classic shim neither replaces it nor pre-judges its
+  // files as ES modules at resolve time. Every `--require` runs before any `--import`, so on
+  // the compat tier — where nub's own preload is an `--import` — tsx's
+  // `--require`d preflight installs its `.ts` handler FIRST; nub then overwrote
+  // it, and a file tsx would have compiled to CJS (mixed `import` + `require`,
+  // the shape its ESM hook hands to the CJS loader) died in nub's handler as
+  // "Cannot require() this file — it is an ES module". Node itself registers only
+  // `.js`/`.json`/`.node`, so nothing but a user transpiler holds one of these
+  // keys here.
+  const foreignExts = new Set(
+    [...core.TRANSPILE_EXTS, ...core.allDataExts(), ...NUB_ADDED_EXTS].filter((ext) =>
+      ext !== ".js" && ext !== ".json" && ext !== ".node" && Object.hasOwn(module_._extensions, ext)),
+  );
+  // Ownership of a key is decided per lookup, never frozen at start-up: user code
+  // may install or replace a handler after nub's preload (`--import tsx` runs
+  // after every `--require`), and from then on that key is the user's own
+  // widening of LOAD_AS_FILE, exactly as under plain Node plus their handler —
+  // `require("dep/sub")` finding a dependency's `sub.ts` through it is the answer
+  // to preserve. A key is nub's only while BOTH hold: nub introduced it (it was
+  // not in `foreignExts` — a user's `.cjs` handler that nub merely wraps still
+  // counts as theirs) and it still holds a function nub registered below
+  // (`nubHandlers`). Anything else is not nub's to strip, nor to pre-judge.
+  const nubHandlers = new Set();
+  const nubOwnsExt = (ext) => !foreignExts.has(ext) && nubHandlers.has(module_._extensions[ext]);
   const withoutNubAddedExtensions = (fn) => {
     const saved = [];
     for (const ext of NUB_ADDED_EXTS) {
-      if (Object.hasOwn(module_._extensions, ext)) {
+      if (nubOwnsExt(ext)) {
         saved.push([ext, module_._extensions[ext]]);
         delete module_._extensions[ext];
       }
@@ -1043,7 +1091,7 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   };
   const isDepAddedExtHit = (filename) =>
     typeof filename === "string" &&
-    NUB_ADDED_EXTS.includes(pathExtname(filename)) &&
+    nubOwnsExt(pathExtname(filename)) &&
     core.isDependency(pathToFileURL(filename).href);
 
   module_._resolveFilename = function (request, parent, isMain, options) {
@@ -1066,7 +1114,8 @@ function installCjsRequireHooks(core, withClassicTranspile) {
       // and 4 from `require.resolve` up to 22.14, but 22.15 and 22.16 pass 4 for both
       // while still lacking native TS — and the translator crash is present on
       // exactly those versions. A clean error beats an opaque crash, so this stays.
-      if (withClassicTranspile && core.requireTargetIsEsm(resolved, pathExtname(resolved))) {
+      if (withClassicTranspile && nubOwnsExt(pathExtname(resolved)) &&
+          core.requireTargetIsEsm(resolved, pathExtname(resolved))) {
         throw requireEsmError(resolved);
       }
       return resolved;
@@ -1195,6 +1244,7 @@ function installCjsRequireHooks(core, withClassicTranspile) {
     if (core.TRANSPILE_EXTS.has(ext)) return transpileExtension(mod, filename);
     return nativeJs.call(module_._extensions, mod, filename);
   };
+  nubHandlers.add(nubExtension);
 
   // Registered for every extension either path may claim, so the dispatcher is
   // reached at all; `nubExtension` then decides. Node's own `.js`/`.json`/`.node`
@@ -1215,7 +1265,7 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   // resolution identical across tiers.
   const CODE_EXTS = new Set([".ts", ".cts", ".mts", ".tsx", ".jsx"]);
   for (const ext of new Set([...core.TRANSPILE_EXTS, ...core.allDataExts()])) {
-    if (ext === ".js" || ext === ".json" || ext === ".node") continue;
+    if (ext === ".js" || ext === ".json" || ext === ".node" || foreignExts.has(ext)) continue;
     Object.defineProperty(module_._extensions, ext, {
       value: nubExtension,
       enumerable: CODE_EXTS.has(ext),
@@ -1243,7 +1293,7 @@ function installCjsRequireHooks(core, withClassicTranspile) {
   // (`nativeJs` is captured above, before the TS handlers are registered.)
   for (const ext of [".js", ".cjs"]) {
     const origExtension = module_._extensions[ext] || nativeJs;
-    module_._extensions[ext] = (mod, filename) => {
+    const plainJsExtension = (mod, filename) => {
       // (0) The project pointed this extension at a data loader (`{".js":"text"}`),
       // which the ESM path honors. These two extensions are skipped by the
       // registration loop above because THIS wrapper owns them and runs after it,
@@ -1266,6 +1316,8 @@ function installCjsRequireHooks(core, withClassicTranspile) {
       }
       return origExtension.call(module_._extensions, mod, filename); // (3)
     };
+    module_._extensions[ext] = plainJsExtension;
+    nubHandlers.add(plainJsExtension);
   }
 }
 

--- a/runtime/transform-core.mjs
+++ b/runtime/transform-core.mjs
@@ -207,6 +207,20 @@ export const TRANSPILE_EXTS = new Set([".ts", ".tsx", ".mts", ".cts", ".jsx"]);
 // `maybeTranspilePlainJs` gate); a no-op plain-JS file falls through to Node's
 // native loader untouched, byte-identical. node_modules is excluded at the gate.
 export const PLAIN_JS_EXTS = new Set([".js", ".mjs", ".cjs"]);
+// A bare `commonjs`/`module` format on a file nub would transpile can only have
+// been assigned by a hook layered ABOVE nub's. Node's resolver labels a `.ts` file
+// `commonjs-typescript`/`module-typescript` (or `typescript` when the package has
+// no `type`) and leaves `.jsx` unlabelled, and nub's own resolve returns no format;
+// the bare form is what tsx's resolve hook writes (getFormatFromFileUrl), and its
+// load hook then expects the RAW source back from `nextLoad` so it can run its own
+// module-format transform — a mixed `import` + `require` file becomes CJS there,
+// where nub's syntax detection would make it ESM and `require` undefined. Both
+// tiers step aside on this signal, the fast tier only once the user registration
+// is known to carry a load hook (preload-common.cjs). Plain JS is excluded: Node
+// assigns those the bare form itself.
+export function outerHookOwnsFormat(format, ext) {
+  return (format === "commonjs" || format === "module") && TRANSPILE_EXTS.has(ext) && !PLAIN_JS_EXTS.has(ext);
+}
 // The data loaders nub SHIPS — a runtime feature, not a project setting, so they stay
 // in force inside node_modules too (see dataExtsFor).
 const BUILTIN_DATA_EXTS = { ".jsonc": "jsonc", ".json5": "json5", ".toml": "toml", ".yaml": "yaml", ".yml": "yaml", ".txt": "txt" };
@@ -1007,7 +1021,15 @@ export function loadTranspile(url, ext, source) {
     const details = result.errors.map((e) => e.codeframe || e.message).join("\n\n");
     throw new Error(`Transpile error in ${filePath}:\n${details}`);
   }
-  return { format: result.format, source: result.code, shortCircuit: true };
+  // `responseURL` is what an OUTER user hook keys on. Node's default load sets it
+  // to the file URL, and tsx's load hook takes its CommonJS branch only when the
+  // result `nextLoad` hands back carries a `file:` responseURL — without it, tsx
+  // re-transformed a `.ts` file nub had already emitted as CJS in its ESM branch,
+  // and `require` was undefined at run time (`tsx script.ts` under `nub run`).
+  // Node itself defaults a missing responseURL to the URL, so only a hook layered
+  // above nub's can observe the difference; every file-URL result nub
+  // short-circuits carries it for that reason.
+  return { format: result.format, source: result.code, responseURL: url, shortCircuit: true };
 }
 
 // Project-source plain JS (`.js`/`.mjs`/`.cjs`) gate. Returns a transpiled load
@@ -1126,7 +1148,7 @@ export function loadData(url, ext) {
   const parsed = dataValue(url, ext);
 
   if (parsed == null) {
-    return { format: "module", source: "export default undefined;\n", shortCircuit: true };
+    return { format: "module", source: "export default undefined;\n", responseURL: url, shortCircuit: true };
   }
 
   // Default export only. Data modules deliberately do NOT emit per-key named
@@ -1136,7 +1158,7 @@ export function loadData(url, ext) {
   // default — `import cfg from "./c.yaml"; const { host } = cfg;` — which the
   // `@nubjs/types` `Record<string, unknown>` default type makes sound.
   const code = `export default ${JSON.stringify(parsed)};\n`;
-  return { format: "module", source: code, shortCircuit: true };
+  return { format: "module", source: code, responseURL: url, shortCircuit: true };
 }
 
 // Import Text: `import s from "./any.file" with { type: "text" }` → the raw file
@@ -1152,5 +1174,5 @@ export function loadData(url, ext) {
 const __textDecoder = new TextDecoder();
 export function loadTextImport(url) {
   const text = __textDecoder.decode(readFileSync(fileURLToPath(url)));
-  return { format: "module", source: `export default ${JSON.stringify(text)};\n`, shortCircuit: true };
+  return { format: "module", source: `export default ${JSON.stringify(text)};\n`, responseURL: url, shortCircuit: true };
 }

--- a/tests/fixtures/loader-outer-hook/cjs/dep-check-cjs.cjs
+++ b/tests/fixtures/loader-outer-hook/cjs/dep-check-cjs.cjs
@@ -1,0 +1,3 @@
+// `dep/plain` resolves to the dependency's `plain.cjs` only through a user's
+// `.cjs` key in `require.extensions` — plain Node has none of its own.
+console.log('dep-cjs-ok', require('dep/plain').answer);

--- a/tests/fixtures/loader-outer-hook/cjs/dep-check.cjs
+++ b/tests/fixtures/loader-outer-hook/cjs/dep-check.cjs
@@ -1,0 +1,4 @@
+// `dep/sub` resolves to the dependency's `sub.ts` only through the `.ts` key a
+// user transpiler put in `require.extensions` — plain Node plus that handler
+// finds it, and nub must not lose it in its own dependency-resolution retry.
+console.log('dep-ok', require('dep/sub').answer);

--- a/tests/fixtures/loader-outer-hook/cjs/entry.ts
+++ b/tests/fixtures/loader-outer-hook/cjs/entry.ts
@@ -1,0 +1,2 @@
+const fs = require('node:fs');
+console.log('cjs-ok', typeof fs.readFileSync);

--- a/tests/fixtures/loader-outer-hook/cjs/mixed.ts
+++ b/tests/fixtures/loader-outer-hook/cjs/mixed.ts
@@ -1,0 +1,4 @@
+import { readFileSync } from 'node:fs';
+const path = require('node:path');
+const n: number = 1;
+console.log('mixed-ok', typeof readFileSync, typeof path.join, n);

--- a/tests/fixtures/loader-outer-hook/cjs/node_modules/dep/package.json
+++ b/tests/fixtures/loader-outer-hook/cjs/node_modules/dep/package.json
@@ -1,0 +1,1 @@
+{"name":"dep","version":"1.0.0"}

--- a/tests/fixtures/loader-outer-hook/cjs/node_modules/dep/plain.cjs
+++ b/tests/fixtures/loader-outer-hook/cjs/node_modules/dep/plain.cjs
@@ -1,0 +1,1 @@
+exports.answer = 7;

--- a/tests/fixtures/loader-outer-hook/cjs/node_modules/dep/sub.ts
+++ b/tests/fixtures/loader-outer-hook/cjs/node_modules/dep/sub.ts
@@ -1,0 +1,1 @@
+exports.answer = 42;

--- a/tests/fixtures/loader-outer-hook/cjs/package.json
+++ b/tests/fixtures/loader-outer-hook/cjs/package.json
@@ -1,0 +1,1 @@
+{"name":"outer-hook-cjs","private":true}

--- a/tests/fixtures/loader-outer-hook/cjs/typed.ts
+++ b/tests/fixtures/loader-outer-hook/cjs/typed.ts
@@ -1,0 +1,4 @@
+// An enum is what Node's own type stripping cannot lower, so only a real
+// transformer — nub's — can run this file.
+enum Kind { One = 1 }
+console.log('typed-ok', Kind.One);

--- a/tests/fixtures/loader-outer-hook/main.mjs
+++ b/tests/fixtures/loader-outer-hook/main.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import module from 'node:module';
+import {spawnSync} from 'node:child_process';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+
+// Each child registers a user hook set the way tsx would on this Node, appended
+// to NODE_OPTIONS after nub's own preload — so its hooks run above nub's.
+const here = new URL('.', import.meta.url);
+const run = (nodeOptions, entry) => spawnSync(process.execPath, ['--input-type=module', '-e', `import ${JSON.stringify(entry)};`], {
+  cwd: fileURLToPath(here),
+  env: {...process.env, NODE_OPTIONS: `${process.env.NODE_OPTIONS || ''} ${nodeOptions}`},
+  encoding: 'utf8',
+});
+const filePath = (name) => fileURLToPath(new URL(name, here));
+const hasSyncHooks = typeof module.registerHooks === 'function';
+
+// Whether this Node hands one sync hook's load result to the hook above it as
+// is. Through 22.21, 24.11.0 and 25.0 the chain rebuilt `{ format, source }`
+// between hooks and dropped `responseURL`, so an outer hook has nothing to see
+// there whatever nub returns. Measured in-process: the pair below never reaches
+// nub's hooks or the disk.
+let passesResponseUrl = false;
+if (hasSyncHooks) {
+  const target = 'file:///outer-hook-probe/probe.mjs';
+  module.registerHooks({
+    resolve: (specifier, context, next) => specifier === 'outer-hook-probe' ? {url: target, shortCircuit: true} : next(specifier, context),
+    load: (url, context, next) => url === target ? {format: 'module', source: 'export {}', responseURL: url, shortCircuit: true} : next(url, context),
+  });
+  module.registerHooks({
+    load: (url, context, next) => {
+      const loaded = next(url, context);
+      if (url === target) passesResponseUrl = loaded.responseURL === url;
+      return loaded;
+    },
+  });
+  await import('outer-hook-probe');
+}
+
+// An outer LOAD hook keys on the responseURL nub's transpiled result carries.
+if (passesResponseUrl) {
+  const child = run(`--require=${filePath('outer-hook.cjs')}`, './cjs/entry.ts');
+  assert.equal(child.status, 0, child.stderr);
+  assert.match(child.stdout, /^cjs-ok function$/m);
+}
+
+// An outer RESOLVE hook that assigns a `.ts` file a bare `commonjs` format owns
+// its transform: nub hands its load hook the raw source, and on the compat tier
+// leaves the `require.extensions` handler it installed first in place.
+const owner = hasSyncHooks
+  ? `--require=${filePath('owner-hook.cjs')}`
+  : `--require=${filePath('owner-cjs.cjs')} --import=${pathToFileURL(filePath('owner-register.mjs')).href}`;
+const child = run(owner, './cjs/mixed.ts');
+assert.equal(child.status, 0, child.stderr);
+assert.match(child.stdout, /^mixed-ok function function 1$/m);
+
+// The same label from a hook WITHOUT a load hook leaves nub as the transformer.
+// Sync hooks only: a loader worker cannot be inspected for what it registered.
+if (hasSyncHooks) {
+  const child = run(`--require=${filePath('resolve-only-hook.cjs')}`, './cjs/typed.ts');
+  assert.equal(child.status, 0, child.stderr);
+  assert.match(child.stdout, /^typed-ok 1$/m);
+}
+
+// A user transpiler's `require.extensions['.ts']` also widens resolution inside
+// dependencies, as it does under plain Node; nub's dependency retry keeps it —
+// whether the handler was there before nub's preload or replaced nub's later.
+for (const registration of [`--require=${filePath('owner-cjs.cjs')}`, `--import=${pathToFileURL(filePath('owner-late.mjs')).href}`]) {
+  const child = run(registration, './cjs/dep-check.cjs');
+  assert.equal(child.status, 0, `${registration}\n${child.stderr}`);
+  assert.match(child.stdout, /^dep-ok 42$/m);
+}
+
+// The same for a key nub wraps rather than replaces: a user's `.cjs` handler.
+{
+  const child = run(`--require=${filePath('owner-cjs-ext.cjs')}`, './cjs/dep-check-cjs.cjs');
+  assert.equal(child.status, 0, child.stderr);
+  assert.match(child.stdout, /^dep-cjs-ok 7$/m);
+}
+
+console.log(`outer-hook:ok responseURL-check=${passesResponseUrl ? 'ran' : 'skipped'}`);

--- a/tests/fixtures/loader-outer-hook/outer-hook.cjs
+++ b/tests/fixtures/loader-outer-hook/outer-hook.cjs
@@ -1,0 +1,16 @@
+// Registered AFTER nub's preload (appended to NODE_OPTIONS), so it runs ABOVE
+// nub's load hook and sees nub's raw result — the position tsx occupies under
+// `nub run`. It models the branch tsx takes on that result: a CommonJS result is
+// left alone only when it carries a `file:` responseURL, as Node's default load
+// always provides; anything else is treated as ESM, which is how a CJS-syntax
+// `.ts` file ended up failing with `require is not defined`.
+require('node:module').registerHooks({
+  load(url, context, nextLoad) {
+    const loaded = nextLoad(url, context);
+    if (!url.endsWith('/entry.ts')) return loaded;
+    if (loaded.format === 'commonjs' && !String(loaded.responseURL).startsWith('file:')) {
+      throw new Error(`load result for entry.ts carries no file: responseURL (got ${loaded.responseURL})`);
+    }
+    return loaded;
+  },
+});

--- a/tests/fixtures/loader-outer-hook/owner-cjs-ext.cjs
+++ b/tests/fixtures/loader-outer-hook/owner-cjs-ext.cjs
@@ -1,0 +1,9 @@
+// A user handler for `.cjs`, which Node itself never registers: its presence
+// widens extensionless resolution to `sub.cjs` under plain Node, and nub — which
+// wraps the handler to lower project files — must not treat the key as one it
+// introduced when it retries a dependency lookup.
+const { readFileSync } = require('node:fs');
+
+require('node:module')._extensions['.cjs'] = (mod, filename) => {
+  mod._compile(readFileSync(filename, 'utf8'), filename);
+};

--- a/tests/fixtures/loader-outer-hook/owner-cjs.cjs
+++ b/tests/fixtures/loader-outer-hook/owner-cjs.cjs
@@ -1,0 +1,9 @@
+// tsx's `--require`d preflight installs its `require.extensions['.ts']` before
+// any `--import` runs — so on the compat tier it lands BEFORE nub's preload, and
+// nub must leave it in charge rather than replace it.
+const { readFileSync } = require('node:fs');
+const { transformSource } = require('./owner-core.cjs');
+
+require('node:module')._extensions['.ts'] = (mod, filename) => {
+  mod._compile(transformSource(readFileSync(filename, 'utf8')), filename);
+};

--- a/tests/fixtures/loader-outer-hook/owner-core.cjs
+++ b/tests/fixtures/loader-outer-hook/owner-core.cjs
@@ -1,0 +1,18 @@
+exports.ownsFile = (url) => typeof url === 'string' && url.endsWith('/mixed.ts');
+
+// nub must have stepped aside: the format it hands back is the one the resolve
+// hook assigned, and the source is either absent (Node's default load for CJS)
+// or the untouched file — nub's transpile would have stripped the `: number`.
+exports.assertRaw = (loaded) => {
+  if (loaded.format !== 'commonjs') {
+    throw new Error(`mixed.ts came back as ${loaded.format}; nub transpiled a file the outer hook owns`);
+  }
+  if (loaded.source != null && !String(loaded.source).includes(': number')) {
+    throw new Error('mixed.ts came back transformed; the outer hook expected the raw source');
+  }
+};
+
+// Stands in for esbuild, for this one file.
+exports.transformSource = (raw) => raw
+  .replace("import { readFileSync } from 'node:fs';", "const { readFileSync } = require('node:fs');")
+  .replace(': number', '');

--- a/tests/fixtures/loader-outer-hook/owner-hook.cjs
+++ b/tests/fixtures/loader-outer-hook/owner-hook.cjs
@@ -1,0 +1,21 @@
+// Models tsx's hook pair on the fast tier: its resolve hook gives a `.ts` file a
+// bare `commonjs` format, and its load hook then expects the RAW source back from
+// `nextLoad` so it can run its own module-format transform. mixed.ts mixes
+// `import` with `require`, which only that outer transform can turn into CJS —
+// nub's syntax detection would call it ESM.
+const { readFileSync } = require('node:fs');
+const { fileURLToPath } = require('node:url');
+const { ownsFile, assertRaw, transformSource } = require('./owner-core.cjs');
+
+require('node:module').registerHooks({
+  resolve(specifier, context, nextResolve) {
+    const resolved = nextResolve(specifier, context);
+    return ownsFile(resolved.url) ? { ...resolved, format: 'commonjs' } : resolved;
+  },
+  load(url, context, nextLoad) {
+    const loaded = nextLoad(url, context);
+    if (!ownsFile(url)) return loaded;
+    assertRaw(loaded);
+    return { format: 'commonjs', source: transformSource(readFileSync(fileURLToPath(url), 'utf8')), shortCircuit: true };
+  },
+});

--- a/tests/fixtures/loader-outer-hook/owner-hooks.mjs
+++ b/tests/fixtures/loader-outer-hook/owner-hooks.mjs
@@ -1,0 +1,18 @@
+// The compat-tier twin of owner-hook.cjs, registered through `module.register`
+// the way tsx does where `module.registerHooks` is absent. Like tsx there, the
+// load hook passes a CommonJS result through untouched and lets Node's CJS
+// loader run the `require.extensions` handler owner-cjs.cjs installed.
+import { createRequire } from 'node:module';
+
+const { ownsFile, assertRaw } = createRequire(import.meta.url)('./owner-core.cjs');
+
+export async function resolve(specifier, context, nextResolve) {
+  const resolved = await nextResolve(specifier, context);
+  return ownsFile(resolved.url) ? { ...resolved, format: 'commonjs' } : resolved;
+}
+
+export async function load(url, context, nextLoad) {
+  const loaded = await nextLoad(url, context);
+  if (ownsFile(url)) assertRaw(loaded);
+  return loaded;
+}

--- a/tests/fixtures/loader-outer-hook/owner-late.mjs
+++ b/tests/fixtures/loader-outer-hook/owner-late.mjs
@@ -1,0 +1,6 @@
+// Installs the `.ts` handler AFTER nub's compat-tier preload: an `--import` runs
+// after every `--require`, which is where `--import tsx` (the shape mocha and
+// vitest document) lands. Ownership nub decided at start-up does not cover it.
+import { createRequire } from 'node:module';
+
+createRequire(import.meta.url)('./owner-cjs.cjs');

--- a/tests/fixtures/loader-outer-hook/owner-register.mjs
+++ b/tests/fixtures/loader-outer-hook/owner-register.mjs
@@ -1,0 +1,3 @@
+import { register } from 'node:module';
+
+register('./owner-hooks.mjs', import.meta.url);

--- a/tests/fixtures/loader-outer-hook/package.json
+++ b/tests/fixtures/loader-outer-hook/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests/fixtures/loader-outer-hook/resolve-only-hook.cjs
+++ b/tests/fixtures/loader-outer-hook/resolve-only-hook.cjs
@@ -1,0 +1,9 @@
+// A user hook that labels a `.ts` file with a bare `commonjs` format but brings
+// no load hook of its own: it still relies on nub as the transformer, so the
+// bare format alone must not make nub hand Node the raw TypeScript.
+require('node:module').registerHooks({
+  resolve(specifier, context, nextResolve) {
+    const resolved = nextResolve(specifier, context);
+    return resolved.url.endsWith('/typed.ts') ? { ...resolved, format: 'commonjs' } : resolved;
+  },
+});


### PR DESCRIPTION
tsx layered over nub — `tsx script.ts` under `nub run`, bruno's `bruno-sqlite` `prepare` under `nub install` — failed with `require is not defined in ES module scope`. Three composition gaps, each pinned by the new `loader-outer-hook` fixture on both tiers:

- nub's load results omitted `responseURL`, which Node's default load always sets; tsx's CommonJS branch keys on it. Every file-URL result nub short-circuits now carries it. Node's own sync-hook chain drops it between hooks through 22.21, 24.11.0 and 25.0, so the fixture probes for pass-through before checking.
- tsx's resolve hook labels a `.ts` file with a bare `commonjs`/`module` format and expects the raw source back to transform itself. Node never labels TypeScript that way, so both tiers now step aside on that signal (the old rule only knew the `typescript` spelling). On the fast tier the registration must also carry a load hook; a resolve-only hook that labels a file keeps nub as its transformer.
- On the compat tier nub's `--import` preload overwrote the `require.extensions['.ts']` handler tsx's `--require`d preflight had installed first, so a mixed `import` + `require` file died in nub's handler. A pre-existing handler now stays in charge of its extension, and the dependency-resolution retry strips only a key that still holds nub's own handler, so `require("dep/sub")` keeps finding a dependency's `sub.ts` through a user handler installed before or after nub's preload, and a user's `.cjs` handler that nub only wraps stays theirs too.

Verified against real tsx 4.23 on Node 26, 22.15 and 20.15, and bruno's `prepare` on its pinned Node 22.12 (same output as `npm run prepare`).
